### PR TITLE
Add typed frontend API client

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,151 @@
+import type { MenuResponse } from '../../../src/routes/menu/model';
+import type {
+  HealthResponse,
+  MetricsSnapshot,
+  PluginsResponse,
+  VectorSearchResponse,
+} from '../../../src/server/types';
+
+export interface ApiRouteResponses {
+  '/api/health': HealthResponse;
+  '/api/metrics': MetricsSnapshot;
+  '/api/menu': MenuResponse;
+  '/api/vector/search': VectorSearchResponse;
+  '/api/plugins': PluginsResponse;
+}
+
+export type ApiRoute = keyof ApiRouteResponses;
+export type ApiResponse<Route extends ApiRoute> = ApiRouteResponses[Route];
+export type ApiFetch = (input: RequestInfo | URL, init?: RequestInit) => Response | Promise<Response>;
+
+export interface ApiClientOptions {
+  baseUrl?: string;
+  fetch?: ApiFetch;
+  headers?: HeadersInit;
+}
+
+export interface VectorSearchParams {
+  q: string;
+  limit?: number;
+  offset?: number;
+  type?: string;
+  project?: string;
+  cwd?: string;
+  model?: string;
+}
+
+export class ApiClientError extends Error {
+  constructor(
+    readonly status: number,
+    readonly path: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ApiClientError';
+  }
+}
+
+function messageFor(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function backendMessage(payload: unknown, fallback: string): string {
+  if (!isRecord(payload)) return fallback;
+  if (typeof payload.error === 'string') return payload.error;
+  if (typeof payload.message === 'string') return payload.message;
+  return fallback;
+}
+
+function urlFor(path: string, baseUrl?: string): string {
+  if (!baseUrl) return path;
+  return new URL(path, baseUrl).toString();
+}
+
+function withJsonHeaders(base: HeadersInit | undefined, init: RequestInit): Headers {
+  const headers = new Headers(base);
+  new Headers(init.headers).forEach((value, key) => headers.set(key, value));
+  if (!headers.has('accept')) headers.set('accept', 'application/json');
+  if (init.body && !headers.has('content-type')) headers.set('content-type', 'application/json');
+  return headers;
+}
+
+function addParam(params: URLSearchParams, key: string, value: unknown): void {
+  if (value === undefined || value === null || value === '') return;
+  params.set(key, String(value));
+}
+
+export class ApiClient {
+  constructor(private readonly options: ApiClientOptions = {}) {}
+
+  async request<Route extends ApiRoute>(route: Route, init: RequestInit = {}): Promise<ApiResponse<Route>> {
+    return this.fetchJson(route, init);
+  }
+
+  health(): Promise<HealthResponse> {
+    return this.request('/api/health');
+  }
+
+  metrics(): Promise<MetricsSnapshot> {
+    return this.request('/api/metrics');
+  }
+
+  menu(): Promise<MenuResponse> {
+    return this.request('/api/menu');
+  }
+
+  plugins(): Promise<PluginsResponse> {
+    return this.request('/api/plugins');
+  }
+
+  vectorSearch(query: string, limit?: number): Promise<VectorSearchResponse>;
+  vectorSearch(params: VectorSearchParams): Promise<VectorSearchResponse>;
+  vectorSearch(input: string | VectorSearchParams, limit?: number): Promise<VectorSearchResponse> {
+    const params = typeof input === 'string' ? { q: input, limit } : input;
+    const query = new URLSearchParams();
+    addParam(query, 'q', params.q);
+    addParam(query, 'limit', params.limit);
+    addParam(query, 'offset', params.offset);
+    addParam(query, 'type', params.type);
+    addParam(query, 'project', params.project);
+    addParam(query, 'cwd', params.cwd);
+    addParam(query, 'model', params.model);
+    return this.fetchJson(`/api/vector/search?${query.toString()}`);
+  }
+
+  private async fetchJson<T>(path: string, init: RequestInit = {}): Promise<T> {
+    const fetcher = this.options.fetch ?? globalThis.fetch?.bind(globalThis);
+    if (!fetcher) throw new ApiClientError(0, path, `${path} is unreachable: fetch is unavailable`);
+
+    const headers = withJsonHeaders(this.options.headers, init);
+    let response: Response;
+    try {
+      response = await fetcher(urlFor(path, this.options.baseUrl), { ...init, headers });
+    } catch (error) {
+      throw new ApiClientError(0, path, `${path} is unreachable: ${messageFor(error)}`);
+    }
+
+    const text = await response.text();
+    let payload: unknown = {};
+    try {
+      payload = text ? JSON.parse(text) : {};
+    } catch {
+      throw new ApiClientError(response.status, path, `${path} returned invalid JSON`);
+    }
+
+    if (!response.ok) {
+      const detail = backendMessage(payload, response.statusText || 'request failed');
+      throw new ApiClientError(response.status, path, `${path} returned ${response.status}: ${detail}`);
+    }
+    return payload as T;
+  }
+}
+
+export function createApiClient(options?: ApiClientOptions): ApiClient {
+  return new ApiClient(options);
+}
+
+export const apiClient = createApiClient();

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -68,11 +68,80 @@ export interface DashboardSummary {
   };
 }
 
-export interface HealthResponse {
-  status: string;
-  server?: string;
-  port?: number | string;
+export type RuntimeStatus = 'ok' | 'down' | 'degraded' | 'draining' | string;
+
+export interface VectorHealthResponse {
+  status: RuntimeStatus;
+  engines: Array<Record<string, unknown>>;
+  checked_at: string;
+  error?: string;
 }
+
+export interface HealthResponse {
+  status: RuntimeStatus;
+  server: string;
+  version: string;
+  port?: number;
+  oracle?: 'connected' | 'degraded';
+  uptimeSeconds?: number;
+  dbStatus?: 'ok' | 'down';
+  vectorStatus?: RuntimeStatus;
+  pluginStatus?: 'ok' | 'degraded';
+  mcpToolCount?: number;
+  pluginCount?: number;
+  draining?: boolean;
+  uptime?: { seconds: number };
+  db?: { status: 'ok'; path: string } | { status: 'down'; error: string; path: string };
+  vector?: VectorHealthResponse;
+  mcp?: { toolCount: number };
+  plugins?: {
+    count: number;
+    status: 'ok' | 'degraded';
+    items: Array<{ name: string; status: 'ok' | 'degraded'; error?: string }>;
+  };
+}
+
+export interface MetricsSnapshot {
+  uptime: number;
+  requestCount: number;
+  avgResponseMs: number;
+  activeConnections: number;
+  lastRestart: string;
+}
+
+export interface PluginEntryResponse {
+  name: string;
+  file: string;
+  size: number;
+  modified: string;
+  version?: string;
+  description?: string;
+  menu?: {
+    label: string;
+    group?: 'main' | 'tools' | 'hidden';
+    order?: number;
+    icon?: string;
+    path?: string;
+  };
+  server?: {
+    command: string;
+    args?: string[];
+    healthPath?: string;
+    autostart?: boolean;
+  };
+}
+
+export interface PluginsResponse {
+  plugins: PluginEntryResponse[];
+  dir: string;
+}
+
+export type VectorSearchResponse = Omit<SearchResponse, 'query' | 'offset' | 'limit'> & {
+  query: string;
+  offset?: number;
+  limit?: number;
+  error?: string;
+};
 
 export interface DashboardActivity {
   searches: Array<{
@@ -101,4 +170,3 @@ export interface DashboardGrowth {
     searches: number;
   }>;
 }
-

--- a/tests/frontend/api-client.test.ts
+++ b/tests/frontend/api-client.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'bun:test';
+import { ApiClientError, createApiClient } from '../../frontend/src/api/client';
+
+function jsonResponse(data: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(data), {
+    status: init.status ?? 200,
+    statusText: init.statusText,
+    headers: { 'content-type': 'application/json', ...(init.headers ?? {}) },
+  });
+}
+
+describe('frontend API client', () => {
+  test('calls each typed backend route with JSON accept headers', async () => {
+    const payloads: Record<string, unknown> = {
+      '/api/health': { status: 'ok', server: 'arra', version: '26.5.30', port: 47778 },
+      '/api/metrics': {
+        uptime: 4.2,
+        requestCount: 7,
+        avgResponseMs: 1.5,
+        activeConnections: 0,
+        lastRestart: '2026-06-16T00:00:00.000Z',
+      },
+      '/api/menu': { items: [{ label: 'Vector', path: '/vector', group: 'tools', order: 1, source: 'api' }] },
+      '/api/vector/search?q=oracle+memory&limit=5&type=docs': {
+        results: [{ id: 'doc-1', type: 'doc', content: 'Oracle memory', source_file: 'note.md', concepts: [] }],
+        total: 1,
+        offset: 0,
+        limit: 5,
+        query: 'oracle memory',
+      },
+      '/api/plugins': {
+        dir: '/tmp/plugins',
+        plugins: [{ name: 'echo', file: 'echo.wasm', size: 12, modified: '2026-06-16T00:00:00.000Z' }],
+      },
+    };
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    const client = createApiClient({
+      fetch: (input, init) => {
+        calls.push({ input, init });
+        return jsonResponse(payloads[String(input)] ?? { error: 'missing route' }, { status: payloads[String(input)] ? 200 : 404 });
+      },
+    });
+
+    await expect(client.health()).resolves.toMatchObject({ status: 'ok', version: '26.5.30' });
+    await expect(client.metrics()).resolves.toMatchObject({ requestCount: 7, activeConnections: 0 });
+    await expect(client.menu()).resolves.toMatchObject({ items: [{ label: 'Vector' }] });
+    await expect(client.vectorSearch({ q: 'oracle memory', limit: 5, type: 'docs' })).resolves.toMatchObject({ total: 1, query: 'oracle memory' });
+    await expect(client.plugins()).resolves.toMatchObject({ plugins: [{ name: 'echo' }] });
+
+    expect(calls.map((call) => String(call.input))).toEqual([
+      '/api/health',
+      '/api/metrics',
+      '/api/menu',
+      '/api/vector/search?q=oracle+memory&limit=5&type=docs',
+      '/api/plugins',
+    ]);
+    for (const call of calls) {
+      expect(new Headers(call.init?.headers).get('accept')).toBe('application/json');
+    }
+  });
+
+  test('supports base URLs, custom headers, and JSON request bodies', async () => {
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    const client = createApiClient({
+      baseUrl: 'http://localhost:47778',
+      headers: { 'x-client': 'studio' },
+      fetch: (input, init) => {
+        calls.push({ input, init });
+        return jsonResponse({ items: [] });
+      },
+    });
+
+    await client.request('/api/menu', { method: 'POST', body: JSON.stringify({ refresh: true }) });
+
+    expect(String(calls[0]?.input)).toBe('http://localhost:47778/api/menu');
+    const headers = new Headers(calls[0]?.init?.headers);
+    expect(headers.get('x-client')).toBe('studio');
+    expect(headers.get('content-type')).toBe('application/json');
+  });
+
+  test('wraps network, JSON parse, and non-OK failures', async () => {
+    const networkClient = createApiClient({ fetch: () => { throw new Error('ECONNREFUSED'); } });
+    await expect(networkClient.health()).rejects.toMatchObject({
+      status: 0,
+      path: '/api/health',
+      message: '/api/health is unreachable: ECONNREFUSED',
+    } as ApiClientError);
+
+    const invalidClient = createApiClient({ fetch: () => new Response('{nope', { status: 200 }) });
+    await expect(invalidClient.plugins()).rejects.toMatchObject({
+      status: 200,
+      path: '/api/plugins',
+      message: '/api/plugins returned invalid JSON',
+    } as ApiClientError);
+
+    const errorClient = createApiClient({ fetch: () => jsonResponse({ error: 'offline' }, { status: 503, statusText: 'Unavailable' }) });
+    await expect(errorClient.metrics()).rejects.toMatchObject({
+      status: 503,
+      path: '/api/metrics',
+      message: '/api/metrics returned 503: offline',
+    } as ApiClientError);
+  });
+});


### PR DESCRIPTION
## Summary\n- add frontend/src/api/client.ts typed wrapper for /api/health, /api/metrics, /api/menu, /api/vector/search, and /api/plugins\n- extend backend public response types used by the client\n- add frontend API client coverage for route calls, base URL/header behavior, and error handling\n\n## Verification\n- tsc --noEmit\n- bun run --cwd frontend build\n- bun test tests/frontend/api-client.test.ts\n- bun test tests/frontend/\n- changed files <=250 lines