### PR TITLE
feat(canvas): Cloudflare Worker subdomain app

### DIFF
--- a/src/workers/canvas/index.ts
+++ b/src/workers/canvas/index.ts
@@ -1,0 +1,55 @@
+import { normalizePlugin, renderCanvasApp } from './render.ts';
+
+export interface CanvasWorkerEnv {
+  ORACLE_API_BASE?: string;
+}
+
+const DEFAULT_API_BASE = 'https://studio.buildwithoracle.com';
+const API_CACHE_HEADERS = {
+  'Access-Control-Allow-Headers': 'authorization, content-type, x-api-key, x-correlation-id',
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+  'Access-Control-Allow-Origin': '*',
+  'Cache-Control': 'no-store',
+};
+const HTML_HEADERS = {
+  'Content-Type': 'text/html; charset=utf-8',
+  'Cache-Control': 'public, max-age=60, stale-while-revalidate=300',
+};
+
+function apiBase(env: CanvasWorkerEnv): string {
+  return (env.ORACLE_API_BASE || DEFAULT_API_BASE).replace(/\/$/, '');
+}
+
+function proxyTarget(request: Request, env: CanvasWorkerEnv): URL {
+  const source = new URL(request.url);
+  const target = new URL(source.pathname + source.search, apiBase(env));
+  return target;
+}
+
+async function proxyApi(request: Request, env: CanvasWorkerEnv): Promise<Response> {
+  const headers = new Headers(request.headers);
+  headers.set('x-oracle-canvas-worker', 'canvas.buildwithoracle.com');
+  headers.delete('host');
+  const upstream = await fetch(proxyTarget(request, env), { ...request, headers });
+  const responseHeaders = new Headers(upstream.headers);
+  for (const [key, value] of Object.entries(API_CACHE_HEADERS)) responseHeaders.set(key, value);
+  return new Response(upstream.body, { status: upstream.status, statusText: upstream.statusText, headers: responseHeaders });
+}
+
+function pluginFrom(url: URL) {
+  const pathPlugin = url.pathname === '/map' || url.pathname === '/planets' ? url.pathname.slice(1) : null;
+  return normalizePlugin(url.searchParams.get('plugin') ?? pathPlugin);
+}
+
+export async function handleCanvasRequest(request: Request, env: CanvasWorkerEnv = {}): Promise<Response> {
+  const url = new URL(request.url);
+  if (url.pathname.startsWith('/api/') && request.method === 'OPTIONS') return new Response(null, { status: 204, headers: API_CACHE_HEADERS });
+  if (url.pathname.startsWith('/api/')) return proxyApi(request, env);
+  if (request.method !== 'GET' && request.method !== 'HEAD') return new Response('Method not allowed', { status: 405 });
+  const html = renderCanvasApp(pluginFrom(url), apiBase(env));
+  return new Response(request.method === 'HEAD' ? null : html, { headers: HTML_HEADERS });
+}
+
+export default {
+  fetch: handleCanvasRequest,
+};

--- a/src/workers/canvas/render.ts
+++ b/src/workers/canvas/render.ts
@@ -1,0 +1,44 @@
+export type CanvasPlugin = 'wave' | 'map' | 'planets';
+
+export const CANVAS_PLUGINS: readonly CanvasPlugin[] = ['wave', 'map', 'planets'];
+
+export function normalizePlugin(value: string | null): CanvasPlugin {
+  return CANVAS_PLUGINS.includes(value as CanvasPlugin) ? value as CanvasPlugin : 'wave';
+}
+
+function titleFor(plugin: CanvasPlugin): string {
+  if (plugin === 'map') return 'Oracle Map Canvas';
+  if (plugin === 'planets') return 'Oracle Planets Canvas';
+  return 'Oracle Wave Canvas';
+}
+
+export function renderCanvasApp(plugin: CanvasPlugin, apiBase: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>${titleFor(plugin)}</title>
+<style>
+:root{color-scheme:dark;font-family:Inter,ui-sans-serif,system-ui,sans-serif;background:#020617;color:#e2e8f0}
+body{margin:0;min-height:100vh;background:radial-gradient(circle at top,#164e63 0,#020617 42%);overflow:hidden}
+header{position:fixed;inset:1rem 1rem auto;z-index:2;display:flex;align-items:center;justify-content:space-between;gap:1rem;padding:1rem 1.25rem;border:1px solid rgb(255 255 255/.12);border-radius:1.25rem;background:rgb(2 6 23/.72);backdrop-filter:blur(18px)}
+h1{margin:0;font-size:clamp(1.2rem,2.5vw,2rem)}
+p{margin:.25rem 0 0;color:#94a3b8}.pill{border:1px solid rgb(45 212 191/.4);border-radius:999px;padding:.45rem .75rem;color:#99f6e4;font-weight:700}
+canvas{display:block;width:100vw;height:100vh}.error{position:fixed;left:1rem;right:1rem;bottom:1rem;color:#fecaca}
+</style>
+</head>
+<body data-plugin="${plugin}" data-api-base="${apiBase}">
+<header><div><h1>${titleFor(plugin)}</h1><p>canvas.buildwithoracle.com · plugin=${plugin}</p></div><span class="pill" id="status">loading API</span></header>
+<canvas id="oracle-canvas" aria-label="${plugin} canvas visualization"></canvas><p class="error" id="error"></p>
+<script type="module">
+const plugin=${JSON.stringify(plugin)};const apiBase=${JSON.stringify(apiBase)};const canvas=document.querySelector('canvas');const ctx=canvas.getContext('2d');
+const status=document.getElementById('status');const error=document.getElementById('error');let t=0;
+function resize(){canvas.width=innerWidth*devicePixelRatio;canvas.height=innerHeight*devicePixelRatio;ctx.setTransform(devicePixelRatio,0,0,devicePixelRatio,0,0)}addEventListener('resize',resize);resize();
+function dot(x,y,r,c){ctx.beginPath();ctx.fillStyle=c;ctx.arc(x,y,r,0,Math.PI*2);ctx.fill()}
+function draw(){t+=.012;ctx.clearRect(0,0,innerWidth,innerHeight);ctx.fillStyle='#020617';ctx.fillRect(0,0,innerWidth,innerHeight);if(plugin==='planets'){for(let i=0;i<9;i++){const a=t+i*.72;dot(innerWidth/2+Math.cos(a)*(70+i*26),innerHeight/2+Math.sin(a)*(35+i*14),6+i*.7, i%2?'#67e8f9':'#c4b5fd')}}else if(plugin==='map'){for(let i=0;i<45;i++){dot((i*97)%innerWidth,(Math.sin(t+i)*120+innerHeight/2),3,'#2dd4bf')}ctx.strokeStyle='#22d3ee66';ctx.strokeRect(innerWidth*.16,innerHeight*.24,innerWidth*.68,innerHeight*.52)}else{ctx.strokeStyle='#5eead4';ctx.lineWidth=3;ctx.beginPath();for(let x=0;x<innerWidth;x+=8){const y=innerHeight/2+Math.sin(x*.018+t*4)*90;ctx[x?'lineTo':'moveTo'](x,y)}ctx.stroke()}requestAnimationFrame(draw)}draw();
+fetch('/api/health').then(r=>{status.textContent=r.ok?'API online':'API '+r.status}).catch(e=>{status.textContent='API offline';error.textContent=String(e)});
+</script>
+</body>
+</html>`;
+}

--- a/tests/workers/canvas-worker.test.ts
+++ b/tests/workers/canvas-worker.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { handleCanvasRequest } from '../../src/workers/canvas/index.ts';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('canvas Cloudflare Worker', () => {
+  test('renders selected canvas plugins from query and path', async () => {
+    const wave = await handleCanvasRequest(new Request('https://canvas.buildwithoracle.com/?plugin=wave'));
+    const planets = await handleCanvasRequest(new Request('https://canvas.buildwithoracle.com/planets'));
+
+    expect(wave.status).toBe(200);
+    expect(wave.headers.get('content-type')).toContain('text/html');
+    expect(await wave.text()).toContain('plugin=wave');
+    expect(await planets.text()).toContain('plugin=planets');
+  });
+
+  test('falls back to wave for unknown plugins', async () => {
+    const response = await handleCanvasRequest(new Request('https://canvas.buildwithoracle.com/?plugin=unknown'));
+    expect(await response.text()).toContain('plugin=wave');
+  });
+
+  test('handles api preflight without upstream fetch', async () => {
+    const response = await handleCanvasRequest(new Request('https://canvas.buildwithoracle.com/api/health', { method: 'OPTIONS' }));
+    expect(response.status).toBe(204);
+    expect(response.headers.get('access-control-allow-origin')).toBe('*');
+  });
+
+  test('proxies api requests to configured oracle backend without caching', async () => {
+    const seen: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      seen.push(String(input));
+      expect(new Headers(init?.headers).get('x-oracle-canvas-worker')).toBe('canvas.buildwithoracle.com');
+      return new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } });
+    }) as typeof fetch;
+
+    const response = await handleCanvasRequest(
+      new Request('https://canvas.buildwithoracle.com/api/health?probe=1'),
+      { ORACLE_API_BASE: 'https://oracle.example.test/root/' },
+    );
+
+    expect(seen).toEqual(['https://oracle.example.test/api/health?probe=1']);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(await response.json()).toEqual({ ok: true });
+  });
+});

--- a/workers/canvas/wrangler.toml
+++ b/workers/canvas/wrangler.toml
@@ -1,0 +1,11 @@
+name = "ui-canvas-oracle-studio"
+main = "../../src/workers/canvas/index.ts"
+compatibility_date = "2026-06-16"
+workers_dev = false
+
+routes = [
+  { pattern = "canvas.buildwithoracle.com", custom_domain = true }
+]
+
+[vars]
+ORACLE_API_BASE = "https://studio.buildwithoracle.com"


### PR DESCRIPTION
Implements #1403 canvas.buildwithoracle.com Worker slice.

Changes:
- Adds `ui-canvas-oracle-studio` Cloudflare Worker handler.
- Renders `/?plugin=wave|map|planets` and `/map`/`/planets` canvas shells.
- Proxies `/api/*` calls to configurable `ORACLE_API_BASE` with no-store API cache headers.
- Handles API CORS preflight locally.
- Adds `workers/canvas/wrangler.toml` custom-domain deploy config.

Validation:
- `bunx tsc --noEmit`
- `bun test tests/workers/canvas-worker.test.ts`
