### PR TITLE
Issue #1423 — Add learn directory auto-index watcher

### DIFF
--- a/src/indexer/__tests__/learn-watcher.test.ts
+++ b/src/indexer/__tests__/learn-watcher.test.ts
@@ -1,0 +1,115 @@
+/**
+ * M6 auto-index watcher tests — queue jobs when learn files change.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import Database from 'bun:sqlite';
+import { startLearnWatcher } from '../learn-watcher.ts';
+
+const FULL_SCHEMA = `
+CREATE TABLE oracle_documents (
+  id TEXT PRIMARY KEY,
+  type TEXT NOT NULL,
+  source_file TEXT NOT NULL,
+  concepts TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  indexed_at INTEGER NOT NULL,
+  superseded_by TEXT,
+  superseded_at INTEGER,
+  superseded_reason TEXT,
+  origin TEXT,
+  project TEXT,
+  created_by TEXT
+);
+CREATE TABLE indexing_jobs (
+  id TEXT PRIMARY KEY,
+  doc_id TEXT NOT NULL,
+  model_key TEXT NOT NULL,
+  collection TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  attempts INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')*1000),
+  claimed_at INTEGER,
+  finished_at INTEGER,
+  error TEXT
+);
+`;
+
+const MODELS = {
+  'bge-m3': { collection: 'oracle_knowledge_bge_m3' },
+  qwen3: { collection: 'oracle_knowledge_qwen3' },
+};
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('startLearnWatcher', () => {
+  let repoRoot: string;
+  let db: Database;
+
+  beforeEach(() => {
+    repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'learn-watcher-'));
+    db = new Database(':memory:');
+    db.exec(FULL_SCHEMA);
+  });
+
+  afterEach(() => {
+    try { db.close(); } catch {}
+    try { fs.rmSync(repoRoot, { recursive: true, force: true }); } catch {}
+  });
+
+  it('enqueues jobs when an existing learn markdown file is changed', async () => {
+    const learnDir = path.join(repoRoot, 'ψ', 'memory', 'learnings');
+    const filePath = path.join(learnDir, 'note.md');
+    const sourceFile = path.join('ψ', 'memory', 'learnings', 'note.md').split(path.sep).join('/');
+
+    fs.mkdirSync(learnDir, { recursive: true });
+    fs.writeFileSync(filePath, 'initial');
+
+    db.exec(
+      `INSERT INTO oracle_documents (id, type, source_file, concepts, created_at, updated_at, indexed_at, created_by)
+       VALUES ('learning-note', 'learning', '${sourceFile}', '[]', 0, 0, 0, 'manual')`,
+    );
+
+    const stop = startLearnWatcher({
+      db,
+      models: MODELS,
+      repoRoot,
+      debounceMs: 20,
+    });
+
+    fs.writeFileSync(filePath, 'updated', 'utf8');
+    await wait(300);
+
+    const rows = db.query<{ count: number }, []>('SELECT COUNT(*) AS count FROM indexing_jobs').get() as { count: number };
+    expect(rows.count).toBe(Object.keys(MODELS).length);
+
+    const jobs = db.query<{ model_key: string }>('SELECT model_key FROM indexing_jobs ORDER BY model_key').all() as { model_key: string }[];
+    expect(jobs).toHaveLength(Object.keys(MODELS).length);
+    expect(jobs.map((r) => r.model_key).sort()).toEqual(Object.keys(MODELS).sort());
+
+    stop();
+  });
+
+  it('does nothing for non-markdown files', async () => {
+    const learnDir = path.join(repoRoot, 'ψ', 'memory', 'learnings');
+    const filePath = path.join(learnDir, 'note.txt');
+    fs.mkdirSync(learnDir, { recursive: true });
+    fs.writeFileSync(filePath, 'tmp', 'utf8');
+
+    const stop = startLearnWatcher({ db, models: MODELS, repoRoot, debounceMs: 20 });
+
+    fs.writeFileSync(filePath, 'changed', 'utf8');
+    await wait(300);
+
+    const rows = db.query<{ count: number }, []>('SELECT COUNT(*) AS count FROM indexing_jobs').get() as { count: number };
+    expect(rows.count).toBe(0);
+
+    stop();
+  });
+});

--- a/src/indexer/daemon.ts
+++ b/src/indexer/daemon.ts
@@ -15,10 +15,11 @@
 
 import Database from 'bun:sqlite';
 import { Elysia } from 'elysia';
-import { DB_PATH } from '../config.ts';
+import { DB_PATH, REPO_ROOT } from '../config.ts';
 import { createVectorStoreForModel, getEmbeddingModels } from '../vector/factory.ts';
 import { runWorker, type WorkerEvent } from './worker.ts';
 import { daemonApiPlugin, makeEventBus } from '../routes/indexer-daemon/index.ts';
+import { startLearnWatcher, type StopWatch } from './learn-watcher.ts';
 
 const PORT = parseInt(process.env.INDEXER_PORT || '47779', 10);
 const HOST = process.env.INDEXER_HOST || '127.0.0.1';
@@ -31,6 +32,7 @@ export async function startDaemon(): Promise<void> {
   const models = getEmbeddingModels();
   const eventBus = makeEventBus<WorkerEvent>();
   let shuttingDown = false;
+  let stopLearnWatcher: StopWatch | undefined;
 
   // Resolve doc text via the FTS5 mirror table — same content oracle_learn writes.
   const getDocText = (docId: string): string | null => {
@@ -112,9 +114,17 @@ export async function startDaemon(): Promise<void> {
   console.log(`[arra-indexer] listening on http://${HOST}:${PORT}`);
   console.log(`[arra-indexer] models: ${Object.keys(models).join(', ')}`);
 
+  stopLearnWatcher = startLearnWatcher({
+    db,
+    models,
+    repoRoot: REPO_ROOT,
+  });
+
   const shutdown = async (signal: string) => {
     console.log(`[arra-indexer] ${signal} — draining…`);
     shuttingDown = true;
+    stopLearnWatcher?.();
+    stopLearnWatcher = undefined;
     await app.stop();
     // Workers exit on next loop tick. Give them up to 5s of in-flight grace.
     const timeout = new Promise((resolve) => setTimeout(resolve, 5000));

--- a/src/indexer/learn-watcher.ts
+++ b/src/indexer/learn-watcher.ts
@@ -1,0 +1,160 @@
+/**
+ * Auto queue learn documents when files change under ψ/memory/learnings.
+ *
+ * The watcher maps changed Markdown files to existing `oracle_documents`
+ * rows by `source_file` and enqueues one queue job per registered model.
+ *
+ * This keeps vector indexing incremental and avoids expensive full reindex runs
+ * when a single learning file is edited.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import type Database from 'bun:sqlite';
+import { enqueueIndexJob } from './jobs.ts';
+import { REPO_ROOT } from '../config.ts';
+
+export interface LearnWatcherOptions {
+  /** sqlite database used by enqueueIndexJob(). */
+  db: Database;
+  /** Model registry from vector/factory.getEmbeddingModels(). */
+  models: Record<string, { collection: string }>;
+  /** Repo root that owns ψ/memory/learnings. Defaults to REPO_ROOT. */
+  repoRoot?: string;
+  /** Debounce window in ms to collapse bursty editor saves. */
+  debounceMs?: number;
+}
+
+export type StopWatch = () => void;
+
+const DEFAULT_DEBOUNCE_MS = 250;
+const LEARN_DIR_REL = path.join('\u03c8', 'memory', 'learnings');
+
+function normalizeSourceFile(repoRoot: string, filePath: string): string {
+  return path.relative(repoRoot, filePath).split(path.sep).join('/');
+}
+
+function isMarkdownFile(filePath: string): boolean {
+  const lower = filePath.toLowerCase();
+  return lower.endsWith('.md') || lower.endsWith('.markdown');
+}
+
+function safeClose(watchers: Array<{ close: () => void }>): void {
+  for (const watcher of watchers) {
+    try {
+      watcher.close();
+    } catch {
+      // Intentionally best-effort.
+    }
+  }
+}
+
+function safeClearTimeout(id: ReturnType<typeof setTimeout> | undefined): void {
+  if (id !== undefined) {
+    clearTimeout(id);
+  }
+}
+
+function enqueueBySourceFile(db: Database, models: Record<string, { collection: string }>, sourceFile: string): number {
+  const rows = db
+    .query<{ id: string }, [string]>(
+      `SELECT id
+       FROM oracle_documents
+       WHERE source_file = ? AND type = 'learning' AND superseded_at IS NULL`,
+    )
+    .all(sourceFile);
+
+  for (const row of rows) {
+    try {
+      enqueueIndexJob(db, { docId: row.id, models });
+    } catch {
+      // Never throw while watching files — indexing is eventually consistent.
+      continue;
+    }
+  }
+  return rows.length;
+}
+
+function isWithinRoot(root: string, candidate: string): boolean {
+  const rel = path.relative(root, candidate);
+  return rel === '' || (rel !== '..' && !rel.startsWith(`..${path.sep}`) && !path.isAbsolute(rel));
+}
+
+/**
+ * Start a file watcher for learn-source Markdown files.
+ *
+ * Returns a stop function that closes all fs watchers and clears pending timers.
+ */
+export function startLearnWatcher({
+  db,
+  models,
+  repoRoot = REPO_ROOT,
+  debounceMs = DEFAULT_DEBOUNCE_MS,
+}: LearnWatcherOptions): StopWatch {
+  const root = path.resolve(repoRoot);
+  const learnDir = path.join(root, LEARN_DIR_REL);
+
+  if (!fs.existsSync(learnDir)) {
+    return () => {};
+  }
+
+  const watchers: Array<fs.FSWatcher> = [];
+  const pending = new Map<string, ReturnType<typeof setTimeout>>();
+  const timerFor = (filePath: string, fn: () => void) => {
+    const existing = pending.get(filePath);
+    safeClearTimeout(existing);
+
+    const timer = setTimeout(() => {
+      pending.delete(filePath);
+      fn();
+    }, debounceMs);
+    pending.set(filePath, timer);
+  };
+
+  const enqueueFromPath = (eventPath: string) => {
+    const fullPath = path.resolve(eventPath);
+    if (!isWithinRoot(learnDir, fullPath)) return;
+    if (!fs.existsSync(fullPath) || !isMarkdownFile(fullPath)) return;
+
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(fullPath);
+    } catch {
+      return;
+    }
+    if (!stat.isFile()) return;
+
+    const sourceFile = normalizeSourceFile(root, fullPath);
+    if (sourceFile.endsWith('/')) return;
+
+    const count = enqueueBySourceFile(db, models, sourceFile);
+    if (count === 0) {
+      console.log(`[learn-watch] no oracle_documents rows for ${sourceFile}`);
+    }
+  };
+
+  const onFileEvent = (_event: string, filename: string | null): void => {
+    if (!filename) return;
+    const candidate = path.join(learnDir, filename);
+    timerFor(candidate, () => {
+      enqueueFromPath(candidate);
+    });
+  };
+
+  try {
+    const watcher = fs.watch(learnDir, { persistent: false, recursive: true }, onFileEvent);
+    watchers.push(watcher);
+  } catch {
+    // `recursive` may fail on some Bun/platform combos; fallback to shallow watch.
+    const watcher = fs.watch(learnDir, { persistent: false }, onFileEvent);
+    watchers.push(watcher);
+  }
+
+  return () => {
+    for (const [p, timer] of pending) {
+      safeClearTimeout(timer);
+      pending.delete(p);
+    }
+    safeClose(watchers);
+  };
+}


### PR DESCRIPTION
## Summary\n- Add learn watcher module `src/indexer/learn-watcher.ts` to watch `ψ/memory/learnings` markdown changes and enqueue existing `learning` docs into `indexing_jobs` for all registered models.\n- Start watcher in `startDaemon` and stop it during shutdown.\n- Add tests `src/indexer/__tests__/learn-watcher.test.ts` for markdown-change enqueue and non-markdown ignore behavior.\n\n## Validation\n- `bunx tsc --noEmit`\n- `bun test src/indexer/__tests__/learn-watcher.test.ts"