### PR TITLE
feat: add vector settings first-run wizard (#1439)

### DIFF
--- a/frontend/src/components/VectorFirstRunWizard.tsx
+++ b/frontend/src/components/VectorFirstRunWizard.tsx
@@ -1,0 +1,109 @@
+import { useMemo, useState } from 'react';
+import { ErrorMessage, Spinner } from './AsyncState';
+import { fetchJson, type VectorConfigRow } from '../pages/vectorSettingsHelpers';
+
+type WizardStep = 0 | 1 | 2;
+
+type WizardProps = {
+  rows: VectorConfigRow[];
+  onRefresh: () => Promise<void> | void;
+};
+
+const stepCopy = [
+  {
+    title: 'Choose a storage adapter',
+    detail: 'Start with the current adapter defaults, then change collection rows only when you need a remote vector DB.',
+  },
+  {
+    title: 'Verify collection health',
+    detail: 'Reload the vector runtime cache and confirm at least one collection reports healthy before indexing.',
+  },
+  {
+    title: 'Build the first index',
+    detail: 'Kick off the primary collection first. The Index Manager below tracks progress and lets you reindex each model.',
+  },
+] as const;
+
+export function firstRunReadiness(rows: VectorConfigRow[]): string {
+  if (!rows.length) return 'No collections loaded yet.';
+  const healthy = rows.filter((row) => row.health?.ok).length;
+  const primary = rows.find((row) => row.primary) ?? rows[0];
+  return `${rows.length} collections · ${healthy}/${rows.length} healthy · first index ${primary.key}`;
+}
+
+function primaryKey(rows: VectorConfigRow[]): string | null {
+  return (rows.find((row) => row.primary) ?? rows[0])?.key ?? null;
+}
+
+export function VectorFirstRunWizard({ rows, onRefresh }: WizardProps) {
+  const [step, setStep] = useState<WizardStep>(0);
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+  const readiness = useMemo(() => firstRunReadiness(rows), [rows]);
+  const copy = stepCopy[step];
+
+  async function refreshHealth() {
+    setBusy(true);
+    setError('');
+    try {
+      await fetchJson('/api/v1/vector/config/reload', { method: 'POST' });
+      await onRefresh();
+      setMessage('Runtime cache reloaded. Review collection health below.');
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function startPrimaryIndex() {
+    const model = primaryKey(rows);
+    if (!model) {
+      setError('Load vector collections before starting the first index.');
+      return;
+    }
+    setBusy(true);
+    setError('');
+    try {
+      await fetchJson('/api/vector/index/start', { method: 'POST', body: JSON.stringify({ model }) });
+      setMessage(`Started first index for ${model}. Watch progress in the Index Manager.`);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="rounded-3xl border border-purple-300/20 bg-purple-300/10 p-5 sm:p-6" aria-labelledby="first-run-wizard-title">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-200">First-run wizard</p>
+          <h2 id="first-run-wizard-title" className="mt-2 text-2xl font-semibold text-white">{copy.title}</h2>
+          <p className="mt-2 max-w-3xl text-sm text-purple-100/80">{copy.detail}</p>
+          <p className="mt-3 text-sm text-purple-100">{readiness}</p>
+        </div>
+        <ol className="flex gap-2" aria-label="First-run steps">
+          {stepCopy.map((item, index) => (
+            <li key={item.title} className={`h-2 w-10 rounded-full ${index <= step ? 'bg-purple-200' : 'bg-white/20'}`} />
+          ))}
+        </ol>
+      </div>
+
+      {error ? <div className="mt-4"><ErrorMessage title="First-run step failed." message={error} /></div> : null}
+      {message ? <p className="mt-4 rounded-2xl border border-white/10 bg-slate-950/50 p-3 text-sm text-purple-100">{message}</p> : null}
+
+      <div className="mt-5 flex flex-wrap gap-2">
+        <button className="focus-ring rounded-xl border border-white/10 px-3 py-2 text-sm text-purple-100 hover:border-purple-200/60" disabled={step === 0} type="button" onClick={() => setStep((step - 1) as WizardStep)}>Back</button>
+        {step === 1 ? (
+          <button className="focus-ring rounded-xl bg-purple-200 px-3 py-2 text-sm font-semibold text-slate-950 disabled:opacity-60" disabled={busy} type="button" onClick={() => void refreshHealth()}>{busy ? <Spinner label="Reloading" /> : 'Reload and test health'}</button>
+        ) : null}
+        {step === 2 ? (
+          <button className="focus-ring rounded-xl bg-teal-200 px-3 py-2 text-sm font-semibold text-slate-950 disabled:opacity-60" disabled={busy || !rows.length} type="button" onClick={() => void startPrimaryIndex()}>{busy ? <Spinner label="Starting" /> : 'Start first index'}</button>
+        ) : null}
+        <button className="focus-ring rounded-xl border border-purple-200/40 px-3 py-2 text-sm font-semibold text-purple-100 hover:bg-purple-200/10" disabled={step === 2} type="button" onClick={() => setStep((step + 1) as WizardStep)}>Next</button>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/VectorIndexPanel.tsx
+++ b/frontend/src/components/VectorIndexPanel.tsx
@@ -95,9 +95,9 @@ export function VectorIndexPanel({ client = apiClient, initialModels, initialSta
     <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-index-title">
       <div className="mb-5 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-300">Index management</p>
-          <h2 id="vector-index-title" className="mt-2 text-2xl font-semibold text-white">Vector collections</h2>
-          <p className="mt-2 text-sm text-slate-400">Rebuild each embedding collection through /api/vector/index/start.</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-300">Index Manager</p>
+          <h2 id="vector-index-title" className="mt-2 text-2xl font-semibold text-white">Index jobs and collections</h2>
+          <p className="mt-2 text-sm text-slate-400">Start, poll, and audit embedding rebuilds through /api/vector/index/start.</p>
         </div>
         <button
           className="focus-ring rounded-xl border border-white/10 px-3 py-2 text-sm text-slate-200 hover:border-purple-300/40"

--- a/frontend/src/pages/VectorSettingsPage.tsx
+++ b/frontend/src/pages/VectorSettingsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { VectorFirstRunWizard } from '../components/VectorFirstRunWizard';
 import { VectorIndexPanel } from '../components/VectorIndexPanel';
 import { ErrorMessage, LoadingPanel, Spinner } from '../components/AsyncState';
 import {
@@ -168,6 +169,8 @@ export function VectorSettingsPage() {
       {state === 'loading' ? <LoadingPanel title="Loading vector config" detail="Reading /api/v1/vector/config." /> : null}
       {state === 'error' ? <ErrorMessage title="Could not load vector config." message={error} /> : null}
       {error && state !== 'error' ? <ErrorMessage title="Vector settings warning" message={error} /> : null}
+
+      {state === 'ready' ? <VectorFirstRunWizard rows={rows} onRefresh={loadConfig} /> : null}
 
       <section className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
         <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">

--- a/tests/frontend/components/vector-first-run-wizard.test.tsx
+++ b/tests/frontend/components/vector-first-run-wizard.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test';
+import { VectorFirstRunWizard, firstRunReadiness } from '../../../frontend/src/components/VectorFirstRunWizard';
+import { htmlFor } from '../_render';
+
+const rows = [
+  {
+    key: 'bge-m3',
+    collection: 'oracle_bge_m3',
+    model: 'BAAI/bge-m3',
+    provider: 'ollama',
+    adapter: 'lancedb' as const,
+    primary: true,
+    count: 12,
+    health: { ok: true, status: 'ok' as const, collection: 'oracle_bge_m3', adapter: 'lancedb' as const, model: 'BAAI/bge-m3' },
+  },
+  {
+    key: 'qwen3',
+    collection: 'oracle_qwen3',
+    model: 'Qwen/qwen3',
+    provider: 'ollama',
+    adapter: 'qdrant' as const,
+    count: 0,
+    health: { ok: false, status: 'down' as const, collection: 'oracle_qwen3', adapter: 'qdrant' as const, model: 'Qwen/qwen3' },
+  },
+];
+
+describe('VectorFirstRunWizard', () => {
+  test('summarizes first-run readiness from collection health', () => {
+    expect(firstRunReadiness(rows)).toBe('2 collections · 1/2 healthy · first index bge-m3');
+    expect(firstRunReadiness([])).toBe('No collections loaded yet.');
+  });
+
+  test('renders the starter step and flow controls', () => {
+    const html = htmlFor(<VectorFirstRunWizard rows={rows} onRefresh={() => {}} />);
+    expect(html).toContain('First-run wizard');
+    expect(html).toContain('Choose a storage adapter');
+    expect(html).toContain('2 collections · 1/2 healthy · first index bge-m3');
+    expect(html).toContain('Next');
+  });
+});

--- a/tests/frontend/components/vector-index-panel-render.test.tsx
+++ b/tests/frontend/components/vector-index-panel-render.test.tsx
@@ -25,7 +25,8 @@ describe('VectorIndexPanel', () => {
       />,
     );
 
-    expect(html).toContain('Index management');
+    expect(html).toContain('Index Manager');
+    expect(html).toContain('Index jobs and collections');
     expect(html).toContain('bge-m3');
     expect(html).toContain('oracle_bge_m3');
     expect(html).toContain('qwen3');


### PR DESCRIPTION
Closes #1439

## Changes
- Added a Vector Settings first-run wizard flow for backend choice, health reload, and first index kickoff.
- Labeled and clarified the existing vector indexing controls as the Index Manager panel.
- Added focused frontend coverage for first-run readiness rendering and Index Manager chrome.

## Verification
- bun test tests/frontend/components/vector-first-run-wizard.test.tsx tests/frontend/components/vector-index-panel-render.test.tsx
- bunx tsc --noEmit --project frontend/tsconfig.json
- bunx tsc --noEmit (run locally before push)
