### PR TITLE
feat: MCP tool detail bento layout (#27)

### DIFF
--- a/frontend/src/pages/McpToolDetailPage.tsx
+++ b/frontend/src/pages/McpToolDetailPage.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { fetchMcpTools } from '../api';
+import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
 import { groupLabel, schemaText, toolMode } from '../components/toolView';
 import type { McpTool } from '../types';
 
 type PageState = 'loading' | 'ready' | 'error';
 
-function DetailRow({ label, value }: { label: string; value?: string }) {
+function DetailCard({ label, value }: { label: string; value?: string }) {
   return (
     <div className="rounded-xl border border-white/10 bg-white/[0.03] p-3">
       <dt className="text-xs uppercase tracking-[0.18em] text-slate-500">{label}</dt>
@@ -15,27 +16,54 @@ function DetailRow({ label, value }: { label: string; value?: string }) {
   );
 }
 
-function ToolDetail({ tool }: { tool: McpTool }) {
+function ToolSummaryCard({ tool }: { tool: McpTool }) {
   return (
-    <div className="grid gap-5 xl:grid-cols-[0.8fr_1.2fr]">
-      <section className="rounded-2xl border border-white/10 bg-slate-950/60 p-5">
-        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-300">MCP tool</p>
-        <h2 className="mt-2 break-all font-mono text-2xl font-semibold text-white">{tool.name}</h2>
-        <p className="mt-4 text-sm leading-6 text-slate-300">{tool.description || 'No description supplied.'}</p>
-        <dl className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
-          <DetailRow label="Group" value={groupLabel(tool)} />
-          <DetailRow label="Mode" value={toolMode(tool)} />
-          <DetailRow label="Source" value={tool.source ?? 'core'} />
-          <DetailRow label="Plugin" value={tool.plugin} />
-        </dl>
-      </section>
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="tool-summary-title">
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">MCP tool</p>
+      <h2 id="tool-summary-title" className="mt-2 break-all text-2xl font-semibold text-white">{tool.name}</h2>
+      <p className="mt-4 text-sm leading-6 text-slate-300">{tool.description || 'No description supplied.'}</p>
+      <dl className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
+        <DetailCard label="Group" value={groupLabel(tool)} />
+        <DetailCard label="Mode" value={toolMode(tool)} />
+        <DetailCard label="Source" value={tool.source ?? 'core'} />
+        <DetailCard label="Plugin" value={tool.plugin} />
+      </dl>
+    </section>
+  );
+}
 
-      <section className="rounded-2xl border border-white/10 bg-slate-950/60 p-5">
-        <h3 className="text-lg font-semibold text-white">Input schema</h3>
-        <p className="mt-1 text-sm text-slate-500">JSON schema advertised by /api/mcp/tools.</p>
-        <pre className="mt-4 max-h-[36rem] overflow-auto rounded-xl bg-black/30 p-4 text-xs text-slate-300">{schemaText(tool)}</pre>
-      </section>
-    </div>
+function ToolSchemaCard({ tool }: { tool: McpTool }) {
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="tool-schema-title">
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Schema</p>
+      <h2 id="tool-schema-title" className="mt-2 text-2xl font-semibold text-white">Input schema</h2>
+      <p className="mt-2 text-sm text-slate-400">JSON schema advertised by /api/mcp/tools.</p>
+      <pre className="mt-4 max-h-[36rem] overflow-auto rounded-xl bg-black/30 p-4 text-xs text-slate-300">{schemaText(tool)}</pre>
+    </section>
+  );
+}
+
+function StatusCard({ status, message, onRetry }: { status: 'ready' | 'loading' | 'error'; message?: string; onRetry?: () => void }) {
+  if (status === 'loading') return <LoadingPanel title="Loading tool detail…" detail="Fetching /api/mcp/tools and matching by name." />;
+  if (status === 'error') {
+    return <ErrorMessage title="Could not load MCP tool details." message={message ?? 'Request failed.'} />;
+  }
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-label="Tool not found">
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Tool lookup</p>
+      <h2 className="mt-2 text-2xl font-semibold text-white">No tool found</h2>
+      <p className="mt-2 text-sm text-slate-400">{message || 'No MCP tool matched this route parameter.'}</p>
+      {onRetry ? (
+        <button
+          className="mt-4 inline-flex rounded-xl border border-white/10 px-3 py-2 text-sm text-slate-200 transition hover:border-teal-300/40"
+          type="button"
+          onClick={onRetry}
+        >
+          Retry
+        </button>
+      ) : null}
+    </section>
   );
 }
 
@@ -75,22 +103,36 @@ export function McpToolDetailPage() {
   }, [toolName]);
 
   const tool = useMemo(() => tools.find((entry) => entry.name === toolName), [toolName, tools]);
+  const refresh = () => {
+    fetchMcpTools()
+      .then((response) => setTools(response.tools))
+      .catch(() => undefined);
+  };
 
   return (
-    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="tool-detail-title">
-      <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-300">Detail viewer</p>
-          <h1 id="tool-detail-title" className="mt-2 text-3xl font-semibold text-white">MCP tool detail</h1>
+    <div className="grid gap-5">
+      <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="tool-detail-title">
+        <div className="mb-4 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Detail viewer</p>
+            <h1 id="tool-detail-title" className="mt-2 text-3xl font-semibold text-white">MCP tool detail</h1>
+            <p className="mt-2 text-sm text-slate-400">Inspect MCP tool metadata and input schema.</p>
+          </div>
+          <Link className="focus-ring rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-teal-300/40" to="/mcp">
+            Back to MCP tools
+          </Link>
         </div>
-        <Link className="focus-ring rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-teal-300/40" to="/mcp">
-          Back to MCP tools
-        </Link>
-      </div>
-      {state === 'loading' ? <p role="status" className="rounded-xl border border-dashed border-white/10 p-6 text-sm text-slate-400">Loading tool detail…</p> : null}
-      {state === 'error' ? <p role="alert" className="rounded-xl border border-red-400/30 bg-red-950/40 p-3 text-sm text-red-100">{error}</p> : null}
-      {state === 'ready' && tool ? <ToolDetail tool={tool} /> : null}
-      {state === 'ready' && !tool ? <p className="rounded-xl border border-dashed border-white/10 p-6 text-sm text-slate-400">No MCP tool named {toolName}.</p> : null}
-    </section>
+      </section>
+
+      {state === 'error' ? <StatusCard status={state} message={error} onRetry={refresh} /> : null}
+      {state === 'loading' ? <StatusCard status="loading" /> : null}
+      {state === 'ready' && !tool ? <StatusCard status="ready" message={`No MCP tool named "${toolName}".`} /> : null}
+      {state === 'ready' && tool ? (
+        <div className="grid gap-5 xl:grid-cols-[0.8fr_1.2fr]">
+          <ToolSummaryCard tool={tool} />
+          <ToolSchemaCard tool={tool} />
+        </div>
+      ) : null}
+    </div>
   );
 }


### PR DESCRIPTION
Closes part of #27 — McpToolDetailPage redesigned to bento card grid and preserves existing MCP behavior