### PR TITLE
Label plugin sandbox as error containment

### DIFF
--- a/src/plugins/sandbox.ts
+++ b/src/plugins/sandbox.ts
@@ -1,3 +1,9 @@
+/**
+ * Error Containment.
+ *
+ * Catches plugin exceptions and reports them; this does NOT provide process
+ * isolation, VM boundaries, or any security boundary.
+ */
 import { pluginEventBus, type PluginErrorPhase, type PluginEventBus } from './event-bus.ts';
 
 export interface PluginSandboxOptions {
@@ -14,6 +20,7 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+/** Error containment wrapper — catches plugin exceptions, does NOT provide process isolation. */
 export async function runPluginSandbox<T>(
   options: PluginSandboxOptions,
   operation: () => T | Promise<T>,


### PR DESCRIPTION
## Summary\n- relabel src/plugins/sandbox.ts file docs as Error Containment\n- add explicit JSDoc warning that the wrapper catches plugin exceptions only and does not provide process isolation\n- leave file/function/type names unchanged for compatibility\n\n## Verification\n- tsc --noEmit\n- bun test tests/plugins/\n\n## Notes\n- comments/docs only\n- files <=250 lines\n- PR targets alpha; never main