### PR TITLE
Print startup runtime banner

### DIFF
--- a/src/lifecycle/banner.ts
+++ b/src/lifecycle/banner.ts
@@ -1,0 +1,47 @@
+export interface BannerMiddleware {
+  name: string;
+  enabled?: boolean;
+  detail?: string;
+}
+
+export interface StartupBannerOptions {
+  version: string;
+  port: number | string;
+  profile: string;
+  middleware: readonly (string | BannerMiddleware)[];
+  dbStatus: string;
+  docsPath?: string;
+  log?: (message: string) => void;
+}
+
+export function formatStartupBanner(options: StartupBannerOptions): string {
+  const docsPath = options.docsPath ?? '/swagger';
+  return [
+    '╭────────────────────────────────────────────╮',
+    '│ 🔮 Arra Oracle HTTP Server                 │',
+    '╰────────────────────────────────────────────╯',
+    `Version:    ${options.version}`,
+    `Port:       ${options.port}`,
+    `Profile:    ${options.profile}`,
+    `Middleware: ${middlewareSummary(options.middleware)}`,
+    `Database:   ${options.dbStatus}`,
+    `Swagger:    ${docsPath}`,
+  ].join('\n');
+}
+
+export function printStartupBanner(options: StartupBannerOptions): void {
+  const log = options.log ?? console.log;
+  log(formatStartupBanner(options));
+}
+
+function middlewareSummary(items: readonly (string | BannerMiddleware)[]): string {
+  if (items.length === 0) return 'none';
+  return items.map(formatMiddleware).join(', ');
+}
+
+function formatMiddleware(item: string | BannerMiddleware): string {
+  if (typeof item === 'string') return item;
+  const state = item.enabled === false ? 'off' : 'on';
+  const detail = item.detail ? `:${item.detail}` : '';
+  return `${item.name}:${state}${detail}`;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,7 @@ import {
 import { PORT, ORACLE_DATA_DIR, VECTOR_URL } from './config.ts';
 import { ScoutAnnouncer, shouldStartScoutAnnouncer } from './peer/scout-announcer.ts';
 import { MCP_SERVER_NAME } from './const.ts';
-import { db, sqlite, closeDb, indexingStatus } from './db/index.ts';
+import { db, sqlite, closeDb, indexingStatus, settings } from './db/index.ts';
 import { isApiAuthorized, isApiPathProtected, unauthorizedApiResponse } from './server/api-token-auth.ts';
 import { seedMenuItems, type HasRoutes as SeedHasRoutes } from './db/seeders/menu-seeder.ts';
 import { createCorsMiddleware, createPrivateNetworkPreflightMiddleware } from './middleware/cors.ts';
@@ -30,6 +30,7 @@ import { closeCachedVectorStores } from './vector/factory.ts';
 import { isDraining, registerGracefulShutdown, trackRequest } from './lifecycle/shutdown.ts';
 import { createErrorMiddleware } from './middleware/errors.ts';
 import { validateStartupEnv } from './config/validate.ts';
+import { printStartupBanner, type BannerMiddleware } from './lifecycle/banner.ts';
 import { createRequestLogger } from './middleware/logger.ts';
 import { createRateLimitMiddleware } from './middleware/rate-limit.ts';
 
@@ -67,7 +68,7 @@ import { gatewayPlugin } from './gateway/index.ts';
 
 import pkg from '../package.json' with { type: 'json' };
 
-validateStartupEnv();
+const startupConfig = validateStartupEnv();
 
 try {
   db.update(indexingStatus).set({ isIndexing: 0 }).where(eq(indexingStatus.id, 1)).run();
@@ -205,13 +206,39 @@ const modules = [...apiModules, mcpRoutes, menuRoutes];
 
 for (const mod of modules) app.use(mod as any);
 
-console.log(`
-🔮 Arra Oracle HTTP Server running! (Elysia)
+printStartupBanner({
+  version: pkg.version,
+  port: Number(PORT),
+  profile: startupConfig.profile.env,
+  middleware: enabledMiddleware(),
+  dbStatus: startupDbStatus(),
+});
 
-   URL:     http://localhost:${PORT}
-   Swagger: http://localhost:${PORT}/swagger
-   Version: ${pkg.version}
-`);
+
+function startupDbStatus(): string {
+  try {
+    db.select({ key: settings.key }).from(settings).limit(1).all();
+    return 'ok';
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return `degraded (${message})`;
+  }
+}
+
+function enabledMiddleware(): BannerMiddleware[] {
+  return [
+    { name: 'request-logger' },
+    { name: 'private-network-preflight' },
+    { name: 'cors' },
+    { name: 'correlation' },
+    { name: 'rate-limit', detail: `${startupConfig.profile.rateLimit.tokensPerWindow}/min` },
+    { name: 'api-key-auth' },
+    { name: 'metrics' },
+    { name: 'structured-errors' },
+    { name: 'swagger' },
+    { name: 'gateway', enabled: Boolean(VECTOR_URL) || process.env.ORACLE_GATEWAY_HOT_RELOAD !== '0' },
+  ];
+}
 
 export default {
   port: Number(PORT),

--- a/tests/lifecycle/banner.test.ts
+++ b/tests/lifecycle/banner.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test';
+import { formatStartupBanner, printStartupBanner } from '../../src/lifecycle/banner.ts';
+
+describe('startup banner', () => {
+  test('formats version and port in the server banner', () => {
+    const banner = formatStartupBanner({
+      version: '26.5.30-alpha.2229',
+      port: 47778,
+      profile: 'production',
+      middleware: ['cors', { name: 'rate-limit', detail: '60/min' }],
+      dbStatus: 'ok',
+    });
+
+    expect(banner).toContain('26.5.30-alpha.2229');
+    expect(banner).toContain('47778');
+    expect(banner).toContain('Profile:    production');
+    expect(banner).toContain('Database:   ok');
+  });
+
+  test('prints the formatted banner through console.log by default', () => {
+    const calls: string[] = [];
+    const original = console.log;
+    console.log = (message?: unknown) => { calls.push(String(message)); };
+    try {
+      printStartupBanner({
+        version: '26.6.1-alpha.1',
+        port: 48888,
+        profile: 'development',
+        middleware: [],
+        dbStatus: 'ok',
+      });
+    } finally {
+      console.log = original;
+    }
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain('26.6.1-alpha.1');
+    expect(calls[0]).toContain('48888');
+  });
+});


### PR DESCRIPTION
## Summary
- add a lifecycle startup banner formatter/printer
- print server version, port, ARRA_ENV profile, enabled middleware, and DB status at HTTP startup
- add lifecycle banner tests that capture console output and assert version/port fields

## Verification
- bun test tests/lifecycle/
- bun run build
- file size check: changed files <=250 lines