### PR TITLE
feat: add conditional ETag middleware

### DIFF
--- a/src/middleware/etag.ts
+++ b/src/middleware/etag.ts
@@ -1,0 +1,74 @@
+import { Elysia } from 'elysia';
+
+export const ETAG_HEADER = 'ETag';
+export const IF_NONE_MATCH_HEADER = 'If-None-Match';
+
+const encoder = new TextEncoder();
+
+type HeaderValue = string | number | string[];
+type HeaderMap = Record<string, HeaderValue>;
+
+function statusCode(response: unknown, status: unknown): number {
+  if (response instanceof Response) return response.status;
+  return typeof status === 'number' ? status : 200;
+}
+
+function hasHeader(headers: HeaderMap, name: string): boolean {
+  const lower = name.toLowerCase();
+  return Object.keys(headers).some((key) => key.toLowerCase() === lower);
+}
+
+function hasExplicitEtag(response: unknown, headers: HeaderMap): boolean {
+  return hasHeader(headers, ETAG_HEADER) || (response instanceof Response && response.headers.has(ETAG_HEADER));
+}
+
+function isEligibleGet(request: Request, response: unknown, status: unknown, headers: HeaderMap): boolean {
+  if (request.method !== 'GET') return false;
+  const code = statusCode(response, status);
+  return code >= 200 && code < 300 && code !== 204 && code !== 205 && !hasExplicitEtag(response, headers);
+}
+
+export async function responseBodyBytes(response: unknown): Promise<Uint8Array> {
+  if (response instanceof Response) return new Uint8Array(await response.clone().arrayBuffer());
+  if (response === undefined || response === null) return new Uint8Array();
+  if (response instanceof Uint8Array) return response;
+  if (typeof response === 'string') return encoder.encode(response);
+  return encoder.encode(JSON.stringify(response));
+}
+
+function hex(bytes: ArrayBuffer): string {
+  return [...new Uint8Array(bytes)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+export async function etagForBody(response: unknown): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', await responseBodyBytes(response));
+  return `"sha256-${hex(digest)}"`;
+}
+
+function withoutWeakPrefix(value: string): string {
+  const trimmed = value.trim();
+  return trimmed.toLowerCase().startsWith('w/') ? trimmed.slice(2).trim() : trimmed;
+}
+
+export function ifNoneMatchMatches(header: string | null, etag: string): boolean {
+  if (!header?.trim()) return false;
+  return header.split(',').map(withoutWeakPrefix).some((candidate) => candidate === '*' || candidate === etag);
+}
+
+function notModified(etag: string): Response {
+  return new Response(null, { status: 304, headers: { [ETAG_HEADER]: etag } });
+}
+
+export function createEtagMiddleware() {
+  return new Elysia({ name: 'etag' }).onAfterHandle({ as: 'global' }, async ({ request, response, set }) => {
+    if (!isEligibleGet(request, response, set.status, set.headers)) return;
+
+    const etag = await etagForBody(response);
+    set.headers[ETAG_HEADER] = etag;
+
+    if (ifNoneMatchMatches(request.headers.get(IF_NONE_MATCH_HEADER), etag)) {
+      set.status = 304;
+      return notModified(etag);
+    }
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,3 @@
-/** Arra Oracle HTTP Server — Elysia (bun-native). */
-
 import { Elysia } from 'elysia';
 import { swagger } from '@elysiajs/swagger';
 import { eq } from 'drizzle-orm';
@@ -29,6 +27,7 @@ import { createSecurityHeadersMiddleware } from './middleware/security-headers.t
 import { createRequestTimeoutFetch } from './middleware/timeout.ts';
 import { createBodyLimitMiddleware } from './middleware/body-limit.ts';
 import { createNotFoundMiddleware } from './middleware/not-found.ts';
+import { createEtagMiddleware } from './middleware/etag.ts';
 
 // Elysia sub-apps — one per cluster
 import { authRoutes } from './routes/auth/index.ts';
@@ -122,6 +121,7 @@ const app = new Elysia()
   .use(createRateLimitMiddleware())
   .use(createApiKeyAuthMiddleware())
   .use(createMetricsLifecycle())
+  .use(createEtagMiddleware())
   .onBeforeHandle(({ request, set }) => {
     const pathname = new URL(request.url).pathname;
     if (isApiPathProtected(pathname) && !isApiAuthorized(request)) {
@@ -233,6 +233,7 @@ function enabledMiddleware(): BannerMiddleware[] {
     { name: 'rate-limit', detail: `${startupConfig.profile.rateLimit.tokensPerWindow}/min` },
     { name: 'api-key-auth' },
     { name: 'metrics' },
+    { name: 'etag' },
     { name: 'structured-errors' },
     { name: 'not-found' },
     { name: 'swagger' },

--- a/tests/http/etag/conditional.test.ts
+++ b/tests/http/etag/conditional.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import {
+  ETAG_HEADER,
+  IF_NONE_MATCH_HEADER,
+  createEtagMiddleware,
+  etagForBody,
+  ifNoneMatchMatches,
+} from '../../../src/middleware/etag.ts';
+
+function app() {
+  return new Elysia()
+    .use(createEtagMiddleware())
+    .get('/json', () => ({ ok: true }))
+    .get('/text', () => new Response('hello', { headers: { 'Content-Type': 'text/plain' } }))
+    .get('/bytes', () => new Uint8Array([1, 2, 3]))
+    .get('/empty', () => null)
+    .get('/missing', ({ set }) => {
+      set.status = 404;
+      return { error: 'missing' };
+    })
+    .get('/no-content', ({ set }) => {
+      set.status = 204;
+      return '';
+    })
+    .get('/explicit', () => new Response('custom', { headers: { [ETAG_HEADER]: '"custom"' } }))
+    .get('/set-explicit', ({ set }) => {
+      set.headers[ETAG_HEADER] = '"set-custom"';
+      return { ok: true };
+    })
+    .post('/json', () => ({ ok: true }));
+}
+
+async function request(path: string, init?: RequestInit) {
+  return app().handle(new Request(`http://local${path}`, init));
+}
+
+describe('ETag conditional GET middleware', () => {
+  test('generates an ETag from JSON GET response bodies', async () => {
+    const res = await request('/json');
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get(ETAG_HEADER)).toBe(await etagForBody({ ok: true }));
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  test('returns 304 Not Modified when If-None-Match matches', async () => {
+    const first = await request('/json');
+    const etag = first.headers.get(ETAG_HEADER) ?? '';
+    const second = await request('/json', { headers: { [IF_NONE_MATCH_HEADER]: etag } });
+
+    expect(second.status).toBe(304);
+    expect(second.headers.get(ETAG_HEADER)).toBe(etag);
+    expect(await second.text()).toBe('');
+  });
+
+  test('matches weak, wildcard, and multi-value If-None-Match headers', async () => {
+    const etag = await etagForBody({ ok: true });
+    const weak = await request('/json', { headers: { 'If-None-Match': `W/${etag}` } });
+    const multi = await request('/json', { headers: { 'If-None-Match': `"other", ${etag}` } });
+    const wildcard = await request('/json', { headers: { 'If-None-Match': '*' } });
+
+    expect(ifNoneMatchMatches(null, etag)).toBe(false);
+    expect(weak.status).toBe(304);
+    expect(multi.status).toBe(304);
+    expect(wildcard.status).toBe(304);
+  });
+
+  test('hashes raw Response, bytes, and empty bodies without replacing them', async () => {
+    const text = await request('/text');
+    const bytes = await request('/bytes');
+    const empty = await request('/empty');
+
+    expect(text.headers.get(ETAG_HEADER)).toBe(await etagForBody(new Response('hello')));
+    expect(await text.text()).toBe('hello');
+    expect(bytes.headers.get(ETAG_HEADER)).toBe(await etagForBody(new Uint8Array([1, 2, 3])));
+    expect([...new Uint8Array(await bytes.arrayBuffer())]).toEqual([1, 2, 3]);
+    expect(empty.headers.get(ETAG_HEADER)).toBe(await etagForBody(null));
+  });
+
+  test('does not tag non-GET, non-success, no-content, or explicit ETag responses', async () => {
+    const post = await request('/json', { method: 'POST' });
+    const missing = await request('/missing');
+    const noContent = await request('/no-content');
+    const explicit = await request('/explicit');
+    const setExplicit = await request('/set-explicit');
+
+    expect(post.headers.get(ETAG_HEADER)).toBeNull();
+    expect(missing.headers.get(ETAG_HEADER)).toBeNull();
+    expect(noContent.headers.get(ETAG_HEADER)).toBeNull();
+    expect(explicit.headers.get(ETAG_HEADER)).toBe('"custom"');
+    expect(setExplicit.headers.get(ETAG_HEADER)).toBe('"set-custom"');
+  });
+});


### PR DESCRIPTION
## Summary
- add ETag middleware that hashes GET response bodies with SHA-256
- return 304 Not Modified when If-None-Match matches the generated ETag
- wire ETag into the HTTP middleware stack and startup middleware summary

## Verification
- tsc --noEmit
- bun test tests/http/etag/
- bun test --coverage tests/http/etag/ (100% funcs/lines for src/middleware/etag.ts)
- bun test tests/http/etag/ tests/http/timing/ tests/http/correlation/ tests/http/errors/ tests/http/content-type/ tests/http/security/ tests/http/versioning/ tests/http/metrics/ tests/http/auth/ tests/http/cors/ tests/http/rate-limit/ tests/http/body-limit/ tests/http/not-found/
- git diff --check origin/alpha...HEAD
- changed files all <=250 lines