### PR TITLE
feat(gateway): rate-limit hook (per-key token bucket)

### DIFF
--- a/src/gateway/__tests__/rate-limit.test.ts
+++ b/src/gateway/__tests__/rate-limit.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { loadHooks, runHooks, type GatewayContext } from '../hooks.ts';
+import { _resetRateLimitState } from '../hooks/rate-limit.ts';
+
+const pipeline = loadHooks({ onRequest: ['rate-limit'] });
+const run = (ctx: GatewayContext) => runHooks(pipeline.onRequest, ctx);
+
+function ctxFor(ip: string, opts: Record<string, unknown> = {}): GatewayContext {
+  return {
+    request: new Request('http://localhost/api/search', {
+      headers: { 'x-forwarded-for': ip },
+    }),
+    meta: { hook_options: { 'rate-limit': opts } },
+  };
+}
+
+describe('rate-limit hook', () => {
+  beforeEach(() => {
+    _resetRateLimitState();
+  });
+
+  it('allows requests within the burst', async () => {
+    const opts = { tokens_per_window: 60, window_ms: 60_000, burst: 3 };
+    expect(await run(ctxFor('1.1.1.1', opts))).toBeUndefined();
+    expect(await run(ctxFor('1.1.1.1', opts))).toBeUndefined();
+    expect(await run(ctxFor('1.1.1.1', opts))).toBeUndefined();
+  });
+
+  it('blocks the 4th request with 429 once burst is drained', async () => {
+    const opts = { tokens_per_window: 60, window_ms: 60_000, burst: 3 };
+    await run(ctxFor('2.2.2.2', opts));
+    await run(ctxFor('2.2.2.2', opts));
+    await run(ctxFor('2.2.2.2', opts));
+    const blocked = await run(ctxFor('2.2.2.2', opts));
+    expect(blocked).toBeInstanceOf(Response);
+    expect((blocked as Response).status).toBe(429);
+    const body = await (blocked as Response).json();
+    expect(body.error).toBe('rate_limited');
+    expect(body.retry_after_seconds).toBeGreaterThan(0);
+    expect((blocked as Response).headers.get('Retry-After')).toBeDefined();
+  });
+
+  it('isolates buckets per client key', async () => {
+    const opts = { tokens_per_window: 60, window_ms: 60_000, burst: 1 };
+    expect(await run(ctxFor('3.3.3.3', opts))).toBeUndefined();
+    // 3.3.3.3 is now drained, but 4.4.4.4 should still have its own bucket
+    expect(await run(ctxFor('4.4.4.4', opts))).toBeUndefined();
+    // 3.3.3.3 again — blocked
+    const blocked = await run(ctxFor('3.3.3.3', opts));
+    expect((blocked as Response).status).toBe(429);
+  });
+
+  it('refills tokens over time', async () => {
+    // 100 tokens per 100ms = 1 per ms. burst=1 → 1ms of wait should refill.
+    const opts = { tokens_per_window: 100, window_ms: 100, burst: 1 };
+    expect(await run(ctxFor('5.5.5.5', opts))).toBeUndefined();
+    // Immediately after, blocked
+    const blocked = await run(ctxFor('5.5.5.5', opts));
+    expect((blocked as Response).status).toBe(429);
+    // Wait long enough for the bucket to refill
+    await new Promise((r) => setTimeout(r, 50));
+    expect(await run(ctxFor('5.5.5.5', opts))).toBeUndefined();
+  });
+
+  it('uses leftmost IP from a comma-separated X-Forwarded-For chain', async () => {
+    const opts = { tokens_per_window: 60, window_ms: 60_000, burst: 1 };
+    const a: GatewayContext = {
+      request: new Request('http://localhost/api/search', {
+        headers: { 'x-forwarded-for': '6.6.6.6, 10.0.0.1' },
+      }),
+      meta: { hook_options: { 'rate-limit': opts } },
+    };
+    const b: GatewayContext = {
+      request: new Request('http://localhost/api/search', {
+        headers: { 'x-forwarded-for': '6.6.6.6, 10.0.0.2' },
+      }),
+      meta: { hook_options: { 'rate-limit': opts } },
+    };
+    expect(await run(a)).toBeUndefined();
+    // Same leftmost IP — should hit the same bucket and be blocked
+    expect((await run(b) as Response).status).toBe(429);
+  });
+
+  it('falls back to "anonymous" when the configured header is absent', async () => {
+    const opts = { tokens_per_window: 60, window_ms: 60_000, burst: 1 };
+    const c: GatewayContext = {
+      request: new Request('http://localhost/api/search'),
+      meta: { hook_options: { 'rate-limit': opts } },
+    };
+    expect(await run(c)).toBeUndefined();
+    // Second anon request shares the same bucket — blocked
+    const d: GatewayContext = {
+      request: new Request('http://localhost/api/search'),
+      meta: { hook_options: { 'rate-limit': opts } },
+    };
+    expect((await run(d) as Response).status).toBe(429);
+  });
+
+  it('disables itself when tokens_per_window <= 0', async () => {
+    const opts = { tokens_per_window: 0, window_ms: 60_000, burst: 1 };
+    // No matter how many requests, no 429.
+    for (let i = 0; i < 5; i++) {
+      expect(await run(ctxFor('7.7.7.7', opts))).toBeUndefined();
+    }
+  });
+
+  it('uses default settings when no options are provided', async () => {
+    // Defaults: 60 tokens / 60s, burst = 60. First request passes.
+    const ctx: GatewayContext = {
+      request: new Request('http://localhost/api/search', {
+        headers: { 'x-forwarded-for': '8.8.8.8' },
+      }),
+      meta: { hook_options: {} },
+    };
+    expect(await run(ctx)).toBeUndefined();
+  });
+
+  it('respects a custom header name', async () => {
+    const opts = {
+      header: 'x-real-ip',
+      tokens_per_window: 60,
+      window_ms: 60_000,
+      burst: 1,
+    };
+    const a: GatewayContext = {
+      request: new Request('http://localhost/api/search', {
+        headers: { 'x-real-ip': '9.9.9.9' },
+      }),
+      meta: { hook_options: { 'rate-limit': opts } },
+    };
+    const b: GatewayContext = {
+      request: new Request('http://localhost/api/search', {
+        headers: { 'x-real-ip': '9.9.9.9' },
+      }),
+      meta: { hook_options: { 'rate-limit': opts } },
+    };
+    expect(await run(a)).toBeUndefined();
+    expect((await run(b) as Response).status).toBe(429);
+  });
+});

--- a/src/gateway/hooks/rate-limit.ts
+++ b/src/gateway/hooks/rate-limit.ts
@@ -1,0 +1,108 @@
+/**
+ * Built-in hook: rate-limit
+ *
+ * Per-key token bucket. The key is read from a request header (default
+ * x-forwarded-for) — fall back to "anonymous" when the header is missing
+ * so the bucket still meters traffic, just bucketed globally.
+ *
+ * Options (via ctx.meta.hook_options['rate-limit']):
+ *   header?: string             // header to read for the key (default x-forwarded-for)
+ *   tokens_per_window?: number  // tokens refilled per window (default 60)
+ *   window_ms?: number          // window duration in ms (default 60000 = 1 min)
+ *   burst?: number              // max bucket size (default = tokens_per_window)
+ *
+ * Returns 429 with Retry-After (seconds) when a bucket is empty.
+ *
+ * In-memory only — per-process. If the gateway runs as multiple instances,
+ * each enforces its own limit. Acceptable for the lean MVP; Redis-backed
+ * variant can come later.
+ */
+import { registerHook, type GatewayContext } from '../hooks.ts';
+
+interface RateLimitOptions {
+  header?: string;
+  tokens_per_window?: number;
+  window_ms?: number;
+  burst?: number;
+}
+
+interface Bucket {
+  tokens: number;
+  lastRefill: number;
+}
+
+const DEFAULTS = {
+  header: 'x-forwarded-for',
+  tokens_per_window: 60,
+  window_ms: 60_000,
+} as const;
+
+// Module-level state — per-process bucket map keyed by client identifier.
+const buckets = new Map<string, Bucket>();
+
+/** Exposed for tests — clear the in-memory state between scenarios. */
+export function _resetRateLimitState(): void {
+  buckets.clear();
+}
+
+function extractKey(request: Request, header: string): string {
+  // X-Forwarded-For can be a comma-separated chain. Use the leftmost (the
+  // originating client) — see RFC 7239 / standard reverse-proxy convention.
+  const raw = request.headers.get(header);
+  if (!raw) return 'anonymous';
+  return raw.split(',')[0].trim() || 'anonymous';
+}
+
+function refill(bucket: Bucket, ratePerMs: number, max: number, now: number): void {
+  const elapsed = now - bucket.lastRefill;
+  if (elapsed <= 0) return;
+  const refilled = elapsed * ratePerMs;
+  bucket.tokens = Math.min(max, bucket.tokens + refilled);
+  bucket.lastRefill = now;
+}
+
+registerHook({
+  name: 'rate-limit',
+  phase: 'onRequest',
+  handler(ctx: GatewayContext): Response | void {
+    const opts =
+      (ctx.meta.hook_options as Record<string, RateLimitOptions> | undefined)?.['rate-limit'] ??
+      {};
+    const headerName = opts.header ?? DEFAULTS.header;
+    const tokensPerWindow = opts.tokens_per_window ?? DEFAULTS.tokens_per_window;
+    const windowMs = opts.window_ms ?? DEFAULTS.window_ms;
+    const burst = opts.burst ?? tokensPerWindow;
+
+    if (tokensPerWindow <= 0 || windowMs <= 0 || burst <= 0) return; // disabled / malformed
+
+    const ratePerMs = tokensPerWindow / windowMs;
+    const now = Date.now();
+    const key = extractKey(ctx.request, headerName);
+
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = { tokens: burst, lastRefill: now };
+      buckets.set(key, bucket);
+    } else {
+      refill(bucket, ratePerMs, burst, now);
+    }
+
+    if (bucket.tokens < 1) {
+      const deficit = 1 - bucket.tokens;
+      const retryMs = Math.ceil(deficit / ratePerMs);
+      const retryAfter = Math.max(1, Math.ceil(retryMs / 1000));
+      return new Response(
+        JSON.stringify({ error: 'rate_limited', retry_after_seconds: retryAfter }),
+        {
+          status: 429,
+          headers: {
+            'Content-Type': 'application/json',
+            'Retry-After': String(retryAfter),
+          },
+        },
+      );
+    }
+
+    bucket.tokens -= 1;
+  },
+});

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -22,6 +22,7 @@ import './hooks/request-logger.ts';
 import './hooks/error-json.ts';
 import './hooks/auth-guard.ts';
 import './hooks/fts5-fallback.ts';
+import './hooks/rate-limit.ts';
 
 export { loadGatewayConfig, compileRoutes, matchRoute, proxyToService, HealthRegistry };
 export type { GatewayConfig, CompiledRoute, ServiceHealth };


### PR DESCRIPTION
## Summary

Follow-up to PR #1177 — the deferred third built-in hook from the gateway epic. In-memory per-process token bucket.

### Behavior

- \`onRequest\` hook, registered alongside auth-guard + fts5-fallback
- Per-key bucket: header (default \`x-forwarded-for\`, leftmost IP), absent → \`anonymous\` global bucket
- 429 + \`Retry-After\` (seconds) when drained
- Self-disables when \`tokens_per_window <= 0\`

### Config

\`\`\`json
{
  "hooks": { "onRequest": ["rate-limit"] },
  "hook_options": {
    "rate-limit": {
      "header": "x-forwarded-for",
      "tokens_per_window": 60,
      "window_ms": 60000,
      "burst": 10
    }
  }
}
\`\`\`

### Limitations (acceptable for lean MVP)
- **In-memory, per-process**: multi-instance gateway = each instance enforces its own limit
- **Anonymous fallback**: if the deployment doesn't set XFF, all unidentified clients share one bucket — meters traffic but coarse
- Redis-backed variant can come later if cross-instance enforcement matters

## Tests

9 new tests in \`rate-limit.test.ts\`:
- burst pass through
- drain → 429 with Retry-After
- isolation per client key
- token refill over time (real wait)
- leftmost IP from comma-separated XFF
- anonymous fallback when header absent
- disabled mode (\`tokens_per_window: 0\`)
- defaults when no options
- custom header name (\`x-real-ip\`)

**Total: 737/737 pass** (was 728), 0 fail with \`--isolate\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)