### PR TITLE
feat(mcp): wire oracle_reflect + oracle_verify (#972 partial)

### DIFF
--- a/src/config/__tests__/tool-groups.test.ts
+++ b/src/config/__tests__/tool-groups.test.ts
@@ -11,19 +11,20 @@ import {
 } from '../tool-groups.ts';
 
 describe('tool-groups', () => {
-  it('defines 5 groups with correct tool counts', () => {
-    expect(Object.keys(TOOL_GROUPS)).toHaveLength(5);
+  it('defines 6 groups with correct tool counts', () => {
+    expect(Object.keys(TOOL_GROUPS)).toHaveLength(6);
     expect(TOOL_GROUPS.search).toHaveLength(4);
     expect(TOOL_GROUPS.knowledge).toHaveLength(3);
     expect(TOOL_GROUPS.session).toHaveLength(2);
     expect(TOOL_GROUPS.forum).toHaveLength(4);
     expect(TOOL_GROUPS.trace).toHaveLength(6);
+    expect(TOOL_GROUPS.standalone).toHaveLength(2);   // #972 wire: reflect + verify (schedule kept HTTP-only)
   });
 
   it('returns empty set when all groups enabled', () => {
     const config: ToolGroupConfig = {
       search: true, knowledge: true, session: true,
-      forum: true, trace: true,
+      forum: true, trace: true, standalone: true,
     };
     expect(getDisabledTools(config).size).toBe(0);
   });
@@ -31,7 +32,7 @@ describe('tool-groups', () => {
   it('disables correct tools when groups are off', () => {
     const config: ToolGroupConfig = {
       search: true, knowledge: true, session: true,
-      forum: true, trace: false,
+      forum: true, trace: false, standalone: true,
     };
     const disabled = getDisabledTools(config);
     expect(disabled.has('oracle_trace')).toBe(true);
@@ -43,7 +44,7 @@ describe('tool-groups', () => {
   it('disabled_tools adds per-tool blocks on top of group config', () => {
     const config: ToolGroupConfig = {
       search: true, knowledge: true, session: true,
-      forum: true, trace: true,
+      forum: true, trace: true, standalone: true,
       disabled_tools: ['oracle_supersede', 'oracle_thread_update'],
     };
     const disabled = getDisabledTools(config);
@@ -57,7 +58,7 @@ describe('tool-groups', () => {
   it('enabled_tools whitelist overrides group-disabled', () => {
     const config: ToolGroupConfig = {
       search: true, knowledge: true, session: true,
-      forum: false, trace: true,
+      forum: false, trace: true, standalone: true,
       enabled_tools: ['oracle_thread_read'],
     };
     const disabled = getDisabledTools(config);
@@ -70,7 +71,7 @@ describe('tool-groups', () => {
   it('enabled_tools whitelist overrides a per-tool block (whitelist wins last)', () => {
     const config: ToolGroupConfig = {
       search: true, knowledge: true, session: true,
-      forum: true, trace: true,
+      forum: true, trace: true, standalone: true,
       disabled_tools: ['oracle_supersede'],
       enabled_tools: ['oracle_supersede'],
     };
@@ -80,7 +81,7 @@ describe('tool-groups', () => {
   it('ignores unknown tool names in disabled_tools and enabled_tools', () => {
     const config: ToolGroupConfig = {
       search: true, knowledge: true, session: true,
-      forum: true, trace: true,
+      forum: true, trace: true, standalone: true,
       disabled_tools: ['typo_search', 'oracle_search'],
       enabled_tools: ['also_typo'],
     };

--- a/src/config/tool-groups.ts
+++ b/src/config/tool-groups.ts
@@ -18,6 +18,11 @@ export const TOOL_GROUPS = {
   session: ['oracle_handoff', 'oracle_inbox'],
   forum: ['oracle_thread', 'oracle_threads', 'oracle_thread_read', 'oracle_thread_update'],
   trace: ['oracle_trace', 'oracle_trace_list', 'oracle_trace_get', 'oracle_trace_link', 'oracle_trace_unlink', 'oracle_trace_chain'],
+  // #972: standalone tools that don't fit any other group. Handlers ALSO power
+  // HTTP routes (/api/reflect, /api/verify) — same code path. NOTE: schedule_*
+  // handlers exist + power /api/schedule/* but are intentionally NOT exposed
+  // as MCP tools (per user direction — keep schedule HTTP-only).
+  standalone: ['oracle_reflect', 'oracle_verify'],
 } as const;
 
 export type ToolGroupName = keyof typeof TOOL_GROUPS;
@@ -40,6 +45,7 @@ const DEFAULT_CONFIG: ToolGroupConfig = {
   session: true,
   forum: true,
   trace: true,
+  standalone: true,
 };
 
 /** All registered tool names — for validating disabled_tools / enabled_tools entries. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,11 @@ import {
   handleThread, handleThreads, handleThreadRead, handleThreadUpdate,
   traceToolDefs,
   handleTrace, handleTraceList, handleTraceGet, handleTraceLink, handleTraceUnlink, handleTraceChain,
+  // Standalone tools (#972 wire — reflect + verify only. Schedule handlers
+  // remain HTTP-only per maintainer direction: /api/schedule/* routes still
+  // use them, but they're not exposed as MCP tools.)
+  reflectToolDef, handleReflect,
+  verifyToolDef, handleVerify,
 } from './tools/index.ts';
 
 import type {
@@ -56,6 +61,8 @@ import type {
   OracleThreadsInput,
   OracleThreadReadInput,
   OracleThreadUpdateInput,
+  OracleReflectInput,
+  OracleVerifyInput,
 } from './tools/index.ts';
 
 import type {
@@ -245,10 +252,13 @@ class OracleMCPServer {
         ...forumToolDefs,
         // Trace tools (from src/tools/trace.ts)
         ...traceToolDefs,
-        // Supersede, Handoff, Inbox, Verify
+        // Supersede, Handoff, Inbox
         supersedeToolDef,
         handoffToolDef,
         inboxToolDef,
+        // Standalone tools (#972 wire — reflect + verify only; schedule kept HTTP-only)
+        reflectToolDef,
+        verifyToolDef,
       ];
 
       let tools = allTools.filter(t => !this.disabledTools.has(t.name));
@@ -333,6 +343,12 @@ class OracleMCPServer {
             return await handleTraceUnlink(request.params.arguments as unknown as { traceId: string; direction: 'prev' | 'next' });
           case 'oracle_trace_chain':
             return await handleTraceChain(request.params.arguments as unknown as { traceId: string });
+
+          // Standalone tools (#972 wire — reflect + verify; schedule kept HTTP-only)
+          case 'oracle_reflect':
+            return await handleReflect(ctx, request.params.arguments as unknown as OracleReflectInput);
+          case 'oracle_verify':
+            return await handleVerify(ctx, request.params.arguments as unknown as OracleVerifyInput);
 
           case '____IMPORTANT':
             return {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -84,3 +84,16 @@ export {
   handleTraceChain,
 } from './trace.ts';
 
+// Standalone tools (closes #972 — handlers existed in-source but weren't wired
+// into the MCP dispatch. Same handlers ALSO power HTTP routes /api/reflect,
+// /api/verify, so they're battle-tested by HTTP consumers).
+//
+// NOTE: schedule_add / schedule_list are NOT wired as MCP tools per maintainer
+// direction — they remain HTTP-only at /api/schedule/*. Their exports stay in
+// place for the HTTP route consumers (src/routes/schedule/*.ts).
+export type {
+  OracleReflectInput,
+  OracleVerifyInput,
+} from './types.ts';
+export { reflectToolDef, handleReflect } from './reflect.ts';
+export { verifyToolDef, handleVerify } from './verify.ts';


### PR DESCRIPTION
## Summary

Closes the MCP half of #972. The 4 \"unwired\" handlers identified by codex's dossier turned out to be **heavily used by HTTP routes** (not orphan code) — archive was unsafe. Wiring them to MCP gives the tested handlers a second invocation surface for free.

## Wired (2 of 4)

| Tool | Handler | Also used by |
|---|---|---|
| \`oracle_reflect\` | \`src/tools/reflect.ts\` | \`src/routes/search/index.ts\` |
| \`oracle_verify\` | \`src/verify/handler.ts\` (via wrapper \`src/tools/verify.ts\`) | shared utility — read/learn/forum/handoff/verify |

## Intentionally NOT wired

- \`oracle_schedule_add\` / \`oracle_schedule_list\` — kept HTTP-only at \`/api/schedule/*\` per maintainer direction. Handlers remain in \`src/tools/schedule.ts\` for HTTP routes; just not exposed via MCP.

## Surfaces touched (lean PR, ~45 lines)

- \`src/index.ts\`: +2 imports +2 allTools entries +2 switch cases
- \`src/tools/index.ts\`: barrel re-exports for reflect + verify
- \`src/config/tool-groups.ts\`: new \`standalone\` group (reflect + verify)
- \`src/config/__tests__/tool-groups.test.ts\`: bump 5→6 groups, standalone=2

## Why not archive (codex dossier was wrong)

Static trace showed each \"unwired\" handler is consumed elsewhere:

\`\`\`
src/tools/reflect.ts          ← src/routes/search/index.ts (HTTP search)
src/tools/schedule.ts         ← 4 HTTP routes (create.ts, list.ts, md.ts, update.ts)
src/verify/handler.ts         ← read.ts, learn.ts, forum.ts, handoff.ts, verify.ts (shared utility)
\`\`\`

Archiving any of these would break production code paths. Wiring is the correct close-out for #972.

## Tests

\`\`\`
727 pass / 22 skip / 0 fail with --isolate · tsc clean · no behavior change
\`\`\`

Backward-compat alias chain (#1232/#1236) preserved: \`arra_reflect\` and \`muninn_reflect\` continue to resolve to \`oracle_reflect\` (same for verify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)