### PR TITLE
feat: rebuild frontend dark mode and mobile layout

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,14 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Arra Oracle Frontend</title>
+    <script>
+      try {
+        const saved = localStorage.getItem('ARRA_FRONTEND_THEME');
+        const dark = saved ? saved === 'dark' : matchMedia('(prefers-color-scheme: dark)').matches;
+        document.documentElement.classList.add(dark ? 'dark' : 'light');
+        document.documentElement.dataset.theme = dark ? 'dark' : 'light';
+      } catch { document.documentElement.classList.add('light'); }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -5,6 +5,7 @@ import { NavSidebar, type NavItem } from './NavSidebar';
 import { routeMeta } from '../routeMeta';
 import { PageChrome } from './PageChrome';
 import { StatCard } from './StatCard';
+import { ThemeToggle } from './ThemeToggle';
 
 type AppShellProps = {
   children: ReactNode;
@@ -48,23 +49,26 @@ export function AppShell({
   );
 
   return (
-    <main className="oracle-shell min-h-screen text-slate-100">
-      <div className="mx-auto grid w-full max-w-7xl gap-6 px-4 py-6 sm:px-6 lg:grid-cols-[18rem_1fr] lg:px-8">
+    <main className="oracle-shell min-h-screen text-slate-900 transition-colors dark:text-slate-100">
+      <div className="mx-auto grid w-full max-w-7xl gap-4 px-3 py-3 sm:gap-6 sm:px-6 sm:py-6 lg:grid-cols-[18rem_1fr] lg:px-8">
         <NavSidebar items={navItems} />
-        <div className="flex min-w-0 flex-col gap-6">
-          <header className="flex flex-col gap-5 rounded-3xl border border-white/10 bg-slate-950/70 p-6 shadow-2xl shadow-black/30 lg:flex-row lg:items-end lg:justify-between">
+        <div className="flex min-w-0 flex-col gap-4 sm:gap-6">
+          <header className="flex flex-col gap-5 rounded-3xl border border-slate-200 bg-white/85 p-4 shadow-2xl shadow-slate-200/60 backdrop-blur sm:p-6 lg:flex-row lg:items-end lg:justify-between dark:border-white/10 dark:bg-slate-950/70 dark:shadow-black/30">
             <PageChrome meta={meta} />
-            <button
-              className="focus-ring rounded-xl bg-teal-300 px-5 py-3 font-semibold text-slate-950 transition hover:bg-teal-200 disabled:cursor-not-allowed disabled:opacity-60"
-              disabled={loading}
-              type="button"
-              onClick={onRefresh}
-            >
-              {loading ? <Spinner label="Refreshing" /> : 'Refresh data'}
-            </button>
+            <div className="grid gap-3 sm:flex sm:items-center sm:justify-end">
+              <ThemeToggle />
+              <button
+                className="focus-ring rounded-xl bg-teal-300 px-5 py-3 font-semibold text-slate-950 transition hover:bg-teal-200 disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={loading}
+                type="button"
+                onClick={onRefresh}
+              >
+                {loading ? <Spinner label="Refreshing" /> : 'Refresh data'}
+              </button>
+            </div>
           </header>
 
-          <section className="grid gap-4 md:grid-cols-3" aria-label="Summary">
+          <section className="grid gap-3 sm:grid-cols-3 sm:gap-4" aria-label="Summary">
             <StatCard label="Menu items" value={loading ? <Spinner label="Loading" /> : menuCount} detail="from /api/menu" />
             <StatCard label="Plugins" value={loading ? <Spinner label="Loading" /> : pluginCount} detail="from /api/plugins" />
             <StatCard label="Surfaces" value={loading ? <Spinner label="Loading" /> : surfaceCount} detail={`updated ${updatedAt}`} />

--- a/frontend/src/components/NavSidebar.tsx
+++ b/frontend/src/components/NavSidebar.tsx
@@ -8,31 +8,31 @@ export type NavItem = {
 };
 
 function navClass({ isActive }: { isActive: boolean }) {
-  const base = 'focus-ring rounded-2xl border px-4 py-3 text-left transition';
-  if (isActive) return `${base} border-teal-300/40 bg-teal-300/10 text-white shadow-lg shadow-teal-950/20`;
-  return `${base} border-white/10 bg-white/[0.03] text-slate-300 hover:border-teal-300/30 hover:bg-slate-900`;
+  const base = 'focus-ring min-w-[10rem] rounded-2xl border px-4 py-3 text-left transition lg:min-w-0';
+  if (isActive) return `${base} border-teal-500/50 bg-teal-500/10 text-slate-950 shadow-lg shadow-teal-900/10 dark:border-teal-300/40 dark:bg-teal-300/10 dark:text-white dark:shadow-teal-950/20`;
+  return `${base} border-slate-200 bg-white/70 text-slate-700 hover:border-teal-500/40 hover:bg-white dark:border-white/10 dark:bg-white/[0.03] dark:text-slate-300 dark:hover:border-teal-300/30 dark:hover:bg-slate-900`;
 }
 
 export function NavSidebar({ items }: { items: NavItem[] }) {
   return (
-    <aside className="lg:sticky lg:top-4 lg:h-[calc(100vh-2rem)]">
-      <div className="flex h-full flex-col gap-5 rounded-3xl border border-white/10 bg-slate-950/80 p-4 shadow-2xl shadow-black/20">
+    <aside className="sticky top-2 z-20 lg:top-4 lg:h-[calc(100vh-2rem)]">
+      <div className="flex h-full flex-col gap-4 rounded-3xl border border-slate-200 bg-white/90 p-3 shadow-2xl shadow-slate-200/70 backdrop-blur sm:p-4 dark:border-white/10 dark:bg-slate-950/80 dark:shadow-black/20">
         <NavLink to="/menu" className="focus-ring rounded-2xl p-2">
-          <p className="text-xs font-medium uppercase tracking-[0.28em] text-teal-300">Arra Oracle</p>
-          <h1 className="mt-2 text-2xl font-bold tracking-tight text-white">Control Surface</h1>
-          <p className="mt-2 text-sm text-slate-500">React routes over the Elysia API.</p>
+          <p className="text-xs font-medium uppercase tracking-[0.28em] text-teal-700 dark:text-teal-300">Arra Oracle</p>
+          <h1 className="mt-2 text-xl font-bold tracking-tight text-slate-950 sm:text-2xl dark:text-white">Control Surface</h1>
+          <p className="mt-2 text-sm text-slate-600 dark:text-slate-500">React routes over the Elysia API.</p>
         </NavLink>
 
-        <nav aria-label="Frontend sections" className="grid gap-2 sm:grid-cols-2 lg:grid-cols-1">
+        <nav aria-label="Frontend sections" className="grid auto-cols-[minmax(10rem,1fr)] grid-flow-col gap-2 overflow-x-auto pb-1 lg:grid-flow-row lg:grid-cols-1 lg:overflow-visible lg:pb-0">
           {items.map((item) => (
             <NavLink key={item.to} to={item.to} className={navClass}>
               <span className="flex items-center justify-between gap-3">
                 <span className="font-semibold">{item.label}</span>
                 {item.badge !== undefined ? (
-                  <span className="rounded-full bg-white/10 px-2 py-1 text-xs text-slate-300">{item.badge}</span>
+                  <span className="rounded-full bg-slate-200 px-2 py-1 text-xs text-slate-600 dark:bg-white/10 dark:text-slate-300">{item.badge}</span>
                 ) : null}
               </span>
-              <span className="mt-1 block text-xs leading-5 text-slate-500">{item.description}</span>
+              <span className="mt-1 block text-xs leading-5 text-slate-500 dark:text-slate-500">{item.description}</span>
             </NavLink>
           ))}
         </nav>

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import { applyTheme, readStoredTheme, saveTheme, type ThemeMode } from '../theme';
+
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<ThemeMode>(() => readStoredTheme());
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  const next = theme === 'dark' ? 'light' : 'dark';
+
+  return (
+    <button
+      className="focus-ring rounded-xl border border-slate-300/70 bg-white/70 px-4 py-3 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-white dark:border-white/10 dark:bg-white/[0.03] dark:text-slate-200 dark:hover:border-teal-300/40"
+      type="button"
+      aria-label={`Switch to ${next} mode`}
+      onClick={() => {
+        saveTheme(next);
+        setTheme(next);
+      }}
+    >
+      {theme === 'dark' ? '☾ Dark' : '☀ Light'}
+    </button>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,9 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import './styles.css';
+import { applyTheme, readStoredTheme } from './theme';
+
+applyTheme(readStoredTheme());
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,22 +1,36 @@
 @import "tailwindcss";
+@custom-variant dark (&:where(.dark, .dark *));
 
 :root {
+  color-scheme: light;
+  background: #f8fafc;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+:root.dark {
   color-scheme: dark;
   background: #030712;
-  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
+  background: #f8fafc;
 }
 
-#root {
-  min-height: 100vh;
-}
+.dark body { background: #030712; }
+
+#root { min-height: 100vh; }
 
 .oracle-shell {
+  background:
+    radial-gradient(circle at top left, rgba(13, 148, 136, 0.14), transparent 32rem),
+    radial-gradient(circle at bottom right, rgba(124, 58, 237, 0.08), transparent 30rem),
+    #f8fafc;
+}
+
+.dark .oracle-shell {
   background:
     radial-gradient(circle at top left, rgba(45, 212, 191, 0.18), transparent 32rem),
     radial-gradient(circle at bottom right, rgba(168, 85, 247, 0.14), transparent 30rem),
@@ -24,6 +38,26 @@ body {
 }
 
 .focus-ring:focus-visible {
-  outline: 2px solid #2dd4bf;
+  outline: 2px solid #0d9488;
   outline-offset: 3px;
 }
+
+.light .border-white\/10 { border-color: rgb(203 213 225 / 0.85); }
+.light .bg-slate-950\/70,
+.light .bg-slate-950\/60,
+.light .bg-slate-950\/80 { background-color: rgb(255 255 255 / 0.86); }
+.light .bg-slate-950 { background-color: rgb(255 255 255 / 0.96); }
+.light .bg-white\/\[0\.03\],
+.light .bg-white\/\[0\.04\] { background-color: rgb(255 255 255 / 0.72); }
+.light .bg-black\/30 { background-color: rgb(15 23 42 / 0.08); }
+.light .text-white,
+.light .text-slate-100 { color: #0f172a; }
+.light .text-slate-200,
+.light .text-slate-300 { color: #334155; }
+.light .text-slate-400 { color: #475569; }
+.light .text-slate-500 { color: #64748b; }
+.light .text-teal-200,
+.light .text-teal-300 { color: #0f766e; }
+.light .text-purple-200,
+.light .text-purple-300 { color: #7e22ce; }
+.light .hover\:bg-slate-900:hover { background-color: rgb(241 245 249 / 0.95); }

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,0 +1,25 @@
+export type ThemeMode = 'light' | 'dark';
+
+export const THEME_KEY = 'ARRA_FRONTEND_THEME';
+
+function systemTheme(): ThemeMode {
+  return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+export function readStoredTheme(): ThemeMode {
+  const stored = window.localStorage.getItem(THEME_KEY);
+  return stored === 'light' || stored === 'dark' ? stored : systemTheme();
+}
+
+export function applyTheme(theme: ThemeMode) {
+  const root = document.documentElement;
+  root.classList.toggle('dark', theme === 'dark');
+  root.classList.toggle('light', theme === 'light');
+  root.dataset.theme = theme;
+  root.style.colorScheme = theme;
+}
+
+export function saveTheme(theme: ThemeMode) {
+  window.localStorage.setItem(THEME_KEY, theme);
+  applyTheme(theme);
+}


### PR DESCRIPTION
## Summary
- Rebuilt from current `origin/alpha` after stale #1506 was closed.
- Adds persisted class-based light/dark theme support with early HTML theme hydration.
- Wires Tailwind v4 dark variant through `frontend/src/styles.css` and adds a theme toggle in the app shell.
- Improves mobile layout with tighter shell spacing, responsive header actions, and sticky horizontal mobile nav.

## Verification
- `bun run --cwd frontend build`
- `tsc --noEmit`
- `git diff --check`
- Changed files all ≤250 lines
