### PR TITLE
feat(gateway): hot-reload oracle-gateway.json (gateway PR 4 of 5)

### DIFF
--- a/src/gateway/__tests__/config-watch.test.ts
+++ b/src/gateway/__tests__/config-watch.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { watchGatewayConfig, type GatewayConfig } from '../config.ts';
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe('watchGatewayConfig', () => {
+  it('fires onChange when the config file is created', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-gateway-watch-'));
+    const calls: Array<GatewayConfig | null> = [];
+    const stop = watchGatewayConfig(dir, (next) => calls.push(next));
+    try {
+      const cfg: GatewayConfig = {
+        services: { vector: { url: 'http://localhost:9999', timeout: 5000 } },
+        routes: [{ match: '/api/vector/**', service: 'vector', fallback: 'fts5' }],
+      };
+      fs.writeFileSync(path.join(dir, 'oracle-gateway.json'), JSON.stringify(cfg));
+      await wait(450);
+      expect(calls.length).toBeGreaterThanOrEqual(1);
+      const last = calls[calls.length - 1];
+      expect(last).not.toBeNull();
+      expect(last!.services.vector.url).toBe('http://localhost:9999');
+    } finally {
+      stop();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does NOT fire when the config write is a no-op', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-gateway-watch-'));
+    const file = path.join(dir, 'oracle-gateway.json');
+    const cfg: GatewayConfig = {
+      services: { v: { url: 'http://localhost:1', timeout: 1000 } },
+      routes: [],
+    };
+    fs.writeFileSync(file, JSON.stringify(cfg));
+    const calls: Array<GatewayConfig | null> = [];
+    const stop = watchGatewayConfig(dir, (next) => calls.push(next));
+    try {
+      // Identical content rewrite.
+      fs.writeFileSync(file, JSON.stringify(cfg));
+      await wait(450);
+      expect(calls.length).toBe(0);
+    } finally {
+      stop();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps last good config when JSON becomes malformed', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-gateway-watch-'));
+    const file = path.join(dir, 'oracle-gateway.json');
+    const cfg: GatewayConfig = {
+      services: { v: { url: 'http://localhost:1', timeout: 1000 } },
+      routes: [],
+    };
+    fs.writeFileSync(file, JSON.stringify(cfg));
+    const calls: Array<GatewayConfig | null> = [];
+    const stop = watchGatewayConfig(dir, (next) => calls.push(next));
+    try {
+      // Mid-edit syntax error: file exists but content is unparseable.
+      // The watcher must NOT call onChange — last good state must hold.
+      fs.writeFileSync(file, '{ not valid json');
+      await wait(450);
+      expect(calls.length).toBe(0);
+    } finally {
+      stop();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('fires onChange(null) when the config file is deleted', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-gateway-watch-'));
+    const file = path.join(dir, 'oracle-gateway.json');
+    const cfg: GatewayConfig = {
+      services: { v: { url: 'http://localhost:1', timeout: 1000 } },
+      routes: [],
+    };
+    fs.writeFileSync(file, JSON.stringify(cfg));
+    const calls: Array<GatewayConfig | null> = [];
+    const stop = watchGatewayConfig(dir, (next) => calls.push(next));
+    try {
+      fs.unlinkSync(file);
+      await wait(450);
+      expect(calls.length).toBeGreaterThanOrEqual(1);
+      expect(calls[calls.length - 1]).toBeNull();
+    } finally {
+      stop();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('stop() closes the watcher and prevents further callbacks', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-gateway-watch-'));
+    const calls: Array<GatewayConfig | null> = [];
+    const stop = watchGatewayConfig(dir, (next) => calls.push(next));
+    stop();
+    try {
+      fs.writeFileSync(
+        path.join(dir, 'oracle-gateway.json'),
+        JSON.stringify({ services: {}, routes: [] }),
+      );
+      await wait(450);
+      expect(calls.length).toBe(0);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/gateway/config.ts
+++ b/src/gateway/config.ts
@@ -59,3 +59,72 @@ export function loadGatewayConfig(dataDir: string, vectorUrl?: string): GatewayC
 
   return null;
 }
+
+/**
+ * Watch the gateway config file and invoke onChange when content changes.
+ * Mirrors watchToolGroupConfig: fs.watch + 200ms debounce + no-op suppression
+ * + malformed-JSON survival + directory-fallback for first-time creation.
+ * VECTOR_URL synthesis is preserved on reload (used when the file is absent).
+ * Returns a stop function.
+ */
+export function watchGatewayConfig(
+  dataDir: string,
+  onChange: (next: GatewayConfig | null) => void,
+  vectorUrl?: string,
+): () => void {
+  const configPath = path.join(dataDir, CONFIG_FILE);
+  const watchers: fs.FSWatcher[] = [];
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let last = JSON.stringify(loadGatewayConfig(dataDir, vectorUrl));
+
+  const tick = (): void => {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = null;
+      // Malformed JSON survival: if the file exists but failed to parse,
+      // loadGatewayConfig returns null AND prints a warning. We only swap
+      // the live state when the new result is either a valid config or a
+      // genuine deletion (file no longer exists). Mid-edit syntax errors
+      // are silently ignored so the running gateway keeps its last good
+      // state until the user saves a valid file.
+      const fileMissing = !fs.existsSync(configPath);
+      const next = loadGatewayConfig(dataDir, vectorUrl);
+      if (next === null && !fileMissing && !vectorUrl) {
+        // file exists but failed to parse — hold last good
+        return;
+      }
+      const serialized = JSON.stringify(next);
+      if (serialized === last) return;
+      last = serialized;
+      console.log('[Gateway] Config changed — reloading');
+      onChange(next);
+    }, 200);
+  };
+
+  try {
+    if (fs.existsSync(configPath)) {
+      watchers.push(fs.watch(configPath, { persistent: false }, tick));
+    } else if (fs.existsSync(dataDir)) {
+      // Watch the directory so we catch creation of the config file later.
+      watchers.push(
+        fs.watch(dataDir, { persistent: false }, (_event, filename) => {
+          if (filename === CONFIG_FILE) tick();
+        }),
+      );
+    }
+  } catch {
+    // fs.watch can fail on platforms without inotify — keep going.
+  }
+
+  return () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    for (const w of watchers) {
+      try {
+        w.close();
+      } catch {}
+    }
+  };
+}

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -11,7 +11,7 @@
  *   onError    → runs when proxy or hook throws
  */
 import { Elysia } from 'elysia';
-import { loadGatewayConfig, type GatewayConfig } from './config.ts';
+import { loadGatewayConfig, watchGatewayConfig, type GatewayConfig } from './config.ts';
 import { compileRoutes, matchRoute, type CompiledRoute } from './matcher.ts';
 import { proxyToService } from './proxy.ts';
 import { HealthRegistry, type ServiceHealth } from './health.ts';
@@ -24,49 +24,103 @@ import './hooks/error-json.ts';
 export { loadGatewayConfig, compileRoutes, matchRoute, proxyToService, HealthRegistry };
 export type { GatewayConfig, CompiledRoute, ServiceHealth };
 
-export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
-  const config = loadGatewayConfig(dataDir, vectorUrl);
+/**
+ * Mutable state holder so the watcher can swap routes/services/hooks in
+ * place without restarting the Elysia plugin. The request handler reads
+ * from `state.*` at request time, so the swap takes effect immediately.
+ */
+interface GatewayState {
+  config: GatewayConfig;
+  compiled: CompiledRoute[];
+  hooks: ReturnType<typeof loadHooks>;
+  registry: HealthRegistry;
+}
 
-  if (!config) {
-    // No gateway config — all routes handled locally
+function describeState(state: GatewayState): string {
+  const hookCount =
+    state.hooks.onRequest.length + state.hooks.onResponse.length + state.hooks.onError.length;
+  return (
+    `${state.config.routes.length} route(s), ${Object.keys(state.config.services).length} service(s)` +
+    (hookCount > 0 ? `, ${hookCount} hook(s)` : '')
+  );
+}
+
+export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
+  const initial = loadGatewayConfig(dataDir, vectorUrl);
+
+  if (!initial && process.env.ORACLE_GATEWAY_HOT_RELOAD === '0') {
+    // No config + no hot-reload — pure no-op
     return new Elysia({ name: 'gateway' });
   }
 
-  const compiled = compileRoutes(config.routes);
-  const registry = new HealthRegistry();
-  registry.start(config.services);
-  const hooks = loadHooks(config.hooks);
+  // Even when no config exists at startup, install the watcher so the
+  // gateway can pick up a file that's created later (unless explicitly
+  // disabled via ORACLE_GATEWAY_HOT_RELOAD=0).
+  const buildState = (cfg: GatewayConfig): GatewayState => {
+    const registry = new HealthRegistry();
+    registry.start(cfg.services);
+    return {
+      config: cfg,
+      compiled: compileRoutes(cfg.routes),
+      hooks: loadHooks(cfg.hooks),
+      registry,
+    };
+  };
 
-  const hookCount =
-    hooks.onRequest.length + hooks.onResponse.length + hooks.onError.length;
+  let state: GatewayState | null = initial ? buildState(initial) : null;
+  if (state) console.log(`[Gateway] Loaded ${describeState(state)}`);
 
-  console.log(
-    `[Gateway] Loaded ${config.routes.length} route(s), ${Object.keys(config.services).length} service(s)` +
-      (hookCount > 0 ? `, ${hookCount} hook(s)` : ''),
-  );
+  if (process.env.ORACLE_GATEWAY_HOT_RELOAD !== '0') {
+    watchGatewayConfig(
+      dataDir,
+      (next) => {
+        // Stop the old health poller before swapping — it holds a timer.
+        if (state) state.registry.stop();
+        if (next) {
+          state = buildState(next);
+          console.log(`[Gateway] Reloaded — ${describeState(state)}`);
+        } else {
+          state = null;
+          console.log('[Gateway] Reloaded — disabled (no config)');
+        }
+      },
+      vectorUrl,
+    );
+  }
 
   return new Elysia({ name: 'gateway' })
-    .get('/api/gateway/status', () => ({
-      enabled: true,
-      routes: config.routes.length,
-      services: Object.fromEntries(
-        Object.entries(config.services).map(([k, v]) => [k, { url: v.url, timeout: v.timeout }]),
-      ),
-      hooks: hookCount,
-    }))
+    .get('/api/gateway/status', () => {
+      if (!state) return { enabled: false };
+      return {
+        enabled: true,
+        routes: state.config.routes.length,
+        services: Object.fromEntries(
+          Object.entries(state.config.services).map(([k, v]) => [
+            k,
+            { url: v.url, timeout: v.timeout },
+          ]),
+        ),
+        hooks:
+          state.hooks.onRequest.length +
+          state.hooks.onResponse.length +
+          state.hooks.onError.length,
+      };
+    })
     .get('/api/gateway/health', () => ({
-      services: registry.getAllStatus(),
+      services: state ? state.registry.getAllStatus() : {},
     }))
     .onRequest(async ({ request }) => {
+      if (!state) return; // no config loaded — fall through
+
       const url = new URL(request.url);
-      const match = matchRoute(url.pathname, compiled);
+      const match = matchRoute(url.pathname, state.compiled);
       if (!match) return; // no match — fall through to local Elysia routes
 
-      const service = config.services[match.service];
+      const service = state.config.services[match.service];
       if (!service || match.service === 'local') return; // "local" = handle locally
 
       // If health registry says service is down, return fallback immediately
-      if (!registry.isUp(match.service)) {
+      if (!state.registry.isUp(match.service)) {
         const fallback = match.fallback ?? 'error';
         if (fallback === 'empty') {
           return new Response(JSON.stringify({ results: [], source: 'gateway-fallback' }), {
@@ -90,11 +144,11 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
 
       // ── onRequest hooks ──
       try {
-        const early = await runHooks(hooks.onRequest, ctx);
+        const early = await runHooks(state.hooks.onRequest, ctx);
         if (early) return early;
       } catch (err) {
         ctx.error = err instanceof Error ? err : new Error(String(err));
-        const errResp = await runHooks(hooks.onError, ctx);
+        const errResp = await runHooks(state.hooks.onError, ctx);
         if (errResp) return errResp;
         throw err;
       }
@@ -105,7 +159,7 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
         response = await proxyToService(request, service);
       } catch (err) {
         ctx.error = err instanceof Error ? err : new Error(String(err));
-        const errResp = await runHooks(hooks.onError, ctx);
+        const errResp = await runHooks(state.hooks.onError, ctx);
         if (errResp) return errResp;
         throw err;
       }
@@ -113,11 +167,11 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
       // ── onResponse hooks ──
       ctx.response = response;
       try {
-        const override = await runHooks(hooks.onResponse, ctx);
+        const override = await runHooks(state.hooks.onResponse, ctx);
         if (override) return override;
       } catch (err) {
         ctx.error = err instanceof Error ? err : new Error(String(err));
-        const errResp = await runHooks(hooks.onError, ctx);
+        const errResp = await runHooks(state.hooks.onError, ctx);
         if (errResp) return errResp;
         throw err;
       }


### PR DESCRIPTION
## Summary

Completes #1072 PR 4 of 5. Mirrors the tool-groups hot-reload pattern (#1174 + #1175).

### What's added

- \`watchGatewayConfig(dataDir, onChange, vectorUrl?)\` in \`src/gateway/config.ts\` — returns a stop function
- 200ms debounce, no-op suppression, directory-fallback for first-time creation
- **Malformed-JSON survival**: only swap when the file is valid or genuinely deleted. Mid-edit syntax errors are silently ignored — running gateway keeps its last good state
- \`gatewayPlugin\` refactored to hold mutable state (\`{ config, compiled, hooks, registry }\`). Request handler reads from the holder at request time → swaps take effect immediately, no Elysia restart
- Health registry properly stopped before swap (timer cleanup)
- \`ORACLE_GATEWAY_HOT_RELOAD=0\` escape hatch (default: enabled)

### Tests

5 new tests in \`src/gateway/__tests__/config-watch.test.ts\`:
- File creation triggers reload
- No-op writes suppressed
- Malformed JSON: keeps last good (no callback)
- File deletion → onChange(null)
- stop() prevents further callbacks

**Total: 719/719 pass** (was 714), 0 fail with \`--isolate\`.

## #1072 progress
- [x] PR 1 — route matcher + proxy dispatcher (#1085)
- [x] PR 2 — hook pipeline (#1091)
- [x] PR 3 — health registry (#1088)
- [x] PR 4 — **hot-reload (this PR)**
- [ ] PR 5 — built-in hooks (auth-guard, fts5-fallback, rate-limit)

## Test plan
- [x] \`bun test --isolate src/gateway/\` — 30/30 pass
- [x] Full suite — 719 pass, 22 skip, 0 fail
- [ ] Manual: edit oracle-gateway.json mid-session, observe \`[Gateway] Reloaded\` log

🤖 Generated with [Claude Code](https://claude.com/claude-code)