### PR TITLE
Trace Drizzle queries with request IDs

### DIFF
--- a/src/middleware/correlation.ts
+++ b/src/middleware/correlation.ts
@@ -81,7 +81,7 @@ export function createCorrelationMiddleware(observer?: ResponseTimingObserver) {
   return new Elysia({ name: 'request-correlation' })
     .state({ requestId: '', requestStartedAtMs: 0, responseTimeMs: 0 })
     .onRequest(({ request, set, store }) => {
-      const requestId = rememberRequestId(request, createRequestId());
+      const requestId = requestIdFor(request);
       rememberRequestStart(request);
       updateStore(store, request, requestId);
       setRequestIdHeader(set, requestId);

--- a/src/middleware/db-context.ts
+++ b/src/middleware/db-context.ts
@@ -1,0 +1,57 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { Logger } from 'drizzle-orm/logger';
+import { requestIdFor } from './correlation.ts';
+
+export type DbRequestContext = {
+  requestId: string;
+};
+
+export type DbQueryTrace = DbRequestContext & {
+  query: string;
+  params: unknown[];
+};
+
+export type DbQueryTraceObserver = (trace: DbQueryTrace) => void;
+
+type FetchHandler = (request: Request) => Response | Promise<Response>;
+
+const dbRequestContext = new AsyncLocalStorage<DbRequestContext>();
+let dbQueryTraceObserver: DbQueryTraceObserver | undefined;
+
+export function currentDbRequestContext(): DbRequestContext | undefined {
+  return dbRequestContext.getStore();
+}
+
+export function currentDbRequestId(): string | undefined {
+  return currentDbRequestContext()?.requestId;
+}
+
+export function runWithDbRequestContext<T>(requestId: string, callback: () => T): T {
+  return dbRequestContext.run({ requestId }, callback);
+}
+
+export function createDbContextFetch(next: FetchHandler): FetchHandler {
+  return (request) => runWithDbRequestContext(requestIdFor(request), () => next(request));
+}
+
+export function setDbQueryTraceObserverForTests(observer?: DbQueryTraceObserver): () => void {
+  const previous = dbQueryTraceObserver;
+  dbQueryTraceObserver = observer;
+  return () => {
+    dbQueryTraceObserver = previous;
+  };
+}
+
+function emitDbQueryTrace(query: string, params: unknown[]): void {
+  const requestId = currentDbRequestId();
+  if (!requestId) return;
+  dbQueryTraceObserver?.({ requestId, query, params });
+}
+
+export function createDbContextQueryLogger(observer = emitDbQueryTrace): Logger {
+  return {
+    logQuery(query, params) {
+      observer(query, params);
+    },
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,6 +28,7 @@ import { createRequestTimeoutFetch } from './middleware/timeout.ts';
 import { createBodyLimitMiddleware } from './middleware/body-limit.ts';
 import { createNotFoundMiddleware } from './middleware/not-found.ts';
 import { createEtagMiddleware } from './middleware/etag.ts';
+import { createDbContextFetch } from './middleware/db-context.ts';
 
 // Elysia sub-apps — one per cluster
 import { authRoutes } from './routes/auth/index.ts';
@@ -241,7 +242,7 @@ function enabledMiddleware(): BannerMiddleware[] {
   ];
 }
 
-const serverFetch = createRequestTimeoutFetch(createApiVersionedFetch((request) => app.fetch(request)));
+const serverFetch = createRequestTimeoutFetch(createApiVersionedFetch(createDbContextFetch((request: Request) => app.fetch(request))));
 
 export default {
   port: Number(PORT),

--- a/src/storage/drizzle-sqlite.ts
+++ b/src/storage/drizzle-sqlite.ts
@@ -8,6 +8,7 @@ import fs from 'fs';
 import path from 'path';
 import { DB_PATH } from '../config.ts';
 import * as schema from '../db/schema.ts';
+import { createDbContextQueryLogger } from '../middleware/db-context.ts';
 import type { StorageBackend, StorageBackendOptions } from './types.ts';
 
 const MIGRATIONS_FOLDER = path.join(import.meta.dirname, '../db/migrations');
@@ -67,7 +68,7 @@ export function createDrizzleSqliteBackend(
   const sqlite = options.readonly
     ? new Database(resolvedPath, { readonly: true })
     : new Database(resolvedPath);
-  const db = drizzle(sqlite, { schema });
+  const db = drizzle(sqlite, { schema, logger: createDbContextQueryLogger() });
 
   if (!options.readonly) initializeDrizzleSqlite(db);
 

--- a/tests/http/db-context/request-trace.test.ts
+++ b/tests/http/db-context/request-trace.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { eq } from 'drizzle-orm';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { settings } from '../../../src/db/schema.ts';
+import { createDbContextFetch, currentDbRequestContext, currentDbRequestId, setDbQueryTraceObserverForTests, type DbQueryTrace } from '../../../src/middleware/db-context.ts';
+import { createCorrelationMiddleware, REQUEST_ID_HEADER } from '../../../src/middleware/correlation.ts';
+import { createStorageBackend } from '../../../src/storage/registry.ts';
+import type { StorageBackend } from '../../../src/storage/types.ts';
+
+let tempDir = '';
+let restoreTraceObserver: (() => void) | undefined;
+let backend: StorageBackend | undefined;
+
+afterEach(() => {
+  restoreTraceObserver?.();
+  restoreTraceObserver = undefined;
+  backend?.close();
+  backend = undefined;
+  if (tempDir && fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true });
+  tempDir = '';
+});
+
+function createBackend(): StorageBackend {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-db-context-'));
+  backend = createStorageBackend({ dbPath: path.join(tempDir, 'oracle.db') });
+  return backend;
+}
+
+function createApp(storage: StorageBackend) {
+  return new Elysia()
+    .use(createCorrelationMiddleware())
+    .get('/db-write', ({ requestId }) => {
+      const key = 'db_context_request_trace';
+      storage.db.insert(settings)
+        .values({ key, value: requestId, updatedAt: Date.now() })
+        .onConflictDoUpdate({ target: settings.key, set: { value: requestId, updatedAt: Date.now() } })
+        .run();
+      const row = storage.db.select({ value: settings.value }).from(settings).where(eq(settings.key, key)).get();
+      return { requestId, stored: row?.value, dbContext: currentDbRequestContext() };
+    });
+}
+
+test('db context attaches the X-Request-Id to Drizzle query traces', async () => {
+  const storage = createBackend();
+  const traces: DbQueryTrace[] = [];
+  restoreTraceObserver = setDbQueryTraceObserverForTests((trace) => traces.push(trace));
+  const app = createApp(storage);
+  const handle = createDbContextFetch((request) => app.handle(request));
+
+  const response = await handle(new Request('http://local/db-write', {
+    headers: { [REQUEST_ID_HEADER]: 'request-trace-test-id' },
+  }));
+  const body = await response.json() as { requestId: string; stored: string; dbContext: { requestId: string } };
+
+  expect(response.status).toBe(200);
+  expect(response.headers.get(REQUEST_ID_HEADER)).toBe('request-trace-test-id');
+  expect(body).toEqual({
+    requestId: 'request-trace-test-id',
+    stored: 'request-trace-test-id',
+    dbContext: { requestId: 'request-trace-test-id' },
+  });
+  expect(currentDbRequestId()).toBeUndefined();
+  expect(traces.length).toBeGreaterThanOrEqual(2);
+  expect(traces.every((trace) => trace.requestId === 'request-trace-test-id')).toBe(true);
+  expect(traces.some((trace) => trace.query.toLowerCase().includes('settings'))).toBe(true);
+  expect(traces.every((trace) => Array.isArray(trace.params))).toBe(true);
+});


### PR DESCRIPTION
## Summary\n- Add request-scoped DB context middleware using X-Request-Id\n- Wire Drizzle sqlite backend to emit request-tagged query traces\n- Preserve inbound request IDs through correlation and add scoped HTTP coverage\n\n## Tests\n- tsc --noEmit\n- bun test tests/http/db-context/\n- bun test tests/http/correlation/ tests/http/timing/ tests/http/timeout/ tests/integration/middleware-stack.test.ts tests/http/etag/\n- bun test --coverage tests/http/db-context/ (src/middleware/db-context.ts 100% lines/functions)