### PR TITLE
feat(cli): resolve API targets from layered config

### DIFF
--- a/cli/src/lib/api.ts
+++ b/cli/src/lib/api.ts
@@ -1,26 +1,29 @@
 /**
  * ARRA Oracle HTTP API helper for arra-cli plugins.
  *
- * Reads ORACLE_API env, then legacy NEO_ARRA_API
- * (default http://localhost:47778).
- * Note: issue #770 spec listed 3457 — real oracle default is 47778 (ORACLE_DEFAULT_PORT).
- * Override: ORACLE_API=http://localhost:47778 arra-cli <cmd>
+ * Resolves in priority order:
+ * ORACLE_API env → --at <target> → project .arra config → global
+ * ~/.config/arra config → legacy NEO_ARRA_API → localhost default.
+ * Note: issue #770 spec listed 3457 — real oracle default is 47778.
  */
 
+import { resolveOracleApi } from "./config.ts";
+
 export function oracleApiBase(): string {
-  return (process.env.ORACLE_API ?? process.env.NEO_ARRA_API ?? "http://localhost:47778").replace(/\/$/, "");
+  return resolveOracleApi().baseUrl;
 }
 
 export const BASE_URL = oracleApiBase();
 
 export async function apiFetch(path: string, opts?: RequestInit): Promise<Response> {
-  const url = `${BASE_URL}${path}`;
+  const baseUrl = oracleApiBase();
+  const url = `${baseUrl}${path}`;
   try {
     return await fetch(url, opts);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     throw new Error(
-      `Cannot reach ARRA Oracle at ${BASE_URL}\n` +
+      `Cannot reach ARRA Oracle at ${baseUrl}\n` +
       `  → Is the server running? Try: bun run server  (in arra-oracle-v3 repo)\n` +
       `  → Override with ORACLE_API=http://localhost:<port>\n` +
       `  Original: ${msg}`

--- a/cli/src/lib/config.ts
+++ b/cli/src/lib/config.ts
@@ -1,0 +1,99 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, parse } from "node:path";
+
+export const DEFAULT_ORACLE_API = "http://localhost:47778";
+
+export type ArraConfig = { default?: string; targets?: Record<string, string> };
+type LoadedConfig = { path: string; config: ArraConfig };
+type Source = "ORACLE_API" | "at" | "project" | "global" | "NEO_ARRA_API" | "default";
+
+export function normalizeApiBase(value: string): string {
+  return value.trim().replace(/\/+$/, "");
+}
+
+export function parseAtFlag(argv = process.argv.slice(2)): string | undefined {
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--at") return argv[i + 1];
+    if (argv[i].startsWith("--at=")) return argv[i].slice(5);
+  }
+}
+
+function readConfig(path: string): LoadedConfig | null {
+  if (!existsSync(path)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(path, "utf8"));
+    const srcTargets = raw?.targets;
+    if (!srcTargets || typeof srcTargets !== "object" || Array.isArray(srcTargets)) return null;
+    const targets: Record<string, string> = {};
+    for (const [name, url] of Object.entries(srcTargets)) {
+      if (typeof url === "string" && url.trim()) targets[name] = normalizeApiBase(url);
+    }
+    return { path, config: { default: typeof raw.default === "string" ? raw.default : undefined, targets } };
+  } catch {
+    return null;
+  }
+}
+
+function configPaths(dir: string): string[] {
+  return [join(dir, "config.json"), join(dir, "targets.json")];
+}
+
+function firstConfig(paths: string[]): LoadedConfig | null {
+  for (const path of paths) {
+    const found = readConfig(path);
+    if (found) return found;
+  }
+  return null;
+}
+
+function findProjectConfig(startDir = process.cwd()): LoadedConfig | null {
+  let dir = startDir;
+  const root = parse(dir).root;
+  while (true) {
+    const found = firstConfig(configPaths(join(dir, ".arra")));
+    if (found || dir === root) return found;
+    dir = dirname(dir);
+  }
+}
+
+function globalConfigDir(env = process.env): string {
+  const xdg = env.XDG_CONFIG_HOME?.trim();
+  return xdg ? join(xdg, "arra") : join(env.HOME ?? homedir(), ".config", "arra");
+}
+
+export function globalConfigPathForWrite(env = process.env): string {
+  return join(globalConfigDir(env), "config.json");
+}
+
+function findGlobalConfig(env = process.env): LoadedConfig | null {
+  return firstConfig(configPaths(globalConfigDir(env)));
+}
+
+function targetFrom(loaded: LoadedConfig | null, name: string | undefined, source: Source) {
+  if (!loaded || !name) return null;
+  const baseUrl = loaded.config.targets?.[name];
+  return baseUrl ? { baseUrl, source, target: name, path: loaded.path } : null;
+}
+
+function defaultFrom(loaded: LoadedConfig | null, source: "project" | "global") {
+  return targetFrom(loaded, loaded?.config.default, source);
+}
+
+export function resolveOracleApi(argv = process.argv.slice(2), env = process.env) {
+  if (env.ORACLE_API !== undefined) return { baseUrl: normalizeApiBase(env.ORACLE_API), source: "ORACLE_API" as const };
+
+  const project = findProjectConfig();
+  const global = findGlobalConfig(env);
+  const atTarget = parseAtFlag(argv);
+  const at = targetFrom(project, atTarget, "at") ?? targetFrom(global, atTarget, "at");
+  if (at) return at;
+  if (atTarget) throw new Error(`Unknown arra target '${atTarget}' in project/global config`);
+
+  const projectDefault = defaultFrom(project, "project");
+  if (projectDefault) return projectDefault;
+  const globalDefault = defaultFrom(global, "global");
+  if (globalDefault) return globalDefault;
+  if (env.NEO_ARRA_API !== undefined) return { baseUrl: normalizeApiBase(env.NEO_ARRA_API), source: "NEO_ARRA_API" as const };
+  return { baseUrl: DEFAULT_ORACLE_API, source: "default" as const };
+}

--- a/tests/cli/config/api-resolution.test.ts
+++ b/tests/cli/config/api-resolution.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { oracleApiBase } from "../../../cli/src/lib/api.ts";
+import { globalConfigPathForWrite } from "../../../cli/src/lib/config.ts";
+
+const env0 = { ...process.env };
+const argv0 = [...process.argv];
+const cwd0 = process.cwd();
+const tempDirs: string[] = [];
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function resetEnv(): void {
+  for (const key of Object.keys(process.env)) delete process.env[key];
+  Object.assign(process.env, env0);
+  delete process.env.ORACLE_API;
+  delete process.env.NEO_ARRA_API;
+  delete process.env.XDG_CONFIG_HOME;
+}
+
+function config(path: string, targets: Record<string, string>, def = "local"): void {
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, JSON.stringify({ default: def, targets }, null, 2));
+}
+
+function projectConfig(root: string, targets: Record<string, string>, def = "local"): void {
+  config(join(root, ".arra", "config.json"), targets, def);
+}
+
+function globalConfig(home: string, targets: Record<string, string>, def = "local"): void {
+  process.env.XDG_CONFIG_HOME = home;
+  config(globalConfigPathForWrite(), targets, def);
+}
+
+beforeEach(() => {
+  resetEnv();
+  process.argv = ["bun", "arra-cli", "health"];
+});
+
+afterEach(() => {
+  process.chdir(cwd0);
+  process.argv = [...argv0];
+  resetEnv();
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true });
+});
+
+test("ORACLE_API env wins over --at, project, and global config", () => {
+  const project = tempDir("arra-project-");
+  projectConfig(project, { local: "http://project.local:47778", m5: "http://project-m5.local:47778" });
+  globalConfig(tempDir("arra-global-"), { local: "http://global.local:47778", m5: "http://global-m5.local:47778" });
+  process.chdir(project);
+  process.argv = ["bun", "arra-cli", "health", "--at", "m5"];
+  process.env.ORACLE_API = "http://env.local:47778/";
+  expect(oracleApiBase()).toBe("http://env.local:47778");
+});
+
+test("--at target wins over project default", () => {
+  const project = tempDir("arra-project-");
+  projectConfig(project, { local: "http://project-default.local:47778", m5: "http://project-m5.local:47778" });
+  process.chdir(project);
+  process.argv = ["bun", "arra-cli", "health", "--at", "m5"];
+  expect(oracleApiBase()).toBe("http://project-m5.local:47778");
+});
+
+test("project .arra/config.json default wins over global config and legacy env", () => {
+  const project = tempDir("arra-project-");
+  const child = join(project, "nested", "cwd");
+  mkdirSync(child, { recursive: true });
+  projectConfig(project, { local: "http://project.local:47778" });
+  globalConfig(tempDir("arra-global-"), { local: "http://global.local:47778" });
+  process.env.NEO_ARRA_API = "http://legacy.local:47778";
+  process.chdir(child);
+  expect(oracleApiBase()).toBe("http://project.local:47778");
+});
+
+test("global config default wins over legacy env", () => {
+  globalConfig(tempDir("arra-global-"), { m5: "http://m5.local:47778" }, "m5");
+  process.env.NEO_ARRA_API = "http://legacy.local:47778";
+  expect(oracleApiBase()).toBe("http://m5.local:47778");
+});
+
+test("global targets.json is supported for shell prototype interop", () => {
+  const home = tempDir("arra-global-");
+  process.env.XDG_CONFIG_HOME = home;
+  config(join(home, "arra", "targets.json"), { local: "http://localhost:47778", docker: "http://localhost:47780/" }, "docker");
+  expect(oracleApiBase()).toBe("http://localhost:47780");
+});
+
+test("legacy NEO_ARRA_API wins when no config exists", () => {
+  process.env.XDG_CONFIG_HOME = tempDir("arra-empty-global-");
+  process.env.NEO_ARRA_API = "http://legacy.local:47778/";
+  expect(oracleApiBase()).toBe("http://legacy.local:47778");
+});
+
+test("missing config falls back cleanly to localhost default", () => {
+  process.env.XDG_CONFIG_HOME = tempDir("arra-empty-global-");
+  expect(oracleApiBase()).toBe("http://localhost:47778");
+});


### PR DESCRIPTION
## Summary
- Add layered `arra-cli` API target resolution: `ORACLE_API` → `--at <name>` → project `.arra` default → global `~/.config/arra`/XDG default → `NEO_ARRA_API` → localhost.
- Add a small config reader that supports both `config.json` and the shell-prototype `targets.json`, with `config.json` as the write target for Phase 4.
- Keep API fetches resolving at call time so config/env changes are reflected without plugin reload assumptions.

## Verification
- `bun run build`
- `bun run test:unit` (278 pass)
- `bun test tests/cli/config/api-resolution.test.ts` (7 pass)
- Smoke: temp XDG `targets.json` + `arra-cli health --at m5` resolved to the configured URL (`http://127.0.0.1:9`)

Note: `bunx tsc -p cli/tsconfig.json --noEmit` still fails on pre-existing CLI tsconfig issues (`allowImportingTsExtensions` absent and older test type errors); not introduced by this PR.

Refs #1275.

🤖 ตอบโดย arra-oracle-v3 จาก Nat → arra-oracle-v3-oracle
