### PR TITLE
Add token connect page with MCP install snippets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -134,10 +134,16 @@ function resolveOracleApiBase(): string | null {
   return trimmed.replace(/\/+$/, '');
 }
 
+function oracleApiHeaders(init?: RequestInit["headers"]): RequestInit["headers"] | undefined {
+  const token = process.env.ARRA_API_TOKEN?.trim() || process.env.NEO_ARRA_API_TOKEN?.trim();
+  if (!token) return init;
+  return { ...(init as Record<string, string> | undefined), Authorization: `Bearer ${token}` };
+}
+
 async function oracleApiFetch(baseUrl: string, apiPath: string, opts?: RequestInit): Promise<Response> {
   const url = `${baseUrl}${apiPath}`;
   try {
-    return await fetch(url, opts);
+    return await fetch(url, { ...opts, headers: oracleApiHeaders(opts?.headers) });
   } catch (err) {
     throw new OracleApiUnavailableError(baseUrl, err);
   }

--- a/src/tools/__tests__/mcp-learn-proxy.test.ts
+++ b/src/tools/__tests__/mcp-learn-proxy.test.ts
@@ -59,6 +59,7 @@ test('oracle_learn proxies through ORACLE_API without opening the MCP DB', async
       ORACLE_DB_PATH: join(serverDataDir, 'oracle.db'),
       ORACLE_REPO_ROOT: serverRepoRoot,
       ORACLE_INDEXER_ENQUEUE: '0',
+      ARRA_API_TOKEN: 'proxy-secret',
     },
   });
   childProcesses.push(server);
@@ -73,6 +74,7 @@ test('oracle_learn proxies through ORACLE_API without opening the MCP DB', async
       ORACLE_DATA_DIR: mcpDataDir,
       ORACLE_DB_PATH: mcpDbPath,
       ORACLE_INDEXER_ENQUEUE: '0',
+      ARRA_API_TOKEN: 'proxy-secret',
     },
     stderr: 'pipe',
   });

--- a/web/src/lib/backend.ts
+++ b/web/src/lib/backend.ts
@@ -245,13 +245,24 @@ export class MockBackend implements BackendClient {
   }
 }
 
+function storedApiToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return window.localStorage.getItem("ARRA_API_TOKEN") || window.localStorage.getItem("NEO_ARRA_API_TOKEN");
+}
+
 export class RealBackend implements BackendClient {
-  constructor(private baseUrl: string) {}
+  constructor(private baseUrl: string, private token: string | null = storedApiToken()) {}
+
+  private headers(init?: HeadersInit): HeadersInit {
+    return this.token
+      ? { ...(init as Record<string, string> | undefined), Authorization: `Bearer ${this.token}` }
+      : (init ?? {});
+  }
 
   private async post<T>(tool: string, args: Record<string, unknown>): Promise<T> {
     const res = await fetch(`${this.baseUrl}/api/${tool}`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: this.headers({ "Content-Type": "application/json" }),
       body: JSON.stringify(args),
     });
     if (!res.ok) throw new Error(`Backend error ${res.status}: ${await res.text()}`);
@@ -265,7 +276,7 @@ export class RealBackend implements BackendClient {
           .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
           .join("&")
       : "";
-    const res = await fetch(`${this.baseUrl}${path}${qs}`);
+    const res = await fetch(`${this.baseUrl}${path}${qs}`, { headers: this.headers() });
     if (!res.ok) throw new Error(`Backend error ${res.status}: ${await res.text()}`);
     return res.json() as Promise<T>;
   }
@@ -319,7 +330,7 @@ export class RealBackend implements BackendClient {
   async consult(q: string, threadId?: number): Promise<ConsultResponse> {
     const res = await fetch(`${this.baseUrl}/api/thread`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: this.headers({ "Content-Type": "application/json" }),
       body: JSON.stringify({ message: q, thread_id: threadId, role: "human" }),
     });
     if (!res.ok) throw new Error(`Backend error ${res.status}: ${await res.text()}`);

--- a/web/src/pages/connect.astro
+++ b/web/src/pages/connect.astro
@@ -1,0 +1,133 @@
+---
+import Base from "../layouts/Base.astro";
+---
+
+<Base title="Connect + MCP install | Neo ARRA V3">
+  <main class="max-w-4xl mx-auto px-6 py-16">
+    <a href="/" class="text-gray-500 hover:text-teal-300 text-sm transition-colors">← home</a>
+    <div class="mt-4 mb-10">
+      <p class="text-sm font-mono text-teal-400 mb-2">Deploy-prep credential helper</p>
+      <h1 class="text-5xl font-bold tracking-tight mb-4">Connect token + MCP install</h1>
+      <p class="text-gray-400 text-lg max-w-2xl">
+        Store your backend URL and optional <code class="text-teal-300">ARRA_API_TOKEN</code> in this browser,
+        then copy a Claude MCP install command/config that points at the same protected HTTP API.
+      </p>
+    </div>
+
+    <section class="grid gap-6 lg:grid-cols-[1fr_1fr]">
+      <div class="bg-gray-900/80 border border-gray-800 rounded-xl p-6 space-y-5">
+        <div>
+          <h2 class="text-xl font-semibold mb-2">1. Browser connection</h2>
+          <p class="text-gray-500 text-sm">Saved locally only. Leave token empty when the server has no <code>ARRA_API_TOKEN</code>.</p>
+        </div>
+        <label class="block">
+          <span class="text-sm text-gray-300">Backend URL</span>
+          <input id="api-url" class="mt-1 w-full bg-black/50 border border-gray-700 rounded-lg px-3 py-2 font-mono text-sm text-gray-100 focus:outline-none focus:border-teal-500" value="http://localhost:47778" />
+        </label>
+        <label class="block">
+          <span class="text-sm text-gray-300">ARRA_API_TOKEN</span>
+          <input id="api-token" type="password" class="mt-1 w-full bg-black/50 border border-gray-700 rounded-lg px-3 py-2 font-mono text-sm text-gray-100 focus:outline-none focus:border-teal-500" placeholder="paste token or generate one" />
+        </label>
+        <div class="flex flex-wrap gap-3">
+          <button id="generate-token" class="bg-gray-800 hover:bg-gray-700 text-gray-200 px-4 py-2 rounded-lg text-sm transition-colors">Generate token</button>
+          <button id="save-token" class="bg-teal-500 hover:bg-teal-400 text-gray-950 font-semibold px-4 py-2 rounded-lg text-sm transition-colors">Save connection</button>
+          <button id="clear-token" class="bg-gray-800 hover:bg-gray-700 text-gray-300 px-4 py-2 rounded-lg text-sm transition-colors">Clear</button>
+        </div>
+        <div id="status" class="text-sm text-gray-500">Not checked yet.</div>
+      </div>
+
+      <div class="bg-gray-900/80 border border-gray-800 rounded-xl p-6 space-y-5">
+        <div>
+          <h2 class="text-xl font-semibold mb-2">2. Server env</h2>
+          <p class="text-gray-500 text-sm">Set this on your HTTP server when you want the deploy gate enabled.</p>
+        </div>
+        <div class="relative">
+          <pre class="bg-black/60 border border-gray-800 rounded-lg p-4 overflow-x-auto text-sm text-teal-300 font-mono"><code id="env-snippet">ARRA_API_TOKEN=...</code></pre>
+          <button data-copy-target="env-snippet" class="copy-btn absolute top-2 right-2 text-xs bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-teal-300 px-3 py-1 rounded transition-colors">copy</button>
+        </div>
+        <p class="text-xs text-gray-500">The app never provisions server secrets remotely; generated tokens are shown so you can copy them into your deploy environment.</p>
+      </div>
+    </section>
+
+    <section class="mt-6 bg-gray-900/80 border border-gray-800 rounded-xl p-6 space-y-5">
+      <div>
+        <h2 class="text-xl font-semibold mb-2">3. Claude MCP install snippet</h2>
+        <p class="text-gray-500 text-sm">Copy one of these into your terminal or Claude config. Token is included only if provided.</p>
+      </div>
+      <div class="relative">
+        <pre class="bg-black/60 border border-gray-800 rounded-lg p-4 overflow-x-auto text-sm text-teal-300 font-mono"><code id="claude-snippet"></code></pre>
+        <button data-copy-target="claude-snippet" class="copy-btn absolute top-2 right-2 text-xs bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-teal-300 px-3 py-1 rounded transition-colors">copy</button>
+      </div>
+      <details class="group">
+        <summary class="cursor-pointer text-sm text-gray-400 hover:text-gray-200">Show JSON config</summary>
+        <div class="relative mt-3">
+          <pre class="bg-black/60 border border-gray-800 rounded-lg p-4 overflow-x-auto text-sm text-teal-300 font-mono"><code id="json-snippet"></code></pre>
+          <button data-copy-target="json-snippet" class="copy-btn absolute top-2 right-2 text-xs bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-teal-300 px-3 py-1 rounded transition-colors">copy</button>
+        </div>
+      </details>
+    </section>
+  </main>
+
+  <script>
+    const apiInput = document.getElementById("api-url") as HTMLInputElement;
+    const tokenInput = document.getElementById("api-token") as HTMLInputElement;
+    const status = document.getElementById("status") as HTMLDivElement;
+    const envSnippet = document.getElementById("env-snippet") as HTMLElement;
+    const claudeSnippet = document.getElementById("claude-snippet") as HTMLElement;
+    const jsonSnippet = document.getElementById("json-snippet") as HTMLElement;
+
+    function shellQuote(value: string) {
+      return `'${value.replaceAll("'", "'\\''")}'`;
+    }
+    function generateToken() {
+      const bytes = new Uint8Array(24);
+      crypto.getRandomValues(bytes);
+      return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+    }
+    function currentApi() { return (apiInput.value || "http://localhost:47778").replace(/\/+$/, ""); }
+    function currentToken() { return tokenInput.value.trim(); }
+    function renderSnippets() {
+      const api = currentApi();
+      const token = currentToken();
+      envSnippet.textContent = token ? `ARRA_API_TOKEN=${token}` : "# optional: ARRA_API_TOKEN=<your-token>";
+      const envParts = [`ORACLE_API=${shellQuote(api)}`];
+      if (token) envParts.push(`ARRA_API_TOKEN=${shellQuote(token)}`);
+      claudeSnippet.textContent = `claude mcp add arra-oracle-v3 --env ${envParts.join(" --env ")} -- bunx --bun arra-oracle-v3@github:Soul-Brews-Studio/arra-oracle-v3`;
+      jsonSnippet.textContent = JSON.stringify({ mcpServers: { "arra-oracle-v3": { command: "bunx", args: ["--bun", "arra-oracle-v3@github:Soul-Brews-Studio/arra-oracle-v3"], env: token ? { ORACLE_API: api, ARRA_API_TOKEN: token } : { ORACLE_API: api } } } }, null, 2);
+    }
+    async function saveAndCheck() {
+      const api = currentApi();
+      const token = currentToken();
+      localStorage.setItem("NEO_ARRA_API", api);
+      if (token) { localStorage.setItem("ARRA_API_TOKEN", token); localStorage.setItem("NEO_ARRA_API_TOKEN", token); }
+      else { localStorage.removeItem("ARRA_API_TOKEN"); localStorage.removeItem("NEO_ARRA_API_TOKEN"); }
+      renderSnippets();
+      status.textContent = "checking /api/health…";
+      status.className = "text-sm text-amber-300";
+      try {
+        const res = await fetch(`${api}/api/health`, token ? { headers: { Authorization: `Bearer ${token}` } } : undefined);
+        status.textContent = res.ok ? `saved ✓ backend reachable (${res.status})` : `saved, but backend returned ${res.status}`;
+        status.className = res.ok ? "text-sm text-teal-300" : "text-sm text-amber-300";
+      } catch (err) {
+        status.textContent = `saved locally; backend unreachable (${err instanceof Error ? err.message : String(err)})`;
+        status.className = "text-sm text-red-300";
+      }
+    }
+    apiInput.value = new URLSearchParams(window.location.search).get("api") || localStorage.getItem("NEO_ARRA_API") || apiInput.value;
+    tokenInput.value = localStorage.getItem("ARRA_API_TOKEN") || localStorage.getItem("NEO_ARRA_API_TOKEN") || "";
+    renderSnippets();
+    apiInput.addEventListener("input", renderSnippets);
+    tokenInput.addEventListener("input", renderSnippets);
+    document.getElementById("generate-token")?.addEventListener("click", () => { tokenInput.value = generateToken(); renderSnippets(); });
+    document.getElementById("save-token")?.addEventListener("click", saveAndCheck);
+    document.getElementById("clear-token")?.addEventListener("click", () => { tokenInput.value = ""; localStorage.removeItem("ARRA_API_TOKEN"); localStorage.removeItem("NEO_ARRA_API_TOKEN"); renderSnippets(); status.textContent = "token cleared locally"; status.className = "text-sm text-gray-500"; });
+    document.querySelectorAll<HTMLButtonElement>(".copy-btn[data-copy-target]").forEach((btn) => {
+      btn.addEventListener("click", async () => {
+        const target = document.getElementById(btn.dataset.copyTarget || "");
+        const text = target?.textContent || "";
+        try { await navigator.clipboard.writeText(text); btn.textContent = "copied ✓"; setTimeout(() => btn.textContent = "copy", 1200); }
+        catch { btn.textContent = "select + copy"; }
+      });
+    });
+  </script>
+</Base>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -5,6 +5,7 @@ const CARDS = [
   { href: "/search", title: "Search", body: "Hybrid semantic + keyword over your Oracle memory." },
   { href: "/learn", title: "Learn", body: "Ingest documents and URLs into your knowledge base." },
   { href: "/tools", title: "Tools", body: "Browse all 22 MCP tools — trace, concepts, stats…" },
+  { href: "/connect", title: "Connect", body: "Save ARRA_API_TOKEN and copy Claude MCP install snippets." },
   { href: "/canvas/", title: "Canvas", body: "Three.js host with pluggable ESM modules — cube, galaxy, torus." },
 ];
 
@@ -29,10 +30,10 @@ const INSTALL = [
       </p>
       <div id="connect-ui">
         <a
-          href="/?api=http://localhost:47778"
+          href="/connect?api=http://localhost:47778"
           class="inline-block bg-teal-500 hover:bg-teal-400 text-gray-950 font-semibold px-8 py-3 rounded-lg transition-colors ring-1 ring-teal-400/40 hover:ring-teal-300/70 shadow-lg shadow-teal-500/20"
         >
-          Connect to localhost
+          Connect / token setup
         </a>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Lean Tier-2 onboarding pass for token-gated deploys:

- Adds `/connect` web page for backend URL + optional `ARRA_API_TOKEN`
- Generates a browser-local token and server env snippet (`ARRA_API_TOKEN=...`)
- Generates copyable `claude mcp add ...` command and JSON config snippets
- Stores `NEO_ARRA_API` + `ARRA_API_TOKEN` locally so Studio pages can call #53-protected APIs
- Adds `ARRA_API_TOKEN` forwarding to the MCP stdio HTTP proxy (`ORACLE_API`) so copied MCP snippets work against token-gated HTTP servers
- Links home “Connect” CTA/card to `/connect`

This intentionally does not implement a full remote credential provisioning/install flow; generated tokens are displayed for operators to copy into deploy env/config.

Closes #1374

## Verification

- `bun run build`
- `cd web && bun run build`
- `bun test src/tools/__tests__/mcp-learn-proxy.test.ts`
