### PR TITLE
feat(web): /learn page with POST form

### DIFF
--- a/web/src/lib/backend.ts
+++ b/web/src/lib/backend.ts
@@ -11,6 +11,7 @@ export interface Learning {
   id: string;
   pattern: string;
   concepts?: string[];
+  file_path?: string;
   created_at: string;
 }
 
@@ -22,7 +23,7 @@ export interface TraceResult {
 
 export interface BackendClient {
   search(query: string): Promise<SearchResult[]>;
-  learn(pattern: string, concepts?: string[]): Promise<Learning>;
+  learn(pattern: string, concepts?: string[], source?: string): Promise<Learning>;
   list(type?: string, limit?: number): Promise<SearchResult[]>;
   trace(query: string): Promise<TraceResult>;
   read(file: string): Promise<string>;
@@ -38,8 +39,8 @@ export class MockBackend implements BackendClient {
     ];
   }
 
-  async learn(pattern: string, concepts?: string[]): Promise<Learning> {
-    return { id: "mock-learn-1", pattern, concepts, created_at: new Date().toISOString() };
+  async learn(pattern: string, concepts?: string[], _source?: string): Promise<Learning> {
+    return { id: "mock-learn-1", pattern, concepts, file_path: "ψ/mock/pattern.md", created_at: new Date().toISOString() };
   }
 
   async list(_type?: string, _limit?: number): Promise<SearchResult[]> {
@@ -83,8 +84,8 @@ export class RealBackend implements BackendClient {
     return this.post("arra_search", { query });
   }
 
-  async learn(pattern: string, concepts?: string[]): Promise<Learning> {
-    return this.post("arra_learn", { pattern, concepts });
+  async learn(pattern: string, concepts?: string[], source?: string): Promise<Learning> {
+    return this.post("arra_learn", { pattern, concepts, source });
   }
 
   async list(type?: string, limit?: number): Promise<SearchResult[]> {

--- a/web/src/pages/learn.astro
+++ b/web/src/pages/learn.astro
@@ -1,0 +1,129 @@
+---
+import Base from "../layouts/Base.astro";
+---
+
+<Base title="Learn | Neo ARRA V3">
+  <main class="max-w-2xl mx-auto px-6 py-16">
+    <h1 class="text-3xl font-bold mb-2">Learn</h1>
+    <p class="text-gray-400 mb-8">Save a pattern to Oracle memory.</p>
+
+    <form id="learn-form" class="space-y-5">
+      <div>
+        <label for="pattern" class="block text-sm font-medium text-gray-300 mb-1">Pattern</label>
+        <textarea
+          id="pattern"
+          name="pattern"
+          rows="6"
+          required
+          class="w-full bg-gray-900 border border-gray-700 rounded-lg px-4 py-3 text-gray-100 placeholder-gray-600 focus:outline-none focus:border-purple-500 resize-y font-mono text-sm"
+          placeholder="Describe the pattern to remember…"
+        ></textarea>
+      </div>
+
+      <div>
+        <label for="concepts" class="block text-sm font-medium text-gray-300 mb-1">Concepts</label>
+        <input
+          id="concepts"
+          name="concepts"
+          type="text"
+          placeholder="comma,separated,tags"
+          class="w-full bg-gray-900 border border-gray-700 rounded-lg px-4 py-3 text-gray-100 placeholder-gray-600 focus:outline-none focus:border-purple-500 text-sm [&::-webkit-search-cancel-button]:hidden [&::-webkit-clear-button]:hidden [&::-ms-clear]:hidden"
+          style="WebkitAppearance: none"
+        />
+      </div>
+
+      <div>
+        <label for="source" class="block text-sm font-medium text-gray-300 mb-1">
+          Source <span class="text-gray-600 font-normal">(optional)</span>
+        </label>
+        <input
+          id="source"
+          name="source"
+          type="text"
+          placeholder="URL, file path, or reference"
+          class="w-full bg-gray-900 border border-gray-700 rounded-lg px-4 py-3 text-gray-100 placeholder-gray-600 focus:outline-none focus:border-purple-500 text-sm [&::-webkit-search-cancel-button]:hidden [&::-webkit-clear-button]:hidden [&::-ms-clear]:hidden"
+          style="WebkitAppearance: none"
+        />
+      </div>
+
+      <div class="flex gap-3 pt-1">
+        <button
+          type="submit"
+          id="submit-btn"
+          class="bg-purple-600 hover:bg-purple-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-semibold px-6 py-2.5 rounded-lg transition-colors text-sm"
+        >
+          Save
+        </button>
+        <button
+          type="reset"
+          class="bg-gray-800 hover:bg-gray-700 text-gray-300 font-semibold px-6 py-2.5 rounded-lg transition-colors text-sm"
+        >
+          Reset
+        </button>
+      </div>
+    </form>
+
+    <div id="result-panel" class="hidden mt-8 rounded-xl border p-6">
+    </div>
+  </main>
+</Base>
+
+<script>
+  import { getBackendClient } from "../lib/backend";
+
+  const form = document.getElementById("learn-form") as HTMLFormElement;
+  const submitBtn = document.getElementById("submit-btn") as HTMLButtonElement;
+  const resultPanel = document.getElementById("result-panel") as HTMLDivElement;
+
+  function showSuccess(id: string, filePath: string | undefined, pattern: string) {
+    const searchUrl = `/search?q=${encodeURIComponent(pattern)}`;
+    resultPanel.className =
+      "mt-8 rounded-xl border border-green-700 bg-green-950/40 p-6 space-y-2";
+    resultPanel.innerHTML = `
+      <p class="text-green-400 font-semibold text-lg">Saved ✓</p>
+      <p class="text-gray-300 text-sm">ID: <code class="text-purple-300 font-mono">${id}</code></p>
+      ${filePath ? `<p class="text-gray-300 text-sm">File: <code class="text-purple-300 font-mono">${filePath}</code></p>` : ""}
+      <a href="${searchUrl}" class="inline-block mt-2 text-purple-400 hover:text-purple-300 underline underline-offset-2 text-sm transition-colors">
+        Search for it →
+      </a>
+    `;
+  }
+
+  function showError(message: string) {
+    resultPanel.className =
+      "mt-8 rounded-xl border border-red-700 bg-red-950/40 p-6";
+    resultPanel.innerHTML = `
+      <p class="text-red-400 font-semibold mb-1">Error</p>
+      <p class="text-gray-300 text-sm">${message}</p>
+    `;
+  }
+
+  form.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const data = new FormData(form);
+    const pattern = (data.get("pattern") as string).trim();
+    const conceptsRaw = (data.get("concepts") as string).trim();
+    const source = (data.get("source") as string).trim() || undefined;
+    const concepts = conceptsRaw
+      ? conceptsRaw.split(",").map((s) => s.trim()).filter(Boolean)
+      : undefined;
+
+    submitBtn.disabled = true;
+    submitBtn.textContent = "Saving…";
+    resultPanel.className = "hidden";
+
+    try {
+      const result = await getBackendClient().learn(pattern, concepts, source);
+      showSuccess(result.id, result.file_path, pattern);
+    } catch (err) {
+      showError(err instanceof Error ? err.message : String(err));
+    } finally {
+      submitBtn.disabled = false;
+      submitBtn.textContent = "Save";
+    }
+  });
+
+  form.addEventListener("reset", () => {
+    resultPanel.className = "hidden";
+  });
+</script>


### PR DESCRIPTION
closes #780

## Summary
- Adds `web/src/pages/learn.astro` — textarea (pattern), concepts tag input, optional source field
- On submit calls `getBackendClient().learn(pattern, concepts, source)` and shows success panel with id, file path, and "search for it" link to `/search?q=<pattern>`
- Error message displayed on failure; Reset button clears form and result panel
- Extends `BackendClient.learn()` interface with optional `source` param and `Learning.file_path` field

## Test plan
- [ ] `bun run build` produces `dist/learn/index.html`
- [ ] Form submits and shows "Saved ✓" with mock backend
- [ ] Reset clears form and result panel
- [ ] Error state renders on backend failure

🤖 ตอบโดย arra-oracle-v3 จาก [Nat White] → arra-oracle-v3-oracle