### PR TITLE
fix: align Gemini provider detection with config

### DIFF
--- a/src/vector/provider-detection.ts
+++ b/src/vector/provider-detection.ts
@@ -69,14 +69,15 @@ export async function detectEmbeddingProviders(
   const env = options.env ?? process.env;
   const cfConfigured = has(env, 'CF_ACCOUNT_ID', 'CLOUDFLARE_ACCOUNT_ID')
     && has(env, 'CF_API_TOKEN', 'CLOUDFLARE_API_TOKEN');
+  const geminiConfigured = has(env, 'GEMINI_API_KEY', 'GOOGLE_API_KEY');
   const providers = [
     await detectOllama({ ...options, env }),
     provider('openai', has(env, 'OPENAI_API_KEY'), {
       models: has(env, 'OPENAI_API_KEY') ? ['text-embedding-3-small', 'text-embedding-3-large'] : [],
       capabilities: ['embed', 'remote'],
     }),
-    provider('gemini', has(env, 'GEMINI_API_KEY'), {
-      models: has(env, 'GEMINI_API_KEY') ? ['text-embedding-004'] : [],
+    provider('gemini', geminiConfigured, {
+      models: geminiConfigured ? ['text-embedding-004'] : [],
       capabilities: ['embed', 'remote', 'free-tier'],
     }),
     provider('cloudflare-ai', cfConfigured, {

--- a/tests/http/vector/providers.test.ts
+++ b/tests/http/vector/providers.test.ts
@@ -33,6 +33,22 @@ test('GET /api/v1/vector/providers returns detected providers and capabilities',
   expect(body.providers).toContainEqual(expect.objectContaining({ type: 'cloudflare-ai', available: true }));
 });
 
+test('GET /api/v1/vector/providers accepts GOOGLE_API_KEY for Gemini detection', async () => {
+  const app = new Elysia({ prefix: '/api' }).use(createVectorProvidersEndpoint({
+    env: { GOOGLE_API_KEY: 'google-gemini-key' },
+    fetcher: mock(async () => new Response('{\"models\":[]}')) as unknown as typeof fetch,
+  }));
+  const res = await createApiVersionedFetch((request) => app.handle(request))(
+    new Request('http://local/api/v1/vector/providers'),
+  );
+  const body = await res.json() as { providers: Array<Record<string, unknown>> };
+
+  expect(res.status).toBe(200);
+  expect(body.providers).toContainEqual(expect.objectContaining({
+    type: 'gemini', available: true, models: ['text-embedding-004'],
+  }));
+});
+
 test('POST /api/v1/vector/providers/test probes one provider config', async () => {
   const res = await fetcher()(new Request('http://local/api/v1/vector/providers/test', {
     method: 'POST',


### PR DESCRIPTION
## Summary
- Verified the Phase 1 embedding provider/config surfaces already on alpha against #1437.
- Hardened Gemini auto-detection so `/api/vector/providers` reports Gemini available when either `GEMINI_API_KEY` or the provider-supported `GOOGLE_API_KEY` is set.
- Added HTTP regression coverage for the Google API key alias.

## Tests
- `bunx tsc --noEmit`
- `bun test tests/http/vector/`

Refs #1437
