### PR TITLE
Core: add explicit MCP HTTP-proxy mode

### DIFF
--- a/cli/src/lib/api.ts
+++ b/cli/src/lib/api.ts
@@ -1,12 +1,17 @@
 /**
  * ARRA Oracle HTTP API helper for arra-cli plugins.
  *
- * Reads NEO_ARRA_API env (default http://localhost:47778).
+ * Reads ORACLE_API env, then legacy NEO_ARRA_API
+ * (default http://localhost:47778).
  * Note: issue #770 spec listed 3457 — real oracle default is 47778 (ORACLE_DEFAULT_PORT).
- * Override: NEO_ARRA_API=http://localhost:47778 arra-cli <cmd>
+ * Override: ORACLE_API=http://localhost:47778 arra-cli <cmd>
  */
 
-export const BASE_URL = (process.env.NEO_ARRA_API ?? "http://localhost:47778").replace(/\/$/, "");
+export function oracleApiBase(): string {
+  return (process.env.ORACLE_API ?? process.env.NEO_ARRA_API ?? "http://localhost:47778").replace(/\/$/, "");
+}
+
+export const BASE_URL = oracleApiBase();
 
 export async function apiFetch(path: string, opts?: RequestInit): Promise<Response> {
   const url = `${BASE_URL}${path}`;
@@ -17,7 +22,7 @@ export async function apiFetch(path: string, opts?: RequestInit): Promise<Respon
     throw new Error(
       `Cannot reach ARRA Oracle at ${BASE_URL}\n` +
       `  → Is the server running? Try: bun run server  (in arra-oracle-v3 repo)\n` +
-      `  → Or set NEO_ARRA_API=http://localhost:<port> to point to the right host\n` +
+      `  → Override with ORACLE_API=http://localhost:<port>\n` +
       `  Original: ${msg}`
     );
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,10 +13,8 @@ import {
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { type BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
-import { Database } from 'bun:sqlite';
+import type { Database } from 'bun:sqlite';
 import * as schema from './db/schema.ts';
-import { createDatabase } from './db/index.ts';
-import { createVectorStore } from './vector/factory.ts';
 import type { VectorStoreAdapter } from './vector/types.ts';
 import path from 'path';
 import fs from 'fs';
@@ -25,7 +23,7 @@ import { ORACLE_DATA_DIR, DB_PATH, REPO_ROOT } from './config.ts';
 import { MCP_SERVER_NAME } from './const.ts';
 
 // Tool handlers (all extracted to src/tools/)
-import type { ToolContext } from './tools/types.ts';
+import type { ToolContext, ToolResponse } from './tools/types.ts';
 import {
   searchToolDef, handleSearch,
   learnToolDef, handleLearn,
@@ -101,22 +99,205 @@ const WRITE_TOOLS = [
   'oracle_handoff',
 ];
 
+const EMBEDDED_API_VALUES = new Set(['embedded', 'embed', 'off', 'none', 'false', '0']);
+
+class OracleApiUnavailableError extends Error {
+  constructor(baseUrl: string, cause: unknown) {
+    const msg = cause instanceof Error ? cause.message : String(cause);
+    super(
+      `Cannot reach ARRA Oracle at ${baseUrl}\n` +
+      `  → Is the server running? Try: bun run server  (in arra-oracle-v3 repo)\n` +
+      `  → Set ORACLE_HTTP_URL=http://localhost:<port> for HTTP-proxy mode\n` +
+      `  → Or unset ORACLE_HTTP_URL to use direct embedded mode\n` +
+      `  Original: ${msg}`,
+    );
+    this.name = 'OracleApiUnavailableError';
+  }
+}
+
+function resolveOracleApiBase(): string | null {
+  const raw = process.env.ORACLE_HTTP_URL ?? process.env.ORACLE_API ?? process.env.NEO_ARRA_API;
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (!trimmed || EMBEDDED_API_VALUES.has(trimmed.toLowerCase())) return null;
+  return trimmed.replace(/\/+$/, '');
+}
+
+async function oracleApiFetch(baseUrl: string, apiPath: string, opts?: RequestInit): Promise<Response> {
+  const url = `${baseUrl}${apiPath}`;
+  try {
+    return await fetch(url, opts);
+  } catch (err) {
+    throw new OracleApiUnavailableError(baseUrl, err);
+  }
+}
+
+type ProxyRequest = {
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
+  path: string;
+  query?: Record<string, unknown>;
+  body?: unknown;
+};
+
+function cleanQueryValue(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return undefined;
+}
+
+function queryFrom(input: Record<string, unknown>, fields: Record<string, string>): Record<string, string> {
+  const query: Record<string, string> = {};
+  for (const [sourceKey, targetKey] of Object.entries(fields)) {
+    const value = cleanQueryValue(input[sourceKey]);
+    if (value !== undefined) query[targetKey] = value;
+  }
+  return query;
+}
+
+function appendQuery(pathname: string, query?: Record<string, unknown>): string {
+  if (!query || Object.keys(query).length === 0) return pathname;
+  const params = new URLSearchParams();
+  for (const [key, raw] of Object.entries(query)) {
+    const value = cleanQueryValue(raw);
+    if (value !== undefined) params.set(key, value);
+  }
+  const qs = params.toString();
+  return qs ? `${pathname}?${qs}` : pathname;
+}
+
+function proxyRequestForTool(toolName: string, args: Record<string, unknown>): ProxyRequest | null {
+  switch (toolName) {
+    case 'oracle_search':
+      return {
+        method: 'GET',
+        path: '/api/search',
+        query: {
+          q: args.query,
+          ...queryFrom(args, {
+            type: 'type',
+            limit: 'limit',
+            offset: 'offset',
+            mode: 'mode',
+            project: 'project',
+            cwd: 'cwd',
+            model: 'model',
+          }),
+        },
+      };
+    case 'oracle_learn':
+      return { method: 'POST', path: '/api/learn', body: args };
+    case 'oracle_stats':
+      return { method: 'GET', path: '/api/stats' };
+    case 'oracle_read':
+      return { method: 'GET', path: '/api/read', query: queryFrom(args, { file: 'file', id: 'id' }) };
+    case 'oracle_list':
+      return {
+        method: 'GET',
+        path: '/api/list',
+        query: {
+          ...queryFrom(args, { type: 'type', limit: 'limit', offset: 'offset' }),
+          group: 'false',
+        },
+      };
+    case 'oracle_inbox':
+      return { method: 'GET', path: '/api/inbox', query: queryFrom(args, { limit: 'limit', offset: 'offset', type: 'type' }) };
+    case 'oracle_handoff':
+      return { method: 'POST', path: '/api/handoff', body: args };
+    case 'oracle_thread':
+      return {
+        method: 'POST',
+        path: '/api/thread',
+        body: {
+          message: args.message,
+          thread_id: args.threadId,
+          title: args.title,
+          role: args.role ?? 'claude',
+          model: args.model,
+        },
+      };
+    case 'oracle_threads':
+      return { method: 'GET', path: '/api/threads', query: queryFrom(args, { status: 'status', limit: 'limit', offset: 'offset' }) };
+    case 'oracle_thread_read': {
+      const threadId = cleanQueryValue(args.threadId);
+      return threadId ? { method: 'GET', path: `/api/thread/${encodeURIComponent(threadId)}` } : null;
+    }
+    case 'oracle_thread_update': {
+      const threadId = cleanQueryValue(args.threadId);
+      return threadId ? { method: 'PATCH', path: `/api/thread/${encodeURIComponent(threadId)}/status`, body: { status: args.status } } : null;
+    }
+    case 'oracle_trace_list':
+      return { method: 'GET', path: '/api/traces', query: queryFrom(args, { query: 'query', status: 'status', project: 'project', limit: 'limit', offset: 'offset' }) };
+    case 'oracle_trace_get': {
+      const traceId = cleanQueryValue(args.traceId);
+      if (!traceId) return null;
+      return args.includeChain === true
+        ? { method: 'GET', path: `/api/traces/${encodeURIComponent(traceId)}/chain` }
+        : { method: 'GET', path: `/api/traces/${encodeURIComponent(traceId)}` };
+    }
+    case 'oracle_trace_link': {
+      const prevTraceId = cleanQueryValue(args.prevTraceId);
+      return prevTraceId ? { method: 'POST', path: `/api/traces/${encodeURIComponent(prevTraceId)}/link`, body: { nextId: args.nextTraceId } } : null;
+    }
+    case 'oracle_trace_unlink': {
+      const traceId = cleanQueryValue(args.traceId);
+      return traceId ? { method: 'DELETE', path: `/api/traces/${encodeURIComponent(traceId)}/link`, query: { direction: args.direction } } : null;
+    }
+    case 'oracle_trace_chain': {
+      const traceId = cleanQueryValue(args.traceId);
+      return traceId ? { method: 'GET', path: `/api/traces/${encodeURIComponent(traceId)}/linked-chain` } : null;
+    }
+    case 'oracle_reflect':
+      return { method: 'GET', path: '/api/reflect' };
+    default:
+      return null;
+  }
+}
+
+async function readHttpPayload(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function httpPayloadToToolResponse(payload: unknown, isError = false): ToolResponse {
+  return {
+    content: [{
+      type: 'text',
+      text: typeof payload === 'string' ? payload : JSON.stringify(payload, null, 2),
+    }],
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
 class OracleMCPServer {
   private server: Server;
-  private sqlite: Database;
-  private db: BunSQLiteDatabase<typeof schema>;
+  private sqlite: Database | null = null;
+  private db: BunSQLiteDatabase<typeof schema> | null = null;
   private repoRoot: string;
-  private vectorStore: VectorStoreAdapter;
+  private vectorStore: VectorStoreAdapter | null = null;
   private vectorStatus: 'unknown' | 'connected' | 'unavailable' = 'unknown';
   private readOnly: boolean;
   private version: string;
   private disabledTools: Set<string>;
   private stopToolGroupsWatch: (() => void) | null = null;
+  private embeddedReady: Promise<void> | null = null;
+  private readonly oracleApiBase: string | null;
 
   constructor(options: { readOnly?: boolean; toolGroups?: ToolGroupConfig } = {}) {
     this.readOnly = options.readOnly ?? false;
     if (this.readOnly) {
       console.error('[Oracle] Running in READ-ONLY mode');
+    }
+    this.oracleApiBase = resolveOracleApiBase();
+    if (this.oracleApiBase) {
+      console.error(`[Oracle] Running in HTTP-proxy mode (ORACLE_HTTP_URL → ${this.oracleApiBase})`);
+    } else {
+      console.error('[Oracle] Running in embedded mode (ORACLE_HTTP_URL unset)');
     }
     // Use safe REPO_ROOT from config.ts: never falls back to process.cwd(),
     // which would create parasitic ψ/ dirs in whatever directory the MCP
@@ -162,13 +343,6 @@ class OracleMCPServer {
       }, this.repoRoot);
     }
 
-    this.vectorStore = createVectorStore({
-      type: 'lancedb',
-      collectionName: 'oracle_knowledge_bge_m3',
-      embeddingProvider: 'ollama',
-      embeddingModel: 'bge-m3',
-    });
-
     const pkg = JSON.parse(fs.readFileSync(path.join(import.meta.dirname || __dirname, '..', 'package.json'), 'utf-8'));
     this.version = pkg.version;
     this.server = new Server(
@@ -176,17 +350,23 @@ class OracleMCPServer {
       { capabilities: { tools: {} } }
     );
 
-    const { sqlite, db } = createDatabase(DB_PATH);
-    this.sqlite = sqlite;
-    this.db = db;
+    if (!this.oracleApiBase) {
+      this.embeddedReady = this.initEmbedded();
+    }
 
     this.setupHandlers();
     this.setupErrorHandling();
-    this.verifyVectorHealth();
   }
 
   /** Build ToolContext from server state */
-  private get toolCtx(): ToolContext {
+  private async getToolCtx(): Promise<ToolContext> {
+    if (!this.embeddedReady) {
+      this.embeddedReady = this.initEmbedded();
+    }
+    await this.embeddedReady;
+    if (!this.sqlite || !this.db || !this.vectorStore) {
+      throw new Error('Embedded Oracle resources failed to initialize');
+    }
     return {
       db: this.db,
       sqlite: this.sqlite,
@@ -197,7 +377,32 @@ class OracleMCPServer {
     };
   }
 
+  private async initEmbedded(): Promise<void> {
+    if (this.sqlite && this.db && this.vectorStore) return;
+
+    const [{ createVectorStore }, { createDatabase }] = await Promise.all([
+      import('./vector/factory.ts'),
+      import('./db/index.ts'),
+    ]);
+
+    this.vectorStore = createVectorStore({
+      type: 'lancedb',
+      collectionName: 'oracle_knowledge_bge_m3',
+      embeddingProvider: 'ollama',
+      embeddingModel: 'bge-m3',
+    });
+
+    const { sqlite, db } = createDatabase(DB_PATH);
+    this.sqlite = sqlite;
+    this.db = db;
+    await this.verifyVectorHealth();
+  }
+
   private async verifyVectorHealth(): Promise<void> {
+    if (!this.vectorStore) {
+      this.vectorStatus = 'unavailable';
+      return;
+    }
     try {
       const stats = await this.vectorStore.getStats();
       if (stats.count > 0) {
@@ -225,8 +430,32 @@ class OracleMCPServer {
   }
 
   private async cleanup(): Promise<void> {
-    this.sqlite.close();
-    await this.vectorStore.close();
+    this.sqlite?.close();
+    await this.vectorStore?.close();
+  }
+
+  private async proxyToolCall(toolName: string, args: Record<string, unknown>): Promise<ToolResponse | null> {
+    if (!this.oracleApiBase) return null;
+
+    const proxyRequest = proxyRequestForTool(toolName, args);
+    if (!proxyRequest) return null;
+
+    const pathWithQuery = appendQuery(proxyRequest.path, proxyRequest.query);
+    try {
+      const response = await oracleApiFetch(this.oracleApiBase, pathWithQuery, {
+        method: proxyRequest.method,
+        headers: proxyRequest.body === undefined ? undefined : { 'content-type': 'application/json' },
+        body: proxyRequest.body === undefined ? undefined : JSON.stringify(proxyRequest.body),
+      });
+
+      const payload = await readHttpPayload(response);
+      return httpPayloadToToolResponse(payload, !response.ok);
+    } catch (err) {
+      if (err instanceof OracleApiUnavailableError) {
+        return httpPayloadToToolResponse(err.message, true);
+      }
+      throw err;
+    }
   }
 
   private setupHandlers(): void {
@@ -297,29 +526,51 @@ class OracleMCPServer {
         };
       }
 
-      const ctx = this.toolCtx;
-
       try {
+        const args = (request.params.arguments && typeof request.params.arguments === 'object')
+          ? request.params.arguments as Record<string, unknown>
+          : {};
+        const proxied = await this.proxyToolCall(toolName, args);
+        if (proxied) return proxied;
+
         switch (toolName) {
           // Core tools (delegated to src/tools/)
-          case 'oracle_search':
+          case 'oracle_search': {
+            const ctx = await this.getToolCtx();
             return await handleSearch(ctx, request.params.arguments as unknown as OracleSearchInput);
-          case 'oracle_read':
+          }
+          case 'oracle_read': {
+            const ctx = await this.getToolCtx();
             return await handleRead(ctx, request.params.arguments as unknown as OracleReadInput);
-          case 'oracle_learn':
+          }
+          case 'oracle_learn': {
+            const ctx = await this.getToolCtx();
             return await handleLearn(ctx, request.params.arguments as unknown as OracleLearnInput);
-          case 'oracle_list':
+          }
+          case 'oracle_list': {
+            const ctx = await this.getToolCtx();
             return await handleList(ctx, request.params.arguments as unknown as OracleListInput);
-          case 'oracle_stats':
+          }
+          case 'oracle_stats': {
+            const ctx = await this.getToolCtx();
             return await handleStats(ctx, request.params.arguments as unknown as OracleStatsInput);
-          case 'oracle_concepts':
+          }
+          case 'oracle_concepts': {
+            const ctx = await this.getToolCtx();
             return await handleConcepts(ctx, request.params.arguments as unknown as OracleConceptsInput);
-          case 'oracle_supersede':
+          }
+          case 'oracle_supersede': {
+            const ctx = await this.getToolCtx();
             return await handleSupersede(ctx, request.params.arguments as unknown as OracleSupersededInput);
-          case 'oracle_handoff':
+          }
+          case 'oracle_handoff': {
+            const ctx = await this.getToolCtx();
             return await handleHandoff(ctx, request.params.arguments as unknown as OracleHandoffInput);
-          case 'oracle_inbox':
+          }
+          case 'oracle_inbox': {
+            const ctx = await this.getToolCtx();
             return await handleInbox(ctx, request.params.arguments as unknown as OracleInboxInput);
+          }
           // Forum tools (delegated to src/tools/forum.ts)
           case 'oracle_thread':
             return await handleThread(request.params.arguments as unknown as OracleThreadInput);
@@ -345,10 +596,14 @@ class OracleMCPServer {
             return await handleTraceChain(request.params.arguments as unknown as { traceId: string });
 
           // Standalone tools (#972 wire — reflect + verify; schedule kept HTTP-only)
-          case 'oracle_reflect':
+          case 'oracle_reflect': {
+            const ctx = await this.getToolCtx();
             return await handleReflect(ctx, request.params.arguments as unknown as OracleReflectInput);
-          case 'oracle_verify':
+          }
+          case 'oracle_verify': {
+            const ctx = await this.getToolCtx();
             return await handleVerify(ctx, request.params.arguments as unknown as OracleVerifyInput);
+          }
 
           case '____IMPORTANT':
             return {
@@ -379,6 +634,12 @@ class OracleMCPServer {
   }
 
   async preConnectVector(): Promise<void> {
+    if (this.oracleApiBase) {
+      console.error('[Startup] Skipping vector pre-connect in HTTP-proxy mode');
+      return;
+    }
+    await this.getToolCtx();
+    if (!this.vectorStore) return;
     await this.vectorStore.connect();
   }
 

--- a/src/tools/__tests__/mcp-proxy-fallback.test.ts
+++ b/src/tools/__tests__/mcp-proxy-fallback.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Regression for #5 Phase 1:
+ * ORACLE_HTTP_URL toggles MCP dual-mode behavior.
+ * - unset: direct embedded mode for standalone usage
+ * - set: covered tools stay on the single HTTP writer path
+ */
+
+import { afterEach, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const repoRoot = resolve(import.meta.dir, '../../..');
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('MCP uses embedded mode when ORACLE_HTTP_URL is unset', async () => {
+  const dataDir = mkdtempSync(join(tmpdir(), 'arra-mcp-fallback-'));
+  tempDirs.push(dataDir);
+
+  const transport = new StdioClientTransport({
+    command: 'bun',
+    args: [join(repoRoot, 'src/index.ts')],
+    env: {
+      ...process.env,
+      ORACLE_HTTP_URL: '',
+      ORACLE_API: '',
+      NEO_ARRA_API: '',
+      ORACLE_DATA_DIR: dataDir,
+      ORACLE_INDEXER_ENQUEUE: '0',
+    },
+    stderr: 'pipe',
+  });
+
+  const stderr: string[] = [];
+  transport.stderr?.on('data', (chunk) => stderr.push(chunk.toString()));
+
+  const client = new Client(
+    { name: 'mcp-proxy-fallback-test', version: '0.0.0' },
+    { capabilities: {} },
+  );
+
+  try {
+    await client.connect(transport);
+
+    const result = await client.callTool({
+      name: 'oracle_search',
+      arguments: { query: 'standalone fallback smoke', mode: 'fts', limit: 1 },
+    }) as { content?: Array<{ type: string; text: string }>; isError?: boolean };
+
+    expect(result.isError).not.toBe(true);
+    expect(result.content?.[0]?.text).toContain('"results"');
+    expect(stderr.join('')).toContain('Running in embedded mode');
+  } finally {
+    await client.close();
+  }
+}, 20_000);
+
+test('MCP covered tools return HTTP error when ORACLE_HTTP_URL is unreachable', async () => {
+  const dataDir = mkdtempSync(join(tmpdir(), 'arra-mcp-http-'));
+  tempDirs.push(dataDir);
+
+  const transport = new StdioClientTransport({
+    command: 'bun',
+    args: [join(repoRoot, 'src/index.ts')],
+    env: {
+      ...process.env,
+      ORACLE_HTTP_URL: 'http://127.0.0.1:1',
+      ORACLE_API: '',
+      NEO_ARRA_API: '',
+      ORACLE_DATA_DIR: dataDir,
+      ORACLE_INDEXER_ENQUEUE: '0',
+    },
+    stderr: 'pipe',
+  });
+
+  const stderr: string[] = [];
+  transport.stderr?.on('data', (chunk) => stderr.push(chunk.toString()));
+
+  const client = new Client(
+    { name: 'mcp-proxy-http-test', version: '0.0.0' },
+    { capabilities: {} },
+  );
+
+  try {
+    await client.connect(transport);
+
+    const result = await client.callTool({
+      name: 'oracle_search',
+      arguments: { query: 'http proxy smoke', mode: 'fts', limit: 1 },
+    }) as { content?: Array<{ type: string; text: string }>; isError?: boolean };
+
+    expect(result.isError).toBe(true);
+    expect(result.content?.[0]?.text).toContain('Cannot reach ARRA Oracle at http://127.0.0.1:1');
+    expect(stderr.join('')).toContain('Running in HTTP-proxy mode');
+    expect(stderr.join('')).not.toContain('lazy-opening embedded fallback');
+  } finally {
+    await client.close();
+  }
+}, 20_000);

--- a/src/tools/forum.ts
+++ b/src/tools/forum.ts
@@ -5,15 +5,16 @@
  * since forum handlers use their own module-scoped DB.
  */
 
-import {
-  handleThreadMessage,
-  listThreads,
-  getFullThread,
-  getMessages,
-  updateThreadStatus,
-} from '../forum/handler.ts';
-
 import type { ToolResponse } from './types.ts';
+
+type ForumHandlerModule = typeof import('../forum/handler.ts');
+let forumHandlerModule: ForumHandlerModule | null = null;
+async function loadForumHandler(): Promise<ForumHandlerModule> {
+  if (!forumHandlerModule) {
+    forumHandlerModule = await import('../forum/handler.ts');
+  }
+  return forumHandlerModule;
+}
 
 // ============================================================================
 // Input interfaces
@@ -160,6 +161,7 @@ export async function handleThread(input: OracleThreadInput): Promise<ToolRespon
   // Prevents handleThreadMessage's unconditional status-flip from silently
   // re-opening closed threads on continuation calls.
   if (typeof input.threadId === 'number') {
+    const { getFullThread } = await loadForumHandler();
     const existing = getFullThread(input.threadId);
     if (existing && existing.thread.status === 'closed' && input.reopen !== true) {
       return {
@@ -177,6 +179,7 @@ export async function handleThread(input: OracleThreadInput): Promise<ToolRespon
     }
   }
 
+  const { handleThreadMessage } = await loadForumHandler();
   const result = await handleThreadMessage({
     message: input.message,
     threadId: input.threadId,
@@ -204,6 +207,7 @@ export async function handleThread(input: OracleThreadInput): Promise<ToolRespon
 }
 
 export async function handleThreads(input: OracleThreadsInput): Promise<ToolResponse> {
+  const { listThreads, getMessages } = await loadForumHandler();
   const result = listThreads({
     status: input.status as any,
     limit: input.limit || 20,
@@ -248,6 +252,7 @@ export async function handleThreadRead(input: OracleThreadReadInput): Promise<To
       isError: true
     };
   }
+  const { getFullThread } = await loadForumHandler();
   const threadData = getFullThread(input.threadId);
   if (!threadData) throw new Error(`Thread ${input.threadId} not found`);
 
@@ -309,6 +314,7 @@ export async function handleThreadUpdate(input: OracleThreadUpdateInput): Promis
     };
   }
 
+  const { updateThreadStatus, getFullThread } = await loadForumHandler();
   updateThreadStatus(input.threadId, input.status);
   const threadData = getFullThread(input.threadId);
 

--- a/src/tools/handoff.ts
+++ b/src/tools/handoff.ts
@@ -7,9 +7,16 @@
 
 import path from 'path';
 import fs from 'fs';
-import { getVaultPsiRoot } from '../vault/handler.ts';
 import { detectProject } from '../server/project-detect.ts';
 import type { ToolContext, ToolResponse, OracleHandoffInput } from './types.ts';
+
+let getVaultPsiRootFn: typeof import('../vault/handler.ts').getVaultPsiRoot | null = null;
+async function loadGetVaultPsiRoot(): Promise<typeof import('../vault/handler.ts').getVaultPsiRoot> {
+  if (!getVaultPsiRootFn) {
+    getVaultPsiRootFn = (await import('../vault/handler.ts')).getVaultPsiRoot;
+  }
+  return getVaultPsiRootFn;
+}
 
 export const handoffToolDef = {
   name: 'oracle_handoff',
@@ -97,6 +104,7 @@ export async function handleHandoff(ctx: ToolContext, input: OracleHandoffInput)
   const filename = `${dateStr}_${timeStr}_${slug}.md`;
 
   // Resolve vault root for central writes
+  const getVaultPsiRoot = await loadGetVaultPsiRoot();
   const vault = getVaultPsiRoot();
   if ('needsInit' in vault) console.error(`[Vault] ${vault.hint}`);
   const vaultRoot = 'path' in vault ? vault.path : null;

--- a/src/tools/learn.ts
+++ b/src/tools/learn.ts
@@ -9,7 +9,6 @@ import path from 'path';
 import fs from 'fs';
 import { oracleDocuments } from '../db/schema.ts';
 import { detectProject } from '../server/project-detect.ts';
-import { getVaultPsiRoot } from '../vault/handler.ts';
 import { getVectorStoreByModel, getEmbeddingModels } from '../vector/factory.ts';
 import { REPO_ROOT } from '../config.ts';
 
@@ -28,6 +27,13 @@ async function loadEnqueue(): Promise<typeof enqueueIndexJob> {
     // Indexer not available — learn still works, just no async job queuing
   }
   return enqueueIndexJob;
+}
+let getVaultPsiRootFn: typeof import('../vault/handler.ts').getVaultPsiRoot | null = null;
+async function loadGetVaultPsiRoot(): Promise<typeof import('../vault/handler.ts').getVaultPsiRoot> {
+  if (!getVaultPsiRootFn) {
+    getVaultPsiRootFn = (await import('../vault/handler.ts')).getVaultPsiRoot;
+  }
+  return getVaultPsiRootFn;
 }
 import type { ToolContext, ToolResponse, OracleLearnInput } from './types.ts';
 
@@ -171,6 +177,7 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
   const filename = `${dateStr}_${slug}.md`;
 
   // Resolve vault root for central writes
+  const getVaultPsiRoot = await loadGetVaultPsiRoot();
   const vault = getVaultPsiRoot();
   if ('needsInit' in vault) console.error(`[Vault] ${vault.hint}`);
   const vaultRoot = 'path' in vault ? vault.path : null;

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -7,8 +7,15 @@
 
 import fs from 'fs';
 import path from 'path';
-import { getVaultPsiRoot } from '../vault/handler.ts';
 import type { ToolContext, ToolResponse, OracleReadInput } from './types.ts';
+
+let getVaultPsiRootFn: typeof import('../vault/handler.ts').getVaultPsiRoot | null = null;
+async function loadGetVaultPsiRoot(): Promise<typeof import('../vault/handler.ts').getVaultPsiRoot> {
+  if (!getVaultPsiRootFn) {
+    getVaultPsiRootFn = (await import('../vault/handler.ts')).getVaultPsiRoot;
+  }
+  return getVaultPsiRootFn;
+}
 
 export const readToolDef = {
   name: 'oracle_read',
@@ -54,11 +61,11 @@ function extractProject(filePath: string): { project: string; remainder: string 
  * Try to resolve a source_file path to a readable absolute path.
  * Returns the absolute path if found, null otherwise.
  */
-function resolveFilePath(
+async function resolveFilePath(
   sourceFile: string,
   repoRoot: string,
   ghqRoot: string,
-): string | null {
+): Promise<string | null> {
   // 1. Try direct from repoRoot (handles "ψ/memory/..." paths)
   const directPath = path.join(repoRoot, sourceFile);
   if (fs.existsSync(directPath)) return fs.realpathSync(directPath);
@@ -71,6 +78,7 @@ function resolveFilePath(
   }
 
   // 3. Try vault fallback
+  const getVaultPsiRoot = await loadGetVaultPsiRoot();
   const vault = getVaultPsiRoot();
   if ('path' in vault) {
     const vaultPath = path.join(vault.path, sourceFile);
@@ -125,7 +133,7 @@ export async function handleRead(ctx: ToolContext, input: OracleReadInput): Prom
   }
 
   const ghqRoot = detectGhqRoot(ctx.repoRoot);
-  const resolvedPath = resolveFilePath(sourceFile!, ctx.repoRoot, ghqRoot);
+  const resolvedPath = await resolveFilePath(sourceFile!, ctx.repoRoot, ghqRoot);
 
   // File found on disk
   if (resolvedPath && isPathAllowed(resolvedPath, ctx.repoRoot, ghqRoot)) {

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -6,12 +6,19 @@
  * combineResults, vectorSearch) for testability.
  */
 
-import { logSearch } from '../server/logging.ts';
 import { detectProject } from '../server/project-detect.ts';
 import { rerankCandidates } from '../server/reranker.ts';
 import { ensureVectorStoreConnected } from '../vector/factory.ts';
 import type { SearchResult } from '../server/types.ts';
 import type { ToolContext, ToolResponse, OracleSearchInput } from './types.ts';
+
+let logSearchFn: typeof import('../server/logging.ts').logSearch | null = null;
+async function loadLogSearch(): Promise<typeof import('../server/logging.ts').logSearch> {
+  if (!logSearchFn) {
+    logSearchFn = (await import('../server/logging.ts')).logSearch;
+  }
+  return logSearchFn;
+}
 
 export const searchToolDef = {
   name: 'oracle_search',
@@ -481,6 +488,7 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
   console.error(`[MCP:SEARCH] "${query}" (${type}, ${mode}, model=${model || 'default'}) → ${results.length} results in ${searchTime}ms`);
 
   try {
+    const logSearch = await loadLogSearch();
     logSearch(query, type, mode, results.length, searchTime, results as unknown as SearchResult[]);
   } catch (e) {
     console.error('[MCP:SEARCH] Failed to log search to database:', e);

--- a/src/tools/trace.ts
+++ b/src/tools/trace.ts
@@ -5,16 +5,6 @@
  * since trace handlers use their own module-scoped DB.
  */
 
-import {
-  createTrace,
-  getTrace,
-  listTraces,
-  getTraceChain,
-  linkTraces,
-  unlinkTraces,
-  getTraceLinkedChain,
-} from '../trace/handler.ts';
-
 import type {
   CreateTraceInput,
   ListTracesInput,
@@ -22,6 +12,15 @@ import type {
 } from '../trace/types.ts';
 
 import type { ToolResponse } from './types.ts';
+
+type TraceHandlerModule = typeof import('../trace/handler.ts');
+let traceHandlerModule: TraceHandlerModule | null = null;
+async function loadTraceHandler(): Promise<TraceHandlerModule> {
+  if (!traceHandlerModule) {
+    traceHandlerModule = await import('../trace/handler.ts');
+  }
+  return traceHandlerModule;
+}
 
 // ============================================================================
 // Tool definitions
@@ -161,6 +160,7 @@ export async function handleTrace(input: CreateTraceInput): Promise<ToolResponse
       isError: true
     };
   }
+  const { createTrace } = await loadTraceHandler();
   const result = createTrace(input);
   console.error(`[MCP:TRACE] query="${input.query}" depth=${result.depth} digPoints=${result.summary.totalDigPoints}`);
 
@@ -184,6 +184,7 @@ export async function handleTrace(input: CreateTraceInput): Promise<ToolResponse
 }
 
 export async function handleTraceList(input: ListTracesInput): Promise<ToolResponse> {
+  const { listTraces } = await loadTraceHandler();
   const result = listTraces(input);
   console.error(`[MCP:TRACE_LIST] found=${result.total} returned=${result.traces.length}`);
 
@@ -225,6 +226,7 @@ export async function handleTraceGet(input: GetTraceInput): Promise<ToolResponse
       isError: true
     };
   }
+  const { getTrace, getTraceChain } = await loadTraceHandler();
   const trace = getTrace(input.traceId);
   if (!trace) throw new Error(`Trace ${input.traceId} not found`);
 
@@ -277,6 +279,7 @@ export async function handleTraceGet(input: GetTraceInput): Promise<ToolResponse
 }
 
 export async function handleTraceLink(input: { prevTraceId: string; nextTraceId: string }): Promise<ToolResponse> {
+  const { linkTraces } = await loadTraceHandler();
   const result = linkTraces(input.prevTraceId, input.nextTraceId);
   if (!result.success) throw new Error(result.message);
 
@@ -304,6 +307,7 @@ export async function handleTraceLink(input: { prevTraceId: string; nextTraceId:
 }
 
 export async function handleTraceUnlink(input: { traceId: string; direction: 'prev' | 'next' }): Promise<ToolResponse> {
+  const { unlinkTraces } = await loadTraceHandler();
   const result = unlinkTraces(input.traceId, input.direction);
   if (!result.success) throw new Error(result.message);
 
@@ -333,6 +337,7 @@ export async function handleTraceChain(input: { traceId: string }): Promise<Tool
       isError: true
     };
   }
+  const { getTraceLinkedChain } = await loadTraceHandler();
   const result = getTraceLinkedChain(input.traceId);
   console.error(`[MCP:TRACE_CHAIN] id=${input.traceId} chain_length=${result.chain.length} position=${result.position}`);
 

--- a/src/tools/verify.ts
+++ b/src/tools/verify.ts
@@ -4,8 +4,15 @@
  * Wraps src/verify/handler.ts for consistency with tools/ pattern.
  */
 
-import { verifyKnowledgeBase } from '../verify/handler.ts';
 import type { ToolContext, ToolResponse, OracleVerifyInput } from './types.ts';
+
+let verifyKnowledgeBaseFn: typeof import('../verify/handler.ts').verifyKnowledgeBase | null = null;
+async function loadVerifyKnowledgeBase(): Promise<typeof import('../verify/handler.ts').verifyKnowledgeBase> {
+  if (!verifyKnowledgeBaseFn) {
+    verifyKnowledgeBaseFn = (await import('../verify/handler.ts')).verifyKnowledgeBase;
+  }
+  return verifyKnowledgeBaseFn;
+}
 
 export const verifyToolDef = {
   name: 'oracle_verify',
@@ -31,6 +38,7 @@ export const verifyToolDef = {
 export async function handleVerify(ctx: ToolContext, input: OracleVerifyInput): Promise<ToolResponse> {
   const { check = true, type } = input;
 
+  const verifyKnowledgeBase = await loadVerifyKnowledgeBase();
   const result = verifyKnowledgeBase({
     check,
     type,


### PR DESCRIPTION
## Summary
- Add explicit dual-mode MCP routing: embedded by default, HTTP proxy when `ORACLE_HTTP_URL` is set.
- Proxy covered MCP tools to the single HTTP writer (`/api/search`, `/api/learn`, `/api/stats`, plus existing HTTP-equivalent routes) without opening SQLite/vector resources in proxy mode.
- Preserve compatibility aliases (`ORACLE_API`, `NEO_ARRA_API`) behind the requested `ORACLE_HTTP_URL` env and keep embedded fallback for tools without HTTP coverage.

Closes #5
Closes Soul-Brews-Studio/arra-oracle-v3-oracle#5

## Test Plan
- [x] `bun test --isolate src/tools/__tests__/mcp-proxy-fallback.test.ts`
- [x] `bun test --isolate $(find src/tools/__tests__ -maxdepth 1 -name '*.test.ts' -print)`
- [x] `bunx tsc -p tsconfig.json --noEmit`

## Notes
- Not live fleet-soaked against many concurrent sessions; local regression verifies unset embedded mode and set unreachable HTTP mode does not lazy-open embedded SQLite for covered tools.
