### PR TITLE
Add startup self-test

### DIFF
--- a/src/lifecycle/self-test.ts
+++ b/src/lifecycle/self-test.ts
@@ -1,0 +1,106 @@
+import { existsSync } from 'node:fs';
+import { configPath, generateDefaultConfig, loadVectorConfig, type VectorServerConfig } from '../vector/config.ts';
+
+export type SelfTestStatus = 'pass' | 'fail';
+export type MaybePromise<T> = T | Promise<T>;
+
+export interface StartupSelfTestCheck {
+  name: string;
+  run: () => MaybePromise<void>;
+}
+
+export interface StartupSelfTestResult {
+  name: string;
+  status: SelfTestStatus;
+  message: string;
+}
+
+export interface StartupSelfTestOptions {
+  checks: readonly StartupSelfTestCheck[];
+  log?: (message: string) => void;
+}
+
+export interface StartupSelfTestDependencies {
+  dbPing: () => MaybePromise<string | void>;
+  healthFetch: () => MaybePromise<Response>;
+  vectorConfig?: () => unknown;
+}
+
+export function createStartupSelfTest(deps: StartupSelfTestDependencies): StartupSelfTestCheck[] {
+  return [
+    { name: 'db', run: () => assertDbPing(deps.dbPing) },
+    { name: 'health-endpoint', run: () => assertHealthEndpoint(deps.healthFetch) },
+    { name: 'vector-config', run: () => validateVectorConfig(readVectorConfig(deps.vectorConfig)) },
+  ];
+}
+
+export async function runStartupSelfTest(options: StartupSelfTestOptions): Promise<StartupSelfTestResult[]> {
+  const log = options.log ?? console.log;
+  const results: StartupSelfTestResult[] = [];
+  for (const check of options.checks) {
+    try {
+      await check.run();
+      results.push({ name: check.name, status: 'pass', message: 'ok' });
+      log(`[SelfTest] PASS ${check.name}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      results.push({ name: check.name, status: 'fail', message });
+      log(`[SelfTest] FAIL ${check.name} — ${message}`);
+    }
+  }
+  const passed = results.filter((result) => result.status === 'pass').length;
+  log(`[SelfTest] summary: ${passed} passed, ${results.length - passed} failed`);
+  return results;
+}
+
+export function validateVectorConfig(config: unknown): asserts config is VectorServerConfig {
+  if (!isRecord(config)) throw new Error('vector config must be an object');
+  if (!filled(config.version)) throw new Error('vector config version is required');
+  if (!filled(config.host)) throw new Error('vector config host is required');
+  if (!validPort(config.port)) throw new Error('vector config port must be 1-65535');
+  if (!filled(config.dataPath)) throw new Error('vector config dataPath is required');
+  if (!isRecord(config.collections) || Object.keys(config.collections).length === 0) {
+    throw new Error('vector config collections must not be empty');
+  }
+  for (const [name, collection] of Object.entries(config.collections)) {
+    validateVectorCollection(name, collection);
+  }
+}
+
+async function assertDbPing(dbPing: StartupSelfTestDependencies['dbPing']): Promise<void> {
+  const status = await dbPing();
+  if (typeof status === 'string' && status !== 'ok') throw new Error(status);
+}
+
+async function assertHealthEndpoint(healthFetch: StartupSelfTestDependencies['healthFetch']): Promise<void> {
+  const response = await healthFetch();
+  if (!response.ok) throw new Error(`/api/health responded ${response.status}`);
+}
+
+function readVectorConfig(loader?: () => unknown): unknown {
+  if (loader) return loader();
+  const path = configPath();
+  const loaded = loadVectorConfig(path);
+  if (loaded) return loaded;
+  if (existsSync(path)) throw new Error(`vector config ${path} could not be parsed`);
+  return generateDefaultConfig();
+}
+
+function validateVectorCollection(name: string, collection: unknown): void {
+  if (!isRecord(collection)) throw new Error(`vector collection ${name} must be an object`);
+  if (!filled(collection.collection)) throw new Error(`vector collection ${name} collection is required`);
+  if (!filled(collection.model)) throw new Error(`vector collection ${name} model is required`);
+  if (!filled(collection.provider)) throw new Error(`vector collection ${name} provider is required`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function filled(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function validPort(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0 && value <= 65_535;
+}

--- a/src/lifecycle/startup-context.ts
+++ b/src/lifecycle/startup-context.ts
@@ -1,0 +1,33 @@
+import type { BannerMiddleware } from './banner.ts';
+
+export interface RuntimeMiddlewareOptions {
+  rateLimitTokensPerWindow: number;
+  gatewayEnabled: boolean;
+}
+
+export function readStartupDbStatus(ping: () => void): string {
+  try {
+    ping();
+    return 'ok';
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return `degraded (${message})`;
+  }
+}
+
+export function runtimeMiddleware(options: RuntimeMiddlewareOptions): BannerMiddleware[] {
+  return [
+    { name: 'request-logger' },
+    { name: 'correlation' },
+    { name: 'private-network-preflight' },
+    { name: 'cors' },
+    { name: 'body-limit' },
+    { name: 'rate-limit', detail: `${options.rateLimitTokensPerWindow}/min` },
+    { name: 'api-key-auth' },
+    { name: 'metrics' },
+    { name: 'structured-errors' },
+    { name: 'not-found' },
+    { name: 'swagger' },
+    { name: 'gateway', enabled: options.gatewayEnabled },
+  ];
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,7 +21,9 @@ import { closeCachedVectorStores } from './vector/factory.ts';
 import { isDraining, registerGracefulShutdown, trackRequest } from './lifecycle/shutdown.ts';
 import { createErrorMiddleware } from './middleware/errors.ts';
 import { validateStartupEnv } from './config/validate.ts';
-import { printStartupBanner, type BannerMiddleware } from './lifecycle/banner.ts';
+import { printStartupBanner } from './lifecycle/banner.ts';
+import { createStartupSelfTest, runStartupSelfTest } from './lifecycle/self-test.ts';
+import { readStartupDbStatus, runtimeMiddleware } from './lifecycle/startup-context.ts';
 import { createRequestLogger } from './middleware/logger.ts';
 import { createRateLimitMiddleware } from './middleware/rate-limit.ts';
 import { createApiVersionHeaderMiddleware, createApiVersionedFetch } from './middleware/api-version.ts';
@@ -205,40 +207,25 @@ const modules = [...apiModules, mcpRoutes, menuRoutes];
 for (const mod of modules) app.use(mod as any);
 app.use(createNotFoundMiddleware());
 
+const dbStatus = () => readStartupDbStatus(() => db.select({ key: settings.key }).from(settings).limit(1).all());
+const middleware = runtimeMiddleware({
+  rateLimitTokensPerWindow: startupConfig.profile.rateLimit.tokensPerWindow,
+  gatewayEnabled: Boolean(VECTOR_URL) || process.env.ORACLE_GATEWAY_HOT_RELOAD !== '0',
+});
+
 printStartupBanner({
   version: pkg.version,
   port: Number(PORT),
   profile: startupConfig.profile.env,
-  middleware: enabledMiddleware(),
-  dbStatus: startupDbStatus(),
+  middleware,
+  dbStatus: dbStatus(),
 });
-
-function startupDbStatus(): string {
-  try {
-    db.select({ key: settings.key }).from(settings).limit(1).all();
-    return 'ok';
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    return `degraded (${message})`;
-  }
-}
-
-function enabledMiddleware(): BannerMiddleware[] {
-  return [
-    { name: 'request-logger' },
-    { name: 'correlation' },
-    { name: 'private-network-preflight' },
-    { name: 'cors' },
-    { name: 'body-limit' },
-    { name: 'rate-limit', detail: `${startupConfig.profile.rateLimit.tokensPerWindow}/min` },
-    { name: 'api-key-auth' },
-    { name: 'metrics' },
-    { name: 'structured-errors' },
-    { name: 'not-found' },
-    { name: 'swagger' },
-    { name: 'gateway', enabled: Boolean(VECTOR_URL) || process.env.ORACLE_GATEWAY_HOT_RELOAD !== '0' },
-  ];
-}
+await runStartupSelfTest({
+  checks: createStartupSelfTest({
+    dbPing: dbStatus,
+    healthFetch: () => app.fetch(new Request(`http://127.0.0.1:${PORT}/api/health`)),
+  }),
+});
 
 const serverFetch = createRequestTimeoutFetch(createApiVersionedFetch((request) => app.fetch(request)));
 

--- a/tests/lifecycle/self-test.test.ts
+++ b/tests/lifecycle/self-test.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  createStartupSelfTest,
+  runStartupSelfTest,
+  validateVectorConfig,
+} from '../../src/lifecycle/self-test.ts';
+
+describe('startup self-test', () => {
+  test('logs pass and fail results without throwing', async () => {
+    const logs: string[] = [];
+    const results = await runStartupSelfTest({
+      checks: [
+        { name: 'db', run: () => undefined },
+        { name: 'health-endpoint', run: () => { throw new Error('boom'); } },
+      ],
+      log: (message) => logs.push(message),
+    });
+
+    expect(results).toEqual([
+      { name: 'db', status: 'pass', message: 'ok' },
+      { name: 'health-endpoint', status: 'fail', message: 'boom' },
+    ]);
+    expect(logs).toContain('[SelfTest] PASS db');
+    expect(logs).toContain('[SelfTest] FAIL health-endpoint — boom');
+    expect(logs.at(-1)).toBe('[SelfTest] summary: 1 passed, 1 failed');
+  });
+
+  test('checks db ping, health endpoint, and vector config dependencies', async () => {
+    const results = await runStartupSelfTest({
+      checks: createStartupSelfTest({
+        dbPing: () => 'ok',
+        healthFetch: async () => new Response('{}', { status: 200 }),
+        vectorConfig: () => validVectorConfig(),
+      }),
+      log: () => undefined,
+    });
+
+    expect(results.map((result) => result.name)).toEqual(['db', 'health-endpoint', 'vector-config']);
+    expect(results.every((result) => result.status === 'pass')).toBe(true);
+  });
+
+  test('rejects incomplete vector config with a clear message', () => {
+    expect(() => validateVectorConfig({ version: '1.0', host: '0.0.0.0', port: 8081, dataPath: '/tmp', collections: {} }))
+      .toThrow(/collections must not be empty/);
+  });
+});
+
+function validVectorConfig() {
+  return {
+    version: '1.0',
+    host: '0.0.0.0',
+    port: 8081,
+    collections: {
+      main: { collection: 'oracle_knowledge', model: 'nomic-embed-text', provider: 'none' },
+    },
+    dataPath: '/tmp/lancedb',
+    embeddingEndpoint: '',
+  };
+}


### PR DESCRIPTION
## Summary
- add a startup self-test runner for DB ping, /api/health, and vector config validation
- run the self-test after the startup banner and log per-check pass/fail
- split startup context helpers so server.ts remains under the 250-line limit

## Verification
- bun test tests/lifecycle/
- bun run build
- git diff --check
- wc -l src/server.ts src/lifecycle/self-test.ts src/lifecycle/startup-context.ts tests/lifecycle/self-test.test.ts