### PR TITLE
Add frontend Learn page

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -5,6 +5,7 @@ import type {
   PluginsResponse,
   VectorSearchResponse,
 } from '../../../src/server/types';
+import type { LearnCreateResponse, LearnDeleteResponse, LearnListResponse, LearnMutationPayload, LearnUpdateResponse } from '../types';
 
 export interface MenuSearchResponse {
   data: MenuItem[];
@@ -19,6 +20,7 @@ export interface ApiRouteResponses {
   '/api/menu/search': MenuSearchResponse;
   '/api/vector/search': VectorSearchResponse;
   '/api/plugins': PluginsResponse;
+  '/api/v1/learn': LearnListResponse;
 }
 
 export type ApiRoute = keyof ApiRouteResponses;
@@ -111,6 +113,22 @@ export class ApiClient {
 
   plugins(): Promise<PluginsResponse> {
     return this.request('/api/plugins');
+  }
+
+  learn(): Promise<LearnListResponse> {
+    return this.request('/api/v1/learn');
+  }
+
+  createLearn(payload: LearnMutationPayload): Promise<LearnCreateResponse> {
+    return this.fetchJson('/api/v1/learn', { method: 'POST', body: JSON.stringify(payload) });
+  }
+
+  updateLearn(id: string, payload: LearnMutationPayload): Promise<LearnUpdateResponse> {
+    return this.fetchJson(`/api/v1/learn/${encodeURIComponent(id)}`, { method: 'PUT', body: JSON.stringify(payload) });
+  }
+
+  deleteLearn(id: string): Promise<LearnDeleteResponse> {
+    return this.fetchJson(`/api/v1/learn/${encodeURIComponent(id)}`, { method: 'DELETE' });
   }
 
   vectorSearch(query: string, limit?: number): Promise<VectorSearchResponse>;

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -50,6 +50,7 @@ export function AppShell({
     { to: '/', label: 'Menu', description: 'Navigation rows from /api/menu', badge: loading ? '…' : menuCount },
     { to: '/plugins', label: 'Plugins', description: 'Registered plugins and surfaces', badge: loading ? '…' : pluginCount },
     { to: '/search', label: 'Search', description: 'Full-text menu search' },
+    { to: '/learn', label: 'Learn', description: 'Create and edit learnings' },
     { to: '/metrics', label: 'Metrics', description: 'Runtime counters from /api/metrics' },
     { to: '/mcp', label: 'MCP', description: 'Tool schemas and groups' },
     { to: '/settings', label: 'Settings', description: 'Storage, embedder, and DB status' },

--- a/frontend/src/pages/LearnPage.tsx
+++ b/frontend/src/pages/LearnPage.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useState, type FormEvent } from 'react';
+import { apiClient, type ApiClient } from '../api/client';
+import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
+import { EmptyState } from '../components/EmptyState';
+import type { LearnEntry, LearnMutationPayload } from '../types';
+
+type PageState = 'idle' | 'loading' | 'ready' | 'saving' | 'error';
+type LearnClient = Pick<ApiClient, 'learn' | 'createLearn' | 'updateLearn' | 'deleteLearn'>;
+
+export interface LearnFormState {
+  title: string;
+  content: string;
+  concepts: string;
+}
+
+const emptyForm: LearnFormState = { title: '', content: '', concepts: '' };
+
+export function conceptsFromInput(value: string): string[] {
+  return value.split(',').map((concept) => concept.trim()).filter(Boolean);
+}
+
+export function patternFromForm(form: LearnFormState): string {
+  const title = form.title.trim();
+  const content = form.content.trim();
+  if (title && content) return `${title}\n\n${content}`;
+  return title || content;
+}
+
+export function learnPayload(form: LearnFormState): LearnMutationPayload {
+  return { pattern: patternFromForm(form), concepts: conceptsFromInput(form.concepts), source: 'Oracle Learn UI' };
+}
+
+export function formFromEntry(entry: LearnEntry): LearnFormState {
+  return { title: entry.title, content: entry.content, concepts: entry.concepts.join(', ') };
+}
+
+export function learnSummary(state: PageState, total: number): string {
+  if (state === 'loading') return 'Loading learn entries from /api/v1/learn…';
+  if (state === 'saving') return 'Saving learn entry…';
+  if (state === 'error') return 'Learn entries could not be loaded.';
+  return total ? `${total} active learn entr${total === 1 ? 'y' : 'ies'}.` : 'No learn entries yet.';
+}
+
+export async function loadLearnEntries(client: Pick<ApiClient, 'learn'> = apiClient): Promise<LearnEntry[]> {
+  return (await client.learn()).items;
+}
+
+function LearnForm({ editing, form, saving, onChange, onCancel, onSubmit }: {
+  editing: boolean;
+  form: LearnFormState;
+  saving: boolean;
+  onChange: (form: LearnFormState) => void;
+  onCancel: () => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+}) {
+  const disabled = saving || !patternFromForm(form);
+  return (
+    <form className="grid gap-3 rounded-2xl border border-white/10 bg-white/[0.03] p-4" aria-label="Learn entry form" onSubmit={onSubmit}>
+      <div className="grid gap-2 sm:grid-cols-[1fr_auto] sm:items-end">
+        <label className="grid gap-2 text-sm font-medium text-slate-300">
+          Learning title
+          <input className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-4 py-3 text-slate-100" value={form.title} onChange={(event) => onChange({ ...form, title: event.currentTarget.value })} />
+        </label>
+        {editing ? <button className="focus-ring rounded-xl border border-white/10 px-4 py-3 text-sm font-semibold text-slate-200" type="button" onClick={onCancel}>Cancel edit</button> : null}
+      </div>
+      <label className="grid gap-2 text-sm font-medium text-slate-300">
+        Content
+        <textarea className="focus-ring min-h-36 rounded-xl border border-white/10 bg-slate-950 px-4 py-3 text-slate-100" value={form.content} onChange={(event) => onChange({ ...form, content: event.currentTarget.value })} />
+      </label>
+      <label className="grid gap-2 text-sm font-medium text-slate-300">
+        Concepts
+        <input className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-4 py-3 text-slate-100" placeholder="comma, separated, concepts" value={form.concepts} onChange={(event) => onChange({ ...form, concepts: event.currentTarget.value })} />
+      </label>
+      <button className="focus-ring rounded-xl bg-teal-300 px-5 py-3 font-semibold text-slate-950 transition hover:bg-teal-200 disabled:cursor-not-allowed disabled:opacity-50" disabled={disabled} type="submit">
+        {saving ? 'Saving…' : editing ? 'Update learning' : 'Add learning'}
+      </button>
+    </form>
+  );
+}
+
+export function LearnEntryList({ entries, busy, onDelete, onEdit }: {
+  entries: LearnEntry[];
+  busy: boolean;
+  onDelete: (entry: LearnEntry) => void;
+  onEdit: (entry: LearnEntry) => void;
+}) {
+  if (!entries.length) return <EmptyState text="Create the first learn entry with the form above." />;
+  return (
+    <ul className="grid gap-3" aria-label="Learn entries">
+      {entries.map((entry) => (
+        <li key={entry.id} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <h2 className="text-xl font-semibold text-white">{entry.title}</h2>
+              <p className="mt-1 text-xs text-slate-500">{entry.sourceFile}</p>
+            </div>
+            <div className="flex gap-2">
+              <button className="focus-ring rounded-lg border border-white/10 px-3 py-2 text-sm font-semibold text-slate-200" disabled={busy} type="button" onClick={() => onEdit(entry)}>Edit</button>
+              <button className="focus-ring rounded-lg border border-red-300/30 px-3 py-2 text-sm font-semibold text-red-100" disabled={busy} type="button" onClick={() => onDelete(entry)}>Soft-delete</button>
+            </div>
+          </div>
+          <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-slate-300">{entry.content}</p>
+          {entry.concepts.length ? <p className="mt-3 text-xs font-semibold uppercase tracking-[0.16em] text-teal-200">{entry.concepts.join(' · ')}</p> : null}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function LearnPage({ client = apiClient }: { client?: LearnClient }) {
+  const [entries, setEntries] = useState<LearnEntry[]>([]);
+  const [form, setForm] = useState<LearnFormState>(emptyForm);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [state, setState] = useState<PageState>('idle');
+  const [error, setError] = useState('');
+
+  async function reload() {
+    setState('loading');
+    setError('');
+    try {
+      setEntries(await loadLearnEntries(client));
+      setState('ready');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setState('error');
+    }
+  }
+
+  useEffect(() => { void reload(); }, []);
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setState('saving');
+    setError('');
+    try {
+      if (editingId) await client.updateLearn(editingId, learnPayload(form));
+      else await client.createLearn(learnPayload(form));
+      setForm(emptyForm);
+      setEditingId(null);
+      await reload();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setState('error');
+    }
+  }
+
+  async function remove(entry: LearnEntry) {
+    setState('saving');
+    setError('');
+    try {
+      await client.deleteLearn(entry.id);
+      setEntries((current) => current.filter((item) => item.id !== entry.id));
+      setState('ready');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setState('error');
+    }
+  }
+
+  const busy = state === 'loading' || state === 'saving';
+  return (
+    <section className="grid gap-5 rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="learn-page-title">
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Learn</p>
+        <h1 id="learn-page-title" className="mt-2 text-3xl font-semibold text-white">Learn entries</h1>
+        <p className="mt-2 text-sm text-slate-400">List, add, edit, and soft-delete Oracle learnings through /api/v1/learn.</p>
+      </div>
+      <LearnForm editing={Boolean(editingId)} form={form} saving={state === 'saving'} onChange={setForm} onCancel={() => { setEditingId(null); setForm(emptyForm); }} onSubmit={submit} />
+      <p className="text-sm text-slate-500">{learnSummary(state, entries.length)}</p>
+      {state === 'loading' ? <LoadingPanel title="Loading learn entries…" detail="Fetching /api/v1/learn from the Elysia backend." /> : null}
+      {state === 'error' ? <ErrorMessage title="Learn operation failed." message={error} /> : null}
+      {state !== 'loading' ? <LearnEntryList entries={entries} busy={busy} onDelete={(entry) => void remove(entry)} onEdit={(entry) => { setEditingId(entry.id); setForm(formFromEntry(entry)); }} /> : null}
+    </section>
+  );
+}

--- a/frontend/src/routeMeta.ts
+++ b/frontend/src/routeMeta.ts
@@ -41,6 +41,7 @@ export function routeMeta(pathname: string, search = ''): RouteMeta {
 
   if (pathname === '/plugins') return base('Plugin list', 'Plugins', 'Registered plugins and exposed runtime surfaces.', [{ label: 'Plugins' }]);
   if (pathname === '/search') return base('Menu search', 'Search', 'Full-text search over /api/menu rows.', [{ label: 'Search' }]);
+  if (pathname === '/learn') return base('Learn entries', 'Learn', 'Capture and edit Oracle learnings.', [{ label: 'Learn' }]);
   if (pathname === '/vector') return base('Vector search', 'Vector', 'Semantic search against Oracle memory.', [{ label: 'Vector search' }]);
   if (pathname === '/mcp') return base('MCP tools', 'MCP', 'Browse available MCP tool schemas and groups.', [{ label: 'MCP tools' }]);
   if (pathname === '/settings') return base('Runtime settings', 'Settings', 'Storage, embedder, and migration status.', [{ label: 'Settings' }]);

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -5,6 +5,7 @@ import { LoadingPanel } from './components/AsyncState';
 import { StatCard } from './components/StatCard';
 import { McpPage } from './pages/McpPage';
 import { McpToolDetailPage } from './pages/McpToolDetailPage';
+import { LearnPage } from './pages/LearnPage';
 import { MenuPage } from './pages/MenuPage';
 import { PluginsPage } from './pages/PluginsPage';
 import { SearchPage } from './pages/SearchPage';
@@ -14,7 +15,7 @@ import { VectorSearchResultsPage } from './pages/VectorSearchResultsPage';
 import type { LoadState, MenuItem, PluginEntry } from './types';
 import type { MetricsSnapshot } from '../../src/server/types';
 
-export const frontendRoutes = ['/', '/plugins', '/metrics', '/search'] as const;
+export const frontendRoutes = ['/', '/plugins', '/metrics', '/search', '/learn'] as const;
 export type FrontendRoute = typeof frontendRoutes[number];
 
 export type DashboardRouteStates = Record<'menu' | 'plugins' | 'metrics', LoadState>;
@@ -79,6 +80,7 @@ export function DashboardRoutes({
       <Route path="/plugins" element={pluginPage} />
       <Route path="/metrics" element={metricsPage} />
       <Route path="/search" element={<SearchPage />} />
+      <Route path="/learn" element={<LearnPage />} />
       <Route path="/menu" element={menuPage} />
       <Route path="/vector" element={<VectorPage />} />
       <Route path="/vector/results" element={<VectorSearchResultsPage />} />

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -79,6 +79,57 @@ export interface SearchResponse {
   error?: string;
 }
 
+export interface LearnEntry {
+  id: string;
+  title: string;
+  content: string;
+  concepts: string[];
+  sourceFile: string;
+  createdAt: number;
+  updatedAt: number;
+  origin?: string | null;
+  project?: string | null;
+}
+
+export interface LearnListResponse {
+  items: LearnEntry[];
+  total: number;
+}
+
+export interface LearnMutationPayload {
+  pattern: string;
+  concepts?: string[];
+  source?: string;
+}
+
+export interface LearnCreateResponse {
+  success: boolean;
+  id: string;
+  file: string;
+}
+
+export interface LearnUpdateResponse {
+  id: string;
+  type: 'learning';
+  sourceFile: string;
+  concepts: string[];
+  createdAt: number;
+  updatedAt: number;
+  indexedAt: number;
+  origin?: string | null;
+  project?: string | null;
+  supersededAt?: number | null;
+  supersededBy?: string | null;
+  supersededReason?: string | null;
+  createdBy?: string | null;
+}
+
+export interface LearnDeleteResponse {
+  id: string;
+  deleted: 'soft';
+  supersededAt: number;
+}
+
 export interface McpToolsResponse {
   tools: McpTool[];
   total: number;

--- a/src/routes/knowledge/index.ts
+++ b/src/routes/knowledge/index.ts
@@ -7,7 +7,7 @@
  */
 
 import { Elysia } from 'elysia';
-import { createLearnCrudRoutes } from '../learn/index.ts';
+import { createLearnCrudRoutes, createLearnListRoutes } from '../learn/index.ts';
 import { handoffEndpoint } from './handoff.ts';
 import { inboxEndpoint } from './inbox.ts';
 
@@ -18,6 +18,7 @@ export const knowledgeRoutes = new Elysia({ prefix: '/api' })
       return { error: error instanceof Error ? error.message : 'Parse error' };
     }
   })
+  .use(createLearnListRoutes())
   .use(createLearnCrudRoutes())
   .use(handoffEndpoint)
   .use(inboxEndpoint);

--- a/src/routes/learn/index.ts
+++ b/src/routes/learn/index.ts
@@ -1,5 +1,7 @@
 import { Elysia } from 'elysia';
 import { createLearnCrudRoutes } from './crud.ts';
+import { createLearnListRoutes } from './list.ts';
 
-export const learnRoutes = new Elysia({ prefix: '/api' }).use(createLearnCrudRoutes());
+export const learnRoutes = new Elysia({ prefix: '/api' }).use(createLearnListRoutes()).use(createLearnCrudRoutes());
 export { createLearnCrudRoutes } from './crud.ts';
+export { createLearnListRoutes } from './list.ts';

--- a/src/routes/learn/list.ts
+++ b/src/routes/learn/list.ts
@@ -1,0 +1,76 @@
+import { Elysia } from 'elysia';
+import { and, desc, eq, isNull } from 'drizzle-orm';
+import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { db, oracleDocuments } from '../../db/index.ts';
+
+type LearnDoc = typeof oracleDocuments.$inferSelect;
+
+const oracleFts = sqliteTable('oracle_fts', {
+  id: text('id'),
+  content: text('content'),
+  concepts: text('concepts'),
+});
+
+function conceptsFrom(value: string): string[] {
+  try {
+    const parsed = JSON.parse(value);
+    if (Array.isArray(parsed)) return parsed.map(String).filter(Boolean);
+  } catch {}
+  return value.split(',').map((concept) => concept.trim()).filter(Boolean);
+}
+
+function titleFrom(content: string, row: LearnDoc): string {
+  const frontmatter = content.match(/^title:\s*(.+)$/m)?.[1]?.trim();
+  if (frontmatter) return frontmatter;
+  const heading = content.match(/^#\s+(.+)$/m)?.[1]?.trim();
+  if (heading) return heading;
+  return row.sourceFile.split('/').pop()?.replace(/\.md$/, '') || row.id;
+}
+
+function displayContentFrom(content: string, title: string): string {
+  const withoutFrontmatter = content.replace(/^---\n[\s\S]*?\n---\n+/, '');
+  const withoutHeading = withoutFrontmatter.replace(/^#\s+.+\n+/, '');
+  const withoutFooter = withoutHeading.replace(/\n---\n\*Added via Oracle Learn\*\s*$/, '');
+  const display = withoutFooter.trim();
+  return display.startsWith(`${title}\n\n`) ? display.slice(title.length).trim() : display || content;
+}
+
+function contentById(id: string): string {
+  return db.select({ content: oracleFts.content })
+    .from(oracleFts)
+    .where(eq(oracleFts.id, id))
+    .get()?.content ?? '';
+}
+
+function learnEntry(row: LearnDoc) {
+  const content = contentById(row.id);
+  const title = titleFrom(content, row);
+  return {
+    id: row.id,
+    title,
+    content: displayContentFrom(content, title),
+    concepts: conceptsFrom(row.concepts),
+    sourceFile: row.sourceFile,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    origin: row.origin,
+    project: row.project,
+  };
+}
+
+function listLearnEntries() {
+  const rows = db.select().from(oracleDocuments)
+    .where(and(eq(oracleDocuments.type, 'learning'), isNull(oracleDocuments.supersededAt)))
+    .orderBy(desc(oracleDocuments.updatedAt))
+    .all();
+  const items = rows.map(learnEntry);
+  return { items, total: items.length };
+}
+
+export function createLearnListRoutes() {
+  return new Elysia().get('/learn', () => listLearnEntries(), {
+    detail: { tags: ['knowledge'], menu: { group: 'main', label: 'Learn', order: 35 }, summary: 'List learn entries' },
+  });
+}
+
+export const learnListRoutes = createLearnListRoutes();

--- a/src/routes/menu/__tests__/menu-learn-route.test.ts
+++ b/src/routes/menu/__tests__/menu-learn-route.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { menuItemsFromRoutes } from '../menu.ts';
+
+describe('learn route menu mapping', () => {
+  test('maps /api/learn route metadata to the /learn frontend page', () => {
+    const routes = new Elysia({ prefix: '/api' }).get('/learn', () => ({}), {
+      detail: { menu: { group: 'main', label: 'Learn', order: 35 } },
+    });
+    expect(menuItemsFromRoutes([routes])).toEqual([
+      { path: '/learn', label: 'Learn', group: 'main', order: 35, source: 'api' },
+    ]);
+  });
+});

--- a/src/routes/menu/menu-items.ts
+++ b/src/routes/menu/menu-items.ts
@@ -11,6 +11,7 @@ export const API_TO_STUDIO: ReadonlyArray<readonly [string, string]> = [
   ['/api/list', '/feed'],
   ['/api/reflect', '/playground'],
   ['/api/threads', '/'],
+  ['/api/learn', '/learn'],
   ['/api/traces', '/traces'],
   ['/api/schedule', '/schedule'],
   ['/api/plugins', '/plugins'],

--- a/tests/frontend/api/learn-create-path.test.ts
+++ b/tests/frontend/api/learn-create-path.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test';
+import { createApiClient } from '../../../frontend/src/api/client';
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify(data), { headers: { 'content-type': 'application/json' } });
+}
+
+describe('ApiClient createLearn', () => {
+  test('posts JSON learn payloads to /api/v1/learn', async () => {
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    const client = createApiClient({ fetch: (input, init) => { calls.push({ input, init }); return jsonResponse({ success: true, id: 'one', file: 'one.md' }); } });
+    await expect(client.createLearn({ pattern: 'One', concepts: ['learn'] })).resolves.toMatchObject({ id: 'one' });
+    expect(calls[0]?.input).toBe('/api/v1/learn');
+    expect(calls[0]?.init?.method).toBe('POST');
+    expect(calls[0]?.init?.body).toBe(JSON.stringify({ pattern: 'One', concepts: ['learn'] }));
+    expect(new Headers(calls[0]?.init?.headers).get('content-type')).toBe('application/json');
+  });
+});

--- a/tests/frontend/api/learn-delete-path.test.ts
+++ b/tests/frontend/api/learn-delete-path.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test';
+import { createApiClient } from '../../../frontend/src/api/client';
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify(data), { headers: { 'content-type': 'application/json' } });
+}
+
+describe('ApiClient deleteLearn', () => {
+  test('soft-deletes encoded learn entry URLs', async () => {
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    const client = createApiClient({ fetch: (input, init) => { calls.push({ input, init }); return jsonResponse({ id: 'learn/id', deleted: 'soft', supersededAt: 7 }); } });
+    await expect(client.deleteLearn('learn/id')).resolves.toMatchObject({ deleted: 'soft', supersededAt: 7 });
+    expect(calls[0]?.input).toBe('/api/v1/learn/learn%2Fid');
+    expect(calls[0]?.init?.method).toBe('DELETE');
+  });
+});

--- a/tests/frontend/api/learn-list-path.test.ts
+++ b/tests/frontend/api/learn-list-path.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test';
+import { createApiClient } from '../../../frontend/src/api/client';
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify(data), { headers: { 'content-type': 'application/json' } });
+}
+
+describe('ApiClient learn list', () => {
+  test('fetches active learn entries from /api/v1/learn', async () => {
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    const client = createApiClient({ fetch: (input, init) => { calls.push({ input, init }); return jsonResponse({ items: [], total: 0 }); } });
+    await expect(client.learn()).resolves.toEqual({ items: [], total: 0 });
+    expect(calls[0]?.input).toBe('/api/v1/learn');
+    expect(new Headers(calls[0]?.init?.headers).get('accept')).toBe('application/json');
+  });
+});

--- a/tests/frontend/api/learn-update-path.test.ts
+++ b/tests/frontend/api/learn-update-path.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test';
+import { createApiClient } from '../../../frontend/src/api/client';
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify(data), { headers: { 'content-type': 'application/json' } });
+}
+
+describe('ApiClient updateLearn', () => {
+  test('puts JSON updates to encoded learn entry URLs', async () => {
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    const client = createApiClient({ fetch: (input, init) => { calls.push({ input, init }); return jsonResponse({ id: 'learn id', title: 'Updated' }); } });
+    await expect(client.updateLearn('learn id', { pattern: 'Updated' })).resolves.toMatchObject({ title: 'Updated' });
+    expect(calls[0]?.input).toBe('/api/v1/learn/learn%20id');
+    expect(calls[0]?.init?.method).toBe('PUT');
+    expect(calls[0]?.init?.body).toBe(JSON.stringify({ pattern: 'Updated' }));
+  });
+});

--- a/tests/frontend/components/app-shell-learn-nav.test.tsx
+++ b/tests/frontend/components/app-shell-learn-nav.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+import { MemoryRouter } from 'react-router-dom';
+import { AppShell } from '../../../frontend/src/components/AppShell';
+import { htmlFor, installBrowserLocation } from '../_render';
+
+describe('AppShell Learn navigation', () => {
+  test('links to the learn CRUD page from the sidebar', () => {
+    const restore = installBrowserLocation('/learn');
+    try {
+      const html = htmlFor(
+        <MemoryRouter initialEntries={['/learn']}>
+          <AppShell error="" loading={false} menuCount={0} pluginCount={0} surfaceCount={0} updatedAt="never" onRefresh={() => {}}>
+            <p>child</p>
+          </AppShell>
+        </MemoryRouter>,
+      );
+      expect(html).toContain('aria-label="Learn: Create and edit learnings"');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/tests/frontend/pages/learn-concepts.test.ts
+++ b/tests/frontend/pages/learn-concepts.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test } from 'bun:test';
+import { conceptsFromInput } from '../../../frontend/src/pages/LearnPage';
+
+describe('conceptsFromInput', () => {
+  test('trims comma-separated concepts and drops empties', () => {
+    expect(conceptsFromInput(' learn, ui ,, oracle ')).toEqual(['learn', 'ui', 'oracle']);
+  });
+});

--- a/tests/frontend/pages/learn-entry-list.test.tsx
+++ b/tests/frontend/pages/learn-entry-list.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+import { LearnEntryList } from '../../../frontend/src/pages/LearnPage';
+import type { LearnEntry } from '../../../frontend/src/types';
+import { htmlFor } from '../_render';
+
+const entry: LearnEntry = {
+  id: 'learning-1',
+  title: 'Learning UI',
+  content: 'React page lists learn entries.',
+  concepts: ['learn', 'ui'],
+  sourceFile: 'ψ/memory/learnings/ui.md',
+  createdAt: 1,
+  updatedAt: 2,
+};
+
+describe('LearnEntryList', () => {
+  test('shows entry title, content, concepts, and edit/delete actions', () => {
+    const html = htmlFor(<LearnEntryList entries={[entry]} busy={false} onDelete={() => {}} onEdit={() => {}} />);
+    expect(html).toContain('Learning UI');
+    expect(html).toContain('React page lists learn entries.');
+    expect(html).toContain('learn · ui');
+    expect(html).toContain('Soft-delete');
+    expect(html).toContain('Edit');
+  });
+});

--- a/tests/frontend/pages/learn-form-from-entry.test.ts
+++ b/tests/frontend/pages/learn-form-from-entry.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from 'bun:test';
+import { formFromEntry } from '../../../frontend/src/pages/LearnPage';
+import type { LearnEntry } from '../../../frontend/src/types';
+
+describe('formFromEntry', () => {
+  test('preloads edit form fields from a learn entry', () => {
+    const entry: LearnEntry = { id: 'id', title: 'Title', content: 'Body', concepts: ['a', 'b'], sourceFile: 'id.md', createdAt: 1, updatedAt: 2 };
+    expect(formFromEntry(entry)).toEqual({ title: 'Title', content: 'Body', concepts: 'a, b' });
+  });
+});

--- a/tests/frontend/pages/learn-load.test.ts
+++ b/tests/frontend/pages/learn-load.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'bun:test';
+import { loadLearnEntries } from '../../../frontend/src/pages/LearnPage';
+
+describe('loadLearnEntries', () => {
+  test('returns learn list items from the API client', async () => {
+    const items = [{ id: 'learning-1', title: 'One', content: 'Body', concepts: [], sourceFile: 'one.md', createdAt: 1, updatedAt: 1 }];
+    await expect(loadLearnEntries({ learn: async () => ({ items, total: 1 }) })).resolves.toBe(items);
+  });
+});

--- a/tests/frontend/pages/learn-page-form.test.tsx
+++ b/tests/frontend/pages/learn-page-form.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+import { LearnPage } from '../../../frontend/src/pages/LearnPage';
+import { htmlFor } from '../_render';
+
+const client = {
+  learn: async () => ({ items: [], total: 0 }),
+  createLearn: async () => ({ success: true, id: 'learning-1', file: 'ψ/memory/learnings/one.md' }),
+  updateLearn: async () => ({ id: 'learning-1' } as never),
+  deleteLearn: async () => ({ id: 'learning-1', deleted: 'soft' as const, supersededAt: 1 }),
+};
+
+describe('LearnPage form', () => {
+  test('renders the learn CRUD form and API hint', () => {
+    const html = htmlFor(<LearnPage client={client} />);
+    expect(html).toContain('Learn entries');
+    expect(html).toContain('aria-label="Learn entry form"');
+    expect(html).toContain('Learning title');
+    expect(html).toContain('/api/v1/learn');
+  });
+});

--- a/tests/frontend/pages/learn-pattern.test.ts
+++ b/tests/frontend/pages/learn-pattern.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from 'bun:test';
+import { learnPayload, patternFromForm } from '../../../frontend/src/pages/LearnPage';
+
+describe('learn form payload', () => {
+  test('combines title and content into the learn pattern payload', () => {
+    const form = { title: 'Title', content: 'Body', concepts: 'one, two' };
+    expect(patternFromForm(form)).toBe('Title\n\nBody');
+    expect(learnPayload(form)).toEqual({ pattern: 'Title\n\nBody', concepts: ['one', 'two'], source: 'Oracle Learn UI' });
+  });
+});

--- a/tests/frontend/pages/learn-summary.test.ts
+++ b/tests/frontend/pages/learn-summary.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'bun:test';
+import { learnSummary } from '../../../frontend/src/pages/LearnPage';
+
+describe('learnSummary', () => {
+  test('describes loading, saving, error, empty, and populated states', () => {
+    expect(learnSummary('loading', 0)).toContain('/api/v1/learn');
+    expect(learnSummary('saving', 1)).toBe('Saving learn entry…');
+    expect(learnSummary('error', 0)).toBe('Learn entries could not be loaded.');
+    expect(learnSummary('ready', 0)).toBe('No learn entries yet.');
+    expect(learnSummary('ready', 2)).toBe('2 active learn entries.');
+  });
+});

--- a/tests/frontend/router.test.ts
+++ b/tests/frontend/router.test.ts
@@ -30,15 +30,16 @@ function htmlAt(path: string): string {
 
 describe('frontend router', () => {
   test('declares the public dashboard route set', () => {
-    expect([...frontendRoutes]).toEqual(['/', '/plugins', '/metrics', '/search']);
+    expect([...frontendRoutes]).toEqual(['/', '/plugins', '/metrics', '/search', '/learn']);
   });
 
-  test('routes root, plugins, metrics, and search surfaces', () => {
+  test('routes root, plugins, metrics, search, and learn surfaces', () => {
     expect(htmlAt('/')).toContain('Menu viewer');
     expect(htmlAt('/plugins')).toContain('Plugin list');
     expect(htmlAt('/metrics')).toContain('Backend metrics');
     expect(htmlAt('/metrics')).toContain('42');
     expect(htmlAt('/search')).toContain('Full-text menu search');
+    expect(htmlAt('/learn')).toContain('Learn entries');
   });
 
   test('wraps routed children in the browser router and error boundary shell', () => {

--- a/tests/frontend/routes/learn-meta.test.ts
+++ b/tests/frontend/routes/learn-meta.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'bun:test';
+import { routeMeta } from '../../../frontend/src/routeMeta';
+
+describe('learn route metadata', () => {
+  test('describes the Learn page route chrome', () => {
+    expect(routeMeta('/learn')).toMatchObject({
+      title: 'Learn entries',
+      eyebrow: 'Learn',
+      description: 'Capture and edit Oracle learnings.',
+    });
+  });
+});

--- a/tests/http/learn/list.test.ts
+++ b/tests/http/learn/list.test.ts
@@ -1,0 +1,77 @@
+import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { eq } from 'drizzle-orm';
+import { mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const root = join(tmpdir(), `arra-learn-list-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+const dbPath = join(root, 'oracle.db');
+mkdirSync(root, { recursive: true });
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = dbPath;
+
+const dbMod = await import('../../../src/db/index.ts');
+dbMod.resetDefaultDatabaseForTests(dbPath);
+const { createLearnCrudRoutes, createLearnListRoutes } = await import('../../../src/routes/learn/index.ts');
+
+function app() {
+  return new Elysia({ prefix: '/api' }).use(createLearnListRoutes()).use(createLearnCrudRoutes());
+}
+
+async function call(method: string, path: string, body?: unknown) {
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.headers = { 'content-type': 'application/json' };
+    init.body = JSON.stringify(body);
+  }
+  const res = await app().handle(new Request(`http://local${path}`, init));
+  const text = await res.text();
+  return { status: res.status, json: text ? JSON.parse(text) : null };
+}
+
+beforeEach(() => {
+  dbMod.db.delete(dbMod.learnLog).run();
+  dbMod.db.delete(dbMod.oracleDocuments)
+    .where(eq(dbMod.oracleDocuments.type, 'learning'))
+    .run();
+});
+
+afterAll(() => {
+  dbMod.closeDb();
+  if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = savedDataDir;
+  if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = savedDbPath;
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('GET /api/learn', () => {
+  test('lists active learn entries with content and hides soft-deleted rows', async () => {
+    const active = await call('POST', '/api/learn', {
+      pattern: 'Visible learn entry\n\nThis content should appear in the frontend.',
+      concepts: ['learn', 'visible'],
+      source: 'list-test',
+    });
+    const deleted = await call('POST', '/api/learn', {
+      pattern: 'Deleted learn entry',
+      concepts: ['learn', 'deleted'],
+      source: 'list-test',
+    });
+    await call('DELETE', `/api/learn/${deleted.json.id}`);
+
+    const listed = await call('GET', '/api/learn');
+    expect(listed.status).toBe(200);
+    expect(listed.json.total).toBe(1);
+    expect(listed.json.items).toHaveLength(1);
+    expect(listed.json.items[0]).toMatchObject({
+      id: active.json.id,
+      title: 'Visible learn entry',
+      concepts: ['learn', 'visible'],
+    });
+    expect(listed.json.items[0].content).toContain('This content should appear in the frontend.');
+    expect(listed.json.items[0].content).not.toContain('title: Visible learn entry');
+  });
+});


### PR DESCRIPTION
## Summary
- add /learn React page for listing, creating, editing, and soft-deleting Learn entries
- add typed /api/v1/learn API client methods and route/nav metadata
- add active Learn list route under knowledge routes with Drizzle-backed filtering

## Tests
- bunx tsc --noEmit
- cd frontend && bunx tsc --noEmit
- bun test tests/frontend/
- bun test tests/http/learn/
- bun test tests/http/menu/list.test.ts src/routes/menu/__tests__/menu-learn-route.test.ts
- cd frontend && bun run build