### PR TITLE
Add native Tauri app menu

### DIFF
--- a/frontend/src-tauri/src/app_menu.rs
+++ b/frontend/src-tauri/src/app_menu.rs
@@ -1,0 +1,92 @@
+use tauri::{
+    menu::{AboutMetadata, Menu, MenuBuilder, PredefinedMenuItem, SubmenuBuilder},
+    AppHandle, Manager, Runtime,
+};
+
+const DOCS_URL: &str =
+    "https://github.com/Soul-Brews-Studio/arra-oracle-v3/blob/alpha/docs/README.md";
+const MENU_EXPORT_DATA: &str = "export_data";
+const MENU_QUIT: &str = "quit";
+const MENU_TOGGLE_FULLSCREEN: &str = "toggle_fullscreen";
+const MENU_ALWAYS_ON_TOP: &str = "always_on_top";
+const MENU_OPEN_DOCS: &str = "open_docs";
+
+pub fn build_app_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
+    let about = PredefinedMenuItem::about(
+        app,
+        Some("About ARRA Oracle"),
+        Some(AboutMetadata {
+            name: Some("ARRA Oracle".into()),
+            version: Some(env!("CARGO_PKG_VERSION").into()),
+            ..Default::default()
+        }),
+    )?;
+    let file = SubmenuBuilder::new(app, "File")
+        .text(MENU_EXPORT_DATA, "Export Data")
+        .separator()
+        .text(MENU_QUIT, "Quit")
+        .build()?;
+    let view = SubmenuBuilder::new(app, "View")
+        .text(MENU_TOGGLE_FULLSCREEN, "Toggle Fullscreen")
+        .text(MENU_ALWAYS_ON_TOP, "Always on Top")
+        .build()?;
+    let help = SubmenuBuilder::new(app, "Help")
+        .item(&about)
+        .text(MENU_OPEN_DOCS, "Open Docs")
+        .build()?;
+    MenuBuilder::new(app)
+        .item(&file)
+        .item(&view)
+        .item(&help)
+        .build()
+}
+
+pub fn handle_menu_event<R: Runtime>(app: &AppHandle<R>, event: tauri::menu::MenuEvent) {
+    match event.id().as_ref() {
+        MENU_EXPORT_DATA => open_export_page(app),
+        MENU_QUIT => app.exit(0),
+        MENU_TOGGLE_FULLSCREEN => toggle_fullscreen(app),
+        MENU_ALWAYS_ON_TOP => toggle_always_on_top(app),
+        MENU_OPEN_DOCS => {
+            if let Err(err) = tauri_plugin_opener::open_url(DOCS_URL, None::<&str>) {
+                eprintln!("[Tauri menu] open docs failed: {err}");
+            }
+        }
+        _ => {}
+    }
+}
+
+fn open_export_page<R: Runtime>(app: &AppHandle<R>) {
+    if let Some(window) = app.get_webview_window("main") {
+        let script = "window.history.pushState(null, '', '/vector/export'); window.dispatchEvent(new PopStateEvent('popstate'));";
+        if let Err(err) = window.eval(script) {
+            eprintln!("[Tauri menu] navigation failed: {err}");
+        }
+    }
+}
+
+fn toggle_fullscreen<R: Runtime>(app: &AppHandle<R>) {
+    if let Some(window) = app.get_webview_window("main") {
+        match window.is_fullscreen() {
+            Ok(fullscreen) => {
+                if let Err(err) = window.set_fullscreen(!fullscreen) {
+                    eprintln!("[Tauri menu] fullscreen toggle failed: {err}");
+                }
+            }
+            Err(err) => eprintln!("[Tauri menu] fullscreen state failed: {err}"),
+        }
+    }
+}
+
+fn toggle_always_on_top<R: Runtime>(app: &AppHandle<R>) {
+    if let Some(window) = app.get_webview_window("main") {
+        match window.is_always_on_top() {
+            Ok(on_top) => {
+                if let Err(err) = window.set_always_on_top(!on_top) {
+                    eprintln!("[Tauri menu] always-on-top toggle failed: {err}");
+                }
+            }
+            Err(err) => eprintln!("[Tauri menu] always-on-top state failed: {err}"),
+        }
+    }
+}

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -5,6 +5,8 @@ use tauri_plugin_shell::{
     ShellExt,
 };
 
+mod app_menu;
+
 const BACKEND_URL: &str = "http://localhost:47778";
 const BACKEND_HEALTH_URL: &str = "http://localhost:47778/api/health";
 const BACKEND_HOST: &str = "localhost:47778";
@@ -221,6 +223,7 @@ pub fn run() {
         .manage(BackendState::default())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_shell::init())
+        .on_menu_event(app_menu::handle_menu_event)
         .invoke_handler(tauri::generate_handler![
             health_check,
             get_backend_url,
@@ -232,6 +235,7 @@ pub fn run() {
             let window = app.get_webview_window("main").unwrap();
             window.set_title("ARRA Oracle").unwrap();
             setup_tray(app)?;
+            app.set_menu(app_menu::build_app_menu(app.handle())?)?;
             autostart_backend(app);
             Ok(())
         })


### PR DESCRIPTION
## Summary
- adds native Tauri menu bar wiring for File, View, and Help
- routes Export Data to /vector/export, Quit to app exit, View toggles fullscreen/always-on-top
- adds Help actions for About ARRA Oracle and Open Docs

## Validation
- cargo check (frontend/src-tauri/)
- git diff --check
- changed file line counts <=250