### PR TITLE
Add development DB seed command

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -144,6 +144,12 @@ async function main() {
     process.exit(await migrateCommand(args.slice(1)));
   }
 
+  if (cmd === "seed") {
+    if (hasHelpFlag(args.slice(1))) return printBuiltinHelp(cmd);
+    const { seedCommand } = await import("../../src/cli/commands/seed.ts");
+    process.exit(await seedCommand(args.slice(1)));
+  }
+
   if (cmd === "use") {
     if (hasHelpFlag(args.slice(1))) return printBuiltinHelp(cmd);
     process.exit(await useCommand(args.slice(1)));

--- a/cli/src/commands/catalog.ts
+++ b/cli/src/commands/catalog.ts
@@ -19,6 +19,7 @@ export const BUILTIN_COMMANDS: CommandSpec[] = [
   { command: "peers", help: "probe configured federation peers", flags: ["--token", "--json", "--help", "-h"] },
   { command: "huginn", help: "run Huginn capture utilities", subcommands: ["sweep"], flags: ["--sessions-dir", "--repo-root", "--lookback-hours", "--max-files", "--json", "--help", "-h"] },
   { command: "migrate", help: "run Drizzle migration generate and push", flags: ["--help", "-h"] },
+  { command: "seed", help: "populate development DB sample data", flags: ["--help", "-h"] },
   { command: "changelog", help: "generate CHANGELOG.md from git history", flags: ["--since", "--out", "--stdout", "--help", "-h"] },
   { command: "release", help: "bump CalVer, write changelog, and create a tag", flags: ["--beta", "--stable", "--changelog", "--dry-run", "--help", "-h"] },
   { command: "export", help: "export vault data as JSON", flags: ["--format", "--out", "--help", "-h"] },

--- a/src/cli/commands/seed.ts
+++ b/src/cli/commands/seed.ts
@@ -1,0 +1,195 @@
+import { and, eq } from 'drizzle-orm';
+import {
+  createDatabase,
+  learnLog,
+  menuItems,
+  oracleDocuments,
+  type DatabaseConnection,
+} from '../../db/index.ts';
+
+type Writer = (message: string) => void;
+type MenuInsert = typeof menuItems.$inferInsert;
+type DocumentInsert = typeof oracleDocuments.$inferInsert;
+type LearnLogInsert = typeof learnLog.$inferInsert;
+
+interface SeedSample {
+  document: Omit<DocumentInsert, 'createdAt' | 'updatedAt' | 'indexedAt'>;
+  log: Omit<LearnLogInsert, 'createdAt'>;
+}
+
+export interface SeedRunResult {
+  menu: { inserted: number; updated: number; skipped: number };
+  learn: { documentsInserted: number; documentsUpdated: number; logsInserted: number; logsUpdated: number };
+}
+
+export interface SeedOptions {
+  connection?: DatabaseConnection;
+  now?: () => number;
+  stdout?: Writer;
+  stderr?: Writer;
+}
+
+export const SAMPLE_MENU_ITEMS: Array<Omit<MenuInsert, 'id' | 'createdAt' | 'updatedAt'>> = [
+  {
+    path: '/dev/vector-search',
+    label: 'Vector Search Lab',
+    groupKey: 'development',
+    position: 910,
+    enabled: true,
+    access: 'public',
+    source: 'seed',
+    icon: 'search',
+    scope: 'main',
+  },
+  {
+    path: '/dev/mcp-tools',
+    label: 'MCP Tool Browser',
+    groupKey: 'development',
+    position: 920,
+    enabled: true,
+    access: 'public',
+    source: 'seed',
+    icon: 'plug',
+    scope: 'main',
+  },
+];
+
+export const SAMPLE_LEARN_ENTRIES: SeedSample[] = [
+  {
+    document: {
+      id: 'seed-learning-menu-aggregation',
+      type: 'learning',
+      sourceFile: 'seed://learn/menu-aggregation.md',
+      concepts: JSON.stringify(['menu', 'unified-plugin', 'development-seed']),
+      origin: 'seed',
+      project: 'github.com/soul-brews-studio/arra-oracle-v3',
+      createdBy: 'seed',
+    },
+    log: {
+      documentId: 'seed-learning-menu-aggregation',
+      patternPreview: 'Unified plugin manifests can enrich the studio menu alongside DB rows.',
+      source: 'seed',
+      concepts: JSON.stringify(['menu', 'unified-plugin']),
+      project: 'github.com/soul-brews-studio/arra-oracle-v3',
+    },
+  },
+  {
+    document: {
+      id: 'seed-learning-vector-mcp',
+      type: 'learning',
+      sourceFile: 'seed://learn/vector-mcp.md',
+      concepts: JSON.stringify(['vector-search', 'mcp-tools', 'development-seed']),
+      origin: 'seed',
+      project: 'github.com/soul-brews-studio/arra-oracle-v3',
+      createdBy: 'seed',
+    },
+    log: {
+      documentId: 'seed-learning-vector-mcp',
+      patternPreview: 'Vector search and MCP browser samples keep fresh dev databases navigable.',
+      source: 'seed',
+      concepts: JSON.stringify(['vector-search', 'mcp-tools']),
+      project: 'github.com/soul-brews-studio/arra-oracle-v3',
+    },
+  },
+];
+
+export function seedDevelopmentData(connection: DatabaseConnection, options: SeedOptions = {}): SeedRunResult {
+  const nowMs = options.now?.() ?? Date.now();
+  const nowDate = new Date(nowMs);
+  return {
+    menu: seedMenuItems(connection, nowDate),
+    learn: seedLearnEntries(connection, nowMs),
+  };
+}
+
+export async function seedCommand(args: string[], options: SeedOptions = {}): Promise<number> {
+  const stdout = options.stdout ?? writeStdout;
+  const stderr = options.stderr ?? writeStderr;
+  if (args.includes('--help') || args.includes('-h')) {
+    printHelp(stdout);
+    return 0;
+  }
+  if (args.length > 0) {
+    stderr(`unknown seed option: ${args[0]}\n`);
+    printHelp(stderr);
+    return 1;
+  }
+
+  let ownedConnection: DatabaseConnection | undefined;
+  const connection = options.connection ?? (ownedConnection = createDatabase());
+  try {
+    const result = seedDevelopmentData(connection, options);
+    stdout(JSON.stringify(result, null, 2) + '\n');
+    return 0;
+  } catch (error) {
+    stderr(`${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  } finally {
+    ownedConnection?.storage.close();
+  }
+}
+
+function seedMenuItems(connection: DatabaseConnection, now: Date): SeedRunResult['menu'] {
+  const result = { inserted: 0, updated: 0, skipped: 0 };
+  for (const item of SAMPLE_MENU_ITEMS) {
+    const existing = connection.db.select().from(menuItems).where(eq(menuItems.path, item.path)).get();
+    const values = { ...item, updatedAt: now };
+    if (existing && existing.source !== 'seed') {
+      result.skipped += 1;
+    } else if (existing) {
+      connection.db.update(menuItems).set(values).where(eq(menuItems.id, existing.id)).run();
+      result.updated += 1;
+    } else {
+      connection.db.insert(menuItems).values({ ...values, createdAt: now }).run();
+      result.inserted += 1;
+    }
+  }
+  return result;
+}
+
+function seedLearnEntries(connection: DatabaseConnection, now: number): SeedRunResult['learn'] {
+  const result = { documentsInserted: 0, documentsUpdated: 0, logsInserted: 0, logsUpdated: 0 };
+  for (const sample of SAMPLE_LEARN_ENTRIES) {
+    const document = { ...sample.document, createdAt: now, updatedAt: now, indexedAt: now };
+    const existingDoc = connection.db.select({ id: oracleDocuments.id })
+      .from(oracleDocuments).where(eq(oracleDocuments.id, document.id)).get();
+    if (existingDoc) {
+      connection.db.update(oracleDocuments).set(document).where(eq(oracleDocuments.id, document.id)).run();
+      result.documentsUpdated += 1;
+    } else {
+      connection.db.insert(oracleDocuments).values(document).run();
+      result.documentsInserted += 1;
+    }
+
+    const existingLog = connection.db.select({ id: learnLog.id }).from(learnLog)
+      .where(and(eq(learnLog.documentId, sample.log.documentId), eq(learnLog.source, 'seed'))).get();
+    if (existingLog) {
+      connection.db.update(learnLog).set({ ...sample.log, createdAt: now }).where(eq(learnLog.id, existingLog.id)).run();
+      result.logsUpdated += 1;
+    } else {
+      connection.db.insert(learnLog).values({ ...sample.log, createdAt: now }).run();
+      result.logsInserted += 1;
+    }
+  }
+  return result;
+}
+
+function printHelp(write: Writer): void {
+  write([
+    'arra-cli seed',
+    '',
+    'Populates the development database with sample menu items and learn entries.',
+    '',
+    'Flags:',
+    '  --help, -h          show this help',
+    '',
+  ].join('\n'));
+}
+
+function writeStdout(message: string): void {
+  process.stdout.write(message);
+}
+
+function writeStderr(message: string): void {
+  process.stderr.write(message);
+}

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -97,6 +97,13 @@ export const BUILTIN_HELP: CliHelpEntry[] = [
     examples: ["arra-cli migrate"],
   },
   {
+    command: "seed",
+    help: "populate development DB sample data",
+    usage: "arra-cli seed",
+    flags: ["--help", "-h"],
+    examples: ["arra-cli seed"],
+  },
+  {
     command: "changelog",
     help: "generate CHANGELOG.md from git history",
     usage: "arra-cli changelog [--since <tag>] [--out CHANGELOG.md] [--stdout]",

--- a/tests/cli/seed/dispatch.test.ts
+++ b/tests/cli/seed/dispatch.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runCli } from '../_run.ts';
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots) rmSync(root, { recursive: true, force: true });
+  roots.length = 0;
+});
+
+function isolatedEnv(): Record<string, string> {
+  const root = mkdtempSync(join(tmpdir(), 'arra-seed-cli-'));
+  roots.push(root);
+  return { HOME: join(root, 'home'), ORACLE_DATA_DIR: join(root, 'data'), ORACLE_REPO_ROOT: root };
+}
+
+describe('seed CLI dispatcher', () => {
+  test('runs the development seed command from arra-cli', async () => {
+    const result = await runCli(['seed'], isolatedEnv());
+    const payload = JSON.parse(result.stdout);
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(payload.menu.inserted).toBeGreaterThan(0);
+    expect(payload.learn.documentsInserted).toBeGreaterThan(0);
+  }, 15_000);
+});

--- a/tests/cli/seed/populate.test.ts
+++ b/tests/cli/seed/populate.test.ts
@@ -1,0 +1,89 @@
+import { afterAll, afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { inArray } from 'drizzle-orm';
+
+const importRoot = mkdtempSync(join(tmpdir(), 'arra-seed-import-'));
+process.env.ORACLE_DATA_DIR = join(importRoot, 'data');
+process.env.ORACLE_REPO_ROOT = importRoot;
+
+const dbModule = await import('../../../src/db/index.ts');
+const seedModule = await import('../../../src/cli/commands/seed.ts');
+
+const {
+  closeDb,
+  createDatabase,
+  learnLog,
+  menuItems,
+  oracleDocuments,
+} = dbModule;
+const {
+  SAMPLE_LEARN_ENTRIES,
+  SAMPLE_MENU_ITEMS,
+  seedCommand,
+  seedDevelopmentData,
+} = seedModule;
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots) rmSync(root, { recursive: true, force: true });
+  roots.length = 0;
+});
+
+afterAll(() => {
+  closeDb();
+  rmSync(importRoot, { recursive: true, force: true });
+});
+
+function tempConnection() {
+  const root = mkdtempSync(join(tmpdir(), 'arra-seed-db-'));
+  roots.push(root);
+  return createDatabase(join(root, 'oracle.db'));
+}
+
+describe('development DB seed command', () => {
+  test('populates sample menu and learn entries idempotently', async () => {
+    const connection = tempConnection();
+    const stdout: string[] = [];
+    try {
+      const code = await seedCommand([], {
+        connection,
+        now: () => 1_700_000_000_000,
+        stdout: (message) => stdout.push(message),
+      });
+
+      expect(code).toBe(0);
+      const result = JSON.parse(stdout.join(''));
+      expect(result.menu.inserted).toBe(SAMPLE_MENU_ITEMS.length);
+      expect(result.learn.documentsInserted).toBe(SAMPLE_LEARN_ENTRIES.length);
+
+      const menuRows = connection.db.select().from(menuItems)
+        .where(inArray(menuItems.path, SAMPLE_MENU_ITEMS.map(item => item.path))).all();
+      const documentRows = connection.db.select().from(oracleDocuments)
+        .where(inArray(oracleDocuments.id, SAMPLE_LEARN_ENTRIES.map(item => item.document.id))).all();
+      const logRows = connection.db.select().from(learnLog)
+        .where(inArray(learnLog.documentId, SAMPLE_LEARN_ENTRIES.map(item => item.document.id))).all();
+
+      expect(menuRows).toHaveLength(SAMPLE_MENU_ITEMS.length);
+      expect(menuRows.every(row => row.source === 'seed')).toBe(true);
+      expect(documentRows).toHaveLength(SAMPLE_LEARN_ENTRIES.length);
+      expect(documentRows.every(row => row.createdBy === 'seed')).toBe(true);
+      expect(logRows).toHaveLength(SAMPLE_LEARN_ENTRIES.length);
+      expect(logRows.every(row => row.source === 'seed')).toBe(true);
+
+      const secondRun = seedDevelopmentData(connection, { now: () => 1_700_000_100_000 });
+      expect(secondRun.menu.inserted).toBe(0);
+      expect(secondRun.menu.updated).toBe(SAMPLE_MENU_ITEMS.length);
+      expect(secondRun.learn.documentsInserted).toBe(0);
+      expect(secondRun.learn.logsInserted).toBe(0);
+      expect(secondRun.learn.logsUpdated).toBe(SAMPLE_LEARN_ENTRIES.length);
+      expect(connection.db.select().from(learnLog)
+        .where(inArray(learnLog.documentId, SAMPLE_LEARN_ENTRIES.map(item => item.document.id))).all()
+      ).toHaveLength(SAMPLE_LEARN_ENTRIES.length);
+    } finally {
+      connection.storage.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add `arra-cli seed` to populate development databases with deterministic sample menu rows and learn entries via Drizzle ORM.
- Wire the seed command into CLI dispatch, builtin help, and command catalog.
- Add focused seed CLI tests for dispatcher execution and idempotent DB population.

## Verification
- `bun test tests/cli/seed/`
- `bun run build`
- `git diff --check`
- changed-file line counts all <=250

Document-refresh: not-needed | Builtin CLI help documents the new development-only command; no operator docs/spec refresh was in task scope.
