### PR TITLE
fix(vector): keep proxy search totals remote-only

### DIFF
--- a/src/server/__tests__/search-vector-proxy-total.test.ts
+++ b/src/server/__tests__/search-vector-proxy-total.test.ts
@@ -1,0 +1,71 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-search-vector-proxy-'));
+const dataDir = path.join(tmpRoot, 'data');
+const originalDataDir = process.env.ORACLE_DATA_DIR;
+const originalDbPath = process.env.ORACLE_DB_PATH;
+const originalVectorUrl = process.env.VECTOR_URL;
+
+const fakeVector = Bun.serve({
+  port: 0,
+  fetch(request) {
+    const url = new URL(request.url);
+    if (url.pathname !== '/api/search') return Response.json({ error: 'not found' }, { status: 404 });
+    return Response.json({
+      results: [{
+        id: 'remote-vector-1',
+        type: 'learning',
+        content: 'Remote vector result',
+        source_file: 'vault/remote.md',
+        concepts: [],
+        source: 'vector',
+        score: 0.91,
+      }],
+      total: 42,
+      offset: 0,
+      limit: 1,
+      mode: 'vector',
+      vectorAvailable: true,
+    });
+  },
+});
+
+process.env.ORACLE_DATA_DIR = dataDir;
+process.env.ORACLE_DB_PATH = path.join(dataDir, 'oracle.db');
+process.env.VECTOR_URL = `http://127.0.0.1:${fakeVector.port}`;
+
+const warnMessages: string[] = [];
+const originalWarn = console.warn;
+console.warn = (...args: unknown[]) => {
+  warnMessages.push(args.map(String).join(' '));
+};
+
+// Dynamic import after env is set because config/db/handlers freeze env at module load.
+const { handleSearch } = await import('../handlers.ts');
+
+describe('handleSearch VECTOR_URL proxy totals', () => {
+  test('uses remote vector total without opening local vector stats in core proxy mode', async () => {
+    const result = await handleSearch('oracle', 'all', 1, 0, 'vector');
+
+    expect(result.total).toBe(42);
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].id).toBe('remote-vector-1');
+    expect(result.vectorAvailable).toBe(true);
+    expect(warnMessages.some((msg) => msg.includes('[Hybrid] getStats for vector-only total failed'))).toBe(false);
+  });
+});
+
+afterAll(() => {
+  fakeVector.stop(true);
+  console.warn = originalWarn;
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  if (originalDataDir !== undefined) process.env.ORACLE_DATA_DIR = originalDataDir;
+  else delete process.env.ORACLE_DATA_DIR;
+  if (originalDbPath !== undefined) process.env.ORACLE_DB_PATH = originalDbPath;
+  else delete process.env.ORACLE_DB_PATH;
+  if (originalVectorUrl !== undefined) process.env.VECTOR_URL = originalVectorUrl;
+  else delete process.env.VECTOR_URL;
+});

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -125,6 +125,7 @@ export async function handleSearch(
 
   // Vector search (skip if fts-only mode)
   let vectorResults: SearchResult[] = [];
+  let remoteVectorTotal: number | undefined;
   // Tracks whether the vector leg succeeded. Stays `true` when mode === 'fts'
   // (vector wasn't asked for), flips to `false` if the proxy is enabled and
   // the remote call failed — clients use this to render a "vector down" hint
@@ -147,6 +148,7 @@ export async function handleSearch(
     });
     if (remote) {
       vectorResults = remote.results || [];
+      if (typeof remote.total === 'number') remoteVectorTotal = remote.total;
     } else {
       vectorAvailable = false;
       warning = 'Vector proxy unavailable — FTS5-only results';
@@ -242,7 +244,9 @@ export async function handleSearch(
   // For vector-only mode, ftsTotal is 0 and combined.length is just top-N,
   // so use the vector collection count as the total for accurate display
   let total = Math.max(ftsTotal, combined.length);
-  if (mode === 'vector' && vectorResults.length > 0) {
+  if (mode === 'vector' && vectorProxy && remoteVectorTotal !== undefined) {
+    total = remoteVectorTotal;
+  } else if (mode === 'vector' && vectorResults.length > 0) {
     try {
       const client = await ensureVectorStoreConnected(model && EMBEDDING_MODELS[model] ? model : undefined);
       const stats = await client.getStats();


### PR DESCRIPTION
Refs #1071.

Small proxy-boundary hardening slice: vector-only search with `VECTOR_URL` already routes results through the sidecar, but the core handler still opened the local vector adapter to compute an accurate total. That leaks vector DB work back into the core process in proxy mode.

Fix:
- Track `remote.total` from the vector sidecar search response.
- For `mode=vector` + `VECTOR_URL`, use that remote total instead of local `ensureVectorStoreConnected().getStats()`.
- Keep legacy local-vector total behavior unchanged when no vector proxy is configured.

Verification:
- `bun test --isolate src/server/__tests__/search-vector-proxy-total.test.ts src/gateway/__tests__/vector-url.test.ts src/server/__tests__/vector-server-route.test.ts`
- `bun run build`
- `bun run test:unit` (262 pass)

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3