### PR TITLE
Isolate vector operations behind boundary

### DIFF
--- a/src/routes/vector/indexer.ts
+++ b/src/routes/vector/indexer.ts
@@ -12,15 +12,10 @@
  */
 
 import { Elysia, t } from 'elysia';
-import { createVectorStore, getEmbeddingModels, getVectorStoreConfigByModel } from '../../vector/factory.ts';
-import type {
-  EmbeddingProviderType,
-  VectorDBType,
-  VectorDocument,
-  VectorStoreAdapter,
-} from '../../vector/types.ts';
+import { getEmbeddingModels } from '../../vector/factory.ts';
 import { loadVectorIndexDocuments, type VectorIndexSource } from './indexer-source.ts';
 import { proxyVectorIndexer } from './indexer-proxy.ts';
+import { localVectorOperations, type RebuildStrategy } from '../../server/vector-operations.ts';
 
 // ── In-memory status (no sqlite writes — avoids the disk I/O problem) ──
 
@@ -47,33 +42,8 @@ let currentJob: IndexJob = {
   startedAt: 0,
 };
 
-export type RebuildStrategy = 'replace' | 'delete-add';
 
-export async function rebuildVectorCollection(
-  store: VectorStoreAdapter,
-  docs: VectorDocument[],
-  batchSize: number,
-  onProgress: (current: number) => void = () => {},
-): Promise<{ strategy: RebuildStrategy }> {
-  await store.connect();
-
-  if (typeof store.replaceDocuments === 'function') {
-    await store.replaceDocuments(docs);
-    onProgress(docs.length);
-    return { strategy: 'replace' };
-  }
-
-  try { await store.deleteCollection(); } catch {}
-  await store.ensureCollection();
-
-  for (let i = 0; i < docs.length; i += batchSize) {
-    const batch = docs.slice(i, i + batchSize);
-    await store.addDocuments(batch);
-    onProgress(Math.min(i + batch.length, docs.length));
-  }
-
-  return { strategy: 'delete-add' };
-}
+export const rebuildVectorCollection = localVectorOperations.rebuildCollection.bind(localVectorOperations);
 
 // ── Endpoints ──────────────────────────────────────────────────────────
 
@@ -94,7 +64,7 @@ export const vectorIndexerEndpoints = new Elysia()
 
     const models = getEmbeddingModels();
     const key = body.model && models[body.model] ? body.model : 'bge-m3';
-    const storeConfig = getVectorStoreConfigByModel(key);
+    const { store, config: storeConfig } = localVectorOperations.createStoreForModel(key);
     const batchSize = body.batchSize ?? (key === 'nomic' ? 100 : 50);
 
     const jobId = `vidx-${Date.now()}`;
@@ -109,15 +79,13 @@ export const vectorIndexerEndpoints = new Elysia()
 
     // Background indexing — fire and forget
     (async () => {
-      let store: VectorStoreAdapter | undefined;
       try {
         const loaded = loadVectorIndexDocuments({ source: body.source, repoRoot: body.repoRoot });
         currentJob.source = loaded.source;
         currentJob.repoRoot = loaded.repoRoot;
         currentJob.total = loaded.docs.length;
 
-        store = createVectorStore(storeConfig);
-        const rebuild = await rebuildVectorCollection(store, loaded.docs, batchSize, current => {
+        const rebuild = await localVectorOperations.rebuildCollection(store, loaded.docs, batchSize, current => {
           currentJob.current = current;
         });
 
@@ -186,46 +154,7 @@ export const vectorIndexerEndpoints = new Elysia()
     const remote = await proxyVectorIndexer('models', set);
     if (remote) return remote;
 
-    const models = getEmbeddingModels();
-    const result: Record<string, {
-      collection: string;
-      model: string;
-      adapter: VectorDBType;
-      provider: EmbeddingProviderType;
-      count?: number;
-    }> = {};
-
-    for (const key of Object.keys(models)) {
-      const storeConfig = getVectorStoreConfigByModel(key);
-      const entry: {
-        collection: string;
-        model: string;
-        adapter: VectorDBType;
-        provider: EmbeddingProviderType;
-        count?: number;
-      } = {
-        collection: storeConfig.collectionName ?? key,
-        model: storeConfig.embeddingModel ?? key,
-        adapter: storeConfig.type ?? 'lancedb',
-        provider: storeConfig.embeddingProvider ?? 'ollama',
-      };
-      let store: ReturnType<typeof createVectorStore> | null = null;
-
-      try {
-        store = createVectorStore(storeConfig);
-        await store.connect();
-        const stats = await store.getStats();
-        entry.count = stats.count;
-      } catch {
-        entry.count = 0;
-      } finally {
-        try { await store?.close(); } catch {}
-      }
-
-      result[key] = entry;
-    }
-
-    return { models: result };
+    return { models: await localVectorOperations.modelStats() };
   }, {
     detail: {
       tags: ['vector-indexer'],

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -7,12 +7,13 @@
 
 import fs from 'fs';
 import path from 'path';
-import { eq, sql, or, inArray } from 'drizzle-orm';
+import { eq, sql, or } from 'drizzle-orm';
 import { db, sqlite, oracleDocuments, indexingStatus, isDbLockError } from '../db/index.ts';
 import { REPO_ROOT, VECTOR_URL } from '../config.ts';
 import { logSearch, logDocumentAccess, logLearning } from './logging.ts';
 import type { SearchResult, SearchResponse } from './types.ts';
 import { ensureVectorStoreConnected, EMBEDDING_MODELS, getVectorStoreConfigByModel } from '../vector/factory.ts';
+import { localVectorOperations } from './vector-operations.ts';
 import { detectProject } from './project-detect.ts';
 import { coerceConcepts } from '../tools/learn.ts';
 import { createVectorProxy } from './vector-proxy.ts';
@@ -230,88 +231,22 @@ export async function handleSearch(
       warning = 'Vector proxy unavailable — FTS5-only results';
     }
   } else if (effectiveMode !== 'fts') {
-    // Determine which models to query
-    const isMulti = model === 'multi';
-    const modelsToQuery = isMulti
-      ? ['bge-m3', 'nomic']
-      : [model && EMBEDDING_MODELS[model] ? model : undefined];
-
-    // Query all models in parallel
-    const modelResults = await Promise.allSettled(
-      modelsToQuery.map(async (m) => {
-        const modelName = m || 'bge-m3';
-        console.log(`[Vector] Searching model=${modelName} for: "${query.substring(0, 30)}..."`);
-        const client = await ensureVectorStoreConnected(m);
-        const whereFilter = type !== 'all' ? { type } : undefined;
-        const chromaResults = await client.query(query, isMulti ? limit : limit * 2, whereFilter);
-
-        if (!chromaResults.ids || chromaResults.ids.length === 0) return [];
-
-        // Get project metadata
-        const rows = db.select({ id: oracleDocuments.id, project: oracleDocuments.project })
-          .from(oracleDocuments)
-          .where(inArray(oracleDocuments.id, chromaResults.ids))
-          .all();
-        const projectMap = new Map<string, string | null>();
-        rows.forEach(r => projectMap.set(r.id, r.project));
-
-        return chromaResults.ids
-          .map((id: string, i: number) => {
-            const distance = chromaResults.distances?.[i] || 0;
-            const similarity = cosineDistanceToSimilarity(distance);
-            const docProject = projectMap.get(id);
-            return {
-              id,
-              type: chromaResults.metadatas?.[i]?.type || 'unknown',
-              content: chromaResults.documents?.[i] || '',
-              source_file: chromaResults.metadatas?.[i]?.source_file || '',
-              concepts: [],
-              project: docProject,
-              source: 'vector' as const,
-              score: similarity,
-              distance,
-              model: modelName
-            };
-          })
-          .filter(r => {
-            if (!resolvedProject) return true;
-            return r.project === resolvedProject || r.project === null;
-          });
-      })
-    );
-
-    // Merge results from all models
-    for (const result of modelResults) {
-      if (result.status === 'fulfilled') {
-        vectorResults.push(...result.value);
-      } else {
-        const msg = result.reason instanceof Error ? result.reason.message : String(result.reason);
-        console.error('[Vector Search Error]', msg);
-        if (!warning) warning = `Vector search error: ${msg}`;
+    try {
+      const vector = await localVectorOperations.search({
+        query,
+        type,
+        limit,
+        project: resolvedProject,
+        model,
+      });
+      vectorResults = vector.results;
+      if (vectorResults.length > 0) {
+        console.log(`[Vector] ${vectorResults.length} results, top scores: ${vectorResults.slice(0, 3).map(r => r.score?.toFixed(3))}`);
       }
-    }
-
-    // For multi-model: deduplicate by id, keep result with best score
-    if (isMulti && vectorResults.length > 0) {
-      const bestByDoc = new Map<string, SearchResult>();
-      for (const r of vectorResults) {
-        const existing = bestByDoc.get(r.id);
-        if (!existing || (r.score || 0) > (existing.score || 0)) {
-          // If found in multiple models, boost score
-          const multiBoost = existing ? 0.05 : 0;
-          bestByDoc.set(r.id, {
-            ...r,
-            score: Math.min(1, (r.score || 0) + multiBoost),
-            source: existing ? 'hybrid' as const : r.source,
-          });
-        }
-      }
-      vectorResults = Array.from(bestByDoc.values());
-      console.log(`[Multi] Merged ${vectorResults.length} unique results from ${modelsToQuery.length} models`);
-    }
-
-    if (vectorResults.length > 0) {
-      console.log(`[Vector] ${vectorResults.length} results, top scores: ${vectorResults.slice(0, 3).map(r => r.score?.toFixed(3))}`);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      console.error('[Vector Search Error]', msg);
+      if (!warning) warning = `Vector search error: ${msg}`;
     }
   }
 

--- a/src/server/vector-handlers.ts
+++ b/src/server/vector-handlers.ts
@@ -21,13 +21,11 @@ import { db, oracleDocuments } from '../db/index.ts';
 import {
   ensureVectorStoreConnected,
   getVectorStoreByModel,
-  getEmbeddingModels,
-  getVectorStoreConfigByModel,
   EMBEDDING_MODELS,
 } from '../vector/factory.ts';
 import type { VectorStoreAdapter } from '../vector/types.ts';
-import { localNativeVectorDisabledReason, localVectorIndexMissingReason } from '../vector/cpu-capabilities.ts';
 import type { SearchResult } from './types.ts';
+import { localVectorOperations } from './vector-operations.ts';
 
 /** Convenience wrapper used by every handler in this file. */
 async function getVectorStore(model?: string): Promise<VectorStoreAdapter> {
@@ -613,44 +611,7 @@ export async function handleVectorStats(): Promise<{
   vector: { enabled: boolean; count: number; collection: string };
   vectors?: Array<{ key: string; model: string; collection: string; count: number; enabled: boolean }>;
 }> {
-  const timeout = parseInt(process.env.ORACLE_CHROMA_TIMEOUT || '5000', 10);
-  const models = getEmbeddingModels();
-  const engines: Array<{ key: string; model: string; collection: string; count: number; enabled: boolean }> = [];
-
-  // Query all registered engines in parallel
-  await Promise.all(
-    Object.entries(models).map(async ([key, preset]) => {
-      try {
-        const cfg = getVectorStoreConfigByModel(key);
-        const unavailable = localNativeVectorDisabledReason(cfg.type) || localVectorIndexMissingReason(cfg);
-        if (unavailable) {
-          engines.push({ key, model: preset.model, collection: preset.collection, count: 0, enabled: false });
-          return;
-        }
-        const store = await ensureVectorStoreConnected(key);
-        const stats = await Promise.race([
-          store.getStats(),
-          new Promise<never>((_, reject) =>
-            setTimeout(() => reject(new Error('timeout')), timeout)
-          ),
-        ]);
-        engines.push({ key, model: preset.model, collection: preset.collection, count: stats.count, enabled: true });
-      } catch {
-        engines.push({ key, model: preset.model, collection: preset.collection, count: 0, enabled: false });
-      }
-    })
-  );
-
-  // Primary = bge-m3 (backward compat)
-  const primary = engines.find(e => e.key === 'bge-m3') || engines[0];
-  return {
-    vector: {
-      enabled: primary?.enabled ?? false,
-      count: primary?.count ?? 0,
-      collection: primary?.collection ?? 'oracle_knowledge_bge_m3',
-    },
-    vectors: engines,
-  };
+  return localVectorOperations.stats();
 }
 
 // ============================================================================
@@ -670,38 +631,5 @@ export async function handleVectorHealth(): Promise<{
   engines: Array<{ key: string; model: string; collection: string; ok: boolean; error?: string }>;
   checked_at: string;
 }> {
-  const timeout = parseInt(process.env.ORACLE_VECTOR_HEALTH_TIMEOUT || '2000', 10);
-  const models = getEmbeddingModels();
-  const engines: Array<{ key: string; model: string; collection: string; ok: boolean; error?: string }> = [];
-
-  await Promise.all(
-    Object.entries(models).map(async ([key, preset]) => {
-      try {
-        const cfg = getVectorStoreConfigByModel(key);
-        const unavailable = localNativeVectorDisabledReason(cfg.type) || localVectorIndexMissingReason(cfg);
-        if (unavailable) {
-          engines.push({ key, model: preset.model, collection: preset.collection, ok: false, error: unavailable });
-          return;
-        }
-        const store = await ensureVectorStoreConnected(key);
-        await Promise.race([
-          store.getStats(),
-          new Promise<never>((_, reject) =>
-            setTimeout(() => reject(new Error('timeout')), timeout)
-          ),
-        ]);
-        engines.push({ key, model: preset.model, collection: preset.collection, ok: true });
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        engines.push({ key, model: preset.model, collection: preset.collection, ok: false, error: msg });
-      }
-    }),
-  );
-
-  const okCount = engines.filter(e => e.ok).length;
-  const status: 'ok' | 'degraded' | 'down' =
-    okCount === engines.length ? 'ok' :
-    okCount === 0 ? 'down' : 'degraded';
-
-  return { status, engines, checked_at: new Date().toISOString() };
+  return localVectorOperations.health();
 }

--- a/src/server/vector-operations.ts
+++ b/src/server/vector-operations.ts
@@ -1,0 +1,254 @@
+import { inArray } from 'drizzle-orm';
+import { db, oracleDocuments } from '../db/index.ts';
+import {
+  createVectorStore,
+  ensureVectorStoreConnected,
+  getEmbeddingModels,
+  getVectorStoreConfigByModel,
+} from '../vector/factory.ts';
+import { localNativeVectorDisabledReason, localVectorIndexMissingReason } from '../vector/cpu-capabilities.ts';
+import type { EmbeddingProviderType, VectorDBType, VectorDocument, VectorStoreAdapter } from '../vector/types.ts';
+import type { SearchResult } from './types.ts';
+
+export interface VectorSearchInput {
+  query: string;
+  type?: string;
+  limit?: number;
+  project?: string | null;
+  model?: string;
+}
+
+export interface VectorSearchOutput {
+  results: SearchResult[];
+  total?: number;
+}
+
+export interface VectorStatsOutput {
+  vector: { enabled: boolean; count: number; collection: string };
+  vectors?: Array<{ key: string; model: string; collection: string; count: number; enabled: boolean }>;
+}
+
+export interface VectorHealthOutput {
+  status: 'ok' | 'degraded' | 'down';
+  engines: Array<{ key: string; model: string; collection: string; ok: boolean; error?: string }>;
+  checked_at: string;
+}
+
+export interface VectorIndexModelInfo {
+  collection: string;
+  model: string;
+  adapter: VectorDBType;
+  provider: EmbeddingProviderType;
+  count?: number;
+}
+
+export type RebuildStrategy = 'replace' | 'delete-add';
+
+export interface VectorOperations {
+  search(input: VectorSearchInput): Promise<VectorSearchOutput>;
+  stats(timeoutMs?: number): Promise<VectorStatsOutput>;
+  health(timeoutMs?: number): Promise<VectorHealthOutput>;
+  modelStats(): Promise<Record<string, VectorIndexModelInfo>>;
+  rebuildCollection(
+    store: VectorStoreAdapter,
+    docs: VectorDocument[],
+    batchSize: number,
+    onProgress?: (current: number) => void,
+  ): Promise<{ strategy: RebuildStrategy }>;
+  createStoreForModel(model: string): { store: VectorStoreAdapter; config: ReturnType<typeof getVectorStoreConfigByModel> };
+}
+
+
+function cosineDistanceToSimilarity(distance: number): number {
+  if (!Number.isFinite(distance)) return 0;
+  return Math.max(0, Math.min(1, 1 - distance / 2));
+}
+
+function modelKeys(model?: string): Array<string | undefined> {
+  const models = getEmbeddingModels();
+  if (model === 'multi') return ['bge-m3', 'nomic'];
+  return [model && models[model] ? model : undefined];
+}
+
+async function searchOneModel(input: VectorSearchInput, model: string | undefined): Promise<SearchResult[]> {
+  const modelName = model || 'bge-m3';
+  const client = await ensureVectorStoreConnected(model);
+  const limit = input.limit ?? 10;
+  const isMulti = input.model === 'multi';
+  const whereFilter = input.type && input.type !== 'all' ? { type: input.type } : undefined;
+  const vectorRows = await client.query(input.query, isMulti ? limit : limit * 2, whereFilter);
+
+  if (!vectorRows.ids || vectorRows.ids.length === 0) return [];
+
+  const rows = db.select({ id: oracleDocuments.id, project: oracleDocuments.project })
+    .from(oracleDocuments)
+    .where(inArray(oracleDocuments.id, vectorRows.ids))
+    .all();
+  const projectMap = new Map<string, string | null>();
+  rows.forEach(r => projectMap.set(r.id, r.project));
+
+  const resolvedProject = input.project?.toLowerCase() ?? null;
+  return vectorRows.ids
+    .map((id: string, i: number) => {
+      const distance = vectorRows.distances?.[i] || 0;
+      const docProject = projectMap.get(id);
+      return {
+        id,
+        type: vectorRows.metadatas?.[i]?.type || 'unknown',
+        content: vectorRows.documents?.[i] || '',
+        source_file: vectorRows.metadatas?.[i]?.source_file || '',
+        concepts: [],
+        project: docProject,
+        source: 'vector' as const,
+        score: cosineDistanceToSimilarity(distance),
+        distance,
+        model: modelName,
+      };
+    })
+    .filter(r => !resolvedProject || r.project === resolvedProject || r.project === null);
+}
+
+function dedupeMultiModel(results: SearchResult[]): SearchResult[] {
+  const bestByDoc = new Map<string, SearchResult>();
+  for (const result of results) {
+    const existing = bestByDoc.get(result.id);
+    if (!existing || (result.score || 0) > (existing.score || 0)) {
+      bestByDoc.set(result.id, {
+        ...result,
+        score: Math.min(1, (result.score || 0) + (existing ? 0.05 : 0)),
+        source: existing ? 'hybrid' as const : result.source,
+      });
+    }
+  }
+  return Array.from(bestByDoc.values());
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) => setTimeout(() => reject(new Error('timeout')), timeoutMs)),
+  ]);
+}
+
+export const localVectorOperations: VectorOperations = {
+  async search(input) {
+    const settled = await Promise.allSettled(modelKeys(input.model).map(model => searchOneModel(input, model)));
+    const results: SearchResult[] = [];
+    const failures: unknown[] = [];
+    for (const result of settled) {
+      if (result.status === 'fulfilled') results.push(...result.value);
+      else failures.push(result.reason);
+    }
+    if (results.length === 0 && failures.length > 0) throw failures[0];
+    return { results: input.model === 'multi' ? dedupeMultiModel(results) : results };
+  },
+
+  async stats(timeoutMs = parseInt(process.env.ORACLE_CHROMA_TIMEOUT || '5000', 10)) {
+    const models = getEmbeddingModels();
+    const engines: Array<{ key: string; model: string; collection: string; count: number; enabled: boolean }> = [];
+
+    await Promise.all(Object.entries(models).map(async ([key, preset]) => {
+      try {
+        const cfg = getVectorStoreConfigByModel(key);
+        const unavailable = localNativeVectorDisabledReason(cfg.type) || localVectorIndexMissingReason(cfg);
+        if (unavailable) {
+          engines.push({ key, model: preset.model, collection: preset.collection, count: 0, enabled: false });
+          return;
+        }
+        const store = await ensureVectorStoreConnected(key);
+        const stats = await withTimeout(store.getStats(), timeoutMs);
+        engines.push({ key, model: preset.model, collection: preset.collection, count: stats.count, enabled: true });
+      } catch {
+        engines.push({ key, model: preset.model, collection: preset.collection, count: 0, enabled: false });
+      }
+    }));
+
+    const primary = engines.find(e => e.key === 'bge-m3') || engines[0];
+    return {
+      vector: {
+        enabled: primary?.enabled ?? false,
+        count: primary?.count ?? 0,
+        collection: primary?.collection ?? 'oracle_knowledge_bge_m3',
+      },
+      vectors: engines,
+    };
+  },
+
+  async health(timeoutMs = parseInt(process.env.ORACLE_VECTOR_HEALTH_TIMEOUT || '2000', 10)) {
+    const models = getEmbeddingModels();
+    const engines: Array<{ key: string; model: string; collection: string; ok: boolean; error?: string }> = [];
+
+    await Promise.all(Object.entries(models).map(async ([key, preset]) => {
+      try {
+        const cfg = getVectorStoreConfigByModel(key);
+        const unavailable = localNativeVectorDisabledReason(cfg.type) || localVectorIndexMissingReason(cfg);
+        if (unavailable) {
+          engines.push({ key, model: preset.model, collection: preset.collection, ok: false, error: unavailable });
+          return;
+        }
+        const store = await ensureVectorStoreConnected(key);
+        await withTimeout(store.getStats(), timeoutMs);
+        engines.push({ key, model: preset.model, collection: preset.collection, ok: true });
+      } catch (error) {
+        engines.push({ key, model: preset.model, collection: preset.collection, ok: false, error: error instanceof Error ? error.message : String(error) });
+      }
+    }));
+
+    const okCount = engines.filter(e => e.ok).length;
+    const status: 'ok' | 'degraded' | 'down' = okCount === engines.length ? 'ok' : okCount === 0 ? 'down' : 'degraded';
+    return { status, engines, checked_at: new Date().toISOString() };
+  },
+
+  async modelStats() {
+    const models = getEmbeddingModels();
+    const result: Record<string, VectorIndexModelInfo> = {};
+    for (const key of Object.keys(models)) {
+      const storeConfig = getVectorStoreConfigByModel(key);
+      const entry: VectorIndexModelInfo = {
+        collection: storeConfig.collectionName ?? key,
+        model: storeConfig.embeddingModel ?? key,
+        adapter: storeConfig.type ?? 'lancedb',
+        provider: storeConfig.embeddingProvider ?? 'ollama',
+      };
+      let store: VectorStoreAdapter | null = null;
+      try {
+        store = createVectorStore(storeConfig);
+        await store.connect();
+        const stats = await store.getStats();
+        entry.count = stats.count;
+      } catch {
+        entry.count = 0;
+      } finally {
+        try { await store?.close(); } catch {}
+      }
+      result[key] = entry;
+    }
+    return result;
+  },
+
+  async rebuildCollection(store, docs, batchSize, onProgress = () => {}) {
+    await store.connect();
+
+    if (typeof store.replaceDocuments === 'function') {
+      await store.replaceDocuments(docs);
+      onProgress(docs.length);
+      return { strategy: 'replace' };
+    }
+
+    try { await store.deleteCollection(); } catch {}
+    await store.ensureCollection();
+
+    for (let i = 0; i < docs.length; i += batchSize) {
+      const batch = docs.slice(i, i + batchSize);
+      await store.addDocuments(batch);
+      onProgress(Math.min(i + batch.length, docs.length));
+    }
+
+    return { strategy: 'delete-add' };
+  },
+
+  createStoreForModel(model) {
+    const config = getVectorStoreConfigByModel(model);
+    return { store: createVectorStore(config), config };
+  },
+};


### PR DESCRIPTION
## Summary
- Add `VectorOperations` boundary for local vector search, stats, health, model stats, and collection rebuild.
- Route hybrid/vector local search, vector stats/health, and vector index model/rebuild operations through that boundary instead of direct route-level adapter factory calls.
- Preserve existing `VECTOR_URL` proxy behavior and keep FTS5 search independent as the always-on floor.

## Notes
- No binary/server split yet; this is the interface refactor foundation for the sidecar slice.
- No web/runtime surface changes.

## Tests
- `bun run build`
- `bun test src/server/__tests__/vector-indexer-rebuild.test.ts`
- `bun test --isolate src/server/__tests__/search-no-avx-fallback.test.ts src/server/__tests__/search-fts-query.test.ts`
- `bun test --isolate src/server/__tests__/vector-indexer-config.test.ts src/server/__tests__/vector-routes-proxy-boundary.test.ts`

Refs #1071
