### PR TITLE
Add DB migration CLI runner

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -126,6 +126,12 @@ async function main() {
     process.exit(await importCommand(args.slice(1)));
   }
 
+  if (cmd === "migrate") {
+    if (hasHelpFlag(args.slice(1))) return printBuiltinHelp(cmd);
+    const { migrateCommand } = await import("../../src/cli/commands/migrate.ts");
+    process.exit(await migrateCommand(args.slice(1)));
+  }
+
   if (cmd === "use") {
     if (hasHelpFlag(args.slice(1))) return printBuiltinHelp(cmd);
     process.exit(await useCommand(args.slice(1)));

--- a/cli/src/commands/catalog.ts
+++ b/cli/src/commands/catalog.ts
@@ -18,6 +18,7 @@ export const BUILTIN_COMMANDS: CommandSpec[] = [
   { command: "completions", help: "print shell completion scripts", subcommands: ["bash", "zsh", "fish"], flags: ["--help", "-h"] },
   { command: "peers", help: "probe configured federation peers", flags: ["--token", "--json", "--help", "-h"] },
   { command: "huginn", help: "run Huginn capture utilities", subcommands: ["sweep"], flags: ["--sessions-dir", "--repo-root", "--lookback-hours", "--max-files", "--json", "--help", "-h"] },
+  { command: "migrate", help: "run Drizzle migration generate and push", flags: ["--help", "-h"] },
   { command: "export", help: "export vault data as JSON", flags: ["--format", "--out", "--help", "-h"] },
   { command: "import", help: "import vault data from JSON", flags: ["--format", "--in", "--help", "-h"] },
 ];

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -1,0 +1,151 @@
+export interface CommandResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface MigrationStep {
+  name: 'generate' | 'push';
+  command: string[];
+}
+
+export interface MigrationStepResult extends MigrationStep {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+  error?: string;
+}
+
+export interface MigrationRunResult {
+  ok: boolean;
+  steps: MigrationStepResult[];
+}
+
+export type CommandRunner = (
+  command: string[],
+  options: { cwd?: string; env?: NodeJS.ProcessEnv },
+) => Promise<CommandResult>;
+
+type Writer = (message: string) => void;
+
+export interface RunMigrationOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  runner?: CommandRunner;
+  stdout?: Writer;
+  stderr?: Writer;
+}
+
+export const DRIZZLE_MIGRATION_STEPS: MigrationStep[] = [
+  { name: 'generate', command: ['bunx', 'drizzle-kit', 'generate'] },
+  { name: 'push', command: ['bunx', 'drizzle-kit', 'push'] },
+];
+
+export async function runDrizzleMigrations(
+  options: RunMigrationOptions = {},
+): Promise<MigrationRunResult> {
+  const runner = options.runner ?? runCommand;
+  const stdout = options.stdout ?? writeStdout;
+  const stderr = options.stderr ?? writeStderr;
+  const steps: MigrationStepResult[] = [];
+
+  for (const step of DRIZZLE_MIGRATION_STEPS) {
+    stdout(`[migrate] running ${formatCommand(step.command)}\n`);
+    const result = await runStep(step, runner, options);
+    steps.push(result);
+    writeProcessOutput(result, stdout, stderr);
+    if (result.code !== 0) {
+      stderr(`[migrate] ${step.name} failed${exitSuffix(result.code)}\n`);
+      return { ok: false, steps };
+    }
+    stdout(`[migrate] ${step.name} complete\n`);
+  }
+
+  stdout('[migrate] migrations generated and pushed\n');
+  return { ok: true, steps };
+}
+
+export async function migrateCommand(args: string[], options: RunMigrationOptions = {}): Promise<number> {
+  const stdout = options.stdout ?? writeStdout;
+  const stderr = options.stderr ?? writeStderr;
+  if (args.includes('--help') || args.includes('-h')) {
+    printHelp(stdout);
+    return 0;
+  }
+  if (args.length > 0) {
+    stderr(`unknown migrate option: ${args[0]}\n`);
+    printHelp(stderr);
+    return 1;
+  }
+  const result = await runDrizzleMigrations({ ...options, stdout, stderr });
+  return result.ok ? 0 : 1;
+}
+
+async function runStep(
+  step: MigrationStep,
+  runner: CommandRunner,
+  options: RunMigrationOptions,
+): Promise<MigrationStepResult> {
+  try {
+    const result = await runner(step.command, { cwd: options.cwd, env: options.env });
+    return { ...step, ...result };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ...step, code: null, stdout: '', stderr: '', error: message };
+  }
+}
+
+async function runCommand(command: string[], options: { cwd?: string; env?: NodeJS.ProcessEnv }): Promise<CommandResult> {
+  const proc = Bun.spawn(command, {
+    cwd: options.cwd,
+    env: options.env ? { ...process.env, ...options.env } : process.env,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { code, stdout, stderr };
+}
+
+function writeProcessOutput(result: MigrationStepResult, stdout: Writer, stderr: Writer): void {
+  if (result.stdout) stdout(result.stdout);
+  if (result.stderr) stderr(result.stderr);
+  if (result.error) stderr(`${result.error}\n`);
+}
+
+function exitSuffix(code: number | null): string {
+  return code === null ? '' : ` with exit code ${code}`;
+}
+
+function formatCommand(command: string[]): string {
+  return command.map(shellWord).join(' ');
+}
+
+function shellWord(value: string): string {
+  return /^[A-Za-z0-9_./:=@-]+$/.test(value) ? value : JSON.stringify(value);
+}
+
+function printHelp(write: Writer): void {
+  write([
+    'arra-cli migrate',
+    '',
+    'Runs Drizzle schema migration commands in order:',
+    '  1. bunx drizzle-kit generate',
+    '  2. bunx drizzle-kit push',
+    '',
+    'Flags:',
+    '  --help, -h          show this help',
+    '',
+  ].join('\n'));
+}
+
+function writeStdout(message: string): void {
+  process.stdout.write(message);
+}
+
+function writeStderr(message: string): void {
+  process.stderr.write(message);
+}

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -89,6 +89,13 @@ export const BUILTIN_HELP: CliHelpEntry[] = [
     flags: ["--sessions-dir <path[:path...]>", "--repo-root <path>", "--lookback-hours <n>", "--max-files <n>", "--json", "--help", "-h"],
     examples: ["arra-cli huginn sweep --lookback-hours 24", "arra-cli huginn sweep --sessions-dir ~/.claude/projects --json"],
   },
+  {
+    command: "migrate",
+    help: "run Drizzle migration generate and push",
+    usage: "arra-cli migrate",
+    flags: ["--help", "-h"],
+    examples: ["arra-cli migrate"],
+  },
 ];
 
 const SUBCOMMAND_HELP: CliHelpEntry[] = [

--- a/tests/cli/migrate/runner.test.ts
+++ b/tests/cli/migrate/runner.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  migrateCommand,
+  runDrizzleMigrations,
+  type CommandRunner,
+} from '../../../src/cli/commands/migrate.ts';
+import { runCli } from '../_run.ts';
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots) rmSync(root, { recursive: true, force: true });
+  roots.length = 0;
+});
+
+function isolatedEnv(): Record<string, string> {
+  const root = mkdtempSync(join(tmpdir(), 'arra-migrate-cli-'));
+  roots.push(root);
+  return { HOME: join(root, 'home'), ORACLE_DATA_DIR: join(root, 'data'), ORACLE_REPO_ROOT: root };
+}
+
+describe('Drizzle migration runner', () => {
+  test('runs generate then push in order', async () => {
+    const calls: string[][] = [];
+    const output: string[] = [];
+    const runner: CommandRunner = async (command) => {
+      calls.push(command);
+      return { code: 0, stdout: `${command.at(-1)} ok\n`, stderr: '' };
+    };
+
+    const result = await runDrizzleMigrations({ runner, stdout: msg => output.push(msg), stderr: msg => output.push(msg) });
+
+    expect(result.ok).toBe(true);
+    expect(calls).toEqual([
+      ['bunx', 'drizzle-kit', 'generate'],
+      ['bunx', 'drizzle-kit', 'push'],
+    ]);
+    expect(output.join('')).toContain('[migrate] migrations generated and pushed');
+  });
+
+  test('stops before push when generate exits non-zero', async () => {
+    const calls: string[][] = [];
+    const errors: string[] = [];
+    const runner: CommandRunner = async (command) => {
+      calls.push(command);
+      return { code: 7, stdout: '', stderr: 'schema error\n' };
+    };
+
+    const result = await runDrizzleMigrations({ runner, stdout: () => undefined, stderr: msg => errors.push(msg) });
+
+    expect(result.ok).toBe(false);
+    expect(calls).toEqual([['bunx', 'drizzle-kit', 'generate']]);
+    expect(result.steps[0]?.code).toBe(7);
+    expect(errors.join('')).toContain('schema error');
+    expect(errors.join('')).toContain('generate failed with exit code 7');
+  });
+
+  test('surfaces spawn errors as command failures', async () => {
+    const errors: string[] = [];
+    const result = await runDrizzleMigrations({
+      runner: async () => { throw new Error('spawn failed'); },
+      stdout: () => undefined,
+      stderr: msg => errors.push(msg),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.steps[0]?.code).toBeNull();
+    expect(result.steps[0]?.error).toBe('spawn failed');
+    expect(errors.join('')).toContain('spawn failed');
+  });
+
+
+
+  test('CLI help exposes the migrate command without running drizzle-kit', async () => {
+    const result = await runCli(['migrate', '--help'], isolatedEnv());
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('Usage: arra-cli migrate');
+    expect(result.stdout).toContain('run Drizzle migration generate and push');
+  }, 15_000);
+
+  test('migrateCommand returns non-zero for unknown flags without running commands', async () => {
+    let ran = false;
+    const errors: string[] = [];
+    const code = await migrateCommand(['--bad'], {
+      runner: async () => { ran = true; return { code: 0, stdout: '', stderr: '' }; },
+      stdout: () => undefined,
+      stderr: msg => errors.push(msg),
+    });
+
+    expect(code).toBe(1);
+    expect(ran).toBe(false);
+    expect(errors.join('')).toContain('unknown migrate option: --bad');
+  });
+});


### PR DESCRIPTION
## Summary
- add `src/cli/commands/migrate.ts` to run `bunx drizzle-kit generate` then `bunx drizzle-kit push`
- stop on failed generate/push and surface command stdout/stderr clearly
- wire `arra-cli migrate` into CLI dispatch, help, and completions catalog

## Verification
- `bun test tests/cli/migrate/`
- `bun run build`
- `git diff --check`
- `wc -l src/cli/commands/migrate.ts tests/cli/migrate/runner.test.ts cli/src/cli.ts src/cli/help.ts cli/src/commands/catalog.ts`
