### PR TITLE
ci: docker → GHCR (public, multi-arch)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# Never ship host-built native deps — they're arch-specific and rebuilt in-image.
+node_modules
+
+# VCS + CI
+.git
+.github
+.gitignore
+
+# Vault / indexed data — belongs in the mounted volume, not the image.
+ψ
+
+# Local data dirs (if anyone ran the server in the repo)
+.arra-oracle-v2
+.oracle
+*.db
+*.db-shm
+*.db-wal
+
+# Editor / OS noise
+.DS_Store
+.vscode
+.idea
+
+# Test + coverage artifacts
+coverage
+.nyc_output
+
+# Docker self
+Dockerfile
+.dockerignore
+
+# Misc local
+.serena
+.maw
+.rtk
+*.log
+dist

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,49 @@
+name: Publish Docker → GHCR
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/soul-brews-studio/arra-oracle-v3
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=tag
+            type=sha,prefix=sha-,format=short
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# arra-oracle-v3 — HTTP server image (FTS5-only / lean, multi-stage)
+#
+# Vector search degrades gracefully to SQLite FTS5 when no Ollama embedding
+# backend is reachable — so this image is fully functional standalone.
+# To enable semantic vector search later, set VECTOR_URL via -e at run time.
+#
+# Build:  docker build -t arra-oracle-v3 .
+# Run:    docker run -p 47778:47778 -v arra-data:/data arra-oracle-v3
+# Health: curl -sf http://localhost:47778/api/health
+
+# ─────────────────────────────────────────────────────────────────────────
+# Stage 1 — builder: resolve production deps, prune cross-arch dead weight
+# ─────────────────────────────────────────────────────────────────────────
+FROM oven/bun:1 AS builder
+WORKDIR /app
+
+# --production drops devDependencies (drizzle-kit, better-sqlite3, typescript,
+#   @types/*, bun-types) — none are used at server runtime. The server runs on
+#   Bun's built-in bun:sqlite + drizzle-orm (a real dep, pure JS). Dropping
+#   better-sqlite3 also removes its node-gyp build, so no toolchain is needed.
+# --ignore-scripts is belt-and-suspenders against any other postinstall.
+COPY package.json bun.lock ./
+RUN bun install --production --ignore-scripts \
+ && rm -rf node_modules/@lancedb/lancedb-*-musl
+
+# ─────────────────────────────────────────────────────────────────────────
+# Stage 2 — runtime: slim base + only what the server needs to run
+# ─────────────────────────────────────────────────────────────────────────
+FROM oven/bun:1-slim
+WORKDIR /app
+
+# HOME must be set — src/config.ts fails fast without it.
+# ORACLE_DATA_DIR holds SQLite (oracle.db), LanceDB collections, and the ψ/ vault.
+ENV HOME=/data \
+    ORACLE_DATA_DIR=/data \
+    ORACLE_PORT=47778
+
+# Pruned production node_modules from the builder (glibc lancedb binary only).
+COPY --from=builder /app/node_modules ./node_modules
+# Runtime source only — migrations live in src/db/migrations/*.sql, so src/
+# covers them. bin/cli/docs/e2e/tests/web/services are not needed to serve.
+COPY package.json bun.lock ./
+COPY src ./src
+
+# Persistent state lives here — mount a volume to keep the index across runs.
+RUN mkdir -p /data
+VOLUME ["/data"]
+
+EXPOSE 47778
+
+CMD ["bun", "src/server.ts"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,75 @@
+# arra-oracle-v3 — full stack: HTTP server + Ollama embedding sidecar
+#
+# This upgrades the lean FTS5-only image to FULL semantic vector search by
+# wiring an Ollama service. arra reaches it via OLLAMA_BASE_URL (service DNS).
+#
+#   docker compose up -d            # start arra + ollama + pull models
+#   docker compose logs -f arra     # watch the server
+#   curl -sf localhost:47778/api/health | jq .
+#   docker compose down             # stop (volumes persist)
+#   docker compose down -v          # stop + wipe data/models
+#
+# First run pulls embedding models (~1.5 GB for bge-m3 + nomic) into the
+# ollama-models volume — slow once, cached after. Until the pull finishes,
+# arra still serves (FTS5 fallback); vector search lights up when models land.
+
+services:
+  arra:
+    build: .
+    image: arra-oracle-v3:slim
+    ports:
+      - "47778:47778"
+    environment:
+      OLLAMA_BASE_URL: http://ollama:11434   # reach the sidecar by service name
+      ORACLE_DATA_DIR: /data
+      HOME: /data
+      ORACLE_PORT: "47778"
+    volumes:
+      - arra-data:/data                       # SQLite + LanceDB + ψ/ vault
+    depends_on:
+      ollama:
+        condition: service_healthy
+    restart: unless-stopped
+
+  ollama:
+    image: ollama/ollama:latest
+    # Expose 11434 on the host only if you want to poke ollama directly:
+    # ports:
+    #   - "11434:11434"
+    volumes:
+      - ollama-models:/root/.ollama           # persist pulled models
+    healthcheck:
+      test: ["CMD-SHELL", "ollama list >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12                              # ~2 min grace for cold start
+    restart: unless-stopped
+    # GPU (NVIDIA only; no effect on macOS Docker Desktop — CPU works fine):
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: all
+    #           capabilities: [gpu]
+
+  # One-shot: pull the embedding models, then exit. Re-runs are instant
+  # (already-pulled models are skipped). qwen3 is opt-in — uncomment if you
+  # query model=qwen3 (adds ~600 MB).
+  ollama-pull:
+    image: ollama/ollama:latest
+    depends_on:
+      ollama:
+        condition: service_healthy
+    environment:
+      OLLAMA_HOST: ollama:11434
+    entrypoint: ["/bin/sh", "-c"]
+    command: >
+      "ollama pull bge-m3 &&
+       ollama pull nomic-embed-text"
+    #   && ollama pull qwen3-embedding"
+    restart: "no"
+
+volumes:
+  arra-data:
+  ollama-models:


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/docker-publish.yml` — publishes the Docker image to **ghcr.io/soul-brews-studio/arra-oracle-v3** on every push to `main` and on `v*` tags
- Commits the existing untracked `Dockerfile`, `.dockerignore`, `docker-compose.yml` so CI has the build context
- Runs on `ubuntu-latest` (GitHub-hosted, not self-hosted) — sidesteps the self-hosted queue-stall pattern we just hit with `inbox-auto-add`
- Multi-arch: `linux/amd64` + `linux/arm64` (m5 + linux servers)
- GHA build cache (`type=gha`) — first build ~5min, subsequent builds ~30s

## Tags produced

```
ghcr.io/soul-brews-studio/arra-oracle-v3:latest         # main pushes
ghcr.io/soul-brews-studio/arra-oracle-v3:sha-<short>    # every commit
ghcr.io/soul-brews-studio/arra-oracle-v3:v26.5.31...    # on tags
```

## Public visibility

GHCR packages start **private** by default. After the first publish lands, set package visibility → public via:
- Org settings → Packages → arra-oracle-v3 → Change visibility → Public

(One-time manual step. The workflow can't set visibility itself.)

## Test plan

- [ ] Merge → first workflow run succeeds on `main`
- [ ] `docker pull ghcr.io/soul-brews-studio/arra-oracle-v3:latest` after package set to public
- [ ] `docker run -p 47778:47778 -v arra-data:/data ghcr.io/soul-brews-studio/arra-oracle-v3:latest`
- [ ] `curl localhost:47778/api/health` returns 200
- [ ] Multi-arch verify: `docker manifest inspect ghcr.io/soul-brews-studio/arra-oracle-v3:latest` shows both amd64 + arm64

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Refs #1242.
