### PR TITLE
fix(plugins): label plugin error containment honestly (#1597)

### DIFF
--- a/src/plugins/error-containment.ts
+++ b/src/plugins/error-containment.ts
@@ -1,0 +1,44 @@
+/**
+ * Plugin error containment.
+ *
+ * Catches plugin exceptions and reports them; this does NOT provide process
+ * isolation, VM boundaries, or any security boundary.
+ */
+import { pluginEventBus, type PluginErrorPhase, type PluginEventBus } from './event-bus.ts';
+
+export interface PluginErrorContainmentOptions {
+  plugin: string;
+  phase: PluginErrorPhase;
+  eventBus?: Pick<PluginEventBus, 'emit'>;
+}
+
+export type PluginErrorContainmentResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: string; cause: unknown };
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** Catches plugin exceptions; does NOT provide process isolation. */
+export async function runPluginWithErrorContainment<T>(
+  options: PluginErrorContainmentOptions,
+  operation: () => T | Promise<T>,
+): Promise<PluginErrorContainmentResult<T>> {
+  try {
+    return { ok: true, value: await operation() };
+  } catch (error) {
+    const message = errorMessage(error);
+    try {
+      await (options.eventBus ?? pluginEventBus).emit('plugin:error', {
+        plugin: options.plugin,
+        phase: options.phase,
+        error,
+        message,
+      });
+    } catch {
+      // Event observers must not turn a contained plugin failure into a server failure.
+    }
+    return { ok: false, error: message, cause: error };
+  }
+}

--- a/src/plugins/export-format-init.ts
+++ b/src/plugins/export-format-init.ts
@@ -1,7 +1,7 @@
 import { pathToFileURL } from 'node:url';
 
 import { registerExportFormat, type ExportFormatter } from '../vector/export-formats.ts';
-import { runPluginSandbox } from './sandbox.ts';
+import { runPluginWithErrorContainment } from './error-containment.ts';
 import type { NormalizedUnifiedPluginManifest } from './unified-manifest.ts';
 
 interface ExportFormatPlugin {
@@ -40,7 +40,7 @@ export async function registerPluginExportFormats(
   timeoutMs: number,
 ): Promise<string | undefined> {
   for (const format of plugin.manifest.exportFormats) {
-    const result = await runPluginSandbox({
+    const result = await runPluginWithErrorContainment({
       plugin: plugin.manifest.name,
       phase: 'init',
     }, () => invokeFormat(plugin, format.name, format.handler, timeoutMs));

--- a/src/plugins/sandbox.ts
+++ b/src/plugins/sandbox.ts
@@ -1,44 +1,9 @@
 /**
- * Error Containment.
- *
- * Catches plugin exceptions and reports them; this does NOT provide process
- * isolation, VM boundaries, or any security boundary.
+ * @deprecated Use error-containment.ts. This module is NOT a sandbox or
+ * security boundary; it only preserves the legacy import path.
  */
-import { pluginEventBus, type PluginErrorPhase, type PluginEventBus } from './event-bus.ts';
-
-export interface PluginSandboxOptions {
-  plugin: string;
-  phase: PluginErrorPhase;
-  eventBus?: Pick<PluginEventBus, 'emit'>;
-}
-
-export type PluginSandboxResult<T> =
-  | { ok: true; value: T }
-  | { ok: false; error: string; cause: unknown };
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
-/** Error containment wrapper — catches plugin exceptions, does NOT provide process isolation. */
-export async function runPluginSandbox<T>(
-  options: PluginSandboxOptions,
-  operation: () => T | Promise<T>,
-): Promise<PluginSandboxResult<T>> {
-  try {
-    return { ok: true, value: await operation() };
-  } catch (error) {
-    const message = errorMessage(error);
-    try {
-      await (options.eventBus ?? pluginEventBus).emit('plugin:error', {
-        plugin: options.plugin,
-        phase: options.phase,
-        error,
-        message,
-      });
-    } catch {
-      // Event observers must not turn a contained plugin failure into a server failure.
-    }
-    return { ok: false, error: message, cause: error };
-  }
-}
+export {
+  runPluginWithErrorContainment as runPluginSandbox,
+  type PluginErrorContainmentOptions as PluginSandboxOptions,
+  type PluginErrorContainmentResult as PluginSandboxResult,
+} from './error-containment.ts';

--- a/src/plugins/unified-loader.ts
+++ b/src/plugins/unified-loader.ts
@@ -6,7 +6,7 @@ import { Elysia } from 'elysia';
 import { normalizeUnifiedPluginManifest, type NormalizedUnifiedPluginManifest, type UnifiedApiRouteManifest, type UnifiedCliSubcommandManifest, type UnifiedMcpToolManifest, type UnifiedMenuManifest } from './unified-manifest.ts';
 import { sortPluginsByDependencies } from './dependency-resolver.ts';
 import { pluginRegistryFromLoadedPlugins, type LoadedPluginRegistryEntry } from './registry.ts';
-import { runPluginSandbox } from './sandbox.ts';
+import { runPluginWithErrorContainment } from './error-containment.ts';
 import { createUnifiedProxyRoute } from './proxy-surface.ts';
 import { unifiedPluginServerRoutes, type UnifiedPluginServer } from './unified-server.ts';
 import { resolveContainedPluginEntry } from './path-containment.ts';
@@ -107,7 +107,7 @@ export async function discoverUnifiedPluginManifests(
 
 async function invoke(plugin: LoadedUnifiedPlugin, handler: string | undefined, ctx: InvokeContext, timeoutMs: number) {
   if (!handler) return { ok: true, plugin: plugin.manifest.name, source: ctx.source };
-  const result = await runPluginSandbox({
+  const result = await runPluginWithErrorContainment({
     plugin: plugin.manifest.name,
     phase: ctx.source === 'init' || ctx.source === 'destroy' ? ctx.source : 'runtime',
   }, async () => {

--- a/tests/plugins/sandbox.test.ts
+++ b/tests/plugins/sandbox.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { PluginEventBus, type PluginEventMap } from "../../src/plugins/event-bus.ts";
+import { runPluginWithErrorContainment } from "../../src/plugins/error-containment.ts";
 import { runPluginSandbox } from "../../src/plugins/sandbox.ts";
 
-describe("runPluginSandbox", () => {
+describe("plugin error containment", () => {
   test("returns plugin failures and emits plugin:error without throwing", async () => {
     const bus = new PluginEventBus();
     const events: PluginEventMap["plugin:error"][] = [];
@@ -10,8 +11,8 @@ describe("runPluginSandbox", () => {
       events.push(event);
     });
 
-    const success = await runPluginSandbox({ plugin: "ok-plugin", phase: "runtime", eventBus: bus }, () => "ok");
-    const failure = await runPluginSandbox({ plugin: "bad-plugin", phase: "init", eventBus: bus }, () => {
+    const success = await runPluginWithErrorContainment({ plugin: "ok-plugin", phase: "runtime", eventBus: bus }, () => "ok");
+    const failure = await runPluginWithErrorContainment({ plugin: "bad-plugin", phase: "init", eventBus: bus }, () => {
       throw new Error("boom");
     });
     const throwingBus = {
@@ -19,7 +20,7 @@ describe("runPluginSandbox", () => {
         throw new Error("observer failed");
       },
     } as Pick<PluginEventBus, "emit">;
-    const observerFailure = await runPluginSandbox({ plugin: "observer-plugin", phase: "destroy", eventBus: throwingBus }, () => {
+    const observerFailure = await runPluginWithErrorContainment({ plugin: "observer-plugin", phase: "destroy", eventBus: throwingBus }, () => {
       throw "plain failure";
     });
 
@@ -29,5 +30,10 @@ describe("runPluginSandbox", () => {
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({ plugin: "bad-plugin", phase: "init", message: "boom" });
     expect(events[0].error).toBeInstanceOf(Error);
+  });
+
+  test("keeps the legacy sandbox export as a compatibility alias", async () => {
+    await expect(runPluginSandbox({ plugin: "legacy", phase: "runtime" }, () => "ok"))
+      .resolves.toEqual({ ok: true, value: "ok" });
   });
 });


### PR DESCRIPTION
## Summary
- Completes the remaining #1597 sandbox-label hardening by moving plugin failure handling into an honest `error-containment` module.
- Keeps `sandbox.ts` as a deprecated compatibility alias so existing callers do not break.
- Updates unified plugin runtime/export-format paths to use the error-containment name directly.
- Adds test coverage for the new error-containment import and legacy alias.

## Existing #1597 coverage verified on alpha
- `/api/health` returns direct 200 without version redirect.
- `LOG_FORMAT` supports JSON/short logging coverage.
- Plugin entry path containment rejects traversal/symlink escapes.

## Validation
- `bunx tsc --noEmit`
- `bun test tests/http/health tests/http/logging tests/plugins/sandbox.test.ts tests/plugins/path-containment.test.ts`
