### PR TITLE
feat(learn): emit vector-source frontmatter in learning markdown

### DIFF
--- a/src/learn/markdown.ts
+++ b/src/learn/markdown.ts
@@ -1,0 +1,63 @@
+import { createHash } from 'node:crypto';
+
+export interface LearningMarkdownOptions {
+  id: string;
+  pattern: string;
+  title: string;
+  concepts: string[];
+  createdAt: Date;
+  source?: string;
+  project?: string | null;
+  footer?: string;
+  type?: string;
+}
+
+export function learningContentHash(pattern: string): string {
+  return `sha256:${createHash('sha256').update(pattern, 'utf8').digest('hex')}`;
+}
+
+export function dateSlug(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+}
+
+function inlineList(values: string[]): string {
+  return values.length > 0 ? `[${values.join(', ')}]` : '[]';
+}
+
+export function buildLearningMarkdown(opts: LearningMarkdownOptions): string {
+  const type = opts.type ?? 'learning';
+  const source = opts.source || 'Oracle Learn';
+  const footer = opts.footer ?? '*Added via Oracle Learn*';
+  const createdDate = dateSlug(opts.createdAt);
+  const timestamp = opts.createdAt.toISOString();
+  const concepts = inlineList(opts.concepts);
+  const hash = learningContentHash(opts.pattern);
+
+  return [
+    '---',
+    `id: ${opts.id}`,
+    `type: ${type}`,
+    `title: ${opts.title}`,
+    `concepts: ${concepts}`,
+    `tags: ${concepts}`,
+    `created: ${createdDate}`,
+    `indexed_at: ${timestamp}`,
+    `updated_at: ${timestamp}`,
+    `hash: ${hash}`,
+    `source: ${source}`,
+    ...(opts.project ? [`project: ${opts.project}`] : []),
+    `arra_id: ${opts.id}`,
+    `arra_type: ${type}`,
+    `arra_concepts: ${concepts}`,
+    `arra_created: ${timestamp}`,
+    '---',
+    '',
+    `# ${opts.title}`,
+    '',
+    opts.pattern,
+    '',
+    '---',
+    footer,
+    ''
+  ].join('\n');
+}

--- a/src/server/__tests__/learn-slug-collision.test.ts
+++ b/src/server/__tests__/learn-slug-collision.test.ts
@@ -66,6 +66,30 @@ describe('handleLearn — slug collision', () => {
     expect(res.success).toBe(true);
     expect(res.file).toMatch(/_completely-different-pattern-with-own-slug\.md$/);
   });
+
+  it('writes vector-server interchange metadata into HTTP learn markdown', () => {
+    const res = handleLearn(
+      'frontmatter contract pattern from HTTP learn',
+      'frontmatter-test',
+      ['frontmatter', 'vector'],
+      undefined,
+      'github.com/soul-brews-studio/arra-oracle-v3',
+    );
+    expect(res.success).toBe(true);
+
+    const markdown = fs.readFileSync(path.join(TMP_REPO_ROOT, res.file), 'utf-8');
+    expect(markdown).toContain(`id: ${res.id}`);
+    expect(markdown).toContain('type: learning');
+    expect(markdown).toContain('concepts: [frontmatter, vector]');
+    expect(markdown).toContain('tags: [frontmatter, vector]');
+    expect(markdown).toMatch(/^hash: sha256:[a-f0-9]{64}$/m);
+    expect(markdown).toMatch(/^indexed_at: .+Z$/m);
+    expect(markdown).toMatch(/^updated_at: .+Z$/m);
+    expect(markdown).toContain(`arra_id: ${res.id}`);
+    expect(markdown).toContain('arra_type: learning');
+    expect(markdown).toContain('arra_concepts: [frontmatter, vector]');
+    expect(markdown).toContain('project: github.com/soul-brews-studio/arra-oracle-v3');
+  });
 });
 
 afterAll(() => {

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -16,6 +16,7 @@ import { ensureVectorStoreConnected, EMBEDDING_MODELS } from '../vector/factory.
 import { detectProject } from './project-detect.ts';
 import { coerceConcepts } from '../tools/learn.ts';
 import { createVectorProxy } from './vector-proxy.ts';
+import { buildLearningMarkdown, dateSlug } from '../learn/markdown.ts';
 
 // Module-level proxy instance — bound to VECTOR_URL at boot. If VECTOR_URL is
 // unset, this is null and the local vector adapter runs in-process (legacy
@@ -686,7 +687,6 @@ export function persistLearningDoc(opts: {
 }): { file: string; id: string } {
   const { pattern, subdir, filename, id } = opts;
   const now = new Date();
-  const dateStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
 
   const dir = path.join(REPO_ROOT, subdir);
   fs.mkdirSync(dir, { recursive: true });
@@ -698,24 +698,16 @@ export function persistLearningDoc(opts: {
 
   const title = pattern.split('\n')[0].substring(0, 80);
   const conceptsList = coerceConcepts(opts.concepts);
-  const footer = opts.footer ?? '*Added via Oracle Learn*';
-
-  const frontmatter = [
-    '---',
-    `title: ${title}`,
-    conceptsList.length > 0 ? `tags: [${conceptsList.join(', ')}]` : 'tags: []',
-    `created: ${dateStr}`,
-    `source: ${opts.source || 'Oracle Learn'}`,
-    '---',
-    '',
-    `# ${title}`,
-    '',
+  const frontmatter = buildLearningMarkdown({
+    id,
     pattern,
-    '',
-    '---',
-    footer,
-    ''
-  ].join('\n');
+    title,
+    concepts: conceptsList,
+    createdAt: now,
+    source: opts.source,
+    project: opts.project,
+    footer: opts.footer,
+  });
 
   fs.writeFileSync(filePath, frontmatter, 'utf-8');
 
@@ -756,7 +748,7 @@ export function handleLearn(
 ) {
   const resolvedProject = (project ?? detectProject(cwd))?.toLowerCase() ?? null;
   const d = new Date();
-  const dateStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  const dateStr = dateSlug(d);
 
   const slug = pattern
     .substring(0, 50)

--- a/src/tools/__tests__/learn-enqueue.test.ts
+++ b/src/tools/__tests__/learn-enqueue.test.ts
@@ -122,6 +122,28 @@ describe('handleLearn — M5 enqueue branch', () => {
     expect(parsed.embedding).toBeDefined();
   });
 
+  it('writes vault interchange frontmatter fields to the learning markdown file', async () => {
+    const res = await handleLearn(h.ctx, {
+      pattern: `frontmatter interchange pattern ${Date.now()}-${Math.random()}`,
+      source: 'frontmatter-test',
+      concepts: ['frontmatter', 'vector'],
+    });
+    const parsed = JSON.parse(res.content[0].text);
+    expect(parsed.success).toBe(true);
+
+    const markdown = fs.readFileSync(path.join(SHARED_REPO_ROOT, parsed.file), 'utf-8');
+    expect(markdown).toContain(`id: ${parsed.id}`);
+    expect(markdown).toContain('type: learning');
+    expect(markdown).toContain('concepts: [frontmatter, vector]');
+    expect(markdown).toContain('tags: [frontmatter, vector]');
+    expect(markdown).toMatch(/^hash: sha256:[a-f0-9]{64}$/m);
+    expect(markdown).toMatch(/^indexed_at: .+Z$/m);
+    expect(markdown).toMatch(/^updated_at: .+Z$/m);
+    expect(markdown).toContain(`arra_id: ${parsed.id}`);
+    expect(markdown).toContain('arra_type: learning');
+    expect(markdown).toContain('arra_concepts: [frontmatter, vector]');
+  });
+
   it('ORACLE_INDEXER_ENQUEUE=1 → enqueues one job per registered model', async () => {
     process.env.ORACLE_INDEXER_ENQUEUE = '1';
     const res = await handleLearn(h.ctx, { pattern: `test pattern B ${Date.now()}-${Math.random()}` });

--- a/src/tools/__tests__/mcp-learn-proxy.test.ts
+++ b/src/tools/__tests__/mcp-learn-proxy.test.ts
@@ -38,7 +38,10 @@ afterEach(() => {
 });
 
 test('oracle_learn proxies through ORACLE_API without opening the MCP DB', async () => {
-  const port = 49600 + Math.floor(Math.random() * 300);
+  // Keep learn on its own port band. This test runs concurrently with the
+  // verify proxy test under `bun test --isolate`; sharing the 496xx band made
+  // CI occasionally start two HTTP servers on the same port.
+  const port = 50600 + Math.floor(Math.random() * 300);
   const baseUrl = `http://127.0.0.1:${port}`;
   const serverDataDir = tempDir('arra-learn-proxy-server-');
   const serverRepoRoot = tempDir('arra-learn-proxy-repo-');

--- a/src/tools/learn.ts
+++ b/src/tools/learn.ts
@@ -11,6 +11,7 @@ import { oracleDocuments } from '../db/schema.ts';
 import { detectProject } from '../server/project-detect.ts';
 import { getVectorStoreByModel, getEmbeddingModels } from '../vector/factory.ts';
 import { REPO_ROOT } from '../config.ts';
+import { buildLearningMarkdown, dateSlug } from '../learn/markdown.ts';
 
 // Lazy-loaded on first use — avoids top-level await which causes a TDZ
 // error in consumers that import learnToolDef synchronously (the tools
@@ -184,7 +185,7 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
   }
 
   const now = new Date();
-  const dateStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+  const dateStr = dateSlug(now);
 
   const slug = pattern
     .substring(0, 50)
@@ -228,29 +229,20 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
     throw new Error(`File already exists: ${filename}`);
   }
 
+  const id = `learning_${dateStr}_${slug}`;
   const title = pattern.split('\n')[0].substring(0, 80);
   const conceptsList = coerceConcepts(concepts);
-  const frontmatter = [
-    '---',
-    `title: ${title}`,
-    conceptsList.length > 0 ? `tags: [${conceptsList.join(', ')}]` : 'tags: []',
-    `created: ${dateStr}`,
-    `source: ${source || 'Oracle Learn'}`,
-    ...(project ? [`project: ${project}`] : []),
-    '---',
-    '',
-    `# ${title}`,
-    '',
+  const frontmatter = buildLearningMarkdown({
+    id,
     pattern,
-    '',
-    '---',
-    '*Added via Oracle Learn*',
-    ''
-  ].join('\n');
+    title,
+    concepts: conceptsList,
+    createdAt: now,
+    source,
+    project,
+  });
 
   fs.writeFileSync(filePath, frontmatter, 'utf-8');
-
-  const id = `learning_${dateStr}_${slug}`;
 
   ctx.db.insert(oracleDocuments).values({
     id,


### PR DESCRIPTION
Refs #1071.

Phase 2.1 vault interchange slice: `oracle_learn` markdown now carries durable source-of-truth metadata for vector-server reindexing while preserving the existing title/tags/created/source fields. Both embedded MCP learn and HTTP `/api/learn` use the same shared markdown builder.

Changes:
- Add shared `src/learn/markdown.ts` builder with `id`, `type`, `concepts`, `hash`, `indexed_at`, `updated_at`, plus `arra_*` aliases.
- Wire `src/tools/learn.ts` and `src/server/handlers.ts` through that builder.
- Add coverage for MCP embedded learn and HTTP learn markdown output.

Verification:
- `bun test --isolate src/tools/__tests__/learn-enqueue.test.ts src/server/__tests__/learn-slug-collision.test.ts` -> 10 pass
- `bun run build` -> pass
- `bun run test:unit` -> 258 pass

Scope note: this is a narrow #1071 Phase 2.1 slice. It does not complete the broader vector-server separation epic.

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3