### PR TITLE
feat(cli): expose npm-safe canonical command names

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ For Docker MCP Toolkit / Gateway / n8n installs, see [docs/DOCKER-MCP-TOOLKIT.md
 ## Architecture
 
 ```
-arra-oracle-v3 (one package, two bins)
-├── bunx arra-oracle-v2                          → MCP server (src/index.ts)
-├── bunx --package arra-oracle-v2 oracle-vault   → Vault CLI (src/vault/cli.ts)
-├── bun run server                          → HTTP API (src/server.ts)
-└── bun run index                           → Indexer (src/indexer.ts)
+arra-oracle-v3 (one package, two primary bins + legacy aliases)
+├── bunx --package github:Soul-Brews-Studio/arra-oracle-v3 arra-oracle  → HTTP API (bin/arra.ts)
+├── bunx --package github:Soul-Brews-Studio/arra-oracle-v3 arra-cli     → operator CLI (cli/src/cli.ts)
+├── bunx arra-oracle-v2                                                  → legacy MCP alias (src/index.ts)
+├── bun run server                                                       → HTTP API (src/server.ts)
+└── bun run index                                                        → Indexer (src/indexer.ts)
 
 oracle-studio (separate repo)
 └── bunx oracle-studio                      → React dashboard
@@ -46,11 +47,11 @@ oracle-studio (separate repo)
 Distributed via GitHub — no npm publish needed:
 
 ```bash
-# Backend (MCP server)
-bunx --bun arra-oracle@github:Soul-Brews-Studio/arra-oracle-v3
+# HTTP server
+bunx --bun --package github:Soul-Brews-Studio/arra-oracle-v3 arra-oracle
 
-# CLI (plugin runner)
-bunx --bun arra-cli@github:Soul-Brews-Studio/arra-oracle-v3 --help
+# CLI (operator client)
+bunx --bun --package github:Soul-Brews-Studio/arra-oracle-v3 arra-cli --help
 
 # UI (dashboard — separate repo)
 bunx --bun oracle-studio@github:Soul-Brews-Studio/oracle-studio
@@ -58,6 +59,10 @@ bunx --bun oracle-studio@github:Soul-Brews-Studio/oracle-studio
 # Vault CLI (secondary bin — use --package)
 bunx --bun --package arra-oracle-v2@github:Soul-Brews-Studio/arra-oracle-v3#main oracle-vault --help
 ```
+
+Canonical bins are `arra-oracle` (server) and `arra-cli` (client).
+Legacy aliases `arra-oracle-v3` and `arra-oracle-v2` stay available for
+existing installs, Docker commands, and MCP configs. See [docs/BINS.md](docs/BINS.md).
 
 ### Add to Claude Code
 

--- a/bin/arra.ts
+++ b/bin/arra.ts
@@ -2,15 +2,16 @@
 const args = process.argv.slice(2);
 
 if (args.includes("--help") || args.includes("-h")) {
-  console.log(`arra-oracle-v3 — Arra Oracle HTTP server
+  console.log(`arra-oracle — Arra Oracle HTTP server
 
 Usage:
-  bunx --bun arra-oracle-v3@github:Soul-Brews-Studio/arra-oracle-v3 [options]
+  bunx --bun --package github:Soul-Brews-Studio/arra-oracle-v3 arra-oracle [options]
 
 Options:
   --port <n>    Port to listen on (default: 47778, env: ORACLE_PORT)
   -h, --help    Show this help
 
+Legacy alias kept working: arra-oracle-v3.
 Once running, open the UI with: bunx oracle-studio`);
   process.exit(0);
 }

--- a/docs/BINS.md
+++ b/docs/BINS.md
@@ -1,0 +1,13 @@
+# Command bins
+
+`arra-oracle-v3` ships two canonical command roles and two legacy aliases.
+
+| Bin | Role | Entrypoint | Status |
+| --- | --- | --- | --- |
+| `arra-oracle` | Server runner | `bin/arra.ts` | Primary |
+| `arra-cli` | Operator client | `cli/src/cli.ts` | Primary |
+| `arra-oracle-v3` | Server runner | `bin/arra.ts` | Legacy alias, kept working |
+| `arra-oracle-v2` | Stdio MCP server | `src/index.ts` | Legacy alias, kept working |
+
+Do not add the bare `arra` bin: the npm package name is already taken by an
+unrelated package, so `bunx arra` would be unsafe.

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "type": "module",
   "main": "src/index.ts",
   "bin": {
+    "arra-oracle": "./bin/arra.ts",
+    "arra-cli": "./cli/src/cli.ts",
     "arra-oracle-v3": "./bin/arra.ts",
-    "arra-oracle-v2": "./src/index.ts",
-    "arra-cli": "./cli/src/cli.ts"
+    "arra-oracle-v2": "./src/index.ts"
   },
   "files": [
     "bin",


### PR DESCRIPTION
Refs #1275 (Phase 1).

## Problem
The naming decision for #1275 is locked to npm-safe role names: `arra-oracle` for the server and `arra-cli` for the operator client. The bare `arra` name is taken on npm, while the existing `arra-oracle-v2/v3` names must keep working for pinned installs, Docker, CI, and MCP configs.

## Fix
- Add canonical `arra-oracle` bin mapped to the existing server wrapper (`bin/arra.ts`).
- Keep `arra-cli`, `arra-oracle-v3`, and `arra-oracle-v2` as working aliases.
- Update `bin/arra.ts --help` and README install/architecture examples to prefer `arra-oracle` + `arra-cli`.
- Add `docs/BINS.md` documenting the canonical/legacy bin map and the “no bare arra” constraint.

## Verification
- `bun ./bin/arra.ts --help` → shows `arra-oracle` usage and legacy alias note.
- `bun ./cli/src/cli.ts --version` → `arra-cli v0.0.1`.
- Package bin assertion: `arra-oracle`/`arra-cli`/legacy aliases present, no bare `arra`.
- `bun run build` → pass.
- `bun run test:unit` → 269 pass, 0 fail.

## Notes
This is intentionally Phase 1 only. Later phases can add `arra-oracle serve|mcp`, layered config, and `arra-cli config` without renaming/removing legacy commands.

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3
