### PR TITLE
feat: add memory multi-model fanout search

### DIFF
--- a/cli/src/plugins/canvas-serve/index.ts
+++ b/cli/src/plugins/canvas-serve/index.ts
@@ -1,0 +1,7 @@
+import type { InvokeContext, InvokeResult } from '../../plugin/types.ts';
+import { canvasServeCommand } from '../../../../src/cli/commands/canvas-serve.ts';
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const code = await canvasServeCommand(['canvas-serve', ...ctx.args]);
+  return code === 0 ? { ok: true } : { ok: false, error: 'canvas-serve failed' };
+}

--- a/cli/src/plugins/canvas-serve/plugin.json
+++ b/cli/src/plugins/canvas-serve/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "arra-canvas-serve",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^0.0.1",
+  "weight": 35,
+  "description": "Serve canvas.buildwithoracle.com locally as a standalone app",
+  "cli": {
+    "command": "canvas-serve",
+    "help": "arra-cli canvas-serve [--port N] [--api-base URL] [--dry-run]",
+    "flags": {
+      "--port": "Standalone canvas port (default 47779)",
+      "--api-base": "Oracle API base URL",
+      "--dry-run": "Print resolved serve config and exit"
+    }
+  }
+}

--- a/frontend/src/api/canvas-plugins.ts
+++ b/frontend/src/api/canvas-plugins.ts
@@ -1,0 +1,44 @@
+import { API_BASE } from './oracle';
+
+export type CanvasPluginKind = 'three' | 'react';
+
+interface BaseCanvasPluginEntry {
+  id: string;
+  label: string;
+  description: string;
+  kind: CanvasPluginKind;
+  path: string;
+  query: { plugin: string };
+}
+
+export interface ThreeCanvasPluginEntry extends BaseCanvasPluginEntry {
+  kind: 'three';
+  mount: string;
+}
+
+export interface ReactCanvasPluginEntry extends BaseCanvasPluginEntry {
+  kind: 'react';
+  renderer: string;
+  apiPath?: string;
+}
+
+export type CanvasPluginEntry = ThreeCanvasPluginEntry | ReactCanvasPluginEntry;
+
+export interface CanvasPluginsResponse {
+  plugins: CanvasPluginEntry[];
+  count: number;
+  kind: CanvasPluginKind | 'all';
+}
+
+function urlFor(path: string): string {
+  if (!API_BASE) return path;
+  return new URL(path, API_BASE).toString();
+}
+
+export async function fetchCanvasPlugins(kind?: CanvasPluginKind): Promise<CanvasPluginsResponse> {
+  const query = kind ? `?${new URLSearchParams({ kind }).toString()}` : '';
+  const path = `/api/canvas/plugins${query}`;
+  const response = await fetch(urlFor(path), { headers: { accept: 'application/json' } });
+  if (!response.ok) throw new Error(`${path} returned ${response.status}`);
+  return await response.json() as CanvasPluginsResponse;
+}

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -50,6 +50,7 @@ export function AppShell({
   const navItems: NavItem[] = [
     { to: '/', label: 'Menu', description: 'Navigation rows from /api/menu', badge: loading ? '…' : menuCount },
     { to: '/plugins', label: 'Plugins', description: 'Registered plugins and surfaces', badge: loading ? '…' : pluginCount },
+    { to: '/canvas/plugins', label: 'Canvas Plugins', description: 'Canvas registry from /api/canvas/plugins' },
     { to: '/search', label: 'Search', description: 'Full-text menu search' },
     { to: '/vector', label: 'Vector Dashboard', description: 'Collection health and indexing', end: true },
     { to: '/vector/documents', label: 'Document Browser', description: 'Browse indexed vector documents' },

--- a/frontend/src/pages/CanvasPluginsPage.tsx
+++ b/frontend/src/pages/CanvasPluginsPage.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useMemo, useState } from 'react';
+import { fetchCanvasPlugins, type CanvasPluginEntry, type CanvasPluginsResponse } from '../api/canvas-plugins';
+import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
+
+type PageState = 'loading' | 'ready' | 'error';
+type CanvasClient = { canvasPlugins: () => Promise<CanvasPluginsResponse> };
+const defaultClient: CanvasClient = { canvasPlugins: () => fetchCanvasPlugins() };
+
+export interface CanvasPluginsPageProps {
+  plugins?: CanvasPluginEntry[];
+  loading?: boolean;
+  client?: CanvasClient;
+}
+
+function pluginHref(plugin: CanvasPluginEntry): string {
+  const qs = new URLSearchParams(plugin.query ?? { plugin: plugin.id });
+  return `${plugin.path || '/canvas'}?${qs.toString()}`;
+}
+
+function statusClass(plugin: CanvasPluginEntry): string {
+  if (plugin.kind === 'react') return 'border-purple-300/30 bg-purple-300/10 text-purple-100';
+  return 'border-teal-300/30 bg-teal-300/10 text-teal-100';
+}
+
+function PluginCard({ plugin }: { plugin: CanvasPluginEntry }) {
+  const target = pluginHref(plugin);
+  return (
+    <article className="rounded-3xl border border-white/10 bg-slate-950/70 p-5" aria-label={`${plugin.label} canvas plugin`}>
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">{plugin.id}</p>
+          <h3 className="mt-1 text-xl font-semibold text-white">{plugin.label}</h3>
+        </div>
+        <span className={`rounded-full border px-2 py-1 text-xs font-semibold ${statusClass(plugin)}`}>{plugin.kind}</span>
+      </div>
+      <p className="text-sm text-slate-300">{plugin.description}</p>
+      <dl className="mt-4 grid gap-3 text-sm">
+        <div><dt className="text-slate-500">Status</dt><dd className="font-semibold text-emerald-200">registered</dd></div>
+        <div><dt className="text-slate-500">Canvas target</dt><dd className="break-all font-mono text-slate-100">{target}</dd></div>
+        <div><dt className="text-slate-500">Runtime hook</dt><dd className="font-mono text-slate-100">{'renderer' in plugin ? plugin.renderer : plugin.mount}</dd></div>
+        {'apiPath' in plugin && plugin.apiPath ? <div><dt className="text-slate-500">Data API</dt><dd className="font-mono text-slate-100">{plugin.apiPath}</dd></div> : null}
+      </dl>
+      <a className="focus-ring mt-4 inline-flex rounded-xl border border-teal-300/30 px-3 py-2 text-sm font-semibold text-teal-100 hover:bg-teal-300/10" href={target}>Open canvas</a>
+    </article>
+  );
+}
+
+export function CanvasPluginsPage({ plugins: initialPlugins = [], loading = true, client = defaultClient }: CanvasPluginsPageProps) {
+  const [plugins, setPlugins] = useState(initialPlugins);
+  const [state, setState] = useState<PageState>(loading ? 'loading' : 'ready');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    setState('loading');
+    setError('');
+    client.canvasPlugins()
+      .then((response) => {
+        if (cancelled) return;
+        setPlugins(response.plugins);
+        setState('ready');
+      })
+      .catch((cause) => {
+        if (cancelled) return;
+        setError(cause instanceof Error ? cause.message : String(cause));
+        setState(initialPlugins.length ? 'ready' : 'error');
+      });
+    return () => { cancelled = true; };
+  }, [client, initialPlugins.length]);
+
+  const summary = useMemo(() => {
+    const react = plugins.filter((plugin) => plugin.kind === 'react').length;
+    const three = plugins.filter((plugin) => plugin.kind === 'three').length;
+    return `${plugins.length} registered · ${three} three · ${react} react`;
+  }, [plugins]);
+
+  return (
+    <section className="grid gap-5" aria-labelledby="canvas-plugins-title">
+      <header className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Canvas plugins</p>
+        <h1 id="canvas-plugins-title" className="mt-2 text-3xl font-semibold text-white">Canvas plugin registry</h1>
+        <p className="mt-2 text-sm text-slate-400">Fetched from /api/canvas/plugins for canvas.buildwithoracle.com standalone rendering.</p>
+        <p className="mt-3 inline-flex rounded-full border border-white/10 px-3 py-2 text-sm text-slate-300">{summary}</p>
+      </header>
+
+      {state === 'loading' ? <LoadingPanel title="Loading canvas plugins" detail="Reading /api/canvas/plugins." /> : null}
+      {state === 'error' ? <ErrorMessage title="Could not load canvas plugins." message={error} /> : null}
+      {state !== 'error' && error ? <ErrorMessage title="Canvas plugin warning" message={error} /> : null}
+      {state !== 'error' ? <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">{plugins.map((plugin) => <PluginCard key={plugin.id} plugin={plugin} />)}</div> : null}
+    </section>
+  );
+}

--- a/frontend/src/pages/FirstRunWizard.tsx
+++ b/frontend/src/pages/FirstRunWizard.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ErrorMessage, Spinner } from '../components/AsyncState';
+import { fetchJson, type VectorConfigRow } from './vectorSettingsHelpers';
+
+type WizardStep = 0 | 1 | 2 | 3;
+type Provider = { type: string; available?: boolean; configured?: boolean; models?: string[]; error?: string; status?: string };
+type ProvidersResponse = { checkedAt?: string; providers?: Provider[] };
+type StatsResponse = { total?: number; total_docs?: number; vector?: { enabled?: boolean; count?: number } };
+
+const steps = ['Welcome', 'Provider', 'Vault + index', 'Done'] as const;
+
+function primaryKey(rows: VectorConfigRow[]): string | null {
+  return (rows.find((row) => row.primary) ?? rows[0])?.key ?? null;
+}
+
+function firstRun(stats: StatsResponse | null, rows: VectorConfigRow[]): boolean {
+  const total = stats?.total_docs ?? stats?.total ?? 0;
+  const vectorCount = stats?.vector?.count ?? rows.reduce((sum, row) => sum + (row.count ?? 0), 0);
+  return total === 0 || vectorCount === 0;
+}
+
+export function FirstRunWizard({ rows, onRefresh }: { rows: VectorConfigRow[]; onRefresh: () => Promise<void> | void }) {
+  const [step, setStep] = useState<WizardStep>(0);
+  const [providers, setProviders] = useState<Provider[]>([]);
+  const [stats, setStats] = useState<StatsResponse | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+  const recommended = useMemo(() => providers.find((item) => item.available) ?? providers[0], [providers]);
+  const showAsFirstRun = firstRun(stats, rows);
+
+  useEffect(() => {
+    let active = true;
+    Promise.allSettled([
+      fetchJson<ProvidersResponse>('/api/v1/vector/providers'),
+      fetchJson<StatsResponse>('/api/stats'),
+    ]).then(([providerResult, statsResult]) => {
+      if (!active) return;
+      if (providerResult.status === 'fulfilled') setProviders(providerResult.value.providers ?? []);
+      if (statsResult.status === 'fulfilled') setStats(statsResult.value);
+    });
+    return () => { active = false; };
+  }, []);
+
+  async function reloadHealth() {
+    setBusy(true);
+    setError('');
+    try {
+      await fetchJson('/api/v1/vector/config/reload', { method: 'POST' });
+      await onRefresh();
+      setMessage('Auto-detect refreshed. Review collection health and continue.');
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function startIndex() {
+    const model = primaryKey(rows);
+    if (!model) return setError('No vector collection is available to index.');
+    setBusy(true);
+    setError('');
+    try {
+      await fetchJson('/api/vector/index/start', { method: 'POST', body: JSON.stringify({ model }) });
+      setStep(3);
+      setMessage(`Started indexing ${model}. Track progress in the Index Manager.`);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className={`rounded-3xl border p-5 sm:p-6 ${showAsFirstRun ? 'border-purple-300/20 bg-purple-300/10' : 'border-white/10 bg-slate-950/70'}`} aria-labelledby="first-run-wizard-title">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-200">First-run wizard</p>
+          <h2 id="first-run-wizard-title" className="mt-2 text-2xl font-semibold text-white">{steps[step]}</h2>
+          <p className="mt-2 max-w-3xl text-sm text-purple-100/80">{copyFor(step, showAsFirstRun, recommended)}</p>
+        </div>
+        <ol className="flex gap-2" aria-label="First-run steps">{steps.map((item, index) => <li key={item} className={`h-2 w-10 rounded-full ${index <= step ? 'bg-purple-200' : 'bg-white/20'}`} />)}</ol>
+      </div>
+
+      {step === 1 ? <ProviderList providers={providers} /> : null}
+      {step === 2 ? <VaultPlan rows={rows} /> : null}
+      {message ? <p className="mt-4 rounded-2xl border border-white/10 bg-slate-950/50 p-3 text-sm text-purple-100">{message}</p> : null}
+      {error ? <div className="mt-4"><ErrorMessage title="First-run step failed." message={error} /></div> : null}
+
+      <div className="mt-5 flex flex-wrap gap-2">
+        <button className="focus-ring rounded-xl border border-white/10 px-3 py-2 text-sm text-purple-100 disabled:opacity-50" disabled={step === 0} type="button" onClick={() => setStep((step - 1) as WizardStep)}>Back</button>
+        {step === 0 ? <button className="focus-ring rounded-xl bg-purple-200 px-3 py-2 text-sm font-semibold text-slate-950" type="button" onClick={() => void reloadHealth()}>{busy ? <Spinner label="Detecting" /> : 'Run auto-detect'}</button> : null}
+        {step === 2 ? <button className="focus-ring rounded-xl bg-teal-200 px-3 py-2 text-sm font-semibold text-slate-950 disabled:opacity-50" disabled={busy || !rows.length} type="button" onClick={() => void startIndex()}>{busy ? <Spinner label="Starting" /> : 'Start indexing'}</button> : null}
+        <button className="focus-ring rounded-xl border border-purple-200/40 px-3 py-2 text-sm font-semibold text-purple-100 disabled:opacity-50" disabled={step === 3} type="button" onClick={() => setStep((step + 1) as WizardStep)}>Next</button>
+      </div>
+    </section>
+  );
+}
+
+function copyFor(step: WizardStep, firstRun: boolean, provider?: Provider): string {
+  if (step === 0) return firstRun ? 'No complete vector index was detected. Start here to choose a provider and build the first index.' : 'Vector search is configured; use this wizard to refresh provider detection or onboard a new vault.';
+  if (step === 1) return provider ? `Recommended provider: ${provider.type}. Choose a configured provider before indexing.` : 'No providers reported yet; run auto-detect or configure keys.';
+  if (step === 2) return 'Select the primary collection, confirm vault/source docs, then start indexing.';
+  return 'Indexing has started. The Index Manager shows live progress and completion state.';
+}
+
+function ProviderList({ providers }: { providers: Provider[] }) {
+  if (!providers.length) return <p className="mt-4 text-sm text-purple-100/70">Provider detection has not returned results yet.</p>;
+  return <div className="mt-4 grid gap-2 sm:grid-cols-2 xl:grid-cols-4">{providers.map((provider) => <div key={provider.type} className="rounded-2xl border border-white/10 bg-slate-950/50 p-3"><p className="font-semibold text-purple-100">{provider.type}</p><p className="text-sm text-slate-400">{provider.available ? 'available' : 'unavailable'} · {(provider.models ?? []).slice(0, 2).join(', ') || 'no models'}</p></div>)}</div>;
+}
+
+function VaultPlan({ rows }: { rows: VectorConfigRow[] }) {
+  const primary = rows.find((row) => row.primary) ?? rows[0];
+  return <div className="mt-4 rounded-2xl border border-white/10 bg-slate-950/50 p-4 text-sm text-purple-100"><p>Primary collection: <span className="font-semibold">{primary?.collection ?? 'none'}</span></p><p className="mt-1 text-purple-100/70">Vault selection is represented by indexed source documents; use Index now to backfill vectors for the primary model.</p></div>;
+}

--- a/frontend/src/pages/IndexManagerPanel.tsx
+++ b/frontend/src/pages/IndexManagerPanel.tsx
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { apiClient, type ApiClient, type VectorIndexCollection, type VectorIndexStatusResponse } from '../api/client';
+import { ErrorMessage, LoadingPanel, Spinner } from '../components/AsyncState';
+
+type VectorIndexClient = Pick<ApiClient, 'startVectorIndex' | 'vectorIndexModels' | 'vectorIndexStatus'>;
+
+function progressFor(status: VectorIndexStatusResponse): number {
+  if (status.total <= 0) return status.status === 'completed' ? 100 : 0;
+  return Math.min(100, Math.round((status.current / status.total) * 100));
+}
+
+function gapLabel(models: Record<string, VectorIndexCollection>): string {
+  const total = Object.values(models).reduce((sum, model) => sum + (model.count ?? 0), 0);
+  if (!total) return 'No vectors indexed yet — first backfill recommended.';
+  return `${total.toLocaleString()} vectors tracked across ${Object.keys(models).length} models.`;
+}
+
+function statusSummary(status: VectorIndexStatusResponse | null): string {
+  if (!status || status.status === 'idle') return 'No active index job.';
+  if (status.status === 'completed') return `Completed ${status.model} reindex.`;
+  if (status.status === 'error') return `Failed ${status.model} reindex.`;
+  return `⏳ Backfilling ${status.model}... ${status.current.toLocaleString()}/${status.total.toLocaleString()} (${progressFor(status)}%)`;
+}
+
+export function IndexManagerPanel({ client = apiClient }: { client?: VectorIndexClient }) {
+  const [models, setModels] = useState<Record<string, VectorIndexCollection>>({});
+  const [loading, setLoading] = useState(true);
+  const [status, setStatus] = useState<VectorIndexStatusResponse | null>(null);
+  const [error, setError] = useState('');
+  const [startingKey, setStartingKey] = useState<string | null>(null);
+  const modelEntries = useMemo(() => Object.entries(models).sort(([a], [b]) => a.localeCompare(b)), [models]);
+  const indexing = status?.status === 'indexing';
+
+  const refreshStatus = useCallback(async () => {
+    const next = await client.vectorIndexStatus();
+    setStatus(next);
+    return next;
+  }, [client]);
+
+  async function refreshAll() {
+    setError('');
+    try {
+      const [modelResponse, nextStatus] = await Promise.all([client.vectorIndexModels(), client.vectorIndexStatus()]);
+      setModels(modelResponse.models);
+      setStatus(nextStatus);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { void refreshAll(); }, [client]);
+  useEffect(() => {
+    if (!indexing || typeof window === 'undefined') return;
+    const timer = window.setInterval(() => void refreshStatus().catch((err) => setError(err instanceof Error ? err.message : String(err))), 2000);
+    return () => window.clearInterval(timer);
+  }, [indexing, refreshStatus]);
+
+  async function startReindex(key: string) {
+    setStartingKey(key);
+    setError('');
+    try {
+      await client.startVectorIndex(key);
+      await refreshStatus();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setStartingKey(null);
+    }
+  }
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-index-title">
+      <div className="mb-5 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-300">Index Manager</p>
+          <h2 id="vector-index-title" className="mt-2 text-2xl font-semibold text-white">Reindex and backfill vectors</h2>
+          <p className="mt-2 text-sm text-slate-400">Trigger model rebuilds and poll active progress.</p>
+        </div>
+        <button className="focus-ring rounded-xl border border-white/10 px-3 py-2 text-sm text-slate-200" type="button" onClick={() => void refreshAll()}>Refresh</button>
+      </div>
+
+      <div className="mb-4 rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+        <p className="text-sm font-semibold text-slate-200">{statusSummary(status)}</p>
+        <p className="mt-1 text-sm text-slate-500">{gapLabel(models)}</p>
+        {status ? <IndexProgress status={status} /> : null}
+      </div>
+
+      {loading ? <LoadingPanel title="Loading vector collections…" detail="Fetching /api/vector/index/models." /> : null}
+      {error ? <ErrorMessage title="Vector indexing failed." message={error} /> : null}
+      <div className="grid gap-3 md:grid-cols-2">
+        {modelEntries.map(([key, model]) => (
+          <article key={key} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+            <div className="flex items-start justify-between gap-3">
+              <div><h3 className="font-mono text-base font-semibold text-teal-200">{key}</h3><p className="mt-1 text-sm text-slate-300">{model.collection}</p></div>
+              <button className="focus-ring rounded-xl bg-purple-300 px-3 py-2 text-sm font-semibold text-slate-950 disabled:opacity-50" disabled={Boolean(startingKey) || indexing} type="button" onClick={() => void startReindex(key)}>{startingKey === key ? <Spinner label="Starting" /> : 'Index now'}</button>
+            </div>
+            <dl className="mt-4 grid gap-2 text-sm text-slate-400"><div><dt className="inline text-slate-500">Model: </dt><dd className="inline">{model.model}</dd></div><div><dt className="inline text-slate-500">Adapter: </dt><dd className="inline">{model.adapter}</dd></div><div><dt className="inline text-slate-500">Vectors: </dt><dd className="inline">{model.count ?? 0}</dd></div></dl>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function IndexProgress({ status }: { status: VectorIndexStatusResponse }) {
+  const progress = progressFor(status);
+  return <div className="mt-3"><div className="h-2 overflow-hidden rounded-full bg-slate-800" role="progressbar" aria-valuemin={0} aria-valuemax={100} aria-valuenow={progress}><div className="h-full rounded-full bg-purple-300 transition-all" style={{ width: `${progress}%` }} /></div>{status.error ? <p className="mt-2 text-sm text-red-200">{status.error}</p> : null}</div>;
+}

--- a/frontend/src/pages/VectorCollectionList.tsx
+++ b/frontend/src/pages/VectorCollectionList.tsx
@@ -1,0 +1,97 @@
+import { Spinner } from '../components/AsyncState';
+import { ADAPTER_OPTIONS, type VectorConfigAdapter, type VectorConfigDraft, type VectorConfigRow } from './vectorSettingsHelpers';
+
+interface CollectionListProps {
+  rows: VectorConfigRow[];
+  drafts: Record<string, VectorConfigDraft>;
+  saving: Record<string, boolean>;
+  testing: Record<string, boolean>;
+  primarySaving: string;
+  actionMessage: Record<string, string>;
+  onDraft: (key: string, next: Partial<VectorConfigDraft>) => void;
+  onSave: (key: string) => void;
+  onTest: (key: string) => void;
+  onPrimary: (key: string) => void;
+}
+
+function CollectionStatus({ row }: { row: VectorConfigRow }) {
+  const ok = row.health?.ok;
+  const label = row.health?.status ?? 'unknown';
+  const classes = ok
+    ? 'border-emerald-300/40 bg-emerald-300/10 text-emerald-200'
+    : 'border-red-300/40 bg-red-300/10 text-red-200';
+  return <span className={`inline-flex rounded-full border px-2 py-1 text-xs ${classes}`}>{label}</span>;
+}
+
+function PrimaryBadge({ primary }: { primary?: boolean }) {
+  if (!primary) return null;
+  return <span className="rounded-full border border-teal-300/40 bg-teal-300/10 px-2 py-1 text-xs text-teal-100">Primary</span>;
+}
+
+export function VectorCollectionList({
+  rows,
+  drafts,
+  saving,
+  testing,
+  primarySaving,
+  actionMessage,
+  onDraft,
+  onSave,
+  onTest,
+  onPrimary,
+}: CollectionListProps) {
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Collections</p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">Collection settings</h2>
+          <p className="mt-2 text-sm text-slate-400">Edit provider/model/adapter and choose the primary collection.</p>
+        </div>
+        <p className="text-sm text-slate-500">{rows.length} configured</p>
+      </div>
+
+      <div className="mt-4 grid gap-3">
+        {rows.map((row) => {
+          const draft = drafts[row.key] ?? { model: row.model, provider: row.provider, adapter: row.adapter };
+          const dirty = draft.model !== row.model || draft.provider !== row.provider || draft.adapter !== row.adapter;
+          return (
+            <article key={row.key} className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+              <div className="mb-3 flex items-start justify-between gap-3">
+                <div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="text-base font-semibold text-teal-200">{row.collection}</h3>
+                    <PrimaryBadge primary={row.primary} />
+                  </div>
+                  <p className="mt-1 text-sm text-slate-400">{row.key} · {row.count ?? 0} docs · {row.adapter}</p>
+                </div>
+                <CollectionStatus row={row} />
+              </div>
+
+              <div className="grid gap-2 sm:grid-cols-3">
+                <label className="grid gap-2 text-sm text-slate-300">Model
+                  <input className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm text-slate-100" value={draft.model} onChange={(event) => onDraft(row.key, { model: event.target.value })} />
+                </label>
+                <label className="grid gap-2 text-sm text-slate-300">Provider
+                  <input className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm text-slate-100" value={draft.provider} onChange={(event) => onDraft(row.key, { provider: event.target.value })} />
+                </label>
+                <label className="grid gap-2 text-sm text-slate-300">Adapter
+                  <select className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm text-slate-100" value={draft.adapter} onChange={(event) => onDraft(row.key, { adapter: event.target.value as VectorConfigAdapter })}>
+                    {ADAPTER_OPTIONS.map((value) => <option key={value} value={value}>{value}</option>)}
+                  </select>
+                </label>
+              </div>
+
+              <div className="mt-3 flex flex-wrap gap-2">
+                <button className="focus-ring rounded-xl border border-teal-300/30 px-3 py-2 text-sm font-semibold text-teal-100 disabled:opacity-50" disabled={!dirty || saving[row.key]} type="button" onClick={() => onSave(row.key)}>{saving[row.key] ? <Spinner label="Saving" /> : 'Save'}</button>
+                <button className="focus-ring rounded-xl border border-purple-300/30 px-3 py-2 text-sm font-semibold text-purple-100 disabled:opacity-50" disabled={testing[row.key]} type="button" onClick={() => onTest(row.key)}>{testing[row.key] ? <Spinner label="Testing" /> : 'Test'}</button>
+                <button className="focus-ring rounded-xl border border-cyan-300/30 px-3 py-2 text-sm font-semibold text-cyan-100 disabled:opacity-50" disabled={row.primary || primarySaving === row.key} type="button" onClick={() => onPrimary(row.key)}>{primarySaving === row.key ? <Spinner label="Setting" /> : 'Set primary'}</button>
+              </div>
+              {actionMessage[row.key] ? <p className="mt-2 text-sm text-slate-500">{actionMessage[row.key]}</p> : null}
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/VectorSettingsPage.tsx
+++ b/frontend/src/pages/VectorSettingsPage.tsx
@@ -1,27 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
 import { VectorAdapterSwitcher } from '../components/VectorAdapterSwitcher';
-import { VectorFirstRunWizard } from '../components/VectorFirstRunWizard';
-import { VectorIndexPanel } from '../components/VectorIndexPanel';
 import { ErrorMessage, LoadingPanel, Spinner } from '../components/AsyncState';
-import {
-  ADAPTER_OPTIONS,
-  type LoadState,
-  type VectorCollectionTest,
-  type VectorConfigDraft,
-  type VectorConfigResponse,
-  type VectorConfigRow,
-  type VectorConfigAdapter,
-  fetchJson,
-  parseVectorConfigResponse,
-  toRows,
-} from './vectorSettingsHelpers';
-
-function CollectionStatus({ status }: { status?: VectorConfigRow['health'] }) {
-  if (!status) return <p className="text-xs text-slate-400">No health yet.</p>;
-  const tone = status.ok ? 'text-emerald-200' : 'text-red-200';
-  const border = status.ok ? 'border-emerald-300/40 bg-emerald-300/10' : 'border-red-300/40 bg-red-300/10';
-  return <span className={`inline-flex rounded-full border px-2 py-1 text-xs ${tone} ${border}`}>{status.status}</span>;
-}
+import { FirstRunWizard } from './FirstRunWizard';
+import { IndexManagerPanel } from './IndexManagerPanel';
+import { VectorCollectionList } from './VectorCollectionList';
+import { type LoadState, type VectorCollectionTest, type VectorConfigDraft, type VectorConfigResponse, type VectorConfigRow, fetchJson, parseVectorConfigResponse, toRows } from './vectorSettingsHelpers';
 
 export function VectorSettingsPage() {
   const [state, setState] = useState<LoadState>('loading');
@@ -31,6 +14,7 @@ export function VectorSettingsPage() {
   const [drafts, setDrafts] = useState<Record<string, VectorConfigDraft>>({});
   const [saving, setSaving] = useState<Record<string, boolean>>({});
   const [testing, setTesting] = useState<Record<string, boolean>>({});
+  const [primarySaving, setPrimarySaving] = useState('');
   const [actionMessage, setActionMessage] = useState<Record<string, string>>({});
   const [reloading, setReloading] = useState(false);
   const [reloadStatus, setReloadStatus] = useState('');
@@ -39,16 +23,11 @@ export function VectorSettingsPage() {
     setState('loading');
     setError('');
     try {
-      const response = await fetchJson<VectorConfigResponse>('/api/v1/vector/config');
-      const normalized = parseVectorConfigResponse(response);
+      const normalized = parseVectorConfigResponse(await fetchJson<VectorConfigResponse>('/api/v1/vector/config'));
       const nextRows = toRows(normalized);
       setConfig(normalized);
       setRows(nextRows);
-      const nextDrafts: Record<string, VectorConfigDraft> = {};
-      for (const row of nextRows) {
-        nextDrafts[row.key] = { model: row.model, provider: row.provider, adapter: row.adapter };
-      }
-      setDrafts(nextDrafts);
+      setDrafts(Object.fromEntries(nextRows.map((row) => [row.key, { model: row.model, provider: row.provider, adapter: row.adapter }])));
       setState('ready');
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause));
@@ -56,14 +35,13 @@ export function VectorSettingsPage() {
     }
   }
 
-  useEffect(() => {
-    void loadConfig();
-  }, []);
+  useEffect(() => { void loadConfig(); }, []);
 
   const stats = useMemo(() => {
     if (!rows.length || !config) return 'No vector collections loaded.';
     const healthy = rows.filter((item) => item.health?.ok).length;
-    return `${rows.length} collections · ${healthy}/${rows.length} healthy · source ${config.source}`;
+    const primary = rows.find((item) => item.primary)?.key ?? 'none';
+    return `${rows.length} collections · ${healthy}/${rows.length} healthy · primary ${primary} · source ${config.source}`;
   }, [rows, config]);
 
   function updateDraft(key: string, next: Partial<VectorConfigDraft>) {
@@ -74,170 +52,69 @@ export function VectorSettingsPage() {
     const row = rows.find((item) => item.key === key);
     const draft = drafts[key];
     if (!row || !draft) return;
-
-    const payload: Record<string, string> = {};
-    if (draft.model !== row.model) payload.model = draft.model.trim();
-    if (draft.provider !== row.provider) payload.provider = draft.provider.trim();
-    if (draft.adapter !== row.adapter) payload.adapter = draft.adapter;
-    if (!Object.keys(payload).length) {
-      setActionMessage((current) => ({ ...current, [key]: 'No changes to save.' }));
-      return;
-    }
-
+    const payload = Object.fromEntries(Object.entries({ model: draft.model.trim(), provider: draft.provider.trim(), adapter: draft.adapter }).filter(([name, value]) => value !== row[name as keyof VectorConfigRow]));
+    if (!Object.keys(payload).length) return setActionMessage((current) => ({ ...current, [key]: 'No changes to save.' }));
     setSaving((current) => ({ ...current, [key]: true }));
     try {
-      await fetchJson<unknown>(`/api/v1/vector/config/${encodeURIComponent(key)}`, { method: 'PUT', body: JSON.stringify(payload) });
-      setActionMessage((current) => ({ ...current, [key]: 'Saved. Refreshing…' }));
+      await fetchJson(`/api/v1/vector/config/${encodeURIComponent(key)}`, { method: 'PUT', body: JSON.stringify(payload) });
       await loadConfig();
       setActionMessage((current) => ({ ...current, [key]: 'Saved.' }));
     } catch (cause) {
       setActionMessage((current) => ({ ...current, [key]: `Save failed: ${cause instanceof Error ? cause.message : String(cause)}` }));
-    } finally {
-      setSaving((current) => ({ ...current, [key]: false }));
-    }
+    } finally { setSaving((current) => ({ ...current, [key]: false })); }
   }
 
   async function testCollection(key: string) {
     setTesting((current) => ({ ...current, [key]: true }));
-    setActionMessage((current) => ({ ...current, [key]: '' }));
     try {
       const response = await fetchJson<VectorCollectionTest>(`/api/v1/vector/config/${encodeURIComponent(key)}/test`, { method: 'POST' });
-      const message = response.success
-        ? `Test passed · docs ${response.count ?? 0}`
-        : `Test failed · ${response.error ?? response.status ?? 'unknown error'}`;
-      setActionMessage((current) => ({ ...current, [key]: message }));
+      setActionMessage((current) => ({ ...current, [key]: response.success ? `Test passed · docs ${response.count ?? 0}` : `Test failed · ${response.error ?? response.status ?? 'unknown error'}` }));
     } catch (cause) {
       setActionMessage((current) => ({ ...current, [key]: `Test failed: ${cause instanceof Error ? cause.message : String(cause)}` }));
-    } finally {
-      setTesting((current) => ({ ...current, [key]: false }));
-      void loadConfig().catch(() => undefined);
-    }
+    } finally { setTesting((current) => ({ ...current, [key]: false })); void loadConfig(); }
+  }
+
+  async function setPrimary(key: string) {
+    setPrimarySaving(key);
+    try {
+      await fetchJson(`/api/v1/vector/config/${encodeURIComponent(key)}/primary`, { method: 'POST' });
+      await loadConfig();
+      setActionMessage((current) => ({ ...current, [key]: 'Primary collection updated.' }));
+    } catch (cause) {
+      setActionMessage((current) => ({ ...current, [key]: `Primary failed: ${cause instanceof Error ? cause.message : String(cause)}` }));
+    } finally { setPrimarySaving(''); }
   }
 
   async function reloadVector() {
     setReloading(true);
-    setReloadStatus('');
-    setError('');
     try {
       await fetchJson('/api/v1/vector/config/reload', { method: 'POST' });
       setReloadStatus(`Reloaded at ${new Date().toLocaleTimeString()}`);
       await loadConfig();
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
-    } finally {
-      setReloading(false);
-    }
+    } catch (cause) { setError(cause instanceof Error ? cause.message : String(cause)); }
+    finally { setReloading(false); }
   }
 
   return (
     <section className="grid gap-5" aria-labelledby="vector-settings-title">
       <header className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
-        <div className="mb-4 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-300">Vector settings</p>
-            <h1 id="vector-settings-title" className="mt-2 text-3xl font-semibold text-white">Vector config and indexing</h1>
-            <p className="mt-2 text-sm text-slate-400">Manage vector collection settings and run quick health checks.</p>
-            <p className="mt-2 text-sm text-slate-500">{stats}</p>
-          </div>
-          <div className="grid gap-2 sm:flex sm:flex-wrap sm:justify-end">
-            <button className="focus-ring rounded-xl border border-white/10 px-3 py-2 text-sm text-slate-200 hover:border-purple-300/40" type="button" onClick={() => void loadConfig()}>
-              {state === 'loading' ? <Spinner label="Refreshing" /> : 'Refresh config'}
-            </button>
-            <button
-              className="focus-ring rounded-xl bg-purple-300 px-3 py-2 text-sm font-semibold text-slate-950 disabled:cursor-not-allowed disabled:opacity-60"
-              disabled={reloading}
-              type="button"
-              onClick={() => void reloadVector()}
-            >
-              {reloading ? <Spinner label="Reloading" /> : 'Reload runtime cache'}
-            </button>
-          </div>
-        </div>
-
-        {config ? (
-          <dl className="grid gap-3 text-sm sm:grid-cols-2 xl:grid-cols-4">
-            <div className="rounded-xl border border-white/10 bg-slate-950/70 p-3"><dt className="text-slate-500">Source / Version</dt><dd className="font-semibold text-teal-200">{config.source} · v{config.config.version}</dd></div>
-            <div className="rounded-xl border border-white/10 bg-slate-950/70 p-3"><dt className="text-slate-500">Store</dt><dd className="font-semibold text-teal-200">{config.config.host}:{config.config.port}</dd></div>
-            <div className="rounded-xl border border-white/10 bg-slate-950/70 p-3"><dt className="text-slate-500">Data path</dt><dd className="font-semibold text-teal-200 break-all">{config.config.dataPath}</dd></div>
-            <div className="rounded-xl border border-white/10 bg-slate-950/70 p-3"><dt className="text-slate-500">Embedder</dt><dd className="font-semibold text-teal-200">{config.config.embedder?.backend ?? 'unknown'}</dd></div>
-            <div className="rounded-xl border border-white/10 bg-slate-950/70 p-3 sm:col-span-2"><dt className="text-slate-500">Checked</dt><dd className="font-semibold text-teal-200">{new Date(config.checked_at).toLocaleString()}</dd></div>
-            <div className="rounded-xl border border-white/10 bg-slate-950/70 p-3 sm:col-span-2"><dt className="text-slate-500">Embedding endpoint</dt><dd className="font-semibold text-teal-200">{config.config.embeddingEndpoint || 'not configured'}</dd></div>
-          </dl>
-        ) : null}
+        <div className="mb-4 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between"><div><p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-300">Vector settings</p><h1 id="vector-settings-title" className="mt-2 text-3xl font-semibold text-white">Vector config and indexing</h1><p className="mt-2 text-sm text-slate-400">Manage vector collection settings, first-run setup, and index jobs.</p><p className="mt-2 text-sm text-slate-500">{stats}</p></div><div className="grid gap-2 sm:flex sm:flex-wrap sm:justify-end"><button className="focus-ring rounded-xl border border-white/10 px-3 py-2 text-sm text-slate-200" type="button" onClick={() => void loadConfig()}>{state === 'loading' ? <Spinner label="Refreshing" /> : 'Refresh config'}</button><button className="focus-ring rounded-xl bg-purple-300 px-3 py-2 text-sm font-semibold text-slate-950 disabled:opacity-60" disabled={reloading} type="button" onClick={() => void reloadVector()}>{reloading ? <Spinner label="Reloading" /> : 'Reload runtime cache'}</button></div></div>
+        {config ? <ConfigSummary config={config} /> : null}
         {reloadStatus ? <p className="mt-3 text-sm text-slate-300">{reloadStatus}</p> : null}
       </header>
-
       {state === 'loading' ? <LoadingPanel title="Loading vector config" detail="Reading /api/v1/vector/config." /> : null}
       {state === 'error' ? <ErrorMessage title="Could not load vector config." message={error} /> : null}
       {error && state !== 'error' ? <ErrorMessage title="Vector settings warning" message={error} /> : null}
       {state === 'ready' ? <VectorAdapterSwitcher rows={rows} onRefresh={loadConfig} /> : null}
-
-      {state === 'ready' ? <VectorFirstRunWizard rows={rows} onRefresh={loadConfig} /> : null}
-
+      {state === 'ready' ? <FirstRunWizard rows={rows} onRefresh={loadConfig} /> : null}
       <section className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
-        <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
-          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Collections</p>
-          <h2 className="mt-2 text-2xl font-semibold text-white">Collection settings</h2>
-          <p className="mt-2 text-sm text-slate-400">Edit provider, model, and adapter per collection.</p>
-
-          <div className="mt-4 grid gap-3">
-            {rows.map((row) => {
-              const draft = drafts[row.key] ?? { model: row.model, provider: row.provider, adapter: row.adapter };
-              const dirty = draft.model !== row.model || draft.provider !== row.provider || draft.adapter !== row.adapter;
-              return (
-                <article key={row.key} className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
-                  <div className="mb-3 flex items-start justify-between gap-3">
-                    <div>
-                      <h3 className="text-base font-semibold text-teal-200">{row.collection}</h3>
-                      <p className="mt-1 text-sm text-slate-400">{row.key} · {row.count ?? 0} docs · {row.primary ? 'Primary' : 'Secondary'}</p>
-                    </div>
-                    <CollectionStatus status={row.health} />
-                  </div>
-                  <div className="grid gap-2 sm:grid-cols-2">
-                    <label className="grid gap-2 text-sm text-slate-300">
-                      Model
-                      <input aria-label={`${row.key} model`} className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm text-slate-100" value={draft.model} onChange={(event) => updateDraft(row.key, { model: event.target.value })} />
-                    </label>
-                    <label className="grid gap-2 text-sm text-slate-300">
-                      Provider
-                      <input aria-label={`${row.key} provider`} className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm text-slate-100" value={draft.provider} onChange={(event) => updateDraft(row.key, { provider: event.target.value })} />
-                    </label>
-                    <label className="grid gap-2 text-sm text-slate-300">
-                      Adapter
-                      <select aria-label={`${row.key} adapter`} className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm text-slate-100" value={draft.adapter} onChange={(event) => updateDraft(row.key, { adapter: event.target.value as VectorConfigAdapter })}>
-                        {ADAPTER_OPTIONS.map((value) => <option key={value} value={value}>{value}</option>)}
-                      </select>
-                    </label>
-                  </div>
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    <button
-                      className="focus-ring rounded-xl border border-teal-300/30 px-3 py-2 text-sm font-semibold text-teal-100 hover:bg-teal-300/10 disabled:cursor-not-allowed disabled:opacity-50"
-                      disabled={!dirty || Boolean(saving[row.key])}
-                      type="button"
-                      onClick={() => void saveCollection(row.key)}
-                    >
-                      {saving[row.key] ? <Spinner label="Saving" /> : 'Save'}
-                    </button>
-                    <button
-                      className="focus-ring rounded-xl border border-purple-300/30 px-3 py-2 text-sm font-semibold text-purple-100 hover:bg-purple-300/10 disabled:cursor-not-allowed disabled:opacity-50"
-                      disabled={Boolean(testing[row.key])}
-                      type="button"
-                      onClick={() => void testCollection(row.key)}
-                    >
-                      {testing[row.key] ? <Spinner label="Testing" /> : 'Test'}
-                    </button>
-                  </div>
-                  <p className="mt-2 text-sm text-slate-500">{actionMessage[row.key]}</p>
-                </article>
-              );
-            })}
-          </div>
-        </section>
-
-        <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
-          <VectorIndexPanel />
-        </section>
+        <VectorCollectionList rows={rows} drafts={drafts} saving={saving} testing={testing} primarySaving={primarySaving} actionMessage={actionMessage} onDraft={updateDraft} onSave={(key) => void saveCollection(key)} onTest={(key) => void testCollection(key)} onPrimary={(key) => void setPrimary(key)} />
+        <IndexManagerPanel />
       </section>
     </section>
   );
+}
+
+function ConfigSummary({ config }: { config: VectorConfigResponse }) {
+  return <dl className="grid gap-3 text-sm sm:grid-cols-2 xl:grid-cols-4"><div className="rounded-xl border border-white/10 bg-slate-950/70 p-3"><dt className="text-slate-500">Source / Version</dt><dd className="font-semibold text-teal-200">{config.source} · v{config.config.version}</dd></div><div className="rounded-xl border border-white/10 bg-slate-950/70 p-3"><dt className="text-slate-500">Store</dt><dd className="font-semibold text-teal-200">{config.config.host}:{config.config.port}</dd></div><div className="rounded-xl border border-white/10 bg-slate-950/70 p-3"><dt className="text-slate-500">Data path</dt><dd className="break-all font-semibold text-teal-200">{config.config.dataPath}</dd></div><div className="rounded-xl border border-white/10 bg-slate-950/70 p-3"><dt className="text-slate-500">Embedder</dt><dd className="font-semibold text-teal-200">{config.config.embedder?.backend ?? 'unknown'}</dd></div></dl>;
 }

--- a/frontend/src/routeMeta.ts
+++ b/frontend/src/routeMeta.ts
@@ -69,6 +69,7 @@ export function routeMeta(pathname: string, search = ''): RouteMeta {
   }
 
   if (pathname === '/plugins') return base('Plugin list', 'Plugins', 'Registered plugins and exposed runtime surfaces.', [{ label: 'Plugins' }]);
+  if (pathname === '/canvas/plugins') return base('Canvas plugins', 'Canvas', 'Canvas plugin registry and standalone status.', [{ label: 'Canvas plugins' }]);
   if (pathname === '/metrics') return base('Runtime metrics', 'Metrics', 'Runtime counters from /api/v1/metrics.', [{ label: 'Metrics' }]);
   if (pathname === '/search') return base('Search', 'Search', 'Search menu, plugin, and MCP tool surfaces.', [{ label: 'Search' }]);
   if (pathname === '/learn') return base('Learn entries', 'Learn', 'Capture and edit Oracle learnings.', [{ label: 'Learn' }]);

--- a/frontend/src/routePaths.ts
+++ b/frontend/src/routePaths.ts
@@ -35,3 +35,7 @@ export function vectorExportPagePath(): string {
 export function vectorSettingsPath(): string {
   return '/vector/settings';
 }
+
+export function canvasPluginsPath(): string {
+  return '/canvas/plugins';
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -7,6 +7,7 @@ import { McpToolDetailPage } from './pages/McpToolDetailPage';
 import { LearnPage } from './pages/LearnPage';
 import { MenuPage } from './pages/MenuPage';
 import { PluginsPage } from './pages/PluginsPage';
+import { CanvasPluginsPage } from './pages/CanvasPluginsPage';
 import { SearchPage } from './pages/SearchPage';
 import { SettingsPage } from './pages/SettingsPage';
 import { VectorPage } from './pages/VectorPage';
@@ -21,6 +22,7 @@ import type { MetricsSnapshot } from '../../src/server/types';
 export const frontendRoutes = [
   '/',
   '/plugins',
+  '/canvas/plugins',
   '/metrics',
   '/search',
   '/learn',
@@ -72,6 +74,7 @@ export function DashboardRoutes({
     <Routes>
       <Route index element={menuPage} />
       <Route path="/plugins" element={pluginPage} />
+      <Route path="/canvas/plugins" element={<CanvasPluginsPage />} />
       <Route path="/metrics" element={<MetricsPage metrics={metrics} loading={isRouteLoading(states.metrics)} />} />
       <Route path="/search" element={<SearchPage />} />
       <Route path="/learn" element={<LearnPage />} />

--- a/src/canvas/standalone.ts
+++ b/src/canvas/standalone.ts
@@ -1,0 +1,44 @@
+import { Elysia } from 'elysia';
+import { canvasRoutes } from '../routes/canvas/index.ts';
+import { handleCanvasRequest, type CanvasWorkerEnv } from '../workers/canvas/index.ts';
+
+export interface CanvasServeOptions {
+  port: number;
+  apiBase?: string;
+  hostname?: string;
+}
+
+export const DEFAULT_CANVAS_PORT = 47779;
+
+export function createCanvasStandaloneApp(env: CanvasWorkerEnv = {}) {
+  return new Elysia({ name: 'canvas-standalone' })
+    .use(canvasRoutes)
+    .all('*', ({ request }) => handleCanvasRequest(request, env));
+}
+
+function readFlag(args: string[], name: string): string | undefined {
+  const eq = args.find((arg) => arg.startsWith(`${name}=`));
+  if (eq) return eq.slice(name.length + 1);
+  const idx = args.indexOf(name);
+  return idx >= 0 ? args[idx + 1] : undefined;
+}
+
+export function parseCanvasServeOptions(args: string[], env: Record<string, string | undefined> = process.env): CanvasServeOptions {
+  const rawPort = readFlag(args, '--port') ?? env.CANVAS_PORT ?? String(DEFAULT_CANVAS_PORT);
+  const port = Number(rawPort);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) throw new Error('--port must be 1-65535');
+  return {
+    port,
+    apiBase: readFlag(args, '--api-base') ?? env.ORACLE_API_BASE,
+    hostname: readFlag(args, '--host') ?? env.CANVAS_HOST ?? '0.0.0.0',
+  };
+}
+
+export function canvasServeSummary(options: CanvasServeOptions) {
+  return {
+    url: `http://localhost:${options.port}`,
+    host: 'canvas.buildwithoracle.com',
+    port: options.port,
+    apiBase: options.apiBase ?? 'https://studio.buildwithoracle.com',
+  };
+}

--- a/src/cli/commands/canvas-serve.ts
+++ b/src/cli/commands/canvas-serve.ts
@@ -1,0 +1,31 @@
+import { canvasServeSummary, createCanvasStandaloneApp, parseCanvasServeOptions } from '../../canvas/standalone.ts';
+
+function printUsage(): void {
+  console.log('Usage: bun run src/cli/index.ts canvas-serve [--port N] [--api-base URL] [--host HOST] [--dry-run] [--json]');
+}
+
+export async function canvasServeCommand(args: string[]): Promise<number> {
+  if (args.includes('--help') || args.includes('-h')) {
+    printUsage();
+    return 0;
+  }
+  try {
+    const options = parseCanvasServeOptions(args.slice(1));
+    const summary = canvasServeSummary(options);
+    if (args.includes('--dry-run')) {
+      console.log(args.includes('--json') ? JSON.stringify(summary, null, 2) : `Canvas standalone ready at ${summary.url}`);
+      return 0;
+    }
+    const app = createCanvasStandaloneApp({ ORACLE_API_BASE: options.apiBase });
+    const server = Bun.serve({ hostname: options.hostname, port: options.port, fetch: (request) => app.handle(request) });
+    console.log(`Canvas standalone serving ${summary.host} on http://${options.hostname}:${server.port}`);
+    return await new Promise<number>((resolve) => {
+      const stop = () => { server.stop(); resolve(0); };
+      process.once('SIGINT', stop);
+      process.once('SIGTERM', stop);
+    });
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,12 +3,14 @@
 import { exportCommand } from './commands/export.ts';
 import { serveCommand } from './commands/serve.ts';
 import { canvasPluginsCommand } from './commands/canvas-plugins.ts';
+import { canvasServeCommand } from './commands/canvas-serve.ts';
 
 function printUsage(): void {
-  console.error('usage: bun run src/cli/index.ts <export|serve|canvas-plugins> ...');
+  console.error('usage: bun run src/cli/index.ts <export|serve|canvas-plugins|canvas-serve> ...');
   console.error('  export: bun run src/cli/index.ts export --format json|markdown [--out <file>]');
   console.error('  serve:  bun run src/cli/index.ts serve <start|stop|status> [--foreground|--background] [--json]');
   console.error('  canvas-plugins: bun run src/cli/index.ts canvas-plugins [--kind three|react] [--id <id>] [--json]');
+  console.error('  canvas-serve: bun run src/cli/index.ts canvas-serve [--port N] [--api-base URL]');
 }
 
 async function main() {
@@ -20,6 +22,7 @@ async function main() {
 
   if (args[0] === 'serve') process.exit(await serveCommand(args));
   if (args[0] === 'canvas-plugins') process.exit(await canvasPluginsCommand(args));
+  if (args[0] === 'canvas-serve') process.exit(await canvasServeCommand(args));
   if (args[0] === 'export') process.exit(await exportCommand(args));
 
   console.error(`unknown command: ${args[0]}`);

--- a/src/middleware/tenant.ts
+++ b/src/middleware/tenant.ts
@@ -1,8 +1,10 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
+import { timingSafeEqual } from 'node:crypto';
 import { Elysia } from 'elysia';
 import { eq, type SQL } from 'drizzle-orm';
 
 export const TENANT_HEADER = 'X-Oracle-Tenant';
+export const TENANT_TOKEN_HEADER = 'X-Oracle-Tenant-Token';
 export const LEGACY_TENANT_HEADER = 'X-Tenant-Id';
 export const ORG_HEADER = 'X-Org-Id';
 const TENANT_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/;
@@ -10,9 +12,26 @@ const TENANT_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/;
 type TenantContext = { tenantId?: string };
 type ProjectColumn = { project: unknown };
 type FetchHandler = (request: Request) => Response | Promise<Response>;
+type TenantTokenMap = Record<string, string>;
 
 const tenantStore = new AsyncLocalStorage<TenantContext>();
 const tenants = new WeakMap<Request, string | undefined>();
+
+function safeEqual(a: string, b: string): boolean {
+  const left = Buffer.from(a);
+  const right = Buffer.from(b);
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+export function parseTenantTokens(raw = process.env.ORACLE_TENANT_TOKENS ?? ''): TenantTokenMap {
+  const value = raw.trim();
+  if (!value) return {};
+  if (value.startsWith('{')) return JSON.parse(value) as TenantTokenMap;
+  return Object.fromEntries(value.split(',').map((entry) => {
+    const [tenant, ...tokenParts] = entry.split('=');
+    return [tenant.trim(), tokenParts.join('=').trim()];
+  }).filter(([tenant, token]) => tenant && token));
+}
 
 export function tenantIdFromHeaders(headers: Headers): string | undefined {
   const raw = headers.get(TENANT_HEADER) ?? headers.get(LEGACY_TENANT_HEADER) ?? headers.get(ORG_HEADER);
@@ -22,6 +41,15 @@ export function tenantIdFromHeaders(headers: Headers): string | undefined {
   return tenant;
 }
 
+export function validateTenantToken(headers: Headers, tenantId: string | undefined, tokens = parseTenantTokens()): void {
+  if (!tenantId) return;
+  const expected = tokens[tenantId] ?? tokens['*'];
+  if (!expected) return;
+  const actual = headers.get(TENANT_TOKEN_HEADER)?.trim() ?? '';
+  if (!actual) throw new Error('tenant token required');
+  if (!safeEqual(actual, expected)) throw new Error('invalid tenant token');
+}
+
 export function rememberTenant(request: Request, tenantId: string | undefined): void {
   tenants.set(request, tenantId);
 }
@@ -29,6 +57,7 @@ export function rememberTenant(request: Request, tenantId: string | undefined): 
 export function tenantIdFor(request: Request): string | undefined {
   if (tenants.has(request)) return tenants.get(request);
   const tenantId = tenantIdFromHeaders(request.headers);
+  validateTenantToken(request.headers, tenantId);
   rememberTenant(request, tenantId);
   return tenantId;
 }

--- a/src/routes/canvas/index.ts
+++ b/src/routes/canvas/index.ts
@@ -1,0 +1,43 @@
+import { Elysia, t } from 'elysia';
+import { findCanvasPlugin, listCanvasPlugins, type CanvasPluginKind } from '../../canvas/plugins.ts';
+
+const kinds = new Set<CanvasPluginKind>(['three', 'react']);
+
+function parseKind(value: unknown): CanvasPluginKind | undefined {
+  return typeof value === 'string' && kinds.has(value as CanvasPluginKind) ? value as CanvasPluginKind : undefined;
+}
+
+function registry(kind?: CanvasPluginKind) {
+  const plugins = listCanvasPlugins(kind);
+  return {
+    plugins,
+    count: plugins.length,
+    kind: kind ?? 'all',
+    standalone: {
+      host: 'canvas.buildwithoracle.com',
+      defaultPlugin: 'wave',
+      serveCommand: 'bun run src/cli/index.ts canvas-serve --port 47779',
+    },
+  };
+}
+
+export const canvasRoutes = new Elysia({ name: 'canvas-routes' })
+  .get('/api/canvas/plugins', ({ query }) => registry(parseKind(query.kind)), {
+    query: t.Object({ kind: t.Optional(t.String()) }),
+    detail: { tags: ['canvas'], summary: 'List canvas plugin registry entries' },
+  })
+  .get('/api/canvas/plugins/:id', ({ params, set }) => {
+    const plugin = findCanvasPlugin(params.id);
+    if (!plugin) {
+      set.status = 404;
+      return { error: 'canvas plugin not found', id: params.id };
+    }
+    return { plugin };
+  }, {
+    params: t.Object({ id: t.String({ minLength: 1 }) }),
+    detail: { tags: ['canvas'], summary: 'Get one canvas plugin registry entry' },
+  })
+  .get('/api/canvas/registry', ({ query }) => registry(parseKind(query.kind)), {
+    query: t.Object({ kind: t.Optional(t.String()) }),
+    detail: { tags: ['canvas'], summary: 'Canvas standalone registry manifest' },
+  });

--- a/src/routes/health/stats.ts
+++ b/src/routes/health/stats.ts
@@ -18,6 +18,10 @@ const StatsResponseSchema = t.Object({
   })),
   database: t.Optional(t.String()),
   vault_repo: t.Optional(t.Nullable(t.String())),
+  tenant: t.Optional(t.Object({
+    id: t.String(),
+    scope: t.String(),
+  })),
   error: t.Optional(t.String()),
 });
 

--- a/src/routes/memory/fanout.ts
+++ b/src/routes/memory/fanout.ts
@@ -1,0 +1,140 @@
+import { Elysia } from 'elysia';
+import type { SearchResult } from '../../server/types.ts';
+import { ensureVectorStoreConnected, getEmbeddingModels, type EmbeddingModelConfig } from '../../vector/factory.ts';
+import type { VectorQueryResult, VectorStoreAdapter } from '../../vector/types.ts';
+import { MemoryFanoutQuery } from './model.ts';
+
+type QueryStore = Pick<VectorStoreAdapter, 'query'>;
+
+type MemoryFanoutDeps = {
+  models?: () => Record<string, EmbeddingModelConfig>;
+  connect?: (key: string, models: Record<string, EmbeddingModelConfig>) => Promise<QueryStore>;
+};
+
+type RankedResult = SearchResult & {
+  fusedScore: number;
+  matches: Array<{ collection: string; rank: number; score: number }>;
+};
+
+const RRF_K = 60;
+
+function sanitize(q: string): string {
+  return q.replace(/<[^>]*>/g, '').replace(/[\x00-\x1f]/g, '').trim();
+}
+
+function parseLimit(raw: string | undefined): number {
+  return Math.min(50, Math.max(1, parseInt(raw ?? '10')));
+}
+
+function estimateTokens(text: string): number {
+  return Math.max(1, Math.ceil(text.length / 4));
+}
+
+function estimateCost(query: string, collections: string[]) {
+  const inputTokens = estimateTokens(query);
+  const vectorQueries = collections.length;
+  return {
+    inputTokens,
+    vectorQueries,
+    embeddingCalls: vectorQueries,
+    estimatedTokenUnits: inputTokens * vectorQueries,
+    estimatedUsd: 0,
+    note: 'Local vector collections have no metered API cost; token units estimate remote embedder exposure.',
+  };
+}
+
+function toSearchResults(collection: string, result: VectorQueryResult): SearchResult[] {
+  return result.ids.map((id, index) => {
+    const metadata = result.metadatas?.[index] ?? {};
+    const distance = result.distances?.[index] ?? 0;
+    return {
+      id,
+      type: metadata.type ?? 'unknown',
+      content: result.documents?.[index] ?? '',
+      source_file: metadata.source_file ?? metadata.path ?? '',
+      concepts: Array.isArray(metadata.concepts) ? metadata.concepts : [],
+      source: 'vector',
+      score: 1 / (1 + distance / 100),
+      distance,
+      model: collection,
+    };
+  });
+}
+
+export function fuseRankedResults(byCollection: Record<string, SearchResult[]>, limit: number): RankedResult[] {
+  const fused = new Map<string, RankedResult>();
+  for (const [collection, results] of Object.entries(byCollection)) {
+    results.forEach((result, index) => {
+      const rank = index + 1;
+      const contribution = 1 / (RRF_K + rank);
+      const score = result.score ?? 0;
+      const existing = fused.get(result.id);
+      if (!existing) {
+        fused.set(result.id, {
+          ...result,
+          fusedScore: contribution,
+          matches: [{ collection, rank, score }],
+        });
+        return;
+      }
+      if (score > (existing.score ?? 0)) Object.assign(existing, result);
+      existing.fusedScore += contribution;
+      existing.matches.push({ collection, rank, score });
+      existing.source = 'hybrid';
+    });
+  }
+  return [...fused.values()]
+    .map((item) => ({ ...item, fusedScore: +item.fusedScore.toFixed(6) }))
+    .sort((a, b) => b.fusedScore - a.fusedScore || (b.score ?? 0) - (a.score ?? 0))
+    .slice(0, limit);
+}
+
+export function createMemoryFanoutEndpoint(deps: MemoryFanoutDeps = {}) {
+  const listModels = deps.models ?? getEmbeddingModels;
+  const connect = deps.connect ?? ensureVectorStoreConnected;
+
+  return new Elysia().get('/memory/fanout', async ({ query, set }) => {
+    if (!query.q) {
+      set.status = 400;
+      return { error: 'Missing query parameter: q' };
+    }
+    const q = sanitize(query.q);
+    if (!q) {
+      set.status = 400;
+      return { error: 'Invalid query: empty after sanitization' };
+    }
+
+    const models = listModels();
+    const collections = Object.keys(models);
+    const limit = parseLimit(query.limit);
+    const errors: Record<string, string> = {};
+    const byCollection: Record<string, SearchResult[]> = {};
+
+    const settled = await Promise.allSettled(collections.map(async (key) => {
+      const store = await connect(key, models);
+      return { key, result: await store.query(q, limit) };
+    }));
+
+    settled.forEach((item, index) => {
+      const key = collections[index];
+      if (item.status === 'rejected') {
+        errors[key] = item.reason instanceof Error ? item.reason.message : String(item.reason);
+        return;
+      }
+      byCollection[key] = toSearchResults(key, item.value.result);
+    });
+
+    return {
+      query: q,
+      strategy: 'reciprocal_rank_fusion',
+      collections,
+      totalCollections: collections.length,
+      results: fuseRankedResults(byCollection, limit),
+      errors,
+      cost: estimateCost(q, collections),
+    };
+  }, {
+    query: MemoryFanoutQuery,
+    detail: { tags: ['memory'], menu: { group: 'hidden' }, summary: 'Fanout memory search across vector collections' },
+  });
+}

--- a/src/routes/memory/index.ts
+++ b/src/routes/memory/index.ts
@@ -1,5 +1,6 @@
 import { Elysia } from 'elysia';
 import { RecallMemoryQuery, SaveMemoryBody, SemanticMemoryQuery } from './model.ts';
+import { createMemoryFanoutEndpoint } from './fanout.ts';
 import { memoryStore, type MemoryInput, type MemoryRecord, type MemoryStore } from './store.ts';
 import { memoryVectorIndex, type MemoryVectorHit, type MemoryVectorIndex } from './vector.ts';
 
@@ -21,6 +22,7 @@ export function createMemoryRoutes(
       body: SaveMemoryBody,
       detail: { tags: ['memory'], menu: { group: 'hidden' }, summary: 'Save a persisted memory' },
     })
+    .use(createMemoryFanoutEndpoint())
     .get('/memory/recall', ({ query }) => {
       const limit = Math.min(50, Math.max(1, parseInt(query.limit ?? '10')));
       const items = store.recall(query.q ?? '', limit);

--- a/src/routes/memory/index.ts
+++ b/src/routes/memory/index.ts
@@ -1,20 +1,25 @@
 import { Elysia } from 'elysia';
-import { RecallMemoryQuery, SaveMemoryBody } from './model.ts';
-import { memoryStore, type MemoryInput, type MemoryStore } from './store.ts';
+import { RecallMemoryQuery, SaveMemoryBody, SemanticMemoryQuery } from './model.ts';
+import { memoryStore, type MemoryInput, type MemoryRecord, type MemoryStore } from './store.ts';
+import { memoryVectorIndex, type MemoryVectorHit, type MemoryVectorIndex } from './vector.ts';
 
-export function createMemoryRoutes(store: MemoryStore = memoryStore) {
+export function createMemoryRoutes(
+  store: MemoryStore = memoryStore,
+  vectorIndex: MemoryVectorIndex = memoryVectorIndex,
+) {
   return new Elysia({ prefix: '/api' })
-    .post('/memory/save', ({ body, set }) => {
+    .post('/memory/save', async ({ body, set }) => {
       try {
         const memory = store.save(body as MemoryInput);
-        return { success: true, memory };
+        const vector = await vectorIndex.index(memory);
+        return { success: true, memory, vector };
       } catch (error) {
         set.status = 400;
         return { success: false, error: error instanceof Error ? error.message : 'failed to save memory' };
       }
     }, {
       body: SaveMemoryBody,
-      detail: { tags: ['memory'], menu: { group: 'hidden' }, summary: 'Save an in-memory note' },
+      detail: { tags: ['memory'], menu: { group: 'hidden' }, summary: 'Save a persisted memory' },
     })
     .get('/memory/recall', ({ query }) => {
       const limit = Math.min(50, Math.max(1, parseInt(query.limit ?? '10')));
@@ -22,8 +27,36 @@ export function createMemoryRoutes(store: MemoryStore = memoryStore) {
       return { query: query.q ?? '', total: items.length, items };
     }, {
       query: RecallMemoryQuery,
-      detail: { tags: ['memory'], menu: { group: 'hidden' }, summary: 'Recall in-memory notes' },
+      detail: { tags: ['memory'], menu: { group: 'hidden' }, summary: 'Recall persisted memories by keyword' },
+    })
+    .get('/memory/search', async ({ query, set }) => {
+      if (!query.q?.trim()) {
+        set.status = 400;
+        return { success: false, error: 'Missing query parameter: q', results: [] };
+      }
+      const limit = Math.min(50, Math.max(1, parseInt(query.limit ?? '10')));
+      try {
+        const hits = await vectorIndex.search(query.q, limit);
+        const records = store.getByIds(hits.map((hit) => hit.memoryId));
+        return { success: true, query: query.q, total: hits.length, results: mergeHits(hits, records) };
+      } catch (error) {
+        set.status = 503;
+        return { success: false, error: error instanceof Error ? error.message : 'memory vector search failed', results: [] };
+      }
+    }, {
+      query: SemanticMemoryQuery,
+      detail: { tags: ['memory'], menu: { group: 'hidden' }, summary: 'Search memories by vector similarity' },
     });
+}
+
+function mergeHits(hits: MemoryVectorHit[], records: MemoryRecord[]) {
+  const byId = new Map(records.map((record) => [record.id, record]));
+  return hits.map((hit) => ({
+    ...(byId.get(hit.memoryId) ?? { id: hit.memoryId, content: hit.document }),
+    score: hit.score,
+    distance: hit.distance,
+    vectorId: hit.vectorId,
+  }));
 }
 
 export const memoryRoutes = createMemoryRoutes();

--- a/src/routes/memory/index.ts
+++ b/src/routes/memory/index.ts
@@ -1,5 +1,6 @@
 import { Elysia } from 'elysia';
 import { RecallMemoryQuery, SaveMemoryBody } from './model.ts';
+import { createMemoryFanoutEndpoint } from './fanout.ts';
 import { memoryStore, type MemoryInput, type MemoryStore } from './store.ts';
 
 export function createMemoryRoutes(store: MemoryStore = memoryStore) {
@@ -16,6 +17,7 @@ export function createMemoryRoutes(store: MemoryStore = memoryStore) {
       body: SaveMemoryBody,
       detail: { tags: ['memory'], menu: { group: 'hidden' }, summary: 'Save an in-memory note' },
     })
+    .use(createMemoryFanoutEndpoint())
     .get('/memory/recall', ({ query }) => {
       const limit = Math.min(50, Math.max(1, parseInt(query.limit ?? '10')));
       const items = store.recall(query.q ?? '', limit);

--- a/src/routes/memory/model.ts
+++ b/src/routes/memory/model.ts
@@ -16,3 +16,8 @@ export const SemanticMemoryQuery = t.Object({
   q: t.Optional(t.String()),
   limit: t.Optional(t.String()),
 });
+
+export const MemoryFanoutQuery = t.Object({
+  q: t.Optional(t.String()),
+  limit: t.Optional(t.String()),
+});

--- a/src/routes/memory/model.ts
+++ b/src/routes/memory/model.ts
@@ -11,3 +11,8 @@ export const RecallMemoryQuery = t.Object({
   q: t.Optional(t.String()),
   limit: t.Optional(t.String()),
 });
+
+export const SemanticMemoryQuery = t.Object({
+  q: t.Optional(t.String()),
+  limit: t.Optional(t.String()),
+});

--- a/src/routes/memory/model.ts
+++ b/src/routes/memory/model.ts
@@ -11,3 +11,8 @@ export const RecallMemoryQuery = t.Object({
   q: t.Optional(t.String()),
   limit: t.Optional(t.String()),
 });
+
+export const MemoryFanoutQuery = t.Object({
+  q: t.Optional(t.String()),
+  limit: t.Optional(t.String()),
+});

--- a/src/routes/memory/store.ts
+++ b/src/routes/memory/store.ts
@@ -1,4 +1,4 @@
-import { desc, like, or } from 'drizzle-orm';
+import { desc, inArray, like, or } from 'drizzle-orm';
 import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 import { db as defaultDb, oracleMemories } from '../../db/index.ts';
 import type * as schema from '../../db/schema.ts';
@@ -52,6 +52,16 @@ export class MemoryStore {
       : base.orderBy(desc(oracleMemories.createdAt)).limit(safeLimit).all();
     return rows.map(memoryFromRow);
   }
+
+  getByIds(ids: string[]): MemoryRecord[] {
+    if (!ids.length) return [];
+    const rows = this.database.select().from(oracleMemories)
+      .where(inArray(oracleMemories.id, ids))
+      .all();
+    const byId = new Map(rows.map((row) => [row.id, memoryFromRow(row)]));
+    return ids.map((id) => byId.get(id)).filter((row): row is MemoryRecord => Boolean(row));
+  }
+
 }
 
 function cleanTags(tags: string[] = []): string[] {

--- a/src/routes/memory/vector.ts
+++ b/src/routes/memory/vector.ts
@@ -1,0 +1,83 @@
+import { ensureVectorStoreConnected } from '../../vector/factory.ts';
+import type { VectorDocument, VectorQueryResult, VectorStoreAdapter } from '../../vector/types.ts';
+import type { MemoryRecord } from './store.ts';
+
+export type MemoryVectorHit = {
+  memoryId: string;
+  vectorId: string;
+  document: string;
+  metadata: Record<string, unknown>;
+  distance: number;
+  score: number;
+};
+
+export type MemoryVectorIndexResult = { indexed: true } | { indexed: false; error: string };
+
+export interface MemoryVectorIndex {
+  index(memory: MemoryRecord): Promise<MemoryVectorIndexResult>;
+  search(query: string, limit: number): Promise<MemoryVectorHit[]>;
+}
+
+type StoreResolver = () => Promise<VectorStoreAdapter>;
+
+export class VectorMemoryIndex implements MemoryVectorIndex {
+  constructor(private readonly resolveStore: StoreResolver = () => ensureVectorStoreConnected('bge-m3')) {}
+
+  async index(memory: MemoryRecord): Promise<MemoryVectorIndexResult> {
+    try {
+      const store = await this.resolveStore();
+      await store.addDocuments([memoryDocument(memory)]);
+      return { indexed: true };
+    } catch (error) {
+      return { indexed: false, error: messageFrom(error) };
+    }
+  }
+
+  async search(query: string, limit: number): Promise<MemoryVectorHit[]> {
+    const clean = query.trim();
+    if (!clean) throw new Error('memory search query is required');
+    const store = await this.resolveStore();
+    const result = await store.query(clean, limit, { type: 'memory' });
+    return hitsFrom(result);
+  }
+}
+
+function memoryDocument(memory: MemoryRecord): VectorDocument {
+  return {
+    id: vectorId(memory.id),
+    document: [memory.title, memory.content, ...(memory.tags ?? [])].filter(Boolean).join('\n'),
+    metadata: {
+      type: 'memory',
+      memoryId: memory.id,
+      title: memory.title ?? '',
+      source: memory.source ?? '',
+      tags: (memory.tags ?? []).join(','),
+      createdAt: memory.createdAt,
+    },
+  };
+}
+
+function hitsFrom(result: VectorQueryResult): MemoryVectorHit[] {
+  return result.ids.map((id, index) => {
+    const metadata = (result.metadatas[index] ?? {}) as Record<string, unknown>;
+    const distance = Number(result.distances[index] ?? 0);
+    return {
+      memoryId: String(metadata.memoryId ?? id.replace(/^memory:/, '')),
+      vectorId: id,
+      document: result.documents[index] ?? '',
+      metadata,
+      distance,
+      score: Math.max(0, 1 - distance),
+    };
+  });
+}
+
+function vectorId(memoryId: string): string {
+  return `memory:${memoryId}`;
+}
+
+function messageFrom(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export const memoryVectorIndex = new VectorMemoryIndex();

--- a/src/routes/vector/cost.ts
+++ b/src/routes/vector/cost.ts
@@ -1,0 +1,72 @@
+import { Elysia, t } from 'elysia';
+import { getDetectedEmbeddingProviders } from '../../vector/provider-detection.ts';
+import { estimateEmbeddingCost, recommendEmbeddingModel, type CostProvider } from '../../vector/cost-estimation.ts';
+import { getEmbeddingModels, createVectorStoreForModel, type EmbeddingModelConfig } from '../../vector/factory.ts';
+
+export interface VectorCostEndpointOptions {
+  getModels?: () => Record<string, EmbeddingModelConfig>;
+  getCount?: (key: string, model: EmbeddingModelConfig) => Promise<number>;
+  detectProviders?: () => Promise<{ providers: Array<{ type: string; available: boolean }> }>;
+}
+
+const providerSchema = t.Union([
+  t.Literal('openai'),
+  t.Literal('gemini'),
+  t.Literal('ollama'),
+  t.Literal('local'),
+  t.Literal('remote'),
+  t.Literal('cloudflare-ai'),
+]);
+
+async function defaultCount(_key: string, model: EmbeddingModelConfig): Promise<number> {
+  const store = createVectorStoreForModel(model);
+  try {
+    await store.connect();
+    return (await store.getStats()).count;
+  } finally {
+    await store.close().catch(() => undefined);
+  }
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+export function createVectorCostEndpoint(options: VectorCostEndpointOptions = {}) {
+  return new Elysia().get('/vector/cost-estimate', async ({ query }) => {
+    const models = options.getModels?.() ?? getEmbeddingModels();
+    const entries = Object.entries(models);
+    const requested = query.collection ? entries.filter(([key]) => key === query.collection) : entries;
+    const counts = await Promise.all(requested.map(async ([key, model]) => options.getCount?.(key, model) ?? defaultCount(key, model)));
+    const docs = query.docs ? parsePositiveInt(query.docs, 0) : counts.reduce((sum, count) => sum + count, 0);
+    const provider = (query.provider ?? 'openai') as CostProvider;
+    const estimate = estimateEmbeddingCost({
+      docs,
+      provider,
+      model: query.model,
+      tokensPerDoc: parsePositiveInt(query.tokensPerDoc, 500),
+    });
+    const detected = await (options.detectProviders?.() ?? getDetectedEmbeddingProviders(false));
+    const availableProviders = detected.providers.filter((item) => item.available).map((item) => item.type);
+    return {
+      ...estimate,
+      collection: query.collection ?? 'all',
+      collections: requested.map(([key], index) => ({ key, docs: counts[index] })),
+      availableProviders,
+      recommendation: recommendEmbeddingModel(docs, availableProviders),
+    };
+  }, {
+    query: t.Object({
+      docs: t.Optional(t.String()),
+      tokensPerDoc: t.Optional(t.String()),
+      provider: t.Optional(providerSchema),
+      model: t.Optional(t.String()),
+      collection: t.Optional(t.String()),
+    }),
+    detail: { tags: ['vector'], summary: 'Estimate embedding cost before remote indexing' },
+  });
+}
+
+export const vectorCostEndpoint = createVectorCostEndpoint();

--- a/src/routes/vector/fanout.ts
+++ b/src/routes/vector/fanout.ts
@@ -1,10 +1,16 @@
 import { Elysia } from 'elysia';
-import { ensureVectorStoreConnected, getEmbeddingModels } from '../../vector/factory.ts';
+import { ensureVectorStoreConnected, getEmbeddingModels, type EmbeddingModelConfig } from '../../vector/factory.ts';
 import { queryFanout } from '../../vector/fanout-query.ts';
 import { QueryCache, stableCacheKey } from '../../vector/query-cache.ts';
 import { FanoutQuery } from './model.ts';
+import type { VectorStoreAdapter } from '../../vector/types.ts';
 
 const cache = new QueryCache<unknown>();
+
+export interface FanoutEndpointOptions {
+  getModels?: () => Record<string, EmbeddingModelConfig>;
+  getStore?: (key: string, models: Record<string, EmbeddingModelConfig>) => Promise<Pick<VectorStoreAdapter, 'query'>>;
+}
 
 function sanitize(q: string): string {
   return q.replace(/<[^>]*>/g, '').replace(/[\x00-\x1f]/g, '').trim();
@@ -15,7 +21,8 @@ function requestedBackends(raw: string | undefined, enabled: string[]): string[]
   return requested.filter((item, index) => enabled.includes(item) && requested.indexOf(item) === index);
 }
 
-export const fanoutEndpoint = new Elysia().get(
+export function createFanoutEndpoint(options: FanoutEndpointOptions = {}) {
+  return new Elysia().get(
   '/vector/fanout',
   async ({ query, set }) => {
     if (!query.q) {
@@ -28,7 +35,7 @@ export const fanoutEndpoint = new Elysia().get(
       return { error: 'Invalid query: empty after sanitization' };
     }
 
-    const models = getEmbeddingModels();
+    const models = options.getModels?.() ?? getEmbeddingModels();
     const backends = requestedBackends(query.fanout, Object.keys(models));
     const limit = Math.min(100, Math.max(1, parseInt(query.limit ?? '20')));
     if (backends.length === 0) return { query: q, strategy: 'merge', backends, results: [], errors: {} };
@@ -42,7 +49,7 @@ export const fanoutEndpoint = new Elysia().get(
     const where = query.type && query.type !== 'all' ? { type: query.type } : undefined;
     const targets = await Promise.all(backends.map(async (key) => ({
       key,
-      store: await ensureVectorStoreConnected(key, models),
+      store: await (options.getStore?.(key, models) ?? ensureVectorStoreConnected(key, models)),
     })));
     const result = { query: q, ...(await queryFanout({ text: q, limit, where, targets })) };
     if (query.cache !== 'false') cache.set(cacheKey, result);
@@ -57,3 +64,6 @@ export const fanoutEndpoint = new Elysia().get(
     },
   },
 );
+}
+
+export const fanoutEndpoint = createFanoutEndpoint();

--- a/src/routes/vector/index.ts
+++ b/src/routes/vector/index.ts
@@ -10,6 +10,7 @@
  *   GET /api/map3d           — 3D PCA projection from real embeddings
  *   GET /api/vector/stats    — per-engine collection counts
  *   GET /api/vector/health   — adapter liveness probe
+ *   GET /api/vector/cost-estimate — estimate remote embedding cost
  *   GET /api/vector/documents — browse indexed vector documents
  *   GET /api/v1/vector/export/formats — available export formats
  *   GET /api/v1/vector/export — stream vector docs in a registered format
@@ -38,6 +39,7 @@ import { vectorDocumentsEndpoint } from './documents.ts';
 import { vectorExportEndpoint } from './export.ts';
 import { vectorServicesApiEndpoint } from './services.ts';
 import { vectorProvidersEndpoint } from './providers.ts';
+import { vectorCostEndpoint } from './cost.ts';
 
 export const vectorRoutes = new Elysia({ prefix: '/api' })
   .use(vectorProxyEndpoint)
@@ -53,5 +55,6 @@ export const vectorRoutes = new Elysia({ prefix: '/api' })
   .use(vectorExportEndpoint)
   .use(vectorConfigApiEndpoint)
   .use(vectorProvidersEndpoint)
+  .use(vectorCostEndpoint)
   .use(vectorServicesApiEndpoint)
   .use(vectorIndexerEndpoints);

--- a/src/server.ts
+++ b/src/server.ts
@@ -57,6 +57,7 @@ import { peerRoutes } from './routes/peer/index.ts';
 import { createMcpRoutes } from './routes/mcp/index.ts';
 import { createMetricsLifecycle, metricsRoutes } from './routes/metrics/index.ts';
 import { memoryRoutes } from './routes/memory/index.ts';
+import { canvasRoutes } from './routes/canvas/index.ts';
 
 let indexerRoutes: any = null;
 try {
@@ -198,6 +199,7 @@ const apiModules = [
   vaultRoutes,
   metricsRoutes,
   memoryRoutes,
+  canvasRoutes,
   ...(indexerRoutes ? [indexerRoutes] : []),
   ...unifiedPlugins.routes,
 ];

--- a/src/vector/config.ts
+++ b/src/vector/config.ts
@@ -61,7 +61,7 @@ export interface VectorServerConfig {
 export type VectorProxyManifest = UnifiedProxyManifest;
 
 /** Absolute path to vector-server.json inside ORACLE_DATA_DIR. */
-export function configPath(dataDir = ORACLE_DATA_DIR): string {
+export function configPath(dataDir = process.env.ORACLE_DATA_DIR || ORACLE_DATA_DIR): string {
   return path.join(dataDir, VECTOR_CONFIG_FILE);
 }
 

--- a/src/vector/cost-estimation.ts
+++ b/src/vector/cost-estimation.ts
@@ -1,0 +1,84 @@
+import type { EmbeddingProviderType } from './types.ts';
+
+export type CostProvider = Extract<EmbeddingProviderType, 'openai' | 'gemini' | 'ollama' | 'local' | 'remote' | 'cloudflare-ai'>;
+
+export interface CostEstimateInput {
+  docs: number;
+  tokensPerDoc?: number;
+  provider?: CostProvider;
+  model?: string;
+}
+
+export interface CostEstimate {
+  docs: number;
+  tokensPerDoc: number;
+  totalTokens: number;
+  provider: CostProvider;
+  model: string;
+  estimatedUsd: number;
+  formula: string;
+  note: string;
+}
+
+const DEFAULT_TOKENS_PER_DOC = 500;
+
+const PRICE_PER_MILLION: Record<CostProvider, number> = {
+  openai: 0.02,
+  gemini: 0,
+  ollama: 0,
+  local: 0,
+  remote: 0,
+  'cloudflare-ai': 0.008,
+};
+
+const DEFAULT_MODEL: Record<CostProvider, string> = {
+  openai: 'text-embedding-3-small',
+  gemini: 'text-embedding-004',
+  ollama: 'nomic-embed-text',
+  local: 'nomic-embed-text',
+  remote: 'remote-embedder',
+  'cloudflare-ai': '@cf/baai/bge-base-en-v1.5',
+};
+
+export function estimateEmbeddingCost(input: CostEstimateInput): CostEstimate {
+  const docs = Math.max(0, Math.floor(input.docs));
+  const tokensPerDoc = Math.max(1, Math.floor(input.tokensPerDoc ?? DEFAULT_TOKENS_PER_DOC));
+  const provider = input.provider ?? 'openai';
+  const model = input.model || DEFAULT_MODEL[provider];
+  const totalTokens = docs * tokensPerDoc;
+  const estimatedUsd = Number(((totalTokens / 1_000_000) * PRICE_PER_MILLION[provider]).toFixed(4));
+  return {
+    docs,
+    tokensPerDoc,
+    totalTokens,
+    provider,
+    model,
+    estimatedUsd,
+    formula: `${docs.toLocaleString()} docs × ~${tokensPerDoc.toLocaleString()} tokens/doc ≈ ${compactTokens(totalTokens)} tokens`,
+    note: noteFor(provider),
+  };
+}
+
+export function recommendEmbeddingModel(docs: number, availableProviders: string[] = []): string {
+  const available = new Set(availableProviders);
+  if (docs < 10_000) return 'Any configured embedding model should work for this corpus size.';
+  if (docs <= 100_000) {
+    if (available.has('gemini')) return 'Gemini free tier is recommended before paid remote embedding.';
+    if (available.has('ollama') || available.has('local')) return 'Ollama/local embeddings are recommended to avoid remote cost.';
+    return 'Use OpenAI small embeddings for speed, but review cost first.';
+  }
+  return 'Use Ollama/local embeddings with GPU acceleration for large indexes.';
+}
+
+function compactTokens(tokens: number): string {
+  if (tokens >= 1_000_000) return `${Number((tokens / 1_000_000).toFixed(1))}M`;
+  if (tokens >= 1_000) return `${Number((tokens / 1_000).toFixed(1))}K`;
+  return String(tokens);
+}
+
+function noteFor(provider: CostProvider): string {
+  if (provider === 'gemini') return 'Gemini estimate is $0 here because this app treats daily free-tier usage as zero marginal cost.';
+  if (provider === 'ollama' || provider === 'local') return 'Local/Ollama estimate excludes hardware and electricity costs.';
+  if (provider === 'remote') return 'Remote provider pricing depends on the configured service.';
+  return 'Estimate only; check provider pricing before large indexing jobs.';
+}

--- a/src/vector/registry.ts
+++ b/src/vector/registry.ts
@@ -120,6 +120,7 @@ function validateService(service: RegisteredVectorService): RegisteredVectorServ
 
 class InMemoryVectorServiceRegistry implements VectorServiceRegistry {
   async register(service: RegisteredVectorService): Promise<RegisteredVectorService> {
+    ensureConfigRefreshed();
     const normalized = validateService(service);
     registry.set(normalized.name, normalized);
     syncConfig(registry);
@@ -138,6 +139,7 @@ class InMemoryVectorServiceRegistry implements VectorServiceRegistry {
   }
 
   async unregister(name: string): Promise<boolean> {
+    ensureConfigRefreshed();
     const removed = registry.delete(name);
     if (removed) syncConfig(registry);
     return removed;

--- a/tests/canvas/phase2.test.ts
+++ b/tests/canvas/phase2.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { canvasRoutes } from '../../src/routes/canvas/index.ts';
+import { canvasServeCommand } from '../../src/cli/commands/canvas-serve.ts';
+import { createCanvasStandaloneApp, parseCanvasServeOptions } from '../../src/canvas/standalone.ts';
+import { discoverPlugins } from '../../cli/src/plugin/loader.ts';
+import { pluginCliCommands } from '../../cli/src/plugin/registry.ts';
+
+describe('canvas phase 2 HTTP and standalone surfaces', () => {
+  test('exposes canvas registry through dedicated HTTP routes', async () => {
+    const app = new Elysia().use(canvasRoutes);
+    const response = await app.handle(new Request('http://local/api/canvas/plugins?kind=react'));
+    const body = await response.json() as { count: number; plugins: Array<{ id: string; kind: string }> };
+
+    expect(response.status).toBe(200);
+    expect(body.count).toBe(2);
+    expect(body.plugins.map((plugin) => plugin.id)).toEqual(['map', 'planets']);
+  });
+
+  test('returns 404 for unknown canvas plugin ids', async () => {
+    const app = new Elysia().use(canvasRoutes);
+    const response = await app.handle(new Request('http://local/api/canvas/plugins/missing'));
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: 'canvas plugin not found', id: 'missing' });
+  });
+
+  test('standalone app serves canvas HTML and registry API together', async () => {
+    const app = createCanvasStandaloneApp({ ORACLE_API_BASE: 'https://oracle.example.test' });
+    const html = await app.handle(new Request('http://canvas.local/?plugin=wave'));
+    const registry = await app.handle(new Request('http://canvas.local/api/canvas/registry'));
+
+    expect(html.status).toBe(200);
+    expect(await html.text()).toContain('plugin=wave');
+    expect((await registry.json() as { standalone: { host: string } }).standalone.host).toBe('canvas.buildwithoracle.com');
+  });
+
+  test('bundled CLI registry exposes canvas-serve command', async () => {
+    const result = await discoverPlugins({ userPluginDir: '/tmp/missing-user-plugins' });
+    const commands = result.plugins.flatMap(pluginCliCommands).map((entry) => entry.command);
+
+    expect(commands).toContain('canvas-serve');
+  });
+
+  test('canvas-serve supports dry-run without binding a port', async () => {
+    const lines: string[] = [];
+    const originalLog = console.log;
+    console.log = (message?: unknown) => lines.push(String(message));
+    try {
+      expect(parseCanvasServeOptions(['--port', '47780']).port).toBe(47780);
+      expect(await canvasServeCommand(['canvas-serve', '--port', '47780', '--dry-run', '--json'])).toBe(0);
+    } finally {
+      console.log = originalLog;
+    }
+    expect(JSON.parse(lines[0])).toMatchObject({ port: 47780, host: 'canvas.buildwithoracle.com' });
+  });
+});

--- a/tests/frontend/pages/canvas-plugins-page.test.tsx
+++ b/tests/frontend/pages/canvas-plugins-page.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test';
+import { CanvasPluginsPage } from '../../../frontend/src/pages/CanvasPluginsPage';
+import { htmlFor } from '../_render';
+
+const plugins = [
+  { id: 'wave', label: 'Wave', description: 'Wave field scene.', kind: 'three' as const, mount: 'waveScene', path: '/canvas', query: { plugin: 'wave' } },
+  { id: 'map', label: 'Knowledge Map', description: 'React map.', kind: 'react' as const, renderer: 'KnowledgeMapCanvas', path: '/map', query: { plugin: 'map' }, apiPath: '/api/map3d' },
+];
+
+describe('CanvasPluginsPage', () => {
+  test('renders canvas plugin list and status from initial data', () => {
+    const html = htmlFor(<CanvasPluginsPage plugins={plugins} loading={false} />);
+
+    expect(html).toContain('Canvas plugin registry');
+    expect(html).toContain('2 registered · 1 three · 1 react');
+    expect(html).toContain('Wave');
+    expect(html).toContain('Knowledge Map');
+    expect(html).toContain('registered');
+    expect(html).toContain('/api/map3d');
+  });
+});

--- a/tests/frontend/router.test.ts
+++ b/tests/frontend/router.test.ts
@@ -34,6 +34,7 @@ describe('frontend router', () => {
     expect([...frontendRoutes]).toEqual([
       '/',
       '/plugins',
+      '/canvas/plugins',
       '/metrics',
       '/search',
       '/learn',
@@ -42,12 +43,14 @@ describe('frontend router', () => {
       '/vector/documents',
       '/vector/results',
       '/vector/export',
+      '/vector/settings',
     ]);
   });
 
   test('routes root, plugins, metrics, search, and learn surfaces', () => {
     expect(htmlAt('/')).toContain('Menu viewer');
     expect(htmlAt('/plugins')).toContain('Registered plugins');
+    expect(htmlAt('/canvas/plugins')).toContain('Canvas plugin registry');
     expect(htmlAt('/metrics')).toContain('Metrics dashboard');
     expect(htmlAt('/metrics')).toContain('42');
     expect(htmlAt('/metrics')).toContain('Memory usage');
@@ -58,6 +61,7 @@ describe('frontend router', () => {
     expect(htmlAt('/vector/documents')).toContain('Vector documents');
     expect(htmlAt('/vector/results')).toContain('Vector search results');
     expect(htmlAt('/vector/export')).toContain('Vector export');
+    expect(htmlAt('/vector/settings')).toContain('Vector config and indexing');
   });
 
   test('wraps routed children in the browser router and error boundary shell', () => {

--- a/tests/http/health/tenant-scope.test.ts
+++ b/tests/http/health/tenant-scope.test.ts
@@ -37,7 +37,7 @@ function createFetch() {
   return createTenantFetch((request) => app.handle(request));
 }
 
-test.skip('GET /api/stats scopes document counts by tenant header', async () => {
+test('GET /api/stats scopes document counts by tenant header', async () => {
   const res = await createFetch()(new Request('http://local/api/stats', {
     headers: { [TENANT_HEADER]: tenantA },
   }));

--- a/tests/http/memory/fanout.test.ts
+++ b/tests/http/memory/fanout.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createMemoryFanoutEndpoint } from '../../../src/routes/memory/fanout.ts';
+import type { EmbeddingModelConfig } from '../../../src/vector/factory.ts';
+import type { VectorQueryResult } from '../../../src/vector/types.ts';
+
+const models: Record<string, EmbeddingModelConfig> = {
+  alpha: { collection: 'alpha_docs', model: 'alpha-embed' },
+  beta: { collection: 'beta_docs', model: 'beta-embed' },
+};
+
+function result(ids: string[]): VectorQueryResult {
+  return {
+    ids,
+    documents: ids.map((id) => `${id} document`),
+    distances: ids.map((_, index) => index * 10),
+    metadatas: ids.map((id) => ({ type: 'memory', source_file: `${id}.md` })),
+  };
+}
+
+function createFetch(responses: Record<string, VectorQueryResult | Error>) {
+  const app = new Elysia({ prefix: '/api' }).use(createMemoryFanoutEndpoint({
+    models: () => models,
+    connect: async (key) => ({
+      query: async () => {
+        const response = responses[key];
+        if (response instanceof Error) throw response;
+        return response;
+      },
+    }),
+  }));
+  return createApiVersionedFetch((request) => app.handle(request));
+}
+
+async function json(response: Response) {
+  return JSON.parse(await response.text());
+}
+
+test('GET /api/v1/memory/fanout queries all collections and rank-fuses results', async () => {
+  const fetcher = createFetch({
+    alpha: result(['shared', 'alpha-only']),
+    beta: result(['beta-only', 'shared']),
+  });
+  const response = await fetcher(new Request('http://local/api/v1/memory/fanout?q=oracle&limit=3'));
+  const body = await json(response);
+
+  expect(response.status).toBe(200);
+  expect(body).toMatchObject({
+    query: 'oracle',
+    strategy: 'reciprocal_rank_fusion',
+    collections: ['alpha', 'beta'],
+    totalCollections: 2,
+    errors: {},
+    cost: { inputTokens: 2, vectorQueries: 2, embeddingCalls: 2, estimatedTokenUnits: 4 },
+  });
+  expect(body.results[0]).toMatchObject({ id: 'shared', source: 'hybrid' });
+  expect(body.results[0].matches.map((match: { collection: string }) => match.collection)).toEqual(['alpha', 'beta']);
+});
+
+test('GET /api/v1/memory/fanout preserves partial collection errors', async () => {
+  const fetcher = createFetch({
+    alpha: result(['alpha-only']),
+    beta: new Error('beta unavailable'),
+  });
+  const response = await fetcher(new Request('http://local/api/v1/memory/fanout?q=oracle'));
+  const body = await json(response);
+
+  expect(response.status).toBe(200);
+  expect(body.results).toHaveLength(1);
+  expect(body.errors).toEqual({ beta: 'beta unavailable' });
+});

--- a/tests/http/memory/save-recall.test.ts
+++ b/tests/http/memory/save-recall.test.ts
@@ -3,6 +3,8 @@ import { inArray } from 'drizzle-orm';
 import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
 import { db, oracleMemories } from '../../../src/db/index.ts';
 import { createMemoryRoutes } from '../../../src/routes/memory/index.ts';
+import type { MemoryRecord } from '../../../src/routes/memory/store.ts';
+import type { MemoryVectorIndex } from '../../../src/routes/memory/vector.ts';
 
 const savedIds: string[] = [];
 
@@ -10,17 +12,43 @@ afterAll(() => {
   if (savedIds.length) db.delete(oracleMemories).where(inArray(oracleMemories.id, savedIds)).run();
 });
 
-function createFetch() {
-  const app = createMemoryRoutes();
-  return createApiVersionedFetch((request) => app.handle(request));
+class FakeMemoryVectorIndex implements MemoryVectorIndex {
+  readonly memories: MemoryRecord[] = [];
+
+  async index(memory: MemoryRecord) {
+    this.memories.push(memory);
+    return { indexed: true as const };
+  }
+
+  async search(query: string, limit: number) {
+    const q = query.toLowerCase();
+    return this.memories
+      .filter((memory) => [memory.title, memory.content, memory.source, ...(memory.tags ?? [])]
+        .filter(Boolean).join(' ').toLowerCase().includes(q))
+      .slice(0, limit)
+      .map((memory, index) => ({
+        memoryId: memory.id,
+        vectorId: `memory:${memory.id}`,
+        document: memory.content,
+        metadata: { type: 'memory', memoryId: memory.id },
+        distance: index * 0.1,
+        score: 1 - index * 0.1,
+      }));
+  }
+}
+
+function createHarness() {
+  const vectorIndex = new FakeMemoryVectorIndex();
+  const app = createMemoryRoutes(undefined, vectorIndex);
+  return { fetcher: createApiVersionedFetch((request) => app.handle(request)), vectorIndex };
 }
 
 async function json(res: Response) {
   return JSON.parse(await res.text());
 }
 
-test('POST /api/v1/memory/save persists a memory and recall finds it by keyword', async () => {
-  const fetcher = createFetch();
+test('POST /api/v1/memory/save persists a memory, indexes it, and recall finds it by keyword', async () => {
+  const { fetcher, vectorIndex } = createHarness();
   const unique = `launch-${Date.now()}-${Math.random().toString(16).slice(2)}`;
   const save = await fetcher(new Request('http://local/api/v1/memory/save', {
     method: 'POST',
@@ -36,8 +64,9 @@ test('POST /api/v1/memory/save persists a memory and recall finds it by keyword'
   savedIds.push(saved.memory.id);
 
   expect(save.status).toBe(200);
-  expect(saved).toMatchObject({ success: true, memory: { title: 'Morning tape', tags: ['continuity', 'oracle'] } });
+  expect(saved).toMatchObject({ success: true, vector: { indexed: true }, memory: { title: 'Morning tape' } });
   expect(saved.memory.id).toStartWith('mem_');
+  expect(vectorIndex.memories[0].id).toBe(saved.memory.id);
 
   const recall = await fetcher(new Request(`http://local/api/v1/memory/recall?q=${unique}&limit=5`));
   const body = await json(recall);
@@ -47,25 +76,27 @@ test('POST /api/v1/memory/save persists a memory and recall finds it by keyword'
   expect(body.items[0]).toMatchObject({ id: saved.memory.id, content: `Read the ${unique} context before coding.` });
 });
 
-test('memory recall searches title, tags, and source fields', async () => {
-  const fetcher = createFetch();
-  const tag = `continuity-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+test('GET /api/v1/memory/search returns vector similarity hits enriched from SQLite', async () => {
+  const { fetcher } = createHarness();
+  const phrase = `semantic-${Date.now()}-${Math.random().toString(16).slice(2)}`;
   const save = await fetcher(new Request('http://local/api/v1/memory/save', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ content: 'Context survives restarts.', tags: [tag] }),
+    body: JSON.stringify({ content: `Similarity should find ${phrase}.`, tags: ['vector'] }),
   }));
   const saved = await json(save);
   savedIds.push(saved.memory.id);
 
-  const recall = await fetcher(new Request(`http://local/api/v1/memory/recall?q=${tag}`));
-  const body = await json(recall);
+  const search = await fetcher(new Request(`http://local/api/v1/memory/search?q=${phrase}&limit=3`));
+  const body = await json(search);
 
-  expect(body.items.map((item: { id: string }) => item.id)).toContain(saved.memory.id);
+  expect(search.status).toBe(200);
+  expect(body).toMatchObject({ success: true, query: phrase, total: 1 });
+  expect(body.results[0]).toMatchObject({ id: saved.memory.id, score: 1, vectorId: `memory:${saved.memory.id}` });
 });
 
 test('memory save rejects blank content', async () => {
-  const res = await createFetch()(new Request('http://local/api/v1/memory/save', {
+  const res = await createHarness().fetcher(new Request('http://local/api/v1/memory/save', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ content: '   ' }),

--- a/tests/http/tenant/auth.test.ts
+++ b/tests/http/tenant/auth.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import {
+  createTenantFetch,
+  createTenantMiddleware,
+  parseTenantTokens,
+  TENANT_HEADER,
+  TENANT_TOKEN_HEADER,
+  validateTenantToken,
+} from '../../../src/middleware/tenant.ts';
+
+describe('tenant auth middleware', () => {
+  test('parses JSON and comma tenant token config', () => {
+    expect(parseTenantTokens('{"acme":"secret"}')).toEqual({ acme: 'secret' });
+    expect(parseTenantTokens('acme=secret, beta=two=parts')).toEqual({ acme: 'secret', beta: 'two=parts' });
+  });
+
+  test('validates configured tenant token header', () => {
+    const headers = new Headers({ [TENANT_TOKEN_HEADER]: 'secret' });
+    expect(() => validateTenantToken(headers, 'acme', { acme: 'secret' })).not.toThrow();
+    expect(() => validateTenantToken(headers, 'acme', { acme: 'wrong' })).toThrow('invalid tenant token');
+    expect(() => validateTenantToken(new Headers(), 'acme', { acme: 'secret' })).toThrow('tenant token required');
+  });
+
+  test('attaches tenantId to Elysia request context', async () => {
+    const app = new Elysia()
+      .use(createTenantMiddleware())
+      .get('/whoami', ({ tenantId }) => ({ tenantId }));
+
+    const res = await app.handle(new Request('http://local/whoami', {
+      headers: { [TENANT_HEADER]: 'acme' },
+    }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ tenantId: 'acme' });
+    expect(res.headers.get(TENANT_HEADER)).toBe('acme');
+  });
+
+  test('rejects invalid tenant token from fetch wrapper', async () => {
+    const previous = process.env.ORACLE_TENANT_TOKENS;
+    process.env.ORACLE_TENANT_TOKENS = 'acme=secret';
+    try {
+      const res = await createTenantFetch(() => Response.json({ ok: true }))(new Request('http://local/', {
+        headers: { [TENANT_HEADER]: 'acme', [TENANT_TOKEN_HEADER]: 'bad' },
+      }));
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: 'invalid tenant token' });
+    } finally {
+      if (previous === undefined) delete process.env.ORACLE_TENANT_TOKENS;
+      else process.env.ORACLE_TENANT_TOKENS = previous;
+    }
+  });
+});

--- a/tests/http/vector/phase4-polish.test.ts
+++ b/tests/http/vector/phase4-polish.test.ts
@@ -1,0 +1,81 @@
+import { expect, mock, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import type { EmbeddingProvider, VectorQueryResult } from '../../../src/vector/types.ts';
+
+const models = {
+  local: { collection: 'local_docs', model: 'bge-m3', adapter: 'lancedb' as const },
+  remote: { collection: 'remote_docs', model: 'qwen3', adapter: 'qdrant' as const },
+};
+
+function queryResult(ids: string[], distances: number[]): VectorQueryResult {
+  return {
+    ids,
+    distances,
+    documents: ids.map((id) => `${id} body`),
+    metadatas: ids.map(() => ({ type: 'note', source_file: 'note.md' })),
+  };
+}
+
+test('GET /api/v1/vector/fanout merges and deduplicates parallel backend results', async () => {
+  const { createFanoutEndpoint } = await import('../../../src/routes/vector/fanout.ts');
+  const app = new Elysia({ prefix: '/api' }).use(createFanoutEndpoint({
+    getModels: () => models,
+    getStore: async (key) => ({
+      query: mock(async () => key === 'local'
+        ? queryResult(['same', 'local-only'], [10, 20])
+        : queryResult(['same', 'remote-only'], [5, 30])),
+    }),
+  }));
+  const res = await createApiVersionedFetch((request) => app.handle(request))(
+    new Request('http://local/api/v1/vector/fanout?q=oracle&fanout=local,remote&limit=5&cache=false'),
+  );
+  const body = await res.json() as { backends: string[]; results: Array<{ id: string; source: string }>; errors: Record<string, string> };
+
+  expect(res.status).toBe(200);
+  expect(body.backends).toEqual(['local', 'remote']);
+  expect(body.results.map((item) => item.id)).toEqual(['same', 'local-only', 'remote-only']);
+  expect(body.results[0].source).toBe('hybrid');
+  expect(body.errors).toEqual({});
+});
+
+test('GET /api/v1/vector/cost-estimate returns token cost and recommendation', async () => {
+  const { createVectorCostEndpoint } = await import('../../../src/routes/vector/cost.ts');
+  const app = new Elysia({ prefix: '/api' }).use(createVectorCostEndpoint({
+    getModels: () => models,
+    getCount: async (key) => key === 'local' ? 10 : 20,
+    detectProviders: async () => ({ providers: [{ type: 'gemini', available: true }] }),
+  }));
+  const res = await createApiVersionedFetch((request) => app.handle(request))(
+    new Request('http://local/api/v1/vector/cost-estimate?provider=openai&tokensPerDoc=500'),
+  );
+  const body = await res.json() as Record<string, unknown>;
+
+  expect(res.status).toBe(200);
+  expect(body.docs).toBe(30);
+  expect(body.totalTokens).toBe(15_000);
+  expect(body.estimatedUsd).toBe(0.0003);
+  expect(String(body.formula)).toContain('30 docs');
+  expect(String(body.recommendation)).toContain('Any configured');
+});
+
+test('FallbackEmbeddings switches to the next provider after primary failure', async () => {
+  const { FallbackEmbeddings } = await import('../../../src/vector/embeddings.ts');
+  const events: Array<{ from: string; to?: string }> = [];
+  const failing: EmbeddingProvider = {
+    name: 'ollama',
+    dimensions: 3,
+    embed: mock(async () => { throw new Error('ollama down'); }),
+  };
+  const fallback: EmbeddingProvider = {
+    name: 'gemini',
+    dimensions: 3,
+    embed: mock(async () => [[1, 2, 3]]),
+  };
+
+  const provider = new FallbackEmbeddings([failing, fallback], (event) => events.push(event));
+  await expect(provider.embed(['hello'], 'passage')).resolves.toEqual([[1, 2, 3]]);
+  expect(failing.embed).toHaveBeenCalled();
+  expect(fallback.embed).toHaveBeenCalled();
+  expect(events).toEqual([{ from: 'ollama', to: 'gemini', error: 'ollama down' }]);
+});

--- a/ψ/memory/hermes-architecture-review.md
+++ b/ψ/memory/hermes-architecture-review.md
@@ -1,0 +1,165 @@
+# Hermes Agent Desktop Architecture Review for arra-oracle-v3
+
+Issue: #1598  
+Source reviewed: `NousResearch/hermes-agent` shallow clone, especially `README.md`, `apps/desktop/README.md`, `apps/desktop/package.json`, `apps/desktop/electron/*.cjs`, `tools/mcp_tool.py`, `tools/memory_tool.py`, `tools/session_search_tool.py`, and `hermes_cli/plugins.py`.
+
+## Executive summary
+
+Hermes is not primarily a single desktop app; it is a multi-surface agent runtime with a desktop shell. The desktop app is an Electron + React/Vite wrapper around the same Python Hermes runtime used by CLI and gateway. It emphasizes shared backend state, first-run bootstrap, provider/tool configuration, local history, MCP extensibility, and rich terminal-like UX.
+
+For arra-oracle-v3, the strongest takeaways are:
+
+1. Treat desktop/web/UI as a thin client over the same HTTP/plugin runtime, not a forked product.
+2. Invest in first-run and backend health UX before adding more feature panels.
+3. Make plugin/tool subprocesses observable, bounded, and recoverable.
+4. Preserve local-first data ownership while adding profile-aware and backup-safe storage patterns.
+5. Adopt Hermes-style command/search UX selectively; avoid copying its dependency and packaging complexity.
+
+## Hermes architecture patterns worth applying
+
+### 1. Thin desktop shell over a shared runtime
+
+Hermes Desktop ships an Electron shell, then resolves or bootstraps the Hermes backend into `HERMES_HOME`. The renderer talks to a dashboard/backend API instead of reimplementing agent logic. This mirrors what arra should do with the Elysia API and unified plugin runtime.
+
+Apply to arra:
+- Keep `frontend/` and any future desktop shell as API clients over `src/server.ts`.
+- Do not duplicate command logic in the UI; expose CLI/plugin/server actions through unified manifests and typed HTTP endpoints.
+- Add a desktop/launcher layer only after the server lifecycle is reliable (`maw arra serve`, health checks, config status).
+
+Pros:
+- One backend truth for CLI, UI, MCP, and plugins.
+- Easier testing via HTTP contract tests.
+- Lower risk of UI drift.
+
+Cons:
+- Requires robust backend boot/status/error reporting.
+- First-run failure modes become product-critical.
+
+### 2. First-run bootstrap and backend readiness as first-class UX
+
+Hermes Desktop has explicit boot overlays, backend probes, install stamps, backend env construction, and logs under `HERMES_HOME/logs/desktop.log`. This is more mature than simply opening a web UI and hoping the server is up.
+
+Apply to arra:
+- Extend Vector first-run wizard into a general Studio first-run checklist: server reachable, DB path, plugin dir, vector adapter, embedder status, API token status.
+- Expose `/api/health` details that UI can render as actionable cards, not raw JSON.
+- Add a persistent boot log location and a “copy diagnostics” action in Settings.
+
+Pros:
+- Reduces support burden.
+- Makes local-first install trustworthy for non-developers.
+
+Cons:
+- Requires discipline to keep probes fast and side-effect-light.
+
+### 3. Safe subprocess and external tool management
+
+Hermes isolates backend resolution, probes candidate commands before trusting them, hides Windows child process windows, logs MCP subprocess stderr to profile logs, and treats missing optional dependencies as degraded rather than fatal.
+
+Apply to arra:
+- For unified plugin `server` surfaces, add per-plugin logs, startup health timeouts, and clear degraded status in `/api/plugins`.
+- For `maw arra serve`, keep PID tracking but add log path output and stale-PID cleanup.
+- For MCP-IN/out, log third-party server stderr away from the interactive UI and redact credentials in errors.
+
+Pros:
+- Plugins become safer to run locally.
+- Better debugging when external MCP servers fail.
+
+Cons:
+- More lifecycle state to test across platforms.
+
+### 4. MCP as an optional extension layer, not the core dependency
+
+Hermes supports stdio, HTTP/streamable HTTP, and SSE MCP transports, but the MCP package is optional and failures degrade. The architecture separates discovery/registration from the main agent loop.
+
+Apply to arra:
+- Keep `muninn_search` and core HTTP routes usable without any external MCP server.
+- Treat external MCP servers as unified plugin capabilities that register tools into the existing MCP manifest.
+- Add transport metadata and capability flags to plugin registry responses.
+
+Pros:
+- Keeps base install light and reliable.
+- Lets power users extend without blocking core search/indexing.
+
+Cons:
+- More compatibility matrix: stdio vs HTTP vs SSE, auth headers, timeouts.
+
+### 5. Local-first state with explicit profiles and backups
+
+Hermes centralizes home/profile paths via `HERMES_HOME`, stores sessions in local SQLite/FTS, stores curated memory in local markdown files, and includes backup logic that handles live SQLite safely. It also warns loudly when profile env propagation is wrong.
+
+Apply to arra:
+- Formalize one source of truth for `ORACLE_DATA_DIR`, DB path, plugin dir, and profile/tenant context.
+- Add backup/export commands that use SQLite backup APIs instead of copying WAL files blindly.
+- Keep `ψ/memory` and DB-backed memory/search complementary: markdown for human review, DB/FTS/vector for retrieval.
+
+Pros:
+- Strong local ownership story.
+- Better recovery and migration path.
+
+Cons:
+- Profiles/tenants can introduce data-placement bugs if env propagation is weak.
+
+### 6. Skills/plugins as procedural memory
+
+Hermes has a large skills/plugin system with security scanning, approval staging, install provenance, and optional skill directories. The valuable pattern is not the exact implementation; it is the lifecycle: discover, inspect, stage, approve, activate, audit.
+
+Apply to arra:
+- Evolve unified manifests with provenance fields, declared capabilities, and explicit enable/disable state.
+- Add “pending plugin changes” UX before enabling new local plugins that can spawn servers or access files.
+- Keep plugin manifests small and declarative; command handlers should be testable functions.
+
+Pros:
+- Safer plugin ecosystem.
+- Better auditability for local automation.
+
+Cons:
+- Approval UX can slow developer iteration unless dev-link workflows stay easy.
+
+### 7. Rich command/search UX
+
+Hermes Desktop uses command/search overlays, session switchers, model/tool settings, side-by-side previews, file browser, voice, and status overlays. Arra has already moved toward bento pages and command palette; Hermes validates that direction.
+
+Apply to arra:
+- Make command palette index plugins, MCP tools, pages, recent traces, and vector collections.
+- Add side-panel previews for search results, trace chains, and plugin docs.
+- Surface long-running jobs (indexing, plugin servers, imports) in a persistent activity HUD.
+
+Pros:
+- Turns arra from “API dashboard” into an operator console.
+- Makes memory/search workflows faster.
+
+Cons:
+- UX polish can hide backend ambiguity unless every card links to raw status/details.
+
+## Patterns to avoid copying directly
+
+- **Dependency weight:** Hermes Desktop carries Electron, Vite, React, node-pty, native dependency staging, Python runtime bootstrapping, and platform-specific installers. Arra should not adopt this until the web app and server lifecycle are stable.
+- **Many surfaces at once:** Hermes supports CLI, TUI, gateway, web, desktop, skills, MCP, cron, voice, and messaging. Arra should stay focused on memory/search/indexing/plugin operations.
+- **Implicit plugin magic:** Hermes has extensive heuristic plugin discovery. Arra’s unified manifest should remain stricter and easier to reason about.
+- **Desktop-first packaging too early:** Electron installer work should wait until `maw arra serve`, config wizard, plugin registry, and backup/export are reliable.
+
+## Recommended roadmap for arra-oracle-v3
+
+### Near term
+
+1. Add a Studio “runtime readiness” panel fed by `/api/health`, `/api/plugins`, and vector config endpoints.
+2. Add per-plugin server logs/status in the unified plugin registry.
+3. Expand `maw arra serve status` to include PID, port, health, data dir, plugin count, and log paths.
+4. Add backup/export command using SQLite backup semantics and include `ψ/memory` files.
+
+### Medium term
+
+1. Convert command palette into an operation launcher: pages, plugins, MCP tools, traces, collections, jobs.
+2. Add plugin capability/provenance fields and a safe enable/disable workflow.
+3. Add profile/tenant-aware data-dir diagnostics to prevent “wrong home” writes.
+4. Add first-run wizard steps for storage backend, vector adapter, embedder, and plugin directory.
+
+### Later / only after server UX is solid
+
+1. Consider a thin Tauri or Electron shell that launches/monitors `maw arra serve` and embeds Studio.
+2. Package installers only if users need non-terminal onboarding; otherwise keep web+CLI install path.
+3. Add native file dialogs and OS notifications via shell layer, not backend rewrites.
+
+## Final recommendation
+
+Adopt Hermes’ architectural principle — one local-first runtime shared by CLI, UI, gateway, and plugins — but not Hermes’ full desktop complexity yet. Arra should first harden its existing Elysia server, unified manifest loader, `maw arra` CLI, and React Studio into a coherent operator console. A desktop wrapper becomes valuable only when it can be a thin launcher/monitor around that stable runtime.


### PR DESCRIPTION
Closes #1457\n\n## Summary\n- add /api/v1/memory/fanout to query every configured vector collection concurrently\n- merge duplicate hits with reciprocal rank fusion across collections\n- include per-query cost estimation for embedding calls/token units\n- preserve partial collection errors without failing the whole search\n\n## Validation\n- bunx tsc --noEmit\n- bun test tests/http/memory/\n\nFiles changed are under 250 lines.