### PR TITLE
CI: publish Docker MCP images to GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+.maw
+.omx
+agents
+node_modules
+web/node_modules
+coverage
+dist
+.DS_Store
+*.log
+oracle.db*
+*.sqlite
+*.sqlite3
+/data

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,77 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: [alpha]
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - docker-compose.yml
+      - catalog/arra-oracle.yaml
+      - package.json
+      - bun.lock
+      - bin/**
+      - cli/**
+      - src/**
+      - .github/workflows/docker-publish.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Resolve lowercase image name
+        id: image
+        run: echo "image=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push HTTP image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: http-server
+          push: true
+          tags: |
+            ${{ steps.image.outputs.image }}:http
+            ${{ steps.image.outputs.image }}:http-alpha
+          cache-from: type=gha,scope=http-server
+          cache-to: type=gha,mode=max,scope=http-server
+
+      - name: Build and push MCP stdio image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: mcp-stdio
+          push: true
+          tags: |
+            ${{ steps.image.outputs.image }}:stdio
+            ${{ steps.image.outputs.image }}:stdio-alpha
+          cache-from: type=gha,scope=mcp-stdio
+          cache-to: type=gha,mode=max,scope=mcp-stdio
+
+      - name: Summary
+        run: |
+          echo "### Docker images published" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`${{ steps.image.outputs.image }}:http\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`${{ steps.image.outputs.image }}:http-alpha\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`${{ steps.image.outputs.image }}:stdio\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`${{ steps.image.outputs.image }}:stdio-alpha\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Catalog image: \`$(grep -E '^    image:' catalog/arra-oracle.yaml | awk '{print $2}')\`" >> "$GITHUB_STEP_SUMMARY"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# arra-oracle-v3 — multi-target image
+#   Default target: http-server  (port 47778)
+#   Alt target:     mcp-stdio    (stdio JSON-RPC MCP server)
+#
+# Build:
+#   docker build -t arra-oracle-v3 .
+#   docker build -t arra-oracle-v3:http --target http-server .
+#   docker build -t arra-oracle-v3:stdio --target mcp-stdio .
+
+FROM oven/bun:1 AS builder
+WORKDIR /app
+COPY package.json bun.lock ./
+RUN bun install --production --frozen-lockfile \
+ && rm -rf node_modules/@lancedb/lancedb-*-musl
+
+FROM oven/bun:1-slim AS base
+WORKDIR /app
+ENV HOME=/data \
+    ORACLE_DATA_DIR=/data
+
+COPY --from=builder /app/node_modules ./node_modules
+COPY package.json bun.lock ./
+COPY bin ./bin
+COPY cli ./cli
+COPY src ./src
+
+RUN mkdir -p /data
+VOLUME ["/data"]
+
+FROM base AS mcp-stdio
+ENV ORACLE_LOG_TARGET=stderr
+CMD ["bun", "src/index.ts"]
+
+FROM base AS http-server
+ENV ORACLE_PORT=47778 \
+    PORT=47778
+EXPOSE 47778
+CMD ["bun", "src/server.ts"]

--- a/README.md
+++ b/README.md
@@ -77,6 +77,46 @@ Or in `~/.claude.json`:
 }
 ```
 
+
+### Docker / Docker MCP Toolkit
+
+The `alpha` branch publishes Docker images to GHCR for both runtime modes:
+
+| Image | Purpose |
+| --- | --- |
+| `ghcr.io/soul-brews-studio/arra-oracle-v3:http` | HTTP API on `:47778` |
+| `ghcr.io/soul-brews-studio/arra-oracle-v3:stdio` | MCP stdio server for Docker MCP Toolkit / Gateway |
+
+Build locally:
+
+```bash
+docker build -t arra-oracle-v3:http --target http-server .
+docker build -t arra-oracle-v3:stdio --target mcp-stdio .
+```
+
+Run the HTTP server:
+
+```bash
+docker run --rm -p 47778:47778 -v arra-data:/data ghcr.io/soul-brews-studio/arra-oracle-v3:http
+curl -sf http://localhost:47778/api/health
+```
+
+Or use Compose, which also serves the HTTP target on `:47778`:
+
+```bash
+docker compose up -d
+curl -sf http://localhost:47778/api/health
+```
+
+For Docker MCP Toolkit click-to-install, use `catalog/arra-oracle.yaml`. It points at the real published stdio image:
+
+```bash
+mkdir -p ~/.docker/mcp/catalogs
+cp catalog/arra-oracle.yaml ~/.docker/mcp/catalogs/
+```
+
+Then add `arra-oracle` to Docker MCP Toolkit's registry configuration and restart Docker Desktop / the MCP gateway.
+
 ### From source
 
 ```bash

--- a/catalog/arra-oracle.yaml
+++ b/catalog/arra-oracle.yaml
@@ -1,0 +1,44 @@
+version: 2
+name: arra-oracle
+displayName: Arra Oracle MCP Servers
+
+registry:
+  arra-oracle:
+    title: Arra Oracle
+    type: server
+    dateAdded: "2026-06-06T00:00:00Z"
+    image: ghcr.io/soul-brews-studio/arra-oracle-v3:stdio
+    description: |
+      Personal MCP memory server with semantic search over your Oracle vault.
+      SQLite FTS5 + LanceDB hybrid search, packaged for Docker MCP Toolkit.
+    longLived: false
+    volumes:
+      - "arra-oracle-data:/data"
+    env:
+      - name: ORACLE_LOG_TARGET
+        value: stderr
+    tools:
+      - name: oracle_search
+        description: Hybrid FTS5 + vector search over the Oracle vault.
+      - name: oracle_learn
+        description: Add new knowledge to Oracle memory.
+      - name: oracle_list
+        description: Browse indexed documents.
+      - name: oracle_stats
+        description: Database and vector backend statistics.
+      - name: oracle_handoff
+        description: Session handoff notes.
+      - name: oracle_inbox
+        description: Oracle inbox messages.
+      - name: oracle_trace
+        description: Create a trace entry.
+      - name: oracle_reflect
+        description: Reflect on a topic across vault entries.
+      - name: oracle_verify
+        description: Verify a claim against vault evidence.
+    secrets: []
+    metadata:
+      category: knowledge
+      tags: [memory, vault, mcp, semantic-search, oracle, fts5, lancedb]
+      license: BUSL-1.1
+      owner: Soul-Brews-Studio

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  arra:
+    build:
+      context: .
+      target: http-server
+    image: arra-oracle-v3:http
+    ports:
+      - "47778:47778"
+    environment:
+      HOME: /data
+      ORACLE_DATA_DIR: /data
+      ORACLE_PORT: "47778"
+      PORT: "47778"
+    volumes:
+      - arra-data:/data
+    restart: unless-stopped
+
+volumes:
+  arra-data:


### PR DESCRIPTION
## Summary
- add multi-target Dockerfile (`http-server`, `mcp-stdio`) and compose smoke path for `:47778`
- add Docker MCP Toolkit catalog pointing at `ghcr.io/soul-brews-studio/arra-oracle-v3:stdio`
- add `docker-publish.yml` to push `:http`, `:http-alpha`, `:stdio`, and `:stdio-alpha` to GHCR on `alpha`
- document GHCR/Docker MCP Toolkit install flow in README

## Issue note
The dispatch said `gh issue view 21`, but in this repo #21 is a closed OpenCode config issue. The matching open Docker MCP Toolkit issue is #1242.

Closes #1242

## Verification
- `bun install --frozen-lockfile`
- `bun run build`
- `docker build --target http-server -t arra-oracle-v3:http-test .`
- `docker build --target mcp-stdio -t arra-oracle-v3:stdio-test .`
- `docker build -t arra-oracle-v3:default-test .`
- `docker compose up -d --build`
- `curl -sf http://localhost:47778/api/health`
- Docker MCP stdio JSON-line `initialize` + `tools/list` smoke showing `oracle_search`
- YAML parse for `.github/workflows/docker-publish.yml` and `catalog/arra-oracle.yaml`
- `git diff --check`

## Not tested
- Actual GitHub Actions GHCR push until merged to `alpha`
- Docker Desktop click-to-install against the published GHCR image
