### PR TITLE
feat: coalesce duplicate in-flight requests

### DIFF
--- a/src/lifecycle/startup-context.ts
+++ b/src/lifecycle/startup-context.ts
@@ -25,6 +25,7 @@ export function runtimeMiddleware(options: RuntimeMiddlewareOptions): BannerMidd
     { name: 'rate-limit', detail: `${options.rateLimitTokensPerWindow}/min` },
     { name: 'api-key-auth' },
     { name: 'metrics' },
+    { name: 'dedup' },
     { name: 'compress' },
     { name: 'etag' },
     { name: 'structured-errors' },

--- a/src/middleware/dedup.ts
+++ b/src/middleware/dedup.ts
@@ -1,0 +1,73 @@
+type FetchHandler = (request: Request) => Response | Promise<Response>;
+type DedupKey = string | null;
+type DedupKeyFn = (request: Request) => DedupKey;
+
+type ResponseSnapshot = {
+  body: ArrayBuffer | null;
+  headers: [string, string][];
+  status: number;
+  statusText: string;
+};
+
+export type RequestDedupOptions = {
+  key?: DedupKeyFn;
+  store?: Map<string, Promise<ResponseSnapshot>>;
+};
+
+const COALESCED_METHODS = new Set(['GET', 'HEAD']);
+const VARIANT_HEADERS = ['accept', 'accept-encoding', 'accept-language', 'authorization', 'cookie', 'range'];
+const defaultStore = new Map<string, Promise<ResponseSnapshot>>();
+
+function variantScope(request: Request): string {
+  return VARIANT_HEADERS.map((name) => `${name}:${request.headers.get(name) ?? ''}`).join('\n');
+}
+
+export function requestDedupKey(request: Request): DedupKey {
+  const method = request.method.toUpperCase();
+  return COALESCED_METHODS.has(method) ? `${method} ${request.url}\n${variantScope(request)}` : null;
+}
+
+async function responseSnapshot(response: Response): Promise<ResponseSnapshot> {
+  return {
+    body: response.body === null ? null : await response.arrayBuffer(),
+    headers: [...response.headers.entries()],
+    status: response.status,
+    statusText: response.statusText,
+  };
+}
+
+function snapshotResponse(snapshot: ResponseSnapshot): Response {
+  const body = snapshot.body === null ? null : snapshot.body.slice(0);
+  return new Response(body, {
+    headers: snapshot.headers,
+    status: snapshot.status,
+    statusText: snapshot.statusText,
+  });
+}
+
+export async function handleRequestDedup(
+  request: Request,
+  next: FetchHandler,
+  options: RequestDedupOptions = {},
+): Promise<Response> {
+  const key = (options.key ?? requestDedupKey)(request);
+  if (!key) return next(request);
+
+  const store = options.store ?? defaultStore;
+  const existing = store.get(key);
+  if (existing) return snapshotResponse(await existing);
+
+  const pending = Promise.resolve().then(() => next(request)).then(responseSnapshot);
+  store.set(key, pending);
+
+  try {
+    return snapshotResponse(await pending);
+  } finally {
+    if (store.get(key) === pending) store.delete(key);
+  }
+}
+
+export function createRequestDedupFetch(next: FetchHandler, options: RequestDedupOptions = {}): FetchHandler {
+  const store = options.store ?? new Map<string, Promise<ResponseSnapshot>>();
+  return (request) => handleRequestDedup(request, next, { ...options, store });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,6 +31,7 @@ import { createBodyLimitMiddleware } from './middleware/body-limit.ts';
 import { createNotFoundMiddleware } from './middleware/not-found.ts';
 import { createEtagMiddleware } from './middleware/etag.ts';
 import { createCompressMiddleware } from './middleware/compress.ts';
+import { createRequestDedupFetch } from './middleware/dedup.ts';
 import { createDbContextFetch } from './middleware/db-context.ts';
 
 import { authRoutes } from './routes/auth/index.ts';
@@ -228,7 +229,9 @@ await runStartupSelfTest({
   }),
 });
 
-const serverFetch = createRequestTimeoutFetch(createApiVersionedFetch(createDbContextFetch((request: Request) => app.fetch(request))));
+const serverFetch = createRequestTimeoutFetch(
+  createRequestDedupFetch(createApiVersionedFetch(createDbContextFetch((request: Request) => app.fetch(request)))),
+);
 
 export default {
   port: Number(PORT),

--- a/tests/http/dedup/coalesce.test.ts
+++ b/tests/http/dedup/coalesce.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import {
+  createRequestDedupFetch,
+  handleRequestDedup,
+  requestDedupKey,
+} from '../../../src/middleware/dedup.ts';
+
+type Gate = { promise: Promise<void>; release: () => void };
+
+function gate(): Gate {
+  let release!: () => void;
+  const promise = new Promise<void>((resolve) => { release = resolve; });
+  return { promise, release };
+}
+
+async function waitFor(check: () => boolean): Promise<void> {
+  for (let i = 0; i < 25; i += 1) {
+    if (check()) return;
+    await Bun.sleep(1);
+  }
+  throw new Error('condition was not met');
+}
+
+function request(path: string, init: RequestInit = {}): Request {
+  return new Request(`http://local${path}`, init);
+}
+
+function slowApp(block: Gate, hits: { count: number }) {
+  return new Elysia()
+    .get('/slow', async ({ request }) => {
+      hits.count += 1;
+      await block.promise;
+      return Response.json({ hit: hits.count, url: request.url }, { headers: { 'x-hit': String(hits.count) } });
+    })
+    .post('/slow', async () => {
+      hits.count += 1;
+      await block.promise;
+      return Response.json({ hit: hits.count });
+    });
+}
+
+async function json(res: Response) {
+  return await res.json() as Record<string, unknown>;
+}
+
+describe('request deduplication middleware', () => {
+  test('coalesces duplicate in-flight GET requests to the same URL', async () => {
+    const block = gate();
+    const hits = { count: 0 };
+    const app = slowApp(block, hits);
+    const fetchDedup = createRequestDedupFetch((req) => app.handle(req));
+
+    const first = fetchDedup(request('/slow?item=1'));
+    await waitFor(() => hits.count === 1);
+    const second = fetchDedup(request('/slow?item=1'));
+    await Bun.sleep(1);
+
+    expect(hits.count).toBe(1);
+    block.release();
+    const [a, b] = await Promise.all([first, second]);
+
+    expect(hits.count).toBe(1);
+    expect(a.headers.get('x-hit')).toBe('1');
+    expect(b.headers.get('x-hit')).toBe('1');
+    expect(await json(a)).toEqual(await json(b));
+  });
+
+  test('deduplicates only while the first matching request is in flight', async () => {
+    let hits = 0;
+    const app = new Elysia().get('/fast', () => Response.json({ hit: ++hits }));
+    const fetchDedup = createRequestDedupFetch((req) => app.handle(req));
+
+    const first = await fetchDedup(request('/fast'));
+    const second = await fetchDedup(request('/fast'));
+
+    expect(await json(first)).toEqual({ hit: 1 });
+    expect(await json(second)).toEqual({ hit: 2 });
+    expect(hits).toBe(2);
+  });
+
+  test('does not coalesce different URLs or unsafe methods', async () => {
+    const block = gate();
+    const hits = { count: 0 };
+    const app = slowApp(block, hits);
+    const fetchDedup = createRequestDedupFetch((req) => app.handle(req));
+
+    const first = fetchDedup(request('/slow?item=1'));
+    const second = fetchDedup(request('/slow?item=2'));
+    const postA = fetchDedup(request('/slow?item=1', { method: 'POST' }));
+    const postB = fetchDedup(request('/slow?item=1', { method: 'POST' }));
+    await waitFor(() => hits.count === 4);
+
+    block.release();
+    await Promise.all([first, second, postA, postB]);
+
+    expect(hits.count).toBe(4);
+    expect(requestDedupKey(request('/slow'))).toContain('GET http://local/slow');
+    expect(requestDedupKey(request('/slow', { method: 'POST' }))).toBeNull();
+  });
+
+  test('keeps response variants isolated by key headers', async () => {
+    const block = gate();
+    const hits = { count: 0 };
+    const app = slowApp(block, hits);
+    const fetchDedup = createRequestDedupFetch((req) => app.handle(req));
+
+    const plain = fetchDedup(request('/slow?item=1'));
+    const gzip = fetchDedup(request('/slow?item=1', { headers: { 'Accept-Encoding': 'gzip' } }));
+    const authorized = fetchDedup(request('/slow?item=1', { headers: { Authorization: 'Bearer one' } }));
+    await waitFor(() => hits.count === 3);
+
+    block.release();
+    await Promise.all([plain, gzip, authorized]);
+
+    expect(hits.count).toBe(3);
+  });
+
+  test('coalesces HEAD responses without materializing a body', async () => {
+    const block = gate();
+    let hits = 0;
+    const fetchDedup = createRequestDedupFetch(async () => {
+      hits += 1;
+      await block.promise;
+      return new Response(null, { status: 204, statusText: 'No Content', headers: { 'x-hit': String(hits) } });
+    });
+
+    const first = fetchDedup(request('/empty', { method: 'HEAD' }));
+    await waitFor(() => hits === 1);
+    const second = fetchDedup(request('/empty', { method: 'HEAD' }));
+    block.release();
+    const [a, b] = await Promise.all([first, second]);
+
+    expect(hits).toBe(1);
+    expect(a.status).toBe(204);
+    expect(a.statusText).toBe('No Content');
+    expect(b.headers.get('x-hit')).toBe('1');
+    expect(await a.text()).toBe('');
+    expect(await b.text()).toBe('');
+  });
+
+  test('clears in-flight entries when the upstream handler fails', async () => {
+    const store = new Map();
+    let hits = 0;
+    const fail = () => {
+      hits += 1;
+      throw new Error('boom');
+    };
+
+    const first = handleRequestDedup(request('/fail'), fail, { store });
+    const second = handleRequestDedup(request('/fail'), fail, { store });
+    const results = await Promise.allSettled([first, second]);
+
+    expect(results.every((result) => result.status === 'rejected')).toBe(true);
+    expect(hits).toBe(1);
+    expect(store.size).toBe(0);
+
+    await expect(handleRequestDedup(request('/open', { method: 'POST' }), fail, { store })).rejects.toThrow('boom');
+    expect(hits).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add a fetch-layer request dedup middleware for in-flight safe-method requests
- key coalescing by URL plus representation/auth headers to avoid response variant leaks
- wire dedup into the server fetch stack and startup middleware banner
- add fetch-based HTTP contract tests under tests/http/dedup/

## Verification
- tsc --noEmit
- bun test tests/http/dedup/
- bun test --coverage tests/http/dedup/ (100% funcs/lines for src/middleware/dedup.ts)
- bun test tests/http/dedup/ tests/http/compress/ tests/http/etag/ tests/http/timing/ tests/http/correlation/ tests/http/timeout/ tests/lifecycle/ tests/integration/middleware-stack.test.ts tests/integration/middleware-order.test.ts
- git diff --check HEAD^..HEAD
- wc -l changed files (all <=250)