### PR TITLE
feat(vector): honor per-collection adapter config

### DIFF
--- a/src/vector/__tests__/config.test.ts
+++ b/src/vector/__tests__/config.test.ts
@@ -1,0 +1,105 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-vector-config-'));
+const tmpDataDir = path.join(tmpRoot, 'nested', 'data');
+const originalDataDir = process.env.ORACLE_DATA_DIR;
+process.env.ORACLE_DATA_DIR = tmpDataDir;
+
+// Dynamic imports after ORACLE_DATA_DIR is set because config.ts freezes env at import time.
+const {
+  configPath,
+  configToModels,
+  generateDefaultConfig,
+  loadVectorConfig,
+  writeVectorConfig,
+} = await import('../config.ts');
+const {
+  createVectorStore,
+  getEmbeddingModels,
+  getVectorStoreConfigByModel,
+} = await import('../factory.ts');
+
+describe('vector-server config', () => {
+  test('default config advertises per-collection adapter/provider metadata', () => {
+    const cfg = generateDefaultConfig();
+    expect(cfg.collections['bge-m3'].adapter).toBe('lancedb');
+    expect(cfg.collections['bge-m3'].provider).toBe('ollama');
+    expect(cfg.collections.nomic.adapter).toBe('lancedb');
+    expect(cfg.collections.qwen3.adapter).toBe('lancedb');
+  });
+
+  test('writeVectorConfig creates ORACLE_DATA_DIR and loadVectorConfig reads it back', () => {
+    const cfg = generateDefaultConfig();
+    cfg.port = 8181;
+
+    const fp = writeVectorConfig(cfg);
+    expect(fp).toBe(configPath());
+    expect(fs.existsSync(fp)).toBe(true);
+    expect(loadVectorConfig()?.port).toBe(8181);
+  });
+
+  test('configToModels preserves per-collection adapter overrides', () => {
+    const cfg = generateDefaultConfig();
+    cfg.dataPath = '/var/lib/arra/lancedb';
+    cfg.collections.scale = {
+      adapter: 'qdrant',
+      collection: 'oracle_scale',
+      model: 'bge-m3',
+      provider: 'ollama',
+      qdrantUrl: 'http://qdrant:6333',
+    };
+    cfg.collections.edge = {
+      adapter: 'lancedb',
+      collection: 'oracle_edge',
+      model: 'nomic-embed-text',
+      provider: 'ollama',
+      dataPath: '/tmp/edge-lancedb',
+    };
+
+    const models = configToModels(cfg);
+    expect(models.scale).toMatchObject({
+      adapter: 'qdrant',
+      collection: 'oracle_scale',
+      model: 'bge-m3',
+      provider: 'ollama',
+      dataPath: '/var/lib/arra/lancedb',
+      qdrantUrl: 'http://qdrant:6333',
+    });
+    expect(models.edge).toMatchObject({
+      adapter: 'lancedb',
+      dataPath: '/tmp/edge-lancedb',
+    });
+  });
+
+  test('getVectorStoreByModel path can select Qdrant from vector-server.json', () => {
+    const cfg = generateDefaultConfig();
+    cfg.collections.scale = {
+      adapter: 'qdrant',
+      collection: 'oracle_scale',
+      model: 'bge-m3',
+      provider: 'ollama',
+      qdrantUrl: 'http://qdrant:6333',
+    };
+    writeVectorConfig(cfg);
+
+    expect(getEmbeddingModels().scale.adapter).toBe('qdrant');
+    const storeConfig = getVectorStoreConfigByModel('scale');
+    expect(storeConfig).toMatchObject({
+      type: 'qdrant',
+      collectionName: 'oracle_scale',
+      embeddingProvider: 'ollama',
+      embeddingModel: 'bge-m3',
+      qdrantUrl: 'http://qdrant:6333',
+    });
+    expect(createVectorStore(storeConfig).name).toBe('qdrant');
+  });
+});
+
+afterAll(() => {
+  try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch {}
+  if (originalDataDir) process.env.ORACLE_DATA_DIR = originalDataDir;
+  else delete process.env.ORACLE_DATA_DIR;
+});

--- a/src/vector/config.ts
+++ b/src/vector/config.ts
@@ -12,13 +12,21 @@ import fs from 'fs';
 import path from 'path';
 import { ORACLE_DATA_DIR, LANCEDB_DIR } from '../config.ts';
 import { COLLECTION_NAME } from '../const.ts';
+import type { EmbeddingProviderType, VectorDBType } from './types.ts';
 
 export const VECTOR_CONFIG_FILE = 'vector-server.json';
 
 export interface VectorCollectionConfig {
   collection: string;
   model: string;
-  provider: string;
+  provider: EmbeddingProviderType;
+  adapter?: VectorDBType;
+  dataPath?: string;
+  pythonVersion?: string;
+  qdrantUrl?: string;
+  qdrantApiKey?: string;
+  cfAccountId?: string;
+  cfApiToken?: string;
   primary?: boolean;
 }
 
@@ -29,6 +37,19 @@ export interface VectorServerConfig {
   collections: Record<string, VectorCollectionConfig>;
   dataPath: string;
   embeddingEndpoint: string;
+}
+
+export interface VectorModelRegistryEntry {
+  collection: string;
+  model: string;
+  dataPath?: string;
+  adapter?: VectorDBType;
+  provider?: EmbeddingProviderType;
+  pythonVersion?: string;
+  qdrantUrl?: string;
+  qdrantApiKey?: string;
+  cfAccountId?: string;
+  cfApiToken?: string;
 }
 
 /** Absolute path to vector-server.json inside ORACLE_DATA_DIR. */
@@ -47,17 +68,20 @@ export function generateDefaultConfig(): VectorServerConfig {
     port: 8081,
     collections: {
       'bge-m3': {
+        adapter: 'lancedb',
         collection: 'oracle_knowledge_bge_m3',
         model: 'bge-m3',
         provider: 'ollama',
         primary: true,
       },
       nomic: {
+        adapter: 'lancedb',
         collection: COLLECTION_NAME,
         model: 'nomic-embed-text',
         provider: 'ollama',
       },
       qwen3: {
+        adapter: 'lancedb',
         collection: 'oracle_knowledge_qwen3',
         model: 'qwen3-embedding',
         provider: 'ollama',
@@ -90,6 +114,7 @@ export function loadVectorConfig(): VectorServerConfig | null {
  */
 export function writeVectorConfig(config: VectorServerConfig): string {
   const fp = configPath();
+  fs.mkdirSync(path.dirname(fp), { recursive: true });
   fs.writeFileSync(fp, JSON.stringify(config, null, 2) + '\n', 'utf-8');
   return fp;
 }
@@ -100,13 +125,20 @@ export function writeVectorConfig(config: VectorServerConfig): string {
  */
 export function configToModels(
   config: VectorServerConfig,
-): Record<string, { collection: string; model: string; dataPath?: string }> {
-  const out: Record<string, { collection: string; model: string; dataPath?: string }> = {};
+): Record<string, VectorModelRegistryEntry> {
+  const out: Record<string, VectorModelRegistryEntry> = {};
   for (const [key, col] of Object.entries(config.collections)) {
     out[key] = {
       collection: col.collection,
       model: col.model,
-      dataPath: config.dataPath || undefined,
+      adapter: col.adapter,
+      provider: col.provider,
+      dataPath: col.dataPath || config.dataPath || undefined,
+      pythonVersion: col.pythonVersion,
+      qdrantUrl: col.qdrantUrl,
+      qdrantApiKey: col.qdrantApiKey,
+      cfAccountId: col.cfAccountId,
+      cfApiToken: col.cfApiToken,
     };
   }
   return out;

--- a/src/vector/factory.ts
+++ b/src/vector/factory.ts
@@ -15,7 +15,7 @@ import { LanceDBAdapter } from './adapters/lancedb.ts';
 import { QdrantAdapter } from './adapters/qdrant.ts';
 import { CloudflareVectorizeAdapter, CloudflareAIEmbeddings } from './adapters/cloudflare-vectorize.ts';
 import { createEmbeddingProvider } from './embeddings.ts';
-import { loadVectorConfig, configToModels } from './config.ts';
+import { loadVectorConfig, configToModels, type VectorModelRegistryEntry } from './config.ts';
 
 export interface VectorStoreConfig {
   type?: VectorDBType;
@@ -132,7 +132,7 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
 // Model-based registry for dual-index search
 // ============================================================================
 
-export function getEmbeddingModels(): Record<string, { collection: string; model: string; dataPath?: string }> {
+export function getEmbeddingModels(): Record<string, VectorModelRegistryEntry> {
   // If vector-server.json exists, use it as source of truth (#1071 phase 2)
   const cfg = loadVectorConfig();
   if (cfg) return configToModels(cfg);
@@ -140,25 +140,31 @@ export function getEmbeddingModels(): Record<string, { collection: string; model
   // Hardcoded fallback — always works even without config file
   return {
     nomic: {
+      adapter: 'lancedb',
       collection: COLLECTION_NAME,
       model: 'nomic-embed-text',
       dataPath: LANCEDB_DIR,
+      provider: 'ollama',
     },
     qwen3: {
+      adapter: 'lancedb',
       collection: 'oracle_knowledge_qwen3',
       model: 'qwen3-embedding',
       dataPath: LANCEDB_DIR,
+      provider: 'ollama',
     },
     'bge-m3': {
+      adapter: 'lancedb',
       collection: 'oracle_knowledge_bge_m3',
       model: 'bge-m3',
       dataPath: LANCEDB_DIR,
+      provider: 'ollama',
     },
   };
 }
 
 /** @deprecated Use getEmbeddingModels() — kept for backward compat */
-export const EMBEDDING_MODELS = new Proxy({} as Record<string, { collection: string; model: string; dataPath?: string }>, {
+export const EMBEDDING_MODELS = new Proxy({} as Record<string, VectorModelRegistryEntry>, {
   get(_, prop: string) { return getEmbeddingModels()[prop]; },
   has(_, prop: string) { return prop in getEmbeddingModels(); },
   ownKeys() { return Object.keys(getEmbeddingModels()); },
@@ -177,19 +183,30 @@ const modelStoreCache = new Map<string, VectorStoreAdapter>();
  */
 const connectPromises = new Map<string, Promise<void>>();
 
+export function getVectorStoreConfigByModel(model?: string): VectorStoreConfig {
+  const models = getEmbeddingModels();
+  const key = model && models[model] ? model : 'bge-m3';
+  const preset = models[key];
+  return {
+    type: preset.adapter || 'lancedb',
+    collectionName: preset.collection,
+    embeddingProvider: preset.provider || 'ollama',
+    embeddingModel: preset.model,
+    ...(preset.dataPath && { dataPath: preset.dataPath }),
+    ...(preset.pythonVersion && { pythonVersion: preset.pythonVersion }),
+    ...(preset.qdrantUrl && { qdrantUrl: preset.qdrantUrl }),
+    ...(preset.qdrantApiKey && { qdrantApiKey: preset.qdrantApiKey }),
+    ...(preset.cfAccountId && { cfAccountId: preset.cfAccountId }),
+    ...(preset.cfApiToken && { cfApiToken: preset.cfApiToken }),
+  };
+}
+
 export function getVectorStoreByModel(model?: string): VectorStoreAdapter {
   const models = getEmbeddingModels();
   const key = model && models[model] ? model : 'bge-m3';
   let store = modelStoreCache.get(key);
   if (!store) {
-    const preset = models[key];
-    store = createVectorStore({
-      type: 'lancedb',
-      collectionName: preset.collection,
-      embeddingProvider: 'ollama',
-      embeddingModel: preset.model,
-      ...(preset.dataPath && { dataPath: preset.dataPath }),
-    });
+    store = createVectorStore(getVectorStoreConfigByModel(model));
     modelStoreCache.set(key, store);
     // Auto-connect in background (non-blocking)
     connectPromises.set(key, store.connect().catch(e =>


### PR DESCRIPTION
Refs #1071.

Narrow vector-server swappability slice: `vector-server.json` can now choose the storage adapter/provider per embedding collection instead of only overriding collection/model/dataPath while `getVectorStoreByModel()` stayed hardcoded to LanceDB + Ollama.

Changes:
- Extend `VectorCollectionConfig` with `adapter`, per-collection `dataPath`, and backend connection fields (`qdrantUrl`, `qdrantApiKey`, Cloudflare fields, Chroma python version).
- Preserve LanceDB/Ollama defaults in generated config and hardcoded fallback models.
- Route model registry entries through `getVectorStoreConfigByModel()` before creating adapters, so Qdrant/other backends are real opt-in peers.
- Make `writeVectorConfig()` create `ORACLE_DATA_DIR`, matching its existing contract.
- Add config tests proving per-collection Qdrant selection without needing a live Qdrant server.

Verification:
- `bun test --isolate src/vector/__tests__/config.test.ts src/vector/__tests__/adapters.test.ts` -> 24 pass, 9 skipped (environment-gated)
- `bun run build` -> pass
- `bun run test:unit` -> 258 pass

Scope note: this does not run or require a live Qdrant/Cloudflare/Chroma backend; it makes the adapter boundary configurable and keeps LanceDB the default.

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3