### PR TITLE
Add droplet seed and remote verify scripts

### DIFF
--- a/scripts/seed-droplet.sh
+++ b/scripts/seed-droplet.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Ship the live Arra Oracle index from this machine to a droplet volume mount.
+# Copies only live index files from ~/.arra-oracle-v2 and excludes backup/export debris.
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/seed-droplet.sh --host user@droplet --remote-dir /path/to/data [options]
+
+Required:
+  --host HOST             SSH target, e.g. root@203.0.113.10
+  --remote-dir PATH       Remote docker volume mount containing oracle.db/lancedb/
+
+Options:
+  --source-dir PATH       Local data dir (default: $ORACLE_DATA_DIR or ~/.arra-oracle-v2)
+  --container NAME        Docker container to stop before sync and start after sync
+  --compose-dir PATH      Remote dir with docker-compose.yml; runs docker compose stop/start
+  --dry-run               Print rsync plan without writing remote files
+  --no-stop               Do not stop/start container or compose service
+  -h, --help              Show this help
+
+Environment equivalents:
+  DROPLET_HOST, DROPLET_DATA_DIR, ORACLE_DATA_DIR, DROPLET_CONTAINER, DROPLET_COMPOSE_DIR
+
+Copies:
+  oracle.db
+  embedding-cache.db
+  lancedb/
+
+Excludes:
+  *.backup-*  *.export-*  *.bak  *.tmp  *-wal  *-shm
+USAGE
+}
+
+log() { printf '[seed-droplet] %s\n' "$*" >&2; }
+fail() { printf '[seed-droplet] ERROR: %s\n' "$*" >&2; exit 1; }
+
+HOST="${DROPLET_HOST:-}"
+REMOTE_DIR="${DROPLET_DATA_DIR:-}"
+SOURCE_DIR="${ORACLE_DATA_DIR:-$HOME/.arra-oracle-v2}"
+CONTAINER="${DROPLET_CONTAINER:-}"
+COMPOSE_DIR="${DROPLET_COMPOSE_DIR:-}"
+DRY_RUN=0
+NO_STOP=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host) HOST="${2:-}"; shift 2 ;;
+    --remote-dir) REMOTE_DIR="${2:-}"; shift 2 ;;
+    --source-dir) SOURCE_DIR="${2:-}"; shift 2 ;;
+    --container) CONTAINER="${2:-}"; shift 2 ;;
+    --compose-dir) COMPOSE_DIR="${2:-}"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --no-stop) NO_STOP=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$HOST" ]] || { usage; fail '--host is required'; }
+[[ -n "$REMOTE_DIR" ]] || { usage; fail '--remote-dir is required'; }
+[[ -d "$SOURCE_DIR" ]] || fail "source dir not found: $SOURCE_DIR"
+[[ -f "$SOURCE_DIR/oracle.db" ]] || fail "missing $SOURCE_DIR/oracle.db"
+[[ -f "$SOURCE_DIR/embedding-cache.db" ]] || log "warning: $SOURCE_DIR/embedding-cache.db not found; rsync will skip it"
+[[ -d "$SOURCE_DIR/lancedb" ]] || log "warning: $SOURCE_DIR/lancedb/ not found; rsync will skip it"
+
+RSYNC_ITEMS=()
+[[ -f "$SOURCE_DIR/oracle.db" ]] && RSYNC_ITEMS+=("oracle.db")
+[[ -f "$SOURCE_DIR/embedding-cache.db" ]] && RSYNC_ITEMS+=("embedding-cache.db")
+[[ -d "$SOURCE_DIR/lancedb" ]] && RSYNC_ITEMS+=("lancedb/")
+
+remote_quote() { printf '%q' "$1"; }
+remote_run() { ssh "$HOST" "$@"; }
+
+stop_remote() {
+  [[ "$NO_STOP" -eq 0 ]] || return 0
+  if [[ -n "$COMPOSE_DIR" ]]; then
+    log "stopping remote compose stack in $COMPOSE_DIR"
+    remote_run "cd $(remote_quote "$COMPOSE_DIR") && docker compose stop"
+  elif [[ -n "$CONTAINER" ]]; then
+    log "stopping remote container $CONTAINER"
+    remote_run "docker stop $(remote_quote "$CONTAINER") >/dev/null || true"
+  else
+    log "no --container/--compose-dir supplied; skipping remote stop"
+  fi
+}
+
+start_remote() {
+  [[ "$NO_STOP" -eq 0 ]] || return 0
+  if [[ -n "$COMPOSE_DIR" ]]; then
+    log "starting remote compose stack in $COMPOSE_DIR"
+    remote_run "cd $(remote_quote "$COMPOSE_DIR") && docker compose start"
+  elif [[ -n "$CONTAINER" ]]; then
+    log "starting remote container $CONTAINER"
+    remote_run "docker start $(remote_quote "$CONTAINER") >/dev/null"
+  else
+    log "no --container/--compose-dir supplied; skipping remote start"
+  fi
+}
+
+log "source: $SOURCE_DIR"
+log "target: $HOST:$REMOTE_DIR"
+log "items: ${RSYNC_ITEMS[*]}"
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  NO_STOP=1
+fi
+remote_run "mkdir -p $(remote_quote "$REMOTE_DIR")"
+
+stop_remote
+trap start_remote EXIT
+
+RSYNC_FLAGS=(-az --info=progress2 --human-readable)
+[[ "$DRY_RUN" -eq 1 ]] && RSYNC_FLAGS+=(--dry-run)
+rsync "${RSYNC_FLAGS[@]}" \
+  --exclude='*.backup-*' \
+  --exclude='*.export-*' \
+  --exclude='*.bak' \
+  --exclude='*.tmp' \
+  --exclude='*-wal' \
+  --exclude='*-shm' \
+  --relative \
+  -- "${RSYNC_ITEMS[@]/#/$SOURCE_DIR/./}" "$HOST:$REMOTE_DIR/"
+
+log "seed complete"

--- a/scripts/verify-remote.sh
+++ b/scripts/verify-remote.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Verify a public Arra endpoint behaves for read clients and gates writes.
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/verify-remote.sh <url> [token]
+
+Checks:
+  GET  /api/health       returns 200
+  GET  /api/stats        returns JSON with a positive-ish document count when available
+  GET  /api/search       returns JSON and at least one result for a sample query
+  POST /api/learn        returns 401/403 without a token (write must be gated)
+  POST /api/learn        with token, if supplied, must not return 401/403
+
+Env:
+  ORACLE_API             URL fallback when <url> is omitted
+  ORACLE_TOKEN           token fallback when [token] is omitted
+  ORACLE_VERIFY_QUERY    search query (default: oracle)
+  ORACLE_TOKEN_HEADER    token header for writes (default: x-oracle-token)
+USAGE
+}
+
+log() { printf '[verify-remote] %s\n' "$*" >&2; }
+fail() { printf '[verify-remote] ERROR: %s\n' "$*" >&2; exit 1; }
+need() { command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"; }
+
+if [[ "${1:-}" == '-h' || "${1:-}" == '--help' ]]; then usage; exit 0; fi
+
+BASE="${1:-${ORACLE_API:-}}"
+TOKEN="${2:-${ORACLE_TOKEN:-}}"
+QUERY="${ORACLE_VERIFY_QUERY:-oracle}"
+TOKEN_HEADER="${ORACLE_TOKEN_HEADER:-x-oracle-token}"
+[[ -n "$BASE" ]] || { usage; fail 'url argument or ORACLE_API is required'; }
+BASE="${BASE%/}"
+need curl
+need jq
+need python3
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+curl_json() {
+  local name="$1"; shift
+  local body="$TMP_DIR/$name.body"
+  local status
+  status=$(curl -sS -o "$body" -w '%{http_code}' "$@") || fail "curl failed for $name"
+  printf '%s %s\n' "$status" "$body"
+}
+
+read -r HEALTH_STATUS HEALTH_BODY < <(curl_json health "$BASE/api/health")
+[[ "$HEALTH_STATUS" == '200' ]] || fail "health returned $HEALTH_STATUS: $(cat "$HEALTH_BODY")"
+jq -e . "$HEALTH_BODY" >/dev/null || fail 'health did not return JSON'
+log "health ok"
+
+read -r STATS_STATUS STATS_BODY < <(curl_json stats "$BASE/api/stats")
+[[ "$STATS_STATUS" == '200' ]] || fail "stats returned $STATS_STATUS: $(cat "$STATS_BODY")"
+jq -e . "$STATS_BODY" >/dev/null || fail 'stats did not return JSON'
+DOC_COUNT=$(jq -r '(.totalDocuments // .total // .documents // .count // .stats.totalDocuments // .stats.total // empty)' "$STATS_BODY")
+if [[ -n "$DOC_COUNT" && "$DOC_COUNT" =~ ^[0-9]+$ ]]; then
+  [[ "$DOC_COUNT" -gt 0 ]] || fail "stats document count is not positive: $DOC_COUNT"
+  log "stats ok: documents=$DOC_COUNT"
+elif [[ -n "$DOC_COUNT" ]]; then
+  log "stats ok: non-numeric document count field: $DOC_COUNT"
+else
+  log "stats ok: document count field not found"
+fi
+
+SEARCH_URL="$BASE/api/search?q=$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1]))' "$QUERY")&limit=5"
+read -r SEARCH_STATUS SEARCH_BODY < <(curl_json search "$SEARCH_URL")
+[[ "$SEARCH_STATUS" == '200' ]] || fail "search returned $SEARCH_STATUS: $(cat "$SEARCH_BODY")"
+jq -e . "$SEARCH_BODY" >/dev/null || fail 'search did not return JSON'
+RESULT_COUNT=$(jq -r '(.results // .items // .data // []) | length' "$SEARCH_BODY")
+[[ "$RESULT_COUNT" =~ ^[0-9]+$ ]] || fail 'search result count not parseable'
+[[ "$RESULT_COUNT" -gt 0 ]] || fail "search returned zero results for query '$QUERY'"
+log "search ok: query='$QUERY' results=$RESULT_COUNT"
+
+# Intentionally invalid body: an authenticated request should reach the handler
+# and return 400 without creating a learning; an unauthenticated request must be
+# rejected earlier by the public token gate.
+LEARN_PAYLOAD='{}'
+read -r WRITE_STATUS WRITE_BODY < <(curl_json write_no_token -X POST -H 'content-type: application/json' --data "$LEARN_PAYLOAD" "$BASE/api/learn")
+case "$WRITE_STATUS" in
+  401|403) log "write gate ok: unauthenticated POST /api/learn returned $WRITE_STATUS" ;;
+  *) fail "write endpoint is not token-gated; unauthenticated POST /api/learn returned $WRITE_STATUS: $(cat "$WRITE_BODY")" ;;
+esac
+
+if [[ -n "$TOKEN" ]]; then
+  read -r AUTH_STATUS AUTH_BODY < <(curl_json write_token -X POST -H 'content-type: application/json' -H "$TOKEN_HEADER: $TOKEN" -H "authorization: Bearer $TOKEN" --data "$LEARN_PAYLOAD" "$BASE/api/learn")
+  case "$AUTH_STATUS" in
+    401|403) fail "token was rejected by POST /api/learn ($AUTH_STATUS): $(cat "$AUTH_BODY")" ;;
+    2*|400|409|422) log "token path reached write handler: status=$AUTH_STATUS" ;;
+    *) fail "unexpected token write status $AUTH_STATUS: $(cat "$AUTH_BODY")" ;;
+  esac
+else
+  log "no token supplied; skipped authenticated write probe"
+fi
+
+printf '{"ok":true,"url":"%s","documents":"%s","searchResults":%s,"writeWithoutToken":%s}\n' "$BASE" "$DOC_COUNT" "$RESULT_COUNT" "$WRITE_STATUS"


### PR DESCRIPTION
## Summary
- Add `scripts/seed-droplet.sh` to rsync the live `~/.arra-oracle-v2` index (`oracle.db`, `embedding-cache.db`, `lancedb/`) to a droplet volume while excluding backup/export/temp/WAL files and optionally stop/start container or compose stack.
- Add `scripts/verify-remote.sh <url> [token]` to assert public health/stats/search works and `POST /api/learn` is token-gated.
- Keep the authenticated write probe non-mutating by sending `{}`: a protected endpoint should pass through with token and return handler-level 400, not create a learning.

## Verification
- `bash -n scripts/seed-droplet.sh scripts/verify-remote.sh`
- `scripts/verify-remote.sh` against a local mock endpoint: health 200, stats doc count 345, search result >0, unauth learn 401, token learn reached handler with 400
- `bun run build`
- `bun run test` — 163 pass / 65 skip / 0 fail
- `shellcheck` not installed locally

Closes Soul-Brews-Studio/arra-oracle-v3-oracle#56
