### PR TITLE
feat: add maw vector-config operations

### DIFF
--- a/maw-plugin/__tests__/vector-config.test.ts
+++ b/maw-plugin/__tests__/vector-config.test.ts
@@ -3,59 +3,79 @@ import { runArra } from '../index.ts';
 
 type Call = { path: string; init?: RequestInit };
 
-const models = {
-  models: {
-    'bge-m3': {
-      collection: 'oracle_knowledge_bge_m3',
-      adapter: 'lancedb',
-      model: 'bge-m3',
-      count: 42,
-    },
-    nomic: {
-      collection: 'oracle_knowledge_nomic',
-      adapter: 'lancedb',
-      model: 'nomic-embed-text',
-      count: 7,
-    },
-  },
-};
-
-const health = {
-  status: 'degraded',
-  checked_at: '2026-06-16T00:00:00.000Z',
-  engines: [
-    { key: 'bge-m3', collection: 'oracle_knowledge_bge_m3', model: 'bge-m3', ok: true },
-    { key: 'nomic', collection: 'oracle_knowledge_nomic', model: 'nomic-embed-text', ok: false },
+const config = {
+  source: 'file',
+  config: { collections: {
+    'bge-m3': { collection: 'oracle_knowledge_bge_m3', adapter: 'lancedb', model: 'bge-m3', primary: true },
+    nomic: { collection: 'oracle_knowledge_nomic', adapter: 'lancedb', model: 'nomic-embed-text' },
+  } },
+  collections: [
+    { key: 'bge-m3', collection: 'oracle_knowledge_bge_m3', adapter: 'lancedb', model: 'bge-m3', count: 42, status: 'ok' },
+    { key: 'nomic', collection: 'oracle_knowledge_nomic', adapter: 'lancedb', model: 'nomic-embed-text', count: 7, status: 'down' },
   ],
+  doc_counts: { 'bge-m3': 42, nomic: 7 },
 };
 
 async function vectorConfig(args: string[]) {
   const calls: Call[] = [];
   const result = await runArra(args, async (path, init) => {
     calls.push({ path, init });
-    return path === '/api/vector/index/models' ? models : health;
+    return { success: true, collection: 'bge-m3', removed: 'old-model', path: '/tmp/vector-server.json', ...config };
   });
   return { result, calls };
 }
 
+async function body(call: Call) {
+  return call.init?.body ? JSON.parse(String(call.init.body)) : undefined;
+}
+
 describe('maw arra vector-config', () => {
-  test('fetches models and health then prints a compact table', async () => {
+  test('reads config and prints a compact table', async () => {
     const { result, calls } = await vectorConfig(['vector-config']);
 
     expect(result.ok).toBe(true);
-    expect(calls.map(call => [call.init?.method, call.path])).toEqual([
-      ['GET', '/api/vector/index/models'],
-      ['GET', '/api/vector/health'],
-    ]);
+    expect(calls.map(call => [call.init?.method, call.path])).toEqual([['GET', '/api/v1/vector/config']]);
     expect(result.output).toContain('Collection | Adapter | Model | Docs | Status');
     expect(result.output).toContain('oracle_knowledge_bge_m3 | lancedb | bge-m3 | 42 | ok');
     expect(result.output).toContain('oracle_knowledge_nomic | lancedb | nomic-embed-text | 7 | down');
   });
 
-  test('prints raw endpoint payloads with --json', async () => {
+  test('prints raw config payload with --json', async () => {
     const { result } = await vectorConfig(['vector-config', '--json']);
 
     expect(result.ok).toBe(true);
-    expect(JSON.parse(result.output ?? '')).toEqual({ models, health });
+    expect(JSON.parse(result.output ?? '').config.collections['bge-m3'].model).toBe('bge-m3');
+  });
+
+  test('writes set, add, primary, reload, test, and remove operations', async () => {
+    let out = await vectorConfig(['vector-config', 'set', 'bge-m3', 'adapter', 'qdrant', '--url', 'http://localhost:6333']);
+    expect(out.calls[0].path).toBe('/api/v1/vector/config/bge-m3');
+    expect(out.calls[0].init?.method).toBe('PUT');
+    expect(await body(out.calls[0])).toEqual({ adapter: 'qdrant', endpoint: 'http://localhost:6333' });
+
+    out = await vectorConfig(['vector-config', 'add', 'qwen4', '--model', 'qwen4-embedding', '--adapter', 'lancedb']);
+    expect(out.calls[0].path).toBe('/api/v1/vector/config/qwen4');
+    expect(out.calls[0].init?.method).toBe('POST');
+    expect(await body(out.calls[0])).toEqual({ adapter: 'lancedb', model: 'qwen4-embedding' });
+
+    out = await vectorConfig(['vector-config', 'set-primary', 'qwen4']);
+    expect(out.calls[0].path).toBe('/api/v1/vector/config/qwen4/primary');
+
+    out = await vectorConfig(['vector-config', 'reload']);
+    expect(out.calls[0].path).toBe('/api/v1/vector/config/reload');
+
+    out = await vectorConfig(['vector-config', 'test', 'qwen4']);
+    expect(out.calls[0].path).toBe('/api/v1/vector/config/qwen4/test');
+
+    out = await vectorConfig(['vector-config', 'remove', 'old-model', '--yes']);
+    expect(out.calls[0].init?.method).toBe('DELETE');
+    expect(out.calls[0].path).toBe('/api/v1/vector/config/old-model');
+  });
+
+  test('remove requires --yes', async () => {
+    const { result, calls } = await vectorConfig(['vector-config', 'remove', 'old-model']);
+
+    expect(result).toEqual({ ok: false, error: 'remove requires --yes' });
+    expect(calls).toEqual([]);
   });
 });

--- a/maw-plugin/index.ts
+++ b/maw-plugin/index.ts
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process';
 import { join } from 'node:path';
 import { apiArgsToCliArgs } from './api.ts';
 import { runServe, type ServeDeps } from './serve.ts';
+import { runVectorConfig, VECTOR_CONFIG_HELP } from './vector-config.ts';
 
 type InvokeContext = { source?: string; args?: string[] | Record<string, unknown>; writer?: (...args: unknown[]) => void };
 type InvokeResult = { ok: boolean; output?: string; error?: string };
@@ -130,39 +131,6 @@ function formatHealth(data: any): string { return [`arra health: ${data?.status 
 function formatStats(data: any): string { return ['arra stats', data?.total_documents !== undefined && `docs: ${data.total_documents}`, data?.total_docs !== undefined && `docs: ${data.total_docs}`, data?.vector && `vector: ${one(JSON.stringify(data.vector), 180)}`].filter(Boolean).join('\n'); }
 function formatRows(label: string, keys: string[]) { return (data: any) => { const rows = keys.map(k => data?.[k]).find(Array.isArray) ?? []; const total = data?.total ?? data?.chain_length ?? rows.length; return Array.isArray(rows) ? [`arra ${label}: ${total} item${Number(total) === 1 ? '' : 's'}`, ...rows.slice(0, 8).map((r: any) => `- ${r.id ?? r.trace_id ?? r.path ?? r.filename ?? r.name ?? '?'} ${one(r.title ?? r.query ?? r.content ?? r.preview ?? r.label ?? '')}`)].join('\n') : `arra ${label}: ${preview(data)}`; }; }
 function formatOk(label: string) { return (data: any) => [`arra ${label}: ${data?.success === false ? 'failed' : 'ok'}`, data?.id && `id: ${data.id}`, data?.trace_id && `trace_id: ${data.trace_id}`, data?.thread_id && `thread_id: ${data.thread_id}`, data?.message && one(data.message), data?.error && `error: ${one(data.error)}`].filter(Boolean).join('\n') || `arra ${label}: ${preview(data)}`; }
-function formatVectorConfig(data: any): string {
-  const models = data?.models?.models && typeof data.models.models === 'object' ? data.models.models : {}, engines = Array.isArray(data?.health?.engines) ? data.health.engines : [], lines = ['Collection | Adapter | Model | Docs | Status'];
-  for (const [key, raw] of Object.entries(models)) {
-    const m = raw as any, engine = engines.find((e: any) => e.key === key || e.collection === m.collection || e.model === m.model);
-    lines.push(`${m.collection ?? key} | ${m.adapter ?? 'lancedb'} | ${m.model ?? key} | ${m.count ?? m.docs ?? 0} | ${engine ? (engine.ok === false ? 'down' : 'ok') : (data?.health?.status ?? 'unknown')}`);
-  }
-  if (lines.length === 1) lines.push('(none) | - | - | 0 | ' + (data?.health?.status ?? 'unknown'));
-  return lines.join('\n');
-}
-function formatVectorConfigWrite(data: any) { return ['arra vector-config: ' + (data?.success === false ? 'failed' : 'ok'), data?.collection && `collection: ${data.collection}`, data?.adapter && `adapter: ${data.adapter}`, data?.count !== undefined && `count: ${data.count}`, data?.error && `error: ${one(data.error)}`].filter(Boolean).join('\n'); }
-const VC_HELP = 'vector-config [--json] | vector-config set <collection> adapter <lancedb|qdrant|sqlite-vec|chroma> | vector-config reload | vector-config test <collection>';
-function buildVectorConfig(p: Parsed): { method: Method; built: Built } | undefined {
-  const action = key(p.pos[0] || ''), collection = p.pos[1], adapter = p.pos[3];
-  if (!action) return undefined;
-  if (action === 'reload') return { method: 'POST', built: route('/api/v1/vector/config/reload') };
-  if (!collection) throw new Error('collection required');
-  if (action === 'test') return { method: 'POST', built: route(`/api/v1/vector/config/${enc(collection)}/test`) };
-  if (action !== 'set' || key(p.pos[2] || '') !== 'adapter') throw new Error(VC_HELP);
-  if (!['lancedb', 'qdrant', 'sqlite-vec', 'chroma'].includes(adapter)) throw new Error('adapter must be lancedb, qdrant, sqlite-vec, or chroma');
-  return { method: 'PUT', built: route(`/api/v1/vector/config/${enc(collection)}`, undefined, { adapter }) };
-}
-async function runVectorConfig(parsed: Parsed, request: Requester): Promise<InvokeResult> {
-  try {
-    const write = buildVectorConfig(parsed);
-    if (write) {
-      const init: RequestInit = { method: write.method, headers: authHeaders() };
-      if (write.built.body) init.body = JSON.stringify(write.built.body);
-      return { ok: true, output: formatVectorConfigWrite(await request(qs(write.built.path, write.built.query), init)) };
-    }
-    const init: RequestInit = { method: 'GET' }, data = { models: await request('/api/vector/index/models', init), health: await request('/api/vector/health', init) };
-    return { ok: true, output: b(parsed, 'json') ? JSON.stringify(data, null, 2) : formatVectorConfig(data) };
-  } catch (error) { return { ok: false, error: error instanceof Error ? error.message : String(error) }; }
-}
 export const COMMANDS: Record<string, Spec> = {
   search: { tool: 'oracle_search', method: 'GET', help: 'search <q> [--mode fts|hybrid|vector] [--limit N]', build: p => route('/api/search', { q: text(p, 'query', 'query'), type: f(p, 'type'), limit: f(p, 'limit') || '5', offset: f(p, 'offset'), mode: f(p, 'mode') || 'fts', project: f(p, 'project'), cwd: f(p, 'cwd'), model: f(p, 'model') }), format: formatSearch },
   learn: { tool: 'oracle_learn', method: 'POST', write: true, help: 'learn <text> [--project P] [--source S] [--concepts a,b]', build: p => route('/api/learn', undefined, { pattern: text(p, 'pattern', 'text'), project: f(p, 'project'), source: f(p, 'source'), concepts: f(p, 'concepts')?.split(',').map(s => s.trim()).filter(Boolean) }), format: formatOk('learn') },
@@ -178,7 +146,7 @@ export const COMMANDS: Record<string, Spec> = {
   vector_status: { tool: 'oracle_vector_status', method: 'GET', help: 'vector-status', build: () => route('/api/vector/index/status'), format: d => `arra vector-status: ${preview(d, 700)}` },
   vector_stop: { tool: 'oracle_vector_stop', method: 'POST', write: true, help: 'vector-stop', build: () => route('/api/vector/index/stop'), format: formatOk('vector-stop') },
   vector_models: { tool: 'oracle_vector_models', method: 'GET', help: 'vector-models', build: () => route('/api/vector/index/models'), format: d => `arra vector-models: ${preview(d, 700)}` },
-  vector_config: { tool: 'oracle_vector_config', method: 'GET', help: VC_HELP, build: () => route('/api/vector/index/models'), format: formatVectorConfig },
+  vector_config: { tool: 'oracle_vector_config', method: 'GET', help: VECTOR_CONFIG_HELP, build: () => route('/api/v1/vector/config'), format: d => preview(d, 700) },
   health: { tool: 'oracle_health', method: 'GET', help: 'health', build: () => route('/api/health'), format: formatHealth },
   trace: { tool: 'oracle_trace', method: 'POST', write: true, help: 'trace <query> [--scope project|cross-project|human]', build: p => route('/api/traces', undefined, { query: text(p, 'query', 'query'), queryType: f(p, 'query_type'), scope: f(p, 'scope'), parentTraceId: f(p, 'parent_trace_id'), project: f(p, 'project'), agentCount: n(p, 'agent_count'), durationMs: n(p, 'duration_ms') }), format: formatOk('trace') },
   trace_list: { tool: 'oracle_trace_list', method: 'GET', help: 'trace_list [--query Q] [--status S] [--project P] [--limit N]', build: p => route('/api/traces', { query: f(p, 'query'), status: f(p, 'status'), project: f(p, 'project'), limit: f(p, 'limit'), offset: f(p, 'offset') }), format: formatRows('trace_list', ['traces']) },
@@ -234,7 +202,7 @@ export async function runArra(args: string[], request: Requester = requestJson, 
   if (sub === 'frontend' || sub === 'ui' || sub === 'open') return runFrontend(parsed, opener, env);
   if (sub === 'studio') return runStudio(parsed, runner, env);
   if (sub === 'serve') return runServe(parsed, runner, env, serveDeps);
-  if (sub === 'vector_config') return runVectorConfig(parsed, request);
+  if (sub === 'vector_config') return runVectorConfig(parsed, request, authHeaders);
   const spec = COMMANDS[sub];
   if (!spec) return usage();
   try {

--- a/maw-plugin/vector-config.ts
+++ b/maw-plugin/vector-config.ts
@@ -1,0 +1,116 @@
+type Method = 'GET' | 'POST' | 'PUT' | 'DELETE';
+type Parsed = { pos: string[]; flags: Record<string, string | boolean> };
+type Built = { path: string; query?: Record<string, unknown>; body?: Record<string, unknown> };
+type Requester = (path: string, init?: RequestInit) => Promise<unknown>;
+type Auth = () => Record<string, string>;
+type InvokeResult = { ok: boolean; output?: string; error?: string };
+
+export const VECTOR_CONFIG_HELP = 'vector-config [--json] | vector-config reload | vector-config set|add|remove|set-primary|test';
+
+const enc = encodeURIComponent;
+const key = (s: string) => s.toLowerCase().replace(/-/g, '_');
+const clean = (o: Record<string, unknown>) => Object.fromEntries(Object.entries(o).filter(([, v]) => v !== undefined && v !== null && v !== ''));
+const route = (path: string, query?: Record<string, unknown>, body?: Record<string, unknown>): Built => ({ path, query: query ? clean(query) : undefined, body: body ? clean(body) : undefined });
+const bool = (v: string | undefined) => v === undefined ? undefined : v === 'true' ? true : v === 'false' ? false : undefined;
+function f(p: Parsed, name: string): string | undefined { const v = p.flags[name.replace(/-/g, '_')]; return v === undefined || v === false ? undefined : v === true ? 'true' : String(v); }
+function b(p: Parsed, name: string): boolean | undefined { return bool(f(p, name)); }
+function qs(path: string, query?: Record<string, unknown>): string { const q = new URLSearchParams(); for (const [k, v] of Object.entries(query ?? {})) q.set(k, String(v)); const s = q.toString(); return s ? `${path}?${s}` : path; }
+function one(v: unknown, max = 140): string { const s = String(v ?? '').replace(/\s+/g, ' ').trim(); return s.length > max ? `${s.slice(0, max - 1)}…` : s; }
+
+function collectionName(p: Parsed): string {
+  const name = p.pos[1];
+  if (!name) throw new Error('collection required');
+  return name;
+}
+
+function adapter(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const normalized = key(value) === 'cloudflare' ? 'cloudflare-vectorize' : value;
+  if (!['lancedb', 'qdrant', 'sqlite-vec', 'chroma', 'cloudflare-vectorize', 'proxy'].includes(normalized)) {
+    throw new Error('adapter must be lancedb, qdrant, sqlite-vec, chroma, cloudflare-vectorize, or proxy');
+  }
+  return normalized;
+}
+
+function updateBody(p: Parsed): Record<string, unknown> {
+  const field = p.pos[2] ? key(p.pos[2]) : undefined;
+  const value = p.pos[3];
+  const body: Record<string, unknown> = {
+    adapter: adapter(f(p, 'adapter')),
+    model: f(p, 'model'),
+    provider: f(p, 'provider'),
+    service: f(p, 'service'),
+    endpoint: f(p, 'endpoint') || f(p, 'url'),
+    enabled: b(p, 'enabled'),
+    primary: b(p, 'primary'),
+  };
+  if (field) {
+    if (!value) throw new Error('value required');
+    body[field] = field === 'adapter' ? adapter(value) : field === 'enabled' || field === 'primary' ? bool(value) : value;
+  }
+  return clean(body);
+}
+
+function createBody(p: Parsed): Record<string, unknown> {
+  const body = updateBody({ ...p, pos: [] });
+  body.collection = f(p, 'collection');
+  if (!body.model) throw new Error('--model required');
+  return clean(body);
+}
+
+function buildVectorConfig(p: Parsed): { method: Method; built: Built } | undefined {
+  const action = key(p.pos[0] || 'list');
+  if (action === 'list' || action === 'get' || action === 'stats') return { method: 'GET', built: route('/api/v1/vector/config') };
+  if (action === 'reload') return { method: 'POST', built: route('/api/v1/vector/config/reload') };
+  if (action === 'test') return { method: 'POST', built: route(`/api/v1/vector/config/${enc(collectionName(p))}/test`) };
+  if (action === 'set_primary') return { method: 'POST', built: route(`/api/v1/vector/config/${enc(collectionName(p))}/primary`) };
+  if (action === 'remove') {
+    if (b(p, 'yes') !== true) throw new Error('remove requires --yes');
+    return { method: 'DELETE', built: route(`/api/v1/vector/config/${enc(collectionName(p))}`) };
+  }
+  if (action === 'add') return { method: 'POST', built: route(`/api/v1/vector/config/${enc(collectionName(p))}`, undefined, createBody(p)) };
+  if (action === 'set') return { method: 'PUT', built: route(`/api/v1/vector/config/${enc(collectionName(p))}`, undefined, updateBody(p)) };
+  throw new Error(VECTOR_CONFIG_HELP);
+}
+
+function rows(data: any): any[] {
+  return Array.isArray(data?.collections) ? data.collections : Object.entries(data?.config?.collections ?? {}).map(([key, col]) => ({ key, ...(col as object), count: data?.doc_counts?.[key] ?? 0, status: data?.health?.[key]?.status ?? 'unknown' }));
+}
+
+function pickCollection(data: any, collection: string): any | undefined {
+  return rows(data).find((row) => row.key === collection || row.collection === collection);
+}
+
+function formatList(data: any): string {
+  const lines = ['Collection | Adapter | Model | Docs | Status'];
+  for (const row of rows(data)) lines.push(`${row.collection ?? row.key} | ${row.adapter ?? 'lancedb'} | ${row.model ?? row.key} | ${row.count ?? 0} | ${row.status ?? (row.ok === false ? 'down' : 'ok')}`);
+  if (lines.length === 1) lines.push('(none) | - | - | 0 | unknown');
+  return lines.join('\n');
+}
+
+function formatRead(data: any, p: Parsed): string {
+  const action = key(p.pos[0] || 'list');
+  if (f(p, 'json')) return JSON.stringify(data, null, 2);
+  if (action === 'get') return one(JSON.stringify(pickCollection(data, collectionName(p)) ?? {}), 900);
+  if (action === 'stats') {
+    const name = p.pos[1];
+    const counts = data?.doc_counts ?? {};
+    return name ? `${name}: ${counts[name] ?? pickCollection(data, name)?.count ?? 0}` : Object.entries(counts).map(([k, v]) => `${k}: ${v}`).join('\n');
+  }
+  return formatList(data);
+}
+
+function formatWrite(data: any): string {
+  return ['arra vector-config: ' + (data?.success === false ? 'failed' : 'ok'), data?.collection && `collection: ${data.collection}`, data?.removed && `removed: ${data.removed}`, data?.path && `path: ${data.path}`, data?.status && `status: ${data.status}`, data?.error && `error: ${one(data.error)}`].filter(Boolean).join('\n');
+}
+
+export async function runVectorConfig(parsed: Parsed, request: Requester, authHeaders: Auth): Promise<InvokeResult> {
+  try {
+    const { method, built } = buildVectorConfig(parsed) ?? { method: 'GET' as Method, built: route('/api/v1/vector/config') };
+    const init: RequestInit = { method };
+    if (method !== 'GET') init.headers = authHeaders();
+    if (built.body) init.body = JSON.stringify(built.body);
+    const data = await request(qs(built.path, built.query), init);
+    return { ok: true, output: method === 'GET' ? formatRead(data, parsed) : formatWrite(data) };
+  } catch (error) { return { ok: false, error: error instanceof Error ? error.message : String(error) }; }
+}


### PR DESCRIPTION
Closes #1596\n\n## Summary\n- move maw vector-config handling into a dedicated helper to keep files under 250 lines\n- read vector config from /api/v1/vector/config with table and --json output\n- add set/add/remove/set-primary/reload/test operations against the vector config API\n- guard destructive remove with --yes\n\n## Validation\n- bunx tsc --noEmit\n- bun test maw-plugin/__tests__/\n\nFiles changed are under 250 lines.