### PR TITLE
Allow zero-config FTS start without vector index

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ curl -sSL https://raw.githubusercontent.com/Soul-Brews-Studio/arra-oracle-v3/mai
 | Problem | Fix |
 |---------|-----|
 | `bun: command not found` | `export PATH="$HOME/.bun/bin:$PATH"` |
-| LanceDB hangs/timeout | Skip it — SQLite FTS5 works fine without vectors |
-| Server crashes on empty DB | Run `bun run index` first to index knowledge base |
+| LanceDB missing/hangs/timeout | Skip it — SQLite FTS5 works fine without vectors |
+| Fresh install has no index yet | Start the server anyway; FTS search returns empty results and vector/hybrid modes degrade to FTS until vectors are indexed |
 
 </details>
 

--- a/src/integration/zero-config-start.test.ts
+++ b/src/integration/zero-config-start.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Zero-config start integration coverage (#1370).
+ *
+ * A fresh install should boot and answer FTS-backed search requests before any
+ * vector DB/index has been created. Vector/hybrid requests quietly degrade to
+ * FTS instead of opening/creating LanceDB during request handling.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import type { Subprocess } from 'bun';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import net from 'node:net';
+
+let serverProcess: Subprocess | null = null;
+let tmpRoot = '';
+let baseUrl = '';
+
+async function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+async function waitForServer(maxAttempts = 40): Promise<void> {
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      const res = await fetch(`${baseUrl}/api/health`);
+      if (res.ok) return;
+    } catch {
+      // Server not ready yet.
+    }
+    await Bun.sleep(250);
+  }
+  throw new Error('zero-config test server failed to start');
+}
+
+async function getJson(pathname: string): Promise<{ res: Response; data: any }> {
+  const res = await fetch(`${baseUrl}${pathname}`);
+  const data = await res.json();
+  return { res, data };
+}
+
+describe('zero-config start without vector index', () => {
+  beforeAll(async () => {
+    const repoRoot = path.resolve(import.meta.dir, '../..');
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-zero-config-'));
+    const dataDir = path.join(tmpRoot, 'data');
+    const repoDataRoot = path.join(tmpRoot, 'empty-repo');
+    fs.mkdirSync(repoDataRoot, { recursive: true });
+
+    const port = await getFreePort();
+    baseUrl = `http://127.0.0.1:${port}`;
+
+    const env = {
+      ...process.env,
+      ORACLE_PORT: String(port),
+      ORACLE_DATA_DIR: dataDir,
+      ORACLE_DB_PATH: path.join(dataDir, 'oracle.db'),
+      ORACLE_REPO_ROOT: repoDataRoot,
+      ORACLE_VECTOR_DB: 'lancedb',
+      ORACLE_CHROMA_TIMEOUT: '1000',
+      ORACLE_VECTOR_HEALTH_TIMEOUT: '1000',
+      VECTOR_URL: '',
+    };
+
+    serverProcess = Bun.spawn(['bun', 'run', 'src/server.ts'], {
+      cwd: repoRoot,
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env,
+    });
+
+    await waitForServer();
+  }, 20_000);
+
+  afterAll(() => {
+    serverProcess?.kill();
+    serverProcess = null;
+    if (tmpRoot) fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  test('boots fresh and serves FTS search without creating a vector index', async () => {
+    const health = await getJson('/api/health');
+    expect(health.res.ok).toBe(true);
+    expect(health.data.status).toBe('ok');
+
+    const stats = await getJson('/api/stats');
+    expect(stats.res.ok).toBe(true);
+    expect(typeof stats.data.total).toBe('number');
+
+    const fts = await getJson('/api/search?q=zero-config&mode=fts');
+    expect(fts.res.ok).toBe(true);
+    expect(Array.isArray(fts.data.results)).toBe(true);
+    expect(fts.data).not.toHaveProperty('vectorAvailable');
+
+    const lancedbDir = path.join(tmpRoot, 'data', 'lancedb');
+    expect(fs.existsSync(lancedbDir)).toBe(false);
+  }, 15_000);
+
+  test('quietly degrades hybrid and vector modes to FTS when vector index is absent', async () => {
+    for (const mode of ['hybrid', 'vector'] as const) {
+      const { res, data } = await getJson(`/api/search?q=zero-config&mode=${mode}`);
+      expect(res.ok).toBe(true);
+      expect(Array.isArray(data.results)).toBe(true);
+      expect(data.mode).toBe(mode);
+      expect(data.vectorAvailable).toBe(false);
+      expect(data).not.toHaveProperty('warning');
+    }
+
+    const lancedbDir = path.join(tmpRoot, 'data', 'lancedb');
+    expect(fs.existsSync(lancedbDir)).toBe(false);
+  }, 15_000);
+});

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -17,7 +17,7 @@ import { detectProject } from './project-detect.ts';
 import { coerceConcepts } from '../tools/learn.ts';
 import { createVectorProxy } from './vector-proxy.ts';
 import { buildLearningMarkdown, dateSlug } from '../learn/markdown.ts';
-import { localNativeVectorDisabledReason, logLocalVectorDisabled } from '../vector/cpu-capabilities.ts';
+import { localNativeVectorDisabledReason, localVectorIndexMissingReason, logLocalVectorDisabled } from '../vector/cpu-capabilities.ts';
 
 // Module-level proxy instance — bound to VECTOR_URL at boot. If VECTOR_URL is
 // unset, this is null and the local vector adapter runs in-process (legacy
@@ -105,17 +105,22 @@ export async function handleSearch(
   const requestedMode = mode;
   let effectiveMode = mode;
   let vectorDisabledReason: string | undefined;
+  let vectorIndexMissingReason: string | undefined;
   if (mode !== 'fts' && !vectorProxy) {
     const modelsToCheck = model === 'multi' ? ['bge-m3', 'nomic'] : [model];
     for (const modelKey of modelsToCheck) {
       const cfg = getVectorStoreConfigByModel(modelKey);
       vectorDisabledReason = localNativeVectorDisabledReason(cfg.type);
       if (vectorDisabledReason) break;
+      vectorIndexMissingReason = localVectorIndexMissingReason(cfg);
+      if (vectorIndexMissingReason) break;
     }
     if (vectorDisabledReason) {
       effectiveMode = 'fts';
       warning = `${vectorDisabledReason}; falling back to FTS5-only results`;
       logLocalVectorDisabled(vectorDisabledReason);
+    } else if (vectorIndexMissingReason) {
+      effectiveMode = 'fts';
     }
   }
 
@@ -196,7 +201,7 @@ export async function handleSearch(
   // (vector wasn't asked for), flips to `false` if the proxy is enabled and
   // the remote call failed — clients use this to render a "vector down" hint
   // while still getting FTS5 results.
-  let vectorAvailable = !vectorDisabledReason;
+  let vectorAvailable = !vectorDisabledReason && !vectorIndexMissingReason;
 
   // VECTOR_URL set → route the vector leg through the remote service.
   // FTS5 always runs locally above. If the proxy fails we return whatever FTS5

--- a/src/server/vector-handlers.ts
+++ b/src/server/vector-handlers.ts
@@ -22,9 +22,11 @@ import {
   ensureVectorStoreConnected,
   getVectorStoreByModel,
   getEmbeddingModels,
+  getVectorStoreConfigByModel,
   EMBEDDING_MODELS,
 } from '../vector/factory.ts';
 import type { VectorStoreAdapter } from '../vector/types.ts';
+import { localNativeVectorDisabledReason, localVectorIndexMissingReason } from '../vector/cpu-capabilities.ts';
 import type { SearchResult } from './types.ts';
 
 /** Convenience wrapper used by every handler in this file. */
@@ -619,6 +621,12 @@ export async function handleVectorStats(): Promise<{
   await Promise.all(
     Object.entries(models).map(async ([key, preset]) => {
       try {
+        const cfg = getVectorStoreConfigByModel(key);
+        const unavailable = localNativeVectorDisabledReason(cfg.type) || localVectorIndexMissingReason(cfg);
+        if (unavailable) {
+          engines.push({ key, model: preset.model, collection: preset.collection, count: 0, enabled: false });
+          return;
+        }
         const store = await ensureVectorStoreConnected(key);
         const stats = await Promise.race([
           store.getStats(),
@@ -669,6 +677,12 @@ export async function handleVectorHealth(): Promise<{
   await Promise.all(
     Object.entries(models).map(async ([key, preset]) => {
       try {
+        const cfg = getVectorStoreConfigByModel(key);
+        const unavailable = localNativeVectorDisabledReason(cfg.type) || localVectorIndexMissingReason(cfg);
+        if (unavailable) {
+          engines.push({ key, model: preset.model, collection: preset.collection, ok: false, error: unavailable });
+          return;
+        }
         const store = await ensureVectorStoreConnected(key);
         await Promise.race([
           store.getStats(),

--- a/src/vector/cpu-capabilities.ts
+++ b/src/vector/cpu-capabilities.ts
@@ -53,6 +53,29 @@ export function localNativeVectorDisabledReason(adapter: string | undefined = pr
   return undefined;
 }
 
+export interface LocalVectorIndexConfig {
+  type?: string;
+  dataPath?: string;
+  collectionName?: string;
+}
+
+export function localVectorIndexMissingReason(config: LocalVectorIndexConfig): string | undefined {
+  const type = config.type || process.env.ORACLE_VECTOR_DB || 'lancedb';
+  if (type === 'lancedb') {
+    const dataPath = config.dataPath;
+    const collectionName = config.collectionName;
+    if (!dataPath || !fs.existsSync(dataPath)) return 'local LanceDB directory is missing';
+    if (collectionName && !fs.existsSync(`${dataPath}/${collectionName}.lance`)) {
+      return `local LanceDB collection is missing (${collectionName})`;
+    }
+  }
+  if (type === 'sqlite-vec') {
+    const dataPath = config.dataPath;
+    if (!dataPath || !fs.existsSync(dataPath)) return 'local sqlite-vec database is missing';
+  }
+  return undefined;
+}
+
 export function logLocalVectorDisabled(reason: string): void {
   if (loggedDisable) return;
   loggedDisable = true;


### PR DESCRIPTION
## Summary
- Detect missing local LanceDB/sqlite-vec vector indexes before opening native adapters.
- Quietly degrade `mode=hybrid`/`mode=vector` search to FTS when no local vector index exists, while preserving #1322 CPU warnings for AVX/native failures.
- Keep vector stats/health from bootstrapping missing local vector collections during fresh starts.
- Document fresh-install behavior and add a zero-config integration test for boot + FTS search with no vector DB/index.

Closes #1370

## Verification
- `bun run build`
- `bun test --isolate src/integration/zero-config-start.test.ts src/server/__tests__/search-no-avx-fallback.test.ts`
- `bun run test:integration` (157 pass, 65 skip; local untracked agent worktrees also present but not committed)
