### PR TITLE
feat(server): add plugin loader seam with core tier guardrails

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,8 +1,9 @@
 /**
  * Arra Oracle HTTP Server — Elysia (bun-native).
  *
- * Composes 15 route modules from src/routes/. Every module is its own
- * Elysia sub-app, nested one file per endpoint.
+ * Composes built-in server plugins from src/server/plugin/. Phase 1 keeps
+ * behavior unchanged while moving hardcoded route/lifecycle registration
+ * behind a plugin-loader seam.
  */
 
 import { Elysia } from 'elysia';
@@ -22,39 +23,17 @@ import { PORT, ORACLE_DATA_DIR, VECTOR_URL } from './config.ts';
 import { MCP_SERVER_NAME } from './const.ts';
 import { db, sqlite, closeDb, indexingStatus } from './db/index.ts';
 import { seedMenuItems, type HasRoutes as SeedHasRoutes } from './db/seeders/menu-seeder.ts';
-import { startScoutAnnouncer, type ScoutAnnouncer } from './peer/scout-announcer.ts';
-
-// Elysia sub-apps — one per cluster
-import { authRoutes } from './routes/auth/index.ts';
-import { settingsRoutes } from './routes/settings/index.ts';
-import { feedRoutes } from './routes/feed/index.ts';
-import { healthRoutes } from './routes/health/index.ts';
-import { dashboardRoutes } from './routes/dashboard/index.ts';
-import { searchRoutes } from './routes/search/index.ts';
-import { conceptsRoutes } from './routes/concepts/index.ts';
-import { verifyRoutes } from './routes/verify/index.ts';
-import { vectorRoutes } from './routes/vector/index.ts';
-import { knowledgeRoutes } from './routes/knowledge/index.ts';
-import { supersedeRoutes } from './routes/supersede/index.ts';
-import { forumApi } from './routes/forum/index.ts';
-import { tracesApi } from './routes/traces/index.ts';
-import { scheduleApi } from './routes/schedule/index.ts';
-import { filesRouter } from './routes/files/index.ts';
-import { pluginsRouter } from './routes/plugins/index.ts';
-import { oraclenetRoutes } from './routes/oraclenet/index.ts';
-import { sessionsRoutes } from './routes/sessions/index.ts';
-import { vaultRoutes } from './routes/vault/index.ts';
-import { peerRoutes } from './routes/peer/index.ts';
-import { createMenuRoutes } from './routes/menu/index.ts';
-
-// Indexer routes are optional — MCP server works without them
-let indexerRoutes: any = null;
-try {
-  indexerRoutes = (await import('./routes/indexer/index.ts')).indexerRoutes;
-} catch {
-  console.log('[Indexer] Routes not loaded — indexer is optional');
-}
-import { gatewayPlugin } from './gateway/index.ts';
+import { createBuiltinServerPlugins } from './server/plugin/builtin.ts';
+import {
+  disabledPluginsFromEnv,
+  enabledServerPlugins,
+  loadServerPlugins,
+  menuSeedRoutes,
+  serverPluginRoutes,
+  startServerPlugins,
+  stopServerPlugins,
+} from './server/plugin/loader.ts';
+import { registerServerPlugins } from './server/plugin/registry.ts';
 
 import pkg from '../package.json' with { type: 'json' };
 
@@ -80,11 +59,17 @@ writePidFile({
   name: 'oracle-http',
 });
 
-let scoutAnnouncer: ScoutAnnouncer | null = null;
+const builtInPlugins = await createBuiltinServerPlugins({
+  dataDir: ORACLE_DATA_DIR,
+  vectorUrl: VECTOR_URL || undefined,
+});
+const loadedPlugins = loadServerPlugins(builtInPlugins, { disabledPlugins: disabledPluginsFromEnv() });
+const enabledPlugins = enabledServerPlugins(loadedPlugins);
+registerServerPlugins(loadedPlugins);
 
 registerSignalHandlers(async () => {
   console.log('\n🔮 Shutting down gracefully...');
-  scoutAnnouncer?.stop();
+  await stopServerPlugins(enabledPlugins);
   await performGracefulShutdown({
     resources: [{ close: () => { closeDb(); return Promise.resolve(); } }],
   });
@@ -109,9 +94,7 @@ const ALLOWED_ORIGINS = [
 
 function originAllowed(origin: string | undefined | null): string | null {
   if (!origin) return null;
-  if (origin.startsWith('http://localhost:') || origin.startsWith('http://127.0.0.1:')) {
-    return origin;
-  }
+  if (origin.startsWith('http://localhost:') || origin.startsWith('http://127.0.0.1:')) return origin;
   if (ALLOWED_ORIGINS.includes(origin)) return origin;
   try {
     const { hostname, protocol } = new URL(origin);
@@ -153,10 +136,7 @@ const app = new Elysia()
   .use(pnaMiddleware)
   .use(
     cors({
-      origin: (request) => {
-        const origin = request.headers.get('origin');
-        return originAllowed(origin) !== null;
-      },
+      origin: (request) => originAllowed(request.headers.get('origin')) !== null,
       credentials: true,
       methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
     }),
@@ -194,8 +174,6 @@ const app = new Elysia()
       },
     }),
   )
-  .use(gatewayPlugin(ORACLE_DATA_DIR, VECTOR_URL || undefined))
-  .use(peerRoutes)
   .get('/', () => ({
     server: MCP_SERVER_NAME,
     version: pkg.version,
@@ -204,31 +182,8 @@ const app = new Elysia()
     api: '/api',
   }));
 
-const apiModules = [
-  authRoutes,
-  settingsRoutes,
-  feedRoutes,
-  healthRoutes,
-  dashboardRoutes,
-  searchRoutes,
-  conceptsRoutes,
-  verifyRoutes,
-  vectorRoutes,
-  knowledgeRoutes,
-  supersedeRoutes,
-  forumApi,
-  tracesApi,
-  scheduleApi,
-  filesRouter,
-  pluginsRouter,
-  oraclenetRoutes,
-  sessionsRoutes,
-  vaultRoutes,
-  ...(indexerRoutes ? [indexerRoutes] : []),
-];
-
 try {
-  const result = seedMenuItems(apiModules as unknown as SeedHasRoutes[]);
+  const result = seedMenuItems(menuSeedRoutes(enabledPlugins) as unknown as SeedHasRoutes[]);
   console.log(
     `🔮 Menu seeded: ${result.inserted} inserted, ${result.updated} updated, ${result.preserved} preserved`,
   );
@@ -236,13 +191,8 @@ try {
   console.error('⚠️  Menu seeder failed:', e);
 }
 
-const menuRoutes = createMenuRoutes();
-
-const modules = [...apiModules, menuRoutes];
-
-for (const mod of modules) app.use(mod as any);
-
-scoutAnnouncer = startScoutAnnouncer();
+for (const mod of serverPluginRoutes(enabledPlugins)) app.use(mod as any);
+await startServerPlugins(enabledPlugins);
 
 console.log(`
 🔮 Arra Oracle HTTP Server running! (Elysia)

--- a/src/server/__tests__/server-plugin-loader.test.ts
+++ b/src/server/__tests__/server-plugin-loader.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { Elysia } from 'elysia';
+
+import {
+  enabledServerPlugins,
+  loadServerPlugins,
+  serverPluginRoutes,
+} from '../plugin/loader.ts';
+import type { ServerPlugin } from '../plugin/types.ts';
+
+const tmp = mkdtempSync(join(tmpdir(), 'arra-server-plugin-loader-'));
+process.env.ORACLE_DATA_DIR = tmp;
+process.env.ORACLE_DB_PATH = join(tmp, 'oracle.db');
+process.env.ORACLE_REPO_ROOT = tmp;
+process.env.ORACLE_PORT = '0';
+process.env.VECTOR_URL = '';
+
+async function coreOnlyApp() {
+  const { createBuiltinServerPlugins } = await import('../plugin/builtin.ts');
+  const loaded = loadServerPlugins(await createBuiltinServerPlugins({ dataDir: tmp }), {
+    disabledPlugins: ['*'],
+  });
+  const enabled = enabledServerPlugins(loaded);
+  const app = new Elysia();
+  for (const routes of serverPluginRoutes(enabled)) app.use(routes as any);
+  return { app, enabled };
+}
+
+afterAll(async () => {
+  const { closeDb } = await import('../../db/index.ts');
+  closeDb();
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('server plugin loader', () => {
+  test('refuses explicit core plugin disable', () => {
+    const plugins: ServerPlugin[] = [
+      { name: 'search', tier: 'core' },
+      { name: 'federation', tier: 'standard' },
+    ];
+    expect(() => loadServerPlugins(plugins, { disabledPlugins: ['search'] })).toThrow(
+      'Cannot disable core server plugin "search"',
+    );
+  });
+
+  test('wildcard disable removes standard/extra while keeping core', () => {
+    const plugins: ServerPlugin[] = [
+      { name: 'search', tier: 'core' },
+      { name: 'federation', tier: 'standard' },
+      { name: 'obsidian', tier: 'extra' },
+    ];
+    const enabled = enabledServerPlugins(loadServerPlugins(plugins, { disabledPlugins: ['*'] }));
+    expect(enabled.map((plugin) => plugin.name)).toEqual(['search']);
+  });
+
+  test('disable everything still serves core search, learn, and stats over FTS5', async () => {
+    const { app, enabled } = await coreOnlyApp();
+    expect(enabled.every((plugin) => plugin.tier === 'core')).toBe(true);
+
+    const pattern = 'server plugin core floor acceptance';
+    const learn = await app.handle(new Request('http://local/api/learn', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ pattern, source: 'test', concepts: ['plugin-core'] }),
+    }));
+    expect(learn.status).toBe(200);
+
+    const stats = await app.handle(new Request('http://local/api/stats'));
+    expect(stats.status).toBe(200);
+    const statsBody = await stats.json() as { total?: number };
+    expect(statsBody.total ?? 0).toBeGreaterThanOrEqual(1);
+
+    const search = await app.handle(new Request(`http://local/api/search?q=${encodeURIComponent(pattern)}&mode=fts`));
+    expect(search.status).toBe(200);
+    const searchBody = await search.json() as { total?: number };
+    expect(searchBody.total ?? 0).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/server/plugin/builtin.ts
+++ b/src/server/plugin/builtin.ts
@@ -1,0 +1,96 @@
+import type { ServerPlugin } from './types.ts';
+
+import { authRoutes } from '../../routes/auth/index.ts';
+import { settingsRoutes } from '../../routes/settings/index.ts';
+import { feedRoutes } from '../../routes/feed/index.ts';
+import { healthRoutes } from '../../routes/health/index.ts';
+import { dashboardRoutes } from '../../routes/dashboard/index.ts';
+import { searchRoutes } from '../../routes/search/index.ts';
+import { conceptsRoutes } from '../../routes/concepts/index.ts';
+import { verifyRoutes } from '../../routes/verify/index.ts';
+import { vectorRoutes } from '../../routes/vector/index.ts';
+import { knowledgeRoutes } from '../../routes/knowledge/index.ts';
+import { supersedeRoutes } from '../../routes/supersede/index.ts';
+import { forumApi } from '../../routes/forum/index.ts';
+import { tracesApi } from '../../routes/traces/index.ts';
+import { scheduleApi } from '../../routes/schedule/index.ts';
+import { filesRouter } from '../../routes/files/index.ts';
+import { pluginsRouter } from '../../routes/plugins/index.ts';
+import { oraclenetRoutes } from '../../routes/oraclenet/index.ts';
+import { sessionsRoutes } from '../../routes/sessions/index.ts';
+import { vaultRoutes } from '../../routes/vault/index.ts';
+import { peerRoutes } from '../../routes/peer/index.ts';
+import { createMenuRoutes } from '../../routes/menu/index.ts';
+import { gatewayPlugin } from '../../gateway/index.ts';
+import { startScoutAnnouncer, type ScoutAnnouncer } from '../../peer/scout-announcer.ts';
+
+interface BuiltinOptions {
+  dataDir: string;
+  vectorUrl?: string;
+}
+
+function routePlugin(
+  name: string,
+  tier: ServerPlugin['tier'],
+  routes: ServerPlugin['routes'],
+  seedMenu = true,
+): ServerPlugin {
+  return { name, tier, routes, seedMenu };
+}
+
+async function optionalIndexerPlugin(): Promise<ServerPlugin | null> {
+  try {
+    const { indexerRoutes } = await import('../../routes/indexer/index.ts');
+    return routePlugin('indexer', 'core', () => indexerRoutes);
+  } catch {
+    console.log('[Indexer] Routes not loaded — indexer is optional');
+    return null;
+  }
+}
+
+export async function createBuiltinServerPlugins(options: BuiltinOptions): Promise<ServerPlugin[]> {
+  const gatewayRoutes = gatewayPlugin(options.dataDir, options.vectorUrl);
+  const menuRoutes = createMenuRoutes();
+  const indexerPlugin = await optionalIndexerPlugin();
+  let scoutAnnouncer: ScoutAnnouncer | null = null;
+
+  const plugins: Array<ServerPlugin | null> = [
+    routePlugin('gateway', 'standard', () => gatewayRoutes, false),
+    {
+      name: 'federation',
+      tier: 'standard',
+      seedMenu: false,
+      routes: () => peerRoutes,
+      start: () => {
+        scoutAnnouncer = startScoutAnnouncer();
+      },
+      stop: () => {
+        scoutAnnouncer?.stop();
+        scoutAnnouncer = null;
+      },
+    },
+    routePlugin('health', 'core', () => healthRoutes),
+    routePlugin('search', 'core', () => searchRoutes),
+    routePlugin('knowledge', 'core', () => knowledgeRoutes),
+    routePlugin('concepts', 'core', () => conceptsRoutes),
+    routePlugin('verify', 'core', () => verifyRoutes),
+    routePlugin('vector', 'core', () => vectorRoutes),
+    routePlugin('files', 'core', () => filesRouter),
+    indexerPlugin,
+    routePlugin('auth', 'standard', () => authRoutes),
+    routePlugin('settings', 'standard', () => settingsRoutes),
+    routePlugin('feed', 'standard', () => feedRoutes),
+    routePlugin('dashboard', 'standard', () => dashboardRoutes),
+    routePlugin('supersede', 'standard', () => supersedeRoutes),
+    routePlugin('forum', 'standard', () => forumApi),
+    routePlugin('traces', 'standard', () => tracesApi),
+    routePlugin('schedule', 'standard', () => scheduleApi),
+    routePlugin('plugins', 'standard', () => pluginsRouter),
+    routePlugin('oraclenet', 'standard', () => oraclenetRoutes),
+    routePlugin('sessions', 'standard', () => sessionsRoutes),
+    routePlugin('vault', 'standard', () => vaultRoutes),
+    routePlugin('menu', 'standard', () => menuRoutes, false),
+  ];
+
+  return plugins.filter((plugin): plugin is ServerPlugin => Boolean(plugin));
+}

--- a/src/server/plugin/loader.ts
+++ b/src/server/plugin/loader.ts
@@ -1,0 +1,52 @@
+import { parseDisabledPlugins, validateServerPlugin } from './manifest.ts';
+import type { ElysiaApp, LoadedServerPlugin, LoadServerPluginsOptions, ServerPlugin } from './types.ts';
+
+export function disabledPluginsFromEnv(): string[] {
+  return parseDisabledPlugins(process.env.ORACLE_DISABLED_PLUGINS ?? process.env.ARRA_DISABLED_PLUGINS);
+}
+
+function isDisabled(plugin: ServerPlugin, disabled: Set<string>): boolean {
+  if (plugin.enabled === false) return true;
+  return disabled.has('*') || disabled.has(plugin.name);
+}
+
+export function loadServerPlugins(
+  plugins: ServerPlugin[],
+  options: LoadServerPluginsOptions = {},
+): LoadedServerPlugin[] {
+  const disabled = new Set(options.disabledPlugins ?? []);
+  return plugins.map((plugin) => {
+    validateServerPlugin(plugin);
+    if (plugin.tier === 'core') {
+      if (plugin.enabled === false || disabled.has(plugin.name)) {
+        throw new Error(`Cannot disable core server plugin "${plugin.name}"`);
+      }
+      return { plugin, disabled: false };
+    }
+    return { plugin, disabled: isDisabled(plugin, disabled) };
+  });
+}
+
+export function enabledServerPlugins(loaded: LoadedServerPlugin[]): ServerPlugin[] {
+  return loaded.filter((entry) => !entry.disabled).map((entry) => entry.plugin);
+}
+
+export function serverPluginRoutes(plugins: ServerPlugin[]): ElysiaApp[] {
+  return plugins.flatMap((plugin) => {
+    const routes = plugin.routes?.();
+    if (!routes) return [];
+    return Array.isArray(routes) ? routes : [routes];
+  });
+}
+
+export function menuSeedRoutes(plugins: ServerPlugin[]): ElysiaApp[] {
+  return serverPluginRoutes(plugins.filter((plugin) => plugin.seedMenu));
+}
+
+export async function startServerPlugins(plugins: ServerPlugin[]): Promise<void> {
+  for (const plugin of plugins) await plugin.start?.();
+}
+
+export async function stopServerPlugins(plugins: ServerPlugin[]): Promise<void> {
+  for (const plugin of [...plugins].reverse()) await plugin.stop?.();
+}

--- a/src/server/plugin/manifest.ts
+++ b/src/server/plugin/manifest.ts
@@ -1,0 +1,19 @@
+import type { ServerPlugin } from './types.ts';
+
+const TIERS = new Set(['core', 'standard', 'extra']);
+
+export function validateServerPlugin(plugin: ServerPlugin): void {
+  if (!plugin.name || !/^[a-z0-9-]+$/.test(plugin.name)) {
+    throw new Error(`server plugin name must match /^[a-z0-9-]+$/, got: ${JSON.stringify(plugin.name)}`);
+  }
+  if (!TIERS.has(plugin.tier)) {
+    throw new Error(`server plugin "${plugin.name}" has invalid tier: ${JSON.stringify(plugin.tier)}`);
+  }
+}
+
+export function parseDisabledPlugins(raw: string | undefined): string[] {
+  return (raw ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}

--- a/src/server/plugin/registry.ts
+++ b/src/server/plugin/registry.ts
@@ -1,0 +1,20 @@
+import type { LoadedServerPlugin, ServerPlugin } from './types.ts';
+
+const registry: LoadedServerPlugin[] = [];
+
+export function registerServerPlugins(plugins: LoadedServerPlugin[]): void {
+  registry.length = 0;
+  registry.push(...plugins);
+}
+
+export function resolveServerPlugin(name: string): LoadedServerPlugin | null {
+  return registry.find((p) => p.plugin.name === name) ?? null;
+}
+
+export function listServerPlugins(): LoadedServerPlugin[] {
+  return [...registry];
+}
+
+export function pluginNames(plugins: ServerPlugin[]): string[] {
+  return plugins.map((p) => p.name);
+}

--- a/src/server/plugin/types.ts
+++ b/src/server/plugin/types.ts
@@ -1,0 +1,23 @@
+import type { Elysia } from 'elysia';
+
+export type ServerPluginTier = 'core' | 'standard' | 'extra';
+export type ElysiaApp = Elysia<any, any, any, any, any, any, any>;
+
+export interface ServerPlugin {
+  name: string;
+  tier: ServerPluginTier;
+  enabled?: boolean;
+  seedMenu?: boolean;
+  routes?: () => ElysiaApp | ElysiaApp[];
+  start?: () => void | Promise<void>;
+  stop?: () => void | Promise<void>;
+}
+
+export interface LoadedServerPlugin {
+  plugin: ServerPlugin;
+  disabled: boolean;
+}
+
+export interface LoadServerPluginsOptions {
+  disabledPlugins?: string[];
+}


### PR DESCRIPTION
Refs #1278 (Phase 1 only).

## Scope
Lean server plugin-loader seam only. This intentionally does **not** implement manifest HTTP auto-mounting, expanded lifecycle hooks, federation extraction, plugin enable/disable CLI UX, unified manifests, or engine-plugin gateway.

## What changed
- Added `src/server/plugin/{types,manifest,registry,loader,builtin}.ts`, mirroring the existing CLI plugin shape.
- Defined minimal server plugin interface: name, tier (`core|standard|extra`), enabled, routes, start, stop.
- Refactored `src/server.ts` to load built-in plugins and iterate enabled plugin routes/lifecycle instead of hardcoded route imports + `startScoutAnnouncer()`.
- Wrapped existing surfaces as built-in plugins:
  - core: health/stats, search/list/reflect, knowledge/learn/inbox/handoff, concepts, verify, vector, files/read, indexer.
  - standard: gateway, federation (`peerRoutes` + Scout announcer), auth/settings/feed/dashboard/supersede/forum/traces/schedule/plugins/oraclenet/sessions/vault/menu.
- Core-tier guardrails: exact core disable throws a clear error; wildcard disable removes standard/extra while core still loads.

## Acceptance / verification
- New test: `disable everything -> core still serves search/learn/stats over FTS5`.
- New test: explicit core disable is refused.
- New test: wildcard disables standard/extra but keeps core.
- `bun test --isolate src/server/__tests__/server-plugin-loader.test.ts` → 3 pass.
- `bun run build` → pass.
- `bun run test:unit` → 272 pass, 0 fail.
- Default HTTP smoke on `:47923`: `/api/health` and `/info` work; Scout starts.
- Core-only smoke with `ORACLE_DISABLED_PLUGINS=*` on `:47924`: `/api/health` works and standard `/info` returns 404.

## Deferred
- Phase 2: HTTP-route auto-mount from manifest `api` field.
- Phase 3: lifecycle hooks beyond start/stop.
- Phase 4 / #1277: federation extraction.
- Phase 5: one manifest across CLI/API/peer.
- Phase 6: plugin enable/disable CLI UX.
- Phase 7: engine-plugin gateway.

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3
