### PR TITLE
feat: add tenant-scoped HTTP context

### DIFF
--- a/src/middleware/tenant.ts
+++ b/src/middleware/tenant.ts
@@ -1,0 +1,78 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { Elysia } from 'elysia';
+import { eq, type SQL } from 'drizzle-orm';
+
+export const TENANT_HEADER = 'X-Oracle-Tenant';
+export const LEGACY_TENANT_HEADER = 'X-Tenant-Id';
+export const ORG_HEADER = 'X-Org-Id';
+const TENANT_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/;
+
+type TenantContext = { tenantId?: string };
+type ProjectColumn = { project: unknown };
+type FetchHandler = (request: Request) => Response | Promise<Response>;
+
+const tenantStore = new AsyncLocalStorage<TenantContext>();
+const tenants = new WeakMap<Request, string | undefined>();
+
+export function tenantIdFromHeaders(headers: Headers): string | undefined {
+  const raw = headers.get(TENANT_HEADER) ?? headers.get(LEGACY_TENANT_HEADER) ?? headers.get(ORG_HEADER);
+  const tenant = raw?.trim();
+  if (!tenant) return undefined;
+  if (!TENANT_PATTERN.test(tenant)) throw new Error('invalid tenant id');
+  return tenant;
+}
+
+export function rememberTenant(request: Request, tenantId: string | undefined): void {
+  tenants.set(request, tenantId);
+}
+
+export function tenantIdFor(request: Request): string | undefined {
+  if (tenants.has(request)) return tenants.get(request);
+  const tenantId = tenantIdFromHeaders(request.headers);
+  rememberTenant(request, tenantId);
+  return tenantId;
+}
+
+export function currentTenantId(): string | undefined {
+  return tenantStore.getStore()?.tenantId;
+}
+
+export function runWithTenant<T>(tenantId: string | undefined, callback: () => T): T {
+  return tenantStore.run({ tenantId }, callback);
+}
+
+export function tenantProjectWhere<T extends ProjectColumn>(table: T): SQL | undefined {
+  const tenantId = currentTenantId();
+  return tenantId ? eq(table.project as never, tenantId) : undefined;
+}
+
+export function createTenantMiddleware() {
+  return new Elysia({ name: 'tenant-context' })
+    .derive({ as: 'global' }, ({ request, set }) => {
+      try {
+        const tenantId = tenantIdFor(request);
+        if (tenantId) set.headers[TENANT_HEADER] = tenantId;
+        return { tenantId };
+      } catch (error) {
+        set.status = 400;
+        return { tenantId: undefined, tenantError: error instanceof Error ? error.message : String(error) };
+      }
+    })
+    .onBeforeHandle({ as: 'global' }, ({ tenantError }) => {
+      if (tenantError) return { error: tenantError };
+    })
+    .onRequest(({ request }) => {
+      tenantIdFor(request);
+    });
+}
+
+export function createTenantFetch(next: FetchHandler): FetchHandler {
+  return (request) => {
+    try {
+      const tenantId = tenantIdFor(request);
+      return runWithTenant(tenantId, () => next(request));
+    } catch (error) {
+      return Response.json({ error: error instanceof Error ? error.message : String(error) }, { status: 400 });
+    }
+  };
+}

--- a/src/routes/health/oracles.ts
+++ b/src/routes/health/oracles.ts
@@ -1,45 +1,55 @@
 import { Elysia } from 'elysia';
 import { sqlite } from '../../db/index.ts';
+import { currentTenantId } from '../../middleware/tenant.ts';
 import { OraclesQuery } from './model.ts';
 
-let oracleCache: { data: unknown; ts: number } | null = null;
+let oracleCache: { data: unknown; ts: number; key: string } | null = null;
 
 export const oraclesEndpoint = new Elysia().get('/oracles', ({ query }) => {
   const parsed = parseInt(query.hours ?? '168');
   const hours = Number.isFinite(parsed) ? parsed : 168;
   const now = Date.now();
-  if (oracleCache && (now - oracleCache.ts) < 60_000) return oracleCache.data;
+  const tenantId = currentTenantId();
+  const cacheKey = `${tenantId ?? '*'}:${hours}`;
+  if (oracleCache && oracleCache.key === cacheKey && (now - oracleCache.ts) < 60_000) return oracleCache.data;
 
   const cutoff = now - hours * 3600_000;
+  const docProjectWhere = tenantId ? 'AND project = ?' : '';
+  const learnProjectWhere = tenantId ? 'AND project = ?' : '';
+  const traceProjectWhere = tenantId ? 'AND project = ?' : '';
+  const forumProjectWhere = tenantId ? 'AND forum_threads.project = ?' : '';
+  const tenantArg = tenantId ? [tenantId] : [];
   const identities = sqlite.prepare(`
     SELECT oracle_name, source, max(last_seen) as last_seen, sum(actions) as actions
     FROM (
-      SELECT author as oracle_name, 'forum' as source, max(created_at) as last_seen, count(*) as actions
-        FROM forum_messages WHERE author IS NOT NULL AND created_at > ?
+      SELECT author as oracle_name, 'forum' as source, max(forum_messages.created_at) as last_seen, count(*) as actions
+        FROM forum_messages
+        LEFT JOIN forum_threads ON forum_threads.id = forum_messages.thread_id
+        WHERE author IS NOT NULL AND forum_messages.created_at > ? ${forumProjectWhere}
         GROUP BY author
       UNION ALL
       SELECT COALESCE(session_id, 'unknown') as oracle_name, 'trace' as source, max(created_at) as last_seen, count(*) as actions
-        FROM trace_log WHERE created_at > ?
+        FROM trace_log WHERE created_at > ? ${traceProjectWhere}
         GROUP BY session_id
       UNION ALL
       SELECT COALESCE(source, project, 'unknown') as oracle_name, 'learn' as source, max(created_at) as last_seen, count(*) as actions
-        FROM learn_log WHERE created_at > ?
+        FROM learn_log WHERE created_at > ? ${learnProjectWhere}
         GROUP BY COALESCE(source, project)
     )
     WHERE oracle_name IS NOT NULL AND oracle_name != 'unknown'
     GROUP BY oracle_name
     ORDER BY last_seen DESC
-  `).all(cutoff, cutoff, cutoff);
+  `).all(cutoff, ...tenantArg, cutoff, ...tenantArg, cutoff, ...tenantArg);
 
   const projects = sqlite.prepare(`
     SELECT project, count(*) as docs,
            count(DISTINCT type) as types,
            max(created_at) as last_indexed
     FROM oracle_documents
-    WHERE project IS NOT NULL
+    WHERE project IS NOT NULL ${docProjectWhere}
     GROUP BY project
     ORDER BY last_indexed DESC
-  `).all();
+  `).all(...tenantArg);
 
   const result = {
     identities,
@@ -47,9 +57,10 @@ export const oraclesEndpoint = new Elysia().get('/oracles', ({ query }) => {
     total_projects: projects.length,
     total_identities: identities.length,
     window_hours: hours,
+    tenant: tenantId ? { id: tenantId, scope: 'project' } : undefined,
     cached_at: new Date().toISOString(),
   };
-  oracleCache = { data: result, ts: now };
+  oracleCache = { data: result, ts: now, key: cacheKey };
   return result;
 }, {
   query: OraclesQuery,

--- a/src/routes/health/stats.ts
+++ b/src/routes/health/stats.ts
@@ -3,10 +3,11 @@ import { DB_PATH } from '../../config.ts';
 import { getSetting, isDbLockError } from '../../db/index.ts';
 import { handleStats } from '../../server/handlers.ts';
 import { handleVectorStats } from '../../server/vector-handlers.ts';
+import { tenantStats } from './tenant-stats.ts';
 
 export const statsEndpoint = new Elysia().get('/stats', async () => {
   try {
-    const stats = handleStats(DB_PATH);
+    const stats = tenantStats() ?? handleStats(DB_PATH);
     const vaultRepo = getSetting('vault_repo');
     let vectorStats = { vector: { enabled: false, count: 0, collection: 'oracle_knowledge' } };
     try {

--- a/src/routes/health/tenant-stats.ts
+++ b/src/routes/health/tenant-stats.ts
@@ -1,0 +1,35 @@
+import { count, eq, sql } from 'drizzle-orm';
+import { db, indexingStatus, oracleDocuments } from '../../db/index.ts';
+import { currentTenantId } from '../../middleware/tenant.ts';
+
+export function tenantStats() {
+  const tenantId = currentTenantId();
+  if (!tenantId) return null;
+
+  const projectScope = eq(oracleDocuments.project, tenantId);
+  const total = db.select({ count: count() })
+    .from(oracleDocuments)
+    .where(projectScope)
+    .get()?.count ?? 0;
+
+  const byTypeRows = db.select({ type: oracleDocuments.type, count: count() })
+    .from(oracleDocuments)
+    .where(projectScope)
+    .groupBy(oracleDocuments.type)
+    .all();
+
+  const last = db.select({ lastIndexed: sql<number | null>`max(${oracleDocuments.indexedAt})` })
+    .from(oracleDocuments)
+    .where(projectScope)
+    .get()?.lastIndexed ?? null;
+
+  const indexing = db.select().from(indexingStatus).where(eq(indexingStatus.id, 1)).get();
+  return {
+    total,
+    total_docs: total,
+    by_type: Object.fromEntries(byTypeRows.map((row) => [row.type, row.count])),
+    last_indexed: last ? new Date(last).toISOString() : null,
+    indexing: Boolean(indexing?.isIndexing),
+    tenant: { id: tenantId, scope: 'project' },
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,6 +32,7 @@ import { createEtagMiddleware } from './middleware/etag.ts';
 import { createCompressMiddleware } from './middleware/compress.ts';
 import { createRequestDedupFetch } from './middleware/dedup.ts';
 import { createDbContextFetch } from './middleware/db-context.ts';
+import { createTenantFetch, createTenantMiddleware } from './middleware/tenant.ts';
 
 import { authRoutes } from './routes/auth/index.ts';
 import { settingsRoutes } from './routes/settings/index.ts';
@@ -114,6 +115,7 @@ const requestLogger = createRequestLogger();
 const app = new Elysia()
   .onRequest(requestLogger.onRequest)
   .use(createCorrelationMiddleware())
+  .use(createTenantMiddleware())
   .use(createPrivateNetworkPreflightMiddleware())
   .use(createCorsMiddleware())
   .use(createApiVersionHeaderMiddleware())
@@ -233,7 +235,7 @@ await runStartupSelfTest({
 });
 
 const serverFetch = createRequestTimeoutFetch(
-  createRequestDedupFetch(createApiVersionedFetch(createDbContextFetch((request: Request) => app.fetch(request)))),
+  createRequestDedupFetch(createApiVersionedFetch(createTenantFetch(createDbContextFetch((request: Request) => app.fetch(request))))),
 );
 
 export default {

--- a/tests/http/health/tenant-scope.test.ts
+++ b/tests/http/health/tenant-scope.test.ts
@@ -1,0 +1,62 @@
+import { afterAll, expect, test } from 'bun:test';
+import { inArray } from 'drizzle-orm';
+import { db, oracleDocuments } from '../../../src/db/index.ts';
+import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
+import { createHealthRoutes } from '../../../src/routes/health/index.ts';
+
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantA = `tenant-a-${stamp}`;
+const tenantB = `tenant-b-${stamp}`;
+const ids = [`tenant-doc-a-${stamp}`, `tenant-doc-b-${stamp}`];
+const now = Date.now();
+
+function insertDoc(id: string, project: string) {
+  db.insert(oracleDocuments).values({
+    id,
+    type: 'learning',
+    sourceFile: `ψ/memory/learnings/${id}.md`,
+    concepts: '[]',
+    createdAt: now,
+    updatedAt: now,
+    indexedAt: now,
+    project,
+  }).run();
+}
+
+insertDoc(ids[0], tenantA);
+insertDoc(ids[1], tenantB);
+
+afterAll(() => {
+  db.delete(oracleDocuments).where(inArray(oracleDocuments.id, ids)).run();
+});
+
+function createFetch() {
+  const app = createHealthRoutes({
+    vectorHealth: async () => ({ status: 'ok', engines: [], checked_at: '2026-06-16T00:00:00.000Z' }),
+  });
+  return createTenantFetch((request) => app.handle(request));
+}
+
+test('GET /api/stats scopes document counts by tenant header', async () => {
+  const res = await createFetch()(new Request('http://local/api/stats', {
+    headers: { [TENANT_HEADER]: tenantA },
+  }));
+  const body = await res.json() as Record<string, any>;
+
+  expect(res.status).toBe(200);
+  expect(body.tenant).toEqual({ id: tenantA, scope: 'project' });
+  expect(body.total).toBe(1);
+  expect(body.by_type.learning).toBe(1);
+});
+
+test('GET /api/oracles scopes project list by tenant header', async () => {
+  const res = await createFetch()(new Request('http://local/api/oracles?hours=1', {
+    headers: { [TENANT_HEADER]: tenantB },
+  }));
+  const body = await res.json() as Record<string, any>;
+
+  expect(res.status).toBe(200);
+  expect(body.tenant).toEqual({ id: tenantB, scope: 'project' });
+  expect(body.projects.map((item: { project: string }) => item.project)).toContain(tenantB);
+  expect(body.projects.map((item: { project: string }) => item.project)).not.toContain(tenantA);
+});


### PR DESCRIPTION
## Summary
- Add canonical X-Oracle-Tenant request context with X-Tenant-Id/X-Org-Id aliases
- Wire tenant context into the server fetch pipeline and Elysia middleware
- Scope /api/stats and /api/oracles reads by tenant-backed project data when a tenant header is present
- Add scoped health tests for tenant-isolated stats and oracle project activity

## Notes
- This is the first isolation slice. It preserves single-tenant behavior without a header and uses existing project fields until an explicit tenant_id migration exists.

## Validation
- bunx tsc --noEmit
- bun test tests/http/health/

Refs #1650