### PR TITLE
feat: make frontend menu searches shareable

### DIFF
--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,7 +1,9 @@
-import { useState, type FormEvent } from 'react';
+import { useEffect, useState, type FormEvent } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { apiClient, type ApiClient, type MenuSearchResponse } from '../api/client';
 import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
 import { EmptyState } from '../components/EmptyState';
+import { menuSearchPath } from '../routePaths';
 import type { MenuItem } from '../types';
 
 type PageState = 'idle' | 'loading' | 'ready' | 'error';
@@ -80,16 +82,18 @@ export function MenuSearchResults({ query, results, state }: { query: string; re
 }
 
 export function SearchPage() {
-  const [query, setQuery] = useState('');
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const routeQuery = searchParams.get('q') ?? '';
+  const [query, setQuery] = useState(routeQuery);
   const [activeQuery, setActiveQuery] = useState('');
   const [results, setResults] = useState<MenuItem[]>([]);
   const [state, setState] = useState<PageState>('idle');
   const [error, setError] = useState('');
 
-  async function submit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    const nextQuery = query.trim();
-    if (!nextQuery) {
+  async function runSearch(nextQuery: string) {
+    const q = nextQuery.trim();
+    if (!q) {
       setActiveQuery('');
       setResults([]);
       setError('');
@@ -99,9 +103,9 @@ export function SearchPage() {
 
     setState('loading');
     setError('');
-    setActiveQuery(nextQuery);
+    setActiveQuery(q);
     try {
-      const response = await searchMenuItems(nextQuery);
+      const response = await searchMenuItems(q);
       setResults(response.data);
       setState('ready');
     } catch (err) {
@@ -109,6 +113,18 @@ export function SearchPage() {
       setError(err instanceof Error ? err.message : String(err));
       setState('error');
     }
+  }
+
+  useEffect(() => {
+    setQuery(routeQuery);
+    void runSearch(routeQuery);
+  }, [routeQuery]);
+
+  function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const nextQuery = query.trim();
+    navigate(menuSearchPath(nextQuery));
+    if (nextQuery === routeQuery.trim()) void runSearch(nextQuery);
   }
 
   const summary = menuSearchSummary(state, activeQuery, results.length);

--- a/frontend/src/routePaths.ts
+++ b/frontend/src/routePaths.ts
@@ -2,6 +2,12 @@ export function mcpToolPath(name: string): string {
   return `/mcp/tools/${encodeURIComponent(name)}`;
 }
 
+export function menuSearchPath(query: string): string {
+  const q = query.trim();
+  if (!q) return '/search';
+  return `/search?${new URLSearchParams({ q })}`;
+}
+
 export function vectorResultsPath(query: string): string {
   const qs = new URLSearchParams();
   if (query.trim()) qs.set('q', query.trim());

--- a/tests/frontend/routes/menu-search-path.test.ts
+++ b/tests/frontend/routes/menu-search-path.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'bun:test';
+import { menuSearchPath } from '../../../frontend/src/routePaths';
+
+describe('menuSearchPath', () => {
+  test('encodes shareable menu search routes', () => {
+    expect(menuSearchPath(' oracle menu ')).toBe('/search?q=oracle+menu');
+  });
+
+  test('omits empty q parameters', () => {
+    expect(menuSearchPath('  ')).toBe('/search');
+  });
+});

--- a/tests/frontend/search-page.test.ts
+++ b/tests/frontend/search-page.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { createElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import { htmlFor } from './_render';
 import {
   MenuSearchResults,
@@ -18,11 +19,21 @@ const result = {
 
 describe('frontend SearchPage', () => {
   test('renders the initial full-text menu search form', () => {
-    const html = htmlFor(createElement(SearchPage));
+    const html = htmlFor(createElement(MemoryRouter, null, createElement(SearchPage)));
     expect(html).toContain('Full-text menu search');
     expect(html).toContain('aria-label="Menu search form"');
     expect(html).toContain('aria-label="Menu search query"');
     expect(html).toContain('/api/menu/search?q=');
+  });
+
+
+  test('seeds the input from the shareable route query', () => {
+    const html = htmlFor(createElement(
+      MemoryRouter,
+      { initialEntries: ['/search?q=plugins'] },
+      createElement(SearchPage),
+    ));
+    expect(html).toContain('value="plugins"');
   });
 
   test('summarizes idle, loading, ready, empty, and error states', () => {


### PR DESCRIPTION
## Summary\n- preserve menu search queries in /search?q= URLs\n- seed the search input from the route query for revisitable searches\n- add route helper coverage for encoded and empty menu search paths\n\n## Verification\n- tsc --noEmit\n- bun run --cwd frontend build\n- bun test tests/frontend/\n- bun test tests/frontend/search-page.test.ts tests/frontend/routes/menu-search-path.test.ts\n- files <=250 lines