### PR TITLE
Auto-start the local API from Tauri

### DIFF
--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -1,6 +1,8 @@
 use std::{
+    net::{TcpStream, ToSocketAddrs},
     path::PathBuf,
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use tauri::{AppHandle, Manager, State};
@@ -10,6 +12,8 @@ use tauri_plugin_shell::{
 };
 
 const BACKEND_URL: &str = "http://localhost:47778";
+const BACKEND_HEALTH_URL: &str = "http://localhost:47778/api/health";
+const BACKEND_HOST: &str = "localhost:47778";
 
 #[derive(Clone, Default)]
 struct BackendState {
@@ -25,8 +29,38 @@ fn project_root() -> Result<PathBuf, String> {
         .ok_or_else(|| "failed to resolve project root".to_string())
 }
 
-#[tauri::command]
-fn start_backend(app: AppHandle, state: State<BackendState>) -> Result<String, String> {
+fn backend_is_reachable() -> bool {
+    let timeout = Duration::from_millis(500);
+    match BACKEND_HOST.to_socket_addrs() {
+        Ok(addrs) => addrs
+            .into_iter()
+            .any(|addr| TcpStream::connect_timeout(&addr, timeout).is_ok()),
+        Err(err) => {
+            eprintln!("[Tauri] Could not resolve {BACKEND_HOST}: {err}");
+            false
+        }
+    }
+}
+
+fn log_backend_event(event: &CommandEvent) {
+    match event {
+        CommandEvent::Stdout(line) => {
+            print!("[Tauri backend stdout] {}", String::from_utf8_lossy(line));
+        }
+        CommandEvent::Stderr(line) => {
+            eprint!("[Tauri backend stderr] {}", String::from_utf8_lossy(line));
+        }
+        CommandEvent::Error(message) => {
+            eprintln!("[Tauri backend error] {message}");
+        }
+        CommandEvent::Terminated(payload) => {
+            println!("[Tauri] Backend process exited with code {:?}", payload.code);
+        }
+        _ => {}
+    }
+}
+
+fn spawn_backend<R: tauri::Runtime>(app: &AppHandle<R>, state: &BackendState) -> Result<String, String> {
     let mut guard = state
         .child
         .lock()
@@ -49,10 +83,11 @@ fn start_backend(app: AppHandle, state: State<BackendState>) -> Result<String, S
     let pid = child.pid();
     *guard = Some(child);
 
-    let state_for_task = state.inner().clone();
+    let state_for_task = state.clone();
     tauri::async_runtime::spawn(async move {
         while let Some(event) = events.recv().await {
-            if matches!(event, CommandEvent::Terminated(_) | CommandEvent::Error(_)) {
+            log_backend_event(&event);
+            if matches!(&event, CommandEvent::Terminated(_) | CommandEvent::Error(_)) {
                 if let Ok(mut child) = state_for_task.child.lock() {
                     if child.as_ref().is_some_and(|current| current.pid() == pid) {
                         *child = None;
@@ -64,6 +99,15 @@ fn start_backend(app: AppHandle, state: State<BackendState>) -> Result<String, S
     });
 
     Ok(format!("backend started at {BACKEND_URL} (pid {pid})"))
+}
+
+#[tauri::command]
+fn start_backend(app: AppHandle, state: State<BackendState>) -> Result<String, String> {
+    if backend_is_reachable() {
+        println!("[Tauri] Backend already reachable at {BACKEND_URL}");
+        return Ok(format!("backend already reachable at {BACKEND_URL}"));
+    }
+    spawn_backend(&app, state.inner())
 }
 
 #[tauri::command]
@@ -89,14 +133,7 @@ fn stop_backend(state: State<BackendState>) -> Result<String, String> {
 #[tauri::command]
 fn health_check() -> Result<String, String> {
     let resp = std::process::Command::new("curl")
-        .args([
-            "-s",
-            "-o",
-            "/dev/null",
-            "-w",
-            "%{http_code}",
-            "http://localhost:47778/api/health",
-        ])
+        .args(["-s", "-o", "/dev/null", "-w", "%{http_code}", BACKEND_HEALTH_URL])
         .output()
         .map_err(|e| e.to_string())?;
     let status = String::from_utf8_lossy(&resp.stdout).to_string();
@@ -106,6 +143,24 @@ fn health_check() -> Result<String, String> {
 #[tauri::command]
 fn get_backend_url() -> String {
     BACKEND_URL.to_string()
+}
+
+fn autostart_backend<R: tauri::Runtime>(app: &tauri::App<R>) {
+    if backend_is_reachable() {
+        println!("[Tauri] Backend already reachable at {BACKEND_URL}");
+        return;
+    }
+
+    let handle = app.handle().clone();
+    let state = app.state::<BackendState>().inner().clone();
+    println!("[Tauri] Backend not reachable at {BACKEND_URL}; spawning `bun run server`");
+
+    tauri::async_runtime::spawn(async move {
+        match spawn_backend(&handle, &state) {
+            Ok(message) => println!("[Tauri] {message}"),
+            Err(err) => eprintln!("[Tauri] Failed to auto-start backend: {err}"),
+        }
+    });
 }
 
 pub fn run() {
@@ -122,6 +177,7 @@ pub fn run() {
         .setup(|app| {
             let window = app.get_webview_window("main").unwrap();
             window.set_title("ARRA Oracle").unwrap();
+            autostart_backend(app);
             Ok(())
         })
         .run(tauri::generate_context!())


### PR DESCRIPTION
## Summary
- Check localhost:47778 during Tauri setup and reuse an already-running backend.
- Spawn `bun run server` through tauri-plugin-shell when the backend is unreachable.
- Log backend startup and child process output/termination to the console.

## Verification
- `cargo check` in `frontend/src-tauri/`
- `git diff --check HEAD~2..HEAD`
- `wc -l frontend/src-tauri/src/lib.rs frontend/src-tauri/build.rs frontend/src-tauri/tauri.conf.json` (all files <=250 lines)

Not tested: manual Tauri window launch with a stopped backend.