### PR TITLE
fix(backup): file lock to prevent rotation race condition

### DIFF
--- a/src/indexer/__tests__/backup-lock.test.ts
+++ b/src/indexer/__tests__/backup-lock.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for backup file-lock to prevent race conditions
+ * when concurrent reindex processes run close together.
+ *
+ * @see https://github.com/Soul-Brews-Studio/arra-oracle-v3/issues/1037
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { acquireLock, releaseLock } from '../backup.ts';
+
+describe('backup file lock', () => {
+  let tmpDir: string;
+  let lockPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oracle-backup-test-'));
+    lockPath = path.join(tmpDir, 'test.db.backup.lock');
+  });
+
+  afterEach(() => {
+    // Clean up
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch { /* best effort */ }
+  });
+
+  it('acquires lock when no lock exists', () => {
+    expect(acquireLock(lockPath)).toBe(true);
+    expect(fs.existsSync(lockPath)).toBe(true);
+    releaseLock(lockPath);
+  });
+
+  it('fails to acquire when lock already held', () => {
+    expect(acquireLock(lockPath)).toBe(true);
+    expect(acquireLock(lockPath)).toBe(false);
+    releaseLock(lockPath);
+  });
+
+  it('allows re-acquire after release', () => {
+    expect(acquireLock(lockPath)).toBe(true);
+    releaseLock(lockPath);
+    expect(acquireLock(lockPath)).toBe(true);
+    releaseLock(lockPath);
+  });
+
+  it('writes PID to lock file', () => {
+    acquireLock(lockPath);
+    const content = fs.readFileSync(lockPath, 'utf-8').trim();
+    expect(content).toBe(String(process.pid));
+    releaseLock(lockPath);
+  });
+
+  it('reclaims stale lock (mtime > threshold)', () => {
+    // Create a lock file and back-date it
+    fs.writeFileSync(lockPath, '99999\n');
+    const staleTime = Date.now() - 6 * 60 * 1000; // 6 minutes ago
+    fs.utimesSync(lockPath, new Date(staleTime), new Date(staleTime));
+
+    // Should reclaim the stale lock
+    expect(acquireLock(lockPath)).toBe(true);
+    const content = fs.readFileSync(lockPath, 'utf-8').trim();
+    expect(content).toBe(String(process.pid));
+    releaseLock(lockPath);
+  });
+
+  it('does not reclaim fresh lock from another process', () => {
+    // Create a lock file with a recent mtime (simulating another live process)
+    fs.writeFileSync(lockPath, '99999\n');
+    // mtime is "now" by default — well within the 5-minute threshold
+
+    expect(acquireLock(lockPath)).toBe(false);
+    // Clean up manually since we didn't acquire
+    fs.unlinkSync(lockPath);
+  });
+
+  it('releaseLock is safe when lock already removed', () => {
+    // Should not throw
+    expect(() => releaseLock(lockPath)).not.toThrow();
+  });
+});

--- a/src/indexer/backup.ts
+++ b/src/indexer/backup.ts
@@ -11,6 +11,52 @@ import type { IndexerConfig } from '../types.ts';
 const DEFAULT_BACKUP_KEEP = 10;
 
 /**
+ * Stale lock threshold: if a lock file is older than this, assume the
+ * owning process crashed and reclaim it.
+ */
+const LOCK_STALE_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Acquire an exclusive file lock using O_CREAT|O_EXCL (atomic on all OS).
+ * Returns `true` if the lock was acquired, `false` if another process holds it.
+ * Automatically removes stale locks from crashed processes.
+ */
+export function acquireLock(lockPath: string): boolean {
+  // Check for stale lock first
+  try {
+    const stat = fs.statSync(lockPath);
+    if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
+      console.warn(`⚠️ Removing stale backup lock (age: ${Math.round((Date.now() - stat.mtimeMs) / 1000)}s)`);
+      fs.unlinkSync(lockPath);
+    }
+  } catch {
+    // Lock file doesn't exist — good, proceed to create it
+  }
+
+  try {
+    const fd = fs.openSync(lockPath, fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY);
+    // Write our PID so stale-lock diagnostics can identify the owner
+    fs.writeSync(fd, `${process.pid}\n`);
+    fs.closeSync(fd);
+    return true;
+  } catch (e: any) {
+    if (e.code === 'EEXIST') return false;
+    throw e;
+  }
+}
+
+/**
+ * Release the file lock.
+ */
+export function releaseLock(lockPath: string): void {
+  try {
+    fs.unlinkSync(lockPath);
+  } catch {
+    // Already removed — harmless
+  }
+}
+
+/**
  * Delete old backup/export files, keeping the most recent `keep`.
  * Each family (.backup-, .export-*.json, .export-*.csv) is rotated
  * independently so a missing member doesn't skew retention.
@@ -33,7 +79,17 @@ function rotateBackups(dbPath: string, keep: number): void {
   }
 
   for (const { prefix, suffix } of families) {
-    const matches = entries
+    // Re-read directory for each family so we see files created by any
+    // concurrent process that finished between families (belt-and-suspenders
+    // with the file lock above).
+    let freshEntries: string[];
+    try {
+      freshEntries = fs.readdirSync(dir);
+    } catch {
+      freshEntries = entries; // fall back to initial snapshot
+    }
+
+    const matches = freshEntries
       .filter(f => f.startsWith(prefix) && f.endsWith(suffix))
       .sort()
       .reverse();
@@ -57,6 +113,25 @@ function rotateBackups(dbPath: string, keep: number): void {
  * 3. CSV export (.export-TIMESTAMP.csv) for DuckDB/analytics
  */
 export function backupDatabase(sqlite: Database, config: IndexerConfig): void {
+  const lockPath = `${config.dbPath}.backup.lock`;
+
+  if (!acquireLock(lockPath)) {
+    console.log('⏳ Backup already in progress (locked by another process) — skipping');
+    return;
+  }
+
+  try {
+    backupDatabaseUnsafe(sqlite, config);
+  } finally {
+    releaseLock(lockPath);
+  }
+}
+
+/**
+ * Internal: performs backup + rotation without locking.
+ * Always call via `backupDatabase()` which serialises concurrent callers.
+ */
+function backupDatabaseUnsafe(sqlite: Database, config: IndexerConfig): void {
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
   const backupPath = `${config.dbPath}.backup-${timestamp}`;
   const jsonPath = `${config.dbPath}.export-${timestamp}.json`;


### PR DESCRIPTION
## Summary

- Adds `O_CREAT|O_EXCL` file lock around `backupDatabase()` so only one concurrent reindex process can run backup+rotate at a time — prevents multiple "latest" backups surviving when `ORACLE_BACKUP_KEEP=1`
- Stale locks (>5 min) are auto-reclaimed in case a process crashes mid-backup
- Rotation now re-reads the directory per family as a belt-and-suspenders measure against any remaining TOCTOU window

Fixes #1037

## Test plan

- [x] 7 new unit tests for lock acquire/release/stale semantics (`src/indexer/__tests__/backup-lock.test.ts`)
- [x] All 145 existing unit tests pass
- [ ] Manual: set `ORACLE_BACKUP_KEEP=1`, trigger 3+ concurrent reindexes, verify only 1 backup file per family survives

🤖 Generated with [Claude Code](https://claude.com/claude-code)