### PR TITLE
fix: harden /api/v1/health DB connectivity status (#1597)

### DIFF
--- a/src/routes/health/health.ts
+++ b/src/routes/health/health.ts
@@ -1,7 +1,7 @@
 import { Elysia } from 'elysia';
 import { DB_PATH, PORT } from '../../config.ts';
 import { MCP_SERVER_NAME } from '../../const.ts';
-import { db, sqlite, settings } from '../../db/index.ts';
+import { sqlite } from '../../db/index.ts';
 import { scanPlugins } from '../plugins/model.ts';
 import { handleVectorHealth } from '../../server/vector-handlers.ts';
 import { mcpTools } from '../../tools/mcp-manifest.ts';
@@ -10,6 +10,7 @@ import pkg from '../../../package.json' with { type: 'json' };
 
 type VectorHealth = Awaited<ReturnType<typeof handleVectorHealth>>;
 type DbStatus = { status: 'connected' } | { status: 'error'; error: string };
+type DbPing = () => DbStatus | Promise<DbStatus>;
 
 export interface HealthEndpointOptions {
   pluginCount?: number;
@@ -18,15 +19,23 @@ export interface HealthEndpointOptions {
   uptimeSeconds?: () => number;
   vectorHealth?: () => Promise<VectorHealth>;
   pluginStatuses?: () => UnifiedPluginStatus[] | Promise<UnifiedPluginStatus[]>;
+  dbPing?: DbPing;
 }
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function readDbStatus(): DbStatus {
+async function readDbStatus(ping: DbPing = defaultDbPing): Promise<DbStatus> {
   try {
-    db.select({ key: settings.key }).from(settings).limit(1).all();
+    return await ping();
+  } catch (error) {
+    return { status: 'error', error: errorMessage(error) };
+  }
+}
+
+async function defaultDbPing(): Promise<DbStatus> {
+  try {
     sqlite.prepare('SELECT 1 as ok').get();
     return { status: 'connected' };
   } catch (error) {
@@ -67,16 +76,16 @@ export function createHealthEndpoint(options: HealthEndpointOptions = {}) {
       };
     }
 
-  const uptimeSeconds = Number(options.uptimeSeconds?.() ?? process.uptime());
-  const dbStatus = readDbStatus();
-  const vector = await readVectorStatus(options.vectorHealth);
-  const pluginItems = await options.pluginStatuses?.() ?? [];
+    const uptimeSeconds = Number(options.uptimeSeconds?.() ?? process.uptime());
+    const dbStatus = await readDbStatus(options.dbPing);
+    const vector = await readVectorStatus(options.vectorHealth);
+    const pluginItems = await options.pluginStatuses?.() ?? [];
     const pluginCount = options.pluginCount ?? (pluginItems.length || installedPluginCount());
     const pluginStatus = pluginItems.some((plugin) => plugin.status === 'degraded') ? 'degraded' : 'ok';
     const toolCount = mcpTools.length + (options.pluginMcpToolCount ?? 0);
 
-  const serviceUptime = Math.round(uptimeSeconds * 1000) / 1000;
-  return {
+    const serviceUptime = Math.round(uptimeSeconds * 1000) / 1000;
+    return {
       status: dbStatus.status === 'connected' ? 'ok' : 'degraded',
       server: MCP_SERVER_NAME,
       version: pkg.version,

--- a/tests/http/health/status.test.ts
+++ b/tests/http/health/status.test.ts
@@ -31,4 +31,22 @@ test('GET /api/health reports uptime, DB, vector, MCP, and plugin status', async
   expect(body.mcp.toolCount).toBe(mcpTools.length + 2);
   expect(body.pluginCount).toBe(5);
   expect(body.plugins.count).toBe(5);
+  expect(body.db).toBe('connected');
+  expect(body.version).toBeTypeOf('string');
+  expect(typeof body.uptime).toBe('number');
+});
+
+test('GET /api/health reflects database ping result in status and db field', async () => {
+  const app = createHealthRoutes({
+    uptimeSeconds: () => 12.25,
+    dbPing: () => ({ status: 'error', error: 'db offline' }),
+    vectorHealth: async () => ({ status: 'ok', engines: [], checked_at: '2026-06-16T00:00:00.000Z' }),
+  });
+  const res = await app.handle(new Request('http://local/api/health'));
+  const body = await res.json() as Record<string, any>;
+
+  expect(res.status).toBe(200);
+  expect(body.status).toBe('degraded');
+  expect(body.db).toBe('error');
+  expect(body.dbCheck).toMatchObject({ status: 'error', error: 'db offline' });
 });


### PR DESCRIPTION
Closes #1597\n\nSupersedes #1673 with a clean branch rebased on current alpha.\n\n## Changes\n- Add pluggable DB ping check in health endpoint options.\n- Rewrite health DB probe to use SQLite ping rather than table query, so connectivity is checked directly.\n- Include stable response fields for hardening: `status`, `uptime`, `version`, and `db`.\n- Add tests for injected DB ping success/failure cases.\n\n## Validation\n- bunx tsc --noEmit\n- bun test tests/http/health/status.test.ts tests/http/health/unversioned.test.ts tests/http/health/draining.test.ts tests/http/health/vector-failure.test.ts tests/http/health/plugin-status.test.ts