### PR TITLE
feat: add request correlation IDs

### DIFF
--- a/src/middleware/correlation.ts
+++ b/src/middleware/correlation.ts
@@ -1,0 +1,51 @@
+import { Elysia } from 'elysia';
+
+export const REQUEST_ID_HEADER = 'X-Request-Id';
+const LEGACY_CORRELATION_HEADER = 'x-correlation-id';
+
+const requestIds = new WeakMap<Request, string>();
+
+export type RequestCorrelationStore = {
+  requestId: string;
+};
+
+export function createRequestId(): string {
+  return crypto.randomUUID();
+}
+
+export function rememberRequestId(request: Request, requestId: string): string {
+  requestIds.set(request, requestId);
+  return requestId;
+}
+
+export function requestIdFor(request: Request): string {
+  const known = requestIds.get(request);
+  if (known) return known;
+
+  const inbound = request.headers.get(REQUEST_ID_HEADER)
+    ?? request.headers.get(LEGACY_CORRELATION_HEADER)
+    ?? createRequestId();
+  return rememberRequestId(request, inbound);
+}
+
+function setRequestIdHeader(set: { headers: Record<string, string | number> }, requestId: string) {
+  set.headers[REQUEST_ID_HEADER] = requestId;
+}
+
+export function createCorrelationMiddleware() {
+  return new Elysia({ name: 'request-correlation' })
+    .state({ requestId: '' })
+    .onRequest(({ request, set, store }) => {
+      const requestId = rememberRequestId(request, createRequestId());
+      (store as RequestCorrelationStore).requestId = requestId;
+      setRequestIdHeader(set, requestId);
+    })
+    .derive({ as: 'global' }, ({ request, store }) => {
+      const requestId = requestIdFor(request);
+      (store as RequestCorrelationStore).requestId = requestId;
+      return { requestId };
+    })
+    .onAfterHandle({ as: 'global' }, ({ request, set }) => {
+      setRequestIdHeader(set, requestIdFor(request));
+    });
+}

--- a/src/middleware/errors.ts
+++ b/src/middleware/errors.ts
@@ -1,4 +1,5 @@
 import { Elysia } from 'elysia';
+import { REQUEST_ID_HEADER, requestIdFor } from './correlation.ts';
 
 export type StructuredErrorResponse = {
   error: string;
@@ -68,19 +69,25 @@ function knownStatus(code: string, error: unknown): number {
   return 500;
 }
 
-function correlationId(request: Request): string {
-  return request.headers.get('x-correlation-id') || crypto.randomUUID();
+type ErrorLogger = (entry: { requestId: string; statusCode: number; code: string; message: string }) => void;
+
+function defaultErrorLogger(entry: { requestId: string; statusCode: number; code: string; message: string }) {
+  if (entry.statusCode < 500) return;
+  console.error(`[HTTP:${entry.requestId}] ${entry.statusCode} ${entry.code}: ${entry.message}`);
 }
 
-export function createErrorMiddleware() {
+export function createErrorMiddleware(logger: ErrorLogger = defaultErrorLogger) {
   return new Elysia({ name: 'structured-errors' }).onError({ as: 'global' }, ({ code, error, request, set }) => {
     const statusCode = knownStatus(String(code), error);
-    const id = correlationId(request);
+    const id = requestIdFor(request);
+    const message = statusCode === 404 && code === 'NOT_FOUND' ? 'Route not found' : errorMessage(error);
     set.status = statusCode;
+    set.headers[REQUEST_ID_HEADER] = id;
     set.headers['x-correlation-id'] = id;
+    logger({ requestId: id, statusCode, code: String(code), message });
     return {
       error: error instanceof HttpError ? error.error : statusLabel(statusCode),
-      message: statusCode === 404 && code === 'NOT_FOUND' ? 'Route not found' : errorMessage(error),
+      message,
       statusCode,
       correlationId: id,
     } satisfies StructuredErrorResponse;

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,6 +23,7 @@ import { isApiAuthorized, isApiPathProtected, unauthorizedApiResponse } from './
 import { seedMenuItems, type HasRoutes as SeedHasRoutes } from './db/seeders/menu-seeder.ts';
 import { createCorsMiddleware, createPrivateNetworkPreflightMiddleware } from './server/cors.ts';
 import { createApiKeyAuthMiddleware } from './middleware/auth.ts';
+import { createCorrelationMiddleware } from './middleware/correlation.ts';
 import { loadUnifiedPlugins, seedUnifiedPluginMenuItems } from './plugins/unified-loader.ts';
 import { startUnifiedPluginServers } from './plugins/unified-server.ts';
 import { closeCachedVectorStores } from './vector/factory.ts';
@@ -105,6 +106,7 @@ registerGracefulShutdown({
 const app = new Elysia()
   .use(createPrivateNetworkPreflightMiddleware())
   .use(createCorsMiddleware())
+  .use(createCorrelationMiddleware())
   .use(createApiKeyAuthMiddleware())
   .onBeforeHandle(({ request, set }) => {
     const pathname = new URL(request.url).pathname;

--- a/tests/http/correlation/request-id.test.ts
+++ b/tests/http/correlation/request-id.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createCorrelationMiddleware } from '../../../src/middleware/correlation.ts';
+import { createErrorMiddleware } from '../../../src/middleware/errors.ts';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function app() {
+  return new Elysia()
+    .use(createCorrelationMiddleware())
+    .use(createErrorMiddleware(() => {}))
+    .get('/ok', ({ requestId, store }) => ({ requestId, storeRequestId: store.requestId }))
+    .get('/boom', () => {
+      throw new Error('boom');
+    });
+}
+
+async function request(path: string) {
+  const res = await app().handle(new Request(`http://localhost${path}`));
+  const body = await res.json() as Record<string, unknown>;
+  return { res, body, requestId: res.headers.get('x-request-id') ?? '' };
+}
+
+describe('request correlation ID middleware', () => {
+  test('adds an X-Request-Id header and exposes it downstream', async () => {
+    const { body, requestId } = await request('/ok');
+
+    expect(requestId).toMatch(UUID_RE);
+    expect(body.requestId).toBe(requestId);
+    expect(body.storeRequestId).toBe(requestId);
+  });
+
+  test('generates a unique request ID for every request', async () => {
+    const first = await request('/ok');
+    const second = await request('/ok');
+
+    expect(first.requestId).toMatch(UUID_RE);
+    expect(second.requestId).toMatch(UUID_RE);
+    expect(second.requestId).not.toBe(first.requestId);
+  });
+
+  test('propagates the request ID to structured error responses', async () => {
+    const { res, body, requestId } = await request('/boom');
+
+    expect(res.status).toBe(500);
+    expect(requestId).toMatch(UUID_RE);
+    expect(body).toMatchObject({
+      error: 'Internal Server Error',
+      message: 'boom',
+      correlationId: requestId,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- adds src/middleware/correlation.ts to generate X-Request-Id per request
- exposes the generated ID through Elysia store and request context for downstream handlers
- propagates the same ID through structured error responses and error logging
- wires correlation ahead of auth/routes so short-circuited responses still get the header

## Tests
- tsc --noEmit
- bun test tests/http/correlation/
- bun test tests/http/auth/ tests/http/errors/
- git diff --check
- changed-file wc -l check (all <=250 lines)