### PR TITLE
feat: add response timing header

### DIFF
--- a/src/middleware/correlation.ts
+++ b/src/middleware/correlation.ts
@@ -1,13 +1,25 @@
 import { Elysia } from 'elysia';
 
 export const REQUEST_ID_HEADER = 'X-Request-Id';
+export const RESPONSE_TIME_HEADER = 'X-Response-Time';
 const LEGACY_CORRELATION_HEADER = 'x-correlation-id';
 
 const requestIds = new WeakMap<Request, string>();
+const requestStarts = new WeakMap<Request, number>();
 
 export type RequestCorrelationStore = {
   requestId: string;
+  requestStartedAtMs: number;
+  responseTimeMs: number;
 };
+
+type MutableHeadersSet = { headers: Record<string, string | number> };
+type ResponseTimingObserver = (entry: {
+  method: string;
+  pathname: string;
+  requestId: string;
+  responseTimeMs: number;
+}) => void;
 
 export function createRequestId(): string {
   return crypto.randomUUID();
@@ -28,24 +40,68 @@ export function requestIdFor(request: Request): string {
   return rememberRequestId(request, inbound);
 }
 
-function setRequestIdHeader(set: { headers: Record<string, string | number> }, requestId: string) {
+export function rememberRequestStart(request: Request, startedAtMs = performance.now()): number {
+  requestStarts.set(request, startedAtMs);
+  return startedAtMs;
+}
+
+export function requestStartedAtFor(request: Request): number {
+  const known = requestStarts.get(request);
+  return known ?? rememberRequestStart(request);
+}
+
+export function responseTimeMsFor(request: Request): number {
+  return Math.max(0, performance.now() - requestStartedAtFor(request));
+}
+
+export function formatResponseTime(ms: number): string {
+  return `${Math.max(0, ms).toFixed(1)}ms`;
+}
+
+export function responseTimeFor(request: Request): string {
+  return formatResponseTime(responseTimeMsFor(request));
+}
+
+function setRequestIdHeader(set: MutableHeadersSet, requestId: string) {
   set.headers[REQUEST_ID_HEADER] = requestId;
 }
 
-export function createCorrelationMiddleware() {
+function setResponseTimeHeader(set: MutableHeadersSet, request: Request) {
+  set.headers[RESPONSE_TIME_HEADER] = responseTimeFor(request);
+}
+
+function updateStore(store: unknown, request: Request, requestId: string) {
+  const target = store as RequestCorrelationStore;
+  target.requestId = requestId;
+  target.requestStartedAtMs = requestStartedAtFor(request);
+  target.responseTimeMs = responseTimeMsFor(request);
+}
+
+export function createCorrelationMiddleware(observer?: ResponseTimingObserver) {
   return new Elysia({ name: 'request-correlation' })
-    .state({ requestId: '' })
+    .state({ requestId: '', requestStartedAtMs: 0, responseTimeMs: 0 })
     .onRequest(({ request, set, store }) => {
       const requestId = rememberRequestId(request, createRequestId());
-      (store as RequestCorrelationStore).requestId = requestId;
+      rememberRequestStart(request);
+      updateStore(store, request, requestId);
       setRequestIdHeader(set, requestId);
+      setResponseTimeHeader(set, request);
     })
     .derive({ as: 'global' }, ({ request, store }) => {
       const requestId = requestIdFor(request);
-      (store as RequestCorrelationStore).requestId = requestId;
+      updateStore(store, request, requestId);
       return { requestId };
     })
-    .onAfterHandle({ as: 'global' }, ({ request, set }) => {
-      setRequestIdHeader(set, requestIdFor(request));
+    .onAfterHandle({ as: 'global' }, ({ request, set, store }) => {
+      const requestId = requestIdFor(request);
+      updateStore(store, request, requestId);
+      setRequestIdHeader(set, requestId);
+      setResponseTimeHeader(set, request);
+    })
+    .onAfterResponse({ as: 'global' }, ({ request, store }) => {
+      const requestId = requestIdFor(request);
+      updateStore(store, request, requestId);
+      const { pathname } = new URL(request.url);
+      observer?.({ method: request.method, pathname, requestId, responseTimeMs: responseTimeMsFor(request) });
     });
 }

--- a/src/middleware/errors.ts
+++ b/src/middleware/errors.ts
@@ -1,5 +1,5 @@
 import { Elysia } from 'elysia';
-import { REQUEST_ID_HEADER, requestIdFor } from './correlation.ts';
+import { REQUEST_ID_HEADER, RESPONSE_TIME_HEADER, requestIdFor, responseTimeFor } from './correlation.ts';
 
 export type StructuredErrorResponse = {
   error: string;
@@ -83,6 +83,7 @@ export function createErrorMiddleware(logger: ErrorLogger = defaultErrorLogger) 
     const message = statusCode === 404 && code === 'NOT_FOUND' ? 'Route not found' : errorMessage(error);
     set.status = statusCode;
     set.headers[REQUEST_ID_HEADER] = id;
+    set.headers[RESPONSE_TIME_HEADER] = responseTimeFor(request);
     set.headers['x-correlation-id'] = id;
     logger({ requestId: id, statusCode, code: String(code), message });
     return {

--- a/src/server.ts
+++ b/src/server.ts
@@ -115,9 +115,9 @@ const requestLogger = createRequestLogger();
 
 const app = new Elysia()
   .onRequest(requestLogger.onRequest)
+  .use(createCorrelationMiddleware())
   .use(createPrivateNetworkPreflightMiddleware())
   .use(createCorsMiddleware())
-  .use(createCorrelationMiddleware())
   .use(createRateLimitMiddleware())
   .use(createApiKeyAuthMiddleware())
   .use(createMetricsLifecycle())

--- a/tests/http/timing/response-time.test.ts
+++ b/tests/http/timing/response-time.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createCorrelationMiddleware } from '../../../src/middleware/correlation.ts';
+import { createErrorMiddleware } from '../../../src/middleware/errors.ts';
+
+const RESPONSE_TIME_RE = /^\d+\.\dms$/;
+
+type TimingEntry = { pathname: string; requestId: string; responseTimeMs: number };
+
+function parseMs(value: string): number {
+  return Number(value.replace(/ms$/, ''));
+}
+
+function app(entries: TimingEntry[] = []) {
+  return new Elysia()
+    .use(createCorrelationMiddleware((entry) => entries.push(entry)))
+    .use(createErrorMiddleware(() => {}))
+    .get('/ok', ({ requestId, store }) => ({
+      requestId,
+      started: store.requestStartedAtMs > 0,
+      responseTimeMs: store.responseTimeMs,
+    }))
+    .get('/boom', () => {
+      throw new Error('boom');
+    });
+}
+
+async function request(path: string, entries?: TimingEntry[]) {
+  const res = await app(entries).handle(new Request(`http://localhost${path}`));
+  const body = await res.json() as Record<string, unknown>;
+  return { res, body, requestId: res.headers.get('x-request-id') ?? '', timing: res.headers.get('x-response-time') ?? '' };
+}
+
+describe('response time header', () => {
+  test('adds X-Response-Time to successful responses', async () => {
+    const { body, requestId, timing } = await request('/ok');
+
+    expect(timing).toMatch(RESPONSE_TIME_RE);
+    expect(parseMs(timing)).toBeGreaterThanOrEqual(0);
+    expect(body.requestId).toBe(requestId);
+    expect(body.started).toBe(true);
+  });
+
+  test('adds X-Response-Time to structured error responses', async () => {
+    const { res, body, requestId, timing } = await request('/boom');
+
+    expect(res.status).toBe(500);
+    expect(timing).toMatch(RESPONSE_TIME_RE);
+    expect(body.correlationId).toBe(requestId);
+    expect(body.message).toBe('boom');
+  });
+
+  test('adds X-Response-Time to before-handle short-circuited responses', async () => {
+    const guarded = new Elysia()
+      .use(createCorrelationMiddleware())
+      .onBeforeHandle(({ set }) => {
+        set.status = 401;
+        return { error: 'denied' };
+      })
+      .get('/private', () => ({ ok: true }));
+
+    const res = await guarded.handle(new Request('http://localhost/private'));
+    expect(res.status).toBe(401);
+    expect(res.headers.get('x-response-time') ?? '').toMatch(RESPONSE_TIME_RE);
+  });
+
+  test('adds X-Response-Time to on-request short-circuited responses', async () => {
+    const early = new Elysia()
+      .use(createCorrelationMiddleware())
+      .onRequest(() => new Response('early', { status: 204 }))
+      .get('/early', () => ({ ok: true }));
+
+    const res = await early.handle(new Request('http://localhost/early'));
+    expect(res.status).toBe(204);
+    expect(res.headers.get('x-response-time') ?? '').toMatch(RESPONSE_TIME_RE);
+  });
+
+  test('observes final timing in the after-response hook', async () => {
+    const entries: TimingEntry[] = [];
+    const { requestId } = await request('/ok', entries);
+    await Bun.sleep(0);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ pathname: '/ok', requestId });
+    expect(entries[0].responseTimeMs).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
## Summary
- adds X-Response-Time formatting and timing state to the existing correlation middleware
- records final timing through the correlation middleware after-response hook
- writes timing headers before finalization for success, structured errors, and short-circuited responses
- moves correlation before short-circuiting CORS/preflight middleware so early responses get timing headers

## Tests
- tsc --noEmit
- bun test tests/http/timing/
- bun test tests/http/correlation/ tests/http/errors/ tests/http/auth/ tests/http/cors/ tests/http/logging/
- git diff --check
- changed-file wc -l check (all <=250 lines)