### PR TITLE
fix: expose tenant-scoped stats response

### DIFF
--- a/src/routes/health/stats.ts
+++ b/src/routes/health/stats.ts
@@ -18,6 +18,10 @@ const StatsResponseSchema = t.Object({
   })),
   database: t.Optional(t.String()),
   vault_repo: t.Optional(t.Nullable(t.String())),
+  tenant: t.Optional(t.Object({
+    id: t.String(),
+    scope: t.String(),
+  })),
   error: t.Optional(t.String()),
 });
 

--- a/tests/http/health/tenant-scope.test.ts
+++ b/tests/http/health/tenant-scope.test.ts
@@ -37,7 +37,7 @@ function createFetch() {
   return createTenantFetch((request) => app.handle(request));
 }
 
-test.skip('GET /api/stats scopes document counts by tenant header', async () => {
+test('GET /api/stats scopes document counts by tenant header', async () => {
   const res = await createFetch()(new Request('http://local/api/stats', {
     headers: { [TENANT_HEADER]: tenantA },
   }));


### PR DESCRIPTION
## Summary
- re-enable the tenant-scoped `/api/stats` regression test
- include the optional `tenant` object in the `/api/stats` TypeBox response schema
- preserve the existing `tenantStats()` filtering by `X-Oracle-Tenant` / project scope

## Tests
- `bun test tests/http/health/tenant-scope.test.ts`
- `bun test tests/http/health/`
- `bunx tsc --noEmit`

Refs #1650
