### PR TITLE
feat: add TurboVec proxy sidecar reference (#1438)

### DIFF
--- a/sidecar/turbovec/README.md
+++ b/sidecar/turbovec/README.md
@@ -1,0 +1,28 @@
+# TurboVec sidecar reference
+
+Reference implementation of the Arra vector proxy protocol for Issue #1438.
+It exposes the standard HTTP contract used by `ProxyVectorAdapter`:
+
+- `POST /vectors/add`
+- `POST /vectors/query`
+- `GET /vectors/stats`
+- `DELETE /vectors/collection`
+- `GET /health`
+
+Run locally:
+
+```bash
+python3 sidecar/turbovec/server.py --port 8082
+```
+
+Register it with Arra:
+
+```bash
+curl -X POST http://localhost:47778/api/vector/services/register \
+  -H 'content-type: application/json' \
+  -d '{"name":"turbovec","type":"proxy","endpoint":"http://127.0.0.1:8082"}'
+```
+
+The reference server has a dependency-free cosine index fallback so the protocol
+can be tested anywhere. It is intentionally small; production TurboVec wiring can
+swap the internal `VectorIndex` implementation while preserving the protocol.

--- a/sidecar/turbovec/server.py
+++ b/sidecar/turbovec/server.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Reference TurboVec-compatible vector proxy sidecar.
+
+Speaks the arra vector proxy protocol:
+  POST   /vectors/add         {"documents": [{id, document, metadata, vector?}]}
+  POST   /vectors/query       {"text": str, "limit": int, "where"?: {}}
+  GET    /vectors/stats       -> {"count": int, "name": str}
+  DELETE /vectors/collection
+  GET    /health              -> {"status":"ok", "name":..., "version":...}
+
+This file intentionally has no required dependencies so CI and local smoke tests
+can boot it. When TurboVec is installed, it still exposes the same HTTP contract;
+the in-memory cosine index is the safe fallback reference path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+VERSION = "0.1.0"
+DIMENSIONS = 64
+
+
+def embed_text(text: str) -> list[float]:
+    vector = [0.0] * DIMENSIONS
+    tokens = text.lower().split() or [text.lower()]
+    for token in tokens:
+        digest = hashlib.sha256(token.encode("utf-8")).digest()
+        index = int.from_bytes(digest[:2], "big") % DIMENSIONS
+        vector[index] += 1.0
+    norm = math.sqrt(sum(value * value for value in vector)) or 1.0
+    return [value / norm for value in vector]
+
+
+def cosine_distance(left: list[float], right: list[float]) -> float:
+    dot = sum(a * b for a, b in zip(left, right))
+    return max(0.0, 1.0 - dot) * 100.0
+
+
+def metadata_matches(metadata: dict[str, Any], where: dict[str, Any] | None) -> bool:
+    if not where:
+        return True
+    return all(metadata.get(key) == value for key, value in where.items())
+
+
+@dataclass
+class StoredDoc:
+    id: str
+    document: str
+    metadata: dict[str, Any]
+    vector: list[float]
+
+
+@dataclass
+class VectorIndex:
+    name: str
+    docs: dict[str, StoredDoc] = field(default_factory=dict)
+
+    def add(self, documents: list[dict[str, Any]]) -> None:
+        for item in documents:
+            doc_id = str(item["id"])
+            text = str(item.get("document", ""))
+            metadata = dict(item.get("metadata") or {})
+            vector = item.get("vector")
+            if not isinstance(vector, list) or not all(isinstance(n, (int, float)) for n in vector):
+                vector = embed_text(text)
+            self.docs[doc_id] = StoredDoc(doc_id, text, metadata, [float(n) for n in vector])
+
+    def query(self, text: str, limit: int, where: dict[str, Any] | None = None) -> dict[str, Any]:
+        query_vector = embed_text(text)
+        rows = [
+            (cosine_distance(query_vector, doc.vector), doc)
+            for doc in self.docs.values()
+            if metadata_matches(doc.metadata, where)
+        ]
+        rows.sort(key=lambda item: item[0])
+        selected = rows[: max(1, min(limit, 100))]
+        return {
+            "ids": [doc.id for _, doc in selected],
+            "documents": [doc.document for _, doc in selected],
+            "distances": [distance for distance, _ in selected],
+            "metadatas": [doc.metadata for _, doc in selected],
+        }
+
+
+class Handler(BaseHTTPRequestHandler):
+    index: VectorIndex
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        print(f"[turbovec-sidecar] {self.address_string()} {fmt % args}")
+
+    def read_json(self) -> dict[str, Any]:
+        length = int(self.headers.get("content-length") or "0")
+        if length == 0:
+            return {}
+        return json.loads(self.rfile.read(length).decode("utf-8"))
+
+    def send_json(self, payload: dict[str, Any], status: int = 200) -> None:
+        raw = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def do_GET(self) -> None:
+        if self.path == "/health":
+            return self.send_json({"status": "ok", "name": self.index.name, "version": VERSION})
+        if self.path == "/vectors/stats":
+            return self.send_json({"count": len(self.index.docs), "name": self.index.name})
+        self.send_json({"error": "not found"}, 404)
+
+    def do_POST(self) -> None:
+        try:
+            body = self.read_json()
+            if self.path == "/vectors/add":
+                documents = body.get("documents")
+                if not isinstance(documents, list):
+                    return self.send_json({"error": "documents must be a list"}, 400)
+                self.index.add(documents)
+                return self.send_json({"success": True, "count": len(documents)})
+            if self.path == "/vectors/query":
+                text = str(body.get("text", ""))
+                limit = int(body.get("limit") or 10)
+                where = body.get("where") if isinstance(body.get("where"), dict) else None
+                return self.send_json(self.index.query(text, limit, where))
+            self.send_json({"error": "not found"}, 404)
+        except Exception as exc:  # noqa: BLE001 - protocol server should return JSON errors.
+            self.send_json({"error": str(exc)}, 500)
+
+    def do_DELETE(self) -> None:
+        if self.path == "/vectors/collection":
+            self.index.docs.clear()
+            return self.send_json({"success": True})
+        self.send_json({"error": "not found"}, 404)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="arra TurboVec proxy protocol sidecar")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8082)
+    parser.add_argument("--name", default="turbovec")
+    args = parser.parse_args()
+
+    Handler.index = VectorIndex(args.name)
+    server = ThreadingHTTPServer((args.host, args.port), Handler)
+    print(f"[turbovec-sidecar] listening on http://{args.host}:{args.port}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/routes/vector/services.ts
+++ b/src/routes/vector/services.ts
@@ -1,71 +1,68 @@
-/**
- * Vector service registry API.
- *
- * Endpoints (mounted under /api via vectorRoutes):
- *   - GET    /vector/services
- *   - POST   /vector/services/register
- *   - DELETE /vector/services/:name
- *   - POST   /vector/services/:name/test
- */
-
+/** Vector service registry API. Mounted under /api. */
 import { Elysia, t } from 'elysia';
 import {
   vectorServiceRegistry,
   type HealthStatus,
+  type RegisteredVectorService,
+  type VectorServiceRegistry,
 } from '../../vector/registry.ts';
 
 const capabilitySchema = t.Record(t.String(), t.Unknown());
 
-export const vectorServicesApiEndpoint = new Elysia()
-  .get('/vector/services', async () => {
-    const services = await vectorServiceRegistry.discover();
-    const health = await vectorServiceRegistry.healthCheck();
-    const list = services.map((service) => ({
-      ...service,
-      health: health.get(service.name) ?? ({ status: 'unknown', checkedAt: new Date().toISOString() } as HealthStatus),
-    }));
-    return { services: list, count: list.length };
-  }, {
-    detail: { tags: ['vector-registry'], summary: 'List registered vector services' },
-  })
-  .post('/vector/services/register', async ({ body, set }) => {
-    try {
-      const service = await vectorServiceRegistry.register(body);
-      return { success: true, service };
-    } catch (error) {
-      set.status = 400;
-      return { success: false, error: error instanceof Error ? error.message : String(error) };
-    }
-  }, {
-    body: t.Object({
-      name: t.String({ minLength: 1 }),
-      type: t.Union([t.Literal('builtin'), t.Literal('proxy')]),
-      endpoint: t.Optional(t.String()),
-      capabilities: t.Optional(capabilitySchema),
-    }),
-    detail: { tags: ['vector-registry'], summary: 'Register a vector service' },
-  })
-  .delete('/vector/services/:name', async ({ params, set }) => {
-    const removed = await vectorServiceRegistry.unregister(params.name);
-    if (!removed) {
-      set.status = 404;
-      return { success: false, error: `Service not found: ${params.name}` };
-    }
-    return { success: true, removed: params.name };
-  }, {
-    params: t.Object({ name: t.String({ minLength: 1 }) }),
-    detail: { tags: ['vector-registry'], summary: 'Unregister one vector service' },
-  })
-  .post('/vector/services/:name/test', async ({ params }) => {
-    const health = await vectorServiceRegistry.healthCheck();
-    const result = health.get(params.name);
-    return {
-      name: params.name,
-      status: result?.status ?? 'unknown',
-      ...(result || {}),
-      success: result?.status === 'up',
-    };
-  }, {
-    params: t.Object({ name: t.String({ minLength: 1 }) }),
-    detail: { tags: ['vector-registry'], summary: 'Test one registered vector service' },
-  });
+export function createVectorServicesApiEndpoint(registry: VectorServiceRegistry = vectorServiceRegistry) {
+  return new Elysia()
+    .get('/vector/services', async () => {
+      const services = await registry.discover();
+      const health = await registry.healthCheck();
+      const list = services.map((service) => ({
+        ...service,
+        health: health.get(service.name) ?? ({ status: 'unknown', checkedAt: new Date().toISOString() } as HealthStatus),
+      }));
+      return { services: list, count: list.length };
+    }, {
+      detail: { tags: ['vector-registry'], summary: 'List registered vector services' },
+    })
+    .post('/vector/services/register', async ({ body, set }) => {
+      try {
+        const service = await registry.register(body as RegisteredVectorService);
+        return { success: true, service };
+      } catch (error) {
+        set.status = 400;
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    }, {
+      body: t.Object({
+        name: t.String({ minLength: 1 }),
+        type: t.Union([t.Literal('builtin'), t.Literal('proxy')]),
+        endpoint: t.Optional(t.String()),
+        capabilities: t.Optional(capabilitySchema),
+      }),
+      detail: { tags: ['vector-registry'], summary: 'Register a vector service' },
+    })
+    .delete('/vector/services/:name', async ({ params, set }) => {
+      const removed = await registry.unregister(params.name);
+      if (!removed) {
+        set.status = 404;
+        return { success: false, error: `Service not found: ${params.name}` };
+      }
+      return { success: true, removed: params.name };
+    }, {
+      params: t.Object({ name: t.String({ minLength: 1 }) }),
+      detail: { tags: ['vector-registry'], summary: 'Unregister one vector service' },
+    })
+    .post('/vector/services/:name/test', async ({ params }) => {
+      const health = await registry.healthCheck();
+      const result = health.get(params.name);
+      return {
+        name: params.name,
+        status: result?.status ?? 'unknown',
+        ...(result || {}),
+        success: result?.status === 'up',
+      };
+    }, {
+      params: t.Object({ name: t.String({ minLength: 1 }) }),
+      detail: { tags: ['vector-registry'], summary: 'Test one registered vector service' },
+    });
+}
+
+export const vectorServicesApiEndpoint = createVectorServicesApiEndpoint();

--- a/tests/http/vector/services.test.ts
+++ b/tests/http/vector/services.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createVectorServicesApiEndpoint } from '../../../src/routes/vector/services.ts';
+import type { HealthStatus, RegisteredVectorService, VectorServiceRegistry } from '../../../src/vector/registry.ts';
+
+class FakeRegistry implements VectorServiceRegistry {
+  services = new Map<string, RegisteredVectorService>([
+    ['lancedb', { name: 'lancedb', type: 'builtin' }],
+  ]);
+
+  async register(service: RegisteredVectorService) {
+    if (service.type === 'proxy' && !service.endpoint) throw new Error('proxy service requires endpoint');
+    this.services.set(service.name, service);
+    return service;
+  }
+
+  async discover() {
+    return [...this.services.values()].sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  async unregister(name: string) {
+    return this.services.delete(name);
+  }
+
+  async healthCheck() {
+    const health = new Map<string, HealthStatus>();
+    for (const service of this.services.values()) {
+      health.set(service.name, { status: service.type === 'proxy' ? 'up' : 'up', checkedAt: '2026-06-16T00:00:00.000Z' });
+    }
+    return health;
+  }
+}
+
+function createFetch(registry = new FakeRegistry()) {
+  const app = new Elysia({ prefix: '/api' }).use(createVectorServicesApiEndpoint(registry));
+  return createApiVersionedFetch((request) => app.handle(request));
+}
+
+async function json(res: Response) {
+  return JSON.parse(await res.text());
+}
+
+test('vector service registry API registers, tests, lists, and removes proxy services', async () => {
+  const fetcher = createFetch();
+  const register = await fetcher(new Request('http://local/api/v1/vector/services/register', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ name: 'turbovec', type: 'proxy', endpoint: 'http://127.0.0.1:8082', capabilities: { protocol: 'vector-proxy-v1' } }),
+  }));
+  expect(register.status).toBe(200);
+  expect(await json(register)).toMatchObject({ success: true, service: { name: 'turbovec', type: 'proxy' } });
+
+  const testRes = await fetcher(new Request('http://local/api/v1/vector/services/turbovec/test', { method: 'POST' }));
+  expect(await json(testRes)).toMatchObject({ name: 'turbovec', status: 'up', success: true });
+
+  const list = await fetcher(new Request('http://local/api/v1/vector/services'));
+  const body = await json(list);
+  expect(body.count).toBe(2);
+  expect(body.services.map((item: { name: string }) => item.name)).toEqual(['lancedb', 'turbovec']);
+
+  const removed = await fetcher(new Request('http://local/api/v1/vector/services/turbovec', { method: 'DELETE' }));
+  expect(await json(removed)).toEqual({ success: true, removed: 'turbovec' });
+});
+
+test('vector service registry API rejects proxy registration without endpoint', async () => {
+  const res = await createFetch()(new Request('http://local/api/v1/vector/services/register', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ name: 'bad', type: 'proxy' }),
+  }));
+
+  expect(res.status).toBe(400);
+  expect(await json(res)).toMatchObject({ success: false, error: 'proxy service requires endpoint' });
+});


### PR DESCRIPTION
Closes #1438\n\n## Changes\n- Add a reference `sidecar/turbovec` HTTP server that speaks the vector proxy protocol (`/vectors/add`, `/vectors/query`, `/vectors/stats`, `/vectors/collection`, `/health`).\n- Keep the sidecar dependency-free for local/CI protocol validation while leaving the internal index swappable for production TurboVec.\n- Make vector services API constructible with an injected registry for deterministic HTTP contract tests.\n- Add scoped HTTP tests for service registration, health test, listing, delete, and invalid proxy registration.\n\n## Validation\n- git fetch origin && git rebase origin/alpha\n- bunx tsc --noEmit\n- bun test tests/http/vector/\n- python3 -m py_compile sidecar/turbovec/server.py\n- changed files <=250 lines