### PR TITLE
Show Tauri desktop backend badge

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -6,6 +6,7 @@ import { routeMeta } from '../routeMeta';
 import { PageChrome } from './PageChrome';
 import { StatCard } from './StatCard';
 import { ThemeToggle } from './ThemeToggle';
+import { TauriBadge } from './TauriBadge';
 import { GlobalSearch } from './GlobalSearch';
 import type { MetricsSnapshot } from '../../../src/server/types';
 
@@ -88,6 +89,7 @@ export function AppShell({
             <div className="grid w-full gap-3 lg:max-w-md">
               <GlobalSearch />
               <div className="grid gap-3 sm:flex sm:items-center sm:justify-end">
+                <TauriBadge connected={!error} />
                 <ThemeToggle />
                 <button
                   aria-label="Refresh menu and plugin dashboard data"

--- a/frontend/src/components/TauriBadge.tsx
+++ b/frontend/src/components/TauriBadge.tsx
@@ -1,0 +1,28 @@
+type TauriWindow = Window & { __TAURI__?: unknown };
+
+export interface TauriBadgeProps {
+  connected: boolean;
+  runtime?: boolean;
+}
+
+export function isTauriRuntime(win: TauriWindow | undefined = typeof window === 'undefined' ? undefined : window): boolean {
+  return Boolean(win?.__TAURI__);
+}
+
+export function TauriBadge({ connected, runtime = isTauriRuntime() }: TauriBadgeProps) {
+  if (!runtime) return null;
+
+  const status = connected ? 'connected' : 'disconnected';
+  const dotClass = connected ? 'bg-emerald-400 shadow-emerald-400/40' : 'bg-red-400 shadow-red-400/40';
+
+  return (
+    <div
+      aria-label={`Desktop backend ${status}`}
+      className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-slate-900/80 px-3 py-2 text-xs font-semibold text-slate-100 shadow-sm dark:bg-white/5"
+    >
+      <span>Desktop</span>
+      <span className={`h-2 w-2 rounded-full shadow ${dotClass}`} aria-hidden="true" />
+      <span className="capitalize text-slate-300">{status}</span>
+    </div>
+  );
+}

--- a/tests/frontend/components/app-shell-tauri-badge.test.tsx
+++ b/tests/frontend/components/app-shell-tauri-badge.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test';
+import { MemoryRouter } from 'react-router-dom';
+import { AppShell } from '../../../frontend/src/components/AppShell';
+import { htmlFor, installBrowserLocation } from '../_render';
+
+describe('AppShell Tauri badge', () => {
+  test('renders the desktop backend badge in the header when Tauri is present', () => {
+    const restore = installBrowserLocation('/');
+    Object.assign(globalThis.window, { __TAURI__: {} });
+    try {
+      const html = htmlFor(
+        <MemoryRouter>
+          <AppShell error="" loading={false} menuCount={1} pluginCount={0} surfaceCount={0} updatedAt="now" onRefresh={() => {}}>
+            <p>content</p>
+          </AppShell>
+        </MemoryRouter>,
+      );
+      expect(html).toContain('Desktop');
+      expect(html).toContain('Desktop backend connected');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/tests/frontend/components/tauri-badge-connected.test.tsx
+++ b/tests/frontend/components/tauri-badge-connected.test.tsx
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test';
+import { TauriBadge, isTauriRuntime } from '../../../frontend/src/components/TauriBadge';
+import { htmlFor } from '../_render';
+
+describe('TauriBadge connected state', () => {
+  test('shows the desktop chip and connected backend status', () => {
+    const html = htmlFor(<TauriBadge connected runtime />);
+    expect(isTauriRuntime({ __TAURI__: {} } as Window & { __TAURI__: unknown })).toBe(true);
+    expect(html).toContain('Desktop');
+    expect(html).toContain('connected');
+    expect(html).toContain('bg-emerald-400');
+  });
+});

--- a/tests/frontend/components/tauri-badge-disconnected.test.tsx
+++ b/tests/frontend/components/tauri-badge-disconnected.test.tsx
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'bun:test';
+import { TauriBadge } from '../../../frontend/src/components/TauriBadge';
+import { htmlFor } from '../_render';
+
+describe('TauriBadge disconnected state', () => {
+  test('shows a red disconnected backend status', () => {
+    const html = htmlFor(<TauriBadge connected={false} runtime />);
+    expect(html).toContain('Desktop');
+    expect(html).toContain('disconnected');
+    expect(html).toContain('bg-red-400');
+  });
+});

--- a/tests/frontend/components/tauri-badge-hidden.test.tsx
+++ b/tests/frontend/components/tauri-badge-hidden.test.tsx
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'bun:test';
+import { TauriBadge } from '../../../frontend/src/components/TauriBadge';
+import { htmlFor } from '../_render';
+
+describe('TauriBadge outside desktop runtime', () => {
+  test('renders nothing when window.__TAURI__ is absent', () => {
+    expect(htmlFor(<TauriBadge connected runtime={false} />)).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary\n- add a Tauri-only Desktop badge component that detects window.__TAURI__\n- show green/red backend connection status in the AppShell header\n- cover hidden, connected, disconnected, and header wiring behaviors\n\n## Tests\n- bunx tsc --noEmit\n- cd frontend && bunx tsc --noEmit\n- bun test tests/frontend/\n\nFiles are <=250 lines; TauriBadge.tsx is 28 lines.