### PR TITLE
Add runtime settings page

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { McpToolsResponse, MenuResponse, PluginsResponse, SearchResponse } from './types';
+import type { McpToolsResponse, MenuResponse, PluginsResponse, SearchResponse, SettingsSystemResponse } from './types';
 
 export class ApiError extends Error {
   constructor(readonly status: number, message: string) {
@@ -64,4 +64,8 @@ export async function fetchMcpTools(): Promise<McpToolsResponse> {
     tools: Array.isArray(data.tools) ? data.tools : [],
     total: Number.isFinite(data.total) ? data.total : 0,
   };
+}
+
+export async function fetchSettingsSystem(): Promise<SettingsSystemResponse> {
+  return getJson<SettingsSystemResponse>('/api/settings/system');
 }

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -29,7 +29,7 @@ export function AppShell({
     { to: '/plugins', label: 'Plugins', description: 'Registered plugins and surfaces', badge: loading ? '…' : pluginCount },
     { to: '/vector', label: 'Vector', description: 'Semantic search over memory' },
     { to: '/mcp', label: 'MCP', description: 'Tool schemas and groups' },
-    { to: '/settings', label: 'Settings', description: 'Frontend/API runtime notes' },
+    { to: '/settings', label: 'Settings', description: 'Storage, embedder, and DB status' },
   ];
   const retry = (
     <button className="focus-ring rounded-lg border border-red-200/30 px-3 py-2 font-semibold text-red-50 hover:bg-red-200/10" type="button" onClick={onRefresh}>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,3 +1,8 @@
+import { useEffect, useState, type ReactNode } from 'react';
+import { fetchSettingsSystem } from '../api';
+import { ErrorMessage, LoadingPanel, Spinner } from '../components/AsyncState';
+import type { SettingsSystemResponse } from '../types';
+
 type SettingsPageProps = {
   menuCount: number;
   pluginCount: number;
@@ -10,32 +15,120 @@ function SettingCard({ label, value, detail }: { label: string; value: string | 
   return (
     <div className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
       <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">{label}</dt>
-      <dd className="mt-2 font-mono text-sm text-teal-200">{value}</dd>
+      <dd className="mt-2 break-words font-mono text-sm text-teal-200">{value}</dd>
       <dd className="mt-2 text-sm leading-6 text-slate-400">{detail}</dd>
     </div>
   );
 }
 
-export function SettingsPage({ menuCount, pluginCount, surfaceCount, updatedAt, onRefresh }: SettingsPageProps) {
+function Section({ title, children }: { title: string; children: ReactNode }) {
   return (
-    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="settings-page-title">
-      <div className="mb-5 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-300">Settings</p>
-          <h2 id="settings-page-title" className="mt-2 text-2xl font-semibold text-white">Frontend runtime</h2>
-          <p className="mt-2 text-sm text-slate-400">Read-only implementation notes for this routed control surface.</p>
-        </div>
-        <button className="focus-ring rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-teal-300/40" type="button" onClick={onRefresh}>
-          Refresh backend data
-        </button>
-      </div>
-
-      <dl className="grid gap-4 md:grid-cols-2">
-        <SettingCard label="API proxy" value="/api/* → :47778" detail="Vite forwards same-origin frontend API calls to the Elysia backend during local development." />
-        <SettingCard label="Routes" value="/menu /plugins /vector /mcp /settings" detail="React Router owns client-side navigation while backend endpoints stay canonical." />
-        <SettingCard label="Loaded rows" value={`${menuCount} menu · ${pluginCount} plugins`} detail={`Last refreshed ${updatedAt}; use refresh after backend changes.`} />
-        <SettingCard label="Plugin surfaces" value={surfaceCount} detail="Counts wasm, menu, server, and MCP surfaces exposed by registered plugin metadata." />
-      </dl>
+    <section className="rounded-2xl border border-white/10 bg-white/[0.03] p-4" aria-label={title}>
+      <h3 className="mb-3 text-lg font-semibold text-white">{title}</h3>
+      {children}
     </section>
+  );
+}
+
+function statusLabel(settings: SettingsSystemResponse) {
+  const { migrations } = settings;
+  if (!migrations.tablePresent) return 'migration table missing';
+  return migrations.status === 'current' ? 'current' : `${migrations.pendingCount} pending`;
+}
+
+export function SettingsPage({ menuCount, pluginCount, surfaceCount, updatedAt, onRefresh }: SettingsPageProps) {
+  const [settings, setSettings] = useState<SettingsSystemResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  async function loadSystemSettings() {
+    setLoading(true);
+    setError('');
+    try {
+      setSettings(await fetchSettingsSystem());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { void loadSystemSettings(); }, []);
+
+  const refreshAll = () => {
+    onRefresh();
+    void loadSystemSettings();
+  };
+
+  return (
+    <div className="grid gap-5">
+      <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="settings-page-title">
+        <div className="mb-5 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-300">Settings</p>
+            <h2 id="settings-page-title" className="mt-2 text-2xl font-semibold text-white">Runtime configuration</h2>
+            <p className="mt-2 text-sm text-slate-400">Storage backend, embedder configuration, and Drizzle migration status.</p>
+          </div>
+          <button className="focus-ring rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-teal-300/40" type="button" onClick={refreshAll}>
+            {loading ? <Spinner label="Refreshing" /> : 'Refresh settings'}
+          </button>
+        </div>
+
+        <dl className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <SettingCard label="API proxy" value="/api/* → :47778" detail="Vite forwards same-origin calls to the Elysia backend in development." />
+          <SettingCard label="Frontend rows" value={`${menuCount} menu · ${pluginCount} plugins`} detail={`Last refreshed ${updatedAt}; use refresh after backend changes.`} />
+          <SettingCard label="Plugin surfaces" value={surfaceCount} detail="Counts wasm, menu, server, and MCP surfaces exposed by plugin metadata." />
+          <SettingCard label="Client routes" value="/menu /plugins /vector /mcp /settings" detail="React Router owns client navigation while backend endpoints stay canonical." />
+        </dl>
+      </section>
+
+      {loading && !settings ? <LoadingPanel title="Loading settings…" detail="Fetching /api/settings/system." /> : null}
+      {error ? <ErrorMessage title="Could not load runtime settings." message={error} /> : null}
+      {settings ? <RuntimeSettings settings={settings} /> : null}
+    </div>
+  );
+}
+
+function RuntimeSettings({ settings }: { settings: SettingsSystemResponse }) {
+  const { storage, embedder, migrations } = settings;
+  return (
+    <div className="grid gap-5 xl:grid-cols-3">
+      <Section title="Storage backend">
+        <dl className="grid gap-3 text-sm">
+          <SettingCard label="Active" value={storage.activeBackend} detail={`Configured ${storage.configuredBackend}; default ${storage.defaultBackend}.`} />
+          <SettingCard label="Database" value={storage.dbPath} detail={`Data directory: ${storage.dataDir}`} />
+          <SettingCard label="Repo root" value={storage.repoRoot} detail="Resolved runtime project root used by storage config." />
+        </dl>
+      </Section>
+
+      <Section title="Embedder">
+        <dl className="grid gap-3 text-sm">
+          <SettingCard label="Backend" value={embedder.backend} detail={`Model ${embedder.model ?? 'none'}; dimensions ${embedder.dimensions ?? 'unknown'}.`} />
+          <SettingCard label="Source" value={embedder.source} detail={`URL ${embedder.url ?? 'not configured'}; endpoint ${embedder.embeddingEndpoint || 'disabled'}.`} />
+          <SettingCard label="Collections" value={embedder.collections.length} detail="Vector collection entries derived from vector-server config or defaults." />
+        </dl>
+      </Section>
+
+      <Section title="DB migrations">
+        <dl className="grid gap-3 text-sm">
+          <SettingCard label="Status" value={statusLabel(settings)} detail={`${migrations.appliedCount}/${migrations.availableCount} migrations applied.`} />
+          <SettingCard label="Latest known" value={migrations.latestKnown ?? 'none'} detail={`Latest applied at ${migrations.latestAppliedAt ?? 'not recorded'}.`} />
+        </dl>
+      </Section>
+
+      <section className="rounded-2xl border border-white/10 bg-white/[0.03] p-4 xl:col-span-3" aria-label="Vector collections">
+        <h3 className="mb-3 text-lg font-semibold text-white">Vector collections</h3>
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {embedder.collections.map((collection) => (
+            <div key={collection.key} className="rounded-xl border border-white/10 bg-slate-950/60 p-4 text-sm">
+              <p className="font-mono text-teal-200">{collection.key}</p>
+              <p className="mt-2 text-slate-300">{collection.collection}</p>
+              <p className="mt-1 text-slate-500">{collection.provider} · {collection.model} · {collection.adapter ?? 'adapter default'}</p>
+              {collection.primary ? <p className="mt-2 text-xs font-semibold uppercase tracking-[0.18em] text-purple-300">Primary</p> : null}
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
   );
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -84,4 +84,49 @@ export interface McpToolsResponse {
   total: number;
 }
 
+
+export interface SettingsStorageConfig {
+  activeBackend: string;
+  configuredBackend: string;
+  defaultBackend: string;
+  dbPath: string;
+  dataDir: string;
+  repoRoot: string;
+}
+
+export interface SettingsEmbedderCollection {
+  key: string;
+  collection: string;
+  model: string;
+  provider: string;
+  adapter?: string;
+  primary?: boolean;
+}
+
+export interface SettingsEmbedderConfig {
+  source: string;
+  backend: string;
+  model: string | null;
+  url: string | null;
+  dimensions: number | null;
+  embeddingEndpoint: string;
+  collections: SettingsEmbedderCollection[];
+}
+
+export interface SettingsMigrationStatus {
+  status: 'current' | 'pending';
+  tablePresent: boolean;
+  appliedCount: number;
+  availableCount: number;
+  pendingCount: number;
+  latestKnown: string | null;
+  latestAppliedAt: string | null;
+}
+
+export interface SettingsSystemResponse {
+  storage: SettingsStorageConfig;
+  embedder: SettingsEmbedderConfig;
+  migrations: SettingsMigrationStatus;
+}
+
 export type LoadState = 'idle' | 'loading' | 'ready' | 'error';

--- a/src/routes/settings/index.ts
+++ b/src/routes/settings/index.ts
@@ -2,6 +2,7 @@ import { Elysia } from 'elysia';
 import { SESSION_COOKIE_NAME, isAuthenticated } from '../auth/index.ts';
 import { getSettingsRoute } from './get.ts';
 import { updateSettingsRoute } from './update.ts';
+import { systemSettingsRoute } from './system.ts';
 
 export const settingsRoutes = new Elysia({ prefix: '/api/settings' })
   .onBeforeHandle(({ server, request, cookie, set }) => {
@@ -12,6 +13,7 @@ export const settingsRoutes = new Elysia({ prefix: '/api/settings' })
     }
   })
   .use(getSettingsRoute)
+  .use(systemSettingsRoute)
   .use(updateSettingsRoute);
 
 export * from './model.ts';

--- a/src/routes/settings/system.ts
+++ b/src/routes/settings/system.ts
@@ -1,0 +1,91 @@
+import { Elysia } from 'elysia';
+import { desc } from 'drizzle-orm';
+import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { DB_PATH, ORACLE_DATA_DIR, REPO_ROOT } from '../../config.ts';
+import { db, storage } from '../../db/index.ts';
+import { DEFAULT_STORAGE_BACKEND, loadStorageConfig } from '../../storage/config.ts';
+import { configPath, generateDefaultConfig, loadVectorConfig } from '../../vector/config.ts';
+
+type JournalEntry = { tag: string; when?: number };
+const drizzleMigrations = sqliteTable('__drizzle_migrations', {
+  hash: text('hash'),
+  createdAt: integer('created_at'),
+});
+
+type MigrationRow = { hash: string | null; createdAt: number | null };
+
+const MIGRATIONS_DIR = join(import.meta.dirname, '..', '..', 'db', 'migrations');
+const JOURNAL_PATH = join(MIGRATIONS_DIR, 'meta', '_journal.json');
+
+function readJournal(): JournalEntry[] {
+  if (!existsSync(JOURNAL_PATH)) return [];
+  try {
+    const raw = JSON.parse(readFileSync(JOURNAL_PATH, 'utf8')) as { entries?: JournalEntry[] };
+    return Array.isArray(raw.entries) ? raw.entries : [];
+  } catch {
+    return [];
+  }
+}
+
+function appliedMigrations(): { rows: MigrationRow[]; tablePresent: boolean } {
+  try {
+    const rows = db
+      .select({ hash: drizzleMigrations.hash, createdAt: drizzleMigrations.createdAt })
+      .from(drizzleMigrations)
+      .orderBy(desc(drizzleMigrations.createdAt))
+      .all() as MigrationRow[];
+    return { rows, tablePresent: true };
+  } catch {
+    return { rows: [], tablePresent: false };
+  }
+}
+
+function migrationStatus() {
+  const journal = readJournal();
+  const applied = appliedMigrations();
+  const pendingCount = Math.max(0, journal.length - applied.rows.length);
+  const latestApplied = applied.rows[0];
+  return {
+    status: applied.tablePresent && pendingCount === 0 ? 'current' : 'pending',
+    tablePresent: applied.tablePresent,
+    appliedCount: applied.rows.length,
+    availableCount: journal.length,
+    pendingCount,
+    latestKnown: journal.at(-1)?.tag ?? null,
+    latestAppliedAt: latestApplied?.createdAt ? new Date(latestApplied.createdAt).toISOString() : null,
+  };
+}
+
+export const systemSettingsRoute = new Elysia().get('/system', () => {
+  const storageConfig = loadStorageConfig({ repoRoot: REPO_ROOT, dataDir: ORACLE_DATA_DIR });
+  const vectorFromDisk = loadVectorConfig();
+  const vectorConfig = vectorFromDisk ?? generateDefaultConfig();
+  return {
+    storage: {
+      activeBackend: storage.name,
+      configuredBackend: storageConfig.backend,
+      defaultBackend: DEFAULT_STORAGE_BACKEND,
+      dbPath: DB_PATH,
+      dataDir: ORACLE_DATA_DIR,
+      repoRoot: REPO_ROOT,
+    },
+    embedder: {
+      source: vectorFromDisk ? configPath() : 'defaults',
+      backend: vectorConfig.embedder?.backend ?? 'none',
+      model: vectorConfig.embedder?.model ?? null,
+      url: vectorConfig.embedder?.url ?? null,
+      dimensions: vectorConfig.embedder?.dimensions ?? null,
+      embeddingEndpoint: vectorConfig.embeddingEndpoint,
+      collections: Object.entries(vectorConfig.collections).map(([key, value]) => ({ key, ...value })),
+    },
+    migrations: migrationStatus(),
+  };
+}, {
+  detail: {
+    tags: ['settings'],
+    menu: { group: 'hidden' },
+    summary: 'Runtime storage, embedder, and migration status',
+  },
+});

--- a/tests/http/settings/system.test.ts
+++ b/tests/http/settings/system.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from 'bun:test';
+import { systemSettingsRoute } from '../../../src/routes/settings/system.ts';
+
+test('GET /system returns runtime storage, embedder, and migration status', async () => {
+  const res = await systemSettingsRoute.handle(new Request('http://local/system'));
+  expect(res.status).toBe(200);
+  const body = await res.json() as Record<string, any>;
+  expect(body.storage.activeBackend).toBeTruthy();
+  expect(body.storage.dbPath).toContain('oracle.db');
+  expect(body.embedder.backend).toBeTruthy();
+  expect(Array.isArray(body.embedder.collections)).toBe(true);
+  expect(body.migrations.availableCount).toBeGreaterThan(0);
+  expect(body.migrations.status).toMatch(/current|pending/);
+});


### PR DESCRIPTION
## Summary
- add a settings system endpoint for storage backend, embedder config, and Drizzle migration status
- render runtime settings on the routed React Settings page
- cover the settings system endpoint with a fetch-based Bun test

## Verification
- bun test tests/http/settings/
- cd frontend && bun run build
- bun run build
- git diff --check
- touched files <= 250 lines

Note: normal push to agents/arra-codex-2 was rejected as non-fast-forward after the required reset, so this PR uses a fresh non-force branch.