### PR TITLE
feat(server): make federation removable via plugin config

### DIFF
--- a/src/server/__tests__/server-plugin-loader.test.ts
+++ b/src/server/__tests__/server-plugin-loader.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { Elysia } from 'elysia';
 
 import {
+  disabledPluginsFromEnv,
   enabledServerPlugins,
   loadServerPlugins,
   serverPluginRoutes,
@@ -18,15 +19,27 @@ process.env.ORACLE_REPO_ROOT = tmp;
 process.env.ORACLE_PORT = '0';
 process.env.VECTOR_URL = '';
 
-async function coreOnlyApp() {
+async function appWithDisabled(disabledPlugins: string[]) {
   const { createBuiltinServerPlugins } = await import('../plugin/builtin.ts');
   const loaded = loadServerPlugins(await createBuiltinServerPlugins({ dataDir: tmp }), {
-    disabledPlugins: ['*'],
+    disabledPlugins,
   });
   const enabled = enabledServerPlugins(loaded);
   const app = new Elysia();
   for (const routes of serverPluginRoutes(enabled)) app.use(routes as any);
   return { app, enabled };
+}
+
+function withEnv(key: string, value: string | undefined, fn: () => void) {
+  const prev = process.env[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+  try {
+    fn();
+  } finally {
+    if (prev === undefined) delete process.env[key];
+    else process.env[key] = prev;
+  }
 }
 
 afterAll(async () => {
@@ -56,8 +69,27 @@ describe('server plugin loader', () => {
     expect(enabled.map((plugin) => plugin.name)).toEqual(['search']);
   });
 
+  test('FED_ENABLED=false maps to the federation plugin disable switch', () => {
+    withEnv('FED_ENABLED', 'false', () => {
+      expect(disabledPluginsFromEnv()).toContain('federation');
+    });
+  });
+
+  test('federation plugin can be removed and restored around core routes', async () => {
+    const disabled = await appWithDisabled(['federation']);
+    expect(disabled.enabled.some((plugin) => plugin.name === 'federation')).toBe(false);
+    expect((await disabled.app.handle(new Request('http://local/info'))).status).toBe(404);
+    expect((await disabled.app.handle(new Request('http://local/api/identity'))).status).toBe(404);
+    expect((await disabled.app.handle(new Request('http://local/api/health'))).status).toBe(200);
+
+    const restored = await appWithDisabled([]);
+    expect(restored.enabled.some((plugin) => plugin.name === 'federation')).toBe(true);
+    expect((await restored.app.handle(new Request('http://local/info'))).status).toBe(200);
+    expect((await restored.app.handle(new Request('http://local/api/identity'))).status).toBe(200);
+  });
+
   test('disable everything still serves core search, learn, and stats over FTS5', async () => {
-    const { app, enabled } = await coreOnlyApp();
+    const { app, enabled } = await appWithDisabled(['*']);
     expect(enabled.every((plugin) => plugin.tier === 'core')).toBe(true);
 
     const pattern = 'server plugin core floor acceptance';

--- a/src/server/plugin/loader.ts
+++ b/src/server/plugin/loader.ts
@@ -2,7 +2,9 @@ import { parseDisabledPlugins, validateServerPlugin } from './manifest.ts';
 import type { ElysiaApp, LoadedServerPlugin, LoadServerPluginsOptions, ServerPlugin } from './types.ts';
 
 export function disabledPluginsFromEnv(): string[] {
-  return parseDisabledPlugins(process.env.ORACLE_DISABLED_PLUGINS ?? process.env.ARRA_DISABLED_PLUGINS);
+  const disabled = parseDisabledPlugins(process.env.ORACLE_DISABLED_PLUGINS ?? process.env.ARRA_DISABLED_PLUGINS);
+  if (process.env.FED_ENABLED?.toLowerCase() === 'false') disabled.push('federation');
+  return [...new Set(disabled)];
 }
 
 function isDisabled(plugin: ServerPlugin, disabled: Set<string>): boolean {


### PR DESCRIPTION
Refs #1277. Builds on the #1278 server plugin seam by proving federation can now be cleanly toggled in/out without changing the maw handshake or Scout protocol shape.

What changed:
- `FED_ENABLED=false` maps to disabling the built-in standard-tier `federation` plugin.
- Existing generic server plugin config still works: `ORACLE_DISABLED_PLUGINS=federation`.
- Core routes stay loaded and healthy while `/info`, `/api/identity`, and Scout are removed.
- Default behavior remains federation-on for the existing mawjs pairing.

Verification:
- `bun test --isolate src/server/__tests__/server-plugin-loader.test.ts` -> 5 pass
- `bun run build` -> pass
- `bun run test:unit` -> 274 pass
- Default smoke on `:47925`: `/api/health=200`, `/info=200`, `/api/identity=200`, Scout log present
- `FED_ENABLED=false` smoke on `:47926`: `/api/health=200`, `/info=404`, `/api/identity=404`, Scout log absent

Phase note: this is the lean Phase 1 proof for #1277. Full extraction/removable packaging stays follow-up.

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3