### PR TITLE
fix: align /api/learn malformed JSON contract (#1718)

### DIFF
--- a/src/routes/knowledge/index.ts
+++ b/src/routes/knowledge/index.ts
@@ -1,9 +1,8 @@
 /**
  * Knowledge Routes (Elysia) — composes /api/{learn,handoff,inbox}.
  *
- * onError PARSE → 500 preserves Hono try/catch semantics (malformed JSON
- * body returned 500 via the old catch block; Elysia defaults to 400 for
- * parse errors, so we remap to match the HTTP contract tests).
+ * Malformed JSON parse failures should surface as 400 Bad Request through
+ * Elysia's default handling or the global structured error middleware.
  */
 
 import { Elysia } from 'elysia';
@@ -12,12 +11,6 @@ import { handoffEndpoint } from './handoff.ts';
 import { inboxEndpoint } from './inbox.ts';
 
 export const knowledgeRoutes = new Elysia({ prefix: '/api' })
-  .onError(({ code, error, set }) => {
-    if (code === 'PARSE') {
-      set.status = 500;
-      return { error: error instanceof Error ? error.message : 'Parse error' };
-    }
-  })
   .use(createLearnListRoutes())
   .use(createLearnCrudRoutes())
   .use(handoffEndpoint)

--- a/tests/http/knowledge.test.ts
+++ b/tests/http/knowledge.test.ts
@@ -62,7 +62,7 @@ describe("HTTP Contract — search / knowledge / supersede", () => {
 
     test("rejects malformed JSON body", async () => {
       const res = await fetch(`${BASE_URL}/api/learn`, { method: "POST", headers: JSON_HEADERS, body: "{not json" });
-      expect(res.status).toBe(500);
+      expect(res.status).toBe(400);
     });
   });
 

--- a/tests/http/learn/crud.test.ts
+++ b/tests/http/learn/crud.test.ts
@@ -51,6 +51,16 @@ afterAll(() => {
 });
 
 describe('POST/GET/PUT/DELETE /api/learn', () => {
+  test('rejects malformed JSON body with bad request status', async () => {
+    const res = await app().handle(new Request('http://local/api/learn', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{not json',
+    }));
+    expect(res.status).toBe(400);
+    expect(await res.text()).toMatch(/bad request/i);
+  });
+
   test('creates, reads, updates, and soft-deletes a learning through Drizzle rows', async () => {
     const created = await call('POST', '/api/learn', {
       pattern: 'Learn CRUD captures route behavior',


### PR DESCRIPTION
Closes #1718

## Changes
- Remove stale knowledge route parse-error override that documented/remapped malformed JSON as 500
- Align /api/learn malformed JSON contract with 400 Bad Request
- Add scoped learn-route regression coverage for malformed JSON
- Update alpha audit knowledge contract expectation

## Test
- bunx tsc --noEmit: green
- bun test tests/http/learn/: passed
- bun test tests/http/knowledge.test.ts: passed