### PR TITLE
feat: package arra for Docker MCP Toolkit

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,6 +16,14 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: http-server
+            channel: http
+          - target: mcp-stdio
+            channel: stdio
     steps:
       - uses: actions/checkout@v4
 
@@ -29,21 +37,56 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/soul-brews-studio/arra-oracle-v3
-          tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=ref,event=tag
-            type=sha,prefix=sha-,format=short
+      - id: tags
+        name: Compose image tags
+        shell: bash
+        env:
+          IMAGE: ghcr.io/soul-brews-studio/arra-oracle-v3
+          TARGET: ${{ matrix.target }}
+          CHANNEL: ${{ matrix.channel }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          short_sha="${GITHUB_SHA::7}"
+          tags=()
+
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            # Preserve the existing release tag for the default HTTP image while
+            # adding explicit per-target tags for Docker MCP consumers.
+            if [[ "${TARGET}" == "http-server" ]]; then
+              tags+=("${IMAGE}:${GITHUB_REF_NAME}")
+            fi
+            tags+=("${IMAGE}:${GITHUB_REF_NAME}-${CHANNEL}")
+            tags+=("${IMAGE}:${CHANNEL}-sha-${short_sha}")
+          elif [[ "${GITHUB_REF_NAME}" == "${DEFAULT_BRANCH}" ]]; then
+            tags+=("${IMAGE}:${CHANNEL}")
+            tags+=("${IMAGE}:${CHANNEL}-sha-${short_sha}")
+            if [[ "${TARGET}" == "http-server" ]]; then
+              # Backward-compatible tags from the original single-target image.
+              tags+=("${IMAGE}:latest" "${IMAGE}:sha-${short_sha}")
+            fi
+          else
+            safe_ref="$(echo "${GITHUB_REF_NAME}" | tr '/[:upper:]' '-[:lower:]' | tr -cd 'a-z0-9_.-')"
+            tags+=("${IMAGE}:${safe_ref}-${CHANNEL}")
+            tags+=("${IMAGE}:${CHANNEL}-sha-${short_sha}")
+          fi
+
+          {
+            echo 'tags<<EOF'
+            printf '%s\n' "${tags[@]}"
+            echo 'EOF'
+          } >> "${GITHUB_OUTPUT}"
 
       - uses: docker/build-push-action@v6
         with:
           context: .
+          target: ${{ matrix.target }}
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          tags: ${{ steps.tags.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.title=arra-oracle-v3-${{ matrix.channel }}
+          cache-from: type=gha,scope=${{ matrix.target }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.target }}
           platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,20 @@
-# arra-oracle-v3 — HTTP server image (FTS5-only / lean, multi-stage)
+# arra-oracle-v3 — multi-target image
+#   Default target: http-server  (port 47778, used by docker-compose.yml)
+#   Alt target:     mcp-stdio    (no port, stdio MCP — for Docker MCP Toolkit)
 #
 # Vector search degrades gracefully to SQLite FTS5 when no Ollama embedding
-# backend is reachable — so this image is fully functional standalone.
-# To enable semantic vector search later, set VECTOR_URL via -e at run time.
+# backend is reachable — so both images are fully functional standalone.
 #
-# Build:  docker build -t arra-oracle-v3 .
-# Run:    docker run -p 47778:47778 -v arra-data:/data arra-oracle-v3
-# Health: curl -sf http://localhost:47778/api/health
+# Build:
+#   docker build -t arra-oracle-v3 .                              # default = http-server
+#   docker build -t arra-oracle-v3:http   --target http-server .  # explicit HTTP server
+#   docker build -t arra-oracle-v3:stdio  --target mcp-stdio .    # MCP stdio variant
+#
+# Run http-server (current behavior):
+#   docker run -p 47778:47778 -v arra-data:/data arra-oracle-v3
+#
+# Run mcp-stdio (manual; Docker MCP Gateway normally does this):
+#   docker run -i --rm -v arra-data:/data arra-oracle-v3:stdio
 
 # ─────────────────────────────────────────────────────────────────────────
 # Stage 1 — builder: resolve production deps, prune cross-arch dead weight
@@ -24,16 +32,15 @@ RUN bun install --production --ignore-scripts \
  && rm -rf node_modules/@lancedb/lancedb-*-musl
 
 # ─────────────────────────────────────────────────────────────────────────
-# Stage 2 — runtime: slim base + only what the server needs to run
+# Stage 2 — base runtime: shared deps + source for all final targets
 # ─────────────────────────────────────────────────────────────────────────
-FROM oven/bun:1-slim
+FROM oven/bun:1-slim AS base
 WORKDIR /app
 
 # HOME must be set — src/config.ts fails fast without it.
 # ORACLE_DATA_DIR holds SQLite (oracle.db), LanceDB collections, and the ψ/ vault.
 ENV HOME=/data \
-    ORACLE_DATA_DIR=/data \
-    ORACLE_PORT=47778
+    ORACLE_DATA_DIR=/data
 
 # Pruned production node_modules from the builder (glibc lancedb binary only).
 COPY --from=builder /app/node_modules ./node_modules
@@ -46,6 +53,23 @@ COPY src ./src
 RUN mkdir -p /data
 VOLUME ["/data"]
 
-EXPOSE 47778
+# ─────────────────────────────────────────────────────────────────────────
+# Target — mcp-stdio (for Docker MCP Toolkit + Gateway)
+# ─────────────────────────────────────────────────────────────────────────
+# This target speaks JSON-RPC on stdin/stdout. NO port, NO stdout logs
+# (the codex-killer bug — see PR #1238). Docker MCP Gateway spawns this
+# container transiently per MCP call.
+FROM base AS mcp-stdio
+# Force any incidental logging to stderr — protect the stdio JSON-RPC channel.
+ENV ORACLE_LOG_TARGET=stderr
+CMD ["bun", "src/index.ts"]
 
+# ─────────────────────────────────────────────────────────────────────────
+# Target — http-server (DEFAULT; current docker-compose behavior)
+# ─────────────────────────────────────────────────────────────────────────
+# Keep this as the final stage so `docker build .` and docker-compose continue
+# to produce the HTTP server image unless an explicit --target is provided.
+FROM base AS http-server
+ENV ORACLE_PORT=47778
+EXPOSE 47778
 CMD ["bun", "src/server.ts"]

--- a/catalog/arra-oracle.yaml
+++ b/catalog/arra-oracle.yaml
@@ -1,0 +1,98 @@
+# Custom Docker MCP Toolkit catalog entry for arra-oracle-v3.
+#
+# To register locally:
+#   1. Copy this file to ~/.docker/mcp/catalogs/arra-oracle.yaml
+#   2. Add `arra-oracle: { ref: "" }` under `registry:` in ~/.docker/mcp/registry.yaml
+#   3. Wire docker/mcp-gateway with --catalog=/mcp/catalogs/arra-oracle.yaml
+#
+# Schema shape was verified against docker/mcp-gateway pkg/catalog/types.go:
+# top-level version/name/displayName/registry, server type, per-server metadata,
+# object-form tool discovery hints, and optional env/allowHosts/volumes.
+
+version: 2
+name: arra-mcp
+displayName: Arra Oracle MCP Servers
+
+registry:
+  arra-oracle:
+    title: "Arra Oracle"
+    type: server
+    dateAdded: "2026-06-01T00:00:00Z"
+    image: ghcr.io/soul-brews-studio/arra-oracle-v3:stdio
+    description: |
+      Personal MCP memory server with semantic search over your Oracle vault.
+      SQLite FTS5 + LanceDB hybrid (degrades to FTS5-only if no Ollama backend).
+      20+ oracle_* tools across search / knowledge / session / forum / trace groups.
+      Backward-compatible aliases: arra_* and muninn_* both resolve to oracle_*.
+
+    # Ephemeral is safe: /data persists SQLite, LanceDB, and the vault between calls.
+    # Flip longLived to true later only if cold LanceDB startup becomes a bottleneck.
+    longLived: false
+
+    volumes:
+      - "arra-oracle-data:/data"
+
+    env:
+      # Optional Ollama backend — semantic vector search lights up when reachable.
+      # Without it, arra serves via FTS5-only (still fully functional).
+      - name: OLLAMA_BASE_URL
+        value: "{{ollama_base_url}}"
+
+    # Network controls — arra only needs host Ollama access for local embeddings.
+    # The MCP stdio channel itself does not require network access.
+    allowHosts:
+      - "host.docker.internal:11434"
+
+    # Tool entries are discovery hints for Docker Desktop, not enablement lists.
+    # arra always exposes the full MCP tool set from src/index.ts.
+    tools:
+      - name: oracle_search
+        description: "Hybrid FTS5 + vector search over the Oracle vault"
+      - name: oracle_learn
+        description: "Index a markdown file into the vault (semantic + FTS5)"
+      - name: oracle_list
+        description: "List indexed knowledge entries with filters"
+      - name: oracle_stats
+        description: "Vector + FTS5 counts, backend health, vault status"
+      - name: oracle_concepts
+        description: "Concept-tag aggregation across the corpus"
+      - name: oracle_supersede
+        description: "Mark an entry as superseded by a newer one"
+      - name: oracle_handoff
+        description: "Read or write session handoff notes"
+      - name: oracle_inbox
+        description: "Read or write Oracle inbox messages"
+      - name: oracle_read
+        description: "Read a specific vault file by path or id"
+      - name: oracle_thread
+        description: "Start a forum thread"
+      - name: oracle_threads
+        description: "List forum threads"
+      - name: oracle_thread_read
+        description: "Read a forum thread"
+      - name: oracle_thread_update
+        description: "Update a forum thread"
+      - name: oracle_trace
+        description: "Log a trace event (query + findings + friction score)"
+      - name: oracle_trace_list
+        description: "List recent traces"
+      - name: oracle_trace_get
+        description: "Get a specific trace by id"
+      - name: oracle_trace_link
+        description: "Link two traces (causal or topical)"
+      - name: oracle_trace_unlink
+        description: "Remove a trace link"
+      - name: oracle_trace_chain
+        description: "Walk a chain of linked traces"
+      - name: oracle_reflect
+        description: "Reflect on a topic across vault entries"
+      - name: oracle_verify
+        description: "Verify a claim against vault evidence"
+
+    secrets: []
+
+    metadata:
+      category: knowledge
+      tags: [memory, vault, mcp, semantic-search, oracle, fts5, lancedb]
+      license: BUSL-1.1
+      owner: Soul-Brews-Studio


### PR DESCRIPTION
Refs #1242 (this-repo Phases 1–3).

## Problem
Docker/GHCR currently publishes only the HTTP server image. Docker MCP Toolkit needs a stdio MCP container image plus a catalog entry, without breaking the existing `docker build .` / `docker compose up` HTTP-server path.

## Fix
- Refactor `Dockerfile` into shared `base` + `mcp-stdio` + final `http-server` targets.
- Keep HTTP as the default final target; stdio is explicit via `--target mcp-stdio`.
- Pin `ORACLE_LOG_TARGET=stderr` on the stdio target to protect JSON-RPC stdout.
- Publish GHCR target tags for both channels: `:http` and `:stdio`, while preserving HTTP `:latest` / release tags.
- Add `catalog/arra-oracle.yaml` using the schema-verified Docker MCP catalog shape from the vault proposal.

## Verification
- `ruby -ryaml -e 'YAML.load_file("catalog/arra-oracle.yaml"); YAML.load_file(".github/workflows/docker-publish.yml")'` -> ok
- `bun run build` -> ok
- `docker build -t arra-oracle-v3:1242-default .` -> ok, default `Cmd=["bun","src/server.ts"]`
- `docker build --target http-server -t arra-oracle-v3:1242-http .` -> ok
- `docker build --target mcp-stdio -t arra-oracle-v3:1242-stdio .` -> ok, stdio `Cmd=["bun","src/index.ts"]`, `ORACLE_LOG_TARGET=stderr`
- HTTP smoke: `docker run -p 47902:47778 arra-oracle-v3:1242-default` + `/api/health` -> ok (`version=26.6.1-alpha.900`)
- Stdio smoke: initialize JSON-RPC through `docker run -i --rm arra-oracle-v3:1242-stdio` -> JSON response on stdout; startup logs on stderr

## Notes
Phase 4 (upstream catalog PR) and Phase 5 (n8n recipe) remain downstream follow-ups after these repo-local artifacts are merged and published.

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3
