### PR TITLE
fix(db): bootstrap oracle_fts FTS5 table via migration (#1111)

### DIFF
--- a/src/db/__tests__/fresh-install.test.ts
+++ b/src/db/__tests__/fresh-install.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Fresh-install regression test for issue #1111.
+ *
+ * Verifies that running drizzle's migrate() against an empty SQLite file
+ * creates the FTS5 `oracle_fts` virtual table. Before migration 0017_fts5_bootstrap,
+ * fresh installs that ran `bun db:migrate` (or any other migration runner that
+ * does not boot the app) ended up without the FTS table — the indexer daemon
+ * would then crash on getDocText() returning null.
+ */
+import { describe, test, expect } from "bun:test";
+import { Database } from "bun:sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import * as schema from "../schema";
+
+describe("fresh install (#1111)", () => {
+	test("drizzle migrate() creates oracle_fts on empty DB", () => {
+		const dir = mkdtempSync(join(tmpdir(), "oracle-fresh-"));
+		const dbPath = join(dir, "test.db");
+		const sqlite = new Database(dbPath);
+		const db = drizzle(sqlite, { schema });
+
+		const migrationsFolder = join(import.meta.dir, "../migrations");
+		migrate(db, { migrationsFolder });
+
+		const row = sqlite
+			.prepare(
+				"SELECT name FROM sqlite_master WHERE type='table' AND name='oracle_fts'",
+			)
+			.get() as { name: string } | undefined;
+
+		expect(row?.name).toBe("oracle_fts");
+
+		// Verify the table is actually queryable (not just registered)
+		expect(() => {
+			sqlite.exec("INSERT INTO oracle_fts(id, content, concepts) VALUES ('t1', 'hello world', 'greeting')");
+		}).not.toThrow();
+
+		const cnt = sqlite
+			.prepare("SELECT COUNT(*) AS n FROM oracle_fts")
+			.get() as { n: number };
+		expect(cnt.n).toBe(1);
+
+		sqlite.close();
+		rmSync(dir, { recursive: true });
+	});
+
+	test("migration is idempotent — re-running migrate() does not fail", () => {
+		const dir = mkdtempSync(join(tmpdir(), "oracle-rerun-"));
+		const dbPath = join(dir, "test.db");
+		const sqlite = new Database(dbPath);
+		const db = drizzle(sqlite, { schema });
+		const migrationsFolder = join(import.meta.dir, "../migrations");
+
+		migrate(db, { migrationsFolder });
+		// Second run should be a no-op (drizzle skips applied migrations)
+		expect(() => migrate(db, { migrationsFolder })).not.toThrow();
+
+		sqlite.close();
+		rmSync(dir, { recursive: true });
+	});
+});

--- a/src/db/migrations/0017_fts5_bootstrap.sql
+++ b/src/db/migrations/0017_fts5_bootstrap.sql
@@ -1,0 +1,6 @@
+CREATE VIRTUAL TABLE IF NOT EXISTS oracle_fts USING fts5(
+	id UNINDEXED,
+	content,
+	concepts,
+	tokenize='porter unicode61'
+);

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1746460800000,
       "tag": "0016_indexing_jobs",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1746547200000,
+      "tag": "0017_fts5_bootstrap",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- New migration `0017_fts5_bootstrap.sql` creates the `oracle_fts` FTS5 virtual table on fresh installs (`bun db:migrate` and any other migration runner).
- Schema mirrors `initFts5()` exactly — `id UNINDEXED, content, concepts, tokenize='porter unicode61'`.
- `IF NOT EXISTS` keeps it idempotent so existing installs are unaffected.
- Adds regression test `src/db/__tests__/fresh-install.test.ts` covering creation + idempotent re-run.

## Why

Drizzle's `tablesFilter` excludes FTS5 virtual tables. Before this migration, only the app boot path (which calls `initFts5()` via `initializeDatabase()`) created the `oracle_fts` table. Anything that opens the DB directly — notably `src/indexer/daemon.ts:27` (`new Database(DB_PATH)`) — assumed the table already existed. On a clean DB, the daemon would crash with `getDocText()` returning null because the FTS row could never be inserted.

`initFts5()` in `src/db/index.ts` is left in place — still useful as a belt-and-suspenders for code paths that bypass migrations (e.g. existing installs upgrading without running `db:migrate`).

## Test plan

- [x] `bun test src/db/__tests__/fresh-install.test.ts` — 2 pass (creation + idempotent rerun)
- [x] `bun test src/integration/database.test.ts` — 14 pass (no regression)
- [x] Manual e2e:
  ```bash
  rm -rf /tmp/fresh-1111 && mkdir /tmp/fresh-1111
  ORACLE_DB_PATH=/tmp/fresh-1111/test.db ORACLE_DATA_DIR=/tmp/fresh-1111 bun db:migrate
  sqlite3 /tmp/fresh-1111/test.db ".schema oracle_fts"
  # → CREATE VIRTUAL TABLE oracle_fts USING fts5(id UNINDEXED, content, concepts, tokenize='porter unicode61')
  ```

Closes #1111

🤖 Generated with [Claude Code](https://claude.com/claude-code)