### PR TITLE
feat(server): rerankCandidates() helper — graceful client for the reranker sidecar

### DIFF
--- a/src/server/__tests__/reranker.test.ts
+++ b/src/server/__tests__/reranker.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for the reranker helper — focus on the graceful-fallback paths.
+ * The success path is exercised end-to-end by the empirical bench against
+ * the real :8765 sidecar (see arra-mcp-installation-guide-oracle/ψ/lab).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { rerankCandidates } from '../reranker.ts';
+
+interface Doc { id: string; text: string }
+const docs: Doc[] = [
+  { id: '1', text: 'hello world' },
+  { id: '2', text: 'foo bar baz' },
+  { id: '3', text: 'quick brown fox' },
+];
+const getText = (d: Doc) => d.text;
+
+const ORIGINAL_ENV = process.env.ORACLE_RERANKER_URL;
+const ORIGINAL_FETCH = globalThis.fetch;
+
+describe('rerankCandidates', () => {
+  beforeEach(() => {
+    delete process.env.ORACLE_RERANKER_URL;
+    globalThis.fetch = ORIGINAL_FETCH;
+  });
+  afterEach(() => {
+    if (ORIGINAL_ENV) process.env.ORACLE_RERANKER_URL = ORIGINAL_ENV;
+    globalThis.fetch = ORIGINAL_FETCH;
+  });
+
+  it('falls back when no URL is configured', async () => {
+    const out = await rerankCandidates({ query: 'q', candidates: docs, getText });
+    expect(out.reranked).toBe(false);
+    expect(out.fallbackReason).toBe('disabled');
+    expect(out.results).toEqual(docs);
+  });
+
+  it('returns empty for empty candidate list (no network call)', async () => {
+    const out = await rerankCandidates({
+      query: 'q', candidates: [] as Doc[], getText, url: 'http://x',
+    });
+    expect(out.reranked).toBe(false);
+    expect(out.results).toEqual([]);
+  });
+
+  it('skips network for single candidate', async () => {
+    const out = await rerankCandidates({
+      query: 'q', candidates: [docs[0]], getText, url: 'http://x',
+    });
+    expect(out.reranked).toBe(false);
+    expect(out.results).toEqual([docs[0]]);
+  });
+
+  it('falls back on non-OK HTTP status', async () => {
+    globalThis.fetch = mock(async () => new Response('boom', { status: 500 })) as typeof fetch;
+    const out = await rerankCandidates({
+      query: 'q', candidates: docs, getText, url: 'http://fake',
+    });
+    expect(out.reranked).toBe(false);
+    expect(out.fallbackReason).toBe('http 500');
+    expect(out.results).toEqual(docs);
+  });
+
+  it('falls back when sidecar returns empty results', async () => {
+    globalThis.fetch = mock(async () =>
+      new Response(JSON.stringify({ results: [], model: 'x' }), { status: 200 })
+    ) as typeof fetch;
+    const out = await rerankCandidates({
+      query: 'q', candidates: docs, getText, url: 'http://fake',
+    });
+    expect(out.reranked).toBe(false);
+    expect(out.fallbackReason).toBe('empty response');
+  });
+
+  it('reorders candidates by sidecar score on success', async () => {
+    globalThis.fetch = mock(async () =>
+      new Response(
+        JSON.stringify({
+          results: [
+            { index: 2, score: 0.9, document: 'quick brown fox' },
+            { index: 0, score: 0.5, document: 'hello world' },
+            { index: 1, score: 0.1, document: 'foo bar baz' },
+          ],
+          model: 'BAAI/bge-reranker-v2-m3',
+        }),
+        { status: 200 },
+      )
+    ) as typeof fetch;
+    const out = await rerankCandidates({
+      query: 'q', candidates: docs, getText, url: 'http://fake',
+    });
+    expect(out.reranked).toBe(true);
+    expect(out.results.map((d) => d.id)).toEqual(['3', '1', '2']);
+  });
+
+  it('honors topK on success', async () => {
+    globalThis.fetch = mock(async () =>
+      new Response(
+        JSON.stringify({
+          results: [
+            { index: 2, score: 0.9, document: 'quick brown fox' },
+            { index: 0, score: 0.5, document: 'hello world' },
+          ],
+          model: 'x',
+        }),
+        { status: 200 },
+      )
+    ) as typeof fetch;
+    const out = await rerankCandidates({
+      query: 'q', candidates: docs, getText, url: 'http://fake', topK: 2,
+    });
+    expect(out.results).toHaveLength(2);
+    expect(out.results.map((d) => d.id)).toEqual(['3', '1']);
+  });
+
+  it('falls back on bogus indices (defensive)', async () => {
+    globalThis.fetch = mock(async () =>
+      new Response(
+        JSON.stringify({
+          results: [{ index: 999, score: 0.9, document: 'wat' }],
+          model: 'x',
+        }),
+        { status: 200 },
+      )
+    ) as typeof fetch;
+    const out = await rerankCandidates({
+      query: 'q', candidates: docs, getText, url: 'http://fake',
+    });
+    expect(out.reranked).toBe(false);
+    expect(out.fallbackReason).toBe('no valid indices');
+  });
+
+  it('reads URL from process.env.ORACLE_RERANKER_URL', async () => {
+    process.env.ORACLE_RERANKER_URL = 'http://from-env';
+    globalThis.fetch = mock(async (url: string) => {
+      expect(url).toBe('http://from-env/rerank');
+      return new Response(
+        JSON.stringify({
+          results: [{ index: 0, score: 1.0, document: docs[0].text }],
+          model: 'x',
+        }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+    const out = await rerankCandidates({ query: 'q', candidates: docs, getText });
+    expect(out.reranked).toBe(true);
+  });
+});

--- a/src/server/reranker.ts
+++ b/src/server/reranker.ts
@@ -1,0 +1,101 @@
+/**
+ * Reranker client — POSTs candidates to the bge-reranker-v2-m3 Python sidecar
+ * (services/reranker-py, default :8765) and returns reordered candidates.
+ *
+ * Optional dependency. If the sidecar is unreachable, slow, or returns an error,
+ * the original (input) ranking is returned unchanged. Search must NEVER block on
+ * the reranker.
+ *
+ * Enable by setting `ORACLE_RERANKER_URL=http://127.0.0.1:8765` (or wherever
+ * the sidecar lives). When unset, `rerankCandidates()` is a pass-through.
+ *
+ * Companion sidecar: arra-oracle-v3/services/reranker-py/.
+ */
+
+const DEFAULT_TIMEOUT_MS = 2000;
+
+export interface RerankInput<T> {
+  /** The user's search query. */
+  query: string;
+  /** Candidates produced by the dense (or hybrid) retrieval step. */
+  candidates: T[];
+  /** Function to extract the text to score from each candidate. */
+  getText: (c: T) => string;
+  /** If set, return only the top N after reranking. */
+  topK?: number;
+  /** Override the default URL (process.env.ORACLE_RERANKER_URL). */
+  url?: string;
+  /** Override the default 2000ms timeout. */
+  timeoutMs?: number;
+}
+
+export interface RerankResult<T> {
+  /** Candidates in their final order — reranked on success, original on fallback. */
+  results: T[];
+  /** True if the reranker scored these; false on any fallback path. */
+  reranked: boolean;
+  /** Reason for fallback, if any (for logs). */
+  fallbackReason?: string;
+}
+
+interface SidecarResponse {
+  results: Array<{ index: number; score: number; document: string }>;
+  model: string;
+}
+
+/**
+ * Score and reorder `candidates` by the cross-encoder running in the sidecar.
+ * Falls back to the input order on any error/timeout/disabled state.
+ */
+export async function rerankCandidates<T>(input: RerankInput<T>): Promise<RerankResult<T>> {
+  const { query, candidates, getText, topK, timeoutMs = DEFAULT_TIMEOUT_MS } = input;
+
+  const fallback = (reason: string): RerankResult<T> => ({
+    results: topK ? candidates.slice(0, topK) : candidates,
+    reranked: false,
+    fallbackReason: reason,
+  });
+
+  const url = input.url || process.env.ORACLE_RERANKER_URL;
+  if (!url) return fallback('disabled');
+  if (candidates.length === 0) return { results: [], reranked: false };
+  if (candidates.length === 1) {
+    return { results: topK ? candidates.slice(0, topK) : candidates, reranked: false };
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(`${url.replace(/\/$/, '')}/rerank`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query,
+        candidates: candidates.map(getText),
+        ...(topK !== undefined ? { top_k: topK } : {}),
+      }),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) return fallback(`http ${res.status}`);
+
+    const json = (await res.json()) as SidecarResponse;
+    if (!Array.isArray(json.results) || json.results.length === 0) {
+      return fallback('empty response');
+    }
+
+    const reordered = json.results
+      .filter((r) => r.index >= 0 && r.index < candidates.length)
+      .map((r) => candidates[r.index]);
+
+    if (reordered.length === 0) return fallback('no valid indices');
+
+    return { results: reordered, reranked: true };
+  } catch (err: unknown) {
+    const name = (err as { name?: string })?.name;
+    return fallback(name === 'AbortError' ? `timeout ${timeoutMs}ms` : 'error');
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
## Summary

Pure helper that POSTs candidates to the `bge-reranker-v2-m3` Python sidecar (companion: #1098) and returns a reordered list. Designed for graceful degradation — search must NEVER block on the reranker.

Wiring this into `search.ts` / `handlers.ts` is a separate follow-up PR. This is just the helper + tests.

## Behavior

| Condition | Result |
|-----------|--------|
| `ORACLE_RERANKER_URL` not set | pass-through, returns input order |
| Empty or single candidate | skips network call, returns input |
| Sidecar 5xx / network error | falls back to input order, logs reason |
| Timeout (default 2s, configurable) | falls back, logs reason |
| Empty or out-of-range indices in response | falls back, logs reason |
| Success | candidates reordered by cross-encoder score, optional `topK` |

The `RerankResult<T>` includes a `reranked: boolean` flag plus `fallbackReason` so callers can log/observe but never need to branch on it.

## Test plan

```
$ bun test src/server/__tests__/reranker.test.ts
 9 pass / 0 fail / 20 expect() calls
```

Tests cover:
- [x] disabled (no URL) → pass-through
- [x] empty candidates → no network
- [x] single candidate → no network
- [x] non-OK HTTP status → fallback with reason
- [x] empty results → fallback
- [x] success → correct reordering
- [x] `topK` honored on success
- [x] bogus indices → defensive fallback
- [x] reads URL from `ORACLE_RERANKER_URL`

The success path is also exercised empirically by the live sidecar (PR #1098) — 4000× score margin on a Thai blockchain query against shared-vocabulary distractors. Documented in `arra-mcp-installation-guide-oracle/ψ/memory/learnings/2026-05-04_reranker-sidecar-empirical.md`.

## Future work (not in this PR)

- Wire `rerankCandidates()` into hybrid search after `combineResults()` (separate PR; depends on #1098 landing)
- Add structured logging when fallback fires (so misconfiguration is visible in metrics)
- Consider passing reranker scores through to the response so the UI can show why something ranked where it did

## Context

Targeting `alpha` per the project's alpha-first release convention. The alpha branch is currently behind main on some tsc errors in `server-legacy.ts` and `handlers.ts` — none of which this PR touches. \`/release-alpha\` will catch up.

🤖 ตอบโดย arra-mcp-installation-guide จาก [Nat] → arra-mcp-installation-guide-oracle

🤖 Generated with [Claude Code](https://claude.com/claude-code)