### PR TITLE
feat: package arra-oracle as a Claude Code plugin

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "arra-oracle",
+  "version": "26.5.30",
+  "description": "MCP memory layer with semantic search over your Oracle vault — SQLite FTS5 + LanceDB hybrid, 20 oracle_* tools across search / knowledge / session / forum / trace / standalone groups. Backward-compatible aliases: arra_* and muninn_* both resolve to oracle_*.",
+  "homepage": "https://github.com/Soul-Brews-Studio/arra-oracle-v3",
+  "license": "BUSL-1.1"
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "arra-oracle": {
+      "type": "stdio",
+      "command": "bun",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/src/index.ts"],
+      "env": {}
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the 2 manifest files \`anthropics/claude-plugins-official\` expects, making arra-oracle installable via Claude Code's \`/plugin install\` system.

\`\`\`
.claude-plugin/plugin.json    marketplace entry
.mcp.json                     stdio server spec
\`\`\`

## What it unlocks

| Install path | Status before | Status after |
|---|---|---|
| \`bunx --bun arra-oracle-v3@github:...\` | ✓ worked | ✓ unchanged |
| \`bun install -g .\` from clone | ✓ worked | ✓ unchanged |
| \`/plugin install arra-oracle@<marketplace>\` | ✗ no manifests | ✓ ready (pending marketplace publication) |

## Why this is the right shape

Same pattern as every plugin in \`external_plugins/\` (serena, context7, discord, slack, etc.). The MCP server entry already works as stdio — these 2 files just declare HOW Claude Code should discover + spawn it.

No code changes. No regressions. 727/22/0 tests still pass.

## Publication options (not in this PR)

1. PR to \`anthropics/claude-plugins-official/external_plugins/arra-oracle/\` — may be blocked by BUSL-1.1 license review
2. Self-hosted \`Soul-Brews-Studio/arra-plugin-marketplace\` repo — works regardless
3. Both — official for discoverability + self-host for sovereignty

This PR is publication-path-agnostic — both options work after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)