### PR TITLE
feat(cli): batch A — read-only query plugins

### DIFF
--- a/cli/src/plugins/reflect/index.ts
+++ b/cli/src/plugins/reflect/index.ts
@@ -1,0 +1,31 @@
+// neo-arra reflect [--json]
+// Calls: GET /api/reflect — returns a random wisdom fragment
+
+import type { InvokeContext, InvokeResult } from "../../plugin/types.ts";
+import { apiFetch } from "../../lib/api.ts";
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const json = ctx.args.includes("--json");
+
+  const res = await apiFetch("/api/reflect");
+  if (!res.ok) {
+    return { ok: false, error: `Reflect failed: HTTP ${res.status}` };
+  }
+
+  const data = await res.json() as Record<string, any>;
+
+  if (json) {
+    return { ok: true, output: JSON.stringify(data, null, 2) };
+  }
+
+  const lines: string[] = [];
+  if (data.type) lines.push(`[${data.type}]${data.id ? ` ${data.id}` : ""}`);
+  const content = data.content ?? data.text ?? data.message;
+  if (content) lines.push(String(content).trim());
+  if (data.source_file) lines.push(`  → ${data.source_file}`);
+
+  if (lines.length === 0) {
+    return { ok: true, output: JSON.stringify(data, null, 2) };
+  }
+  return { ok: true, output: lines.join("\n") };
+}

--- a/cli/src/plugins/reflect/plugin.json
+++ b/cli/src/plugins/reflect/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "arra-reflect",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^0.0.1",
+  "weight": 10,
+  "description": "Get a random reflection / wisdom from the Oracle",
+  "cli": {
+    "command": "reflect",
+    "help": "neo-arra reflect [--json]",
+    "flags": {
+      "--json": "Output raw JSON instead of formatted reflection"
+    }
+  }
+}

--- a/cli/src/plugins/stats/index.ts
+++ b/cli/src/plugins/stats/index.ts
@@ -1,0 +1,43 @@
+// neo-arra stats [--json]
+// Calls: GET /api/stats
+
+import type { InvokeContext, InvokeResult } from "../../plugin/types.ts";
+import { apiFetch } from "../../lib/api.ts";
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const json = ctx.args.includes("--json");
+
+  const res = await apiFetch("/api/stats");
+  if (!res.ok) {
+    return { ok: false, error: `Stats failed: HTTP ${res.status}` };
+  }
+
+  const data = await res.json() as Record<string, any>;
+
+  if (json) {
+    return { ok: true, output: JSON.stringify(data, null, 2) };
+  }
+
+  const lines: string[] = ["ARRA Oracle Stats:\n"];
+  const counts = data.counts ?? {};
+  for (const [k, v] of Object.entries(counts)) {
+    lines.push(`  ${k.padEnd(20)} ${v}`);
+  }
+  if (data.vector) {
+    lines.push("");
+    lines.push(`  vector.enabled       ${data.vector.enabled}`);
+    lines.push(`  vector.count         ${data.vector.count}`);
+    lines.push(`  vector.collection    ${data.vector.collection}`);
+  }
+  if (data.vault_repo) {
+    lines.push("");
+    lines.push(`  vault_repo           ${data.vault_repo}`);
+  }
+  for (const [k, v] of Object.entries(data)) {
+    if (k === "counts" || k === "vector" || k === "vault_repo") continue;
+    if (typeof v === "object") continue;
+    lines.push(`  ${k.padEnd(20)} ${v}`);
+  }
+
+  return { ok: true, output: lines.join("\n") };
+}

--- a/cli/src/plugins/stats/plugin.json
+++ b/cli/src/plugins/stats/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "arra-stats",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^0.0.1",
+  "weight": 10,
+  "description": "Show ARRA Oracle database statistics",
+  "cli": {
+    "command": "stats",
+    "help": "neo-arra stats [--json]",
+    "flags": {
+      "--json": "Output raw JSON instead of summary"
+    }
+  }
+}


### PR DESCRIPTION
closes #815.

Adds neo-arra CLI plugins for read-only query routes (batch A):

- `neo-arra stats` → GET /api/stats (pretty-printed counts + vector + vault_repo; `--json` for raw)
- `neo-arra reflect` → GET /api/reflect (random wisdom; `--json` for raw)

### Skipped

- `concepts` → GET /api/concepts does not exist on the server
- `consult` → GET /api/consult does not exist on the server

Per task spec ("skip any route that doesn't exist"), these are not included. A follow-up batch can add them once the server routes land.

### Verification

```
$ bun run cli/src/cli.ts --help
loaded 9 plugins (9 bundled)
...
  reflect         neo-arra reflect [--json]
  stats           neo-arra stats [--json]
```

Auto-discovery picked up both plugins; `cli/src/cli.ts` and `cli/src/lib/api.ts` untouched.