### PR TITLE
feat: add response timing header

### DIFF
--- a/src/middleware/correlation.ts
+++ b/src/middleware/correlation.ts
@@ -1,13 +1,25 @@
 import { Elysia } from 'elysia';
 
 export const REQUEST_ID_HEADER = 'X-Request-Id';
+export const RESPONSE_TIME_HEADER = 'X-Response-Time';
 const LEGACY_CORRELATION_HEADER = 'x-correlation-id';
 
 const requestIds = new WeakMap<Request, string>();
+const requestStarts = new WeakMap<Request, number>();
 
 export type RequestCorrelationStore = {
   requestId: string;
+  requestStartedAtMs: number;
+  responseTimeMs: number;
 };
+
+type MutableHeadersSet = { headers: Record<string, string | number> };
+type ResponseTimingObserver = (entry: {
+  method: string;
+  pathname: string;
+  requestId: string;
+  responseTimeMs: number;
+}) => void;
 
 export function createRequestId(): string {
   return crypto.randomUUID();
@@ -28,24 +40,68 @@ export function requestIdFor(request: Request): string {
   return rememberRequestId(request, inbound);
 }
 
-function setRequestIdHeader(set: { headers: Record<string, string | number> }, requestId: string) {
+export function rememberRequestStart(request: Request, startedAtMs = performance.now()): number {
+  requestStarts.set(request, startedAtMs);
+  return startedAtMs;
+}
+
+export function requestStartedAtFor(request: Request): number {
+  const known = requestStarts.get(request);
+  return known ?? rememberRequestStart(request);
+}
+
+export function responseTimeMsFor(request: Request): number {
+  return Math.max(0, performance.now() - requestStartedAtFor(request));
+}
+
+export function formatResponseTime(ms: number): string {
+  return `${Math.max(0, ms).toFixed(1)}ms`;
+}
+
+export function responseTimeFor(request: Request): string {
+  return formatResponseTime(responseTimeMsFor(request));
+}
+
+function setRequestIdHeader(set: MutableHeadersSet, requestId: string) {
   set.headers[REQUEST_ID_HEADER] = requestId;
 }
 
-export function createCorrelationMiddleware() {
+function setResponseTimeHeader(set: MutableHeadersSet, request: Request) {
+  set.headers[RESPONSE_TIME_HEADER] = responseTimeFor(request);
+}
+
+function updateStore(store: unknown, request: Request, requestId: string) {
+  const target = store as RequestCorrelationStore;
+  target.requestId = requestId;
+  target.requestStartedAtMs = requestStartedAtFor(request);
+  target.responseTimeMs = responseTimeMsFor(request);
+}
+
+export function createCorrelationMiddleware(observer?: ResponseTimingObserver) {
   return new Elysia({ name: 'request-correlation' })
-    .state({ requestId: '' })
+    .state({ requestId: '', requestStartedAtMs: 0, responseTimeMs: 0 })
     .onRequest(({ request, set, store }) => {
       const requestId = rememberRequestId(request, createRequestId());
-      (store as RequestCorrelationStore).requestId = requestId;
+      rememberRequestStart(request);
+      updateStore(store, request, requestId);
       setRequestIdHeader(set, requestId);
+      setResponseTimeHeader(set, request);
     })
     .derive({ as: 'global' }, ({ request, store }) => {
       const requestId = requestIdFor(request);
-      (store as RequestCorrelationStore).requestId = requestId;
+      updateStore(store, request, requestId);
       return { requestId };
     })
-    .onAfterHandle({ as: 'global' }, ({ request, set }) => {
-      setRequestIdHeader(set, requestIdFor(request));
+    .onAfterHandle({ as: 'global' }, ({ request, set, store }) => {
+      const requestId = requestIdFor(request);
+      updateStore(store, request, requestId);
+      setRequestIdHeader(set, requestId);
+      setResponseTimeHeader(set, request);
+    })
+    .onAfterResponse({ as: 'global' }, ({ request, store }) => {
+      const requestId = requestIdFor(request);
+      updateStore(store, request, requestId);
+      const { pathname } = new URL(request.url);
+      observer?.({ method: request.method, pathname, requestId, responseTimeMs: responseTimeMsFor(request) });
     });
 }

--- a/src/middleware/errors.ts
+++ b/src/middleware/errors.ts
@@ -1,5 +1,5 @@
 import { Elysia } from 'elysia';
-import { REQUEST_ID_HEADER, requestIdFor } from './correlation.ts';
+import { REQUEST_ID_HEADER, RESPONSE_TIME_HEADER, requestIdFor, responseTimeFor } from './correlation.ts';
 
 export type StructuredErrorResponse = {
   error: string;
@@ -83,6 +83,7 @@ export function createErrorMiddleware(logger: ErrorLogger = defaultErrorLogger) 
     const message = statusCode === 404 && code === 'NOT_FOUND' ? 'Route not found' : errorMessage(error);
     set.status = statusCode;
     set.headers[REQUEST_ID_HEADER] = id;
+    set.headers[RESPONSE_TIME_HEADER] = responseTimeFor(request);
     set.headers['x-correlation-id'] = id;
     logger({ requestId: id, statusCode, code: String(code), message });
     return {

--- a/src/server.ts
+++ b/src/server.ts
@@ -118,12 +118,12 @@ const requestLogger = createRequestLogger();
 
 const app = new Elysia()
   .onRequest(requestLogger.onRequest)
+  .use(createCorrelationMiddleware())
   .use(createPrivateNetworkPreflightMiddleware())
   .use(createCorsMiddleware())
   .use(createApiVersionHeaderMiddleware())
   .use(createSecurityHeadersMiddleware())
   .use(createContentTypeMiddleware())
-  .use(createCorrelationMiddleware())
   .use(createRateLimitMiddleware())
   .use(createApiKeyAuthMiddleware())
   .use(createMetricsLifecycle())
@@ -230,9 +230,9 @@ function startupDbStatus(): string {
 function enabledMiddleware(): BannerMiddleware[] {
   return [
     { name: 'request-logger' },
+    { name: 'correlation' },
     { name: 'private-network-preflight' },
     { name: 'cors' },
-    { name: 'correlation' },
     { name: 'rate-limit', detail: `${startupConfig.profile.rateLimit.tokensPerWindow}/min` },
     { name: 'api-key-auth' },
     { name: 'metrics' },

--- a/tests/http/timing/response-time.test.ts
+++ b/tests/http/timing/response-time.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import {
+  RESPONSE_TIME_HEADER,
+  createCorrelationMiddleware,
+} from '../../../src/middleware/correlation.ts';
+import { createErrorMiddleware } from '../../../src/middleware/errors.ts';
+
+const RESPONSE_TIME_RE = /^\d+\.\dms$/;
+
+async function waitForAfterResponse() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function timingMs(response: Response): number {
+  const value = response.headers.get(RESPONSE_TIME_HEADER) ?? '';
+  expect(value).toMatch(RESPONSE_TIME_RE);
+  return Number(value.replace('ms', ''));
+}
+
+describe('response time header', () => {
+  test('adds X-Response-Time to successful responses', async () => {
+    const app = new Elysia()
+      .use(createCorrelationMiddleware())
+      .get('/ok', ({ requestId, store }) => ({ requestId, started: store.requestStartedAtMs > 0 }));
+
+    const res = await app.handle(new Request('http://local/ok'));
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(timingMs(res)).toBeGreaterThanOrEqual(0);
+    expect(body.requestId).toBe(res.headers.get('x-request-id'));
+    expect(body.started).toBe(true);
+  });
+
+  test('adds X-Response-Time to structured error responses', async () => {
+    const app = new Elysia()
+      .use(createCorrelationMiddleware())
+      .use(createErrorMiddleware(() => {}))
+      .get('/boom', () => {
+        throw new Error('boom');
+      });
+
+    const res = await app.handle(new Request('http://local/boom'));
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(500);
+    expect(timingMs(res)).toBeGreaterThanOrEqual(0);
+    expect(body.correlationId).toBe(res.headers.get('x-request-id'));
+  });
+
+  test('adds X-Response-Time to before-handle short-circuited responses', async () => {
+    const app = new Elysia()
+      .use(createCorrelationMiddleware())
+      .onBeforeHandle(({ set }) => {
+        set.status = 204;
+        return '';
+      })
+      .get('/short', () => ({ unreachable: true }));
+
+    const res = await app.handle(new Request('http://local/short'));
+
+    expect(res.status).toBe(204);
+    expect(timingMs(res)).toBeGreaterThanOrEqual(0);
+  });
+
+  test('adds X-Response-Time to on-request short-circuited responses', async () => {
+    const app = new Elysia()
+      .use(createCorrelationMiddleware())
+      .onRequest(({ set }) => {
+        set.status = 204;
+        return '';
+      })
+      .get('/short', () => ({ unreachable: true }));
+
+    const res = await app.handle(new Request('http://local/short'));
+
+    expect(res.status).toBe(204);
+    expect(timingMs(res)).toBeGreaterThanOrEqual(0);
+  });
+
+  test('observes final timing in the after-response hook', async () => {
+    const entries: Array<{ requestId: string; responseTimeMs: number; pathname: string }> = [];
+    const app = new Elysia()
+      .use(createCorrelationMiddleware((entry) => entries.push(entry)))
+      .get('/ok', () => ({ ok: true }));
+
+    const res = await app.handle(new Request('http://local/ok'));
+    await waitForAfterResponse();
+
+    expect(res.status).toBe(200);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].pathname).toBe('/ok');
+    expect(entries[0].requestId).toBe(res.headers.get('x-request-id'));
+    expect(entries[0].responseTimeMs).toBeGreaterThanOrEqual(timingMs(res));
+  });
+});


### PR DESCRIPTION
## Summary
- add X-Response-Time generation to the request correlation middleware
- preserve request ID propagation while recording final timing via Elysia onAfterResponse
- include timing headers on success, structured error, before-handle, and on-request short-circuit responses

## Verification
- tsc --noEmit
- bun test tests/http/timing/
- bun test tests/http/correlation/ tests/http/errors/ tests/http/auth/ tests/http/cors/ tests/http/logging/ tests/http/rate-limit/ tests/http/security/ tests/http/versioning/ tests/http/metrics/ tests/http/content-type/
- bun test --coverage tests/http/timing/ tests/http/correlation/ tests/http/errors/ (100% funcs/lines for touched middleware)
- git diff --check origin/alpha...HEAD
- changed files all <=250 lines

Notes: #1533 was closed per lead due chronic conflicts; this is a clean rebuild from current alpha.