### PR TITLE
Fix scanner symlink crashes and append reindex mode

### DIFF
--- a/src/indexer/__tests__/append-reindex.test.ts
+++ b/src/indexer/__tests__/append-reindex.test.ts
@@ -1,0 +1,68 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-append-reindex-'));
+const dataDir = path.join(tmp, 'data');
+const repoA = path.join(tmp, 'repo-a');
+const repoB = path.join(tmp, 'repo-b');
+
+function writeLearning(repoRoot: string, filename: string, body: string) {
+  const dir = path.join(repoRoot, 'ψ', 'memory', 'learnings');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, filename), body);
+}
+
+writeLearning(repoA, 'a.md', '# repo a\n\nalpha append preservation');
+writeLearning(repoB, 'b.md', '# repo b\n\nbeta append upsert');
+
+const originalDataDir = process.env.ORACLE_DATA_DIR;
+const originalDbPath = process.env.ORACLE_DB_PATH;
+const originalRepoRoot = process.env.ORACLE_REPO_ROOT;
+process.env.ORACLE_DATA_DIR = dataDir;
+process.env.ORACLE_DB_PATH = path.join(dataDir, 'oracle.db');
+delete process.env.ORACLE_REPO_ROOT;
+
+const { runOracleReindex } = await import('../runner.ts');
+const { createDatabase, closeDb } = await import('../../db/index.ts');
+
+describe('append reindex mode', () => {
+  afterAll(() => {
+    try { closeDb(); } catch {}
+    fs.rmSync(tmp, { recursive: true, force: true });
+    if (originalDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+    else process.env.ORACLE_DATA_DIR = originalDataDir;
+    if (originalDbPath === undefined) delete process.env.ORACLE_DB_PATH;
+    else process.env.ORACLE_DB_PATH = originalDbPath;
+    if (originalRepoRoot === undefined) delete process.env.ORACLE_REPO_ROOT;
+    else process.env.ORACLE_REPO_ROOT = originalRepoRoot;
+  });
+
+  test('upserts from a new repo root without deleting older indexed docs', async () => {
+    const first = await runOracleReindex({ repoRoot: repoA });
+    expect(first.ok).toBe(true);
+    expect(first.append).toBe(false);
+
+    const second = await runOracleReindex({ repoRoot: repoB, append: true });
+    expect(second.ok).toBe(true);
+    expect(second.append).toBe(true);
+
+    const { sqlite } = createDatabase(process.env.ORACLE_DB_PATH);
+    try {
+      const rows = sqlite.prepare(`
+        SELECT source_file AS sourceFile
+        FROM oracle_documents
+        WHERE source_file IN ('ψ/memory/learnings/a.md', 'ψ/memory/learnings/b.md')
+        ORDER BY source_file
+      `).all() as Array<{ sourceFile: string }>;
+
+      expect(rows.map(r => r.sourceFile)).toEqual([
+        'ψ/memory/learnings/a.md',
+        'ψ/memory/learnings/b.md',
+      ]);
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/src/indexer/__tests__/collectors.test.ts
+++ b/src/indexer/__tests__/collectors.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { getAllMarkdownFiles } from '../collectors.ts';
+
+describe('getAllMarkdownFiles', () => {
+  test('skips broken symlinks instead of crashing on ENOENT', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-md-scan-'));
+    try {
+      const keep = path.join(tmp, 'keep.md');
+      fs.writeFileSync(keep, '# keep\n');
+      fs.symlinkSync(path.join(tmp, 'missing.md'), path.join(tmp, 'broken.md'));
+
+      expect(() => getAllMarkdownFiles(tmp)).not.toThrow();
+      expect(getAllMarkdownFiles(tmp)).toEqual([keep]);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/indexer/collectors.ts
+++ b/src/indexer/collectors.ts
@@ -20,7 +20,14 @@ export function getAllMarkdownFiles(dir: string): string[] {
   const items = fs.readdirSync(dir);
   for (const item of items) {
     const fullPath = path.join(dir, item);
-    const stat = fs.statSync(fullPath);
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(fullPath);
+    } catch (err) {
+      const code = err && typeof err === 'object' && 'code' in err ? (err as NodeJS.ErrnoException).code : undefined;
+      if (code === 'ENOENT') continue;
+      throw err;
+    }
     if (stat.isDirectory()) {
       files.push(...getAllMarkdownFiles(fullPath));
     } else if (item.endsWith('.md')) {

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -27,6 +27,10 @@ import { parseResonanceFile, parseLearningFile, parseRetroFile, parseDistillatio
 import { collectDocuments, collectSecurityCorpus } from './collectors.ts';
 import { storeDocuments } from './storage.ts';
 
+export interface IndexOptions {
+  append?: boolean;
+}
+
 export class OracleIndexer {
   private sqlite: Database;
   private db: BunSQLiteDatabase<typeof schema>;
@@ -46,8 +50,9 @@ export class OracleIndexer {
   /**
    * Main indexing workflow
    */
-  async index(): Promise<void> {
-    console.log('Starting Oracle indexing...');
+  async index(options: IndexOptions = {}): Promise<void> {
+    const append = options.append === true;
+    console.log(append ? 'Starting Oracle indexing in append mode...' : 'Starting Oracle indexing...');
     this.seenContentHashes.clear();
 
     setIndexingStatus(this.sqlite, this.config, true, 0, 100);
@@ -62,7 +67,7 @@ export class OracleIndexer {
       .where(or(eq(oracleDocuments.createdBy, 'indexer'), isNull(oracleDocuments.createdBy)))
       .all().length;
 
-    if (!fs.existsSync(psiMemoryDir) && existingIndexerDocCount > 0) {
+    if (!append && !fs.existsSync(psiMemoryDir) && existingIndexerDocCount > 0) {
       throw new Error(
         `Refusing to index: ${psiMemoryDir} does not exist but DB has ${existingIndexerDocCount} indexer docs. ` +
         `Set ORACLE_REPO_ROOT or run from a directory containing ψ/memory/ to avoid data loss.`
@@ -81,49 +86,53 @@ export class OracleIndexer {
 
     // Safety: if we found zero source documents but the DB has existing
     // indexer-created content, abort rather than smart-deleting everything.
-    if (documents.length === 0 && existingIndexerDocCount > 0) {
+    if (!append && documents.length === 0 && existingIndexerDocCount > 0) {
       throw new Error(
         `Refusing to index: found 0 source documents but DB has ${existingIndexerDocCount} indexer docs. ` +
         `Check that ψ/memory/ contains .md files and ORACLE_REPO_ROOT points to the correct location.`
       );
     }
 
-    // Smart deletion: remove indexer-created docs whose source file no longer exists
-    const allIndexerDocs = this.db.select({ id: oracleDocuments.id, sourceFile: oracleDocuments.sourceFile })
-      .from(oracleDocuments)
-      .where(or(eq(oracleDocuments.createdBy, 'indexer'), isNull(oracleDocuments.createdBy)))
-      .all();
+    if (append) {
+      console.log('Append mode: skipping smart delete (preserving existing docs from other repo roots)');
+    } else {
+      // Smart deletion: remove indexer-created docs whose source file no longer exists
+      const allIndexerDocs = this.db.select({ id: oracleDocuments.id, sourceFile: oracleDocuments.sourceFile })
+        .from(oracleDocuments)
+        .where(or(eq(oracleDocuments.createdBy, 'indexer'), isNull(oracleDocuments.createdBy)))
+        .all();
 
-    const idsToDelete = allIndexerDocs
-      .filter(d => !fs.existsSync(path.join(this.config.repoRoot, d.sourceFile)))
-      .map(d => d.id);
+      const idsToDelete = allIndexerDocs
+        .filter(d => !fs.existsSync(path.join(this.config.repoRoot, d.sourceFile)))
+        .map(d => d.id);
 
-    // Safety: if smart-delete would drop more than half of existing indexer
-    // docs, we're almost certainly running from the wrong repoRoot — the docs
-    // on disk at this repoRoot just don't match what's in the DB. Abort rather
-    // than wiping historical data. Set ORACLE_FORCE_REINDEX=1 to override.
-    const forceFlag = process.env.ORACLE_FORCE_REINDEX === '1';
-    if (
-      !forceFlag &&
-      allIndexerDocs.length > 0 &&
-      idsToDelete.length / allIndexerDocs.length > 0.5
-    ) {
-      throw new Error(
-        `Refusing to delete ${idsToDelete.length}/${allIndexerDocs.length} docs (>50%). ` +
-        `repoRoot="${this.config.repoRoot}" likely doesn't match the source files this DB was built from. ` +
-        `Set ORACLE_REPO_ROOT to the correct path, or ORACLE_FORCE_REINDEX=1 to override.`
-      );
-    }
+      // Safety: if smart-delete would drop more than half of existing indexer
+      // docs, we're almost certainly running from the wrong repoRoot — the docs
+      // on disk at this repoRoot just don't match what's in the DB. Abort rather
+      // than wiping historical data. Set ORACLE_FORCE_REINDEX=1 to override.
+      const forceFlag = process.env.ORACLE_FORCE_REINDEX === '1';
+      if (
+        !forceFlag &&
+        allIndexerDocs.length > 0 &&
+        idsToDelete.length / allIndexerDocs.length > 0.5
+      ) {
+        throw new Error(
+          `Refusing to delete ${idsToDelete.length}/${allIndexerDocs.length} docs (>50%). ` +
+          `repoRoot="${this.config.repoRoot}" likely doesn't match the source files this DB was built from. ` +
+          `Set ORACLE_REPO_ROOT to the correct path, or ORACLE_FORCE_REINDEX=1 to override.`
+        );
+      }
 
-    console.log(`Smart delete: ${idsToDelete.length} stale docs (preserving oracle_learn)`);
+      console.log(`Smart delete: ${idsToDelete.length} stale docs (preserving oracle_learn)`);
 
-    if (idsToDelete.length > 0) {
-      this.db.delete(oracleDocuments).where(inArray(oracleDocuments.id, idsToDelete)).run();
-      const BATCH_SIZE = 500;
-      for (let i = 0; i < idsToDelete.length; i += BATCH_SIZE) {
-        const batch = idsToDelete.slice(i, i + BATCH_SIZE);
-        const placeholders = batch.map(() => '?').join(',');
-        this.sqlite.prepare(`DELETE FROM oracle_fts WHERE id IN (${placeholders})`).run(...batch);
+      if (idsToDelete.length > 0) {
+        this.db.delete(oracleDocuments).where(inArray(oracleDocuments.id, idsToDelete)).run();
+        const BATCH_SIZE = 500;
+        for (let i = 0; i < idsToDelete.length; i += BATCH_SIZE) {
+          const batch = idsToDelete.slice(i, i + BATCH_SIZE);
+          const placeholders = batch.map(() => '?').join(',');
+          this.sqlite.prepare(`DELETE FROM oracle_fts WHERE id IN (${placeholders})`).run(...batch);
+        }
       }
     }
 

--- a/src/indexer/runner.ts
+++ b/src/indexer/runner.ts
@@ -59,14 +59,15 @@ export function createIndexerConfig(repoRoot: string): IndexerConfig {
   };
 }
 
-export async function runOracleReindex(opts: { repoRoot?: string | null } = {}) {
+export async function runOracleReindex(opts: { repoRoot?: string | null; append?: boolean } = {}) {
   const repoRoot = resolveIndexerRepoRoot(opts.repoRoot);
+  const append = opts.append === true;
   const config = createIndexerConfig(repoRoot);
   const indexer = new OracleIndexer(config);
 
   try {
-    await indexer.index();
-    return { ok: true as const, repoRoot };
+    await indexer.index({ append });
+    return { ok: true as const, repoRoot, append };
   } finally {
     await indexer.close();
   }

--- a/src/routes/indexer/__tests__/reindex.test.ts
+++ b/src/routes/indexer/__tests__/reindex.test.ts
@@ -12,7 +12,7 @@ function post(app: Elysia, body: unknown) {
 
 describe('POST /indexer/reindex', () => {
   it('runs the full reindex by default and waits for completion', async () => {
-    const runFull = mock(async ({ repoRoot }: { repoRoot?: string | null }) => ({ ok: true as const, repoRoot: repoRoot ?? '/repo' }));
+    const runFull = mock(async ({ repoRoot, append }: { repoRoot?: string | null; append?: boolean }) => ({ ok: true as const, repoRoot: repoRoot ?? '/repo', append: append === true }));
     const runRetros = mock(async (repoRoot: string) => ({ ok: true as const, repoRoot, documents: 0 }));
     const runRetroFile = mock(async (repoRoot: string, filePath: string) => ({ ok: true as const, repoRoot, filePath, documents: 0 }));
     const app = new Elysia().use(createReindexRoute({
@@ -30,11 +30,34 @@ describe('POST /indexer/reindex', () => {
     expect(body.status).toBe('complete');
     expect(body.repoRoot).toBe('/repo');
     expect(runFull).toHaveBeenCalledTimes(1);
+    expect(runFull).toHaveBeenCalledWith({ repoRoot: '/repo', append: false });
+    expect(runRetros).not.toHaveBeenCalled();
+  });
+
+  it('passes append mode to the full reindex runner', async () => {
+    const runFull = mock(async ({ repoRoot, append }: { repoRoot?: string | null; append?: boolean }) => ({ ok: true as const, repoRoot: repoRoot ?? '/repo', append: append === true }));
+    const runRetros = mock(async (repoRoot: string) => ({ ok: true as const, repoRoot, documents: 0 }));
+    const runRetroFile = mock(async (repoRoot: string, filePath: string) => ({ ok: true as const, repoRoot, filePath, documents: 0 }));
+    const app = new Elysia().use(createReindexRoute({
+      resolveRepoRoot: () => '/new-root',
+      runFull,
+      runRetros,
+      runRetroFile,
+    }));
+
+    const res = await post(app, { append: true });
+    const body = await res.json() as any;
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.append).toBe(true);
+    expect(runFull).toHaveBeenCalledTimes(1);
+    expect(runFull).toHaveBeenCalledWith({ repoRoot: '/new-root', append: true });
     expect(runRetros).not.toHaveBeenCalled();
   });
 
   it('supports retrospective-only indexing without full smart-delete', async () => {
-    const runFull = mock(async ({ repoRoot }: { repoRoot?: string | null }) => ({ ok: true as const, repoRoot: repoRoot ?? '/repo' }));
+    const runFull = mock(async ({ repoRoot, append }: { repoRoot?: string | null; append?: boolean }) => ({ ok: true as const, repoRoot: repoRoot ?? '/repo', append: append === true }));
     const runRetros = mock(async (repoRoot: string) => ({ ok: true as const, repoRoot, documents: 3 }));
     const runRetroFile = mock(async (repoRoot: string, filePath: string) => ({ ok: true as const, repoRoot, filePath, documents: 0 }));
     const app = new Elysia().use(createReindexRoute({
@@ -57,7 +80,7 @@ describe('POST /indexer/reindex', () => {
   it('returns a 409 while a non-waiting job is active', async () => {
     let release!: () => void;
     const blocker = new Promise<void>(resolve => { release = resolve; });
-    const runFull = mock(async ({ repoRoot }: { repoRoot?: string | null }) => {
+    const runFull = mock(async ({ repoRoot }: { repoRoot?: string | null; append?: boolean }) => {
       await blocker;
       return { ok: true as const, repoRoot: repoRoot ?? '/repo' };
     });

--- a/src/routes/indexer/reindex.ts
+++ b/src/routes/indexer/reindex.ts
@@ -9,7 +9,7 @@ type ReindexResult =
 
 export interface ReindexDeps {
   resolveRepoRoot: (repoRoot?: string | null) => string;
-  runFull: (opts: { repoRoot?: string | null }) => Promise<ReindexResult>;
+  runFull: (opts: { repoRoot?: string | null; append?: boolean }) => Promise<ReindexResult>;
   runRetros: (repoRoot: string) => Promise<ReindexResult>;
   runRetroFile: (repoRoot: string, filePath: string) => Promise<ReindexResult>;
 }
@@ -28,6 +28,7 @@ export function createReindexRoute(deps: ReindexDeps = defaultDeps) {
     const requested = body ?? {};
     const scope = requested.scope ?? 'all';
     const wait = requested.wait !== false;
+    const append = requested.append === true;
     const repoRoot = deps.resolveRepoRoot(requested.repoRoot);
     const jobId = `reindex-${Date.now()}`;
 
@@ -42,7 +43,7 @@ export function createReindexRoute(deps: ReindexDeps = defaultDeps) {
         if (!requested.filePath) throw new Error('filePath is required for scope=retro-file');
         return deps.runRetroFile(repoRoot, requested.filePath);
       }
-      return deps.runFull({ repoRoot });
+      return deps.runFull({ repoRoot, append });
     };
 
     activeJob = { id: jobId, startedAt: new Date().toISOString() };
@@ -60,7 +61,7 @@ export function createReindexRoute(deps: ReindexDeps = defaultDeps) {
 
     // Ensure background failures are observed by the task catch above.
     void task;
-    return { ok: true, jobId, status: 'started', repoRoot, scope };
+    return { ok: true, jobId, status: 'started', repoRoot, scope, append };
   }, {
     body: t.Optional(t.Object({
       repoRoot: t.Optional(t.String()),
@@ -71,6 +72,7 @@ export function createReindexRoute(deps: ReindexDeps = defaultDeps) {
       ])),
       filePath: t.Optional(t.String()),
       wait: t.Optional(t.Boolean()),
+      append: t.Optional(t.Boolean()),
     })),
     detail: {
       tags: ['indexer'],


### PR DESCRIPTION
## Summary
- skip broken symlinks during markdown collection instead of crashing on ENOENT
- add `append:true` support to full reindex requests so new repo roots upsert docs without smart-delete
- cover broken symlink scanning, HTTP append propagation, and append-mode preservation from a second repo root

## Verification
- `bun test --isolate src/indexer/__tests__/collectors.test.ts src/indexer/__tests__/append-reindex.test.ts src/routes/indexer/__tests__/reindex.test.ts`
- `bun test --isolate src/indexer/__tests__/ src/routes/indexer/__tests__/ src/indexer-preservation.test.ts`
- `bun run test:unit`
- `bun run build`
- `git diff --check`

Closes #1428
