### PR TITLE
feat(peer): expose maw handshake identity endpoints

### DIFF
--- a/src/peer/identity-key.ts
+++ b/src/peer/identity-key.ts
@@ -1,0 +1,44 @@
+import { randomBytes } from 'node:crypto';
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { ORACLE_DATA_DIR } from '../config.ts';
+
+const HEX_32_BYTES = /^[0-9a-f]{64}$/i;
+const DEFAULT_KEY_PATH = join(ORACLE_DATA_DIR, 'peer-key.hex');
+const cache = new Map<string, string>();
+
+export function peerKeyPath(dataDir = ORACLE_DATA_DIR): string {
+  return join(dataDir, 'peer-key.hex');
+}
+
+export function resetPubkeyCache(): void {
+  cache.clear();
+}
+
+function validate(hex: string, source: string): string {
+  const trimmed = hex.trim();
+  if (!HEX_32_BYTES.test(trimmed)) {
+    throw new Error(`${source} must contain a 64-char hex peer key`);
+  }
+  return trimmed.toLowerCase();
+}
+
+export function getPubkeyHex(keyPath = DEFAULT_KEY_PATH): string {
+  const cached = cache.get(keyPath);
+  if (cached) return cached;
+
+  if (existsSync(keyPath)) {
+    const existing = validate(readFileSync(keyPath, 'utf8'), keyPath);
+    try { chmodSync(keyPath, 0o600); } catch { /* best-effort for non-POSIX filesystems */ }
+    cache.set(keyPath, existing);
+    return existing;
+  }
+
+  mkdirSync(dirname(keyPath), { recursive: true, mode: 0o700 });
+  const generated = randomBytes(32).toString('hex');
+  writeFileSync(keyPath, `${generated}\n`, { mode: 0o600 });
+  try { chmodSync(keyPath, 0o600); } catch { /* best-effort for non-POSIX filesystems */ }
+  cache.set(keyPath, generated);
+  return generated;
+}

--- a/src/routes/peer/identity.ts
+++ b/src/routes/peer/identity.ts
@@ -1,0 +1,36 @@
+import { Elysia } from 'elysia';
+import { hostname } from 'node:os';
+
+import { getPubkeyHex } from '../../peer/identity-key.ts';
+import pkg from '../../../package.json' with { type: 'json' };
+
+function peerHost(): string {
+  return process.env.ORACLE_HOST?.trim() || hostname();
+}
+
+function peerNode(host = peerHost()): string {
+  return process.env.ORACLE_NODE?.trim() || `arra@${host}`;
+}
+
+export function createPeerIdentityRoute(keyPath?: string) {
+  return new Elysia().get('/api/identity', () => {
+    const host = peerHost();
+    return {
+      pubkey: getPubkeyHex(keyPath),
+      node: peerNode(host),
+      oracle: 'arra',
+      version: pkg.version,
+      host,
+      uptime: process.uptime(),
+      clockUtc: new Date().toISOString(),
+    };
+  }, {
+    detail: {
+      tags: ['peer'],
+      menu: { group: 'hidden' },
+      summary: 'Maw peer identity (TOFU-pinned pubkey)',
+    },
+  });
+}
+
+export const peerIdentityRoute = createPeerIdentityRoute();

--- a/src/routes/peer/index.ts
+++ b/src/routes/peer/index.ts
@@ -1,0 +1,8 @@
+import { Elysia } from 'elysia';
+
+import { peerInfoRoute } from './info.ts';
+import { peerIdentityRoute } from './identity.ts';
+
+export const peerRoutes = new Elysia()
+  .use(peerInfoRoute)
+  .use(peerIdentityRoute);

--- a/src/routes/peer/info.ts
+++ b/src/routes/peer/info.ts
@@ -1,0 +1,40 @@
+import { Elysia } from 'elysia';
+import { hostname, userInfo } from 'node:os';
+
+import { PORT } from '../../config.ts';
+import pkg from '../../../package.json' with { type: 'json' };
+
+function peerHost(): string {
+  return process.env.ORACLE_HOST?.trim() || hostname();
+}
+
+function peerNode(host = peerHost()): string {
+  return process.env.ORACLE_NODE?.trim() || `arra@${host}`;
+}
+
+function peerUser(): string | undefined {
+  if (process.env.ORACLE_USER?.trim()) return process.env.ORACLE_USER.trim();
+  if (process.env.USER?.trim()) return process.env.USER.trim();
+  try { return userInfo().username; } catch { return undefined; }
+}
+
+export const peerInfoRoute = new Elysia().get('/info', () => {
+  const host = peerHost();
+  return {
+    maw: { schema: '1', capabilities: ['arra-search'] },
+    node: peerNode(host),
+    oracle: 'arra',
+    version: pkg.version,
+    ts: new Date().toISOString(),
+    host,
+    user: peerUser(),
+    port: Number(PORT),
+    nickname: process.env.ORACLE_NICKNAME?.trim() || 'arra',
+  };
+}, {
+  detail: {
+    tags: ['peer'],
+    menu: { group: 'hidden' },
+    summary: 'Maw peer handshake gate',
+  },
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -41,6 +41,7 @@ import { pluginsRouter } from './routes/plugins/index.ts';
 import { oraclenetRoutes } from './routes/oraclenet/index.ts';
 import { sessionsRoutes } from './routes/sessions/index.ts';
 import { vaultRoutes } from './routes/vault/index.ts';
+import { peerRoutes } from './routes/peer/index.ts';
 import { createMenuRoutes } from './routes/menu/index.ts';
 
 // Indexer routes are optional — MCP server works without them
@@ -188,6 +189,7 @@ const app = new Elysia()
     }),
   )
   .use(gatewayPlugin(ORACLE_DATA_DIR, VECTOR_URL || undefined))
+  .use(peerRoutes)
   .get('/', () => ({
     server: MCP_SERVER_NAME,
     version: pkg.version,

--- a/src/server/__tests__/peer-identity.test.ts
+++ b/src/server/__tests__/peer-identity.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { Elysia } from 'elysia';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { getPubkeyHex, peerKeyPath, resetPubkeyCache } from '../../peer/identity-key.ts';
+import { peerInfoRoute } from '../../routes/peer/info.ts';
+import { createPeerIdentityRoute } from '../../routes/peer/identity.ts';
+
+const tmpDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-peer-identity-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  resetPubkeyCache();
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('maw peer handshake identity', () => {
+  it('serves /info as JSON from its own path', async () => {
+    const app = new Elysia().use(peerInfoRoute);
+    const response = await app.handle(new Request('http://localhost/info'));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.maw.schema).toBe('1');
+    expect(payload.maw.capabilities).toContain('arra-search');
+    expect(payload.node).toMatch(/^arra@.+/);
+    expect(payload.oracle).toBe('arra');
+  });
+
+  it('creates and reuses a persisted 0600 peer pubkey', () => {
+    const dir = makeTempDir();
+    const keyFile = peerKeyPath(dir);
+
+    const first = getPubkeyHex(keyFile);
+    const second = getPubkeyHex(keyFile);
+    const mode = fs.statSync(keyFile).mode & 0o777;
+
+    expect(first).toMatch(/^[0-9a-f]{64}$/);
+    expect(second).toBe(first);
+    expect(mode).toBe(0o600);
+  });
+
+  it('serves /api/identity with pubkey, node, and oracle fields', async () => {
+    const dir = makeTempDir();
+    const keyFile = peerKeyPath(dir);
+    const app = new Elysia().use(createPeerIdentityRoute(keyFile));
+
+    const response = await app.handle(new Request('http://localhost/api/identity'));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.pubkey).toMatch(/^[0-9a-f]{64}$/);
+    expect(payload.node).toMatch(/^arra@.+/);
+    expect(payload.oracle).toBe('arra');
+    expect(fs.existsSync(keyFile)).toBe(true);
+  });
+});


### PR DESCRIPTION
Refs #1211 (Phase 1 mawjs pairing unblocker).

## Problem
mawjs `maw peers add <base-url>` probes `GET /info` as the JSON handshake gate and then fetches `GET /api/identity` for TOFU pinning. Arra did not expose either endpoint, so mawjs could not pair with Arra as a discoverable federated-search peer.

## Fix
- Add unauthed `GET /info` at the exact path mawjs probes, returning `maw.schema='1'`, `node='arra@<host>'`, `oracle='arra'`, and a bare `arra-search` capability.
- Add unauthed `GET /api/identity`, returning a stable 64-char hex `pubkey`, `node`, and `oracle='arra'`.
- Generate the pubkey with `crypto.randomBytes(32)` and persist it at `ORACLE_DATA_DIR/peer-key.hex` with mode `0600`.
- Keep Phase 1 narrow: no Scout multicast, no pair endpoint, no reverse-pairing, no Arra-side TOFU store.

## Verification
- `bun test --isolate src/server/__tests__/peer-identity.test.ts` → 3 pass
- `bun run build` → pass
- `bun run test:unit` → 239 pass
- Smoke server on spare port (`ORACLE_PORT=47921`, temp data dir):
  - `/info` → `{ maw: { schema: '1', capabilities: ['arra-search'] }, node: 'arra@m5', oracle: 'arra' }`
  - `/api/identity` → stable 64-char hex pubkey + `node` + `oracle='arra'`
  - `peer-key.hex` mode → `600`

## Not tested
- External mawjs `maw peers add` against a deployed base URL; ready once this lands and the live Arra HTTP server is serving the new routes.

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3
