### PR TITLE
feat(mcp): proxy oracle_trace through HTTP writer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -226,6 +226,8 @@ function proxyRequestForTool(toolName: string, args: Record<string, unknown>): P
       const threadId = cleanQueryValue(args.threadId);
       return threadId ? { method: 'PATCH', path: `/api/thread/${encodeURIComponent(threadId)}/status`, body: { status: args.status } } : null;
     }
+    case 'oracle_trace':
+      return { method: 'POST', path: '/api/traces', body: args };
     case 'oracle_trace_list':
       return { method: 'GET', path: '/api/traces', query: queryFrom(args, { query: 'query', status: 'status', project: 'project', limit: 'limit', offset: 'offset' }) };
     case 'oracle_trace_get': {

--- a/src/routes/traces/create.ts
+++ b/src/routes/traces/create.ts
@@ -1,0 +1,39 @@
+import { Elysia } from 'elysia';
+
+import { createTrace } from '../../trace/handler.ts';
+import { traceCreateBody } from './model.ts';
+import type { CreateTraceInput } from '../../trace/types.ts';
+
+export const traceCreateRoute = new Elysia().post('/api/traces', ({ body, set }) => {
+  const input = body as Partial<CreateTraceInput> | null | undefined;
+  if (!input || typeof input.query !== 'string' || input.query.trim().length === 0) {
+    set.status = 400;
+    return {
+      success: false,
+      error: "oracle_trace requires field 'query' (non-empty string).",
+      usage: "POST /api/traces { query: 'what was traced', scope?: 'project'|'cross-project'|'human' }",
+    };
+  }
+
+  const result = createTrace(input as CreateTraceInput);
+  set.status = 201;
+  return {
+    success: result.success,
+    trace_id: result.traceId,
+    depth: result.depth,
+    summary: {
+      file_count: result.summary.fileCount,
+      commit_count: result.summary.commitCount,
+      issue_count: result.summary.issueCount,
+      total_dig_points: result.summary.totalDigPoints,
+    },
+    message: `Trace logged. Use oracle_trace_get with trace_id="${result.traceId}" to explore dig points.`,
+  };
+}, {
+  body: traceCreateBody,
+  detail: {
+    tags: ['traces'],
+    menu: { group: 'hidden' },
+    summary: 'Create a trace log entry',
+  },
+});

--- a/src/routes/traces/index.ts
+++ b/src/routes/traces/index.ts
@@ -1,4 +1,5 @@
 import { Elysia } from 'elysia';
+import { traceCreateRoute } from './create.ts';
 import { tracesListRoute } from './list.ts';
 import { traceGetRoute } from './get.ts';
 import { traceChainRoute } from './chain.ts';
@@ -7,6 +8,7 @@ import { traceUnlinkRoute } from './unlink.ts';
 import { traceLinkedChainRoute } from './linked-chain.ts';
 
 export const tracesApi = new Elysia()
+  .use(traceCreateRoute)
   .use(tracesListRoute)
   .use(traceGetRoute)
   .use(traceChainRoute)

--- a/src/routes/traces/model.ts
+++ b/src/routes/traces/model.ts
@@ -20,3 +20,5 @@ export const unlinkQuery = t.Object({
 });
 
 export const linkBody = t.Unknown();
+
+export const traceCreateBody = t.Unknown();

--- a/src/server/__tests__/trace-create-route.test.ts
+++ b/src/server/__tests__/trace-create-route.test.ts
@@ -1,0 +1,63 @@
+import { afterAll, describe, expect, it } from 'bun:test';
+import { Elysia } from 'elysia';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-trace-route-repo-'));
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-trace-route-data-'));
+const originalRepoRoot = process.env.ORACLE_REPO_ROOT;
+const originalDataDir = process.env.ORACLE_DATA_DIR;
+const originalDbPath = process.env.ORACLE_DB_PATH;
+
+process.env.ORACLE_REPO_ROOT = repoRoot;
+process.env.ORACLE_DATA_DIR = dataDir;
+process.env.ORACLE_DB_PATH = path.join(dataDir, 'oracle.db');
+
+const { traceCreateRoute } = await import('../../routes/traces/create.ts');
+const { getTrace } = await import('../../trace/handler.ts');
+
+describe('POST /api/traces', () => {
+  it('creates a trace and returns the MCP-compatible summary shape', async () => {
+    const app = new Elysia().use(traceCreateRoute);
+
+    const response = await app.handle(new Request('http://localhost/api/traces', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ query: 'phase 2 trace route smoke', scope: 'project', project: 'test/repo' }),
+    }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(payload.success).toBe(true);
+    expect(payload.trace_id).toBeString();
+    expect(payload.summary.total_dig_points).toBeNumber();
+    expect(getTrace(payload.trace_id)?.query).toBe('phase 2 trace route smoke');
+  });
+
+  it('rejects a missing query before writing', async () => {
+    const app = new Elysia().use(traceCreateRoute);
+
+    const response = await app.handle(new Request('http://localhost/api/traces', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.success).toBe(false);
+    expect(payload.error).toContain('query');
+  });
+});
+
+afterAll(() => {
+  fs.rmSync(repoRoot, { recursive: true, force: true });
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  if (originalRepoRoot) process.env.ORACLE_REPO_ROOT = originalRepoRoot;
+  else delete process.env.ORACLE_REPO_ROOT;
+  if (originalDataDir) process.env.ORACLE_DATA_DIR = originalDataDir;
+  else delete process.env.ORACLE_DATA_DIR;
+  if (originalDbPath) process.env.ORACLE_DB_PATH = originalDbPath;
+  else delete process.env.ORACLE_DB_PATH;
+});

--- a/src/tools/__tests__/mcp-trace-proxy.test.ts
+++ b/src/tools/__tests__/mcp-trace-proxy.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Regression for #1244 Phase 2 (trace-create gap): oracle_trace should proxy
+ * through ORACLE_API instead of lazy-opening embedded SQLite when the HTTP
+ * server is reachable.
+ */
+
+import { afterEach, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const repoRoot = resolve(import.meta.dir, '../../..');
+const tempDirs: string[] = [];
+const childProcesses: Array<{ kill: () => void }> = [];
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function waitForHealth(baseUrl: string): Promise<void> {
+  for (let i = 0; i < 60; i++) {
+    try {
+      const res = await fetch(`${baseUrl}/api/health`);
+      if (res.ok) return;
+    } catch { /* server still booting */ }
+    await Bun.sleep(250);
+  }
+  throw new Error(`server did not become healthy: ${baseUrl}`);
+}
+
+afterEach(() => {
+  for (const proc of childProcesses.splice(0)) proc.kill();
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+test('oracle_trace proxies through ORACLE_API without opening the MCP DB', async () => {
+  const port = 48600 + Math.floor(Math.random() * 500);
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const serverDataDir = tempDir('arra-trace-proxy-server-');
+  const serverRepoRoot = tempDir('arra-trace-proxy-repo-');
+  const mcpDataDir = tempDir('arra-trace-proxy-mcp-');
+  const mcpDbPath = join(mcpDataDir, 'oracle.db');
+
+  const server = Bun.spawn(['bun', 'src/server.ts'], {
+    cwd: repoRoot,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      ...process.env,
+      ORACLE_PORT: String(port),
+      ORACLE_DATA_DIR: serverDataDir,
+      ORACLE_DB_PATH: join(serverDataDir, 'oracle.db'),
+      ORACLE_REPO_ROOT: serverRepoRoot,
+      ORACLE_INDEXER_ENQUEUE: '0',
+    },
+  });
+  childProcesses.push(server);
+  await waitForHealth(baseUrl);
+
+  const transport = new StdioClientTransport({
+    command: 'bun',
+    args: [join(repoRoot, 'src/index.ts')],
+    env: {
+      ...process.env,
+      ORACLE_API: baseUrl,
+      ORACLE_DATA_DIR: mcpDataDir,
+      ORACLE_DB_PATH: mcpDbPath,
+      ORACLE_INDEXER_ENQUEUE: '0',
+    },
+    stderr: 'pipe',
+  });
+
+  const stderr: string[] = [];
+  transport.stderr?.on('data', (chunk) => stderr.push(chunk.toString()));
+
+  const client = new Client(
+    { name: 'mcp-trace-proxy-test', version: '0.0.0' },
+    { capabilities: {} },
+  );
+
+  try {
+    await client.connect(transport);
+    const result = await client.callTool({
+      name: 'oracle_trace',
+      arguments: { query: 'trace proxy route smoke', scope: 'project', project: 'test/repo' },
+    }) as { content?: Array<{ type: string; text: string }>; isError?: boolean };
+
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content?.[0]?.text ?? '{}');
+    expect(payload.success).toBe(true);
+    expect(payload.trace_id).toBeString();
+    expect(stderr.join('')).not.toContain('ORACLE_API unavailable for oracle_trace');
+    expect(existsSync(mcpDbPath)).toBe(false);
+  } finally {
+    await client.close();
+  }
+}, 30_000);


### PR DESCRIPTION
Refs #1244 (Phase 2, first remaining gap tool: trace-create).

## Problem
#1245 made stdio MCP proxy-first through `ORACLE_API`, but `oracle_trace` still had no HTTP route/mapping. In proxy mode, calling `oracle_trace` therefore fell through to lazy embedded mode and opened the MCP process' own SQLite handle.

## Fix
- Add `POST /api/traces` for trace creation using the existing `createTrace()` handler.
- Return the same MCP-compatible summary shape (`success`, `trace_id`, `depth`, `summary`, `message`).
- Map `oracle_trace` in the MCP proxy table to `POST /api/traces`.

## Verification
- `bun test --isolate src/server/__tests__/trace-create-route.test.ts src/tools/__tests__/mcp-trace-proxy.test.ts` → 3 pass
- `bun run build` → pass
- `bun run test:unit` → 242 pass
- New proxy regression proves `oracle_trace` succeeds through `ORACLE_API` and the stdio MCP data dir never gets an `oracle.db` file (no embedded DB opened on the covered path).

## Remaining #1244 Phase 2 gaps
Kept intentionally lean per tool:
- `oracle_concepts` → needs HTTP route + proxy mapping
- `oracle_verify` → needs HTTP route + proxy mapping
- `oracle_supersede` → existing HTTP routes are legacy/list surfaces; MCP `oracle_documents.superseded_by` semantics still need a matching HTTP route/mapping

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3
