### PR TITLE
feat: add multi-tenant auth middleware

### DIFF
--- a/src/middleware/tenant.ts
+++ b/src/middleware/tenant.ts
@@ -1,8 +1,10 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
+import { timingSafeEqual } from 'node:crypto';
 import { Elysia } from 'elysia';
 import { eq, type SQL } from 'drizzle-orm';
 
 export const TENANT_HEADER = 'X-Oracle-Tenant';
+export const TENANT_TOKEN_HEADER = 'X-Oracle-Tenant-Token';
 export const LEGACY_TENANT_HEADER = 'X-Tenant-Id';
 export const ORG_HEADER = 'X-Org-Id';
 const TENANT_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/;
@@ -10,9 +12,26 @@ const TENANT_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/;
 type TenantContext = { tenantId?: string };
 type ProjectColumn = { project: unknown };
 type FetchHandler = (request: Request) => Response | Promise<Response>;
+type TenantTokenMap = Record<string, string>;
 
 const tenantStore = new AsyncLocalStorage<TenantContext>();
 const tenants = new WeakMap<Request, string | undefined>();
+
+function safeEqual(a: string, b: string): boolean {
+  const left = Buffer.from(a);
+  const right = Buffer.from(b);
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+export function parseTenantTokens(raw = process.env.ORACLE_TENANT_TOKENS ?? ''): TenantTokenMap {
+  const value = raw.trim();
+  if (!value) return {};
+  if (value.startsWith('{')) return JSON.parse(value) as TenantTokenMap;
+  return Object.fromEntries(value.split(',').map((entry) => {
+    const [tenant, ...tokenParts] = entry.split('=');
+    return [tenant.trim(), tokenParts.join('=').trim()];
+  }).filter(([tenant, token]) => tenant && token));
+}
 
 export function tenantIdFromHeaders(headers: Headers): string | undefined {
   const raw = headers.get(TENANT_HEADER) ?? headers.get(LEGACY_TENANT_HEADER) ?? headers.get(ORG_HEADER);
@@ -22,6 +41,15 @@ export function tenantIdFromHeaders(headers: Headers): string | undefined {
   return tenant;
 }
 
+export function validateTenantToken(headers: Headers, tenantId: string | undefined, tokens = parseTenantTokens()): void {
+  if (!tenantId) return;
+  const expected = tokens[tenantId] ?? tokens['*'];
+  if (!expected) return;
+  const actual = headers.get(TENANT_TOKEN_HEADER)?.trim() ?? '';
+  if (!actual) throw new Error('tenant token required');
+  if (!safeEqual(actual, expected)) throw new Error('invalid tenant token');
+}
+
 export function rememberTenant(request: Request, tenantId: string | undefined): void {
   tenants.set(request, tenantId);
 }
@@ -29,6 +57,7 @@ export function rememberTenant(request: Request, tenantId: string | undefined): 
 export function tenantIdFor(request: Request): string | undefined {
   if (tenants.has(request)) return tenants.get(request);
   const tenantId = tenantIdFromHeaders(request.headers);
+  validateTenantToken(request.headers, tenantId);
   rememberTenant(request, tenantId);
   return tenantId;
 }

--- a/src/routes/health/stats.ts
+++ b/src/routes/health/stats.ts
@@ -18,6 +18,10 @@ const StatsResponseSchema = t.Object({
   })),
   database: t.Optional(t.String()),
   vault_repo: t.Optional(t.Nullable(t.String())),
+  tenant: t.Optional(t.Object({
+    id: t.String(),
+    scope: t.String(),
+  })),
   error: t.Optional(t.String()),
 });
 

--- a/tests/http/tenant/auth.test.ts
+++ b/tests/http/tenant/auth.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import {
+  createTenantFetch,
+  createTenantMiddleware,
+  parseTenantTokens,
+  TENANT_HEADER,
+  TENANT_TOKEN_HEADER,
+  validateTenantToken,
+} from '../../../src/middleware/tenant.ts';
+
+describe('tenant auth middleware', () => {
+  test('parses JSON and comma tenant token config', () => {
+    expect(parseTenantTokens('{"acme":"secret"}')).toEqual({ acme: 'secret' });
+    expect(parseTenantTokens('acme=secret, beta=two=parts')).toEqual({ acme: 'secret', beta: 'two=parts' });
+  });
+
+  test('validates configured tenant token header', () => {
+    const headers = new Headers({ [TENANT_TOKEN_HEADER]: 'secret' });
+    expect(() => validateTenantToken(headers, 'acme', { acme: 'secret' })).not.toThrow();
+    expect(() => validateTenantToken(headers, 'acme', { acme: 'wrong' })).toThrow('invalid tenant token');
+    expect(() => validateTenantToken(new Headers(), 'acme', { acme: 'secret' })).toThrow('tenant token required');
+  });
+
+  test('attaches tenantId to Elysia request context', async () => {
+    const app = new Elysia()
+      .use(createTenantMiddleware())
+      .get('/whoami', ({ tenantId }) => ({ tenantId }));
+
+    const res = await app.handle(new Request('http://local/whoami', {
+      headers: { [TENANT_HEADER]: 'acme' },
+    }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ tenantId: 'acme' });
+    expect(res.headers.get(TENANT_HEADER)).toBe('acme');
+  });
+
+  test('rejects invalid tenant token from fetch wrapper', async () => {
+    const previous = process.env.ORACLE_TENANT_TOKENS;
+    process.env.ORACLE_TENANT_TOKENS = 'acme=secret';
+    try {
+      const res = await createTenantFetch(() => Response.json({ ok: true }))(new Request('http://local/', {
+        headers: { [TENANT_HEADER]: 'acme', [TENANT_TOKEN_HEADER]: 'bad' },
+      }));
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: 'invalid tenant token' });
+    } finally {
+      if (previous === undefined) delete process.env.ORACLE_TENANT_TOKENS;
+      else process.env.ORACLE_TENANT_TOKENS = previous;
+    }
+  });
+});


### PR DESCRIPTION
## Changes
- Added `X-Oracle-Tenant-Token` validation to `src/middleware/tenant.ts`
- Supports `ORACLE_TENANT_TOKENS` as JSON (`{"tenant":"token"}`) or comma config (`tenant=token,*=fallback`)
- Preserves header-only tenant scoping when no tenant token is configured
- Keeps tenantId attached through Elysia derived context and fetch wrapper
- Allows tenant metadata through `/api/stats` response schema

## Test
- bun test tests/http/tenant/
- bunx tsc --noEmit
