### PR TITLE
fix(menu): declare route nav targets without API_TO_STUDIO

### DIFF
--- a/docs/HOOK-MENU-PACKAGE.md
+++ b/docs/HOOK-MENU-PACKAGE.md
@@ -11,7 +11,7 @@ The reusable parts of the Oracle navigation system — TypeBox schemas, `buildMe
 | In-tree source | hook-menu module |
 |---|---|
 | `src/routes/menu/model.ts` | `hook-menu/model` — `MenuItem`, `MenuItemSchema`, `MenuResponseSchema` |
-| `src/routes/menu/menu.ts` (`buildMenuItems` + `API_TO_STUDIO`) | `hook-menu/build` — `buildMenuItems`, `defineMenu`, `API_TO_STUDIO` |
+| `src/routes/menu/menu.ts` (`buildMenuItems` + route-declared `detail.menu.path`) | `hook-menu/build` — `buildMenuItems`, `defineMenu` |
 | `src/routes/menu/studio-tag.ts`, `studio-href.ts` | `hook-menu/studio` — `parseStudioTag`, `studioHref` |
 | `src/menu/frontend.ts` (hardcoded items) | `hook-menu/frontend` — `defineFrontendMenu` (parametrized — takes items as input) |
 | `src/routes/menu/menu.ts` (`createMenuEndpoint`) | `hook-menu/elysia` — `mountMenu` |

--- a/src/db/seeders/menu-seeder.ts
+++ b/src/db/seeders/menu-seeder.ts
@@ -2,7 +2,7 @@
  * Menu seeder — syncs route-declared menu items into the `menu_items` table.
  *
  * Called at server boot (src/server.ts) and idempotent. For each route with
- * `detail.menu`, upserts by path:
+ * `detail.menu.path`, upserts by (path, studio):
  *   - Path not in DB           → INSERT with source='route', touchedAt=null
  *   - In DB, source='route'+untouched → UPDATE label/group/position from route
  *   - touchedAt != null        → PRESERVE (user edit wins); log drift
@@ -13,7 +13,6 @@ import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 import * as schema from '../schema.ts';
 import { db as defaultDb } from '../index.ts';
 import type { MenuMeta } from '../../routes/menu/model.ts';
-import { API_TO_STUDIO } from '../../routes/menu/menu.ts';
 
 export type RouteLike = { method?: string; path: string; hooks?: { detail?: unknown } };
 export type HasRoutes = { routes: RouteLike[] };
@@ -28,13 +27,6 @@ export interface RouteMenuRow {
   studio?: string | null; // host subdomain (e.g. feed.buildwithoracle.com); null = legacy studio.*
 }
 
-function studioPathFor(apiPath: string): string | null {
-  for (const [prefix, studio] of API_TO_STUDIO) {
-    if (apiPath === prefix || apiPath.startsWith(prefix + '/')) return studio;
-  }
-  return null;
-}
-
 export function collectRouteMenuRows(sources: HasRoutes[]): RouteMenuRow[] {
   const rows: RouteMenuRow[] = [];
   const seen = new Set<string>();
@@ -45,26 +37,25 @@ export function collectRouteMenuRows(sources: HasRoutes[]): RouteMenuRow[] {
       const menu = detail.menu;
       if (!menu || !menu.group) continue;
 
-      const studio = studioPathFor(route.path);
-      if (!studio) continue;
+      if (!menu.path) continue;
 
-      const key = `${menu.group}:${studio}`;
+      const key = `${menu.group}:${menu.path}:${menu.studio ?? ''}`;
       if (seen.has(key)) continue;
       seen.add(key);
 
-      const slug = studio.replace(/^\//, '') || 'home';
+      const slug = menu.path.replace(/^\//, '') || 'home';
       const label = menu.label ?? slug.charAt(0).toUpperCase() + slug.slice(1);
       const order =
         typeof menu.order === 'number' && Number.isFinite(menu.order) ? menu.order : 999;
 
       rows.push({
-        path: studio,
+        path: menu.path,
         label,
         groupKey: menu.group,
         position: order,
         access: menu.access ?? 'public',
         icon: menu.icon ?? null,
-        studio: null,
+        studio: menu.studio ?? null,
       });
     }
   }

--- a/src/routes/files/context.ts
+++ b/src/routes/files/context.ts
@@ -9,7 +9,7 @@ export const contextRoute = new Elysia().get(
     query: contextQuery,
     detail: {
       tags: ['files'],
-      menu: { group: 'tools', order: 40 },
+      menu: { group: 'tools', path: '/evolution', order: 40 },
       summary: 'Context for a working directory',
     },
   },

--- a/src/routes/forum/threads-list.ts
+++ b/src/routes/forum/threads-list.ts
@@ -23,7 +23,7 @@ export const threadsListRoute = new Elysia().get('/api/threads', ({ query }) => 
   query: threadsQuery,
   detail: {
     tags: ['forum'],
-    menu: { group: 'main', order: 40 },
+    menu: { group: 'main', path: '/', order: 40 },
     summary: 'List forum threads',
   },
 });

--- a/src/routes/health/stats.ts
+++ b/src/routes/health/stats.ts
@@ -22,7 +22,7 @@ export const statsEndpoint = new Elysia().get('/stats', async () => {
 }, {
   detail: {
     tags: ['health'],
-    menu: { group: 'tools', order: 50 },
+    menu: { group: 'tools', path: '/pulse', order: 50 },
     summary: 'Database and vector stats',
   },
 });

--- a/src/routes/menu/__tests__/menu-route-metadata.test.ts
+++ b/src/routes/menu/__tests__/menu-route-metadata.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'bun:test';
+import { Elysia } from 'elysia';
+
+import { collectRouteMenuRows } from '../../../db/seeders/menu-seeder.ts';
+import { menuItemsFromRoutes } from '../menu.ts';
+
+function routeSource() {
+  return new Elysia({ prefix: '/api' })
+    .get('/search', () => ({}), {
+      detail: {
+        menu: {
+          group: 'main',
+          path: '/search',
+          studio: 'studio.buildwithoracle.com',
+          order: 10,
+          label: 'Search',
+        },
+      },
+    })
+    .get('/internal', () => ({}), {
+      detail: {
+        menu: { group: 'main', order: 999, label: 'Internal' },
+      },
+    });
+}
+
+describe('route-declared menu metadata', () => {
+  it('uses detail.menu.path/studio instead of deriving from API path', () => {
+    expect(menuItemsFromRoutes([routeSource()])).toEqual([
+      {
+        path: '/search',
+        studio: 'studio.buildwithoracle.com',
+        label: 'Search',
+        group: 'main',
+        order: 10,
+        source: 'api',
+      },
+    ]);
+  });
+
+  it('seeds only opt-in route menu rows with explicit frontend path', () => {
+    expect(collectRouteMenuRows([routeSource()])).toEqual([
+      {
+        path: '/search',
+        studio: 'studio.buildwithoracle.com',
+        label: 'Search',
+        groupKey: 'main',
+        position: 10,
+        access: 'public',
+        icon: null,
+      },
+    ]);
+  });
+});

--- a/src/routes/menu/__tests__/menu-seeder-composite.test.ts
+++ b/src/routes/menu/__tests__/menu-seeder-composite.test.ts
@@ -33,7 +33,7 @@ function cleanupRows(): void {
 function routeSource() {
   return new Elysia({ prefix: '/api' }).get('/threads', () => ({}), {
     detail: {
-      menu: { group: 'main', order: 40, label: '__composite_route__' },
+      menu: { group: 'main', path: '/', order: 40, label: '__composite_route__' },
       summary: 'Threads',
     },
   });

--- a/src/routes/menu/index.ts
+++ b/src/routes/menu/index.ts
@@ -26,6 +26,5 @@ export {
   menuItemsFromRoutes,
   readApiMenuItemsFromDb,
   scopeMatches,
-  API_TO_STUDIO,
 } from './menu.ts';
 export type { MenuItem, MenuResponse, Scope } from './model.ts';

--- a/src/routes/menu/menu.ts
+++ b/src/routes/menu/menu.ts
@@ -4,7 +4,8 @@
  *
  * Flow:
  *   1. Boot-time seeder (src/db/seeders/menu-seeder.ts) upserts route-declared
- *      items into DB, preserving user-edited rows (`touchedAt != null`).
+ *      items with `detail.menu.path` into DB, preserving user-edited rows
+ *      (`touchedAt != null`).
  *   2. This endpoint reads `menu_items` via Drizzle, merges frontend pages,
  *      gist extras, and custom items — preserving /api/menu response shape.
  */
@@ -22,29 +23,6 @@ export type MenuExtras = {
   disable?: Iterable<string>;
 };
 
-export const API_TO_STUDIO: ReadonlyArray<readonly [string, string]> = [
-  ['/api/supersede', '/superseded'],
-  ['/api/search', '/search'],
-  ['/api/list', '/feed'],
-  ['/api/reflect', '/playground'],
-  ['/api/threads', '/'],
-  ['/api/traces', '/traces'],
-  ['/api/schedule', '/schedule'],
-  ['/api/plugins', '/plugins'],
-  ['/api/graph', '/map'],
-  ['/api/map3d', '/map'],
-  ['/api/map', '/map'],
-  ['/api/context', '/evolution'],
-  ['/api/stats', '/pulse'],
-];
-
-function studioPathFor(apiPath: string): string | null {
-  for (const [prefix, studio] of API_TO_STUDIO) {
-    if (apiPath === prefix || apiPath.startsWith(prefix + '/')) return studio;
-  }
-  return null;
-}
-
 type RouteLike = { method?: string; path: string; hooks?: { detail?: unknown } };
 type HasRoutes = { routes: RouteLike[] };
 
@@ -52,6 +30,9 @@ const GROUP_RANK: Record<MenuItem['group'], number> = { main: 0, tools: 1, admin
 
 /**
  * Pure scan of Elysia route sources into MenuItems (source='api').
+ * A route becomes a menu row only when it declares `detail.menu.path`; this
+ * keeps each owning route responsible for its frontend/studio target instead
+ * of relying on a central API-prefix translation table.
  * Used by tests and exported for callers that need pre-DB scanning.
  */
 export function menuItemsFromRoutes(sources: HasRoutes[]): MenuItem[] {
@@ -64,19 +45,22 @@ export function menuItemsFromRoutes(sources: HasRoutes[]): MenuItem[] {
       const menu = detail.menu;
       if (!menu || !menu.group) continue;
 
-      const studio = studioPathFor(route.path);
-      if (!studio) continue;
+      if (!menu.path) continue;
 
-      const key = `${menu.group}:${studio}`;
+      const key = `${menu.group}:${menu.path}:${menu.studio ?? ''}`;
       if (seen.has(key)) continue;
       seen.add(key);
 
       const order =
         typeof menu.order === 'number' && Number.isFinite(menu.order) ? menu.order : 999;
-      const slug = studio.replace(/^\//, '') || 'home';
+      const slug = menu.path.replace(/^\//, '') || 'home';
       const label = menu.label ?? slug.charAt(0).toUpperCase() + slug.slice(1);
 
-      items.push({ path: studio, label, group: menu.group, order, source: 'api' });
+      const item: MenuItem = { path: menu.path, label, group: menu.group, order, source: 'api' };
+      if (menu.studio) item.studio = menu.studio;
+      if (menu.icon) item.icon = menu.icon;
+      if (menu.access) item.access = menu.access;
+      items.push(item);
     }
   }
 

--- a/src/routes/menu/model.ts
+++ b/src/routes/menu/model.ts
@@ -7,9 +7,19 @@ import type { Static } from 'elysia';
 
 export interface MenuMeta {
   group: 'main' | 'tools' | 'admin' | 'hidden';
+  /**
+   * Studio/frontend path to expose in /api/menu. Route-declared menu items are
+   * opt-in: omit `path` for API endpoints that should not create nav rows.
+   */
+  path?: string;
   order?: number;
   label?: string;
   icon?: string;
+  /**
+   * Optional studio host for cross-studio menu entries, e.g.
+   * `canvas.buildwithoracle.com`. Null/undefined means the current studio.
+   */
+  studio?: string | null;
   access?: 'public' | 'auth';
 }
 

--- a/src/routes/plugins/list.ts
+++ b/src/routes/plugins/list.ts
@@ -4,7 +4,7 @@ import { scanPlugins } from './model.ts';
 export const pluginsListRoute = new Elysia().get('/api/plugins', () => scanPlugins(), {
   detail: {
     tags: ['plugins'],
-    menu: { group: 'main', order: 70 },
+    menu: { group: 'main', path: '/plugins', order: 70 },
     summary: 'List available plugins',
   },
 });

--- a/src/routes/schedule/list.ts
+++ b/src/routes/schedule/list.ts
@@ -21,7 +21,7 @@ export const scheduleListRoute = new Elysia().get('/api/schedule', async ({ quer
   query: listQuery,
   detail: {
     tags: ['schedule'],
-    menu: { group: 'main', order: 60 },
+    menu: { group: 'main', path: '/schedule', order: 60 },
     summary: 'List scheduled events',
   },
 });

--- a/src/routes/search/list.ts
+++ b/src/routes/search/list.ts
@@ -19,7 +19,7 @@ export const listEndpoint = new Elysia().get(
     query: ListQuery,
     detail: {
       tags: ['search'],
-      menu: { group: 'main', order: 20 },
+      menu: { group: 'main', path: '/feed', order: 20 },
       summary: 'List oracle documents',
     },
   },

--- a/src/routes/search/reflect.ts
+++ b/src/routes/search/reflect.ts
@@ -8,7 +8,7 @@ import { handleReflect } from '../../server/handlers.ts';
 export const reflectEndpoint = new Elysia().get('/reflect', () => handleReflect(), {
   detail: {
     tags: ['search'],
-    menu: { group: 'main', order: 30 },
+    menu: { group: 'main', path: '/playground', order: 30 },
     summary: 'Oracle self-reflection snapshot',
   },
 });

--- a/src/routes/search/search.ts
+++ b/src/routes/search/search.ts
@@ -44,7 +44,7 @@ export const searchEndpoint = new Elysia().get(
     query: SearchQuery,
     detail: {
       tags: ['search'],
-      menu: { group: 'main', order: 10 },
+      menu: { group: 'main', path: '/search', order: 10 },
       summary: 'Hybrid search over oracle docs',
     },
   },

--- a/src/routes/supersede/list.ts
+++ b/src/routes/supersede/list.ts
@@ -67,7 +67,7 @@ export const supersedeListEndpoint = new Elysia().get(
     query: SupersedeQuery,
     detail: {
       tags: ['supersede'],
-      menu: { group: 'tools', order: 60 },
+      menu: { group: 'tools', path: '/superseded', order: 60 },
       summary: 'List superseded documents',
     },
   },

--- a/src/routes/traces/list.ts
+++ b/src/routes/traces/list.ts
@@ -17,7 +17,7 @@ export const tracesListRoute = new Elysia().get('/api/traces', ({ query }) => {
   query: listQuery,
   detail: {
     tags: ['traces'],
-    menu: { group: 'main', order: 50 },
+    menu: { group: 'main', path: '/traces', order: 50 },
     summary: 'List traces',
   },
 });

--- a/src/routes/vector/map.ts
+++ b/src/routes/vector/map.ts
@@ -29,7 +29,7 @@ export const mapEndpoint = new Elysia().get('/map', async ({ set }) => {
 }, {
   detail: {
     tags: ['vector'],
-    menu: { group: 'tools', order: 20 },
+    menu: { group: 'tools', path: '/map', order: 20 },
     summary: '2D projection of embeddings',
   },
 });

--- a/tests/http/menu/crud.test.ts
+++ b/tests/http/menu/crud.test.ts
@@ -19,13 +19,13 @@ function clearMenu() {
 function sampleSource() {
   return new Elysia({ prefix: '/api' })
     .get('/search', () => ({}), {
-      detail: { menu: { group: 'main', order: 10 }, summary: 'Search' },
+      detail: { menu: { group: 'main', path: '/search', order: 10 }, summary: 'Search' },
     })
     .get('/traces', () => ({}), {
-      detail: { menu: { group: 'main', order: 40 }, summary: 'Traces' },
+      detail: { menu: { group: 'main', path: '/traces', order: 40 }, summary: 'Traces' },
     })
     .get('/map', () => ({}), {
-      detail: { menu: { group: 'tools', order: 20 }, summary: 'Map' },
+      detail: { menu: { group: 'tools', path: '/map', order: 20 }, summary: 'Map' },
     });
 }
 

--- a/tests/http/menu/db-seeder.test.ts
+++ b/tests/http/menu/db-seeder.test.ts
@@ -25,18 +25,18 @@ function clearMenu() {
 function sampleSource() {
   return new Elysia({ prefix: '/api' })
     .get('/search', () => ({}), {
-      detail: { menu: { group: 'main', order: 10 }, summary: 'Search' },
+      detail: { menu: { group: 'main', path: '/search', order: 10 }, summary: 'Search' },
     })
     .get('/traces', () => ({}), {
-      detail: { menu: { group: 'main', order: 40 }, summary: 'Traces' },
+      detail: { menu: { group: 'main', path: '/traces', order: 40 }, summary: 'Traces' },
     })
     .get('/map', () => ({}), {
-      detail: { menu: { group: 'tools', order: 20 }, summary: 'Map' },
+      detail: { menu: { group: 'tools', path: '/map', order: 20 }, summary: 'Map' },
     });
 }
 
 describe('collectRouteMenuRows', () => {
-  test('maps api paths to studio paths + menu meta', () => {
+  test('uses route-declared frontend paths + menu meta', () => {
     const rows = collectRouteMenuRows([sampleSource()]);
     expect(rows).toEqual([
       { path: '/search', label: 'Search', groupKey: 'main', position: 10, access: 'public', icon: null, studio: null },
@@ -45,10 +45,10 @@ describe('collectRouteMenuRows', () => {
     ]);
   });
 
-  test('skips routes without detail.menu', () => {
+  test('skips routes without detail.menu.path', () => {
     const sub = new Elysia({ prefix: '/api' })
       .get('/search', () => ({}), {
-        detail: { menu: { group: 'main', order: 1 }, summary: 'Search' },
+        detail: { menu: { group: 'main', path: '/search', order: 1 }, summary: 'Search' },
       })
       .get('/health', () => ({}), { detail: { summary: 'Health' } });
     expect(collectRouteMenuRows([sub])).toHaveLength(1);
@@ -87,7 +87,7 @@ describe('seedMenuItems', () => {
 
     const changed = new Elysia({ prefix: '/api' })
       .get('/search', () => ({}), {
-        detail: { menu: { group: 'tools', order: 99, label: 'Find' }, summary: 'Search' },
+        detail: { menu: { group: 'tools', path: '/search', order: 99, label: 'Find' }, summary: 'Search' },
       });
     const result = seedMenuItems([changed]);
     expect(result.updated).toBe(1);
@@ -113,7 +113,7 @@ describe('seedMenuItems', () => {
 
     const changed = new Elysia({ prefix: '/api' })
       .get('/search', () => ({}), {
-        detail: { menu: { group: 'main', order: 10, label: 'Route Search' }, summary: 'Search' },
+        detail: { menu: { group: 'main', path: '/search', order: 10, label: 'Route Search' }, summary: 'Search' },
       });
     const result = seedMenuItems([changed]);
     expect(result.preserved).toBe(1);

--- a/tests/http/menu/list.test.ts
+++ b/tests/http/menu/list.test.ts
@@ -23,20 +23,20 @@ function clearMenu() {
 function fakeApiModule() {
   return new Elysia({ prefix: '/api' })
     .get('/search', () => ({}), {
-      detail: { tags: ['search'], menu: { group: 'main', order: 10 }, summary: 'Search' },
+      detail: { tags: ['search'], menu: { group: 'main', path: '/search', order: 10 }, summary: 'Search' },
     })
     .get('/list', () => ({}), {
       detail: {
         tags: ['search'],
-        menu: { group: 'main', order: 20 },
+        menu: { group: 'main', path: '/feed', order: 20 },
         summary: 'List oracle documents',
       },
     })
     .get('/map', () => ({}), {
-      detail: { tags: ['map'], menu: { group: 'tools', order: 20 }, summary: 'Map 2D' },
+      detail: { tags: ['map'], menu: { group: 'tools', path: '/map', order: 20 }, summary: 'Map 2D' },
     })
     .get('/map3d', () => ({}), {
-      detail: { tags: ['map'], menu: { group: 'tools', order: 30 }, summary: 'Map 3D' },
+      detail: { tags: ['map'], menu: { group: 'tools', path: '/map', order: 30 }, summary: 'Map 3D' },
     })
     .get('/settings', () => ({}), {
       detail: { tags: ['settings'], menu: { group: 'hidden' }, summary: 'Settings' },
@@ -82,7 +82,7 @@ describe('/api/menu', () => {
     expect(tools[0]).toMatchObject({ path: '/map', order: 20 });
   });
 
-  test('unmapped or untagged paths are skipped', () => {
+  test('routes without menu.path or menu metadata are skipped', () => {
     const sub = new Elysia({ prefix: '/api' })
       .get('/unknown', () => ({}), {
         detail: { menu: { group: 'main', order: 1 }, summary: 'Unknown' },

--- a/tests/http/menu/playground-config.test.ts
+++ b/tests/http/menu/playground-config.test.ts
@@ -28,11 +28,11 @@ function clearMenu() {
 }
 
 function playgroundSource() {
-  // Mirrors the real route shape — /api/reflect maps to /playground via
-  // API_TO_STUDIO, group='main' order=30 in production.
+  // Mirrors the real route shape — /api/reflect declares its /playground
+  // frontend target directly in detail.menu metadata.
   return new Elysia({ prefix: '/api' })
     .get('/reflect', () => ({}), {
-      detail: { menu: { group: 'main', order: 30 }, summary: 'Playground' },
+      detail: { menu: { group: 'main', path: '/playground', order: 30 }, summary: 'Playground' },
     });
 }
 

--- a/tests/http/menu/reorder.test.ts
+++ b/tests/http/menu/reorder.test.ts
@@ -20,13 +20,13 @@ function clearMenu() {
 function sampleSource() {
   return new Elysia({ prefix: '/api' })
     .get('/search', () => ({}), {
-      detail: { menu: { group: 'main', order: 10 }, summary: 'Search' },
+      detail: { menu: { group: 'main', path: '/search', order: 10 }, summary: 'Search' },
     })
     .get('/traces', () => ({}), {
-      detail: { menu: { group: 'main', order: 40 }, summary: 'Traces' },
+      detail: { menu: { group: 'main', path: '/traces', order: 40 }, summary: 'Traces' },
     })
     .get('/map', () => ({}), {
-      detail: { menu: { group: 'tools', order: 20 }, summary: 'Map' },
+      detail: { menu: { group: 'tools', path: '/map', order: 20 }, summary: 'Map' },
     });
 }
 

--- a/tests/http/menu/reset.test.ts
+++ b/tests/http/menu/reset.test.ts
@@ -19,7 +19,7 @@ function clearMenu() {
 
 function routeSource(label = 'Search', order = 10) {
   return new Elysia({ prefix: '/api' }).get('/search', () => ({}), {
-    detail: { menu: { group: 'main', order, label }, summary: 'Search' },
+    detail: { menu: { group: 'main', path: '/search', order, label }, summary: 'Search' },
   });
 }
 


### PR DESCRIPTION
Refs #901.

This removes the remaining hardcoded `API_TO_STUDIO` API-prefix → frontend-path translation from the hook_menu backend. Route-sourced nav rows now opt in by declaring their target directly on the owning route via `detail.menu.path` (and optional `detail.menu.studio`). Routes without a declared menu path are skipped, keeping non-nav/internal API endpoints out of `/api/menu` without a central mapper.

What changed:
- Extended route `MenuMeta` with `path` + optional `studio`.
- Updated the visible route-owned nav entries (`/search`, `/feed`, `/playground`, `/`, `/traces`, `/schedule`, `/plugins`, `/map`, `/evolution`, `/pulse`, `/superseded`) to declare their own frontend paths.
- Removed `API_TO_STUDIO` from the menu aggregator/seeder exports.
- Updated menu HTTP/seed tests and docs to lock the route-declared metadata behavior.

Verification:
- `bun test tests/http/menu` → 84 pass
- `bun test src/routes/menu/__tests__` → 38 pass
- `bun run build` → exit 0
- `bun run test:unit` → 255 pass
- Smoke: isolated server `/api/menu?scope=main` seeds 11 route rows with the expected declared paths.

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3
