### PR TITLE
Remove NEO backend and CLI fallbacks

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
 # arra-cli CLI
 
-`arra-cli` is the command-line interface for ARRA Oracle V3 — a plugin-based CLI that wraps the arra-oracle-v3 MCP tools (`muninn_search`, `muninn_learn`, `muninn_list`, `muninn_trace`, and more) so humans can call them directly from the shell. Plugins live in `src/plugins/` (bundled) or `~/.neo-arra/plugins/` (user-installed), each providing a `plugin.json` manifest and a default-export handler.
+`arra-cli` is the command-line interface for ARRA Oracle V3 — a plugin-based CLI that wraps the arra-oracle-v3 MCP tools (`muninn_search`, `muninn_learn`, `muninn_list`, `muninn_trace`, and more) so humans can call them directly from the shell. Plugins live in `src/plugins/` (bundled) or `~/.arra/plugins/` (user-installed), each providing a `plugin.json` manifest and a default-export handler.
 
 ```
 arra-cli --help

--- a/cli/src/commands/session-api.ts
+++ b/cli/src/commands/session-api.ts
@@ -1,5 +1,5 @@
 export function sessionApiBase(): string {
-  const raw = process.env.ORACLE_API ?? process.env.NEO_ARRA_API ?? "http://localhost:47778";
+  const raw = process.env.ORACLE_API ?? "http://localhost:47778";
   return raw.replace(/\/$/, "");
 }
 

--- a/cli/src/lib/api.ts
+++ b/cli/src/lib/api.ts
@@ -3,7 +3,7 @@
  *
  * Resolves in priority order:
  * ORACLE_API env → --at <target> → project .arra config → global
- * ~/.config/arra config → legacy NEO_ARRA_API → localhost default.
+ * ~/.config/arra config → localhost default.
  * Note: issue #770 spec listed 3457 — real oracle default is 47778.
  */
 

--- a/cli/src/lib/config.ts
+++ b/cli/src/lib/config.ts
@@ -11,7 +11,7 @@ export type ArraConfig = {
   enabledPlugins?: string[];
 };
 export type LoadedConfig = { path: string; config: ArraConfig };
-export type OracleApiSource = "ORACLE_API" | "at" | "project" | "global" | "NEO_ARRA_API" | "default";
+export type OracleApiSource = "ORACLE_API" | "at" | "project" | "global" | "default";
 
 export interface ResolvedOracleApi {
   baseUrl: string;
@@ -147,7 +147,6 @@ export function resolveOracleApi(argv = process.argv.slice(2), env = process.env
   if (projectDefault) return projectDefault;
   const globalDefault = defaultFrom(global, "global");
   if (globalDefault) return globalDefault;
-  if (env.NEO_ARRA_API !== undefined) return { baseUrl: normalizeApiBase(env.NEO_ARRA_API), source: "NEO_ARRA_API" };
   return { baseUrl: DEFAULT_ORACLE_API, source: "default" };
 }
 

--- a/cli/src/plugin/loader.ts
+++ b/cli/src/plugin/loader.ts
@@ -4,7 +4,7 @@ import { existsSync, readdirSync } from "fs";
 import { parseManifest, validateManifest } from "./manifest.ts";
 import type { LoadedPlugin } from "./types.ts";
 
-const USER_PLUGIN_DIR = join(homedir(), ".neo-arra", "plugins");
+const USER_PLUGIN_DIR = join(homedir(), ".arra", "plugins");
 const BUNDLED_PLUGIN_DIR = join(import.meta.dir, "..", "plugins");
 
 export interface DiscoverResult {

--- a/cli/src/plugins/plugin/index.ts
+++ b/cli/src/plugins/plugin/index.ts
@@ -5,14 +5,14 @@ import { homedir } from "os";
 import { existsSync, mkdirSync, cpSync, symlinkSync, rmSync } from "fs";
 import { createHash } from "crypto";
 
-const USER_PLUGIN_DIR = join(homedir(), ".neo-arra", "plugins");
+const USER_PLUGIN_DIR = join(homedir(), ".arra", "plugins");
 
 const USAGE = `arra-cli plugin — manage plugins
 
 Usage: arra-cli plugin <subcommand> [args]
 
 Subcommands:
-  init <name>             Scaffold a new plugin in ~/.neo-arra/plugins/<name>/
+  init <name>             Scaffold a new plugin in ~/.arra/plugins/<name>/
   list                    List installed plugins (bundled + user)
   install <path> [--link] Install plugin dir by copy (--link to symlink for dev)
   build [path]            Hash entry file, update plugin.json artifact field

--- a/maw-plugin/README.md
+++ b/maw-plugin/README.md
@@ -1,6 +1,6 @@
 # maw arra plugin
 
-Compact `maw arra` commands for the ARRA Oracle HTTP API. The plugin is a thin 1:1 CLI surface over the Oracle MCP tools, using `ORACLE_API` / `NEO_ARRA_API` as the base URL and falling back to `http://localhost:47778`.
+Compact `maw arra` commands for the ARRA Oracle HTTP API. The plugin is a thin 1:1 CLI surface over the Oracle MCP tools, using `ORACLE_API` as the base URL and falling back to `http://localhost:47778`.
 
 ## Install
 
@@ -11,7 +11,7 @@ maw plugin enable arra
 
 ## Auth
 
-Read commands are open. Write commands attach `Authorization: Bearer $ARRA_API_TOKEN` when `ARRA_API_TOKEN` (or `NEO_ARRA_API_TOKEN`) is set, matching the `/api/learn` token gate.
+Read commands are open. Write commands attach `Authorization: Bearer $ARRA_API_TOKEN` when `ARRA_API_TOKEN` is set, matching the `/api/learn` token gate.
 
 ## Commands
 
@@ -46,6 +46,6 @@ maw arra thread_update 42 --status closed
 maw arra verify --check false --type learning
 ```
 
-`frontend`, `ui`, and `open` construct `/?api=<backend>` from `ARRA_FRONTEND_URL` (default `https://studio.buildwithoracle.com`) and `ORACLE_API` / `NEO_ARRA_API`.
+`frontend`, `ui`, and `open` construct `/?api=<backend>` from `ARRA_FRONTEND_URL` (default `https://studio.buildwithoracle.com`) and `ORACLE_API`.
 
 Hyphenated aliases work for underscored commands, e.g. `trace-get` and `thread-update`.

--- a/maw-plugin/index.ts
+++ b/maw-plugin/index.ts
@@ -13,7 +13,7 @@ type Spec = { tool: string; method: Method; help: string; write?: boolean; build
 export const command = { name: 'arra', description: 'ARRA Oracle HTTP helper — 1:1 maw CLI surface for ARRA MCP tools.' };
 
 export function resolveBaseUrl(env: Record<string, string | undefined> = process.env): string {
-  return normalizeApiBase(env.ORACLE_API?.trim() || env.NEO_ARRA_API?.trim() || DEFAULT_ORACLE_API);
+  return normalizeApiBase(env.ORACLE_API?.trim() || DEFAULT_ORACLE_API);
 }
 
 export function resolveFrontendUrl(env: Record<string, string | undefined> = process.env): string {
@@ -30,7 +30,7 @@ function openUrl(url: string): void {
 }
 
 export function authHeaders(env: Record<string, string | undefined> = process.env): Record<string, string> {
-  const token = env.ARRA_API_TOKEN?.trim() || env.NEO_ARRA_API_TOKEN?.trim();
+  const token = env.ARRA_API_TOKEN?.trim();
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,14 +128,14 @@ class OracleApiUnavailableError extends Error {
 }
 
 function resolveOracleApiBase(): string | null {
-  const raw = process.env.ORACLE_API ?? process.env.NEO_ARRA_API ?? DEFAULT_ORACLE_API;
+  const raw = process.env.ORACLE_API ?? DEFAULT_ORACLE_API;
   const trimmed = raw.trim();
   if (!trimmed || EMBEDDED_API_VALUES.has(trimmed.toLowerCase())) return null;
   return trimmed.replace(/\/+$/, '');
 }
 
 function oracleApiHeaders(init?: RequestInit["headers"]): RequestInit["headers"] | undefined {
-  const token = process.env.ARRA_API_TOKEN?.trim() || process.env.NEO_ARRA_API_TOKEN?.trim();
+  const token = process.env.ARRA_API_TOKEN?.trim();
   if (!token) return init;
   return { ...(init as Record<string, string> | undefined), Authorization: `Bearer ${token}` };
 }

--- a/src/server/plugin/unified.ts
+++ b/src/server/plugin/unified.ts
@@ -13,7 +13,7 @@ import type {
   ServerPluginTier,
 } from './types.ts';
 
-const USER_PLUGIN_DIR = join(homedir(), '.neo-arra', 'plugins');
+const USER_PLUGIN_DIR = join(homedir(), '.arra', 'plugins');
 const BUNDLED_PLUGIN_DIR = join(import.meta.dir, '../../../cli/src/plugins');
 const TIMEOUT_MS = Number(process.env.ARRA_PLUGIN_TIMEOUT_MS ?? 5000);
 const TIERS = new Set(['core', 'standard', 'extra']);

--- a/tests/cli/config/api-resolution.test.ts
+++ b/tests/cli/config/api-resolution.test.ts
@@ -20,7 +20,6 @@ function resetEnv(): void {
   for (const key of Object.keys(process.env)) delete process.env[key];
   Object.assign(process.env, env0);
   delete process.env.ORACLE_API;
-  delete process.env.NEO_ARRA_API;
   delete process.env.XDG_CONFIG_HOME;
 }
 
@@ -68,20 +67,18 @@ test("--at target wins over project default", () => {
   expect(oracleApiBase()).toBe("http://project-m5.local:47778");
 });
 
-test("project .arra/config.json default wins over global config and legacy env", () => {
+test("project .arra/config.json default wins over global config", () => {
   const project = tempDir("arra-project-");
   const child = join(project, "nested", "cwd");
   mkdirSync(child, { recursive: true });
   projectConfig(project, { local: "http://project.local:47778" });
   globalConfig(tempDir("arra-global-"), { local: "http://global.local:47778" });
-  process.env.NEO_ARRA_API = "http://legacy.local:47778";
   process.chdir(child);
   expect(oracleApiBase()).toBe("http://project.local:47778");
 });
 
-test("global config default wins over legacy env", () => {
+test("global config default wins over localhost default", () => {
   globalConfig(tempDir("arra-global-"), { m5: "http://m5.local:47778" }, "m5");
-  process.env.NEO_ARRA_API = "http://legacy.local:47778";
   expect(oracleApiBase()).toBe("http://m5.local:47778");
 });
 
@@ -90,12 +87,6 @@ test("global targets.json is supported for shell prototype interop", () => {
   process.env.XDG_CONFIG_HOME = home;
   config(join(home, "arra", "targets.json"), { local: "http://localhost:47778", docker: "http://localhost:47780/" }, "docker");
   expect(oracleApiBase()).toBe("http://localhost:47780");
-});
-
-test("legacy NEO_ARRA_API wins when no config exists", () => {
-  process.env.XDG_CONFIG_HOME = tempDir("arra-empty-global-");
-  process.env.NEO_ARRA_API = "http://legacy.local:47778/";
-  expect(oracleApiBase()).toBe("http://legacy.local:47778");
 });
 
 test("missing config falls back cleanly to localhost default", () => {

--- a/tests/cli/config/command.test.ts
+++ b/tests/cli/config/command.test.ts
@@ -7,7 +7,7 @@ import { runCli } from "../_run.ts";
 const cwd0 = process.cwd();
 const temps: string[] = [];
 const tmp = (p: string) => (temps.push(mkdtempSync(join(tmpdir(), p))), temps.at(-1)!);
-const env = (xdg: string, extra = {}) => ({ XDG_CONFIG_HOME: xdg, ORACLE_API: undefined, NEO_ARRA_API: undefined, ...extra });
+const env = (xdg: string, extra = {}) => ({ XDG_CONFIG_HOME: xdg, ORACLE_API: undefined, ...extra });
 function cfg(path: string, targets: Record<string, string>, def = "local") {
   mkdirSync(join(path, ".."), { recursive: true });
   writeFileSync(path, JSON.stringify({ default: def, targets }, null, 2));

--- a/tests/cli/plugin/toggle.test.ts
+++ b/tests/cli/plugin/toggle.test.ts
@@ -6,7 +6,7 @@ import { runCli } from '../_run.ts';
 
 const temps: string[] = [];
 const tmp = () => (temps.push(mkdtempSync(join(tmpdir(), 'arra-plugin-toggle-'))), temps.at(-1)!);
-const env = (xdg: string) => ({ XDG_CONFIG_HOME: xdg, ORACLE_API: undefined, NEO_ARRA_API: undefined });
+const env = (xdg: string) => ({ XDG_CONFIG_HOME: xdg, ORACLE_API: undefined });
 
 afterEach(() => {
   for (const dir of temps.splice(0)) rmSync(dir, { recursive: true, force: true });

--- a/tests/cli/plugin/unified-example.test.ts
+++ b/tests/cli/plugin/unified-example.test.ts
@@ -4,7 +4,6 @@ import { runCli } from '../_run.ts';
 test('bundled unified manifest plugin still exposes a CLI command', async () => {
   const result = await runCli(['unified-example'], {
     ORACLE_API: undefined,
-    NEO_ARRA_API: undefined,
   });
 
   expect(result.code).toBe(0);


### PR DESCRIPTION
## Summary
- remove `NEO_ARRA_API` / `NEO_ARRA_API_TOKEN` fallbacks from backend, CLI config/session API, and maw-plugin
- switch user plugin dir references from `~/.neo-arra/plugins` to `~/.arra/plugins`
- update CLI/maw docs and remove legacy NEO fallback test cases

Refs #1418

## Verification
- `rg -n "NEO_|neo-arra" src cli maw-plugin tests --glob '!web/**'`
- `bun test maw-plugin/__tests__/index.test.ts tests/cli/config tests/cli/plugin`
- `bun run build`
