### PR TITLE
feat(server): add config-backed plugin enable disable UX

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -8,6 +8,7 @@ import type { LoadedPlugin } from "./plugin/types.ts";
 import { pluginsList } from "./commands/plugins-list.ts";
 import { pluginsRemove } from "./commands/plugins-remove.ts";
 import { pluginsInfo } from "./commands/plugins-info.ts";
+import { pluginsDisable, pluginsEnable } from "./commands/plugins-toggle.ts";
 import { sessionList } from "./commands/session-list.ts";
 import { sessionShow } from "./commands/session-show.ts";
 import { sessionContext } from "./commands/session-context.ts";
@@ -182,6 +183,12 @@ async function main() {
     if (sub === "info") {
       process.exit(await pluginsInfo(rest));
     }
+    if (sub === "disable") {
+      process.exit(await pluginsDisable(rest));
+    }
+    if (sub === "enable") {
+      process.exit(await pluginsEnable(rest));
+    }
     if (!sub || sub === "--help" || sub === "-h") {
       console.log("arra-cli plugin <subcommand>\n");
       console.log("Subcommands:");
@@ -189,11 +196,13 @@ async function main() {
       console.log("  info <name>             show plugin details");
       console.log("  install <url-or-path>   install a plugin (see --help)");
       console.log("  remove <name>           remove an installed plugin");
+      console.log("  disable <name>          disable a standard/extra server plugin in config");
+      console.log("  enable <name>           enable a server plugin in config");
       console.log("\nOutput defaults to JSON; pass --yml for YAML.");
       return;
     }
     console.error(`\x1b[31m✗\x1b[0m unknown plugin subcommand: ${args[1]}`);
-    console.error("  try: arra-cli plugin list|info|install|remove");
+    console.error("  try: arra-cli plugin list|info|install|remove|enable|disable");
     process.exit(1);
   }
 

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -28,6 +28,8 @@ function knownTargets(): Record<string, string> {
 
 function show(): number {
   const resolved = resolveOracleApi();
+  const projectConfig = loadProjectConfig()?.config;
+  const globalConfig = loadGlobalConfig()?.config;
   const targets = knownTargets();
   const active = resolved.target ?? Object.entries(targets)
     .find(([, url]) => normalizeApiBase(url) === resolved.baseUrl)?.[0];
@@ -41,6 +43,11 @@ function show(): number {
   for (const name of names) {
     console.log(`${name === active ? "*" : " "} ${name.padEnd(12)} ${targets[name]}`);
   }
+  const disabledPlugins = [...new Set([...(globalConfig?.disabledPlugins ?? []), ...(projectConfig?.disabledPlugins ?? [])])].sort();
+  const enabledPlugins = [...new Set([...(globalConfig?.enabledPlugins ?? []), ...(projectConfig?.enabledPlugins ?? [])])].sort();
+  console.log("Server plugins:");
+  console.log(`  disabled: ${disabledPlugins.join(", ") || "(none)"}`);
+  console.log(`  enabled:  ${enabledPlugins.join(", ") || "(none)"}`);
   return 0;
 }
 

--- a/cli/src/commands/plugins-toggle.ts
+++ b/cli/src/commands/plugins-toggle.ts
@@ -1,0 +1,58 @@
+import { disableGlobalPlugin, enableGlobalPlugin } from '../lib/config.ts';
+
+const CORE_SERVER_PLUGINS = new Set([
+  'health',
+  'search',
+  'knowledge',
+  'concepts',
+  'verify',
+  'vector',
+  'files',
+  'indexer',
+]);
+
+function pluginName(value: string | undefined): string {
+  if (!value) throw new Error('missing plugin name');
+  if (!/^[a-z0-9-]+$/.test(value)) {
+    throw new Error(`plugin name must match /^[a-z0-9-]+$/, got: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+function printLists(config: { disabledPlugins?: string[]; enabledPlugins?: string[] }) {
+  const disabled = config.disabledPlugins?.join(', ') || '(none)';
+  const enabled = config.enabledPlugins?.join(', ') || '(none)';
+  console.log(`Disabled server plugins: ${disabled}`);
+  console.log(`Enabled server plugins: ${enabled}`);
+}
+
+export async function pluginsDisable(args: string[]): Promise<number> {
+  try {
+    const name = pluginName(args[0]);
+    if (CORE_SERVER_PLUGINS.has(name)) {
+      throw new Error(`Cannot disable core server plugin "${name}"`);
+    }
+    const loaded = disableGlobalPlugin(name);
+    console.log(`disabled server plugin: ${name}`);
+    console.log(`Config: ${loaded.path}`);
+    printLists(loaded.config);
+    return 0;
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+}
+
+export async function pluginsEnable(args: string[]): Promise<number> {
+  try {
+    const name = pluginName(args[0]);
+    const loaded = enableGlobalPlugin(name);
+    console.log(`enabled server plugin: ${name}`);
+    console.log(`Config: ${loaded.path}`);
+    printLists(loaded.config);
+    return 0;
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+}

--- a/cli/src/lib/config.ts
+++ b/cli/src/lib/config.ts
@@ -4,7 +4,12 @@ import { dirname, join, parse } from "node:path";
 
 export const DEFAULT_ORACLE_API = "http://localhost:47778";
 
-export type ArraConfig = { default?: string; targets?: Record<string, string> };
+export type ArraConfig = {
+  default?: string;
+  targets?: Record<string, string>;
+  disabledPlugins?: string[];
+  enabledPlugins?: string[];
+};
 export type LoadedConfig = { path: string; config: ArraConfig };
 export type OracleApiSource = "ORACLE_API" | "at" | "project" | "global" | "NEO_ARRA_API" | "default";
 
@@ -39,14 +44,33 @@ export function stripAtFlag(argv: string[]): string[] {
   return out;
 }
 
+function coercePluginList(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const names = value
+    .filter((entry): entry is string => typeof entry === "string")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  return names.length ? [...new Set(names)].sort() : undefined;
+}
+
 function coerceConfig(raw: any): ArraConfig | null {
-  const srcTargets = raw?.targets;
-  if (!srcTargets || typeof srcTargets !== "object" || Array.isArray(srcTargets)) return null;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const srcTargets = raw.targets;
   const targets: Record<string, string> = {};
-  for (const [name, url] of Object.entries(srcTargets)) {
-    if (typeof url === "string" && url.trim()) targets[name] = normalizeApiBase(url);
+  if (srcTargets && typeof srcTargets === "object" && !Array.isArray(srcTargets)) {
+    for (const [name, url] of Object.entries(srcTargets)) {
+      if (typeof url === "string" && url.trim()) targets[name] = normalizeApiBase(url);
+    }
   }
-  return { default: typeof raw.default === "string" ? raw.default : undefined, targets };
+  const disabledPlugins = coercePluginList(raw.disabledPlugins);
+  const enabledPlugins = coercePluginList(raw.enabledPlugins);
+  if (Object.keys(targets).length === 0 && !disabledPlugins?.length && !enabledPlugins?.length) return null;
+  return {
+    default: typeof raw.default === "string" ? raw.default : undefined,
+    ...(Object.keys(targets).length ? { targets } : {}),
+    ...(disabledPlugins?.length ? { disabledPlugins } : {}),
+    ...(enabledPlugins?.length ? { enabledPlugins } : {}),
+  };
 }
 
 export function readArraConfig(path: string): LoadedConfig | null {
@@ -127,9 +151,21 @@ export function resolveOracleApi(argv = process.argv.slice(2), env = process.env
   return { baseUrl: DEFAULT_ORACLE_API, source: "default" };
 }
 
+function sortedUnique(values: string[] | undefined): string[] | undefined {
+  const unique = [...new Set((values ?? []).map((value) => value.trim()).filter(Boolean))].sort();
+  return unique.length ? unique : undefined;
+}
+
 function cleanConfig(config: ArraConfig): ArraConfig {
   const targets = Object.fromEntries(Object.entries(config.targets ?? {}).sort(([a], [b]) => a.localeCompare(b)));
-  return config.default ? { default: config.default, targets } : { targets };
+  const disabledPlugins = sortedUnique(config.disabledPlugins);
+  const enabledPlugins = sortedUnique(config.enabledPlugins);
+  return {
+    ...(config.default ? { default: config.default } : {}),
+    ...(Object.keys(targets).length ? { targets } : {}),
+    ...(disabledPlugins ? { disabledPlugins } : {}),
+    ...(enabledPlugins ? { enabledPlugins } : {}),
+  };
 }
 
 export function writeArraConfig(path: string, config: ArraConfig): void {
@@ -145,7 +181,7 @@ function writableGlobal(env = process.env): LoadedConfig {
 export function addGlobalTarget(name: string, url: string, env = process.env): LoadedConfig {
   const loaded = writableGlobal(env);
   const targets = { ...(loaded.config.targets ?? {}), [name]: normalizeApiBase(url) };
-  const config = { default: loaded.config.default ?? name, targets };
+  const config = { ...loaded.config, default: loaded.config.default ?? name, targets };
   writeArraConfig(loaded.path, config);
   return { path: loaded.path, config };
 }
@@ -156,4 +192,30 @@ export function useGlobalTarget(name: string, env = process.env): LoadedConfig {
   const config = { ...loaded.config, default: name };
   writeArraConfig(loaded.path, config);
   return { path: loaded.path, config };
+}
+
+function assertPluginName(name: string): void {
+  if (!/^[a-z0-9-]+$/.test(name)) {
+    throw new Error(`plugin name must match /^[a-z0-9-]+$/, got: ${JSON.stringify(name)}`);
+  }
+}
+
+export function disableGlobalPlugin(name: string, env = process.env): LoadedConfig {
+  assertPluginName(name);
+  const loaded = writableGlobal(env);
+  const disabledPlugins = sortedUnique([...(loaded.config.disabledPlugins ?? []), name]);
+  const enabledPlugins = sortedUnique((loaded.config.enabledPlugins ?? []).filter((entry) => entry !== name));
+  const config = { ...loaded.config, disabledPlugins, enabledPlugins };
+  writeArraConfig(loaded.path, config);
+  return { path: loaded.path, config: cleanConfig(config) };
+}
+
+export function enableGlobalPlugin(name: string, env = process.env): LoadedConfig {
+  assertPluginName(name);
+  const loaded = writableGlobal(env);
+  const disabledPlugins = sortedUnique((loaded.config.disabledPlugins ?? []).filter((entry) => entry !== name));
+  const enabledPlugins = sortedUnique([...(loaded.config.enabledPlugins ?? []), name]);
+  const config = { ...loaded.config, disabledPlugins, enabledPlugins };
+  writeArraConfig(loaded.path, config);
+  return { path: loaded.path, config: cleanConfig(config) };
 }

--- a/src/server/__tests__/server-plugin-loader.test.ts
+++ b/src/server/__tests__/server-plugin-loader.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test, afterAll } from 'bun:test';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { describe, expect, test, afterAll, afterEach } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { Elysia } from 'elysia';
@@ -20,6 +20,8 @@ process.env.ORACLE_DB_PATH = join(tmp, 'oracle.db');
 process.env.ORACLE_REPO_ROOT = tmp;
 process.env.ORACLE_PORT = '0';
 process.env.VECTOR_URL = '';
+process.env.HOME = tmp;
+process.env.XDG_CONFIG_HOME = join(tmp, 'xdg');
 
 async function appWithConfig(disabledPlugins: string[], enabledPlugins: string[] = []) {
   const { createBuiltinServerPlugins } = await import('../plugin/builtin.ts');
@@ -52,6 +54,13 @@ function withEnv(key: string, value: string | undefined, fn: () => void) {
   }
 }
 
+
+function writeGlobalConfig(config: unknown) {
+  const dir = join(tmp, 'xdg', 'arra');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'config.json'), JSON.stringify(config, null, 2));
+}
+
 const testLifecycleOptions = {
   dataDir: tmp,
   vectorUrl: 'http://vector.local',
@@ -61,6 +70,10 @@ const testLifecycleOptions = {
     error: () => {},
   },
 };
+
+afterEach(() => {
+  rmSync(join(tmp, 'xdg'), { recursive: true, force: true });
+});
 
 afterAll(async () => {
   const { closeDb } = await import('../../db/index.ts');
@@ -120,6 +133,28 @@ describe('server plugin loader', () => {
     expect(conflicted.enabled.some((plugin) => plugin.name === 'federation')).toBe(false);
     expect((await conflicted.app.handle(new Request('http://local/info'))).status).toBe(404);
     expect((await conflicted.app.handle(new Request('http://local/api/health'))).status).toBe(200);
+  });
+
+  test('config file can disable standard plugins and enable opt-in plugins', async () => {
+    writeGlobalConfig({ disabledPlugins: ['gateway'], enabledPlugins: ['federation'] });
+    const { createBuiltinServerPlugins } = await import('../plugin/builtin.ts');
+    const loaded = loadServerPlugins(await createBuiltinServerPlugins({ dataDir: tmp }), {
+      disabledPlugins: disabledPluginsFromEnv(),
+      enabledPlugins: enabledPluginsFromEnv(),
+    });
+    const enabled = enabledServerPlugins(loaded);
+    expect(enabled.some((plugin) => plugin.name === 'gateway')).toBe(false);
+    expect(enabled.some((plugin) => plugin.name === 'federation')).toBe(true);
+  });
+
+  test('config file cannot disable core server plugins', async () => {
+    writeGlobalConfig({ disabledPlugins: ['search'] });
+    const { createBuiltinServerPlugins } = await import('../plugin/builtin.ts');
+    const plugins = await createBuiltinServerPlugins({ dataDir: tmp });
+    expect(() => loadServerPlugins(plugins, {
+      disabledPlugins: disabledPluginsFromEnv(),
+      enabledPlugins: enabledPluginsFromEnv(),
+    })).toThrow('Cannot disable core server plugin "search"');
   });
 
   test('dedicated federation plugin owns the peer route contract', async () => {

--- a/src/server/plugin/config.ts
+++ b/src/server/plugin/config.ts
@@ -1,0 +1,86 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, parse } from 'node:path';
+
+export interface ServerPluginConfig {
+  disabledPlugins: string[];
+  enabledPlugins: string[];
+}
+
+type Env = Record<string, string | undefined>;
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
+}
+
+function pluginList(...values: unknown[]): string[] {
+  const out: string[] = [];
+  for (const value of values) {
+    if (!Array.isArray(value)) continue;
+    for (const entry of value) {
+      if (typeof entry === 'string' && entry.trim()) out.push(entry.trim());
+    }
+  }
+  return unique(out);
+}
+
+function readConfigFile(path: string): ServerPluginConfig | null {
+  if (!existsSync(path)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(path, 'utf8')) as any;
+    const disabledPlugins = pluginList(
+      raw.disabledPlugins,
+      raw.serverPlugins?.disabledPlugins,
+      raw.serverPlugins?.disabled,
+    );
+    const enabledPlugins = pluginList(
+      raw.enabledPlugins,
+      raw.serverPlugins?.enabledPlugins,
+      raw.serverPlugins?.enabled,
+    );
+    if (!disabledPlugins.length && !enabledPlugins.length) return null;
+    return { disabledPlugins, enabledPlugins };
+  } catch {
+    return null;
+  }
+}
+
+function configPaths(dir: string): string[] {
+  return [join(dir, 'config.json'), join(dir, 'targets.json')];
+}
+
+function firstConfig(paths: string[]): ServerPluginConfig | null {
+  for (const path of paths) {
+    const found = readConfigFile(path);
+    if (found) return found;
+  }
+  return null;
+}
+
+function loadProjectPluginConfig(startDir = process.cwd()): ServerPluginConfig | null {
+  let dir = startDir;
+  const root = parse(dir).root;
+  while (true) {
+    const found = firstConfig(configPaths(join(dir, '.arra')));
+    if (found || dir === root) return found;
+    dir = dirname(dir);
+  }
+}
+
+function globalConfigDir(env: Env = process.env): string {
+  const xdg = env.XDG_CONFIG_HOME?.trim();
+  return xdg ? join(xdg, 'arra') : join(env.HOME ?? homedir(), '.config', 'arra');
+}
+
+function loadGlobalPluginConfig(env: Env = process.env): ServerPluginConfig | null {
+  return firstConfig(configPaths(globalConfigDir(env)));
+}
+
+export function loadServerPluginConfig(env: Env = process.env, startDir = process.cwd()): ServerPluginConfig {
+  const global = loadGlobalPluginConfig(env);
+  const project = loadProjectPluginConfig(startDir);
+  return {
+    disabledPlugins: unique([...(global?.disabledPlugins ?? []), ...(project?.disabledPlugins ?? [])]),
+    enabledPlugins: unique([...(global?.enabledPlugins ?? []), ...(project?.enabledPlugins ?? [])]),
+  };
+}

--- a/src/server/plugin/loader.ts
+++ b/src/server/plugin/loader.ts
@@ -1,5 +1,6 @@
 import { Elysia } from 'elysia';
 
+import { loadServerPluginConfig } from './config.ts';
 import { parseDisabledPlugins, parseEnabledPlugins, validateServerPlugin } from './manifest.ts';
 import type {
   ElysiaApp,
@@ -13,13 +14,21 @@ import type {
 } from './types.ts';
 
 export function disabledPluginsFromEnv(): string[] {
-  const disabled = parseDisabledPlugins(process.env.ORACLE_DISABLED_PLUGINS ?? process.env.ARRA_DISABLED_PLUGINS);
+  const config = loadServerPluginConfig();
+  const disabled = [
+    ...config.disabledPlugins,
+    ...parseDisabledPlugins(process.env.ORACLE_DISABLED_PLUGINS ?? process.env.ARRA_DISABLED_PLUGINS),
+  ];
   if (process.env.FED_ENABLED?.toLowerCase() === 'false') disabled.push('federation');
   return [...new Set(disabled)];
 }
 
 export function enabledPluginsFromEnv(): string[] {
-  const enabled = parseEnabledPlugins(process.env.ORACLE_ENABLED_PLUGINS ?? process.env.ARRA_ENABLED_PLUGINS);
+  const config = loadServerPluginConfig();
+  const enabled = [
+    ...config.enabledPlugins,
+    ...parseEnabledPlugins(process.env.ORACLE_ENABLED_PLUGINS ?? process.env.ARRA_ENABLED_PLUGINS),
+  ];
   if (process.env.FED_ENABLED?.toLowerCase() === 'true') enabled.push('federation');
   return [...new Set(enabled)];
 }

--- a/tests/cli/config/command.test.ts
+++ b/tests/cli/config/command.test.ts
@@ -62,3 +62,14 @@ test("config path and writes reuse existing targets.json for shell interop", asy
   expect((await runCli(["config", "add", "m5", "http://m5.local:47778"], env(xdg))).code).toBe(0);
   expect(JSON.parse(readFileSync(path, "utf8")).targets.m5).toBe("http://m5.local:47778");
 });
+
+test("config target writes preserve server plugin toggles", async () => {
+  const xdg = tmp("arra-plugin-preserve-");
+  const path = join(xdg, "arra", "config.json");
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, JSON.stringify({ disabledPlugins: ["federation"] }, null, 2));
+  expect((await runCli(["config", "add", "m5", "http://m5.local:47778"], env(xdg))).code).toBe(0);
+  const data = JSON.parse(readFileSync(path, "utf8"));
+  expect(data.targets.m5).toBe("http://m5.local:47778");
+  expect(data.disabledPlugins).toEqual(["federation"]);
+});

--- a/tests/cli/plugin/toggle.test.ts
+++ b/tests/cli/plugin/toggle.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runCli } from '../_run.ts';
+
+const temps: string[] = [];
+const tmp = () => (temps.push(mkdtempSync(join(tmpdir(), 'arra-plugin-toggle-'))), temps.at(-1)!);
+const env = (xdg: string) => ({ XDG_CONFIG_HOME: xdg, ORACLE_API: undefined, NEO_ARRA_API: undefined });
+
+afterEach(() => {
+  for (const dir of temps.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+test('plugin disable/enable writes server plugin config toggles', async () => {
+  const xdg = tmp();
+  const configPath = join(xdg, 'arra', 'config.json');
+
+  const disabled = await runCli(['plugin', 'disable', 'federation'], env(xdg));
+  expect(disabled.code).toBe(0);
+  expect(disabled.stdout).toContain('disabled server plugin: federation');
+  expect(disabled.stdout).toContain(`Config: ${configPath}`);
+  expect(JSON.parse(readFileSync(configPath, 'utf8'))).toEqual({
+    disabledPlugins: ['federation'],
+  });
+
+  const enabled = await runCli(['plugin', 'enable', 'federation'], env(xdg));
+  expect(enabled.code).toBe(0);
+  expect(enabled.stdout).toContain('enabled server plugin: federation');
+  expect(JSON.parse(readFileSync(configPath, 'utf8'))).toEqual({
+    enabledPlugins: ['federation'],
+  });
+});
+
+test('plugin disable refuses known core server plugins before writing config', async () => {
+  const xdg = tmp();
+  const result = await runCli(['plugin', 'disable', 'search'], env(xdg));
+  expect(result.code).toBe(1);
+  expect(result.stderr).toContain('Cannot disable core server plugin "search"');
+});


### PR DESCRIPTION
Refs #1278 (Phase 6).

Adds the maw-style plug in/out UX for server plugins:
- `arra-cli plugin disable <name>` persists `disabledPlugins` in the existing arra config.
- `arra-cli plugin enable <name>` removes the disable and persists `enabledPlugins` for opt-in plugins like `federation`.
- `arra-cli config show` now reports configured server plugin toggles.
- HTTP server plugin loader reads project/global `.arra` / `~/.config/arra` plugin toggles alongside the existing env controls.
- Core floor stays protected: known core plugins are refused by CLI, and server loader still refuses any core disable from config/env.

Verification:
- `bun run build` → pass
- `bunx tsc -p cli/tsconfig.json --noEmit` → pass
- `bun run test:unit` → 283 pass
- `bun test tests/cli` → 41 pass
- Spare-port server smoke: config `enabledPlugins:[federation]` with no `FED_ENABLED` → `/info=200` + Scout yes
- Spare-port server smoke: config `disabledPlugins:[federation]` with `FED_ENABLED=true` → `/info=404` + Scout no (disabled wins)

Deploy note: m5-live still needs `FED_ENABLED=true ORACLE_SCOUT_URL=http://m5.local:47778` after alpha; do not persist-disable federation on that host unless intentionally unpairing mawjs.

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3