### PR TITLE
Add JSONL vector export format

### DIFF
--- a/src/routes/vector/export.ts
+++ b/src/routes/vector/export.ts
@@ -1,5 +1,5 @@
 /**
- * GET /api/vector/export — stream a vector collection as JSON or CSV.
+ * GET /api/vector/export — stream a vector collection as JSON, JSONL, or CSV.
  */
 
 import { Elysia, t } from 'elysia';
@@ -15,6 +15,7 @@ const DEFAULT_COLLECTION = 'bge-m3';
 const DEFAULT_EXPORT_LIMIT = 50_000;
 
 function contentType(format: string): string {
+  if (format === 'jsonl') return 'application/x-ndjson; charset=utf-8';
   return format === 'csv' ? 'text/csv; charset=utf-8' : 'application/json; charset=utf-8';
 }
 
@@ -66,7 +67,7 @@ export function createVectorExportEndpoint(deps: VectorExportDeps = {}) {
       detail: {
         tags: ['vector'],
         menu: { group: 'tools', order: 57 },
-        summary: 'Export a vector collection as JSON or CSV',
+        summary: 'Export a vector collection as JSON, JSONL, or CSV',
       },
     },
   );

--- a/src/vector/export-formats.ts
+++ b/src/vector/export-formats.ts
@@ -57,6 +57,17 @@ function streamJson(dump: EmbeddingDump): ReadableStream<Uint8Array> {
   });
 }
 
+function streamJsonl(dump: EmbeddingDump): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (let i = 0; i < dump.ids.length; i++) {
+        controller.enqueue(encoder.encode(`${JSON.stringify(rowAt(dump, i))}\n`));
+      }
+      controller.close();
+    },
+  });
+}
+
 function csvCell(value: unknown): string {
   return `"${text(value).replaceAll('"', '""')}"`;
 }
@@ -85,5 +96,6 @@ function streamCsv(dump: EmbeddingDump): ReadableStream<Uint8Array> {
 
 export const exportFormatters: Record<string, ExportFormatter> = {
   json: streamJson,
+  jsonl: streamJsonl,
   csv: streamCsv,
 };

--- a/tests/http/vector/export-jsonl.test.ts
+++ b/tests/http/vector/export-jsonl.test.ts
@@ -1,0 +1,59 @@
+import { expect, mock, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createVectorExportEndpoint } from '../../../src/routes/vector/export.ts';
+import type { VectorStoreAdapter } from '../../../src/vector/types.ts';
+
+function createStore(): VectorStoreAdapter {
+  return {
+    name: 'fake-vector',
+    connect: mock(async () => {}),
+    close: mock(async () => {}),
+    ensureCollection: mock(async () => {}),
+    deleteCollection: mock(async () => {}),
+    addDocuments: mock(async () => {}),
+    query: mock(async () => ({ ids: [], documents: [], distances: [], metadatas: [] })),
+    queryById: mock(async () => ({ ids: [], documents: [], distances: [], metadatas: [] })),
+    getStats: mock(async () => ({ count: 2 })),
+    getCollectionInfo: mock(async () => ({ count: 2, name: 'fake' })),
+    getAllEmbeddings: mock(async () => ({
+      ids: ['doc-1', 'doc-2'],
+      documents: ['alpha document', 'bravo document'],
+      embeddings: [[0, 0, 0], [1, 1, 1]],
+      metadatas: [
+        { type: 'learning', source_file: 'notes/alpha.md', concepts: '["alpha","beta"]' },
+        { type: 'trace', sourceFile: 'traces/bravo.md', concepts: ['gamma'] },
+      ],
+    })),
+  };
+}
+
+test('GET /api/v1/vector/export streams JSONL rows', async () => {
+  const app = new Elysia({ prefix: '/api' }).use(createVectorExportEndpoint({ getStore: () => createStore() }));
+  const fetcher = createApiVersionedFetch((request) => app.handle(request));
+
+  const res = await fetcher(new Request(
+    'http://local/api/v1/vector/export?collection=bge-m3&format=jsonl',
+  ));
+  const lines = (await res.text()).trimEnd().split('\n').map((line) => JSON.parse(line));
+
+  expect(res.status).toBe(200);
+  expect(res.headers.get('content-type')).toContain('application/x-ndjson');
+  expect(res.headers.get('content-disposition')).toContain('bge-m3.jsonl');
+  expect(lines).toEqual([
+    {
+      id: 'doc-1',
+      document: 'alpha document',
+      type: 'learning',
+      source_file: 'notes/alpha.md',
+      concepts: ['alpha', 'beta'],
+    },
+    {
+      id: 'doc-2',
+      document: 'bravo document',
+      type: 'trace',
+      source_file: 'traces/bravo.md',
+      concepts: ['gamma'],
+    },
+  ]);
+});


### PR DESCRIPTION
## Summary
- add a JSONL formatter to the shared vector export formatter registry
- return newline-delimited JSON rows with `application/x-ndjson` content type
- cover JSONL export through the versioned vector export endpoint

## Tests
- tsc --noEmit
- bun test tests/http/vector/
- wc -l src/vector/export-formats.ts src/routes/vector/export.ts tests/http/vector/export-jsonl.test.ts

Not-tested: Large live collection export against a real vector store.