### PR TITLE
feat(mcp): proxy oracle_verify through HTTP writer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -253,6 +253,8 @@ function proxyRequestForTool(toolName: string, args: Record<string, unknown>): P
     }
     case 'oracle_reflect':
       return { method: 'GET', path: '/api/reflect' };
+    case 'oracle_verify':
+      return { method: 'POST', path: '/api/verify', body: args };
     default:
       return null;
   }

--- a/src/routes/verify/index.ts
+++ b/src/routes/verify/index.ts
@@ -1,0 +1,59 @@
+import { Elysia, t } from 'elysia';
+
+import { REPO_ROOT } from '../../config.ts';
+import { runVerify } from '../../tools/verify.ts';
+import type { OracleVerifyInput } from '../../tools/types.ts';
+
+const VerifyQuery = t.Object({
+  check: t.Optional(t.String()),
+  type: t.Optional(t.String()),
+});
+
+const VerifyBody = t.Object({
+  check: t.Optional(t.Boolean()),
+  type: t.Optional(t.String()),
+});
+
+function parseBoolean(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  if (value === 'false') return false;
+  if (value === 'true') return true;
+  return undefined;
+}
+
+function parseType(value: string | undefined): OracleVerifyInput['type'] {
+  return ['principle', 'pattern', 'learning', 'retro', 'all'].includes(value ?? '')
+    ? value as OracleVerifyInput['type']
+    : 'all';
+}
+
+function queryToInput(query: { check?: string; type?: string }): OracleVerifyInput {
+  return {
+    check: parseBoolean(query.check),
+    type: parseType(query.type),
+  };
+}
+
+function bodyToInput(body: { check?: boolean; type?: string }): OracleVerifyInput {
+  return {
+    check: body.check,
+    type: parseType(body.type),
+  };
+}
+
+export const verifyRoutes = new Elysia({ prefix: '/api' })
+  .get('/verify', async ({ query }) => runVerify(queryToInput(query), REPO_ROOT), {
+    query: VerifyQuery,
+    detail: {
+      tags: ['search'],
+      menu: { group: 'tools', order: 46 },
+      summary: 'Verify knowledge base disk files against the DB index',
+    },
+  })
+  .post('/verify', async ({ body }) => runVerify(bodyToInput(body), REPO_ROOT), {
+    body: VerifyBody,
+    detail: {
+      tags: ['search'],
+      summary: 'Verify knowledge base and optionally flag orphaned DB entries',
+    },
+  });

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,6 +31,7 @@ import { healthRoutes } from './routes/health/index.ts';
 import { dashboardRoutes } from './routes/dashboard/index.ts';
 import { searchRoutes } from './routes/search/index.ts';
 import { conceptsRoutes } from './routes/concepts/index.ts';
+import { verifyRoutes } from './routes/verify/index.ts';
 import { vectorRoutes } from './routes/vector/index.ts';
 import { knowledgeRoutes } from './routes/knowledge/index.ts';
 import { supersedeRoutes } from './routes/supersede/index.ts';
@@ -207,6 +208,7 @@ const apiModules = [
   dashboardRoutes,
   searchRoutes,
   conceptsRoutes,
+  verifyRoutes,
   vectorRoutes,
   knowledgeRoutes,
   supersedeRoutes,

--- a/src/server/__tests__/verify-route.test.ts
+++ b/src/server/__tests__/verify-route.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, describe, expect, it } from 'bun:test';
+import { Elysia } from 'elysia';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-verify-route-data-'));
+const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-verify-route-repo-'));
+const originalDataDir = process.env.ORACLE_DATA_DIR;
+const originalDbPath = process.env.ORACLE_DB_PATH;
+const originalRepoRoot = process.env.ORACLE_REPO_ROOT;
+
+process.env.ORACLE_DATA_DIR = dataDir;
+process.env.ORACLE_DB_PATH = path.join(dataDir, 'oracle.db');
+process.env.ORACLE_REPO_ROOT = repoRoot;
+
+fs.mkdirSync(path.join(repoRoot, 'ψ/memory/learnings'), { recursive: true });
+fs.writeFileSync(path.join(repoRoot, 'ψ/memory/learnings/healthy.md'), '# Healthy\n');
+
+const { db, oracleDocuments } = await import('../../db/index.ts');
+const { verifyRoutes } = await import('../../routes/verify/index.ts');
+
+describe('GET/POST /api/verify', () => {
+  it('reports disk-vs-index health and supports orphan flagging through HTTP', async () => {
+    db.insert(oracleDocuments).values([
+      {
+        id: 'verify-healthy-1',
+        type: 'learning',
+        concepts: JSON.stringify(['verify']),
+        sourceFile: 'ψ/memory/learnings/healthy.md',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        indexedAt: Date.now() + 10_000,
+      },
+      {
+        id: 'verify-orphan-1',
+        type: 'learning',
+        concepts: JSON.stringify(['verify']),
+        sourceFile: 'ψ/memory/learnings/missing.md',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        indexedAt: Date.now(),
+      },
+    ]).run();
+
+    const app = new Elysia().use(verifyRoutes);
+    const checkResponse = await app.handle(new Request('http://localhost/api/verify?type=learning'));
+    const checkPayload = await checkResponse.json();
+
+    expect(checkResponse.status).toBe(200);
+    expect(checkPayload.counts.healthy).toBe(1);
+    expect(checkPayload.counts.orphaned).toBe(1);
+    expect(checkPayload.orphaned).toContain('ψ/memory/learnings/missing.md');
+
+    const fixResponse = await app.handle(new Request('http://localhost/api/verify', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ check: false, type: 'learning' }),
+    }));
+    const fixPayload = await fixResponse.json();
+
+    expect(fixResponse.status).toBe(200);
+    expect(fixPayload.fixed_orphans).toBe(1);
+  });
+});
+
+afterAll(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  fs.rmSync(repoRoot, { recursive: true, force: true });
+  if (originalDataDir) process.env.ORACLE_DATA_DIR = originalDataDir;
+  else delete process.env.ORACLE_DATA_DIR;
+  if (originalDbPath) process.env.ORACLE_DB_PATH = originalDbPath;
+  else delete process.env.ORACLE_DB_PATH;
+  if (originalRepoRoot) process.env.ORACLE_REPO_ROOT = originalRepoRoot;
+  else delete process.env.ORACLE_REPO_ROOT;
+});

--- a/src/tools/__tests__/mcp-verify-proxy.test.ts
+++ b/src/tools/__tests__/mcp-verify-proxy.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Regression for #1244 Phase 2 (verify gap): oracle_verify should proxy
+ * through ORACLE_API instead of lazy-opening embedded SQLite when the HTTP
+ * server is reachable.
+ */
+
+import { afterEach, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const repoRoot = resolve(import.meta.dir, '../../..');
+const tempDirs: string[] = [];
+const childProcesses: Array<{ kill: () => void }> = [];
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function waitForHealth(baseUrl: string): Promise<void> {
+  for (let i = 0; i < 60; i++) {
+    try {
+      const res = await fetch(`${baseUrl}/api/health`);
+      if (res.ok) return;
+    } catch { /* server still booting */ }
+    await Bun.sleep(250);
+  }
+  throw new Error(`server did not become healthy: ${baseUrl}`);
+}
+
+afterEach(() => {
+  for (const proc of childProcesses.splice(0)) proc.kill();
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+test('oracle_verify proxies through ORACLE_API without opening the MCP DB', async () => {
+  const port = 49600 + Math.floor(Math.random() * 300);
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const serverDataDir = tempDir('arra-verify-proxy-server-');
+  const serverRepoRoot = tempDir('arra-verify-proxy-repo-');
+  const mcpDataDir = tempDir('arra-verify-proxy-mcp-');
+  const mcpDbPath = join(mcpDataDir, 'oracle.db');
+
+  const server = Bun.spawn(['bun', 'src/server.ts'], {
+    cwd: repoRoot,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      ...process.env,
+      ORACLE_PORT: String(port),
+      ORACLE_DATA_DIR: serverDataDir,
+      ORACLE_DB_PATH: join(serverDataDir, 'oracle.db'),
+      ORACLE_REPO_ROOT: serverRepoRoot,
+      ORACLE_INDEXER_ENQUEUE: '0',
+    },
+  });
+  childProcesses.push(server);
+  await waitForHealth(baseUrl);
+
+  const transport = new StdioClientTransport({
+    command: 'bun',
+    args: [join(repoRoot, 'src/index.ts')],
+    env: {
+      ...process.env,
+      ORACLE_API: baseUrl,
+      ORACLE_DATA_DIR: mcpDataDir,
+      ORACLE_DB_PATH: mcpDbPath,
+      ORACLE_INDEXER_ENQUEUE: '0',
+    },
+    stderr: 'pipe',
+  });
+
+  const stderr: string[] = [];
+  transport.stderr?.on('data', (chunk) => stderr.push(chunk.toString()));
+
+  const client = new Client(
+    { name: 'mcp-verify-proxy-test', version: '0.0.0' },
+    { capabilities: {} },
+  );
+
+  try {
+    await client.connect(transport);
+    const result = await client.callTool({
+      name: 'oracle_verify',
+      arguments: { check: true, type: 'all' },
+    }) as { content?: Array<{ type: string; text: string }>; isError?: boolean };
+
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content?.[0]?.text ?? '{}');
+    expect(payload.counts).toBeDefined();
+    expect(payload.counts.healthy).toBeNumber();
+    expect(stderr.join('')).not.toContain('ORACLE_API unavailable for oracle_verify');
+    expect(existsSync(mcpDbPath)).toBe(false);
+  } finally {
+    await client.close();
+  }
+}, 30_000);

--- a/src/tools/verify.ts
+++ b/src/tools/verify.ts
@@ -35,30 +35,34 @@ export const verifyToolDef = {
   }
 };
 
-export async function handleVerify(ctx: ToolContext, input: OracleVerifyInput): Promise<ToolResponse> {
+export async function runVerify(input: OracleVerifyInput, repoRoot: string) {
   const { check = true, type } = input;
 
   const verifyKnowledgeBase = await loadVerifyKnowledgeBase();
   const result = verifyKnowledgeBase({
     check,
     type,
-    repoRoot: ctx.repoRoot,
+    repoRoot,
   });
 
-  console.error(`[MCP:VERIFY] healthy=${result.counts.healthy} missing=${result.counts.missing} orphaned=${result.counts.orphaned} drifted=${result.counts.drifted}`);
+  console.error(`[VERIFY] healthy=${result.counts.healthy} missing=${result.counts.missing} orphaned=${result.counts.orphaned} drifted=${result.counts.drifted}`);
 
+  return {
+    counts: result.counts,
+    missing: result.missing,
+    orphaned: result.orphaned,
+    drifted: result.drifted,
+    untracked: result.untracked,
+    recommendation: result.recommendation,
+    ...(result.fixedOrphans ? { fixed_orphans: result.fixedOrphans } : {}),
+  };
+}
+
+export async function handleVerify(ctx: ToolContext, input: OracleVerifyInput): Promise<ToolResponse> {
   return {
     content: [{
       type: 'text',
-      text: JSON.stringify({
-        counts: result.counts,
-        missing: result.missing,
-        orphaned: result.orphaned,
-        drifted: result.drifted,
-        untracked: result.untracked,
-        recommendation: result.recommendation,
-        ...(result.fixedOrphans ? { fixed_orphans: result.fixedOrphans } : {}),
-      }, null, 2)
+      text: JSON.stringify(await runVerify(input, ctx.repoRoot), null, 2)
     }]
   };
 }


### PR DESCRIPTION
Refs #1244 (Phase 2).

Problem: `oracle_verify` was still an embedded MCP fallback, so in proxied fleet mode invoking verify could lazy-open an MCP-side SQLite handle instead of using the single HTTP writer.

Fix: adds `/api/verify` (GET for read-only reports, POST for body/check=false orphan-flagging), extracts a shared `runVerify()` payload helper, and maps MCP `oracle_verify` through `ORACLE_API`.

Regression proof: `src/tools/__tests__/mcp-verify-proxy.test.ts` calls `oracle_verify` through a live test HTTP server and asserts the MCP-side `oracle.db` is not created/opened.

Verification:
- `bun test --isolate src/server/__tests__/verify-route.test.ts src/tools/__tests__/mcp-verify-proxy.test.ts` → 2 pass
- `bun run build` → exit 0
- `bun run test:unit` → 246 pass

Tool coverage update:
- Proxied now: search/learn/stats/read/list/inbox/handoff/forum/trace-create/trace-read/trace-list/trace-link/trace-unlink/trace-chain/reflect/concepts/verify
- Remaining #1244 embedded gap: supersede

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3
