### PR TITLE
Degrade vector search on non-AVX hosts

### DIFF
--- a/src/server/__tests__/search-no-avx-fallback.test.ts
+++ b/src/server/__tests__/search-no-avx-fallback.test.ts
@@ -1,0 +1,73 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-search-no-avx-'));
+const repoRoot = path.join(tmpRoot, 'repo');
+const dataDir = path.join(tmpRoot, 'data');
+
+const originalRepoRoot = process.env.ORACLE_REPO_ROOT;
+const originalDataDir = process.env.ORACLE_DATA_DIR;
+const originalDbPath = process.env.ORACLE_DB_PATH;
+const originalVectorUrl = process.env.VECTOR_URL;
+const originalVectorDb = process.env.ORACLE_VECTOR_DB;
+const originalForceAvx = process.env.ARRA_FORCE_AVX;
+
+process.env.ORACLE_REPO_ROOT = repoRoot;
+process.env.ORACLE_DATA_DIR = dataDir;
+process.env.ORACLE_DB_PATH = path.join(dataDir, 'oracle.db');
+delete process.env.VECTOR_URL;
+process.env.ORACLE_VECTOR_DB = 'lancedb';
+process.env.ARRA_FORCE_AVX = '0';
+
+const warnMessages: string[] = [];
+const originalWarn = console.warn;
+console.warn = (...args: unknown[]) => {
+  warnMessages.push(args.map(String).join(' '));
+};
+
+const { handleLearn, handleSearch } = await import('../handlers.ts');
+
+describe('handleSearch local vector on non-AVX CPU', () => {
+  test('vector mode falls back to FTS instead of touching native vector adapter', async () => {
+    handleLearn('noavxunique deploy blocker should still be searchable through fts fallback', 'test', ['noavxunique']);
+
+    const result = await handleSearch('noavxunique', 'all', 5, 0, 'vector');
+
+    expect(result.mode).toBe('vector');
+    expect(result.vectorAvailable).toBe(false);
+    expect(result.warning).toContain('CPU lacks AVX');
+    expect(result.warning).toContain('FTS5-only');
+    expect(result.results.length).toBeGreaterThan(0);
+    expect(result.results[0].source).toBe('fts');
+    expect(warnMessages.some((msg) => msg.includes('Local vector search disabled'))).toBe(true);
+  });
+
+  test('hybrid mode also degrades to FTS with a warning', async () => {
+    const result = await handleSearch('noavxunique', 'all', 5, 0, 'hybrid');
+
+    expect(result.mode).toBe('hybrid');
+    expect(result.vectorAvailable).toBe(false);
+    expect(result.warning).toContain('CPU lacks AVX');
+    expect(result.results.length).toBeGreaterThan(0);
+    expect(result.results.every((r) => r.source === 'fts')).toBe(true);
+  });
+});
+
+afterAll(() => {
+  console.warn = originalWarn;
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  if (originalRepoRoot !== undefined) process.env.ORACLE_REPO_ROOT = originalRepoRoot;
+  else delete process.env.ORACLE_REPO_ROOT;
+  if (originalDataDir !== undefined) process.env.ORACLE_DATA_DIR = originalDataDir;
+  else delete process.env.ORACLE_DATA_DIR;
+  if (originalDbPath !== undefined) process.env.ORACLE_DB_PATH = originalDbPath;
+  else delete process.env.ORACLE_DB_PATH;
+  if (originalVectorUrl !== undefined) process.env.VECTOR_URL = originalVectorUrl;
+  else delete process.env.VECTOR_URL;
+  if (originalVectorDb !== undefined) process.env.ORACLE_VECTOR_DB = originalVectorDb;
+  else delete process.env.ORACLE_VECTOR_DB;
+  if (originalForceAvx !== undefined) process.env.ARRA_FORCE_AVX = originalForceAvx;
+  else delete process.env.ARRA_FORCE_AVX;
+});

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -12,11 +12,12 @@ import { db, sqlite, oracleDocuments, indexingStatus, isDbLockError } from '../d
 import { REPO_ROOT, VECTOR_URL } from '../config.ts';
 import { logSearch, logDocumentAccess, logLearning } from './logging.ts';
 import type { SearchResult, SearchResponse } from './types.ts';
-import { ensureVectorStoreConnected, EMBEDDING_MODELS } from '../vector/factory.ts';
+import { ensureVectorStoreConnected, EMBEDDING_MODELS, getVectorStoreConfigByModel } from '../vector/factory.ts';
 import { detectProject } from './project-detect.ts';
 import { coerceConcepts } from '../tools/learn.ts';
 import { createVectorProxy } from './vector-proxy.ts';
 import { buildLearningMarkdown, dateSlug } from '../learn/markdown.ts';
+import { localNativeVectorDisabledReason, logLocalVectorDisabled } from '../vector/cpu-capabilities.ts';
 
 // Module-level proxy instance — bound to VECTOR_URL at boot. If VECTOR_URL is
 // unset, this is null and the local vector adapter runs in-process (legacy
@@ -52,8 +53,24 @@ export async function handleSearch(
   }
 
   let warning: string | undefined;
+  const requestedMode = mode;
+  let effectiveMode = mode;
+  let vectorDisabledReason: string | undefined;
+  if (mode !== 'fts' && !vectorProxy) {
+    const modelsToCheck = model === 'multi' ? ['bge-m3', 'nomic'] : [model];
+    for (const modelKey of modelsToCheck) {
+      const cfg = getVectorStoreConfigByModel(modelKey);
+      vectorDisabledReason = localNativeVectorDisabledReason(cfg.type);
+      if (vectorDisabledReason) break;
+    }
+    if (vectorDisabledReason) {
+      effectiveMode = 'fts';
+      warning = `${vectorDisabledReason}; falling back to FTS5-only results`;
+      logLocalVectorDisabled(vectorDisabledReason);
+    }
+  }
 
-  // FTS5 search (skip if vector-only mode)
+  // FTS5 search (skip only when the effective mode is vector-only)
   let ftsResults: SearchResult[] = [];
   let ftsTotal = 0;
 
@@ -65,7 +82,7 @@ export async function handleSearch(
   const projectParams = resolvedProject ? [resolvedProject] : [];
 
   // FTS5 search must use raw SQL (Drizzle doesn't support virtual tables)
-  if (mode !== 'vector') {
+  if (effectiveMode !== 'vector') {
     if (type === 'all') {
       const countStmt = sqlite.prepare(`
         SELECT COUNT(*) as total
@@ -130,12 +147,12 @@ export async function handleSearch(
   // (vector wasn't asked for), flips to `false` if the proxy is enabled and
   // the remote call failed — clients use this to render a "vector down" hint
   // while still getting FTS5 results.
-  let vectorAvailable = true;
+  let vectorAvailable = !vectorDisabledReason;
 
   // VECTOR_URL set → route the vector leg through the remote service.
   // FTS5 always runs locally above. If the proxy fails we return whatever FTS5
   // produced and set vectorAvailable: false (per VECTOR_FALLBACK = 'fts5').
-  if (mode !== 'fts' && vectorProxy) {
+  if (effectiveMode !== 'fts' && vectorProxy) {
     const remote = await vectorProxy.search({
       q: query,
       type,
@@ -153,7 +170,7 @@ export async function handleSearch(
       vectorAvailable = false;
       warning = 'Vector proxy unavailable — FTS5-only results';
     }
-  } else if (mode !== 'fts') {
+  } else if (effectiveMode !== 'fts') {
     // Determine which models to query
     const isMulti = model === 'multi';
     const modelsToQuery = isMulti
@@ -244,9 +261,9 @@ export async function handleSearch(
   // For vector-only mode, ftsTotal is 0 and combined.length is just top-N,
   // so use the vector collection count as the total for accurate display
   let total = Math.max(ftsTotal, combined.length);
-  if (mode === 'vector' && vectorProxy && remoteVectorTotal !== undefined) {
+  if (requestedMode === 'vector' && vectorProxy && remoteVectorTotal !== undefined) {
     total = remoteVectorTotal;
-  } else if (mode === 'vector' && vectorResults.length > 0) {
+  } else if (requestedMode === 'vector' && vectorResults.length > 0) {
     try {
       const client = await ensureVectorStoreConnected(model && EMBEDDING_MODELS[model] ? model : undefined);
       const stats = await client.getStats();
@@ -261,7 +278,7 @@ export async function handleSearch(
 
   // Log search
   const searchTime = Date.now() - startTime;
-  logSearch(query, type, mode, total, searchTime, results);
+  logSearch(query, type, requestedMode, total, searchTime, results);
   results.forEach(r => logDocumentAccess(r.id, 'search'));
 
   return {
@@ -269,9 +286,9 @@ export async function handleSearch(
     total,
     offset,
     limit,
-    mode,
+    mode: requestedMode,
     ...(model === 'multi' ? { model: 'multi' } : model && EMBEDDING_MODELS[model] ? { model } : {}),
-    ...(mode !== 'fts' ? { vectorAvailable } : {}),
+    ...(requestedMode !== 'fts' ? { vectorAvailable } : {}),
     ...(warning && { warning })
   };
 }

--- a/src/vector/cpu-capabilities.ts
+++ b/src/vector/cpu-capabilities.ts
@@ -1,0 +1,60 @@
+import fs from 'fs';
+import { execFileSync } from 'child_process';
+
+let cachedHasAvx: boolean | undefined;
+let loggedDisable = false;
+
+function truthy(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  return undefined;
+}
+
+function detectCpuFlags(): string {
+  if (process.env.ARRA_CPU_FLAGS !== undefined) return process.env.ARRA_CPU_FLAGS;
+  if (process.platform === 'linux') {
+    try { return fs.readFileSync('/proc/cpuinfo', 'utf-8'); } catch {}
+  }
+  if (process.platform === 'darwin') {
+    try { return execFileSync('/usr/sbin/sysctl', ['-n', 'machdep.cpu.features'], { encoding: 'utf-8' }); } catch {}
+    try { return execFileSync('/usr/sbin/sysctl', ['-n', 'machdep.cpu.leaf7_features'], { encoding: 'utf-8' }); } catch {}
+  }
+  return '';
+}
+
+export function resetCpuCapabilityCacheForTests(): void {
+  cachedHasAvx = undefined;
+  loggedDisable = false;
+}
+
+export function hasAvx(): boolean {
+  const forced = truthy(process.env.ARRA_FORCE_AVX);
+  if (forced !== undefined) return forced;
+  if (cachedHasAvx !== undefined) return cachedHasAvx;
+  const flags = detectCpuFlags().toLowerCase();
+  // AVX2 implies AVX on normal CPUs, but check both for explicitness.
+  cachedHasAvx = /(^|[\s:])avx([\s_]|$)/.test(flags) || /(^|[\s:])avx2([\s_]|$)/.test(flags);
+  return cachedHasAvx;
+}
+
+export function localNativeVectorDisabledReason(adapter: string | undefined = process.env.ORACLE_VECTOR_DB || 'lancedb'): string | undefined {
+  const disabled = truthy(process.env.ORACLE_DISABLE_LOCAL_VECTOR);
+  if (disabled === true) return 'ORACLE_DISABLE_LOCAL_VECTOR is enabled';
+  if (disabled === false) return undefined;
+
+  const nativeAdapters = new Set(['lancedb', 'sqlite-vec']);
+  const forcedAvx = truthy(process.env.ARRA_FORCE_AVX);
+  const needsX64AvxGate = forcedAvx === false || (process.arch === 'x64' && ['linux', 'win32'].includes(process.platform));
+  if (adapter && nativeAdapters.has(adapter) && needsX64AvxGate && !hasAvx()) {
+    return `CPU lacks AVX required by local native vector adapter (${adapter})`;
+  }
+  return undefined;
+}
+
+export function logLocalVectorDisabled(reason: string): void {
+  if (loggedDisable) return;
+  loggedDisable = true;
+  console.warn(`[Vector] Local vector search disabled: ${reason}. Falling back to FTS5-only results.`);
+}

--- a/src/vector/factory.ts
+++ b/src/vector/factory.ts
@@ -16,6 +16,7 @@ import { QdrantAdapter } from './adapters/qdrant.ts';
 import { CloudflareVectorizeAdapter, CloudflareAIEmbeddings } from './adapters/cloudflare-vectorize.ts';
 import { createEmbeddingProvider } from './embeddings.ts';
 import { loadVectorConfig, configToModels, type VectorModelRegistryEntry } from './config.ts';
+import { localNativeVectorDisabledReason, logLocalVectorDisabled } from './cpu-capabilities.ts';
 
 export interface VectorStoreConfig {
   type?: VectorDBType;
@@ -52,6 +53,11 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
     || 'lancedb';
 
   const collectionName = config.collectionName || COLLECTION_NAME;
+  const disabledReason = localNativeVectorDisabledReason(type);
+  if (disabledReason) {
+    logLocalVectorDisabled(disabledReason);
+    throw new Error(disabledReason);
+  }
 
   switch (type) {
     case 'sqlite-vec': {


### PR DESCRIPTION
## Summary
- Add CPU capability detection for local native vector adapters and disable LanceDB/sqlite-vec on x64 Linux/Windows hosts without AVX.
- Make `mode=vector` and `mode=hybrid` degrade to FTS5-only when local native vector is disabled, returning `vectorAvailable: false` plus a warning instead of touching native code that can SIGILL.
- Guard vector-store factory creation too, so stats/health/vector routes fail closed/degraded rather than loading native adapters on non-AVX hosts.
- Add regression coverage with `ARRA_FORCE_AVX=0` for vector and hybrid search fallback.

## Verification
Clean archive verification with this diff applied:
- `bun run build`
- `bun test --isolate src/server/__tests__/search-no-avx-fallback.test.ts src/server/__tests__/search-vector-proxy-total.test.ts`
- `bun run test:unit` — 286 pass / 0 fail
- `bun run test:integration` — 31 pass / 13 skip / 0 fail

Note: live non-AVX droplet smoke not run here; regression simulates no AVX via `ARRA_FORCE_AVX=0`.

Closes #1322
