### PR TITLE
fix(indexer): preserve oracle_learn frontmatter identity from vault markdown

### DIFF
--- a/src/indexer/__tests__/frontmatter-vault-contract.test.ts
+++ b/src/indexer/__tests__/frontmatter-vault-contract.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'bun:test';
+import { buildLearningMarkdown } from '../../learn/markdown.ts';
+import { parseLearningFile } from '../parser.ts';
+
+describe('parseLearningFile — oracle_learn frontmatter contract', () => {
+  it('preserves oracle_learn ids, concepts, timestamps, and project from vault markdown', () => {
+    const createdAt = new Date('2026-06-01T01:02:03.000Z');
+    const id = 'learning_2026-06-01_frontmatter-contract-123';
+    const sourceFile = 'ψ/memory/learnings/2026-06-01_frontmatter-contract.md';
+    const markdown = buildLearningMarkdown({
+      id,
+      pattern: 'frontmatter identity vector replay pattern from oracle_learn',
+      title: 'Frontmatter Contract',
+      concepts: ['frontmatter', 'vector'],
+      createdAt,
+      source: 'Oracle Learn',
+      project: 'github.com/Soul-Brews-Studio/arra-oracle-v3',
+    });
+
+    const docs = parseLearningFile('2026-06-01_frontmatter-contract.md', markdown, sourceFile);
+
+    expect(docs).toHaveLength(1);
+    expect(docs[0].id).toBe(id);
+    expect(docs[0].type).toBe('learning');
+    expect(docs[0].source_file).toBe(sourceFile);
+    expect(docs[0].project).toBe('github.com/Soul-Brews-Studio/arra-oracle-v3');
+    expect(docs[0].concepts).toContain('frontmatter');
+    expect(docs[0].concepts).toContain('vector');
+    expect(docs[0].created_at).toBe(createdAt.getTime());
+    expect(docs[0].updated_at).toBe(createdAt.getTime());
+    expect(docs[0].content).toContain('# Frontmatter Contract');
+    expect(docs[0].content).toContain('frontmatter identity vector replay pattern');
+    expect(docs[0].content).not.toContain('arra_id:');
+  });
+});

--- a/src/indexer/frontmatter.ts
+++ b/src/indexer/frontmatter.ts
@@ -1,25 +1,66 @@
 /**
- * Frontmatter parsing: extract tags and project from markdown YAML frontmatter
+ * Frontmatter parsing for the small YAML subset emitted by Oracle files.
  */
+
+import type { OracleDocumentType } from '../types.ts';
+
+const ORACLE_DOC_TYPES = new Set([
+  'principle', 'pattern', 'learning', 'retro', 'distillation', 'security-corpus',
+]);
+
+function frontmatterBlock(content: string): string | null {
+  return content.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? null;
+}
+
+function cleanValue(value: string): string {
+  const trimmed = value.trim();
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+      (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+export function stripFrontmatter(content: string): string {
+  return content.replace(/^---\n[\s\S]*?\n---\n?/, '');
+}
+
+export function parseFrontmatterString(content: string, keys: string[]): string | null {
+  const frontmatter = frontmatterBlock(content);
+  if (!frontmatter) return null;
+  for (const key of keys) {
+    const match = frontmatter.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
+    const value = match ? cleanValue(match[1]) : '';
+    if (value) return value;
+  }
+  return null;
+}
+
+export function parseFrontmatterList(content: string, keys: string[]): string[] {
+  const raw = parseFrontmatterString(content, keys);
+  if (!raw) return [];
+  const inner = raw.startsWith('[') && raw.endsWith(']') ? raw.slice(1, -1) : raw;
+  return inner.split(',').map(t => cleanValue(t).toLowerCase()).filter(Boolean);
+}
+
+export function parseFrontmatterTime(content: string, keys: string[]): number | null {
+  const raw = parseFrontmatterString(content, keys);
+  if (!raw) return null;
+  const timestamp = Date.parse(raw);
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+export function parseFrontmatterDocType(content: string, keys: string[], fallback: OracleDocumentType): OracleDocumentType {
+  const raw = parseFrontmatterString(content, keys);
+  return raw && ORACLE_DOC_TYPES.has(raw) ? raw as OracleDocumentType : fallback;
+}
 
 /**
  * Parse frontmatter tags from markdown content
  * Supports: tags: [a, b, c] or tags: a, b, c
  */
 export function parseFrontmatterTags(content: string): string[] {
-  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
-  if (!frontmatterMatch) return [];
-
-  const frontmatter = frontmatterMatch[1];
-
-  // Match tags: [tag1, tag2] or tags: tag1, tag2
-  const tagsMatch = frontmatter.match(/^tags:\s*\[?([^\]\n]+)\]?/m);
-  if (!tagsMatch) return [];
-
-  return tagsMatch[1]
-    .split(',')
-    .map(t => t.trim().toLowerCase())
-    .filter(t => t.length > 0);
+  return parseFrontmatterList(content, ['tags']);
 }
 
 /**
@@ -28,22 +69,12 @@ export function parseFrontmatterTags(content: string): string[] {
  * Also extracts project from source field (e.g., "source: rrr: owner/repo")
  */
 export function parseFrontmatterProject(content: string): string | null {
-  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
-  if (!frontmatterMatch) return null;
-
-  const frontmatter = frontmatterMatch[1];
+  const frontmatter = frontmatterBlock(content);
+  if (!frontmatter) return null;
 
   // First, try direct project: field
-  const projectMatch = frontmatter.match(/^project:\s*(.+)$/m);
-  if (projectMatch) {
-    const project = projectMatch[1].trim();
-    // Handle quoted values
-    if ((project.startsWith('"') && project.endsWith('"')) ||
-        (project.startsWith("'") && project.endsWith("'"))) {
-      return project.slice(1, -1);
-    }
-    return project || null;
-  }
+  const project = parseFrontmatterString(content, ['project']);
+  if (project) return project;
 
   // Fallback: extract from source field (e.g., "source: rrr: owner/repo")
   const sourceMatch = frontmatter.match(/^source:\s*rrr:\s*(.+)$/m);

--- a/src/indexer/parser.ts
+++ b/src/indexer/parser.ts
@@ -6,7 +6,7 @@ import path from 'path';
 import type { OracleDocument } from '../types.ts';
 import { extractConcepts, mergeConceptsWithTags } from './concepts.ts';
 import { inferProjectFromPath } from './discovery.ts';
-import { parseFrontmatterTags, parseFrontmatterProject } from './frontmatter.ts';
+import { parseFrontmatterTags, parseFrontmatterProject, parseFrontmatterString, parseFrontmatterList, parseFrontmatterTime, parseFrontmatterDocType, stripFrontmatter } from './frontmatter.ts';
 
 /**
  * Parse resonance markdown into granular documents
@@ -64,13 +64,21 @@ export function parseLearningFile(filename: string, content: string, sourceFileO
   const sourceFile = sourceFileOverride || `\u03c8/memory/learnings/${filename}`;
   const now = Date.now();
 
-  const fileTags = parseFrontmatterTags(content);
+  const frontmatterId = parseFrontmatterString(content, ['arra_id', 'id']);
+  const baseId = frontmatterId || `learning_${filename.replace('.md', '')}`;
+  const docType = parseFrontmatterDocType(content, ['arra_type', 'type'], 'learning');
+  const fileTags = mergeConceptsWithTags(
+    parseFrontmatterTags(content),
+    parseFrontmatterList(content, ['arra_concepts', 'concepts']),
+  );
   const fileProject = parseFrontmatterProject(content) || inferProjectFromPath(sourceFile);
+  const createdAt = parseFrontmatterTime(content, ['arra_created', 'indexed_at', 'created']) || now;
+  const updatedAt = parseFrontmatterTime(content, ['updated_at', 'arra_created', 'indexed_at', 'created']) || createdAt;
+  const bodyContent = stripFrontmatter(content).trim() || content;
 
-  const titleMatch = content.match(/^title:\s*(.+)$/m);
-  const title = titleMatch ? titleMatch[1] : filename.replace('.md', '');
+  const title = parseFrontmatterString(content, ['title']) || filename.replace('.md', '');
 
-  const sections = content.split(/^##\s+/m).filter(s => s.trim());
+  const sections = /^##\s+/m.test(bodyContent) ? bodyContent.split(/^##\s+/m).filter(s => s.trim()) : [];
 
   sections.forEach((section, index) => {
     const lines = section.split('\n');
@@ -81,19 +89,19 @@ export function parseLearningFile(filename: string, content: string, sourceFileO
     const id = `learning_${filename.replace('.md', '')}_${index}`;
     const extracted = extractConcepts(sectionTitle, body);
     documents.push({
-      id, type: 'learning', source_file: sourceFile,
+      id: frontmatterId ? `${frontmatterId}_${index}` : id, type: docType, source_file: sourceFile,
       content: `${title} - ${sectionTitle}: ${body}`,
       concepts: mergeConceptsWithTags(extracted, fileTags),
-      created_at: now, updated_at: now, project: fileProject || undefined
+      created_at: createdAt, updated_at: updatedAt, project: fileProject || undefined
     });
   });
 
   if (documents.length === 0) {
-    const extracted = extractConcepts(title, content);
+    const extracted = extractConcepts(title, bodyContent);
     documents.push({
-      id: `learning_${filename.replace('.md', '')}`, type: 'learning', source_file: sourceFile,
-      content, concepts: mergeConceptsWithTags(extracted, fileTags),
-      created_at: now, updated_at: now, project: fileProject || undefined
+      id: baseId, type: docType, source_file: sourceFile,
+      content: bodyContent, concepts: mergeConceptsWithTags(extracted, fileTags),
+      created_at: createdAt, updated_at: updatedAt, project: fileProject || undefined
     });
   }
 


### PR DESCRIPTION
Refs #1071.

This is the next vault-as-source-of-truth hardening slice for the vector-server split: `oracle_learn` already writes durable markdown frontmatter (`id`/`arra_id`, `concepts`/`arra_concepts`, project, timestamps), but the indexer parser was still deriving learning document IDs from filenames and embedding the YAML block as body text. That would make vault replay mint divergent vector IDs once vector reindexing moves off SQLite.

Fix:
- Add small frontmatter helpers for scalar/list/time/doc-type fields.
- Make `parseLearningFile()` honor `arra_id`/`id`, `arra_type`/`type`, `arra_concepts`/`concepts`, project, and timestamps.
- Strip frontmatter from the embedded body and use whole-file fallback when no `##` sections exist.
- Keep `parser.ts` at 250 LOC and add a regression test built from the real `buildLearningMarkdown()` contract.

Verification:
- `bun test --isolate src/indexer/__tests__/frontmatter-vault-contract.test.ts src/server/__tests__/learn-slug-collision.test.ts` → 6 pass
- `bun run build` → exit 0
- `bun run test:unit` → 263 pass

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3