### PR TITLE
feat: add vector backend config controls

### DIFF
--- a/cli/src/commands/catalog.ts
+++ b/cli/src/commands/catalog.ts
@@ -18,7 +18,7 @@ export const BUILTIN_COMMANDS: CommandSpec[] = [
   { command: "completions", help: "print shell completion scripts", subcommands: ["bash", "zsh", "fish"], flags: ["--help", "-h"] },
   { command: "peers", help: "probe configured federation peers", flags: ["--token", "--json", "--help", "-h"] },
   { command: "huginn", help: "run Huginn capture utilities", subcommands: ["sweep"], flags: ["--sessions-dir", "--repo-root", "--lookback-hours", "--max-files", "--json", "--help", "-h"] },
-  { command: "vector-config", help: "inspect and manage vector embedding collection config", subcommands: ["list", "get", "stats", "set", "reload", "test"], flags: ["--json", "--yml", "--help", "-h", "--model", "--provider", "--adapter"] },
+  { command: "vector-config", help: "inspect and manage vector embedding collection config", subcommands: ["list", "get", "stats", "set", "reload", "test"], flags: ["--json", "--yml", "--help", "-h", "--model", "--provider", "--adapter", "--enabled"] },
   { command: "migrate", help: "run Drizzle migration generate and push", flags: ["--help", "-h"] },
   { command: "seed", help: "populate development DB sample data", flags: ["--help", "-h"] },
   { command: "backup", help: "dump SQLite DB to timestamped SQL", flags: ["--out-dir", "--help", "-h"] },

--- a/cli/src/commands/vector-config.ts
+++ b/cli/src/commands/vector-config.ts
@@ -8,6 +8,7 @@ type CollectionEntry = {
   model: string;
   provider: string;
   adapter?: string;
+  enabled?: boolean;
   primary?: boolean;
 };
 
@@ -22,10 +23,11 @@ type UpdatePayload = {
   adapter?: string;
   model?: string;
   provider?: string;
+  enabled?: boolean;
 };
 
 const HELP = `arra-cli vector-config <subcommand>\n
-Subcommands:\n  list                                      list known vector collections\n  get <collection-key-or-name>              show embedding config for one collection\n  stats [<collection-key-or-name>]          show doc count for all or one collection\n  set <collection-key-or-name> <field> <value> set collection config (model|provider|adapter)\n  set <collection-key-or-name> [--model <name>] [--provider <name>] [--adapter <name>] set with flags\n  reload                                    reload server vector config cache\n  test <collection-key-or-name>             probe adapter for one collection\n\nExamples:\n  arra-cli vector-config list\n  arra-cli vector-config get bge-m3\n  arra-cli vector-config stats bge-m3\n  arra-cli vector-config set bge-m3 model qwen3-embedding\n  arra-cli vector-config set bge-m3 --adapter qdrant --provider remote\n  arra-cli vector-config reload\n\nOutput format: default JSON; pass --json or --yml for explicit format.`;
+Subcommands:\n  list                                      list known vector collections\n  get <collection-key-or-name>              show embedding config for one collection\n  stats [<collection-key-or-name>]          show doc count for all or one collection\n  set <collection-key-or-name> <field> <value> set collection config (model|provider|adapter|enabled)\n  set <collection-key-or-name> [--model <name>] [--provider <name>] [--adapter <name>] [--enabled <true|false>]\n  reload                                    reload server vector config cache\n  test <collection-key-or-name>             probe adapter for one collection\n\nExamples:\n  arra-cli vector-config list\n  arra-cli vector-config get bge-m3\n  arra-cli vector-config stats bge-m3\n  arra-cli vector-config set bge-m3 model qwen3-embedding\n  arra-cli vector-config set bge-m3 enabled false\n  arra-cli vector-config set bge-m3 --adapter qdrant --provider remote\n  arra-cli vector-config reload\n\nOutput format: default JSON; pass --json or --yml for explicit format.`;
 
 function usage(message: string): never {
   throw new Error(message);
@@ -39,6 +41,12 @@ function requireCollection(args: string[], command: string): string {
   const collection = args[0];
   if (!collection || collection.startsWith("-")) usage(`usage: arra-cli vector-config ${command} <collection-key-or-name>`);
   return collection as string;
+}
+
+function parseBoolean(value: string | undefined): boolean {
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  usage('enabled must be true or false');
 }
 
 function parseSetPayload(args: string[]): UpdatePayload {
@@ -64,6 +72,10 @@ function parseSetPayload(args: string[]): UpdatePayload {
       payload.adapter = value;
       continue;
     }
+    if (arg === "--enabled") {
+      payload.enabled = parseBoolean(args[++i]);
+      continue;
+    }
     if (arg.startsWith("--")) usage(`unknown option: ${arg}`);
 
     const key = arg.toLowerCase();
@@ -72,10 +84,11 @@ function parseSetPayload(args: string[]): UpdatePayload {
     if (key === "model") payload.model = value;
     else if (key === "provider") payload.provider = value;
     else if (key === "adapter") payload.adapter = value;
+    else if (key === "enabled") payload.enabled = parseBoolean(value);
     else usage(`unknown field: ${arg}`);
     i++;
   }
-  if (!payload.model && !payload.provider && !payload.adapter) usage("usage: arra-cli vector-config set ... (model|provider|adapter)");
+  if (!payload.model && !payload.provider && !payload.adapter && payload.enabled === undefined) usage("usage: arra-cli vector-config set ... (model|provider|adapter|enabled)");
   return payload;
 }
 
@@ -97,6 +110,7 @@ function emitList(payload: VectorPayload, args: string[]) {
     model: item.model,
     provider: item.provider,
     adapter: item.adapter,
+    enabled: item.enabled !== false,
     primary: item.primary,
     source: payload.source,
   }));
@@ -112,6 +126,7 @@ function emitStats(payload: VectorPayload, requested: string | undefined, args: 
       collection: item.collection,
       model: item.model,
       adapter: item.adapter,
+      enabled: item.enabled !== false,
       docs,
       status: health?.status ?? (health?.ok === false ? "down" : "unknown"),
       provider: item.provider,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,5 +1,5 @@
 import { apiUrl } from './api/oracle';
-import type { McpToolsResponse, MenuResponse, PluginsResponse, SearchResponse, SettingsSystemResponse } from './types';
+import type { McpToolsResponse, MenuResponse, PluginsResponse, SearchResponse, SettingsSystemResponse, VectorConfigResponse, VectorConfigUpdateResponse } from './types';
 
 export { API_BASE, apiUrl, isTauri } from './api/oracle';
 
@@ -71,4 +71,19 @@ export async function fetchMcpTools(): Promise<McpToolsResponse> {
 
 export async function fetchSettingsSystem(): Promise<SettingsSystemResponse> {
   return getJson<SettingsSystemResponse>('/api/settings/system');
+}
+
+export async function fetchVectorConfig(): Promise<VectorConfigResponse> {
+  return getJson<VectorConfigResponse>('/api/v1/vector/config');
+}
+
+export async function updateVectorCollection(collection: string, patch: { adapter?: string; enabled?: boolean }): Promise<VectorConfigUpdateResponse> {
+  return getJson<VectorConfigUpdateResponse>(`/api/v1/vector/config/${encodeURIComponent(collection)}`, {
+    method: 'PUT',
+    body: JSON.stringify(patch),
+  });
+}
+
+export async function reloadVectorConfig(): Promise<VectorConfigUpdateResponse> {
+  return getJson<VectorConfigUpdateResponse>('/api/v1/vector/config/reload', { method: 'POST' });
 }

--- a/frontend/src/components/VectorConfigPanel.tsx
+++ b/frontend/src/components/VectorConfigPanel.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useState } from 'react';
+import { fetchVectorConfig, reloadVectorConfig, updateVectorCollection } from '../api';
+import { ErrorMessage, Spinner } from './AsyncState';
+import type { VectorConfigResponse } from '../types';
+
+const ADAPTERS = ['lancedb', 'qdrant', 'chroma', 'sqlite-vec'] as const;
+
+type SaveState = Record<string, 'idle' | 'saving'>;
+
+function statusClass(status: string) {
+  if (status === 'ok') return 'border-emerald-400/30 text-emerald-200';
+  if (status === 'disabled') return 'border-slate-600 text-slate-400';
+  return 'border-rose-400/30 text-rose-200';
+}
+
+export function VectorConfigPanel() {
+  const [state, setState] = useState<VectorConfigResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [saving, setSaving] = useState<SaveState>({});
+
+  async function load() {
+    setError('');
+    setLoading(true);
+    try {
+      setState(await fetchVectorConfig());
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { void load(); }, []);
+
+  async function patchCollection(key: string, patch: { adapter?: string; enabled?: boolean }) {
+    setSaving((current) => ({ ...current, [key]: 'saving' }));
+    setError('');
+    try {
+      await updateVectorCollection(key, patch);
+      await load();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setSaving((current) => ({ ...current, [key]: 'idle' }));
+    }
+  }
+
+  async function reload() {
+    setError('');
+    setLoading(true);
+    try {
+      await reloadVectorConfig();
+      await load();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+      setLoading(false);
+    }
+  }
+
+  const rows = state ? Object.entries(state.config.collections) : [];
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-label="Vector backend config">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-teal-300">Vector config</p>
+          <h3 className="mt-2 text-lg font-semibold text-white">Backend state</h3>
+          <p className="mt-2 text-sm text-slate-400">Switch adapters, enable collections, and reload cached vector stores.</p>
+        </div>
+        <button className="focus-ring rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-teal-300/40" type="button" onClick={reload}>
+          {loading ? <Spinner label="Reloading" /> : 'Reload vector config'}
+        </button>
+      </div>
+
+      {error ? <div className="mt-4"><ErrorMessage title="Vector config update failed." message={error} /></div> : null}
+
+      <div className="mt-5 grid gap-3">
+        {rows.map(([key, item]) => {
+          const health = state?.health[key];
+          const enabled = item.enabled !== false;
+          const status = health?.status ?? (enabled ? 'unknown' : 'disabled');
+          return (
+            <article key={key} className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                <div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="font-mono text-sm text-teal-200">{key}</p>
+                    <span className={`rounded-full border px-2 py-0.5 text-xs ${statusClass(status)}`}>{status}</span>
+                  </div>
+                  <p className="mt-2 text-sm text-slate-100">{item.collection}</p>
+                  <p className="mt-1 text-xs text-slate-500">{item.provider} · {item.model} · {state?.doc_counts[key] ?? 0} docs</p>
+                  {health?.error ? <p className="mt-2 text-xs text-rose-300">{health.error}</p> : null}
+                </div>
+                <div className="flex flex-wrap items-center gap-3">
+                  <label className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                    Adapter
+                    <select
+                      className="mt-1 block rounded-xl border border-white/10 bg-slate-900 px-3 py-2 text-sm text-slate-100"
+                      value={item.adapter ?? 'lancedb'}
+                      onChange={(event) => void patchCollection(key, { adapter: event.target.value })}
+                    >
+                      {ADAPTERS.map((adapter) => <option key={adapter} value={adapter}>{adapter}</option>)}
+                    </select>
+                  </label>
+                  <label className="flex items-center gap-2 text-sm text-slate-200">
+                    <input
+                      type="checkbox"
+                      checked={enabled}
+                      onChange={(event) => void patchCollection(key, { enabled: event.target.checked })}
+                    />
+                    Enabled
+                  </label>
+                  {saving[key] === 'saving' ? <Spinner label="Saving" /> : null}
+                </div>
+              </div>
+            </article>
+          );
+        })}
+        {!loading && rows.length === 0 ? <p className="text-sm text-slate-500">No vector collections configured.</p> : null}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, type ReactNode } from 'react';
 import { fetchSettingsSystem } from '../api';
 import { ErrorMessage, LoadingPanel, Spinner } from '../components/AsyncState';
+import { VectorConfigPanel } from '../components/VectorConfigPanel';
 import type { SettingsSystemResponse } from '../types';
 
 type SettingsPageProps = {
@@ -108,6 +109,10 @@ export function SettingsPage({ menuCount, pluginCount, surfaceCount, updatedAt, 
 
       {settings ? (
         <section className="grid gap-5 xl:grid-cols-2">
+          <div className="xl:col-span-2">
+            <VectorConfigPanel />
+          </div>
+
           <SectionCard title="Storage backend">
             <div className="grid gap-3 sm:grid-cols-2">
               <SettingPair

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -184,6 +184,7 @@ export interface SettingsEmbedderCollection {
   model: string;
   provider: string;
   adapter?: string;
+  enabled?: boolean;
   primary?: boolean;
 }
 
@@ -211,6 +212,32 @@ export interface SettingsSystemResponse {
   storage: SettingsStorageConfig;
   embedder: SettingsEmbedderConfig;
   migrations: SettingsMigrationStatus;
+}
+
+export interface VectorConfigHealth {
+  ok: boolean;
+  status: 'ok' | 'down' | 'disabled' | string;
+  collection: string;
+  adapter?: string;
+  model?: string;
+  enabled?: boolean;
+  error?: string;
+}
+
+export interface VectorConfigResponse {
+  source: 'file' | 'defaults';
+  config: { collections: Record<string, SettingsEmbedderCollection> };
+  doc_counts: Record<string, number>;
+  health: Record<string, VectorConfigHealth>;
+  checked_at?: string;
+}
+
+export interface VectorConfigUpdateResponse {
+  success: boolean;
+  source: 'file' | 'defaults';
+  path?: string;
+  collection?: string;
+  config: { collections: Record<string, SettingsEmbedderCollection> };
 }
 
 export type LoadState = 'idle' | 'loading' | 'ready' | 'error';

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -95,7 +95,7 @@ export const BUILTIN_HELP: CliHelpEntry[] = [
     usage: "arra-cli vector-config <subcommand>",
     subcommands: ["list", "get <collection>", "stats [<collection>]", "set <collection> <field> <value>", "reload", "test <collection>"],
     flags: ["--json", "--yml", "--help", "-h", "--model <name>", "--provider <name>", "--adapter <name>"],
-    examples: ["arra-cli vector-config list", "arra-cli vector-config get bge-m3", "arra-cli vector-config stats bge-m3", "arra-cli vector-config set bge-m3 model qwen3-embedding", "arra-cli vector-config reload"],
+    examples: ["arra-cli vector-config list", "arra-cli vector-config get bge-m3", "arra-cli vector-config stats bge-m3", "arra-cli vector-config set bge-m3 enabled false", "arra-cli vector-config reload"],
   },
   {
     command: "migrate",
@@ -152,7 +152,7 @@ const SUBCOMMAND_HELP: CliHelpEntry[] = [
   { command: "vector-config list", help: "list available vector collections", usage: "arra-cli vector-config list", examples: ["arra-cli vector-config list"] },
   { command: "vector-config get", help: "show a collection config", usage: "arra-cli vector-config get <collection>", examples: ["arra-cli vector-config get bge-m3"] },
   { command: "vector-config stats", help: "show vector document counts", usage: "arra-cli vector-config stats [<collection>]", examples: ["arra-cli vector-config stats", "arra-cli vector-config stats bge-m3"] },
-  { command: "vector-config set", help: "set collection model/provider/adapter", usage: "arra-cli vector-config set <collection> <field> <value>", examples: ["arra-cli vector-config set bge-m3 model qwen3-embedding", "arra-cli vector-config set bge-m3 --adapter qdrant --provider remote"] },
+  { command: "vector-config set", help: "set collection model/provider/adapter/enabled", usage: "arra-cli vector-config set <collection> <field> <value>", examples: ["arra-cli vector-config set bge-m3 enabled false", "arra-cli vector-config set bge-m3 --adapter qdrant --provider remote"] },
   { command: "vector-config reload", help: "clear cached vector collection stores", usage: "arra-cli vector-config reload", examples: ["arra-cli vector-config reload"] },
   { command: "vector-config test", help: "probe one collection adapter", usage: "arra-cli vector-config test <collection>", examples: ["arra-cli vector-config test bge-m3"] },
   { command: "plugins list", help: "list MCP tool plugins", usage: "arra-cli plugins list [--json]", examples: ["arra-cli plugins list --json"] },

--- a/src/routes/health/health.ts
+++ b/src/routes/health/health.ts
@@ -3,12 +3,12 @@ import { DB_PATH, PORT } from '../../config.ts';
 import { MCP_SERVER_NAME } from '../../const.ts';
 import { sqlite } from '../../db/index.ts';
 import { scanPlugins } from '../plugins/model.ts';
-import { handleVectorHealth } from '../../server/vector-handlers.ts';
+import { readVectorBackendHealth } from '../../vector/health.ts';
 import { mcpTools } from '../../tools/mcp-manifest.ts';
 import type { UnifiedPluginStatus } from '../../plugins/unified-loader.ts';
 import pkg from '../../../package.json' with { type: 'json' };
 
-type VectorHealth = Awaited<ReturnType<typeof handleVectorHealth>>;
+type VectorHealth = Awaited<ReturnType<typeof readVectorBackendHealth>>;
 type DbStatus = { status: 'connected' } | { status: 'error'; error: string };
 type DbPing = () => DbStatus | Promise<DbStatus>;
 
@@ -43,7 +43,7 @@ async function defaultDbPing(): Promise<DbStatus> {
   }
 }
 
-async function readVectorStatus(check = handleVectorHealth): Promise<VectorHealth> {
+async function readVectorStatus(check = readVectorBackendHealth): Promise<VectorHealth> {
   try {
     return await check();
   } catch (error) {

--- a/src/routes/vector/config-api.ts
+++ b/src/routes/vector/config-api.ts
@@ -1,10 +1,3 @@
-/**
- * Vector config API — external path `/api/v1/vector/config`.
- *
- * The app mounts vector routes at `/api`; api-version middleware rewrites
- * `/api/v1/*` to those internal routes.
- */
-
 import fs from 'fs';
 import path from 'path';
 import { Elysia, t } from 'elysia';
@@ -29,7 +22,7 @@ const adapterSchema = t.Union([
   t.Literal('proxy'),
 ]);
 
-type CollectionUpdate = Partial<Pick<VectorCollectionConfig, 'adapter' | 'model' | 'provider' | 'service' | 'endpoint'>>;
+type CollectionUpdate = Partial<Pick<VectorCollectionConfig, 'adapter' | 'model' | 'provider' | 'service' | 'endpoint' | 'enabled'>>;
 type CollectionHealth = {
   key: string;
   collection: string;
@@ -38,9 +31,10 @@ type CollectionHealth = {
   adapter: VectorDBType;
   service?: string;
   endpoint?: string;
+  enabled: boolean;
   count: number;
   ok: boolean;
-  status: 'ok' | 'down';
+  status: 'ok' | 'down' | 'disabled';
   error?: string;
 };
 
@@ -72,10 +66,7 @@ function atomicWriteVectorConfig(config: VectorServerConfig): string {
     writeVectorConfig(config, tmp);
     fs.renameSync(tmp, target);
     return target;
-  } catch (e) {
-    try { if (fs.existsSync(tmp)) fs.unlinkSync(tmp); } catch {}
-    throw e;
-  }
+  } catch (e) { try { if (fs.existsSync(tmp)) fs.unlinkSync(tmp); } catch {} throw e; }
 }
 
 function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
@@ -83,9 +74,7 @@ function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   const timeout = new Promise<never>((_, reject) => {
     timer = setTimeout(() => reject(new Error('timeout')), ms);
   });
-  return Promise.race([promise, timeout]).finally(() => {
-    if (timer) clearTimeout(timer);
-  });
+  return Promise.race([promise, timeout]).finally(() => { if (timer) clearTimeout(timer); });
 }
 
 async function inspectCollection(
@@ -93,9 +82,25 @@ async function inspectCollection(
   col: VectorCollectionConfig,
   config: VectorServerConfig,
 ): Promise<CollectionHealth> {
+  const adapter = col.adapter || 'lancedb';
+  if (col.enabled === false) {
+    return {
+      key,
+      collection: col.collection,
+      model: col.model,
+      provider: col.provider,
+      adapter,
+      service: col.service,
+      endpoint: col.endpoint,
+      enabled: false,
+      count: 0,
+      ok: false,
+      status: 'disabled',
+    };
+  }
   const timeout = parseInt(process.env.ORACLE_VECTOR_HEALTH_TIMEOUT || '2000', 10);
   const preset = configToModels(config)[key];
-  const adapter = preset.adapter || 'lancedb';
+  if (!preset) throw new Error(`Collection ${key} is not enabled`);
   const store = createVectorStoreForModel(preset);
   try {
     await withTimeout(store.connect(), timeout);
@@ -106,6 +111,9 @@ async function inspectCollection(
       model: col.model,
       provider: col.provider,
       adapter,
+      service: col.service,
+      endpoint: col.endpoint,
+      enabled: true,
       count: stats.count,
       ok: true,
       status: 'ok',
@@ -117,6 +125,9 @@ async function inspectCollection(
       model: col.model,
       provider: col.provider,
       adapter,
+      service: col.service,
+      endpoint: col.endpoint,
+      enabled: true,
       count: 0,
       ok: false,
       status: 'down',
@@ -135,14 +146,15 @@ function normalizedUpdate(body: CollectionUpdate): CollectionUpdate | { error: s
     if (!model) return { error: 'model must be a non-empty string' };
     update.model = model;
   }
-    if (body.provider !== undefined) {
-      const provider = body.provider.trim();
-      if (!provider) return { error: 'provider must be a non-empty string' };
-      update.provider = provider;
-    }
-    if (body.service !== undefined) update.service = body.service;
-    if (body.endpoint !== undefined) update.endpoint = body.endpoint;
-  if (Object.keys(update).length === 0) return { error: 'body must include adapter, model, provider, service, or endpoint' };
+  if (body.provider !== undefined) {
+    const provider = body.provider.trim();
+    if (!provider) return { error: 'provider must be a non-empty string' };
+    update.provider = provider;
+  }
+  if (body.service !== undefined) update.service = body.service;
+  if (body.endpoint !== undefined) update.endpoint = body.endpoint;
+  if (body.enabled !== undefined) update.enabled = body.enabled;
+  if (Object.keys(update).length === 0) return { error: 'body must include adapter, model, provider, service, endpoint, or enabled' };
   return update;
 }
 
@@ -163,6 +175,7 @@ export const vectorConfigApiEndpoint = new Elysia()
         collection: col.collection,
         adapter: col.adapter,
         model: col.model,
+        enabled: col.enabled,
         ...(col.error && { error: col.error }),
       }])),
       checked_at: new Date().toISOString(),
@@ -225,6 +238,7 @@ export const vectorConfigApiEndpoint = new Elysia()
       provider: t.Optional(t.String()),
       service: t.Optional(t.String()),
       endpoint: t.Optional(t.String()),
+      enabled: t.Optional(t.Boolean()),
     }),
     detail: { tags: ['vector'], summary: 'Update one vector collection config' },
   });

--- a/src/routes/vector/health.ts
+++ b/src/routes/vector/health.ts
@@ -10,13 +10,13 @@
  */
 
 import { Elysia } from 'elysia';
-import { handleVectorHealth } from '../../server/vector-handlers.ts';
 import { createVectorProxy } from '../../server/vector-proxy.ts';
 import { VECTOR_URL } from '../../config.ts';
+import { readVectorBackendHealth } from '../../vector/health.ts';
 
 const defaultProxy = createVectorProxy(VECTOR_URL);
 
-type VectorHealthResult = Awaited<ReturnType<typeof handleVectorHealth>>;
+type VectorHealthResult = Awaited<ReturnType<typeof readVectorBackendHealth>>;
 
 export interface VectorHealthEndpointOptions {
   vectorHealth?: () => Promise<VectorHealthResult>;
@@ -25,7 +25,7 @@ export interface VectorHealthEndpointOptions {
 
 export function createVectorHealthEndpoint(options: VectorHealthEndpointOptions = {}) {
   const proxy = options.proxy === undefined ? defaultProxy : options.proxy;
-  const vectorHealth = options.vectorHealth ?? handleVectorHealth;
+  const vectorHealth = options.vectorHealth ?? readVectorBackendHealth;
 
   async function readHealth({ set }: { set: { status?: number | string } }) {
     if (proxy) {

--- a/src/vector/config.ts
+++ b/src/vector/config.ts
@@ -41,6 +41,7 @@ export interface VectorCollectionConfig {
   service?: string;
   /** Explicit endpoint for proxy adapter (optional, defaults to registered service). */
   endpoint?: string;
+  enabled?: boolean;
   primary?: boolean;
 }
 
@@ -173,6 +174,7 @@ export function configToModels(
     endpoint?: string;
   }> = {};
   for (const [key, col] of Object.entries(config.collections)) {
+    if (col.enabled === false) continue;
     const adapter = col.adapter || 'lancedb';
     const serviceEndpoint = col.endpoint
       || resolveServiceEndpoint(config, col.service)

--- a/src/vector/health.ts
+++ b/src/vector/health.ts
@@ -1,0 +1,60 @@
+import { ensureVectorStoreConnected, getEmbeddingModels } from './factory.ts';
+
+export type VectorBackendEngine = {
+  key: string;
+  model: string;
+  collection: string;
+  adapter?: string;
+  count: number;
+  ok: boolean;
+  error?: string;
+};
+
+export type VectorBackendHealth = {
+  status: 'ok' | 'degraded' | 'down';
+  engines: VectorBackendEngine[];
+  checked_at: string;
+};
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error('timeout')), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => { if (timer) clearTimeout(timer); });
+}
+
+export async function readVectorBackendHealth(): Promise<VectorBackendHealth> {
+  const timeout = parseInt(process.env.ORACLE_VECTOR_HEALTH_TIMEOUT || '2000', 10);
+  const models = getEmbeddingModels();
+  const engines: VectorBackendEngine[] = [];
+
+  await Promise.all(Object.entries(models).map(async ([key, preset]) => {
+    try {
+      const store = await ensureVectorStoreConnected(key);
+      const stats = await withTimeout(store.getStats(), timeout);
+      engines.push({
+        key,
+        model: preset.model,
+        collection: preset.collection,
+        adapter: preset.adapter,
+        count: stats.count,
+        ok: true,
+      });
+    } catch (error) {
+      engines.push({
+        key,
+        model: preset.model,
+        collection: preset.collection,
+        adapter: preset.adapter,
+        count: 0,
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }));
+
+  const okCount = engines.filter((engine) => engine.ok).length;
+  const status = okCount === engines.length ? 'ok' : okCount === 0 ? 'down' : 'degraded';
+  return { status, engines, checked_at: new Date().toISOString() };
+}

--- a/tests/cli/vector-config/cli.test.ts
+++ b/tests/cli/vector-config/cli.test.ts
@@ -9,6 +9,7 @@ type CollectionKey = {
   model: string;
   provider: string;
   adapter?: string;
+  enabled?: boolean;
   primary?: boolean;
 };
 
@@ -148,7 +149,7 @@ describe("arra-cli vector-config", () => {
     expect(onePayload?.docs).toBe(8);
   });
 
-  test("shows one collection config and updates model", async () => {
+  test("shows one collection config and updates model/enabled state", async () => {
     const getBefore = await runCli(["vector-config", "get", "phase2"], env);
     const before = tryParseJson(getBefore.stdout);
     expect(before?.config?.model).toBe("nomic-embed-text");
@@ -161,6 +162,11 @@ describe("arra-cli vector-config", () => {
     const getAfter = await runCli(["vector-config", "get", "phase2"], env);
     const after = tryParseJson(getAfter.stdout);
     expect(after?.config?.model).toBe("embed-v2");
+
+    const disable = await runCli(["vector-config", "set", "phase2", "enabled", "false"], env);
+    expect(disable.code).toBe(0);
+    const disabled = await runCli(["vector-config", "get", "phase2"], env);
+    expect(tryParseJson(disabled.stdout)?.config?.enabled).toBe(false);
   });
 
   test("supports collection ops", async () => {

--- a/tests/frontend/api/fetch-settings-system-passthrough.test.ts
+++ b/tests/frontend/api/fetch-settings-system-passthrough.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { fetchSettingsSystem } from '../../../frontend/src/api';
+import { fetchSettingsSystem, fetchVectorConfig, reloadVectorConfig, updateVectorCollection } from '../../../frontend/src/api';
 import { installFetch, jsonResponse } from './_fetch';
 
 describe('fetchSettingsSystem', () => {
@@ -9,6 +9,26 @@ describe('fetchSettingsSystem', () => {
     try {
       await expect(fetchSettingsSystem()).resolves.toEqual(payload);
       expect(fetchMock.calls[0]?.input).toBe('/api/settings/system');
+    } finally {
+      fetchMock.restore();
+    }
+  });
+});
+
+describe('vector config api client', () => {
+  test('uses vector config endpoints for state, update, and reload', async () => {
+    const fetchMock = installFetch(() => jsonResponse({ success: true, config: { collections: {} } }));
+    try {
+      await fetchVectorConfig();
+      await updateVectorCollection('bge-m3', { adapter: 'lancedb', enabled: true });
+      await reloadVectorConfig();
+      expect(fetchMock.calls.map((call) => call.input)).toEqual([
+        '/api/v1/vector/config',
+        '/api/v1/vector/config/bge-m3',
+        '/api/v1/vector/config/reload',
+      ]);
+      expect(fetchMock.calls[1]?.init?.method).toBe('PUT');
+      expect(fetchMock.calls[2]?.init?.method).toBe('POST');
     } finally {
       fetchMock.restore();
     }


### PR DESCRIPTION
## Summary
- Add vector collection enabled state to config API and model registry filtering
- Extend vector-config CLI get/list/stats/set to support enabled true/false
- Add Settings UI vector backend panel for adapter switching, enable toggles, and reload
- Route /health and /api/vector/health through detailed vector health helper with adapter/count data

## Validation
- bunx tsc --noEmit
- bun test tests/cli/vector-config tests/frontend/api/fetch-settings-system-passthrough.test.ts tests/http/health tests/vector

Closes #1595