### PR TITLE
Tests: raise vector adapter and MCP tool coverage

### DIFF
--- a/src/tools/__tests__/backend-tools-unit.test.ts
+++ b/src/tools/__tests__/backend-tools-unit.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createDatabase } from '../../db/index.ts';
+import { oracleDocuments } from '../../db/schema.ts';
+import type { ToolContext } from '../types.ts';
+import { handleConcepts } from '../concepts.ts';
+import { handleInbox } from '../inbox.ts';
+import { handleList } from '../list.ts';
+import { handleRead } from '../read.ts';
+import { handleStats } from '../stats.ts';
+import { handleSupersede, runSupersede } from '../supersede.ts';
+
+const tempRoots: string[] = [];
+
+function tempRoot(prefix: string) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempRoots.push(dir);
+  return dir;
+}
+
+function parse(response: { content: Array<{ text: string }> }) {
+  return JSON.parse(response.content[0].text);
+}
+
+function makeCtx(): ToolContext {
+  const repoRoot = tempRoot('arra-tools-repo-');
+  const dbPath = path.join(tempRoot('arra-tools-db-'), 'oracle.db');
+  const { sqlite, db } = createDatabase(dbPath);
+  const now = Date.now();
+
+  db.insert(oracleDocuments).values([
+    {
+      id: 'doc-principle',
+      type: 'principle',
+      sourceFile: 'ψ/principles/nothing.md',
+      concepts: JSON.stringify(['oracle', 'safety']),
+      createdAt: now - 1000,
+      updatedAt: now - 1000,
+      indexedAt: now - 1000,
+      project: 'github.com/soul/arra',
+    },
+    {
+      id: 'doc-learning',
+      type: 'learning',
+      sourceFile: 'ψ/memory/learnings/vector.md',
+      concepts: JSON.stringify(['vector', 'adapter', 'oracle']),
+      createdAt: now,
+      updatedAt: now,
+      indexedAt: now,
+      project: 'github.com/soul/arra',
+    },
+  ]).run();
+
+  sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
+    .run('doc-principle', 'Nothing is Deleted\nKeep append-only history.', 'oracle safety');
+  sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
+    .run('doc-learning', 'Vector adapters switch per collection.', 'vector adapter oracle');
+
+  return {
+    db,
+    sqlite,
+    repoRoot,
+    vectorStore: { name: 'mock-vector' } as any,
+    vectorStatus: 'connected',
+    version: 'test-version',
+  };
+}
+
+afterEach(() => {
+  for (const dir of tempRoots.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('backend MCP tools unit coverage', () => {
+  test('handleConcepts counts JSON and comma concepts with type filter', async () => {
+    const ctx = makeCtx();
+
+    const all = parse(await handleConcepts(ctx, { limit: 10, type: 'all' }));
+    expect(all.total_unique).toBe(4);
+    expect(all.concepts.find((c: any) => c.name === 'oracle').count).toBe(2);
+
+    const learning = parse(await handleConcepts(ctx, { limit: 5, type: 'learning' }));
+    expect(learning.filter_type).toBe('learning');
+    expect(learning.concepts.map((c: any) => c.name)).toContain('adapter');
+    expect(learning.concepts.map((c: any) => c.name)).not.toContain('safety');
+  });
+
+  test('handleList paginates and validates filters', async () => {
+    const ctx = makeCtx();
+
+    const all = parse(await handleList(ctx, { type: 'all', limit: 10, offset: 0 }));
+    expect(all.total).toBe(2);
+    expect(all.documents).toHaveLength(2);
+    expect(all.documents[0].id).toBe('doc-learning');
+
+    const filtered = parse(await handleList(ctx, { type: 'principle', limit: 10, offset: 0 }));
+    expect(filtered.total).toBe(1);
+    expect(filtered.documents[0].type).toBe('principle');
+
+    await expect(handleList(ctx, { type: 'all', limit: 0, offset: 0 })).rejects.toThrow('limit must be between');
+    await expect(handleList(ctx, { type: 'bad' as never, limit: 10, offset: 0 })).rejects.toThrow('Invalid type');
+  });
+
+  test('handleStats returns counts, FTS health, vector status, and version', async () => {
+    const ctx = makeCtx();
+
+    const stats = parse(await handleStats(ctx, {}));
+    expect(stats.total_documents).toBe(2);
+    expect(stats.by_type).toEqual({ learning: 1, principle: 1 });
+    expect(stats.fts_indexed).toBe(2);
+    expect(stats.unique_concepts).toBe(4);
+    expect(stats.vector_status).toBe('connected');
+    expect(stats.version).toBe('test-version');
+  });
+
+  test('handleRead resolves direct files, id lookup, FTS fallback, and not-found errors', async () => {
+    const ctx = makeCtx();
+    const directFile = path.join(ctx.repoRoot, 'ψ/principles/nothing.md');
+    fs.mkdirSync(path.dirname(directFile), { recursive: true });
+    fs.writeFileSync(directFile, '# Nothing is Deleted\nappend-only');
+
+    const direct = parse(await handleRead(ctx, { file: 'ψ/principles/nothing.md' }));
+    expect(direct.source).toBe('file');
+    expect(direct.content).toContain('append-only');
+
+    const byId = parse(await handleRead(ctx, { id: 'doc-principle' }));
+    expect(byId.source).toBe('file');
+    expect(byId.project).toBe('github.com/soul/arra');
+
+    const fallback = parse(await handleRead(ctx, { id: 'doc-learning' }));
+    expect(fallback.source).toBe('fts_cache');
+    expect(fallback.content).toContain('Vector adapters');
+
+    const missing = await handleRead(ctx, { id: 'missing' });
+    expect(missing.isError).toBe(true);
+    expect(parse(missing).error).toContain('Document not found');
+
+    const usage = await handleRead(ctx, {});
+    expect(usage.isError).toBe(true);
+    expect(parse(usage).error).toContain('Provide file or id');
+  });
+
+  test('handleInbox lists handoff files newest first with previews and pagination', async () => {
+    const ctx = makeCtx();
+    const dir = path.join(ctx.repoRoot, 'ψ/inbox/handoff');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, '2026-06-06_01-00_old.md'), 'old handoff');
+    fs.writeFileSync(path.join(dir, '2026-06-07_02-00_new.md'), 'new handoff'.repeat(80));
+
+    const first = parse(await handleInbox(ctx, { type: 'handoff', limit: 1, offset: 0 }));
+    expect(first.total).toBe(2);
+    expect(first.files).toHaveLength(1);
+    expect(first.files[0].filename).toContain('new');
+    expect(first.files[0].preview.length).toBeLessThanOrEqual(500);
+
+    const second = parse(await handleInbox(ctx, { type: 'all', limit: 1, offset: 1 }));
+    expect(second.files[0].filename).toContain('old');
+  });
+
+  test('runSupersede validates inputs and handleSupersede marks the old document', async () => {
+    const ctx = makeCtx();
+
+    expect(runSupersede(ctx.db, null as never).isError).toBe(true);
+    expect(runSupersede(ctx.db, { oldId: '', newId: 'doc-learning' }).isError).toBe(true);
+    expect(runSupersede(ctx.db, { oldId: 'doc-principle', newId: '' }).isError).toBe(true);
+    expect(runSupersede(ctx.db, { oldId: 'doc-principle', newId: 'doc-principle' }).isError).toBe(true);
+
+    const response = parse(await handleSupersede(ctx, {
+      oldId: 'doc-principle',
+      newId: 'doc-learning',
+      reason: 'newer vector note',
+    }));
+    expect(response.success).toBe(true);
+    expect(response.old_id).toBe('doc-principle');
+    expect(response.new_id).toBe('doc-learning');
+
+    const row = ctx.sqlite.prepare('SELECT superseded_by, superseded_reason FROM oracle_documents WHERE id = ?')
+      .get('doc-principle') as { superseded_by: string; superseded_reason: string };
+    expect(row.superseded_by).toBe('doc-learning');
+    expect(row.superseded_reason).toBe('newer vector note');
+  });
+});

--- a/src/vector/__tests__/adapter-methods-unit.test.ts
+++ b/src/vector/__tests__/adapter-methods-unit.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from 'bun:test';
+import { QdrantAdapter } from '../adapters/qdrant.ts';
+import type { EmbeddingProvider } from '../types.ts';
+
+const embedder: EmbeddingProvider = {
+  name: 'unit-embedder',
+  dimensions: 3,
+  model: 'unit-model',
+  async embed(texts: string[]) {
+    return texts.map((text) => text === 'query' ? [0.1, 0.2, 0.3] : [0.3, 0.2, 0.1]);
+  },
+};
+
+describe('QdrantAdapter unit behavior without network', () => {
+  test('not-connected guards are explicit and stats default to zero', async () => {
+    const adapter = new QdrantAdapter('unit_collection', embedder);
+
+    await expect(adapter.ensureCollection()).rejects.toThrow('Qdrant not connected');
+    await expect(adapter.deleteCollection()).rejects.toThrow('Qdrant not connected');
+    await expect(adapter.addDocuments([{ id: 'a', document: 'doc', metadata: {} }])).rejects.toThrow('Qdrant not connected');
+    await expect(adapter.query('query')).rejects.toThrow('Qdrant not connected');
+    await expect(adapter.queryById('a')).rejects.toThrow('Qdrant not connected');
+    expect(await adapter.getStats()).toEqual({ count: 0 });
+    expect(await adapter.getCollectionInfo()).toEqual({ name: 'unit_collection', count: 0 });
+  });
+
+  test('ensureCollection creates missing collection with embedder dimensions', async () => {
+    const adapter = new QdrantAdapter('unit_collection', embedder) as any;
+    const calls: any[] = [];
+    adapter.client = {
+      async getCollection() { throw new Error('missing'); },
+      async createCollection(name: string, config: unknown) { calls.push({ name, config }); },
+    };
+
+    await adapter.ensureCollection();
+
+    expect(calls).toEqual([{
+      name: 'unit_collection',
+      config: { vectors: { size: 3, distance: 'Cosine' } },
+    }]);
+  });
+
+  test('addDocuments embeds passages and upserts payload documents', async () => {
+    const adapter = new QdrantAdapter('unit_collection', embedder) as any;
+    let upsertPayload: any;
+    adapter.client = {
+      async upsert(collection: string, payload: unknown) { upsertPayload = { collection, payload }; },
+    };
+
+    await adapter.addDocuments([
+      { id: 'doc-a', document: 'alpha', metadata: { type: 'learning' } },
+      { id: 'doc-b', document: 'beta', metadata: { source_file: 'b.md' } },
+    ]);
+
+    expect(upsertPayload.collection).toBe('unit_collection');
+    expect(upsertPayload.payload.points).toHaveLength(2);
+    expect(upsertPayload.payload.points[0].payload).toMatchObject({ _id: 'doc-a', document: 'alpha', type: 'learning' });
+    expect(upsertPayload.payload.points[0].vector).toEqual([0.3, 0.2, 0.1]);
+  });
+
+  test('query maps Qdrant similarity scores to distances and metadata', async () => {
+    const adapter = new QdrantAdapter('unit_collection', embedder) as any;
+    let searchRequest: any;
+    adapter.client = {
+      async search(collection: string, request: unknown) {
+        searchRequest = { collection, request };
+        return [
+          { id: 1, score: 0.8, payload: { _id: 'doc-a', document: 'alpha', type: 'learning' } },
+          { id: 2, score: 0.5, payload: { document: 'fallback id', type: 'pattern' } },
+        ];
+      },
+    };
+
+    const result = await adapter.query('query', 2, { type: 'learning' });
+
+    expect(searchRequest.collection).toBe('unit_collection');
+    expect(searchRequest.request).toMatchObject({
+      vector: [0.1, 0.2, 0.3],
+      limit: 2,
+      with_payload: true,
+      filter: { must: [{ key: 'type', match: { value: 'learning' } }] },
+    });
+    expect(result.ids).toEqual(['doc-a', '2']);
+    expect(result.documents).toEqual(['alpha', 'fallback id']);
+    expect(result.distances).toEqual([0.19999999999999996, 0.5]);
+    expect(result.metadatas).toEqual([{ type: 'learning' }, { type: 'pattern' }]);
+  });
+
+  test('queryById retrieves source vector and filters self from neighbors', async () => {
+    const adapter = new QdrantAdapter('unit_collection', embedder) as any;
+    adapter.client = {
+      async retrieve(_collection: string, request: any) {
+        expect(request.with_vector).toBe(true);
+        return [{ id: request.ids[0], vector: [0.4, 0.5, 0.6] }];
+      },
+      async search(_collection: string, request: any) {
+        expect(request.limit).toBe(3);
+        return [
+          { id: 11, score: 1, payload: { _id: 'doc-a', document: 'self' } },
+          { id: 12, score: 0.7, payload: { _id: 'doc-b', document: 'neighbor', source_file: 'b.md' } },
+          { id: 13, score: 0.6, payload: { _id: 'doc-c', document: 'neighbor c' } },
+        ];
+      },
+    };
+
+    const result = await adapter.queryById('doc-a', 2);
+
+    expect(result.ids).toEqual(['doc-b', 'doc-c']);
+    expect(result.documents).toEqual(['neighbor', 'neighbor c']);
+    expect(result.distances).toEqual([0.30000000000000004, 0.4]);
+    expect(result.metadatas[0]).toEqual({ source_file: 'b.md' });
+  });
+});
+
+import { SqliteVecAdapter } from '../adapters/sqlite-vec.ts';
+
+describe('SqliteVecAdapter unit behavior without sqlite-vec extension', () => {
+  test('not-connected guards and empty-result helpers are stable', async () => {
+    const adapter = new SqliteVecAdapter('unit_sqlite', '/tmp/unit-sqlite.db', embedder);
+
+    await expect(adapter.ensureCollection()).rejects.toThrow('sqlite-vec not connected');
+    await expect(adapter.deleteCollection()).rejects.toThrow('sqlite-vec not connected');
+    await expect(adapter.query('query')).rejects.toThrow('sqlite-vec not connected');
+    await expect(adapter.queryById('doc-a')).rejects.toThrow('sqlite-vec not connected');
+    await adapter.addDocuments([]);
+    expect(await adapter.getStats()).toEqual({ count: 0 });
+    expect(await adapter.getCollectionInfo()).toEqual({ name: 'unit_sqlite', count: 0 });
+    expect(await adapter.getAllEmbeddings()).toEqual({ ids: [], embeddings: [], metadatas: [] });
+  });
+});

--- a/src/vector/__tests__/factory-config-selection.test.ts
+++ b/src/vector/__tests__/factory-config-selection.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const originalEnv = { ...process.env };
+
+function restoreEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, originalEnv);
+}
+
+afterEach(() => {
+  restoreEnv();
+});
+
+describe('vector engine/config selection coverage', () => {
+  test('defaultDataPathForEngine maps local engines to expected storage', async () => {
+    const { defaultDataPathForEngine } = await import('../config.ts');
+
+    expect(defaultDataPathForEngine('qdrant')).toBe('');
+    expect(defaultDataPathForEngine('lancedb')).toContain('lancedb');
+    expect(defaultDataPathForEngine('sqlite-vec')).toContain('vectors.db');
+  });
+
+  test('activeVectorEngine prefers primary collection then first collection then lancedb fallback', async () => {
+    const { activeVectorEngine, generateDefaultConfig } = await import('../config.ts');
+    const cfg = generateDefaultConfig();
+
+    cfg.collections['bge-m3'].adapter = 'qdrant';
+    cfg.collections.nomic.adapter = 'sqlite-vec';
+    expect(activeVectorEngine(cfg)).toBe('qdrant');
+
+    delete cfg.collections['bge-m3'].primary;
+    expect(activeVectorEngine(cfg)).toBe('qdrant');
+
+    cfg.collections = {};
+    expect(activeVectorEngine(cfg)).toBe('lancedb');
+  });
+
+  test('applyVectorConfigUpdate switches qdrant without per-collection dataPath leakage', async () => {
+    const { applyVectorConfigUpdate, generateDefaultConfig } = await import('../config.ts');
+    const cfg = generateDefaultConfig();
+    cfg.collections.nomic.dataPath = '/tmp/old-lance';
+
+    const next = applyVectorConfigUpdate(cfg, {
+      engine: 'qdrant',
+      embeddingEndpoint: 'http://ollama.internal:11434',
+    });
+
+    expect(next.dataPath).toBe('');
+    expect(next.embeddingEndpoint).toBe('http://ollama.internal:11434');
+    expect(Object.values(next.collections).every((collection) => collection.adapter === 'qdrant')).toBe(true);
+    expect(Object.values(next.collections).every((collection) => collection.dataPath === undefined)).toBe(true);
+  });
+
+  test('applyVectorConfigUpdate rejects unsupported global and per-collection engines', async () => {
+    const { applyVectorConfigUpdate, generateDefaultConfig } = await import('../config.ts');
+    const cfg = generateDefaultConfig();
+
+    expect(() => applyVectorConfigUpdate(cfg, { engine: 'chroma' as never })).toThrow('Unsupported local vector engine');
+    expect(() => applyVectorConfigUpdate(cfg, {
+      collections: { bad: { adapter: 'cloudflare-vectorize' as never } },
+    })).toThrow('Unsupported local vector engine');
+  });
+
+  test('getVectorStoreConfigByModel carries per-collection model/provider/adapter config', async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-vector-selection-'));
+    const previousDataDir = process.env.ORACLE_DATA_DIR;
+    process.env.ORACLE_DATA_DIR = tmpRoot;
+    try {
+      const { generateDefaultConfig, writeVectorConfig } = await import('../config.ts');
+      const { getEmbeddingModels, getVectorStoreConfigByModel } = await import('../factory.ts');
+      const cfg = generateDefaultConfig();
+      cfg.collections.perCollection = {
+        adapter: 'qdrant',
+        collection: 'oracle_per_collection',
+        model: 'qwen3-embedding',
+        provider: 'ollama',
+        qdrantUrl: 'http://qdrant.local:6333',
+        qdrantApiKey: 'secret-key',
+      };
+      writeVectorConfig(cfg);
+
+      expect(getEmbeddingModels().perCollection).toMatchObject({
+        adapter: 'qdrant',
+        collection: 'oracle_per_collection',
+        model: 'qwen3-embedding',
+      });
+      expect(getVectorStoreConfigByModel('perCollection')).toMatchObject({
+        type: 'qdrant',
+        collectionName: 'oracle_per_collection',
+        embeddingModel: 'qwen3-embedding',
+        qdrantUrl: 'http://qdrant.local:6333',
+        qdrantApiKey: 'secret-key',
+      });
+      expect(getVectorStoreConfigByModel('missing-model')).toMatchObject({
+        type: 'lancedb',
+        collectionName: 'oracle_knowledge_bge_m3',
+        embeddingModel: 'bge-m3',
+      });
+    } finally {
+      if (previousDataDir) process.env.ORACLE_DATA_DIR = previousDataDir;
+      else delete process.env.ORACLE_DATA_DIR;
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('factory constructors wire lancedb/qdrant/sqlite config without connecting', async () => {
+    const { createVectorStore } = await import('../factory.ts');
+
+    const lance = createVectorStore({ type: 'lancedb', collectionName: 'col_lance', dataPath: '/tmp/lance-a', embeddingModel: 'm1' }) as any;
+    expect(lance.name).toBe('lancedb');
+    expect(lance.collectionName).toBe('col_lance');
+    expect(lance.dbPath).toBe('/tmp/lance-a');
+    expect(lance.embedder.model).toBe('m1');
+
+    const qdrant = createVectorStore({ type: 'qdrant', collectionName: 'col_q', qdrantUrl: 'http://q:6333', qdrantApiKey: 'key', embeddingModel: 'm2' }) as any;
+    expect(qdrant.name).toBe('qdrant');
+    expect(qdrant.collectionName).toBe('col_q');
+    expect(qdrant.url).toBe('http://q:6333');
+    expect(qdrant.apiKey).toBe('key');
+    expect(qdrant.embedder.model).toBe('m2');
+
+    const sqlite = createVectorStore({ type: 'sqlite-vec', collectionName: 'col_s', dataPath: '/tmp/sqlite.db', embeddingModel: 'm3' }) as any;
+    expect(sqlite.name).toBe('sqlite-vec');
+    expect(sqlite.collectionName).toBe('col_s');
+    expect(sqlite.dbPath).toBe('/tmp/sqlite.db');
+    expect(sqlite.embedder.model).toBe('m3');
+  });
+});


### PR DESCRIPTION
## Summary
- test-only backend coverage pass (no web changes, no runtime logic changes)
- adds vector config/factory selection tests for local engine switching, unsupported engines, per-collection model routing, and constructor wiring
- adds offline adapter method tests for Qdrant and sqlite-vec guard/helper behavior without live vector services
- adds temp-DB unit tests for low-covered MCP tools: concepts, list, stats, read, inbox, supersede

## Coverage delta (same targeted suite)
Baseline without these tests:
- All files: funcs 31.93%, lines 41.92%
- `src/tools/concepts.ts`: lines 35.29% → 90.62%
- `src/tools/inbox.ts`: lines 39.13% → 100.00%
- `src/tools/list.ts`: lines 33.33% → 98.51%
- `src/tools/read.ts`: lines 14.10% → 85.61%
- `src/tools/stats.ts`: lines 16.18% → 100.00%
- `src/tools/supersede.ts`: lines 21.19% → 100.00%
- `src/vector/adapters/qdrant.ts`: lines 7.23% → 87.12%
- `src/vector/adapters/sqlite-vec.ts`: lines 3.69% → 68.29%

After this PR (rebased on main):
- All files: funcs 51.44%, lines 56.12%
- 122 pass / 9 skip / 0 fail in targeted suite

## Verification
- `bun test --coverage src/vector/__tests__/config.test.ts src/vector/__tests__/adapters.test.ts src/vector/__tests__/factory-config-selection.test.ts src/vector/__tests__/adapter-methods-unit.test.ts src/tools/__tests__/coerce-concepts.test.ts src/tools/__tests__/index.test.ts src/tools/__tests__/learn.test.ts src/tools/__tests__/schedule.test.ts src/tools/__tests__/search.test.ts src/tools/__tests__/backend-tools-unit.test.ts src/tools/__tests__/mcp-concepts-proxy.test.ts src/tools/__tests__/mcp-learn-proxy.test.ts src/tools/__tests__/mcp-proxy-fallback.test.ts src/tools/__tests__/mcp-supersede-proxy.test.ts src/tools/__tests__/mcp-trace-proxy.test.ts src/tools/__tests__/mcp-verify-proxy.test.ts`
- `git diff --check HEAD~1..HEAD`
- `bun run build`

Note: full `src/tools/__tests__/*.test.ts` includes an existing unrelated `learn-enqueue` vault-path failure; excluded from the stable coverage suite above.
