### PR TITLE
Port federation stack into source alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,8 +257,8 @@ HTTP API on port 47778 (`bun run server`).
 | `GET` | `/api/dashboard/activity` | `dashboard` |  |
 | `GET` | `/api/dashboard/growth` | `dashboard` |  |
 | `GET` | `/api/session/stats` | `dashboard` | Session stats endpoint - tracks activity from DB (includes MCP usage) |
-| `GET` | `/api/feed` | `feed` |  |
-| `POST` | `/api/feed` | `feed` | Log an event to feed.log |
+| `GET` | `/api/peer/feed` | `feed` |  |
+| `POST` | `/api/peer/feed` | `feed` | Log an event to feed.log |
 | `GET` | `/api/graph` | `files` | Graph |
 | `GET` | `/api/context` | `files` | Context |
 | `GET` | `/api/file` | `files` | File - supports cross-repo access via ghq project paths |
@@ -375,3 +375,15 @@ for categories and signature convention.
 ## Acknowledgments
 
 Inspired by [claude-mem](https://github.com/thedotmack/claude-mem) by Alex Newman — process manager pattern, worker service architecture, and hook system concepts.
+
+## Federation peer endpoints
+
+Arra exposes a small MAW-compatible federation surface for peer oracles:
+
+- `GET /info` — public MAW schema/capability document.
+- `GET /api/identity` — public stable node identity and local TOFU pubkey.
+- `GET /api/peers` — probes peers from `ARRA_NAMED_PEERS` or `peers.json` and pins pubkeys on first contact.
+- `GET /api/peer/feed` — peer-readable feed (optionally protected).
+- `POST /api/peer/search` — peer-callable Arra search (also available as `POST /api/search`; existing `GET /api/search` is unchanged).
+
+Set `ARRA_PEER_TOKEN` to require `Authorization: Bearer <token>` (or `?token=`) for `/api/peer/feed` and peer search. `/info` and `/api/identity` stay open for discovery. Configure peers with `ARRA_NAMED_PEERS='{"mawjs":"http://host:port"}'` or `$ORACLE_DATA_DIR/peers.json`. Run `arra peers --token <token>` to probe them. Scout HELLO multicast is opt-in with `ARRA_SCOUT_ANNOUNCE=1`.

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -25,6 +25,7 @@ import { menuResetAll } from "./commands/menu-reset.ts";
 import { configCommand, useCommand } from "./commands/config.ts";
 import { doctorCommand } from "./commands/doctor.ts";
 import { completionsCommand } from "./commands/completions.ts";
+import { peersCommand } from "./commands/peers.ts";
 import { BUILTIN_COMMANDS } from "./commands/catalog.ts";
 
 const pkg = await Bun.file(join(import.meta.dir, "../package.json")).json();
@@ -101,6 +102,10 @@ async function main() {
 
   if (cmd === "doctor") {
     process.exit(await doctorCommand(args.slice(1)));
+  }
+
+  if (cmd === "peers") {
+    process.exit(await peersCommand(args.slice(1)));
   }
 
   if (cmd === "use") {

--- a/cli/src/commands/catalog.ts
+++ b/cli/src/commands/catalog.ts
@@ -16,4 +16,5 @@ export const BUILTIN_COMMANDS: CommandSpec[] = [
   { command: "doctor", help: "run operator diagnostics against the resolved target", flags: ["--json", "--help", "-h"] },
   { command: "use", help: "set the global default API target" },
   { command: "completions", help: "print shell completion scripts", subcommands: ["bash", "zsh", "fish"], flags: ["--help", "-h"] },
+  { command: "peers", help: "probe configured federation peers", flags: ["--token", "--json", "--help", "-h"] },
 ];

--- a/cli/src/commands/peers.ts
+++ b/cli/src/commands/peers.ts
@@ -1,0 +1,16 @@
+export async function peersCommand(args: string[]): Promise<number> {
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log('arra-cli peers [--token <token>] [--json]\n');
+    console.log('Probe configured federation peers from ARRA_NAMED_PEERS or peers.json.');
+    return 0;
+  }
+  const tokenIndex = args.indexOf('--token');
+  const token = tokenIndex >= 0 ? args[tokenIndex + 1] : undefined;
+  if (tokenIndex >= 0 && !token) { console.error('usage: arra-cli peers --token <token>'); return 1; }
+  const json = args.includes('--json');
+  const { listPeerStatuses, formatPeerStatuses } = await import('../../../src/peer/peer-query.ts');
+  const statuses = await listPeerStatuses(undefined, { token });
+  if (json) console.log(JSON.stringify({ peers: statuses }, null, 2));
+  else console.log(formatPeerStatuses(statuses));
+  return statuses.every((s: any) => s.ok) ? 0 : 1;
+}

--- a/src/integration/federation-peer.test.ts
+++ b/src/integration/federation-peer.test.ts
@@ -1,0 +1,29 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const ROOT = process.cwd();
+let serverProc: Bun.Subprocess | undefined;
+let mockPeer: ReturnType<typeof Bun.serve> | undefined;
+let base = '';
+let peerPubkey = 'a'.repeat(64);
+async function waitFor(url: string, timeoutMs = 15000) { const start = Date.now(); while (Date.now() - start < timeoutMs) { try { const r = await fetch(url); if (r.ok) return; } catch {} await new Promise(r => setTimeout(r, 200)); } throw new Error(`Timed out waiting for ${url}`); }
+async function json(path: string, init?: RequestInit) { const res = await fetch(`${base}${path}`, init); const body = await res.json().catch(() => ({})); return { res, body }; }
+
+describe('federation peer stack', () => {
+  beforeAll(async () => {
+    mockPeer = Bun.serve({ port: 0, fetch(req) { const url = new URL(req.url); if (url.pathname === '/info') return Response.json({ maw: { schema: '1', capabilities: ['feed', 'arra-search'] }, node: 'mawjs@test', oracle: 'mawjs', locators: [`http://127.0.0.1:${mockPeer!.port}`], ts: Date.now() }); if (url.pathname === '/api/identity') return Response.json({ pubkey: peerPubkey, node: 'mawjs@test', oracle: 'mawjs' }); return Response.json({ error: 'not found' }, { status: 404 }); }});
+    const dataDir = mkdtempSync(join(tmpdir(), 'arra-fed-data-'));
+    const repoRoot = mkdtempSync(join(tmpdir(), 'arra-fed-repo-'));
+    mkdirSync(join(repoRoot, 'ψ'), { recursive: true });
+    writeFileSync(join(repoRoot, 'ψ', 'federation.md'), '# Federation Note\n\nmawjs peer search regression sentinel.\n');
+    const port = 49000 + Math.floor(Math.random() * 1000); base = `http://127.0.0.1:${port}`;
+    serverProc = Bun.spawn(['bun', 'src/server.ts'], { cwd: ROOT, stdout: 'ignore', stderr: 'ignore', env: { ...process.env, ORACLE_PORT: String(port), ORACLE_DATA_DIR: dataDir, ORACLE_DB_PATH: join(dataDir, 'oracle.db'), ORACLE_REPO_ROOT: repoRoot, ARRA_NAMED_PEERS: JSON.stringify({ mawjs: `http://127.0.0.1:${mockPeer.port}` }), ARRA_PEER_TOKEN: 'secret', VECTOR_URL: '', MAW_JS_URL: 'http://127.0.0.1:1' } });
+    await waitFor(`${base}/api/health`);
+  });
+  afterAll(() => { serverProc?.kill(); mockPeer?.stop(true); });
+  test('serves discovery and stable identity while protected endpoints require token', async () => { const info = await json('/info'); expect(info.res.status).toBe(200); expect(info.body.maw.schema).toBe('1'); expect(info.body.maw.capabilities).toContain('feed'); expect(info.body.maw.capabilities).toContain('arra-search'); const id1 = await json('/api/identity'); const id2 = await json('/api/identity'); expect(id1.body.pubkey).toMatch(/^[0-9a-f]{64}$/); expect(id2.body.pubkey).toBe(id1.body.pubkey); const localFeed = await json('/api/feed'); expect(localFeed.body.error).not.toBe('peer_auth_required'); expect((await json('/api/peer/feed')).res.status).toBe(401); expect((await json('/api/peer/search', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ query: 'mawjs' }) })).res.status).toBe(401); });
+  test('pins peers with TOFU and reports mismatches', async () => { const first = await json('/api/peers'); expect(first.body.peers[0].ok).toBe(true); expect(first.body.peers[0].pinStatus).toBe('new'); const second = await json('/api/peers'); expect(second.body.peers[0].pinStatus).toBe('pinned'); peerPubkey = 'b'.repeat(64); const mismatch = await json('/api/peers'); expect(mismatch.body.peers[0].ok).toBe(false); expect(mismatch.body.peers[0].error).toBe('MISMATCH'); });
+  test('serves authenticated feed and peer search with bounded results', async () => { const feed = await json('/api/peer/feed?token=secret&limit=500'); expect(feed.res.status).toBe(200); expect(feed.body.items.length).toBeGreaterThan(0); expect(feed.body.items.length).toBeLessThanOrEqual(100); const search = await json('/api/peer/search', { method: 'POST', headers: { 'content-type': 'application/json', authorization: 'Bearer secret' }, body: JSON.stringify({ query: 'mawjs', limit: 5 }) }); expect(search.res.status).toBe(200); expect(search.body.results.length).toBeGreaterThan(0); expect(search.body.results[0].snippet.toLowerCase()).toContain('mawjs'); });
+});

--- a/src/peer/feed.ts
+++ b/src/peer/feed.ts
@@ -1,0 +1,21 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
+import { basename, extname, join, relative } from 'path';
+import { FEED_LOG, REPO_ROOT } from '../config.ts';
+import { nodeName } from './identity.ts';
+export interface PeerFeedItem { id: string; title: string; url?: string; ts: string; summary?: string; source?: string; }
+function capLimit(limit: unknown) { const n = Number(limit ?? 20); return Math.min(100, Math.max(1, Number.isFinite(n) ? Math.trunc(n) : 20)); }
+function titleFrom(path: string, text: string) { return text.match(/^#\s+(.+)$/m)?.[1]?.trim() || basename(path, extname(path)); }
+function walk(dir: string, out: string[] = []): string[] { if (!existsSync(dir)) return out; for (const ent of readdirSync(dir, { withFileTypes: true })) { if (['node_modules','.git','.omx','agents'].includes(ent.name)) continue; const p = join(dir, ent.name); if (ent.isDirectory()) walk(p, out); else if (/\.(md|mdx|txt)$/i.test(ent.name)) out.push(p); } return out; }
+function feedLogItems(): PeerFeedItem[] { if (!existsSync(FEED_LOG)) return []; return readFileSync(FEED_LOG, 'utf8').split(/\n+/).filter(Boolean).slice(-200).map((line, i) => { try { const v = JSON.parse(line); return { id: String(v.id ?? `feed-log-${i}`), title: String(v.title ?? v.event ?? 'Feed item'), ts: String(v.ts ?? v.createdAt ?? new Date().toISOString()), summary: v.summary ?? v.text ?? undefined, source: 'feed-log' }; } catch { return { id: `feed-log-${i}`, title: line.slice(0, 80), ts: new Date().toISOString(), summary: line, source: 'feed-log' }; } }); }
+export async function getPeerFeed(limitArg?: unknown) {
+  const limit = capLimit(limitArg);
+  const items = feedLogItems();
+  if (items.length < limit) {
+    for (const file of walk(REPO_ROOT).sort((a,b) => statSync(b).mtimeMs - statSync(a).mtimeMs).slice(0, limit * 2)) {
+      const text = readFileSync(file, 'utf8'); const st = statSync(file);
+      items.push({ id: relative(REPO_ROOT, file), title: titleFrom(file, text), ts: st.mtime.toISOString(), summary: text.replace(/\s+/g, ' ').slice(0, 240), source: 'filesystem' });
+      if (items.length >= limit) break;
+    }
+  }
+  return { node: nodeName(), oracle: 'arra', ts: Date.now(), items: items.slice(0, limit) };
+}

--- a/src/peer/identity-key.ts
+++ b/src/peer/identity-key.ts
@@ -1,0 +1,18 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from 'fs';
+import { dirname, join } from 'path';
+import { randomBytes } from 'crypto';
+import { ORACLE_DATA_DIR } from '../config.ts';
+
+export function identityKeyPath() { return join(ORACLE_DATA_DIR, 'peer-key.hex'); }
+export function getIdentityPubkey(path = identityKeyPath()): string {
+  if (existsSync(path)) {
+    const key = readFileSync(path, 'utf8').trim().toLowerCase();
+    if (!/^[0-9a-f]{64}$/.test(key)) throw new Error(`Invalid peer identity key at ${path}`);
+    return key;
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  const key = randomBytes(32).toString('hex');
+  writeFileSync(path, `${key}\n`, { mode: 0o600 });
+  try { chmodSync(path, 0o600); } catch {}
+  return key;
+}

--- a/src/peer/identity.ts
+++ b/src/peer/identity.ts
@@ -1,0 +1,16 @@
+import os from 'os';
+import pkg from '../../package.json' with { type: 'json' };
+import { PORT } from '../config.ts';
+import { getIdentityPubkey } from './identity-key.ts';
+
+export const FEDERATION_CAPABILITIES = ['arra-search', 'feed'] as const;
+export const SCOUT_CAPABILITIES = ['pair', 'feed', 'send', 'arra-search'] as const;
+
+export function nodeName() { return `arra@${os.hostname()}`; }
+export function locators() { return [`http://${os.hostname()}:${PORT}`]; }
+export function federationInfo() {
+  return { maw: { schema: '1', capabilities: [...FEDERATION_CAPABILITIES] }, node: nodeName(), oracle: 'arra', locators: locators(), version: pkg.version, ts: Date.now() };
+}
+export function identityDocument() {
+  return { pubkey: getIdentityPubkey(), node: nodeName(), oracle: 'arra', version: pkg.version, uptime: process.uptime(), clockUtc: new Date().toISOString() };
+}

--- a/src/peer/peer-auth.ts
+++ b/src/peer/peer-auth.ts
@@ -1,0 +1,17 @@
+import { timingSafeEqual } from 'crypto';
+
+export function peerToken() { return process.env.ARRA_PEER_TOKEN?.trim() || ''; }
+export function isPeerAuthEnabled() { return peerToken().length > 0; }
+function safeEqual(a: string, b: string) {
+  const ab = Buffer.from(a); const bb = Buffer.from(b);
+  return ab.length === bb.length && timingSafeEqual(ab, bb);
+}
+export function isPeerAuthorized(request: Request) {
+  const configured = peerToken();
+  if (!configured) return true;
+  const auth = request.headers.get('authorization') ?? '';
+  const bearer = auth.match(/^Bearer\s+(.+)$/i)?.[1]?.trim();
+  const urlToken = new URL(request.url).searchParams.get('token')?.trim();
+  return Boolean((bearer && safeEqual(bearer, configured)) || (urlToken && safeEqual(urlToken, configured)));
+}
+export function unauthorizedPeerResponse() { return { error: 'peer_auth_required', message: 'ARRA peer token required' }; }

--- a/src/peer/peer-query.ts
+++ b/src/peer/peer-query.ts
@@ -1,0 +1,21 @@
+import { loadNamedPeers, type NamedPeers } from './peer-registry.ts';
+import { pinPeerPubkey, PeerPubkeyMismatch, type PinStatus } from './peer-tofu.ts';
+export interface PeerStatus { name: string; url: string; ok: boolean; node?: string; oracle?: string; pubkey?: string; pinStatus?: PinStatus; capabilities?: string[]; error?: string; }
+function headers(token?: string) { return token ? { authorization: `Bearer ${token}` } : undefined; }
+async function getJson(url: string, token?: string): Promise<any> { const res = await fetch(url, { headers: headers(token) }); if (!res.ok) throw new Error(`${res.status} ${res.statusText}`); return res.json(); }
+export async function probePeer(name: string, url: string, opts: { token?: string } = {}): Promise<PeerStatus> {
+  const base = url.replace(/\/+$/, '');
+  try {
+    const info = await getJson(`${base}/info`, opts.token);
+    if (info?.maw?.schema !== '1') throw new Error('missing maw schema 1');
+    const ident = await getJson(`${base}/api/identity`, opts.token);
+    if (!ident?.node || !/^[0-9a-f]{64}$/i.test(ident?.pubkey ?? '')) throw new Error('invalid identity');
+    const pinStatus = pinPeerPubkey(name, ident.pubkey);
+    return { name, url: base, ok: true, node: ident.node, oracle: ident.oracle ?? info.oracle, pubkey: ident.pubkey.toLowerCase(), pinStatus, capabilities: info.maw.capabilities ?? [] };
+  } catch (error) {
+    if (error instanceof PeerPubkeyMismatch) return { name, url: base, ok: false, error: 'MISMATCH', pubkey: error.actual };
+    return { name, url: base, ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+export async function listPeerStatuses(peers: NamedPeers = loadNamedPeers(), opts: { token?: string } = {}) { return Promise.all(Object.entries(peers).map(([name, url]) => probePeer(name, url, opts))); }
+export function formatPeerStatuses(statuses: PeerStatus[]) { return statuses.map(s => s.ok ? `${s.name}\tOK\t${s.node}\t${s.pinStatus}\t${s.url}` : `${s.name}\tFAIL\t${s.error}\t${s.url}`).join('\n'); }

--- a/src/peer/peer-registry.ts
+++ b/src/peer/peer-registry.ts
@@ -1,0 +1,18 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { ORACLE_DATA_DIR } from '../config.ts';
+export type NamedPeers = Record<string, string>;
+function normalize(v: unknown): NamedPeers {
+  const source = (v && typeof v === 'object' && 'namedPeers' in (v as any)) ? (v as any).namedPeers : v;
+  if (!source || typeof source !== 'object') return {};
+  const out: NamedPeers = {};
+  for (const [k, val] of Object.entries(source as Record<string, unknown>)) {
+    if (typeof val === 'string' && /^https?:\/\//.test(val)) out[k] = val.replace(/\/+$/, '');
+  }
+  return out;
+}
+export function loadNamedPeers(configPath = process.env.ARRA_PEERS_CONFIG || join(ORACLE_DATA_DIR, 'peers.json')): NamedPeers {
+  if (process.env.ARRA_NAMED_PEERS?.trim()) return normalize(JSON.parse(process.env.ARRA_NAMED_PEERS));
+  if (existsSync(configPath)) return normalize(JSON.parse(readFileSync(configPath, 'utf8')));
+  return {};
+}

--- a/src/peer/peer-tofu.ts
+++ b/src/peer/peer-tofu.ts
@@ -1,0 +1,15 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from 'fs';
+import { dirname, join } from 'path';
+import { ORACLE_DATA_DIR } from '../config.ts';
+export type PinStatus = 'new' | 'pinned';
+export class PeerPubkeyMismatch extends Error { constructor(public peer: string, public expected: string, public actual: string) { super(`Peer pubkey mismatch for ${peer}`); this.name = 'PeerPubkeyMismatch'; } }
+function pinPath() { return process.env.ARRA_PEERS_TOFU_PATH || join(ORACLE_DATA_DIR, 'peers-tofu.json'); }
+function readPins(path = pinPath()): Record<string,string> { if (!existsSync(path)) return {}; return JSON.parse(readFileSync(path, 'utf8')); }
+function writePins(pins: Record<string,string>, path = pinPath()) { mkdirSync(dirname(path), { recursive: true }); writeFileSync(path, JSON.stringify(pins, null, 2) + '\n', { mode: 0o600 }); try { chmodSync(path, 0o600); } catch {} }
+export function pinPeerPubkey(peer: string, pubkey: string, path = pinPath()): PinStatus {
+  if (!/^[0-9a-f]{64}$/i.test(pubkey)) throw new Error('Invalid peer pubkey');
+  const pins = readPins(path); const key = pubkey.toLowerCase();
+  if (!pins[peer]) { pins[peer] = key; writePins(pins, path); return 'new'; }
+  if (pins[peer] !== key) throw new PeerPubkeyMismatch(peer, pins[peer], key);
+  return 'pinned';
+}

--- a/src/peer/scout-announcer.ts
+++ b/src/peer/scout-announcer.ts
@@ -1,0 +1,14 @@
+import dgram from 'dgram';
+import { getIdentityPubkey } from './identity-key.ts';
+import { locators, nodeName, SCOUT_CAPABILITIES } from './identity.ts';
+export const SCOUT_GROUP = process.env.ARRA_SCOUT_GROUP || '224.0.0.224';
+export const SCOUT_PORT = Number(process.env.ARRA_SCOUT_PORT || 31746);
+export function shouldStartScoutAnnouncer() { return process.env.ARRA_SCOUT_ANNOUNCE === '1'; }
+export class ScoutAnnouncer {
+  private socket: dgram.Socket | null = null; private timer: Timer | null = null;
+  constructor(private intervalMs = Number(process.env.ARRA_SCOUT_INTERVAL_MS || 5000)) {}
+  payload() { const pub = getIdentityPubkey(); return { type: 'maw-hello', version: 1, zid: pub.slice(0, 16), whatAmI: 'oracle', node: nodeName(), oracle: 'arra', locators: locators(), capabilities: [...SCOUT_CAPABILITIES], oracles: ['arra'], ts: Date.now() }; }
+  start() { if (this.socket) return; this.socket = dgram.createSocket('udp4'); this.socket.bind(() => { this.socket?.setMulticastTTL(2); this.announce(); this.timer = setInterval(() => this.announce(), this.intervalMs); }); }
+  announce() { if (!this.socket) return; const buf = Buffer.from(JSON.stringify(this.payload())); this.socket.send(buf, SCOUT_PORT, SCOUT_GROUP); }
+  stop() { if (this.timer) clearInterval(this.timer); this.timer = null; this.socket?.close(); this.socket = null; }
+}

--- a/src/peer/search.ts
+++ b/src/peer/search.ts
@@ -1,0 +1,13 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
+import { basename, extname, join, relative } from 'path';
+import { REPO_ROOT } from '../config.ts';
+import { handleSearch } from '../server/handlers.ts';
+import { nodeName } from './identity.ts';
+export interface PeerSearchResult { id: string; score: number; title: string; snippet: string; }
+function capLimit(limit: unknown) { const n = Number(limit ?? 10); return Math.min(50, Math.max(1, Number.isFinite(n) ? Math.trunc(n) : 10)); }
+function walk(dir: string, out: string[] = []): string[] { if (!existsSync(dir)) return out; for (const ent of readdirSync(dir, { withFileTypes: true })) { if (['node_modules','.git','.omx','agents'].includes(ent.name)) continue; const p = join(dir, ent.name); if (ent.isDirectory()) walk(p, out); else if (/\.(md|mdx|txt)$/i.test(ent.name)) out.push(p); } return out; }
+function titleFrom(path: string, text: string) { return text.match(/^#\s+(.+)$/m)?.[1]?.trim() || basename(path, extname(path)); }
+function snippet(text: string, q: string) { const idx = text.toLowerCase().indexOf(q.toLowerCase()); const start = Math.max(0, idx < 0 ? 0 : idx - 80); return text.slice(start, start + 240).replace(/\s+/g, ' ').trim(); }
+async function dbSearch(query: string, limit: number): Promise<PeerSearchResult[]> { const r = await handleSearch(query, 'all', limit, 0, 'hybrid'); return (r.results ?? []).slice(0, limit).map((x: any, i: number) => ({ id: String(x.id), score: typeof x.score === 'number' ? x.score : 1 / (i + 1), title: x.source_file ? basename(String(x.source_file)) : String(x.type ?? x.id), snippet: String(x.content ?? '').replace(/\s+/g, ' ').slice(0, 240) })); }
+function fsSearch(query: string, limit: number): PeerSearchResult[] { const q = query.toLowerCase(); const results: PeerSearchResult[] = []; for (const file of walk(REPO_ROOT)) { const text = readFileSync(file, 'utf8'); const idx = text.toLowerCase().indexOf(q); if (idx < 0) continue; results.push({ id: relative(REPO_ROOT, file), score: 1, title: titleFrom(file, text), snippet: snippet(text, query) }); if (results.length >= limit) break; } return results.sort((a,b) => statSync(join(REPO_ROOT,b.id)).mtimeMs - statSync(join(REPO_ROOT,a.id)).mtimeMs); }
+export async function peerSearch(input: { query?: unknown; q?: unknown; limit?: unknown }) { const q = String(input.query ?? input.q ?? '').trim(); const limit = capLimit(input.limit); if (!q) return { node: nodeName(), oracle: 'arra', results: [] as PeerSearchResult[] }; let results: PeerSearchResult[] = []; try { results = await dbSearch(q, limit); } catch {} if (!results.length) results = fsSearch(q, limit); return { node: nodeName(), oracle: 'arra', query: q, results: results.slice(0, limit) }; }

--- a/src/routes/peer/feed.ts
+++ b/src/routes/peer/feed.ts
@@ -1,0 +1,4 @@
+import { Elysia } from 'elysia';
+import { getPeerFeed } from '../../peer/feed.ts';
+import { isPeerAuthorized, unauthorizedPeerResponse } from '../../peer/peer-auth.ts';
+export const peerFeedRoutes = new Elysia({ prefix: '/api' }).get('/peer/feed', async ({ request, query, set }) => { if (!isPeerAuthorized(request)) { set.status = 401; return unauthorizedPeerResponse(); } return getPeerFeed(query.limit); }, { detail: { tags: ['federation'], summary: 'Peer-readable federation feed' } });

--- a/src/routes/peer/identity.ts
+++ b/src/routes/peer/identity.ts
@@ -1,0 +1,3 @@
+import { Elysia } from 'elysia';
+import { identityDocument } from '../../peer/identity.ts';
+export const peerIdentityRoutes = new Elysia({ prefix: '/api' }).get('/identity', () => identityDocument(), { detail: { tags: ['federation'], summary: 'Stable federation identity' } });

--- a/src/routes/peer/index.ts
+++ b/src/routes/peer/index.ts
@@ -1,0 +1,12 @@
+import { Elysia } from 'elysia';
+import { peerInfoRoutes } from './info.ts';
+import { peerIdentityRoutes } from './identity.ts';
+import { peerListRoutes } from './peers.ts';
+import { peerFeedRoutes } from './feed.ts';
+import { peerSearchRoutes } from './search.ts';
+export const peerRoutes = new Elysia()
+  .use(peerInfoRoutes)
+  .use(peerIdentityRoutes)
+  .use(peerListRoutes)
+  .use(peerFeedRoutes)
+  .use(peerSearchRoutes);

--- a/src/routes/peer/info.ts
+++ b/src/routes/peer/info.ts
@@ -1,0 +1,3 @@
+import { Elysia } from 'elysia';
+import { federationInfo } from '../../peer/identity.ts';
+export const peerInfoRoutes = new Elysia().get('/info', () => federationInfo(), { detail: { tags: ['federation'], summary: 'MAW federation info' } });

--- a/src/routes/peer/peers.ts
+++ b/src/routes/peer/peers.ts
@@ -1,0 +1,3 @@
+import { Elysia } from 'elysia';
+import { listPeerStatuses } from '../../peer/peer-query.ts';
+export const peerListRoutes = new Elysia({ prefix: '/api' }).get('/peers', async () => ({ peers: await listPeerStatuses() }), { detail: { tags: ['federation'], summary: 'Probe configured peers with TOFU pins' } });

--- a/src/routes/peer/search.ts
+++ b/src/routes/peer/search.ts
@@ -1,0 +1,7 @@
+import { Elysia } from 'elysia';
+import { peerSearch } from '../../peer/search.ts';
+import { isPeerAuthorized, unauthorizedPeerResponse } from '../../peer/peer-auth.ts';
+async function handle({ request, body, set }: any) { if (!isPeerAuthorized(request)) { set.status = 401; return unauthorizedPeerResponse(); } return peerSearch((body ?? {}) as any); }
+export const peerSearchRoutes = new Elysia({ prefix: '/api' })
+  .post('/peer/search', handle, { detail: { tags: ['federation'], summary: 'Peer-callable Arra search' } })
+  .post('/search', handle, { detail: { tags: ['federation'], summary: 'Peer-callable Arra search alias' } });

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ import {
 } from './process-manager/index.ts';
 
 import { PORT, ORACLE_DATA_DIR, VECTOR_URL } from './config.ts';
+import { ScoutAnnouncer, shouldStartScoutAnnouncer } from './peer/scout-announcer.ts';
 import { MCP_SERVER_NAME } from './const.ts';
 import { db, sqlite, closeDb, indexingStatus } from './db/index.ts';
 import { seedMenuItems, type HasRoutes as SeedHasRoutes } from './db/seeders/menu-seeder.ts';
@@ -42,6 +43,7 @@ import { oraclenetRoutes } from './routes/oraclenet/index.ts';
 import { sessionsRoutes } from './routes/sessions/index.ts';
 import { vaultRoutes } from './routes/vault/index.ts';
 import { createMenuRoutes } from './routes/menu/index.ts';
+import { peerRoutes } from './routes/peer/index.ts';
 
 // Indexer routes are optional — MCP server works without them
 let indexerRoutes: any = null;
@@ -76,10 +78,16 @@ writePidFile({
   name: 'oracle-http',
 });
 
+const scoutAnnouncer = shouldStartScoutAnnouncer() ? new ScoutAnnouncer() : null;
+scoutAnnouncer?.start();
+
 registerSignalHandlers(async () => {
   console.log('\n🔮 Shutting down gracefully...');
   await performGracefulShutdown({
-    resources: [{ close: () => { closeDb(); return Promise.resolve(); } }],
+    resources: [
+      { close: () => { scoutAnnouncer?.stop(); return Promise.resolve(); } },
+      { close: () => { closeDb(); return Promise.resolve(); } },
+    ],
   });
   removePidFile();
   console.log('👋 Arra Oracle HTTP Server stopped.');
@@ -188,6 +196,7 @@ const app = new Elysia()
     }),
   )
   .use(gatewayPlugin(ORACLE_DATA_DIR, VECTOR_URL || undefined))
+  .use(peerRoutes)
   .get('/', () => ({
     server: MCP_SERVER_NAME,
     version: pkg.version,


### PR DESCRIPTION
## Summary

Ports the federation stack into the publishable source repo (`Soul-Brews-Studio/arra-oracle-v3`) instead of the oracle repo:

- MAW discovery: `GET /info`, `GET /api/identity`
- Peer registry/probe: `GET /api/peers`, TOFU pinning and `arra peers --token`
- Scout HELLO announcer behind `ARRA_SCOUT_ANNOUNCE=1`
- Peer feed and peer search: `GET /api/peer/feed`, `POST /api/peer/search`
- Optional endpoint auth via `ARRA_PEER_TOKEN`
- E2E regression guard for pair → identity → TOFU → feed → search → auth

Notes:
- Per triage #42, peer feed is mounted at `/api/peer/feed` so source repo's existing `GET /api/feed` local/oraclenet feed is not shadowed.
- #11 MCP tool toggle was already source-native via the existing tool group config/manifest path, so this PR does not re-port the oracle-repo scaffold.

## Ported work

Ports federation functionality originally built for oracle issues #6, #17, #20, #23, #27, #29, #33, and #36 into source alpha.

Closes Soul-Brews-Studio/arra-oracle-v3-oracle#39

## Verification

- `bun run build`
- `bun test src/integration/federation-peer.test.ts tests/cli/completions/completions.test.ts`
