### PR TITLE
feat: declare ARRA maw plugin menu and backend config (#1467)

### DIFF
--- a/maw-plugin/__tests__/manifest.test.ts
+++ b/maw-plugin/__tests__/manifest.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from 'bun:test';
+import manifest from '../plugin.json' with { type: 'json' };
+
+test('arra maw plugin declares modern dual surfaces and swappable backend config', () => {
+  expect(manifest).toMatchObject({
+    name: 'arra',
+    entry: './index.ts',
+    cli: { command: 'arra' },
+    api: { path: '/api/arra' },
+    config: { dbBackend: 'http', embedderBackend: 'none' },
+  });
+  expect(manifest.menu.map((item) => item.path)).toContain('/plugins/arra');
+  expect(manifest.configSchema.properties.dbBackend.enum).toEqual(['http', 'sqlite', 'memory', 'custom']);
+});

--- a/maw-plugin/plugin.json
+++ b/maw-plugin/plugin.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Query and write ARRA Oracle over HTTP from maw.",
+  "description": "Unified maw-js plugin for ARRA Oracle CLI, API, and menu surfaces.",
   "cli": {
     "command": "arra",
     "aliases": [
@@ -23,5 +23,50 @@
       "GET",
       "POST"
     ]
-  }
+  },
+  "config": {
+    "dbBackend": "http",
+    "embedderBackend": "none",
+    "apiBase": "http://localhost:47778"
+  },
+  "configSchema": {
+    "type": "object",
+    "properties": {
+      "dbBackend": {
+        "type": "string",
+        "enum": [
+          "http",
+          "sqlite",
+          "memory",
+          "custom"
+        ]
+      },
+      "embedderBackend": {
+        "type": "string"
+      },
+      "apiBase": {
+        "type": "string"
+      },
+      "remoteEmbedderUrl": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": true
+  },
+  "menu": [
+    {
+      "label": "ARRA Oracle",
+      "path": "/plugins/arra",
+      "group": "tools",
+      "order": 15,
+      "icon": "sparkles"
+    },
+    {
+      "label": "ARRA Search",
+      "path": "/search",
+      "group": "main",
+      "order": 10,
+      "icon": "search"
+    }
+  ]
 }

--- a/tests/http/menu/arra-maw-plugin-menu.test.ts
+++ b/tests/http/menu/arra-maw-plugin-menu.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from 'bun:test';
+import { loadUnifiedPlugins } from '../../../src/plugins/unified-loader.ts';
+import { createMenuRoutes, menuItemsFromUnifiedPlugins } from '../../../src/routes/menu/index.ts';
+
+async function fetchMenu() {
+  const runtime = await loadUnifiedPlugins({ dirs: [process.cwd()], warn: () => {} });
+  const app = createMenuRoutes(menuItemsFromUnifiedPlugins(runtime.menu));
+  const res = await app.handle(new Request('http://local/api/menu'));
+  return await res.json() as { items: Array<Record<string, unknown>> };
+}
+
+test('maw arra plugin contributes HTTP menu entries from its manifest', async () => {
+  const body = await fetchMenu();
+  const pluginItem = body.items.find((item) => item.path === '/plugins/arra');
+  const searchItem = body.items.find((item) => item.path === '/search' && item.sourceName === 'arra');
+
+  expect(pluginItem).toMatchObject({
+    label: 'ARRA Oracle',
+    group: 'tools',
+    source: 'plugin',
+    sourceName: 'arra',
+  });
+  expect(searchItem).toMatchObject({ label: 'ARRA Search', group: 'main' });
+});


### PR DESCRIPTION
Closes part of #1467

## Changes
- Add explicit HTTP menu entries to the ARRA maw plugin manifest
- Declare swappable backend/embedder config defaults and schema
- Add regression coverage for plugin menu discovery and manifest contract

## Test
- bunx tsc --noEmit: green
- bun test tests/http/menu/ maw-plugin/__tests__/: passed