### PR TITLE
Add vector index management panel

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -19,6 +19,8 @@ export interface ApiRouteResponses {
   '/api/menu': MenuResponse;
   '/api/menu/search': MenuSearchResponse;
   '/api/vector/search': VectorSearchResponse;
+  '/api/vector/index/models': VectorIndexModelsResponse;
+  '/api/vector/index/status': VectorIndexStatusResponse;
   '/api/v1/plugins': PluginsResponse;
   '/api/v1/learn': LearnListResponse;
 }
@@ -41,6 +43,39 @@ export interface VectorSearchParams {
   project?: string;
   cwd?: string;
   model?: string;
+}
+
+export interface VectorIndexCollection {
+  collection: string;
+  model: string;
+  adapter: string;
+  count?: number;
+}
+
+export interface VectorIndexModelsResponse {
+  models: Record<string, VectorIndexCollection>;
+}
+
+export type VectorIndexJobStatus = 'idle' | 'indexing' | 'completed' | 'error';
+
+export interface VectorIndexStatusResponse {
+  jobId: string;
+  model: string;
+  status: VectorIndexJobStatus;
+  current: number;
+  total: number;
+  startedAt: number;
+  completedAt?: number;
+  error?: string;
+  docsPerSec: number;
+  eta: number;
+}
+
+export interface VectorIndexStartResponse {
+  jobId: string;
+  status: 'started';
+  model: string;
+  batchSize: number;
 }
 
 export class ApiClientError extends Error {
@@ -144,6 +179,18 @@ export class ApiClient {
     addParam(query, 'cwd', params.cwd);
     addParam(query, 'model', params.model);
     return this.fetchJson(`/api/vector/search?${query.toString()}`);
+  }
+
+  vectorIndexModels(): Promise<VectorIndexModelsResponse> {
+    return this.request('/api/vector/index/models');
+  }
+
+  vectorIndexStatus(): Promise<VectorIndexStatusResponse> {
+    return this.request('/api/vector/index/status');
+  }
+
+  startVectorIndex(model: string): Promise<VectorIndexStartResponse> {
+    return this.fetchJson('/api/vector/index/start', { method: 'POST', body: JSON.stringify({ model }) });
   }
 
   private async fetchJson<T>(path: string, init: RequestInit = {}): Promise<T> {

--- a/frontend/src/components/VectorIndexPanel.tsx
+++ b/frontend/src/components/VectorIndexPanel.tsx
@@ -1,0 +1,165 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  apiClient,
+  type ApiClient,
+  type VectorIndexCollection,
+  type VectorIndexStatusResponse,
+} from '../api/client';
+import { ErrorMessage, LoadingPanel, Spinner } from './AsyncState';
+
+type VectorIndexClient = Pick<ApiClient, 'startVectorIndex' | 'vectorIndexModels' | 'vectorIndexStatus'>;
+
+interface VectorIndexPanelProps {
+  client?: VectorIndexClient;
+  initialModels?: Record<string, VectorIndexCollection>;
+  initialStatus?: VectorIndexStatusResponse | null;
+}
+
+export function formatIndexEta(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) return 'calculating';
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const rest = seconds % 60;
+  return rest ? `${minutes}m ${rest}s` : `${minutes}m`;
+}
+
+function progressFor(status: VectorIndexStatusResponse): number {
+  if (status.total <= 0) return status.status === 'completed' ? 100 : 0;
+  return Math.min(100, Math.round((status.current / status.total) * 100));
+}
+
+function statusSummary(status: VectorIndexStatusResponse | null): string {
+  if (!status || status.status === 'idle') return 'No active index job.';
+  if (status.status === 'completed') return `Completed ${status.model} reindex.`;
+  if (status.status === 'error') return `Failed ${status.model} reindex.`;
+  return `Indexing ${status.model}; polling every 2s.`;
+}
+
+export function VectorIndexPanel({ client = apiClient, initialModels, initialStatus = null }: VectorIndexPanelProps) {
+  const [models, setModels] = useState<Record<string, VectorIndexCollection>>(initialModels ?? {});
+  const [loading, setLoading] = useState(!initialModels);
+  const [status, setStatus] = useState<VectorIndexStatusResponse | null>(initialStatus);
+  const [error, setError] = useState('');
+  const [startingKey, setStartingKey] = useState<string | null>(null);
+
+  const modelEntries = useMemo(() => Object.entries(models).sort(([a], [b]) => a.localeCompare(b)), [models]);
+  const indexing = status?.status === 'indexing';
+
+  const refreshStatus = useCallback(async () => {
+    const next = await client.vectorIndexStatus();
+    setStatus(next);
+    return next;
+  }, [client]);
+
+  useEffect(() => {
+    if (initialModels) return;
+    let active = true;
+    setLoading(true);
+    client.vectorIndexModels()
+      .then((response) => { if (active) setModels(response.models); })
+      .catch((err) => { if (active) setError(err instanceof Error ? err.message : String(err)); })
+      .finally(() => { if (active) setLoading(false); });
+    return () => { active = false; };
+  }, [client, initialModels]);
+
+  useEffect(() => {
+    let active = true;
+    client.vectorIndexStatus()
+      .then((next) => { if (active) setStatus(next); })
+      .catch((err) => { if (active) setError(err instanceof Error ? err.message : String(err)); });
+    return () => { active = false; };
+  }, [client]);
+
+  useEffect(() => {
+    if (!indexing || typeof window === 'undefined') return;
+    const timer = window.setInterval(() => {
+      refreshStatus().catch((err) => setError(err instanceof Error ? err.message : String(err)));
+    }, 2000);
+    return () => window.clearInterval(timer);
+  }, [indexing, refreshStatus]);
+
+  async function startReindex(key: string) {
+    setStartingKey(key);
+    setError('');
+    try {
+      await client.startVectorIndex(key);
+      await refreshStatus();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setStartingKey(null);
+    }
+  }
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-index-title">
+      <div className="mb-5 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-300">Index management</p>
+          <h2 id="vector-index-title" className="mt-2 text-2xl font-semibold text-white">Vector collections</h2>
+          <p className="mt-2 text-sm text-slate-400">Rebuild each embedding collection through /api/vector/index/start.</p>
+        </div>
+        <button
+          className="focus-ring rounded-xl border border-white/10 px-3 py-2 text-sm text-slate-200 hover:border-purple-300/40"
+          type="button"
+          onClick={() => void refreshStatus()}
+        >
+          Refresh status
+        </button>
+      </div>
+
+      <div className="mb-4 rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+        <p className="text-sm font-semibold text-slate-200">{statusSummary(status)}</p>
+        {status ? <IndexProgress status={status} /> : null}
+      </div>
+
+      {loading ? <LoadingPanel title="Loading vector collections…" detail="Fetching /api/vector/index/models." /> : null}
+      {error ? <ErrorMessage title="Vector indexing failed." message={error} /> : null}
+      {!loading && !modelEntries.length ? <p className="text-sm text-slate-500">No vector collections reported.</p> : null}
+
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {modelEntries.map(([key, model]) => {
+          const active = indexing && status?.model === key;
+          return (
+            <article key={key} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <h3 className="font-mono text-base font-semibold text-teal-200">{key}</h3>
+                  <p className="mt-1 text-sm text-slate-300">{model.collection}</p>
+                </div>
+                <button
+                  className="focus-ring rounded-xl bg-purple-300 px-3 py-2 text-sm font-semibold text-slate-950 hover:bg-purple-200 disabled:cursor-not-allowed disabled:opacity-50"
+                  disabled={Boolean(startingKey) || indexing}
+                  type="button"
+                  onClick={() => void startReindex(key)}
+                >
+                  {startingKey === key ? <Spinner label="Starting" /> : active ? 'Reindexing…' : 'Reindex'}
+                </button>
+              </div>
+              <dl className="mt-4 grid gap-2 text-sm text-slate-400">
+                <div><dt className="inline text-slate-500">Model: </dt><dd className="inline">{model.model}</dd></div>
+                <div><dt className="inline text-slate-500">Adapter: </dt><dd className="inline">{model.adapter}</dd></div>
+                <div><dt className="inline text-slate-500">Docs: </dt><dd className="inline">{model.count ?? 0}</dd></div>
+              </dl>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function IndexProgress({ status }: { status: VectorIndexStatusResponse }) {
+  const progress = progressFor(status);
+  return (
+    <div className="mt-3">
+      <div className="h-2 overflow-hidden rounded-full bg-slate-800" role="progressbar" aria-valuemin={0} aria-valuemax={100} aria-valuenow={progress}>
+        <div className="h-full rounded-full bg-purple-300 transition-all" style={{ width: `${progress}%` }} />
+      </div>
+      <p className="mt-2 text-sm text-slate-400">
+        {status.current}/{status.total} docs · {status.docsPerSec} docs/sec · ETA {formatIndexEta(status.eta)}
+      </p>
+      {status.error ? <p className="mt-2 text-sm text-red-200">{status.error}</p> : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/VectorPage.tsx
+++ b/frontend/src/pages/VectorPage.tsx
@@ -1,11 +1,12 @@
 import { Link, useNavigate } from 'react-router-dom';
+import { VectorIndexPanel } from '../components/VectorIndexPanel';
 import { VectorSearchWidget } from '../components/VectorSearchWidget';
 import { vectorDocumentsPath, vectorResultsPath } from '../routePaths';
 
 export function VectorPage() {
   const navigate = useNavigate();
   return (
-    <div className="grid gap-4">
+    <div className="grid gap-5">
       <div className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Documents</p>
         <h2 className="mt-2 text-2xl font-semibold text-white">Browse indexed documents</h2>
@@ -15,6 +16,7 @@ export function VectorPage() {
         </Link>
       </div>
       <VectorSearchWidget onOpenResults={(query) => navigate(vectorResultsPath(query))} />
+      <VectorIndexPanel />
     </div>
   );
 }

--- a/tests/frontend/api-client.test.ts
+++ b/tests/frontend/api-client.test.ts
@@ -30,6 +30,19 @@ describe('frontend API client', () => {
         limit: 5,
         query: 'oracle memory',
       },
+      '/api/vector/index/models': {
+        models: { 'bge-m3': { collection: 'oracle_bge_m3', model: 'bge-m3', adapter: 'lancedb', count: 12 } },
+      },
+      '/api/vector/index/status': {
+        jobId: 'vidx-1',
+        model: 'bge-m3',
+        status: 'indexing',
+        current: 5,
+        total: 12,
+        startedAt: 1781560000000,
+        docsPerSec: 2.5,
+        eta: 3,
+      },
       '/api/v1/plugins': {
         dir: '/tmp/plugins',
         plugins: [{ name: 'echo', file: 'echo.wasm', size: 12, modified: '2026-06-16T00:00:00.000Z' }],
@@ -48,6 +61,8 @@ describe('frontend API client', () => {
     await expect(client.menu()).resolves.toMatchObject({ items: [{ label: 'Vector' }] });
     await expect(client.menuSearch('  vector  ')).resolves.toMatchObject({ total: 1, q: 'vector' });
     await expect(client.vectorSearch({ q: 'oracle memory', limit: 5, type: 'docs' })).resolves.toMatchObject({ total: 1, query: 'oracle memory' });
+    await expect(client.vectorIndexModels()).resolves.toMatchObject({ models: { 'bge-m3': { count: 12 } } });
+    await expect(client.vectorIndexStatus()).resolves.toMatchObject({ status: 'indexing', current: 5, total: 12 });
     await expect(client.plugins()).resolves.toMatchObject({ plugins: [{ name: 'echo' }] });
 
     expect(calls.map((call) => String(call.input))).toEqual([
@@ -56,6 +71,8 @@ describe('frontend API client', () => {
       '/api/menu',
       '/api/menu/search?q=vector',
       '/api/vector/search?q=oracle+memory&limit=5&type=docs',
+      '/api/vector/index/models',
+      '/api/vector/index/status',
       '/api/v1/plugins',
     ]);
     for (const call of calls) {
@@ -75,11 +92,15 @@ describe('frontend API client', () => {
     });
 
     await client.request('/api/menu', { method: 'POST', body: JSON.stringify({ refresh: true }) });
+    await client.startVectorIndex('qwen3');
 
     expect(String(calls[0]?.input)).toBe('http://localhost:47778/api/menu');
     const headers = new Headers(calls[0]?.init?.headers);
     expect(headers.get('x-client')).toBe('studio');
     expect(headers.get('content-type')).toBe('application/json');
+    expect(String(calls[1]?.input)).toBe('http://localhost:47778/api/vector/index/start');
+    expect(calls[1]?.init?.method).toBe('POST');
+    expect(calls[1]?.init?.body).toBe(JSON.stringify({ model: 'qwen3' }));
   });
 
   test('wraps network, JSON parse, and non-OK failures', async () => {

--- a/tests/frontend/components/vector-index-panel-render.test.tsx
+++ b/tests/frontend/components/vector-index-panel-render.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'bun:test';
+import { VectorIndexPanel, formatIndexEta } from '../../../frontend/src/components/VectorIndexPanel';
+import { htmlFor } from '../_render';
+
+const status = {
+  jobId: 'vidx-1',
+  model: 'bge-m3',
+  status: 'indexing' as const,
+  current: 25,
+  total: 100,
+  startedAt: 1781560000000,
+  docsPerSec: 12.5,
+  eta: 95,
+};
+
+describe('VectorIndexPanel', () => {
+  test('renders per-collection reindex controls with progress details', () => {
+    const html = htmlFor(
+      <VectorIndexPanel
+        initialStatus={status}
+        initialModels={{
+          'bge-m3': { collection: 'oracle_bge_m3', model: 'BAAI/bge-m3', adapter: 'lancedb', count: 100 },
+          qwen3: { collection: 'oracle_qwen3', model: 'Qwen3', adapter: 'lancedb', count: 80 },
+        }}
+      />,
+    );
+
+    expect(html).toContain('Index management');
+    expect(html).toContain('bge-m3');
+    expect(html).toContain('oracle_bge_m3');
+    expect(html).toContain('qwen3');
+    expect(html).toContain('Reindexing');
+    expect(html).toContain('25/100 docs');
+    expect(html).toContain('12.5 docs/sec');
+    expect(html).toContain('ETA 1m 35s');
+  });
+
+  test('formats ETA values for compact status labels', () => {
+    expect(formatIndexEta(0)).toBe('calculating');
+    expect(formatIndexEta(18)).toBe('18s');
+    expect(formatIndexEta(120)).toBe('2m');
+  });
+});

--- a/tests/frontend/pages/vector-page-widget.test.tsx
+++ b/tests/frontend/pages/vector-page-widget.test.tsx
@@ -8,5 +8,6 @@ describe('VectorPage', () => {
     const html = htmlFor(<MemoryRouter><VectorPage /></MemoryRouter>);
     expect(html).toContain('Vector search');
     expect(html).toContain('Semantic search against Oracle memory');
+    expect(html).toContain('Index management');
   });
 });


### PR DESCRIPTION
## Summary
- add a Vector index management panel with per-collection Reindex actions
- wire apiClient to `/api/vector/index/models`, `/api/vector/index/status`, and POST `/api/vector/index/start` with `{ model }`
- show current/total docs, docs/sec, ETA, and a progress bar while polling active indexing every 2s until completed/error

## Verification
- `tsc --noEmit`
- `bun test tests/frontend/` (123 pass)
- `git diff --check origin/alpha...HEAD`
- changed files are all <=250 lines

Note: used `agents/arra-codex-6-vector-index` because the original `agents/arra-codex-6` branch contained stale unrelated history and project policy forbids force-resetting published/shared branches.
