### PR TITLE
Guard MCP search when vectors are disabled

### DIFF
--- a/src/tools/__tests__/mcp-vector-guard.test.ts
+++ b/src/tools/__tests__/mcp-vector-guard.test.ts
@@ -1,0 +1,87 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-mcp-vector-guard-'));
+const originalDataDir = process.env.ORACLE_DATA_DIR;
+const originalDbPath = process.env.ORACLE_DB_PATH;
+const originalVectorEnabled = process.env.ORACLE_VECTOR_ENABLED;
+
+process.env.ORACLE_DATA_DIR = path.join(tmp, 'data');
+process.env.ORACLE_DB_PATH = path.join(tmp, 'data', 'oracle.db');
+delete process.env.ORACLE_VECTOR_ENABLED;
+
+const { createDatabase, closeDb } = await import('../../db/index.ts');
+const { oracleDocuments } = await import('../../db/schema.ts');
+const { handleSearch } = await import('../search.ts');
+
+function parse(response: { content: Array<{ text: string }> }) {
+  return JSON.parse(response.content[0].text);
+}
+
+function makeCtx() {
+  const { sqlite, db } = createDatabase(process.env.ORACLE_DB_PATH);
+  sqlite.exec('DELETE FROM oracle_documents');
+  sqlite.exec('DELETE FROM oracle_fts');
+  const now = Date.now();
+  db.insert(oracleDocuments).values({
+    id: 'mcp-vector-disabled-doc',
+    type: 'learning',
+    sourceFile: 'ψ/memory/learnings/mcp-vector-disabled.md',
+    concepts: JSON.stringify(['mcp', 'vector', 'guard']),
+    createdAt: now,
+    updatedAt: now,
+    indexedAt: now,
+    project: null,
+  }).run();
+  sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
+    .run('mcp-vector-disabled-doc', 'MCP vector disabled guard falls back to FTS without touching vector search.', 'mcp vector guard');
+
+  return {
+    db,
+    sqlite,
+    repoRoot: tmp,
+    vectorStore: {
+      name: 'must-not-be-called',
+      query: () => { throw new Error('vector query should be skipped when vector section is disabled'); },
+    } as any,
+    vectorStatus: 'unavailable' as const,
+    version: 'test-version',
+  };
+}
+
+afterAll(() => {
+  try { closeDb(); } catch {}
+  fs.rmSync(tmp, { recursive: true, force: true });
+  if (originalDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = originalDataDir;
+  if (originalDbPath === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = originalDbPath;
+  if (originalVectorEnabled === undefined) delete process.env.ORACLE_VECTOR_ENABLED;
+  else process.env.ORACLE_VECTOR_ENABLED = originalVectorEnabled;
+});
+
+describe('MCP muninn_search vector section guard', () => {
+  test('hybrid mode skips vector and returns FTS metadata when vector section is disabled', async () => {
+    const ctx = makeCtx();
+    const body = parse(await handleSearch(ctx, { query: 'MCP vector disabled guard', mode: 'hybrid', limit: 5 }));
+
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0].source).toBe('fts');
+    expect(body.metadata.vectorAvailable).toBe(false);
+    expect(body.metadata.vectorMatches).toBe(0);
+    expect(body.metadata.ftsMatches).toBe(1);
+  });
+
+  test('vector mode also falls back to FTS when vector section is disabled', async () => {
+    const ctx = makeCtx();
+    const body = parse(await handleSearch(ctx, { query: 'MCP vector disabled guard', mode: 'vector', limit: 5 }));
+
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0].source).toBe('fts');
+    expect(body.metadata.mode).toBe('vector');
+    expect(body.metadata.vectorAvailable).toBe(false);
+    expect(body.metadata.vectorMatches).toBe(0);
+  });
+});

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -9,6 +9,7 @@
 import { detectProject } from '../server/project-detect.ts';
 import { rerankCandidates } from '../server/reranker.ts';
 import { ensureVectorStoreConnected } from '../vector/factory.ts';
+import { isVectorSectionEnabled } from '../vector/config.ts';
 import type { SearchResult } from '../server/types.ts';
 import type { ToolContext, ToolResponse, OracleSearchInput } from './types.ts';
 
@@ -337,10 +338,18 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
 
   let warning: string | undefined;
   let vectorSearchError = false;
+  const requestedMode = mode;
+  let effectiveMode = mode;
+  const vectorSectionEnabled = requestedMode !== 'fts' && isVectorSectionEnabled();
+  let vectorAvailable = requestedMode !== 'fts' ? vectorSectionEnabled : undefined;
 
-  // Run FTS5 search (skip if vector-only mode)
+  if (requestedMode !== 'fts' && !vectorSectionEnabled) {
+    effectiveMode = 'fts';
+  }
+
+  // Run FTS5 search (skip only when vector is both requested and available)
   let ftsRawResults: any[] = [];
-  if (mode !== 'vector' && safeQuery) {
+  if (effectiveMode !== 'vector' && safeQuery) {
     try {
       if (type === 'all') {
         const stmt = ctx.sqlite.prepare(`
@@ -371,13 +380,14 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
     }
   }
 
-  // Run vector search (skip if fts-only mode)
+  // Run vector search (skip if fts-only mode or vector section is disabled)
   let vecResults: Awaited<ReturnType<typeof vectorSearch>> = [];
-  if (mode !== 'fts') {
+  if (effectiveMode !== 'fts') {
     try {
       vecResults = await vectorSearch(ctx, query, type, limit * 2, model);
     } catch (error) {
       vectorSearchError = true;
+      vectorAvailable = false;
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.error('[ChromaDB]', errorMessage);
       warning = `Vector search unavailable: ${errorMessage}. Using FTS5 only.`;
@@ -467,6 +477,7 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
     vectorMatches: number;
     sources: { fts: number; vector: number; hybrid: number };
     searchTime: number;
+    vectorAvailable?: boolean;
     reranked?: boolean;
     rerankFallbackReason?: string;
     warning?: string;
@@ -479,6 +490,7 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
     vectorMatches: vecResults.length,
     sources: { fts: ftsCount, vector: vectorCount, hybrid: hybridCount },
     searchTime,
+    ...(requestedMode !== 'fts' ? { vectorAvailable: vectorAvailable === true } : {}),
     reranked: reranked.reranked,
     ...(reranked.fallbackReason ? { rerankFallbackReason: reranked.fallbackReason } : {}),
   };


### PR DESCRIPTION
## Summary
- make MCP `muninn_search` honor `isVectorSectionEnabled()` before local vector search
- fall back to FTS for hybrid/vector requests when the vector section is disabled
- report `metadata.vectorAvailable = false` when vector search is skipped by config
- add MCP regression coverage that fails if the vector store is touched while disabled

## Verification
- `bun test --isolate src/tools/__tests__/mcp-vector-guard.test.ts src/tools/__tests__/search.test.ts`
- `bun test --isolate src/tools/__tests__/`
- `bun run test:unit`
- `bun run build`
- `git diff --check`

Closes #1434
