### PR TITLE
Persist frontend theme preference on startup

### DIFF
--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -8,7 +8,13 @@ export function ThemeToggle() {
     applyTheme(theme);
   }, [theme]);
 
-  const next = theme === 'dark' ? 'light' : 'dark';
+  function toggleTheme() {
+    setTheme((current) => {
+      const next = current === 'dark' ? 'light' : 'dark';
+      saveTheme(next);
+      return next;
+    });
+  }
 
   return (
     <button
@@ -16,10 +22,7 @@ export function ThemeToggle() {
       type="button"
       aria-label="Dark mode"
       aria-pressed={theme === 'dark'}
-      onClick={() => {
-        saveTheme(next);
-        setTheme(next);
-      }}
+      onClick={toggleTheme}
     >
       {theme === 'dark' ? '☾ Dark' : '☀ Light'}
     </button>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,9 +5,9 @@ import { BackendGate } from './components/BackendGate';
 import { AppRouter } from './router';
 import './styles.css';
 import { registerServiceWorker } from './registerServiceWorker';
-import { applyTheme, readStoredTheme } from './theme';
+import { loadTheme } from './theme';
 
-applyTheme(readStoredTheme());
+loadTheme();
 registerServiceWorker();
 
 createRoot(document.getElementById('root')!).render(

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -28,6 +28,12 @@ export function applyTheme(theme: ThemeMode) {
   root.style.colorScheme = theme;
 }
 
+export function loadTheme(): ThemeMode {
+  const theme = readStoredTheme();
+  applyTheme(theme);
+  return theme;
+}
+
 export function saveTheme(theme: ThemeMode) {
   try {
     browserWindow()?.localStorage.setItem(THEME_KEY, theme);

--- a/tests/frontend/theme/load-theme-persisted.test.ts
+++ b/tests/frontend/theme/load-theme-persisted.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test';
+import { loadTheme, THEME_KEY } from '../../../frontend/src/theme';
+import { installBrowserLocation } from '../_render';
+
+describe('loadTheme persistence', () => {
+  test('loads a saved preference and applies it on startup', () => {
+    const restore = installBrowserLocation('/menu');
+    try {
+      window.localStorage.setItem(THEME_KEY, 'dark');
+      expect(loadTheme()).toBe('dark');
+      expect(document.documentElement.dataset.theme).toBe('dark');
+      expect(document.documentElement.style.colorScheme).toBe('dark');
+    } finally {
+      restore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a loadTheme helper that reads the saved localStorage preference and applies it before app render
- keep ThemeToggle persistence tied to the state transition
- add frontend coverage proving saved dark mode is applied on startup

## Verification
- tsc --noEmit
- bun test tests/frontend/
- wc -l frontend/src/theme.ts frontend/src/components/ThemeToggle.tsx frontend/src/main.tsx tests/frontend/theme/load-theme-persisted.test.ts
