### PR TITLE
test(menu): lock in Playground config behavior — RCA #929 Part B (not-a-bug)

### DIFF
--- a/tests/http/menu/playground-config.test.ts
+++ b/tests/http/menu/playground-config.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Regression — Playground row (route-sourced, /playground, group='main') must
+ * accept the same PATCH operations the /menu editor emits: toggle enabled,
+ * rename, move to another group, and reorder via position.
+ *
+ * Guards against issue #929 Part B symptom: "Playground item cannot be
+ * configured — changes fail silently or do not persist."
+ *
+ * Covers hypotheses 1, 3, 7, 8 from the issue:
+ *   H1. PATCH body accepts native `{ enabled: boolean }`
+ *   H3. :id param coerces from string to int
+ *   H7. Seeder preserves touchedAt!=null on re-run (user edit wins)
+ *   H8. All editor-emitted partial bodies are accepted by TypeBox schema
+ *
+ * Also verifies aggregated `/api/menu` reflects DB mutations — the live nav
+ * surface that studio's Header reads.
+ */
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { Elysia } from 'elysia';
+import { eq } from 'drizzle-orm';
+import { createMenuRoutes } from '../../../src/routes/menu/index.ts';
+import { db, menuItems } from '../../../src/db/index.ts';
+import { seedMenuItems } from '../../../src/db/seeders/menu-seeder.ts';
+
+function clearMenu() {
+  db.delete(menuItems).run();
+}
+
+function playgroundSource() {
+  // Mirrors the real route shape — /api/reflect maps to /playground via
+  // API_TO_STUDIO, group='main' order=30 in production.
+  return new Elysia({ prefix: '/api' })
+    .get('/reflect', () => ({}), {
+      detail: { menu: { group: 'main', order: 30 }, summary: 'Playground' },
+    });
+}
+
+async function call(
+  app: Elysia,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; json: any }> {
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+    init.headers = { 'content-type': 'application/json' };
+  }
+  const res = await app.handle(new Request(`http://localhost${path}`, init));
+  const text = await res.text();
+  return { status: res.status, json: text ? JSON.parse(text) : null };
+}
+
+function getPlayground() {
+  return db.select().from(menuItems).where(eq(menuItems.path, '/playground')).get()!;
+}
+
+describe('PATCH /api/menu/items/:id — Playground row (issue #929 Part B)', () => {
+  beforeEach(() => clearMenu());
+
+  test('toggle enabled=false persists and aggregated /api/menu drops the row', async () => {
+    seedMenuItems([playgroundSource()]);
+    const row = getPlayground();
+    expect(row.enabled).toBe(true);
+    expect(row.source).toBe('route');
+
+    const app = createMenuRoutes();
+    const { status, json } = await call(app, 'PATCH', `/api/menu/items/${row.id}`, {
+      enabled: false,
+    });
+    expect(status).toBe(200);
+    expect(json.enabled).toBe(false);
+    expect(json.touchedAt).toBeGreaterThan(0);
+
+    expect(getPlayground().enabled).toBe(false);
+
+    const menu = await call(app, 'GET', '/api/menu');
+    expect(menu.status).toBe(200);
+    expect(menu.json.items.find((i: any) => i.path === '/playground')).toBeUndefined();
+  });
+
+  test('toggle enabled=true re-enables and aggregated /api/menu includes the row', async () => {
+    seedMenuItems([playgroundSource()]);
+    const row = getPlayground();
+    const app = createMenuRoutes();
+
+    await call(app, 'PATCH', `/api/menu/items/${row.id}`, { enabled: false });
+    const { status, json } = await call(app, 'PATCH', `/api/menu/items/${row.id}`, {
+      enabled: true,
+    });
+    expect(status).toBe(200);
+    expect(json.enabled).toBe(true);
+
+    const menu = await call(app, 'GET', '/api/menu');
+    expect(menu.json.items.find((i: any) => i.path === '/playground')).toBeDefined();
+  });
+
+  test('rename label persists and is visible in aggregated /api/menu', async () => {
+    seedMenuItems([playgroundSource()]);
+    const row = getPlayground();
+    const app = createMenuRoutes();
+
+    const { status, json } = await call(app, 'PATCH', `/api/menu/items/${row.id}`, {
+      label: 'PG Renamed',
+    });
+    expect(status).toBe(200);
+    expect(json.label).toBe('PG Renamed');
+
+    const menu = await call(app, 'GET', '/api/menu');
+    const pg = menu.json.items.find((i: any) => i.path === '/playground');
+    expect(pg?.label).toBe('PG Renamed');
+  });
+
+  test('move to different group persists', async () => {
+    seedMenuItems([playgroundSource()]);
+    const row = getPlayground();
+    const app = createMenuRoutes();
+
+    const { status, json } = await call(app, 'PATCH', `/api/menu/items/${row.id}`, {
+      groupKey: 'tools',
+    });
+    expect(status).toBe(200);
+    expect(json.groupKey).toBe('tools');
+
+    const menu = await call(app, 'GET', '/api/menu');
+    const pg = menu.json.items.find((i: any) => i.path === '/playground');
+    expect(pg?.group).toBe('tools');
+  });
+
+  test('position change persists across fetch', async () => {
+    seedMenuItems([playgroundSource()]);
+    const row = getPlayground();
+    const app = createMenuRoutes();
+
+    const { status, json } = await call(app, 'PATCH', `/api/menu/items/${row.id}`, {
+      position: 5,
+    });
+    expect(status).toBe(200);
+    expect(json.position).toBe(5);
+
+    const list = await call(app, 'GET', '/api/menu/items');
+    const pg = list.json.items.find((i: any) => i.path === '/playground');
+    expect(pg.position).toBe(5);
+  });
+
+  test('native boolean body (not 0/1) is accepted — H1 regression', async () => {
+    seedMenuItems([playgroundSource()]);
+    const row = getPlayground();
+    const app = createMenuRoutes();
+
+    // This is the exact body shape MenuEditor emits (JSON.stringify of a JS
+    // boolean → `false`, not `0`). SQLite via Drizzle mode:'boolean' must
+    // round-trip without coercion errors.
+    const { status } = await call(app, 'PATCH', `/api/menu/items/${row.id}`, {
+      enabled: false,
+    });
+    expect(status).toBe(200);
+  });
+
+  test('seeder preserves user edit on re-run — H7 regression', async () => {
+    seedMenuItems([playgroundSource()]);
+    const row = getPlayground();
+    const app = createMenuRoutes();
+
+    await call(app, 'PATCH', `/api/menu/items/${row.id}`, {
+      label: 'User Edit',
+      enabled: false,
+      groupKey: 'tools',
+    });
+
+    // Second seeder run (simulates server reboot)
+    seedMenuItems([playgroundSource()]);
+
+    const after = getPlayground();
+    expect(after.label).toBe('User Edit');
+    expect(after.enabled).toBe(false);
+    expect(after.groupKey).toBe('tools');
+  });
+});


### PR DESCRIPTION
## Summary

Issue #929 Part B reports: *Playground row cannot be configured from /menu editor — toggle/rename/move fails silently or doesn't persist.*

**RCA: not reproducible against alpha.13+menu Phase A+B.** Every one of the 8 hypotheses in the issue disproven by direct curl + code audit. This PR ships a 7-test regression suite that locks in the reported behaviors so the bug cannot silently regress.

No production code changed.

## Evidence

Backend running locally on `http://localhost:47778`.

### 1. Fetch Playground row
```bash
curl -s http://localhost:47778/api/menu/items | jq '.items[] | select(.path=="/playground")'
# { "id": 149, "path": "/playground", "label": "Playground",
#   "groupKey": "main", "position": 30, "enabled": true,
#   "source": "route", "touchedAt": 1776576141000, ... }
```

### 2. PATCH toggle/rename/move (H1, H3, H8)
```bash
curl -sX PATCH http://localhost:47778/api/menu/items/149 \
  -H 'content-type: application/json' \
  -d '{"enabled":false}' -w '\nHTTP: %{http_code}\n'
# HTTP: 200 — enabled:false persisted

curl -sX PATCH http://localhost:47778/api/menu/items/149 \
  -d '{"label":"PG Test"}' -H 'content-type: application/json' -w '\nHTTP: %{http_code}\n'
# HTTP: 200

curl -sX PATCH http://localhost:47778/api/menu/items/149 \
  -d '{"position":5}' -H 'content-type: application/json' -w '\nHTTP: %{http_code}\n'
# HTTP: 200

curl -sX PATCH http://localhost:47778/api/menu/items/149 \
  -d '{"groupKey":"tools"}' -H 'content-type: application/json' -w '\nHTTP: %{http_code}\n'
# HTTP: 200
```

All operations return 200 and persist across subsequent GETs.

### 3. CORS preflight from studio origin (H2)
```bash
curl -sX OPTIONS http://localhost:47778/api/menu/items/149 \
  -H 'Origin: https://studio.buildwithoracle.com' \
  -H 'Access-Control-Request-Method: PATCH' \
  -H 'Access-Control-Request-Headers: content-type' -i | head -6
# HTTP/1.1 204 No Content
# Access-Control-Allow-Origin: https://studio.buildwithoracle.com
# Access-Control-Allow-Methods: GET, POST, PUT, DELETE, PATCH, OPTIONS
# Access-Control-Allow-Headers: content-type
```

Preflight succeeds; PATCH is in the allowed-methods list.

### 4. Aggregated `/api/menu` reflects DB mutation
```bash
curl -sX PATCH http://localhost:47778/api/menu/items/149 \
  -d '{"enabled":false}' -H 'content-type: application/json' >/dev/null
curl -s http://localhost:47778/api/menu | jq '.items[] | select(.path=="/playground")'
# (empty) — aggregated menu correctly excludes disabled item ✓
```

## Hypothesis-by-hypothesis disposition

| # | Hypothesis | Verdict | Note |
|---|---|---|---|
| 1 | PATCH body shape mismatch (boolean vs 0/1) | **Disproven** | Schema is `t.Optional(t.Boolean())` — native booleans accepted. Drizzle `mode:'boolean'` round-trips cleanly. |
| 2 | CORS pre-flight blocks PATCH | **Disproven** | Elysia CORS allows `PATCH` with `studio.buildwithoracle.com` origin — see curl evidence. |
| 3 | ID type coercion | **Disproven** | `Number(params.id)` at `src/routes/menu/admin.ts:140` returns 400 only on `!Number.isFinite`; integer paths work. |
| 4 | Cross-origin Link interception in editor | **N/A** | MenuEditor row uses `<input onChange/onBlur>` and `<select onChange>` — no `<Link>`, no bubble nav. `isVectorPath` only affects the *top Header nav*, not the editor controls. |
| 5 | Stale state after drag | **Not reproducible** | Editor calls `await load()` after every patch; no stale-read window observed. |
| 6 | Controlled-input wrapper issue | **Disproven** | `MenuEditor.tsx:89-94` is plain HTML `<input>` + `onBlur` — no RHF/Radix wrapper. |
| 7 | Seeder overwrites user edits | **Disproven** | `menu-seeder.ts:117` guards `existing.touchedAt == null` before update. Test `seeds twice` asserts this. |
| 8 | TypeBox optional fields | **Disproven** | All PATCH body fields are `t.Optional(…)`; partial bodies accepted. |

## Why the user may have *perceived* the bug

1. **Header nav 5-min localStorage cache** (`oracle-studio/src/components/Header.tsx:30` `CACHE_TTL_MS`) — after an edit, the *top navigation bar* keeps showing the old label/ordering until the cache expires or the user does a hard reload. The `/menu` editor itself updates immediately, but the user may be looking at the nav to verify "did it stick?" and concluding it didn't.
2. Tab-focus / browser back: if the user makes the edit on studio.buildwithoracle.com but checks `local.buildwithoracle.com`, they hit a different backend (Header stores host per-origin).

Neither of these is a bug in the PATCH path. If the cache is judged user-hostile, file a separate issue; this PR is about proving the editor→DB→nav pipeline works.

## What this PR ships

- `tests/http/menu/playground-config.test.ts` — 7 tests, 24 expectations, scoped to the exact route shape (`/api/reflect` → `/playground`, group `main`, order 30) Playground uses in production.

Tests cover: toggle enabled off, toggle enabled on, rename, group-move, position-move, native-boolean body, and the seeder-preservation-on-reboot scenario.

```
$ bun test tests/http/menu/playground-config.test.ts
 7 pass
 0 fail
 24 expect() calls
Ran 7 tests across 1 file. [181.00ms]
```

## Closes

- Closes #929 Part B (not-a-bug — regression suite shipped instead)
- Part A of #929 continues in parallel on `feat/menu-gist-source`
- Part C (nav entry for /menu) remains open

## Test plan

- [ ] CI: `bun test tests/http/menu/` passes all suites
- [ ] Reviewer manually re-runs the curl sequence in §Evidence against a fresh backend
- [ ] Reviewer confirms no production code changed (`git diff origin/main -- src/` returns empty)

🤖 ตอบโดย arra-oracle-v3 จาก Nat → arra-oracle-v3-oracle