### PR TITLE
Extract vector export formatter registry

### DIFF
--- a/src/routes/vector/export.ts
+++ b/src/routes/vector/export.ts
@@ -4,96 +4,17 @@
 
 import { Elysia, t } from 'elysia';
 import { getVectorStoreByModel } from '../../vector/factory.ts';
+import { exportFormatters } from '../../vector/export-formats.ts';
 import type { VectorStoreAdapter } from '../../vector/types.ts';
-
-interface ExportRow {
-  id: string;
-  document: string;
-  type: string;
-  source_file: string;
-  concepts: string[];
-}
 
 interface VectorExportDeps {
   getStore?: (collection?: string) => VectorStoreAdapter;
 }
 
-type ExportFormat = 'json' | 'csv';
-type EmbeddingDump = Awaited<ReturnType<NonNullable<VectorStoreAdapter['getAllEmbeddings']>>>;
-
 const DEFAULT_COLLECTION = 'bge-m3';
 const DEFAULT_EXPORT_LIMIT = 50_000;
-const encoder = new TextEncoder();
 
-function text(value: unknown): string {
-  if (typeof value === 'string') return value;
-  if (value == null) return '';
-  return String(value);
-}
-
-function concepts(value: unknown): string[] {
-  if (Array.isArray(value)) return value.map(text).filter(Boolean);
-  if (typeof value !== 'string') return [];
-  try {
-    const parsed = JSON.parse(value);
-    if (Array.isArray(parsed)) return parsed.map(text).filter(Boolean);
-  } catch { /* fall through to comma split */ }
-  return value.split(',').map((part) => part.trim()).filter(Boolean);
-}
-
-function rowAt(dump: EmbeddingDump, index: number): ExportRow {
-  const metadata = dump.metadatas[index] ?? {};
-  const meta = metadata && typeof metadata === 'object' ? metadata as Record<string, unknown> : {};
-  return {
-    id: text(dump.ids[index]),
-    document: text(dump.documents?.[index] ?? meta.document ?? meta.content ?? meta.text),
-    type: text(meta.type),
-    source_file: text(meta.source_file ?? meta.sourceFile),
-    concepts: concepts(meta.concepts),
-  };
-}
-
-function streamJson(dump: EmbeddingDump): ReadableStream<Uint8Array> {
-  return new ReadableStream({
-    start(controller) {
-      controller.enqueue(encoder.encode('['));
-      for (let i = 0; i < dump.ids.length; i++) {
-        if (i > 0) controller.enqueue(encoder.encode(','));
-        controller.enqueue(encoder.encode(JSON.stringify(rowAt(dump, i))));
-      }
-      controller.enqueue(encoder.encode(']'));
-      controller.close();
-    },
-  });
-}
-
-function csvCell(value: unknown): string {
-  return `"${text(value).replaceAll('"', '""')}"`;
-}
-
-function csvLine(row: ExportRow): string {
-  return [
-    csvCell(row.id),
-    csvCell(row.document),
-    csvCell(row.type),
-    csvCell(row.source_file),
-    csvCell(JSON.stringify(row.concepts)),
-  ].join(',');
-}
-
-function streamCsv(dump: EmbeddingDump): ReadableStream<Uint8Array> {
-  return new ReadableStream({
-    start(controller) {
-      controller.enqueue(encoder.encode('id,document,type,source_file,concepts\n'));
-      for (let i = 0; i < dump.ids.length; i++) {
-        controller.enqueue(encoder.encode(`${csvLine(rowAt(dump, i))}\n`));
-      }
-      controller.close();
-    },
-  });
-}
-
-function contentType(format: ExportFormat): string {
+function contentType(format: string): string {
   return format === 'csv' ? 'text/csv; charset=utf-8' : 'application/json; charset=utf-8';
 }
 
@@ -103,10 +24,11 @@ export function createVectorExportEndpoint(deps: VectorExportDeps = {}) {
   return new Elysia().get(
     '/vector/export',
     async ({ query, set }) => {
-      const format = (query.format || 'json') as ExportFormat;
-      if (format !== 'json' && format !== 'csv') {
+      const format = query.format || 'json';
+      const formatter = exportFormatters[format];
+      if (!formatter) {
         set.status = 400;
-        return { error: 'Invalid format: expected json or csv' };
+        return { error: `Invalid format: expected ${Object.keys(exportFormatters).join(' or ')}` };
       }
 
       const collection = query.collection || DEFAULT_COLLECTION;
@@ -122,7 +44,7 @@ export function createVectorExportEndpoint(deps: VectorExportDeps = {}) {
         const stats = await store.getStats().catch(() => ({ count: 0 }));
         const limit = stats.count > 0 ? stats.count : DEFAULT_EXPORT_LIMIT;
         const dump = await store.getAllEmbeddings(limit);
-        const stream = format === 'csv' ? streamCsv(dump) : streamJson(dump);
+        const stream = formatter(dump);
 
         return new Response(stream, {
           headers: {

--- a/src/vector/export-formats.ts
+++ b/src/vector/export-formats.ts
@@ -1,0 +1,89 @@
+import type { VectorStoreAdapter } from './types.ts';
+
+export type EmbeddingDump = Awaited<ReturnType<NonNullable<VectorStoreAdapter['getAllEmbeddings']>>>;
+export type ExportFormatter = (dump: EmbeddingDump) => ReadableStream<Uint8Array>;
+
+interface ExportRow {
+  id: string;
+  document: string;
+  type: string;
+  source_file: string;
+  concepts: string[];
+}
+
+const encoder = new TextEncoder();
+
+function text(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value == null) return '';
+  return String(value);
+}
+
+function concepts(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map(text).filter(Boolean);
+  if (typeof value !== 'string') return [];
+  try {
+    const parsed = JSON.parse(value);
+    if (Array.isArray(parsed)) return parsed.map(text).filter(Boolean);
+  } catch {
+    // fall through to comma split
+  }
+  return value.split(',').map((part) => part.trim()).filter(Boolean);
+}
+
+function rowAt(dump: EmbeddingDump, index: number): ExportRow {
+  const metadata = dump.metadatas[index] ?? {};
+  const meta = metadata && typeof metadata === 'object' ? metadata as Record<string, unknown> : {};
+  return {
+    id: text(dump.ids[index]),
+    document: text(dump.documents?.[index] ?? meta.document ?? meta.content ?? meta.text),
+    type: text(meta.type),
+    source_file: text(meta.source_file ?? meta.sourceFile),
+    concepts: concepts(meta.concepts),
+  };
+}
+
+function streamJson(dump: EmbeddingDump): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode('['));
+      for (let i = 0; i < dump.ids.length; i++) {
+        if (i > 0) controller.enqueue(encoder.encode(','));
+        controller.enqueue(encoder.encode(JSON.stringify(rowAt(dump, i))));
+      }
+      controller.enqueue(encoder.encode(']'));
+      controller.close();
+    },
+  });
+}
+
+function csvCell(value: unknown): string {
+  return `"${text(value).replaceAll('"', '""')}"`;
+}
+
+function csvLine(row: ExportRow): string {
+  return [
+    csvCell(row.id),
+    csvCell(row.document),
+    csvCell(row.type),
+    csvCell(row.source_file),
+    csvCell(JSON.stringify(row.concepts)),
+  ].join(',');
+}
+
+function streamCsv(dump: EmbeddingDump): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode('id,document,type,source_file,concepts\n'));
+      for (let i = 0; i < dump.ids.length; i++) {
+        controller.enqueue(encoder.encode(`${csvLine(rowAt(dump, i))}\n`));
+      }
+      controller.close();
+    },
+  });
+}
+
+export const exportFormatters: Record<string, ExportFormatter> = {
+  json: streamJson,
+  csv: streamCsv,
+};


### PR DESCRIPTION
## Summary
- Added `src/vector/export-formats.ts` with `EmbeddingDump`, `ExportFormatter`, and a `Record<string, ExportFormatter>` registry for JSON/CSV streams.
- Moved JSON and CSV row serialization out of `src/routes/vector/export.ts`.
- Refactored the vector export route to select a formatter from the registry while preserving existing JSON/CSV behavior.

## Verification
- `tsc --noEmit`
- `bun test tests/http/vector/`
- `git diff --check`
- `wc -l src/routes/vector/export.ts src/vector/export-formats.ts`