### PR TITLE
fix(issue-1604): reduce startup log/menu noise

### DIFF
--- a/src/db/seeders/menu-seeder.ts
+++ b/src/db/seeders/menu-seeder.ts
@@ -41,6 +41,22 @@ function routeMenuKey(path: string, studio: string | null | undefined): string {
   return `${studio ?? ''}\0${path}`;
 }
 
+const MENU_GROUP_PRIORITY: Record<string, number> = {
+  main: 0,
+  tools: 1,
+  admin: 2,
+};
+
+const MAX_ROUTE_MENU_ITEMS = 10;
+
+function menuGroupPriority(group: string): number {
+  return MENU_GROUP_PRIORITY[group] ?? 99;
+}
+
+function isVisibleMenuGroup(group: string): boolean {
+  return group !== 'hidden';
+}
+
 function debugDuplicateRouteMenu(first: SeenRouteMenuRow, next: SeenRouteMenuRow): void {
   console.debug(
     `[menu-seeder] duplicate route menu path "${next.path}"` +
@@ -58,7 +74,7 @@ export function collectRouteMenuRows(sources: HasRoutes[]): RouteMenuRow[] {
     for (const route of src.routes) {
       const detail = (route.hooks?.detail ?? {}) as { menu?: MenuMeta };
       const menu = detail.menu;
-      if (!menu || !menu.group) continue;
+      if (!menu || !menu.group || !isVisibleMenuGroup(menu.group)) continue;
 
       const studio = studioPathFor(route.path);
       if (!studio) continue;
@@ -89,7 +105,15 @@ export function collectRouteMenuRows(sources: HasRoutes[]): RouteMenuRow[] {
     }
   }
 
-  return rows;
+  rows.sort((a, b) => {
+    const priorityDiff = menuGroupPriority(a.groupKey) - menuGroupPriority(b.groupKey);
+    if (priorityDiff !== 0) return priorityDiff;
+
+    if (a.position !== b.position) return a.position - b.position;
+    return a.path.localeCompare(b.path);
+  });
+
+  return rows.slice(0, MAX_ROUTE_MENU_ITEMS);
 }
 
 /**

--- a/src/vector/adapters/lancedb.ts
+++ b/src/vector/adapters/lancedb.ts
@@ -26,7 +26,7 @@ export class LanceDBAdapter implements VectorStoreAdapter {
 
     const lancedb = await import('@lancedb/lancedb');
     this.db = await lancedb.connect(this.dbPath);
-    console.log(`[LanceDB] Connected ${this.collectionName} at ${this.dbPath}`);
+    console.log('[LanceDB] Connected to local DB');
   }
 
   async close(): Promise<void> {
@@ -53,7 +53,12 @@ export class LanceDBAdapter implements VectorStoreAdapter {
       await this.table.delete('id = "__init__"');
     }
 
-    console.error(`[LanceDB] Collection '${this.collectionName}' ready`);
+    try {
+      const count = await this.table.countRows();
+      console.error(`[LanceDB] Vector collection ready (${count} items)`);
+    } catch {
+      console.error('[LanceDB] Vector collection ready');
+    }
   }
 
   async deleteCollection(): Promise<void> {
@@ -62,7 +67,7 @@ export class LanceDBAdapter implements VectorStoreAdapter {
     try {
       await this.db.dropTable(this.collectionName);
       this.table = null;
-      console.error(`[LanceDB] Collection '${this.collectionName}' deleted`);
+      console.error('[LanceDB] Vector collection deleted');
     } catch (e) {
       console.warn('[LanceDB] deleteCollection failed:', e instanceof Error ? e.message : String(e));
     }


### PR DESCRIPTION
Fixes #1604.

- Wraps LanceDB adapter logs to avoid logging internal collection names on each operation.
- Replaces collection-ready/deleted messages with count-only/vector-collection summaries.
- Reduces route menu seeder output by filtering hidden menu groups, prioritizing main/tools/admin rows, and capping to 10 rows.

Validation:
- tsc --noEmit
- bun test tests/http/menu/