### PR TITLE
Expose local vector engine and model selection

### DIFF
--- a/src/routes/vector/__tests__/config.test.ts
+++ b/src/routes/vector/__tests__/config.test.ts
@@ -1,0 +1,82 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-vector-config-route-'));
+const originalDataDir = process.env.ORACLE_DATA_DIR;
+process.env.ORACLE_DATA_DIR = path.join(tmpRoot, 'data');
+
+const { vectorConfigEndpoint } = await import('../config.ts');
+const { configPath } = await import('../../../vector/config.ts');
+const { getEmbeddingModels, getVectorStoreConfigByModel } = await import('../../../vector/factory.ts');
+
+const app = new Elysia({ prefix: '/api' }).use(vectorConfigEndpoint);
+
+describe('/api/vector/config', () => {
+  test('GET keeps backward-compatible defaults when no config file exists', async () => {
+    const res = await app.handle(new Request('http://localhost/api/vector/config'));
+    const body = await res.json() as any;
+
+    expect(res.status).toBe(200);
+    expect(body.source).toBe('defaults');
+    expect(body.engine).toBe('lancedb');
+    expect(body.config.collections['bge-m3']).toMatchObject({
+      adapter: 'lancedb',
+      model: 'bge-m3',
+      primary: true,
+    });
+    expect(fs.existsSync(configPath())).toBe(false);
+  });
+
+  test('PATCH switches local engine and adds selectable embedding model collection', async () => {
+    const res = await app.handle(new Request('http://localhost/api/vector/config', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        engine: 'sqlite-vec',
+        collections: {
+          fast: {
+            adapter: 'qdrant',
+            collection: 'oracle_fast_nomic',
+            model: 'nomic-embed-text',
+            provider: 'ollama',
+            qdrantUrl: 'http://localhost:6333',
+          },
+        },
+      }),
+    }));
+    const body = await res.json() as any;
+
+    expect(res.status).toBe(200);
+    expect(body.source).toBe('file');
+    expect(body.engine).toBe('sqlite-vec');
+    expect(body.config.collections['bge-m3'].adapter).toBe('sqlite-vec');
+    expect(body.config.collections.fast).toMatchObject({
+      adapter: 'qdrant',
+      collection: 'oracle_fast_nomic',
+      model: 'nomic-embed-text',
+      provider: 'ollama',
+    });
+    expect(fs.existsSync(configPath())).toBe(true);
+
+    expect(getEmbeddingModels().fast).toMatchObject({
+      adapter: 'qdrant',
+      model: 'nomic-embed-text',
+      collection: 'oracle_fast_nomic',
+    });
+    expect(getVectorStoreConfigByModel('fast')).toMatchObject({
+      type: 'qdrant',
+      embeddingModel: 'nomic-embed-text',
+      collectionName: 'oracle_fast_nomic',
+      qdrantUrl: 'http://localhost:6333',
+    });
+  });
+});
+
+afterAll(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  if (originalDataDir !== undefined) process.env.ORACLE_DATA_DIR = originalDataDir;
+  else delete process.env.ORACLE_DATA_DIR;
+});

--- a/src/routes/vector/config.ts
+++ b/src/routes/vector/config.ts
@@ -1,29 +1,103 @@
 /**
- * GET /api/vector/config — read-only view of vector-server.json.
+ * /api/vector/config — active local vector engine + embedding-model registry.
  *
- * Returns the active config (from disk if it exists, otherwise defaults).
- * Phase 2 of #1071.
+ * Reads vector-server.json when present, otherwise returns defaults. PATCH writes
+ * the same config file so local adapter selection is durable without requiring
+ * the standalone vector server (#1071) path.
  */
 
-import { Elysia } from 'elysia';
+import { Elysia, t } from 'elysia';
 import {
-  loadVectorConfig,
+  LOCAL_VECTOR_ENGINES,
+  activeVectorEngine,
+  applyVectorConfigUpdate,
   generateDefaultConfig,
+  loadVectorConfig,
+  writeVectorConfig,
 } from '../../vector/config.ts';
+import type { EmbeddingProviderType } from '../../vector/types.ts';
 
-export const vectorConfigEndpoint = new Elysia().get(
-  '/vector/config',
-  () => {
-    const fromDisk = loadVectorConfig();
-    return {
-      source: fromDisk ? 'file' : 'defaults',
-      config: fromDisk ?? generateDefaultConfig(),
-    };
-  },
-  {
-    detail: {
-      tags: ['vector'],
-      summary: 'Active vector server configuration (read-only)',
+const providerSchema = t.Union([
+  t.Literal('chromadb-internal'),
+  t.Literal('ollama'),
+  t.Literal('openai'),
+  t.Literal('cloudflare-ai'),
+]);
+
+const localEngineSchema = t.Union([
+  t.Literal('lancedb'),
+  t.Literal('qdrant'),
+  t.Literal('sqlite-vec'),
+]);
+
+function configPayload(source: 'file' | 'defaults', config: ReturnType<typeof generateDefaultConfig>) {
+  const collections = Object.fromEntries(
+    Object.entries(config.collections).map(([key, collection]) => [key, {
+      key,
+      ...collection,
+      adapter: collection.adapter ?? activeVectorEngine(config),
+      provider: collection.provider ?? 'ollama' as EmbeddingProviderType,
+    }]),
+  );
+
+  return {
+    source,
+    engine: activeVectorEngine(config),
+    options: {
+      localEngines: LOCAL_VECTOR_ENGINES,
+      embeddingProviders: ['ollama', 'openai', 'cloudflare-ai', 'chromadb-internal'],
     },
-  },
-);
+    config: { ...config, collections },
+  };
+}
+
+export const vectorConfigEndpoint = new Elysia()
+  .get(
+    '/vector/config',
+    () => {
+      const fromDisk = loadVectorConfig();
+      return configPayload(fromDisk ? 'file' : 'defaults', fromDisk ?? generateDefaultConfig());
+    },
+    {
+      detail: {
+        tags: ['vector'],
+        summary: 'Active local vector engine and embedding-model configuration',
+      },
+    },
+  )
+  .patch(
+    '/vector/config',
+    ({ body, set }) => {
+      try {
+        const base = loadVectorConfig() ?? generateDefaultConfig();
+        const next = applyVectorConfigUpdate(base, body ?? {});
+        const path = writeVectorConfig(next);
+        return { ...configPayload('file', next), path };
+      } catch (error) {
+        set.status = 400;
+        return { error: error instanceof Error ? error.message : String(error) };
+      }
+    },
+    {
+      body: t.Optional(t.Object({
+        engine: t.Optional(localEngineSchema),
+        dataPath: t.Optional(t.String()),
+        embeddingEndpoint: t.Optional(t.String()),
+        collections: t.Optional(t.Record(t.String(), t.Object({
+          collection: t.Optional(t.String()),
+          model: t.Optional(t.String()),
+          provider: t.Optional(providerSchema),
+          adapter: t.Optional(localEngineSchema),
+          dataPath: t.Optional(t.String()),
+          pythonVersion: t.Optional(t.String()),
+          qdrantUrl: t.Optional(t.String()),
+          qdrantApiKey: t.Optional(t.String()),
+          primary: t.Optional(t.Boolean()),
+        }))),
+      })),
+      detail: {
+        tags: ['vector'],
+        summary: 'Update local vector engine and per-collection embedding models',
+      },
+    },
+  );

--- a/src/vector/__tests__/config.test.ts
+++ b/src/vector/__tests__/config.test.ts
@@ -103,3 +103,38 @@ afterAll(() => {
   if (originalDataDir) process.env.ORACLE_DATA_DIR = originalDataDir;
   else delete process.env.ORACLE_DATA_DIR;
 });
+
+describe('local vector engine selection', () => {
+  test('applyVectorConfigUpdate switches every default collection to sqlite-vec with sqlite path', async () => {
+    const { applyVectorConfigUpdate } = await import('../config.ts');
+    const cfg = applyVectorConfigUpdate(generateDefaultConfig(), { engine: 'sqlite-vec' });
+
+    expect(cfg.dataPath.endsWith('vectors.db')).toBe(true);
+    expect(Object.values(cfg.collections).every(c => c.adapter === 'sqlite-vec')).toBe(true);
+    expect(configToModels(cfg)['bge-m3'].dataPath?.endsWith('vectors.db')).toBe(true);
+  });
+
+  test('applyVectorConfigUpdate adds a selectable model collection without changing defaults', async () => {
+    const { applyVectorConfigUpdate } = await import('../config.ts');
+    const cfg = applyVectorConfigUpdate(generateDefaultConfig(), {
+      collections: {
+        fast: {
+          adapter: 'qdrant',
+          collection: 'oracle_fast_nomic',
+          model: 'nomic-embed-text',
+          provider: 'ollama',
+          qdrantUrl: 'http://localhost:6333',
+        },
+      },
+    });
+
+    expect(cfg.collections['bge-m3'].adapter).toBe('lancedb');
+    expect(configToModels(cfg).fast).toMatchObject({
+      adapter: 'qdrant',
+      collection: 'oracle_fast_nomic',
+      model: 'nomic-embed-text',
+      provider: 'ollama',
+      qdrantUrl: 'http://localhost:6333',
+    });
+  });
+});

--- a/src/vector/config.ts
+++ b/src/vector/config.ts
@@ -10,11 +10,13 @@
 
 import fs from 'fs';
 import path from 'path';
-import { ORACLE_DATA_DIR, LANCEDB_DIR } from '../config.ts';
+import { ORACLE_DATA_DIR, LANCEDB_DIR, VECTORS_DB_PATH } from '../config.ts';
 import { COLLECTION_NAME } from '../const.ts';
 import type { EmbeddingProviderType, VectorDBType } from './types.ts';
 
 export const VECTOR_CONFIG_FILE = 'vector-server.json';
+export const LOCAL_VECTOR_ENGINES = ['lancedb', 'qdrant', 'sqlite-vec'] as const;
+export type LocalVectorEngine = typeof LOCAL_VECTOR_ENGINES[number];
 
 export interface VectorCollectionConfig {
   collection: string;
@@ -28,6 +30,26 @@ export interface VectorCollectionConfig {
   cfAccountId?: string;
   cfApiToken?: string;
   primary?: boolean;
+}
+
+
+export interface VectorConfigUpdateCollection {
+  collection?: string;
+  model?: string;
+  provider?: EmbeddingProviderType;
+  adapter?: LocalVectorEngine;
+  dataPath?: string;
+  pythonVersion?: string;
+  qdrantUrl?: string;
+  qdrantApiKey?: string;
+  primary?: boolean;
+}
+
+export interface VectorConfigUpdate {
+  engine?: LocalVectorEngine;
+  dataPath?: string;
+  embeddingEndpoint?: string;
+  collections?: Record<string, VectorConfigUpdateCollection>;
 }
 
 export interface VectorServerConfig {
@@ -142,4 +164,73 @@ export function configToModels(
     };
   }
   return out;
+}
+
+
+export function isLocalVectorEngine(value: unknown): value is LocalVectorEngine {
+  return typeof value === 'string' && (LOCAL_VECTOR_ENGINES as readonly string[]).includes(value);
+}
+
+export function defaultDataPathForEngine(engine: LocalVectorEngine): string {
+  if (engine === 'sqlite-vec') return VECTORS_DB_PATH;
+  if (engine === 'qdrant') return '';
+  return LANCEDB_DIR;
+}
+
+export function activeVectorEngine(config: VectorServerConfig): VectorDBType {
+  const primary = Object.values(config.collections).find(c => c.primary);
+  return primary?.adapter || Object.values(config.collections)[0]?.adapter || 'lancedb';
+}
+
+export function applyVectorConfigUpdate(
+  base: VectorServerConfig,
+  update: VectorConfigUpdate,
+): VectorServerConfig {
+  const next: VectorServerConfig = structuredClone(base);
+
+  if (update.engine !== undefined) {
+    if (!isLocalVectorEngine(update.engine)) {
+      throw new Error(`Unsupported local vector engine: ${String(update.engine)}`);
+    }
+    next.dataPath = update.dataPath ?? defaultDataPathForEngine(update.engine);
+    for (const collection of Object.values(next.collections)) {
+      collection.adapter = update.engine;
+      if (update.engine === 'qdrant') delete collection.dataPath;
+      else collection.dataPath = collection.dataPath || next.dataPath;
+    }
+  } else if (update.dataPath !== undefined) {
+    next.dataPath = update.dataPath;
+  }
+
+  if (update.embeddingEndpoint !== undefined) next.embeddingEndpoint = update.embeddingEndpoint;
+
+  for (const [key, patch] of Object.entries(update.collections ?? {})) {
+    if (!key.trim()) throw new Error('Collection key cannot be empty');
+    const existing = next.collections[key] ?? {
+      collection: key,
+      model: key,
+      provider: 'ollama' as EmbeddingProviderType,
+      adapter: update.engine ?? activeVectorEngine(next),
+    };
+    if (patch.adapter !== undefined && !isLocalVectorEngine(patch.adapter)) {
+      throw new Error(`Unsupported local vector engine: ${String(patch.adapter)}`);
+    }
+    next.collections[key] = {
+      ...existing,
+      ...patch,
+      collection: patch.collection ?? existing.collection ?? key,
+      model: patch.model ?? existing.model ?? key,
+      provider: patch.provider ?? existing.provider ?? 'ollama',
+      adapter: patch.adapter ?? existing.adapter ?? update.engine ?? activeVectorEngine(next),
+    };
+  }
+
+  const primaryKeys = Object.entries(next.collections).filter(([, c]) => c.primary).map(([key]) => key);
+  if (primaryKeys.length === 0 && next.collections['bge-m3']) next.collections['bge-m3'].primary = true;
+  if (primaryKeys.length > 1) {
+    const keep = primaryKeys[0];
+    for (const [key, collection] of Object.entries(next.collections)) collection.primary = key === keep;
+  }
+
+  return next;
 }


### PR DESCRIPTION
## Summary
- Add durable `PATCH /api/vector/config` for local vector engine selection (`lancedb`, `qdrant`, `sqlite-vec`) while keeping missing config as the existing LanceDB defaults.
- Return active engine/options from `GET /api/vector/config` so clients can render available adapter/provider choices.
- Allow per-collection embedding-model entries to be added/updated in `vector-server.json`, and verify the existing factory/search model registry sees them.
- Preserve zero-config behavior: no config file is written until PATCH is called, and vector remains opt-in.

Closes #1377

## Verification
- `bun run build`
- `bun test --isolate src/vector/__tests__/config.test.ts src/routes/vector/__tests__/config.test.ts src/server/__tests__/vector-indexer-config.test.ts src/server/__tests__/vector-routes-proxy-boundary.test.ts src/integration/zero-config-start.test.ts src/indexer/__tests__/psi-fts-index.test.ts src/routes/indexer/__tests__/scan.test.ts`
