### PR TITLE
feat(canvas): register React plugin metadata

### DIFF
--- a/src/canvas/plugins.ts
+++ b/src/canvas/plugins.ts
@@ -1,0 +1,47 @@
+export type CanvasPluginKind = 'three' | 'react';
+
+interface BaseCanvasPlugin {
+  id: string;
+  label: string;
+  description: string;
+  path: string;
+  query: { plugin: string };
+}
+
+export interface ThreeCanvasPlugin extends BaseCanvasPlugin {
+  kind: 'three';
+  mount: string;
+}
+
+export interface ReactCanvasPlugin extends BaseCanvasPlugin {
+  kind: 'react';
+  renderer: string;
+  apiPath?: string;
+}
+
+export type CanvasPluginDescriptor = ThreeCanvasPlugin | ReactCanvasPlugin;
+
+const THREE_PLUGINS: readonly ThreeCanvasPlugin[] = [
+  { id: 'cube', label: 'Cube', description: 'Rotating geometry scene.', kind: 'three', mount: 'cubeScene', path: '/canvas', query: { plugin: 'cube' } },
+  { id: 'galaxy', label: 'Galaxy', description: 'Particle galaxy scene.', kind: 'three', mount: 'galaxyScene', path: '/canvas', query: { plugin: 'galaxy' } },
+  { id: 'torus', label: 'Torus', description: 'Torus knot scene.', kind: 'three', mount: 'torusScene', path: '/canvas', query: { plugin: 'torus' } },
+  { id: 'graph3d', label: 'Graph 3D', description: 'Three-dimensional graph scene.', kind: 'three', mount: 'graph3dScene', path: '/canvas', query: { plugin: 'graph3d' } },
+  { id: 'solar', label: 'Solar', description: 'Solar orbit scene.', kind: 'three', mount: 'solarScene', path: '/canvas', query: { plugin: 'solar' } },
+  { id: 'wave', label: 'Wave', description: 'Wave field scene.', kind: 'three', mount: 'waveScene', path: '/canvas', query: { plugin: 'wave' } },
+  { id: 'map3d', label: 'Map 3D', description: 'Legacy 3D knowledge map scene.', kind: 'three', mount: 'map3dScene', path: '/canvas', query: { plugin: 'map3d' } },
+];
+
+const REACT_PLUGINS: readonly ReactCanvasPlugin[] = [
+  { id: 'map', label: 'Knowledge Map', description: 'React knowledge-map canvas backed by /api/map3d.', kind: 'react', renderer: 'KnowledgeMapCanvas', path: '/map', query: { plugin: 'map' }, apiPath: '/api/map3d' },
+  { id: 'planets', label: 'Planets', description: 'React orbital canvas view.', kind: 'react', renderer: 'PlanetsCanvas', path: '/planets', query: { plugin: 'planets' }, apiPath: '/api/map3d' },
+];
+
+export const CANVAS_PLUGINS: readonly CanvasPluginDescriptor[] = [...THREE_PLUGINS, ...REACT_PLUGINS];
+
+export function listCanvasPlugins(kind?: CanvasPluginKind): CanvasPluginDescriptor[] {
+  return kind ? CANVAS_PLUGINS.filter((plugin) => plugin.kind === kind) : [...CANVAS_PLUGINS];
+}
+
+export function findCanvasPlugin(id: string): CanvasPluginDescriptor | undefined {
+  return CANVAS_PLUGINS.find((plugin) => plugin.id === id);
+}

--- a/src/cli/commands/canvas-plugins.ts
+++ b/src/cli/commands/canvas-plugins.ts
@@ -1,0 +1,41 @@
+import { findCanvasPlugin, listCanvasPlugins, type CanvasPluginKind } from '../../canvas/plugins.ts';
+
+interface Options {
+  json: boolean;
+  kind?: CanvasPluginKind;
+  id?: string;
+}
+
+function parseArgs(args: string[]): Options {
+  const options: Options = { json: false };
+  for (let i = 1; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--json') options.json = true;
+    else if (arg === '--kind') options.kind = args[++i] as CanvasPluginKind;
+    else if (arg === '--id') options.id = args[++i];
+    else if (arg) throw new Error(`unknown canvas-plugins option: ${arg}`);
+  }
+  return options;
+}
+
+function printTable(plugins: ReturnType<typeof listCanvasPlugins>): void {
+  for (const plugin of plugins) {
+    const target = `${plugin.path}?plugin=${plugin.query.plugin}`;
+    console.log(`${plugin.id}\t${plugin.kind}\t${plugin.label}\t${target}`);
+  }
+}
+
+export async function canvasPluginsCommand(args: string[]): Promise<number> {
+  try {
+    const options = parseArgs(args);
+    const plugins = options.id
+      ? [findCanvasPlugin(options.id)].filter(Boolean) as ReturnType<typeof listCanvasPlugins>
+      : listCanvasPlugins(options.kind);
+    if (options.json) console.log(JSON.stringify({ plugins, count: plugins.length }, null, 2));
+    else printTable(plugins);
+    return plugins.length || !options.id ? 0 : 1;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,29 +2,29 @@
 
 import { exportCommand } from './commands/export.ts';
 import { serveCommand } from './commands/serve.ts';
+import { canvasPluginsCommand } from './commands/canvas-plugins.ts';
+
+function printUsage(): void {
+  console.error('usage: bun run src/cli/index.ts <export|serve|canvas-plugins> ...');
+  console.error('  export: bun run src/cli/index.ts export --format json|markdown [--out <file>]');
+  console.error('  serve:  bun run src/cli/index.ts serve <start|stop|status> [--foreground|--background] [--json]');
+  console.error('  canvas-plugins: bun run src/cli/index.ts canvas-plugins [--kind three|react] [--id <id>] [--json]');
+}
 
 async function main() {
   const args = process.argv.slice(2);
   if (args.length === 0) {
-    console.error('usage: bun run src/cli/index.ts <export|serve> ...');
-    console.error('  export: bun run src/cli/index.ts export --format json|markdown [--out <file>]');
-    console.error('  serve:  bun run src/cli/index.ts serve <start|stop|status> [--foreground|--background] [--json]');
+    printUsage();
     process.exit(1);
   }
 
-  if (args[0] === 'serve') {
-    process.exit(await serveCommand(args));
-  }
+  if (args[0] === 'serve') process.exit(await serveCommand(args));
+  if (args[0] === 'canvas-plugins') process.exit(await canvasPluginsCommand(args));
+  if (args[0] === 'export') process.exit(await exportCommand(args));
 
-  if (args[0] !== 'export') {
-    console.error(`unknown command: ${args[0]}`);
-    console.error('usage: bun run src/cli/index.ts <export|serve> ...');
-    console.error('  export: bun run src/cli/index.ts export --format json|markdown [--out <file>]');
-    console.error('  serve:  bun run src/cli/index.ts serve <start|stop|status> [--foreground|--background] [--json]');
-    process.exit(1);
-  }
-
-  process.exit(await exportCommand(args));
+  console.error(`unknown command: ${args[0]}`);
+  printUsage();
+  process.exit(1);
 }
 
 main().catch((err) => {

--- a/src/routes/plugins/canvas.ts
+++ b/src/routes/plugins/canvas.ts
@@ -1,0 +1,29 @@
+import { Elysia, t } from 'elysia';
+import { findCanvasPlugin, listCanvasPlugins, type CanvasPluginKind } from '../../canvas/plugins.ts';
+
+const kinds = new Set<CanvasPluginKind>(['three', 'react']);
+
+function parseKind(value: unknown): CanvasPluginKind | undefined {
+  return typeof value === 'string' && kinds.has(value as CanvasPluginKind) ? value as CanvasPluginKind : undefined;
+}
+
+export const canvasPluginRegistryRoute = new Elysia()
+  .get('/api/plugins/canvas', ({ query }) => {
+    const kind = parseKind(query.kind);
+    const plugins = listCanvasPlugins(kind);
+    return { plugins, count: plugins.length, kind: kind ?? 'all' };
+  }, {
+    query: t.Object({ kind: t.Optional(t.String()) }),
+    detail: { tags: ['plugins'], summary: 'List bundled canvas plugins' },
+  })
+  .get('/api/plugins/canvas/:id', ({ params, set }) => {
+    const plugin = findCanvasPlugin(params.id);
+    if (!plugin) {
+      set.status = 404;
+      return { error: 'canvas plugin not found', id: params.id };
+    }
+    return { plugin };
+  }, {
+    params: t.Object({ id: t.String({ minLength: 1 }) }),
+    detail: { tags: ['plugins'], summary: 'Get one bundled canvas plugin' },
+  });

--- a/src/routes/plugins/index.ts
+++ b/src/routes/plugins/index.ts
@@ -3,11 +3,13 @@ import { Elysia } from 'elysia';
 import { createPluginsRegistryRoute, type PluginsRegistryRouteOptions } from './registry.ts';
 import { pluginGetByNameRoute } from './get-by-name.ts';
 import { pluginStateRoute } from './state.ts';
+import { canvasPluginRegistryRoute } from './canvas.ts';
 
 export function createPluginsRouter(options: PluginsRegistryRouteOptions = {}) {
   return new Elysia()
     .use(createPluginsRegistryRoute(options))
     .use(pluginStateRoute)
+    .use(canvasPluginRegistryRoute)
     .use(pluginGetByNameRoute);
 }
 

--- a/tests/plugins/canvas-registry.test.ts
+++ b/tests/plugins/canvas-registry.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { listCanvasPlugins, findCanvasPlugin } from '../../src/canvas/plugins.ts';
+import { createPluginsRouter } from '../../src/routes/plugins/index.ts';
+import { canvasPluginsCommand } from '../../src/cli/commands/canvas-plugins.ts';
+
+describe('canvas plugin registry', () => {
+  test('registers three and react canvas plugins', () => {
+    const plugins = listCanvasPlugins();
+    expect(plugins.map((plugin) => plugin.id)).toContain('wave');
+    expect(plugins.map((plugin) => plugin.id)).toContain('map');
+    expect(plugins.map((plugin) => plugin.id)).toContain('planets');
+    expect(listCanvasPlugins('react').map((plugin) => plugin.id)).toEqual(['map', 'planets']);
+    expect(findCanvasPlugin('map')).toMatchObject({ kind: 'react', renderer: 'KnowledgeMapCanvas' });
+  });
+
+  test('exposes canvas plugins through plugin registry HTTP route', async () => {
+    const app = new Elysia().use(createPluginsRouter());
+    const response = await app.handle(new Request('http://local/api/plugins/canvas?kind=react'));
+    expect(response.status).toBe(200);
+    const body = await response.json() as { count: number; plugins: Array<{ id: string; kind: string }> };
+    expect(body.count).toBe(2);
+    expect(body.plugins).toEqual([
+      expect.objectContaining({ id: 'map', kind: 'react' }),
+      expect.objectContaining({ id: 'planets', kind: 'react' }),
+    ]);
+  });
+
+  test('lists canvas plugins through CLI command', async () => {
+    const lines: string[] = [];
+    const originalLog = console.log;
+    console.log = (message?: unknown) => lines.push(String(message));
+    try {
+      expect(await canvasPluginsCommand(['canvas-plugins', '--kind', 'react'])).toBe(0);
+    } finally {
+      console.log = originalLog;
+    }
+    expect(lines.join('\n')).toContain('map\treact\tKnowledge Map');
+    expect(lines.join('\n')).toContain('planets\treact\tPlanets');
+  });
+});


### PR DESCRIPTION
Implements #950 Phase 1 scaffold for the unified canvas plugin system.

Changes:
- Adds shared bundled canvas plugin registry with `three` and `react` plugin descriptors.
- Registers React canvas plugins for `map` and `planets` with renderer/API metadata.
- Preserves seven existing Three plugin IDs as metadata (`cube`, `galaxy`, `torus`, `graph3d`, `solar`, `wave`, `map3d`).
- Adds HTTP discovery route: `GET /api/plugins/canvas?kind=three|react` and `GET /api/plugins/canvas/:id`.
- Adds CLI discovery surface: `bun run src/cli/index.ts canvas-plugins [--kind three|react] [--id <id>] [--json]`.
- Leaves Studio `/canvas?plugin=X` unchanged; metadata-only registry does not dynamically execute unsigned React/Three code.

Validation:
- `bunx tsc --noEmit`
- `bun test tests/plugins/canvas-registry.test.ts`
