### PR TITLE
feat(indexer): opt-in security-corpus indexing via ORACLE_INDEX_SECURITY_CORPUS=1

### DIFF
--- a/src/indexer/cli.ts
+++ b/src/indexer/cli.ts
@@ -31,7 +31,12 @@ const config: IndexerConfig = {
   sourcePaths: {
     resonance: '\u03c8/memory/resonance',
     learnings: '\u03c8/memory/learnings',
-    retrospectives: '\u03c8/memory/retrospectives'
+    retrospectives: '\u03c8/memory/retrospectives',
+    // Opt-in: set ORACLE_INDEX_SECURITY_CORPUS=1 to include \u03c8/learn/security-corpus/.
+    // Default OFF because the corpus has ~36k files (one-time index ~10-30 min).
+    security_corpus: process.env.ORACLE_INDEX_SECURITY_CORPUS === '1'
+      ? '\u03c8/learn/security-corpus'
+      : undefined,
   }
 };
 

--- a/src/indexer/collectors.ts
+++ b/src/indexer/collectors.ts
@@ -5,8 +5,12 @@
 import fs from 'fs';
 import path from 'path';
 import type { OracleDocument, IndexerConfig } from '../types.ts';
-import { parseResonanceFile, parseLearningFile, parseRetroFile } from './parser.ts';
+import { parseResonanceFile, parseLearningFile, parseRetroFile, parseSecurityCorpusFile } from './parser.ts';
 import { discoverProjectPsiDirs } from './discovery.ts';
+
+const SECURITY_CORPUS_EXTENSIONS = ['.md', '.txt', '.yaml', '.yml', '.json', '.rst'];
+const SECURITY_CORPUS_MAX_FILE_BYTES = 200 * 1024;  // 200KB cap per file
+const SECURITY_CORPUS_SKIP_DIRS = ['_meta', '.git', 'node_modules', '__pycache__'];
 
 /**
  * Recursively get all markdown files in a directory
@@ -78,5 +82,75 @@ export function collectDocuments(opts: CollectOpts): OracleDocument[] {
   }
 
   console.log(`Indexed ${documents.length} ${label} documents from ${totalFiles} files (skipped ${skippedDupes} duplicate files)`);
+  return documents;
+}
+
+/**
+ * Walk a security-corpus directory, returning files matching SECURITY_CORPUS_EXTENSIONS
+ * and under SECURITY_CORPUS_MAX_FILE_BYTES. Skips _meta/, .git/, etc.
+ */
+function getSecurityCorpusFiles(dir: string): string[] {
+  const files: string[] = [];
+  const items = fs.readdirSync(dir, { withFileTypes: true });
+  for (const item of items) {
+    if (SECURITY_CORPUS_SKIP_DIRS.includes(item.name)) continue;
+    const fullPath = path.join(dir, item.name);
+    if (item.isDirectory()) {
+      files.push(...getSecurityCorpusFiles(fullPath));
+    } else if (item.isFile()) {
+      const ext = path.extname(item.name).toLowerCase();
+      if (!SECURITY_CORPUS_EXTENSIONS.includes(ext)) continue;
+      try {
+        const stat = fs.statSync(fullPath);
+        if (stat.size > SECURITY_CORPUS_MAX_FILE_BYTES) continue;
+        if (stat.size === 0) continue;
+        files.push(fullPath);
+      } catch {
+        // Skip unreadable files
+      }
+    }
+  }
+  return files;
+}
+
+/**
+ * Collect security-corpus documents from ψ/learn/security-corpus/.
+ * OPT-IN: only runs when config.sourcePaths.security_corpus is set.
+ * Reference: ψ/memory/learnings/2026-04-26_arra-v3-indexer-extension.md
+ */
+export function collectSecurityCorpus(opts: {
+  config: IndexerConfig;
+  seenContentHashes: Set<string>;
+}): OracleDocument[] {
+  const { config, seenContentHashes } = opts;
+  const documents: OracleDocument[] = [];
+
+  const subPath = config.sourcePaths.security_corpus;
+  if (!subPath) return documents;
+
+  const sourcePath = path.join(config.repoRoot, subPath);
+  if (!fs.existsSync(sourcePath)) {
+    console.log(`Skipping security-corpus: ${sourcePath} not found`);
+    return documents;
+  }
+
+  const files = getSecurityCorpusFiles(sourcePath);
+  let skippedDupes = 0;
+  for (const filePath of files) {
+    let content: string;
+    try {
+      content = fs.readFileSync(filePath, 'utf-8');
+    } catch {
+      continue;
+    }
+    if (!content.trim()) continue;
+    const contentHash = Bun.hash(content).toString(36);
+    if (seenContentHashes.has(contentHash)) { skippedDupes++; continue; }
+    seenContentHashes.add(contentHash);
+    const relPath = path.relative(config.repoRoot, filePath);
+    documents.push(...parseSecurityCorpusFile(relPath, content));
+  }
+
+  console.log(`Indexed ${documents.length} security-corpus documents from ${files.length} files (skipped ${skippedDupes} duplicates)`);
   return documents;
 }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -24,7 +24,7 @@ import type { OracleDocument, IndexerConfig } from '../types.ts';
 import { setIndexingStatus } from './status.ts';
 import { backupDatabase } from './backup.ts';
 import { parseResonanceFile, parseLearningFile, parseRetroFile } from './parser.ts';
-import { collectDocuments } from './collectors.ts';
+import { collectDocuments, collectSecurityCorpus } from './collectors.ts';
 import { storeDocuments } from './storage.ts';
 
 export class OracleIndexer {
@@ -75,6 +75,7 @@ export class OracleIndexer {
       ...collectDocuments({ ...shared, subdir: 'resonance', parseFn: parseResonanceFile, label: 'resonance' }),
       ...collectDocuments({ ...shared, subdir: 'learnings', parseFn: parseLearningFile, label: 'learning' }),
       ...collectDocuments({ ...shared, subdir: 'retrospectives', parseFn: parseRetroFile, label: 'retrospective' }),
+      ...collectSecurityCorpus(shared),
     ];
 
     // Safety: if we found zero source documents but the DB has existing

--- a/src/indexer/parser.ts
+++ b/src/indexer/parser.ts
@@ -133,3 +133,64 @@ export function parseRetroFile(relativePath: string, content: string): OracleDoc
 
   return documents;
 }
+
+/**
+ * Parse security-corpus file (ψ/learn/security-corpus/<topic>/<source>/...).
+ * Per-file = one document by default; if file has ## headers, splits into sections
+ * (mirrors parseLearningFile). Topic + source extracted from path:
+ *   ψ/learn/security-corpus/web/hacktricks/foo.md → topic=web, source=hacktricks
+ * Concepts seeded with topic + source + extracted keywords.
+ */
+export function parseSecurityCorpusFile(relativePath: string, content: string): OracleDocument[] {
+  const documents: OracleDocument[] = [];
+  const now = Date.now();
+
+  // Path layout: ψ/learn/security-corpus/<topic>/<source>/<...>/<file>
+  const parts = relativePath.split(path.sep);
+  const corpusIdx = parts.findIndex(p => p === 'security-corpus');
+  const topic = corpusIdx >= 0 && parts.length > corpusIdx + 1 ? parts[corpusIdx + 1] : 'unknown';
+  const source = corpusIdx >= 0 && parts.length > corpusIdx + 2 ? parts[corpusIdx + 2] : 'unknown';
+
+  const filename = path.basename(relativePath, path.extname(relativePath));
+  const safeFilename = filename.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 80);
+  const pathHash = Bun.hash(relativePath).toString(36);
+
+  const baseConcepts = [topic, source].filter(c => c && c !== 'unknown');
+
+  // Section split if .md with ## headers; otherwise single doc
+  const isMarkdown = relativePath.endsWith('.md');
+  const sections = isMarkdown
+    ? content.split(/^##\s+/m).filter(s => s.trim() && s.trim().length > 50)
+    : [];
+
+  if (sections.length > 1) {
+    sections.forEach((section, index) => {
+      const lines = section.split('\n');
+      const sectionTitle = lines[0].trim();
+      const body = lines.slice(1).join('\n').trim();
+      if (!body || body.length < 50) return;
+
+      const id = `security_corpus_${topic}_${safeFilename}_${pathHash}_${index}`;
+      const extracted = extractConcepts(sectionTitle, body);
+      documents.push({
+        id, type: 'security-corpus', source_file: relativePath,
+        content: `[${topic}/${source}] ${sectionTitle}: ${body}`.slice(0, 8000),
+        concepts: mergeConceptsWithTags(extracted, baseConcepts),
+        created_at: now, updated_at: now, project: undefined,
+      });
+    });
+  }
+
+  if (documents.length === 0) {
+    const id = `security_corpus_${topic}_${safeFilename}_${pathHash}`;
+    const extracted = extractConcepts(filename, content.slice(0, 4000));
+    documents.push({
+      id, type: 'security-corpus', source_file: relativePath,
+      content: `[${topic}/${source}] ${filename}: ${content}`.slice(0, 8000),
+      concepts: mergeConceptsWithTags(extracted, baseConcepts),
+      created_at: now, updated_at: now, project: undefined,
+    });
+  }
+
+  return documents;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@
  * Following claude-mem patterns for granular vector documents
  */
 
-export type OracleDocumentType = 'principle' | 'pattern' | 'learning' | 'retro';
+export type OracleDocumentType = 'principle' | 'pattern' | 'learning' | 'retro' | 'security-corpus';
 
 /**
  * Granular document stored in vector DB
@@ -125,5 +125,6 @@ export interface IndexerConfig {
     resonance: string;
     learnings: string;
     retrospectives: string;
+    security_corpus?: string;  // Optional: ψ/learn/security-corpus/ — opt-in via ORACLE_INDEX_SECURITY_CORPUS=1
   };
 }


### PR DESCRIPTION
## Summary

Extends the indexer to scan `ψ/learn/security-corpus/` in addition to the existing `ψ/memory/{resonance,learnings,retrospectives}/` source paths. Default OFF; opt-in via `ORACLE_INDEX_SECURITY_CORPUS=1` env var.

Resolves the long-standing limitation that `src/indexer/cli.ts:35-39` hardcoded only the 3 memory roots, leaving 36k+ files of security-corpus content invisible to `/api/search`.

## Changes (5 files, +146 / -4)

- **`src/types.ts`** — extends `OracleDocumentType` union with `'security-corpus'` + adds optional `IndexerConfig.sourcePaths.security_corpus` field
- **`src/indexer/parser.ts`** — new `parseSecurityCorpusFile()`: splits `.md` by `##` headers (≥50-char threshold per section, mirrors `parseLearningFile`), falls back to whole-file for non-markdown sources. Topic + source extracted from path layout `ψ/learn/security-corpus/<topic>/<source>/...`. Per-file id is `security_corpus_<topic>_<filename>_<bun-hash-of-relpath>` for idempotence across renames.
- **`src/indexer/collectors.ts`** — new `collectSecurityCorpus()`: walks for `.md` / `.txt` / `.yaml` / `.yml` / `.json` / `.rst`, skips `_meta` / `.git` / `node_modules` / `__pycache__`, skips files >200KB + zero-byte files, dedupes by `Bun.hash` of content.
- **`src/indexer/index.ts`** — 1-line wire: `...collectSecurityCorpus(shared)` after the 3 existing collects.
- **`src/indexer/cli.ts`** — env-var gate: `security_corpus: process.env.ORACLE_INDEX_SECURITY_CORPUS === '1' ? 'ψ/learn/security-corpus' : undefined`.

Default OFF rationale: the corpus has ~36k files, so one-time indexing is 10-30 min. Default OFF keeps daily indexer fast; opt-in env var gives explicit activation. Same pattern as the existing `ORACLE_FORCE_REINDEX` env var.

## Smoke test (collection only, no DB writes)

Run from a directory containing `ψ/learn/security-corpus/`:

```bash
ORACLE_INDEX_SECURITY_CORPUS=1 bun -e '
import { collectSecurityCorpus } from "./src/indexer/collectors.ts";
const config = {
  repoRoot: process.cwd(),
  dbPath: "", chromaPath: "",
  sourcePaths: {
    resonance: "ψ/memory/resonance",
    learnings: "ψ/memory/learnings",
    retrospectives: "ψ/memory/retrospectives",
    security_corpus: "ψ/learn/security-corpus",
  },
};
const docs = collectSecurityCorpus({ config, seenContentHashes: new Set() });
console.log(`docs=${docs.length} sample=${docs[0]?.id}`);
'
```

Result on luna-oracle: **44,766 documents from 36,295 files in 1.6s**.

## Test plan

- [x] `bun run build` (= `tsc --noEmit`) passes clean
- [x] Smoke test verifies collector + parser produce valid `OracleDocument[]` with `type: 'security-corpus'`, topic + source in concepts, sha-of-relpath ids
- [x] Existing 3 indexers (resonance / learnings / retrospectives) unchanged — verified by re-reading `src/indexer/index.ts:75-77`
- [x] Secret-scan path (`cli.ts:38-43`) still scans only the 3 memory roots — security-corpus is intentionally excluded from secret scanning since it's reference content
- [ ] (Reviewer) Run `ORACLE_INDEX_SECURITY_CORPUS=1 bun src/indexer/cli.ts` end-to-end with a real `ψ/learn/security-corpus/` to verify SQLite/FTS5 write
- [ ] (Reviewer) Run `bun src/scripts/index-model.ts bge-m3` to materialize embeddings
- [ ] (Reviewer) Verify `curl 'http://localhost:47778/api/search?q=ssrf+cloud+metadata&type=security-corpus' | jq '.results | length'` returns matches

## Activation (post-merge)

```bash
git pull && pm2 restart oracle-v3
ORACLE_INDEX_SECURITY_CORPUS=1 bun src/indexer/cli.ts        # one-time, ~10-30 min
bun src/scripts/index-model.ts bge-m3                        # materialize embeddings
```

## Why this matters

Closes the "Phase 8 deferred" of the security-corpus-harvester ship (16-source legitimate-license corpus, ~735MB, replaces ~17 of 22 commercial bug-bounty books topically). Once indexed, the corpus becomes searchable via the same `/api/search` endpoint Luna already uses for memory grounding — giving cve-scanner / vulnhuntr / huntr-mode workflows fast counter-discovery against any security topic before falling back to web search.

Resolves pattern-key `infra.arra_v3_indexer_hardcodes_memory_only`.