### PR TITLE
feat: retry transient upstream proxy failures

### DIFF
--- a/src/gateway/proxy.ts
+++ b/src/gateway/proxy.ts
@@ -5,6 +5,7 @@
  * Returns 502 on connection refused, 504 on timeout.
  */
 import type { ServiceConfig } from './config.ts';
+import { cloneRetryableBody, retryableRequestBody, retryUpstreamRequest } from '../middleware/retry.ts';
 
 const DEFAULT_TIMEOUT_MS = 15_000;
 
@@ -20,16 +21,15 @@ export async function proxyToService(
   try {
     const headers = new Headers(request.headers);
     headers.delete('host');
+    const body = await retryableRequestBody(request);
 
-    const res = await fetch(targetUrl, {
+    const res = await retryUpstreamRequest(() => fetch(targetUrl, {
       method: request.method,
-      headers,
-      body: request.method !== 'GET' && request.method !== 'HEAD'
-        ? request.body
-        : undefined,
+      headers: new Headers(headers),
+      body: cloneRetryableBody(body),
       signal: AbortSignal.timeout(timeoutMs),
       duplex: 'half',
-    });
+    }));
 
     // Stream the response back, preserving status and headers
     const responseHeaders = new Headers(res.headers);

--- a/src/middleware/retry.ts
+++ b/src/middleware/retry.ts
@@ -1,0 +1,55 @@
+const DEFAULT_RETRY_COUNT = 2;
+const RETRIABLE_STATUSES = new Set([500, 502, 503, 504]);
+
+type RetryAttempt = (attempt: number) => Promise<Response>;
+type RetryableResponse = (response: Response) => boolean;
+
+export type UpstreamRetryOptions = {
+  maxRetries?: number;
+  shouldRetryResponse?: RetryableResponse;
+};
+
+export function retryCountFromEnv(value = process.env.ARRA_RETRY_COUNT): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : DEFAULT_RETRY_COUNT;
+}
+
+export function isRetryableUpstreamStatus(status: number): boolean {
+  return RETRIABLE_STATUSES.has(status);
+}
+
+export async function retryableRequestBody(request: Request): Promise<ArrayBuffer | undefined> {
+  return request.method === 'GET' || request.method === 'HEAD' ? undefined : await request.arrayBuffer();
+}
+
+export function cloneRetryableBody(body: ArrayBuffer | undefined): ArrayBuffer | undefined {
+  return body ? body.slice(0) : undefined;
+}
+
+async function discard(response: Response): Promise<void> {
+  const cancelled = response.body?.cancel();
+  if (cancelled) await cancelled.catch(() => undefined);
+}
+
+export async function retryUpstreamRequest(
+  attempt: RetryAttempt,
+  options: UpstreamRetryOptions = {},
+): Promise<Response> {
+  const maxRetries = Math.max(0, Math.floor(options.maxRetries ?? retryCountFromEnv()));
+  const shouldRetry = options.shouldRetryResponse ?? ((response) => isRetryableUpstreamStatus(response.status));
+  async function run(current: number): Promise<Response> {
+    try {
+      const response = await attempt(current);
+      if (current < maxRetries && shouldRetry(response)) {
+        await discard(response);
+        return run(current + 1);
+      }
+      return response;
+    } catch (error) {
+      if (current >= maxRetries) throw error;
+      return run(current + 1);
+    }
+  }
+
+  return run(0);
+}

--- a/src/plugins/proxy-surface.ts
+++ b/src/plugins/proxy-surface.ts
@@ -1,5 +1,6 @@
 import { Elysia } from 'elysia';
 import type { UnifiedProxyManifest } from './unified-manifest.ts';
+import { cloneRetryableBody, retryableRequestBody, retryUpstreamRequest } from '../middleware/retry.ts';
 
 const DEFAULT_TIMEOUT_MS = Number(process.env.ARRA_PLUGIN_PROXY_TIMEOUT_MS ?? 15_000);
 type ElysiaApp = Elysia<any, any, any, any, any, any, any>;
@@ -50,13 +51,14 @@ async function forward(request: Request, target: string): Promise<Response> {
   try {
     const headers = new Headers(request.headers);
     headers.delete('host');
-    const res = await fetch(target, {
+    const body = await retryableRequestBody(request);
+    const res = await retryUpstreamRequest(() => fetch(target, {
       method: request.method,
-      headers,
-      body: request.method === 'GET' || request.method === 'HEAD' ? undefined : request.body,
+      headers: new Headers(headers),
+      body: cloneRetryableBody(body),
       signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
       duplex: 'half',
-    });
+    }));
     const responseHeaders = new Headers(res.headers);
     responseHeaders.set('x-unified-proxy-target', new URL(target).origin);
     return new Response(res.body, { status: res.status, statusText: res.statusText, headers: responseHeaders });

--- a/tests/http/retry/upstream.test.ts
+++ b/tests/http/retry/upstream.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { proxyToService } from '../../../src/gateway/proxy.ts';
+import {
+  isRetryableUpstreamStatus,
+  retryCountFromEnv,
+  retryUpstreamRequest,
+} from '../../../src/middleware/retry.ts';
+import { proxyRequestForManifest } from '../../../src/plugins/proxy-surface.ts';
+
+const previousRetryCount = process.env.ARRA_RETRY_COUNT;
+const manifest = { path: '/api/retry', targetEnv: 'TEST_RETRY_URL', stripPrefix: true, methods: ['GET', 'POST'] };
+const servers: ReturnType<typeof Bun.serve>[] = [];
+
+afterEach(() => {
+  if (previousRetryCount === undefined) delete process.env.ARRA_RETRY_COUNT;
+  else process.env.ARRA_RETRY_COUNT = previousRetryCount;
+  while (servers.length) servers.pop()!.stop();
+});
+
+function startServer(handler: (request: Request) => Response | Promise<Response>): string {
+  const server = Bun.serve({ port: 0, fetch: handler });
+  servers.push(server);
+  return `http://127.0.0.1:${server.port}`;
+}
+
+function proxyApp(target: string) {
+  return new Elysia().onRequest(({ request }) => proxyRequestForManifest(request, [manifest], { TEST_RETRY_URL: target }));
+}
+
+async function json(response: Response) {
+  return await response.json() as Record<string, unknown>;
+}
+
+describe('upstream proxy retry middleware', () => {
+  test('retries failed unified proxy responses with the default retry count', async () => {
+    let attempts = 0;
+    const target = startServer(async (request) => {
+      attempts += 1;
+      if (attempts < 3) return Response.json({ attempts }, { status: 503 });
+      return Response.json({ attempts, method: request.method, body: await request.text() });
+    });
+    const app = proxyApp(target);
+
+    const response = await app.handle(new Request('http://local/api/retry/echo', {
+      method: 'POST',
+      body: 'payload',
+    }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-unified-proxy-target')).toBe(new URL(target).origin);
+    expect(await json(response)).toEqual({ attempts: 3, method: 'POST', body: 'payload' });
+  });
+
+  test('honors ARRA_RETRY_COUNT=0 for upstream proxy responses', async () => {
+    process.env.ARRA_RETRY_COUNT = '0';
+    let attempts = 0;
+    const target = startServer(() => {
+      attempts += 1;
+      return Response.json({ attempts }, { status: 503 });
+    });
+    const app = proxyApp(target);
+
+    const response = await app.handle(new Request('http://local/api/retry/down'));
+
+    expect(response.status).toBe(503);
+    expect(await json(response)).toEqual({ attempts: 1 });
+    expect(attempts).toBe(1);
+  });
+
+  test('retries gateway proxy failures before returning success', async () => {
+    let attempts = 0;
+    const target = startServer(() => {
+      attempts += 1;
+      return attempts === 1 ? new Response('busy', { status: 500 }) : Response.json({ attempts });
+    });
+
+    const response = await proxyToService(new Request('http://local/api/search?q=retry'), { url: target, timeout: 500 });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('X-Gateway-Service')).toBe(target);
+    expect(await json(response)).toEqual({ attempts: 2 });
+  });
+
+  test('retries thrown attempts and then rethrows after the retry budget', async () => {
+    let recoveredAttempts = 0;
+    const recovered = await retryUpstreamRequest(async () => {
+      recoveredAttempts += 1;
+      if (recoveredAttempts < 3) throw new Error('temporary upstream failure');
+      return Response.json({ ok: true });
+    }, { maxRetries: 2 });
+
+    let failedAttempts = 0;
+    await expect(retryUpstreamRequest(async () => {
+      failedAttempts += 1;
+      throw new Error('upstream down');
+    }, { maxRetries: 1 })).rejects.toThrow('upstream down');
+
+    expect(await json(recovered)).toEqual({ ok: true });
+    expect(recoveredAttempts).toBe(3);
+    expect(failedAttempts).toBe(2);
+  });
+
+  test('parses retry counts and supports custom response retry predicates', async () => {
+    const statuses = [418, 200];
+    const response = await retryUpstreamRequest(async () => new Response('ok', { status: statuses.shift() }), {
+      maxRetries: 1,
+      shouldRetryResponse: (candidate) => candidate.status === 418,
+    });
+
+    expect(response.status).toBe(200);
+    expect(retryCountFromEnv(undefined)).toBe(2);
+    expect(retryCountFromEnv('3.9')).toBe(3);
+    expect(retryCountFromEnv('-1')).toBe(2);
+    expect(retryCountFromEnv('invalid')).toBe(2);
+    let cancelAttempts = 0;
+    const cancelResponse = await retryUpstreamRequest(async () => {
+      cancelAttempts += 1;
+      if (cancelAttempts === 1) {
+        return new Response(new ReadableStream({ cancel: () => { throw new Error('ignore cancel'); } }), { status: 503 });
+      }
+      return new Response('recovered');
+    }, { maxRetries: 1 });
+
+    expect(await cancelResponse.text()).toBe('recovered');
+    expect(isRetryableUpstreamStatus(500)).toBe(true);
+    expect(isRetryableUpstreamStatus(418)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add `src/middleware/retry.ts` for configurable upstream retry handling via `ARRA_RETRY_COUNT` (default 2)
- retry transient 5xx upstream proxy responses and thrown fetch attempts
- wire retries into gateway and unified/plugin/vector proxy dispatch while replaying request bodies safely per attempt
- add fetch-based HTTP contract tests under `tests/http/retry/`

## Verification
- `tsc --noEmit`
- `bun test tests/http/retry/`
- `bun test --coverage tests/http/retry/` (100% funcs/lines for `src/middleware/retry.ts`)
- affected proxy/gateway regressions: plugin server proxy, vector proxy, gateway hook/matcher/health tests
- `git diff --check HEAD^..HEAD`
- `wc -l` changed files (all <=250)