### PR TITLE
feat: make storage backend swappable

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "build": "tsc --noEmit",
     "start": "bun dist/index.js",
     "test": "bun run test:unit && bun run test:integration",
-    "test:unit": "bun test --isolate src/tools/__tests__/ src/server/__tests__/ src/vault/__tests__/ src/indexer/__tests__/ src/drizzle-migration.test.ts src/indexer-preservation.test.ts",
+    "test:unit": "bun test --isolate src/tools/__tests__/ src/server/__tests__/ src/storage/__tests__/ src/vault/__tests__/ src/indexer/__tests__/ src/drizzle-migration.test.ts src/indexer-preservation.test.ts",
     "test:integration": "bun test --isolate src/integration/",
     "test:integration:db": "bun test --isolate src/integration/database.test.ts",
     "test:integration:mcp": "bun test src/integration/mcp.test.ts",

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,146 +1,53 @@
 /**
  * Oracle v2 Drizzle Database Client
  *
- * Single source of truth for DB initialization:
- * 1. Drizzle migrations (schema tables)
- * 2. FTS5 virtual table (raw SQL, can't be managed by Drizzle)
- * 3. Seed indexing_status row
+ * Single source of truth for DB access. The active storage backend is resolved
+ * by src/storage/registry.ts so command handlers keep using the same db/sqlite
+ * context while the backend can be swapped by config.
  */
 
 import { eq } from 'drizzle-orm';
-import { drizzle, type BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
-import { migrate } from 'drizzle-orm/bun-sqlite/migrator';
-import { Database } from 'bun:sqlite';
+import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
+import type { Database } from 'bun:sqlite';
 import path from 'path';
-import fs from 'fs';
 import * as schema from './schema.ts';
 import { DB_PATH, ORACLE_DATA_DIR } from '../config.ts';
+import { createStorageBackend } from '../storage/registry.ts';
+import type { StorageBackend } from '../storage/types.ts';
 
-// Migrations folder (relative to this file)
-const MIGRATIONS_FOLDER = path.join(import.meta.dirname || __dirname, 'migrations');
+export {
+  initFts5,
+  initSupersedeLog,
+  initializeDrizzleSqlite,
+} from '../storage/drizzle-sqlite.ts';
 
-/**
- * Initialize FTS5 virtual table (must use raw SQL)
- * Drizzle doesn't manage FTS5 — this is idempotent.
- */
-export function initFts5(sqliteDb: Database): void {
-  sqliteDb.exec(`
-    CREATE VIRTUAL TABLE IF NOT EXISTS oracle_fts USING fts5(
-      id UNINDEXED,
-      content,
-      concepts,
-      tokenize='porter unicode61'
-    )
-  `);
-}
-
-/**
- * Initialize supersede_log table (migration 0003)
- * Added to fix existing installations missing this table.
- * Idempotent - safe to call on every startup.
- */
-export function initSupersedeLog(sqliteDb: Database): void {
-  // Create table
-  sqliteDb.exec(`
-    CREATE TABLE IF NOT EXISTS supersede_log (
-      id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
-      old_path text NOT NULL,
-      old_id text,
-      old_title text,
-      old_type text,
-      new_path text,
-      new_id text,
-      new_title text,
-      reason text,
-      superseded_at integer NOT NULL,
-      superseded_by text,
-      project text
-    )
-  `);
-
-  // Create indexes
-  sqliteDb.exec(`
-    CREATE INDEX IF NOT EXISTS idx_supersede_old_path ON supersede_log (old_path);
-    CREATE INDEX IF NOT EXISTS idx_supersede_new_path ON supersede_log (new_path);
-    CREATE INDEX IF NOT EXISTS idx_supersede_created ON supersede_log (superseded_at);
-    CREATE INDEX IF NOT EXISTS idx_supersede_project ON supersede_log (project);
-  `);
-}
-
-/**
- * Initialize a database: run migrations, create FTS5, seed indexing_status.
- */
-function initializeDatabase(sqliteDb: Database, drizzleDb: BunSQLiteDatabase<typeof schema>): void {
-  // WAL mode for concurrent reads
-  sqliteDb.exec('PRAGMA journal_mode = WAL');
-  sqliteDb.exec('PRAGMA busy_timeout = 5000');
-
-  // Run Drizzle migrations (creates/updates all schema tables)
-  migrate(drizzleDb, { migrationsFolder: MIGRATIONS_FOLDER });
-
-  // FTS5 (raw SQL, idempotent)
-  initFts5(sqliteDb);
-
-  // Supersede log table (migration 0003 - idempotent for existing DBs)
-  initSupersedeLog(sqliteDb);
-
-  // Ensure indexing_status has its single row
-  sqliteDb.exec('INSERT OR IGNORE INTO indexing_status (id, is_indexing) VALUES (1, 0)');
-
-  // One-time migration: normalize project casing to lowercase
-  const migrated = sqliteDb.prepare("SELECT value FROM settings WHERE key = 'migration_lowercase_projects'").get() as { value: string } | undefined;
-  if (!migrated) {
-    sqliteDb.exec("UPDATE oracle_documents SET project = LOWER(project) WHERE project <> LOWER(project)");
-    sqliteDb.exec("INSERT OR REPLACE INTO settings (key, value, updated_at) VALUES ('migration_lowercase_projects', '1', unixepoch() * 1000)");
-  }
+export interface DatabaseConnection {
+  sqlite: Database;
+  db: BunSQLiteDatabase<typeof schema>;
+  storage: StorageBackend;
 }
 
 /**
  * Create a fully-initialized database connection.
  * Used by MCP entry (src/index.ts) and indexer (src/indexer.ts).
  */
-export function createDatabase(dbPath?: string): {
-  sqlite: Database;
-  db: BunSQLiteDatabase<typeof schema>;
-} {
-  const resolvedPath = dbPath || DB_PATH;
-
-  // Ensure parent directory exists
-  const dir = path.dirname(resolvedPath);
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
-
-  const sqliteDb = new Database(resolvedPath);
-  const drizzleDb = drizzle(sqliteDb, { schema });
-
-  initializeDatabase(sqliteDb, drizzleDb);
-
-  return { sqlite: sqliteDb, db: drizzleDb };
+export function createDatabase(dbPath?: string): DatabaseConnection {
+  const storage = createStorageBackend({ dbPath: dbPath || DB_PATH });
+  return { sqlite: storage.sqlite, db: storage.db, storage };
 }
 
 // ============================================================================
 // Default module-level connection (used by server.ts, handlers, etc.)
 // ============================================================================
 
-// Ensure data dir exists before opening DB
-if (!fs.existsSync(ORACLE_DATA_DIR)) {
-  fs.mkdirSync(ORACLE_DATA_DIR, { recursive: true });
-}
-
 const isReadonly = process.env.ORACLE_VECTOR_READONLY === '1';
-let defaultSqlite = isReadonly
-  ? new Database(DB_PATH, { readonly: true })
-  : new Database(DB_PATH);
-let defaultDb = drizzle(defaultSqlite, { schema });
+let defaultStorage = createStorageBackend({ dbPath: DB_PATH, readonly: isReadonly });
+let defaultSqlite = defaultStorage.sqlite;
+let defaultDb = defaultStorage.db;
 
-if (isReadonly) {
-  console.log('[DB] Opened in READONLY mode (vector sidecar)');
-} else {
-  // Run initialization on the default connection (skipped in readonly mode)
-  initializeDatabase(defaultSqlite, defaultDb);
-}
+if (isReadonly) console.log('[DB] Opened in READONLY mode (vector sidecar)');
 
+export let storage = defaultStorage;
 export let sqlite = defaultSqlite;
 export let db = defaultDb;
 
@@ -151,13 +58,13 @@ export let db = defaultDb;
  * isolation. Production callers should prefer createDatabase().
  */
 export function resetDefaultDatabaseForTests(dbPath?: string): void {
-  try { defaultSqlite.close(); } catch {}
-  const resolvedPath = dbPath || process.env.ORACLE_DB_PATH || path.join(process.env.ORACLE_DATA_DIR || ORACLE_DATA_DIR, 'oracle.db');
-  const dir = path.dirname(resolvedPath);
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-  defaultSqlite = new Database(resolvedPath);
-  defaultDb = drizzle(defaultSqlite, { schema });
-  initializeDatabase(defaultSqlite, defaultDb);
+  try { defaultStorage.close(); } catch {}
+  const resolvedPath = dbPath || process.env.ORACLE_DB_PATH
+    || path.join(process.env.ORACLE_DATA_DIR || ORACLE_DATA_DIR, 'oracle.db');
+  defaultStorage = createStorageBackend({ dbPath: resolvedPath });
+  defaultSqlite = defaultStorage.sqlite;
+  defaultDb = defaultStorage.db;
+  storage = defaultStorage;
   sqlite = defaultSqlite;
   db = defaultDb;
 }
@@ -165,11 +72,9 @@ export function resetDefaultDatabaseForTests(dbPath?: string): void {
 // Export schema for use in queries
 export * from './schema.ts';
 
-/**
- * Close database connection
- */
+/** Close database connection. */
 export function closeDb() {
-  defaultSqlite.close();
+  defaultStorage.close();
 }
 
 // ============================================================================

--- a/src/storage/__tests__/backend.test.ts
+++ b/src/storage/__tests__/backend.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { settings } from '../../db/schema.ts';
+import { loadStorageConfig } from '../config.ts';
+import {
+  createStorageBackend,
+  registerStorageBackend,
+  resetStorageBackendsForTests,
+} from '../registry.ts';
+import type { StorageBackend } from '../types.ts';
+
+const tempDirs: string[] = [];
+const originalStorageBackend = process.env.ORACLE_STORAGE_BACKEND;
+const originalDbBackend = process.env.ORACLE_DB_BACKEND;
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-storage-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function clearBackendEnv(): void {
+  delete process.env.ORACLE_STORAGE_BACKEND;
+  delete process.env.ORACLE_DB_BACKEND;
+}
+
+function restoreBackendEnv(): void {
+  if (originalStorageBackend === undefined) delete process.env.ORACLE_STORAGE_BACKEND;
+  else process.env.ORACLE_STORAGE_BACKEND = originalStorageBackend;
+  if (originalDbBackend === undefined) delete process.env.ORACLE_DB_BACKEND;
+  else process.env.ORACLE_DB_BACKEND = originalDbBackend;
+}
+
+afterEach(() => {
+  resetStorageBackendsForTests();
+  restoreBackendEnv();
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()!;
+    if (dir.startsWith(os.tmpdir()) && fs.existsSync(dir)) {
+      fs.rmSync(dir, { recursive: true });
+    }
+  }
+});
+
+describe('storage backends', () => {
+  it('defaults to drizzle-sqlite and initializes sqlite schema', () => {
+    clearBackendEnv();
+    const repoRoot = makeTempDir();
+    const dataDir = makeTempDir();
+    const dbPath = path.join(dataDir, 'oracle.db');
+    const config = loadStorageConfig({ repoRoot, dataDir });
+
+    expect(config.backend).toBe('drizzle-sqlite');
+    const backend = createStorageBackend({ dbPath, backend: config.backend });
+    backend.db.insert(settings).values({
+      key: 'storage_backend_test',
+      value: 'ok',
+      updatedAt: Date.now(),
+    }).run();
+
+    const row = backend.sqlite
+      .prepare('SELECT value FROM settings WHERE key = ?')
+      .get('storage_backend_test') as { value: string } | undefined;
+    expect(row?.value).toBe('ok');
+    backend.close();
+  });
+
+  it('selects a registered stub backend from config', () => {
+    clearBackendEnv();
+    const repoRoot = makeTempDir();
+    const dataDir = makeTempDir();
+    const calls: string[] = [];
+    fs.writeFileSync(
+      path.join(repoRoot, 'arra.config.json'),
+      JSON.stringify({ storage: { backend: 'stub' } }),
+    );
+
+    registerStorageBackend('stub', (options): StorageBackend => {
+      calls.push(options.dbPath ?? 'missing');
+      return {
+        name: 'stub',
+        db: {} as StorageBackend['db'],
+        sqlite: {} as StorageBackend['sqlite'],
+        close: () => calls.push('closed'),
+      };
+    });
+
+    const backend = createStorageBackend({
+      repoRoot,
+      dataDir,
+      dbPath: path.join(dataDir, 'ignored.db'),
+    });
+
+    expect(backend.name).toBe('stub');
+    expect(calls[0].endsWith('ignored.db')).toBe(true);
+    backend.close();
+    expect(calls).toContain('closed');
+  });
+});

--- a/src/storage/config.ts
+++ b/src/storage/config.ts
@@ -1,0 +1,62 @@
+/** Storage backend config resolution. */
+
+import fs from 'fs';
+import path from 'path';
+import { ORACLE_DATA_DIR } from '../config.ts';
+
+export const DEFAULT_STORAGE_BACKEND = 'drizzle-sqlite';
+
+export interface StorageConfig {
+  backend: string;
+}
+
+interface ConfigShape {
+  storage?: { backend?: unknown };
+  database?: { backend?: unknown };
+  storageBackend?: unknown;
+  databaseBackend?: unknown;
+}
+
+interface LoadStorageConfigOptions {
+  repoRoot?: string;
+  dataDir?: string;
+}
+
+function readJson(filePath: string): ConfigShape | null {
+  if (!fs.existsSync(filePath)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8')) as ConfigShape;
+  } catch {
+    return null;
+  }
+}
+
+function backendFrom(raw: ConfigShape | null): string | null {
+  const value = raw?.storage?.backend
+    ?? raw?.database?.backend
+    ?? raw?.storageBackend
+    ?? raw?.databaseBackend;
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+export function loadStorageConfig(
+  options: LoadStorageConfigOptions = {},
+): StorageConfig {
+  const envBackend = process.env.ORACLE_STORAGE_BACKEND
+    || process.env.ORACLE_DB_BACKEND;
+  if (envBackend?.trim()) return { backend: envBackend.trim() };
+
+  const repoRoot = options.repoRoot || process.env.ORACLE_REPO_ROOT || process.cwd();
+  const dataDir = options.dataDir || ORACLE_DATA_DIR;
+  const candidates = [
+    path.join(repoRoot, 'arra.config.json'),
+    path.join(dataDir, 'config.json'),
+  ];
+
+  for (const filePath of candidates) {
+    const backend = backendFrom(readJson(filePath));
+    if (backend) return { backend };
+  }
+
+  return { backend: DEFAULT_STORAGE_BACKEND };
+}

--- a/src/storage/drizzle-sqlite.ts
+++ b/src/storage/drizzle-sqlite.ts
@@ -1,0 +1,94 @@
+/** Default storage backend: Drizzle over bun:sqlite. */
+
+import { Database } from 'bun:sqlite';
+import { drizzle, type BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
+import { migrate } from 'drizzle-orm/bun-sqlite/migrator';
+import fs from 'fs';
+import path from 'path';
+import { DB_PATH } from '../config.ts';
+import * as schema from '../db/schema.ts';
+import type { StorageBackend, StorageBackendOptions } from './types.ts';
+
+const MIGRATIONS_FOLDER = path.join(import.meta.dirname, '../db/migrations');
+
+/** Initialize FTS5 virtual table (raw SQL, idempotent). */
+export function initFts5(sqliteDb: Database): void {
+  sqliteDb.exec(`
+    CREATE VIRTUAL TABLE IF NOT EXISTS oracle_fts USING fts5(
+      id UNINDEXED,
+      content,
+      concepts,
+      tokenize='porter unicode61'
+    )
+  `);
+}
+
+/** Initialize supersede_log table for older installs missing migration 0003. */
+export function initSupersedeLog(sqliteDb: Database): void {
+  sqliteDb.exec(`
+    CREATE TABLE IF NOT EXISTS supersede_log (
+      id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+      old_path text NOT NULL,
+      old_id text,
+      old_title text,
+      old_type text,
+      new_path text,
+      new_id text,
+      new_title text,
+      reason text,
+      superseded_at integer NOT NULL,
+      superseded_by text,
+      project text
+    )
+  `);
+
+  sqliteDb.exec(`
+    CREATE INDEX IF NOT EXISTS idx_supersede_old_path ON supersede_log (old_path);
+    CREATE INDEX IF NOT EXISTS idx_supersede_new_path ON supersede_log (new_path);
+    CREATE INDEX IF NOT EXISTS idx_supersede_created ON supersede_log (superseded_at);
+    CREATE INDEX IF NOT EXISTS idx_supersede_project ON supersede_log (project);
+  `);
+}
+
+/** Run all default sqlite initialization. */
+export function initializeDrizzleSqlite(
+  sqliteDb: Database,
+  drizzleDb: BunSQLiteDatabase<typeof schema>,
+): void {
+  sqliteDb.exec('PRAGMA journal_mode = WAL');
+  sqliteDb.exec('PRAGMA busy_timeout = 5000');
+  migrate(drizzleDb, { migrationsFolder: MIGRATIONS_FOLDER });
+  initFts5(sqliteDb);
+  initSupersedeLog(sqliteDb);
+  sqliteDb.exec('INSERT OR IGNORE INTO indexing_status (id, is_indexing) VALUES (1, 0)');
+
+  const migrated = sqliteDb
+    .prepare("SELECT value FROM settings WHERE key = 'migration_lowercase_projects'")
+    .get() as { value: string } | undefined;
+  if (!migrated) {
+    sqliteDb.exec("UPDATE oracle_documents SET project = LOWER(project) WHERE project <> LOWER(project)");
+    sqliteDb.exec("INSERT OR REPLACE INTO settings (key, value, updated_at) VALUES ('migration_lowercase_projects', '1', unixepoch() * 1000)");
+  }
+}
+
+export function createDrizzleSqliteBackend(
+  options: StorageBackendOptions = {},
+): StorageBackend {
+  const resolvedPath = options.dbPath || DB_PATH;
+  const dir = path.dirname(resolvedPath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+
+  const sqlite = options.readonly
+    ? new Database(resolvedPath, { readonly: true })
+    : new Database(resolvedPath);
+  const db = drizzle(sqlite, { schema });
+
+  if (!options.readonly) initializeDrizzleSqlite(sqlite, db);
+
+  return {
+    name: 'drizzle-sqlite',
+    db,
+    sqlite,
+    close: () => sqlite.close(),
+  };
+}

--- a/src/storage/registry.ts
+++ b/src/storage/registry.ts
@@ -1,0 +1,46 @@
+/** Storage backend registry and factory. */
+
+import { loadStorageConfig } from './config.ts';
+import { createDrizzleSqliteBackend } from './drizzle-sqlite.ts';
+import type {
+  StorageBackend,
+  StorageBackendFactory,
+  StorageBackendOptions,
+} from './types.ts';
+
+interface CreateStorageBackendOptions extends StorageBackendOptions {
+  backend?: string;
+}
+
+const defaultFactories = new Map<string, StorageBackendFactory>([
+  ['drizzle-sqlite', createDrizzleSqliteBackend],
+]);
+const factories = new Map(defaultFactories);
+
+export function registerStorageBackend(
+  name: string,
+  factory: StorageBackendFactory,
+): void {
+  factories.set(name, factory);
+}
+
+export function resetStorageBackendsForTests(): void {
+  factories.clear();
+  for (const [name, factory] of defaultFactories) factories.set(name, factory);
+}
+
+export function createStorageBackend(
+  options: CreateStorageBackendOptions = {},
+): StorageBackend {
+  const backend = options.backend
+    || loadStorageConfig({ repoRoot: options.repoRoot, dataDir: options.dataDir }).backend;
+  const factory = factories.get(backend);
+
+  if (!factory) {
+    throw new Error(
+      `Unknown storage backend "${backend}". Register it before selecting it in config.`,
+    );
+  }
+
+  return factory(options);
+}

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -1,0 +1,31 @@
+/**
+ * Minimal storage backend contract for command/runtime code.
+ *
+ * Existing command handlers consume Drizzle and raw SQLite handles via their
+ * context. A swappable backend therefore only needs to provide those handles
+ * plus a lifecycle close hook; command code stays unchanged.
+ */
+
+import type { Database } from 'bun:sqlite';
+import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
+import type * as schema from '../db/schema.ts';
+
+export type StorageBackendName = 'drizzle-sqlite' | (string & {});
+
+export interface StorageBackendOptions {
+  dbPath?: string;
+  readonly?: boolean;
+  repoRoot?: string;
+  dataDir?: string;
+}
+
+export interface StorageBackend {
+  name: StorageBackendName;
+  db: BunSQLiteDatabase<typeof schema>;
+  sqlite: Database;
+  close(): void;
+}
+
+export type StorageBackendFactory = (
+  options: StorageBackendOptions,
+) => StorageBackend;


### PR DESCRIPTION
## Summary
- add minimal storage backend interface + registry with drizzle/sqlite default
- route db/index.ts through the selected backend so command handlers keep using db/sqlite unchanged
- add config resolution for storage.backend and a stub-backend swap test

## Verification
- tsc --noEmit
- bun test src/storage/__tests__/backend.test.ts
- bun run test
- changed files <= 250 lines

Target: alpha