### PR TITLE
feat(cli): manage ARRA API targets

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -22,6 +22,8 @@ import {
 } from "./commands/menu-gist.ts";
 import { menuResetAll } from "./commands/menu-reset.ts";
 import { reindex } from "./commands/reindex.ts";
+import { configCommand } from "./commands/config.ts";
+import { stripAtFlag } from "./lib/config.ts";
 
 const pkg = await Bun.file(join(import.meta.dir, "../package.json")).json();
 const VERSION: string = pkg.version;
@@ -33,6 +35,7 @@ function printHelp(commands: Array<{ command: string; help?: string }>) {
   console.log(`  ${"plugin".padEnd(16)}manage plugins (install)`);
   console.log(`  ${"session".padEnd(16)}inspect sessions (list, show, context)`);
   console.log(`  ${"menu".padEnd(16)}inspect and customize studio menu (list, add, remove)`);
+  console.log(`  ${"config".padEnd(16)}show and manage API target config`);
   console.log(`  ${"reindex".padEnd(16)}trigger SQLite/FTS reindex via ORACLE_API`);
   for (const { command, help } of commands) {
     console.log(`  ${command.padEnd(16)}${help ?? ""}`);
@@ -41,6 +44,7 @@ function printHelp(commands: Array<{ command: string; help?: string }>) {
   console.log("  --help, -h        Show this help");
   console.log("  -h <command>      Show command help + flags");
   console.log("  --version         Show version");
+  console.log("  --at <name>       Use a configured API target for this invocation");
 }
 
 function printCommandHelp(plugin: LoadedPlugin) {
@@ -69,7 +73,7 @@ async function loadAll() {
 }
 
 async function main() {
-  const args = process.argv.slice(2);
+  const args = stripAtFlag(process.argv.slice(2));
   const cmd = args[0]?.toLowerCase();
 
   if (cmd === "--version" || cmd === "version") {
@@ -156,6 +160,10 @@ async function main() {
 
   if (cmd === "reindex") {
     process.exit(await reindex(args.slice(1)));
+  }
+
+  if (cmd === "config") {
+    process.exit(await configCommand(args.slice(1)));
   }
 
   if (cmd === "plugin") {

--- a/cli/src/commands/_output.ts
+++ b/cli/src/commands/_output.ts
@@ -1,8 +1,7 @@
 export function emit(data: unknown, args: string[]): void {
   const yaml = args.includes("--yml") || args.includes("--yaml");
   if (yaml) {
-    // @ts-expect-error Bun.YAML is available at runtime in Bun ≥1.1
-    const out = Bun.YAML.stringify(data);
+    const out = (Bun as any).YAML.stringify(data);
     process.stdout.write(out.endsWith("\n") ? out : out + "\n");
     return;
   }

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -1,0 +1,78 @@
+import {
+  addGlobalTarget, globalConfigPathForWrite, loadGlobalConfig, loadProjectConfig,
+  normalizeApiBase, resolveOracleApi, useGlobalTarget,
+} from "../lib/config.ts";
+
+function usage(): void {
+  console.log(`arra-cli config <subcommand>
+
+Subcommands:
+  show                 show resolved API target and configured targets
+  use <name>           set global default target
+  add <name> <url>     add or update a global target
+  path                 print global config file path
+
+Aliases: \`arra-cli config\` is \`arra-cli config show\`.`);
+}
+
+function sourceLabel(source: string): string {
+  return source === "ORACLE_API" ? "env" : source === "at" ? "--at" : source;
+}
+
+function knownTargets(): Record<string, string> {
+  return {
+    ...(loadGlobalConfig()?.config.targets ?? {}),
+    ...(loadProjectConfig()?.config.targets ?? {}),
+  };
+}
+
+function show(): number {
+  const resolved = resolveOracleApi();
+  const targets = knownTargets();
+  const active = resolved.target ?? Object.entries(targets)
+    .find(([, url]) => normalizeApiBase(url) === resolved.baseUrl)?.[0];
+  console.log(`Resolved: ${resolved.baseUrl}`);
+  console.log(`Source: ${sourceLabel(resolved.source)}`);
+  if (resolved.target) console.log(`Target: ${resolved.target}`);
+  if (resolved.path) console.log(`Config: ${resolved.path}`);
+  console.log("Targets:");
+  const names = Object.keys(targets).sort();
+  if (names.length === 0) console.log("  (none configured)");
+  for (const name of names) {
+    console.log(`${name === active ? "*" : " "} ${name.padEnd(12)} ${targets[name]}`);
+  }
+  return 0;
+}
+
+function arg(value: string | undefined, label: string): string {
+  if (!value) throw new Error(`missing ${label}`);
+  return value;
+}
+
+export async function configCommand(args: string[]): Promise<number> {
+  const sub = args[0]?.toLowerCase();
+  try {
+    if (!sub || sub === "show") return show();
+    if (sub === "path") return console.log(globalConfigPathForWrite()), 0;
+    if (sub === "add") {
+      const name = arg(args[1], "target name");
+      const url = arg(args[2], "target URL");
+      const loaded = addGlobalTarget(name, url);
+      console.log(`saved ${name} -> ${normalizeApiBase(url)}\nConfig: ${loaded.path}`);
+      return 0;
+    }
+    if (sub === "use") {
+      const name = arg(args[1], "target name");
+      const loaded = useGlobalTarget(name);
+      console.log(`default target: ${name}\nConfig: ${loaded.path}`);
+      return 0;
+    }
+    if (sub === "--help" || sub === "-h" || sub === "help") return usage(), 0;
+    console.error(`\x1b[31m✗\x1b[0m unknown config subcommand: ${args[0]}`);
+    usage();
+    return 1;
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+}

--- a/cli/src/commands/menu-reset.ts
+++ b/cli/src/commands/menu-reset.ts
@@ -3,11 +3,11 @@ import { emit } from "./_output.ts";
 
 async function confirm(prompt: string): Promise<boolean> {
   process.stdout.write(`${prompt} `);
-  for await (const chunk of Bun.stdin.stream()) {
-    const answer = new TextDecoder().decode(chunk).trim().toLowerCase();
-    return answer === "y" || answer === "yes";
-  }
-  return false;
+  const reader = Bun.stdin.stream().getReader();
+  const { value } = await reader.read();
+  reader.releaseLock();
+  const answer = new TextDecoder().decode(value).trim().toLowerCase();
+  return answer === "y" || answer === "yes";
 }
 
 export async function menuResetAll(args: string[]): Promise<number> {

--- a/cli/src/commands/plugins-remove.ts
+++ b/cli/src/commands/plugins-remove.ts
@@ -7,11 +7,11 @@ const ORACLE_PLUGIN_DIR = join(homedir(), ".oracle", "plugins");
 
 async function confirm(prompt: string): Promise<boolean> {
   process.stderr.write(prompt);
-  for await (const chunk of Bun.stdin.stream()) {
-    const input = new TextDecoder().decode(chunk).trim().toLowerCase();
-    return input === "y" || input === "yes";
-  }
-  return false;
+  const reader = Bun.stdin.stream().getReader();
+  const { value } = await reader.read();
+  reader.releaseLock();
+  const input = new TextDecoder().decode(value).trim().toLowerCase();
+  return input === "y" || input === "yes";
 }
 
 export async function pluginsRemove(args: string[]): Promise<number> {

--- a/cli/src/lib/config.ts
+++ b/cli/src/lib/config.ts
@@ -1,12 +1,19 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, parse } from "node:path";
 
 export const DEFAULT_ORACLE_API = "http://localhost:47778";
 
 export type ArraConfig = { default?: string; targets?: Record<string, string> };
-type LoadedConfig = { path: string; config: ArraConfig };
-type Source = "ORACLE_API" | "at" | "project" | "global" | "NEO_ARRA_API" | "default";
+export type LoadedConfig = { path: string; config: ArraConfig };
+export type OracleApiSource = "ORACLE_API" | "at" | "project" | "global" | "NEO_ARRA_API" | "default";
+
+export interface ResolvedOracleApi {
+  baseUrl: string;
+  source: OracleApiSource;
+  target?: string;
+  path?: string;
+}
 
 export function normalizeApiBase(value: string): string {
   return value.trim().replace(/\/+$/, "");
@@ -19,17 +26,34 @@ export function parseAtFlag(argv = process.argv.slice(2)): string | undefined {
   }
 }
 
-function readConfig(path: string): LoadedConfig | null {
+export function stripAtFlag(argv: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--at") {
+      i++;
+      continue;
+    }
+    if (argv[i].startsWith("--at=")) continue;
+    out.push(argv[i]);
+  }
+  return out;
+}
+
+function coerceConfig(raw: any): ArraConfig | null {
+  const srcTargets = raw?.targets;
+  if (!srcTargets || typeof srcTargets !== "object" || Array.isArray(srcTargets)) return null;
+  const targets: Record<string, string> = {};
+  for (const [name, url] of Object.entries(srcTargets)) {
+    if (typeof url === "string" && url.trim()) targets[name] = normalizeApiBase(url);
+  }
+  return { default: typeof raw.default === "string" ? raw.default : undefined, targets };
+}
+
+export function readArraConfig(path: string): LoadedConfig | null {
   if (!existsSync(path)) return null;
   try {
-    const raw = JSON.parse(readFileSync(path, "utf8"));
-    const srcTargets = raw?.targets;
-    if (!srcTargets || typeof srcTargets !== "object" || Array.isArray(srcTargets)) return null;
-    const targets: Record<string, string> = {};
-    for (const [name, url] of Object.entries(srcTargets)) {
-      if (typeof url === "string" && url.trim()) targets[name] = normalizeApiBase(url);
-    }
-    return { path, config: { default: typeof raw.default === "string" ? raw.default : undefined, targets } };
+    const config = coerceConfig(JSON.parse(readFileSync(path, "utf8")));
+    return config ? { path, config } : null;
   } catch {
     return null;
   }
@@ -41,13 +65,13 @@ function configPaths(dir: string): string[] {
 
 function firstConfig(paths: string[]): LoadedConfig | null {
   for (const path of paths) {
-    const found = readConfig(path);
+    const found = readArraConfig(path);
     if (found) return found;
   }
   return null;
 }
 
-function findProjectConfig(startDir = process.cwd()): LoadedConfig | null {
+export function loadProjectConfig(startDir = process.cwd()): LoadedConfig | null {
   let dir = startDir;
   const root = parse(dir).root;
   while (true) {
@@ -62,15 +86,20 @@ function globalConfigDir(env = process.env): string {
   return xdg ? join(xdg, "arra") : join(env.HOME ?? homedir(), ".config", "arra");
 }
 
-export function globalConfigPathForWrite(env = process.env): string {
-  return join(globalConfigDir(env), "config.json");
-}
-
-function findGlobalConfig(env = process.env): LoadedConfig | null {
+export function loadGlobalConfig(env = process.env): LoadedConfig | null {
   return firstConfig(configPaths(globalConfigDir(env)));
 }
 
-function targetFrom(loaded: LoadedConfig | null, name: string | undefined, source: Source) {
+export function globalConfigPathForWrite(env = process.env): string {
+  const dir = globalConfigDir(env);
+  const configJson = join(dir, "config.json");
+  const targetsJson = join(dir, "targets.json");
+  if (existsSync(configJson)) return configJson;
+  if (existsSync(targetsJson)) return targetsJson;
+  return configJson;
+}
+
+function targetFrom(loaded: LoadedConfig | null, name: string | undefined, source: OracleApiSource) {
   if (!loaded || !name) return null;
   const baseUrl = loaded.config.targets?.[name];
   return baseUrl ? { baseUrl, source, target: name, path: loaded.path } : null;
@@ -80,11 +109,11 @@ function defaultFrom(loaded: LoadedConfig | null, source: "project" | "global") 
   return targetFrom(loaded, loaded?.config.default, source);
 }
 
-export function resolveOracleApi(argv = process.argv.slice(2), env = process.env) {
-  if (env.ORACLE_API !== undefined) return { baseUrl: normalizeApiBase(env.ORACLE_API), source: "ORACLE_API" as const };
+export function resolveOracleApi(argv = process.argv.slice(2), env = process.env): ResolvedOracleApi {
+  if (env.ORACLE_API !== undefined) return { baseUrl: normalizeApiBase(env.ORACLE_API), source: "ORACLE_API" };
 
-  const project = findProjectConfig();
-  const global = findGlobalConfig(env);
+  const project = loadProjectConfig();
+  const global = loadGlobalConfig(env);
   const atTarget = parseAtFlag(argv);
   const at = targetFrom(project, atTarget, "at") ?? targetFrom(global, atTarget, "at");
   if (at) return at;
@@ -94,6 +123,37 @@ export function resolveOracleApi(argv = process.argv.slice(2), env = process.env
   if (projectDefault) return projectDefault;
   const globalDefault = defaultFrom(global, "global");
   if (globalDefault) return globalDefault;
-  if (env.NEO_ARRA_API !== undefined) return { baseUrl: normalizeApiBase(env.NEO_ARRA_API), source: "NEO_ARRA_API" as const };
-  return { baseUrl: DEFAULT_ORACLE_API, source: "default" as const };
+  if (env.NEO_ARRA_API !== undefined) return { baseUrl: normalizeApiBase(env.NEO_ARRA_API), source: "NEO_ARRA_API" };
+  return { baseUrl: DEFAULT_ORACLE_API, source: "default" };
+}
+
+function cleanConfig(config: ArraConfig): ArraConfig {
+  const targets = Object.fromEntries(Object.entries(config.targets ?? {}).sort(([a], [b]) => a.localeCompare(b)));
+  return config.default ? { default: config.default, targets } : { targets };
+}
+
+export function writeArraConfig(path: string, config: ArraConfig): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(cleanConfig(config), null, 2) + "\n");
+}
+
+function writableGlobal(env = process.env): LoadedConfig {
+  const path = globalConfigPathForWrite(env);
+  return readArraConfig(path) ?? { path, config: { targets: {} } };
+}
+
+export function addGlobalTarget(name: string, url: string, env = process.env): LoadedConfig {
+  const loaded = writableGlobal(env);
+  const targets = { ...(loaded.config.targets ?? {}), [name]: normalizeApiBase(url) };
+  const config = { default: loaded.config.default ?? name, targets };
+  writeArraConfig(loaded.path, config);
+  return { path: loaded.path, config };
+}
+
+export function useGlobalTarget(name: string, env = process.env): LoadedConfig {
+  const loaded = writableGlobal(env);
+  if (!loaded.config.targets?.[name]) throw new Error(`No global arra target named '${name}'. Add it first with: arra-cli config add ${name} <url>`);
+  const config = { ...loaded.config, default: name };
+  writeArraConfig(loaded.path, config);
+  return { path: loaded.path, config };
 }

--- a/cli/src/plugins/export-obsidian/lib/__tests__/render-index.test.ts
+++ b/cli/src/plugins/export-obsidian/lib/__tests__/render-index.test.ts
@@ -11,8 +11,8 @@ const stats: VaultStats = {
     { name: "drizzle", count: 5 },
   ],
   topLinked: [
-    { id: "A", slug: "doc-a", linkCount: 8 },
-    { id: "B", slug: "doc-b", linkCount: 5 },
+    { slug: "doc-a", linkCount: 8 },
+    { slug: "doc-b", linkCount: 5 },
   ],
   generatedAt: new Date("2026-04-19T10:00:00Z"),
 };

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -3,8 +3,9 @@
     "strict": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "target": "esnext",
-    "lib": ["esnext"],
+    "lib": ["esnext", "dom"],
     "types": ["bun-types"],
     "skipLibCheck": true
   },

--- a/tests/cli/_run.ts
+++ b/tests/cli/_run.ts
@@ -18,12 +18,17 @@ export interface RunResult {
 
 export async function runCli(
   args: string[],
-  env: Record<string, string> = {},
+  env: Record<string, string | undefined> = {},
 ): Promise<RunResult> {
+  const childEnv: Record<string, string> = { ...process.env };
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) delete childEnv[key];
+    else childEnv[key] = value;
+  }
   const proc = Bun.spawn(["bun", "run", CLI_ENTRY, ...args], {
     stdout: "pipe",
     stderr: "pipe",
-    env: { ...process.env, ...env },
+    env: childEnv,
   });
   const [stdout, stderr] = await Promise.all([
     new Response(proc.stdout).text(),

--- a/tests/cli/config/command.test.ts
+++ b/tests/cli/config/command.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runCli } from "../_run.ts";
+
+const cwd0 = process.cwd();
+const temps: string[] = [];
+const tmp = (p: string) => (temps.push(mkdtempSync(join(tmpdir(), p))), temps.at(-1)!);
+const env = (xdg: string, extra = {}) => ({ XDG_CONFIG_HOME: xdg, ORACLE_API: undefined, NEO_ARRA_API: undefined, ...extra });
+function cfg(path: string, targets: Record<string, string>, def = "local") {
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, JSON.stringify({ default: def, targets }, null, 2));
+}
+
+afterEach(() => {
+  process.chdir(cwd0);
+  for (const dir of temps.splice(0)) rmSync(dir, { recursive: true });
+});
+
+test("config show reports env, --at, and project/global source precedence", async () => {
+  const xdg = tmp("arra-global-");
+  cfg(join(xdg, "arra", "config.json"), { local: "http://global.local:47778", m5: "http://m5.local:47778" });
+  const project = tmp("arra-project-");
+  mkdirSync(join(project, "nested"), { recursive: true });
+  cfg(join(project, ".arra", "config.json"), { local: "http://project.local:47778" });
+  process.chdir(join(project, "nested"));
+
+  const projectShow = await runCli(["config", "show"], env(xdg));
+  expect(projectShow.stdout).toContain("Resolved: http://project.local:47778");
+  expect(projectShow.stdout).toContain("Source: project");
+  expect(projectShow.stdout).toMatch(/\* local\s+http:\/\/project\.local:47778/);
+
+  const atShow = await runCli(["--at", "m5", "config", "show"], env(xdg));
+  expect(atShow.stdout).toContain("Resolved: http://m5.local:47778");
+  expect(atShow.stdout).toContain("Source: --at");
+  expect(atShow.stdout).toMatch(/\* m5\s+http:\/\/m5\.local:47778/);
+
+  const envShow = await runCli(["--at", "m5", "config", "show"], env(xdg, { ORACLE_API: "http://env.local:47778" }));
+  expect(envShow.stdout).toContain("Resolved: http://env.local:47778");
+  expect(envShow.stdout).toContain("Source: env");
+});
+
+test("config add/use mutate global config and path prints config.json by default", async () => {
+  const xdg = tmp("arra-write-");
+  const path = join(xdg, "arra", "config.json");
+  expect((await runCli(["config", "path"], env(xdg))).stdout.trim()).toBe(path);
+  expect((await runCli(["config", "add", "m5", "http://m5.local:47778/"], env(xdg))).code).toBe(0);
+  expect((await runCli(["config", "add", "docker", "http://localhost:47780"], env(xdg))).code).toBe(0);
+  expect((await runCli(["config", "use", "docker"], env(xdg))).code).toBe(0);
+  const data = JSON.parse(readFileSync(path, "utf8"));
+  expect(data.default).toBe("docker");
+  expect(data.targets.m5).toBe("http://m5.local:47778");
+  expect(data.targets.docker).toBe("http://localhost:47780");
+});
+
+test("config path and writes reuse existing targets.json for shell interop", async () => {
+  const xdg = tmp("arra-targets-");
+  const path = join(xdg, "arra", "targets.json");
+  cfg(path, { local: "http://localhost:47778" });
+  expect((await runCli(["config", "path"], env(xdg))).stdout.trim()).toBe(path);
+  expect((await runCli(["config", "add", "m5", "http://m5.local:47778"], env(xdg))).code).toBe(0);
+  expect(JSON.parse(readFileSync(path, "utf8")).targets.m5).toBe("http://m5.local:47778");
+});


### PR DESCRIPTION
## Summary
- add `arra-cli config` (`show`, `path`, `add`, `use`) over the layered config resolver
- surface top-level `--at <name>` / `--at=<name>` so any command can use a one-off target
- keep config reads/writes interoperable with `~/.config/arra/config.json` and existing `targets.json`
- clean up quick CLI typecheck noise while staying in the CLI lane

## Verification
- `bun test tests/cli/config/api-resolution.test.ts tests/cli/config/command.test.ts` — 10 pass
- `bunx tsc -p cli/tsconfig.json --noEmit` — pass
- `bun run build` — pass
- `bun run test:unit` — 280 pass
- `bun test cli/src/plugins/export-obsidian/lib/__tests__/render-index.test.ts` — 7 pass
- targeted smoke: `config add`, `--at m5 config show`, and top-level `--at m5 health` routed to configured URL

## Notes
- Scope stayed in `cli/`; no server/federation/peer/scout files touched.
- PR is intentionally lean for #1275 Phase 4; Phase 4 closes the naming/config epic after alpha release.
