### PR TITLE
feat(config): per-tool enable/disable on top of group config

### DIFF
--- a/src/config/__tests__/tool-groups.test.ts
+++ b/src/config/__tests__/tool-groups.test.ts
@@ -40,6 +40,58 @@ describe('tool-groups', () => {
     expect(disabled.has('muninn_learn')).toBe(false);
   });
 
+  it('disabled_tools adds per-tool blocks on top of group config', () => {
+    const config: ToolGroupConfig = {
+      search: true, knowledge: true, session: true,
+      forum: true, trace: true,
+      disabled_tools: ['muninn_supersede', 'muninn_thread_update'],
+    };
+    const disabled = getDisabledTools(config);
+    expect(disabled.has('muninn_supersede')).toBe(true);
+    expect(disabled.has('muninn_thread_update')).toBe(true);
+    // Sibling tools in the same group stay enabled
+    expect(disabled.has('muninn_learn')).toBe(false);
+    expect(disabled.has('muninn_thread')).toBe(false);
+  });
+
+  it('enabled_tools whitelist overrides group-disabled', () => {
+    const config: ToolGroupConfig = {
+      search: true, knowledge: true, session: true,
+      forum: false, trace: true,
+      enabled_tools: ['muninn_thread_read'],
+    };
+    const disabled = getDisabledTools(config);
+    // Whole forum group disabled, except the whitelisted one
+    expect(disabled.has('muninn_thread')).toBe(true);
+    expect(disabled.has('muninn_thread_update')).toBe(true);
+    expect(disabled.has('muninn_thread_read')).toBe(false);
+  });
+
+  it('enabled_tools whitelist overrides a per-tool block (whitelist wins last)', () => {
+    const config: ToolGroupConfig = {
+      search: true, knowledge: true, session: true,
+      forum: true, trace: true,
+      disabled_tools: ['muninn_supersede'],
+      enabled_tools: ['muninn_supersede'],
+    };
+    expect(getDisabledTools(config).has('muninn_supersede')).toBe(false);
+  });
+
+  it('ignores unknown tool names in disabled_tools and enabled_tools', () => {
+    const config: ToolGroupConfig = {
+      search: true, knowledge: true, session: true,
+      forum: true, trace: true,
+      disabled_tools: ['typo_search', 'muninn_search'],
+      enabled_tools: ['also_typo'],
+    };
+    const disabled = getDisabledTools(config);
+    // Real one applied
+    expect(disabled.has('muninn_search')).toBe(true);
+    // Typos didn't leak in
+    expect(disabled.has('typo_search')).toBe(false);
+    expect(disabled.has('also_typo')).toBe(false);
+  });
+
   it('defaults to all groups enabled', () => {
     const config = loadToolGroupConfig('/nonexistent/path');
     expect(config.search).toBe(true);

--- a/src/config/tool-groups.ts
+++ b/src/config/tool-groups.ts
@@ -22,7 +22,17 @@ export const TOOL_GROUPS = {
 
 export type ToolGroupName = keyof typeof TOOL_GROUPS;
 
-export type ToolGroupConfig = Record<ToolGroupName, boolean>;
+/**
+ * Resolved tool-group config used at request time.
+ * - The named group booleans toggle whole groups.
+ * - `disabled_tools` adds per-tool blocks on top of the group-disabled set.
+ * - `enabled_tools` is a whitelist override — brings back a single tool from
+ *   a disabled group OR cancels a per-tool block. Whitelist wins last.
+ */
+export type ToolGroupConfig = Record<ToolGroupName, boolean> & {
+  disabled_tools?: string[];
+  enabled_tools?: string[];
+};
 
 const DEFAULT_CONFIG: ToolGroupConfig = {
   search: true,
@@ -31,6 +41,11 @@ const DEFAULT_CONFIG: ToolGroupConfig = {
   forum: true,
   trace: true,
 };
+
+/** All registered tool names — for validating disabled_tools / enabled_tools entries. */
+const ALL_TOOL_NAMES: ReadonlySet<string> = new Set(
+  Object.values(TOOL_GROUPS).flat() as string[],
+);
 
 function readJsonSafe(filePath: string): Record<string, any> | null {
   try {
@@ -41,28 +56,49 @@ function readJsonSafe(filePath: string): Record<string, any> | null {
   }
 }
 
+function mergeRaw(raw: Record<string, any>): ToolGroupConfig {
+  const merged: ToolGroupConfig = { ...DEFAULT_CONFIG, ...raw.tools };
+  if (Array.isArray(raw.disabled_tools)) {
+    merged.disabled_tools = raw.disabled_tools.filter((t: unknown) => typeof t === 'string');
+  }
+  if (Array.isArray(raw.enabled_tools)) {
+    merged.enabled_tools = raw.enabled_tools.filter((t: unknown) => typeof t === 'string');
+  }
+  return merged;
+}
+
 export function loadToolGroupConfig(repoRoot?: string): ToolGroupConfig {
   const root = repoRoot || process.env.ORACLE_REPO_ROOT || process.cwd();
 
   // Priority 1: repo-local arra.config.json
   const localConfig = readJsonSafe(path.join(root, 'arra.config.json'));
-  if (localConfig?.tools) {
+  if (localConfig && (localConfig.tools || localConfig.disabled_tools || localConfig.enabled_tools)) {
     console.error('[ToolGroups] Using arra.config.json from repo root');
-    return { ...DEFAULT_CONFIG, ...localConfig.tools };
+    return mergeRaw(localConfig);
   }
 
   // Priority 2: global config.json in data dir
   const globalConfig = readJsonSafe(path.join(ORACLE_DATA_DIR, 'config.json'));
-  if (globalConfig?.tools) {
+  if (globalConfig && (globalConfig.tools || globalConfig.disabled_tools || globalConfig.enabled_tools)) {
     console.error(`[ToolGroups] Using ${ORACLE_DATA_DIR}/config.json`);
-    return { ...DEFAULT_CONFIG, ...globalConfig.tools };
+    return mergeRaw(globalConfig);
   }
 
   // Priority 3: all enabled
   return { ...DEFAULT_CONFIG };
 }
 
-/** Returns a Set of tool names that should be disabled based on config */
+/**
+ * Returns a Set of tool names that should be disabled based on config.
+ *
+ * Resolution order:
+ *   1. group-disabled (any tool whose group has `<group>: false`)
+ *   2. ∪ per-tool blocklist (`disabled_tools`)
+ *   3. \ per-tool whitelist (`enabled_tools`) — wins last
+ *
+ * Unknown tool names in `disabled_tools` / `enabled_tools` are ignored with
+ * a warning — typos shouldn't crash the server or silently disable real tools.
+ */
 export function getDisabledTools(config: ToolGroupConfig): Set<string> {
   const disabled = new Set<string>();
   for (const [group, tools] of Object.entries(TOOL_GROUPS)) {
@@ -71,6 +107,20 @@ export function getDisabledTools(config: ToolGroupConfig): Set<string> {
         disabled.add(tool);
       }
     }
+  }
+  for (const t of config.disabled_tools ?? []) {
+    if (!ALL_TOOL_NAMES.has(t)) {
+      console.error(`[ToolGroups] disabled_tools: unknown tool "${t}" — ignored`);
+      continue;
+    }
+    disabled.add(t);
+  }
+  for (const t of config.enabled_tools ?? []) {
+    if (!ALL_TOOL_NAMES.has(t)) {
+      console.error(`[ToolGroups] enabled_tools: unknown tool "${t}" — ignored`);
+      continue;
+    }
+    disabled.delete(t);
   }
   return disabled;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,9 +98,17 @@ class OracleMCPServer {
 
     const groupConfig = options.toolGroups ?? loadToolGroupConfig(this.repoRoot);
     this.disabledTools = getDisabledTools(groupConfig);
-    const disabledGroups = Object.entries(groupConfig).filter(([, v]) => !v).map(([k]) => k);
+    const disabledGroups = Object.entries(groupConfig)
+      .filter(([, v]) => typeof v === 'boolean' && !v)
+      .map(([k]) => k);
     if (disabledGroups.length > 0) {
-      console.error(`[ToolGroups] Disabled: ${disabledGroups.join(', ')}`);
+      console.error(`[ToolGroups] Disabled groups: ${disabledGroups.join(', ')}`);
+    }
+    if (groupConfig.disabled_tools?.length) {
+      console.error(`[ToolGroups] disabled_tools: ${groupConfig.disabled_tools.join(', ')}`);
+    }
+    if (groupConfig.enabled_tools?.length) {
+      console.error(`[ToolGroups] enabled_tools (whitelist): ${groupConfig.enabled_tools.join(', ')}`);
     }
 
     // Hot reload: rebuild the disabled set in place when config changes.
@@ -112,11 +120,17 @@ class OracleMCPServer {
         const nextDisabled = getDisabledTools(next);
         this.disabledTools.clear();
         for (const t of nextDisabled) this.disabledTools.add(t);
-        const disabled = Object.entries(next).filter(([, v]) => !v).map(([k]) => k);
+        const disabledGroups = Object.entries(next)
+          .filter(([, v]) => typeof v === 'boolean' && !v)
+          .map(([k]) => k);
+        const parts: string[] = [];
+        if (disabledGroups.length) parts.push(`groups: ${disabledGroups.join(', ')}`);
+        if (next.disabled_tools?.length) parts.push(`disabled_tools: ${next.disabled_tools.join(', ')}`);
+        if (next.enabled_tools?.length) parts.push(`enabled_tools: ${next.enabled_tools.join(', ')}`);
         console.error(
-          disabled.length
-            ? `[ToolGroups] Reloaded — disabled: ${disabled.join(', ')}`
-            : '[ToolGroups] Reloaded — all groups enabled',
+          parts.length
+            ? `[ToolGroups] Reloaded — ${parts.join(' | ')}`
+            : '[ToolGroups] Reloaded — all tools enabled',
         );
       }, this.repoRoot);
     }


### PR DESCRIPTION
## Summary

Completes the dynamic plugin/plugout story alongside #1174 (hot-reload) and the original group-level toggles.

### Schema additions to \`arra.config.json\`

\`\`\`json
{
  "tools": { "search": true, "forum": false },
  "disabled_tools": ["muninn_reflect", "muninn_supersede"],
  "enabled_tools": ["muninn_thread_read"]
}
\`\`\`

### Resolution order

\`\`\`
disabled = group_disabled ∪ disabled_tools
disabled = disabled \\ enabled_tools   // whitelist wins last
\`\`\`

So you can disable a whole group then bring back a single tool, or override a per-tool block.

### Safety

Unknown tool names in either list are logged + ignored — a typo can't crash the server or silently disable real tools.

### Hot reload

No additional wiring needed — \`watchToolGroupConfig\` already detects file changes and \`getDisabledTools\` consumes the new fields directly.

## Tests

4 new tests added (13 total in tool-groups.test.ts):
- \`disabled_tools adds per-tool blocks on top of group config\`
- \`enabled_tools whitelist overrides group-disabled\`
- \`enabled_tools whitelist overrides a per-tool block (whitelist wins last)\`
- \`ignores unknown tool names in disabled_tools and enabled_tools\`

**Total: 714/714 pass** (was 710), 0 fail with \`--isolate\`.

## Test plan
- [x] \`bun test --isolate src/config/__tests__/tool-groups.test.ts\` — 13/13
- [x] Full suite — 714 pass, 22 skip, 0 fail
- [ ] Manual: edit \`arra.config.json\` with \`disabled_tools\` mid-session, observe reload log + missing tool from MCP list

🤖 Generated with [Claude Code](https://claude.com/claude-code)