### PR TITLE
feat(gateway): built-in hooks auth-guard + fts5-fallback (gateway PR 5)

### DIFF
--- a/src/gateway/__tests__/builtin-hooks.test.ts
+++ b/src/gateway/__tests__/builtin-hooks.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeAll } from 'bun:test';
+import { loadHooks, runHooks, type GatewayContext } from '../hooks.ts';
+
+// Side-effect imports register the hooks into the global registry.
+import '../hooks/auth-guard.ts';
+import '../hooks/fts5-fallback.ts';
+
+function makeCtx(
+  url: string,
+  init: RequestInit = {},
+  hookOptions: Record<string, unknown> = {},
+): GatewayContext {
+  return {
+    request: new Request(url, init),
+    meta: { hook_options: hookOptions },
+  };
+}
+
+describe('auth-guard hook', () => {
+  let runRequest: (ctx: GatewayContext) => Promise<Response | void>;
+  beforeAll(() => {
+    const pipeline = loadHooks({ onRequest: ['auth-guard'] });
+    runRequest = (ctx) => runHooks(pipeline.onRequest, ctx);
+  });
+
+  it('rejects when the configured header is missing', async () => {
+    const ctx = makeCtx('http://localhost/api/search', {}, {
+      'auth-guard': { header: 'x-oracle-token' },
+    });
+    const res = await runRequest(ctx);
+    expect(res).toBeInstanceOf(Response);
+    expect((res as Response).status).toBe(401);
+    const body = await (res as Response).json();
+    expect(body.reason).toContain('missing');
+  });
+
+  it('rejects when expected token does not match', async () => {
+    const ctx = makeCtx(
+      'http://localhost/api/search',
+      { headers: { 'x-oracle-token': 'wrong' } },
+      { 'auth-guard': { header: 'x-oracle-token', expected: 'secret' } },
+    );
+    const res = await runRequest(ctx);
+    expect((res as Response).status).toBe(401);
+    const body = await (res as Response).json();
+    expect(body.reason).toContain('invalid');
+  });
+
+  it('allows when expected token matches', async () => {
+    const ctx = makeCtx(
+      'http://localhost/api/search',
+      { headers: { 'x-oracle-token': 'secret' } },
+      { 'auth-guard': { header: 'x-oracle-token', expected: 'secret' } },
+    );
+    const res = await runRequest(ctx);
+    expect(res).toBeUndefined();
+  });
+
+  it('allows when any non-empty token is acceptable (no expected)', async () => {
+    const ctx = makeCtx(
+      'http://localhost/api/search',
+      { headers: { 'x-oracle-token': 'anything' } },
+      { 'auth-guard': { header: 'x-oracle-token' } },
+    );
+    const res = await runRequest(ctx);
+    expect(res).toBeUndefined();
+  });
+
+  it('bypasses check for allowlisted paths', async () => {
+    const ctx = makeCtx('http://localhost/api/health', {}, {
+      'auth-guard': { header: 'x-oracle-token', allowlist: ['/api/health'] },
+    });
+    const res = await runRequest(ctx);
+    expect(res).toBeUndefined();
+  });
+
+  it('allowlist matches prefix (e.g. /api/gateway/status under /api/gateway)', async () => {
+    const ctx = makeCtx('http://localhost/api/gateway/status', {}, {
+      'auth-guard': { header: 'x-oracle-token', allowlist: ['/api/gateway'] },
+    });
+    const res = await runRequest(ctx);
+    expect(res).toBeUndefined();
+  });
+
+  it('defaults to header x-oracle-token when none specified', async () => {
+    const ctx = makeCtx('http://localhost/api/search', {}, { 'auth-guard': {} });
+    const res = await runRequest(ctx);
+    expect((res as Response).status).toBe(401);
+    const body = await (res as Response).json();
+    expect(body.reason).toContain('x-oracle-token');
+  });
+});
+
+describe('fts5-fallback hook', () => {
+  let runError: (ctx: GatewayContext) => Promise<Response | void>;
+  beforeAll(() => {
+    const pipeline = loadHooks({ onError: ['fts5-fallback'] });
+    runError = (ctx) => runHooks(pipeline.onError, ctx);
+  });
+
+  it('sets ctx.meta.fallback_to_local = true on proxy error', async () => {
+    const ctx = makeCtx('http://localhost/api/search');
+    ctx.error = new Error('connection refused');
+    const res = await runError(ctx);
+    expect(res).toBeUndefined(); // void return — gateway falls through
+    expect(ctx.meta.fallback_to_local).toBe(true);
+  });
+
+  it('does not synthesize a Response (lets local routes handle)', async () => {
+    const ctx = makeCtx('http://localhost/api/similar?id=42');
+    ctx.error = new Error('timeout');
+    const res = await runError(ctx);
+    expect(res).toBeUndefined();
+  });
+});

--- a/src/gateway/config.ts
+++ b/src/gateway/config.ts
@@ -26,6 +26,12 @@ export interface GatewayConfig {
   services: Record<string, ServiceConfig>;
   routes: RouteConfig[];
   hooks?: HooksConfig;
+  /**
+   * Per-hook options keyed by hook name. Each hook reads its own slot via
+   * `ctx.meta.hook_options[<name>]`. Optional — hooks should provide sensible
+   * defaults when missing.
+   */
+  hook_options?: Record<string, unknown>;
 }
 
 const CONFIG_FILE = 'oracle-gateway.json';

--- a/src/gateway/hooks/auth-guard.ts
+++ b/src/gateway/hooks/auth-guard.ts
@@ -1,0 +1,48 @@
+/**
+ * Built-in hook: auth-guard
+ *
+ * Rejects requests missing a valid token. Reads its options from
+ * `ctx.meta.hook_options['auth-guard']`:
+ *
+ *   {
+ *     header: string,        // header name (default "x-oracle-token")
+ *     expected?: string,     // exact match — omit to require ANY non-empty value
+ *     allowlist?: string[]   // path prefixes that bypass the check (health, status)
+ *   }
+ *
+ * Returns 401 JSON when the token is missing or mismatched.
+ */
+import { registerHook, type GatewayContext } from '../hooks.ts';
+
+interface AuthGuardOptions {
+  header?: string;
+  expected?: string;
+  allowlist?: string[];
+}
+
+function unauthorized(reason: string): Response {
+  return new Response(JSON.stringify({ error: 'unauthorized', reason }), {
+    status: 401,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+registerHook({
+  name: 'auth-guard',
+  phase: 'onRequest',
+  handler(ctx: GatewayContext): Response | void {
+    const opts =
+      (ctx.meta.hook_options as Record<string, AuthGuardOptions> | undefined)?.['auth-guard'] ??
+      {};
+    const headerName = opts.header ?? 'x-oracle-token';
+
+    const pathname = new URL(ctx.request.url).pathname;
+    for (const prefix of opts.allowlist ?? []) {
+      if (pathname === prefix || pathname.startsWith(prefix + '/')) return;
+    }
+
+    const token = ctx.request.headers.get(headerName);
+    if (!token) return unauthorized(`missing ${headerName}`);
+    if (opts.expected && token !== opts.expected) return unauthorized(`invalid ${headerName}`);
+  },
+});

--- a/src/gateway/hooks/fts5-fallback.ts
+++ b/src/gateway/hooks/fts5-fallback.ts
@@ -1,0 +1,28 @@
+/**
+ * Built-in hook: fts5-fallback
+ *
+ * onError hook for proxy failures. Sets `ctx.meta.fallback_to_local = true`
+ * so the gateway request handler falls through to the local Elysia routes
+ * instead of rethrowing the proxy error to the client. The local handlers
+ * still serve FTS5 search via the normal `/api/search` etc.
+ *
+ * No options needed — the route's existing `fallback: 'fts5'` config
+ * already documents intent. This hook adds the equivalent behavior for
+ * runtime proxy errors (timeout, 502, refused) on routes where the
+ * route-level fallback is set to something else.
+ */
+import { registerHook, type GatewayContext } from '../hooks.ts';
+
+registerHook({
+  name: 'fts5-fallback',
+  phase: 'onError',
+  handler(ctx: GatewayContext): void {
+    // Mark the request for local fall-through. The gateway request handler
+    // checks this flag in its proxy catch block before rethrowing.
+    ctx.meta.fallback_to_local = true;
+    const url = new URL(ctx.request.url);
+    console.log(
+      `[Gateway] fts5-fallback: ${url.pathname} → local (proxy err: ${ctx.error?.message ?? 'unknown'})`,
+    );
+  },
+});

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -20,6 +20,8 @@ import { loadHooks, runHooks, type GatewayContext } from './hooks.ts';
 // Register built-in hooks (side-effect imports)
 import './hooks/request-logger.ts';
 import './hooks/error-json.ts';
+import './hooks/auth-guard.ts';
+import './hooks/fts5-fallback.ts';
 
 export { loadGatewayConfig, compileRoutes, matchRoute, proxyToService, HealthRegistry };
 export type { GatewayConfig, CompiledRoute, ServiceHealth };
@@ -139,7 +141,9 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
         request,
         route: match,
         service,
-        meta: {},
+        // Surface per-hook options so hooks can be config-driven without
+        // module-level globals. Hooks read ctx.meta.hook_options['<name>'].
+        meta: { hook_options: state.config.hook_options ?? {} },
       };
 
       // ── onRequest hooks ──
@@ -150,6 +154,7 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
         ctx.error = err instanceof Error ? err : new Error(String(err));
         const errResp = await runHooks(state.hooks.onError, ctx);
         if (errResp) return errResp;
+        if (ctx.meta.fallback_to_local) return; // fall through to local Elysia
         throw err;
       }
 
@@ -161,6 +166,7 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
         ctx.error = err instanceof Error ? err : new Error(String(err));
         const errResp = await runHooks(state.hooks.onError, ctx);
         if (errResp) return errResp;
+        if (ctx.meta.fallback_to_local) return; // fall through to local Elysia
         throw err;
       }
 
@@ -173,6 +179,7 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
         ctx.error = err instanceof Error ? err : new Error(String(err));
         const errResp = await runHooks(state.hooks.onError, ctx);
         if (errResp) return errResp;
+        if (ctx.meta.fallback_to_local) return;
         throw err;
       }
 


### PR DESCRIPTION
## Summary

Closes #1072 PR 5 (lean scope per QA — rate-limit deferred to a separate follow-up PR).

### What's added

**auth-guard** (\`onRequest\` hook)
- Rejects requests missing a valid token
- Config: \`header\` name (default \`x-oracle-token\`), optional \`expected\` for exact match, optional \`allowlist\` of path prefixes
- Returns 401 JSON on rejection: \`{ "error": "unauthorized", "reason": "missing x-oracle-token" }\`

**fts5-fallback** (\`onError\` hook)
- Sets \`ctx.meta.fallback_to_local = true\` when the proxy throws
- Gateway request handler checks this flag in all three catch blocks (onRequest/proxy/onResponse) before rethrowing — when set, returns \`undefined\` so Elysia falls through to the local routes
- Works alongside the existing route-level \`fallback: 'fts5'\` (which handles "service marked down by health registry"); this hook handles "proxy actually fired and failed"

### Config schema

\`\`\`json
{
  "services": { "vector": { "url": "http://localhost:8081" } },
  "routes": [{ "match": "/api/search", "service": "vector" }],
  "hooks": {
    "onRequest": ["auth-guard"],
    "onError": ["fts5-fallback", "error-json"]
  },
  "hook_options": {
    "auth-guard": {
      "header": "x-oracle-token",
      "expected": "secret",
      "allowlist": ["/api/health", "/api/gateway"]
    }
  }
}
\`\`\`

### Tests

9 new tests in \`builtin-hooks.test.ts\`:
- missing token (401)
- wrong token (401)
- correct token (passes)
- any non-empty token when no \`expected\` (passes)
- allowlist exact match
- allowlist prefix match
- default header \`x-oracle-token\` when none specified
- fts5-fallback sets meta flag
- fts5-fallback returns void (does not synthesize Response)

**Total: 728/728 pass** (was 719), 0 fail with \`--isolate\`.

## #1072 epic — COMPLETE
- [x] PR 1 — route matcher + proxy (#1085)
- [x] PR 2 — hook pipeline (#1091)
- [x] PR 3 — health registry (#1088)
- [x] PR 4 — hot-reload (#1176)
- [x] PR 5 — **built-in hooks (this PR)**

Rate-limit deferred to follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)