### PR TITLE
fix: expose core containment label header

### DIFF
--- a/src/middleware/logger.ts
+++ b/src/middleware/logger.ts
@@ -35,6 +35,8 @@ export type RequestLoggerOptions = {
   now?: () => number;
 };
 
+export const SANDBOX_LABEL_HEADER = 'X-Sandbox-Label';
+
 const REDACTED = '[REDACTED]';
 const sensitiveHeaders = new Set(['authorization', 'proxy-authorization']);
 const logFormats = new Set<RequestLogFormat>(['json', 'nginx', 'short']);
@@ -123,14 +125,17 @@ export function createRequestLogger(options: RequestLoggerOptions = {}) {
   return {
     onRequest({ request, set }: RequestContext) {
       const correlationId = requestCorrelationId(request);
-      metaByRequest.set(request, { startedAt: now(), correlationId, headers: redactHeaders(request.headers), sandbox: sandboxLabel() });
+      const sandbox = sandboxLabel();
+      metaByRequest.set(request, { startedAt: now(), correlationId, headers: redactHeaders(request.headers), sandbox });
       set.headers['X-Correlation-Id'] = correlationId;
+      set.headers[SANDBOX_LABEL_HEADER] = sandbox;
     },
     onAfterResponse({ request, responseValue, set }: AfterResponseContext) {
       const meta = metaByRequest.get(request);
       const endedAt = now();
       const startedAt = meta?.startedAt ?? endedAt;
       const durationMs = Math.max(0, Math.round((endedAt - startedAt) * 100) / 100);
+      set.headers[SANDBOX_LABEL_HEADER] = meta?.sandbox ?? sandboxLabel();
       log({
         event: 'http_request',
         method: request.method,

--- a/tests/http/logger/format.test.ts
+++ b/tests/http/logger/format.test.ts
@@ -44,6 +44,7 @@ async function captureLogLine(format: string | undefined, env?: string): Promise
     }));
     expect(response.status).toBe(200);
     expect(response.headers.get('x-correlation-id')).toBe(CORRELATION_ID);
+    expect(response.headers.get('x-sandbox-label')).toBe(env === 'production' ? 'prod' : 'dev');
 
     return await waitForLog(lines);
   } finally {

--- a/tests/http/logging/request-log.test.ts
+++ b/tests/http/logging/request-log.test.ts
@@ -35,6 +35,7 @@ test('request logger emits structured JSON and redacts Authorization headers', a
     }));
     expect(response.status).toBe(201);
     expect(response.headers.get('x-correlation-id')).toBe('test-correlation-id');
+    expect(response.headers.get('x-sandbox-label')).toBe('dev');
 
     const raw = await waitForLog(lines);
     expect(raw).not.toContain('secret-token');


### PR DESCRIPTION
## Summary\n- expose the runtime containment/sandbox label as an `X-Sandbox-Label` response header\n- keep existing correlation/log behavior intact while preserving dev/staging/prod labels\n- add assertions for the new header in logger tests\n\n## Existing #1597 hardening verified on alpha\n- `/api/health` returns directly without version redirect\n- `LOG_FORMAT` supports nginx/json/short request logging\n- plugin entry path containment rejects traversal and external symlinks\n- plugin sandbox comments are labeled as error containment, not a security sandbox\n\n## Validation\n- `bunx tsc --noEmit`\n- `bun test tests/http/health/`\n- `bun test tests/http/logger/format.test.ts tests/http/logging/request-log.test.ts tests/plugins/path-containment.test.ts`\n\nFiles changed are under 250 lines.