### PR TITLE
Cover backup CLI subprocess dispatch

### DIFF
--- a/tests/cli/backup/dispatch.test.ts
+++ b/tests/cli/backup/dispatch.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import { runCli } from '../_run.ts';
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots) rmSync(root, { recursive: true, force: true });
+  roots.length = 0;
+});
+
+function isolatedEnv(): Record<string, string> {
+  const root = mkdtempSync(join(tmpdir(), 'arra-backup-cli-'));
+  roots.push(root);
+  return {
+    HOME: join(root, 'home'),
+    ORACLE_DATA_DIR: join(root, 'data'),
+    ORACLE_REPO_ROOT: root,
+    ORACLE_DB_PATH: join(root, 'data', 'oracle.db'),
+  };
+}
+
+describe('backup CLI dispatcher', () => {
+  test('writes an SQL dump through arra-cli backup --out-dir', async () => {
+    const env = isolatedEnv();
+    const outDir = join(env.ORACLE_DATA_DIR!, 'custom-backups');
+    const seed = await runCli(['seed'], env);
+    const backup = await runCli(['backup', '--out-dir', outDir], env);
+    const result = JSON.parse(backup.stdout);
+
+    expect(seed.code).toBe(0);
+    expect(backup.code).toBe(0);
+    expect(backup.stderr).toBe('');
+    expect(result.path.startsWith(outDir)).toBe(true);
+    expect(basename(result.path)).toMatch(/^arra-oracle-.*\.sql$/);
+    expect(existsSync(result.path)).toBe(true);
+
+    const sql = readFileSync(result.path, 'utf8');
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS "menu_items"');
+    expect(sql).toContain('/dev/vector-search');
+    expect(sql).toContain('seed-learning-menu-aggregation');
+  }, 15_000);
+});


### PR DESCRIPTION
## Summary
- Close the remaining DB-CLI backup coverage gap with a subprocess test for `arra-cli backup --out-dir`.
- The test seeds an isolated real DB, runs the backup command through the CLI entrypoint, and asserts the timestamped SQL dump exists with seeded menu/learn content.

## Verification
- `bun test tests/cli/backup/`
- `bun run build`
- `git diff --check`
- changed-file line counts all <=250

Document-refresh: not-needed | Test-only coverage PR; no operator behavior or docs changed.
