### PR TITLE
Run production Docker image as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,9 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/src/db/migrations ./db/migrations
 COPY package.json bun.lock ./
-RUN mkdir -p /data
+RUN mkdir -p /data \
+ && chown -R bun:bun /data
+USER bun
 VOLUME ["/data"]
 
 FROM production AS mcp-stdio


### PR DESCRIPTION
## Summary\n- switch production-derived Docker targets to the built-in bun user\n- chown /data so SQLite and LanceDB runtime files stay writable under the non-root user\n- keep existing dist-based HTTP/MCP targets and healthcheck behavior\n\n## Tests\n- bunx tsc --noEmit\n- docker build -t arra-oracle-v3:codex1-nonroot --target http-server .\n- docker run image reports UID 1000, /api/health returns HTTP 200, Docker health becomes healthy, and /data/oracle.db is writable