### PR TITLE
feat: auto-index psi learn docs

### DIFF
--- a/src/indexer/__tests__/learn-watcher.test.ts
+++ b/src/indexer/__tests__/learn-watcher.test.ts
@@ -25,6 +25,7 @@ CREATE TABLE oracle_documents (
   project TEXT,
   created_by TEXT
 );
+CREATE VIRTUAL TABLE oracle_fts USING fts5(id UNINDEXED, content, concepts, tokenize='porter unicode61');
 CREATE TABLE indexing_jobs (
   id TEXT PRIMARY KEY,
   doc_id TEXT NOT NULL,
@@ -92,6 +93,34 @@ describe('startLearnWatcher', () => {
     const jobs = db.query<{ model_key: string }>('SELECT model_key FROM indexing_jobs ORDER BY model_key').all() as { model_key: string }[];
     expect(jobs).toHaveLength(Object.keys(MODELS).length);
     expect(jobs.map((r) => r.model_key).sort()).toEqual(Object.keys(MODELS).sort());
+
+    stop();
+  });
+
+
+  it('stores and enqueues new ψ/learn markdown files', async () => {
+    const learnDir = path.join(repoRoot, 'ψ', 'learn', 'Soul-Brews-Studio', 'demo');
+    const filePath = path.join(learnDir, 'exploration.md');
+
+    fs.mkdirSync(learnDir, { recursive: true });
+    fs.writeFileSync(filePath, '# Exploration\n\n## Finding\n\nAuto indexing should capture new learn docs.', 'utf8');
+
+    const stop = startLearnWatcher({ db, models: MODELS, repoRoot, debounceMs: 20 });
+
+    fs.writeFileSync(filePath, '# Exploration\n\n## Finding\n\nAuto indexing should capture updated learn docs.', 'utf8');
+    await wait(300);
+
+    const docs = db.query<{ id: string; source_file: string }>(
+      'SELECT id, source_file FROM oracle_documents ORDER BY id',
+    ).all() as { id: string; source_file: string }[];
+    expect(docs).toHaveLength(1);
+    expect(docs[0].source_file).toBe('ψ/learn/Soul-Brews-Studio/demo/exploration.md');
+
+    const fts = db.query<{ count: number }, []>('SELECT COUNT(*) AS count FROM oracle_fts').get() as { count: number };
+    expect(fts.count).toBe(1);
+
+    const jobs = db.query<{ count: number }, []>('SELECT COUNT(*) AS count FROM indexing_jobs').get() as { count: number };
+    expect(jobs.count).toBe(Object.keys(MODELS).length);
 
     stop();
   });

--- a/src/indexer/cli.ts
+++ b/src/indexer/cli.ts
@@ -34,6 +34,7 @@ const config: IndexerConfig = {
     learnings: '\u03c8/memory/learnings',
     retrospectives: '\u03c8/memory/retrospectives',
     distillations: '\u03c8/memory/distillations',
+    learn: '\u03c8/learn',
     // Opt-in: set ORACLE_INDEX_SECURITY_CORPUS=1 to include \u03c8/learn/security-corpus/.
     // Default OFF because the corpus has ~36k files (one-time index ~10-30 min).
     security_corpus: process.env.ORACLE_INDEX_SECURITY_CORPUS === '1'

--- a/src/indexer/collectors.ts
+++ b/src/indexer/collectors.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import path from 'path';
 import type { OracleDocument, IndexerConfig } from '../types.ts';
 import { parseResonanceFile, parseLearningFile, parseRetroFile, parseSecurityCorpusFile } from './parser.ts';
+import { isPsiLearnSource, parsePsiLearnFile } from './learn-doc-source.ts';
 import { discoverProjectPsiDirs } from './discovery.ts';
 
 const SECURITY_CORPUS_EXTENSIONS = ['.md', '.txt', '.yaml', '.yml', '.json', '.rst'];
@@ -118,6 +119,36 @@ function getSecurityCorpusFiles(dir: string): string[] {
  * OPT-IN: only runs when config.sourcePaths.security_corpus is set.
  * Reference: ψ/memory/learnings/2026-04-26_arra-v3-indexer-extension.md
  */
+export function collectPsiLearn(opts: {
+  config: IndexerConfig;
+  seenContentHashes: Set<string>;
+}): OracleDocument[] {
+  const { config, seenContentHashes } = opts;
+  const documents: OracleDocument[] = [];
+  const subPath = config.sourcePaths.learn;
+  if (!subPath) return documents;
+
+  const sourcePath = path.join(config.repoRoot, subPath);
+  if (!fs.existsSync(sourcePath)) return documents;
+
+  const files = getAllMarkdownFiles(sourcePath);
+  let skippedDupes = 0;
+  for (const filePath of files) {
+    const relPath = path.relative(config.repoRoot, filePath).split(path.sep).join('/');
+    if (!isPsiLearnSource(relPath)) continue;
+
+    const content = fs.readFileSync(filePath, 'utf-8');
+    if (!content.trim()) continue;
+    const contentHash = Bun.hash(content).toString(36);
+    if (seenContentHashes.has(contentHash)) { skippedDupes++; continue; }
+    seenContentHashes.add(contentHash);
+    documents.push(...parsePsiLearnFile(relPath, content));
+  }
+
+  console.log(`Indexed ${documents.length} ψ/learn documents from ${files.length} files (skipped ${skippedDupes} duplicates)`);
+  return documents;
+}
+
 export function collectSecurityCorpus(opts: {
   config: IndexerConfig;
   seenContentHashes: Set<string>;

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -24,7 +24,7 @@ import type { OracleDocument, IndexerConfig } from '../types.ts';
 import { setIndexingStatus } from './status.ts';
 import { backupDatabase } from './backup.ts';
 import { parseResonanceFile, parseLearningFile, parseRetroFile, parseDistillationFile } from './parser.ts';
-import { collectDocuments, collectSecurityCorpus } from './collectors.ts';
+import { collectDocuments, collectPsiLearn, collectSecurityCorpus } from './collectors.ts';
 import { storeDocuments } from './storage.ts';
 
 export class OracleIndexer {
@@ -76,6 +76,7 @@ export class OracleIndexer {
       ...collectDocuments({ ...shared, subdir: 'learnings', parseFn: parseLearningFile, label: 'learning' }),
       ...collectDocuments({ ...shared, subdir: 'retrospectives', parseFn: parseRetroFile, label: 'retrospective' }),
       ...collectDocuments({ ...shared, subdir: 'distillations', parseFn: parseDistillationFile, label: 'distillation' }),
+      ...collectPsiLearn(shared),
       ...collectSecurityCorpus(shared),
     ];
 

--- a/src/indexer/learn-doc-source.ts
+++ b/src/indexer/learn-doc-source.ts
@@ -1,0 +1,87 @@
+/**
+ * Helpers for indexing ψ/learn Markdown documents incrementally.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import type Database from 'bun:sqlite';
+import type { OracleDocument } from '../types.ts';
+import { parseLearningFile } from './parser.ts';
+
+export const PSI_LEARN_REL = path.join('ψ', 'learn');
+
+export function normalizeSourceFile(repoRoot: string, filePath: string): string {
+  return path.relative(repoRoot, filePath).split(path.sep).join('/');
+}
+
+export function isMarkdownFile(filePath: string): boolean {
+  const lower = filePath.toLowerCase();
+  return lower.endsWith('.md') || lower.endsWith('.markdown');
+}
+
+export function isPsiLearnSource(sourceFile: string): boolean {
+  const normalized = sourceFile.split(path.sep).join('/');
+  return normalized.startsWith('ψ/learn/') && !normalized.startsWith('ψ/learn/security-corpus/');
+}
+
+export function parsePsiLearnFile(relativePath: string, content: string): OracleDocument[] {
+  const sourceFile = relativePath.split(path.sep).join('/');
+  const basename = path.basename(sourceFile);
+  const pathHash = Bun.hash(sourceFile).toString(36);
+
+  return parseLearningFile(basename, content, sourceFile).map((doc) => ({
+    ...doc,
+    id: doc.id.replace(/^learning_/, `learning_psi_learn_${pathHash}_`),
+    source_file: sourceFile,
+  }));
+}
+
+export function readPsiLearnDocuments(repoRoot: string, filePath: string): OracleDocument[] {
+  const sourceFile = normalizeSourceFile(repoRoot, filePath);
+  if (!isPsiLearnSource(sourceFile) || !isMarkdownFile(filePath)) return [];
+  const content = fs.readFileSync(filePath, 'utf8');
+  if (!content.trim()) return [];
+  return parsePsiLearnFile(sourceFile, content);
+}
+
+export function storeSqliteDocuments(db: Database, documents: OracleDocument[]): string[] {
+  if (documents.length === 0) return [];
+  const now = Date.now();
+  const upsertDoc = db.prepare(`
+    INSERT INTO oracle_documents
+      (id, type, source_file, concepts, created_at, updated_at, indexed_at, project, created_by)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'indexer')
+    ON CONFLICT(id) DO UPDATE SET
+      type = excluded.type,
+      source_file = excluded.source_file,
+      concepts = excluded.concepts,
+      updated_at = excluded.updated_at,
+      indexed_at = excluded.indexed_at,
+      project = excluded.project
+  `);
+  const deleteFts = db.prepare('DELETE FROM oracle_fts WHERE id = ?');
+  const insertFts = db.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)');
+
+  db.exec('BEGIN');
+  try {
+    for (const doc of documents) {
+      upsertDoc.run(
+        doc.id,
+        doc.type,
+        doc.source_file,
+        JSON.stringify(doc.concepts),
+        doc.created_at,
+        doc.updated_at,
+        now,
+        doc.project?.toLowerCase() ?? null,
+      );
+      deleteFts.run(doc.id);
+      insertFts.run(doc.id, doc.content, doc.concepts.join(' '));
+    }
+    db.exec('COMMIT');
+  } catch (error) {
+    db.exec('ROLLBACK');
+    throw error;
+  }
+  return documents.map((doc) => doc.id);
+}

--- a/src/indexer/learn-watcher.ts
+++ b/src/indexer/learn-watcher.ts
@@ -1,11 +1,8 @@
 /**
- * Auto queue learn documents when files change under ψ/memory/learnings.
+ * Auto-index learn documents when files change under ψ/memory/learnings or ψ/learn.
  *
- * The watcher maps changed Markdown files to existing `oracle_documents`
- * rows by `source_file` and enqueues one queue job per registered model.
- *
- * This keeps vector indexing incremental and avoids expensive full reindex runs
- * when a single learning file is edited.
+ * Existing indexed learning files are re-queued by source_file. New ψ/learn
+ * Markdown files are inserted into SQLite/FTS first, then queued for vector jobs.
  */
 
 import fs from 'fs';
@@ -13,13 +10,21 @@ import path from 'path';
 import type Database from 'bun:sqlite';
 import { enqueueIndexJob } from './jobs.ts';
 import { REPO_ROOT } from '../config.ts';
+import {
+  PSI_LEARN_REL,
+  isMarkdownFile,
+  isPsiLearnSource,
+  normalizeSourceFile,
+  readPsiLearnDocuments,
+  storeSqliteDocuments,
+} from './learn-doc-source.ts';
 
 export interface LearnWatcherOptions {
   /** sqlite database used by enqueueIndexJob(). */
   db: Database;
   /** Model registry from vector/factory.getEmbeddingModels(). */
   models: Record<string, { collection: string }>;
-  /** Repo root that owns ψ/memory/learnings. Defaults to REPO_ROOT. */
+  /** Repo root that owns ψ memory/learn sources. Defaults to REPO_ROOT. */
   repoRoot?: string;
   /** Debounce window in ms to collapse bursty editor saves. */
   debounceMs?: number;
@@ -28,56 +33,83 @@ export interface LearnWatcherOptions {
 export type StopWatch = () => void;
 
 const DEFAULT_DEBOUNCE_MS = 250;
-const LEARN_DIR_REL = path.join('\u03c8', 'memory', 'learnings');
-
-function normalizeSourceFile(repoRoot: string, filePath: string): string {
-  return path.relative(repoRoot, filePath).split(path.sep).join('/');
-}
-
-function isMarkdownFile(filePath: string): boolean {
-  const lower = filePath.toLowerCase();
-  return lower.endsWith('.md') || lower.endsWith('.markdown');
-}
+const MEMORY_LEARN_REL = path.join('ψ', 'memory', 'learnings');
 
 function safeClose(watchers: Array<{ close: () => void }>): void {
   for (const watcher of watchers) {
-    try {
-      watcher.close();
-    } catch {
-      // Intentionally best-effort.
-    }
+    try { watcher.close(); } catch {}
   }
 }
 
 function safeClearTimeout(id: ReturnType<typeof setTimeout> | undefined): void {
-  if (id !== undefined) {
-    clearTimeout(id);
-  }
+  if (id !== undefined) clearTimeout(id);
 }
 
-function enqueueBySourceFile(db: Database, models: Record<string, { collection: string }>, sourceFile: string): number {
-  const rows = db
+function hasActiveJobs(db: Database, docId: string): boolean {
+  const row = db.query<{ count: number }, [string]>(
+    `SELECT COUNT(*) AS count FROM indexing_jobs
+     WHERE doc_id = ? AND status IN ('pending', 'claimed')`,
+  ).get(docId);
+  return (row?.count ?? 0) > 0;
+}
+
+function enqueueDocIds(db: Database, models: Record<string, { collection: string }>, ids: string[]): number {
+  let count = 0;
+  for (const id of ids) {
+    if (hasActiveJobs(db, id)) continue;
+    try {
+      count += enqueueIndexJob(db, { docId: id, models }).length;
+    } catch {
+      continue;
+    }
+  }
+  return count;
+}
+
+function existingLearningIds(db: Database, sourceFile: string): string[] {
+  return db
     .query<{ id: string }, [string]>(
       `SELECT id
        FROM oracle_documents
        WHERE source_file = ? AND type = 'learning' AND superseded_at IS NULL`,
     )
-    .all(sourceFile);
-
-  for (const row of rows) {
-    try {
-      enqueueIndexJob(db, { docId: row.id, models });
-    } catch {
-      // Never throw while watching files — indexing is eventually consistent.
-      continue;
-    }
-  }
-  return rows.length;
+    .all(sourceFile)
+    .map((row) => row.id);
 }
 
 function isWithinRoot(root: string, candidate: string): boolean {
   const rel = path.relative(root, candidate);
   return rel === '' || (rel !== '..' && !rel.startsWith(`..${path.sep}`) && !path.isAbsolute(rel));
+}
+
+function listDirs(root: string): string[] {
+  const dirs = [root];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name === '.git' || entry.name === 'node_modules') continue;
+    dirs.push(...listDirs(path.join(root, entry.name)));
+  }
+  return dirs;
+}
+
+function listMarkdownFiles(root: string): string[] {
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) files.push(...listMarkdownFiles(fullPath));
+    else if (entry.isFile() && isMarkdownFile(fullPath)) files.push(fullPath);
+  }
+  return files;
+}
+
+function watchDir(dir: string, onFileEvent: (filePath: string) => void): fs.FSWatcher | null {
+  try {
+    return fs.watch(dir, { persistent: false }, (_event, filename) => {
+      if (filename) onFileEvent(path.join(dir, filename));
+    });
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -92,69 +124,71 @@ export function startLearnWatcher({
   debounceMs = DEFAULT_DEBOUNCE_MS,
 }: LearnWatcherOptions): StopWatch {
   const root = path.resolve(repoRoot);
-  const learnDir = path.join(root, LEARN_DIR_REL);
+  const roots = [path.join(root, MEMORY_LEARN_REL), path.join(root, PSI_LEARN_REL)]
+    .filter((dir) => fs.existsSync(dir));
 
-  if (!fs.existsSync(learnDir)) {
-    return () => {};
-  }
+  if (roots.length === 0) return () => {};
 
   const watchers: Array<fs.FSWatcher> = [];
+  const watchedDirs = new Set<string>();
   const pending = new Map<string, ReturnType<typeof setTimeout>>();
-  const timerFor = (filePath: string, fn: () => void) => {
-    const existing = pending.get(filePath);
-    safeClearTimeout(existing);
 
-    const timer = setTimeout(() => {
-      pending.delete(filePath);
-      fn();
-    }, debounceMs);
+  const timerFor = (filePath: string, fn: () => void) => {
+    safeClearTimeout(pending.get(filePath));
+    const timer = setTimeout(() => { pending.delete(filePath); fn(); }, debounceMs);
     pending.set(filePath, timer);
   };
 
-  const enqueueFromPath = (eventPath: string) => {
-    const fullPath = path.resolve(eventPath);
-    if (!isWithinRoot(learnDir, fullPath)) return;
-    if (!fs.existsSync(fullPath) || !isMarkdownFile(fullPath)) return;
+  const indexOrQueue = (filePath: string) => {
+    const fullPath = path.resolve(filePath);
+    if (!roots.some((sourceRoot) => isWithinRoot(sourceRoot, fullPath))) return;
+    if (!fs.existsSync(fullPath)) return;
 
     let stat: fs.Stats;
-    try {
-      stat = fs.statSync(fullPath);
-    } catch {
-      return;
-    }
-    if (!stat.isFile()) return;
+    try { stat = fs.statSync(fullPath); } catch { return; }
+    if (stat.isDirectory()) { addWatchers(fullPath); return; }
+    if (!stat.isFile() || !isMarkdownFile(fullPath)) return;
 
     const sourceFile = normalizeSourceFile(root, fullPath);
-    if (sourceFile.endsWith('/')) return;
-
-    const count = enqueueBySourceFile(db, models, sourceFile);
-    if (count === 0) {
-      console.log(`[learn-watch] no oracle_documents rows for ${sourceFile}`);
+    let ids = existingLearningIds(db, sourceFile);
+    if (ids.length === 0 && isPsiLearnSource(sourceFile)) {
+      try {
+        ids = storeSqliteDocuments(db, readPsiLearnDocuments(root, fullPath));
+      } catch (error) {
+        console.warn(`[learn-watch] failed to index ${sourceFile}:`, error);
+        return;
+      }
     }
+
+    if (ids.length === 0) {
+      console.log(`[learn-watch] no oracle_documents rows for ${sourceFile}`);
+      return;
+    }
+    enqueueDocIds(db, models, ids);
   };
 
-  const onFileEvent = (_event: string, filename: string | null): void => {
-    if (!filename) return;
-    const candidate = path.join(learnDir, filename);
-    timerFor(candidate, () => {
-      enqueueFromPath(candidate);
-    });
-  };
+  function addWatchers(dir: string): void {
+    for (const childDir of listDirs(dir)) {
+      if (watchedDirs.has(childDir)) continue;
+      const watcher = watchDir(childDir, (candidate) => timerFor(candidate, () => indexOrQueue(candidate)));
+      if (!watcher) continue;
+      watchedDirs.add(childDir);
+      watchers.push(watcher);
+    }
+  }
 
-  try {
-    const watcher = fs.watch(learnDir, { persistent: false, recursive: true }, onFileEvent);
-    watchers.push(watcher);
-  } catch {
-    // `recursive` may fail on some Bun/platform combos; fallback to shallow watch.
-    const watcher = fs.watch(learnDir, { persistent: false }, onFileEvent);
-    watchers.push(watcher);
+  for (const sourceRoot of roots) addWatchers(sourceRoot);
+
+  const psiLearnRoot = path.join(root, PSI_LEARN_REL);
+  if (fs.existsSync(psiLearnRoot)) {
+    for (const filePath of listMarkdownFiles(psiLearnRoot)) {
+      const sourceFile = normalizeSourceFile(root, filePath);
+      if (existingLearningIds(db, sourceFile).length === 0) indexOrQueue(filePath);
+    }
   }
 
   return () => {
-    for (const [p, timer] of pending) {
-      safeClearTimeout(timer);
-      pending.delete(p);
-    }
+    for (const [p, timer] of pending) { safeClearTimeout(timer); pending.delete(p); }
     safeClose(watchers);
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,6 +126,7 @@ export interface IndexerConfig {
     learnings: string;
     retrospectives: string;
     distillations: string;
+    learn?: string;             // ψ/learn/ — auto-learned repo exploration docs
     security_corpus?: string;  // Optional: ψ/learn/security-corpus/ — opt-in via ORACLE_INDEX_SECURITY_CORPUS=1
   };
 }


### PR DESCRIPTION
## Summary
- Add ψ/learn as a general learning source while keeping ψ/learn/security-corpus opt-in/excluded.
- Persist new ψ/learn markdown into oracle_documents + oracle_fts before enqueueing vector indexing jobs.
- Extend the learn watcher to watch ψ/learn recursively and catch up existing unindexed files on daemon startup.

## Tests
- `bunx tsc --noEmit`
- `bun test src/indexer/__tests__/learn-watcher.test.ts`

Refs #1423
