### PR TITLE
Add vector documents browse API

### DIFF
--- a/src/routes/vector/documents.ts
+++ b/src/routes/vector/documents.ts
@@ -1,0 +1,126 @@
+/**
+ * GET /api/vector/documents — browse indexed vector documents.
+ */
+
+import { Elysia, t } from 'elysia';
+import { getVectorStoreByModel } from '../../vector/factory.ts';
+import type { VectorQueryResult, VectorStoreAdapter } from '../../vector/types.ts';
+
+interface DocumentItem {
+  id: string;
+  document: string;
+  metadata: Record<string, unknown>;
+}
+
+interface VectorDocumentsDeps {
+  getStore?: (collection?: string) => VectorStoreAdapter;
+}
+
+const DEFAULT_COLLECTION = 'bge-m3';
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 500;
+
+function parsePositiveInt(value: string | undefined, fallback: number, max?: number): number {
+  const parsed = Number.parseInt(value ?? '', 10);
+  const normalized = Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  return max ? Math.min(normalized, max) : normalized;
+}
+
+function normalizeMetadata(metadata: unknown): Record<string, unknown> {
+  if (metadata && typeof metadata === 'object' && !Array.isArray(metadata)) {
+    return metadata as Record<string, unknown>;
+  }
+  return {};
+}
+
+function text(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value == null) return '';
+  return String(value);
+}
+
+function pageItems(
+  ids: string[],
+  documents: unknown[],
+  metadatas: unknown[],
+  offset: number,
+  limit: number,
+): DocumentItem[] {
+  return ids.slice(offset, offset + limit).map((id, index) => {
+    const sourceIndex = offset + index;
+    return {
+      id,
+      document: text(documents[sourceIndex]),
+      metadata: normalizeMetadata(metadatas[sourceIndex]),
+    };
+  });
+}
+
+async function listWithQuery(
+  store: VectorStoreAdapter,
+  offset: number,
+  limit: number,
+): Promise<{ items: DocumentItem[]; totalFallback: number }> {
+  const result: VectorQueryResult = await store.query('', offset + limit);
+  return {
+    items: pageItems(result.ids, result.documents, result.metadatas, offset, limit),
+    totalFallback: result.ids.length,
+  };
+}
+
+export function createVectorDocumentsEndpoint(deps: VectorDocumentsDeps = {}) {
+  const getStore = deps.getStore ?? getVectorStoreByModel;
+
+  return new Elysia().get(
+    '/vector/documents',
+    async ({ query, set }) => {
+      const collection = query.collection || DEFAULT_COLLECTION;
+      const page = parsePositiveInt(query.page, DEFAULT_PAGE);
+      const limit = parsePositiveInt(query.limit, DEFAULT_LIMIT, MAX_LIMIT);
+      const offset = (page - 1) * limit;
+
+      try {
+        const store = getStore(collection);
+        await store.connect();
+        await store.ensureCollection();
+
+        const stats = await store.getStats().catch(() => ({ count: 0 }));
+        let listed: { items: DocumentItem[]; totalFallback: number };
+
+        if (store.getAllEmbeddings) {
+          const all = await store.getAllEmbeddings(offset + limit);
+          const docs = (all as { documents?: unknown[] }).documents;
+          listed = Array.isArray(docs)
+            ? {
+                items: pageItems(all.ids, docs, all.metadatas, offset, limit),
+                totalFallback: all.ids.length,
+              }
+            : await listWithQuery(store, offset, limit);
+        } else {
+          listed = await listWithQuery(store, offset, limit);
+        }
+
+        return { items: listed.items, total: stats.count || listed.totalFallback, page, limit };
+      } catch (error) {
+        set.status = 500;
+        const message = error instanceof Error ? error.message : String(error);
+        return { error: 'Vector documents browse failed', message, items: [], total: 0, page, limit };
+      }
+    },
+    {
+      query: t.Object({
+        collection: t.Optional(t.String()),
+        page: t.Optional(t.String()),
+        limit: t.Optional(t.String()),
+      }),
+      detail: {
+        tags: ['vector'],
+        menu: { group: 'tools', order: 56 },
+        summary: 'Browse documents in a vector collection',
+      },
+    },
+  );
+}
+
+export const vectorDocumentsEndpoint = createVectorDocumentsEndpoint();

--- a/src/routes/vector/index.ts
+++ b/src/routes/vector/index.ts
@@ -9,6 +9,8 @@
  *   GET /api/map3d           — 3D PCA projection from real embeddings
  *   GET /api/vector/stats    — per-engine collection counts
  *   GET /api/vector/health   — adapter liveness probe
+ *   GET /api/vector/documents — browse indexed vector documents
+ *   GET /api/vector/export — stream vector documents as JSON or CSV
  *
  * Mounted with the `/api` prefix from server.ts. Phase 1 of #1071: separating
  * the vector layer from FTS/hybrid so it can later move behind VECTOR_URL.
@@ -25,6 +27,8 @@ import { vectorHealthEndpoint } from './health.ts';
 import { vectorConfigEndpoint } from './config.ts';
 import { vectorIndexerEndpoints } from './indexer.ts';
 import { vectorProxyEndpoint } from './proxy.ts';
+import { vectorDocumentsEndpoint } from './documents.ts';
+import { vectorExportEndpoint } from './export.ts';
 
 export const vectorRoutes = new Elysia({ prefix: '/api' })
   .use(vectorProxyEndpoint)
@@ -35,5 +39,7 @@ export const vectorRoutes = new Elysia({ prefix: '/api' })
   .use(map3dEndpoint)
   .use(vectorStatsEndpoint)
   .use(vectorHealthEndpoint)
+  .use(vectorDocumentsEndpoint)
+  .use(vectorExportEndpoint)
   .use(vectorConfigEndpoint)
   .use(vectorIndexerEndpoints);

--- a/src/vector/adapters/lancedb.ts
+++ b/src/vector/adapters/lancedb.ts
@@ -176,13 +176,14 @@ export class LanceDBAdapter implements VectorStoreAdapter {
     return { count: stats.count, name: this.collectionName };
   }
 
-  async getAllEmbeddings(limit: number = 5000): Promise<{ ids: string[]; embeddings: number[][]; metadatas: any[] }> {
-    if (!this.table) return { ids: [], embeddings: [], metadatas: [] };
+  async getAllEmbeddings(limit: number = 5000): Promise<{ ids: string[]; embeddings: number[][]; metadatas: any[]; documents: string[] }> {
+    if (!this.table) return { ids: [], documents: [], embeddings: [], metadatas: [] };
 
     const rows = await this.table.query().limit(limit).toArray();
 
     return {
       ids: rows.map((r: any) => r.id),
+      documents: rows.map((r: any) => r.text),
       embeddings: rows.map((r: any) => Array.from(r.vector)),
       metadatas: rows.map((r: any) => JSON.parse(r.metadata || '{}')),
     };

--- a/src/vector/types.ts
+++ b/src/vector/types.ts
@@ -44,7 +44,12 @@ export interface VectorStoreAdapter {
   queryById(id: string, nResults?: number): Promise<VectorQueryResult>;
   getStats(): Promise<{ count: number }>;
   getCollectionInfo(): Promise<{ count: number; name: string }>;
-  getAllEmbeddings?(limit?: number): Promise<{ ids: string[]; embeddings: number[][]; metadatas: any[] }>;
+  getAllEmbeddings?(limit?: number): Promise<{
+    ids: string[];
+    embeddings: number[][];
+    metadatas: any[];
+    documents?: string[];
+  }>;
 }
 
 export type EmbedType = 'query' | 'passage';

--- a/tests/http/vector/documents.test.ts
+++ b/tests/http/vector/documents.test.ts
@@ -1,0 +1,82 @@
+import { expect, mock, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createVectorDocumentsEndpoint } from '../../../src/routes/vector/documents.ts';
+import type { VectorStoreAdapter } from '../../../src/vector/types.ts';
+
+const docs = [
+  { id: 'doc-1', document: 'alpha', metadata: { type: 'note' } },
+  { id: 'doc-2', document: 'bravo', metadata: { type: 'note' } },
+  { id: 'doc-3', document: 'charlie', metadata: { type: 'trace' } },
+  { id: 'doc-4', document: 'delta', metadata: { type: 'trace' } },
+  { id: 'doc-5', document: 'echo', metadata: { type: 'vault' } },
+];
+
+function createStore(): VectorStoreAdapter {
+  return {
+    name: 'fake-vector',
+    connect: mock(async () => {}),
+    close: mock(async () => {}),
+    ensureCollection: mock(async () => {}),
+    deleteCollection: mock(async () => {}),
+    addDocuments: mock(async () => {}),
+    query: mock(async () => ({
+      ids: docs.map((doc) => doc.id),
+      documents: docs.map((doc) => doc.document),
+      distances: docs.map(() => 0),
+      metadatas: docs.map((doc) => doc.metadata),
+    })),
+    queryById: mock(async () => ({ ids: [], documents: [], distances: [], metadatas: [] })),
+    getStats: mock(async () => ({ count: docs.length })),
+    getCollectionInfo: mock(async () => ({ count: docs.length, name: 'fake' })),
+    getAllEmbeddings: mock(async (limit = 5000) => {
+      const limited = docs.slice(0, limit);
+      return {
+        ids: limited.map((doc) => doc.id),
+        documents: limited.map((doc) => doc.document),
+        embeddings: limited.map(() => [0, 0, 0]),
+        metadatas: limited.map((doc) => doc.metadata),
+      };
+    }),
+  };
+}
+
+function createFetch(store: VectorStoreAdapter, collections: string[]) {
+  const app = new Elysia({ prefix: '/api' }).use(createVectorDocumentsEndpoint({
+    getStore: (collection) => {
+      collections.push(collection ?? '');
+      return store;
+    },
+  }));
+
+  return createApiVersionedFetch((request) => app.handle(request));
+}
+
+test('GET /api/v1/vector/documents returns paged vector documents', async () => {
+  const store = createStore();
+  const collections: string[] = [];
+  const fetcher = createFetch(store, collections);
+
+  const res = await fetcher(new Request(
+    'http://local/api/v1/vector/documents?collection=bge-m3&page=2&limit=2',
+  ));
+  const body = await res.json() as {
+    items: Array<{ id: string; document: string; metadata: Record<string, unknown> }>;
+    total: number;
+    page: number;
+    limit: number;
+  };
+
+  expect(res.status).toBe(200);
+  expect(collections).toEqual(['bge-m3']);
+  expect(body).toEqual({
+    items: [
+      { id: 'doc-3', document: 'charlie', metadata: { type: 'trace' } },
+      { id: 'doc-4', document: 'delta', metadata: { type: 'trace' } },
+    ],
+    total: 5,
+    page: 2,
+    limit: 2,
+  });
+  expect(store.getAllEmbeddings).toHaveBeenCalledWith(4);
+});


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/vector/documents` for paged vector document browsing via the vector adapter registry.
- Register the endpoint in the vector route cluster.
- Return LanceDB document text from `getAllEmbeddings()` so browse does not need a semantic query.

## Verification
- `tsc --noEmit`
- `bun test tests/http/vector/`
- changed files ≤250 lines
