### PR TITLE
Polish frontend dashboard data loading

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
-import { fetchMenu, fetchPlugins } from './api';
+import { apiClient, type ApiClient } from './api/client';
 import { AppShell } from './components/AppShell';
 import { countPluginSurfaces } from './plugin-surfaces';
 import { McpPage } from './pages/McpPage';
@@ -11,35 +11,101 @@ import { SettingsPage } from './pages/SettingsPage';
 import { VectorPage } from './pages/VectorPage';
 import { VectorSearchResultsPage } from './pages/VectorSearchResultsPage';
 import type { LoadState, MenuItem, PluginEntry } from './types';
+import type { MetricsSnapshot } from '../../src/server/types';
+
+type DashboardClient = Pick<ApiClient, 'menu' | 'plugins' | 'metrics'>;
+type DashboardKey = 'menu' | 'plugins' | 'metrics';
+export type DashboardErrors = Partial<Record<DashboardKey, string>>;
+
+type LoadStates = Record<DashboardKey, LoadState>;
+
+export interface DashboardLoadResult {
+  menu: MenuItem[] | null;
+  plugins: PluginEntry[] | null;
+  metrics: MetricsSnapshot | null;
+  errors: DashboardErrors;
+}
+
+const loadingStates: LoadStates = { menu: 'loading', plugins: 'loading', metrics: 'loading' };
+const idleStates: LoadStates = { menu: 'idle', plugins: 'idle', metrics: 'idle' };
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function stateFor(key: DashboardKey, errors: DashboardErrors): LoadState {
+  return errors[key] ? 'error' : 'ready';
+}
+
+function isLoading(state: LoadState): boolean {
+  return state === 'loading' || state === 'idle';
+}
+
+export async function loadDashboardData(client: DashboardClient = apiClient): Promise<DashboardLoadResult> {
+  const [menu, plugins, metrics] = await Promise.allSettled([
+    client.menu(),
+    client.plugins(),
+    client.metrics(),
+  ]);
+  const errors: DashboardErrors = {};
+  if (menu.status === 'rejected') errors.menu = `Menu: ${errorText(menu.reason)}`;
+  if (plugins.status === 'rejected') errors.plugins = `Plugins: ${errorText(plugins.reason)}`;
+  if (metrics.status === 'rejected') errors.metrics = `Metrics: ${errorText(metrics.reason)}`;
+
+  return {
+    menu: menu.status === 'fulfilled' ? menu.value.items : null,
+    plugins: plugins.status === 'fulfilled' ? plugins.value.plugins : null,
+    metrics: metrics.status === 'fulfilled' ? metrics.value : null,
+    errors,
+  };
+}
 
 export default function App() {
-  const [state, setState] = useState<LoadState>('idle');
+  const [states, setStates] = useState<LoadStates>(idleStates);
   const [menu, setMenu] = useState<MenuItem[]>([]);
   const [plugins, setPlugins] = useState<PluginEntry[]>([]);
-  const [error, setError] = useState('');
+  const [metrics, setMetrics] = useState<MetricsSnapshot | null>(null);
+  const [errors, setErrors] = useState<DashboardErrors>({});
   const [updatedAt, setUpdatedAt] = useState('never');
 
   async function load() {
-    setState('loading');
-    setError('');
+    setStates(loadingStates);
+    const result = await loadDashboardData();
+    if (result.menu) setMenu(result.menu);
+    if (result.plugins) setPlugins(result.plugins);
+    if (result.metrics) setMetrics(result.metrics);
+    setErrors(result.errors);
+    setStates({
+      menu: stateFor('menu', result.errors),
+      plugins: stateFor('plugins', result.errors),
+      metrics: stateFor('metrics', result.errors),
+    });
+    setUpdatedAt(new Date().toLocaleTimeString());
+  }
+
+  async function refreshMetrics() {
+    setStates((current) => ({ ...current, metrics: 'loading' }));
     try {
-      const [menuResponse, pluginsResponse] = await Promise.all([fetchMenu(), fetchPlugins()]);
-      setMenu(menuResponse.items);
-      setPlugins(pluginsResponse.plugins);
+      setMetrics(await apiClient.metrics());
+      setErrors(({ metrics: _metrics, ...rest }) => rest);
+      setStates((current) => ({ ...current, metrics: 'ready' }));
       setUpdatedAt(new Date().toLocaleTimeString());
-      setState('ready');
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-      setState('error');
+      setErrors((current) => ({ ...current, metrics: `Metrics: ${errorText(err)}` }));
+      setStates((current) => ({ ...current, metrics: 'error' }));
     }
   }
 
   useEffect(() => {
     void load();
+    const timer = window.setInterval(() => void refreshMetrics(), 5_000);
+    return () => window.clearInterval(timer);
   }, []);
 
   const surfaceCount = useMemo(() => countPluginSurfaces(plugins), [plugins]);
-  const loading = state === 'loading' || state === 'idle';
+  const loading = isLoading(states.menu) || isLoading(states.plugins);
+  const metricsLoading = isLoading(states.metrics);
+  const error = Object.values(errors).filter(Boolean).join(' · ');
   const refresh = () => void load();
 
   return (
@@ -50,13 +116,15 @@ export default function App() {
         menuCount={menu.length}
         pluginCount={plugins.length}
         surfaceCount={surfaceCount}
+        metrics={metrics}
+        metricsLoading={metricsLoading}
         updatedAt={updatedAt}
         onRefresh={refresh}
       >
         <Routes>
           <Route index element={<Navigate to="/menu" replace />} />
-          <Route path="/menu" element={<MenuPage items={menu} loading={loading} />} />
-          <Route path="/plugins" element={<PluginsPage plugins={plugins} loading={loading} />} />
+          <Route path="/menu" element={<MenuPage items={menu} loading={isLoading(states.menu)} />} />
+          <Route path="/plugins" element={<PluginsPage plugins={plugins} loading={isLoading(states.plugins)} />} />
           <Route path="/vector" element={<VectorPage />} />
           <Route path="/vector/results" element={<VectorSearchResultsPage />} />
           <Route path="/mcp" element={<McpPage />} />

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -7,6 +7,7 @@ import { PageChrome } from './PageChrome';
 import { StatCard } from './StatCard';
 import { ThemeToggle } from './ThemeToggle';
 import { GlobalSearch } from './GlobalSearch';
+import type { MetricsSnapshot } from '../../../src/server/types';
 
 type AppShellProps = {
   children: ReactNode;
@@ -15,6 +16,8 @@ type AppShellProps = {
   menuCount: number;
   pluginCount: number;
   surfaceCount: number;
+  metrics?: MetricsSnapshot | null;
+  metricsLoading?: boolean;
   updatedAt: string;
   onRefresh: () => void;
 };
@@ -26,6 +29,8 @@ export function AppShell({
   menuCount,
   pluginCount,
   surfaceCount,
+  metrics = null,
+  metricsLoading = false,
   updatedAt,
   onRefresh,
 }: AppShellProps) {
@@ -48,6 +53,11 @@ export function AppShell({
     { to: '/mcp', label: 'MCP', description: 'Tool schemas and groups' },
     { to: '/settings', label: 'Settings', description: 'Storage, embedder, and DB status' },
   ];
+  const requestValue = metricsLoading ? <Spinner label="Loading metrics" /> : metrics?.requestCount ?? '—';
+  const responseValue = metricsLoading ? <Spinner label="Loading metrics" /> : `${metrics?.avgResponseMs ?? 0} ms`;
+  const metricsDetail = metrics
+    ? `${metrics.activeConnections} active · uptime ${Math.round(metrics.uptime)}s`
+    : 'from /api/metrics';
   const retry = (
     <button
       aria-label="Retry loading backend dashboard data"
@@ -89,10 +99,12 @@ export function AppShell({
             </div>
           </header>
 
-          <section className="grid gap-3 sm:grid-cols-3 sm:gap-4" aria-label="Summary">
+          <section className="grid gap-3 sm:grid-cols-2 sm:gap-4 xl:grid-cols-5" aria-label="Summary">
             <StatCard label="Menu items" value={loading ? <Spinner label="Loading" /> : menuCount} detail="from /api/menu" />
             <StatCard label="Plugins" value={loading ? <Spinner label="Loading" /> : pluginCount} detail="from /api/plugins" />
             <StatCard label="Surfaces" value={loading ? <Spinner label="Loading" /> : surfaceCount} detail={`updated ${updatedAt}`} />
+            <StatCard label="Requests" value={requestValue} detail={metricsDetail} />
+            <StatCard label="Avg response" value={responseValue} detail="real-time backend latency" />
           </section>
 
           {error ? <ErrorMessage title="Could not load backend data." message={error} action={retry} /> : null}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,4 +1,4 @@
-export type MenuGroup = 'main' | 'tools' | 'hidden';
+export type MenuGroup = 'main' | 'tools' | 'admin' | 'hidden';
 
 export interface MenuItem {
   label: string;

--- a/tests/frontend/dashboard.test.ts
+++ b/tests/frontend/dashboard.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test';
+import { createElement } from 'react';
+import App, { loadDashboardData } from '../../frontend/src/App';
+import { htmlFor, installBrowserLocation } from './_render';
+
+describe('dashboard data loading', () => {
+  test('loads menu, plugins, and metrics through the typed API client surface', async () => {
+    const result = await loadDashboardData({
+      menu: async () => ({ items: [{ label: 'Menu', path: '/menu', group: 'main', order: 1, source: 'api' }] }),
+      plugins: async () => ({ dir: '/plugins', plugins: [{ name: 'echo', file: 'echo.wasm', size: 12, modified: 'now' }] }),
+      metrics: async () => ({ uptime: 12.5, requestCount: 42, avgResponseMs: 3.2, activeConnections: 1, lastRestart: '2026-06-16T00:00:00.000Z' }),
+    });
+
+    expect(result.errors).toEqual({});
+    expect(result.menu).toMatchObject([{ label: 'Menu', path: '/menu' }]);
+    expect(result.plugins).toMatchObject([{ name: 'echo' }]);
+    expect(result.metrics).toMatchObject({ requestCount: 42, avgResponseMs: 3.2 });
+  });
+
+  test('keeps successful route data while reporting failed metric fetches', async () => {
+    const result = await loadDashboardData({
+      menu: async () => ({ items: [] }),
+      plugins: async () => ({ dir: '/plugins', plugins: [] }),
+      metrics: async () => { throw new Error('/api/metrics unavailable'); },
+    });
+
+    expect(result.menu).toEqual([]);
+    expect(result.plugins).toEqual([]);
+    expect(result.metrics).toBeNull();
+    expect(result.errors.metrics).toBe('Metrics: /api/metrics unavailable');
+  });
+
+  test('renders dashboard metric cards with loading state before effects resolve', () => {
+    const restore = installBrowserLocation('/menu');
+    try {
+      const html = htmlFor(createElement(App));
+      expect(html).toContain('Requests');
+      expect(html).toContain('Avg response');
+      expect(html).toContain('Loading metrics');
+      expect(html).toContain('/api/metrics');
+    } finally {
+      restore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary\n- switch App dashboard loading to the typed frontend API client\n- load menu, plugins, and metrics independently with partial-error handling\n- add real-time /api/metrics summary cards and periodic metric refresh\n- cover dashboard loader and initial metric loading UI\n\n## Verification\n- bun test tests/frontend/dashboard.test.ts\n- bun test tests/frontend/\n- bun run --cwd frontend build\n- tsc --noEmit\n- changed files <=250 lines