### PR TITLE
feat(menu): Phase A — Drizzle schema + seeder + DB-backed /api/menu (#924)

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -29,5 +29,6 @@ export default defineConfig({
     'activity_log',   // User activity tracking
     'settings',       // Auth & app settings
     'schedule',       // Appointments & events
+    'menu_items',     // Studio navigation (seeded from route detail.menu)
   ],
 });

--- a/src/db/migrations/0007_add_menu_items.sql
+++ b/src/db/migrations/0007_add_menu_items.sql
@@ -1,0 +1,20 @@
+CREATE TABLE `menu_items` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`path` text NOT NULL,
+	`label` text NOT NULL,
+	`group_key` text NOT NULL,
+	`parent_id` integer,
+	`position` integer DEFAULT 999 NOT NULL,
+	`enabled` integer DEFAULT true NOT NULL,
+	`access` text DEFAULT 'public' NOT NULL,
+	`source` text NOT NULL,
+	`icon` text,
+	`touched_at` integer,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`parent_id`) REFERENCES `menu_items`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `menu_items_path_unique` ON `menu_items` (`path`);--> statement-breakpoint
+CREATE INDEX `idx_menu_parent` ON `menu_items` (`parent_id`,`position`);--> statement-breakpoint
+CREATE INDEX `idx_menu_group` ON `menu_items` (`group_key`,`position`);

--- a/src/db/migrations/meta/0007_snapshot.json
+++ b/src/db/migrations/meta/0007_snapshot.json
@@ -1,0 +1,1520 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "44053e96-0dc0-4c44-ab81-2bf10c01d283",
+  "prevId": "68d1f757-6421-41ac-a46e-88763c740439",
+  "tables": {
+    "activity_log": {
+      "name": "activity_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_activity_date": {
+          "name": "idx_activity_date",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        },
+        "idx_activity_type": {
+          "name": "idx_activity_type",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "idx_activity_project": {
+          "name": "idx_activity_project",
+          "columns": [
+            "project"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "consult_log": {
+      "name": "consult_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "principles_found": {
+          "name": "principles_found",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patterns_found": {
+          "name": "patterns_found",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guidance": {
+          "name": "guidance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_consult_project": {
+          "name": "idx_consult_project",
+          "columns": [
+            "project"
+          ],
+          "isUnique": false
+        },
+        "idx_consult_created": {
+          "name": "idx_consult_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "document_access": {
+      "name": "document_access",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_type": {
+          "name": "access_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_access_project": {
+          "name": "idx_access_project",
+          "columns": [
+            "project"
+          ],
+          "isUnique": false
+        },
+        "idx_access_created": {
+          "name": "idx_access_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_access_doc": {
+          "name": "idx_access_doc",
+          "columns": [
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "forum_messages": {
+      "name": "forum_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "principles_found": {
+          "name": "principles_found",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "patterns_found": {
+          "name": "patterns_found",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_query": {
+          "name": "search_query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_message_thread": {
+          "name": "idx_message_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_message_role": {
+          "name": "idx_message_role",
+          "columns": [
+            "role"
+          ],
+          "isUnique": false
+        },
+        "idx_message_created": {
+          "name": "idx_message_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "forum_messages_thread_id_forum_threads_id_fk": {
+          "name": "forum_messages_thread_id_forum_threads_id_fk",
+          "tableFrom": "forum_messages",
+          "tableTo": "forum_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "forum_threads": {
+      "name": "forum_threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'human'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "issue_url": {
+          "name": "issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_thread_status": {
+          "name": "idx_thread_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_thread_project": {
+          "name": "idx_thread_project",
+          "columns": [
+            "project"
+          ],
+          "isUnique": false
+        },
+        "idx_thread_created": {
+          "name": "idx_thread_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "indexing_status": {
+      "name": "indexing_status",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_indexing": {
+          "name": "is_indexing",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "progress_current": {
+          "name": "progress_current",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "progress_total": {
+          "name": "progress_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_root": {
+          "name": "repo_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "learn_log": {
+      "name": "learn_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern_preview": {
+          "name": "pattern_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "concepts": {
+          "name": "concepts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_learn_project": {
+          "name": "idx_learn_project",
+          "columns": [
+            "project"
+          ],
+          "isUnique": false
+        },
+        "idx_learn_created": {
+          "name": "idx_learn_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "menu_items": {
+      "name": "menu_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 999
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "access": {
+          "name": "access",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'public'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "touched_at": {
+          "name": "touched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "menu_items_path_unique": {
+          "name": "menu_items_path_unique",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true
+        },
+        "idx_menu_parent": {
+          "name": "idx_menu_parent",
+          "columns": [
+            "parent_id",
+            "position"
+          ],
+          "isUnique": false
+        },
+        "idx_menu_group": {
+          "name": "idx_menu_group",
+          "columns": [
+            "group_key",
+            "position"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "menu_items_parent_id_menu_items_id_fk": {
+          "name": "menu_items_parent_id_menu_items_id_fk",
+          "tableFrom": "menu_items",
+          "tableTo": "menu_items",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oracle_documents": {
+      "name": "oracle_documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_file": {
+          "name": "source_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "concepts": {
+          "name": "concepts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "superseded_by": {
+          "name": "superseded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "superseded_reason": {
+          "name": "superseded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_source": {
+          "name": "idx_source",
+          "columns": [
+            "source_file"
+          ],
+          "isUnique": false
+        },
+        "idx_type": {
+          "name": "idx_type",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "idx_superseded": {
+          "name": "idx_superseded",
+          "columns": [
+            "superseded_by"
+          ],
+          "isUnique": false
+        },
+        "idx_origin": {
+          "name": "idx_origin",
+          "columns": [
+            "origin"
+          ],
+          "isUnique": false
+        },
+        "idx_project": {
+          "name": "idx_project",
+          "columns": [
+            "project"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "schedule": {
+      "name": "schedule",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date_raw": {
+          "name": "date_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurring": {
+          "name": "recurring",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_schedule_date": {
+          "name": "idx_schedule_date",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        },
+        "idx_schedule_status": {
+          "name": "idx_schedule_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "search_log": {
+      "name": "search_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "results_count": {
+          "name": "results_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_time_ms": {
+          "name": "search_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "results": {
+          "name": "results",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_search_project": {
+          "name": "idx_search_project",
+          "columns": [
+            "project"
+          ],
+          "isUnique": false
+        },
+        "idx_search_created": {
+          "name": "idx_search_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "supersede_log": {
+      "name": "supersede_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "old_path": {
+          "name": "old_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "old_id": {
+          "name": "old_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "old_title": {
+          "name": "old_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "old_type": {
+          "name": "old_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_path": {
+          "name": "new_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_id": {
+          "name": "new_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_title": {
+          "name": "new_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "superseded_by": {
+          "name": "superseded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_supersede_old_path": {
+          "name": "idx_supersede_old_path",
+          "columns": [
+            "old_path"
+          ],
+          "isUnique": false
+        },
+        "idx_supersede_new_path": {
+          "name": "idx_supersede_new_path",
+          "columns": [
+            "new_path"
+          ],
+          "isUnique": false
+        },
+        "idx_supersede_created": {
+          "name": "idx_supersede_created",
+          "columns": [
+            "superseded_at"
+          ],
+          "isUnique": false
+        },
+        "idx_supersede_project": {
+          "name": "idx_supersede_project",
+          "columns": [
+            "project"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trace_log": {
+      "name": "trace_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "query_type": {
+          "name": "query_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'general'"
+        },
+        "found_files": {
+          "name": "found_files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "found_commits": {
+          "name": "found_commits",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "found_issues": {
+          "name": "found_issues",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "found_retrospectives": {
+          "name": "found_retrospectives",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "found_learnings": {
+          "name": "found_learnings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "found_resonance": {
+          "name": "found_resonance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "commit_count": {
+          "name": "commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "parent_trace_id": {
+          "name": "parent_trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "child_trace_ids": {
+          "name": "child_trace_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "prev_trace_id": {
+          "name": "prev_trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_trace_id": {
+          "name": "next_trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'project'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_count": {
+          "name": "agent_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'raw'"
+        },
+        "awakening": {
+          "name": "awakening",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "distilled_to_id": {
+          "name": "distilled_to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "distilled_at": {
+          "name": "distilled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "trace_log_trace_id_unique": {
+          "name": "trace_log_trace_id_unique",
+          "columns": [
+            "trace_id"
+          ],
+          "isUnique": true
+        },
+        "idx_trace_query": {
+          "name": "idx_trace_query",
+          "columns": [
+            "query"
+          ],
+          "isUnique": false
+        },
+        "idx_trace_project": {
+          "name": "idx_trace_project",
+          "columns": [
+            "project"
+          ],
+          "isUnique": false
+        },
+        "idx_trace_status": {
+          "name": "idx_trace_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_trace_parent": {
+          "name": "idx_trace_parent",
+          "columns": [
+            "parent_trace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_trace_prev": {
+          "name": "idx_trace_prev",
+          "columns": [
+            "prev_trace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_trace_next": {
+          "name": "idx_trace_next",
+          "columns": [
+            "next_trace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_trace_created": {
+          "name": "idx_trace_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1772415363037,
       "tag": "0006_magenta_screwball",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1776574727337,
+      "tag": "0007_add_menu_items",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -5,7 +5,7 @@
  * then cleaned up to exclude FTS5 internal tables.
  */
 
-import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, text, integer, index, type AnySQLiteColumn } from 'drizzle-orm/sqlite-core';
 
 // Main document index table
 export const oracleDocuments = sqliteTable('oracle_documents', {
@@ -58,6 +58,22 @@ export const searchLog = sqliteTable('search_log', {
 }, (table) => [
   index('idx_search_project').on(table.project),
   index('idx_search_created').on(table.createdAt),
+]);
+
+// Consult log — legacy table kept for backward compat (pre-0007 snapshot had it).
+// Not actively used; retained to avoid destructive migration drop.
+export const consultLog = sqliteTable('consult_log', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  decision: text('decision').notNull(),
+  context: text('context'),
+  principlesFound: integer('principles_found').notNull(),
+  patternsFound: integer('patterns_found').notNull(),
+  guidance: text('guidance').notNull(),
+  createdAt: integer('created_at').notNull(),
+  project: text('project'),
+}, (table) => [
+  index('idx_consult_project').on(table.project),
+  index('idx_consult_created').on(table.createdAt),
 ]);
 
 // Learning/pattern logging
@@ -273,3 +289,26 @@ export const settings = sqliteTable('settings', {
   value: text('value'),
   updatedAt: integer('updated_at').notNull(),
 });
+
+// ============================================================================
+// Menu Items Table — studio navigation, seeded from route detail.menu metadata
+// ============================================================================
+
+export const menuItems = sqliteTable('menu_items', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  path: text('path').notNull().unique(),
+  label: text('label').notNull(),
+  groupKey: text('group_key').notNull(),
+  parentId: integer('parent_id').references((): AnySQLiteColumn => menuItems.id, { onDelete: 'cascade' }),
+  position: integer('position').notNull().default(999),
+  enabled: integer('enabled', { mode: 'boolean' }).notNull().default(true),
+  access: text('access').notNull().default('public'),
+  source: text('source').notNull(),
+  icon: text('icon'),
+  touchedAt: integer('touched_at', { mode: 'timestamp' }),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),
+}, (t) => [
+  index('idx_menu_parent').on(t.parentId, t.position),
+  index('idx_menu_group').on(t.groupKey, t.position),
+]);

--- a/src/db/seeders/menu-seeder.ts
+++ b/src/db/seeders/menu-seeder.ts
@@ -1,0 +1,146 @@
+/**
+ * Menu seeder — syncs route-declared menu items into the `menu_items` table.
+ *
+ * Called at server boot (src/server.ts) and idempotent. For each route with
+ * `detail.menu`, upserts by path:
+ *   - Path not in DB           → INSERT with source='route', touchedAt=null
+ *   - In DB, source='route'+untouched → UPDATE label/group/position from route
+ *   - touchedAt != null        → PRESERVE (user edit wins); log drift
+ */
+
+import { eq } from 'drizzle-orm';
+import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
+import * as schema from '../schema.ts';
+import { db as defaultDb } from '../index.ts';
+import type { MenuMeta } from '../../routes/menu/model.ts';
+import { API_TO_STUDIO } from '../../routes/menu/menu.ts';
+
+export type RouteLike = { method?: string; path: string; hooks?: { detail?: unknown } };
+export type HasRoutes = { routes: RouteLike[] };
+
+export interface RouteMenuRow {
+  path: string;        // studio path (e.g. /search)
+  label: string;
+  groupKey: string;
+  position: number;
+  access: string;
+  icon?: string | null;
+}
+
+function studioPathFor(apiPath: string): string | null {
+  for (const [prefix, studio] of API_TO_STUDIO) {
+    if (apiPath === prefix || apiPath.startsWith(prefix + '/')) return studio;
+  }
+  return null;
+}
+
+export function collectRouteMenuRows(sources: HasRoutes[]): RouteMenuRow[] {
+  const rows: RouteMenuRow[] = [];
+  const seen = new Set<string>();
+
+  for (const src of sources) {
+    for (const route of src.routes) {
+      const detail = (route.hooks?.detail ?? {}) as { menu?: MenuMeta };
+      const menu = detail.menu;
+      if (!menu || !menu.group) continue;
+
+      const studio = studioPathFor(route.path);
+      if (!studio) continue;
+
+      const key = `${menu.group}:${studio}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      const slug = studio.replace(/^\//, '') || 'home';
+      const label = menu.label ?? slug.charAt(0).toUpperCase() + slug.slice(1);
+      const order =
+        typeof menu.order === 'number' && Number.isFinite(menu.order) ? menu.order : 999;
+
+      rows.push({
+        path: studio,
+        label,
+        groupKey: menu.group,
+        position: order,
+        access: menu.access ?? 'public',
+        icon: menu.icon ?? null,
+      });
+    }
+  }
+
+  return rows;
+}
+
+export interface SeedResult {
+  inserted: number;
+  updated: number;
+  preserved: number;
+}
+
+export function seedMenuItems(
+  sources: HasRoutes[],
+  db: BunSQLiteDatabase<typeof schema> = defaultDb,
+  now: Date = new Date(),
+): SeedResult {
+  const rows = collectRouteMenuRows(sources);
+  let inserted = 0;
+  let updated = 0;
+  let preserved = 0;
+
+  db.transaction((tx) => {
+    for (const row of rows) {
+      const existing = tx
+        .select()
+        .from(schema.menuItems)
+        .where(eq(schema.menuItems.path, row.path))
+        .get();
+
+      if (!existing) {
+        tx.insert(schema.menuItems)
+          .values({
+            path: row.path,
+            label: row.label,
+            groupKey: row.groupKey,
+            position: row.position,
+            access: row.access,
+            source: 'route',
+            icon: row.icon ?? null,
+            enabled: true,
+            touchedAt: null,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .run();
+        inserted += 1;
+        continue;
+      }
+
+      if (existing.source === 'route' && existing.touchedAt == null) {
+        const changed =
+          existing.label !== row.label ||
+          existing.groupKey !== row.groupKey ||
+          existing.position !== row.position ||
+          existing.access !== row.access ||
+          existing.icon !== (row.icon ?? null);
+        if (changed) {
+          tx.update(schema.menuItems)
+            .set({
+              label: row.label,
+              groupKey: row.groupKey,
+              position: row.position,
+              access: row.access,
+              icon: row.icon ?? null,
+              updatedAt: now,
+            })
+            .where(eq(schema.menuItems.id, existing.id))
+            .run();
+          updated += 1;
+        }
+        continue;
+      }
+
+      preserved += 1;
+    }
+  });
+
+  return { inserted, updated, preserved };
+}

--- a/src/routes/menu/index.ts
+++ b/src/routes/menu/index.ts
@@ -1,21 +1,24 @@
 /**
  * Menu Routes (Elysia) — composes /api/menu.
  *
- * The menu endpoint reads swagger nav tags off the other modules' routes,
- * so it's built via a factory that accepts the sibling modules to inspect.
+ * The endpoint reads navigation from the `menu_items` DB table (seeded at
+ * boot from route `detail.menu` metadata by src/db/seeders/menu-seeder.ts).
  */
 
 import { Elysia } from 'elysia';
 import { createMenuEndpoint } from './menu.ts';
 import { createCustomMenuRoutes } from './custom.ts';
 
-type HasRoutes = { routes: Array<{ path: string; hooks?: { detail?: unknown } }> };
-
-export function createMenuRoutes(sources: HasRoutes[]) {
+export function createMenuRoutes() {
   return new Elysia({ prefix: '/api' })
-    .use(createMenuEndpoint(sources))
+    .use(createMenuEndpoint())
     .use(createCustomMenuRoutes());
 }
 
-export { buildMenuItems, API_TO_STUDIO } from './menu.ts';
+export {
+  buildMenuItems,
+  menuItemsFromRoutes,
+  readApiMenuItemsFromDb,
+  API_TO_STUDIO,
+} from './menu.ts';
 export type { MenuItem, MenuResponse } from './model.ts';

--- a/src/routes/menu/menu.ts
+++ b/src/routes/menu/menu.ts
@@ -1,16 +1,21 @@
 /**
- * GET /api/menu — aggregates navigation from `detail.menu` on mounted routes.
+ * GET /api/menu — returns studio navigation, seeded from `detail.menu` on
+ * mounted routes and persisted in the `menu_items` table.
  *
- * Reads typed `detail.menu: { group, order }` off each endpoint. Maps API
- * prefixes to studio routes using API_TO_STUDIO (kept in sync with
- * oracle-studio's Header.tsx).
+ * Flow:
+ *   1. Boot-time seeder (src/db/seeders/menu-seeder.ts) upserts route-declared
+ *      items into DB, preserving user-edited rows (`touchedAt != null`).
+ *   2. This endpoint reads `menu_items` via Drizzle, merges frontend pages,
+ *      gist extras, and custom items — preserving /api/menu response shape.
  */
 
 import { Elysia, t } from 'elysia';
+import { asc } from 'drizzle-orm';
 import { MenuItemSchema, MenuResponseSchema, type MenuItem, type MenuMeta } from './model.ts';
 import { getFrontendMenuItems } from '../../menu/index.ts';
 import { getMenuConfig, getMenuSource, reloadMenuConfig } from '../../menu/config.ts';
 import { listCustomMenuItems } from '../../menu/custom-store.ts';
+import { db, menuItems } from '../../db/index.ts';
 
 export type MenuExtras = {
   items?: MenuItem[];
@@ -45,20 +50,17 @@ type HasRoutes = { routes: RouteLike[] };
 
 const GROUP_RANK: Record<MenuItem['group'], number> = { main: 0, tools: 1, admin: 2, hidden: 3 };
 
-export function buildMenuItems(
-  sources: HasRoutes[],
-  extras?: MenuExtras,
-  customItems: MenuItem[] = [],
-): MenuItem[] {
+/**
+ * Pure scan of Elysia route sources into MenuItems (source='api').
+ * Used by tests and exported for callers that need pre-DB scanning.
+ */
+export function menuItemsFromRoutes(sources: HasRoutes[]): MenuItem[] {
   const items: MenuItem[] = [];
   const seen = new Set<string>();
-  const disableSet = new Set<string>(extras?.disable ?? []);
 
   for (const src of sources) {
     for (const route of src.routes) {
-      const detail = (route.hooks?.detail ?? {}) as {
-        menu?: MenuMeta;
-      };
+      const detail = (route.hooks?.detail ?? {}) as { menu?: MenuMeta };
       const menu = detail.menu;
       if (!menu || !menu.group) continue;
 
@@ -69,13 +71,70 @@ export function buildMenuItems(
       if (seen.has(key)) continue;
       seen.add(key);
 
-      const order = typeof menu.order === 'number' && Number.isFinite(menu.order) ? menu.order : 999;
-
+      const order =
+        typeof menu.order === 'number' && Number.isFinite(menu.order) ? menu.order : 999;
       const slug = studio.replace(/^\//, '') || 'home';
       const label = menu.label ?? slug.charAt(0).toUpperCase() + slug.slice(1);
 
       items.push({ path: studio, label, group: menu.group, order, source: 'api' });
     }
+  }
+
+  return items;
+}
+
+/**
+ * Read API-sourced menu items from the `menu_items` DB table.
+ * Only enabled rows are returned. Source is always 'api' for studio consumers.
+ */
+export function readApiMenuItemsFromDb(): MenuItem[] {
+  const rows = db
+    .select()
+    .from(menuItems)
+    .orderBy(asc(menuItems.position))
+    .all();
+
+  const items: MenuItem[] = [];
+  for (const row of rows) {
+    if (row.enabled === false) continue;
+    const group = (['main', 'tools', 'admin', 'hidden'] as const).includes(
+      row.groupKey as MenuItem['group'],
+    )
+      ? (row.groupKey as MenuItem['group'])
+      : 'hidden';
+    const item: MenuItem = {
+      path: row.path,
+      label: row.label,
+      group,
+      order: row.position,
+      source: 'api',
+    };
+    if (row.icon) item.icon = row.icon;
+    if (row.access === 'public' || row.access === 'auth') item.access = row.access;
+    items.push(item);
+  }
+  return items;
+}
+
+/**
+ * Merge pre-resolved API items with frontend pages, gist extras, and custom
+ * items into the final /api/menu response. First-seen wins on dedupe; disable
+ * filters any path.
+ */
+export function buildMenuItems(
+  apiItems: MenuItem[],
+  extras?: MenuExtras,
+  customItems: MenuItem[] = [],
+): MenuItem[] {
+  const items: MenuItem[] = [];
+  const seen = new Set<string>();
+  const disableSet = new Set<string>(extras?.disable ?? []);
+
+  for (const item of apiItems) {
+    const key = `${item.group}:${item.path}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    items.push(item);
   }
 
   for (const item of getFrontendMenuItems()) {
@@ -118,21 +177,25 @@ const MenuSourceSchema = t.Object({
   ]),
 });
 
-export function createMenuEndpoint(sources: HasRoutes[]) {
+export function createMenuEndpoint() {
   return new Elysia()
     .get(
       '/menu',
       async () => {
         const { items, disable } = await getMenuConfig();
         return {
-          items: buildMenuItems(sources, { items, disable }, listCustomMenuItems()),
+          items: buildMenuItems(
+            readApiMenuItemsFromDb(),
+            { items, disable },
+            listCustomMenuItems(),
+          ),
         };
       },
       {
         detail: {
           tags: ['menu'],
           menu: { group: 'hidden' },
-          summary: 'Aggregated studio navigation from swagger nav tags',
+          summary: 'Aggregated studio navigation from menu_items table',
         },
       },
     )

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,7 @@ import {
 import { PORT, ORACLE_DATA_DIR } from './config.ts';
 import { MCP_SERVER_NAME } from './const.ts';
 import { db, closeDb, indexingStatus } from './db/index.ts';
+import { seedMenuItems, type HasRoutes as SeedHasRoutes } from './db/seeders/menu-seeder.ts';
 
 // Elysia sub-apps — one per cluster
 import { authRoutes } from './routes/auth/index.ts';
@@ -179,7 +180,16 @@ const apiModules = [
   sessionsRoutes,
 ];
 
-const menuRoutes = createMenuRoutes(apiModules as unknown as Parameters<typeof createMenuRoutes>[0]);
+try {
+  const result = seedMenuItems(apiModules as unknown as SeedHasRoutes[]);
+  console.log(
+    `🔮 Menu seeded: ${result.inserted} inserted, ${result.updated} updated, ${result.preserved} preserved`,
+  );
+} catch (e) {
+  console.error('⚠️  Menu seeder failed:', e);
+}
+
+const menuRoutes = createMenuRoutes();
 
 const modules = [...apiModules, menuRoutes];
 

--- a/tests/http/menu/config.test.ts
+++ b/tests/http/menu/config.test.ts
@@ -5,8 +5,17 @@
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { Elysia } from 'elysia';
-import { buildMenuItems, type MenuItem } from '../../../src/routes/menu/index.ts';
+import {
+  buildMenuItems,
+  menuItemsFromRoutes,
+  type MenuItem,
+} from '../../../src/routes/menu/index.ts';
 import { createMenuEndpoint } from '../../../src/routes/menu/menu.ts';
+import { db, menuItems } from '../../../src/db/index.ts';
+
+function clearMenu() {
+  db.delete(menuItems).run();
+}
 import {
   fetchGistMenu,
   toRawGistUrl,
@@ -36,7 +45,7 @@ describe('buildMenuItems with extras', () => {
     const sub = new Elysia({ prefix: '/api' }).get('/search', () => ({}), {
       detail: { menu: { group: 'main', order: 10 }, summary: 'Search' },
     });
-    const items = buildMenuItems([sub], { disable: ['/search'] });
+    const items = buildMenuItems(menuItemsFromRoutes([sub]), { disable: ['/search'] });
     expect(items.find((i) => i.path === '/search')).toBeUndefined();
   });
 
@@ -247,7 +256,7 @@ describe('/api/menu/source and /api/menu/reload', () => {
   });
 
   test('source returns status:none when no gist configured', async () => {
-    const app = new Elysia({ prefix: '/api' }).use(createMenuEndpoint([]));
+    const app = new Elysia({ prefix: '/api' }).use(createMenuEndpoint());
     await app.handle(new Request('http://localhost/api/menu'));
     const res = await app.handle(new Request('http://localhost/api/menu/source'));
     expect(res.status).toBe(200);
@@ -266,7 +275,7 @@ describe('/api/menu/source and /api/menu/reload', () => {
       return res;
     }) as typeof fetch;
 
-    const app = new Elysia({ prefix: '/api' }).use(createMenuEndpoint([]));
+    const app = new Elysia({ prefix: '/api' }).use(createMenuEndpoint());
     await app.handle(new Request('http://localhost/api/menu'));
     const res = await app.handle(new Request('http://localhost/api/menu/source'));
     const body = await res.json();
@@ -282,7 +291,7 @@ describe('/api/menu/source and /api/menu/reload', () => {
       throw new Error('ENOTFOUND');
     }) as typeof fetch;
 
-    const app = new Elysia({ prefix: '/api' }).use(createMenuEndpoint([]));
+    const app = new Elysia({ prefix: '/api' }).use(createMenuEndpoint());
     await app.handle(new Request('http://localhost/api/menu'));
     const res = await app.handle(new Request('http://localhost/api/menu/source'));
     const body = await res.json();
@@ -297,7 +306,7 @@ describe('/api/menu/source and /api/menu/reload', () => {
       return new Response(JSON.stringify({ items: [] }), { status: 200 });
     }) as typeof fetch;
 
-    const app = new Elysia({ prefix: '/api' }).use(createMenuEndpoint([]));
+    const app = new Elysia({ prefix: '/api' }).use(createMenuEndpoint());
     await app.handle(new Request('http://localhost/api/menu'));
     await app.handle(new Request('http://localhost/api/menu')); // cached
     expect(callCount).toBe(1);

--- a/tests/http/menu/db-seeder.test.ts
+++ b/tests/http/menu/db-seeder.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for the menu_items seeder + DB-backed /api/menu endpoint.
+ *
+ * Covers:
+ *   - seedMenuItems inserts route-declared items
+ *   - seedMenuItems is idempotent (re-run → same state)
+ *   - user edits (touchedAt != null) survive re-seed
+ *   - readApiMenuItemsFromDb returns seeded rows
+ */
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { Elysia } from 'elysia';
+import { eq } from 'drizzle-orm';
+import { db, menuItems } from '../../../src/db/index.ts';
+import {
+  seedMenuItems,
+  collectRouteMenuRows,
+} from '../../../src/db/seeders/menu-seeder.ts';
+import { readApiMenuItemsFromDb } from '../../../src/routes/menu/menu.ts';
+
+function clearMenu() {
+  db.delete(menuItems).run();
+}
+
+function sampleSource() {
+  return new Elysia({ prefix: '/api' })
+    .get('/search', () => ({}), {
+      detail: { menu: { group: 'main', order: 10 }, summary: 'Search' },
+    })
+    .get('/traces', () => ({}), {
+      detail: { menu: { group: 'main', order: 40 }, summary: 'Traces' },
+    })
+    .get('/map', () => ({}), {
+      detail: { menu: { group: 'tools', order: 20 }, summary: 'Map' },
+    });
+}
+
+describe('collectRouteMenuRows', () => {
+  test('maps api paths to studio paths + menu meta', () => {
+    const rows = collectRouteMenuRows([sampleSource()]);
+    expect(rows).toEqual([
+      { path: '/search', label: 'Search', groupKey: 'main', position: 10, access: 'public', icon: null },
+      { path: '/traces', label: 'Traces', groupKey: 'main', position: 40, access: 'public', icon: null },
+      { path: '/map', label: 'Map', groupKey: 'tools', position: 20, access: 'public', icon: null },
+    ]);
+  });
+
+  test('skips routes without detail.menu', () => {
+    const sub = new Elysia({ prefix: '/api' })
+      .get('/search', () => ({}), {
+        detail: { menu: { group: 'main', order: 1 }, summary: 'Search' },
+      })
+      .get('/health', () => ({}), { detail: { summary: 'Health' } });
+    expect(collectRouteMenuRows([sub])).toHaveLength(1);
+  });
+});
+
+describe('seedMenuItems', () => {
+  beforeEach(() => {
+    clearMenu();
+  });
+
+  test('inserts new rows on first run', () => {
+    const result = seedMenuItems([sampleSource()]);
+    expect(result).toEqual({ inserted: 3, updated: 0, preserved: 0 });
+
+    const rows = db.select().from(menuItems).all();
+    expect(rows).toHaveLength(3);
+    const paths = rows.map((r) => r.path).sort();
+    expect(paths).toEqual(['/map', '/search', '/traces']);
+    for (const row of rows) {
+      expect(row.source).toBe('route');
+      expect(row.touchedAt).toBeNull();
+      expect(row.enabled).toBe(true);
+    }
+  });
+
+  test('is idempotent — second run makes no changes', () => {
+    seedMenuItems([sampleSource()]);
+    const result = seedMenuItems([sampleSource()]);
+    expect(result).toEqual({ inserted: 0, updated: 0, preserved: 0 });
+    expect(db.select().from(menuItems).all()).toHaveLength(3);
+  });
+
+  test('updates untouched route rows when route metadata changes', () => {
+    seedMenuItems([sampleSource()]);
+
+    const changed = new Elysia({ prefix: '/api' })
+      .get('/search', () => ({}), {
+        detail: { menu: { group: 'tools', order: 99, label: 'Find' }, summary: 'Search' },
+      });
+    const result = seedMenuItems([changed]);
+    expect(result.updated).toBe(1);
+
+    const row = db
+      .select()
+      .from(menuItems)
+      .where(eq(menuItems.path, '/search'))
+      .get();
+    expect(row?.label).toBe('Find');
+    expect(row?.groupKey).toBe('tools');
+    expect(row?.position).toBe(99);
+  });
+
+  test('preserves user-edited rows (touchedAt != null) across re-seed', () => {
+    seedMenuItems([sampleSource()]);
+
+    const now = new Date();
+    db.update(menuItems)
+      .set({ label: 'My Search', touchedAt: now, updatedAt: now })
+      .where(eq(menuItems.path, '/search'))
+      .run();
+
+    const changed = new Elysia({ prefix: '/api' })
+      .get('/search', () => ({}), {
+        detail: { menu: { group: 'main', order: 10, label: 'Route Search' }, summary: 'Search' },
+      });
+    const result = seedMenuItems([changed]);
+    expect(result.preserved).toBe(1);
+    expect(result.updated).toBe(0);
+
+    const row = db
+      .select()
+      .from(menuItems)
+      .where(eq(menuItems.path, '/search'))
+      .get();
+    expect(row?.label).toBe('My Search');
+  });
+});
+
+describe('readApiMenuItemsFromDb', () => {
+  beforeEach(() => {
+    clearMenu();
+  });
+
+  test('returns seeded rows as MenuItems with source=api', () => {
+    seedMenuItems([sampleSource()]);
+    const items = readApiMenuItemsFromDb();
+    expect(items).toHaveLength(3);
+    for (const item of items) expect(item.source).toBe('api');
+    const search = items.find((i) => i.path === '/search');
+    expect(search).toMatchObject({ label: 'Search', group: 'main', order: 10 });
+  });
+
+  test('skips disabled rows', () => {
+    seedMenuItems([sampleSource()]);
+    db.update(menuItems).set({ enabled: false }).where(eq(menuItems.path, '/map')).run();
+    const items = readApiMenuItemsFromDb();
+    expect(items.find((i) => i.path === '/map')).toBeUndefined();
+  });
+});

--- a/tests/http/menu/list.test.ts
+++ b/tests/http/menu/list.test.ts
@@ -1,14 +1,24 @@
 /**
  * Unit tests for /api/menu — aggregates nav tags off mounted Elysia routes.
  *
- * These exercise the menu builder in isolation with synthetic sub-apps so
- * they run without a live server. The real server wires `apiModules` into
- * `createMenuRoutes` in src/server.ts.
+ * Post-migration: items live in the `menu_items` table; the endpoint reads
+ * DB. Tests seed via `seedMenuItems` after clearing the table for isolation.
  */
 
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, beforeEach } from 'bun:test';
 import { Elysia } from 'elysia';
-import { createMenuRoutes, buildMenuItems, type MenuItem } from '../../../src/routes/menu/index.ts';
+import {
+  createMenuRoutes,
+  buildMenuItems,
+  menuItemsFromRoutes,
+  type MenuItem,
+} from '../../../src/routes/menu/index.ts';
+import { db, menuItems } from '../../../src/db/index.ts';
+import { seedMenuItems } from '../../../src/db/seeders/menu-seeder.ts';
+
+function clearMenu() {
+  db.delete(menuItems).run();
+}
 
 function fakeApiModule() {
   return new Elysia({ prefix: '/api' })
@@ -37,8 +47,13 @@ function fakeApiModule() {
 }
 
 describe('/api/menu', () => {
+  beforeEach(() => {
+    clearMenu();
+  });
+
   test('groups routes into main / tools / hidden', async () => {
-    const app = createMenuRoutes([fakeApiModule()]);
+    seedMenuItems([fakeApiModule()]);
+    const app = createMenuRoutes();
     const res = await app.handle(new Request('http://localhost/api/menu'));
     expect(res.status).toBe(200);
     const body = (await res.json()) as { items: MenuItem[] };
@@ -58,8 +73,7 @@ describe('/api/menu', () => {
   });
 
   test('respects menu.order and studio path dedupe', () => {
-    const sub = fakeApiModule();
-    const items = buildMenuItems([sub]).filter((i) => i.source === 'api');
+    const items = menuItemsFromRoutes([fakeApiModule()]);
     const main = items.filter((i) => i.group === 'main');
     const tools = items.filter((i) => i.group === 'tools');
     expect(main[0]).toMatchObject({ path: '/search', label: 'Search', order: 10, source: 'api' });
@@ -76,12 +90,12 @@ describe('/api/menu', () => {
       .get('/plain', () => ({}), {
         detail: { tags: [], summary: 'plain' },
       });
-    const items = buildMenuItems([sub]).filter((i) => i.source === 'api');
+    const items = menuItemsFromRoutes([sub]);
     expect(items).toHaveLength(0);
   });
 
   test('menu endpoint self-marks as hidden via detail.menu', () => {
-    const app = createMenuRoutes([]);
+    const app = createMenuRoutes();
     const menuRoute = app.routes.find((r) => r.path === '/api/menu');
     expect(menuRoute).toBeDefined();
     const detail = (menuRoute!.hooks as { detail?: { tags?: string[]; menu?: { group?: string } } })


### PR DESCRIPTION
## Summary
Phase A of menu_ui tracker #924 — move navigation from a per-request route scan to a persisted `menu_items` Drizzle table, with boot-time seeder that preserves user edits.

- **Schema**: new `menuItems` table in `src/db/schema.ts` (path UNIQUE, group_key, position, enabled, access, source, icon, touched_at, parent_id self-ref, timestamps) with `idx_menu_parent` + `idx_menu_group`.
- **Migration**: `src/db/migrations/0007_add_menu_items.sql` — Drizzle-generated, not hand-written.
- **Seeder**: `src/db/seeders/menu-seeder.ts` — idempotent, transactional. Iterates routes with `detail.menu`, upserts by studio path. User-edited rows (`touchedAt != null`) are preserved across re-seed; route drift on untouched rows triggers UPDATE.
- **Endpoint**: `src/routes/menu/menu.ts` now reads from DB via `readApiMenuItemsFromDb()`. `buildMenuItems` signature changed to take pre-resolved api items (from DB or `menuItemsFromRoutes` helper for tests).
- **Wiring**: `src/server.ts` runs the seeder against `apiModules` before starting the HTTP listener, logs `inserted/updated/preserved` counts.
- **Tangent**: added a minimal `consultLog` schema stub so this migration doesn't drop the legacy table (zero rows in live DB but out of scope for this PR).

## Test plan
- [x] `bun test` — 375 pass / 17 skip / 0 fail
- [x] `tests/http/menu/db-seeder.test.ts` — 8 new tests (row mapping, insert, idempotency, untouched-update, user-edit preservation, enabled flag filter)
- [x] Existing menu tests updated to new signatures: `buildMenuItems(menuItemsFromRoutes(sources), ...)` and `createMenuRoutes()` takes no args
- [x] `bun build src/server.ts` — clean bundle
- [ ] Manual /api/menu smoke (deferred to team-lead merge)

Links #924. Builds on #925 (detail.menu extension from PR #2 in this wave).

🤖 Generated with [Claude Code](https://claude.com/claude-code)