### PR TITLE
CI: publish Docker images for arm64

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           context: .
           target: http-server
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ steps.image.outputs.image }}:http
@@ -60,6 +61,7 @@ jobs:
         with:
           context: .
           target: mcp-stdio
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ steps.image.outputs.image }}:stdio


### PR DESCRIPTION
## Summary
- update Docker Publish to build both `linux/amd64` and `linux/arm64`
- applies to both `http-server` and `mcp-stdio` targets

## Why
PR #1339 published GHCR images successfully, but Docker Desktop on m5/Apple Silicon could not pull `ghcr.io/soul-brews-studio/arra-oracle-v3:stdio` because the manifest only had `linux/amd64`.

## Verification
- workflow YAML parse
- `git diff --check`
- observed pre-fix pull failure: `no matching manifest for linux/arm64/v8`

## Not tested
- GHCR multi-platform publish until merged/rerun
