### PR TITLE
Commands: add native layered API target config

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,36 @@ bun run dev          # MCP server
 bun run server       # HTTP API on :47778
 ```
 
+### Operator CLI targets
+
+`arra` and `arra-cli` resolve the HTTP API target in this order:
+
+1. `ORACLE_API=http://host:47778`
+2. `arra --at <name> <command>` from configured targets
+3. nearest project `.arra/config.json` default target
+4. global `$XDG_CONFIG_HOME/arra/config.json` (or `~/.config/arra/config.json`) default target
+5. legacy `NEO_ARRA_API`
+6. `http://localhost:47778`
+
+Config shape:
+
+```json
+{
+  "default": "local",
+  "targets": {
+    "local": "http://localhost:47778",
+    "m5": "http://m5.local:47778"
+  }
+}
+```
+
+```bash
+arra config          # show resolved target, sources, and targets
+arra config path     # print global config path
+arra use m5          # set global default target
+arra --at m5 health  # one-off target override
+```
+
 <details>
 <summary>Install script (legacy)</summary>
 

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -21,6 +21,7 @@ import {
   menuGistReload,
 } from "./commands/menu-gist.ts";
 import { menuResetAll } from "./commands/menu-reset.ts";
+import { configCommand, useCommand } from "./commands/config.ts";
 
 const pkg = await Bun.file(join(import.meta.dir, "../package.json")).json();
 const VERSION: string = pkg.version;
@@ -32,10 +33,13 @@ function printHelp(commands: Array<{ command: string; help?: string }>) {
   console.log(`  ${"plugin".padEnd(16)}manage plugins (install)`);
   console.log(`  ${"session".padEnd(16)}inspect sessions (list, show, context)`);
   console.log(`  ${"menu".padEnd(16)}inspect and customize studio menu (list, add, remove)`);
+  console.log(`  ${"config".padEnd(16)}show resolved API target and config sources`);
+  console.log(`  ${"use".padEnd(16)}set the global default API target`);
   for (const { command, help } of commands) {
     console.log(`  ${command.padEnd(16)}${help ?? ""}`);
   }
   console.log("\nFlags:");
+  console.log("  --at <name>       Run against a named ARRA target from config");
   console.log("  --help, -h        Show this help");
   console.log("  -h <command>      Show command help + flags");
   console.log("  --version         Show version");
@@ -68,11 +72,29 @@ async function loadAll() {
 
 async function main() {
   const args = process.argv.slice(2);
+  const atIndex = args.indexOf("--at");
+  if (atIndex >= 0) {
+    const target = args[atIndex + 1];
+    if (!target) {
+      console.error("usage: arra --at <name> <command>");
+      process.exit(1);
+    }
+    process.env.ARRA_AT = target;
+    args.splice(atIndex, 2);
+  }
   const cmd = args[0]?.toLowerCase();
 
   if (cmd === "--version" || cmd === "version") {
     console.log(`arra-cli v${VERSION}`);
     return;
+  }
+
+  if (cmd === "config") {
+    process.exit(await configCommand(args.slice(1)));
+  }
+
+  if (cmd === "use") {
+    process.exit(await useCommand(args.slice(1)));
   }
 
   if (cmd === "session") {

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -1,0 +1,47 @@
+import { loadConfigSources, mergedTargets, resolveOracleApiBase, globalConfigPath, writeGlobalDefault } from "../lib/config.ts";
+
+export async function configCommand(args: string[]): Promise<number> {
+  const sub = args[0]?.toLowerCase();
+  if (sub === "path") {
+    console.log(globalConfigPath());
+    return 0;
+  }
+  if (sub === "use") {
+    const name = args[1];
+    if (!name) {
+      console.error("usage: arra config use <name>");
+      return 1;
+    }
+    const path = writeGlobalDefault(name);
+    console.log(`Set global ARRA target to '${name}' (${path})`);
+    return 0;
+  }
+  if (sub && sub !== "show") {
+    console.error(`unknown config subcommand: ${args[0]}`);
+    console.error("try: arra config [show|path|use <name>]");
+    return 1;
+  }
+
+  const resolved = resolveOracleApiBase();
+  const sources = loadConfigSources();
+  const targets = mergedTargets(sources);
+  const data = {
+    resolved,
+    configPath: globalConfigPath(),
+    sources: sources.map(s => ({ kind: s.kind, path: s.path, default: s.config.default })),
+    targets,
+  };
+  console.log(JSON.stringify(data, null, 2));
+  return 0;
+}
+
+export async function useCommand(args: string[]): Promise<number> {
+  const name = args[0];
+  if (!name) {
+    console.error("usage: arra use <name>");
+    return 1;
+  }
+  const path = writeGlobalDefault(name);
+  console.log(`Set global ARRA target to '${name}' (${path})`);
+  return 0;
+}

--- a/cli/src/lib/api.ts
+++ b/cli/src/lib/api.ts
@@ -1,28 +1,27 @@
 /**
  * ARRA Oracle HTTP API helper for arra-cli plugins.
  *
- * Reads ORACLE_API env, then legacy NEO_ARRA_API
+ * Resolves ORACLE_API, --at, project/global ARRA config, then legacy NEO_ARRA_API
  * (default http://localhost:47778).
  * Note: issue #770 spec listed 3457 — real oracle default is 47778 (ORACLE_DEFAULT_PORT).
  * Override: ORACLE_API=http://localhost:47778 arra-cli <cmd>
  */
 
-export function oracleApiBase(): string {
-  return (process.env.ORACLE_API ?? process.env.NEO_ARRA_API ?? "http://localhost:47778").replace(/\/$/, "");
-}
+import { oracleApiBase } from "./config.ts";
 
-export const BASE_URL = oracleApiBase();
+export { oracleApiBase };
 
 export async function apiFetch(path: string, opts?: RequestInit): Promise<Response> {
-  const url = `${BASE_URL}${path}`;
+  const baseUrl = oracleApiBase();
+  const url = `${baseUrl}${path}`;
   try {
     return await fetch(url, opts);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     throw new Error(
-      `Cannot reach ARRA Oracle at ${BASE_URL}\n` +
+      `Cannot reach ARRA Oracle at ${baseUrl}\n` +
       `  → Is the server running? Try: bun run server  (in arra-oracle-v3 repo)\n` +
-      `  → Override with ORACLE_API=http://localhost:<port>\n` +
+      `  → Override with ORACLE_API=http://localhost:<port> or arra --at <target> <command>\n` +
       `  Original: ${msg}`
     );
   }

--- a/cli/src/lib/config.ts
+++ b/cli/src/lib/config.ts
@@ -1,0 +1,136 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, join, parse } from "path";
+import { homedir } from "os";
+
+export interface ArraConfig {
+  default?: string;
+  targets?: Record<string, string>;
+}
+
+export interface ConfigSource {
+  kind: "project" | "global";
+  path: string;
+  config: ArraConfig;
+}
+
+export interface ResolvedApiBase {
+  url: string;
+  source: "ORACLE_API" | "--at" | "project" | "global" | "NEO_ARRA_API" | "default";
+  target?: string;
+  path?: string;
+}
+
+const DEFAULT_API_BASE = "http://localhost:47778";
+
+function cleanUrl(url: string): string {
+  return url.replace(/\/$/, "");
+}
+
+function readConfig(path: string): ArraConfig | null {
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as ArraConfig;
+    return {
+      default: typeof parsed.default === "string" ? parsed.default : undefined,
+      targets: parsed.targets && typeof parsed.targets === "object" ? parsed.targets : undefined,
+    };
+  } catch (err) {
+    throw new Error(`Failed to read ARRA config at ${path}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+export function globalConfigPath(env: NodeJS.ProcessEnv = process.env): string {
+  const base = env.XDG_CONFIG_HOME && env.XDG_CONFIG_HOME.trim()
+    ? env.XDG_CONFIG_HOME
+    : join(env.HOME || homedir(), ".config");
+  return join(base, "arra", "config.json");
+}
+
+export function findProjectConfigPath(cwd: string = process.cwd()): string | null {
+  let dir = cwd;
+  while (true) {
+    const candidate = join(dir, ".arra", "config.json");
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir || dir === parse(dir).root) return null;
+    dir = parent;
+  }
+}
+
+export function loadConfigSources(options: {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+} = {}): ConfigSource[] {
+  const env = options.env ?? process.env;
+  const sources: ConfigSource[] = [];
+  const globalPath = globalConfigPath(env);
+  const globalConfig = readConfig(globalPath);
+  if (globalConfig) sources.push({ kind: "global", path: globalPath, config: globalConfig });
+
+  const projectPath = findProjectConfigPath(options.cwd ?? process.cwd());
+  if (projectPath) {
+    const projectConfig = readConfig(projectPath);
+    if (projectConfig) sources.push({ kind: "project", path: projectPath, config: projectConfig });
+  }
+  return sources;
+}
+
+export function mergedTargets(sources: ConfigSource[]): Record<string, string> {
+  const targets: Record<string, string> = {};
+  for (const source of sources) Object.assign(targets, source.config.targets ?? {});
+  return targets;
+}
+
+function targetUrl(targets: Record<string, string>, name: string): string | undefined {
+  const value = targets[name];
+  return typeof value === "string" && value.trim() ? cleanUrl(value) : undefined;
+}
+
+export function resolveOracleApiBase(options: {
+  at?: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+} = {}): ResolvedApiBase {
+  const env = options.env ?? process.env;
+  if (env.ORACLE_API?.trim()) return { url: cleanUrl(env.ORACLE_API), source: "ORACLE_API" };
+
+  const sources = loadConfigSources({ cwd: options.cwd, env });
+  const targets = mergedTargets(sources);
+  const at = options.at ?? env.ARRA_AT;
+  if (at?.trim()) {
+    const url = targetUrl(targets, at);
+    if (!url) throw new Error(`Unknown ARRA target '${at}'. Add it to .arra/config.json or ${globalConfigPath(env)}.`);
+    return { url, source: "--at", target: at };
+  }
+
+  const project = [...sources].reverse().find(s => s.kind === "project");
+  if (project?.config.default) {
+    const url = targetUrl(targets, project.config.default);
+    if (!url) throw new Error(`Project ARRA config default '${project.config.default}' has no matching target in ${project.path}.`);
+    return { url, source: "project", target: project.config.default, path: project.path };
+  }
+
+  const global = sources.find(s => s.kind === "global");
+  if (global?.config.default) {
+    const url = targetUrl(targets, global.config.default);
+    if (!url) throw new Error(`Global ARRA config default '${global.config.default}' has no matching target in ${global.path}.`);
+    return { url, source: "global", target: global.config.default, path: global.path };
+  }
+
+  if (env.NEO_ARRA_API?.trim()) return { url: cleanUrl(env.NEO_ARRA_API), source: "NEO_ARRA_API" };
+  return { url: DEFAULT_API_BASE, source: "default" };
+}
+
+export function oracleApiBase(): string {
+  return resolveOracleApiBase().url;
+}
+
+export function writeGlobalDefault(name: string, env: NodeJS.ProcessEnv = process.env): string {
+  const path = globalConfigPath(env);
+  const existing = readConfig(path) ?? { targets: {} };
+  const targets = existing.targets ?? {};
+  if (!targets[name]) throw new Error(`Unknown global ARRA target '${name}' in ${path}. Add it before selecting it.`);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify({ ...existing, targets, default: name }, null, 2) + "\n");
+  return path;
+}

--- a/tests/cli/_run.ts
+++ b/tests/cli/_run.ts
@@ -19,10 +19,12 @@ export interface RunResult {
 export async function runCli(
   args: string[],
   env: Record<string, string> = {},
+  options: { cwd?: string } = {},
 ): Promise<RunResult> {
   const proc = Bun.spawn(["bun", "run", CLI_ENTRY, ...args], {
     stdout: "pipe",
     stderr: "pipe",
+    cwd: options.cwd,
     env: { ...process.env, ...env },
   });
   const [stdout, stderr] = await Promise.all([

--- a/tests/cli/config/cli.test.ts
+++ b/tests/cli/config/cli.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { runCli } from "../_run.ts";
+
+function writeJson(path: string, value: unknown) {
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, JSON.stringify(value, null, 2));
+}
+
+function startHealthServer(serverName: string) {
+  return Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/health") {
+        return Response.json({
+          status: "ok",
+          server: serverName,
+          version: "test",
+          port: Number(new URL(req.url).port),
+          oracle: "connected",
+        });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+}
+
+describe("arra CLI layered config", () => {
+  let root: string;
+  let m5: ReturnType<typeof Bun.serve> | undefined;
+  let envServer: ReturnType<typeof Bun.serve> | undefined;
+
+  beforeEach(() => {
+    root = join(tmpdir(), `arra-cli-config-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+    m5 = startHealthServer("m5-target");
+    envServer = startHealthServer("env-target");
+  });
+
+  afterEach(() => {
+    m5?.stop(true);
+    envServer?.stop(true);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("--at selects a named XDG target for health", async () => {
+    const xdg = join(root, "xdg");
+    writeJson(join(xdg, "arra", "config.json"), {
+      default: "local",
+      targets: {
+        local: "http://localhost:47778",
+        m5: m5!.url.href,
+      },
+    });
+
+    const result = await runCli(["--at", "m5", "health"], {
+      HOME: join(root, "home"),
+      XDG_CONFIG_HOME: xdg,
+      ORACLE_API: "",
+      NEO_ARRA_API: "",
+    });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("Server:  m5-target");
+    expect(result.stdout).toContain(`Port:    ${m5!.url.port}`);
+  }, 15_000);
+
+  test("project .arra/config.json default selects the API target", async () => {
+    const repo = join(root, "repo", "nested");
+    mkdirSync(repo, { recursive: true });
+    writeJson(join(root, "repo", ".arra", "config.json"), {
+      default: "m5",
+      targets: { m5: m5!.url.href },
+    });
+
+    const result = await runCli(["health"], {
+      HOME: join(root, "home"),
+      XDG_CONFIG_HOME: join(root, "xdg"),
+      ORACLE_API: "",
+      NEO_ARRA_API: "",
+    }, { cwd: repo });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("Server:  m5-target");
+    expect(result.stdout).toContain(`Port:    ${m5!.url.port}`);
+  }, 15_000);
+
+  test("ORACLE_API still wins over --at", async () => {
+    const xdg = join(root, "xdg");
+    writeJson(join(xdg, "arra", "config.json"), {
+      default: "m5",
+      targets: { m5: m5!.url.href },
+    });
+
+    const result = await runCli(["--at", "m5", "health"], {
+      HOME: join(root, "home"),
+      XDG_CONFIG_HOME: xdg,
+      ORACLE_API: envServer!.url.href,
+      NEO_ARRA_API: "",
+    });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("Server:  env-target");
+    expect(result.stdout).toContain(`Port:    ${envServer!.url.port}`);
+  }, 15_000);
+});

--- a/tests/cli/config/resolve.test.ts
+++ b/tests/cli/config/resolve.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { resolveOracleApiBase, writeGlobalDefault } from "../../../cli/src/lib/config.ts";
+
+function writeJson(path: string, value: unknown) {
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, JSON.stringify(value, null, 2));
+}
+
+describe("ARRA layered API config resolution", () => {
+  let root: string;
+  let project: string;
+  let env: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    root = join(tmpdir(), `arra-config-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+    project = join(root, "repo", "nested");
+    mkdirSync(project, { recursive: true });
+    env = {
+      HOME: join(root, "home"),
+      XDG_CONFIG_HOME: join(root, "xdg"),
+    };
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("ORACLE_API wins over --at, project, global, and legacy env", () => {
+    writeJson(join(root, "xdg", "arra", "config.json"), {
+      default: "global",
+      targets: { global: "http://global:47778", m5: "http://m5:47778" },
+    });
+    writeJson(join(root, "repo", ".arra", "config.json"), {
+      default: "project",
+      targets: { project: "http://project:47778" },
+    });
+
+    const resolved = resolveOracleApiBase({
+      at: "m5",
+      cwd: project,
+      env: { ...env, ORACLE_API: "http://env:47778/", NEO_ARRA_API: "http://legacy:47778" },
+    });
+
+    expect(resolved).toEqual({ url: "http://env:47778", source: "ORACLE_API" });
+  });
+
+  test("--at resolves named targets from merged global and project configs", () => {
+    writeJson(join(root, "xdg", "arra", "config.json"), {
+      default: "global",
+      targets: { m5: "http://global-m5:47778", global: "http://global:47778" },
+    });
+    writeJson(join(root, "repo", ".arra", "config.json"), {
+      default: "project",
+      targets: { m5: "http://project-m5:47778", project: "http://project:47778" },
+    });
+
+    const resolved = resolveOracleApiBase({ at: "m5", cwd: project, env });
+
+    expect(resolved).toEqual({ url: "http://project-m5:47778", source: "--at", target: "m5" });
+  });
+
+  test("project default wins over global default and legacy env", () => {
+    writeJson(join(root, "xdg", "arra", "config.json"), {
+      default: "global",
+      targets: { global: "http://global:47778" },
+    });
+    writeJson(join(root, "repo", ".arra", "config.json"), {
+      default: "project",
+      targets: { project: "http://project:47778" },
+    });
+
+    const resolved = resolveOracleApiBase({ cwd: project, env: { ...env, NEO_ARRA_API: "http://legacy:47778" } });
+
+    expect(resolved.source).toBe("project");
+    expect(resolved.target).toBe("project");
+    expect(resolved.url).toBe("http://project:47778");
+  });
+
+  test("global default wins over legacy env when no project config exists", () => {
+    writeJson(join(root, "xdg", "arra", "config.json"), {
+      default: "global",
+      targets: { global: "http://global:47778" },
+    });
+
+    const resolved = resolveOracleApiBase({ cwd: project, env: { ...env, NEO_ARRA_API: "http://legacy:47778" } });
+
+    expect(resolved.source).toBe("global");
+    expect(resolved.target).toBe("global");
+    expect(resolved.url).toBe("http://global:47778");
+  });
+
+  test("legacy NEO_ARRA_API wins over fallback when no config exists", () => {
+    const resolved = resolveOracleApiBase({ cwd: project, env: { ...env, NEO_ARRA_API: "http://legacy:47778/" } });
+
+    expect(resolved).toEqual({ url: "http://legacy:47778", source: "NEO_ARRA_API" });
+  });
+
+  test("arra use writes the global default only for existing targets", () => {
+    writeJson(join(root, "xdg", "arra", "config.json"), {
+      default: "local",
+      targets: { local: "http://localhost:47778", m5: "http://m5:47778" },
+    });
+
+    const path = writeGlobalDefault("m5", env);
+    expect(path).toBe(join(root, "xdg", "arra", "config.json"));
+    const resolved = resolveOracleApiBase({ cwd: project, env });
+    expect(resolved.source).toBe("global");
+    expect(resolved.target).toBe("m5");
+    expect(resolved.url).toBe("http://m5:47778");
+  });
+});


### PR DESCRIPTION
## Summary
- add native API target resolution for `arra`/`arra-cli`: `ORACLE_API` → `--at` → project `.arra/config.json` → XDG global config → `NEO_ARRA_API` → localhost
- add `arra config` / `arra config path` / `arra config use <name>` plus `arra use <name>` for global default selection
- update `apiFetch` to resolve the base URL at call time and document the config format in README

Closes Soul-Brews-Studio/arra-oracle-v3-oracle#16

## Verification
- `bun test tests/cli/config`
- `bun test tests/cli`
- `bun run build`
- manual isolated XDG smoke: `arra config` showed global target; `arra use m5` rewrote global default

## Notes
- `ORACLE_API` remains the highest-priority explicit override.
- CLI integration tests use ephemeral local health servers instead of the real m5 host.