### PR TITLE
Make vector dashboard show collection health

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -3,6 +3,7 @@ import type {
   HealthResponse,
   MetricsSnapshot,
   PluginsResponse,
+  RuntimeStatus,
   VectorSearchResponse,
 } from '../../../src/server/types';
 import type { LearnCreateResponse, LearnDeleteResponse, LearnListResponse, LearnMutationPayload, LearnUpdateResponse } from '../types';
@@ -13,12 +14,41 @@ export interface MenuSearchResponse {
   total: number;
 }
 
+export interface VectorIndexModelEntry {
+  collection: string;
+  model: string;
+  adapter: string;
+  count?: number;
+}
+
+export interface VectorIndexModelsResponse {
+  models: Record<string, VectorIndexModelEntry>;
+}
+
+export interface VectorHealthEngine {
+  key?: string;
+  model?: string;
+  collection?: string;
+  ok?: boolean;
+  error?: string;
+}
+
+export interface VectorHealthResponse {
+  status: RuntimeStatus;
+  engines: VectorHealthEngine[];
+  checked_at: string;
+  proxy?: string;
+  error?: string;
+}
+
 export interface ApiRouteResponses {
   '/api/health': HealthResponse;
   '/api/v1/metrics': MetricsSnapshot;
   '/api/menu': MenuResponse;
   '/api/menu/search': MenuSearchResponse;
   '/api/vector/search': VectorSearchResponse;
+  '/api/vector/index/models': VectorIndexModelsResponse;
+  '/api/vector/health': VectorHealthResponse;
   '/api/v1/plugins': PluginsResponse;
   '/api/v1/learn': LearnListResponse;
 }
@@ -129,6 +159,14 @@ export class ApiClient {
 
   deleteLearn(id: string): Promise<LearnDeleteResponse> {
     return this.fetchJson(`/api/v1/learn/${encodeURIComponent(id)}`, { method: 'DELETE' });
+  }
+
+  vectorIndexModels(): Promise<VectorIndexModelsResponse> {
+    return this.request('/api/vector/index/models');
+  }
+
+  vectorHealth(): Promise<VectorHealthResponse> {
+    return this.request('/api/vector/health');
   }
 
   vectorSearch(query: string, limit?: number): Promise<VectorSearchResponse>;

--- a/frontend/src/pages/VectorPage.tsx
+++ b/frontend/src/pages/VectorPage.tsx
@@ -1,8 +1,169 @@
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { apiClient, type ApiClient, type VectorHealthResponse, type VectorIndexModelEntry, type VectorIndexModelsResponse } from '../api/client';
+import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
 import { VectorSearchWidget } from '../components/VectorSearchWidget';
 import { vectorResultsPath } from '../routePaths';
 
-export function VectorPage() {
+type PageState = 'loading' | 'ready' | 'error';
+type VectorStatusClient = Pick<ApiClient, 'vectorIndexModels' | 'vectorHealth'>;
+
+export interface VectorCollectionCard {
+  key: string;
+  collection: string;
+  adapter: string;
+  model: string;
+  count?: number;
+  healthy: boolean;
+  healthLabel: string;
+  healthDetail?: string;
+}
+
+export interface VectorPageProps {
+  modelsResponse?: VectorIndexModelsResponse | null;
+  healthResponse?: VectorHealthResponse | null;
+  loading?: boolean;
+  client?: VectorStatusClient;
+}
+
+function healthFor(key: string, model: VectorIndexModelEntry, health?: VectorHealthResponse | null) {
+  return health?.engines.find((engine) => (
+    engine.key === key || engine.collection === model.collection || engine.model === model.model
+  ));
+}
+
+function healthLabel(healthy: boolean, error?: string): string {
+  if (healthy) return 'Healthy';
+  return error ? 'Down' : 'Unavailable';
+}
+
+export function buildVectorCollectionCards(
+  modelsResponse?: VectorIndexModelsResponse | null,
+  healthResponse?: VectorHealthResponse | null,
+): VectorCollectionCard[] {
+  const models = modelsResponse?.models ?? {};
+  return Object.entries(models)
+    .map(([key, model]) => {
+      const engine = healthFor(key, model, healthResponse);
+      const healthy = engine ? engine.ok !== false : healthResponse?.status === 'ok';
+      const detail = engine?.error ?? healthResponse?.error;
+      return {
+        key,
+        collection: model.collection,
+        adapter: model.adapter || 'lancedb',
+        model: model.model,
+        count: model.count,
+        healthy,
+        healthLabel: healthLabel(healthy, detail),
+        healthDetail: detail,
+      };
+    })
+    .sort((left, right) => left.collection.localeCompare(right.collection));
+}
+
+export function vectorDashboardSummary(cards: VectorCollectionCard[], state: PageState): string {
+  if (state === 'loading') return 'Loading vector collections…';
+  if (state === 'error' && cards.length === 0) return 'Vector status is unavailable.';
+  if (cards.length === 0) return 'No vector collections are registered.';
+  const healthy = cards.filter((card) => card.healthy).length;
+  return `${healthy}/${cards.length} vector collections healthy.`;
+}
+
+function docCountLabel(count?: number): string {
+  if (typeof count !== 'number') return 'unknown docs';
+  return `${count.toLocaleString()} doc${count === 1 ? '' : 's'}`;
+}
+
+function statusClasses(healthy: boolean): string {
+  return healthy
+    ? 'border-emerald-300/30 bg-emerald-300/10 text-emerald-200'
+    : 'border-red-300/30 bg-red-300/10 text-red-100';
+}
+
+function VectorCollectionCards({ cards }: { cards: VectorCollectionCard[] }) {
+  return (
+    <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3" aria-label="Vector collections">
+      {cards.map((card) => (
+        <article key={card.key} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Collection</p>
+              <h2 className="mt-1 text-lg font-semibold text-white">{card.collection}</h2>
+            </div>
+            <span className={`inline-flex rounded-full border px-2 py-1 text-xs font-semibold ${statusClasses(card.healthy)}`}>
+              {card.healthLabel}
+            </span>
+          </div>
+          <dl className="mt-4 grid gap-3 text-sm">
+            <div>
+              <dt className="text-slate-500">Adapter</dt>
+              <dd className="font-medium text-slate-100">{card.adapter}</dd>
+            </div>
+            <div>
+              <dt className="text-slate-500">Model</dt>
+              <dd className="font-medium text-slate-100">{card.model}</dd>
+            </div>
+            <div>
+              <dt className="text-slate-500">Documents</dt>
+              <dd className="font-medium text-slate-100">{docCountLabel(card.count)}</dd>
+            </div>
+          </dl>
+          {card.healthDetail ? <p className="mt-3 text-xs text-red-200">{card.healthDetail}</p> : null}
+        </article>
+      ))}
+    </div>
+  );
+}
+
+export function VectorPage({ modelsResponse = null, healthResponse = null, loading = true, client = apiClient }: VectorPageProps) {
   const navigate = useNavigate();
-  return <VectorSearchWidget onOpenResults={(query) => navigate(vectorResultsPath(query))} />;
+  const [models, setModels] = useState(modelsResponse);
+  const [health, setHealth] = useState(healthResponse);
+  const [state, setState] = useState<PageState>(loading ? 'loading' : 'ready');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    setState('loading');
+    setError('');
+    Promise.all([client.vectorIndexModels(), client.vectorHealth()])
+      .then(([nextModels, nextHealth]) => {
+        if (cancelled) return;
+        setModels(nextModels);
+        setHealth(nextHealth);
+        setState('ready');
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+        setState(models ? 'ready' : 'error');
+      });
+    return () => { cancelled = true; };
+  }, [client]);
+
+  const cards = useMemo(() => buildVectorCollectionCards(models, health), [models, health]);
+  const summary = vectorDashboardSummary(cards, state);
+  const isLoading = state === 'loading';
+
+  return (
+    <div className="grid gap-5">
+      <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-status-title">
+        <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Vector status</p>
+            <h1 id="vector-status-title" className="mt-2 text-3xl font-semibold text-white">Vector dashboard</h1>
+            <p className="mt-2 text-sm text-slate-400">Collection health from /api/vector/index/models and /api/vector/health.</p>
+          </div>
+          <p className="rounded-full border border-white/10 px-3 py-2 text-sm text-slate-300">{summary}</p>
+        </div>
+
+        {isLoading ? <LoadingPanel title="Loading vector status…" detail="Fetching /api/vector/index/models and /api/vector/health." /> : null}
+        {state === 'error' ? <ErrorMessage title="Could not load vector status." message={error} /> : null}
+        {!isLoading && state !== 'error' && cards.length === 0 ? <p className="text-sm text-slate-400">No vector collections are registered.</p> : null}
+        {cards.length ? <VectorCollectionCards cards={cards} /> : null}
+      </section>
+
+      <VectorSearchWidget onOpenResults={(query) => navigate(vectorResultsPath(query))} />
+    </div>
+  );
 }

--- a/tests/frontend/api/vector-health-client.test.ts
+++ b/tests/frontend/api/vector-health-client.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test';
+import { createApiClient } from '../../../frontend/src/api/client';
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify(data), { headers: { 'content-type': 'application/json' } });
+}
+
+describe('ApiClient vectorHealth', () => {
+  test('fetches vector adapter health', async () => {
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    const client = createApiClient({
+      fetch: (input, init) => {
+        calls.push({ input, init });
+        return jsonResponse({ status: 'ok', engines: [{ key: 'bge', ok: true }], checked_at: 'now' });
+      },
+    });
+
+    await expect(client.vectorHealth()).resolves.toMatchObject({ status: 'ok', engines: [{ key: 'bge', ok: true }] });
+    expect(String(calls[0]?.input)).toBe('/api/vector/health');
+  });
+});

--- a/tests/frontend/api/vector-index-models-client.test.ts
+++ b/tests/frontend/api/vector-index-models-client.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+import { createApiClient } from '../../../frontend/src/api/client';
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify(data), { headers: { 'content-type': 'application/json' } });
+}
+
+describe('ApiClient vectorIndexModels', () => {
+  test('fetches the vector model registry endpoint', async () => {
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    const client = createApiClient({
+      fetch: (input, init) => {
+        calls.push({ input, init });
+        return jsonResponse({ models: { bge: { collection: 'oracle_bge', model: 'bge-m3', adapter: 'lancedb', count: 4 } } });
+      },
+    });
+
+    await expect(client.vectorIndexModels()).resolves.toMatchObject({ models: { bge: { count: 4 } } });
+    expect(String(calls[0]?.input)).toBe('/api/vector/index/models');
+    expect(new Headers(calls[0]?.init?.headers).get('accept')).toBe('application/json');
+  });
+});

--- a/tests/frontend/pages/vector-dashboard-cards.test.tsx
+++ b/tests/frontend/pages/vector-dashboard-cards.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test';
+import { MemoryRouter } from 'react-router-dom';
+import { VectorPage } from '../../../frontend/src/pages/VectorPage';
+import { htmlFor } from '../_render';
+
+const modelsResponse = {
+  models: {
+    bge: { collection: 'oracle_bge', model: 'BAAI/bge-m3', adapter: 'lancedb', count: 12 },
+    qwen: { collection: 'oracle_qwen', model: 'Qwen/qwen3', adapter: 'qdrant', count: 0 },
+  },
+};
+
+const healthResponse = {
+  status: 'degraded',
+  checked_at: '2026-06-16T00:00:00.000Z',
+  engines: [
+    { key: 'bge', collection: 'oracle_bge', model: 'BAAI/bge-m3', ok: true },
+    { key: 'qwen', collection: 'oracle_qwen', model: 'Qwen/qwen3', ok: false, error: 'timeout' },
+  ],
+};
+
+describe('VectorPage dashboard cards', () => {
+  test('renders collection status details above the search widget', () => {
+    const html = htmlFor(<MemoryRouter><VectorPage modelsResponse={modelsResponse} healthResponse={healthResponse} loading={false} /></MemoryRouter>);
+    expect(html).toContain('Vector dashboard');
+    expect(html).toContain('1/2 vector collections healthy.');
+    expect(html).toContain('oracle_bge');
+    expect(html).toContain('BAAI/bge-m3');
+    expect(html).toContain('12 docs');
+    expect(html).toContain('lancedb');
+    expect(html).toContain('qdrant');
+    expect(html).toContain('Down');
+    expect(html).toContain('timeout');
+    expect(html).toContain('Vector search');
+  });
+});

--- a/tests/frontend/pages/vector-dashboard-loading.test.tsx
+++ b/tests/frontend/pages/vector-dashboard-loading.test.tsx
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'bun:test';
+import { MemoryRouter } from 'react-router-dom';
+import { VectorPage } from '../../../frontend/src/pages/VectorPage';
+import { htmlFor } from '../_render';
+
+describe('VectorPage loading state', () => {
+  test('shows the vector status endpoints while loading', () => {
+    const html = htmlFor(<MemoryRouter><VectorPage /></MemoryRouter>);
+    expect(html).toContain('Loading vector status');
+    expect(html).toContain('/api/vector/index/models and /api/vector/health');
+  });
+});

--- a/tests/frontend/pages/vector-dashboard-summary.test.ts
+++ b/tests/frontend/pages/vector-dashboard-summary.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test';
+import { buildVectorCollectionCards, vectorDashboardSummary } from '../../../frontend/src/pages/VectorPage';
+
+describe('vectorDashboardSummary', () => {
+  test('counts healthy cards from model and health responses', () => {
+    const cards = buildVectorCollectionCards(
+      { models: { bge: { collection: 'bge_docs', model: 'bge-m3', adapter: 'lancedb', count: 1 } } },
+      { status: 'ok', engines: [{ key: 'bge', model: 'bge-m3', collection: 'bge_docs', ok: true }], checked_at: 'now' },
+    );
+
+    expect(cards).toMatchObject([{ collection: 'bge_docs', healthy: true, healthLabel: 'Healthy' }]);
+    expect(vectorDashboardSummary(cards, 'ready')).toBe('1/1 vector collections healthy.');
+  });
+});


### PR DESCRIPTION
## Summary\n- rewrote VectorPage into a vector status dashboard with collection cards\n- added typed apiClient methods for /api/vector/index/models and /api/vector/health\n- kept the existing vector search widget below the dashboard cards\n\n## Tests\n- bunx tsc --noEmit\n- bun test tests/frontend/\n\n## Notes\n- Local frontend tests required removing an untracked duplicate frontend/node_modules install from module resolution so React SSR used one React copy.