### PR TITLE
Add opt-in HTTP API token gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,11 @@ for categories and signature convention.
 
 Inspired by [claude-mem](https://github.com/thedotmack/claude-mem) by Alex Newman — process manager pattern, worker service architecture, and hook system concepts.
 
+
+### Opt-in HTTP API token
+
+Set `ARRA_API_TOKEN` to require `Authorization: Bearer <token>` (or `?token=`) for HTTP `/api/*` endpoints, including write/index routes such as `POST /api/learn` and `/api/indexer/*`. The default is unset/open for backward compatibility, and local MCP stdio calls do not use this HTTP gate. `/api/health`, `/info`, and `/api/identity` stay open for monitoring and federation handshakes; `/api/peer/*` continues to use the separate `ARRA_PEER_TOKEN` gate.
+
 ## Federation peer endpoints
 
 Arra exposes a MAW-compatible federation surface for peer oracles. See

--- a/src/integration/api-token-auth.test.ts
+++ b/src/integration/api-token-auth.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const ROOT = process.cwd();
+let proc: Bun.Subprocess | undefined;
+
+async function waitFor(base: string, timeoutMs = 15000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try { const r = await fetch(`${base}/api/health`); if (r.ok) return; } catch {}
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error(`Timed out waiting for ${base}`);
+}
+
+async function startServer(token?: string) {
+  const port = 52000 + Math.floor(Math.random() * 1000);
+  const dataDir = mkdtempSync(join(tmpdir(), 'arra-api-token-data-'));
+  const repoRoot = mkdtempSync(join(tmpdir(), 'arra-api-token-repo-'));
+  mkdirSync(join(repoRoot, 'ψ'), { recursive: true });
+  proc = Bun.spawn(['bun', 'src/server.ts'], {
+    cwd: ROOT,
+    stdout: 'ignore',
+    stderr: 'ignore',
+    env: {
+      ...process.env,
+      ORACLE_PORT: String(port),
+      ORACLE_DATA_DIR: dataDir,
+      ORACLE_DB_PATH: join(dataDir, 'oracle.db'),
+      ORACLE_REPO_ROOT: repoRoot,
+      ARRA_API_TOKEN: token ?? '',
+      VECTOR_URL: '',
+      MAW_JS_URL: 'http://127.0.0.1:1',
+    },
+  });
+  const base = `http://127.0.0.1:${port}`;
+  await waitFor(base);
+  return base;
+}
+
+async function postLearn(base: string, init: RequestInit = {}) {
+  return fetch(`${base}/api/learn`, {
+    ...init,
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...(init.headers as Record<string, string> | undefined) },
+    body: JSON.stringify({ pattern: 'api token auth integration sentinel', source: 'test' }),
+  });
+}
+
+afterEach(() => { proc?.kill(); proc = undefined; });
+
+describe('ARRA_API_TOKEN HTTP auth', () => {
+  test('unset token keeps /api/learn open', async () => {
+    const base = await startServer();
+    const res = await postLearn(base);
+    expect(res.status).not.toBe(401);
+    expect(res.ok).toBe(true);
+  });
+
+  test('set token gates /api/learn but leaves health and federation handshake open', async () => {
+    const base = await startServer('secret');
+    expect((await fetch(`${base}/api/health`)).status).toBe(200);
+    expect((await fetch(`${base}/info`)).status).toBe(200);
+    expect((await fetch(`${base}/api/identity`)).status).toBe(200);
+    expect((await fetch(`${base}/api/peer/feed`)).status).not.toBe(401);
+
+    expect((await fetch(`${base}/api/search?q=sentinel`)).status).toBe(401);
+
+    const denied = await postLearn(base);
+    expect(denied.status).toBe(401);
+    expect(await denied.json()).toMatchObject({ error: 'api_auth_required' });
+
+    const allowed = await postLearn(base, { headers: { authorization: 'Bearer secret' } });
+    expect(allowed.status).toBe(200);
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,6 +22,7 @@ import { PORT, ORACLE_DATA_DIR, VECTOR_URL } from './config.ts';
 import { ScoutAnnouncer, shouldStartScoutAnnouncer } from './peer/scout-announcer.ts';
 import { MCP_SERVER_NAME } from './const.ts';
 import { db, sqlite, closeDb, indexingStatus } from './db/index.ts';
+import { isApiAuthorized, isApiPathProtected, unauthorizedApiResponse } from './server/api-token-auth.ts';
 import { seedMenuItems, type HasRoutes as SeedHasRoutes } from './db/seeders/menu-seeder.ts';
 
 // Elysia sub-apps — one per cluster
@@ -162,6 +163,13 @@ const app = new Elysia()
       methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
     }),
   )
+  .onBeforeHandle(({ request, set }) => {
+    const pathname = new URL(request.url).pathname;
+    if (isApiPathProtected(pathname) && !isApiAuthorized(request)) {
+      set.status = 401;
+      return unauthorizedApiResponse();
+    }
+  })
   .onAfterHandle(({ set }) => {
     set.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate';
     set.headers['X-Content-Type-Options'] = 'nosniff';

--- a/src/server/api-token-auth.ts
+++ b/src/server/api-token-auth.ts
@@ -1,0 +1,33 @@
+import { timingSafeEqual } from 'crypto';
+
+const OPEN_PATHS = new Set(['/info', '/api/identity']);
+const OPEN_PREFIXES = ['/api/health', '/api/peer/'];
+
+export function apiToken() { return process.env.ARRA_API_TOKEN?.trim() || ''; }
+export function isApiTokenEnabled() { return apiToken().length > 0; }
+
+function safeEqual(a: string, b: string) {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  return ab.length === bb.length && timingSafeEqual(ab, bb);
+}
+
+export function isApiPathProtected(pathname: string) {
+  if (!pathname.startsWith('/api/')) return false;
+  if (OPEN_PATHS.has(pathname)) return false;
+  if (OPEN_PREFIXES.some((prefix) => pathname === prefix.slice(0, -1) || pathname.startsWith(prefix))) return false;
+  return true;
+}
+
+export function isApiAuthorized(request: Request) {
+  const configured = apiToken();
+  if (!configured) return true;
+  const auth = request.headers.get('authorization') ?? '';
+  const bearer = auth.match(/^Bearer\s+(.+)$/i)?.[1]?.trim();
+  const urlToken = new URL(request.url).searchParams.get('token')?.trim();
+  return Boolean((bearer && safeEqual(bearer, configured)) || (urlToken && safeEqual(urlToken, configured)));
+}
+
+export function unauthorizedApiResponse() {
+  return { error: 'api_auth_required', message: 'ARRA API token required' };
+}


### PR DESCRIPTION
## Summary

Adds opt-in deploy auth for the public HTTP API:

- `ARRA_API_TOKEN` default unset/open for backward compatibility
- When set, `/api/*` requires `Authorization: Bearer <token>` or `?token=`
- Keeps `/api/health`, `/info`, and `/api/identity` open for monitoring/federation handshakes
- Keeps `/api/peer/*` separate under existing `ARRA_PEER_TOKEN`
- Covers `/api/learn`, `/api/indexer/*`, and read APIs such as `/api/search` when enabled

Local MCP stdio is unaffected because this is only HTTP middleware.

Closes Soul-Brews-Studio/arra-oracle-v3-oracle#53

## Verification

- `bun run build`
- `bun test src/integration/api-token-auth.test.ts src/integration/federation-peer.test.ts tests/cli/completions/completions.test.ts`
