### PR TITLE
docs(readme): fix MCP install command + link to Oracle 101 canonical guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For Docker MCP Toolkit / Gateway / n8n installs, see [docs/DOCKER-MCP-TOOLKIT.md
 arra-oracle-v3 (one package, two primary bins + legacy aliases)
 ├── bunx --package github:Soul-Brews-Studio/arra-oracle-v3 arra-oracle  → HTTP API (bin/arra.ts)
 ├── bunx --package github:Soul-Brews-Studio/arra-oracle-v3 arra-cli     → operator CLI (cli/src/cli.ts)
-├── bunx arra-oracle-v2                                                  → legacy MCP alias (src/index.ts)
+├── bunx --package github:Soul-Brews-Studio/arra-oracle-v3 arra-oracle-v2 → legacy MCP alias (src/index.ts)
 ├── bun run server                                                       → HTTP API (src/server.ts)
 └── bun run index                                                        → Indexer (src/indexer.ts)
 
@@ -67,7 +67,7 @@ existing installs, Docker commands, and MCP configs. See [docs/BINS.md](docs/BIN
 ### Add to Claude Code
 
 ```bash
-claude mcp add arra-oracle-v2 -- bunx --bun arra-oracle-v2@github:Soul-Brews-Studio/arra-oracle-v3#main
+claude mcp add arra-oracle-v2 -- bunx --bun --package github:Soul-Brews-Studio/arra-oracle-v3 arra-oracle-v2
 ```
 
 Or in `~/.claude.json`:
@@ -76,11 +76,17 @@ Or in `~/.claude.json`:
   "mcpServers": {
     "arra-oracle-v2": {
       "command": "bunx",
-      "args": ["--bun", "arra-oracle-v2@github:Soul-Brews-Studio/arra-oracle-v3#main"]
+      "args": ["--bun", "--package", "github:Soul-Brews-Studio/arra-oracle-v3", "arra-oracle-v2"]
     }
   }
 }
 ```
+
+> For a canonical install that shares `ORACLE_DATA_DIR` with Codex / the HTTP API
+> (and gives pinned-commit control + offline starts), see
+> [Oracle 101 — ch03 "ติดตั้งจาก 0"](https://oracle101.vercel.app/ch03.html).
+> §3.11 note: if both Claude Code and Codex are installed, they MUST point at
+> the same `ORACLE_DATA_DIR`.
 
 ### From source
 


### PR DESCRIPTION
## Summary

The `### Add to Claude Code` quickstart command in README starts the **HTTP server (Elysia)** on port 47778 instead of the **MCP stdio server**, because `bunx <bin>@<url>` requires `<bin>` to match the package name — and the package was renamed `arra-oracle-v2` → `arra-oracle-v3` while `arra-oracle-v2` was kept as a legacy bin alias. bunx cannot match the requested bin and falls back to the primary bin (`arra-oracle-v3` → `bin/arra.ts` HTTP server).

## Fix

Switch to the `--package` form already used elsewhere in the README (Architecture inline directory line 25-26, `bunx (recommended)` section). This is the minimal change that:

1. Makes the quickstart actually install MCP stdio (verified locally — `arra-oracle-v2: ✓ Connected` in `claude mcp list`).
2. Stays consistent with how every other bin is invoked in the same README.

The Architecture inline directory entry for `arra-oracle-v2` is updated to use the same `--package` form for consistency.

## Verification (local)

```
# Before (buggy README quickstart):
🔮 Arra Oracle HTTP Server running! (Elysia)
   URL:     http://localhost:47778

# After (--package form):
[Oracle] Running in HTTP-client mode
Arra Oracle MCP Server running on stdio (FTS5 mode)
arra-oracle-v2: ... - ✓ Connected
```

## Also

Added a pointer to [Oracle 101 ch03](https://oracle101.vercel.app/ch03.html), the canonical install guide. The README quickstart is a shortcut; ch03 covers the full path (local clone, `ORACLE_DATA_DIR`, HTTP API as MCP backend in HTTP-client mode, etc.). The §3.11 precaution about Codex + Claude Code sharing `ORACLE_DATA_DIR` is preserved as an inline note for users who'll install both agents.

## Environment

| | |
|---|---|
| Bun | 1.3.14 |
| Claude Code | 2.6.6 |
| arra-oracle-v3 | 26.6.1-alpha.1506 (commit `f96f28b`) |
| OS | Linux 6.8.0-1052-azure (GitHub Codespaces) |

— Argon Oracle 🌿 (AI, on behalf of @H25P1)