### PR TITLE
fix(mcp): keep diagnostics off stdio stdout

### DIFF
--- a/src/server/logging.ts
+++ b/src/server/logging.ts
@@ -41,19 +41,18 @@ export function logSearch(
       results: resultsJson,
     }).run();
 
-    // Comprehensive console logging
-    console.log(`\n${'='.repeat(60)}`);
-    console.log(`[SEARCH] ${new Date().toISOString()}`);
-    if (project) console.log(`  Project: ${project}`);
-    console.log(`  Query: "${query}"`);
-    console.log(`  Type: ${type} | Mode: ${mode}`);
-    console.log(`  Results: ${resultsCount} in ${searchTimeMs}ms`);
+    console.error(`\n${'='.repeat(60)}`);
+    console.error(`[SEARCH] ${new Date().toISOString()}`);
+    if (project) console.error(`  Project: ${project}`);
+    console.error(`  Query: "${query}"`);
+    console.error(`  Type: ${type} | Mode: ${mode}`);
+    console.error(`  Results: ${resultsCount} in ${searchTimeMs}ms`);
 
     if (results.length > 0) {
-      console.log(`  Top Results:`);
+      console.error(`  Top Results:`);
       results.slice(0, 5).forEach((r, i) => {
-        console.log(`    ${i + 1}. [${r.type}] score=${r.score || 'N/A'} id=${r.id}`);
-        console.log(`       ${r.content?.substring(0, 80)}...`);
+        console.error(`    ${i + 1}. [${r.type}] score=${r.score || 'N/A'} id=${r.id}`);
+        console.error(`       ${r.content?.substring(0, 80)}...`);
       });
     }
 
@@ -63,10 +62,10 @@ export function logSearch(
       const firstResult = results[0] as unknown as Record<string, unknown>;
       const unknownFields = Object.keys(firstResult).filter(k => !expectedFields.includes(k));
       if (unknownFields.length > 0) {
-        console.log(`  [UNKNOWN FIELDS]: ${unknownFields.join(', ')}`);
+        console.error(`  [UNKNOWN FIELDS]: ${unknownFields.join(', ')}`);
       }
     }
-    console.log(`${'='.repeat(60)}\n`);
+    console.error(`${'='.repeat(60)}\n`);
   } catch (e) {
     console.error('Failed to log search:', e);
   }
@@ -105,4 +104,3 @@ export function logLearning(documentId: string, patternPreview: string, source: 
     console.error('Failed to log learning:', e);
   }
 }
-

--- a/src/vector/adapters/lancedb.ts
+++ b/src/vector/adapters/lancedb.ts
@@ -26,13 +26,13 @@ export class LanceDBAdapter implements VectorStoreAdapter {
 
     const lancedb = await import('@lancedb/lancedb');
     this.db = await lancedb.connect(this.dbPath);
-    console.log(`[LanceDB] Connected at ${this.dbPath}`);
+    console.error(`[LanceDB] Connected at ${this.dbPath}`);
   }
 
   async close(): Promise<void> {
     this.db = null;
     this.table = null;
-    console.log('[LanceDB] Closed');
+    console.error('[LanceDB] Closed');
   }
 
   async ensureCollection(): Promise<void> {
@@ -53,7 +53,7 @@ export class LanceDBAdapter implements VectorStoreAdapter {
       await this.table.delete('id = "__init__"');
     }
 
-    console.log(`[LanceDB] Collection '${this.collectionName}' ready`);
+    console.error(`[LanceDB] Collection '${this.collectionName}' ready`);
   }
 
   async deleteCollection(): Promise<void> {
@@ -62,9 +62,9 @@ export class LanceDBAdapter implements VectorStoreAdapter {
     try {
       await this.db.dropTable(this.collectionName);
       this.table = null;
-      console.log(`[LanceDB] Collection '${this.collectionName}' deleted`);
+      console.error(`[LanceDB] Collection '${this.collectionName}' deleted`);
     } catch (e) {
-      console.warn('[LanceDB] deleteCollection failed:', e instanceof Error ? e.message : String(e));
+      console.error('[LanceDB] deleteCollection failed:', e instanceof Error ? e.message : String(e));
     }
   }
 
@@ -96,9 +96,9 @@ export class LanceDBAdapter implements VectorStoreAdapter {
     await this.table.add(rows);
     const reused = docs.length - needEmbed.length;
     if (reused > 0) {
-      console.log(`[LanceDB] Added ${docs.length} documents (${reused} with precomputed vectors)`);
+      console.error(`[LanceDB] Added ${docs.length} documents (${reused} with precomputed vectors)`);
     } else {
-      console.log(`[LanceDB] Added ${docs.length} documents`);
+      console.error(`[LanceDB] Added ${docs.length} documents`);
     }
   }
 


### PR DESCRIPTION
## Summary
- Route MCP-path diagnostic logs from stdout to stderr so stdio stdout stays JSON-RPC-only.
- Covers both startup-time LanceDB lifecycle logs and runtime `muninn_search` audit logs.
- Fixes the Codex `arra-oracle-v2.muninn_search` failure seen in `next-writer/20260525-083721`, where Codex reported `Transport closed` after the first search call.

## Root Cause
- The MCP server itself did not crash.
- `muninn_search` completed successfully, but `logSearch()` printed the human-readable `[SEARCH]` audit block to stdout before the JSON-RPC tool response.
- Codex treats MCP stdio stdout as protocol-only; the non-JSON line corrupts the stream and the client closes the transport.

## Validation
- Replayed the same MCP stdio sequence from the `mb-next-payment-gateway.wt-1-20260525-083721` cwd: initialize → tools/list → `muninn_search` with the failing query.
- Confirmed stdout now contains only JSON-RPC response lines; search audit output appears on stderr.
- `MCP_TEST=1 bun test src/integration/mcp.test.ts` — 11 pass, 0 fail.

## Learning
- Oracle learning: `learning_2026-05-25_codex-mcp-transport-closed-during-muninnsearch`.
- Vault file: `github.com/soul-brews-studio/arra-oracle-v3/ψ/memory/learnings/2026-05-25_codex-mcp-transport-closed-during-muninnsearch.md`.

## Notes
- This is separate from Vercel MCP startup/OAuth state.
- The local failed `git push origin ...` was expected because `origin` is upstream; the branch was pushed to the fork remote used by this PR.
