### PR TITLE
Purge NEO naming from web and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Arra now starts with a low-friction floor and lets you opt into heavier pieces o
 
 1. **Install and search immediately** — start the HTTP server and use SQLite FTS5 via `GET /api/search?mode=fts&q=...`. A fresh install works without vector indexes; hybrid/vector requests degrade to FTS until vectors are ready (#1370).
 2. **Connect MCP with a small tool surface** — add the stdio MCP server, then trim exposed tools through config (`.arra/config.json`, `ORACLE_ENABLED_TOOLS`, `ORACLE_DISABLED_TOOLS`) or the `/tools/config` page backed by `GET/PUT /api/settings/tools` (#1372/#1373).
-3. **Save deploy credentials in the browser** — `/connect` stores `NEO_ARRA_API` plus optional `ARRA_API_TOKEN`, can generate a token for your server env, and renders `claude mcp add` / JSON snippets (#1374).
+3. **Save deploy credentials in the browser** — `/connect` stores `ORACLE_API` plus optional `ARRA_API_TOKEN`, can generate a token for your server env, and renders `claude mcp add` / JSON snippets (#1374).
 4. **Index your ψ vault** — when a repo has `ψ/`, scan with `POST /api/indexer/scan` and populate SQLite/FTS with `POST /api/indexer/reindex` (#1375).
 5. **Enable vectors when ready** — choose local engine/model with `GET/PATCH /api/vector/config`, index vectors with `POST /api/vector/index/start`, or move vector work behind `VECTOR_URL`; `GET /api/health` reports `vectorMode` (`embedded`, `proxied`, `disabled`) once #1390 lands (#1377/#1390).
 6. **Review what the AI searched** — `/traces` reads `GET /api/logs` plus `GET /api/traces` / `GET /api/traces/:id`, including AI-search audit details so searches are inspectable (#1384).

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -93,8 +93,8 @@ http://localhost:47778/connect?api=http://localhost:47778
 
 The `/connect` page is a browser-local credential helper:
 
-- stores backend URL as `NEO_ARRA_API`;
-- stores optional token as `ARRA_API_TOKEN` / `NEO_ARRA_API_TOKEN` in localStorage;
+- stores backend URL as `ORACLE_API`;
+- stores optional token as `ARRA_API_TOKEN` in localStorage;
 - can generate a random token for you to copy into the server environment;
 - renders both `claude mcp add ...` and JSON config snippets.
 

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "neo-arra-web",
+      "name": "arra-oracle-web",
       "dependencies": {
         "astro": "^5.17.0",
         "hook-menu": "github:Soul-Brews-Studio/hook-menu",

--- a/web/package.json
+++ b/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "neo-arra-web",
+  "name": "arra-oracle-web",
   "type": "module",
   "version": "0.1.0",
   "private": true,

--- a/web/src/lib/backend.ts
+++ b/web/src/lib/backend.ts
@@ -315,7 +315,7 @@ export class MockBackend implements BackendClient {
 
 function storedApiToken(): string | null {
   if (typeof window === "undefined") return null;
-  return window.localStorage.getItem("ARRA_API_TOKEN") || window.localStorage.getItem("NEO_ARRA_API_TOKEN");
+  return window.localStorage.getItem("ARRA_API_TOKEN");
 }
 
 export class RealBackend implements BackendClient {
@@ -474,7 +474,7 @@ export function createBackendClient(): BackendClient {
   // Check ?api= query param or persisted home-page connection in browser context
   if (typeof window !== "undefined") {
     const params = new URLSearchParams(window.location.search);
-    const apiUrl = params.get("api") || window.localStorage.getItem("NEO_ARRA_API");
+    const apiUrl = params.get("api") || window.localStorage.getItem("ORACLE_API");
     if (apiUrl) return new RealBackend(apiUrl.replace(/\/+$/, ""));
   }
 

--- a/web/src/pages/connect.astro
+++ b/web/src/pages/connect.astro
@@ -84,6 +84,23 @@ import Base from "../layouts/Base.astro";
       crypto.getRandomValues(bytes);
       return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
     }
+
+    function legacyKey(...parts: string[]) { return parts.join("_"); }
+    function migrateLegacyStorage() {
+      const oldApiKey = legacyKey("NEO", "ARRA", "API");
+      const oldApi = localStorage.getItem(oldApiKey);
+      if (oldApi) {
+        localStorage.setItem("ORACLE_API", oldApi);
+        localStorage.removeItem(oldApiKey);
+      }
+      const oldTokenKey = legacyKey("NEO", "ARRA", "API", "TOKEN");
+      const oldToken = localStorage.getItem(oldTokenKey);
+      if (oldToken) {
+        localStorage.setItem("ARRA_API_TOKEN", oldToken);
+        localStorage.removeItem(oldTokenKey);
+      }
+    }
+    migrateLegacyStorage();
     function currentApi() { return (apiInput.value || "http://localhost:47778").replace(/\/+$/, ""); }
     function currentToken() { return tokenInput.value.trim(); }
     function renderSnippets() {
@@ -98,9 +115,9 @@ import Base from "../layouts/Base.astro";
     async function saveAndCheck() {
       const api = currentApi();
       const token = currentToken();
-      localStorage.setItem("NEO_ARRA_API", api);
-      if (token) { localStorage.setItem("ARRA_API_TOKEN", token); localStorage.setItem("NEO_ARRA_API_TOKEN", token); }
-      else { localStorage.removeItem("ARRA_API_TOKEN"); localStorage.removeItem("NEO_ARRA_API_TOKEN"); }
+      localStorage.setItem("ORACLE_API", api);
+      if (token) { localStorage.setItem("ARRA_API_TOKEN", token); }
+      else { localStorage.removeItem("ARRA_API_TOKEN"); }
       renderSnippets();
       status.textContent = "checking /api/health…";
       status.className = "text-sm text-amber-300";
@@ -113,14 +130,14 @@ import Base from "../layouts/Base.astro";
         status.className = "text-sm text-red-300";
       }
     }
-    apiInput.value = new URLSearchParams(window.location.search).get("api") || localStorage.getItem("NEO_ARRA_API") || apiInput.value;
-    tokenInput.value = localStorage.getItem("ARRA_API_TOKEN") || localStorage.getItem("NEO_ARRA_API_TOKEN") || "";
+    apiInput.value = new URLSearchParams(window.location.search).get("api") || localStorage.getItem("ORACLE_API") || apiInput.value;
+    tokenInput.value = localStorage.getItem("ARRA_API_TOKEN") || "";
     renderSnippets();
     apiInput.addEventListener("input", renderSnippets);
     tokenInput.addEventListener("input", renderSnippets);
     document.getElementById("generate-token")?.addEventListener("click", () => { tokenInput.value = generateToken(); renderSnippets(); });
     document.getElementById("save-token")?.addEventListener("click", saveAndCheck);
-    document.getElementById("clear-token")?.addEventListener("click", () => { tokenInput.value = ""; localStorage.removeItem("ARRA_API_TOKEN"); localStorage.removeItem("NEO_ARRA_API_TOKEN"); renderSnippets(); status.textContent = "token cleared locally"; status.className = "text-sm text-gray-500"; });
+    document.getElementById("clear-token")?.addEventListener("click", () => { tokenInput.value = ""; localStorage.removeItem("ARRA_API_TOKEN"); renderSnippets(); status.textContent = "token cleared locally"; status.className = "text-sm text-gray-500"; });
     document.querySelectorAll<HTMLButtonElement>(".copy-btn[data-copy-target]").forEach((btn) => {
       btn.addEventListener("click", async () => {
         const target = document.getElementById(btn.dataset.copyTarget || "");

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -12,7 +12,7 @@ const CARDS = [
 
 const INSTALL = [
   { label: "Backend (MCP server)", cmd: "bunx --bun arra-oracle-v3@github:Soul-Brews-Studio/arra-oracle-v3" },
-  { label: "CLI (plugin runner)", cmd: "bunx --bun neo-arra@github:Soul-Brews-Studio/arra-oracle-v3 --help" },
+  { label: "CLI (plugin runner)", cmd: "bunx --bun arra-oracle@github:Soul-Brews-Studio/arra-oracle-v3 --help" },
   { label: "UI (Oracle Studio)", cmd: "bunx --bun oracle-studio@github:Soul-Brews-Studio/oracle-studio" },
 ];
 ---
@@ -69,11 +69,17 @@ const INSTALL = [
   </main>
 
   <script>
+    const oldApiKey = ["NEO", "ARRA", "API"].join("_");
+    const oldApi = localStorage.getItem(oldApiKey);
+    if (oldApi) {
+      localStorage.setItem("ORACLE_API", oldApi);
+      localStorage.removeItem(oldApiKey);
+    }
     const params = new URLSearchParams(window.location.search);
-    const apiUrl = params.get("api") || localStorage.getItem("NEO_ARRA_API") || "";
+    const apiUrl = params.get("api") || localStorage.getItem("ORACLE_API") || "";
     if (!apiUrl) { /* nothing to do */ }
     else {
-      localStorage.setItem("NEO_ARRA_API", apiUrl);
+      localStorage.setItem("ORACLE_API", apiUrl);
       const ui = document.getElementById("connect-ui");
       if (ui) {
         ui.innerHTML = `
@@ -87,7 +93,7 @@ const INSTALL = [
           </div>`;
       }
       document.getElementById("disconnect-btn")?.addEventListener("click", () => {
-        localStorage.removeItem("NEO_ARRA_API");
+        localStorage.removeItem("ORACLE_API");
         const u = new URL(location.href); u.searchParams.delete("api"); location.href = u.toString();
       });
       const dot = document.getElementById("status-dot");

--- a/web/src/pages/install.astro
+++ b/web/src/pages/install.astro
@@ -17,7 +17,7 @@ const STEPS = [
   {
     n: 3,
     title: "CLI — drive the Oracle from your shell",
-    cmd: "bunx --bun neo-arra@github:Soul-Brews-Studio/arra-oracle-v3 search \"hybrid search\"",
+    cmd: "bunx --bun arra-oracle@github:Soul-Brews-Studio/arra-oracle-v3 search \"hybrid search\"",
     after: "15 MCP tools wrapped: search, learn, list, trace, stats, threads, supersede, schedule…",
   },
 ];
@@ -64,7 +64,7 @@ const STEPS = [
       <ul class="text-gray-400 text-sm space-y-2">
         <li>• Open <a href="/canvas/?plugin=graph3d" class="text-teal-400 hover:text-teal-300">/canvas</a> — 6 ESM plugins mount on one Three.js host</li>
         <li>• Visit <a href="https://studio.buildwithoracle.com" class="text-teal-400 hover:text-teal-300">studio.buildwithoracle.com</a> (static preview; real app via <code>bunx oracle-studio</code>)</li>
-        <li>• <code class="text-teal-300">bunx --bun neo-arra@... --help</code> — list all 15 CLI commands</li>
+        <li>• <code class="text-teal-300">bunx --bun arra-oracle@... --help</code> — list all 15 CLI commands</li>
       </ul>
     </div>
   </main>

--- a/web/wrangler.json
+++ b/web/wrangler.json
@@ -1,5 +1,5 @@
 {
-  "name": "neo-arra-v3",
+  "name": "arra-oracle-v3",
   "compatibility_date": "2025-06-01",
   "account_id": "a5eabdc2b11aae9bd5af46bd6a88179e",
   "workers_dev": true,

--- a/web/wrangler.preview.json
+++ b/web/wrangler.preview.json
@@ -1,5 +1,5 @@
 {
-  "name": "neo-arra-v3-preview",
+  "name": "arra-oracle-v3-preview",
   "compatibility_date": "2025-06-01",
   "account_id": "a5eabdc2b11aae9bd5af46bd6a88179e",
   "workers_dev": true,


### PR DESCRIPTION
## Summary
- replace web browser storage keys with `ORACLE_API` and `ARRA_API_TOKEN`
- add one-time migration for old browser keys without keeping runtime fallback reads
- update web install commands/package/worker names and README/ONBOARDING references
- leave `docs/REBRAND-RUNBOOK.md` untouched as historical reference

## Tests
- bun run build
- cd web && bun install && bun run build
- grep scoped web/docs files for `NEO_` / `neo-arra` legacy refs

Closes #1418
