### PR TITLE
Add maw arra plugin

### DIFF
--- a/maw-plugin/README.md
+++ b/maw-plugin/README.md
@@ -1,0 +1,25 @@
+# maw arra plugin
+
+`maw arra` is a compact ARRA Oracle HTTP client for the maw plugin system.
+
+## Install from this repo
+
+```bash
+ln -s $(pwd)/maw-plugin ~/.maw/plugins/arra
+maw plugin enable arra
+```
+
+## Usage
+
+```bash
+maw arra health
+maw arra stats
+maw arra search "oracle memory" --mode fts --limit 5
+maw arra learn "FTS stays useful before vectors" --project arra-oracle-v3
+maw arra trace
+maw arra trace <trace-id>
+```
+
+The base URL resolves from `ORACLE_API`, then `NEO_ARRA_API`, then `http://localhost:47778`.
+
+`learn` sends `Authorization: Bearer $ARRA_API_TOKEN` when `ARRA_API_TOKEN` (or `NEO_ARRA_API_TOKEN`) is set, matching the optional HTTP write gate.

--- a/maw-plugin/__tests__/index.test.ts
+++ b/maw-plugin/__tests__/index.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test';
+import { authHeaders, resolveBaseUrl, runArra } from '../index.ts';
+
+describe('maw arra plugin', () => {
+  test('resolves base URL from ORACLE_API with localhost fallback', () => {
+    expect(resolveBaseUrl({})).toBe('http://localhost:47778');
+    expect(resolveBaseUrl({ ORACLE_API: 'http://example.test:47778/' })).toBe('http://example.test:47778');
+  });
+
+  test('routes search with fts default mode and limit', async () => {
+    const calls: Array<{ path: string; init?: RequestInit }> = [];
+    const result = await runArra(['search', 'hello', 'world'], async (path, init) => {
+      calls.push({ path, init });
+      return { total: 1, results: [{ id: 'doc1', type: 'learning', content: 'hello world memory', score: 0.9 }] };
+    });
+
+    expect(result.ok).toBe(true);
+    expect(calls[0]?.path).toBe('/api/search?q=hello+world&mode=fts&limit=5');
+    expect(result.output).toContain('arra search: 1 result');
+  });
+
+  test('attaches ARRA_API_TOKEN as bearer auth', () => {
+    expect(authHeaders({ ARRA_API_TOKEN: 'secret' })).toEqual({ Authorization: 'Bearer secret' });
+  });
+
+  test('routes learn to POST /api/learn with project', async () => {
+    const calls: Array<{ path: string; init?: RequestInit }> = [];
+    const result = await runArra(['learn', 'new', 'pattern', '--project', 'demo'], async (path, init) => {
+      calls.push({ path, init });
+      return { success: true, id: 'learning_demo' };
+    });
+
+    expect(result.ok).toBe(true);
+    expect(calls[0]?.path).toBe('/api/learn');
+    expect(calls[0]?.init?.method).toBe('POST');
+    expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({ pattern: 'new pattern', project: 'demo' });
+  });
+
+  test('routes compact health and trace commands', async () => {
+    const health = await runArra(['health'], async () => ({ status: 'ok', vectorMode: 'proxied' }));
+    expect(health.output).toContain('vectorMode: proxied');
+
+    const trace = await runArra(['trace', 'abc123'], async (path) => ({ trace_id: path.split('/').pop(), query: 'audit me' }));
+    expect(trace.output).toContain('abc123');
+  });
+});

--- a/maw-plugin/index.ts
+++ b/maw-plugin/index.ts
@@ -1,0 +1,202 @@
+import { DEFAULT_ORACLE_API, normalizeApiBase } from '../cli/src/lib/config.ts';
+
+type InvokeContext = {
+  source?: string;
+  args?: string[];
+  writer?: (...args: unknown[]) => void;
+};
+
+type InvokeResult = {
+  ok: boolean;
+  output?: string;
+  error?: string;
+};
+
+type Requester = (path: string, init?: RequestInit) => Promise<unknown>;
+
+export const command = {
+  name: 'arra',
+  description: 'ARRA Oracle HTTP helper — search, learn, stats, health, trace.',
+};
+
+export function resolveBaseUrl(env: Record<string, string | undefined> = process.env): string {
+  return normalizeApiBase(env.ORACLE_API?.trim() || env.NEO_ARRA_API?.trim() || DEFAULT_ORACLE_API);
+}
+
+export function authHeaders(env: Record<string, string | undefined> = process.env): Record<string, string> {
+  const token = env.ARRA_API_TOKEN?.trim() || env.NEO_ARRA_API_TOKEN?.trim();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+async function requestJson(path: string, init: RequestInit = {}): Promise<unknown> {
+  const headers = {
+    ...(init.body ? { 'content-type': 'application/json' } : {}),
+    ...authHeaders(),
+    ...(init.headers as Record<string, string> | undefined),
+  };
+  const base = resolveBaseUrl();
+  let res: Response;
+  try {
+    // Reuse arra-cli's default URL + normalization helpers; keep maw plugin
+    // routing intentionally simple: ORACLE_API/NEO_ARRA_API or localhost.
+    res = await fetch(`${base}${path}`, { ...init, headers });
+  } catch (error) {
+    throw new Error(`Cannot reach ARRA at ${base}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  const text = await res.text();
+  const data = text ? JSON.parse(text) : null;
+  if (!res.ok) {
+    const message = data && typeof data === 'object' && 'error' in data ? String((data as { error: unknown }).error) : text;
+    throw new Error(`HTTP ${res.status}${message ? `: ${message}` : ''}`);
+  }
+  return data;
+}
+
+function usage(): InvokeResult {
+  return {
+    ok: false,
+    error: 'usage',
+    output: [
+      'usage: maw arra <search|learn|stats|health|trace>',
+      '  search <q> [--mode fts|hybrid|vector] [--limit N]',
+      '  learn <text> [--project P]',
+      '  stats',
+      '  health',
+      '  trace [id]',
+    ].join('\n'),
+  };
+}
+
+function takeFlag(args: string[], name: string): string | undefined {
+  const idx = args.indexOf(name);
+  if (idx === -1) return undefined;
+  return args[idx + 1];
+}
+
+function positional(args: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a.startsWith('--')) { i++; continue; }
+    out.push(a);
+  }
+  return out;
+}
+
+function oneLine(value: unknown, max = 140): string {
+  const text = String(value ?? '').replace(/\s+/g, ' ').trim();
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}
+
+function formatSearch(data: any, query: string): string {
+  const results = Array.isArray(data?.results) ? data.results : [];
+  const total = data?.total ?? results.length;
+  if (!results.length) return `arra search: 0 results for "${query}"`;
+  const lines = [`arra search: ${total} result${Number(total) === 1 ? '' : 's'} for "${query}"`];
+  for (const [i, r] of results.slice(0, 8).entries()) {
+    const label = [r.type, r.source ?? r.mode].filter(Boolean).join('/');
+    lines.push(`${i + 1}. ${label ? `[${label}] ` : ''}${r.id ?? r.source_file ?? 'doc'} score=${r.score ?? 'n/a'}`);
+    lines.push(`   ${oneLine(r.content ?? r.snippet ?? r.text ?? '')}`);
+    if (r.source_file) lines.push(`   → ${r.source_file}`);
+  }
+  return lines.join('\n');
+}
+
+function formatLearn(data: any): string {
+  return [
+    `arra learn: ${data?.success === false ? 'failed' : 'ok'}`,
+    data?.id ? `id: ${data.id}` : undefined,
+    data?.path || data?.file ? `file: ${data.path ?? data.file}` : undefined,
+    data?.message ? oneLine(data.message) : undefined,
+  ].filter(Boolean).join('\n');
+}
+
+function formatStats(data: any): string {
+  const docs = data?.total_documents ?? data?.totalDocuments ?? data?.documents ?? data?.stats?.documents;
+  const fts = data?.fts_count ?? data?.ftsCount ?? data?.stats?.fts;
+  const vector = data?.vector ?? data?.vectors ?? data?.vector_status;
+  return [
+    'arra stats',
+    docs !== undefined ? `docs: ${docs}` : undefined,
+    fts !== undefined ? `fts: ${fts}` : undefined,
+    vector !== undefined ? `vector: ${typeof vector === 'string' ? vector : oneLine(JSON.stringify(vector), 180)}` : undefined,
+  ].filter(Boolean).join('\n');
+}
+
+function formatHealth(data: any): string {
+  return [
+    `arra health: ${data?.status ?? 'unknown'}`,
+    data?.server ? `server: ${data.server}` : undefined,
+    data?.version ? `version: ${data.version}` : undefined,
+    data?.port ? `port: ${data.port}` : undefined,
+    data?.vectorMode ? `vectorMode: ${data.vectorMode}` : undefined,
+    data?.vectorUrl ? `vectorUrl: ${data.vectorUrl}` : undefined,
+    data?.vectorDisabledReason ? `vectorDisabledReason: ${oneLine(data.vectorDisabledReason)}` : undefined,
+  ].filter(Boolean).join('\n');
+}
+
+function formatTrace(data: any, id?: string): string {
+  if (id) {
+    const trace = data?.trace ?? data;
+    return [
+      `arra trace: ${trace?.trace_id ?? trace?.id ?? id}`,
+      trace?.query ? `query: ${oneLine(trace.query)}` : undefined,
+      trace?.status ? `status: ${trace.status}` : undefined,
+      trace?.created_at || trace?.createdAt ? `at: ${trace.created_at ?? trace.createdAt}` : undefined,
+    ].filter(Boolean).join('\n');
+  }
+  const logs = Array.isArray(data?.logs) ? data.logs : [];
+  const traces = Array.isArray(data?.traces) ? data.traces : [];
+  const rows = logs.length ? logs : traces;
+  if (!rows.length) return 'arra trace: no audit rows';
+  const kind = logs.length ? 'search logs' : 'traces';
+  const lines = [`arra trace: latest ${Math.min(rows.length, 8)} ${kind}`];
+  for (const row of rows.slice(0, 8)) {
+    lines.push(`- ${row.id ?? row.trace_id ?? '?'} ${oneLine(row.query ?? row.title ?? row.mode ?? row.type ?? '')}`);
+  }
+  return lines.join('\n');
+}
+
+export async function runArra(args: string[], request: Requester = requestJson): Promise<InvokeResult> {
+  const sub = (args[0] || '').toLowerCase();
+  const rest = args.slice(1);
+  try {
+    if (sub === 'search') {
+      const mode = takeFlag(rest, '--mode') || 'fts';
+      if (!['fts', 'hybrid', 'vector'].includes(mode)) return { ok: false, error: `invalid mode: ${mode}` };
+      const limit = takeFlag(rest, '--limit') || '5';
+      const q = positional(rest).join(' ').trim();
+      if (!q) return { ok: false, error: 'query required', output: 'usage: maw arra search <q> [--mode fts|hybrid|vector] [--limit N]' };
+      const params = new URLSearchParams({ q, mode, limit });
+      const data = await request(`/api/search?${params}`);
+      return { ok: true, output: formatSearch(data, q) };
+    }
+
+    if (sub === 'learn') {
+      const project = takeFlag(rest, '--project');
+      const text = positional(rest).join(' ').trim();
+      if (!text) return { ok: false, error: 'text required', output: 'usage: maw arra learn <text> [--project P]' };
+      const data = await request('/api/learn', {
+        method: 'POST',
+        body: JSON.stringify({ pattern: text, ...(project ? { project } : {}) }),
+      });
+      return { ok: true, output: formatLearn(data) };
+    }
+
+    if (sub === 'stats') return { ok: true, output: formatStats(await request('/api/stats')) };
+    if (sub === 'health') return { ok: true, output: formatHealth(await request('/api/health')) };
+    if (sub === 'trace') {
+      const id = rest[0];
+      const data = await request(id ? `/api/traces/${encodeURIComponent(id)}` : '/api/logs?limit=8');
+      return { ok: true, output: formatTrace(data, id) };
+    }
+
+    return usage();
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  return runArra(ctx.args ?? []);
+}

--- a/maw-plugin/plugin.json
+++ b/maw-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "arra",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Query and write ARRA Oracle over HTTP from maw.",
+  "cli": {
+    "command": "arra",
+    "aliases": ["or"],
+    "help": "maw arra <search|learn|stats|health|trace>"
+  },
+  "capabilities": ["net:http"],
+  "weight": 50,
+  "schemaVersion": 1
+}


### PR DESCRIPTION
## Summary
- Add `maw-plugin/` with `plugin.json` for `maw arra` (`or` alias) and net:http capability.
- Implement compact subcommands over ARRA HTTP: `search`, `learn`, `stats`, `health`, and `trace`.
- Resolve base URL from `ORACLE_API` / `NEO_ARRA_API` / localhost and attach `ARRA_API_TOKEN` / `NEO_ARRA_API_TOKEN` bearer auth for protected writes.
- Add plugin README with symlink install command.

## Notes
- New files only under `maw-plugin/`; no runtime/web changes.
- Search defaults to `mode=fts` for the zero-config floor.

## Tests
- `bun test maw-plugin/__tests__/index.test.ts`
- `bun run build`

Refs #1396
