### PR TITLE
Add vector export format selector

### DIFF
--- a/frontend/src/pages/VectorExportPage.tsx
+++ b/frontend/src/pages/VectorExportPage.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useMemo, useState } from 'react';
 import { apiClient, type ApiClient, type VectorIndexModelsResponse } from '../api/client';
 import { ErrorMessage, LoadingPanel, Spinner } from '../components/AsyncState';
-import { downloadVectorCollection, type VectorExportFormat } from './VectorPage';
+import {
+  downloadVectorCollection,
+  fallbackVectorExportFormats,
+  fetchVectorExportFormats,
+  formatLabelFor,
+  type VectorExportFormat,
+  type VectorExportFormatOption,
+} from '../vectorExport';
 
 type LoadState = 'loading' | 'ready' | 'error';
 type VectorExportClient = Pick<ApiClient, 'vectorIndexModels'>;
@@ -19,6 +26,8 @@ export interface VectorExportPageProps {
   modelsResponse?: VectorIndexModelsResponse | null;
   loading?: boolean;
   download?: (collection: string, format: VectorExportFormat) => Promise<void>;
+  formats?: VectorExportFormatOption[];
+  loadFormats?: () => Promise<VectorExportFormatOption[]>;
 }
 
 export function exportCollectionsFromModels(response?: VectorIndexModelsResponse | null): VectorExportCollection[] {
@@ -43,10 +52,14 @@ export function VectorExportPage({
   modelsResponse = null,
   loading = true,
   download = downloadVectorCollection,
+  formats = fallbackVectorExportFormats,
+  loadFormats = fetchVectorExportFormats,
 }: VectorExportPageProps) {
   const initialCollections = useMemo(() => exportCollectionsFromModels(modelsResponse), [modelsResponse]);
   const [collections, setCollections] = useState(initialCollections);
   const [collection, setCollection] = useState(initialCollections[0]?.collection ?? '');
+  const [formatOptions, setFormatOptions] = useState(formats);
+  const [format, setFormat] = useState(formats[0]?.format ?? 'json');
   const [state, setState] = useState<LoadState>(loading ? 'loading' : 'ready');
   const [error, setError] = useState('');
   const [downloadError, setDownloadError] = useState('');
@@ -57,12 +70,15 @@ export function VectorExportPage({
     let cancelled = false;
     setState('loading');
     setError('');
-    client.vectorIndexModels()
-      .then((response) => {
+    Promise.all([client.vectorIndexModels(), loadFormats()])
+      .then(([response, nextFormats]) => {
         if (cancelled) return;
         const next = exportCollectionsFromModels(response);
         setCollections(next);
         setCollection((current) => current || next[0]?.collection || '');
+        const available = nextFormats.length ? nextFormats : fallbackVectorExportFormats;
+        setFormatOptions(available);
+        setFormat((current) => available.some((item) => item.format === current) ? current : available[0]?.format ?? 'json');
         setState('ready');
       })
       .catch((err) => {
@@ -77,10 +93,10 @@ export function VectorExportPage({
     if (state === 'loading') return 'Loading vector collections…';
     if (state === 'error') return 'Could not load vector collections.';
     if (!collections.length) return 'No vector collections are available to export.';
-    return `Ready to export ${collection || 'a collection'} as JSON or CSV.`;
-  }, [collection, collections.length, state]);
+    return `Ready to export ${collection || 'a collection'} as ${formatLabelFor(formatOptions, format)}.`;
+  }, [collection, collections.length, format, formatOptions, state]);
 
-  async function exportSelected(format: VectorExportFormat) {
+  async function exportSelected() {
     if (!collection) return;
     setDownloadError('');
     setDownloading(format);
@@ -98,7 +114,7 @@ export function VectorExportPage({
       <div className="mb-5">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Vector</p>
         <h1 id="vector-export-title" className="mt-2 text-3xl font-semibold text-white">Vector export</h1>
-        <p className="mt-2 text-sm text-slate-400">Download vector collections from /api/vector/export as JSON or CSV.</p>
+        <p className="mt-2 text-sm text-slate-400">Download vector collections from /api/v1/vector/export in any available format.</p>
       </div>
 
       {state === 'loading' ? <LoadingPanel title="Loading vector collections…" detail="Fetching /api/vector/index/models." /> : null}
@@ -118,14 +134,22 @@ export function VectorExportPage({
             )) : <option value="">No collections loaded</option>}
           </select>
         </label>
+        <label className="grid gap-2 text-sm font-medium text-slate-300">
+          Format
+          <select
+            aria-label="Export format"
+            className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-4 py-3 text-slate-100"
+            value={format}
+            onChange={(event) => setFormat(event.target.value)}
+          >
+            {formatOptions.map((item) => <option key={item.format} value={item.format}>{item.label}</option>)}
+          </select>
+        </label>
         <p className="text-sm text-slate-500">{status}</p>
         {downloadError ? <ErrorMessage title="Vector export failed." message={downloadError} /> : null}
         <div className="flex flex-wrap gap-2">
-          <button className="focus-ring rounded-xl border border-teal-300/30 px-4 py-2 text-sm font-semibold text-teal-100 hover:bg-teal-300/10 disabled:cursor-not-allowed disabled:opacity-50" disabled={!collection || Boolean(downloading)} type="button" onClick={() => void exportSelected('json')}>
-            {downloading === 'json' ? <Spinner label="Downloading JSON" /> : 'Export JSON'}
-          </button>
-          <button className="focus-ring rounded-xl border border-purple-300/30 px-4 py-2 text-sm font-semibold text-purple-100 hover:bg-purple-300/10 disabled:cursor-not-allowed disabled:opacity-50" disabled={!collection || Boolean(downloading)} type="button" onClick={() => void exportSelected('csv')}>
-            {downloading === 'csv' ? <Spinner label="Downloading CSV" /> : 'Export CSV'}
+          <button className="focus-ring rounded-xl border border-teal-300/30 px-4 py-2 text-sm font-semibold text-teal-100 hover:bg-teal-300/10 disabled:cursor-not-allowed disabled:opacity-50" disabled={!collection || Boolean(downloading) || formatOptions.length === 0} type="button" onClick={() => void exportSelected()}>
+            {downloading ? <Spinner label={`Downloading ${formatLabelFor(formatOptions, downloading)}`} /> : 'Export'}
           </button>
         </div>
       </div>

--- a/frontend/src/pages/VectorPage.tsx
+++ b/frontend/src/pages/VectorPage.tsx
@@ -1,18 +1,22 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { apiClient, type ApiClient, type VectorHealthResponse, type VectorIndexModelEntry, type VectorIndexModelsResponse } from '../api/client';
-import { apiUrl } from '../api/oracle';
 import { ErrorMessage, LoadingPanel, Spinner } from '../components/AsyncState';
 import { VectorIndexPanel } from '../components/VectorIndexPanel';
 import { VectorSearchWidget } from '../components/VectorSearchWidget';
 import { vectorDocumentsPath, vectorSearchPath } from '../routePaths';
+import {
+  downloadVectorCollection,
+  fallbackVectorExportFormats,
+  fetchVectorExportFormats,
+  formatLabelFor,
+  type VectorExportFormat,
+  type VectorExportFormatOption,
+} from '../vectorExport';
 
 type PageState = 'loading' | 'ready' | 'error';
 type VectorStatusClient = Pick<ApiClient, 'vectorIndexModels' | 'vectorHealth'>;
-export type VectorExportFormat = 'json' | 'csv';
 type DownloadByCollection = Record<string, VectorExportFormat | undefined>;
-type ExportFetch = (input: RequestInfo | URL, init?: RequestInit) => Response | Promise<Response>;
-type SaveBlob = (blob: Blob, filename: string) => void | Promise<void>;
 export interface VectorCollectionCard {
   key: string;
   collection: string;
@@ -74,40 +78,6 @@ export function vectorDashboardSummary(cards: VectorCollectionCard[], state: Pag
   return `${healthy}/${cards.length} vector collections healthy.`;
 }
 
-export function vectorExportPath(collection: string, format: VectorExportFormat): string { return `/api/vector/export?${new URLSearchParams({ collection, format }).toString()}`; }
-
-export function vectorExportFilename(collection: string, format: VectorExportFormat): string {
-  const safeName = collection.trim().replace(/[^a-z0-9._-]+/gi, '-').replace(/^-+|-+$/g, '') || 'collection';
-  return `${safeName}.${format}`;
-}
-
-export function saveBlobAsDownload(blob: Blob, filename: string): void {
-  if (!globalThis.document?.createElement || !globalThis.URL?.createObjectURL) throw new Error('Browser downloads are unavailable');
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = filename;
-  link.style.display = 'none';
-  document.body?.appendChild(link);
-  link.click();
-  link.remove();
-  URL.revokeObjectURL(url);
-}
-
-export async function downloadVectorCollection(
-  collection: string,
-  format: VectorExportFormat,
-  deps: { fetch?: ExportFetch; saveBlob?: SaveBlob } = {},
-): Promise<void> {
-  const fetcher = deps.fetch ?? globalThis.fetch?.bind(globalThis);
-  if (!fetcher) throw new Error('fetch is unavailable');
-  const response = await fetcher(apiUrl(vectorExportPath(collection, format)), {
-    headers: { accept: format === 'json' ? 'application/json' : 'text/csv' },
-  });
-  if (!response.ok) throw new Error(`/api/vector/export returned ${response.status}`);
-  await (deps.saveBlob ?? saveBlobAsDownload)(await response.blob(), vectorExportFilename(collection, format));
-}
-
 function docCountLabel(count?: number): string {
   if (typeof count !== 'number') return 'unknown docs';
   return `${count.toLocaleString()} doc${count === 1 ? '' : 's'}`;
@@ -121,18 +91,23 @@ function statusClasses(healthy: boolean): string {
 
 export function VectorCollectionCards({
   cards,
+  formats = fallbackVectorExportFormats,
   downloads = {},
   onExport,
 }: {
   cards: VectorCollectionCard[];
+  formats?: VectorExportFormatOption[];
   downloads?: DownloadByCollection;
   onExport?: (collection: string, format: VectorExportFormat) => void;
 }) {
+  const [selectedFormats, setSelectedFormats] = useState<Record<string, VectorExportFormat>>({});
   return (
     <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3" aria-label="Vector collections">
       {cards.map((card) => {
         const downloading = downloads[card.collection];
         const disabled = Boolean(downloading);
+        const selected = selectedFormats[card.collection] ?? formats[0]?.format ?? 'json';
+        const label = formatLabelFor(formats, selected);
         return (
           <article key={card.key} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
             <div className="flex items-start justify-between gap-3">
@@ -151,11 +126,17 @@ export function VectorCollectionCards({
             </dl>
             {card.healthDetail ? <p className="mt-3 text-xs text-red-200">{card.healthDetail}</p> : null}
             <div className="mt-4 flex flex-wrap gap-2">
-              <button className="focus-ring rounded-xl border border-teal-300/30 px-3 py-2 text-sm font-semibold text-teal-100 hover:bg-teal-300/10 disabled:cursor-not-allowed disabled:opacity-50" disabled={disabled} type="button" onClick={() => onExport?.(card.collection, 'json')}>
-                {downloading === 'json' ? <Spinner label="Downloading JSON" /> : 'Export JSON'}
-              </button>
-              <button className="focus-ring rounded-xl border border-purple-300/30 px-3 py-2 text-sm font-semibold text-purple-100 hover:bg-purple-300/10 disabled:cursor-not-allowed disabled:opacity-50" disabled={disabled} type="button" onClick={() => onExport?.(card.collection, 'csv')}>
-                {downloading === 'csv' ? <Spinner label="Downloading CSV" /> : 'Export CSV'}
+              <select
+                aria-label={`Export format for ${card.collection}`}
+                className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm text-slate-100"
+                disabled={disabled || formats.length === 0}
+                value={selected}
+                onChange={(event) => setSelectedFormats((current) => ({ ...current, [card.collection]: event.target.value }))}
+              >
+                {formats.map((format) => <option key={format.format} value={format.format}>{format.label}</option>)}
+              </select>
+              <button className="focus-ring rounded-xl border border-teal-300/30 px-3 py-2 text-sm font-semibold text-teal-100 hover:bg-teal-300/10 disabled:cursor-not-allowed disabled:opacity-50" disabled={disabled || formats.length === 0} type="button" onClick={() => onExport?.(card.collection, selected)}>
+                {downloading ? <Spinner label={`Downloading ${label}`} /> : 'Export'}
               </button>
             </div>
           </article>
@@ -185,17 +166,19 @@ export function VectorPage({ modelsResponse = null, healthResponse = null, loadi
   const [state, setState] = useState<PageState>(loading ? 'loading' : 'ready');
   const [error, setError] = useState('');
   const [downloads, setDownloads] = useState<DownloadByCollection>({});
+  const [formats, setFormats] = useState(fallbackVectorExportFormats);
   const [downloadError, setDownloadError] = useState('');
 
   useEffect(() => {
     let cancelled = false;
     setState('loading');
     setError('');
-    Promise.all([client.vectorIndexModels(), client.vectorHealth()])
-      .then(([nextModels, nextHealth]) => {
+    Promise.all([client.vectorIndexModels(), client.vectorHealth(), fetchVectorExportFormats()])
+      .then(([nextModels, nextHealth, nextFormats]) => {
         if (cancelled) return;
         setModels(nextModels);
         setHealth(nextHealth);
+        setFormats(nextFormats.length ? nextFormats : fallbackVectorExportFormats);
         setState('ready');
       })
       .catch((err) => {
@@ -238,7 +221,7 @@ export function VectorPage({ modelsResponse = null, healthResponse = null, loadi
         {state === 'error' ? <ErrorMessage title="Could not load vector status." message={error} /> : null}
         {downloadError ? <div className="mb-4"><ErrorMessage title="Vector export failed." message={downloadError} /></div> : null}
         {!isLoading && state !== 'error' && cards.length === 0 ? <p className="text-sm text-slate-400">No vector collections are registered.</p> : null}
-        {cards.length ? <VectorCollectionCards cards={cards} downloads={downloads} onExport={onExport} /> : null}
+        {cards.length ? <VectorCollectionCards cards={cards} formats={formats} downloads={downloads} onExport={onExport} /> : null}
       </section>
 
       <VectorDocumentsCard />

--- a/frontend/src/routeMeta.ts
+++ b/frontend/src/routeMeta.ts
@@ -55,7 +55,7 @@ export function routeMeta(pathname: string, search = ''): RouteMeta {
   }
 
   if (pathname === '/vector/export') {
-    return base('Vector export', 'Vector', 'Download vector collections as JSON or CSV.', [
+    return base('Vector export', 'Vector', 'Download vector collections in available formats.', [
       { label: 'Vector dashboard', to: '/vector' },
       { label: 'Export' },
     ]);

--- a/frontend/src/vectorExport.ts
+++ b/frontend/src/vectorExport.ts
@@ -1,0 +1,91 @@
+import { apiUrl } from './api/oracle';
+
+export type VectorExportFormat = string;
+
+export interface VectorExportFormatOption {
+  format: VectorExportFormat;
+  label: string;
+  mimeType: string;
+  extension: string;
+}
+
+type ExportFetch = (input: RequestInfo | URL, init?: RequestInit) => Response | Promise<Response>;
+type SaveBlob = (blob: Blob, filename: string) => void | Promise<void>;
+
+export const fallbackVectorExportFormats: VectorExportFormatOption[] = [
+  { format: 'json', label: 'JSON', mimeType: 'application/json', extension: 'json' },
+  { format: 'jsonl', label: 'JSONL', mimeType: 'application/x-ndjson', extension: 'jsonl' },
+  { format: 'csv', label: 'CSV', mimeType: 'text/csv', extension: 'csv' },
+  { format: 'markdown', label: 'Markdown', mimeType: 'text/markdown', extension: 'md' },
+];
+
+export function vectorExportPath(collection: string, format: VectorExportFormat): string {
+  return `/api/v1/vector/export?${new URLSearchParams({ collection, format }).toString()}`;
+}
+
+export function vectorExportFormatsPath(): string {
+  return '/api/v1/vector/export/formats';
+}
+
+export function formatLabelFor(formats: VectorExportFormatOption[], format: VectorExportFormat): string {
+  return formats.find((item) => item.format === format)?.label ?? format.toUpperCase();
+}
+
+export function vectorExportFilename(collection: string, format: VectorExportFormat): string {
+  const safeName = collection.trim().replace(/[^a-z0-9._-]+/gi, '-').replace(/^-+|-+$/g, '') || 'collection';
+  return `${safeName}.${format}`;
+}
+
+export function saveBlobAsDownload(blob: Blob, filename: string): void {
+  if (!globalThis.document?.createElement || !globalThis.URL?.createObjectURL) throw new Error('Browser downloads are unavailable');
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.style.display = 'none';
+  document.body?.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+function isFormatOption(value: unknown): value is VectorExportFormatOption {
+  if (!value || typeof value !== 'object') return false;
+  const item = value as Record<string, unknown>;
+  return typeof item.format === 'string'
+    && typeof item.label === 'string'
+    && typeof item.mimeType === 'string'
+    && typeof item.extension === 'string';
+}
+
+export function normalizeVectorExportFormats(payload: unknown): VectorExportFormatOption[] {
+  const formats = (payload && typeof payload === 'object') ? (payload as { formats?: unknown }).formats : undefined;
+  return Array.isArray(formats) ? formats.filter(isFormatOption) : [];
+}
+
+export async function fetchVectorExportFormats(deps: { fetch?: ExportFetch } = {}): Promise<VectorExportFormatOption[]> {
+  const fetcher = deps.fetch ?? globalThis.fetch?.bind(globalThis);
+  if (!fetcher) throw new Error('fetch is unavailable');
+  const path = vectorExportFormatsPath();
+  const response = await fetcher(apiUrl(path), { headers: { accept: 'application/json' } });
+  if (!response.ok) throw new Error(`${path} returned ${response.status}`);
+  return normalizeVectorExportFormats(await response.json());
+}
+
+function acceptHeader(format: VectorExportFormat): string {
+  return fallbackVectorExportFormats.find((item) => item.format === format)?.mimeType ?? '*/*';
+}
+
+export async function downloadVectorCollection(
+  collection: string,
+  format: VectorExportFormat,
+  deps: { fetch?: ExportFetch; saveBlob?: SaveBlob } = {},
+): Promise<void> {
+  const fetcher = deps.fetch ?? globalThis.fetch?.bind(globalThis);
+  if (!fetcher) throw new Error('fetch is unavailable');
+  const response = await fetcher(apiUrl(vectorExportPath(collection, format)), {
+    headers: { accept: acceptHeader(format) },
+  });
+  if (!response.ok) throw new Error('/api/v1/vector/export returned ' + response.status);
+  await (deps.saveBlob ?? saveBlobAsDownload)(await response.blob(), vectorExportFilename(collection, format));
+}

--- a/src/routes/vector/export.ts
+++ b/src/routes/vector/export.ts
@@ -1,10 +1,10 @@
 /**
- * GET /api/vector/export — stream a vector collection as JSON, JSONL, CSV, or Markdown.
+ * GET /api/vector/export — stream a vector collection in a registered format.
  */
 
 import { Elysia, t } from 'elysia';
 import { getVectorStoreByModel } from '../../vector/factory.ts';
-import { getExportFormat, listExportFormats } from '../../vector/export-formats.ts';
+import { availableExportFormats, exportFormatInfo, getExportFormat } from '../../vector/export-formats.ts';
 import type { VectorStoreAdapter } from '../../vector/types.ts';
 
 interface VectorExportDeps {
@@ -18,7 +18,7 @@ export function createVectorExportEndpoint(deps: VectorExportDeps = {}) {
   const getStore = deps.getStore ?? getVectorStoreByModel;
 
   return new Elysia()
-    .get('/vector/export/formats', () => Object.keys(exportFormatters), {
+    .get('/vector/export/formats', () => ({ formats: availableExportFormats() }), {
       detail: {
         tags: ['vector'],
         summary: 'List available vector export formats',
@@ -27,9 +27,10 @@ export function createVectorExportEndpoint(deps: VectorExportDeps = {}) {
     .get('/vector/export', async ({ query, set }) => {
       const format = query.format || 'json';
       const formatter = getExportFormat(format);
-      if (!formatter) {
+      const info = exportFormatInfo(format);
+      if (!formatter || !info) {
         set.status = 400;
-        return { error: `Invalid format: expected ${listExportFormats().join(' or ')}` };
+        return { error: 'Invalid format', formats: availableExportFormats() };
       }
 
       const collection = query.collection || DEFAULT_COLLECTION;
@@ -49,8 +50,8 @@ export function createVectorExportEndpoint(deps: VectorExportDeps = {}) {
 
         return new Response(stream, {
           headers: {
-            'Content-Type': formatter.contentType ?? 'application/octet-stream',
-            'Content-Disposition': `attachment; filename="${collection}.${formatter.extension ?? format}"`,
+            'Content-Type': info.mimeType,
+            'Content-Disposition': `attachment; filename="${collection}.${info.extension}"`,
           },
         });
       } catch (error) {
@@ -66,10 +67,9 @@ export function createVectorExportEndpoint(deps: VectorExportDeps = {}) {
       detail: {
         tags: ['vector'],
         menu: { group: 'tools', order: 57 },
-        summary: 'Export a vector collection as JSON, JSONL, CSV, or Markdown',
+        summary: 'Export a vector collection in a registered format',
       },
-    },
-  );
+    });
 }
 
 export const vectorExportEndpoint = createVectorExportEndpoint();

--- a/src/routes/vector/index.ts
+++ b/src/routes/vector/index.ts
@@ -9,8 +9,9 @@
  *   GET /api/map3d           — 3D PCA projection from real embeddings
  *   GET /api/vector/stats    — per-engine collection counts
  *   GET /api/vector/health   — adapter liveness probe
- *   GET /api/vector/export   — export collection docs as JSON, JSONL, CSV, or Markdown
  *   GET /api/vector/documents — browse indexed vector documents
+ *   GET /api/v1/vector/export/formats — available export formats
+ *   GET /api/v1/vector/export — stream vector docs in a registered format
  *   GET /api/v1/vector/config — config + per-collection health/counts
  *   PUT /api/v1/vector/config/:collection — update collection adapter/model/provider
  *   POST /api/v1/vector/config/reload — clear cached vector stores
@@ -43,7 +44,7 @@ export const vectorRoutes = new Elysia({ prefix: '/api' })
   .use(map3dEndpoint)
   .use(vectorStatsEndpoint)
   .use(vectorHealthEndpoint)
-  .use(vectorExportEndpoint)
   .use(vectorDocumentsEndpoint)
+  .use(vectorExportEndpoint)
   .use(vectorConfigApiEndpoint)
   .use(vectorIndexerEndpoints);

--- a/src/vector/export-formats.ts
+++ b/src/vector/export-formats.ts
@@ -4,7 +4,15 @@ export type EmbeddingDump = Awaited<ReturnType<NonNullable<VectorStoreAdapter['g
 export type ExportFormatter = ((dump: EmbeddingDump) => ReadableStream<Uint8Array>) & {
   contentType?: string;
   extension?: string;
+  label?: string;
 };
+
+export interface ExportFormatInfo {
+  format: string;
+  label: string;
+  mimeType: string;
+  extension: string;
+}
 
 interface ExportRow {
   id: string;
@@ -132,8 +140,13 @@ function normalizeName(name: string, strict = true): string {
 function withMeta(formatter: ExportFormatter, meta: {
   contentType: string;
   extension: string;
+  label: string;
 }): ExportFormatter {
   return Object.assign(formatter, meta);
+}
+
+function fallbackLabel(format: string): string {
+  return format.split('-').map((part) => part.toUpperCase()).join(' ');
 }
 
 export const exportFormatters: Record<string, ExportFormatter> = {};
@@ -151,19 +164,39 @@ export function listExportFormats(): string[] {
   return Object.keys(exportFormatters).sort();
 }
 
+export function exportFormatInfo(name: string): ExportFormatInfo | undefined {
+  const format = normalizeName(name, false);
+  const formatter = getExportFormat(format);
+  if (!formatter) return undefined;
+  return {
+    format,
+    label: formatter.label ?? fallbackLabel(format),
+    mimeType: formatter.contentType ?? 'application/octet-stream',
+    extension: formatter.extension ?? format,
+  };
+}
+
+export function availableExportFormats(): ExportFormatInfo[] {
+  return listExportFormats().flatMap((format) => exportFormatInfo(format) ?? []);
+}
+
 registerExportFormat('json', withMeta(streamJson, {
   contentType: 'application/json; charset=utf-8',
   extension: 'json',
+  label: 'JSON',
 }));
 registerExportFormat('jsonl', withMeta(streamJsonl, {
   contentType: 'application/x-ndjson; charset=utf-8',
   extension: 'jsonl',
+  label: 'JSONL',
 }));
 registerExportFormat('csv', withMeta(streamCsv, {
   contentType: 'text/csv; charset=utf-8',
   extension: 'csv',
+  label: 'CSV',
 }));
 registerExportFormat('markdown', withMeta(streamMarkdown, {
   contentType: 'text/markdown; charset=utf-8',
   extension: 'md',
+  label: 'Markdown',
 }));

--- a/tests/frontend/pages/vector-export-page.test.tsx
+++ b/tests/frontend/pages/vector-export-page.test.tsx
@@ -14,9 +14,21 @@ describe('VectorExportPage', () => {
     const html = htmlFor(<VectorExportPage modelsResponse={modelsResponse} loading={false} />);
     expect(html).toContain('Vector export');
     expect(html).toContain('aria-label="Export collection"');
+    expect(html).toContain('aria-label="Export format"');
     expect(html).toContain('oracle_bge');
-    expect(html).toContain('Export JSON');
-    expect(html).toContain('Export CSV');
+    expect(html).toContain('JSON');
+    expect(html).toContain('CSV');
+    expect(html).toContain('Export');
+  });
+
+  test('renders provided available formats', () => {
+    const html = htmlFor(<VectorExportPage
+      modelsResponse={modelsResponse}
+      loading={false}
+      formats={[{ format: 'jsonl', label: 'JSONL', mimeType: 'application/x-ndjson', extension: 'jsonl' }]}
+    />);
+    expect(html).toContain('JSONL');
+    expect(html).not.toContain('CSV');
   });
 
   test('normalizes model response entries into export collections', () => {

--- a/tests/frontend/pages/vector-page-export.test.tsx
+++ b/tests/frontend/pages/vector-page-export.test.tsx
@@ -2,9 +2,12 @@ import { describe, expect, test } from 'bun:test';
 import { MemoryRouter } from 'react-router-dom';
 import {
   downloadVectorCollection,
+  fetchVectorExportFormats,
   saveBlobAsDownload,
   vectorExportFilename,
   vectorExportPath,
+} from '../../../frontend/src/vectorExport';
+import {
   VectorCollectionCards,
   VectorPage,
   type VectorCollectionCard,
@@ -22,14 +25,26 @@ const card: VectorCollectionCard = {
 };
 
 describe('VectorPage export buttons', () => {
-  test('renders JSON and CSV export buttons for collection cards', () => {
+  test('renders available export formats dropdown for collection cards', () => {
     const modelsResponse = { models: { bge: { collection: card.collection, model: card.model, adapter: card.adapter, count: card.count } } };
     const healthResponse = { status: 'ok' as const, engines: [{ key: 'bge', ok: true }], checked_at: 'now' };
     const html = htmlFor(<MemoryRouter><VectorPage modelsResponse={modelsResponse} healthResponse={healthResponse} loading={false} /></MemoryRouter>);
     expect(html).toContain('Vector collections');
     expect(html).toContain('oracle_knowledge_bge_m3');
-    expect(html).toContain('Export JSON');
-    expect(html).toContain('Export CSV');
+    expect(html).toContain('Export format for oracle_knowledge_bge_m3');
+    expect(html).toContain('JSON');
+    expect(html).toContain('CSV');
+    expect(html).toContain('Export');
+  });
+
+  test('collection cards render supplied registry formats', () => {
+    const html = htmlFor(<VectorCollectionCards
+      cards={[card]}
+      formats={[{ format: 'jsonl', label: 'JSONL', mimeType: 'application/x-ndjson', extension: 'jsonl' }]}
+      onExport={() => {}}
+    />);
+    expect(html).toContain('JSONL');
+    expect(html).not.toContain('CSV');
   });
 
   test('renders a spinner label while a collection is downloading', () => {
@@ -39,8 +54,17 @@ describe('VectorPage export buttons', () => {
   });
 
   test('builds encoded export URLs and safe filenames', () => {
-    expect(vectorExportPath('oracle knowledge', 'csv')).toBe('/api/vector/export?collection=oracle+knowledge&format=csv');
+    expect(vectorExportPath('oracle knowledge', 'csv')).toBe('/api/v1/vector/export?collection=oracle+knowledge&format=csv');
     expect(vectorExportFilename('oracle knowledge/bge m3', 'json')).toBe('oracle-knowledge-bge-m3.json');
+  });
+
+  test('fetches available export formats', async () => {
+    const formats = await fetchVectorExportFormats({
+      fetch: () => new Response(JSON.stringify({
+        formats: [{ format: 'csv', label: 'CSV', mimeType: 'text/csv', extension: 'csv' }],
+      })),
+    });
+    expect(formats).toEqual([{ format: 'csv', label: 'CSV', mimeType: 'text/csv', extension: 'csv' }]);
   });
 
   test('fetches export blobs and passes them to the download sink', async () => {
@@ -54,7 +78,7 @@ describe('VectorPage export buttons', () => {
       saveBlob: (blob, filename) => saved.push({ blob, filename }),
     });
 
-    expect(calls).toEqual(['/api/vector/export?collection=oracle_knowledge_bge_m3&format=csv']);
+    expect(calls).toEqual(['/api/v1/vector/export?collection=oracle_knowledge_bge_m3&format=csv']);
     expect(saved[0]?.filename).toBe('oracle_knowledge_bge_m3.csv');
     await expect(saved[0]?.blob.text()).resolves.toContain('oracle');
   });

--- a/tests/frontend/routes/vector-meta.test.ts
+++ b/tests/frontend/routes/vector-meta.test.ts
@@ -6,7 +6,7 @@ describe('vector route metadata', () => {
     expect(routeMeta('/vector')).toMatchObject({ title: 'Vector dashboard', eyebrow: 'Vector' });
     expect(routeMeta('/vector/export')).toMatchObject({
       title: 'Vector export',
-      description: 'Download vector collections as JSON or CSV.',
+      description: 'Download vector collections in available formats.',
     });
   });
 });

--- a/tests/http/vector/export.test.ts
+++ b/tests/http/vector/export.test.ts
@@ -83,3 +83,18 @@ test('GET /api/v1/vector/export returns JSON rows for the selected collection', 
   ]);
   expect(store.getAllEmbeddings).toHaveBeenCalledWith(2);
 });
+
+test('GET /api/v1/vector/export/formats lists registered export formats', async () => {
+  const fetcher = createFetch(createStore(), []);
+
+  const res = await fetcher(new Request('http://local/api/v1/vector/export/formats'));
+  const body = await res.json() as { formats: Array<Record<string, string>> };
+
+  expect(res.status).toBe(200);
+  expect(body.formats).toEqual([
+    { format: 'csv', label: 'CSV', mimeType: 'text/csv; charset=utf-8', extension: 'csv' },
+    { format: 'json', label: 'JSON', mimeType: 'application/json; charset=utf-8', extension: 'json' },
+    { format: 'jsonl', label: 'JSONL', mimeType: 'application/x-ndjson; charset=utf-8', extension: 'jsonl' },
+    { format: 'markdown', label: 'Markdown', mimeType: 'text/markdown; charset=utf-8', extension: 'md' },
+  ]);
+});


### PR DESCRIPTION
## Summary
- expose the vector export format registry at GET /api/v1/vector/export/formats
- drive frontend vector export controls from the available format list instead of hardcoded JSON/CSV buttons
- add coverage for registry metadata, frontend format dropdowns, and export helpers

## Verification
- tsc --noEmit
- bun test tests/frontend/
- bun test tests/http/vector/export.test.ts tests/http/vector/export-csv.test.ts
- changed files checked <=250 lines