### PR TITLE
feat: expose ARRA maw plugin over CLI and HTTP (#1467)

### DIFF
--- a/maw-plugin/__tests__/api.test.ts
+++ b/maw-plugin/__tests__/api.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test';
+import handler from '../index.ts';
+import { apiArgsToCliArgs } from '../api.ts';
+
+describe('maw arra API surface', () => {
+  test('manifest API query args map to CLI argv', () => {
+    expect(apiArgsToCliArgs({ command: 'search', query: 'hello world', limit: '3' })).toEqual([
+      'search',
+      '--query',
+      'hello world',
+      '--limit',
+      '3',
+    ]);
+    expect(apiArgsToCliArgs({ subcommand: 'vector-config', args: ['set', 'bge-m3', 'adapter', 'qdrant'] })).toEqual([
+      'vector-config',
+      'set',
+      'bge-m3',
+      'adapter',
+      'qdrant',
+    ]);
+  });
+
+  test('default handler accepts maw-js API object args', async () => {
+    const oldFetch = globalThis.fetch;
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    globalThis.fetch = (async (url: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ url: String(url), init });
+      return new Response(JSON.stringify({ status: 'ok', version: 'test' }), { status: 200 });
+    }) as typeof fetch;
+    try {
+      const result = await handler({ source: 'api', args: { command: 'health' } });
+      expect(result.ok).toBe(true);
+      expect(result.output).toContain('arra health: ok');
+      expect(calls[0]).toMatchObject({ url: 'http://localhost:47778/api/health' });
+      expect(calls[0]?.init?.method).toBe('GET');
+    } finally {
+      globalThis.fetch = oldFetch;
+    }
+  });
+});

--- a/maw-plugin/api.ts
+++ b/maw-plugin/api.ts
@@ -1,0 +1,43 @@
+type ApiArgs = Record<string, unknown>;
+
+const COMMAND_KEYS = new Set(['command', 'subcommand', 'action', 'cmd', 'tool']);
+const ARRAY_KEYS = new Set(['args', 'argv']);
+
+function commandFrom(input: ApiArgs): string | undefined {
+  for (const key of COMMAND_KEYS) {
+    const value = input[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+}
+
+function appendFlag(argv: string[], key: string, value: unknown): void {
+  if (value === undefined || value === null || value === '') return;
+  const flag = `--${key.replace(/_/g, '-')}`;
+  if (Array.isArray(value)) {
+    if (value.length) argv.push(flag, value.map(String).join(','));
+    return;
+  }
+  argv.push(flag, String(value));
+}
+
+function appendPositionals(argv: string[], value: unknown): void {
+  if (Array.isArray(value)) argv.push(...value.map(String));
+  else if (typeof value === 'string' && value.trim()) argv.push(...value.trim().split(/\s+/));
+}
+
+export function apiArgsToCliArgs(args: string[] | ApiArgs | undefined): string[] {
+  if (Array.isArray(args)) return args;
+  if (!args || typeof args !== 'object') return [];
+  const command = commandFrom(args);
+  const argv = command ? [command] : [];
+  appendPositionals(argv, args.argv ?? args.args);
+
+  const flags = args.flags && typeof args.flags === 'object' && !Array.isArray(args.flags)
+    ? args.flags as ApiArgs
+    : undefined;
+  for (const [key, value] of Object.entries(flags ?? args)) {
+    if (COMMAND_KEYS.has(key) || ARRAY_KEYS.has(key) || key === 'flags') continue;
+    appendFlag(argv, key, value);
+  }
+  return argv;
+}

--- a/maw-plugin/index.ts
+++ b/maw-plugin/index.ts
@@ -1,8 +1,9 @@
 import { spawn } from 'node:child_process';
 import { join } from 'node:path';
+import { apiArgsToCliArgs } from './api.ts';
 import { runServe, type ServeDeps } from './serve.ts';
 
-type InvokeContext = { source?: string; args?: string[]; writer?: (...args: unknown[]) => void };
+type InvokeContext = { source?: string; args?: string[] | Record<string, unknown>; writer?: (...args: unknown[]) => void };
 type InvokeResult = { ok: boolean; output?: string; error?: string };
 type Requester = (path: string, init?: RequestInit) => Promise<unknown>;
 type Opener = (url: string) => void;
@@ -30,7 +31,6 @@ export function resolveFrontendUrl(env: Record<string, string | undefined> = pro
 export function buildFrontendUrl(env: Record<string, string | undefined> = process.env): string {
   return `${resolveFrontendUrl(env)}/?api=${resolveBaseUrl(env)}`;
 }
-
 
 function runCommand(cmd: string, args: string[], options: RunOptions = {}): Promise<RunResult> {
   return new Promise((resolve, reject) => {
@@ -247,4 +247,4 @@ export async function runArra(args: string[], request: Requester = requestJson, 
   } catch (error) { return { ok: false, error: error instanceof Error ? error.message : String(error) }; }
 }
 
-export default async function handler(ctx: InvokeContext): Promise<InvokeResult> { return runArra(ctx.args ?? []); }
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> { return runArra(apiArgsToCliArgs(ctx.args)); }

--- a/maw-plugin/plugin.json
+++ b/maw-plugin/plugin.json
@@ -16,5 +16,12 @@
   ],
   "weight": 50,
   "schemaVersion": 1,
-  "help": "maw arra <frontend|ui|open|serve|studio|search|learn|stats|health|index|scan|plugins|settings|feed|menu|vector|vector-config|vector_index|vector_status|vector_stop|vector_models|trace|trace_list|trace_get|trace_link|trace_unlink|trace_chain|concepts|handoff|inbox|list|read|reflect|supersede|thread|thread_read|thread_update|threads|verify>"
+  "help": "maw arra <frontend|ui|open|serve|studio|search|learn|stats|health|index|scan|plugins|settings|feed|menu|vector|vector-config|vector_index|vector_status|vector_stop|vector_models|trace|trace_list|trace_get|trace_link|trace_unlink|trace_chain|concepts|handoff|inbox|list|read|reflect|supersede|thread|thread_read|thread_update|threads|verify>",
+  "api": {
+    "path": "/api/arra",
+    "methods": [
+      "GET",
+      "POST"
+    ]
+  }
 }


### PR DESCRIPTION
Closes #1467

## Changes
- Declared the ARRA maw plugin HTTP API surface via manifest `api { path: /api/arra, methods: [GET, POST] }`.
- Added API object-argument normalization so maw-js API/menu invocations reuse the existing `runArra` CLI command registry.
- Added regression coverage for API object args and default handler dispatch.

## Verification
- bun test maw-plugin/__tests__/api.test.ts maw-plugin/__tests__/index.test.ts maw-plugin/__tests__/vector-config.test.ts
- bunx tsc --noEmit (run locally before push)
