### PR TITLE
Hide soft-deleted menu rows from public reads

### DIFF
--- a/src/routes/menu/list-paginated.ts
+++ b/src/routes/menu/list-paginated.ts
@@ -1,5 +1,5 @@
 import { Elysia, t } from 'elysia';
-import { asc, count, eq } from 'drizzle-orm';
+import { and, asc, count, eq, isNull } from 'drizzle-orm';
 import { db, menuItems } from '../../db/index.ts';
 import { getMenuConfig } from '../../menu/config.ts';
 import { listCustomMenuItems } from '../../menu/custom-store.ts';
@@ -70,7 +70,7 @@ export function menuRowToItem(row: MenuRow): MenuItem {
 }
 
 function readPaginatedMenuItems(pageSize: number, offset: number) {
-  const where = eq(menuItems.enabled, true);
+  const where = and(eq(menuItems.enabled, true), isNull(menuItems.deletedAt));
   const total = Number(
     db.select({ total: count() }).from(menuItems).where(where).get()?.total ?? 0,
   );

--- a/src/routes/menu/menu-items.ts
+++ b/src/routes/menu/menu-items.ts
@@ -1,4 +1,4 @@
-import { asc } from 'drizzle-orm';
+import { asc, isNull } from 'drizzle-orm';
 import { db, menuItems } from '../../db/index.ts';
 import { getFrontendMenuItems } from '../../menu/index.ts';
 import { getPluginMenuItems } from '../plugins/model.ts';
@@ -82,6 +82,7 @@ export function readApiMenuItemsFromDb(host?: string, scope?: Scope): MenuItem[]
   const rows = db
     .select()
     .from(menuItems)
+    .where(isNull(menuItems.deletedAt))
     .orderBy(asc(menuItems.position))
     .all();
 

--- a/src/routes/menu/search.ts
+++ b/src/routes/menu/search.ts
@@ -1,5 +1,5 @@
 import { Elysia, t } from 'elysia';
-import { and, asc, eq, like, or } from 'drizzle-orm';
+import { and, asc, eq, isNull, like, or } from 'drizzle-orm';
 import { db, menuItems } from '../../db/index.ts';
 import { menuRowToItem } from './list-paginated.ts';
 
@@ -16,6 +16,7 @@ function searchMenuRows(q: string) {
     .where(
       and(
         eq(menuItems.enabled, true),
+        isNull(menuItems.deletedAt),
         or(like(menuItems.label, pattern), like(menuItems.path, pattern)),
       ),
     )

--- a/tests/http/menu/deleted-filter.test.ts
+++ b/tests/http/menu/deleted-filter.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { db, menuItems } from '../../../src/db/index.ts';
+import { clearMenuRows, createMenuApp, insertMenuRow, requestJson } from './_helpers.ts';
+
+type MenuResponse = {
+  items?: Array<{ path: string }>;
+  data?: Array<{ path: string }>;
+  total?: number;
+};
+
+describe('public menu soft-delete filtering', () => {
+  beforeEach(clearMenuRows);
+
+  test('omits deletedAt rows even when enabled remains true', async () => {
+    insertMenuRow({ path: '/active-soft-filter', label: 'Soft Filter Active' });
+    const deleted = insertMenuRow({ path: '/deleted-soft-filter', label: 'Soft Filter Deleted' });
+    db.update(menuItems)
+      .set({ deletedAt: new Date(1700000020000), enabled: true })
+      .where(eq(menuItems.id, deleted.id))
+      .run();
+
+    const app = createMenuApp();
+    const aggregate = await requestJson<MenuResponse>(app, 'GET', '/api/menu');
+    const paginated = await requestJson<MenuResponse>(app, 'GET', '/api/menu?page=1&limit=10');
+    const search = await requestJson<MenuResponse>(app, 'GET', '/api/menu/search?q=soft-filter');
+
+    expect(aggregate.json.items?.map((item) => item.path)).toContain('/active-soft-filter');
+    expect(aggregate.json.items?.map((item) => item.path)).not.toContain('/deleted-soft-filter');
+    expect(paginated.json).toMatchObject({ total: 1 });
+    expect(paginated.json.data?.map((item) => item.path)).toEqual(['/active-soft-filter']);
+    expect(search.json.data?.map((item) => item.path)).toEqual(['/active-soft-filter']);
+  });
+});


### PR DESCRIPTION
## Summary
- require deleted_at to be null for public menu aggregate, paginated, and search reads
- add a focused HTTP regression test where a deletedAt row remains enabled but stays hidden

## Tests
- tsc --noEmit
- bun test tests/http/menu/
- bun test --coverage tests/http/menu/deleted-filter.test.ts

## Notes
- Full bare bun test not run per worktree guidance.