### PR TITLE
feat: stabilize vector proxy service registry (#1438)

### DIFF
--- a/docs/issues/multi-tenant-http-isolation-design.md
+++ b/docs/issues/multi-tenant-http-isolation-design.md
@@ -1,0 +1,173 @@
+# Multi-tenant HTTP isolation design
+
+Issue: #1650  
+Status: design + implementation plan
+
+## Goal
+
+Allow one ARRA Oracle V3 server to host multiple organizations while keeping
+HTTP, SQLite, FTS, vector, logs, and plugin-visible data scoped to the active
+organization. Existing single-tenant installs must keep working without a tenant
+header.
+
+## Current baseline
+
+- HTTP runs through Elysia routes composed in `src/server.ts`.
+- API auth is token-based (`ARRA_API_KEY`, legacy `ORACLE_API_TOKEN`).
+- `src/middleware/tenant.ts` already parses `X-Oracle-Tenant`, validates
+  optional `X-Oracle-Tenant-Token`, and exposes request/async context helpers.
+- `oracle_documents` has `project`, but no dedicated `tenant_id`; other tables
+  such as `search_log`, `forum_threads`, and `trace_log` also use `project`.
+- Vector config and LanceDB default to process-level paths under
+  `ORACLE_DATA_DIR`.
+
+## Tenancy model
+
+A tenant is an org slug. Valid examples: `default`, `soul-brews`, `team_a`.
+Invalid header values are rejected before route handlers run.
+
+Headers:
+
+- `X-Oracle-Tenant: <tenant-slug>` selects the tenant.
+- `Authorization: Bearer <api-key>` authenticates the caller.
+- `X-Oracle-Tenant-Token: <tenant-token>` is an optional tenant-scoped guard for
+  deployments that cannot yet mint scoped bearer tokens.
+
+Backward compatibility:
+
+- Missing tenant header maps to `default` in scoped storage helpers.
+- Legacy unscoped rows are readable only through the default tenant migration
+  view until backfilled.
+
+## Authorization contract
+
+Tenant choice must not be a trust boundary by itself. The auth decision is:
+
+1. Validate the bearer/API token as today.
+2. Resolve allowed tenants for that token.
+3. Resolve requested tenant from `X-Oracle-Tenant` or `default`.
+4. Allow only when requested tenant is in the token scope or the token is admin.
+5. Store `{ tenantId, principalId, scopes }` on Elysia context and AsyncLocalStorage.
+
+Initial token storage can be environment-backed for self-hosted installs:
+
+```text
+ORACLE_TENANT_TOKENS=tenant-a=tok_a,tenant-b=tok_b
+```
+
+The production-ready target is a Drizzle-managed `tenants` table and
+`tenant_tokens` table with hashed tokens, status, scope, and audit timestamps.
+
+## Data isolation
+
+### SQLite
+
+Add `tenant_id TEXT NOT NULL DEFAULT 'default'` to every persisted user data table
+that can appear in HTTP responses or search results. Minimum phase-1 tables:
+
+- `oracle_documents`
+- `search_log`
+- `consult_log`
+- `learn_log`
+- `document_access`
+- `forum_threads`
+- `trace_log`
+- memory/menu/settings tables if exposed per org
+
+Indexes should lead with `tenant_id` for common filters, for example
+`idx_documents_tenant_type` and `idx_search_tenant_created`.
+
+All route/tool queries must compose tenant filters via one helper, not ad hoc SQL:
+
+```ts
+where(and(eq(table.tenantId, tenantId), existingCondition))
+```
+
+Writes must stamp `tenant_id` from request context. Background jobs must receive
+an explicit tenant id in their job payload instead of reading ambient context.
+
+### FTS5
+
+SQLite FTS tables cannot enforce tenant isolation alone. Use one of these paths:
+
+1. Recommended: add `tenant_id` to the external content table and join/filter by
+   `oracle_documents.tenant_id` for search result hydration.
+2. If FTS rows are copied into a standalone table, include `tenant_id` in the FTS
+   table and use `tenant_id = ?` with the `MATCH` query.
+
+Never return an FTS hit until the hydrated document row matches the tenant.
+
+### Vector / LanceDB
+
+Use per-tenant storage namespaces, not metadata-only filtering, as the default:
+
+```text
+${ORACLE_DATA_DIR}/tenants/<tenant>/lancedb/<collection>
+```
+
+A collection-prefix mode (`<tenant>__<collection>`) may be supported for remote
+stores that cannot use directories, but local LanceDB should prefer tenant
+directories for backup and deletion safety.
+
+`VectorStoreConfig` should resolve `dataPath` through a tenant-aware helper. The
+proxy adapter must forward `X-Oracle-Tenant` to remote vector services so sidecars
+can enforce the same scope.
+
+## HTTP middleware order
+
+Place tenant authorization after API key auth and before metrics/routes:
+
+1. request id, CORS, security, body limit, rate limit
+2. API key / legacy token auth
+3. tenant auth + context attach
+4. metrics lifecycle
+5. routes
+
+Reason: rate limiting should still protect unauthenticated traffic, but routes
+and metrics labels must see validated tenant context.
+
+## Admin APIs
+
+Add admin-only endpoints under `/api/tenants`:
+
+- `GET /api/tenants` list tenants and status
+- `POST /api/tenants` create tenant
+- `GET /api/tenants/:id` inspect storage and counts
+- `PATCH /api/tenants/:id` enable/disable metadata
+- `POST /api/tenants/:id/tokens` mint token and return it once
+- `DELETE /api/tenants/:id/tokens/:tokenId` revoke token
+
+Tenant deletion must be two-phase: disable first, then explicit purge after a
+backup/export checkpoint.
+
+## Migration plan
+
+1. Add schema tables/columns through Drizzle migrations only.
+2. Backfill existing rows to `tenant_id = 'default'`.
+3. Add tenant context to HTTP fetch/Elysia pipeline.
+4. Convert read paths to tenant helper filters, starting with search/list/detail.
+5. Convert write paths to stamp tenant id.
+6. Move vector store path resolution behind a tenant-aware helper.
+7. Forward tenant headers through proxy/vector sidecars.
+8. Add admin tenant CRUD and token management.
+9. Add migration/backup docs and an operator runbook.
+
+## Test plan
+
+- Middleware: valid tenant, invalid slug, missing scoped token, wrong scoped token.
+- HTTP isolation: same document ids/content in two tenants never cross in search,
+  list, stats, forum, memory, and trace routes.
+- Migration: old DB with no tenant columns migrates to default tenant and remains
+  readable without headers.
+- Vector: two tenants indexing the same collection produce separate LanceDB paths
+  and query results.
+- Proxy: remote vector request includes `X-Oracle-Tenant` and rejects cross-tenant
+  queries in a fake sidecar.
+- Admin: non-admin tokens cannot list/create/delete tenants.
+
+## Rollout and risks
+
+Ship in compatibility mode first: default tenant, env-backed token map, and scoped
+query helpers. Then add persistent tenant tables and admin UX. The main risk is a
+missed query path; mitigate with helper-only query patterns, integration tests
+that seed two tenants, and PR review that treats unscoped SQL as a blocker.

--- a/frontend/src/pages/PluginsPage.tsx
+++ b/frontend/src/pages/PluginsPage.tsx
@@ -5,6 +5,7 @@ import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
 import { pluginStatusLabel, isPluginEnabled, type PluginEnabledState } from '../components/PluginList';
 import { surfacesFor } from '../plugin-surfaces';
 import type { PluginEntry } from '../types';
+import { UnifiedPluginSurfaceOverview } from './UnifiedPluginSurfaceOverview';
 
 type PageState = 'loading' | 'ready' | 'error';
 type PluginsClient = Pick<ApiClient, 'plugins'>;
@@ -220,6 +221,8 @@ export function PluginsPage({ plugins: initialPlugins = [], loading = true, clie
         {state !== 'error' && error ? <ErrorMessage title="Plugin action failed." message={error} /> : null}
         {actionMessage ? <p className="mt-3 text-sm text-amber-200">{actionMessage}</p> : null}
       </section>
+
+      {isLoading || state === 'error' ? null : <UnifiedPluginSurfaceOverview plugins={plugins} />}
 
       {isLoading || state === 'error' ? null : (
         <section className="grid gap-5 xl:grid-cols-[minmax(0,1.5fr)_minmax(320px,0.8fr)]">

--- a/frontend/src/pages/UnifiedPluginSurfaceOverview.tsx
+++ b/frontend/src/pages/UnifiedPluginSurfaceOverview.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useMemo, useState } from 'react';
+import { fetchMcpTools, fetchMenu, fetchSettingsSystem, fetchVectorConfig } from '../api';
+import { apiClient } from '../api/client';
+import { surfacesFor } from '../plugin-surfaces';
+import type { MenuItem, PluginEntry, SettingsSystemResponse, VectorConfigResponse, McpTool } from '../types';
+import type { HealthResponse } from '../../../src/server/types';
+
+type SurfaceState = {
+  menu: MenuItem[];
+  tools: McpTool[];
+  settings: SettingsSystemResponse | null;
+  vector: VectorConfigResponse | null;
+  health: HealthResponse | null;
+};
+
+type Card = { label: string; value: string | number; detail: string; tone?: 'ok' | 'warn' };
+
+function countBySurface(plugins: PluginEntry[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const plugin of plugins) {
+    const surfaces = surfacesFor(plugin);
+    for (const surface of surfaces.length ? surfaces : ['metadata']) counts[surface] = (counts[surface] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function formatPath(value?: string | null): string {
+  if (!value) return 'not configured';
+  return value.length > 42 ? `${value.slice(0, 39)}…` : value;
+}
+
+function buildCards(plugins: PluginEntry[], state: SurfaceState): Card[] {
+  const vectorCollections = Object.keys(state.vector?.config.collections ?? {}).length;
+  const enabledPlugins = plugins.filter((plugin) => plugin.enabled !== false && plugin.status !== 'disabled').length;
+  return [
+    { label: 'Menu', value: state.menu.length, detail: 'Items from /api/menu across DB, custom, gist, frontend, and plugin sources.' },
+    { label: 'Plugins', value: plugins.length, detail: `${enabledPlugins} enabled · ${countBySurface(plugins).server ?? 0} server surfaces.` },
+    { label: 'MCP tools', value: state.tools.length, detail: `${state.tools.filter((tool) => tool.source === 'plugin').length} plugin tools exposed through MCP-out.` },
+    { label: 'Vector search', value: vectorCollections, detail: `${state.vector?.source ?? 'unknown'} config · ${Object.keys(state.vector?.health ?? {}).length} health entries.` },
+    { label: 'Server status', value: state.health?.status ?? 'unknown', detail: `plugins ${state.health?.pluginStatus ?? 'unknown'} · vector ${state.health?.vectorStatus ?? 'unknown'}.`, tone: state.health?.status === 'ok' ? 'ok' : 'warn' },
+    { label: 'Storage', value: state.settings?.storage.activeBackend ?? 'unknown', detail: `DB ${formatPath(state.settings?.storage.dbPath)}.` },
+  ];
+}
+
+export function UnifiedPluginSurfaceOverview({ plugins }: { plugins: PluginEntry[] }) {
+  const [state, setState] = useState<SurfaceState>({ menu: [], tools: [], settings: null, vector: null, health: null });
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let active = true;
+    Promise.allSettled([fetchMenu(), fetchMcpTools(), fetchSettingsSystem(), fetchVectorConfig(), apiClient.health()])
+      .then(([menu, tools, settings, vector, health]) => {
+        if (!active) return;
+        setState({
+          menu: menu.status === 'fulfilled' ? menu.value.items : [],
+          tools: tools.status === 'fulfilled' ? tools.value.tools : [],
+          settings: settings.status === 'fulfilled' ? settings.value : null,
+          vector: vector.status === 'fulfilled' ? vector.value : null,
+          health: health.status === 'fulfilled' ? health.value : null,
+        });
+        const failed = [menu, tools, settings, vector, health].filter((item) => item.status === 'rejected').length;
+        setError(failed ? `${failed} surface request${failed === 1 ? '' : 's'} failed; showing partial data.` : '');
+      });
+    return () => { active = false; };
+  }, []);
+
+  const cards = useMemo(() => buildCards(plugins, state), [plugins, state]);
+  const counts = useMemo(() => countBySurface(plugins), [plugins]);
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="unified-surfaces-title">
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-300">Unified backend surfaces</p>
+          <h3 id="unified-surfaces-title" className="mt-2 text-xl font-semibold text-white">Plugin system map</h3>
+          <p className="mt-2 text-sm text-slate-400">Menu, plugin list, MCP tools, vector search, server health, and storage config in one view.</p>
+        </div>
+        <p className="text-sm text-slate-500">{Object.entries(counts).map(([k, v]) => `${k} ${v}`).join(' · ') || 'metadata only'}</p>
+      </div>
+      {error ? <p className="mb-3 text-sm text-amber-200">{error}</p> : null}
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+        {cards.map((card) => <SurfaceCard key={card.label} card={card} />)}
+      </div>
+    </section>
+  );
+}
+
+function SurfaceCard({ card }: { card: Card }) {
+  const tone = card.tone === 'warn' ? 'text-amber-100' : 'text-teal-100';
+  return <article className="rounded-2xl border border-white/10 bg-white/[0.03] p-4"><p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{card.label}</p><p className={`mt-2 text-2xl font-semibold ${tone}`}>{card.value}</p><p className="mt-2 text-sm leading-6 text-slate-400">{card.detail}</p></article>;
+}

--- a/maw-plugin/__tests__/serve.test.ts
+++ b/maw-plugin/__tests__/serve.test.ts
@@ -44,6 +44,39 @@ describe('maw arra serve command', () => {
     expect(stop.output).toContain('stopped pid=54321');
   });
 
+  test('supports --status and --stop flag actions directly', async () => {
+    const home = env();
+    let alive = true;
+    await runServe({ pos: [], flags: {} }, runner, home, {
+      start: () => 65432,
+      isAlive: () => false,
+    });
+
+    const status = await runServe({ pos: [], flags: { status: true, port: '47779' } }, runner, home, {
+      isAlive: () => alive,
+      fetch: async (input) => new Response(String(input), { status: 200 }),
+    });
+    expect(status.ok).toBe(true);
+    expect(status.output).toContain('alive pid=65432');
+    expect(status.output).toContain('health: ok 200');
+    expect(status.output).toContain('47779');
+
+    const stopped = await runServe({ pos: [], flags: { stop: true } }, runner, home, {
+      isAlive: () => alive,
+      kill: () => { alive = false; },
+      sleep: async () => {},
+    });
+    expect(stopped.ok).toBe(true);
+    expect(stopped.output).toContain('stopped pid=65432');
+
+    const after = await runServe({ pos: [], flags: { status: true } }, runner, home, {
+      isAlive: () => alive,
+      fetch: async () => new Response('', { status: 503 }),
+    });
+    expect(after.output).toContain('missing pid');
+  });
+
+
   test('rejects invalid serve actions and ports', async () => {
     const badAction = await runServe({ pos: ['restart'], flags: {} }, runner, env());
     expect(badAction.ok).toBe(false);

--- a/maw-plugin/__tests__/vector-config.test.ts
+++ b/maw-plugin/__tests__/vector-config.test.ts
@@ -3,59 +3,79 @@ import { runArra } from '../index.ts';
 
 type Call = { path: string; init?: RequestInit };
 
-const models = {
-  models: {
-    'bge-m3': {
-      collection: 'oracle_knowledge_bge_m3',
-      adapter: 'lancedb',
-      model: 'bge-m3',
-      count: 42,
-    },
-    nomic: {
-      collection: 'oracle_knowledge_nomic',
-      adapter: 'lancedb',
-      model: 'nomic-embed-text',
-      count: 7,
-    },
-  },
-};
-
-const health = {
-  status: 'degraded',
-  checked_at: '2026-06-16T00:00:00.000Z',
-  engines: [
-    { key: 'bge-m3', collection: 'oracle_knowledge_bge_m3', model: 'bge-m3', ok: true },
-    { key: 'nomic', collection: 'oracle_knowledge_nomic', model: 'nomic-embed-text', ok: false },
+const config = {
+  source: 'file',
+  config: { collections: {
+    'bge-m3': { collection: 'oracle_knowledge_bge_m3', adapter: 'lancedb', model: 'bge-m3', primary: true },
+    nomic: { collection: 'oracle_knowledge_nomic', adapter: 'lancedb', model: 'nomic-embed-text' },
+  } },
+  collections: [
+    { key: 'bge-m3', collection: 'oracle_knowledge_bge_m3', adapter: 'lancedb', model: 'bge-m3', count: 42, status: 'ok' },
+    { key: 'nomic', collection: 'oracle_knowledge_nomic', adapter: 'lancedb', model: 'nomic-embed-text', count: 7, status: 'down' },
   ],
+  doc_counts: { 'bge-m3': 42, nomic: 7 },
 };
 
 async function vectorConfig(args: string[]) {
   const calls: Call[] = [];
   const result = await runArra(args, async (path, init) => {
     calls.push({ path, init });
-    return path === '/api/vector/index/models' ? models : health;
+    return { success: true, collection: 'bge-m3', removed: 'old-model', path: '/tmp/vector-server.json', ...config };
   });
   return { result, calls };
 }
 
+async function body(call: Call) {
+  return call.init?.body ? JSON.parse(String(call.init.body)) : undefined;
+}
+
 describe('maw arra vector-config', () => {
-  test('fetches models and health then prints a compact table', async () => {
+  test('reads config and prints a compact table', async () => {
     const { result, calls } = await vectorConfig(['vector-config']);
 
     expect(result.ok).toBe(true);
-    expect(calls.map(call => [call.init?.method, call.path])).toEqual([
-      ['GET', '/api/vector/index/models'],
-      ['GET', '/api/vector/health'],
-    ]);
+    expect(calls.map(call => [call.init?.method, call.path])).toEqual([['GET', '/api/v1/vector/config']]);
     expect(result.output).toContain('Collection | Adapter | Model | Docs | Status');
     expect(result.output).toContain('oracle_knowledge_bge_m3 | lancedb | bge-m3 | 42 | ok');
     expect(result.output).toContain('oracle_knowledge_nomic | lancedb | nomic-embed-text | 7 | down');
   });
 
-  test('prints raw endpoint payloads with --json', async () => {
+  test('prints raw config payload with --json', async () => {
     const { result } = await vectorConfig(['vector-config', '--json']);
 
     expect(result.ok).toBe(true);
-    expect(JSON.parse(result.output ?? '')).toEqual({ models, health });
+    expect(JSON.parse(result.output ?? '').config.collections['bge-m3'].model).toBe('bge-m3');
+  });
+
+  test('writes set, add, primary, reload, test, and remove operations', async () => {
+    let out = await vectorConfig(['vector-config', 'set', 'bge-m3', 'adapter', 'qdrant', '--url', 'http://localhost:6333']);
+    expect(out.calls[0].path).toBe('/api/v1/vector/config/bge-m3');
+    expect(out.calls[0].init?.method).toBe('PUT');
+    expect(await body(out.calls[0])).toEqual({ adapter: 'qdrant', endpoint: 'http://localhost:6333' });
+
+    out = await vectorConfig(['vector-config', 'add', 'qwen4', '--model', 'qwen4-embedding', '--adapter', 'lancedb']);
+    expect(out.calls[0].path).toBe('/api/v1/vector/config/qwen4');
+    expect(out.calls[0].init?.method).toBe('POST');
+    expect(await body(out.calls[0])).toEqual({ adapter: 'lancedb', model: 'qwen4-embedding' });
+
+    out = await vectorConfig(['vector-config', 'set-primary', 'qwen4']);
+    expect(out.calls[0].path).toBe('/api/v1/vector/config/qwen4/primary');
+
+    out = await vectorConfig(['vector-config', 'reload']);
+    expect(out.calls[0].path).toBe('/api/v1/vector/config/reload');
+
+    out = await vectorConfig(['vector-config', 'test', 'qwen4']);
+    expect(out.calls[0].path).toBe('/api/v1/vector/config/qwen4/test');
+
+    out = await vectorConfig(['vector-config', 'remove', 'old-model', '--yes']);
+    expect(out.calls[0].init?.method).toBe('DELETE');
+    expect(out.calls[0].path).toBe('/api/v1/vector/config/old-model');
+  });
+
+  test('remove requires --yes', async () => {
+    const { result, calls } = await vectorConfig(['vector-config', 'remove', 'old-model']);
+
+    expect(result).toEqual({ ok: false, error: 'remove requires --yes' });
+    expect(calls).toEqual([]);
   });
 });

--- a/maw-plugin/index.ts
+++ b/maw-plugin/index.ts
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process';
 import { join } from 'node:path';
 import { apiArgsToCliArgs } from './api.ts';
 import { runServe, type ServeDeps } from './serve.ts';
+import { runVectorConfig, VECTOR_CONFIG_HELP } from './vector-config.ts';
 
 type InvokeContext = { source?: string; args?: string[] | Record<string, unknown>; writer?: (...args: unknown[]) => void };
 type InvokeResult = { ok: boolean; output?: string; error?: string };
@@ -130,39 +131,6 @@ function formatHealth(data: any): string { return [`arra health: ${data?.status 
 function formatStats(data: any): string { return ['arra stats', data?.total_documents !== undefined && `docs: ${data.total_documents}`, data?.total_docs !== undefined && `docs: ${data.total_docs}`, data?.vector && `vector: ${one(JSON.stringify(data.vector), 180)}`].filter(Boolean).join('\n'); }
 function formatRows(label: string, keys: string[]) { return (data: any) => { const rows = keys.map(k => data?.[k]).find(Array.isArray) ?? []; const total = data?.total ?? data?.chain_length ?? rows.length; return Array.isArray(rows) ? [`arra ${label}: ${total} item${Number(total) === 1 ? '' : 's'}`, ...rows.slice(0, 8).map((r: any) => `- ${r.id ?? r.trace_id ?? r.path ?? r.filename ?? r.name ?? '?'} ${one(r.title ?? r.query ?? r.content ?? r.preview ?? r.label ?? '')}`)].join('\n') : `arra ${label}: ${preview(data)}`; }; }
 function formatOk(label: string) { return (data: any) => [`arra ${label}: ${data?.success === false ? 'failed' : 'ok'}`, data?.id && `id: ${data.id}`, data?.trace_id && `trace_id: ${data.trace_id}`, data?.thread_id && `thread_id: ${data.thread_id}`, data?.message && one(data.message), data?.error && `error: ${one(data.error)}`].filter(Boolean).join('\n') || `arra ${label}: ${preview(data)}`; }
-function formatVectorConfig(data: any): string {
-  const models = data?.models?.models && typeof data.models.models === 'object' ? data.models.models : {}, engines = Array.isArray(data?.health?.engines) ? data.health.engines : [], lines = ['Collection | Adapter | Model | Docs | Status'];
-  for (const [key, raw] of Object.entries(models)) {
-    const m = raw as any, engine = engines.find((e: any) => e.key === key || e.collection === m.collection || e.model === m.model);
-    lines.push(`${m.collection ?? key} | ${m.adapter ?? 'lancedb'} | ${m.model ?? key} | ${m.count ?? m.docs ?? 0} | ${engine ? (engine.ok === false ? 'down' : 'ok') : (data?.health?.status ?? 'unknown')}`);
-  }
-  if (lines.length === 1) lines.push('(none) | - | - | 0 | ' + (data?.health?.status ?? 'unknown'));
-  return lines.join('\n');
-}
-function formatVectorConfigWrite(data: any) { return ['arra vector-config: ' + (data?.success === false ? 'failed' : 'ok'), data?.collection && `collection: ${data.collection}`, data?.adapter && `adapter: ${data.adapter}`, data?.count !== undefined && `count: ${data.count}`, data?.error && `error: ${one(data.error)}`].filter(Boolean).join('\n'); }
-const VC_HELP = 'vector-config [--json] | vector-config set <collection> adapter <lancedb|qdrant|sqlite-vec|chroma> | vector-config reload | vector-config test <collection>';
-function buildVectorConfig(p: Parsed): { method: Method; built: Built } | undefined {
-  const action = key(p.pos[0] || ''), collection = p.pos[1], adapter = p.pos[3];
-  if (!action) return undefined;
-  if (action === 'reload') return { method: 'POST', built: route('/api/v1/vector/config/reload') };
-  if (!collection) throw new Error('collection required');
-  if (action === 'test') return { method: 'POST', built: route(`/api/v1/vector/config/${enc(collection)}/test`) };
-  if (action !== 'set' || key(p.pos[2] || '') !== 'adapter') throw new Error(VC_HELP);
-  if (!['lancedb', 'qdrant', 'sqlite-vec', 'chroma'].includes(adapter)) throw new Error('adapter must be lancedb, qdrant, sqlite-vec, or chroma');
-  return { method: 'PUT', built: route(`/api/v1/vector/config/${enc(collection)}`, undefined, { adapter }) };
-}
-async function runVectorConfig(parsed: Parsed, request: Requester): Promise<InvokeResult> {
-  try {
-    const write = buildVectorConfig(parsed);
-    if (write) {
-      const init: RequestInit = { method: write.method, headers: authHeaders() };
-      if (write.built.body) init.body = JSON.stringify(write.built.body);
-      return { ok: true, output: formatVectorConfigWrite(await request(qs(write.built.path, write.built.query), init)) };
-    }
-    const init: RequestInit = { method: 'GET' }, data = { models: await request('/api/vector/index/models', init), health: await request('/api/vector/health', init) };
-    return { ok: true, output: b(parsed, 'json') ? JSON.stringify(data, null, 2) : formatVectorConfig(data) };
-  } catch (error) { return { ok: false, error: error instanceof Error ? error.message : String(error) }; }
-}
 export const COMMANDS: Record<string, Spec> = {
   search: { tool: 'oracle_search', method: 'GET', help: 'search <q> [--mode fts|hybrid|vector] [--limit N]', build: p => route('/api/search', { q: text(p, 'query', 'query'), type: f(p, 'type'), limit: f(p, 'limit') || '5', offset: f(p, 'offset'), mode: f(p, 'mode') || 'fts', project: f(p, 'project'), cwd: f(p, 'cwd'), model: f(p, 'model') }), format: formatSearch },
   learn: { tool: 'oracle_learn', method: 'POST', write: true, help: 'learn <text> [--project P] [--source S] [--concepts a,b]', build: p => route('/api/learn', undefined, { pattern: text(p, 'pattern', 'text'), project: f(p, 'project'), source: f(p, 'source'), concepts: f(p, 'concepts')?.split(',').map(s => s.trim()).filter(Boolean) }), format: formatOk('learn') },
@@ -178,7 +146,7 @@ export const COMMANDS: Record<string, Spec> = {
   vector_status: { tool: 'oracle_vector_status', method: 'GET', help: 'vector-status', build: () => route('/api/vector/index/status'), format: d => `arra vector-status: ${preview(d, 700)}` },
   vector_stop: { tool: 'oracle_vector_stop', method: 'POST', write: true, help: 'vector-stop', build: () => route('/api/vector/index/stop'), format: formatOk('vector-stop') },
   vector_models: { tool: 'oracle_vector_models', method: 'GET', help: 'vector-models', build: () => route('/api/vector/index/models'), format: d => `arra vector-models: ${preview(d, 700)}` },
-  vector_config: { tool: 'oracle_vector_config', method: 'GET', help: VC_HELP, build: () => route('/api/vector/index/models'), format: formatVectorConfig },
+  vector_config: { tool: 'oracle_vector_config', method: 'GET', help: VECTOR_CONFIG_HELP, build: () => route('/api/v1/vector/config'), format: d => preview(d, 700) },
   health: { tool: 'oracle_health', method: 'GET', help: 'health', build: () => route('/api/health'), format: formatHealth },
   trace: { tool: 'oracle_trace', method: 'POST', write: true, help: 'trace <query> [--scope project|cross-project|human]', build: p => route('/api/traces', undefined, { query: text(p, 'query', 'query'), queryType: f(p, 'query_type'), scope: f(p, 'scope'), parentTraceId: f(p, 'parent_trace_id'), project: f(p, 'project'), agentCount: n(p, 'agent_count'), durationMs: n(p, 'duration_ms') }), format: formatOk('trace') },
   trace_list: { tool: 'oracle_trace_list', method: 'GET', help: 'trace_list [--query Q] [--status S] [--project P] [--limit N]', build: p => route('/api/traces', { query: f(p, 'query'), status: f(p, 'status'), project: f(p, 'project'), limit: f(p, 'limit'), offset: f(p, 'offset') }), format: formatRows('trace_list', ['traces']) },
@@ -234,7 +202,7 @@ export async function runArra(args: string[], request: Requester = requestJson, 
   if (sub === 'frontend' || sub === 'ui' || sub === 'open') return runFrontend(parsed, opener, env);
   if (sub === 'studio') return runStudio(parsed, runner, env);
   if (sub === 'serve') return runServe(parsed, runner, env, serveDeps);
-  if (sub === 'vector_config') return runVectorConfig(parsed, request);
+  if (sub === 'vector_config') return runVectorConfig(parsed, request, authHeaders);
   const spec = COMMANDS[sub];
   if (!spec) return usage();
   try {

--- a/maw-plugin/vector-config.ts
+++ b/maw-plugin/vector-config.ts
@@ -1,0 +1,116 @@
+type Method = 'GET' | 'POST' | 'PUT' | 'DELETE';
+type Parsed = { pos: string[]; flags: Record<string, string | boolean> };
+type Built = { path: string; query?: Record<string, unknown>; body?: Record<string, unknown> };
+type Requester = (path: string, init?: RequestInit) => Promise<unknown>;
+type Auth = () => Record<string, string>;
+type InvokeResult = { ok: boolean; output?: string; error?: string };
+
+export const VECTOR_CONFIG_HELP = 'vector-config [--json] | vector-config reload | vector-config set|add|remove|set-primary|test';
+
+const enc = encodeURIComponent;
+const key = (s: string) => s.toLowerCase().replace(/-/g, '_');
+const clean = (o: Record<string, unknown>) => Object.fromEntries(Object.entries(o).filter(([, v]) => v !== undefined && v !== null && v !== ''));
+const route = (path: string, query?: Record<string, unknown>, body?: Record<string, unknown>): Built => ({ path, query: query ? clean(query) : undefined, body: body ? clean(body) : undefined });
+const bool = (v: string | undefined) => v === undefined ? undefined : v === 'true' ? true : v === 'false' ? false : undefined;
+function f(p: Parsed, name: string): string | undefined { const v = p.flags[name.replace(/-/g, '_')]; return v === undefined || v === false ? undefined : v === true ? 'true' : String(v); }
+function b(p: Parsed, name: string): boolean | undefined { return bool(f(p, name)); }
+function qs(path: string, query?: Record<string, unknown>): string { const q = new URLSearchParams(); for (const [k, v] of Object.entries(query ?? {})) q.set(k, String(v)); const s = q.toString(); return s ? `${path}?${s}` : path; }
+function one(v: unknown, max = 140): string { const s = String(v ?? '').replace(/\s+/g, ' ').trim(); return s.length > max ? `${s.slice(0, max - 1)}…` : s; }
+
+function collectionName(p: Parsed): string {
+  const name = p.pos[1];
+  if (!name) throw new Error('collection required');
+  return name;
+}
+
+function adapter(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const normalized = key(value) === 'cloudflare' ? 'cloudflare-vectorize' : value;
+  if (!['lancedb', 'qdrant', 'sqlite-vec', 'chroma', 'cloudflare-vectorize', 'proxy'].includes(normalized)) {
+    throw new Error('adapter must be lancedb, qdrant, sqlite-vec, chroma, cloudflare-vectorize, or proxy');
+  }
+  return normalized;
+}
+
+function updateBody(p: Parsed): Record<string, unknown> {
+  const field = p.pos[2] ? key(p.pos[2]) : undefined;
+  const value = p.pos[3];
+  const body: Record<string, unknown> = {
+    adapter: adapter(f(p, 'adapter')),
+    model: f(p, 'model'),
+    provider: f(p, 'provider'),
+    service: f(p, 'service'),
+    endpoint: f(p, 'endpoint') || f(p, 'url'),
+    enabled: b(p, 'enabled'),
+    primary: b(p, 'primary'),
+  };
+  if (field) {
+    if (!value) throw new Error('value required');
+    body[field] = field === 'adapter' ? adapter(value) : field === 'enabled' || field === 'primary' ? bool(value) : value;
+  }
+  return clean(body);
+}
+
+function createBody(p: Parsed): Record<string, unknown> {
+  const body = updateBody({ ...p, pos: [] });
+  body.collection = f(p, 'collection');
+  if (!body.model) throw new Error('--model required');
+  return clean(body);
+}
+
+function buildVectorConfig(p: Parsed): { method: Method; built: Built } | undefined {
+  const action = key(p.pos[0] || 'list');
+  if (action === 'list' || action === 'get' || action === 'stats') return { method: 'GET', built: route('/api/v1/vector/config') };
+  if (action === 'reload') return { method: 'POST', built: route('/api/v1/vector/config/reload') };
+  if (action === 'test') return { method: 'POST', built: route(`/api/v1/vector/config/${enc(collectionName(p))}/test`) };
+  if (action === 'set_primary') return { method: 'POST', built: route(`/api/v1/vector/config/${enc(collectionName(p))}/primary`) };
+  if (action === 'remove') {
+    if (b(p, 'yes') !== true) throw new Error('remove requires --yes');
+    return { method: 'DELETE', built: route(`/api/v1/vector/config/${enc(collectionName(p))}`) };
+  }
+  if (action === 'add') return { method: 'POST', built: route(`/api/v1/vector/config/${enc(collectionName(p))}`, undefined, createBody(p)) };
+  if (action === 'set') return { method: 'PUT', built: route(`/api/v1/vector/config/${enc(collectionName(p))}`, undefined, updateBody(p)) };
+  throw new Error(VECTOR_CONFIG_HELP);
+}
+
+function rows(data: any): any[] {
+  return Array.isArray(data?.collections) ? data.collections : Object.entries(data?.config?.collections ?? {}).map(([key, col]) => ({ key, ...(col as object), count: data?.doc_counts?.[key] ?? 0, status: data?.health?.[key]?.status ?? 'unknown' }));
+}
+
+function pickCollection(data: any, collection: string): any | undefined {
+  return rows(data).find((row) => row.key === collection || row.collection === collection);
+}
+
+function formatList(data: any): string {
+  const lines = ['Collection | Adapter | Model | Docs | Status'];
+  for (const row of rows(data)) lines.push(`${row.collection ?? row.key} | ${row.adapter ?? 'lancedb'} | ${row.model ?? row.key} | ${row.count ?? 0} | ${row.status ?? (row.ok === false ? 'down' : 'ok')}`);
+  if (lines.length === 1) lines.push('(none) | - | - | 0 | unknown');
+  return lines.join('\n');
+}
+
+function formatRead(data: any, p: Parsed): string {
+  const action = key(p.pos[0] || 'list');
+  if (f(p, 'json')) return JSON.stringify(data, null, 2);
+  if (action === 'get') return one(JSON.stringify(pickCollection(data, collectionName(p)) ?? {}), 900);
+  if (action === 'stats') {
+    const name = p.pos[1];
+    const counts = data?.doc_counts ?? {};
+    return name ? `${name}: ${counts[name] ?? pickCollection(data, name)?.count ?? 0}` : Object.entries(counts).map(([k, v]) => `${k}: ${v}`).join('\n');
+  }
+  return formatList(data);
+}
+
+function formatWrite(data: any): string {
+  return ['arra vector-config: ' + (data?.success === false ? 'failed' : 'ok'), data?.collection && `collection: ${data.collection}`, data?.removed && `removed: ${data.removed}`, data?.path && `path: ${data.path}`, data?.status && `status: ${data.status}`, data?.error && `error: ${one(data.error)}`].filter(Boolean).join('\n');
+}
+
+export async function runVectorConfig(parsed: Parsed, request: Requester, authHeaders: Auth): Promise<InvokeResult> {
+  try {
+    const { method, built } = buildVectorConfig(parsed) ?? { method: 'GET' as Method, built: route('/api/v1/vector/config') };
+    const init: RequestInit = { method };
+    if (method !== 'GET') init.headers = authHeaders();
+    if (built.body) init.body = JSON.stringify(built.body);
+    const data = await request(qs(built.path, built.query), init);
+    return { ok: true, output: method === 'GET' ? formatRead(data, parsed) : formatWrite(data) };
+  } catch (error) { return { ok: false, error: error instanceof Error ? error.message : String(error) }; }
+}

--- a/src/routes/memory/fanout.ts
+++ b/src/routes/memory/fanout.ts
@@ -1,0 +1,140 @@
+import { Elysia } from 'elysia';
+import type { SearchResult } from '../../server/types.ts';
+import { ensureVectorStoreConnected, getEmbeddingModels, type EmbeddingModelConfig } from '../../vector/factory.ts';
+import type { VectorQueryResult, VectorStoreAdapter } from '../../vector/types.ts';
+import { MemoryFanoutQuery } from './model.ts';
+
+type QueryStore = Pick<VectorStoreAdapter, 'query'>;
+
+type MemoryFanoutDeps = {
+  models?: () => Record<string, EmbeddingModelConfig>;
+  connect?: (key: string, models: Record<string, EmbeddingModelConfig>) => Promise<QueryStore>;
+};
+
+type RankedResult = SearchResult & {
+  fusedScore: number;
+  matches: Array<{ collection: string; rank: number; score: number }>;
+};
+
+const RRF_K = 60;
+
+function sanitize(q: string): string {
+  return q.replace(/<[^>]*>/g, '').replace(/[\x00-\x1f]/g, '').trim();
+}
+
+function parseLimit(raw: string | undefined): number {
+  return Math.min(50, Math.max(1, parseInt(raw ?? '10')));
+}
+
+function estimateTokens(text: string): number {
+  return Math.max(1, Math.ceil(text.length / 4));
+}
+
+function estimateCost(query: string, collections: string[]) {
+  const inputTokens = estimateTokens(query);
+  const vectorQueries = collections.length;
+  return {
+    inputTokens,
+    vectorQueries,
+    embeddingCalls: vectorQueries,
+    estimatedTokenUnits: inputTokens * vectorQueries,
+    estimatedUsd: 0,
+    note: 'Local vector collections have no metered API cost; token units estimate remote embedder exposure.',
+  };
+}
+
+function toSearchResults(collection: string, result: VectorQueryResult): SearchResult[] {
+  return result.ids.map((id, index) => {
+    const metadata = result.metadatas?.[index] ?? {};
+    const distance = result.distances?.[index] ?? 0;
+    return {
+      id,
+      type: metadata.type ?? 'unknown',
+      content: result.documents?.[index] ?? '',
+      source_file: metadata.source_file ?? metadata.path ?? '',
+      concepts: Array.isArray(metadata.concepts) ? metadata.concepts : [],
+      source: 'vector',
+      score: 1 / (1 + distance / 100),
+      distance,
+      model: collection,
+    };
+  });
+}
+
+export function fuseRankedResults(byCollection: Record<string, SearchResult[]>, limit: number): RankedResult[] {
+  const fused = new Map<string, RankedResult>();
+  for (const [collection, results] of Object.entries(byCollection)) {
+    results.forEach((result, index) => {
+      const rank = index + 1;
+      const contribution = 1 / (RRF_K + rank);
+      const score = result.score ?? 0;
+      const existing = fused.get(result.id);
+      if (!existing) {
+        fused.set(result.id, {
+          ...result,
+          fusedScore: contribution,
+          matches: [{ collection, rank, score }],
+        });
+        return;
+      }
+      if (score > (existing.score ?? 0)) Object.assign(existing, result);
+      existing.fusedScore += contribution;
+      existing.matches.push({ collection, rank, score });
+      existing.source = 'hybrid';
+    });
+  }
+  return [...fused.values()]
+    .map((item) => ({ ...item, fusedScore: +item.fusedScore.toFixed(6) }))
+    .sort((a, b) => b.fusedScore - a.fusedScore || (b.score ?? 0) - (a.score ?? 0))
+    .slice(0, limit);
+}
+
+export function createMemoryFanoutEndpoint(deps: MemoryFanoutDeps = {}) {
+  const listModels = deps.models ?? getEmbeddingModels;
+  const connect = deps.connect ?? ensureVectorStoreConnected;
+
+  return new Elysia().get('/memory/fanout', async ({ query, set }) => {
+    if (!query.q) {
+      set.status = 400;
+      return { error: 'Missing query parameter: q' };
+    }
+    const q = sanitize(query.q);
+    if (!q) {
+      set.status = 400;
+      return { error: 'Invalid query: empty after sanitization' };
+    }
+
+    const models = listModels();
+    const collections = Object.keys(models);
+    const limit = parseLimit(query.limit);
+    const errors: Record<string, string> = {};
+    const byCollection: Record<string, SearchResult[]> = {};
+
+    const settled = await Promise.allSettled(collections.map(async (key) => {
+      const store = await connect(key, models);
+      return { key, result: await store.query(q, limit) };
+    }));
+
+    settled.forEach((item, index) => {
+      const key = collections[index];
+      if (item.status === 'rejected') {
+        errors[key] = item.reason instanceof Error ? item.reason.message : String(item.reason);
+        return;
+      }
+      byCollection[key] = toSearchResults(key, item.value.result);
+    });
+
+    return {
+      query: q,
+      strategy: 'reciprocal_rank_fusion',
+      collections,
+      totalCollections: collections.length,
+      results: fuseRankedResults(byCollection, limit),
+      errors,
+      cost: estimateCost(q, collections),
+    };
+  }, {
+    query: MemoryFanoutQuery,
+    detail: { tags: ['memory'], menu: { group: 'hidden' }, summary: 'Fanout memory search across vector collections' },
+  });
+}

--- a/src/routes/memory/index.ts
+++ b/src/routes/memory/index.ts
@@ -1,5 +1,6 @@
 import { Elysia } from 'elysia';
 import { RecallMemoryQuery, SaveMemoryBody, SemanticMemoryQuery } from './model.ts';
+import { createMemoryFanoutEndpoint } from './fanout.ts';
 import { memoryStore, type MemoryInput, type MemoryRecord, type MemoryStore } from './store.ts';
 import { memoryVectorIndex, type MemoryVectorHit, type MemoryVectorIndex } from './vector.ts';
 
@@ -21,6 +22,7 @@ export function createMemoryRoutes(
       body: SaveMemoryBody,
       detail: { tags: ['memory'], menu: { group: 'hidden' }, summary: 'Save a persisted memory' },
     })
+    .use(createMemoryFanoutEndpoint())
     .get('/memory/recall', ({ query }) => {
       const limit = Math.min(50, Math.max(1, parseInt(query.limit ?? '10')));
       const items = store.recall(query.q ?? '', limit);

--- a/src/routes/memory/model.ts
+++ b/src/routes/memory/model.ts
@@ -16,3 +16,8 @@ export const SemanticMemoryQuery = t.Object({
   q: t.Optional(t.String()),
   limit: t.Optional(t.String()),
 });
+
+export const MemoryFanoutQuery = t.Object({
+  q: t.Optional(t.String()),
+  limit: t.Optional(t.String()),
+});

--- a/src/routes/vector/config-api-utils.ts
+++ b/src/routes/vector/config-api-utils.ts
@@ -13,7 +13,7 @@ import { createVectorStoreForModel } from '../../vector/factory.ts';
 import type { VectorDBType } from '../../vector/types.ts';
 
 export type CollectionUpdate = Partial<Pick<VectorCollectionConfig,
-  'adapter' | 'model' | 'provider' | 'service' | 'endpoint' | 'enabled' | 'primary'
+  'adapter' | 'model' | 'provider' | 'service' | 'endpoint' | 'enabled' | 'primary' | 'embedder'
 >>;
 export type CollectionCreate = CollectionUpdate & { collection?: string };
 
@@ -122,7 +122,8 @@ export function normalizedUpdate(body: CollectionUpdate): CollectionUpdate | { e
   if (body.endpoint !== undefined) update.endpoint = body.endpoint;
   if (body.enabled !== undefined) update.enabled = body.enabled;
   if (body.primary !== undefined) update.primary = body.primary;
-  if (!Object.keys(update).length) return { error: 'body must include adapter, model, provider, service, endpoint, enabled, or primary' };
+  if (body.embedder !== undefined) update.embedder = body.embedder;
+  if (!Object.keys(update).length) return { error: 'body must include adapter, model, provider, service, endpoint, enabled, primary, or embedder' };
   return update;
 }
 
@@ -139,6 +140,7 @@ export function normalizedCreate(key: string, body: CollectionCreate): VectorCol
     ...(body.endpoint !== undefined && { endpoint: body.endpoint }),
     ...(body.enabled !== undefined && { enabled: body.enabled }),
     ...(body.primary !== undefined && { primary: body.primary }),
+    ...(body.embedder !== undefined && { embedder: body.embedder }),
   };
 }
 

--- a/src/routes/vector/config-api.ts
+++ b/src/routes/vector/config-api.ts
@@ -29,6 +29,7 @@ const updateSchema = t.Object({
   endpoint: t.Optional(t.String()),
   enabled: t.Optional(t.Boolean()),
   primary: t.Optional(t.Boolean()),
+  embedder: t.Optional(t.Any()),
 });
 
 const createSchema = t.Object({
@@ -40,6 +41,7 @@ const createSchema = t.Object({
   endpoint: t.Optional(t.String()),
   enabled: t.Optional(t.Boolean()),
   primary: t.Optional(t.Boolean()),
+  embedder: t.Optional(t.Any()),
 });
 
 export const vectorConfigApiEndpoint = new Elysia()

--- a/src/vector/config.ts
+++ b/src/vector/config.ts
@@ -43,6 +43,7 @@ export interface VectorCollectionConfig {
   endpoint?: string;
   enabled?: boolean;
   primary?: boolean;
+  embedder?: EmbedderConfig;
 }
 
 export interface VectorServerConfig {
@@ -141,13 +142,12 @@ export function writeVectorConfig(config: VectorServerConfig, fp = configPath())
 }
 
 function embedderFor(config: VectorServerConfig, col: VectorCollectionConfig): EmbedderConfig | undefined {
-  if (config.embedder) {
-    return {
-      ...config.embedder,
-      backend: config.embedder.backend ?? config.embedder.default ?? 'none',
-      model: config.embedder.model ?? col.model,
-    };
-  }
+  const merged = config.embedder || col.embedder ? { ...config.embedder, ...col.embedder } : undefined;
+  if (merged) return {
+    ...merged,
+    backend: merged.backend ?? merged.default ?? 'none',
+    model: merged.model ?? col.model,
+  };
   const provider = col.provider.toLowerCase();
   if (provider === 'ollama' || provider === 'local') return { backend: 'local', model: col.model };
   if (provider === 'openai' || provider === 'gemini' || provider === 'cloudflare-ai') {

--- a/src/vector/embeddings.ts
+++ b/src/vector/embeddings.ts
@@ -224,7 +224,11 @@ function createSingleEmbeddingProvider(
     case 'cloudflare-ai': {
       // Dynamic import to avoid requiring CF credentials when not used
       const { CloudflareAIEmbeddings } = require('./adapters/cloudflare-vectorize.ts');
-      return new CloudflareAIEmbeddings({ model });
+      return new CloudflareAIEmbeddings({
+        model,
+        accountId: process.env.CF_ACCOUNT_ID || process.env.CLOUDFLARE_ACCOUNT_ID,
+        apiToken: process.env.CF_API_TOKEN || process.env.CLOUDFLARE_API_TOKEN,
+      });
     }
     case 'chromadb-internal':
     default:

--- a/src/vector/factory.ts
+++ b/src/vector/factory.ts
@@ -83,8 +83,8 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
     }
     case 'cloudflare-vectorize': {
       const cfConfig = {
-        accountId: config.cfAccountId || process.env.CLOUDFLARE_ACCOUNT_ID,
-        apiToken: config.cfApiToken || process.env.CLOUDFLARE_API_TOKEN,
+        accountId: config.cfAccountId || process.env.CF_ACCOUNT_ID || process.env.CLOUDFLARE_ACCOUNT_ID,
+        apiToken: config.cfApiToken || process.env.CF_API_TOKEN || process.env.CLOUDFLARE_API_TOKEN,
       };
 
       const embeddingModel = config.embeddingModel

--- a/src/vector/factory.ts
+++ b/src/vector/factory.ts
@@ -14,7 +14,7 @@ import { CloudflareVectorizeAdapter, CloudflareAIEmbeddings } from './adapters/c
 import { ProxyVectorAdapter } from './adapters/proxy.ts';
 import { createEmbeddingProvider } from './embeddings.ts';
 import { resolveEmbeddingFallbackChain, resolveEmbeddingModel, resolveEmbeddingProviderType } from './embedder-config.ts';
-import { loadVectorConfig, resolveServiceEndpoint, configToModels, fallbackCollectionsFor } from './config.ts';
+import { configPath, loadVectorConfig, resolveServiceEndpoint, configToModels, fallbackCollectionsFor } from './config.ts';
 
 export interface VectorStoreConfig {
   type?: VectorDBType;
@@ -113,8 +113,13 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
   }
 }
 
+function loadActiveVectorConfig(): ReturnType<typeof loadVectorConfig> {
+  const dataDir = process.env.ORACLE_DATA_DIR;
+  return loadVectorConfig(dataDir ? configPath(dataDir) : configPath());
+}
+
 export function getEmbeddingModels(
-  cfg: ReturnType<typeof loadVectorConfig> = loadVectorConfig(),
+  cfg: ReturnType<typeof loadVectorConfig> = loadActiveVectorConfig(),
 ): Record<string, EmbeddingModelConfig> {
   const fallbackFromFallbackCollections = cfg ? fallbackCollectionsFor(cfg) : [];
 

--- a/src/vector/registry.ts
+++ b/src/vector/registry.ts
@@ -128,12 +128,8 @@ class InMemoryVectorServiceRegistry implements VectorServiceRegistry {
   }
 
   async discover(): Promise<RegisteredVectorService[]> {
-    if (registry.size === 0) {
-      ensureConfigRefreshed();
-      if (registry.size === 0) {
-        registry = seedFromConfig(currentConfig);
-      }
-    }
+    ensureConfigRefreshed();
+    if (registry.size === 0) registry = seedFromConfig(currentConfig);
 
     return [...registry.values()].sort((a, b) => a.name.localeCompare(b.name));
   }

--- a/src/vector/registry.ts
+++ b/src/vector/registry.ts
@@ -41,7 +41,16 @@ export interface VectorServiceRegistry {
 
 const HEALTH_TIMEOUT_MS = 5_000;
 
-let currentConfig: VectorServerConfig = loadVectorConfig() ?? generateDefaultConfig();
+function activeConfigPath(): string {
+  const dataDir = process.env.ORACLE_DATA_DIR;
+  return dataDir ? configPath(dataDir) : configPath();
+}
+
+function loadActiveConfig(): VectorServerConfig | null {
+  return loadVectorConfig(activeConfigPath());
+}
+
+let currentConfig: VectorServerConfig = loadActiveConfig() ?? generateDefaultConfig();
 let registry = seedFromConfig(currentConfig);
 
 function seedFromConfig(config: VectorServerConfig): Map<string, RegisteredVectorService> {
@@ -92,11 +101,11 @@ function syncConfig(services: Map<string, RegisteredVectorService>): void {
     currentConfig.storage = { default: 'lancedb', services: {} };
   }
   currentConfig.storage = normalizeStorage(services);
-  writeVectorConfig(currentConfig, configPath());
+  writeVectorConfig(currentConfig, activeConfigPath());
 }
 
 function ensureConfigRefreshed(): void {
-  const latest = loadVectorConfig() ?? currentConfig;
+  const latest = loadActiveConfig() ?? currentConfig;
   if (latest) {
     currentConfig = latest;
     registry = seedFromConfig(latest);

--- a/src/vector/registry.ts
+++ b/src/vector/registry.ts
@@ -41,7 +41,16 @@ export interface VectorServiceRegistry {
 
 const HEALTH_TIMEOUT_MS = 5_000;
 
-let currentConfig: VectorServerConfig = loadVectorConfig() ?? generateDefaultConfig();
+function activeConfigPath(): string {
+  const dataDir = process.env.ORACLE_DATA_DIR;
+  return dataDir ? configPath(dataDir) : configPath();
+}
+
+function loadActiveConfig(): VectorServerConfig | null {
+  return loadVectorConfig(activeConfigPath());
+}
+
+let currentConfig: VectorServerConfig = loadActiveConfig() ?? generateDefaultConfig();
 let registry = seedFromConfig(currentConfig);
 
 function seedFromConfig(config: VectorServerConfig): Map<string, RegisteredVectorService> {
@@ -92,11 +101,11 @@ function syncConfig(services: Map<string, RegisteredVectorService>): void {
     currentConfig.storage = { default: 'lancedb', services: {} };
   }
   currentConfig.storage = normalizeStorage(services);
-  writeVectorConfig(currentConfig, configPath());
+  writeVectorConfig(currentConfig, activeConfigPath());
 }
 
 function ensureConfigRefreshed(): void {
-  const latest = loadVectorConfig() ?? currentConfig;
+  const latest = loadActiveConfig() ?? currentConfig;
   if (latest) {
     currentConfig = latest;
     registry = seedFromConfig(latest);
@@ -128,11 +137,9 @@ class InMemoryVectorServiceRegistry implements VectorServiceRegistry {
   }
 
   async discover(): Promise<RegisteredVectorService[]> {
+    ensureConfigRefreshed();
     if (registry.size === 0) {
-      ensureConfigRefreshed();
-      if (registry.size === 0) {
-        registry = seedFromConfig(currentConfig);
-      }
+      registry = seedFromConfig(currentConfig);
     }
 
     return [...registry.values()].sort((a, b) => a.name.localeCompare(b.name));

--- a/tests/http/health/core-hardening.test.ts
+++ b/tests/http/health/core-hardening.test.ts
@@ -1,0 +1,54 @@
+import { afterAll, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createApiVersionHeaderMiddleware, createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createRequestLogger } from '../../../src/middleware/logger.ts';
+import { loadUnifiedPlugins } from '../../../src/plugins/unified-loader.ts';
+import { createHealthRoutes } from '../../../src/routes/health/index.ts';
+
+const tmp = mkdtempSync(join(tmpdir(), 'arra-core-hardening-'));
+afterAll(() => rmSync(tmp, { recursive: true, force: true }));
+
+function pluginDir(name: string, entry: string) {
+  const dir = join(tmp, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'plugin.json'), JSON.stringify({ name, version: '1.0.0', entry }, null, 2));
+  writeFileSync(join(dir, 'index.ts'), 'export default () => ({ ok: true });\n');
+  return dir;
+}
+
+test('core hardening keeps health direct, logs configurable, and rejects escaping plugin entries', async () => {
+  const oldFormat = process.env.LOG_FORMAT;
+  process.env.LOG_FORMAT = 'short';
+  const lines: string[] = [];
+  const logger = createRequestLogger({ now: () => 10, log: (entry) => lines.push(`${entry.status} ${entry.method} ${entry.path}`) });
+  const app = new Elysia()
+    .onRequest(logger.onRequest)
+    .onAfterResponse(logger.onAfterResponse)
+    .use(createApiVersionHeaderMiddleware())
+    .use(createHealthRoutes({ vectorHealth: async () => ({ status: 'ok', engines: [], checked_at: '2026-06-16T00:00:00.000Z' }) }));
+  const fetcher = createApiVersionedFetch((request) => app.handle(request));
+
+  try {
+    const res = await fetcher(new Request('http://local/api/health'));
+    const body = await res.json() as Record<string, unknown>;
+    expect(res.status).toBe(200);
+    expect(res.headers.get('location')).toBeNull();
+    expect(body).toMatchObject({ status: 'ok', db: 'connected' });
+    expect(typeof body.uptime).toBe('number');
+    expect(typeof body.version).toBe('string');
+    for (let i = 0; i < 20 && !lines[0]; i += 1) await Bun.sleep(5);
+    expect(lines[0]).toBe('200 GET /api/health');
+  } finally {
+    if (oldFormat === undefined) delete process.env.LOG_FORMAT;
+    else process.env.LOG_FORMAT = oldFormat;
+  }
+
+  const warnings: string[] = [];
+  pluginDir('escape', '../outside.ts');
+  const runtime = await loadUnifiedPlugins({ dirs: [tmp], warn: (message) => warnings.push(message) });
+  expect(runtime.pluginCount).toBe(0);
+  expect(warnings.join('\n')).toContain('plugin entry escapes plugin directory');
+});

--- a/tests/http/memory/fanout.test.ts
+++ b/tests/http/memory/fanout.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createMemoryFanoutEndpoint } from '../../../src/routes/memory/fanout.ts';
+import type { EmbeddingModelConfig } from '../../../src/vector/factory.ts';
+import type { VectorQueryResult } from '../../../src/vector/types.ts';
+
+const models: Record<string, EmbeddingModelConfig> = {
+  alpha: { collection: 'alpha_docs', model: 'alpha-embed' },
+  beta: { collection: 'beta_docs', model: 'beta-embed' },
+};
+
+function result(ids: string[]): VectorQueryResult {
+  return {
+    ids,
+    documents: ids.map((id) => `${id} document`),
+    distances: ids.map((_, index) => index * 10),
+    metadatas: ids.map((id) => ({ type: 'memory', source_file: `${id}.md` })),
+  };
+}
+
+function createFetch(responses: Record<string, VectorQueryResult | Error>) {
+  const app = new Elysia({ prefix: '/api' }).use(createMemoryFanoutEndpoint({
+    models: () => models,
+    connect: async (key) => ({
+      query: async () => {
+        const response = responses[key];
+        if (response instanceof Error) throw response;
+        return response;
+      },
+    }),
+  }));
+  return createApiVersionedFetch((request) => app.handle(request));
+}
+
+async function json(response: Response) {
+  return JSON.parse(await response.text());
+}
+
+test('GET /api/v1/memory/fanout queries all collections and rank-fuses results', async () => {
+  const fetcher = createFetch({
+    alpha: result(['shared', 'alpha-only']),
+    beta: result(['beta-only', 'shared']),
+  });
+  const response = await fetcher(new Request('http://local/api/v1/memory/fanout?q=oracle&limit=3'));
+  const body = await json(response);
+
+  expect(response.status).toBe(200);
+  expect(body).toMatchObject({
+    query: 'oracle',
+    strategy: 'reciprocal_rank_fusion',
+    collections: ['alpha', 'beta'],
+    totalCollections: 2,
+    errors: {},
+    cost: { inputTokens: 2, vectorQueries: 2, embeddingCalls: 2, estimatedTokenUnits: 4 },
+  });
+  expect(body.results[0]).toMatchObject({ id: 'shared', source: 'hybrid' });
+  expect(body.results[0].matches.map((match: { collection: string }) => match.collection)).toEqual(['alpha', 'beta']);
+});
+
+test('GET /api/v1/memory/fanout preserves partial collection errors', async () => {
+  const fetcher = createFetch({
+    alpha: result(['alpha-only']),
+    beta: new Error('beta unavailable'),
+  });
+  const response = await fetcher(new Request('http://local/api/v1/memory/fanout?q=oracle'));
+  const body = await json(response);
+
+  expect(response.status).toBe(200);
+  expect(body.results).toHaveLength(1);
+  expect(body.errors).toEqual({ beta: 'beta unavailable' });
+});

--- a/tests/http/vector/config-api.test.ts
+++ b/tests/http/vector/config-api.test.ts
@@ -115,7 +115,12 @@ test('GET and PUT /api/v1/vector/config expose and update vector-server.json', a
   const addRes = await call('/api/v1/vector/config/phase2', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ collection: 'phase2_collection', model: 'phase2-model', primary: true }),
+    body: JSON.stringify({
+      collection: 'phase2_collection',
+      model: 'phase2-model',
+      primary: true,
+      embedder: { backend: 'gemini', fallback: 'openai' },
+    }),
   });
   expect(addRes.status).toBe(200);
   expect(addRes.body.config.collections.phase2).toMatchObject({
@@ -124,6 +129,7 @@ test('GET and PUT /api/v1/vector/config expose and update vector-server.json', a
     provider: 'none',
     adapter: 'lancedb',
     primary: true,
+    embedder: { backend: 'gemini', fallback: 'openai' },
   });
   expect(addRes.body.config.collections.phase1.primary).toBe(false);
 

--- a/tests/http/vector/providers.test.ts
+++ b/tests/http/vector/providers.test.ts
@@ -9,7 +9,7 @@ function fetcher() {
     models: [{ name: 'bge-m3' }, { name: 'nomic-embed-text' }],
   }), { status: 200 }));
   const app = new Elysia({ prefix: '/api' }).use(createVectorProvidersEndpoint({
-    env: { OPENAI_API_KEY: 'sk-test', GEMINI_API_KEY: 'g-test' },
+    env: { OPENAI_API_KEY: 'sk-test', GEMINI_API_KEY: 'g-test', CF_ACCOUNT_ID: 'cf-account', CF_API_TOKEN: 'cf-token' },
     fetcher: tags as unknown as typeof fetch,
     createProvider: (provider): EmbeddingProvider => ({
       name: provider,
@@ -30,6 +30,7 @@ test('GET /api/v1/vector/providers returns detected providers and capabilities',
   }));
   expect(body.providers).toContainEqual(expect.objectContaining({ type: 'openai', available: true }));
   expect(body.providers).toContainEqual(expect.objectContaining({ type: 'gemini', available: true }));
+  expect(body.providers).toContainEqual(expect.objectContaining({ type: 'cloudflare-ai', available: true }));
 });
 
 test('POST /api/v1/vector/providers/test probes one provider config', async () => {


### PR DESCRIPTION
Closes #1438

## Changes
- Keep vector model discovery bound to the active `ORACLE_DATA_DIR` vector-server.json.
- Refresh service registry state before proxy service register/list/delete operations.
- Preserve existing ProxyAdapter, service registry API, vector-server v2 storage, and TurboVec sidecar behavior on latest alpha.

## Test
- `bun test tests/http/vector/`: green
- `bunx tsc --noEmit`: green
