### PR TITLE
Config: filter MCP tools from tools/list

### DIFF
--- a/src/__tests__/tool-list-filter.test.ts
+++ b/src/__tests__/tool-list-filter.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+import { filterAdvertisedTools } from '../index.ts';
+
+describe('filterAdvertisedTools', () => {
+  const tools = [
+    { name: '____IMPORTANT' },
+    { name: 'oracle_search' },
+    { name: 'oracle_learn' },
+    { name: 'oracle_trace_get' },
+  ];
+
+  test('hides disabled MCP tools from tools/list output', () => {
+    const listed = filterAdvertisedTools(tools, new Set(['oracle_learn', 'oracle_trace_get']));
+    const names = listed.map((t) => t.name);
+
+    expect(names).toContain('oracle_search');
+    expect(names).not.toContain('oracle_learn');
+    expect(names).not.toContain('oracle_trace_get');
+  });
+
+  test('can hide the meta guide tool for strict allow-lists', () => {
+    const listed = filterAdvertisedTools(tools, new Set(['____IMPORTANT', 'oracle_learn', 'oracle_trace_get']));
+    expect(listed.map((t) => t.name)).toEqual(['oracle_search']);
+  });
+});

--- a/src/config/__tests__/tool-groups.test.ts
+++ b/src/config/__tests__/tool-groups.test.ts
@@ -5,6 +5,8 @@ import path from 'path';
 import {
   TOOL_GROUPS,
   getDisabledTools,
+  getEnabledToolNames,
+  normalizeToolName,
   loadToolGroupConfig,
   watchToolGroupConfig,
   type ToolGroupConfig,
@@ -91,6 +93,63 @@ describe('tool-groups', () => {
     // Typos didn't leak in
     expect(disabled.has('typo_search')).toBe(false);
     expect(disabled.has('also_typo')).toBe(false);
+  });
+
+
+  it('normalizes legacy arra_* and muninn_* aliases in per-tool config', () => {
+    expect(normalizeToolName('arra_search')).toBe('oracle_search');
+    expect(normalizeToolName('muninn_trace_get')).toBe('oracle_trace_get');
+
+    const disabled = getDisabledTools({
+      search: true, knowledge: true, session: true,
+      forum: true, trace: true, standalone: true,
+      disabled_tools: ['arra_search', 'muninn_trace_get'],
+    });
+
+    expect(disabled.has('oracle_search')).toBe(true);
+    expect(disabled.has('oracle_trace_get')).toBe(true);
+  });
+
+  it('allowed_tools is a strict MCP tool allow-list for context reduction', () => {
+    const enabled = getEnabledToolNames({
+      search: true, knowledge: true, session: true,
+      forum: true, trace: true, standalone: true,
+      allowed_tools: ['arra_search', 'muninn_trace_get'],
+    });
+
+    expect(enabled).toEqual(new Set(['oracle_search', 'oracle_trace_get']));
+  });
+
+  it('ORACLE_ENABLED_TOOLS and ORACLE_DISABLED_TOOLS load env tool filters', () => {
+    const oldEnabled = process.env.ORACLE_ENABLED_TOOLS;
+    const oldDisabled = process.env.ORACLE_DISABLED_TOOLS;
+    try {
+      process.env.ORACLE_ENABLED_TOOLS = 'arra_search, muninn_trace_get';
+      process.env.ORACLE_DISABLED_TOOLS = 'oracle_trace_get';
+      const config = loadToolGroupConfig('/nonexistent/path');
+      expect(config.allowed_tools).toEqual(['oracle_search', 'oracle_trace_get']);
+      expect(config.disabled_tools).toEqual(['oracle_trace_get']);
+      const enabled = getEnabledToolNames(config);
+      expect(enabled).toEqual(new Set(['oracle_search']));
+    } finally {
+      if (oldEnabled === undefined) delete process.env.ORACLE_ENABLED_TOOLS;
+      else process.env.ORACLE_ENABLED_TOOLS = oldEnabled;
+      if (oldDisabled === undefined) delete process.env.ORACLE_DISABLED_TOOLS;
+      else process.env.ORACLE_DISABLED_TOOLS = oldDisabled;
+    }
+  });
+
+  it('loads MCP tool filters from repo .arra/config.json', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-toolgroups-dotarra-'));
+    try {
+      fs.mkdirSync(path.join(dir, '.arra'));
+      fs.writeFileSync(path.join(dir, '.arra', 'config.json'), JSON.stringify({ allowed_tools: ['muninn_search'] }));
+      const config = loadToolGroupConfig(dir);
+      expect(config.allowed_tools).toEqual(['oracle_search']);
+      expect(getEnabledToolNames(config)).toEqual(new Set(['oracle_search']));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('defaults to all groups enabled', () => {

--- a/src/config/tool-groups.ts
+++ b/src/config/tool-groups.ts
@@ -3,14 +3,17 @@
  *
  * Controls which tool groups are registered at startup.
  * Config sources (in priority order):
- *   1. arra.config.json in repo root (ORACLE_REPO_ROOT or cwd)
- *   2. ORACLE_DATA_DIR/config.json (global, see const.ts)
- *   3. Defaults: all groups enabled
+ *   1. ORACLE_ENABLED_TOOLS / ORACLE_DISABLED_TOOLS env lists
+ *   2. arra.config.json or .arra/config.json in repo root (ORACLE_REPO_ROOT or cwd)
+ *   3. ORACLE_DATA_DIR/config.json (global, see const.ts)
+ *   4. Defaults: all groups enabled
  */
 
 import fs from 'fs';
 import path from 'path';
 import { ORACLE_DATA_DIR } from '../config.ts';
+
+export const META_TOOL_NAME = '____IMPORTANT';
 
 export const TOOL_GROUPS = {
   search: ['oracle_search', 'oracle_read', 'oracle_list', 'oracle_concepts'],
@@ -36,7 +39,10 @@ export type ToolGroupName = keyof typeof TOOL_GROUPS;
  */
 export type ToolGroupConfig = Record<ToolGroupName, boolean> & {
   disabled_tools?: string[];
+  /** Legacy override: re-enables listed tools after group/disabled_tools processing. */
   enabled_tools?: string[];
+  /** Strict allow-list: when present, every other MCP tool is hidden from tools/list and calls. */
+  allowed_tools?: string[];
 };
 
 const DEFAULT_CONFIG: ToolGroupConfig = {
@@ -49,9 +55,34 @@ const DEFAULT_CONFIG: ToolGroupConfig = {
 };
 
 /** All registered tool names — for validating disabled_tools / enabled_tools entries. */
-const ALL_TOOL_NAMES: ReadonlySet<string> = new Set(
-  Object.values(TOOL_GROUPS).flat() as string[],
-);
+const ALIAS_PREFIXES = ['arra_', 'muninn_'] as const;
+
+export function normalizeToolName(name: string): string {
+  for (const p of ALIAS_PREFIXES) {
+    if (name.startsWith(p)) return 'oracle_' + name.slice(p.length);
+  }
+  return name;
+}
+
+const ALL_TOOL_NAMES: ReadonlySet<string> = new Set([
+  META_TOOL_NAME,
+  ...(Object.values(TOOL_GROUPS).flat() as string[]),
+]);
+
+function parseToolList(raw: string | undefined): string[] {
+  if (!raw?.trim()) return [];
+  return raw
+    .split(/[\s,]+/)
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
+
+function normalizeToolList(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  return raw
+    .filter((t: unknown): t is string => typeof t === 'string')
+    .map(normalizeToolName);
+}
 
 function readJsonSafe(filePath: string): Record<string, any> | null {
   try {
@@ -62,30 +93,59 @@ function readJsonSafe(filePath: string): Record<string, any> | null {
   }
 }
 
+function hasToolConfig(raw: Record<string, any>): boolean {
+  return Boolean(
+    raw.tools ||
+      raw.disabled_tools ||
+      raw.enabled_tools ||
+      raw.allowed_tools ||
+      raw.only_tools ||
+      raw.mcp_disabled_tools ||
+      raw.mcp_enabled_tools ||
+      raw.mcp_allowed_tools
+  );
+}
+
 function mergeRaw(raw: Record<string, any>): ToolGroupConfig {
   const merged: ToolGroupConfig = { ...DEFAULT_CONFIG, ...raw.tools };
-  if (Array.isArray(raw.disabled_tools)) {
-    merged.disabled_tools = raw.disabled_tools.filter((t: unknown) => typeof t === 'string');
-  }
-  if (Array.isArray(raw.enabled_tools)) {
-    merged.enabled_tools = raw.enabled_tools.filter((t: unknown) => typeof t === 'string');
-  }
+  const disabled = normalizeToolList(raw.disabled_tools ?? raw.mcp_disabled_tools);
+  if (disabled) merged.disabled_tools = disabled;
+  const enabled = normalizeToolList(raw.enabled_tools ?? raw.mcp_enabled_tools);
+  if (enabled) merged.enabled_tools = enabled;
+  const allowed = normalizeToolList(raw.allowed_tools ?? raw.only_tools ?? raw.mcp_allowed_tools);
+  if (allowed) merged.allowed_tools = allowed;
   return merged;
 }
 
 export function loadToolGroupConfig(repoRoot?: string): ToolGroupConfig {
   const root = repoRoot || process.env.ORACLE_REPO_ROOT || process.cwd();
 
-  // Priority 1: repo-local arra.config.json
-  const localConfig = readJsonSafe(path.join(root, 'arra.config.json'));
-  if (localConfig && (localConfig.tools || localConfig.disabled_tools || localConfig.enabled_tools)) {
-    console.error('[ToolGroups] Using arra.config.json from repo root');
-    return mergeRaw(localConfig);
+  const envAllowed = parseToolList(process.env.ORACLE_ENABLED_TOOLS).map(normalizeToolName);
+  const envDisabled = parseToolList(process.env.ORACLE_DISABLED_TOOLS).map(normalizeToolName);
+  if (envAllowed.length || envDisabled.length) {
+    console.error('[ToolGroups] Using ORACLE_ENABLED_TOOLS / ORACLE_DISABLED_TOOLS');
+    return {
+      ...DEFAULT_CONFIG,
+      ...(envAllowed.length ? { allowed_tools: envAllowed } : {}),
+      ...(envDisabled.length ? { disabled_tools: envDisabled } : {}),
+    };
+  }
+
+  // Priority 1: repo-local arra.config.json or .arra/config.json
+  for (const [label, filePath] of [
+    ['arra.config.json from repo root', path.join(root, 'arra.config.json')],
+    ['.arra/config.json from repo root', path.join(root, '.arra', 'config.json')],
+  ] as const) {
+    const localConfig = readJsonSafe(filePath);
+    if (localConfig && hasToolConfig(localConfig)) {
+      console.error(`[ToolGroups] Using ${label}`);
+      return mergeRaw(localConfig);
+    }
   }
 
   // Priority 2: global config.json in data dir
   const globalConfig = readJsonSafe(path.join(ORACLE_DATA_DIR, 'config.json'));
-  if (globalConfig && (globalConfig.tools || globalConfig.disabled_tools || globalConfig.enabled_tools)) {
+  if (globalConfig && hasToolConfig(globalConfig)) {
     console.error(`[ToolGroups] Using ${ORACLE_DATA_DIR}/config.json`);
     return mergeRaw(globalConfig);
   }
@@ -114,21 +174,42 @@ export function getDisabledTools(config: ToolGroupConfig): Set<string> {
       }
     }
   }
-  for (const t of config.disabled_tools ?? []) {
+  for (const raw of config.disabled_tools ?? []) {
+    const t = normalizeToolName(raw);
     if (!ALL_TOOL_NAMES.has(t)) {
       console.error(`[ToolGroups] disabled_tools: unknown tool "${t}" — ignored`);
       continue;
     }
     disabled.add(t);
   }
-  for (const t of config.enabled_tools ?? []) {
+  for (const raw of config.enabled_tools ?? []) {
+    const t = normalizeToolName(raw);
     if (!ALL_TOOL_NAMES.has(t)) {
       console.error(`[ToolGroups] enabled_tools: unknown tool "${t}" — ignored`);
       continue;
     }
     disabled.delete(t);
   }
+  if (config.allowed_tools?.length) {
+    const allowed = new Set<string>();
+    for (const raw of config.allowed_tools) {
+      const t = normalizeToolName(raw);
+      if (!ALL_TOOL_NAMES.has(t)) {
+        console.error(`[ToolGroups] allowed_tools: unknown tool "${raw}" — ignored`);
+        continue;
+      }
+      allowed.add(t);
+    }
+    for (const t of ALL_TOOL_NAMES) {
+      if (!allowed.has(t)) disabled.add(t);
+    }
+  }
   return disabled;
+}
+
+export function getEnabledToolNames(config: ToolGroupConfig): Set<string> {
+  const disabled = getDisabledTools(config);
+  return new Set([...ALL_TOOL_NAMES].filter((t) => !disabled.has(t)));
 }
 
 /**
@@ -147,6 +228,7 @@ export function watchToolGroupConfig(
 ): () => void {
   const root = repoRoot || process.env.ORACLE_REPO_ROOT || process.cwd();
   const localPath = path.join(root, 'arra.config.json');
+  const dotArraPath = path.join(root, '.arra', 'config.json');
   const globalPath = path.join(ORACLE_DATA_DIR, 'config.json');
   const watchers: fs.FSWatcher[] = [];
   let timer: ReturnType<typeof setTimeout> | null = null;
@@ -165,7 +247,7 @@ export function watchToolGroupConfig(
     }, 200);
   };
 
-  for (const target of [localPath, globalPath]) {
+  for (const target of [localPath, dotArraPath, globalPath]) {
     try {
       // Watch the file directly. fs.watch on a missing file throws on Linux
       // and silently fails on macOS, so probe with existsSync first.

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,17 @@ const WRITE_TOOLS = [
   'oracle_handoff',
 ];
 
+
+export function filterAdvertisedTools<T extends { name: string }>(
+  tools: T[],
+  disabledTools: Set<string>,
+  readOnly = false,
+): T[] {
+  return tools
+    .filter((t) => !disabledTools.has(t.name))
+    .filter((t) => !(readOnly && WRITE_TOOLS.includes(t.name)));
+}
+
 const DEFAULT_ORACLE_API = 'http://localhost:47778';
 const EMBEDDED_API_VALUES = new Set(['embedded', 'embed', 'off', 'none', 'false', '0']);
 
@@ -499,10 +510,7 @@ class OracleMCPServer {
         verifyToolDef,
       ];
 
-      let tools = allTools.filter(t => !this.disabledTools.has(t.name));
-      if (this.readOnly) {
-        tools = tools.filter(t => !WRITE_TOOLS.includes(t.name));
-      }
+      const tools = filterAdvertisedTools(allTools, this.disabledTools, this.readOnly);
 
       return { tools };
     });
@@ -674,4 +682,6 @@ async function main() {
   await server.run();
 }
 
-main().catch(console.error);
+if (import.meta.main) {
+  main().catch(console.error);
+}


### PR DESCRIPTION
## Summary
- add strict MCP tool allow/disallow filtering via `ORACLE_ENABLED_TOOLS` and `ORACLE_DISABLED_TOOLS`
- support repo `.arra/config.json` tool filters in addition to existing `arra.config.json` / data-dir config
- normalize configured legacy aliases (`arra_*`, `muninn_*`) to canonical `oracle_*`
- hide disabled tools from `tools/list` and reject disabled calls, preserving default all-tools behavior
- add an import-safe entrypoint guard so tool-list helpers can be unit-tested without starting stdio

## Config examples
```json
{
  "allowed_tools": ["oracle_search", "muninn_trace_get"],
  "disabled_tools": ["arra_learn"]
}
```

```bash
ORACLE_ENABLED_TOOLS=oracle_search,muninn_trace_get \
ORACLE_DISABLED_TOOLS=oracle_learn \
  bun src/index.ts
```

## Verification
- `bun run build`
- `bun test src/__tests__/resolve-tool-name.test.ts src/__tests__/tool-list-filter.test.ts src/config/__tests__/tool-groups.test.ts`
- `git diff --check`

Relates to #950
Closes #1372
