### PR TITLE
fix(gateway): make VECTOR_URL cover and degrade vector routes safely

### DIFF
--- a/src/gateway/__tests__/vector-url.test.ts
+++ b/src/gateway/__tests__/vector-url.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'bun:test';
+import { Elysia } from 'elysia';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { loadGatewayConfig } from '../config.ts';
+import { compileRoutes, matchRoute } from '../matcher.ts';
+import { gatewayPlugin } from '../index.ts';
+
+describe('VECTOR_URL synthesized gateway config', () => {
+  it('covers the full vector route surface without local-vector fallback', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-gateway-vector-url-'));
+    try {
+      const cfg = loadGatewayConfig(dir, 'http://vector.local:47779/')!;
+      expect(cfg.services.vector.url).toBe('http://vector.local:47779/');
+      expect(cfg.services.vector.healthCheck).toBe('http://vector.local:47779/api/vector/health');
+
+      const routes = compileRoutes(cfg.routes);
+      expect(matchRoute('/api/search', routes)).toEqual({
+        service: 'vector',
+        fallback: 'fts5',
+        pattern: '/api/search',
+      });
+      expect(matchRoute('/api/similar', routes)).toEqual({
+        service: 'vector',
+        fallback: 'error',
+        pattern: '/api/similar',
+      });
+      expect(matchRoute('/api/compare', routes)).toEqual({
+        service: 'vector',
+        fallback: 'error',
+        pattern: '/api/compare',
+      });
+      expect(matchRoute('/api/map', routes)).toEqual({
+        service: 'vector',
+        fallback: 'empty',
+        pattern: '/api/map',
+      });
+      expect(matchRoute('/api/map3d', routes)).toEqual({
+        service: 'vector',
+        fallback: 'empty',
+        pattern: '/api/map3d',
+      });
+      expect(matchRoute('/api/vector/stats', routes)).toEqual({
+        service: 'vector',
+        fallback: 'error',
+        pattern: '/api/vector/**',
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to local FTS5 for search but not local map when VECTOR_URL is down', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-gateway-vector-url-'));
+    try {
+      const app = new Elysia()
+        .use(gatewayPlugin(dir, 'http://127.0.0.1:9'))
+        .get('/api/search', () => ({ source: 'local-fts5', results: [] }))
+        .get('/api/map', () => ({ source: 'local-vector-map' }));
+
+      const search = await app.handle(new Request('http://localhost/api/search?q=oracle'));
+      expect(search.status).toBe(200);
+      expect(await search.json()).toEqual({ source: 'local-fts5', results: [] });
+
+      const map = await app.handle(new Request('http://localhost/api/map'));
+      expect(map.status).toBe(200);
+      expect(await map.json()).toEqual({ results: [], source: 'gateway-fallback' });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/gateway/config.ts
+++ b/src/gateway/config.ts
@@ -49,16 +49,26 @@ export function loadGatewayConfig(dataDir: string, vectorUrl?: string): GatewayC
     }
   }
 
-  // Backward compat: synthesize config from VECTOR_URL
+  // Backward compat: synthesize config from VECTOR_URL. Search can
+  // fall through to local FTS5 when the vector service is unreachable; pure
+  // vector routes must not fall back to local LanceDB inside the core process.
   if (vectorUrl) {
+    const vectorBase = vectorUrl.replace(/\/+$/, '');
     return {
       services: {
-        vector: { url: vectorUrl, timeout: 5000 },
+        vector: {
+          url: vectorUrl,
+          healthCheck: `${vectorBase}/api/vector/health`,
+          timeout: 5000,
+        },
       },
       routes: [
-        { match: '/api/vector/**', service: 'vector', fallback: 'fts5' },
-        { match: '/api/similar', service: 'vector', fallback: 'fts5' },
         { match: '/api/search', service: 'vector', fallback: 'fts5' },
+        { match: '/api/similar', service: 'vector', fallback: 'error' },
+        { match: '/api/compare', service: 'vector', fallback: 'error' },
+        { match: '/api/map', service: 'vector', fallback: 'empty' },
+        { match: '/api/map3d', service: 'vector', fallback: 'empty' },
+        { match: '/api/vector/**', service: 'vector', fallback: 'error' },
       ],
     };
   }

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -48,6 +48,20 @@ function describeState(state: GatewayState): string {
   );
 }
 
+function emptyFallbackResponse(): Response {
+  return new Response(JSON.stringify({ results: [], source: 'gateway-fallback' }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function serviceUnavailableResponse(service: string): Response {
+  return new Response(JSON.stringify({ error: 'Service unavailable', service }), {
+    status: 503,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
 export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
   const initial = loadGatewayConfig(dataDir, vectorUrl);
 
@@ -125,17 +139,9 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
       // If health registry says service is down, return fallback immediately
       if (!state.registry.isUp(match.service)) {
         const fallback = match.fallback ?? 'error';
-        if (fallback === 'empty') {
-          return new Response(JSON.stringify({ results: [], source: 'gateway-fallback' }), {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' },
-          });
-        }
+        if (fallback === 'empty') return emptyFallbackResponse();
         if (fallback === 'fts5') return;
-        return new Response(
-          JSON.stringify({ error: 'Service unavailable', service: match.service }),
-          { status: 503, headers: { 'Content-Type': 'application/json' } },
-        );
+        return serviceUnavailableResponse(match.service);
       }
 
       const ctx: GatewayContext = {
@@ -169,6 +175,15 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
         if (errResp) return errResp;
         if (ctx.meta.fallback_to_local) return; // fall through to local Elysia
         throw err;
+      }
+
+      // proxyToService converts network/timeout failures into 502/504
+      // responses. Apply route-level fallback here too; otherwise a down
+      // VECTOR_URL would bypass the intended FTS5/empty degradation path.
+      if (response.status === 502 || response.status === 504) {
+        const fallback = match.fallback ?? 'error';
+        if (fallback === 'empty') return emptyFallbackResponse();
+        if (fallback === 'fts5') return;
       }
 
       // ── onResponse hooks ──


### PR DESCRIPTION
Refs #1071.

Fixes the next VECTOR_URL gateway gap after #1260:

- Synthesized `VECTOR_URL` config now covers the full vector route surface: `/api/search`, `/api/similar`, `/api/compare`, `/api/map`, `/api/map3d`, and `/api/vector/**`.
- Adds a vector health check at `${VECTOR_URL}/api/vector/health`.
- Applies route fallback when `proxyToService` returns 502/504, so a dead vector sidecar degrades correctly instead of leaking a gateway 502:
  - search → falls through to local FTS5
  - pure vector routes → error or empty response, not local LanceDB fallback inside core

Verification:
- `bun test src/gateway/__tests__/vector-url.test.ts` → 2 pass
- `bun test src/gateway/__tests__` → 50 pass
- `bun run build` → pass
- `bun run test:unit` → 255 pass / 0 fail

Scope: narrow #1071 slice only; broader vector-server separation remains open.

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3
