### PR TITLE
docs: add Docker MCP Gateway and n8n recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Phukhao Oracle is landing here: https://phukhao.buildwithoracle.com/presentation
 TypeScript MCP server for semantic search over Oracle philosophy — SQLite FTS5 + ChromaDB hybrid search, HTTP API, and vault CLI.
 
 See [docs/LOCAL-DEV.md](docs/LOCAL-DEV.md) for local development.
+For Docker MCP Toolkit / Gateway / n8n installs, see [docs/DOCKER-MCP-TOOLKIT.md](docs/DOCKER-MCP-TOOLKIT.md).
 
 ## Architecture
 

--- a/catalog/arra-oracle.yaml
+++ b/catalog/arra-oracle.yaml
@@ -33,6 +33,12 @@ registry:
       - "arra-oracle-data:/data"
 
     env:
+      # Docker MCP Toolkit starts this as a stdio container; embedded mode keeps
+      # it self-contained. To route through a long-running HTTP writer instead,
+      # change this to e.g. http://host.docker.internal:47778.
+      - name: ORACLE_API
+        value: "embedded"
+
       # Optional Ollama backend — semantic vector search lights up when reachable.
       # Without it, arra serves via FTS5-only (still fully functional).
       - name: OLLAMA_BASE_URL

--- a/docs/DOCKER-MCP-TOOLKIT.md
+++ b/docs/DOCKER-MCP-TOOLKIT.md
@@ -1,0 +1,106 @@
+# Docker MCP Toolkit
+
+Arra ships two Docker targets:
+
+| Target | Image tag | Purpose |
+|---|---|---|
+| `http-server` | `ghcr.io/soul-brews-studio/arra-oracle-v3:http` / `:latest` | Long-running HTTP writer on port `47778` |
+| `mcp-stdio` | `ghcr.io/soul-brews-studio/arra-oracle-v3:stdio` | Stdio MCP server for Docker MCP Toolkit / Gateway |
+
+The stdio target sets `ORACLE_LOG_TARGET=stderr` so JSON-RPC stays clean on stdout.
+
+## Local smoke tests
+
+```bash
+# HTTP server target (default)
+docker build -t arra-oracle-v3:http --target http-server .
+docker run --rm -p 47902:47778 -v arra-oracle-data:/data arra-oracle-v3:http
+curl -fsS http://localhost:47902/api/health
+
+# MCP stdio target
+docker build -t arra-oracle-v3:stdio --target mcp-stdio .
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}' \
+  | docker run -i --rm -v arra-oracle-data:/data arra-oracle-v3:stdio
+```
+
+## Docker MCP Gateway (stdio clients)
+
+The repo includes a custom Docker MCP catalog at [`catalog/arra-oracle.yaml`](../catalog/arra-oracle.yaml). For a local Gateway run:
+
+```bash
+mkdir -p ~/.docker/mcp/catalogs
+cp catalog/arra-oracle.yaml ~/.docker/mcp/catalogs/arra-oracle.yaml
+
+docker mcp gateway run \
+  --catalog arra-oracle.yaml \
+  --servers arra-oracle \
+  --transport stdio
+```
+
+For local development before GHCR/package visibility is available, build the stdio image locally and change the catalog `image:` field to `arra-oracle-v3:stdio`.
+
+```bash
+docker build --target mcp-stdio -t arra-oracle-v3:stdio .
+perl -0pi -e 's#ghcr.io/soul-brews-studio/arra-oracle-v3:stdio#arra-oracle-v3:stdio#' \
+  ~/.docker/mcp/catalogs/arra-oracle.yaml
+```
+
+## n8n / SSE Gateway recipe
+
+n8n talks to HTTP/SSE endpoints, not stdio. Run Docker MCP Gateway with SSE transport and point n8n's MCP node at the Gateway URL.
+
+```bash
+# Terminal 1: start the Gateway on a non-conflicting port.
+MCP_GATEWAY_AUTH_TOKEN="$(openssl rand -hex 24)"
+export MCP_GATEWAY_AUTH_TOKEN
+
+docker mcp gateway run \
+  --catalog ~/.docker/mcp/catalogs/arra-oracle.yaml \
+  --servers arra-oracle \
+  --transport sse \
+  --port 8811 \
+  --long-lived
+```
+
+Then in n8n:
+
+1. Add an MCP Client node.
+2. Transport: SSE.
+3. Server URL: `http://localhost:8811/sse`.
+4. Header: `Authorization: Bearer $MCP_GATEWAY_AUTH_TOKEN`.
+5. Enable the `oracle_*` tools you want to expose to the workflow.
+
+Use `--long-lived` for n8n so the Gateway does not pay container cold-start cost on every workflow step. Arra persists state in the `arra-oracle-data:/data` Docker volume.
+
+## Optional semantic embeddings
+
+Arra works without Ollama via SQLite FTS5. To enable vector embeddings, make Ollama reachable from the container and set `OLLAMA_BASE_URL` in the catalog.
+
+Typical host Ollama value:
+
+```yaml
+env:
+  - name: OLLAMA_BASE_URL
+    value: "http://host.docker.internal:11434"
+```
+
+## HTTP writer mode
+
+For fleet-style single-writer operation, run the HTTP image separately and point the stdio container at it:
+
+```bash
+docker run -d --name arra-http \
+  -p 47778:47778 \
+  -v arra-oracle-data:/data \
+  ghcr.io/soul-brews-studio/arra-oracle-v3:http
+```
+
+Then set this in the catalog env block:
+
+```yaml
+- name: ORACLE_API
+  value: "http://host.docker.internal:47778"
+```
+
+If `ORACLE_API=embedded`, the stdio container opens `/data/oracle.db` directly. That is fine for Docker MCP Toolkit's single-container usage; use HTTP writer mode when multiple MCP processes share the same SQLite database.


### PR DESCRIPTION
Refs #1242 (downstream Phase 5 docs + catalog polish).

## Problem
PR #1255 shipped the repo-local Docker MCP Toolkit artifacts, but the issue still needed the user-facing Gateway / n8n recipe. Also, the bundled custom catalog inherited MCP stdio's default `ORACLE_API=http://localhost:47778` behavior, which is correct for fleet proxy mode but noisy for standalone Docker MCP Toolkit usage.

## Fix
- Add `docs/DOCKER-MCP-TOOLKIT.md` covering:
  - local HTTP and stdio Docker smoke tests
  - Docker MCP Gateway stdio run with `catalog/arra-oracle.yaml`
  - n8n SSE Gateway recipe (`docker mcp gateway run --transport sse --port 8811`)
  - optional Ollama embeddings
  - optional HTTP-writer / single-writer mode
- Link the guide from README.
- Set bundled catalog `ORACLE_API=embedded` by default so standalone stdio containers stay self-contained; users can still change it to `http://host.docker.internal:47778` for single-writer proxy mode.

## Verification
- `ruby -ryaml -e 'YAML.load_file("catalog/arra-oracle.yaml")'` -> ok
- doc smoke: n8n section present
- `docker mcp gateway run --dry-run --catalog <local catalog> --servers arra-oracle --transport stdio --verbose` with local `arra-oracle-v3:stdio` image -> parsed config, ran Arra in embedded mode, listed 22 tools

## Related downstream
Opened Docker upstream registry PR for Phase 4: https://github.com/docker/mcp-registry/pull/3875

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3
