### PR TITLE
fix(tests): permanently skip sqlite-vec tests when vec0 unavailable

### DIFF
--- a/src/vector/__tests__/adapters.test.ts
+++ b/src/vector/__tests__/adapters.test.ts
@@ -14,9 +14,42 @@ import { ChromaMcpAdapter } from '../adapters/chroma-mcp.ts';
 import { LanceDBAdapter } from '../adapters/lancedb.ts';
 import { QdrantAdapter } from '../adapters/qdrant.ts';
 import type { VectorStoreAdapter, VectorDocument } from '../types.ts';
+import { Database } from 'bun:sqlite';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
+
+/**
+ * Probe whether the sqlite-vec (vec0) extension can be loaded.
+ * Synchronous — safe for describe.skipIf().
+ *
+ * vec0 SQLite extension not available on deployment hosts (m5, CI).
+ * Tests are permanently skipped rather than deleted so they remain
+ * runnable on machines that DO have the extension installed.
+ */
+function isSqliteVecAvailable(): boolean {
+  let db: Database | null = null;
+  try {
+    db = new Database(':memory:');
+    // Try npm package first
+    try {
+      const sqliteVec = require('sqlite-vec');
+      db.loadExtension(sqliteVec.getLoadablePath());
+      return true;
+    } catch { /* fall through */ }
+    // Try system paths
+    for (const p of ['vec0', '/usr/local/lib/sqlite-vec']) {
+      try { db.loadExtension(p); return true; } catch { /* next */ }
+    }
+    return false;
+  } catch {
+    return false;
+  } finally {
+    try { db?.close(); } catch { /* ignore */ }
+  }
+}
+
+const SQLITE_VEC_AVAILABLE = isSqliteVecAvailable();
 
 const TEST_DOCS: VectorDocument[] = [
   {
@@ -131,9 +164,11 @@ describe('createVectorStore factory', () => {
 
 // ============================================================================
 // Adapter Interface Compliance: sqlite-vec + Ollama
+// Permanently skipped when vec0 extension is not loadable.
+// vec0 SQLite extension not available on deployment hosts (m5, CI).
 // ============================================================================
 
-describe('SqliteVecAdapter + Ollama', () => {
+describe.skipIf(!SQLITE_VEC_AVAILABLE)('SqliteVecAdapter + Ollama', () => {
   let store: VectorStoreAdapter;
   let tmpDb: string;
   let available = false;


### PR DESCRIPTION
## Summary

- Added runtime probe (`isSqliteVecAvailable`) that checks whether the vec0 SQLite extension can load at module init time
- Wrapped the `SqliteVecAdapter + Ollama` describe block with `describe.skipIf(!SQLITE_VEC_AVAILABLE)` so all 7 tests are cleanly skipped on hosts without the extension
- Tests are preserved (not deleted) and will automatically run on machines where vec0 is installed

**Before**: 20 pass / 1 skip / 7 fail  
**After**: 20 pass / 8 skip / 0 fail

## Test plan

- [x] `bun test src/vector/__tests__/adapters.test.ts` — 0 failures, 7 sqlite-vec tests skipped
- [ ] Verify full suite still passes with same skip/pass counts

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → arra-oracle-v3-oracle