### PR TITLE
Index detected psi folders into FTS

### DIFF
--- a/src/indexer/__tests__/psi-fts-index.test.ts
+++ b/src/indexer/__tests__/psi-fts-index.test.ts
@@ -1,0 +1,69 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-psi-fts-'));
+const dataDir = path.join(tmp, 'data');
+const repoRoot = path.join(tmp, 'vault-root');
+const psiRoot = path.join(repoRoot, 'ψ');
+const learningDir = path.join(psiRoot, 'memory', 'learnings');
+fs.mkdirSync(learningDir, { recursive: true });
+fs.writeFileSync(path.join(learningDir, '2026-06-07_psi-detect.md'), `---
+tags: [psi-detect, onboarding]
+---
+
+ψ folder detection should feed FTS-only onboarding search without vector indexing.
+`);
+
+const originalDataDir = process.env.ORACLE_DATA_DIR;
+const originalDbPath = process.env.ORACLE_DB_PATH;
+const originalRepoRoot = process.env.ORACLE_REPO_ROOT;
+process.env.ORACLE_DATA_DIR = dataDir;
+process.env.ORACLE_DB_PATH = path.join(dataDir, 'oracle.db');
+delete process.env.ORACLE_REPO_ROOT;
+
+const { normalizeIndexerRepoRoot, runOracleReindex } = await import('../runner.ts');
+const { createDatabase, closeDb } = await import('../../db/index.ts');
+
+describe('ψ-folder detection → FTS indexing', () => {
+  afterAll(() => {
+    try { closeDb(); } catch {}
+    fs.rmSync(tmp, { recursive: true, force: true });
+    if (originalDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+    else process.env.ORACLE_DATA_DIR = originalDataDir;
+    if (originalDbPath === undefined) delete process.env.ORACLE_DB_PATH;
+    else process.env.ORACLE_DB_PATH = originalDbPath;
+    if (originalRepoRoot === undefined) delete process.env.ORACLE_REPO_ROOT;
+    else process.env.ORACLE_REPO_ROOT = originalRepoRoot;
+  });
+
+  test('normalizes an explicit ψ path to its repo root', () => {
+    expect(normalizeIndexerRepoRoot(psiRoot)).toBe(repoRoot);
+  });
+
+  test('indexes an explicit ψ folder into SQLite FTS without vector setup', async () => {
+    const result = await runOracleReindex({ repoRoot: psiRoot });
+    expect(result.ok).toBe(true);
+    expect(result.repoRoot).toBe(repoRoot);
+
+    const { sqlite } = createDatabase(process.env.ORACLE_DB_PATH);
+    try {
+      const row = sqlite.prepare(`
+        SELECT d.source_file, f.content
+        FROM oracle_documents d
+        JOIN oracle_fts f ON f.id = d.id
+        WHERE oracle_fts MATCH 'onboarding'
+        LIMIT 1
+      `).get() as { source_file: string; content: string } | undefined;
+
+      expect(row).toBeTruthy();
+      expect(row?.source_file).toBe('ψ/memory/learnings/2026-06-07_psi-detect.md');
+      expect(row?.content).toContain('FTS-only onboarding search');
+    } finally {
+      sqlite.close();
+    }
+
+    expect(fs.existsSync(path.join(dataDir, 'lancedb'))).toBe(false);
+  });
+});

--- a/src/indexer/runner.ts
+++ b/src/indexer/runner.ts
@@ -16,9 +16,17 @@ import { OracleIndexer } from './index.ts';
 const scriptDir = import.meta.dirname || path.dirname(new URL(import.meta.url).pathname);
 const projectRoot = path.resolve(scriptDir, '..', '..');
 
+export function normalizeIndexerRepoRoot(root: string): string {
+  const resolved = path.resolve(root);
+  if (path.basename(resolved) === '\u03c8' && fs.existsSync(path.join(resolved, 'memory'))) {
+    return path.dirname(resolved);
+  }
+  return resolved;
+}
+
 export function resolveIndexerRepoRoot(explicitRoot?: string | null): string {
-  if (explicitRoot?.trim()) return path.resolve(explicitRoot);
-  if (process.env.ORACLE_REPO_ROOT?.trim()) return path.resolve(process.env.ORACLE_REPO_ROOT);
+  if (explicitRoot?.trim()) return normalizeIndexerRepoRoot(explicitRoot);
+  if (process.env.ORACLE_REPO_ROOT?.trim()) return normalizeIndexerRepoRoot(process.env.ORACLE_REPO_ROOT);
 
   const vaultResult = getVaultPsiRoot();
   const vaultRoot = 'path' in vaultResult ? vaultResult.path : null;

--- a/src/routes/indexer/__tests__/scan.test.ts
+++ b/src/routes/indexer/__tests__/scan.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { scanEndpoint } from '../scan.ts';
+
+function post(app: Elysia, body: unknown) {
+  return app.handle(new Request('http://localhost/indexer/scan', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+}
+
+describe('POST /indexer/scan', () => {
+  test('detects an explicit ψ folder and recommends FTS reindex', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-scan-psi-'));
+    try {
+      const psiRoot = path.join(tmp, 'ψ');
+      fs.mkdirSync(path.join(psiRoot, 'memory', 'learnings'), { recursive: true });
+      fs.writeFileSync(path.join(psiRoot, 'memory', 'learnings', 'scan.md'), '# scan psi folder\n');
+      const app = new Elysia().use(scanEndpoint);
+
+      const res = await post(app, { sourcePath: psiRoot });
+      const body = await res.json() as any;
+
+      expect(res.status).toBe(200);
+      expect(body.psiDetected).toBe(true);
+      expect(body.repoRoot).toBe(tmp);
+      expect(body.psiPath).toBe(psiRoot);
+      expect(body.canIndexFts).toBe(true);
+      expect(body.recommendedAction).toBe('POST /api/indexer/reindex');
+      expect(body.total).toBe(1);
+      expect(body.byType.learning).toBe(1);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/routes/indexer/scan.ts
+++ b/src/routes/indexer/scan.ts
@@ -2,19 +2,23 @@ import { Elysia, t } from 'elysia';
 import fs from 'fs';
 import path from 'path';
 import { getAllMarkdownFiles } from '../../indexer/collectors.ts';
+import { normalizeIndexerRepoRoot, resolveIndexerRepoRoot } from '../../indexer/runner.ts';
 
 export const scanEndpoint = new Elysia().post('/indexer/scan', async ({ body }) => {
-  const { sourcePath, types } = body;
+  const { sourcePath, types } = body ?? {};
+  const repoRoot = sourcePath ? normalizeIndexerRepoRoot(sourcePath) : resolveIndexerRepoRoot();
+  const psiPath = path.join(repoRoot, '\u03c8');
+  const scanPath = fs.existsSync(psiPath) ? psiPath : repoRoot;
 
-  if (!fs.existsSync(sourcePath)) {
-    return { error: `Path not found: ${sourcePath}`, files: [], total: 0, byType: {} };
+  if (!fs.existsSync(scanPath)) {
+    return { error: `Path not found: ${scanPath}`, files: [], total: 0, byType: {}, repoRoot, psiDetected: false };
   }
 
-  const allFiles = getAllMarkdownFiles(sourcePath);
+  const allFiles = getAllMarkdownFiles(scanPath);
 
   const files = allFiles.map(filePath => {
     const stat = fs.statSync(filePath);
-    const rel = path.relative(sourcePath, filePath);
+    const rel = path.relative(scanPath, filePath);
 
     let type = 'unknown';
     if (rel.includes('distillations') || rel.includes('distillation')) type = 'distillation';
@@ -40,12 +44,21 @@ export const scanEndpoint = new Elysia().post('/indexer/scan', async ({ body }) 
     byType[f.type] = (byType[f.type] || 0) + 1;
   }
 
-  return { files: filtered, total: filtered.length, byType };
+  return {
+    files: filtered,
+    total: filtered.length,
+    byType,
+    repoRoot,
+    psiPath: fs.existsSync(psiPath) ? psiPath : null,
+    psiDetected: fs.existsSync(psiPath),
+    canIndexFts: fs.existsSync(psiPath) && filtered.length > 0,
+    recommendedAction: fs.existsSync(psiPath) && filtered.length > 0 ? 'POST /api/indexer/reindex' : null,
+  };
 }, {
-  body: t.Object({
-    sourcePath: t.String(),
+  body: t.Optional(t.Object({
+    sourcePath: t.Optional(t.String()),
     types: t.Optional(t.Array(t.String())),
-  }),
+  })),
   detail: {
     tags: ['indexer'],
     summary: 'Scan directory for .md files',


### PR DESCRIPTION
## Summary
- Normalize explicit `ψ` source paths to their repo root so the existing path/github collectors can index them.
- Extend `/api/indexer/scan` to auto-detect ψ folders, report `psiDetected`, `canIndexFts`, and recommend `POST /api/indexer/reindex` when markdown is present.
- Add FTS-only regression coverage proving a fresh ψ vault indexes into SQLite/FTS without creating LanceDB/vector state.

Closes #1375

## Verification
- `bun run build`
- `bun test --isolate src/indexer/__tests__/ src/routes/indexer/__tests__/ src/integration/zero-config-start.test.ts`
