### PR TITLE
Add structured request logging middleware

### DIFF
--- a/src/middleware/logger.ts
+++ b/src/middleware/logger.ts
@@ -1,0 +1,94 @@
+import { randomUUID } from 'node:crypto';
+
+type RequestMeta = {
+  startedAt: number;
+  correlationId: string;
+  headers: Record<string, string>;
+};
+
+type RequestContext = {
+  request: Request;
+  set: { headers: Record<string, unknown> };
+};
+
+type AfterResponseContext = RequestContext & {
+  responseValue: unknown;
+  set: RequestContext['set'] & { status?: number | string };
+};
+
+export type RequestLogEntry = {
+  event: 'http_request';
+  method: string;
+  path: string;
+  status: number;
+  durationMs: number;
+  correlationId: string;
+  headers: Record<string, string>;
+};
+
+export type RequestLoggerOptions = {
+  log?: (entry: RequestLogEntry) => void;
+};
+
+const REDACTED = '[REDACTED]';
+const sensitiveHeaders = new Set(['authorization', 'proxy-authorization']);
+
+function nowMs(): number {
+  return performance.now();
+}
+
+function safePath(request: Request): string {
+  try {
+    return new URL(request.url).pathname;
+  } catch {
+    return request.url;
+  }
+}
+
+function redactHeaders(headers: Headers): Record<string, string> {
+  const redacted: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    const normalized = key.toLowerCase();
+    redacted[normalized] = sensitiveHeaders.has(normalized) ? REDACTED : value;
+  });
+  return redacted;
+}
+
+function requestCorrelationId(request: Request): string {
+  return request.headers.get('x-correlation-id') || request.headers.get('x-request-id') || randomUUID();
+}
+
+function responseStatus(responseValue: unknown, setStatus?: number | string): number {
+  if (responseValue instanceof Response) return responseValue.status;
+  if (typeof setStatus === 'number') return setStatus;
+  return 200;
+}
+
+export function createRequestLogger(options: RequestLoggerOptions = {}) {
+  const metaByRequest = new WeakMap<Request, RequestMeta>();
+  const log = options.log ?? ((entry: RequestLogEntry) => console.log(JSON.stringify(entry)));
+
+  return {
+    onRequest({ request, set }: RequestContext) {
+      const correlationId = requestCorrelationId(request);
+      metaByRequest.set(request, { startedAt: nowMs(), correlationId, headers: redactHeaders(request.headers) });
+      set.headers['X-Correlation-Id'] = correlationId;
+    },
+    onAfterResponse({ request, responseValue, set }: AfterResponseContext) {
+      const meta = metaByRequest.get(request);
+      const endedAt = nowMs();
+      const startedAt = meta?.startedAt ?? endedAt;
+      const durationMs = Math.max(0, Math.round((endedAt - startedAt) * 100) / 100);
+      log({
+        event: 'http_request',
+        method: request.method,
+        path: safePath(request),
+        status: responseStatus(responseValue, set.status),
+        durationMs,
+        correlationId: meta?.correlationId ?? requestCorrelationId(request),
+        headers: meta?.headers ?? redactHeaders(request.headers),
+      });
+      metaByRequest.delete(request);
+    },
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,6 +30,7 @@ import { closeCachedVectorStores } from './vector/factory.ts';
 import { isDraining, registerGracefulShutdown, trackRequest } from './lifecycle/shutdown.ts';
 import { createErrorMiddleware } from './middleware/errors.ts';
 import { validateStartupEnv } from './config/validate.ts';
+import { createRequestLogger } from './middleware/logger.ts';
 
 // Elysia sub-apps — one per cluster
 import { authRoutes } from './routes/auth/index.ts';
@@ -106,7 +107,10 @@ registerGracefulShutdown({
   },
 });
 
+const requestLogger = createRequestLogger();
+
 const app = new Elysia()
+  .onRequest(requestLogger.onRequest)
   .use(createPrivateNetworkPreflightMiddleware())
   .use(createCorsMiddleware())
   .use(createCorrelationMiddleware())
@@ -125,6 +129,7 @@ const app = new Elysia()
     set.headers['X-XSS-Protection'] = '1; mode=block';
     set.headers['Referrer-Policy'] = 'strict-origin-when-cross-origin';
   })
+  .onAfterResponse(requestLogger.onAfterResponse)
   .use(createErrorMiddleware())
   .use(
     swagger({

--- a/tests/http/logging/request-log.test.ts
+++ b/tests/http/logging/request-log.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createRequestLogger, type RequestLogEntry } from '../../../src/middleware/logger.ts';
+
+async function waitForLog(logs: string[]): Promise<string> {
+  const deadline = Date.now() + 500;
+  while (Date.now() < deadline) {
+    if (logs[0]) return logs[0];
+    await Bun.sleep(5);
+  }
+  throw new Error('request log was not emitted');
+}
+
+test('request logger emits structured JSON and redacts Authorization headers', async () => {
+  const lines: string[] = [];
+  const original = console.log;
+  console.log = (message?: unknown) => {
+    lines.push(String(message));
+  };
+
+  try {
+    const logger = createRequestLogger();
+    const app = new Elysia()
+      .onRequest(logger.onRequest)
+      .onAfterResponse(logger.onAfterResponse)
+      .get('/logged', ({ set }) => {
+        set.status = 201;
+        return { ok: true };
+      });
+
+    const response = await app.fetch(new Request('http://localhost/logged?ignored=true', {
+      headers: { authorization: 'Bearer secret-token', 'x-correlation-id': 'test-correlation-id' },
+    }));
+    expect(response.status).toBe(201);
+    expect(response.headers.get('x-correlation-id')).toBe('test-correlation-id');
+
+    const raw = await waitForLog(lines);
+    expect(raw).not.toContain('secret-token');
+    const entry = JSON.parse(raw) as RequestLogEntry;
+    expect(entry).toMatchObject({
+      event: 'http_request',
+      method: 'GET',
+      path: '/logged',
+      status: 201,
+      correlationId: 'test-correlation-id',
+      headers: { authorization: '[REDACTED]', 'x-correlation-id': 'test-correlation-id' },
+    });
+    expect(typeof entry.durationMs).toBe('number');
+    expect(entry.durationMs).toBeGreaterThanOrEqual(0);
+  } finally {
+    console.log = original;
+  }
+});


### PR DESCRIPTION
## Summary\n- add Elysia request/response logging middleware using onRequest + onAfterResponse\n- emit structured JSON logs with method, path, status, durationMs, correlationId\n- redact Authorization-style headers and wire middleware into server startup\n\n## Validation\n- bun run build\n- bun test tests/http/logging/\n- file sizes checked: logger 94, request-log test 53, server 217 lines