### PR TITLE
fix(lancedb): self-connect on first use so default/hybrid vector search works

### DIFF
--- a/src/vector/__tests__/lancedb-autoconnect.test.ts
+++ b/src/vector/__tests__/lancedb-autoconnect.test.ts
@@ -1,0 +1,73 @@
+/**
+ * LanceDB adapter self-connect — regression test.
+ *
+ * The MCP server builds the default vector store but only connect()s the
+ * per-model registry stores. Default/hybrid searches therefore reached
+ * query()/getStats() with this.db === null. ensureCollection() used to throw
+ * "LanceDB not connected" (swallowed by vectorSearch() into a silent FTS-only
+ * fallback), and getStats() returned { count: 0 } — so the health check
+ * reported vectorStatus = 'connected' over a store that was never opened.
+ *
+ * These tests pin the fix: an adapter that is NEVER explicitly connect()-ed
+ * must still answer getStats() and query() by auto-connecting on first use.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+import { LanceDBAdapter } from '../adapters/lancedb.ts';
+import type { EmbeddingProvider, EmbedType, VectorDocument } from '../types.ts';
+
+class StubEmbedder implements EmbeddingProvider {
+  readonly name = 'stub';
+  readonly dimensions = 8;
+  async embed(texts: string[], _type?: EmbedType): Promise<number[][]> {
+    // Deterministic 8-d vectors so tests don't depend on a model.
+    return texts.map((_, i) => Array.from({ length: 8 }, (_, j) => (i + 1) * 0.1 + j * 0.01));
+  }
+}
+
+const TMP_BASE = path.join(os.tmpdir(), `oracle-autoconnect-${Date.now()}`);
+const COLLECTION = 'autoconnect_test';
+
+describe('LanceDB adapter — self-connect on first use', () => {
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    tmpDir = path.join(TMP_BASE, 'col');
+    fs.mkdirSync(tmpDir, { recursive: true });
+
+    // Seed the on-disk table via a normally-connected adapter, then drop the
+    // handle. Fresh adapters below reuse the same dir/collection.
+    const seed = new LanceDBAdapter(COLLECTION, tmpDir, new StubEmbedder());
+    await seed.connect();
+    await seed.ensureCollection();
+    const docs: VectorDocument[] = [
+      { id: 'a', document: 'alpha', metadata: { type: 'note' }, vector: [0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9] },
+      { id: 'b', document: 'beta', metadata: { type: 'note' }, vector: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1] },
+    ];
+    await seed.addDocuments(docs);
+    await seed.close();
+  });
+
+  afterAll(async () => {
+    try { fs.rmSync(TMP_BASE, { recursive: true, force: true }); } catch {}
+  });
+
+  it('getStats() returns the real row count without an explicit connect()', async () => {
+    // Never call .connect() — mirrors the un-connected default store.
+    const adapter = new LanceDBAdapter(COLLECTION, tmpDir, new StubEmbedder());
+    const stats = await adapter.getStats();
+    expect(stats.count).toBe(2);
+    await adapter.close();
+  });
+
+  it('query() returns results without an explicit connect()', async () => {
+    const adapter = new LanceDBAdapter(COLLECTION, tmpDir, new StubEmbedder());
+    const res = await adapter.query('alpha', 5);
+    expect(res.ids.length).toBeGreaterThan(0);
+    expect(res.ids).toContain('a');
+    await adapter.close();
+  });
+});

--- a/src/vector/adapters/lancedb.ts
+++ b/src/vector/adapters/lancedb.ts
@@ -39,7 +39,15 @@ export class LanceDBAdapter implements VectorStoreAdapter {
   }
 
   async ensureCollection(): Promise<void> {
-    if (!this.db) throw new Error('LanceDB not connected');
+    // Self-connect if a caller reaches a query/write path without an explicit
+    // connect() first. The MCP server builds the default vector store but only
+    // connect()s the per-model registry stores — so hybrid/default searches hit
+    // this with this.db === null and used to throw "LanceDB not connected",
+    // which vectorSearch() swallowed into [] (silent FTS-only fallback). connect()
+    // is idempotent (early-returns when this.db is set), so this is safe to call
+    // on every path. See vector/factory.ts getVectorStoreByModel for the
+    // registry path that already pre-connects.
+    if (!this.db) await this.connect();
 
     const tableNames = await this.db.tableNames();
     if (tableNames.includes(this.collectionName)) {
@@ -216,6 +224,13 @@ export class LanceDBAdapter implements VectorStoreAdapter {
 
   async getStats(): Promise<{ count: number }> {
     if (!this.table) {
+      // Self-connect first so health checks report the real row count instead
+      // of a false 0. verifyVectorHealth() calls getStats() before any query;
+      // without this it saw this.db === null, returned { count: 0 }, and set
+      // vectorStatus = 'connected' while the store was never actually opened.
+      if (!this.db) {
+        try { await this.connect(); } catch {}
+      }
       // Try to open existing table
       if (this.db) {
         try {


### PR DESCRIPTION
## Problem

`oracle_stats` reports `vector_status: connected`, but **every** `oracle_search` returns `vectorMatches: 0` (silent FTS-only fallback) — *unless* you pass an explicit `model` (e.g. `model: "bge-m3"`), which works fine.

Observed on a healthy install: Ollama up, `bge-m3:latest` pulled, embeddings return 1024-d vectors, and the LanceDB table `oracle_knowledge_bge_m3` is fully populated. Yet default/hybrid search is blind.

## Root cause

`src/index.ts` builds the **default** vector store correctly:

```ts
this.vectorStore = createVectorStore({
  type: 'lancedb',
  collectionName: 'oracle_knowledge_bge_m3',
  embeddingProvider: 'ollama',
  embeddingModel: 'bge-m3',
});
```

…but it **never calls `connect()` on it**. Only the per-model registry stores get connected (`vector/factory.ts` → `getVectorStoreByModel` → `ensureVectorStoreConnected`, used when a `model` arg is passed).

So a default/hybrid search (no `model`) reaches `LanceDBAdapter.query()` with `this.db === null`:

1. `query()` → `ensureCollection()` → `throw new Error('LanceDB not connected')`
2. `search.ts` `vectorSearch()` catches it and returns `[]` → silent FTS-only fallback
3. Separately, `verifyVectorHealth()` calls `getStats()`, which returns `{ count: 0 }` **without connecting**, so `vectorStatus` is set to `'connected'` over a store that was never opened — the misleading status.

`searchTime: 0ms` on vector-only mode is the tell: it throws before ever embedding the query.

## Fix

Make the adapter self-healing — `connect()` is already idempotent (early-returns when `this.db` is set), so it's safe to call on any path:

- `ensureCollection()`: `if (!this.db) await this.connect();` instead of throwing
- `getStats()`: auto-connect before opening the table, so health checks report the real row count

This fixes both the silent query failure and the false health status, regardless of whether the caller pre-connected.

## Tests

- New `src/vector/__tests__/lancedb-autoconnect.test.ts` seeds a table, then drives `getStats()` and `query()` on a **never-connected** adapter. Fails on `main` with `LanceDB not connected`; passes with this change.
- Full `src/vector` + `src/tools` suites: no new failures introduced (the 7 pre-existing `LanceDBAdapter + Ollama` / `handleLearn` failures are present on `main` too, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)