### PR TITLE
feat: scaffold memory save recall API (#1457)

### DIFF
--- a/src/routes/memory/index.ts
+++ b/src/routes/memory/index.ts
@@ -1,0 +1,29 @@
+import { Elysia } from 'elysia';
+import { RecallMemoryQuery, SaveMemoryBody } from './model.ts';
+import { memoryStore, type InMemoryStore, type MemoryInput } from './store.ts';
+
+export function createMemoryRoutes(store: InMemoryStore = memoryStore) {
+  return new Elysia({ prefix: '/api' })
+    .post('/memory/save', ({ body, set }) => {
+      try {
+        const memory = store.save(body as MemoryInput);
+        return { success: true, memory };
+      } catch (error) {
+        set.status = 400;
+        return { success: false, error: error instanceof Error ? error.message : 'failed to save memory' };
+      }
+    }, {
+      body: SaveMemoryBody,
+      detail: { tags: ['memory'], menu: { group: 'hidden' }, summary: 'Save an in-memory note' },
+    })
+    .get('/memory/recall', ({ query }) => {
+      const limit = Math.min(50, Math.max(1, parseInt(query.limit ?? '10')));
+      const items = store.recall(query.q ?? '', limit);
+      return { query: query.q ?? '', total: items.length, items };
+    }, {
+      query: RecallMemoryQuery,
+      detail: { tags: ['memory'], menu: { group: 'hidden' }, summary: 'Recall in-memory notes' },
+    });
+}
+
+export const memoryRoutes = createMemoryRoutes();

--- a/src/routes/memory/model.ts
+++ b/src/routes/memory/model.ts
@@ -1,0 +1,13 @@
+import { t } from 'elysia';
+
+export const SaveMemoryBody = t.Object({
+  content: t.String(),
+  title: t.Optional(t.String()),
+  tags: t.Optional(t.Array(t.String())),
+  source: t.Optional(t.String()),
+});
+
+export const RecallMemoryQuery = t.Object({
+  q: t.Optional(t.String()),
+  limit: t.Optional(t.String()),
+});

--- a/src/routes/memory/store.ts
+++ b/src/routes/memory/store.ts
@@ -1,0 +1,53 @@
+export type MemoryInput = {
+  content: string;
+  title?: string;
+  tags?: string[];
+  source?: string;
+};
+
+export type MemoryRecord = MemoryInput & {
+  id: string;
+  createdAt: string;
+};
+
+export class InMemoryStore {
+  private readonly records = new Map<string, MemoryRecord>();
+  private counter = 0;
+
+  save(input: MemoryInput): MemoryRecord {
+    const content = input.content.trim();
+    if (!content) throw new Error('memory content is required');
+    const id = `mem_${Date.now().toString(36)}_${(++this.counter).toString(36)}`;
+    const record: MemoryRecord = {
+      id,
+      content,
+      title: input.title?.trim() || undefined,
+      tags: input.tags?.map((tag) => tag.trim()).filter(Boolean) ?? [],
+      source: input.source?.trim() || undefined,
+      createdAt: new Date().toISOString(),
+    };
+    this.records.set(id, record);
+    return record;
+  }
+
+  recall(query = '', limit = 10): MemoryRecord[] {
+    const normalized = query.trim().toLowerCase();
+    const records = [...this.records.values()].reverse();
+    const matches = normalized ? records.filter((record) => searchable(record).includes(normalized)) : records;
+    return matches.slice(0, limit);
+  }
+
+  clear(): void {
+    this.records.clear();
+    this.counter = 0;
+  }
+}
+
+function searchable(record: MemoryRecord): string {
+  return [record.content, record.title, record.source, ...(record.tags ?? [])]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+}
+
+export const memoryStore = new InMemoryStore();

--- a/src/server.ts
+++ b/src/server.ts
@@ -55,6 +55,7 @@ import { createMenuRoutes, menuItemsFromUnifiedPlugins } from './routes/menu/ind
 import { peerRoutes } from './routes/peer/index.ts';
 import { createMcpRoutes } from './routes/mcp/index.ts';
 import { createMetricsLifecycle, metricsRoutes } from './routes/metrics/index.ts';
+import { memoryRoutes } from './routes/memory/index.ts';
 
 let indexerRoutes: any = null;
 try {
@@ -192,6 +193,7 @@ const apiModules = [
   sessionsRoutes,
   vaultRoutes,
   metricsRoutes,
+  memoryRoutes,
   ...(indexerRoutes ? [indexerRoutes] : []),
   ...unifiedPlugins.routes,
 ];

--- a/tests/http/memory/save-recall.test.ts
+++ b/tests/http/memory/save-recall.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from 'bun:test';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createMemoryRoutes } from '../../../src/routes/memory/index.ts';
+import { InMemoryStore } from '../../../src/routes/memory/store.ts';
+
+function createFetch() {
+  const app = createMemoryRoutes(new InMemoryStore());
+  return createApiVersionedFetch((request) => app.handle(request));
+}
+
+async function json(res: Response) {
+  return JSON.parse(await res.text());
+}
+
+test('POST /api/v1/memory/save stores a memory and recall finds it', async () => {
+  const fetcher = createFetch();
+  const save = await fetcher(new Request('http://local/api/v1/memory/save', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      title: 'Morning tape',
+      content: 'Read the launch context before coding.',
+      tags: ['continuity', 'oracle'],
+      source: 'challenge-2',
+    }),
+  }));
+  const saved = await json(save);
+
+  expect(save.status).toBe(200);
+  expect(saved).toMatchObject({ success: true, memory: { title: 'Morning tape', tags: ['continuity', 'oracle'] } });
+  expect(saved.memory.id).toStartWith('mem_');
+
+  const recall = await fetcher(new Request('http://local/api/v1/memory/recall?q=launch&limit=5'));
+  const body = await json(recall);
+
+  expect(recall.status).toBe(200);
+  expect(body).toMatchObject({ query: 'launch', total: 1 });
+  expect(body.items[0]).toMatchObject({ id: saved.memory.id, content: 'Read the launch context before coding.' });
+});
+
+test('memory save rejects blank content', async () => {
+  const res = await createFetch()(new Request('http://local/api/v1/memory/save', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ content: '   ' }),
+  }));
+
+  expect(res.status).toBe(400);
+  expect(await json(res)).toEqual({ success: false, error: 'memory content is required' });
+});


### PR DESCRIPTION
Closes part of #1457\n\n## Changes\n- Add in-memory MemoryStore scaffold\n- Add POST /api/v1/memory/save endpoint\n- Add GET /api/v1/memory/recall endpoint\n- Mount memory routes in server\n- Add scoped HTTP tests for save/recall and validation\n\n## Test\n- bunx tsc --noEmit: green\n- bun test tests/http/memory/: passed