### PR TITLE
Add Docker vector sidecar profile

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,6 +24,8 @@ jobs:
             channel: http
           - target: mcp-stdio
             channel: stdio
+          - target: vector-server
+            channel: vector
     steps:
       - uses: actions/checkout@v4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # arra-oracle-v3 — multi-target image
 #   Default target: http-server  (port 47778, used by docker-compose.yml)
-#   Alt target:     mcp-stdio    (no port, stdio MCP — for Docker MCP Toolkit)
+#   Alt target:     mcp-stdio     (no port, stdio MCP — for Docker MCP Toolkit)
+#   Alt target:     vector-server (port 47779, standalone vector sidecar)
 #
 # Vector search degrades gracefully to SQLite FTS5 when no Ollama embedding
 # backend is reachable — so both images are fully functional standalone.
@@ -8,7 +9,8 @@
 # Build:
 #   docker build -t arra-oracle-v3 .                              # default = http-server
 #   docker build -t arra-oracle-v3:http   --target http-server .  # explicit HTTP server
-#   docker build -t arra-oracle-v3:stdio  --target mcp-stdio .    # MCP stdio variant
+#   docker build -t arra-oracle-v3:stdio  --target mcp-stdio .     # MCP stdio variant
+#   docker build -t arra-oracle-v3:vector --target vector-server . # vector sidecar
 #
 # Run http-server (current behavior):
 #   docker run -p 47778:47778 -v arra-data:/data arra-oracle-v3
@@ -63,6 +65,19 @@ FROM base AS mcp-stdio
 # Force any incidental logging to stderr — protect the stdio JSON-RPC channel.
 ENV ORACLE_LOG_TARGET=stderr
 CMD ["bun", "src/index.ts"]
+
+# ─────────────────────────────────────────────────────────────────────────
+# Target — vector-server (standalone sidecar for VECTOR_URL)
+# ─────────────────────────────────────────────────────────────────────────
+# Runs only vector/search routes and opens oracle.db readonly by default so the
+# core HTTP writer can keep owning SQLite writes. Core points at this with:
+#   VECTOR_URL=http://vector:47779
+FROM base AS vector-server
+ENV ORACLE_VECTOR_SERVER=1 \
+    ORACLE_VECTOR_READONLY=1 \
+    VECTOR_PORT=47779
+EXPOSE 47779
+CMD ["sh", "-c", "touch ${ORACLE_DB_PATH:-/data/oracle.db} && exec bun src/vector-server.ts"]
 
 # ─────────────────────────────────────────────────────────────────────────
 # Target — http-server (DEFAULT; current docker-compose behavior)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,31 +1,66 @@
-# arra-oracle-v3 — full stack: HTTP server + Ollama embedding sidecar
+# arra-oracle-v3 — Docker stack
 #
-# This upgrades the lean FTS5-only image to FULL semantic vector search by
-# wiring an Ollama service. arra reaches it via OLLAMA_BASE_URL (service DNS).
+# Default: HTTP server + Ollama embedding sidecar. Arra still serves FTS5 while
+# models/indexes warm up.
 #
-#   docker compose up -d            # start arra + ollama + pull models
-#   docker compose logs -f arra     # watch the server
+#   docker compose up -d
 #   curl -sf localhost:47778/api/health | jq .
-#   docker compose down             # stop (volumes persist)
-#   docker compose down -v          # stop + wipe data/models
 #
-# First run pulls embedding models (~1.5 GB for bge-m3 + nomic) into the
-# ollama-models volume — slow once, cached after. Until the pull finishes,
-# arra still serves (FTS5 fallback); vector search lights up when models land.
+# Standalone vector sidecar profile (#1071/#1405): run core + vector process.
+# Core keeps SQLite/FTS5 and proxies vector operations to the vector service.
+#
+#   VECTOR_URL=http://vector:47779 docker compose --profile vector up -d
+#   curl -sf localhost:47778/api/health | jq .vectorMode
+#
+# Stop:
+#   docker compose down             # volumes persist
+#   docker compose down -v          # wipe data/models
+
+x-arra-http: &arra-http
+  build:
+    context: .
+    target: http-server
+  image: arra-oracle-v3:slim
+  environment: &arra-http-env
+    OLLAMA_BASE_URL: http://ollama:11434
+    ORACLE_DATA_DIR: /data
+    HOME: /data
+    ORACLE_PORT: "47778"
+  volumes:
+    - arra-data:/data
+  depends_on:
+    ollama:
+      condition: service_healthy
+  restart: unless-stopped
 
 services:
+  # Core server. Set VECTOR_URL=http://vector:47779 when enabling the vector
+  # profile so vector operations route to the sidecar service.
   arra:
-    build: .
-    image: arra-oracle-v3:slim
+    <<: *arra-http
     ports:
       - "47778:47778"
     environment:
-      OLLAMA_BASE_URL: http://ollama:11434   # reach the sidecar by service name
+      <<: *arra-http-env
+      VECTOR_URL: ${VECTOR_URL:-}
+
+  vector:
+    profiles: ["vector"]
+    build:
+      context: .
+      target: vector-server
+    image: arra-oracle-v3:vector
+    environment:
+      OLLAMA_BASE_URL: http://ollama:11434
       ORACLE_DATA_DIR: /data
       HOME: /data
-      ORACLE_PORT: "47778"
+      VECTOR_PORT: "47779"
+      ORACLE_VECTOR_SERVER: "1"
+      ORACLE_VECTOR_READONLY: "1"
     volumes:
-      - arra-data:/data                       # SQLite + LanceDB + ψ/ vault
+      - arra-data:/data
+    expose:
+      - "47779"
     depends_on:
       ollama:
         condition: service_healthy
@@ -33,29 +68,15 @@ services:
 
   ollama:
     image: ollama/ollama:latest
-    # Expose 11434 on the host only if you want to poke ollama directly:
-    # ports:
-    #   - "11434:11434"
     volumes:
-      - ollama-models:/root/.ollama           # persist pulled models
+      - ollama-models:/root/.ollama
     healthcheck:
       test: ["CMD-SHELL", "ollama list >/dev/null 2>&1 || exit 1"]
       interval: 10s
       timeout: 5s
-      retries: 12                              # ~2 min grace for cold start
+      retries: 12
     restart: unless-stopped
-    # GPU (NVIDIA only; no effect on macOS Docker Desktop — CPU works fine):
-    # deploy:
-    #   resources:
-    #     reservations:
-    #       devices:
-    #         - driver: nvidia
-    #           count: all
-    #           capabilities: [gpu]
 
-  # One-shot: pull the embedding models, then exit. Re-runs are instant
-  # (already-pulled models are skipped). qwen3 is opt-in — uncomment if you
-  # query model=qwen3 (adds ~600 MB).
   ollama-pull:
     image: ollama/ollama:latest
     depends_on:
@@ -67,7 +88,6 @@ services:
     command: >
       "ollama pull bge-m3 &&
        ollama pull nomic-embed-text"
-    #   && ollama pull qwen3-embedding"
     restart: "no"
 
 volumes:

--- a/docs/DOCKER-MCP-TOOLKIT.md
+++ b/docs/DOCKER-MCP-TOOLKIT.md
@@ -1,11 +1,12 @@
 # Docker MCP Toolkit
 
-Arra ships two Docker targets:
+Arra ships three Docker targets:
 
 | Target | Image tag | Purpose |
 |---|---|---|
 | `http-server` | `ghcr.io/soul-brews-studio/arra-oracle-v3:http` / `:latest` | Long-running HTTP writer on port `47778` |
 | `mcp-stdio` | `ghcr.io/soul-brews-studio/arra-oracle-v3:stdio` | Stdio MCP server for Docker MCP Toolkit / Gateway |
+| `vector-server` | `ghcr.io/soul-brews-studio/arra-oracle-v3:vector` | Standalone vector sidecar for `VECTOR_URL` on port `47779` |
 
 The stdio target sets `ORACLE_LOG_TARGET=stderr` so JSON-RPC stays clean on stdout.
 
@@ -22,7 +23,24 @@ docker build -t arra-oracle-v3:stdio --target mcp-stdio .
 printf '%s\n' \
   '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}' \
   | docker run -i --rm -v arra-oracle-data:/data arra-oracle-v3:stdio
+
+# Vector sidecar target
+docker build -t arra-oracle-v3:vector --target vector-server .
+docker run --rm -p 47903:47779 -v arra-oracle-data:/data arra-oracle-v3:vector
+curl -fsS http://localhost:47903/api/vector/health
 ```
+
+## Standalone vector sidecar profile
+
+Use the `vector` compose profile when you want core HTTP/FTS5 in one process and vector operations in another process. Set `VECTOR_URL=http://vector:47779` when enabling the profile; Compose starts the normal `arra` core plus the `vector` sidecar target.
+
+```bash
+VECTOR_URL=http://vector:47779 docker compose --profile vector up -d
+curl -fsS http://localhost:47778/api/health | jq .vectorMode   # proxied
+curl -fsS 'http://localhost:47778/api/search?q=oracle&mode=hybrid' | jq .vectorAvailable
+```
+
+FTS5 remains local to the core server. If the vector sidecar is unavailable, hybrid search returns local FTS5 results with `vectorAvailable: false`.
 
 ## Docker MCP Gateway (stdio clients)
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -134,6 +134,17 @@ bun run server
 
 Without uvx, Oracle falls back to FTS5-only search (still works).
 
+### Docker vector sidecar
+
+For process separation, build/run the `vector-server` Docker target or use the compose `vector` profile:
+
+```bash
+docker build -t arra-oracle-v3:vector --target vector-server .
+VECTOR_URL=http://vector:47779 docker compose --profile vector up -d
+```
+
+With `VECTOR_URL=http://vector:47779`, the core service proxies vector work to the vector container, which runs `src/vector-server.ts` with `ORACLE_VECTOR_SERVER=1` and `ORACLE_VECTOR_READONLY=1`. FTS5 stays available in the core process if the vector sidecar is down.
+
 ## Troubleshooting
 
 ### Search returns 0 results after indexing


### PR DESCRIPTION
## Summary
- Add Dockerfile `vector-server` target for `src/vector-server.ts` with `ORACLE_VECTOR_SERVER=1`, `ORACLE_VECTOR_READONLY=1`, and `VECTOR_PORT=47779`.
- Add GHCR publish matrix entry for `ghcr.io/soul-brews-studio/arra-oracle-v3:vector`.
- Add docker-compose `vector` profile sidecar; operators enable it with `VECTOR_URL=http://vector:47779 docker compose --profile vector up -d` so core HTTP/FTS5 proxies vector work to the sidecar.
- Update Docker/install docs for vector target/profile usage.

## Verification
- `docker compose config`
- `VECTOR_URL=http://vector:47779 docker compose --profile vector config`
- `docker build --target vector-server -t arra-oracle-v3:vector-test .`
- `docker run ... arra-oracle-v3:vector-test` + `GET /api/vector/health` smoke: server stayed up readonly; fresh volume returned expected `503 status=down` because no LanceDB index exists yet.
- `bun run build`
- `bun test --isolate src/server/__tests__/search-vector-proxy-fallback.test.ts src/server/__tests__/search-vector-proxy-total.test.ts src/server/__tests__/vector-routes-proxy-boundary.test.ts src/server/__tests__/vector-server-route.test.ts`

## Not tested
- Full compose runtime with Ollama model pulls and a populated vector index.

Refs #1405
