### PR TITLE
Commands: add shell completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,23 @@ arra plugins disable trace
 arra plugins enable trace
 ```
 
+Shell completions:
+
+```bash
+# zsh
+mkdir -p ~/.zsh/completions
+arra completions zsh > ~/.zsh/completions/_arra
+# then add to ~/.zshrc: fpath=(~/.zsh/completions $fpath); autoload -Uz compinit && compinit
+
+# bash
+arra completions bash > ~/.arra-completion.bash
+# then source ~/.arra-completion.bash from ~/.bashrc
+
+# fish
+mkdir -p ~/.config/fish/completions
+arra completions fish > ~/.config/fish/completions/arra.fish
+```
+
 <details>
 <summary>Install script (legacy)</summary>
 

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -24,6 +24,8 @@ import {
 import { menuResetAll } from "./commands/menu-reset.ts";
 import { configCommand, useCommand } from "./commands/config.ts";
 import { doctorCommand } from "./commands/doctor.ts";
+import { completionsCommand } from "./commands/completions.ts";
+import { BUILTIN_COMMANDS } from "./commands/catalog.ts";
 
 const pkg = await Bun.file(join(import.meta.dir, "../package.json")).json();
 const VERSION: string = pkg.version;
@@ -32,13 +34,9 @@ function printHelp(commands: Array<{ command: string; help?: string }>) {
   console.log(`arra-cli v${VERSION} — ARRA Oracle V3 CLI\n`);
   console.log("Usage: arra-cli <command> [args...]\n");
   console.log("Commands:");
-  console.log(`  ${"plugin".padEnd(16)}manage installable CLI plugins`);
-  console.log(`  ${"plugins".padEnd(16)}manage MCP tool plugin manifest`);
-  console.log(`  ${"session".padEnd(16)}inspect sessions (list, show, context)`);
-  console.log(`  ${"menu".padEnd(16)}inspect and customize studio menu (list, add, remove)`);
-  console.log(`  ${"config".padEnd(16)}show resolved API target and config sources`);
-  console.log(`  ${"doctor".padEnd(16)}run operator diagnostics against the resolved target`);
-  console.log(`  ${"use".padEnd(16)}set the global default API target`);
+  for (const { command, help } of BUILTIN_COMMANDS) {
+    console.log(`  ${command.padEnd(16)}${help}`);
+  }
   for (const { command, help } of commands) {
     console.log(`  ${command.padEnd(16)}${help ?? ""}`);
   }
@@ -91,6 +89,10 @@ async function main() {
   if (cmd === "--version" || cmd === "version") {
     console.log(`arra-cli v${VERSION}`);
     return;
+  }
+
+  if (cmd === "completions") {
+    process.exit(await completionsCommand(args.slice(1)));
   }
 
   if (cmd === "config") {

--- a/cli/src/commands/catalog.ts
+++ b/cli/src/commands/catalog.ts
@@ -1,0 +1,19 @@
+export interface CommandSpec {
+  command: string;
+  help: string;
+  subcommands?: string[];
+  flags?: string[];
+}
+
+export const COMMON_FLAGS = ["--at", "--json", "--help", "-h", "--version"];
+
+export const BUILTIN_COMMANDS: CommandSpec[] = [
+  { command: "plugin", help: "manage installable CLI plugins", subcommands: ["list", "info", "install", "remove"], flags: ["--json", "--yml", "--help", "-h"] },
+  { command: "plugins", help: "manage MCP tool plugin manifest", subcommands: ["list", "enable", "disable"], flags: ["--json", "--help", "-h"] },
+  { command: "session", help: "inspect sessions", subcommands: ["list", "show", "context"], flags: ["--json", "--yml", "--help", "-h"] },
+  { command: "menu", help: "inspect and customize studio menu", subcommands: ["list", "add", "remove", "gist-status", "gist-url", "gist-clear", "gist-reload", "reset-all"], flags: ["--json", "--yml", "--help", "-h"] },
+  { command: "config", help: "show resolved API target and config sources", subcommands: ["show", "path", "use"], flags: ["--json", "--help", "-h"] },
+  { command: "doctor", help: "run operator diagnostics against the resolved target", flags: ["--json", "--help", "-h"] },
+  { command: "use", help: "set the global default API target" },
+  { command: "completions", help: "print shell completion scripts", subcommands: ["bash", "zsh", "fish"], flags: ["--help", "-h"] },
+];

--- a/cli/src/commands/completions.ts
+++ b/cli/src/commands/completions.ts
@@ -1,0 +1,88 @@
+import type { CommandSpec } from "./catalog.ts";
+import { BUILTIN_COMMANDS, COMMON_FLAGS } from "./catalog.ts";
+import { discoverPlugins } from "../plugin/loader.ts";
+
+function uniq(values: string[]): string[] {
+  return [...new Set(values)].filter(Boolean).sort();
+}
+
+function shellWords(values: string[]): string {
+  return uniq(values).join(" ");
+}
+
+function shQuote(value: string): string {
+  return "'" + value.replace(/'/g, "'\\''") + "'";
+}
+
+function zshWords(commands: CommandSpec[]): string {
+  return uniq(commands.map(c => shQuote(`${c.command}:${c.help.replace(/[:\\]/g, " ")}`))).join(" ");
+}
+
+export async function getCompletionCommandSpecs(): Promise<CommandSpec[]> {
+  const discovered = await discoverPlugins();
+  const pluginCommands = discovered.plugins
+    .filter(p => p.manifest.cli?.command)
+    .map((p): CommandSpec => ({
+      command: p.manifest.cli!.command,
+      help: p.manifest.cli!.help ?? p.manifest.description ?? "ARRA command",
+      flags: Object.keys(p.manifest.cli!.flags ?? {}),
+    }));
+  const byCommand = new Map<string, CommandSpec>();
+  for (const spec of [...BUILTIN_COMMANDS, ...pluginCommands]) byCommand.set(spec.command, spec);
+  return [...byCommand.values()].sort((a, b) => a.command.localeCompare(b.command));
+}
+
+function bash(specs: CommandSpec[]): string {
+  const commands = shellWords(specs.map(s => s.command));
+  const flags = shellWords(COMMON_FLAGS);
+  const subcase = specs
+    .filter(s => s.subcommands?.length)
+    .map(s => `    ${s.command}) COMPREPLY=( $(compgen -W "${shellWords([...(s.subcommands ?? []), ...(s.flags ?? [])])}" -- "$cur") ) ;;`)
+    .join("\n");
+  return `# bash completion for arra/arra-cli\n_arra_completion() {\n  local cur prev cmd\n  COMPREPLY=()\n  cur="\${COMP_WORDS[COMP_CWORD]}"\n  prev="\${COMP_WORDS[COMP_CWORD-1]}"\n\n  if [[ $COMP_CWORD -eq 1 ]]; then\n    COMPREPLY=( $(compgen -W "${commands} ${flags}" -- "$cur") )\n    return 0\n  fi\n\n  cmd="\${COMP_WORDS[1]}"\n  case "$cmd" in\n${subcase}\n    *) COMPREPLY=( $(compgen -W "${flags}" -- "$cur") ) ;;\n  esac\n}\ncomplete -F _arra_completion arra\ncomplete -F _arra_completion arra-cli\n`;
+}
+
+function zsh(specs: CommandSpec[]): string {
+  const top = zshWords(specs);
+  const flags = shellWords(COMMON_FLAGS);
+  const subcase = specs
+    .filter(s => s.subcommands?.length)
+    .map(s => `    ${s.command}) _values '${s.command}' ${shellWords([...(s.subcommands ?? []), ...(s.flags ?? [])])} ;;`)
+    .join("\n");
+  return `#compdef arra arra-cli\n# zsh completion for arra/arra-cli\n_arra() {\n  local -a commands\n  commands=(${top})\n\n  if (( CURRENT == 2 )); then\n    _describe 'command' commands\n    _values 'global flags' ${flags}\n    return\n  fi\n\n  case "\${words[2]}" in\n${subcase}\n    *) _values 'flags' ${flags} ;;\n  esac\n}\n_arra "$@"\n`;
+}
+
+function fish(specs: CommandSpec[]): string {
+  const lines = ["# fish completion for arra/arra-cli"];
+  for (const bin of ["arra", "arra-cli"]) {
+    for (const spec of specs) {
+      lines.push(`complete -c ${bin} -f -n '__fish_use_subcommand' -a '${spec.command}' -d '${spec.help.replace(/'/g, "").replace(/\n/g, " ")}'`);
+      for (const sub of spec.subcommands ?? []) {
+        lines.push(`complete -c ${bin} -f -n '__fish_seen_subcommand_from ${spec.command}' -a '${sub}'`);
+      }
+    }
+    for (const flag of COMMON_FLAGS) {
+      if (flag.startsWith("--")) lines.push(`complete -c ${bin} -f -l ${flag.slice(2)} -d '${flag}'`);
+      else if (flag.startsWith("-") && flag.length === 2) lines.push(`complete -c ${bin} -f -s ${flag.slice(1)} -d '${flag}'`);
+    }
+  }
+  return lines.join("\n") + "\n";
+}
+
+export async function completionsCommand(args: string[]): Promise<number> {
+  const shell = args[0]?.toLowerCase();
+  if (!shell || shell === "--help" || shell === "-h") {
+    console.log("usage: arra completions <bash|zsh|fish>");
+    return shell ? 0 : 1;
+  }
+  const specs = await getCompletionCommandSpecs();
+  if (shell === "bash") console.log(bash(specs));
+  else if (shell === "zsh") console.log(zsh(specs));
+  else if (shell === "fish") console.log(fish(specs));
+  else {
+    console.error(`unknown shell: ${args[0]}`);
+    console.error("usage: arra completions <bash|zsh|fish>");
+    return 1;
+  }
+  return 0;
+}

--- a/tests/cli/completions/completions.test.ts
+++ b/tests/cli/completions/completions.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { runCli } from "../_run.ts";
+
+describe("arra completions", () => {
+  for (const shell of ["bash", "zsh", "fish"] as const) {
+    test(`${shell} emits a non-empty completion script with known commands`, async () => {
+      const result = await runCli(["completions", shell]);
+      expect(result.code).toBe(0);
+      expect(result.stdout.length).toBeGreaterThan(100);
+      expect(result.stdout).toContain("health");
+      expect(result.stdout).toContain("config");
+      expect(result.stdout).toContain("doctor");
+      expect(result.stdout).toContain("plugins");
+      expect(result.stdout).toContain("completions");
+      expect(result.stdout).toContain("--at");
+    }, 15_000);
+  }
+
+  test("unknown shell exits non-zero", async () => {
+    const result = await runCli(["completions", "powershell"]);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("unknown shell");
+  }, 15_000);
+});


### PR DESCRIPTION
## Summary
- add `arra completions <bash|zsh|fish>` to print shell completion scripts
- generate top-level completions from a shared built-in command catalog plus discovered plugin commands
- cover common flags (`--at`, `--json`, `--help`, `-h`, `--version`) and built-in subcommands
- document zsh/bash/fish installation snippets in README

Closes Soul-Brews-Studio/arra-oracle-v3-oracle#37

## Verification
- `bun test tests/cli/completions/completions.test.ts`
- `bun test tests/cli`
- `bun run build`
- generated bash completion passed `bash -n`
- generated zsh/fish syntax checks were run when those shells were available

## Notes
- No static completion files are committed; operators install generated stdout into their shell-specific completion directory.