### PR TITLE
Test versioned vector status endpoints

### DIFF
--- a/src/routes/vector/health.ts
+++ b/src/routes/vector/health.ts
@@ -14,11 +14,20 @@ import { handleVectorHealth } from '../../server/vector-handlers.ts';
 import { createVectorProxy } from '../../server/vector-proxy.ts';
 import { VECTOR_URL } from '../../config.ts';
 
-const proxy = createVectorProxy(VECTOR_URL);
+const defaultProxy = createVectorProxy(VECTOR_URL);
 
-export const vectorHealthEndpoint = new Elysia().get(
-  '/vector/health',
-  async ({ set }) => {
+type VectorHealthResult = Awaited<ReturnType<typeof handleVectorHealth>>;
+
+export interface VectorHealthEndpointOptions {
+  vectorHealth?: () => Promise<VectorHealthResult>;
+  proxy?: typeof defaultProxy;
+}
+
+export function createVectorHealthEndpoint(options: VectorHealthEndpointOptions = {}) {
+  const proxy = options.proxy === undefined ? defaultProxy : options.proxy;
+  const vectorHealth = options.vectorHealth ?? handleVectorHealth;
+
+  async function readHealth({ set }: { set: { status?: number | string } }) {
     if (proxy) {
       const ok = await proxy.available();
       if (ok) {
@@ -28,19 +37,30 @@ export const vectorHealthEndpoint = new Elysia().get(
       return { status: 'down' as const, engines: [], checked_at: new Date().toISOString(), proxy: VECTOR_URL };
     }
     try {
-      const result = await handleVectorHealth();
+      const result = await vectorHealth();
       if (result.status === 'down') set.status = 503;
       return result;
     } catch (e: any) {
       set.status = 500;
       return { error: e.message, status: 'down', engines: [], checked_at: new Date().toISOString() };
     }
-  },
-  {
-    detail: {
-      tags: ['vector'],
-      menu: { group: 'hidden' },
-      summary: 'Vector adapter liveness check',
-    },
-  },
-);
+  }
+
+  return new Elysia()
+    .get('/vector/health', readHealth, {
+      detail: {
+        tags: ['vector'],
+        menu: { group: 'hidden' },
+        summary: 'Vector adapter liveness check',
+      },
+    })
+    .get('/vector/status', readHealth, {
+      detail: {
+        tags: ['vector'],
+        menu: { group: 'hidden' },
+        summary: 'Versioned vector adapter status alias',
+      },
+    });
+}
+
+export const vectorHealthEndpoint = createVectorHealthEndpoint();

--- a/src/routes/vector/indexer.ts
+++ b/src/routes/vector/indexer.ts
@@ -13,10 +13,60 @@
 
 import { Elysia, t } from 'elysia';
 import { Database } from 'bun:sqlite';
-import { createVectorStoreForModel, getEmbeddingModels } from '../../vector/factory.ts';
+import { createVectorStoreForModel, getEmbeddingModels, type EmbeddingModelConfig } from '../../vector/factory.ts';
+import type { VectorStoreAdapter } from '../../vector/types.ts';
 import { DB_PATH } from '../../config.ts';
 
 // ── In-memory status (no sqlite writes — avoids the disk I/O problem) ──
+
+type VectorModelEntry = { collection: string; model: string; adapter: string; count?: number };
+
+export interface VectorModelsEndpointOptions {
+  getModels?: () => Record<string, EmbeddingModelConfig>;
+  createStore?: (preset: EmbeddingModelConfig) => Pick<VectorStoreAdapter, 'connect' | 'getStats' | 'close'>;
+}
+
+async function readVectorModels(options: VectorModelsEndpointOptions = {}) {
+  const models = (options.getModels ?? getEmbeddingModels)();
+  const createStore = options.createStore ?? createVectorStoreForModel;
+  const result: Record<string, VectorModelEntry> = {};
+
+  for (const [key, preset] of Object.entries(models)) {
+    const entry: VectorModelEntry = {
+      collection: preset.collection,
+      model: preset.model,
+      adapter: preset.adapter || 'lancedb',
+    };
+
+    let store: Pick<VectorStoreAdapter, 'connect' | 'getStats' | 'close'> | undefined;
+    try {
+      store = createStore(preset);
+      await store.connect();
+      const stats = await store.getStats();
+      entry.count = stats.count;
+    } catch {
+      entry.count = 0;
+    } finally {
+      await store?.close().catch(() => {});
+    }
+
+    result[key] = entry;
+  }
+
+  return { models: result };
+}
+
+export function createVectorModelEndpoints(options: VectorModelsEndpointOptions = {}) {
+  const readModels = () => readVectorModels(options);
+  const detail = {
+    tags: ['vector-indexer'],
+    summary: 'Available embedding models and collection counts',
+  };
+
+  return new Elysia()
+    .get('/vector/index/models', readModels, { detail })
+    .get('/vector/models', readModels, { detail: { ...detail, summary: 'Versioned vector model registry alias' } });
+}
 
 interface IndexJob {
   jobId: string;
@@ -155,35 +205,4 @@ export const vectorIndexerEndpoints = new Elysia()
     },
   })
 
-  // GET /vector/index/models
-  .get('/vector/index/models', async () => {
-    const models = getEmbeddingModels();
-    const result: Record<string, { collection: string; model: string; adapter: string; count?: number }> = {};
-
-    for (const [key, preset] of Object.entries(models)) {
-      const entry: { collection: string; model: string; adapter: string; count?: number } = {
-        collection: preset.collection,
-        model: preset.model,
-        adapter: preset.adapter || 'lancedb',
-      };
-
-      try {
-        const store = createVectorStoreForModel(preset);
-        await store.connect();
-        const stats = await store.getStats();
-        entry.count = stats.count;
-        await store.close();
-      } catch {
-        entry.count = 0;
-      }
-
-      result[key] = entry;
-    }
-
-    return { models: result };
-  }, {
-    detail: {
-      tags: ['vector-indexer'],
-      summary: 'Available embedding models and collection counts',
-    },
-  });
+  .use(createVectorModelEndpoints());

--- a/tests/http/vector/status.test.ts
+++ b/tests/http/vector/status.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { API_VERSION_HEADER, createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createVectorHealthEndpoint } from '../../../src/routes/vector/health.ts';
+import { createVectorModelEndpoints } from '../../../src/routes/vector/indexer.ts';
+import type { EmbeddingModelConfig } from '../../../src/vector/factory.ts';
+
+const models = {
+  'bge-m3': { collection: 'oracle_bge', model: 'bge-m3', adapter: 'lancedb' },
+  qdrant: { collection: 'oracle_qdrant', model: 'qdrant-embed', adapter: 'qdrant' },
+} satisfies Record<string, EmbeddingModelConfig>;
+
+function createFetch() {
+  const app = new Elysia({ prefix: '/api' })
+    .use(createVectorHealthEndpoint({
+      proxy: null,
+      vectorHealth: async () => ({
+        status: 'ok',
+        checked_at: '2026-06-16T00:00:00.000Z',
+        engines: [
+          { key: 'bge-m3', model: 'bge-m3', collection: 'oracle_bge', ok: true },
+          { key: 'qdrant', model: 'qdrant-embed', collection: 'oracle_qdrant', ok: true },
+        ],
+      }),
+    }))
+    .use(createVectorModelEndpoints({
+      getModels: () => models,
+      createStore: (preset) => ({
+        connect: async () => {},
+        getStats: async () => ({ count: preset.collection === 'oracle_bge' ? 12 : 3 }),
+        close: async () => {},
+      }),
+    }));
+
+  return createApiVersionedFetch((request) => app.handle(request));
+}
+
+test('GET /api/v1/vector/status and /api/v1/vector/models return vector status shapes', async () => {
+  const fetcher = createFetch();
+
+  const statusRes = await fetcher(new Request('http://local/api/v1/vector/status'));
+  const statusBody = await statusRes.json() as Record<string, any>;
+  expect(statusRes.status).toBe(200);
+  expect(statusRes.headers.get(API_VERSION_HEADER)).toBe('v1');
+  expect(statusBody).toMatchObject({
+    status: 'ok',
+    checked_at: '2026-06-16T00:00:00.000Z',
+    engines: [
+      { key: 'bge-m3', model: 'bge-m3', collection: 'oracle_bge', ok: true },
+      { key: 'qdrant', model: 'qdrant-embed', collection: 'oracle_qdrant', ok: true },
+    ],
+  });
+
+  const modelsRes = await fetcher(new Request('http://local/api/v1/vector/models'));
+  const modelsBody = await modelsRes.json() as Record<string, any>;
+  expect(modelsRes.status).toBe(200);
+  expect(modelsRes.headers.get(API_VERSION_HEADER)).toBe('v1');
+  expect(modelsBody).toMatchObject({
+    models: {
+      'bge-m3': { collection: 'oracle_bge', model: 'bge-m3', adapter: 'lancedb', count: 12 },
+      qdrant: { collection: 'oracle_qdrant', model: 'qdrant-embed', adapter: 'qdrant', count: 3 },
+    },
+  });
+});


### PR DESCRIPTION
## Summary\n- add versioned vector aliases for /api/v1/vector/status and /api/v1/vector/models\n- add fetch-based HTTP integration coverage under tests/http/vector/status.test.ts\n- keep vector model listing injectable so tests avoid real vector adapters\n\n## Tests\n- bun test tests/http/vector/\n- bunx tsc --noEmit