### PR TITLE
Backend vector config API

### DIFF
--- a/src/routes/vector/config-api.ts
+++ b/src/routes/vector/config-api.ts
@@ -1,0 +1,185 @@
+/**
+ * Vector config API — external path `/api/v1/vector/config`.
+ *
+ * The app mounts vector routes at `/api`; api-version middleware rewrites
+ * `/api/v1/*` to those internal routes.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { Elysia, t } from 'elysia';
+import {
+  configPath,
+  configToModels,
+  generateDefaultConfig,
+  loadVectorConfig,
+  writeVectorConfig,
+  type VectorCollectionConfig,
+  type VectorServerConfig,
+} from '../../vector/config.ts';
+import { createVectorStoreForModel } from '../../vector/factory.ts';
+import type { VectorDBType } from '../../vector/types.ts';
+
+const adapterSchema = t.Union([
+  t.Literal('chroma'),
+  t.Literal('sqlite-vec'),
+  t.Literal('lancedb'),
+  t.Literal('qdrant'),
+  t.Literal('cloudflare-vectorize'),
+]);
+
+type CollectionUpdate = Partial<Pick<VectorCollectionConfig, 'adapter' | 'model' | 'provider'>>;
+type CollectionHealth = {
+  key: string;
+  collection: string;
+  model: string;
+  provider: string;
+  adapter: VectorDBType;
+  count: number;
+  ok: boolean;
+  status: 'ok' | 'down';
+  error?: string;
+};
+
+function activeConfig(): { source: 'file' | 'defaults'; config: VectorServerConfig } {
+  const fromDisk = loadVectorConfig();
+  return { source: fromDisk ? 'file' : 'defaults', config: fromDisk ?? generateDefaultConfig() };
+}
+
+function atomicWriteVectorConfig(config: VectorServerConfig): string {
+  const target = configPath();
+  const dir = path.dirname(target);
+  fs.mkdirSync(dir, { recursive: true });
+  const tmp = path.join(dir, `.${path.basename(target)}.${process.pid}.${Date.now()}.tmp`);
+  try {
+    writeVectorConfig(config, tmp);
+    fs.renameSync(tmp, target);
+    return target;
+  } catch (e) {
+    try { if (fs.existsSync(tmp)) fs.unlinkSync(tmp); } catch {}
+    throw e;
+  }
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error('timeout')), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+async function inspectCollection(
+  key: string,
+  col: VectorCollectionConfig,
+  config: VectorServerConfig,
+): Promise<CollectionHealth> {
+  const timeout = parseInt(process.env.ORACLE_VECTOR_HEALTH_TIMEOUT || '2000', 10);
+  const preset = configToModels(config)[key];
+  const adapter = preset.adapter || 'lancedb';
+  const store = createVectorStoreForModel(preset);
+  try {
+    await withTimeout(store.connect(), timeout);
+    const stats = await withTimeout(store.getStats(), timeout);
+    return {
+      key,
+      collection: col.collection,
+      model: col.model,
+      provider: col.provider,
+      adapter,
+      count: stats.count,
+      ok: true,
+      status: 'ok',
+    };
+  } catch (e) {
+    return {
+      key,
+      collection: col.collection,
+      model: col.model,
+      provider: col.provider,
+      adapter,
+      count: 0,
+      ok: false,
+      status: 'down',
+      error: e instanceof Error ? e.message : String(e),
+    };
+  } finally {
+    await store.close().catch(() => undefined);
+  }
+}
+
+function normalizedUpdate(body: CollectionUpdate): CollectionUpdate | { error: string } {
+  const update: CollectionUpdate = {};
+  if (body.adapter !== undefined) update.adapter = body.adapter;
+  if (body.model !== undefined) {
+    const model = body.model.trim();
+    if (!model) return { error: 'model must be a non-empty string' };
+    update.model = model;
+  }
+  if (body.provider !== undefined) {
+    const provider = body.provider.trim();
+    if (!provider) return { error: 'provider must be a non-empty string' };
+    update.provider = provider;
+  }
+  if (Object.keys(update).length === 0) return { error: 'body must include adapter, model, or provider' };
+  return update;
+}
+
+export const vectorConfigApiEndpoint = new Elysia()
+  .get('/vector/config', async () => {
+    const { source, config } = activeConfig();
+    const collections = await Promise.all(
+      Object.entries(config.collections).map(([key, col]) => inspectCollection(key, col, config)),
+    );
+    return {
+      source,
+      config,
+      collections,
+      doc_counts: Object.fromEntries(collections.map((col) => [col.key, col.count])),
+      health: Object.fromEntries(collections.map((col) => [col.key, {
+        ok: col.ok,
+        status: col.status,
+        collection: col.collection,
+        adapter: col.adapter,
+        model: col.model,
+        ...(col.error && { error: col.error }),
+      }])),
+      checked_at: new Date().toISOString(),
+    };
+  }, {
+    detail: { tags: ['vector'], summary: 'Vector server config with collection health' },
+  })
+  .put('/vector/config/:collection', ({ params, body, set }) => {
+    const update = normalizedUpdate(body);
+    if ('error' in update) {
+      set.status = 400;
+      return { error: update.error };
+    }
+
+    const { source, config } = activeConfig();
+    const current = config.collections[params.collection];
+    if (!current) {
+      set.status = 404;
+      return { error: `Unknown vector collection: ${params.collection}` };
+    }
+
+    const next: VectorServerConfig = {
+      ...config,
+      collections: {
+        ...config.collections,
+        [params.collection]: { ...current, ...update },
+      },
+    };
+    const path = atomicWriteVectorConfig(next);
+    return { success: true, source, path, collection: params.collection, config: next };
+  }, {
+    params: t.Object({ collection: t.String({ minLength: 1 }) }),
+    body: t.Object({
+      adapter: t.Optional(adapterSchema),
+      model: t.Optional(t.String()),
+      provider: t.Optional(t.String()),
+    }),
+    detail: { tags: ['vector'], summary: 'Update one vector collection config' },
+  });

--- a/src/routes/vector/config-api.ts
+++ b/src/routes/vector/config-api.ts
@@ -42,12 +42,16 @@ type CollectionHealth = {
 };
 
 function activeConfig(): { source: 'file' | 'defaults'; config: VectorServerConfig } {
-  const fromDisk = loadVectorConfig();
+  const fromDisk = loadVectorConfig(currentConfigPath());
   return { source: fromDisk ? 'file' : 'defaults', config: fromDisk ?? generateDefaultConfig() };
 }
 
+function currentConfigPath(): string {
+  return process.env.ORACLE_DATA_DIR ? configPath(process.env.ORACLE_DATA_DIR) : configPath();
+}
+
 function atomicWriteVectorConfig(config: VectorServerConfig): string {
-  const target = configPath();
+  const target = currentConfigPath();
   const dir = path.dirname(target);
   fs.mkdirSync(dir, { recursive: true });
   const tmp = path.join(dir, `.${path.basename(target)}.${process.pid}.${Date.now()}.tmp`);

--- a/src/routes/vector/index.ts
+++ b/src/routes/vector/index.ts
@@ -9,6 +9,8 @@
  *   GET /api/map3d           — 3D PCA projection from real embeddings
  *   GET /api/vector/stats    — per-engine collection counts
  *   GET /api/vector/health   — adapter liveness probe
+ *   GET /api/v1/vector/config — config + per-collection health/counts
+ *   PUT /api/v1/vector/config/:collection — update collection adapter/model/provider
  *
  * Mounted with the `/api` prefix from server.ts. Phase 1 of #1071: separating
  * the vector layer from FTS/hybrid so it can later move behind VECTOR_URL.
@@ -22,7 +24,7 @@ import { mapEndpoint } from './map.ts';
 import { map3dEndpoint } from './map3d.ts';
 import { vectorStatsEndpoint } from './stats.ts';
 import { vectorHealthEndpoint } from './health.ts';
-import { vectorConfigEndpoint } from './config.ts';
+import { vectorConfigApiEndpoint } from './config-api.ts';
 import { vectorIndexerEndpoints } from './indexer.ts';
 import { vectorProxyEndpoint } from './proxy.ts';
 
@@ -35,5 +37,5 @@ export const vectorRoutes = new Elysia({ prefix: '/api' })
   .use(map3dEndpoint)
   .use(vectorStatsEndpoint)
   .use(vectorHealthEndpoint)
-  .use(vectorConfigEndpoint)
+  .use(vectorConfigApiEndpoint)
   .use(vectorIndexerEndpoints);

--- a/tests/http/vector/config-api.test.ts
+++ b/tests/http/vector/config-api.test.ts
@@ -1,0 +1,106 @@
+import { afterAll, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { mkdtempSync, readdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedHealthTimeout = process.env.ORACLE_VECTOR_HEALTH_TIMEOUT;
+const root = mkdtempSync(join(tmpdir(), 'vector-config-api-'));
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_VECTOR_HEALTH_TIMEOUT = '1500';
+
+const vectorConfig = await import('../../../src/vector/config.ts');
+const { vectorConfigApiEndpoint } = await import('../../../src/routes/vector/config-api.ts');
+
+const app = new Elysia({ prefix: '/api' }).use(vectorConfigApiEndpoint);
+const versionedFetch = createApiVersionedFetch((request) => app.handle(request));
+
+function seedConfig() {
+  const config = vectorConfig.generateDefaultConfig();
+  config.dataPath = join(root, 'lance');
+  config.collections = {
+    phase1: {
+      collection: 'phase1_collection',
+      model: 'old-model',
+      provider: 'none',
+      adapter: 'lancedb',
+      primary: true,
+    },
+  };
+  vectorConfig.writeVectorConfig(config, vectorConfig.configPath(root));
+  return config;
+}
+
+async function call(path: string, init: RequestInit = {}) {
+  const res = await versionedFetch(new Request(`http://local${path}`, init));
+  const text = await res.text();
+  return { status: res.status, body: text ? JSON.parse(text) : null };
+}
+
+afterAll(() => {
+  if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = savedDataDir;
+  if (savedHealthTimeout === undefined) delete process.env.ORACLE_VECTOR_HEALTH_TIMEOUT;
+  else process.env.ORACLE_VECTOR_HEALTH_TIMEOUT = savedHealthTimeout;
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('GET and PUT /api/v1/vector/config expose and update vector-server.json', async () => {
+  seedConfig();
+
+  const getRes = await call('/api/v1/vector/config');
+  expect(getRes.status).toBe(200);
+  expect(getRes.body.source).toBe('file');
+  expect(getRes.body.config.collections.phase1).toMatchObject({
+    collection: 'phase1_collection',
+    model: 'old-model',
+    provider: 'none',
+    adapter: 'lancedb',
+  });
+  expect(getRes.body.doc_counts.phase1).toEqual(expect.any(Number));
+  expect(getRes.body.health.phase1).toMatchObject({
+    collection: 'phase1_collection',
+    model: 'old-model',
+    adapter: 'lancedb',
+  });
+  expect(getRes.body.collections[0].count).toEqual(expect.any(Number));
+
+  const emptyUpdate = await call('/api/v1/vector/config/phase1', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+  expect(emptyUpdate.status).toBe(400);
+
+  const missing = await call('/api/v1/vector/config/missing', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ model: 'ignored' }),
+  });
+  expect(missing.status).toBe(404);
+
+  const putRes = await call('/api/v1/vector/config/phase1', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ adapter: 'qdrant', model: 'new-model', provider: 'remote' }),
+  });
+  expect(putRes.status).toBe(200);
+  expect(putRes.body.success).toBe(true);
+  expect(putRes.body.config.collections.phase1).toMatchObject({
+    collection: 'phase1_collection',
+    model: 'new-model',
+    provider: 'remote',
+    adapter: 'qdrant',
+    primary: true,
+  });
+
+  const persisted = vectorConfig.loadVectorConfig(vectorConfig.configPath(root));
+  expect(persisted?.collections.phase1).toMatchObject({
+    model: 'new-model',
+    provider: 'remote',
+    adapter: 'qdrant',
+  });
+  expect(readdirSync(root).some((name) => name.includes('.tmp'))).toBe(false);
+});


### PR DESCRIPTION
## Summary
- add versioned vector config API for GET config + per-collection counts/health
- add PUT collection updates for adapter/model/provider with temp-file + rename atomic write
- register the new vector config API and cover it with scoped HTTP tests

## Verification
- tsc --noEmit
- bun test tests/http/vector/
- changed files <=250 lines

Target: alpha