### PR TITLE
feat(menu): Phase B — tree/items CRUD, reorder (txn), reset

### DIFF
--- a/src/routes/menu/admin-order.ts
+++ b/src/routes/menu/admin-order.ts
@@ -1,0 +1,101 @@
+/**
+ * Menu admin — bulk reorder + reset.
+ * Reorder wraps all updates in a Drizzle transaction so any missing id
+ * rolls back the whole batch.
+ */
+
+import { Elysia, t } from 'elysia';
+import { eq } from 'drizzle-orm';
+import { db, menuItems } from '../../db/index.ts';
+
+export function createMenuOrderRoutes() {
+  return new Elysia()
+    .post(
+      '/menu/reorder',
+      ({ body, set }) => {
+        const now = new Date();
+        try {
+          const ids = db.transaction((tx) => {
+            const touched: number[] = [];
+            for (const item of body.items) {
+              const row = tx
+                .update(menuItems)
+                .set({
+                  parentId: item.parentId ?? null,
+                  position: item.position,
+                  touchedAt: now,
+                  updatedAt: now,
+                })
+                .where(eq(menuItems.id, item.id))
+                .returning({ id: menuItems.id })
+                .get();
+              if (!row) {
+                throw new Error(`menu item ${item.id} not found`);
+              }
+              touched.push(row.id);
+            }
+            return touched;
+          });
+          return { updated: ids.length, ids };
+        } catch (err) {
+          set.status = 400;
+          return { error: (err as Error).message };
+        }
+      },
+      {
+        body: t.Object({
+          items: t.Array(
+            t.Object({
+              id: t.Number(),
+              parentId: t.Optional(t.Nullable(t.Number())),
+              position: t.Number(),
+            }),
+          ),
+        }),
+        detail: {
+          tags: ['menu'],
+          menu: { group: 'admin', order: 905 },
+          summary: 'Bulk reorder in a transaction; any missing id rolls back the batch',
+        },
+      },
+    )
+    .post(
+      '/menu/reset/:id',
+      ({ params, set }) => {
+        const id = Number(params.id);
+        if (!Number.isFinite(id)) {
+          set.status = 400;
+          return { error: 'invalid id' };
+        }
+        const row = db.select().from(menuItems).where(eq(menuItems.id, id)).get();
+        if (!row) {
+          set.status = 404;
+          return { error: 'not found' };
+        }
+        if (row.source !== 'route') {
+          set.status = 400;
+          return { error: 'only route-sourced items can be reset' };
+        }
+        const now = new Date();
+        const updated = db
+          .update(menuItems)
+          .set({ touchedAt: null, updatedAt: now })
+          .where(eq(menuItems.id, id))
+          .returning()
+          .get();
+        return {
+          id: updated!.id,
+          path: updated!.path,
+          touchedAt: updated!.touchedAt,
+        };
+      },
+      {
+        params: t.Object({ id: t.String() }),
+        detail: {
+          tags: ['menu'],
+          menu: { group: 'admin', order: 906 },
+          summary: 'Clear touchedAt so next boot seed re-applies route defaults',
+        },
+      },
+    );
+}

--- a/src/routes/menu/admin.ts
+++ b/src/routes/menu/admin.ts
@@ -1,0 +1,218 @@
+/**
+ * Menu admin endpoints — tree, list, CRUD, reorder, reset.
+ * All writes go through Drizzle ORM. User edits set touchedAt=now so the
+ * boot seeder preserves them on the next run.
+ */
+
+import { Elysia, t } from 'elysia';
+import { eq, asc } from 'drizzle-orm';
+import { db, menuItems } from '../../db/index.ts';
+
+type MenuRow = typeof menuItems.$inferSelect;
+
+const GroupSchema = t.Union([
+  t.Literal('main'),
+  t.Literal('tools'),
+  t.Literal('admin'),
+  t.Literal('hidden'),
+]);
+const AccessSchema = t.Union([t.Literal('public'), t.Literal('auth')]);
+
+function toResponse(row: MenuRow) {
+  return {
+    id: row.id,
+    path: row.path,
+    label: row.label,
+    groupKey: row.groupKey,
+    parentId: row.parentId,
+    position: row.position,
+    enabled: row.enabled,
+    access: row.access,
+    source: row.source,
+    icon: row.icon,
+    touchedAt: row.touchedAt ? row.touchedAt.getTime() : null,
+    createdAt: row.createdAt.getTime(),
+    updatedAt: row.updatedAt.getTime(),
+  };
+}
+
+type ResponseRow = ReturnType<typeof toResponse>;
+type TreeNode = ResponseRow & { children: TreeNode[] };
+
+function buildTree(rows: MenuRow[]): TreeNode[] {
+  const nodes = new Map<number, TreeNode>();
+  for (const row of rows) nodes.set(row.id, { ...toResponse(row), children: [] });
+  const roots: TreeNode[] = [];
+  for (const row of rows) {
+    const node = nodes.get(row.id)!;
+    const parent = row.parentId == null ? null : nodes.get(row.parentId);
+    if (parent) parent.children.push(node);
+    else roots.push(node);
+  }
+  return roots;
+}
+
+export function createMenuAdminRoutes() {
+  return new Elysia()
+    .get(
+      '/menu/tree',
+      () => {
+        const rows = db.select().from(menuItems).orderBy(asc(menuItems.position)).all();
+        return { items: buildTree(rows) };
+      },
+      {
+        detail: {
+          tags: ['menu'],
+          menu: { group: 'admin', order: 900 },
+          summary: 'Menu items as nested tree by parent_id',
+        },
+      },
+    )
+    .get(
+      '/menu/items',
+      () => {
+        const rows = db
+          .select()
+          .from(menuItems)
+          .orderBy(asc(menuItems.groupKey), asc(menuItems.position))
+          .all();
+        return { items: rows.map(toResponse) };
+      },
+      {
+        detail: {
+          tags: ['menu'],
+          menu: { group: 'admin', order: 901 },
+          summary: 'Admin list of all menu_items rows (all DB fields)',
+        },
+      },
+    )
+    .post(
+      '/menu/items',
+      ({ body, set }) => {
+        const now = new Date();
+        try {
+          const inserted = db
+            .insert(menuItems)
+            .values({
+              path: body.path,
+              label: body.label,
+              groupKey: body.groupKey ?? 'main',
+              parentId: body.parentId ?? null,
+              position: body.position ?? 999,
+              enabled: body.enabled ?? true,
+              access: body.access ?? 'public',
+              source: 'custom',
+              icon: body.icon ?? null,
+              touchedAt: now,
+              createdAt: now,
+              updatedAt: now,
+            })
+            .returning()
+            .get();
+          set.status = 201;
+          return toResponse(inserted);
+        } catch (err) {
+          set.status = 409;
+          return { error: (err as Error).message };
+        }
+      },
+      {
+        body: t.Object({
+          path: t.String({ minLength: 1 }),
+          label: t.String({ minLength: 1 }),
+          groupKey: t.Optional(GroupSchema),
+          parentId: t.Optional(t.Nullable(t.Number())),
+          position: t.Optional(t.Number()),
+          enabled: t.Optional(t.Boolean()),
+          access: t.Optional(AccessSchema),
+          icon: t.Optional(t.String()),
+        }),
+        detail: {
+          tags: ['menu'],
+          menu: { group: 'admin', order: 902 },
+          summary: 'Create a custom menu item (source=custom)',
+        },
+      },
+    )
+    .patch(
+      '/menu/items/:id',
+      ({ params, body, set }) => {
+        const id = Number(params.id);
+        if (!Number.isFinite(id)) {
+          set.status = 400;
+          return { error: 'invalid id' };
+        }
+        const now = new Date();
+        const patch: Partial<MenuRow> = { updatedAt: now, touchedAt: now };
+        if (body.label !== undefined) patch.label = body.label;
+        if (body.groupKey !== undefined) patch.groupKey = body.groupKey;
+        if (body.parentId !== undefined) patch.parentId = body.parentId;
+        if (body.position !== undefined) patch.position = body.position;
+        if (body.enabled !== undefined) patch.enabled = body.enabled;
+        if (body.access !== undefined) patch.access = body.access;
+        if (body.icon !== undefined) patch.icon = body.icon;
+
+        const updated = db
+          .update(menuItems)
+          .set(patch)
+          .where(eq(menuItems.id, id))
+          .returning()
+          .get();
+        if (!updated) {
+          set.status = 404;
+          return { error: 'not found' };
+        }
+        return toResponse(updated);
+      },
+      {
+        params: t.Object({ id: t.String() }),
+        body: t.Object({
+          label: t.Optional(t.String({ minLength: 1 })),
+          groupKey: t.Optional(GroupSchema),
+          parentId: t.Optional(t.Nullable(t.Number())),
+          position: t.Optional(t.Number()),
+          enabled: t.Optional(t.Boolean()),
+          access: t.Optional(AccessSchema),
+          icon: t.Optional(t.Nullable(t.String())),
+        }),
+        detail: {
+          tags: ['menu'],
+          menu: { group: 'admin', order: 903 },
+          summary: 'Edit a menu item (sets touchedAt=now)',
+        },
+      },
+    )
+    .delete(
+      '/menu/items/:id',
+      ({ params, set }) => {
+        const id = Number(params.id);
+        if (!Number.isFinite(id)) {
+          set.status = 400;
+          return { error: 'invalid id' };
+        }
+        const row = db.select().from(menuItems).where(eq(menuItems.id, id)).get();
+        if (!row) {
+          set.status = 404;
+          return { error: 'not found' };
+        }
+        if (row.source === 'custom') {
+          db.delete(menuItems).where(eq(menuItems.id, id)).run();
+          return { id, deleted: 'hard' as const };
+        }
+        const now = new Date();
+        db.update(menuItems)
+          .set({ enabled: false, touchedAt: now, updatedAt: now })
+          .where(eq(menuItems.id, id))
+          .run();
+        return { id, deleted: 'soft' as const };
+      },
+      {
+        params: t.Object({ id: t.String() }),
+        detail: {
+          tags: ['menu'],
+          menu: { group: 'admin', order: 904 },
+          summary: 'Hard-delete custom items; soft-delete (enabled=false) others',
+        },
+      },
+    );
+}

--- a/src/routes/menu/index.ts
+++ b/src/routes/menu/index.ts
@@ -8,11 +8,15 @@
 import { Elysia } from 'elysia';
 import { createMenuEndpoint } from './menu.ts';
 import { createCustomMenuRoutes } from './custom.ts';
+import { createMenuAdminRoutes } from './admin.ts';
+import { createMenuOrderRoutes } from './admin-order.ts';
 
 export function createMenuRoutes() {
   return new Elysia({ prefix: '/api' })
     .use(createMenuEndpoint())
-    .use(createCustomMenuRoutes());
+    .use(createCustomMenuRoutes())
+    .use(createMenuAdminRoutes())
+    .use(createMenuOrderRoutes());
 }
 
 export {

--- a/tests/http/menu/crud.test.ts
+++ b/tests/http/menu/crud.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Menu admin CRUD — tree, list, create, patch, delete.
+ *
+ * Covers the full lifecycle of custom + route-sourced rows, including the
+ * soft-vs-hard delete split and the touchedAt=now invariant on edits.
+ */
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { Elysia } from 'elysia';
+import { eq } from 'drizzle-orm';
+import { createMenuRoutes } from '../../../src/routes/menu/index.ts';
+import { db, menuItems } from '../../../src/db/index.ts';
+import { seedMenuItems } from '../../../src/db/seeders/menu-seeder.ts';
+
+function clearMenu() {
+  db.delete(menuItems).run();
+}
+
+function sampleSource() {
+  return new Elysia({ prefix: '/api' })
+    .get('/search', () => ({}), {
+      detail: { menu: { group: 'main', order: 10 }, summary: 'Search' },
+    })
+    .get('/traces', () => ({}), {
+      detail: { menu: { group: 'main', order: 40 }, summary: 'Traces' },
+    })
+    .get('/map', () => ({}), {
+      detail: { menu: { group: 'tools', order: 20 }, summary: 'Map' },
+    });
+}
+
+async function call(
+  app: Elysia,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; json: any }> {
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+    init.headers = { 'content-type': 'application/json' };
+  }
+  const res = await app.handle(new Request(`http://localhost${path}`, init));
+  const text = await res.text();
+  return { status: res.status, json: text ? JSON.parse(text) : null };
+}
+
+describe('GET /api/menu/tree', () => {
+  beforeEach(() => clearMenu());
+
+  test('returns all rows nested by parent_id', async () => {
+    seedMenuItems([sampleSource()]);
+    const app = createMenuRoutes();
+
+    const rows = db.select().from(menuItems).all();
+    const search = rows.find((r) => r.path === '/search')!;
+    db.update(menuItems)
+      .set({ parentId: search.id })
+      .where(eq(menuItems.path, '/traces'))
+      .run();
+
+    const { status, json } = await call(app, 'GET', '/api/menu/tree');
+    expect(status).toBe(200);
+    const root = json.items.find((i: any) => i.path === '/search');
+    expect(root).toBeDefined();
+    expect(root.children.map((c: any) => c.path)).toContain('/traces');
+  });
+});
+
+describe('GET /api/menu/items', () => {
+  beforeEach(() => clearMenu());
+
+  test('lists every DB field incl. touchedAt / source / enabled', async () => {
+    seedMenuItems([sampleSource()]);
+    const app = createMenuRoutes();
+    const { status, json } = await call(app, 'GET', '/api/menu/items');
+    expect(status).toBe(200);
+    expect(json.items).toHaveLength(3);
+    const search = json.items.find((i: any) => i.path === '/search');
+    expect(search).toMatchObject({
+      label: 'Search',
+      groupKey: 'main',
+      position: 10,
+      enabled: true,
+      source: 'route',
+      touchedAt: null,
+    });
+  });
+});
+
+describe('POST /api/menu/items (create custom)', () => {
+  beforeEach(() => clearMenu());
+
+  test('creates a custom row with source=custom and touchedAt set', async () => {
+    const app = createMenuRoutes();
+    const { status, json } = await call(app, 'POST', '/api/menu/items', {
+      path: '/my-page',
+      label: 'My Page',
+      groupKey: 'tools',
+      position: 50,
+    });
+    expect(status).toBe(201);
+    expect(json.source).toBe('custom');
+    expect(json.path).toBe('/my-page');
+    expect(json.touchedAt).toBeGreaterThan(0);
+
+    const row = db.select().from(menuItems).where(eq(menuItems.path, '/my-page')).get();
+    expect(row?.source).toBe('custom');
+    expect(row?.touchedAt).not.toBeNull();
+  });
+
+  test('returns 409 on duplicate path', async () => {
+    const app = createMenuRoutes();
+    await call(app, 'POST', '/api/menu/items', { path: '/dup', label: 'Dup' });
+    const dup = await call(app, 'POST', '/api/menu/items', { path: '/dup', label: 'Dup 2' });
+    expect(dup.status).toBe(409);
+  });
+});
+
+describe('PATCH /api/menu/items/:id', () => {
+  beforeEach(() => clearMenu());
+
+  test('edits fields and sets touchedAt=now', async () => {
+    seedMenuItems([sampleSource()]);
+    const before = db
+      .select()
+      .from(menuItems)
+      .where(eq(menuItems.path, '/search'))
+      .get()!;
+    expect(before.touchedAt).toBeNull();
+
+    const app = createMenuRoutes();
+    const { status, json } = await call(app, 'PATCH', `/api/menu/items/${before.id}`, {
+      label: 'Find',
+      position: 5,
+    });
+    expect(status).toBe(200);
+    expect(json.label).toBe('Find');
+    expect(json.position).toBe(5);
+    expect(json.touchedAt).toBeGreaterThan(0);
+  });
+
+  test('404 on unknown id', async () => {
+    const app = createMenuRoutes();
+    const { status } = await call(app, 'PATCH', '/api/menu/items/99999', { label: 'x' });
+    expect(status).toBe(404);
+  });
+});
+
+describe('DELETE /api/menu/items/:id', () => {
+  beforeEach(() => clearMenu());
+
+  test('soft-deletes route-sourced rows (enabled=false)', async () => {
+    seedMenuItems([sampleSource()]);
+    const row = db
+      .select()
+      .from(menuItems)
+      .where(eq(menuItems.path, '/map'))
+      .get()!;
+
+    const app = createMenuRoutes();
+    const { status, json } = await call(app, 'DELETE', `/api/menu/items/${row.id}`);
+    expect(status).toBe(200);
+    expect(json.deleted).toBe('soft');
+
+    const after = db.select().from(menuItems).where(eq(menuItems.id, row.id)).get();
+    expect(after?.enabled).toBe(false);
+  });
+
+  test('hard-deletes custom rows', async () => {
+    const app = createMenuRoutes();
+    const created = await call(app, 'POST', '/api/menu/items', {
+      path: '/custom-x',
+      label: 'X',
+    });
+    const { status, json } = await call(app, 'DELETE', `/api/menu/items/${created.json.id}`);
+    expect(status).toBe(200);
+    expect(json.deleted).toBe('hard');
+    const after = db
+      .select()
+      .from(menuItems)
+      .where(eq(menuItems.id, created.json.id))
+      .get();
+    expect(after).toBeUndefined();
+  });
+
+  test('404 on unknown id', async () => {
+    const app = createMenuRoutes();
+    const { status } = await call(app, 'DELETE', '/api/menu/items/99999');
+    expect(status).toBe(404);
+  });
+});

--- a/tests/http/menu/reorder.test.ts
+++ b/tests/http/menu/reorder.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Menu admin — POST /api/menu/reorder.
+ *
+ * Verifies: bulk update applies to all listed rows, each row gets
+ * touchedAt=now, and any missing id rolls back the entire batch
+ * (Drizzle transaction semantics).
+ */
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { Elysia } from 'elysia';
+import { eq } from 'drizzle-orm';
+import { createMenuRoutes } from '../../../src/routes/menu/index.ts';
+import { db, menuItems } from '../../../src/db/index.ts';
+import { seedMenuItems } from '../../../src/db/seeders/menu-seeder.ts';
+
+function clearMenu() {
+  db.delete(menuItems).run();
+}
+
+function sampleSource() {
+  return new Elysia({ prefix: '/api' })
+    .get('/search', () => ({}), {
+      detail: { menu: { group: 'main', order: 10 }, summary: 'Search' },
+    })
+    .get('/traces', () => ({}), {
+      detail: { menu: { group: 'main', order: 40 }, summary: 'Traces' },
+    })
+    .get('/map', () => ({}), {
+      detail: { menu: { group: 'tools', order: 20 }, summary: 'Map' },
+    });
+}
+
+async function post(app: Elysia, path: string, body: unknown) {
+  const res = await app.handle(
+    new Request(`http://localhost${path}`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'content-type': 'application/json' },
+    }),
+  );
+  const text = await res.text();
+  return { status: res.status, json: text ? JSON.parse(text) : null };
+}
+
+describe('POST /api/menu/reorder', () => {
+  beforeEach(() => clearMenu());
+
+  test('updates position + parentId for every listed row', async () => {
+    seedMenuItems([sampleSource()]);
+    const rows = db.select().from(menuItems).all();
+    const search = rows.find((r) => r.path === '/search')!;
+    const traces = rows.find((r) => r.path === '/traces')!;
+    const map = rows.find((r) => r.path === '/map')!;
+
+    const app = createMenuRoutes();
+    const { status, json } = await post(app, '/api/menu/reorder', {
+      items: [
+        { id: search.id, parentId: null, position: 1 },
+        { id: traces.id, parentId: search.id, position: 2 },
+        { id: map.id, parentId: null, position: 3 },
+      ],
+    });
+    expect(status).toBe(200);
+    expect(json.updated).toBe(3);
+
+    const after = db.select().from(menuItems).all();
+    const afterSearch = after.find((r) => r.id === search.id)!;
+    const afterTraces = after.find((r) => r.id === traces.id)!;
+    const afterMap = after.find((r) => r.id === map.id)!;
+    expect(afterSearch.position).toBe(1);
+    expect(afterTraces.position).toBe(2);
+    expect(afterTraces.parentId).toBe(search.id);
+    expect(afterMap.position).toBe(3);
+  });
+
+  test('sets touchedAt=now on every modified row', async () => {
+    seedMenuItems([sampleSource()]);
+    const before = db.select().from(menuItems).all();
+    expect(before.every((r) => r.touchedAt === null)).toBe(true);
+
+    const app = createMenuRoutes();
+    await post(app, '/api/menu/reorder', {
+      items: before.map((r, i) => ({ id: r.id, position: i })),
+    });
+
+    const after = db.select().from(menuItems).all();
+    for (const row of after) {
+      expect(row.touchedAt).not.toBeNull();
+    }
+  });
+
+  test('rolls back the entire batch when any id is missing', async () => {
+    seedMenuItems([sampleSource()]);
+    const rows = db.select().from(menuItems).all();
+    const search = rows.find((r) => r.path === '/search')!;
+    const map = rows.find((r) => r.path === '/map')!;
+
+    const app = createMenuRoutes();
+    const { status } = await post(app, '/api/menu/reorder', {
+      items: [
+        { id: search.id, position: 100 },
+        { id: 999999, position: 101 },
+        { id: map.id, position: 102 },
+      ],
+    });
+    expect(status).toBe(400);
+
+    const afterSearch = db
+      .select()
+      .from(menuItems)
+      .where(eq(menuItems.id, search.id))
+      .get();
+    const afterMap = db
+      .select()
+      .from(menuItems)
+      .where(eq(menuItems.id, map.id))
+      .get();
+    expect(afterSearch?.position).toBe(10);
+    expect(afterMap?.position).toBe(20);
+    expect(afterSearch?.touchedAt).toBeNull();
+    expect(afterMap?.touchedAt).toBeNull();
+  });
+
+  test('accepts an empty items array as a no-op', async () => {
+    const app = createMenuRoutes();
+    const { status, json } = await post(app, '/api/menu/reorder', { items: [] });
+    expect(status).toBe(200);
+    expect(json.updated).toBe(0);
+  });
+});

--- a/tests/http/menu/reset.test.ts
+++ b/tests/http/menu/reset.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Menu admin — POST /api/menu/reset/:id.
+ *
+ * Resetting a route-sourced row clears touchedAt so the next boot
+ * seed run re-applies the current route metadata (label, position,
+ * group, access, icon).
+ */
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { Elysia } from 'elysia';
+import { eq } from 'drizzle-orm';
+import { createMenuRoutes } from '../../../src/routes/menu/index.ts';
+import { db, menuItems } from '../../../src/db/index.ts';
+import { seedMenuItems } from '../../../src/db/seeders/menu-seeder.ts';
+
+function clearMenu() {
+  db.delete(menuItems).run();
+}
+
+function routeSource(label = 'Search', order = 10) {
+  return new Elysia({ prefix: '/api' }).get('/search', () => ({}), {
+    detail: { menu: { group: 'main', order, label }, summary: 'Search' },
+  });
+}
+
+async function post(app: Elysia, path: string, body?: unknown) {
+  const init: RequestInit = { method: 'POST' };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+    init.headers = { 'content-type': 'application/json' };
+  }
+  const res = await app.handle(new Request(`http://localhost${path}`, init));
+  const text = await res.text();
+  return { status: res.status, json: text ? JSON.parse(text) : null };
+}
+
+describe('POST /api/menu/reset/:id', () => {
+  beforeEach(() => clearMenu());
+
+  test('clears touchedAt on a previously user-edited row', async () => {
+    seedMenuItems([routeSource()]);
+    const row = db
+      .select()
+      .from(menuItems)
+      .where(eq(menuItems.path, '/search'))
+      .get()!;
+
+    const now = new Date();
+    db.update(menuItems)
+      .set({ label: 'My Search', touchedAt: now, updatedAt: now })
+      .where(eq(menuItems.id, row.id))
+      .run();
+    const touched = db.select().from(menuItems).where(eq(menuItems.id, row.id)).get()!;
+    expect(touched.touchedAt).not.toBeNull();
+
+    const app = createMenuRoutes();
+    const { status, json } = await post(app, `/api/menu/reset/${row.id}`);
+    expect(status).toBe(200);
+    expect(json.touchedAt).toBeNull();
+
+    const after = db.select().from(menuItems).where(eq(menuItems.id, row.id)).get();
+    expect(after?.touchedAt).toBeNull();
+  });
+
+  test('after reset, re-seeding restores the current route defaults', async () => {
+    seedMenuItems([routeSource('Search', 10)]);
+    const row = db
+      .select()
+      .from(menuItems)
+      .where(eq(menuItems.path, '/search'))
+      .get()!;
+
+    const now = new Date();
+    db.update(menuItems)
+      .set({ label: 'User Rename', position: 77, touchedAt: now, updatedAt: now })
+      .where(eq(menuItems.id, row.id))
+      .run();
+
+    const preReseed = seedMenuItems([routeSource('Search', 10)]);
+    expect(preReseed.preserved).toBe(1);
+
+    const app = createMenuRoutes();
+    await post(app, `/api/menu/reset/${row.id}`);
+
+    const postReseed = seedMenuItems([routeSource('Search', 10)]);
+    expect(postReseed.updated).toBe(1);
+
+    const after = db.select().from(menuItems).where(eq(menuItems.id, row.id)).get();
+    expect(after?.label).toBe('Search');
+    expect(after?.position).toBe(10);
+  });
+
+  test('400 when target row is not route-sourced', async () => {
+    const app = createMenuRoutes();
+    const created = await post(app, '/api/menu/items', {
+      path: '/custom-reset',
+      label: 'C',
+    });
+    const { status, json } = await post(app, `/api/menu/reset/${created.json.id}`);
+    expect(status).toBe(400);
+    expect(json.error).toMatch(/route-sourced/);
+  });
+
+  test('404 on unknown id', async () => {
+    const app = createMenuRoutes();
+    const { status } = await post(app, '/api/menu/reset/99999');
+    expect(status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds menu_items admin endpoints (tree, list, create, patch, delete, bulk reorder, reset) wired into `/api` via Drizzle ORM.
- Reorder wraps updates in a Drizzle transaction — a missing id rolls back the full batch (verified by test).
- User-edit endpoints set `touchedAt=now` so the boot seeder preserves them on next run. `POST /menu/reset/:id` clears `touchedAt` so the next seed restores route defaults.
- Admin endpoints are tagged `detail.menu: { group: 'admin', order: 900+ }` so they surface in the admin group, not main nav.

## Endpoints (all under `/api`)
| Method | Path | Notes |
|---|---|---|
| GET | `/menu/tree` | Nested by `parent_id` |
| GET | `/menu/items` | Full DB fields, ordered by group+position |
| POST | `/menu/items` | Create custom (`source='custom'`, `touchedAt=now`) |
| PATCH | `/menu/items/:id` | Edit any field, sets `touchedAt=now` |
| DELETE | `/menu/items/:id` | Hard-delete `source='custom'`, soft-delete (`enabled=false`) otherwise |
| POST | `/menu/reorder` | Bulk `[{id, parentId, position}]` in a txn |
| POST | `/menu/reset/:id` | Route-sourced only; clears `touchedAt` |

## Files
- `src/routes/menu/admin.ts` (tree/list/CRUD)
- `src/routes/menu/admin-order.ts` (reorder/reset; split to keep files ≤250 lines)
- `src/routes/menu/index.ts` (wire new sub-apps into `createMenuRoutes`)
- `tests/http/menu/{crud,reorder,reset}.test.ts`

## Test plan
- [x] `bun test tests/http/menu/` — 62 pass, 0 fail
- [x] `bun test` — 392 pass, 17 skip, 0 fail (409 across 35 files)
- [x] `bun run build` (tsc --noEmit) — clean
- [ ] Manual smoke after merge — curl each endpoint

Closes #924. Blocks Phase C (#2 — studio drag-drop UI).

🤖 ตอบโดย arra-oracle-v3 จาก [Nat Weerawan] → arra-oracle-v3-oracle