### PR TITLE
Core: close Qdrant adapter parity gaps

### DIFF
--- a/src/vector/__tests__/adapters.test.ts
+++ b/src/vector/__tests__/adapters.test.ts
@@ -12,7 +12,7 @@ import { createEmbeddingProvider, OllamaEmbeddings } from '../embeddings.ts';
 import { SqliteVecAdapter } from '../adapters/sqlite-vec.ts';
 import { ChromaMcpAdapter } from '../adapters/chroma-mcp.ts';
 import { LanceDBAdapter } from '../adapters/lancedb.ts';
-import { QdrantAdapter } from '../adapters/qdrant.ts';
+import { QdrantAdapter, qdrantPointId } from '../adapters/qdrant.ts';
 import type { VectorStoreAdapter, VectorDocument } from '../types.ts';
 import { Database } from 'bun:sqlite';
 import path from 'path';
@@ -170,6 +170,43 @@ describe('createVectorStore factory', () => {
 
     expect(store.name).toBe('qdrant');
     expect(store).toBeInstanceOf(QdrantAdapter);
+  });
+});
+
+describe('QdrantAdapter parity helpers', () => {
+  test('qdrantPointId is a stable UUID, not a 32-bit integer hash', () => {
+    const id = qdrantPointId('learning_2026-06-06_qdrant-parity');
+
+    expect(id).toBe(qdrantPointId('learning_2026-06-06_qdrant-parity'));
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    expect(Number.isInteger(Number(id))).toBe(false);
+  });
+
+  test('addDocuments honors doc.vector and embeds only missing vectors', async () => {
+    const embedCalls: string[][] = [];
+    const embedder = {
+      name: 'fake',
+      dimensions: 3,
+      embed: async (texts: string[]) => {
+        embedCalls.push(texts);
+        return texts.map((_, i) => [9 + i, 8 + i, 7 + i]);
+      },
+    };
+    const upserts: any[] = [];
+    const adapter = new QdrantAdapter('oracle_test_qdrant_parity', embedder);
+    (adapter as any).client = {
+      upsert: async (_collection: string, payload: any) => upserts.push(payload),
+    };
+
+    await adapter.addDocuments([
+      { id: 'with-vector', document: 'already embedded', metadata: { type: 'learning' }, vector: [1, 2, 3] },
+      { id: 'without-vector', document: 'needs embedding', metadata: { type: 'learning' } },
+    ]);
+
+    expect(embedCalls).toEqual([['needs embedding']]);
+    expect(upserts[0].points[0].vector).toEqual([1, 2, 3]);
+    expect(upserts[0].points[1].vector).toEqual([9, 8, 7]);
+    expect(upserts[0].points[0].id).toBe(qdrantPointId('with-vector'));
   });
 });
 

--- a/src/vector/adapters/qdrant.ts
+++ b/src/vector/adapters/qdrant.ts
@@ -6,6 +6,18 @@
  */
 
 import type { VectorStoreAdapter, VectorDocument, VectorQueryResult, EmbeddingProvider } from '../types.ts';
+import { createHash } from 'node:crypto';
+
+export function qdrantPointId(id: string): string {
+  const hex = createHash('sha256').update(id).digest('hex').slice(0, 32);
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    `5${hex.slice(13, 16)}`,
+    ((parseInt(hex.slice(16, 17), 16) & 0x3) | 0x8).toString(16) + hex.slice(17, 20),
+    hex.slice(20, 32),
+  ].join('-');
+}
 
 export class QdrantAdapter implements VectorStoreAdapter {
   readonly name = 'qdrant';
@@ -75,12 +87,20 @@ export class QdrantAdapter implements VectorStoreAdapter {
     if (docs.length === 0) return;
     if (!this.client) throw new Error('Qdrant not connected');
 
-    const texts = docs.map(d => d.document);
-    const embeddings = await this.embedder.embed(texts, 'passage');
+    const needEmbed: number[] = [];
+    for (let i = 0; i < docs.length; i++) {
+      if (!docs[i].vector) needEmbed.push(i);
+    }
+
+    let fresh: number[][] = [];
+    if (needEmbed.length > 0) {
+      fresh = await this.embedder.embed(needEmbed.map(i => docs[i].document), 'passage');
+    }
+    let freshIdx = 0;
 
     const points = docs.map((doc, i) => ({
-      id: this.hashId(doc.id),
-      vector: embeddings[i],
+      id: this.pointId(doc.id),
+      vector: doc.vector ?? fresh[freshIdx++],
       payload: {
         _id: doc.id,
         document: doc.document,
@@ -89,7 +109,12 @@ export class QdrantAdapter implements VectorStoreAdapter {
     }));
 
     await this.client.upsert(this.collectionName, { points });
-    console.log(`[Qdrant] Added ${docs.length} documents`);
+    const reused = docs.length - needEmbed.length;
+    if (reused > 0) {
+      console.log(`[Qdrant] Added ${docs.length} documents (${reused} with precomputed vectors)`);
+    } else {
+      console.log(`[Qdrant] Added ${docs.length} documents`);
+    }
   }
 
   async query(text: string, limit: number = 10, where?: Record<string, any>): Promise<VectorQueryResult> {
@@ -125,11 +150,11 @@ export class QdrantAdapter implements VectorStoreAdapter {
   async queryById(id: string, nResults: number = 5): Promise<VectorQueryResult> {
     if (!this.client) throw new Error('Qdrant not connected');
 
-    const numericId = this.hashId(id);
+    const pointId = this.pointId(id);
 
     // Get the point's vector (retrieve replaces getPoints in newer client versions)
     const points = await this.client.retrieve(this.collectionName, {
-      ids: [numericId],
+      ids: [pointId],
       with_vector: true,
     });
 
@@ -175,15 +200,11 @@ export class QdrantAdapter implements VectorStoreAdapter {
   }
 
   /**
-   * Convert string ID to numeric hash for Qdrant (requires integer or UUID IDs).
-   * Uses FNV-1a hash for deterministic mapping.
+   * Convert arbitrary document IDs to stable UUID-shaped point IDs.
+   * Qdrant accepts UUID strings; SHA-256 avoids the old 32-bit FNV collision
+   * space while keeping deterministic lookup for queryById().
    */
-  private hashId(id: string): number {
-    let hash = 0x811c9dc5;
-    for (let i = 0; i < id.length; i++) {
-      hash ^= id.charCodeAt(i);
-      hash = Math.imul(hash, 0x01000193);
-    }
-    return hash >>> 0; // Ensure positive 32-bit integer
+  private pointId(id: string): string {
+    return qdrantPointId(id);
   }
 }


### PR DESCRIPTION
## Summary
- Make Qdrant `addDocuments()` honor precomputed `doc.vector` and only embed documents that lack vectors.
- Replace the 32-bit FNV numeric point hash with deterministic SHA-256-derived UUID point IDs.
- Add non-network adapter tests for both Qdrant parity fixes.

Closes #19
Closes Soul-Brews-Studio/arra-oracle-v3-oracle#19

## Test Plan
- [x] `bun test --isolate src/vector/__tests__/adapters.test.ts`
- [x] `bunx tsc -p tsconfig.json --noEmit`

## Notes
- Live Qdrant integration remains availability-gated by the existing test block.
- Existing Qdrant points written with numeric hash IDs would need a migration if preserving an old Qdrant collection matters.
