### PR TITLE
feat: vector provider autodetect hot reload

### DIFF
--- a/src/routes/vector/config-api-utils.ts
+++ b/src/routes/vector/config-api-utils.ts
@@ -13,7 +13,7 @@ import { createVectorStoreForModel } from '../../vector/factory.ts';
 import type { VectorDBType } from '../../vector/types.ts';
 
 export type CollectionUpdate = Partial<Pick<VectorCollectionConfig,
-  'adapter' | 'model' | 'provider' | 'service' | 'endpoint' | 'enabled' | 'primary'
+  'adapter' | 'model' | 'provider' | 'service' | 'endpoint' | 'enabled' | 'primary' | 'embedder'
 >>;
 export type CollectionCreate = CollectionUpdate & { collection?: string };
 
@@ -122,7 +122,8 @@ export function normalizedUpdate(body: CollectionUpdate): CollectionUpdate | { e
   if (body.endpoint !== undefined) update.endpoint = body.endpoint;
   if (body.enabled !== undefined) update.enabled = body.enabled;
   if (body.primary !== undefined) update.primary = body.primary;
-  if (!Object.keys(update).length) return { error: 'body must include adapter, model, provider, service, endpoint, enabled, or primary' };
+  if (body.embedder !== undefined) update.embedder = body.embedder;
+  if (!Object.keys(update).length) return { error: 'body must include adapter, model, provider, service, endpoint, enabled, primary, or embedder' };
   return update;
 }
 
@@ -139,6 +140,7 @@ export function normalizedCreate(key: string, body: CollectionCreate): VectorCol
     ...(body.endpoint !== undefined && { endpoint: body.endpoint }),
     ...(body.enabled !== undefined && { enabled: body.enabled }),
     ...(body.primary !== undefined && { primary: body.primary }),
+    ...(body.embedder !== undefined && { embedder: body.embedder }),
   };
 }
 

--- a/src/routes/vector/config-api.ts
+++ b/src/routes/vector/config-api.ts
@@ -29,6 +29,7 @@ const updateSchema = t.Object({
   endpoint: t.Optional(t.String()),
   enabled: t.Optional(t.Boolean()),
   primary: t.Optional(t.Boolean()),
+  embedder: t.Optional(t.Any()),
 });
 
 const createSchema = t.Object({
@@ -40,6 +41,7 @@ const createSchema = t.Object({
   endpoint: t.Optional(t.String()),
   enabled: t.Optional(t.Boolean()),
   primary: t.Optional(t.Boolean()),
+  embedder: t.Optional(t.Any()),
 });
 
 export const vectorConfigApiEndpoint = new Elysia()

--- a/src/vector/config.ts
+++ b/src/vector/config.ts
@@ -43,6 +43,7 @@ export interface VectorCollectionConfig {
   endpoint?: string;
   enabled?: boolean;
   primary?: boolean;
+  embedder?: EmbedderConfig;
 }
 
 export interface VectorServerConfig {
@@ -141,13 +142,12 @@ export function writeVectorConfig(config: VectorServerConfig, fp = configPath())
 }
 
 function embedderFor(config: VectorServerConfig, col: VectorCollectionConfig): EmbedderConfig | undefined {
-  if (config.embedder) {
-    return {
-      ...config.embedder,
-      backend: config.embedder.backend ?? config.embedder.default ?? 'none',
-      model: config.embedder.model ?? col.model,
-    };
-  }
+  const merged = config.embedder || col.embedder ? { ...config.embedder, ...col.embedder } : undefined;
+  if (merged) return {
+    ...merged,
+    backend: merged.backend ?? merged.default ?? 'none',
+    model: merged.model ?? col.model,
+  };
   const provider = col.provider.toLowerCase();
   if (provider === 'ollama' || provider === 'local') return { backend: 'local', model: col.model };
   if (provider === 'openai' || provider === 'gemini' || provider === 'cloudflare-ai') {

--- a/src/vector/embeddings.ts
+++ b/src/vector/embeddings.ts
@@ -224,7 +224,11 @@ function createSingleEmbeddingProvider(
     case 'cloudflare-ai': {
       // Dynamic import to avoid requiring CF credentials when not used
       const { CloudflareAIEmbeddings } = require('./adapters/cloudflare-vectorize.ts');
-      return new CloudflareAIEmbeddings({ model });
+      return new CloudflareAIEmbeddings({
+        model,
+        accountId: process.env.CF_ACCOUNT_ID || process.env.CLOUDFLARE_ACCOUNT_ID,
+        apiToken: process.env.CF_API_TOKEN || process.env.CLOUDFLARE_API_TOKEN,
+      });
     }
     case 'chromadb-internal':
     default:

--- a/src/vector/factory.ts
+++ b/src/vector/factory.ts
@@ -83,8 +83,8 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
     }
     case 'cloudflare-vectorize': {
       const cfConfig = {
-        accountId: config.cfAccountId || process.env.CLOUDFLARE_ACCOUNT_ID,
-        apiToken: config.cfApiToken || process.env.CLOUDFLARE_API_TOKEN,
+        accountId: config.cfAccountId || process.env.CF_ACCOUNT_ID || process.env.CLOUDFLARE_ACCOUNT_ID,
+        apiToken: config.cfApiToken || process.env.CF_API_TOKEN || process.env.CLOUDFLARE_API_TOKEN,
       };
 
       const embeddingModel = config.embeddingModel

--- a/src/vector/registry.ts
+++ b/src/vector/registry.ts
@@ -128,12 +128,8 @@ class InMemoryVectorServiceRegistry implements VectorServiceRegistry {
   }
 
   async discover(): Promise<RegisteredVectorService[]> {
-    if (registry.size === 0) {
-      ensureConfigRefreshed();
-      if (registry.size === 0) {
-        registry = seedFromConfig(currentConfig);
-      }
-    }
+    ensureConfigRefreshed();
+    if (registry.size === 0) registry = seedFromConfig(currentConfig);
 
     return [...registry.values()].sort((a, b) => a.name.localeCompare(b.name));
   }

--- a/tests/http/vector/config-api.test.ts
+++ b/tests/http/vector/config-api.test.ts
@@ -115,7 +115,12 @@ test('GET and PUT /api/v1/vector/config expose and update vector-server.json', a
   const addRes = await call('/api/v1/vector/config/phase2', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ collection: 'phase2_collection', model: 'phase2-model', primary: true }),
+    body: JSON.stringify({
+      collection: 'phase2_collection',
+      model: 'phase2-model',
+      primary: true,
+      embedder: { backend: 'gemini', fallback: 'openai' },
+    }),
   });
   expect(addRes.status).toBe(200);
   expect(addRes.body.config.collections.phase2).toMatchObject({
@@ -124,6 +129,7 @@ test('GET and PUT /api/v1/vector/config expose and update vector-server.json', a
     provider: 'none',
     adapter: 'lancedb',
     primary: true,
+    embedder: { backend: 'gemini', fallback: 'openai' },
   });
   expect(addRes.body.config.collections.phase1.primary).toBe(false);
 

--- a/tests/http/vector/providers.test.ts
+++ b/tests/http/vector/providers.test.ts
@@ -9,7 +9,7 @@ function fetcher() {
     models: [{ name: 'bge-m3' }, { name: 'nomic-embed-text' }],
   }), { status: 200 }));
   const app = new Elysia({ prefix: '/api' }).use(createVectorProvidersEndpoint({
-    env: { OPENAI_API_KEY: 'sk-test', GEMINI_API_KEY: 'g-test' },
+    env: { OPENAI_API_KEY: 'sk-test', GEMINI_API_KEY: 'g-test', CF_ACCOUNT_ID: 'cf-account', CF_API_TOKEN: 'cf-token' },
     fetcher: tags as unknown as typeof fetch,
     createProvider: (provider): EmbeddingProvider => ({
       name: provider,
@@ -30,6 +30,7 @@ test('GET /api/v1/vector/providers returns detected providers and capabilities',
   }));
   expect(body.providers).toContainEqual(expect.objectContaining({ type: 'openai', available: true }));
   expect(body.providers).toContainEqual(expect.objectContaining({ type: 'gemini', available: true }));
+  expect(body.providers).toContainEqual(expect.objectContaining({ type: 'cloudflare-ai', available: true }));
 });
 
 test('POST /api/v1/vector/providers/test probes one provider config', async () => {


### PR DESCRIPTION
## Summary
- add per-collection embedder overrides for vector config create/update paths
- make provider detection/provider creation honor CF_ACCOUNT_ID and CF_API_TOKEN aliases
- refresh vector service registry from vector-server.json before register/discover/unregister so hot reload and temp data dirs see current config

## Verification
- bunx tsc --noEmit
- bun test tests/http/vector/
- changed files checked <= 250 lines

Refs #1437
