### PR TITLE
Add maw vector-config write commands

### DIFF
--- a/maw-plugin/README.md
+++ b/maw-plugin/README.md
@@ -36,6 +36,9 @@ maw arra menu
 maw arra vector
 maw arra vector-config
 maw arra vector-config --json
+maw arra vector-config set bge-m3 adapter qdrant
+maw arra vector-config reload
+maw arra vector-config test bge-m3
 
 maw arra trace "investigate auth loop" --scope project
 maw arra trace_list --status raw --limit 10

--- a/maw-plugin/__tests__/index.test.ts
+++ b/maw-plugin/__tests__/index.test.ts
@@ -74,6 +74,7 @@ describe('maw arra plugin', () => {
     expect(help.output).toContain('index');
     expect(help.output).toContain('vector');
     expect(help.output).toContain('vector-config [--json]');
+    expect(help.output).toContain('vector-config reload');
     expect(help.output).toContain('trace_chain');
     expect(help.output).toContain('thread_update');
     expect(help.output).toContain('serve [--stop|--status] [--port N]');
@@ -181,6 +182,9 @@ describe('maw arra plugin', () => {
       [['thread_update', '42', '--status', 'closed'], 'PATCH', '/api/thread/42/status', { status: 'closed' }],
       [['vector_index', '--model', 'nomic'], 'POST', '/api/vector/index/start', { model: 'nomic' }],
       [['vector_stop'], 'POST', '/api/vector/index/stop', undefined],
+      [['vector-config', 'set', 'bge-m3', 'adapter', 'qdrant'], 'PUT', '/api/v1/vector/config/bge-m3', { adapter: 'qdrant' }],
+      [['vector-config', 'reload'], 'POST', '/api/v1/vector/config/reload', undefined],
+      [['vector-config', 'test', 'bge-m3'], 'POST', '/api/v1/vector/config/bge-m3/test', undefined],
       [['verify', '--check', 'false', '--type', 'learning'], 'POST', '/api/verify', { check: false, type: 'learning' }],
     ];
 

--- a/maw-plugin/index.ts
+++ b/maw-plugin/index.ts
@@ -9,7 +9,7 @@ type Opener = (url: string) => void;
 type RunOptions = { cwd?: string; env?: Record<string, string | undefined>; inherit?: boolean; capture?: boolean };
 type RunResult = { code: number | null; stdout?: string; stderr?: string };
 type Runner = (cmd: string, args: string[], options?: RunOptions) => Promise<RunResult>;
-type Method = 'GET' | 'POST' | 'PATCH' | 'DELETE';
+type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 type Parsed = { pos: string[]; flags: Record<string, string | boolean> };
 type Built = { path: string; query?: Record<string, unknown>; body?: Record<string, unknown> };
 type Spec = { tool: string; method: Method; help: string; write?: boolean; build: (p: Parsed) => Built; format?: (data: any, p: Parsed) => string };
@@ -131,30 +131,38 @@ function formatStats(data: any): string { return ['arra stats', data?.total_docu
 function formatRows(label: string, keys: string[]) { return (data: any) => { const rows = keys.map(k => data?.[k]).find(Array.isArray) ?? []; const total = data?.total ?? data?.chain_length ?? rows.length; return Array.isArray(rows) ? [`arra ${label}: ${total} item${Number(total) === 1 ? '' : 's'}`, ...rows.slice(0, 8).map((r: any) => `- ${r.id ?? r.trace_id ?? r.path ?? r.filename ?? r.name ?? '?'} ${one(r.title ?? r.query ?? r.content ?? r.preview ?? r.label ?? '')}`)].join('\n') : `arra ${label}: ${preview(data)}`; }; }
 function formatOk(label: string) { return (data: any) => [`arra ${label}: ${data?.success === false ? 'failed' : 'ok'}`, data?.id && `id: ${data.id}`, data?.trace_id && `trace_id: ${data.trace_id}`, data?.thread_id && `thread_id: ${data.thread_id}`, data?.message && one(data.message), data?.error && `error: ${one(data.error)}`].filter(Boolean).join('\n') || `arra ${label}: ${preview(data)}`; }
 function formatVectorConfig(data: any): string {
-  const models = data?.models?.models && typeof data.models.models === 'object' ? data.models.models : {};
-  const engines = Array.isArray(data?.health?.engines) ? data.health.engines : [];
-  const lines = ['Collection | Adapter | Model | Docs | Status'];
+  const models = data?.models?.models && typeof data.models.models === 'object' ? data.models.models : {}, engines = Array.isArray(data?.health?.engines) ? data.health.engines : [], lines = ['Collection | Adapter | Model | Docs | Status'];
   for (const [key, raw] of Object.entries(models)) {
-    const m = raw as any;
-    const engine = engines.find((e: any) => e.key === key || e.collection === m.collection || e.model === m.model);
-    const status = engine ? (engine.ok === false ? 'down' : 'ok') : (data?.health?.status ?? 'unknown');
-    lines.push(`${m.collection ?? key} | ${m.adapter ?? 'lancedb'} | ${m.model ?? key} | ${m.count ?? m.docs ?? 0} | ${status}`);
+    const m = raw as any, engine = engines.find((e: any) => e.key === key || e.collection === m.collection || e.model === m.model);
+    lines.push(`${m.collection ?? key} | ${m.adapter ?? 'lancedb'} | ${m.model ?? key} | ${m.count ?? m.docs ?? 0} | ${engine ? (engine.ok === false ? 'down' : 'ok') : (data?.health?.status ?? 'unknown')}`);
   }
   if (lines.length === 1) lines.push('(none) | - | - | 0 | ' + (data?.health?.status ?? 'unknown'));
   return lines.join('\n');
 }
-
+function formatVectorConfigWrite(data: any) { return ['arra vector-config: ' + (data?.success === false ? 'failed' : 'ok'), data?.collection && `collection: ${data.collection}`, data?.adapter && `adapter: ${data.adapter}`, data?.count !== undefined && `count: ${data.count}`, data?.error && `error: ${one(data.error)}`].filter(Boolean).join('\n'); }
+const VC_HELP = 'vector-config [--json] | vector-config set <collection> adapter <lancedb|qdrant|sqlite-vec|chroma> | vector-config reload | vector-config test <collection>';
+function buildVectorConfig(p: Parsed): { method: Method; built: Built } | undefined {
+  const action = key(p.pos[0] || ''), collection = p.pos[1], adapter = p.pos[3];
+  if (!action) return undefined;
+  if (action === 'reload') return { method: 'POST', built: route('/api/v1/vector/config/reload') };
+  if (!collection) throw new Error('collection required');
+  if (action === 'test') return { method: 'POST', built: route(`/api/v1/vector/config/${enc(collection)}/test`) };
+  if (action !== 'set' || key(p.pos[2] || '') !== 'adapter') throw new Error(VC_HELP);
+  if (!['lancedb', 'qdrant', 'sqlite-vec', 'chroma'].includes(adapter)) throw new Error('adapter must be lancedb, qdrant, sqlite-vec, or chroma');
+  return { method: 'PUT', built: route(`/api/v1/vector/config/${enc(collection)}`, undefined, { adapter }) };
+}
 async function runVectorConfig(parsed: Parsed, request: Requester): Promise<InvokeResult> {
   try {
-    const init: RequestInit = { method: 'GET' };
-    const data = {
-      models: await request('/api/vector/index/models', init),
-      health: await request('/api/vector/health', init),
-    };
+    const write = buildVectorConfig(parsed);
+    if (write) {
+      const init: RequestInit = { method: write.method, headers: authHeaders() };
+      if (write.built.body) init.body = JSON.stringify(write.built.body);
+      return { ok: true, output: formatVectorConfigWrite(await request(qs(write.built.path, write.built.query), init)) };
+    }
+    const init: RequestInit = { method: 'GET' }, data = { models: await request('/api/vector/index/models', init), health: await request('/api/vector/health', init) };
     return { ok: true, output: b(parsed, 'json') ? JSON.stringify(data, null, 2) : formatVectorConfig(data) };
   } catch (error) { return { ok: false, error: error instanceof Error ? error.message : String(error) }; }
 }
-
 export const COMMANDS: Record<string, Spec> = {
   search: { tool: 'oracle_search', method: 'GET', help: 'search <q> [--mode fts|hybrid|vector] [--limit N]', build: p => route('/api/search', { q: text(p, 'query', 'query'), type: f(p, 'type'), limit: f(p, 'limit') || '5', offset: f(p, 'offset'), mode: f(p, 'mode') || 'fts', project: f(p, 'project'), cwd: f(p, 'cwd'), model: f(p, 'model') }), format: formatSearch },
   learn: { tool: 'oracle_learn', method: 'POST', write: true, help: 'learn <text> [--project P] [--source S] [--concepts a,b]', build: p => route('/api/learn', undefined, { pattern: text(p, 'pattern', 'text'), project: f(p, 'project'), source: f(p, 'source'), concepts: f(p, 'concepts')?.split(',').map(s => s.trim()).filter(Boolean) }), format: formatOk('learn') },
@@ -170,7 +178,7 @@ export const COMMANDS: Record<string, Spec> = {
   vector_status: { tool: 'oracle_vector_status', method: 'GET', help: 'vector-status', build: () => route('/api/vector/index/status'), format: d => `arra vector-status: ${preview(d, 700)}` },
   vector_stop: { tool: 'oracle_vector_stop', method: 'POST', write: true, help: 'vector-stop', build: () => route('/api/vector/index/stop'), format: formatOk('vector-stop') },
   vector_models: { tool: 'oracle_vector_models', method: 'GET', help: 'vector-models', build: () => route('/api/vector/index/models'), format: d => `arra vector-models: ${preview(d, 700)}` },
-  vector_config: { tool: 'oracle_vector_config', method: 'GET', help: 'vector-config [--json]', build: () => route('/api/vector/index/models'), format: formatVectorConfig },
+  vector_config: { tool: 'oracle_vector_config', method: 'GET', help: VC_HELP, build: () => route('/api/vector/index/models'), format: formatVectorConfig },
   health: { tool: 'oracle_health', method: 'GET', help: 'health', build: () => route('/api/health'), format: formatHealth },
   trace: { tool: 'oracle_trace', method: 'POST', write: true, help: 'trace <query> [--scope project|cross-project|human]', build: p => route('/api/traces', undefined, { query: text(p, 'query', 'query'), queryType: f(p, 'query_type'), scope: f(p, 'scope'), parentTraceId: f(p, 'parent_trace_id'), project: f(p, 'project'), agentCount: n(p, 'agent_count'), durationMs: n(p, 'duration_ms') }), format: formatOk('trace') },
   trace_list: { tool: 'oracle_trace_list', method: 'GET', help: 'trace_list [--query Q] [--status S] [--project P] [--limit N]', build: p => route('/api/traces', { query: f(p, 'query'), status: f(p, 'status'), project: f(p, 'project'), limit: f(p, 'limit'), offset: f(p, 'offset') }), format: formatRows('trace_list', ['traces']) },

--- a/src/routes/vector/config-api.ts
+++ b/src/routes/vector/config-api.ts
@@ -17,7 +17,7 @@ import {
   type VectorCollectionConfig,
   type VectorServerConfig,
 } from '../../vector/config.ts';
-import { createVectorStoreForModel } from '../../vector/factory.ts';
+import { closeCachedVectorStores, createVectorStoreForModel } from '../../vector/factory.ts';
 import type { VectorDBType } from '../../vector/types.ts';
 
 const adapterSchema = t.Union([
@@ -48,6 +48,16 @@ function activeConfig(): { source: 'file' | 'defaults'; config: VectorServerConf
 
 function currentConfigPath(): string {
   return process.env.ORACLE_DATA_DIR ? configPath(process.env.ORACLE_DATA_DIR) : configPath();
+}
+
+function resolveCollection(
+  config: VectorServerConfig,
+  collection: string,
+): [string, VectorCollectionConfig] | null {
+  const direct = config.collections[collection];
+  if (direct) return [collection, direct];
+  return Object.entries(config.collections)
+    .find(([, value]) => value.collection === collection) ?? null;
 }
 
 function atomicWriteVectorConfig(config: VectorServerConfig): string {
@@ -155,6 +165,29 @@ export const vectorConfigApiEndpoint = new Elysia()
   }, {
     detail: { tags: ['vector'], summary: 'Vector server config with collection health' },
   })
+  .post('/vector/config/reload', async () => {
+    await closeCachedVectorStores();
+    const { source, config } = activeConfig();
+    return { success: true, reloaded: true, source, config };
+  }, {
+    detail: { tags: ['vector'], summary: 'Reload vector config and clear cached vector stores' },
+  })
+  .post('/vector/config/:collection/test', async ({ params, set }) => {
+    const { config } = activeConfig();
+    const resolved = resolveCollection(config, params.collection);
+    if (!resolved) {
+      set.status = 404;
+      return { error: `Unknown vector collection: ${params.collection}` };
+    }
+
+    const [key, col] = resolved;
+    const health = await inspectCollection(key, col, config);
+    if (!health.ok) set.status = 503;
+    return { success: health.ok, ...health };
+  }, {
+    params: t.Object({ collection: t.String({ minLength: 1 }) }),
+    detail: { tags: ['vector'], summary: 'Test one vector collection adapter' },
+  })
   .put('/vector/config/:collection', ({ params, body, set }) => {
     const update = normalizedUpdate(body);
     if ('error' in update) {
@@ -163,21 +196,22 @@ export const vectorConfigApiEndpoint = new Elysia()
     }
 
     const { source, config } = activeConfig();
-    const current = config.collections[params.collection];
-    if (!current) {
+    const resolved = resolveCollection(config, params.collection);
+    if (!resolved) {
       set.status = 404;
       return { error: `Unknown vector collection: ${params.collection}` };
     }
+    const [key, current] = resolved;
 
     const next: VectorServerConfig = {
       ...config,
       collections: {
         ...config.collections,
-        [params.collection]: { ...current, ...update },
+        [key]: { ...current, ...update },
       },
     };
     const path = atomicWriteVectorConfig(next);
-    return { success: true, source, path, collection: params.collection, config: next };
+    return { success: true, source, path, collection: key, config: next };
   }, {
     params: t.Object({ collection: t.String({ minLength: 1 }) }),
     body: t.Object({

--- a/src/routes/vector/index.ts
+++ b/src/routes/vector/index.ts
@@ -12,6 +12,8 @@
  *   GET /api/vector/documents — browse indexed vector documents
  *   GET /api/v1/vector/config — config + per-collection health/counts
  *   PUT /api/v1/vector/config/:collection — update collection adapter/model/provider
+ *   POST /api/v1/vector/config/reload — clear cached vector stores
+ *   POST /api/v1/vector/config/:collection/test — probe one collection
  *
  * Mounted with the `/api` prefix from server.ts. Phase 1 of #1071: separating
  * the vector layer from FTS/hybrid so it can later move behind VECTOR_URL.

--- a/tests/http/vector/config-api.test.ts
+++ b/tests/http/vector/config-api.test.ts
@@ -67,6 +67,15 @@ test('GET and PUT /api/v1/vector/config expose and update vector-server.json', a
   });
   expect(getRes.body.collections[0].count).toEqual(expect.any(Number));
 
+  const testRes = await call('/api/v1/vector/config/phase1/test', { method: 'POST' });
+  expect(testRes.status).toBe(200);
+  expect(testRes.body).toMatchObject({
+    success: true,
+    key: 'phase1',
+    collection: 'phase1_collection',
+    adapter: 'lancedb',
+  });
+
   const emptyUpdate = await call('/api/v1/vector/config/phase1', {
     method: 'PUT',
     headers: { 'content-type': 'application/json' },
@@ -102,5 +111,10 @@ test('GET and PUT /api/v1/vector/config expose and update vector-server.json', a
     provider: 'remote',
     adapter: 'qdrant',
   });
+
+  const reloadRes = await call('/api/v1/vector/config/reload', { method: 'POST' });
+  expect(reloadRes.status).toBe(200);
+  expect(reloadRes.body).toMatchObject({ success: true, reloaded: true, source: 'file' });
+  expect(reloadRes.body.config.collections.phase1.adapter).toBe('qdrant');
   expect(readdirSync(root).some((name) => name.includes('.tmp'))).toBe(false);
 });


### PR DESCRIPTION
## Summary
- add maw arra vector-config set/reload/test write actions
- add versioned vector config reload and per-collection test endpoints
- cover CLI routing plus vector config API behavior

## Verification
- tsc --noEmit
- bun test tests/http/vector/
- bun test maw-plugin/__tests__/index.test.ts maw-plugin/__tests__/vector-config.test.ts
- MAW_PLUGINS_DIR smoke: maw arra vector-config set/reload/test against an ephemeral Elysia server