### PR TITLE
Add CalVer release CLI

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -122,6 +122,12 @@ async function main() {
     process.exit(await changelogCommand(args.slice(1)));
   }
 
+  if (cmd === "release") {
+    if (hasHelpFlag(args.slice(1))) return printBuiltinHelp(cmd);
+    const { releaseCommand } = await import("../../src/cli/commands/release.ts");
+    process.exit(await releaseCommand(args.slice(1)));
+  }
+
   if (cmd === "export") {
     const { exportCommand } = await import("../../src/cli/commands/export.ts");
     process.exit(await exportCommand(args.slice(1)));

--- a/cli/src/commands/catalog.ts
+++ b/cli/src/commands/catalog.ts
@@ -19,6 +19,7 @@ export const BUILTIN_COMMANDS: CommandSpec[] = [
   { command: "peers", help: "probe configured federation peers", flags: ["--token", "--json", "--help", "-h"] },
   { command: "huginn", help: "run Huginn capture utilities", subcommands: ["sweep"], flags: ["--sessions-dir", "--repo-root", "--lookback-hours", "--max-files", "--json", "--help", "-h"] },
   { command: "changelog", help: "generate CHANGELOG.md from git history", flags: ["--since", "--out", "--stdout", "--help", "-h"] },
+  { command: "release", help: "bump CalVer, write changelog, and create a tag", flags: ["--beta", "--stable", "--changelog", "--dry-run", "--help", "-h"] },
   { command: "export", help: "export vault data as JSON", flags: ["--format", "--out", "--help", "-h"] },
   { command: "import", help: "import vault data from JSON", flags: ["--format", "--in", "--help", "-h"] },
 ];

--- a/src/cli/commands/release.ts
+++ b/src/cli/commands/release.ts
@@ -1,0 +1,122 @@
+import { readFile, writeFile } from "fs/promises";
+import { fileURLToPath } from "url";
+import { isAbsolute, resolve } from "path";
+import { generateChangelog } from "./changelog.ts";
+
+type ReleaseChannel = "alpha" | "beta" | "stable";
+
+export interface ReleaseOptions {
+  cwd?: string;
+  channel: ReleaseChannel;
+  changelogFile: string;
+  dryRun: boolean;
+}
+
+export interface ReleaseResult {
+  version: string;
+  tag: string;
+  changelogPath?: string;
+  dryRun: boolean;
+}
+
+const CALVER_SCRIPT = fileURLToPath(new URL("../../../scripts/calver.ts", import.meta.url));
+
+function printHelp(): void {
+  console.log("arra-cli release [--beta|--stable] [--changelog CHANGELOG.md] [--dry-run]\n");
+  console.log("Bumps package.json with scripts/calver.ts, writes a changelog, and creates a git tag.");
+  console.log("\nFlags:");
+  console.log("  --beta              cut a beta CalVer instead of alpha");
+  console.log("  --stable            cut stable CalVer without a prerelease suffix");
+  console.log("  --changelog <file>  changelog output path (default: CHANGELOG.md)");
+  console.log("  --dry-run, --check  print the target version without writing files or tags");
+  console.log("  --help, -h          show this help");
+}
+
+function readValue(args: string[], flag: string): string | undefined {
+  const index = args.indexOf(flag);
+  if (index >= 0) return args[index + 1];
+  const prefix = `${flag}=`;
+  return args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+}
+
+export function parseReleaseOptions(args: string[]): ReleaseOptions {
+  const stable = args.includes("--stable");
+  const beta = args.includes("--beta");
+  if (stable && beta) throw new Error("--stable and --beta are mutually exclusive");
+  return {
+    channel: stable ? "stable" : beta ? "beta" : "alpha",
+    changelogFile: readValue(args, "--changelog") ?? "CHANGELOG.md",
+    dryRun: args.includes("--dry-run") || args.includes("--check"),
+  };
+}
+
+async function run(command: string[], cwd: string): Promise<string> {
+  const proc = Bun.spawn(command, { cwd, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const code = await proc.exited;
+  if (code !== 0) throw new Error((stderr || stdout).trim() || `${command.join(" ")} failed`);
+  return stdout.trim();
+}
+
+function calverArgs(options: ReleaseOptions): string[] {
+  const args: string[] = [];
+  if (options.channel === "beta") args.push("--beta");
+  if (options.channel === "stable") args.push("--stable");
+  if (options.dryRun) args.push("--check");
+  return args;
+}
+
+function parseTarget(output: string): string {
+  const match = output.match(/Target:\s+v([^\s]+)/);
+  if (!match) throw new Error("calver did not print a target version");
+  return match[1];
+}
+
+async function readPackageVersion(cwd: string): Promise<string> {
+  const pkg = JSON.parse(await readFile(resolve(cwd, "package.json"), "utf8")) as { version?: unknown };
+  if (typeof pkg.version !== "string") throw new Error("package.json version must be a string");
+  return pkg.version;
+}
+
+function outputPath(cwd: string, file: string): string {
+  return isAbsolute(file) ? file : resolve(cwd, file);
+}
+
+async function createTag(cwd: string, tag: string): Promise<void> {
+  await run(["git", "tag", tag], cwd);
+}
+
+export async function runRelease(options: ReleaseOptions): Promise<ReleaseResult> {
+  const cwd = options.cwd ?? process.cwd();
+  const calverOutput = await run(["bun", CALVER_SCRIPT, ...calverArgs(options)], cwd);
+  const version = options.dryRun ? parseTarget(calverOutput) : await readPackageVersion(cwd);
+  const tag = `v${version}`;
+
+  if (options.dryRun) return { version, tag, dryRun: true };
+
+  const changelogPath = outputPath(cwd, options.changelogFile);
+  await writeFile(changelogPath, await generateChangelog({ cwd }), "utf8");
+  await createTag(cwd, tag);
+  return { version, tag, changelogPath, dryRun: false };
+}
+
+export async function releaseCommand(args: string[]): Promise<number> {
+  if (args.includes("--help") || args.includes("-h")) {
+    printHelp();
+    return 0;
+  }
+
+  try {
+    const result = await runRelease({ ...parseReleaseOptions(args), cwd: process.cwd() });
+    process.stdout.write(`target ${result.tag}\n`);
+    if (result.dryRun) process.stdout.write("dry run: no files or tags written\n");
+    else process.stdout.write(`wrote ${result.changelogPath}\ncreated ${result.tag}\n`);
+    return 0;
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+}

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -96,6 +96,13 @@ export const BUILTIN_HELP: CliHelpEntry[] = [
     flags: ["--since <tag>", "--out <file>", "--stdout", "--help", "-h"],
     examples: ["arra-cli changelog", "arra-cli changelog --since v1.2.3 --stdout"],
   },
+  {
+    command: "release",
+    help: "bump CalVer, write changelog, and create a tag",
+    usage: "arra-cli release [--beta|--stable] [--changelog CHANGELOG.md] [--dry-run]",
+    flags: ["--beta", "--stable", "--changelog <file>", "--dry-run", "--check", "--help", "-h"],
+    examples: ["arra-cli release", "arra-cli release --beta", "arra-cli release --dry-run"],
+  },
 ];
 
 const SUBCOMMAND_HELP: CliHelpEntry[] = [

--- a/tests/cli/release/calver.test.ts
+++ b/tests/cli/release/calver.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  parseReleaseOptions,
+  releaseCommand,
+  runRelease,
+} from "../../../src/cli/commands/release.ts";
+import { runCli } from "../_run.ts";
+
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "ARRA Test",
+  GIT_AUTHOR_EMAIL: "arra-test@example.com",
+  GIT_COMMITTER_NAME: "ARRA Test",
+  GIT_COMMITTER_EMAIL: "arra-test@example.com",
+};
+
+async function git(cwd: string, args: string[]): Promise<string> {
+  const proc = Bun.spawn(["git", ...args], { cwd, env: gitEnv, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const code = await proc.exited;
+  if (code !== 0) throw new Error(stderr);
+  return stdout.trim();
+}
+
+function writePackage(root: string, version = "26.1.1-alpha.1"): void {
+  writeFileSync(join(root, "package.json"), JSON.stringify({ name: "release-test", version }, null, 2) + "\n");
+}
+
+async function initRepo(root: string): Promise<void> {
+  await git(root, ["init"]);
+  await git(root, ["config", "user.name", "ARRA Test"]);
+  await git(root, ["config", "user.email", "arra-test@example.com"]);
+  writePackage(root);
+  await git(root, ["add", "package.json"]);
+  await git(root, ["commit", "-m", "chore: baseline"]);
+  await git(root, ["tag", "v26.1.1-alpha.1"]);
+}
+
+async function emptyCommit(root: string, message: string): Promise<void> {
+  await git(root, ["commit", "--allow-empty", "-m", message]);
+}
+
+async function inCwd<T>(cwd: string, action: () => Promise<T>): Promise<T> {
+  const previous = process.cwd();
+  process.chdir(cwd);
+  try {
+    return await action();
+  } finally {
+    process.chdir(previous);
+  }
+}
+
+async function captureOutput(action: () => Promise<number>): Promise<{
+  code: number;
+  stdout: string;
+  stderr: string;
+}> {
+  const originalWrite = process.stdout.write;
+  const originalLog = console.log;
+  const originalError = console.error;
+  let stdout = "";
+  let stderr = "";
+  (process.stdout as unknown as { write: (chunk: unknown) => boolean }).write = (chunk) => {
+    stdout += String(chunk);
+    return true;
+  };
+  console.log = (...parts: unknown[]) => {
+    stdout += parts.join(" ") + "\n";
+  };
+  console.error = (...parts: unknown[]) => {
+    stderr += parts.join(" ") + "\n";
+  };
+  try {
+    const code = await action();
+    return { code, stdout, stderr };
+  } finally {
+    process.stdout.write = originalWrite;
+    console.log = originalLog;
+    console.error = originalError;
+  }
+}
+
+describe("release CalVer CLI", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "arra-release-"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("bumps package.json, writes changelog, and creates a tag", async () => {
+    await initRepo(root);
+    await emptyCommit(root, "feat: release cli");
+    await emptyCommit(root, "fix: release tag");
+
+    const result = await inCwd(root, () => captureOutput(() => releaseCommand(["--changelog", "notes.md"])));
+    const version = JSON.parse(readFileSync(join(root, "package.json"), "utf8")).version;
+
+    expect(result.code).toBe(0);
+    expect(version).toMatch(/^\d+\.\d+\.\d+-alpha\.\d+$/);
+    expect(result.stdout).toContain(`target v${version}`);
+    expect(readFileSync(join(root, "notes.md"), "utf8")).toContain("- release cli (");
+    expect(await git(root, ["tag", "--list", `v${version}`])).toBe(`v${version}`);
+  }, 20_000);
+
+  test("dry run reports stable target without writing files or tags", async () => {
+    await initRepo(root);
+
+    const result = await runRelease({ ...parseReleaseOptions(["--stable", "--dry-run"]), cwd: root });
+    const packageVersion = JSON.parse(readFileSync(join(root, "package.json"), "utf8")).version;
+
+    expect(result.dryRun).toBe(true);
+    expect(result.version).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(packageVersion).toBe("26.1.1-alpha.1");
+    expect(existsSync(join(root, "CHANGELOG.md"))).toBe(false);
+    expect(await git(root, ["tag", "--list", result.tag])).toBe("");
+  }, 20_000);
+
+  test("dry run supports beta CalVer targets", async () => {
+    await initRepo(root);
+
+    const result = await runRelease({ ...parseReleaseOptions(["--beta", "--dry-run"]), cwd: root });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.version).toMatch(/^\d+\.\d+\.\d+-beta\.\d+$/);
+    expect(result.tag).toBe(`v${result.version}`);
+  }, 20_000);
+
+  test("parses options and rejects conflicting channels", () => {
+    expect(parseReleaseOptions(["--beta", "--changelog=beta.md", "--check"])).toEqual({
+      channel: "beta",
+      changelogFile: "beta.md",
+      dryRun: true,
+    });
+    expect(() => parseReleaseOptions(["--stable", "--beta"])).toThrow("--stable and --beta");
+  });
+
+  test("prints command help", async () => {
+    const result = await captureOutput(() => releaseCommand(["--help"]));
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("arra-cli release");
+    expect(result.stdout).toContain("--stable");
+  });
+
+  test("reports calver failures", async () => {
+    writePackage(root, "26.13.1-alpha.1");
+
+    const result = await inCwd(root, () => captureOutput(() => releaseCommand([])));
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("ghost date");
+  }, 20_000);
+
+  test("is wired into the CLI dispatcher", async () => {
+    await initRepo(root);
+
+    const result = await runCli(["release", "--dry-run"], {
+      HOME: join(root, "home"),
+      ORACLE_DATA_DIR: join(root, "data"),
+    }, { cwd: root });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("dry run: no files or tags written");
+  }, 20_000);
+});


### PR DESCRIPTION
## Summary\n- add release CLI command that invokes scripts/calver.ts to bump package.json\n- generate CHANGELOG.md (or a custom changelog path) and create a local git tag\n- wire release into CLI dispatch/help/completions and cover alpha/beta/stable dry-run paths\n\n## Tests\n- bunx tsc --noEmit\n- bun test tests/cli/release/\n- bun test --coverage tests/cli/release/ (100% lines/functions for src/cli/commands/release.ts)