### PR TITLE
feat: add frontend accessibility affordances

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, type ReactNode } from 'react';
 import { useLocation } from 'react-router-dom';
 import { ErrorMessage, Spinner } from './AsyncState';
 import { NavSidebar, type NavItem } from './NavSidebar';
@@ -29,11 +29,16 @@ export function AppShell({
   onRefresh,
 }: AppShellProps) {
   const location = useLocation();
+  const contentRef = useRef<HTMLDivElement>(null);
   const meta = useMemo(() => routeMeta(location.pathname, location.search), [location.pathname, location.search]);
 
   useEffect(() => {
     document.title = `${meta.title} · Arra Oracle`;
   }, [meta.title]);
+
+  useEffect(() => {
+    contentRef.current?.focus({ preventScroll: true });
+  }, [location.pathname, location.search]);
 
   const navItems: NavItem[] = [
     { to: '/menu', label: 'Menu', description: 'Navigation rows from /api/menu', badge: loading ? '…' : menuCount },
@@ -43,13 +48,24 @@ export function AppShell({
     { to: '/settings', label: 'Settings', description: 'Storage, embedder, and DB status' },
   ];
   const retry = (
-    <button className="focus-ring rounded-lg border border-red-200/30 px-3 py-2 font-semibold text-red-50 hover:bg-red-200/10" type="button" onClick={onRefresh}>
+    <button
+      className="focus-ring rounded-lg border border-red-200/30 px-3 py-2 font-semibold text-red-50 hover:bg-red-200/10"
+      type="button"
+      aria-label="Retry loading backend dashboard data"
+      onClick={onRefresh}
+    >
       Retry
     </button>
   );
 
   return (
     <main className="oracle-shell min-h-screen text-slate-900 transition-colors dark:text-slate-100">
+      <a
+        className="focus-ring sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-xl focus:bg-teal-300 focus:px-4 focus:py-3 focus:font-semibold focus:text-slate-950"
+        href="#main-content"
+      >
+        Skip to main content
+      </a>
       <div className="mx-auto grid w-full max-w-7xl gap-4 px-3 py-3 sm:gap-6 sm:px-6 sm:py-6 lg:grid-cols-[18rem_1fr] lg:px-8">
         <NavSidebar items={navItems} />
         <div className="flex min-w-0 flex-col gap-4 sm:gap-6">
@@ -61,6 +77,7 @@ export function AppShell({
                 className="focus-ring rounded-xl bg-teal-300 px-5 py-3 font-semibold text-slate-950 transition hover:bg-teal-200 disabled:cursor-not-allowed disabled:opacity-60"
                 disabled={loading}
                 type="button"
+                aria-label="Refresh menu and plugin dashboard data"
                 onClick={onRefresh}
               >
                 {loading ? <Spinner label="Refreshing" /> : 'Refresh data'}
@@ -75,7 +92,9 @@ export function AppShell({
           </section>
 
           {error ? <ErrorMessage title="Could not load backend data." message={error} action={retry} /> : null}
-          {children}
+          <div id="main-content" ref={contentRef} tabIndex={-1} className="focus:outline-none">
+            {children}
+          </div>
         </div>
       </div>
     </main>

--- a/frontend/src/components/McpToolBrowser.tsx
+++ b/frontend/src/components/McpToolBrowser.tsx
@@ -17,6 +17,7 @@ function ToolCard({ tool, onOpen }: { tool: McpTool; onOpen?: (tool: McpTool) =>
         <button
           className="focus-ring mt-4 rounded-xl border border-white/10 px-3 py-2 text-sm text-slate-200 hover:border-teal-300/40"
           type="button"
+          aria-label={`Open schema detail for ${tool.name}`}
           onClick={() => onOpen(tool)}
         >
           Open schema detail
@@ -71,6 +72,7 @@ export function McpToolBrowser({ onOpenTool }: { onOpenTool?: (tool: McpTool) =>
           className="focus-ring rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-teal-300/40 disabled:cursor-not-allowed disabled:opacity-60"
           disabled={loading}
           type="button"
+          aria-label="Reload MCP tool list"
           onClick={() => void load()}
         >
           {loading ? <Spinner label="Reloading" /> : 'Reload'}
@@ -84,6 +86,7 @@ export function McpToolBrowser({ onOpenTool }: { onOpenTool?: (tool: McpTool) =>
           onChange={(event) => setFilter(event.target.value)}
           placeholder="Filter tools, groups, descriptions…"
           type="search"
+          aria-label="Filter MCP tools"
         />
         <p className="text-sm text-slate-500">{loading ? <Spinner label="Loading tools" /> : `${visible.length}/${tools.length} tools · ${groups} groups`}</p>
       </div>
@@ -93,7 +96,7 @@ export function McpToolBrowser({ onOpenTool }: { onOpenTool?: (tool: McpTool) =>
         <ErrorMessage
           title="Could not load MCP tools."
           message={error}
-          action={<button className="focus-ring rounded-lg border border-red-200/30 px-3 py-2 font-semibold text-red-50 hover:bg-red-200/10" type="button" onClick={() => void load()}>Retry</button>}
+          action={<button className="focus-ring rounded-lg border border-red-200/30 px-3 py-2 font-semibold text-red-50 hover:bg-red-200/10" type="button" aria-label="Retry loading MCP tools" onClick={() => void load()}>Retry</button>}
         />
       ) : null}
       {state === 'ready' && !visible.length ? <p className="rounded-xl border border-dashed border-white/10 p-6 text-sm text-slate-400">No MCP tools matched.</p> : null}

--- a/frontend/src/components/NavSidebar.tsx
+++ b/frontend/src/components/NavSidebar.tsx
@@ -15,9 +15,9 @@ function navClass({ isActive }: { isActive: boolean }) {
 
 export function NavSidebar({ items }: { items: NavItem[] }) {
   return (
-    <aside className="sticky top-2 z-20 lg:top-4 lg:h-[calc(100vh-2rem)]">
+    <aside className="sticky top-2 z-20 lg:top-4 lg:h-[calc(100vh-2rem)]" aria-label="Application navigation">
       <div className="flex h-full flex-col gap-4 rounded-3xl border border-slate-200 bg-white/90 p-3 shadow-2xl shadow-slate-200/70 backdrop-blur sm:p-4 dark:border-white/10 dark:bg-slate-950/80 dark:shadow-black/20">
-        <NavLink to="/menu" className="focus-ring rounded-2xl p-2">
+        <NavLink to="/menu" className="focus-ring rounded-2xl p-2" aria-label="Arra Oracle control surface home">
           <p className="text-xs font-medium uppercase tracking-[0.28em] text-teal-700 dark:text-teal-300">Arra Oracle</p>
           <h1 className="mt-2 text-xl font-bold tracking-tight text-slate-950 sm:text-2xl dark:text-white">Control Surface</h1>
           <p className="mt-2 text-sm text-slate-600 dark:text-slate-500">React routes over the Elysia API.</p>
@@ -25,7 +25,7 @@ export function NavSidebar({ items }: { items: NavItem[] }) {
 
         <nav aria-label="Frontend sections" className="grid auto-cols-[minmax(10rem,1fr)] grid-flow-col gap-2 overflow-x-auto pb-1 lg:grid-flow-row lg:grid-cols-1 lg:overflow-visible lg:pb-0">
           {items.map((item) => (
-            <NavLink key={item.to} to={item.to} className={navClass}>
+            <NavLink key={item.to} to={item.to} className={navClass} aria-label={`${item.label}: ${item.description}`}>
               <span className="flex items-center justify-between gap-3">
                 <span className="font-semibold">{item.label}</span>
                 {item.badge !== undefined ? (

--- a/frontend/src/components/PageChrome.tsx
+++ b/frontend/src/components/PageChrome.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 import type { RouteMeta } from '../routeMeta';
 
 function BreadcrumbLink({ label, to }: { label: string; to?: string }) {
-  if (!to) return <span className="text-slate-300">{label}</span>;
+  if (!to) return <span className="text-slate-300" aria-current="page">{label}</span>;
   return <Link className="focus-ring rounded-md text-slate-500 transition hover:text-teal-200" to={to}>{label}</Link>;
 }
 

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -15,6 +15,7 @@ export function ThemeToggle() {
       className="focus-ring rounded-xl border border-slate-300/70 bg-white/70 px-4 py-3 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-white dark:border-white/10 dark:bg-white/[0.03] dark:text-slate-200 dark:hover:border-teal-300/40"
       type="button"
       aria-label={`Switch to ${next} mode`}
+      aria-pressed={theme === 'dark'}
       onClick={() => {
         saveTheme(next);
         setTheme(next);

--- a/frontend/src/components/VectorSearchWidget.tsx
+++ b/frontend/src/components/VectorSearchWidget.tsx
@@ -51,13 +51,14 @@ export function VectorSearchWidget({ onOpenResults }: { onOpenResults?: (query: 
         <p className="mt-2 text-sm text-slate-400">Semantic search against Oracle memory through the Elysia API.</p>
       </div>
 
-      <form onSubmit={onSubmit} className="flex flex-col gap-3 sm:flex-row">
+      <form onSubmit={onSubmit} className="flex flex-col gap-3 sm:flex-row" aria-label="Vector search form">
         <input
           className="focus-ring min-w-0 flex-1 rounded-xl border border-white/10 bg-slate-950 px-4 py-3 text-slate-100 placeholder:text-slate-600"
           value={query}
           onChange={(event) => setQuery(event.target.value)}
           placeholder="Search vector memory…"
           type="search"
+          aria-label="Vector search query"
         />
         <button
           className="focus-ring rounded-xl bg-teal-300 px-5 py-3 font-semibold text-slate-950 transition hover:bg-teal-200 disabled:cursor-not-allowed disabled:opacity-50"
@@ -74,6 +75,7 @@ export function VectorSearchWidget({ onOpenResults }: { onOpenResults?: (query: 
           className="focus-ring rounded-xl border border-white/10 px-3 py-2 text-sm text-slate-200 hover:border-teal-300/40 disabled:cursor-not-allowed disabled:opacity-50"
           disabled={!query.trim()}
           type="button"
+          aria-label="Open full vector search results page"
           onClick={() => onOpenResults?.(query.trim())}
         >
           Open results page
@@ -85,7 +87,7 @@ export function VectorSearchWidget({ onOpenResults }: { onOpenResults?: (query: 
           <ErrorMessage
             title="Vector search failed."
             message={error}
-            action={lastQuery ? <button className="focus-ring rounded-lg border border-red-200/30 px-3 py-2 font-semibold text-red-50 hover:bg-red-200/10" type="button" onClick={() => void runSearch(lastQuery)}>Retry search</button> : null}
+            action={lastQuery ? <button className="focus-ring rounded-lg border border-red-200/30 px-3 py-2 font-semibold text-red-50 hover:bg-red-200/10" type="button" aria-label={`Retry vector search for ${lastQuery}`} onClick={() => void runSearch(lastQuery)}>Retry search</button> : null}
           />
         </div>
       ) : null}

--- a/frontend/src/pages/McpToolDetailPage.tsx
+++ b/frontend/src/pages/McpToolDetailPage.tsx
@@ -87,8 +87,8 @@ export function McpToolDetailPage() {
           Back to MCP tools
         </Link>
       </div>
-      {state === 'loading' ? <p className="rounded-xl border border-dashed border-white/10 p-6 text-sm text-slate-400">Loading tool detail…</p> : null}
-      {state === 'error' ? <p className="rounded-xl border border-red-400/30 bg-red-950/40 p-3 text-sm text-red-100">{error}</p> : null}
+      {state === 'loading' ? <p className="rounded-xl border border-dashed border-white/10 p-6 text-sm text-slate-400" role="status">Loading tool detail…</p> : null}
+      {state === 'error' ? <p className="rounded-xl border border-red-400/30 bg-red-950/40 p-3 text-sm text-red-100" role="alert">{error}</p> : null}
       {state === 'ready' && tool ? <ToolDetail tool={tool} /> : null}
       {state === 'ready' && !tool ? <p className="rounded-xl border border-dashed border-white/10 p-6 text-sm text-slate-400">No MCP tool named {toolName}.</p> : null}
     </section>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -69,7 +69,7 @@ export function SettingsPage({ menuCount, pluginCount, surfaceCount, updatedAt, 
             <h2 id="settings-page-title" className="mt-2 text-2xl font-semibold text-white">Runtime configuration</h2>
             <p className="mt-2 text-sm text-slate-400">Storage backend, embedder configuration, and Drizzle migration status.</p>
           </div>
-          <button className="focus-ring rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-teal-300/40" type="button" onClick={refreshAll}>
+          <button className="focus-ring rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-teal-300/40" type="button" aria-label="Refresh runtime settings" onClick={refreshAll}>
             {loading ? <Spinner label="Refreshing" /> : 'Refresh settings'}
           </button>
         </div>

--- a/frontend/src/pages/VectorSearchResultsPage.tsx
+++ b/frontend/src/pages/VectorSearchResultsPage.tsx
@@ -77,21 +77,22 @@ export function VectorSearchResultsPage() {
         </Link>
       </div>
 
-      <form onSubmit={submit} className="flex flex-col gap-3 sm:flex-row">
+      <form onSubmit={submit} className="flex flex-col gap-3 sm:flex-row" aria-label="Full-page vector search form">
         <input
           className="focus-ring min-w-0 flex-1 rounded-xl border border-white/10 bg-slate-950 px-4 py-3 text-slate-100 placeholder:text-slate-600"
           value={query}
           onChange={(event) => setQuery(event.target.value)}
           placeholder="Search vector memory…"
           type="search"
+          aria-label="Vector search query"
         />
-        <button className="focus-ring rounded-xl bg-teal-300 px-5 py-3 font-semibold text-slate-950 transition hover:bg-teal-200 disabled:cursor-not-allowed disabled:opacity-50" disabled={state === 'loading' || !query.trim()} type="submit">
+        <button className="focus-ring rounded-xl bg-teal-300 px-5 py-3 font-semibold text-slate-950 transition hover:bg-teal-200 disabled:cursor-not-allowed disabled:opacity-50" disabled={state === 'loading' || !query.trim()} type="submit" aria-label="Run vector search">
           {state === 'loading' ? 'Searching…' : 'Search'}
         </button>
       </form>
 
       <p className="mt-4 text-sm text-slate-500">{status}</p>
-      {error ? <p className="mt-3 rounded-xl border border-red-400/30 bg-red-950/40 p-3 text-sm text-red-100">{error}</p> : null}
+      {error ? <p className="mt-3 rounded-xl border border-red-400/30 bg-red-950/40 p-3 text-sm text-red-100" role="alert">{error}</p> : null}
       <div className="mt-5 grid gap-3 lg:grid-cols-2">{results.map((result) => <SearchResultCard key={result.id} result={result} />)}</div>
     </section>
   );

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -2,17 +2,26 @@ export type ThemeMode = 'light' | 'dark';
 
 export const THEME_KEY = 'ARRA_FRONTEND_THEME';
 
+function browserWindow(): Window | undefined {
+  return typeof window === 'undefined' ? undefined : window;
+}
+
 function systemTheme(): ThemeMode {
-  return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  return browserWindow()?.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 }
 
 export function readStoredTheme(): ThemeMode {
-  const stored = window.localStorage.getItem(THEME_KEY);
-  return stored === 'light' || stored === 'dark' ? stored : systemTheme();
+  try {
+    const stored = browserWindow()?.localStorage.getItem(THEME_KEY);
+    return stored === 'light' || stored === 'dark' ? stored : systemTheme();
+  } catch {
+    return systemTheme();
+  }
 }
 
 export function applyTheme(theme: ThemeMode) {
-  const root = document.documentElement;
+  const root = typeof document === 'undefined' ? undefined : document.documentElement;
+  if (!root) return;
   root.classList.toggle('dark', theme === 'dark');
   root.classList.toggle('light', theme === 'light');
   root.dataset.theme = theme;
@@ -20,6 +29,9 @@ export function applyTheme(theme: ThemeMode) {
 }
 
 export function saveTheme(theme: ThemeMode) {
-  window.localStorage.setItem(THEME_KEY, theme);
-  applyTheme(theme);
+  try {
+    browserWindow()?.localStorage.setItem(THEME_KEY, theme);
+  } finally {
+    applyTheme(theme);
+  }
 }

--- a/tests/frontend/components/app-shell-skip-link.test.tsx
+++ b/tests/frontend/components/app-shell-skip-link.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+import { MemoryRouter } from 'react-router-dom';
+import { AppShell } from '../../../frontend/src/components/AppShell';
+import { htmlFor } from '../_render';
+
+describe('AppShell skip link', () => {
+  test('renders a skip link targeting focusable main content', () => {
+    const html = htmlFor(
+      <MemoryRouter initialEntries={['/menu']}>
+        <AppShell error="" loading={false} menuCount={0} pluginCount={0} surfaceCount={0} updatedAt="never" onRefresh={() => {}}>
+          <p>main body</p>
+        </AppShell>
+      </MemoryRouter>,
+    );
+    expect(html).toContain('Skip to main content');
+    expect(html).toContain('href="#main-content"');
+    expect(html).toContain('id="main-content"');
+    expect(html).toContain('tabindex="-1"');
+  });
+});

--- a/tests/frontend/components/mcp-tool-browser-filter-label.test.tsx
+++ b/tests/frontend/components/mcp-tool-browser-filter-label.test.tsx
@@ -1,0 +1,11 @@
+import { describe, expect, test } from 'bun:test';
+import { McpToolBrowser } from '../../../frontend/src/components/McpToolBrowser';
+import { htmlFor } from '../_render';
+
+describe('McpToolBrowser accessibility labels', () => {
+  test('labels tool filtering and reload controls', () => {
+    const html = htmlFor(<McpToolBrowser />);
+    expect(html).toContain('aria-label="Filter MCP tools"');
+    expect(html).toContain('aria-label="Reload MCP tool list"');
+  });
+});

--- a/tests/frontend/components/page-chrome-current-breadcrumb.test.tsx
+++ b/tests/frontend/components/page-chrome-current-breadcrumb.test.tsx
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test';
+import { MemoryRouter } from 'react-router-dom';
+import { PageChrome } from '../../../frontend/src/components/PageChrome';
+import { routeMeta } from '../../../frontend/src/routeMeta';
+import { htmlFor } from '../_render';
+
+describe('PageChrome breadcrumbs', () => {
+  test('marks the current breadcrumb for assistive tech', () => {
+    const html = htmlFor(
+      <MemoryRouter>
+        <PageChrome meta={routeMeta('/settings')} />
+      </MemoryRouter>,
+    );
+    expect(html).toContain('aria-current="page"');
+    expect(html).toContain('Settings');
+  });
+});

--- a/tests/frontend/components/vector-search-widget-labels.test.tsx
+++ b/tests/frontend/components/vector-search-widget-labels.test.tsx
@@ -1,0 +1,11 @@
+import { describe, expect, test } from 'bun:test';
+import { VectorSearchWidget } from '../../../frontend/src/components/VectorSearchWidget';
+import { htmlFor } from '../_render';
+
+describe('VectorSearchWidget accessibility labels', () => {
+  test('labels the search form and query input', () => {
+    const html = htmlFor(<VectorSearchWidget />);
+    expect(html).toContain('aria-label="Vector search form"');
+    expect(html).toContain('aria-label="Vector search query"');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds skip-to-content navigation and route-change focus handoff in the React app shell.
- Adds axe-style accessible names/states for navigation, refresh/retry buttons, theme toggle, vector search forms, and MCP tool controls.
- Marks current breadcrumbs and async detail/error states for assistive technology.
- Hardens theme helpers for SSR/static render tests where `window`/`document` may be absent.

## Verification
- `bun run --cwd frontend build`
- `tsc --noEmit`
- `bun test tests/frontend/`
- `git diff --check`
- Changed files all ≤250 lines

## Note
- Built on fresh codex-6 accessibility branch from current `origin/alpha` because the long-lived `agents/arra-codex-6` branch has stale merged history.
