### PR TITLE
Commands: add arra plugins manifest CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ arra use m5          # set global default target
 arra --at m5 health  # one-off target override
 arra doctor          # diagnose target, server, DB/vector, config, and MCP mode
 arra doctor --json   # machine-readable diagnostics
+arra plugins         # list MCP tool plugins from plugins.json
+arra plugins disable trace
+arra plugins enable trace
 ```
 
 <details>

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -6,6 +6,7 @@ import { registerPlugins, resolveCommand, listPlugins } from "./plugin/registry.
 import { invokePlugin } from "./plugin/invoke.ts";
 import type { LoadedPlugin } from "./plugin/types.ts";
 import { pluginsList } from "./commands/plugins-list.ts";
+import { pluginsCommand } from "./commands/plugins.ts";
 import { pluginsRemove } from "./commands/plugins-remove.ts";
 import { pluginsInfo } from "./commands/plugins-info.ts";
 import { sessionList } from "./commands/session-list.ts";
@@ -31,7 +32,8 @@ function printHelp(commands: Array<{ command: string; help?: string }>) {
   console.log(`arra-cli v${VERSION} — ARRA Oracle V3 CLI\n`);
   console.log("Usage: arra-cli <command> [args...]\n");
   console.log("Commands:");
-  console.log(`  ${"plugin".padEnd(16)}manage plugins (install)`);
+  console.log(`  ${"plugin".padEnd(16)}manage installable CLI plugins`);
+  console.log(`  ${"plugins".padEnd(16)}manage MCP tool plugin manifest`);
   console.log(`  ${"session".padEnd(16)}inspect sessions (list, show, context)`);
   console.log(`  ${"menu".padEnd(16)}inspect and customize studio menu (list, add, remove)`);
   console.log(`  ${"config".padEnd(16)}show resolved API target and config sources`);
@@ -178,6 +180,10 @@ async function main() {
     console.error(`\x1b[31m✗\x1b[0m unknown menu subcommand: ${args[1]}`);
     console.error("  try: arra-cli menu list|add|remove|gist-*|reset-all");
     process.exit(1);
+  }
+
+  if (cmd === "plugins") {
+    process.exit(await pluginsCommand(args.slice(1)));
   }
 
   if (cmd === "plugin") {

--- a/cli/src/commands/plugins.ts
+++ b/cli/src/commands/plugins.ts
@@ -1,0 +1,169 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+import { homedir } from "os";
+import { TOOL_PLUGINS, type PluginManifestEntry, type PluginTier } from "../../../src/config/tool-groups.ts";
+
+export interface PluginListEntry {
+  name: string;
+  tier: PluginTier;
+  weight: number;
+  enabled: boolean;
+}
+
+export interface PluginManifestFile {
+  plugins: PluginManifestEntry[];
+  disabled_tools?: string[];
+  enabled_tools?: string[];
+}
+
+export interface PluginManifestState {
+  path: string;
+  source: "repo" | "global" | "default";
+  exists: boolean;
+  manifest: PluginManifestFile;
+}
+
+function repoRoot(): string {
+  return process.env.ORACLE_REPO_ROOT || process.cwd();
+}
+
+function repoManifestPath(): string {
+  return join(repoRoot(), "plugins.json");
+}
+
+function oracleDataDir(): string {
+  return process.env.ORACLE_DATA_DIR || join(process.env.HOME || homedir(), ".arra-oracle-v2");
+}
+
+function globalManifestPath(): string {
+  return join(oracleDataDir(), "plugins.json");
+}
+
+function defaultManifest(): PluginManifestFile {
+  return {
+    plugins: Object.values(TOOL_PLUGINS)
+      .sort((a, b) => a.weight - b.weight || a.name.localeCompare(b.name))
+      .map((p) => ({ name: p.name, tier: p.tier, weight: p.weight, enabled: true })),
+  };
+}
+
+function normalizeManifest(raw: unknown): PluginManifestFile {
+  const obj = raw && typeof raw === "object" ? raw as Record<string, unknown> : {};
+  const plugins = Array.isArray(obj.plugins)
+    ? obj.plugins
+        .filter((p): p is Record<string, unknown> => !!p && typeof p === "object" && typeof p.name === "string")
+        .map((p): PluginManifestEntry => ({
+          name: String(p.name),
+          ...(typeof p.enabled === "boolean" && { enabled: p.enabled }),
+          ...((p.tier === "core" || p.tier === "standard" || p.tier === "extra") && { tier: p.tier }),
+          ...(typeof p.weight === "number" && { weight: p.weight }),
+        }))
+    : [];
+  const manifest: PluginManifestFile = { plugins };
+  if (Array.isArray(obj.disabled_tools)) manifest.disabled_tools = obj.disabled_tools.filter((t): t is string => typeof t === "string");
+  if (Array.isArray(obj.enabled_tools)) manifest.enabled_tools = obj.enabled_tools.filter((t): t is string => typeof t === "string");
+  return manifest;
+}
+
+function readManifest(path: string): PluginManifestFile {
+  return normalizeManifest(JSON.parse(readFileSync(path, "utf8")));
+}
+
+export function loadPluginManifestState(): PluginManifestState {
+  const local = repoManifestPath();
+  if (existsSync(local)) return { path: local, source: "repo", exists: true, manifest: readManifest(local) };
+  const global = globalManifestPath();
+  if (existsSync(global)) return { path: global, source: "global", exists: true, manifest: readManifest(global) };
+  return { path: local, source: "default", exists: false, manifest: defaultManifest() };
+}
+
+export function listPlugins(): { source: PluginManifestState["source"]; path: string; plugins: PluginListEntry[] } {
+  const state = loadPluginManifestState();
+  const byName = new Map(state.manifest.plugins.map((entry) => [entry.name, entry]));
+  const names = new Set([...Object.keys(TOOL_PLUGINS), ...byName.keys()]);
+  const plugins = [...names].map((name): PluginListEntry | null => {
+    const base = TOOL_PLUGINS[name];
+    const entry = byName.get(name);
+    if (!base && !entry) return null;
+    return {
+      name,
+      tier: entry?.tier ?? base?.tier ?? "extra",
+      weight: entry?.weight ?? base?.weight ?? 999,
+      enabled: entry?.enabled !== false,
+    };
+  }).filter((p): p is PluginListEntry => !!p)
+    .sort((a, b) => a.weight - b.weight || a.name.localeCompare(b.name));
+  return { source: state.source, path: state.path, plugins };
+}
+
+function writableManifestState(): PluginManifestState {
+  const state = loadPluginManifestState();
+  if (state.exists) return state;
+  return { ...state, source: "repo", path: repoManifestPath(), manifest: defaultManifest() };
+}
+
+export function setPluginEnabled(name: string, enabled: boolean): PluginListEntry {
+  const base = TOOL_PLUGINS[name];
+  if (!base) throw new Error(`Unknown plugin '${name}'. Try: arra plugins list`);
+
+  const state = writableManifestState();
+  const manifest = state.manifest;
+  const idx = manifest.plugins.findIndex((p) => p.name === name);
+  if (idx >= 0) {
+    manifest.plugins[idx] = { ...manifest.plugins[idx], enabled };
+  } else {
+    manifest.plugins.push({ name, tier: base.tier, weight: base.weight, enabled });
+  }
+  mkdirSync(dirname(state.path), { recursive: true });
+  writeFileSync(state.path, JSON.stringify(manifest, null, 2) + "\n");
+  const entry = manifest.plugins.find((p) => p.name === name)!;
+  return {
+    name,
+    tier: entry.tier ?? base.tier,
+    weight: entry.weight ?? base.weight,
+    enabled: entry.enabled !== false,
+  };
+}
+
+function printText(data: ReturnType<typeof listPlugins>): void {
+  console.log(`ARRA plugins (${data.source}: ${data.path})\n`);
+  for (const p of data.plugins) {
+    const status = p.enabled ? "enabled " : "disabled";
+    console.log(`${status}  ${p.name.padEnd(12)} tier=${p.tier.padEnd(8)} weight=${p.weight}`);
+  }
+}
+
+export async function pluginsCommand(args: string[]): Promise<number> {
+  const json = args.includes("--json");
+  const filtered = args.filter((a) => a !== "--json");
+  const sub = filtered[0]?.toLowerCase() ?? "list";
+
+  if (sub === "list" || sub === "ls") {
+    const data = listPlugins();
+    if (json) console.log(JSON.stringify(data, null, 2));
+    else printText(data);
+    return 0;
+  }
+
+  if (sub === "enable" || sub === "disable") {
+    const name = filtered[1];
+    if (!name) {
+      console.error(`usage: arra plugins ${sub} <name>`);
+      return 1;
+    }
+    try {
+      const plugin = setPluginEnabled(name, sub === "enable");
+      const data = { path: loadPluginManifestState().path, plugin };
+      if (json) console.log(JSON.stringify(data, null, 2));
+      else console.log(`${plugin.enabled ? "enabled" : "disabled"} ${plugin.name} (${data.path})`);
+      return 0;
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      return 1;
+    }
+  }
+
+  console.error(`unknown plugins subcommand: ${filtered[0]}`);
+  console.error("try: arra plugins [list|enable <name>|disable <name>] [--json]");
+  return 1;
+}

--- a/tests/cli/plugins/plugins.test.ts
+++ b/tests/cli/plugins/plugins.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { runCli, tryParseJson } from "../_run.ts";
+import { getEnabledToolNames, loadToolGroupConfig } from "../../../src/config/tool-groups.ts";
+
+function writeJson(path: string, value: unknown) {
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, JSON.stringify(value, null, 2));
+}
+
+describe("arra plugins CLI", () => {
+  let root: string;
+  let env: Record<string, string>;
+
+  beforeEach(() => {
+    root = join(tmpdir(), `arra-plugins-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+    mkdirSync(root, { recursive: true });
+    env = {
+      HOME: join(root, "home"),
+      ORACLE_REPO_ROOT: root,
+      ORACLE_DATA_DIR: join(root, "data"),
+    };
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("list reads repo plugins.json and shows enabled state", async () => {
+    writeJson(join(root, "plugins.json"), {
+      plugins: [
+        { name: "trace", enabled: false, tier: "standard", weight: 1 },
+        { name: "dig", enabled: true, tier: "standard", weight: 2 },
+      ],
+    });
+
+    const result = await runCli(["plugins", "list", "--json"], env);
+
+    expect(result.code).toBe(0);
+    const data = tryParseJson(result.stdout) as { source: string; path: string; plugins: Array<{ name: string; enabled: boolean; weight: number }> } | null;
+    expect(data?.source).toBe("repo");
+    expect(data?.path).toBe(join(root, "plugins.json"));
+    expect(data?.plugins.find(p => p.name === "trace")?.enabled).toBe(false);
+    expect(data?.plugins.find(p => p.name === "dig")?.enabled).toBe(true);
+  }, 15_000);
+
+  test("plugins with no subcommand defaults to list", async () => {
+    const result = await runCli(["plugins", "--json"], env);
+    expect(result.code).toBe(0);
+    const data = tryParseJson(result.stdout) as { source: string; plugins: Array<{ name: string }> } | null;
+    expect(data?.source).toBe("default");
+    expect(data?.plugins.some(p => p.name === "trace")).toBe(true);
+  }, 15_000);
+
+  test("disable and enable persist to the manifest the MCP loader honors", async () => {
+    const disable = await runCli(["plugins", "disable", "trace", "--json"], env);
+    expect(disable.code).toBe(0);
+    let manifest = JSON.parse(readFileSync(join(root, "plugins.json"), "utf8"));
+    expect(manifest.plugins.find((p: any) => p.name === "trace")?.enabled).toBe(false);
+    let config = loadToolGroupConfig(root);
+    expect(getEnabledToolNames(config)).not.toContain("oracle_trace");
+
+    const enable = await runCli(["plugins", "enable", "trace", "--json"], env);
+    expect(enable.code).toBe(0);
+    manifest = JSON.parse(readFileSync(join(root, "plugins.json"), "utf8"));
+    expect(manifest.plugins.find((p: any) => p.name === "trace")?.enabled).toBe(true);
+    config = loadToolGroupConfig(root);
+    expect(getEnabledToolNames(config)).toContain("oracle_trace");
+  }, 15_000);
+
+  test("unknown plugin exits non-zero without mutating manifest", async () => {
+    const result = await runCli(["plugins", "disable", "not-a-plugin"], env);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("Unknown plugin");
+  }, 15_000);
+});


### PR DESCRIPTION
## Summary
- add `arra plugins` / `arra plugins list` for MCP tool plugin manifest status
- add `arra plugins enable <name>` and `arra plugins disable <name>` with persisted `plugins.json` toggles
- support `--json` and keep singular `arra plugin` for installable CLI/WASM plugins
- document the new operator commands

Closes Soul-Brews-Studio/arra-oracle-v3-oracle#31

## Verification
- `bun test tests/cli/plugins/plugins.test.ts`
- `bun test tests/cli`
- `bun test src/config/__tests__/tool-groups.test.ts --test-name-pattern "fires onChange"`
- `bun run build`

## Notes
- Uses the existing `plugins.json` manifest format consumed by `src/config/tool-groups.ts`; no new schema.
- Toggle persistence is cross-checked with `loadToolGroupConfig()` / `getEnabledToolNames()`.