### PR TITLE
Restore /api/peers in federation plugin

### DIFF
--- a/src/peer/peer-query.ts
+++ b/src/peer/peer-query.ts
@@ -1,0 +1,48 @@
+import { loadNamedPeers, type NamedPeers } from './peer-registry.ts';
+import { PeerPubkeyMismatch, pinPeerPubkey, type PinStatus } from './peer-tofu.ts';
+
+export interface PeerStatus {
+  name: string;
+  url: string;
+  ok: boolean;
+  node?: string;
+  oracle?: string;
+  pubkey?: string;
+  pinStatus?: PinStatus;
+  capabilities?: string[];
+  error?: string;
+}
+
+async function fetchJson(url: string): Promise<any> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return res.json();
+}
+
+export async function probePeer(name: string, url: string): Promise<PeerStatus> {
+  const base = url.replace(/\/+$/, '');
+  try {
+    const info = await fetchJson(`${base}/info`);
+    if (info?.maw?.schema !== '1') throw new Error('missing maw schema 1');
+    const identity = await fetchJson(`${base}/api/identity`);
+    if (!identity?.node || !/^[0-9a-f]{64}$/i.test(identity?.pubkey ?? '')) throw new Error('invalid identity');
+    const pubkey = String(identity.pubkey).toLowerCase();
+    return {
+      name,
+      url: base,
+      ok: true,
+      node: String(identity.node),
+      oracle: typeof identity.oracle === 'string' ? identity.oracle : info.oracle,
+      pubkey,
+      pinStatus: pinPeerPubkey(name, pubkey),
+      capabilities: Array.isArray(info?.maw?.capabilities) ? info.maw.capabilities : [],
+    };
+  } catch (error) {
+    if (error instanceof PeerPubkeyMismatch) return { name, url: base, ok: false, error: 'MISMATCH', pubkey: error.actual };
+    return { name, url: base, ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export async function listPeerStatuses(peers: NamedPeers = loadNamedPeers()): Promise<PeerStatus[]> {
+  return Promise.all(Object.entries(peers).map(([name, url]) => probePeer(name, url)));
+}

--- a/src/peer/peer-registry.ts
+++ b/src/peer/peer-registry.ts
@@ -1,0 +1,27 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { ORACLE_DATA_DIR } from '../config.ts';
+
+export type NamedPeers = Record<string, string>;
+
+function normalize(raw: unknown): NamedPeers {
+  const source = raw && typeof raw === 'object' && 'namedPeers' in raw
+    ? (raw as { namedPeers?: unknown }).namedPeers
+    : raw;
+  if (!source || typeof source !== 'object') return {};
+  const peers: NamedPeers = {};
+  for (const [name, value] of Object.entries(source as Record<string, unknown>)) {
+    if (typeof value !== 'string') continue;
+    const url = value.trim().replace(/\/+$/, '');
+    if (/^https?:\/\//.test(url)) peers[name] = url;
+  }
+  return peers;
+}
+
+export function loadNamedPeers(configPath = process.env.ARRA_PEERS_CONFIG || join(ORACLE_DATA_DIR, 'peers.json')): NamedPeers {
+  const envPeers = process.env.ARRA_NAMED_PEERS?.trim();
+  if (envPeers) return normalize(JSON.parse(envPeers));
+  if (!existsSync(configPath)) return {};
+  return normalize(JSON.parse(readFileSync(configPath, 'utf8')));
+}

--- a/src/peer/peer-tofu.ts
+++ b/src/peer/peer-tofu.ts
@@ -1,0 +1,37 @@
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { ORACLE_DATA_DIR } from '../config.ts';
+
+export type PinStatus = 'new' | 'pinned';
+
+export class PeerPubkeyMismatch extends Error {
+  constructor(public peer: string, public expected: string, public actual: string) {
+    super(`Peer pubkey mismatch for ${peer}`);
+    this.name = 'PeerPubkeyMismatch';
+  }
+}
+
+function defaultPinPath() { return process.env.ARRA_PEERS_TOFU_PATH || join(ORACLE_DATA_DIR, 'peers-tofu.json'); }
+function readPins(path = defaultPinPath()): Record<string, string> {
+  if (!existsSync(path)) return {};
+  return JSON.parse(readFileSync(path, 'utf8')) as Record<string, string>;
+}
+function writePins(pins: Record<string, string>, path = defaultPinPath()) {
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  writeFileSync(path, `${JSON.stringify(pins, null, 2)}\n`, { mode: 0o600 });
+  try { chmodSync(path, 0o600); } catch {}
+}
+
+export function pinPeerPubkey(peer: string, pubkey: string, path = defaultPinPath()): PinStatus {
+  if (!/^[0-9a-f]{64}$/i.test(pubkey)) throw new Error('Invalid peer pubkey');
+  const pins = readPins(path);
+  const actual = pubkey.toLowerCase();
+  if (!pins[peer]) {
+    pins[peer] = actual;
+    writePins(pins, path);
+    return 'new';
+  }
+  if (pins[peer] !== actual) throw new PeerPubkeyMismatch(peer, pins[peer], actual);
+  return 'pinned';
+}

--- a/src/routes/peer/index.ts
+++ b/src/routes/peer/index.ts
@@ -2,7 +2,9 @@ import { Elysia } from 'elysia';
 
 import { peerInfoRoute } from './info.ts';
 import { peerIdentityRoute } from './identity.ts';
+import { peerListRoute } from './peers.ts';
 
 export const peerRoutes = new Elysia()
   .use(peerInfoRoute)
-  .use(peerIdentityRoute);
+  .use(peerIdentityRoute)
+  .use(peerListRoute);

--- a/src/routes/peer/peers.ts
+++ b/src/routes/peer/peers.ts
@@ -1,0 +1,13 @@
+import { Elysia } from 'elysia';
+
+import { listPeerStatuses } from '../../peer/peer-query.ts';
+
+export const peerListRoute = new Elysia().get('/api/peers', async () => ({
+  peers: await listPeerStatuses(),
+}), {
+  detail: {
+    tags: ['peer'],
+    menu: { group: 'hidden' },
+    summary: 'Probe configured maw federation peers with TOFU pins',
+  },
+});

--- a/src/server/__tests__/server-plugin-loader.test.ts
+++ b/src/server/__tests__/server-plugin-loader.test.ts
@@ -182,6 +182,10 @@ describe('server plugin loader', () => {
     expect(identityBody.pubkey).toMatch(/^[0-9a-f]{64}$/);
     expect(identityBody.node).toStartWith('arra@');
     expect(identityBody.oracle).toBe('arra');
+
+    const peers = await app.handle(new Request('http://local/api/peers'));
+    expect(peers.status).toBe(200);
+    expect(await peers.json()).toEqual({ peers: [] });
   });
 
   test('api manifest mounts a built-in example plugin under its declared path', async () => {


### PR DESCRIPTION
## Summary

Re-verified #1347 on current `main` before editing:

- `/info` => 200
- `/api/identity` => 200
- `/api/peers` => 404
- `/api/feed` => 200
- `/api/search?q=oracle` => 200

Root cause: the server-plugin migration kept the federation plugin mounted, but `src/routes/peer/index.ts` only composed `/info` and `/api/identity`; `/api/peers` was missing from the federation route bundle.

Fix:

- Adds `GET /api/peers` back to `peerRoutes`
- Loads named peers from `ARRA_NAMED_PEERS` or `$ORACLE_DATA_DIR/peers.json`
- Probes `/info` + `/api/identity` and TOFU-pins peer pubkeys
- Extends the federation plugin contract test to assert `/api/peers` returns 200

Closes #1347

## Verification

Live smoke on current main + this branch with `ORACLE_ENABLED_PLUGINS=federation`:

```text
commit=c2c648e port=54560
--- /info HTTP 200
{"maw":{"schema":"1","capabilities":["arra-search"]},"node":"arra@m5","oracle":"arra",...}
--- /api/identity HTTP 200
{"pubkey":"0b43474029b29c263c78149b7b096046a2f24135edb25a98b32f16623f8d1ff0","node":"arra@m5","oracle":"arra",...}
--- /api/peers HTTP 200
{"peers":[]}
--- /api/feed HTTP 200
{"events":[],"total":0,"active_oracles":[]}
--- /api/search?q=oracle HTTP 200
{"results":[],"total":0,"offset":0,"limit":10,"mode":"hybrid","vectorAvailable":true,"query":"oracle"}
```

Commands:

- `bun run build`
- `bun test src/server/__tests__/peer-identity.test.ts src/server/__tests__/scout-announcer.test.ts src/server/__tests__/server-plugin-loader.test.ts`
