### PR TITLE
Test vector export formats endpoint

### DIFF
--- a/src/routes/vector/export.ts
+++ b/src/routes/vector/export.ts
@@ -27,9 +27,14 @@ function extensionFor(format: string): string {
 export function createVectorExportEndpoint(deps: VectorExportDeps = {}) {
   const getStore = deps.getStore ?? getVectorStoreByModel;
 
-  return new Elysia().get(
-    '/vector/export',
-    async ({ query, set }) => {
+  return new Elysia()
+    .get('/vector/export/formats', () => Object.keys(exportFormatters), {
+      detail: {
+        tags: ['vector'],
+        summary: 'List available vector export formats',
+      },
+    })
+    .get('/vector/export', async ({ query, set }) => {
       const format = query.format || 'json';
       const formatter = exportFormatters[format];
       if (!formatter) {
@@ -63,8 +68,7 @@ export function createVectorExportEndpoint(deps: VectorExportDeps = {}) {
         const message = error instanceof Error ? error.message : String(error);
         return { error: 'Vector export failed', message };
       }
-    },
-    {
+    }, {
       query: t.Object({
         collection: t.Optional(t.String()),
         format: t.Optional(t.String()),

--- a/src/routes/vector/index.ts
+++ b/src/routes/vector/index.ts
@@ -9,7 +9,7 @@
  *   GET /api/map3d           — 3D PCA projection from real embeddings
  *   GET /api/vector/stats    — per-engine collection counts
  *   GET /api/vector/health   — adapter liveness probe
- *   GET /api/vector/export   — export collection docs as JSON or CSV
+ *   GET /api/vector/export   — export collection docs as JSON, JSONL, CSV, or Markdown
  *   GET /api/vector/documents — browse indexed vector documents
  *   GET /api/v1/vector/config — config + per-collection health/counts
  *   PUT /api/v1/vector/config/:collection — update collection adapter/model/provider

--- a/tests/http/vector/export-formats.test.ts
+++ b/tests/http/vector/export-formats.test.ts
@@ -1,0 +1,51 @@
+import { expect, mock, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createVectorExportEndpoint } from '../../../src/routes/vector/export.ts';
+import type { VectorStoreAdapter } from '../../../src/vector/types.ts';
+
+function createStore(): VectorStoreAdapter {
+  return {
+    name: 'fake-vector',
+    connect: mock(async () => {}),
+    close: mock(async () => {}),
+    ensureCollection: mock(async () => {}),
+    deleteCollection: mock(async () => {}),
+    addDocuments: mock(async () => {}),
+    query: mock(async () => ({ ids: [], documents: [], distances: [], metadatas: [] })),
+    queryById: mock(async () => ({ ids: [], documents: [], distances: [], metadatas: [] })),
+    getStats: mock(async () => ({ count: 1 })),
+    getCollectionInfo: mock(async () => ({ count: 1, name: 'fake' })),
+    getAllEmbeddings: mock(async () => ({
+      ids: ['doc-1'],
+      documents: ['alpha document'],
+      embeddings: [[0, 0, 0]],
+      metadatas: [{ type: 'learning', source_file: 'notes/alpha.md', concepts: ['alpha'] }],
+    })),
+  };
+}
+
+function createFetch() {
+  const app = new Elysia({ prefix: '/api' }).use(createVectorExportEndpoint({ getStore: () => createStore() }));
+  return createApiVersionedFetch((request) => app.handle(request));
+}
+
+test('GET /api/v1/vector/export/formats lists available export formats', async () => {
+  const res = await createFetch()(new Request('http://local/api/v1/vector/export/formats'));
+  const formats = await res.json() as string[];
+
+  expect(res.status).toBe(200);
+  expect(Array.isArray(formats)).toBe(true);
+  expect(formats).toContain('json');
+  expect(formats).toContain('csv');
+  expect(formats).toContain('jsonl');
+});
+
+test('GET /api/v1/vector/export supports jsonl format', async () => {
+  const res = await createFetch()(new Request('http://local/api/v1/vector/export?collection=bge-m3&format=jsonl'));
+  const text = await res.text();
+
+  expect(res.status).toBe(200);
+  expect(res.headers.get('content-type')).toContain('application/x-ndjson');
+  expect(JSON.parse(text.trim())).toMatchObject({ id: 'doc-1', document: 'alpha document' });
+});


### PR DESCRIPTION
## Summary
- expose `GET /api/v1/vector/export/formats` from the vector export endpoint using registered formatter keys
- add HTTP coverage for the formats list and JSONL export path
- update vector route docs to include Markdown alongside JSON/JSONL/CSV

## Verification
- `bun test tests/http/vector/`
- `tsc --noEmit`
- `git diff --check`
- `wc -l src/routes/vector/export.ts src/routes/vector/index.ts tests/http/vector/export-formats.test.ts`
