### PR TITLE
feat(web): /tools catalog page

### DIFF
--- a/web/src/pages/tools.astro
+++ b/web/src/pages/tools.astro
@@ -1,0 +1,65 @@
+---
+import Base from "../layouts/Base.astro";
+
+const tools = [
+  { name: "arra_search", desc: "Hybrid FTS + vector search over memory", href: "/search" },
+  { name: "arra_learn", desc: "Store a new memory entry with embeddings", href: "/learn" },
+  { name: "arra_read", desc: "Read a specific memory entry by ID", href: "/tools/arra_read" },
+  { name: "arra_list", desc: "List memory entries with filtering and pagination", href: "/tools/arra_list" },
+  { name: "arra_trace", desc: "Record a reasoning trace linked to memories", href: "/trace" },
+  { name: "arra_trace_get", desc: "Retrieve a single trace by ID", href: "/tools/arra_trace_get" },
+  { name: "arra_trace_list", desc: "List traces with optional filters", href: "/tools/arra_trace_list" },
+  { name: "arra_trace_chain", desc: "Follow a chain of linked traces", href: "/tools/arra_trace_chain" },
+  { name: "arra_trace_link", desc: "Link two traces together as related", href: "/tools/arra_trace_link" },
+  { name: "arra_trace_unlink", desc: "Remove a link between two traces", href: "/tools/arra_trace_unlink" },
+  { name: "arra_thread", desc: "Create a new conversation thread", href: "/tools/arra_thread" },
+  { name: "arra_threads", desc: "List all threads with summaries", href: "/tools/arra_threads" },
+  { name: "arra_thread_read", desc: "Read messages within a thread", href: "/tools/arra_thread_read" },
+  { name: "arra_thread_update", desc: "Append or update a thread message", href: "/tools/arra_thread_update" },
+  { name: "arra_concepts", desc: "Extract and surface recurring concepts from memory", href: "/tools/arra_concepts" },
+  { name: "arra_handoff", desc: "Package context for handoff to another agent", href: "/tools/arra_handoff" },
+  { name: "arra_inbox", desc: "Read and process the agent inbox queue", href: "/tools/arra_inbox" },
+  { name: "arra_stats", desc: "Memory store statistics — counts, sizes, coverage", href: "/tools/arra_stats" },
+  { name: "arra_supersede", desc: "Mark an entry as superseded by a newer one", href: "/tools/arra_supersede" },
+];
+
+const stubPages = new Set([
+  "/tools/arra_read", "/tools/arra_list", "/tools/arra_trace_get",
+  "/tools/arra_trace_list", "/tools/arra_trace_chain", "/tools/arra_trace_link",
+  "/tools/arra_trace_unlink", "/tools/arra_thread", "/tools/arra_threads",
+  "/tools/arra_thread_read", "/tools/arra_thread_update", "/tools/arra_concepts",
+  "/tools/arra_handoff", "/tools/arra_inbox", "/tools/arra_stats", "/tools/arra_supersede",
+]);
+---
+
+<Base title="MCP Tools | Neo ARRA V3">
+  <main class="max-w-5xl mx-auto px-6 py-20">
+    <div class="mb-12">
+      <a href="/" class="text-gray-500 hover:text-gray-300 text-sm transition-colors">← home</a>
+      <h1 class="text-4xl font-bold tracking-tight mt-4 mb-2">MCP Tools</h1>
+      <p class="text-gray-400 text-lg">
+        {tools.length} tools exposed over MCP — stdio or HTTP.
+      </p>
+    </div>
+
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      {tools.map((tool) => {
+        const isStub = stubPages.has(tool.href);
+        return (
+          <a
+            href={tool.href}
+            class="group relative bg-gray-900 border border-gray-800 hover:border-purple-700 rounded-xl p-5 transition-colors flex flex-col gap-2"
+          >
+            {isStub && (
+              <span class="absolute top-3 right-3 text-xs text-gray-600 font-mono">soon</span>
+            )}
+            <span class="font-mono text-purple-300 text-sm group-hover:text-purple-200 transition-colors">
+              {tool.name}
+            </span>
+            <span class="text-gray-400 text-sm leading-snug">{tool.desc}</span>
+          </a>
+        );
+      })}
+    </div>
+  </main>
+</Base>


### PR DESCRIPTION
closes #781

## Summary
- Adds `web/src/pages/tools.astro` — a 3-column responsive grid of 19 MCP tools
- Each card shows tool name (mono font) + one-line description
- `arra_search` → `/search`, `arra_learn` → `/learn`, `arra_trace` → `/trace`; all others show a `soon` badge and link to `/tools/<name>` stub
- Build verified: `bun install && bun run build` succeeds, `dist/tools/index.html` emitted

## Test plan
- [ ] `bun run build` passes with no errors
- [ ] `/tools` renders grid of tool cards
- [ ] `arra_search`, `arra_learn`, `arra_trace` link to their real pages
- [ ] Other cards show "soon" badge

🤖 ตอบโดย arra-oracle-v3 จาก [Nat White] → arra-oracle-v3-oracle