### PR TITLE
Issue #27: Redesign VectorPage to bento layout

### DIFF
--- a/frontend/src/pages/VectorPage.tsx
+++ b/frontend/src/pages/VectorPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { apiClient, type ApiClient, type VectorHealthResponse, type VectorIndexModelEntry, type VectorIndexModelsResponse } from '../api/client';
-import { ErrorMessage, LoadingPanel, Spinner } from '../components/AsyncState';
+import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
 import { VectorIndexPanel } from '../components/VectorIndexPanel';
 import { VectorSearchWidget } from '../components/VectorSearchWidget';
 import { vectorDocumentsPath, vectorSearchPath } from '../routePaths';
@@ -9,24 +9,18 @@ import {
   downloadVectorCollection,
   fallbackVectorExportFormats,
   fetchVectorExportFormats,
-  formatLabelFor,
   type VectorExportFormat,
-  type VectorExportFormatOption,
 } from '../vectorExport';
+import {
+  VectorCollectionCards,
+  VectorStatsCard,
+  QuickExportCard,
+  type VectorCollectionCard,
+} from './vector-dashboard-cards';
 
 type PageState = 'loading' | 'ready' | 'error';
 type VectorStatusClient = Pick<ApiClient, 'vectorIndexModels' | 'vectorHealth'>;
 type DownloadByCollection = Record<string, VectorExportFormat | undefined>;
-export interface VectorCollectionCard {
-  key: string;
-  collection: string;
-  adapter: string;
-  model: string;
-  count?: number;
-  healthy: boolean;
-  healthLabel: string;
-  healthDetail?: string;
-}
 
 export interface VectorPageProps {
   modelsResponse?: VectorIndexModelsResponse | null;
@@ -36,9 +30,7 @@ export interface VectorPageProps {
 }
 
 function healthFor(key: string, model: VectorIndexModelEntry, health?: VectorHealthResponse | null) {
-  return health?.engines.find((engine) => (
-    engine.key === key || engine.collection === model.collection || engine.model === model.model
-  ));
+  return health?.engines.find((engine) => engine.key === key || engine.collection === model.collection || engine.model === model.model);
 }
 
 function healthLabel(healthy: boolean, error?: string): string {
@@ -78,74 +70,6 @@ export function vectorDashboardSummary(cards: VectorCollectionCard[], state: Pag
   return `${healthy}/${cards.length} vector collections healthy.`;
 }
 
-function docCountLabel(count?: number): string {
-  if (typeof count !== 'number') return 'unknown docs';
-  return `${count.toLocaleString()} doc${count === 1 ? '' : 's'}`;
-}
-
-function statusClasses(healthy: boolean): string {
-  return healthy
-    ? 'border-emerald-300/30 bg-emerald-300/10 text-emerald-200'
-    : 'border-red-300/30 bg-red-300/10 text-red-100';
-}
-
-export function VectorCollectionCards({
-  cards,
-  formats = fallbackVectorExportFormats,
-  downloads = {},
-  onExport,
-}: {
-  cards: VectorCollectionCard[];
-  formats?: VectorExportFormatOption[];
-  downloads?: DownloadByCollection;
-  onExport?: (collection: string, format: VectorExportFormat) => void;
-}) {
-  const [selectedFormats, setSelectedFormats] = useState<Record<string, VectorExportFormat>>({});
-  return (
-    <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3" aria-label="Vector collections">
-      {cards.map((card) => {
-        const downloading = downloads[card.collection];
-        const disabled = Boolean(downloading);
-        const selected = selectedFormats[card.collection] ?? formats[0]?.format ?? 'json';
-        const label = formatLabelFor(formats, selected);
-        return (
-          <article key={card.key} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
-            <div className="flex items-start justify-between gap-3">
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Collection</p>
-                <h2 className="mt-1 text-lg font-semibold text-white">{card.collection}</h2>
-              </div>
-              <span className={`inline-flex rounded-full border px-2 py-1 text-xs font-semibold ${statusClasses(card.healthy)}`}>
-                {card.healthLabel}
-              </span>
-            </div>
-            <dl className="mt-4 grid gap-3 text-sm">
-              <div><dt className="text-slate-500">Adapter</dt><dd className="font-medium text-slate-100">{card.adapter}</dd></div>
-              <div><dt className="text-slate-500">Model</dt><dd className="font-medium text-slate-100">{card.model}</dd></div>
-              <div><dt className="text-slate-500">Documents</dt><dd className="font-medium text-slate-100">{docCountLabel(card.count)}</dd></div>
-            </dl>
-            {card.healthDetail ? <p className="mt-3 text-xs text-red-200">{card.healthDetail}</p> : null}
-            <div className="mt-4 flex flex-wrap gap-2">
-              <select
-                aria-label={`Export format for ${card.collection}`}
-                className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm text-slate-100"
-                disabled={disabled || formats.length === 0}
-                value={selected}
-                onChange={(event) => setSelectedFormats((current) => ({ ...current, [card.collection]: event.target.value }))}
-              >
-                {formats.map((format) => <option key={format.format} value={format.format}>{format.label}</option>)}
-              </select>
-              <button className="focus-ring rounded-xl border border-teal-300/30 px-3 py-2 text-sm font-semibold text-teal-100 hover:bg-teal-300/10 disabled:cursor-not-allowed disabled:opacity-50" disabled={disabled || formats.length === 0} type="button" onClick={() => onExport?.(card.collection, selected)}>
-                {downloading ? <Spinner label={`Downloading ${label}`} /> : 'Export'}
-              </button>
-            </div>
-          </article>
-        );
-      })}
-    </div>
-  );
-}
-
 function VectorDocumentsCard() {
   return (
     <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-documents-title">
@@ -159,15 +83,20 @@ function VectorDocumentsCard() {
   );
 }
 
-export function VectorPage({ modelsResponse = null, healthResponse = null, loading = true, client = apiClient }: VectorPageProps) {
+export function VectorPage({
+  modelsResponse = null,
+  healthResponse = null,
+  loading = true,
+  client = apiClient,
+}: VectorPageProps) {
   const navigate = useNavigate();
   const [models, setModels] = useState(modelsResponse);
   const [health, setHealth] = useState(healthResponse);
   const [state, setState] = useState<PageState>(loading ? 'loading' : 'ready');
   const [error, setError] = useState('');
+  const [downloadError, setDownloadError] = useState('');
   const [downloads, setDownloads] = useState<DownloadByCollection>({});
   const [formats, setFormats] = useState(fallbackVectorExportFormats);
-  const [downloadError, setDownloadError] = useState('');
 
   useEffect(() => {
     let cancelled = false;
@@ -181,9 +110,9 @@ export function VectorPage({ modelsResponse = null, healthResponse = null, loadi
         setFormats(nextFormats.length ? nextFormats : fallbackVectorExportFormats);
         setState('ready');
       })
-      .catch((err) => {
+      .catch((cause) => {
         if (cancelled) return;
-        setError(err instanceof Error ? err.message : String(err));
+        setError(cause instanceof Error ? cause.message : String(cause));
         setState(models ? 'ready' : 'error');
       });
     return () => { cancelled = true; };
@@ -194,10 +123,14 @@ export function VectorPage({ modelsResponse = null, healthResponse = null, loadi
     setDownloads((current) => ({ ...current, [collection]: format }));
     try {
       await downloadVectorCollection(collection, format);
-    } catch (err) {
-      setDownloadError(err instanceof Error ? err.message : String(err));
+    } catch (cause) {
+      setDownloadError(cause instanceof Error ? cause.message : String(cause));
     } finally {
-      setDownloads(({ [collection]: _done, ...rest }) => rest);
+      setDownloads((current) => {
+        const next = { ...current };
+        delete next[collection];
+        return next;
+      });
     }
   }
 
@@ -220,13 +153,31 @@ export function VectorPage({ modelsResponse = null, healthResponse = null, loadi
         {isLoading ? <LoadingPanel title="Loading vector status…" detail="Fetching /api/vector/index/models and /api/vector/health." /> : null}
         {state === 'error' ? <ErrorMessage title="Could not load vector status." message={error} /> : null}
         {downloadError ? <div className="mb-4"><ErrorMessage title="Vector export failed." message={downloadError} /></div> : null}
-        {!isLoading && state !== 'error' && cards.length === 0 ? <p className="text-sm text-slate-400">No vector collections are registered.</p> : null}
-        {cards.length ? <VectorCollectionCards cards={cards} formats={formats} downloads={downloads} onExport={onExport} /> : null}
       </section>
 
-      <VectorDocumentsCard />
-      <VectorSearchWidget onOpenResults={(query) => navigate(vectorSearchPath(query))} />
-      <VectorIndexPanel />
+      <section className="grid gap-5 xl:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]" aria-label="Vector dashboard cards">
+        <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Collection health</p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">Vector collections</h2>
+          <p className="mt-2 text-sm text-slate-400">Status, model, and adapter details by collection.</p>
+          {!isLoading && state !== 'error' && cards.length === 0 ? <p className="mt-4 text-sm text-slate-400">No vector collections are registered.</p> : null}
+          {cards.length ? <VectorCollectionCards cards={cards} formats={formats} downloads={downloads} onExport={onExport} /> : null}
+        </section>
+
+        <div className="grid gap-4">
+          <VectorStatsCard cards={cards} />
+          <QuickExportCard cards={cards} formats={formats} downloads={downloads} onExport={onExport} />
+          <VectorIndexPanel />
+        </div>
+      </section>
+
+      <section className="grid gap-5 xl:grid-cols-2">
+        <VectorSearchWidget onOpenResults={(query) => navigate(vectorSearchPath(query))} />
+        <VectorDocumentsCard />
+      </section>
+
     </div>
   );
 }
+
+export { VectorCollectionCards, type VectorCollectionCard, VectorStatsCard, QuickExportCard };

--- a/frontend/src/pages/vector-dashboard-cards.tsx
+++ b/frontend/src/pages/vector-dashboard-cards.tsx
@@ -1,0 +1,193 @@
+import { useMemo, useState } from 'react';
+import { fallbackVectorExportFormats, formatLabelFor, type VectorExportFormat, type VectorExportFormatOption } from '../vectorExport';
+import { Spinner } from '../components/AsyncState';
+
+export interface VectorCollectionCard {
+  key: string;
+  collection: string;
+  adapter: string;
+  model: string;
+  count?: number;
+  healthy: boolean;
+  healthLabel: string;
+  healthDetail?: string;
+}
+
+type DownloadByCollection = Record<string, VectorExportFormat | undefined>;
+
+type VectorTotals = {
+  collections: number;
+  knownDocs: number;
+  hasUnknownDocs: boolean;
+};
+
+function statusClasses(healthy: boolean): string {
+  return healthy
+    ? 'border-emerald-300/30 bg-emerald-300/10 text-emerald-200'
+    : 'border-red-300/30 bg-red-300/10 text-red-100';
+}
+
+export function docCountLabel(count?: number): string {
+  if (typeof count !== 'number') return 'unknown docs';
+  return `${count.toLocaleString()} doc${count === 1 ? '' : 's'}`;
+}
+
+export function vectorTotals(cards: VectorCollectionCard[]): VectorTotals {
+  const knownDocs = cards.reduce((sum, card) => sum + (typeof card.count === 'number' ? card.count : 0), 0);
+  const hasUnknownDocs = cards.some((card) => typeof card.count !== 'number');
+  return { collections: cards.length, knownDocs, hasUnknownDocs };
+}
+
+function docsLabel(cards: VectorCollectionCard[]): string {
+  const { collections, knownDocs, hasUnknownDocs } = vectorTotals(cards);
+  if (!collections) return 'No collection data yet';
+  if (hasUnknownDocs) return `${knownDocs.toLocaleString()}+ docs across ${collections} collections`;
+  return `${knownDocs.toLocaleString()} docs · ${collections} collections`;
+}
+
+export function VectorCollectionCards({
+  cards,
+  formats = fallbackVectorExportFormats,
+  downloads = {},
+  onExport,
+}: {
+  cards: VectorCollectionCard[];
+  formats?: VectorExportFormatOption[];
+  downloads?: DownloadByCollection;
+  onExport?: (collection: string, format: VectorExportFormat) => void;
+}) {
+  const [selectedFormats, setSelectedFormats] = useState<Record<string, VectorExportFormat>>({});
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3" aria-label="Vector collections">
+      {cards.map((card) => {
+        const downloading = downloads[card.collection];
+        const disabled = Boolean(downloading);
+        const selected = selectedFormats[card.collection] ?? formats?.[0]?.format ?? 'json';
+        const label = formatLabelFor(formats, selected);
+        return (
+          <article key={card.key} className="rounded-2xl border border-white/10 bg-slate-950/70 p-4">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Collection</p>
+                <h2 className="mt-1 text-lg font-semibold text-white">{card.collection}</h2>
+              </div>
+              <span className={`inline-flex rounded-full border px-2 py-1 text-xs font-semibold ${statusClasses(card.healthy)}`}>
+                {card.healthLabel}
+              </span>
+            </div>
+            <dl className="mt-4 grid gap-3 text-sm">
+              <div><dt className="text-slate-500">Adapter</dt><dd className="font-medium text-slate-100">{card.adapter}</dd></div>
+              <div><dt className="text-slate-500">Model</dt><dd className="font-medium text-slate-100">{card.model}</dd></div>
+              <div><dt className="text-slate-500">Documents</dt><dd className="font-medium text-slate-100">{docCountLabel(card.count)}</dd></div>
+            </dl>
+            {card.healthDetail ? <p className="mt-3 text-xs text-red-200">{card.healthDetail}</p> : null}
+            <div className="mt-4 flex flex-wrap gap-2">
+              <select
+                aria-label={`Export format for ${card.collection}`}
+                className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm text-slate-100"
+                disabled={disabled || !formats || formats.length === 0}
+                value={selected}
+                onChange={(event) => setSelectedFormats((current) => ({ ...current, [card.collection]: event.target.value }))}
+              >
+                {formats?.map((format) => <option key={format.format} value={format.format}>{format.label}</option>)}
+              </select>
+              <button
+                className="focus-ring rounded-xl border border-teal-300/30 px-3 py-2 text-sm font-semibold text-teal-100 hover:bg-teal-300/10 disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={disabled || !formats || formats.length === 0}
+                type="button"
+                onClick={() => onExport?.(card.collection, selected)}
+              >
+                {downloading ? <Spinner label={`Downloading ${label}`} /> : 'Export'}
+              </button>
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+}
+
+export function VectorStatsCard({ cards }: { cards: VectorCollectionCard[] }) {
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-stats-title">
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Stats</p>
+      <h2 id="vector-stats-title" className="mt-2 text-2xl font-semibold text-white">Collection stats</h2>
+      <dl className="mt-4 grid gap-3 text-sm text-slate-300">
+        <div><dt className="text-slate-500">Total docs</dt><dd className="text-lg font-semibold text-white">{docsLabel(cards)}</dd></div>
+        <div><dt className="text-slate-500">Models</dt><dd className="text-lg font-semibold text-white">{vectorTotals(cards).collections}</dd></div>
+      </dl>
+    </section>
+  );
+}
+
+export function QuickExportCard({
+  cards,
+  formats,
+  downloads,
+  onExport,
+}: {
+  cards: VectorCollectionCard[];
+  formats: VectorExportFormatOption[];
+  downloads: DownloadByCollection;
+  onExport: (collection: string, format: VectorExportFormat) => void;
+}) {
+  const options = useMemo(() => cards.map((card) => ({
+    value: card.collection,
+    label: `${card.collection} (${docCountLabel(card.count)})`,
+  })), [cards]);
+  const [collection, setCollection] = useState(options[0]?.value ?? '');
+  const [format, setFormat] = useState(formats[0]?.format ?? 'json');
+
+  if (!cards.length) {
+    return (
+      <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-quick-export-title">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Quick export</p>
+        <h2 id="vector-quick-export-title" className="mt-2 text-2xl font-semibold text-white">Export collection</h2>
+        <p className="mt-2 text-sm text-slate-400">No collections are loaded yet.</p>
+      </section>
+    );
+  }
+
+  const label = formatLabelFor(formats, format);
+  const isDownloading = Boolean(downloads[collection]);
+  const disabled = isDownloading || formats.length === 0;
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-quick-export-title">
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Quick export</p>
+      <h2 id="vector-quick-export-title" className="mt-2 text-2xl font-semibold text-white">Export collection</h2>
+      <p className="mt-2 text-sm text-slate-400">Pick a collection and format to download from /api/v1/vector/export.</p>
+      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+        <label className="grid gap-2 text-sm text-slate-300">
+          Collection
+          <select
+            aria-label="Quick export collection"
+            className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm text-slate-100"
+            value={collection}
+            onChange={(event) => setCollection(event.target.value)}
+          >
+            {options.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+          </select>
+        </label>
+        <label className="grid gap-2 text-sm text-slate-300">
+          Format
+          <select
+            aria-label="Quick export format"
+            className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm text-slate-100"
+            value={format}
+            onChange={(event) => setFormat(event.target.value)}
+          >
+            {formats.map((item) => <option key={item.format} value={item.format}>{item.label}</option>)}
+          </select>
+        </label>
+      </div>
+      <button
+        className="focus-ring mt-4 rounded-xl border border-teal-300/30 px-4 py-2 text-sm font-semibold text-teal-100 hover:bg-teal-300/10 disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={disabled || !collection}
+        type="button"
+        onClick={() => onExport(collection, format)}
+      >
+        {isDownloading ? <Spinner label={`Downloading ${label}`} /> : 'Export selected'}
+      </button>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- Refactors `frontend/src/pages/VectorPage.tsx` into a bento-style dashboard layout.
- Adds reusable card components in `frontend/src/pages/vector-dashboard-cards.tsx` for collection health, stats, and quick export.
- Preserves existing vector collection fetch/health, export/download flow, search navigation, and index-management integration.

## Verification
- `bunx tsc --noEmit` (root)
- `bun test tests/frontend/pages/vector-dashboard-cards.test.tsx tests/frontend/pages/vector-dashboard-summary.test.ts tests/frontend/pages/vector-page-widget.test.tsx tests/frontend/pages/vector-page-export.test.tsx tests/frontend/pages/vector-dashboard-loading.test.tsx tests/frontend/pages/vector-search-page-controls.test.tsx`
- Screenshot posted to issue #1647 (comment: https://github.com/Soul-Brews-Studio/arra-oracle-v3/issues/1647#issuecomment-4714623035)
