### PR TITLE
fix(gateway): return route-shaped empty fallbacks for vector maps

### DIFF
--- a/src/gateway/__tests__/vector-url.test.ts
+++ b/src/gateway/__tests__/vector-url.test.ts
@@ -66,7 +66,24 @@ describe('VECTOR_URL synthesized gateway config', () => {
 
       const map = await app.handle(new Request('http://localhost/api/map'));
       expect(map.status).toBe(200);
-      expect(await map.json()).toEqual({ results: [], source: 'gateway-fallback' });
+      expect(await map.json()).toEqual({
+        documents: [],
+        total: 0,
+        source: 'gateway-fallback',
+      });
+
+      const map3d = await app.handle(new Request('http://localhost/api/map3d'));
+      expect(map3d.status).toBe(200);
+      const map3dBody = await map3d.json();
+      expect(map3dBody.documents).toEqual([]);
+      expect(map3dBody.total).toBe(0);
+      expect(map3dBody.source).toBe('gateway-fallback');
+      expect(map3dBody.pca_info).toMatchObject({
+        variance_explained: [],
+        n_vectors: 0,
+        n_dimensions: 0,
+      });
+      expect(typeof map3dBody.pca_info.computed_at).toBe('string');
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -48,8 +48,28 @@ function describeState(state: GatewayState): string {
   );
 }
 
-function emptyFallbackResponse(): Response {
-  return new Response(JSON.stringify({ results: [], source: 'gateway-fallback' }), {
+function emptyFallbackResponse(pathname: string): Response {
+  let payload: Record<string, unknown>;
+
+  if (pathname === '/api/map3d') {
+    payload = {
+      documents: [],
+      total: 0,
+      pca_info: {
+        variance_explained: [],
+        n_vectors: 0,
+        n_dimensions: 0,
+        computed_at: new Date().toISOString(),
+      },
+      source: 'gateway-fallback',
+    };
+  } else if (pathname === '/api/map') {
+    payload = { documents: [], total: 0, source: 'gateway-fallback' };
+  } else {
+    payload = { results: [], source: 'gateway-fallback' };
+  }
+
+  return new Response(JSON.stringify(payload), {
     status: 200,
     headers: { 'Content-Type': 'application/json' },
   });
@@ -139,7 +159,7 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
       // If health registry says service is down, return fallback immediately
       if (!state.registry.isUp(match.service)) {
         const fallback = match.fallback ?? 'error';
-        if (fallback === 'empty') return emptyFallbackResponse();
+        if (fallback === 'empty') return emptyFallbackResponse(url.pathname);
         if (fallback === 'fts5') return;
         return serviceUnavailableResponse(match.service);
       }
@@ -182,7 +202,7 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
       // VECTOR_URL would bypass the intended FTS5/empty degradation path.
       if (response.status === 502 || response.status === 504) {
         const fallback = match.fallback ?? 'error';
-        if (fallback === 'empty') return emptyFallbackResponse();
+        if (fallback === 'empty') return emptyFallbackResponse(url.pathname);
         if (fallback === 'fts5') return;
       }
 


### PR DESCRIPTION
Refs #1071.

Follow-up to #1261: keeps the VECTOR_URL empty fallback safe *and* route-shaped.

Problem: `/api/map` and `/api/map3d` clients expect `documents`/`total` payloads (and map3d expects `pca_info`). The generic gateway empty fallback returned `{ results: [] }`, which avoids local LanceDB but mismatches existing map consumers.

Fix:
- `/api/map` empty fallback → `{ documents: [], total: 0, source: 'gateway-fallback' }`
- `/api/map3d` empty fallback → same plus empty `pca_info`
- Other future empty fallbacks keep generic `{ results: [] }`

Verification:
- `bun test src/gateway/__tests__/vector-url.test.ts` → 2 pass / 18 expects
- `bun test src/gateway/__tests__` → 50 pass / 109 expects
- `bun run build` → pass
- `bun run test:unit` → 255 pass / 0 fail

Scope: narrow #1071 fallback-shape hardening; broader vector-server separation remains open.

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3
