### PR TITLE
feat(mcp): proxy oracle_concepts through HTTP writer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -189,6 +189,8 @@ function proxyRequestForTool(toolName: string, args: Record<string, unknown>): P
       return { method: 'POST', path: '/api/learn', body: args };
     case 'oracle_stats':
       return { method: 'GET', path: '/api/stats' };
+    case 'oracle_concepts':
+      return { method: 'GET', path: '/api/concepts', query: queryFrom(args, { limit: 'limit', type: 'type' }) };
     case 'oracle_read':
       return { method: 'GET', path: '/api/read', query: queryFrom(args, { file: 'file', id: 'id' }) };
     case 'oracle_list':

--- a/src/routes/concepts/index.ts
+++ b/src/routes/concepts/index.ts
@@ -1,0 +1,30 @@
+import { Elysia, t } from 'elysia';
+
+import { db } from '../../db/index.ts';
+import { listConcepts } from '../../tools/concepts.ts';
+import type { OracleConceptsInput } from '../../tools/types.ts';
+
+const ConceptsQuery = t.Object({
+  limit: t.Optional(t.String()),
+  type: t.Optional(t.String()),
+});
+
+function toConceptsInput(query: { limit?: string; type?: string }): OracleConceptsInput {
+  const parsedLimit = query.limit ? parseInt(query.limit, 10) : NaN;
+  const limit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : undefined;
+  const type = ['principle', 'pattern', 'learning', 'retro', 'all'].includes(query.type ?? '')
+    ? query.type as OracleConceptsInput['type']
+    : 'all';
+  return { limit, type };
+}
+
+export const conceptsRoutes = new Elysia({ prefix: '/api' }).get('/concepts', ({ query }) => (
+  listConcepts(db, toConceptsInput(query))
+), {
+  query: ConceptsQuery,
+  detail: {
+    tags: ['search'],
+    menu: { group: 'tools', order: 45 },
+    summary: 'List concept tags with document counts',
+  },
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,6 +30,7 @@ import { feedRoutes } from './routes/feed/index.ts';
 import { healthRoutes } from './routes/health/index.ts';
 import { dashboardRoutes } from './routes/dashboard/index.ts';
 import { searchRoutes } from './routes/search/index.ts';
+import { conceptsRoutes } from './routes/concepts/index.ts';
 import { vectorRoutes } from './routes/vector/index.ts';
 import { knowledgeRoutes } from './routes/knowledge/index.ts';
 import { supersedeRoutes } from './routes/supersede/index.ts';
@@ -205,6 +206,7 @@ const apiModules = [
   healthRoutes,
   dashboardRoutes,
   searchRoutes,
+  conceptsRoutes,
   vectorRoutes,
   knowledgeRoutes,
   supersedeRoutes,

--- a/src/server/__tests__/concepts-route.test.ts
+++ b/src/server/__tests__/concepts-route.test.ts
@@ -1,0 +1,66 @@
+import { afterAll, describe, expect, it } from 'bun:test';
+import { Elysia } from 'elysia';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-concepts-route-data-'));
+const originalDataDir = process.env.ORACLE_DATA_DIR;
+const originalDbPath = process.env.ORACLE_DB_PATH;
+
+process.env.ORACLE_DATA_DIR = dataDir;
+process.env.ORACLE_DB_PATH = path.join(dataDir, 'oracle.db');
+
+const { db, oracleDocuments } = await import('../../db/index.ts');
+const { conceptsRoutes } = await import('../../routes/concepts/index.ts');
+
+describe('GET /api/concepts', () => {
+  it('lists concept tags with counts and type filtering', async () => {
+    db.insert(oracleDocuments).values([
+      {
+        id: 'concepts-learning-1',
+        type: 'learning',
+        title: 'Learning 1',
+        content: 'one',
+        concepts: JSON.stringify(['alpha', 'shared']),
+        sourceFile: 'ψ/memory/learnings/concepts-learning-1.md',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        indexedAt: Date.now(),
+      },
+      {
+        id: 'concepts-retro-1',
+        type: 'retro',
+        title: 'Retro 1',
+        content: 'two',
+        concepts: JSON.stringify(['shared']),
+        sourceFile: 'ψ/memory/retrospectives/concepts-retro-1.md',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        indexedAt: Date.now(),
+      },
+    ]).run();
+
+    const app = new Elysia().use(conceptsRoutes);
+    const allResponse = await app.handle(new Request('http://localhost/api/concepts?limit=5'));
+    const allPayload = await allResponse.json();
+    const learningResponse = await app.handle(new Request('http://localhost/api/concepts?type=learning&limit=5'));
+    const learningPayload = await learningResponse.json();
+
+    expect(allResponse.status).toBe(200);
+    expect(allPayload.concepts).toContainEqual({ name: 'shared', count: 2 });
+    expect(allPayload.total_unique).toBeGreaterThanOrEqual(2);
+    expect(learningResponse.status).toBe(200);
+    expect(learningPayload.concepts).toContainEqual({ name: 'alpha', count: 1 });
+    expect(learningPayload.concepts).toContainEqual({ name: 'shared', count: 1 });
+    expect(learningPayload.filter_type).toBe('learning');
+  });
+});
+
+afterAll(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  if (originalDataDir) process.env.ORACLE_DATA_DIR = originalDataDir;
+  else delete process.env.ORACLE_DATA_DIR;
+  if (originalDbPath) process.env.ORACLE_DB_PATH = originalDbPath;
+  else delete process.env.ORACLE_DB_PATH;
+});

--- a/src/tools/__tests__/mcp-concepts-proxy.test.ts
+++ b/src/tools/__tests__/mcp-concepts-proxy.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Regression for #1244 Phase 2 (concepts gap): oracle_concepts should proxy
+ * through ORACLE_API instead of lazy-opening embedded SQLite when the HTTP
+ * server is reachable.
+ */
+
+import { afterEach, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const repoRoot = resolve(import.meta.dir, '../../..');
+const tempDirs: string[] = [];
+const childProcesses: Array<{ kill: () => void }> = [];
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function waitForHealth(baseUrl: string): Promise<void> {
+  for (let i = 0; i < 60; i++) {
+    try {
+      const res = await fetch(`${baseUrl}/api/health`);
+      if (res.ok) return;
+    } catch { /* server still booting */ }
+    await Bun.sleep(250);
+  }
+  throw new Error(`server did not become healthy: ${baseUrl}`);
+}
+
+afterEach(() => {
+  for (const proc of childProcesses.splice(0)) proc.kill();
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+test('oracle_concepts proxies through ORACLE_API without opening the MCP DB', async () => {
+  const port = 49100 + Math.floor(Math.random() * 500);
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const serverDataDir = tempDir('arra-concepts-proxy-server-');
+  const serverRepoRoot = tempDir('arra-concepts-proxy-repo-');
+  const mcpDataDir = tempDir('arra-concepts-proxy-mcp-');
+  const mcpDbPath = join(mcpDataDir, 'oracle.db');
+
+  const server = Bun.spawn(['bun', 'src/server.ts'], {
+    cwd: repoRoot,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      ...process.env,
+      ORACLE_PORT: String(port),
+      ORACLE_DATA_DIR: serverDataDir,
+      ORACLE_DB_PATH: join(serverDataDir, 'oracle.db'),
+      ORACLE_REPO_ROOT: serverRepoRoot,
+      ORACLE_INDEXER_ENQUEUE: '0',
+    },
+  });
+  childProcesses.push(server);
+  await waitForHealth(baseUrl);
+
+  const transport = new StdioClientTransport({
+    command: 'bun',
+    args: [join(repoRoot, 'src/index.ts')],
+    env: {
+      ...process.env,
+      ORACLE_API: baseUrl,
+      ORACLE_DATA_DIR: mcpDataDir,
+      ORACLE_DB_PATH: mcpDbPath,
+      ORACLE_INDEXER_ENQUEUE: '0',
+    },
+    stderr: 'pipe',
+  });
+
+  const stderr: string[] = [];
+  transport.stderr?.on('data', (chunk) => stderr.push(chunk.toString()));
+
+  const client = new Client(
+    { name: 'mcp-concepts-proxy-test', version: '0.0.0' },
+    { capabilities: {} },
+  );
+
+  try {
+    await client.connect(transport);
+    const result = await client.callTool({
+      name: 'oracle_concepts',
+      arguments: { type: 'all', limit: 5 },
+    }) as { content?: Array<{ type: string; text: string }>; isError?: boolean };
+
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content?.[0]?.text ?? '{}');
+    expect(Array.isArray(payload.concepts)).toBe(true);
+    expect(payload.filter_type).toBe('all');
+    expect(stderr.join('')).not.toContain('ORACLE_API unavailable for oracle_concepts');
+    expect(existsSync(mcpDbPath)).toBe(false);
+  } finally {
+    await client.close();
+  }
+}, 30_000);

--- a/src/tools/concepts.ts
+++ b/src/tools/concepts.ts
@@ -30,13 +30,13 @@ export const conceptsToolDef = {
   }
 };
 
-export async function handleConcepts(ctx: ToolContext, input: OracleConceptsInput): Promise<ToolResponse> {
+export function listConcepts(db: ToolContext['db'], input: OracleConceptsInput) {
   const { limit = 50, type = 'all' } = input;
 
   const baseCondition = and(isNotNull(oracleDocuments.concepts), ne(oracleDocuments.concepts, '[]'));
   const rows = type === 'all'
-    ? ctx.db.select({ concepts: oracleDocuments.concepts }).from(oracleDocuments).where(baseCondition).all()
-    : ctx.db.select({ concepts: oracleDocuments.concepts }).from(oracleDocuments).where(and(baseCondition, eq(oracleDocuments.type, type))).all();
+    ? db.select({ concepts: oracleDocuments.concepts }).from(oracleDocuments).where(baseCondition).all()
+    : db.select({ concepts: oracleDocuments.concepts }).from(oracleDocuments).where(and(baseCondition, eq(oracleDocuments.type, type))).all();
 
   const conceptCounts = new Map<string, number>();
   for (const row of rows as Array<{ concepts: string }>) {
@@ -65,13 +65,17 @@ export async function handleConcepts(ctx: ToolContext, input: OracleConceptsInpu
     .slice(0, limit);
 
   return {
+    concepts: sortedConcepts,
+    total_unique: conceptCounts.size,
+    filter_type: type,
+  };
+}
+
+export async function handleConcepts(ctx: ToolContext, input: OracleConceptsInput): Promise<ToolResponse> {
+  return {
     content: [{
       type: 'text',
-      text: JSON.stringify({
-        concepts: sortedConcepts,
-        total_unique: conceptCounts.size,
-        filter_type: type,
-      }, null, 2)
-    }]
+      text: JSON.stringify(listConcepts(ctx.db, input), null, 2),
+    }],
   };
 }


### PR DESCRIPTION
Refs #1244 (Phase 2).

Problem: `oracle_concepts` was still an embedded-only MCP fallback, so a proxied fleet MCP process could lazy-open its own SQLite handle when that tool was used.

Fix: adds `GET /api/concepts`, reuses the existing concept-counting implementation for HTTP + embedded paths, and maps MCP `oracle_concepts` through `ORACLE_API` when the HTTP writer is reachable.

Regression proof: `src/tools/__tests__/mcp-concepts-proxy.test.ts` calls `oracle_concepts` through a live test HTTP server and asserts the MCP-side `oracle.db` is not created/opened.

Verification:
- `bun test --isolate src/server/__tests__/concepts-route.test.ts src/tools/__tests__/mcp-concepts-proxy.test.ts` → 2 pass
- `bun run build` → exit 0
- `bun run test:unit` → 244 pass

Tool coverage update:
- Proxied now: search/learn/stats/read/list/inbox/handoff/forum/trace-create/trace-read/trace-list/trace-link/trace-unlink/trace-chain/reflect/concepts
- Remaining #1244 embedded gaps: verify, supersede

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3
