### PR TITLE
Expose canvas plugin metadata bridge

### DIFF
--- a/docs/PLUGIN-TAXONOMY.md
+++ b/docs/PLUGIN-TAXONOMY.md
@@ -48,6 +48,7 @@ type CanvasPlugin =
   | { id: string; label: string; kind: 'react'; renderer: CanvasReactRenderer };
 ```
 
-Future metadata endpoints such as `GET /api/plugins?kind=canvas` should expose
-CanvasPlugin metadata only. They should not imply dynamic execution of unsigned
-React or Three code from the database.
+`GET /api/plugins?kind=canvas` exposes CanvasPlugin metadata (`id`, `label`,
+`kind`, `renderer`) for Studio and future canvas hosts to share one plugin list.
+It exposes metadata only and does not imply dynamic execution of unsigned React
+or Three code from the database.

--- a/src/canvas/index.ts
+++ b/src/canvas/index.ts
@@ -10,3 +10,5 @@ export type {
   CanvasThreePlugin,
 } from './plugin.ts';
 export { isCanvasPlugin } from './plugin.ts';
+export type { CanvasPluginMetadataEntry, CanvasPluginRenderer } from './metadata.ts';
+export { CANVAS_PLUGIN_METADATA, listCanvasPluginMetadata } from './metadata.ts';

--- a/src/canvas/metadata.ts
+++ b/src/canvas/metadata.ts
@@ -1,0 +1,81 @@
+import type { CanvasPluginKind } from './plugin.ts';
+
+export type CanvasPluginRenderer = 'Three' | 'React';
+
+export interface CanvasPluginMetadataEntry {
+  id: string;
+  label: string;
+  kind: CanvasPluginKind;
+  renderer: CanvasPluginRenderer;
+  description?: string;
+}
+
+export const CANVAS_PLUGIN_METADATA: CanvasPluginMetadataEntry[] = [
+  {
+    id: 'cube',
+    label: 'Cube',
+    kind: 'three',
+    renderer: 'Three',
+    description: 'Bundled Three.js cube scene.',
+  },
+  {
+    id: 'galaxy',
+    label: 'Galaxy',
+    kind: 'three',
+    renderer: 'Three',
+    description: 'Bundled Three.js galaxy scene.',
+  },
+  {
+    id: 'torus',
+    label: 'Torus',
+    kind: 'three',
+    renderer: 'Three',
+    description: 'Bundled Three.js torus scene.',
+  },
+  {
+    id: 'graph3d',
+    label: 'Graph 3D',
+    kind: 'three',
+    renderer: 'Three',
+    description: 'Bundled Three.js graph scene.',
+  },
+  {
+    id: 'solar',
+    label: 'Solar',
+    kind: 'three',
+    renderer: 'Three',
+    description: 'Bundled Three.js solar scene.',
+  },
+  {
+    id: 'wave',
+    label: 'Wave',
+    kind: 'three',
+    renderer: 'Three',
+    description: 'Bundled Three.js wave scene.',
+  },
+  {
+    id: 'map3d',
+    label: 'Map 3D',
+    kind: 'three',
+    renderer: 'Three',
+    description: 'Bundled Three.js map scene.',
+  },
+  {
+    id: 'map',
+    label: 'Knowledge Map',
+    kind: 'react',
+    renderer: 'React',
+    description: 'React canvas plugin target for the knowledge map.',
+  },
+  {
+    id: 'planets',
+    label: 'Planets',
+    kind: 'react',
+    renderer: 'React',
+    description: 'React canvas plugin target for the planet/orbit view.',
+  },
+];
+
+export function listCanvasPluginMetadata(): { kind: 'canvas'; plugins: CanvasPluginMetadataEntry[] } {
+  return { kind: 'canvas', plugins: CANVAS_PLUGIN_METADATA };
+}

--- a/src/routes/plugins/__tests__/canvas-metadata.test.ts
+++ b/src/routes/plugins/__tests__/canvas-metadata.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+
+import { pluginsRouter } from '../index.ts';
+
+describe('/api/plugins?kind=canvas', () => {
+  test('returns CanvasPlugin metadata without scanning installed wasm plugins', async () => {
+    const app = new Elysia().use(pluginsRouter);
+    const response = await app.handle(new Request('http://localhost/api/plugins?kind=canvas'));
+    const body = await response.json() as {
+      kind: string;
+      plugins: Array<{ id: string; kind: string; renderer: string }>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.kind).toBe('canvas');
+    expect(body.plugins).toContainEqual(expect.objectContaining({ id: 'wave', kind: 'three', renderer: 'Three' }));
+    expect(body.plugins).toContainEqual(expect.objectContaining({ id: 'map', kind: 'react', renderer: 'React' }));
+    expect(body.plugins).toContainEqual(expect.objectContaining({ id: 'planets', kind: 'react', renderer: 'React' }));
+  });
+});

--- a/src/routes/plugins/list.ts
+++ b/src/routes/plugins/list.ts
@@ -1,10 +1,19 @@
-import { Elysia } from 'elysia';
+import { Elysia, t } from 'elysia';
+import { listCanvasPluginMetadata } from '../../canvas/index.ts';
 import { scanPlugins } from './model.ts';
 
-export const pluginsListRoute = new Elysia().get('/api/plugins', () => scanPlugins(), {
+const PluginListQuery = t.Object({
+  kind: t.Optional(t.String()),
+});
+
+export const pluginsListRoute = new Elysia().get('/api/plugins', ({ query }) => {
+  if (query.kind === 'canvas') return listCanvasPluginMetadata();
+  return scanPlugins();
+}, {
+  query: PluginListQuery,
   detail: {
     tags: ['plugins'],
     menu: { group: 'main', path: '/plugins', order: 70 },
-    summary: 'List available plugins',
+    summary: 'List available plugins or canvas plugin metadata',
   },
 });


### PR DESCRIPTION
## Summary
- add shared CanvasPlugin metadata for current Three plugins plus map/planets React targets
- expose `GET /api/plugins?kind=canvas` as metadata-only bridge
- document that canvas metadata is not dynamic unsigned renderer execution

## Tests
- bun test --isolate src/routes/plugins/__tests__/canvas-metadata.test.ts src/canvas/__tests__/plugin.test.ts
- bun run build

Closes #1404
