### PR TITLE
Fix vector route typecheck after documents merge

### DIFF
--- a/src/routes/vector/index.ts
+++ b/src/routes/vector/index.ts
@@ -10,7 +10,6 @@
  *   GET /api/vector/stats    — per-engine collection counts
  *   GET /api/vector/health   — adapter liveness probe
  *   GET /api/vector/documents — browse indexed vector documents
- *   GET /api/vector/export — stream vector documents as JSON or CSV
  *
  * Mounted with the `/api` prefix from server.ts. Phase 1 of #1071: separating
  * the vector layer from FTS/hybrid so it can later move behind VECTOR_URL.
@@ -28,7 +27,6 @@ import { vectorConfigEndpoint } from './config.ts';
 import { vectorIndexerEndpoints } from './indexer.ts';
 import { vectorProxyEndpoint } from './proxy.ts';
 import { vectorDocumentsEndpoint } from './documents.ts';
-import { vectorExportEndpoint } from './export.ts';
 
 export const vectorRoutes = new Elysia({ prefix: '/api' })
   .use(vectorProxyEndpoint)
@@ -40,6 +38,5 @@ export const vectorRoutes = new Elysia({ prefix: '/api' })
   .use(vectorStatsEndpoint)
   .use(vectorHealthEndpoint)
   .use(vectorDocumentsEndpoint)
-  .use(vectorExportEndpoint)
   .use(vectorConfigEndpoint)
   .use(vectorIndexerEndpoints);


### PR DESCRIPTION
## Summary
- Fix the alpha typecheck break from PR #1606 by removing registration of the unfinished `vector/export` route.
- Keeps the shipped `/api/v1/vector/documents` route registered.

## Verification
- `tsc --noEmit`
- `bun test tests/http/vector/`
- changed files ≤250 lines
