### PR TITLE
Add maw arra Studio opener

### DIFF
--- a/maw-plugin/README.md
+++ b/maw-plugin/README.md
@@ -17,6 +17,8 @@ Read commands are open. Write commands attach `Authorization: Bearer $ARRA_API_T
 
 ```sh
 maw arra help
+maw arra frontend          # opens https://studio.buildwithoracle.com/?api=<backend>
+maw arra ui --no-open      # prints the link only
 maw arra search "query" --mode fts --limit 5
 maw arra learn "new project fact" --project my-repo
 maw arra stats
@@ -43,5 +45,7 @@ maw arra thread_read 42
 maw arra thread_update 42 --status closed
 maw arra verify --check false --type learning
 ```
+
+`frontend`, `ui`, and `open` construct `/?api=<backend>` from `ARRA_FRONTEND_URL` (default `https://studio.buildwithoracle.com`) and `ORACLE_API` / `NEO_ARRA_API`.
 
 Hyphenated aliases work for underscored commands, e.g. `trace-get` and `thread-update`.

--- a/maw-plugin/__tests__/index.test.ts
+++ b/maw-plugin/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { authHeaders, listSubcommands, resolveBaseUrl, runArra } from '../index.ts';
+import { authHeaders, buildFrontendUrl, listSubcommands, resolveBaseUrl, runArra } from '../index.ts';
 
 type Call = { path: string; init?: RequestInit };
 
@@ -29,11 +29,13 @@ describe('maw arra plugin', () => {
   test('help lists the full compact MCP surface', async () => {
     expect(listSubcommands()).toEqual([
       'concepts',
+      'frontend',
       'handoff',
       'health',
       'inbox',
       'learn',
       'list',
+      'open',
       'read',
       'reflect',
       'search',
@@ -49,13 +51,31 @@ describe('maw arra plugin', () => {
       'trace_link',
       'trace_list',
       'trace_unlink',
+      'ui',
       'verify',
     ]);
 
     const help = await runArra(['help']);
+    expect(help.output).toContain('frontend');
     expect(help.output).toContain('trace_chain');
     expect(help.output).toContain('thread_update');
     expect(help.output).toContain('verify');
+  });
+
+
+  test('builds and optionally opens the frontend link', async () => {
+    const env = { ORACLE_API: 'http://localhost:47778', ARRA_FRONTEND_URL: 'https://studio.buildwithoracle.com' };
+    expect(buildFrontendUrl(env)).toBe('https://studio.buildwithoracle.com/?api=http://localhost:47778');
+
+    const opened: string[] = [];
+    const openResult = await runArra(['ui'], async () => ({}), url => opened.push(url), env);
+    expect(openResult.ok).toBe(true);
+    expect(openResult.output).toContain('https://studio.buildwithoracle.com/?api=http://localhost:47778');
+    expect(opened).toEqual(['https://studio.buildwithoracle.com/?api=http://localhost:47778']);
+
+    const noOpenResult = await runArra(['open', '--no-open'], async () => ({}), url => opened.push(url), env);
+    expect(noOpenResult.output).toContain('not opened');
+    expect(opened).toEqual(['https://studio.buildwithoracle.com/?api=http://localhost:47778']);
   });
 
   test('routes read-only commands to the expected endpoints', async () => {

--- a/maw-plugin/index.ts
+++ b/maw-plugin/index.ts
@@ -1,8 +1,10 @@
+import { spawn } from 'node:child_process';
 import { DEFAULT_ORACLE_API, normalizeApiBase } from '../cli/src/lib/config.ts';
 
 type InvokeContext = { source?: string; args?: string[]; writer?: (...args: unknown[]) => void };
 type InvokeResult = { ok: boolean; output?: string; error?: string };
 type Requester = (path: string, init?: RequestInit) => Promise<unknown>;
+type Opener = (url: string) => void;
 type Method = 'GET' | 'POST' | 'PATCH' | 'DELETE';
 type Parsed = { pos: string[]; flags: Record<string, string | boolean> };
 type Built = { path: string; query?: Record<string, unknown>; body?: Record<string, unknown> };
@@ -12,6 +14,19 @@ export const command = { name: 'arra', description: 'ARRA Oracle HTTP helper —
 
 export function resolveBaseUrl(env: Record<string, string | undefined> = process.env): string {
   return normalizeApiBase(env.ORACLE_API?.trim() || env.NEO_ARRA_API?.trim() || DEFAULT_ORACLE_API);
+}
+
+export function resolveFrontendUrl(env: Record<string, string | undefined> = process.env): string {
+  return normalizeApiBase(env.ARRA_FRONTEND_URL?.trim() || 'https://studio.buildwithoracle.com');
+}
+
+export function buildFrontendUrl(env: Record<string, string | undefined> = process.env): string {
+  return `${resolveFrontendUrl(env)}/?api=${resolveBaseUrl(env)}`;
+}
+
+function openUrl(url: string): void {
+  const cmd = process.platform === 'darwin' ? 'open' : 'xdg-open';
+  spawn(cmd, [url], { detached: true, stdio: 'ignore' }).unref();
 }
 
 export function authHeaders(env: Record<string, string | undefined> = process.env): Record<string, string> {
@@ -102,16 +117,29 @@ export const COMMANDS: Record<string, Spec> = {
   verify: { tool: 'oracle_verify', method: 'POST', write: true, help: 'verify [--check true|false] [--type all|learning|pattern]', build: p => route('/api/verify', undefined, { check: b(p, 'check'), type: f(p, 'type') }), format: d => `arra verify: ${preview(d, 500)}` },
 };
 
-function usage(): InvokeResult { return { ok: false, error: 'usage', output: ['usage: maw arra <subcommand> [args]', `subcommands: ${Object.keys(COMMANDS).sort().join('|')}`, '', ...Object.entries(COMMANDS).sort().map(([name, spec]) => `  ${name}  ${spec.help}`)].join('\n') }; }
-export function listSubcommands(): string[] { return Object.keys(COMMANDS).sort(); }
+const LOCAL_COMMANDS = { frontend: 'frontend [--no-open]', ui: 'ui [--no-open]', open: 'open [--no-open]' } as const;
 
-export async function runArra(args: string[], request: Requester = requestJson): Promise<InvokeResult> {
+function usage(): InvokeResult {
+  const commandNames = [...Object.keys(COMMANDS), ...Object.keys(LOCAL_COMMANDS)].sort();
+  return { ok: false, error: 'usage', output: ['usage: maw arra <subcommand> [args]', `subcommands: ${commandNames.join('|')}`, '', ...Object.entries(LOCAL_COMMANDS).sort().map(([name, help]) => `  ${name}  ${help}`), ...Object.entries(COMMANDS).sort().map(([name, spec]) => `  ${name}  ${spec.help}`)].join('\n') };
+}
+export function listSubcommands(): string[] { return [...Object.keys(COMMANDS), ...Object.keys(LOCAL_COMMANDS)].sort(); }
+
+function runFrontend(parsed: Parsed, opener: Opener, env: Record<string, string | undefined>): InvokeResult {
+  const url = buildFrontendUrl(env);
+  const shouldOpen = b(parsed, 'no_open') !== true;
+  if (shouldOpen) opener(url);
+  return { ok: true, output: [`arra frontend: ${url}`, shouldOpen ? 'opened browser' : 'not opened (--no-open)'].join('\n') };
+}
+
+export async function runArra(args: string[], request: Requester = requestJson, opener: Opener = openUrl, env: Record<string, string | undefined> = process.env): Promise<InvokeResult> {
   const sub = key(args[0] || '');
   if (!sub || sub === 'help' || sub === '--help' || sub === '-h') return usage();
+  const parsed = parse(args.slice(1));
+  if (sub === 'frontend' || sub === 'ui' || sub === 'open') return runFrontend(parsed, opener, env);
   const spec = COMMANDS[sub];
   if (!spec) return usage();
   try {
-    const parsed = parse(args.slice(1));
     const built = spec.build(parsed);
     const init: RequestInit = { method: spec.method };
     if (built.body && Object.keys(built.body).length > 0) init.body = JSON.stringify(built.body);

--- a/maw-plugin/plugin.json
+++ b/maw-plugin/plugin.json
@@ -9,12 +9,12 @@
     "aliases": [
       "or"
     ],
-    "help": "maw arra <search|learn|stats|health|trace|trace_list|trace_get|trace_link|trace_unlink|trace_chain|concepts|handoff|inbox|list|read|reflect|supersede|thread|thread_read|thread_update|threads|verify>"
+    "help": "maw arra <frontend|ui|open|search|learn|stats|health|trace|trace_list|trace_get|trace_link|trace_unlink|trace_chain|concepts|handoff|inbox|list|read|reflect|supersede|thread|thread_read|thread_update|threads|verify>"
   },
   "capabilities": [
     "net:http"
   ],
   "weight": 50,
   "schemaVersion": 1,
-  "help": "maw arra <search|learn|stats|health|trace|trace_list|trace_get|trace_link|trace_unlink|trace_chain|concepts|handoff|inbox|list|read|reflect|supersede|thread|thread_read|thread_update|threads|verify>"
+  "help": "maw arra <frontend|ui|open|search|learn|stats|health|trace|trace_list|trace_get|trace_link|trace_unlink|trace_chain|concepts|handoff|inbox|list|read|reflect|supersede|thread|thread_read|thread_update|threads|verify>"
 }


### PR DESCRIPTION
## Summary
- add local `maw arra frontend` command with `ui` / `open` aliases
- build Studio URL as `ARRA_FRONTEND_URL || https://studio.buildwithoracle.com` plus `/?api=<backend>` from existing `resolveBaseUrl()`
- open with platform browser command unless `--no-open` is passed
- update plugin help/README and frontend command tests

Closes #1416

## Verification
- `grep -R "params.get.*api\|NEO_ARRA_API" -n web/src/pages/index.astro web/src | head -20`
- `bun test maw-plugin/__tests__/index.test.ts`
- `bun run build`
