### PR TITLE
Verify federation smoke and feed namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,9 @@
     "vault:pull": "bun src/vault/cli.ts pull",
     "vault:status": "bun src/vault/cli.ts status",
     "vault:migrate": "bun src/vault/cli.ts migrate",
-    "vault:rsync": "./scripts/vault-rsync.sh"
+    "vault:rsync": "./scripts/vault-rsync.sh",
+    "test:e2e:federation": "bun test tests/e2e/federation-smoke.test.ts",
+    "smoke:federation": "bun scripts/federation-smoke.ts"
   },
   "dependencies": {
     "@elysiajs/cors": "^1.4.1",

--- a/scripts/federation-smoke.ts
+++ b/scripts/federation-smoke.ts
@@ -1,0 +1,192 @@
+#!/usr/bin/env bun
+/**
+ * Federation smoke harness for source alpha.
+ *
+ * Pre-staged for oracle issue #44: after the federation migration lands, run
+ * this against a live source server to verify the peer route namespace and auth
+ * contract without clobbering the existing local/oraclenet `/api/feed` route.
+ */
+
+type SmokeStatus = 'pass' | 'fail' | 'pending';
+
+export interface SmokeCheck {
+  name: string;
+  status: SmokeStatus;
+  detail?: string;
+}
+
+export interface SmokeOptions {
+  baseUrl: string;
+  token?: string;
+  requireFederation?: boolean;
+  verbose?: boolean;
+}
+
+const FEDERATION_PATHS = ['/info', '/api/identity', '/api/peers', '/api/peer/feed', '/api/peer/search'] as const;
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, '');
+}
+
+async function requestJson(baseUrl: string, path: string, init?: RequestInit): Promise<{ status: number; body: any; text: string }> {
+  const res = await fetch(`${baseUrl}${path}`, init);
+  const text = await res.text();
+  let body: any = null;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = null;
+  }
+  return { status: res.status, body, text };
+}
+
+function isMissingRoute(status: number): boolean {
+  return status === 404 || status === 405;
+}
+
+function pass(name: string, detail?: string): SmokeCheck {
+  return { name, status: 'pass', detail };
+}
+
+function fail(name: string, detail: string): SmokeCheck {
+  return { name, status: 'fail', detail };
+}
+
+function pending(name: string, detail: string): SmokeCheck {
+  return { name, status: 'pending', detail };
+}
+
+function expectObject(name: string, status: number, body: any, missingOk: boolean): SmokeCheck {
+  if (isMissingRoute(status) && missingOk) return pending(name, `route not present yet (${status})`);
+  if (status < 200 || status >= 300) return fail(name, `expected 2xx, got ${status}`);
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return fail(name, 'expected JSON object body');
+  return pass(name, `HTTP ${status}`);
+}
+
+export async function runFederationSmoke(options: SmokeOptions): Promise<SmokeCheck[]> {
+  const baseUrl = normalizeBaseUrl(options.baseUrl);
+  const missingOk = !options.requireFederation;
+  const checks: SmokeCheck[] = [];
+
+  for (const path of FEDERATION_PATHS) {
+    const method = path === '/api/peer/search' ? 'POST' : 'GET';
+    const headers: Record<string, string> = {};
+    if (path.startsWith('/api/peer/') && options.token) headers.authorization = `Bearer ${options.token}`;
+    const init: RequestInit = method === 'POST'
+      ? {
+          method,
+          headers: { ...headers, 'content-type': 'application/json' },
+          body: JSON.stringify({ q: 'federation smoke', limit: 3 }),
+        }
+      : { method, headers };
+    const res = await requestJson(baseUrl, path, init);
+    checks.push(expectObject(`${method} ${path}`, res.status, res.body, missingOk));
+  }
+
+  const info = await requestJson(baseUrl, '/info');
+  if (info.status >= 200 && info.status < 300 && info.body) {
+    const capabilities = info.body.capabilities ?? info.body.maw?.capabilities ?? info.body.node?.capabilities ?? [];
+    const hasSearch = JSON.stringify(capabilities).includes('arra-search');
+    const hasFeed = JSON.stringify(capabilities).includes('feed');
+    const hasSchema = Boolean(info.body.maw?.schema ?? info.body['maw.schema'] ?? info.body.schema);
+    checks.push(hasSearch && hasFeed ? pass('/info capabilities', 'advertises arra-search + feed') : fail('/info capabilities', 'missing arra-search/feed capability'));
+    checks.push(hasSchema ? pass('/info maw schema', 'schema advertised') : fail('/info maw schema', 'missing maw.schema/schema'));
+  }
+
+  const identity = await requestJson(baseUrl, '/api/identity');
+  if (identity.status >= 200 && identity.status < 300 && identity.body) {
+    const pubkey = String(identity.body.pubkey ?? identity.body.publicKey ?? identity.body.identity?.pubkey ?? '');
+    checks.push(/^[a-f0-9]{64}$/i.test(pubkey) ? pass('/api/identity pubkey', '64 hex chars') : fail('/api/identity pubkey', 'pubkey is not 64-hex'));
+  }
+
+  // Namespace regression guard: source already owns `/api/feed`; federation must
+  // live under `/api/peer/feed` and must not replace `/api/feed` semantics.
+  const localFeed = await requestJson(baseUrl, '/api/feed?limit=1');
+  const peerFeed = await requestJson(baseUrl, '/api/peer/feed?limit=1');
+  if (!isMissingRoute(peerFeed.status) || options.requireFederation) {
+    if (localFeed.status === peerFeed.status && JSON.stringify(localFeed.body) === JSON.stringify(peerFeed.body)) {
+      checks.push(fail('feed namespace separation', '/api/feed and /api/peer/feed returned identical response'));
+    } else if (isMissingRoute(peerFeed.status) && missingOk) {
+      checks.push(pending('feed namespace separation', '/api/peer/feed not present yet'));
+    } else {
+      checks.push(pass('feed namespace separation', '/api/peer/feed is distinct from existing /api/feed'));
+    }
+  } else {
+    checks.push(pending('feed namespace separation', '/api/peer/feed not present yet'));
+  }
+
+  if (options.token) {
+    const unauthFeed = await requestJson(baseUrl, '/api/peer/feed?limit=1');
+    const authFeed = await requestJson(baseUrl, '/api/peer/feed?limit=1', { headers: { authorization: `Bearer ${options.token}` } });
+    const unauthSearch = await requestJson(baseUrl, '/api/peer/search', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ q: 'federation smoke' }),
+    });
+    const authSearch = await requestJson(baseUrl, '/api/peer/search', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${options.token}` },
+      body: JSON.stringify({ q: 'federation smoke' }),
+    });
+
+    if (isMissingRoute(unauthFeed.status) && missingOk) {
+      checks.push(pending('peer auth feed', 'route not present yet'));
+    } else {
+      checks.push(unauthFeed.status === 401 && authFeed.status >= 200 && authFeed.status < 300
+        ? pass('peer auth feed', 'Bearer token required')
+        : fail('peer auth feed', `expected 401 without token + 2xx with token, got ${unauthFeed.status}/${authFeed.status}`));
+    }
+
+    if (isMissingRoute(unauthSearch.status) && missingOk) {
+      checks.push(pending('peer auth search', 'route not present yet'));
+    } else {
+      checks.push(unauthSearch.status === 401 && authSearch.status >= 200 && authSearch.status < 300
+        ? pass('peer auth search', 'Bearer token required')
+        : fail('peer auth search', `expected 401 without token + 2xx with token, got ${unauthSearch.status}/${authSearch.status}`));
+    }
+
+    const openInfo = await requestJson(baseUrl, '/info');
+    const openIdentity = await requestJson(baseUrl, '/api/identity');
+    if (!isMissingRoute(openInfo.status) || options.requireFederation) {
+      checks.push(openInfo.status >= 200 && openInfo.status < 300 ? pass('auth open /info', 'open without token') : fail('auth open /info', `got ${openInfo.status}`));
+    }
+    if (!isMissingRoute(openIdentity.status) || options.requireFederation) {
+      checks.push(openIdentity.status >= 200 && openIdentity.status < 300 ? pass('auth open /api/identity', 'open without token') : fail('auth open /api/identity', `got ${openIdentity.status}`));
+    }
+  }
+
+  return checks;
+}
+
+function printChecks(checks: SmokeCheck[]): void {
+  for (const check of checks) {
+    const icon = check.status === 'pass' ? '✓' : check.status === 'pending' ? '…' : '✗';
+    console.log(`${icon} ${check.status.toUpperCase()} ${check.name}${check.detail ? ` — ${check.detail}` : ''}`);
+  }
+  const summary = checks.reduce<Record<SmokeStatus, number>>((acc, check) => {
+    acc[check.status] += 1;
+    return acc;
+  }, { pass: 0, fail: 0, pending: 0 });
+  console.log(`\nFederation smoke: ${summary.pass} pass, ${summary.pending} pending, ${summary.fail} fail`);
+}
+
+function getArg(name: string): string | undefined {
+  const prefix = `${name}=`;
+  const value = Bun.argv.find((arg) => arg.startsWith(prefix));
+  if (value) return value.slice(prefix.length);
+  const index = Bun.argv.indexOf(name);
+  return index >= 0 ? Bun.argv[index + 1] : undefined;
+}
+
+if (import.meta.main) {
+  const baseUrl = getArg('--base-url') || process.env.ORACLE_HTTP_URL || `http://localhost:${process.env.PORT || '3000'}`;
+  const requireFederation = Bun.argv.includes('--require-federation') || Bun.argv.includes('--require');
+  const token = getArg('--token') || process.env.ARRA_PEER_TOKEN;
+  const checks = await runFederationSmoke({ baseUrl, token, requireFederation });
+  printChecks(checks);
+  const failures = checks.filter((check) => check.status === 'fail');
+  const pendingChecks = checks.filter((check) => check.status === 'pending');
+  if (failures.length > 0 || (requireFederation && pendingChecks.length > 0)) {
+    process.exit(1);
+  }
+}

--- a/src/gateway/config.ts
+++ b/src/gateway/config.ts
@@ -81,31 +81,42 @@ export function watchGatewayConfig(
   const configPath = path.join(dataDir, CONFIG_FILE);
   const watchers: fs.FSWatcher[] = [];
   let timer: ReturnType<typeof setTimeout> | null = null;
+  let poller: ReturnType<typeof setInterval> | null = null;
   let last = JSON.stringify(loadGatewayConfig(dataDir, vectorUrl));
+
+  const reloadIfChanged = (): void => {
+    // Malformed JSON survival: if the file exists but failed to parse,
+    // loadGatewayConfig returns null AND prints a warning. We only swap
+    // the live state when the new result is either a valid config or a
+    // genuine deletion (file no longer exists). Mid-edit syntax errors
+    // are silently ignored so the running gateway keeps its last good
+    // state until the user saves a valid file.
+    const fileMissing = !fs.existsSync(configPath);
+    const next = loadGatewayConfig(dataDir, vectorUrl);
+    if (next === null && !fileMissing && !vectorUrl) {
+      // file exists but failed to parse — hold last good
+      return;
+    }
+    const serialized = JSON.stringify(next);
+    if (serialized === last) return;
+    last = serialized;
+    console.log('[Gateway] Config changed — reloading');
+    onChange(next);
+  };
 
   const tick = (): void => {
     if (timer) clearTimeout(timer);
     timer = setTimeout(() => {
       timer = null;
-      // Malformed JSON survival: if the file exists but failed to parse,
-      // loadGatewayConfig returns null AND prints a warning. We only swap
-      // the live state when the new result is either a valid config or a
-      // genuine deletion (file no longer exists). Mid-edit syntax errors
-      // are silently ignored so the running gateway keeps its last good
-      // state until the user saves a valid file.
-      const fileMissing = !fs.existsSync(configPath);
-      const next = loadGatewayConfig(dataDir, vectorUrl);
-      if (next === null && !fileMissing && !vectorUrl) {
-        // file exists but failed to parse — hold last good
-        return;
-      }
-      const serialized = JSON.stringify(next);
-      if (serialized === last) return;
-      last = serialized;
-      console.log('[Gateway] Config changed — reloading');
-      onChange(next);
+      reloadIfChanged();
     }, 200);
   };
+
+  // fs.watch can drop create/delete events under raw `bun test` load. Polling
+  // the resolved config keeps no-op writes silent while making creation tests
+  // deterministic.
+  poller = setInterval(reloadIfChanged, 100);
+  poller.unref?.();
 
   try {
     if (fs.existsSync(dataDir)) {
@@ -128,6 +139,10 @@ export function watchGatewayConfig(
     if (timer) {
       clearTimeout(timer);
       timer = null;
+    }
+    if (poller) {
+      clearInterval(poller);
+      poller = null;
     }
     for (const w of watchers) {
       try {

--- a/tests/e2e/federation-smoke.test.ts
+++ b/tests/e2e/federation-smoke.test.ts
@@ -1,0 +1,64 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { runFederationSmoke } from '../../scripts/federation-smoke.ts';
+
+let server: ReturnType<typeof Bun.serve>;
+let baseUrl: string;
+const TOKEN = 'test-peer-token';
+const PUBKEY = 'a'.repeat(64);
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function authed(req: Request): boolean {
+  return req.headers.get('authorization') === `Bearer ${TOKEN}`;
+}
+
+beforeAll(() => {
+  server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === '/info') {
+        return json({ maw: { schema: 'arra-federation/v1' }, node: { id: 'mock-peer' }, locators: [baseUrl], capabilities: ['arra-search', 'feed'] });
+      }
+      if (url.pathname === '/api/identity') {
+        return json({ pubkey: PUBKEY, tofu: { pinned: true } });
+      }
+      if (url.pathname === '/api/peers') {
+        return json({ peers: [{ id: 'mock-peer', url: baseUrl, pinned: true }] });
+      }
+      if (url.pathname === '/api/feed') {
+        return json({ events: [{ source: 'local-oraclenet-feed' }], total: 1 });
+      }
+      if (url.pathname === '/api/peer/feed') {
+        if (!authed(req)) return json({ error: 'Unauthorized' }, 401);
+        return json({ items: [{ source: 'peer-feed' }], total: 1 });
+      }
+      if (url.pathname === '/api/peer/search') {
+        if (!authed(req)) return json({ error: 'Unauthorized' }, 401);
+        return json({ results: [{ id: 'doc-1', score: 0.99 }], total: 1 });
+      }
+      return json({ error: 'Not found' }, 404);
+    },
+  });
+  baseUrl = `http://127.0.0.1:${server.port}`;
+});
+
+afterAll(() => {
+  server.stop(true);
+});
+
+describe('federation smoke harness (#44)', () => {
+  test('walks info → identity → peers → peer feed/search and guards /api/feed namespace', async () => {
+    const checks = await runFederationSmoke({ baseUrl, token: TOKEN, requireFederation: true });
+    expect(checks.filter((check) => check.status === 'fail')).toEqual([]);
+    expect(checks.filter((check) => check.status === 'pending')).toEqual([]);
+    expect(checks.map((check) => check.name)).toContain('feed namespace separation');
+    expect(checks.map((check) => check.name)).toContain('peer auth feed');
+    expect(checks.map((check) => check.name)).toContain('peer auth search');
+  });
+});


### PR DESCRIPTION
## Summary
- adds a reusable federation smoke harness for `/info`, `/api/identity`, `/api/peers`, `/api/peer/feed`, and `/api/peer/search`
- adds a mock-server E2E guard for the #36/#44 peer lifecycle and `/api/feed` namespace separation
- fixes the gateway config watcher creation flake found during the post-#39 raw `bun test` verification

Closes Soul-Brews-Studio/arra-oracle-v3-oracle#44

## Verification
- `bun run build`
- `bun run test`
- clean archive raw `bun test` with latest source `alpha` + this fix: 762 pass, 22 skip, 0 fail
- `bun run test:e2e:federation`
- live source server smoke: `bun scripts/federation-smoke.ts --base-url http://127.0.0.1:37654 --token secret --require-federation` → 13 pass, 0 pending, 0 fail

## Namespace proof
- `/api/feed?limit=1` → 200 local feed shape `{ events, total, active_oracles }`
- `/api/peer/feed?limit=1` without token → 401 `peer_auth_required`
- `/api/peer/feed?limit=1` with Bearer token → 200 peer feed shape `{ node, oracle, ts, items }`
