### PR TITLE
feat(mcp): proxy oracle_supersede through HTTP writer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,8 @@ function proxyRequestForTool(toolName: string, args: Record<string, unknown>): P
       };
     case 'oracle_learn':
       return { method: 'POST', path: '/api/learn', body: args };
+    case 'oracle_supersede':
+      return { method: 'POST', path: '/api/supersede/document', body: args };
     case 'oracle_stats':
       return { method: 'GET', path: '/api/stats' };
     case 'oracle_concepts':

--- a/src/routes/supersede/create.ts
+++ b/src/routes/supersede/create.ts
@@ -7,7 +7,9 @@
 
 import { Elysia } from 'elysia';
 import { db, supersedeLog } from '../../db/index.ts';
-import { SupersedeBody } from './model.ts';
+import { runSupersede } from '../../tools/supersede.ts';
+import type { OracleSupersededInput } from '../../tools/types.ts';
+import { SupersedeBody, SupersedeDocumentBody } from './model.ts';
 
 export const supersedeCreateEndpoint = new Elysia().post(
   '/supersede',
@@ -49,6 +51,28 @@ export const supersedeCreateEndpoint = new Elysia().post(
       tags: ['supersede'],
       menu: { group: 'hidden' },
       summary: 'Append to legacy supersede_log',
+    },
+  },
+);
+
+export const supersedeDocumentEndpoint = new Elysia().post(
+  '/supersede/document',
+  ({ body, set }) => {
+    try {
+      const result = runSupersede(db, body as OracleSupersededInput);
+      if (result.isError) set.status = 400;
+      return result.payload;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      set.status = message.includes('not found') ? 404 : 500;
+      return { success: false, error: message };
+    }
+  },
+  {
+    body: SupersedeDocumentBody,
+    detail: {
+      tags: ['supersede'],
+      summary: 'Mark an indexed document as superseded by another document',
     },
   },
 );

--- a/src/routes/supersede/index.ts
+++ b/src/routes/supersede/index.ts
@@ -5,9 +5,10 @@
 import { Elysia } from 'elysia';
 import { supersedeListEndpoint } from './list.ts';
 import { supersedeChainEndpoint } from './chain.ts';
-import { supersedeCreateEndpoint } from './create.ts';
+import { supersedeCreateEndpoint, supersedeDocumentEndpoint } from './create.ts';
 
 export const supersedeRoutes = new Elysia({ prefix: '/api' })
   .use(supersedeListEndpoint)
   .use(supersedeChainEndpoint)
-  .use(supersedeCreateEndpoint);
+  .use(supersedeCreateEndpoint)
+  .use(supersedeDocumentEndpoint);

--- a/src/routes/supersede/model.ts
+++ b/src/routes/supersede/model.ts
@@ -11,3 +11,5 @@ export const SupersedeQuery = t.Object({
 });
 
 export const SupersedeBody = t.Any();
+
+export const SupersedeDocumentBody = t.Any();

--- a/src/server/__tests__/supersede-document-route.test.ts
+++ b/src/server/__tests__/supersede-document-route.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, describe, expect, it } from 'bun:test';
+import { Elysia } from 'elysia';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { eq } from 'drizzle-orm';
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-supersede-route-data-'));
+const originalDataDir = process.env.ORACLE_DATA_DIR;
+const originalDbPath = process.env.ORACLE_DB_PATH;
+
+process.env.ORACLE_DATA_DIR = dataDir;
+process.env.ORACLE_DB_PATH = path.join(dataDir, 'oracle.db');
+
+const { db, oracleDocuments } = await import('../../db/index.ts');
+const { supersedeRoutes } = await import('../../routes/supersede/index.ts');
+
+describe('POST /api/supersede/document', () => {
+  it('marks oracle_documents supersession using MCP semantics', async () => {
+    const now = Date.now();
+    db.insert(oracleDocuments).values([
+      {
+        id: 'supersede-old-1',
+        type: 'learning',
+        concepts: JSON.stringify(['supersede']),
+        sourceFile: 'ψ/memory/learnings/supersede-old.md',
+        createdAt: now,
+        updatedAt: now,
+        indexedAt: now,
+      },
+      {
+        id: 'supersede-new-1',
+        type: 'learning',
+        concepts: JSON.stringify(['supersede']),
+        sourceFile: 'ψ/memory/learnings/supersede-new.md',
+        createdAt: now,
+        updatedAt: now,
+        indexedAt: now,
+      },
+    ]).run();
+
+    const app = new Elysia().use(supersedeRoutes);
+    const response = await app.handle(new Request('http://localhost/api/supersede/document', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ oldId: 'supersede-old-1', newId: 'supersede-new-1', reason: 'newer learning' }),
+    }));
+    const payload = await response.json();
+
+    const oldDoc = db.select({ supersededBy: oracleDocuments.supersededBy, supersededReason: oracleDocuments.supersededReason })
+      .from(oracleDocuments)
+      .where(eq(oracleDocuments.id, 'supersede-old-1'))
+      .get();
+
+    expect(response.status).toBe(200);
+    expect(payload.success).toBe(true);
+    expect(payload.old_id).toBe('supersede-old-1');
+    expect(payload.new_id).toBe('supersede-new-1');
+    expect(oldDoc?.supersededBy).toBe('supersede-new-1');
+    expect(oldDoc?.supersededReason).toBe('newer learning');
+  });
+});
+
+afterAll(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  if (originalDataDir) process.env.ORACLE_DATA_DIR = originalDataDir;
+  else delete process.env.ORACLE_DATA_DIR;
+  if (originalDbPath) process.env.ORACLE_DB_PATH = originalDbPath;
+  else delete process.env.ORACLE_DB_PATH;
+});

--- a/src/tools/__tests__/mcp-supersede-proxy.test.ts
+++ b/src/tools/__tests__/mcp-supersede-proxy.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Regression for #1244 Phase 2 (supersede gap): oracle_supersede should proxy
+ * through ORACLE_API instead of lazy-opening embedded SQLite when the HTTP
+ * server is reachable.
+ */
+
+import { afterEach, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const repoRoot = resolve(import.meta.dir, '../../..');
+const tempDirs: string[] = [];
+const childProcesses: Array<{ kill: () => void }> = [];
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function waitForHealth(baseUrl: string): Promise<void> {
+  for (let i = 0; i < 60; i++) {
+    try {
+      const res = await fetch(`${baseUrl}/api/health`);
+      if (res.ok) return;
+    } catch { /* server still booting */ }
+    await Bun.sleep(250);
+  }
+  throw new Error(`server did not become healthy: ${baseUrl}`);
+}
+
+async function learn(baseUrl: string, pattern: string): Promise<string> {
+  const res = await fetch(`${baseUrl}/api/learn`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ pattern, concepts: ['supersede-proxy'], source: 'mcp-supersede-proxy-test' }),
+  });
+  expect(res.status).toBe(200);
+  const payload = await res.json() as { id?: string };
+  expect(payload.id).toBeString();
+  return payload.id!;
+}
+
+afterEach(() => {
+  for (const proc of childProcesses.splice(0)) proc.kill();
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+test('oracle_supersede proxies through ORACLE_API without opening the MCP DB', async () => {
+  const port = 49900 + Math.floor(Math.random() * 300);
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const serverDataDir = tempDir('arra-supersede-proxy-server-');
+  const serverRepoRoot = tempDir('arra-supersede-proxy-repo-');
+  const mcpDataDir = tempDir('arra-supersede-proxy-mcp-');
+  const mcpDbPath = join(mcpDataDir, 'oracle.db');
+
+  const server = Bun.spawn(['bun', 'src/server.ts'], {
+    cwd: repoRoot,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      ...process.env,
+      ORACLE_PORT: String(port),
+      ORACLE_DATA_DIR: serverDataDir,
+      ORACLE_DB_PATH: join(serverDataDir, 'oracle.db'),
+      ORACLE_REPO_ROOT: serverRepoRoot,
+      ORACLE_INDEXER_ENQUEUE: '0',
+    },
+  });
+  childProcesses.push(server);
+  await waitForHealth(baseUrl);
+
+  const suffix = `${Date.now()}-${Math.random()}`;
+  const oldId = await learn(baseUrl, `old supersede proxy ${suffix}`);
+  const newId = await learn(baseUrl, `new supersede proxy ${suffix}`);
+
+  const transport = new StdioClientTransport({
+    command: 'bun',
+    args: [join(repoRoot, 'src/index.ts')],
+    env: {
+      ...process.env,
+      ORACLE_API: baseUrl,
+      ORACLE_DATA_DIR: mcpDataDir,
+      ORACLE_DB_PATH: mcpDbPath,
+      ORACLE_INDEXER_ENQUEUE: '0',
+    },
+    stderr: 'pipe',
+  });
+
+  const stderr: string[] = [];
+  transport.stderr?.on('data', (chunk) => stderr.push(chunk.toString()));
+
+  const client = new Client(
+    { name: 'mcp-supersede-proxy-test', version: '0.0.0' },
+    { capabilities: {} },
+  );
+
+  try {
+    await client.connect(transport);
+    const result = await client.callTool({
+      name: 'oracle_supersede',
+      arguments: { oldId, newId, reason: 'proxy regression' },
+    }) as { content?: Array<{ type: string; text: string }>; isError?: boolean };
+
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content?.[0]?.text ?? '{}');
+    expect(payload.success).toBe(true);
+    expect(payload.old_id).toBe(oldId);
+    expect(payload.new_id).toBe(newId);
+    expect(stderr.join('')).not.toContain('ORACLE_API unavailable for oracle_supersede');
+    expect(existsSync(mcpDbPath)).toBe(false);
+  } finally {
+    await client.close();
+  }
+}, 30_000);

--- a/src/tools/supersede.ts
+++ b/src/tools/supersede.ts
@@ -9,6 +9,11 @@ import { eq } from 'drizzle-orm';
 import { oracleDocuments } from '../db/schema.ts';
 import type { ToolContext, ToolResponse, OracleSupersededInput } from './types.ts';
 
+type SupersedeRunResult = {
+  payload: Record<string, unknown>;
+  isError?: boolean;
+};
+
 export const supersedeToolDef = {
   name: 'oracle_supersede',
   description: 'Mark an old learning/document as superseded by a newer one. Aligns with "Nothing is Deleted" - old doc preserved but marked outdated.',
@@ -32,71 +37,62 @@ export const supersedeToolDef = {
   }
 };
 
-export async function handleSupersede(ctx: ToolContext, input: OracleSupersededInput): Promise<ToolResponse> {
+export function runSupersede(db: ToolContext['db'], input: OracleSupersededInput): SupersedeRunResult {
   if (input == null || typeof input !== 'object') {
     return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          success: false,
-          error: "arra_supersede requires fields 'oldId' and 'newId' (both non-empty strings).",
-          usage: "arra_supersede({ oldId: 'learning_X', newId: 'learning_Y', reason?: 'why' })",
-          tip: "Search for the IDs with arra_search or arra_list first."
-        }, null, 2)
-      }],
-      isError: true
+      payload: {
+        success: false,
+        error: "arra_supersede requires fields 'oldId' and 'newId' (both non-empty strings).",
+        usage: "arra_supersede({ oldId: 'learning_X', newId: 'learning_Y', reason?: 'why' })",
+        tip: 'Search for the IDs with arra_search or arra_list first.',
+      },
+      isError: true,
     };
   }
+
   const { oldId, newId, reason } = input as { oldId?: unknown; newId?: unknown; reason?: unknown };
   if (typeof oldId !== 'string' || oldId.length === 0) {
     return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          success: false,
-          error: "arra_supersede requires field 'oldId' (non-empty string).",
-          received: oldId === undefined ? 'undefined' : typeof oldId,
-          usage: "arra_supersede({ oldId: 'learning_X', newId: 'learning_Y' })"
-        }, null, 2)
-      }],
-      isError: true
+      payload: {
+        success: false,
+        error: "arra_supersede requires field 'oldId' (non-empty string).",
+        received: oldId === undefined ? 'undefined' : typeof oldId,
+        usage: "arra_supersede({ oldId: 'learning_X', newId: 'learning_Y' })",
+      },
+      isError: true,
     };
   }
+
   if (typeof newId !== 'string' || newId.length === 0) {
     return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          success: false,
-          error: "arra_supersede requires field 'newId' (non-empty string).",
-          received: newId === undefined ? 'undefined' : typeof newId,
-          usage: "arra_supersede({ oldId: 'learning_X', newId: 'learning_Y' })"
-        }, null, 2)
-      }],
-      isError: true
+      payload: {
+        success: false,
+        error: "arra_supersede requires field 'newId' (non-empty string).",
+        received: newId === undefined ? 'undefined' : typeof newId,
+        usage: "arra_supersede({ oldId: 'learning_X', newId: 'learning_Y' })",
+      },
+      isError: true,
     };
   }
+
   if (oldId === newId) {
     return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          success: false,
-          error: "arra_supersede oldId and newId must be different documents.",
-          received: { oldId, newId },
-          tip: "A document cannot supersede itself. Did you intend to update content via arra_learn instead?"
-        }, null, 2)
-      }],
-      isError: true
+      payload: {
+        success: false,
+        error: 'arra_supersede oldId and newId must be different documents.',
+        received: { oldId, newId },
+        tip: 'A document cannot supersede itself. Did you intend to update content via arra_learn instead?',
+      },
+      isError: true,
     };
   }
-  const now = Date.now();
 
-  const oldDoc = ctx.db.select({ id: oracleDocuments.id, type: oracleDocuments.type })
+  const now = Date.now();
+  const oldDoc = db.select({ id: oracleDocuments.id, type: oracleDocuments.type })
     .from(oracleDocuments)
     .where(eq(oracleDocuments.id, oldId))
     .get();
-  const newDoc = ctx.db.select({ id: oracleDocuments.id, type: oracleDocuments.type })
+  const newDoc = db.select({ id: oracleDocuments.id, type: oracleDocuments.type })
     .from(oracleDocuments)
     .where(eq(oracleDocuments.id, newId))
     .get();
@@ -104,7 +100,7 @@ export async function handleSupersede(ctx: ToolContext, input: OracleSupersededI
   if (!oldDoc) throw new Error(`Old document not found: ${oldId}`);
   if (!newDoc) throw new Error(`New document not found: ${newId}`);
 
-  ctx.db.update(oracleDocuments)
+  db.update(oracleDocuments)
     .set({
       supersededBy: newId,
       supersededAt: now,
@@ -113,21 +109,29 @@ export async function handleSupersede(ctx: ToolContext, input: OracleSupersededI
     .where(eq(oracleDocuments.id, oldId))
     .run();
 
-  console.error(`[MCP:SUPERSEDE] ${oldId} → superseded by → ${newId}`);
+  console.error(`[SUPERSEDE] ${oldId} → superseded by → ${newId}`);
 
+  return {
+    payload: {
+      success: true,
+      old_id: oldId,
+      old_type: oldDoc.type,
+      new_id: newId,
+      new_type: newDoc.type,
+      reason: reason || null,
+      superseded_at: new Date(now).toISOString(),
+      message: `"${oldId}" is now marked as superseded by "${newId}". It will still appear in search results (P-001 Nothing is Deleted), now flagged with "superseded_by", "superseded_at", and "superseded_reason" fields so callers can follow the replacement pointer.`,
+    },
+  };
+}
+
+export async function handleSupersede(ctx: ToolContext, input: OracleSupersededInput): Promise<ToolResponse> {
+  const result = runSupersede(ctx.db, input);
   return {
     content: [{
       type: 'text',
-      text: JSON.stringify({
-        success: true,
-        old_id: oldId,
-        old_type: oldDoc.type,
-        new_id: newId,
-        new_type: newDoc.type,
-        reason: reason || null,
-        superseded_at: new Date(now).toISOString(),
-        message: `"${oldId}" is now marked as superseded by "${newId}". It will still appear in search results (P-001 Nothing is Deleted), now flagged with "superseded_by", "superseded_at", and "superseded_reason" fields so callers can follow the replacement pointer.`
-      }, null, 2)
-    }]
+      text: JSON.stringify(result.payload, null, 2),
+    }],
+    ...(result.isError ? { isError: true } : {}),
   };
 }


### PR DESCRIPTION
Refs #1244 (Phase 2).

Problem: `oracle_supersede` was the last MCP embedded gap. In proxied fleet mode, invoking it could lazy-open an MCP-side SQLite handle instead of routing through the single HTTP writer.

Fix: adds `POST /api/supersede/document` for the MCP document-supersession semantics (`oracle_documents.superseded_by`). The legacy `POST /api/supersede` log endpoint is unchanged. MCP `oracle_supersede` now routes through `ORACLE_API` to the new endpoint when reachable.

Regression proof: `src/tools/__tests__/mcp-supersede-proxy.test.ts` calls `oracle_supersede` through a live test HTTP server and asserts the MCP-side `oracle.db` is not created/opened.

Verification:
- `bun test --isolate src/server/__tests__/supersede-document-route.test.ts src/tools/__tests__/mcp-supersede-proxy.test.ts` → 2 pass
- `bun run build` → exit 0
- `bun run test:unit` → 248 pass

Tool coverage update:
- Proxied now: search/learn/stats/read/list/inbox/handoff/forum/trace-create/trace-read/trace-list/trace-link/trace-unlink/trace-chain/reflect/concepts/verify/supersede
- Remaining #1244 embedded gaps: none from the Phase 2 list

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3
