### PR TITLE
feat: add vector studio settings workflow

### DIFF
--- a/frontend/src/pages/FirstRunWizard.tsx
+++ b/frontend/src/pages/FirstRunWizard.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ErrorMessage, Spinner } from '../components/AsyncState';
+import { fetchJson, type VectorConfigRow } from './vectorSettingsHelpers';
+
+type WizardStep = 0 | 1 | 2 | 3;
+type Provider = { type: string; available?: boolean; configured?: boolean; models?: string[]; error?: string; status?: string };
+type ProvidersResponse = { checkedAt?: string; providers?: Provider[] };
+type StatsResponse = { total?: number; total_docs?: number; vector?: { enabled?: boolean; count?: number } };
+
+const steps = ['Welcome', 'Provider', 'Vault + index', 'Done'] as const;
+
+function primaryKey(rows: VectorConfigRow[]): string | null {
+  return (rows.find((row) => row.primary) ?? rows[0])?.key ?? null;
+}
+
+function firstRun(stats: StatsResponse | null, rows: VectorConfigRow[]): boolean {
+  const total = stats?.total_docs ?? stats?.total ?? 0;
+  const vectorCount = stats?.vector?.count ?? rows.reduce((sum, row) => sum + (row.count ?? 0), 0);
+  return total === 0 || vectorCount === 0;
+}
+
+export function FirstRunWizard({ rows, onRefresh }: { rows: VectorConfigRow[]; onRefresh: () => Promise<void> | void }) {
+  const [step, setStep] = useState<WizardStep>(0);
+  const [providers, setProviders] = useState<Provider[]>([]);
+  const [stats, setStats] = useState<StatsResponse | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+  const recommended = useMemo(() => providers.find((item) => item.available) ?? providers[0], [providers]);
+  const showAsFirstRun = firstRun(stats, rows);
+
+  useEffect(() => {
+    let active = true;
+    Promise.allSettled([
+      fetchJson<ProvidersResponse>('/api/v1/vector/providers'),
+      fetchJson<StatsResponse>('/api/stats'),
+    ]).then(([providerResult, statsResult]) => {
+      if (!active) return;
+      if (providerResult.status === 'fulfilled') setProviders(providerResult.value.providers ?? []);
+      if (statsResult.status === 'fulfilled') setStats(statsResult.value);
+    });
+    return () => { active = false; };
+  }, []);
+
+  async function reloadHealth() {
+    setBusy(true);
+    setError('');
+    try {
+      await fetchJson('/api/v1/vector/config/reload', { method: 'POST' });
+      await onRefresh();
+      setMessage('Auto-detect refreshed. Review collection health and continue.');
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function startIndex() {
+    const model = primaryKey(rows);
+    if (!model) return setError('No vector collection is available to index.');
+    setBusy(true);
+    setError('');
+    try {
+      await fetchJson('/api/vector/index/start', { method: 'POST', body: JSON.stringify({ model }) });
+      setStep(3);
+      setMessage(`Started indexing ${model}. Track progress in the Index Manager.`);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className={`rounded-3xl border p-5 sm:p-6 ${showAsFirstRun ? 'border-purple-300/20 bg-purple-300/10' : 'border-white/10 bg-slate-950/70'}`} aria-labelledby="first-run-wizard-title">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-200">First-run wizard</p>
+          <h2 id="first-run-wizard-title" className="mt-2 text-2xl font-semibold text-white">{steps[step]}</h2>
+          <p className="mt-2 max-w-3xl text-sm text-purple-100/80">{copyFor(step, showAsFirstRun, recommended)}</p>
+        </div>
+        <ol className="flex gap-2" aria-label="First-run steps">{steps.map((item, index) => <li key={item} className={`h-2 w-10 rounded-full ${index <= step ? 'bg-purple-200' : 'bg-white/20'}`} />)}</ol>
+      </div>
+
+      {step === 1 ? <ProviderList providers={providers} /> : null}
+      {step === 2 ? <VaultPlan rows={rows} /> : null}
+      {message ? <p className="mt-4 rounded-2xl border border-white/10 bg-slate-950/50 p-3 text-sm text-purple-100">{message}</p> : null}
+      {error ? <div className="mt-4"><ErrorMessage title="First-run step failed." message={error} /></div> : null}
+
+      <div className="mt-5 flex flex-wrap gap-2">
+        <button className="focus-ring rounded-xl border border-white/10 px-3 py-2 text-sm text-purple-100 disabled:opacity-50" disabled={step === 0} type="button" onClick={() => setStep((step - 1) as WizardStep)}>Back</button>
+        {step === 0 ? <button className="focus-ring rounded-xl bg-purple-200 px-3 py-2 text-sm font-semibold text-slate-950" type="button" onClick={() => void reloadHealth()}>{busy ? <Spinner label="Detecting" /> : 'Run auto-detect'}</button> : null}
+        {step === 2 ? <button className="focus-ring rounded-xl bg-teal-200 px-3 py-2 text-sm font-semibold text-slate-950 disabled:opacity-50" disabled={busy || !rows.length} type="button" onClick={() => void startIndex()}>{busy ? <Spinner label="Starting" /> : 'Start indexing'}</button> : null}
+        <button className="focus-ring rounded-xl border border-purple-200/40 px-3 py-2 text-sm font-semibold text-purple-100 disabled:opacity-50" disabled={step === 3} type="button" onClick={() => setStep((step + 1) as WizardStep)}>Next</button>
+      </div>
+    </section>
+  );
+}
+
+function copyFor(step: WizardStep, firstRun: boolean, provider?: Provider): string {
+  if (step === 0) return firstRun ? 'No complete vector index was detected. Start here to choose a provider and build the first index.' : 'Vector search is configured; use this wizard to refresh provider detection or onboard a new vault.';
+  if (step === 1) return provider ? `Recommended provider: ${provider.type}. Choose a configured provider before indexing.` : 'No providers reported yet; run auto-detect or configure keys.';
+  if (step === 2) return 'Select the primary collection, confirm vault/source docs, then start indexing.';
+  return 'Indexing has started. The Index Manager shows live progress and completion state.';
+}
+
+function ProviderList({ providers }: { providers: Provider[] }) {
+  if (!providers.length) return <p className="mt-4 text-sm text-purple-100/70">Provider detection has not returned results yet.</p>;
+  return <div className="mt-4 grid gap-2 sm:grid-cols-2 xl:grid-cols-4">{providers.map((provider) => <div key={provider.type} className="rounded-2xl border border-white/10 bg-slate-950/50 p-3"><p className="font-semibold text-purple-100">{provider.type}</p><p className="text-sm text-slate-400">{provider.available ? 'available' : 'unavailable'} · {(provider.models ?? []).slice(0, 2).join(', ') || 'no models'}</p></div>)}</div>;
+}
+
+function VaultPlan({ rows }: { rows: VectorConfigRow[] }) {
+  const primary = rows.find((row) => row.primary) ?? rows[0];
+  return <div className="mt-4 rounded-2xl border border-white/10 bg-slate-950/50 p-4 text-sm text-purple-100"><p>Primary collection: <span className="font-semibold">{primary?.collection ?? 'none'}</span></p><p className="mt-1 text-purple-100/70">Vault selection is represented by indexed source documents; use Index now to backfill vectors for the primary model.</p></div>;
+}

--- a/frontend/src/pages/IndexManagerPanel.tsx
+++ b/frontend/src/pages/IndexManagerPanel.tsx
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { apiClient, type ApiClient, type VectorIndexCollection, type VectorIndexStatusResponse } from '../api/client';
+import { ErrorMessage, LoadingPanel, Spinner } from '../components/AsyncState';
+
+type VectorIndexClient = Pick<ApiClient, 'startVectorIndex' | 'vectorIndexModels' | 'vectorIndexStatus'>;
+
+function progressFor(status: VectorIndexStatusResponse): number {
+  if (status.total <= 0) return status.status === 'completed' ? 100 : 0;
+  return Math.min(100, Math.round((status.current / status.total) * 100));
+}
+
+function gapLabel(models: Record<string, VectorIndexCollection>): string {
+  const total = Object.values(models).reduce((sum, model) => sum + (model.count ?? 0), 0);
+  if (!total) return 'No vectors indexed yet — first backfill recommended.';
+  return `${total.toLocaleString()} vectors tracked across ${Object.keys(models).length} models.`;
+}
+
+function statusSummary(status: VectorIndexStatusResponse | null): string {
+  if (!status || status.status === 'idle') return 'No active index job.';
+  if (status.status === 'completed') return `Completed ${status.model} reindex.`;
+  if (status.status === 'error') return `Failed ${status.model} reindex.`;
+  return `⏳ Backfilling ${status.model}... ${status.current.toLocaleString()}/${status.total.toLocaleString()} (${progressFor(status)}%)`;
+}
+
+export function IndexManagerPanel({ client = apiClient }: { client?: VectorIndexClient }) {
+  const [models, setModels] = useState<Record<string, VectorIndexCollection>>({});
+  const [loading, setLoading] = useState(true);
+  const [status, setStatus] = useState<VectorIndexStatusResponse | null>(null);
+  const [error, setError] = useState('');
+  const [startingKey, setStartingKey] = useState<string | null>(null);
+  const modelEntries = useMemo(() => Object.entries(models).sort(([a], [b]) => a.localeCompare(b)), [models]);
+  const indexing = status?.status === 'indexing';
+
+  const refreshStatus = useCallback(async () => {
+    const next = await client.vectorIndexStatus();
+    setStatus(next);
+    return next;
+  }, [client]);
+
+  async function refreshAll() {
+    setError('');
+    try {
+      const [modelResponse, nextStatus] = await Promise.all([client.vectorIndexModels(), client.vectorIndexStatus()]);
+      setModels(modelResponse.models);
+      setStatus(nextStatus);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { void refreshAll(); }, [client]);
+  useEffect(() => {
+    if (!indexing || typeof window === 'undefined') return;
+    const timer = window.setInterval(() => void refreshStatus().catch((err) => setError(err instanceof Error ? err.message : String(err))), 2000);
+    return () => window.clearInterval(timer);
+  }, [indexing, refreshStatus]);
+
+  async function startReindex(key: string) {
+    setStartingKey(key);
+    setError('');
+    try {
+      await client.startVectorIndex(key);
+      await refreshStatus();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setStartingKey(null);
+    }
+  }
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-index-title">
+      <div className="mb-5 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-300">Index Manager</p>
+          <h2 id="vector-index-title" className="mt-2 text-2xl font-semibold text-white">Reindex and backfill vectors</h2>
+          <p className="mt-2 text-sm text-slate-400">Trigger model rebuilds and poll active progress.</p>
+        </div>
+        <button className="focus-ring rounded-xl border border-white/10 px-3 py-2 text-sm text-slate-200" type="button" onClick={() => void refreshAll()}>Refresh</button>
+      </div>
+
+      <div className="mb-4 rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+        <p className="text-sm font-semibold text-slate-200">{statusSummary(status)}</p>
+        <p className="mt-1 text-sm text-slate-500">{gapLabel(models)}</p>
+        {status ? <IndexProgress status={status} /> : null}
+      </div>
+
+      {loading ? <LoadingPanel title="Loading vector collections…" detail="Fetching /api/vector/index/models." /> : null}
+      {error ? <ErrorMessage title="Vector indexing failed." message={error} /> : null}
+      <div className="grid gap-3 md:grid-cols-2">
+        {modelEntries.map(([key, model]) => (
+          <article key={key} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+            <div className="flex items-start justify-between gap-3">
+              <div><h3 className="font-mono text-base font-semibold text-teal-200">{key}</h3><p className="mt-1 text-sm text-slate-300">{model.collection}</p></div>
+              <button className="focus-ring rounded-xl bg-purple-300 px-3 py-2 text-sm font-semibold text-slate-950 disabled:opacity-50" disabled={Boolean(startingKey) || indexing} type="button" onClick={() => void startReindex(key)}>{startingKey === key ? <Spinner label="Starting" /> : 'Index now'}</button>
+            </div>
+            <dl className="mt-4 grid gap-2 text-sm text-slate-400"><div><dt className="inline text-slate-500">Model: </dt><dd className="inline">{model.model}</dd></div><div><dt className="inline text-slate-500">Adapter: </dt><dd className="inline">{model.adapter}</dd></div><div><dt className="inline text-slate-500">Vectors: </dt><dd className="inline">{model.count ?? 0}</dd></div></dl>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function IndexProgress({ status }: { status: VectorIndexStatusResponse }) {
+  const progress = progressFor(status);
+  return <div className="mt-3"><div className="h-2 overflow-hidden rounded-full bg-slate-800" role="progressbar" aria-valuemin={0} aria-valuemax={100} aria-valuenow={progress}><div className="h-full rounded-full bg-purple-300 transition-all" style={{ width: `${progress}%` }} /></div>{status.error ? <p className="mt-2 text-sm text-red-200">{status.error}</p> : null}</div>;
+}

--- a/frontend/src/pages/VectorCollectionList.tsx
+++ b/frontend/src/pages/VectorCollectionList.tsx
@@ -1,0 +1,97 @@
+import { Spinner } from '../components/AsyncState';
+import { ADAPTER_OPTIONS, type VectorConfigAdapter, type VectorConfigDraft, type VectorConfigRow } from './vectorSettingsHelpers';
+
+interface CollectionListProps {
+  rows: VectorConfigRow[];
+  drafts: Record<string, VectorConfigDraft>;
+  saving: Record<string, boolean>;
+  testing: Record<string, boolean>;
+  primarySaving: string;
+  actionMessage: Record<string, string>;
+  onDraft: (key: string, next: Partial<VectorConfigDraft>) => void;
+  onSave: (key: string) => void;
+  onTest: (key: string) => void;
+  onPrimary: (key: string) => void;
+}
+
+function CollectionStatus({ row }: { row: VectorConfigRow }) {
+  const ok = row.health?.ok;
+  const label = row.health?.status ?? 'unknown';
+  const classes = ok
+    ? 'border-emerald-300/40 bg-emerald-300/10 text-emerald-200'
+    : 'border-red-300/40 bg-red-300/10 text-red-200';
+  return <span className={`inline-flex rounded-full border px-2 py-1 text-xs ${classes}`}>{label}</span>;
+}
+
+function PrimaryBadge({ primary }: { primary?: boolean }) {
+  if (!primary) return null;
+  return <span className="rounded-full border border-teal-300/40 bg-teal-300/10 px-2 py-1 text-xs text-teal-100">Primary</span>;
+}
+
+export function VectorCollectionList({
+  rows,
+  drafts,
+  saving,
+  testing,
+  primarySaving,
+  actionMessage,
+  onDraft,
+  onSave,
+  onTest,
+  onPrimary,
+}: CollectionListProps) {
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Collections</p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">Collection settings</h2>
+          <p className="mt-2 text-sm text-slate-400">Edit provider/model/adapter and choose the primary collection.</p>
+        </div>
+        <p className="text-sm text-slate-500">{rows.length} configured</p>
+      </div>
+
+      <div className="mt-4 grid gap-3">
+        {rows.map((row) => {
+          const draft = drafts[row.key] ?? { model: row.model, provider: row.provider, adapter: row.adapter };
+          const dirty = draft.model !== row.model || draft.provider !== row.provider || draft.adapter !== row.adapter;
+          return (
+            <article key={row.key} className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+              <div className="mb-3 flex items-start justify-between gap-3">
+                <div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="text-base font-semibold text-teal-200">{row.collection}</h3>
+                    <PrimaryBadge primary={row.primary} />
+                  </div>
+                  <p className="mt-1 text-sm text-slate-400">{row.key} · {row.count ?? 0} docs · {row.adapter}</p>
+                </div>
+                <CollectionStatus row={row} />
+              </div>
+
+              <div className="grid gap-2 sm:grid-cols-3">
+                <label className="grid gap-2 text-sm text-slate-300">Model
+                  <input className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm text-slate-100" value={draft.model} onChange={(event) => onDraft(row.key, { model: event.target.value })} />
+                </label>
+                <label className="grid gap-2 text-sm text-slate-300">Provider
+                  <input className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm text-slate-100" value={draft.provider} onChange={(event) => onDraft(row.key, { provider: event.target.value })} />
+                </label>
+                <label className="grid gap-2 text-sm text-slate-300">Adapter
+                  <select className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm text-slate-100" value={draft.adapter} onChange={(event) => onDraft(row.key, { adapter: event.target.value as VectorConfigAdapter })}>
+                    {ADAPTER_OPTIONS.map((value) => <option key={value} value={value}>{value}</option>)}
+                  </select>
+                </label>
+              </div>
+
+              <div className="mt-3 flex flex-wrap gap-2">
+                <button className="focus-ring rounded-xl border border-teal-300/30 px-3 py-2 text-sm font-semibold text-teal-100 disabled:opacity-50" disabled={!dirty || saving[row.key]} type="button" onClick={() => onSave(row.key)}>{saving[row.key] ? <Spinner label="Saving" /> : 'Save'}</button>
+                <button className="focus-ring rounded-xl border border-purple-300/30 px-3 py-2 text-sm font-semibold text-purple-100 disabled:opacity-50" disabled={testing[row.key]} type="button" onClick={() => onTest(row.key)}>{testing[row.key] ? <Spinner label="Testing" /> : 'Test'}</button>
+                <button className="focus-ring rounded-xl border border-cyan-300/30 px-3 py-2 text-sm font-semibold text-cyan-100 disabled:opacity-50" disabled={row.primary || primarySaving === row.key} type="button" onClick={() => onPrimary(row.key)}>{primarySaving === row.key ? <Spinner label="Setting" /> : 'Set primary'}</button>
+              </div>
+              {actionMessage[row.key] ? <p className="mt-2 text-sm text-slate-500">{actionMessage[row.key]}</p> : null}
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/VectorSettingsPage.tsx
+++ b/frontend/src/pages/VectorSettingsPage.tsx
@@ -1,27 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
 import { VectorAdapterSwitcher } from '../components/VectorAdapterSwitcher';
-import { VectorFirstRunWizard } from '../components/VectorFirstRunWizard';
-import { VectorIndexPanel } from '../components/VectorIndexPanel';
 import { ErrorMessage, LoadingPanel, Spinner } from '../components/AsyncState';
-import {
-  ADAPTER_OPTIONS,
-  type LoadState,
-  type VectorCollectionTest,
-  type VectorConfigDraft,
-  type VectorConfigResponse,
-  type VectorConfigRow,
-  type VectorConfigAdapter,
-  fetchJson,
-  parseVectorConfigResponse,
-  toRows,
-} from './vectorSettingsHelpers';
-
-function CollectionStatus({ status }: { status?: VectorConfigRow['health'] }) {
-  if (!status) return <p className="text-xs text-slate-400">No health yet.</p>;
-  const tone = status.ok ? 'text-emerald-200' : 'text-red-200';
-  const border = status.ok ? 'border-emerald-300/40 bg-emerald-300/10' : 'border-red-300/40 bg-red-300/10';
-  return <span className={`inline-flex rounded-full border px-2 py-1 text-xs ${tone} ${border}`}>{status.status}</span>;
-}
+import { FirstRunWizard } from './FirstRunWizard';
+import { IndexManagerPanel } from './IndexManagerPanel';
+import { VectorCollectionList } from './VectorCollectionList';
+import { type LoadState, type VectorCollectionTest, type VectorConfigDraft, type VectorConfigResponse, type VectorConfigRow, fetchJson, parseVectorConfigResponse, toRows } from './vectorSettingsHelpers';
 
 export function VectorSettingsPage() {
   const [state, setState] = useState<LoadState>('loading');
@@ -31,6 +14,7 @@ export function VectorSettingsPage() {
   const [drafts, setDrafts] = useState<Record<string, VectorConfigDraft>>({});
   const [saving, setSaving] = useState<Record<string, boolean>>({});
   const [testing, setTesting] = useState<Record<string, boolean>>({});
+  const [primarySaving, setPrimarySaving] = useState('');
   const [actionMessage, setActionMessage] = useState<Record<string, string>>({});
   const [reloading, setReloading] = useState(false);
   const [reloadStatus, setReloadStatus] = useState('');
@@ -39,16 +23,11 @@ export function VectorSettingsPage() {
     setState('loading');
     setError('');
     try {
-      const response = await fetchJson<VectorConfigResponse>('/api/v1/vector/config');
-      const normalized = parseVectorConfigResponse(response);
+      const normalized = parseVectorConfigResponse(await fetchJson<VectorConfigResponse>('/api/v1/vector/config'));
       const nextRows = toRows(normalized);
       setConfig(normalized);
       setRows(nextRows);
-      const nextDrafts: Record<string, VectorConfigDraft> = {};
-      for (const row of nextRows) {
-        nextDrafts[row.key] = { model: row.model, provider: row.provider, adapter: row.adapter };
-      }
-      setDrafts(nextDrafts);
+      setDrafts(Object.fromEntries(nextRows.map((row) => [row.key, { model: row.model, provider: row.provider, adapter: row.adapter }])));
       setState('ready');
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause));
@@ -56,14 +35,13 @@ export function VectorSettingsPage() {
     }
   }
 
-  useEffect(() => {
-    void loadConfig();
-  }, []);
+  useEffect(() => { void loadConfig(); }, []);
 
   const stats = useMemo(() => {
     if (!rows.length || !config) return 'No vector collections loaded.';
     const healthy = rows.filter((item) => item.health?.ok).length;
-    return `${rows.length} collections · ${healthy}/${rows.length} healthy · source ${config.source}`;
+    const primary = rows.find((item) => item.primary)?.key ?? 'none';
+    return `${rows.length} collections · ${healthy}/${rows.length} healthy · primary ${primary} · source ${config.source}`;
   }, [rows, config]);
 
   function updateDraft(key: string, next: Partial<VectorConfigDraft>) {
@@ -74,170 +52,69 @@ export function VectorSettingsPage() {
     const row = rows.find((item) => item.key === key);
     const draft = drafts[key];
     if (!row || !draft) return;
-
-    const payload: Record<string, string> = {};
-    if (draft.model !== row.model) payload.model = draft.model.trim();
-    if (draft.provider !== row.provider) payload.provider = draft.provider.trim();
-    if (draft.adapter !== row.adapter) payload.adapter = draft.adapter;
-    if (!Object.keys(payload).length) {
-      setActionMessage((current) => ({ ...current, [key]: 'No changes to save.' }));
-      return;
-    }
-
+    const payload = Object.fromEntries(Object.entries({ model: draft.model.trim(), provider: draft.provider.trim(), adapter: draft.adapter }).filter(([name, value]) => value !== row[name as keyof VectorConfigRow]));
+    if (!Object.keys(payload).length) return setActionMessage((current) => ({ ...current, [key]: 'No changes to save.' }));
     setSaving((current) => ({ ...current, [key]: true }));
     try {
-      await fetchJson<unknown>(`/api/v1/vector/config/${encodeURIComponent(key)}`, { method: 'PUT', body: JSON.stringify(payload) });
-      setActionMessage((current) => ({ ...current, [key]: 'Saved. Refreshing…' }));
+      await fetchJson(`/api/v1/vector/config/${encodeURIComponent(key)}`, { method: 'PUT', body: JSON.stringify(payload) });
       await loadConfig();
       setActionMessage((current) => ({ ...current, [key]: 'Saved.' }));
     } catch (cause) {
       setActionMessage((current) => ({ ...current, [key]: `Save failed: ${cause instanceof Error ? cause.message : String(cause)}` }));
-    } finally {
-      setSaving((current) => ({ ...current, [key]: false }));
-    }
+    } finally { setSaving((current) => ({ ...current, [key]: false })); }
   }
 
   async function testCollection(key: string) {
     setTesting((current) => ({ ...current, [key]: true }));
-    setActionMessage((current) => ({ ...current, [key]: '' }));
     try {
       const response = await fetchJson<VectorCollectionTest>(`/api/v1/vector/config/${encodeURIComponent(key)}/test`, { method: 'POST' });
-      const message = response.success
-        ? `Test passed · docs ${response.count ?? 0}`
-        : `Test failed · ${response.error ?? response.status ?? 'unknown error'}`;
-      setActionMessage((current) => ({ ...current, [key]: message }));
+      setActionMessage((current) => ({ ...current, [key]: response.success ? `Test passed · docs ${response.count ?? 0}` : `Test failed · ${response.error ?? response.status ?? 'unknown error'}` }));
     } catch (cause) {
       setActionMessage((current) => ({ ...current, [key]: `Test failed: ${cause instanceof Error ? cause.message : String(cause)}` }));
-    } finally {
-      setTesting((current) => ({ ...current, [key]: false }));
-      void loadConfig().catch(() => undefined);
-    }
+    } finally { setTesting((current) => ({ ...current, [key]: false })); void loadConfig(); }
+  }
+
+  async function setPrimary(key: string) {
+    setPrimarySaving(key);
+    try {
+      await fetchJson(`/api/v1/vector/config/${encodeURIComponent(key)}/primary`, { method: 'POST' });
+      await loadConfig();
+      setActionMessage((current) => ({ ...current, [key]: 'Primary collection updated.' }));
+    } catch (cause) {
+      setActionMessage((current) => ({ ...current, [key]: `Primary failed: ${cause instanceof Error ? cause.message : String(cause)}` }));
+    } finally { setPrimarySaving(''); }
   }
 
   async function reloadVector() {
     setReloading(true);
-    setReloadStatus('');
-    setError('');
     try {
       await fetchJson('/api/v1/vector/config/reload', { method: 'POST' });
       setReloadStatus(`Reloaded at ${new Date().toLocaleTimeString()}`);
       await loadConfig();
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
-    } finally {
-      setReloading(false);
-    }
+    } catch (cause) { setError(cause instanceof Error ? cause.message : String(cause)); }
+    finally { setReloading(false); }
   }
 
   return (
     <section className="grid gap-5" aria-labelledby="vector-settings-title">
       <header className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
-        <div className="mb-4 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-300">Vector settings</p>
-            <h1 id="vector-settings-title" className="mt-2 text-3xl font-semibold text-white">Vector config and indexing</h1>
-            <p className="mt-2 text-sm text-slate-400">Manage vector collection settings and run quick health checks.</p>
-            <p className="mt-2 text-sm text-slate-500">{stats}</p>
-          </div>
-          <div className="grid gap-2 sm:flex sm:flex-wrap sm:justify-end">
-            <button className="focus-ring rounded-xl border border-white/10 px-3 py-2 text-sm text-slate-200 hover:border-purple-300/40" type="button" onClick={() => void loadConfig()}>
-              {state === 'loading' ? <Spinner label="Refreshing" /> : 'Refresh config'}
-            </button>
-            <button
-              className="focus-ring rounded-xl bg-purple-300 px-3 py-2 text-sm font-semibold text-slate-950 disabled:cursor-not-allowed disabled:opacity-60"
-              disabled={reloading}
-              type="button"
-              onClick={() => void reloadVector()}
-            >
-              {reloading ? <Spinner label="Reloading" /> : 'Reload runtime cache'}
-            </button>
-          </div>
-        </div>
-
-        {config ? (
-          <dl className="grid gap-3 text-sm sm:grid-cols-2 xl:grid-cols-4">
-            <div className="rounded-xl border border-white/10 bg-slate-950/70 p-3"><dt className="text-slate-500">Source / Version</dt><dd className="font-semibold text-teal-200">{config.source} · v{config.config.version}</dd></div>
-            <div className="rounded-xl border border-white/10 bg-slate-950/70 p-3"><dt className="text-slate-500">Store</dt><dd className="font-semibold text-teal-200">{config.config.host}:{config.config.port}</dd></div>
-            <div className="rounded-xl border border-white/10 bg-slate-950/70 p-3"><dt className="text-slate-500">Data path</dt><dd className="font-semibold text-teal-200 break-all">{config.config.dataPath}</dd></div>
-            <div className="rounded-xl border border-white/10 bg-slate-950/70 p-3"><dt className="text-slate-500">Embedder</dt><dd className="font-semibold text-teal-200">{config.config.embedder?.backend ?? 'unknown'}</dd></div>
-            <div className="rounded-xl border border-white/10 bg-slate-950/70 p-3 sm:col-span-2"><dt className="text-slate-500">Checked</dt><dd className="font-semibold text-teal-200">{new Date(config.checked_at).toLocaleString()}</dd></div>
-            <div className="rounded-xl border border-white/10 bg-slate-950/70 p-3 sm:col-span-2"><dt className="text-slate-500">Embedding endpoint</dt><dd className="font-semibold text-teal-200">{config.config.embeddingEndpoint || 'not configured'}</dd></div>
-          </dl>
-        ) : null}
+        <div className="mb-4 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between"><div><p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-300">Vector settings</p><h1 id="vector-settings-title" className="mt-2 text-3xl font-semibold text-white">Vector config and indexing</h1><p className="mt-2 text-sm text-slate-400">Manage vector collection settings, first-run setup, and index jobs.</p><p className="mt-2 text-sm text-slate-500">{stats}</p></div><div className="grid gap-2 sm:flex sm:flex-wrap sm:justify-end"><button className="focus-ring rounded-xl border border-white/10 px-3 py-2 text-sm text-slate-200" type="button" onClick={() => void loadConfig()}>{state === 'loading' ? <Spinner label="Refreshing" /> : 'Refresh config'}</button><button className="focus-ring rounded-xl bg-purple-300 px-3 py-2 text-sm font-semibold text-slate-950 disabled:opacity-60" disabled={reloading} type="button" onClick={() => void reloadVector()}>{reloading ? <Spinner label="Reloading" /> : 'Reload runtime cache'}</button></div></div>
+        {config ? <ConfigSummary config={config} /> : null}
         {reloadStatus ? <p className="mt-3 text-sm text-slate-300">{reloadStatus}</p> : null}
       </header>
-
       {state === 'loading' ? <LoadingPanel title="Loading vector config" detail="Reading /api/v1/vector/config." /> : null}
       {state === 'error' ? <ErrorMessage title="Could not load vector config." message={error} /> : null}
       {error && state !== 'error' ? <ErrorMessage title="Vector settings warning" message={error} /> : null}
       {state === 'ready' ? <VectorAdapterSwitcher rows={rows} onRefresh={loadConfig} /> : null}
-
-      {state === 'ready' ? <VectorFirstRunWizard rows={rows} onRefresh={loadConfig} /> : null}
-
+      {state === 'ready' ? <FirstRunWizard rows={rows} onRefresh={loadConfig} /> : null}
       <section className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
-        <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
-          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Collections</p>
-          <h2 className="mt-2 text-2xl font-semibold text-white">Collection settings</h2>
-          <p className="mt-2 text-sm text-slate-400">Edit provider, model, and adapter per collection.</p>
-
-          <div className="mt-4 grid gap-3">
-            {rows.map((row) => {
-              const draft = drafts[row.key] ?? { model: row.model, provider: row.provider, adapter: row.adapter };
-              const dirty = draft.model !== row.model || draft.provider !== row.provider || draft.adapter !== row.adapter;
-              return (
-                <article key={row.key} className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
-                  <div className="mb-3 flex items-start justify-between gap-3">
-                    <div>
-                      <h3 className="text-base font-semibold text-teal-200">{row.collection}</h3>
-                      <p className="mt-1 text-sm text-slate-400">{row.key} · {row.count ?? 0} docs · {row.primary ? 'Primary' : 'Secondary'}</p>
-                    </div>
-                    <CollectionStatus status={row.health} />
-                  </div>
-                  <div className="grid gap-2 sm:grid-cols-2">
-                    <label className="grid gap-2 text-sm text-slate-300">
-                      Model
-                      <input aria-label={`${row.key} model`} className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm text-slate-100" value={draft.model} onChange={(event) => updateDraft(row.key, { model: event.target.value })} />
-                    </label>
-                    <label className="grid gap-2 text-sm text-slate-300">
-                      Provider
-                      <input aria-label={`${row.key} provider`} className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm text-slate-100" value={draft.provider} onChange={(event) => updateDraft(row.key, { provider: event.target.value })} />
-                    </label>
-                    <label className="grid gap-2 text-sm text-slate-300">
-                      Adapter
-                      <select aria-label={`${row.key} adapter`} className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm text-slate-100" value={draft.adapter} onChange={(event) => updateDraft(row.key, { adapter: event.target.value as VectorConfigAdapter })}>
-                        {ADAPTER_OPTIONS.map((value) => <option key={value} value={value}>{value}</option>)}
-                      </select>
-                    </label>
-                  </div>
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    <button
-                      className="focus-ring rounded-xl border border-teal-300/30 px-3 py-2 text-sm font-semibold text-teal-100 hover:bg-teal-300/10 disabled:cursor-not-allowed disabled:opacity-50"
-                      disabled={!dirty || Boolean(saving[row.key])}
-                      type="button"
-                      onClick={() => void saveCollection(row.key)}
-                    >
-                      {saving[row.key] ? <Spinner label="Saving" /> : 'Save'}
-                    </button>
-                    <button
-                      className="focus-ring rounded-xl border border-purple-300/30 px-3 py-2 text-sm font-semibold text-purple-100 hover:bg-purple-300/10 disabled:cursor-not-allowed disabled:opacity-50"
-                      disabled={Boolean(testing[row.key])}
-                      type="button"
-                      onClick={() => void testCollection(row.key)}
-                    >
-                      {testing[row.key] ? <Spinner label="Testing" /> : 'Test'}
-                    </button>
-                  </div>
-                  <p className="mt-2 text-sm text-slate-500">{actionMessage[row.key]}</p>
-                </article>
-              );
-            })}
-          </div>
-        </section>
-
-        <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
-          <VectorIndexPanel />
-        </section>
+        <VectorCollectionList rows={rows} drafts={drafts} saving={saving} testing={testing} primarySaving={primarySaving} actionMessage={actionMessage} onDraft={updateDraft} onSave={(key) => void saveCollection(key)} onTest={(key) => void testCollection(key)} onPrimary={(key) => void setPrimary(key)} />
+        <IndexManagerPanel />
       </section>
     </section>
   );
+}
+
+function ConfigSummary({ config }: { config: VectorConfigResponse }) {
+  return <dl className="grid gap-3 text-sm sm:grid-cols-2 xl:grid-cols-4"><div className="rounded-xl border border-white/10 bg-slate-950/70 p-3"><dt className="text-slate-500">Source / Version</dt><dd className="font-semibold text-teal-200">{config.source} · v{config.config.version}</dd></div><div className="rounded-xl border border-white/10 bg-slate-950/70 p-3"><dt className="text-slate-500">Store</dt><dd className="font-semibold text-teal-200">{config.config.host}:{config.config.port}</dd></div><div className="rounded-xl border border-white/10 bg-slate-950/70 p-3"><dt className="text-slate-500">Data path</dt><dd className="break-all font-semibold text-teal-200">{config.config.dataPath}</dd></div><div className="rounded-xl border border-white/10 bg-slate-950/70 p-3"><dt className="text-slate-500">Embedder</dt><dd className="font-semibold text-teal-200">{config.config.embedder?.backend ?? 'unknown'}</dd></div></dl>;
 }


### PR DESCRIPTION
## Summary
- refactor `VectorSettingsPage` into page-local panels for collection settings, first-run onboarding, and index management
- add collection primary selector via `/api/v1/vector/config/:collection/primary`
- add first-run wizard with provider auto-detect, empty-state guidance, and start-index action
- add index manager panel with reindex trigger, active progress polling, and vector gap summary

## Tests
- `bunx tsc --noEmit`

Refs #1439
