### PR TITLE
fix(learn): suffix slug on collision to avoid 500 on /api/learn

### DIFF
--- a/src/server/__tests__/learn-slug-collision.test.ts
+++ b/src/server/__tests__/learn-slug-collision.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Regression test — POST /api/learn slug collision must NOT 500.
+ *
+ * Bug: when two patterns share the same first-50-char prefix on the same
+ * day, the slug+filename collide. The pre-fix handler bubbled the
+ * "File already exists" throw from persistLearningDoc up to the Elysia
+ * try/catch and returned HTTP 500.
+ *
+ * Fix: handleLearn appends `-2`, `-3`, … to the slug until the target
+ * filename is unique. Second write succeeds with the suffixed slug.
+ *
+ * Hermetic: ORACLE_DATA_DIR + ORACLE_REPO_ROOT point at tmp dirs, set
+ * BEFORE the dynamic import so config.ts module state captures them.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+
+const TMP_REPO_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-learn-collision-repo-'));
+const TMP_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-learn-collision-data-'));
+
+const ORIGINAL_REPO_ROOT = process.env.ORACLE_REPO_ROOT;
+const ORIGINAL_DATA_DIR = process.env.ORACLE_DATA_DIR;
+
+process.env.ORACLE_REPO_ROOT = TMP_REPO_ROOT;
+process.env.ORACLE_DATA_DIR = TMP_DATA_DIR;
+
+// Dynamic import after env is set (REPO_ROOT and DB_PATH are module-frozen).
+const { handleLearn } = await import('../handlers.ts');
+
+describe('handleLearn — slug collision', () => {
+  // Slug is built from pattern.substring(0, 50). Use a 50-char prefix so any
+  // tail variation does NOT affect the slug — that's exactly the collision
+  // case reproduced in prod (different hot-write bodies, identical first
+  // line, same generated slug).
+  // Length check: 50 chars exactly.
+  const PATTERN_PREFIX = 'collision test pattern shared first line very long';
+  const EXPECTED_SLUG = 'collision-test-pattern-shared-first-line-very-long';
+
+  it('first write succeeds with the bare slug', () => {
+    const res = handleLearn(`${PATTERN_PREFIX}\nbody one`);
+    expect(res.success).toBe(true);
+    expect(res.file).toMatch(new RegExp(`ψ/memory/learnings/\\d{4}-\\d{2}-\\d{2}_${EXPECTED_SLUG}\\.md$`));
+    expect(fs.existsSync(path.join(TMP_REPO_ROOT, res.file))).toBe(true);
+  });
+
+  it('second write with the SAME slug-producing prefix gets a -2 suffix (no 500)', () => {
+    const res = handleLearn(`${PATTERN_PREFIX}\nbody two`);
+    expect(res.success).toBe(true);
+    expect(res.file).toMatch(new RegExp(`_${EXPECTED_SLUG}-2\\.md$`));
+    expect(res.id).toMatch(/-2$/);
+    expect(fs.existsSync(path.join(TMP_REPO_ROOT, res.file))).toBe(true);
+  });
+
+  it('third write bumps to -3', () => {
+    const res = handleLearn(`${PATTERN_PREFIX}\nbody three`);
+    expect(res.success).toBe(true);
+    expect(res.file).toMatch(new RegExp(`_${EXPECTED_SLUG}-3\\.md$`));
+    expect(res.id).toMatch(/-3$/);
+  });
+
+  it('unrelated pattern still uses bare slug', () => {
+    const res = handleLearn('completely different pattern with own slug');
+    expect(res.success).toBe(true);
+    expect(res.file).toMatch(/_completely-different-pattern-with-own-slug\.md$/);
+  });
+});
+
+afterAll(() => {
+  try { fs.rmSync(TMP_REPO_ROOT, { recursive: true, force: true }); } catch {}
+  try { fs.rmSync(TMP_DATA_DIR, { recursive: true, force: true }); } catch {}
+  if (ORIGINAL_REPO_ROOT) process.env.ORACLE_REPO_ROOT = ORIGINAL_REPO_ROOT;
+  else delete process.env.ORACLE_REPO_ROOT;
+  if (ORIGINAL_DATA_DIR) process.env.ORACLE_DATA_DIR = ORIGINAL_DATA_DIR;
+  else delete process.env.ORACLE_DATA_DIR;
+});

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -765,11 +765,23 @@ export function handleLearn(
     .replace(/-+/g, '-')
     .replace(/^-|-$/g, '');
 
+  // On slug collision (same date + same first-50-char prefix), append -2, -3, …
+  // until unique. Prevents 500s when two writes share a slug within one day
+  // (e.g. repeated hot-write snapshots from the same agent).
+  const subdir = 'ψ/memory/learnings';
+  const learningsDir = path.join(REPO_ROOT, subdir);
+  let uniqueSlug = slug;
+  let suffix = 2;
+  while (fs.existsSync(path.join(learningsDir, `${dateStr}_${uniqueSlug}.md`))) {
+    uniqueSlug = `${slug}-${suffix}`;
+    suffix++;
+  }
+
   const { file, id } = persistLearningDoc({
     pattern,
-    subdir: 'ψ/memory/learnings',
-    filename: `${dateStr}_${slug}.md`,
-    id: `learning_${dateStr}_${slug}`,
+    subdir,
+    filename: `${dateStr}_${uniqueSlug}.md`,
+    id: `learning_${dateStr}_${uniqueSlug}`,
     concepts,
     source,
     origin,


### PR DESCRIPTION
## Summary

- `POST /api/learn` returns HTTP 500 when two patterns share the same first-50-char prefix on the same day (slug collision → `persistLearningDoc` throws `File already exists` → Elysia catch returns 500).
- Fix: `handleLearn` probes the target directory and appends `-2`, `-3`, … to the slug until the filename is unique. `persistLearningDoc` keeps its existence check as a defensive backstop.
- Scope held tight per spec: slug algorithm unchanged, response schema unchanged, only `/api/learn` touched, `handleSessionSummary` unaffected.

## Reproduction (prod, 2026-05-18)

`brain` repeatedly wrote `[HOT] brain` snapshots. Two back-to-back writes shared the first line `active: standby — waiting maintainer review on 7 PRs`, producing slug `hot-brain-active-standby-waiting-maintainer-r`. Second write 500'd. Workaround: prepend a unique timestamp to the body's first line so the slug differs.

## Regression test

`src/server/__tests__/learn-slug-collision.test.ts` — hermetic (tmp `ORACLE_DATA_DIR` + `ORACLE_REPO_ROOT`, dynamic import).

1. First write → bare slug.
2. Second write same prefix → `-2` suffix.
3. Third write same prefix → `-3` suffix.
4. Unrelated pattern → bare slug (no false suffix).

Verified the test **fails on `main`** (`File already exists` throw) and **passes with this patch**.

## Test plan

- [ ] `bun test src/server/__tests__/learn-slug-collision.test.ts` → 4 pass
- [ ] `bun test src/server/` → 24 pass (no regressions in adjacent tests)
- [ ] Manual: two `do-rag learn` calls with identical first-50-char prefix → both succeed; second file ends with `-2.md`

## Out of scope (separate follow-up)

- `src/tools/learn.ts` MCP handler carries the same bug but uses a different write path. Not touched here per spec "Don't touch other routes."

🤖 Generated with [Claude Code](https://claude.com/claude-code)