### PR TITLE
feat: add response compression middleware

### DIFF
--- a/src/lifecycle/startup-context.ts
+++ b/src/lifecycle/startup-context.ts
@@ -25,6 +25,7 @@ export function runtimeMiddleware(options: RuntimeMiddlewareOptions): BannerMidd
     { name: 'rate-limit', detail: `${options.rateLimitTokensPerWindow}/min` },
     { name: 'api-key-auth' },
     { name: 'metrics' },
+    { name: 'compress' },
     { name: 'etag' },
     { name: 'structured-errors' },
     { name: 'not-found' },

--- a/src/middleware/compress.ts
+++ b/src/middleware/compress.ts
@@ -1,0 +1,108 @@
+import { Elysia } from 'elysia';
+
+export const CONTENT_ENCODING_HEADER = 'Content-Encoding';
+export const MIN_COMPRESSIBLE_BYTES = 1024;
+const ACCEPT_ENCODING_HEADER = 'Accept-Encoding';
+const VARY_HEADER = 'Vary';
+const encoder = new TextEncoder();
+
+type CompressionEncoding = 'gzip' | 'deflate';
+type HeaderValue = string | number | string[];
+type HeaderMap = Record<string, HeaderValue>;
+
+function qValue(entry: string): number {
+  const q = entry.split(';').slice(1).find((part) => part.trim().toLowerCase().startsWith('q='));
+  if (!q) return 1;
+  const parsed = Number(q.split('=')[1]?.trim());
+  return Number.isFinite(parsed) && parsed >= 0 && parsed <= 1 ? parsed : 0;
+}
+
+function tokens(header: string | null): Map<string, number> {
+  const result = new Map<string, number>();
+  for (const raw of header?.split(',') ?? []) {
+    const name = raw.split(';')[0]?.trim().toLowerCase();
+    if (name) result.set(name, qValue(raw));
+  }
+  return result;
+}
+
+export function acceptedEncoding(header: string | null): CompressionEncoding | null {
+  const accepted = tokens(header);
+  if ((accepted.get('gzip') ?? accepted.get('*') ?? 0) > 0) return 'gzip';
+  if ((accepted.get('deflate') ?? accepted.get('*') ?? 0) > 0) return 'deflate';
+  return null;
+}
+
+function responseStatus(response: unknown, setStatus: unknown): number {
+  if (response instanceof Response) return response.status;
+  return typeof setStatus === 'number' ? setStatus : 200;
+}
+
+function isBodyAllowed(status: number): boolean {
+  return status !== 204 && status !== 205 && status !== 304;
+}
+
+function hasHeader(headers: HeaderMap, name: string): boolean {
+  const lower = name.toLowerCase();
+  return Object.keys(headers).some((key) => key.toLowerCase() === lower);
+}
+
+function hasContentEncoding(response: unknown, headers: HeaderMap): boolean {
+  return hasHeader(headers, CONTENT_ENCODING_HEADER)
+    || (response instanceof Response && response.headers.has(CONTENT_ENCODING_HEADER));
+}
+
+export async function responseBodyBytes(response: unknown): Promise<Uint8Array> {
+  if (response instanceof Response) return new Uint8Array(await response.clone().arrayBuffer());
+  if (response === undefined || response === null) return new Uint8Array();
+  if (response instanceof Uint8Array) return response;
+  if (typeof response === 'string') return encoder.encode(response);
+  return encoder.encode(JSON.stringify(response));
+}
+
+export function compressBytes(bytes: Uint8Array, encoding: CompressionEncoding): Uint8Array {
+  const input = new Uint8Array(bytes);
+  return encoding === 'gzip' ? Bun.gzipSync(input) : Bun.deflateSync(input);
+}
+
+function mergedHeaders(response: unknown, setHeaders: HeaderMap): Headers {
+  const headers = new Headers(response instanceof Response ? response.headers : undefined);
+  for (const [key, value] of Object.entries(setHeaders)) {
+    headers.set(key, Array.isArray(value) ? value.join(', ') : String(value));
+  }
+  return headers;
+}
+
+function addVary(headers: Headers): void {
+  const current = headers.get(VARY_HEADER);
+  if (!current) return headers.set(VARY_HEADER, ACCEPT_ENCODING_HEADER);
+  if (current === '*' || current.toLowerCase().split(',').map((part) => part.trim()).includes('accept-encoding')) return;
+  headers.set(VARY_HEADER, `${current}, ${ACCEPT_ENCODING_HEADER}`);
+}
+
+export async function compressedResponse(
+  request: Request,
+  response: unknown,
+  setStatus: unknown,
+  setHeaders: HeaderMap,
+): Promise<Response | undefined> {
+  const encoding = acceptedEncoding(request.headers.get(ACCEPT_ENCODING_HEADER));
+  const status = responseStatus(response, setStatus);
+  if (!encoding || request.method === 'HEAD' || !isBodyAllowed(status) || hasContentEncoding(response, setHeaders)) return;
+
+  const body = await responseBodyBytes(response);
+  if (body.byteLength <= MIN_COMPRESSIBLE_BYTES) return;
+
+  const headers = mergedHeaders(response, setHeaders);
+  const compressed = compressBytes(body, encoding);
+  headers.set(CONTENT_ENCODING_HEADER, encoding);
+  headers.set('Content-Length', String(compressed.byteLength));
+  addVary(headers);
+  return new Response(compressed, { status, statusText: response instanceof Response ? response.statusText : undefined, headers });
+}
+
+export function createCompressMiddleware() {
+  return new Elysia({ name: 'response-compression' }).onAfterHandle({ as: 'global' }, ({ request, response, set }) => {
+    return compressedResponse(request, response, set.status, set.headers);
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,9 +30,9 @@ import { createRequestTimeoutFetch } from './middleware/timeout.ts';
 import { createBodyLimitMiddleware } from './middleware/body-limit.ts';
 import { createNotFoundMiddleware } from './middleware/not-found.ts';
 import { createEtagMiddleware } from './middleware/etag.ts';
+import { createCompressMiddleware } from './middleware/compress.ts';
 import { createDbContextFetch } from './middleware/db-context.ts';
 
-// Elysia sub-apps — one per cluster
 import { authRoutes } from './routes/auth/index.ts';
 import { settingsRoutes } from './routes/settings/index.ts';
 import { feedRoutes } from './routes/feed/index.ts';
@@ -55,7 +55,6 @@ import { peerRoutes } from './routes/peer/index.ts';
 import { createMcpRoutes } from './routes/mcp/index.ts';
 import { createMetricsLifecycle, metricsRoutes } from './routes/metrics/index.ts';
 
-// Indexer routes are optional — MCP server works without them
 let indexerRoutes: any = null;
 try {
   indexerRoutes = (await import('./routes/indexer/index.ts')).indexerRoutes;
@@ -124,6 +123,7 @@ const app = new Elysia()
   .use(createRateLimitMiddleware())
   .use(createApiKeyAuthMiddleware())
   .use(createMetricsLifecycle())
+  .use(createCompressMiddleware())
   .use(createEtagMiddleware())
   .onBeforeHandle(({ request, set }) => {
     const pathname = new URL(request.url).pathname;

--- a/tests/http/compress/encoding.test.ts
+++ b/tests/http/compress/encoding.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import {
+  CONTENT_ENCODING_HEADER,
+  MIN_COMPRESSIBLE_BYTES,
+  acceptedEncoding,
+  compressBytes,
+  createCompressMiddleware,
+  responseBodyBytes,
+} from '../../../src/middleware/compress.ts';
+
+const LARGE = 'x'.repeat(MIN_COMPRESSIBLE_BYTES + 1);
+const SMALL = 'x'.repeat(MIN_COMPRESSIBLE_BYTES);
+
+function app() {
+  return new Elysia()
+    .use(createCompressMiddleware())
+    .get('/large', () => LARGE)
+    .get('/small', () => SMALL)
+    .get('/json', () => ({ data: LARGE }))
+    .get('/bytes', () => new Uint8Array(MIN_COMPRESSIBLE_BYTES + 2).fill(65))
+    .get('/encoded', () => new Response(LARGE, { headers: { [CONTENT_ENCODING_HEADER]: 'br' } }))
+    .get('/vary-origin', ({ set }) => {
+      set.headers.Vary = 'Origin';
+      set.headers['X-List'] = ['a', 'b'];
+      return LARGE;
+    })
+    .get('/vary-encoded', ({ set }) => {
+      set.headers.Vary = 'Origin, Accept-Encoding';
+      return LARGE;
+    })
+    .get('/vary-wildcard', ({ set }) => {
+      set.headers.Vary = '*';
+      return LARGE;
+    })
+    .get('/empty', ({ set }) => {
+      set.status = 204;
+      return '';
+    })
+    .head('/large', () => LARGE);
+}
+
+function request(path: string, acceptEncoding = 'gzip') {
+  return app().handle(new Request(`http://local${path}`, { headers: { 'Accept-Encoding': acceptEncoding } }));
+}
+
+describe('response compression middleware', () => {
+  test('gzip-compresses responses larger than 1KB when accepted', async () => {
+    const res = await request('/large', 'br, gzip');
+    const body = new Uint8Array(await res.arrayBuffer());
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get(CONTENT_ENCODING_HEADER)).toBe('gzip');
+    expect(res.headers.get('Vary')).toContain('Accept-Encoding');
+    expect(res.headers.get('Content-Length')).toBe(String(body.byteLength));
+    expect(new TextDecoder().decode(Bun.gunzipSync(body))).toBe(LARGE);
+  });
+
+  test('deflate-compresses when gzip is unavailable but deflate is accepted', async () => {
+    const res = await request('/json', 'deflate');
+    const body = new Uint8Array(await res.arrayBuffer());
+
+    expect(res.headers.get(CONTENT_ENCODING_HEADER)).toBe('deflate');
+    expect(JSON.parse(new TextDecoder().decode(Bun.inflateSync(body)))).toEqual({ data: LARGE });
+  });
+
+  test('keeps small, HEAD, no-content, and already encoded responses uncompressed', async () => {
+    const small = await request('/small');
+    const head = await app().handle(new Request('http://local/large', { method: 'HEAD', headers: { 'Accept-Encoding': 'gzip' } }));
+    const empty = await request('/empty');
+    const encoded = await request('/encoded');
+
+    expect(small.headers.get(CONTENT_ENCODING_HEADER)).toBeNull();
+    expect(await small.text()).toBe(SMALL);
+    expect(head.headers.get(CONTENT_ENCODING_HEADER)).toBeNull();
+    expect(empty.headers.get(CONTENT_ENCODING_HEADER)).toBeNull();
+    expect(encoded.headers.get(CONTENT_ENCODING_HEADER)).toBe('br');
+  });
+
+  test('preserves set headers while maintaining Vary correctly', async () => {
+    const origin = await request('/vary-origin');
+    const encoded = await request('/vary-encoded');
+    const wildcard = await request('/vary-wildcard');
+
+    expect(origin.headers.get('Vary')).toBe('Origin, Accept-Encoding');
+    expect(origin.headers.get('X-List')).toBe('a, b');
+    expect(encoded.headers.get('Vary')).toBe('Origin, Accept-Encoding');
+    expect(wildcard.headers.get('Vary')).toBe('*');
+  });
+
+  test('skips compression when Accept-Encoding does not allow gzip or deflate', async () => {
+    const missing = await app().handle(new Request('http://local/large'));
+    const qZero = await request('/large', 'gzip;q=0, deflate;q=0');
+    const unsupported = await request('/large', 'br');
+
+    expect(missing.headers.get(CONTENT_ENCODING_HEADER)).toBeNull();
+    expect(qZero.headers.get(CONTENT_ENCODING_HEADER)).toBeNull();
+    expect(unsupported.headers.get(CONTENT_ENCODING_HEADER)).toBeNull();
+  });
+
+  test('exposes compression helpers for bytes and Accept-Encoding parsing', async () => {
+    const bytes = await responseBodyBytes(new Uint8Array([1, 2, 3]));
+    const gzip = compressBytes(bytes, 'gzip');
+    const deflate = compressBytes(bytes, 'deflate');
+
+    expect(acceptedEncoding('deflate, gzip;q=0')).toBe('deflate');
+    expect(acceptedEncoding('*;q=1')).toBe('gzip');
+    expect([...Bun.gunzipSync(gzip)]).toEqual([1, 2, 3]);
+    expect([...Bun.inflateSync(deflate)]).toEqual([1, 2, 3]);
+  });
+});


### PR DESCRIPTION
## Summary
- add response compression middleware using Bun.gzipSync/Bun.deflateSync
- compress bodyful responses larger than 1KB when Accept-Encoding allows gzip or deflate
- place compression before ETag so validators describe the encoded representation

## Verification
- tsc --noEmit
- bun test tests/http/compress/
- bun test --coverage tests/http/compress/ (100% funcs/lines for src/middleware/compress.ts)
- bun test tests/http/compress/ tests/http/etag/ tests/http/timing/ tests/http/correlation/ tests/http/errors/ tests/http/content-type/ tests/http/security/ tests/http/versioning/ tests/http/metrics/ tests/http/auth/ tests/http/cors/ tests/http/rate-limit/ tests/http/body-limit/ tests/http/not-found/ tests/http/db-context/ tests/lifecycle/
- git diff --check origin/alpha...HEAD
- changed files all <=250 lines