### PR TITLE
feat: bunx neo-arra — CLI install one-liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,14 @@ oracle-studio (separate repo)
 Distributed via GitHub — no npm publish needed:
 
 ```bash
-# MCP server (stdio, for Claude Code)
-bunx --bun arra-oracle-v2@github:Soul-Brews-Studio/arra-oracle-v2#main
+# Backend (MCP server)
+bunx --bun arra-oracle@github:Soul-Brews-Studio/arra-oracle-v3
+
+# CLI (plugin runner)
+bunx --bun neo-arra@github:Soul-Brews-Studio/arra-oracle-v3 --help
+
+# UI (dashboard — separate repo)
+bunx --bun oracle-studio@github:Soul-Brews-Studio/oracle-studio
 
 # Vault CLI (secondary bin — use --package)
 bunx --bun --package arra-oracle-v2@github:Soul-Brews-Studio/arra-oracle-v2#main oracle-vault --help

--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
   "type": "module",
   "main": "src/index.ts",
   "bin": {
-    "arra-oracle-v2": "./src/index.ts"
+    "arra-oracle-v2": "./src/index.ts",
+    "neo-arra": "./cli/src/cli.ts"
   },
   "files": [
     "src",
+    "cli",
     "README.md"
   ],
   "engines": {


### PR DESCRIPTION
## Summary

Makes `bunx --bun neo-arra@github:Soul-Brews-Studio/arra-oracle-v3 --help` work.

- Added `neo-arra` bin entry at root `package.json` pointing to `./cli/src/cli.ts`
- Added `cli` to root `files` so it ships in the tarball
- Updated README Install section with the three install one-liners (backend / CLI / UI)

closes #802

## Test plan

- [ ] `bunx --bun neo-arra@github:Soul-Brews-Studio/arra-oracle-v3 --help` resolves to `cli/src/cli.ts` and prints help
- [ ] Does not conflict with `arra-oracle` rename PR (#799 / feat/799-bunx-arra-oracle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)