### PR TITLE
feat: add JSON content negotiation middleware

### DIFF
--- a/src/middleware/content-type.ts
+++ b/src/middleware/content-type.ts
@@ -1,0 +1,83 @@
+import { Elysia } from 'elysia';
+
+export const JSON_CONTENT_TYPE = 'application/json';
+const WILDCARD_MEDIA = '*/*';
+
+interface MediaRange {
+  type: string;
+  subtype: string;
+  q: number;
+  specificity: number;
+}
+
+type MutableHeaders = Record<string, string | number | string[]>;
+
+function mediaRanges(accept: string): MediaRange[] {
+  return accept
+    .split(',')
+    .map(part => part.trim())
+    .filter(Boolean)
+    .map(parseMediaRange)
+    .filter((range): range is MediaRange => range !== null);
+}
+
+function parseMediaRange(value: string): MediaRange | null {
+  const [rawType, ...params] = value.split(';').map(part => part.trim());
+  const [type, subtype] = rawType.toLowerCase().split('/');
+  if (!type || !subtype) return null;
+  const qParam = params.find(param => param.toLowerCase().startsWith('q='));
+  const q = qParam ? Number(qParam.slice(2)) : 1;
+  if (!Number.isFinite(q) || q < 0 || q > 1) return null;
+  const specificity = type === '*' && subtype === '*' ? 0 : subtype === '*' ? 1 : 2;
+  return { type, subtype, q, specificity };
+}
+
+function matchesJson(range: MediaRange): boolean {
+  if (range.type === '*' && range.subtype === '*') return true;
+  if (range.type === 'application' && range.subtype === '*') return true;
+  return range.type === 'application' && range.subtype === 'json';
+}
+
+export function acceptsJson(accept: string | null | undefined): boolean {
+  if (!accept?.trim()) return true;
+  const ranges = mediaRanges(accept).filter(matchesJson);
+  if (ranges.length === 0) return false;
+  ranges.sort((a, b) => b.specificity - a.specificity || b.q - a.q);
+  return ranges[0]!.q > 0;
+}
+
+function hasContentType(headers: MutableHeaders): boolean {
+  return headers['Content-Type'] !== undefined || headers['content-type'] !== undefined;
+}
+
+export function setJsonContentType(headers: MutableHeaders): void {
+  if (!hasContentType(headers)) headers['Content-Type'] = JSON_CONTENT_TYPE;
+}
+
+export function notAcceptableBody(accept: string | null) {
+  return {
+    error: 'not_acceptable',
+    message: 'Only application/json responses are supported.',
+    accept: accept ?? null,
+    supported: [JSON_CONTENT_TYPE],
+  };
+}
+
+export function createContentTypeMiddleware() {
+  return new Elysia({ name: 'content-type-negotiation' })
+    .onBeforeHandle({ as: 'global' }, ({ request, set }) => {
+      if (request.method === 'OPTIONS') return;
+      const accept = request.headers.get('accept');
+      if (acceptsJson(accept)) return;
+
+      set.status = 406;
+      setJsonContentType(set.headers);
+      return notAcceptableBody(accept);
+    })
+    .onAfterHandle({ as: 'global' }, ({ set }) => {
+      setJsonContentType(set.headers);
+    })
+    .onError({ as: 'global' }, ({ set }) => {
+      setJsonContentType(set.headers);
+    });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,7 +14,6 @@ import {
   writePidFile,
   removePidFile,
 } from './process-manager/index.ts';
-
 import { PORT, ORACLE_DATA_DIR, VECTOR_URL } from './config.ts';
 import { ScoutAnnouncer, shouldStartScoutAnnouncer } from './peer/scout-announcer.ts';
 import { MCP_SERVER_NAME } from './const.ts';
@@ -22,6 +21,7 @@ import { db, sqlite, closeDb, indexingStatus, settings } from './db/index.ts';
 import { isApiAuthorized, isApiPathProtected, unauthorizedApiResponse } from './server/api-token-auth.ts';
 import { seedMenuItems, type HasRoutes as SeedHasRoutes } from './db/seeders/menu-seeder.ts';
 import { createCorsMiddleware, createPrivateNetworkPreflightMiddleware } from './middleware/cors.ts';
+import { createContentTypeMiddleware } from './middleware/content-type.ts';
 import { createApiKeyAuthMiddleware } from './middleware/auth.ts';
 import { createCorrelationMiddleware } from './middleware/correlation.ts';
 import { loadUnifiedPlugins, seedUnifiedPluginMenuItems } from './plugins/unified-loader.ts';
@@ -122,6 +122,7 @@ const app = new Elysia()
   .use(createCorsMiddleware())
   .use(createApiVersionHeaderMiddleware())
   .use(createSecurityHeadersMiddleware())
+  .use(createContentTypeMiddleware())
   .use(createCorrelationMiddleware())
   .use(createRateLimitMiddleware())
   .use(createApiKeyAuthMiddleware())

--- a/tests/http/content-type/negotiation.test.ts
+++ b/tests/http/content-type/negotiation.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import {
+  acceptsJson,
+  createContentTypeMiddleware,
+} from '../../../src/middleware/content-type.ts';
+
+function app() {
+  return new Elysia()
+    .use(createContentTypeMiddleware())
+    .get('/api/ping', () => ({ ok: true }))
+    .get('/api/file', () => new Response('wasm', { headers: { 'Content-Type': 'application/wasm' } }));
+}
+
+function request(path: string, accept?: string) {
+  const headers = accept === undefined ? undefined : { accept };
+  return app().handle(new Request(`http://local${path}`, { headers }));
+}
+
+describe('content-type negotiation middleware', () => {
+  test('allows clients that accept JSON and sets JSON content type', async () => {
+    const explicit = await request('/api/ping', 'application/json');
+    const wildcard = await request('/api/ping', 'text/html, */*;q=0.8');
+    const noHeader = await request('/api/ping');
+
+    expect(explicit.status).toBe(200);
+    expect(explicit.headers.get('Content-Type')).toBe('application/json');
+    expect(await explicit.json()).toEqual({ ok: true });
+    expect(wildcard.status).toBe(200);
+    expect(noHeader.status).toBe(200);
+  });
+
+  test('returns 406 for unsupported Accept headers', async () => {
+    const res = await request('/api/ping', 'text/html, application/xml;q=0.9');
+
+    expect(res.status).toBe(406);
+    expect(res.headers.get('Content-Type')).toBe('application/json');
+    expect(await res.json()).toEqual({
+      error: 'not_acceptable',
+      message: 'Only application/json responses are supported.',
+      accept: 'text/html, application/xml;q=0.9',
+      supported: ['application/json'],
+    });
+  });
+
+  test('honors q=0 JSON rejection over broader wildcards', () => {
+    expect(acceptsJson('application/json;q=0, */*;q=1')).toBe(false);
+    expect(acceptsJson('application/*;q=0.5')).toBe(true);
+  });
+
+  test('does not overwrite explicit response content types', async () => {
+    const res = await request('/api/file', 'application/json');
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/wasm');
+  });
+});


### PR DESCRIPTION
## Summary
- clean rebuild from current `origin/alpha` after closing conflicting #1535
- add `src/middleware/content-type.ts` for JSON-only Accept negotiation
- return structured 406 JSON for unsupported Accept headers and default successful route responses to `application/json` without clobbering explicit content types

## Verification
- `tsc --noEmit`
- `bun test tests/http/content-type/`
- `bun test tests/http/cors/ tests/http/auth/api-key.test.ts tests/http/errors/structured-errors.test.ts tests/http/correlation/request-id.test.ts tests/http/metrics/basic-metrics.test.ts tests/http/rate-limit/sliding-window.test.ts`
- `wc -l src/middleware/content-type.ts src/server.ts tests/http/content-type/negotiation.test.ts` (all ≤250)
