### PR TITLE
fix(vector): keep core vector routes on the proxy boundary

### DIFF
--- a/src/routes/vector/indexer-proxy.ts
+++ b/src/routes/vector/indexer-proxy.ts
@@ -1,0 +1,41 @@
+import { VECTOR_URL } from '../../config.ts';
+
+const TIMEOUT_MS = 15_000;
+
+type StatusSetter = { status?: number | string };
+
+async function responseBody(res: Response) {
+  const contentType = res.headers.get('content-type') || '';
+  if (contentType.includes('application/json')) return res.json();
+  return { body: await res.text() };
+}
+
+export async function proxyVectorIndexer(
+  path: 'start' | 'status' | 'models',
+  set: StatusSetter,
+  init: RequestInit = {},
+): Promise<unknown | null> {
+  if (!VECTOR_URL) return null;
+  const url = `${VECTOR_URL.replace(/\/+$/, '')}/api/vector/index/${path}`;
+
+  try {
+    const res = await fetch(url, {
+      ...init,
+      headers: {
+        accept: 'application/json',
+        ...(init.body ? { 'content-type': 'application/json' } : {}),
+        ...(init.headers || {}),
+      },
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+    set.status = res.status;
+    return await responseBody(res);
+  } catch (e) {
+    set.status = 503;
+    return {
+      error: 'Vector proxy unavailable',
+      proxy: VECTOR_URL,
+      detail: e instanceof Error ? e.message : String(e),
+    };
+  }
+}

--- a/src/routes/vector/indexer.ts
+++ b/src/routes/vector/indexer.ts
@@ -20,6 +20,7 @@ import type {
   VectorStoreAdapter,
 } from '../../vector/types.ts';
 import { loadVectorIndexDocuments, type VectorIndexSource } from './indexer-source.ts';
+import { proxyVectorIndexer } from './indexer-proxy.ts';
 
 // ── In-memory status (no sqlite writes — avoids the disk I/O problem) ──
 
@@ -80,6 +81,12 @@ export const vectorIndexerEndpoints = new Elysia()
 
   // POST /vector/index/start
   .post('/vector/index/start', async ({ body, set }) => {
+    const remote = await proxyVectorIndexer('start', set, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+    if (remote) return remote;
+
     if (currentJob.status === 'indexing') {
       set.status = 409;
       return { error: 'Indexing already in progress', job: currentJob };
@@ -149,7 +156,10 @@ export const vectorIndexerEndpoints = new Elysia()
   })
 
   // GET /vector/index/status
-  .get('/vector/index/status', () => {
+  .get('/vector/index/status', async ({ set }) => {
+    const remote = await proxyVectorIndexer('status', set);
+    if (remote) return remote;
+
     const elapsed = currentJob.startedAt
       ? (Date.now() - currentJob.startedAt) / 1000
       : 0;
@@ -172,7 +182,10 @@ export const vectorIndexerEndpoints = new Elysia()
   })
 
   // GET /vector/index/models
-  .get('/vector/index/models', async () => {
+  .get('/vector/index/models', async ({ set }) => {
+    const remote = await proxyVectorIndexer('models', set);
+    if (remote) return remote;
+
     const models = getEmbeddingModels();
     const result: Record<string, {
       collection: string;

--- a/src/routes/vector/map.ts
+++ b/src/routes/vector/map.ts
@@ -17,7 +17,8 @@ export const mapEndpoint = new Elysia().get('/map', async ({ set }) => {
   if (proxy) {
     const remote = await proxy.map();
     if (remote) return remote;
-    // Proxy failed — fall through to local handler
+    set.status = 503;
+    return { error: 'Vector proxy unavailable', documents: [], total: 0 };
   }
 
   try {

--- a/src/routes/vector/map3d.ts
+++ b/src/routes/vector/map3d.ts
@@ -22,7 +22,8 @@ export const map3dEndpoint = new Elysia().get(
     if (proxy) {
       const remote = await proxy.map3d(model);
       if (remote) return remote;
-      // Proxy failed — fall through to local handler
+      set.status = 503;
+      return { error: 'Vector proxy unavailable', documents: [], total: 0 };
     }
 
     try {

--- a/src/server/__tests__/vector-routes-proxy-boundary.test.ts
+++ b/src/server/__tests__/vector-routes-proxy-boundary.test.ts
@@ -1,0 +1,91 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+
+const originalVectorUrl = process.env.VECTOR_URL;
+const calls: string[] = [];
+
+const remote = Bun.serve({
+  port: 0,
+  async fetch(req) {
+    const url = new URL(req.url);
+    calls.push(`${req.method} ${url.pathname}${url.search}`);
+
+    if (url.pathname === '/api/map') {
+      return Response.json({ error: 'remote map down' }, { status: 500 });
+    }
+    if (url.pathname === '/api/map3d') {
+      return Response.json({
+        documents: [],
+        total: 3,
+        pca_info: { variance_explained: [], n_vectors: 0, n_dimensions: 0, computed_at: 'now' },
+      });
+    }
+    if (url.pathname === '/api/vector/index/start') {
+      return Response.json({ status: 'started', received: await req.json() });
+    }
+    if (url.pathname === '/api/vector/index/status') {
+      return Response.json({ status: 'completed', source: 'vault', current: 1, total: 1 });
+    }
+    if (url.pathname === '/api/vector/index/models') {
+      return Response.json({ models: { 'bge-m3': { count: 1, adapter: 'lancedb' } } });
+    }
+    return Response.json({ error: 'not found' }, { status: 404 });
+  },
+});
+
+process.env.VECTOR_URL = `http://127.0.0.1:${remote.port}`;
+
+const { mapEndpoint } = await import('../../routes/vector/map.ts');
+const { map3dEndpoint } = await import('../../routes/vector/map3d.ts');
+const { vectorIndexerEndpoints } = await import('../../routes/vector/indexer.ts');
+
+const app = new Elysia({ prefix: '/api' })
+  .use(mapEndpoint)
+  .use(map3dEndpoint)
+  .use(vectorIndexerEndpoints);
+
+describe('VECTOR_URL route boundary', () => {
+  test('/api/map returns proxy 503 instead of local vector fallback', async () => {
+    const res = await app.handle(new Request('http://localhost/api/map'));
+    const body = await res.json() as { error: string };
+
+    expect(res.status).toBe(503);
+    expect(body.error).toBe('Vector proxy unavailable');
+    expect(calls).toContain('GET /api/map');
+  });
+
+  test('/api/map3d proxies to the remote vector sidecar', async () => {
+    const res = await app.handle(new Request('http://localhost/api/map3d?model=bge-m3'));
+    const body = await res.json() as { total: number };
+
+    expect(res.status).toBe(200);
+    expect(body.total).toBe(3);
+    expect(calls).toContain('GET /api/map3d?model=bge-m3');
+  });
+
+  test('/api/vector/index/* proxies to the remote vector sidecar', async () => {
+    const start = await app.handle(new Request('http://localhost/api/vector/index/start', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ source: 'vault', repoRoot: '/tmp/vault' }),
+    }));
+    const startBody = await start.json() as { received: { source: string; repoRoot: string } };
+    expect(start.status).toBe(200);
+    expect(startBody.received).toEqual({ source: 'vault', repoRoot: '/tmp/vault' });
+
+    const status = await app.handle(new Request('http://localhost/api/vector/index/status'));
+    expect((await status.json() as { source: string }).source).toBe('vault');
+
+    const models = await app.handle(new Request('http://localhost/api/vector/index/models'));
+    expect((await models.json() as { models: Record<string, unknown> }).models['bge-m3']).toBeDefined();
+    expect(calls).toContain('POST /api/vector/index/start');
+    expect(calls).toContain('GET /api/vector/index/status');
+    expect(calls).toContain('GET /api/vector/index/models');
+  });
+});
+
+afterAll(() => {
+  remote.stop(true);
+  if (originalVectorUrl !== undefined) process.env.VECTOR_URL = originalVectorUrl;
+  else delete process.env.VECTOR_URL;
+});


### PR DESCRIPTION
Refs #1071.

Hardens the vector/core process boundary when `VECTOR_URL` is configured. A few pure-vector routes still had local fallbacks or local execution paths in the core HTTP process:

- `/api/map` and `/api/map3d` proxied first, then fell back to local LanceDB on proxy failure.
- `/api/vector/index/start|status|models` still ran the local vector indexer from core instead of forwarding to the sidecar.

Fix:
- `/api/map` and `/api/map3d` are now proxy-or-503 under `VECTOR_URL`.
- `/api/vector/index/*` now proxies to `${VECTOR_URL}/api/vector/index/*` under `VECTOR_URL`.
- Sidecar behavior remains local because `config.ts` already clears `VECTOR_URL` for the `vector-server` entrypoint.

Verification:
- `bun test --isolate src/server/__tests__/vector-routes-proxy-boundary.test.ts src/server/__tests__/search-vector-proxy-total.test.ts src/server/__tests__/vector-server-route.test.ts` → 6 pass
- `bun run build` → exit 0
- `bun run test:unit` → 269 pass

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3