### PR TITLE
Add live unified plugin e2e schema test

### DIFF
--- a/src/routes/plugins/model.ts
+++ b/src/routes/plugins/model.ts
@@ -72,8 +72,9 @@ export function readPluginManifest(dir: string): RawPluginManifest | null {
 }
 
 function parseMenu(raw: unknown): PluginMenu | undefined {
-  if (!raw || typeof raw !== 'object') return undefined;
-  const m = raw as Record<string, unknown>;
+  const candidate = Array.isArray(raw) ? raw[0] : raw;
+  if (!candidate || typeof candidate !== 'object') return undefined;
+  const m = candidate as Record<string, unknown>;
   if (typeof m.label !== 'string' || !m.label) return undefined;
   const group =
     m.group === 'main' || m.group === 'tools' || m.group === 'hidden' ? m.group : undefined;

--- a/src/routes/vector/index.ts
+++ b/src/routes/vector/index.ts
@@ -2,6 +2,7 @@
  * Vector Routes (Elysia) — composes the vector-only HTTP surface.
  *
  * Endpoints:
+ *   GET /api/vector/search  — vector-mode search alias
  *   GET /api/similar         — nearest-neighbor by doc id
  *   GET /api/compare         — fan-out search across embedding models
  *   GET /api/map             — 2D layout of all docs
@@ -14,6 +15,7 @@
  */
 
 import { Elysia } from 'elysia';
+import { vectorSearchEndpoint } from './search.ts';
 import { similarEndpoint } from './similar.ts';
 import { compareEndpoint } from './compare.ts';
 import { mapEndpoint } from './map.ts';
@@ -26,6 +28,7 @@ import { vectorProxyEndpoint } from './proxy.ts';
 
 export const vectorRoutes = new Elysia({ prefix: '/api' })
   .use(vectorProxyEndpoint)
+  .use(vectorSearchEndpoint)
   .use(similarEndpoint)
   .use(compareEndpoint)
   .use(mapEndpoint)

--- a/src/routes/vector/search.ts
+++ b/src/routes/vector/search.ts
@@ -1,0 +1,54 @@
+/** GET /api/vector/search — vector-mode search alias for routed vector clients. */
+import { Elysia } from 'elysia';
+import { handleSearch } from '../../server/handlers.ts';
+import { SearchQuery } from '../search/model.ts';
+
+function sanitize(query: string): string {
+  return query
+    .replace(/<[^>]*>/g, '')
+    .replace(/[\x00-\x1f]/g, '')
+    .trim();
+}
+
+export const vectorSearchEndpoint = new Elysia().get(
+  '/vector/search',
+  async ({ query, set }) => {
+    if (!query.q) {
+      set.status = 400;
+      return { error: 'Missing query parameter: q' };
+    }
+    const sanitizedQ = sanitize(query.q);
+    if (!sanitizedQ) {
+      set.status = 400;
+      return { error: 'Invalid query: empty after sanitization' };
+    }
+
+    const type = query.type ?? 'all';
+    const limit = Math.min(100, Math.max(1, parseInt(query.limit ?? '10')));
+    const offset = Math.max(0, parseInt(query.offset ?? '0'));
+    try {
+      const result = await handleSearch(
+        sanitizedQ,
+        type,
+        limit,
+        offset,
+        'vector',
+        query.project,
+        query.cwd,
+        query.model,
+      );
+      return { ...result, query: sanitizedQ };
+    } catch {
+      set.status = 400;
+      return { results: [], total: 0, query: sanitizedQ, error: 'Vector search failed' };
+    }
+  },
+  {
+    query: SearchQuery,
+    detail: {
+      tags: ['vector'],
+      menu: { group: 'hidden' },
+      summary: 'Vector-mode search under the vector route namespace',
+    },
+  },
+);

--- a/tests/e2e/unified-plugin-schema.test.ts
+++ b/tests/e2e/unified-plugin-schema.test.ts
@@ -1,0 +1,102 @@
+import { afterAll, beforeAll, expect, test } from 'bun:test';
+import { startSmokeServer, type SmokeServer } from '../smoke/_helpers.ts';
+
+type MenuItem = {
+  label: string;
+  path: string;
+  group: string;
+  order: number;
+  source: string;
+};
+
+type PluginEntry = {
+  name: string;
+  file: string;
+  size: number;
+  modified: string;
+  version?: string;
+  description?: string;
+  menu?: Record<string, unknown>;
+  server?: Record<string, unknown>;
+};
+
+type SearchBody = {
+  query: string;
+  total: number;
+  limit: number;
+  offset: number;
+  results: Array<Record<string, unknown>>;
+};
+
+let server: SmokeServer;
+
+beforeAll(async () => {
+  server = await startSmokeServer({
+    name: 'e2e-unified-plugin-schema',
+    withPlugin: true,
+    vectorResponder: (url) => ({
+      query: url.searchParams.get('q') ?? '',
+      total: 1,
+      limit: Number(url.searchParams.get('limit') ?? 1),
+      offset: 0,
+      results: [{
+        id: 'smoke-vector-doc',
+        type: 'learning',
+        content: 'Unified plugin vector search smoke result',
+        source_file: 'plugins/smoke-orbit.md',
+        concepts: ['plugin', 'smoke'],
+        source: 'vector',
+        score: 0.94,
+        project: null,
+      }],
+    }),
+  });
+});
+
+afterAll(async () => {
+  await server.stop();
+});
+
+async function getJson<T>(path: string): Promise<T> {
+  const response = await fetch(`${server.baseUrl}${path}`, { headers: { accept: 'application/json' } });
+  expect(response.status).toBe(200);
+  return response.json() as Promise<T>;
+}
+
+test('live backend responses match the unified plugin menu, registry, and vector search schema', async () => {
+  const menu = await getJson<{ items: MenuItem[] }>('/api/menu');
+  const menuItem = menu.items.find((item) => item.path === '/smoke-orbit');
+  expect(menuItem).toMatchObject({
+    label: 'Smoke Orbit',
+    group: 'tools',
+    order: 123,
+    source: 'plugin',
+  });
+
+  const registry = await getJson<{ plugins: PluginEntry[]; dir: string }>('/api/plugins');
+  expect(registry.dir).toContain('.oracle/plugins');
+  const plugin = registry.plugins.find((entry) => entry.name === 'smoke-orbit');
+  expect(plugin).toMatchObject({
+    name: 'smoke-orbit',
+    file: '',
+    size: 0,
+    version: '0.1.0',
+    description: 'Smoke fixture plugin',
+    menu: { label: 'Smoke Orbit', path: '/smoke-orbit', group: 'tools', order: 123 },
+    server: { command: 'bun', args: ['index.ts'], healthPath: '/health', autostart: false },
+  });
+  expect(Number.isNaN(Date.parse(plugin?.modified ?? ''))).toBe(false);
+  expect(plugin?.server && 'env' in plugin.server).toBe(false);
+
+  const vector = await getJson<SearchBody>('/api/vector/search?q=smoke-orbit&limit=1');
+  expect(vector).toMatchObject({ query: 'smoke-orbit', total: 1, limit: 1, offset: 0 });
+  expect(vector.results).toHaveLength(1);
+  expect(vector.results[0]).toMatchObject({
+    id: 'smoke-vector-doc',
+    type: 'learning',
+    source_file: 'plugins/smoke-orbit.md',
+    source: 'vector',
+    concepts: ['plugin', 'smoke'],
+    project: null,
+  });
+});

--- a/tests/smoke/_helpers.ts
+++ b/tests/smoke/_helpers.ts
@@ -74,7 +74,7 @@ export function writeOraclePlugin(home: string): void {
       version: '0.1.0',
       entry: './index.ts',
       description: 'Smoke fixture plugin',
-      menu: { label: 'Smoke Orbit', path: '/smoke-orbit', group: 'tools', order: 123 },
+      menu: [{ label: 'Smoke Orbit', path: '/smoke-orbit', group: 'tools', order: 123 }],
       server: { command: 'bun', args: ['index.ts'], healthPath: '/health', autostart: false },
     }, null, 2),
   );
@@ -157,7 +157,9 @@ export function startVectorStub(responder: VectorResponder): VectorStub {
     fetch(request) {
       const url = new URL(request.url);
       requests.push(url);
-      if (url.pathname === '/api/search') return Response.json(responder(url));
+      if (url.pathname === '/api/search' || url.pathname === '/api/vector/search') {
+        return Response.json(responder(url));
+      }
       if (url.pathname === '/api/vector/health') {
         return Response.json({ status: 'ok', engines: [], checked_at: new Date().toISOString() });
       }


### PR DESCRIPTION
## Summary
- add a Bun e2e test that starts the backend and fetches /api/menu, /api/plugins, and /api/vector/search
- expose /api/vector/search as a vector-mode SearchResponse alias under the vector route namespace
- let plugin registry parsing read unified menu[] manifests and update smoke fixtures to use the unified shape

## Verification
- bun test tests/e2e/
- bun test tests/smoke/plugins-api.test.ts tests/integration/frontend-proxy-unified-plugin.test.ts
- bun run build
- git diff --check
- touched files <= 250 lines

Note: normal push to agents/arra-codex-2 was rejected as non-fast-forward after the previous reset, so this PR uses a fresh non-force branch.