### PR TITLE
Add opt-in Huginn session auto-capture hook

### DIFF
--- a/docs/huginn-capture.md
+++ b/docs/huginn-capture.md
@@ -1,0 +1,54 @@
+# Huginn auto-capture hook
+
+Huginn is the passive capture half of the Huginn/Muninn split: Muninn recalls with `oracle_search`; Huginn captures the current session before context is lost.
+
+Phase 1 is deliberately opt-in and default-off. When enabled, the hook mines a session JSONL transcript for salient decisions, learnings, file changes, issue/PR events, and verification notes, then writes one deduped `oracle_learn` entry. The normal learn path writes the vault markdown and indexes FTS immediately, so the capture is visible to `oracle_search` without waiting for a later aggregation pass.
+
+## Enable
+
+Set one of these environment variables in the hook environment:
+
+```sh
+export ARRA_HUGINN_CAPTURE=1
+# legacy alias also accepted:
+export ORACLE_HUGINN_CAPTURE=1
+```
+
+If neither variable is truthy, the hook exits successfully with `skipped: disabled` and writes nothing.
+
+## Hook command
+
+Use the same script for Stop and PreCompact hooks:
+
+```sh
+bun /path/to/arra-oracle-v3/scripts/huginn-capture-hook.ts
+```
+
+The script accepts hook JSON on stdin with any of these transcript fields:
+
+- `transcript_path`
+- `transcriptPath`
+- `session_path`
+- `sessionPath`
+
+Optional fields: `session_id` / `sessionId`, `cwd`.
+
+For manual testing:
+
+```sh
+ARRA_HUGINN_CAPTURE=1 bun scripts/huginn-capture-hook.ts /path/to/session.jsonl optional-session-id
+```
+
+## Dedup
+
+Dedup state is stored at:
+
+```text
+$ORACLE_DATA_DIR/huginn-captures.json
+```
+
+The key is `session id + content hash`, so rerunning the hook on the same transcript does not create duplicate learnings. If the same session transcript gains new salient content, the content hash changes and a new capture may be written.
+
+## Output
+
+The script prints JSON and exits zero for disabled, empty, duplicate, or successful captures. It exits non-zero only on unexpected errors.

--- a/package.json
+++ b/package.json
@@ -58,7 +58,9 @@
     "vault:migrate": "bun src/vault/cli.ts migrate",
     "vault:rsync": "./scripts/vault-rsync.sh",
     "test:e2e:federation": "bun test tests/e2e/federation-smoke.test.ts",
-    "smoke:federation": "bun scripts/federation-smoke.ts"
+    "smoke:federation": "bun scripts/federation-smoke.ts",
+    "huginn:capture": "bun scripts/huginn-capture-hook.ts",
+    "test:huginn": "bun test src/huginn/__tests__/capture.test.ts"
   },
   "dependencies": {
     "@elysiajs/cors": "^1.4.1",

--- a/scripts/huginn-capture-hook.ts
+++ b/scripts/huginn-capture-hook.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env bun
+/**
+ * Opt-in Stop/PreCompact hook: mine the just-ended session JSONL into one
+ * deduped oracle_learn entry. Default-off; enable with ARRA_HUGINN_CAPTURE=1.
+ *
+ * Hook JSON stdin may include: transcript_path, session_id, cwd.
+ * CLI fallback: bun scripts/huginn-capture-hook.ts /path/to/session.jsonl [session-id]
+ */
+import { captureSession, huginnEnabled, readHookInput } from '../src/huginn/capture.ts';
+
+const stdin = await new Response(Bun.stdin.stream()).text();
+const input = readHookInput(stdin);
+const transcriptPath = input.transcriptPath || Bun.argv[2];
+const sessionId = input.sessionId || Bun.argv[3];
+
+if (!huginnEnabled()) {
+  console.log(JSON.stringify({ ok: true, skipped: 'disabled', message: 'Set ARRA_HUGINN_CAPTURE=1 to enable Huginn auto-capture.' }));
+  process.exit(0);
+}
+
+if (!transcriptPath) {
+  console.log(JSON.stringify({ ok: true, skipped: 'missing-transcript', message: 'No transcript path supplied.' }));
+  process.exit(0);
+}
+
+try {
+  const result = await captureSession({ transcriptPath, sessionId, cwd: input.cwd });
+  console.log(JSON.stringify(result, null, 2));
+} catch (error: any) {
+  console.error(JSON.stringify({ ok: false, error: error?.message ?? String(error) }, null, 2));
+  process.exit(1);
+}

--- a/src/huginn/__tests__/capture.test.ts
+++ b/src/huginn/__tests__/capture.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { captureSession, huginnEnabled, mineSessionJsonl, readHookInput } from '../capture.ts';
+
+const tmpDirs: string[] = [];
+function tmpdir(prefix = 'huginn-capture-') {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+function writeJsonl(file: string, rows: unknown[]) {
+  fs.writeFileSync(file, rows.map((row) => JSON.stringify(row)).join('\n') + '\n');
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('Huginn session capture', () => {
+  it('is opt-in and default-off', () => {
+    expect(huginnEnabled({} as any)).toBe(false);
+    expect(huginnEnabled({ ARRA_HUGINN_CAPTURE: '1' } as any)).toBe(true);
+    expect(huginnEnabled({ ORACLE_HUGINN_CAPTURE: 'true' } as any)).toBe(true);
+  });
+
+  it('reads transcript path from hook stdin aliases', () => {
+    const parsed = readHookInput(JSON.stringify({ transcript_path: '/tmp/session.jsonl', session_id: 's1', cwd: '/repo' }), {} as any);
+    expect(parsed).toEqual({ transcriptPath: '/tmp/session.jsonl', sessionId: 's1', cwd: '/repo' });
+  });
+
+  it('mines salient decisions, learnings, issues, commands, and file changes from JSONL', () => {
+    const dir = tmpdir();
+    const transcript = path.join(dir, 'session.jsonl');
+    writeJsonl(transcript, [
+      { message: { role: 'user', content: 'hello there' } },
+      { message: { role: 'assistant', content: 'Decision: keep /api/feed local and add peer feed at /api/peer/feed.' } },
+      { message: { role: 'assistant', content: [{ type: 'text', text: 'Fixed regression in src/gateway/config.ts; bun test is green.' }] } },
+      { message: { role: 'assistant', content: 'PR #1356 merged and issue #44 closed.' } },
+    ]);
+
+    const mined = mineSessionJsonl(transcript);
+    expect(mined.moments.length).toBe(3);
+    expect(mined.moments.map((m) => m.kind)).toContain('decision');
+    expect(mined.moments.map((m) => m.kind)).toContain('command');
+    expect(mined.sourceText).toContain('/api/peer/feed');
+    expect(mined.hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('learns once per session+content hash and skips duplicate reruns', async () => {
+    const dir = tmpdir();
+    const transcript = path.join(dir, 'session-abc.jsonl');
+    const statePath = path.join(dir, 'state.json');
+    writeJsonl(transcript, [
+      { message: { role: 'assistant', content: 'Learned: raw bun test shares module state, so reset test DB handles after env changes.' } },
+      { message: { role: 'assistant', content: 'Changed src/db/index.ts and verified bun test 755 pass 0 fail.' } },
+    ]);
+
+    const learned: any[] = [];
+    const learn = (pattern: string, source?: string, concepts?: string[]) => {
+      learned.push({ pattern, source, concepts });
+      return { id: 'learning_huginn', file: 'ψ/memory/learnings/huginn.md' };
+    };
+
+    const first = await captureSession({ transcriptPath: transcript, sessionId: 'abc', statePath, learn });
+    expect(first.learned).toBe(true);
+    expect(first.learningId).toBe('learning_huginn');
+    expect(learned).toHaveLength(1);
+    expect(learned[0].pattern).toContain('Huginn auto-capture session abc');
+    expect(learned[0].concepts).toContain('huginn');
+
+    const second = await captureSession({ transcriptPath: transcript, sessionId: 'abc', statePath, learn });
+    expect(second.skipped).toBe('duplicate');
+    expect(learned).toHaveLength(1);
+  });
+
+  it('does not learn empty/non-salient transcripts', async () => {
+    const dir = tmpdir();
+    const transcript = path.join(dir, 'quiet.jsonl');
+    writeJsonl(transcript, [{ message: { role: 'assistant', content: 'ok' } }]);
+    const result = await captureSession({ transcriptPath: transcript, learn: () => { throw new Error('should not learn'); } });
+    expect(result.skipped).toBe('empty');
+  });
+});

--- a/src/huginn/capture.ts
+++ b/src/huginn/capture.ts
@@ -1,0 +1,200 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { ORACLE_DATA_DIR } from '../config.ts';
+
+export interface HuginnCaptureOptions {
+  transcriptPath: string;
+  sessionId?: string;
+  cwd?: string;
+  maxItems?: number;
+  statePath?: string;
+  learn?: (pattern: string, source?: string, concepts?: string[], origin?: string, project?: string, cwd?: string) => unknown;
+}
+
+export interface HuginnMoment {
+  kind: 'decision' | 'learning' | 'file-change' | 'issue' | 'command' | 'summary';
+  text: string;
+}
+
+export interface HuginnCaptureResult {
+  ok: boolean;
+  skipped?: 'disabled' | 'missing-transcript' | 'empty' | 'duplicate';
+  sessionId?: string;
+  hash?: string;
+  learned?: boolean;
+  learningId?: string;
+  sourceFile?: string;
+  moments: HuginnMoment[];
+}
+
+interface CaptureState {
+  captures: Record<string, { sessionId: string; hash: string; capturedAt: string; learningId?: string }>;
+}
+
+const SALIENT = /\b(decision|decided|learned|learning|root cause|fix(?:ed)?|bug|regression|issue\s*#?\d+|pr\s*#?\d+|merged|verified|test(?:s)?\s+(?:pass|green|fail)|implemented|changed|added|removed|deleted|refactor|migration|blocker|risk|todo|follow[- ]?up)\b/i;
+const FILE_HINT = /(?:^|\s)([\w./-]+\.(?:ts|tsx|js|jsx|json|md|yml|yaml|toml|sh|sql|css|html|py|rs|go))\b/g;
+
+export function huginnEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return ['1', 'true', 'yes', 'on'].includes(String(env.ARRA_HUGINN_CAPTURE ?? env.ORACLE_HUGINN_CAPTURE ?? '').toLowerCase());
+}
+
+export function defaultStatePath(): string {
+  return path.join(process.env.ORACLE_DATA_DIR || ORACLE_DATA_DIR, 'huginn-captures.json');
+}
+
+export function readHookInput(raw: string, env: NodeJS.ProcessEnv = process.env): { transcriptPath?: string; sessionId?: string; cwd?: string } {
+  const trimmed = raw.trim();
+  let parsed: any = null;
+  if (trimmed) {
+    try { parsed = JSON.parse(trimmed); } catch {}
+  }
+  return {
+    transcriptPath: parsed?.transcript_path || parsed?.transcriptPath || parsed?.session_path || parsed?.sessionPath || env.CODEX_SESSION_FILE || env.CLAUDE_TRANSCRIPT_PATH || env.TRANSCRIPT_PATH,
+    sessionId: parsed?.session_id || parsed?.sessionId || env.CODEX_SESSION_ID || env.CLAUDE_SESSION_ID,
+    cwd: parsed?.cwd || parsed?.workspace || env.ORACLE_REPO_ROOT || process.cwd(),
+  };
+}
+
+function sha256(text: string): string {
+  return crypto.createHash('sha256').update(text).digest('hex');
+}
+
+function readState(statePath: string): CaptureState {
+  try {
+    const raw = fs.readFileSync(statePath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    return { captures: parsed && typeof parsed.captures === 'object' ? parsed.captures : {} };
+  } catch {
+    return { captures: {} };
+  }
+}
+
+function writeState(statePath: string, state: CaptureState): void {
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  const tmp = `${statePath}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(state, null, 2));
+  fs.renameSync(tmp, statePath);
+}
+
+function stableSessionId(transcriptPath: string, explicit?: string): string {
+  if (explicit) return explicit.replace(/[^a-zA-Z0-9._-]/g, '-').slice(0, 120);
+  const base = path.basename(transcriptPath).replace(/\.jsonl$/i, '');
+  return (base || sha256(transcriptPath).slice(0, 16)).replace(/[^a-zA-Z0-9._-]/g, '-').slice(0, 120);
+}
+
+function textFromContent(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content.map((part: any) => {
+      if (typeof part === 'string') return part;
+      if (typeof part?.text === 'string') return part.text;
+      if (typeof part?.content === 'string') return part.content;
+      if (part?.type === 'tool_use') return `[tool:${part.name ?? 'unknown'} ${JSON.stringify(part.input ?? {})}]`;
+      if (part?.type === 'tool_result') return typeof part.content === 'string' ? part.content : JSON.stringify(part.content ?? '');
+      return '';
+    }).filter(Boolean).join('\n');
+  }
+  return '';
+}
+
+function lineToText(obj: any): string {
+  const message = obj?.message ?? obj;
+  const role = message?.role || obj?.role || obj?.type || 'event';
+  const text = textFromContent(message?.content ?? obj?.content ?? obj?.text ?? obj?.message);
+  return text ? `${role}: ${text}` : '';
+}
+
+function classify(text: string): HuginnMoment['kind'] {
+  if (/\b(decision|decided|rejected|chosen)\b/i.test(text)) return 'decision';
+  if (/\b(learned|learning|root cause|insight)\b/i.test(text)) return 'learning';
+  if (/\b(issue\s*#?\d+|pr\s*#?\d+|merged|closed)\b/i.test(text)) return 'issue';
+  if (/\b(bun test|bun run|npm|git |gh |docker|curl)\b/i.test(text)) return 'command';
+  FILE_HINT.lastIndex = 0;
+  if (FILE_HINT.test(text)) {
+    FILE_HINT.lastIndex = 0;
+    return 'file-change';
+  }
+  return 'summary';
+}
+
+function compact(text: string, max = 360): string {
+  return text.replace(/\s+/g, ' ').trim().slice(0, max).trim();
+}
+
+export function mineSessionJsonl(transcriptPath: string, maxItems = 12): { moments: HuginnMoment[]; hash: string; sourceText: string } {
+  if (!fs.existsSync(transcriptPath)) return { moments: [], hash: '', sourceText: '' };
+  const raw = fs.readFileSync(transcriptPath, 'utf-8');
+  const selected: HuginnMoment[] = [];
+  const seen = new Set<string>();
+
+  for (const line of raw.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    let obj: any;
+    try { obj = JSON.parse(line); } catch { continue; }
+    const text = lineToText(obj);
+    if (!text || !SALIENT.test(text)) continue;
+    const clipped = compact(text);
+    if (clipped.length < 24) continue;
+    const key = sha256(clipped).slice(0, 16);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    selected.push({ kind: classify(clipped), text: clipped });
+    if (selected.length >= maxItems) break;
+  }
+
+  const sourceText = selected.map((m) => `${m.kind}: ${m.text}`).join('\n');
+  return { moments: selected, hash: sha256(sourceText || raw), sourceText };
+}
+
+export function formatLearning(sessionId: string, moments: HuginnMoment[], transcriptPath: string): string {
+  const title = `Huginn auto-capture session ${sessionId}`;
+  const lines = [
+    title,
+    '',
+    `Transcript: ${transcriptPath}`,
+    `Captured: ${new Date().toISOString()}`,
+    '',
+    'Salient moments:',
+    ...moments.map((m) => `- [${m.kind}] ${m.text}`),
+    '',
+    'This passive learning was mined from a session JSONL by the opt-in Huginn Stop/PreCompact hook.',
+  ];
+  return lines.join('\n');
+}
+
+export async function captureSession(options: HuginnCaptureOptions): Promise<HuginnCaptureResult> {
+  const sessionId = stableSessionId(options.transcriptPath, options.sessionId);
+  if (!fs.existsSync(options.transcriptPath)) return { ok: true, skipped: 'missing-transcript', sessionId, moments: [] };
+
+  const mined = mineSessionJsonl(options.transcriptPath, options.maxItems ?? 12);
+  if (mined.moments.length === 0) return { ok: true, skipped: 'empty', sessionId, hash: mined.hash, moments: [] };
+
+  const statePath = options.statePath ?? defaultStatePath();
+  const state = readState(statePath);
+  const dedupKey = `${sessionId}:${mined.hash}`;
+  if (state.captures[dedupKey]) return { ok: true, skipped: 'duplicate', sessionId, hash: mined.hash, moments: mined.moments };
+
+  const learn = options.learn ?? ((await import('../server/handlers.ts')).handleLearn);
+  const pattern = formatLearning(sessionId, mined.moments, options.transcriptPath);
+  const concepts = ['huginn', 'auto-capture', 'session-jsonl', `session-${sessionId}`];
+  const result: any = await learn(pattern, `huginn:auto-capture:${sessionId}`, concepts, 'huginn', undefined, options.cwd);
+
+  state.captures[dedupKey] = {
+    sessionId,
+    hash: mined.hash,
+    capturedAt: new Date().toISOString(),
+    learningId: result?.id,
+  };
+  writeState(statePath, state);
+
+  return {
+    ok: true,
+    sessionId,
+    hash: mined.hash,
+    learned: true,
+    learningId: result?.id,
+    sourceFile: result?.file,
+    moments: mined.moments,
+  };
+}


### PR DESCRIPTION
## Summary
- Add opt-in/default-off Huginn Stop/PreCompact hook for mining session JSONL into `oracle_learn`.
- Dedup captures by sanitized session id + salient-content SHA-256 hash, writing state only after successful learn.
- Document hook setup and add focused Huginn capture tests plus package scripts.

## Verification
- `bun run build`
- `bun run test:huginn`
- `bun run test`
- Manual temp hook run with `ARRA_HUGINN_CAPTURE=1`: first run wrote one learning markdown through `handleLearn`; second run skipped as duplicate.

Closes Soul-Brews-Studio/arra-oracle-v3-oracle#49
