### PR TITLE
feat: rebuild frontend accessibility

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, type ReactNode } from 'react';
 import { useLocation } from 'react-router-dom';
 import { ErrorMessage, Spinner } from './AsyncState';
 import { NavSidebar, type NavItem } from './NavSidebar';
@@ -30,11 +30,16 @@ export function AppShell({
   onRefresh,
 }: AppShellProps) {
   const location = useLocation();
+  const contentRef = useRef<HTMLDivElement>(null);
   const meta = useMemo(() => routeMeta(location.pathname, location.search), [location.pathname, location.search]);
 
   useEffect(() => {
     document.title = `${meta.title} · Arra Oracle`;
   }, [meta.title]);
+
+  useEffect(() => {
+    contentRef.current?.focus({ preventScroll: true });
+  }, [location.pathname, location.search]);
 
   const navItems: NavItem[] = [
     { to: '/menu', label: 'Menu', description: 'Navigation rows from /api/menu', badge: loading ? '…' : menuCount },
@@ -44,13 +49,24 @@ export function AppShell({
     { to: '/settings', label: 'Settings', description: 'Storage, embedder, and DB status' },
   ];
   const retry = (
-    <button className="focus-ring rounded-lg border border-red-200/30 px-3 py-2 font-semibold text-red-50 hover:bg-red-200/10" type="button" onClick={onRefresh}>
+    <button
+      aria-label="Retry loading backend dashboard data"
+      className="focus-ring rounded-lg border border-red-200/30 px-3 py-2 font-semibold text-red-50 hover:bg-red-200/10"
+      type="button"
+      onClick={onRefresh}
+    >
       Retry
     </button>
   );
 
   return (
     <main className="oracle-shell min-h-screen text-slate-900 transition-colors dark:text-slate-100">
+      <a
+        className="focus-ring sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-xl focus:bg-teal-300 focus:px-4 focus:py-3 focus:font-semibold focus:text-slate-950"
+        href="#main-content"
+      >
+        Skip to main content
+      </a>
       <div className="mx-auto grid w-full max-w-7xl gap-4 px-3 py-3 sm:gap-6 sm:px-6 sm:py-6 lg:grid-cols-[18rem_1fr] lg:px-8">
         <NavSidebar items={navItems} />
         <div className="flex min-w-0 flex-col gap-4 sm:gap-6">
@@ -61,6 +77,7 @@ export function AppShell({
               <div className="grid gap-3 sm:flex sm:items-center sm:justify-end">
                 <ThemeToggle />
                 <button
+                  aria-label="Refresh menu and plugin dashboard data"
                   className="focus-ring rounded-xl bg-teal-300 px-5 py-3 font-semibold text-slate-950 transition hover:bg-teal-200 disabled:cursor-not-allowed disabled:opacity-60"
                   disabled={loading}
                   type="button"
@@ -79,7 +96,9 @@ export function AppShell({
           </section>
 
           {error ? <ErrorMessage title="Could not load backend data." message={error} action={retry} /> : null}
-          {children}
+          <div id="main-content" ref={contentRef} tabIndex={-1} className="focus:outline-none">
+            {children}
+          </div>
         </div>
       </div>
     </main>

--- a/frontend/src/components/McpToolBrowser.tsx
+++ b/frontend/src/components/McpToolBrowser.tsx
@@ -15,6 +15,7 @@ function ToolCard({ tool, onOpen }: { tool: McpTool; onOpen?: (tool: McpTool) =>
       <p className="mt-3 text-sm leading-6 text-slate-400">{tool.description || 'No description supplied.'}</p>
       {onOpen ? (
         <button
+          aria-label={`Open schema detail for ${tool.name}`}
           className="focus-ring mt-4 rounded-xl border border-white/10 px-3 py-2 text-sm text-slate-200 hover:border-teal-300/40"
           type="button"
           onClick={() => onOpen(tool)}
@@ -68,6 +69,7 @@ export function McpToolBrowser({ onOpenTool }: { onOpenTool?: (tool: McpTool) =>
           <p className="mt-2 text-sm text-slate-400">Live tool schemas from /api/mcp/tools.</p>
         </div>
         <button
+          aria-label="Reload MCP tool list"
           className="focus-ring rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-teal-300/40 disabled:cursor-not-allowed disabled:opacity-60"
           disabled={loading}
           type="button"
@@ -79,6 +81,7 @@ export function McpToolBrowser({ onOpenTool }: { onOpenTool?: (tool: McpTool) =>
 
       <div className="mb-4 grid gap-3 sm:grid-cols-[1fr_auto] sm:items-center">
         <input
+          aria-label="Filter MCP tools"
           className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600"
           value={filter}
           onChange={(event) => setFilter(event.target.value)}
@@ -93,7 +96,7 @@ export function McpToolBrowser({ onOpenTool }: { onOpenTool?: (tool: McpTool) =>
         <ErrorMessage
           title="Could not load MCP tools."
           message={error}
-          action={<button className="focus-ring rounded-lg border border-red-200/30 px-3 py-2 font-semibold text-red-50 hover:bg-red-200/10" type="button" onClick={() => void load()}>Retry</button>}
+          action={<button aria-label="Retry loading MCP tools" className="focus-ring rounded-lg border border-red-200/30 px-3 py-2 font-semibold text-red-50 hover:bg-red-200/10" type="button" onClick={() => void load()}>Retry</button>}
         />
       ) : null}
       {state === 'ready' && !visible.length ? <p className="rounded-xl border border-dashed border-white/10 p-6 text-sm text-slate-400">No MCP tools matched.</p> : null}

--- a/frontend/src/components/NavSidebar.tsx
+++ b/frontend/src/components/NavSidebar.tsx
@@ -15,9 +15,9 @@ function navClass({ isActive }: { isActive: boolean }) {
 
 export function NavSidebar({ items }: { items: NavItem[] }) {
   return (
-    <aside className="sticky top-2 z-20 lg:top-4 lg:h-[calc(100vh-2rem)]">
+    <aside aria-label="Application navigation" className="sticky top-2 z-20 lg:top-4 lg:h-[calc(100vh-2rem)]">
       <div className="flex h-full flex-col gap-4 rounded-3xl border border-slate-200 bg-white/90 p-3 shadow-2xl shadow-slate-200/70 backdrop-blur sm:p-4 dark:border-white/10 dark:bg-slate-950/80 dark:shadow-black/20">
-        <NavLink to="/menu" className="focus-ring rounded-2xl p-2">
+        <NavLink to="/menu" aria-label="Arra Oracle control surface home" className="focus-ring rounded-2xl p-2">
           <p className="text-xs font-medium uppercase tracking-[0.28em] text-teal-700 dark:text-teal-300">Arra Oracle</p>
           <h1 className="mt-2 text-xl font-bold tracking-tight text-slate-950 sm:text-2xl dark:text-white">Control Surface</h1>
           <p className="mt-2 text-sm text-slate-600 dark:text-slate-500">React routes over the Elysia API.</p>
@@ -25,7 +25,7 @@ export function NavSidebar({ items }: { items: NavItem[] }) {
 
         <nav aria-label="Frontend sections" className="grid auto-cols-[minmax(10rem,1fr)] grid-flow-col gap-2 overflow-x-auto pb-1 lg:grid-flow-row lg:grid-cols-1 lg:overflow-visible lg:pb-0">
           {items.map((item) => (
-            <NavLink key={item.to} to={item.to} className={navClass}>
+            <NavLink key={item.to} to={item.to} aria-label={`${item.label}: ${item.description}`} className={navClass}>
               <span className="flex items-center justify-between gap-3">
                 <span className="font-semibold">{item.label}</span>
                 {item.badge !== undefined ? (

--- a/frontend/src/components/PageChrome.tsx
+++ b/frontend/src/components/PageChrome.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 import type { RouteMeta } from '../routeMeta';
 
 function BreadcrumbLink({ label, to }: { label: string; to?: string }) {
-  if (!to) return <span className="text-slate-300">{label}</span>;
+  if (!to) return <span className="text-slate-300" aria-current="page">{label}</span>;
   return <Link className="focus-ring rounded-md text-slate-500 transition hover:text-teal-200" to={to}>{label}</Link>;
 }
 

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -14,7 +14,8 @@ export function ThemeToggle() {
     <button
       className="focus-ring rounded-xl border border-slate-300/70 bg-white/70 px-4 py-3 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-white dark:border-white/10 dark:bg-white/[0.03] dark:text-slate-200 dark:hover:border-teal-300/40"
       type="button"
-      aria-label={`Switch to ${next} mode`}
+      aria-label="Dark mode"
+      aria-pressed={theme === 'dark'}
       onClick={() => {
         saveTheme(next);
         setTheme(next);

--- a/frontend/src/components/VectorSearchWidget.tsx
+++ b/frontend/src/components/VectorSearchWidget.tsx
@@ -51,8 +51,9 @@ export function VectorSearchWidget({ onOpenResults }: { onOpenResults?: (query: 
         <p className="mt-2 text-sm text-slate-400">Semantic search against Oracle memory through the Elysia API.</p>
       </div>
 
-      <form onSubmit={onSubmit} className="flex flex-col gap-3 sm:flex-row">
+      <form aria-label="Vector search form" onSubmit={onSubmit} className="flex flex-col gap-3 sm:flex-row">
         <input
+          aria-label="Vector search query"
           className="focus-ring min-w-0 flex-1 rounded-xl border border-white/10 bg-slate-950 px-4 py-3 text-slate-100 placeholder:text-slate-600"
           value={query}
           onChange={(event) => setQuery(event.target.value)}
@@ -71,6 +72,7 @@ export function VectorSearchWidget({ onOpenResults }: { onOpenResults?: (query: 
       <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <p className="text-sm text-slate-500">{status}</p>
         <button
+          aria-label="Open full vector search results page"
           className="focus-ring rounded-xl border border-white/10 px-3 py-2 text-sm text-slate-200 hover:border-teal-300/40 disabled:cursor-not-allowed disabled:opacity-50"
           disabled={!query.trim()}
           type="button"
@@ -85,7 +87,7 @@ export function VectorSearchWidget({ onOpenResults }: { onOpenResults?: (query: 
           <ErrorMessage
             title="Vector search failed."
             message={error}
-            action={lastQuery ? <button className="focus-ring rounded-lg border border-red-200/30 px-3 py-2 font-semibold text-red-50 hover:bg-red-200/10" type="button" onClick={() => void runSearch(lastQuery)}>Retry search</button> : null}
+            action={lastQuery ? <button aria-label={`Retry vector search for ${lastQuery}`} className="focus-ring rounded-lg border border-red-200/30 px-3 py-2 font-semibold text-red-50 hover:bg-red-200/10" type="button" onClick={() => void runSearch(lastQuery)}>Retry search</button> : null}
           />
         </div>
       ) : null}

--- a/frontend/src/pages/McpToolDetailPage.tsx
+++ b/frontend/src/pages/McpToolDetailPage.tsx
@@ -87,8 +87,8 @@ export function McpToolDetailPage() {
           Back to MCP tools
         </Link>
       </div>
-      {state === 'loading' ? <p className="rounded-xl border border-dashed border-white/10 p-6 text-sm text-slate-400">Loading tool detail…</p> : null}
-      {state === 'error' ? <p className="rounded-xl border border-red-400/30 bg-red-950/40 p-3 text-sm text-red-100">{error}</p> : null}
+      {state === 'loading' ? <p role="status" className="rounded-xl border border-dashed border-white/10 p-6 text-sm text-slate-400">Loading tool detail…</p> : null}
+      {state === 'error' ? <p role="alert" className="rounded-xl border border-red-400/30 bg-red-950/40 p-3 text-sm text-red-100">{error}</p> : null}
       {state === 'ready' && tool ? <ToolDetail tool={tool} /> : null}
       {state === 'ready' && !tool ? <p className="rounded-xl border border-dashed border-white/10 p-6 text-sm text-slate-400">No MCP tool named {toolName}.</p> : null}
     </section>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -69,7 +69,7 @@ export function SettingsPage({ menuCount, pluginCount, surfaceCount, updatedAt, 
             <h2 id="settings-page-title" className="mt-2 text-2xl font-semibold text-white">Runtime configuration</h2>
             <p className="mt-2 text-sm text-slate-400">Storage backend, embedder configuration, and Drizzle migration status.</p>
           </div>
-          <button className="focus-ring rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-teal-300/40" type="button" onClick={refreshAll}>
+          <button aria-label="Refresh runtime settings" className="focus-ring rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-teal-300/40" type="button" onClick={refreshAll}>
             {loading ? <Spinner label="Refreshing" /> : 'Refresh settings'}
           </button>
         </div>

--- a/frontend/src/pages/VectorSearchResultsPage.tsx
+++ b/frontend/src/pages/VectorSearchResultsPage.tsx
@@ -77,21 +77,22 @@ export function VectorSearchResultsPage() {
         </Link>
       </div>
 
-      <form onSubmit={submit} className="flex flex-col gap-3 sm:flex-row">
+      <form aria-label="Full-page vector search form" onSubmit={submit} className="flex flex-col gap-3 sm:flex-row">
         <input
+          aria-label="Vector search query"
           className="focus-ring min-w-0 flex-1 rounded-xl border border-white/10 bg-slate-950 px-4 py-3 text-slate-100 placeholder:text-slate-600"
           value={query}
           onChange={(event) => setQuery(event.target.value)}
           placeholder="Search vector memory…"
           type="search"
         />
-        <button className="focus-ring rounded-xl bg-teal-300 px-5 py-3 font-semibold text-slate-950 transition hover:bg-teal-200 disabled:cursor-not-allowed disabled:opacity-50" disabled={state === 'loading' || !query.trim()} type="submit">
+        <button aria-label="Run vector search" className="focus-ring rounded-xl bg-teal-300 px-5 py-3 font-semibold text-slate-950 transition hover:bg-teal-200 disabled:cursor-not-allowed disabled:opacity-50" disabled={state === 'loading' || !query.trim()} type="submit">
           {state === 'loading' ? 'Searching…' : 'Search'}
         </button>
       </form>
 
       <p className="mt-4 text-sm text-slate-500">{status}</p>
-      {error ? <p className="mt-3 rounded-xl border border-red-400/30 bg-red-950/40 p-3 text-sm text-red-100">{error}</p> : null}
+      {error ? <p role="alert" className="mt-3 rounded-xl border border-red-400/30 bg-red-950/40 p-3 text-sm text-red-100">{error}</p> : null}
       <div className="mt-5 grid gap-3 lg:grid-cols-2">{results.map((result) => <SearchResultCard key={result.id} result={result} />)}</div>
     </section>
   );

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -2,17 +2,26 @@ export type ThemeMode = 'light' | 'dark';
 
 export const THEME_KEY = 'ARRA_FRONTEND_THEME';
 
+function browserWindow(): Window | undefined {
+  return typeof window === 'undefined' ? undefined : window;
+}
+
 function systemTheme(): ThemeMode {
-  return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  return browserWindow()?.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 }
 
 export function readStoredTheme(): ThemeMode {
-  const stored = window.localStorage.getItem(THEME_KEY);
-  return stored === 'light' || stored === 'dark' ? stored : systemTheme();
+  try {
+    const stored = browserWindow()?.localStorage.getItem(THEME_KEY);
+    return stored === 'light' || stored === 'dark' ? stored : systemTheme();
+  } catch {
+    return systemTheme();
+  }
 }
 
 export function applyTheme(theme: ThemeMode) {
-  const root = document.documentElement;
+  const root = typeof document === 'undefined' ? undefined : document.documentElement;
+  if (!root) return;
   root.classList.toggle('dark', theme === 'dark');
   root.classList.toggle('light', theme === 'light');
   root.dataset.theme = theme;
@@ -20,6 +29,10 @@ export function applyTheme(theme: ThemeMode) {
 }
 
 export function saveTheme(theme: ThemeMode) {
-  window.localStorage.setItem(THEME_KEY, theme);
+  try {
+    browserWindow()?.localStorage.setItem(THEME_KEY, theme);
+  } catch {
+    // localStorage can be unavailable in privacy-restricted contexts.
+  }
   applyTheme(theme);
 }

--- a/tests/frontend/components/app-shell-retry-label.test.tsx
+++ b/tests/frontend/components/app-shell-retry-label.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+import { MemoryRouter } from 'react-router-dom';
+import { AppShell } from '../../../frontend/src/components/AppShell';
+import { htmlFor, installBrowserLocation } from '../_render';
+
+describe('AppShell retry action label', () => {
+  test('labels the backend retry control for screen readers', () => {
+    const restore = installBrowserLocation('/menu');
+    try {
+      const html = htmlFor(
+        <MemoryRouter>
+          <AppShell error="backend offline" loading={false} menuCount={0} pluginCount={0} surfaceCount={0} updatedAt="never" onRefresh={() => {}}>
+            <p />
+          </AppShell>
+        </MemoryRouter>,
+      );
+      expect(html).toContain('aria-label="Retry loading backend dashboard data"');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/tests/frontend/components/app-shell-skip-link.test.tsx
+++ b/tests/frontend/components/app-shell-skip-link.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+import { MemoryRouter } from 'react-router-dom';
+import { AppShell } from '../../../frontend/src/components/AppShell';
+import { htmlFor, installBrowserLocation } from '../_render';
+
+describe('AppShell skip link', () => {
+  test('renders a skip link targeting focusable main content', () => {
+    const restore = installBrowserLocation('/menu');
+    try {
+      const html = htmlFor(
+        <MemoryRouter initialEntries={['/menu']}>
+          <AppShell error="" loading={false} menuCount={0} pluginCount={0} surfaceCount={0} updatedAt="never" onRefresh={() => {}}>
+            <p>main body</p>
+          </AppShell>
+        </MemoryRouter>,
+      );
+      expect(html).toContain('Skip to main content');
+      expect(html).toContain('href="#main-content"');
+      expect(html).toContain('id="main-content"');
+      expect(html).toContain('tabindex="-1"');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/tests/frontend/components/mcp-tool-browser-filter-label.test.tsx
+++ b/tests/frontend/components/mcp-tool-browser-filter-label.test.tsx
@@ -1,0 +1,11 @@
+import { describe, expect, test } from 'bun:test';
+import { McpToolBrowser } from '../../../frontend/src/components/McpToolBrowser';
+import { htmlFor } from '../_render';
+
+describe('McpToolBrowser accessibility labels', () => {
+  test('labels tool filtering and reload controls', () => {
+    const html = htmlFor(<McpToolBrowser />);
+    expect(html).toContain('aria-label="Filter MCP tools"');
+    expect(html).toContain('aria-label="Reload MCP tool list"');
+  });
+});

--- a/tests/frontend/components/nav-sidebar-aria-labels.test.tsx
+++ b/tests/frontend/components/nav-sidebar-aria-labels.test.tsx
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test';
+import { MemoryRouter } from 'react-router-dom';
+import { NavSidebar } from '../../../frontend/src/components/NavSidebar';
+import { htmlFor } from '../_render';
+
+describe('NavSidebar accessibility labels', () => {
+  test('labels the navigation landmark and route links', () => {
+    const html = htmlFor(
+      <MemoryRouter>
+        <NavSidebar items={[{ to: '/menu', label: 'Menu', description: 'Navigation rows' }]} />
+      </MemoryRouter>,
+    );
+    expect(html).toContain('aria-label="Application navigation"');
+    expect(html).toContain('aria-label="Arra Oracle control surface home"');
+    expect(html).toContain('aria-label="Menu: Navigation rows"');
+  });
+});

--- a/tests/frontend/components/page-chrome-current-breadcrumb.test.tsx
+++ b/tests/frontend/components/page-chrome-current-breadcrumb.test.tsx
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test';
+import { MemoryRouter } from 'react-router-dom';
+import { PageChrome } from '../../../frontend/src/components/PageChrome';
+import { routeMeta } from '../../../frontend/src/routeMeta';
+import { htmlFor } from '../_render';
+
+describe('PageChrome breadcrumbs', () => {
+  test('marks the current breadcrumb for assistive tech', () => {
+    const html = htmlFor(
+      <MemoryRouter>
+        <PageChrome meta={routeMeta('/settings')} />
+      </MemoryRouter>,
+    );
+    expect(html).toContain('aria-current="page"');
+    expect(html).toContain('Settings');
+  });
+});

--- a/tests/frontend/components/theme-toggle-pressed.test.tsx
+++ b/tests/frontend/components/theme-toggle-pressed.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test';
+import { ThemeToggle } from '../../../frontend/src/components/ThemeToggle';
+import { THEME_KEY } from '../../../frontend/src/theme';
+import { htmlFor, installBrowserLocation } from '../_render';
+
+describe('ThemeToggle pressed state', () => {
+  test('marks dark mode as pressed for assistive tech', () => {
+    const restore = installBrowserLocation('/menu');
+    try {
+      window.localStorage.setItem(THEME_KEY, 'dark');
+      const html = htmlFor(<ThemeToggle />);
+      expect(html).toContain('aria-pressed="true"');
+      expect(html).toContain('aria-label="Dark mode"');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/tests/frontend/components/vector-search-widget-labels.test.tsx
+++ b/tests/frontend/components/vector-search-widget-labels.test.tsx
@@ -1,0 +1,11 @@
+import { describe, expect, test } from 'bun:test';
+import { VectorSearchWidget } from '../../../frontend/src/components/VectorSearchWidget';
+import { htmlFor } from '../_render';
+
+describe('VectorSearchWidget accessibility labels', () => {
+  test('labels the search form and query input', () => {
+    const html = htmlFor(<VectorSearchWidget />);
+    expect(html).toContain('aria-label="Vector search form"');
+    expect(html).toContain('aria-label="Vector search query"');
+  });
+});

--- a/tests/frontend/pages/mcp-tool-detail-loading-status.test.tsx
+++ b/tests/frontend/pages/mcp-tool-detail-loading-status.test.tsx
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { McpToolDetailPage } from '../../../frontend/src/pages/McpToolDetailPage';
+import { htmlFor } from '../_render';
+
+describe('McpToolDetailPage loading status', () => {
+  test('announces the loading state as status text', () => {
+    const html = htmlFor(
+      <MemoryRouter initialEntries={['/mcp/tools/plugin%3Aecho']}>
+        <Routes><Route path="/mcp/tools/:name" element={<McpToolDetailPage />} /></Routes>
+      </MemoryRouter>,
+    );
+    expect(html).toContain('role="status"');
+    expect(html).toContain('Loading tool detail…');
+  });
+});

--- a/tests/frontend/pages/settings-refresh-label.test.tsx
+++ b/tests/frontend/pages/settings-refresh-label.test.tsx
@@ -1,0 +1,10 @@
+import { describe, expect, test } from 'bun:test';
+import { SettingsPage } from '../../../frontend/src/pages/SettingsPage';
+import { htmlFor } from '../_render';
+
+describe('SettingsPage refresh label', () => {
+  test('labels the runtime settings refresh control', () => {
+    const html = htmlFor(<SettingsPage menuCount={0} pluginCount={0} surfaceCount={0} updatedAt="never" onRefresh={() => {}} />);
+    expect(html).toContain('aria-label="Refresh runtime settings"');
+  });
+});

--- a/tests/frontend/pages/vector-results-labels.test.tsx
+++ b/tests/frontend/pages/vector-results-labels.test.tsx
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test';
+import { MemoryRouter } from 'react-router-dom';
+import { VectorSearchResultsPage } from '../../../frontend/src/pages/VectorSearchResultsPage';
+import { htmlFor } from '../_render';
+
+describe('VectorSearchResultsPage accessibility labels', () => {
+  test('labels the full-page vector search controls', () => {
+    const html = htmlFor(<MemoryRouter initialEntries={['/vector/results']}><VectorSearchResultsPage /></MemoryRouter>);
+    expect(html).toContain('aria-label="Full-page vector search form"');
+    expect(html).toContain('aria-label="Vector search query"');
+    expect(html).toContain('aria-label="Run vector search"');
+  });
+});

--- a/tests/frontend/theme/apply-theme-no-dom.test.ts
+++ b/tests/frontend/theme/apply-theme-no-dom.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test';
+import { applyTheme } from '../../../frontend/src/theme';
+
+function withoutDocument() {
+  const previousDocument = globalThis.document;
+  Reflect.deleteProperty(globalThis, 'document');
+  return () => {
+    globalThis.document = previousDocument;
+  };
+}
+
+describe('applyTheme without document', () => {
+  test('returns safely when no document element is available', () => {
+    const restore = withoutDocument();
+    try {
+      expect(() => applyTheme('dark')).not.toThrow();
+    } finally {
+      restore();
+    }
+  });
+});

--- a/tests/frontend/theme/read-stored-theme-ssr.test.ts
+++ b/tests/frontend/theme/read-stored-theme-ssr.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test';
+import { readStoredTheme } from '../../../frontend/src/theme';
+
+function withoutBrowserGlobals() {
+  const previousWindow = globalThis.window;
+  const previousDocument = globalThis.document;
+  Reflect.deleteProperty(globalThis, 'window');
+  Reflect.deleteProperty(globalThis, 'document');
+  return () => {
+    globalThis.window = previousWindow;
+    globalThis.document = previousDocument;
+  };
+}
+
+describe('readStoredTheme without browser globals', () => {
+  test('falls back to light without throwing', () => {
+    const restore = withoutBrowserGlobals();
+    try {
+      expect(readStoredTheme()).toBe('light');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/tests/frontend/theme/read-stored-theme-storage-error.test.ts
+++ b/tests/frontend/theme/read-stored-theme-storage-error.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test';
+import { readStoredTheme } from '../../../frontend/src/theme';
+
+function withThrowingStorage() {
+  const previousWindow = globalThis.window;
+  globalThis.window = {
+    localStorage: { getItem() { throw new Error('blocked'); } },
+    matchMedia: () => ({ matches: false }),
+  } as unknown as Window & typeof globalThis;
+  return () => {
+    globalThis.window = previousWindow;
+  };
+}
+
+describe('readStoredTheme storage errors', () => {
+  test('falls back to the system theme when localStorage is blocked', () => {
+    const restore = withThrowingStorage();
+    try {
+      expect(readStoredTheme()).toBe('light');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/tests/frontend/theme/save-theme-persists.test.ts
+++ b/tests/frontend/theme/save-theme-persists.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test';
+import { saveTheme, THEME_KEY } from '../../../frontend/src/theme';
+import { installBrowserLocation } from '../_render';
+
+describe('saveTheme persistence', () => {
+  test('stores the selected theme and applies document metadata', () => {
+    const restore = installBrowserLocation('/menu');
+    try {
+      saveTheme('dark');
+      expect(window.localStorage.getItem(THEME_KEY)).toBe('dark');
+      expect(document.documentElement.dataset.theme).toBe('dark');
+      expect(document.documentElement.style.colorScheme).toBe('dark');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/tests/frontend/theme/save-theme-storage-error.test.ts
+++ b/tests/frontend/theme/save-theme-storage-error.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test';
+import { saveTheme } from '../../../frontend/src/theme';
+import { installBrowserLocation } from '../_render';
+
+describe('saveTheme storage errors', () => {
+  test('still applies the theme when localStorage is blocked', () => {
+    const restore = installBrowserLocation('/menu');
+    try {
+      Object.defineProperty(window.localStorage, 'setItem', { value: () => { throw new Error('blocked'); } });
+      expect(() => saveTheme('dark')).not.toThrow();
+      expect(document.documentElement.dataset.theme).toBe('dark');
+    } finally {
+      restore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- rebuilds the closed #1516 accessibility work on current origin/alpha
- adds skip-to-content and route focus management in AppShell
- labels navigation/search/refresh controls and announces status/error states
- hardens theme helpers for SSR/storage-restricted test contexts

## Tests
- bun run --cwd frontend build
- tsc --noEmit
- bun test tests/frontend/
- git diff --check
- changed-file wc -l check (all <=250 lines)