### PR TITLE
feat(canvas): HTTP registry + standalone serve surface (#950)

### DIFF
--- a/cli/src/plugins/canvas-serve/index.ts
+++ b/cli/src/plugins/canvas-serve/index.ts
@@ -1,0 +1,7 @@
+import type { InvokeContext, InvokeResult } from '../../plugin/types.ts';
+import { canvasServeCommand } from '../../../../src/cli/commands/canvas-serve.ts';
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const code = await canvasServeCommand(['canvas-serve', ...ctx.args]);
+  return code === 0 ? { ok: true } : { ok: false, error: 'canvas-serve failed' };
+}

--- a/cli/src/plugins/canvas-serve/plugin.json
+++ b/cli/src/plugins/canvas-serve/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "arra-canvas-serve",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^0.0.1",
+  "weight": 35,
+  "description": "Serve canvas.buildwithoracle.com locally as a standalone app",
+  "cli": {
+    "command": "canvas-serve",
+    "help": "arra-cli canvas-serve [--port N] [--api-base URL] [--dry-run]",
+    "flags": {
+      "--port": "Standalone canvas port (default 47779)",
+      "--api-base": "Oracle API base URL",
+      "--dry-run": "Print resolved serve config and exit"
+    }
+  }
+}

--- a/src/canvas/standalone.ts
+++ b/src/canvas/standalone.ts
@@ -1,0 +1,44 @@
+import { Elysia } from 'elysia';
+import { canvasRoutes } from '../routes/canvas/index.ts';
+import { handleCanvasRequest, type CanvasWorkerEnv } from '../workers/canvas/index.ts';
+
+export interface CanvasServeOptions {
+  port: number;
+  apiBase?: string;
+  hostname?: string;
+}
+
+export const DEFAULT_CANVAS_PORT = 47779;
+
+export function createCanvasStandaloneApp(env: CanvasWorkerEnv = {}) {
+  return new Elysia({ name: 'canvas-standalone' })
+    .use(canvasRoutes)
+    .all('*', ({ request }) => handleCanvasRequest(request, env));
+}
+
+function readFlag(args: string[], name: string): string | undefined {
+  const eq = args.find((arg) => arg.startsWith(`${name}=`));
+  if (eq) return eq.slice(name.length + 1);
+  const idx = args.indexOf(name);
+  return idx >= 0 ? args[idx + 1] : undefined;
+}
+
+export function parseCanvasServeOptions(args: string[], env: Record<string, string | undefined> = process.env): CanvasServeOptions {
+  const rawPort = readFlag(args, '--port') ?? env.CANVAS_PORT ?? String(DEFAULT_CANVAS_PORT);
+  const port = Number(rawPort);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) throw new Error('--port must be 1-65535');
+  return {
+    port,
+    apiBase: readFlag(args, '--api-base') ?? env.ORACLE_API_BASE,
+    hostname: readFlag(args, '--host') ?? env.CANVAS_HOST ?? '0.0.0.0',
+  };
+}
+
+export function canvasServeSummary(options: CanvasServeOptions) {
+  return {
+    url: `http://localhost:${options.port}`,
+    host: 'canvas.buildwithoracle.com',
+    port: options.port,
+    apiBase: options.apiBase ?? 'https://studio.buildwithoracle.com',
+  };
+}

--- a/src/cli/commands/canvas-serve.ts
+++ b/src/cli/commands/canvas-serve.ts
@@ -1,0 +1,31 @@
+import { canvasServeSummary, createCanvasStandaloneApp, parseCanvasServeOptions } from '../../canvas/standalone.ts';
+
+function printUsage(): void {
+  console.log('Usage: bun run src/cli/index.ts canvas-serve [--port N] [--api-base URL] [--host HOST] [--dry-run] [--json]');
+}
+
+export async function canvasServeCommand(args: string[]): Promise<number> {
+  if (args.includes('--help') || args.includes('-h')) {
+    printUsage();
+    return 0;
+  }
+  try {
+    const options = parseCanvasServeOptions(args.slice(1));
+    const summary = canvasServeSummary(options);
+    if (args.includes('--dry-run')) {
+      console.log(args.includes('--json') ? JSON.stringify(summary, null, 2) : `Canvas standalone ready at ${summary.url}`);
+      return 0;
+    }
+    const app = createCanvasStandaloneApp({ ORACLE_API_BASE: options.apiBase });
+    const server = Bun.serve({ hostname: options.hostname, port: options.port, fetch: (request) => app.handle(request) });
+    console.log(`Canvas standalone serving ${summary.host} on http://${options.hostname}:${server.port}`);
+    return await new Promise<number>((resolve) => {
+      const stop = () => { server.stop(); resolve(0); };
+      process.once('SIGINT', stop);
+      process.once('SIGTERM', stop);
+    });
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,12 +3,14 @@
 import { exportCommand } from './commands/export.ts';
 import { serveCommand } from './commands/serve.ts';
 import { canvasPluginsCommand } from './commands/canvas-plugins.ts';
+import { canvasServeCommand } from './commands/canvas-serve.ts';
 
 function printUsage(): void {
-  console.error('usage: bun run src/cli/index.ts <export|serve|canvas-plugins> ...');
+  console.error('usage: bun run src/cli/index.ts <export|serve|canvas-plugins|canvas-serve> ...');
   console.error('  export: bun run src/cli/index.ts export --format json|markdown [--out <file>]');
   console.error('  serve:  bun run src/cli/index.ts serve <start|stop|status> [--foreground|--background] [--json]');
   console.error('  canvas-plugins: bun run src/cli/index.ts canvas-plugins [--kind three|react] [--id <id>] [--json]');
+  console.error('  canvas-serve: bun run src/cli/index.ts canvas-serve [--port N] [--api-base URL]');
 }
 
 async function main() {
@@ -20,6 +22,7 @@ async function main() {
 
   if (args[0] === 'serve') process.exit(await serveCommand(args));
   if (args[0] === 'canvas-plugins') process.exit(await canvasPluginsCommand(args));
+  if (args[0] === 'canvas-serve') process.exit(await canvasServeCommand(args));
   if (args[0] === 'export') process.exit(await exportCommand(args));
 
   console.error(`unknown command: ${args[0]}`);

--- a/src/routes/canvas/index.ts
+++ b/src/routes/canvas/index.ts
@@ -1,0 +1,43 @@
+import { Elysia, t } from 'elysia';
+import { findCanvasPlugin, listCanvasPlugins, type CanvasPluginKind } from '../../canvas/plugins.ts';
+
+const kinds = new Set<CanvasPluginKind>(['three', 'react']);
+
+function parseKind(value: unknown): CanvasPluginKind | undefined {
+  return typeof value === 'string' && kinds.has(value as CanvasPluginKind) ? value as CanvasPluginKind : undefined;
+}
+
+function registry(kind?: CanvasPluginKind) {
+  const plugins = listCanvasPlugins(kind);
+  return {
+    plugins,
+    count: plugins.length,
+    kind: kind ?? 'all',
+    standalone: {
+      host: 'canvas.buildwithoracle.com',
+      defaultPlugin: 'wave',
+      serveCommand: 'bun run src/cli/index.ts canvas-serve --port 47779',
+    },
+  };
+}
+
+export const canvasRoutes = new Elysia({ name: 'canvas-routes' })
+  .get('/api/canvas/plugins', ({ query }) => registry(parseKind(query.kind)), {
+    query: t.Object({ kind: t.Optional(t.String()) }),
+    detail: { tags: ['canvas'], summary: 'List canvas plugin registry entries' },
+  })
+  .get('/api/canvas/plugins/:id', ({ params, set }) => {
+    const plugin = findCanvasPlugin(params.id);
+    if (!plugin) {
+      set.status = 404;
+      return { error: 'canvas plugin not found', id: params.id };
+    }
+    return { plugin };
+  }, {
+    params: t.Object({ id: t.String({ minLength: 1 }) }),
+    detail: { tags: ['canvas'], summary: 'Get one canvas plugin registry entry' },
+  })
+  .get('/api/canvas/registry', ({ query }) => registry(parseKind(query.kind)), {
+    query: t.Object({ kind: t.Optional(t.String()) }),
+    detail: { tags: ['canvas'], summary: 'Canvas standalone registry manifest' },
+  });

--- a/src/server.ts
+++ b/src/server.ts
@@ -56,6 +56,7 @@ import { peerRoutes } from './routes/peer/index.ts';
 import { createMcpRoutes } from './routes/mcp/index.ts';
 import { createMetricsLifecycle, metricsRoutes } from './routes/metrics/index.ts';
 import { memoryRoutes } from './routes/memory/index.ts';
+import { canvasRoutes } from './routes/canvas/index.ts';
 
 let indexerRoutes: any = null;
 try {
@@ -194,6 +195,7 @@ const apiModules = [
   vaultRoutes,
   metricsRoutes,
   memoryRoutes,
+  canvasRoutes,
   ...(indexerRoutes ? [indexerRoutes] : []),
   ...unifiedPlugins.routes,
 ];

--- a/tests/canvas/phase2.test.ts
+++ b/tests/canvas/phase2.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { canvasRoutes } from '../../src/routes/canvas/index.ts';
+import { canvasServeCommand } from '../../src/cli/commands/canvas-serve.ts';
+import { createCanvasStandaloneApp, parseCanvasServeOptions } from '../../src/canvas/standalone.ts';
+import { discoverPlugins } from '../../cli/src/plugin/loader.ts';
+import { pluginCliCommands } from '../../cli/src/plugin/registry.ts';
+
+describe('canvas phase 2 HTTP and standalone surfaces', () => {
+  test('exposes canvas registry through dedicated HTTP routes', async () => {
+    const app = new Elysia().use(canvasRoutes);
+    const response = await app.handle(new Request('http://local/api/canvas/plugins?kind=react'));
+    const body = await response.json() as { count: number; plugins: Array<{ id: string; kind: string }> };
+
+    expect(response.status).toBe(200);
+    expect(body.count).toBe(2);
+    expect(body.plugins.map((plugin) => plugin.id)).toEqual(['map', 'planets']);
+  });
+
+  test('returns 404 for unknown canvas plugin ids', async () => {
+    const app = new Elysia().use(canvasRoutes);
+    const response = await app.handle(new Request('http://local/api/canvas/plugins/missing'));
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: 'canvas plugin not found', id: 'missing' });
+  });
+
+  test('standalone app serves canvas HTML and registry API together', async () => {
+    const app = createCanvasStandaloneApp({ ORACLE_API_BASE: 'https://oracle.example.test' });
+    const html = await app.handle(new Request('http://canvas.local/?plugin=wave'));
+    const registry = await app.handle(new Request('http://canvas.local/api/canvas/registry'));
+
+    expect(html.status).toBe(200);
+    expect(await html.text()).toContain('plugin=wave');
+    expect((await registry.json() as { standalone: { host: string } }).standalone.host).toBe('canvas.buildwithoracle.com');
+  });
+
+  test('bundled CLI registry exposes canvas-serve command', async () => {
+    const result = await discoverPlugins({ userPluginDir: '/tmp/missing-user-plugins' });
+    const commands = result.plugins.flatMap(pluginCliCommands).map((entry) => entry.command);
+
+    expect(commands).toContain('canvas-serve');
+  });
+
+  test('canvas-serve supports dry-run without binding a port', async () => {
+    const lines: string[] = [];
+    const originalLog = console.log;
+    console.log = (message?: unknown) => lines.push(String(message));
+    try {
+      expect(parseCanvasServeOptions(['--port', '47780']).port).toBe(47780);
+      expect(await canvasServeCommand(['canvas-serve', '--port', '47780', '--dry-run', '--json'])).toBe(0);
+    } finally {
+      console.log = originalLog;
+    }
+    expect(JSON.parse(lines[0])).toMatchObject({ port: 47780, host: 'canvas.buildwithoracle.com' });
+  });
+});


### PR DESCRIPTION
Implements #950 Phase 2 canvas HTTP + standalone serve surface.

Changes:
- Adds dedicated canvas registry HTTP routes under `/api/canvas/plugins` and `/api/canvas/registry`.
- Registers the canvas routes in the main HTTP server.
- Adds reusable standalone canvas app wrapper that serves registry API plus canvas HTML/proxy fallback.
- Adds `canvas-serve` command surface via `src/cli/index.ts` and bundled CLI plugin metadata for `arra-cli canvas-serve`.
- Keeps worker/plugin registry behavior using the shared `src/canvas/plugins.ts` source of truth.

Validation:
- `bunx tsc --noEmit`
- `bun test tests/canvas/phase2.test.ts tests/workers/canvas-worker.test.ts tests/plugins/canvas-registry.test.ts`
