### PR TITLE
fix(maw-plugin): align scan with indexer POST

### DIFF
--- a/maw-plugin/README.md
+++ b/maw-plugin/README.md
@@ -24,7 +24,7 @@ maw arra learn "new project fact" --project my-repo
 maw arra stats
 maw arra health
 maw arra index --project my-repo --path /path/to/vault
-maw arra scan
+maw arra scan --path /path/to/repo-or-ψ
 maw arra plugins
 maw arra settings
 maw arra feed

--- a/maw-plugin/__tests__/index.test.ts
+++ b/maw-plugin/__tests__/index.test.ts
@@ -91,7 +91,6 @@ describe('maw arra plugin', () => {
     const cases: Array<[string[], string, string]> = [
       [['search', 'hello', '--mode', 'vector', '--limit', '3'], 'GET', '/api/search?q=hello&limit=3&mode=vector'],
       [['stats'], 'GET', '/api/stats'],
-      [['scan'], 'GET', '/api/indexer/scan'],
       [['plugins'], 'GET', '/api/plugins'],
       [['settings'], 'GET', '/api/settings/tools'],
       [['feed'], 'GET', '/api/feed'],
@@ -123,6 +122,7 @@ describe('maw arra plugin', () => {
     const cases: Array<[string[], string, string, unknown]> = [
       [['learn', 'new', 'pattern', '--project', 'demo'], 'POST', '/api/learn', { pattern: 'new pattern', project: 'demo' }],
       [['index', '--project', 'demo', '--path', '/tmp/vault'], 'POST', '/api/indexer/reindex', { project: 'demo', path: '/tmp/vault' }],
+      [['scan', '--path', '/tmp/vault'], 'POST', '/api/indexer/scan', { sourcePath: '/tmp/vault' }],
       [['trace', 'audit', '--scope', 'project'], 'POST', '/api/traces', { query: 'audit', scope: 'project' }],
       [['trace_link', 'a', 'b'], 'POST', '/api/traces/a/link', { nextId: 'b' }],
       [['trace_unlink', 'a', '--direction', 'next'], 'DELETE', '/api/traces/a/link?direction=next', undefined],

--- a/maw-plugin/index.ts
+++ b/maw-plugin/index.ts
@@ -97,7 +97,7 @@ export const COMMANDS: Record<string, Spec> = {
   learn: { tool: 'oracle_learn', method: 'POST', write: true, help: 'learn <text> [--project P] [--source S] [--concepts a,b]', build: p => route('/api/learn', undefined, { pattern: text(p, 'pattern', 'text'), project: f(p, 'project'), source: f(p, 'source'), concepts: f(p, 'concepts')?.split(',').map(s => s.trim()).filter(Boolean) }), format: formatOk('learn') },
   stats: { tool: 'oracle_stats', method: 'GET', help: 'stats', build: () => route('/api/stats'), format: formatStats },
   index: { tool: 'oracle_index', method: 'POST', write: true, help: 'index [--project P] [--path PATH]', build: p => route('/api/indexer/reindex', undefined, { project: f(p, 'project'), path: f(p, 'path') || p.pos[0] }), format: formatOk('index') },
-  scan: { tool: 'oracle_scan', method: 'GET', help: 'scan', build: () => route('/api/indexer/scan'), format: formatRows('scan', ['files', 'items']) },
+  scan: { tool: 'oracle_scan', method: 'POST', help: 'scan [--path PATH]', build: p => route('/api/indexer/scan', undefined, { sourcePath: f(p, 'path') || p.pos[0] }), format: formatRows('scan', ['files', 'items']) },
   plugins: { tool: 'oracle_plugins', method: 'GET', help: 'plugins', build: () => route('/api/plugins'), format: formatRows('plugins', ['plugins']) },
   settings: { tool: 'oracle_settings', method: 'GET', help: 'settings', build: () => route('/api/settings/tools'), format: d => `arra settings: ${preview(d, 700)}` },
   feed: { tool: 'oracle_feed', method: 'GET', help: 'feed', build: () => route('/api/feed'), format: formatRows('feed', ['feed', 'items', 'entries']) },

--- a/src/routes/indexer/__tests__/scan.test.ts
+++ b/src/routes/indexer/__tests__/scan.test.ts
@@ -37,4 +37,45 @@ describe('POST /indexer/scan', () => {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });
+
+  test('classifies oracle workspace folders by type', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-scan-types-'));
+    try {
+      const psiRoot = path.join(tmp, 'ψ');
+      const cases: Array<[string, string]> = [
+        ['inbox/message.md', 'inbox'],
+        ['outbox/sent.md', 'outbox'],
+        ['plans/next.md', 'plans'],
+        ['writing/draft.md', 'writing'],
+        ['learn/topic.md', 'learn'],
+        ['incubate/project/plan.md', 'incubate'],
+        ['archive/old.md', 'archive'],
+        ['memory/learnings/scan.md', 'learning'],
+        ['retrospectives/day.md', 'retro'],
+        ['distillations/finding.md', 'distillation'],
+        ['principles/rule.md', 'principle'],
+      ];
+
+      for (const [relative, type] of cases) {
+        const file = path.join(psiRoot, relative);
+        fs.mkdirSync(path.dirname(file), { recursive: true });
+        fs.writeFileSync(file, `# ${type}\n`);
+      }
+
+      const app = new Elysia().use(scanEndpoint);
+      const res = await post(app, { sourcePath: psiRoot });
+      const body = await res.json() as any;
+
+      expect(res.status).toBe(200);
+      for (const [, type] of cases) expect(body.byType[type]).toBeGreaterThanOrEqual(1);
+      expect(body.total).toBe(cases.length);
+
+      const filtered = await (await post(app, { sourcePath: psiRoot, types: ['inbox', 'plans'] })).json() as any;
+      expect(filtered.total).toBe(2);
+      expect(filtered.byType).toEqual({ inbox: 1, plans: 1 });
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
 });

--- a/src/routes/indexer/scan.ts
+++ b/src/routes/indexer/scan.ts
@@ -4,6 +4,26 @@ import path from 'path';
 import { getAllMarkdownFiles } from '../../indexer/collectors.ts';
 import { normalizeIndexerRepoRoot, resolveIndexerRepoRoot } from '../../indexer/runner.ts';
 
+
+function detectFileType(relativePath: string): string {
+  const segments = relativePath.toLowerCase().split(path.sep).flatMap(segment => segment.split(/[\s._-]+/)).filter(Boolean);
+  const has = (...names: string[]) => names.some(name => segments.includes(name));
+  const rel = relativePath.toLowerCase();
+
+  if (has('inbox')) return 'inbox';
+  if (has('outbox')) return 'outbox';
+  if (has('learn')) return 'learn';
+  if (has('incubate')) return 'incubate';
+  if (has('archive', 'archives', 'archived')) return 'archive';
+  if (has('plans', 'plan')) return 'plans';
+  if (has('writing', 'writings')) return 'writing';
+  if (rel.includes('distillations') || rel.includes('distillation')) return 'distillation';
+  if (rel.includes('learnings') || rel.includes('learning')) return 'learning';
+  if (rel.includes('retrospectives') || rel.includes('retro')) return 'retro';
+  if (rel.includes('resonance') || rel.includes('principle')) return 'principle';
+  return 'unknown';
+}
+
 export const scanEndpoint = new Elysia().post('/indexer/scan', async ({ body }) => {
   const { sourcePath, types } = body ?? {};
   const repoRoot = sourcePath ? normalizeIndexerRepoRoot(sourcePath) : resolveIndexerRepoRoot();
@@ -20,11 +40,7 @@ export const scanEndpoint = new Elysia().post('/indexer/scan', async ({ body }) 
     const stat = fs.statSync(filePath);
     const rel = path.relative(scanPath, filePath);
 
-    let type = 'unknown';
-    if (rel.includes('distillations') || rel.includes('distillation')) type = 'distillation';
-    else if (rel.includes('learnings') || rel.includes('learning')) type = 'learning';
-    else if (rel.includes('retrospectives') || rel.includes('retro')) type = 'retro';
-    else if (rel.includes('resonance') || rel.includes('principle')) type = 'principle';
+    const type = detectFileType(rel);
 
     return {
       path: filePath,


### PR DESCRIPTION
## Summary
- Change `maw arra scan` from GET to POST `/api/indexer/scan`.
- Accept `--path PATH` (or positional path) and send it as `sourcePath` in the request body.
- Extend indexer scan type detection for `inbox`, `outbox`, `plans`, `writing`, `learn`, `incubate`, and `archive` while preserving existing legacy types.

Closes #1427

## Test Plan
- [x] `bun test --isolate maw-plugin/__tests__/index.test.ts src/routes/indexer/__tests__/scan.test.ts`
- [x] `bunx tsc -p tsconfig.json --noEmit`

## Notes
- Did not run a live `maw arra scan` against a running ARRA server.

🤖 ตอบโดย arra-oracle-v3 จาก Nat → arra-oracle-v3-oracle