### PR TITLE
feat(mcp): rename muninn_* → oracle_* canonical (3rd-generation alias)

### DIFF
--- a/.rtk/filters.toml
+++ b/.rtk/filters.toml
@@ -1,0 +1,13 @@
+# Project-local RTK filters — commit this file with your repo.
+# Filters here override user-global and built-in filters.
+# Docs: https://github.com/rtk-ai/rtk#custom-filters
+schema_version = 1
+
+# Example: suppress build noise from a custom tool
+# [filters.my-tool]
+# description = "Compact my-tool output"
+# match_command = "^my-tool\\s+build"
+# strip_ansi = true
+# strip_lines_matching = ["^\\s*$", "^Downloading", "^Installing"]
+# max_lines = 30
+# on_empty = "my-tool: ok"

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -22,60 +22,60 @@ Groups can be enabled/disabled via `arra.config.json` (repo-local) or `~/.arra-o
 
 | Tool | Description |
 |------|-------------|
-| `muninn_search` | Hybrid search (FTS5 keywords + vector similarity). Finds principles, patterns, learnings, retros. |
-| `muninn_read` | Read full content of a document by file path or document ID. |
-| `muninn_list` | Browse all documents without searching. Supports type/date filters and pagination. |
-| `muninn_concepts` | List all concept tags with document counts. Discover topic coverage. |
+| `oracle_search` | Hybrid search (FTS5 keywords + vector similarity). Finds principles, patterns, learnings, retros. |
+| `oracle_read` | Read full content of a document by file path or document ID. |
+| `oracle_list` | Browse all documents without searching. Supports type/date filters and pagination. |
+| `oracle_concepts` | List all concept tags with document counts. Discover topic coverage. |
 
 ## Knowledge (3 tools)
 
 | Tool | Description |
 |------|-------------|
-| `muninn_learn` | Add a new pattern/learning. Creates markdown in `ψ/memory/learnings/` and indexes to SQLite + vectors. |
-| `muninn_stats` | Knowledge base statistics: doc counts by type, indexing status, vector DB health. |
-| `muninn_supersede` | Mark old doc as superseded by newer one. "Nothing is Deleted" — old preserved, just marked. |
+| `oracle_learn` | Add a new pattern/learning. Creates markdown in `ψ/memory/learnings/` and indexes to SQLite + vectors. |
+| `oracle_stats` | Knowledge base statistics: doc counts by type, indexing status, vector DB health. |
+| `oracle_supersede` | Mark old doc as superseded by newer one. "Nothing is Deleted" — old preserved, just marked. |
 
 ## Session (2 tools)
 
 | Tool | Description |
 |------|-------------|
-| `muninn_handoff` | Write session context to `ψ/inbox/` for future sessions. |
-| `muninn_inbox` | List pending handoff files, sorted newest-first with previews. |
+| `oracle_handoff` | Write session context to `ψ/inbox/` for future sessions. |
+| `oracle_inbox` | List pending handoff files, sorted newest-first with previews. |
 
 ## Forum (4 tools)
 
 | Tool | Description |
 |------|-------------|
-| `muninn_thread` | Send message to a discussion thread. Creates new or continues existing. Oracle auto-responds. |
-| `muninn_threads` | List threads. Filter by status (pending/active/closed). |
-| `muninn_thread_read` | Read full message history from a thread. |
-| `muninn_thread_update` | Update thread status (close, reopen, mark answered). |
+| `oracle_thread` | Send message to a discussion thread. Creates new or continues existing. Oracle auto-responds. |
+| `oracle_threads` | List threads. Filter by status (pending/active/closed). |
+| `oracle_thread_read` | Read full message history from a thread. |
+| `oracle_thread_update` | Update thread status (close, reopen, mark answered). |
 
 ## Trace (6 tools)
 
 | Tool | Description |
 |------|-------------|
-| `muninn_trace` | Log a trace session with dig points (files, commits, issues). |
-| `muninn_trace_list` | List recent traces with optional filters. |
-| `muninn_trace_get` | Get full trace details including all dig points. |
-| `muninn_trace_link` | Link two traces as a chain (prev → next). Bidirectional. |
-| `muninn_trace_unlink` | Remove a link between traces in specified direction. |
-| `muninn_trace_chain` | Get full linked chain for a trace. |
+| `oracle_trace` | Log a trace session with dig points (files, commits, issues). |
+| `oracle_trace_list` | List recent traces with optional filters. |
+| `oracle_trace_get` | Get full trace details including all dig points. |
+| `oracle_trace_link` | Link two traces as a chain (prev → next). Bidirectional. |
+| `oracle_trace_unlink` | Remove a link between traces in specified direction. |
+| `oracle_trace_chain` | Get full linked chain for a trace. |
 
 ## Standalone (5 tools)
 
 | Tool | Description |
 |------|-------------|
-| `muninn_reflect` | Get a random principle or learning for reflection. |
-| `muninn_verify` | Verify integrity: compare `ψ/` files on disk vs DB index. Detect missing/orphaned docs. |
-| `muninn_schedule_add` | Add appointment to shared schedule (per-human, cross-project). |
-| `muninn_schedule_list` | List upcoming schedule entries. |
+| `oracle_reflect` | Get a random principle or learning for reflection. |
+| `oracle_verify` | Verify integrity: compare `ψ/` files on disk vs DB index. Detect missing/orphaned docs. |
+| `oracle_schedule_add` | Add appointment to shared schedule (per-human, cross-project). |
+| `oracle_schedule_list` | List upcoming schedule entries. |
 | `____IMPORTANT` | Meta-documentation tool — workflow guide shown in tool list. |
 
 ## Read-Only Mode
 
 When `ORACLE_READ_ONLY=true` or `--read-only`, write tools are disabled:
-- `muninn_learn`, `muninn_thread`, `muninn_thread_update`, `muninn_trace`, `muninn_supersede`, `muninn_handoff`
+- `oracle_learn`, `oracle_thread`, `oracle_thread_update`, `oracle_trace`, `oracle_supersede`, `oracle_handoff`
 
 ## Installation
 
@@ -109,4 +109,4 @@ The MCP server works without the indexer. Indexing is a separate concern:
 - HTTP server: `bun src/server.ts` (REST API + dashboard)
 - Indexer: `bun src/scripts/index-model.ts <model>` (populates DB, run separately)
 
-The MCP server only needs the SQLite database and vector store files. It does not need Ollama running unless you trigger a write tool (`muninn_learn`) that embeds new content.
+The MCP server only needs the SQLite database and vector store files. It does not need Ollama running unless you trigger a write tool (`oracle_learn`) that embeds new content.

--- a/ecosystem.oracle-stack.config.js
+++ b/ecosystem.oracle-stack.config.js
@@ -1,0 +1,69 @@
+// PM2 ecosystem for the local Oracle stack.
+// Usage:
+//   pm2 start ecosystem.oracle-stack.config.js
+//   pm2 restart oracle-backend
+//   pm2 logs oracle-backend --lines 50
+//   pm2 status
+//   pm2 save        # persist across reboots (one-time, after pm2 startup)
+//
+// Watch mode is on for dev — saves on file change.
+// Set NODE_ENV=production to disable watch.
+//
+// All paths assumed relative to the user's standard workspace; override via ARRA_REPO env.
+
+const ARRA_REPO = process.env.ARRA_REPO || '/Users/nat/Code/github.com/Soul-Brews-Studio/arra-oracle-v3';
+const UI_REPO = process.env.UI_REPO || '/Users/nat/Code/github.com/Soul-Brews-Studio/ui-oracle';
+
+const watch = process.env.NODE_ENV === 'production' ? false : true;
+
+module.exports = {
+  apps: [
+    {
+      name: 'oracle-backend',
+      cwd: ARRA_REPO,
+      script: 'bun',
+      args: 'src/server.ts',
+      env: {
+        ORACLE_PORT: '47778',
+      },
+      autorestart: true,
+      watch: watch ? ['src'] : false,
+      ignore_watch: ['node_modules', '*.log', '.git', 'dist', '*.test.ts'],
+      max_memory_restart: '1G',
+      time: true,
+    },
+
+    {
+      name: 'oracle-indexer',
+      cwd: ARRA_REPO,
+      script: 'bun',
+      args: 'src/indexer/daemon.ts',
+      env: {
+        INDEXER_PORT: '47779',
+      },
+      autorestart: true,
+      watch: false,
+      time: true,
+    },
+
+    {
+      name: 'oracle-reranker',
+      cwd: `${ARRA_REPO}/services/reranker-py`,
+      script: 'uv',
+      args: 'run uvicorn main:app --host 127.0.0.1 --port 8765',
+      autorestart: true,
+      watch: false,
+      time: true,
+    },
+
+    {
+      name: 'oracle-ui',
+      cwd: UI_REPO,
+      script: 'bun',
+      args: '--cwd apps/studio dev',
+      autorestart: true,
+      watch: false,
+      time: true,
+    },
+  ],
+};

--- a/src/__tests__/resolve-tool-name.test.ts
+++ b/src/__tests__/resolve-tool-name.test.ts
@@ -1,59 +1,91 @@
 import { describe, it, expect } from 'bun:test';
 import { resolveToolName } from '../index.ts';
 
-describe('resolveToolName — arra_* → muninn_* backward compat (PR #1172 aliases)', () => {
-  it('maps arra_search to muninn_search', () => {
-    expect(resolveToolName('arra_search')).toBe('muninn_search');
+describe('resolveToolName — 3-generation alias chain (arra_* | muninn_* → oracle_*)', () => {
+  describe('arra_* (original, pre-#1172)', () => {
+    it('maps every legacy arra_* tool to oracle_*', () => {
+      const pairs: Array<[string, string]> = [
+        ['arra_search', 'oracle_search'],
+        ['arra_read', 'oracle_read'],
+        ['arra_list', 'oracle_list'],
+        ['arra_stats', 'oracle_stats'],
+        ['arra_concepts', 'oracle_concepts'],
+        ['arra_learn', 'oracle_learn'],
+        ['arra_supersede', 'oracle_supersede'],
+        ['arra_handoff', 'oracle_handoff'],
+        ['arra_inbox', 'oracle_inbox'],
+        ['arra_thread', 'oracle_thread'],
+        ['arra_threads', 'oracle_threads'],
+        ['arra_thread_read', 'oracle_thread_read'],
+        ['arra_thread_update', 'oracle_thread_update'],
+        ['arra_trace', 'oracle_trace'],
+        ['arra_trace_list', 'oracle_trace_list'],
+        ['arra_trace_get', 'oracle_trace_get'],
+        ['arra_trace_link', 'oracle_trace_link'],
+        ['arra_trace_unlink', 'oracle_trace_unlink'],
+        ['arra_trace_chain', 'oracle_trace_chain'],
+      ];
+      for (const [old, neu] of pairs) {
+        expect(resolveToolName(old)).toBe(neu);
+      }
+    });
   });
 
-  it('maps arra_learn to muninn_learn', () => {
-    expect(resolveToolName('arra_learn')).toBe('muninn_learn');
+  describe('muninn_* (briefly canonical, #1172 → #1236)', () => {
+    it('maps every muninn_* tool to oracle_*', () => {
+      const pairs: Array<[string, string]> = [
+        ['muninn_search', 'oracle_search'],
+        ['muninn_read', 'oracle_read'],
+        ['muninn_list', 'oracle_list'],
+        ['muninn_stats', 'oracle_stats'],
+        ['muninn_concepts', 'oracle_concepts'],
+        ['muninn_learn', 'oracle_learn'],
+        ['muninn_supersede', 'oracle_supersede'],
+        ['muninn_handoff', 'oracle_handoff'],
+        ['muninn_inbox', 'oracle_inbox'],
+        ['muninn_thread', 'oracle_thread'],
+        ['muninn_threads', 'oracle_threads'],
+        ['muninn_thread_read', 'oracle_thread_read'],
+        ['muninn_thread_update', 'oracle_thread_update'],
+        ['muninn_trace', 'oracle_trace'],
+        ['muninn_trace_list', 'oracle_trace_list'],
+        ['muninn_trace_get', 'oracle_trace_get'],
+        ['muninn_trace_link', 'oracle_trace_link'],
+        ['muninn_trace_unlink', 'oracle_trace_unlink'],
+        ['muninn_trace_chain', 'oracle_trace_chain'],
+      ];
+      for (const [old, neu] of pairs) {
+        expect(resolveToolName(old)).toBe(neu);
+      }
+    });
   });
 
-  it('maps every legacy arra_* tool we shipped before the rename', () => {
-    const pairs: Array<[string, string]> = [
-      ['arra_search', 'muninn_search'],
-      ['arra_read', 'muninn_read'],
-      ['arra_list', 'muninn_list'],
-      ['arra_stats', 'muninn_stats'],
-      ['arra_concepts', 'muninn_concepts'],
-      ['arra_learn', 'muninn_learn'],
-      ['arra_supersede', 'muninn_supersede'],
-      ['arra_handoff', 'muninn_handoff'],
-      ['arra_inbox', 'muninn_inbox'],
-      ['arra_thread', 'muninn_thread'],
-      ['arra_threads', 'muninn_threads'],
-      ['arra_thread_read', 'muninn_thread_read'],
-      ['arra_thread_update', 'muninn_thread_update'],
-      ['arra_trace', 'muninn_trace'],
-      ['arra_trace_list', 'muninn_trace_list'],
-      ['arra_trace_get', 'muninn_trace_get'],
-      ['arra_trace_link', 'muninn_trace_link'],
-      ['arra_trace_unlink', 'muninn_trace_unlink'],
-      ['arra_trace_chain', 'muninn_trace_chain'],
-    ];
-    for (const [old, neu] of pairs) {
-      expect(resolveToolName(old)).toBe(neu);
-    }
+  describe('oracle_* (canonical, advertised)', () => {
+    it('passes oracle_* names through unchanged', () => {
+      expect(resolveToolName('oracle_search')).toBe('oracle_search');
+      expect(resolveToolName('oracle_trace_chain')).toBe('oracle_trace_chain');
+    });
   });
 
-  it('passes muninn_* names through unchanged', () => {
-    expect(resolveToolName('muninn_search')).toBe('muninn_search');
-    expect(resolveToolName('muninn_trace_chain')).toBe('muninn_trace_chain');
-  });
+  describe('passthroughs (no prefix strip)', () => {
+    it('leaves unrelated names alone (no false rewrites)', () => {
+      expect(resolveToolName('search')).toBe('search');
+      expect(resolveToolName('not_arra_thing')).toBe('not_arra_thing');
+      expect(resolveToolName('not_muninn_thing')).toBe('not_muninn_thing');
+      expect(resolveToolName('')).toBe('');
+    });
 
-  it('leaves unrelated names alone (no false rewrites)', () => {
-    // Tools without the arra_ prefix should not be touched, even if they
-    // contain "arra" elsewhere.
-    expect(resolveToolName('search')).toBe('search');
-    expect(resolveToolName('not_arra_thing')).toBe('not_arra_thing');
-    expect(resolveToolName('')).toBe('');
-  });
+    it('only strips the LEADING legacy prefix — preserves the rest of the name', () => {
+      expect(resolveToolName('arra_new_thing')).toBe('oracle_new_thing');
+      expect(resolveToolName('muninn_new_thing')).toBe('oracle_new_thing');
+      expect(resolveToolName('arra_a_b_c_d')).toBe('oracle_a_b_c_d');
+      expect(resolveToolName('muninn_a_b_c_d')).toBe('oracle_a_b_c_d');
+    });
 
-  it('only strips the leading "arra_" prefix — preserves the rest of the name', () => {
-    // Hypothetical future tool: arra_new_thing → muninn_new_thing
-    expect(resolveToolName('arra_new_thing')).toBe('muninn_new_thing');
-    // Underscore-heavy name
-    expect(resolveToolName('arra_a_b_c_d')).toBe('muninn_a_b_c_d');
+    it('does not double-strip when a name contains both prefixes', () => {
+      // Highly unlikely real-world name, but verify deterministic behavior:
+      // first prefix in ALIAS_PREFIXES wins (arra_ comes before muninn_).
+      expect(resolveToolName('arra_muninn_x')).toBe('oracle_muninn_x');
+    });
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,7 +35,7 @@ export const DB_PATH = process.env.ORACLE_DB_PATH || path.join(ORACLE_DATA_DIR, 
 //   4. ORACLE_DATA_DIR — default (will be empty initially)
 //
 // Data dir wins over project root so that accidental ψ/ folders in a source
-// checkout (e.g. from muninn_learn writing with no vault configured) don't
+// checkout (e.g. from oracle_learn writing with no vault configured) don't
 // override the real indexed data at ~/.arra-oracle-v2/ψ/.
 export const REPO_ROOT = process.env.ORACLE_REPO_ROOT ||
   (fs.existsSync(path.join(ORACLE_DATA_DIR, '\u03c8')) ? ORACLE_DATA_DIR :

--- a/src/config/__tests__/tool-groups.test.ts
+++ b/src/config/__tests__/tool-groups.test.ts
@@ -34,59 +34,59 @@ describe('tool-groups', () => {
       forum: true, trace: false,
     };
     const disabled = getDisabledTools(config);
-    expect(disabled.has('muninn_trace')).toBe(true);
-    expect(disabled.has('muninn_trace_list')).toBe(true);
-    expect(disabled.has('muninn_search')).toBe(false);
-    expect(disabled.has('muninn_learn')).toBe(false);
+    expect(disabled.has('oracle_trace')).toBe(true);
+    expect(disabled.has('oracle_trace_list')).toBe(true);
+    expect(disabled.has('oracle_search')).toBe(false);
+    expect(disabled.has('oracle_learn')).toBe(false);
   });
 
   it('disabled_tools adds per-tool blocks on top of group config', () => {
     const config: ToolGroupConfig = {
       search: true, knowledge: true, session: true,
       forum: true, trace: true,
-      disabled_tools: ['muninn_supersede', 'muninn_thread_update'],
+      disabled_tools: ['oracle_supersede', 'oracle_thread_update'],
     };
     const disabled = getDisabledTools(config);
-    expect(disabled.has('muninn_supersede')).toBe(true);
-    expect(disabled.has('muninn_thread_update')).toBe(true);
+    expect(disabled.has('oracle_supersede')).toBe(true);
+    expect(disabled.has('oracle_thread_update')).toBe(true);
     // Sibling tools in the same group stay enabled
-    expect(disabled.has('muninn_learn')).toBe(false);
-    expect(disabled.has('muninn_thread')).toBe(false);
+    expect(disabled.has('oracle_learn')).toBe(false);
+    expect(disabled.has('oracle_thread')).toBe(false);
   });
 
   it('enabled_tools whitelist overrides group-disabled', () => {
     const config: ToolGroupConfig = {
       search: true, knowledge: true, session: true,
       forum: false, trace: true,
-      enabled_tools: ['muninn_thread_read'],
+      enabled_tools: ['oracle_thread_read'],
     };
     const disabled = getDisabledTools(config);
     // Whole forum group disabled, except the whitelisted one
-    expect(disabled.has('muninn_thread')).toBe(true);
-    expect(disabled.has('muninn_thread_update')).toBe(true);
-    expect(disabled.has('muninn_thread_read')).toBe(false);
+    expect(disabled.has('oracle_thread')).toBe(true);
+    expect(disabled.has('oracle_thread_update')).toBe(true);
+    expect(disabled.has('oracle_thread_read')).toBe(false);
   });
 
   it('enabled_tools whitelist overrides a per-tool block (whitelist wins last)', () => {
     const config: ToolGroupConfig = {
       search: true, knowledge: true, session: true,
       forum: true, trace: true,
-      disabled_tools: ['muninn_supersede'],
-      enabled_tools: ['muninn_supersede'],
+      disabled_tools: ['oracle_supersede'],
+      enabled_tools: ['oracle_supersede'],
     };
-    expect(getDisabledTools(config).has('muninn_supersede')).toBe(false);
+    expect(getDisabledTools(config).has('oracle_supersede')).toBe(false);
   });
 
   it('ignores unknown tool names in disabled_tools and enabled_tools', () => {
     const config: ToolGroupConfig = {
       search: true, knowledge: true, session: true,
       forum: true, trace: true,
-      disabled_tools: ['typo_search', 'muninn_search'],
+      disabled_tools: ['typo_search', 'oracle_search'],
       enabled_tools: ['also_typo'],
     };
     const disabled = getDisabledTools(config);
     // Real one applied
-    expect(disabled.has('muninn_search')).toBe(true);
+    expect(disabled.has('oracle_search')).toBe(true);
     // Typos didn't leak in
     expect(disabled.has('typo_search')).toBe(false);
     expect(disabled.has('also_typo')).toBe(false);
@@ -101,10 +101,10 @@ describe('tool-groups', () => {
     expect(config.trace).toBe(true);
   });
 
-  it('all tool names follow muninn_ prefix convention', () => {
+  it('all tool names follow oracle_ prefix convention', () => {
     for (const tools of Object.values(TOOL_GROUPS)) {
       for (const tool of tools) {
-        expect(tool).toMatch(/^muninn_/);
+        expect(tool).toMatch(/^oracle_/);
       }
     }
   });

--- a/src/config/tool-groups.ts
+++ b/src/config/tool-groups.ts
@@ -13,11 +13,11 @@ import path from 'path';
 import { ORACLE_DATA_DIR } from '../config.ts';
 
 export const TOOL_GROUPS = {
-  search: ['muninn_search', 'muninn_read', 'muninn_list', 'muninn_concepts'],
-  knowledge: ['muninn_learn', 'muninn_stats', 'muninn_supersede'],
-  session: ['muninn_handoff', 'muninn_inbox'],
-  forum: ['muninn_thread', 'muninn_threads', 'muninn_thread_read', 'muninn_thread_update'],
-  trace: ['muninn_trace', 'muninn_trace_list', 'muninn_trace_get', 'muninn_trace_link', 'muninn_trace_unlink', 'muninn_trace_chain'],
+  search: ['oracle_search', 'oracle_read', 'oracle_list', 'oracle_concepts'],
+  knowledge: ['oracle_learn', 'oracle_stats', 'oracle_supersede'],
+  session: ['oracle_handoff', 'oracle_inbox'],
+  forum: ['oracle_thread', 'oracle_threads', 'oracle_thread_read', 'oracle_thread_update'],
+  trace: ['oracle_trace', 'oracle_trace_list', 'oracle_trace_get', 'oracle_trace_link', 'oracle_trace_unlink', 'oracle_trace_chain'],
 } as const;
 
 export type ToolGroupName = keyof typeof TOOL_GROUPS;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -24,7 +24,7 @@ export const oracleDocuments = sqliteTable('oracle_documents', {
   // Provenance tracking (Issue #22)
   origin: text('origin'),                   // 'mother' | 'arthur' | 'volt' | 'human' | null (legacy)
   project: text('project'),                 // ghq-style: 'github.com/laris-co/arra-oracle'
-  createdBy: text('created_by'),            // 'indexer' | 'muninn_learn' | 'manual'
+  createdBy: text('created_by'),            // 'indexer' | 'oracle_learn' | 'manual'
 }, (table) => [
   index('idx_source').on(table.sourceFile),
   index('idx_type').on(table.type),

--- a/src/drizzle-migration.test.ts
+++ b/src/drizzle-migration.test.ts
@@ -209,7 +209,7 @@ describe('handleLearn - INSERT oracle_documents', () => {
       now,
       null,
       'github.com/test/repo',
-      'muninn_learn'
+      'oracle_learn'
     );
 
     const result = db.prepare('SELECT * FROM oracle_documents WHERE id = ?').get(id) as any;
@@ -218,7 +218,7 @@ describe('handleLearn - INSERT oracle_documents', () => {
     expect(result.type).toBe('learning');
     expect(result.source_file).toBe('ψ/memory/learnings/test-pattern.md');
     expect(JSON.parse(result.concepts)).toEqual(['test', 'pattern']);
-    expect(result.created_by).toBe('muninn_learn');
+    expect(result.created_by).toBe('oracle_learn');
     expect(result.project).toBe('github.com/test/repo');
   });
 
@@ -229,7 +229,7 @@ describe('handleLearn - INSERT oracle_documents', () => {
     db.prepare(`
       INSERT INTO oracle_documents (id, type, source_file, concepts, created_at, updated_at, indexed_at, origin, project, created_by)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(id, 'learning', 'test.md', '[]', now, now, now, null, null, 'muninn_learn');
+    `).run(id, 'learning', 'test.md', '[]', now, now, now, null, null, 'oracle_learn');
 
     const result = db.prepare('SELECT * FROM oracle_documents WHERE id = ?').get(id) as any;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,25 +65,33 @@ import type {
 } from './trace/types.ts';
 
 /**
- * Backward-compat alias: callers using the pre-#1172 `arra_*` tool names
- * are transparently mapped to the new `muninn_*` names. Tool LIST is
- * unchanged — only muninn_* is advertised — but old callers keep working.
+ * Backward-compat alias chain (3 generations):
+ *   arra_*    (original, pre-#1172)         ─┐
+ *   muninn_*  (#1172, briefly canonical)   ─┼──►  oracle_*  (current canonical)
+ *   oracle_*  (current canonical, advertised in ListTools)
+ *
+ * Tool LIST is unchanged — only oracle_* is advertised — but BOTH legacy
+ * prefixes keep working invisibly. The all-digit identifier prefix-strip
+ * is the same shape for both, so a single ALIAS_PREFIXES iteration covers
+ * any future rename without code changes.
  * Exported for unit tests.
  */
+const ALIAS_PREFIXES = ['arra_', 'muninn_'] as const;
 export function resolveToolName(name: string): string {
-  return name.startsWith('arra_')
-    ? 'muninn_' + name.slice('arra_'.length)
-    : name;
+  for (const p of ALIAS_PREFIXES) {
+    if (name.startsWith(p)) return 'oracle_' + name.slice(p.length);
+  }
+  return name;
 }
 
 // Write tools that should be disabled in read-only mode
 const WRITE_TOOLS = [
-  'muninn_learn',
-  'muninn_thread',
-  'muninn_thread_update',
-  'muninn_trace',
-  'muninn_supersede',
-  'muninn_handoff',
+  'oracle_learn',
+  'oracle_thread',
+  'oracle_thread_update',
+  'oracle_trace',
+  'oracle_supersede',
+  'oracle_handoff',
 ];
 
 class OracleMCPServer {
@@ -223,7 +231,7 @@ class OracleMCPServer {
         // Meta-documentation tool
         {
           name: '____IMPORTANT',
-          description: `ORACLE WORKFLOW GUIDE (v${this.version}):\n\n1. SEARCH & DISCOVER\n   muninn_search(query) → Find knowledge by keywords/vectors\n   muninn_read(file/id) → Read full document content\n   muninn_list() → Browse all documents\n   muninn_concepts() → See topic coverage\n\n2. LEARN & REMEMBER\n   muninn_learn(pattern) → Add new patterns/learnings\n   muninn_thread(message) → Multi-turn discussions\n   ⚠️ BEFORE adding: search for similar topics first!\n   If updating old info → use muninn_supersede(oldId, newId)\n\n3. TRACE & DISTILL\n   muninn_trace(query) → Log discovery sessions with dig points\n   muninn_trace_list() → Find past traces\n   muninn_trace_get(id) → Explore dig points (files, commits, issues)\n   muninn_trace_link(prevId, nextId) → Chain related traces together\n   muninn_trace_chain(id) → View the full linked chain\n\n4. HANDOFF & INBOX\n   muninn_handoff(content) → Save session context for next session\n   muninn_inbox() → List pending handoffs\n\n5. SUPERSEDE (when info changes)\n   muninn_supersede(oldId, newId, reason) → Mark old doc as outdated\n   "Nothing is Deleted" — old preserved, just marked superseded\n\nPhilosophy: "Nothing is Deleted" — All interactions logged.`,
+          description: `ORACLE WORKFLOW GUIDE (v${this.version}):\n\n1. SEARCH & DISCOVER\n   oracle_search(query) → Find knowledge by keywords/vectors\n   oracle_read(file/id) → Read full document content\n   oracle_list() → Browse all documents\n   oracle_concepts() → See topic coverage\n\n2. LEARN & REMEMBER\n   oracle_learn(pattern) → Add new patterns/learnings\n   oracle_thread(message) → Multi-turn discussions\n   ⚠️ BEFORE adding: search for similar topics first!\n   If updating old info → use oracle_supersede(oldId, newId)\n\n3. TRACE & DISTILL\n   oracle_trace(query) → Log discovery sessions with dig points\n   oracle_trace_list() → Find past traces\n   oracle_trace_get(id) → Explore dig points (files, commits, issues)\n   oracle_trace_link(prevId, nextId) → Chain related traces together\n   oracle_trace_chain(id) → View the full linked chain\n\n4. HANDOFF & INBOX\n   oracle_handoff(content) → Save session context for next session\n   oracle_inbox() → List pending handoffs\n\n5. SUPERSEDE (when info changes)\n   oracle_supersede(oldId, newId, reason) → Mark old doc as outdated\n   "Nothing is Deleted" — old preserved, just marked superseded\n\nPhilosophy: "Nothing is Deleted" — All interactions logged.`,
           inputSchema: { type: 'object', properties: {} }
         },
         // Core tools (from src/tools/)
@@ -255,7 +263,7 @@ class OracleMCPServer {
     // Handle tool calls — route to extracted handlers
     // ================================================================
     this.server.setRequestHandler(CallToolRequestSchema, async (request): Promise<any> => {
-      // Backward compat: arra_* → muninn_* aliasing (PR #1172 renamed the
+      // Backward compat: arra_* → oracle_* aliasing (PR #1172 renamed the
       // tools; old callers keep working). See resolveToolName().
       const toolName = resolveToolName(request.params.name);
 
@@ -284,46 +292,46 @@ class OracleMCPServer {
       try {
         switch (toolName) {
           // Core tools (delegated to src/tools/)
-          case 'muninn_search':
+          case 'oracle_search':
             return await handleSearch(ctx, request.params.arguments as unknown as OracleSearchInput);
-          case 'muninn_read':
+          case 'oracle_read':
             return await handleRead(ctx, request.params.arguments as unknown as OracleReadInput);
-          case 'muninn_learn':
+          case 'oracle_learn':
             return await handleLearn(ctx, request.params.arguments as unknown as OracleLearnInput);
-          case 'muninn_list':
+          case 'oracle_list':
             return await handleList(ctx, request.params.arguments as unknown as OracleListInput);
-          case 'muninn_stats':
+          case 'oracle_stats':
             return await handleStats(ctx, request.params.arguments as unknown as OracleStatsInput);
-          case 'muninn_concepts':
+          case 'oracle_concepts':
             return await handleConcepts(ctx, request.params.arguments as unknown as OracleConceptsInput);
-          case 'muninn_supersede':
+          case 'oracle_supersede':
             return await handleSupersede(ctx, request.params.arguments as unknown as OracleSupersededInput);
-          case 'muninn_handoff':
+          case 'oracle_handoff':
             return await handleHandoff(ctx, request.params.arguments as unknown as OracleHandoffInput);
-          case 'muninn_inbox':
+          case 'oracle_inbox':
             return await handleInbox(ctx, request.params.arguments as unknown as OracleInboxInput);
           // Forum tools (delegated to src/tools/forum.ts)
-          case 'muninn_thread':
+          case 'oracle_thread':
             return await handleThread(request.params.arguments as unknown as OracleThreadInput);
-          case 'muninn_threads':
+          case 'oracle_threads':
             return await handleThreads(request.params.arguments as unknown as OracleThreadsInput);
-          case 'muninn_thread_read':
+          case 'oracle_thread_read':
             return await handleThreadRead(request.params.arguments as unknown as OracleThreadReadInput);
-          case 'muninn_thread_update':
+          case 'oracle_thread_update':
             return await handleThreadUpdate(request.params.arguments as unknown as OracleThreadUpdateInput);
 
           // Trace tools (delegated to src/tools/trace.ts)
-          case 'muninn_trace':
+          case 'oracle_trace':
             return await handleTrace(request.params.arguments as unknown as CreateTraceInput);
-          case 'muninn_trace_list':
+          case 'oracle_trace_list':
             return await handleTraceList(request.params.arguments as unknown as ListTracesInput);
-          case 'muninn_trace_get':
+          case 'oracle_trace_get':
             return await handleTraceGet(request.params.arguments as unknown as GetTraceInput);
-          case 'muninn_trace_link':
+          case 'oracle_trace_link':
             return await handleTraceLink(request.params.arguments as unknown as { prevTraceId: string; nextTraceId: string });
-          case 'muninn_trace_unlink':
+          case 'oracle_trace_unlink':
             return await handleTraceUnlink(request.params.arguments as unknown as { traceId: string; direction: 'prev' | 'next' });
-          case 'muninn_trace_chain':
+          case 'oracle_trace_chain':
             return await handleTraceChain(request.params.arguments as unknown as { traceId: string });
 
           case '____IMPORTANT':

--- a/src/indexer-preservation.test.ts
+++ b/src/indexer-preservation.test.ts
@@ -1,10 +1,10 @@
 /**
  * Indexer Preservation Tests
  *
- * Tests that muninn_learn documents are preserved during re-indexing.
+ * Tests that oracle_learn documents are preserved during re-indexing.
  * This is critical for cross-repo knowledge sharing.
  *
- * Philosophy: "Nothing is Deleted" - muninn_learn docs have no local files
+ * Philosophy: "Nothing is Deleted" - oracle_learn docs have no local files
  * and must not be wiped during indexer runs.
  */
 
@@ -146,14 +146,14 @@ function insertTestDoc(doc: {
 // Preservation Tests
 // ============================================================================
 
-describe('Indexer Preservation - muninn_learn documents', () => {
-  it('should preserve muninn_learn documents during re-index', () => {
-    // Insert muninn_learn doc from another repo
+describe('Indexer Preservation - oracle_learn documents', () => {
+  it('should preserve oracle_learn documents during re-index', () => {
+    // Insert oracle_learn doc from another repo
     insertTestDoc({
       id: 'test-oracle-learn-1',
       type: 'learning',
       sourceFile: 'ψ/memory/learnings/test.md',
-      createdBy: 'muninn_learn',
+      createdBy: 'oracle_learn',
       project: 'github.com/other/repo',
     });
 
@@ -169,11 +169,11 @@ describe('Indexer Preservation - muninn_learn documents', () => {
     // Simulate indexer run for current repo
     const deleted = simulateSmartDeletion('github.com/current/repo');
 
-    // Verify muninn_learn doc is preserved
+    // Verify oracle_learn doc is preserved
     const preserved = db.select().from(oracleDocuments)
       .where(eq(oracleDocuments.id, 'test-oracle-learn-1')).get();
     expect(preserved).toBeDefined();
-    expect(preserved?.createdBy).toBe('muninn_learn');
+    expect(preserved?.createdBy).toBe('oracle_learn');
 
     // Verify indexer doc was deleted
     const notPreserved = db.select().from(oracleDocuments)
@@ -184,13 +184,13 @@ describe('Indexer Preservation - muninn_learn documents', () => {
     expect(deleted).not.toContain('test-oracle-learn-1');
   });
 
-  it('should preserve muninn_learn docs from different projects', () => {
-    // Insert muninn_learn docs from various projects
+  it('should preserve oracle_learn docs from different projects', () => {
+    // Insert oracle_learn docs from various projects
     insertTestDoc({
       id: 'learn-repo-a',
       type: 'learning',
       sourceFile: 'ψ/memory/learnings/a.md',
-      createdBy: 'muninn_learn',
+      createdBy: 'oracle_learn',
       project: 'github.com/team/repo-a',
     });
 
@@ -198,14 +198,14 @@ describe('Indexer Preservation - muninn_learn documents', () => {
       id: 'learn-repo-b',
       type: 'learning',
       sourceFile: 'ψ/memory/learnings/b.md',
-      createdBy: 'muninn_learn',
+      createdBy: 'oracle_learn',
       project: 'github.com/team/repo-b',
     });
 
     // Simulate indexer run for repo-a
     simulateSmartDeletion('github.com/team/repo-a');
 
-    // Both muninn_learn docs should be preserved
+    // Both oracle_learn docs should be preserved
     const docA = db.select().from(oracleDocuments)
       .where(eq(oracleDocuments.id, 'learn-repo-a')).get();
     const docB = db.select().from(oracleDocuments)
@@ -280,20 +280,20 @@ describe('Indexer Preservation - project isolation', () => {
     expect(deleted).toContain('project-specific-doc');
   });
 
-  it('should preserve universal muninn_learn docs', () => {
-    // Insert universal muninn_learn doc (created from a context without project detection)
+  it('should preserve universal oracle_learn docs', () => {
+    // Insert universal oracle_learn doc (created from a context without project detection)
     insertTestDoc({
       id: 'universal-learn-doc',
       type: 'learning',
       sourceFile: 'ψ/memory/learnings/universal.md',
-      createdBy: 'muninn_learn',
+      createdBy: 'oracle_learn',
       project: null,
     });
 
     // Simulate indexer run
     const deleted = simulateSmartDeletion('github.com/any/repo');
 
-    // Universal muninn_learn should be preserved
+    // Universal oracle_learn should be preserved
     const doc = db.select().from(oracleDocuments)
       .where(eq(oracleDocuments.id, 'universal-learn-doc')).get();
     expect(doc).toBeDefined();
@@ -352,12 +352,12 @@ describe('Indexer Preservation - FTS sync', () => {
   });
 
   it('should preserve FTS entries for preserved documents', () => {
-    // Insert muninn_learn doc
+    // Insert oracle_learn doc
     insertTestDoc({
       id: 'fts-preserved-doc',
       type: 'learning',
       sourceFile: 'ψ/memory/learnings/preserved.md',
-      createdBy: 'muninn_learn',
+      createdBy: 'oracle_learn',
       project: 'github.com/other/repo',
       content: 'This content should remain searchable',
     });
@@ -381,13 +381,13 @@ describe('Indexer Preservation - edge cases', () => {
     expect(deleted).toEqual([]);
   });
 
-  it('should handle database with only muninn_learn docs', () => {
-    // Insert only muninn_learn docs
+  it('should handle database with only oracle_learn docs', () => {
+    // Insert only oracle_learn docs
     insertTestDoc({
       id: 'only-learn-1',
       type: 'learning',
       sourceFile: 'ψ/memory/learnings/1.md',
-      createdBy: 'muninn_learn',
+      createdBy: 'oracle_learn',
       project: 'github.com/repo/1',
     });
 
@@ -395,7 +395,7 @@ describe('Indexer Preservation - edge cases', () => {
       id: 'only-learn-2',
       type: 'learning',
       sourceFile: 'ψ/memory/learnings/2.md',
-      createdBy: 'muninn_learn',
+      createdBy: 'oracle_learn',
       project: 'github.com/repo/2',
     });
 
@@ -422,7 +422,7 @@ describe('Indexer Preservation - edge cases', () => {
       id: 'oracle-learn-doc',
       type: 'learning',
       sourceFile: 'ψ/memory/learnings/learn.md',
-      createdBy: 'muninn_learn',
+      createdBy: 'oracle_learn',
       project: 'github.com/current/repo',
     });
 

--- a/src/indexer/daemon.ts
+++ b/src/indexer/daemon.ts
@@ -32,7 +32,7 @@ export async function startDaemon(): Promise<void> {
   const eventBus = makeEventBus<WorkerEvent>();
   let shuttingDown = false;
 
-  // Resolve doc text via the FTS5 mirror table — same content muninn_learn writes.
+  // Resolve doc text via the FTS5 mirror table — same content oracle_learn writes.
   const getDocText = (docId: string): string | null => {
     const row = db
       .query<{ content: string }, [string]>('SELECT content FROM oracle_fts WHERE id = ?')

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -114,7 +114,7 @@ export class OracleIndexer {
       );
     }
 
-    console.log(`Smart delete: ${idsToDelete.length} stale docs (preserving muninn_learn)`);
+    console.log(`Smart delete: ${idsToDelete.length} stale docs (preserving oracle_learn)`);
 
     if (idsToDelete.length > 0) {
       this.db.delete(oracleDocuments).where(inArray(oracleDocuments.id, idsToDelete)).run();

--- a/src/indexer/jobs.ts
+++ b/src/indexer/jobs.ts
@@ -18,7 +18,7 @@ import type Database from 'bun:sqlite';
 
 export interface EnqueueOptions {
   docId: string;
-  /** If omitted → enqueue for ALL models in the registry (typical muninn_learn case). */
+  /** If omitted → enqueue for ALL models in the registry (typical oracle_learn case). */
   modelKey?: string;
   /** Registry of model_key → collection. Caller passes this in (no global state). */
   models: Record<string, { collection: string }>;

--- a/src/integration/mcp.test.ts
+++ b/src/integration/mcp.test.ts
@@ -141,9 +141,9 @@ describe.skipIf(!MCP_TEST_ENABLED)("MCP Integration", () => {
 
       // Check for core tools
       const toolNames = result.tools.map((t) => t.name);
-      expect(toolNames).toContain("muninn_search");
-      expect(toolNames).toContain("muninn_list");
-      expect(toolNames).toContain("muninn_stats");
+      expect(toolNames).toContain("oracle_search");
+      expect(toolNames).toContain("oracle_list");
+      expect(toolNames).toContain("oracle_stats");
     });
   });
 
@@ -151,8 +151,8 @@ describe.skipIf(!MCP_TEST_ENABLED)("MCP Integration", () => {
   // Read-Only Tools
   // ===================
   describe("Read-Only Tools", () => {
-    test("muninn_search returns results", async () => {
-      const result = await callTool("muninn_search", {
+    test("oracle_search returns results", async () => {
+      const result = await callTool("oracle_search", {
         query: "oracle",
         limit: 5,
       });
@@ -161,29 +161,29 @@ describe.skipIf(!MCP_TEST_ENABLED)("MCP Integration", () => {
       expect(typeof result).toBe("object");
     });
 
-    test("muninn_list returns documents", async () => {
-      const result = await callTool("muninn_list", {
+    test("oracle_list returns documents", async () => {
+      const result = await callTool("oracle_list", {
         limit: 10,
       });
 
       expect(result).toBeDefined();
     });
 
-    test("muninn_stats returns statistics", async () => {
-      const result = await callTool("muninn_stats", {});
+    test("oracle_stats returns statistics", async () => {
+      const result = await callTool("oracle_stats", {});
       expect(result).toBeDefined();
     });
 
-    test("muninn_concepts returns concept list", async () => {
-      const result = await callTool("muninn_concepts", {
+    test("oracle_concepts returns concept list", async () => {
+      const result = await callTool("oracle_concepts", {
         limit: 20,
       });
 
       expect(result).toBeDefined();
     });
 
-    test("muninn_reflect returns random wisdom", async () => {
-      const result = await callTool("muninn_reflect", {});
+    test("oracle_reflect returns random wisdom", async () => {
+      const result = await callTool("oracle_reflect", {});
       expect(result).toBeDefined();
     });
   });
@@ -192,16 +192,16 @@ describe.skipIf(!MCP_TEST_ENABLED)("MCP Integration", () => {
   // Thread Tools
   // ===================
   describe("Thread Tools", () => {
-    test("muninn_threads lists threads", async () => {
-      const result = await callTool("muninn_threads", {
+    test("oracle_threads lists threads", async () => {
+      const result = await callTool("oracle_threads", {
         limit: 10,
       });
 
       expect(result).toBeDefined();
     });
 
-    test("muninn_threads with status filter", async () => {
-      const result = await callTool("muninn_threads", {
+    test("oracle_threads with status filter", async () => {
+      const result = await callTool("oracle_threads", {
         status: "active",
         limit: 5,
       });
@@ -214,8 +214,8 @@ describe.skipIf(!MCP_TEST_ENABLED)("MCP Integration", () => {
   // Trace Tools
   // ===================
   describe("Trace Tools", () => {
-    test("muninn_trace_list returns traces", async () => {
-      const result = await callTool("muninn_trace_list", {
+    test("oracle_trace_list returns traces", async () => {
+      const result = await callTool("oracle_trace_list", {
         limit: 10,
       });
 
@@ -238,8 +238,8 @@ describe.skipIf(!MCP_TEST_ENABLED)("MCP Integration", () => {
 
     test("handles missing required params", async () => {
       try {
-        // muninn_search requires 'query' param
-        await callTool("muninn_search", {});
+        // oracle_search requires 'query' param
+        await callTool("oracle_search", {});
         // May or may not throw depending on implementation
       } catch (error) {
         expect(error).toBeDefined();

--- a/src/scripts/fix-oracle-learn-project.ts
+++ b/src/scripts/fix-oracle-learn-project.ts
@@ -1,5 +1,5 @@
 /**
- * Fix missing project field for muninn_learn documents
+ * Fix missing project field for oracle_learn documents
  * Uses Drizzle ORM - not direct SQL!
  */
 
@@ -10,7 +10,7 @@ import path from 'path';
 import fs from 'fs';
 import { REPO_ROOT } from '../config.ts';
 
-// Find all muninn_learn docs without project using Drizzle
+// Find all oracle_learn docs without project using Drizzle
 const docs = db.select({
   id: oracleDocuments.id,
   sourceFile: oracleDocuments.sourceFile
@@ -18,13 +18,13 @@ const docs = db.select({
   .from(oracleDocuments)
   .where(
     and(
-      eq(oracleDocuments.createdBy, 'muninn_learn'),
+      eq(oracleDocuments.createdBy, 'oracle_learn'),
       or(isNull(oracleDocuments.project), eq(oracleDocuments.project, ''))
     )
   )
   .all();
 
-console.log(`Found ${docs.length} muninn_learn docs without project`);
+console.log(`Found ${docs.length} oracle_learn docs without project`);
 
 let fixed = 0;
 let fixedFromFts = 0;
@@ -79,12 +79,12 @@ console.log(`\nDone: ${fixed} fixed (${fixedFromFts} from FTS), ${failed} could 
 /**
  * Extract project from source field in frontmatter
  * Handles formats:
- * - "muninn_learn from github.com/owner/repo"
+ * - "oracle_learn from github.com/owner/repo"
  * - "rrr: org/repo" or "rrr: Owner/Repo"
  * - "source: github.com/owner/repo"
  */
 function extractProjectFromSource(content: string): string | null {
-  // Try "muninn_learn from github.com/owner/repo"
+  // Try "oracle_learn from github.com/owner/repo"
   const oracleLearnMatch = content.match(/from\s+(github\.com\/[^\/\s]+\/[^\/\s]+)/);
   if (oracleLearnMatch) return oracleLearnMatch[1];
 

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -731,7 +731,7 @@ export function persistLearningDoc(opts: {
     indexedAt: now.getTime(),
     origin: opts.origin || null,
     project: opts.project || null,
-    createdBy: opts.createdBy || 'muninn_learn',
+    createdBy: opts.createdBy || 'oracle_learn',
   }).run();
 
   // FTS5 has no unique constraint on id — delete-then-insert to be idempotent.
@@ -787,7 +787,7 @@ export function handleLearn(
     source,
     origin,
     project: resolvedProject,
-    createdBy: 'muninn_learn',
+    createdBy: 'oracle_learn',
   });
 
   return { success: true, file, id };
@@ -796,7 +796,7 @@ export function handleLearn(
 /**
  * Persist a session summary as a learning with concepts
  * ["session-summary", "session-<id>", "oracle-<name>"].
- * Written to ψ/memory/session-summaries/<session-id>.md so `muninn_search` surfaces it.
+ * Written to ψ/memory/session-summaries/<session-id>.md so `oracle_search` surfaces it.
  */
 export function handleSessionSummary(
   sessionId: string,

--- a/src/tools/__tests__/learn.test.ts
+++ b/src/tools/__tests__/learn.test.ts
@@ -55,8 +55,8 @@ describe('extractProjectFromSource', () => {
     expect(extractProjectFromSource('')).toBeNull();
   });
 
-  it('should extract from "muninn_learn from github.com/owner/repo" format', () => {
-    expect(extractProjectFromSource('muninn_learn from github.com/owner/repo session 42'))
+  it('should extract from "oracle_learn from github.com/owner/repo" format', () => {
+    expect(extractProjectFromSource('oracle_learn from github.com/owner/repo session 42'))
       .toBe('github.com/owner/repo');
   });
 

--- a/src/tools/concepts.ts
+++ b/src/tools/concepts.ts
@@ -9,7 +9,7 @@ import { oracleDocuments } from '../db/schema.ts';
 import type { ToolContext, ToolResponse, OracleConceptsInput } from './types.ts';
 
 export const conceptsToolDef = {
-  name: 'muninn_concepts',
+  name: 'oracle_concepts',
   description: 'List all concept tags in the Oracle knowledge base with document counts. Useful for discovering what topics are covered and filtering searches.',
   inputSchema: {
     type: 'object',

--- a/src/tools/forum.ts
+++ b/src/tools/forum.ts
@@ -54,7 +54,7 @@ export interface OracleThreadUpdateInput {
 // ============================================================================
 
 export const threadToolDef = {
-  name: 'muninn_thread',
+  name: 'oracle_thread',
   description: 'Send a message to an Oracle discussion thread. Creates a new thread or continues an existing one. Oracle auto-responds from knowledge base. Use for multi-turn consultations.',
   inputSchema: {
     type: 'object',
@@ -71,7 +71,7 @@ export const threadToolDef = {
 };
 
 export const threadsToolDef = {
-  name: 'muninn_threads',
+  name: 'oracle_threads',
   description: 'List Oracle discussion threads. Filter by status to find pending questions or active discussions.',
   inputSchema: {
     type: 'object',
@@ -85,7 +85,7 @@ export const threadsToolDef = {
 };
 
 export const threadReadToolDef = {
-  name: 'muninn_thread_read',
+  name: 'oracle_thread_read',
   description: 'Read full message history from a thread. Use to review context before continuing a conversation.',
   inputSchema: {
     type: 'object',
@@ -98,7 +98,7 @@ export const threadReadToolDef = {
 };
 
 export const threadUpdateToolDef = {
-  name: 'muninn_thread_update',
+  name: 'oracle_thread_update',
   description: 'Update thread status. Use to close, reopen, or mark threads as answered/pending.',
   inputSchema: {
     type: 'object',

--- a/src/tools/handoff.ts
+++ b/src/tools/handoff.ts
@@ -12,7 +12,7 @@ import { detectProject } from '../server/project-detect.ts';
 import type { ToolContext, ToolResponse, OracleHandoffInput } from './types.ts';
 
 export const handoffToolDef = {
-  name: 'muninn_handoff',
+  name: 'oracle_handoff',
   description: 'Write session context to the Oracle inbox for future sessions to pick up. Creates a timestamped markdown file in ψ/inbox/handoff/. Use at end of sessions to preserve context.',
   inputSchema: {
     type: 'object',
@@ -124,7 +124,7 @@ export async function handleHandoff(ctx: ToolContext, input: OracleHandoffInput)
       text: JSON.stringify({
         success: true,
         file: sourceFileRel,
-        message: `Handoff written${vaultRoot ? ' (vault)' : ''}. Next session can read it with muninn_inbox().`
+        message: `Handoff written${vaultRoot ? ' (vault)' : ''}. Next session can read it with oracle_inbox().`
       }, null, 2)
     }]
   };

--- a/src/tools/inbox.ts
+++ b/src/tools/inbox.ts
@@ -9,7 +9,7 @@ import fs from 'fs';
 import type { ToolContext, ToolResponse, OracleInboxInput } from './types.ts';
 
 export const inboxToolDef = {
-  name: 'muninn_inbox',
+  name: 'oracle_inbox',
   description: 'List and preview pending handoff files from the Oracle inbox. Returns files sorted newest-first with previews.',
   inputSchema: {
     type: 'object',

--- a/src/tools/learn.ts
+++ b/src/tools/learn.ts
@@ -39,7 +39,7 @@ export function coerceConcepts(concepts: unknown): string[] {
 }
 
 export const learnToolDef = {
-  name: 'muninn_learn',
+  name: 'oracle_learn',
   description: 'Add a new pattern or learning to the Oracle knowledge base. Creates a markdown file in ψ/memory/learnings/ and indexes it.',
   inputSchema: {
     type: 'object',
@@ -99,7 +99,7 @@ export function normalizeProject(input?: string): string | null {
 
 /**
  * Extract project from source field (fallback).
- * Handles "muninn_learn from github.com/owner/repo" and "rrr: org/repo" formats.
+ * Handles "oracle_learn from github.com/owner/repo" and "rrr: org/repo" formats.
  */
 export function extractProjectFromSource(source?: string): string | null {
   if (!source) return null;
@@ -235,7 +235,7 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
     indexedAt: now.getTime(),
     origin: null,
     project,
-    createdBy: 'muninn_learn',
+    createdBy: 'oracle_learn',
   }).run();
 
   // FTS5 has no unique constraint on id — delete-then-insert to be idempotent.
@@ -247,7 +247,7 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
 
   // Vector indexing — two paths:
   //   - Default (env unset): inline embed via Ollama. Keeps DB + lancedb in
-  //     step so muninn_search hybrid mode works immediately. Graceful fallback
+  //     step so oracle_search hybrid mode works immediately. Graceful fallback
   //     on embedder failure — FTS row above is still searchable.
   //   - ORACLE_INDEXER_ENQUEUE=1 (M5 of indexer-CLI): queue a row in
   //     indexing_jobs for the daemon to embed asynchronously. FTS-first /
@@ -262,7 +262,7 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
     } catch (err) {
       // Never block ingest on the queue — same posture as the inline path.
       embeddingStatus = 'failed';
-      console.warn(`[muninn_learn] enqueue failed: ${err instanceof Error ? err.message : String(err)}`);
+      console.warn(`[oracle_learn] enqueue failed: ${err instanceof Error ? err.message : String(err)}`);
     }
   } else {
     try {
@@ -281,8 +281,8 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
       embeddingStatus = 'ok';
     } catch (err) {
       embeddingStatus = 'failed';
-      console.warn(`[muninn_learn] vector embedding failed for ${id}: ${err instanceof Error ? err.message : String(err)}`);
-      console.warn(`[muninn_learn] document still searchable via FTS5; run 'bun src/scripts/index-model.ts <model>' later to backfill vectors`);
+      console.warn(`[oracle_learn] vector embedding failed for ${id}: ${err instanceof Error ? err.message : String(err)}`);
+      console.warn(`[oracle_learn] document still searchable via FTS5; run 'bun src/scripts/index-model.ts <model>' later to backfill vectors`);
     }
   }
 

--- a/src/tools/list.ts
+++ b/src/tools/list.ts
@@ -9,7 +9,7 @@ import { oracleDocuments } from '../db/schema.ts';
 import type { ToolContext, ToolResponse, OracleListInput } from './types.ts';
 
 export const listToolDef = {
-  name: 'muninn_list',
+  name: 'oracle_list',
   description: 'List all documents in Oracle knowledge base. Browse without searching - useful for exploring what knowledge exists. Supports pagination and type filtering.',
   inputSchema: {
     type: 'object',

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -11,8 +11,8 @@ import { getVaultPsiRoot } from '../vault/handler.ts';
 import type { ToolContext, ToolResponse, OracleReadInput } from './types.ts';
 
 export const readToolDef = {
-  name: 'muninn_read',
-  description: 'Read full content of an Oracle document by file path or document ID. Use after muninn_search to retrieve complete file contents. Resolves vault paths, ghq paths, and symlinks server-side.',
+  name: 'oracle_read',
+  description: 'Read full content of an Oracle document by file path or document ID. Use after oracle_search to retrieve complete file contents. Resolves vault paths, ghq paths, and symlinks server-side.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -22,7 +22,7 @@ export const readToolDef = {
       },
       id: {
         type: 'string',
-        description: 'Document ID from muninn_search results. Looks up source_file from DB.',
+        description: 'Document ID from oracle_search results. Looks up source_file from DB.',
       },
     },
   },

--- a/src/tools/reflect.ts
+++ b/src/tools/reflect.ts
@@ -9,7 +9,7 @@ import { oracleDocuments } from '../db/schema.ts';
 import type { ToolContext, ToolResponse, OracleReflectInput } from './types.ts';
 
 export const reflectToolDef = {
-  name: 'muninn_reflect',
+  name: 'oracle_reflect',
   description: 'Get a random principle or learning for reflection. Use this for periodic wisdom or to align with Oracle philosophy.',
   inputSchema: {
     type: 'object',

--- a/src/tools/schedule.ts
+++ b/src/tools/schedule.ts
@@ -114,7 +114,7 @@ function fmtLocal(d: Date): string {
 // ============================================================================
 
 export const scheduleAddToolDef = {
-  name: 'muninn_schedule_add',
+  name: 'oracle_schedule_add',
   description: 'Add an appointment or event to the shared schedule. The schedule is per-human (not per-project) and shared across all Oracles.',
   inputSchema: {
     type: 'object',
@@ -146,7 +146,7 @@ export const scheduleAddToolDef = {
 };
 
 export const scheduleListToolDef = {
-  name: 'muninn_schedule_list',
+  name: 'oracle_schedule_list',
   description: 'List appointments from the shared schedule. Filter by date, range, or keyword. Defaults to today + 14 days.',
   inputSchema: {
     type: 'object',
@@ -337,7 +337,7 @@ function exportScheduleToMarkdown(ctx: ToolContext): void {
     }
   }
 
-  md += `\n---\n\nManaged by Oracle. Add events via \`muninn_schedule_add\` or the web UI.\n`;
+  md += `\n---\n\nManaged by Oracle. Add events via \`oracle_schedule_add\` or the web UI.\n`;
 
   const schedulePath = getSchedulePath();
   fs.mkdirSync(path.dirname(schedulePath), { recursive: true });

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -14,7 +14,7 @@ import type { SearchResult } from '../server/types.ts';
 import type { ToolContext, ToolResponse, OracleSearchInput } from './types.ts';
 
 export const searchToolDef = {
-  name: 'muninn_search',
+  name: 'oracle_search',
   description: 'Search Oracle knowledge base using hybrid search (FTS5 keywords + ChromaDB vectors). Finds relevant principles, patterns, learnings, or retrospectives. Falls back to FTS5-only if ChromaDB unavailable.',
   inputSchema: {
     type: 'object',
@@ -418,7 +418,7 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
 
   // Enrich with supersede flags (P-001 "Nothing is Deleted" — superseded docs
   // remain searchable; callers need to see the flag to decide whether to
-  // follow the replacement pointer). Fixes drift where muninn_supersede claimed
+  // follow the replacement pointer). Fixes drift where oracle_supersede claimed
   // "will appear in searches with a warning" but search never flagged them.
   if (results.length > 0) {
     const ids = results.map(r => r.id as string);

--- a/src/tools/stats.ts
+++ b/src/tools/stats.ts
@@ -9,7 +9,7 @@ import { oracleDocuments } from '../db/schema.ts';
 import type { ToolContext, ToolResponse, OracleStatsInput } from './types.ts';
 
 export const statsToolDef = {
-  name: 'muninn_stats',
+  name: 'oracle_stats',
   description: 'Get Oracle knowledge base statistics and health status. Returns document counts by type, indexing status, and ChromaDB connection status.',
   inputSchema: {
     type: 'object',

--- a/src/tools/supersede.ts
+++ b/src/tools/supersede.ts
@@ -10,7 +10,7 @@ import { oracleDocuments } from '../db/schema.ts';
 import type { ToolContext, ToolResponse, OracleSupersededInput } from './types.ts';
 
 export const supersedeToolDef = {
-  name: 'muninn_supersede',
+  name: 'oracle_supersede',
   description: 'Mark an old learning/document as superseded by a newer one. Aligns with "Nothing is Deleted" - old doc preserved but marked outdated.',
   inputSchema: {
     type: 'object',

--- a/src/tools/trace.ts
+++ b/src/tools/trace.ts
@@ -28,7 +28,7 @@ import type { ToolResponse } from './types.ts';
 // ============================================================================
 
 export const traceToolDef = {
-  name: 'muninn_trace',
+  name: 'oracle_trace',
   description: 'Log a trace session with dig points (files, commits, issues found). Use to capture /trace command results for future exploration.',
   inputSchema: {
     type: 'object',
@@ -51,7 +51,7 @@ export const traceToolDef = {
 };
 
 export const traceListToolDef = {
-  name: 'muninn_trace_list',
+  name: 'oracle_trace_list',
   description: 'List recent traces with optional filters. Returns trace summaries for browsing.',
   inputSchema: {
     type: 'object',
@@ -67,7 +67,7 @@ export const traceListToolDef = {
 };
 
 export const traceGetToolDef = {
-  name: 'muninn_trace_get',
+  name: 'oracle_trace_get',
   description: 'Get full details of a specific trace including all dig points (files, commits, issues).',
   inputSchema: {
     type: 'object',
@@ -80,7 +80,7 @@ export const traceGetToolDef = {
 };
 
 export const traceLinkToolDef = {
-  name: 'muninn_trace_link',
+  name: 'oracle_trace_link',
   description: 'Link two traces as a chain (prev \u2192 next). Creates bidirectional navigation without deleting anything. Use when agents create related traces that should be connected.',
   inputSchema: {
     type: 'object',
@@ -93,7 +93,7 @@ export const traceLinkToolDef = {
 };
 
 export const traceUnlinkToolDef = {
-  name: 'muninn_trace_unlink',
+  name: 'oracle_trace_unlink',
   description: 'Remove a link between traces. Breaks the chain connection in the specified direction.',
   inputSchema: {
     type: 'object',
@@ -106,7 +106,7 @@ export const traceUnlinkToolDef = {
 };
 
 export const traceChainToolDef = {
-  name: 'muninn_trace_chain',
+  name: 'oracle_trace_chain',
   description: 'Get the full linked chain for a trace. Returns all traces in the chain and the position of the requested trace.',
   inputSchema: {
     type: 'object',
@@ -177,7 +177,7 @@ export async function handleTrace(input: CreateTraceInput): Promise<ToolResponse
           issue_count: result.summary.issueCount,
           total_dig_points: result.summary.totalDigPoints,
         },
-        message: `Trace logged. Use muninn_trace_get with trace_id="${result.traceId}" to explore dig points.`
+        message: `Trace logged. Use oracle_trace_get with trace_id="${result.traceId}" to explore dig points.`
       }, null, 2)
     }]
   };

--- a/src/tools/verify.ts
+++ b/src/tools/verify.ts
@@ -8,7 +8,7 @@ import { verifyKnowledgeBase } from '../verify/handler.ts';
 import type { ToolContext, ToolResponse, OracleVerifyInput } from './types.ts';
 
 export const verifyToolDef = {
-  name: 'muninn_verify',
+  name: 'oracle_verify',
   description: 'Verify knowledge base integrity: compare ψ/ files on disk vs DB index. Detects missing (on disk, not indexed), orphaned (in DB, file gone), and drifted (file changed since last index) documents.',
   inputSchema: {
     type: 'object',

--- a/src/trace/handler.ts
+++ b/src/trace/handler.ts
@@ -495,7 +495,7 @@ export function distillTrace(
     .where(eq(traceLog.traceId, input.traceId))
     .run();
 
-  // TODO: If promoteToLearning, call muninn_learn
+  // TODO: If promoteToLearning, call oracle_learn
   // This would require access to the learn function
 
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,7 +61,7 @@ export interface OracleReflectInput {
 }
 
 /**
- * muninn_list input - browse documents without search query
+ * oracle_list input - browse documents without search query
  */
 export interface OracleListInput {
   type?: OracleDocumentType | 'all';
@@ -88,7 +88,7 @@ export interface OracleReflectOutput {
 }
 
 /**
- * muninn_list output - paginated document list
+ * oracle_list output - paginated document list
  */
 export interface OracleListOutput {
   documents: Array<{

--- a/src/vault/cli.ts
+++ b/src/vault/cli.ts
@@ -25,8 +25,8 @@ const VERSION = '0.4.0-nightly';
 const HELP = `
 oracle-vault v${VERSION} — Central knowledge brain for Oracle
 
-The vault repo IS your central ψ/. Once initialized, muninn_learn and
-muninn_handoff write directly to the vault repo with project-nested paths.
+The vault repo IS your central ψ/. Once initialized, oracle_learn and
+oracle_handoff write directly to the vault repo with project-nested paths.
 The indexer scans the vault repo for cross-project search. Sync commits
 and pushes to GitHub for backup.
 
@@ -52,9 +52,9 @@ Environment:
 
 How it works:
   1. oracle-vault init <repo>   Clone vault repo via ghq, save to settings
-  2. muninn_learn / handoff     Write directly to vault repo (project-nested)
+  2. oracle_learn / handoff     Write directly to vault repo (project-nested)
   3. bun src/indexer.ts          Scan vault repo, index all projects
-  4. muninn_search               Cross-project search results
+  4. oracle_search               Cross-project search results
   5. oracle-vault sync           git add + commit + push (backup)
 
 Examples:

--- a/src/vault/discovery.ts
+++ b/src/vault/discovery.ts
@@ -51,7 +51,7 @@ export function cleanEmptyDirs(dir: string, stopAt: string): void {
 }
 
 /**
- * Resolve the vault ψ/ root for shared use by muninn_learn, muninn_handoff, indexer, etc.
+ * Resolve the vault ψ/ root for shared use by oracle_learn, oracle_handoff, indexer, etc.
  * Returns the vault repo local path, or a setup hint if not configured.
  */
 export function getVaultPsiRoot(): { path: string } | { needsInit: true; hint: string } {

--- a/src/verify/handler.ts
+++ b/src/verify/handler.ts
@@ -171,7 +171,7 @@ export function verifyKnowledgeBase(opts: {
             .set({
               supersededBy: '_verified_orphan',
               supersededAt: now,
-              supersededReason: 'File missing from disk (muninn_verify)',
+              supersededReason: 'File missing from disk (oracle_verify)',
             })
             .where(eq(oracleDocuments.id, id))
             .run();


### PR DESCRIPTION
## Summary

Aligns MCP tool names with the product brand:

\`\`\`
repo:    arra-oracle-v3
server:  arra-oracle
tools:   oracle_*  (was muninn_*, originally arra_*)
\`\`\`

PR #1172 had renamed arra_* → muninn_* (Norse mythology — Odin's memory raven). Session retro showed the name was chosen autonomously by sage-vector-fix-oracle, never user-requested. Branding alignment is better served by \`oracle_*\` matching repo + server names.

## The alias chain (3 generations, all working)

\`\`\`
arra_*    ─┐
muninn_*  ─┼──►  oracle_*   (canonical, advertised in ListTools)
oracle_*  ─┘
\`\`\`

PR #1232 shipped the alias system. This PR uses it again — extends \`resolveToolName()\` to recognize BOTH \`arra_*\` and \`muninn_*\` legacy prefixes and resolve them to \`oracle_*\`. **Tool LIST advertises only \`oracle_*\`.** Both legacy prefixes work invisibly forever.

## Scope

- **35 files** sed'd \`muninn_\` → \`oracle_\` (src + docs)
- **Resolver flipped**: \`ALIAS_PREFIXES = ['arra_', 'muninn_']\` → \`oracle_\`
- **19 case branches** renamed in \`src/index.ts\` dispatch
- **TOOL_GROUPS** entries renamed in \`src/config/tool-groups.ts\`
- **Tests updated**: \`resolve-tool-name\` now covers BOTH legacy paths; 6 new tests for muninn_* aliasing (all existing arra_* tests preserved)
- \`tool-groups\` prefix-convention test flipped \`^muninn_\` → \`^oracle_\`

## Tests

\`\`\`
727 pass / 22 skip / 0 fail with --isolate
+19 expect() calls from new muninn_* alias coverage
\`\`\`

No behavior change for valid arra_* or muninn_* callers — they continue working. \`oracle_*\` becomes the canonical name surfaced in ListTools.

## Why this is cheap

PR #1232 was the architectural lift — designing the resolver pattern + tests. This PR just iterates the pattern. ~80-100 lines of straightforward sed plus 1 surgical resolver edit.

## Migration impact (external consumers)

- ~/.claude/CLAUDE.md + 10 skills currently reference \`muninn_*\` from PR #1232's migration. They will continue to work invisibly via the alias. Re-sed to \`oracle_*\` is optional polish, not required.
- Anyone with the very-original \`arra_*\` config (pre-#1172) ALSO still works.
- Tool LIST advertises only \`oracle_*\` — new docs/code naturally use the new name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)