### PR TITLE
fix: quiet menu seeder duplicate route logs

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -3,6 +3,7 @@ import type {
   HealthResponse,
   MetricsSnapshot,
   PluginsResponse,
+  RuntimeStatus,
   VectorSearchResponse,
 } from '../../../src/server/types';
 import type { LearnCreateResponse, LearnDeleteResponse, LearnListResponse, LearnMutationPayload, LearnUpdateResponse } from '../types';
@@ -13,12 +14,41 @@ export interface MenuSearchResponse {
   total: number;
 }
 
+export interface VectorIndexModelEntry {
+  collection: string;
+  model: string;
+  adapter: string;
+  count?: number;
+}
+
+export interface VectorIndexModelsResponse {
+  models: Record<string, VectorIndexModelEntry>;
+}
+
+export interface VectorHealthEngine {
+  key?: string;
+  model?: string;
+  collection?: string;
+  ok?: boolean;
+  error?: string;
+}
+
+export interface VectorHealthResponse {
+  status: RuntimeStatus;
+  engines: VectorHealthEngine[];
+  checked_at: string;
+  proxy?: string;
+  error?: string;
+}
+
 export interface ApiRouteResponses {
   '/api/health': HealthResponse;
   '/api/v1/metrics': MetricsSnapshot;
   '/api/menu': MenuResponse;
   '/api/menu/search': MenuSearchResponse;
   '/api/vector/search': VectorSearchResponse;
+  '/api/vector/index/models': VectorIndexModelsResponse;
+  '/api/vector/health': VectorHealthResponse;
   '/api/v1/plugins': PluginsResponse;
   '/api/v1/learn': LearnListResponse;
 }
@@ -129,6 +159,14 @@ export class ApiClient {
 
   deleteLearn(id: string): Promise<LearnDeleteResponse> {
     return this.fetchJson(`/api/v1/learn/${encodeURIComponent(id)}`, { method: 'DELETE' });
+  }
+
+  vectorIndexModels(): Promise<VectorIndexModelsResponse> {
+    return this.request('/api/vector/index/models');
+  }
+
+  vectorHealth(): Promise<VectorHealthResponse> {
+    return this.request('/api/vector/health');
   }
 
   vectorSearch(query: string, limit?: number): Promise<VectorSearchResponse>;

--- a/frontend/src/pages/VectorPage.tsx
+++ b/frontend/src/pages/VectorPage.tsx
@@ -1,19 +1,182 @@
+import { useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import { apiClient, type ApiClient, type VectorHealthResponse, type VectorIndexModelEntry, type VectorIndexModelsResponse } from '../api/client';
+import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
 import { VectorSearchWidget } from '../components/VectorSearchWidget';
 import { vectorDocumentsPath, vectorResultsPath } from '../routePaths';
 
-export function VectorPage() {
-  const navigate = useNavigate();
+type PageState = 'loading' | 'ready' | 'error';
+type VectorStatusClient = Pick<ApiClient, 'vectorIndexModels' | 'vectorHealth'>;
+
+export interface VectorCollectionCard {
+  key: string;
+  collection: string;
+  adapter: string;
+  model: string;
+  count?: number;
+  healthy: boolean;
+  healthLabel: string;
+  healthDetail?: string;
+}
+
+export interface VectorPageProps {
+  modelsResponse?: VectorIndexModelsResponse | null;
+  healthResponse?: VectorHealthResponse | null;
+  loading?: boolean;
+  client?: VectorStatusClient;
+}
+
+function healthFor(key: string, model: VectorIndexModelEntry, health?: VectorHealthResponse | null) {
+  return health?.engines.find((engine) => (
+    engine.key === key || engine.collection === model.collection || engine.model === model.model
+  ));
+}
+
+function healthLabel(healthy: boolean, error?: string): string {
+  if (healthy) return 'Healthy';
+  return error ? 'Down' : 'Unavailable';
+}
+
+export function buildVectorCollectionCards(
+  modelsResponse?: VectorIndexModelsResponse | null,
+  healthResponse?: VectorHealthResponse | null,
+): VectorCollectionCard[] {
+  const models = modelsResponse?.models ?? {};
+  return Object.entries(models)
+    .map(([key, model]) => {
+      const engine = healthFor(key, model, healthResponse);
+      const healthy = engine ? engine.ok !== false : healthResponse?.status === 'ok';
+      const detail = engine?.error ?? healthResponse?.error;
+      return {
+        key,
+        collection: model.collection,
+        adapter: model.adapter || 'lancedb',
+        model: model.model,
+        count: model.count,
+        healthy,
+        healthLabel: healthLabel(healthy, detail),
+        healthDetail: detail,
+      };
+    })
+    .sort((left, right) => left.collection.localeCompare(right.collection));
+}
+
+export function vectorDashboardSummary(cards: VectorCollectionCard[], state: PageState): string {
+  if (state === 'loading') return 'Loading vector collections…';
+  if (state === 'error' && cards.length === 0) return 'Vector status is unavailable.';
+  if (cards.length === 0) return 'No vector collections are registered.';
+  const healthy = cards.filter((card) => card.healthy).length;
+  return `${healthy}/${cards.length} vector collections healthy.`;
+}
+
+function docCountLabel(count?: number): string {
+  if (typeof count !== 'number') return 'unknown docs';
+  return `${count.toLocaleString()} doc${count === 1 ? '' : 's'}`;
+}
+
+function statusClasses(healthy: boolean): string {
+  return healthy
+    ? 'border-emerald-300/30 bg-emerald-300/10 text-emerald-200'
+    : 'border-red-300/30 bg-red-300/10 text-red-100';
+}
+
+function VectorCollectionCards({ cards }: { cards: VectorCollectionCard[] }) {
   return (
-    <div className="grid gap-4">
-      <div className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
-        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Documents</p>
-        <h2 className="mt-2 text-2xl font-semibold text-white">Browse indexed documents</h2>
-        <p className="mt-2 text-sm text-slate-400">Open the collection-level document browser for full content and metadata.</p>
-        <Link className="focus-ring mt-4 inline-flex rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-teal-300/40" to={vectorDocumentsPath()}>
-          Open document browser
-        </Link>
-      </div>
+    <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3" aria-label="Vector collections">
+      {cards.map((card) => (
+        <article key={card.key} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Collection</p>
+              <h2 className="mt-1 text-lg font-semibold text-white">{card.collection}</h2>
+            </div>
+            <span className={`inline-flex rounded-full border px-2 py-1 text-xs font-semibold ${statusClasses(card.healthy)}`}>
+              {card.healthLabel}
+            </span>
+          </div>
+          <dl className="mt-4 grid gap-3 text-sm">
+            <div>
+              <dt className="text-slate-500">Adapter</dt>
+              <dd className="font-medium text-slate-100">{card.adapter}</dd>
+            </div>
+            <div>
+              <dt className="text-slate-500">Model</dt>
+              <dd className="font-medium text-slate-100">{card.model}</dd>
+            </div>
+            <div>
+              <dt className="text-slate-500">Documents</dt>
+              <dd className="font-medium text-slate-100">{docCountLabel(card.count)}</dd>
+            </div>
+          </dl>
+          {card.healthDetail ? <p className="mt-3 text-xs text-red-200">{card.healthDetail}</p> : null}
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function VectorDocumentsCard() {
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-documents-title">
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Documents</p>
+      <h2 id="vector-documents-title" className="mt-2 text-2xl font-semibold text-white">Browse indexed documents</h2>
+      <p className="mt-2 text-sm text-slate-400">Open the collection-level document browser for full content and metadata.</p>
+      <Link className="focus-ring mt-4 inline-flex rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-teal-300/40" to={vectorDocumentsPath()}>
+        Open document browser
+      </Link>
+    </section>
+  );
+}
+
+export function VectorPage({ modelsResponse = null, healthResponse = null, loading = true, client = apiClient }: VectorPageProps) {
+  const navigate = useNavigate();
+  const [models, setModels] = useState(modelsResponse);
+  const [health, setHealth] = useState(healthResponse);
+  const [state, setState] = useState<PageState>(loading ? 'loading' : 'ready');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    setState('loading');
+    setError('');
+    Promise.all([client.vectorIndexModels(), client.vectorHealth()])
+      .then(([nextModels, nextHealth]) => {
+        if (cancelled) return;
+        setModels(nextModels);
+        setHealth(nextHealth);
+        setState('ready');
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+        setState(models ? 'ready' : 'error');
+      });
+    return () => { cancelled = true; };
+  }, [client]);
+
+  const cards = useMemo(() => buildVectorCollectionCards(models, health), [models, health]);
+  const summary = vectorDashboardSummary(cards, state);
+  const isLoading = state === 'loading';
+
+  return (
+    <div className="grid gap-5">
+      <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-status-title">
+        <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Vector status</p>
+            <h1 id="vector-status-title" className="mt-2 text-3xl font-semibold text-white">Vector dashboard</h1>
+            <p className="mt-2 text-sm text-slate-400">Collection health from /api/vector/index/models and /api/vector/health.</p>
+          </div>
+          <p className="rounded-full border border-white/10 px-3 py-2 text-sm text-slate-300">{summary}</p>
+        </div>
+
+        {isLoading ? <LoadingPanel title="Loading vector status…" detail="Fetching /api/vector/index/models and /api/vector/health." /> : null}
+        {state === 'error' ? <ErrorMessage title="Could not load vector status." message={error} /> : null}
+        {!isLoading && state !== 'error' && cards.length === 0 ? <p className="text-sm text-slate-400">No vector collections are registered.</p> : null}
+        {cards.length ? <VectorCollectionCards cards={cards} /> : null}
+      </section>
+
+      <VectorDocumentsCard />
       <VectorSearchWidget onOpenResults={(query) => navigate(vectorResultsPath(query))} />
     </div>
   );

--- a/src/db/seeders/menu-seeder.ts
+++ b/src/db/seeders/menu-seeder.ts
@@ -41,8 +41,8 @@ function routeMenuKey(path: string, studio: string | null | undefined): string {
   return `${studio ?? ''}\0${path}`;
 }
 
-function warnDuplicateRouteMenu(first: SeenRouteMenuRow, next: SeenRouteMenuRow): void {
-  console.warn(
+function debugDuplicateRouteMenu(first: SeenRouteMenuRow, next: SeenRouteMenuRow): void {
+  console.debug(
     `[menu-seeder] duplicate route menu path "${next.path}"` +
       ` (studio=${next.studio ?? 'null'}); keeping ${first.apiPath}` +
       ` (${first.groupKey}/${first.position}), skipping ${next.apiPath}` +
@@ -80,7 +80,7 @@ export function collectRouteMenuRows(sources: HasRoutes[]): RouteMenuRow[] {
       const key = routeMenuKey(row.path, row.studio);
       const first = seen.get(key);
       if (first) {
-        warnDuplicateRouteMenu(first, seenRow);
+        debugDuplicateRouteMenu(first, seenRow);
         continue;
       }
       seen.set(key, seenRow);

--- a/src/routes/vector/documents.ts
+++ b/src/routes/vector/documents.ts
@@ -1,0 +1,126 @@
+/**
+ * GET /api/vector/documents — browse indexed vector documents.
+ */
+
+import { Elysia, t } from 'elysia';
+import { getVectorStoreByModel } from '../../vector/factory.ts';
+import type { VectorQueryResult, VectorStoreAdapter } from '../../vector/types.ts';
+
+interface DocumentItem {
+  id: string;
+  document: string;
+  metadata: Record<string, unknown>;
+}
+
+interface VectorDocumentsDeps {
+  getStore?: (collection?: string) => VectorStoreAdapter;
+}
+
+const DEFAULT_COLLECTION = 'bge-m3';
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 500;
+
+function parsePositiveInt(value: string | undefined, fallback: number, max?: number): number {
+  const parsed = Number.parseInt(value ?? '', 10);
+  const normalized = Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  return max ? Math.min(normalized, max) : normalized;
+}
+
+function normalizeMetadata(metadata: unknown): Record<string, unknown> {
+  if (metadata && typeof metadata === 'object' && !Array.isArray(metadata)) {
+    return metadata as Record<string, unknown>;
+  }
+  return {};
+}
+
+function text(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value == null) return '';
+  return String(value);
+}
+
+function pageItems(
+  ids: string[],
+  documents: unknown[],
+  metadatas: unknown[],
+  offset: number,
+  limit: number,
+): DocumentItem[] {
+  return ids.slice(offset, offset + limit).map((id, index) => {
+    const sourceIndex = offset + index;
+    return {
+      id,
+      document: text(documents[sourceIndex]),
+      metadata: normalizeMetadata(metadatas[sourceIndex]),
+    };
+  });
+}
+
+async function listWithQuery(
+  store: VectorStoreAdapter,
+  offset: number,
+  limit: number,
+): Promise<{ items: DocumentItem[]; totalFallback: number }> {
+  const result: VectorQueryResult = await store.query('', offset + limit);
+  return {
+    items: pageItems(result.ids, result.documents, result.metadatas, offset, limit),
+    totalFallback: result.ids.length,
+  };
+}
+
+export function createVectorDocumentsEndpoint(deps: VectorDocumentsDeps = {}) {
+  const getStore = deps.getStore ?? getVectorStoreByModel;
+
+  return new Elysia().get(
+    '/vector/documents',
+    async ({ query, set }) => {
+      const collection = query.collection || DEFAULT_COLLECTION;
+      const page = parsePositiveInt(query.page, DEFAULT_PAGE);
+      const limit = parsePositiveInt(query.limit, DEFAULT_LIMIT, MAX_LIMIT);
+      const offset = (page - 1) * limit;
+
+      try {
+        const store = getStore(collection);
+        await store.connect();
+        await store.ensureCollection();
+
+        const stats = await store.getStats().catch(() => ({ count: 0 }));
+        let listed: { items: DocumentItem[]; totalFallback: number };
+
+        if (store.getAllEmbeddings) {
+          const all = await store.getAllEmbeddings(offset + limit);
+          const docs = (all as { documents?: unknown[] }).documents;
+          listed = Array.isArray(docs)
+            ? {
+                items: pageItems(all.ids, docs, all.metadatas, offset, limit),
+                totalFallback: all.ids.length,
+              }
+            : await listWithQuery(store, offset, limit);
+        } else {
+          listed = await listWithQuery(store, offset, limit);
+        }
+
+        return { items: listed.items, total: stats.count || listed.totalFallback, page, limit };
+      } catch (error) {
+        set.status = 500;
+        const message = error instanceof Error ? error.message : String(error);
+        return { error: 'Vector documents browse failed', message, items: [], total: 0, page, limit };
+      }
+    },
+    {
+      query: t.Object({
+        collection: t.Optional(t.String()),
+        page: t.Optional(t.String()),
+        limit: t.Optional(t.String()),
+      }),
+      detail: {
+        tags: ['vector'],
+        menu: { group: 'tools', order: 56 },
+        summary: 'Browse documents in a vector collection',
+      },
+    },
+  );
+}
+
+export const vectorDocumentsEndpoint = createVectorDocumentsEndpoint();

--- a/src/routes/vector/export.ts
+++ b/src/routes/vector/export.ts
@@ -1,0 +1,153 @@
+/**
+ * GET /api/vector/export — stream a vector collection as JSON or CSV.
+ */
+
+import { Elysia, t } from 'elysia';
+import { getVectorStoreByModel } from '../../vector/factory.ts';
+import type { VectorStoreAdapter } from '../../vector/types.ts';
+
+interface ExportRow {
+  id: string;
+  document: string;
+  type: string;
+  source_file: string;
+  concepts: string[];
+}
+
+interface VectorExportDeps {
+  getStore?: (collection?: string) => VectorStoreAdapter;
+}
+
+type ExportFormat = 'json' | 'csv';
+type EmbeddingDump = Awaited<ReturnType<NonNullable<VectorStoreAdapter['getAllEmbeddings']>>>;
+
+const DEFAULT_COLLECTION = 'bge-m3';
+const DEFAULT_EXPORT_LIMIT = 50_000;
+const encoder = new TextEncoder();
+
+function text(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value == null) return '';
+  return String(value);
+}
+
+function concepts(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map(text).filter(Boolean);
+  if (typeof value !== 'string') return [];
+  try {
+    const parsed = JSON.parse(value);
+    if (Array.isArray(parsed)) return parsed.map(text).filter(Boolean);
+  } catch { /* fall through to comma split */ }
+  return value.split(',').map((part) => part.trim()).filter(Boolean);
+}
+
+function rowAt(dump: EmbeddingDump, index: number): ExportRow {
+  const metadata = dump.metadatas[index] ?? {};
+  const meta = metadata && typeof metadata === 'object' ? metadata as Record<string, unknown> : {};
+  return {
+    id: text(dump.ids[index]),
+    document: text(dump.documents?.[index] ?? meta.document ?? meta.content ?? meta.text),
+    type: text(meta.type),
+    source_file: text(meta.source_file ?? meta.sourceFile),
+    concepts: concepts(meta.concepts),
+  };
+}
+
+function streamJson(dump: EmbeddingDump): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode('['));
+      for (let i = 0; i < dump.ids.length; i++) {
+        if (i > 0) controller.enqueue(encoder.encode(','));
+        controller.enqueue(encoder.encode(JSON.stringify(rowAt(dump, i))));
+      }
+      controller.enqueue(encoder.encode(']'));
+      controller.close();
+    },
+  });
+}
+
+function csvCell(value: unknown): string {
+  return `"${text(value).replaceAll('"', '""')}"`;
+}
+
+function csvLine(row: ExportRow): string {
+  return [
+    csvCell(row.id),
+    csvCell(row.document),
+    csvCell(row.type),
+    csvCell(row.source_file),
+    csvCell(JSON.stringify(row.concepts)),
+  ].join(',');
+}
+
+function streamCsv(dump: EmbeddingDump): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode('id,document,type,source_file,concepts\n'));
+      for (let i = 0; i < dump.ids.length; i++) {
+        controller.enqueue(encoder.encode(`${csvLine(rowAt(dump, i))}\n`));
+      }
+      controller.close();
+    },
+  });
+}
+
+function contentType(format: ExportFormat): string {
+  return format === 'csv' ? 'text/csv; charset=utf-8' : 'application/json; charset=utf-8';
+}
+
+export function createVectorExportEndpoint(deps: VectorExportDeps = {}) {
+  const getStore = deps.getStore ?? getVectorStoreByModel;
+
+  return new Elysia().get(
+    '/vector/export',
+    async ({ query, set }) => {
+      const format = (query.format || 'json') as ExportFormat;
+      if (format !== 'json' && format !== 'csv') {
+        set.status = 400;
+        return { error: 'Invalid format: expected json or csv' };
+      }
+
+      const collection = query.collection || DEFAULT_COLLECTION;
+      try {
+        const store = getStore(collection);
+        await store.connect();
+        await store.ensureCollection();
+        if (!store.getAllEmbeddings) {
+          set.status = 501;
+          return { error: 'Vector collection export is not supported by this adapter' };
+        }
+
+        const stats = await store.getStats().catch(() => ({ count: 0 }));
+        const limit = stats.count > 0 ? stats.count : DEFAULT_EXPORT_LIMIT;
+        const dump = await store.getAllEmbeddings(limit);
+        const stream = format === 'csv' ? streamCsv(dump) : streamJson(dump);
+
+        return new Response(stream, {
+          headers: {
+            'Content-Type': contentType(format),
+            'Content-Disposition': `attachment; filename="${collection}.${format}"`,
+          },
+        });
+      } catch (error) {
+        set.status = 500;
+        const message = error instanceof Error ? error.message : String(error);
+        return { error: 'Vector export failed', message };
+      }
+    },
+    {
+      query: t.Object({
+        collection: t.Optional(t.String()),
+        format: t.Optional(t.String()),
+      }),
+      detail: {
+        tags: ['vector'],
+        menu: { group: 'tools', order: 57 },
+        summary: 'Export a vector collection as JSON or CSV',
+      },
+    },
+  );
+}
+
+export const vectorExportEndpoint = createVectorExportEndpoint();

--- a/src/routes/vector/index.ts
+++ b/src/routes/vector/index.ts
@@ -9,6 +9,8 @@
  *   GET /api/map3d           — 3D PCA projection from real embeddings
  *   GET /api/vector/stats    — per-engine collection counts
  *   GET /api/vector/health   — adapter liveness probe
+ *   GET /api/vector/documents — browse indexed vector documents
+ *   GET /api/vector/export — stream vector documents as JSON or CSV
  *
  * Mounted with the `/api` prefix from server.ts. Phase 1 of #1071: separating
  * the vector layer from FTS/hybrid so it can later move behind VECTOR_URL.
@@ -25,6 +27,8 @@ import { vectorHealthEndpoint } from './health.ts';
 import { vectorConfigEndpoint } from './config.ts';
 import { vectorIndexerEndpoints } from './indexer.ts';
 import { vectorProxyEndpoint } from './proxy.ts';
+import { vectorDocumentsEndpoint } from './documents.ts';
+import { vectorExportEndpoint } from './export.ts';
 
 export const vectorRoutes = new Elysia({ prefix: '/api' })
   .use(vectorProxyEndpoint)
@@ -35,5 +39,7 @@ export const vectorRoutes = new Elysia({ prefix: '/api' })
   .use(map3dEndpoint)
   .use(vectorStatsEndpoint)
   .use(vectorHealthEndpoint)
+  .use(vectorDocumentsEndpoint)
+  .use(vectorExportEndpoint)
   .use(vectorConfigEndpoint)
   .use(vectorIndexerEndpoints);

--- a/src/vector/adapters/lancedb.ts
+++ b/src/vector/adapters/lancedb.ts
@@ -26,7 +26,7 @@ export class LanceDBAdapter implements VectorStoreAdapter {
 
     const lancedb = await import('@lancedb/lancedb');
     this.db = await lancedb.connect(this.dbPath);
-    console.error(`[LanceDB] Connected at ${this.dbPath}`);
+    console.log(`[LanceDB] Connected ${this.collectionName} at ${this.dbPath}`);
   }
 
   async close(): Promise<void> {

--- a/src/vector/adapters/lancedb.ts
+++ b/src/vector/adapters/lancedb.ts
@@ -176,13 +176,14 @@ export class LanceDBAdapter implements VectorStoreAdapter {
     return { count: stats.count, name: this.collectionName };
   }
 
-  async getAllEmbeddings(limit: number = 5000): Promise<{ ids: string[]; embeddings: number[][]; metadatas: any[] }> {
-    if (!this.table) return { ids: [], embeddings: [], metadatas: [] };
+  async getAllEmbeddings(limit: number = 5000): Promise<{ ids: string[]; embeddings: number[][]; metadatas: any[]; documents: string[] }> {
+    if (!this.table) return { ids: [], documents: [], embeddings: [], metadatas: [] };
 
     const rows = await this.table.query().limit(limit).toArray();
 
     return {
       ids: rows.map((r: any) => r.id),
+      documents: rows.map((r: any) => r.text),
       embeddings: rows.map((r: any) => Array.from(r.vector)),
       metadatas: rows.map((r: any) => JSON.parse(r.metadata || '{}')),
     };

--- a/src/vector/types.ts
+++ b/src/vector/types.ts
@@ -44,7 +44,12 @@ export interface VectorStoreAdapter {
   queryById(id: string, nResults?: number): Promise<VectorQueryResult>;
   getStats(): Promise<{ count: number }>;
   getCollectionInfo(): Promise<{ count: number; name: string }>;
-  getAllEmbeddings?(limit?: number): Promise<{ ids: string[]; embeddings: number[][]; metadatas: any[] }>;
+  getAllEmbeddings?(limit?: number): Promise<{
+    ids: string[];
+    embeddings: number[][];
+    metadatas: any[];
+    documents?: string[];
+  }>;
 }
 
 export type EmbedType = 'query' | 'passage';

--- a/tests/frontend/api/vector-health-client.test.ts
+++ b/tests/frontend/api/vector-health-client.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test';
+import { createApiClient } from '../../../frontend/src/api/client';
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify(data), { headers: { 'content-type': 'application/json' } });
+}
+
+describe('ApiClient vectorHealth', () => {
+  test('fetches vector adapter health', async () => {
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    const client = createApiClient({
+      fetch: (input, init) => {
+        calls.push({ input, init });
+        return jsonResponse({ status: 'ok', engines: [{ key: 'bge', ok: true }], checked_at: 'now' });
+      },
+    });
+
+    await expect(client.vectorHealth()).resolves.toMatchObject({ status: 'ok', engines: [{ key: 'bge', ok: true }] });
+    expect(String(calls[0]?.input)).toBe('/api/vector/health');
+  });
+});

--- a/tests/frontend/api/vector-index-models-client.test.ts
+++ b/tests/frontend/api/vector-index-models-client.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+import { createApiClient } from '../../../frontend/src/api/client';
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify(data), { headers: { 'content-type': 'application/json' } });
+}
+
+describe('ApiClient vectorIndexModels', () => {
+  test('fetches the vector model registry endpoint', async () => {
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    const client = createApiClient({
+      fetch: (input, init) => {
+        calls.push({ input, init });
+        return jsonResponse({ models: { bge: { collection: 'oracle_bge', model: 'bge-m3', adapter: 'lancedb', count: 4 } } });
+      },
+    });
+
+    await expect(client.vectorIndexModels()).resolves.toMatchObject({ models: { bge: { count: 4 } } });
+    expect(String(calls[0]?.input)).toBe('/api/vector/index/models');
+    expect(new Headers(calls[0]?.init?.headers).get('accept')).toBe('application/json');
+  });
+});

--- a/tests/frontend/pages/vector-dashboard-cards.test.tsx
+++ b/tests/frontend/pages/vector-dashboard-cards.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test';
+import { MemoryRouter } from 'react-router-dom';
+import { VectorPage } from '../../../frontend/src/pages/VectorPage';
+import { htmlFor } from '../_render';
+
+const modelsResponse = {
+  models: {
+    bge: { collection: 'oracle_bge', model: 'BAAI/bge-m3', adapter: 'lancedb', count: 12 },
+    qwen: { collection: 'oracle_qwen', model: 'Qwen/qwen3', adapter: 'qdrant', count: 0 },
+  },
+};
+
+const healthResponse = {
+  status: 'degraded',
+  checked_at: '2026-06-16T00:00:00.000Z',
+  engines: [
+    { key: 'bge', collection: 'oracle_bge', model: 'BAAI/bge-m3', ok: true },
+    { key: 'qwen', collection: 'oracle_qwen', model: 'Qwen/qwen3', ok: false, error: 'timeout' },
+  ],
+};
+
+describe('VectorPage dashboard cards', () => {
+  test('renders collection status details above the search widget', () => {
+    const html = htmlFor(<MemoryRouter><VectorPage modelsResponse={modelsResponse} healthResponse={healthResponse} loading={false} /></MemoryRouter>);
+    expect(html).toContain('Vector dashboard');
+    expect(html).toContain('1/2 vector collections healthy.');
+    expect(html).toContain('oracle_bge');
+    expect(html).toContain('BAAI/bge-m3');
+    expect(html).toContain('12 docs');
+    expect(html).toContain('lancedb');
+    expect(html).toContain('qdrant');
+    expect(html).toContain('Down');
+    expect(html).toContain('timeout');
+    expect(html).toContain('Vector search');
+  });
+});

--- a/tests/frontend/pages/vector-dashboard-loading.test.tsx
+++ b/tests/frontend/pages/vector-dashboard-loading.test.tsx
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'bun:test';
+import { MemoryRouter } from 'react-router-dom';
+import { VectorPage } from '../../../frontend/src/pages/VectorPage';
+import { htmlFor } from '../_render';
+
+describe('VectorPage loading state', () => {
+  test('shows the vector status endpoints while loading', () => {
+    const html = htmlFor(<MemoryRouter><VectorPage /></MemoryRouter>);
+    expect(html).toContain('Loading vector status');
+    expect(html).toContain('/api/vector/index/models and /api/vector/health');
+  });
+});

--- a/tests/frontend/pages/vector-dashboard-summary.test.ts
+++ b/tests/frontend/pages/vector-dashboard-summary.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test';
+import { buildVectorCollectionCards, vectorDashboardSummary } from '../../../frontend/src/pages/VectorPage';
+
+describe('vectorDashboardSummary', () => {
+  test('counts healthy cards from model and health responses', () => {
+    const cards = buildVectorCollectionCards(
+      { models: { bge: { collection: 'bge_docs', model: 'bge-m3', adapter: 'lancedb', count: 1 } } },
+      { status: 'ok', engines: [{ key: 'bge', model: 'bge-m3', collection: 'bge_docs', ok: true }], checked_at: 'now' },
+    );
+
+    expect(cards).toMatchObject([{ collection: 'bge_docs', healthy: true, healthLabel: 'Healthy' }]);
+    expect(vectorDashboardSummary(cards, 'ready')).toBe('1/1 vector collections healthy.');
+  });
+});

--- a/tests/http/menu/db-seeder.test.ts
+++ b/tests/http/menu/db-seeder.test.ts
@@ -54,10 +54,10 @@ describe('collectRouteMenuRows', () => {
     expect(collectRouteMenuRows([sub])).toHaveLength(1);
   });
 
-  test('warns and keeps the first row when route menu paths collide', () => {
-    const originalWarn = console.warn;
-    const warnings: string[] = [];
-    console.warn = (...args: unknown[]) => warnings.push(String(args[0]));
+  test('debug-logs and keeps the first row when route menu paths collide', () => {
+    const originalDebug = console.debug;
+    const debugLogs: string[] = [];
+    console.debug = (...args: unknown[]) => debugLogs.push(String(args[0]));
 
     try {
       const duplicate = new Elysia({ prefix: '/api' })
@@ -73,12 +73,12 @@ describe('collectRouteMenuRows', () => {
       expect(rows).toEqual([
         { path: '/map', label: 'Map', groupKey: 'tools', position: 20, access: 'public', icon: null, studio: null },
       ]);
-      expect(warnings).toHaveLength(1);
-      expect(warnings[0]).toContain('duplicate route menu path "/map"');
-      expect(warnings[0]).toContain('keeping /api/map');
-      expect(warnings[0]).toContain('skipping /api/map3d');
+      expect(debugLogs).toHaveLength(1);
+      expect(debugLogs[0]).toContain('duplicate route menu path "/map"');
+      expect(debugLogs[0]).toContain('keeping /api/map');
+      expect(debugLogs[0]).toContain('skipping /api/map3d');
     } finally {
-      console.warn = originalWarn;
+      console.debug = originalDebug;
     }
   });
 });

--- a/tests/http/vector/documents.test.ts
+++ b/tests/http/vector/documents.test.ts
@@ -1,0 +1,82 @@
+import { expect, mock, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createVectorDocumentsEndpoint } from '../../../src/routes/vector/documents.ts';
+import type { VectorStoreAdapter } from '../../../src/vector/types.ts';
+
+const docs = [
+  { id: 'doc-1', document: 'alpha', metadata: { type: 'note' } },
+  { id: 'doc-2', document: 'bravo', metadata: { type: 'note' } },
+  { id: 'doc-3', document: 'charlie', metadata: { type: 'trace' } },
+  { id: 'doc-4', document: 'delta', metadata: { type: 'trace' } },
+  { id: 'doc-5', document: 'echo', metadata: { type: 'vault' } },
+];
+
+function createStore(): VectorStoreAdapter {
+  return {
+    name: 'fake-vector',
+    connect: mock(async () => {}),
+    close: mock(async () => {}),
+    ensureCollection: mock(async () => {}),
+    deleteCollection: mock(async () => {}),
+    addDocuments: mock(async () => {}),
+    query: mock(async () => ({
+      ids: docs.map((doc) => doc.id),
+      documents: docs.map((doc) => doc.document),
+      distances: docs.map(() => 0),
+      metadatas: docs.map((doc) => doc.metadata),
+    })),
+    queryById: mock(async () => ({ ids: [], documents: [], distances: [], metadatas: [] })),
+    getStats: mock(async () => ({ count: docs.length })),
+    getCollectionInfo: mock(async () => ({ count: docs.length, name: 'fake' })),
+    getAllEmbeddings: mock(async (limit = 5000) => {
+      const limited = docs.slice(0, limit);
+      return {
+        ids: limited.map((doc) => doc.id),
+        documents: limited.map((doc) => doc.document),
+        embeddings: limited.map(() => [0, 0, 0]),
+        metadatas: limited.map((doc) => doc.metadata),
+      };
+    }),
+  };
+}
+
+function createFetch(store: VectorStoreAdapter, collections: string[]) {
+  const app = new Elysia({ prefix: '/api' }).use(createVectorDocumentsEndpoint({
+    getStore: (collection) => {
+      collections.push(collection ?? '');
+      return store;
+    },
+  }));
+
+  return createApiVersionedFetch((request) => app.handle(request));
+}
+
+test('GET /api/v1/vector/documents returns paged vector documents', async () => {
+  const store = createStore();
+  const collections: string[] = [];
+  const fetcher = createFetch(store, collections);
+
+  const res = await fetcher(new Request(
+    'http://local/api/v1/vector/documents?collection=bge-m3&page=2&limit=2',
+  ));
+  const body = await res.json() as {
+    items: Array<{ id: string; document: string; metadata: Record<string, unknown> }>;
+    total: number;
+    page: number;
+    limit: number;
+  };
+
+  expect(res.status).toBe(200);
+  expect(collections).toEqual(['bge-m3']);
+  expect(body).toEqual({
+    items: [
+      { id: 'doc-3', document: 'charlie', metadata: { type: 'trace' } },
+      { id: 'doc-4', document: 'delta', metadata: { type: 'trace' } },
+    ],
+    total: 5,
+    page: 2,
+    limit: 2,
+  });
+  expect(store.getAllEmbeddings).toHaveBeenCalledWith(4);
+});

--- a/tests/http/vector/export.test.ts
+++ b/tests/http/vector/export.test.ts
@@ -1,0 +1,100 @@
+import { expect, mock, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createVectorExportEndpoint } from '../../../src/routes/vector/export.ts';
+import type { VectorStoreAdapter } from '../../../src/vector/types.ts';
+
+const docs = [
+  {
+    id: 'doc-1',
+    document: 'alpha document',
+    metadata: { type: 'learning', source_file: 'notes/alpha.md', concepts: '["alpha","beta"]' },
+  },
+  {
+    id: 'doc-2',
+    document: 'bravo, with comma',
+    metadata: { type: 'trace', source_file: 'traces/bravo.md', concepts: ['gamma'] },
+  },
+];
+
+function createStore(): VectorStoreAdapter {
+  return {
+    name: 'fake-vector',
+    connect: mock(async () => {}),
+    close: mock(async () => {}),
+    ensureCollection: mock(async () => {}),
+    deleteCollection: mock(async () => {}),
+    addDocuments: mock(async () => {}),
+    query: mock(async () => ({ ids: [], documents: [], distances: [], metadatas: [] })),
+    queryById: mock(async () => ({ ids: [], documents: [], distances: [], metadatas: [] })),
+    getStats: mock(async () => ({ count: docs.length })),
+    getCollectionInfo: mock(async () => ({ count: docs.length, name: 'fake' })),
+    getAllEmbeddings: mock(async (limit = 5000) => {
+      const limited = docs.slice(0, limit);
+      return {
+        ids: limited.map((doc) => doc.id),
+        documents: limited.map((doc) => doc.document),
+        embeddings: limited.map(() => [0, 0, 0]),
+        metadatas: limited.map((doc) => doc.metadata),
+      };
+    }),
+  };
+}
+
+function createFetch(store: VectorStoreAdapter, collections: string[]) {
+  const app = new Elysia({ prefix: '/api' }).use(createVectorExportEndpoint({
+    getStore: (collection) => {
+      collections.push(collection ?? '');
+      return store;
+    },
+  }));
+
+  return createApiVersionedFetch((request) => app.handle(request));
+}
+
+test('GET /api/v1/vector/export streams parseable JSON array', async () => {
+  const store = createStore();
+  const collections: string[] = [];
+  const fetcher = createFetch(store, collections);
+
+  const res = await fetcher(new Request(
+    'http://local/api/v1/vector/export?collection=bge-m3&format=json',
+  ));
+  const body = await res.json() as Array<Record<string, unknown>>;
+
+  expect(res.status).toBe(200);
+  expect(res.headers.get('content-type')).toContain('application/json');
+  expect(collections).toEqual(['bge-m3']);
+  expect(body).toEqual([
+    {
+      id: 'doc-1',
+      document: 'alpha document',
+      type: 'learning',
+      source_file: 'notes/alpha.md',
+      concepts: ['alpha', 'beta'],
+    },
+    {
+      id: 'doc-2',
+      document: 'bravo, with comma',
+      type: 'trace',
+      source_file: 'traces/bravo.md',
+      concepts: ['gamma'],
+    },
+  ]);
+  expect(store.getAllEmbeddings).toHaveBeenCalledWith(2);
+});
+
+test('GET /api/v1/vector/export streams CSV with headers', async () => {
+  const store = createStore();
+  const fetcher = createFetch(store, []);
+
+  const res = await fetcher(new Request(
+    'http://local/api/v1/vector/export?collection=bge-m3&format=csv',
+  ));
+  const csv = await res.text();
+
+  expect(res.status).toBe(200);
+  expect(res.headers.get('content-type')).toContain('text/csv');
+  expect(csv.split('\n')[0]).toBe('id,document,type,source_file,concepts');
+  expect(csv).toContain('"doc-2","bravo, with comma","trace","traces/bravo.md","[""gamma""]"');
+});


### PR DESCRIPTION
## Summary\n- Include the LanceDB collection name in the connect log.\n- Move duplicate route menu path diagnostics to console.debug.\n- Update the menu seeder regression test to assert the debug channel.\n\n## Validation\n- tsc --noEmit\n- bun test tests/http/health/\n- bun test tests/http/menu/db-seeder.test.ts\n- wc -l changed files (all ≤250)\n\nNot-tested: full bare bun test intentionally skipped per repo contract because it pulls agents/ worktrees.