### PR TITLE
feat(menu): scope column for sub-nav separation

### DIFF
--- a/src/db/migrations/0015_menu_scope.sql
+++ b/src/db/migrations/0015_menu_scope.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `menu_items` ADD COLUMN `scope` text DEFAULT 'main' NOT NULL;

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1780012800000,
       "tag": "0014_menu_path_studio_composite",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "6",
+      "when": 1780099200000,
+      "tag": "0015_menu_scope",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -307,6 +307,7 @@ export const menuItems = sqliteTable('menu_items', {
   icon: text('icon'),
   host: text('host'),
   hidden: integer('hidden', { mode: 'boolean' }).notNull().default(false),
+  scope: text('scope').notNull().default('main'),  // 'main' | 'sub' | 'both'
   query: text('query'),
   studio: text('studio'),
   touchedAt: integer('touched_at', { mode: 'timestamp' }),

--- a/src/routes/menu/__tests__/menu-scope.test.ts
+++ b/src/routes/menu/__tests__/menu-scope.test.ts
@@ -1,0 +1,157 @@
+/**
+ * #949: scope column — sub-nav scope separation.
+ * Exercises scopeMatches() and readApiMenuItemsFromDb(?scope=) filtering.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { scopeMatches, readApiMenuItemsFromDb } from '../menu.ts';
+import { db, menuItems } from '../../../db/index.ts';
+
+// ---------------------------------------------------------------------------
+// scopeMatches unit tests (pure function, no DB)
+// ---------------------------------------------------------------------------
+
+describe('scopeMatches', () => {
+  it('returns true when no filter is provided (backward compat)', () => {
+    expect(scopeMatches('main', undefined)).toBe(true);
+    expect(scopeMatches('sub', undefined)).toBe(true);
+    expect(scopeMatches('both', undefined)).toBe(true);
+  });
+
+  it('scope=main matches rows with scope=main', () => {
+    expect(scopeMatches('main', 'main')).toBe(true);
+  });
+
+  it('scope=main does NOT match rows with scope=sub', () => {
+    expect(scopeMatches('sub', 'main')).toBe(false);
+  });
+
+  it('scope=sub matches rows with scope=sub', () => {
+    expect(scopeMatches('sub', 'sub')).toBe(true);
+  });
+
+  it('scope=sub does NOT match rows with scope=main', () => {
+    expect(scopeMatches('main', 'sub')).toBe(false);
+  });
+
+  it('scope=both matches any filter', () => {
+    expect(scopeMatches('both', 'main')).toBe(true);
+    expect(scopeMatches('both', 'sub')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DB round-trip: scope filtering via readApiMenuItemsFromDb
+// ---------------------------------------------------------------------------
+
+describe('readApiMenuItemsFromDb — scope filter', () => {
+  const now = new Date();
+  const prefix = `/__scope_test_${Date.now()}`;
+  const mainPath = `${prefix}/header`;
+  const subPath = `${prefix}/subnav`;
+  const bothPath = `${prefix}/shared`;
+
+  function seed() {
+    db.insert(menuItems)
+      .values([
+        {
+          path: mainPath,
+          label: 'Header Item',
+          groupKey: 'main',
+          position: 10,
+          enabled: true,
+          access: 'public',
+          source: 'custom',
+          scope: 'main',
+          touchedAt: now,
+          createdAt: now,
+          updatedAt: now,
+        },
+        {
+          path: subPath,
+          label: 'SubNav Item',
+          groupKey: 'main',
+          position: 11,
+          enabled: true,
+          access: 'public',
+          source: 'custom',
+          scope: 'sub',
+          touchedAt: now,
+          createdAt: now,
+          updatedAt: now,
+        },
+        {
+          path: bothPath,
+          label: 'Shared Item',
+          groupKey: 'main',
+          position: 12,
+          enabled: true,
+          access: 'public',
+          source: 'custom',
+          scope: 'both',
+          touchedAt: now,
+          createdAt: now,
+          updatedAt: now,
+        },
+      ])
+      .run();
+  }
+
+  function cleanup() {
+    db.delete(menuItems).where(eq(menuItems.path, mainPath)).run();
+    db.delete(menuItems).where(eq(menuItems.path, subPath)).run();
+    db.delete(menuItems).where(eq(menuItems.path, bothPath)).run();
+  }
+
+  it('no scope filter returns all three items', () => {
+    seed();
+    try {
+      const items = readApiMenuItemsFromDb();
+      const paths = items.filter((i) => i.path.startsWith(prefix)).map((i) => i.path);
+      expect(paths).toContain(mainPath);
+      expect(paths).toContain(subPath);
+      expect(paths).toContain(bothPath);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('scope=main returns main + both, excludes sub', () => {
+    seed();
+    try {
+      const items = readApiMenuItemsFromDb(undefined, 'main');
+      const paths = items.filter((i) => i.path.startsWith(prefix)).map((i) => i.path);
+      expect(paths).toContain(mainPath);
+      expect(paths).toContain(bothPath);
+      expect(paths).not.toContain(subPath);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('scope=sub returns sub + both, excludes main', () => {
+    seed();
+    try {
+      const items = readApiMenuItemsFromDb(undefined, 'sub');
+      const paths = items.filter((i) => i.path.startsWith(prefix)).map((i) => i.path);
+      expect(paths).toContain(subPath);
+      expect(paths).toContain(bothPath);
+      expect(paths).not.toContain(mainPath);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('scope=sub items expose scope field in response', () => {
+    seed();
+    try {
+      const items = readApiMenuItemsFromDb(undefined, 'sub');
+      const subItem = items.find((i) => i.path === subPath);
+      expect(subItem).toBeDefined();
+      expect(subItem!.scope).toBe('sub');
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/routes/menu/admin.ts
+++ b/src/routes/menu/admin.ts
@@ -7,6 +7,7 @@
 import { Elysia, t } from 'elysia';
 import { eq, asc } from 'drizzle-orm';
 import { db, menuItems } from '../../db/index.ts';
+import { ScopeSchema } from './model.ts';
 
 type MenuRow = typeof menuItems.$inferSelect;
 
@@ -47,6 +48,7 @@ export function toResponse(row: MenuRow) {
     icon: row.icon,
     host: row.host,
     hidden: row.hidden,
+    scope: row.scope,
     query: parseQuery(row.query),
     touchedAt: row.touchedAt ? row.touchedAt.getTime() : null,
     createdAt: row.createdAt.getTime(),
@@ -123,6 +125,7 @@ export function createMenuAdminRoutes() {
               icon: body.icon ?? null,
               host: body.host ?? null,
               hidden: body.hidden ?? false,
+              scope: body.scope ?? 'main',
               query: body.query ? JSON.stringify(body.query) : null,
               touchedAt: now,
               createdAt: now,
@@ -149,6 +152,7 @@ export function createMenuAdminRoutes() {
           icon: t.Optional(t.String()),
           host: t.Optional(t.Nullable(t.String())),
           hidden: t.Optional(t.Boolean()),
+          scope: t.Optional(ScopeSchema),
           query: t.Optional(t.Nullable(t.Record(t.String(), t.String()))),
         }),
         detail: {
@@ -177,6 +181,7 @@ export function createMenuAdminRoutes() {
         if (body.icon !== undefined) patch.icon = body.icon;
         if (body.host !== undefined) patch.host = body.host;
         if (body.hidden !== undefined) patch.hidden = body.hidden;
+        if (body.scope !== undefined) patch.scope = body.scope;
         if (body.query !== undefined) patch.query = body.query == null ? null : JSON.stringify(body.query);
 
         const updated = db
@@ -203,6 +208,7 @@ export function createMenuAdminRoutes() {
           icon: t.Optional(t.Nullable(t.String())),
           host: t.Optional(t.Nullable(t.String())),
           hidden: t.Optional(t.Boolean()),
+          scope: t.Optional(ScopeSchema),
           query: t.Optional(t.Nullable(t.Record(t.String(), t.String()))),
         }),
         detail: {

--- a/src/routes/menu/index.ts
+++ b/src/routes/menu/index.ts
@@ -25,6 +25,7 @@ export {
   buildMenuItems,
   menuItemsFromRoutes,
   readApiMenuItemsFromDb,
+  scopeMatches,
   API_TO_STUDIO,
 } from './menu.ts';
-export type { MenuItem, MenuResponse } from './model.ts';
+export type { MenuItem, MenuResponse, Scope } from './model.ts';

--- a/src/routes/menu/menu.ts
+++ b/src/routes/menu/menu.ts
@@ -11,7 +11,7 @@
 
 import { Elysia, t } from 'elysia';
 import { asc } from 'drizzle-orm';
-import { MenuItemSchema, MenuResponseSchema, type MenuItem, type MenuMeta } from './model.ts';
+import { MenuItemSchema, MenuResponseSchema, ScopeSchema, type MenuItem, type MenuMeta, type Scope } from './model.ts';
 import { getFrontendMenuItems } from '../../menu/index.ts';
 import { getMenuConfig, getMenuSource, reloadMenuConfig } from '../../menu/config.ts';
 import { listCustomMenuItems } from '../../menu/custom-store.ts';
@@ -95,12 +95,26 @@ export function hostMatches(pattern: string | null | undefined, host: string): b
 }
 
 /**
+ * Does the row's scope match the requested scope filter?
+ *
+ * - No scope filter -> everything passes (backward compat)
+ * - scope='main'   -> rows with scope='main' or scope='both'
+ * - scope='sub'    -> rows with scope='sub'  or scope='both'
+ */
+export function scopeMatches(rowScope: string, filterScope?: Scope): boolean {
+  if (filterScope == null) return true;
+  if (rowScope === 'both') return true;
+  return rowScope === filterScope;
+}
+
+/**
  * Read API-sourced menu items from the `menu_items` DB table.
  * Only enabled rows are returned. Source is always 'api' for studio consumers.
  * When `host` is provided, rows are filtered to those with null `host` (shown
  * everywhere) or a glob pattern matching the supplied host.
+ * When `scope` is provided, rows are filtered to that scope or 'both'.
  */
-export function readApiMenuItemsFromDb(host?: string): MenuItem[] {
+export function readApiMenuItemsFromDb(host?: string, scope?: Scope): MenuItem[] {
   const rows = db
     .select()
     .from(menuItems)
@@ -111,6 +125,7 @@ export function readApiMenuItemsFromDb(host?: string): MenuItem[] {
   for (const row of rows) {
     if (row.enabled === false) continue;
     if (host !== undefined && !hostMatches(row.host, host)) continue;
+    if (!scopeMatches(row.scope, scope)) continue;
     const group = (['main', 'tools', 'admin', 'hidden'] as const).includes(
       row.groupKey as MenuItem['group'],
     )
@@ -129,6 +144,7 @@ export function readApiMenuItemsFromDb(host?: string): MenuItem[] {
     if (row.access === 'public' || row.access === 'auth') item.access = row.access;
     if (row.hidden) item.hidden = true;
     if (row.studio) item.studio = row.studio;
+    if (row.scope !== 'main') item.scope = row.scope as Scope;
     if (row.query) {
       try {
         const parsed = JSON.parse(row.query);
@@ -214,16 +230,21 @@ export function createMenuEndpoint() {
       async ({ query }) => {
         const { items, disable } = await getMenuConfig();
         const host = typeof query.host === 'string' && query.host.length > 0 ? query.host : undefined;
+        const validScopes = ['main', 'sub', 'both'] as const;
+        const scope = validScopes.includes(query.scope as Scope) ? (query.scope as Scope) : undefined;
         return {
           items: buildMenuItems(
-            readApiMenuItemsFromDb(host),
+            readApiMenuItemsFromDb(host, scope),
             { items, disable },
             listCustomMenuItems(),
           ),
         };
       },
       {
-        query: t.Object({ host: t.Optional(t.String()) }),
+        query: t.Object({
+          host: t.Optional(t.String()),
+          scope: t.Optional(ScopeSchema),
+        }),
         detail: {
           tags: ['menu'],
           menu: { group: 'hidden' },

--- a/src/routes/menu/model.ts
+++ b/src/routes/menu/model.ts
@@ -19,6 +19,14 @@ declare module 'elysia' {
   }
 }
 
+export const ScopeSchema = t.Union([
+  t.Literal('main'),
+  t.Literal('sub'),
+  t.Literal('both'),
+]);
+
+export type Scope = Static<typeof ScopeSchema>;
+
 export const MenuItemSchema = t.Object({
   id: t.Optional(t.String()),
   parentId: t.Optional(t.Nullable(t.String())),
@@ -41,6 +49,7 @@ export const MenuItemSchema = t.Object({
   ]),
   added: t.Optional(t.Boolean()),
   hidden: t.Optional(t.Boolean()),
+  scope: t.Optional(ScopeSchema),
   query: t.Optional(t.Record(t.String(), t.String())),
 });
 


### PR DESCRIPTION
## Summary
- Adds `scope` column (`main`/`sub`/`both`) to `menu_items` table via migration 0015
- `/api/menu?scope=main` returns main + both items (for Header)
- `/api/menu?scope=sub` returns sub + both items (for SubNav)
- No `scope` param = backward compatible (returns everything)
- Admin CRUD (POST/PATCH) supports `scope` field
- 10 new tests covering `scopeMatches()` logic and DB round-trip

## How it fixes #949
The root cause: `?host=vector.*` returns null-host items ("show everywhere"), so both Header and SubNav got the same items. Now each component can request its own scope:
- Header: `GET /api/menu?scope=main`
- SubNav: `GET /api/menu?host=vector.*&scope=sub`
- Items marked `scope=both` appear in both contexts

## Frontend changes needed (ui-oracle repo)
- SubNav component: change fetch URL from `/api/menu?host=...` to `/api/menu?host=...&scope=sub`
- Header component: optionally add `?scope=main` (not required since existing items default to `main`)
- Admin UI: expose scope dropdown when editing menu items

## Test plan
- [x] `scopeMatches()` unit tests (7 cases)
- [x] DB round-trip tests (3 cases) — no filter, main filter, sub filter
- [x] All existing menu tests pass (36/36)

Closes #949

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>