### PR TITLE
feat: add frontend menu search page

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,4 @@
-import type { MenuResponse } from '../../../src/routes/menu/model';
+import type { MenuItem, MenuResponse } from '../../../src/routes/menu/model';
 import type {
   HealthResponse,
   MetricsSnapshot,
@@ -6,10 +6,17 @@ import type {
   VectorSearchResponse,
 } from '../../../src/server/types';
 
+export interface MenuSearchResponse {
+  data: MenuItem[];
+  q: string;
+  total: number;
+}
+
 export interface ApiRouteResponses {
   '/api/health': HealthResponse;
   '/api/metrics': MetricsSnapshot;
   '/api/menu': MenuResponse;
+  '/api/menu/search': MenuSearchResponse;
   '/api/vector/search': VectorSearchResponse;
   '/api/plugins': PluginsResponse;
 }
@@ -95,6 +102,11 @@ export class ApiClient {
 
   menu(): Promise<MenuResponse> {
     return this.request('/api/menu');
+  }
+
+  menuSearch(q: string): Promise<MenuSearchResponse> {
+    const query = new URLSearchParams({ q: q.trim() });
+    return this.fetchJson(`/api/menu/search?${query.toString()}`);
   }
 
   plugins(): Promise<PluginsResponse> {

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -49,7 +49,7 @@ export function AppShell({
   const navItems: NavItem[] = [
     { to: '/', label: 'Menu', description: 'Navigation rows from /api/menu', badge: loading ? '…' : menuCount },
     { to: '/plugins', label: 'Plugins', description: 'Registered plugins and surfaces', badge: loading ? '…' : pluginCount },
-    { to: '/search', label: 'Search', description: 'Semantic search over memory' },
+    { to: '/search', label: 'Search', description: 'Full-text menu search' },
     { to: '/metrics', label: 'Metrics', description: 'Runtime counters from /api/metrics' },
     { to: '/mcp', label: 'MCP', description: 'Tool schemas and groups' },
     { to: '/settings', label: 'Settings', description: 'Storage, embedder, and DB status' },

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,0 +1,143 @@
+import { useState, type FormEvent } from 'react';
+import { apiClient, type ApiClient, type MenuSearchResponse } from '../api/client';
+import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
+import { EmptyState } from '../components/EmptyState';
+import type { MenuItem } from '../types';
+
+type PageState = 'idle' | 'loading' | 'ready' | 'error';
+type SearchClient = Pick<ApiClient, 'menuSearch'>;
+
+export type HighlightPart = {
+  text: string;
+  match: boolean;
+};
+
+export function highlightParts(text: string, query: string): HighlightPart[] {
+  const needle = query.trim().toLocaleLowerCase();
+  if (!needle) return [{ text, match: false }];
+
+  const parts: HighlightPart[] = [];
+  const haystack = text.toLocaleLowerCase();
+  let cursor = 0;
+  let index = haystack.indexOf(needle, cursor);
+
+  while (index !== -1) {
+    if (index > cursor) parts.push({ text: text.slice(cursor, index), match: false });
+    const end = index + needle.length;
+    parts.push({ text: text.slice(index, end), match: true });
+    cursor = end;
+    index = haystack.indexOf(needle, cursor);
+  }
+
+  if (cursor < text.length) parts.push({ text: text.slice(cursor), match: false });
+  return parts.length ? parts : [{ text, match: false }];
+}
+
+export function menuSearchSummary(state: PageState, query: string, total: number): string {
+  if (state === 'idle') return 'Enter a query to search the menu catalog.';
+  if (state === 'loading') return `Searching menu for “${query}”…`;
+  if (state === 'error') return 'Menu search failed.';
+  return total ? `${total} menu result${total === 1 ? '' : 's'} for “${query}”.` : `No menu results found for “${query}”.`;
+}
+
+export async function searchMenuItems(query: string, client: SearchClient = apiClient): Promise<MenuSearchResponse> {
+  return client.menuSearch(query.trim());
+}
+
+function HighlightedText({ text, query }: { text: string; query: string }) {
+  return (
+    <>
+      {highlightParts(text, query).map((part, index) => part.match ? (
+        <mark key={`${part.text}-${index}`} className="rounded bg-amber-300/25 px-0.5 text-amber-100">
+          {part.text}
+        </mark>
+      ) : <span key={`${part.text}-${index}`}>{part.text}</span>)}
+    </>
+  );
+}
+
+export function MenuSearchResults({ query, results, state }: { query: string; results: MenuItem[]; state: PageState }) {
+  if (state === 'loading') return <LoadingPanel title="Searching menu…" detail="Fetching /api/menu/search?q= from the Elysia backend." />;
+  if (state === 'idle') return <EmptyState text="Search labels and paths from /api/menu/search?q=." />;
+  if (state === 'error') return null;
+  if (!results.length) return <EmptyState text={`No menu results found for “${query}”.`} />;
+
+  return (
+    <ul className="grid gap-3" aria-label="Menu search results">
+      {results.map((item) => (
+        <li key={`${item.source ?? 'api'}:${item.path}:${item.label}`}>
+          <a className="focus-ring block rounded-2xl border border-white/10 bg-white/[0.03] p-4 transition hover:border-teal-300/40" href={item.path}>
+            <span className="text-lg font-semibold text-white"><HighlightedText text={item.label} query={query} /></span>
+            <span className="mt-1 block text-sm text-slate-400"><HighlightedText text={item.path} query={query} /></span>
+            <span className="mt-3 inline-flex rounded-full bg-teal-300/10 px-2 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-teal-200">
+              {item.group}
+            </span>
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function SearchPage() {
+  const [query, setQuery] = useState('');
+  const [activeQuery, setActiveQuery] = useState('');
+  const [results, setResults] = useState<MenuItem[]>([]);
+  const [state, setState] = useState<PageState>('idle');
+  const [error, setError] = useState('');
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const nextQuery = query.trim();
+    if (!nextQuery) {
+      setActiveQuery('');
+      setResults([]);
+      setError('');
+      setState('idle');
+      return;
+    }
+
+    setState('loading');
+    setError('');
+    setActiveQuery(nextQuery);
+    try {
+      const response = await searchMenuItems(nextQuery);
+      setResults(response.data);
+      setState('ready');
+    } catch (err) {
+      setResults([]);
+      setError(err instanceof Error ? err.message : String(err));
+      setState('error');
+    }
+  }
+
+  const summary = menuSearchSummary(state, activeQuery, results.length);
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="menu-search-title">
+      <div className="mb-5">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Menu search</p>
+        <h1 id="menu-search-title" className="mt-2 text-3xl font-semibold text-white">Full-text menu search</h1>
+        <p className="mt-2 text-sm text-slate-400">Search dashboard labels and paths through /api/menu/search?q=.</p>
+      </div>
+
+      <form aria-label="Menu search form" className="flex flex-col gap-3 sm:flex-row" role="search" onSubmit={submit}>
+        <input
+          aria-label="Menu search query"
+          className="focus-ring min-w-0 flex-1 rounded-xl border border-white/10 bg-slate-950 px-4 py-3 text-slate-100 placeholder:text-slate-600"
+          placeholder="Search menu items…"
+          type="search"
+          value={query}
+          onChange={(event) => setQuery(event.currentTarget.value)}
+        />
+        <button className="focus-ring rounded-xl bg-teal-300 px-5 py-3 font-semibold text-slate-950 transition hover:bg-teal-200 disabled:cursor-not-allowed disabled:opacity-50" disabled={state === 'loading' || !query.trim()} type="submit">
+          {state === 'loading' ? 'Searching…' : 'Search'}
+        </button>
+      </form>
+
+      <p className="mt-4 text-sm text-slate-500">{summary}</p>
+      {state === 'error' ? <div className="mt-4"><ErrorMessage title="Menu search failed." message={error} /></div> : null}
+      <div className="mt-5"><MenuSearchResults query={activeQuery} results={results} state={state} /></div>
+    </section>
+  );
+}

--- a/frontend/src/routeMeta.ts
+++ b/frontend/src/routeMeta.ts
@@ -40,6 +40,7 @@ export function routeMeta(pathname: string, search = ''): RouteMeta {
   }
 
   if (pathname === '/plugins') return base('Plugin list', 'Plugins', 'Registered plugins and exposed runtime surfaces.', [{ label: 'Plugins' }]);
+  if (pathname === '/search') return base('Menu search', 'Search', 'Full-text search over /api/menu rows.', [{ label: 'Search' }]);
   if (pathname === '/vector') return base('Vector search', 'Vector', 'Semantic search against Oracle memory.', [{ label: 'Vector search' }]);
   if (pathname === '/mcp') return base('MCP tools', 'MCP', 'Browse available MCP tool schemas and groups.', [{ label: 'MCP tools' }]);
   if (pathname === '/settings') return base('Runtime settings', 'Settings', 'Storage, embedder, and migration status.', [{ label: 'Settings' }]);

--- a/frontend/src/routePaths.ts
+++ b/frontend/src/routePaths.ts
@@ -5,5 +5,5 @@ export function mcpToolPath(name: string): string {
 export function vectorResultsPath(query: string): string {
   const qs = new URLSearchParams();
   if (query.trim()) qs.set('q', query.trim());
-  return qs.toString() ? `/search/results?${qs}` : '/search/results';
+  return qs.toString() ? `/vector/results?${qs}` : '/vector/results';
 }

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -7,6 +7,7 @@ import { McpPage } from './pages/McpPage';
 import { McpToolDetailPage } from './pages/McpToolDetailPage';
 import { MenuPage } from './pages/MenuPage';
 import { PluginsPage } from './pages/PluginsPage';
+import { SearchPage } from './pages/SearchPage';
 import { SettingsPage } from './pages/SettingsPage';
 import { VectorPage } from './pages/VectorPage';
 import { VectorSearchResultsPage } from './pages/VectorSearchResultsPage';
@@ -77,10 +78,9 @@ export function DashboardRoutes({
       <Route index element={menuPage} />
       <Route path="/plugins" element={pluginPage} />
       <Route path="/metrics" element={metricsPage} />
-      <Route path="/search" element={<VectorPage />} />
-      <Route path="/search/results" element={<VectorSearchResultsPage />} />
+      <Route path="/search" element={<SearchPage />} />
       <Route path="/menu" element={menuPage} />
-      <Route path="/vector" element={<Navigate to="/search" replace />} />
+      <Route path="/vector" element={<VectorPage />} />
       <Route path="/vector/results" element={<VectorSearchResultsPage />} />
       <Route path="/mcp" element={<McpPage />} />
       <Route path="/mcp/tools/:name" element={<McpToolDetailPage />} />

--- a/tests/frontend/api-client.test.ts
+++ b/tests/frontend/api-client.test.ts
@@ -21,6 +21,7 @@ describe('frontend API client', () => {
         lastRestart: '2026-06-16T00:00:00.000Z',
       },
       '/api/menu': { items: [{ label: 'Vector', path: '/vector', group: 'tools', order: 1, source: 'api' }] },
+      '/api/menu/search?q=vector': { data: [{ label: 'Vector', path: '/vector', group: 'tools', order: 1, source: 'api' }], q: 'vector', total: 1 },
       '/api/vector/search?q=oracle+memory&limit=5&type=docs': {
         results: [{ id: 'doc-1', type: 'doc', content: 'Oracle memory', source_file: 'note.md', concepts: [] }],
         total: 1,
@@ -44,6 +45,7 @@ describe('frontend API client', () => {
     await expect(client.health()).resolves.toMatchObject({ status: 'ok', version: '26.5.30' });
     await expect(client.metrics()).resolves.toMatchObject({ requestCount: 7, activeConnections: 0 });
     await expect(client.menu()).resolves.toMatchObject({ items: [{ label: 'Vector' }] });
+    await expect(client.menuSearch('  vector  ')).resolves.toMatchObject({ total: 1, q: 'vector' });
     await expect(client.vectorSearch({ q: 'oracle memory', limit: 5, type: 'docs' })).resolves.toMatchObject({ total: 1, query: 'oracle memory' });
     await expect(client.plugins()).resolves.toMatchObject({ plugins: [{ name: 'echo' }] });
 
@@ -51,6 +53,7 @@ describe('frontend API client', () => {
       '/api/health',
       '/api/metrics',
       '/api/menu',
+      '/api/menu/search?q=vector',
       '/api/vector/search?q=oracle+memory&limit=5&type=docs',
       '/api/plugins',
     ]);

--- a/tests/frontend/router.test.ts
+++ b/tests/frontend/router.test.ts
@@ -38,7 +38,7 @@ describe('frontend router', () => {
     expect(htmlAt('/plugins')).toContain('Plugin list');
     expect(htmlAt('/metrics')).toContain('Backend metrics');
     expect(htmlAt('/metrics')).toContain('42');
-    expect(htmlAt('/search')).toContain('Vector search');
+    expect(htmlAt('/search')).toContain('Full-text menu search');
   });
 
   test('wraps routed children in the browser router and error boundary shell', () => {

--- a/tests/frontend/routes/vector-results-empty-path.test.ts
+++ b/tests/frontend/routes/vector-results-empty-path.test.ts
@@ -3,6 +3,6 @@ import { vectorResultsPath } from '../../../frontend/src/routePaths';
 
 describe('vectorResultsPath empty query', () => {
   test('omits the q parameter when no query is present', () => {
-    expect(vectorResultsPath('  ')).toBe('/search/results');
+    expect(vectorResultsPath('  ')).toBe('/vector/results');
   });
 });

--- a/tests/frontend/routes/vector-results-path.test.ts
+++ b/tests/frontend/routes/vector-results-path.test.ts
@@ -3,6 +3,6 @@ import { vectorResultsPath } from '../../../frontend/src/routePaths';
 
 describe('vectorResultsPath', () => {
   test('encodes vector result queries in the route query string', () => {
-    expect(vectorResultsPath('oracle memory')).toBe('/search/results?q=oracle+memory');
+    expect(vectorResultsPath('oracle memory')).toBe('/vector/results?q=oracle+memory');
   });
 });

--- a/tests/frontend/search-page.test.ts
+++ b/tests/frontend/search-page.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'bun:test';
+import { createElement } from 'react';
+import { htmlFor } from './_render';
+import {
+  MenuSearchResults,
+  SearchPage,
+  highlightParts,
+  menuSearchSummary,
+  searchMenuItems,
+} from '../../frontend/src/pages/SearchPage';
+const result = {
+  label: 'Vector Search',
+  path: '/vector',
+  group: 'tools' as const,
+  order: 3,
+  source: 'api' as const,
+};
+
+describe('frontend SearchPage', () => {
+  test('renders the initial full-text menu search form', () => {
+    const html = htmlFor(createElement(SearchPage));
+    expect(html).toContain('Full-text menu search');
+    expect(html).toContain('aria-label="Menu search form"');
+    expect(html).toContain('aria-label="Menu search query"');
+    expect(html).toContain('/api/menu/search?q=');
+  });
+
+  test('summarizes idle, loading, ready, empty, and error states', () => {
+    expect(menuSearchSummary('idle', '', 0)).toBe('Enter a query to search the menu catalog.');
+    expect(menuSearchSummary('loading', 'vector', 0)).toBe('Searching menu for “vector”…');
+    expect(menuSearchSummary('ready', 'vector', 1)).toBe('1 menu result for “vector”.');
+    expect(menuSearchSummary('ready', 'missing', 0)).toBe('No menu results found for “missing”.');
+    expect(menuSearchSummary('error', 'vector', 0)).toBe('Menu search failed.');
+  });
+
+  test('delegates trimmed queries to the menu search API client', async () => {
+    let seen = '';
+    const response = await searchMenuItems('  vector  ', {
+      menuSearch: async (q: string) => {
+        seen = q;
+        return { data: [result], q, total: 1 };
+      },
+    });
+
+    expect(seen).toBe('vector');
+    expect(response).toMatchObject({ q: 'vector', total: 1 });
+  });
+
+  test('renders loading, empty, and highlighted result states', () => {
+    const loading = htmlFor(createElement(MenuSearchResults, { query: 'vector', results: [], state: 'loading' }));
+    expect(loading).toContain('Searching menu…');
+    expect(loading).toContain('/api/menu/search?q=');
+
+    const empty = htmlFor(createElement(MenuSearchResults, { query: 'missing', results: [], state: 'ready' }));
+    expect(empty).toContain('No menu results found for “missing”.');
+
+    const ready = htmlFor(createElement(MenuSearchResults, { query: 'search', results: [result], state: 'ready' }));
+    expect(ready).toContain('href="/vector"');
+    expect(ready).toContain('<mark');
+    expect(ready).toContain('Search');
+  });
+
+  test('splits highlighted text without regex escaping hazards', () => {
+    expect(highlightParts('/api/menu/search?q=', 'SEARCH')).toEqual([
+      { text: '/api/menu/', match: false },
+      { text: 'search', match: true },
+      { text: '?q=', match: false },
+    ]);
+    expect(highlightParts('Settings', '')).toEqual([{ text: 'Settings', match: false }]);
+  });
+});


### PR DESCRIPTION
## Summary\n- add a full-text menu SearchPage backed by /api/menu/search?q=\n- highlight matching labels/paths with loading and empty states\n- keep vector search on /vector and /vector/results while routing /search to menu search\n\n## Verification\n- tsc --noEmit\n- bun run --cwd frontend build\n- bun test tests/frontend/\n- files <=250 lines