### PR TITLE
Enable vector sidecar proxy and optional embedders

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -59,5 +59,9 @@ if (!fs.existsSync(ORACLE_DATA_DIR)) {
 //                      if empty, the local vector adapter is used (backward compat).
 //   VECTOR_FALLBACK  — what to do when proxy is unreachable. 'fts5' = serve FTS5-only
 //                      results with vectorAvailable: false. (Future: 'cache', 'fail'.)
+//   VECTOR_DB_URL    — target for vector-server.json proxy manifests such as
+//                      /api/vector-db → sidecar vector DB passthrough.
+//   ORACLE_EMBEDDER  — 'none' (default), 'local', or 'remote'. Remote uses
+//                      ORACLE_EMBEDDER_URL and falls back to FTS5 on failure.
 export const VECTOR_URL = process.env.VECTOR_URL || '';
 export const VECTOR_FALLBACK = process.env.VECTOR_FALLBACK || 'fts5';

--- a/src/plugins/proxy-surface.ts
+++ b/src/plugins/proxy-surface.ts
@@ -1,0 +1,72 @@
+import { Elysia } from 'elysia';
+import type { UnifiedProxyManifest } from './unified-manifest.ts';
+
+const DEFAULT_TIMEOUT_MS = Number(process.env.ARRA_PLUGIN_PROXY_TIMEOUT_MS ?? 15_000);
+type ElysiaApp = Elysia<any, any, any, any, any, any, any>;
+
+export function createUnifiedProxyRoute(plugin: string, proxy: UnifiedProxyManifest): ElysiaApp {
+  const app = new Elysia({ name: `unified:${plugin}:proxy:${proxy.path}` });
+  (app as any).route('ALL', `${normalize(proxy.path)}*`, ({ request }: any) =>
+    proxyRequestForManifest(request, [proxy]));
+  return app;
+}
+
+export async function proxyRequestForManifest(
+  request: Request,
+  manifests: UnifiedProxyManifest[],
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<Response | undefined> {
+  const url = new URL(request.url);
+  const manifest = manifests.find((item) => pathMatches(url.pathname, item.path));
+  if (!manifest) return undefined;
+
+  const allowed = manifest.methods?.map((method) => method.toUpperCase());
+  if (allowed?.length && !allowed.includes('ALL') && !allowed.includes(request.method.toUpperCase())) {
+    return json({ ok: false, error: 'method not allowed' }, 405, { allow: allowed.join(', ') });
+  }
+
+  const targetBase = env[manifest.targetEnv]?.replace(/\/+$/, '');
+  if (!targetBase) {
+    return json({ ok: false, error: `${manifest.targetEnv} is unset`, targetEnv: manifest.targetEnv }, 502);
+  }
+
+  const targetPath = manifest.stripPrefix
+    ? (url.pathname.slice(normalize(manifest.path).length) || '/')
+    : url.pathname;
+  return forward(request, `${targetBase}${targetPath.startsWith('/') ? targetPath : `/${targetPath}`}${url.search}`);
+}
+
+function pathMatches(pathname: string, manifestPath: string): boolean {
+  const base = normalize(manifestPath);
+  return pathname === base || pathname.startsWith(`${base}/`);
+}
+
+function normalize(pathname: string): string {
+  const rooted = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  return rooted.length > 1 ? rooted.replace(/\/+$/, '') : rooted;
+}
+
+async function forward(request: Request, target: string): Promise<Response> {
+  try {
+    const headers = new Headers(request.headers);
+    headers.delete('host');
+    const res = await fetch(target, {
+      method: request.method,
+      headers,
+      body: request.method === 'GET' || request.method === 'HEAD' ? undefined : request.body,
+      signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+      duplex: 'half',
+    });
+    const responseHeaders = new Headers(res.headers);
+    responseHeaders.set('x-unified-proxy-target', new URL(target).origin);
+    return new Response(res.body, { status: res.status, statusText: res.statusText, headers: responseHeaders });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const timeout = /timeout|aborted/i.test(message);
+    return json({ ok: false, error: timeout ? 'gateway timeout' : message }, timeout ? 504 : 502);
+  }
+}
+
+function json(body: unknown, status: number, headers: Record<string, string> = {}): Response {
+  return Response.json(body, { status, headers });
+}

--- a/src/plugins/unified-loader.ts
+++ b/src/plugins/unified-loader.ts
@@ -12,9 +12,9 @@ import {
   type UnifiedCliSubcommandManifest,
   type UnifiedMcpToolManifest,
   type UnifiedMenuManifest,
-  type UnifiedProxyManifest,
   type UnifiedServerManifest,
 } from './unified-manifest.ts';
+import { createUnifiedProxyRoute } from './proxy-surface.ts';
 
 const DEFAULT_TIMEOUT_MS = Number(process.env.ARRA_PLUGIN_TIMEOUT_MS ?? 5000);
 const DEFAULT_DIRS = [join(homedir(), '.arra', 'plugins'), join(homedir(), '.oracle', 'plugins')];
@@ -150,39 +150,6 @@ function apiRoute(plugin: LoadedUnifiedPlugin, route: UnifiedApiRouteManifest, t
   return app;
 }
 
-function proxyTarget(proxy: UnifiedProxyManifest, request: Request): string | null {
-  const base = process.env[proxy.targetEnv]?.replace(/\/+$/, '');
-  if (!base) return null;
-  const url = new URL(request.url);
-  const suffix = proxy.stripPrefix
-    ? (url.pathname.slice(proxy.path.length) || '/')
-    : url.pathname;
-  return `${base}${suffix.startsWith('/') ? suffix : `/${suffix}`}${url.search}`;
-}
-
-function proxyRoute(plugin: LoadedUnifiedPlugin, proxy: UnifiedProxyManifest): ElysiaApp {
-  const app = new Elysia({ name: `unified:${plugin.manifest.name}:proxy:${proxy.path}` });
-  for (const method of proxy.methods?.length ? proxy.methods : ['ALL']) {
-    (app as any).route(method.toUpperCase(), proxy.path, async ({ request }: any) => {
-      const target = proxyTarget(proxy, request);
-      if (!target) return Response.json({ ok: false, error: `${proxy.targetEnv} is unset` }, { status: 502 });
-      try {
-        return await fetch(target, {
-          method: request.method,
-          headers: request.headers,
-          body: request.method === 'GET' || request.method === 'HEAD' ? undefined : request.body,
-        });
-      } catch (error) {
-        return Response.json(
-          { ok: false, error: error instanceof Error ? error.message : String(error) },
-          { status: 502 },
-        );
-      }
-    });
-  }
-  return app;
-}
-
 function runtimeFrom(plugins: LoadedUnifiedPlugin[], options: UnifiedLoaderOptions): UnifiedRuntime {
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const routes: ElysiaApp[] = [];
@@ -194,7 +161,7 @@ function runtimeFrom(plugins: LoadedUnifiedPlugin[], options: UnifiedLoaderOptio
   for (const plugin of plugins) {
     for (const tool of plugin.manifest.mcpTools) mcpTools.push({ ...tool, plugin: plugin.manifest.name });
     for (const route of plugin.manifest.apiRoutes) routes.push(apiRoute(plugin, route, timeoutMs));
-    for (const proxy of plugin.manifest.proxy) routes.push(proxyRoute(plugin, proxy));
+    for (const proxy of plugin.manifest.proxy) routes.push(createUnifiedProxyRoute(plugin.manifest.name, proxy));
     if (plugin.manifest.server) servers.push({ ...plugin.manifest.server, plugin: plugin.manifest.name });
     for (const item of plugin.manifest.menu) menu.push({ ...item, plugin: plugin.manifest.name });
     for (const command of plugin.manifest.cliSubcommands) {

--- a/src/routes/vector/index.ts
+++ b/src/routes/vector/index.ts
@@ -22,8 +22,10 @@ import { vectorStatsEndpoint } from './stats.ts';
 import { vectorHealthEndpoint } from './health.ts';
 import { vectorConfigEndpoint } from './config.ts';
 import { vectorIndexerEndpoints } from './indexer.ts';
+import { vectorProxyEndpoint } from './proxy.ts';
 
 export const vectorRoutes = new Elysia({ prefix: '/api' })
+  .use(vectorProxyEndpoint)
   .use(similarEndpoint)
   .use(compareEndpoint)
   .use(mapEndpoint)

--- a/src/routes/vector/proxy.ts
+++ b/src/routes/vector/proxy.ts
@@ -1,0 +1,16 @@
+/** Manifest-driven vector sidecar pass-through. */
+import { Elysia } from 'elysia';
+import { activeVectorProxyManifest, proxyVectorSidecarRequest } from '../../vector/proxy-manifest.ts';
+
+function routePath(publicPath: string): string {
+  const withoutApi = publicPath.startsWith('/api/') ? publicPath.slice('/api'.length) : publicPath;
+  const rooted = withoutApi.startsWith('/') ? withoutApi : `/${withoutApi}`;
+  return `${rooted.replace(/\/+$/, '')}*`;
+}
+
+export const vectorProxyEndpoint = new Elysia({ name: 'vector-proxy-manifest' });
+
+for (const manifest of activeVectorProxyManifest()) {
+  (vectorProxyEndpoint as any).route('ALL', routePath(manifest.path), ({ request }: any) =>
+    proxyVectorSidecarRequest(request, [manifest]));
+}

--- a/src/vector/config.ts
+++ b/src/vector/config.ts
@@ -12,7 +12,8 @@ import fs from 'fs';
 import path from 'path';
 import { ORACLE_DATA_DIR, LANCEDB_DIR } from '../config.ts';
 import { COLLECTION_NAME } from '../const.ts';
-import type { VectorDBType } from './types.ts';
+import type { UnifiedProxyManifest } from '../plugins/unified-manifest.ts';
+import type { EmbedderConfig, VectorDBType } from './types.ts';
 
 export const VECTOR_CONFIG_FILE = 'vector-server.json';
 
@@ -31,8 +32,13 @@ export interface VectorServerConfig {
   port: number;
   collections: Record<string, VectorCollectionConfig>;
   dataPath: string;
+  /** Default is none: semantic failures fall back to SQLite FTS5. */
+  embedder?: EmbedderConfig;
   embeddingEndpoint: string;
+  proxy?: VectorProxyManifest[];
 }
+
+export type VectorProxyManifest = UnifiedProxyManifest;
 
 /** Absolute path to vector-server.json inside ORACLE_DATA_DIR. */
 export function configPath(): string {
@@ -52,26 +58,36 @@ export function generateDefaultConfig(): VectorServerConfig {
       'bge-m3': {
         collection: 'oracle_knowledge_bge_m3',
         model: 'bge-m3',
-        provider: 'ollama',
+        provider: 'none',
         adapter: 'lancedb',
         primary: true,
       },
       nomic: {
         collection: COLLECTION_NAME,
         model: 'nomic-embed-text',
-        provider: 'ollama',
+        provider: 'none',
         adapter: 'lancedb',
       },
       qwen3: {
         collection: 'oracle_knowledge_qwen3',
         model: 'qwen3-embedding',
-        provider: 'ollama',
+        provider: 'none',
         adapter: 'lancedb',
       },
     },
     dataPath: LANCEDB_DIR,
-    embeddingEndpoint: 'http://localhost:11434',
+    embedder: { backend: 'none' },
+    embeddingEndpoint: '',
+    proxy: defaultVectorProxyManifest(),
   };
+}
+
+export function defaultVectorProxyManifest(): VectorProxyManifest[] {
+  return [{
+    path: '/api/vector-db',
+    targetEnv: 'VECTOR_DB_URL',
+    stripPrefix: true,
+  }];
 }
 
 /**
@@ -100,20 +116,42 @@ export function writeVectorConfig(config: VectorServerConfig): string {
   return fp;
 }
 
+function embedderFor(config: VectorServerConfig, col: VectorCollectionConfig): EmbedderConfig | undefined {
+  if (config.embedder) return { ...config.embedder, model: config.embedder.model ?? col.model };
+  const provider = col.provider.toLowerCase();
+  if (provider === 'ollama' || provider === 'local') return { backend: 'local', model: col.model };
+  if (provider === 'remote') return { backend: 'remote', model: col.model };
+  if (provider === 'none') return { backend: 'none' };
+  return undefined;
+}
+
 /**
  * Derive the getEmbeddingModels()-compatible registry from a VectorServerConfig.
  * Used by factory.ts to let the config file override hardcoded models.
  */
 export function configToModels(
   config: VectorServerConfig,
-): Record<string, { collection: string; model: string; adapter?: VectorDBType; dataPath?: string }> {
-  const out: Record<string, { collection: string; model: string; adapter?: VectorDBType; dataPath?: string }> = {};
+): Record<string, {
+  collection: string;
+  model: string;
+  adapter?: VectorDBType;
+  dataPath?: string;
+  embedder?: EmbedderConfig;
+}> {
+  const out: Record<string, {
+    collection: string;
+    model: string;
+    adapter?: VectorDBType;
+    dataPath?: string;
+    embedder?: EmbedderConfig;
+  }> = {};
   for (const [key, col] of Object.entries(config.collections)) {
     out[key] = {
       collection: col.collection,
       model: col.model,
       adapter: col.adapter || 'lancedb',
       dataPath: config.dataPath || undefined,
+      embedder: embedderFor(config, col),
     };
   }
   return out;

--- a/src/vector/embedder-config.ts
+++ b/src/vector/embedder-config.ts
@@ -1,0 +1,38 @@
+/** Env/config resolver for the optional embedder capability. */
+import type { EmbeddingProviderType } from './types.ts';
+
+const VALID = new Set<EmbeddingProviderType>([
+  'none',
+  'local',
+  'remote',
+  'chromadb-internal',
+  'ollama',
+  'openai',
+  'cloudflare-ai',
+]);
+
+export function resolveEmbeddingProviderType(
+  configured?: EmbeddingProviderType,
+): EmbeddingProviderType {
+  if (configured) return configured;
+
+  const legacy = process.env.ORACLE_EMBEDDING_PROVIDER as EmbeddingProviderType | undefined;
+  if (legacy) return normalizeProvider(legacy);
+
+  return normalizeProvider(process.env.ORACLE_EMBEDDER || process.env.ORACLE_EMBEDDER_BACKEND);
+}
+
+export function resolveEmbeddingModel(configured?: string): string | undefined {
+  return configured || process.env.ORACLE_EMBEDDING_MODEL;
+}
+
+function normalizeProvider(raw?: string): EmbeddingProviderType {
+  const value = (raw || 'none').trim().toLowerCase();
+  if (value === 'disabled' || value === 'off' || value === 'zero') return 'none';
+  if (value === 'http' || value === 'external') return 'remote';
+  if (value === 'ollama-local') return 'local';
+  if (VALID.has(value as EmbeddingProviderType)) return value as EmbeddingProviderType;
+
+  console.warn(`[Embedder] Unknown provider '${raw}', falling back to none/FTS5.`);
+  return 'none';
+}

--- a/src/vector/embedding-backends.ts
+++ b/src/vector/embedding-backends.ts
@@ -1,0 +1,101 @@
+/** Optional embedding backends: disabled-by-default + remote HTTP. */
+import type { EmbedType, EmbeddingProvider } from './types.ts';
+
+export class EmbeddingUnavailableError extends Error {
+  readonly fallback = 'fts5';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'EmbeddingUnavailableError';
+  }
+}
+
+export class NoneEmbeddings implements EmbeddingProvider {
+  readonly name = 'none';
+  readonly dimensions = 1;
+
+  async embed(_texts: string[], _type?: EmbedType): Promise<number[][]> {
+    throw new EmbeddingUnavailableError(
+      'Embedding backend disabled (ORACLE_EMBEDDER=none); use FTS5 fallback.',
+    );
+  }
+}
+
+export interface RemoteHttpEmbeddingOptions {
+  url?: string;
+  model?: string;
+  dimensions?: number;
+  timeoutMs?: number;
+}
+
+export class RemoteHttpEmbeddings implements EmbeddingProvider {
+  readonly name = 'remote';
+  dimensions: number;
+  private readonly url: string;
+  private readonly model?: string;
+  private readonly timeoutMs: number;
+
+  constructor(options: RemoteHttpEmbeddingOptions = {}) {
+    this.url = options.url
+      || process.env.ORACLE_EMBEDDER_URL
+      || process.env.ORACLE_REMOTE_EMBEDDING_URL
+      || '';
+    this.model = options.model || process.env.ORACLE_EMBEDDING_MODEL;
+    this.dimensions = options.dimensions
+      || Number(process.env.ORACLE_EMBEDDING_DIMENSIONS || 768);
+    this.timeoutMs = options.timeoutMs
+      || Number(process.env.ORACLE_EMBEDDER_TIMEOUT_MS || 15_000);
+  }
+
+  async embed(texts: string[], type?: EmbedType): Promise<number[][]> {
+    if (!this.url) {
+      throw new EmbeddingUnavailableError('Remote embedder selected but ORACLE_EMBEDDER_URL is unset.');
+    }
+
+    try {
+      const res = await fetch(this.url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', accept: 'application/json' },
+        body: JSON.stringify({ texts, input: texts, type, model: this.model }),
+        signal: AbortSignal.timeout(this.timeoutMs),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+
+      const vectors = parseRemoteEmbeddingResponse(await res.json(), texts.length);
+      if (vectors[0]?.length) this.dimensions = vectors[0].length;
+      return vectors;
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      throw new EmbeddingUnavailableError(`Remote embedder unavailable: ${msg}. Use FTS5 fallback.`);
+    }
+  }
+}
+
+export function parseRemoteEmbeddingResponse(payload: unknown, expected: number): number[][] {
+  const value = payload as {
+    embeddings?: unknown;
+    embedding?: unknown;
+    data?: Array<{ embedding?: unknown; index?: number }>;
+  };
+
+  let vectors: unknown;
+  if (Array.isArray(value.embeddings)) vectors = value.embeddings;
+  else if (Array.isArray(value.data)) {
+    vectors = [...value.data]
+      .sort((a, b) => (a.index ?? 0) - (b.index ?? 0))
+      .map((item) => item.embedding);
+  } else if (Array.isArray(value.embedding)) vectors = [value.embedding];
+
+  if (!Array.isArray(vectors)) throw new Error('missing embeddings array');
+  const normalized = vectors.map((vector) => {
+    if (!Array.isArray(vector) || !vector.every((n) => typeof n === 'number')) {
+      throw new Error('embedding must be number[]');
+    }
+    return vector as number[];
+  });
+
+  if (normalized.length !== expected) {
+    throw new Error(`embedding count ${normalized.length} does not match input count ${expected}`);
+  }
+  return normalized;
+}

--- a/src/vector/embeddings.ts
+++ b/src/vector/embeddings.ts
@@ -6,6 +6,7 @@
  */
 
 import type { EmbeddingProvider, EmbeddingProviderType, EmbedType } from './types.ts';
+import { NoneEmbeddings, RemoteHttpEmbeddings } from './embedding-backends.ts';
 
 /**
  * Placeholder for ChromaDB's internal embeddings.
@@ -158,12 +159,18 @@ export class OpenAIEmbeddings implements EmbeddingProvider {
  * Create embedding provider from type string
  */
 export function createEmbeddingProvider(
-  type: EmbeddingProviderType = 'chromadb-internal',
-  model?: string
+  type: EmbeddingProviderType = 'none',
+  model?: string,
+  options: { url?: string; dimensions?: number } = {},
 ): EmbeddingProvider {
   switch (type) {
+    case 'none':
+      return new NoneEmbeddings();
+    case 'local':
     case 'ollama':
       return new OllamaEmbeddings({ model });
+    case 'remote':
+      return new RemoteHttpEmbeddings({ model, url: options.url, dimensions: options.dimensions });
     case 'openai':
       return new OpenAIEmbeddings({ model });
     case 'cloudflare-ai': {

--- a/src/vector/factory.ts
+++ b/src/vector/factory.ts
@@ -8,13 +8,19 @@
 import path from 'path';
 import { VECTORS_DB_PATH, LANCEDB_DIR, CHROMADB_DIR } from '../config.ts';
 import { COLLECTION_NAME } from '../const.ts';
-import type { VectorStoreAdapter, VectorDBType, EmbeddingProviderType } from './types.ts';
+import type {
+  EmbedderConfig,
+  VectorStoreAdapter,
+  VectorDBType,
+  EmbeddingProviderType,
+} from './types.ts';
 import { ChromaMcpAdapter } from './adapters/chroma-mcp.ts';
 import { SqliteVecAdapter } from './adapters/sqlite-vec.ts';
 import { LanceDBAdapter } from './adapters/lancedb.ts';
 import { QdrantAdapter } from './adapters/qdrant.ts';
 import { CloudflareVectorizeAdapter, CloudflareAIEmbeddings } from './adapters/cloudflare-vectorize.ts';
 import { createEmbeddingProvider } from './embeddings.ts';
+import { resolveEmbeddingModel, resolveEmbeddingProviderType } from './embedder-config.ts';
 import { loadVectorConfig, configToModels } from './config.ts';
 
 export interface VectorStoreConfig {
@@ -25,6 +31,8 @@ export interface VectorStoreConfig {
   pythonVersion?: string;
   embeddingProvider?: EmbeddingProviderType;
   embeddingModel?: string;
+  embeddingUrl?: string;
+  embeddingDimensions?: number;
   /** Qdrant URL (default: http://localhost:6333) */
   qdrantUrl?: string;
   /** Qdrant API key */
@@ -40,6 +48,7 @@ export interface EmbeddingModelConfig {
   model: string;
   adapter?: VectorDBType;
   dataPath?: string;
+  embedder?: EmbedderConfig;
 }
 
 /**
@@ -47,7 +56,9 @@ export interface EmbeddingModelConfig {
  *
  * Env vars:
  *   ORACLE_VECTOR_DB          = 'chroma' | 'sqlite-vec' | 'lancedb' | 'qdrant' | 'cloudflare-vectorize'
- *   ORACLE_EMBEDDING_PROVIDER = 'chromadb-internal' | 'ollama' | 'openai' | 'cloudflare-ai'
+ *   ORACLE_EMBEDDER           = 'none' | 'local' | 'remote' (default: none/FTS5)
+ *   ORACLE_EMBEDDER_URL       = remote HTTP embedding endpoint
+ *   ORACLE_EMBEDDING_PROVIDER = legacy provider override
  *   ORACLE_EMBEDDING_MODEL    = model name override
  *   ORACLE_VECTOR_DB_PATH     = sqlite-vec / lancedb path
  *   CLOUDFLARE_ACCOUNT_ID     = CF account (for cloudflare-vectorize)
@@ -66,14 +77,13 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
         || process.env.ORACLE_VECTOR_DB_PATH
         || VECTORS_DB_PATH;
 
-      const embeddingType = config.embeddingProvider
-        || (process.env.ORACLE_EMBEDDING_PROVIDER as EmbeddingProviderType)
-        || 'ollama';
+      const embeddingType = resolveEmbeddingProviderType(config.embeddingProvider);
+      const embeddingModel = resolveEmbeddingModel(config.embeddingModel);
 
-      const embeddingModel = config.embeddingModel
-        || process.env.ORACLE_EMBEDDING_MODEL;
-
-      const embedder = createEmbeddingProvider(embeddingType, embeddingModel);
+      const embedder = createEmbeddingProvider(embeddingType, embeddingModel, {
+        url: config.embeddingUrl,
+        dimensions: config.embeddingDimensions,
+      });
       return new SqliteVecAdapter(collectionName, dbPath, embedder);
     }
 
@@ -82,26 +92,24 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
         || process.env.ORACLE_VECTOR_DB_PATH
         || LANCEDB_DIR;
 
-      const embeddingType = config.embeddingProvider
-        || (process.env.ORACLE_EMBEDDING_PROVIDER as EmbeddingProviderType)
-        || 'ollama';
+      const embeddingType = resolveEmbeddingProviderType(config.embeddingProvider);
+      const embeddingModel = resolveEmbeddingModel(config.embeddingModel);
 
-      const embeddingModel = config.embeddingModel
-        || process.env.ORACLE_EMBEDDING_MODEL;
-
-      const embedder = createEmbeddingProvider(embeddingType, embeddingModel);
+      const embedder = createEmbeddingProvider(embeddingType, embeddingModel, {
+        url: config.embeddingUrl,
+        dimensions: config.embeddingDimensions,
+      });
       return new LanceDBAdapter(collectionName, dbPath, embedder);
     }
 
     case 'qdrant': {
-      const embeddingType = config.embeddingProvider
-        || (process.env.ORACLE_EMBEDDING_PROVIDER as EmbeddingProviderType)
-        || 'ollama';
+      const embeddingType = resolveEmbeddingProviderType(config.embeddingProvider);
+      const embeddingModel = resolveEmbeddingModel(config.embeddingModel);
 
-      const embeddingModel = config.embeddingModel
-        || process.env.ORACLE_EMBEDDING_MODEL;
-
-      const embedder = createEmbeddingProvider(embeddingType, embeddingModel);
+      const embedder = createEmbeddingProvider(embeddingType, embeddingModel, {
+        url: config.embeddingUrl,
+        dimensions: config.embeddingDimensions,
+      });
       return new QdrantAdapter(collectionName, embedder, {
         url: config.qdrantUrl || process.env.QDRANT_URL,
         apiKey: config.qdrantApiKey || process.env.QDRANT_API_KEY,
@@ -183,7 +191,8 @@ const modelStoreCache = new Map<string, VectorStoreAdapter>();
 
 /**
  * Get a vector store for a specific embedding model.
- * Uses LanceDB + Ollama. Caches instances by model key.
+ * Uses the configured embedder backend. Default is none, so vector calls fail
+ * fast and callers keep serving FTS5-only results until local/remote is set.
  */
 const connectPromises = new Map<string, Promise<void>>();
 
@@ -191,8 +200,10 @@ export function createVectorStoreForModel(preset: EmbeddingModelConfig): VectorS
   return createVectorStore({
     type: preset.adapter || 'lancedb',
     collectionName: preset.collection,
-    embeddingProvider: 'ollama',
-    embeddingModel: preset.model,
+    embeddingProvider: preset.embedder?.backend ?? resolveEmbeddingProviderType(),
+    embeddingModel: preset.embedder?.model || preset.model,
+    embeddingUrl: preset.embedder?.url,
+    embeddingDimensions: preset.embedder?.dimensions,
     ...(preset.dataPath && { dataPath: preset.dataPath }),
   });
 }

--- a/src/vector/proxy-manifest.ts
+++ b/src/vector/proxy-manifest.ts
@@ -1,0 +1,19 @@
+/** Vector sidecar passthrough backed by the unified proxy manifest shape. */
+import {
+  defaultVectorProxyManifest,
+  loadVectorConfig,
+  type VectorProxyManifest,
+} from './config.ts';
+import { proxyRequestForManifest } from '../plugins/proxy-surface.ts';
+
+export function activeVectorProxyManifest(): VectorProxyManifest[] {
+  return loadVectorConfig()?.proxy ?? defaultVectorProxyManifest();
+}
+
+export function proxyVectorSidecarRequest(
+  request: Request,
+  manifests: VectorProxyManifest[] = activeVectorProxyManifest(),
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<Response | undefined> {
+  return proxyRequestForManifest(request, manifests, env);
+}

--- a/src/vector/types.ts
+++ b/src/vector/types.ts
@@ -60,5 +60,21 @@ export interface EmbeddingProvider {
   embed(texts: string[], type?: EmbedType): Promise<number[][]>;
 }
 
+export type EmbedderBackend = 'none' | 'local' | 'remote';
+
+export interface EmbedderConfig {
+  backend: EmbedderBackend;
+  url?: string;
+  model?: string;
+  dimensions?: number;
+}
+
 export type VectorDBType = 'chroma' | 'sqlite-vec' | 'lancedb' | 'qdrant' | 'cloudflare-vectorize';
-export type EmbeddingProviderType = 'chromadb-internal' | 'ollama' | 'openai' | 'cloudflare-ai';
+export type EmbeddingProviderType =
+  | 'none'
+  | 'local'
+  | 'remote'
+  | 'chromadb-internal'
+  | 'ollama'
+  | 'openai'
+  | 'cloudflare-ai';

--- a/tests/http/vector/proxy-embedder.test.ts
+++ b/tests/http/vector/proxy-embedder.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Elysia } from 'elysia';
+import { createEmbeddingProvider } from '../../../src/vector/embeddings.ts';
+import { loadUnifiedPlugins } from '../../../src/plugins/unified-loader.ts';
+import { proxyVectorSidecarRequest } from '../../../src/vector/proxy-manifest.ts';
+import type { VectorProxyManifest } from '../../../src/vector/config.ts';
+
+const manifest: VectorProxyManifest = {
+  path: '/api/vector-db',
+  targetEnv: 'TEST_VECTOR_DB_URL',
+  stripPrefix: true,
+  methods: ['GET', 'POST'],
+};
+
+const servers: ReturnType<typeof Bun.serve>[] = [];
+const tmpDirs: string[] = [];
+
+function startServer(handler: (req: Request) => Response | Promise<Response>): string {
+  const server = Bun.serve({ port: 0, fetch: handler });
+  servers.push(server);
+  return `http://127.0.0.1:${server.port}`;
+}
+
+function proxyApp(target?: string, manifests = [manifest]) {
+  const env: NodeJS.ProcessEnv = target ? { TEST_VECTOR_DB_URL: target } : {};
+  return new Elysia()
+    .onRequest(({ request }) => proxyVectorSidecarRequest(request, manifests, env))
+    .get('/api/health', () => ({ ok: true }));
+}
+
+async function json(res: Response) {
+  return JSON.parse(await res.text());
+}
+
+afterEach(() => {
+  while (servers.length) servers.pop()!.stop();
+  while (tmpDirs.length) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+  delete process.env.TEST_VECTOR_DB_URL;
+});
+
+describe('vector proxy manifest', () => {
+  test('passes through to sidecar and strips the public prefix', async () => {
+    const target = startServer(async (req) => Response.json({
+      method: req.method,
+      path: new URL(req.url).pathname + new URL(req.url).search,
+      body: await req.text(),
+    }));
+    const app = proxyApp(target);
+
+    const res = await app.handle(new Request('http://local/api/vector-db/collections?q=one', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ok: true }),
+    }));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-unified-proxy-target')).toBe(new URL(target).origin);
+    expect(await json(res)).toEqual({
+      method: 'POST',
+      path: '/collections?q=one',
+      body: JSON.stringify({ ok: true }),
+    });
+  });
+
+  test('enforces manifest methods and reports missing target env', async () => {
+    const app = proxyApp(undefined, [{ ...manifest, methods: ['GET'] }]);
+
+    const blocked = await app.handle(new Request('http://local/api/vector-db/items', {
+      method: 'POST',
+    }));
+    expect(blocked.status).toBe(405);
+    expect(blocked.headers.get('allow')).toBe('GET');
+
+    const missing = await app.handle(new Request('http://local/api/vector-db/items'));
+    expect(missing.status).toBe(502);
+    expect((await json(missing)).targetEnv).toBe('TEST_VECTOR_DB_URL');
+  });
+
+  test('unified loader registers proxy manifest for nested sidecar paths', async () => {
+    const target = startServer((req) => Response.json({ path: new URL(req.url).pathname }));
+    process.env.TEST_VECTOR_DB_URL = target;
+    const base = mkdtempSync(join(tmpdir(), 'arra-vector-plugin-'));
+    tmpDirs.push(base);
+    const dir = join(base, 'vector-proxy-plugin');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'index.ts'), 'export function noop() { return { ok: true }; }\n');
+    writeFileSync(join(dir, 'plugin.json'), JSON.stringify({
+      name: 'vector-proxy-plugin',
+      version: '1.0.0',
+      entry: './index.ts',
+      proxy: [{ path: '/api/plugin-vector', targetEnv: 'TEST_VECTOR_DB_URL', stripPrefix: true }],
+    }));
+
+    const runtime = await loadUnifiedPlugins({ dirs: [base] });
+    const app = new Elysia();
+    for (const route of runtime.routes) app.use(route as any);
+    const res = await app.handle(new Request('http://local/api/plugin-vector/collections'));
+
+    expect(runtime.routes).toHaveLength(1);
+    expect(res.status).toBe(200);
+    expect(await json(res)).toEqual({ path: '/collections' });
+  });
+
+  test('non-matching paths fall through to local Elysia routes', async () => {
+    const app = proxyApp('http://127.0.0.1:1');
+    const res = await app.handle(new Request('http://local/api/health'));
+
+    expect(res.status).toBe(200);
+    expect(await json(res)).toEqual({ ok: true });
+  });
+});
+
+describe('embedder capability', () => {
+  test('default provider is none and fails fast for FTS fallback', async () => {
+    const provider = createEmbeddingProvider();
+
+    expect(provider.name).toBe('none');
+    await expect(provider.embed(['hello'])).rejects.toThrow(/FTS5 fallback/);
+  });
+
+  test('local backend aliases to Ollama without network work at construction', () => {
+    const provider = createEmbeddingProvider('local', 'nomic-embed-text');
+
+    expect(provider.name).toBe('ollama');
+    expect(provider.dimensions).toBe(768);
+  });
+
+  test('remote backend posts texts and accepts embeddings arrays', async () => {
+    let payload: any = null;
+    const target = startServer(async (req) => {
+      payload = await req.json();
+      return Response.json({ embeddings: [[1, 2], [3, 4]] });
+    });
+    const provider = createEmbeddingProvider('remote', 'bge-m3', { url: target, dimensions: 2 });
+
+    const vectors = await provider.embed(['alpha', 'beta'], 'query');
+
+    expect(vectors).toEqual([[1, 2], [3, 4]]);
+    expect(payload).toMatchObject({ texts: ['alpha', 'beta'], type: 'query', model: 'bge-m3' });
+    expect(provider.dimensions).toBe(2);
+  });
+
+  test('remote backend reports graceful FTS fallback on HTTP failure', async () => {
+    const target = startServer(() => new Response('down', { status: 503 }));
+    const provider = createEmbeddingProvider('remote', 'bge-m3', { url: target });
+
+    await expect(provider.embed(['alpha'])).rejects.toThrow(/Remote embedder unavailable.*FTS5 fallback/);
+  });
+});


### PR DESCRIPTION
## Summary\n- adds unified proxy surface routing for nested sidecar paths, reused by vector proxy manifests\n- adds none/local/remote embedder backends with none as default FTS-first path\n- adds scoped vector HTTP tests for proxy passthrough, unified loader registration, and embedder fallback\n\n## Verification\n- tsc --noEmit\n- bun test tests/http/vector/\n- bun test src/plugins/__tests__/unified-loader.test.ts src/plugins/__tests__/unified-manifest.test.ts src/plugins/__tests__/unified-example.test.ts\n\n## Notes\n- Live Colab/cafe remote embedder and real sidecar vector DB were not exercised locally.