### PR TITLE
Make vector search an explicit opt-in

### DIFF
--- a/src/routes/vector/__tests__/config.test.ts
+++ b/src/routes/vector/__tests__/config.test.ts
@@ -22,6 +22,8 @@ describe('/api/vector/config', () => {
     expect(res.status).toBe(200);
     expect(body.source).toBe('defaults');
     expect(body.engine).toBe('lancedb');
+    expect(body.enabled).toBe(false);
+    expect(body.state).toMatchObject({ enabled: false, ready: false, reason: 'vector section disabled' });
     expect(body.config.collections['bge-m3']).toMatchObject({
       adapter: 'lancedb',
       model: 'bge-m3',
@@ -35,6 +37,7 @@ describe('/api/vector/config', () => {
       method: 'PATCH',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
+        enabled: true,
         engine: 'sqlite-vec',
         collections: {
           fast: {
@@ -52,6 +55,10 @@ describe('/api/vector/config', () => {
     expect(res.status).toBe(200);
     expect(body.source).toBe('file');
     expect(body.engine).toBe('sqlite-vec');
+    expect(body.enabled).toBe(true);
+    expect(body.state.enabled).toBe(true);
+    expect(body.state.ready).toBe(false);
+    expect(body.state.recommendedAction).toBe('POST /api/vector/index/start');
     expect(body.config.collections['bge-m3'].adapter).toBe('sqlite-vec');
     expect(body.config.collections.fast).toMatchObject({
       adapter: 'qdrant',

--- a/src/routes/vector/config.ts
+++ b/src/routes/vector/config.ts
@@ -1,9 +1,9 @@
 /**
- * /api/vector/config — active local vector engine + embedding-model registry.
+ * /api/vector/config — vector-section opt-in + local engine/model registry.
  *
  * Reads vector-server.json when present, otherwise returns defaults. PATCH writes
- * the same config file so local adapter selection is durable without requiring
- * the standalone vector server (#1071) path.
+ * the same config file so semantic search is an explicit opt-in after FTS is
+ * already working; no config file is created until the user opts in.
  */
 
 import { Elysia, t } from 'elysia';
@@ -11,10 +11,12 @@ import {
   LOCAL_VECTOR_ENGINES,
   activeVectorEngine,
   applyVectorConfigUpdate,
+  configToModels,
   generateDefaultConfig,
   loadVectorConfig,
   writeVectorConfig,
 } from '../../vector/config.ts';
+import { localNativeVectorDisabledReason, localVectorIndexMissingReason } from '../../vector/cpu-capabilities.ts';
 import type { EmbeddingProviderType } from '../../vector/types.ts';
 
 const providerSchema = t.Union([
@@ -30,6 +32,37 @@ const localEngineSchema = t.Union([
   t.Literal('sqlite-vec'),
 ]);
 
+function vectorReadiness(config: ReturnType<typeof generateDefaultConfig>) {
+  const models = configToModels(config);
+  const collections = Object.fromEntries(Object.entries(models).map(([key, model]) => {
+    const disabledReason = localNativeVectorDisabledReason(model.adapter);
+    const missingReason = disabledReason ? undefined : localVectorIndexMissingReason({
+      type: model.adapter,
+      dataPath: model.dataPath,
+      collectionName: model.collection,
+    });
+    return [key, {
+      key,
+      ready: !disabledReason && !missingReason,
+      reason: disabledReason ?? missingReason,
+      adapter: model.adapter ?? activeVectorEngine(config),
+      collection: model.collection,
+      model: model.model,
+      provider: model.provider ?? 'ollama',
+    }];
+  }));
+  const primaryKey = Object.entries(config.collections).find(([, c]) => c.primary)?.[0] ?? 'bge-m3';
+  const primary = collections[primaryKey] ?? Object.values(collections)[0];
+  return {
+    enabled: config.enabled === true,
+    ready: config.enabled === true && Boolean(primary?.ready),
+    primary: primaryKey,
+    reason: config.enabled === true ? primary?.reason : 'vector section disabled',
+    recommendedAction: config.enabled === true && !primary?.ready ? 'POST /api/vector/index/start' : null,
+    collections,
+  };
+}
+
 function configPayload(source: 'file' | 'defaults', config: ReturnType<typeof generateDefaultConfig>) {
   const collections = Object.fromEntries(
     Object.entries(config.collections).map(([key, collection]) => [key, {
@@ -40,14 +73,17 @@ function configPayload(source: 'file' | 'defaults', config: ReturnType<typeof ge
     }]),
   );
 
+  const effective = { ...config, enabled: config.enabled === true, collections };
   return {
     source,
+    enabled: effective.enabled,
     engine: activeVectorEngine(config),
+    state: vectorReadiness(config),
     options: {
       localEngines: LOCAL_VECTOR_ENGINES,
       embeddingProviders: ['ollama', 'openai', 'cloudflare-ai', 'chromadb-internal'],
     },
-    config: { ...config, collections },
+    config: effective,
   };
 }
 
@@ -61,7 +97,7 @@ export const vectorConfigEndpoint = new Elysia()
     {
       detail: {
         tags: ['vector'],
-        summary: 'Active local vector engine and embedding-model configuration',
+        summary: 'Vector-section opt-in state plus local engine/model configuration',
       },
     },
   )
@@ -80,6 +116,7 @@ export const vectorConfigEndpoint = new Elysia()
     },
     {
       body: t.Optional(t.Object({
+        enabled: t.Optional(t.Boolean()),
         engine: t.Optional(localEngineSchema),
         dataPath: t.Optional(t.String()),
         embeddingEndpoint: t.Optional(t.String()),
@@ -97,7 +134,7 @@ export const vectorConfigEndpoint = new Elysia()
       })),
       detail: {
         tags: ['vector'],
-        summary: 'Update local vector engine and per-collection embedding models',
+        summary: 'Opt in/out of vector section and update local engine/model choices',
       },
     },
   );

--- a/src/server/__tests__/search-vector-opt-in.test.ts
+++ b/src/server/__tests__/search-vector-opt-in.test.ts
@@ -1,0 +1,60 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-vector-opt-in-search-'));
+const originalDataDir = process.env.ORACLE_DATA_DIR;
+const originalDbPath = process.env.ORACLE_DB_PATH;
+const originalRepoRoot = process.env.ORACLE_REPO_ROOT;
+const originalVectorEnabled = process.env.ORACLE_VECTOR_ENABLED;
+
+process.env.ORACLE_DATA_DIR = path.join(tmpRoot, 'data');
+process.env.ORACLE_DB_PATH = path.join(tmpRoot, 'data', 'oracle.db');
+process.env.ORACLE_REPO_ROOT = tmpRoot;
+delete process.env.ORACLE_VECTOR_ENABLED;
+
+const { sqlite, closeDb } = await import('../../db/index.ts');
+const { generateDefaultConfig, writeVectorConfig } = await import('../../vector/config.ts');
+const { handleSearch } = await import('../handlers.ts');
+
+sqlite.exec(`
+  INSERT OR REPLACE INTO oracle_documents
+    (id, type, source_file, concepts, created_at, updated_at, indexed_at, project, created_by)
+  VALUES
+    ('vector-opt-in-doc', 'learning', 'ψ/memory/learnings/vector-opt-in.md', '["semantic"]', 1, 1, 1, NULL, 'indexer')
+`);
+sqlite.prepare('DELETE FROM oracle_fts WHERE id = ?').run('vector-opt-in-doc');
+sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
+  .run('vector-opt-in-doc', 'vector opt in disabled still returns FTS recall', 'semantic');
+
+const cfg = generateDefaultConfig();
+cfg.enabled = false;
+cfg.collections['bge-m3'].adapter = 'qdrant';
+cfg.collections['bge-m3'].qdrantUrl = 'http://127.0.0.1:9';
+writeVectorConfig(cfg);
+
+describe('handleSearch vector opt-in gate', () => {
+  test('local hybrid/vector requests stay FTS-only until vector section is enabled', async () => {
+    for (const mode of ['hybrid', 'vector'] as const) {
+      const result = await handleSearch('opt in disabled', 'all', 5, 0, mode);
+      expect(result.mode).toBe(mode);
+      expect(result.vectorAvailable).toBe(false);
+      expect(result.warning).toBeUndefined();
+      expect(result.results.some(r => r.id === 'vector-opt-in-doc')).toBe(true);
+    }
+  });
+});
+
+afterAll(() => {
+  try { closeDb(); } catch {}
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  if (originalDataDir !== undefined) process.env.ORACLE_DATA_DIR = originalDataDir;
+  else delete process.env.ORACLE_DATA_DIR;
+  if (originalDbPath !== undefined) process.env.ORACLE_DB_PATH = originalDbPath;
+  else delete process.env.ORACLE_DB_PATH;
+  if (originalRepoRoot !== undefined) process.env.ORACLE_REPO_ROOT = originalRepoRoot;
+  else delete process.env.ORACLE_REPO_ROOT;
+  if (originalVectorEnabled !== undefined) process.env.ORACLE_VECTOR_ENABLED = originalVectorEnabled;
+  else delete process.env.ORACLE_VECTOR_ENABLED;
+});

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -18,6 +18,7 @@ import { coerceConcepts } from '../tools/learn.ts';
 import { createVectorProxy } from './vector-proxy.ts';
 import { buildLearningMarkdown, dateSlug } from '../learn/markdown.ts';
 import { localNativeVectorDisabledReason, localVectorIndexMissingReason, logLocalVectorDisabled } from '../vector/cpu-capabilities.ts';
+import { isVectorSectionEnabled } from '../vector/config.ts';
 
 // Module-level proxy instance — bound to VECTOR_URL at boot. If VECTOR_URL is
 // unset, this is null and the local vector adapter runs in-process (legacy
@@ -106,6 +107,7 @@ export async function handleSearch(
   let effectiveMode = mode;
   let vectorDisabledReason: string | undefined;
   let vectorIndexMissingReason: string | undefined;
+  let vectorSectionDisabled = false;
   if (mode !== 'fts' && !vectorProxy) {
     const modelsToCheck = model === 'multi' ? ['bge-m3', 'nomic'] : [model];
     for (const modelKey of modelsToCheck) {
@@ -119,6 +121,9 @@ export async function handleSearch(
       effectiveMode = 'fts';
       warning = `${vectorDisabledReason}; falling back to FTS5-only results`;
       logLocalVectorDisabled(vectorDisabledReason);
+    } else if (!isVectorSectionEnabled()) {
+      vectorSectionDisabled = true;
+      effectiveMode = 'fts';
     } else if (vectorIndexMissingReason) {
       effectiveMode = 'fts';
     }
@@ -201,7 +206,7 @@ export async function handleSearch(
   // (vector wasn't asked for), flips to `false` if the proxy is enabled and
   // the remote call failed — clients use this to render a "vector down" hint
   // while still getting FTS5 results.
-  let vectorAvailable = !vectorDisabledReason && !vectorIndexMissingReason;
+  let vectorAvailable = !vectorSectionDisabled && !vectorDisabledReason && !vectorIndexMissingReason;
 
   // VECTOR_URL set → route the vector leg through the remote service.
   // FTS5 always runs locally above. If the proxy fails we return whatever FTS5

--- a/src/vector/__tests__/config.test.ts
+++ b/src/vector/__tests__/config.test.ts
@@ -25,6 +25,7 @@ const {
 describe('vector-server config', () => {
   test('default config advertises per-collection adapter/provider metadata', () => {
     const cfg = generateDefaultConfig();
+    expect(cfg.enabled).toBe(false);
     expect(cfg.collections['bge-m3'].adapter).toBe('lancedb');
     expect(cfg.collections['bge-m3'].provider).toBe('ollama');
     expect(cfg.collections.nomic.adapter).toBe('lancedb');
@@ -107,8 +108,9 @@ afterAll(() => {
 describe('local vector engine selection', () => {
   test('applyVectorConfigUpdate switches every default collection to sqlite-vec with sqlite path', async () => {
     const { applyVectorConfigUpdate } = await import('../config.ts');
-    const cfg = applyVectorConfigUpdate(generateDefaultConfig(), { engine: 'sqlite-vec' });
+    const cfg = applyVectorConfigUpdate(generateDefaultConfig(), { enabled: true, engine: 'sqlite-vec' });
 
+    expect(cfg.enabled).toBe(true);
     expect(cfg.dataPath.endsWith('vectors.db')).toBe(true);
     expect(Object.values(cfg.collections).every(c => c.adapter === 'sqlite-vec')).toBe(true);
     expect(configToModels(cfg)['bge-m3'].dataPath?.endsWith('vectors.db')).toBe(true);

--- a/src/vector/config.ts
+++ b/src/vector/config.ts
@@ -46,6 +46,7 @@ export interface VectorConfigUpdateCollection {
 }
 
 export interface VectorConfigUpdate {
+  enabled?: boolean;
   engine?: LocalVectorEngine;
   dataPath?: string;
   embeddingEndpoint?: string;
@@ -54,6 +55,7 @@ export interface VectorConfigUpdate {
 
 export interface VectorServerConfig {
   version: string;
+  enabled?: boolean;
   host: string;
   port: number;
   collections: Record<string, VectorCollectionConfig>;
@@ -86,6 +88,7 @@ export function configPath(): string {
 export function generateDefaultConfig(): VectorServerConfig {
   return {
     version: '1.0',
+    enabled: false,
     host: '0.0.0.0',
     port: 8081,
     collections: {
@@ -188,6 +191,8 @@ export function applyVectorConfigUpdate(
 ): VectorServerConfig {
   const next: VectorServerConfig = structuredClone(base);
 
+  if (update.enabled !== undefined) next.enabled = update.enabled;
+
   if (update.engine !== undefined) {
     if (!isLocalVectorEngine(update.engine)) {
       throw new Error(`Unsupported local vector engine: ${String(update.engine)}`);
@@ -233,4 +238,9 @@ export function applyVectorConfigUpdate(
   }
 
   return next;
+}
+
+
+export function isVectorSectionEnabled(config: VectorServerConfig | null = loadVectorConfig()): boolean {
+  return config?.enabled === true || process.env.ORACLE_VECTOR_ENABLED === '1';
 }


### PR DESCRIPTION
## Summary
- Add an explicit vector-section opt-in flag (`enabled`) to `vector-server.json`; defaults remain disabled/FTS-only and no config file is written until PATCH.
- Extend `GET/PATCH /api/vector/config` with enabled state, active engine/model options, readiness per collection, and a recommended vector index action when enabled but not ready.
- Gate local vector search in `handleSearch` so hybrid/vector requests stay FTS-only until the user opts in; CPU/AVX fallback warnings still take precedence.
- Backend-only slice; no `web/` changes, avoiding #1389 UI files.

Closes #1376

## Verification
- `bun run build`
- `bun test --isolate src/vector/__tests__/config.test.ts src/routes/vector/__tests__/config.test.ts src/server/__tests__/search-vector-opt-in.test.ts src/server/__tests__/search-no-avx-fallback.test.ts src/server/__tests__/vector-indexer-config.test.ts src/server/__tests__/vector-routes-proxy-boundary.test.ts src/integration/zero-config-start.test.ts`
