### PR TITLE
Stabilize CanvasPlugin contract

### DIFF
--- a/docs/PLUGIN-TAXONOMY.md
+++ b/docs/PLUGIN-TAXONOMY.md
@@ -1,0 +1,53 @@
+# Plugin taxonomy
+
+Arra currently has several plugin-shaped extension points. Keep the names below
+precise so `unified plugin system` work does not mix backend lifecycle code with
+frontend renderer code.
+
+## ServerPlugin
+
+**Meaning:** server-side API/lifecycle plugin.
+
+**Code:** `src/server/plugin/types.ts`, `src/server/plugin/loader.ts`,
+`src/server/plugin/unified.ts`.
+
+**Owns:** Elysia routes, API mount paths, startup/shutdown lifecycle, optional
+menu seeding, and server feature boundaries such as federation/maw, gateway,
+vector, trace, and plugin manifest routes.
+
+**Does not own:** browser rendering or canvas scene mounting.
+
+## InstalledPlugin / WasmPlugin
+
+**Meaning:** local plugin package discovered from the user's plugin directory and
+optionally exposed through menu metadata.
+
+**Code:** `src/routes/plugins/model.ts`, `src/routes/plugins/*`,
+`src/routes/menu/*`.
+
+**Owns:** scanning `~/.oracle/plugins` or `ORACLE_PLUGIN_DIR`, reading
+`plugin.json`/`.wasm`, serving `/api/plugins`, and contributing menu entries.
+
+**Does not own:** server lifecycle hooks or bundled canvas renderer execution.
+
+## CanvasPlugin
+
+**Meaning:** frontend renderer plugin for canvas hosts.
+
+**Code:** `src/canvas/plugin.ts`.
+
+**Owns:** a stable renderer contract selected by `/canvas?plugin=<id>` or a
+future `canvas.buildwithoracle.com` host.
+
+Canvas plugins are bundled frontend renderers, not arbitrary code loaded from the
+server plugin registry. The first supported kinds are:
+
+```ts
+type CanvasPlugin =
+  | { id: string; label: string; kind: 'three'; mount: CanvasSceneMount }
+  | { id: string; label: string; kind: 'react'; renderer: CanvasReactRenderer };
+```
+
+Future metadata endpoints such as `GET /api/plugins?kind=canvas` should expose
+CanvasPlugin metadata only. They should not imply dynamic execution of unsigned
+React or Three code from the database.

--- a/src/canvas/__tests__/plugin.test.ts
+++ b/src/canvas/__tests__/plugin.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { CanvasPlugin } from '../index.ts';
+import { isCanvasPlugin } from '../index.ts';
+
+describe('CanvasPlugin contract', () => {
+  test('accepts Three renderer plugins with a mount function', () => {
+    const plugin: CanvasPlugin = {
+      id: 'wave',
+      label: 'Wave',
+      kind: 'three',
+      mount: () => {},
+    };
+
+    expect(isCanvasPlugin(plugin)).toBe(true);
+  });
+
+  test('accepts React renderer plugins with a renderer function', () => {
+    const plugin: CanvasPlugin = {
+      id: 'planets',
+      label: 'Planets',
+      kind: 'react',
+      renderer: () => null,
+    };
+
+    expect(isCanvasPlugin(plugin)).toBe(true);
+  });
+
+  test('rejects server/local plugin shaped objects without a frontend renderer', () => {
+    expect(isCanvasPlugin({ name: 'federation', tier: 'standard', routes: () => null })).toBe(false);
+    expect(isCanvasPlugin({ name: 'menu-plugin', file: 'menu-plugin.wasm', size: 42 })).toBe(false);
+  });
+});

--- a/src/canvas/index.ts
+++ b/src/canvas/index.ts
@@ -1,0 +1,12 @@
+export type {
+  CanvasMountTarget,
+  CanvasPlugin,
+  CanvasPluginCleanup,
+  CanvasPluginKind,
+  CanvasPluginMetadata,
+  CanvasReactPlugin,
+  CanvasReactRenderer,
+  CanvasSceneMount,
+  CanvasThreePlugin,
+} from './plugin.ts';
+export { isCanvasPlugin } from './plugin.ts';

--- a/src/canvas/plugin.ts
+++ b/src/canvas/plugin.ts
@@ -1,0 +1,60 @@
+/**
+ * Frontend renderer plugin contract for canvas surfaces.
+ *
+ * Naming guardrail: CanvasPlugin is not the server-side ServerPlugin and not
+ * the local InstalledPlugin/WasmPlugin exposed by /api/plugins. Canvas plugins
+ * are bundled frontend renderers selected by canvas hosts such as /canvas or a
+ * future canvas.buildwithoracle.com app.
+ */
+export type CanvasPluginKind = 'three' | 'react';
+
+export interface CanvasPluginMetadata {
+  /** Stable URL/config identifier, for example /canvas?plugin=wave. */
+  id: string;
+  /** Human-readable picker label. */
+  label: string;
+  /** Optional short explanation for plugin lists and docs. */
+  description?: string;
+  /** Optional grouping/search metadata. */
+  tags?: string[];
+}
+
+export interface CanvasMountTarget {
+  /** Host element supplied by the canvas runtime. Frontend apps may narrow this to HTMLElement. */
+  element: unknown;
+  /** Optional AbortSignal for teardown-aware renderers. */
+  signal?: AbortSignal;
+}
+
+export type CanvasPluginCleanup = void | (() => void | Promise<void>);
+
+export type CanvasSceneMount = (target: CanvasMountTarget) => CanvasPluginCleanup | Promise<CanvasPluginCleanup>;
+
+export type CanvasReactRenderer<Props extends Record<string, unknown> = Record<string, unknown>> = (
+  props: Props,
+) => unknown;
+
+export type CanvasThreePlugin = CanvasPluginMetadata & {
+  kind: 'three';
+  mount: CanvasSceneMount;
+};
+
+export type CanvasReactPlugin<Props extends Record<string, unknown> = Record<string, unknown>> =
+  CanvasPluginMetadata & {
+    kind: 'react';
+    renderer: CanvasReactRenderer<Props>;
+  };
+
+export type CanvasPlugin<Props extends Record<string, unknown> = Record<string, unknown>> =
+  | CanvasThreePlugin
+  | CanvasReactPlugin<Props>;
+
+export function isCanvasPlugin(value: unknown): value is CanvasPlugin {
+  if (!value || typeof value !== 'object') return false;
+  const plugin = value as Partial<CanvasPlugin>;
+  if (typeof plugin.id !== 'string' || plugin.id.length === 0) return false;
+  if (typeof plugin.label !== 'string' || plugin.label.length === 0) return false;
+  if (plugin.kind === 'three') return typeof plugin.mount === 'function';
+  if (plugin.kind === 'react') return typeof plugin.renderer === 'function';
+  return false;
+}


### PR DESCRIPTION
## Summary\n- define frontend-only CanvasPlugin contract for three/react renderers\n- add plugin taxonomy docs separating ServerPlugin, InstalledPlugin/WasmPlugin, and CanvasPlugin\n- add contract tests for valid canvas renderers and non-canvas plugin shapes\n\n## Tests\n- bun test --isolate src/canvas/__tests__/plugin.test.ts\n- bun run build\n\nCloses #1401