### PR TITLE
feat(gateway): config-driven route matcher + proxy dispatcher

### DIFF
--- a/src/gateway/__tests__/matcher.test.ts
+++ b/src/gateway/__tests__/matcher.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for gateway route matcher — glob-to-regex compilation.
+ */
+import { describe, test, expect } from 'bun:test';
+import { compileRoutes, matchRoute } from '../matcher.ts';
+
+const routes = compileRoutes([
+  { match: '/api/similar', service: 'vector', fallback: 'fts5' },
+  { match: '/api/vector/**', service: 'vector' },
+  { match: '/api/map*', service: 'maps' },
+  { match: '/api/local', service: 'local' },
+]);
+
+describe('gateway matcher', () => {
+  test('exact match', () => {
+    const m = matchRoute('/api/similar', routes);
+    expect(m).not.toBeNull();
+    expect(m!.service).toBe('vector');
+    expect(m!.fallback).toBe('fts5');
+  });
+
+  test('exact match rejects sub-paths', () => {
+    expect(matchRoute('/api/similar/extra', routes)).toBeNull();
+  });
+
+  test('prefix match with /**', () => {
+    expect(matchRoute('/api/vector', routes)?.service).toBe('vector');
+    expect(matchRoute('/api/vector/', routes)?.service).toBe('vector');
+    expect(matchRoute('/api/vector/stats', routes)?.service).toBe('vector');
+    expect(matchRoute('/api/vector/health/deep', routes)?.service).toBe('vector');
+  });
+
+  test('prefix match rejects non-matching paths', () => {
+    expect(matchRoute('/api/vectorize', routes)).toBeNull();
+  });
+
+  test('wildcard match with *', () => {
+    expect(matchRoute('/api/map', routes)?.service).toBe('maps');
+    expect(matchRoute('/api/mapper', routes)?.service).toBe('maps');
+    expect(matchRoute('/api/map-view', routes)?.service).toBe('maps');
+  });
+
+  test('no match returns null', () => {
+    expect(matchRoute('/api/health', routes)).toBeNull();
+    expect(matchRoute('/', routes)).toBeNull();
+  });
+
+  test('first match wins', () => {
+    const m = matchRoute('/api/similar', routes);
+    expect(m!.pattern).toBe('/api/similar');
+  });
+
+  test('empty routes returns null', () => {
+    expect(matchRoute('/api/anything', compileRoutes([]))).toBeNull();
+  });
+
+  test('special regex chars in pattern are escaped', () => {
+    const r = compileRoutes([{ match: '/api/v1.0/data', service: 'v1' }]);
+    expect(matchRoute('/api/v1.0/data', r)?.service).toBe('v1');
+    expect(matchRoute('/api/v1X0/data', r)).toBeNull(); // dot must not match any char
+  });
+});

--- a/src/gateway/config.ts
+++ b/src/gateway/config.ts
@@ -1,0 +1,59 @@
+/**
+ * Gateway configuration loader.
+ *
+ * Reads `oracle-gateway.json` from ORACLE_DATA_DIR.
+ * If the file is missing, returns null (all routes stay local).
+ * If VECTOR_URL is set but no config file exists, auto-generates
+ * a gateway config that proxies vector routes to VECTOR_URL.
+ */
+import fs from 'fs';
+import path from 'path';
+
+export interface ServiceConfig {
+  url: string;
+  healthCheck?: string;
+  timeout?: number;
+}
+
+export interface RouteConfig {
+  match: string;
+  service: string;
+  fallback?: 'fts5' | 'empty' | 'error';
+}
+
+export interface GatewayConfig {
+  services: Record<string, ServiceConfig>;
+  routes: RouteConfig[];
+}
+
+const CONFIG_FILE = 'oracle-gateway.json';
+
+export function loadGatewayConfig(dataDir: string, vectorUrl?: string): GatewayConfig | null {
+  const configPath = path.join(dataDir, CONFIG_FILE);
+
+  if (fs.existsSync(configPath)) {
+    try {
+      const raw = fs.readFileSync(configPath, 'utf-8');
+      return JSON.parse(raw) as GatewayConfig;
+    } catch (e) {
+      console.warn(`[Gateway] Failed to parse ${configPath}:`, e);
+      return null;
+    }
+  }
+
+  // Backward compat: synthesize config from VECTOR_URL
+  if (vectorUrl) {
+    return {
+      services: {
+        vector: { url: vectorUrl, timeout: 5000 },
+      },
+      routes: [
+        { match: '/api/vector/**', service: 'vector', fallback: 'fts5' },
+        { match: '/api/similar', service: 'vector', fallback: 'fts5' },
+        { match: '/api/search', service: 'vector', fallback: 'fts5' },
+      ],
+    };
+  }
+
+  return null;
+}

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -1,0 +1,47 @@
+/**
+ * Gateway Elysia plugin — wires config + matcher + proxy into onRequest.
+ *
+ * If no config file and no VECTOR_URL → no-op (all routes local).
+ * If matched service = "local" → fall through to Elysia handlers.
+ * If matched service has a URL → proxy to upstream.
+ */
+import { Elysia } from 'elysia';
+import { loadGatewayConfig, type GatewayConfig } from './config.ts';
+import { compileRoutes, matchRoute, type CompiledRoute } from './matcher.ts';
+import { proxyToService } from './proxy.ts';
+
+export { loadGatewayConfig, compileRoutes, matchRoute, proxyToService };
+export type { GatewayConfig, CompiledRoute };
+
+export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
+  const config = loadGatewayConfig(dataDir, vectorUrl);
+
+  if (!config) {
+    // No gateway config — all routes handled locally
+    return new Elysia({ name: 'gateway' });
+  }
+
+  const compiled = compileRoutes(config.routes);
+  console.log(
+    `[Gateway] Loaded ${config.routes.length} route(s), ${Object.keys(config.services).length} service(s)`,
+  );
+
+  return new Elysia({ name: 'gateway' })
+    .get('/api/gateway/status', () => ({
+      enabled: true,
+      routes: config.routes.length,
+      services: Object.fromEntries(
+        Object.entries(config.services).map(([k, v]) => [k, { url: v.url, timeout: v.timeout }]),
+      ),
+    }))
+    .onRequest(({ request }) => {
+      const url = new URL(request.url);
+      const match = matchRoute(url.pathname, compiled);
+      if (!match) return; // no match — fall through to local Elysia routes
+
+      const service = config.services[match.service];
+      if (!service || match.service === 'local') return; // "local" = handle locally
+
+      return proxyToService(request, service);
+    });
+}

--- a/src/gateway/matcher.ts
+++ b/src/gateway/matcher.ts
@@ -1,0 +1,62 @@
+/**
+ * Route matcher — compiles glob patterns to RegExp at startup.
+ *
+ * Three pattern types:
+ *   - Exact:    `/api/similar`       — matches only that path
+ *   - Prefix:   `/api/vector/**`     — matches path and all sub-paths
+ *   - Wildcard: `/api/map*`          — matches anything starting with prefix
+ *
+ * First match wins.
+ */
+import type { RouteConfig } from './config.ts';
+
+export interface CompiledRoute {
+  regex: RegExp;
+  service: string;
+  fallback?: 'fts5' | 'empty' | 'error';
+  pattern: string;
+}
+
+export interface MatchedRoute {
+  service: string;
+  fallback?: 'fts5' | 'empty' | 'error';
+  pattern: string;
+}
+
+/** Escape regex special chars (except our glob tokens). */
+function escapeRegex(s: string): string {
+  return s.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function compileRoutes(routes: RouteConfig[]): CompiledRoute[] {
+  return routes.map((r) => {
+    let regexStr: string;
+    if (r.match.endsWith('/**')) {
+      // Prefix match: /api/vector/** -> /api/vector and /api/vector/anything
+      const prefix = r.match.slice(0, -3);
+      regexStr = `^${escapeRegex(prefix)}(?:/.*)?$`;
+    } else if (r.match.includes('*')) {
+      // Wildcard: /api/map* -> /api/map, /api/mapper, /api/map-view etc.
+      const parts = r.match.split('*');
+      regexStr = `^${parts.map(escapeRegex).join('.*')}$`;
+    } else {
+      // Exact match
+      regexStr = `^${escapeRegex(r.match)}$`;
+    }
+    return {
+      regex: new RegExp(regexStr),
+      service: r.service,
+      fallback: r.fallback,
+      pattern: r.match,
+    };
+  });
+}
+
+export function matchRoute(pathname: string, routes: CompiledRoute[]): MatchedRoute | null {
+  for (const r of routes) {
+    if (r.regex.test(pathname)) {
+      return { service: r.service, fallback: r.fallback, pattern: r.pattern };
+    }
+  }
+  return null;
+}

--- a/src/gateway/proxy.ts
+++ b/src/gateway/proxy.ts
@@ -1,0 +1,62 @@
+/**
+ * Gateway proxy dispatcher — forwards requests to upstream services.
+ *
+ * Uses built-in fetch(). No dependencies.
+ * Returns 502 on connection refused, 504 on timeout.
+ */
+import type { ServiceConfig } from './config.ts';
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+export async function proxyToService(
+  request: Request,
+  service: ServiceConfig,
+): Promise<Response> {
+  const incomingUrl = new URL(request.url);
+  const targetBase = service.url.replace(/\/+$/, '');
+  const targetUrl = `${targetBase}${incomingUrl.pathname}${incomingUrl.search}`;
+  const timeoutMs = service.timeout ?? DEFAULT_TIMEOUT_MS;
+
+  try {
+    const headers = new Headers(request.headers);
+    headers.delete('host');
+
+    const res = await fetch(targetUrl, {
+      method: request.method,
+      headers,
+      body: request.method !== 'GET' && request.method !== 'HEAD'
+        ? request.body
+        : undefined,
+      signal: AbortSignal.timeout(timeoutMs),
+      // @ts-expect-error — Bun supports duplex streaming
+      duplex: 'half',
+    });
+
+    // Stream the response back, preserving status and headers
+    const responseHeaders = new Headers(res.headers);
+    responseHeaders.set('X-Gateway-Service', service.url);
+
+    return new Response(res.body, {
+      status: res.status,
+      statusText: res.statusText,
+      headers: responseHeaders,
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    const isTimeout = msg.includes('timeout') || msg.includes('aborted');
+
+    console.warn(`[Gateway] proxy to ${targetBase} failed: ${msg}`);
+
+    if (isTimeout) {
+      return new Response(JSON.stringify({ error: 'Gateway timeout', target: targetBase }), {
+        status: 504,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    return new Response(JSON.stringify({ error: 'Bad gateway', target: targetBase }), {
+      status: 502,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -43,6 +43,7 @@ import { sessionsRoutes } from './routes/sessions/index.ts';
 import { vaultRoutes } from './routes/vault/index.ts';
 import { indexerRoutes } from './routes/indexer/index.ts';
 import { createMenuRoutes } from './routes/menu/index.ts';
+import { gatewayPlugin } from './gateway/index.ts';
 
 import pkg from '../package.json' with { type: 'json' };
 
@@ -179,6 +180,7 @@ const app = new Elysia()
       },
     }),
   )
+  .use(gatewayPlugin(ORACLE_DATA_DIR, VECTOR_URL || undefined))
   .get('/', () => ({
     server: MCP_SERVER_NAME,
     version: pkg.version,


### PR DESCRIPTION
## Summary
- Add `src/gateway/` module with config loader, glob-to-regex route matcher, and fetch-based proxy dispatcher
- Wire gateway as Elysia plugin in `src/server.ts` via `onRequest` hook — intercepts before local routes
- Fully optional: no `oracle-gateway.json` = zero behavior change (all routes local)
- Backward compat: if `VECTOR_URL` is set but no config file, auto-generates gateway config for vector routes
- New endpoint: `GET /api/gateway/status` shows loaded config when gateway is active

## Files (6 files, 294 lines)
- `src/gateway/config.ts` — load `oracle-gateway.json` from ORACLE_DATA_DIR, synthesize from VECTOR_URL
- `src/gateway/matcher.ts` — compile glob patterns (exact, prefix `/**`, wildcard `*`) to RegExp
- `src/gateway/proxy.ts` — forward requests to upstream via fetch(), 502/504 on failure
- `src/gateway/index.ts` — Elysia plugin wiring matcher + proxy into onRequest
- `src/gateway/__tests__/matcher.test.ts` — 9 unit tests for glob-to-regex conversion
- `src/server.ts` — 2 lines: import + `.use(gatewayPlugin(...))`

## Test plan
- [x] `bun test src/gateway/__tests__/matcher.test.ts` — 9/9 pass
- [ ] Deploy with no config file — verify zero behavior change
- [ ] Deploy with `VECTOR_URL` set — verify auto-generated gateway config
- [ ] Create `oracle-gateway.json` — verify route proxying

Closes #1072

🤖 Generated with [Claude Code](https://claude.com/claude-code)