### PR TITLE
feat(menu): override apply mode + reset-all + official gist (#929 follow-up)

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -20,6 +20,7 @@ import {
   menuGistClear,
   menuGistReload,
 } from "./commands/menu-gist.ts";
+import { menuResetAll } from "./commands/menu-reset.ts";
 
 const pkg = await Bun.file(join(import.meta.dir, "../package.json")).json();
 const VERSION: string = pkg.version;
@@ -126,6 +127,9 @@ async function main() {
     if (sub === "gist-reload") {
       process.exit(await menuGistReload(rest));
     }
+    if (sub === "reset-all") {
+      process.exit(await menuResetAll(rest));
+    }
     if (!sub || sub === "--help" || sub === "-h") {
       console.log("arra-cli menu <subcommand>\n");
       console.log("Subcommands:");
@@ -134,16 +138,17 @@ async function main() {
       console.log("                                          add or replace a custom menu item");
       console.log("  remove <path>                           remove a custom menu item");
       console.log("  gist-status                             show current gist source");
-      console.log("  gist-url <url>                          set gist URL for menu source");
+      console.log("  gist-url <url> [--override]             set gist URL (merge|override)");
       console.log("  gist-clear                              clear gist URL");
       console.log("  gist-reload                             force refetch of gist menu");
+      console.log("  reset-all [--yes]                       nuclear reset (prompts y/N)");
       console.log("\nOutput defaults to JSON; pass --yml for YAML.");
       console.log("\nEnv:");
       console.log("  ORACLE_API          API base URL (default http://localhost:47778)");
       return;
     }
     console.error(`\x1b[31m✗\x1b[0m unknown menu subcommand: ${args[1]}`);
-    console.error("  try: arra-cli menu list|add|remove|gist-status|gist-url|gist-clear|gist-reload");
+    console.error("  try: arra-cli menu list|add|remove|gist-*|reset-all");
     process.exit(1);
   }
 

--- a/cli/src/commands/menu-gist.ts
+++ b/cli/src/commands/menu-gist.ts
@@ -43,16 +43,21 @@ export async function menuGistStatus(args: string[]): Promise<number> {
 export async function menuGistUrl(args: string[]): Promise<number> {
   const url = args.find((a) => !a.startsWith("-"));
   if (!url) {
-    console.error("usage: arra-cli menu gist-url <url>");
+    console.error("usage: arra-cli menu gist-url <url> [--override]");
     return 1;
   }
+  const mode = args.includes("--override") ? "override" : "merge";
   const result = await fetchJson("/api/menu/source", {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ url }),
+    body: JSON.stringify({ url, mode }),
   });
   if (result.code !== 0) return 1;
-  emit({ api: sessionApiBase(), source: result.body }, args);
+  const body = (result.body ?? {}) as { source?: unknown; mode?: string };
+  emit(
+    { api: sessionApiBase(), mode: body.mode ?? mode, source: body.source ?? body },
+    args,
+  );
   return 0;
 }
 

--- a/cli/src/commands/menu-reset.ts
+++ b/cli/src/commands/menu-reset.ts
@@ -1,0 +1,43 @@
+import { sessionApiBase, sessionFetch } from "./session-api.ts";
+import { emit } from "./_output.ts";
+
+async function confirm(prompt: string): Promise<boolean> {
+  process.stdout.write(`${prompt} `);
+  for await (const chunk of Bun.stdin.stream()) {
+    const answer = new TextDecoder().decode(chunk).trim().toLowerCase();
+    return answer === "y" || answer === "yes";
+  }
+  return false;
+}
+
+export async function menuResetAll(args: string[]): Promise<number> {
+  const skipConfirm = args.includes("--yes") || args.includes("-y");
+  if (!skipConfirm) {
+    const ok = await confirm(
+      "This will clear all user menu edits and delete custom items. Continue? [y/N]",
+    );
+    if (!ok) {
+      console.error("aborted");
+      return 1;
+    }
+  }
+
+  let res: Response;
+  try {
+    res = await sessionFetch("/api/menu/reset-all", { method: "POST" });
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+  if (!res.ok) {
+    console.error(`\x1b[31m✗\x1b[0m POST /api/menu/reset-all failed: HTTP ${res.status}`);
+    return 1;
+  }
+  const body = (await res.json()) as {
+    clearedTouched: number;
+    deletedCustom: number;
+    source: unknown;
+  };
+  emit({ api: sessionApiBase(), ...body }, args);
+  return 0;
+}

--- a/src/menu/config.ts
+++ b/src/menu/config.ts
@@ -1,5 +1,5 @@
 import type { MenuItem } from '../routes/menu/model.ts';
-import { getSetting, setSetting } from '../db/index.ts';
+import { getSetting } from '../db/index.ts';
 import { fetchGistMenu, invalidateGistCache } from './gist.ts';
 
 export type MenuConfig = {
@@ -25,10 +25,8 @@ export function getMenuSource(): MenuSource {
   return { ...sourceState };
 }
 
-export const MENU_GIST_SETTING_KEY = 'menu_gist_url';
-
 function resolveGistUrl(): string | null {
-  const fromDb = getSetting(MENU_GIST_SETTING_KEY);
+  const fromDb = getSetting('menu_gist_url');
   if (fromDb && fromDb.trim()) return fromDb.trim();
   const fromEnvNew = process.env.ORACLE_MENU_GIST_URL;
   if (fromEnvNew && fromEnvNew.trim()) return fromEnvNew.trim();
@@ -99,12 +97,6 @@ export async function reloadMenuConfig(): Promise<MenuConfig> {
   if (gistUrl) invalidateGistCache(gistUrl);
   else invalidateGistCache();
   return getMenuConfig();
-}
-
-export function setMenuGistUrl(url: string | null): void {
-  setSetting(MENU_GIST_SETTING_KEY, url);
-  invalidateGistCache();
-  sourceState = { url: null, hash: null, loaded_at: null, status: 'none' };
 }
 
 export function _resetMenuSource(): void {

--- a/src/menu/source-store.ts
+++ b/src/menu/source-store.ts
@@ -1,0 +1,87 @@
+/**
+ * Menu source persistence + apply modes.
+ *
+ * Gist URL is persisted in `settings.menu_gist_url` (Drizzle). Two apply modes:
+ *   - merge    — gist items fill in; user edits preserved (default)
+ *   - override — on top of merge, clears touchedAt on menu_items rows whose
+ *                path matches a gist item, so the seeder re-applies route
+ *                defaults on next boot (user label/group edits erased for
+ *                those paths). The gist overlay then merges as usual.
+ *
+ * resetAllMenu: nuclear reset — clears touchedAt + enables all route rows,
+ * deletes all custom rows, removes custom-menu.json. Use for "fresh start".
+ */
+import fs from 'fs';
+import { eq, inArray } from 'drizzle-orm';
+import { db, menuItems, setSetting } from '../db/index.ts';
+import { fetchGistMenu, invalidateGistCache, parseGistUrl } from './gist.ts';
+import { _resetMenuSource } from './config.ts';
+import { CUSTOM_MENU_FILE } from './custom-store.ts';
+
+export const MENU_GIST_SETTING_KEY = 'menu_gist_url';
+
+export type ApplyMode = 'merge' | 'override';
+
+export async function applyMenuGistUrl(url: string, mode: ApplyMode = 'merge'): Promise<void> {
+  setSetting(MENU_GIST_SETTING_KEY, url);
+  invalidateGistCache();
+  _resetMenuSource();
+  if (mode !== 'override') return;
+
+  const result = await fetchGistMenu(url);
+  const paths = (result?.data.items ?? [])
+    .map((i) => (typeof i?.path === 'string' ? i.path : ''))
+    .filter((p) => p.length > 0);
+  if (!paths.length) return;
+
+  const now = new Date();
+  db.update(menuItems)
+    .set({ touchedAt: null, enabled: true, updatedAt: now })
+    .where(inArray(menuItems.path, paths))
+    .run();
+}
+
+export function clearMenuGistUrl(): void {
+  setSetting(MENU_GIST_SETTING_KEY, null);
+  invalidateGistCache();
+  _resetMenuSource();
+}
+
+export interface ResetAllResult {
+  clearedTouched: number;
+  deletedCustom: number;
+}
+
+export function resetAllMenu(): ResetAllResult {
+  const now = new Date();
+  const touchedRows = db
+    .update(menuItems)
+    .set({ touchedAt: null, enabled: true, updatedAt: now })
+    .where(eq(menuItems.source, 'route'))
+    .returning()
+    .all();
+  const customDeleted = db
+    .delete(menuItems)
+    .where(eq(menuItems.source, 'custom'))
+    .returning()
+    .all();
+  try {
+    if (fs.existsSync(CUSTOM_MENU_FILE)) fs.rmSync(CUSTOM_MENU_FILE);
+  } catch {
+    // best-effort cleanup — seed file may not exist on fresh installs
+  }
+  invalidateGistCache();
+  _resetMenuSource();
+  return {
+    clearedTouched: touchedRows.length,
+    deletedCustom: customDeleted.length,
+  };
+}
+
+export function getOfficialGistUrl(): string | null {
+  const raw = process.env.ORACLE_OFFICIAL_MENU_GIST;
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  return parseGistUrl(trimmed) ? trimmed : null;
+}

--- a/src/routes/menu/admin-source.ts
+++ b/src/routes/menu/admin-source.ts
@@ -1,0 +1,95 @@
+/**
+ * Menu source admin endpoints — write side.
+ *
+ *   POST   /api/menu/source           body {url, mode?} set gist URL
+ *   DELETE /api/menu/source           clear gist URL
+ *   POST   /api/menu/reset-all        nuclear reset (clear touchedAt, drop custom)
+ *   GET    /api/menu/source/official  returns ORACLE_OFFICIAL_MENU_GIST URL
+ *
+ * mode: 'merge' (default) preserves user edits; 'override' clears touchedAt on
+ * rows whose path matches a gist item so the boot seeder re-applies route
+ * defaults. Persistence via Drizzle settings (see src/menu/source-store.ts).
+ */
+import { Elysia, t } from 'elysia';
+import { parseGistUrl } from '../../menu/gist.ts';
+import {
+  applyMenuGistUrl,
+  clearMenuGistUrl,
+  resetAllMenu,
+  getOfficialGistUrl,
+} from '../../menu/source-store.ts';
+import { getMenuSource, reloadMenuConfig } from '../../menu/config.ts';
+
+const ModeSchema = t.Union([t.Literal('merge'), t.Literal('override')]);
+
+export function createMenuSourceAdminRoutes() {
+  return new Elysia()
+    .post(
+      '/menu/source',
+      async ({ body, set }) => {
+        const raw = body.url.trim();
+        if (!raw) {
+          set.status = 400;
+          return { error: 'url required' };
+        }
+        if (!parseGistUrl(raw)) {
+          set.status = 400;
+          return {
+            error: 'invalid gist URL (expected https://gist.github.com/<user>/<id>[/<hash>])',
+          };
+        }
+        await applyMenuGistUrl(raw, body.mode ?? 'merge');
+        await reloadMenuConfig();
+        return { mode: body.mode ?? 'merge', source: getMenuSource() };
+      },
+      {
+        body: t.Object({ url: t.String(), mode: t.Optional(ModeSchema) }),
+        detail: {
+          tags: ['menu'],
+          menu: { group: 'hidden' },
+          summary: 'Set gist URL (modes: merge|override)',
+        },
+      },
+    )
+    .delete(
+      '/menu/source',
+      async () => {
+        clearMenuGistUrl();
+        await reloadMenuConfig();
+        return getMenuSource();
+      },
+      {
+        detail: {
+          tags: ['menu'],
+          menu: { group: 'hidden' },
+          summary: 'Clear persisted gist URL',
+        },
+      },
+    )
+    .post(
+      '/menu/reset-all',
+      async () => {
+        const result = resetAllMenu();
+        await reloadMenuConfig();
+        return { ...result, source: getMenuSource() };
+      },
+      {
+        detail: {
+          tags: ['menu'],
+          menu: { group: 'hidden' },
+          summary: 'Reset all menu state — clear touchedAt on routes, drop custom items',
+        },
+      },
+    )
+    .get(
+      '/menu/source/official',
+      () => ({ url: getOfficialGistUrl() }),
+      {
+        detail: {
+          tags: ['menu'],
+          menu: { group: 'hidden' },
+          summary: 'Official menu gist URL (from ORACLE_OFFICIAL_MENU_GIST)',
+        },
+      },
+    );
+}

--- a/src/routes/menu/index.ts
+++ b/src/routes/menu/index.ts
@@ -10,13 +10,15 @@ import { createMenuEndpoint } from './menu.ts';
 import { createCustomMenuRoutes } from './custom.ts';
 import { createMenuAdminRoutes } from './admin.ts';
 import { createMenuOrderRoutes } from './admin-order.ts';
+import { createMenuSourceAdminRoutes } from './admin-source.ts';
 
 export function createMenuRoutes() {
   return new Elysia({ prefix: '/api' })
     .use(createMenuEndpoint())
     .use(createCustomMenuRoutes())
     .use(createMenuAdminRoutes())
-    .use(createMenuOrderRoutes());
+    .use(createMenuOrderRoutes())
+    .use(createMenuSourceAdminRoutes());
 }
 
 export {

--- a/src/routes/menu/menu.ts
+++ b/src/routes/menu/menu.ts
@@ -13,13 +13,7 @@ import { Elysia, t } from 'elysia';
 import { asc } from 'drizzle-orm';
 import { MenuItemSchema, MenuResponseSchema, type MenuItem, type MenuMeta } from './model.ts';
 import { getFrontendMenuItems } from '../../menu/index.ts';
-import {
-  getMenuConfig,
-  getMenuSource,
-  reloadMenuConfig,
-  setMenuGistUrl,
-} from '../../menu/config.ts';
-import { parseGistUrl } from '../../menu/gist.ts';
+import { getMenuConfig, getMenuSource, reloadMenuConfig } from '../../menu/config.ts';
 import { listCustomMenuItems } from '../../menu/custom-store.ts';
 import { db, menuItems } from '../../db/index.ts';
 
@@ -225,49 +219,6 @@ export function createMenuEndpoint() {
           tags: ['menu'],
           menu: { group: 'hidden' },
           summary: 'Force refetch of gist menu source, bypassing cache',
-        },
-      },
-    )
-    .post(
-      '/menu/source',
-      async ({ body, set }) => {
-        const raw = body.url.trim();
-        if (!raw) {
-          set.status = 400;
-          return { error: 'url required' };
-        }
-        if (!parseGistUrl(raw)) {
-          set.status = 400;
-          return {
-            error: 'invalid gist URL (expected https://gist.github.com/<user>/<id>[/<hash>])',
-          };
-        }
-        setMenuGistUrl(raw);
-        await reloadMenuConfig();
-        return getMenuSource();
-      },
-      {
-        body: t.Object({ url: t.String() }),
-        detail: {
-          tags: ['menu'],
-          menu: { group: 'hidden' },
-          summary: 'Set gist URL for menu source (persists via settings)',
-        },
-      },
-    )
-    .delete(
-      '/menu/source',
-      async () => {
-        setMenuGistUrl(null);
-        await reloadMenuConfig();
-        return getMenuSource();
-      },
-      {
-        response: MenuSourceSchema,
-        detail: {
-          tags: ['menu'],
-          menu: { group: 'hidden' },
-          summary: 'Clear gist URL from menu source',
         },
       },
     );

--- a/tests/cli/menu/gist.test.ts
+++ b/tests/cli/menu/gist.test.ts
@@ -43,7 +43,10 @@ describe("arra-cli menu gist-*", () => {
     const url = "https://gist.github.com/natw/c11eabcd01";
     const setRes = await runCli(["menu", "gist-url", url]);
     expect(setRes.code).toBe(0);
-    const setData = tryParseJson(setRes.stdout) as { source: { url: string | null } } | null;
+    const setData = tryParseJson(setRes.stdout) as
+      | { mode: string; source: { url: string | null } }
+      | null;
+    expect(setData?.mode).toBe("merge");
     expect(setData?.source.url).toBe(url);
 
     const statusRes = await runCli(["menu", "gist-status"]);
@@ -63,6 +66,27 @@ describe("arra-cli menu gist-*", () => {
     const statusAfterData = tryParseJson(statusAfter.stdout) as { source: { url: string | null } } | null;
     expect(statusAfterData?.source.url).toBeNull();
   }, 30_000);
+
+  test("gist-url --override reports mode:override", async () => {
+    const url = "https://gist.github.com/natw/0ff21da01";
+    const res = await runCli(["menu", "gist-url", url, "--override"]);
+    expect(res.code).toBe(0);
+    const data = tryParseJson(res.stdout) as { mode: string; source: { url: string | null } } | null;
+    expect(data?.mode).toBe("override");
+    expect(data?.source.url).toBe(url);
+  }, 15_000);
+
+  test("reset-all --yes clears state", async () => {
+    const res = await runCli(["menu", "reset-all", "--yes"]);
+    expect(res.code).toBe(0);
+    const data = tryParseJson(res.stdout) as
+      | { clearedTouched: number; deletedCustom: number; source: { status: string } }
+      | null;
+    expect(data).not.toBeNull();
+    expect(typeof data!.clearedTouched).toBe("number");
+    expect(typeof data!.deletedCustom).toBe("number");
+    expect(data!.source.status).toBe("none");
+  }, 15_000);
 
   test("gist-reload returns source JSON", async () => {
     const result = await runCli(["menu", "gist-reload"]);

--- a/tests/http/menu/gist-source.test.ts
+++ b/tests/http/menu/gist-source.test.ts
@@ -12,13 +12,18 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { Elysia } from 'elysia';
 import { createMenuEndpoint } from '../../../src/routes/menu/menu.ts';
-import { setSetting, getSetting } from '../../../src/db/index.ts';
-import {
-  MENU_GIST_SETTING_KEY,
-  _resetMenuSource,
-  getMenuConfig,
-} from '../../../src/menu/config.ts';
+import { createMenuSourceAdminRoutes } from '../../../src/routes/menu/admin-source.ts';
+import { db, menuItems, setSetting, getSetting } from '../../../src/db/index.ts';
+import { eq } from 'drizzle-orm';
+import { _resetMenuSource, getMenuConfig } from '../../../src/menu/config.ts';
+import { MENU_GIST_SETTING_KEY } from '../../../src/menu/source-store.ts';
 import { _clearGistCache, _setRetryDelays } from '../../../src/menu/gist.ts';
+
+function buildApp() {
+  return new Elysia({ prefix: '/api' })
+    .use(createMenuEndpoint())
+    .use(createMenuSourceAdminRoutes());
+}
 
 const ORIG_FETCH = globalThis.fetch;
 const ORIG_ENV_GIST = process.env.ORACLE_MENU_GIST;
@@ -64,7 +69,7 @@ describe('POST /api/menu/source', () => {
       return res;
     }) as typeof fetch;
 
-    const app = new Elysia({ prefix: '/api' }).use(createMenuEndpoint());
+    const app = buildApp();
     const res = await app.handle(
       new Request('http://localhost/api/menu/source', {
         method: 'POST',
@@ -74,16 +79,17 @@ describe('POST /api/menu/source', () => {
     );
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.url).toBe('https://gist.github.com/natw/abcdef01');
-    expect(body.status).toBe('ok');
-    expect(body.hash).toBe('aaaabbbbccccddddeeeeffff0000111122223333');
+    expect(body.mode).toBe('merge');
+    expect(body.source.url).toBe('https://gist.github.com/natw/abcdef01');
+    expect(body.source.status).toBe('ok');
+    expect(body.source.hash).toBe('aaaabbbbccccddddeeeeffff0000111122223333');
     expect(getSetting(MENU_GIST_SETTING_KEY)).toBe(
       'https://gist.github.com/natw/abcdef01',
     );
   });
 
   test('rejects invalid URL with 400', async () => {
-    const app = new Elysia({ prefix: '/api' }).use(createMenuEndpoint());
+    const app = buildApp();
     const res = await app.handle(
       new Request('http://localhost/api/menu/source', {
         method: 'POST',
@@ -98,7 +104,7 @@ describe('POST /api/menu/source', () => {
   });
 
   test('rejects empty URL with 400', async () => {
-    const app = new Elysia({ prefix: '/api' }).use(createMenuEndpoint());
+    const app = buildApp();
     const res = await app.handle(
       new Request('http://localhost/api/menu/source', {
         method: 'POST',
@@ -124,7 +130,7 @@ describe('DELETE /api/menu/source', () => {
 
   test('clears gist URL from settings and returns status:none', async () => {
     setSetting(MENU_GIST_SETTING_KEY, 'https://gist.github.com/natw/deadbeef01');
-    const app = new Elysia({ prefix: '/api' }).use(createMenuEndpoint());
+    const app = buildApp();
     const res = await app.handle(
       new Request('http://localhost/api/menu/source', { method: 'DELETE' }),
     );
@@ -156,7 +162,7 @@ describe('GET /api/menu/source boot-read order', () => {
       return new Response(JSON.stringify({ items: [] }), { status: 200 });
     }) as typeof fetch;
 
-    const app = new Elysia({ prefix: '/api' }).use(createMenuEndpoint());
+    const app = buildApp();
     await app.handle(new Request('http://localhost/api/menu'));
     const res = await app.handle(new Request('http://localhost/api/menu/source'));
     const body = await res.json();
@@ -170,7 +176,7 @@ describe('GET /api/menu/source boot-read order', () => {
     globalThis.fetch = (async () =>
       new Response(JSON.stringify({ items: [] }), { status: 200 })) as typeof fetch;
 
-    const app = new Elysia({ prefix: '/api' }).use(createMenuEndpoint());
+    const app = buildApp();
     await app.handle(new Request('http://localhost/api/menu'));
     const res = await app.handle(new Request('http://localhost/api/menu/source'));
     const body = await res.json();
@@ -183,7 +189,7 @@ describe('GET /api/menu/source boot-read order', () => {
     globalThis.fetch = (async () =>
       new Response(JSON.stringify({ items: [] }), { status: 200 })) as typeof fetch;
 
-    const app = new Elysia({ prefix: '/api' }).use(createMenuEndpoint());
+    const app = buildApp();
     await app.handle(new Request('http://localhost/api/menu'));
     const res = await app.handle(new Request('http://localhost/api/menu/source'));
     const body = await res.json();
@@ -193,5 +199,195 @@ describe('GET /api/menu/source boot-read order', () => {
   test('getMenuConfig with no sources returns empty items and status:none', async () => {
     const result = await getMenuConfig();
     expect(result.items).toEqual([]);
+  });
+});
+
+describe('POST /api/menu/source mode=override', () => {
+  beforeEach(() => {
+    resetAll();
+    db.delete(menuItems).run();
+  });
+  afterEach(() => {
+    restoreFetch();
+    resetAll();
+    restoreEnv();
+    db.delete(menuItems).run();
+  });
+
+  function seedRow(path: string, touchedAt: Date | null) {
+    const now = new Date();
+    db.insert(menuItems)
+      .values({
+        path,
+        label: 'User Edit',
+        groupKey: 'main',
+        position: 10,
+        enabled: true,
+        access: 'public',
+        source: 'route',
+        icon: null,
+        touchedAt,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+  }
+
+  test('override clears touchedAt on rows matching gist paths', async () => {
+    seedRow('/search', new Date());
+    seedRow('/feed', new Date());
+    seedRow('/not-in-gist', new Date());
+
+    const payload = {
+      items: [
+        { path: '/search', label: 'Search', group: 'main', order: 10, source: 'page' },
+        { path: '/feed', label: 'Feed', group: 'main', order: 20, source: 'page' },
+      ],
+    };
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify(payload), { status: 200 })) as typeof fetch;
+
+    const app = buildApp();
+    const res = await app.handle(
+      new Request('http://localhost/api/menu/source', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          url: 'https://gist.github.com/natw/0ffeabcd01',
+          mode: 'override',
+        }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.mode).toBe('override');
+
+    const search = db.select().from(menuItems).where(eq(menuItems.path, '/search')).get();
+    const feed = db.select().from(menuItems).where(eq(menuItems.path, '/feed')).get();
+    const untouched = db.select().from(menuItems).where(eq(menuItems.path, '/not-in-gist')).get();
+    expect(search?.touchedAt).toBeNull();
+    expect(feed?.touchedAt).toBeNull();
+    expect(untouched?.touchedAt).not.toBeNull();
+  });
+
+  test('merge (default) preserves touchedAt on matching rows', async () => {
+    seedRow('/search', new Date());
+
+    const payload = {
+      items: [{ path: '/search', label: 'Search', group: 'main', order: 10, source: 'page' }],
+    };
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify(payload), { status: 200 })) as typeof fetch;
+
+    const app = buildApp();
+    const res = await app.handle(
+      new Request('http://localhost/api/menu/source', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ url: 'https://gist.github.com/natw/fedcba0001' }),
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    const search = db.select().from(menuItems).where(eq(menuItems.path, '/search')).get();
+    expect(search?.touchedAt).not.toBeNull();
+  });
+});
+
+describe('POST /api/menu/reset-all', () => {
+  beforeEach(() => {
+    resetAll();
+    db.delete(menuItems).run();
+  });
+  afterEach(() => {
+    restoreFetch();
+    resetAll();
+    restoreEnv();
+    db.delete(menuItems).run();
+  });
+
+  test('clears touchedAt on route rows, deletes custom rows', async () => {
+    const now = new Date();
+    db.insert(menuItems)
+      .values([
+        {
+          path: '/search',
+          label: 'Search',
+          groupKey: 'main',
+          position: 10,
+          enabled: false,
+          access: 'public',
+          source: 'route',
+          icon: null,
+          touchedAt: now,
+          createdAt: now,
+          updatedAt: now,
+        },
+        {
+          path: '/my-custom',
+          label: 'Custom',
+          groupKey: 'tools',
+          position: 90,
+          enabled: true,
+          access: 'public',
+          source: 'custom',
+          icon: null,
+          touchedAt: now,
+          createdAt: now,
+          updatedAt: now,
+        },
+      ])
+      .run();
+
+    const app = buildApp();
+    const res = await app.handle(
+      new Request('http://localhost/api/menu/reset-all', { method: 'POST' }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.clearedTouched).toBe(1);
+    expect(body.deletedCustom).toBe(1);
+
+    const route = db.select().from(menuItems).where(eq(menuItems.path, '/search')).get();
+    expect(route?.touchedAt).toBeNull();
+    expect(route?.enabled).toBe(true);
+
+    const custom = db.select().from(menuItems).where(eq(menuItems.path, '/my-custom')).get();
+    expect(custom).toBeUndefined();
+  });
+});
+
+describe('GET /api/menu/source/official', () => {
+  const ORIG_OFFICIAL = process.env.ORACLE_OFFICIAL_MENU_GIST;
+  beforeEach(() => {
+    resetAll();
+    delete process.env.ORACLE_OFFICIAL_MENU_GIST;
+  });
+  afterEach(() => {
+    if (ORIG_OFFICIAL !== undefined) process.env.ORACLE_OFFICIAL_MENU_GIST = ORIG_OFFICIAL;
+    else delete process.env.ORACLE_OFFICIAL_MENU_GIST;
+  });
+
+  test('returns null when env unset', async () => {
+    const app = buildApp();
+    const res = await app.handle(new Request('http://localhost/api/menu/source/official'));
+    const body = await res.json();
+    expect(body).toEqual({ url: null });
+  });
+
+  test('returns URL when env set to valid gist', async () => {
+    process.env.ORACLE_OFFICIAL_MENU_GIST = 'https://gist.github.com/arra/0ff1c1a1de';
+    const app = buildApp();
+    const res = await app.handle(new Request('http://localhost/api/menu/source/official'));
+    const body = await res.json();
+    expect(body.url).toBe('https://gist.github.com/arra/0ff1c1a1de');
+  });
+
+  test('returns null when env is non-gist garbage', async () => {
+    process.env.ORACLE_OFFICIAL_MENU_GIST = 'https://example.com/not-a-gist';
+    const app = buildApp();
+    const res = await app.handle(new Request('http://localhost/api/menu/source/official'));
+    const body = await res.json();
+    expect(body.url).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
Follow-up to merged PR #931 — treats gist URL as override/reset tool, not just config source.

- **POST /api/menu/source** accepts `{url, mode?: 'merge'|'override'}`
  - `merge` (default): gist fills in, user edits preserved
  - `override`: clears touchedAt on menu_items rows whose path matches a gist item → seeder re-applies route defaults
- **POST /api/menu/reset-all** — nuclear reset (clear touchedAt on route rows, delete custom rows, remove custom-menu.json)
- **GET /api/menu/source/official** — returns `ORACLE_OFFICIAL_MENU_GIST` env (validates; null otherwise)

### File split (per 150-200 line guideline)
- **NEW** `src/menu/source-store.ts` (87) — write-side persist/apply/reset
- **NEW** `src/routes/menu/admin-source.ts` (95) — source write endpoints
- `src/routes/menu/menu.ts` trimmed back to 227 (removed POST/DELETE /menu/source)
- `src/menu/config.ts` read-only (104)

### CLI
- `arra-cli menu gist-url <url> [--override]`
- `arra-cli menu reset-all [--yes]` — y/N prompt without `--yes`

## Test plan
- [x] `tests/http/menu/gist-source.test.ts` — 14 cases (added: override touches, merge preserves, reset-all clears+deletes, official null/valid/garbage)
- [x] `tests/cli/menu/gist.test.ts` — 7 cases (added: --override mode, reset-all --yes)
- [x] Full suite: **413 pass / 0 fail** (baseline 392+; up from 405)
- [x] `tsc --noEmit` clean

Drizzle-only; no raw SQL.

🤖 ตอบโดย arra-oracle-v3 จาก Nat → arra-oracle-v3