### PR TITLE
feat: canvas plugin hot-swap picker (#950)

### DIFF
--- a/src/workers/canvas/render.ts
+++ b/src/workers/canvas/render.ts
@@ -12,15 +12,27 @@ function titleFor(plugin: CanvasPlugin): string {
   return `Oracle ${plugin.label} Canvas`;
 }
 
-function pluginLinks(): string {
+function pluginUrl(id: string): string {
+  return id === 'map' || id === 'planets' ? `/${id}` : `/?plugin=${id}`;
+}
+
+function pluginLinks(current: string): string {
   return listCanvasPlugins().map((plugin) => {
-    const href = plugin.id === 'map' || plugin.id === 'planets' ? `/${plugin.id}` : `/?plugin=${plugin.id}`;
-    return `<a href="${href}"${plugin.id === DEFAULT_PLUGIN ? ' aria-current="page"' : ''}>${plugin.label}</a>`;
+    const currentAttr = plugin.id === current ? ' aria-current="page"' : '';
+    return `<a href="${pluginUrl(plugin.id)}" data-plugin-link="${plugin.id}"${currentAttr}>${plugin.label}</a>`;
+  }).join('');
+}
+
+function pluginOptions(current: string): string {
+  return listCanvasPlugins().map((plugin) => {
+    const selected = plugin.id === current ? ' selected' : '';
+    return `<option value="${plugin.id}"${selected}>${plugin.label} · ${plugin.kind}</option>`;
   }).join('');
 }
 
 export function renderCanvasApp(plugin: CanvasPlugin, apiBase: string): string {
   const id = plugin.id;
+  const plugins = listCanvasPlugins().map((item) => ({ id: item.id, label: item.label, kind: item.kind, href: pluginUrl(item.id) }));
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -33,17 +45,17 @@ body{margin:0;min-height:100vh;background:radial-gradient(circle at top,#164e63 
 header{position:fixed;inset:1rem 1rem auto;z-index:2;display:grid;gap:.8rem;padding:1rem 1.25rem;border:1px solid rgb(255 255 255/.12);border-radius:1.25rem;background:rgb(2 6 23/.72);backdrop-filter:blur(18px)}
 .top{display:flex;align-items:center;justify-content:space-between;gap:1rem}nav{display:flex;flex-wrap:wrap;gap:.4rem}a{color:#99f6e4;text-decoration:none;border:1px solid rgb(45 212 191/.25);border-radius:999px;padding:.3rem .55rem;font-size:.75rem}h1{margin:0;font-size:clamp(1.2rem,2.5vw,2rem)}
 p{margin:.25rem 0 0;color:#94a3b8}.pill{border:1px solid rgb(45 212 191/.4);border-radius:999px;padding:.45rem .75rem;color:#99f6e4;font-weight:700}
-canvas{display:block;width:100vw;height:100vh}.error{position:fixed;left:1rem;right:1rem;bottom:1rem;color:#fecaca}
+.picker{display:flex;flex-wrap:wrap;gap:.5rem;align-items:center}.picker label{font-size:.75rem;color:#94a3b8}.picker select{border:1px solid rgb(45 212 191/.28);border-radius:.8rem;background:#020617;color:#e2e8f0;padding:.45rem .65rem}canvas{display:block;width:100vw;height:100vh}.error{position:fixed;left:1rem;right:1rem;bottom:1rem;color:#fecaca}
 </style>
 </head>
 <body data-plugin="${id}" data-kind="${plugin.kind}" data-api-base="${apiBase}">
-<header><div class="top"><div><h1>${titleFor(plugin)}</h1><p>canvas.buildwithoracle.com · plugin=${id} · ${plugin.kind}</p></div><span class="pill" id="status">loading API</span></div><nav aria-label="Canvas plugins">${pluginLinks()}</nav></header>
+<header><div class="top"><div><h1 id="canvas-title">${titleFor(plugin)}</h1><p id="canvas-subtitle">canvas.buildwithoracle.com · plugin=${id} · ${plugin.kind}</p></div><span class="pill" id="status">loading API</span></div><div class="picker"><label for="plugin-picker">Hot-swap plugin</label><select id="plugin-picker" aria-label="Hot-swap canvas plugin">${pluginOptions(id)}</select></div><nav aria-label="Canvas plugins">${pluginLinks(id)}</nav></header>
 <canvas id="oracle-canvas" aria-label="${id} canvas visualization"></canvas><p class="error" id="error"></p>
 <script type="module">
-const plugin=${JSON.stringify(id)};const apiBase=${JSON.stringify(apiBase)};const canvas=document.querySelector('canvas');const ctx=canvas.getContext('2d');
-const status=document.getElementById('status');const error=document.getElementById('error');let t=0;
+const plugins=${JSON.stringify(plugins)};let plugin=${JSON.stringify(id)};const apiBase=${JSON.stringify(apiBase)};const canvas=document.querySelector('canvas');const ctx=canvas.getContext('2d');
+const status=document.getElementById('status');const error=document.getElementById('error');const picker=document.getElementById('plugin-picker');const title=document.getElementById('canvas-title');const subtitle=document.getElementById('canvas-subtitle');let t=0;
 function resize(){canvas.width=innerWidth*devicePixelRatio;canvas.height=innerHeight*devicePixelRatio;ctx.setTransform(devicePixelRatio,0,0,devicePixelRatio,0,0)}addEventListener('resize',resize);resize();
-function dot(x,y,r,c){ctx.beginPath();ctx.fillStyle=c;ctx.arc(x,y,r,0,Math.PI*2);ctx.fill()}
+function setPlugin(next,replace=false){const meta=plugins.find((item)=>item.id===next);if(!meta)return;plugin=meta.id;document.body.dataset.plugin=plugin;document.body.dataset.kind=meta.kind;picker.value=plugin;title.textContent='Oracle '+meta.label+' Canvas';subtitle.textContent='canvas.buildwithoracle.com · plugin='+meta.id+' · '+meta.kind;document.querySelectorAll('[data-plugin-link]').forEach((a)=>a.toggleAttribute('aria-current',a.dataset.pluginLink===plugin));if(!replace)history.pushState({plugin},'',meta.href)}picker.addEventListener('change',()=>setPlugin(picker.value));addEventListener('popstate',()=>{const path=location.pathname.slice(1);const query=new URLSearchParams(location.search).get('plugin');setPlugin(query||path||'wave',true)});function dot(x,y,r,c){ctx.beginPath();ctx.fillStyle=c;ctx.arc(x,y,r,0,Math.PI*2);ctx.fill()}
 function star(i){dot((i*97+t*200)%innerWidth,(i*53)%innerHeight,1+(i%4),'#e0f2fe')}
 function draw(){t+=.012;ctx.clearRect(0,0,innerWidth,innerHeight);ctx.fillStyle='#020617';ctx.fillRect(0,0,innerWidth,innerHeight);if(plugin==='cube'||plugin==='torus'){ctx.strokeStyle=plugin==='cube'?'#5eead4':'#c4b5fd';ctx.lineWidth=4;ctx.strokeRect(innerWidth/2-90,innerHeight/2-90,180,180);ctx.strokeRect(innerWidth/2-45+Math.sin(t)*40,innerHeight/2-45,90,90)}else if(plugin==='galaxy'){for(let i=0;i<120;i++)star(i)}else if(plugin==='solar'||plugin==='planets'){for(let i=0;i<9;i++){const a=t+i*.72;dot(innerWidth/2+Math.cos(a)*(70+i*26),innerHeight/2+Math.sin(a)*(35+i*14),6+i*.7,i%2?'#67e8f9':'#c4b5fd')}}else if(plugin==='map'||plugin==='map3d'||plugin==='graph3d'){for(let i=0;i<45;i++)dot((i*97)%innerWidth,(Math.sin(t+i)*120+innerHeight/2),3,'#2dd4bf');ctx.strokeStyle='#22d3ee66';ctx.strokeRect(innerWidth*.16,innerHeight*.24,innerWidth*.68,innerHeight*.52)}else{ctx.strokeStyle='#5eead4';ctx.lineWidth=3;ctx.beginPath();for(let x=0;x<innerWidth;x+=8){const y=innerHeight/2+Math.sin(x*.018+t*4)*90;ctx[x?'lineTo':'moveTo'](x,y)}ctx.stroke()}requestAnimationFrame(draw)}draw();
 fetch('/api/health').then(r=>{status.textContent=r.ok?'API online':'API '+r.status}).catch(e=>{status.textContent='API offline';error.textContent=String(e)});

--- a/tests/workers/canvas-worker.test.ts
+++ b/tests/workers/canvas-worker.test.ts
@@ -20,6 +20,17 @@ describe('canvas Cloudflare Worker', () => {
     expect(await cube.text()).toContain('plugin=cube');
   });
 
+
+  test('renders hot-swap picker with selected plugin state', async () => {
+    const response = await handleCanvasRequest(new Request('https://canvas.buildwithoracle.com/planets'));
+    const html = await response.text();
+
+    expect(html).toContain('aria-label="Hot-swap canvas plugin"');
+    expect(html).toContain('<option value="planets" selected>Planets · react</option>');
+    expect(html).toContain('data-plugin-link="planets" aria-current="page"');
+    expect(html).toContain('history.pushState');
+  });
+
   test('falls back to wave for unknown plugins', async () => {
     const response = await handleCanvasRequest(new Request('https://canvas.buildwithoracle.com/?plugin=unknown'));
     expect(await response.text()).toContain('plugin=wave');


### PR DESCRIPTION
Closes part of #950

## Changes
- Add a hot-swap plugin picker to the canvas.buildwithoracle.com worker shell
- Preserve query and clean path plugin URLs while updating history on picker changes
- Mark the active plugin link correctly for query/path-selected plugins
- Add worker regression coverage for selected picker state and client-side hot-swap behavior

## Test
- bunx tsc --noEmit: green
- bun test tests/workers/canvas-worker.test.ts tests/http/canvas-worker.test.ts tests/canvas/phase2.test.ts tests/plugins/canvas-registry.test.ts: passed