### PR TITLE
fix(core): harden request log format labels

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -4,6 +4,7 @@ export const KNOWN_ENV_KEYS = [
   'HOME',
   'USERPROFILE',
   'ARRA_ENV',
+  'LOG_FORMAT',
   'PORT',
   'DATABASE_URL',
   'VECTOR_URL',

--- a/src/middleware/logger.ts
+++ b/src/middleware/logger.ts
@@ -4,6 +4,7 @@ type RequestMeta = {
   startedAt: number;
   correlationId: string;
   headers: Record<string, string>;
+  sandbox: string;
 };
 
 type RequestContext = {
@@ -24,6 +25,7 @@ export type RequestLogEntry = {
   durationMs: number;
   correlationId: string;
   headers: Record<string, string>;
+  sandbox: string;
 };
 
 export type RequestLogFormat = 'json' | 'nginx' | 'short';
@@ -70,7 +72,14 @@ function responseStatus(responseValue: unknown, setStatus?: number | string): nu
 
 function requestLogFormat(): RequestLogFormat {
   const requested = process.env.LOG_FORMAT as RequestLogFormat | undefined;
-  return requested && logFormats.has(requested) ? requested : 'json';
+  return requested && logFormats.has(requested) ? requested : 'nginx';
+}
+
+function sandboxLabel(env = process.env.ARRA_ENV): string {
+  const value = env?.trim().toLowerCase();
+  if (value === 'production') return 'prod';
+  if (value === 'staging') return 'staging';
+  return 'dev';
 }
 
 function formatDurationMs(durationMs: number): string {
@@ -89,6 +98,7 @@ export function formatRequestLog(entry: RequestLogEntry, format: RequestLogForma
       entry.status,
       formatDurationMs(entry.durationMs),
       `[${shortCorrelationId(entry.correlationId)}]`,
+      `[${entry.sandbox}]`,
     ].join(' ');
   }
 
@@ -113,7 +123,7 @@ export function createRequestLogger(options: RequestLoggerOptions = {}) {
   return {
     onRequest({ request, set }: RequestContext) {
       const correlationId = requestCorrelationId(request);
-      metaByRequest.set(request, { startedAt: now(), correlationId, headers: redactHeaders(request.headers) });
+      metaByRequest.set(request, { startedAt: now(), correlationId, headers: redactHeaders(request.headers), sandbox: sandboxLabel() });
       set.headers['X-Correlation-Id'] = correlationId;
     },
     onAfterResponse({ request, responseValue, set }: AfterResponseContext) {
@@ -129,6 +139,7 @@ export function createRequestLogger(options: RequestLoggerOptions = {}) {
         durationMs,
         correlationId: meta?.correlationId ?? requestCorrelationId(request),
         headers: meta?.headers ?? redactHeaders(request.headers),
+        sandbox: meta?.sandbox ?? sandboxLabel(),
       });
       metaByRequest.delete(request);
     },

--- a/tests/http/logger/format.test.ts
+++ b/tests/http/logger/format.test.ts
@@ -18,11 +18,15 @@ function restoreLogFormat(value: string | undefined) {
   else process.env.LOG_FORMAT = value;
 }
 
-async function captureLogLine(format: string): Promise<string> {
+async function captureLogLine(format: string | undefined, env?: string): Promise<string> {
   const lines: string[] = [];
   const originalLog = console.log;
   const originalFormat = process.env.LOG_FORMAT;
-  process.env.LOG_FORMAT = format;
+  const originalEnv = process.env.ARRA_ENV;
+  if (format === undefined) delete process.env.LOG_FORMAT;
+  else process.env.LOG_FORMAT = format;
+  if (env === undefined) delete process.env.ARRA_ENV;
+  else process.env.ARRA_ENV = env;
   console.log = (message?: unknown) => {
     lines.push(String(message));
   };
@@ -45,6 +49,8 @@ async function captureLogLine(format: string): Promise<string> {
   } finally {
     console.log = originalLog;
     restoreLogFormat(originalFormat);
+    if (originalEnv === undefined) delete process.env.ARRA_ENV;
+    else process.env.ARRA_ENV = originalEnv;
   }
 }
 
@@ -57,8 +63,13 @@ test('LOG_FORMAT selects json, nginx, and short request log output', async () =>
     status: 200,
     durationMs: 1.37,
     correlationId: CORRELATION_ID,
+    sandbox: 'dev',
   });
 
-  expect(await captureLogLine('nginx')).toBe('GET /api/health 200 1.37ms [abcdef12]');
+  expect(await captureLogLine('nginx')).toBe('GET /api/health 200 1.37ms [abcdef12] [dev]');
   expect(await captureLogLine('short')).toBe('200 GET /api/health 1ms');
+});
+
+test('LOG_FORMAT defaults to nginx and labels production sandbox', async () => {
+  expect(await captureLogLine(undefined, 'production')).toBe('GET /api/health 200 1.37ms [abcdef12] [prod]');
 });

--- a/tests/http/logging/request-log.test.ts
+++ b/tests/http/logging/request-log.test.ts
@@ -14,6 +14,8 @@ async function waitForLog(logs: string[]): Promise<string> {
 test('request logger emits structured JSON and redacts Authorization headers', async () => {
   const lines: string[] = [];
   const original = console.log;
+  const originalFormat = process.env.LOG_FORMAT;
+  process.env.LOG_FORMAT = 'json';
   console.log = (message?: unknown) => {
     lines.push(String(message));
   };
@@ -44,10 +46,13 @@ test('request logger emits structured JSON and redacts Authorization headers', a
       status: 201,
       correlationId: 'test-correlation-id',
       headers: { authorization: '[REDACTED]', 'x-correlation-id': 'test-correlation-id' },
+      sandbox: 'dev',
     });
     expect(typeof entry.durationMs).toBe('number');
     expect(entry.durationMs).toBeGreaterThanOrEqual(0);
   } finally {
     console.log = original;
+    if (originalFormat === undefined) delete process.env.LOG_FORMAT;
+    else process.env.LOG_FORMAT = originalFormat;
   }
 });


### PR DESCRIPTION
Implements remaining #1597 core hardening items around request logging and environment labeling.

Changes:
- LOG_FORMAT now defaults to dev-friendly nginx output and still supports json/short.
- Structured JSON request logs include a sandbox label (dev/staging/prod).
- Nginx-format logs include the sandbox label for dev/prod operations visibility.
- LOG_FORMAT is registered as a known env key.

Notes:
- Plugin entry path containment/security validation and error-containment labeling are already present on alpha; targeted tests were run to verify them.

Validation:
- bunx tsc --noEmit
- bun test tests/http/logger/format.test.ts tests/http/logging/request-log.test.ts tests/plugins/path-containment.test.ts tests/plugins/sandbox.test.ts