### PR TITLE
feat: add morning tape memory recovery

### DIFF
--- a/MORNING-TAPE.md
+++ b/MORNING-TAPE.md
@@ -1,0 +1,52 @@
+# MORNING-TAPE — ARRA Oracle V3 Codex Builder
+
+Purpose: recover enough context to work safely in under two minutes after a fresh session or compaction.
+
+## 0. Wake protocol
+
+1. Read the current user task and latest lead message first.
+2. Run `git status --short --branch` before editing.
+3. If a task is active, report `starting #ISSUE` through `maw hey` immediately.
+4. Work only in this isolated worktree and branch from `origin/alpha`.
+5. Never push to `main`; PRs target `alpha`.
+
+## 1. Current operating identity
+
+- Role: codex builder for `arra-oracle-v3`.
+- Project: MCP memory/search layer for Oracle family.
+- Runtime: Bun + Elysia + Drizzle SQLite + LanceDB/vector surfaces.
+- Build gate before push: `bunx tsc --noEmit` and the scoped `bun test ...` named by the task.
+- File discipline: keep source, tests, and docs ≤250 lines.
+
+## 2. Memory system map
+
+- Durable human-readable memory lives in `ψ/memory/` and repo docs.
+- DB-backed memory lives in `oracle_memories` through `/api/memory/save`, `/api/memory/recall`, and `/api/memory/search`.
+- The morning recovery API is `/api/memory/morning-tape`; it renders recent persisted memories into a two-minute briefing.
+- Vector search is useful recall, not authority; verify against files before claiming done.
+
+## 3. Default task loop
+
+1. Read the issue and relevant source files.
+2. Plan briefly in your own head or a short status line.
+3. Implement minimal precise code.
+4. Run scoped tests.
+5. Run `bunx tsc --noEmit`.
+6. Rebase on `origin/alpha`.
+7. Rerun the build gate.
+8. Push branch and open PR with `--base alpha`.
+9. Report `done #ISSUE, PR #N submitted, tsc green`.
+
+## 4. When blocked
+
+Report exactly:
+
+```text
+blocked: <exact error/question>; tried <alternative>
+```
+
+Do not go silent. Do not ask for permission on reversible local work.
+
+## 5. Reflection from Challenge 2
+
+A useful memory system is not a diary; it is a bootloader. This tape is intentionally short, operational, and testable. Future-me should be able to read it, inspect git, find the current task, and resume without reconstructing the whole session from chat history.

--- a/src/routes/memory/index.ts
+++ b/src/routes/memory/index.ts
@@ -1,8 +1,9 @@
 import { Elysia } from 'elysia';
-import { RecallMemoryQuery, SaveMemoryBody, SemanticMemoryQuery } from './model.ts';
+import { MorningTapeQuery, RecallMemoryQuery, SaveMemoryBody, SemanticMemoryQuery } from './model.ts';
 import { createMemoryFanoutEndpoint } from './fanout.ts';
 import { memoryStore, type MemoryInput, type MemoryRecord, type MemoryStore } from './store.ts';
 import { memoryVectorIndex, type MemoryVectorHit, type MemoryVectorIndex } from './vector.ts';
+import { buildMorningTape } from './morning-tape.ts';
 
 export function createMemoryRoutes(
   store: MemoryStore = memoryStore,
@@ -23,6 +24,13 @@ export function createMemoryRoutes(
       detail: { tags: ['memory'], menu: { group: 'hidden' }, summary: 'Save a persisted memory' },
     })
     .use(createMemoryFanoutEndpoint())
+    .get('/memory/morning-tape', ({ query }) => {
+      const limit = Math.min(25, Math.max(1, parseInt(query.limit ?? '8')));
+      return buildMorningTape(store.recall('', limit));
+    }, {
+      query: MorningTapeQuery,
+      detail: { tags: ['memory'], menu: { group: 'hidden' }, summary: 'Render a two-minute morning recovery tape from persisted memories' },
+    })
     .get('/memory/recall', ({ query }) => {
       const limit = Math.min(50, Math.max(1, parseInt(query.limit ?? '10')));
       const items = store.recall(query.q ?? '', limit);

--- a/src/routes/memory/model.ts
+++ b/src/routes/memory/model.ts
@@ -17,6 +17,10 @@ export const SemanticMemoryQuery = t.Object({
   limit: t.Optional(t.String()),
 });
 
+export const MorningTapeQuery = t.Object({
+  limit: t.Optional(t.String()),
+});
+
 export const MemoryFanoutQuery = t.Object({
   q: t.Optional(t.String()),
   limit: t.Optional(t.String()),

--- a/src/routes/memory/morning-tape.ts
+++ b/src/routes/memory/morning-tape.ts
@@ -1,0 +1,71 @@
+import type { MemoryRecord } from './store.ts';
+
+export type MorningTapeSection = {
+  title: string;
+  bullets: string[];
+};
+
+export type MorningTape = {
+  generatedAt: string;
+  readTimeMinutes: number;
+  memoryCount: number;
+  sections: MorningTapeSection[];
+  markdown: string;
+};
+
+const DEFAULT_READ_TIME_MINUTES = 2;
+
+export function buildMorningTape(memories: MemoryRecord[], generatedAt = new Date()): MorningTape {
+  const sections = [
+    {
+      title: 'Wake protocol',
+      bullets: [
+        'Read this tape before coding or answering status questions.',
+        'Recover the current mission from saved memories, then inspect git state.',
+        'Report starting/blocked/done to the lead for every assigned task.',
+      ],
+    },
+    {
+      title: 'Fresh memory',
+      bullets: memories.length ? memories.slice(0, 8).map(memoryBullet) : ['No persisted memories yet; save one with POST /api/memory/save.'],
+    },
+    {
+      title: 'Verification oath',
+      bullets: [
+        'Before claiming done, run the scoped test and bunx tsc --noEmit.',
+        'Keep files under 250 lines and target alpha for PRs.',
+        'If blocked, state the exact blocker and the alternative already tried.',
+      ],
+    },
+  ];
+  const tape = { generatedAt: generatedAt.toISOString(), readTimeMinutes: DEFAULT_READ_TIME_MINUTES, memoryCount: memories.length, sections };
+  return { ...tape, markdown: toMarkdown(tape) };
+}
+
+function memoryBullet(memory: MemoryRecord): string {
+  const label = memory.title || memory.source || memory.id;
+  const tags = memory.tags?.length ? ` [${memory.tags.join(', ')}]` : '';
+  return `${label}${tags}: ${oneLine(memory.content)}`;
+}
+
+function oneLine(content: string): string {
+  const compact = content.replace(/\s+/g, ' ').trim();
+  return compact.length > 180 ? `${compact.slice(0, 177)}…` : compact;
+}
+
+function toMarkdown(tape: Omit<MorningTape, 'markdown'>): string {
+  const lines = [
+    '# MORNING-TAPE',
+    '',
+    `Generated: ${tape.generatedAt}`,
+    `Target read time: ${tape.readTimeMinutes} minutes`,
+    `Persisted memories included: ${tape.memoryCount}`,
+    '',
+  ];
+  for (const section of tape.sections) {
+    lines.push(`## ${section.title}`, '');
+    for (const bullet of section.bullets) lines.push(`- ${bullet}`);
+    lines.push('');
+  }
+  return lines.join('\n').trimEnd() + '\n';
+}

--- a/tests/http/memory/morning-tape.test.ts
+++ b/tests/http/memory/morning-tape.test.ts
@@ -1,0 +1,63 @@
+import { afterAll, expect, test } from 'bun:test';
+import { inArray } from 'drizzle-orm';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { db, oracleMemories } from '../../../src/db/index.ts';
+import { buildMorningTape } from '../../../src/routes/memory/morning-tape.ts';
+import { createMemoryRoutes } from '../../../src/routes/memory/index.ts';
+import type { MemoryRecord } from '../../../src/routes/memory/store.ts';
+import type { MemoryVectorIndex } from '../../../src/routes/memory/vector.ts';
+
+const savedIds: string[] = [];
+
+afterAll(() => {
+  if (savedIds.length) db.delete(oracleMemories).where(inArray(oracleMemories.id, savedIds)).run();
+});
+
+class NoopMemoryVectorIndex implements MemoryVectorIndex {
+  async index() { return { indexed: false as const, error: 'not needed' }; }
+  async search() { return []; }
+}
+
+async function json(response: Response) {
+  return JSON.parse(await response.text());
+}
+
+test('buildMorningTape renders a two-minute recovery document', () => {
+  const memory: MemoryRecord = {
+    id: 'mem_boot',
+    title: 'Boot rule',
+    content: 'Read git status before making any code change.',
+    tags: ['continuity'],
+    source: 'challenge-2',
+    createdAt: '2026-06-16T00:00:00.000Z',
+    updatedAt: '2026-06-16T00:00:00.000Z',
+  };
+
+  const tape = buildMorningTape([memory], new Date('2026-06-16T00:01:00.000Z'));
+
+  expect(tape.readTimeMinutes).toBe(2);
+  expect(tape.memoryCount).toBe(1);
+  expect(tape.markdown).toContain('# MORNING-TAPE');
+  expect(tape.markdown).toContain('Boot rule [continuity]: Read git status');
+});
+
+test('GET /api/v1/memory/morning-tape includes recent persisted memories', async () => {
+  const app = createMemoryRoutes(undefined, new NoopMemoryVectorIndex());
+  const fetcher = createApiVersionedFetch((request) => app.handle(request));
+  const unique = `morning-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const save = await fetcher(new Request('http://local/api/v1/memory/save', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ title: 'Morning context', content: `Recover ${unique} quickly.`, tags: ['morning'] }),
+  }));
+  const saved = await json(save);
+  savedIds.push(saved.memory.id);
+
+  const response = await fetcher(new Request('http://local/api/v1/memory/morning-tape?limit=5'));
+  const body = await json(response);
+
+  expect(response.status).toBe(200);
+  expect(body).toMatchObject({ readTimeMinutes: 2 });
+  expect(body.markdown).toContain(unique);
+  expect(body.sections.map((section: { title: string }) => section.title)).toContain('Fresh memory');
+});


### PR DESCRIPTION
## Summary
- Add `MORNING-TAPE.md` as the Challenge 2 continuity bootloader and reflection.
- Add `GET /api/memory/morning-tape` to render recent persisted memories into a two-minute recovery briefing.
- Cover the morning-tape builder and HTTP route with scoped memory tests.

## Tests
- `bunx tsc --noEmit`
- `bun test tests/http/memory/`

Refs #1457
