### PR TITLE
Fix raw Bun test shared-state isolation

### DIFF
--- a/src/config/tool-groups.ts
+++ b/src/config/tool-groups.ts
@@ -275,39 +275,65 @@ export function watchToolGroupConfig(
   const globalPluginsPath = path.join(ORACLE_DATA_DIR, 'plugins.json');
   const watchers: fs.FSWatcher[] = [];
   let timer: ReturnType<typeof setTimeout> | null = null;
+  let poller: ReturnType<typeof setInterval> | null = null;
   let last = JSON.stringify(loadToolGroupConfig(root));
+
+  const reloadIfChanged = (): void => {
+    const next = loadToolGroupConfig(root);
+    const serialized = JSON.stringify(next);
+    if (serialized === last) return;
+    last = serialized;
+    console.error('[ToolGroups] Config changed — reloading');
+    onChange(next);
+  };
 
   const tick = (): void => {
     if (timer) clearTimeout(timer);
     timer = setTimeout(() => {
       timer = null;
-      const next = loadToolGroupConfig(root);
-      const serialized = JSON.stringify(next);
-      if (serialized === last) return;
-      last = serialized;
-      console.error('[ToolGroups] Config changed — reloading');
-      onChange(next);
+      reloadIfChanged();
     }, 200);
   };
 
+  const byDir = new Map<string, Set<string>>();
   for (const target of [localPath, localPluginsPath, globalPath, globalPluginsPath]) {
+    const dir = path.dirname(target);
+    const names = byDir.get(dir) ?? new Set<string>();
+    names.add(path.basename(target));
+    byDir.set(dir, names);
+
     try {
-      // Watch the file directly. fs.watch on a missing file throws on Linux
-      // and silently fails on macOS, so probe with existsSync first.
+      // File watchers are useful for direct writes, but cannot observe a
+      // missing file being created and can go stale after unlink/replace.
       if (fs.existsSync(target)) {
         watchers.push(fs.watch(target, { persistent: false }, tick));
-      } else {
-        // Watch the directory so we catch creation. Ignored if dir is missing.
-        const dir = path.dirname(target);
-        if (fs.existsSync(dir)) {
-          const base = path.basename(target);
-          watchers.push(
-            fs.watch(dir, { persistent: false }, (_event, filename) => {
-              if (filename === base) tick();
-            }),
-          );
-        }
       }
+    } catch {
+      // fs.watch can fail on platforms without inotify — keep going.
+    }
+  }
+
+  // Poll as a safety net for raw `bun test` shared-process runs: fs.watch can
+  // drop creation events under load, while comparing the resolved config keeps
+  // no-op writes silent.
+  poller = setInterval(reloadIfChanged, 100);
+  poller.unref?.();
+
+  for (const [dir, names] of byDir) {
+    try {
+      // Always watch directories that exist so raw `bun test` shared-process
+      // runs reliably catch create/delete/replace events between test files.
+      if (!fs.existsSync(dir)) continue;
+      watchers.push(
+        fs.watch(dir, { persistent: false }, (_event, filename) => {
+          if (!filename) {
+            tick();
+            return;
+          }
+          const changed = Buffer.isBuffer(filename) ? filename.toString() : String(filename);
+          if (names.has(changed)) tick();
+        }),
+      );
     } catch {
       // fs.watch can fail on platforms without inotify — keep going.
     }
@@ -317,6 +343,10 @@ export function watchToolGroupConfig(
     if (timer) {
       clearTimeout(timer);
       timer = null;
+    }
+    if (poller) {
+      clearInterval(poller);
+      poller = null;
     }
     for (const w of watchers) {
       try {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -129,10 +129,10 @@ if (!fs.existsSync(ORACLE_DATA_DIR)) {
 }
 
 const isReadonly = process.env.ORACLE_VECTOR_READONLY === '1';
-const defaultSqlite = isReadonly
+let defaultSqlite = isReadonly
   ? new Database(DB_PATH, { readonly: true })
   : new Database(DB_PATH);
-const defaultDb = drizzle(defaultSqlite, { schema });
+let defaultDb = drizzle(defaultSqlite, { schema });
 
 if (isReadonly) {
   console.log('[DB] Opened in READONLY mode (vector sidecar)');
@@ -141,8 +141,26 @@ if (isReadonly) {
   initializeDatabase(defaultSqlite, defaultDb);
 }
 
-export const sqlite = defaultSqlite;
-export const db = defaultDb;
+export let sqlite = defaultSqlite;
+export let db = defaultDb;
+
+/**
+ * Test-only escape hatch for raw `bun test` non-isolate runs. Some tests set
+ * ORACLE_DATA_DIR after another file has already imported the module-level DB;
+ * live bindings let them re-point the default connection without process-level
+ * isolation. Production callers should prefer createDatabase().
+ */
+export function resetDefaultDatabaseForTests(dbPath?: string): void {
+  try { defaultSqlite.close(); } catch {}
+  const resolvedPath = dbPath || process.env.ORACLE_DB_PATH || path.join(process.env.ORACLE_DATA_DIR || ORACLE_DATA_DIR, 'oracle.db');
+  const dir = path.dirname(resolvedPath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  defaultSqlite = new Database(resolvedPath);
+  defaultDb = drizzle(defaultSqlite, { schema });
+  initializeDatabase(defaultSqlite, defaultDb);
+  sqlite = defaultSqlite;
+  db = defaultDb;
+}
 
 // Export schema for use in queries
 export * from './schema.ts';

--- a/src/gateway/config.ts
+++ b/src/gateway/config.ts
@@ -108,15 +108,17 @@ export function watchGatewayConfig(
   };
 
   try {
-    if (fs.existsSync(configPath)) {
-      watchers.push(fs.watch(configPath, { persistent: false }, tick));
-    } else if (fs.existsSync(dataDir)) {
-      // Watch the directory so we catch creation of the config file later.
+    if (fs.existsSync(dataDir)) {
+      // Always watch the directory: file watchers may miss unlink/replace
+      // events for a directly watched file on some platforms.
       watchers.push(
         fs.watch(dataDir, { persistent: false }, (_event, filename) => {
           if (filename === CONFIG_FILE) tick();
         }),
       );
+    }
+    if (fs.existsSync(configPath)) {
+      watchers.push(fs.watch(configPath, { persistent: false }, tick));
     }
   } catch {
     // fs.watch can fail on platforms without inotify — keep going.

--- a/src/routes/files/file.ts
+++ b/src/routes/files/file.ts
@@ -13,6 +13,8 @@ import { REPO_ROOT } from '../../config.ts';
 import { getVaultPsiRoot } from '../../vault/handler.ts';
 import { fileQuery } from './model.ts';
 
+const currentRepoRoot = () => process.env.ORACLE_REPO_ROOT || REPO_ROOT;
+
 export const fileRoute = new Elysia().get(
   '/api/file',
   ({ query, set }) => {
@@ -38,13 +40,15 @@ export const fileRoute = new Elysia().get(
           const proc = Bun.spawnSync(['ghq', 'root']);
           GHQ_ROOT = proc.stdout.toString().trim();
         } catch {
-          const match = REPO_ROOT.match(/^(.+?)\/github\.com\//);
+          const root = currentRepoRoot();
+          const match = root.match(/^(.+?)\/github\.com\//);
           GHQ_ROOT = match
             ? match[1]
-            : path.dirname(path.dirname(path.dirname(REPO_ROOT)));
+            : path.dirname(path.dirname(path.dirname(root)));
         }
       }
-      const basePath = project ? path.join(GHQ_ROOT, project) : REPO_ROOT;
+      const root = currentRepoRoot();
+      const basePath = project ? path.join(GHQ_ROOT, project) : root;
 
       // Strip project prefix if source_file already contains it.
       let resolvedFilePath = filePath;
@@ -63,7 +67,7 @@ export const fileRoute = new Elysia().get(
       }
 
       const realGhqRoot = fs.realpathSync(GHQ_ROOT);
-      const realRepoRoot = fs.realpathSync(REPO_ROOT);
+      const realRepoRoot = fs.realpathSync(root);
       if (
         !realPath.startsWith(realGhqRoot) &&
         !realPath.startsWith(realRepoRoot)
@@ -80,7 +84,7 @@ export const fileRoute = new Elysia().get(
       // live in the universal vault (REPO_ROOT / ORACLE_DATA_DIR / ψ/), not
       // in the project's ghq checkout. Try REPO_ROOT before giving up.
       if (project) {
-        const repoFullPath = path.join(REPO_ROOT, filePath);
+        const repoFullPath = path.join(root, filePath);
         const realRepoFullPath = path.resolve(repoFullPath);
         if (
           realRepoFullPath.startsWith(realRepoRoot) &&

--- a/src/routes/files/plugin-by-name.ts
+++ b/src/routes/files/plugin-by-name.ts
@@ -6,13 +6,16 @@ import path from 'path';
 import { PLUGINS_DIR } from '../../config.ts';
 import { pluginParams } from './model.ts';
 
+const currentPluginsDir = () => process.env.ORACLE_DATA_DIR ? path.join(process.env.ORACLE_DATA_DIR, 'plugins') : PLUGINS_DIR;
+
+
 export const pluginByNameRoute = new Elysia().get(
   '/api/plugins/:name',
   ({ params, set }) => {
     const file = params.name.endsWith('.wasm')
       ? params.name
       : `${params.name}.wasm`;
-    const filePath = path.join(PLUGINS_DIR, file);
+    const filePath = path.join(currentPluginsDir(), file);
     if (!fs.existsSync(filePath)) {
       set.status = 404;
       return { error: 'Plugin not found' };

--- a/src/routes/files/plugins.ts
+++ b/src/routes/files/plugins.ts
@@ -7,12 +7,15 @@ import fs from 'fs';
 import path from 'path';
 import { PLUGINS_DIR } from '../../config.ts';
 
+const currentPluginsDir = () => process.env.ORACLE_DATA_DIR ? path.join(process.env.ORACLE_DATA_DIR, 'plugins') : PLUGINS_DIR;
+
+
 export const pluginsListRoute = new Elysia().get('/api/plugins', () => {
   try {
-    if (!fs.existsSync(PLUGINS_DIR)) return { plugins: [] };
-    const files = fs.readdirSync(PLUGINS_DIR).filter((f) => f.endsWith('.wasm'));
+    if (!fs.existsSync(currentPluginsDir())) return { plugins: [] };
+    const files = fs.readdirSync(currentPluginsDir()).filter((f) => f.endsWith('.wasm'));
     const plugins = files.map((f) => {
-      const stat = fs.statSync(path.join(PLUGINS_DIR, f));
+      const stat = fs.statSync(path.join(currentPluginsDir(), f));
       return {
         name: f.replace('.wasm', ''),
         file: f,

--- a/src/server/__tests__/learn-slug-collision.test.ts
+++ b/src/server/__tests__/learn-slug-collision.test.ts
@@ -23,11 +23,14 @@ const TMP_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-learn-collision
 
 const ORIGINAL_REPO_ROOT = process.env.ORACLE_REPO_ROOT;
 const ORIGINAL_DATA_DIR = process.env.ORACLE_DATA_DIR;
+const ORIGINAL_DB_PATH = process.env.ORACLE_DB_PATH;
 
 process.env.ORACLE_REPO_ROOT = TMP_REPO_ROOT;
 process.env.ORACLE_DATA_DIR = TMP_DATA_DIR;
 
-// Dynamic import after env is set (REPO_ROOT and DB_PATH are module-frozen).
+// Dynamic imports after env is set; reset DB in case raw bun test imported db earlier.
+const { resetDefaultDatabaseForTests } = await import('../../db/index.ts');
+resetDefaultDatabaseForTests(path.join(TMP_DATA_DIR, 'oracle.db'));
 const { handleLearn } = await import('../handlers.ts');
 
 describe('handleLearn — slug collision', () => {
@@ -75,4 +78,7 @@ afterAll(() => {
   else delete process.env.ORACLE_REPO_ROOT;
   if (ORIGINAL_DATA_DIR) process.env.ORACLE_DATA_DIR = ORIGINAL_DATA_DIR;
   else delete process.env.ORACLE_DATA_DIR;
+  if (ORIGINAL_DB_PATH) process.env.ORACLE_DB_PATH = ORIGINAL_DB_PATH;
+  else delete process.env.ORACLE_DB_PATH;
+  resetDefaultDatabaseForTests();
 });

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -10,6 +10,8 @@ import path from 'path';
 import { eq, sql, or, inArray } from 'drizzle-orm';
 import { db, sqlite, oracleDocuments, indexingStatus, isDbLockError } from '../db/index.ts';
 import { REPO_ROOT, VECTOR_URL } from '../config.ts';
+
+const currentRepoRoot = () => process.env.ORACLE_REPO_ROOT || REPO_ROOT;
 import { logSearch, logDocumentAccess, logLearning } from './logging.ts';
 import type { SearchResult, SearchResponse } from './types.ts';
 import { ensureVectorStoreConnected, EMBEDDING_MODELS } from '../vector/factory.ts';
@@ -688,7 +690,7 @@ export function persistLearningDoc(opts: {
   const now = new Date();
   const dateStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
 
-  const dir = path.join(REPO_ROOT, subdir);
+  const dir = path.join(currentRepoRoot(), subdir);
   fs.mkdirSync(dir, { recursive: true });
   const filePath = path.join(dir, filename);
 
@@ -770,7 +772,7 @@ export function handleLearn(
   // until unique. Prevents 500s when two writes share a slug within one day
   // (e.g. repeated hot-write snapshots from the same agent).
   const subdir = 'ψ/memory/learnings';
-  const learningsDir = path.join(REPO_ROOT, subdir);
+  const learningsDir = path.join(currentRepoRoot(), subdir);
   let uniqueSlug = slug;
   let suffix = 2;
   while (fs.existsSync(path.join(learningsDir, `${dateStr}_${uniqueSlug}.md`))) {

--- a/tests/http/files-plugins.test.ts
+++ b/tests/http/files-plugins.test.ts
@@ -9,6 +9,10 @@ import { join } from 'path';
 const WASM_HEADER = Buffer.from([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]);
 
 let tmp: string;
+const ORIGINAL_DATA_DIR = process.env.ORACLE_DATA_DIR;
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_REPO_ROOT = process.env.ORACLE_REPO_ROOT;
+const ORIGINAL_GHQ_ROOT = process.env.GHQ_ROOT;
 // combined: mirrors production — files.ts registers /api/plugins first and
 // shadows plugins.ts. pluginsOnly: canonical dual-layout scanner in isolation.
 let combined: any;
@@ -74,6 +78,10 @@ const req = (path: string) => new Request(`http://localhost${path}`);
 
 afterAll(() => {
   if (tmp) rmSync(tmp, { recursive: true, force: true });
+  if (ORIGINAL_DATA_DIR) process.env.ORACLE_DATA_DIR = ORIGINAL_DATA_DIR; else delete process.env.ORACLE_DATA_DIR;
+  if (ORIGINAL_HOME) process.env.HOME = ORIGINAL_HOME; else delete process.env.HOME;
+  if (ORIGINAL_REPO_ROOT) process.env.ORACLE_REPO_ROOT = ORIGINAL_REPO_ROOT; else delete process.env.ORACLE_REPO_ROOT;
+  if (ORIGINAL_GHQ_ROOT) process.env.GHQ_ROOT = ORIGINAL_GHQ_ROOT; else delete process.env.GHQ_ROOT;
 });
 
 describe('GET /api/file — security', () => {


### PR DESCRIPTION
## Summary
- make raw `bun test` shared-process runs hermetic across DB/env mutations
- re-read repo/data paths at request time where tests intentionally swap `ORACLE_*` env
- harden config watchers against create/delete/replace events under raw all-test load

Closes #1346

## Verification
- `bun run build`
- `bun run test`
- clean archive copy: `ORACLE_DATA_DIR=$(mktemp -d) ORACLE_REPO_ROOT=$PWD bun test` → 755 pass, 22 skip, 0 fail
