### PR TITLE
feat: add request timeout middleware

### DIFF
--- a/src/middleware/timeout.ts
+++ b/src/middleware/timeout.ts
@@ -1,0 +1,64 @@
+import { REQUEST_ID_HEADER, requestIdFor } from './correlation.ts';
+import type { StructuredErrorResponse } from './errors.ts';
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+type FetchHandler = (request: Request) => Response | Promise<Response>;
+
+export function requestTimeoutMsFromEnv(value = process.env.ARRA_REQUEST_TIMEOUT_MS): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : DEFAULT_TIMEOUT_MS;
+}
+
+function timeoutBody(request: Request, timeoutMs: number): StructuredErrorResponse {
+  return {
+    error: 'Request Timeout',
+    message: `Request exceeded ${timeoutMs}ms timeout`,
+    statusCode: 408,
+    correlationId: requestIdFor(request),
+  };
+}
+
+function timeoutResponse(request: Request, timeoutMs: number): Response {
+  const body = timeoutBody(request, timeoutMs);
+  return Response.json(body, {
+    status: 408,
+    headers: {
+      [REQUEST_ID_HEADER]: body.correlationId,
+      'x-correlation-id': body.correlationId,
+    },
+  });
+}
+
+function requestWithSignal(request: Request, signal: AbortSignal): Request {
+  return new Request(request, { signal });
+}
+
+export async function handleRequestTimeout(
+  request: Request,
+  next: FetchHandler,
+  timeoutMs = requestTimeoutMsFromEnv(),
+): Promise<Response> {
+  const controller = new AbortController();
+  const timedRequest = requestWithSignal(request, controller.signal);
+  const response = Promise.resolve(next(timedRequest));
+  response.catch(() => {});
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<Response>((resolve) => {
+    timer = setTimeout(() => {
+      controller.abort(new Error('request timeout'));
+      resolve(timeoutResponse(request, timeoutMs));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([response, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export function createRequestTimeoutFetch(next: FetchHandler, timeoutMs = requestTimeoutMsFromEnv()): FetchHandler {
+  return (request) => handleRequestTimeout(request, next, timeoutMs);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,6 +35,7 @@ import { createRequestLogger } from './middleware/logger.ts';
 import { createRateLimitMiddleware } from './middleware/rate-limit.ts';
 import { createApiVersionHeaderMiddleware, createApiVersionedFetch } from './middleware/api-version.ts';
 import { createSecurityHeadersMiddleware } from './middleware/security-headers.ts';
+import { createRequestTimeoutFetch } from './middleware/timeout.ts';
 
 // Elysia sub-apps — one per cluster
 import { authRoutes } from './routes/auth/index.ts';
@@ -241,9 +242,9 @@ function enabledMiddleware(): BannerMiddleware[] {
   ];
 }
 
-const versionedFetch = createApiVersionedFetch((request) => app.fetch(request));
+const serverFetch = createRequestTimeoutFetch(createApiVersionedFetch((request) => app.fetch(request)));
 
 export default {
   port: Number(PORT),
-  fetch: (request: Request) => trackRequest(() => versionedFetch(request)),
+  fetch: (request: Request) => trackRequest(() => serverFetch(request)),
 };

--- a/tests/http/timeout/request-timeout.test.ts
+++ b/tests/http/timeout/request-timeout.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import {
+  createRequestTimeoutFetch,
+  requestTimeoutMsFromEnv,
+} from '../../../src/middleware/timeout.ts';
+
+const previousTimeout = process.env.ARRA_REQUEST_TIMEOUT_MS;
+
+afterEach(() => {
+  if (previousTimeout === undefined) delete process.env.ARRA_REQUEST_TIMEOUT_MS;
+  else process.env.ARRA_REQUEST_TIMEOUT_MS = previousTimeout;
+});
+
+function timeoutApp(onAbort?: () => void) {
+  return new Elysia()
+    .get('/fast', () => ({ ok: true }))
+    .get('/slow', async ({ request }) => {
+      request.signal.addEventListener('abort', () => onAbort?.(), { once: true });
+      await Bun.sleep(25);
+      return { ok: false };
+    });
+}
+
+function request(path: string, headers: Record<string, string> = {}) {
+  return new Request(`http://local${path}`, { headers });
+}
+
+async function body(res: Response) {
+  return await res.json() as Record<string, unknown>;
+}
+
+describe('request timeout fetch middleware', () => {
+  test('passes through responses that complete before the timeout', async () => {
+    const app = timeoutApp();
+    const fetchWithTimeout = createRequestTimeoutFetch((req) => app.handle(req), 50);
+
+    const res = await fetchWithTimeout(request('/fast'));
+
+    expect(res.status).toBe(200);
+    expect(await body(res)).toEqual({ ok: true });
+  });
+
+  test('returns structured 408 JSON when a handler exceeds the timeout', async () => {
+    let aborted = false;
+    const app = timeoutApp(() => { aborted = true; });
+    const fetchWithTimeout = createRequestTimeoutFetch((req) => app.handle(req), 5);
+
+    const res = await fetchWithTimeout(request('/slow', { 'x-correlation-id': 'timeout-test' }));
+
+    expect(res.status).toBe(408);
+    expect(res.headers.get('X-Request-Id')).toBe('timeout-test');
+    expect(res.headers.get('x-correlation-id')).toBe('timeout-test');
+    expect(await body(res)).toEqual({
+      error: 'Request Timeout',
+      message: 'Request exceeded 5ms timeout',
+      statusCode: 408,
+      correlationId: 'timeout-test',
+    });
+    expect(aborted).toBe(true);
+  });
+
+
+  test('propagates handler failures that happen before the timeout', async () => {
+    const fetchWithTimeout = createRequestTimeoutFetch(() => Promise.reject(new Error('boom')), 50);
+
+    await expect(fetchWithTimeout(request('/boom'))).rejects.toThrow('boom');
+  });
+
+  test('uses ARRA_REQUEST_TIMEOUT_MS when no explicit timeout is provided', async () => {
+    process.env.ARRA_REQUEST_TIMEOUT_MS = '5';
+    const app = timeoutApp();
+    const fetchWithTimeout = createRequestTimeoutFetch((req) => app.handle(req));
+
+    const res = await fetchWithTimeout(request('/slow'));
+
+    expect(res.status).toBe(408);
+    expect(await body(res)).toMatchObject({
+      error: 'Request Timeout',
+      message: 'Request exceeded 5ms timeout',
+      statusCode: 408,
+    });
+  });
+
+  test('parses positive timeout values or falls back to 30000ms', () => {
+    expect(requestTimeoutMsFromEnv('250')).toBe(250);
+    expect(requestTimeoutMsFromEnv('2.9')).toBe(2);
+    expect(requestTimeoutMsFromEnv('0')).toBe(30_000);
+    expect(requestTimeoutMsFromEnv('invalid')).toBe(30_000);
+  });
+});


### PR DESCRIPTION
## Summary
- add request timeout handling in src/middleware/timeout.ts
- configure timeout via ARRA_REQUEST_TIMEOUT_MS with 30000ms default
- abort timed-out request signals and return structured 408 JSON
- wire timeout wrapper into the server fetch path

## Tests
- bun test tests/http/timeout/
- bun test --coverage tests/http/timeout/ (100% lines/functions on src/middleware/timeout.ts)
- bunx tsc --noEmit
- git diff --check

Target: alpha