### PR TITLE
Add changelog generator CLI

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -116,6 +116,12 @@ async function main() {
     process.exit(await huginnCommand(args.slice(1)));
   }
 
+  if (cmd === "changelog") {
+    if (hasHelpFlag(args.slice(1))) return printBuiltinHelp(cmd);
+    const { changelogCommand } = await import("../../src/cli/commands/changelog.ts");
+    process.exit(await changelogCommand(args.slice(1)));
+  }
+
   if (cmd === "export") {
     const { exportCommand } = await import("../../src/cli/commands/export.ts");
     process.exit(await exportCommand(args.slice(1)));

--- a/cli/src/commands/catalog.ts
+++ b/cli/src/commands/catalog.ts
@@ -18,6 +18,7 @@ export const BUILTIN_COMMANDS: CommandSpec[] = [
   { command: "completions", help: "print shell completion scripts", subcommands: ["bash", "zsh", "fish"], flags: ["--help", "-h"] },
   { command: "peers", help: "probe configured federation peers", flags: ["--token", "--json", "--help", "-h"] },
   { command: "huginn", help: "run Huginn capture utilities", subcommands: ["sweep"], flags: ["--sessions-dir", "--repo-root", "--lookback-hours", "--max-files", "--json", "--help", "-h"] },
+  { command: "changelog", help: "generate CHANGELOG.md from git history", flags: ["--since", "--out", "--stdout", "--help", "-h"] },
   { command: "export", help: "export vault data as JSON", flags: ["--format", "--out", "--help", "-h"] },
   { command: "import", help: "import vault data from JSON", flags: ["--format", "--in", "--help", "-h"] },
 ];

--- a/src/cli/commands/changelog.ts
+++ b/src/cli/commands/changelog.ts
@@ -1,0 +1,161 @@
+import { writeFile } from "fs/promises";
+import { isAbsolute, resolve } from "path";
+
+export const CHANGE_TYPES = ["feat", "fix", "docs", "test", "chore"] as const;
+
+export type ChangeType = typeof CHANGE_TYPES[number];
+
+export interface ChangelogOptions {
+  cwd?: string;
+  outFile?: string;
+  since?: string;
+  stdout?: boolean;
+}
+
+export interface ChangelogCommit {
+  hash: string;
+  subject: string;
+  type: ChangeType;
+  text: string;
+}
+
+const TYPE_LABELS: Record<ChangeType, string> = {
+  feat: "Features",
+  fix: "Fixes",
+  docs: "Documentation",
+  test: "Tests",
+  chore: "Chores",
+};
+
+function printHelp(): void {
+  console.log("arra-cli changelog [--since <tag>] [--out CHANGELOG.md] [--stdout]\n");
+  console.log("Generates CHANGELOG.md entries from git log since the last tag.");
+  console.log("\nFlags:");
+  console.log("  --since <tag>       start after this tag instead of the latest tag");
+  console.log("  --out <file>        write to a custom file (default: CHANGELOG.md)");
+  console.log("  --stdout            print changelog content instead of writing a file");
+  console.log("  --help, -h          show this help");
+}
+
+function readValue(args: string[], flag: string): string | undefined {
+  const index = args.indexOf(flag);
+  if (index >= 0) return args[index + 1];
+  const prefix = `${flag}=`;
+  return args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+}
+
+export function parseChangelogOptions(args: string[]): ChangelogOptions {
+  const since = readValue(args, "--since");
+  const outFile = readValue(args, "--out");
+  return {
+    ...(since ? { since } : {}),
+    ...(outFile ? { outFile } : {}),
+    stdout: args.includes("--stdout"),
+  };
+}
+
+async function git(args: string[], cwd: string): Promise<string> {
+  const proc = Bun.spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const code = await proc.exited;
+  if (code !== 0) throw new Error(stderr.trim() || `git ${args.join(" ")} failed`);
+  return stdout.trim();
+}
+
+async function latestTag(cwd: string): Promise<string | undefined> {
+  try {
+    return (await git(["describe", "--tags", "--abbrev=0"], cwd)) || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function classifySubject(subject: string): Pick<ChangelogCommit, "type" | "text"> {
+  const match = /^(feat|fix|docs|test|chore)(?:\([^)]+\))?!?:\s+(.+)$/i.exec(subject);
+  if (!match) return { type: "chore", text: subject };
+  return { type: match[1].toLowerCase() as ChangeType, text: match[2] };
+}
+
+function parseLog(output: string): ChangelogCommit[] {
+  return output
+    .split("\x1e")
+    .map((record) => record.trim())
+    .filter(Boolean)
+    .map((record) => {
+      const [hash, subject = ""] = record.split("\x1f");
+      return { hash, subject, ...classifySubject(subject) };
+    });
+}
+
+export async function readCommitsSinceTag(options: ChangelogOptions = {}): Promise<{
+  commits: ChangelogCommit[];
+  since?: string;
+}> {
+  const cwd = options.cwd ?? process.cwd();
+  const since = options.since ?? await latestTag(cwd);
+  const range = since ? `${since}..HEAD` : "HEAD";
+  try {
+    const output = await git(["log", range, "--pretty=format:%H%x1f%s%x1e"], cwd);
+    return { commits: parseLog(output), ...(since ? { since } : {}) };
+  } catch (err) {
+    if (String(err).includes("does not have any commits")) return { commits: [], ...(since ? { since } : {}) };
+    throw err;
+  }
+}
+
+export function renderChangelog(commits: ChangelogCommit[], since?: string): string {
+  const lines = ["# Changelog", "", "## Unreleased", ""];
+  lines.push(since ? `Changes since \`${since}\`.` : "Changes from the full git history.");
+  lines.push("");
+  const byType = new Map<ChangeType, ChangelogCommit[]>();
+  for (const type of CHANGE_TYPES) byType.set(type, []);
+  for (const commit of commits) byType.get(commit.type)?.push(commit);
+
+  let wroteEntry = false;
+  for (const type of CHANGE_TYPES) {
+    const entries = byType.get(type) ?? [];
+    if (!entries.length) continue;
+    wroteEntry = true;
+    lines.push(`### ${TYPE_LABELS[type]}`);
+    for (const entry of entries) lines.push(`- ${entry.text} (${entry.hash.slice(0, 7)})`);
+    lines.push("");
+  }
+  if (!wroteEntry) lines.push("No matching changes.", "");
+  return lines.join("\n");
+}
+
+export async function generateChangelog(options: ChangelogOptions = {}): Promise<string> {
+  const { commits, since } = await readCommitsSinceTag(options);
+  return renderChangelog(commits, since);
+}
+
+function outputPath(cwd: string, outFile?: string): string {
+  const file = outFile ?? "CHANGELOG.md";
+  return isAbsolute(file) ? file : resolve(cwd, file);
+}
+
+export async function changelogCommand(args: string[]): Promise<number> {
+  if (args.includes("--help") || args.includes("-h")) {
+    printHelp();
+    return 0;
+  }
+
+  try {
+    const options = parseChangelogOptions(args);
+    const cwd = options.cwd ?? process.cwd();
+    const content = await generateChangelog({ ...options, cwd });
+    if (options.stdout) process.stdout.write(content);
+    else {
+      const file = outputPath(cwd, options.outFile);
+      await writeFile(file, content, "utf8");
+      process.stdout.write(`wrote ${file}\n`);
+    }
+    return 0;
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+}

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -89,6 +89,13 @@ export const BUILTIN_HELP: CliHelpEntry[] = [
     flags: ["--sessions-dir <path[:path...]>", "--repo-root <path>", "--lookback-hours <n>", "--max-files <n>", "--json", "--help", "-h"],
     examples: ["arra-cli huginn sweep --lookback-hours 24", "arra-cli huginn sweep --sessions-dir ~/.claude/projects --json"],
   },
+  {
+    command: "changelog",
+    help: "generate CHANGELOG.md from git history",
+    usage: "arra-cli changelog [--since <tag>] [--out CHANGELOG.md] [--stdout]",
+    flags: ["--since <tag>", "--out <file>", "--stdout", "--help", "-h"],
+    examples: ["arra-cli changelog", "arra-cli changelog --since v1.2.3 --stdout"],
+  },
 ];
 
 const SUBCOMMAND_HELP: CliHelpEntry[] = [

--- a/tests/cli/changelog/generate.test.ts
+++ b/tests/cli/changelog/generate.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  changelogCommand,
+  generateChangelog,
+  parseChangelogOptions,
+} from "../../../src/cli/commands/changelog.ts";
+import { runCli } from "../_run.ts";
+
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "ARRA Test",
+  GIT_AUTHOR_EMAIL: "arra-test@example.com",
+  GIT_COMMITTER_NAME: "ARRA Test",
+  GIT_COMMITTER_EMAIL: "arra-test@example.com",
+};
+
+async function git(cwd: string, args: string[]): Promise<void> {
+  const proc = Bun.spawn(["git", ...args], { cwd, env: gitEnv, stdout: "pipe", stderr: "pipe" });
+  const stderr = await new Response(proc.stderr).text();
+  const code = await proc.exited;
+  if (code !== 0) throw new Error(stderr);
+}
+
+async function emptyCommit(cwd: string, message: string): Promise<void> {
+  await git(cwd, ["commit", "--allow-empty", "-m", message]);
+}
+
+async function initRepo(cwd: string): Promise<void> {
+  await git(cwd, ["init"]);
+  await git(cwd, ["config", "user.name", "ARRA Test"]);
+  await git(cwd, ["config", "user.email", "arra-test@example.com"]);
+}
+
+async function captureOutput(action: () => Promise<number>): Promise<{
+  code: number;
+  stdout: string;
+  stderr: string;
+}> {
+  const originalWrite = process.stdout.write;
+  const originalLog = console.log;
+  const originalError = console.error;
+  let stdout = "";
+  let stderr = "";
+  (process.stdout as unknown as { write: (chunk: unknown) => boolean }).write = (chunk) => {
+    stdout += String(chunk);
+    return true;
+  };
+  console.log = (...parts: unknown[]) => {
+    stdout += parts.join(" ") + "\n";
+  };
+  console.error = (...parts: unknown[]) => {
+    stderr += parts.join(" ") + "\n";
+  };
+  try {
+    const code = await action();
+    return { code, stdout, stderr };
+  } finally {
+    process.stdout.write = originalWrite;
+    console.log = originalLog;
+    console.error = originalError;
+  }
+}
+
+async function inCwd<T>(cwd: string, action: () => Promise<T>): Promise<T> {
+  const previous = process.cwd();
+  process.chdir(cwd);
+  try {
+    return await action();
+  } finally {
+    process.chdir(previous);
+  }
+}
+
+describe("changelog generator", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "arra-changelog-"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("groups conventional commits since the latest tag", async () => {
+    await initRepo(root);
+    await emptyCommit(root, "chore: baseline");
+    await git(root, ["tag", "v1.0.0"]);
+    await emptyCommit(root, "feat(api): add search");
+    await emptyCommit(root, "fix: repair menu");
+    await emptyCommit(root, "docs: update plugin guide");
+    await emptyCommit(root, "test: cover changelog");
+    await emptyCommit(root, "chore: tidy scripts");
+    await emptyCommit(root, "refactor: simplify internals");
+
+    const output = await generateChangelog({ cwd: root });
+
+    expect(output).toContain("Changes since `v1.0.0`.");
+    expect(output).toContain("### Features\n- add search (");
+    expect(output).toContain("### Fixes\n- repair menu (");
+    expect(output).toContain("### Documentation\n- update plugin guide (");
+    expect(output).toContain("### Tests\n- cover changelog (");
+    expect(output).toContain("### Chores");
+    expect(output).toContain("- tidy scripts (");
+    expect(output).toContain("- refactor: simplify internals (");
+    expect(output).not.toContain("baseline");
+  });
+
+  test("uses full history when no tag exists", async () => {
+    await initRepo(root);
+    await emptyCommit(root, "feat: first release note");
+
+    const output = await generateChangelog({ cwd: root });
+
+    expect(output).toContain("Changes from the full git history.");
+    expect(output).toContain("- first release note (");
+  });
+
+  test("parses spaced and equals-form flags", () => {
+    expect(parseChangelogOptions(["--since", "v1.0.0", "--out=notes.md", "--stdout"])).toEqual({
+      since: "v1.0.0",
+      outFile: "notes.md",
+      stdout: true,
+    });
+  });
+
+  test("writes CHANGELOG.md through the command", async () => {
+    await initRepo(root);
+    await emptyCommit(root, "chore: baseline");
+    await git(root, ["tag", "v1.0.0"]);
+    await emptyCommit(root, "fix: write release notes");
+
+    const result = await inCwd(root, () => captureOutput(() => changelogCommand([])));
+    const path = join(root, "CHANGELOG.md");
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("wrote ");
+    expect(existsSync(path)).toBe(true);
+    expect(readFileSync(path, "utf8")).toContain("- write release notes (");
+  });
+
+  test("prints changelog content to stdout", async () => {
+    await initRepo(root);
+    await emptyCommit(root, "feat: stdout release note");
+
+    const result = await inCwd(root, () => captureOutput(() => changelogCommand(["--stdout"])));
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("# Changelog");
+    expect(result.stdout).toContain("- stdout release note (");
+  });
+
+  test("reports git failures as command errors", async () => {
+    const result = await inCwd(root, () => captureOutput(() => changelogCommand(["--stdout"])));
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toMatch(/git|repository/i);
+  });
+
+  test("prints command help", async () => {
+    const result = await captureOutput(() => changelogCommand(["--help"]));
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("arra-cli changelog");
+    expect(result.stdout).toContain("--since <tag>");
+  });
+
+  test("is wired into the CLI dispatcher", async () => {
+    await initRepo(root);
+    await emptyCommit(root, "docs: cli dispatcher release note");
+
+    const result = await runCli(["changelog", "--stdout"], {
+      HOME: join(root, "home"),
+      ORACLE_DATA_DIR: join(root, "data"),
+    }, { cwd: root });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("- cli dispatcher release note (");
+  }, 15_000);
+});


### PR DESCRIPTION
## Summary\n- add a changelog CLI command that reads git history since the latest tag\n- group generated entries by feat/fix/docs/test/chore and write CHANGELOG.md by default\n- add scoped changelog generator and CLI dispatcher tests\n\n## Tests\n- bunx tsc --noEmit\n- bun test tests/cli/changelog/\n- bun test --coverage tests/cli/changelog/ (100% lines/functions for src/cli/commands/changelog.ts)