### PR TITLE
Add periodic Huginn sweep backstop

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -26,6 +26,7 @@ import { configCommand, useCommand } from "./commands/config.ts";
 import { doctorCommand } from "./commands/doctor.ts";
 import { completionsCommand } from "./commands/completions.ts";
 import { peersCommand } from "./commands/peers.ts";
+import { huginnCommand } from "./commands/huginn.ts";
 import { BUILTIN_COMMANDS } from "./commands/catalog.ts";
 
 const pkg = await Bun.file(join(import.meta.dir, "../package.json")).json();
@@ -106,6 +107,10 @@ async function main() {
 
   if (cmd === "peers") {
     process.exit(await peersCommand(args.slice(1)));
+  }
+
+  if (cmd === "huginn") {
+    process.exit(await huginnCommand(args.slice(1)));
   }
 
   if (cmd === "use") {

--- a/cli/src/commands/catalog.ts
+++ b/cli/src/commands/catalog.ts
@@ -17,4 +17,5 @@ export const BUILTIN_COMMANDS: CommandSpec[] = [
   { command: "use", help: "set the global default API target" },
   { command: "completions", help: "print shell completion scripts", subcommands: ["bash", "zsh", "fish"], flags: ["--help", "-h"] },
   { command: "peers", help: "probe configured federation peers", flags: ["--token", "--json", "--help", "-h"] },
+  { command: "huginn", help: "run Huginn capture utilities", subcommands: ["sweep"], flags: ["--sessions-dir", "--repo-root", "--lookback-hours", "--max-files", "--json", "--help", "-h"] },
 ];

--- a/cli/src/commands/huginn.ts
+++ b/cli/src/commands/huginn.ts
@@ -1,0 +1,35 @@
+import { sweepHuginn } from '../../../src/huginn/sweep.ts';
+
+function value(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  return idx >= 0 ? args[idx + 1] : undefined;
+}
+
+export async function huginnCommand(args: string[]): Promise<number> {
+  const sub = args[0]?.toLowerCase();
+  const rest = args.slice(1);
+  if (!sub || sub === '--help' || sub === '-h') {
+    console.log('arra huginn <subcommand>\n');
+    console.log('Subcommands:');
+    console.log('  sweep    back-fill missed Huginn session captures and unindexed learnings');
+    console.log('\nSweep flags: --sessions-dir PATH[:PATH...] --repo-root PATH --lookback-hours N --max-files N --json');
+    return 0;
+  }
+  if (sub !== 'sweep') {
+    console.error(`unknown huginn subcommand: ${sub}`);
+    return 1;
+  }
+  const sessionDirs = value(rest, '--sessions-dir')?.split(':').filter(Boolean);
+  const lookback = value(rest, '--lookback-hours');
+  const maxFiles = value(rest, '--max-files');
+  const summary = await sweepHuginn({
+    sessionDirs,
+    repoRoot: value(rest, '--repo-root'),
+    statePath: value(rest, '--state'),
+    lookbackHours: lookback ? Number(lookback) : undefined,
+    maxFiles: maxFiles ? Number(maxFiles) : undefined,
+    log: rest.includes('--json') ? undefined : (message) => console.error(message),
+  });
+  console.log(JSON.stringify(summary, null, 2));
+  return 0;
+}

--- a/docs/huginn-capture.md
+++ b/docs/huginn-capture.md
@@ -49,6 +49,28 @@ $ORACLE_DATA_DIR/huginn-captures.json
 
 The key is `session id + content hash`, so rerunning the hook on the same transcript does not create duplicate learnings. If the same session transcript gains new salient content, the content hash changes and a new capture may be written.
 
+## Periodic sweep backstop
+
+The Stop/PreCompact hook is the fast path. The sweep is the safety net for missed hooks, disabled hook runs, crashed sessions, and learning markdown written by external processes.
+
+Run it manually or from cron/launchd:
+
+```sh
+arra huginn sweep --lookback-hours 24
+# or directly from source:
+bun scripts/huginn-sweep.ts --lookback-hours 24
+```
+
+Useful flags:
+
+- `--sessions-dir PATH[:PATH...]` — override session JSONL roots. Defaults to `$ORACLE_DATA_DIR/sessions`, `~/.codex/sessions`, and `~/.claude/projects`.
+- `--repo-root PATH` — repo/vault root containing `ψ/memory/learnings`.
+- `--lookback-hours N` — first-run scan window; default 24.
+- `--max-files N` — cap session JSONL candidates; default 200 and reported as `capped: true` when hit.
+- `--state PATH` — override shared Huginn state file.
+
+The sweep reuses the same capture/dedup state as the hook (`$ORACLE_DATA_DIR/huginn-captures.json`). It also stores `sweeps.lastSweepAtMs` as the watermark, so later runs only scan files modified after the previous successful sweep. Recent markdown in `ψ/memory/learnings` that is missing from `oracle_documents.source_file` is indexed in place instead of being rewritten as a duplicate learning.
+
 ## Output
 
 The script prints JSON and exits zero for disabled, empty, duplicate, or successful captures. It exits non-zero only on unexpected errors.

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "test:e2e:federation": "bun test tests/e2e/federation-smoke.test.ts",
     "smoke:federation": "bun scripts/federation-smoke.ts",
     "huginn:capture": "bun scripts/huginn-capture-hook.ts",
-    "test:huginn": "bun test src/huginn/__tests__/capture.test.ts"
+    "test:huginn": "bun test src/huginn/__tests__/capture.test.ts src/huginn/__tests__/sweep.test.ts",
+    "huginn:sweep": "bun scripts/huginn-sweep.ts"
   },
   "dependencies": {
     "@elysiajs/cors": "^1.4.1",

--- a/scripts/huginn-sweep.ts
+++ b/scripts/huginn-sweep.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env bun
+import { sweepHuginn } from '../src/huginn/sweep.ts';
+
+function value(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  return idx >= 0 ? args[idx + 1] : undefined;
+}
+
+const args = Bun.argv.slice(2);
+if (args.includes('--help') || args.includes('-h')) {
+  console.log(`Usage: bun scripts/huginn-sweep.ts [--sessions-dir PATH[:PATH...]] [--repo-root PATH] [--lookback-hours N] [--max-files N] [--json]\n\nBack-fill missed Huginn captures from recent session JSONL and unindexed ψ/memory/learnings markdown.`);
+  process.exit(0);
+}
+
+const sessionDirs = value(args, '--sessions-dir')?.split(':').filter(Boolean);
+const lookback = value(args, '--lookback-hours');
+const maxFiles = value(args, '--max-files');
+
+const summary = await sweepHuginn({
+  sessionDirs,
+  repoRoot: value(args, '--repo-root'),
+  statePath: value(args, '--state'),
+  lookbackHours: lookback ? Number(lookback) : undefined,
+  maxFiles: maxFiles ? Number(maxFiles) : undefined,
+  log: args.includes('--json') ? undefined : (message) => console.error(message),
+});
+
+console.log(JSON.stringify(summary, null, 2));

--- a/src/huginn/__tests__/sweep.test.ts
+++ b/src/huginn/__tests__/sweep.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { sweepHuginn } from '../sweep.ts';
+
+const tmpDirs: string[] = [];
+function tmpdir(prefix = 'huginn-sweep-') {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+function writeJsonl(file: string, rows: unknown[], mtimeMs?: number) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, rows.map((row) => JSON.stringify(row)).join('\n') + '\n');
+  if (mtimeMs) fs.utimesSync(file, new Date(mtimeMs), new Date(mtimeMs));
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('Huginn periodic sweep', () => {
+  it('back-fills hook-missed session JSONL once through capture dedup', async () => {
+    const dir = tmpdir();
+    const sessions = path.join(dir, 'sessions');
+    const transcript = path.join(sessions, 'missed.jsonl');
+    const statePath = path.join(dir, 'state.json');
+    writeJsonl(transcript, [
+      { message: { role: 'assistant', content: 'Decision: periodic Huginn sweep backfills sessions where Stop hook was disabled.' } },
+      { message: { role: 'assistant', content: 'Changed src/huginn/sweep.ts and verified bun run test:huginn is green.' } },
+    ], 2_000);
+
+    const learned: any[] = [];
+    const learn = (pattern: string, source?: string) => {
+      learned.push({ pattern, source });
+      return { id: `learn_${learned.length}`, file: 'ψ/memory/learnings/huginn.md' };
+    };
+
+    const first = await sweepHuginn({ sessionDirs: [sessions], statePath, lookbackHours: 1, now: 3_000, learn, indexMarkdown: () => {} });
+    expect(first.scanned).toBe(1);
+    expect(first.learned).toBe(1);
+    expect(first.duplicates).toBe(0);
+    expect(learned).toHaveLength(1);
+
+    const second = await sweepHuginn({ sessionDirs: [sessions], statePath, lookbackHours: 1, now: 4_000, learn, indexMarkdown: () => {} });
+    expect(second.scanned).toBe(0);
+    expect(second.learned).toBe(0);
+    expect(learned).toHaveLength(1);
+
+    const state = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    expect(state.sweeps.lastSweepAtMs).toBe(4_000);
+    expect(Object.keys(state.captures)).toHaveLength(1);
+  });
+
+  it('uses #49 dedup state when the fast-path hook already captured the transcript', async () => {
+    const dir = tmpdir();
+    const sessions = path.join(dir, 'sessions');
+    const transcript = path.join(sessions, 'already.jsonl');
+    const statePath = path.join(dir, 'state.json');
+    writeJsonl(transcript, [
+      { message: { role: 'assistant', content: 'Learned: fast-path capture and periodic sweep share one dedup state.' } },
+    ], 2_000);
+
+    const learned: any[] = [];
+    const learn = () => {
+      learned.push(1);
+      return { id: `learn_${learned.length}` };
+    };
+
+    const first = await sweepHuginn({ sessionDirs: [sessions], statePath, now: 3_000, learn, indexMarkdown: () => {} });
+    expect(first.learned).toBe(1);
+    const second = await sweepHuginn({ sessionDirs: [sessions], statePath, now: 3_500, lookbackHours: 1, learn, indexMarkdown: () => {} });
+    expect(second.duplicates + second.scanned).toBe(0); // watermark skips old file before dedup even runs
+
+    fs.utimesSync(transcript, new Date(4_000), new Date(4_000));
+    const third = await sweepHuginn({ sessionDirs: [sessions], statePath, now: 5_000, learn, indexMarkdown: () => {} });
+    expect(third.scanned).toBe(1);
+    expect(third.duplicates).toBe(1);
+    expect(learned).toHaveLength(1);
+  });
+
+  it('indexes recent vault learning markdown once and advances watermark', async () => {
+    const dir = tmpdir();
+    const repoRoot = path.join(dir, 'repo');
+    const learning = path.join(repoRoot, 'ψ', 'memory', 'learnings', 'external.md');
+    const statePath = path.join(dir, 'state.json');
+    fs.mkdirSync(path.dirname(learning), { recursive: true });
+    fs.writeFileSync(learning, '---\ntitle: External write\ntags: [huginn]\n---\n\nLearned: external processes can write markdown while hooks are off.\n');
+    fs.utimesSync(learning, new Date(2_000), new Date(2_000));
+
+    const indexed: string[] = [];
+    const first = await sweepHuginn({ sessionDirs: [], repoRoot, statePath, now: 3_000, indexMarkdown: (_file, sourceFile) => indexed.push(sourceFile) });
+    expect(first.markdownIndexed).toBe(1);
+    expect(indexed).toEqual(['ψ/memory/learnings/external.md']);
+
+    const second = await sweepHuginn({ sessionDirs: [], repoRoot, statePath, now: 4_000, indexMarkdown: (_file, sourceFile) => indexed.push(sourceFile) });
+    expect(second.markdownIndexed).toBe(0);
+    expect(indexed).toHaveLength(1);
+  });
+});

--- a/src/huginn/sweep.ts
+++ b/src/huginn/sweep.ts
@@ -1,0 +1,215 @@
+import fs from 'fs';
+import path from 'path';
+import { ORACLE_DATA_DIR, REPO_ROOT } from '../config.ts';
+import { captureSession, defaultStatePath, type HuginnCaptureResult } from './capture.ts';
+
+export interface HuginnSweepOptions {
+  sessionDirs?: string[];
+  repoRoot?: string;
+  statePath?: string;
+  lookbackHours?: number;
+  maxFiles?: number;
+  now?: number;
+  cwd?: string;
+  learn?: Parameters<typeof captureSession>[0]['learn'];
+  indexMarkdown?: (filePath: string, sourceFile: string) => unknown;
+  log?: (message: string) => void;
+}
+
+export interface HuginnSweepState {
+  captures: Record<string, { sessionId: string; hash: string; capturedAt: string; learningId?: string }>;
+  sweeps?: { lastSweepAtMs?: number; lastStartedAtMs?: number; lastSummary?: HuginnSweepSummary };
+}
+
+export interface HuginnSweepSummary {
+  ok: boolean;
+  startedAtMs: number;
+  watermarkBeforeMs?: number;
+  watermarkAfterMs: number;
+  scanned: number;
+  learned: number;
+  duplicates: number;
+  empty: number;
+  missing: number;
+  markdownIndexed: number;
+  markdownAlreadyIndexed: number;
+  capped: boolean;
+  files: Array<{ path: string; action: string; sessionId?: string; hash?: string; sourceFile?: string }>;
+}
+
+function readSweepState(statePath: string): HuginnSweepState {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    return {
+      captures: parsed && typeof parsed.captures === 'object' ? parsed.captures : {},
+      sweeps: parsed && typeof parsed.sweeps === 'object' ? parsed.sweeps : {},
+    };
+  } catch {
+    return { captures: {}, sweeps: {} };
+  }
+}
+
+function writeSweepState(statePath: string, state: HuginnSweepState): void {
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  const tmp = `${statePath}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(state, null, 2));
+  fs.renameSync(tmp, statePath);
+}
+
+function defaultSessionDirs(): string[] {
+  const home = process.env.HOME || process.env.USERPROFILE || '';
+  const configured = process.env.ARRA_HUGINN_SWEEP_DIRS || process.env.ORACLE_HUGINN_SWEEP_DIRS;
+  if (configured) return configured.split(path.delimiter).filter(Boolean);
+  return [
+    path.join(ORACLE_DATA_DIR, 'sessions'),
+    path.join(home, '.codex', 'sessions'),
+    path.join(home, '.claude', 'projects'),
+  ].filter(Boolean);
+}
+
+function walkRecentFiles(root: string, sinceMs: number, out: string[], maxFiles: number): boolean {
+  if (out.length >= maxFiles) return true;
+  let entries: fs.Dirent[];
+  try { entries = fs.readdirSync(root, { withFileTypes: true }); } catch { return false; }
+  for (const entry of entries) {
+    if (out.length >= maxFiles) return true;
+    const full = path.join(root, entry.name);
+    let stat: fs.Stats;
+    try { stat = fs.statSync(full); } catch { continue; }
+    if (entry.isDirectory()) {
+      // If the directory itself is old, still recurse: session stores often bucket by old date dirs.
+      if (walkRecentFiles(full, sinceMs, out, maxFiles)) return true;
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith('.jsonl')) continue;
+    if (stat.mtimeMs <= sinceMs) continue;
+    out.push(full);
+  }
+  return out.length >= maxFiles;
+}
+
+function sourceFileForMarkdown(repoRoot: string, filePath: string): string {
+  return path.relative(repoRoot, filePath).split(path.sep).join('/');
+}
+
+function safeSessionIdFromFile(filePath: string): string {
+  return path.basename(filePath).replace(/\.jsonl$/i, '');
+}
+
+async function defaultIndexMarkdown(filePath: string, sourceFile: string): Promise<void> {
+  const [{ createDatabase }, { parseLearningFile }, { storeDocuments }] = await Promise.all([
+    import('../db/index.ts'),
+    import('../indexer/parser.ts'),
+    import('../indexer/storage.ts'),
+  ]);
+  const { sqlite, db } = createDatabase();
+  try {
+    const exists = sqlite.prepare('SELECT id FROM oracle_documents WHERE source_file = ? LIMIT 1').get(sourceFile);
+    if (exists) return;
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const docs = parseLearningFile(path.basename(filePath), content, sourceFile);
+    const originalLog = console.log;
+    try {
+      console.log = () => {};
+      await storeDocuments(sqlite, db, null, null, docs);
+    } finally {
+      console.log = originalLog;
+    }
+  } finally {
+    sqlite.close();
+  }
+}
+
+async function markdownIndexed(sourceFile: string): Promise<boolean> {
+  const { createDatabase } = await import('../db/index.ts');
+  const { sqlite } = createDatabase();
+  try {
+    return Boolean(sqlite.prepare('SELECT id FROM oracle_documents WHERE source_file = ? LIMIT 1').get(sourceFile));
+  } finally {
+    sqlite.close();
+  }
+}
+
+export async function sweepHuginn(options: HuginnSweepOptions = {}): Promise<HuginnSweepSummary> {
+  const now = options.now ?? Date.now();
+  const statePath = options.statePath ?? defaultStatePath();
+  const state = readSweepState(statePath);
+  const lookbackMs = (options.lookbackHours ?? Number(process.env.ARRA_HUGINN_SWEEP_LOOKBACK_HOURS || 24)) * 60 * 60 * 1000;
+  const watermarkBeforeMs = state.sweeps?.lastSweepAtMs;
+  const sinceMs = watermarkBeforeMs ?? now - lookbackMs;
+  const maxFiles = options.maxFiles ?? Number(process.env.ARRA_HUGINN_SWEEP_MAX_FILES || 200);
+  const files: HuginnSweepSummary['files'] = [];
+  const summary: HuginnSweepSummary = {
+    ok: true,
+    startedAtMs: now,
+    watermarkBeforeMs,
+    watermarkAfterMs: now,
+    scanned: 0,
+    learned: 0,
+    duplicates: 0,
+    empty: 0,
+    missing: 0,
+    markdownIndexed: 0,
+    markdownAlreadyIndexed: 0,
+    capped: false,
+    files,
+  };
+
+  const candidates: string[] = [];
+  for (const dir of options.sessionDirs ?? defaultSessionDirs()) {
+    summary.capped = walkRecentFiles(dir, sinceMs, candidates, maxFiles) || summary.capped;
+    if (summary.capped) break;
+  }
+
+  for (const transcriptPath of candidates.sort()) {
+    summary.scanned++;
+    const result: HuginnCaptureResult = await captureSession({
+      transcriptPath,
+      sessionId: safeSessionIdFromFile(transcriptPath),
+      cwd: options.cwd,
+      statePath,
+      learn: options.learn,
+    });
+    if (result.learned) summary.learned++;
+    else if (result.skipped === 'duplicate') summary.duplicates++;
+    else if (result.skipped === 'empty') summary.empty++;
+    else if (result.skipped === 'missing-transcript') summary.missing++;
+    files.push({ path: transcriptPath, action: result.learned ? 'learned' : result.skipped ?? 'skipped', sessionId: result.sessionId, hash: result.hash });
+  }
+
+  const repoRoot = options.repoRoot ?? REPO_ROOT;
+  const learningsDir = path.join(repoRoot, 'ψ', 'memory', 'learnings');
+  const markdowns: string[] = [];
+  walkRecentFiles(learningsDir, sinceMs, [], 0); // no-op guard for missing dir parity
+  if (fs.existsSync(learningsDir)) {
+    const collectMd = (dir: string) => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) { collectMd(full); continue; }
+        if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+        const stat = fs.statSync(full);
+        if (stat.mtimeMs > sinceMs) markdowns.push(full);
+      }
+    };
+    collectMd(learningsDir);
+  }
+
+  for (const filePath of markdowns.sort()) {
+    const sourceFile = sourceFileForMarkdown(repoRoot, filePath);
+    const already = options.indexMarkdown ? false : await markdownIndexed(sourceFile);
+    if (already) {
+      summary.markdownAlreadyIndexed++;
+      files.push({ path: filePath, action: 'markdown-already-indexed', sourceFile });
+      continue;
+    }
+    await (options.indexMarkdown ?? defaultIndexMarkdown)(filePath, sourceFile);
+    summary.markdownIndexed++;
+    files.push({ path: filePath, action: 'markdown-indexed', sourceFile });
+  }
+
+  const latest = readSweepState(statePath);
+  latest.sweeps = { lastStartedAtMs: now, lastSweepAtMs: now, lastSummary: summary };
+  writeSweepState(statePath, latest);
+  options.log?.(`Huginn sweep scanned ${summary.scanned} session JSONL, learned ${summary.learned}, duplicates ${summary.duplicates}, indexed ${summary.markdownIndexed} markdown files${summary.capped ? ' (capped)' : ''}.`);
+  return summary;
+}


### PR DESCRIPTION
## Summary
- Add `arra huginn sweep` / `bun scripts/huginn-sweep.ts` periodic backstop for missed Huginn captures.
- Reuse #49 `captureSession` dedup state for recent session JSONL and persist `sweeps.lastSweepAtMs` watermark in the same Huginn state file.
- Backfill recent `ψ/memory/learnings/*.md` that are missing from `oracle_documents.source_file` without rewriting duplicate markdown.
- Document sweep scheduling flags and extend focused Huginn tests for backfill, dedup, and watermark behavior.

## Verification
- `bun run build`
- `bun run test:huginn`
- `bun run test`
- Manual temp sweep: first run backfilled a missed JSONL + external markdown; second run used the watermark and skipped session recapture.

Closes Soul-Brews-Studio/arra-oracle-v3-oracle#52
