### PR TITLE
feat: add embedding provider detection API

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -108,6 +108,7 @@ export const EMBEDDER_VALUES = [
   'chromadb-internal',
   'ollama',
   'openai',
+  'gemini',
   'cloudflare-ai',
   'disabled',
   'off',

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -155,8 +155,9 @@ function validateProviderRequirements(env: RuntimeEnv, issues: string[]): void {
     issues.push('Remote embedder requires ORACLE_EMBEDDER_URL or ORACLE_REMOTE_EMBEDDING_URL.');
   }
   if (embedder === 'openai' && !filled(env.OPENAI_API_KEY)) issues.push('OpenAI embedder requires OPENAI_API_KEY.');
+  if (embedder === 'gemini' && !filled(env.GEMINI_API_KEY)) issues.push('Gemini embedder requires GEMINI_API_KEY.');
   const cloudflare = embedder === 'cloudflare-ai' || env.ORACLE_VECTOR_DB === 'cloudflare-vectorize';
-  if (cloudflare && (!filled(env.CLOUDFLARE_ACCOUNT_ID) || !filled(env.CLOUDFLARE_API_TOKEN))) {
+  if (cloudflare && ((!filled(env.CLOUDFLARE_ACCOUNT_ID) && !filled(env.CF_ACCOUNT_ID)) || (!filled(env.CLOUDFLARE_API_TOKEN) && !filled(env.CF_API_TOKEN)))) {
     issues.push('Cloudflare vector/AI config requires CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN.');
   }
 }

--- a/src/routes/vector/config-api.ts
+++ b/src/routes/vector/config-api.ts
@@ -70,6 +70,16 @@ export const vectorConfigApiEndpoint = new Elysia()
     const { source, config } = activeConfig();
     return { success: true, reloaded: true, source, config };
   }, { detail: { tags: ['vector'], summary: 'Reload vector config and clear cached vector stores' } })
+  .patch('/vector/config', async ({ body }) => {
+    const { source, config } = activeConfig();
+    const next = { ...config, ...(body as Partial<VectorServerConfig>) };
+    const path = atomicWriteVectorConfig(next);
+    await closeCachedVectorStores();
+    return { success: true, reloaded: true, source, path, config: next };
+  }, {
+    body: t.Any(),
+    detail: { tags: ['vector'], summary: 'Patch vector config and hot-reload adapters' },
+  })
   .post('/vector/config/:collection/test', async ({ params, set }) => {
     const { config } = activeConfig();
     const resolved = resolveCollection(config, params.collection);
@@ -85,7 +95,7 @@ export const vectorConfigApiEndpoint = new Elysia()
     params: t.Object({ collection: t.String({ minLength: 1 }) }),
     detail: { tags: ['vector'], summary: 'Test one vector collection adapter' },
   })
-  .post('/vector/config/:collection', ({ params, body, set }) => {
+  .post('/vector/config/:collection', async ({ params, body, set }) => {
     const { source, config } = activeConfig();
     if (config.collections[params.collection]) {
       set.status = 409;
@@ -102,13 +112,14 @@ export const vectorConfigApiEndpoint = new Elysia()
     };
     const next = created.primary ? withPrimary(nextBase, params.collection) : nextBase;
     const path = atomicWriteVectorConfig(next);
-    return { success: true, source, path, collection: params.collection, config: next };
+    await closeCachedVectorStores();
+    return { success: true, reloaded: true, source, path, collection: params.collection, config: next };
   }, {
     params: t.Object({ collection: t.String({ minLength: 1 }) }),
     body: createSchema,
     detail: { tags: ['vector'], summary: 'Add a vector collection config' },
   })
-  .post('/vector/config/:collection/primary', ({ params, set }) => {
+  .post('/vector/config/:collection/primary', async ({ params, set }) => {
     const { source, config } = activeConfig();
     const resolved = resolveCollection(config, params.collection);
     if (!resolved) {
@@ -118,12 +129,13 @@ export const vectorConfigApiEndpoint = new Elysia()
     const [key] = resolved;
     const next = withPrimary(config, key);
     const path = atomicWriteVectorConfig(next);
-    return { success: true, source, path, collection: key, config: next };
+    await closeCachedVectorStores();
+    return { success: true, reloaded: true, source, path, collection: key, config: next };
   }, {
     params: t.Object({ collection: t.String({ minLength: 1 }) }),
     detail: { tags: ['vector'], summary: 'Set primary vector collection' },
   })
-  .delete('/vector/config/:collection', ({ params, set }) => {
+  .delete('/vector/config/:collection', async ({ params, set }) => {
     const { source, config } = activeConfig();
     const resolved = resolveCollection(config, params.collection);
     if (!resolved) {
@@ -133,12 +145,13 @@ export const vectorConfigApiEndpoint = new Elysia()
     const [key] = resolved;
     const next = withoutCollection(config, key);
     const path = atomicWriteVectorConfig(next);
-    return { success: true, source, path, removed: key, config: next };
+    await closeCachedVectorStores();
+    return { success: true, reloaded: true, source, path, removed: key, config: next };
   }, {
     params: t.Object({ collection: t.String({ minLength: 1 }) }),
     detail: { tags: ['vector'], summary: 'Remove a vector collection config' },
   })
-  .put('/vector/config/:collection', ({ params, body, set }) => {
+  .put('/vector/config/:collection', async ({ params, body, set }) => {
     const update = normalizedUpdate(body);
     if ('error' in update) {
       set.status = 400;
@@ -157,7 +170,8 @@ export const vectorConfigApiEndpoint = new Elysia()
     };
     const next = update.primary ? withPrimary(nextBase, key) : nextBase;
     const path = atomicWriteVectorConfig(next);
-    return { success: true, source, path, collection: key, config: next };
+    await closeCachedVectorStores();
+    return { success: true, reloaded: true, source, path, collection: key, config: next };
   }, {
     params: t.Object({ collection: t.String({ minLength: 1 }) }),
     body: updateSchema,

--- a/src/routes/vector/index.ts
+++ b/src/routes/vector/index.ts
@@ -37,6 +37,7 @@ import { vectorProxyEndpoint } from './proxy.ts';
 import { vectorDocumentsEndpoint } from './documents.ts';
 import { vectorExportEndpoint } from './export.ts';
 import { vectorServicesApiEndpoint } from './services.ts';
+import { vectorProvidersEndpoint } from './providers.ts';
 
 export const vectorRoutes = new Elysia({ prefix: '/api' })
   .use(vectorProxyEndpoint)
@@ -51,5 +52,6 @@ export const vectorRoutes = new Elysia({ prefix: '/api' })
   .use(vectorDocumentsEndpoint)
   .use(vectorExportEndpoint)
   .use(vectorConfigApiEndpoint)
+  .use(vectorProvidersEndpoint)
   .use(vectorServicesApiEndpoint)
   .use(vectorIndexerEndpoints);

--- a/src/routes/vector/providers.ts
+++ b/src/routes/vector/providers.ts
@@ -1,0 +1,72 @@
+import { Elysia, t } from 'elysia';
+import { createEmbeddingProvider } from '../../vector/embeddings.ts';
+import {
+  getDetectedEmbeddingProviders,
+  type ProviderDetectionOptions,
+} from '../../vector/provider-detection.ts';
+import type { EmbeddingProviderType } from '../../vector/types.ts';
+
+export interface VectorProvidersEndpointOptions extends ProviderDetectionOptions {
+  createProvider?: typeof createEmbeddingProvider;
+}
+
+const providerSchema = t.Union([
+  t.Literal('none'),
+  t.Literal('local'),
+  t.Literal('remote'),
+  t.Literal('chromadb-internal'),
+  t.Literal('ollama'),
+  t.Literal('openai'),
+  t.Literal('gemini'),
+  t.Literal('cloudflare-ai'),
+]);
+
+export function createVectorProvidersEndpoint(options: VectorProvidersEndpointOptions = {}) {
+  return new Elysia()
+    .get('/vector/providers', async () => {
+      const result = await getDetectedEmbeddingProviders(true, options);
+      return {
+        ...result,
+        providers: result.providers.map((provider) => ({
+          ...provider,
+          status: provider.available ? 'available' : 'unavailable',
+        })),
+      };
+    }, {
+      detail: { tags: ['vector'], summary: 'Detected embedding providers and capabilities' },
+    })
+    .post('/vector/providers/test', async ({ body, set }) => {
+      const createProvider = options.createProvider ?? createEmbeddingProvider;
+      try {
+        const provider = createProvider(body.provider, body.model, {
+          url: body.url,
+          dimensions: body.dimensions,
+        });
+        const vectors = await provider.embed([body.text ?? 'oracle provider probe'], 'query');
+        return {
+          success: true,
+          provider: provider.name,
+          dimensions: vectors[0]?.length ?? provider.dimensions,
+          model: body.model,
+        };
+      } catch (error) {
+        set.status = 503;
+        return {
+          success: false,
+          provider: body.provider,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    }, {
+      body: t.Object({
+        provider: providerSchema,
+        model: t.Optional(t.String()),
+        url: t.Optional(t.String()),
+        dimensions: t.Optional(t.Number()),
+        text: t.Optional(t.String()),
+      }),
+      detail: { tags: ['vector'], summary: 'Test one embedding provider configuration' },
+    });
+}
+
+export const vectorProvidersEndpoint = createVectorProvidersEndpoint();

--- a/src/vector/config.ts
+++ b/src/vector/config.ts
@@ -141,7 +141,13 @@ export function writeVectorConfig(config: VectorServerConfig, fp = configPath())
 }
 
 function embedderFor(config: VectorServerConfig, col: VectorCollectionConfig): EmbedderConfig | undefined {
-  if (config.embedder) return { ...config.embedder, model: config.embedder.model ?? col.model };
+  if (config.embedder) {
+    return {
+      ...config.embedder,
+      backend: config.embedder.backend ?? config.embedder.default ?? 'none',
+      model: config.embedder.model ?? col.model,
+    };
+  }
   const provider = col.provider.toLowerCase();
   if (provider === 'ollama' || provider === 'local') return { backend: 'local', model: col.model };
   if (provider === 'openai' || provider === 'gemini' || provider === 'cloudflare-ai') {

--- a/src/vector/embeddings.ts
+++ b/src/vector/embeddings.ts
@@ -214,7 +214,7 @@ function createSingleEmbeddingProvider(
       return new NoneEmbeddings();
     case 'local':
     case 'ollama':
-      return new OllamaEmbeddings({ model });
+      return new OllamaEmbeddings({ model, baseUrl: options.url });
     case 'remote':
       return new RemoteHttpEmbeddings({ model, url: options.url, dimensions: options.dimensions });
     case 'openai':

--- a/src/vector/factory.ts
+++ b/src/vector/factory.ts
@@ -60,7 +60,6 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
     || 'lancedb';
 
   const collectionName = config.collectionName || COLLECTION_NAME;
-
   switch (type) {
     case 'sqlite-vec': {
       const dbPath = config.dataPath
@@ -69,7 +68,6 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
 
       return new SqliteVecAdapter(collectionName, dbPath, createConfiguredEmbedder(config));
     }
-
     case 'lancedb': {
       const dbPath = config.dataPath
         || process.env.ORACLE_VECTOR_DB_PATH
@@ -77,14 +75,12 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
 
       return new LanceDBAdapter(collectionName, dbPath, createConfiguredEmbedder(config));
     }
-
     case 'qdrant': {
       return new QdrantAdapter(collectionName, createConfiguredEmbedder(config), {
         url: config.qdrantUrl || process.env.QDRANT_URL,
         apiKey: config.qdrantApiKey || process.env.QDRANT_API_KEY,
       });
     }
-
     case 'cloudflare-vectorize': {
       const cfConfig = {
         accountId: config.cfAccountId || process.env.CLOUDFLARE_ACCOUNT_ID,
@@ -101,7 +97,6 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
 
       return new CloudflareVectorizeAdapter(collectionName, embedder, cfConfig);
     }
-
     case 'proxy': {
       const proxyUrl = config.proxyEndpoint || process.env.ORACLE_PROXY_VECTOR_URL;
       if (!proxyUrl) {
@@ -109,7 +104,6 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
       }
       return new ProxyVectorAdapter(collectionName, proxyUrl);
     }
-
     case 'chroma':
     default: {
       const dataPath = config.dataPath || CHROMADB_DIR;
@@ -164,7 +158,6 @@ export function getEmbeddingModels(
     },
   };
 }
-
 export const EMBEDDING_MODELS = new Proxy({} as Record<string, EmbeddingModelConfig>, {
   get(_, prop: string) { return getEmbeddingModels()[prop]; },
   has(_, prop: string) { return prop in getEmbeddingModels(); },
@@ -177,9 +170,7 @@ export const EMBEDDING_MODELS = new Proxy({} as Record<string, EmbeddingModelCon
 });
 
 const modelStoreCache = new Map<string, VectorStoreAdapter>();
-
 const connectPromises = new Map<string, Promise<void>>();
-
 export function createVectorStoreForModel(preset: EmbeddingModelConfig): VectorStoreAdapter {
   return createVectorStore({
     type: preset.adapter || 'lancedb',
@@ -188,7 +179,8 @@ export function createVectorStoreForModel(preset: EmbeddingModelConfig): VectorS
     embeddingModel: preset.embedder?.model || preset.model,
     embeddingUrl: preset.embedder?.url,
     embeddingDimensions: preset.embedder?.dimensions,
-    embeddingFallbackChain: preset.embedder?.fallbackChain,
+    embeddingFallbackChain: preset.embedder?.fallbackChain
+      ?? (preset.embedder?.fallback ? [preset.embedder.fallback] : undefined),
     proxyEndpoint: preset.endpoint,
     ...(preset.dataPath && { dataPath: preset.dataPath }),
   });

--- a/src/vector/provider-detection.ts
+++ b/src/vector/provider-detection.ts
@@ -1,0 +1,100 @@
+import type { EmbeddingProviderType } from './types.ts';
+
+export interface DetectedEmbeddingProvider {
+  type: EmbeddingProviderType;
+  available: boolean;
+  configured: boolean;
+  source: 'env' | 'probe';
+  models: string[];
+  capabilities: string[];
+  error?: string;
+}
+
+export interface ProviderDetectionOptions {
+  env?: NodeJS.ProcessEnv;
+  fetcher?: typeof fetch;
+  ollamaUrl?: string;
+  timeoutMs?: number;
+}
+
+let cached: { checkedAt: string; providers: DetectedEmbeddingProvider[] } | null = null;
+
+function has(env: NodeJS.ProcessEnv, ...keys: string[]): boolean {
+  return keys.some((key) => Boolean(env[key]?.trim()));
+}
+
+function provider(
+  type: EmbeddingProviderType,
+  configured: boolean,
+  extras: Partial<DetectedEmbeddingProvider> = {},
+): DetectedEmbeddingProvider {
+  return {
+    type,
+    configured,
+    available: configured,
+    source: 'env',
+    models: [],
+    capabilities: ['embed'],
+    ...extras,
+  };
+}
+
+async function detectOllama(options: ProviderDetectionOptions): Promise<DetectedEmbeddingProvider> {
+  const fetcher = options.fetcher ?? fetch;
+  const base = options.ollamaUrl || options.env?.OLLAMA_BASE_URL || 'http://localhost:11434';
+  try {
+    const res = await fetcher(`${base}/api/tags`, { signal: AbortSignal.timeout(options.timeoutMs ?? 1500) });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json() as { models?: Array<{ name?: string }> };
+    const models = (data.models ?? []).map((item) => item.name).filter(Boolean) as string[];
+    return provider('ollama', true, {
+      source: 'probe',
+      available: true,
+      models,
+      capabilities: ['embed', 'local', 'models:list'],
+    });
+  } catch (error) {
+    return provider('ollama', false, {
+      source: 'probe',
+      available: false,
+      capabilities: ['embed', 'local', 'models:list'],
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export async function detectEmbeddingProviders(
+  options: ProviderDetectionOptions = {},
+): Promise<{ checkedAt: string; providers: DetectedEmbeddingProvider[] }> {
+  const env = options.env ?? process.env;
+  const cfConfigured = has(env, 'CF_ACCOUNT_ID', 'CLOUDFLARE_ACCOUNT_ID')
+    && has(env, 'CF_API_TOKEN', 'CLOUDFLARE_API_TOKEN');
+  const providers = [
+    await detectOllama({ ...options, env }),
+    provider('openai', has(env, 'OPENAI_API_KEY'), {
+      models: has(env, 'OPENAI_API_KEY') ? ['text-embedding-3-small', 'text-embedding-3-large'] : [],
+      capabilities: ['embed', 'remote'],
+    }),
+    provider('gemini', has(env, 'GEMINI_API_KEY'), {
+      models: has(env, 'GEMINI_API_KEY') ? ['text-embedding-004'] : [],
+      capabilities: ['embed', 'remote', 'free-tier'],
+    }),
+    provider('cloudflare-ai', cfConfigured, {
+      models: cfConfigured ? ['@cf/baai/bge-base-en-v1.5'] : [],
+      capabilities: ['embed', 'remote', 'edge'],
+    }),
+  ];
+  return { checkedAt: new Date().toISOString(), providers };
+}
+
+export async function getDetectedEmbeddingProviders(
+  force = false,
+  options: ProviderDetectionOptions = {},
+): Promise<{ checkedAt: string; providers: DetectedEmbeddingProvider[] }> {
+  if (!cached || force) cached = await detectEmbeddingProviders(options);
+  return cached;
+}
+
+export function clearProviderDetectionCache(): void {
+  cached = null;
+}

--- a/src/vector/types.ts
+++ b/src/vector/types.ts
@@ -68,11 +68,14 @@ export interface EmbeddingProvider {
 export type EmbedderBackend = 'none' | 'local' | 'remote' | 'ollama' | 'openai' | 'gemini' | 'cloudflare-ai';
 
 export interface EmbedderConfig {
-  backend: EmbedderBackend;
+  backend?: EmbeddingProviderType;
   url?: string;
   model?: string;
   dimensions?: number;
   fallbackChain?: EmbeddingProviderType[];
+  default?: EmbeddingProviderType;
+  fallback?: EmbeddingProviderType;
+  fallbackModel?: string;
 }
 
 export type VectorDBType =

--- a/tests/http/vector/config-api.test.ts
+++ b/tests/http/vector/config-api.test.ts
@@ -137,6 +137,15 @@ test('GET and PUT /api/v1/vector/config expose and update vector-server.json', a
   expect(removeRes.body.removed).toBe('phase2');
   expect(removeRes.body.config.collections.phase2).toBeUndefined();
 
+const patchRes = await call('/api/v1/vector/config', {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ embedder: { default: 'ollama', fallback: 'openai' } }),
+  });
+  expect(patchRes.status).toBe(200);
+  expect(patchRes.body).toMatchObject({ success: true, reloaded: true, source: 'file' });
+  expect(patchRes.body.config.embedder).toMatchObject({ default: 'ollama', fallback: 'openai' });
+
   const reloadRes = await call('/api/v1/vector/config/reload', { method: 'POST' });
   expect(reloadRes.status).toBe(200);
   expect(reloadRes.body).toMatchObject({ success: true, reloaded: true, source: 'file' });

--- a/tests/http/vector/providers.test.ts
+++ b/tests/http/vector/providers.test.ts
@@ -1,0 +1,45 @@
+import { expect, mock, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createVectorProvidersEndpoint } from '../../../src/routes/vector/providers.ts';
+import type { EmbeddingProvider } from '../../../src/vector/types.ts';
+
+function fetcher() {
+  const tags = mock(async () => new Response(JSON.stringify({
+    models: [{ name: 'bge-m3' }, { name: 'nomic-embed-text' }],
+  }), { status: 200 }));
+  const app = new Elysia({ prefix: '/api' }).use(createVectorProvidersEndpoint({
+    env: { OPENAI_API_KEY: 'sk-test', GEMINI_API_KEY: 'g-test' },
+    fetcher: tags as unknown as typeof fetch,
+    createProvider: (provider): EmbeddingProvider => ({
+      name: provider,
+      dimensions: 3,
+      embed: mock(async () => [[1, 2, 3]]),
+    }),
+  }));
+  return createApiVersionedFetch((request) => app.handle(request));
+}
+
+test('GET /api/v1/vector/providers returns detected providers and capabilities', async () => {
+  const res = await fetcher()(new Request('http://local/api/v1/vector/providers'));
+  const body = await res.json() as { providers: Array<Record<string, unknown>> };
+
+  expect(res.status).toBe(200);
+  expect(body.providers).toContainEqual(expect.objectContaining({
+    type: 'ollama', status: 'available', models: ['bge-m3', 'nomic-embed-text'],
+  }));
+  expect(body.providers).toContainEqual(expect.objectContaining({ type: 'openai', available: true }));
+  expect(body.providers).toContainEqual(expect.objectContaining({ type: 'gemini', available: true }));
+});
+
+test('POST /api/v1/vector/providers/test probes one provider config', async () => {
+  const res = await fetcher()(new Request('http://local/api/v1/vector/providers/test', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ provider: 'gemini', model: 'text-embedding-004', text: 'hello' }),
+  }));
+  const body = await res.json() as Record<string, unknown>;
+
+  expect(res.status).toBe(200);
+  expect(body).toMatchObject({ success: true, provider: 'gemini', dimensions: 3 });
+});


### PR DESCRIPTION
## Summary
- add Gemini embedding provider support and provider auto-detection for Ollama/OpenAI/Gemini/Cloudflare
- add `/api/vector/providers` and `/api/vector/providers/test`
- add vector config PATCH + hot-reload cache clearing and fallback provider config wiring

## Tests
- `bunx tsc --noEmit`
- `bun test tests/http/vector/ tests/vector/config-provider-global-embedder.test.ts tests/vector/config-provider-local.test.ts tests/vector/config-provider-none.test.ts tests/vector/config-provider-remote.test.ts tests/vector/factory-model-remote.test.ts`

Closes #1437
