### PR TITLE
Keep existing studio search on HTTP FTS

### DIFF
--- a/web/src/lib/backend.ts
+++ b/web/src/lib/backend.ts
@@ -271,7 +271,12 @@ export class RealBackend implements BackendClient {
   }
 
   async search(query: string): Promise<SearchResult[]> {
-    return this.post("arra_search", { query });
+    const response = await this.get<{ results: SearchResult[] }>("/api/search", {
+      q: query,
+      mode: "fts",
+      limit: 20,
+    });
+    return response.results;
   }
 
   async learn(pattern: string, concepts?: string[], source?: string): Promise<Learning> {
@@ -279,7 +284,12 @@ export class RealBackend implements BackendClient {
   }
 
   async list(type?: string, limit?: number): Promise<SearchResult[]> {
-    return this.post("arra_list", { type, limit });
+    const response = await this.get<{ results: SearchResult[] }>("/api/list", {
+      type: type ?? "all",
+      limit: limit ?? 20,
+      group: "false",
+    });
+    return response.results;
   }
 
   async trace(query: string): Promise<TraceResult> {
@@ -364,11 +374,11 @@ export function createBackendClient(): BackendClient {
   const envUrl = import.meta.env.PUBLIC_BACKEND_URL;
   if (envUrl) return new RealBackend(envUrl);
 
-  // Check ?api= query param in browser context
+  // Check ?api= query param or persisted home-page connection in browser context
   if (typeof window !== "undefined") {
     const params = new URLSearchParams(window.location.search);
-    const apiUrl = params.get("api");
-    if (apiUrl) return new RealBackend(apiUrl);
+    const apiUrl = params.get("api") || window.localStorage.getItem("NEO_ARRA_API");
+    if (apiUrl) return new RealBackend(apiUrl.replace(/\/+$/, ""));
   }
 
   return new MockBackend();


### PR DESCRIPTION
## Summary
- Kept the existing web/oracle-studio search page; no UI rebuild.
- Pointed the existing frontend backend client at the already-available HTTP endpoints:
  - search → `GET /api/search?mode=fts`
  - browse/list → `GET /api/list`
- Made the client reuse the home-page `NEO_ARRA_API` connection so `/search` keeps talking to the selected backend after navigating away from `/?api=...`.

## Findings / receipt
- Existing backend exposes Scalar `/swagger` at `/swagger` and raw spec at `/swagger/json` per `docs/SWAGGER-DEPLOY.md`.
- Existing `web/src/pages/search.astro` was already present; the only break was its client used MCP-style `/api/arra_search`, not the HTTP API route.
- Smoke with a fresh learned doc returned FTS results without vector indexing.
- Browser smoke captured the existing `/search` UI calling `http://127.0.0.1:47778/api/search?q=issue1371unique&mode=fts&limit=20` and rendering the result.

## Validation
- `bun run build`
- `cd web && bun install && bun run build`
- `GET /api/health` smoke
- `POST /api/learn` smoke seed
- `GET /api/search?q=issue1371unique&mode=fts&limit=5` smoke
- Playwright browser smoke for existing `/search` UI

Closes #1371
