### PR TITLE
Core: make vector collections adapter-configurable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -380,17 +380,13 @@ class OracleMCPServer {
   private async initEmbedded(): Promise<void> {
     if (this.sqlite && this.db && this.vectorStore) return;
 
-    const [{ createVectorStore }, { createDatabase }] = await Promise.all([
+    const [{ createVectorStoreForModel, getEmbeddingModels }, { createDatabase }] = await Promise.all([
       import('./vector/factory.ts'),
       import('./db/index.ts'),
     ]);
 
-    this.vectorStore = createVectorStore({
-      type: 'lancedb',
-      collectionName: 'oracle_knowledge_bge_m3',
-      embeddingProvider: 'ollama',
-      embeddingModel: 'bge-m3',
-    });
+    const models = getEmbeddingModels();
+    this.vectorStore = createVectorStoreForModel(models['bge-m3']);
 
     const { sqlite, db } = createDatabase(DB_PATH);
     this.sqlite = sqlite;

--- a/src/indexer/daemon.ts
+++ b/src/indexer/daemon.ts
@@ -15,8 +15,8 @@
 
 import Database from 'bun:sqlite';
 import { Elysia } from 'elysia';
-import { DB_PATH, LANCEDB_DIR } from '../config.ts';
-import { createVectorStore, getEmbeddingModels } from '../vector/factory.ts';
+import { DB_PATH } from '../config.ts';
+import { createVectorStoreForModel, getEmbeddingModels } from '../vector/factory.ts';
 import { runWorker, type WorkerEvent } from './worker.ts';
 import { daemonApiPlugin, makeEventBus } from '../routes/indexer-daemon/index.ts';
 
@@ -42,17 +42,13 @@ export async function startDaemon(): Promise<void> {
 
   // Embed via the existing factory — produces a model-aware OllamaEmbeddings.
   // Lazy per model so we don't spin up unused embedders.
-  const stores = new Map<string, ReturnType<typeof createVectorStore>>();
-  const getStore = async (modelKey: string, collection: string) => {
+  const stores = new Map<string, ReturnType<typeof createVectorStoreForModel>>();
+  const getStore = async (modelKey: string) => {
     let s = stores.get(modelKey);
     if (!s) {
-      s = createVectorStore({
-        type: 'lancedb',
-        dataPath: LANCEDB_DIR,
-        collectionName: collection,
-        embeddingProvider: 'ollama',
-        embeddingModel: modelKey,
-      });
+      const preset = models[modelKey];
+      if (!preset) throw new Error(`Unknown model_key: ${modelKey}`);
+      s = createVectorStoreForModel(preset);
       await s.connect();
       await s.ensureCollection();
       stores.set(modelKey, s);
@@ -63,7 +59,7 @@ export async function startDaemon(): Promise<void> {
   const embed = async (modelKey: string, text: string): Promise<number[]> => {
     const preset = models[modelKey];
     if (!preset) throw new Error(`Unknown model_key: ${modelKey}`);
-    const store = await getStore(modelKey, preset.collection);
+    const store = await getStore(modelKey);
     const embedder = (store as { embedder?: { embed: (texts: string[], type?: 'query' | 'passage') => Promise<number[][]> } }).embedder;
     if (!embedder) throw new Error(`No embedder on store for ${modelKey}`);
     const [vector] = await embedder.embed([text], 'passage');
@@ -74,7 +70,7 @@ export async function startDaemon(): Promise<void> {
     const entry = Object.entries(models).find(([, m]) => m.collection === collection);
     if (!entry) throw new Error(`No registered model has collection: ${collection}`);
     const [modelKey] = entry;
-    const store = await getStore(modelKey, collection);
+    const store = await getStore(modelKey);
     await store.addDocuments([{ id: docId, document: '', metadata: { id: docId, indexed_at: Date.now() } }]);
     // TODO: extend VectorStoreAdapter with `upsert(id, vector, metadata)`
     // that doesn't re-embed. For now we accept the extra Ollama call.

--- a/src/routes/indexer/config.ts
+++ b/src/routes/indexer/config.ts
@@ -8,12 +8,12 @@ export const configEndpoint = new Elysia().get('/indexer/config', async () => {
     key,
     model: m.model,
     collection: m.collection,
+    adapter: m.adapter || 'lancedb',
     dims: key === 'nomic' ? 768 : key === 'bge-m3' ? 1024 : 4096,
     speed: key === 'nomic' ? '~100 doc/s' : key === 'bge-m3' ? '~50 doc/s' : '~30 doc/s',
   }));
 
   const adapters = ['lancedb', 'sqlite-vec', 'chroma', 'qdrant', 'cloudflare-vectorize'];
-  const currentAdapter = process.env.ORACLE_VECTOR_DB || 'lancedb';
 
   let ollamaModels: string[] = [];
   try {
@@ -24,7 +24,7 @@ export const configEndpoint = new Elysia().get('/indexer/config', async () => {
     }
   } catch {}
 
-  return { adapters, models: modelList, ollamaModels, currentAdapter };
+  return { adapters, models: modelList, ollamaModels };
 }, {
   detail: {
     tags: ['indexer'],

--- a/src/routes/indexer/start.ts
+++ b/src/routes/indexer/start.ts
@@ -1,5 +1,5 @@
 import { Elysia, t } from 'elysia';
-import { createVectorStore, getEmbeddingModels } from '../../vector/factory.ts';
+import { createVectorStoreForModel, getEmbeddingModels } from '../../vector/factory.ts';
 import { createDatabase } from '../../db/index.ts';
 import { setIndexingStatus } from '../../indexer/status.ts';
 import { DB_PATH, REPO_ROOT } from '../../config.ts';
@@ -30,13 +30,7 @@ export const startEndpoint = new Elysia().post('/indexer/start', async ({ body }
     },
   };
 
-  const store = createVectorStore({
-    type: 'lancedb',
-    collectionName: preset.collection,
-    embeddingProvider: 'ollama',
-    embeddingModel: preset.model,
-    ...(preset.dataPath && { dataPath: preset.dataPath }),
-  });
+  const store = createVectorStoreForModel(preset);
 
   abortFlag = false;
 

--- a/src/routes/vector/indexer.ts
+++ b/src/routes/vector/indexer.ts
@@ -13,7 +13,7 @@
 
 import { Elysia, t } from 'elysia';
 import { Database } from 'bun:sqlite';
-import { createVectorStore, getEmbeddingModels } from '../../vector/factory.ts';
+import { createVectorStoreForModel, getEmbeddingModels } from '../../vector/factory.ts';
 import { DB_PATH } from '../../config.ts';
 
 // ── In-memory status (no sqlite writes — avoids the disk I/O problem) ──
@@ -85,13 +85,7 @@ export const vectorIndexerEndpoints = new Elysia()
 
         currentJob.total = rows.length;
 
-        const store = createVectorStore({
-          type: 'lancedb',
-          collectionName: preset.collection,
-          embeddingProvider: 'ollama',
-          embeddingModel: preset.model,
-          ...(preset.dataPath && { dataPath: preset.dataPath }),
-        });
+        const store = createVectorStoreForModel(preset);
 
         await store.connect();
         try { await store.deleteCollection(); } catch {}
@@ -164,22 +158,17 @@ export const vectorIndexerEndpoints = new Elysia()
   // GET /vector/index/models
   .get('/vector/index/models', async () => {
     const models = getEmbeddingModels();
-    const result: Record<string, { collection: string; model: string; count?: number }> = {};
+    const result: Record<string, { collection: string; model: string; adapter: string; count?: number }> = {};
 
     for (const [key, preset] of Object.entries(models)) {
-      const entry: { collection: string; model: string; count?: number } = {
+      const entry: { collection: string; model: string; adapter: string; count?: number } = {
         collection: preset.collection,
         model: preset.model,
+        adapter: preset.adapter || 'lancedb',
       };
 
       try {
-        const store = createVectorStore({
-          type: 'lancedb',
-          collectionName: preset.collection,
-          embeddingProvider: 'ollama',
-          embeddingModel: preset.model,
-          ...(preset.dataPath && { dataPath: preset.dataPath }),
-        });
+        const store = createVectorStoreForModel(preset);
         await store.connect();
         const stats = await store.getStats();
         entry.count = stats.count;

--- a/src/scripts/index-model.ts
+++ b/src/scripts/index-model.ts
@@ -9,7 +9,7 @@
  *   bun src/scripts/index-model.ts nomic
  */
 
-import { createVectorStore, EMBEDDING_MODELS } from '../vector/factory.ts';
+import { createVectorStoreForModel, EMBEDDING_MODELS } from '../vector/factory.ts';
 import { createDatabase, oracleDocuments } from '../db/index.ts';
 import { count } from 'drizzle-orm';
 import { DB_PATH } from '../config.ts';
@@ -32,6 +32,7 @@ async function main() {
   console.log(`DB: ${DB_PATH}`);
   console.log(`Collection: ${preset.collection}`);
   console.log(`Model: ${preset.model}`);
+  console.log(`Adapter: ${preset.adapter || 'lancedb'}`);
   console.log(`Batch size: ${BATCH_SIZE}`);
 
   // Use Drizzle for structured queries, raw sqlite only for FTS5 joins
@@ -39,13 +40,7 @@ async function main() {
   const [{ total: docCount }] = db.select({ total: count() }).from(oracleDocuments).all();
   console.log(`Documents: ${docCount}`);
 
-  const store = createVectorStore({
-    type: 'lancedb',
-    collectionName: preset.collection,
-    embeddingProvider: 'ollama',
-    embeddingModel: preset.model,
-    ...(preset.dataPath && { dataPath: preset.dataPath }),
-  });
+  const store = createVectorStoreForModel(preset);
 
   await store.connect();
 

--- a/src/scripts/index-qwen3.ts
+++ b/src/scripts/index-qwen3.ts
@@ -1,39 +1,33 @@
 #!/usr/bin/env bun
 /**
- * Index oracle knowledge with qwen3-embedding into a separate LanceDB collection.
+ * Index oracle knowledge with qwen3-embedding into its configured vector collection.
  * Runs alongside the default nomic-embed-text collection.
  *
  * Usage: bun src/scripts/index-qwen3.ts
  *
- * Creates: ~/.chromadb/oracle_knowledge_qwen3.lance/
- * (same LanceDB dir as default, different table name)
+ * Adapter defaults to LanceDB, but follows vector-server.json when configured.
  */
 
-import { createVectorStore } from '../vector/factory.ts';
+import { createVectorStoreForModel, getEmbeddingModels } from '../vector/factory.ts';
 import { Database } from 'bun:sqlite';
 import { DB_PATH } from '../config.ts';
 
 const BATCH_SIZE = 50; // Smaller batches — qwen3 is slower per embedding
-const COLLECTION = 'oracle_knowledge_qwen3';
 
 async function main() {
+  const preset = getEmbeddingModels().qwen3;
   console.log('=== Qwen3-Embedding Indexer ===');
   console.log(`DB: ${DB_PATH}`);
-  console.log(`Collection: ${COLLECTION}`);
-  console.log(`Model: qwen3-embedding (4096 dims)`);
+  console.log(`Collection: ${preset.collection}`);
+  console.log(`Model: ${preset.model} (4096 dims)`);
+  console.log(`Adapter: ${preset.adapter || 'lancedb'}`);
 
   // Open oracle.db to read documents
   const db = new Database(DB_PATH, { readonly: true });
   const total = db.query('SELECT COUNT(*) as count FROM oracle_documents').get() as { count: number };
   console.log(`Documents: ${total.count}`);
 
-  // Create LanceDB store with qwen3
-  const store = createVectorStore({
-    type: 'lancedb',
-    collectionName: COLLECTION,
-    embeddingProvider: 'ollama',
-    embeddingModel: 'qwen3-embedding',
-  });
+  const store = createVectorStoreForModel(preset);
 
   await store.connect();
 

--- a/src/vector/__tests__/adapters.test.ts
+++ b/src/vector/__tests__/adapters.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, test, expect, afterAll } from 'bun:test';
-import { createVectorStore } from '../factory.ts';
+import { createVectorStore, createVectorStoreForModel } from '../factory.ts';
 import { createEmbeddingProvider, OllamaEmbeddings } from '../embeddings.ts';
 import { SqliteVecAdapter } from '../adapters/sqlite-vec.ts';
 import { ChromaMcpAdapter } from '../adapters/chroma-mcp.ts';
@@ -159,6 +159,17 @@ describe('createVectorStore factory', () => {
     if (orig) process.env.ORACLE_VECTOR_DB = orig;
     else delete process.env.ORACLE_VECTOR_DB;
     delete process.env.ORACLE_VECTOR_DB_PATH;
+  });
+
+  test('creates model store from per-collection adapter config', () => {
+    const store = createVectorStoreForModel({
+      collection: 'oracle_test_qdrant',
+      model: 'bge-m3',
+      adapter: 'qdrant',
+    });
+
+    expect(store.name).toBe('qdrant');
+    expect(store).toBeInstanceOf(QdrantAdapter);
   });
 });
 

--- a/src/vector/config.ts
+++ b/src/vector/config.ts
@@ -12,6 +12,7 @@ import fs from 'fs';
 import path from 'path';
 import { ORACLE_DATA_DIR, LANCEDB_DIR } from '../config.ts';
 import { COLLECTION_NAME } from '../const.ts';
+import type { VectorDBType } from './types.ts';
 
 export const VECTOR_CONFIG_FILE = 'vector-server.json';
 
@@ -19,6 +20,8 @@ export interface VectorCollectionConfig {
   collection: string;
   model: string;
   provider: string;
+  /** Vector adapter for this collection. Defaults to lancedb for embedded Bun. */
+  adapter?: VectorDBType;
   primary?: boolean;
 }
 
@@ -50,17 +53,20 @@ export function generateDefaultConfig(): VectorServerConfig {
         collection: 'oracle_knowledge_bge_m3',
         model: 'bge-m3',
         provider: 'ollama',
+        adapter: 'lancedb',
         primary: true,
       },
       nomic: {
         collection: COLLECTION_NAME,
         model: 'nomic-embed-text',
         provider: 'ollama',
+        adapter: 'lancedb',
       },
       qwen3: {
         collection: 'oracle_knowledge_qwen3',
         model: 'qwen3-embedding',
         provider: 'ollama',
+        adapter: 'lancedb',
       },
     },
     dataPath: LANCEDB_DIR,
@@ -100,12 +106,13 @@ export function writeVectorConfig(config: VectorServerConfig): string {
  */
 export function configToModels(
   config: VectorServerConfig,
-): Record<string, { collection: string; model: string; dataPath?: string }> {
-  const out: Record<string, { collection: string; model: string; dataPath?: string }> = {};
+): Record<string, { collection: string; model: string; adapter?: VectorDBType; dataPath?: string }> {
+  const out: Record<string, { collection: string; model: string; adapter?: VectorDBType; dataPath?: string }> = {};
   for (const [key, col] of Object.entries(config.collections)) {
     out[key] = {
       collection: col.collection,
       model: col.model,
+      adapter: col.adapter || 'lancedb',
       dataPath: config.dataPath || undefined,
     };
   }

--- a/src/vector/factory.ts
+++ b/src/vector/factory.ts
@@ -35,6 +35,13 @@ export interface VectorStoreConfig {
   cfApiToken?: string;
 }
 
+export interface EmbeddingModelConfig {
+  collection: string;
+  model: string;
+  adapter?: VectorDBType;
+  dataPath?: string;
+}
+
 /**
  * Create a VectorStoreAdapter from config or env vars.
  *
@@ -132,7 +139,7 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
 // Model-based registry for dual-index search
 // ============================================================================
 
-export function getEmbeddingModels(): Record<string, { collection: string; model: string; dataPath?: string }> {
+export function getEmbeddingModels(): Record<string, EmbeddingModelConfig> {
   // If vector-server.json exists, use it as source of truth (#1071 phase 2)
   const cfg = loadVectorConfig();
   if (cfg) return configToModels(cfg);
@@ -142,23 +149,26 @@ export function getEmbeddingModels(): Record<string, { collection: string; model
     nomic: {
       collection: COLLECTION_NAME,
       model: 'nomic-embed-text',
+      adapter: 'lancedb',
       dataPath: LANCEDB_DIR,
     },
     qwen3: {
       collection: 'oracle_knowledge_qwen3',
       model: 'qwen3-embedding',
+      adapter: 'lancedb',
       dataPath: LANCEDB_DIR,
     },
     'bge-m3': {
       collection: 'oracle_knowledge_bge_m3',
       model: 'bge-m3',
+      adapter: 'lancedb',
       dataPath: LANCEDB_DIR,
     },
   };
 }
 
 /** @deprecated Use getEmbeddingModels() — kept for backward compat */
-export const EMBEDDING_MODELS = new Proxy({} as Record<string, { collection: string; model: string; dataPath?: string }>, {
+export const EMBEDDING_MODELS = new Proxy({} as Record<string, EmbeddingModelConfig>, {
   get(_, prop: string) { return getEmbeddingModels()[prop]; },
   has(_, prop: string) { return prop in getEmbeddingModels(); },
   ownKeys() { return Object.keys(getEmbeddingModels()); },
@@ -177,19 +187,23 @@ const modelStoreCache = new Map<string, VectorStoreAdapter>();
  */
 const connectPromises = new Map<string, Promise<void>>();
 
+export function createVectorStoreForModel(preset: EmbeddingModelConfig): VectorStoreAdapter {
+  return createVectorStore({
+    type: preset.adapter || 'lancedb',
+    collectionName: preset.collection,
+    embeddingProvider: 'ollama',
+    embeddingModel: preset.model,
+    ...(preset.dataPath && { dataPath: preset.dataPath }),
+  });
+}
+
 export function getVectorStoreByModel(model?: string): VectorStoreAdapter {
   const models = getEmbeddingModels();
   const key = model && models[model] ? model : 'bge-m3';
   let store = modelStoreCache.get(key);
   if (!store) {
     const preset = models[key];
-    store = createVectorStore({
-      type: 'lancedb',
-      collectionName: preset.collection,
-      embeddingProvider: 'ollama',
-      embeddingModel: preset.model,
-      ...(preset.dataPath && { dataPath: preset.dataPath }),
-    });
+    store = createVectorStoreForModel(preset);
     modelStoreCache.set(key, store);
     // Auto-connect in background (non-blocking)
     connectPromises.set(key, store.connect().catch(e =>


### PR DESCRIPTION
## Summary
- Add `adapter` to each vector collection config entry, defaulting generated config/fallbacks to `lancedb`.
- Centralize model-registry store creation in `createVectorStoreForModel()` so per-collection config can route to Qdrant/LanceDB without code edits.
- Replace production LanceDB hardcodes in MCP embedded init, indexer endpoints, vector indexer endpoints, daemon, and scripts with factory-resolved adapter creation.

Closes #10
Closes Soul-Brews-Studio/arra-oracle-v3-oracle#10

## Test Plan
- [x] `bun test --isolate src/vector/__tests__/adapters.test.ts src/tools/__tests__/learn-enqueue.test.ts`
- [x] `bunx tsc -p tsconfig.json --noEmit`

## Follow-ups intentionally not fixed here
- Qdrant re-embed behavior parity.
- 32-bit hash collision risk.
