### PR TITLE
feat: vector fanout cache controls

### DIFF
--- a/src/routes/vector/fanout.ts
+++ b/src/routes/vector/fanout.ts
@@ -22,9 +22,12 @@ function requestedBackends(raw: string | undefined, enabled: string[]): string[]
 }
 
 export function createFanoutEndpoint(options: FanoutEndpointOptions = {}) {
-  return new Elysia().get(
-  '/vector/fanout',
-  async ({ query, set }) => {
+  return new Elysia()
+    .get('/vector/fanout/cache', () => ({ cache: cache.stats() }), { detail: { tags: ['vector'], summary: 'Fan-out query cache stats' } })
+    .delete('/vector/fanout/cache', () => { cache.clear(); return { success: true, cache: cache.stats() }; }, { detail: { tags: ['vector'], summary: 'Clear fan-out query cache' } })
+    .get(
+      '/vector/fanout',
+      async ({ query, set }) => {
     if (!query.q) {
       set.status = 400;
       return { error: 'Missing query parameter: q' };
@@ -54,16 +57,16 @@ export function createFanoutEndpoint(options: FanoutEndpointOptions = {}) {
     const result = { query: q, ...(await queryFanout({ text: q, limit, where, targets })) };
     if (query.cache !== 'false') cache.set(cacheKey, result);
     return result;
-  },
-  {
-    query: FanoutQuery,
-    detail: {
-      tags: ['vector'],
-      menu: { group: 'hidden' },
-      summary: 'Fan out vector search across configured collections/backends',
-    },
-  },
-);
+      },
+      {
+        query: FanoutQuery,
+        detail: {
+          tags: ['vector'],
+          menu: { group: 'hidden' },
+          summary: 'Fan out vector search across configured collections/backends',
+        },
+      },
+    );
 }
 
 export const fanoutEndpoint = createFanoutEndpoint();

--- a/src/vector/query-cache.ts
+++ b/src/vector/query-cache.ts
@@ -48,6 +48,10 @@ export class QueryCache<T> {
   clear(): void {
     this.entries.clear();
   }
+
+  stats(): { size: number; maxEntries: number; ttlMs: number } {
+    return { size: this.entries.size, maxEntries: this.maxEntries, ttlMs: this.ttlMs };
+  }
 }
 
 export function stableCacheKey(parts: Record<string, unknown>): string {

--- a/tests/http/vector/phase4-polish.test.ts
+++ b/tests/http/vector/phase4-polish.test.ts
@@ -39,6 +39,28 @@ test('GET /api/v1/vector/fanout merges and deduplicates parallel backend results
   expect(body.errors).toEqual({});
 });
 
+test('GET /api/v1/vector/fanout caches and clears query results', async () => {
+  const { createFanoutEndpoint } = await import('../../../src/routes/vector/fanout.ts');
+  const query = mock(async () => queryResult(['cached'], [1]));
+  const app = new Elysia({ prefix: '/api' }).use(createFanoutEndpoint({
+    getModels: () => ({ local: models.local }),
+    getStore: async () => ({ query }),
+  }));
+  const fetch = createApiVersionedFetch((request) => app.handle(request));
+
+  const first = await fetch(new Request('http://local/api/v1/vector/fanout?q=cache&fanout=local'));
+  const second = await fetch(new Request('http://local/api/v1/vector/fanout?q=cache&fanout=local'));
+  const cached = await second.json() as { cached?: boolean };
+  const stats = await (await fetch(new Request('http://local/api/v1/vector/fanout/cache'))).json() as { cache: { size: number } };
+  const cleared = await (await fetch(new Request('http://local/api/v1/vector/fanout/cache', { method: 'DELETE' }))).json() as { cache: { size: number } };
+
+  expect(first.status).toBe(200);
+  expect(cached.cached).toBe(true);
+  expect(query).toHaveBeenCalledTimes(1);
+  expect(stats.cache.size).toBeGreaterThanOrEqual(1);
+  expect(cleared.cache.size).toBe(0);
+});
+
 test('GET /api/v1/vector/cost-estimate returns token cost and recommendation', async () => {
   const { createVectorCostEndpoint } = await import('../../../src/routes/vector/cost.ts');
   const app = new Elysia({ prefix: '/api' }).use(createVectorCostEndpoint({


### PR DESCRIPTION
## Summary
- add fan-out query cache stats endpoint
- add fan-out query cache clear endpoint
- cover cache hit behavior and clear operation in vector Phase 4 tests

## Existing Phase 4 coverage on alpha
- fallback chain is implemented via `FallbackEmbeddings`
- fan-out query merge/dedupe is implemented at `/api/v1/vector/fanout`
- cost estimation is implemented at `/api/v1/vector/cost-estimate`

## Verification
- bunx tsc --noEmit
- bun test tests/http/vector/
- changed files checked <= 250 lines

Refs #1440
