### PR TITLE
feat: add optional API key auth middleware

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,0 +1,60 @@
+import { timingSafeEqual } from 'crypto';
+import { Elysia } from 'elysia';
+
+const HEALTH_BYPASS_PATH = '/api/health';
+
+type AuthFailureReason = 'missing' | 'invalid';
+
+export function configuredApiKey(): string {
+  return process.env.ARRA_API_KEY?.trim() ?? '';
+}
+
+export function isApiKeyAuthEnabled(): boolean {
+  return configuredApiKey().length > 0;
+}
+
+export function isApiKeyAuthBypassed(pathname: string): boolean {
+  return pathname === HEALTH_BYPASS_PATH;
+}
+
+function safeEqual(a: string, b: string): boolean {
+  const left = Buffer.from(a);
+  const right = Buffer.from(b);
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+function bearerToken(request: Request): string {
+  const value = request.headers.get('authorization') ?? '';
+  return value.match(/^Bearer\s+(.+)$/i)?.[1]?.trim() ?? '';
+}
+
+export function isApiKeyAuthorized(request: Request): boolean {
+  const expected = configuredApiKey();
+  if (!expected) return true;
+  const token = bearerToken(request);
+  return token.length > 0 && safeEqual(token, expected);
+}
+
+export function apiKeyUnauthorizedResponse(reason: AuthFailureReason) {
+  return {
+    error: 'api_key_auth_required',
+    reason,
+    message: reason === 'missing'
+      ? 'Authorization: Bearer token required'
+      : 'Invalid API key',
+  };
+}
+
+export function createApiKeyAuthMiddleware() {
+  return new Elysia().onBeforeHandle({ as: 'global' }, ({ request, set }) => {
+    const key = configuredApiKey();
+    const pathname = new URL(request.url).pathname;
+    if (!key || isApiKeyAuthBypassed(pathname)) return;
+
+    const token = bearerToken(request);
+    if (token && safeEqual(token, key)) return;
+
+    set.status = 401;
+    return apiKeyUnauthorizedResponse(token ? 'invalid' : 'missing');
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,6 +24,7 @@ import { db, sqlite, closeDb, indexingStatus } from './db/index.ts';
 import { isApiAuthorized, isApiPathProtected, unauthorizedApiResponse } from './server/api-token-auth.ts';
 import { seedMenuItems, type HasRoutes as SeedHasRoutes } from './db/seeders/menu-seeder.ts';
 import { createCorsMiddleware, createPrivateNetworkPreflightMiddleware } from './server/cors.ts';
+import { createApiKeyAuthMiddleware } from './middleware/auth.ts';
 import { loadUnifiedPlugins, seedUnifiedPluginMenuItems } from './plugins/unified-loader.ts';
 import { startUnifiedPluginServers } from './plugins/unified-server.ts';
 
@@ -104,6 +105,7 @@ registerSignalHandlers(async () => {
 const app = new Elysia()
   .use(createPrivateNetworkPreflightMiddleware())
   .use(createCorsMiddleware())
+  .use(createApiKeyAuthMiddleware())
   .onBeforeHandle(({ request, set }) => {
     const pathname = new URL(request.url).pathname;
     if (isApiPathProtected(pathname) && !isApiAuthorized(request)) {

--- a/tests/http/auth/api-key.test.ts
+++ b/tests/http/auth/api-key.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiKeyAuthMiddleware } from '../../../src/middleware/auth.ts';
+
+const previousApiKey = process.env.ARRA_API_KEY;
+
+afterEach(() => {
+  if (previousApiKey === undefined) delete process.env.ARRA_API_KEY;
+  else process.env.ARRA_API_KEY = previousApiKey;
+});
+
+function app() {
+  return new Elysia()
+    .use(createApiKeyAuthMiddleware())
+    .get('/api/health', () => ({ status: 'ok' }))
+    .get('/api/search', () => ({ ok: true }))
+    .get('/', () => ({ ok: true }));
+}
+
+async function get(path: string, key?: string) {
+  const headers = key ? { authorization: `Bearer ${key}` } : undefined;
+  return app().handle(new Request(`http://local${path}`, { headers }));
+}
+
+describe('ARRA_API_KEY auth middleware', () => {
+  test('skips auth entirely when no API key is configured', async () => {
+    delete process.env.ARRA_API_KEY;
+
+    expect((await get('/api/search')).status).toBe(200);
+    expect((await get('/')).status).toBe(200);
+  });
+
+  test('requires a matching bearer token when API key is configured', async () => {
+    process.env.ARRA_API_KEY = 'secret';
+
+    const missing = await get('/api/search');
+    expect(missing.status).toBe(401);
+    expect(await missing.json()).toMatchObject({ error: 'api_key_auth_required', reason: 'missing' });
+
+    const invalid = await get('/api/search', 'wrong');
+    expect(invalid.status).toBe(401);
+    expect(await invalid.json()).toMatchObject({ error: 'api_key_auth_required', reason: 'invalid' });
+
+    expect((await get('/api/search', 'secret')).status).toBe(200);
+    expect((await get('/', 'secret')).status).toBe(200);
+  });
+
+  test('bypasses API key auth for /api/health', async () => {
+    process.env.ARRA_API_KEY = 'secret';
+
+    const res = await get('/api/health');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: 'ok' });
+  });
+});


### PR DESCRIPTION
## Summary
- adds src/middleware/auth.ts for optional ARRA_API_KEY bearer auth
- protects every route when ARRA_API_KEY is set, with /api/health as the bypass
- returns structured 401 JSON for missing and invalid bearer tokens
- wires the middleware into the Elysia server after CORS

## Tests
- tsc --noEmit
- bun test tests/http/auth/
- git diff --check
- changed-file wc -l check (all <=250 lines)