### PR TITLE
fix(learn): stamp doc id/filename with GMT+7 date, not UTC

### DIFF
--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -10,6 +10,7 @@ import path from 'path';
 import { eq, sql, or, inArray } from 'drizzle-orm';
 import { db, sqlite, oracleDocuments, indexingStatus, isDbLockError } from '../db/index.ts';
 import { REPO_ROOT, VECTOR_URL } from '../config.ts';
+import { bangkokDateStr } from '../time-util.ts';
 import { logSearch, logDocumentAccess, logLearning } from './logging.ts';
 import type { SearchResult, SearchResponse } from './types.ts';
 import { ensureVectorStoreConnected, EMBEDDING_MODELS } from '../vector/factory.ts';
@@ -686,7 +687,7 @@ export function persistLearningDoc(opts: {
 }): { file: string; id: string } {
   const { pattern, subdir, filename, id } = opts;
   const now = new Date();
-  const dateStr = now.toISOString().split('T')[0];
+  const dateStr = bangkokDateStr(now); // GMT+7 date for in-doc frontmatter (not UTC)
 
   const dir = path.join(REPO_ROOT, subdir);
   fs.mkdirSync(dir, { recursive: true });
@@ -755,7 +756,7 @@ export function handleLearn(
   cwd?: string
 ) {
   const resolvedProject = (project ?? detectProject(cwd))?.toLowerCase() ?? null;
-  const dateStr = new Date().toISOString().split('T')[0];
+  const dateStr = bangkokDateStr(); // GMT+7 calendar date for id/filename (not UTC)
 
   const slug = pattern
     .substring(0, 50)

--- a/src/time-util.ts
+++ b/src/time-util.ts
@@ -1,0 +1,17 @@
+/**
+ * Time helpers — Oracle fleet standard timezone is GMT+7 (Asia/Bangkok).
+ *
+ * Doc ids / filenames must stamp the LOCAL Thai calendar date, not UTC. A write at
+ * 00:30 Bangkok is still the *previous* day in UTC, so `new Date().toISOString()`
+ * mis-dated ids (e.g. a 2026-06-15 00:06 ICT learning got id `learning_2026-06-14_…`),
+ * which fooled date-based corpus checks fleet-wide. (TK timezone-standardization 2026-06-15)
+ *
+ * Thailand is a fixed UTC+7 offset (no DST), so shifting the instant by +7h and taking
+ * the UTC date part yields the exact Bangkok calendar date with no Intl/tz-data dependency.
+ *
+ * Note: stored timestamps (createdAt/updatedAt) stay as `Date.now()` epoch-ms — those are
+ * absolute instants and timezone-neutral; only the human-readable date STRING needs GMT+7.
+ */
+export function bangkokDateStr(d: Date = new Date()): string {
+  return new Date(d.getTime() + 7 * 60 * 60 * 1000).toISOString().split('T')[0];
+}

--- a/src/tools/learn.ts
+++ b/src/tools/learn.ts
@@ -12,6 +12,7 @@ import { detectProject } from '../server/project-detect.ts';
 import { getVaultPsiRoot } from '../vault/handler.ts';
 import { getVectorStoreByModel, getEmbeddingModels } from '../vector/factory.ts';
 import { REPO_ROOT } from '../config.ts';
+import { bangkokDateStr } from '../time-util.ts';
 
 // Lazy-loaded on first use — avoids top-level await which causes a TDZ
 // error in consumers that import learnToolDef synchronously (the tools
@@ -123,7 +124,7 @@ export function extractProjectFromSource(source?: string): string | null {
 export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Promise<ToolResponse> {
   const { pattern, source, concepts, project: projectInput } = input;
   const now = new Date();
-  const dateStr = now.toISOString().split('T')[0];
+  const dateStr = bangkokDateStr(now); // GMT+7 calendar date for id/filename (not UTC)
 
   const slug = pattern
     .substring(0, 50)


### PR DESCRIPTION
## Problem
`muninn_learn` builds doc ids/filenames from `new Date().toISOString()` (UTC). A learning written **00:00–06:59 Asia/Bangkok** is still the *previous* calendar day in UTC, so the id is mis-dated — e.g. a doc created `2026-06-15 00:06` ICT got id `learning_2026-06-14_…`. This silently fooled every date-based corpus check (watchdogs, "today's docs" queries) across the fleet on 2026-06-15.

## Fix
Fleet timezone standard is **GMT+7**. Adds `bangkokDateStr()` (fixed UTC+7, no DST, no Intl dependency) and uses it for the id/filename date in:
- `src/tools/learn.ts` (MCP `muninn_learn` path)
- `src/server/handlers.ts` (HTTP `/api/learn` path + in-doc frontmatter date)

## Notes
- Stored `createdAt`/`updatedAt` stay epoch-ms (absolute, timezone-neutral) — **unchanged**. Only the human-readable date string needed GMT+7.
- **Going-forward only** — existing docs are NOT re-stamped (Nothing is Deleted).
- `tsc --noEmit` clean. Logic verified: instant `2026-06-15T17:30Z` (00:30 Bangkok) → `2026-06-16` (correct) vs old `2026-06-15`.

Requested by TK (fleet timezone standardization). cc @No.6 — coordinating per directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)