### PR TITLE
Expand health endpoint runtime status

### DIFF
--- a/src/plugins/unified-loader.ts
+++ b/src/plugins/unified-loader.ts
@@ -35,6 +35,7 @@ export interface UnifiedLoaderOptions {
 }
 
 export interface UnifiedRuntime {
+  pluginCount?: number;
   routes: ElysiaApp[];
   mcpTools: Array<UnifiedMcpToolManifest & { plugin: string }>;
   menu: Array<UnifiedMenuManifest & { plugin: string }>;
@@ -187,7 +188,7 @@ function runtimeFrom(plugins: LoadedUnifiedPlugin[], options: UnifiedLoaderOptio
     if (!hit) return { ok: false, error: `MCP tool not found: ${name}` };
     return invoke(hit.plugin, hit.tool.handler, { source: 'mcp', plugin: hit.plugin.manifest.name, args: [args], body: args }, timeoutMs);
   };
-  return { routes, mcpTools, menu, cliSubcommands, servers, callMcpTool, stop: async () => {} };
+  return { pluginCount: plugins.length, routes, mcpTools, menu, cliSubcommands, servers, callMcpTool, stop: async () => {} };
 }
 
 export async function loadUnifiedPlugins(options: UnifiedLoaderOptions = {}): Promise<UnifiedRuntime> {

--- a/src/routes/health/health.ts
+++ b/src/routes/health/health.ts
@@ -1,18 +1,88 @@
 import { Elysia } from 'elysia';
-import { PORT } from '../../config.ts';
+import { DB_PATH, PORT } from '../../config.ts';
 import { MCP_SERVER_NAME } from '../../const.ts';
+import { db, settings } from '../../db/index.ts';
+import { scanPlugins } from '../plugins/model.ts';
+import { handleVectorHealth } from '../../server/vector-handlers.ts';
+import { mcpTools } from '../../tools/mcp-manifest.ts';
 import pkg from '../../../package.json' with { type: 'json' };
 
-export const healthEndpoint = new Elysia().get('/health', () => ({
-  status: 'ok',
-  server: MCP_SERVER_NAME,
-  version: pkg.version,
-  port: PORT,
-  oracle: 'connected',
-}), {
-  detail: {
-    tags: ['health'],
-    menu: { group: 'hidden' },
-    summary: 'Server liveness check',
-  },
-});
+type VectorHealth = Awaited<ReturnType<typeof handleVectorHealth>>;
+type DbStatus = { status: 'ok' } | { status: 'down'; error: string };
+
+export interface HealthEndpointOptions {
+  pluginCount?: number;
+  pluginMcpToolCount?: number;
+  uptimeSeconds?: () => number;
+  vectorHealth?: () => Promise<VectorHealth>;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function readDbStatus(): DbStatus {
+  try {
+    db.select({ key: settings.key }).from(settings).limit(1).all();
+    return { status: 'ok' };
+  } catch (error) {
+    return { status: 'down', error: errorMessage(error) };
+  }
+}
+
+async function readVectorStatus(check = handleVectorHealth): Promise<VectorHealth> {
+  try {
+    return await check();
+  } catch (error) {
+    return {
+      status: 'down',
+      engines: [],
+      checked_at: new Date().toISOString(),
+      error: errorMessage(error),
+    } as VectorHealth & { error: string };
+  }
+}
+
+function installedPluginCount(): number {
+  try {
+    return scanPlugins().plugins.length;
+  } catch {
+    return 0;
+  }
+}
+
+export function createHealthEndpoint(options: HealthEndpointOptions = {}) {
+  return new Elysia().get('/health', async () => {
+    const uptimeSeconds = Number(options.uptimeSeconds?.() ?? process.uptime());
+    const dbStatus = readDbStatus();
+    const vector = await readVectorStatus(options.vectorHealth);
+    const pluginCount = options.pluginCount ?? installedPluginCount();
+    const toolCount = mcpTools.length + (options.pluginMcpToolCount ?? 0);
+
+    return {
+      status: 'ok',
+      server: MCP_SERVER_NAME,
+      version: pkg.version,
+      port: Number(PORT),
+      oracle: dbStatus.status === 'ok' ? 'connected' : 'degraded',
+      uptimeSeconds: Math.round(uptimeSeconds * 1000) / 1000,
+      dbStatus: dbStatus.status,
+      vectorStatus: vector.status,
+      mcpToolCount: toolCount,
+      pluginCount,
+      uptime: { seconds: Math.round(uptimeSeconds * 1000) / 1000 },
+      db: { ...dbStatus, path: DB_PATH },
+      vector,
+      mcp: { toolCount },
+      plugins: { count: pluginCount },
+    };
+  }, {
+    detail: {
+      tags: ['health'],
+      menu: { group: 'hidden' },
+      summary: 'Server liveness, dependencies, and runtime counts',
+    },
+  });
+}
+
+export const healthEndpoint = createHealthEndpoint();

--- a/src/routes/health/index.ts
+++ b/src/routes/health/index.ts
@@ -2,11 +2,15 @@
  * Health Routes (Elysia) — /api/health, /api/stats, /api/oracles
  */
 import { Elysia } from 'elysia';
-import { healthEndpoint } from './health.ts';
+import { createHealthEndpoint, type HealthEndpointOptions } from './health.ts';
 import { statsEndpoint } from './stats.ts';
 import { oraclesEndpoint } from './oracles.ts';
 
-export const healthRoutes = new Elysia({ prefix: '/api' })
-  .use(healthEndpoint)
-  .use(statsEndpoint)
-  .use(oraclesEndpoint);
+export function createHealthRoutes(options: HealthEndpointOptions = {}) {
+  return new Elysia({ prefix: '/api' })
+    .use(createHealthEndpoint(options))
+    .use(statsEndpoint)
+    .use(oraclesEndpoint);
+}
+
+export const healthRoutes = createHealthRoutes();

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,7 +31,7 @@ import { startUnifiedPluginServers } from './plugins/unified-server.ts';
 import { authRoutes } from './routes/auth/index.ts';
 import { settingsRoutes } from './routes/settings/index.ts';
 import { feedRoutes } from './routes/feed/index.ts';
-import { healthRoutes } from './routes/health/index.ts';
+import { createHealthRoutes } from './routes/health/index.ts';
 import { dashboardRoutes } from './routes/dashboard/index.ts';
 import { searchRoutes } from './routes/search/index.ts';
 import { vectorRoutes } from './routes/vector/index.ts';
@@ -153,6 +153,11 @@ const app = new Elysia()
     docs: '/swagger',
     api: '/api',
   }));
+
+const healthRoutes = createHealthRoutes({
+  pluginCount: unifiedPlugins.pluginCount,
+  pluginMcpToolCount: unifiedPlugins.mcpTools.length,
+});
 
 const apiModules = [
   authRoutes,

--- a/tests/http/health/status.test.ts
+++ b/tests/http/health/status.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'bun:test';
+import { mcpTools } from '../../../src/tools/mcp-manifest.ts';
+import { createHealthRoutes } from '../../../src/routes/health/index.ts';
+
+test('GET /api/health reports uptime, DB, vector, MCP, and plugin status', async () => {
+  const app = createHealthRoutes({
+    pluginCount: 5,
+    pluginMcpToolCount: 2,
+    uptimeSeconds: () => 42.125,
+    vectorHealth: async () => ({
+      status: 'ok',
+      engines: [{ key: 'bge-m3', model: 'bge-m3', collection: 'oracle_knowledge_bge_m3', ok: true }],
+      checked_at: '2026-06-16T00:00:00.000Z',
+    }),
+  });
+
+  const res = await app.handle(new Request('http://local/api/health'));
+  expect(res.status).toBe(200);
+  const body = await res.json() as Record<string, any>;
+
+  expect(body.status).toBe('ok');
+  expect(body.uptimeSeconds).toBe(42.125);
+  expect(body.uptime).toEqual({ seconds: 42.125 });
+  expect(body.dbStatus).toBe('ok');
+  expect(body.db.status).toBe('ok');
+  expect(body.vectorStatus).toBe('ok');
+  expect(body.vector).toMatchObject({ status: 'ok', engines: [{ key: 'bge-m3', ok: true }] });
+  expect(body.mcpToolCount).toBe(mcpTools.length + 2);
+  expect(body.mcp.toolCount).toBe(mcpTools.length + 2);
+  expect(body.pluginCount).toBe(5);
+  expect(body.plugins.count).toBe(5);
+});


### PR DESCRIPTION
## Summary
- expand /api/health with uptime, DB status, vector status, MCP tool count, and plugin count
- pass loaded unified plugin counts from server boot into health routes
- add scoped HTTP health test under tests/http/health/

## Verification
- bun test tests/http/health/
- bun test tests/smoke/server-health-endpoint.test.ts
- bun run build
- git diff --check
- touched files <= 250 lines

Note: normal push to agents/arra-codex-2 was rejected as non-fast-forward due the stale remote branch, so this PR uses a fresh non-force branch.