### PR TITLE
feat(trace): promote Thor awakenings to learnings (#1030)

### DIFF
--- a/src/routes/traces/distill.ts
+++ b/src/routes/traces/distill.ts
@@ -1,5 +1,6 @@
 import { Elysia, t } from 'elysia';
-import { distillTrace, getTrace } from '../../trace/handler.ts';
+import { distillTraceAwakening } from '../../trace/distill.ts';
+import { getTrace } from '../../trace/handler.ts';
 import { traceIdParam } from './model.ts';
 
 const distillBody = t.Object({
@@ -17,7 +18,7 @@ export const traceDistillRoute = new Elysia().post('/api/traces/:id/distill', ({
     set.status = 404;
     return { error: 'Trace not found' };
   }
-  return distillTrace({
+  return distillTraceAwakening({
     traceId: params.id,
     awakening,
     promoteToLearning: body.promoteToLearning,

--- a/src/trace/distill.ts
+++ b/src/trace/distill.ts
@@ -1,0 +1,50 @@
+import { eq } from 'drizzle-orm';
+import { db, traceLog } from '../db/index.ts';
+import { handleLearn } from '../server/handlers.ts';
+import { getTrace } from './handler.ts';
+import type { DistillTraceInput } from './types.ts';
+
+export type DistillTraceResult = {
+  success: boolean;
+  status: string;
+  learningId?: string;
+  error?: string;
+};
+
+function learningConcepts(traceId: string): string[] {
+  return ['trace-awakening', 'thor-oracle', 'dev-research', `trace-${traceId}`];
+}
+
+export function distillTraceAwakening(input: DistillTraceInput): DistillTraceResult {
+  const trace = getTrace(input.traceId);
+  if (!trace) return { success: false, status: 'not_found', error: 'Trace not found' };
+
+  const learning = input.promoteToLearning
+    ? handleLearn(
+      input.awakening,
+      `Trace awakening ${input.traceId}`,
+      learningConcepts(input.traceId),
+      'thor-oracle',
+      trace.project ?? undefined,
+    )
+    : undefined;
+  const now = Date.now();
+  const update: Partial<typeof traceLog.$inferInsert> = {
+    status: 'distilled',
+    awakening: input.awakening,
+    distilledAt: now,
+    updatedAt: now,
+  };
+  if (learning?.id) update.distilledToId = learning.id;
+
+  db.update(traceLog)
+    .set(update)
+    .where(eq(traceLog.traceId, input.traceId))
+    .run();
+
+  return {
+    success: true,
+    status: 'distilled',
+    learningId: learning?.id,
+  };
+}

--- a/tests/http/traces/routes.test.ts
+++ b/tests/http/traces/routes.test.ts
@@ -120,6 +120,31 @@ describe("Trace routes", () => {
     expect(chain).toMatchObject({ hasAwakening: true, awakeningTraceId: traceA });
   });
 
+  test("POST /api/traces/:id/distill can promote Thor awakening to a learning", async () => {
+    const res = await fetch(`${BASE_URL}/api/traces/${traceB}/distill`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        awakening: "Thor preserves dev research context as a searchable learning.",
+        promoteToLearning: true,
+      }),
+    });
+    expect(res.ok).toBe(true);
+    const body = await res.json();
+    expect(body).toMatchObject({ success: true, status: "distilled" });
+    expect(body.learningId).toContain("learning_");
+
+    const traceRes = await fetch(`${BASE_URL}/api/traces/${traceB}`);
+    const trace = await traceRes.json();
+    expect(trace.distilledToId).toBe(body.learningId);
+
+    const learnRes = await fetch(`${BASE_URL}/api/learn/${body.learningId}`);
+    expect(learnRes.ok).toBe(true);
+    const learning = await learnRes.json();
+    expect(learning.concepts).toContain("thor-oracle");
+    expect(learning.origin).toBe("thor-oracle");
+  });
+
   test("POST /api/traces/:prevId/link without body returns 400", async () => {
     const res = await fetch(`${BASE_URL}/api/traces/${traceA}/link`, {
       method: "POST",


### PR DESCRIPTION
## Summary
- Continues #1030 Thor Oracle Phase 2 after PR #1720 by making `promoteToLearning` functional for trace distillation.
- Distilled awakenings can now persist as searchable Oracle Learn documents with Thor/dev-research concepts.
- Links the source trace back to the promoted learning through `distilledToId` / `learningId`.
- Adds scoped HTTP coverage for the promotion flow.

## Validation
- `bunx tsc --noEmit`
- `bun test tests/http/traces/`
