### PR TITLE
Add frontend plugin admin page

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -38,7 +38,7 @@ export async function fetchMenu(): Promise<MenuResponse> {
 }
 
 export async function fetchPlugins(): Promise<PluginsResponse> {
-  const data = await getJson<PluginsResponse>('/api/plugins');
+  const data = await getJson<PluginsResponse>('/api/v1/plugins');
   return {
     dir: typeof data.dir === 'string' ? data.dir : '',
     plugins: Array.isArray(data.plugins) ? data.plugins : [],

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -18,7 +18,7 @@ export interface ApiRouteResponses {
   '/api/menu': MenuResponse;
   '/api/menu/search': MenuSearchResponse;
   '/api/vector/search': VectorSearchResponse;
-  '/api/plugins': PluginsResponse;
+  '/api/v1/plugins': PluginsResponse;
 }
 
 export type ApiRoute = keyof ApiRouteResponses;
@@ -110,7 +110,7 @@ export class ApiClient {
   }
 
   plugins(): Promise<PluginsResponse> {
-    return this.request('/api/plugins');
+    return this.request('/api/v1/plugins');
   }
 
   vectorSearch(query: string, limit?: number): Promise<VectorSearchResponse>;

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -102,7 +102,7 @@ export function AppShell({
 
           <section className="grid gap-3 sm:grid-cols-2 sm:gap-4 xl:grid-cols-5" aria-label="Summary">
             <StatCard label="Menu items" value={loading ? <Spinner label="Loading" /> : menuCount} detail="from /api/menu" />
-            <StatCard label="Plugins" value={loading ? <Spinner label="Loading" /> : pluginCount} detail="from /api/plugins" />
+            <StatCard label="Plugins" value={loading ? <Spinner label="Loading" /> : pluginCount} detail="from /api/v1/plugins" />
             <StatCard label="Surfaces" value={loading ? <Spinner label="Loading" /> : surfaceCount} detail={`updated ${updatedAt}`} />
             <StatCard label="Requests" value={requestValue} detail={metricsDetail} />
             <StatCard label="Avg response" value={responseValue} detail="real-time backend latency" />

--- a/frontend/src/components/PluginList.tsx
+++ b/frontend/src/components/PluginList.tsx
@@ -3,13 +3,40 @@ import type { PluginEntry } from '../types';
 import { Badge } from './Badge';
 import { EmptyState } from './EmptyState';
 
-export function PluginList({ plugins }: { plugins: PluginEntry[] }) {
-  if (!plugins.length) return <EmptyState text="No plugins registered in /api/plugins." />;
+export type PluginEnabledState = Record<string, boolean>;
+
+export function isPluginEnabled(plugin: PluginEntry, state: PluginEnabledState = {}): boolean {
+  if (plugin.name in state) return state[plugin.name] ?? true;
+  if (typeof plugin.enabled === 'boolean') return plugin.enabled;
+  return plugin.status !== 'disabled';
+}
+
+export function pluginStatusLabel(plugin: PluginEntry, enabled: boolean): string {
+  if (!enabled) return 'disabled';
+  return plugin.status || 'ok';
+}
+
+export function togglePluginEnabled(state: PluginEnabledState, name: string): PluginEnabledState {
+  return { ...state, [name]: !(state[name] ?? true) };
+}
+
+export function PluginList({
+  plugins,
+  enabledState = {},
+  onToggle,
+}: {
+  plugins: PluginEntry[];
+  enabledState?: PluginEnabledState;
+  onToggle?: (name: string) => void;
+}) {
+  if (!plugins.length) return <EmptyState text="No plugins registered in /api/v1/plugins." />;
 
   return (
     <div className="grid gap-4">
       {plugins.map((plugin) => {
         const surfaces = surfacesFor(plugin);
+        const enabled = isPluginEnabled(plugin, enabledState);
+        const status = pluginStatusLabel(plugin, enabled);
         return (
           <article key={plugin.name} className="rounded-2xl border border-white/10 bg-slate-950/60 p-5">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -17,7 +44,8 @@ export function PluginList({ plugins }: { plugins: PluginEntry[] }) {
                 <h3 className="text-lg font-semibold text-white">{plugin.name}</h3>
                 <p className="mt-1 text-sm text-slate-400">{plugin.description ?? 'No description supplied.'}</p>
               </div>
-              <div className="flex flex-wrap gap-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge>{status}</Badge>
                 {surfaces.length ? surfaces.map((surface) => <Badge key={surface}>{surface}</Badge>) : <Badge>metadata</Badge>}
               </div>
             </div>
@@ -27,9 +55,33 @@ export function PluginList({ plugins }: { plugins: PluginEntry[] }) {
                 <dd className="font-mono text-slate-200">{plugin.version ?? 'unknown'}</dd>
               </div>
               <div>
+                <dt className="text-slate-500">Status</dt>
+                <dd className="font-mono text-slate-200">{status}</dd>
+              </div>
+              <div>
                 <dt className="text-slate-500">Artifact</dt>
                 <dd className="font-mono text-slate-200">{plugin.file || 'server-only'}</dd>
               </div>
+              <div>
+                <dt className="text-slate-500">Admin</dt>
+                <dd>
+                  <button
+                    aria-label={`${enabled ? 'Disable' : 'Enable'} ${plugin.name}`}
+                    aria-pressed={enabled}
+                    className="focus-ring rounded-lg border border-teal-300/30 px-3 py-2 font-semibold text-teal-100 transition hover:bg-teal-300/10"
+                    type="button"
+                    onClick={() => onToggle?.(plugin.name)}
+                  >
+                    {enabled ? 'Disable' : 'Enable'}
+                  </button>
+                </dd>
+              </div>
+              {plugin.error ? (
+                <div className="sm:col-span-2">
+                  <dt className="text-slate-500">Error</dt>
+                  <dd className="text-amber-200">{plugin.error}</dd>
+                </div>
+              ) : null}
               {plugin.server ? (
                 <div className="sm:col-span-2">
                   <dt className="text-slate-500">Server</dt>

--- a/frontend/src/pages/PluginsPage.tsx
+++ b/frontend/src/pages/PluginsPage.tsx
@@ -1,13 +1,73 @@
-import { LoadingPanel } from '../components/AsyncState';
-import { PluginList } from '../components/PluginList';
+import { useEffect, useMemo, useState } from 'react';
+import { apiClient, type ApiClient } from '../api/client';
+import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
+import { PluginList, isPluginEnabled, togglePluginEnabled, type PluginEnabledState } from '../components/PluginList';
 import type { PluginEntry } from '../types';
 
-export function PluginsPage({ plugins, loading }: { plugins: PluginEntry[]; loading: boolean }) {
+type PageState = 'loading' | 'ready' | 'error';
+type PluginsClient = Pick<ApiClient, 'plugins'>;
+
+export interface PluginsPageProps {
+  plugins?: PluginEntry[];
+  loading?: boolean;
+  client?: PluginsClient;
+}
+
+export function enabledStateForPlugins(plugins: PluginEntry[]): PluginEnabledState {
+  return Object.fromEntries(plugins.map((plugin) => [
+    plugin.name,
+    typeof plugin.enabled === 'boolean' ? plugin.enabled : plugin.status !== 'disabled',
+  ]));
+}
+
+export function pluginAdminSummary(plugins: PluginEntry[], enabledState: PluginEnabledState): string {
+  const enabled = plugins.filter((plugin) => isPluginEnabled(plugin, enabledState)).length;
+  const disabled = plugins.length - enabled;
+  return `${enabled} enabled · ${disabled} disabled · ${plugins.length} registered`;
+}
+
+export function PluginsPage({ plugins: initialPlugins = [], loading = true, client = apiClient }: PluginsPageProps) {
+  const [plugins, setPlugins] = useState(initialPlugins);
+  const [state, setState] = useState<PageState>(loading ? 'loading' : 'ready');
+  const [error, setError] = useState('');
+  const [enabledState, setEnabledState] = useState<PluginEnabledState>(() => enabledStateForPlugins(initialPlugins));
+
+  useEffect(() => {
+    let cancelled = false;
+    setState('loading');
+    setError('');
+    client.plugins()
+      .then((response) => {
+        if (cancelled) return;
+        setPlugins(response.plugins);
+        setEnabledState(enabledStateForPlugins(response.plugins));
+        setState('ready');
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+        setState(initialPlugins.length ? 'ready' : 'error');
+      });
+    return () => { cancelled = true; };
+  }, [client]);
+
+  const summary = useMemo(() => pluginAdminSummary(plugins, enabledState), [plugins, enabledState]);
+  const toggle = (name: string) => setEnabledState((current) => togglePluginEnabled(current, name));
+  const isLoading = state === 'loading';
+
   return (
     <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="plugins-page-title">
-      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Plugins</p>
-      <h2 id="plugins-page-title" className="mt-2 mb-4 text-2xl font-semibold text-white">Plugin list</h2>
-      {loading ? <LoadingPanel title="Loading plugins…" detail="Fetching /api/plugins and plugin server manifests." /> : <PluginList plugins={plugins} />}
+      <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Plugin admin</p>
+          <h2 id="plugins-page-title" className="mt-2 text-2xl font-semibold text-white">Registered plugins</h2>
+          <p className="mt-2 text-sm text-slate-400">Loaded from GET /api/v1/plugins with local enable/disable controls.</p>
+        </div>
+        <p className="rounded-full border border-white/10 px-3 py-2 text-sm text-slate-300">{summary}</p>
+      </div>
+      {isLoading ? <LoadingPanel title="Loading plugins…" detail="Fetching /api/v1/plugins and plugin server manifests." /> : null}
+      {state === 'error' ? <ErrorMessage title="Could not load plugins." message={error} /> : null}
+      {!isLoading && state !== 'error' ? <PluginList plugins={plugins} enabledState={enabledState} onToggle={toggle} /> : null}
     </section>
   );
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -46,15 +46,20 @@ export interface PluginEntry {
   size: number;
   modified: string;
   version?: string;
+  status?: 'ok' | 'degraded' | 'disabled' | string;
+  enabled?: boolean;
+  error?: string;
   description?: string;
   menu?: PluginMenu;
   server?: PublicServerManifest;
   mcpTools?: McpTool[];
+  surfaces?: string[];
 }
 
 export interface PluginsResponse {
   plugins: PluginEntry[];
   dir: string;
+  count?: number;
 }
 
 export interface SearchResult {

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -115,6 +115,10 @@ export interface PluginEntryResponse {
   size: number;
   modified: string;
   version?: string;
+  status?: 'ok' | 'degraded' | 'disabled' | string;
+  enabled?: boolean;
+  error?: string;
+  surfaces?: string[];
   description?: string;
   menu?: {
     label: string;
@@ -134,6 +138,7 @@ export interface PluginEntryResponse {
 export interface PluginsResponse {
   plugins: PluginEntryResponse[];
   dir: string;
+  count?: number;
 }
 
 export type VectorSearchResponse = Omit<SearchResponse, 'query' | 'offset' | 'limit'> & {

--- a/tests/frontend/api-client.test.ts
+++ b/tests/frontend/api-client.test.ts
@@ -29,7 +29,7 @@ describe('frontend API client', () => {
         limit: 5,
         query: 'oracle memory',
       },
-      '/api/plugins': {
+      '/api/v1/plugins': {
         dir: '/tmp/plugins',
         plugins: [{ name: 'echo', file: 'echo.wasm', size: 12, modified: '2026-06-16T00:00:00.000Z' }],
       },
@@ -55,7 +55,7 @@ describe('frontend API client', () => {
       '/api/menu',
       '/api/menu/search?q=vector',
       '/api/vector/search?q=oracle+memory&limit=5&type=docs',
-      '/api/plugins',
+      '/api/v1/plugins',
     ]);
     for (const call of calls) {
       expect(new Headers(call.init?.headers).get('accept')).toBe('application/json');
@@ -92,8 +92,8 @@ describe('frontend API client', () => {
     const invalidClient = createApiClient({ fetch: () => new Response('{nope', { status: 200 }) });
     await expect(invalidClient.plugins()).rejects.toMatchObject({
       status: 200,
-      path: '/api/plugins',
-      message: '/api/plugins returned invalid JSON',
+      path: '/api/v1/plugins',
+      message: '/api/v1/plugins returned invalid JSON',
     } as ApiClientError);
 
     const errorClient = createApiClient({ fetch: () => jsonResponse({ error: 'offline' }, { status: 503, statusText: 'Unavailable' }) });

--- a/tests/frontend/api/api-error-non-ok.test.ts
+++ b/tests/frontend/api/api-error-non-ok.test.ts
@@ -6,7 +6,7 @@ describe('API non-OK errors', () => {
   test('includes backend error text in ApiError messages', async () => {
     const fetchMock = installFetch(() => jsonResponse({ error: 'offline' }, { status: 503, statusText: 'Unavailable' }));
     try {
-      await expect(fetchPlugins()).rejects.toMatchObject({ status: 503, message: '/api/plugins returned 503: offline' } as ApiError);
+      await expect(fetchPlugins()).rejects.toMatchObject({ status: 503, message: '/api/v1/plugins returned 503: offline' } as ApiError);
     } finally {
       fetchMock.restore();
     }

--- a/tests/frontend/components/plugin-list-empty.test.tsx
+++ b/tests/frontend/components/plugin-list-empty.test.tsx
@@ -4,6 +4,6 @@ import { htmlFor } from '../_render';
 
 describe('PluginList empty state', () => {
   test('renders an empty state when no plugins are registered', () => {
-    expect(htmlFor(<PluginList plugins={[]} />)).toContain('No plugins registered in /api/plugins.');
+    expect(htmlFor(<PluginList plugins={[]} />)).toContain('No plugins registered in /api/v1/plugins.');
   });
 });

--- a/tests/frontend/components/plugin-list-toggle.test.ts
+++ b/tests/frontend/components/plugin-list-toggle.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test';
+import { isPluginEnabled, pluginStatusLabel, togglePluginEnabled } from '../../../frontend/src/components/PluginList';
+
+describe('PluginList toggle helpers', () => {
+  test('derive status from local enable state', () => {
+    const plugin = { name: 'canvas', file: '', size: 0, modified: 'now', status: 'ok' };
+    const disabled = togglePluginEnabled({ canvas: true }, 'canvas');
+
+    expect(isPluginEnabled(plugin, disabled)).toBe(false);
+    expect(pluginStatusLabel(plugin, false)).toBe('disabled');
+    expect(pluginStatusLabel(plugin, true)).toBe('ok');
+  });
+});

--- a/tests/frontend/components/stat-card-render.test.tsx
+++ b/tests/frontend/components/stat-card-render.test.tsx
@@ -4,9 +4,9 @@ import { htmlFor } from '../_render';
 
 describe('StatCard render', () => {
   test('renders a label, value, and detail string', () => {
-    const html = htmlFor(<StatCard label="Plugins" value={3} detail="from /api/plugins" />);
+    const html = htmlFor(<StatCard label="Plugins" value={3} detail="from /api/v1/plugins" />);
     expect(html).toContain('Plugins');
     expect(html).toContain('3');
-    expect(html).toContain('from /api/plugins');
+    expect(html).toContain('from /api/v1/plugins');
   });
 });

--- a/tests/frontend/pages/plugins-page-admin.test.tsx
+++ b/tests/frontend/pages/plugins-page-admin.test.tsx
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test';
+import { PluginsPage, enabledStateForPlugins, pluginAdminSummary } from '../../../frontend/src/pages/PluginsPage';
+import { htmlFor } from '../_render';
+
+describe('PluginsPage admin view', () => {
+  test('renders version status and toggle controls for registered plugins', () => {
+    const plugins = [{ name: 'canvas', file: '', size: 0, modified: 'now', version: '1.2.3', status: 'ok' }];
+    const html = htmlFor(<PluginsPage plugins={plugins} loading={false} />);
+
+    expect(pluginAdminSummary(plugins, enabledStateForPlugins(plugins))).toBe('1 enabled · 0 disabled · 1 registered');
+    expect(html).toContain('GET /api/v1/plugins');
+    expect(html).toContain('canvas');
+    expect(html).toContain('1.2.3');
+    expect(html).toContain('ok');
+    expect(html).toContain('Disable canvas');
+  });
+});

--- a/tests/frontend/pages/plugins-page-loading.test.tsx
+++ b/tests/frontend/pages/plugins-page-loading.test.tsx
@@ -5,7 +5,7 @@ import { htmlFor } from '../_render';
 describe('PluginsPage loading state', () => {
   test('shows a loading panel while plugin manifests load', () => {
     const html = htmlFor(<PluginsPage plugins={[]} loading={true} />);
-    expect(html).toContain('Plugin list');
+    expect(html).toContain('Registered plugins');
     expect(html).toContain('Loading plugins…');
   });
 });

--- a/tests/frontend/router.test.ts
+++ b/tests/frontend/router.test.ts
@@ -35,7 +35,7 @@ describe('frontend router', () => {
 
   test('routes root, plugins, metrics, and search surfaces', () => {
     expect(htmlAt('/')).toContain('Menu viewer');
-    expect(htmlAt('/plugins')).toContain('Plugin list');
+    expect(htmlAt('/plugins')).toContain('Registered plugins');
     expect(htmlAt('/metrics')).toContain('Backend metrics');
     expect(htmlAt('/metrics')).toContain('42');
     expect(htmlAt('/search')).toContain('Full-text menu search');

--- a/tests/frontend/search/search-all-surfaces-endpoints.test.ts
+++ b/tests/frontend/search/search-all-surfaces-endpoints.test.ts
@@ -6,13 +6,13 @@ describe('searchAllSurfaces endpoints', () => {
   test('queries menu, plugin, and MCP tool APIs before unifying matches', async () => {
     const fetchMock = installFetch((input) => {
       if (input === '/api/menu') return jsonResponse({ items: [{ label: 'Echo menu', path: '/echo', group: 'tools', order: 1 }] });
-      if (input === '/api/plugins') return jsonResponse({ dir: '/plugins', plugins: [{ name: 'echo-plugin', file: '', size: 0, modified: 'now' }] });
+      if (input === '/api/v1/plugins') return jsonResponse({ dir: '/plugins', plugins: [{ name: 'echo-plugin', file: '', size: 0, modified: 'now' }] });
       if (input === '/api/mcp/tools') return jsonResponse({ total: 1, tools: [{ name: 'echo.tool', description: 'Echo helper' }] });
       return jsonResponse({}, { status: 404 });
     });
     try {
       const results = await searchAllSurfaces('echo');
-      expect(fetchMock.calls.map((call) => call.input)).toEqual(['/api/menu', '/api/plugins', '/api/mcp/tools']);
+      expect(fetchMock.calls.map((call) => call.input)).toEqual(['/api/menu', '/api/v1/plugins', '/api/mcp/tools']);
       expect(results.map((result) => result.surface)).toEqual(['menu', 'plugin', 'mcp-tool']);
     } finally {
       fetchMock.restore();


### PR DESCRIPTION
## Summary
- Add a `/plugins` frontend admin page backed by `GET /api/v1/plugins`.
- Render plugin name, version, status, surfaces, errors, and local enable/disable controls.
- Update typed frontend/server plugin response shapes and frontend API calls to the versioned plugin endpoint.

Closes #1484.

## Verification
- `bun test tests/frontend/` — 90 pass, 0 fail
- `tsc --noEmit`
- `cd frontend && bun run build`
- `git diff --check`
- changed-file line counts <=250

## Note
Enable/disable is local UI state because the current plugin registry route exposes read-only listing only; wire it to a persisted backend mutation once that endpoint exists.
