### PR TITLE
Design unified plugin manifest

### DIFF
--- a/docs/UNIFIED-PLUGIN.md
+++ b/docs/UNIFIED-PLUGIN.md
@@ -1,0 +1,124 @@
+# Unified plugin manifest
+
+Issue #1412 extends the plugin taxonomy from `docs/PLUGIN-TAXONOMY.md` into one
+manifest shape. The goal is one `plugin.json` that can declare every capability a
+plugin contributes while preserving the current ServerPlugin, Installed/Wasm,
+CanvasPlugin, and CLI plugin surfaces.
+
+This is a design-first slice: schema, migration map, reference manifest, and
+validation tests. Runtime wiring should land surface-by-surface after this doc is
+accepted.
+
+## Manifest shape
+
+```ts
+type UnifiedPluginManifest = {
+  name: string;
+  version: string;
+  entry: string;
+  sdk?: string;
+  tier?: 'core' | 'standard' | 'extra';
+  enabled?: boolean;
+  description?: string;
+
+  mcpTools?: McpToolContribution[];
+  apiRoutes?: ApiRouteContribution[];
+  proxy?: ProxyContribution[];
+  server?: ServerContribution;
+  menu?: MenuContribution[];
+  cliSubcommands?: CliSubcommandContribution[];
+
+  // Back-compat aliases consumed by current loaders during migration.
+  api?: { path: string; methods?: HttpMethod[] };
+  lifecycle?: { start?: boolean; stop?: boolean };
+  seedMenu?: boolean;
+  cli?: { command: string; help: string };
+};
+```
+
+The implemented TypeScript schema/normalizer lives in
+`src/plugins/unified-manifest.ts`. A reference plugin manifest lives at
+`docs/examples/unified-plugin/plugin.json`.
+
+## Six capability surfaces
+
+| Surface | Manifest key | Current owner | Unified migration |
+| --- | --- | --- | --- |
+| MCP tools | `mcpTools[]` | in-tree `src/tools/*` plus `src/index.ts` switch | Add dynamic MCP tool registry fed by normalized manifests. |
+| API routes | `apiRoutes[]` | `ServerPlugin.api` + `routes()` | Normalize legacy `api` into `apiRoutes[]`; then mount via ServerPlugin bridge. |
+| Proxy | `proxy[]` | gateway/vector-specific config | Add generic gateway entries from manifest path → target env. |
+| Serve server | `server` | lifecycle/vector-server patterns | Spawn/health-check plugin-owned server from lifecycle manager. |
+| URL/menu path | `menu[]` | menu DB/plugin metadata | Seed or expose menu contribution without treating it as renderer code. |
+| CLI subcommand | `cliSubcommands[]` | `cli/src/plugins/*/plugin.json` | Normalize legacy `cli` into command entries and register with CLI loader. |
+
+## MCP tool registration gap
+
+This is the largest missing capability. Today MCP tools are static:
+
+1. definitions are imported from `src/tools/*`;
+2. `src/index.ts` lists them in `ListToolsRequestSchema`;
+3. calls are routed by a `switch (toolName)`;
+4. `src/config/tool-groups.ts` only knows static names in `TOOL_GROUPS`.
+
+A plugin MCP tool needs a dynamic registry before it can be advertised or called:
+
+```ts
+type RegisteredMcpTool = {
+  pluginName: string;
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  group: string;              // e.g. "canvas" or "plugin:<name>"
+  readOnly: boolean;
+  enabledByDefault: boolean;
+  call(args, ctx): Promise<ToolResponse>;
+};
+```
+
+Recommended runtime flow:
+
+1. load and normalize all unified manifests;
+2. for each `mcpTools[]` item, import `entry` and bind `handler`;
+3. append registered tool definitions to `ListToolsRequestSchema` output;
+4. before the static `switch`, dispatch `toolName` to the dynamic registry;
+5. extend tool toggles so plugin tools are known names, not ignored typos.
+
+### Toggle integration (#1372)
+
+`getDisabledTools()` currently rejects names not present in its static
+`ALL_TOOL_NAMES`. Plugin tools need an additional known-tool set:
+
+```ts
+getDisabledTools(config, { extraToolNames: registry.toolNames() })
+```
+
+Resolution should stay the same:
+
+1. disabled groups;
+2. `disabled_tools` blocklist;
+3. `enabled_tools` whitelist;
+4. `allowed_tools` strict allow-list.
+
+For groups, plugin tools can use their manifest `group` field. If no group is
+provided, default to `plugin:<manifest.name>`. Existing config files keep working
+because no static tool names change.
+
+## Mapping existing plugin types
+
+- **ServerPlugin** remains the runtime API/lifecycle adapter. Unified manifests
+  normalize `api` → `apiRoutes[]` and `lifecycle`/`server` into a ServerPlugin
+  bridge during migration.
+- **InstalledPlugin/WasmPlugin** remains the local install/menu scanner. It can
+  read unified `menu[]` later, but it should not execute renderer or MCP code.
+- **CanvasPlugin** remains frontend bundled renderer code. Unified manifests may
+  expose metadata/menu entries for canvas plugins, but must not imply dynamic
+  unsigned React/Three execution.
+- **CLI plugins** keep their current `cli` key until the CLI loader consumes
+  `cliSubcommands[]` directly.
+
+## Non-goals for this PR
+
+- No dynamic MCP execution yet.
+- No generic proxy/server process manager yet.
+- No npm package extraction.
+- No subdomain deploy work.

--- a/docs/examples/unified-plugin/plugin.json
+++ b/docs/examples/unified-plugin/plugin.json
@@ -1,0 +1,47 @@
+{
+  "name": "canvas-inspector",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^0.1.0",
+  "tier": "extra",
+  "enabled": false,
+  "description": "Reference unified manifest plugin with MCP tool, API route, menu path, and CLI command surfaces.",
+  "mcpTools": [
+    {
+      "name": "oracle_canvas_inspect",
+      "description": "Inspect registered canvas plugin metadata.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" }
+        }
+      },
+      "handler": "inspectCanvasPlugin",
+      "group": "canvas",
+      "readOnly": true,
+      "enabledByDefault": false
+    }
+  ],
+  "apiRoutes": [
+    {
+      "path": "/api/plugins/canvas-inspector",
+      "methods": ["GET"],
+      "handler": "canvasInspectorRoute"
+    }
+  ],
+  "menu": [
+    {
+      "label": "Canvas Inspector",
+      "path": "/tools/canvas-inspector",
+      "group": "tools",
+      "order": 82
+    }
+  ],
+  "cliSubcommands": [
+    {
+      "command": "canvas-inspect",
+      "help": "Inspect canvas plugin metadata",
+      "handler": "canvasInspectCli"
+    }
+  ]
+}

--- a/src/plugins/__tests__/unified-manifest.test.ts
+++ b/src/plugins/__tests__/unified-manifest.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  manifestSurfaces,
+  mcpToolNamesForToggle,
+  normalizeUnifiedPluginManifest,
+} from '../unified-manifest.ts';
+
+describe('unified plugin manifest schema', () => {
+  test('normalizes reference plugin with multiple capability surfaces', () => {
+    const raw = JSON.parse(readFileSync(join(process.cwd(), 'docs/examples/unified-plugin/plugin.json'), 'utf8'));
+    const manifest = normalizeUnifiedPluginManifest(raw);
+
+    expect(manifest.name).toBe('canvas-inspector');
+    expect(manifestSurfaces(manifest)).toEqual(['mcpTools', 'apiRoutes', 'menu', 'cliSubcommands']);
+    expect(mcpToolNamesForToggle(manifest)).toEqual(['oracle_canvas_inspect']);
+  });
+
+  test('maps legacy ServerPlugin/CLI aliases into unified surfaces', () => {
+    const manifest = normalizeUnifiedPluginManifest({
+      name: 'legacy-bridge',
+      version: '1.0.0',
+      entry: './index.ts',
+      sdk: '^0.0.1',
+      api: { path: '/api/legacy-bridge', methods: ['GET'] },
+      cli: { command: 'legacy-bridge', help: 'legacy bridge command' },
+    });
+
+    expect(manifest.apiRoutes).toEqual([{ path: '/api/legacy-bridge', methods: ['GET'] }]);
+    expect(manifest.cliSubcommands).toEqual([{ command: 'legacy-bridge', help: 'legacy bridge command' }]);
+    expect(manifestSurfaces(manifest)).toEqual(['apiRoutes', 'cliSubcommands']);
+  });
+
+  test('rejects invalid MCP tool names before registry wiring', () => {
+    expect(() => normalizeUnifiedPluginManifest({
+      name: 'bad-tool',
+      version: '1.0.0',
+      entry: './index.ts',
+      mcpTools: [{ name: 'Bad Tool', description: 'bad', inputSchema: {}, handler: 'run' }],
+    })).toThrow('mcpTools.name');
+  });
+});

--- a/src/plugins/unified-manifest.ts
+++ b/src/plugins/unified-manifest.ts
@@ -1,0 +1,187 @@
+import type { ServerPluginTier } from '../server/plugin/types.ts';
+
+export type UnifiedPluginSurface =
+  | 'mcpTools'
+  | 'apiRoutes'
+  | 'proxy'
+  | 'server'
+  | 'menu'
+  | 'cliSubcommands';
+
+export type UnifiedHttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'ALL';
+export type UnifiedPluginRenderer = 'Three' | 'React';
+
+export interface UnifiedMcpToolManifest {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  handler: string;
+  group?: string;
+  readOnly?: boolean;
+  enabledByDefault?: boolean;
+}
+
+export interface UnifiedApiRouteManifest {
+  path: string;
+  methods?: UnifiedHttpMethod[];
+  handler?: string;
+}
+
+export interface UnifiedProxyManifest {
+  path: string;
+  targetEnv: string;
+  stripPrefix?: boolean;
+  methods?: UnifiedHttpMethod[];
+}
+
+export interface UnifiedServerManifest {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  healthPath?: string;
+  autostart?: boolean;
+}
+
+export interface UnifiedMenuManifest {
+  label: string;
+  path: string;
+  group?: 'main' | 'tools' | 'hidden';
+  order?: number;
+  icon?: string;
+}
+
+export interface UnifiedCliSubcommandManifest {
+  command: string;
+  help: string;
+  handler?: string;
+}
+
+export interface UnifiedPluginManifest {
+  name: string;
+  version: string;
+  entry: string;
+  sdk?: string;
+  tier?: ServerPluginTier;
+  enabled?: boolean;
+  description?: string;
+  mcpTools?: UnifiedMcpToolManifest[];
+  apiRoutes?: UnifiedApiRouteManifest[];
+  proxy?: UnifiedProxyManifest[];
+  server?: UnifiedServerManifest;
+  menu?: UnifiedMenuManifest[];
+  cliSubcommands?: UnifiedCliSubcommandManifest[];
+
+  /** Legacy compatibility aliases used by existing ServerPlugin/CLI manifests. */
+  api?: { path: string; methods?: UnifiedHttpMethod[] };
+  lifecycle?: { start?: boolean; stop?: boolean };
+  seedMenu?: boolean;
+  cli?: { command: string; help: string };
+}
+
+export interface NormalizedUnifiedPluginManifest extends Omit<UnifiedPluginManifest, 'api' | 'cli' | 'seedMenu'> {
+  sdk: string;
+  apiRoutes: UnifiedApiRouteManifest[];
+  mcpTools: UnifiedMcpToolManifest[];
+  proxy: UnifiedProxyManifest[];
+  menu: UnifiedMenuManifest[];
+  cliSubcommands: UnifiedCliSubcommandManifest[];
+}
+
+const NAME_RE = /^[a-z0-9-]+$/;
+const SEMVER_RE = /^\d+\.\d+\.\d+/;
+const TOOL_RE = /^[a-z][a-z0-9_]*$/;
+const HTTP_METHODS = new Set<UnifiedHttpMethod>(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'HEAD', 'ALL']);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function asArray<T>(value: T[] | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function assertAbsolutePath(path: string, field: string): void {
+  if (typeof path !== 'string' || !path.startsWith('/')) throw new Error(`${field} must be an absolute path`);
+}
+
+function assertMethods(methods: unknown, field: string): void {
+  if (methods === undefined) return;
+  if (!Array.isArray(methods)) throw new Error(`${field} must be an array`);
+  for (const method of methods) {
+    if (typeof method !== 'string' || !HTTP_METHODS.has(method.toUpperCase() as UnifiedHttpMethod)) {
+      throw new Error(`${field} contains invalid method: ${JSON.stringify(method)}`);
+    }
+  }
+}
+
+export function normalizeUnifiedPluginManifest(raw: unknown): NormalizedUnifiedPluginManifest {
+  if (!isRecord(raw)) throw new Error('manifest must be a JSON object');
+  const manifest = raw as unknown as UnifiedPluginManifest;
+
+  if (!manifest.name || !NAME_RE.test(manifest.name)) {
+    throw new Error(`manifest.name must match ${NAME_RE}, got: ${JSON.stringify(manifest.name)}`);
+  }
+  if (!manifest.version || !SEMVER_RE.test(manifest.version)) {
+    throw new Error(`manifest.version must be semver, got: ${JSON.stringify(manifest.version)}`);
+  }
+  if (!manifest.entry || typeof manifest.entry !== 'string') throw new Error('manifest.entry must be a string path');
+
+  const apiRoutes = [...asArray(manifest.apiRoutes)];
+  if (manifest.api) apiRoutes.push({ path: manifest.api.path, methods: manifest.api.methods });
+
+  const cliSubcommands = [...asArray(manifest.cliSubcommands)];
+  if (manifest.cli) cliSubcommands.push({ command: manifest.cli.command, help: manifest.cli.help });
+
+  const menu = [...asArray(manifest.menu)];
+  const mcpTools = asArray(manifest.mcpTools);
+  const proxy = asArray(manifest.proxy);
+
+  for (const tool of mcpTools) {
+    if (!TOOL_RE.test(tool.name)) throw new Error(`mcpTools.name must match ${TOOL_RE}, got: ${JSON.stringify(tool.name)}`);
+    if (!tool.description || typeof tool.description !== 'string') throw new Error(`mcpTools.${tool.name}.description must be a string`);
+    if (!isRecord(tool.inputSchema)) throw new Error(`mcpTools.${tool.name}.inputSchema must be an object`);
+    if (!tool.handler || typeof tool.handler !== 'string') throw new Error(`mcpTools.${tool.name}.handler must be a string`);
+  }
+  for (const route of apiRoutes) {
+    assertAbsolutePath(route.path, 'apiRoutes.path');
+    assertMethods(route.methods, 'apiRoutes.methods');
+  }
+  for (const item of proxy) {
+    assertAbsolutePath(item.path, 'proxy.path');
+    if (!item.targetEnv || typeof item.targetEnv !== 'string') throw new Error('proxy.targetEnv must be a string');
+    assertMethods(item.methods, 'proxy.methods');
+  }
+  for (const item of menu) {
+    assertAbsolutePath(item.path, 'menu.path');
+    if (!item.label || typeof item.label !== 'string') throw new Error('menu.label must be a string');
+  }
+  for (const command of cliSubcommands) {
+    if (!command.command || typeof command.command !== 'string') throw new Error('cliSubcommands.command must be a string');
+    if (!command.help || typeof command.help !== 'string') throw new Error('cliSubcommands.help must be a string');
+  }
+
+  return {
+    ...manifest,
+    sdk: manifest.sdk ?? '^0.0.1',
+    apiRoutes,
+    mcpTools,
+    proxy,
+    menu,
+    cliSubcommands,
+  };
+}
+
+export function manifestSurfaces(manifest: NormalizedUnifiedPluginManifest): UnifiedPluginSurface[] {
+  const surfaces: UnifiedPluginSurface[] = [];
+  if (manifest.mcpTools.length) surfaces.push('mcpTools');
+  if (manifest.apiRoutes.length) surfaces.push('apiRoutes');
+  if (manifest.proxy.length) surfaces.push('proxy');
+  if (manifest.server) surfaces.push('server');
+  if (manifest.menu.length) surfaces.push('menu');
+  if (manifest.cliSubcommands.length) surfaces.push('cliSubcommands');
+  return surfaces;
+}
+
+export function mcpToolNamesForToggle(manifest: NormalizedUnifiedPluginManifest): string[] {
+  return manifest.mcpTools.map((tool) => tool.name);
+}


### PR DESCRIPTION
## Summary
- add `docs/UNIFIED-PLUGIN.md` design for one manifest across MCP tools, API routes, proxy, server, menu, and CLI surfaces
- add `src/plugins/unified-manifest.ts` schema/types/normalizer with legacy `api`/`cli` alias mapping
- add reference plugin manifest using MCP + API + menu + CLI surfaces
- add tests for multi-surface normalization, legacy mapping, and MCP tool validation

## Tests
- bun test --isolate src/plugins/__tests__/unified-manifest.test.ts
- bun run build

Closes #1412
