### PR TITLE
Fix unversioned health endpoint redirect

### DIFF
--- a/src/middleware/api-version.ts
+++ b/src/middleware/api-version.ts
@@ -4,6 +4,7 @@ export const API_VERSION = 'v1';
 export const API_VERSION_HEADER = 'X-API-Version';
 const API_PREFIX = '/api';
 const VERSIONED_PREFIX = `${API_PREFIX}/${API_VERSION}`;
+const UNVERSIONED_INFRASTRUCTURE_PATHS = new Set(['/api/health', '/api/ready']);
 const publicPaths = new WeakMap<Request, string>();
 
 type FetchHandler = (request: Request) => Response | Promise<Response>;
@@ -22,13 +23,21 @@ function isVersionedApiPath(pathname: string): boolean {
   return pathname === VERSIONED_PREFIX || pathname.startsWith(`${VERSIONED_PREFIX}/`);
 }
 
+function isUnversionedInfrastructurePath(pathname: string): boolean {
+  return UNVERSIONED_INFRASTRUCTURE_PATHS.has(pathname);
+}
+
 export function apiRequestPath(request: Request): string {
   return publicPaths.get(request) ?? new URL(request.url).pathname;
 }
 
 function versionedLocation(request: Request): string | null {
   const url = new URL(request.url);
-  if (!isApiPath(url.pathname) || isVersionedApiPath(url.pathname)) return null;
+  if (
+    !isApiPath(url.pathname)
+    || isVersionedApiPath(url.pathname)
+    || isUnversionedInfrastructurePath(url.pathname)
+  ) return null;
   const suffix = url.pathname.slice(API_PREFIX.length);
   url.pathname = `${VERSIONED_PREFIX}${suffix}`;
   return url.toString();

--- a/tests/http/health/unversioned.test.ts
+++ b/tests/http/health/unversioned.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import {
+  createApiVersionHeaderMiddleware,
+  createApiVersionedFetch,
+} from '../../../src/middleware/api-version.ts';
+import { createHealthRoutes } from '../../../src/routes/health/index.ts';
+
+function createFetch() {
+  const app = new Elysia()
+    .use(createApiVersionHeaderMiddleware())
+    .use(createHealthRoutes({
+      uptimeSeconds: () => 1,
+      vectorHealth: async () => ({ status: 'ok', engines: [], checked_at: '2026-06-16T00:00:00.000Z' }),
+    }));
+
+  return createApiVersionedFetch((request) => app.handle(request));
+}
+
+test('GET /api/health returns ok directly without a version redirect', async () => {
+  const res = await createFetch()(new Request('http://local/api/health'));
+  const body = await res.json() as { status: string };
+
+  expect(res.status).toBe(200);
+  expect(res.headers.get('location')).toBeNull();
+  expect(body.status).toBe('ok');
+});
+
+test('GET /api/v1/health still rewrites to the health route', async () => {
+  const res = await createFetch()(new Request('http://local/api/v1/health'));
+  const body = await res.json() as { status: string };
+
+  expect(res.status).toBe(200);
+  expect(body.status).toBe('ok');
+});

--- a/tests/http/versioning/prefix.test.ts
+++ b/tests/http/versioning/prefix.test.ts
@@ -9,18 +9,18 @@ import {
 test('API routes are served under /api/v1 and legacy /api paths redirect', async () => {
   const app = new Elysia()
     .use(createApiVersionHeaderMiddleware())
-    .get('/api/health', () => ({ status: 'ok' }))
+    .get('/api/search', () => ({ status: 'ok' }))
     .get('/public', () => ({ public: true }));
   const fetchVersioned = createApiVersionedFetch((request) => app.handle(request));
 
-  const versioned = await fetchVersioned(new Request('http://local/api/v1/health'));
+  const versioned = await fetchVersioned(new Request('http://local/api/v1/search'));
   expect(versioned.status).toBe(200);
   expect(versioned.headers.get(API_VERSION_HEADER)).toBe('v1');
   expect(await versioned.json()).toEqual({ status: 'ok' });
 
-  const legacy = await fetchVersioned(new Request('http://local/api/health?probe=1'));
+  const legacy = await fetchVersioned(new Request('http://local/api/search?probe=1'));
   expect(legacy.status).toBe(308);
-  expect(legacy.headers.get('location')).toBe('http://local/api/v1/health?probe=1');
+  expect(legacy.headers.get('location')).toBe('http://local/api/v1/search?probe=1');
   expect(legacy.headers.get(API_VERSION_HEADER)).toBe('v1');
 
   const publicRoute = await fetchVersioned(new Request('http://local/public'));


### PR DESCRIPTION
## Summary
- Bypass API version redirects for infrastructure endpoints `/api/health` and `/api/ready`
- Keep `/api/v1/health` rewriting to the internal health route
- Add health contract coverage for direct unversioned health responses

## Verification
- `tsc --noEmit`
- `bun test tests/http/health/`
- `bun test tests/http/versioning/`
- `wc -l src/middleware/api-version.ts tests/http/health/unversioned.test.ts tests/http/versioning/prefix.test.ts`

Base: `alpha`
Closes #1597 item 1