### PR TITLE
chore: archive oracle-v2/ (moved to vault)

### DIFF
--- a/oracle-v2
+++ b/oracle-v2
@@ -1,1 +1,0 @@
-/home/nat/Code/github.com/Soul-Brews-Studio/oracle-v2


### PR DESCRIPTION
## Summary

- Removes the git-tracked `oracle-v2` symlink from the repo root.
- It was a symlink (`120000` blob) → `~/Code/github.com/Soul-Brews-Studio/oracle-v2`, the standalone sibling repo.
- Target repo remains intact locally and on GitHub — only the symlink pointer is removed.

## Why

Legacy v2-era artifact. The real `arra-oracle-v2` package lives in its own repo; the symlink inside v3 added no value and confused tooling (recursive self-link when dereferenced).

## Archive

Preserved in the Oracle vault with full context:

`ψ/archive/arra-oracle-v3-cleanup-2026-04-19/oracle-v2-legacy/NOTES.md`

## References audit

Other mentions of `arra-oracle-v2` in the repo (package name, URLs, README, docs, install scripts) are name/URL references only — none import from the local `oracle-v2/` path, so they're unaffected.

## Test plan

- [x] `git ls-tree HEAD oracle-v2` → no longer present after merge
- [x] `git grep "oracle-v2/"` — no remaining path imports (only package-name / GitHub-URL mentions)
- [ ] CI passes

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → arra-oracle-v3-oracle