### PR TITLE
Add environment config profiles

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -9,8 +9,10 @@ import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
 import * as C from './const.ts';
+import { applyProfileDefaultsToProcessEnv } from './config/profiles.ts';
 import { validateEnv } from './config/validate.ts';
 
+applyProfileDefaultsToProcessEnv();
 validateEnv({ emitOptionalWarnings: false });
 
 // ES Module compatibility for __dirname

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -1,0 +1,119 @@
+import { ARRA_ENV_VALUES, type RuntimeEnv } from './schema.ts';
+
+export type ArraEnv = typeof ARRA_ENV_VALUES[number];
+
+export interface RateLimitProfile {
+  enabled: boolean;
+  tokensPerWindow: number;
+  windowMs: number;
+  burst: number;
+}
+
+export interface ConfigProfile {
+  env: ArraEnv;
+  verboseLogging: boolean;
+  rateLimit: RateLimitProfile;
+  envDefaults: Record<string, string>;
+}
+
+const PROFILE_DEFAULTS: Record<ArraEnv, { envDefaults: Record<string, string> }> = {
+  development: {
+    envDefaults: {
+      DEBUG: '1',
+      ARRA_VERBOSE_LOGGING: '1',
+      ARRA_RATE_LIMIT_ENABLED: '0',
+      ARRA_RATE_LIMIT_TOKENS_PER_WINDOW: '600',
+      ARRA_RATE_LIMIT_WINDOW_MS: '60000',
+      ARRA_RATE_LIMIT_BURST: '600',
+      ORACLE_GATEWAY_HOT_RELOAD: '1',
+      ORACLE_TOOL_GROUPS_HOT_RELOAD: '1',
+    },
+  },
+  staging: {
+    envDefaults: {
+      DEBUG: '0',
+      ARRA_VERBOSE_LOGGING: '0',
+      ARRA_RATE_LIMIT_ENABLED: '1',
+      ARRA_RATE_LIMIT_TOKENS_PER_WINDOW: '120',
+      ARRA_RATE_LIMIT_WINDOW_MS: '60000',
+      ARRA_RATE_LIMIT_BURST: '180',
+      ORACLE_GATEWAY_HOT_RELOAD: '1',
+      ORACLE_TOOL_GROUPS_HOT_RELOAD: '1',
+    },
+  },
+  production: {
+    envDefaults: {
+      DEBUG: '0',
+      ARRA_VERBOSE_LOGGING: '0',
+      ARRA_RATE_LIMIT_ENABLED: '1',
+      ARRA_RATE_LIMIT_TOKENS_PER_WINDOW: '60',
+      ARRA_RATE_LIMIT_WINDOW_MS: '60000',
+      ARRA_RATE_LIMIT_BURST: '60',
+      ORACLE_GATEWAY_HOT_RELOAD: '0',
+      ORACLE_TOOL_GROUPS_HOT_RELOAD: '0',
+    },
+  },
+};
+
+export function isArraEnv(value: string): value is ArraEnv {
+  return (ARRA_ENV_VALUES as readonly string[]).includes(value);
+}
+
+export function resolveArraEnv(env: NodeJS.ProcessEnv = process.env): ArraEnv {
+  const value = env.ARRA_ENV?.trim().toLowerCase();
+  return value && isArraEnv(value) ? value : 'development';
+}
+
+export function profileDefaultsFor(envName: ArraEnv): Record<string, string> {
+  return { ...PROFILE_DEFAULTS[envName].envDefaults };
+}
+
+export function applyProfileDefaults(env: NodeJS.ProcessEnv = process.env): RuntimeEnv {
+  const profileName = resolveArraEnv(env);
+  const merged: Record<string, string> = profileDefaultsFor(profileName);
+  for (const [key, value] of Object.entries(env)) {
+    if (filled(value)) merged[key] = String(value);
+  }
+  if (!filled(merged.ARRA_ENV)) merged.ARRA_ENV = profileName;
+  return merged as RuntimeEnv;
+}
+
+export function applyProfileDefaultsToProcessEnv(env: NodeJS.ProcessEnv = process.env): RuntimeEnv {
+  const profileName = resolveArraEnv(env);
+  for (const [key, value] of Object.entries(PROFILE_DEFAULTS[profileName].envDefaults)) {
+    if (!filled(env[key])) env[key] = value;
+  }
+  if (!filled(env.ARRA_ENV)) env.ARRA_ENV = profileName;
+  return applyProfileDefaults(env);
+}
+
+export function resolveConfigProfile(env: NodeJS.ProcessEnv = process.env): ConfigProfile {
+  const merged = applyProfileDefaults(env);
+  const envName = resolveArraEnv(merged);
+  return {
+    env: envName,
+    verboseLogging: boolFrom(merged.ARRA_VERBOSE_LOGGING ?? merged.DEBUG, envName === 'development'),
+    rateLimit: {
+      enabled: boolFrom(merged.ARRA_RATE_LIMIT_ENABLED, envName !== 'development'),
+      tokensPerWindow: intFrom(merged.ARRA_RATE_LIMIT_TOKENS_PER_WINDOW, envName === 'production' ? 60 : 120),
+      windowMs: intFrom(merged.ARRA_RATE_LIMIT_WINDOW_MS, 60_000),
+      burst: intFrom(merged.ARRA_RATE_LIMIT_BURST, envName === 'staging' ? 180 : 60),
+    },
+    envDefaults: profileDefaultsFor(envName),
+  };
+}
+
+function boolFrom(value: string | undefined, fallback: boolean): boolean {
+  if (!filled(value)) return fallback;
+  return ['1', 'true', 'yes', 'on'].includes(value.toLowerCase());
+}
+
+function intFrom(value: string | undefined, fallback: number): number {
+  if (!filled(value)) return fallback;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function filled(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -3,6 +3,7 @@ import { Type, type Static } from '@sinclair/typebox';
 export const KNOWN_ENV_KEYS = [
   'HOME',
   'USERPROFILE',
+  'ARRA_ENV',
   'PORT',
   'DATABASE_URL',
   'VECTOR_URL',
@@ -19,6 +20,7 @@ export const KNOWN_ENV_KEYS = [
   'ARRA_CORS_ORIGINS',
   'ORACLE_CORS_ORIGIN',
   'CORS_ORIGIN',
+  'ARRA_API_KEY',
   'ARRA_API_TOKEN',
   'ORACLE_HTTP_URL',
   'ORACLE_API',
@@ -82,6 +84,11 @@ export const KNOWN_ENV_KEYS = [
   'ORACLE_HUGINN_SWEEP_DIRS',
   'ARRA_HUGINN_SWEEP_LOOKBACK_HOURS',
   'ARRA_HUGINN_SWEEP_MAX_FILES',
+  'ARRA_VERBOSE_LOGGING',
+  'ARRA_RATE_LIMIT_ENABLED',
+  'ARRA_RATE_LIMIT_TOKENS_PER_WINDOW',
+  'ARRA_RATE_LIMIT_WINDOW_MS',
+  'ARRA_RATE_LIMIT_BURST',
   'DEBUG',
 ] as const;
 
@@ -117,6 +124,7 @@ export const VECTOR_DB_VALUES = [
 ] as const;
 
 export const VECTOR_FALLBACK_VALUES = ['fts5', 'cache', 'fail', 'empty', 'error'] as const;
+export const ARRA_ENV_VALUES = ['development', 'staging', 'production'] as const;
 
 export const BOOLEAN_ENV_KEYS = [
   'ORACLE_VECTOR_READONLY',
@@ -128,6 +136,8 @@ export const BOOLEAN_ENV_KEYS = [
   'ORACLE_INDEX_SECURITY_CORPUS',
   'ARRA_HUGINN_CAPTURE',
   'ORACLE_HUGINN_CAPTURE',
+  'ARRA_VERBOSE_LOGGING',
+  'ARRA_RATE_LIMIT_ENABLED',
 ] as const;
 
 export const INTEGER_ENV_KEYS = [
@@ -149,6 +159,9 @@ export const INTEGER_ENV_KEYS = [
   'INDEXER_PORT',
   'ARRA_HUGINN_SWEEP_LOOKBACK_HOURS',
   'ARRA_HUGINN_SWEEP_MAX_FILES',
+  'ARRA_RATE_LIMIT_TOKENS_PER_WINDOW',
+  'ARRA_RATE_LIMIT_WINDOW_MS',
+  'ARRA_RATE_LIMIT_BURST',
 ] as const;
 
 export const PORT_ENV_KEYS = ['PORT', 'ORACLE_PORT', 'VECTOR_PORT', 'ARRA_PLUGIN_PORT', 'ARRA_SCOUT_PORT', 'INDEXER_PORT'] as const;

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -1,5 +1,6 @@
 import { Value } from '@sinclair/typebox/value';
 import {
+  ARRA_ENV_VALUES,
   BOOLEAN_ENV_KEYS,
   EMBEDDER_VALUES,
   EnvSchema,
@@ -11,6 +12,7 @@ import {
   VECTOR_FALLBACK_VALUES,
   type RuntimeEnv,
 } from './schema.ts';
+import { applyProfileDefaults, resolveConfigProfile, type ConfigProfile } from './profiles.ts';
 
 export class ConfigValidationError extends Error {
   constructor(readonly issues: string[]) {
@@ -27,6 +29,7 @@ interface ValidateEnvOptions {
 
 export interface ConfigValidationResult {
   env: RuntimeEnv;
+  profile: ConfigProfile;
   warnings: string[];
 }
 
@@ -34,7 +37,7 @@ const BOOL_VALUES = new Set(['0', '1', 'true', 'false', 'yes', 'no', 'on', 'off'
 const SQLITE_PROTOCOLS = ['file:', 'sqlite:', 'sqlite3:'];
 
 export function validateEnv(options: ValidateEnvOptions = {}): ConfigValidationResult {
-  const env = cleanEnv(options.env ?? process.env);
+  const env = applyProfileDefaults(cleanEnv(options.env ?? process.env));
   const issues = schemaIssues(env);
 
   requireHome(env, issues);
@@ -51,7 +54,7 @@ export function validateEnv(options: ValidateEnvOptions = {}): ConfigValidationR
   if (options.emitOptionalWarnings !== false) {
     for (const warning of warnings) (options.warn ?? console.warn)(`[Config] ${warning}`);
   }
-  return { env, warnings };
+  return { env, profile: resolveConfigProfile(env), warnings };
 }
 
 export function validateStartupEnv(): ConfigValidationResult {
@@ -125,6 +128,7 @@ function validateUrls(env: RuntimeEnv, issues: string[]): void {
 }
 
 function validateEnums(env: RuntimeEnv, issues: string[]): void {
+  checkEnum(env, issues, ['ARRA_ENV'], ARRA_ENV_VALUES);
   checkEnum(env, issues, ['ORACLE_EMBEDDER', 'ORACLE_EMBEDDER_BACKEND', 'ORACLE_EMBEDDING_PROVIDER', 'EMBEDDER_TYPE'], EMBEDDER_VALUES);
   checkEnum(env, issues, ['ORACLE_VECTOR_DB'], VECTOR_DB_VALUES);
   checkEnum(env, issues, ['VECTOR_FALLBACK'], VECTOR_FALLBACK_VALUES);

--- a/tests/config/profiles.test.ts
+++ b/tests/config/profiles.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  applyProfileDefaults,
+  resolveArraEnv,
+  resolveConfigProfile,
+} from '../../src/config/profiles.ts';
+import { validateEnv } from '../../src/config/validate.ts';
+
+describe('environment config profiles', () => {
+  test('defaults to development with verbose logging and no rate limit', () => {
+    const env = applyProfileDefaults({ HOME: '/tmp/arra-home' });
+    const profile = resolveConfigProfile(env);
+
+    expect(resolveArraEnv(env)).toBe('development');
+    expect(env.DEBUG).toBe('1');
+    expect(profile.verboseLogging).toBe(true);
+    expect(profile.rateLimit.enabled).toBe(false);
+  });
+
+  test('production enables conservative rate limiting defaults', () => {
+    const result = validateEnv({ env: { HOME: '/tmp/arra-home', ARRA_ENV: 'production' }, emitOptionalWarnings: false });
+
+    expect(result.profile.env).toBe('production');
+    expect(result.profile.verboseLogging).toBe(false);
+    expect(result.profile.rateLimit).toEqual({ enabled: true, tokensPerWindow: 60, windowMs: 60000, burst: 60 });
+    expect(result.env.ORACLE_GATEWAY_HOT_RELOAD).toBe('0');
+  });
+
+  test('explicit environment overrides profile defaults', () => {
+    const profile = resolveConfigProfile({
+      HOME: '/tmp/arra-home',
+      ARRA_ENV: 'production',
+      ARRA_RATE_LIMIT_TOKENS_PER_WINDOW: '250',
+      ARRA_RATE_LIMIT_BURST: '300',
+      ARRA_VERBOSE_LOGGING: '1',
+    });
+
+    expect(profile.verboseLogging).toBe(true);
+    expect(profile.rateLimit.tokensPerWindow).toBe(250);
+    expect(profile.rateLimit.burst).toBe(300);
+  });
+
+  test('validation rejects unknown ARRA_ENV values clearly', () => {
+    expect(() => validateEnv({ env: { HOME: '/tmp/arra-home', ARRA_ENV: 'qa' }, emitOptionalWarnings: false }))
+      .toThrow(/ARRA_ENV must be one of development, staging, production/);
+  });
+});


### PR DESCRIPTION
## Summary
- add ARRA_ENV profile resolution for development, staging, and production
- apply unset profile defaults before startup config validation while preserving explicit env overrides
- include profile-aware validation/schema support and tests for dev/prod/override/invalid env behavior

## Verification
- bun test tests/config/
- bun run build
- file size check: all changed files <=250 lines