### PR TITLE
feat(canvas): React plugin registry page (#950)

### DIFF
--- a/frontend/src/api/canvas-plugins.ts
+++ b/frontend/src/api/canvas-plugins.ts
@@ -1,0 +1,44 @@
+import { API_BASE } from './oracle';
+
+export type CanvasPluginKind = 'three' | 'react';
+
+interface BaseCanvasPluginEntry {
+  id: string;
+  label: string;
+  description: string;
+  kind: CanvasPluginKind;
+  path: string;
+  query: { plugin: string };
+}
+
+export interface ThreeCanvasPluginEntry extends BaseCanvasPluginEntry {
+  kind: 'three';
+  mount: string;
+}
+
+export interface ReactCanvasPluginEntry extends BaseCanvasPluginEntry {
+  kind: 'react';
+  renderer: string;
+  apiPath?: string;
+}
+
+export type CanvasPluginEntry = ThreeCanvasPluginEntry | ReactCanvasPluginEntry;
+
+export interface CanvasPluginsResponse {
+  plugins: CanvasPluginEntry[];
+  count: number;
+  kind: CanvasPluginKind | 'all';
+}
+
+function urlFor(path: string): string {
+  if (!API_BASE) return path;
+  return new URL(path, API_BASE).toString();
+}
+
+export async function fetchCanvasPlugins(kind?: CanvasPluginKind): Promise<CanvasPluginsResponse> {
+  const query = kind ? `?${new URLSearchParams({ kind }).toString()}` : '';
+  const path = `/api/canvas/plugins${query}`;
+  const response = await fetch(urlFor(path), { headers: { accept: 'application/json' } });
+  if (!response.ok) throw new Error(`${path} returned ${response.status}`);
+  return await response.json() as CanvasPluginsResponse;
+}

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -50,6 +50,7 @@ export function AppShell({
   const navItems: NavItem[] = [
     { to: '/', label: 'Menu', description: 'Navigation rows from /api/menu', badge: loading ? '…' : menuCount },
     { to: '/plugins', label: 'Plugins', description: 'Registered plugins and surfaces', badge: loading ? '…' : pluginCount },
+    { to: '/canvas/plugins', label: 'Canvas Plugins', description: 'Canvas registry from /api/canvas/plugins' },
     { to: '/search', label: 'Search', description: 'Full-text menu search' },
     { to: '/vector', label: 'Vector Dashboard', description: 'Collection health and indexing', end: true },
     { to: '/vector/documents', label: 'Document Browser', description: 'Browse indexed vector documents' },

--- a/frontend/src/pages/CanvasPluginsPage.tsx
+++ b/frontend/src/pages/CanvasPluginsPage.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useMemo, useState } from 'react';
+import { fetchCanvasPlugins, type CanvasPluginEntry, type CanvasPluginsResponse } from '../api/canvas-plugins';
+import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
+
+type PageState = 'loading' | 'ready' | 'error';
+type CanvasClient = { canvasPlugins: () => Promise<CanvasPluginsResponse> };
+const defaultClient: CanvasClient = { canvasPlugins: () => fetchCanvasPlugins() };
+
+export interface CanvasPluginsPageProps {
+  plugins?: CanvasPluginEntry[];
+  loading?: boolean;
+  client?: CanvasClient;
+}
+
+function pluginHref(plugin: CanvasPluginEntry): string {
+  const qs = new URLSearchParams(plugin.query ?? { plugin: plugin.id });
+  return `${plugin.path || '/canvas'}?${qs.toString()}`;
+}
+
+function statusClass(plugin: CanvasPluginEntry): string {
+  if (plugin.kind === 'react') return 'border-purple-300/30 bg-purple-300/10 text-purple-100';
+  return 'border-teal-300/30 bg-teal-300/10 text-teal-100';
+}
+
+function PluginCard({ plugin }: { plugin: CanvasPluginEntry }) {
+  const target = pluginHref(plugin);
+  return (
+    <article className="rounded-3xl border border-white/10 bg-slate-950/70 p-5" aria-label={`${plugin.label} canvas plugin`}>
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">{plugin.id}</p>
+          <h3 className="mt-1 text-xl font-semibold text-white">{plugin.label}</h3>
+        </div>
+        <span className={`rounded-full border px-2 py-1 text-xs font-semibold ${statusClass(plugin)}`}>{plugin.kind}</span>
+      </div>
+      <p className="text-sm text-slate-300">{plugin.description}</p>
+      <dl className="mt-4 grid gap-3 text-sm">
+        <div><dt className="text-slate-500">Status</dt><dd className="font-semibold text-emerald-200">registered</dd></div>
+        <div><dt className="text-slate-500">Canvas target</dt><dd className="break-all font-mono text-slate-100">{target}</dd></div>
+        <div><dt className="text-slate-500">Runtime hook</dt><dd className="font-mono text-slate-100">{'renderer' in plugin ? plugin.renderer : plugin.mount}</dd></div>
+        {'apiPath' in plugin && plugin.apiPath ? <div><dt className="text-slate-500">Data API</dt><dd className="font-mono text-slate-100">{plugin.apiPath}</dd></div> : null}
+      </dl>
+      <a className="focus-ring mt-4 inline-flex rounded-xl border border-teal-300/30 px-3 py-2 text-sm font-semibold text-teal-100 hover:bg-teal-300/10" href={target}>Open canvas</a>
+    </article>
+  );
+}
+
+export function CanvasPluginsPage({ plugins: initialPlugins = [], loading = true, client = defaultClient }: CanvasPluginsPageProps) {
+  const [plugins, setPlugins] = useState(initialPlugins);
+  const [state, setState] = useState<PageState>(loading ? 'loading' : 'ready');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    setState('loading');
+    setError('');
+    client.canvasPlugins()
+      .then((response) => {
+        if (cancelled) return;
+        setPlugins(response.plugins);
+        setState('ready');
+      })
+      .catch((cause) => {
+        if (cancelled) return;
+        setError(cause instanceof Error ? cause.message : String(cause));
+        setState(initialPlugins.length ? 'ready' : 'error');
+      });
+    return () => { cancelled = true; };
+  }, [client, initialPlugins.length]);
+
+  const summary = useMemo(() => {
+    const react = plugins.filter((plugin) => plugin.kind === 'react').length;
+    const three = plugins.filter((plugin) => plugin.kind === 'three').length;
+    return `${plugins.length} registered · ${three} three · ${react} react`;
+  }, [plugins]);
+
+  return (
+    <section className="grid gap-5" aria-labelledby="canvas-plugins-title">
+      <header className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Canvas plugins</p>
+        <h1 id="canvas-plugins-title" className="mt-2 text-3xl font-semibold text-white">Canvas plugin registry</h1>
+        <p className="mt-2 text-sm text-slate-400">Fetched from /api/canvas/plugins for canvas.buildwithoracle.com standalone rendering.</p>
+        <p className="mt-3 inline-flex rounded-full border border-white/10 px-3 py-2 text-sm text-slate-300">{summary}</p>
+      </header>
+
+      {state === 'loading' ? <LoadingPanel title="Loading canvas plugins" detail="Reading /api/canvas/plugins." /> : null}
+      {state === 'error' ? <ErrorMessage title="Could not load canvas plugins." message={error} /> : null}
+      {state !== 'error' && error ? <ErrorMessage title="Canvas plugin warning" message={error} /> : null}
+      {state !== 'error' ? <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">{plugins.map((plugin) => <PluginCard key={plugin.id} plugin={plugin} />)}</div> : null}
+    </section>
+  );
+}

--- a/frontend/src/routeMeta.ts
+++ b/frontend/src/routeMeta.ts
@@ -69,6 +69,7 @@ export function routeMeta(pathname: string, search = ''): RouteMeta {
   }
 
   if (pathname === '/plugins') return base('Plugin list', 'Plugins', 'Registered plugins and exposed runtime surfaces.', [{ label: 'Plugins' }]);
+  if (pathname === '/canvas/plugins') return base('Canvas plugins', 'Canvas', 'Canvas plugin registry and standalone status.', [{ label: 'Canvas plugins' }]);
   if (pathname === '/metrics') return base('Runtime metrics', 'Metrics', 'Runtime counters from /api/v1/metrics.', [{ label: 'Metrics' }]);
   if (pathname === '/search') return base('Search', 'Search', 'Search menu, plugin, and MCP tool surfaces.', [{ label: 'Search' }]);
   if (pathname === '/learn') return base('Learn entries', 'Learn', 'Capture and edit Oracle learnings.', [{ label: 'Learn' }]);

--- a/frontend/src/routePaths.ts
+++ b/frontend/src/routePaths.ts
@@ -35,3 +35,7 @@ export function vectorExportPagePath(): string {
 export function vectorSettingsPath(): string {
   return '/vector/settings';
 }
+
+export function canvasPluginsPath(): string {
+  return '/canvas/plugins';
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -7,6 +7,7 @@ import { McpToolDetailPage } from './pages/McpToolDetailPage';
 import { LearnPage } from './pages/LearnPage';
 import { MenuPage } from './pages/MenuPage';
 import { PluginsPage } from './pages/PluginsPage';
+import { CanvasPluginsPage } from './pages/CanvasPluginsPage';
 import { SearchPage } from './pages/SearchPage';
 import { SettingsPage } from './pages/SettingsPage';
 import { VectorPage } from './pages/VectorPage';
@@ -21,6 +22,7 @@ import type { MetricsSnapshot } from '../../src/server/types';
 export const frontendRoutes = [
   '/',
   '/plugins',
+  '/canvas/plugins',
   '/metrics',
   '/search',
   '/learn',
@@ -72,6 +74,7 @@ export function DashboardRoutes({
     <Routes>
       <Route index element={menuPage} />
       <Route path="/plugins" element={pluginPage} />
+      <Route path="/canvas/plugins" element={<CanvasPluginsPage />} />
       <Route path="/metrics" element={<MetricsPage metrics={metrics} loading={isRouteLoading(states.metrics)} />} />
       <Route path="/search" element={<SearchPage />} />
       <Route path="/learn" element={<LearnPage />} />

--- a/tests/frontend/pages/canvas-plugins-page.test.tsx
+++ b/tests/frontend/pages/canvas-plugins-page.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test';
+import { CanvasPluginsPage } from '../../../frontend/src/pages/CanvasPluginsPage';
+import { htmlFor } from '../_render';
+
+const plugins = [
+  { id: 'wave', label: 'Wave', description: 'Wave field scene.', kind: 'three' as const, mount: 'waveScene', path: '/canvas', query: { plugin: 'wave' } },
+  { id: 'map', label: 'Knowledge Map', description: 'React map.', kind: 'react' as const, renderer: 'KnowledgeMapCanvas', path: '/map', query: { plugin: 'map' }, apiPath: '/api/map3d' },
+];
+
+describe('CanvasPluginsPage', () => {
+  test('renders canvas plugin list and status from initial data', () => {
+    const html = htmlFor(<CanvasPluginsPage plugins={plugins} loading={false} />);
+
+    expect(html).toContain('Canvas plugin registry');
+    expect(html).toContain('2 registered · 1 three · 1 react');
+    expect(html).toContain('Wave');
+    expect(html).toContain('Knowledge Map');
+    expect(html).toContain('registered');
+    expect(html).toContain('/api/map3d');
+  });
+});

--- a/tests/frontend/router.test.ts
+++ b/tests/frontend/router.test.ts
@@ -34,6 +34,7 @@ describe('frontend router', () => {
     expect([...frontendRoutes]).toEqual([
       '/',
       '/plugins',
+      '/canvas/plugins',
       '/metrics',
       '/search',
       '/learn',
@@ -42,12 +43,14 @@ describe('frontend router', () => {
       '/vector/documents',
       '/vector/results',
       '/vector/export',
+      '/vector/settings',
     ]);
   });
 
   test('routes root, plugins, metrics, search, and learn surfaces', () => {
     expect(htmlAt('/')).toContain('Menu viewer');
     expect(htmlAt('/plugins')).toContain('Registered plugins');
+    expect(htmlAt('/canvas/plugins')).toContain('Canvas plugin registry');
     expect(htmlAt('/metrics')).toContain('Metrics dashboard');
     expect(htmlAt('/metrics')).toContain('42');
     expect(htmlAt('/metrics')).toContain('Memory usage');
@@ -58,6 +61,7 @@ describe('frontend router', () => {
     expect(htmlAt('/vector/documents')).toContain('Vector documents');
     expect(htmlAt('/vector/results')).toContain('Vector search results');
     expect(htmlAt('/vector/export')).toContain('Vector export');
+    expect(htmlAt('/vector/settings')).toContain('Vector config and indexing');
   });
 
   test('wraps routed children in the browser router and error boundary shell', () => {


### PR DESCRIPTION
Implements #950 Phase 3 React frontend integration for the canvas plugin registry.

Changes:
- Adds `frontend/src/pages/CanvasPluginsPage.tsx` to fetch `/api/canvas/plugins` and render plugin cards/status.
- Adds a small canvas-specific frontend API helper for the canvas registry response.
- Registers `/canvas/plugins` in the React router, route metadata, route paths, and sidebar nav.
- Adds focused frontend tests for the new page and route registration.

Validation:
- `bunx tsc --noEmit`
- `bunx tsc --noEmit -p frontend/tsconfig.json`
- `bun test tests/frontend/pages/canvas-plugins-page.test.tsx tests/frontend/router.test.ts`
