### PR TITLE
Fix FTS natural-language search regressions

### DIFF
--- a/src/server/__tests__/search-fts-query.test.ts
+++ b/src/server/__tests__/search-fts-query.test.ts
@@ -1,0 +1,67 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-search-fts-query-'));
+const dataDir = path.join(tmpRoot, 'data');
+const originalDataDir = process.env.ORACLE_DATA_DIR;
+const originalDbPath = process.env.ORACLE_DB_PATH;
+const originalVectorUrl = process.env.VECTOR_URL;
+
+process.env.ORACLE_DATA_DIR = dataDir;
+process.env.ORACLE_DB_PATH = path.join(dataDir, 'oracle.db');
+delete process.env.VECTOR_URL;
+
+const { sqlite } = await import('../../db/index.ts');
+const { buildFtsQuery, handleSearch } = await import('../handlers.ts');
+const { sanitizeFtsQuery } = await import('../../tools/search.ts');
+
+function insertDoc(id: string, content: string, concepts: string[] = []) {
+  const now = Date.now();
+  sqlite.prepare(`
+    INSERT OR REPLACE INTO oracle_documents
+      (id, type, source_file, concepts, created_at, updated_at, indexed_at, project, created_by)
+    VALUES (?, 'learning', ?, ?, ?, ?, ?, NULL, 'test')
+  `).run(id, `${id}.md`, JSON.stringify(concepts), now, now, now);
+  sqlite.prepare('DELETE FROM oracle_fts WHERE id = ?').run(id);
+  sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
+    .run(id, content, concepts.join(' '));
+}
+
+insertDoc('punctuation', 'Muninn recalls foo bar baz from punctuation-heavy notes.', ['muninn']);
+insertDoc('alpha-only', 'Issue one three one four alphaonly recall lives here.', ['alphaonly1314']);
+insertDoc('beta-only', 'Issue one three one four betaonly memory lives here.', ['betaonly1314']);
+insertDoc('alpha-beta', 'Issue one three one four alphaonly and betaonly both appear here.', ['alphaonly1314', 'betaonly1314']);
+
+describe('FTS query sanitation and recall behavior', () => {
+  test('builds quoted OR terms instead of raw punctuation syntax', () => {
+    expect(buildFtsQuery('foo.bar, baz (now)!')).toBe('"foo" OR "bar" OR "baz" OR "now"');
+    expect(sanitizeFtsQuery('foo.bar, baz (now)!')).toBe('"foo" OR "bar" OR "baz" OR "now"');
+  });
+
+  test('punctuation-heavy FTS queries degrade gracefully instead of throwing', async () => {
+    const result = await handleSearch('foo.bar, baz (now)!', 'all', 10, 0, 'fts');
+    expect(result.results.map((r) => r.id)).toContain('punctuation');
+    expect(result.total).toBeGreaterThanOrEqual(1);
+  });
+
+  test('natural-language multi-token recall uses OR semantics instead of implicit AND only', async () => {
+    const result = await handleSearch('alphaonly1314 betaonly1314', 'all', 20, 0, 'fts');
+    const ids = result.results.map((r) => r.id);
+    expect(ids).toContain('alpha-only');
+    expect(ids).toContain('beta-only');
+    expect(ids).toContain('alpha-beta');
+  });
+});
+
+afterAll(() => {
+  sqlite.close();
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  if (originalDataDir !== undefined) process.env.ORACLE_DATA_DIR = originalDataDir;
+  else delete process.env.ORACLE_DATA_DIR;
+  if (originalDbPath !== undefined) process.env.ORACLE_DB_PATH = originalDbPath;
+  else delete process.env.ORACLE_DB_PATH;
+  if (originalVectorUrl !== undefined) process.env.VECTOR_URL = originalVectorUrl;
+  else delete process.env.VECTOR_URL;
+});

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -25,6 +25,49 @@ import { localNativeVectorDisabledReason, logLocalVectorDisabled } from '../vect
 // remote service; on remote failure we fall back to FTS5-only.
 const vectorProxy = createVectorProxy(VECTOR_URL);
 
+
+const FTS_TOKEN_LIMIT = 8;
+
+/**
+ * Convert natural-language input into a punctuation-safe FTS5 MATCH query.
+ *
+ * SQLite FTS5 treats punctuation such as '.', ',', ':' or parentheses as query
+ * syntax. Instead of maintaining a brittle blocklist, strip anything that is
+ * not a unicode letter/number/underscore into token boundaries, quote every
+ * token, and OR the terms. OR avoids the default implicit-AND behavior that
+ * made multi-word recall queries overly strict.
+ */
+export function buildFtsQuery(query: string): string {
+  const tokens = query
+    .replace(/<[^>]*>/g, ' ')
+    .normalize('NFKC')
+    .match(/[\p{L}\p{N}_]+/gu)
+    ?.map((token) => token.trim())
+    .filter((token) => token.length > 0)
+    .slice(0, FTS_TOKEN_LIMIT) ?? [];
+
+  const uniqueTokens = Array.from(new Set(tokens));
+  return uniqueTokens.map((token) => `"${token.replace(/"/g, '""')}"`).join(' OR ');
+}
+
+function runFtsGet<T>(stmt: { get: (...args: any[]) => T }, args: unknown[]): T | null {
+  try {
+    return stmt.get(...args);
+  } catch (error) {
+    console.warn('[FTS5] MATCH query failed; degrading to empty keyword leg:', error instanceof Error ? error.message : String(error));
+    return null;
+  }
+}
+
+function runFtsAll<T>(stmt: { all: (...args: any[]) => T[] }, args: unknown[]): T[] {
+  try {
+    return stmt.all(...args);
+  } catch (error) {
+    console.warn('[FTS5] MATCH query failed; degrading to empty keyword leg:', error instanceof Error ? error.message : String(error));
+    return [];
+  }
+}
+
 /**
  * LanceDB is configured for cosine distance, where nearest-neighbor distances
  * are in the 0..2 range: 0 means identical, 2 means opposite. Convert that
@@ -53,13 +96,8 @@ export async function handleSearch(
   // Auto-detect project from cwd if not explicitly specified
   const resolvedProject = (project ?? detectProject(cwd))?.toLowerCase() ?? null;
   const startTime = Date.now();
-  // Remove FTS5 special characters and HTML: ? * + - ( ) ^ ~ " ' : < > { } [ ] ; / \
-  const safeQuery = query
-    .replace(/<[^>]*>/g, ' ')           // Strip HTML tags
-    .replace(/[?*+\-()^~"':;<>{}[\]\\\/]/g, ' ')  // Strip FTS5 + SQL special chars
-    .replace(/\s+/g, ' ')
-    .trim();
-  if (!safeQuery) {
+  const ftsQuery = buildFtsQuery(query);
+  if (!ftsQuery) {
     return { results: [], total: 0, limit, offset, query };
   }
 
@@ -101,7 +139,7 @@ export async function handleSearch(
         JOIN oracle_documents d ON f.id = d.id
         WHERE oracle_fts MATCH ? AND ${projectFilter}
       `);
-      ftsTotal = (countStmt.get(safeQuery, ...projectParams) as { total: number }).total;
+      ftsTotal = (runFtsGet(countStmt, [ftsQuery, ...projectParams]) as { total: number } | null)?.total ?? 0;
 
       const stmt = sqlite.prepare(`
         SELECT f.id, f.content, d.type, d.source_file, d.concepts, d.project, rank as score
@@ -111,7 +149,7 @@ export async function handleSearch(
         ORDER BY rank
         LIMIT ?
       `);
-      ftsResults = stmt.all(safeQuery, ...projectParams, limit * 2).map((row: any) => ({
+      ftsResults = runFtsAll<any>(stmt, [ftsQuery, ...projectParams, limit * 3]).map((row: any) => ({
         id: row.id,
         type: row.type,
         content: row.content,
@@ -128,7 +166,7 @@ export async function handleSearch(
         JOIN oracle_documents d ON f.id = d.id
         WHERE oracle_fts MATCH ? AND d.type = ? AND ${projectFilter}
       `);
-      ftsTotal = (countStmt.get(safeQuery, type, ...projectParams) as { total: number }).total;
+      ftsTotal = (runFtsGet(countStmt, [ftsQuery, type, ...projectParams]) as { total: number } | null)?.total ?? 0;
 
       const stmt = sqlite.prepare(`
         SELECT f.id, f.content, d.type, d.source_file, d.concepts, d.project, rank as score
@@ -138,7 +176,7 @@ export async function handleSearch(
         ORDER BY rank
         LIMIT ?
       `);
-      ftsResults = stmt.all(safeQuery, type, ...projectParams, limit * 2).map((row: any) => ({
+      ftsResults = runFtsAll<any>(stmt, [ftsQuery, type, ...projectParams, limit * 3]).map((row: any) => ({
         id: row.id,
         type: row.type,
         content: row.content,
@@ -314,36 +352,47 @@ function normalizeRank(rank: number): number {
 }
 
 /**
- * Combine FTS and vector results with hybrid scoring
+ * Combine FTS and vector results with rank-fusion hybrid scoring.
+ *
+ * Raw FTS rank and vector similarity are not calibrated to the same scale. Use
+ * each leg's normalized score plus reciprocal rank, then boost overlap. This
+ * keeps strong keyword-only hits visible while still letting semantic-only
+ * vector hits fill gaps in natural-language recall.
  */
 function combineSearchResults(fts: SearchResult[], vector: SearchResult[]): SearchResult[] {
   const seen = new Map<string, SearchResult>();
 
-  // Add FTS results first
-  for (const r of fts) {
-    seen.set(r.id, r);
-  }
+  const addScore = (base: number | undefined, rank: number, scoreWeight: number, rankWeight: number) => {
+    const score = Math.max(0, Math.min(1, base ?? 0));
+    return score * scoreWeight + (1 / (rank + 1)) * rankWeight;
+  };
 
-  // Merge vector results (boost score if found in both)
-  for (const r of vector) {
-    if (seen.has(r.id)) {
-      const existing = seen.get(r.id)!;
-      // Use max score + bonus for appearing in both (hybrid boost)
-      const maxScore = Math.max(existing.score || 0, r.score || 0);
-      const bonus = 0.1; // Bonus for appearing in both FTS and vector
+  fts.forEach((r, index) => {
+    seen.set(r.id, {
+      ...r,
+      score: addScore(r.score, index, 0.7, 0.3),
+    });
+  });
+
+  vector.forEach((r, index) => {
+    const vectorScore = addScore(r.score, index, 0.65, 0.35);
+    const existing = seen.get(r.id);
+    if (existing) {
       seen.set(r.id, {
         ...existing,
-        score: Math.min(1, maxScore + bonus), // Cap at 1.0
+        score: Math.min(1, (existing.score || 0) + vectorScore + 0.12),
         source: 'hybrid' as const,
         distance: r.distance,
-        model: r.model
+        model: r.model,
       });
     } else {
-      seen.set(r.id, r);
+      seen.set(r.id, {
+        ...r,
+        score: vectorScore,
+      });
     }
-  }
+  });
 
-  // Sort by score descending
   return Array.from(seen.values()).sort((a, b) => (b.score || 0) - (a.score || 0));
 }
 

--- a/src/tools/__tests__/search.test.ts
+++ b/src/tools/__tests__/search.test.ts
@@ -17,40 +17,40 @@ import {
 
 describe('sanitizeFtsQuery', () => {
   it('should remove FTS5 special characters', () => {
-    expect(sanitizeFtsQuery('hello?')).toBe('hello');
-    expect(sanitizeFtsQuery('test*')).toBe('test');
-    expect(sanitizeFtsQuery('a + b')).toBe('a b');
-    expect(sanitizeFtsQuery('NOT this')).toBe('NOT this');
+    expect(sanitizeFtsQuery('hello?')).toBe('\"hello\"');
+    expect(sanitizeFtsQuery('test*')).toBe('\"test\"');
+    expect(sanitizeFtsQuery('a + b')).toBe('\"a\" OR \"b\"');
+    expect(sanitizeFtsQuery('NOT this')).toBe('\"NOT\" OR \"this\"');
   });
 
   it('should handle quotes', () => {
-    expect(sanitizeFtsQuery('"exact phrase"')).toBe('exact phrase');
-    expect(sanitizeFtsQuery("it's a test")).toBe('it s a test');
+    expect(sanitizeFtsQuery('\"exact phrase\"')).toBe('\"exact\" OR \"phrase\"');
+    expect(sanitizeFtsQuery("it's a test")).toBe('\"it\" OR \"s\" OR \"a\" OR \"test\"');
   });
 
   it('should normalize whitespace', () => {
-    expect(sanitizeFtsQuery('  hello   world  ')).toBe('hello world');
-    expect(sanitizeFtsQuery('a  b  c')).toBe('a b c');
+    expect(sanitizeFtsQuery('  hello   world  ')).toBe('\"hello\" OR \"world\"');
+    expect(sanitizeFtsQuery('a  b  c')).toBe('\"a\" OR \"b\" OR \"c\"');
   });
 
-  it('should handle empty result by returning original', () => {
-    expect(sanitizeFtsQuery('???')).toBe('???');
-    expect(sanitizeFtsQuery('***')).toBe('***');
+  it('should return empty when no searchable tokens remain', () => {
+    expect(sanitizeFtsQuery('???')).toBe('');
+    expect(sanitizeFtsQuery('***')).toBe('');
   });
 
   it('should preserve valid queries', () => {
-    expect(sanitizeFtsQuery('oracle philosophy')).toBe('oracle philosophy');
-    expect(sanitizeFtsQuery('git safety')).toBe('git safety');
+    expect(sanitizeFtsQuery('oracle philosophy')).toBe('\"oracle\" OR \"philosophy\"');
+    expect(sanitizeFtsQuery('git safety')).toBe('\"git\" OR \"safety\"');
   });
 
   it('should handle colons which break FTS5', () => {
-    expect(sanitizeFtsQuery('error: no such column')).toBe('error no such column');
-    expect(sanitizeFtsQuery('time: 15:30')).toBe('time 15 30');
+    expect(sanitizeFtsQuery('error: no such column')).toBe('\"error\" OR \"no\" OR \"such\" OR \"column\"');
+    expect(sanitizeFtsQuery('time: 15:30')).toBe('\"time\" OR \"15\" OR \"30\"');
   });
 
   it('should handle forward slashes which break FTS5', () => {
-    expect(sanitizeFtsQuery('Shopee/Lazada/TikTok')).toBe('Shopee Lazada TikTok');
-    expect(sanitizeFtsQuery('path/to/file')).toBe('path to file');
+    expect(sanitizeFtsQuery('Shopee/Lazada/TikTok')).toBe('\"Shopee\" OR \"Lazada\" OR \"TikTok\"');
+    expect(sanitizeFtsQuery('path/to/file')).toBe('\"path\" OR \"to\" OR \"file\"');
   });
 });
 

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -79,21 +79,16 @@ export const searchToolDef = {
  * Removes FTS5 special characters that cause syntax errors.
  */
 export function sanitizeFtsQuery(query: string): string {
-  // Strip FTS5 special chars + SQL-comment / statement-terminator chars that
-  // can leak as raw FTS5 parser errors (e.g. ';' or '--' in user input).
-  let sanitized = query
-    .replace(/[?*+()^~"':.\/;,!=<>{}\[\]\\|&]/g, ' ')
-    .replace(/--+/g, ' ')   // collapse consecutive dashes (SQL comment)
-    .replace(/-+/g, ' ')    // and any remaining dashes (FTS5 prefix-NOT)
-    .replace(/\s+/g, ' ')
-    .trim();
+  const tokens = query
+    .replace(/<[^>]*>/g, ' ')
+    .normalize('NFKC')
+    .match(/[\p{L}\p{N}_]+/gu)
+    ?.map((token) => token.trim())
+    .filter((token) => token.length > 0)
+    .slice(0, 8) ?? [];
 
-  if (!sanitized) {
-    console.error('[FTS5] Query became empty after sanitization:', query);
-    return query;
-  }
-
-  return sanitized;
+  const uniqueTokens = Array.from(new Set(tokens));
+  return uniqueTokens.map((token) => `"${token.replace(/"/g, '""')}"`).join(' OR ');
 }
 
 /**
@@ -345,27 +340,34 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
 
   // Run FTS5 search (skip if vector-only mode)
   let ftsRawResults: any[] = [];
-  if (mode !== 'vector') {
-    if (type === 'all') {
-      const stmt = ctx.sqlite.prepare(`
-        SELECT f.id, f.content, d.type, d.source_file, d.concepts, rank
-        FROM oracle_fts f
-        JOIN oracle_documents d ON f.id = d.id
-        WHERE oracle_fts MATCH ? ${projectFilter}
-        ORDER BY rank
-        LIMIT ?
-      `);
-      ftsRawResults = stmt.all(safeQuery, ...projectParams, limit * 2);
-    } else {
-      const stmt = ctx.sqlite.prepare(`
-        SELECT f.id, f.content, d.type, d.source_file, d.concepts, rank
-        FROM oracle_fts f
-        JOIN oracle_documents d ON f.id = d.id
-        WHERE oracle_fts MATCH ? AND d.type = ? ${projectFilter}
-        ORDER BY rank
-        LIMIT ?
-      `);
-      ftsRawResults = stmt.all(safeQuery, type, ...projectParams, limit * 2);
+  if (mode !== 'vector' && safeQuery) {
+    try {
+      if (type === 'all') {
+        const stmt = ctx.sqlite.prepare(`
+          SELECT f.id, f.content, d.type, d.source_file, d.concepts, rank
+          FROM oracle_fts f
+          JOIN oracle_documents d ON f.id = d.id
+          WHERE oracle_fts MATCH ? ${projectFilter}
+          ORDER BY rank
+          LIMIT ?
+        `);
+        ftsRawResults = stmt.all(safeQuery, ...projectParams, limit * 3);
+      } else {
+        const stmt = ctx.sqlite.prepare(`
+          SELECT f.id, f.content, d.type, d.source_file, d.concepts, rank
+          FROM oracle_fts f
+          JOIN oracle_documents d ON f.id = d.id
+          WHERE oracle_fts MATCH ? AND d.type = ? ${projectFilter}
+          ORDER BY rank
+          LIMIT ?
+        `);
+        ftsRawResults = stmt.all(safeQuery, type, ...projectParams, limit * 3);
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      warning = `FTS5 keyword search unavailable: ${errorMessage}`;
+      console.error('[FTS5]', errorMessage);
+      ftsRawResults = [];
     }
   }
 


### PR DESCRIPTION
## Summary
- Rebased #1314 on latest `origin/main` after #1366/#1367 and kept the FTS leg gated by `effectiveMode`.
- Replaced unsafe FTS5 blocklist sanitizing with quoted token OR queries for both HTTP `handleSearch` and MCP `oracle_search`.
- Wrapped FTS `MATCH` reads so malformed/unexpected FTS errors degrade to an empty keyword leg instead of HTTP 400.
- Tuned hybrid merge with rank-aware overlap fusion and a wider FTS candidate leg so keyword/vector results combine better.

## Gold eval / regression corpus
Added `src/server/__tests__/search-fts-query.test.ts` with a tiny corpus:

| Query | Expected behavior |
| --- | --- |
| `foo.bar, baz (now)!` | no FTS syntax throw; returns punctuation doc |
| `alphaonly1314 betaonly1314` | OR-style NL recall returns alpha-only, beta-only, and overlap docs |
| sanitizer parity | HTTP/MCP builders emit quoted OR terms, e.g. `"foo" OR "bar"` |

## Validation
- `bun run test:unit` (292 pass)
- `bun run build`
- `git diff --check`

Closes #1314
