### PR TITLE
Detect Tauri frontend API base

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,7 @@
+import { apiUrl } from './api/oracle';
 import type { McpToolsResponse, MenuResponse, PluginsResponse, SearchResponse, SettingsSystemResponse } from './types';
+
+export { API_BASE, apiUrl, isTauri } from './api/oracle';
 
 export class ApiError extends Error {
   constructor(readonly status: number, message: string) {
@@ -12,7 +15,7 @@ async function getJson<T>(path: string, init?: RequestInit): Promise<T> {
   if (init?.body && !headers.has('content-type')) headers.set('content-type', 'application/json');
   let response: Response;
   try {
-    response = await fetch(path, { ...init, headers });
+    response = await fetch(apiUrl(path), { ...init, headers });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     throw new ApiError(0, `${path} is unreachable: ${message}`);

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -7,6 +7,7 @@ import type {
   VectorSearchResponse,
 } from '../../../src/server/types';
 import type { LearnCreateResponse, LearnDeleteResponse, LearnListResponse, LearnMutationPayload, LearnUpdateResponse } from '../types';
+import { API_BASE } from './oracle';
 
 export interface MenuSearchResponse {
   data: MenuItem[];
@@ -124,7 +125,7 @@ function backendMessage(payload: unknown, fallback: string): string {
   return fallback;
 }
 
-function urlFor(path: string, baseUrl?: string): string {
+function urlFor(path: string, baseUrl = API_BASE): string {
   if (!baseUrl) return path;
   return new URL(path, baseUrl).toString();
 }
@@ -246,5 +247,4 @@ export class ApiClient {
 }
 
 export const createApiClient = (options?: ApiClientOptions): ApiClient => new ApiClient(options);
-
 export const apiClient = createApiClient();

--- a/frontend/src/api/oracle.ts
+++ b/frontend/src/api/oracle.ts
@@ -1,0 +1,16 @@
+export const TAURI_API_BASE = 'http://localhost:47778';
+export const API_BASE = isTauri() ? TAURI_API_BASE : '';
+
+declare global {
+  interface Window {
+    __TAURI__?: unknown;
+  }
+}
+
+export function isTauri(): boolean {
+  return typeof window !== 'undefined' && '__TAURI__' in window;
+}
+
+export function apiUrl(path: string): string {
+  return API_BASE ? new URL(path, API_BASE).toString() : path;
+}

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { apiUrl } from '../api/oracle';
 
 export type ErrorReportStatus = 'idle' | 'reporting' | 'reported' | 'failed';
 export type ErrorReporter = (error: Error, info: ErrorInfo, retryCount: number) => Promise<boolean> | boolean;
@@ -64,7 +65,7 @@ export async function reportErrorToMetrics(
   };
 
   try {
-    const response = await fetcher('/api/metrics', {
+    const response = await fetcher(apiUrl('/api/metrics'), {
       method: 'POST',
       keepalive: true,
       headers: {

--- a/frontend/src/pages/VectorDocumentsPage.tsx
+++ b/frontend/src/pages/VectorDocumentsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { apiUrl } from '../api/oracle';
 
 type LoadState = 'idle' | 'loading' | 'ready' | 'error';
 
@@ -49,7 +50,7 @@ function isAbort(error: unknown): boolean {
 }
 
 async function fetchJson<T>(path: string, signal?: AbortSignal): Promise<T> {
-  const response = await fetch(path, { headers: { accept: 'application/json' }, signal });
+  const response = await fetch(apiUrl(path), { headers: { accept: 'application/json' }, signal });
   const text = await response.text();
   const data = text ? JSON.parse(text) : {};
   if (!response.ok) throw new Error(`${path} returned ${response.status}`);

--- a/frontend/src/pages/VectorPage.tsx
+++ b/frontend/src/pages/VectorPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { apiClient, type ApiClient, type VectorHealthResponse, type VectorIndexModelEntry, type VectorIndexModelsResponse } from '../api/client';
+import { apiUrl } from '../api/oracle';
 import { ErrorMessage, LoadingPanel, Spinner } from '../components/AsyncState';
 import { VectorIndexPanel } from '../components/VectorIndexPanel';
 import { VectorSearchWidget } from '../components/VectorSearchWidget';
@@ -73,9 +74,7 @@ export function vectorDashboardSummary(cards: VectorCollectionCard[], state: Pag
   return `${healthy}/${cards.length} vector collections healthy.`;
 }
 
-export function vectorExportPath(collection: string, format: VectorExportFormat): string {
-  return `/api/vector/export?${new URLSearchParams({ collection, format }).toString()}`;
-}
+export function vectorExportPath(collection: string, format: VectorExportFormat): string { return `/api/vector/export?${new URLSearchParams({ collection, format }).toString()}`; }
 
 export function vectorExportFilename(collection: string, format: VectorExportFormat): string {
   const safeName = collection.trim().replace(/[^a-z0-9._-]+/gi, '-').replace(/^-+|-+$/g, '') || 'collection';
@@ -102,7 +101,7 @@ export async function downloadVectorCollection(
 ): Promise<void> {
   const fetcher = deps.fetch ?? globalThis.fetch?.bind(globalThis);
   if (!fetcher) throw new Error('fetch is unavailable');
-  const response = await fetcher(vectorExportPath(collection, format), {
+  const response = await fetcher(apiUrl(vectorExportPath(collection, format)), {
     headers: { accept: format === 'json' ? 'application/json' : 'text/csv' },
   });
   if (!response.ok) throw new Error(`/api/vector/export returned ${response.status}`);


### PR DESCRIPTION
## Summary
- add a shared frontend API base helper that switches to `http://localhost:47778` when `window.__TAURI__` is present
- export `isTauri()`/`API_BASE`/`apiUrl()` for frontend callers
- route raw frontend API fetches and the API client through the shared helper

## Verification
- `tsc --noEmit`
- `cd frontend && bun run build`
- `git diff --check`
- `wc -l frontend/src/api/oracle.ts frontend/src/api/client.ts frontend/src/api.ts frontend/src/pages/VectorDocumentsPage.tsx frontend/src/pages/VectorPage.tsx frontend/src/components/ErrorBoundary.tsx`
