### PR TITLE
feat(fed): announce Arra via maw Scout multicast (refs #1211)

### DIFF
--- a/src/peer/scout-announcer.ts
+++ b/src/peer/scout-announcer.ts
@@ -1,0 +1,173 @@
+import { randomBytes } from 'node:crypto';
+import { createSocket } from 'node:dgram';
+import { hostname } from 'node:os';
+
+import { PORT } from '../config.ts';
+
+export const SCOUT_MULTICAST_ADDR = '224.0.0.224';
+export const SCOUT_MULTICAST_PORT = 31746;
+export const SCOUT_VERSION = 1;
+export const DEFAULT_SCOUT_INTERVAL_MS = 30_000;
+
+const DEFAULT_CAPABILITIES = ['pair', 'feed', 'send', 'arra-search'] as const;
+const DEFAULT_ORACLES = ['arra'] as const;
+
+type Env = Record<string, string | undefined>;
+
+export interface ScoutHelloMessage {
+  type: 'maw-hello';
+  version: number;
+  zid: string;
+  whatAmI: 'oracle';
+  node: string;
+  oracle: 'arra';
+  locators: string[];
+  capabilities: string[];
+  oracles: string[];
+  ts: number;
+}
+
+export interface ScoutAnnouncerConfig {
+  zid: string;
+  node: string;
+  locator: string;
+  intervalMs: number;
+  capabilities: string[];
+  oracles: string[];
+}
+
+export interface ScoutAnnouncer {
+  readonly config: ScoutAnnouncerConfig;
+  stop(): void;
+  sendNow(): void;
+}
+
+function peerHost(env: Env = process.env): string {
+  return env.ORACLE_HOST?.trim() || hostname();
+}
+
+function peerNode(host = peerHost(), env: Env = process.env): string {
+  return env.ORACLE_NODE?.trim() || `arra@${host}`;
+}
+
+function parsePositiveInt(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+function trimTrailingSlash(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+function defaultAnnounceHost(host: string): string {
+  return host.includes('.') ? host : `${host}.local`;
+}
+
+function resolveLocator(host: string, env: Env): string {
+  const explicit =
+    env.ORACLE_SCOUT_URL?.trim() ||
+    env.ORACLE_PUBLIC_URL?.trim() ||
+    env.ORACLE_BASE_URL?.trim();
+  if (explicit) return trimTrailingSlash(new URL(explicit).toString());
+
+  const advertiseHost =
+    env.MAW_ANNOUNCE_HOST?.trim() ||
+    env.ORACLE_SCOUT_HOST?.trim() ||
+    defaultAnnounceHost(host);
+  return `http://${advertiseHost}:${Number(PORT)}`;
+}
+
+export function generateScoutZid(): string {
+  return randomBytes(16).toString('hex');
+}
+
+export function createScoutAnnouncerConfig(env: Env = process.env): ScoutAnnouncerConfig {
+  const host = peerHost(env);
+  return {
+    zid: generateScoutZid(),
+    node: peerNode(host, env),
+    locator: resolveLocator(host, env),
+    intervalMs: parsePositiveInt(env.ORACLE_SCOUT_INTERVAL_MS, DEFAULT_SCOUT_INTERVAL_MS),
+    capabilities: [...DEFAULT_CAPABILITIES],
+    oracles: [...DEFAULT_ORACLES],
+  };
+}
+
+export function makeScoutHello(
+  config: Pick<ScoutAnnouncerConfig, 'zid' | 'node' | 'locator' | 'capabilities' | 'oracles'>,
+  now = Date.now(),
+): ScoutHelloMessage {
+  return {
+    type: 'maw-hello',
+    version: SCOUT_VERSION,
+    zid: config.zid,
+    whatAmI: 'oracle',
+    node: config.node,
+    oracle: 'arra',
+    locators: [config.locator],
+    capabilities: config.capabilities,
+    oracles: config.oracles,
+    ts: now,
+  };
+}
+
+export function startScoutAnnouncer(
+  config = createScoutAnnouncerConfig(),
+  deps: {
+    createSocketFn?: typeof createSocket;
+    log?: Pick<Console, 'log' | 'warn'>;
+  } = {},
+): ScoutAnnouncer {
+  const log = deps.log ?? console;
+  const createSocketFn = deps.createSocketFn ?? createSocket;
+  const socket = createSocketFn({ type: 'udp4', reuseAddr: true });
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let closed = false;
+
+  const sendNow = () => {
+    if (closed) return;
+    const hello = makeScoutHello(config);
+    const buf = Buffer.from(JSON.stringify(hello));
+    socket.send(buf, SCOUT_MULTICAST_PORT, SCOUT_MULTICAST_ADDR, (err) => {
+      if (err) log.warn(`[scout] hello send failed: ${err.message}`);
+    });
+  };
+
+  socket.on('error', (err) => {
+    log.warn(`[scout] announcer socket error: ${err.message}`);
+  });
+
+  socket.bind(0, () => {
+    try {
+      socket.setMulticastTTL(2);
+    } catch (err) {
+      log.warn(`[scout] unable to set multicast TTL: ${err instanceof Error ? err.message : err}`);
+    }
+    sendNow();
+    timer = setInterval(sendNow, config.intervalMs);
+    timer.unref?.();
+    socket.unref?.();
+    log.log(
+      `[scout] announcing ${config.node} at ${config.locator} on ${SCOUT_MULTICAST_ADDR}:${SCOUT_MULTICAST_PORT} (zid: ${config.zid.slice(0, 8)}…)`,
+    );
+  });
+
+  return {
+    config,
+    sendNow,
+    stop() {
+      if (closed) return;
+      closed = true;
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+      try {
+        socket.close();
+      } catch {
+        // socket may already be closed after an error
+      }
+    },
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,6 +22,7 @@ import { PORT, ORACLE_DATA_DIR, VECTOR_URL } from './config.ts';
 import { MCP_SERVER_NAME } from './const.ts';
 import { db, sqlite, closeDb, indexingStatus } from './db/index.ts';
 import { seedMenuItems, type HasRoutes as SeedHasRoutes } from './db/seeders/menu-seeder.ts';
+import { startScoutAnnouncer, type ScoutAnnouncer } from './peer/scout-announcer.ts';
 
 // Elysia sub-apps — one per cluster
 import { authRoutes } from './routes/auth/index.ts';
@@ -79,8 +80,11 @@ writePidFile({
   name: 'oracle-http',
 });
 
+let scoutAnnouncer: ScoutAnnouncer | null = null;
+
 registerSignalHandlers(async () => {
   console.log('\n🔮 Shutting down gracefully...');
+  scoutAnnouncer?.stop();
   await performGracefulShutdown({
     resources: [{ close: () => { closeDb(); return Promise.resolve(); } }],
   });
@@ -237,6 +241,8 @@ const menuRoutes = createMenuRoutes();
 const modules = [...apiModules, menuRoutes];
 
 for (const mod of modules) app.use(mod as any);
+
+scoutAnnouncer = startScoutAnnouncer();
 
 console.log(`
 🔮 Arra Oracle HTTP Server running! (Elysia)

--- a/src/server/__tests__/scout-announcer.test.ts
+++ b/src/server/__tests__/scout-announcer.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+
+import {
+  createScoutAnnouncerConfig,
+  DEFAULT_SCOUT_INTERVAL_MS,
+  makeScoutHello,
+} from '../../peer/scout-announcer.ts';
+import { PORT } from '../../config.ts';
+
+const originalEnv = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+describe('Scout announcer', () => {
+  it('builds maw-compatible hello packets with arra-search capability', () => {
+    const hello = makeScoutHello({
+      zid: '0123456789abcdef0123456789abcdef',
+      node: 'arra@m5',
+      locator: 'http://m5.local:47778',
+      capabilities: ['pair', 'feed', 'send', 'arra-search'],
+      oracles: ['arra'],
+    }, 1_700_000_000_000);
+
+    expect(hello).toEqual({
+      type: 'maw-hello',
+      version: 1,
+      zid: '0123456789abcdef0123456789abcdef',
+      whatAmI: 'oracle',
+      node: 'arra@m5',
+      oracle: 'arra',
+      locators: ['http://m5.local:47778'],
+      capabilities: ['pair', 'feed', 'send', 'arra-search'],
+      oracles: ['arra'],
+      ts: 1_700_000_000_000,
+    });
+  });
+
+  it('uses ORACLE_SCOUT_URL for the advertised locator without changing node identity', () => {
+    process.env.ORACLE_HOST = 'm5';
+    process.env.ORACLE_NODE = 'arra@m5';
+    process.env.ORACLE_SCOUT_URL = 'http://m5.local:47778/';
+    process.env.ORACLE_SCOUT_INTERVAL_MS = '1234';
+
+    const config = createScoutAnnouncerConfig(process.env);
+
+    expect(config.node).toBe('arra@m5');
+    expect(config.locator).toBe('http://m5.local:47778');
+    expect(config.intervalMs).toBe(1234);
+    expect(config.zid).toMatch(/^[0-9a-f]{32}$/);
+    expect(config.capabilities).toContain('pair');
+    expect(config.capabilities).toContain('arra-search');
+    expect(config.oracles).toEqual(['arra']);
+  });
+
+  it('defaults the locator to <host>.local and honors MAW_ANNOUNCE_HOST', () => {
+    process.env.ORACLE_HOST = 'm5';
+
+    const defaultConfig = createScoutAnnouncerConfig(process.env);
+    expect(defaultConfig.node).toBe('arra@m5');
+    expect(defaultConfig.locator).toBe(`http://m5.local:${PORT}`);
+
+    process.env.MAW_ANNOUNCE_HOST = 'arra.lan';
+    const overrideConfig = createScoutAnnouncerConfig(process.env);
+    expect(overrideConfig.locator).toBe(`http://arra.lan:${PORT}`);
+  });
+
+  it('defaults to maw-compatible 30s reannounce cadence', () => {
+    const config = createScoutAnnouncerConfig(process.env);
+
+    expect(config.intervalMs).toBe(DEFAULT_SCOUT_INTERVAL_MS);
+  });
+});


### PR DESCRIPTION
Refs #1211.

Phase 2 of Arra-as-maw-peer: embed an announce-only Scout HELLO sender in the HTTP server so maw peers can discover Arra on the LAN without a manual `maw peers add`. Phase 1 `/info` + `/api/identity` remains the authoritative handshake/TOFU path; this PR does not add receive-side Scout logic or `/api/pair/auto`.

What changed:
- Emits `maw-hello` over UDP multicast `224.0.0.224:31746` with TTL 2.
- Generates one 32-hex zid at boot and re-announces every 30s.
- Advertises `capabilities: ["pair", "feed", "send", "arra-search"]` and `oracles: ["arra"]`.
- Uses runtime config for locator: `ORACLE_SCOUT_URL`/`ORACLE_PUBLIC_URL` full URL, or `MAW_ANNOUNCE_HOST`/`ORACLE_SCOUT_HOST`, else `<host>.local:<ORACLE_PORT>`.
- Stops the announcer on graceful HTTP shutdown.

Verification:
- `bun run build` -> pass.
- `bun run test:unit` -> 254 pass / 0 fail.
- Local smoke: `ORACLE_PORT=47911 ORACLE_SCOUT_URL=http://127.0.0.1:47911 ORACLE_SCOUT_INTERVAL_MS=1000 bun src/server.ts`; `maw scout --transport scout --json` detects `arra@m5` with locator `http://127.0.0.1:47911` and `arra-search` capability.

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3