### PR TITLE
Add unified plugin web-server surface

### DIFF
--- a/docs/UNIFIED-PLUGIN.md
+++ b/docs/UNIFIED-PLUGIN.md
@@ -59,7 +59,9 @@ loads normalized manifests at boot, then registers whichever surfaces are presen
 
 - `apiRoutes[]` become Elysia routes that call the named handler from `entry`.
 - `proxy[]` become best-effort Elysia proxy routes using `targetEnv`.
-- `server` entries are autostarted unless `autostart: false`.
+- `server` entries are autostarted unless `autostart: false`, get `PORT` /
+  `ARRA_PLUGIN_PORT`, must pass `healthPath` (default `/health`), and are proxied
+  behind `/api/plugins/<name>/server/*`.
 - `menu[]` entries are seeded into `menu_items` as plugin-owned rows.
 - `mcpTools[]` and `cliSubcommands[]` are collected as registry metadata for the
   MCP/CLI loaders to consume in follow-up slices.
@@ -135,6 +137,6 @@ because no static tool names change.
 ## Non-goals for this PR
 
 - No dynamic MCP execution yet.
-- No long-lived health supervisor for plugin-owned servers yet.
+- No restart/backoff supervisor for plugin-owned servers yet.
 - No npm package extraction.
 - No subdomain deploy work.

--- a/src/plugins/__tests__/unified-loader.test.ts
+++ b/src/plugins/__tests__/unified-loader.test.ts
@@ -61,7 +61,7 @@ describe('unified plugin loader', () => {
     expect(runtime.menu.map((item) => item.path)).toEqual(['/surface-pack']);
     expect(runtime.cliSubcommands.map((cmd) => cmd.command)).toEqual(['surface-pack']);
     expect(runtime.servers.map((server) => server.plugin)).toEqual(['surface-pack']);
-    expect(runtime.routes).toHaveLength(2);
+    expect(runtime.routes).toHaveLength(3);
 
     const app = new Elysia();
     for (const route of runtime.routes) app.use(route as any);

--- a/src/plugins/unified-loader.ts
+++ b/src/plugins/unified-loader.ts
@@ -12,9 +12,9 @@ import {
   type UnifiedCliSubcommandManifest,
   type UnifiedMcpToolManifest,
   type UnifiedMenuManifest,
-  type UnifiedServerManifest,
 } from './unified-manifest.ts';
 import { createUnifiedProxyRoute } from './proxy-surface.ts';
+import { unifiedPluginServerRoutes, type UnifiedPluginServer } from './unified-server.ts';
 
 const DEFAULT_TIMEOUT_MS = Number(process.env.ARRA_PLUGIN_TIMEOUT_MS ?? 5000);
 const DEFAULT_DIRS = [join(homedir(), '.arra', 'plugins'), join(homedir(), '.oracle', 'plugins')];
@@ -39,7 +39,7 @@ export interface UnifiedRuntime {
   mcpTools: Array<UnifiedMcpToolManifest & { plugin: string }>;
   menu: Array<UnifiedMenuManifest & { plugin: string }>;
   cliSubcommands: Array<UnifiedCliSubcommandManifest & { plugin: string }>;
-  servers: Array<UnifiedServerManifest & { plugin: string }>;
+  servers: UnifiedPluginServer[];
   callMcpTool: (name: string, args?: unknown) => Promise<unknown>;
   stop: () => Promise<void>;
 }
@@ -167,12 +167,20 @@ function runtimeFrom(plugins: LoadedUnifiedPlugin[], options: UnifiedLoaderOptio
     }
     for (const route of plugin.manifest.apiRoutes) routes.push(apiRoute(plugin, route, timeoutMs));
     for (const proxy of plugin.manifest.proxy) routes.push(createUnifiedProxyRoute(plugin.manifest.name, proxy));
-    if (plugin.manifest.server) servers.push({ ...plugin.manifest.server, plugin: plugin.manifest.name });
+    if (plugin.manifest.server) {
+      servers.push({
+        ...plugin.manifest.server,
+        plugin: plugin.manifest.name,
+        dir: plugin.dir,
+        routePrefix: `/api/plugins/${plugin.manifest.name}/server`,
+      });
+    }
     for (const item of plugin.manifest.menu) menu.push({ ...item, plugin: plugin.manifest.name });
     for (const command of plugin.manifest.cliSubcommands) {
       cliSubcommands.push({ ...command, plugin: plugin.manifest.name });
     }
   }
+  if (servers.length) routes.push(unifiedPluginServerRoutes(servers));
 
   const callMcpTool = async (name: string, args?: unknown): Promise<unknown> => {
     const hit = mcpInvokers.get(name);

--- a/src/plugins/unified-manifest.ts
+++ b/src/plugins/unified-manifest.ts
@@ -42,6 +42,8 @@ export interface UnifiedServerManifest {
   autostart?: boolean;
 }
 
+export type PublicUnifiedServerManifest = Omit<UnifiedServerManifest, 'env'>;
+
 export interface UnifiedMenuManifest {
   label: string;
   path: string;
@@ -114,6 +116,20 @@ function assertMethods(methods: unknown, field: string): void {
   }
 }
 
+function assertStringArray(value: unknown, field: string): void {
+  if (value === undefined) return;
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw new Error(`${field} must be an array of strings`);
+  }
+}
+
+function assertStringRecord(value: unknown, field: string): void {
+  if (value === undefined) return;
+  if (!isRecord(value) || Object.values(value).some((item) => typeof item !== 'string')) {
+    throw new Error(`${field} must be a string map`);
+  }
+}
+
 export function normalizeUnifiedPluginManifest(raw: unknown): NormalizedUnifiedPluginManifest {
   if (!isRecord(raw)) throw new Error('manifest must be a JSON object');
   const manifest = raw as unknown as UnifiedPluginManifest;
@@ -151,6 +167,17 @@ export function normalizeUnifiedPluginManifest(raw: unknown): NormalizedUnifiedP
     if (!item.targetEnv || typeof item.targetEnv !== 'string') throw new Error('proxy.targetEnv must be a string');
     assertMethods(item.methods, 'proxy.methods');
   }
+  if (manifest.server) {
+    if (!manifest.server.command || typeof manifest.server.command !== 'string') {
+      throw new Error('server.command must be a string');
+    }
+    assertStringArray(manifest.server.args, 'server.args');
+    assertStringRecord(manifest.server.env, 'server.env');
+    if (manifest.server.healthPath !== undefined) assertAbsolutePath(manifest.server.healthPath, 'server.healthPath');
+    if (manifest.server.autostart !== undefined && typeof manifest.server.autostart !== 'boolean') {
+      throw new Error('server.autostart must be a boolean');
+    }
+  }
   for (const item of menu) {
     assertAbsolutePath(item.path, 'menu.path');
     if (!item.label || typeof item.label !== 'string') throw new Error('menu.label must be a string');
@@ -184,4 +211,16 @@ export function manifestSurfaces(manifest: NormalizedUnifiedPluginManifest): Uni
 
 export function mcpToolNamesForToggle(manifest: NormalizedUnifiedPluginManifest): string[] {
   return manifest.mcpTools.map((tool) => tool.name);
+}
+
+export function publicUnifiedServerManifest(
+  server?: UnifiedServerManifest,
+): PublicUnifiedServerManifest | undefined {
+  if (!server) return undefined;
+  return {
+    command: server.command,
+    args: server.args,
+    healthPath: server.healthPath,
+    autostart: server.autostart,
+  };
 }

--- a/src/plugins/unified-server.ts
+++ b/src/plugins/unified-server.ts
@@ -1,46 +1,236 @@
-import type { UnifiedRuntime } from './unified-loader.ts';
+import { Elysia } from 'elysia';
+import type { UnifiedServerManifest } from './unified-manifest.ts';
 
 type Spawned = ReturnType<typeof Bun.spawn>;
+
+export interface UnifiedPluginServer extends UnifiedServerManifest {
+  plugin: string;
+  dir: string;
+  routePrefix: string;
+}
+
+interface RunningServer {
+  config: UnifiedPluginServer;
+  process: Spawned;
+  baseUrl: string;
+  port: number;
+  startedAt: string;
+}
+
+interface HealthResult {
+  healthy: boolean;
+  healthPath: string;
+  status?: number;
+  error?: string;
+}
+
+interface ServerFailure {
+  ok: false;
+  status: number;
+  error: string;
+  plugin: string;
+}
+
+interface ServerSuccess {
+  ok: true;
+  running: RunningServer;
+  health: HealthResult;
+}
 
 export interface UnifiedServerRuntime {
   started: number;
   stop: () => Promise<void>;
 }
 
-function commandFor(server: UnifiedRuntime['servers'][number]): string[] | null {
-  if (!server.command || server.autostart === false) return null;
-  return [server.command, ...(server.args ?? [])];
+const startTimeoutMs = () => Number(process.env.ARRA_PLUGIN_START_TIMEOUT_MS ?? 4000);
+const healthTimeoutMs = () => Number(process.env.ARRA_PLUGIN_HEALTH_TIMEOUT_MS ?? 500);
+const running = new Map<string, RunningServer>();
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const healthPathFor = (server: UnifiedPluginServer) => server.healthPath ?? '/health';
+const shouldAutostart = (server: UnifiedPluginServer) => server.autostart !== false;
+
+function failure(plugin: string, status: number, error: string): ServerFailure {
+  return { ok: false, plugin, status, error };
 }
 
-export function startUnifiedPluginServers(
-  servers: UnifiedRuntime['servers'],
-  warn: (message: string) => void = console.warn,
-): UnifiedServerRuntime {
-  const children: Spawned[] = [];
-  for (const server of servers) {
-    const cmd = commandFor(server);
-    if (!cmd) continue;
-    try {
-      children.push(Bun.spawn(cmd, {
-        env: { ...process.env, ...(server.env ?? {}) },
-        stdout: 'inherit',
-        stderr: 'inherit',
-      }));
-    } catch (error) {
-      warn(`[unified-plugin] server ${server.plugin} skipped: ${error instanceof Error ? error.message : String(error)}`);
-    }
+function serverMap(servers: UnifiedPluginServer[]) {
+  return new Map(servers.map((server) => [server.plugin, server]));
+}
+
+function childEnv(server: UnifiedPluginServer, port: number) {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (typeof value === 'string') env[key] = value;
   }
   return {
-    started: children.length,
-    stop: async () => {
-      for (const child of [...children].reverse()) {
-        try {
-          child.kill();
-          await child.exited;
-        } catch {
-          // best effort on shutdown
-        }
-      }
-    },
+    ...env,
+    ...(server.env ?? {}),
+    ARRA_PLUGIN_NAME: server.plugin,
+    ARRA_PLUGIN_PORT: String(port),
+    PORT: String(port),
   };
+}
+
+async function allocatePort(): Promise<number> {
+  const reservation = Bun.serve({
+    hostname: '127.0.0.1',
+    port: 0,
+    fetch: () => new Response('reserved'),
+  });
+  const { port } = reservation;
+  await reservation.stop(true);
+  if (!port) throw new Error('failed to allocate plugin server port');
+  return port;
+}
+
+async function health(r: RunningServer): Promise<HealthResult> {
+  const healthPath = healthPathFor(r.config);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), healthTimeoutMs());
+  try {
+    const res = await fetch(new URL(healthPath, r.baseUrl), { signal: controller.signal });
+    return { healthy: res.ok, status: res.status, healthPath };
+  } catch (error) {
+    return {
+      healthy: false,
+      healthPath,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function waitForHealth(r: RunningServer): Promise<HealthResult> {
+  const deadline = Date.now() + startTimeoutMs();
+  let last: HealthResult = { healthy: false, healthPath: healthPathFor(r.config) };
+  while (Date.now() < deadline) {
+    last = await health(r);
+    if (last.healthy) return last;
+    await sleep(100);
+  }
+  return last;
+}
+
+async function spawnServer(config: UnifiedPluginServer): Promise<RunningServer> {
+  const port = await allocatePort();
+  const process = Bun.spawn([config.command, ...(config.args ?? [])], {
+    cwd: config.dir,
+    env: childEnv(config, port),
+    stdout: 'ignore',
+    stderr: 'ignore',
+  });
+  const r: RunningServer = {
+    config,
+    process,
+    port,
+    baseUrl: `http://127.0.0.1:${port}`,
+    startedAt: new Date().toISOString(),
+  };
+  process.exited.finally(() => {
+    if (running.get(config.plugin)?.process === process) running.delete(config.plugin);
+  });
+  return r;
+}
+
+async function ensureServer(config: UnifiedPluginServer): Promise<ServerSuccess | ServerFailure> {
+  const existing = running.get(config.plugin);
+  if (existing) return { ok: true, running: existing, health: await health(existing) };
+
+  try {
+    const r = await spawnServer(config);
+    running.set(config.plugin, r);
+    const result = await waitForHealth(r);
+    if (result.healthy) return { ok: true, running: r, health: result };
+    r.process.kill();
+    running.delete(config.plugin);
+    return failure(config.plugin, 502, result.error ?? 'plugin server health check failed');
+  } catch (error) {
+    return failure(config.plugin, 500, error instanceof Error ? error.message : String(error));
+  }
+}
+
+async function stopServer(plugin: string): Promise<void> {
+  const r = running.get(plugin);
+  if (!r) return;
+  running.delete(plugin);
+  try {
+    r.process.kill();
+    await Promise.race([r.process.exited.catch(() => undefined), sleep(500)]);
+  } catch {
+    // best effort shutdown
+  }
+}
+
+function sendFailure(set: { status?: number | string }, result: ServerFailure) {
+  set.status = result.status;
+  return { ok: false, plugin: result.plugin, error: result.error };
+}
+
+export async function startUnifiedPluginServers(
+  servers: UnifiedPluginServer[],
+  warn: (message: string) => void = console.warn,
+): Promise<UnifiedServerRuntime> {
+  let started = 0;
+  for (const server of servers.filter(shouldAutostart)) {
+    const result = await ensureServer(server);
+    if (result.ok) started += 1;
+    else warn(`[unified-plugin] server ${server.plugin} skipped: ${result.error}`);
+  }
+  return { started, stop: () => stopUnifiedPluginServers(servers) };
+}
+
+export async function stopUnifiedPluginServers(servers?: UnifiedPluginServer[]): Promise<void> {
+  const names = servers?.map((server) => server.plugin) ?? [...running.keys()];
+  await Promise.all(names.map((name) => stopServer(name)));
+}
+
+export function unifiedPluginServerRoutes(servers: UnifiedPluginServer[]) {
+  const configs = serverMap(servers);
+  return new Elysia({ name: 'unified:plugin-server-routes' })
+    .get('/api/plugins/:name/server/health', async ({ params, set }) => {
+      const config = configs.get(params.name);
+      if (!config) return sendFailure(set, failure(params.name, 404, 'plugin server not found'));
+      const result = await ensureServer(config);
+      if (!result.ok) return sendFailure(set, result);
+      if (!result.health.healthy) set.status = 502;
+      return {
+        ok: result.health.healthy,
+        plugin: result.running.config.plugin,
+        healthy: result.health.healthy,
+        status: result.health.status,
+        healthPath: result.health.healthPath,
+        routePrefix: result.running.config.routePrefix,
+        startedAt: result.running.startedAt,
+      };
+    })
+    .all('/api/plugins/:name/server/*', async ({ params, request, set }) => {
+      const p = params as { name: string; '*': string };
+      const config = configs.get(p.name);
+      if (!config) return sendFailure(set, failure(p.name, 404, 'plugin server not found'));
+      const result = await ensureServer(config);
+      if (!result.ok) return sendFailure(set, result);
+
+      const source = new URL(request.url);
+      const target = new URL(`/${p['*']}`, result.running.baseUrl);
+      target.search = source.search;
+      const headers = new Headers(request.headers);
+      headers.delete('host');
+      headers.set('x-arra-plugin-name', result.running.config.plugin);
+      try {
+        return await fetch(target, {
+          method: request.method,
+          headers,
+          body: request.method === 'GET' || request.method === 'HEAD' ? undefined : request.body,
+          redirect: 'manual',
+          duplex: 'half',
+        });
+      } catch (error) {
+        return Response.json(
+          { ok: false, error: error instanceof Error ? error.message : String(error) },
+          { status: 502 },
+        );
+      }
+    });
 }

--- a/src/routes/plugins/get-by-name.ts
+++ b/src/routes/plugins/get-by-name.ts
@@ -1,11 +1,11 @@
 import { Elysia } from 'elysia';
 import { readFileSync } from 'fs';
-import { pluginNameParams, resolveWasmPath } from './model.ts';
+import { pluginNameParams, resolveWasmPath, sanitizePluginName } from './model.ts';
 
 export const pluginGetByNameRoute = new Elysia().get(
   '/api/plugins/:name',
   ({ params, set }) => {
-    const name = params.name.replace(/[^\w.-]/g, '').replace(/\.wasm$/, '');
+    const name = sanitizePluginName(params.name);
     if (!name) {
       set.status = 400;
       return { error: 'invalid plugin name' };

--- a/src/routes/plugins/model.ts
+++ b/src/routes/plugins/model.ts
@@ -9,6 +9,11 @@ import { t, type Static } from 'elysia';
 import { readdirSync, statSync, readFileSync, existsSync } from 'fs';
 import { join, basename } from 'path';
 import { homedir } from 'os';
+import {
+  normalizeUnifiedPluginManifest,
+  publicUnifiedServerManifest,
+  type PublicUnifiedServerManifest,
+} from '../../plugins/unified-manifest.ts';
 
 export const PLUGIN_DIR = join(homedir(), '.oracle', 'plugins');
 
@@ -30,6 +35,7 @@ export type PluginEntry = {
   version?: string;
   description?: string;
   menu?: PluginMenu;
+  server?: PublicUnifiedServerManifest;
 };
 
 export type MenuItem = {
@@ -44,6 +50,27 @@ export type MenuItem = {
 
 export const pluginNameParams = t.Object({ name: t.String() });
 
+type RawPluginManifest = {
+  name?: string;
+  version?: string;
+  description?: string;
+  wasm?: string;
+  menu?: unknown;
+  server?: unknown;
+};
+
+export function sanitizePluginName(name: string): string {
+  return name.replace(/[^\w.-]/g, '').replace(/\.wasm$/, '');
+}
+
+export function readPluginManifest(dir: string): RawPluginManifest | null {
+  try {
+    return JSON.parse(readFileSync(join(dir, 'plugin.json'), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
 function parseMenu(raw: unknown): PluginMenu | undefined {
   if (!raw || typeof raw !== 'object') return undefined;
   const m = raw as Record<string, unknown>;
@@ -56,47 +83,60 @@ function parseMenu(raw: unknown): PluginMenu | undefined {
   return { label: m.label, group, order, icon, path };
 }
 
+function serverEntry(manifest: RawPluginManifest): PublicUnifiedServerManifest | undefined {
+  if (!manifest.server) return undefined;
+  try {
+    return publicUnifiedServerManifest(normalizeUnifiedPluginManifest(manifest).server);
+  } catch {
+    return undefined;
+  }
+}
+
 export function readNestedPlugin(
   dir: string,
   entryName: string,
 ): PluginEntry | null {
   const manifestPath = join(dir, 'plugin.json');
   if (!existsSync(manifestPath)) return null;
-  let manifest: {
-    name?: string;
-    version?: string;
-    description?: string;
-    wasm?: string;
-    menu?: unknown;
+  const manifest = readPluginManifest(dir);
+  if (!manifest) return null;
+
+  const server = serverEntry(manifest);
+  const base = {
+    name: typeof manifest.name === 'string' && manifest.name ? manifest.name : entryName,
+    version: typeof manifest.version === 'string' ? manifest.version : undefined,
+    description: typeof manifest.description === 'string' ? manifest.description : undefined,
+    menu: parseMenu(manifest.menu),
+    server,
   };
-  try {
-    manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
-  } catch {
-    return null;
-  }
   const wasmName = manifest.wasm;
-  if (!wasmName || typeof wasmName !== 'string') return null;
+  if (!wasmName || typeof wasmName !== 'string') {
+    if (!server) return null;
+    const st = statSync(manifestPath);
+    return { ...base, file: '', size: 0, modified: st.mtime.toISOString() };
+  }
 
   // Try manifest path as-is, then fall back to basename (plugins copied flat
   // by `arra-cli plugin install` keep the source path in manifest.wasm).
   let wasmPath = join(dir, wasmName);
   let resolvedName = wasmName;
   if (!existsSync(wasmPath)) {
-    const base = basename(wasmName);
-    const basePath = join(dir, base);
-    if (!existsSync(basePath)) return null;
+    const baseName = basename(wasmName);
+    const basePath = join(dir, baseName);
+    if (!existsSync(basePath)) {
+      if (!server) return null;
+      const st = statSync(manifestPath);
+      return { ...base, file: '', size: 0, modified: st.mtime.toISOString() };
+    }
     wasmPath = basePath;
-    resolvedName = base;
+    resolvedName = baseName;
   }
   const st = statSync(wasmPath);
   return {
-    name: typeof manifest.name === 'string' && manifest.name ? manifest.name : entryName,
+    ...base,
     file: resolvedName,
     size: st.size,
     modified: st.mtime.toISOString(),
-    version: typeof manifest.version === 'string' ? manifest.version : undefined,
-    description: typeof manifest.description === 'string' ? manifest.description : undefined,
-    menu: parseMenu(manifest.menu),
   };
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -85,7 +85,7 @@ const scoutAnnouncer = shouldStartScoutAnnouncer() ? new ScoutAnnouncer() : null
 scoutAnnouncer?.start();
 
 const unifiedPlugins = await loadUnifiedPlugins({ warn: (message) => console.warn(message) });
-const unifiedServers = startUnifiedPluginServers(unifiedPlugins.servers);
+const unifiedServers = await startUnifiedPluginServers(unifiedPlugins.servers);
 
 registerSignalHandlers(async () => {
   console.log('\n🔮 Shutting down gracefully...');

--- a/tests/http/plugins/model-invalid-server.test.ts
+++ b/tests/http/plugins/model-invalid-server.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readNestedPlugin } from '../../../src/routes/plugins/model.ts';
+
+let tmp = '';
+let dir = '';
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'arra-plugin-model-'));
+  dir = join(tmp, 'invalid-server');
+  mkdirSync(dir, { recursive: true });
+});
+
+afterEach(() => {
+  if (tmp) rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('readNestedPlugin invalid server manifest', () => {
+  test('skips server-only plugins when server validation fails', () => {
+    writeFileSync(join(dir, 'plugin.json'), JSON.stringify({
+      name: 'invalid-server',
+      version: '1.0.0',
+      entry: './index.ts',
+      server: { command: '' },
+    }));
+    expect(readNestedPlugin(dir, 'invalid-server')).toBeNull();
+  });
+});

--- a/tests/http/plugins/model-server-missing-wasm.test.ts
+++ b/tests/http/plugins/model-server-missing-wasm.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readNestedPlugin } from '../../../src/routes/plugins/model.ts';
+
+let tmp = '';
+let dir = '';
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'arra-plugin-model-'));
+  dir = join(tmp, 'server-missing-wasm');
+  mkdirSync(dir, { recursive: true });
+});
+
+afterEach(() => {
+  if (tmp) rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('readNestedPlugin server manifest with missing wasm', () => {
+  test('keeps the server plugin listed when wasm is absent', () => {
+    writeFileSync(join(dir, 'plugin.json'), JSON.stringify({
+      name: 'server-missing-wasm',
+      version: '1.0.0',
+      entry: './index.ts',
+      wasm: 'missing.wasm',
+      server: { command: 'bun', args: ['server.ts'] },
+    }));
+    expect(readNestedPlugin(dir, 'server-missing-wasm')).toMatchObject({
+      name: 'server-missing-wasm',
+      file: '',
+      server: { command: 'bun', args: ['server.ts'] },
+    });
+  });
+});

--- a/tests/http/plugins/model-server-only.test.ts
+++ b/tests/http/plugins/model-server-only.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readNestedPlugin } from '../../../src/routes/plugins/model.ts';
+
+let tmp = '';
+let dir = '';
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'arra-plugin-model-'));
+  dir = join(tmp, 'server-only');
+  mkdirSync(dir, { recursive: true });
+});
+
+afterEach(() => {
+  if (tmp) rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('readNestedPlugin server-only manifest', () => {
+  test('returns a plugin entry without wasm bytes', () => {
+    writeFileSync(join(dir, 'plugin.json'), JSON.stringify({
+      name: 'server-only',
+      version: '1.0.0',
+      entry: './index.ts',
+      server: { command: 'bun', healthPath: '/ready' },
+    }));
+    expect(readNestedPlugin(dir, 'server-only')).toMatchObject({
+      name: 'server-only',
+      file: '',
+      server: { command: 'bun', healthPath: '/ready' },
+    });
+  });
+});

--- a/tests/http/plugins/server-custom-health.test.ts
+++ b/tests/http/plugins/server-custom-health.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'bun:test';
+import { createPluginServerFixture } from './server-fixture.ts';
+
+describe('server.healthPath manifest option', () => {
+  test('uses the declared health path for readiness checks', async () => {
+    const fixture = await createPluginServerFixture({ healthPath: '/ready' });
+    try {
+      const res = await fetch(`${fixture.baseUrl}/api/plugins/${fixture.pluginName}/server/health`);
+      expect(res.status).toBe(200);
+      expect((await res.json()) as { healthPath: string }).toMatchObject({ healthPath: '/ready' });
+    } finally {
+      await fixture.stop();
+    }
+  });
+});

--- a/tests/http/plugins/server-fixture.ts
+++ b/tests/http/plugins/server-fixture.ts
@@ -1,0 +1,107 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { Elysia } from 'elysia';
+
+import { loadUnifiedPlugins, type UnifiedRuntime } from '../../../src/plugins/unified-loader.ts';
+import {
+  startUnifiedPluginServers,
+  type UnifiedServerRuntime,
+} from '../../../src/plugins/unified-server.ts';
+
+type TestServer = ReturnType<typeof Bun.serve>;
+
+export interface PluginServerFixture {
+  baseUrl: string;
+  pluginName: string;
+  runtime: UnifiedRuntime;
+  servers: UnifiedServerRuntime;
+  stop: () => Promise<void>;
+}
+
+interface FixtureOptions {
+  autostart?: boolean;
+  command?: string;
+  args?: string[];
+  flipHealth?: boolean;
+  healthPath?: string;
+  healthy?: boolean;
+}
+
+export async function createPluginServerFixture(
+  options: FixtureOptions = {},
+): Promise<PluginServerFixture> {
+  const root = mkdtempSync(join(tmpdir(), 'arra-plugin-server-'));
+  const pluginName = `self-server-${randomUUID().slice(0, 8)}`;
+  writeServerPlugin(root, pluginName, options);
+  const runtime = await loadUnifiedPlugins({ dirs: [root] });
+  const servers = await startUnifiedPluginServers(runtime.servers);
+  const http = serveRuntime(runtime);
+
+  return {
+    baseUrl: `http://127.0.0.1:${http.port}`,
+    pluginName,
+    runtime,
+    servers,
+    stop: async () => {
+      await http.stop(true);
+      await servers.stop();
+      rmSync(root, { recursive: true, force: true });
+    },
+  };
+}
+
+function serveRuntime(runtime: UnifiedRuntime): TestServer {
+  const app = new Elysia();
+  for (const route of runtime.routes) app.use(route as any);
+  return Bun.serve({ hostname: '127.0.0.1', port: 0, fetch: app.fetch });
+}
+
+function writeServerPlugin(root: string, pluginName: string, options: FixtureOptions) {
+  const dir = join(root, pluginName);
+  const healthPath = options.healthPath ?? '/health';
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'plugin.json'), JSON.stringify({
+    name: pluginName,
+    version: '1.0.0',
+    entry: './index.ts',
+    server: {
+      command: options.command ?? 'bun',
+      args: options.args ?? ['server.ts'],
+      env: { PLUGIN_MESSAGE: 'pong' },
+      healthPath,
+      autostart: options.autostart,
+    },
+  }));
+  writeFileSync(join(dir, 'index.ts'), 'export function noop() { return { ok: true }; }\n');
+  writeFileSync(join(dir, 'server.ts'), serverSource(healthPath, options));
+}
+
+function serverSource(healthPath: string, options: FixtureOptions) {
+  return `const port = Number(process.env.ARRA_PLUGIN_PORT || process.env.PORT);
+let healthChecks = 0;
+const healthy = ${options.healthy === false ? 'false' : 'true'};
+const flipHealth = ${options.flipHealth ? 'true' : 'false'};
+const server = Bun.serve({
+  hostname: '127.0.0.1',
+  port,
+  fetch(req) {
+    const url = new URL(req.url);
+    if (url.pathname === ${JSON.stringify(healthPath)}) {
+      healthChecks += 1;
+      const ok = healthy && (!flipHealth || healthChecks === 1);
+      return Response.json({ ok, port }, { status: ok ? 200 : 500 });
+    }
+    if (url.pathname === '/crash') process.exit(1);
+    if (url.pathname === '/echo') return Response.json({
+      message: process.env.PLUGIN_MESSAGE || 'missing',
+      plugin: req.headers.get('x-arra-plugin-name'),
+      query: url.searchParams.get('q'),
+    });
+    return new Response('missing', { status: 404 });
+  },
+});
+process.on('SIGTERM', () => { server.stop(true); process.exit(0); });
+`;
+}

--- a/tests/http/plugins/server-health-unhealthy.test.ts
+++ b/tests/http/plugins/server-health-unhealthy.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+import { createPluginServerFixture } from './server-fixture.ts';
+
+describe('running plugin server with failing health', () => {
+  test('marks health response unhealthy with 502 status', async () => {
+    const fixture = await createPluginServerFixture({ flipHealth: true });
+    try {
+      expect(fixture.servers.started).toBe(1);
+      const res = await fetch(`${fixture.baseUrl}/api/plugins/${fixture.pluginName}/server/health`);
+      expect(res.status).toBe(502);
+      expect((await res.json()) as { ok: boolean; healthy: boolean; status: number }).toMatchObject({
+        ok: false,
+        healthy: false,
+        status: 500,
+      });
+    } finally {
+      await fixture.stop();
+    }
+  });
+});

--- a/tests/http/plugins/server-health.test.ts
+++ b/tests/http/plugins/server-health.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+import { createPluginServerFixture } from './server-fixture.ts';
+
+describe('GET /api/plugins/:name/server/health', () => {
+  test('returns the plugin-owned server health through arra', async () => {
+    const fixture = await createPluginServerFixture();
+    try {
+      const res = await fetch(`${fixture.baseUrl}/api/plugins/${fixture.pluginName}/server/health`);
+      expect(res.status).toBe(200);
+      const body = await res.json() as { plugin: string; healthy: boolean; routePrefix: string };
+      expect(body).toMatchObject({
+        plugin: fixture.pluginName,
+        healthy: true,
+        routePrefix: `/api/plugins/${fixture.pluginName}/server`,
+      });
+    } finally {
+      await fixture.stop();
+    }
+  });
+});

--- a/tests/http/plugins/server-invalid-command.test.ts
+++ b/tests/http/plugins/server-invalid-command.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+import { createPluginServerFixture } from './server-fixture.ts';
+
+describe('invalid plugin server command', () => {
+  test('returns a 500 health response instead of crashing arra', async () => {
+    const fixture = await createPluginServerFixture({ command: 'not-a-real-arra-plugin-command' });
+    try {
+      expect(fixture.servers.started).toBe(0);
+      const res = await fetch(`${fixture.baseUrl}/api/plugins/${fixture.pluginName}/server/health`);
+      expect(res.status).toBe(500);
+      expect((await res.json()) as { ok: boolean; plugin: string }).toMatchObject({
+        ok: false,
+        plugin: fixture.pluginName,
+      });
+    } finally {
+      await fixture.stop();
+    }
+  });
+});

--- a/tests/http/plugins/server-lazy-start.test.ts
+++ b/tests/http/plugins/server-lazy-start.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test';
+import { createPluginServerFixture } from './server-fixture.ts';
+
+describe('autostart:false plugin server manifests', () => {
+  test('start lazily on first health request', async () => {
+    const fixture = await createPluginServerFixture({ autostart: false });
+    try {
+      expect(fixture.servers.started).toBe(0);
+      const res = await fetch(`${fixture.baseUrl}/api/plugins/${fixture.pluginName}/server/health`);
+      expect(res.status).toBe(200);
+      expect((await res.json()) as { healthy: boolean }).toMatchObject({ healthy: true });
+    } finally {
+      await fixture.stop();
+    }
+  });
+});

--- a/tests/http/plugins/server-manifest-invalid-args.test.ts
+++ b/tests/http/plugins/server-manifest-invalid-args.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test';
+import { normalizeUnifiedPluginManifest } from '../../../src/plugins/unified-manifest.ts';
+
+describe('server.args manifest validation', () => {
+  test('rejects non-string args entries', () => {
+    expect(() => normalizeUnifiedPluginManifest({
+      name: 'bad-server-args',
+      version: '1.0.0',
+      entry: './index.ts',
+      server: { command: 'bun', args: ['ok', 1] },
+    })).toThrow('server.args');
+  });
+});

--- a/tests/http/plugins/server-manifest-invalid-command.test.ts
+++ b/tests/http/plugins/server-manifest-invalid-command.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test';
+import { normalizeUnifiedPluginManifest } from '../../../src/plugins/unified-manifest.ts';
+
+describe('server.command manifest validation', () => {
+  test('rejects empty server commands', () => {
+    expect(() => normalizeUnifiedPluginManifest({
+      name: 'bad-server-command',
+      version: '1.0.0',
+      entry: './index.ts',
+      server: { command: '' },
+    })).toThrow('server.command');
+  });
+});

--- a/tests/http/plugins/server-manifest-invalid-env.test.ts
+++ b/tests/http/plugins/server-manifest-invalid-env.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test';
+import { normalizeUnifiedPluginManifest } from '../../../src/plugins/unified-manifest.ts';
+
+describe('server.env manifest validation', () => {
+  test('rejects non-string env values', () => {
+    expect(() => normalizeUnifiedPluginManifest({
+      name: 'bad-server-env',
+      version: '1.0.0',
+      entry: './index.ts',
+      server: { command: 'bun', env: { PORT: 47778 } },
+    })).toThrow('server.env');
+  });
+});

--- a/tests/http/plugins/server-missing.test.ts
+++ b/tests/http/plugins/server-missing.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+import { createPluginServerFixture } from './server-fixture.ts';
+
+describe('unknown plugin server routes', () => {
+  test('return 404 without spawning a server', async () => {
+    const fixture = await createPluginServerFixture();
+    try {
+      const res = await fetch(`${fixture.baseUrl}/api/plugins/missing/server/health`);
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({
+        ok: false,
+        plugin: 'missing',
+        error: 'plugin server not found',
+      });
+    } finally {
+      await fixture.stop();
+    }
+  });
+});

--- a/tests/http/plugins/server-proxy-upstream-crash.test.ts
+++ b/tests/http/plugins/server-proxy-upstream-crash.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'bun:test';
+import { createPluginServerFixture } from './server-fixture.ts';
+
+describe('plugin server proxy upstream failure', () => {
+  test('returns 502 when the plugin server drops the proxied request', async () => {
+    const fixture = await createPluginServerFixture();
+    try {
+      const res = await fetch(`${fixture.baseUrl}/api/plugins/${fixture.pluginName}/server/crash`);
+      expect(res.status).toBe(502);
+      expect((await res.json()) as { ok: boolean; error: string }).toMatchObject({ ok: false });
+    } finally {
+      await fixture.stop();
+    }
+  });
+});

--- a/tests/http/plugins/server-proxy.test.ts
+++ b/tests/http/plugins/server-proxy.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+import { createPluginServerFixture } from './server-fixture.ts';
+
+describe('ALL /api/plugins/:name/server/*', () => {
+  test('proxies requests to the plugin-owned web server', async () => {
+    const fixture = await createPluginServerFixture();
+    try {
+      const res = await fetch(`${fixture.baseUrl}/api/plugins/${fixture.pluginName}/server/echo?q=ok`);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        message: 'pong',
+        plugin: fixture.pluginName,
+        query: 'ok',
+      });
+    } finally {
+      await fixture.stop();
+    }
+  });
+});

--- a/tests/http/plugins/server-register.test.ts
+++ b/tests/http/plugins/server-register.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+import { createPluginServerFixture } from './server-fixture.ts';
+
+describe('unified plugin server manifest registration', () => {
+  test('exposes one manifest server for reverse-proxy mounting', async () => {
+    const fixture = await createPluginServerFixture();
+    try {
+      expect(fixture.runtime.servers).toHaveLength(1);
+      expect(fixture.runtime.servers[0]).toMatchObject({
+        plugin: fixture.pluginName,
+        routePrefix: `/api/plugins/${fixture.pluginName}/server`,
+        env: { PLUGIN_MESSAGE: 'pong' },
+      });
+      expect(fixture.servers.started).toBe(1);
+    } finally {
+      await fixture.stop();
+    }
+  });
+});

--- a/tests/http/plugins/server-unready.test.ts
+++ b/tests/http/plugins/server-unready.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test';
+import { createPluginServerFixture } from './server-fixture.ts';
+
+describe('unready plugin server', () => {
+  test('returns 502 when readiness never passes', async () => {
+    const oldStart = process.env.ARRA_PLUGIN_START_TIMEOUT_MS;
+    process.env.ARRA_PLUGIN_START_TIMEOUT_MS = '120';
+    const fixture = await createPluginServerFixture({ healthy: false });
+    try {
+      expect(fixture.servers.started).toBe(0);
+      const res = await fetch(`${fixture.baseUrl}/api/plugins/${fixture.pluginName}/server/health`);
+      expect(res.status).toBe(502);
+      expect((await res.json()) as { ok: boolean; error: string }).toMatchObject({
+        ok: false,
+        error: 'plugin server health check failed',
+      });
+    } finally {
+      if (oldStart === undefined) delete process.env.ARRA_PLUGIN_START_TIMEOUT_MS;
+      else process.env.ARRA_PLUGIN_START_TIMEOUT_MS = oldStart;
+      await fixture.stop();
+    }
+  });
+});


### PR DESCRIPTION
## Summary\n- Add manifest-driven plugin web-server runtime with port allocation, health checks, autostart/lazy start, shutdown, and reverse proxy under /api/plugins/:name/server/*\n- Wire server manifests through unified-loader and public plugin metadata without leaking env\n- Split plugin server HTTP coverage into one-behavior-per-file tests under tests/http/plugins/\n\n## Verification\n- tsc --noEmit\n- bun test src/plugins/__tests__/ tests/http/plugins/\n- bun test --coverage tests/http/plugins/ src/plugins/__tests__/unified-loader.test.ts src/plugins/__tests__/unified-manifest.test.ts (src/plugins/unified-server.ts line coverage 100%)\n\n## Notes\n- Full bare bun test intentionally not run because this repo contract says it pulls agents/ worktrees.