### PR TITLE
feat(cli): dispatch arra-oracle serve and mcp

### DIFF
--- a/bin/arra.ts
+++ b/bin/arra.ts
@@ -1,36 +1,53 @@
 #!/usr/bin/env bun
 const args = process.argv.slice(2);
+const command = args[0];
 
-if (args.includes("--help") || args.includes("-h")) {
-  console.log(`arra-oracle — Arra Oracle HTTP server
+function showHelp(): void {
+  console.log(`arra-oracle — Arra Oracle HTTP/MCP server
 
 Usage:
-  bunx --bun --package github:Soul-Brews-Studio/arra-oracle-v3 arra-oracle [options]
+  arra-oracle [serve] [options]
+  arra-oracle mcp [--read-only]
 
-Options:
+Commands:
+  serve        Run the HTTP server (default)
+  mcp          Run the stdio MCP server
+
+Serve options:
   --port <n>    Port to listen on (default: 47778, env: ORACLE_PORT)
   -h, --help    Show this help
 
-Legacy alias kept working: arra-oracle-v3.
+Legacy aliases kept working: arra-oracle-v3, arra-oracle-v2.
 Once running, open the UI with: bunx oracle-studio`);
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  showHelp();
   process.exit(0);
 }
 
-const portIdx = args.indexOf("--port");
-if (portIdx !== -1) {
-  const val = args[portIdx + 1];
-  if (!val || !/^\d+$/.test(val)) {
-    console.error("Error: --port requires a numeric value");
-    process.exit(1);
+if (command === "mcp") {
+  process.env.ORACLE_LOG_TARGET ??= "stderr";
+  console.log = (...data: unknown[]) => console.error(...data);
+  await import("../src/index.ts");
+} else {
+  const serveArgs = command === "serve" ? args.slice(1) : args;
+  const portIdx = serveArgs.indexOf("--port");
+  if (portIdx !== -1) {
+    const val = serveArgs[portIdx + 1];
+    if (!val || !/^\d+$/.test(val)) {
+      console.error("Error: --port requires a numeric value");
+      process.exit(1);
+    }
+    process.env.ORACLE_PORT = val;
   }
-  process.env.ORACLE_PORT = val;
-}
 
-// Load server module (registers routes + plugins via Elysia setup).
-// Bun's `export default { port, fetch }` auto-server pattern only fires when
-// the file is the entry script. When bin/arra.ts wraps server.ts via
-// `await import()`, the export becomes plain data and no listener is bound.
-// Call Bun.serve() explicitly so the wrapper actually starts a server.
-const { default: appSpec } = await import("../src/server.ts");
-const server = Bun.serve(appSpec);
-console.log(`🔮 Arra Oracle HTTP server → http://localhost:${server.port}`);
+  // Load server module (registers routes + plugins via Elysia setup).
+  // Bun's `export default { port, fetch }` auto-server pattern only fires when
+  // the file is the entry script. When bin/arra.ts wraps server.ts via
+  // `await import()`, the export becomes plain data and no listener is bound.
+  // Call Bun.serve() explicitly so the wrapper actually starts a server.
+  const { default: appSpec } = await import("../src/server.ts");
+  const server = Bun.serve(appSpec);
+  console.log(`🔮 Arra Oracle HTTP server → http://localhost:${server.port}`);
+}

--- a/tests/bin/arra-oracle-dispatch.test.ts
+++ b/tests/bin/arra-oracle-dispatch.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, expect, test } from "bun:test";
+import type { ReadableStream } from "node:stream/web";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dir, "../..");
+const binEntry = join(repoRoot, "bin/arra.ts");
+const tempDirs: string[] = [];
+const childProcesses: Array<{ kill: () => void }> = [];
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function nextPort(): number {
+  return 49152 + Math.floor(Math.random() * 1000);
+}
+
+async function waitForHealth(baseUrl: string): Promise<void> {
+  for (let i = 0; i < 60; i++) {
+    try {
+      const res = await fetch(`${baseUrl}/api/health`);
+      if (res.ok) return;
+    } catch { /* still booting */ }
+    await Bun.sleep(250);
+  }
+  throw new Error(`server did not become healthy: ${baseUrl}`);
+}
+
+async function readStdoutLine(
+  stdout: ReadableStream<Uint8Array>,
+  timeoutMs: number,
+): Promise<string> {
+  const reader = stdout.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let timer: Timer | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error("timed out waiting for stdout JSON-RPC")), timeoutMs);
+  });
+
+  try {
+    while (true) {
+      const { value, done } = await Promise.race([reader.read(), timeout]);
+      if (done) throw new Error("stdout closed before JSON-RPC response");
+      buffer += decoder.decode(value);
+      const newline = buffer.indexOf("\n");
+      if (newline !== -1) return buffer.slice(0, newline);
+    }
+  } finally {
+    if (timer) clearTimeout(timer);
+    reader.releaseLock();
+  }
+}
+
+afterEach(async () => {
+  for (const proc of childProcesses.splice(0)) proc.kill();
+  for (const dir of tempDirs.splice(0)) {
+    if (existsSync(dir)) rmSync(dir, { recursive: true });
+  }
+});
+
+test("arra-oracle mcp emits JSON-RPC on stdout and logs on stderr", async () => {
+  const port = nextPort();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const dataDir = tempDir("arra-oracle-mcp-dispatch-");
+  const proc = Bun.spawn(["bun", binEntry, "mcp", "--read-only"], {
+    cwd: repoRoot,
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      ORACLE_API: baseUrl,
+      ORACLE_PORT: String(port),
+      ORACLE_DATA_DIR: dataDir,
+      ORACLE_DB_PATH: join(dataDir, "oracle.db"),
+      ORACLE_INDEXER_ENQUEUE: "0",
+    },
+  });
+  childProcesses.push(proc);
+  const stderrText = new Response(proc.stderr).text();
+
+  proc.stdin.write(JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "arra-oracle-dispatch-test", version: "0.0.0" },
+    },
+  }) + "\n");
+
+  const line = await readStdoutLine(proc.stdout, 10_000);
+  const response = JSON.parse(line) as { id?: number; result?: unknown };
+  expect(response.id).toBe(1);
+  expect(response.result).toBeDefined();
+  expect(line).not.toContain("Arra Oracle MCP Server running");
+
+  await expect(fetch(`${baseUrl}/api/health`)).rejects.toThrow();
+  proc.kill();
+  await proc.exited;
+
+  const stderr = await stderrText;
+  expect(stderr).toContain("Arra Oracle MCP Server running on stdio");
+  expect(stderr).not.toContain("Arra Oracle HTTP server");
+});
+
+test("arra-oracle without a subcommand defaults to HTTP serve", async () => {
+  const port = nextPort();
+  const dataDir = tempDir("arra-oracle-serve-dispatch-");
+  const repoDir = tempDir("arra-oracle-serve-repo-");
+  const proc = Bun.spawn(["bun", binEntry, "--port", String(port)], {
+    cwd: repoRoot,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      ORACLE_DATA_DIR: dataDir,
+      ORACLE_DB_PATH: join(dataDir, "oracle.db"),
+      ORACLE_REPO_ROOT: repoDir,
+      ORACLE_INDEXER_ENQUEUE: "0",
+    },
+  });
+  childProcesses.push(proc);
+  const stdoutText = new Response(proc.stdout).text();
+  const stderrText = new Response(proc.stderr).text();
+
+  await waitForHealth(`http://127.0.0.1:${port}`);
+  proc.kill();
+  await proc.exited;
+
+  expect(await stdoutText).toContain(`Arra Oracle HTTP server → http://localhost:${port}`);
+  expect(await stderrText).not.toContain("Arra Oracle MCP Server running");
+});


### PR DESCRIPTION
## Summary
- Add `arra-oracle mcp` dispatch that lazy-imports `src/index.ts` and redirects incidental `console.log` output to stderr before import.
- Keep no-arg/default and `serve` paths on the existing HTTP server wrapper.
- Add focused subprocess tests for MCP stdout JSON-RPC cleanliness and no-arg HTTP default.

## Verification
- `bun run build`
- `bun run test:unit` (276 pass)
- `bun test tests/bin/arra-oracle-dispatch.test.ts` (2 pass)
- Manual smoke: `bun bin/arra.ts serve --port 49666` + `/api/health` OK

Refs #1275.

🤖 ตอบโดย arra-oracle-v3 จาก Nat → arra-oracle-v3-oracle
