### PR TITLE
feat: add security headers middleware

### DIFF
--- a/src/middleware/security-headers.ts
+++ b/src/middleware/security-headers.ts
@@ -1,0 +1,26 @@
+import { Elysia } from 'elysia';
+
+const HSTS_VALUE = 'max-age=31536000; includeSubDomains';
+
+type MutableHeaders = Record<string, string | number | string[]>;
+
+export function isHstsEnabled(value = process.env.ARRA_HSTS): boolean {
+  return value?.trim().toLowerCase() === 'true';
+}
+
+function applySecurityHeaders(headers: MutableHeaders, hstsEnabled: boolean): void {
+  headers['X-Content-Type-Options'] = 'nosniff';
+  headers['X-Frame-Options'] = 'DENY';
+  headers['X-XSS-Protection'] = '0';
+  if (hstsEnabled) headers['Strict-Transport-Security'] = HSTS_VALUE;
+}
+
+export function createSecurityHeadersMiddleware(hstsEnabled = isHstsEnabled()) {
+  return new Elysia({ name: 'security-headers' })
+    .onAfterHandle({ as: 'global' }, ({ set }) => {
+      applySecurityHeaders(set.headers, hstsEnabled);
+    })
+    .onError({ as: 'global' }, ({ set }) => {
+      applySecurityHeaders(set.headers, hstsEnabled);
+    });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,6 +34,7 @@ import { printStartupBanner, type BannerMiddleware } from './lifecycle/banner.ts
 import { createRequestLogger } from './middleware/logger.ts';
 import { createRateLimitMiddleware } from './middleware/rate-limit.ts';
 import { createApiVersionHeaderMiddleware, createApiVersionedFetch } from './middleware/api-version.ts';
+import { createSecurityHeadersMiddleware } from './middleware/security-headers.ts';
 
 // Elysia sub-apps — one per cluster
 import { authRoutes } from './routes/auth/index.ts';
@@ -120,6 +121,7 @@ const app = new Elysia()
   .use(createPrivateNetworkPreflightMiddleware())
   .use(createCorsMiddleware())
   .use(createApiVersionHeaderMiddleware())
+  .use(createSecurityHeadersMiddleware())
   .use(createCorrelationMiddleware())
   .use(createRateLimitMiddleware())
   .use(createApiKeyAuthMiddleware())
@@ -133,9 +135,6 @@ const app = new Elysia()
   })
   .onAfterHandle(({ set }) => {
     set.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate';
-    set.headers['X-Content-Type-Options'] = 'nosniff';
-    set.headers['X-Frame-Options'] = 'DENY';
-    set.headers['X-XSS-Protection'] = '1; mode=block';
     set.headers['Referrer-Policy'] = 'strict-origin-when-cross-origin';
   })
   .onAfterResponse(requestLogger.onAfterResponse)

--- a/tests/http/security/headers.test.ts
+++ b/tests/http/security/headers.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createSecurityHeadersMiddleware, isHstsEnabled } from '../../../src/middleware/security-headers.ts';
+
+const previousHsts = process.env.ARRA_HSTS;
+
+function restoreHsts() {
+  if (previousHsts === undefined) delete process.env.ARRA_HSTS;
+  else process.env.ARRA_HSTS = previousHsts;
+}
+
+afterEach(restoreHsts);
+
+function app() {
+  return new Elysia()
+    .use(createSecurityHeadersMiddleware())
+    .get('/ok', () => ({ ok: true }))
+    .get('/boom', () => {
+      throw new Error('boom');
+    });
+}
+
+function request(path: string) {
+  return app().handle(new Request(`http://local${path}`));
+}
+
+function expectBaseSecurityHeaders(res: Response) {
+  expect(res.headers.get('X-Content-Type-Options')).toBe('nosniff');
+  expect(res.headers.get('X-Frame-Options')).toBe('DENY');
+  expect(res.headers.get('X-XSS-Protection')).toBe('0');
+}
+
+describe('security headers middleware', () => {
+  test('sets baseline browser security headers by default', async () => {
+    delete process.env.ARRA_HSTS;
+
+    const res = await request('/ok');
+
+    expect(res.status).toBe(200);
+    expectBaseSecurityHeaders(res);
+    expect(res.headers.get('Strict-Transport-Security')).toBeNull();
+  });
+
+  test('sets HSTS only when ARRA_HSTS is true', async () => {
+    process.env.ARRA_HSTS = ' true ';
+
+    const res = await request('/ok');
+
+    expect(res.status).toBe(200);
+    expectBaseSecurityHeaders(res);
+    expect(res.headers.get('Strict-Transport-Security')).toBe('max-age=31536000; includeSubDomains');
+  });
+
+  test('applies security headers to error responses', async () => {
+    process.env.ARRA_HSTS = 'true';
+
+    const res = await request('/boom');
+
+    expect(res.status).toBe(500);
+    expectBaseSecurityHeaders(res);
+    expect(res.headers.get('Strict-Transport-Security')).toBe('max-age=31536000; includeSubDomains');
+  });
+
+  test('parses only true-like HSTS values as enabled', () => {
+    expect(isHstsEnabled('TRUE')).toBe(true);
+    expect(isHstsEnabled('false')).toBe(false);
+    expect(isHstsEnabled(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add dedicated Elysia security-headers middleware
- set X-Content-Type-Options, X-Frame-Options, and X-XSS-Protection=0
- add opt-in Strict-Transport-Security when ARRA_HSTS=true
- move conflicting inline X-* header writes out of src/server.ts

## Tests
- bun test tests/http/security/
- bun test --coverage tests/http/security/ (100% lines/functions on src/middleware/security-headers.ts)
- bunx tsc --noEmit
- git diff --check

Target: alpha