### PR TITLE
Commands: add arra bin alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ See [docs/LOCAL-DEV.md](docs/LOCAL-DEV.md) for local development.
 ## Architecture
 
 ```
-arra-oracle-v3 (one package, two bins)
-├── bunx arra-oracle-v2                          → MCP server (src/index.ts)
-├── bunx --package arra-oracle-v2 oracle-vault   → Vault CLI (src/vault/cli.ts)
-├── bun run server                          → HTTP API (src/server.ts)
-└── bun run index                           → Indexer (src/indexer.ts)
+arra-oracle-v3 (one package, four bins)
+├── bunx arra-oracle-v3                     → HTTP API / server launcher (bin/arra.ts)
+├── bunx arra-oracle-v2                     → MCP server (src/index.ts)
+├── bunx arra-cli                           → operator CLI (cli/src/cli.ts)
+└── bunx arra                               → operator CLI alias (cli/src/cli.ts)
 
 oracle-studio (separate repo)
 └── bunx oracle-studio                      → React dashboard
@@ -48,14 +48,15 @@ Distributed via GitHub — no npm publish needed:
 # Backend (MCP server)
 bunx --bun arra-oracle@github:Soul-Brews-Studio/arra-oracle-v3
 
-# CLI (plugin runner)
+# Operator CLI (plugin runner)
 bunx --bun arra-cli@github:Soul-Brews-Studio/arra-oracle-v3 --help
+
+# Short operator CLI alias
+bunx --bun arra@github:Soul-Brews-Studio/arra-oracle-v3 health
 
 # UI (dashboard — separate repo)
 bunx --bun oracle-studio@github:Soul-Brews-Studio/oracle-studio
 
-# Vault CLI (secondary bin — use --package)
-bunx --bun --package arra-oracle-v2@github:Soul-Brews-Studio/arra-oracle-v3#main oracle-vault --help
 ```
 
 ### Add to Claude Code

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "bin": {
     "arra-oracle-v3": "./bin/arra.ts",
     "arra-oracle-v2": "./src/index.ts",
-    "arra-cli": "./cli/src/cli.ts"
+    "arra-cli": "./cli/src/cli.ts",
+    "arra": "./cli/src/cli.ts"
   },
   "files": [
     "bin",


### PR DESCRIPTION
## Summary
- add `arra` as a bin alias for the existing operator CLI entrypoint
- keep `arra-cli` unchanged for backward compatibility
- update the README bin list from 3 to 4 entries

Closes Soul-Brews-Studio/arra-oracle-v3-oracle#7

## Verification
- `node -e "const p=require('./package.json'); if(p.bin.arra !== './cli/src/cli.ts') process.exit(1)"`
- `bun run build`
- isolated `HOME`/`BUN_INSTALL`: `bun install -g file:$PWD` listed binaries including `arra`; with local server running, `arra health` returned `Status: ok`

## Notes
- The tracker issue lives in `arra-oracle-v3-oracle`; the package source lives in `arra-oracle-v3`, so the close reference is fully qualified.