### PR TITLE
fix(vector): ignore gateway VECTOR_URL inside vector sidecar

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "scripts": {
     "dev": "bun src/index.ts",
     "server": "bun src/server.ts",
-    "vector": "ORACLE_VECTOR_READONLY=1 bun src/vector-server.ts",
-    "vector:dev": "ORACLE_VECTOR_READONLY=1 bun --watch src/vector-server.ts",
+    "vector": "ORACLE_VECTOR_SERVER=1 ORACLE_VECTOR_READONLY=1 bun src/vector-server.ts",
+    "vector:dev": "ORACLE_VECTOR_SERVER=1 ORACLE_VECTOR_READONLY=1 bun --watch src/vector-server.ts",
     "server:ensure": "bun src/ensure-server.ts",
     "server:status": "bun src/ensure-server.ts --status",
     "serve": "bun dist/server.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -55,9 +55,25 @@ if (!fs.existsSync(ORACLE_DATA_DIR)) {
 }
 
 // Vector layer routing (#1071 phase 1.2)
-//   VECTOR_URL       — if set, vector calls proxy to this base URL (e.g. http://vector.local:8080)
-//                      if empty, the local vector adapter is used (backward compat).
+//   VECTOR_URL       — if set, the core HTTP server proxies vector calls to this
+//                      base URL (e.g. http://vector.local:8080). The vector
+//                      server itself must ignore inherited VECTOR_URL so it
+//                      cannot proxy back to itself or another sidecar.
 //   VECTOR_FALLBACK  — what to do when proxy is unreachable. 'fts5' = serve FTS5-only
 //                      results with vectorAvailable: false. (Future: 'cache', 'fail'.)
-export const VECTOR_URL = process.env.VECTOR_URL || '';
+export function isVectorServerEntrypoint(argv1: string | undefined): boolean {
+  return /(^|[/\\])vector-server\.(ts|js|mjs)$/.test(argv1 || '');
+}
+
+export function resolveVectorUrl(
+  env: Record<string, string | undefined> = process.env,
+  argv: string[] = process.argv,
+): string {
+  if (env.ORACLE_VECTOR_SERVER === '1' || isVectorServerEntrypoint(argv[1])) {
+    return '';
+  }
+  return env.VECTOR_URL || '';
+}
+
+export const VECTOR_URL = resolveVectorUrl();
 export const VECTOR_FALLBACK = process.env.VECTOR_FALLBACK || 'fts5';

--- a/src/config/__tests__/vector-url.test.ts
+++ b/src/config/__tests__/vector-url.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test';
+
+import { isVectorServerEntrypoint, resolveVectorUrl } from '../../config.ts';
+
+describe('VECTOR_URL routing guard', () => {
+  test('core server honors VECTOR_URL', () => {
+    expect(
+      resolveVectorUrl({ VECTOR_URL: 'http://127.0.0.1:8081' }, ['bun', 'src/server.ts']),
+    ).toBe('http://127.0.0.1:8081');
+  });
+
+  test('vector server env flag disables inherited VECTOR_URL', () => {
+    expect(
+      resolveVectorUrl(
+        { VECTOR_URL: 'http://127.0.0.1:8081', ORACLE_VECTOR_SERVER: '1' },
+        ['bun', 'src/server.ts'],
+      ),
+    ).toBe('');
+  });
+
+  test('direct vector-server entrypoint disables inherited VECTOR_URL', () => {
+    expect(isVectorServerEntrypoint('/app/src/vector-server.ts')).toBe(true);
+    expect(
+      resolveVectorUrl({ VECTOR_URL: 'http://127.0.0.1:8081' }, ['bun', '/app/src/vector-server.ts']),
+    ).toBe('');
+  });
+});

--- a/src/server/__tests__/vector-server-route.test.ts
+++ b/src/server/__tests__/vector-server-route.test.ts
@@ -8,10 +8,14 @@ const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-vector-server-route
 const originalDataDir = process.env.ORACLE_DATA_DIR;
 const originalDbPath = process.env.ORACLE_DB_PATH;
 const originalRepoRoot = process.env.ORACLE_REPO_ROOT;
+const originalVectorUrl = process.env.VECTOR_URL;
+const originalVectorServer = process.env.ORACLE_VECTOR_SERVER;
 
 process.env.ORACLE_DATA_DIR = dataDir;
 process.env.ORACLE_DB_PATH = path.join(dataDir, 'oracle.db');
 process.env.ORACLE_REPO_ROOT = repoRoot;
+process.env.VECTOR_URL = 'http://127.0.0.1:9';
+process.env.ORACLE_VECTOR_SERVER = '1';
 
 const { createVectorServerApp } = await import('../../vector-server.ts');
 
@@ -24,6 +28,17 @@ describe('vector-server route surface', () => {
     expect(response.status).toBe(400);
     expect(payload.error).toBe('Missing query parameter: q');
   });
+
+  it('ignores inherited VECTOR_URL instead of proxying its own vector health route', async () => {
+    const app = createVectorServerApp();
+    const response = await app.handle(new Request('http://localhost/api/vector/health'));
+    const payload = await response.json() as Record<string, unknown>;
+
+    // If the sidecar honored VECTOR_URL, this would take the proxy path and
+    // include { proxy: "http://127.0.0.1:9" }. The sidecar must always answer
+    // from its local vector adapter surface to avoid loops.
+    expect(payload.proxy).toBeUndefined();
+  });
 });
 
 afterAll(() => {
@@ -35,4 +50,8 @@ afterAll(() => {
   else delete process.env.ORACLE_DB_PATH;
   if (originalRepoRoot) process.env.ORACLE_REPO_ROOT = originalRepoRoot;
   else delete process.env.ORACLE_REPO_ROOT;
+  if (originalVectorUrl !== undefined) process.env.VECTOR_URL = originalVectorUrl;
+  else delete process.env.VECTOR_URL;
+  if (originalVectorServer !== undefined) process.env.ORACLE_VECTOR_SERVER = originalVectorServer;
+  else delete process.env.ORACLE_VECTOR_SERVER;
 });


### PR DESCRIPTION
Refs #1071.

## Problem
`VECTOR_URL` is a core-server gateway setting, but a `src/vector-server.ts` sidecar can inherit that environment from tmux/compose/process managers. If honored inside the sidecar, vector routes can proxy back out instead of answering from the local vector adapter surface, creating loop/bad-gateway behavior.

## Fix
- Add `resolveVectorUrl()` guard: `ORACLE_VECTOR_SERVER=1` or a `vector-server.ts/js/mjs` entrypoint disables inherited `VECTOR_URL`.
- Mark `bun run vector` and `bun run vector:dev` with `ORACLE_VECTOR_SERVER=1`.
- Add regression coverage for core honoring `VECTOR_URL` while vector-server mode ignores it.

## Verification
- `bun test src/config/__tests__/vector-url.test.ts src/server/__tests__/vector-server-route.test.ts`
- `bun run build`
- `bun run test:unit`

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3