### PR TITLE
Let vector proxy target move to cloud

### DIFF
--- a/docs/CLOUD-VECTOR-PROXY.md
+++ b/docs/CLOUD-VECTOR-PROXY.md
@@ -1,0 +1,88 @@
+# Cloud vector proxy runbook
+
+Arra can keep SQLite/FTS5 local while sending the vector leg to a separate
+backend such as a Cloudflare-hosted Worker/service, a VM, or another LAN host.
+This is the Tier 4 path for cloud indexing without moving the local ground
+truth database.
+
+## Contract
+
+- Local Arra HTTP server keeps `/api/search?mode=fts` as the source of truth.
+- Set `VECTOR_URL` (or durable `vectorProxyUrl`) on the core server to route
+  vector-only operations backend-to-backend.
+- The remote service exposes the same vector HTTP surface:
+  - `GET /api/search?...&mode=vector`
+  - `GET /api/vector/health`
+  - `GET /api/vector/stats`
+  - `GET /api/vector/index/models`
+  - `GET /api/vector/index/status`
+  - `POST /api/vector/index/start`
+  - optional visualization routes: `/api/map`, `/api/map3d`, `/api/similar`, `/api/compare`
+- If the remote vector service is unavailable, hybrid search degrades to local
+  FTS5 results with `vectorAvailable: false` and a warning.
+
+## One-shot env config
+
+```bash
+VECTOR_URL="https://vectors.example.com" bun run server
+```
+
+Use this for temporary routing, local tunnels, or CI smoke tests. `VECTOR_URL`
+wins over file config.
+
+## Durable config
+
+Persist the remote vector base URL in `ORACLE_DATA_DIR/vector-server.json` via
+HTTP:
+
+```bash
+curl -X PATCH "http://localhost:47778/api/vector/config" \
+  -H 'content-type: application/json' \
+  --data '{"vectorProxyUrl":"https://vectors.example.com"}'
+```
+
+Or edit the file directly:
+
+```json
+{
+  "version": "1.0",
+  "host": "0.0.0.0",
+  "port": 8081,
+  "vectorProxyUrl": "https://vectors.example.com",
+  "dataPath": "~/.arra-oracle-v2/lancedb",
+  "embeddingEndpoint": "http://localhost:11434",
+  "collections": {}
+}
+```
+
+Restart the core server after changing file config. The standalone vector
+server ignores inherited `VECTOR_URL` so it cannot proxy back to itself.
+
+## Cloudflare shape
+
+A Cloudflare deployment can be any backend that implements the vector HTTP
+surface above. Typical options:
+
+- Worker in front of Vectorize / AI Gateway / another vector service.
+- Worker proxying to a private vector sidecar.
+- Tunnel exposing a VM-hosted `bun src/vector-server.ts`.
+
+Keep auth/token handling at the edge. The core server only needs the base URL.
+
+## Fallback receipt
+
+Hybrid search always runs FTS5 locally first. When remote `/api/search` returns
+an error or times out, Arra returns local FTS results instead of failing the
+request:
+
+```json
+{
+  "mode": "hybrid",
+  "vectorAvailable": false,
+  "warning": "Vector proxy unavailable — FTS5-only results",
+  "results": ["local FTS matches..."]
+}
+```
+
+Vector-only visualization routes such as `/api/map` may return `503` because
+there is no meaningful local FTS replacement for embedding maps.

--- a/src/config.ts
+++ b/src/config.ts
@@ -72,7 +72,25 @@ export function resolveVectorUrl(
   if (env.ORACLE_VECTOR_SERVER === '1' || isVectorServerEntrypoint(argv[1])) {
     return '';
   }
-  return env.VECTOR_URL || '';
+  if (env.VECTOR_URL?.trim()) return env.VECTOR_URL.trim();
+
+  // Durable cloud/sidecar routing: if vector-server.json declares a remote
+  // proxy URL, the core server uses it for vector legs while FTS remains local.
+  // Keep this small and local to avoid importing vector/config.ts here (that
+  // module imports config.ts for ORACLE_DATA_DIR and would create a cycle).
+  try {
+    const dataDir = env.ORACLE_DATA_DIR || process.env.ORACLE_DATA_DIR || ORACLE_DATA_DIR;
+    const raw = fs.readFileSync(path.join(dataDir, 'vector-server.json'), 'utf-8');
+    const config = JSON.parse(raw) as { vectorProxyUrl?: unknown; vectorUrl?: unknown };
+    const fromConfig = typeof config.vectorProxyUrl === 'string'
+      ? config.vectorProxyUrl
+      : typeof config.vectorUrl === 'string'
+        ? config.vectorUrl
+        : '';
+    return fromConfig.trim();
+  } catch {
+    return '';
+  }
 }
 
 export const VECTOR_URL = resolveVectorUrl();

--- a/src/config/__tests__/vector-url.test.ts
+++ b/src/config/__tests__/vector-url.test.ts
@@ -1,8 +1,18 @@
-import { describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import { isVectorServerEntrypoint, resolveVectorUrl } from '../../config.ts';
 
 describe('VECTOR_URL routing guard', () => {
+  const originalDataDir = process.env.ORACLE_DATA_DIR;
+
+  afterEach(() => {
+    if (originalDataDir !== undefined) process.env.ORACLE_DATA_DIR = originalDataDir;
+    else delete process.env.ORACLE_DATA_DIR;
+  });
+
   test('core server honors VECTOR_URL', () => {
     expect(
       resolveVectorUrl({ VECTOR_URL: 'http://127.0.0.1:8081' }, ['bun', 'src/server.ts']),
@@ -24,4 +34,34 @@ describe('VECTOR_URL routing guard', () => {
       resolveVectorUrl({ VECTOR_URL: 'http://127.0.0.1:8081' }, ['bun', '/app/src/vector-server.ts']),
     ).toBe('');
   });
+  test('core server can read durable vectorProxyUrl from vector-server.json', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-vector-url-config-'));
+    try {
+      process.env.ORACLE_DATA_DIR = tmp;
+      fs.writeFileSync(
+        path.join(tmp, 'vector-server.json'),
+        JSON.stringify({ vectorProxyUrl: 'https://vectors.example.test/' }),
+      );
+      expect(resolveVectorUrl({ ORACLE_DATA_DIR: tmp }, ['bun', 'src/server.ts'])).toBe('https://vectors.example.test/');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('env VECTOR_URL overrides durable vectorProxyUrl config', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-vector-url-config-'));
+    try {
+      process.env.ORACLE_DATA_DIR = tmp;
+      fs.writeFileSync(
+        path.join(tmp, 'vector-server.json'),
+        JSON.stringify({ vectorProxyUrl: 'https://vectors.example.test' }),
+      );
+      expect(
+        resolveVectorUrl({ VECTOR_URL: 'http://127.0.0.1:8081', ORACLE_DATA_DIR: tmp }, ['bun', 'src/server.ts']),
+      ).toBe('http://127.0.0.1:8081');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
 });

--- a/src/routes/vector/__tests__/config.test.ts
+++ b/src/routes/vector/__tests__/config.test.ts
@@ -36,6 +36,7 @@ describe('/api/vector/config', () => {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
         engine: 'sqlite-vec',
+        vectorProxyUrl: 'https://vectors.example.test/api-root/',
         collections: {
           fast: {
             adapter: 'qdrant',
@@ -53,6 +54,7 @@ describe('/api/vector/config', () => {
     expect(body.source).toBe('file');
     expect(body.engine).toBe('sqlite-vec');
     expect(body.config.collections['bge-m3'].adapter).toBe('sqlite-vec');
+    expect(body.config.vectorProxyUrl).toBe('https://vectors.example.test/api-root');
     expect(body.config.collections.fast).toMatchObject({
       adapter: 'qdrant',
       collection: 'oracle_fast_nomic',

--- a/src/routes/vector/config.ts
+++ b/src/routes/vector/config.ts
@@ -83,6 +83,7 @@ export const vectorConfigEndpoint = new Elysia()
         engine: t.Optional(localEngineSchema),
         dataPath: t.Optional(t.String()),
         embeddingEndpoint: t.Optional(t.String()),
+        vectorProxyUrl: t.Optional(t.String()),
         collections: t.Optional(t.Record(t.String(), t.Object({
           collection: t.Optional(t.String()),
           model: t.Optional(t.String()),

--- a/src/server/__tests__/search-vector-proxy-fallback.test.ts
+++ b/src/server/__tests__/search-vector-proxy-fallback.test.ts
@@ -1,0 +1,50 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-search-vector-proxy-fallback-'));
+const dataDir = path.join(tmpRoot, 'data');
+const originalDataDir = process.env.ORACLE_DATA_DIR;
+const originalDbPath = process.env.ORACLE_DB_PATH;
+const originalVectorUrl = process.env.VECTOR_URL;
+
+const remote = Bun.serve({
+  port: 0,
+  fetch(request) {
+    const url = new URL(request.url);
+    if (url.pathname === '/api/search') return Response.json({ error: 'remote vector down' }, { status: 503 });
+    if (url.pathname === '/api/vector/health') return Response.json({ status: 'down', engines: [], checked_at: new Date().toISOString() });
+    return Response.json({ error: 'not found' }, { status: 404 });
+  },
+});
+
+process.env.ORACLE_DATA_DIR = dataDir;
+process.env.ORACLE_DB_PATH = path.join(dataDir, 'oracle.db');
+process.env.VECTOR_URL = `http://127.0.0.1:${remote.port}`;
+
+const { handleLearn, handleSearch } = await import('../handlers.ts');
+
+describe('handleSearch cloud vector proxy fallback', () => {
+  test('keeps local FTS as ground truth when remote vector proxy is down', async () => {
+    handleLearn('cloudproxy1378 local fts ground truth survives remote vector outage', 'test', ['cloudproxy1378']);
+
+    const result = await handleSearch('cloudproxy1378', 'all', 5, 0, 'hybrid');
+
+    expect(result.results.length).toBeGreaterThan(0);
+    expect(result.results[0].content).toContain('cloudproxy1378');
+    expect(result.vectorAvailable).toBe(false);
+    expect(result.warning).toBe('Vector proxy unavailable — FTS5-only results');
+  });
+});
+
+afterAll(() => {
+  remote.stop(true);
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  if (originalDataDir !== undefined) process.env.ORACLE_DATA_DIR = originalDataDir;
+  else delete process.env.ORACLE_DATA_DIR;
+  if (originalDbPath !== undefined) process.env.ORACLE_DB_PATH = originalDbPath;
+  else delete process.env.ORACLE_DB_PATH;
+  if (originalVectorUrl !== undefined) process.env.VECTOR_URL = originalVectorUrl;
+  else delete process.env.VECTOR_URL;
+});

--- a/src/vector/config.ts
+++ b/src/vector/config.ts
@@ -49,6 +49,8 @@ export interface VectorConfigUpdate {
   engine?: LocalVectorEngine;
   dataPath?: string;
   embeddingEndpoint?: string;
+  /** Remote vector service base URL for backend-to-backend VECTOR_URL proxying. */
+  vectorProxyUrl?: string;
   collections?: Record<string, VectorConfigUpdateCollection>;
 }
 
@@ -56,6 +58,8 @@ export interface VectorServerConfig {
   version: string;
   host: string;
   port: number;
+  /** Optional remote vector service base URL used by core server proxy mode. */
+  vectorProxyUrl?: string;
   collections: Record<string, VectorCollectionConfig>;
   dataPath: string;
   embeddingEndpoint: string;
@@ -203,6 +207,11 @@ export function applyVectorConfigUpdate(
   }
 
   if (update.embeddingEndpoint !== undefined) next.embeddingEndpoint = update.embeddingEndpoint;
+  if (update.vectorProxyUrl !== undefined) {
+    const trimmed = update.vectorProxyUrl.trim();
+    if (trimmed) next.vectorProxyUrl = trimmed.replace(/\/+$/, '');
+    else delete next.vectorProxyUrl;
+  }
 
   for (const [key, patch] of Object.entries(update.collections ?? {})) {
     if (!key.trim()) throw new Error('Collection key cannot be empty');


### PR DESCRIPTION
## Summary
- Adds durable `vectorProxyUrl` to `vector-server.json` / `/api/vector/config` so the core server can point vector legs at a cloud/remote backend without env-only setup.
- Keeps `VECTOR_URL` env as the highest-priority override and keeps vector-server entrypoints from inheriting proxy mode.
- Documents the cloud vector proxy contract, Cloudflare-ready shape, and FTS fallback behavior.
- Adds mock-remote tests for durable config resolution and remote vector outage fallback.

## Receipt
- Mock remote vector service returning 503 for `/api/search` still lets hybrid search return local FTS results with `vectorAvailable: false` and `warning: Vector proxy unavailable — FTS5-only results`.
- `/api/vector/config` PATCH accepts `vectorProxyUrl`, trims trailing slash, persists it, and returns it in config payload.
- `VECTOR_URL` env still overrides file config.

## Validation
- `bun test --isolate src/config/__tests__/vector-url.test.ts src/routes/vector/__tests__/config.test.ts src/server/__tests__/search-vector-proxy-total.test.ts src/server/__tests__/search-vector-proxy-fallback.test.ts src/server/__tests__/vector-routes-proxy-boundary.test.ts`
- `bun run test:unit` (295 pass)
- `bun run build`
- `git diff --check`

Closes #1378
