### PR TITLE
Add structured not-found handler

### DIFF
--- a/src/middleware/api-version.ts
+++ b/src/middleware/api-version.ts
@@ -4,6 +4,7 @@ export const API_VERSION = 'v1';
 export const API_VERSION_HEADER = 'X-API-Version';
 const API_PREFIX = '/api';
 const VERSIONED_PREFIX = `${API_PREFIX}/${API_VERSION}`;
+const publicPaths = new WeakMap<Request, string>();
 
 type FetchHandler = (request: Request) => Response | Promise<Response>;
 
@@ -21,6 +22,10 @@ function isVersionedApiPath(pathname: string): boolean {
   return pathname === VERSIONED_PREFIX || pathname.startsWith(`${VERSIONED_PREFIX}/`);
 }
 
+export function apiRequestPath(request: Request): string {
+  return publicPaths.get(request) ?? new URL(request.url).pathname;
+}
+
 function versionedLocation(request: Request): string | null {
   const url = new URL(request.url);
   if (!isApiPath(url.pathname) || isVersionedApiPath(url.pathname)) return null;
@@ -32,9 +37,12 @@ function versionedLocation(request: Request): string | null {
 function rewriteVersionedRequest(request: Request): Request {
   const url = new URL(request.url);
   if (!isVersionedApiPath(url.pathname)) return request;
+  const publicPath = url.pathname;
   const suffix = url.pathname.slice(VERSIONED_PREFIX.length);
   url.pathname = `${API_PREFIX}${suffix}`;
-  return new Request(url.toString(), request);
+  const rewritten = new Request(url.toString(), request);
+  publicPaths.set(rewritten, publicPath);
+  return rewritten;
 }
 
 function withVersionHeader(response: Response): Response {

--- a/src/middleware/not-found.ts
+++ b/src/middleware/not-found.ts
@@ -1,0 +1,23 @@
+import { Elysia } from 'elysia';
+import { apiRequestPath } from './api-version.ts';
+
+export type NotFoundResponse = {
+  error: 'Not Found';
+  path: string;
+  method: string;
+};
+
+export function notFoundResponse(request: Request): NotFoundResponse {
+  return {
+    error: 'Not Found',
+    path: apiRequestPath(request),
+    method: request.method,
+  };
+}
+
+export function createNotFoundMiddleware() {
+  return new Elysia({ name: 'not-found' }).all('*', ({ request, set }) => {
+    set.status = 404;
+    return notFoundResponse(request);
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,9 +1,4 @@
-/**
- * Arra Oracle HTTP Server — Elysia (bun-native).
- *
- * Composes 15 route modules from src/routes/. Every module is its own
- * Elysia sub-app, nested one file per endpoint.
- */
+/** Arra Oracle HTTP Server — Elysia (bun-native). */
 
 import { Elysia } from 'elysia';
 import { swagger } from '@elysiajs/swagger';
@@ -33,6 +28,7 @@ import { createApiVersionHeaderMiddleware, createApiVersionedFetch } from './mid
 import { createSecurityHeadersMiddleware } from './middleware/security-headers.ts';
 import { createRequestTimeoutFetch } from './middleware/timeout.ts';
 import { createBodyLimitMiddleware } from './middleware/body-limit.ts';
+import { createNotFoundMiddleware } from './middleware/not-found.ts';
 
 // Elysia sub-apps — one per cluster
 import { authRoutes } from './routes/auth/index.ts';
@@ -207,6 +203,7 @@ const mcpRoutes = createMcpRoutes(unifiedPlugins.mcpTools);
 const modules = [...apiModules, mcpRoutes, menuRoutes];
 
 for (const mod of modules) app.use(mod as any);
+app.use(createNotFoundMiddleware());
 
 printStartupBanner({
   version: pkg.version,
@@ -237,6 +234,7 @@ function enabledMiddleware(): BannerMiddleware[] {
     { name: 'api-key-auth' },
     { name: 'metrics' },
     { name: 'structured-errors' },
+    { name: 'not-found' },
     { name: 'swagger' },
     { name: 'gateway', enabled: Boolean(VECTOR_URL) || process.env.ORACLE_GATEWAY_HOT_RELOAD !== '0' },
   ];

--- a/tests/http/not-found/handler.test.ts
+++ b/tests/http/not-found/handler.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createNotFoundMiddleware } from '../../../src/middleware/not-found.ts';
+
+test('unmatched routes return structured not-found JSON', async () => {
+  const app = new Elysia()
+    .get('/api/known', () => ({ ok: true }))
+    .use(createNotFoundMiddleware());
+  const fetchVersioned = createApiVersionedFetch((request) => app.handle(request));
+
+  const known = await fetchVersioned(new Request('http://local/api/v1/known'));
+  expect(known.status).toBe(200);
+  expect(await known.json()).toEqual({ ok: true });
+
+  const missing = await fetchVersioned(new Request('http://local/api/v1/missing?debug=1', { method: 'POST' }));
+  expect(missing.status).toBe(404);
+  expect(await missing.json()).toEqual({
+    error: 'Not Found',
+    path: '/api/v1/missing',
+    method: 'POST',
+  });
+});


### PR DESCRIPTION
## Summary\n- add catch-all Elysia not-found middleware returning { error, path, method }\n- mount the catch-all after all route modules so real routes still win\n- preserve public /api/v1 paths through the versioned fetch rewrite for 404 payloads\n- add scoped not-found handler test\n\n## Verification\n- tsc --noEmit\n- bun test tests/http/not-found/\n- bun test tests/http/versioning/\n- changed files all <=250 lines\n\nTarget: alpha