### PR TITLE
Add production Docker Compose stack

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,14 @@
+# Production environment for docker-compose.prod.yml.
+# Copy to .env.production and edit for your deployment.
+
+# Host binding for the HTTP API.
+ARRA_HTTP_BIND=127.0.0.1
+ARRA_HTTP_PORT=47778
+ARRA_IMAGE=arra-oracle-v3:prod
+
+# Application settings passed into the container.
+ORACLE_SESSION_SECRET=change-me
+CORS_ORIGIN=
+VECTOR_URL=
+VECTOR_FALLBACK=fts5
+ORACLE_EMBEDDER=none

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,34 @@
+# Production compose stack for arra-oracle-v3.
+# Copy .env.production.example to .env.production and fill deployment secrets.
+
+services:
+  arra-oracle:
+    image: ${ARRA_IMAGE:-arra-oracle-v3:prod}
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: http-server
+    env_file:
+      - path: ./.env.production
+        required: false
+    environment:
+      HOME: /data
+      ORACLE_DATA_DIR: /data
+      ORACLE_DB_PATH: /data/oracle.db
+      ORACLE_PORT: "47778"
+      PORT: "47778"
+      ORACLE_LOG_TARGET: stderr
+    ports:
+      - "${ARRA_HTTP_BIND:-127.0.0.1}:${ARRA_HTTP_PORT:-47778}:47778"
+    volumes:
+      - arra-oracle-data:/data
+    healthcheck:
+      test: ["CMD", "bun", "-e", "const r=await fetch('http://127.0.0.1:47778/api/health');process.exit(r.ok?0:1)"]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
+    restart: unless-stopped
+
+volumes:
+  arra-oracle-data:


### PR DESCRIPTION
## Summary\n- add docker-compose.prod.yml for the production http-server target\n- mount persistent SQLite/data volume at /data and load optional .env.production\n- publish port 47778, set restart policy, and include a /api/health service healthcheck\n- add .env.production.example for deployment defaults\n\n## Tests\n- bunx tsc --noEmit\n- docker compose -f docker-compose.prod.yml config\n- ARRA_HTTP_PORT=47882 docker compose -p arra-codex1-prod-test -f docker-compose.prod.yml up -d --build; /api/health returned HTTP 200 and service health became healthy