### PR TITLE
feat: add Studio vector API helpers

### DIFF
--- a/frontend/src/api/oracle.ts
+++ b/frontend/src/api/oracle.ts
@@ -7,10 +7,91 @@ declare global {
   }
 }
 
+export type VectorProvider = {
+  type: string;
+  available: boolean;
+  configured?: boolean;
+  status?: string;
+  models?: string[];
+  capabilities?: string[];
+  error?: string;
+};
+
+export type VectorProviderTestConfig = {
+  provider: string;
+  model?: string;
+  url?: string;
+  dimensions?: number;
+  text?: string;
+};
+
+export type VectorProviderTestResult = {
+  success: boolean;
+  provider: string;
+  dimensions?: number;
+  model?: string;
+  error?: string;
+};
+
+export type VectorService = {
+  name: string;
+  type: 'builtin' | 'proxy';
+  endpoint?: string;
+  capabilities?: Record<string, unknown>;
+  health?: VectorHealthStatus;
+};
+
+export type VectorHealthStatus = {
+  status: string;
+  checkedAt?: string;
+  success?: boolean;
+  error?: string;
+};
+
 export function isTauri(): boolean {
   return typeof window !== 'undefined' && '__TAURI__' in window;
 }
 
 export function apiUrl(path: string): string {
   return API_BASE ? new URL(path, API_BASE).toString() : path;
+}
+
+async function fetchJson<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const response = await fetch(apiUrl(path), {
+    ...init,
+    headers: { accept: 'application/json', 'content-type': 'application/json', ...(init.headers ?? {}) },
+  });
+  const text = await response.text();
+  const payload = text ? JSON.parse(text) as unknown : {};
+  if (!response.ok) {
+    const error = typeof payload === 'object' && payload && 'error' in payload ? String(payload.error) : response.statusText;
+    throw new Error(`${path} returned ${response.status}: ${error}`);
+  }
+  return payload as T;
+}
+
+export async function getVectorProviders(): Promise<VectorProvider[]> {
+  const body = await fetchJson<{ providers?: VectorProvider[] }>('/api/v1/vector/providers');
+  return body.providers ?? [];
+}
+
+export function testVectorProvider(config: VectorProviderTestConfig): Promise<VectorProviderTestResult> {
+  return fetchJson('/api/v1/vector/providers/test', { method: 'POST', body: JSON.stringify(config) });
+}
+
+export async function getVectorServices(): Promise<VectorService[]> {
+  const body = await fetchJson<{ services?: VectorService[] }>('/api/v1/vector/services');
+  return body.services ?? [];
+}
+
+export async function registerVectorService(service: VectorService): Promise<void> {
+  await fetchJson('/api/v1/vector/services/register', { method: 'POST', body: JSON.stringify(service) });
+}
+
+export async function unregisterVectorService(name: string): Promise<void> {
+  await fetchJson(`/api/v1/vector/services/${encodeURIComponent(name)}`, { method: 'DELETE' });
+}
+
+export function testVectorService(name: string): Promise<VectorHealthStatus> {
+  return fetchJson(`/api/v1/vector/services/${encodeURIComponent(name)}/test`, { method: 'POST' });
 }

--- a/tests/http/vector/oracle-api-client.test.ts
+++ b/tests/http/vector/oracle-api-client.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, expect, test } from 'bun:test';
+import {
+  getVectorProviders,
+  getVectorServices,
+  registerVectorService,
+  testVectorProvider,
+  testVectorService,
+  unregisterVectorService,
+} from '../../../frontend/src/api/oracle.ts';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => { globalThis.fetch = originalFetch; });
+
+function mockFetch(handler: (url: string, init?: RequestInit) => unknown) {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const body = handler(String(input), init);
+    return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } });
+  }) as typeof fetch;
+}
+
+test('Studio vector API helpers call provider endpoints', async () => {
+  const calls: Array<{ url: string; method: string; body?: string }> = [];
+  mockFetch((url, init) => {
+    calls.push({ url, method: init?.method ?? 'GET', body: init?.body as string | undefined });
+    if (url.endsWith('/providers')) return { providers: [{ type: 'gemini', available: true }] };
+    return { success: true, provider: 'gemini', dimensions: 768 };
+  });
+
+  await expect(getVectorProviders()).resolves.toEqual([{ type: 'gemini', available: true }]);
+  await expect(testVectorProvider({ provider: 'gemini', text: 'hello' })).resolves.toMatchObject({ success: true });
+  expect(calls.map((call) => `${call.method} ${call.url}`)).toEqual([
+    'GET /api/v1/vector/providers',
+    'POST /api/v1/vector/providers/test',
+  ]);
+});
+
+test('Studio vector API helpers call service registry endpoints', async () => {
+  const calls: Array<{ url: string; method: string }> = [];
+  mockFetch((url, init) => {
+    calls.push({ url, method: init?.method ?? 'GET' });
+    if (url.endsWith('/services')) return { services: [{ name: 'qdrant', type: 'proxy' }] };
+    if (url.endsWith('/test')) return { status: 'up', success: true };
+    return { success: true };
+  });
+
+  await expect(getVectorServices()).resolves.toEqual([{ name: 'qdrant', type: 'proxy' }]);
+  await expect(registerVectorService({ name: 'qdrant', type: 'proxy', endpoint: 'http://qdrant' })).resolves.toBeUndefined();
+  await expect(testVectorService('qdrant')).resolves.toMatchObject({ status: 'up' });
+  await expect(unregisterVectorService('qdrant')).resolves.toBeUndefined();
+  expect(calls.map((call) => `${call.method} ${call.url}`)).toEqual([
+    'GET /api/v1/vector/services',
+    'POST /api/v1/vector/services/register',
+    'POST /api/v1/vector/services/qdrant/test',
+    'DELETE /api/v1/vector/services/qdrant',
+  ]);
+});


### PR DESCRIPTION
## Summary
- Added typed Studio API helpers for vector provider detection/testing.
- Added typed Studio API helpers for vector service list/register/test/unregister.
- Covered the helpers with scoped vector HTTP regression tests.

## Existing UI on alpha
- `frontend/src/pages/VectorSettingsPage.tsx`
- `frontend/src/pages/IndexManagerPanel.tsx`
- `frontend/src/pages/FirstRunWizard.tsx`

## Tests
- `bunx tsc --noEmit`
- `bun test tests/http/vector/`

Refs #1439
