### PR TITLE
Add Tauri cargo check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,19 @@ jobs:
 
       - name: Typecheck
         run: bun run build
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Tauri Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgtk-3-dev \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf
+
+      - name: Check Tauri shell
+        run: cd frontend/src-tauri && cargo check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,22 @@ jobs:
           export PATH="$PWD/node_modules/.bin:$PATH"
           tsc --noEmit
 
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Tauri Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgtk-3-dev \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf
+
+      - name: Check Tauri shell
+        run: cd frontend/src-tauri && cargo check
+
       - name: Run scoped unit tests
         run: >
           bun test --isolate


### PR DESCRIPTION
## Summary
- add Rust toolchain setup, Tauri Linux system packages, and `cd frontend/src-tauri && cargo check` after typecheck in the CI workflow
- mirror the same cargo check in the alpha PR test workflow so the Tauri skeleton compiles during review CI too

## Verification
- `python -c` / `yaml.safe_load` for `.github/workflows/ci.yml` and `.github/workflows/test.yml`
- `actionlint .github/workflows/ci.yml .github/workflows/test.yml`
- `cd frontend/src-tauri && cargo check`
- `git diff --check`
- workflow files are <=250 lines
