### PR TITLE
feat: add vector adapter switcher (#1595)

### DIFF
--- a/frontend/src/components/VectorAdapterSwitcher.tsx
+++ b/frontend/src/components/VectorAdapterSwitcher.tsx
@@ -1,0 +1,105 @@
+import { useMemo, useState } from 'react';
+import { ErrorMessage, Spinner } from './AsyncState';
+import { type VectorConfigAdapter, type VectorConfigRow, fetchJson } from '../pages/vectorSettingsHelpers';
+
+const SWITCHABLE_ADAPTERS = ['lancedb', 'qdrant'] as const satisfies readonly VectorConfigAdapter[];
+type SwitchableAdapter = (typeof SWITCHABLE_ADAPTERS)[number];
+
+interface VectorAdapterSwitcherProps {
+  rows: VectorConfigRow[];
+  onRefresh: () => Promise<void> | void;
+}
+
+export function adapterStatus(rows: VectorConfigRow[]): string {
+  if (!rows.length) return 'No vector collections configured.';
+  const counts = new Map<VectorConfigAdapter, number>();
+  let healthy = 0;
+  for (const row of rows) {
+    counts.set(row.adapter, (counts.get(row.adapter) ?? 0) + 1);
+    if (row.health?.ok) healthy += 1;
+  }
+  const adapterText = [...counts.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([adapter, count]) => `${adapter} ${count}`)
+    .join(' · ');
+  return `${rows.length} collections · ${adapterText} · ${healthy}/${rows.length} healthy`;
+}
+
+function currentAdapter(rows: VectorConfigRow[]): string {
+  if (!rows.length) return 'none';
+  const unique = new Set(rows.map((row) => row.adapter));
+  return unique.size === 1 ? rows[0]?.adapter ?? 'none' : 'mixed';
+}
+
+function targetLabel(adapter: SwitchableAdapter): string {
+  return adapter === 'lancedb' ? 'Use LanceDB' : 'Use Qdrant';
+}
+
+export function VectorAdapterSwitcher({ rows, onRefresh }: VectorAdapterSwitcherProps) {
+  const [saving, setSaving] = useState<SwitchableAdapter | null>(null);
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+  const summary = useMemo(() => adapterStatus(rows), [rows]);
+  const activeAdapter = useMemo(() => currentAdapter(rows), [rows]);
+
+  async function switchAdapter(adapter: SwitchableAdapter) {
+    const changedRows = rows.filter((row) => row.adapter !== adapter);
+    setSaving(adapter);
+    setMessage('');
+    setError('');
+    try {
+      for (const row of changedRows) {
+        await fetchJson(`/api/v1/vector/config/${encodeURIComponent(row.key)}`, {
+          method: 'PUT',
+          body: JSON.stringify({ adapter }),
+        });
+      }
+      await fetchJson('/api/v1/vector/config/reload', { method: 'POST' });
+      await onRefresh();
+      setMessage(changedRows.length ? `Switched ${changedRows.length} collections to ${adapter}.` : `Already using ${adapter}.`);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setSaving(null);
+    }
+  }
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-adapter-switcher-title">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-300">Adapter switcher</p>
+          <h2 id="vector-adapter-switcher-title" className="mt-2 text-2xl font-semibold text-white">LanceDB / Qdrant backend</h2>
+          <p className="mt-2 text-sm text-slate-400">Toggle all vector collections between local LanceDB and Qdrant backends.</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {SWITCHABLE_ADAPTERS.map((adapter) => (
+            <button
+              className="focus-ring rounded-xl border border-cyan-300/30 px-3 py-2 text-sm font-semibold text-cyan-100 hover:bg-cyan-300/10 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={Boolean(saving) || !rows.length}
+              key={adapter}
+              type="button"
+              onClick={() => void switchAdapter(adapter)}
+            >
+              {saving === adapter ? <Spinner label="Switching" /> : targetLabel(adapter)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <dl className="mt-5 grid gap-3 text-sm sm:grid-cols-2">
+        <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+          <dt className="text-slate-500">Current adapter</dt>
+          <dd className="mt-1 text-lg font-semibold text-cyan-100">{activeAdapter}</dd>
+        </div>
+        <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+          <dt className="text-slate-500">Status</dt>
+          <dd className="mt-1 text-sm font-semibold text-slate-200">{summary}</dd>
+        </div>
+      </dl>
+
+      {message ? <p className="mt-4 text-sm text-emerald-200">{message}</p> : null}
+      {error ? <div className="mt-4"><ErrorMessage title="Adapter switch failed." message={error} /></div> : null}
+    </section>
+  );
+}

--- a/frontend/src/pages/VectorSettingsPage.tsx
+++ b/frontend/src/pages/VectorSettingsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { VectorAdapterSwitcher } from '../components/VectorAdapterSwitcher';
 import { VectorFirstRunWizard } from '../components/VectorFirstRunWizard';
 import { VectorIndexPanel } from '../components/VectorIndexPanel';
 import { ErrorMessage, LoadingPanel, Spinner } from '../components/AsyncState';
@@ -169,6 +170,7 @@ export function VectorSettingsPage() {
       {state === 'loading' ? <LoadingPanel title="Loading vector config" detail="Reading /api/v1/vector/config." /> : null}
       {state === 'error' ? <ErrorMessage title="Could not load vector config." message={error} /> : null}
       {error && state !== 'error' ? <ErrorMessage title="Vector settings warning" message={error} /> : null}
+      {state === 'ready' ? <VectorAdapterSwitcher rows={rows} onRefresh={loadConfig} /> : null}
 
       {state === 'ready' ? <VectorFirstRunWizard rows={rows} onRefresh={loadConfig} /> : null}
 

--- a/tests/frontend/components/vector-adapter-switcher.test.tsx
+++ b/tests/frontend/components/vector-adapter-switcher.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test';
+import { VectorAdapterSwitcher, adapterStatus } from '../../../frontend/src/components/VectorAdapterSwitcher';
+import type { VectorConfigRow } from '../../../frontend/src/pages/vectorSettingsHelpers';
+import { htmlFor } from '../_render';
+
+const rows: VectorConfigRow[] = [
+  {
+    key: 'bge-m3',
+    collection: 'oracle_bge_m3',
+    model: 'BAAI/bge-m3',
+    provider: 'ollama',
+    adapter: 'lancedb',
+    primary: true,
+    count: 100,
+    health: { ok: true, status: 'ok', collection: 'oracle_bge_m3', adapter: 'lancedb', model: 'BAAI/bge-m3' },
+  },
+  {
+    key: 'qwen3',
+    collection: 'oracle_qwen3',
+    model: 'Qwen3',
+    provider: 'ollama',
+    adapter: 'qdrant',
+    count: 40,
+    health: { ok: false, status: 'down', collection: 'oracle_qwen3', adapter: 'qdrant', model: 'Qwen3' },
+  },
+];
+
+describe('VectorAdapterSwitcher', () => {
+  test('renders current adapter status and LanceDB/Qdrant actions', () => {
+    const html = htmlFor(<VectorAdapterSwitcher rows={rows} onRefresh={() => undefined} />);
+
+    expect(html).toContain('Adapter switcher');
+    expect(html).toContain('LanceDB / Qdrant backend');
+    expect(html).toContain('Current adapter');
+    expect(html).toContain('mixed');
+    expect(html).toContain('Use LanceDB');
+    expect(html).toContain('Use Qdrant');
+    expect(html).toContain('2 collections · lancedb 1 · qdrant 1 · 1/2 healthy');
+  });
+
+  test('summarizes empty and single-adapter states', () => {
+    expect(adapterStatus([])).toBe('No vector collections configured.');
+    expect(adapterStatus([rows[0]])).toBe('1 collections · lancedb 1 · 1/1 healthy');
+  });
+});


### PR DESCRIPTION
Closes #1595

## Changes
- Added a Vector Settings adapter-switcher panel for LanceDB/Qdrant
- Displays current adapter status, adapter counts, and health summary
- Uses existing vector config collection updates plus runtime reload

## Test
- bun test tests/frontend/components/vector-adapter-switcher.test.tsx tests/frontend/components/vector-index-panel-render.test.tsx
- bunx tsc --noEmit --project frontend/tsconfig.json
- bunx tsc --noEmit
