### PR TITLE
feat(mcp): backward-compat alias arra_* → muninn_* tool names

### DIFF
--- a/src/__tests__/resolve-tool-name.test.ts
+++ b/src/__tests__/resolve-tool-name.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'bun:test';
+import { resolveToolName } from '../index.ts';
+
+describe('resolveToolName — arra_* → muninn_* backward compat (PR #1172 aliases)', () => {
+  it('maps arra_search to muninn_search', () => {
+    expect(resolveToolName('arra_search')).toBe('muninn_search');
+  });
+
+  it('maps arra_learn to muninn_learn', () => {
+    expect(resolveToolName('arra_learn')).toBe('muninn_learn');
+  });
+
+  it('maps every legacy arra_* tool we shipped before the rename', () => {
+    const pairs: Array<[string, string]> = [
+      ['arra_search', 'muninn_search'],
+      ['arra_read', 'muninn_read'],
+      ['arra_list', 'muninn_list'],
+      ['arra_stats', 'muninn_stats'],
+      ['arra_concepts', 'muninn_concepts'],
+      ['arra_learn', 'muninn_learn'],
+      ['arra_supersede', 'muninn_supersede'],
+      ['arra_handoff', 'muninn_handoff'],
+      ['arra_inbox', 'muninn_inbox'],
+      ['arra_thread', 'muninn_thread'],
+      ['arra_threads', 'muninn_threads'],
+      ['arra_thread_read', 'muninn_thread_read'],
+      ['arra_thread_update', 'muninn_thread_update'],
+      ['arra_trace', 'muninn_trace'],
+      ['arra_trace_list', 'muninn_trace_list'],
+      ['arra_trace_get', 'muninn_trace_get'],
+      ['arra_trace_link', 'muninn_trace_link'],
+      ['arra_trace_unlink', 'muninn_trace_unlink'],
+      ['arra_trace_chain', 'muninn_trace_chain'],
+    ];
+    for (const [old, neu] of pairs) {
+      expect(resolveToolName(old)).toBe(neu);
+    }
+  });
+
+  it('passes muninn_* names through unchanged', () => {
+    expect(resolveToolName('muninn_search')).toBe('muninn_search');
+    expect(resolveToolName('muninn_trace_chain')).toBe('muninn_trace_chain');
+  });
+
+  it('leaves unrelated names alone (no false rewrites)', () => {
+    // Tools without the arra_ prefix should not be touched, even if they
+    // contain "arra" elsewhere.
+    expect(resolveToolName('search')).toBe('search');
+    expect(resolveToolName('not_arra_thing')).toBe('not_arra_thing');
+    expect(resolveToolName('')).toBe('');
+  });
+
+  it('only strips the leading "arra_" prefix — preserves the rest of the name', () => {
+    // Hypothetical future tool: arra_new_thing → muninn_new_thing
+    expect(resolveToolName('arra_new_thing')).toBe('muninn_new_thing');
+    // Underscore-heavy name
+    expect(resolveToolName('arra_a_b_c_d')).toBe('muninn_a_b_c_d');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,18 @@ import type {
   GetTraceInput,
 } from './trace/types.ts';
 
+/**
+ * Backward-compat alias: callers using the pre-#1172 `arra_*` tool names
+ * are transparently mapped to the new `muninn_*` names. Tool LIST is
+ * unchanged — only muninn_* is advertised — but old callers keep working.
+ * Exported for unit tests.
+ */
+export function resolveToolName(name: string): string {
+  return name.startsWith('arra_')
+    ? 'muninn_' + name.slice('arra_'.length)
+    : name;
+}
+
 // Write tools that should be disabled in read-only mode
 const WRITE_TOOLS = [
   'muninn_learn',
@@ -243,21 +255,25 @@ class OracleMCPServer {
     // Handle tool calls — route to extracted handlers
     // ================================================================
     this.server.setRequestHandler(CallToolRequestSchema, async (request): Promise<any> => {
-      if (this.disabledTools.has(request.params.name)) {
+      // Backward compat: arra_* → muninn_* aliasing (PR #1172 renamed the
+      // tools; old callers keep working). See resolveToolName().
+      const toolName = resolveToolName(request.params.name);
+
+      if (this.disabledTools.has(toolName)) {
         return {
           content: [{
             type: 'text',
-            text: `Error: Tool "${request.params.name}" is disabled by tool group config. Check ${ORACLE_DATA_DIR}/config.json or arra.config.json.`
+            text: `Error: Tool "${toolName}" is disabled by tool group config. Check ${ORACLE_DATA_DIR}/config.json or arra.config.json.`
           }],
           isError: true
         };
       }
 
-      if (this.readOnly && WRITE_TOOLS.includes(request.params.name)) {
+      if (this.readOnly && WRITE_TOOLS.includes(toolName)) {
         return {
           content: [{
             type: 'text',
-            text: `Error: Tool "${request.params.name}" is disabled in read-only mode. This Oracle instance is configured for read-only access.`
+            text: `Error: Tool "${toolName}" is disabled in read-only mode. This Oracle instance is configured for read-only access.`
           }],
           isError: true
         };
@@ -266,7 +282,7 @@ class OracleMCPServer {
       const ctx = this.toolCtx;
 
       try {
-        switch (request.params.name) {
+        switch (toolName) {
           // Core tools (delegated to src/tools/)
           case 'muninn_search':
             return await handleSearch(ctx, request.params.arguments as unknown as OracleSearchInput);
@@ -311,7 +327,7 @@ class OracleMCPServer {
             return await handleTraceChain(request.params.arguments as unknown as { traceId: string });
 
           default:
-            throw new Error(`Unknown tool: ${request.params.name}`);
+            throw new Error(`Unknown tool: ${toolName}`);
         }
       } catch (error) {
         return {


### PR DESCRIPTION
## Summary

Anything still calling the pre-#1172 \`arra_*\` tool names is transparently mapped to \`muninn_*\`. Tool LIST is unchanged — only \`muninn_*\` is advertised. Soft compat forever (no sunset).

### Why

PR #1172 renamed all 24 MCP tools \`arra_*\` → \`muninn_*\` with a clean cut — no aliases. That breaks:
- Other oracles on the fleet (white, mba, oracle-world) whose CLAUDE.md still references old names
- Stale Claude Code session JSONLs replayed after the rename
- External docs, blog posts, tutorial code samples
- Anyone who installed/forked before today

### Implementation

\`\`\`typescript
export function resolveToolName(name: string): string {
  return name.startsWith('arra_')
    ? 'muninn_' + name.slice('arra_'.length)
    : name;
}
\`\`\`

Called at the entry of the CallTool dispatch — disabled-tool checks, read-only checks, and the switch all use the canonical \`muninn_*\` name. Old callers get the right handler invisibly.

**Generalised over a 24-entry table** — works for any future \`arra_*\` name without code changes.

## Tests

6 new unit tests in \`src/__tests__/resolve-tool-name.test.ts\`:
- Every known legacy pair (19 of them)
- \`muninn_*\` passthrough
- Unrelated names untouched
- Empty string
- Prefix-only stripping preserves rest of name
- Hypothetical future \`arra_*\` tools

**Total: 743/743 pass** (was 737), 0 fail with \`--isolate\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)