### PR TITLE
fix(vector): serve /api/search from vector sidecar for VECTOR_URL routing

### DIFF
--- a/src/server/__tests__/vector-server-route.test.ts
+++ b/src/server/__tests__/vector-server-route.test.ts
@@ -1,0 +1,38 @@
+import { afterAll, describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-vector-server-route-data-'));
+const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-vector-server-route-repo-'));
+const originalDataDir = process.env.ORACLE_DATA_DIR;
+const originalDbPath = process.env.ORACLE_DB_PATH;
+const originalRepoRoot = process.env.ORACLE_REPO_ROOT;
+
+process.env.ORACLE_DATA_DIR = dataDir;
+process.env.ORACLE_DB_PATH = path.join(dataDir, 'oracle.db');
+process.env.ORACLE_REPO_ROOT = repoRoot;
+
+const { createVectorServerApp } = await import('../../vector-server.ts');
+
+describe('vector-server route surface', () => {
+  it('serves /api/search as the VECTOR_URL gateway target', async () => {
+    const app = createVectorServerApp();
+    const response = await app.handle(new Request('http://localhost/api/search'));
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe('Missing query parameter: q');
+  });
+});
+
+afterAll(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  fs.rmSync(repoRoot, { recursive: true, force: true });
+  if (originalDataDir) process.env.ORACLE_DATA_DIR = originalDataDir;
+  else delete process.env.ORACLE_DATA_DIR;
+  if (originalDbPath) process.env.ORACLE_DB_PATH = originalDbPath;
+  else delete process.env.ORACLE_DB_PATH;
+  if (originalRepoRoot) process.env.ORACLE_REPO_ROOT = originalRepoRoot;
+  else delete process.env.ORACLE_REPO_ROOT;
+});

--- a/src/vector-server.ts
+++ b/src/vector-server.ts
@@ -17,6 +17,7 @@ import { swagger } from '@elysiajs/swagger';
 
 import { loadVectorConfig, generateDefaultConfig } from './vector/config.ts';
 import { vectorRoutes } from './routes/vector/index.ts';
+import { searchEndpoint } from './routes/search/search.ts';
 
 import pkg from '../package.json' with { type: 'json' };
 
@@ -25,27 +26,35 @@ const config = loadVectorConfig() ?? generateDefaultConfig();
 const PORT = Number(process.env.VECTOR_PORT ?? config.port);
 
 // ── App ─────────────────────────────────────────────────────────────
-const app = new Elysia()
-  .use(cors())                           // permissive — internal sidecar
-  .use(
-    swagger({
-      path: '/swagger',
-      documentation: {
-        info: {
-          title: 'Arra Vector Server',
-          version: pkg.version,
-          description: 'Standalone vector / embedding sidecar for Arra Oracle.',
+export function createVectorServerApp() {
+  return new Elysia()
+    .use(cors())                           // permissive — internal sidecar
+    .use(
+      swagger({
+        path: '/swagger',
+        documentation: {
+          info: {
+            title: 'Arra Vector Server',
+            version: pkg.version,
+            description: 'Standalone vector / embedding sidecar for Arra Oracle.',
+          },
         },
-      },
-    }),
-  )
-  .get('/', () => ({
-    server: 'arra-vector',
-    version: pkg.version,
-    status: 'ok',
-    docs: '/swagger',
-  }))
-  .use(vectorRoutes);
+      }),
+    )
+    .get('/', () => ({
+      server: 'arra-vector',
+      version: pkg.version,
+      status: 'ok',
+      docs: '/swagger',
+    }))
+    // VECTOR_URL/gateway proxies /api/search to the sidecar. Mount only the
+    // search endpoint (not reflect/list) so hybrid/vector search has a remote
+    // target while non-vector browsing remains core-owned.
+    .use(new Elysia({ prefix: '/api' }).use(searchEndpoint))
+    .use(vectorRoutes);
+}
+
+const app = createVectorServerApp();
 
 console.log(`
 🧭 Arra Vector Server running! (Elysia)


### PR DESCRIPTION
Refs #1071.

Fixes the first sidecar-routing gap in the vector-server split: `VECTOR_URL`/gateway routing already sends `/api/search` to the vector service, but `src/vector-server.ts` only served the `/api/vector/*` route family. The sidecar now mounts the existing `searchEndpoint` at `/api/search`, giving gateway/proxy search a real remote target while leaving `reflect`/`list` core-owned.

Verification:
- `bun test src/server/__tests__/vector-server-route.test.ts` → pass (`GET /api/search` on vector server returns the expected search handler 400 when `q` is missing)
- `bun run build` → pass
- `bun run test:unit` → 255 pass / 0 fail

Scope: narrow #1071 slice only; broader vector-server separation remains follow-up work.

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3
