### PR TITLE
Add request logger LOG_FORMAT output modes

### DIFF
--- a/src/middleware/logger.ts
+++ b/src/middleware/logger.ts
@@ -26,12 +26,16 @@ export type RequestLogEntry = {
   headers: Record<string, string>;
 };
 
+export type RequestLogFormat = 'json' | 'nginx' | 'short';
+
 export type RequestLoggerOptions = {
   log?: (entry: RequestLogEntry) => void;
+  now?: () => number;
 };
 
 const REDACTED = '[REDACTED]';
 const sensitiveHeaders = new Set(['authorization', 'proxy-authorization']);
+const logFormats = new Set<RequestLogFormat>(['json', 'nginx', 'short']);
 
 function nowMs(): number {
   return performance.now();
@@ -64,19 +68,57 @@ function responseStatus(responseValue: unknown, setStatus?: number | string): nu
   return 200;
 }
 
+function requestLogFormat(): RequestLogFormat {
+  const requested = process.env.LOG_FORMAT as RequestLogFormat | undefined;
+  return requested && logFormats.has(requested) ? requested : 'json';
+}
+
+function formatDurationMs(durationMs: number): string {
+  return `${Math.max(0, durationMs).toFixed(2).replace(/\.?0+$/, '')}ms`;
+}
+
+function shortCorrelationId(correlationId: string): string {
+  return correlationId.slice(0, 8);
+}
+
+export function formatRequestLog(entry: RequestLogEntry, format: RequestLogFormat): string {
+  if (format === 'nginx') {
+    return [
+      entry.method,
+      entry.path,
+      entry.status,
+      formatDurationMs(entry.durationMs),
+      `[${shortCorrelationId(entry.correlationId)}]`,
+    ].join(' ');
+  }
+
+  if (format === 'short') {
+    return [
+      entry.status,
+      entry.method,
+      entry.path,
+      `${Math.max(0, Math.round(entry.durationMs))}ms`,
+    ].join(' ');
+  }
+
+  return JSON.stringify(entry);
+}
+
 export function createRequestLogger(options: RequestLoggerOptions = {}) {
   const metaByRequest = new WeakMap<Request, RequestMeta>();
-  const log = options.log ?? ((entry: RequestLogEntry) => console.log(JSON.stringify(entry)));
+  const now = options.now ?? nowMs;
+  const format = requestLogFormat();
+  const log = options.log ?? ((entry: RequestLogEntry) => console.log(formatRequestLog(entry, format)));
 
   return {
     onRequest({ request, set }: RequestContext) {
       const correlationId = requestCorrelationId(request);
-      metaByRequest.set(request, { startedAt: nowMs(), correlationId, headers: redactHeaders(request.headers) });
+      metaByRequest.set(request, { startedAt: now(), correlationId, headers: redactHeaders(request.headers) });
       set.headers['X-Correlation-Id'] = correlationId;
     },
     onAfterResponse({ request, responseValue, set }: AfterResponseContext) {
       const meta = metaByRequest.get(request);
-      const endedAt = nowMs();
+      const endedAt = now();
       const startedAt = meta?.startedAt ?? endedAt;
       const durationMs = Math.max(0, Math.round((endedAt - startedAt) * 100) / 100);
       log({

--- a/tests/http/logger/format.test.ts
+++ b/tests/http/logger/format.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createRequestLogger, type RequestLogEntry } from '../../../src/middleware/logger.ts';
+
+const CORRELATION_ID = 'abcdef12-correlation-id';
+
+async function waitForLog(logs: string[]): Promise<string> {
+  const deadline = Date.now() + 500;
+  while (Date.now() < deadline) {
+    if (logs[0]) return logs[0];
+    await Bun.sleep(5);
+  }
+  throw new Error('request log was not emitted');
+}
+
+function restoreLogFormat(value: string | undefined) {
+  if (value === undefined) delete process.env.LOG_FORMAT;
+  else process.env.LOG_FORMAT = value;
+}
+
+async function captureLogLine(format: string): Promise<string> {
+  const lines: string[] = [];
+  const originalLog = console.log;
+  const originalFormat = process.env.LOG_FORMAT;
+  process.env.LOG_FORMAT = format;
+  console.log = (message?: unknown) => {
+    lines.push(String(message));
+  };
+
+  try {
+    const ticks = [100, 101.37];
+    const logger = createRequestLogger({ now: () => ticks.shift() ?? 101.37 });
+    const app = new Elysia()
+      .onRequest(logger.onRequest)
+      .onAfterResponse(logger.onAfterResponse)
+      .get('/api/health', () => ({ ok: true }));
+
+    const response = await app.fetch(new Request('http://local/api/health?ignored=true', {
+      headers: { 'x-correlation-id': CORRELATION_ID },
+    }));
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-correlation-id')).toBe(CORRELATION_ID);
+
+    return await waitForLog(lines);
+  } finally {
+    console.log = originalLog;
+    restoreLogFormat(originalFormat);
+  }
+}
+
+test('LOG_FORMAT selects json, nginx, and short request log output', async () => {
+  const json = JSON.parse(await captureLogLine('json')) as RequestLogEntry;
+  expect(json).toMatchObject({
+    event: 'http_request',
+    method: 'GET',
+    path: '/api/health',
+    status: 200,
+    durationMs: 1.37,
+    correlationId: CORRELATION_ID,
+  });
+
+  expect(await captureLogLine('nginx')).toBe('GET /api/health 200 1.37ms [abcdef12]');
+  expect(await captureLogLine('short')).toBe('200 GET /api/health 1ms');
+});


### PR DESCRIPTION
## Summary\n- add LOG_FORMAT=json/nginx/short formatting for request logger output\n- keep json as the default/backward-compatible behavior\n- cover all three output formats with fetch-based logger tests\n\n## Verification\n- tsc --noEmit\n- bun test tests/http/logger/\n- bun test tests/http/logging/ tests/http/logger/\n- wc -l src/middleware/logger.ts tests/http/logger/format.test.ts