### PR TITLE
feat(maw-plugin): add local Oracle Studio launcher

### DIFF
--- a/maw-plugin/README.md
+++ b/maw-plugin/README.md
@@ -18,7 +18,9 @@ Read commands are open. Write commands attach `Authorization: Bearer $ARRA_API_T
 ```sh
 maw arra help
 maw arra frontend          # opens https://studio.buildwithoracle.com/?api=<backend>
-maw arra ui --no-open      # prints the link only
+maw arra ui --no-open      # prints the hosted link only
+maw arra studio            # ghq get/update oracle-studio + bun dev on :4321
+maw arra studio --port 3000
 maw arra search "query" --mode fts --limit 5
 maw arra learn "new project fact" --project my-repo
 maw arra stats
@@ -53,6 +55,8 @@ maw arra thread_update 42 --status closed
 maw arra verify --check false --type learning
 ```
 
-`frontend`, `ui`, and `open` construct `/?api=<backend>` from `ARRA_FRONTEND_URL` (default `https://studio.buildwithoracle.com`) and `ORACLE_API`.
+`frontend`, `ui`, and `open` construct hosted `/?api=<backend>` links from `ARRA_FRONTEND_URL` (default `https://studio.buildwithoracle.com`) and `ORACLE_API`.
+
+`studio` starts the local Oracle Studio dev server: it runs `ghq get -u Soul-Brews-Studio/oracle-studio`, installs dependencies in the ghq checkout, then runs `VITE_ARRA_API=http://localhost:47778 bun run dev --port <port>` (default `4321`). It requires `ghq` and `bun` on PATH.
 
 Hyphenated aliases work for underscored commands, e.g. `trace-get` and `thread-update`.

--- a/maw-plugin/__tests__/index.test.ts
+++ b/maw-plugin/__tests__/index.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { authHeaders, buildFrontendUrl, listSubcommands, resolveBaseUrl, runArra } from '../index.ts';
 
 type Call = { path: string; init?: RequestInit };
+type RunCall = { cmd: string; args: string[]; options?: { cwd?: string; env?: Record<string, string | undefined>; inherit?: boolean; capture?: boolean } };
 
 async function route(args: string[], response: unknown = { success: true }): Promise<{ result: Awaited<ReturnType<typeof runArra>>; calls: Call[] }> {
   const calls: Call[] = [];
@@ -46,6 +47,7 @@ describe('maw arra plugin', () => {
       'search',
       'settings',
       'stats',
+      'studio',
       'supersede',
       'thread',
       'thread_read',
@@ -64,6 +66,7 @@ describe('maw arra plugin', () => {
 
     const help = await runArra(['help']);
     expect(help.output).toContain('frontend');
+    expect(help.output).toContain('studio');
     expect(help.output).toContain('index');
     expect(help.output).toContain('vector');
     expect(help.output).toContain('trace_chain');
@@ -86,6 +89,40 @@ describe('maw arra plugin', () => {
     expect(noOpenResult.output).toContain('not opened');
     expect(opened).toEqual(['https://studio.buildwithoracle.com/?api=http://localhost:47778']);
   });
+
+
+
+  test('starts local Oracle Studio through ghq with default and custom ports', async () => {
+    const calls: RunCall[] = [];
+    const runner = async (cmd: string, args: string[], options?: RunCall['options']) => {
+      calls.push({ cmd, args, options });
+      return { code: 0, stdout: cmd === 'ghq' && args[0] === 'root' ? '/tmp/ghq\n' : '' };
+    };
+
+    const result = await runArra(['studio'], async () => ({}), () => {}, {}, runner);
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain('port 4321');
+    expect(calls.map(c => [c.cmd, c.args])).toEqual([
+      ['ghq', ['get', '-u', 'Soul-Brews-Studio/oracle-studio']],
+      ['ghq', ['root']],
+      ['bun', ['install']],
+      ['bun', ['run', 'dev', '--port', '4321']],
+    ]);
+    expect(calls[2]?.options?.cwd).toBe('/tmp/ghq/github.com/Soul-Brews-Studio/oracle-studio');
+    expect(calls[3]?.options?.cwd).toBe('/tmp/ghq/github.com/Soul-Brews-Studio/oracle-studio');
+    expect(calls[3]?.options?.env?.VITE_ARRA_API).toBe('http://localhost:47778');
+
+    calls.length = 0;
+    await runArra(['studio', '--port', '3000'], async () => ({}), () => {}, {}, runner);
+    expect(calls[3]?.args).toEqual(['run', 'dev', '--port', '3000']);
+  });
+
+  test('rejects invalid studio ports', async () => {
+    const result = await runArra(['studio', '--port', 'nope'], async () => ({}), () => {}, {}, async () => ({ code: 0 }));
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('--port');
+  });
+
 
   test('routes read-only commands to the expected endpoints', async () => {
     const cases: Array<[string[], string, string]> = [

--- a/maw-plugin/index.ts
+++ b/maw-plugin/index.ts
@@ -1,10 +1,14 @@
 import { spawn } from 'node:child_process';
+import { join } from 'node:path';
 import { DEFAULT_ORACLE_API, normalizeApiBase } from '../cli/src/lib/config.ts';
 
 type InvokeContext = { source?: string; args?: string[]; writer?: (...args: unknown[]) => void };
 type InvokeResult = { ok: boolean; output?: string; error?: string };
 type Requester = (path: string, init?: RequestInit) => Promise<unknown>;
 type Opener = (url: string) => void;
+type RunOptions = { cwd?: string; env?: Record<string, string | undefined>; inherit?: boolean; capture?: boolean };
+type RunResult = { code: number | null; stdout?: string; stderr?: string };
+type Runner = (cmd: string, args: string[], options?: RunOptions) => Promise<RunResult>;
 type Method = 'GET' | 'POST' | 'PATCH' | 'DELETE';
 type Parsed = { pos: string[]; flags: Record<string, string | boolean> };
 type Built = { path: string; query?: Record<string, unknown>; body?: Record<string, unknown> };
@@ -22,6 +26,38 @@ export function resolveFrontendUrl(env: Record<string, string | undefined> = pro
 
 export function buildFrontendUrl(env: Record<string, string | undefined> = process.env): string {
   return `${resolveFrontendUrl(env)}/?api=${resolveBaseUrl(env)}`;
+}
+
+
+function runCommand(cmd: string, args: string[], options: RunOptions = {}): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    const child = spawn(cmd, args, {
+      cwd: options.cwd,
+      env: { ...process.env, ...options.env },
+      stdio: options.inherit ? 'inherit' : options.capture ? ['ignore', 'pipe', 'pipe'] : 'ignore',
+    });
+    if (options.capture && child.stdout) child.stdout.on('data', chunk => stdout.push(Buffer.from(chunk)));
+    if (options.capture && child.stderr) child.stderr.on('data', chunk => stderr.push(Buffer.from(chunk)));
+    child.on('error', reject);
+    child.on('close', code => resolve({ code, stdout: Buffer.concat(stdout).toString('utf8'), stderr: Buffer.concat(stderr).toString('utf8') }));
+  });
+}
+
+async function mustRun(runner: Runner, cmd: string, args: string[], options: RunOptions = {}): Promise<RunResult> {
+  const result = await runner(cmd, args, options);
+  if (result.code !== 0) {
+    const detail = result.stderr?.trim() || result.stdout?.trim();
+    throw new Error(`${cmd} ${args.join(' ')} failed${result.code === null ? '' : ` (${result.code})`}${detail ? `: ${detail}` : ''}`);
+  }
+  return result;
+}
+
+function parsePort(parsed: Parsed): string {
+  const port = f(parsed, 'port') || '4321';
+  if (!/^\d+$/.test(port) || Number(port) < 1 || Number(port) > 65535) throw new Error('--port must be a number from 1 to 65535');
+  return port;
 }
 
 function openUrl(url: string): void {
@@ -124,7 +160,7 @@ export const COMMANDS: Record<string, Spec> = {
   verify: { tool: 'oracle_verify', method: 'POST', write: true, help: 'verify [--check true|false] [--type all|learning|pattern]', build: p => route('/api/verify', undefined, { check: b(p, 'check'), type: f(p, 'type') }), format: d => `arra verify: ${preview(d, 500)}` },
 };
 
-const LOCAL_COMMANDS = { frontend: 'frontend [--no-open]', ui: 'ui [--no-open]', open: 'open [--no-open]' } as const;
+const LOCAL_COMMANDS = { frontend: 'frontend [--no-open]', ui: 'ui [--no-open]', open: 'open [--no-open]', studio: 'studio [--port N]' } as const;
 
 function usage(): InvokeResult {
   const commandNames = [...Object.keys(COMMANDS), ...Object.keys(LOCAL_COMMANDS)].sort();
@@ -139,11 +175,25 @@ function runFrontend(parsed: Parsed, opener: Opener, env: Record<string, string 
   return { ok: true, output: [`arra frontend: ${url}`, shouldOpen ? 'opened browser' : 'not opened (--no-open)'].join('\n') };
 }
 
-export async function runArra(args: string[], request: Requester = requestJson, opener: Opener = openUrl, env: Record<string, string | undefined> = process.env): Promise<InvokeResult> {
+async function runStudio(parsed: Parsed, runner: Runner, env: Record<string, string | undefined>): Promise<InvokeResult> {
+  try {
+    const port = parsePort(parsed);
+    await mustRun(runner, 'ghq', ['get', '-u', 'Soul-Brews-Studio/oracle-studio'], { inherit: true });
+    const root = (await mustRun(runner, 'ghq', ['root'], { capture: true })).stdout?.trim();
+    if (!root) throw new Error('ghq root returned no path');
+    const cwd = join(root, 'github.com', 'Soul-Brews-Studio', 'oracle-studio');
+    await mustRun(runner, 'bun', ['install'], { cwd, inherit: true });
+    await mustRun(runner, 'bun', ['run', 'dev', '--port', port], { cwd, inherit: true, env: { ...env, VITE_ARRA_API: 'http://localhost:47778' } });
+    return { ok: true, output: `arra studio: stopped (port ${port})` };
+  } catch (error) { return { ok: false, error: error instanceof Error ? error.message : String(error) }; }
+}
+
+export async function runArra(args: string[], request: Requester = requestJson, opener: Opener = openUrl, env: Record<string, string | undefined> = process.env, runner: Runner = runCommand): Promise<InvokeResult> {
   const sub = key(args[0] || '');
   if (!sub || sub === 'help' || sub === '--help' || sub === '-h') return usage();
   const parsed = parse(args.slice(1));
   if (sub === 'frontend' || sub === 'ui' || sub === 'open') return runFrontend(parsed, opener, env);
+  if (sub === 'studio') return runStudio(parsed, runner, env);
   const spec = COMMANDS[sub];
   if (!spec) return usage();
   try {

--- a/maw-plugin/plugin.json
+++ b/maw-plugin/plugin.json
@@ -9,12 +9,12 @@
     "aliases": [
       "or"
     ],
-    "help": "maw arra <frontend|ui|open|search|learn|stats|health|index|scan|plugins|settings|feed|menu|vector|trace|trace_list|trace_get|trace_link|trace_unlink|trace_chain|concepts|handoff|inbox|list|read|reflect|supersede|thread|thread_read|thread_update|threads|verify>"
+    "help": "maw arra <frontend|ui|open|studio|search|learn|stats|health|index|scan|plugins|settings|feed|menu|vector|trace|trace_list|trace_get|trace_link|trace_unlink|trace_chain|concepts|handoff|inbox|list|read|reflect|supersede|thread|thread_read|thread_update|threads|verify>"
   },
   "capabilities": [
     "net:http"
   ],
   "weight": 50,
   "schemaVersion": 1,
-  "help": "maw arra <frontend|ui|open|search|learn|stats|health|index|scan|plugins|settings|feed|menu|vector|trace|trace_list|trace_get|trace_link|trace_unlink|trace_chain|concepts|handoff|inbox|list|read|reflect|supersede|thread|thread_read|thread_update|threads|verify>"
+  "help": "maw arra <frontend|ui|open|studio|search|learn|stats|health|index|scan|plugins|settings|feed|menu|vector|trace|trace_list|trace_get|trace_link|trace_unlink|trace_chain|concepts|handoff|inbox|list|read|reflect|supersede|thread|thread_read|thread_update|threads|verify>"
 }


### PR DESCRIPTION
## Summary
- Add `maw arra studio` as a local Oracle Studio dev-server launcher beside hosted `frontend`/`ui`/`open`.
- Run the requested flow: `ghq get -u Soul-Brews-Studio/oracle-studio`, resolve `$(ghq root)/github.com/Soul-Brews-Studio/oracle-studio`, `bun install`, then `VITE_ARRA_API=http://localhost:47778 bun run dev --port <port>`.
- Support `--port` with default `4321`, plus docs, manifest help, and focused unit coverage.

Closes #1424

## Test Plan
- [x] `bun test --isolate maw-plugin/__tests__/index.test.ts`
- [x] `bunx tsc -p tsconfig.json --noEmit`
- [x] `ghq get -u Soul-Brews-Studio/oracle-studio`
- [x] `bun install` in the ghq `oracle-studio` checkout

## Notes
- Did not leave the long-running Vite server alive during verification.

🤖 ตอบโดย arra-oracle-v3 จาก Nat → arra-oracle-v3-oracle