### PR TITLE
feat(server): make federation opt-in by default

### DIFF
--- a/docs/BINS.md
+++ b/docs/BINS.md
@@ -11,3 +11,24 @@
 
 Do not add the bare `arra` bin: the npm package name is already taken by an
 unrelated package, so `bunx arra` would be unsafe.
+
+## Federation opt-in
+
+Bare `arra-oracle serve` is network-silent by default: it serves core HTTP APIs
+but does not mount maw peer discovery routes (`/info`, `/api/identity`) or emit
+Scout multicast HELLO packets.
+
+Enable federation explicitly for paired hosts:
+
+```bash
+FED_ENABLED=true arra-oracle serve
+```
+
+Equivalent plugin config also works:
+
+```bash
+ORACLE_ENABLED_PLUGINS=federation arra-oracle serve
+```
+
+`ORACLE_DISABLED_PLUGINS=federation` wins over an enable switch when both are
+set, so deployment configs can force federation off.

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,6 +26,7 @@ import { seedMenuItems, type HasRoutes as SeedHasRoutes } from './db/seeders/men
 import { createBuiltinServerPlugins } from './server/plugin/builtin.ts';
 import {
   disabledPluginsFromEnv,
+  enabledPluginsFromEnv,
   enabledServerPlugins,
   loadServerPlugins,
   menuSeedRoutes,
@@ -63,7 +64,10 @@ const builtInPlugins = await createBuiltinServerPlugins({
   dataDir: ORACLE_DATA_DIR,
   vectorUrl: VECTOR_URL || undefined,
 });
-const loadedPlugins = loadServerPlugins(builtInPlugins, { disabledPlugins: disabledPluginsFromEnv() });
+const loadedPlugins = loadServerPlugins(builtInPlugins, {
+  disabledPlugins: disabledPluginsFromEnv(),
+  enabledPlugins: enabledPluginsFromEnv(),
+});
 const enabledPlugins = enabledServerPlugins(loadedPlugins);
 registerServerPlugins(loadedPlugins);
 

--- a/src/server/__tests__/server-plugin-loader.test.ts
+++ b/src/server/__tests__/server-plugin-loader.test.ts
@@ -6,6 +6,7 @@ import { Elysia } from 'elysia';
 
 import {
   disabledPluginsFromEnv,
+  enabledPluginsFromEnv,
   enabledServerPlugins,
   loadServerPlugins,
   serverPluginRoutes,
@@ -19,10 +20,11 @@ process.env.ORACLE_REPO_ROOT = tmp;
 process.env.ORACLE_PORT = '0';
 process.env.VECTOR_URL = '';
 
-async function appWithDisabled(disabledPlugins: string[]) {
+async function appWithConfig(disabledPlugins: string[], enabledPlugins: string[] = []) {
   const { createBuiltinServerPlugins } = await import('../plugin/builtin.ts');
   const loaded = loadServerPlugins(await createBuiltinServerPlugins({ dataDir: tmp }), {
     disabledPlugins,
+    enabledPlugins,
   });
   const enabled = enabledServerPlugins(loaded);
   const app = new Elysia();
@@ -69,27 +71,41 @@ describe('server plugin loader', () => {
     expect(enabled.map((plugin) => plugin.name)).toEqual(['search']);
   });
 
-  test('FED_ENABLED=false maps to the federation plugin disable switch', () => {
-    withEnv('FED_ENABLED', 'false', () => {
-      expect(disabledPluginsFromEnv()).toContain('federation');
+  test('FED_ENABLED=true maps to the federation plugin enable switch', () => {
+    withEnv('FED_ENABLED', 'true', () => {
+      expect(enabledPluginsFromEnv()).toContain('federation');
+      expect(disabledPluginsFromEnv()).not.toContain('federation');
     });
   });
 
-  test('federation plugin can be removed and restored around core routes', async () => {
-    const disabled = await appWithDisabled(['federation']);
+  test('ORACLE_ENABLED_PLUGINS can opt federation in', () => {
+    withEnv('ORACLE_ENABLED_PLUGINS', 'federation', () => {
+      expect(enabledPluginsFromEnv()).toContain('federation');
+    });
+  });
+
+  test('federation plugin is off by default and opt-in around core routes', async () => {
+    const disabled = await appWithConfig([]);
     expect(disabled.enabled.some((plugin) => plugin.name === 'federation')).toBe(false);
     expect((await disabled.app.handle(new Request('http://local/info'))).status).toBe(404);
     expect((await disabled.app.handle(new Request('http://local/api/identity'))).status).toBe(404);
     expect((await disabled.app.handle(new Request('http://local/api/health'))).status).toBe(200);
 
-    const restored = await appWithDisabled([]);
+    const restored = await appWithConfig([], ['federation']);
     expect(restored.enabled.some((plugin) => plugin.name === 'federation')).toBe(true);
     expect((await restored.app.handle(new Request('http://local/info'))).status).toBe(200);
     expect((await restored.app.handle(new Request('http://local/api/identity'))).status).toBe(200);
   });
 
+  test('ORACLE_DISABLED_PLUGINS still wins over explicit federation enable', async () => {
+    const conflicted = await appWithConfig(['federation'], ['federation']);
+    expect(conflicted.enabled.some((plugin) => plugin.name === 'federation')).toBe(false);
+    expect((await conflicted.app.handle(new Request('http://local/info'))).status).toBe(404);
+    expect((await conflicted.app.handle(new Request('http://local/api/health'))).status).toBe(200);
+  });
+
   test('disable everything still serves core search, learn, and stats over FTS5', async () => {
-    const { app, enabled } = await appWithDisabled(['*']);
+    const { app, enabled } = await appWithConfig(['*']);
     expect(enabled.every((plugin) => plugin.tier === 'core')).toBe(true);
 
     const pattern = 'server plugin core floor acceptance';

--- a/src/server/plugin/builtin.ts
+++ b/src/server/plugin/builtin.ts
@@ -59,6 +59,7 @@ export async function createBuiltinServerPlugins(options: BuiltinOptions): Promi
     {
       name: 'federation',
       tier: 'standard',
+      enabled: false,
       seedMenu: false,
       routes: () => peerRoutes,
       start: () => {

--- a/src/server/plugin/loader.ts
+++ b/src/server/plugin/loader.ts
@@ -1,4 +1,4 @@
-import { parseDisabledPlugins, validateServerPlugin } from './manifest.ts';
+import { parseDisabledPlugins, parseEnabledPlugins, validateServerPlugin } from './manifest.ts';
 import type { ElysiaApp, LoadedServerPlugin, LoadServerPluginsOptions, ServerPlugin } from './types.ts';
 
 export function disabledPluginsFromEnv(): string[] {
@@ -7,8 +7,19 @@ export function disabledPluginsFromEnv(): string[] {
   return [...new Set(disabled)];
 }
 
-function isDisabled(plugin: ServerPlugin, disabled: Set<string>): boolean {
-  if (plugin.enabled === false) return true;
+export function enabledPluginsFromEnv(): string[] {
+  const enabled = parseEnabledPlugins(process.env.ORACLE_ENABLED_PLUGINS ?? process.env.ARRA_ENABLED_PLUGINS);
+  if (process.env.FED_ENABLED?.toLowerCase() === 'true') enabled.push('federation');
+  return [...new Set(enabled)];
+}
+
+function isEnabled(plugin: ServerPlugin, enabled: Set<string>): boolean {
+  if (plugin.enabled !== false) return true;
+  return enabled.has('*') || enabled.has(plugin.name);
+}
+
+function isDisabled(plugin: ServerPlugin, disabled: Set<string>, enabled: Set<string>): boolean {
+  if (!isEnabled(plugin, enabled)) return true;
   return disabled.has('*') || disabled.has(plugin.name);
 }
 
@@ -17,6 +28,7 @@ export function loadServerPlugins(
   options: LoadServerPluginsOptions = {},
 ): LoadedServerPlugin[] {
   const disabled = new Set(options.disabledPlugins ?? []);
+  const enabled = new Set(options.enabledPlugins ?? []);
   return plugins.map((plugin) => {
     validateServerPlugin(plugin);
     if (plugin.tier === 'core') {
@@ -25,7 +37,7 @@ export function loadServerPlugins(
       }
       return { plugin, disabled: false };
     }
-    return { plugin, disabled: isDisabled(plugin, disabled) };
+    return { plugin, disabled: isDisabled(plugin, disabled, enabled) };
   });
 }
 

--- a/src/server/plugin/manifest.ts
+++ b/src/server/plugin/manifest.ts
@@ -17,3 +17,5 @@ export function parseDisabledPlugins(raw: string | undefined): string[] {
     .map((s) => s.trim())
     .filter(Boolean);
 }
+
+export const parseEnabledPlugins = parseDisabledPlugins;

--- a/src/server/plugin/types.ts
+++ b/src/server/plugin/types.ts
@@ -20,4 +20,5 @@ export interface LoadedServerPlugin {
 
 export interface LoadServerPluginsOptions {
   disabledPlugins?: string[];
+  enabledPlugins?: string[];
 }


### PR DESCRIPTION
Closes #1282. Follow-up to #1281 before the next alpha cut: federation is now opt-in instead of default-on, so bare `arra-oracle serve` is network-silent.

What changed:
- Built-in `federation` server plugin is disabled by default.
- `FED_ENABLED=true` opts in to `/info`, `/api/identity`, and Scout multicast.
- `ORACLE_ENABLED_PLUGINS=federation` also opts in through the generic plugin path.
- `ORACLE_DISABLED_PLUGINS=federation` still wins over explicit enable.
- `docs/BINS.md` documents the opt-in deployment model.

Verification:
- `bun test --isolate src/server/__tests__/server-plugin-loader.test.ts` -> 7 pass
- `bun run build` -> pass
- `bun run test:unit` -> 276 pass
- Default smoke on `:47927`: `/api/health=200`, `/info=404`, `/api/identity=404`, Scout log absent
- `FED_ENABLED=true` smoke on `:47928`: `/api/health=200`, `/info=200`, `/api/identity=200`, Scout log present

Deployment note: m5 live must be restarted with `FED_ENABLED=true` so the existing mawjs TOFU pairing remains reachable.

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3