### PR TITLE
feat(vector): make indexer honor per-collection adapter config

### DIFF
--- a/src/routes/vector/indexer.ts
+++ b/src/routes/vector/indexer.ts
@@ -13,8 +13,9 @@
 
 import { Elysia, t } from 'elysia';
 import { Database } from 'bun:sqlite';
-import { createVectorStore, getEmbeddingModels } from '../../vector/factory.ts';
+import { createVectorStore, getEmbeddingModels, getVectorStoreConfigByModel } from '../../vector/factory.ts';
 import { DB_PATH } from '../../config.ts';
+import type { EmbeddingProviderType, VectorDBType } from '../../vector/types.ts';
 
 // ── In-memory status (no sqlite writes — avoids the disk I/O problem) ──
 
@@ -51,7 +52,7 @@ export const vectorIndexerEndpoints = new Elysia()
 
     const models = getEmbeddingModels();
     const key = body.model && models[body.model] ? body.model : 'bge-m3';
-    const preset = models[key];
+    const storeConfig = getVectorStoreConfigByModel(key);
     const batchSize = body.batchSize ?? (key === 'nomic' ? 100 : 50);
 
     const jobId = `vidx-${Date.now()}`;
@@ -85,13 +86,7 @@ export const vectorIndexerEndpoints = new Elysia()
 
         currentJob.total = rows.length;
 
-        const store = createVectorStore({
-          type: 'lancedb',
-          collectionName: preset.collection,
-          embeddingProvider: 'ollama',
-          embeddingModel: preset.model,
-          ...(preset.dataPath && { dataPath: preset.dataPath }),
-        });
+        const store = createVectorStore(storeConfig);
 
         await store.connect();
         try { await store.deleteCollection(); } catch {}
@@ -126,7 +121,14 @@ export const vectorIndexerEndpoints = new Elysia()
       }
     })();
 
-    return { jobId, status: 'started', model: key, batchSize };
+    return {
+      jobId,
+      status: 'started',
+      model: key,
+      adapter: storeConfig.type,
+      collection: storeConfig.collectionName,
+      batchSize,
+    };
   }, {
     body: t.Object({
       model: t.Optional(t.String()),
@@ -164,28 +166,39 @@ export const vectorIndexerEndpoints = new Elysia()
   // GET /vector/index/models
   .get('/vector/index/models', async () => {
     const models = getEmbeddingModels();
-    const result: Record<string, { collection: string; model: string; count?: number }> = {};
+    const result: Record<string, {
+      collection: string;
+      model: string;
+      adapter: VectorDBType;
+      provider: EmbeddingProviderType;
+      count?: number;
+    }> = {};
 
-    for (const [key, preset] of Object.entries(models)) {
-      const entry: { collection: string; model: string; count?: number } = {
-        collection: preset.collection,
-        model: preset.model,
+    for (const key of Object.keys(models)) {
+      const storeConfig = getVectorStoreConfigByModel(key);
+      const entry: {
+        collection: string;
+        model: string;
+        adapter: VectorDBType;
+        provider: EmbeddingProviderType;
+        count?: number;
+      } = {
+        collection: storeConfig.collectionName ?? key,
+        model: storeConfig.embeddingModel ?? key,
+        adapter: storeConfig.type ?? 'lancedb',
+        provider: storeConfig.embeddingProvider ?? 'ollama',
       };
+      let store: ReturnType<typeof createVectorStore> | null = null;
 
       try {
-        const store = createVectorStore({
-          type: 'lancedb',
-          collectionName: preset.collection,
-          embeddingProvider: 'ollama',
-          embeddingModel: preset.model,
-          ...(preset.dataPath && { dataPath: preset.dataPath }),
-        });
+        store = createVectorStore(storeConfig);
         await store.connect();
         const stats = await store.getStats();
         entry.count = stats.count;
-        await store.close();
       } catch {
         entry.count = 0;
+      } finally {
+        try { await store?.close(); } catch {}
       }
 
       result[key] = entry;

--- a/src/server/__tests__/vector-indexer-config.test.ts
+++ b/src/server/__tests__/vector-indexer-config.test.ts
@@ -1,0 +1,66 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-vector-indexer-config-'));
+const dataDir = path.join(tmpRoot, 'data');
+const originalDataDir = process.env.ORACLE_DATA_DIR;
+const originalQdrantUrl = process.env.QDRANT_URL;
+
+process.env.ORACLE_DATA_DIR = dataDir;
+process.env.QDRANT_URL = 'http://127.0.0.1:9';
+
+// Dynamic imports after ORACLE_DATA_DIR is set because config.ts freezes env.
+const { writeVectorConfig } = await import('../../vector/config.ts');
+const { vectorIndexerEndpoints } = await import('../../routes/vector/indexer.ts');
+
+describe('vector indexer config', () => {
+  test('GET /api/vector/index/models reports configured adapter/provider per collection', async () => {
+    writeVectorConfig({
+      port: 47779,
+      adapter: 'lancedb',
+      vaultPath: '/tmp/vault',
+      dataPath: path.join(dataDir, 'lancedb'),
+      embedding: {
+        provider: 'ollama',
+        model: 'bge-m3',
+        url: 'http://localhost:11434',
+      },
+      watch: true,
+      batchSize: 50,
+      distance: 'cosine',
+      collections: {
+        scale: {
+          adapter: 'qdrant',
+          collection: 'oracle_scale',
+          model: 'bge-m3',
+          provider: 'ollama',
+          qdrantUrl: 'http://127.0.0.1:9',
+        },
+      },
+    });
+
+    const app = new Elysia({ prefix: '/api' }).use(vectorIndexerEndpoints);
+    const response = await app.handle(new Request('http://localhost/api/vector/index/models'));
+    const payload = await response.json() as any;
+
+    expect(response.status).toBe(200);
+    expect(payload.models.scale).toMatchObject({
+      adapter: 'qdrant',
+      provider: 'ollama',
+      collection: 'oracle_scale',
+      model: 'bge-m3',
+      count: 0,
+    });
+  });
+});
+
+afterAll(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  if (originalDataDir !== undefined) process.env.ORACLE_DATA_DIR = originalDataDir;
+  else delete process.env.ORACLE_DATA_DIR;
+  if (originalQdrantUrl !== undefined) process.env.QDRANT_URL = originalQdrantUrl;
+  else delete process.env.QDRANT_URL;
+});


### PR DESCRIPTION
Refs #1071.

Small vector-server consistency slice after #1268: query-time vector stores were already selected from `vector-server.json`, but `/api/vector/index/start` and `/api/vector/index/models` still hardcoded LanceDB + Ollama. This makes vector reindex/model status reuse `getVectorStoreConfigByModel`, so configured Qdrant/Cloudflare/etc. backends do not drift from search.

Changes:
- `/api/vector/index/start` constructs the store from per-collection adapter config and returns the selected adapter/collection in the start response.
- `/api/vector/index/models` reports adapter/provider metadata and counts using the configured backend.
- Adds a regression test with a Qdrant collection override.

Verification:
- `bun test --isolate src/server/__tests__/vector-indexer-config.test.ts src/vector/__tests__/config.test.ts src/vector/__tests__/adapters.test.ts` → 25 pass, 9 skip
- `bun run test:unit` → 259 pass
- `bun run build` → pass

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3