### PR TITLE
feat(server): mount plugin API routes from manifest

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,9 +1,8 @@
 /**
  * Arra Oracle HTTP Server — Elysia (bun-native).
  *
- * Composes built-in server plugins from src/server/plugin/. Phase 1 keeps
- * behavior unchanged while moving hardcoded route/lifecycle registration
- * behind a plugin-loader seam.
+ * Composes built-in server plugins from src/server/plugin/. The loader owns
+ * route mounting, manifest API prefixes, and lifecycle startup/shutdown.
  */
 
 import { Elysia } from 'elysia';
@@ -195,7 +194,7 @@ try {
   console.error('⚠️  Menu seeder failed:', e);
 }
 
-for (const mod of serverPluginRoutes(enabledPlugins)) app.use(mod as any);
+for (const mod of serverPluginRoutes(enabledPlugins, { warn: console.warn })) app.use(mod as any);
 await startServerPlugins(enabledPlugins);
 
 console.log(`

--- a/src/server/__tests__/server-plugin-loader.test.ts
+++ b/src/server/__tests__/server-plugin-loader.test.ts
@@ -32,6 +32,13 @@ async function appWithConfig(disabledPlugins: string[], enabledPlugins: string[]
   return { app, enabled };
 }
 
+function appFromPlugins(plugins: ServerPlugin[], warn?: (message: string) => void) {
+  const enabled = enabledServerPlugins(loadServerPlugins(plugins, { enabledPlugins: ['*'] }));
+  const app = new Elysia();
+  for (const routes of serverPluginRoutes(enabled, { warn })) app.use(routes as any);
+  return { app, enabled };
+}
+
 function withEnv(key: string, value: string | undefined, fn: () => void) {
   const prev = process.env[key];
   if (value === undefined) delete process.env[key];
@@ -102,6 +109,43 @@ describe('server plugin loader', () => {
     expect(conflicted.enabled.some((plugin) => plugin.name === 'federation')).toBe(false);
     expect((await conflicted.app.handle(new Request('http://local/info'))).status).toBe(404);
     expect((await conflicted.app.handle(new Request('http://local/api/health'))).status).toBe(200);
+  });
+
+  test('api manifest mounts a built-in example plugin under its declared path', async () => {
+    const { app, enabled } = await appWithConfig([], ['plugin-api-example']);
+    expect(enabled.some((plugin) => plugin.name === 'plugin-api-example')).toBe(true);
+
+    const response = await app.handle(new Request('http://local/api/plugin-example'));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ok: true,
+      plugin: 'plugin-api-example',
+      mountedBy: 'server-plugin-api-manifest',
+    });
+  });
+
+  test('direct route wins over api manifest route collision', async () => {
+    const warnings: string[] = [];
+    const { app } = appFromPlugins([
+      {
+        name: 'direct-conflict',
+        tier: 'standard',
+        routes: () => new Elysia().get('/api/plugin-conflict', () => ({ source: 'direct' })),
+      },
+      {
+        name: 'manifest-conflict',
+        tier: 'extra',
+        enabled: false,
+        api: { path: '/api/plugin-conflict', methods: ['GET'] },
+        routes: () => new Elysia().get('/', () => ({ source: 'manifest' })),
+      },
+    ], (message) => warnings.push(message));
+
+    const response = await app.handle(new Request('http://local/api/plugin-conflict'));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ source: 'direct' });
+    expect(warnings.some((message) => message.includes('direct route wins'))).toBe(true);
+    expect(warnings.some((message) => message.includes('manifest-conflict'))).toBe(true);
   });
 
   test('disable everything still serves core search, learn, and stats over FTS5', async () => {

--- a/src/server/plugin/builtin.ts
+++ b/src/server/plugin/builtin.ts
@@ -1,3 +1,5 @@
+import { Elysia } from 'elysia';
+
 import type { ServerPlugin } from './types.ts';
 
 import { authRoutes } from '../../routes/auth/index.ts';
@@ -48,6 +50,21 @@ async function optionalIndexerPlugin(): Promise<ServerPlugin | null> {
   }
 }
 
+export function createApiManifestExamplePlugin(): ServerPlugin {
+  return {
+    name: 'plugin-api-example',
+    tier: 'extra',
+    enabled: false,
+    seedMenu: false,
+    api: { path: '/api/plugin-example', methods: ['GET'] },
+    routes: () => new Elysia().get('/', () => ({
+      ok: true,
+      plugin: 'plugin-api-example',
+      mountedBy: 'server-plugin-api-manifest',
+    })),
+  };
+}
+
 export async function createBuiltinServerPlugins(options: BuiltinOptions): Promise<ServerPlugin[]> {
   const gatewayRoutes = gatewayPlugin(options.dataDir, options.vectorUrl);
   const menuRoutes = createMenuRoutes();
@@ -56,6 +73,7 @@ export async function createBuiltinServerPlugins(options: BuiltinOptions): Promi
 
   const plugins: Array<ServerPlugin | null> = [
     routePlugin('gateway', 'standard', () => gatewayRoutes, false),
+    createApiManifestExamplePlugin(),
     {
       name: 'federation',
       tier: 'standard',

--- a/src/server/plugin/loader.ts
+++ b/src/server/plugin/loader.ts
@@ -1,5 +1,13 @@
+import { Elysia } from 'elysia';
+
 import { parseDisabledPlugins, parseEnabledPlugins, validateServerPlugin } from './manifest.ts';
-import type { ElysiaApp, LoadedServerPlugin, LoadServerPluginsOptions, ServerPlugin } from './types.ts';
+import type {
+  ElysiaApp,
+  LoadedServerPlugin,
+  LoadServerPluginsOptions,
+  ServerPlugin,
+  ServerPluginRoutesOptions,
+} from './types.ts';
 
 export function disabledPluginsFromEnv(): string[] {
   const disabled = parseDisabledPlugins(process.env.ORACLE_DISABLED_PLUGINS ?? process.env.ARRA_DISABLED_PLUGINS);
@@ -45,12 +53,109 @@ export function enabledServerPlugins(loaded: LoadedServerPlugin[]): ServerPlugin
   return loaded.filter((entry) => !entry.disabled).map((entry) => entry.plugin);
 }
 
-export function serverPluginRoutes(plugins: ServerPlugin[]): ElysiaApp[] {
-  return plugins.flatMap((plugin) => {
-    const routes = plugin.routes?.();
-    if (!routes) return [];
-    return Array.isArray(routes) ? routes : [routes];
-  });
+interface PluginRouteApps {
+  plugin: ServerPlugin;
+  routes: ElysiaApp[];
+}
+
+interface RouteSignature {
+  method: string;
+  path: string;
+}
+
+function routeApps(plugin: ServerPlugin): ElysiaApp[] {
+  const routes = plugin.routes?.();
+  if (!routes) return [];
+  return Array.isArray(routes) ? routes : [routes];
+}
+
+function normalizePath(path: string): string {
+  const withSlash = path.startsWith('/') ? path : `/${path}`;
+  const withoutTrailing = withSlash.replace(/\/+$/, '');
+  return withoutTrailing || '/';
+}
+
+function joinPaths(prefix: string, path: string): string {
+  const base = normalizePath(prefix);
+  const child = normalizePath(path);
+  if (child === '/') return base;
+  if (base === '/') return child;
+  return `${base}${child}`;
+}
+
+function routeSignatures(routes: ElysiaApp[], prefix = '', fallbackMethods: string[] = []): RouteSignature[] {
+  const signatures: RouteSignature[] = [];
+  for (const app of routes as Array<ElysiaApp & { routes?: Array<{ method?: string; path?: string }> }>) {
+    for (const route of app.routes ?? []) {
+      const path = joinPaths(prefix, route.path ?? '/');
+      const method = route.method?.toUpperCase();
+      if (method) {
+        signatures.push({ method, path });
+        continue;
+      }
+      for (const fallback of fallbackMethods) signatures.push({ method: fallback.toUpperCase(), path });
+    }
+  }
+  if (signatures.length === 0 && prefix && fallbackMethods.length > 0) {
+    for (const fallback of fallbackMethods) {
+      signatures.push({ method: fallback.toUpperCase(), path: normalizePath(prefix) });
+    }
+  }
+  return signatures;
+}
+
+function routeSignatureKey(signature: RouteSignature): string {
+  return `${signature.method} ${signature.path}`;
+}
+
+function manifestMountedRoutes(plugin: ServerPlugin, routes: ElysiaApp[]): ElysiaApp[] {
+  const api = plugin.api;
+  if (!api) return routes;
+  return routes.map((route) => new Elysia().group(api.path, (app) => app.use(route as any)));
+}
+
+export function serverPluginRoutes(
+  plugins: ServerPlugin[],
+  options: ServerPluginRoutesOptions = {},
+): ElysiaApp[] {
+  const entries: PluginRouteApps[] = plugins.map((plugin) => ({ plugin, routes: routeApps(plugin) }));
+  const directSignatures = new Set(
+    entries
+      .filter((entry) => !entry.plugin.api)
+      .flatMap((entry) => routeSignatures(entry.routes))
+      .map(routeSignatureKey),
+  );
+  const claimedSignatures = new Set(directSignatures);
+  const mounted: ElysiaApp[] = [];
+
+  for (const { plugin, routes } of entries) {
+    if (routes.length === 0) continue;
+    if (!plugin.api) {
+      mounted.push(...routes);
+      continue;
+    }
+
+    const fallbackMethods = plugin.api.methods ?? [];
+    const signatures = routeSignatures(routes, plugin.api.path, fallbackMethods);
+    const directCollision = signatures.find((signature) => directSignatures.has(routeSignatureKey(signature)));
+    if (directCollision) {
+      options.warn?.(
+        `[server-plugin] skipped api mount for "${plugin.name}" at ${routeSignatureKey(directCollision)}: direct route wins`,
+      );
+      continue;
+    }
+    const claimedCollision = signatures.find((signature) => claimedSignatures.has(routeSignatureKey(signature)));
+    if (claimedCollision) {
+      options.warn?.(
+        `[server-plugin] skipped api mount for "${plugin.name}" at ${routeSignatureKey(claimedCollision)}: route already mounted`,
+      );
+      continue;
+    }
+    for (const signature of signatures) claimedSignatures.add(routeSignatureKey(signature));
+    mounted.push(...manifestMountedRoutes(plugin, routes));
+  }
+
+  return mounted;
 }
 
 export function menuSeedRoutes(plugins: ServerPlugin[]): ElysiaApp[] {

--- a/src/server/plugin/manifest.ts
+++ b/src/server/plugin/manifest.ts
@@ -1,6 +1,7 @@
 import type { ServerPlugin } from './types.ts';
 
 const TIERS = new Set(['core', 'standard', 'extra']);
+const HTTP_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'HEAD', 'ALL']);
 
 export function validateServerPlugin(plugin: ServerPlugin): void {
   if (!plugin.name || !/^[a-z0-9-]+$/.test(plugin.name)) {
@@ -8,6 +9,16 @@ export function validateServerPlugin(plugin: ServerPlugin): void {
   }
   if (!TIERS.has(plugin.tier)) {
     throw new Error(`server plugin "${plugin.name}" has invalid tier: ${JSON.stringify(plugin.tier)}`);
+  }
+  if (plugin.api) {
+    if (!plugin.api.path || typeof plugin.api.path !== 'string' || !plugin.api.path.startsWith('/')) {
+      throw new Error(`server plugin "${plugin.name}" api.path must be an absolute path`);
+    }
+    for (const method of plugin.api.methods ?? []) {
+      if (typeof method !== 'string' || !HTTP_METHODS.has(method.toUpperCase())) {
+        throw new Error(`server plugin "${plugin.name}" api.methods contains invalid method: ${JSON.stringify(method)}`);
+      }
+    }
   }
 }
 

--- a/src/server/plugin/types.ts
+++ b/src/server/plugin/types.ts
@@ -3,11 +3,21 @@ import type { Elysia } from 'elysia';
 export type ServerPluginTier = 'core' | 'standard' | 'extra';
 export type ElysiaApp = Elysia<any, any, any, any, any, any, any>;
 
+export interface ServerPluginApiManifest {
+  /**
+   * Prefix where this plugin's relative Elysia routes should be mounted.
+   * Example: api.path "/api/example" + route "/" => "/api/example".
+   */
+  path: string;
+  methods?: string[];
+}
+
 export interface ServerPlugin {
   name: string;
   tier: ServerPluginTier;
   enabled?: boolean;
   seedMenu?: boolean;
+  api?: ServerPluginApiManifest;
   routes?: () => ElysiaApp | ElysiaApp[];
   start?: () => void | Promise<void>;
   stop?: () => void | Promise<void>;
@@ -21,4 +31,8 @@ export interface LoadedServerPlugin {
 export interface LoadServerPluginsOptions {
   disabledPlugins?: string[];
   enabledPlugins?: string[];
+}
+
+export interface ServerPluginRoutesOptions {
+  warn?: (message: string) => void;
 }


### PR DESCRIPTION
Refs #1278 (Phase 2).

Adds the HTTP-route manifest seam to the server plugin loader:
- `api: { path, methods }` on a server plugin mounts its Elysia routes under the declared prefix.
- Direct routes win on collision; manifest-mounted routes are skipped with a warning instead of shadowing built-ins.
- Adds an opt-in built-in example plugin (`plugin-api-example`) that proves manifest API mounting without changing default behavior.
- Keeps this PR scoped to `src/server` + server plugin loader; no CLI/bin changes.

Verification:
- `bun test --isolate src/server/__tests__/server-plugin-loader.test.ts` -> 9 pass
- `bun run build` -> exit 0
- `bun run test:unit` -> 278 pass
- HTTP smoke with `ORACLE_ENABLED_PLUGINS=plugin-api-example`: `/api/plugin-example` -> 200; `/info` -> 404 (federation remains opt-in)

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3