### PR TITLE
feat: vector phase 4 fallback fanout cost

### DIFF
--- a/src/routes/vector/cost.ts
+++ b/src/routes/vector/cost.ts
@@ -1,0 +1,72 @@
+import { Elysia, t } from 'elysia';
+import { getDetectedEmbeddingProviders } from '../../vector/provider-detection.ts';
+import { estimateEmbeddingCost, recommendEmbeddingModel, type CostProvider } from '../../vector/cost-estimation.ts';
+import { getEmbeddingModels, createVectorStoreForModel, type EmbeddingModelConfig } from '../../vector/factory.ts';
+
+export interface VectorCostEndpointOptions {
+  getModels?: () => Record<string, EmbeddingModelConfig>;
+  getCount?: (key: string, model: EmbeddingModelConfig) => Promise<number>;
+  detectProviders?: () => Promise<{ providers: Array<{ type: string; available: boolean }> }>;
+}
+
+const providerSchema = t.Union([
+  t.Literal('openai'),
+  t.Literal('gemini'),
+  t.Literal('ollama'),
+  t.Literal('local'),
+  t.Literal('remote'),
+  t.Literal('cloudflare-ai'),
+]);
+
+async function defaultCount(_key: string, model: EmbeddingModelConfig): Promise<number> {
+  const store = createVectorStoreForModel(model);
+  try {
+    await store.connect();
+    return (await store.getStats()).count;
+  } finally {
+    await store.close().catch(() => undefined);
+  }
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+export function createVectorCostEndpoint(options: VectorCostEndpointOptions = {}) {
+  return new Elysia().get('/vector/cost-estimate', async ({ query }) => {
+    const models = options.getModels?.() ?? getEmbeddingModels();
+    const entries = Object.entries(models);
+    const requested = query.collection ? entries.filter(([key]) => key === query.collection) : entries;
+    const counts = await Promise.all(requested.map(async ([key, model]) => options.getCount?.(key, model) ?? defaultCount(key, model)));
+    const docs = query.docs ? parsePositiveInt(query.docs, 0) : counts.reduce((sum, count) => sum + count, 0);
+    const provider = (query.provider ?? 'openai') as CostProvider;
+    const estimate = estimateEmbeddingCost({
+      docs,
+      provider,
+      model: query.model,
+      tokensPerDoc: parsePositiveInt(query.tokensPerDoc, 500),
+    });
+    const detected = await (options.detectProviders?.() ?? getDetectedEmbeddingProviders(false));
+    const availableProviders = detected.providers.filter((item) => item.available).map((item) => item.type);
+    return {
+      ...estimate,
+      collection: query.collection ?? 'all',
+      collections: requested.map(([key], index) => ({ key, docs: counts[index] })),
+      availableProviders,
+      recommendation: recommendEmbeddingModel(docs, availableProviders),
+    };
+  }, {
+    query: t.Object({
+      docs: t.Optional(t.String()),
+      tokensPerDoc: t.Optional(t.String()),
+      provider: t.Optional(providerSchema),
+      model: t.Optional(t.String()),
+      collection: t.Optional(t.String()),
+    }),
+    detail: { tags: ['vector'], summary: 'Estimate embedding cost before remote indexing' },
+  });
+}
+
+export const vectorCostEndpoint = createVectorCostEndpoint();

--- a/src/routes/vector/fanout.ts
+++ b/src/routes/vector/fanout.ts
@@ -1,10 +1,16 @@
 import { Elysia } from 'elysia';
-import { ensureVectorStoreConnected, getEmbeddingModels } from '../../vector/factory.ts';
+import { ensureVectorStoreConnected, getEmbeddingModels, type EmbeddingModelConfig } from '../../vector/factory.ts';
 import { queryFanout } from '../../vector/fanout-query.ts';
 import { QueryCache, stableCacheKey } from '../../vector/query-cache.ts';
 import { FanoutQuery } from './model.ts';
+import type { VectorStoreAdapter } from '../../vector/types.ts';
 
 const cache = new QueryCache<unknown>();
+
+export interface FanoutEndpointOptions {
+  getModels?: () => Record<string, EmbeddingModelConfig>;
+  getStore?: (key: string, models: Record<string, EmbeddingModelConfig>) => Promise<Pick<VectorStoreAdapter, 'query'>>;
+}
 
 function sanitize(q: string): string {
   return q.replace(/<[^>]*>/g, '').replace(/[\x00-\x1f]/g, '').trim();
@@ -15,7 +21,8 @@ function requestedBackends(raw: string | undefined, enabled: string[]): string[]
   return requested.filter((item, index) => enabled.includes(item) && requested.indexOf(item) === index);
 }
 
-export const fanoutEndpoint = new Elysia().get(
+export function createFanoutEndpoint(options: FanoutEndpointOptions = {}) {
+  return new Elysia().get(
   '/vector/fanout',
   async ({ query, set }) => {
     if (!query.q) {
@@ -28,7 +35,7 @@ export const fanoutEndpoint = new Elysia().get(
       return { error: 'Invalid query: empty after sanitization' };
     }
 
-    const models = getEmbeddingModels();
+    const models = options.getModels?.() ?? getEmbeddingModels();
     const backends = requestedBackends(query.fanout, Object.keys(models));
     const limit = Math.min(100, Math.max(1, parseInt(query.limit ?? '20')));
     if (backends.length === 0) return { query: q, strategy: 'merge', backends, results: [], errors: {} };
@@ -42,7 +49,7 @@ export const fanoutEndpoint = new Elysia().get(
     const where = query.type && query.type !== 'all' ? { type: query.type } : undefined;
     const targets = await Promise.all(backends.map(async (key) => ({
       key,
-      store: await ensureVectorStoreConnected(key, models),
+      store: await (options.getStore?.(key, models) ?? ensureVectorStoreConnected(key, models)),
     })));
     const result = { query: q, ...(await queryFanout({ text: q, limit, where, targets })) };
     if (query.cache !== 'false') cache.set(cacheKey, result);
@@ -57,3 +64,6 @@ export const fanoutEndpoint = new Elysia().get(
     },
   },
 );
+}
+
+export const fanoutEndpoint = createFanoutEndpoint();

--- a/src/routes/vector/index.ts
+++ b/src/routes/vector/index.ts
@@ -10,6 +10,7 @@
  *   GET /api/map3d           — 3D PCA projection from real embeddings
  *   GET /api/vector/stats    — per-engine collection counts
  *   GET /api/vector/health   — adapter liveness probe
+ *   GET /api/vector/cost-estimate — estimate remote embedding cost
  *   GET /api/vector/documents — browse indexed vector documents
  *   GET /api/v1/vector/export/formats — available export formats
  *   GET /api/v1/vector/export — stream vector docs in a registered format
@@ -38,6 +39,7 @@ import { vectorDocumentsEndpoint } from './documents.ts';
 import { vectorExportEndpoint } from './export.ts';
 import { vectorServicesApiEndpoint } from './services.ts';
 import { vectorProvidersEndpoint } from './providers.ts';
+import { vectorCostEndpoint } from './cost.ts';
 
 export const vectorRoutes = new Elysia({ prefix: '/api' })
   .use(vectorProxyEndpoint)
@@ -53,5 +55,6 @@ export const vectorRoutes = new Elysia({ prefix: '/api' })
   .use(vectorExportEndpoint)
   .use(vectorConfigApiEndpoint)
   .use(vectorProvidersEndpoint)
+  .use(vectorCostEndpoint)
   .use(vectorServicesApiEndpoint)
   .use(vectorIndexerEndpoints);

--- a/src/vector/config.ts
+++ b/src/vector/config.ts
@@ -61,7 +61,7 @@ export interface VectorServerConfig {
 export type VectorProxyManifest = UnifiedProxyManifest;
 
 /** Absolute path to vector-server.json inside ORACLE_DATA_DIR. */
-export function configPath(dataDir = ORACLE_DATA_DIR): string {
+export function configPath(dataDir = process.env.ORACLE_DATA_DIR || ORACLE_DATA_DIR): string {
   return path.join(dataDir, VECTOR_CONFIG_FILE);
 }
 

--- a/src/vector/cost-estimation.ts
+++ b/src/vector/cost-estimation.ts
@@ -1,0 +1,84 @@
+import type { EmbeddingProviderType } from './types.ts';
+
+export type CostProvider = Extract<EmbeddingProviderType, 'openai' | 'gemini' | 'ollama' | 'local' | 'remote' | 'cloudflare-ai'>;
+
+export interface CostEstimateInput {
+  docs: number;
+  tokensPerDoc?: number;
+  provider?: CostProvider;
+  model?: string;
+}
+
+export interface CostEstimate {
+  docs: number;
+  tokensPerDoc: number;
+  totalTokens: number;
+  provider: CostProvider;
+  model: string;
+  estimatedUsd: number;
+  formula: string;
+  note: string;
+}
+
+const DEFAULT_TOKENS_PER_DOC = 500;
+
+const PRICE_PER_MILLION: Record<CostProvider, number> = {
+  openai: 0.02,
+  gemini: 0,
+  ollama: 0,
+  local: 0,
+  remote: 0,
+  'cloudflare-ai': 0.008,
+};
+
+const DEFAULT_MODEL: Record<CostProvider, string> = {
+  openai: 'text-embedding-3-small',
+  gemini: 'text-embedding-004',
+  ollama: 'nomic-embed-text',
+  local: 'nomic-embed-text',
+  remote: 'remote-embedder',
+  'cloudflare-ai': '@cf/baai/bge-base-en-v1.5',
+};
+
+export function estimateEmbeddingCost(input: CostEstimateInput): CostEstimate {
+  const docs = Math.max(0, Math.floor(input.docs));
+  const tokensPerDoc = Math.max(1, Math.floor(input.tokensPerDoc ?? DEFAULT_TOKENS_PER_DOC));
+  const provider = input.provider ?? 'openai';
+  const model = input.model || DEFAULT_MODEL[provider];
+  const totalTokens = docs * tokensPerDoc;
+  const estimatedUsd = Number(((totalTokens / 1_000_000) * PRICE_PER_MILLION[provider]).toFixed(4));
+  return {
+    docs,
+    tokensPerDoc,
+    totalTokens,
+    provider,
+    model,
+    estimatedUsd,
+    formula: `${docs.toLocaleString()} docs × ~${tokensPerDoc.toLocaleString()} tokens/doc ≈ ${compactTokens(totalTokens)} tokens`,
+    note: noteFor(provider),
+  };
+}
+
+export function recommendEmbeddingModel(docs: number, availableProviders: string[] = []): string {
+  const available = new Set(availableProviders);
+  if (docs < 10_000) return 'Any configured embedding model should work for this corpus size.';
+  if (docs <= 100_000) {
+    if (available.has('gemini')) return 'Gemini free tier is recommended before paid remote embedding.';
+    if (available.has('ollama') || available.has('local')) return 'Ollama/local embeddings are recommended to avoid remote cost.';
+    return 'Use OpenAI small embeddings for speed, but review cost first.';
+  }
+  return 'Use Ollama/local embeddings with GPU acceleration for large indexes.';
+}
+
+function compactTokens(tokens: number): string {
+  if (tokens >= 1_000_000) return `${Number((tokens / 1_000_000).toFixed(1))}M`;
+  if (tokens >= 1_000) return `${Number((tokens / 1_000).toFixed(1))}K`;
+  return String(tokens);
+}
+
+function noteFor(provider: CostProvider): string {
+  if (provider === 'gemini') return 'Gemini estimate is $0 here because this app treats daily free-tier usage as zero marginal cost.';
+  if (provider === 'ollama' || provider === 'local') return 'Local/Ollama estimate excludes hardware and electricity costs.';
+  if (provider === 'remote') return 'Remote provider pricing depends on the configured service.';
+  return 'Estimate only; check provider pricing before large indexing jobs.';
+}

--- a/src/vector/registry.ts
+++ b/src/vector/registry.ts
@@ -120,6 +120,7 @@ function validateService(service: RegisteredVectorService): RegisteredVectorServ
 
 class InMemoryVectorServiceRegistry implements VectorServiceRegistry {
   async register(service: RegisteredVectorService): Promise<RegisteredVectorService> {
+    ensureConfigRefreshed();
     const normalized = validateService(service);
     registry.set(normalized.name, normalized);
     syncConfig(registry);
@@ -138,6 +139,7 @@ class InMemoryVectorServiceRegistry implements VectorServiceRegistry {
   }
 
   async unregister(name: string): Promise<boolean> {
+    ensureConfigRefreshed();
     const removed = registry.delete(name);
     if (removed) syncConfig(registry);
     return removed;

--- a/tests/http/vector/phase4-polish.test.ts
+++ b/tests/http/vector/phase4-polish.test.ts
@@ -1,0 +1,81 @@
+import { expect, mock, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import type { EmbeddingProvider, VectorQueryResult } from '../../../src/vector/types.ts';
+
+const models = {
+  local: { collection: 'local_docs', model: 'bge-m3', adapter: 'lancedb' as const },
+  remote: { collection: 'remote_docs', model: 'qwen3', adapter: 'qdrant' as const },
+};
+
+function queryResult(ids: string[], distances: number[]): VectorQueryResult {
+  return {
+    ids,
+    distances,
+    documents: ids.map((id) => `${id} body`),
+    metadatas: ids.map(() => ({ type: 'note', source_file: 'note.md' })),
+  };
+}
+
+test('GET /api/v1/vector/fanout merges and deduplicates parallel backend results', async () => {
+  const { createFanoutEndpoint } = await import('../../../src/routes/vector/fanout.ts');
+  const app = new Elysia({ prefix: '/api' }).use(createFanoutEndpoint({
+    getModels: () => models,
+    getStore: async (key) => ({
+      query: mock(async () => key === 'local'
+        ? queryResult(['same', 'local-only'], [10, 20])
+        : queryResult(['same', 'remote-only'], [5, 30])),
+    }),
+  }));
+  const res = await createApiVersionedFetch((request) => app.handle(request))(
+    new Request('http://local/api/v1/vector/fanout?q=oracle&fanout=local,remote&limit=5&cache=false'),
+  );
+  const body = await res.json() as { backends: string[]; results: Array<{ id: string; source: string }>; errors: Record<string, string> };
+
+  expect(res.status).toBe(200);
+  expect(body.backends).toEqual(['local', 'remote']);
+  expect(body.results.map((item) => item.id)).toEqual(['same', 'local-only', 'remote-only']);
+  expect(body.results[0].source).toBe('hybrid');
+  expect(body.errors).toEqual({});
+});
+
+test('GET /api/v1/vector/cost-estimate returns token cost and recommendation', async () => {
+  const { createVectorCostEndpoint } = await import('../../../src/routes/vector/cost.ts');
+  const app = new Elysia({ prefix: '/api' }).use(createVectorCostEndpoint({
+    getModels: () => models,
+    getCount: async (key) => key === 'local' ? 10 : 20,
+    detectProviders: async () => ({ providers: [{ type: 'gemini', available: true }] }),
+  }));
+  const res = await createApiVersionedFetch((request) => app.handle(request))(
+    new Request('http://local/api/v1/vector/cost-estimate?provider=openai&tokensPerDoc=500'),
+  );
+  const body = await res.json() as Record<string, unknown>;
+
+  expect(res.status).toBe(200);
+  expect(body.docs).toBe(30);
+  expect(body.totalTokens).toBe(15_000);
+  expect(body.estimatedUsd).toBe(0.0003);
+  expect(String(body.formula)).toContain('30 docs');
+  expect(String(body.recommendation)).toContain('Any configured');
+});
+
+test('FallbackEmbeddings switches to the next provider after primary failure', async () => {
+  const { FallbackEmbeddings } = await import('../../../src/vector/embeddings.ts');
+  const events: Array<{ from: string; to?: string }> = [];
+  const failing: EmbeddingProvider = {
+    name: 'ollama',
+    dimensions: 3,
+    embed: mock(async () => { throw new Error('ollama down'); }),
+  };
+  const fallback: EmbeddingProvider = {
+    name: 'gemini',
+    dimensions: 3,
+    embed: mock(async () => [[1, 2, 3]]),
+  };
+
+  const provider = new FallbackEmbeddings([failing, fallback], (event) => events.push(event));
+  await expect(provider.embed(['hello'], 'passage')).resolves.toEqual([[1, 2, 3]]);
+  expect(failing.embed).toHaveBeenCalled();
+  expect(fallback.embed).toHaveBeenCalled();
+  expect(events).toEqual([{ from: 'ollama', to: 'gemini', error: 'ollama down' }]);
+});


### PR DESCRIPTION
## Summary
- add `/api/v1/vector/cost-estimate` for pre-index token/cost estimates and model recommendations
- make fan-out vector query endpoint injectable/testable and cover merge/dedup behavior
- cover embedding fallback-chain behavior and fix vector registry config refresh so service registration preserves current collections

## Verification
- bunx tsc --noEmit
- bun test tests/http/vector/

Closes #1440
