### PR TITLE
Fix vector score saturation for cosine distance

### DIFF
--- a/src/server/__tests__/vector-score.test.ts
+++ b/src/server/__tests__/vector-score.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test';
+import { cosineDistanceToSimilarity } from '../handlers.ts';
+
+describe('cosineDistanceToSimilarity', () => {
+  test('maps LanceDB cosine distance across the full 0..1 relevance range', () => {
+    const scores = [0, 0.5, 1, 1.5, 2].map(cosineDistanceToSimilarity);
+
+    expect(scores).toEqual([1, 0.75, 0.5, 0.25, 0]);
+    expect(Math.max(...scores)).toBeLessThanOrEqual(1);
+    expect(Math.min(...scores)).toBeGreaterThanOrEqual(0);
+  });
+
+  test('does not saturate ordinary cosine distances near 0.99', () => {
+    const scores = [0.2, 0.8, 1.6].map(cosineDistanceToSimilarity);
+
+    expect(scores[0]).toBeCloseTo(0.9, 6);
+    expect(scores[1]).toBeCloseTo(0.6, 6);
+    expect(scores[2]).toBeCloseTo(0.2, 6);
+    expect(Math.max(...scores) - Math.min(...scores)).toBeGreaterThan(0.6);
+  });
+
+  test('clamps out-of-range adapter distances defensively', () => {
+    expect(cosineDistanceToSimilarity(-1)).toBe(1);
+    expect(cosineDistanceToSimilarity(3)).toBe(0);
+  });
+});

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -25,6 +25,17 @@ import { buildLearningMarkdown, dateSlug } from '../learn/markdown.ts';
 const vectorProxy = createVectorProxy(VECTOR_URL);
 
 /**
+ * LanceDB is configured for cosine distance, where nearest-neighbor distances
+ * are in the 0..2 range: 0 means identical, 2 means opposite. Convert that
+ * directly to a bounded relevance score instead of using the old L2 scaling
+ * formula, which saturated normal cosine distances around 0.99.
+ */
+export function cosineDistanceToSimilarity(distance: number): number {
+  if (!Number.isFinite(distance)) return 0;
+  return Math.max(0, Math.min(1, 1 - distance / 2));
+}
+
+/**
  * Search Oracle knowledge base with hybrid search (FTS5 + Vector)
  * HTTP server can safely use ChromaMcpClient since it's not an MCP server
  */
@@ -182,7 +193,7 @@ export async function handleSearch(
         return chromaResults.ids
           .map((id: string, i: number) => {
             const distance = chromaResults.distances?.[i] || 0;
-            const similarity = 1 / (1 + distance / 100);
+            const similarity = cosineDistanceToSimilarity(distance);
             const docProject = projectMap.get(id);
             return {
               id,


### PR DESCRIPTION
## Summary
- replace the local vector-search L2-era score formula with cosine distance scoring: `max(0, min(1, 1 - distance / 2))`
- reuse the same cosine logic already used for `/api/similar` semantics, matching LanceDB cosine distance range `0..2`
- add regression coverage proving scores spread across `0..1` and no longer saturate near `0.99`

## Verification
- `bun test src/server/__tests__/vector-score.test.ts`
- `bun test src/server/__tests__/search-vector-proxy-total.test.ts`
- `git diff --check`

## Note
- `bun test src/server/__tests__/vector-routes-proxy-boundary.test.ts` currently fails in this environment because the remote vector sidecar mock is not reached; this appears unrelated to the score conversion and was not changed here.

Closes #1313
