### PR TITLE
fix: harden LanceDB reindex against stale handles

### DIFF
--- a/src/scripts/index-model.ts
+++ b/src/scripts/index-model.ts
@@ -49,9 +49,9 @@ async function main() {
 
   await store.connect();
 
-  // Fresh index
-  try { await store.deleteCollection(); } catch {}
-  await store.ensureCollection();
+  if (!store.replaceDocuments) {
+    throw new Error(`Vector adapter '${store.name}' does not support safe replaceDocuments(); refusing drop/recreate reindex (#987).`);
+  }
 
   // FTS5 join requires raw SQL — Drizzle doesn't support virtual tables
   const rows = sqlite.prepare(`
@@ -75,6 +75,10 @@ async function main() {
   let errors = 0;
   const startTime = Date.now();
 
+  if (rows.length === 0) {
+    await store.replaceDocuments([]);
+  }
+
   for (let i = 0; i < rows.length; i += BATCH_SIZE) {
     const batch = rows.slice(i, i + BATCH_SIZE);
     const batchNum = Math.floor(i / BATCH_SIZE) + 1;
@@ -91,7 +95,15 @@ async function main() {
     }));
 
     try {
-      await store.addDocuments(docs);
+      if (i === 0) {
+        // Replace the first batch in-place instead of drop/recreate. Dropping
+        // the LanceDB table invalidates long-lived server/MCP table handles and
+        // caused silent vector-store corruption after index-model backfills
+        // (#987). Subsequent batches append to the same table version chain.
+        await store.replaceDocuments(docs);
+      } else {
+        await store.addDocuments(docs);
+      }
       indexed += docs.length;
 
       const elapsed = ((Date.now() - startTime) / 1000).toFixed(0);
@@ -101,6 +113,11 @@ async function main() {
     } catch (e) {
       errors++;
       console.error(`  Batch ${batchNum} FAILED:`, e instanceof Error ? e.message : String(e));
+      if (i === 0) {
+        throw new Error('First reindex batch failed during safe replace; aborting to avoid appending into stale pre-reindex data.', {
+          cause: e,
+        });
+      }
     }
   }
 

--- a/src/tools/__tests__/learn.test.ts
+++ b/src/tools/__tests__/learn.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from 'bun:test';
-import { normalizeProject, extractProjectFromSource } from '../learn.ts';
+import { normalizeProject, extractProjectFromSource, errorDetails } from '../learn.ts';
 
 // ============================================================================
 // normalizeProject
@@ -72,5 +72,19 @@ describe('extractProjectFromSource', () => {
 
   it('should return null when no project found', () => {
     expect(extractProjectFromSource('just some random text')).toBeNull();
+  });
+});
+
+describe('errorDetails', () => {
+  it('includes name, message, stack, and cause for Error instances', () => {
+    const cause = new Error('root cause');
+    const err = new TypeError('embed failed') as TypeError & { cause?: Error };
+    err.cause = cause;
+    const details = errorDetails(err);
+
+    expect(details.name).toBe('TypeError');
+    expect(details.message).toBe('embed failed');
+    expect(details.stack).toContain('TypeError');
+    expect(details.cause).toContain('root cause');
   });
 });

--- a/src/tools/__tests__/mcp-learn-proxy.test.ts
+++ b/src/tools/__tests__/mcp-learn-proxy.test.ts
@@ -1,0 +1,105 @@
+/**
+ * #987 / #1244 architecture guard:
+ * with ORACLE_API set, oracle_learn must run through the HTTP server and avoid
+ * opening the stdio MCP's embedded SQLite/vector path entirely.
+ */
+
+import { afterEach, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const repoRoot = resolve(import.meta.dir, '../../..');
+const tempDirs: string[] = [];
+const childProcesses: Array<{ kill: () => void }> = [];
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function waitForHealth(baseUrl: string): Promise<void> {
+  for (let i = 0; i < 60; i++) {
+    try {
+      const res = await fetch(`${baseUrl}/api/health`);
+      if (res.ok) return;
+    } catch { /* server still booting */ }
+    await Bun.sleep(250);
+  }
+  throw new Error(`server did not become healthy: ${baseUrl}`);
+}
+
+afterEach(() => {
+  for (const proc of childProcesses.splice(0)) proc.kill();
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+test('oracle_learn proxies through ORACLE_API without opening the MCP DB', async () => {
+  const port = 49600 + Math.floor(Math.random() * 300);
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const serverDataDir = tempDir('arra-learn-proxy-server-');
+  const serverRepoRoot = tempDir('arra-learn-proxy-repo-');
+  const mcpDataDir = tempDir('arra-learn-proxy-mcp-');
+  const mcpDbPath = join(mcpDataDir, 'oracle.db');
+
+  const server = Bun.spawn(['bun', 'src/server.ts'], {
+    cwd: repoRoot,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      ...process.env,
+      ORACLE_PORT: String(port),
+      ORACLE_DATA_DIR: serverDataDir,
+      ORACLE_DB_PATH: join(serverDataDir, 'oracle.db'),
+      ORACLE_REPO_ROOT: serverRepoRoot,
+      ORACLE_INDEXER_ENQUEUE: '0',
+    },
+  });
+  childProcesses.push(server);
+  await waitForHealth(baseUrl);
+
+  const transport = new StdioClientTransport({
+    command: 'bun',
+    args: [join(repoRoot, 'src/index.ts')],
+    env: {
+      ...process.env,
+      ORACLE_API: baseUrl,
+      ORACLE_DATA_DIR: mcpDataDir,
+      ORACLE_DB_PATH: mcpDbPath,
+      ORACLE_INDEXER_ENQUEUE: '0',
+    },
+    stderr: 'pipe',
+  });
+
+  const stderr: string[] = [];
+  transport.stderr?.on('data', (chunk) => stderr.push(chunk.toString()));
+
+  const client = new Client(
+    { name: 'mcp-learn-proxy-test', version: '0.0.0' },
+    { capabilities: {} },
+  );
+
+  try {
+    await client.connect(transport);
+    const result = await client.callTool({
+      name: 'oracle_learn',
+      arguments: {
+        pattern: `#987 learn proxy smoke ${Date.now()}`,
+        concepts: ['proxy', 'sqlite-contention'],
+        project: 'github.com/soul-brews-studio/arra-oracle-v3',
+      },
+    }) as { content?: Array<{ type: string; text: string }>; isError?: boolean };
+
+    expect(result.isError).not.toBe(true);
+    const payload = JSON.parse(result.content?.[0]?.text ?? '{}');
+    expect(payload.success).toBe(true);
+    expect(payload.file).toContain('ψ/memory/learnings/');
+    expect(stderr.join('')).not.toContain('ORACLE_API unavailable for oracle_learn');
+    expect(existsSync(mcpDbPath)).toBe(false);
+  } finally {
+    await client.close();
+  }
+}, 30_000);

--- a/src/tools/learn.ts
+++ b/src/tools/learn.ts
@@ -122,6 +122,26 @@ export function extractProjectFromSource(source?: string): string | null {
   return null;
 }
 
+export function errorDetails(error: unknown): {
+  name: string;
+  message: string;
+  stack?: string;
+  cause?: unknown;
+} {
+  if (error instanceof Error) {
+    return {
+      name: error.name || 'Error',
+      message: error.message,
+      ...(error.stack && { stack: error.stack }),
+      ...('cause' in error && error.cause !== undefined && { cause: String(error.cause) }),
+    };
+  }
+  return {
+    name: 'NonError',
+    message: String(error),
+  };
+}
+
 // ============================================================================
 // Handler
 // ============================================================================
@@ -261,6 +281,7 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
   //     vector-later. Never blocks ingest. Architecture:
   //     ψ/lab/indexer-cli/DESIGN.md.
   let embeddingStatus: 'ok' | 'skipped' | 'failed' | 'enqueued' = 'skipped';
+  let embeddingError: ReturnType<typeof errorDetails> | undefined;
   const enqueue = process.env.ORACLE_INDEXER_ENQUEUE === '1' ? await loadEnqueue() : null;
   if (enqueue) {
     try {
@@ -269,6 +290,7 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
     } catch (err) {
       // Never block ingest on the queue — same posture as the inline path.
       embeddingStatus = 'failed';
+      embeddingError = errorDetails(err);
       console.warn(`[oracle_learn] enqueue failed: ${err instanceof Error ? err.message : String(err)}`);
     }
   } else {
@@ -288,6 +310,7 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
       embeddingStatus = 'ok';
     } catch (err) {
       embeddingStatus = 'failed';
+      embeddingError = errorDetails(err);
       console.warn(`[oracle_learn] vector embedding failed for ${id}: ${err instanceof Error ? err.message : String(err)}`);
       console.warn(`[oracle_learn] document still searchable via FTS5; run 'bun src/scripts/index-model.ts <model>' later to backfill vectors`);
     }
@@ -301,6 +324,7 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
         file: sourceFileRel,
         id,
         embedding: embeddingStatus,
+        ...(embeddingError && { embeddingError }),
         message: `Pattern added to Oracle knowledge base${vaultRoot ? ' (vault)' : ''}${embeddingStatus === 'failed' ? ' — vector embedding failed, see server log' : ''}`
       }, null, 2)
     }]

--- a/src/vector/__tests__/embeddings-retry.test.ts
+++ b/src/vector/__tests__/embeddings-retry.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { OllamaEmbeddings } from '../embeddings.ts';
+
+const originalFetch = globalThis.fetch;
+const originalAttempts = process.env.ORACLE_EMBED_ATTEMPTS;
+const originalDelay = process.env.ORACLE_EMBED_RETRY_DELAY_MS;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalAttempts === undefined) delete process.env.ORACLE_EMBED_ATTEMPTS;
+  else process.env.ORACLE_EMBED_ATTEMPTS = originalAttempts;
+  if (originalDelay === undefined) delete process.env.ORACLE_EMBED_RETRY_DELAY_MS;
+  else process.env.ORACLE_EMBED_RETRY_DELAY_MS = originalDelay;
+});
+
+describe('OllamaEmbeddings retry diagnostics (#987)', () => {
+  it('retries transient embed failures before succeeding', async () => {
+    process.env.ORACLE_EMBED_ATTEMPTS = '2';
+    process.env.ORACLE_EMBED_RETRY_DELAY_MS = '1';
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      if (calls === 1) {
+        return new Response('temporary ollama failure', { status: 500 });
+      }
+      return Response.json({ embedding: [1, 2, 3, 4] });
+    }) as typeof fetch;
+
+    const embedder = new OllamaEmbeddings({ model: 'bge-m3' });
+    const vectors = await embedder.embed(['hello'], 'passage');
+
+    expect(calls).toBe(2);
+    expect(vectors).toEqual([[1, 2, 3, 4]]);
+    expect(embedder.dimensions).toBe(4);
+  });
+
+  it('throws attempt count and original message after retries are exhausted', async () => {
+    process.env.ORACLE_EMBED_ATTEMPTS = '2';
+    process.env.ORACLE_EMBED_RETRY_DELAY_MS = '1';
+    globalThis.fetch = (async () => {
+      throw new Error('socket reset');
+    }) as typeof fetch;
+
+    const embedder = new OllamaEmbeddings({ model: 'bge-m3' });
+
+    await expect(embedder.embed(['hello'], 'passage')).rejects.toThrow('failed after 2 attempts: socket reset');
+  });
+});

--- a/src/vector/__tests__/lancedb-stale-handle.test.ts
+++ b/src/vector/__tests__/lancedb-stale-handle.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Regression for #987:
+ * A long-lived LanceDB Table handle must not silently corrupt storage after
+ * another process rebuilds the collection. The adapter now checks out the
+ * latest table manifest before reads/writes, and index-model uses in-place
+ * replacement instead of drop/recreate.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { LanceDBAdapter } from '../adapters/lancedb.ts';
+import type { EmbeddingProvider, EmbedType, VectorDocument } from '../types.ts';
+
+class DeterministicEmbedder implements EmbeddingProvider {
+  readonly name = 'deterministic';
+  readonly dimensions = 4;
+
+  async embed(texts: string[], _type?: EmbedType): Promise<number[][]> {
+    return texts.map((text) => {
+      const seed = Array.from(text).reduce((sum, char) => sum + char.charCodeAt(0), 0) % 10;
+      return [seed + 0.1, seed + 0.2, seed + 0.3, seed + 0.4];
+    });
+  }
+}
+
+const doc = (id: string, document = id): VectorDocument => ({
+  id,
+  document,
+  metadata: { type: 'test' },
+});
+
+describe('LanceDB stale-handle safety (#987)', () => {
+  it('keeps a long-lived handle safe after another process drop/recreates the table', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oracle-lancedb-stale-'));
+    const collection = 'stale_handle_regression';
+    const live = new LanceDBAdapter(collection, tmpDir, new DeterministicEmbedder());
+    const reindexer = new LanceDBAdapter(collection, tmpDir, new DeterministicEmbedder());
+    const fresh = new LanceDBAdapter(collection, tmpDir, new DeterministicEmbedder());
+
+    try {
+      await live.connect();
+      await live.ensureCollection();
+      await live.addDocuments([doc('before-reindex')]);
+
+      // Simulate the pre-fix destructive index-model behavior from a second
+      // process. This used to leave `live` holding a stale table handle; its
+      // next add returned OK but fresh readers crashed on missing Lance files.
+      await reindexer.connect();
+      await reindexer.deleteCollection();
+      await reindexer.ensureCollection();
+      await reindexer.addDocuments([doc('from-reindex')]);
+
+      await live.addDocuments([doc('after-stale-handle')]);
+
+      await fresh.connect();
+      await fresh.ensureCollection();
+      const stats = await fresh.getStats();
+      const result = await fresh.query('reindex', 10);
+
+      expect(stats.count).toBe(2);
+      expect(result.ids).toContain('from-reindex');
+      expect(result.ids).toContain('after-stale-handle');
+    } finally {
+      try { await live.close(); } catch {}
+      try { await reindexer.close(); } catch {}
+      try { await fresh.close(); } catch {}
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('replaceDocuments clears/replaces rows without dropCollection', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oracle-lancedb-replace-'));
+    const collection = 'replace_documents_regression';
+    const adapter = new LanceDBAdapter(collection, tmpDir, new DeterministicEmbedder());
+
+    try {
+      await adapter.connect();
+      await adapter.ensureCollection();
+      await adapter.addDocuments([doc('old-1'), doc('old-2')]);
+      await adapter.replaceDocuments([doc('new-1')]);
+
+      const stats = await adapter.getStats();
+      const result = await adapter.query('new', 10);
+
+      expect(stats.count).toBe(1);
+      expect(result.ids).toEqual(['new-1']);
+    } finally {
+      try { await adapter.close(); } catch {}
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/vector/adapters/lancedb.ts
+++ b/src/vector/adapters/lancedb.ts
@@ -30,6 +30,9 @@ export class LanceDBAdapter implements VectorStoreAdapter {
   }
 
   async close(): Promise<void> {
+    try {
+      if (this.table && typeof this.table.close === 'function') this.table.close();
+    } catch {}
     this.db = null;
     this.table = null;
     console.error('[LanceDB] Closed');
@@ -56,6 +59,27 @@ export class LanceDBAdapter implements VectorStoreAdapter {
     console.error(`[LanceDB] Collection '${this.collectionName}' ready`);
   }
 
+  /**
+   * Refresh a long-lived table handle to the latest manifest version.
+   *
+   * `index-model.ts` historically dropped and recreated the table while MCP or
+   * the HTTP server still held a LanceDB Table object. A subsequent write on
+   * that stale object can return success while fresh readers fail with missing
+   * data files (#987). LanceDB exposes checkoutLatest() for long-lived table
+   * handles; call it before reads/writes and reopen as a last-resort fallback.
+   */
+  private async checkoutLatest(): Promise<void> {
+    if (!this.db || !this.table) return;
+    try {
+      if (typeof this.table.checkoutLatest === 'function') {
+        await this.table.checkoutLatest();
+      }
+    } catch (e) {
+      console.warn('[LanceDB] checkoutLatest failed, reopening table:', e instanceof Error ? e.message : String(e));
+      this.table = await this.db.openTable(this.collectionName);
+    }
+  }
+
   async deleteCollection(): Promise<void> {
     if (!this.db) throw new Error('LanceDB not connected');
 
@@ -71,7 +95,52 @@ export class LanceDBAdapter implements VectorStoreAdapter {
   async addDocuments(docs: VectorDocument[]): Promise<void> {
     if (docs.length === 0) return;
     if (!this.table) await this.ensureCollection();
+    await this.checkoutLatest();
 
+    const rows = await this.rowsForDocuments(docs);
+
+    await this.table.add(rows);
+    const reused = docs.filter(doc => doc.vector).length;
+    if (reused > 0) {
+      console.error(`[LanceDB] Added ${docs.length} documents (${reused} with precomputed vectors)`);
+    } else {
+      console.error(`[LanceDB] Added ${docs.length} documents`);
+    }
+  }
+
+  /**
+   * Replace all rows while preserving the table identity.
+   *
+   * This is intentionally NOT `dropTable()` + `createTable()`: other live
+   * processes may hold Table handles. LanceDB's add({ mode: 'overwrite' })
+   * writes a new table version instead of invalidating those handles.
+   */
+  async replaceDocuments(docs: VectorDocument[]): Promise<void> {
+    if (!this.table) await this.ensureCollection();
+    await this.checkoutLatest();
+
+    if (docs.length === 0) {
+      await this.table.delete('id IS NOT NULL');
+      console.error('[LanceDB] Replaced collection with 0 documents');
+      return;
+    }
+
+    const rows = await this.rowsForDocuments(docs);
+    await this.table.add(rows, { mode: 'overwrite' });
+    const reused = docs.filter(doc => doc.vector).length;
+    if (reused > 0) {
+      console.error(`[LanceDB] Replaced collection with ${docs.length} documents (${reused} with precomputed vectors)`);
+    } else {
+      console.error(`[LanceDB] Replaced collection with ${docs.length} documents`);
+    }
+  }
+
+  private async rowsForDocuments(docs: VectorDocument[]): Promise<Array<{
+    id: string;
+    text: string;
+    metadata: string;
+    vector: number[];
+  }>> {
     // Embed only the docs that lack a precomputed vector. Callers that
     // already have a vector (e.g. the indexer worker loop, where embed
     // happens before the storage write) skip the second Ollama round-trip.
@@ -92,18 +161,12 @@ export class LanceDBAdapter implements VectorStoreAdapter {
       metadata: JSON.stringify(doc.metadata),
       vector: doc.vector ?? fresh[freshIdx++],
     }));
-
-    await this.table.add(rows);
-    const reused = docs.length - needEmbed.length;
-    if (reused > 0) {
-      console.error(`[LanceDB] Added ${docs.length} documents (${reused} with precomputed vectors)`);
-    } else {
-      console.error(`[LanceDB] Added ${docs.length} documents`);
-    }
+    return rows;
   }
 
   async query(text: string, limit: number = 10, where?: Record<string, any>): Promise<VectorQueryResult> {
     if (!this.table) await this.ensureCollection();
+    await this.checkoutLatest();
 
     const [queryEmbedding] = await this.embedder.embed([text], 'query');
 
@@ -130,6 +193,7 @@ export class LanceDBAdapter implements VectorStoreAdapter {
 
   async queryById(id: string, nResults: number = 5): Promise<VectorQueryResult> {
     if (!this.table) await this.ensureCollection();
+    await this.checkoutLatest();
 
     // Get the document's vector using filter query (not vector search)
     const rows = await this.table.query().where(`id = '${id}'`).limit(1).toArray();
@@ -163,6 +227,7 @@ export class LanceDBAdapter implements VectorStoreAdapter {
       }
       if (!this.table) return { count: 0 };
     }
+    await this.checkoutLatest();
     try {
       const count = await this.table.countRows();
       return { count };
@@ -178,6 +243,7 @@ export class LanceDBAdapter implements VectorStoreAdapter {
 
   async getAllEmbeddings(limit: number = 5000): Promise<{ ids: string[]; embeddings: number[][]; metadatas: any[] }> {
     if (!this.table) return { ids: [], embeddings: [], metadatas: [] };
+    await this.checkoutLatest();
 
     const rows = await this.table.query().limit(limit).toArray();
 

--- a/src/vector/embeddings.ts
+++ b/src/vector/embeddings.ts
@@ -29,10 +29,14 @@ export class OllamaEmbeddings implements EmbeddingProvider {
   private baseUrl: string;
   private model: string;
   private _dimensionsDetected = false;
+  private attempts: number;
+  private retryDelayMs: number;
 
   constructor(config: { baseUrl?: string; model?: string } = {}) {
     this.baseUrl = config.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
     this.model = config.model || 'nomic-embed-text';
+    this.attempts = positiveInt(process.env.ORACLE_EMBED_ATTEMPTS, 3);
+    this.retryDelayMs = positiveInt(process.env.ORACLE_EMBED_RETRY_DELAY_MS, 150);
     // Known model dimensions (fallback before auto-detect).
     // For unknown models, set to 0 → adapters MUST probe via embed() before
     // creating columns (see #qwen3-dim-fallback issue).
@@ -85,18 +89,7 @@ export class OllamaEmbeddings implements EmbeddingProvider {
         // qwen3-embedding: passages stay raw per HF model card
       }
 
-      const response = await fetch(`${this.baseUrl}/api/embeddings`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ model: this.model, prompt: truncated }),
-      });
-
-      if (!response.ok) {
-        const error = await response.text();
-        throw new Error(`Ollama API error: ${error}`);
-      }
-
-      const data = await response.json() as { embedding: number[] };
+      const data = await this.embedOneWithRetry(truncated);
       embeddings.push(data.embedding);
 
       // Auto-detect dimensions from first response
@@ -108,6 +101,46 @@ export class OllamaEmbeddings implements EmbeddingProvider {
 
     return embeddings;
   }
+
+  private async embedOneWithRetry(prompt: string): Promise<{ embedding: number[] }> {
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= this.attempts; attempt++) {
+      try {
+        const response = await fetch(`${this.baseUrl}/api/embeddings`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ model: this.model, prompt }),
+        });
+
+        if (!response.ok) {
+          const error = await response.text();
+          throw new Error(`Ollama API error (${response.status}): ${error}`);
+        }
+
+        return await response.json() as { embedding: number[] };
+      } catch (err) {
+        lastError = err;
+        if (attempt < this.attempts) {
+          await sleep(this.retryDelayMs * attempt);
+        }
+      }
+    }
+
+    const message = lastError instanceof Error ? lastError.message : String(lastError);
+    throw new Error(`Ollama embedding failed after ${this.attempts} attempts: ${message}`, {
+      cause: lastError,
+    });
+  }
+}
+
+function positiveInt(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 /**

--- a/src/vector/types.ts
+++ b/src/vector/types.ts
@@ -40,6 +40,15 @@ export interface VectorStoreAdapter {
   ensureCollection(): Promise<void>;
   deleteCollection(): Promise<void>;
   addDocuments(docs: VectorDocument[]): Promise<void>;
+  /**
+   * Replace collection contents without dropping/recreating the table.
+   *
+   * This is optional because not every backend has an efficient whole-table
+   * replace primitive. Callers that hold long-lived handles (MCP/server) rely
+   * on this for reindex paths: drop/recreate invalidates LanceDB table handles
+   * in sibling processes and can produce silent vector-store corruption (#987).
+   */
+  replaceDocuments?(docs: VectorDocument[]): Promise<void>;
   query(text: string, limit?: number, where?: Record<string, any>): Promise<VectorQueryResult>;
   queryById(id: string, nResults?: number): Promise<VectorQueryResult>;
   getStats(): Promise<{ count: number }>;


### PR DESCRIPTION
Closes #987.

Problem:
- `index-model.ts` rebuilt LanceDB with drop/recreate, leaving long-lived MCP/server table handles stale. A later write could return OK while fresh readers failed on missing Lance files.
- Standalone embedded `oracle_learn` hid vector embed failures behind server logs only.

Fix:
- LanceDB adapter now checks out the latest manifest before reads/writes, so long-lived handles recover after external table version changes.
- `index-model.ts` now replaces the first batch in-place via `replaceDocuments()` instead of drop/recreate, preserving table identity for live handles.
- Ollama embeddings retry transient failures by default (`ORACLE_EMBED_ATTEMPTS`, `ORACLE_EMBED_RETRY_DELAY_MS`) and embedded `oracle_learn` returns structured `embeddingError` diagnostics.
- Added ORACLE_API guard test proving proxied `oracle_learn` does not open the stdio MCP DB, so alpha fleet mode stays off the embedded vector path.

Verification:
- Reproduced pre-fix stale-handle shape with two LanceDB handles: drop/recreate + stale write returned OK, fresh query failed on missing Lance files.
- `bun run build` -> exit 0
- `bun run test:unit` -> 250 pass
- `bun test src/vector/__tests__/lancedb-stale-handle.test.ts src/vector/__tests__/embeddings-retry.test.ts` -> 4 pass

Release plan: merge to main when green, then cut alpha only per standing rule.

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3