### PR TITLE
feat: add trace awakening distillation API

### DIFF
--- a/src/routes/traces/distill.ts
+++ b/src/routes/traces/distill.ts
@@ -1,0 +1,33 @@
+import { Elysia, t } from 'elysia';
+import { distillTrace, getTrace } from '../../trace/handler.ts';
+import { traceIdParam } from './model.ts';
+
+const distillBody = t.Object({
+  awakening: t.String({ minLength: 1 }),
+  promoteToLearning: t.Optional(t.Boolean()),
+});
+
+export const traceDistillRoute = new Elysia().post('/api/traces/:id/distill', ({ params, body, set }) => {
+  const awakening = body.awakening.trim();
+  if (!awakening) {
+    set.status = 400;
+    return { error: 'awakening is required' };
+  }
+  if (!getTrace(params.id)) {
+    set.status = 404;
+    return { error: 'Trace not found' };
+  }
+  return distillTrace({
+    traceId: params.id,
+    awakening,
+    promoteToLearning: body.promoteToLearning,
+  });
+}, {
+  params: traceIdParam,
+  body: distillBody,
+  detail: {
+    tags: ['traces'],
+    menu: { group: 'hidden' },
+    summary: 'Distill an awakening insight from a trace',
+  },
+});

--- a/src/routes/traces/index.ts
+++ b/src/routes/traces/index.ts
@@ -5,6 +5,7 @@ import { traceChainRoute } from './chain.ts';
 import { traceLinkRoute } from './link.ts';
 import { traceUnlinkRoute } from './unlink.ts';
 import { traceLinkedChainRoute } from './linked-chain.ts';
+import { traceDistillRoute } from './distill.ts';
 
 export const tracesApi = new Elysia()
   .use(tracesListRoute)
@@ -12,4 +13,5 @@ export const tracesApi = new Elysia()
   .use(traceChainRoute)
   .use(traceLinkRoute)
   .use(traceUnlinkRoute)
-  .use(traceLinkedChainRoute);
+  .use(traceLinkedChainRoute)
+  .use(traceDistillRoute);

--- a/src/routes/traces/link.ts
+++ b/src/routes/traces/link.ts
@@ -1,15 +1,15 @@
 import { Elysia } from 'elysia';
 import { linkTraces } from '../../trace/handler.ts';
-import { prevIdParam, linkBody } from './model.ts';
+import { traceIdParam, linkBody } from './model.ts';
 
-export const traceLinkRoute = new Elysia().post('/api/traces/:prevId/link', async ({ params, body, set }) => {
+export const traceLinkRoute = new Elysia().post('/api/traces/:id/link', async ({ params, body, set }) => {
   try {
     const { nextId } = (body as any) ?? {};
     if (!nextId) {
       set.status = 400;
       return { error: 'Missing nextId in request body' };
     }
-    const result = linkTraces(params.prevId, nextId);
+    const result = linkTraces(params.id, nextId);
     if (!result.success) {
       set.status = 400;
       return { error: result.message };
@@ -21,7 +21,7 @@ export const traceLinkRoute = new Elysia().post('/api/traces/:prevId/link', asyn
     return { error: 'Failed to link traces' };
   }
 }, {
-  params: prevIdParam,
+  params: traceIdParam,
   body: linkBody,
   detail: {
     tags: ['traces'],

--- a/src/routes/traces/model.ts
+++ b/src/routes/traces/model.ts
@@ -1,7 +1,6 @@
 import { t } from 'elysia';
 
 export const traceIdParam = t.Object({ id: t.String() });
-export const prevIdParam = t.Object({ prevId: t.String() });
 
 export const listQuery = t.Object({
   query: t.Optional(t.String()),

--- a/tests/http/traces/routes.test.ts
+++ b/tests/http/traces/routes.test.ts
@@ -101,6 +101,25 @@ describe("Trace routes", () => {
     expect(data).toHaveProperty("chain");
   });
 
+  test("POST /api/traces/:id/distill stores an awakening", async () => {
+    const res = await fetch(`${BASE_URL}/api/traces/${traceA}/distill`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ awakening: "Thor turns storm into research-grade dev context." }),
+    });
+    expect(res.ok).toBe(true);
+    expect(await res.json()).toMatchObject({ success: true, status: "distilled" });
+
+    const traceRes = await fetch(`${BASE_URL}/api/traces/${traceA}`);
+    const trace = await traceRes.json();
+    expect(trace.status).toBe("distilled");
+    expect(trace.awakening).toContain("Thor turns storm");
+
+    const chainRes = await fetch(`${BASE_URL}/api/traces/${traceA}/chain`);
+    const chain = await chainRes.json();
+    expect(chain).toMatchObject({ hasAwakening: true, awakeningTraceId: traceA });
+  });
+
   test("POST /api/traces/:prevId/link without body returns 400", async () => {
     const res = await fetch(`${BASE_URL}/api/traces/${traceA}/link`, {
       method: "POST",


### PR DESCRIPTION
Closes #1030\n\n## Summary\n- Phase 1 only: expose the existing trace distillation core as POST /api/traces/:id/distill\n- validate non-empty awakening text and missing trace handling\n- normalize trace link route param naming to avoid Elysia route conflicts while preserving the same URL shape\n- add HTTP contract coverage that stores a Thor-style awakening and verifies chain metadata\n\n## Validation\n- bunx tsc --noEmit\n- bun test tests/http/traces/\n\nFiles changed are under 250 lines. Later Thor Dev + Research phases intentionally not included.