### PR TITLE
feat: add maw arra serve lifecycle actions (#1603)

### DIFF
--- a/maw-plugin/README.md
+++ b/maw-plugin/README.md
@@ -21,7 +21,9 @@ maw arra frontend          # opens https://studio.buildwithoracle.com/?api=<back
 maw arra ui --no-open      # prints the link only
 maw arra serve             # starts bun run server in the background
 maw arra serve --status    # checks PID + /api/health
+maw arra serve status      # same as --status
 maw arra serve --stop      # stops the PID from ~/.arra-oracle-v2/server.pid
+maw arra serve stop        # same as --stop
 maw arra serve --port 47779
 maw arra search "query" --mode fts --limit 5
 maw arra learn "new project fact" --project my-repo
@@ -62,7 +64,7 @@ maw arra thread_update 42 --status closed
 maw arra verify --check false --type learning
 ```
 
-`serve` resolves the repo root from `ORACLE_ROOT` or `ghq locate`, writes `~/.arra-oracle-v2/server.pid`, and passes `--port` as `ORACLE_PORT`.
+`serve` accepts `start`/`stop`/`status` positionals or `--stop`/`--status` flags. It resolves the repo root from `ORACLE_ROOT` or `ghq locate`, writes `~/.arra-oracle-v2/server.pid`, and passes `--port` as `ORACLE_PORT`.
 
 `frontend`, `ui`, and `open` construct `/?api=<backend>` from `ARRA_FRONTEND_URL` (default `https://studio.buildwithoracle.com`) and `ORACLE_API`.
 

--- a/maw-plugin/__tests__/serve.test.ts
+++ b/maw-plugin/__tests__/serve.test.ts
@@ -1,0 +1,56 @@
+import { mkdtempSync } from 'node:fs';
+import { describe, expect, test } from 'bun:test';
+import { runServe, type Runner } from '../serve.ts';
+
+function env() {
+  return { HOME: mkdtempSync('/tmp/arra-serve-test-'), ORACLE_ROOT: '/repo/arra-oracle-v3' };
+}
+
+const runner: Runner = async () => ({ code: 1, stdout: '', stderr: '' });
+
+describe('maw arra serve command', () => {
+  test('starts with ORACLE_ROOT and port override', async () => {
+    const started: unknown[] = [];
+    const result = await runServe({ pos: [], flags: { port: '47779' } }, runner, env(), {
+      start: (cwd, startEnv) => {
+        started.push({ cwd, port: startEnv.ORACLE_PORT });
+        return 43210;
+      },
+      isAlive: () => false,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain('started pid=43210 port=47779');
+    expect(started).toEqual([{ cwd: '/repo/arra-oracle-v3', port: '47779' }]);
+  });
+
+  test('supports positional start stop status actions', async () => {
+    const home = env();
+    let alive = true;
+    await runServe({ pos: ['start'], flags: {} }, runner, home, { start: () => 54321, isAlive: () => false });
+
+    const status = await runServe({ pos: ['status'], flags: {} }, runner, home, {
+      isAlive: () => alive,
+      fetch: async () => new Response('{"status":"ok"}', { status: 200 }),
+    });
+    expect(status.output).toContain('alive pid=54321');
+    expect(status.output).toContain('health: ok 200');
+
+    const stop = await runServe({ pos: ['stop'], flags: {} }, runner, home, {
+      isAlive: () => alive,
+      kill: () => { alive = false; },
+      sleep: async () => {},
+    });
+    expect(stop.output).toContain('stopped pid=54321');
+  });
+
+  test('rejects invalid serve actions and ports', async () => {
+    const badAction = await runServe({ pos: ['restart'], flags: {} }, runner, env());
+    expect(badAction.ok).toBe(false);
+    expect(badAction.error).toContain('serve action must be start, stop, or status');
+
+    const badPort = await runServe({ pos: [], flags: { port: '99999' } }, runner, env());
+    expect(badPort.ok).toBe(false);
+    expect(badPort.error).toContain('--port must be a number from 1 to 65535');
+  });
+});

--- a/maw-plugin/serve.ts
+++ b/maw-plugin/serve.ts
@@ -25,6 +25,14 @@ function flag(parsed: Parsed, name: string): string | undefined {
   return value === undefined || value === false ? undefined : value === true ? 'true' : String(value);
 }
 
+function serveAction(parsed: Parsed): 'start' | 'stop' | 'status' {
+  const action = parsed.pos[0]?.toLowerCase();
+  if (flag(parsed, 'status') || action === 'status') return 'status';
+  if (flag(parsed, 'stop') || action === 'stop') return 'stop';
+  if (!action || action === 'start') return 'start';
+  throw new Error('serve action must be start, stop, or status');
+}
+
 function parsePort(parsed: Parsed, env: Record<string, string | undefined>): string {
   const port = flag(parsed, 'port') || env.ORACLE_PORT || env.PORT || DEFAULT_PORT;
   if (!/^\d+$/.test(port) || Number(port) < 1 || Number(port) > 65535) {
@@ -97,12 +105,14 @@ export async function runServe(parsed: Parsed, runner: Runner, env: Record<strin
     const kill = deps.kill ?? ((pid, signal) => process.kill(pid, signal));
     const sleep = deps.sleep ?? ((ms) => new Promise<void>(resolve => setTimeout(resolve, ms)));
 
-    if (flag(parsed, 'status')) {
+    const action = serveAction(parsed);
+
+    if (action === 'status') {
       const pidState = currentPid ? `${isAlive(currentPid) ? 'alive' : 'dead'} pid=${currentPid}` : 'missing pid';
       return { ok: true, output: `arra serve: ${pidState}\nhealth: ${await health(port, deps.fetch ?? fetch)}` };
     }
 
-    if (flag(parsed, 'stop')) {
+    if (action === 'stop') {
       if (!currentPid) return { ok: true, output: `arra serve: stopped (no ${path})` };
       const stopped = await stopPid(currentPid, { isAlive, kill, sleep });
       if (stopped && existsSync(path)) unlinkSync(path);


### PR DESCRIPTION
Closes #1603

## Changes
- Extended `maw arra serve` lifecycle handling for explicit `start`, `stop`, and `status` actions
- Preserved existing `--stop`, `--status`, and `--port N` flag behavior
- Added focused tests for start/status/stop, port validation, and invalid actions
- Documented positional lifecycle aliases in the maw arra plugin README

## Test
- bun test maw-plugin/__tests__/serve.test.ts maw-plugin/__tests__/index.test.ts
- bunx tsc --noEmit
