### PR TITLE
fix(vector): avoid drop-recreate during sidecar reindex

### DIFF
--- a/src/routes/vector/indexer.ts
+++ b/src/routes/vector/indexer.ts
@@ -15,7 +15,12 @@ import { Elysia, t } from 'elysia';
 import { Database } from 'bun:sqlite';
 import { createVectorStore, getEmbeddingModels, getVectorStoreConfigByModel } from '../../vector/factory.ts';
 import { DB_PATH } from '../../config.ts';
-import type { EmbeddingProviderType, VectorDBType } from '../../vector/types.ts';
+import type {
+  EmbeddingProviderType,
+  VectorDBType,
+  VectorDocument,
+  VectorStoreAdapter,
+} from '../../vector/types.ts';
 
 // ── In-memory status (no sqlite writes — avoids the disk I/O problem) ──
 
@@ -28,6 +33,7 @@ interface IndexJob {
   startedAt: number;
   completedAt?: number;
   error?: string;
+  strategy?: RebuildStrategy;
 }
 
 let currentJob: IndexJob = {
@@ -38,6 +44,34 @@ let currentJob: IndexJob = {
   total: 0,
   startedAt: 0,
 };
+
+export type RebuildStrategy = 'replace' | 'delete-add';
+
+export async function rebuildVectorCollection(
+  store: VectorStoreAdapter,
+  docs: VectorDocument[],
+  batchSize: number,
+  onProgress: (current: number) => void = () => {},
+): Promise<{ strategy: RebuildStrategy }> {
+  await store.connect();
+
+  if (typeof store.replaceDocuments === 'function') {
+    await store.replaceDocuments(docs);
+    onProgress(docs.length);
+    return { strategy: 'replace' };
+  }
+
+  try { await store.deleteCollection(); } catch {}
+  await store.ensureCollection();
+
+  for (let i = 0; i < docs.length; i += batchSize) {
+    const batch = docs.slice(i, i + batchSize);
+    await store.addDocuments(batch);
+    onProgress(Math.min(i + batch.length, docs.length));
+  }
+
+  return { strategy: 'delete-add' };
+}
 
 // ── Endpoints ──────────────────────────────────────────────────────────
 
@@ -68,6 +102,7 @@ export const vectorIndexerEndpoints = new Elysia()
     // Background indexing — fire and forget
     (async () => {
       let sqlite: Database | undefined;
+      let store: VectorStoreAdapter | undefined;
       try {
         sqlite = new Database(DB_PATH, { readonly: true });
 
@@ -86,30 +121,23 @@ export const vectorIndexerEndpoints = new Elysia()
 
         currentJob.total = rows.length;
 
-        const store = createVectorStore(storeConfig);
+        store = createVectorStore(storeConfig);
+        const docs: VectorDocument[] = rows.map(row => ({
+          id: row.id,
+          document: row.content,
+          metadata: {
+            type: row.type,
+            source_file: row.source_file,
+            concepts: row.concepts,
+            ...(row.project && { project: row.project }),
+          },
+        }));
 
-        await store.connect();
-        try { await store.deleteCollection(); } catch {}
-        await store.ensureCollection();
+        const rebuild = await rebuildVectorCollection(store, docs, batchSize, current => {
+          currentJob.current = current;
+        });
 
-        for (let i = 0; i < rows.length; i += batchSize) {
-          const batch = rows.slice(i, i + batchSize);
-          const docs = batch.map(row => ({
-            id: row.id,
-            document: row.content,
-            metadata: {
-              type: row.type,
-              source_file: row.source_file,
-              concepts: row.concepts,
-              ...(row.project && { project: row.project }),
-            },
-          }));
-
-          await store.addDocuments(docs);
-          currentJob.current = i + batch.length;
-        }
-
-        await store.close();
+        currentJob.strategy = rebuild.strategy;
         currentJob.status = 'completed';
         currentJob.completedAt = Date.now();
       } catch (e) {
@@ -117,6 +145,7 @@ export const vectorIndexerEndpoints = new Elysia()
         currentJob.error = e instanceof Error ? e.message : String(e);
         currentJob.completedAt = Date.now();
       } finally {
+        try { await store?.close(); } catch {}
         sqlite?.close();
       }
     })();

--- a/src/server/__tests__/vector-indexer-rebuild.test.ts
+++ b/src/server/__tests__/vector-indexer-rebuild.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'bun:test';
+import { rebuildVectorCollection } from '../../routes/vector/indexer.ts';
+import type { VectorDocument, VectorQueryResult, VectorStoreAdapter } from '../../vector/types.ts';
+
+const docs: VectorDocument[] = [
+  { id: 'a', document: 'alpha', metadata: { type: 'note' } },
+  { id: 'b', document: 'beta', metadata: { type: 'note' } },
+  { id: 'c', document: 'gamma', metadata: { type: 'note' } },
+];
+
+function emptyQuery(): VectorQueryResult {
+  return { ids: [], documents: [], distances: [], metadatas: [] };
+}
+
+function baseStore(calls: string[]): VectorStoreAdapter {
+  return {
+    name: 'fake',
+    async connect() { calls.push('connect'); },
+    async close() { calls.push('close'); },
+    async ensureCollection() { calls.push('ensureCollection'); },
+    async deleteCollection() { calls.push('deleteCollection'); },
+    async addDocuments(batch) { calls.push(`addDocuments:${batch.map(doc => doc.id).join(',')}`); },
+    async query() { return emptyQuery(); },
+    async queryById() { return emptyQuery(); },
+    async getStats() { return { count: 0 }; },
+    async getCollectionInfo() { return { count: 0, name: 'fake' }; },
+  };
+}
+
+describe('rebuildVectorCollection', () => {
+  test('uses replaceDocuments when adapter supports in-place replacement', async () => {
+    const calls: string[] = [];
+    const progress: number[] = [];
+    const store = {
+      ...baseStore(calls),
+      async replaceDocuments(nextDocs: VectorDocument[]) {
+        calls.push(`replaceDocuments:${nextDocs.map(doc => doc.id).join(',')}`);
+      },
+    } satisfies VectorStoreAdapter;
+
+    const result = await rebuildVectorCollection(store, docs, 2, current => progress.push(current));
+
+    expect(result).toEqual({ strategy: 'replace' });
+    expect(calls).toEqual(['connect', 'replaceDocuments:a,b,c']);
+    expect(progress).toEqual([3]);
+  });
+
+  test('falls back to delete plus batched add when replaceDocuments is unavailable', async () => {
+    const calls: string[] = [];
+    const progress: number[] = [];
+    const store = baseStore(calls);
+
+    const result = await rebuildVectorCollection(store, docs, 2, current => progress.push(current));
+
+    expect(result).toEqual({ strategy: 'delete-add' });
+    expect(calls).toEqual([
+      'connect',
+      'deleteCollection',
+      'ensureCollection',
+      'addDocuments:a,b',
+      'addDocuments:c',
+    ]);
+    expect(progress).toEqual([2, 3]);
+  });
+});


### PR DESCRIPTION
Refs #1071.

This hardens the vector sidecar reindex path so it does not drop/recreate the collection when the active adapter can do an in-place whole-collection replacement.

Why:
- The sidecar reindex route still called deleteCollection()+ensureCollection()+addDocuments().
- For LanceDB, drop/recreate can invalidate table handles in sibling/live processes, which is part of the #987 stale-handle/write-corruption family.

Fix:
- Add rebuildVectorCollection() helper.
- Prefer adapter replaceDocuments(docs) when available (LanceDB implements it).
- Fall back to the existing delete+batched-add behavior for adapters without replaceDocuments.
- Expose the rebuild strategy in /api/vector/index/status for observability.

Verification:
- bun test --isolate src/server/__tests__/vector-indexer-rebuild.test.ts
- bun test --isolate src/server/__tests__/vector-indexer-config.test.ts src/server/__tests__/vector-server-route.test.ts
- bun run build
- bun run test:unit (261 pass)

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3