### PR TITLE
feat: unified plugin backend surface UI (#1484)

### DIFF
--- a/frontend/src/pages/PluginsPage.tsx
+++ b/frontend/src/pages/PluginsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { apiClient, type ApiClient } from '../api/client';
 import { setPluginEnabled } from '../api/plugin-admin';
 import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
+import { VectorSearchWidget } from '../components/VectorSearchWidget';
 import { pluginStatusLabel, isPluginEnabled, type PluginEnabledState } from '../components/PluginList';
 import { surfacesFor } from '../plugin-surfaces';
 import type { PluginEntry } from '../types';
@@ -223,6 +224,8 @@ export function PluginsPage({ plugins: initialPlugins = [], loading = true, clie
       </section>
 
       {isLoading || state === 'error' ? null : <UnifiedPluginSurfaceOverview plugins={plugins} />}
+
+      {isLoading || state === 'error' ? null : <VectorSearchWidget />}
 
       {isLoading || state === 'error' ? null : (
         <section className="grid gap-5 xl:grid-cols-[minmax(0,1.5fr)_minmax(320px,0.8fr)]">

--- a/frontend/src/pages/UnifiedPluginSurfaceOverview.tsx
+++ b/frontend/src/pages/UnifiedPluginSurfaceOverview.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { fetchMcpTools, fetchMenu, fetchSettingsSystem, fetchVectorConfig } from '../api';
 import { apiClient } from '../api/client';
 import { surfacesFor } from '../plugin-surfaces';
-import type { MenuItem, PluginEntry, SettingsSystemResponse, VectorConfigResponse, McpTool } from '../types';
+import type { McpTool, MenuItem, PluginEntry, SettingsSystemResponse, VectorConfigResponse } from '../types';
 import type { HealthResponse } from '../../../src/server/types';
 
 type SurfaceState = {
@@ -42,6 +42,16 @@ function buildCards(plugins: PluginEntry[], state: SurfaceState): Card[] {
   ];
 }
 
+export function pluginServerRows(plugins: PluginEntry[]): Array<{ name: string; status: string; health: string }> {
+  return plugins
+    .filter((plugin) => plugin.server || plugin.proxy?.length)
+    .map((plugin) => ({
+      name: plugin.name,
+      status: plugin.status ?? 'ok',
+      health: plugin.server?.healthPath ?? plugin.proxy?.[0]?.path ?? 'proxy route',
+    }));
+}
+
 export function UnifiedPluginSurfaceOverview({ plugins }: { plugins: PluginEntry[] }) {
   const [state, setState] = useState<SurfaceState>({ menu: [], tools: [], settings: null, vector: null, health: null });
   const [error, setError] = useState('');
@@ -66,6 +76,7 @@ export function UnifiedPluginSurfaceOverview({ plugins }: { plugins: PluginEntry
 
   const cards = useMemo(() => buildCards(plugins, state), [plugins, state]);
   const counts = useMemo(() => countBySurface(plugins), [plugins]);
+  const servers = useMemo(() => pluginServerRows(plugins), [plugins]);
 
   return (
     <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="unified-surfaces-title">
@@ -78,8 +89,12 @@ export function UnifiedPluginSurfaceOverview({ plugins }: { plugins: PluginEntry
         <p className="text-sm text-slate-500">{Object.entries(counts).map(([k, v]) => `${k} ${v}`).join(' · ') || 'metadata only'}</p>
       </div>
       {error ? <p className="mb-3 text-sm text-amber-200">{error}</p> : null}
-      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-        {cards.map((card) => <SurfaceCard key={card.label} card={card} />)}
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">{cards.map((card) => <SurfaceCard key={card.label} card={card} />)}</div>
+      <div className="mt-4 grid gap-3 xl:grid-cols-4">
+        <SurfaceList title="Menu items" items={state.menu.slice(0, 5).map((item) => `${item.label} → ${item.path}`)} empty="No /api/menu items loaded yet." />
+        <SurfaceList title="MCP tools" items={state.tools.slice(0, 5).map((tool) => `${tool.name}${tool.plugin ? ` · ${tool.plugin}` : ''}`)} empty="No /api/mcp/tools entries loaded yet." />
+        <SurfaceList title="Plugin servers" items={servers.map((server) => `${server.name} · ${server.status} · ${server.health}`)} empty="No plugin server or proxy surfaces." />
+        <SurfaceList title="Storage" items={[state.settings ? `${state.settings.storage.activeBackend} · ${formatPath(state.settings.storage.dbPath)}` : 'Storage config not loaded yet.']} empty="Storage config not loaded yet." />
       </div>
     </section>
   );
@@ -88,4 +103,14 @@ export function UnifiedPluginSurfaceOverview({ plugins }: { plugins: PluginEntry
 function SurfaceCard({ card }: { card: Card }) {
   const tone = card.tone === 'warn' ? 'text-amber-100' : 'text-teal-100';
   return <article className="rounded-2xl border border-white/10 bg-white/[0.03] p-4"><p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{card.label}</p><p className={`mt-2 text-2xl font-semibold ${tone}`}>{card.value}</p><p className="mt-2 text-sm leading-6 text-slate-400">{card.detail}</p></article>;
+}
+
+function SurfaceList({ title, items, empty }: { title: string; items: string[]; empty: string }) {
+  const visible = items.filter(Boolean);
+  return (
+    <article className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{title}</p>
+      {visible.length ? <ul className="mt-3 space-y-2 text-sm text-slate-300">{visible.map((item) => <li key={item} className="truncate font-mono">{item}</li>)}</ul> : <p className="mt-3 text-sm text-slate-500">{empty}</p>}
+    </article>
+  );
 }

--- a/tests/frontend/pages/plugins-page-admin.test.tsx
+++ b/tests/frontend/pages/plugins-page-admin.test.tsx
@@ -13,5 +13,6 @@ describe('PluginsPage admin view', () => {
     expect(html).toContain('1.2.3');
     expect(html).toContain('ok');
     expect(html).toContain('Disable canvas');
+    expect(html).toContain('Vector search');
   });
 });

--- a/tests/frontend/pages/unified-plugin-overview.test.tsx
+++ b/tests/frontend/pages/unified-plugin-overview.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test';
+import { UnifiedPluginSurfaceOverview, pluginServerRows } from '../../../frontend/src/pages/UnifiedPluginSurfaceOverview';
+import { htmlFor } from '../_render';
+
+describe('UnifiedPluginSurfaceOverview', () => {
+  test('renders plugin server and proxy management details', () => {
+    const plugins = [{
+      name: 'echo',
+      file: '',
+      size: 0,
+      modified: 'now',
+      status: 'ok',
+      server: { command: 'bun', healthPath: '/health' },
+      proxy: [{ path: '/api/plugins/echo/server', targetEnv: 'ECHO_URL' }],
+    }];
+
+    expect(pluginServerRows(plugins)).toEqual([{ name: 'echo', status: 'ok', health: '/health' }]);
+    const html = htmlFor(<UnifiedPluginSurfaceOverview plugins={plugins} />);
+    expect(html).toContain('Menu items');
+    expect(html).toContain('MCP tools');
+    expect(html).toContain('Plugin servers');
+    expect(html).toContain('echo · ok · /health');
+  });
+});


### PR DESCRIPTION
Closes #1484

## Changes
- Expand the Plugins page into a unified backend surface dashboard
- Show menu, MCP tool, plugin server/proxy, storage, vector, and health surface summaries
- Add vector search directly to the plugin management page
- Add regression coverage for unified plugin surface rendering

## Test
- bunx tsc --noEmit: green
- bun test tests/frontend/pages/plugins-page-admin.test.tsx tests/frontend/pages/plugins-page-ready.test.tsx tests/frontend/pages/plugins-page-loading.test.tsx tests/frontend/pages/unified-plugin-overview.test.tsx tests/frontend/components/vector-search-widget-labels.test.tsx: passed