### PR TITLE
fix(menu-seeder): guard duplicate route collisions by (path,studio) (#958)

### DIFF
--- a/src/db/seeders/menu-seeder.ts
+++ b/src/db/seeders/menu-seeder.ts
@@ -28,6 +28,8 @@ export interface RouteMenuRow {
   studio?: string | null; // host subdomain (e.g. feed.buildwithoracle.com); null = legacy studio.*
 }
 
+type SeenRouteMenuRow = RouteMenuRow & { apiPath: string };
+
 function studioPathFor(apiPath: string): string | null {
   for (const [prefix, studio] of API_TO_STUDIO) {
     if (apiPath === prefix || apiPath.startsWith(prefix + '/')) return studio;
@@ -35,9 +37,22 @@ function studioPathFor(apiPath: string): string | null {
   return null;
 }
 
+function routeMenuKey(path: string, studio: string | null | undefined): string {
+  return `${studio ?? ''}\0${path}`;
+}
+
+function warnDuplicateRouteMenu(first: SeenRouteMenuRow, next: SeenRouteMenuRow): void {
+  console.warn(
+    `[menu-seeder] duplicate route menu path "${next.path}"` +
+      ` (studio=${next.studio ?? 'null'}); keeping ${first.apiPath}` +
+      ` (${first.groupKey}/${first.position}), skipping ${next.apiPath}` +
+      ` (${next.groupKey}/${next.position})`,
+  );
+}
+
 export function collectRouteMenuRows(sources: HasRoutes[]): RouteMenuRow[] {
   const rows: RouteMenuRow[] = [];
-  const seen = new Set<string>();
+  const seen = new Map<string, SeenRouteMenuRow>();
 
   for (const src of sources) {
     for (const route of src.routes) {
@@ -48,16 +63,11 @@ export function collectRouteMenuRows(sources: HasRoutes[]): RouteMenuRow[] {
       const studio = studioPathFor(route.path);
       if (!studio) continue;
 
-      const key = `${menu.group}:${studio}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-
       const slug = studio.replace(/^\//, '') || 'home';
       const label = menu.label ?? slug.charAt(0).toUpperCase() + slug.slice(1);
       const order =
         typeof menu.order === 'number' && Number.isFinite(menu.order) ? menu.order : 999;
-
-      rows.push({
+      const row = {
         path: studio,
         label,
         groupKey: menu.group,
@@ -65,7 +75,17 @@ export function collectRouteMenuRows(sources: HasRoutes[]): RouteMenuRow[] {
         access: menu.access ?? 'public',
         icon: menu.icon ?? null,
         studio: null,
-      });
+      };
+      const seenRow = { ...row, apiPath: route.path };
+      const key = routeMenuKey(row.path, row.studio);
+      const first = seen.get(key);
+      if (first) {
+        warnDuplicateRouteMenu(first, seenRow);
+        continue;
+      }
+      seen.set(key, seenRow);
+
+      rows.push(row);
     }
   }
 

--- a/tests/http/menu/db-seeder.test.ts
+++ b/tests/http/menu/db-seeder.test.ts
@@ -53,6 +53,34 @@ describe('collectRouteMenuRows', () => {
       .get('/health', () => ({}), { detail: { summary: 'Health' } });
     expect(collectRouteMenuRows([sub])).toHaveLength(1);
   });
+
+  test('warns and keeps the first row when route menu paths collide', () => {
+    const originalWarn = console.warn;
+    const warnings: string[] = [];
+    console.warn = (...args: unknown[]) => warnings.push(String(args[0]));
+
+    try {
+      const duplicate = new Elysia({ prefix: '/api' })
+        .get('/map', () => ({}), {
+          detail: { menu: { group: 'tools', order: 20, label: 'Map' } },
+        })
+        .get('/map3d', () => ({}), {
+          detail: { menu: { group: 'main', order: 30, label: 'Map 3D' } },
+        });
+
+      const rows = collectRouteMenuRows([duplicate]);
+
+      expect(rows).toEqual([
+        { path: '/map', label: 'Map', groupKey: 'tools', position: 20, access: 'public', icon: null, studio: null },
+      ]);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('duplicate route menu path "/map"');
+      expect(warnings[0]).toContain('keeping /api/map');
+      expect(warnings[0]).toContain('skipping /api/map3d');
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
 });
 
 describe('seedMenuItems', () => {


### PR DESCRIPTION
Clean repackage of codex-2's menu-seeder #958 fix (PR #1464 carried a worktree .claude/skills symlink-vs-files artifact). Only src/db/seeders/menu-seeder.ts + tests/http/menu/db-seeder.test.ts. menu #958 reparent 5/5 green, scoped menu 85 pass, tsc --noEmit pass.