### PR TITLE
Add frontend metrics dashboard

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -14,7 +14,7 @@ export interface MenuSearchResponse {
 
 export interface ApiRouteResponses {
   '/api/health': HealthResponse;
-  '/api/metrics': MetricsSnapshot;
+  '/api/v1/metrics': MetricsSnapshot;
   '/api/menu': MenuResponse;
   '/api/menu/search': MenuSearchResponse;
   '/api/vector/search': VectorSearchResponse;
@@ -97,7 +97,7 @@ export class ApiClient {
   }
 
   metrics(): Promise<MetricsSnapshot> {
-    return this.request('/api/metrics');
+    return this.request('/api/v1/metrics');
   }
 
   menu(): Promise<MenuResponse> {

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -50,7 +50,7 @@ export function AppShell({
     { to: '/', label: 'Menu', description: 'Navigation rows from /api/menu', badge: loading ? '…' : menuCount },
     { to: '/plugins', label: 'Plugins', description: 'Registered plugins and surfaces', badge: loading ? '…' : pluginCount },
     { to: '/search', label: 'Search', description: 'Full-text menu search' },
-    { to: '/metrics', label: 'Metrics', description: 'Runtime counters from /api/metrics' },
+    { to: '/metrics', label: 'Metrics', description: 'Runtime counters from /api/v1/metrics' },
     { to: '/mcp', label: 'MCP', description: 'Tool schemas and groups' },
     { to: '/settings', label: 'Settings', description: 'Storage, embedder, and DB status' },
   ];
@@ -58,7 +58,7 @@ export function AppShell({
   const responseValue = metricsLoading ? <Spinner label="Loading metrics" /> : `${metrics?.avgResponseMs ?? 0} ms`;
   const metricsDetail = metrics
     ? `${metrics.activeConnections} active · uptime ${Math.round(metrics.uptime)}s`
-    : 'from /api/metrics';
+    : 'from /api/v1/metrics';
   const retry = (
     <button
       aria-label="Retry loading backend dashboard data"

--- a/frontend/src/pages/MetricsPage.tsx
+++ b/frontend/src/pages/MetricsPage.tsx
@@ -1,0 +1,55 @@
+import { LoadingPanel } from '../components/AsyncState';
+import { StatCard } from '../components/StatCard';
+import type { MetricsSnapshot } from '../../../src/server/types';
+
+export function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remaining = Math.round(seconds % 60);
+  if (minutes < 60) return remaining ? `${minutes}m ${remaining}s` : `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const minuteRemainder = minutes % 60;
+  return minuteRemainder ? `${hours}h ${minuteRemainder}m` : `${hours}h`;
+}
+
+export function formatBytes(bytes: number): string {
+  const units = ['B', 'KB', 'MB', 'GB'] as const;
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  const precision = unitIndex === 0 || value >= 10 ? 0 : 1;
+  return `${value.toFixed(precision)} ${units[unitIndex]}`;
+}
+
+function restartLabel(iso: string): string {
+  const timestamp = Date.parse(iso);
+  if (!Number.isFinite(timestamp)) return iso;
+  return new Date(timestamp).toLocaleString();
+}
+
+export function MetricsPage({ metrics, loading }: { metrics: MetricsSnapshot | null; loading: boolean }) {
+  const memory = metrics?.memoryUsage;
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="metrics-page-title">
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Runtime metrics</p>
+      <h1 id="metrics-page-title" className="mt-2 text-3xl font-semibold text-white">Metrics dashboard</h1>
+      <p className="mt-2 text-sm text-slate-400">Live counters from GET /api/v1/metrics.</p>
+
+      {loading ? <div className="mt-5"><LoadingPanel title="Loading metrics…" detail="Fetching /api/v1/metrics from the Elysia backend." /></div> : null}
+      {!loading && !metrics ? <p className="mt-5 text-sm text-slate-400">No metrics snapshot is available yet.</p> : null}
+
+      {metrics ? (
+        <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <StatCard label="Uptime" value={formatDuration(metrics.uptime)} detail={`last restart ${restartLabel(metrics.lastRestart)}`} />
+          <StatCard label="Requests" value={metrics.requestCount} detail={`${metrics.avgResponseMs} ms average response`} />
+          <StatCard label="Memory usage" value={memory ? formatBytes(memory.heapUsed) : '—'} detail={memory ? `${formatBytes(memory.rss)} RSS` : 'memory data unavailable'} />
+          <StatCard label="Active connections" value={metrics.activeConnections} detail="currently tracked HTTP requests" />
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/routeMeta.ts
+++ b/frontend/src/routeMeta.ts
@@ -40,6 +40,7 @@ export function routeMeta(pathname: string, search = ''): RouteMeta {
   }
 
   if (pathname === '/plugins') return base('Plugin list', 'Plugins', 'Registered plugins and exposed runtime surfaces.', [{ label: 'Plugins' }]);
+  if (pathname === '/metrics') return base('Metrics dashboard', 'Metrics', 'Runtime counters from /api/v1/metrics.', [{ label: 'Metrics' }]);
   if (pathname === '/search') return base('Menu search', 'Search', 'Full-text search over /api/menu rows.', [{ label: 'Search' }]);
   if (pathname === '/vector') return base('Vector search', 'Vector', 'Semantic search against Oracle memory.', [{ label: 'Vector search' }]);
   if (pathname === '/mcp') return base('MCP tools', 'MCP', 'Browse available MCP tool schemas and groups.', [{ label: 'MCP tools' }]);

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,9 +1,8 @@
 import type { ReactNode } from 'react';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { ErrorBoundary } from './components/ErrorBoundary';
-import { LoadingPanel } from './components/AsyncState';
-import { StatCard } from './components/StatCard';
 import { McpPage } from './pages/McpPage';
+import { MetricsPage } from './pages/MetricsPage';
 import { McpToolDetailPage } from './pages/McpToolDetailPage';
 import { MenuPage } from './pages/MenuPage';
 import { PluginsPage } from './pages/PluginsPage';
@@ -41,25 +40,6 @@ export function AppRouter({ children }: { children: ReactNode }) {
   );
 }
 
-function MetricsPage({ metrics, loading }: { metrics: MetricsSnapshot | null; loading: boolean }) {
-  return (
-    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="metrics-page-title">
-      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Metrics</p>
-      <h2 id="metrics-page-title" className="mt-2 mb-4 text-2xl font-semibold text-white">Backend metrics</h2>
-      {loading ? <LoadingPanel title="Loading metrics…" detail="Fetching /api/metrics from the Elysia backend." /> : null}
-      {!loading && !metrics ? <p className="text-sm text-slate-400">No metrics snapshot is available yet.</p> : null}
-      {metrics ? (
-        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-          <StatCard label="Requests" value={metrics.requestCount} detail="tracked by Elysia lifecycle" />
-          <StatCard label="Avg response" value={`${metrics.avgResponseMs} ms`} detail="mean response time" />
-          <StatCard label="Active" value={metrics.activeConnections} detail="active HTTP requests" />
-          <StatCard label="Uptime" value={`${Math.round(metrics.uptime)}s`} detail={`since ${metrics.lastRestart}`} />
-        </div>
-      ) : null}
-    </section>
-  );
-}
-
 export function DashboardRoutes({
   menu,
   plugins,
@@ -71,13 +51,11 @@ export function DashboardRoutes({
 }: DashboardRoutesProps) {
   const menuPage = <MenuPage items={menu} loading={isRouteLoading(states.menu)} />;
   const pluginPage = <PluginsPage plugins={plugins} loading={isRouteLoading(states.plugins)} />;
-  const metricsPage = <MetricsPage metrics={metrics} loading={isRouteLoading(states.metrics)} />;
-
   return (
     <Routes>
       <Route index element={menuPage} />
       <Route path="/plugins" element={pluginPage} />
-      <Route path="/metrics" element={metricsPage} />
+      <Route path="/metrics" element={<MetricsPage metrics={metrics} loading={isRouteLoading(states.metrics)} />} />
       <Route path="/search" element={<SearchPage />} />
       <Route path="/menu" element={menuPage} />
       <Route path="/vector" element={<VectorPage />} />

--- a/src/routes/metrics/index.ts
+++ b/src/routes/metrics/index.ts
@@ -5,4 +5,4 @@ export {
   metricsRoutes,
   serverMetrics,
 } from './metrics.ts';
-export type { MetricsSnapshot, MetricsTracker, MetricsTrackerOptions } from './metrics.ts';
+export type { MemoryUsageSnapshot, MetricsSnapshot, MetricsTracker, MetricsTrackerOptions } from './metrics.ts';

--- a/src/routes/metrics/metrics.ts
+++ b/src/routes/metrics/metrics.ts
@@ -1,17 +1,27 @@
 import { Elysia } from 'elysia';
 
+export interface MemoryUsageSnapshot {
+  rss: number;
+  heapTotal: number;
+  heapUsed: number;
+  external: number;
+  arrayBuffers: number;
+}
+
 export interface MetricsSnapshot {
   uptime: number;
   requestCount: number;
   avgResponseMs: number;
   activeConnections: number;
   lastRestart: string;
+  memoryUsage: MemoryUsageSnapshot;
 }
 
 export interface MetricsTrackerOptions {
   startedAtMs?: number;
   nowMs?: () => number;
   lastRestart?: string;
+  memoryUsage?: () => MemoryUsageSnapshot;
 }
 
 export interface MetricsTracker {
@@ -24,10 +34,22 @@ function round(value: number): number {
   return Math.round(value * 1000) / 1000;
 }
 
+function processMemoryUsage(): MemoryUsageSnapshot {
+  const usage = process.memoryUsage();
+  return {
+    rss: usage.rss,
+    heapTotal: usage.heapTotal,
+    heapUsed: usage.heapUsed,
+    external: usage.external,
+    arrayBuffers: usage.arrayBuffers ?? 0,
+  };
+}
+
 export function createMetricsTracker(options: MetricsTrackerOptions = {}): MetricsTracker {
   const nowMs = options.nowMs ?? (() => Date.now());
   const startedAtMs = options.startedAtMs ?? nowMs();
   const lastRestart = options.lastRestart ?? new Date(startedAtMs).toISOString();
+  const memoryUsage = options.memoryUsage ?? processMemoryUsage;
   const starts = new WeakMap<Request, number>();
   let requestCount = 0;
   let totalResponseMs = 0;
@@ -53,6 +75,7 @@ export function createMetricsTracker(options: MetricsTrackerOptions = {}): Metri
         avgResponseMs: requestCount === 0 ? 0 : round(totalResponseMs / requestCount),
         activeConnections,
         lastRestart,
+        memoryUsage: memoryUsage(),
       };
     },
   };

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -101,12 +101,21 @@ export interface HealthResponse {
   };
 }
 
+export interface MemoryUsageSnapshot {
+  rss: number;
+  heapTotal: number;
+  heapUsed: number;
+  external: number;
+  arrayBuffers: number;
+}
+
 export interface MetricsSnapshot {
   uptime: number;
   requestCount: number;
   avgResponseMs: number;
   activeConnections: number;
   lastRestart: string;
+  memoryUsage: MemoryUsageSnapshot;
 }
 
 export interface PluginEntryResponse {

--- a/tests/frontend/api-client.test.ts
+++ b/tests/frontend/api-client.test.ts
@@ -13,12 +13,13 @@ describe('frontend API client', () => {
   test('calls each typed backend route with JSON accept headers', async () => {
     const payloads: Record<string, unknown> = {
       '/api/health': { status: 'ok', server: 'arra', version: '26.5.30', port: 47778 },
-      '/api/metrics': {
+      '/api/v1/metrics': {
         uptime: 4.2,
         requestCount: 7,
         avgResponseMs: 1.5,
         activeConnections: 0,
         lastRestart: '2026-06-16T00:00:00.000Z',
+        memoryUsage: { rss: 67108864, heapTotal: 33554432, heapUsed: 16777216, external: 1024, arrayBuffers: 0 },
       },
       '/api/menu': { items: [{ label: 'Vector', path: '/vector', group: 'tools', order: 1, source: 'api' }] },
       '/api/menu/search?q=vector': { data: [{ label: 'Vector', path: '/vector', group: 'tools', order: 1, source: 'api' }], q: 'vector', total: 1 },
@@ -51,7 +52,7 @@ describe('frontend API client', () => {
 
     expect(calls.map((call) => String(call.input))).toEqual([
       '/api/health',
-      '/api/metrics',
+      '/api/v1/metrics',
       '/api/menu',
       '/api/menu/search?q=vector',
       '/api/vector/search?q=oracle+memory&limit=5&type=docs',
@@ -99,8 +100,8 @@ describe('frontend API client', () => {
     const errorClient = createApiClient({ fetch: () => jsonResponse({ error: 'offline' }, { status: 503, statusText: 'Unavailable' }) });
     await expect(errorClient.metrics()).rejects.toMatchObject({
       status: 503,
-      path: '/api/metrics',
-      message: '/api/metrics returned 503: offline',
+      path: '/api/v1/metrics',
+      message: '/api/v1/metrics returned 503: offline',
     } as ApiClientError);
   });
 });

--- a/tests/frontend/dashboard.test.ts
+++ b/tests/frontend/dashboard.test.ts
@@ -9,7 +9,7 @@ describe('dashboard data loading', () => {
     const result = await loadDashboardData({
       menu: async () => ({ items: [{ label: 'Menu', path: '/menu', group: 'main', order: 1, source: 'api' }] }),
       plugins: async () => ({ dir: '/plugins', plugins: [{ name: 'echo', file: 'echo.wasm', size: 12, modified: 'now' }] }),
-      metrics: async () => ({ uptime: 12.5, requestCount: 42, avgResponseMs: 3.2, activeConnections: 1, lastRestart: '2026-06-16T00:00:00.000Z' }),
+      metrics: async () => ({ uptime: 12.5, requestCount: 42, avgResponseMs: 3.2, activeConnections: 1, lastRestart: '2026-06-16T00:00:00.000Z', memoryUsage: { rss: 67108864, heapTotal: 33554432, heapUsed: 16777216, external: 1024, arrayBuffers: 0 } }),
     });
 
     expect(result.errors).toEqual({});
@@ -22,13 +22,13 @@ describe('dashboard data loading', () => {
     const result = await loadDashboardData({
       menu: async () => ({ items: [] }),
       plugins: async () => ({ dir: '/plugins', plugins: [] }),
-      metrics: async () => { throw new Error('/api/metrics unavailable'); },
+      metrics: async () => { throw new Error('/api/v1/metrics unavailable'); },
     });
 
     expect(result.menu).toEqual([]);
     expect(result.plugins).toEqual([]);
     expect(result.metrics).toBeNull();
-    expect(result.errors.metrics).toBe('Metrics: /api/metrics unavailable');
+    expect(result.errors.metrics).toBe('Metrics: /api/v1/metrics unavailable');
   });
 
   test('renders dashboard metric cards with loading state before effects resolve', () => {
@@ -38,7 +38,7 @@ describe('dashboard data loading', () => {
       expect(html).toContain('Requests');
       expect(html).toContain('Avg response');
       expect(html).toContain('Loading metrics');
-      expect(html).toContain('/api/metrics');
+      expect(html).toContain('/api/v1/metrics');
     } finally {
       restore();
     }

--- a/tests/frontend/pages/metrics-format.test.ts
+++ b/tests/frontend/pages/metrics-format.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test';
+import { formatBytes, formatDuration } from '../../../frontend/src/pages/MetricsPage';
+
+describe('metrics formatting helpers', () => {
+  test('formats durations and bytes for dashboard cards', () => {
+    expect(formatDuration(12.4)).toBe('12s');
+    expect(formatDuration(125)).toBe('2m 5s');
+    expect(formatDuration(7200)).toBe('2h');
+    expect(formatBytes(512)).toBe('512 B');
+    expect(formatBytes(1536)).toBe('1.5 KB');
+    expect(formatBytes(16 * 1024 * 1024)).toBe('16 MB');
+  });
+});

--- a/tests/frontend/pages/metrics-page-loading.test.tsx
+++ b/tests/frontend/pages/metrics-page-loading.test.tsx
@@ -1,0 +1,11 @@
+import { describe, expect, test } from 'bun:test';
+import { MetricsPage } from '../../../frontend/src/pages/MetricsPage';
+import { htmlFor } from '../_render';
+
+describe('MetricsPage loading state', () => {
+  test('renders the versioned metrics loading endpoint', () => {
+    const html = htmlFor(<MetricsPage metrics={null} loading />);
+    expect(html).toContain('Loading metrics');
+    expect(html).toContain('/api/v1/metrics');
+  });
+});

--- a/tests/frontend/pages/metrics-page-ready.test.tsx
+++ b/tests/frontend/pages/metrics-page-ready.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test';
+import { MetricsPage } from '../../../frontend/src/pages/MetricsPage';
+import { htmlFor } from '../_render';
+
+const metrics = {
+  uptime: 3665,
+  requestCount: 42,
+  avgResponseMs: 3.2,
+  activeConnections: 2,
+  lastRestart: '2026-06-16T00:00:00.000Z',
+  memoryUsage: { rss: 67108864, heapTotal: 33554432, heapUsed: 16777216, external: 1024, arrayBuffers: 0 },
+};
+
+describe('MetricsPage ready state', () => {
+  test('renders runtime counters from the versioned metrics endpoint', () => {
+    const html = htmlFor(<MetricsPage metrics={metrics} loading={false} />);
+    expect(html).toContain('GET /api/v1/metrics');
+    expect(html).toContain('Uptime');
+    expect(html).toContain('1h 1m');
+    expect(html).toContain('Requests');
+    expect(html).toContain('42');
+    expect(html).toContain('Memory usage');
+    expect(html).toContain('16 MB');
+    expect(html).toContain('Active connections');
+  });
+});

--- a/tests/frontend/router.test.ts
+++ b/tests/frontend/router.test.ts
@@ -14,6 +14,7 @@ const routeProps: DashboardRoutesProps = {
     avgResponseMs: 3.2,
     activeConnections: 1,
     lastRestart: '2026-06-16T00:00:00.000Z',
+    memoryUsage: { rss: 67108864, heapTotal: 33554432, heapUsed: 16777216, external: 1024, arrayBuffers: 0 },
   },
   surfaceCount: 1,
   updatedAt: '11:11',
@@ -36,8 +37,9 @@ describe('frontend router', () => {
   test('routes root, plugins, metrics, and search surfaces', () => {
     expect(htmlAt('/')).toContain('Menu viewer');
     expect(htmlAt('/plugins')).toContain('Registered plugins');
-    expect(htmlAt('/metrics')).toContain('Backend metrics');
+    expect(htmlAt('/metrics')).toContain('Metrics dashboard');
     expect(htmlAt('/metrics')).toContain('42');
+    expect(htmlAt('/metrics')).toContain('Memory usage');
     expect(htmlAt('/search')).toContain('Full-text menu search');
   });
 

--- a/tests/http/metrics/basic-metrics.test.ts
+++ b/tests/http/metrics/basic-metrics.test.ts
@@ -12,6 +12,7 @@ test('GET /api/metrics reports lifecycle-tracked runtime counters', async () => 
     startedAtMs: 0,
     lastRestart: '2026-06-16T00:00:00.000Z',
     nowMs: () => now,
+    memoryUsage: () => ({ rss: 67108864, heapTotal: 33554432, heapUsed: 16777216, external: 1024, arrayBuffers: 0 }),
   });
   const app = new Elysia()
     .use(createMetricsLifecycle(tracker))
@@ -34,5 +35,6 @@ test('GET /api/metrics reports lifecycle-tracked runtime counters', async () => 
     avgResponseMs: 25,
     activeConnections: 1,
     lastRestart: '2026-06-16T00:00:00.000Z',
+    memoryUsage: { rss: 67108864, heapTotal: 33554432, heapUsed: 16777216, external: 1024, arrayBuffers: 0 },
   });
 });


### PR DESCRIPTION
## Summary\n- add a dedicated /metrics React dashboard page backed by GET /api/v1/metrics\n- display uptime, request count, memory usage, and active connection cards\n- include process memory usage in runtime metrics snapshots and update frontend tests\n\n## Verification\n- tsc --noEmit\n- bun test tests/frontend/\n- bun test tests/http/metrics/\n\n## Notes\n- files <=250 lines\n- scoped PR against alpha; no main changes