### PR TITLE
feat: expose unified plugin backend surfaces

### DIFF
--- a/frontend/src/pages/PluginsPage.tsx
+++ b/frontend/src/pages/PluginsPage.tsx
@@ -5,6 +5,7 @@ import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
 import { pluginStatusLabel, isPluginEnabled, type PluginEnabledState } from '../components/PluginList';
 import { surfacesFor } from '../plugin-surfaces';
 import type { PluginEntry } from '../types';
+import { UnifiedPluginSurfaceOverview } from './UnifiedPluginSurfaceOverview';
 
 type PageState = 'loading' | 'ready' | 'error';
 type PluginsClient = Pick<ApiClient, 'plugins'>;
@@ -220,6 +221,8 @@ export function PluginsPage({ plugins: initialPlugins = [], loading = true, clie
         {state !== 'error' && error ? <ErrorMessage title="Plugin action failed." message={error} /> : null}
         {actionMessage ? <p className="mt-3 text-sm text-amber-200">{actionMessage}</p> : null}
       </section>
+
+      {isLoading || state === 'error' ? null : <UnifiedPluginSurfaceOverview plugins={plugins} />}
 
       {isLoading || state === 'error' ? null : (
         <section className="grid gap-5 xl:grid-cols-[minmax(0,1.5fr)_minmax(320px,0.8fr)]">

--- a/frontend/src/pages/UnifiedPluginSurfaceOverview.tsx
+++ b/frontend/src/pages/UnifiedPluginSurfaceOverview.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useMemo, useState } from 'react';
+import { fetchMcpTools, fetchMenu, fetchSettingsSystem, fetchVectorConfig } from '../api';
+import { apiClient } from '../api/client';
+import { surfacesFor } from '../plugin-surfaces';
+import type { MenuItem, PluginEntry, SettingsSystemResponse, VectorConfigResponse, McpTool } from '../types';
+import type { HealthResponse } from '../../../src/server/types';
+
+type SurfaceState = {
+  menu: MenuItem[];
+  tools: McpTool[];
+  settings: SettingsSystemResponse | null;
+  vector: VectorConfigResponse | null;
+  health: HealthResponse | null;
+};
+
+type Card = { label: string; value: string | number; detail: string; tone?: 'ok' | 'warn' };
+
+function countBySurface(plugins: PluginEntry[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const plugin of plugins) {
+    const surfaces = surfacesFor(plugin);
+    for (const surface of surfaces.length ? surfaces : ['metadata']) counts[surface] = (counts[surface] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function formatPath(value?: string | null): string {
+  if (!value) return 'not configured';
+  return value.length > 42 ? `${value.slice(0, 39)}…` : value;
+}
+
+function buildCards(plugins: PluginEntry[], state: SurfaceState): Card[] {
+  const vectorCollections = Object.keys(state.vector?.config.collections ?? {}).length;
+  const enabledPlugins = plugins.filter((plugin) => plugin.enabled !== false && plugin.status !== 'disabled').length;
+  return [
+    { label: 'Menu', value: state.menu.length, detail: 'Items from /api/menu across DB, custom, gist, frontend, and plugin sources.' },
+    { label: 'Plugins', value: plugins.length, detail: `${enabledPlugins} enabled · ${countBySurface(plugins).server ?? 0} server surfaces.` },
+    { label: 'MCP tools', value: state.tools.length, detail: `${state.tools.filter((tool) => tool.source === 'plugin').length} plugin tools exposed through MCP-out.` },
+    { label: 'Vector search', value: vectorCollections, detail: `${state.vector?.source ?? 'unknown'} config · ${Object.keys(state.vector?.health ?? {}).length} health entries.` },
+    { label: 'Server status', value: state.health?.status ?? 'unknown', detail: `plugins ${state.health?.pluginStatus ?? 'unknown'} · vector ${state.health?.vectorStatus ?? 'unknown'}.`, tone: state.health?.status === 'ok' ? 'ok' : 'warn' },
+    { label: 'Storage', value: state.settings?.storage.activeBackend ?? 'unknown', detail: `DB ${formatPath(state.settings?.storage.dbPath)}.` },
+  ];
+}
+
+export function UnifiedPluginSurfaceOverview({ plugins }: { plugins: PluginEntry[] }) {
+  const [state, setState] = useState<SurfaceState>({ menu: [], tools: [], settings: null, vector: null, health: null });
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let active = true;
+    Promise.allSettled([fetchMenu(), fetchMcpTools(), fetchSettingsSystem(), fetchVectorConfig(), apiClient.health()])
+      .then(([menu, tools, settings, vector, health]) => {
+        if (!active) return;
+        setState({
+          menu: menu.status === 'fulfilled' ? menu.value.items : [],
+          tools: tools.status === 'fulfilled' ? tools.value.tools : [],
+          settings: settings.status === 'fulfilled' ? settings.value : null,
+          vector: vector.status === 'fulfilled' ? vector.value : null,
+          health: health.status === 'fulfilled' ? health.value : null,
+        });
+        const failed = [menu, tools, settings, vector, health].filter((item) => item.status === 'rejected').length;
+        setError(failed ? `${failed} surface request${failed === 1 ? '' : 's'} failed; showing partial data.` : '');
+      });
+    return () => { active = false; };
+  }, []);
+
+  const cards = useMemo(() => buildCards(plugins, state), [plugins, state]);
+  const counts = useMemo(() => countBySurface(plugins), [plugins]);
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="unified-surfaces-title">
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-300">Unified backend surfaces</p>
+          <h3 id="unified-surfaces-title" className="mt-2 text-xl font-semibold text-white">Plugin system map</h3>
+          <p className="mt-2 text-sm text-slate-400">Menu, plugin list, MCP tools, vector search, server health, and storage config in one view.</p>
+        </div>
+        <p className="text-sm text-slate-500">{Object.entries(counts).map(([k, v]) => `${k} ${v}`).join(' · ') || 'metadata only'}</p>
+      </div>
+      {error ? <p className="mb-3 text-sm text-amber-200">{error}</p> : null}
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+        {cards.map((card) => <SurfaceCard key={card.label} card={card} />)}
+      </div>
+    </section>
+  );
+}
+
+function SurfaceCard({ card }: { card: Card }) {
+  const tone = card.tone === 'warn' ? 'text-amber-100' : 'text-teal-100';
+  return <article className="rounded-2xl border border-white/10 bg-white/[0.03] p-4"><p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{card.label}</p><p className={`mt-2 text-2xl font-semibold ${tone}`}>{card.value}</p><p className="mt-2 text-sm leading-6 text-slate-400">{card.detail}</p></article>;
+}


### PR DESCRIPTION
## Summary
- add a unified backend surface overview to the Plugins page
- show Menu, Plugin list, MCP tools, Vector search/config, Server health/proxy status, and Storage config from existing APIs
- keep the existing plugin cards/status panel and stay under the 250-line file limit

## Tests
- `bunx tsc --noEmit`

Refs #1484
