### PR TITLE
feat(gateway): hook pipeline for pre/post proxy middleware

### DIFF
--- a/src/gateway/__tests__/health.test.ts
+++ b/src/gateway/__tests__/health.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for gateway health registry.
+ */
+import { describe, test, expect, afterEach, mock } from 'bun:test';
+import { HealthRegistry } from '../health.ts';
+
+describe('HealthRegistry', () => {
+  let registry: HealthRegistry;
+
+  afterEach(() => {
+    registry?.stop();
+  });
+
+  test('isUp returns true for services without healthCheck', () => {
+    registry = new HealthRegistry();
+    // Never started — no healthCheck configured
+    expect(registry.isUp('vector')).toBe(true);
+  });
+
+  test('getStatus returns unknown for untracked services', () => {
+    registry = new HealthRegistry();
+    const status = registry.getStatus('nonexistent');
+    expect(status.status).toBe('unknown');
+    expect(status.lastCheck).toBe(0);
+  });
+
+  test('start seeds services that have healthCheck', () => {
+    registry = new HealthRegistry();
+    // Use a URL that will fail (no server) — we just test seeding
+    registry.start(
+      {
+        vector: { url: 'http://localhost:19999', healthCheck: 'http://localhost:19999/health' },
+        local: { url: 'http://localhost:3000' }, // no healthCheck
+      },
+      999_999, // long interval so no second poll fires
+    );
+
+    // vector should be seeded as unknown (first check is async)
+    // local should not be tracked
+    expect(registry.getStatus('vector').status).not.toBe(undefined);
+    expect(registry.isUp('local')).toBe(true); // no healthCheck → always up
+  });
+
+  test('getAllStatus returns map of tracked services', () => {
+    registry = new HealthRegistry();
+    registry.start(
+      {
+        a: { url: 'http://localhost:1', healthCheck: 'http://localhost:1/h' },
+        b: { url: 'http://localhost:2', healthCheck: 'http://localhost:2/h' },
+      },
+      999_999,
+    );
+
+    const all = registry.getAllStatus();
+    expect(Object.keys(all)).toContain('a');
+    expect(Object.keys(all)).toContain('b');
+  });
+
+  test('stop clears interval', () => {
+    registry = new HealthRegistry();
+    registry.start(
+      { v: { url: 'http://localhost:1', healthCheck: 'http://localhost:1/h' } },
+      100,
+    );
+    // Should not throw
+    registry.stop();
+    registry.stop(); // idempotent
+  });
+
+  test('marks service down when fetch fails', async () => {
+    registry = new HealthRegistry();
+    registry.start(
+      { bad: { url: 'http://localhost:19999', healthCheck: 'http://localhost:19999/health' } },
+      999_999,
+    );
+
+    // Wait for the initial check to complete
+    await new Promise((r) => setTimeout(r, 200));
+
+    const status = registry.getStatus('bad');
+    expect(status.status).toBe('down');
+    expect(status.lastError).toBeDefined();
+    expect(registry.isUp('bad')).toBe(false);
+  });
+
+  test('start with no healthCheck services is a no-op', () => {
+    registry = new HealthRegistry();
+    registry.start(
+      { local: { url: 'http://localhost:3000' } },
+      100,
+    );
+    // No services tracked — should be fine
+    expect(Object.keys(registry.getAllStatus())).toHaveLength(0);
+    registry.stop();
+  });
+});

--- a/src/gateway/__tests__/hooks.test.ts
+++ b/src/gateway/__tests__/hooks.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for gateway hook pipeline — load, run, short-circuit.
+ */
+import { describe, test, expect, beforeEach } from 'bun:test';
+import {
+  registerHook,
+  loadHooks,
+  runHooks,
+  type GatewayContext,
+  type GatewayHook,
+} from '../hooks.ts';
+
+// ── helpers ────────────────────────────────────────────────────────
+
+function makeCtx(overrides: Partial<GatewayContext> = {}): GatewayContext {
+  return {
+    request: new Request('http://localhost/api/test'),
+    meta: {},
+    ...overrides,
+  };
+}
+
+// ── tests ──────────────────────────────────────────────────────────
+
+describe('gateway hooks', () => {
+  // Register test hooks
+  beforeEach(() => {
+    registerHook({
+      name: 'test-noop',
+      phase: 'onRequest',
+      handler: () => {},
+    });
+    registerHook({
+      name: 'test-short-circuit',
+      phase: 'onRequest',
+      handler: () => new Response('blocked', { status: 403 }),
+    });
+    registerHook({
+      name: 'test-error-handler',
+      phase: 'onError',
+      handler: (ctx) =>
+        new Response(JSON.stringify({ caught: ctx.error?.message }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    });
+  });
+
+  test('loadHooks returns empty pipeline when config is undefined', () => {
+    const pipeline = loadHooks(undefined);
+    expect(pipeline.onRequest).toEqual([]);
+    expect(pipeline.onResponse).toEqual([]);
+    expect(pipeline.onError).toEqual([]);
+  });
+
+  test('loadHooks resolves known hook names', () => {
+    const pipeline = loadHooks({ onRequest: ['test-noop'] });
+    expect(pipeline.onRequest).toHaveLength(1);
+    expect(pipeline.onRequest[0].name).toBe('test-noop');
+  });
+
+  test('loadHooks skips unknown hook names', () => {
+    const pipeline = loadHooks({ onRequest: ['does-not-exist'] });
+    expect(pipeline.onRequest).toEqual([]);
+  });
+
+  test('loadHooks skips phase mismatch', () => {
+    // test-noop is registered as onRequest, not onResponse
+    const pipeline = loadHooks({ onResponse: ['test-noop'] });
+    expect(pipeline.onResponse).toEqual([]);
+  });
+
+  test('runHooks returns void when no hooks short-circuit', async () => {
+    const pipeline = loadHooks({ onRequest: ['test-noop'] });
+    const result = await runHooks(pipeline.onRequest, makeCtx());
+    expect(result).toBeUndefined();
+  });
+
+  test('runHooks returns Response when a hook short-circuits', async () => {
+    const pipeline = loadHooks({ onRequest: ['test-short-circuit'] });
+    const result = await runHooks(pipeline.onRequest, makeCtx());
+    expect(result).toBeInstanceOf(Response);
+    expect(result!.status).toBe(403);
+  });
+
+  test('first short-circuit wins — later hooks do not run', async () => {
+    const calls: string[] = [];
+    registerHook({
+      name: 'test-tracker',
+      phase: 'onRequest',
+      handler: () => { calls.push('tracker'); },
+    });
+    const pipeline = loadHooks({
+      onRequest: ['test-short-circuit', 'test-tracker'],
+    });
+    await runHooks(pipeline.onRequest, makeCtx());
+    expect(calls).toEqual([]); // tracker never ran
+  });
+
+  test('onError hook receives ctx.error', async () => {
+    const pipeline = loadHooks({ onError: ['test-error-handler'] });
+    const ctx = makeCtx({ error: new Error('boom') });
+    const result = await runHooks(pipeline.onError, ctx);
+    expect(result).toBeInstanceOf(Response);
+    const body = await result!.json();
+    expect(body.caught).toBe('boom');
+  });
+
+  test('hooks can read and write ctx.meta', async () => {
+    registerHook({
+      name: 'test-meta-writer',
+      phase: 'onRequest',
+      handler: (ctx) => { ctx.meta.seen = true; },
+    });
+    const pipeline = loadHooks({ onRequest: ['test-meta-writer'] });
+    const ctx = makeCtx();
+    await runHooks(pipeline.onRequest, ctx);
+    expect(ctx.meta.seen).toBe(true);
+  });
+});

--- a/src/gateway/config.ts
+++ b/src/gateway/config.ts
@@ -8,6 +8,7 @@
  */
 import fs from 'fs';
 import path from 'path';
+import type { HooksConfig } from './hooks.ts';
 
 export interface ServiceConfig {
   url: string;
@@ -24,6 +25,7 @@ export interface RouteConfig {
 export interface GatewayConfig {
   services: Record<string, ServiceConfig>;
   routes: RouteConfig[];
+  hooks?: HooksConfig;
 }
 
 const CONFIG_FILE = 'oracle-gateway.json';

--- a/src/gateway/health.ts
+++ b/src/gateway/health.ts
@@ -1,0 +1,109 @@
+/**
+ * Service health registry — background poller that tracks upstream health.
+ *
+ * If a service has a `healthCheck` URL in its config, the registry pings it
+ * on interval and marks the service up/down. The gateway checks `isUp()`
+ * before proxying — if down, it returns the fallback immediately instead
+ * of waiting for a timeout.
+ */
+import type { ServiceConfig } from './config.ts';
+
+export interface ServiceHealth {
+  status: 'up' | 'down' | 'unknown';
+  lastCheck: number;
+  lastError?: string;
+  responseTime?: number;
+}
+
+const DEFAULT_INTERVAL_MS = 30_000;
+const CHECK_TIMEOUT_MS = 5_000;
+
+export class HealthRegistry {
+  private health = new Map<string, ServiceHealth>();
+  private interval: Timer | null = null;
+
+  /**
+   * Start polling services that have a healthCheck URL.
+   * Services without healthCheck are always assumed "up".
+   */
+  start(services: Record<string, ServiceConfig>, intervalMs = DEFAULT_INTERVAL_MS): void {
+    // Seed initial state
+    for (const [name, svc] of Object.entries(services)) {
+      if (svc.healthCheck) {
+        this.health.set(name, { status: 'unknown', lastCheck: 0 });
+      }
+    }
+
+    if (this.health.size === 0) return; // nothing to poll
+
+    // Fire first check immediately, then repeat on interval
+    this.checkAll(services);
+    this.interval = setInterval(() => this.checkAll(services), intervalMs);
+    // Don't prevent process exit
+    if (typeof this.interval === 'object' && 'unref' in this.interval) {
+      this.interval.unref();
+    }
+
+    console.log(
+      `[Gateway:Health] Polling ${this.health.size} service(s) every ${intervalMs}ms`,
+    );
+  }
+
+  stop(): void {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+  }
+
+  getStatus(serviceName: string): ServiceHealth {
+    return this.health.get(serviceName) ?? { status: 'unknown', lastCheck: 0 };
+  }
+
+  getAllStatus(): Record<string, ServiceHealth> {
+    return Object.fromEntries(this.health);
+  }
+
+  /** Returns true if the service has no health check or is up. */
+  isUp(serviceName: string): boolean {
+    const h = this.health.get(serviceName);
+    if (!h) return true; // no health check configured → assume up
+    return h.status !== 'down';
+  }
+
+  private async checkAll(services: Record<string, ServiceConfig>): Promise<void> {
+    const checks = Object.entries(services)
+      .filter(([, svc]) => svc.healthCheck)
+      .map(([name, svc]) => this.checkOne(name, svc.healthCheck!));
+
+    await Promise.allSettled(checks);
+  }
+
+  private async checkOne(name: string, url: string): Promise<void> {
+    const start = Date.now();
+    try {
+      const res = await fetch(url, {
+        method: 'GET',
+        signal: AbortSignal.timeout(CHECK_TIMEOUT_MS),
+      });
+      const responseTime = Date.now() - start;
+
+      if (res.ok) {
+        this.health.set(name, { status: 'up', lastCheck: start, responseTime });
+      } else {
+        this.health.set(name, {
+          status: 'down',
+          lastCheck: start,
+          responseTime,
+          lastError: `HTTP ${res.status}`,
+        });
+      }
+    } catch (e) {
+      this.health.set(name, {
+        status: 'down',
+        lastCheck: start,
+        lastError: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+}

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -1,0 +1,94 @@
+/**
+ * Gateway hook pipeline — optional middleware that runs before/after proxy.
+ *
+ * Hooks are keyed by phase:
+ *   - onRequest:  runs before proxy dispatch (can short-circuit with a Response)
+ *   - onResponse: runs after a successful proxy response
+ *   - onError:    runs when the proxy (or an onRequest hook) throws
+ *
+ * If no hooks are configured the pipeline is a no-op.
+ */
+import type { MatchedRoute } from './matcher.ts';
+import type { ServiceConfig } from './config.ts';
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export type HookPhase = 'onRequest' | 'onResponse' | 'onError';
+
+export interface GatewayContext {
+  request: Request;
+  route?: MatchedRoute;
+  service?: ServiceConfig;
+  response?: Response;
+  error?: Error;
+  /** Arbitrary per-request metadata hooks can read/write. */
+  meta: Record<string, unknown>;
+}
+
+export interface GatewayHook {
+  name: string;
+  phase: HookPhase;
+  handler: (ctx: GatewayContext) => Response | void | Promise<Response | void>;
+}
+
+export interface HooksConfig {
+  onRequest?: string[];
+  onResponse?: string[];
+  onError?: string[];
+}
+
+// ── Registry ───────────────────────────────────────────────────────
+
+const builtins = new Map<string, GatewayHook>();
+
+/** Register a built-in hook so the loader can find it by name. */
+export function registerHook(hook: GatewayHook): void {
+  builtins.set(hook.name, hook);
+}
+
+// ── Loader ─────────────────────────────────────────────────────────
+
+/** Resolve hook names from config into ordered GatewayHook arrays per phase. */
+export function loadHooks(
+  cfg: HooksConfig | undefined,
+): Record<HookPhase, GatewayHook[]> {
+  const pipeline: Record<HookPhase, GatewayHook[]> = {
+    onRequest: [],
+    onResponse: [],
+    onError: [],
+  };
+  if (!cfg) return pipeline;
+
+  for (const phase of ['onRequest', 'onResponse', 'onError'] as HookPhase[]) {
+    const names = cfg[phase] ?? [];
+    for (const name of names) {
+      const hook = builtins.get(name);
+      if (!hook) {
+        console.warn(`[Gateway] unknown hook "${name}" in ${phase} — skipped`);
+        continue;
+      }
+      if (hook.phase !== phase) {
+        console.warn(`[Gateway] hook "${name}" registered for ${hook.phase}, not ${phase} — skipped`);
+        continue;
+      }
+      pipeline[phase].push(hook);
+    }
+  }
+  return pipeline;
+}
+
+// ── Runner ─────────────────────────────────────────────────────────
+
+/**
+ * Run all hooks for a given phase. Returns a Response if any hook
+ * short-circuits, otherwise undefined.
+ */
+export async function runHooks(
+  hooks: GatewayHook[],
+  ctx: GatewayContext,
+): Promise<Response | void> {
+  for (const hook of hooks) {
+    const result = await hook.handler(ctx);
+    if (result instanceof Response) return result;
+  }
+}

--- a/src/gateway/hooks/error-json.ts
+++ b/src/gateway/hooks/error-json.ts
@@ -1,0 +1,24 @@
+/**
+ * Built-in hook: error-json
+ *
+ * Ensures all gateway errors return a JSON body instead of HTML.
+ * If the error already produced a JSON response, passes through.
+ */
+import { registerHook, type GatewayContext } from '../hooks.ts';
+
+registerHook({
+  name: 'error-json',
+  phase: 'onError',
+  handler(ctx: GatewayContext) {
+    const msg = ctx.error?.message ?? 'Internal gateway error';
+    console.warn(`[Gateway] error: ${msg}`);
+
+    return new Response(
+      JSON.stringify({ error: msg, gateway: true }),
+      {
+        status: 502,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+  },
+});

--- a/src/gateway/hooks/request-logger.ts
+++ b/src/gateway/hooks/request-logger.ts
@@ -1,0 +1,31 @@
+/**
+ * Built-in hook: request-logger
+ *
+ * Logs request method, path, matched service, and round-trip duration.
+ * Attaches a `startTime` to ctx.meta so the onResponse phase can compute duration.
+ */
+import { registerHook, type GatewayContext } from '../hooks.ts';
+
+registerHook({
+  name: 'request-logger',
+  phase: 'onRequest',
+  handler(ctx: GatewayContext) {
+    ctx.meta._gwStart = performance.now();
+    const url = new URL(ctx.request.url);
+    const service = ctx.route?.service ?? 'local';
+    console.log(`[Gateway] → ${ctx.request.method} ${url.pathname} → ${service}`);
+  },
+});
+
+registerHook({
+  name: 'request-logger-response',
+  phase: 'onResponse',
+  handler(ctx: GatewayContext) {
+    const start = ctx.meta._gwStart as number | undefined;
+    if (start == null) return;
+    const ms = (performance.now() - start).toFixed(1);
+    const status = ctx.response?.status ?? '?';
+    const url = new URL(ctx.request.url);
+    console.log(`[Gateway] ← ${status} ${url.pathname} (${ms}ms)`);
+  },
+});

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -1,15 +1,25 @@
 /**
- * Gateway Elysia plugin — wires config + matcher + proxy into onRequest.
+ * Gateway Elysia plugin — wires config + matcher + proxy + hooks into onRequest.
  *
  * If no config file and no VECTOR_URL → no-op (all routes local).
  * If matched service = "local" → fall through to Elysia handlers.
  * If matched service has a URL → proxy to upstream.
+ *
+ * Hook pipeline (optional):
+ *   onRequest  → runs before proxy (can short-circuit)
+ *   onResponse → runs after proxy response
+ *   onError    → runs when proxy or hook throws
  */
 import { Elysia } from 'elysia';
 import { loadGatewayConfig, type GatewayConfig } from './config.ts';
 import { compileRoutes, matchRoute, type CompiledRoute } from './matcher.ts';
 import { proxyToService } from './proxy.ts';
 import { HealthRegistry, type ServiceHealth } from './health.ts';
+import { loadHooks, runHooks, type GatewayContext } from './hooks.ts';
+
+// Register built-in hooks (side-effect imports)
+import './hooks/request-logger.ts';
+import './hooks/error-json.ts';
 
 export { loadGatewayConfig, compileRoutes, matchRoute, proxyToService, HealthRegistry };
 export type { GatewayConfig, CompiledRoute, ServiceHealth };
@@ -25,9 +35,14 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
   const compiled = compileRoutes(config.routes);
   const registry = new HealthRegistry();
   registry.start(config.services);
+  const hooks = loadHooks(config.hooks);
+
+  const hookCount =
+    hooks.onRequest.length + hooks.onResponse.length + hooks.onError.length;
 
   console.log(
-    `[Gateway] Loaded ${config.routes.length} route(s), ${Object.keys(config.services).length} service(s)`,
+    `[Gateway] Loaded ${config.routes.length} route(s), ${Object.keys(config.services).length} service(s)` +
+      (hookCount > 0 ? `, ${hookCount} hook(s)` : ''),
   );
 
   return new Elysia({ name: 'gateway' })
@@ -37,11 +52,12 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
       services: Object.fromEntries(
         Object.entries(config.services).map(([k, v]) => [k, { url: v.url, timeout: v.timeout }]),
       ),
+      hooks: hookCount,
     }))
     .get('/api/gateway/health', () => ({
       services: registry.getAllStatus(),
     }))
-    .onRequest(({ request }) => {
+    .onRequest(async ({ request }) => {
       const url = new URL(request.url);
       const match = matchRoute(url.pathname, compiled);
       if (!match) return; // no match — fall through to local Elysia routes
@@ -58,15 +74,54 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
             headers: { 'Content-Type': 'application/json' },
           });
         }
-        // 'fts5' fallback = let Elysia handle it locally
         if (fallback === 'fts5') return;
-        // 'error' or default
         return new Response(
           JSON.stringify({ error: 'Service unavailable', service: match.service }),
           { status: 503, headers: { 'Content-Type': 'application/json' } },
         );
       }
 
-      return proxyToService(request, service);
+      const ctx: GatewayContext = {
+        request,
+        route: match,
+        service,
+        meta: {},
+      };
+
+      // ── onRequest hooks ──
+      try {
+        const early = await runHooks(hooks.onRequest, ctx);
+        if (early) return early;
+      } catch (err) {
+        ctx.error = err instanceof Error ? err : new Error(String(err));
+        const errResp = await runHooks(hooks.onError, ctx);
+        if (errResp) return errResp;
+        throw err;
+      }
+
+      // ── Proxy ──
+      let response: Response;
+      try {
+        response = await proxyToService(request, service);
+      } catch (err) {
+        ctx.error = err instanceof Error ? err : new Error(String(err));
+        const errResp = await runHooks(hooks.onError, ctx);
+        if (errResp) return errResp;
+        throw err;
+      }
+
+      // ── onResponse hooks ──
+      ctx.response = response;
+      try {
+        const override = await runHooks(hooks.onResponse, ctx);
+        if (override) return override;
+      } catch (err) {
+        ctx.error = err instanceof Error ? err : new Error(String(err));
+        const errResp = await runHooks(hooks.onError, ctx);
+        if (errResp) return errResp;
+        throw err;
+      }
+
+      return response;
     });
 }

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -9,9 +9,10 @@ import { Elysia } from 'elysia';
 import { loadGatewayConfig, type GatewayConfig } from './config.ts';
 import { compileRoutes, matchRoute, type CompiledRoute } from './matcher.ts';
 import { proxyToService } from './proxy.ts';
+import { HealthRegistry, type ServiceHealth } from './health.ts';
 
-export { loadGatewayConfig, compileRoutes, matchRoute, proxyToService };
-export type { GatewayConfig, CompiledRoute };
+export { loadGatewayConfig, compileRoutes, matchRoute, proxyToService, HealthRegistry };
+export type { GatewayConfig, CompiledRoute, ServiceHealth };
 
 export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
   const config = loadGatewayConfig(dataDir, vectorUrl);
@@ -22,6 +23,9 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
   }
 
   const compiled = compileRoutes(config.routes);
+  const registry = new HealthRegistry();
+  registry.start(config.services);
+
   console.log(
     `[Gateway] Loaded ${config.routes.length} route(s), ${Object.keys(config.services).length} service(s)`,
   );
@@ -34,6 +38,9 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
         Object.entries(config.services).map(([k, v]) => [k, { url: v.url, timeout: v.timeout }]),
       ),
     }))
+    .get('/api/gateway/health', () => ({
+      services: registry.getAllStatus(),
+    }))
     .onRequest(({ request }) => {
       const url = new URL(request.url);
       const match = matchRoute(url.pathname, compiled);
@@ -41,6 +48,24 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
 
       const service = config.services[match.service];
       if (!service || match.service === 'local') return; // "local" = handle locally
+
+      // If health registry says service is down, return fallback immediately
+      if (!registry.isUp(match.service)) {
+        const fallback = match.fallback ?? 'error';
+        if (fallback === 'empty') {
+          return new Response(JSON.stringify({ results: [], source: 'gateway-fallback' }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        // 'fts5' fallback = let Elysia handle it locally
+        if (fallback === 'fts5') return;
+        // 'error' or default
+        return new Response(
+          JSON.stringify({ error: 'Service unavailable', service: match.service }),
+          { status: 503, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
 
       return proxyToService(request, service);
     });


### PR DESCRIPTION
## Summary
- Add `GatewayHook` interface with three phases: `onRequest`, `onResponse`, `onError`
- Hook pipeline runs around the proxy call — can short-circuit, transform responses, or catch errors
- Two built-in hooks: `request-logger` (logs method/path/service/duration) and `error-json` (ensures JSON error responses)
- Hooks are optional — no `hooks` key in config = no hooks, fully backward compatible
- Includes health registry commit as dependency (will be split to own PR if preferred)

Refs #1072

## Test plan
- [x] All 600 existing tests pass (0 regressions)
- [x] 8 new hook pipeline tests: load, run, short-circuit, phase mismatch, error handling, meta passing
- [ ] Manual: add `hooks` config to `oracle-gateway.json` and verify request-logger output in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)