### PR TITLE
Consume hook-menu studio helpers in-tree

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "commander": "^14.0.3",
         "drizzle-orm": "^0.45.2",
         "elysia": "^1.4.28",
+        "hook-menu": "github:Soul-Brews-Studio/hook-menu",
         "sqlite-vec": "^0.1.9",
       },
       "devDependencies": {
@@ -291,6 +292,8 @@
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
+
+    "hook-menu": ["hook-menu@github:Soul-Brews-Studio/hook-menu#cc5b563", { "peerDependencies": { "@sinclair/typebox": "^0.32.0", "elysia": "^1.0.0" } }, "Soul-Brews-Studio-hook-menu-cc5b563", "sha512-Ta7T8wEP3BDflB4sJpbLw5FptCpv5VnR4jpavuINRSONWyV3sI2XzU3d5Rk2VRHS/dJbOCnzFGSRXrgzmqtXCg=="],
 
     "hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
 

--- a/docs/HOOK-MENU-PACKAGE.md
+++ b/docs/HOOK-MENU-PACKAGE.md
@@ -1,6 +1,6 @@
 # hook-menu package
 
-> **Status**: Extracted, not yet consumed. This repo still uses the in-tree copy under `src/routes/menu/` and `src/menu/`.
+> **Status**: Partially consumed in-tree. Arra now imports compatible backend helpers from `hook-menu`; the richer in-tree menu model/build endpoint remains local until the package catches up with route-owned `detail.menu.path/studio`, DB-backed ordering, custom/gist items, and submenu fields.
 
 The reusable parts of the Oracle navigation system — TypeBox schemas, `buildMenuItems`, studio-tag helpers, and the Elysia plugin — have been lifted into a standalone repo:
 
@@ -37,7 +37,7 @@ Or as a dep:
 
 ## Follow-up
 
-Swapping arra-oracle-v3's in-tree `src/routes/menu/*` + `src/menu/*` for `hook-menu` imports is deliberately **not** part of #906. Track that as a separate task — it's a pure migration once the package stabilizes.
+Part 1 of #1398 consumes the compatible `hook-menu/studio` helpers in-tree and removes those duplicated local implementations. Full replacement of `src/routes/menu/model.ts`, `src/routes/menu/menu.ts`, and `src/menu/*` is intentionally deferred until the package exposes the newer Arra-specific capabilities: route-owned `detail.menu.path/studio`, DB-backed menu rows, `id`/`parentId`, `scope`, `query`, `sourceName`, gist/custom sources, and plugin merging. React `useMenu` / `MenuRenderer` remains part 2.
 
 ## Origin
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "commander": "^14.0.3",
     "drizzle-orm": "^0.45.2",
     "elysia": "^1.4.28",
+    "hook-menu": "github:Soul-Brews-Studio/hook-menu",
     "sqlite-vec": "^0.1.9"
   },
   "devDependencies": {

--- a/src/routes/menu/studio-href.ts
+++ b/src/routes/menu/studio-href.ts
@@ -1,8 +1,1 @@
-import type { MenuItem } from './model.ts';
-
-export function studioHref(item: Pick<MenuItem, 'path' | 'studio'>, currentHost: string): string {
-  if (item.studio) {
-    return `https://${item.studio}${item.path}?host=${encodeURIComponent(currentHost)}`;
-  }
-  return item.path;
-}
+export { studioHref } from 'hook-menu/studio';

--- a/src/routes/menu/studio-tag.ts
+++ b/src/routes/menu/studio-tag.ts
@@ -1,10 +1,1 @@
-const STUDIO_TAG = /^studio:(.+)$/;
-
-export function parseStudioTag(tags: readonly string[] | undefined | null): string | null {
-  if (!tags) return null;
-  for (const tag of tags) {
-    const m = STUDIO_TAG.exec(tag);
-    if (m) return m[1].trim() || null;
-  }
-  return null;
-}
+export { parseStudioTag } from 'hook-menu/studio';


### PR DESCRIPTION
## Summary
- add the extracted `hook-menu` package as an in-tree dependency
- replace duplicated local studio helpers with re-exports from `hook-menu/studio`
- update `docs/HOOK-MENU-PACKAGE.md` to mark partial consumption and document why richer menu pieces remain local for now

## Scope
Lean #1398 part 1 only. React `useMenu` / `MenuRenderer` is intentionally deferred to part 2.

The full menu model/build endpoint is not swapped yet because `hook-menu` v0.1 is narrower than current Arra: it lacks route-owned `detail.menu.path/studio`, DB-backed rows, `id`/`parentId`, `scope`, `query`, `sourceName`, gist/custom sources, and plugin merging.

## Verification
- `bun test tests/http/menu/studio-tag.test.ts src/routes/menu/__tests__/menu-route-metadata.test.ts`
- `bun test tests/http/menu src/routes/menu/__tests__` → 124 pass / 0 fail
- `bun run build`
- `git diff --check HEAD~1..HEAD`

Refs #1398
