### PR TITLE
Add plugin export format registration seam

### DIFF
--- a/src/plugins/__tests__/unified-export-formats.test.ts
+++ b/src/plugins/__tests__/unified-export-formats.test.ts
@@ -1,0 +1,54 @@
+import { afterAll, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { getExportFormat } from '../../vector/export-formats.ts';
+import { loadUnifiedPlugins } from '../unified-loader.ts';
+
+const tmp = mkdtempSync(join(tmpdir(), 'arra-export-format-plugin-'));
+
+afterAll(() => rmSync(tmp, { recursive: true, force: true }));
+
+function pluginDir(name: string, manifest: Record<string, unknown>, entry: string) {
+  const dir = join(tmp, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'plugin.json'), JSON.stringify({
+    name,
+    version: '1.0.0',
+    entry: './index.ts',
+    ...manifest,
+  }, null, 2));
+  writeFileSync(join(dir, 'index.ts'), entry);
+}
+
+test('plugin exportFormats handlers can register custom formats during init', async () => {
+  pluginDir('format-pack', {
+    exportFormats: [{ name: 'codex9-lines', handler: 'registerLines' }],
+  }, `
+    const encoder = new TextEncoder();
+    export function registerLines(ctx) {
+      ctx.registerExportFormat(ctx.format, Object.assign((dump) => new ReadableStream({
+        start(controller) {
+          for (const id of dump.ids) controller.enqueue(encoder.encode(id + '\\n'));
+          controller.close();
+        },
+      }), { contentType: 'text/plain; charset=utf-8', extension: 'txt' }));
+    }
+  `);
+
+  const runtime = await loadUnifiedPlugins({ dirs: [tmp] });
+  await runtime.init();
+
+  const registered = getExportFormat('codex9-lines');
+  expect(runtime.pluginRegistry()[0].surfaces).toContain('exportFormats');
+  expect(registered?.contentType).toBe('text/plain; charset=utf-8');
+  expect(registered?.extension).toBe('txt');
+  const body = await new Response(registered!({
+    ids: ['alpha', 'beta'],
+    embeddings: [],
+    metadatas: [],
+    documents: [],
+  })).text();
+  expect(body).toBe('alpha\nbeta\n');
+});

--- a/src/plugins/export-format-init.ts
+++ b/src/plugins/export-format-init.ts
@@ -1,0 +1,52 @@
+import { pathToFileURL } from 'node:url';
+
+import { registerExportFormat, type ExportFormatter } from '../vector/export-formats.ts';
+import { runPluginSandbox } from './sandbox.ts';
+import type { NormalizedUnifiedPluginManifest } from './unified-manifest.ts';
+
+interface ExportFormatPlugin {
+  manifest: NormalizedUnifiedPluginManifest;
+  entryPath: string;
+}
+
+interface ExportFormatContext {
+  source: 'exportFormat';
+  plugin: string;
+  format: string;
+  config: unknown;
+  registerExportFormat: typeof registerExportFormat;
+}
+
+function timeout(ms: number): Promise<never> {
+  return new Promise((_, reject) => setTimeout(() => reject(new Error('handler timed out')), ms));
+}
+
+async function invokeFormat(plugin: ExportFormatPlugin, format: string, handler: string, timeoutMs: number) {
+  const mod = await import(pathToFileURL(plugin.entryPath).href);
+  const fn = handler === 'default' ? mod.default : (mod[handler] ?? mod.default);
+  if (typeof fn !== 'function') throw new Error(`handler not found: ${handler}`);
+  const ctx: ExportFormatContext = {
+    source: 'exportFormat',
+    plugin: plugin.manifest.name,
+    format,
+    config: plugin.manifest.config ?? {},
+    registerExportFormat,
+  };
+  return Promise.race([Promise.resolve(fn(ctx)), timeout(timeoutMs)]);
+}
+
+export async function registerPluginExportFormats(
+  plugin: ExportFormatPlugin,
+  timeoutMs: number,
+): Promise<string | undefined> {
+  for (const format of plugin.manifest.exportFormats) {
+    const result = await runPluginSandbox({
+      plugin: plugin.manifest.name,
+      phase: 'init',
+    }, () => invokeFormat(plugin, format.name, format.handler, timeoutMs));
+    if (!result.ok) return result.error;
+    if (typeof result.value === 'function') {
+      registerExportFormat(format.name, result.value as ExportFormatter);
+    }
+  }
+}

--- a/src/plugins/export-format-manifest.ts
+++ b/src/plugins/export-format-manifest.ts
@@ -1,0 +1,17 @@
+const FORMAT_RE = /^[a-z0-9-]+$/;
+
+export interface UnifiedExportFormatManifest {
+  name: string;
+  handler: string;
+}
+
+export function validateExportFormatManifests(formats: UnifiedExportFormatManifest[]): void {
+  for (const format of formats) {
+    if (!FORMAT_RE.test(format.name)) {
+      throw new Error(`exportFormats.name must match ${FORMAT_RE}, got: ${JSON.stringify(format.name)}`);
+    }
+    if (!format.handler || typeof format.handler !== 'string') {
+      throw new Error(`exportFormats.${format.name}.handler must be a string`);
+    }
+  }
+}

--- a/src/plugins/unified-loader.ts
+++ b/src/plugins/unified-loader.ts
@@ -3,18 +3,14 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { Elysia } from 'elysia';
-
-import {
-  normalizeUnifiedPluginManifest, type NormalizedUnifiedPluginManifest,
-  type UnifiedApiRouteManifest, type UnifiedCliSubcommandManifest,
-  type UnifiedMcpToolManifest, type UnifiedMenuManifest,
-} from './unified-manifest.ts';
+import { normalizeUnifiedPluginManifest, type NormalizedUnifiedPluginManifest, type UnifiedApiRouteManifest, type UnifiedCliSubcommandManifest, type UnifiedMcpToolManifest, type UnifiedMenuManifest } from './unified-manifest.ts';
 import { sortPluginsByDependencies } from './dependency-resolver.ts';
 import { pluginRegistryFromLoadedPlugins, type LoadedPluginRegistryEntry } from './registry.ts';
 import { runPluginSandbox } from './sandbox.ts';
 import { createUnifiedProxyRoute } from './proxy-surface.ts';
 import { unifiedPluginServerRoutes, type UnifiedPluginServer } from './unified-server.ts';
 import { resolveContainedPluginEntry } from './path-containment.ts';
+import { registerPluginExportFormats } from './export-format-init.ts';
 
 const DEFAULT_TIMEOUT_MS = Number(process.env.ARRA_PLUGIN_TIMEOUT_MS ?? 5000);
 const DEFAULT_DIRS = [join(homedir(), '.arra', 'plugins'), join(homedir(), '.oracle', 'plugins')];
@@ -219,6 +215,10 @@ function runtimeFrom(plugins: LoadedUnifiedPlugin[], options: UnifiedLoaderOptio
   };
   const init = async () => {
     for (const plugin of plugins) {
+      if (plugin.manifest.exportFormats.length) {
+        const error = await registerPluginExportFormats(plugin, timeoutMs);
+        if (error) { pluginStatus.set(plugin.manifest.name, { name: plugin.manifest.name, status: 'degraded', error }); continue; }
+      }
       if (!plugin.manifest.lifecycle?.init || initialized.has(plugin.manifest.name)) continue;
       await invokeLifecycle('init', plugin);
     }

--- a/src/plugins/unified-manifest.ts
+++ b/src/plugins/unified-manifest.ts
@@ -1,5 +1,6 @@
 import type { ServerPluginTier } from '../server/plugin/types.ts';
 import { validatePluginConfig, type JsonSchema } from './config-schema.ts';
+import { validateExportFormatManifests, type UnifiedExportFormatManifest } from './export-format-manifest.ts';
 
 export type UnifiedPluginSurface =
   | 'mcpTools'
@@ -7,10 +8,10 @@ export type UnifiedPluginSurface =
   | 'proxy'
   | 'server'
   | 'menu'
-  | 'cliSubcommands';
+  | 'cliSubcommands'
+  | 'exportFormats';
 
 export type UnifiedHttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'ALL';
-export type UnifiedPluginRenderer = 'Three' | 'React';
 
 export interface UnifiedMcpToolManifest {
   name: string;
@@ -83,8 +84,8 @@ export interface UnifiedPluginManifest {
   server?: UnifiedServerManifest;
   menu?: UnifiedMenuManifest[];
   cliSubcommands?: UnifiedCliSubcommandManifest[];
+  exportFormats?: UnifiedExportFormatManifest[];
 
-  /** Legacy compatibility aliases used by existing ServerPlugin/CLI manifests. */
   api?: { path: string; methods?: UnifiedHttpMethod[] };
   lifecycle?: UnifiedLifecycleManifest;
   seedMenu?: boolean;
@@ -99,6 +100,7 @@ export interface NormalizedUnifiedPluginManifest extends Omit<UnifiedPluginManif
   proxy: UnifiedProxyManifest[];
   menu: UnifiedMenuManifest[];
   cliSubcommands: UnifiedCliSubcommandManifest[];
+  exportFormats: UnifiedExportFormatManifest[];
 }
 
 const NAME_RE = /^[a-z0-9-]+$/;
@@ -164,6 +166,7 @@ export function normalizeUnifiedPluginManifest(raw: unknown): NormalizedUnifiedP
   const menu = [...asArray(manifest.menu)];
   const mcpTools = asArray(manifest.mcpTools);
   const proxy = asArray(manifest.proxy);
+  const exportFormats = asArray(manifest.exportFormats);
 
   for (const tool of mcpTools) {
     if (!TOOL_RE.test(tool.name)) throw new Error(`mcpTools.name must match ${TOOL_RE}, got: ${JSON.stringify(tool.name)}`);
@@ -199,6 +202,7 @@ export function normalizeUnifiedPluginManifest(raw: unknown): NormalizedUnifiedP
     if (!command.command || typeof command.command !== 'string') throw new Error('cliSubcommands.command must be a string');
     if (!command.help || typeof command.help !== 'string') throw new Error('cliSubcommands.help must be a string');
   }
+  validateExportFormatManifests(exportFormats);
   if (manifest.configSchema !== undefined) validatePluginConfig(manifest.config ?? {}, manifest.configSchema, manifest.name);
 
   if (manifest.lifecycle) {
@@ -218,6 +222,7 @@ export function normalizeUnifiedPluginManifest(raw: unknown): NormalizedUnifiedP
     proxy,
     menu,
     cliSubcommands,
+    exportFormats,
   };
 }
 
@@ -229,6 +234,7 @@ export function manifestSurfaces(manifest: NormalizedUnifiedPluginManifest): Uni
   if (manifest.server) surfaces.push('server');
   if (manifest.menu.length) surfaces.push('menu');
   if (manifest.cliSubcommands.length) surfaces.push('cliSubcommands');
+  if (manifest.exportFormats.length) surfaces.push('exportFormats');
   return surfaces;
 }
 

--- a/src/routes/vector/export.ts
+++ b/src/routes/vector/export.ts
@@ -4,7 +4,7 @@
 
 import { Elysia, t } from 'elysia';
 import { getVectorStoreByModel } from '../../vector/factory.ts';
-import { exportFormatters } from '../../vector/export-formats.ts';
+import { getExportFormat, listExportFormats } from '../../vector/export-formats.ts';
 import type { VectorStoreAdapter } from '../../vector/types.ts';
 
 interface VectorExportDeps {
@@ -14,16 +14,6 @@ interface VectorExportDeps {
 const DEFAULT_COLLECTION = 'bge-m3';
 const DEFAULT_EXPORT_LIMIT = 50_000;
 
-function contentType(format: string): string {
-  if (format === 'jsonl') return 'application/x-ndjson; charset=utf-8';
-  if (format === 'markdown') return 'text/markdown; charset=utf-8';
-  return format === 'csv' ? 'text/csv; charset=utf-8' : 'application/json; charset=utf-8';
-}
-
-function extensionFor(format: string): string {
-  return format === 'markdown' ? 'md' : format;
-}
-
 export function createVectorExportEndpoint(deps: VectorExportDeps = {}) {
   const getStore = deps.getStore ?? getVectorStoreByModel;
 
@@ -31,10 +21,10 @@ export function createVectorExportEndpoint(deps: VectorExportDeps = {}) {
     '/vector/export',
     async ({ query, set }) => {
       const format = query.format || 'json';
-      const formatter = exportFormatters[format];
+      const formatter = getExportFormat(format);
       if (!formatter) {
         set.status = 400;
-        return { error: `Invalid format: expected ${Object.keys(exportFormatters).join(' or ')}` };
+        return { error: `Invalid format: expected ${listExportFormats().join(' or ')}` };
       }
 
       const collection = query.collection || DEFAULT_COLLECTION;
@@ -54,8 +44,8 @@ export function createVectorExportEndpoint(deps: VectorExportDeps = {}) {
 
         return new Response(stream, {
           headers: {
-            'Content-Type': contentType(format),
-            'Content-Disposition': `attachment; filename="${collection}.${extensionFor(format)}"`,
+            'Content-Type': formatter.contentType ?? 'application/octet-stream',
+            'Content-Disposition': `attachment; filename="${collection}.${formatter.extension ?? format}"`,
           },
         });
       } catch (error) {

--- a/src/vector/export-formats.ts
+++ b/src/vector/export-formats.ts
@@ -1,7 +1,10 @@
 import type { VectorStoreAdapter } from './types.ts';
 
 export type EmbeddingDump = Awaited<ReturnType<NonNullable<VectorStoreAdapter['getAllEmbeddings']>>>;
-export type ExportFormatter = (dump: EmbeddingDump) => ReadableStream<Uint8Array>;
+export type ExportFormatter = ((dump: EmbeddingDump) => ReadableStream<Uint8Array>) & {
+  contentType?: string;
+  extension?: string;
+};
 
 interface ExportRow {
   id: string;
@@ -117,9 +120,50 @@ function streamMarkdown(dump: EmbeddingDump): ReadableStream<Uint8Array> {
   });
 }
 
-export const exportFormatters: Record<string, ExportFormatter> = {
-  json: streamJson,
-  jsonl: streamJsonl,
-  csv: streamCsv,
-  markdown: streamMarkdown,
-};
+function normalizeName(name: string, strict = true): string {
+  const normalized = name.trim().toLowerCase();
+  if (!/^[a-z0-9-]+$/.test(normalized)) {
+    if (strict) throw new Error(`invalid export format: ${name}`);
+    return '';
+  }
+  return normalized;
+}
+
+function withMeta(formatter: ExportFormatter, meta: {
+  contentType: string;
+  extension: string;
+}): ExportFormatter {
+  return Object.assign(formatter, meta);
+}
+
+export const exportFormatters: Record<string, ExportFormatter> = {};
+
+export function registerExportFormat(name: string, formatter: ExportFormatter): void {
+  if (typeof formatter !== 'function') throw new Error(`formatter for ${name} must be a function`);
+  exportFormatters[normalizeName(name)] = formatter;
+}
+
+export function getExportFormat(name: string): ExportFormatter | undefined {
+  return exportFormatters[normalizeName(name, false)];
+}
+
+export function listExportFormats(): string[] {
+  return Object.keys(exportFormatters).sort();
+}
+
+registerExportFormat('json', withMeta(streamJson, {
+  contentType: 'application/json; charset=utf-8',
+  extension: 'json',
+}));
+registerExportFormat('jsonl', withMeta(streamJsonl, {
+  contentType: 'application/x-ndjson; charset=utf-8',
+  extension: 'jsonl',
+}));
+registerExportFormat('csv', withMeta(streamCsv, {
+  contentType: 'text/csv; charset=utf-8',
+  extension: 'csv',
+}));
+registerExportFormat('markdown', withMeta(streamMarkdown, {
+  contentType: 'text/markdown; charset=utf-8',
+  extension: 'md',
+}));


### PR DESCRIPTION
## Summary
- add registerExportFormat/get/list helpers on top of the alpha export formatter registry
- allow unified plugin manifests to declare exportFormats handlers
- register declared plugin export formats during runtime init and cover it with a temporary test plugin

## Verification
- tsc --noEmit
- bun test src/plugins/__tests__/unified-loader.test.ts src/plugins/__tests__/unified-manifest.test.ts src/plugins/__tests__/unified-export-formats.test.ts tests/http/vector/
- changed files <=250 lines

Target: alpha