### PR TITLE
Document Huginn and Muninn taxonomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,20 @@ The alpha docs wave is reachable from here in one hop:
 | [docs/README.md](docs/README.md) | Docs index and feature-knob map. |
 | [docs/INSTALL.md](docs/INSTALL.md) | Fresh install through Bun remote, Docker GHCR, and Docker MCP Toolkit. |
 | [docs/FEDERATION.md](docs/FEDERATION.md) | Pairing, Scout discovery, TOFU pins, peer feed/search, and peer auth. |
+| [docs/HUGINN-MUNINN.md](docs/HUGINN-MUNINN.md) | Capture/recall naming taxonomy: Arra=Muninn recall, Huginn=capture now. |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Two-repo rule and PR target rules. |
 | [CHANGELOG.md](CHANGELOG.md) | Alpha wave release notes and source PR links. |
 | [docs/TONIGHT-SHIPPED.md](docs/TONIGHT-SHIPPED.md) | Consolidated feature reference and per-feature config knobs. |
 
+
+## Huginn & Muninn
+
+Arra is **Muninn**, the recall raven: `oracle_search`, `oracle_read`,
+`oracle_list`, `oracle_stats`, and `oracle_trace*` help recover what is already
+in memory. **Huginn** is capture-now: `oracle_learn`, `oracle_handoff`,
+write-time indexing, and future auto-capture work save the present so Muninn can
+recall it later. This taxonomy is for legibility, not a rename; do not add
+`huginn_*` aliases. See [docs/HUGINN-MUNINN.md](docs/HUGINN-MUNINN.md).
 
 ## Architecture
 

--- a/docs/HUGINN-MUNINN.md
+++ b/docs/HUGINN-MUNINN.md
@@ -1,0 +1,76 @@
+# Huginn & Muninn taxonomy
+
+Arra's memory surface has two legible halves:
+
+- **Muninn = recall.** Arra is Muninn: remembering, searching, reading,
+  tracing, and summarizing what is already in memory.
+- **Huginn = capture now.** Huginn is the write-side practice: catching the
+  current thought/session/handoff so Muninn has something truthful to recall
+  later.
+
+This is a conceptual taxonomy for operators and roadmap readers. It is **not a
+rename** of the MCP API.
+
+## Naming rule
+
+Keep the current tool names:
+
+- Canonical MCP tools stay `oracle_*`.
+- Existing compatibility aliases such as `muninn_*` may continue to normalize to
+  `oracle_*` where already supported.
+- Do **not** add `huginn_*` aliases. Capture is a different verb and lifecycle,
+  not the same recall tools renamed.
+
+## Muninn: recall tools
+
+Muninn answers: "What do we already know, where did it come from, and how do I
+navigate it?"
+
+| Tool family | Role |
+| --- | --- |
+| `oracle_search` | Find matching memory by keyword/vector search. |
+| `oracle_read` | Read the full source for a search result or document id. |
+| `oracle_list` | Browse indexed documents. |
+| `oracle_stats` | Inspect database/vector health and counts. |
+| `oracle_trace*` | Recall and navigate discovery traces (`oracle_trace_list`, `oracle_trace_get`, `oracle_trace_chain`, etc.). |
+
+Because Arra is the recall layer, the older `muninn_*` compatibility spelling is
+understandable as a recall alias. The canonical spelling remains `oracle_*`.
+
+## Huginn: capture-now surfaces
+
+Huginn answers: "What should be saved from this moment before it disappears?"
+
+| Surface | Role | Status |
+| --- | --- | --- |
+| `oracle_learn` | Capture a pattern/learning and index it for immediate recall. | shipped |
+| `oracle_handoff` | Capture session context into the inbox for a future session. | shipped |
+| Write-time indexing | Make newly captured memory searchable without a separate manual pass when the write path supports it. | shipped for `oracle_learn`; expanding by roadmap |
+| Auto-save hook | Passive Stop/PreCompact capture from session JSONL into memory. | planned in [tracker #49](https://github.com/Soul-Brews-Studio/arra-oracle-v3-oracle/issues/49) |
+| `/huginn` skill | Human-facing capture ritual/command for saving the current thought. | roadmap |
+
+Huginn should create or queue new memory. It should not be implemented as a
+second name for recall calls like `oracle_search`.
+
+## Relationship to `/munin`
+
+`/munin` is the planned thin WHERE-finder skill for federated location and
+lookup work. Track it in [tracker #50](https://github.com/Soul-Brews-Studio/arra-oracle-v3-oracle/issues/50).
+When it lands, link it here as a Muninn-facing recall/navigation surface rather
+than as a new canonical MCP prefix.
+
+## Quick operator read
+
+- If you are **finding** something: you are using Muninn/Arra recall.
+- If you are **saving** something: you are using Huginn capture.
+- If you are tempted to add `huginn_search` or `huginn_read`: stop. Those are
+  recall actions and should stay `oracle_*`/existing `muninn_*` compatibility.
+- If you are adding passive or active write capture, connect it to Huginn and
+  make sure Muninn can recall it afterward.
+
+## See also
+
+- [mcp-tools.md](./mcp-tools.md) — canonical MCP tool reference.
+- [TONIGHT-SHIPPED.md](./TONIGHT-SHIPPED.md#mcp-tool-plugin-toggles) — tool group/config reference.
+- [README.md](../README.md) — top-level docs navigation.
+- [CHANGELOG.md](../CHANGELOG.md) — release notes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Use this page as the one-hop map for the 2026-06-06/07 alpha docs wave.
 | --- | --- | --- |
 | [INSTALL.md](./INSTALL.md) | Fresh install through Bun, Docker GHCR, or Docker MCP Toolkit | `bunx`, `ghcr.io/soul-brews-studio/arra-oracle-v3:{http,stdio}`, `docker mcp` |
 | [FEDERATION.md](./FEDERATION.md) | Pair and secure Arra peers | `/info`, `/api/identity`, `/api/peer/feed`, `/api/peer/search`, TOFU pins |
+| [HUGINN-MUNINN.md](./HUGINN-MUNINN.md) | Understand the capture/recall naming split | Muninn recall, Huginn capture, no `huginn_*` aliases |
 | [CONTRIBUTING.md](../CONTRIBUTING.md) | Pick the correct repo/branch for PRs | two-repo rule, source PRs to `arra-oracle-v3:alpha` |
 | [CHANGELOG.md](../CHANGELOG.md) | Review what changed in the alpha wave | release notes, tracker issues, source PRs |
 | [TONIGHT-SHIPPED.md](./TONIGHT-SHIPPED.md) | Find feature knobs and first commands | MCP modes, plugins, CLI targets, vectors, Docker, federation |
@@ -23,6 +24,7 @@ Use this page as the one-hop map for the 2026-06-06/07 alpha docs wave.
 | Docker/GHCR | [INSTALL.md](./INSTALL.md#channel-2-docker-ghcr-images) | `:http`, `:stdio`, `docker compose`, Docker volumes |
 | Docker MCP Toolkit | [INSTALL.md](./INSTALL.md#channel-3-docker-mcp-toolkit-install) | `catalog/arra-oracle.yaml`, `docker mcp profile create` |
 | Federation | [FEDERATION.md](./FEDERATION.md) | `ARRA_PEER_TOKEN`, `ARRA_NAMED_PEERS`, `ARRA_SCOUT_ANNOUNCE`, `peers-tofu.json` |
+| Capture/recall taxonomy | [HUGINN-MUNINN.md](./HUGINN-MUNINN.md) | `oracle_search`, `oracle_trace*`, `oracle_learn`, `oracle_handoff`, no `huginn_*` aliases |
 
 ## Source references
 


### PR DESCRIPTION
## Summary
- adds `docs/HUGINN-MUNINN.md` to make the capture/recall taxonomy legible
- documents Arra as Muninn/recall: `oracle_search`, `oracle_read`, `oracle_list`, `oracle_stats`, `oracle_trace*`
- documents Huginn as capture-now: `oracle_learn`, `oracle_handoff`, write-time indexing, planned auto-save hook (#49), and roadmap `/huginn`
- explicitly states this is not a rename and does not add `huginn_*` aliases
- links the taxonomy from README and the docs hub

## Validation
- `rg` check confirmed no `huginn_` aliases in `src`, `cli`, or `package.json`
- custom local markdown file+anchor link check
- `bun run build`
- `git diff --check`

Not-tested: future #49 auto-capture and #50 `/munin` surfaces because both trackers are still open.

Closes Soul-Brews-Studio/arra-oracle-v3-oracle#51
