### PR TITLE
fix(mcp): route logSearch + LanceDB logs to stderr (closes #1036, supersedes #1133)

### DIFF
--- a/src/server/logging.ts
+++ b/src/server/logging.ts
@@ -42,18 +42,18 @@ export function logSearch(
     }).run();
 
     // Comprehensive console logging
-    console.log(`\n${'='.repeat(60)}`);
-    console.log(`[SEARCH] ${new Date().toISOString()}`);
-    if (project) console.log(`  Project: ${project}`);
-    console.log(`  Query: "${query}"`);
-    console.log(`  Type: ${type} | Mode: ${mode}`);
-    console.log(`  Results: ${resultsCount} in ${searchTimeMs}ms`);
+    console.error(`\n${'='.repeat(60)}`);
+    console.error(`[SEARCH] ${new Date().toISOString()}`);
+    if (project) console.error(`  Project: ${project}`);
+    console.error(`  Query: "${query}"`);
+    console.error(`  Type: ${type} | Mode: ${mode}`);
+    console.error(`  Results: ${resultsCount} in ${searchTimeMs}ms`);
 
     if (results.length > 0) {
-      console.log(`  Top Results:`);
+      console.error(`  Top Results:`);
       results.slice(0, 5).forEach((r, i) => {
-        console.log(`    ${i + 1}. [${r.type}] score=${r.score || 'N/A'} id=${r.id}`);
-        console.log(`       ${r.content?.substring(0, 80)}...`);
+        console.error(`    ${i + 1}. [${r.type}] score=${r.score || 'N/A'} id=${r.id}`);
+        console.error(`       ${r.content?.substring(0, 80)}...`);
       });
     }
 
@@ -63,10 +63,10 @@ export function logSearch(
       const firstResult = results[0] as unknown as Record<string, unknown>;
       const unknownFields = Object.keys(firstResult).filter(k => !expectedFields.includes(k));
       if (unknownFields.length > 0) {
-        console.log(`  [UNKNOWN FIELDS]: ${unknownFields.join(', ')}`);
+        console.error(`  [UNKNOWN FIELDS]: ${unknownFields.join(', ')}`);
       }
     }
-    console.log(`${'='.repeat(60)}\n`);
+    console.error(`${'='.repeat(60)}\n`);
   } catch (e) {
     console.error('Failed to log search:', e);
   }

--- a/src/vector/adapters/lancedb.ts
+++ b/src/vector/adapters/lancedb.ts
@@ -26,13 +26,13 @@ export class LanceDBAdapter implements VectorStoreAdapter {
 
     const lancedb = await import('@lancedb/lancedb');
     this.db = await lancedb.connect(this.dbPath);
-    console.log(`[LanceDB] Connected at ${this.dbPath}`);
+    console.error(`[LanceDB] Connected at ${this.dbPath}`);
   }
 
   async close(): Promise<void> {
     this.db = null;
     this.table = null;
-    console.log('[LanceDB] Closed');
+    console.error('[LanceDB] Closed');
   }
 
   async ensureCollection(): Promise<void> {
@@ -53,7 +53,7 @@ export class LanceDBAdapter implements VectorStoreAdapter {
       await this.table.delete('id = "__init__"');
     }
 
-    console.log(`[LanceDB] Collection '${this.collectionName}' ready`);
+    console.error(`[LanceDB] Collection '${this.collectionName}' ready`);
   }
 
   async deleteCollection(): Promise<void> {
@@ -62,7 +62,7 @@ export class LanceDBAdapter implements VectorStoreAdapter {
     try {
       await this.db.dropTable(this.collectionName);
       this.table = null;
-      console.log(`[LanceDB] Collection '${this.collectionName}' deleted`);
+      console.error(`[LanceDB] Collection '${this.collectionName}' deleted`);
     } catch (e) {
       console.warn('[LanceDB] deleteCollection failed:', e instanceof Error ? e.message : String(e));
     }
@@ -96,9 +96,9 @@ export class LanceDBAdapter implements VectorStoreAdapter {
     await this.table.add(rows);
     const reused = docs.length - needEmbed.length;
     if (reused > 0) {
-      console.log(`[LanceDB] Added ${docs.length} documents (${reused} with precomputed vectors)`);
+      console.error(`[LanceDB] Added ${docs.length} documents (${reused} with precomputed vectors)`);
     } else {
-      console.log(`[LanceDB] Added ${docs.length} documents`);
+      console.error(`[LanceDB] Added ${docs.length} documents`);
     }
   }
 


### PR DESCRIPTION
## Summary

**The codex-killer.** `logSearch()` in `src/server/logging.ts` emitted ~7 `console.log` → **stdout** on *every* search (called from `tools/search.ts:484`). On the MCP **stdio** transport, non-JSON on stdout corrupts the JSON-RPC stream → Codex/stdio MCP clients disconnect. (Hit live this session when codex's MCP closed mid-task.)

Fix: route all `logSearch` diagnostics → `console.error` (stderr). Also flipped LanceDB's 6 connect/collection `console.log` → `console.error` (startup stdout noise on the same transport).

## Why this supersedes #1133

Fork PR #1133 (@TTT3P) targeted `learn.ts` (console.warn→error — cosmetic, warn already → stderr) and `lancedb.ts`, but **missed the actual culprit** — the per-search `logSearch` in `logging.ts` — and bundled an unrelated full CLAUDE.md rewrite. This is the minimal, complete fix for the real bug. Credit @TTT3P for the report + the lancedb intent.

## Verification
- [x] `grep -F "console.log(" src/server/logging.ts src/vector/adapters/lancedb.ts` → 0
- [x] `bun run build` (tsc) clean
- [x] `bun test --isolate` — 749 pass / 22 skip / 0 fail
- [ ] Manual: run MCP over stdio, issue a search, confirm stdout stays pure JSON-RPC (Codex client no longer drops)

🤖 Generated with [Claude Code](https://claude.com/claude-code)