### PR TITLE
Add v2-compatible vector export format

### DIFF
--- a/src/vector/export-formats.ts
+++ b/src/vector/export-formats.ts
@@ -167,6 +167,7 @@ function streamMarkdown(dump: EmbeddingDump): ReadableStream<Uint8Array> {
   });
 }
 
+<<<<<<< HEAD
 function normalizeName(name: string, strict = true): string {
   const normalized = name.trim().toLowerCase();
   if (!/^[a-z0-9-]+$/.test(normalized)) {
@@ -238,10 +239,6 @@ registerExportFormat('markdown', withMeta(streamMarkdown, {
   contentType: 'text/markdown; charset=utf-8',
   extension: 'md',
   label: 'Markdown',
-}));
-registerExportFormat('v2', withMeta(streamV2Compat, {
-  contentType: 'application/json; charset=utf-8',
-  extension: 'v2.json',
 }));
 registerExportFormat('v2', withMeta(streamV2Compat, {
   contentType: 'application/json; charset=utf-8',

--- a/src/vector/export-formats.ts
+++ b/src/vector/export-formats.ts
@@ -22,6 +22,13 @@ interface ExportRow {
   concepts: string[];
 }
 
+interface V2CompatDocument {
+  id: string;
+  content: string;
+  metadata: Record<string, unknown>;
+  source: string;
+}
+
 const encoder = new TextEncoder();
 
 function text(value: unknown): string {
@@ -42,15 +49,33 @@ function concepts(value: unknown): string[] {
   return value.split(',').map((part) => part.trim()).filter(Boolean);
 }
 
-function rowAt(dump: EmbeddingDump, index: number): ExportRow {
+function metadataAt(dump: EmbeddingDump, index: number): Record<string, unknown> {
   const metadata = dump.metadatas[index] ?? {};
-  const meta = metadata && typeof metadata === 'object' ? metadata as Record<string, unknown> : {};
+  return metadata && typeof metadata === 'object' ? metadata as Record<string, unknown> : {};
+}
+
+function contentAt(dump: EmbeddingDump, index: number, meta: Record<string, unknown>): string {
+  return text(dump.documents?.[index] ?? meta.document ?? meta.content ?? meta.text);
+}
+
+function rowAt(dump: EmbeddingDump, index: number): ExportRow {
+  const meta = metadataAt(dump, index);
   return {
     id: text(dump.ids[index]),
-    document: text(dump.documents?.[index] ?? meta.document ?? meta.content ?? meta.text),
+    document: contentAt(dump, index, meta),
     type: text(meta.type),
     source_file: text(meta.source_file ?? meta.sourceFile),
     concepts: concepts(meta.concepts),
+  };
+}
+
+function v2CompatDocumentAt(dump: EmbeddingDump, index: number): V2CompatDocument {
+  const metadata = metadataAt(dump, index);
+  return {
+    id: text(dump.ids[index]),
+    content: contentAt(dump, index, metadata),
+    metadata,
+    source: text(metadata.source_file ?? metadata.sourceFile ?? metadata.source),
   };
 }
 
@@ -74,6 +99,20 @@ function streamJsonl(dump: EmbeddingDump): ReadableStream<Uint8Array> {
       for (let i = 0; i < dump.ids.length; i++) {
         controller.enqueue(encoder.encode(`${JSON.stringify(rowAt(dump, i))}\n`));
       }
+      controller.close();
+    },
+  });
+}
+
+function streamV2Compat(dump: EmbeddingDump): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode('{"version":1,"documents":['));
+      for (let i = 0; i < dump.ids.length; i++) {
+        if (i > 0) controller.enqueue(encoder.encode(','));
+        controller.enqueue(encoder.encode(JSON.stringify(v2CompatDocumentAt(dump, i))));
+      }
+      controller.enqueue(encoder.encode(']}'));
       controller.close();
     },
   });
@@ -199,4 +238,8 @@ registerExportFormat('markdown', withMeta(streamMarkdown, {
   contentType: 'text/markdown; charset=utf-8',
   extension: 'md',
   label: 'Markdown',
+}));
+registerExportFormat('v2', withMeta(streamV2Compat, {
+  contentType: 'application/json; charset=utf-8',
+  extension: 'v2.json',
 }));

--- a/src/vector/export-formats.ts
+++ b/src/vector/export-formats.ts
@@ -243,3 +243,7 @@ registerExportFormat('v2', withMeta(streamV2Compat, {
   contentType: 'application/json; charset=utf-8',
   extension: 'v2.json',
 }));
+registerExportFormat('v2', withMeta(streamV2Compat, {
+  contentType: 'application/json; charset=utf-8',
+  extension: 'v2.json',
+}));

--- a/src/vector/export-formats.ts
+++ b/src/vector/export-formats.ts
@@ -167,7 +167,6 @@ function streamMarkdown(dump: EmbeddingDump): ReadableStream<Uint8Array> {
   });
 }
 
-<<<<<<< HEAD
 function normalizeName(name: string, strict = true): string {
   const normalized = name.trim().toLowerCase();
   if (!/^[a-z0-9-]+$/.test(normalized)) {
@@ -243,4 +242,5 @@ registerExportFormat('markdown', withMeta(streamMarkdown, {
 registerExportFormat('v2', withMeta(streamV2Compat, {
   contentType: 'application/json; charset=utf-8',
   extension: 'v2.json',
+  label: 'V2',
 }));

--- a/tests/http/vector/export-formats.test.ts
+++ b/tests/http/vector/export-formats.test.ts
@@ -32,13 +32,14 @@ function createFetch() {
 
 test('GET /api/v1/vector/export/formats lists available export formats', async () => {
   const res = await createFetch()(new Request('http://local/api/v1/vector/export/formats'));
-  const formats = await res.json() as string[];
+  const body = await res.json() as { formats: Array<{ format: string }> };
 
   expect(res.status).toBe(200);
-  expect(Array.isArray(formats)).toBe(true);
-  expect(formats).toContain('json');
-  expect(formats).toContain('csv');
-  expect(formats).toContain('jsonl');
+  expect(Array.isArray(body.formats)).toBe(true);
+  expect(body.formats.map((item) => item.format)).toContain('json');
+  expect(body.formats.map((item) => item.format)).toContain('csv');
+  expect(body.formats.map((item) => item.format)).toContain('jsonl');
+  expect(body.formats.map((item) => item.format)).toContain('v2');
 });
 
 test('GET /api/v1/vector/export supports jsonl format', async () => {

--- a/tests/http/vector/export-v2.test.ts
+++ b/tests/http/vector/export-v2.test.ts
@@ -1,0 +1,51 @@
+import { expect, mock, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createVectorExportEndpoint } from '../../../src/routes/vector/export.ts';
+import type { VectorStoreAdapter } from '../../../src/vector/types.ts';
+
+const metadata = [
+  { type: 'learning', source_file: 'notes/alpha.md', concepts: ['alpha', 'beta'] },
+  { type: 'trace', sourceFile: 'traces/bravo.md', source: 'fallback', concepts: 'gamma' },
+];
+
+function createStore(): VectorStoreAdapter {
+  return {
+    name: 'fake-vector',
+    connect: mock(async () => {}),
+    close: mock(async () => {}),
+    ensureCollection: mock(async () => {}),
+    deleteCollection: mock(async () => {}),
+    addDocuments: mock(async () => {}),
+    query: mock(async () => ({ ids: [], documents: [], distances: [], metadatas: [] })),
+    queryById: mock(async () => ({ ids: [], documents: [], distances: [], metadatas: [] })),
+    getStats: mock(async () => ({ count: 2 })),
+    getCollectionInfo: mock(async () => ({ count: 2, name: 'fake' })),
+    getAllEmbeddings: mock(async () => ({
+      ids: ['doc-1', 'doc-2'],
+      documents: ['alpha document', 'bravo document'],
+      embeddings: [[0, 0, 0], [1, 1, 1]],
+      metadatas: metadata,
+    })),
+  };
+}
+
+test('GET /api/v1/vector/export streams v2-compatible vault JSON', async () => {
+  const app = new Elysia({ prefix: '/api' }).use(createVectorExportEndpoint({ getStore: () => createStore() }));
+  const fetcher = createApiVersionedFetch((request) => app.handle(request));
+
+  const res = await fetcher(new Request(
+    'http://local/api/v1/vector/export?collection=bge-m3&format=v2',
+  ));
+  const body = await res.json() as Record<string, unknown>;
+
+  expect(res.status).toBe(200);
+  expect(res.headers.get('content-type')).toContain('application/json');
+  expect(body).toEqual({
+    version: 1,
+    documents: [
+      { id: 'doc-1', content: 'alpha document', metadata: metadata[0], source: 'notes/alpha.md' },
+      { id: 'doc-2', content: 'bravo document', metadata: metadata[1], source: 'traces/bravo.md' },
+    ],
+  });
+});

--- a/tests/http/vector/export.test.ts
+++ b/tests/http/vector/export.test.ts
@@ -96,5 +96,6 @@ test('GET /api/v1/vector/export/formats lists registered export formats', async 
     { format: 'json', label: 'JSON', mimeType: 'application/json; charset=utf-8', extension: 'json' },
     { format: 'jsonl', label: 'JSONL', mimeType: 'application/x-ndjson; charset=utf-8', extension: 'jsonl' },
     { format: 'markdown', label: 'Markdown', mimeType: 'text/markdown; charset=utf-8', extension: 'md' },
+    { format: 'v2', label: 'V2', mimeType: 'application/json; charset=utf-8', extension: 'v2.json' },
   ]);
 });


### PR DESCRIPTION
## Summary
- add a `v2` export formatter that streams a version 1 vault-compatible payload
- emit documents with `id`, `content`, `metadata`, and `source` fields
- keep Markdown/JSONL/CSV formatter support from current alpha and add focused v2 HTTP coverage

## Tests
- tsc --noEmit
- bun test tests/http/vector/
- wc -l src/vector/export-formats.ts src/routes/vector/export.ts tests/http/vector/export-v2.test.ts

Not-tested: importing the v2 payload into a live arra-oracle-v2 instance.