### PR TITLE
Expose vector runtime mode on health

### DIFF
--- a/docs/vector-runtime.md
+++ b/docs/vector-runtime.md
@@ -1,0 +1,17 @@
+# Vector runtime mode
+
+Arra keeps an FTS5 floor: `/api/search` always runs the local SQLite FTS leg, even when the vector layer is disabled or proxied. Vector failures must degrade to FTS5 results instead of making core search unavailable.
+
+`/api/health` exposes the current vector runtime:
+
+- `vectorMode: "embedded"` — local vector adapter is usable in this process.
+- `vectorMode: "proxied"` — `VECTOR_URL` is set and vector requests are sent to a separate vector HTTP process.
+- `vectorMode: "disabled"` — local vector is intentionally unavailable, for example CPU/AVX guard failure or a missing local vector index.
+
+To split vector work out of the core server today, run a compatible vector HTTP service and start the core server with:
+
+```bash
+VECTOR_URL=http://127.0.0.1:48080 bun src/server.ts
+```
+
+With `VECTOR_URL` set, hybrid search still performs local FTS5 first and asks the vector service for the vector leg. If the proxy is down, search returns FTS5-only results with `vectorAvailable: false`.

--- a/src/routes/health/__tests__/health-vector-mode.test.ts
+++ b/src/routes/health/__tests__/health-vector-mode.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from 'bun:test';
+import { healthEndpoint } from '../health.ts';
+
+describe('/api/health vector mode', () => {
+  test('includes vector runtime mode in health payload', async () => {
+    const res = await healthEndpoint.handle(new Request('http://localhost/health'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(['embedded', 'proxied', 'disabled']).toContain(body.vectorMode);
+  });
+});

--- a/src/routes/health/health.ts
+++ b/src/routes/health/health.ts
@@ -1,6 +1,7 @@
 import { Elysia } from 'elysia';
 import { PORT } from '../../config.ts';
 import { MCP_SERVER_NAME } from '../../const.ts';
+import { getVectorRuntimeStatus } from '../../vector/runtime-status.ts';
 import pkg from '../../../package.json' with { type: 'json' };
 
 export const healthEndpoint = new Elysia().get('/health', () => ({
@@ -9,6 +10,7 @@ export const healthEndpoint = new Elysia().get('/health', () => ({
   version: pkg.version,
   port: PORT,
   oracle: 'connected',
+  ...getVectorRuntimeStatus(),
 }), {
   detail: {
     tags: ['health'],

--- a/src/vector/__tests__/runtime-status.test.ts
+++ b/src/vector/__tests__/runtime-status.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { resetCpuCapabilityCacheForTests } from '../cpu-capabilities.ts';
+import { getVectorRuntimeStatus } from '../runtime-status.ts';
+
+const original = {
+  forceAvx: process.env.ARRA_FORCE_AVX,
+};
+
+afterEach(() => {
+  if (original.forceAvx === undefined) delete process.env.ARRA_FORCE_AVX;
+  else process.env.ARRA_FORCE_AVX = original.forceAvx;
+  resetCpuCapabilityCacheForTests();
+});
+
+describe('vector runtime status', () => {
+  test('reports proxied when VECTOR_URL is configured', () => {
+    const status = getVectorRuntimeStatus({ env: { VECTOR_URL: 'http://127.0.0.1:48080' }, argv: ['bun', 'src/index.ts'] });
+    expect(status.vectorMode).toBe('proxied');
+    expect(status.vectorUrl).toBe('http://127.0.0.1:48080');
+  });
+
+  test('reports disabled when local native vector is gated off', () => {
+    process.env.ARRA_FORCE_AVX = '0';
+    resetCpuCapabilityCacheForTests();
+
+    const status = getVectorRuntimeStatus({
+      env: {},
+      localConfig: { type: 'lancedb', collectionName: 'oracle_knowledge_bge_m3', dataPath: '/tmp/missing.lancedb' },
+    });
+
+    expect(status.vectorMode).toBe('disabled');
+    expect(status.vectorDisabledReason).toContain('CPU lacks AVX');
+  });
+
+  test('reports disabled when local vector index is missing', () => {
+    process.env.ARRA_FORCE_AVX = '1';
+    resetCpuCapabilityCacheForTests();
+
+    const status = getVectorRuntimeStatus({
+      env: {},
+      localConfig: { type: 'lancedb', collectionName: 'oracle_knowledge_bge_m3', dataPath: '/tmp/arra-missing-vector-index' },
+    });
+
+    expect(status.vectorMode).toBe('disabled');
+    expect(status.vectorDisabledReason).toMatch(/LanceDB directory is missing|index not found/);
+  });
+
+  test('reports embedded when local LanceDB collection exists', () => {
+    process.env.ARRA_FORCE_AVX = '1';
+    resetCpuCapabilityCacheForTests();
+
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-vector-mode-'));
+    fs.mkdirSync(path.join(dir, 'oracle_knowledge_bge_m3.lance'), { recursive: true });
+    try {
+      const status = getVectorRuntimeStatus({
+        env: {},
+        localConfig: { type: 'lancedb', collectionName: 'oracle_knowledge_bge_m3', dataPath: dir },
+      });
+      expect(status.vectorMode).toBe('embedded');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/vector/runtime-status.ts
+++ b/src/vector/runtime-status.ts
@@ -1,0 +1,39 @@
+import { resolveVectorUrl } from '../config.ts';
+import { getVectorStoreConfigByModel, type VectorStoreConfig } from './factory.ts';
+import { localNativeVectorDisabledReason, localVectorIndexMissingReason } from './cpu-capabilities.ts';
+
+export type VectorMode = 'embedded' | 'proxied' | 'disabled';
+
+export interface VectorRuntimeStatus {
+  vectorMode: VectorMode;
+  vectorUrl?: string;
+  vectorDisabledReason?: string;
+}
+
+export interface VectorRuntimeStatusOptions {
+  env?: Record<string, string | undefined>;
+  argv?: string[];
+  localConfig?: VectorStoreConfig;
+}
+
+/**
+ * Report how the core server is wired to vector search.
+ *
+ * This is intentionally observability-only: search handlers keep FTS5 available
+ * as the always-on floor even when this reports disabled/proxied vector mode.
+ */
+export function getVectorRuntimeStatus(options: VectorRuntimeStatusOptions = {}): VectorRuntimeStatus {
+  const env = options.env || process.env;
+  const argv = options.argv || process.argv;
+  const vectorUrl = resolveVectorUrl(env, argv).trim();
+  if (vectorUrl) return { vectorMode: 'proxied', vectorUrl };
+
+  const cfg = options.localConfig || getVectorStoreConfigByModel(undefined);
+  const disabledReason = localNativeVectorDisabledReason(cfg.type);
+  if (disabledReason) return { vectorMode: 'disabled', vectorDisabledReason: disabledReason };
+
+  const indexMissingReason = localVectorIndexMissingReason(cfg);
+  if (indexMissingReason) return { vectorMode: 'disabled', vectorDisabledReason: indexMissingReason };
+
+  return { vectorMode: 'embedded' };
+}


### PR DESCRIPTION
## Summary
- Add vector runtime observability to `/api/health` via `vectorMode: "embedded" | "proxied" | "disabled"`.
- Report `proxied` from `VECTOR_URL`, `disabled` for local AVX/index gates, and `embedded` when the local LanceDB collection is present.
- Document the current VECTOR_URL split-process path and the FTS5 always-on floor.

## FTS5 floor
This slice does not make vector mode a search gate: existing `/api/search` FTS5 fallback behavior remains covered so FTS works when vector is disabled or proxied.

## Tests
- `bun run build`
- `bun test src/vector/__tests__/runtime-status.test.ts`
- `bun test src/routes/health/__tests__/health-vector-mode.test.ts`
- `bun test --isolate src/server/__tests__/search-no-avx-fallback.test.ts src/server/__tests__/search-fts-query.test.ts`

Refs #1071
