### PR TITLE
fix(indexer): collect ψ/memory/distillations/ — make L1 distillation artifacts searchable (closes #990)

### DIFF
--- a/src/indexer/cli.ts
+++ b/src/indexer/cli.ts
@@ -31,7 +31,8 @@ const config: IndexerConfig = {
   sourcePaths: {
     resonance: '\u03c8/memory/resonance',
     learnings: '\u03c8/memory/learnings',
-    retrospectives: '\u03c8/memory/retrospectives'
+    retrospectives: '\u03c8/memory/retrospectives',
+    distillations: '\u03c8/memory/distillations'
   }
 };
 
@@ -40,6 +41,7 @@ if (process.argv.includes('--scan')) {
     path.join(repoRoot, config.sourcePaths.resonance),
     path.join(repoRoot, config.sourcePaths.learnings),
     path.join(repoRoot, config.sourcePaths.retrospectives),
+    path.join(repoRoot, config.sourcePaths.distillations),
   ];
   const findings = scanRoots(roots);
   if (findings.length === 0) {

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -23,7 +23,7 @@ import type { OracleDocument, IndexerConfig } from '../types.ts';
 
 import { setIndexingStatus } from './status.ts';
 import { backupDatabase } from './backup.ts';
-import { parseResonanceFile, parseLearningFile, parseRetroFile } from './parser.ts';
+import { parseResonanceFile, parseLearningFile, parseRetroFile, parseDistillationFile } from './parser.ts';
 import { collectDocuments } from './collectors.ts';
 import { storeDocuments } from './storage.ts';
 
@@ -75,6 +75,7 @@ export class OracleIndexer {
       ...collectDocuments({ ...shared, subdir: 'resonance', parseFn: parseResonanceFile, label: 'resonance' }),
       ...collectDocuments({ ...shared, subdir: 'learnings', parseFn: parseLearningFile, label: 'learning' }),
       ...collectDocuments({ ...shared, subdir: 'retrospectives', parseFn: parseRetroFile, label: 'retrospective' }),
+      ...collectDocuments({ ...shared, subdir: 'distillations', parseFn: parseDistillationFile, label: 'distillation' }),
     ];
 
     // Safety: if we found zero source documents but the DB has existing

--- a/src/indexer/parser.ts
+++ b/src/indexer/parser.ts
@@ -101,6 +101,52 @@ export function parseLearningFile(filename: string, content: string, sourceFileO
 }
 
 /**
+ * Parse distillation markdown into documents
+ * L1–L4 brain-compression artifacts produced by /distill skill.
+ * Splits by ## headers, falls back to whole-file document.
+ */
+export function parseDistillationFile(filename: string, content: string, sourceFileOverride?: string): OracleDocument[] {
+  const documents: OracleDocument[] = [];
+  const sourceFile = sourceFileOverride || `ψ/memory/distillations/${filename}`;
+  const now = Date.now();
+
+  const fileTags = parseFrontmatterTags(content);
+  const fileProject = parseFrontmatterProject(content) || inferProjectFromPath(sourceFile);
+
+  const titleMatch = content.match(/^title:\s*(.+)$/m);
+  const title = titleMatch ? titleMatch[1] : filename.replace('.md', '');
+
+  const sections = content.split(/^##\s+/m).filter(s => s.trim());
+
+  sections.forEach((section, index) => {
+    const lines = section.split('\n');
+    const sectionTitle = lines[0].trim();
+    const body = lines.slice(1).join('\n').trim();
+    if (!body) return;
+
+    const id = `distillation_${filename.replace('.md', '')}_${index}`;
+    const extracted = extractConcepts(sectionTitle, body);
+    documents.push({
+      id, type: 'distillation', source_file: sourceFile,
+      content: `${title} - ${sectionTitle}: ${body}`,
+      concepts: mergeConceptsWithTags(extracted, fileTags),
+      created_at: now, updated_at: now, project: fileProject || undefined
+    });
+  });
+
+  if (documents.length === 0) {
+    const extracted = extractConcepts(title, content);
+    documents.push({
+      id: `distillation_${filename.replace('.md', '')}`, type: 'distillation', source_file: sourceFile,
+      content, concepts: mergeConceptsWithTags(extracted, fileTags),
+      created_at: now, updated_at: now, project: fileProject || undefined
+    });
+  }
+
+  return documents;
+}
+
+/**
  * Parse retrospective markdown
  * Splits by ## headers, skips sections shorter than 50 chars
  */

--- a/src/routes/indexer/scan.ts
+++ b/src/routes/indexer/scan.ts
@@ -17,7 +17,8 @@ export const scanEndpoint = new Elysia().post('/indexer/scan', async ({ body }) 
     const rel = path.relative(sourcePath, filePath);
 
     let type = 'unknown';
-    if (rel.includes('learnings') || rel.includes('learning')) type = 'learning';
+    if (rel.includes('distillations') || rel.includes('distillation')) type = 'distillation';
+    else if (rel.includes('learnings') || rel.includes('learning')) type = 'learning';
     else if (rel.includes('retrospectives') || rel.includes('retro')) type = 'retro';
     else if (rel.includes('resonance') || rel.includes('principle')) type = 'principle';
 

--- a/src/routes/indexer/start.ts
+++ b/src/routes/indexer/start.ts
@@ -26,6 +26,7 @@ export const startEndpoint = new Elysia().post('/indexer/start', async ({ body }
       resonance: `${sourcePath || REPO_ROOT}/memory/resonance`,
       learnings: `${sourcePath || REPO_ROOT}/memory/learnings`,
       retrospectives: `${sourcePath || REPO_ROOT}/memory/retrospectives`,
+      distillations: `${sourcePath || REPO_ROOT}/memory/distillations`,
     },
   };
 

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -301,7 +301,8 @@ export function handleReflect() {
     .from(oracleDocuments)
     .where(or(
       eq(oracleDocuments.type, 'principle'),
-      eq(oracleDocuments.type, 'learning')
+      eq(oracleDocuments.type, 'learning'),
+      eq(oracleDocuments.type, 'distillation')
     ))
     .orderBy(sql`RANDOM()`)
     .limit(1)
@@ -585,7 +586,14 @@ export function handleGraph(limitPerType = 310) {
     .limit(perType)
     .all();
 
-  const docs = [...principles, ...learnings, ...retros];
+  const distillations = db.select(selectFields)
+    .from(oracleDocuments)
+    .where(eq(oracleDocuments.type, 'distillation'))
+    .orderBy(sql`RANDOM()`)
+    .limit(perType)
+    .all();
+
+  const docs = [...principles, ...learnings, ...retros, ...distillations];
 
   // Build nodes
   const nodes = docs.map(doc => ({

--- a/src/tools/concepts.ts
+++ b/src/tools/concepts.ts
@@ -21,7 +21,7 @@ export const conceptsToolDef = {
       },
       type: {
         type: 'string',
-        enum: ['principle', 'pattern', 'learning', 'retro', 'all'],
+        enum: ['principle', 'pattern', 'learning', 'retro', 'distillation', 'all'],
         description: 'Filter concepts by document type',
         default: 'all'
       }

--- a/src/tools/list.ts
+++ b/src/tools/list.ts
@@ -16,7 +16,7 @@ export const listToolDef = {
     properties: {
       type: {
         type: 'string',
-        enum: ['principle', 'pattern', 'learning', 'retro', 'all'],
+        enum: ['principle', 'pattern', 'learning', 'retro', 'distillation', 'all'],
         description: 'Filter by document type',
         default: 'all'
       },
@@ -45,7 +45,7 @@ export async function handleList(ctx: ToolContext, input: OracleListInput): Prom
     throw new Error('offset must be >= 0');
   }
 
-  const validTypes = ['principle', 'pattern', 'learning', 'retro', 'all'];
+  const validTypes = ['principle', 'pattern', 'learning', 'retro', 'distillation', 'all'];
   if (!validTypes.includes(type)) {
     throw new Error(`Invalid type: ${type}. Must be one of: ${validTypes.join(', ')}`);
   }

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -24,7 +24,7 @@ export const searchToolDef = {
       },
       type: {
         type: 'string',
-        enum: ['principle', 'pattern', 'learning', 'retro', 'all'],
+        enum: ['principle', 'pattern', 'learning', 'retro', 'distillation', 'all'],
         description: 'Filter by document type',
         default: 'all'
       },

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -31,7 +31,7 @@ export interface ToolResponse {
 
 export interface OracleSearchInput {
   query: string;
-  type?: 'principle' | 'pattern' | 'learning' | 'retro' | 'all';
+  type?: 'principle' | 'pattern' | 'learning' | 'retro' | 'distillation' | 'all';
   limit?: number;
   offset?: number;
   mode?: 'hybrid' | 'fts' | 'vector';
@@ -50,7 +50,7 @@ export interface OracleLearnInput {
 }
 
 export interface OracleListInput {
-  type?: 'principle' | 'pattern' | 'learning' | 'retro' | 'all';
+  type?: 'principle' | 'pattern' | 'learning' | 'retro' | 'distillation' | 'all';
   limit?: number;
   offset?: number;
 }
@@ -59,7 +59,7 @@ export interface OracleStatsInput {}
 
 export interface OracleConceptsInput {
   limit?: number;
-  type?: 'principle' | 'pattern' | 'learning' | 'retro' | 'all';
+  type?: 'principle' | 'pattern' | 'learning' | 'retro' | 'distillation' | 'all';
 }
 
 export interface OracleSupersededInput {

--- a/src/tools/verify.ts
+++ b/src/tools/verify.ts
@@ -21,7 +21,7 @@ export const verifyToolDef = {
       type: {
         type: 'string',
         description: 'Filter by document type (default: all)',
-        enum: ['principle', 'pattern', 'learning', 'retro', 'all'],
+        enum: ['principle', 'pattern', 'learning', 'retro', 'distillation', 'all'],
         default: 'all'
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@
  * Following claude-mem patterns for granular vector documents
  */
 
-export type OracleDocumentType = 'principle' | 'pattern' | 'learning' | 'retro';
+export type OracleDocumentType = 'principle' | 'pattern' | 'learning' | 'retro' | 'distillation';
 
 /**
  * Granular document stored in vector DB
@@ -125,5 +125,6 @@ export interface IndexerConfig {
     resonance: string;
     learnings: string;
     retrospectives: string;
+    distillations: string;
   };
 }


### PR DESCRIPTION
## Summary

Closes #990. The indexer collects from `ψ/memory/{resonance,learnings,retrospectives}/` but skipped `ψ/memory/distillations/` — the path used for L1–L4 brain-compression artifacts produced by the `/distill` skill. Files written there existed on disk but were unsearchable, forcing workarounds via `arra_learn` that duplicated content into `learnings/` and conflated synthesized summaries with atomic patterns.

## What changed

- **`types.ts`** — add `'distillation'` to `OracleDocumentType` + `sourcePaths`.
- **`indexer/parser.ts`** — new `parseDistillationFile` (mirrors `parseLearningFile`: splits by `##` headers, falls back to whole-file when no sections).
- **`indexer/index.ts` + `cli.ts`** — collect from `ψ/memory/distillations/` and include in the `--scan` secret-detection roots.
- **`routes/indexer/{scan,start}.ts`** — detect `'distillation'` type from path; populate `distillations` `sourcePath` in the interactive indexer-API config (PR #1063).
- **`tools/{search,list,verify,concepts,types}.ts`** — extend type-filter enums so distillations are searchable / listable / verifiable.
- **`server/handlers.ts`** — include distillations in `oracle_consult` random pull (alongside `principle` / `learning`) and as a node category in the knowledge-graph sample.

## Verification

- `bun run test:unit` → **145/145 pass**
- `bunx tsc --noEmit` → clean
- End-to-end smoke test: created `ψ/memory/distillations/2026-04-23/test-l1.md` with marker `xyzzy-distill-marker-12345`, ran `bun src/indexer/cli.ts` → `Indexed 3 distillation documents from 1 files`, then queried `oracle_fts MATCH 'xyzzy'` → returned the matching chunk.

```
Indexed 0 resonance documents from 0 files
Indexed 0 learning documents from 0 files
Indexed 0 retrospective documents from 0 files
Indexed 3 distillation documents from 1 files (skipped 0 duplicate files)
```

## Why it matters

Every Oracle in the family that uses `/distill` (L1 brain-compression) currently has invisible artifacts. After this lands:

- `arra_search` finds distillations directly — no more `arra_learn` duplicate workaround.
- `arra_supersede` can target distillation chunks by ID (no more split-SQL workaround the issue describes).
- `type='distillation'` cleanly separates synthesized summaries (10×+ compression) from atomic learnings.

## Notes / out of scope

- The slug-collision side note in #990 (`arra_learn` baking `title:` / `date:` keys into filenames) is **not** addressed here — different surface, separate PR.
- DB schema has no `CHECK` constraint on `oracle_documents.type`, so existing rows are unaffected; new docs simply get `type='distillation'`.
- No migration required — purely additive.

🤖 Co-authored by Echo Oracle 📚 (Knowledge Seeker)