### PR TITLE
Add Markdown vector export formatter

### DIFF
--- a/src/routes/vector/export.ts
+++ b/src/routes/vector/export.ts
@@ -1,5 +1,5 @@
 /**
- * GET /api/vector/export — stream a vector collection as JSON, JSONL, or CSV.
+ * GET /api/vector/export — stream a vector collection as JSON, JSONL, CSV, or Markdown.
  */
 
 import { Elysia, t } from 'elysia';
@@ -16,7 +16,12 @@ const DEFAULT_EXPORT_LIMIT = 50_000;
 
 function contentType(format: string): string {
   if (format === 'jsonl') return 'application/x-ndjson; charset=utf-8';
+  if (format === 'markdown') return 'text/markdown; charset=utf-8';
   return format === 'csv' ? 'text/csv; charset=utf-8' : 'application/json; charset=utf-8';
+}
+
+function extensionFor(format: string): string {
+  return format === 'markdown' ? 'md' : format;
 }
 
 export function createVectorExportEndpoint(deps: VectorExportDeps = {}) {
@@ -50,7 +55,7 @@ export function createVectorExportEndpoint(deps: VectorExportDeps = {}) {
         return new Response(stream, {
           headers: {
             'Content-Type': contentType(format),
-            'Content-Disposition': `attachment; filename="${collection}.${format}"`,
+            'Content-Disposition': `attachment; filename="${collection}.${extensionFor(format)}"`,
           },
         });
       } catch (error) {
@@ -67,7 +72,7 @@ export function createVectorExportEndpoint(deps: VectorExportDeps = {}) {
       detail: {
         tags: ['vector'],
         menu: { group: 'tools', order: 57 },
-        summary: 'Export a vector collection as JSON, JSONL, or CSV',
+        summary: 'Export a vector collection as JSON, JSONL, CSV, or Markdown',
       },
     },
   );

--- a/src/vector/export-formats.ts
+++ b/src/vector/export-formats.ts
@@ -94,8 +94,32 @@ function streamCsv(dump: EmbeddingDump): ReadableStream<Uint8Array> {
   });
 }
 
+function markdownBlocks(dump: EmbeddingDump): string {
+  const files = new Map<string, string[]>();
+  for (let i = 0; i < dump.ids.length; i++) {
+    const row = rowAt(dump, i);
+    const path = row.source_file || row.id || `document-${i + 1}`;
+    const blocks = files.get(path) ?? [];
+    if (row.document.trim()) blocks.push(row.document.trim());
+    files.set(path, blocks);
+  }
+  return [...files.entries()]
+    .map(([path, blocks]) => [`<!-- source: ${path} -->`, ...blocks].join('\n\n'))
+    .join('\n\n---\n\n');
+}
+
+function streamMarkdown(dump: EmbeddingDump): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(markdownBlocks(dump)));
+      controller.close();
+    },
+  });
+}
+
 export const exportFormatters: Record<string, ExportFormatter> = {
   json: streamJson,
   jsonl: streamJsonl,
   csv: streamCsv,
+  markdown: streamMarkdown,
 };

--- a/tests/http/vector/export-markdown.test.ts
+++ b/tests/http/vector/export-markdown.test.ts
@@ -1,0 +1,43 @@
+import { expect, mock, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createVectorExportEndpoint } from '../../../src/routes/vector/export.ts';
+import type { VectorStoreAdapter } from '../../../src/vector/types.ts';
+
+function createStore(): VectorStoreAdapter {
+  return {
+    name: 'fake-vector',
+    connect: mock(async () => {}),
+    close: mock(async () => {}),
+    ensureCollection: mock(async () => {}),
+    deleteCollection: mock(async () => {}),
+    addDocuments: mock(async () => {}),
+    query: mock(async () => ({ ids: [], documents: [], distances: [], metadatas: [] })),
+    queryById: mock(async () => ({ ids: [], documents: [], distances: [], metadatas: [] })),
+    getStats: mock(async () => ({ count: 3 })),
+    getCollectionInfo: mock(async () => ({ count: 3, name: 'fake' })),
+    getAllEmbeddings: mock(async () => ({
+      ids: ['alpha-1', 'alpha-2', 'bravo-1'],
+      embeddings: [[0], [1], [2]],
+      metadatas: [
+        { source_file: 'notes/alpha.md', content: '# Alpha' },
+        { source_file: 'notes/alpha.md', content: 'Second paragraph' },
+        { sourceFile: 'notes/bravo.md', text: 'Bravo body' },
+      ],
+    })),
+  };
+}
+
+test('GET /api/v1/vector/export reconstructs Markdown from source metadata', async () => {
+  const app = new Elysia({ prefix: '/api' }).use(createVectorExportEndpoint({ getStore: () => createStore() }));
+  const fetcher = createApiVersionedFetch((request) => app.handle(request));
+
+  const res = await fetcher(new Request('http://local/api/v1/vector/export?collection=bge-m3&format=markdown'));
+  const markdown = await res.text();
+
+  expect(res.status).toBe(200);
+  expect(res.headers.get('content-type')).toContain('text/markdown');
+  expect(res.headers.get('content-disposition')).toContain('bge-m3.md');
+  expect(markdown).toContain('<!-- source: notes/alpha.md -->\n\n# Alpha\n\nSecond paragraph');
+  expect(markdown).toContain('---\n\n<!-- source: notes/bravo.md -->\n\nBravo body');
+});


### PR DESCRIPTION
## Summary\n- add a Markdown vector export formatter to the shared formatter registry\n- emit source-path comments and reconstructed Markdown content grouped by source file\n- return text/markdown responses with .md download filenames\n\n## Tests\n- bun test tests/http/vector/\n- bunx tsc --noEmit\n\nFiles are <=250 lines.