### PR TITLE
Add API v1 prefix routing

### DIFF
--- a/src/middleware/api-version.ts
+++ b/src/middleware/api-version.ts
@@ -1,0 +1,81 @@
+import { Elysia } from 'elysia';
+
+export const API_VERSION = 'v1';
+export const API_VERSION_HEADER = 'X-API-Version';
+const API_PREFIX = '/api';
+const VERSIONED_PREFIX = `${API_PREFIX}/${API_VERSION}`;
+
+type FetchHandler = (request: Request) => Response | Promise<Response>;
+
+type HeaderSet = { headers: Record<string, string | number> };
+
+function setVersionHeader(set: HeaderSet): void {
+  set.headers[API_VERSION_HEADER] = API_VERSION;
+}
+
+function isApiPath(pathname: string): boolean {
+  return pathname === API_PREFIX || pathname.startsWith(`${API_PREFIX}/`);
+}
+
+function isVersionedApiPath(pathname: string): boolean {
+  return pathname === VERSIONED_PREFIX || pathname.startsWith(`${VERSIONED_PREFIX}/`);
+}
+
+function versionedLocation(request: Request): string | null {
+  const url = new URL(request.url);
+  if (!isApiPath(url.pathname) || isVersionedApiPath(url.pathname)) return null;
+  const suffix = url.pathname.slice(API_PREFIX.length);
+  url.pathname = `${VERSIONED_PREFIX}${suffix}`;
+  return url.toString();
+}
+
+function rewriteVersionedRequest(request: Request): Request {
+  const url = new URL(request.url);
+  if (!isVersionedApiPath(url.pathname)) return request;
+  const suffix = url.pathname.slice(VERSIONED_PREFIX.length);
+  url.pathname = `${API_PREFIX}${suffix}`;
+  return new Request(url.toString(), request);
+}
+
+function withVersionHeader(response: Response): Response {
+  const headers = new Headers(response.headers);
+  headers.set(API_VERSION_HEADER, API_VERSION);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function redirectResponse(location: string): Response {
+  return new Response(null, {
+    status: 308,
+    headers: {
+      Location: location,
+      [API_VERSION_HEADER]: API_VERSION,
+    },
+  });
+}
+
+export function createApiVersionHeaderMiddleware() {
+  return new Elysia({ name: 'api-version-header' })
+    .onAfterHandle({ as: 'global' }, ({ set }) => {
+      setVersionHeader(set);
+    })
+    .onError({ as: 'global' }, ({ set }) => {
+      setVersionHeader(set);
+    });
+}
+
+export async function handleApiVersionedRequest(
+  request: Request,
+  next: FetchHandler,
+): Promise<Response> {
+  const location = versionedLocation(request);
+  if (location) return redirectResponse(location);
+  return withVersionHeader(await next(rewriteVersionedRequest(request)));
+}
+
+export function createApiVersionedFetch(next: FetchHandler): FetchHandler {
+  return (request) => handleApiVersionedRequest(request, next);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,6 +32,7 @@ import { createErrorMiddleware } from './middleware/errors.ts';
 import { validateStartupEnv } from './config/validate.ts';
 import { createRequestLogger } from './middleware/logger.ts';
 import { createRateLimitMiddleware } from './middleware/rate-limit.ts';
+import { createApiVersionHeaderMiddleware, createApiVersionedFetch } from './middleware/api-version.ts';
 
 // Elysia sub-apps — one per cluster
 import { authRoutes } from './routes/auth/index.ts';
@@ -117,6 +118,7 @@ const app = new Elysia()
   .onRequest(requestLogger.onRequest)
   .use(createPrivateNetworkPreflightMiddleware())
   .use(createCorsMiddleware())
+  .use(createApiVersionHeaderMiddleware())
   .use(createCorrelationMiddleware())
   .use(createRateLimitMiddleware())
   .use(createApiKeyAuthMiddleware())
@@ -156,7 +158,7 @@ const app = new Elysia()
     version: pkg.version,
     status: 'ok',
     docs: '/swagger',
-    api: '/api',
+    api: '/api/v1',
   }));
 
 const healthRoutes = createHealthRoutes({
@@ -213,7 +215,9 @@ console.log(`
    Version: ${pkg.version}
 `);
 
+const versionedFetch = createApiVersionedFetch((request) => app.fetch(request));
+
 export default {
   port: Number(PORT),
-  fetch: (request: Request) => trackRequest(() => app.fetch(request)),
+  fetch: (request: Request) => trackRequest(() => versionedFetch(request)),
 };

--- a/tests/http/versioning/prefix.test.ts
+++ b/tests/http/versioning/prefix.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import {
+  API_VERSION_HEADER,
+  createApiVersionHeaderMiddleware,
+  createApiVersionedFetch,
+} from '../../../src/middleware/api-version.ts';
+
+test('API routes are served under /api/v1 and legacy /api paths redirect', async () => {
+  const app = new Elysia()
+    .use(createApiVersionHeaderMiddleware())
+    .get('/api/health', () => ({ status: 'ok' }))
+    .get('/public', () => ({ public: true }));
+  const fetchVersioned = createApiVersionedFetch((request) => app.handle(request));
+
+  const versioned = await fetchVersioned(new Request('http://local/api/v1/health'));
+  expect(versioned.status).toBe(200);
+  expect(versioned.headers.get(API_VERSION_HEADER)).toBe('v1');
+  expect(await versioned.json()).toEqual({ status: 'ok' });
+
+  const legacy = await fetchVersioned(new Request('http://local/api/health?probe=1'));
+  expect(legacy.status).toBe(308);
+  expect(legacy.headers.get('location')).toBe('http://local/api/v1/health?probe=1');
+  expect(legacy.headers.get(API_VERSION_HEADER)).toBe('v1');
+
+  const publicRoute = await fetchVersioned(new Request('http://local/public'));
+  expect(publicRoute.status).toBe(200);
+  expect(publicRoute.headers.get(API_VERSION_HEADER)).toBe('v1');
+});


### PR DESCRIPTION
## Summary\n- add API versioning middleware with /api/v1 request rewrite and legacy /api redirect support\n- expose X-API-Version on API responses and redirects\n- wire server fetch through the versioning wrapper and advertise /api/v1\n- add scoped prefix/redirect/header test\n\n## Verification\n- tsc --noEmit\n- bun test tests/http/versioning/\n- changed files all <=250 lines\n\nTarget: alpha