### PR TITLE
feat(vector): VectorDocument.vector — precomputed embeddings skip the embedder

### DIFF
--- a/src/vector/__tests__/lancedb-precomputed-vectors.test.ts
+++ b/src/vector/__tests__/lancedb-precomputed-vectors.test.ts
@@ -1,0 +1,119 @@
+/**
+ * LanceDB precomputed-vectors path — unit tests for the addDocuments
+ * upgrade that lets callers skip the embedder when they already have
+ * a vector (e.g. the indexer worker loop after embed → upsert).
+ *
+ * Uses real LanceDB on a tmp dir + a recording mock embedder.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+import { LanceDBAdapter } from '../adapters/lancedb.ts';
+import type { EmbeddingProvider, EmbedType, VectorDocument } from '../types.ts';
+
+class RecordingEmbedder implements EmbeddingProvider {
+  readonly name = 'recording';
+  readonly dimensions = 8;
+  embedCalls: Array<{ texts: string[]; type?: EmbedType }> = [];
+
+  async embed(texts: string[], type?: EmbedType): Promise<number[][]> {
+    this.embedCalls.push({ texts, type });
+    // Deterministic 8-d vectors so tests don't depend on a model.
+    return texts.map((_, i) => Array.from({ length: 8 }, (_, j) => (i + 1) * 0.1 + j * 0.01));
+  }
+}
+
+const FRESH_VECTOR = Array.from({ length: 8 }, (_, i) => i * 0.5);
+
+const TMP_BASE = path.join(os.tmpdir(), `oracle-precomputed-${Date.now()}`);
+
+describe('LanceDB addDocuments — precomputed vectors', () => {
+  let adapter: LanceDBAdapter;
+  let embedder: RecordingEmbedder;
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    tmpDir = path.join(TMP_BASE, 'col1');
+    fs.mkdirSync(tmpDir, { recursive: true });
+    embedder = new RecordingEmbedder();
+    adapter = new LanceDBAdapter('precomputed_test', tmpDir, embedder);
+    await adapter.connect();
+    await adapter.ensureCollection();
+  });
+
+  afterAll(async () => {
+    try { await adapter.deleteCollection(); } catch {}
+    try { await adapter.close(); } catch {}
+    try { fs.rmSync(TMP_BASE, { recursive: true, force: true }); } catch {}
+  });
+
+  it('skips the embedder when ALL docs have precomputed vectors', async () => {
+    embedder.embedCalls = [];
+
+    const docs: VectorDocument[] = [
+      { id: 'doc-1', document: 'first', metadata: { type: 'test' }, vector: FRESH_VECTOR },
+      { id: 'doc-2', document: 'second', metadata: { type: 'test' }, vector: FRESH_VECTOR },
+    ];
+
+    await adapter.addDocuments(docs);
+
+    expect(embedder.embedCalls).toHaveLength(0);
+    const stats = await adapter.getStats();
+    expect(stats.count).toBeGreaterThanOrEqual(2);
+  });
+
+  it('embeds normally when NO docs have precomputed vectors (backwards compat)', async () => {
+    embedder.embedCalls = [];
+
+    const docs: VectorDocument[] = [
+      { id: 'doc-3', document: 'third', metadata: { type: 'test' } },
+      { id: 'doc-4', document: 'fourth', metadata: { type: 'test' } },
+    ];
+
+    await adapter.addDocuments(docs);
+
+    expect(embedder.embedCalls).toHaveLength(1);
+    expect(embedder.embedCalls[0].texts).toEqual(['third', 'fourth']);
+  });
+
+  it('embeds only the docs missing vectors in a mixed batch', async () => {
+    embedder.embedCalls = [];
+
+    const docs: VectorDocument[] = [
+      { id: 'doc-5', document: 'fifth', metadata: { type: 'test' }, vector: FRESH_VECTOR },
+      { id: 'doc-6', document: 'sixth', metadata: { type: 'test' } },                 // needs embed
+      { id: 'doc-7', document: 'seventh', metadata: { type: 'test' }, vector: FRESH_VECTOR },
+      { id: 'doc-8', document: 'eighth', metadata: { type: 'test' } },                // needs embed
+    ];
+
+    await adapter.addDocuments(docs);
+
+    expect(embedder.embedCalls).toHaveLength(1);
+    expect(embedder.embedCalls[0].texts).toEqual(['sixth', 'eighth']);
+  });
+
+  it('handles an empty batch without calling the embedder', async () => {
+    embedder.embedCalls = [];
+    await adapter.addDocuments([]);
+    expect(embedder.embedCalls).toHaveLength(0);
+  });
+
+  it('preserves the precomputed vector through round-trip query', async () => {
+    embedder.embedCalls = [];
+
+    // Use a vector that's distinct + close to the query for retrieval verification.
+    const QUERY_LIKE_VECTOR: number[] = [0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9];
+    const docs: VectorDocument[] = [
+      { id: 'doc-rt', document: 'roundtrip', metadata: { type: 'test' }, vector: QUERY_LIKE_VECTOR },
+    ];
+
+    await adapter.addDocuments(docs);
+    expect(embedder.embedCalls).toHaveLength(0);
+
+    // Query with a text — embed for the query is unavoidable, but the doc's vector should be reachable.
+    const res = await adapter.query('roundtrip', 5);
+    expect(res.ids).toContain('doc-rt');
+  });
+});

--- a/src/vector/adapters/lancedb.ts
+++ b/src/vector/adapters/lancedb.ts
@@ -72,18 +72,34 @@ export class LanceDBAdapter implements VectorStoreAdapter {
     if (docs.length === 0) return;
     if (!this.table) await this.ensureCollection();
 
-    const texts = docs.map(d => d.document);
-    const embeddings = await this.embedder.embed(texts);
+    // Embed only the docs that lack a precomputed vector. Callers that
+    // already have a vector (e.g. the indexer worker loop, where embed
+    // happens before the storage write) skip the second Ollama round-trip.
+    const needEmbed: number[] = [];
+    for (let i = 0; i < docs.length; i++) {
+      if (!docs[i].vector) needEmbed.push(i);
+    }
+    let fresh: number[][] = [];
+    if (needEmbed.length > 0) {
+      const texts = needEmbed.map(i => docs[i].document);
+      fresh = await this.embedder.embed(texts);
+    }
+    let freshIdx = 0;
 
-    const rows = docs.map((doc, i) => ({
+    const rows = docs.map((doc) => ({
       id: doc.id,
       text: doc.document,
       metadata: JSON.stringify(doc.metadata),
-      vector: embeddings[i],
+      vector: doc.vector ?? fresh[freshIdx++],
     }));
 
     await this.table.add(rows);
-    console.log(`[LanceDB] Added ${docs.length} documents`);
+    const reused = docs.length - needEmbed.length;
+    if (reused > 0) {
+      console.log(`[LanceDB] Added ${docs.length} documents (${reused} with precomputed vectors)`);
+    } else {
+      console.log(`[LanceDB] Added ${docs.length} documents`);
+    }
   }
 
   async query(text: string, limit: number = 10, where?: Record<string, any>): Promise<VectorQueryResult> {

--- a/src/vector/types.ts
+++ b/src/vector/types.ts
@@ -9,6 +9,17 @@ export interface VectorDocument {
   id: string;
   document: string;
   metadata: Record<string, string | number>;
+  /**
+   * Optional precomputed embedding. When present, adapters MUST use this
+   * vector and skip the embedder. Lets a caller (e.g. the indexer worker
+   * loop) embed once and route the vector to the storage tier without a
+   * second Ollama round-trip.
+   *
+   * Vector dimension MUST match the collection's column dim or the storage
+   * write will fail. Adapters that don't yet honor this field fall back to
+   * embedding (the default behavior is preserved — the field is optional).
+   */
+  vector?: number[];
 }
 
 export interface VectorQueryResult {


### PR DESCRIPTION
## Summary

Backwards-compatible interface extension. Adds an optional `vector?: number[]` field to `VectorDocument`. Adapters that honor it (LanceDB in this PR) use the supplied vector and skip the embedder; adapters that don't yet honor it fall back to embedding.

Unblocks the **known limitation surfaced in PR #1104** (M3 daemon).

## Motivation

The indexer M3 daemon already embeds via Ollama in the worker loop (so we can apply per-model instruction prefixes, retry on Ollama timeout, attribute embed cost to a specific job). Without this PR, the storage write re-embeds the same text — a second Ollama round-trip per doc, **~50–150ms wasted** per indexed document.

```
Before:                                 After:
  worker:                                worker:
    vector = await embed(text)              vector = await embed(text)
    await store.addDocuments([{             await store.addDocuments([{
      id, document: text, metadata           id, document: text, metadata,
    }])                                       vector  ← passed through
                                            }])
    # store re-embeds the same text         # store skips embed
```

## Scope

- `VectorDocument.vector?: number[]` — new optional field
- LanceDB adapter — partitions into `needs-embed` / `has-vector`, embeds only the former
- Other adapters (chroma-mcp, sqlite-vec, qdrant, cloudflare-vectorize) unchanged — they still embed everything. Interface change is additive; no breakage. They can adopt the field in follow-up PRs as needed.

## Test plan

`bun test src/vector/__tests__/lancedb-precomputed-vectors.test.ts` → **5 pass / 0 fail / 9 expects**

- [x] all docs with precomputed vectors → embedder NOT called
- [x] no precomputed vectors → embedder called once with all texts (backwards compat)
- [x] mixed batch → embedder called only with the docs missing vectors
- [x] empty batch → embedder NOT called (early return)
- [x] round-trip: precomputed vector survives storage and is retrievable via query

Hermetic — uses real LanceDB on a tmp directory + a recording mock embedder. Vector dim 8 (deterministic, no Ollama dependency).

## Backwards compatibility

The field is optional. Every existing call site that constructs a `VectorDocument` continues to work — the storage layer embeds as before. Only callers that opt in (pass `vector`) benefit from the skip.

## What this PR does NOT do

- Update other adapters (chroma-mcp, qdrant, sqlite-vec, cloudflare-vectorize) — they ignore the field and embed as before. Each can adopt the optimization in a follow-up if they have a parallel "write precomputed vector" path in their underlying API.
- Update M3's `daemon.ts` to use the new field — that's a small commit on PR #1104's branch (or a tiny follow-up after both land).
- Probe-first dim auto-detection (TODO from #1097).

## Companion PRs

- **#1104** (M3 daemon) — surfaced this limitation in its body. After this PR lands, M3's `upsertVector` can pass the worker's precomputed vector through cleanly.

🤖 ตอบโดย arra-mcp-installation-guide จาก [Nat] → arra-mcp-installation-guide-oracle

🤖 Generated with [Claude Code](https://claude.com/claude-code)