### PR TITLE
feat(vector): standalone vector-server.ts entry point (#1071 Phase 3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
   "scripts": {
     "dev": "bun src/index.ts",
     "server": "bun src/server.ts",
+    "vector": "ORACLE_VECTOR_READONLY=1 bun src/vector-server.ts",
+    "vector:dev": "ORACLE_VECTOR_READONLY=1 bun --watch src/vector-server.ts",
     "server:ensure": "bun src/ensure-server.ts",
     "server:status": "bun src/ensure-server.ts --status",
     "serve": "bun dist/server.js",

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -128,11 +128,18 @@ if (!fs.existsSync(ORACLE_DATA_DIR)) {
   fs.mkdirSync(ORACLE_DATA_DIR, { recursive: true });
 }
 
-const defaultSqlite = new Database(DB_PATH);
+const isReadonly = process.env.ORACLE_VECTOR_READONLY === '1';
+const defaultSqlite = isReadonly
+  ? new Database(DB_PATH, { readonly: true })
+  : new Database(DB_PATH);
 const defaultDb = drizzle(defaultSqlite, { schema });
 
-// Run initialization on the default connection
-initializeDatabase(defaultSqlite, defaultDb);
+if (isReadonly) {
+  console.log('[DB] Opened in READONLY mode (vector sidecar)');
+} else {
+  // Run initialization on the default connection (skipped in readonly mode)
+  initializeDatabase(defaultSqlite, defaultDb);
+}
 
 export const sqlite = defaultSqlite;
 export const db = defaultDb;

--- a/src/vector-server.ts
+++ b/src/vector-server.ts
@@ -1,0 +1,62 @@
+/**
+ * Arra Vector Server — standalone Elysia sidecar.
+ *
+ * Phase 3 of #1071: runs as a separate process so the vector layer
+ * can scale independently of the main Oracle HTTP server.
+ *
+ * Usage:
+ *   ORACLE_VECTOR_READONLY=1 bun src/vector-server.ts
+ *
+ * The main server proxies to this via VECTOR_URL=http://localhost:<port>.
+ * Opens oracle.db in READ-ONLY mode (no WAL contention).
+ */
+
+import { Elysia } from 'elysia';
+import { cors } from '@elysiajs/cors';
+import { swagger } from '@elysiajs/swagger';
+
+import { loadVectorConfig, generateDefaultConfig } from './vector/config.ts';
+import { vectorRoutes } from './routes/vector/index.ts';
+
+import pkg from '../package.json' with { type: 'json' };
+
+// ── Config ──────────────────────────────────────────────────────────
+const config = loadVectorConfig() ?? generateDefaultConfig();
+const PORT = Number(process.env.VECTOR_PORT ?? config.port);
+
+// ── App ─────────────────────────────────────────────────────────────
+const app = new Elysia()
+  .use(cors())                           // permissive — internal sidecar
+  .use(
+    swagger({
+      path: '/swagger',
+      documentation: {
+        info: {
+          title: 'Arra Vector Server',
+          version: pkg.version,
+          description: 'Standalone vector / embedding sidecar for Arra Oracle.',
+        },
+      },
+    }),
+  )
+  .get('/', () => ({
+    server: 'arra-vector',
+    version: pkg.version,
+    status: 'ok',
+    docs: '/swagger',
+  }))
+  .use(vectorRoutes);
+
+console.log(`
+🧭 Arra Vector Server running! (Elysia)
+
+   URL:     http://localhost:${PORT}
+   Swagger: http://localhost:${PORT}/swagger
+   Version: ${pkg.version}
+   DB mode: ${process.env.ORACLE_VECTOR_READONLY === '1' ? 'readonly' : 'read-write'}
+`);
+
+export default {
+  port: PORT,
+  fetch: app.fetch,
+};


### PR DESCRIPTION
## Summary

- **New file `src/vector-server.ts`** (62 lines) — standalone Elysia HTTP sidecar that mounts all vector routes (`/api/similar`, `/api/compare`, `/api/map`, `/api/map3d`, `/api/vector/stats`, `/api/vector/health`, `/api/vector/config`) on its own port (default 8081 from `vector-server.json`)
- **Modified `src/db/index.ts`** — when `ORACLE_VECTOR_READONLY=1` env var is set, opens `oracle.db` in SQLite read-only mode, skipping migrations/FTS5 init. Eliminates WAL contention with the main server
- **Added `package.json` scripts** — `bun run vector` and `bun run vector:dev` for easy startup

## Design

The vector server is a **read-only sidecar** — it needs LanceDB for embeddings and oracle.db for metadata enrichment, but never writes to SQLite. The main Oracle server can proxy to it via `VECTOR_URL=http://localhost:8081`.

Config is loaded from `vector-server.json` (Phase 2, #1081) with fallback to `generateDefaultConfig()`. Port can be overridden via `VECTOR_PORT` env var.

## Test plan

- [x] `ORACLE_VECTOR_READONLY=1 bun src/vector-server.ts` starts and responds on port 8081
- [x] Root `/` returns `{ server: 'arra-vector', version, status: 'ok' }`
- [x] `/swagger` returns 200
- [x] `/api/vector/stats` returns collection counts
- [x] `/api/vector/health` returns engine liveness
- [x] All 584 existing tests pass (0 fail, 22 skip)
- [x] No new npm dependencies

Refs #1071

🤖 Generated with [Claude Code](https://claude.com/claude-code)