### PR TITLE
feat(web): /search page

### DIFF
--- a/web/src/pages/search.astro
+++ b/web/src/pages/search.astro
@@ -1,0 +1,79 @@
+---
+import Base from "../layouts/Base.astro";
+---
+
+<Base title="Search | Neo ARRA V3">
+  <main class="max-w-3xl mx-auto px-6 py-12">
+    <h1 class="text-3xl font-bold mb-8">Search</h1>
+
+    <form method="GET" action="/search" class="flex gap-3 mb-10">
+      <input
+        type="text"
+        name="q"
+        id="search-input"
+        placeholder="Search oracle memory…"
+        autocomplete="off"
+        class="flex-1 bg-gray-900 border border-gray-700 rounded-lg px-4 py-2.5 text-gray-100 placeholder-gray-500 focus:outline-none focus:border-purple-500 [&::-webkit-search-cancel-button]:hidden [&::-webkit-clear-button]:hidden [&::-ms-clear]:hidden"
+        style="-webkit-appearance: none;"
+      />
+      <button
+        type="submit"
+        class="bg-purple-600 hover:bg-purple-500 text-white font-semibold px-6 py-2.5 rounded-lg transition-colors"
+      >
+        Search
+      </button>
+    </form>
+
+    <div id="results-area"></div>
+  </main>
+</Base>
+
+<script>
+  import { getBackendClient } from "../lib/backend";
+
+  const input = document.getElementById("search-input") as HTMLInputElement;
+  const area = document.getElementById("results-area")!;
+
+  const q = new URLSearchParams(window.location.search).get("q")?.trim();
+
+  if (q) {
+    input.value = q;
+    area.innerHTML = `<p class="text-gray-400 animate-pulse">Searching…</p>`;
+
+    getBackendClient()
+      .search(q)
+      .then((results) => {
+        if (results.length === 0) {
+          area.innerHTML = `<p class="text-gray-500">No results — try simpler keywords</p>`;
+          return;
+        }
+
+        const cards = results
+          .map((r) => {
+            const title = (r as Record<string, unknown>).source_file as string ?? r.id;
+            const snippet = r.content.substring(0, 200);
+            const score = Math.round(r.score * 100);
+            const ellipsis = r.content.length > 200 ? "…" : "";
+            return `
+              <a
+                href="/read?id=${encodeURIComponent(r.id)}"
+                class="block bg-gray-900 border border-gray-800 rounded-xl p-5 mb-3 hover:border-purple-600 transition-colors group"
+              >
+                <div class="flex items-start justify-between gap-3 mb-2">
+                  <span class="font-mono text-sm text-purple-300 group-hover:text-purple-200 break-all">${title}</span>
+                  <span class="shrink-0 bg-purple-900/60 text-purple-300 text-xs font-semibold px-2 py-0.5 rounded-full">${score}%</span>
+                </div>
+                <p class="text-gray-400 text-sm leading-relaxed">${snippet}${ellipsis}</p>
+              </a>`;
+          })
+          .join("");
+
+        area.innerHTML = `
+          <p class="text-gray-500 text-sm mb-4">${results.length} result${results.length !== 1 ? "s" : ""}</p>
+          ${cards}`;
+      })
+      .catch(() => {
+        area.innerHTML = `<p class="text-red-400">Backend not reachable — is the MCP server running? Check URL or set PUBLIC_BACKEND_URL</p>`;
+      });
+  }
+</script>


### PR DESCRIPTION
closes #779

## Summary
- Add `web/src/pages/search.astro` — search UI with GET form (`?q=`)
- Client-side: calls `getBackendClient().search(q)` on page load when `?q=` present
- Result cards: title (source_file or id), score % badge, 200-char snippet, link to `/read?id=`
- States: loading (`Searching…`), empty, error (backend unreachable), success (N results)
- Uses Base.astro layout + Tailwind v4

## Test plan
- [ ] `bun run build` passes, `dist/search/index.html` exists
- [ ] `/search?q=oracle` renders result cards with score badge and snippet
- [ ] Empty query → no results state shown
- [ ] Backend down → error message shown

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → arra-oracle-v3-oracle