### PR TITLE
feat(menu): merge plugin manifest items into api menu

### DIFF
--- a/src/routes/menu/menu.ts
+++ b/src/routes/menu/menu.ts
@@ -16,10 +16,12 @@ import { MenuItemSchema, MenuResponseSchema, ScopeSchema, type MenuItem, type Me
 import { getFrontendMenuItems } from '../../menu/index.ts';
 import { getMenuConfig, getMenuSource, reloadMenuConfig } from '../../menu/config.ts';
 import { listCustomMenuItems } from '../../menu/custom-store.ts';
+import { getPluginMenuItems } from '../plugins/model.ts';
 import { db, menuItems } from '../../db/index.ts';
 
 export type MenuExtras = {
   items?: MenuItem[];
+  pluginItems?: MenuItem[];
   disable?: Iterable<string>;
 };
 
@@ -174,6 +176,15 @@ export function buildMenuItems(
     items.push(item);
   }
 
+  if (extras?.pluginItems) {
+    for (const item of extras.pluginItems) {
+      const key = `${item.group}:${item.path}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      items.push(item);
+    }
+  }
+
   if (extras?.items) {
     for (const item of extras.items) {
       const key = `${item.group}:${item.path}`;
@@ -219,7 +230,7 @@ export function createMenuEndpoint() {
         return {
           items: buildMenuItems(
             readApiMenuItemsFromDb(host, scope),
-            { items, disable },
+            { items, pluginItems: getPluginMenuItems(), disable },
             listCustomMenuItems(),
           ),
         };

--- a/src/routes/menu/model.ts
+++ b/src/routes/menu/model.ts
@@ -57,6 +57,7 @@ export const MenuItemSchema = t.Object({
     t.Literal('page'),
     t.Literal('plugin'),
   ]),
+  sourceName: t.Optional(t.String()),
   added: t.Optional(t.Boolean()),
   hidden: t.Optional(t.Boolean()),
   scope: t.Optional(ScopeSchema),

--- a/src/routes/plugins/model.ts
+++ b/src/routes/plugins/model.ts
@@ -9,8 +9,14 @@ import { t, type Static } from 'elysia';
 import { readdirSync, statSync, readFileSync, existsSync } from 'fs';
 import { join, basename } from 'path';
 import { homedir } from 'os';
+import type { MenuItem as NavMenuItem } from '../menu/model.ts';
 
 export const PLUGIN_DIR = join(homedir(), '.oracle', 'plugins');
+
+export function getPluginDir(): string {
+  const override = process.env.ORACLE_PLUGIN_DIR?.trim();
+  return override || PLUGIN_DIR;
+}
 
 export const PluginMenuSchema = t.Object({
   label: t.String(),
@@ -32,15 +38,11 @@ export type PluginEntry = {
   menu?: PluginMenu;
 };
 
-export type MenuItem = {
-  label: string;
-  path: string;
-  group: 'main' | 'tools' | 'hidden';
-  order: number;
-  icon?: string;
-  source: 'plugin';
+export type PluginMenuItem = NavMenuItem & {
   sourceName: string;
 };
+
+export type MenuItem = PluginMenuItem;
 
 export const pluginNameParams = t.Object({ name: t.String() });
 
@@ -100,8 +102,8 @@ export function readNestedPlugin(
   };
 }
 
-export function readFlatPlugin(file: string): PluginEntry {
-  const st = statSync(join(PLUGIN_DIR, file));
+export function readFlatPlugin(file: string, dir = getPluginDir()): PluginEntry {
+  const st = statSync(join(dir, file));
   return {
     name: file.replace(/\.wasm$/, ''),
     file,
@@ -110,31 +112,31 @@ export function readFlatPlugin(file: string): PluginEntry {
   };
 }
 
-export function resolveWasmPath(name: string): string | null {
-  const nestedManifest = join(PLUGIN_DIR, name, 'plugin.json');
+export function resolveWasmPath(name: string, dir = getPluginDir()): string | null {
+  const nestedManifest = join(dir, name, 'plugin.json');
   if (existsSync(nestedManifest)) {
     try {
       const manifest = JSON.parse(readFileSync(nestedManifest, 'utf8'));
       if (manifest.wasm && typeof manifest.wasm === 'string') {
-        const full = join(PLUGIN_DIR, name, manifest.wasm);
+        const full = join(dir, name, manifest.wasm);
         if (existsSync(full)) return full;
-        const base = join(PLUGIN_DIR, name, basename(manifest.wasm));
+        const base = join(dir, name, basename(manifest.wasm));
         if (existsSync(base)) return base;
       }
     } catch {
       // fall through to flat
     }
   }
-  const flat = join(PLUGIN_DIR, `${name}.wasm`);
+  const flat = join(dir, `${name}.wasm`);
   if (existsSync(flat)) return flat;
   return null;
 }
 
-export function scanPlugins(): { plugins: PluginEntry[]; dir: string } {
-  if (!existsSync(PLUGIN_DIR)) return { plugins: [], dir: PLUGIN_DIR };
+export function scanPlugins(dir = getPluginDir()): { plugins: PluginEntry[]; dir: string } {
+  if (!existsSync(dir)) return { plugins: [], dir };
   const plugins: PluginEntry[] = [];
-  for (const entry of readdirSync(PLUGIN_DIR)) {
-    const fullPath = join(PLUGIN_DIR, entry);
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry);
     let st;
     try {
       st = statSync(fullPath);
@@ -145,15 +147,15 @@ export function scanPlugins(): { plugins: PluginEntry[]; dir: string } {
       const nested = readNestedPlugin(fullPath, entry);
       if (nested) plugins.push(nested);
     } else if (st.isFile() && entry.endsWith('.wasm')) {
-      plugins.push(readFlatPlugin(entry));
+      plugins.push(readFlatPlugin(entry, dir));
     }
   }
-  return { plugins, dir: PLUGIN_DIR };
+  return { plugins, dir };
 }
 
-export function getPluginMenuItems(): MenuItem[] {
-  const { plugins } = scanPlugins();
-  const items: MenuItem[] = [];
+export function getPluginMenuItems(dir = getPluginDir()): PluginMenuItem[] {
+  const { plugins } = scanPlugins(dir);
+  const items: PluginMenuItem[] = [];
   for (const p of plugins) {
     if (!p.menu) continue;
     items.push({

--- a/tests/http/menu/plugin-items.test.ts
+++ b/tests/http/menu/plugin-items.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { createMenuRoutes } from '../../../src/routes/menu/index.ts';
+import { getPluginMenuItems } from '../../../src/routes/plugins/model.ts';
+
+let pluginDir: string;
+let priorPluginDir: string | undefined;
+
+function writePlugin(
+  name: string,
+  menu: Record<string, unknown>,
+  wasm = `${name}.wasm`,
+): void {
+  const dir = join(pluginDir, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, wasm), 'wasm');
+  writeFileSync(
+    join(dir, 'plugin.json'),
+    JSON.stringify({ name, version: '1.0.0', wasm, menu }, null, 2),
+  );
+}
+
+async function getMenu() {
+  const app = createMenuRoutes();
+  const res = await app.handle(new Request('http://localhost/api/menu'));
+  expect(res.status).toBe(200);
+  return (await res.json()) as { items: any[] };
+}
+
+describe('plugin manifest menu items', () => {
+  beforeEach(() => {
+    pluginDir = mkdtempSync(join(tmpdir(), 'arra-plugin-menu-'));
+    priorPluginDir = process.env.ORACLE_PLUGIN_DIR;
+    process.env.ORACLE_PLUGIN_DIR = pluginDir;
+  });
+
+  afterEach(() => {
+    if (priorPluginDir === undefined) delete process.env.ORACLE_PLUGIN_DIR;
+    else process.env.ORACLE_PLUGIN_DIR = priorPluginDir;
+    rmSync(pluginDir, { recursive: true, force: true });
+  });
+
+  test('scanner turns plugin.json menu fields into plugin-sourced nav items', () => {
+    writePlugin('hello', {
+      label: 'Hello',
+      group: 'tools',
+      order: 100,
+      icon: 'wave',
+    });
+
+    expect(getPluginMenuItems()).toEqual([
+      {
+        label: 'Hello',
+        path: '/plugins/hello',
+        group: 'tools',
+        order: 100,
+        icon: 'wave',
+        source: 'plugin',
+        sourceName: 'hello',
+      },
+    ]);
+  });
+
+  test('/api/menu merges plugin items with the normal menu sources', async () => {
+    writePlugin('hello', {
+      label: 'Hello',
+      group: 'tools',
+      order: 100,
+      icon: 'wave',
+      path: '/plugins/hello',
+    });
+
+    const body = await getMenu();
+    const item = body.items.find((i) => i.source === 'plugin' && i.sourceName === 'hello');
+    expect(item).toMatchObject({
+      label: 'Hello',
+      path: '/plugins/hello',
+      group: 'tools',
+      order: 100,
+      icon: 'wave',
+      source: 'plugin',
+      sourceName: 'hello',
+    });
+  });
+});


### PR DESCRIPTION
Refs #901.

## Problem
Plugin manifests already support optional `menu` metadata, but `/api/menu` did not consume `getPluginMenuItems()`, so plugin nav docs were aspirational and installed plugins stayed invisible to the menu aggregator.

## Fix
- Merge plugin-sourced menu rows into `buildMenuItems()` before gist/custom entries.
- Expose optional `sourceName` on menu items so plugin rows identify their owning plugin.
- Make plugin scanning respect `ORACLE_PLUGIN_DIR` for isolated tests/dev while preserving the `~/.oracle/plugins` default.
- Add HTTP-level coverage proving `/api/menu` emits plugin manifest menu rows.

## Verification
- `bun test tests/http/menu/plugin-items.test.ts`
- `bun test tests/http/menu`
- `bun run build`
- `bun run test:unit`

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3