### PR TITLE
Add SQLite backup CLI command

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -150,6 +150,12 @@ async function main() {
     process.exit(await seedCommand(args.slice(1)));
   }
 
+  if (cmd === "backup") {
+    if (hasHelpFlag(args.slice(1))) return printBuiltinHelp(cmd);
+    const { backupCommand } = await import("../../src/cli/commands/backup.ts");
+    process.exit(await backupCommand(args.slice(1)));
+  }
+
   if (cmd === "use") {
     if (hasHelpFlag(args.slice(1))) return printBuiltinHelp(cmd);
     process.exit(await useCommand(args.slice(1)));

--- a/cli/src/commands/catalog.ts
+++ b/cli/src/commands/catalog.ts
@@ -20,6 +20,7 @@ export const BUILTIN_COMMANDS: CommandSpec[] = [
   { command: "huginn", help: "run Huginn capture utilities", subcommands: ["sweep"], flags: ["--sessions-dir", "--repo-root", "--lookback-hours", "--max-files", "--json", "--help", "-h"] },
   { command: "migrate", help: "run Drizzle migration generate and push", flags: ["--help", "-h"] },
   { command: "seed", help: "populate development DB sample data", flags: ["--help", "-h"] },
+  { command: "backup", help: "dump SQLite DB to timestamped SQL", flags: ["--out-dir", "--help", "-h"] },
   { command: "changelog", help: "generate CHANGELOG.md from git history", flags: ["--since", "--out", "--stdout", "--help", "-h"] },
   { command: "release", help: "bump CalVer, write changelog, and create a tag", flags: ["--beta", "--stable", "--changelog", "--dry-run", "--help", "-h"] },
   { command: "export", help: "export vault data as JSON", flags: ["--format", "--out", "--help", "-h"] },

--- a/src/cli/commands/backup.ts
+++ b/src/cli/commands/backup.ts
@@ -1,0 +1,198 @@
+import { getTableColumns, getTableName, isTable } from 'drizzle-orm';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { ORACLE_DATA_DIR, DB_PATH } from '../../config.ts';
+import type { DatabaseConnection } from '../../db/index.ts';
+import * as schema from '../../db/schema.ts';
+import { auditLog } from '../../storage/audit-log.ts';
+import { createStorageBackend } from '../../storage/registry.ts';
+
+interface DumpColumn {
+  name: string;
+  primary: boolean;
+  notNull: boolean;
+  autoIncrement?: boolean;
+  getSQLType(): string;
+}
+
+type Writer = (message: string) => void;
+type DumpRow = Record<string, unknown>;
+type DumpTable = Parameters<typeof getTableName>[0];
+
+export interface BackupOptions {
+  connection?: DatabaseConnection;
+  outDir?: string;
+  now?: () => Date;
+  stdout?: Writer;
+  stderr?: Writer;
+}
+
+export interface BackupResult {
+  path: string;
+  tableCount: number;
+  rowCount: number;
+}
+
+export function introspectDrizzleTables(): DumpTable[] {
+  const tables = [...Object.values(schema), auditLog].filter(isTable) as DumpTable[];
+  return tables.sort((a, b) => getTableName(a).localeCompare(getTableName(b)));
+}
+
+export async function writeSqliteBackup(options: BackupOptions = {}): Promise<BackupResult> {
+  const now = options.now?.() ?? new Date();
+  const outDir = options.outDir ?? path.join(ORACLE_DATA_DIR, 'backups');
+  const close = options.connection ? undefined : openReadonlyConnection();
+  const connection = options.connection ?? close!.connection;
+  const tables = introspectDrizzleTables();
+  const dump = buildSqlDump(connection, tables, now);
+  const outFile = path.join(outDir, `arra-oracle-${timestampForFile(now)}.sql`);
+
+  try {
+    await mkdir(outDir, { recursive: true });
+    await writeFile(outFile, dump.sql, 'utf8');
+    return { path: outFile, tableCount: tables.length, rowCount: dump.rowCount };
+  } finally {
+    close?.connection.storage.close();
+  }
+}
+
+export async function backupCommand(args: string[], options: BackupOptions = {}): Promise<number> {
+  const stdout = options.stdout ?? writeStdout;
+  const stderr = options.stderr ?? writeStderr;
+  try {
+    if (args.includes('--help') || args.includes('-h')) {
+      printHelp(stdout);
+      return 0;
+    }
+    const parsed = parseBackupArgs(args);
+    const result = await writeSqliteBackup({ ...options, ...parsed });
+    stdout(JSON.stringify(result, null, 2) + '\n');
+    return 0;
+  } catch (error) {
+    stderr(`${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+export function buildSqlDump(
+  connection: DatabaseConnection,
+  tables: DumpTable[] = introspectDrizzleTables(),
+  createdAt: Date = new Date(),
+): { sql: string; rowCount: number } {
+  const lines = [
+    '-- ARRA Oracle SQLite backup',
+    `-- Created at ${createdAt.toISOString()}`,
+    'PRAGMA foreign_keys=OFF;',
+    'BEGIN TRANSACTION;',
+  ];
+  let rowCount = 0;
+  for (const table of tables) {
+    const tableName = getTableName(table);
+    const columns = columnEntries(table);
+    lines.push('', createTableSql(tableName, columns));
+    for (const row of selectRows(connection, table)) {
+      lines.push(insertSql(tableName, columns, row));
+      rowCount += 1;
+    }
+  }
+  lines.push('', 'COMMIT;', 'PRAGMA foreign_keys=ON;', '');
+  return { sql: lines.join('\n'), rowCount };
+}
+
+function openReadonlyConnection(): { connection: DatabaseConnection } {
+  const storage = createStorageBackend({ dbPath: DB_PATH, readonly: true });
+  return { connection: { sqlite: storage.sqlite, db: storage.db, storage } };
+}
+
+function parseBackupArgs(args: string[]): Pick<BackupOptions, 'outDir'> {
+  if (args.length === 0) return {};
+  const outDir = readValue(args, '--out-dir');
+  const consumed = new Set<string>();
+  const index = args.findIndex(arg => arg === '--out-dir' || arg.startsWith('--out-dir='));
+  if (index >= 0) {
+    consumed.add(args[index]!);
+    if (args[index] === '--out-dir') consumed.add(args[index + 1]!);
+  }
+  const unknown = args.find(arg => !consumed.has(arg));
+  if (unknown) throw new Error(`unknown backup option: ${unknown}`);
+  if (outDir === undefined) throw new Error('missing value for --out-dir');
+  return { outDir };
+}
+
+function readValue(args: string[], flag: string): string | undefined {
+  const index = args.indexOf(flag);
+  if (index >= 0) return args[index + 1];
+  const prefix = `${flag}=`;
+  return args.find(arg => arg.startsWith(prefix))?.slice(prefix.length);
+}
+
+function columnEntries(table: DumpTable): Array<[string, DumpColumn]> {
+  return Object.entries(getTableColumns(table)) as Array<[string, DumpColumn]>;
+}
+
+function createTableSql(tableName: string, columns: Array<[string, DumpColumn]>): string {
+  const definitions = columns.map(([, column]) => `  ${quoteIdent(column.name)} ${columnDefinition(column)}`);
+  return [`CREATE TABLE IF NOT EXISTS ${quoteIdent(tableName)} (`, definitions.join(',\n'), ');'].join('\n');
+}
+
+function columnDefinition(column: DumpColumn): string {
+  const parts = [column.getSQLType().toUpperCase()];
+  if (column.primary) parts.push('PRIMARY KEY');
+  if (column.autoIncrement) parts.push('AUTOINCREMENT');
+  if (column.notNull && !column.primary) parts.push('NOT NULL');
+  return parts.join(' ');
+}
+
+function selectRows(connection: DatabaseConnection, table: DumpTable): DumpRow[] {
+  return (connection.db as any).select().from(table).all() as DumpRow[];
+}
+
+function insertSql(tableName: string, columns: Array<[string, DumpColumn]>, row: DumpRow): string {
+  const names = columns.map(([, column]) => quoteIdent(column.name)).join(', ');
+  const values = columns.map(([property]) => sqlValue(row[property])).join(', ');
+  return `INSERT INTO ${quoteIdent(tableName)} (${names}) VALUES (${values});`;
+}
+
+function sqlValue(value: unknown): string {
+  if (value === null || value === undefined) return 'NULL';
+  if (value instanceof Date) return String(value.getTime());
+  if (typeof value === 'boolean') return value ? '1' : '0';
+  if (typeof value === 'number') return Number.isFinite(value) ? String(value) : 'NULL';
+  if (typeof value === 'bigint') return value.toString();
+  if (value instanceof Uint8Array) return `X'${Buffer.from(value).toString('hex')}'`;
+  if (typeof value === 'object') return quoteString(JSON.stringify(value));
+  return quoteString(String(value));
+}
+
+function quoteIdent(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+function quoteString(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function timestampForFile(date: Date): string {
+  return date.toISOString().replace(/[:.]/g, '-');
+}
+
+function printHelp(write: Writer): void {
+  write([
+    'arra-cli backup [--out-dir <dir>]',
+    '',
+    'Dumps Drizzle-known SQLite tables to a timestamped .sql file.',
+    '',
+    'Flags:',
+    '  --out-dir <dir>    write backup file under this directory',
+    '  --help, -h         show this help',
+    '',
+  ].join('\n'));
+}
+
+function writeStdout(message: string): void {
+  process.stdout.write(message);
+}
+
+function writeStderr(message: string): void {
+  process.stderr.write(message);
+}

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -104,6 +104,13 @@ export const BUILTIN_HELP: CliHelpEntry[] = [
     examples: ["arra-cli seed"],
   },
   {
+    command: "backup",
+    help: "dump SQLite DB to timestamped SQL",
+    usage: "arra-cli backup [--out-dir <dir>]",
+    flags: ["--out-dir <dir>", "--help", "-h"],
+    examples: ["arra-cli backup", "arra-cli backup --out-dir ./backups"],
+  },
+  {
     command: "changelog",
     help: "generate CHANGELOG.md from git history",
     usage: "arra-cli changelog [--since <tag>] [--out CHANGELOG.md] [--stdout]",

--- a/tests/cli/backup/dump.test.ts
+++ b/tests/cli/backup/dump.test.ts
@@ -1,0 +1,97 @@
+import { afterAll, afterEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+
+const importRoot = mkdtempSync(join(tmpdir(), 'arra-backup-import-'));
+process.env.ORACLE_DATA_DIR = join(importRoot, 'data');
+process.env.ORACLE_REPO_ROOT = importRoot;
+
+const dbModule = await import('../../../src/db/index.ts');
+const backupModule = await import('../../../src/cli/commands/backup.ts');
+
+const { closeDb, createDatabase, learnLog, menuItems, oracleDocuments } = dbModule;
+const { backupCommand, writeSqliteBackup } = backupModule;
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots) rmSync(root, { recursive: true, force: true });
+  roots.length = 0;
+});
+
+afterAll(() => {
+  closeDb();
+  rmSync(importRoot, { recursive: true, force: true });
+});
+
+function tempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'arra-backup-db-'));
+  roots.push(root);
+  return root;
+}
+
+function populate(connection: ReturnType<typeof createDatabase>): void {
+  const createdAt = new Date('2026-01-02T03:04:05.006Z');
+  connection.db.insert(menuItems).values({
+    path: '/dev/backup',
+    label: "Backup's Lab",
+    groupKey: 'development',
+    position: 930,
+    enabled: true,
+    access: 'public',
+    source: 'test',
+    createdAt,
+    updatedAt: createdAt,
+  }).run();
+  connection.db.insert(oracleDocuments).values({
+    id: 'backup-doc',
+    type: 'learning',
+    sourceFile: 'seed://backup.md',
+    concepts: JSON.stringify(['backup', 'drizzle']),
+    createdAt: 1_766_000_000_000,
+    updatedAt: 1_766_000_000_000,
+    indexedAt: 1_766_000_000_000,
+    createdBy: 'test',
+  }).run();
+  connection.db.insert(learnLog).values({
+    documentId: 'backup-doc',
+    patternPreview: 'Drizzle schema metadata can produce SQL dumps.',
+    source: 'test',
+    concepts: JSON.stringify(['backup']),
+    createdAt: 1_766_000_000_000,
+  }).run();
+}
+
+describe('SQLite backup dump command', () => {
+  test('writes a timestamped SQL dump from Drizzle table metadata', async () => {
+    const root = tempRoot();
+    const connection = createDatabase(join(root, 'oracle.db'));
+    const outDir = join(root, 'backups');
+    populate(connection);
+    try {
+      const fixedNow = () => new Date('2026-01-02T03:04:05.006Z');
+      const result = await writeSqliteBackup({ connection, outDir, now: fixedNow });
+      const stdout: string[] = [];
+      const code = await backupCommand([], { connection, outDir, now: fixedNow, stdout: msg => stdout.push(msg) });
+      const commandResult = JSON.parse(stdout.join(''));
+
+      expect(code).toBe(0);
+      expect(existsSync(result.path)).toBe(true);
+      expect(basename(result.path)).toBe('arra-oracle-2026-01-02T03-04-05-006Z.sql');
+      expect(commandResult.path).toBe(result.path);
+      expect(result.tableCount).toBeGreaterThan(5);
+      expect(result.rowCount).toBeGreaterThanOrEqual(3);
+
+      const sql = readFileSync(result.path, 'utf8');
+      expect(sql).toContain('CREATE TABLE IF NOT EXISTS "menu_items"');
+      expect(sql).toContain('CREATE TABLE IF NOT EXISTS "oracle_documents"');
+      expect(sql).toContain('INSERT INTO "menu_items"');
+      expect(sql).toContain("Backup''s Lab");
+      expect(sql).toContain('INSERT INTO "learn_log"');
+      expect(sql).toContain('COMMIT;');
+    } finally {
+      connection.storage.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add `arra-cli backup [--out-dir <dir>]` to write timestamped `.sql` dumps from Drizzle-known SQLite tables.
- Use Drizzle table metadata (`getTableName` / `getTableColumns`) to build SQL table and insert statements without shelling out to sqlite `.dump`.
- Wire the command into CLI dispatch, builtin help, and command catalog.
- Add scoped backup coverage for timestamped output and SQL dump contents.

## Verification
- `bun test tests/cli/backup/`
- `bun run build`
- `git diff --check`
- changed-file line counts all <=250

Document-refresh: not-needed | Builtin CLI help documents the new operator command; broader operator docs refresh was not requested for this scoped CLI task.
