### PR TITLE
fix(indexer): collect ψ/memory/distillations/ (closes #990, supersedes #1065)

### DIFF
--- a/src/indexer/cli.ts
+++ b/src/indexer/cli.ts
@@ -33,6 +33,7 @@ const config: IndexerConfig = {
     resonance: '\u03c8/memory/resonance',
     learnings: '\u03c8/memory/learnings',
     retrospectives: '\u03c8/memory/retrospectives',
+    distillations: '\u03c8/memory/distillations',
     // Opt-in: set ORACLE_INDEX_SECURITY_CORPUS=1 to include \u03c8/learn/security-corpus/.
     // Default OFF because the corpus has ~36k files (one-time index ~10-30 min).
     security_corpus: process.env.ORACLE_INDEX_SECURITY_CORPUS === '1'

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -23,7 +23,7 @@ import type { OracleDocument, IndexerConfig } from '../types.ts';
 
 import { setIndexingStatus } from './status.ts';
 import { backupDatabase } from './backup.ts';
-import { parseResonanceFile, parseLearningFile, parseRetroFile } from './parser.ts';
+import { parseResonanceFile, parseLearningFile, parseRetroFile, parseDistillationFile } from './parser.ts';
 import { collectDocuments, collectSecurityCorpus } from './collectors.ts';
 import { storeDocuments } from './storage.ts';
 
@@ -75,6 +75,7 @@ export class OracleIndexer {
       ...collectDocuments({ ...shared, subdir: 'resonance', parseFn: parseResonanceFile, label: 'resonance' }),
       ...collectDocuments({ ...shared, subdir: 'learnings', parseFn: parseLearningFile, label: 'learning' }),
       ...collectDocuments({ ...shared, subdir: 'retrospectives', parseFn: parseRetroFile, label: 'retrospective' }),
+      ...collectDocuments({ ...shared, subdir: 'distillations', parseFn: parseDistillationFile, label: 'distillation' }),
       ...collectSecurityCorpus(shared),
     ];
 

--- a/src/indexer/parser.ts
+++ b/src/indexer/parser.ts
@@ -101,6 +101,52 @@ export function parseLearningFile(filename: string, content: string, sourceFileO
 }
 
 /**
+ * Parse distillation markdown into documents
+ * L1–L4 brain-compression artifacts produced by /distill skill.
+ * Splits by ## headers, falls back to whole-file document.
+ */
+export function parseDistillationFile(filename: string, content: string, sourceFileOverride?: string): OracleDocument[] {
+  const documents: OracleDocument[] = [];
+  const sourceFile = sourceFileOverride || `ψ/memory/distillations/${filename}`;
+  const now = Date.now();
+
+  const fileTags = parseFrontmatterTags(content);
+  const fileProject = parseFrontmatterProject(content) || inferProjectFromPath(sourceFile);
+
+  const titleMatch = content.match(/^title:\s*(.+)$/m);
+  const title = titleMatch ? titleMatch[1] : filename.replace('.md', '');
+
+  const sections = content.split(/^##\s+/m).filter(s => s.trim());
+
+  sections.forEach((section, index) => {
+    const lines = section.split('\n');
+    const sectionTitle = lines[0].trim();
+    const body = lines.slice(1).join('\n').trim();
+    if (!body) return;
+
+    const id = `distillation_${filename.replace('.md', '')}_${index}`;
+    const extracted = extractConcepts(sectionTitle, body);
+    documents.push({
+      id, type: 'distillation', source_file: sourceFile,
+      content: `${title} - ${sectionTitle}: ${body}`,
+      concepts: mergeConceptsWithTags(extracted, fileTags),
+      created_at: now, updated_at: now, project: fileProject || undefined
+    });
+  });
+
+  if (documents.length === 0) {
+    const extracted = extractConcepts(title, content);
+    documents.push({
+      id: `distillation_${filename.replace('.md', '')}`, type: 'distillation', source_file: sourceFile,
+      content, concepts: mergeConceptsWithTags(extracted, fileTags),
+      created_at: now, updated_at: now, project: fileProject || undefined
+    });
+  }
+
+  return documents;
+}
+
+/**
  * Parse retrospective markdown
  * Splits by ## headers, skips sections shorter than 50 chars
  */

--- a/src/routes/indexer/scan.ts
+++ b/src/routes/indexer/scan.ts
@@ -17,7 +17,8 @@ export const scanEndpoint = new Elysia().post('/indexer/scan', async ({ body }) 
     const rel = path.relative(sourcePath, filePath);
 
     let type = 'unknown';
-    if (rel.includes('learnings') || rel.includes('learning')) type = 'learning';
+    if (rel.includes('distillations') || rel.includes('distillation')) type = 'distillation';
+    else if (rel.includes('learnings') || rel.includes('learning')) type = 'learning';
     else if (rel.includes('retrospectives') || rel.includes('retro')) type = 'retro';
     else if (rel.includes('resonance') || rel.includes('principle')) type = 'principle';
 

--- a/src/routes/indexer/start.ts
+++ b/src/routes/indexer/start.ts
@@ -26,6 +26,7 @@ export const startEndpoint = new Elysia().post('/indexer/start', async ({ body }
       resonance: `${sourcePath || REPO_ROOT}/memory/resonance`,
       learnings: `${sourcePath || REPO_ROOT}/memory/learnings`,
       retrospectives: `${sourcePath || REPO_ROOT}/memory/retrospectives`,
+      distillations: `${sourcePath || REPO_ROOT}/memory/distillations`,
     },
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@
  * Following claude-mem patterns for granular vector documents
  */
 
-export type OracleDocumentType = 'principle' | 'pattern' | 'learning' | 'retro' | 'security-corpus';
+export type OracleDocumentType = 'principle' | 'pattern' | 'learning' | 'retro' | 'distillation' | 'security-corpus';
 
 /**
  * Granular document stored in vector DB
@@ -125,6 +125,7 @@ export interface IndexerConfig {
     resonance: string;
     learnings: string;
     retrospectives: string;
+    distillations: string;
     security_corpus?: string;  // Optional: ψ/learn/security-corpus/ — opt-in via ORACLE_INDEX_SECURITY_CORPUS=1
   };
 }


### PR DESCRIPTION
## Summary

Recreates contributor fork PR #1065 (@natman95) on an origin branch, rebased onto current `alpha`. The original fork branch went `CONFLICTING/DIRTY` after #1026 (security-corpus) and #1236 (oracle_* rename) landed on alpha — and being a cross-repo fork PR, it couldn't be resolved in place. This is the same change, applied cleanly to current alpha with the strict-typing follow-ups the fork predated.

Closes #990. Supersedes #1065 (credit @natman95).

## Changes
- `parser.ts` — `parseDistillationFile()`: splits L1–L4 distillation artifacts by `##` headers, whole-file fallback (mirrors parseRetroFile)
- `index.ts` — wire `distillations` into the `collectDocuments` pipeline
- `cli.ts` + `routes/indexer/start.ts` — `distillations` sourcePath
- `routes/indexer/scan.ts` — distillation type detection (before learning)
- `types.ts` — add `'distillation'` to `OracleDocumentType` + `distillations` to `IndexerConfig.sourcePaths` (the strict-typing the fork PR predated)

## Test plan
- [x] `bun run build` (tsc) clean
- [x] `bun test --isolate` — 749 pass / 22 skip / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)