### PR TITLE
feat: add API rate limiting middleware

### DIFF
--- a/src/middleware/rate-limit.ts
+++ b/src/middleware/rate-limit.ts
@@ -1,0 +1,74 @@
+import { Elysia } from 'elysia';
+import { REQUEST_ID_HEADER, requestIdFor } from './correlation.ts';
+import type { StructuredErrorResponse } from './errors.ts';
+
+const DEFAULT_RPM = 60;
+const DEFAULT_WINDOW_MS = 60_000;
+const HEALTH_BYPASS_PATH = '/api/health';
+
+type RateLimitOptions = {
+  rpm?: number;
+  windowMs?: number;
+  now?: () => number;
+  getIp?: (request: Request) => string;
+  store?: Map<string, number[]>;
+};
+
+export function rateLimitRpmFromEnv(value = process.env.ARRA_RATE_LIMIT_RPM): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : DEFAULT_RPM;
+}
+
+export function isRateLimitBypassed(pathname: string): boolean {
+  return pathname === HEALTH_BYPASS_PATH;
+}
+
+function clientIp(request: Request): string {
+  const forwarded = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim();
+  return forwarded || request.headers.get('x-real-ip') || request.headers.get('cf-connecting-ip') || 'unknown';
+}
+
+
+function messageFor(limit: number, windowMs: number): string {
+  return `Rate limit exceeded: ${limit} requests per ${Math.round(windowMs / 1000)} seconds`;
+}
+
+function retryAfterSeconds(timestamps: number[], now: number, windowMs: number): number {
+  return Math.max(1, Math.ceil(((timestamps[0] ?? now) + windowMs - now) / 1000));
+}
+
+export function createRateLimitMiddleware(options: RateLimitOptions = {}) {
+  const limit = Math.max(1, Math.floor(options.rpm ?? rateLimitRpmFromEnv()));
+  const windowMs = Math.max(1, options.windowMs ?? DEFAULT_WINDOW_MS);
+  const now = options.now ?? Date.now;
+  const getIp = options.getIp ?? clientIp;
+  const store = options.store ?? new Map<string, number[]>();
+
+  return new Elysia({ name: 'rate-limit' }).onBeforeHandle({ as: 'global' }, ({ request, set }) => {
+    const pathname = new URL(request.url).pathname;
+    if (isRateLimitBypassed(pathname)) return;
+
+    const timestamp = now();
+    const key = getIp(request);
+    const cutoff = timestamp - windowMs;
+    const current = (store.get(key) ?? []).filter((entry) => entry > cutoff);
+    if (current.length >= limit) {
+      const retryAfter = retryAfterSeconds(current, timestamp, windowMs);
+      const id = requestIdFor(request);
+      store.set(key, current);
+      set.status = 429;
+      set.headers['Retry-After'] = String(retryAfter);
+      set.headers[REQUEST_ID_HEADER] = id;
+      set.headers['x-correlation-id'] = id;
+      return {
+        error: 'Too Many Requests',
+        message: messageFor(limit, windowMs),
+        statusCode: 429,
+        correlationId: id,
+      } satisfies StructuredErrorResponse;
+    }
+
+    current.push(timestamp);
+    store.set(key, current);
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,6 +31,7 @@ import { isDraining, registerGracefulShutdown, trackRequest } from './lifecycle/
 import { createErrorMiddleware } from './middleware/errors.ts';
 import { validateStartupEnv } from './config/validate.ts';
 import { createRequestLogger } from './middleware/logger.ts';
+import { createRateLimitMiddleware } from './middleware/rate-limit.ts';
 
 // Elysia sub-apps — one per cluster
 import { authRoutes } from './routes/auth/index.ts';
@@ -115,6 +116,7 @@ const app = new Elysia()
   .use(createPrivateNetworkPreflightMiddleware())
   .use(createCorsMiddleware())
   .use(createCorrelationMiddleware())
+  .use(createRateLimitMiddleware())
   .use(createApiKeyAuthMiddleware())
   .use(createMetricsLifecycle())
   .onBeforeHandle(({ request, set }) => {

--- a/tests/http/rate-limit/sliding-window.test.ts
+++ b/tests/http/rate-limit/sliding-window.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import {
+  createRateLimitMiddleware,
+  isRateLimitBypassed,
+  rateLimitRpmFromEnv,
+} from '../../../src/middleware/rate-limit.ts';
+
+function createApp(options: Parameters<typeof createRateLimitMiddleware>[0] = {}) {
+  return new Elysia()
+    .use(createRateLimitMiddleware(options))
+    .get('/api/health', () => ({ status: 'ok' }))
+    .get('/api/search', () => ({ ok: true }));
+}
+
+async function get(app: Elysia, path: string, headers: Record<string, string> = {}) {
+  return app.handle(new Request(`http://local${path}`, { headers }));
+}
+
+async function json(res: Response) {
+  return await res.json() as Record<string, unknown>;
+}
+
+describe('rate limit sliding window middleware', () => {
+  test('blocks requests above the per-IP limit with structured 429 JSON', async () => {
+    const app = createApp({ rpm: 2, windowMs: 1_000, now: () => 1_000 });
+    const headers = { 'x-forwarded-for': '203.0.113.7', 'x-correlation-id': 'rate-limit-test' };
+
+    expect((await get(app, '/api/search', headers)).status).toBe(200);
+    expect((await get(app, '/api/search', headers)).status).toBe(200);
+
+    const blocked = await get(app, '/api/search', headers);
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get('Retry-After')).toBe('1');
+    expect(blocked.headers.get('X-Request-Id')).toBe('rate-limit-test');
+    expect(blocked.headers.get('x-correlation-id')).toBe('rate-limit-test');
+    expect(await json(blocked)).toEqual({
+      error: 'Too Many Requests',
+      message: 'Rate limit exceeded: 2 requests per 1 seconds',
+      statusCode: 429,
+      correlationId: 'rate-limit-test',
+    });
+  });
+
+  test('expires old requests as the sliding window advances', async () => {
+    let now = 1_000;
+    const app = createApp({ rpm: 1, windowMs: 1_000, now: () => now });
+    const headers = { 'x-forwarded-for': '203.0.113.8' };
+
+    expect((await get(app, '/api/search', headers)).status).toBe(200);
+    expect((await get(app, '/api/search', headers)).status).toBe(429);
+
+    now = 2_001;
+    expect((await get(app, '/api/search', headers)).status).toBe(200);
+  });
+
+  test('tracks windows independently per client IP', async () => {
+    const app = createApp({ rpm: 1, windowMs: 1_000, now: () => 1_000 });
+
+    expect((await get(app, '/api/search', { 'x-forwarded-for': '203.0.113.9' })).status).toBe(200);
+    expect((await get(app, '/api/search', { 'x-forwarded-for': '203.0.113.9' })).status).toBe(429);
+    expect((await get(app, '/api/search', { 'x-forwarded-for': '203.0.113.10' })).status).toBe(200);
+  });
+
+  test('bypasses rate limiting for the health endpoint', async () => {
+    const app = createApp({ rpm: 1, windowMs: 1_000, now: () => 1_000 });
+    const headers = { 'x-forwarded-for': '203.0.113.11' };
+
+    expect((await get(app, '/api/search', headers)).status).toBe(200);
+    expect((await get(app, '/api/search', headers)).status).toBe(429);
+    expect((await get(app, '/api/health', headers)).status).toBe(200);
+    expect((await get(app, '/api/health', headers)).status).toBe(200);
+  });
+
+  test('uses a positive integer env limit or falls back to the default', () => {
+    expect(rateLimitRpmFromEnv('125')).toBe(125);
+    expect(rateLimitRpmFromEnv('2.9')).toBe(2);
+    expect(rateLimitRpmFromEnv('0')).toBe(60);
+    expect(rateLimitRpmFromEnv('not-a-number')).toBe(60);
+  });
+
+  test('only marks the health route as bypassed', () => {
+    expect(isRateLimitBypassed('/api/health')).toBe(true);
+    expect(isRateLimitBypassed('/api/healthz')).toBe(false);
+    expect(isRateLimitBypassed('/api/search')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add Elysia rate-limit middleware with per-IP in-memory sliding window
- configure RPM via ARRA_RATE_LIMIT_RPM with default 60/min and bypass /api/health
- return structured 429 JSON with Retry-After plus request/correlation id headers
- rebuilt clean from current origin/alpha after closing conflicted #1527

## Tests
- bun test tests/http/rate-limit/
- bun test --coverage tests/http/rate-limit/ (100% lines/functions on src/middleware/rate-limit.ts)
- bunx tsc --noEmit
- git diff --check

Target: alpha