### PR TITLE
Commands: add arra doctor diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ arra config          # show resolved target, sources, and targets
 arra config path     # print global config path
 arra use m5          # set global default target
 arra --at m5 health  # one-off target override
+arra doctor          # diagnose target, server, DB/vector, config, and MCP mode
+arra doctor --json   # machine-readable diagnostics
 ```
 
 <details>

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -22,6 +22,7 @@ import {
 } from "./commands/menu-gist.ts";
 import { menuResetAll } from "./commands/menu-reset.ts";
 import { configCommand, useCommand } from "./commands/config.ts";
+import { doctorCommand } from "./commands/doctor.ts";
 
 const pkg = await Bun.file(join(import.meta.dir, "../package.json")).json();
 const VERSION: string = pkg.version;
@@ -34,6 +35,7 @@ function printHelp(commands: Array<{ command: string; help?: string }>) {
   console.log(`  ${"session".padEnd(16)}inspect sessions (list, show, context)`);
   console.log(`  ${"menu".padEnd(16)}inspect and customize studio menu (list, add, remove)`);
   console.log(`  ${"config".padEnd(16)}show resolved API target and config sources`);
+  console.log(`  ${"doctor".padEnd(16)}run operator diagnostics against the resolved target`);
   console.log(`  ${"use".padEnd(16)}set the global default API target`);
   for (const { command, help } of commands) {
     console.log(`  ${command.padEnd(16)}${help ?? ""}`);
@@ -91,6 +93,10 @@ async function main() {
 
   if (cmd === "config") {
     process.exit(await configCommand(args.slice(1)));
+  }
+
+  if (cmd === "doctor") {
+    process.exit(await doctorCommand(args.slice(1)));
   }
 
   if (cmd === "use") {

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -1,0 +1,149 @@
+import { existsSync } from "fs";
+import { globalConfigPath, findProjectConfigPath, loadConfigSources, resolveOracleApiBase, type ResolvedApiBase } from "../lib/config.ts";
+
+export type DoctorStatus = "pass" | "fail" | "warn";
+
+export interface DoctorCheck {
+  id: string;
+  label: string;
+  status: DoctorStatus;
+  critical: boolean;
+  detail?: string;
+  data?: unknown;
+}
+
+export interface DoctorReport {
+  ok: boolean;
+  resolved: ResolvedApiBase;
+  checks: DoctorCheck[];
+}
+
+function ok(id: string, label: string, detail?: string, data?: unknown): DoctorCheck {
+  return { id, label, status: "pass", critical: true, detail, data };
+}
+
+function fail(id: string, label: string, detail?: string, data?: unknown): DoctorCheck {
+  return { id, label, status: "fail", critical: true, detail, data };
+}
+
+function warn(id: string, label: string, detail?: string, data?: unknown): DoctorCheck {
+  return { id, label, status: "warn", critical: false, detail, data };
+}
+
+async function fetchJson(baseUrl: string, path: string): Promise<{ status: number; data: any }> {
+  const res = await fetch(`${baseUrl}${path}`);
+  let data: any = null;
+  try { data = await res.json(); } catch { /* non-json */ }
+  return { status: res.status, data };
+}
+
+function adapterFromStats(stats: any): string | undefined {
+  const vector = stats?.vector ?? stats?.vectors;
+  if (!vector) return undefined;
+  if (typeof vector.adapter === "string") return vector.adapter;
+  if (typeof vector.type === "string") return vector.type;
+  if (typeof vector.engine === "string") return vector.engine;
+  if (typeof vector.collection === "string") return vector.collection;
+  return undefined;
+}
+
+function countFromStats(stats: any): number | undefined {
+  const vector = stats?.vector ?? stats?.vectors;
+  if (typeof vector?.count === "number") return vector.count;
+  if (typeof vector?.total === "number") return vector.total;
+  if (typeof stats?.total === "number") return stats.total;
+  if (typeof stats?.total_docs === "number") return stats.total_docs;
+  return undefined;
+}
+
+export async function runDoctor(options: { env?: NodeJS.ProcessEnv; cwd?: string } = {}): Promise<DoctorReport> {
+  const env = options.env ?? process.env;
+  const cwd = options.cwd ?? process.cwd();
+  const checks: DoctorCheck[] = [];
+  let resolved: ResolvedApiBase;
+
+  try {
+    resolved = resolveOracleApiBase({ env, cwd });
+    const target = resolved.target ? ` target=${resolved.target}` : "";
+    checks.push(ok("config.resolved", "resolved API target", `${resolved.url} (${resolved.source}${target})`, resolved));
+  } catch (err) {
+    resolved = { url: "", source: "default" };
+    checks.push(fail("config.resolved", "resolved API target", err instanceof Error ? err.message : String(err)));
+  }
+
+  try { loadConfigSources({ env, cwd }); } catch (err) {
+    checks.push(fail("config.files", "config files parse", err instanceof Error ? err.message : String(err)));
+  }
+  const projectPath = findProjectConfigPath(cwd);
+  const globalPath = globalConfigPath(env);
+  checks.push((projectPath && existsSync(projectPath))
+    ? ok("config.project", "project config file", projectPath)
+    : warn("config.project", "project config file", "not found"));
+  checks.push(existsSync(globalPath)
+    ? ok("config.global", "global config file", globalPath)
+    : warn("config.global", "global config file", `not found (${globalPath})`));
+
+  checks.push(ok(
+    "mcp.mode",
+    "MCP mode",
+    env.ORACLE_HTTP_URL?.trim()
+      ? `HTTP proxy mode (${env.ORACLE_HTTP_URL})`
+      : "embedded mode (ORACLE_HTTP_URL not set)",
+    { ORACLE_HTTP_URL: env.ORACLE_HTTP_URL ?? null }
+  ));
+
+  if (resolved.url) {
+    try {
+      const health = await fetchJson(resolved.url, "/api/health");
+      if (health.status >= 200 && health.status < 300) {
+        checks.push(ok("server.health", "server reachable", `${resolved.url}/api/health HTTP ${health.status}`, health.data));
+      } else {
+        checks.push(fail("server.health", "server reachable", `${resolved.url}/api/health HTTP ${health.status}`, health.data));
+      }
+    } catch (err) {
+      checks.push(fail("server.health", "server reachable", err instanceof Error ? err.message : String(err)));
+    }
+
+    try {
+      const stats = await fetchJson(resolved.url, "/api/stats");
+      if (stats.status >= 200 && stats.status < 300) {
+        const total = typeof stats.data?.total === "number" ? stats.data.total : stats.data?.total_docs;
+        const vector = stats.data?.vector ?? stats.data?.vectors;
+        checks.push(ok("db.stats", "DB stats", `documents=${total ?? "unknown"}`, stats.data));
+        checks.push(ok(
+          "vector.stats",
+          "vector adapter stats",
+          `adapter=${adapterFromStats(stats.data) ?? "unknown"} count=${countFromStats({ vector }) ?? "unknown"}`,
+          vector
+        ));
+      } else {
+        checks.push(fail("db.stats", "DB + vector stats", `${resolved.url}/api/stats HTTP ${stats.status}`, stats.data));
+      }
+    } catch (err) {
+      checks.push(fail("db.stats", "DB + vector stats", err instanceof Error ? err.message : String(err)));
+    }
+  }
+
+  return { ok: checks.every(check => check.status !== "fail" || !check.critical), resolved, checks };
+}
+
+function symbol(status: DoctorStatus): string {
+  if (status === "pass") return "✓";
+  if (status === "warn") return "!";
+  return "✗";
+}
+
+export async function doctorCommand(args: string[]): Promise<number> {
+  const json = args.includes("--json");
+  const report = await runDoctor();
+  if (json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log("ARRA Doctor\n");
+    for (const check of report.checks) {
+      const suffix = check.detail ? ` — ${check.detail}` : "";
+      console.log(`${symbol(check.status)} ${check.label}${suffix}`);
+    }
+  }
+  return report.ok ? 0 : 1;
+}

--- a/tests/cli/doctor/doctor.test.ts
+++ b/tests/cli/doctor/doctor.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { runDoctor } from "../../../cli/src/commands/doctor.ts";
+import { runCli, tryParseJson } from "../_run.ts";
+
+function writeJson(path: string, value: unknown) {
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, JSON.stringify(value, null, 2));
+}
+
+function startDoctorServer(options: { healthStatus?: number; statsStatus?: number } = {}) {
+  return Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/health") {
+        return Response.json({ status: "ok", server: "doctor-test", version: "test", port: Number(url.port), oracle: "connected" }, { status: options.healthStatus ?? 200 });
+      }
+      if (url.pathname === "/api/stats") {
+        return Response.json({ total: 42, vector: { enabled: true, adapter: "lancedb", count: 7, collection: "oracle_knowledge" } }, { status: options.statsStatus ?? 200 });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+}
+
+describe("arra doctor", () => {
+  let root: string;
+  let server: ReturnType<typeof Bun.serve> | undefined;
+
+  beforeEach(() => {
+    root = join(tmpdir(), `arra-doctor-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  });
+
+  afterEach(() => {
+    server?.stop(true);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("runDoctor reports config, server, stats, vector, and MCP mode", async () => {
+    server = startDoctorServer();
+    const xdg = join(root, "xdg");
+    writeJson(join(xdg, "arra", "config.json"), {
+      default: "m5",
+      targets: { m5: server.url.href },
+    });
+
+    const report = await runDoctor({
+      cwd: root,
+      env: { HOME: join(root, "home"), XDG_CONFIG_HOME: xdg, ORACLE_API: "", NEO_ARRA_API: "", ORACLE_HTTP_URL: "http://proxy:47778" },
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.resolved.source).toBe("global");
+    expect(report.checks.find(c => c.id === "server.health")?.status).toBe("pass");
+    expect(report.checks.find(c => c.id === "db.stats")?.detail).toContain("documents=42");
+    expect(report.checks.find(c => c.id === "vector.stats")?.detail).toContain("adapter=lancedb");
+    expect(report.checks.find(c => c.id === "mcp.mode")?.detail).toContain("HTTP proxy mode");
+  });
+
+  test("runDoctor fails when a critical server check fails", async () => {
+    server = startDoctorServer({ healthStatus: 503 });
+
+    const report = await runDoctor({
+      cwd: root,
+      env: { HOME: join(root, "home"), XDG_CONFIG_HOME: join(root, "xdg"), ORACLE_API: server.url.href, NEO_ARRA_API: "" },
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.checks.find(c => c.id === "server.health")?.status).toBe("fail");
+  });
+
+  test("CLI --json emits structured report and exits 0 when healthy", async () => {
+    server = startDoctorServer();
+    const result = await runCli(["doctor", "--json"], {
+      HOME: join(root, "home"),
+      XDG_CONFIG_HOME: join(root, "xdg"),
+      ORACLE_API: server.url.href,
+      NEO_ARRA_API: "",
+    });
+
+    expect(result.code).toBe(0);
+    const data = tryParseJson(result.stdout) as { ok: boolean; checks: Array<{ id: string; status: string }> } | null;
+    expect(data?.ok).toBe(true);
+    expect(data?.checks.some(c => c.id === "vector.stats" && c.status === "pass")).toBe(true);
+  }, 15_000);
+
+  test("CLI exits non-zero when a critical probe fails", async () => {
+    server = startDoctorServer({ healthStatus: 503 });
+    const result = await runCli(["doctor", "--json"], {
+      HOME: join(root, "home"),
+      XDG_CONFIG_HOME: join(root, "xdg"),
+      ORACLE_API: server.url.href,
+      NEO_ARRA_API: "",
+    });
+
+    expect(result.code).toBe(1);
+    const data = tryParseJson(result.stdout) as { ok: boolean } | null;
+    expect(data?.ok).toBe(false);
+  }, 15_000);
+
+  test("CLI text output is a clear checklist", async () => {
+    server = startDoctorServer();
+    const result = await runCli(["doctor"], {
+      HOME: join(root, "home"),
+      XDG_CONFIG_HOME: join(root, "xdg"),
+      ORACLE_API: server.url.href,
+      NEO_ARRA_API: "",
+    });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("ARRA Doctor");
+    expect(result.stdout).toContain("✓ resolved API target");
+    expect(result.stdout).toContain("✓ server reachable");
+    expect(result.stdout).toContain("✓ vector adapter stats");
+  }, 15_000);
+});


### PR DESCRIPTION
## Summary
- add built-in `arra doctor` with checklist and `--json` output
- diagnose resolved API target/source, project/global config files, MCP mode, server `/api/health`, and DB/vector `/api/stats`
- exit non-zero when critical probes fail

Closes Soul-Brews-Studio/arra-oracle-v3-oracle#25

## Verification
- `bun test tests/cli`
- `bun run build`

## Notes
- Doctor is read-only and implemented as a built-in command so it can inspect config resolution before plugin dispatch.
- Tests use mocked local health/stats endpoints; real m5/proxy targets were not exercised.