### PR TITLE
feat: register ARRA as a maw plugin (#1467)

### DIFF
--- a/src/plugins/__tests__/arra-plugin.test.ts
+++ b/src/plugins/__tests__/arra-plugin.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { Elysia } from 'elysia';
+import { loadUnifiedPlugins } from '../unified-loader.ts';
+
+const pluginRoot = join(process.cwd(), 'src/plugins');
+
+describe('built-in arra plugin', () => {
+  test('declares modern maw-js CLI, menu, and HTTP surfaces', () => {
+    const manifest = JSON.parse(readFileSync(join(pluginRoot, 'arra/plugin.json'), 'utf8'));
+
+    expect(manifest.name).toBe('arra');
+    expect(manifest.entry).toBe('./index.ts');
+    expect(manifest.cli.command).toBe('arra');
+    expect(manifest.cli.handler).toBe('arraCli');
+    expect(manifest.verbs).toEqual(['help', 'version', 'menu', 'status']);
+    expect(manifest.httpRoutes[0].path).toBe('/api/plugins/arra');
+  });
+
+  test('loads and serves the shared ARRA plugin registry route', async () => {
+    const runtime = await loadUnifiedPlugins({ dirs: [pluginRoot] });
+    const arra = runtime.pluginRegistry().find((plugin) => plugin.name === 'arra');
+
+    expect(arra?.surfaces).toEqual(['apiRoutes', 'menu', 'cliSubcommands']);
+    expect(runtime.menu.find((item) => item.plugin === 'arra')?.path).toBe('/plugins/arra');
+    const command = runtime.cliSubcommands.find((item) => item.plugin === 'arra');
+    expect(command?.command).toBe('arra');
+    expect(command?.handler).toBe('arraCli');
+
+    const app = new Elysia();
+    for (const route of runtime.routes) app.use(route as never);
+    const response = await app.handle(new Request('http://local/api/plugins/arra'));
+    const body = await response.json() as { plugin: string; embedderRequired: boolean; verbs: Array<{ name: string }> };
+
+    expect(response.status).toBe(200);
+    expect(body.plugin).toBe('arra');
+    expect(body.embedderRequired).toBe(false);
+    expect(body.verbs.map((verb) => verb.name)).toEqual(['help', 'version', 'menu', 'status']);
+  });
+});

--- a/src/plugins/arra/index.ts
+++ b/src/plugins/arra/index.ts
@@ -1,0 +1,66 @@
+type ArraPluginContext = {
+  source: 'api' | 'mcp' | 'cli' | 'server' | 'init' | 'destroy';
+  plugin: string;
+  args?: unknown[];
+  request?: Request;
+};
+
+type ArraVerb = {
+  name: string;
+  help: string;
+  menuPath: string;
+  httpPath: string;
+  requiresEmbedder: boolean;
+  storage: 'swappable';
+};
+
+const VERSION = '1.0.0';
+const MENU_PATH = '/plugins/arra';
+const HTTP_PATH = '/api/plugins/arra';
+
+const VERBS: ArraVerb[] = [
+  { name: 'help', help: 'Show ARRA plugin commands', menuPath: MENU_PATH, httpPath: HTTP_PATH, requiresEmbedder: false, storage: 'swappable' },
+  { name: 'version', help: 'Print ARRA plugin version', menuPath: MENU_PATH, httpPath: HTTP_PATH, requiresEmbedder: false, storage: 'swappable' },
+  { name: 'menu', help: 'Describe the ARRA menu surface', menuPath: MENU_PATH, httpPath: HTTP_PATH, requiresEmbedder: false, storage: 'swappable' },
+  { name: 'status', help: 'Describe optional backend capabilities', menuPath: MENU_PATH, httpPath: HTTP_PATH, requiresEmbedder: false, storage: 'swappable' },
+];
+
+function commandName(ctx: ArraPluginContext): string {
+  const arg = ctx.args?.[0];
+  return typeof arg === 'string' && arg.trim() ? arg.trim().toLowerCase() : 'help';
+}
+
+function pluginBody(ctx: ArraPluginContext) {
+  return {
+    plugin: ctx.plugin || 'arra',
+    version: VERSION,
+    surface: ctx.source,
+    menuPath: MENU_PATH,
+    httpPath: HTTP_PATH,
+    cliCommand: 'arra',
+    embedderRequired: false,
+    storageBackend: 'swappable',
+    verbs: VERBS,
+  };
+}
+
+function renderCli(ctx: ArraPluginContext): string {
+  const command = commandName(ctx);
+  if (command === 'version') return `arra ${VERSION}`;
+  if (command === 'menu') return `arra menu: ${MENU_PATH}`;
+  if (command === 'status') return 'arra status: ok (embedder optional, storage swappable)';
+  if (command !== 'help') return `unknown arra command: ${command}\n${renderCli({ ...ctx, args: ['help'] })}`;
+  return ['maw arra <command>', ...VERBS.map((verb) => `  ${verb.name.padEnd(8)} ${verb.help}`)].join('\n');
+}
+
+export function arraHttpRoute(ctx: ArraPluginContext) {
+  return { ok: true, body: pluginBody(ctx) };
+}
+
+export function arraCli(ctx: ArraPluginContext) {
+  return { ok: true, output: renderCli(ctx) };
+}
+
+export default function handler(ctx: ArraPluginContext) {
+  return ctx.source === 'cli' ? arraCli(ctx) : arraHttpRoute(ctx);
+}

--- a/src/plugins/arra/plugin.json
+++ b/src/plugins/arra/plugin.json
@@ -1,0 +1,41 @@
+{
+  "name": "arra",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^0.1.0",
+  "enabled": true,
+  "description": "ARRA Oracle V3 maw-js plugin surface for CLI, menu, and HTTP discovery.",
+  "verbs": [
+    "help",
+    "version",
+    "menu",
+    "status"
+  ],
+  "httpRoutes": [
+    {
+      "path": "/api/plugins/arra",
+      "methods": ["GET"]
+    }
+  ],
+  "apiRoutes": [
+    {
+      "path": "/api/plugins/arra",
+      "methods": ["GET"],
+      "handler": "arraHttpRoute"
+    }
+  ],
+  "menu": [
+    {
+      "label": "ARRA Oracle",
+      "path": "/plugins/arra",
+      "group": "tools",
+      "order": 30,
+      "icon": "🔮"
+    }
+  ],
+  "cli": {
+    "command": "arra",
+    "help": "maw arra <help|version|menu|status>",
+    "handler": "arraCli"
+  }
+}

--- a/src/plugins/unified-loader.ts
+++ b/src/plugins/unified-loader.ts
@@ -66,9 +66,8 @@ interface InvokeResult {
   error?: string;
 }
 
-function uniqueDirs(dirs: string[]): string[] {
-  return [...new Set(dirs.filter(Boolean))];
-}
+function uniqueDirs(dirs: string[]): string[] { return [...new Set(dirs.filter(Boolean))]; }
+export function defaultUnifiedPluginDirs(extra: string[] = []): string[] { return uniqueDirs([...extra, ...DEFAULT_DIRS]); }
 
 function warn(options: UnifiedLoaderOptions, message: string): void {
   options.warn?.(`[unified-plugin] ${message}`);

--- a/src/plugins/unified-manifest.ts
+++ b/src/plugins/unified-manifest.ts
@@ -89,7 +89,7 @@ export interface UnifiedPluginManifest {
   api?: { path: string; methods?: UnifiedHttpMethod[] };
   lifecycle?: UnifiedLifecycleManifest;
   seedMenu?: boolean;
-  cli?: { command: string; help: string };
+  cli?: { command: string; help: string; handler?: string };
 }
 
 export interface NormalizedUnifiedPluginManifest extends Omit<UnifiedPluginManifest, 'api' | 'cli' | 'seedMenu'> {
@@ -161,7 +161,7 @@ export function normalizeUnifiedPluginManifest(raw: unknown): NormalizedUnifiedP
   if (manifest.api) apiRoutes.push({ path: manifest.api.path, methods: manifest.api.methods });
 
   const cliSubcommands = [...asArray(manifest.cliSubcommands)];
-  if (manifest.cli) cliSubcommands.push({ command: manifest.cli.command, help: manifest.cli.help });
+  if (manifest.cli) cliSubcommands.push({ command: manifest.cli.command, help: manifest.cli.help, handler: manifest.cli.handler });
 
   const menu = [...asArray(manifest.menu)];
   const mcpTools = asArray(manifest.mcpTools);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,5 @@
 import { Elysia } from 'elysia';
+import { join } from 'node:path';
 import { swagger } from '@elysiajs/swagger';
 import { eq } from 'drizzle-orm';
 
@@ -13,7 +14,7 @@ import { createCorsMiddleware, createPrivateNetworkPreflightMiddleware } from '.
 import { createContentTypeMiddleware } from './middleware/content-type.ts';
 import { createApiKeyAuthMiddleware } from './middleware/auth.ts';
 import { createCorrelationMiddleware } from './middleware/correlation.ts';
-import { loadUnifiedPlugins, seedUnifiedPluginMenuItems } from './plugins/unified-loader.ts';
+import { defaultUnifiedPluginDirs, loadUnifiedPlugins, seedUnifiedPluginMenuItems } from './plugins/unified-loader.ts';
 import { startUnifiedPluginServers } from './plugins/unified-server.ts';
 import { closeCachedVectorStores } from './vector/factory.ts';
 import { isDraining, registerGracefulShutdown, trackRequest } from './lifecycle/shutdown.ts';
@@ -94,7 +95,10 @@ writePidFile({
 const scoutAnnouncer = shouldStartScoutAnnouncer() ? new ScoutAnnouncer() : null;
 scoutAnnouncer?.start();
 
-const unifiedPlugins = await loadUnifiedPlugins({ warn: (message) => console.warn(message) });
+const unifiedPlugins = await loadUnifiedPlugins({
+  dirs: defaultUnifiedPluginDirs([join(import.meta.dir, 'plugins')]),
+  warn: (message) => console.warn(message),
+});
 await unifiedPlugins.init();
 const unifiedServers = await startUnifiedPluginServers(unifiedPlugins.servers);
 


### PR DESCRIPTION
Closes #1467

## Changes
- Added built-in `src/plugins/arra/` unified plugin manifest and InvokeContext handlers
- Declared ARRA CLI, menu, verbs, and HTTP discovery surfaces
- Registered built-in `src/plugins` with the unified plugin loader from `src/server.ts`
- Allowed `cli.handler` metadata to flow into normalized CLI subcommands

## Test
- bun test src/plugins/__tests__/arra-plugin.test.ts src/plugins/__tests__/unified-loader.test.ts src/plugins/__tests__/unified-manifest.test.ts
- bunx tsc --noEmit
