### PR TITLE
fix(retros): add server/CLI reindex path for local retrospective files

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -21,6 +21,7 @@ import {
   menuGistReload,
 } from "./commands/menu-gist.ts";
 import { menuResetAll } from "./commands/menu-reset.ts";
+import { reindex } from "./commands/reindex.ts";
 
 const pkg = await Bun.file(join(import.meta.dir, "../package.json")).json();
 const VERSION: string = pkg.version;
@@ -32,6 +33,7 @@ function printHelp(commands: Array<{ command: string; help?: string }>) {
   console.log(`  ${"plugin".padEnd(16)}manage plugins (install)`);
   console.log(`  ${"session".padEnd(16)}inspect sessions (list, show, context)`);
   console.log(`  ${"menu".padEnd(16)}inspect and customize studio menu (list, add, remove)`);
+  console.log(`  ${"reindex".padEnd(16)}trigger SQLite/FTS reindex via ORACLE_API`);
   for (const { command, help } of commands) {
     console.log(`  ${command.padEnd(16)}${help ?? ""}`);
   }
@@ -150,6 +152,10 @@ async function main() {
     console.error(`\x1b[31m✗\x1b[0m unknown menu subcommand: ${args[1]}`);
     console.error("  try: arra-cli menu list|add|remove|gist-*|reset-all");
     process.exit(1);
+  }
+
+  if (cmd === "reindex") {
+    process.exit(await reindex(args.slice(1)));
   }
 
   if (cmd === "plugin") {

--- a/cli/src/commands/reindex.ts
+++ b/cli/src/commands/reindex.ts
@@ -1,0 +1,50 @@
+import { apiFetch } from "../lib/api.ts";
+
+function takeFlagValue(args: string[], name: string): string | undefined {
+  const eq = args.find(a => a.startsWith(`${name}=`));
+  if (eq) return eq.slice(name.length + 1);
+  const idx = args.indexOf(name);
+  if (idx >= 0) return args[idx + 1];
+  return undefined;
+}
+
+export async function reindex(args: string[]): Promise<number> {
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log("arra-cli reindex [--repo-root <path>] [--retros] [--file <path>] [--no-wait]\n");
+    console.log("Triggers the server-side SQLite/FTS indexer via POST /api/indexer/reindex.");
+    console.log("\nOptions:");
+    console.log("  --repo-root <path>   Source repo/vault root to scan (default: server resolution)");
+    console.log("  --retros             Index only ψ/memory/retrospectives from repo-root (no smart-delete)");
+    console.log("  --file <path>        Index one retrospective markdown file (implies --retros)");
+    console.log("  --no-wait            Return after starting the server-side job");
+    console.log("\nEnv:");
+    console.log("  ORACLE_API           API base URL (default http://localhost:47778)");
+    return 0;
+  }
+
+  const repoRoot = takeFlagValue(args, "--repo-root");
+  const filePath = takeFlagValue(args, "--file");
+  const scope = filePath ? "retro-file" : args.includes("--retros") ? "retros" : "all";
+  const wait = !args.includes("--no-wait");
+
+  const res = await apiFetch("/api/indexer/reindex", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ repoRoot, filePath, scope, wait }),
+  });
+  const text = await res.text();
+  let payload: unknown = text;
+  try {
+    payload = text ? JSON.parse(text) : {};
+  } catch {
+    // Keep raw text for non-JSON server errors.
+  }
+
+  if (!res.ok) {
+    console.error(typeof payload === "string" ? payload : JSON.stringify(payload, null, 2));
+    return 1;
+  }
+
+  console.log(typeof payload === "string" ? payload : JSON.stringify(payload, null, 2));
+  return 0;
+}

--- a/src/indexer/cli.ts
+++ b/src/indexer/cli.ts
@@ -1,56 +1,14 @@
 /**
- * CLI entrypoint for running the Oracle indexer
+ * CLI entrypoint for running the Oracle indexer.
  */
 
-import fs from 'fs';
-import path from 'path';
-import { DB_PATH, CHROMADB_DIR } from '../config.ts';
-import { getVaultPsiRoot } from '../vault/handler.ts';
-import type { IndexerConfig } from '../types.ts';
-import { OracleIndexer } from './index.ts';
+import { runOracleReindex } from './runner.ts';
 
-// Prefer vault repo for centralized indexing, fall back to local psi/ detection
-const scriptDir = import.meta.dirname || path.dirname(new URL(import.meta.url).pathname);
-const projectRoot = path.resolve(scriptDir, '..', '..');
-
-const vaultResult = getVaultPsiRoot();
-const vaultRoot = 'path' in vaultResult ? vaultResult.path : null;
-
-// Vault may have project-first layout (github.com/org/repo/psi/) without a root psi/
-const vaultHasContent = vaultRoot && (
-  fs.existsSync(path.join(vaultRoot, '\u03c8')) ||
-  fs.existsSync(path.join(vaultRoot, 'github.com'))
-);
-const repoRoot = process.env.ORACLE_REPO_ROOT ||
-  (vaultHasContent ? vaultRoot :
-   fs.existsSync(path.join(projectRoot, '\u03c8')) ? projectRoot : process.cwd());
-
-const config: IndexerConfig = {
-  repoRoot,
-  dbPath: DB_PATH,
-  chromaPath: CHROMADB_DIR,
-  sourcePaths: {
-    resonance: '\u03c8/memory/resonance',
-    learnings: '\u03c8/memory/learnings',
-    retrospectives: '\u03c8/memory/retrospectives',
-    distillations: '\u03c8/memory/distillations',
-    // Opt-in: set ORACLE_INDEX_SECURITY_CORPUS=1 to include \u03c8/learn/security-corpus/.
-    // Default OFF because the corpus has ~36k files (one-time index ~10-30 min).
-    security_corpus: process.env.ORACLE_INDEX_SECURITY_CORPUS === '1'
-      ? '\u03c8/learn/security-corpus'
-      : undefined,
-  }
-};
-
-const indexer = new OracleIndexer(config);
-
-indexer.index()
-  .then(async () => {
+runOracleReindex()
+  .then(() => {
     console.log('Indexing complete!');
-    await indexer.close();
   })
-  .catch(async err => {
+  .catch(err => {
     console.error('Indexing failed:', err);
-    await indexer.close();
     process.exit(1);
   });

--- a/src/indexer/retro-index.ts
+++ b/src/indexer/retro-index.ts
@@ -1,0 +1,80 @@
+/**
+ * Retrospective-only indexing for local oracle ψ/ directories.
+ *
+ * Full reindex uses a canonical repoRoot and smart-delete. That is correct for
+ * aggregate vault indexing, but it is too blunt for `/rrr`-style local retro
+ * writes: a single oracle can write a fresh markdown file under its own
+ * `ψ/memory/retrospectives/` while the live DB was originally built from an
+ * older aggregate vault. This path mirrors oracle_learn's write-time behavior:
+ * parse the local file(s), upsert SQLite + FTS rows, and do not smart-delete
+ * unrelated historical docs.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { createDatabase } from '../db/index.ts';
+import { DB_PATH } from '../config.ts';
+import { detectProject } from '../server/project-detect.ts';
+import { collectDocuments } from './collectors.ts';
+import { parseRetroFile } from './parser.ts';
+import { storeDocuments } from './storage.ts';
+
+export async function indexRetrospectives(repoRoot: string) {
+  const resolvedRoot = path.resolve(repoRoot);
+  const seenContentHashes = new Set<string>();
+  const documents = collectDocuments({
+    config: {
+      repoRoot: resolvedRoot,
+      dbPath: DB_PATH,
+      chromaPath: '',
+      sourcePaths: {
+        resonance: 'ψ/memory/resonance',
+        learnings: 'ψ/memory/learnings',
+        retrospectives: 'ψ/memory/retrospectives',
+        distillations: 'ψ/memory/distillations',
+      },
+    },
+    seenContentHashes,
+    subdir: 'retrospectives',
+    parseFn: parseRetroFile,
+    label: 'retrospective',
+  });
+
+  const { sqlite, db } = createDatabase(DB_PATH);
+  try {
+    await storeDocuments(sqlite, db, null, detectProject(resolvedRoot), documents, {
+      createdBy: 'retro_indexer',
+    });
+  } finally {
+    sqlite.close();
+  }
+
+  return { ok: true as const, repoRoot: resolvedRoot, documents: documents.length };
+}
+
+export async function indexRetroFile(repoRoot: string, filePath: string) {
+  const resolvedRoot = path.resolve(repoRoot);
+  const resolvedFile = path.resolve(filePath);
+  const retroRoot = path.join(resolvedRoot, 'ψ', 'memory', 'retrospectives');
+
+  if (!resolvedFile.startsWith(retroRoot + path.sep)) {
+    throw new Error(`Refusing to index non-retro file outside ${retroRoot}: ${resolvedFile}`);
+  }
+  if (!fs.existsSync(resolvedFile)) {
+    throw new Error(`Retrospective file not found: ${resolvedFile}`);
+  }
+
+  const relPath = path.relative(resolvedRoot, resolvedFile);
+  const content = fs.readFileSync(resolvedFile, 'utf-8');
+  const documents = parseRetroFile(relPath, content);
+  const { sqlite, db } = createDatabase(DB_PATH);
+  try {
+    await storeDocuments(sqlite, db, null, detectProject(resolvedRoot), documents, {
+      createdBy: 'retro_indexer',
+    });
+  } finally {
+    sqlite.close();
+  }
+
+  return { ok: true as const, repoRoot: resolvedRoot, filePath: resolvedFile, documents: documents.length };
+}

--- a/src/indexer/runner.ts
+++ b/src/indexer/runner.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared reindex runner for the CLI and HTTP API.
+ *
+ * Keeps repoRoot resolution in one place so `bun run index`,
+ * `POST /api/indexer/reindex`, and `arra-cli reindex` all index the same
+ * source tree unless explicitly overridden.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { DB_PATH, CHROMADB_DIR } from '../config.ts';
+import { getVaultPsiRoot } from '../vault/handler.ts';
+import type { IndexerConfig } from '../types.ts';
+import { OracleIndexer } from './index.ts';
+
+const scriptDir = import.meta.dirname || path.dirname(new URL(import.meta.url).pathname);
+const projectRoot = path.resolve(scriptDir, '..', '..');
+
+export function resolveIndexerRepoRoot(explicitRoot?: string | null): string {
+  if (explicitRoot?.trim()) return path.resolve(explicitRoot);
+  if (process.env.ORACLE_REPO_ROOT?.trim()) return path.resolve(process.env.ORACLE_REPO_ROOT);
+
+  const vaultResult = getVaultPsiRoot();
+  const vaultRoot = 'path' in vaultResult ? vaultResult.path : null;
+  const vaultHasContent = vaultRoot && (
+    fs.existsSync(path.join(vaultRoot, 'ψ')) ||
+    fs.existsSync(path.join(vaultRoot, 'github.com'))
+  );
+
+  if (vaultHasContent) return vaultRoot;
+  if (fs.existsSync(path.join(projectRoot, 'ψ'))) return projectRoot;
+  return process.cwd();
+}
+
+export function createIndexerConfig(repoRoot: string): IndexerConfig {
+  return {
+    repoRoot,
+    dbPath: DB_PATH,
+    chromaPath: CHROMADB_DIR,
+    sourcePaths: {
+      resonance: 'ψ/memory/resonance',
+      learnings: 'ψ/memory/learnings',
+      retrospectives: 'ψ/memory/retrospectives',
+      distillations: 'ψ/memory/distillations',
+      // Opt-in: set ORACLE_INDEX_SECURITY_CORPUS=1 to include ψ/learn/security-corpus/.
+      // Default OFF because the corpus has ~36k files (one-time index ~10-30 min).
+      security_corpus: process.env.ORACLE_INDEX_SECURITY_CORPUS === '1'
+        ? 'ψ/learn/security-corpus'
+        : undefined,
+    },
+  };
+}
+
+export async function runOracleReindex(opts: { repoRoot?: string | null } = {}) {
+  const repoRoot = resolveIndexerRepoRoot(opts.repoRoot);
+  const config = createIndexerConfig(repoRoot);
+  const indexer = new OracleIndexer(config);
+
+  try {
+    await indexer.index();
+    return { ok: true as const, repoRoot };
+  } finally {
+    await indexer.close();
+  }
+}

--- a/src/indexer/storage.ts
+++ b/src/indexer/storage.ts
@@ -18,7 +18,8 @@ export async function storeDocuments(
   db: BunSQLiteDatabase<typeof schema>,
   vectorClient: VectorStoreAdapter | null,
   project: string | null,
-  documents: OracleDocument[]
+  documents: OracleDocument[],
+  opts: { createdBy?: string } = {}
 ): Promise<void> {
   const now = Date.now();
 
@@ -56,7 +57,7 @@ export async function storeDocuments(
           updatedAt: doc.updated_at,
           indexedAt: now,
           project: docProject,
-          createdBy: 'indexer',
+          createdBy: opts.createdBy || 'indexer',
         })
         .onConflictDoUpdate({
           target: oracleDocuments.id,

--- a/src/routes/indexer/__tests__/reindex.test.ts
+++ b/src/routes/indexer/__tests__/reindex.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, mock } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createReindexRoute } from '../reindex.ts';
+
+function post(app: Elysia, body: unknown) {
+  return app.handle(new Request('http://localhost/indexer/reindex', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+}
+
+describe('POST /indexer/reindex', () => {
+  it('runs the full reindex by default and waits for completion', async () => {
+    const runFull = mock(async ({ repoRoot }: { repoRoot?: string | null }) => ({ ok: true as const, repoRoot: repoRoot ?? '/repo' }));
+    const runRetros = mock(async (repoRoot: string) => ({ ok: true as const, repoRoot, documents: 0 }));
+    const runRetroFile = mock(async (repoRoot: string, filePath: string) => ({ ok: true as const, repoRoot, filePath, documents: 0 }));
+    const app = new Elysia().use(createReindexRoute({
+      resolveRepoRoot: () => '/repo',
+      runFull,
+      runRetros,
+      runRetroFile,
+    }));
+
+    const res = await post(app, {});
+    const body = await res.json() as any;
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.status).toBe('complete');
+    expect(body.repoRoot).toBe('/repo');
+    expect(runFull).toHaveBeenCalledTimes(1);
+    expect(runRetros).not.toHaveBeenCalled();
+  });
+
+  it('supports retrospective-only indexing without full smart-delete', async () => {
+    const runFull = mock(async ({ repoRoot }: { repoRoot?: string | null }) => ({ ok: true as const, repoRoot: repoRoot ?? '/repo' }));
+    const runRetros = mock(async (repoRoot: string) => ({ ok: true as const, repoRoot, documents: 3 }));
+    const runRetroFile = mock(async (repoRoot: string, filePath: string) => ({ ok: true as const, repoRoot, filePath, documents: 0 }));
+    const app = new Elysia().use(createReindexRoute({
+      resolveRepoRoot: () => '/oracle',
+      runFull,
+      runRetros,
+      runRetroFile,
+    }));
+
+    const res = await post(app, { scope: 'retros' });
+    const body = await res.json() as any;
+
+    expect(body.ok).toBe(true);
+    expect(body.documents).toBe(3);
+    expect(body.repoRoot).toBe('/oracle');
+    expect(runRetros).toHaveBeenCalledTimes(1);
+    expect(runFull).not.toHaveBeenCalled();
+  });
+
+  it('returns a 409 while a non-waiting job is active', async () => {
+    let release!: () => void;
+    const blocker = new Promise<void>(resolve => { release = resolve; });
+    const runFull = mock(async ({ repoRoot }: { repoRoot?: string | null }) => {
+      await blocker;
+      return { ok: true as const, repoRoot: repoRoot ?? '/repo' };
+    });
+    const runRetros = mock(async (repoRoot: string) => ({ ok: true as const, repoRoot, documents: 0 }));
+    const runRetroFile = mock(async (repoRoot: string, filePath: string) => ({ ok: true as const, repoRoot, filePath, documents: 0 }));
+    const app = new Elysia().use(createReindexRoute({
+      resolveRepoRoot: () => '/repo',
+      runFull,
+      runRetros,
+      runRetroFile,
+    }));
+
+    const first = await post(app, { wait: false });
+    expect(first.status).toBe(200);
+
+    const second = await post(app, {});
+    const body = await second.json() as any;
+    expect(second.status).toBe(409);
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('Reindex already running');
+
+    release();
+    await new Promise(resolve => setTimeout(resolve, 0));
+  });
+});

--- a/src/routes/indexer/index.ts
+++ b/src/routes/indexer/index.ts
@@ -2,6 +2,7 @@ import { Elysia } from 'elysia';
 import { configEndpoint } from './config.ts';
 import { scanEndpoint } from './scan.ts';
 import { startEndpoint } from './start.ts';
+import { reindexEndpoint } from './reindex.ts';
 import { progressEndpoint } from './progress.ts';
 import { stopEndpoint } from './stop.ts';
 
@@ -9,5 +10,6 @@ export const indexerRoutes = new Elysia({ prefix: '/api' })
   .use(configEndpoint)
   .use(scanEndpoint)
   .use(startEndpoint)
+  .use(reindexEndpoint)
   .use(progressEndpoint)
   .use(stopEndpoint);

--- a/src/routes/indexer/reindex.ts
+++ b/src/routes/indexer/reindex.ts
@@ -1,0 +1,82 @@
+import { Elysia, t } from 'elysia';
+import { runOracleReindex, resolveIndexerRepoRoot } from '../../indexer/runner.ts';
+import { indexRetrospectives, indexRetroFile } from '../../indexer/retro-index.ts';
+
+type ReindexResult =
+  | Awaited<ReturnType<typeof runOracleReindex>>
+  | Awaited<ReturnType<typeof indexRetrospectives>>
+  | Awaited<ReturnType<typeof indexRetroFile>>;
+
+export interface ReindexDeps {
+  resolveRepoRoot: (repoRoot?: string | null) => string;
+  runFull: (opts: { repoRoot?: string | null }) => Promise<ReindexResult>;
+  runRetros: (repoRoot: string) => Promise<ReindexResult>;
+  runRetroFile: (repoRoot: string, filePath: string) => Promise<ReindexResult>;
+}
+
+const defaultDeps: ReindexDeps = {
+  resolveRepoRoot: resolveIndexerRepoRoot,
+  runFull: runOracleReindex,
+  runRetros: indexRetrospectives,
+  runRetroFile: indexRetroFile,
+};
+
+export function createReindexRoute(deps: ReindexDeps = defaultDeps) {
+  let activeJob: { id: string; startedAt: string } | null = null;
+
+  return new Elysia().post('/indexer/reindex', async ({ body, set }) => {
+    const requested = body ?? {};
+    const scope = requested.scope ?? 'all';
+    const wait = requested.wait !== false;
+    const repoRoot = deps.resolveRepoRoot(requested.repoRoot);
+    const jobId = `reindex-${Date.now()}`;
+
+    if (activeJob) {
+      set.status = 409;
+      return { ok: false, error: 'Reindex already running', activeJob };
+    }
+
+    const run = async () => {
+      if (scope === 'retros') return deps.runRetros(repoRoot);
+      if (scope === 'retro-file') {
+        if (!requested.filePath) throw new Error('filePath is required for scope=retro-file');
+        return deps.runRetroFile(repoRoot, requested.filePath);
+      }
+      return deps.runFull({ repoRoot });
+    };
+
+    activeJob = { id: jobId, startedAt: new Date().toISOString() };
+    const task = run()
+      .then((result) => ({ jobId, status: 'complete' as const, ...result }))
+      .catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        return { ok: false as const, jobId, status: 'error' as const, repoRoot, error: message };
+      })
+      .finally(() => {
+        activeJob = null;
+      });
+
+    if (wait) return await task;
+
+    // Ensure background failures are observed by the task catch above.
+    void task;
+    return { ok: true, jobId, status: 'started', repoRoot, scope };
+  }, {
+    body: t.Optional(t.Object({
+      repoRoot: t.Optional(t.String()),
+      scope: t.Optional(t.Union([
+        t.Literal('all'),
+        t.Literal('retros'),
+        t.Literal('retro-file'),
+      ])),
+      filePath: t.Optional(t.String()),
+      wait: t.Optional(t.Boolean()),
+    })),
+    detail: {
+      tags: ['indexer'],
+      summary: 'Run SQLite/FTS reindex from the server process',
+    },
+  });
+}
+
+export const reindexEndpoint = createReindexRoute();


### PR DESCRIPTION
Closes #926

Refs #926.

Problem: retrospectives are written as markdown under local oracle `ψ/memory/retrospectives/`, while fresh learnings go through `oracle_learn` and index immediately. With `vaultRepo=null` or a stale aggregate vault, retros stay invisible until someone runs an ad-hoc direct DB reindex.

Fix:
- Add `POST /api/indexer/reindex` so the HTTP server can trigger SQLite/FTS reindexing through the same `ORACLE_API` path used by the CLI.
- Add `arra-cli reindex` (`--repo-root`, `--retros`, `--file`, `--no-wait`) as the first-class reindex command Nat asked for.
- Share repoRoot resolution between `bun run index` and the HTTP route.
- Add a retrospective-only local indexing path that upserts local `ψ/memory/retrospectives` with `createdBy=retro_indexer`, mirroring `oracle_learn` write-time durability and avoiding full smart-delete of unrelated aggregate-vault history.

Operational note:
- Phase 1 visible win already run live: copied local arra retros into the aggregate vault path and ran `ORACLE_REPO_ROOT=/opt/Code/github.com/Soul-Brews-Studio/oracle-vault bun run index`; `q="team comms bidirectional" type=retro mode=fts` went from `total=0` to `total=4` including `2026-05-31/09.37_team-comms-loop-bidirectional.md`.
- Release guidance: alpha only per Nat's standing rule; do not cut stable for this.

Verification:
- `bun test --isolate src/routes/indexer/__tests__/reindex.test.ts` -> 3 pass
- `bun run build` -> pass
- `bun run test:unit` -> 236 pass
- `bun run test:integration` -> 31 pass / 13 skipped
- isolated `ORACLE_API=http://localhost:47905 arra-cli reindex --repo-root <tmprepo>`: search before `0`, after `1`
- isolated `ORACLE_API=http://localhost:47906 arra-cli reindex --repo-root <tmprepo> --retros`: search before `0`, after `1`, `created_by=retro_indexer`

Not done:
- Did not restart live `:47778`; rollout is separate.
- Did not touch global `~/.claude.json`.

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3