### PR TITLE
Add vector search preview page

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -46,7 +46,7 @@ export interface ApiRouteResponses {
   '/api/v1/metrics': MetricsSnapshot;
   '/api/menu': MenuResponse;
   '/api/menu/search': MenuSearchResponse;
-  '/api/vector/search': VectorSearchResponse;
+  '/api/v1/vector/search': VectorSearchResponse;
   '/api/vector/index/models': VectorIndexModelsResponse;
   '/api/vector/health': VectorHealthResponse;
   '/api/v1/plugins': PluginsResponse;
@@ -181,7 +181,7 @@ export class ApiClient {
     addParam(query, 'project', params.project);
     addParam(query, 'cwd', params.cwd);
     addParam(query, 'model', params.model);
-    return this.fetchJson(`/api/vector/search?${query.toString()}`);
+    return this.fetchJson(`/api/v1/vector/search?${query.toString()}`);
   }
 
   private async fetchJson<T>(path: string, init: RequestInit = {}): Promise<T> {

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -50,6 +50,7 @@ export function AppShell({
     { to: '/', label: 'Menu', description: 'Navigation rows from /api/menu', badge: loading ? '…' : menuCount },
     { to: '/plugins', label: 'Plugins', description: 'Registered plugins and surfaces', badge: loading ? '…' : pluginCount },
     { to: '/search', label: 'Search', description: 'Full-text menu search' },
+    { to: '/vector/search', label: 'Vector', description: 'Semantic preview by collection' },
     { to: '/learn', label: 'Learn', description: 'Create and edit learnings' },
     { to: '/metrics', label: 'Metrics', description: 'Runtime counters from /api/v1/metrics' },
     { to: '/mcp', label: 'MCP', description: 'Tool schemas and groups' },

--- a/frontend/src/pages/VectorPage.tsx
+++ b/frontend/src/pages/VectorPage.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { apiClient, type ApiClient, type VectorHealthResponse, type VectorIndexModelEntry, type VectorIndexModelsResponse } from '../api/client';
 import { ErrorMessage, LoadingPanel, Spinner } from '../components/AsyncState';
 import { VectorSearchWidget } from '../components/VectorSearchWidget';
-import { vectorDocumentsPath, vectorResultsPath } from '../routePaths';
+import { vectorDocumentsPath, vectorSearchPath } from '../routePaths';
 
 type PageState = 'loading' | 'ready' | 'error';
 type VectorStatusClient = Pick<ApiClient, 'vectorIndexModels' | 'vectorHealth'>;
@@ -243,7 +243,7 @@ export function VectorPage({ modelsResponse = null, healthResponse = null, loadi
       </section>
 
       <VectorDocumentsCard />
-      <VectorSearchWidget onOpenResults={(query) => navigate(vectorResultsPath(query))} />
+      <VectorSearchWidget onOpenResults={(query) => navigate(vectorSearchPath(query))} />
     </div>
   );
 }

--- a/frontend/src/pages/VectorSearchPage.tsx
+++ b/frontend/src/pages/VectorSearchPage.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import { apiClient, type ApiClient, type VectorIndexModelsResponse } from '../api/client';
+import type { VectorSearchResponse } from '../../../src/server/types';
+
+type LoadState = 'idle' | 'loading' | 'ready' | 'error';
+type VectorSearchResult = VectorSearchResponse['results'][number];
+type VectorSearchClient = Pick<ApiClient, 'vectorIndexModels' | 'vectorSearch'>;
+
+export type VectorSearchCollection = {
+  key: string;
+  collection: string;
+  model: string;
+  adapter: string;
+  count?: number;
+};
+
+const FALLBACK_COLLECTIONS: VectorSearchCollection[] = [
+  { key: 'bge-m3', collection: 'oracle_knowledge_bge_m3', model: 'bge-m3', adapter: 'lancedb' },
+  { key: 'nomic', collection: 'oracle_knowledge', model: 'nomic-embed-text', adapter: 'lancedb' },
+  { key: 'qwen3', collection: 'oracle_knowledge_qwen3', model: 'qwen3-embedding', adapter: 'lancedb' },
+];
+
+export function collectionsFromModels(response?: VectorIndexModelsResponse | null): VectorSearchCollection[] {
+  const entries = Object.entries(response?.models ?? {});
+  if (!entries.length) return FALLBACK_COLLECTIONS;
+  return entries
+    .map(([key, value]) => ({
+      key,
+      collection: value.collection || key,
+      model: value.model || key,
+      adapter: value.adapter || 'unknown',
+      count: value.count,
+    }))
+    .sort((left, right) => left.collection.localeCompare(right.collection));
+}
+
+export function contentPreview(content: string, maxLength = 180): string {
+  const compact = content.replace(/\s+/g, ' ').trim();
+  if (compact.length <= maxLength) return compact;
+  return `${compact.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+export function distanceLabel(result: Pick<VectorSearchResult, 'distance' | 'score'>): string {
+  if (typeof result.distance === 'number' && Number.isFinite(result.distance)) return result.distance.toFixed(3);
+  if (typeof result.score === 'number' && Number.isFinite(result.score)) return `${(result.score * 100).toFixed(1)}%`;
+  return '—';
+}
+
+export function distancePercent(result: Pick<VectorSearchResult, 'distance' | 'score'>): number {
+  if (typeof result.score === 'number' && Number.isFinite(result.score)) return Math.max(0, Math.min(100, result.score * 100));
+  if (typeof result.distance === 'number' && Number.isFinite(result.distance)) return Math.max(0, Math.min(100, (1 / (1 + Math.max(0, result.distance))) * 100));
+  return 0;
+}
+
+function titleFor(result: VectorSearchResult): string {
+  return ('title' in result && typeof result.title === 'string' && result.title) || result.source_file || result.id;
+}
+
+function conceptsFor(result: VectorSearchResult): string[] {
+  return Array.isArray(result.concepts) ? result.concepts.filter((item) => typeof item === 'string') : [];
+}
+
+function collectionLabel(item: VectorSearchCollection): string {
+  const count = typeof item.count === 'number' ? ` · ${item.count.toLocaleString()} docs` : '';
+  return `${item.key} · ${item.collection}${count}`;
+}
+
+function ResultCard({ result }: { result: VectorSearchResult }) {
+  const percent = distancePercent(result);
+  const concepts = conceptsFor(result);
+  return (
+    <article className="rounded-2xl border border-white/10 bg-slate-900/70 p-4 shadow-lg shadow-black/20">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-base font-semibold text-white">{titleFor(result)}</h2>
+          <p className="mt-1 text-sm leading-6 text-slate-300">{contentPreview(result.content)}</p>
+        </div>
+        <span className="rounded-full border border-teal-300/20 bg-teal-300/10 px-2 py-1 text-xs font-semibold text-teal-100">
+          distance {distanceLabel(result)}
+        </span>
+      </div>
+      <div className="mt-4" aria-label="Vector distance score">
+        <div className="h-2 overflow-hidden rounded-full bg-slate-800">
+          <span className="block h-full rounded-full bg-gradient-to-r from-teal-400 to-cyan-300" style={{ width: `${percent}%` }} />
+        </div>
+      </div>
+      <dl aria-label="Vector result metadata" className="mt-4 grid gap-2 text-xs text-slate-400 sm:grid-cols-3">
+        <div><dt className="font-semibold text-slate-300">type</dt><dd>{result.type || '—'}</dd></div>
+        <div><dt className="font-semibold text-slate-300">source_file</dt><dd className="break-all">{result.source_file || '—'}</dd></div>
+        <div><dt className="font-semibold text-slate-300">model</dt><dd>{result.model || 'selected collection'}</dd></div>
+        {concepts.length ? <div className="sm:col-span-3"><dt className="font-semibold text-slate-300">concepts</dt><dd className="mt-1 flex flex-wrap gap-1">{concepts.map((concept) => <span key={concept} className="rounded-full bg-teal-400/10 px-2 py-0.5 text-teal-100">{concept}</span>)}</dd></div> : null}
+      </dl>
+    </article>
+  );
+}
+
+export function VectorSearchPage({ client = apiClient }: { client?: VectorSearchClient }) {
+  const [collections, setCollections] = useState(FALLBACK_COLLECTIONS);
+  const [collectionKey, setCollectionKey] = useState(FALLBACK_COLLECTIONS[0].key);
+  const [query, setQuery] = useState('');
+  const [activeQuery, setActiveQuery] = useState('');
+  const [results, setResults] = useState<VectorSearchResult[]>([]);
+  const [total, setTotal] = useState(0);
+  const [state, setState] = useState<LoadState>('idle');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    client.vectorIndexModels()
+      .then((response) => {
+        if (cancelled) return;
+        const next = collectionsFromModels(response);
+        setCollections(next);
+        setCollectionKey((current) => next.some((item) => item.key === current) ? current : next[0].key);
+      })
+      .catch(() => undefined);
+    return () => { cancelled = true; };
+  }, [client]);
+
+  const status = useMemo(() => {
+    if (state === 'idle') return 'Enter a query and choose a collection to preview vector matches.';
+    if (state === 'loading') return `Searching “${activeQuery}”…`;
+    if (state === 'error') return 'Vector search failed.';
+    if (!results.length) return `No vector matches found for “${activeQuery}”.`;
+    return `${results.length} shown${total > results.length ? ` of ${total}` : ''} for “${activeQuery}”.`;
+  }, [activeQuery, results.length, state, total]);
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const q = query.trim();
+    if (!q) return;
+    setState('loading');
+    setError('');
+    setActiveQuery(q);
+    try {
+      const response = await client.vectorSearch({ q, limit: 20, model: collectionKey });
+      setResults(response.results);
+      setTotal(response.total);
+      setState('ready');
+    } catch (err) {
+      setResults([]);
+      setTotal(0);
+      setError(err instanceof Error ? err.message : String(err));
+      setState('error');
+    }
+  }
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-search-preview-title">
+      <div className="mb-5">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Vector</p>
+        <h1 id="vector-search-preview-title" className="mt-2 text-3xl font-semibold text-white">Vector search preview</h1>
+        <p className="mt-2 text-sm text-slate-400">Preview semantic matches from /api/v1/vector/search by collection.</p>
+      </div>
+
+      <form aria-label="Vector search preview form" onSubmit={submit} className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_18rem_auto]">
+        <input aria-label="Vector search query" className="focus-ring min-w-0 rounded-xl border border-white/10 bg-slate-950 px-4 py-3 text-slate-100 placeholder:text-slate-600" value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Search vector memory…" type="search" />
+        <select aria-label="Vector collection" className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-4 py-3 text-slate-100" value={collectionKey} onChange={(event) => setCollectionKey(event.target.value)}>
+          {collections.map((collection) => <option key={collection.key} value={collection.key}>{collectionLabel(collection)}</option>)}
+        </select>
+        <button aria-label="Submit vector search" className="focus-ring rounded-xl bg-teal-300 px-5 py-3 font-semibold text-slate-950 transition hover:bg-teal-200 disabled:cursor-not-allowed disabled:opacity-50" disabled={state === 'loading' || !query.trim()} type="submit">
+          {state === 'loading' ? 'Searching…' : 'Search'}
+        </button>
+      </form>
+
+      <p className="mt-4 text-sm text-slate-500">{status}</p>
+      {error ? <p role="alert" className="mt-3 rounded-xl border border-red-400/30 bg-red-950/40 p-3 text-sm text-red-100">{error}</p> : null}
+      <div className="mt-5 grid gap-3 lg:grid-cols-2" aria-busy={state === 'loading'}>
+        {state !== 'loading' ? results.map((result) => <ResultCard key={result.id} result={result} />) : null}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/routeMeta.ts
+++ b/frontend/src/routeMeta.ts
@@ -31,6 +31,14 @@ export function routeMeta(pathname: string, search = ''): RouteMeta {
     ]);
   }
 
+  if (pathname === '/vector/search') {
+    const query = new URLSearchParams(search).get('q')?.trim();
+    return base('Vector search preview', 'Vector', query ? `Preview semantic matches for “${query}”.` : 'Preview semantic matches by collection.', [
+      { label: 'Vector search', to: '/vector' },
+      { label: 'Preview' },
+    ]);
+  }
+
   if (pathname === '/vector/documents') {
     return base('Vector documents', 'Vector', 'Browse indexed document content and metadata by collection.', [
       { label: 'Vector search', to: '/vector' },

--- a/frontend/src/routePaths.ts
+++ b/frontend/src/routePaths.ts
@@ -8,6 +8,13 @@ export function menuSearchPath(query: string): string {
   return `/search?${new URLSearchParams({ q })}`;
 }
 
+
+export function vectorSearchPath(query = ''): string {
+  const qs = new URLSearchParams();
+  if (query.trim()) qs.set('q', query.trim());
+  return qs.toString() ? `/vector/search?${qs}` : '/vector/search';
+}
+
 export function vectorResultsPath(query: string): string {
   const qs = new URLSearchParams();
   if (query.trim()) qs.set('q', query.trim());

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -10,6 +10,7 @@ import { PluginsPage } from './pages/PluginsPage';
 import { SearchPage } from './pages/SearchPage';
 import { SettingsPage } from './pages/SettingsPage';
 import { VectorPage } from './pages/VectorPage';
+import { VectorSearchPage } from './pages/VectorSearchPage';
 import { VectorDocumentsPage } from './pages/VectorDocumentsPage';
 import { VectorSearchResultsPage } from './pages/VectorSearchResultsPage';
 import type { LoadState, MenuItem, PluginEntry } from './types';
@@ -62,6 +63,7 @@ export function DashboardRoutes({
       <Route path="/learn" element={<LearnPage />} />
       <Route path="/menu" element={menuPage} />
       <Route path="/vector" element={<VectorPage />} />
+      <Route path="/vector/search" element={<VectorSearchPage />} />
       <Route path="/vector/documents" element={<VectorDocumentsPage />} />
       <Route path="/vector/results" element={<VectorSearchResultsPage />} />
       <Route path="/mcp" element={<McpPage />} />

--- a/tests/frontend/api-client.test.ts
+++ b/tests/frontend/api-client.test.ts
@@ -23,7 +23,7 @@ describe('frontend API client', () => {
       },
       '/api/menu': { items: [{ label: 'Vector', path: '/vector', group: 'tools', order: 1, source: 'api' }] },
       '/api/menu/search?q=vector': { data: [{ label: 'Vector', path: '/vector', group: 'tools', order: 1, source: 'api' }], q: 'vector', total: 1 },
-      '/api/vector/search?q=oracle+memory&limit=5&type=docs': {
+      '/api/v1/vector/search?q=oracle+memory&limit=5&type=docs': {
         results: [{ id: 'doc-1', type: 'doc', content: 'Oracle memory', source_file: 'note.md', concepts: [] }],
         total: 1,
         offset: 0,
@@ -55,7 +55,7 @@ describe('frontend API client', () => {
       '/api/v1/metrics',
       '/api/menu',
       '/api/menu/search?q=vector',
-      '/api/vector/search?q=oracle+memory&limit=5&type=docs',
+      '/api/v1/vector/search?q=oracle+memory&limit=5&type=docs',
       '/api/v1/plugins',
     ]);
     for (const call of calls) {

--- a/tests/frontend/components/app-shell-vector-nav.test.tsx
+++ b/tests/frontend/components/app-shell-vector-nav.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+import { MemoryRouter } from 'react-router-dom';
+import { AppShell } from '../../../frontend/src/components/AppShell';
+import { htmlFor, installBrowserLocation } from '../_render';
+
+describe('AppShell Vector navigation', () => {
+  test('links to the vector search preview page from the sidebar', () => {
+    const restore = installBrowserLocation('/vector/search');
+    try {
+      const html = htmlFor(
+        <MemoryRouter initialEntries={['/vector/search']}>
+          <AppShell error="" loading={false} menuCount={0} pluginCount={0} surfaceCount={0} updatedAt="never" onRefresh={() => {}}>
+            <p>child</p>
+          </AppShell>
+        </MemoryRouter>,
+      );
+      expect(html).toContain('aria-label="Vector: Semantic preview by collection"');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/tests/frontend/pages/vector-search-page-collections.test.ts
+++ b/tests/frontend/pages/vector-search-page-collections.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test';
+import { collectionsFromModels } from '../../../frontend/src/pages/VectorSearchPage';
+
+describe('VectorSearchPage collection options', () => {
+  test('normalizes vector index models into collection selector rows', () => {
+    const collections = collectionsFromModels({
+      models: {
+        nomic: { collection: 'oracle_nomic', model: 'nomic-embed-text', adapter: 'lancedb', count: 4 },
+      },
+    });
+
+    expect(collections).toEqual([{ key: 'nomic', collection: 'oracle_nomic', model: 'nomic-embed-text', adapter: 'lancedb', count: 4 }]);
+  });
+});

--- a/tests/frontend/pages/vector-search-page-controls.test.tsx
+++ b/tests/frontend/pages/vector-search-page-controls.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'bun:test';
+import { VectorSearchPage } from '../../../frontend/src/pages/VectorSearchPage';
+import { htmlFor } from '../_render';
+
+describe('VectorSearchPage controls', () => {
+  test('renders query, collection, and submit controls for vector preview', () => {
+    const html = htmlFor(<VectorSearchPage />);
+
+    expect(html).toContain('Vector search preview');
+    expect(html).toContain('aria-label="Vector search query"');
+    expect(html).toContain('aria-label="Vector collection"');
+    expect(html).toContain('aria-label="Submit vector search"');
+    expect(html).toContain('/api/v1/vector/search');
+  });
+});

--- a/tests/frontend/pages/vector-search-page-distance.test.ts
+++ b/tests/frontend/pages/vector-search-page-distance.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from 'bun:test';
+import { distanceLabel, distancePercent } from '../../../frontend/src/pages/VectorSearchPage';
+
+describe('VectorSearchPage distance helpers', () => {
+  test('formats distance scores and inverse distance percentages', () => {
+    const result = { distance: 0.25 };
+
+    expect(distanceLabel(result)).toBe('0.250');
+    expect(distancePercent(result)).toBe(80);
+  });
+});

--- a/tests/frontend/pages/vector-search-page-preview.test.ts
+++ b/tests/frontend/pages/vector-search-page-preview.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from 'bun:test';
+import { contentPreview } from '../../../frontend/src/pages/VectorSearchPage';
+
+describe('VectorSearchPage content preview', () => {
+  test('compacts whitespace and truncates long content previews', () => {
+    const preview = contentPreview('Oracle\n\nmemory '.repeat(20), 24);
+
+    expect(preview).toBe('Oracle memory Oracle me…');
+  });
+});

--- a/tests/frontend/routes/vector-search-path.test.ts
+++ b/tests/frontend/routes/vector-search-path.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'bun:test';
+import { vectorSearchPath } from '../../../frontend/src/routePaths';
+
+describe('vectorSearchPath', () => {
+  test('encodes shareable vector search preview routes', () => {
+    expect(vectorSearchPath(' oracle memory ')).toBe('/vector/search?q=oracle+memory');
+    expect(vectorSearchPath()).toBe('/vector/search');
+  });
+});


### PR DESCRIPTION
## Summary\n- Add /vector/search preview page with query input, collection selector, submit flow, distance score bars, content previews, and metadata chips\n- Route the vector dashboard search widget and sidebar to the preview page\n- Move typed vector search client calls to /api/v1/vector/search\n\n## Verification\n- tsc --noEmit\n- bun test tests/frontend/\n- bun run build (frontend)\n\n## Notes\n- Existing /vector/results remains available for older links.