### PR TITLE
Make MCP method toggles visible and persistent

### DIFF
--- a/src/routes/settings/index.ts
+++ b/src/routes/settings/index.ts
@@ -2,6 +2,7 @@ import { Elysia } from 'elysia';
 import { SESSION_COOKIE_NAME, isAuthenticated } from '../auth/index.ts';
 import { getSettingsRoute } from './get.ts';
 import { updateSettingsRoute } from './update.ts';
+import { toolSettingsRoute } from './tools.ts';
 
 export const settingsRoutes = new Elysia({ prefix: '/api/settings' })
   .onBeforeHandle(({ server, request, cookie, set }) => {
@@ -12,6 +13,7 @@ export const settingsRoutes = new Elysia({ prefix: '/api/settings' })
     }
   })
   .use(getSettingsRoute)
-  .use(updateSettingsRoute);
+  .use(updateSettingsRoute)
+  .use(toolSettingsRoute);
 
 export * from './model.ts';

--- a/src/routes/settings/tools.ts
+++ b/src/routes/settings/tools.ts
@@ -1,0 +1,84 @@
+import fs from 'fs';
+import path from 'path';
+import { Elysia, t } from 'elysia';
+import { REPO_ROOT } from '../../config.ts';
+import {
+  TOOL_GROUPS,
+  getEnabledToolNames,
+  loadToolGroupConfig,
+  normalizeToolName,
+  type ToolGroupName,
+} from '../../config/tool-groups.ts';
+
+const ALL_TOOL_NAMES = Object.values(TOOL_GROUPS).flat();
+const ALL_TOOL_SET: ReadonlySet<string> = new Set(ALL_TOOL_NAMES);
+
+const UpdateToolsBody = t.Object({
+  enabled_tools: t.Array(t.String()),
+});
+
+function configPath(): string {
+  return path.join(process.env.ORACLE_REPO_ROOT || REPO_ROOT, '.arra', 'config.json');
+}
+
+function readExistingConfig(filePath: string): Record<string, unknown> {
+  try {
+    if (!fs.existsSync(filePath)) return {};
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+function serializeToolConfig() {
+  const config = loadToolGroupConfig(process.env.ORACLE_REPO_ROOT || REPO_ROOT);
+  const enabled = getEnabledToolNames(config);
+  const envOverride = Boolean(process.env.ORACLE_ENABLED_TOOLS?.trim() || process.env.ORACLE_DISABLED_TOOLS?.trim());
+  return {
+    groups: Object.entries(TOOL_GROUPS).map(([group, tools]) => ({
+      group: group as ToolGroupName,
+      tools: tools.map((name) => ({ name, enabled: enabled.has(name) })),
+    })),
+    enabled_tools: ALL_TOOL_NAMES.filter((name) => enabled.has(name)),
+    disabled_tools: ALL_TOOL_NAMES.filter((name) => !enabled.has(name)),
+    config_path: configPath(),
+    env_override: envOverride,
+  };
+}
+
+export const toolSettingsRoute = new Elysia()
+  .get('/tools', () => serializeToolConfig(), {
+    detail: {
+      tags: ['settings'],
+      menu: { group: 'tools', path: '/tools/config', order: 120 },
+      summary: 'Read MCP tool enablement config',
+    },
+  })
+  .put('/tools', ({ body, set }) => {
+    const normalized = Array.from(new Set(body.enabled_tools.map(normalizeToolName)));
+    const unknown = normalized.filter((name) => !ALL_TOOL_SET.has(name));
+    if (unknown.length) {
+      set.status = 400;
+      return { error: 'Unknown MCP tools', unknown };
+    }
+
+    const filePath = configPath();
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const existing = readExistingConfig(filePath);
+    const next = {
+      ...existing,
+      // allowed_tools is the strict allow-list that #1372 already resolves via
+      // getEnabledToolNames/getDisabledTools. Persisting the visual toggle as
+      // an allow-list avoids duplicating group/filter semantics in the UI.
+      allowed_tools: ALL_TOOL_NAMES.filter((name) => normalized.includes(name)),
+    };
+    fs.writeFileSync(filePath, JSON.stringify(next, null, 2) + '\n');
+    return { success: true, ...serializeToolConfig() };
+  }, {
+    body: UpdateToolsBody,
+    detail: {
+      tags: ['settings'],
+      menu: { group: 'tools', path: '/tools/config', order: 120 },
+      summary: 'Persist MCP tool enablement config',
+    },
+  });

--- a/web/src/lib/backend.ts
+++ b/web/src/lib/backend.ts
@@ -131,6 +131,25 @@ export interface ScheduleResponse {
   total?: number;
 }
 
+export interface ToolToggleItem {
+  name: string;
+  enabled: boolean;
+}
+
+export interface ToolToggleGroup {
+  group: string;
+  tools: ToolToggleItem[];
+}
+
+export interface ToolConfigResponse {
+  groups: ToolToggleGroup[];
+  enabled_tools: string[];
+  disabled_tools: string[];
+  config_path?: string;
+  env_override?: boolean;
+  success?: boolean;
+}
+
 export interface BackendClient {
   search(query: string): Promise<SearchResult[]>;
   learn(pattern: string, concepts?: string[], source?: string): Promise<Learning>;
@@ -152,6 +171,8 @@ export interface BackendClient {
   superseded(): Promise<SupersedeListResponse>;
   supersedeChain(path: string): Promise<SupersedeChainResponse>;
   schedule(): Promise<ScheduleResponse>;
+  toolConfig(): Promise<ToolConfigResponse>;
+  saveToolConfig(enabledTools: string[]): Promise<ToolConfigResponse>;
 }
 
 export class MockBackend implements BackendClient {
@@ -242,6 +263,31 @@ export class MockBackend implements BackendClient {
 
   async schedule(): Promise<ScheduleResponse> {
     return { items: [], total: 0 };
+  }
+
+  async toolConfig(): Promise<ToolConfigResponse> {
+    const groups: ToolToggleGroup[] = [
+      { group: "search", tools: ["oracle_search", "oracle_read", "oracle_list", "oracle_concepts"].map((name) => ({ name, enabled: true })) },
+      { group: "knowledge", tools: ["oracle_learn", "oracle_stats", "oracle_supersede"].map((name) => ({ name, enabled: true })) },
+      { group: "session", tools: ["oracle_handoff", "oracle_inbox"].map((name) => ({ name, enabled: true })) },
+      { group: "forum", tools: ["oracle_thread", "oracle_threads", "oracle_thread_read", "oracle_thread_update"].map((name) => ({ name, enabled: true })) },
+      { group: "trace", tools: ["oracle_trace", "oracle_trace_list", "oracle_trace_get", "oracle_trace_link", "oracle_trace_unlink", "oracle_trace_chain"].map((name) => ({ name, enabled: true })) },
+      { group: "standalone", tools: ["oracle_reflect", "oracle_verify"].map((name) => ({ name, enabled: true })) },
+    ];
+    const enabled_tools = groups.flatMap((g) => g.tools.map((t) => t.name));
+    return { groups, enabled_tools, disabled_tools: [] };
+  }
+
+  async saveToolConfig(enabledTools: string[]): Promise<ToolConfigResponse> {
+    const current = await this.toolConfig();
+    const enabled = new Set(enabledTools);
+    return {
+      ...current,
+      groups: current.groups.map((g) => ({ ...g, tools: g.tools.map((t) => ({ ...t, enabled: enabled.has(t.name) })) })),
+      enabled_tools: enabledTools,
+      disabled_tools: current.enabled_tools.filter((name) => !enabled.has(name)),
+      success: true,
+    };
   }
 }
 
@@ -364,6 +410,20 @@ export class RealBackend implements BackendClient {
 
   async schedule(): Promise<ScheduleResponse> {
     return this.get("/api/schedule");
+  }
+
+  async toolConfig(): Promise<ToolConfigResponse> {
+    return this.get("/api/settings/tools");
+  }
+
+  async saveToolConfig(enabledTools: string[]): Promise<ToolConfigResponse> {
+    const res = await fetch(`${this.baseUrl}/api/settings/tools`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ enabled_tools: enabledTools }),
+    });
+    if (!res.ok) throw new Error(`Backend error ${res.status}: ${await res.text()}`);
+    return res.json() as Promise<ToolConfigResponse>;
   }
 }
 

--- a/web/src/pages/tools.astro
+++ b/web/src/pages/tools.astro
@@ -20,6 +20,7 @@ const tools = [
   { name: "arra_handoff", desc: "Package context for handoff to another agent", href: "/tools/arra_handoff" },
   { name: "arra_inbox", desc: "Read and process the agent inbox queue", href: "/tools/arra_inbox" },
   { name: "arra_stats", desc: "Memory store statistics — counts, sizes, coverage", href: "/tools/arra_stats" },
+  { name: "oracle_tool_toggles", desc: "Enable or hide MCP methods from the visual settings UI", href: "/tools/config" },
   { name: "arra_supersede", desc: "Mark an entry as superseded by a newer one", href: "/tools/arra_supersede" },
 ];
 

--- a/web/src/pages/tools/config.astro
+++ b/web/src/pages/tools/config.astro
@@ -1,0 +1,116 @@
+---
+import Base from "../../layouts/Base.astro";
+---
+
+<Base title="MCP Tool Toggles | Neo ARRA V3">
+  <main class="max-w-5xl mx-auto px-6 py-16">
+    <a href="/tools" class="text-gray-500 hover:text-teal-300 text-sm transition-colors">← tools</a>
+    <div class="mt-4 mb-10 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+      <div>
+        <h1 class="text-5xl font-bold tracking-tight mb-2">MCP Tool Toggles</h1>
+        <p class="text-gray-400 text-lg">Enable or hide individual MCP methods for the next tool list refresh.</p>
+      </div>
+      <div id="status-chip" class="text-xs font-mono text-gray-500 md:text-right">loading…</div>
+    </div>
+
+    <div id="notice" class="hidden mb-6 rounded-xl border p-4 text-sm"></div>
+    <form id="tools-form" class="space-y-6"></form>
+
+    <div class="mt-8 flex gap-3">
+      <button id="save-btn" type="button" class="bg-teal-500 hover:bg-teal-400 disabled:opacity-50 disabled:cursor-not-allowed text-gray-950 font-semibold px-6 py-2.5 rounded-lg transition-colors text-sm">
+        Save toggles
+      </button>
+      <button id="enable-all-btn" type="button" class="bg-gray-800 hover:bg-gray-700 text-gray-300 font-semibold px-6 py-2.5 rounded-lg transition-colors text-sm">
+        Enable all
+      </button>
+    </div>
+  </main>
+</Base>
+
+<script>
+  import { getBackendClient, type ToolConfigResponse } from "../../lib/backend";
+
+  const form = document.getElementById("tools-form") as HTMLFormElement;
+  const saveBtn = document.getElementById("save-btn") as HTMLButtonElement;
+  const enableAllBtn = document.getElementById("enable-all-btn") as HTMLButtonElement;
+  const statusChip = document.getElementById("status-chip")!;
+  const notice = document.getElementById("notice")!;
+
+  function escapeHtml(value: string): string {
+    return value.replace(/[&<>'"]/g, (char) => ({
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      "'": "&#39;",
+      '"': "&quot;",
+    }[char] ?? char));
+  }
+
+  function setNotice(kind: "ok" | "warn" | "error", message: string) {
+    const classes = {
+      ok: "mb-6 rounded-xl border border-green-700 bg-green-950/40 p-4 text-sm text-green-200",
+      warn: "mb-6 rounded-xl border border-amber-700 bg-amber-950/40 p-4 text-sm text-amber-200",
+      error: "mb-6 rounded-xl border border-red-700 bg-red-950/40 p-4 text-sm text-red-200",
+    };
+    notice.className = classes[kind];
+    notice.textContent = message;
+  }
+
+  function render(config: ToolConfigResponse) {
+    const total = config.groups.flatMap((g) => g.tools).length;
+    statusChip.textContent = `${config.enabled_tools.length}/${total} enabled`;
+    statusChip.className = "text-xs font-mono text-teal-300 md:text-right";
+    if (config.env_override) {
+      setNotice("warn", "Environment tool filters are active; saved .arra config may not take effect until ORACLE_ENABLED_TOOLS / ORACLE_DISABLED_TOOLS are unset.");
+    } else if (config.config_path) {
+      setNotice("ok", `Persist target: ${config.config_path}`);
+    }
+
+    form.innerHTML = config.groups.map((group) => `
+      <fieldset class="bg-gray-900/80 border border-gray-800 rounded-xl p-5">
+        <legend class="px-1 font-mono text-teal-300 text-sm">${escapeHtml(group.group)}</legend>
+        <div class="mt-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          ${group.tools.map((tool) => `
+            <label class="flex items-center justify-between gap-3 rounded-lg border border-gray-800 bg-gray-950/60 px-3 py-2.5 hover:border-teal-900 transition-colors">
+              <span class="font-mono text-sm text-gray-300 break-all">${escapeHtml(tool.name)}</span>
+              <input class="tool-toggle h-5 w-5 accent-teal-400" type="checkbox" value="${escapeHtml(tool.name)}" ${tool.enabled ? "checked" : ""} />
+            </label>
+          `).join("")}
+        </div>
+      </fieldset>
+    `).join("");
+  }
+
+  function selectedTools(): string[] {
+    return Array.from(document.querySelectorAll<HTMLInputElement>(".tool-toggle:checked")).map((input) => input.value);
+  }
+
+  async function load() {
+    try {
+      render(await getBackendClient().toolConfig());
+    } catch (err) {
+      statusChip.textContent = "backend unavailable";
+      setNotice("error", err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  saveBtn.addEventListener("click", async () => {
+    saveBtn.disabled = true;
+    saveBtn.textContent = "Saving…";
+    try {
+      render(await getBackendClient().saveToolConfig(selectedTools()));
+      setNotice("ok", "Saved MCP tool toggles. The MCP server reload watcher will apply the config shortly.");
+    } catch (err) {
+      setNotice("error", err instanceof Error ? err.message : String(err));
+    } finally {
+      saveBtn.disabled = false;
+      saveBtn.textContent = "Save toggles";
+    }
+  });
+
+  enableAllBtn.addEventListener("click", () => {
+    document.querySelectorAll<HTMLInputElement>(".tool-toggle").forEach((input) => { input.checked = true; });
+  });
+
+  load();
+</script>


### PR DESCRIPTION
## Summary
- Adds `GET/PUT /api/settings/tools` for visual MCP method toggles.
- Reuses #1372 config helpers (`TOOL_GROUPS`, `loadToolGroupConfig`, `getEnabledToolNames`, `normalizeToolName`) so filtering logic stays centralized.
- Persists UI selections to `.arra/config.json` as `allowed_tools`, which #1372 already resolves.
- Adds a lean `/tools/config` web page and a link from the existing tools page.

## Receipt
- API smoke with temp `ORACLE_REPO_ROOT` wrote `.arra/config.json`:
  - input `['oracle_search', 'arra_read']`
  - persisted `['oracle_search', 'oracle_read']`
  - resolver response showed the sibling search tools disabled.
- Browser smoke opened `/tools/config`, loaded tool toggles, checked `oracle_list`, saved, and captured `GET` + `PUT /api/settings/tools`.

## Validation
- `bun run build`
- `cd web && bun run build`
- `bun test src/config/__tests__/tool-groups.test.ts src/server/__tests__/server-plugin-loader.test.ts`
- `bun run test:unit` (292 pass)
- HTTP smoke `GET/PUT /api/settings/tools`
- Playwright smoke `/tools/config`

Closes #1373
