### PR TITLE
Add alpha docs navigation index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,15 +29,15 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) an
 - `arra plugins list|enable|disable` manages the local MCP plugin manifest from the CLI. ([tracker #31][t31], [source PR #1343][s1343])
 - `arra completions bash|zsh|fish` emits shell completion scripts for the operator CLI. ([tracker #37][t37], [source PR #1348][s1348])
 
-#### Federation — landing via #39
+#### Federation
 
-- Peer identity endpoints (`/info`, `/api/identity`) and persistent identity keys are landing in source via migration #39. ([tracker #6][t6], [tracker #39][t39], [source PR #1353][s1353])
-- Scout HELLO announcement support is landing in source via migration #39. ([tracker #17][t17], [tracker #39][t39], [source PR #1353][s1353])
-- Reverse peer query support for named peers is landing in source via migration #39. ([tracker #20][t20], [tracker #39][t39], [source PR #1353][s1353])
-- TOFU peer-key pinning and verification are landing in source via migration #39. ([tracker #23][t23], [tracker #39][t39], [source PR #1353][s1353])
-- Peer feed routes are landing in source via migration #39; these are separate from the local/oraclenet feed surface. ([tracker #27][t27], [tracker #39][t39], [source PR #1353][s1353])
-- Peer search integration is landing in source via migration #39. ([tracker #29][t29], [tracker #39][t39], [source PR #1353][s1353])
-- Peer endpoint token auth with `ARRA_PEER_TOKEN` is landing in source via migration #39. ([tracker #33][t33], [tracker #39][t39], [source PR #1353][s1353])
+- Peer identity endpoints (`/info`, `/api/identity`) and persistent identity keys landed in source via migration #39. ([tracker #6][t6], [tracker #39][t39], [source PR #1353][s1353])
+- Scout HELLO announcement support landed in source via migration #39. ([tracker #17][t17], [tracker #39][t39], [source PR #1353][s1353])
+- Reverse peer query support for named peers landed in source via migration #39. ([tracker #20][t20], [tracker #39][t39], [source PR #1353][s1353])
+- TOFU peer-key pinning and verification landed in source via migration #39. ([tracker #23][t23], [tracker #39][t39], [source PR #1353][s1353])
+- Peer feed routes landed in source via migration #39; these are separate from the local/oraclenet feed surface. ([tracker #27][t27], [tracker #39][t39], [source PR #1353][s1353])
+- Peer search integration landed in source via migration #39. ([tracker #29][t29], [tracker #39][t39], [source PR #1353][s1353])
+- Peer endpoint token auth with `ARRA_PEER_TOKEN` landed in source via migration #39. ([tracker #33][t33], [tracker #39][t39], [source PR #1353][s1353])
 
 #### Docker / Distribution
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,20 @@ Phukhao Oracle is landing here: https://phukhao.buildwithoracle.com/presentation
 TypeScript MCP server for semantic search over Oracle philosophy — SQLite FTS5 + ChromaDB hybrid search, HTTP API, and vault CLI.
 
 See [docs/LOCAL-DEV.md](docs/LOCAL-DEV.md) for local development.
-See [CONTRIBUTING.md](CONTRIBUTING.md) for repository topology and PR-target rules.
-See [docs/TONIGHT-SHIPPED.md](docs/TONIGHT-SHIPPED.md) for the consolidated reference covering the config, plugin, vector, federation-track, Docker, and GHCR features shipped in the 2026-06-06 alpha wave.
+
+## Docs navigation
+
+The alpha docs wave is reachable from here in one hop:
+
+| Guide | What it covers |
+| --- | --- |
+| [docs/README.md](docs/README.md) | Docs index and feature-knob map. |
+| [docs/INSTALL.md](docs/INSTALL.md) | Fresh install through Bun remote, Docker GHCR, and Docker MCP Toolkit. |
+| [docs/FEDERATION.md](docs/FEDERATION.md) | Pairing, Scout discovery, TOFU pins, peer feed/search, and peer auth. |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Two-repo rule and PR target rules. |
+| [CHANGELOG.md](CHANGELOG.md) | Alpha wave release notes and source PR links. |
+| [docs/TONIGHT-SHIPPED.md](docs/TONIGHT-SHIPPED.md) | Consolidated feature reference and per-feature config knobs. |
+
 
 ## Architecture
 

--- a/docs/FEDERATION.md
+++ b/docs/FEDERATION.md
@@ -254,3 +254,11 @@ bun run build
 
 The integration test covers public discovery, stable identity, token-protected
 feed/search, named peer probing, first-use pins, and mismatch detection.
+
+## See also
+
+- [README.md](./README.md) — docs index and feature-knob map.
+- [INSTALL.md](./INSTALL.md) — Bun, Docker GHCR, and Docker MCP Toolkit install paths.
+- [TONIGHT-SHIPPED.md](./TONIGHT-SHIPPED.md#federation-peer-identity) — compact shipped-surface summary.
+- [../CONTRIBUTING.md](../CONTRIBUTING.md) — two-repo PR target rules.
+- [../CHANGELOG.md](../CHANGELOG.md) — alpha wave release notes.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -4,7 +4,7 @@ Fresh-install guide for the current `arra-oracle-v3` alpha distribution
 channels: Bun remote, Docker GHCR, and Docker MCP Toolkit.
 
 For the full alpha operator surface (MCP modes, CLI targets, plugins, vector
-adapters, Docker/GHCR, and federation-track notes), see
+adapters, Docker/GHCR, and federation notes), see
 [TONIGHT-SHIPPED.md](./TONIGHT-SHIPPED.md).
 
 ## Prerequisites
@@ -180,7 +180,7 @@ Common scanned paths include:
 ## Optional: Vector adapters
 
 Arra Oracle runs with local LanceDB vector storage by default. See
-[TONIGHT-SHIPPED.md](./TONIGHT-SHIPPED.md#vector-store-adapters) for Qdrant,
+[TONIGHT-SHIPPED.md](./TONIGHT-SHIPPED.md#vector-store-adapters-and-per-collection-config) for Qdrant,
 remote vector service, fallback, and read-only mode environment variables.
 
 ## Troubleshooting
@@ -231,6 +231,7 @@ docker mcp profile remove arra_oracle
 
 See also:
 
+- [README.md](./README.md) - Docs index and feature-knob map
 - [README.md](../README.md) - Overview
 - [TONIGHT-SHIPPED.md](./TONIGHT-SHIPPED.md) - Current alpha operator reference
 - [FEDERATION.md](./FEDERATION.md) - Federation pairing, peer search/feed, and security guide

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,32 @@
+# Arra Oracle docs index
+
+Use this page as the one-hop map for the 2026-06-06/07 alpha docs wave.
+
+## Start here
+
+| Guide | Use when you need | Key surfaces |
+| --- | --- | --- |
+| [INSTALL.md](./INSTALL.md) | Fresh install through Bun, Docker GHCR, or Docker MCP Toolkit | `bunx`, `ghcr.io/soul-brews-studio/arra-oracle-v3:{http,stdio}`, `docker mcp` |
+| [FEDERATION.md](./FEDERATION.md) | Pair and secure Arra peers | `/info`, `/api/identity`, `/api/peer/feed`, `/api/peer/search`, TOFU pins |
+| [CONTRIBUTING.md](../CONTRIBUTING.md) | Pick the correct repo/branch for PRs | two-repo rule, source PRs to `arra-oracle-v3:alpha` |
+| [CHANGELOG.md](../CHANGELOG.md) | Review what changed in the alpha wave | release notes, tracker issues, source PRs |
+| [TONIGHT-SHIPPED.md](./TONIGHT-SHIPPED.md) | Find feature knobs and first commands | MCP modes, plugins, CLI targets, vectors, Docker, federation |
+
+## Feature knobs quick map
+
+| Feature | Main doc | Common knobs / paths |
+| --- | --- | --- |
+| MCP embedded vs HTTP-proxy | [TONIGHT-SHIPPED.md](./TONIGHT-SHIPPED.md#mcp-modes-embedded-vs-http-proxy) | `ORACLE_HTTP_URL`, `ORACLE_API`, `NEO_ARRA_API` |
+| MCP tool/plugin toggles | [TONIGHT-SHIPPED.md](./TONIGHT-SHIPPED.md#mcp-tool-plugin-toggles) | `arra.config.json`, `plugins.json`, `$ORACLE_DATA_DIR/config.json` |
+| Operator CLI targets | [TONIGHT-SHIPPED.md](./TONIGHT-SHIPPED.md#operator-cli-arra-targets-config-doctor-plugins) | `ORACLE_API`, `--at`, `.arra/config.json`, XDG config |
+| Vector adapters | [TONIGHT-SHIPPED.md](./TONIGHT-SHIPPED.md#vector-store-adapters-and-per-collection-config) | `ORACLE_VECTOR_DB`, `QDRANT_URL`, `VECTOR_URL`, `VECTOR_FALLBACK` |
+| Docker/GHCR | [INSTALL.md](./INSTALL.md#channel-2-docker-ghcr-images) | `:http`, `:stdio`, `docker compose`, Docker volumes |
+| Docker MCP Toolkit | [INSTALL.md](./INSTALL.md#channel-3-docker-mcp-toolkit-install) | `catalog/arra-oracle.yaml`, `docker mcp profile create` |
+| Federation | [FEDERATION.md](./FEDERATION.md) | `ARRA_PEER_TOKEN`, `ARRA_NAMED_PEERS`, `ARRA_SCOUT_ANNOUNCE`, `peers-tofu.json` |
+
+## Source references
+
+- [README.md](../README.md) — project overview and top-level install snippets.
+- [API.md](./API.md) — HTTP API notes.
+- [architecture.md](./architecture.md) — system architecture.
+- [LOCAL-DEV.md](./LOCAL-DEV.md) — local development setup.

--- a/docs/TONIGHT-SHIPPED.md
+++ b/docs/TONIGHT-SHIPPED.md
@@ -2,6 +2,8 @@
 
 This is the compact operator map for the large 2026-06-06/07 alpha wave. It is meant to answer: *what shipped, where is the code, what knob controls it, and what is the first command to try?*
 
+See [README.md](./README.md) for the docs index that links every guide in this wave.
+
 ## Quick index
 
 | Surface | Status | Primary knobs | First command |
@@ -11,7 +13,7 @@ This is the compact operator map for the large 2026-06-06/07 alpha wave. It is m
 | Operator CLI targets | `alpha` | `ORACLE_API`, `--at`, `.arra/config.json`, XDG config | `arra config` |
 | Vector adapter selection | `alpha` | `ORACLE_VECTOR_DB`, `ORACLE_VECTOR_DB_PATH`, `QDRANT_URL`, `VECTOR_URL` | `ORACLE_VECTOR_DB=qdrant QDRANT_URL=http://localhost:6333 bun run server` |
 | Docker/GHCR | `alpha` | Docker targets `http-server`, `mcp-stdio` | `docker run --rm -p 47778:47778 ghcr.io/soul-brews-studio/arra-oracle-v3:http` |
-| Docker MCP Toolkit catalog | `alpha` | `catalog/arra-oracle.yaml` | copy catalog into Docker MCP Toolkit catalog dir |
+| Docker MCP Toolkit catalog | `alpha` | `catalog/arra-oracle.yaml` | `docker mcp profile create --server file://$(pwd)/catalog/arra-oracle.yaml` |
 | Federation / peer identity | shipped on `alpha` | `ARRA_SCOUT_ANNOUNCE`, `ARRA_PEER_TOKEN`, `ARRA_NAMED_PEERS` | see [FEDERATION.md](./FEDERATION.md) |
 
 ## MCP modes: embedded vs HTTP-proxy


### PR DESCRIPTION
## Summary
- adds `docs/README.md` as the docs hub and feature-knob map
- adds a README docs navigation table with one-hop links to INSTALL, FEDERATION, CONTRIBUTING, CHANGELOG, and TONIGHT-SHIPPED
- cross-links INSTALL/FEDERATION/TONIGHT-SHIPPED back into the docs set
- fixes stale wording surfaced while wiring links (`federation-track`, Docker MCP copy-catalog wording, and changelog "landing" language after #39 shipped)

## Validation
- custom local markdown file+anchor link check across README, docs/README, INSTALL, FEDERATION, TONIGHT-SHIPPED, CONTRIBUTING, CHANGELOG
- `bun run build`
- `git diff --check`

Not-tested: external URL availability.

Closes Soul-Brews-Studio/arra-oracle-v3-oracle#48
