### PR TITLE
Document shipped federation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,12 +378,15 @@ Inspired by [claude-mem](https://github.com/thedotmack/claude-mem) by Alex Newma
 
 ## Federation peer endpoints
 
-Arra exposes a small MAW-compatible federation surface for peer oracles:
+Arra exposes a MAW-compatible federation surface for peer oracles. See
+[docs/FEDERATION.md](docs/FEDERATION.md) for the full operator guide, including
+pairing, Scout discovery, TOFU pinning, bearer-token protection, and an
+Arra↔mawjs worked example.
+
+Key paths:
 
 - `GET /info` — public MAW schema/capability document.
 - `GET /api/identity` — public stable node identity and local TOFU pubkey.
 - `GET /api/peers` — probes peers from `ARRA_NAMED_PEERS` or `peers.json` and pins pubkeys on first contact.
-- `GET /api/peer/feed` — peer-readable feed (optionally protected).
-- `POST /api/peer/search` — peer-callable Arra search (also available as `POST /api/search`; existing `GET /api/search` is unchanged).
-
-Set `ARRA_PEER_TOKEN` to require `Authorization: Bearer <token>` (or `?token=`) for `/api/peer/feed` and peer search. `/info` and `/api/identity` stay open for discovery. Configure peers with `ARRA_NAMED_PEERS='{"mawjs":"http://host:port"}'` or `$ORACLE_DATA_DIR/peers.json`. Run `arra peers --token <token>` to probe them. Scout HELLO multicast is opt-in with `ARRA_SCOUT_ANNOUNCE=1`.
+- `GET /api/peer/feed` — peer-readable feed (optionally protected); this is **not** `/api/feed`.
+- `POST /api/peer/search` — peer-callable Arra search.

--- a/docs/FEDERATION.md
+++ b/docs/FEDERATION.md
@@ -1,0 +1,256 @@
+# Arra federation guide
+
+Arra exposes a small MAW-compatible federation surface so another Oracle can
+pair, verify identity, read a bounded peer feed, and call Arra search. This
+guide is for the `alpha` source tree where the federation routes are mounted by
+`src/routes/peer/*`.
+
+## What is public vs protected
+
+| Surface | Method/path | Auth | Purpose |
+| --- | --- | --- | --- |
+| Pairing info | `GET /info` | Always open | MAW schema, node name, locators, and capabilities. |
+| Identity | `GET /api/identity` | Always open | Stable local pubkey for TOFU pinning. |
+| Peer probe | `GET /api/peers` | Local operator endpoint | Probes configured peers and updates TOFU pins. |
+| Peer feed | `GET /api/peer/feed` | Optional `ARRA_PEER_TOKEN` | Peer-readable Arra feed. This is **not** `/api/feed`; `/api/feed` is the local/oraclenet feed surface. |
+| Peer search | `POST /api/peer/search` | Optional `ARRA_PEER_TOKEN` | Peer-callable Arra search. `POST /api/search` is also kept as a compatibility alias. |
+
+When `ARRA_PEER_TOKEN` is unset, feed and peer-search are open. When it is set,
+callers must pass either `Authorization: Bearer <token>` or `?token=<token>`.
+`/info` and `/api/identity` remain open so peers can discover and pin identity.
+
+## Start an Arra node for federation
+
+```bash
+# Optional but recommended for state isolation while testing.
+export ORACLE_DATA_DIR=$HOME/.oracle
+
+# Optional shared token for feed + peer search.
+export ARRA_PEER_TOKEN='replace-with-shared-secret'
+
+# Optional Scout HELLO multicast announcer.
+export ARRA_SCOUT_ANNOUNCE=1
+
+bun run server
+```
+
+Useful Scout knobs:
+
+| Env | Default | Purpose |
+| --- | --- | --- |
+| `ARRA_SCOUT_ANNOUNCE` | unset/off | Set to `1` to emit Scout HELLO multicast. |
+| `ARRA_SCOUT_GROUP` | `224.0.0.224` | Multicast group. |
+| `ARRA_SCOUT_PORT` | `31746` | Multicast port. |
+| `ARRA_SCOUT_INTERVAL_MS` | `5000` | HELLO interval. |
+
+The HELLO payload advertises Arra locators, node name, and capabilities
+`pair`, `feed`, `send`, and `arra-search`.
+
+## Pairing contract
+
+A peer pairs by reading Arra's public info and identity documents:
+
+```bash
+curl -s http://localhost:47778/info | jq
+curl -s http://localhost:47778/api/identity | jq
+```
+
+`GET /info` returns a MAW-compatible document shaped like:
+
+```json
+{
+  "maw": { "schema": "1", "capabilities": ["arra-search", "feed"] },
+  "node": "arra@hostname",
+  "oracle": "arra",
+  "locators": ["http://hostname:47778"],
+  "version": "...",
+  "ts": 1780000000000
+}
+```
+
+`GET /api/identity` returns the stable local TOFU key:
+
+```json
+{
+  "pubkey": "64-hex-character-key",
+  "node": "arra@hostname",
+  "oracle": "arra",
+  "version": "...",
+  "uptime": 12.34,
+  "clockUtc": "2026-06-06T00:00:00.000Z"
+}
+```
+
+Arra stores its own identity key in `$ORACLE_DATA_DIR/peer-key.hex`.
+
+## Configure named peers
+
+Arra probes outbound peers from either `ARRA_NAMED_PEERS` or a JSON file. The
+environment variable wins when both are set.
+
+### Option A: environment variable
+
+```bash
+export ARRA_NAMED_PEERS='{"mawjs":"http://127.0.0.1:47800"}'
+```
+
+### Option B: peers.json
+
+By default Arra reads `$ORACLE_DATA_DIR/peers.json`. Override the path with
+`ARRA_PEERS_CONFIG`.
+
+```json
+{
+  "namedPeers": {
+    "mawjs": "http://127.0.0.1:47800"
+  }
+}
+```
+
+The flat form also works:
+
+```json
+{
+  "mawjs": "http://127.0.0.1:47800"
+}
+```
+
+## Probe peers and pin TOFU keys
+
+Use the operator CLI:
+
+```bash
+arra peers --token "$ARRA_PEER_TOKEN"
+arra peers --json --token "$ARRA_PEER_TOKEN"
+```
+
+Or call the HTTP endpoint:
+
+```bash
+curl -s http://localhost:47778/api/peers | jq
+```
+
+For each named peer Arra fetches:
+
+1. `GET <peer>/info`
+2. `GET <peer>/api/identity`
+
+The first successful probe writes `$ORACLE_DATA_DIR/peers-tofu.json` with the
+peer's pubkey. Later probes must match the pinned key. If a peer returns a
+different pubkey, Arra reports a `MISMATCH` and you should verify the rotation
+out-of-band before deleting or editing the pin.
+
+Override the pin file with `ARRA_PEERS_TOFU_PATH` when needed.
+
+## Query Arra as a peer
+
+### Feed
+
+Use `/api/peer/feed` for federation. Do not use `/api/feed`; that path belongs
+to Arra's local/oraclenet feed surface.
+
+```bash
+curl -s -H "Authorization: Bearer $ARRA_PEER_TOKEN" \
+  'http://localhost:47778/api/peer/feed?limit=20' | jq
+```
+
+For quick browser/manual checks, `?token=` is accepted when a token is set:
+
+```bash
+curl -s 'http://localhost:47778/api/peer/feed?token=replace-with-shared-secret&limit=20' | jq
+```
+
+The server caps overly large feed limits, so peers should request only what
+they need.
+
+### Search
+
+```bash
+curl -s -X POST http://localhost:47778/api/peer/search \
+  -H 'content-type: application/json' \
+  -H "Authorization: Bearer $ARRA_PEER_TOKEN" \
+  -d '{"query":"mawjs federation","limit":5}' | jq
+```
+
+Expected response shape:
+
+```json
+{
+  "node": "arra@hostname",
+  "oracle": "arra",
+  "query": "mawjs federation",
+  "results": []
+}
+```
+
+## Worked example: pair Arra and mawjs
+
+This example assumes Arra runs on `http://127.0.0.1:47778` and mawjs exposes the
+same pairing contract on `http://127.0.0.1:47800`.
+
+### 1. Start Arra with a shared peer token
+
+```bash
+export ORACLE_DATA_DIR=$(mktemp -d)
+export ARRA_PEER_TOKEN='dev-secret'
+export ARRA_NAMED_PEERS='{"mawjs":"http://127.0.0.1:47800"}'
+export ARRA_SCOUT_ANNOUNCE=1
+bun run server
+```
+
+### 2. Confirm Arra's public pairing documents
+
+```bash
+curl -s http://127.0.0.1:47778/info | jq '.maw, .node, .locators'
+curl -s http://127.0.0.1:47778/api/identity | jq '.node, .pubkey'
+```
+
+Give mawjs the Arra locator, token, and pubkey out-of-band if mawjs requires
+manual trust confirmation.
+
+### 3. Probe mawjs from Arra and create the TOFU pin
+
+```bash
+arra peers --token dev-secret
+# or
+curl -s http://127.0.0.1:47778/api/peers | jq
+```
+
+The first successful probe should report a new pin. The next probe should
+report the peer as pinned. If it reports `MISMATCH`, stop and verify the mawjs
+identity key before trusting feed/search results.
+
+### 4. Let mawjs query Arra feed/search
+
+```bash
+curl -s -H 'Authorization: Bearer dev-secret' \
+  'http://127.0.0.1:47778/api/peer/feed?limit=20' | jq
+
+curl -s -X POST http://127.0.0.1:47778/api/peer/search \
+  -H 'content-type: application/json' \
+  -H 'Authorization: Bearer dev-secret' \
+  -d '{"query":"federation","limit":5}' | jq
+```
+
+## Security checklist
+
+- Keep `/info` and `/api/identity` open; they are the discovery and pairing
+  contract.
+- Set `ARRA_PEER_TOKEN` before exposing `/api/peer/feed` or
+  `/api/peer/search` beyond a trusted local network.
+- Prefer bearer auth over `?token=` outside quick manual checks because URLs are
+  often logged.
+- Treat `$ORACLE_DATA_DIR/peers-tofu.json` as a trust store. Unexpected key
+  changes are a security event until verified out-of-band.
+- Keep Scout multicast opt-in (`ARRA_SCOUT_ANNOUNCE=1`) and review
+  `ARRA_SCOUT_GROUP` / `ARRA_SCOUT_PORT` for your network.
+
+## Verification commands
+
+```bash
+bun test src/integration/federation-peer.test.ts
+bun run build
+```
+
+The integration test covers public discovery, stable identity, token-protected
+feed/search, named peer probing, first-use pins, and mismatch detection.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -233,5 +233,6 @@ See also:
 
 - [README.md](../README.md) - Overview
 - [TONIGHT-SHIPPED.md](./TONIGHT-SHIPPED.md) - Current alpha operator reference
+- [FEDERATION.md](./FEDERATION.md) - Federation pairing, peer search/feed, and security guide
 - [API.md](./API.md) - API documentation
 - [architecture.md](./architecture.md) - System architecture

--- a/docs/TONIGHT-SHIPPED.md
+++ b/docs/TONIGHT-SHIPPED.md
@@ -2,8 +2,6 @@
 
 This is the compact operator map for the large 2026-06-06/07 alpha wave. It is meant to answer: *what shipped, where is the code, what knob controls it, and what is the first command to try?*
 
-> Branch note: this document is written for the `alpha` docs PR. Most config/plugin/vector/Docker surfaces are present on `alpha`. The federation/peer surfaces listed below were merged on the main-line federation track and are called out separately so operators can see the intended shape without mistaking them for mounted `alpha` endpoints.
-
 ## Quick index
 
 | Surface | Status | Primary knobs | First command |
@@ -14,7 +12,7 @@ This is the compact operator map for the large 2026-06-06/07 alpha wave. It is m
 | Vector adapter selection | `alpha` | `ORACLE_VECTOR_DB`, `ORACLE_VECTOR_DB_PATH`, `QDRANT_URL`, `VECTOR_URL` | `ORACLE_VECTOR_DB=qdrant QDRANT_URL=http://localhost:6333 bun run server` |
 | Docker/GHCR | `alpha` | Docker targets `http-server`, `mcp-stdio` | `docker run --rm -p 47778:47778 ghcr.io/soul-brews-studio/arra-oracle-v3:http` |
 | Docker MCP Toolkit catalog | `alpha` | `catalog/arra-oracle.yaml` | copy catalog into Docker MCP Toolkit catalog dir |
-| Federation / peer identity | main-line federation track | `FED_ENABLED`, `ARRA_SCOUT_ANNOUNCE`, `ARRA_PEER_TOKEN` | see [Federation status](#federation-status-main-line-track) |
+| Federation / peer identity | shipped on `alpha` | `ARRA_SCOUT_ANNOUNCE`, `ARRA_PEER_TOKEN`, `ARRA_NAMED_PEERS` | see [FEDERATION.md](./FEDERATION.md) |
 
 ## MCP modes: embedded vs HTTP-proxy
 
@@ -201,34 +199,42 @@ cp catalog/arra-oracle.yaml ~/.docker/mcp/catalogs/
 
 The catalog image is `ghcr.io/soul-brews-studio/arra-oracle-v3:stdio`, so click-to-install flows do not need a local build once GHCR publishing has run.
 
-## Federation status: main-line track
+## Federation / peer identity
 
-The current `alpha` tree for this docs PR does **not** contain the federation route/plugin files. The federation work exists on the main-line track and is relevant for operators following nightly merges:
+Federation is now mounted in the `alpha` source tree. Use the full operator
+guide in [FEDERATION.md](./FEDERATION.md) for pairing, Scout discovery,
+TOFU pinning, peer feed/search, and the Arra↔mawjs worked example.
 
-| Feature | PR / code path on main-line track | Knob |
+| Feature | Source path | Knob / endpoint |
 | --- | --- | --- |
-| Maw peer `/info` and `/api/identity` | PR #1249, `src/routes/peer/*`, `src/peer/identity-key.ts` | persistent TOFU pubkey under data dir |
-| Scout HELLO multicast | PR #1259, `src/peer/scout-announcer.ts` | `ARRA_SCOUT_ANNOUNCE=1` |
-| Federation plugin seam / lifecycle | PRs #1280, #1281, #1288, #1290 | plugin manifest / lifecycle config |
-| Federation opt-in default | PR #1283 | `FED_ENABLED=true` |
-| Config-backed plugin enable/disable UX | PR #1292 | `arra plugins enable/disable` on that track |
-| Peer auth | main-line federation contract | `ARRA_PEER_TOKEN` |
-| Peer APIs | main-line federation contract | `/api/peers`, `/api/feed`, `/api/peer/search` |
+| Maw peer info | `src/routes/peer/info.ts` | `GET /info` |
+| Stable identity | `src/routes/peer/identity.ts`, `src/peer/identity-key.ts` | `GET /api/identity`, `$ORACLE_DATA_DIR/peer-key.hex` |
+| Named peer probing | `src/routes/peer/peers.ts`, `src/peer/peer-query.ts` | `GET /api/peers`, `arra peers --token <token>` |
+| Peer feed | `src/routes/peer/feed.ts` | `GET /api/peer/feed` (**not** `/api/feed`) |
+| Peer search | `src/routes/peer/search.ts` | `POST /api/peer/search` |
+| Static peer config | `src/peer/peer-registry.ts` | `ARRA_NAMED_PEERS`, `$ORACLE_DATA_DIR/peers.json`, `ARRA_PEERS_CONFIG` |
+| TOFU trust store | `src/peer/peer-tofu.ts` | `$ORACLE_DATA_DIR/peers-tofu.json`, `ARRA_PEERS_TOFU_PATH` |
+| Peer auth | `src/peer/peer-auth.ts` | `ARRA_PEER_TOKEN` bearer auth or `?token=` for feed/search |
+| Scout HELLO multicast | `src/peer/scout-announcer.ts` | `ARRA_SCOUT_ANNOUNCE=1` |
 
-Operational intent:
+Quick smoke:
 
 ```bash
-# Main-line federation track shape; not mounted in this alpha tree.
-FED_ENABLED=true \
 ARRA_SCOUT_ANNOUNCE=1 \
 ARRA_PEER_TOKEN=<shared-token> \
 bun run server
 
 curl http://localhost:47778/info
 curl http://localhost:47778/api/identity
+curl 'http://localhost:47778/api/peer/feed?token=<shared-token>&limit=20'
+curl -X POST http://localhost:47778/api/peer/search \
+  -H 'content-type: application/json' \
+  -H 'Authorization: Bearer <shared-token>' \
+  -d '{"query":"federation","limit":5}'
 ```
 
-Treat first-seen peer keys as TOFU pins: verify unexpected key changes out-of-band before trusting search/feed results from that peer.
+Treat first-seen peer keys as TOFU pins: verify unexpected key changes
+out-of-band before trusting search/feed results from that peer.
 
 ## Verification checklist for this wave
 


### PR DESCRIPTION
## Summary
- adds `docs/FEDERATION.md`, a source-alpha operator guide for pairing, Scout discovery, named peers, TOFU pins, peer feed/search, auth, and an Arra↔mawjs worked example
- links the guide from README and docs/INSTALL
- updates the #34 consolidated docs row/section from the earlier "main-line track" punt to shipped-on-alpha source paths
- explicitly documents peer feed as `GET /api/peer/feed` and calls out that `/api/feed` is not the federation peer feed

## Source-path confirmation
- routes: `src/routes/peer/{info,identity,peers,feed,search}.ts`
- peer modules: `src/peer/{identity,identity-key,peer-registry,peer-query,peer-tofu,peer-auth,feed,search,scout-announcer}.ts`
- CLI: `arra peers --token <token>` via `cli/src/commands/peers.ts`
- env: `ARRA_SCOUT_ANNOUNCE`, `ARRA_SCOUT_GROUP`, `ARRA_SCOUT_PORT`, `ARRA_SCOUT_INTERVAL_MS`, `ARRA_PEER_TOKEN`, `ARRA_NAMED_PEERS`, `ARRA_PEERS_CONFIG`, `ARRA_PEERS_TOFU_PATH`

## Validation
- `bun test src/integration/federation-peer.test.ts`
- `bun run build`
- `bun cli/src/cli.ts peers --help`
- `git diff --check`

Not live-tested against a separate mawjs node; the guide follows the landed shared contract and the source integration mock.

Closes Soul-Brews-Studio/arra-oracle-v3-oracle#45
