### PR TITLE
Add routed frontend pages

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -3,8 +3,8 @@
 ## Source of truth
 - Status: Draft
 - Last refreshed: 2026-06-15
-- Primary product surfaces: Frontend dashboard for menu and plugin discovery.
-- Evidence reviewed: `web/src/pages/index.astro`, `web/src/styles/global.css`, `src/routes/menu/menu.ts`, `src/routes/plugins/model.ts`, `src/routes/plugins/list.ts`.
+- Primary product surfaces: Routed frontend dashboard for menu, plugin, vector, MCP, and settings discovery.
+- Evidence reviewed: `web/src/pages/index.astro`, `web/src/styles/global.css`, `src/routes/menu/menu.ts`, `src/routes/plugins/model.ts`, `src/routes/plugins/list.ts`, `frontend/src/components/VectorSearchWidget.tsx`, `frontend/src/components/McpToolBrowser.tsx`.
 
 ## Brand
 - Personality: technical, calm, observability-first Oracle tooling.
@@ -12,24 +12,24 @@
 - Avoid: decorative UI that hides operational state.
 
 ## Product goals
-- Goals: show `/api/menu` navigation rows and `/api/plugins` registered plugin metadata quickly.
-- Non-goals: editing menus/plugins, auth flows, or embedding the Astro marketing site.
-- Success signals: frontend build passes; users can scan menu groups and plugin surfaces on desktop/mobile.
+- Goals: expose routed pages for `/api/menu`, `/api/plugins`, vector search, MCP tools, and frontend runtime settings.
+- Non-goals: editing menus/plugins/settings, auth flows, or embedding the Astro marketing site.
+- Success signals: frontend build passes; users can navigate routes and scan menu, plugin, vector, MCP, and settings surfaces on desktop/mobile.
 
 ## Personas and jobs
 - Primary personas: Oracle operators, plugin authors, maintainers.
-- User jobs: confirm backend connectivity, inspect available navigation, inspect registered plugins/surfaces.
+- User jobs: confirm backend connectivity, inspect available navigation, inspect registered plugins/surfaces, run vector searches, and browse MCP tools.
 - Key contexts of use: local Vite dev proxy to `:47778`, same-origin deployed UI.
 
 ## Information architecture
-- Primary navigation: in-page anchors for Overview, Menu, Plugins.
-- Core routes/screens: single dashboard screen with two data panels.
-- Content hierarchy: connection status, summary stats, menu viewer, plugin list.
+- Primary navigation: responsive React Router sidebar for Menu, Plugins, Vector, MCP, and Settings.
+- Core routes/screens: `/menu`, `/plugins`, `/vector`, `/mcp`, `/settings`; `/` redirects to `/menu`.
+- Content hierarchy: sidebar navigation, connection/status summary, then one focused routed page at a time.
 
 ## Design principles
 - Principle 1: make live system state visible before details.
 - Principle 2: prefer dense but readable operational cards.
-- Tradeoffs: simple single-page UI over routing until more screens are required.
+- Tradeoffs: lightweight route components over a larger design-system layer.
 
 ## Visual language
 - Color: dark neutral base with teal/cyan Oracle accent and purple secondary accent.
@@ -40,8 +40,8 @@
 - Imagery/iconography: text badges over icon dependencies.
 
 ## Components
-- Existing components to reuse: none in `frontend/`; visual cues borrowed from `web/src/styles/global.css`.
-- New/changed components: status banner, stat cards, menu cards, plugin cards, badges.
+- Existing components to reuse: `VectorSearchWidget`, `McpToolBrowser`, menu/plugin cards, and visual cues from `web/src/styles/global.css`.
+- New/changed components: nav sidebar, routed pages, status banner, stat cards, menu cards, plugin cards, badges.
 - Variants and states: loading, error, empty, success.
 - Token/component ownership: local Tailwind utility classes in `frontend/src/styles.css` and React components.
 
@@ -54,7 +54,7 @@
 
 ## Responsive behavior
 - Supported breakpoints/devices: mobile single column, desktop two-column content grid.
-- Layout adaptations: summary cards wrap; menu/plugin panels stack below large screens.
+- Layout adaptations: sidebar stacks above content on small screens and becomes sticky at desktop widths; summary cards wrap.
 - Touch/hover differences: cards do not require hover-only controls.
 
 ## Interaction states
@@ -71,7 +71,7 @@
 - Microcopy rules: describe exact endpoint on failures.
 
 ## Implementation constraints
-- Framework/styling system: React + Vite + Tailwind in `frontend/`.
+- Framework/styling system: React + React Router + Vite + Tailwind in `frontend/`.
 - Design-token constraints: no new shared design system layer.
 - Performance constraints: small static bundle; parallel API fetches.
 - Compatibility constraints: `/api/*` dev proxy targets backend `:47778`.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,11 +11,12 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.1.0",
     "@vitejs/plugin-react": "^5.1.1",
-    "vite": "^7.3.0",
-    "typescript": "^5.8.0",
-    "tailwindcss": "^4.1.0",
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "react-router-dom": "^7.17.0",
+    "tailwindcss": "^4.1.0",
+    "typescript": "^5.8.0",
+    "vite": "^7.3.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.7",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,132 +1,14 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { fetchMenu, fetchPlugins } from './api';
-import { ErrorMessage, LoadingPanel, Spinner } from './components/AsyncState';
-import { McpToolBrowser } from './components/McpToolBrowser';
-import { VectorSearchWidget } from './components/VectorSearchWidget';
+import { AppShell } from './components/AppShell';
+import { countPluginSurfaces } from './plugin-surfaces';
+import { McpPage } from './pages/McpPage';
+import { MenuPage } from './pages/MenuPage';
+import { PluginsPage } from './pages/PluginsPage';
+import { SettingsPage } from './pages/SettingsPage';
+import { VectorPage } from './pages/VectorPage';
 import type { LoadState, MenuItem, PluginEntry } from './types';
-
-type Surface = 'wasm' | 'menu' | 'server';
-
-function surfacesFor(plugin: PluginEntry): Surface[] {
-  const surfaces: Surface[] = [];
-  if (plugin.file) surfaces.push('wasm');
-  if (plugin.menu) surfaces.push('menu');
-  if (plugin.server) surfaces.push('server');
-  return surfaces;
-}
-
-function groupMenu(items: MenuItem[]) {
-  return items.reduce<Record<string, MenuItem[]>>((groups, item) => {
-    const key = item.group ?? 'tools';
-    groups[key] = [...(groups[key] ?? []), item];
-    return groups;
-  }, {});
-}
-
-function StatCard({ label, value, detail }: { label: string; value: ReactNode; detail: string }) {
-  return (
-    <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-4 shadow-xl shadow-black/10">
-      <p className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">{label}</p>
-      <p className="mt-2 text-3xl font-semibold text-white">{value}</p>
-      <p className="mt-1 text-sm text-slate-400">{detail}</p>
-    </div>
-  );
-}
-
-function Badge({ children }: { children: ReactNode }) {
-  return (
-    <span className="rounded-full border border-teal-300/20 bg-teal-300/10 px-2.5 py-1 text-xs font-medium text-teal-200">
-      {children}
-    </span>
-  );
-}
-
-function EmptyState({ text }: { text: string }) {
-  return <div className="rounded-xl border border-dashed border-white/10 p-6 text-sm text-slate-400">{text}</div>;
-}
-
-function MenuViewer({ items }: { items: MenuItem[] }) {
-  const groups = groupMenu(items);
-  const orderedGroups = Object.keys(groups).sort((a, b) => a.localeCompare(b));
-  if (!items.length) return <EmptyState text="No menu items returned from /api/menu." />;
-
-  return (
-    <div className="space-y-5">
-      {orderedGroups.map((group) => (
-        <section key={group} aria-labelledby={`menu-${group}`}>
-          <h3 id={`menu-${group}`} className="mb-3 text-sm font-semibold uppercase tracking-[0.2em] text-slate-500">
-            {group}
-          </h3>
-          <div className="grid gap-3 sm:grid-cols-2">
-            {[...groups[group]]
-              .sort((a, b) => (a.order ?? 999) - (b.order ?? 999))
-              .map((item) => (
-                <a
-                  key={`${item.path}-${item.label}`}
-                  href={item.path}
-                  className="focus-ring rounded-xl border border-white/10 bg-slate-950/60 p-4 transition hover:border-teal-300/40 hover:bg-slate-900"
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div>
-                      <p className="font-medium text-white">{item.label}</p>
-                      <p className="mt-1 font-mono text-xs text-teal-200">{item.path}</p>
-                    </div>
-                    <span className="rounded-full bg-white/5 px-2 py-1 text-xs text-slate-400">#{item.order ?? 999}</span>
-                  </div>
-                  <p className="mt-3 text-xs text-slate-500">
-                    {item.sourceName ? `${item.source ?? 'source'}:${item.sourceName}` : item.source ?? 'route'}
-                  </p>
-                </a>
-              ))}
-          </div>
-        </section>
-      ))}
-    </div>
-  );
-}
-
-function PluginList({ plugins }: { plugins: PluginEntry[] }) {
-  if (!plugins.length) return <EmptyState text="No plugins registered in /api/plugins." />;
-
-  return (
-    <div className="grid gap-4">
-      {plugins.map((plugin) => {
-        const surfaces = surfacesFor(plugin);
-        return (
-          <article key={plugin.name} className="rounded-2xl border border-white/10 bg-slate-950/60 p-5">
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-              <div>
-                <h3 className="text-lg font-semibold text-white">{plugin.name}</h3>
-                <p className="mt-1 text-sm text-slate-400">{plugin.description ?? 'No description supplied.'}</p>
-              </div>
-              <div className="flex flex-wrap gap-2">
-                {surfaces.length ? surfaces.map((surface) => <Badge key={surface}>{surface}</Badge>) : <Badge>metadata</Badge>}
-              </div>
-            </div>
-            <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-2">
-              <div>
-                <dt className="text-slate-500">Version</dt>
-                <dd className="font-mono text-slate-200">{plugin.version ?? 'unknown'}</dd>
-              </div>
-              <div>
-                <dt className="text-slate-500">Artifact</dt>
-                <dd className="font-mono text-slate-200">{plugin.file || 'server-only'}</dd>
-              </div>
-              {plugin.server ? (
-                <div className="sm:col-span-2">
-                  <dt className="text-slate-500">Server</dt>
-                  <dd className="font-mono text-slate-200">
-                    {plugin.server.command} {(plugin.server.args ?? []).join(' ')} · {plugin.server.healthPath ?? '/health'}
-                  </dd>
-                </div>
-              ) : null}
-            </dl>
-          </article>
-        );
-      })}
-    </div>
-  );
-}
 
 export default function App() {
   const [state, setState] = useState<LoadState>('idle');
@@ -154,66 +36,34 @@ export default function App() {
     void load();
   }, []);
 
-  const surfaceCount = useMemo(() => plugins.reduce((total, plugin) => total + Math.max(1, surfacesFor(plugin).length), 0), [plugins]);
+  const surfaceCount = useMemo(() => countPluginSurfaces(plugins), [plugins]);
   const loading = state === 'loading' || state === 'idle';
-  const retryButton = (
-    <button
-      className="focus-ring rounded-lg border border-red-200/30 px-3 py-2 text-sm font-semibold text-red-50 hover:bg-red-200/10"
-      type="button"
-      onClick={() => void load()}
-    >
-      Retry
-    </button>
-  );
+  const refresh = () => void load();
 
   return (
-    <main className="oracle-shell min-h-screen text-slate-100">
-      <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-4 py-6 sm:px-6 lg:px-8">
-        <header className="flex flex-col gap-5 rounded-3xl border border-white/10 bg-slate-950/70 p-6 shadow-2xl shadow-black/30 lg:flex-row lg:items-end lg:justify-between">
-          <div>
-            <p className="text-sm font-medium uppercase tracking-[0.28em] text-teal-300">Arra Oracle</p>
-            <h1 className="mt-3 text-4xl font-bold tracking-tight text-white sm:text-5xl">Frontend Control Surface</h1>
-            <p className="mt-3 max-w-2xl text-slate-400">
-              Live menu and plugin inventory from the Elysia backend via the Vite `/api/*` proxy.
-            </p>
-          </div>
-          <button
-            className="focus-ring rounded-xl bg-teal-300 px-5 py-3 font-semibold text-slate-950 transition hover:bg-teal-200"
-            disabled={loading}
-            type="button"
-            onClick={() => void load()}
-          >
-            {loading ? <Spinner label="Refreshing" /> : 'Refresh data'}
-          </button>
-        </header>
-
-        <section className="grid gap-4 md:grid-cols-3" aria-label="Summary">
-          <StatCard label="Menu items" value={loading ? <Spinner label="Loading" /> : menu.length} detail="from /api/menu" />
-          <StatCard label="Plugins" value={loading ? <Spinner label="Loading" /> : plugins.length} detail="from /api/plugins" />
-          <StatCard label="Surfaces" value={loading ? <Spinner label="Loading" /> : surfaceCount} detail={`updated ${updatedAt}`} />
-        </section>
-
-        {state === 'error' ? (
-          <ErrorMessage title="Could not load backend data." message={error} action={retryButton} />
-        ) : null}
-
-        <div className="grid gap-6 xl:grid-cols-2">
-          <VectorSearchWidget />
-          <McpToolBrowser />
-        </div>
-
-        <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
-          <section id="menu" className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
-            <h2 className="mb-4 text-2xl font-semibold text-white">Menu viewer</h2>
-            {loading ? <LoadingPanel title="Loading menu items…" detail="Fetching /api/menu from the Elysia backend." /> : <MenuViewer items={menu} />}
-          </section>
-
-          <section id="plugins" className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
-            <h2 className="mb-4 text-2xl font-semibold text-white">Plugin list</h2>
-            {loading ? <LoadingPanel title="Loading plugins…" detail="Fetching /api/plugins and plugin server manifests." /> : <PluginList plugins={plugins} />}
-          </section>
-        </div>
-      </div>
-    </main>
+    <BrowserRouter>
+      <AppShell
+        error={error}
+        loading={loading}
+        menuCount={menu.length}
+        pluginCount={plugins.length}
+        surfaceCount={surfaceCount}
+        updatedAt={updatedAt}
+        onRefresh={refresh}
+      >
+        <Routes>
+          <Route index element={<Navigate to="/menu" replace />} />
+          <Route path="/menu" element={<MenuPage items={menu} loading={loading} />} />
+          <Route path="/plugins" element={<PluginsPage plugins={plugins} loading={loading} />} />
+          <Route path="/vector" element={<VectorPage />} />
+          <Route path="/mcp" element={<McpPage />} />
+          <Route
+            path="/settings"
+            element={<SettingsPage menuCount={menu.length} pluginCount={plugins.length} surfaceCount={surfaceCount} updatedAt={updatedAt} onRefresh={refresh} />}
+          />
+          <Route path="*" element={<Navigate to="/menu" replace />} />
+        </Routes>
+      </AppShell>
+    </BrowserRouter>
   );
 }

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from 'react';
+import { ErrorMessage, Spinner } from './AsyncState';
+import { NavSidebar, type NavItem } from './NavSidebar';
+import { StatCard } from './StatCard';
+
+type AppShellProps = {
+  children: ReactNode;
+  error: string;
+  loading: boolean;
+  menuCount: number;
+  pluginCount: number;
+  surfaceCount: number;
+  updatedAt: string;
+  onRefresh: () => void;
+};
+
+export function AppShell({
+  children,
+  error,
+  loading,
+  menuCount,
+  pluginCount,
+  surfaceCount,
+  updatedAt,
+  onRefresh,
+}: AppShellProps) {
+  const navItems: NavItem[] = [
+    { to: '/menu', label: 'Menu', description: 'Navigation rows from /api/menu', badge: loading ? '…' : menuCount },
+    { to: '/plugins', label: 'Plugins', description: 'Registered plugins and surfaces', badge: loading ? '…' : pluginCount },
+    { to: '/vector', label: 'Vector', description: 'Semantic search over memory' },
+    { to: '/mcp', label: 'MCP', description: 'Tool schemas and groups' },
+    { to: '/settings', label: 'Settings', description: 'Frontend/API runtime notes' },
+  ];
+  const retry = (
+    <button className="focus-ring rounded-lg border border-red-200/30 px-3 py-2 font-semibold text-red-50 hover:bg-red-200/10" type="button" onClick={onRefresh}>
+      Retry
+    </button>
+  );
+
+  return (
+    <main className="oracle-shell min-h-screen text-slate-100">
+      <div className="mx-auto grid w-full max-w-7xl gap-6 px-4 py-6 sm:px-6 lg:grid-cols-[18rem_1fr] lg:px-8">
+        <NavSidebar items={navItems} />
+        <div className="flex min-w-0 flex-col gap-6">
+          <header className="flex flex-col gap-5 rounded-3xl border border-white/10 bg-slate-950/70 p-6 shadow-2xl shadow-black/30 lg:flex-row lg:items-end lg:justify-between">
+            <div>
+              <p className="text-sm font-medium uppercase tracking-[0.28em] text-teal-300">Frontend UI</p>
+              <h2 className="mt-3 text-4xl font-bold tracking-tight text-white sm:text-5xl">Operational dashboard</h2>
+              <p className="mt-3 max-w-2xl text-slate-400">
+                Routed menu, plugin, vector, MCP, and settings pages over the Vite `/api/*` proxy.
+              </p>
+            </div>
+            <button
+              className="focus-ring rounded-xl bg-teal-300 px-5 py-3 font-semibold text-slate-950 transition hover:bg-teal-200 disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={loading}
+              type="button"
+              onClick={onRefresh}
+            >
+              {loading ? <Spinner label="Refreshing" /> : 'Refresh data'}
+            </button>
+          </header>
+
+          <section className="grid gap-4 md:grid-cols-3" aria-label="Summary">
+            <StatCard label="Menu items" value={loading ? <Spinner label="Loading" /> : menuCount} detail="from /api/menu" />
+            <StatCard label="Plugins" value={loading ? <Spinner label="Loading" /> : pluginCount} detail="from /api/plugins" />
+            <StatCard label="Surfaces" value={loading ? <Spinner label="Loading" /> : surfaceCount} detail={`updated ${updatedAt}`} />
+          </section>
+
+          {error ? <ErrorMessage title="Could not load backend data." message={error} action={retry} /> : null}
+          {children}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/components/Badge.tsx
+++ b/frontend/src/components/Badge.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react';
+
+export function Badge({ children }: { children: ReactNode }) {
+  return (
+    <span className="rounded-full border border-teal-300/20 bg-teal-300/10 px-2.5 py-1 text-xs font-medium text-teal-200">
+      {children}
+    </span>
+  );
+}

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,0 +1,3 @@
+export function EmptyState({ text }: { text: string }) {
+  return <div className="rounded-xl border border-dashed border-white/10 p-6 text-sm text-slate-400">{text}</div>;
+}

--- a/frontend/src/components/MenuViewer.tsx
+++ b/frontend/src/components/MenuViewer.tsx
@@ -1,0 +1,50 @@
+import type { MenuItem } from '../types';
+import { EmptyState } from './EmptyState';
+
+function groupMenu(items: MenuItem[]) {
+  return items.reduce<Record<string, MenuItem[]>>((groups, item) => {
+    const key = item.group ?? 'tools';
+    groups[key] = [...(groups[key] ?? []), item];
+    return groups;
+  }, {});
+}
+
+export function MenuViewer({ items }: { items: MenuItem[] }) {
+  const groups = groupMenu(items);
+  const orderedGroups = Object.keys(groups).sort((a, b) => a.localeCompare(b));
+  if (!items.length) return <EmptyState text="No menu items returned from /api/menu." />;
+
+  return (
+    <div className="space-y-5">
+      {orderedGroups.map((group) => (
+        <section key={group} aria-labelledby={`menu-${group}`}>
+          <h3 id={`menu-${group}`} className="mb-3 text-sm font-semibold uppercase tracking-[0.2em] text-slate-500">
+            {group}
+          </h3>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {[...groups[group]]
+              .sort((a, b) => (a.order ?? 999) - (b.order ?? 999))
+              .map((item) => (
+                <a
+                  key={`${item.path}-${item.label}`}
+                  href={item.path}
+                  className="focus-ring rounded-xl border border-white/10 bg-slate-950/60 p-4 transition hover:border-teal-300/40 hover:bg-slate-900"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="font-medium text-white">{item.label}</p>
+                      <p className="mt-1 font-mono text-xs text-teal-200">{item.path}</p>
+                    </div>
+                    <span className="rounded-full bg-white/5 px-2 py-1 text-xs text-slate-400">#{item.order ?? 999}</span>
+                  </div>
+                  <p className="mt-3 text-xs text-slate-500">
+                    {item.sourceName ? `${item.source ?? 'source'}:${item.sourceName}` : item.source ?? 'route'}
+                  </p>
+                </a>
+              ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/NavSidebar.tsx
+++ b/frontend/src/components/NavSidebar.tsx
@@ -1,0 +1,42 @@
+import { NavLink } from 'react-router-dom';
+
+export type NavItem = {
+  to: string;
+  label: string;
+  description: string;
+  badge?: string | number;
+};
+
+function navClass({ isActive }: { isActive: boolean }) {
+  const base = 'focus-ring rounded-2xl border px-4 py-3 text-left transition';
+  if (isActive) return `${base} border-teal-300/40 bg-teal-300/10 text-white shadow-lg shadow-teal-950/20`;
+  return `${base} border-white/10 bg-white/[0.03] text-slate-300 hover:border-teal-300/30 hover:bg-slate-900`;
+}
+
+export function NavSidebar({ items }: { items: NavItem[] }) {
+  return (
+    <aside className="lg:sticky lg:top-4 lg:h-[calc(100vh-2rem)]">
+      <div className="flex h-full flex-col gap-5 rounded-3xl border border-white/10 bg-slate-950/80 p-4 shadow-2xl shadow-black/20">
+        <NavLink to="/menu" className="focus-ring rounded-2xl p-2">
+          <p className="text-xs font-medium uppercase tracking-[0.28em] text-teal-300">Arra Oracle</p>
+          <h1 className="mt-2 text-2xl font-bold tracking-tight text-white">Control Surface</h1>
+          <p className="mt-2 text-sm text-slate-500">React routes over the Elysia API.</p>
+        </NavLink>
+
+        <nav aria-label="Frontend sections" className="grid gap-2 sm:grid-cols-2 lg:grid-cols-1">
+          {items.map((item) => (
+            <NavLink key={item.to} to={item.to} className={navClass}>
+              <span className="flex items-center justify-between gap-3">
+                <span className="font-semibold">{item.label}</span>
+                {item.badge !== undefined ? (
+                  <span className="rounded-full bg-white/10 px-2 py-1 text-xs text-slate-300">{item.badge}</span>
+                ) : null}
+              </span>
+              <span className="mt-1 block text-xs leading-5 text-slate-500">{item.description}</span>
+            </NavLink>
+          ))}
+        </nav>
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/components/PluginList.tsx
+++ b/frontend/src/components/PluginList.tsx
@@ -1,0 +1,53 @@
+import { surfacesFor } from '../plugin-surfaces';
+import type { PluginEntry } from '../types';
+import { Badge } from './Badge';
+import { EmptyState } from './EmptyState';
+
+export function PluginList({ plugins }: { plugins: PluginEntry[] }) {
+  if (!plugins.length) return <EmptyState text="No plugins registered in /api/plugins." />;
+
+  return (
+    <div className="grid gap-4">
+      {plugins.map((plugin) => {
+        const surfaces = surfacesFor(plugin);
+        return (
+          <article key={plugin.name} className="rounded-2xl border border-white/10 bg-slate-950/60 p-5">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h3 className="text-lg font-semibold text-white">{plugin.name}</h3>
+                <p className="mt-1 text-sm text-slate-400">{plugin.description ?? 'No description supplied.'}</p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {surfaces.length ? surfaces.map((surface) => <Badge key={surface}>{surface}</Badge>) : <Badge>metadata</Badge>}
+              </div>
+            </div>
+            <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-2">
+              <div>
+                <dt className="text-slate-500">Version</dt>
+                <dd className="font-mono text-slate-200">{plugin.version ?? 'unknown'}</dd>
+              </div>
+              <div>
+                <dt className="text-slate-500">Artifact</dt>
+                <dd className="font-mono text-slate-200">{plugin.file || 'server-only'}</dd>
+              </div>
+              {plugin.server ? (
+                <div className="sm:col-span-2">
+                  <dt className="text-slate-500">Server</dt>
+                  <dd className="font-mono text-slate-200">
+                    {plugin.server.command} {(plugin.server.args ?? []).join(' ')} · {plugin.server.healthPath ?? '/health'}
+                  </dd>
+                </div>
+              ) : null}
+              {plugin.mcpTools?.length ? (
+                <div className="sm:col-span-2">
+                  <dt className="text-slate-500">MCP tools</dt>
+                  <dd className="font-mono text-slate-200">{plugin.mcpTools.length}</dd>
+                </div>
+              ) : null}
+            </dl>
+          </article>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/StatCard.tsx
+++ b/frontend/src/components/StatCard.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from 'react';
+
+export function StatCard({ label, value, detail }: { label: string; value: ReactNode; detail: string }) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-4 shadow-xl shadow-black/10">
+      <p className="text-xs font-medium uppercase tracking-[0.2em] text-slate-500">{label}</p>
+      <p className="mt-2 text-3xl font-semibold text-white">{value}</p>
+      <p className="mt-1 text-sm text-slate-400">{detail}</p>
+    </div>
+  );
+}

--- a/frontend/src/pages/McpPage.tsx
+++ b/frontend/src/pages/McpPage.tsx
@@ -1,0 +1,5 @@
+import { McpToolBrowser } from '../components/McpToolBrowser';
+
+export function McpPage() {
+  return <McpToolBrowser />;
+}

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -1,0 +1,13 @@
+import { LoadingPanel } from '../components/AsyncState';
+import { MenuViewer } from '../components/MenuViewer';
+import type { MenuItem } from '../types';
+
+export function MenuPage({ items, loading }: { items: MenuItem[]; loading: boolean }) {
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="menu-page-title">
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Menu</p>
+      <h2 id="menu-page-title" className="mt-2 mb-4 text-2xl font-semibold text-white">Menu viewer</h2>
+      {loading ? <LoadingPanel title="Loading menu items…" detail="Fetching /api/menu from the Elysia backend." /> : <MenuViewer items={items} />}
+    </section>
+  );
+}

--- a/frontend/src/pages/PluginsPage.tsx
+++ b/frontend/src/pages/PluginsPage.tsx
@@ -1,0 +1,13 @@
+import { LoadingPanel } from '../components/AsyncState';
+import { PluginList } from '../components/PluginList';
+import type { PluginEntry } from '../types';
+
+export function PluginsPage({ plugins, loading }: { plugins: PluginEntry[]; loading: boolean }) {
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="plugins-page-title">
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Plugins</p>
+      <h2 id="plugins-page-title" className="mt-2 mb-4 text-2xl font-semibold text-white">Plugin list</h2>
+      {loading ? <LoadingPanel title="Loading plugins…" detail="Fetching /api/plugins and plugin server manifests." /> : <PluginList plugins={plugins} />}
+    </section>
+  );
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,41 @@
+type SettingsPageProps = {
+  menuCount: number;
+  pluginCount: number;
+  surfaceCount: number;
+  updatedAt: string;
+  onRefresh: () => void;
+};
+
+function SettingCard({ label, value, detail }: { label: string; value: string | number; detail: string }) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+      <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">{label}</dt>
+      <dd className="mt-2 font-mono text-sm text-teal-200">{value}</dd>
+      <dd className="mt-2 text-sm leading-6 text-slate-400">{detail}</dd>
+    </div>
+  );
+}
+
+export function SettingsPage({ menuCount, pluginCount, surfaceCount, updatedAt, onRefresh }: SettingsPageProps) {
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="settings-page-title">
+      <div className="mb-5 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-300">Settings</p>
+          <h2 id="settings-page-title" className="mt-2 text-2xl font-semibold text-white">Frontend runtime</h2>
+          <p className="mt-2 text-sm text-slate-400">Read-only implementation notes for this routed control surface.</p>
+        </div>
+        <button className="focus-ring rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-teal-300/40" type="button" onClick={onRefresh}>
+          Refresh backend data
+        </button>
+      </div>
+
+      <dl className="grid gap-4 md:grid-cols-2">
+        <SettingCard label="API proxy" value="/api/* → :47778" detail="Vite forwards same-origin frontend API calls to the Elysia backend during local development." />
+        <SettingCard label="Routes" value="/menu /plugins /vector /mcp /settings" detail="React Router owns client-side navigation while backend endpoints stay canonical." />
+        <SettingCard label="Loaded rows" value={`${menuCount} menu · ${pluginCount} plugins`} detail={`Last refreshed ${updatedAt}; use refresh after backend changes.`} />
+        <SettingCard label="Plugin surfaces" value={surfaceCount} detail="Counts wasm, menu, server, and MCP surfaces exposed by registered plugin metadata." />
+      </dl>
+    </section>
+  );
+}

--- a/frontend/src/pages/VectorPage.tsx
+++ b/frontend/src/pages/VectorPage.tsx
@@ -1,0 +1,5 @@
+import { VectorSearchWidget } from '../components/VectorSearchWidget';
+
+export function VectorPage() {
+  return <VectorSearchWidget />;
+}

--- a/frontend/src/plugin-surfaces.ts
+++ b/frontend/src/plugin-surfaces.ts
@@ -1,0 +1,16 @@
+import type { PluginEntry } from './types';
+
+export type Surface = 'wasm' | 'menu' | 'server' | 'mcp';
+
+export function surfacesFor(plugin: PluginEntry): Surface[] {
+  const surfaces: Surface[] = [];
+  if (plugin.file) surfaces.push('wasm');
+  if (plugin.menu) surfaces.push('menu');
+  if (plugin.server) surfaces.push('server');
+  if (plugin.mcpTools?.length) surfaces.push('mcp');
+  return surfaces;
+}
+
+export function countPluginSurfaces(plugins: PluginEntry[]): number {
+  return plugins.reduce((total, plugin) => total + Math.max(1, surfacesFor(plugin).length), 0);
+}


### PR DESCRIPTION
## Summary
- Rebuild the frontend routing work cleanly from current alpha after stale #1497 was closed
- Add React Router routes for /menu, /plugins, /vector, /mcp, and /settings
- Introduce a responsive nav sidebar and shared AppShell using alpha's AsyncState loading/error components
- Split existing menu/plugin UI into route-safe reusable components and keep Vector/MCP widgets wired into pages

## Verification
- cd frontend && bun run build
- tsc --noEmit
- git diff --check
- wc -l DESIGN.md frontend/package.json frontend/src/App.tsx frontend/src/components/AppShell.tsx frontend/src/components/Badge.tsx frontend/src/components/EmptyState.tsx frontend/src/components/MenuViewer.tsx frontend/src/components/NavSidebar.tsx frontend/src/components/PluginList.tsx frontend/src/components/StatCard.tsx frontend/src/pages/McpPage.tsx frontend/src/pages/MenuPage.tsx frontend/src/pages/PluginsPage.tsx frontend/src/pages/SettingsPage.tsx frontend/src/pages/VectorPage.tsx frontend/src/plugin-surfaces.ts

## Notes
- Original remote agents/arra-codex-7 branch was not fast-forwardable after #1497 closed; this uses a fresh codex-7 rebuild head to avoid force-push.
- No backend route changes in this PR.