### PR TITLE
feat(plugins): unified plugin management UI

### DIFF
--- a/frontend/src/api/plugin-admin.ts
+++ b/frontend/src/api/plugin-admin.ts
@@ -1,0 +1,30 @@
+import { apiUrl } from './oracle';
+
+export interface PluginStateResponse {
+  ok: boolean;
+  plugin: string;
+  enabled: boolean;
+  requiresRestart: boolean;
+  message: string;
+}
+
+function errorMessage(payload: unknown, fallback: string): string {
+  if (payload && typeof payload === 'object' && 'error' in payload) {
+    const error = (payload as { error?: unknown }).error;
+    if (typeof error === 'string') return error;
+  }
+  return fallback;
+}
+
+export async function setPluginEnabled(name: string, enabled: boolean): Promise<PluginStateResponse> {
+  const path = `/api/plugins/${encodeURIComponent(name)}/state`;
+  const response = await fetch(apiUrl(path), {
+    method: 'PATCH',
+    headers: { accept: 'application/json', 'content-type': 'application/json' },
+    body: JSON.stringify({ enabled }),
+  });
+  const text = await response.text();
+  const payload = text ? JSON.parse(text) as unknown : {};
+  if (!response.ok) throw new Error(`${path} returned ${response.status}: ${errorMessage(payload, response.statusText)}`);
+  return payload as PluginStateResponse;
+}

--- a/frontend/src/pages/PluginsPage.tsx
+++ b/frontend/src/pages/PluginsPage.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
 import { apiClient, type ApiClient } from '../api/client';
+import { setPluginEnabled } from '../api/plugin-admin';
 import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
-import { pluginStatusLabel, isPluginEnabled, togglePluginEnabled, type PluginEnabledState } from '../components/PluginList';
+import { pluginStatusLabel, isPluginEnabled, type PluginEnabledState } from '../components/PluginList';
 import { surfacesFor } from '../plugin-surfaces';
 import type { PluginEntry } from '../types';
 
@@ -37,10 +38,12 @@ function PluginsCards({
   plugins,
   enabledState,
   onToggle,
+  pending,
 }: {
   plugins: PluginEntry[];
   enabledState: PluginEnabledState;
-  onToggle: (name: string) => void;
+  onToggle: (name: string, enabled: boolean) => void;
+  pending: string | null;
 }) {
   if (!plugins.length) return <p className="text-sm text-slate-400">No plugins are registered.</p>;
 
@@ -83,11 +86,12 @@ function PluginsCards({
               <button
                 aria-label={`${enabled ? 'Disable' : 'Enable'} ${plugin.name}`}
                 aria-pressed={enabled}
-                className="focus-ring rounded-lg border border-teal-300/30 px-3 py-2 text-sm font-semibold text-teal-100 transition hover:bg-teal-300/10"
+                className="focus-ring rounded-lg border border-teal-300/30 px-3 py-2 text-sm font-semibold text-teal-100 transition hover:bg-teal-300/10 disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={pending === plugin.name}
                 type="button"
-                onClick={() => onToggle(plugin.name)}
+                onClick={() => onToggle(plugin.name, !enabled)}
               >
-                {enabled ? 'Disable' : 'Enable'}
+                {pending === plugin.name ? 'Saving…' : enabled ? 'Disable' : 'Enable'}
               </button>
             </div>
           </article>
@@ -101,6 +105,8 @@ export function PluginsPage({ plugins: initialPlugins = [], loading = true, clie
   const [plugins, setPlugins] = useState(initialPlugins);
   const [state, setState] = useState<PageState>(loading ? 'loading' : 'ready');
   const [error, setError] = useState('');
+  const [actionMessage, setActionMessage] = useState('');
+  const [pendingPlugin, setPendingPlugin] = useState<string | null>(null);
   const [enabledState, setEnabledState] = useState<PluginEnabledState>(() => enabledStateForPlugins(initialPlugins));
 
   useEffect(() => {
@@ -125,6 +131,20 @@ export function PluginsPage({ plugins: initialPlugins = [], loading = true, clie
   const summary = useMemo(() => pluginAdminSummary(plugins, enabledState), [plugins, enabledState]);
   const isLoading = state === 'loading';
 
+  async function togglePlugin(name: string, enabled: boolean) {
+    setPendingPlugin(name);
+    setActionMessage('');
+    try {
+      const response = await setPluginEnabled(name, enabled);
+      setEnabledState((current) => ({ ...current, [name]: response.enabled }));
+      setActionMessage(response.message);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setPendingPlugin(null);
+    }
+  }
+
   return (
     <div className="grid gap-5">
       <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="plugins-page-title">
@@ -133,12 +153,14 @@ export function PluginsPage({ plugins: initialPlugins = [], loading = true, clie
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Plugin admin</p>
             <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Plugin list</p>
             <h2 id="plugins-page-title" className="mt-2 text-2xl font-semibold text-white">Registered plugins</h2>
-            <p className="mt-2 text-sm text-slate-400">Loaded from GET /api/v1/plugins with local enable/disable controls.</p>
+            <p className="mt-2 text-sm text-slate-400">Loaded from GET /api/v1/plugins with manifest-backed enable/disable controls.</p>
           </div>
           <p className="rounded-full border border-white/10 px-3 py-2 text-sm text-slate-300">{summary}</p>
         </div>
         {isLoading ? <LoadingPanel title="Loading plugins…" detail="Fetching /api/v1/plugins and plugin server manifests." /> : null}
         {state === 'error' ? <ErrorMessage title="Could not load plugins." message={error} /> : null}
+        {state !== 'error' && error ? <ErrorMessage title="Plugin action failed." message={error} /> : null}
+        {actionMessage ? <p className="mt-3 text-sm text-amber-200">{actionMessage}</p> : null}
       </section>
 
       <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-label="Plugin registry cards">
@@ -147,7 +169,8 @@ export function PluginsPage({ plugins: initialPlugins = [], loading = true, clie
           : <PluginsCards
               plugins={plugins}
               enabledState={enabledState}
-              onToggle={(name) => setEnabledState((current) => togglePluginEnabled(current, name))}
+              onToggle={(name, enabled) => void togglePlugin(name, enabled)}
+              pending={pendingPlugin}
             />}
       </section>
     </div>

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -15,6 +15,7 @@ export interface LoadedPluginRegistryEntry {
   status: UnifiedPluginStatus['status'];
   surfaces: UnifiedPluginSurface[];
   error?: string;
+  enabled?: boolean;
   description?: string;
   menu?: UnifiedMenuManifest;
   server?: ReturnType<typeof publicUnifiedServerManifest>;
@@ -39,6 +40,7 @@ export function pluginRegistryFromLoadedPlugins(
       version: plugin.manifest.version,
       status: status?.status ?? 'ok',
       error: status?.error,
+      enabled: plugin.manifest.enabled !== false,
       surfaces: manifestSurfaces(plugin.manifest),
       description: plugin.manifest.description,
       menu: plugin.manifest.menu[0],

--- a/src/routes/plugins/index.ts
+++ b/src/routes/plugins/index.ts
@@ -2,10 +2,12 @@
 import { Elysia } from 'elysia';
 import { createPluginsRegistryRoute, type PluginsRegistryRouteOptions } from './registry.ts';
 import { pluginGetByNameRoute } from './get-by-name.ts';
+import { pluginStateRoute } from './state.ts';
 
 export function createPluginsRouter(options: PluginsRegistryRouteOptions = {}) {
   return new Elysia()
     .use(createPluginsRegistryRoute(options))
+    .use(pluginStateRoute)
     .use(pluginGetByNameRoute);
 }
 

--- a/src/routes/plugins/model.ts
+++ b/src/routes/plugins/model.ts
@@ -34,6 +34,7 @@ export type PluginEntry = {
   modified: string;
   version?: string;
   description?: string;
+  enabled?: boolean;
   menu?: PluginMenu;
   server?: PublicUnifiedServerManifest;
 };
@@ -54,6 +55,7 @@ type RawPluginManifest = {
   name?: string;
   version?: string;
   description?: string;
+  enabled?: boolean;
   wasm?: string;
   menu?: unknown;
   server?: unknown;
@@ -107,6 +109,7 @@ export function readNestedPlugin(
     name: typeof manifest.name === 'string' && manifest.name ? manifest.name : entryName,
     version: typeof manifest.version === 'string' ? manifest.version : undefined,
     description: typeof manifest.description === 'string' ? manifest.description : undefined,
+    enabled: manifest.enabled !== false,
     menu: parseMenu(manifest.menu),
     server,
   };
@@ -148,6 +151,7 @@ export function readFlatPlugin(file: string): PluginEntry {
     file,
     size: st.size,
     modified: st.mtime.toISOString(),
+    enabled: true,
   };
 }
 

--- a/src/routes/plugins/registry.ts
+++ b/src/routes/plugins/registry.ts
@@ -1,6 +1,7 @@
 import { Elysia } from 'elysia';
 import type { LoadedPluginRegistryEntry } from '../../plugins/registry.ts';
 import { PLUGIN_DIR, scanPlugins } from './model.ts';
+import { readPluginEnabled } from './state.ts';
 
 export interface PluginsRegistryRouteOptions {
   dir?: string;
@@ -10,7 +11,10 @@ export interface PluginsRegistryRouteOptions {
 export function createPluginsRegistryRoute(options: PluginsRegistryRouteOptions = {}) {
   return new Elysia().get('/api/plugins', () => {
     if (!options.registry) return scanPlugins();
-    const plugins = options.registry();
+    const plugins = options.registry().map((plugin) => ({
+      ...plugin,
+      enabled: readPluginEnabled(plugin.name) ?? plugin.enabled ?? true,
+    }));
     return { plugins, count: plugins.length, dir: options.dir ?? PLUGIN_DIR };
   }, {
     detail: {

--- a/src/routes/plugins/state.ts
+++ b/src/routes/plugins/state.ts
@@ -1,0 +1,92 @@
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { Elysia, t } from 'elysia';
+import { sanitizePluginName } from './model.ts';
+
+const DEFAULT_PLUGIN_DIRS = [join(homedir(), '.arra', 'plugins'), join(homedir(), '.oracle', 'plugins')];
+
+type PluginManifest = {
+  name?: string;
+  enabled?: boolean;
+  [key: string]: unknown;
+};
+
+function pluginDirs(): string[] {
+  const configured = process.env.ARRA_PLUGIN_DIRS?.split(':').map((item) => item.trim()).filter(Boolean);
+  return configured?.length ? configured : DEFAULT_PLUGIN_DIRS;
+}
+
+function readJson(path: string): PluginManifest | null {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as PluginManifest;
+  } catch {
+    return null;
+  }
+}
+
+function manifestPathFor(name: string): string | null {
+  const safe = sanitizePluginName(name);
+  if (!safe) return null;
+  for (const base of pluginDirs()) {
+    const direct = join(base, safe, 'plugin.json');
+    if (existsSync(direct)) return direct;
+  }
+  for (const base of pluginDirs()) {
+    if (!existsSync(base)) continue;
+    try {
+      for (const entry of readdirSync(base)) {
+        const dir = join(base, entry);
+        if (!statSync(dir).isDirectory()) continue;
+        const path = join(dir, 'plugin.json');
+        if (!existsSync(path)) continue;
+        const manifest = readJson(path);
+        if (manifest?.name && sanitizePluginName(manifest.name) === safe) return path;
+      }
+    } catch {
+      // best-effort fallback only
+    }
+  }
+  return null;
+}
+
+export function readPluginEnabled(name: string): boolean | undefined {
+  const path = manifestPathFor(name);
+  if (!path) return undefined;
+  const manifest = readJson(path);
+  if (!manifest) return undefined;
+  return manifest.enabled !== false;
+}
+
+function writePluginEnabled(name: string, enabled: boolean) {
+  const path = manifestPathFor(name);
+  if (!path) return null;
+  const manifest = readJson(path);
+  if (!manifest) return null;
+  const next = { ...manifest, enabled };
+  writeFileSync(path, JSON.stringify(next, null, 2) + '\n', 'utf8');
+  return { path, name: manifest.name ?? sanitizePluginName(name), enabled };
+}
+
+export const pluginStateRoute = new Elysia().patch(
+  '/api/plugins/:name/state',
+  ({ params, body, set }) => {
+    const result = writePluginEnabled(params.name, body.enabled);
+    if (!result) {
+      set.status = 404;
+      return { error: 'plugin manifest not found', name: sanitizePluginName(params.name) };
+    }
+    return {
+      ok: true,
+      plugin: result.name,
+      enabled: result.enabled,
+      requiresRestart: true,
+      message: 'Plugin manifest updated; restart/reload required for runtime surfaces to change.',
+    };
+  },
+  {
+    params: t.Object({ name: t.String({ minLength: 1 }) }),
+    body: t.Object({ enabled: t.Boolean() }),
+    detail: { tags: ['plugins'], summary: 'Enable or disable an installed plugin manifest' },
+  },
+);

--- a/tests/http/plugins/state.test.ts
+++ b/tests/http/plugins/state.test.ts
@@ -1,0 +1,47 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Elysia } from 'elysia';
+import { createPluginsRouter } from '../../../src/routes/plugins/index.ts';
+import { pluginDir } from '../../plugins/_fixtures.ts';
+
+const tmp = mkdtempSync(join(tmpdir(), 'arra-plugin-state-'));
+const previousDirs = process.env.ARRA_PLUGIN_DIRS;
+process.env.ARRA_PLUGIN_DIRS = tmp;
+
+afterAll(() => {
+  if (previousDirs === undefined) delete process.env.ARRA_PLUGIN_DIRS;
+  else process.env.ARRA_PLUGIN_DIRS = previousDirs;
+  rmSync(tmp, { recursive: true });
+});
+
+describe('PATCH /api/plugins/:name/state', () => {
+  test('persists enabled=false to plugin.json', async () => {
+    const dir = pluginDir(tmp, 'toggle-plugin', { description: 'toggle me' });
+    const app = new Elysia().use(createPluginsRouter());
+
+    const response = await app.handle(new Request('http://local/api/plugins/toggle-plugin/state', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ enabled: false }),
+    }));
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { enabled: boolean; requiresRestart: boolean };
+    expect(body).toMatchObject({ enabled: false, requiresRestart: true });
+    const manifest = JSON.parse(readFileSync(join(dir, 'plugin.json'), 'utf8')) as { enabled?: boolean };
+    expect(manifest.enabled).toBe(false);
+  });
+
+  test('returns 404 for unknown plugin manifests', async () => {
+    const app = new Elysia().use(createPluginsRouter());
+    const response = await app.handle(new Request('http://local/api/plugins/missing/state', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ enabled: true }),
+    }));
+
+    expect(response.status).toBe(404);
+  });
+});


### PR DESCRIPTION
Implements #1484 plugin management controls for unified plugin backend surfaces.

Changes:
- Adds manifest-backed PATCH /api/plugins/:name/state enable/disable endpoint.
- Exposes enabled state in plugin registry responses.
- Wires the React Plugins page toggle controls to the backend endpoint.
- Adds targeted HTTP coverage for plugin state updates.

Validation:
- bunx tsc --noEmit
- bun test tests/http/plugins/state.test.ts tests/http/plugins/registry.test.ts tests/frontend/pages/plugins-page-admin.test.tsx