### PR TITLE
refactor(server): extract federation into its own plugin module

### DIFF
--- a/src/server/__tests__/server-plugin-loader.test.ts
+++ b/src/server/__tests__/server-plugin-loader.test.ts
@@ -122,6 +122,33 @@ describe('server plugin loader', () => {
     expect((await conflicted.app.handle(new Request('http://local/api/health'))).status).toBe(200);
   });
 
+  test('dedicated federation plugin owns the peer route contract', async () => {
+    const { createFederationPlugin } = await import('../plugin/federation.ts');
+    const plugin = createFederationPlugin();
+
+    expect(plugin.name).toBe('federation');
+    expect(plugin.tier).toBe('standard');
+    expect(plugin.enabled).toBe(false);
+    expect(plugin.seedMenu).toBe(false);
+
+    const app = new Elysia();
+    for (const routes of serverPluginRoutes([plugin])) app.use(routes as any);
+
+    const info = await app.handle(new Request('http://local/info'));
+    expect(info.status).toBe(200);
+    const infoBody = await info.json() as { maw?: { schema?: string }; node?: string; oracle?: string };
+    expect(infoBody.maw?.schema).toBe('1');
+    expect(infoBody.node).toStartWith('arra@');
+    expect(infoBody.oracle).toBe('arra');
+
+    const identity = await app.handle(new Request('http://local/api/identity'));
+    expect(identity.status).toBe(200);
+    const identityBody = await identity.json() as { pubkey?: string; node?: string; oracle?: string };
+    expect(identityBody.pubkey).toMatch(/^[0-9a-f]{64}$/);
+    expect(identityBody.node).toStartWith('arra@');
+    expect(identityBody.oracle).toBe('arra');
+  });
+
   test('api manifest mounts a built-in example plugin under its declared path', async () => {
     const { app, enabled } = await appWithConfig([], ['plugin-api-example']);
     expect(enabled.some((plugin) => plugin.name === 'plugin-api-example')).toBe(true);

--- a/src/server/plugin/builtin.ts
+++ b/src/server/plugin/builtin.ts
@@ -1,5 +1,6 @@
 import { Elysia } from 'elysia';
 
+import { createFederationPlugin } from './federation.ts';
 import type { ServerPlugin } from './types.ts';
 
 import { authRoutes } from '../../routes/auth/index.ts';
@@ -21,10 +22,8 @@ import { pluginsRouter } from '../../routes/plugins/index.ts';
 import { oraclenetRoutes } from '../../routes/oraclenet/index.ts';
 import { sessionsRoutes } from '../../routes/sessions/index.ts';
 import { vaultRoutes } from '../../routes/vault/index.ts';
-import { peerRoutes } from '../../routes/peer/index.ts';
 import { createMenuRoutes } from '../../routes/menu/index.ts';
 import { gatewayPlugin } from '../../gateway/index.ts';
-import { startScoutAnnouncer, type ScoutAnnouncer } from '../../peer/scout-announcer.ts';
 
 interface BuiltinOptions {
   dataDir: string;
@@ -69,25 +68,10 @@ export async function createBuiltinServerPlugins(options: BuiltinOptions): Promi
   const gatewayRoutes = gatewayPlugin(options.dataDir, options.vectorUrl);
   const menuRoutes = createMenuRoutes();
   const indexerPlugin = await optionalIndexerPlugin();
-  let scoutAnnouncer: ScoutAnnouncer | null = null;
-
   const plugins: Array<ServerPlugin | null> = [
     routePlugin('gateway', 'standard', () => gatewayRoutes, false),
     createApiManifestExamplePlugin(),
-    {
-      name: 'federation',
-      tier: 'standard',
-      enabled: false,
-      seedMenu: false,
-      routes: () => peerRoutes,
-      start: () => {
-        scoutAnnouncer = startScoutAnnouncer();
-      },
-      stop: () => {
-        scoutAnnouncer?.stop();
-        scoutAnnouncer = null;
-      },
-    },
+    createFederationPlugin(),
     routePlugin('health', 'core', () => healthRoutes),
     routePlugin('search', 'core', () => searchRoutes),
     routePlugin('knowledge', 'core', () => knowledgeRoutes),

--- a/src/server/plugin/federation.ts
+++ b/src/server/plugin/federation.ts
@@ -1,0 +1,30 @@
+import type { ServerPlugin } from './types.ts';
+
+import { startScoutAnnouncer, type ScoutAnnouncer } from '../../peer/scout-announcer.ts';
+import { peerRoutes } from '../../routes/peer/index.ts';
+
+/**
+ * maw federation plugin: owns the peer handshake routes plus Scout announcer.
+ *
+ * Wire contract is defined in src/routes/peer and src/peer/scout-announcer;
+ * this module only packages those existing surfaces behind the server plugin
+ * lifecycle seam so federation can be plugged in/out without server.ts edits.
+ */
+export function createFederationPlugin(): ServerPlugin {
+  let scoutAnnouncer: ScoutAnnouncer | null = null;
+
+  return {
+    name: 'federation',
+    tier: 'standard',
+    enabled: false,
+    seedMenu: false,
+    routes: () => peerRoutes,
+    start: () => {
+      scoutAnnouncer = startScoutAnnouncer();
+    },
+    stop: () => {
+      scoutAnnouncer?.stop();
+      scoutAnnouncer = null;
+    },
+  };
+}


### PR DESCRIPTION
Refs #1277.

Extracts the existing maw federation surface into a dedicated built-in server plugin module:
- `src/server/plugin/federation.ts` now owns the existing `peerRoutes` mount and `startScoutAnnouncer()` lifecycle.
- `src/server/plugin/builtin.ts` registers `createFederationPlugin()` instead of inlining the federation plugin.
- No wire-contract change: `/info`, `/api/identity`, and Scout HELLO remain implemented by the same existing route/announcer modules.
- Opt-in/default-off behavior is unchanged: bare serve stays network-silent; `FED_ENABLED=true` enables federation.

Verification:
- `bun test --isolate src/server/__tests__/server-plugin-loader.test.ts` → 12 pass
- `bun run build` → pass
- `bun run test:unit` → 281 pass
- Spare-port smoke, default env → `/api/health=200`, `/info=404`, `/api/identity=404`
- Spare-port smoke, `FED_ENABLED=true` → `/api/health=200`, `/info=200`, `/api/identity=200`, Scout announce log observed

Deploy note: m5-live must continue restarting with `FED_ENABLED=true ORACLE_SCOUT_URL=http://m5.local:47778` so the existing mawjs TOFU pair remains discoverable after this behavior-preserving refactor.

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3