### PR TITLE
Add frontend router for public dashboard routes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
-import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { apiClient, type ApiClient } from './api/client';
 import { AppShell } from './components/AppShell';
 import { countPluginSurfaces } from './plugin-surfaces';
-import { McpPage } from './pages/McpPage';
-import { McpToolDetailPage } from './pages/McpToolDetailPage';
-import { MenuPage } from './pages/MenuPage';
-import { PluginsPage } from './pages/PluginsPage';
-import { SettingsPage } from './pages/SettingsPage';
-import { VectorPage } from './pages/VectorPage';
-import { VectorSearchResultsPage } from './pages/VectorSearchResultsPage';
+import { DashboardRoutes, isRouteLoading } from './router';
 import type { LoadState, MenuItem, PluginEntry } from './types';
 import type { MetricsSnapshot } from '../../src/server/types';
 
@@ -35,10 +28,6 @@ function errorText(error: unknown): string {
 
 function stateFor(key: DashboardKey, errors: DashboardErrors): LoadState {
   return errors[key] ? 'error' : 'ready';
-}
-
-function isLoading(state: LoadState): boolean {
-  return state === 'loading' || state === 'idle';
 }
 
 export async function loadDashboardData(client: DashboardClient = apiClient): Promise<DashboardLoadResult> {
@@ -103,39 +92,32 @@ export default function App() {
   }, []);
 
   const surfaceCount = useMemo(() => countPluginSurfaces(plugins), [plugins]);
-  const loading = isLoading(states.menu) || isLoading(states.plugins);
-  const metricsLoading = isLoading(states.metrics);
+  const loading = isRouteLoading(states.menu) || isRouteLoading(states.plugins);
+  const metricsLoading = isRouteLoading(states.metrics);
   const error = Object.values(errors).filter(Boolean).join(' · ');
   const refresh = () => void load();
 
   return (
-    <BrowserRouter>
-      <AppShell
-        error={error}
-        loading={loading}
-        menuCount={menu.length}
-        pluginCount={plugins.length}
-        surfaceCount={surfaceCount}
+    <AppShell
+      error={error}
+      loading={loading}
+      menuCount={menu.length}
+      pluginCount={plugins.length}
+      surfaceCount={surfaceCount}
+      metrics={metrics}
+      metricsLoading={metricsLoading}
+      updatedAt={updatedAt}
+      onRefresh={refresh}
+    >
+      <DashboardRoutes
+        menu={menu}
+        plugins={plugins}
+        states={states}
         metrics={metrics}
-        metricsLoading={metricsLoading}
+        surfaceCount={surfaceCount}
         updatedAt={updatedAt}
         onRefresh={refresh}
-      >
-        <Routes>
-          <Route index element={<Navigate to="/menu" replace />} />
-          <Route path="/menu" element={<MenuPage items={menu} loading={isLoading(states.menu)} />} />
-          <Route path="/plugins" element={<PluginsPage plugins={plugins} loading={isLoading(states.plugins)} />} />
-          <Route path="/vector" element={<VectorPage />} />
-          <Route path="/vector/results" element={<VectorSearchResultsPage />} />
-          <Route path="/mcp" element={<McpPage />} />
-          <Route path="/mcp/tools/:name" element={<McpToolDetailPage />} />
-          <Route
-            path="/settings"
-            element={<SettingsPage menuCount={menu.length} pluginCount={plugins.length} surfaceCount={surfaceCount} updatedAt={updatedAt} onRefresh={refresh} />}
-          />
-          <Route path="*" element={<Navigate to="/menu" replace />} />
-        </Routes>
-      </AppShell>
-    </BrowserRouter>
+      />
+    </AppShell>
   );
 }

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -47,9 +47,10 @@ export function AppShell({
   }, [location.pathname, location.search]);
 
   const navItems: NavItem[] = [
-    { to: '/menu', label: 'Menu', description: 'Navigation rows from /api/menu', badge: loading ? '…' : menuCount },
+    { to: '/', label: 'Menu', description: 'Navigation rows from /api/menu', badge: loading ? '…' : menuCount },
     { to: '/plugins', label: 'Plugins', description: 'Registered plugins and surfaces', badge: loading ? '…' : pluginCount },
-    { to: '/vector', label: 'Vector', description: 'Semantic search over memory' },
+    { to: '/search', label: 'Search', description: 'Semantic search over memory' },
+    { to: '/metrics', label: 'Metrics', description: 'Runtime counters from /api/metrics' },
     { to: '/mcp', label: 'MCP', description: 'Tool schemas and groups' },
     { to: '/settings', label: 'Settings', description: 'Storage, embedder, and DB status' },
   ];

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
-import { ErrorBoundary } from './components/ErrorBoundary';
+import { AppRouter } from './router';
 import './styles.css';
 import { registerServiceWorker } from './registerServiceWorker';
 import { applyTheme, readStoredTheme } from './theme';
@@ -11,8 +11,8 @@ registerServiceWorker();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ErrorBoundary>
+    <AppRouter>
       <App />
-    </ErrorBoundary>
+    </AppRouter>
   </StrictMode>,
 );

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -78,7 +78,7 @@ export function SettingsPage({ menuCount, pluginCount, surfaceCount, updatedAt, 
           <SettingCard label="API proxy" value="/api/* → :47778" detail="Vite forwards same-origin calls to the Elysia backend in development." />
           <SettingCard label="Frontend rows" value={`${menuCount} menu · ${pluginCount} plugins`} detail={`Last refreshed ${updatedAt}; use refresh after backend changes.`} />
           <SettingCard label="Plugin surfaces" value={surfaceCount} detail="Counts wasm, menu, server, and MCP surfaces exposed by plugin metadata." />
-          <SettingCard label="Client routes" value="/menu /plugins /vector /mcp /settings" detail="React Router owns client navigation while backend endpoints stay canonical." />
+          <SettingCard label="Client routes" value="/ /plugins /metrics /search" detail="React Router owns client navigation while backend endpoints stay canonical." />
         </dl>
       </section>
 

--- a/frontend/src/routePaths.ts
+++ b/frontend/src/routePaths.ts
@@ -5,5 +5,5 @@ export function mcpToolPath(name: string): string {
 export function vectorResultsPath(query: string): string {
   const qs = new URLSearchParams();
   if (query.trim()) qs.set('q', query.trim());
-  return qs.toString() ? `/vector/results?${qs}` : '/vector/results';
+  return qs.toString() ? `/search/results?${qs}` : '/search/results';
 }

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,0 +1,94 @@
+import type { ReactNode } from 'react';
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { ErrorBoundary } from './components/ErrorBoundary';
+import { LoadingPanel } from './components/AsyncState';
+import { StatCard } from './components/StatCard';
+import { McpPage } from './pages/McpPage';
+import { McpToolDetailPage } from './pages/McpToolDetailPage';
+import { MenuPage } from './pages/MenuPage';
+import { PluginsPage } from './pages/PluginsPage';
+import { SettingsPage } from './pages/SettingsPage';
+import { VectorPage } from './pages/VectorPage';
+import { VectorSearchResultsPage } from './pages/VectorSearchResultsPage';
+import type { LoadState, MenuItem, PluginEntry } from './types';
+import type { MetricsSnapshot } from '../../src/server/types';
+
+export const frontendRoutes = ['/', '/plugins', '/metrics', '/search'] as const;
+export type FrontendRoute = typeof frontendRoutes[number];
+
+export type DashboardRouteStates = Record<'menu' | 'plugins' | 'metrics', LoadState>;
+
+export interface DashboardRoutesProps {
+  menu: MenuItem[];
+  plugins: PluginEntry[];
+  states: DashboardRouteStates;
+  metrics: MetricsSnapshot | null;
+  surfaceCount: number;
+  updatedAt: string;
+  onRefresh: () => void;
+}
+
+export function isRouteLoading(state: LoadState): boolean {
+  return state === 'loading' || state === 'idle';
+}
+
+export function AppRouter({ children }: { children: ReactNode }) {
+  return (
+    <ErrorBoundary>
+      <BrowserRouter>{children}</BrowserRouter>
+    </ErrorBoundary>
+  );
+}
+
+function MetricsPage({ metrics, loading }: { metrics: MetricsSnapshot | null; loading: boolean }) {
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="metrics-page-title">
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Metrics</p>
+      <h2 id="metrics-page-title" className="mt-2 mb-4 text-2xl font-semibold text-white">Backend metrics</h2>
+      {loading ? <LoadingPanel title="Loading metrics…" detail="Fetching /api/metrics from the Elysia backend." /> : null}
+      {!loading && !metrics ? <p className="text-sm text-slate-400">No metrics snapshot is available yet.</p> : null}
+      {metrics ? (
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <StatCard label="Requests" value={metrics.requestCount} detail="tracked by Elysia lifecycle" />
+          <StatCard label="Avg response" value={`${metrics.avgResponseMs} ms`} detail="mean response time" />
+          <StatCard label="Active" value={metrics.activeConnections} detail="active HTTP requests" />
+          <StatCard label="Uptime" value={`${Math.round(metrics.uptime)}s`} detail={`since ${metrics.lastRestart}`} />
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+export function DashboardRoutes({
+  menu,
+  plugins,
+  states,
+  metrics,
+  surfaceCount,
+  updatedAt,
+  onRefresh,
+}: DashboardRoutesProps) {
+  const menuPage = <MenuPage items={menu} loading={isRouteLoading(states.menu)} />;
+  const pluginPage = <PluginsPage plugins={plugins} loading={isRouteLoading(states.plugins)} />;
+  const metricsPage = <MetricsPage metrics={metrics} loading={isRouteLoading(states.metrics)} />;
+
+  return (
+    <Routes>
+      <Route index element={menuPage} />
+      <Route path="/plugins" element={pluginPage} />
+      <Route path="/metrics" element={metricsPage} />
+      <Route path="/search" element={<VectorPage />} />
+      <Route path="/search/results" element={<VectorSearchResultsPage />} />
+      <Route path="/menu" element={menuPage} />
+      <Route path="/vector" element={<Navigate to="/search" replace />} />
+      <Route path="/vector/results" element={<VectorSearchResultsPage />} />
+      <Route path="/mcp" element={<McpPage />} />
+      <Route path="/mcp/tools/:name" element={<McpToolDetailPage />} />
+      <Route
+        path="/settings"
+        element={<SettingsPage menuCount={menu.length} pluginCount={plugins.length} surfaceCount={surfaceCount} updatedAt={updatedAt} onRefresh={onRefresh} />}
+      />
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Routes>
+  );
+}

--- a/tests/frontend/app/app-renders-shell.test.tsx
+++ b/tests/frontend/app/app-renders-shell.test.tsx
@@ -1,12 +1,13 @@
 import { describe, expect, test } from 'bun:test';
 import App from '../../../frontend/src/App';
+import { AppRouter } from '../../../frontend/src/router';
 import { htmlFor, installBrowserLocation } from '../_render';
 
 describe('App shell render', () => {
   test('renders the dashboard shell at the menu route before data loads', () => {
     const restore = installBrowserLocation('/menu');
     try {
-      const html = htmlFor(<App />);
+      const html = htmlFor(<AppRouter><App /></AppRouter>);
       expect(html).toContain('Control Surface');
       expect(html).toContain('Menu viewer');
       expect(html).toContain('Arra Oracle');

--- a/tests/frontend/dashboard.test.ts
+++ b/tests/frontend/dashboard.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { createElement } from 'react';
 import App, { loadDashboardData } from '../../frontend/src/App';
+import { AppRouter } from '../../frontend/src/router';
 import { htmlFor, installBrowserLocation } from './_render';
 
 describe('dashboard data loading', () => {
@@ -33,7 +34,7 @@ describe('dashboard data loading', () => {
   test('renders dashboard metric cards with loading state before effects resolve', () => {
     const restore = installBrowserLocation('/menu');
     try {
-      const html = htmlFor(createElement(App));
+      const html = htmlFor(createElement(AppRouter, null, createElement(App)));
       expect(html).toContain('Requests');
       expect(html).toContain('Avg response');
       expect(html).toContain('Loading metrics');

--- a/tests/frontend/pages/settings-page-summary.test.tsx
+++ b/tests/frontend/pages/settings-page-summary.test.tsx
@@ -8,6 +8,6 @@ describe('SettingsPage summary', () => {
     expect(html).toContain('Runtime configuration');
     expect(html).toContain('3 menu · 2 plugins');
     expect(html).toContain('Plugin surfaces');
-    expect(html).toContain('/menu /plugins /vector /mcp /settings');
+    expect(html).toContain('/ /plugins /metrics /search');
   });
 });

--- a/tests/frontend/router.test.ts
+++ b/tests/frontend/router.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test';
+import { createElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { AppRouter, DashboardRoutes, frontendRoutes, type DashboardRoutesProps } from '../../frontend/src/router';
+import { htmlFor, installBrowserLocation } from './_render';
+
+const routeProps: DashboardRoutesProps = {
+  menu: [{ label: 'Dashboard', path: '/', group: 'main', order: 1, source: 'api' }],
+  plugins: [{ name: 'echo', file: 'echo.wasm', size: 12, modified: 'now' }],
+  states: { menu: 'ready', plugins: 'ready', metrics: 'ready' },
+  metrics: {
+    uptime: 12.5,
+    requestCount: 42,
+    avgResponseMs: 3.2,
+    activeConnections: 1,
+    lastRestart: '2026-06-16T00:00:00.000Z',
+  },
+  surfaceCount: 1,
+  updatedAt: '11:11',
+  onRefresh: () => {},
+};
+
+function htmlAt(path: string): string {
+  return htmlFor(createElement(
+    MemoryRouter,
+    { initialEntries: [path] },
+    createElement(DashboardRoutes, routeProps),
+  ));
+}
+
+describe('frontend router', () => {
+  test('declares the public dashboard route set', () => {
+    expect([...frontendRoutes]).toEqual(['/', '/plugins', '/metrics', '/search']);
+  });
+
+  test('routes root, plugins, metrics, and search surfaces', () => {
+    expect(htmlAt('/')).toContain('Menu viewer');
+    expect(htmlAt('/plugins')).toContain('Plugin list');
+    expect(htmlAt('/metrics')).toContain('Backend metrics');
+    expect(htmlAt('/metrics')).toContain('42');
+    expect(htmlAt('/search')).toContain('Vector search');
+  });
+
+  test('wraps routed children in the browser router and error boundary shell', () => {
+    const restore = installBrowserLocation('/');
+    try {
+      const html = htmlFor(createElement(AppRouter, null, createElement('p', null, 'router child')));
+      expect(html).toContain('router child');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/tests/frontend/routes/vector-results-empty-path.test.ts
+++ b/tests/frontend/routes/vector-results-empty-path.test.ts
@@ -3,6 +3,6 @@ import { vectorResultsPath } from '../../../frontend/src/routePaths';
 
 describe('vectorResultsPath empty query', () => {
   test('omits the q parameter when no query is present', () => {
-    expect(vectorResultsPath('  ')).toBe('/vector/results');
+    expect(vectorResultsPath('  ')).toBe('/search/results');
   });
 });

--- a/tests/frontend/routes/vector-results-path.test.ts
+++ b/tests/frontend/routes/vector-results-path.test.ts
@@ -3,6 +3,6 @@ import { vectorResultsPath } from '../../../frontend/src/routePaths';
 
 describe('vectorResultsPath', () => {
   test('encodes vector result queries in the route query string', () => {
-    expect(vectorResultsPath('oracle memory')).toBe('/vector/results?q=oracle+memory');
+    expect(vectorResultsPath('oracle memory')).toBe('/search/results?q=oracle+memory');
   });
 });


### PR DESCRIPTION
## Summary\n- add frontend/src/router.tsx with ErrorBoundary-wrapped BrowserRouter support and dashboard routes for /, /plugins, /metrics, and /search\n- move route rendering out of App so App owns dashboard state while router owns navigation\n- add a metrics route surface backed by /api/metrics data and keep legacy aliases working\n- add router coverage and update existing frontend route tests\n\n## Verification\n- bun test tests/frontend/router.test.ts\n- bun test tests/frontend/\n- bun run --cwd frontend build\n- tsc --noEmit\n- changed files <=250 lines