### PR TITLE
feat(server): unify plugin manifests across CLI and HTTP surfaces

### DIFF
--- a/cli/src/plugin/manifest.ts
+++ b/cli/src/plugin/manifest.ts
@@ -1,5 +1,8 @@
 import type { PluginManifest } from "./types.ts";
 
+const TIERS = new Set(["core", "standard", "extra"]);
+const HTTP_METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD", "ALL"]);
+
 export function parseManifest(raw: unknown): PluginManifest {
   if (typeof raw !== "object" || raw === null) {
     throw new Error("manifest must be a JSON object");
@@ -19,5 +22,32 @@ export function validateManifest(m: PluginManifest): void {
   }
   if (!m.sdk || typeof m.sdk !== "string") {
     throw new Error(`manifest.sdk must be a semver range string`);
+  }
+  if (m.tier !== undefined && !TIERS.has(m.tier)) {
+    throw new Error(`manifest.tier must be core, standard, or extra; got: ${JSON.stringify(m.tier)}`);
+  }
+  if (m.enabled !== undefined && typeof m.enabled !== "boolean") {
+    throw new Error(`manifest.enabled must be a boolean`);
+  }
+  if (m.seedMenu !== undefined && typeof m.seedMenu !== "boolean") {
+    throw new Error(`manifest.seedMenu must be a boolean`);
+  }
+  if (m.api) {
+    if (!m.api.path || typeof m.api.path !== "string" || !m.api.path.startsWith("/")) {
+      throw new Error(`manifest.api.path must be an absolute path`);
+    }
+    for (const method of m.api.methods ?? []) {
+      if (typeof method !== "string" || !HTTP_METHODS.has(method.toUpperCase())) {
+        throw new Error(`manifest.api.methods contains invalid method: ${JSON.stringify(method)}`);
+      }
+    }
+  }
+  if (m.lifecycle) {
+    if (m.lifecycle.start !== undefined && typeof m.lifecycle.start !== "boolean") {
+      throw new Error(`manifest.lifecycle.start must be a boolean`);
+    }
+    if (m.lifecycle.stop !== undefined && typeof m.lifecycle.stop !== "boolean") {
+      throw new Error(`manifest.lifecycle.stop must be a boolean`);
+    }
   }
 }

--- a/cli/src/plugin/types.ts
+++ b/cli/src/plugin/types.ts
@@ -6,11 +6,22 @@ export interface PluginManifest {
   weight?: number;
   description?: string;
   author?: string;
+  tier?: "core" | "standard" | "extra";
+  enabled?: boolean;
+  seedMenu?: boolean;
   cli?: {
     command: string;
     aliases?: string[];
     help?: string;
     flags?: Record<string, string>;
+  };
+  api?: {
+    path: string;
+    methods?: string[];
+  };
+  lifecycle?: {
+    start?: boolean;
+    stop?: boolean;
   };
 }
 
@@ -21,13 +32,31 @@ export interface LoadedPlugin {
 }
 
 export interface InvokeContext {
-  source: "cli" | "api";
+  source: "cli" | "api" | "peer" | "lifecycle";
   args: string[];
+  request?: Request;
+  params?: Record<string, string>;
+  query?: Record<string, unknown>;
+  body?: unknown;
+  lifecycle?: "start" | "stop";
+  server?: {
+    dataDir: string;
+    vectorUrl?: string;
+    signal: AbortSignal;
+    logger?: {
+      info: (...args: unknown[]) => void;
+      warn: (...args: unknown[]) => void;
+      error: (...args: unknown[]) => void;
+    };
+  };
   writer?: (...args: unknown[]) => void;
 }
 
 export interface InvokeResult {
   ok: boolean;
   output?: string;
+  body?: unknown;
+  status?: number;
+  headers?: Record<string, string>;
   error?: string;
 }

--- a/cli/src/plugins/unified-example/index.ts
+++ b/cli/src/plugins/unified-example/index.ts
@@ -1,0 +1,26 @@
+import type { InvokeContext, InvokeResult } from '../../plugin/types.ts';
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  if (ctx.source === 'api') {
+    return {
+      ok: true,
+      body: {
+        ok: true,
+        plugin: 'unified-example',
+        source: ctx.source,
+        method: ctx.request?.method ?? 'GET',
+        body: ctx.body ?? null,
+      },
+    };
+  }
+
+  if (ctx.source === 'lifecycle') {
+    ctx.server?.logger?.info(`[unified-example] ${ctx.lifecycle}`);
+    return { ok: true };
+  }
+
+  return {
+    ok: true,
+    output: 'Hello from the unified-example plugin (cli surface)',
+  };
+}

--- a/cli/src/plugins/unified-example/plugin.json
+++ b/cli/src/plugins/unified-example/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "unified-example",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^0.0.1",
+  "tier": "extra",
+  "enabled": false,
+  "seedMenu": false,
+  "description": "Example unified plugin: CLI command, HTTP route, and lifecycle from one handler",
+  "cli": {
+    "command": "unified-example",
+    "help": "arra-cli unified-example — sample unified plugin"
+  },
+  "api": {
+    "path": "/api/unified-example",
+    "methods": ["GET", "POST"]
+  },
+  "lifecycle": {
+    "start": true,
+    "stop": true
+  }
+}

--- a/src/server/__tests__/server-plugin-loader.test.ts
+++ b/src/server/__tests__/server-plugin-loader.test.ts
@@ -197,6 +197,44 @@ describe('server plugin loader', () => {
     });
   });
 
+  test('unified manifest plugin exposes api route and lifecycle from one handler', async () => {
+    const { createBuiltinServerPlugins } = await import('../plugin/builtin.ts');
+    const enabled = enabledServerPlugins(loadServerPlugins(await createBuiltinServerPlugins({ dataDir: tmp }), {
+      enabledPlugins: ['unified-example'],
+    }));
+    expect(enabled.some((plugin) => plugin.name === 'unified-example')).toBe(true);
+
+    const app = new Elysia();
+    for (const routes of serverPluginRoutes(enabled)) app.use(routes as any);
+
+    const response = await app.handle(new Request('http://local/api/unified-example', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ phase: 5 }),
+    }));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ok: true,
+      plugin: 'unified-example',
+      source: 'api',
+      method: 'POST',
+      body: { phase: 5 },
+    });
+
+    const events: string[] = [];
+    const unified = enabled.filter((plugin) => plugin.name === 'unified-example');
+    const lifecycle = await startServerPlugins(unified, {
+      ...testLifecycleOptions,
+      logger: {
+        info: (...args) => events.push(args.join(' ')),
+        warn: () => {},
+        error: () => {},
+      },
+    });
+    await lifecycle.stop();
+    expect(events).toEqual(['[unified-example] start', '[unified-example] stop']);
+  });
+
   test('direct route wins over api manifest route collision', async () => {
     const warnings: string[] = [];
     const { app } = appFromPlugins([

--- a/src/server/plugin/builtin.ts
+++ b/src/server/plugin/builtin.ts
@@ -1,6 +1,7 @@
 import { Elysia } from 'elysia';
 
 import { createFederationPlugin } from './federation.ts';
+import { createUnifiedManifestServerPlugins } from './unified.ts';
 import type { ServerPlugin } from './types.ts';
 
 import { authRoutes } from '../../routes/auth/index.ts';
@@ -68,6 +69,7 @@ export async function createBuiltinServerPlugins(options: BuiltinOptions): Promi
   const gatewayRoutes = gatewayPlugin(options.dataDir, options.vectorUrl);
   const menuRoutes = createMenuRoutes();
   const indexerPlugin = await optionalIndexerPlugin();
+  const unifiedManifestPlugins = await createUnifiedManifestServerPlugins();
   const plugins: Array<ServerPlugin | null> = [
     routePlugin('gateway', 'standard', () => gatewayRoutes, false),
     createApiManifestExamplePlugin(),
@@ -95,5 +97,8 @@ export async function createBuiltinServerPlugins(options: BuiltinOptions): Promi
     routePlugin('menu', 'standard', () => menuRoutes, false),
   ];
 
-  return plugins.filter((plugin): plugin is ServerPlugin => Boolean(plugin));
+  return [
+    ...plugins.filter((plugin): plugin is ServerPlugin => Boolean(plugin)),
+    ...unifiedManifestPlugins,
+  ];
 }

--- a/src/server/plugin/unified.ts
+++ b/src/server/plugin/unified.ts
@@ -1,0 +1,259 @@
+import { existsSync, readdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { Elysia } from 'elysia';
+
+import type {
+  ElysiaApp,
+  ServerPlugin,
+  ServerPluginApiManifest,
+  ServerPluginLifecycleContext,
+  ServerPluginTier,
+} from './types.ts';
+
+const USER_PLUGIN_DIR = join(homedir(), '.neo-arra', 'plugins');
+const BUNDLED_PLUGIN_DIR = join(import.meta.dir, '../../../cli/src/plugins');
+const TIMEOUT_MS = Number(process.env.ARRA_PLUGIN_TIMEOUT_MS ?? 5000);
+const TIERS = new Set(['core', 'standard', 'extra']);
+const HTTP_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'HEAD', 'ALL']);
+
+interface UnifiedManifestLifecycle {
+  start?: boolean;
+  stop?: boolean;
+}
+
+interface UnifiedManifest {
+  name: string;
+  version: string;
+  entry: string;
+  sdk: string;
+  tier?: ServerPluginTier;
+  enabled?: boolean;
+  seedMenu?: boolean;
+  api?: ServerPluginApiManifest;
+  lifecycle?: UnifiedManifestLifecycle;
+}
+
+interface LoadedUnifiedManifestPlugin {
+  manifest: UnifiedManifest;
+  dir: string;
+  entryPath: string;
+}
+
+export interface UnifiedManifestPluginOptions {
+  bundledDir?: string;
+  userDir?: string;
+}
+
+type UnifiedInvokeContext = {
+  source: 'api' | 'lifecycle';
+  args: string[];
+  request?: Request;
+  params?: Record<string, string>;
+  query?: Record<string, unknown>;
+  body?: unknown;
+  lifecycle?: 'start' | 'stop';
+  server?: ServerPluginLifecycleContext;
+};
+
+type UnifiedInvokeResult = {
+  ok: boolean;
+  output?: string;
+  body?: unknown;
+  status?: number;
+  headers?: Record<string, string>;
+  error?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function parseManifest(raw: unknown): UnifiedManifest {
+  if (!isRecord(raw)) throw new Error('manifest must be a JSON object');
+  return raw as unknown as UnifiedManifest;
+}
+
+function validateUnifiedManifest(m: UnifiedManifest): void {
+  if (!m.name || !/^[a-z0-9-]+$/.test(m.name)) {
+    throw new Error(`manifest.name must match /^[a-z0-9-]+$/, got: ${JSON.stringify(m.name)}`);
+  }
+  if (!m.version || !/^\d+\.\d+\.\d+/.test(m.version)) {
+    throw new Error(`manifest.version must be semver, got: ${JSON.stringify(m.version)}`);
+  }
+  if (!m.entry || typeof m.entry !== 'string') {
+    throw new Error('manifest.entry must be a string path');
+  }
+  if (!m.sdk || typeof m.sdk !== 'string') {
+    throw new Error('manifest.sdk must be a semver range string');
+  }
+  if (m.tier !== undefined && !TIERS.has(m.tier)) {
+    throw new Error(`manifest.tier must be core, standard, or extra; got: ${JSON.stringify(m.tier)}`);
+  }
+  if (m.enabled !== undefined && typeof m.enabled !== 'boolean') {
+    throw new Error('manifest.enabled must be a boolean');
+  }
+  if (m.seedMenu !== undefined && typeof m.seedMenu !== 'boolean') {
+    throw new Error('manifest.seedMenu must be a boolean');
+  }
+  if (m.api) {
+    if (!m.api.path || typeof m.api.path !== 'string' || !m.api.path.startsWith('/')) {
+      throw new Error('manifest.api.path must be an absolute path');
+    }
+    for (const method of m.api.methods ?? []) {
+      if (typeof method !== 'string' || !HTTP_METHODS.has(method.toUpperCase())) {
+        throw new Error(`manifest.api.methods contains invalid method: ${JSON.stringify(method)}`);
+      }
+    }
+  }
+  if (m.lifecycle) {
+    if (m.lifecycle.start !== undefined && typeof m.lifecycle.start !== 'boolean') {
+      throw new Error('manifest.lifecycle.start must be a boolean');
+    }
+    if (m.lifecycle.stop !== undefined && typeof m.lifecycle.stop !== 'boolean') {
+      throw new Error('manifest.lifecycle.stop must be a boolean');
+    }
+  }
+}
+
+async function loadPluginDir(dir: string): Promise<LoadedUnifiedManifestPlugin | null> {
+  const manifestPath = join(dir, 'plugin.json');
+  if (!existsSync(manifestPath)) return null;
+  try {
+    const manifest = parseManifest(await Bun.file(manifestPath).json());
+    validateUnifiedManifest(manifest);
+    if (!manifest.api && !manifest.lifecycle) return null;
+    return { manifest, dir, entryPath: resolve(dir, manifest.entry) };
+  } catch (error) {
+    console.warn(`[server-plugin] skipped unified manifest plugin at ${dir}: ${error instanceof Error ? error.message : String(error)}`);
+    return null;
+  }
+}
+
+export async function discoverUnifiedManifestPlugins(
+  options: UnifiedManifestPluginOptions = {},
+): Promise<LoadedUnifiedManifestPlugin[]> {
+  const plugins: LoadedUnifiedManifestPlugin[] = [];
+  const seen = new Set<string>();
+  const scanDirs: Array<[string, string]> = [
+    ['user', options.userDir ?? USER_PLUGIN_DIR],
+    ['bundled', options.bundledDir ?? BUNDLED_PLUGIN_DIR],
+  ];
+
+  for (const [, baseDir] of scanDirs) {
+    if (!existsSync(baseDir)) continue;
+    for (const entry of readdirSync(baseDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const loaded = await loadPluginDir(join(baseDir, entry.name));
+      if (!loaded || seen.has(loaded.manifest.name)) continue;
+      seen.add(loaded.manifest.name);
+      plugins.push(loaded);
+    }
+  }
+
+  return plugins;
+}
+
+async function invokeUnifiedPlugin(
+  plugin: LoadedUnifiedManifestPlugin,
+  context: UnifiedInvokeContext,
+): Promise<UnifiedInvokeResult> {
+  const mod = await import(pathToFileURL(plugin.entryPath).href);
+  const handler = mod.default;
+  if (typeof handler !== 'function') {
+    return { ok: false, error: `plugin ${plugin.manifest.name}: default export must be a function` };
+  }
+
+  return await Promise.race([
+    handler(context) as Promise<UnifiedInvokeResult>,
+    new Promise<UnifiedInvokeResult>((_, reject) =>
+      setTimeout(() => reject(new Error(`plugin ${plugin.manifest.name} timed out after ${TIMEOUT_MS}ms`)), TIMEOUT_MS),
+    ),
+  ]) ?? { ok: true };
+}
+
+function responseFromResult(result: UnifiedInvokeResult): Response | Record<string, unknown> | unknown {
+  if (!result.ok) {
+    return Response.json(
+      { ok: false, error: result.error ?? 'plugin failed' },
+      { status: result.status ?? 500, headers: result.headers },
+    );
+  }
+  if (result.body !== undefined) return result.body;
+  if (result.output !== undefined) return { ok: true, output: result.output };
+  return { ok: true };
+}
+
+function apiRoutes(plugin: LoadedUnifiedManifestPlugin): ElysiaApp | undefined {
+  const api = plugin.manifest.api;
+  if (!api) return undefined;
+  const methods = (api.methods?.length ? api.methods : ['GET']).map((method) => method.toUpperCase());
+  const app = new Elysia();
+
+  for (const method of methods) {
+    (app as any).route(method, '/', async ({ request, params, query, body }: any) => {
+      try {
+        const result = await invokeUnifiedPlugin(plugin, {
+          source: 'api',
+          args: [],
+          request,
+          params,
+          query,
+          body,
+        });
+        return responseFromResult(result);
+      } catch (error) {
+        return Response.json(
+          { ok: false, error: error instanceof Error ? error.message : String(error) },
+          { status: 500 },
+        );
+      }
+    });
+  }
+
+  return app;
+}
+
+export function createUnifiedManifestServerPlugin(plugin: LoadedUnifiedManifestPlugin): ServerPlugin {
+  const routes = apiRoutes(plugin);
+  const lifecycle = plugin.manifest.lifecycle;
+  return {
+    name: plugin.manifest.name,
+    tier: plugin.manifest.tier ?? 'extra',
+    enabled: plugin.manifest.enabled,
+    seedMenu: plugin.manifest.seedMenu ?? true,
+    api: plugin.manifest.api,
+    routes: routes ? () => routes : undefined,
+    start: lifecycle?.start
+      ? async (server) => {
+          const result = await invokeUnifiedPlugin(plugin, {
+            source: 'lifecycle',
+            args: ['start'],
+            lifecycle: 'start',
+            server,
+          });
+          if (!result.ok) throw new Error(result.error ?? `plugin ${plugin.manifest.name} start failed`);
+        }
+      : undefined,
+    stop: lifecycle?.stop
+      ? async (server) => {
+          const result = await invokeUnifiedPlugin(plugin, {
+            source: 'lifecycle',
+            args: ['stop'],
+            lifecycle: 'stop',
+            server,
+          });
+          if (!result.ok) throw new Error(result.error ?? `plugin ${plugin.manifest.name} stop failed`);
+        }
+      : undefined,
+  };
+}
+
+export async function createUnifiedManifestServerPlugins(
+  options: UnifiedManifestPluginOptions = {},
+): Promise<ServerPlugin[]> {
+  const plugins = await discoverUnifiedManifestPlugins(options);
+  return plugins.map(createUnifiedManifestServerPlugin);
+}

--- a/tests/cli/plugin/unified-example.test.ts
+++ b/tests/cli/plugin/unified-example.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from 'bun:test';
+import { runCli } from '../_run.ts';
+
+test('bundled unified manifest plugin still exposes a CLI command', async () => {
+  const result = await runCli(['unified-example'], {
+    ORACLE_API: undefined,
+    NEO_ARRA_API: undefined,
+  });
+
+  expect(result.code).toBe(0);
+  expect(result.stdout).toContain('Hello from the unified-example plugin (cli surface)');
+}, 15_000);


### PR DESCRIPTION
Refs #1278 (Phase 5).

Adds the lean unified-manifest seam: a single `plugin.json` can now contribute CLI, HTTP route, and lifecycle surfaces from one handler that branches on `ctx.source`.

What changed:
- Extends CLI plugin manifest/types with optional `tier`, `enabled`, `seedMenu`, `api`, and `lifecycle` fields.
- Adds a server-side unified manifest adapter that scans existing CLI plugin directories, adapts `api` into server routes, and dispatches lifecycle `start`/`stop` through the same plugin entrypoint.
- Adds bundled opt-in `unified-example` proving one plugin entry handles CLI (`ctx.source=cli`), HTTP (`ctx.source=api`), and lifecycle (`ctx.source=lifecycle`).
- Keeps existing built-in server plugins behavior-preserving; unified plugins remain opt-in unless enabled by config/env.

Verification:
- `bun run build` → pass
- `bunx tsc -p cli/tsconfig.json --noEmit` → pass
- `bun run test:unit` → 284 pass
- `bun test tests/cli` → 42 pass
- Spare-port smoke with `ORACLE_ENABLED_PLUGINS=unified-example` → `/api/health` 200; `GET/POST /api/unified-example` 200 and dispatches through the unified handler.

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → Soul-Brews-Studio/arra-oracle-v3
