### PR TITLE
feat(server): make plugin lifecycle startup and shutdown explicit

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -31,9 +31,9 @@ import {
   menuSeedRoutes,
   serverPluginRoutes,
   startServerPlugins,
-  stopServerPlugins,
 } from './server/plugin/loader.ts';
 import { registerServerPlugins } from './server/plugin/registry.ts';
+import type { StartedServerPlugins } from './server/plugin/types.ts';
 
 import pkg from '../package.json' with { type: 'json' };
 
@@ -69,10 +69,15 @@ const loadedPlugins = loadServerPlugins(builtInPlugins, {
 });
 const enabledPlugins = enabledServerPlugins(loadedPlugins);
 registerServerPlugins(loadedPlugins);
+let pluginLifecycle: StartedServerPlugins | null = null;
 
 registerSignalHandlers(async () => {
   console.log('\n🔮 Shutting down gracefully...');
-  await stopServerPlugins(enabledPlugins);
+  try {
+    await pluginLifecycle?.stop();
+  } catch (error) {
+    console.warn('[server-plugin] lifecycle stop failed:', error);
+  }
   await performGracefulShutdown({
     resources: [{ close: () => { closeDb(); return Promise.resolve(); } }],
   });
@@ -195,7 +200,11 @@ try {
 }
 
 for (const mod of serverPluginRoutes(enabledPlugins, { warn: console.warn })) app.use(mod as any);
-await startServerPlugins(enabledPlugins);
+pluginLifecycle = await startServerPlugins(enabledPlugins, {
+  dataDir: ORACLE_DATA_DIR,
+  vectorUrl: VECTOR_URL || undefined,
+  logger: console,
+});
 
 console.log(`
 🔮 Arra Oracle HTTP Server running! (Elysia)

--- a/src/server/__tests__/server-plugin-loader.test.ts
+++ b/src/server/__tests__/server-plugin-loader.test.ts
@@ -10,6 +10,7 @@ import {
   enabledServerPlugins,
   loadServerPlugins,
   serverPluginRoutes,
+  startServerPlugins,
 } from '../plugin/loader.ts';
 import type { ServerPlugin } from '../plugin/types.ts';
 
@@ -50,6 +51,16 @@ function withEnv(key: string, value: string | undefined, fn: () => void) {
     else process.env[key] = prev;
   }
 }
+
+const testLifecycleOptions = {
+  dataDir: tmp,
+  vectorUrl: 'http://vector.local',
+  logger: {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  },
+};
 
 afterAll(async () => {
   const { closeDb } = await import('../../db/index.ts');
@@ -146,6 +157,73 @@ describe('server plugin loader', () => {
     expect(await response.json()).toEqual({ source: 'direct' });
     expect(warnings.some((message) => message.includes('direct route wins'))).toBe(true);
     expect(warnings.some((message) => message.includes('manifest-conflict'))).toBe(true);
+  });
+
+  test('lifecycle starts plugins in order and stops them in reverse', async () => {
+    const events: string[] = [];
+    const plugins: ServerPlugin[] = [
+      {
+        name: 'worker-a',
+        tier: 'standard',
+        start: (context) => {
+          events.push(`start:a:${context.dataDir}:${context.vectorUrl}:${context.signal.aborted}`);
+        },
+        stop: (context) => {
+          events.push(`stop:a:${context.signal.aborted}`);
+        },
+      },
+      {
+        name: 'worker-b',
+        tier: 'standard',
+        start: () => {
+          events.push('start:b');
+        },
+        stop: () => {
+          events.push('stop:b');
+        },
+      },
+    ];
+
+    const lifecycle = await startServerPlugins(plugins, testLifecycleOptions);
+    expect(lifecycle.plugins.map((plugin) => plugin.name)).toEqual(['worker-a', 'worker-b']);
+    expect(events).toEqual([`start:a:${tmp}:http://vector.local:false`, 'start:b']);
+
+    await lifecycle.stop();
+    await lifecycle.stop();
+    expect(events).toEqual([`start:a:${tmp}:http://vector.local:false`, 'start:b', 'stop:b', 'stop:a:true']);
+  });
+
+  test('lifecycle rolls back already-started plugins when a later start fails', async () => {
+    const events: string[] = [];
+    let signal: AbortSignal | null = null;
+    const plugins: ServerPlugin[] = [
+      {
+        name: 'started-worker',
+        tier: 'standard',
+        start: (context) => {
+          signal = context.signal;
+          events.push('start:started');
+        },
+        stop: (context) => {
+          events.push(`stop:started:${context.signal.aborted}`);
+        },
+      },
+      {
+        name: 'broken-worker',
+        tier: 'standard',
+        start: () => {
+          events.push('start:broken');
+          throw new Error('boom');
+        },
+        stop: () => {
+          events.push('stop:broken');
+        },
+      },
+    ];
+
+    await expect(startServerPlugins(plugins, testLifecycleOptions)).rejects.toThrow('boom');
+    expect(signal?.aborted).toBe(true);
+    expect(events).toEqual(['start:started', 'start:broken', 'stop:started:true']);
   });
 
   test('disable everything still serves core search, learn, and stats over FTS5', async () => {

--- a/src/server/plugin/loader.ts
+++ b/src/server/plugin/loader.ts
@@ -6,7 +6,10 @@ import type {
   LoadedServerPlugin,
   LoadServerPluginsOptions,
   ServerPlugin,
+  ServerPluginLifecycleContext,
+  ServerPluginLifecycleOptions,
   ServerPluginRoutesOptions,
+  StartedServerPlugins,
 } from './types.ts';
 
 export function disabledPluginsFromEnv(): string[] {
@@ -162,10 +165,69 @@ export function menuSeedRoutes(plugins: ServerPlugin[]): ElysiaApp[] {
   return serverPluginRoutes(plugins.filter((plugin) => plugin.seedMenu));
 }
 
-export async function startServerPlugins(plugins: ServerPlugin[]): Promise<void> {
-  for (const plugin of plugins) await plugin.start?.();
+const defaultLogger = {
+  info: (...args: unknown[]) => console.info(...args),
+  warn: (...args: unknown[]) => console.warn(...args),
+  error: (...args: unknown[]) => console.error(...args),
+};
+
+function lifecycleContext(
+  abortController: AbortController,
+  options: ServerPluginLifecycleOptions,
+): ServerPluginLifecycleContext {
+  return {
+    dataDir: options.dataDir,
+    vectorUrl: options.vectorUrl,
+    signal: abortController.signal,
+    logger: options.logger ?? defaultLogger,
+  };
 }
 
-export async function stopServerPlugins(plugins: ServerPlugin[]): Promise<void> {
-  for (const plugin of [...plugins].reverse()) await plugin.stop?.();
+export async function startServerPlugins(
+  plugins: ServerPlugin[],
+  options: ServerPluginLifecycleOptions,
+): Promise<StartedServerPlugins> {
+  const abortController = options.abortController ?? new AbortController();
+  const context = lifecycleContext(abortController, options);
+  const started: ServerPlugin[] = [];
+  let stopped = false;
+
+  try {
+    for (const plugin of plugins) {
+      await plugin.start?.(context);
+      started.push(plugin);
+    }
+  } catch (error) {
+    abortController.abort(error);
+    await stopServerPlugins(started, context);
+    throw error;
+  }
+
+  return {
+    plugins: started,
+    context,
+    stop: async () => {
+      if (stopped) return;
+      stopped = true;
+      abortController.abort();
+      await stopServerPlugins(started, context);
+    },
+  };
+}
+
+export async function stopServerPlugins(
+  plugins: ServerPlugin[],
+  context: ServerPluginLifecycleContext,
+): Promise<void> {
+  const errors: Error[] = [];
+  for (const plugin of [...plugins].reverse()) {
+    try {
+      await plugin.stop?.(context);
+    } catch (error) {
+      const cause = error instanceof Error ? error : new Error(String(error));
+      errors.push(new Error(`server plugin "${plugin.name}" stop failed: ${cause.message}`, { cause }));
+    }
+  }
+  if (errors.length === 1) throw errors[0];
+  if (errors.length > 1) throw new AggregateError(errors, 'server plugin stop failures');
 }

--- a/src/server/plugin/manifest.ts
+++ b/src/server/plugin/manifest.ts
@@ -10,6 +10,12 @@ export function validateServerPlugin(plugin: ServerPlugin): void {
   if (!TIERS.has(plugin.tier)) {
     throw new Error(`server plugin "${plugin.name}" has invalid tier: ${JSON.stringify(plugin.tier)}`);
   }
+  if (plugin.start !== undefined && typeof plugin.start !== 'function') {
+    throw new Error(`server plugin "${plugin.name}" start must be a function`);
+  }
+  if (plugin.stop !== undefined && typeof plugin.stop !== 'function') {
+    throw new Error(`server plugin "${plugin.name}" stop must be a function`);
+  }
   if (plugin.api) {
     if (!plugin.api.path || typeof plugin.api.path !== 'string' || !plugin.api.path.startsWith('/')) {
       throw new Error(`server plugin "${plugin.name}" api.path must be an absolute path`);

--- a/src/server/plugin/types.ts
+++ b/src/server/plugin/types.ts
@@ -12,6 +12,19 @@ export interface ServerPluginApiManifest {
   methods?: string[];
 }
 
+export interface ServerPluginLogger {
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+}
+
+export interface ServerPluginLifecycleContext {
+  dataDir: string;
+  vectorUrl?: string;
+  signal: AbortSignal;
+  logger: ServerPluginLogger;
+}
+
 export interface ServerPlugin {
   name: string;
   tier: ServerPluginTier;
@@ -19,8 +32,8 @@ export interface ServerPlugin {
   seedMenu?: boolean;
   api?: ServerPluginApiManifest;
   routes?: () => ElysiaApp | ElysiaApp[];
-  start?: () => void | Promise<void>;
-  stop?: () => void | Promise<void>;
+  start?: (context: ServerPluginLifecycleContext) => void | Promise<void>;
+  stop?: (context: ServerPluginLifecycleContext) => void | Promise<void>;
 }
 
 export interface LoadedServerPlugin {
@@ -35,4 +48,17 @@ export interface LoadServerPluginsOptions {
 
 export interface ServerPluginRoutesOptions {
   warn?: (message: string) => void;
+}
+
+export interface ServerPluginLifecycleOptions {
+  dataDir: string;
+  vectorUrl?: string;
+  logger?: ServerPluginLogger;
+  abortController?: AbortController;
+}
+
+export interface StartedServerPlugins {
+  plugins: ServerPlugin[];
+  context: ServerPluginLifecycleContext;
+  stop: () => Promise<void>;
 }


### PR DESCRIPTION
Refs #1278 (Phase 3).

Adds an explicit server plugin lifecycle runtime:
- `start(context)` / `stop(context)` now receive `dataDir`, optional `vectorUrl`, logger, and an `AbortSignal`.
- Startup tracks successfully-started plugins and rolls them back in reverse order if a later plugin fails.
- Shutdown is idempotent, aborts the lifecycle signal, and stops plugins in reverse order.
- `server.ts` owns one lifecycle handle and uses it during graceful shutdown.
- Validates lifecycle hooks as functions at plugin load time.

This stays scoped to the server plugin seam; no CLI/bin changes.

Verification:
- `bun test --isolate src/server/__tests__/server-plugin-loader.test.ts` -> 11 pass
- `bun run build` -> exit 0
- `bun run test:unit` -> 280 pass
- HTTP smoke on spare port: `/api/health` -> 200; `/info` -> 404 with federation still default-off

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3