### PR TITLE
feat(vector): rebuild index from vault markdown before SQLite fallback

### DIFF
--- a/src/routes/vector/indexer-source.ts
+++ b/src/routes/vector/indexer-source.ts
@@ -1,0 +1,97 @@
+import { Database } from 'bun:sqlite';
+import { DB_PATH } from '../../config.ts';
+import { collectDocuments, collectSecurityCorpus } from '../../indexer/collectors.ts';
+import { parseDistillationFile, parseLearningFile, parseResonanceFile, parseRetroFile } from '../../indexer/parser.ts';
+import { createIndexerConfig, resolveIndexerRepoRoot } from '../../indexer/runner.ts';
+import type { OracleDocument } from '../../types.ts';
+import type { VectorDocument } from '../../vector/types.ts';
+
+export type VectorIndexSource = 'auto' | 'vault' | 'sqlite';
+
+export interface LoadedVectorIndexDocuments {
+  source: Exclude<VectorIndexSource, 'auto'>;
+  docs: VectorDocument[];
+  repoRoot?: string;
+}
+
+export function resolveVectorIndexSource(value?: string | null): VectorIndexSource {
+  const raw = (value || process.env.VECTOR_INDEX_SOURCE || process.env.ORACLE_VECTOR_INDEX_SOURCE || 'auto').toLowerCase();
+  return raw === 'vault' || raw === 'sqlite' ? raw : 'auto';
+}
+
+function toVectorDocs(documents: OracleDocument[]): VectorDocument[] {
+  return documents.map(doc => ({
+    id: doc.id,
+    document: doc.content,
+    metadata: {
+      type: doc.type,
+      source_file: doc.source_file,
+      concepts: JSON.stringify(doc.concepts),
+      ...(doc.project && { project: doc.project }),
+    },
+  }));
+}
+
+export function loadVaultVectorDocuments(repoRoot = resolveIndexerRepoRoot()): LoadedVectorIndexDocuments {
+  const config = createIndexerConfig(repoRoot);
+  const shared = { config, seenContentHashes: new Set<string>() };
+  const documents: OracleDocument[] = [
+    ...collectDocuments({ ...shared, subdir: 'resonance', parseFn: parseResonanceFile, label: 'resonance' }),
+    ...collectDocuments({ ...shared, subdir: 'learnings', parseFn: parseLearningFile, label: 'learning' }),
+    ...collectDocuments({ ...shared, subdir: 'retrospectives', parseFn: parseRetroFile, label: 'retrospective' }),
+    ...collectDocuments({ ...shared, subdir: 'distillations', parseFn: parseDistillationFile, label: 'distillation' }),
+    ...collectSecurityCorpus(shared),
+  ];
+
+  return { source: 'vault', repoRoot, docs: toVectorDocs(documents) };
+}
+
+export function loadSqliteVectorDocuments(dbPath = DB_PATH): LoadedVectorIndexDocuments {
+  const sqlite = new Database(dbPath, { readonly: true });
+  try {
+    const rows = sqlite.prepare(`
+      SELECT d.id, d.type, GROUP_CONCAT(f.content, '\n') as content,
+             d.source_file, d.concepts, d.project, d.created_at
+      FROM oracle_documents d
+      JOIN oracle_fts f ON d.id = f.id
+      GROUP BY d.id
+      ORDER BY d.created_at DESC
+    `).all() as Array<{
+      id: string; type: string; content: string;
+      source_file: string; concepts: string; project: string | null;
+      created_at: string;
+    }>;
+
+    return {
+      source: 'sqlite',
+      docs: rows.map(row => ({
+        id: row.id,
+        document: row.content,
+        metadata: {
+          type: row.type,
+          source_file: row.source_file,
+          concepts: row.concepts,
+          ...(row.project && { project: row.project }),
+        },
+      })),
+    };
+  } finally {
+    sqlite.close();
+  }
+}
+
+export function loadVectorIndexDocuments(opts: {
+  source?: string | null;
+  repoRoot?: string | null;
+  dbPath?: string;
+} = {}): LoadedVectorIndexDocuments {
+  const source = resolveVectorIndexSource(opts.source);
+  if (source !== 'sqlite') {
+    const vault = loadVaultVectorDocuments(opts.repoRoot ? resolveIndexerRepoRoot(opts.repoRoot) : undefined);
+    if (source === 'vault' && vault.docs.length === 0) {
+      throw new Error(`Refusing vault vector reindex: found 0 vault documents at ${vault.repoRoot}`);
+    }
+    if (vault.docs.length > 0) return vault;
+  }
+  return loadSqliteVectorDocuments(opts.dbPath);
+}

--- a/src/routes/vector/indexer.ts
+++ b/src/routes/vector/indexer.ts
@@ -12,15 +12,14 @@
  */
 
 import { Elysia, t } from 'elysia';
-import { Database } from 'bun:sqlite';
 import { createVectorStore, getEmbeddingModels, getVectorStoreConfigByModel } from '../../vector/factory.ts';
-import { DB_PATH } from '../../config.ts';
 import type {
   EmbeddingProviderType,
   VectorDBType,
   VectorDocument,
   VectorStoreAdapter,
 } from '../../vector/types.ts';
+import { loadVectorIndexDocuments, type VectorIndexSource } from './indexer-source.ts';
 
 // ── In-memory status (no sqlite writes — avoids the disk I/O problem) ──
 
@@ -34,6 +33,8 @@ interface IndexJob {
   completedAt?: number;
   error?: string;
   strategy?: RebuildStrategy;
+  source?: Exclude<VectorIndexSource, 'auto'>;
+  repoRoot?: string;
 }
 
 let currentJob: IndexJob = {
@@ -101,39 +102,15 @@ export const vectorIndexerEndpoints = new Elysia()
 
     // Background indexing — fire and forget
     (async () => {
-      let sqlite: Database | undefined;
       let store: VectorStoreAdapter | undefined;
       try {
-        sqlite = new Database(DB_PATH, { readonly: true });
-
-        const rows = sqlite.prepare(`
-          SELECT d.id, d.type, GROUP_CONCAT(f.content, '\n') as content,
-                 d.source_file, d.concepts, d.project, d.created_at
-          FROM oracle_documents d
-          JOIN oracle_fts f ON d.id = f.id
-          GROUP BY d.id
-          ORDER BY d.created_at DESC
-        `).all() as Array<{
-          id: string; type: string; content: string;
-          source_file: string; concepts: string; project: string | null;
-          created_at: string;
-        }>;
-
-        currentJob.total = rows.length;
+        const loaded = loadVectorIndexDocuments({ source: body.source, repoRoot: body.repoRoot });
+        currentJob.source = loaded.source;
+        currentJob.repoRoot = loaded.repoRoot;
+        currentJob.total = loaded.docs.length;
 
         store = createVectorStore(storeConfig);
-        const docs: VectorDocument[] = rows.map(row => ({
-          id: row.id,
-          document: row.content,
-          metadata: {
-            type: row.type,
-            source_file: row.source_file,
-            concepts: row.concepts,
-            ...(row.project && { project: row.project }),
-          },
-        }));
-
-        const rebuild = await rebuildVectorCollection(store, docs, batchSize, current => {
+        const rebuild = await rebuildVectorCollection(store, loaded.docs, batchSize, current => {
           currentJob.current = current;
         });
 
@@ -146,7 +123,6 @@ export const vectorIndexerEndpoints = new Elysia()
         currentJob.completedAt = Date.now();
       } finally {
         try { await store?.close(); } catch {}
-        sqlite?.close();
       }
     })();
 
@@ -157,11 +133,14 @@ export const vectorIndexerEndpoints = new Elysia()
       adapter: storeConfig.type,
       collection: storeConfig.collectionName,
       batchSize,
+      source: body.source ?? 'auto',
     };
   }, {
     body: t.Object({
       model: t.Optional(t.String()),
       batchSize: t.Optional(t.Number()),
+      source: t.Optional(t.String()),
+      repoRoot: t.Optional(t.String()),
     }),
     detail: {
       tags: ['vector-indexer'],

--- a/src/server/__tests__/vector-indexer-source.test.ts
+++ b/src/server/__tests__/vector-indexer-source.test.ts
@@ -1,0 +1,82 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { buildLearningMarkdown } from '../../learn/markdown.ts';
+import { loadVectorIndexDocuments } from '../../routes/vector/indexer-source.ts';
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-vector-index-source-'));
+const vaultRoot = path.join(tmpRoot, 'vault');
+const emptyRoot = path.join(tmpRoot, 'empty');
+const sqlitePath = path.join(tmpRoot, 'oracle.db');
+
+function writeLearningFile() {
+  const dir = path.join(vaultRoot, 'ψ', 'memory', 'learnings');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, '2026-06-01_vector-source.md'), buildLearningMarkdown({
+    id: 'learning_2026-06-01_vector-source-1',
+    pattern: 'vector sidecar source of truth should replay vault markdown',
+    title: 'Vector Source',
+    concepts: ['vector', 'vault'],
+    createdAt: new Date('2026-06-01T02:03:04.000Z'),
+    project: 'github.com/Soul-Brews-Studio/arra-oracle-v3',
+  }));
+}
+
+function writeSqliteDb() {
+  const db = new Database(sqlitePath);
+  db.exec(`
+    CREATE TABLE oracle_documents (
+      id TEXT PRIMARY KEY, type TEXT, source_file TEXT,
+      concepts TEXT, project TEXT, created_at INTEGER
+    );
+    CREATE TABLE oracle_fts (id TEXT, content TEXT);
+  `);
+  db.prepare(`
+    INSERT INTO oracle_documents
+      (id, type, source_file, concepts, project, created_at)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run('sqlite-doc-1', 'learning', 'ψ/memory/learnings/sqlite.md', '["sqlite"]', null, 1);
+  db.prepare('INSERT INTO oracle_fts (id, content) VALUES (?, ?)').run('sqlite-doc-1', 'sqlite fallback body');
+  db.close();
+}
+
+describe('loadVectorIndexDocuments', () => {
+  test('loads vector documents from vault markdown with stable oracle_learn identity', () => {
+    writeLearningFile();
+    const loaded = loadVectorIndexDocuments({ source: 'vault', repoRoot: vaultRoot, dbPath: sqlitePath });
+
+    expect(loaded.source).toBe('vault');
+    expect(loaded.repoRoot).toBe(vaultRoot);
+    expect(loaded.docs).toHaveLength(1);
+    expect(loaded.docs[0].id).toBe('learning_2026-06-01_vector-source-1');
+    expect(loaded.docs[0].document).toContain('vector sidecar source of truth');
+    expect(JSON.parse(String(loaded.docs[0].metadata.concepts))).toEqual(expect.arrayContaining(['vector', 'vault']));
+    expect(loaded.docs[0].metadata.project).toBe('github.com/Soul-Brews-Studio/arra-oracle-v3');
+  });
+
+  test('auto mode falls back to SQLite when no vault markdown exists', () => {
+    fs.mkdirSync(emptyRoot, { recursive: true });
+    writeSqliteDb();
+    const loaded = loadVectorIndexDocuments({ source: 'auto', repoRoot: emptyRoot, dbPath: sqlitePath });
+
+    expect(loaded.source).toBe('sqlite');
+    expect(loaded.docs).toHaveLength(1);
+    expect(loaded.docs[0]).toMatchObject({
+      id: 'sqlite-doc-1',
+      document: 'sqlite fallback body',
+      metadata: { type: 'learning', source_file: 'ψ/memory/learnings/sqlite.md', concepts: '["sqlite"]' },
+    });
+  });
+
+  test('explicit vault mode refuses an empty vault instead of wiping vectors', () => {
+    fs.mkdirSync(emptyRoot, { recursive: true });
+    expect(() => loadVectorIndexDocuments({ source: 'vault', repoRoot: emptyRoot, dbPath: sqlitePath }))
+      .toThrow(/found 0 vault documents/);
+  });
+});
+
+afterAll(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});


### PR DESCRIPTION
Refs #1071.

Moves vector reindexing one step closer to the #1071 vault-as-source-of-truth architecture. `/api/vector/index/start` was still rebuilding vectors from `oracle_documents` + `oracle_fts`; this adds an explicit source loader that prefers vault markdown via the existing indexer collectors, and falls back to SQLite when no vault files are present so standalone installs keep working.

Fix:
- Add `loadVectorIndexDocuments()` with `auto` / `vault` / `sqlite` source selection.
- `auto` uses vault markdown when populated, otherwise keeps the prior SQLite-backed path.
- explicit `vault` mode refuses an empty vault instead of wiping vector collections.
- indexer job status now records the actual document source and repo root.
- route body accepts optional `source` and `repoRoot` for controlled reindex runs.

Verification:
- `bun test --isolate src/server/__tests__/vector-indexer-source.test.ts src/server/__tests__/vector-indexer-rebuild.test.ts src/indexer/__tests__/frontmatter-vault-contract.test.ts` → 6 pass
- `bun run build` → exit 0
- `bun run test:unit` → 266 pass

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3