### PR TITLE
feat: implement multi-tenant HTTP isolation (#1650)

### DIFF
--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -65,6 +65,7 @@ function parseDocument(value: unknown): OracleDocumentInsert {
   const row = asRecord(value, "document");
   return {
     id: requiredString(row, "id"),
+    tenantId: optionalString(row, "tenantId") ?? "default",
     type: requiredString(row, "type"),
     sourceFile: requiredString(row, "sourceFile"),
     concepts: requiredString(row, "concepts"),
@@ -90,6 +91,7 @@ export function parseVaultJsonExport(input: string): OracleDocumentInsert[] {
 
 function updateSet(row: OracleDocumentInsert): Omit<OracleDocumentRow, "id"> {
   return {
+    tenantId: row.tenantId ?? "default",
     type: row.type,
     sourceFile: row.sourceFile,
     concepts: row.concepts,

--- a/src/db/migrations/0022_tenant_isolation.sql
+++ b/src/db/migrations/0022_tenant_isolation.sql
@@ -1,0 +1,36 @@
+CREATE TABLE `tenants` (
+  `id` text PRIMARY KEY NOT NULL,
+  `name` text,
+  `status` text DEFAULT 'active' NOT NULL,
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_tenants_status` ON `tenants` (`status`);
+--> statement-breakpoint
+INSERT INTO `tenants` (`id`, `name`, `status`, `created_at`, `updated_at`)
+VALUES ('default', 'Default tenant', 'active', strftime('%s','now') * 1000, strftime('%s','now') * 1000);
+--> statement-breakpoint
+ALTER TABLE `oracle_documents` ADD COLUMN `tenant_id` text DEFAULT 'default' NOT NULL;
+--> statement-breakpoint
+CREATE INDEX `idx_documents_tenant` ON `oracle_documents` (`tenant_id`);
+--> statement-breakpoint
+ALTER TABLE `search_log` ADD COLUMN `tenant_id` text DEFAULT 'default' NOT NULL;
+--> statement-breakpoint
+CREATE INDEX `idx_search_tenant` ON `search_log` (`tenant_id`);
+--> statement-breakpoint
+ALTER TABLE `learn_log` ADD COLUMN `tenant_id` text DEFAULT 'default' NOT NULL;
+--> statement-breakpoint
+CREATE INDEX `idx_learn_tenant` ON `learn_log` (`tenant_id`);
+--> statement-breakpoint
+ALTER TABLE `document_access` ADD COLUMN `tenant_id` text DEFAULT 'default' NOT NULL;
+--> statement-breakpoint
+CREATE INDEX `idx_access_tenant` ON `document_access` (`tenant_id`);
+--> statement-breakpoint
+ALTER TABLE `forum_threads` ADD COLUMN `tenant_id` text DEFAULT 'default' NOT NULL;
+--> statement-breakpoint
+CREATE INDEX `idx_thread_tenant` ON `forum_threads` (`tenant_id`);
+--> statement-breakpoint
+ALTER TABLE `trace_log` ADD COLUMN `tenant_id` text DEFAULT 'default' NOT NULL;
+--> statement-breakpoint
+CREATE INDEX `idx_trace_tenant` ON `trace_log` (`tenant_id`);

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1781591042651,
       "tag": "0021_add_oracle_memories",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "6",
+      "when": 1781595000000,
+      "tag": "0022_tenant_isolation",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -8,9 +8,16 @@
 import { sql } from 'drizzle-orm';
 import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
 
-// Main document index table
+export const tenants = sqliteTable('tenants', {
+  id: text('id').primaryKey(),
+  name: text('name'),
+  status: text('status').default('active').notNull(),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+}, (table) => [index('idx_tenants_status').on(table.status)]);
 export const oracleDocuments = sqliteTable('oracle_documents', {
   id: text('id').primaryKey(),
+  tenantId: text('tenant_id').default('default').notNull(),
   type: text('type').notNull(),
   sourceFile: text('source_file').notNull(),
   concepts: text('concepts').notNull(), // JSON array
@@ -31,6 +38,7 @@ export const oracleDocuments = sqliteTable('oracle_documents', {
   index('idx_superseded').on(table.supersededBy),
   index('idx_origin').on(table.origin),
   index('idx_project').on(table.project),
+  index('idx_documents_tenant').on(table.tenantId),
 ]);
 
 
@@ -86,6 +94,7 @@ export const indexingJobs = sqliteTable('indexing_jobs', {
 export const searchLog = sqliteTable('search_log', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   query: text('query').notNull(),
+  tenantId: text('tenant_id').default('default').notNull(),
   type: text('type'),
   mode: text('mode'),
   resultsCount: integer('results_count'),
@@ -95,6 +104,7 @@ export const searchLog = sqliteTable('search_log', {
   results: text('results'), // JSON array of top 5 results (id, type, score, snippet)
 }, (table) => [
   index('idx_search_project').on(table.project),
+  index('idx_search_tenant').on(table.tenantId),
   index('idx_search_created').on(table.createdAt),
 ]);
 
@@ -118,6 +128,7 @@ export const consultLog = sqliteTable('consult_log', {
 export const learnLog = sqliteTable('learn_log', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   documentId: text('document_id').notNull(),
+  tenantId: text('tenant_id').default('default').notNull(),
   patternPreview: text('pattern_preview'),
   source: text('source'),
   concepts: text('concepts'), // JSON array
@@ -125,6 +136,7 @@ export const learnLog = sqliteTable('learn_log', {
   project: text('project'),
 }, (table) => [
   index('idx_learn_project').on(table.project),
+  index('idx_learn_tenant').on(table.tenantId),
   index('idx_learn_created').on(table.createdAt),
 ]);
 
@@ -132,23 +144,22 @@ export const learnLog = sqliteTable('learn_log', {
 export const documentAccess = sqliteTable('document_access', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   documentId: text('document_id').notNull(),
+  tenantId: text('tenant_id').default('default').notNull(),
   accessType: text('access_type'),
   createdAt: integer('created_at').notNull(),
   project: text('project'),
 }, (table) => [
   index('idx_access_project').on(table.project),
+  index('idx_access_tenant').on(table.tenantId),
   index('idx_access_created').on(table.createdAt),
   index('idx_access_doc').on(table.documentId),
 ]);
 
-// ============================================================================
-// Forum Tables (threaded discussions with Oracle)
-// ============================================================================
 
-// Forum threads - conversation topics
 export const forumThreads = sqliteTable('forum_threads', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   title: text('title').notNull(),
+  tenantId: text('tenant_id').default('default').notNull(),
   createdBy: text('created_by').default('human'),
   status: text('status').default('active'), // active, answered, pending, closed
   issueUrl: text('issue_url'),              // GitHub mirror URL
@@ -160,10 +171,10 @@ export const forumThreads = sqliteTable('forum_threads', {
 }, (table) => [
   index('idx_thread_status').on(table.status),
   index('idx_thread_project').on(table.project),
+  index('idx_thread_tenant').on(table.tenantId),
   index('idx_thread_created').on(table.createdAt),
 ]);
 
-// Forum messages - individual Q&A in threads
 export const forumMessages = sqliteTable('forum_messages', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   threadId: integer('thread_id').notNull().references(() => forumThreads.id),
@@ -184,18 +195,15 @@ export const forumMessages = sqliteTable('forum_messages', {
 // Note: FTS5 virtual table (oracle_fts) is managed via raw SQL
 // since Drizzle doesn't natively support FTS5
 
-// ============================================================================
 // Trace Log Tables (discovery tracing with dig points)
-// ============================================================================
 
-// Trace log - captures /trace sessions with actionable dig points
 export const traceLog = sqliteTable('trace_log', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   traceId: text('trace_id').unique().notNull(),
+  tenantId: text('tenant_id').default('default').notNull(),
   query: text('query').notNull(),
   queryType: text('query_type').default('general'),  // general, project, pattern, evolution
 
-  // Dig Points (JSON arrays)
   foundFiles: text('found_files'),            // [{path, type, matchReason, confidence}]
   foundCommits: text('found_commits'),        // [{hash, shortHash, date, message}]
   foundIssues: text('found_issues'),          // [{number, title, state, url}]
@@ -203,39 +211,34 @@ export const traceLog = sqliteTable('trace_log', {
   foundLearnings: text('found_learnings'),    // [paths]
   foundResonance: text('found_resonance'),    // [paths]
 
-  // Counts (for quick stats)
   fileCount: integer('file_count').default(0),
   commitCount: integer('commit_count').default(0),
   issueCount: integer('issue_count').default(0),
 
-  // Recursion (hierarchical)
   depth: integer('depth').default(0),         // 0 = initial, 1+ = dig from parent
   parentTraceId: text('parent_trace_id'),     // Links to parent trace
   childTraceIds: text('child_trace_ids').default('[]'),  // Links to child traces
 
-  // Linked list (horizontal chain)
   prevTraceId: text('prev_trace_id'),         // ← Previous trace in chain
   nextTraceId: text('next_trace_id'),         // → Next trace in chain
 
-  // Context
   project: text('project'),                   // ghq format project path
   scope: text('scope').default('project'),    // 'project' | 'cross-project' | 'human'
   sessionId: text('session_id'),              // Claude session if available
   agentCount: integer('agent_count').default(1),
   durationMs: integer('duration_ms'),
 
-  // Distillation
   status: text('status').default('raw'),      // raw, reviewed, distilling, distilled
   awakening: text('awakening'),               // Extracted insight (markdown)
   distilledToId: text('distilled_to_id'),     // Learning ID if promoted
   distilledAt: integer('distilled_at'),
 
-  // Timestamps
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
 }, (table) => [
   index('idx_trace_query').on(table.query),
   index('idx_trace_project').on(table.project),
+  index('idx_trace_tenant').on(table.tenantId),
   index('idx_trace_status').on(table.status),
   index('idx_trace_parent').on(table.parentTraceId),
   index('idx_trace_prev').on(table.prevTraceId),

--- a/src/drizzle-migration.test.ts
+++ b/src/drizzle-migration.test.ts
@@ -44,12 +44,14 @@ beforeAll(() => {
       superseded_reason TEXT,
       origin TEXT,
       project TEXT,
+      tenant_id TEXT NOT NULL DEFAULT 'default',
       created_by TEXT
     );
 
     CREATE INDEX idx_type ON oracle_documents(type);
     CREATE INDEX idx_source ON oracle_documents(source_file);
     CREATE INDEX idx_project ON oracle_documents(project);
+    CREATE INDEX idx_tenant ON oracle_documents(tenant_id);
 
     -- FTS5 virtual table
     CREATE VIRTUAL TABLE oracle_fts USING fts5(

--- a/src/indexer-preservation.test.ts
+++ b/src/indexer-preservation.test.ts
@@ -49,12 +49,14 @@ beforeAll(() => {
       superseded_reason TEXT,
       origin TEXT,
       project TEXT,
+      tenant_id TEXT NOT NULL DEFAULT 'default',
       created_by TEXT
     );
 
     CREATE INDEX idx_type ON oracle_documents(type);
     CREATE INDEX idx_source ON oracle_documents(source_file);
     CREATE INDEX idx_project ON oracle_documents(project);
+    CREATE INDEX idx_tenant ON oracle_documents(tenant_id);
     CREATE INDEX idx_created_by ON oracle_documents(created_by);
 
     -- FTS5 virtual table

--- a/src/indexer/__tests__/learn-watcher.test.ts
+++ b/src/indexer/__tests__/learn-watcher.test.ts
@@ -23,6 +23,7 @@ CREATE TABLE oracle_documents (
   superseded_reason TEXT,
   origin TEXT,
   project TEXT,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
   created_by TEXT
 );
 CREATE VIRTUAL TABLE oracle_fts USING fts5(id UNINDEXED, content, concepts, tokenize='porter unicode61');

--- a/src/middleware/tenant.ts
+++ b/src/middleware/tenant.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
+import path from 'node:path';
 import { timingSafeEqual } from 'node:crypto';
 import { Elysia } from 'elysia';
 import { eq, type SQL } from 'drizzle-orm';
@@ -9,6 +10,7 @@ export const LEGACY_TENANT_HEADER = 'X-Tenant-Id';
 export const ORG_HEADER = 'X-Org-Id';
 const TENANT_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/;
 
+export const DEFAULT_TENANT_ID = 'default';
 type TenantContext = { tenantId?: string };
 type ProjectColumn = { project: unknown };
 type FetchHandler = (request: Request) => Response | Promise<Response>;
@@ -64,6 +66,35 @@ export function tenantIdFor(request: Request): string | undefined {
 
 export function currentTenantId(): string | undefined {
   return tenantStore.getStore()?.tenantId;
+}
+
+export function activeTenantId(): string {
+  return currentTenantId() ?? DEFAULT_TENANT_ID;
+}
+
+export function tenantIdForWrite(): string {
+  return activeTenantId();
+}
+
+export function tenantSql(alias = 'd'): { clause: string; params: string[] } {
+  const tenantId = currentTenantId();
+  return tenantId ? { clause: `AND ${alias}.tenant_id = ?`, params: [tenantId] } : { clause: '', params: [] };
+}
+
+export function withTenantWhere(where?: Record<string, any>): Record<string, any> | undefined {
+  const tenantId = currentTenantId();
+  return tenantId ? { ...(where ?? {}), tenant_id: tenantId } : where;
+}
+
+function safeTenantSegment(tenantId: string): string {
+  return tenantId.replace(/[^a-zA-Z0-9._:-]/g, '_');
+}
+
+export function tenantDataPath(basePath: string): string {
+  const tenantId = currentTenantId();
+  if (!tenantId) return basePath;
+  const root = path.dirname(basePath);
+  return path.join(root, 'tenants', safeTenantSegment(tenantId), path.basename(basePath));
 }
 
 export function runWithTenant<T>(tenantId: string | undefined, callback: () => T): T {

--- a/src/routes/health/oracles.ts
+++ b/src/routes/health/oracles.ts
@@ -61,10 +61,10 @@ export const oraclesEndpoint = new Elysia().get('/oracles', ({ query }) => {
   if (oracleCache && oracleCache.key === cacheKey && (now - oracleCache.ts) < 60_000) return oracleCache.data;
 
   const cutoff = now - hours * 3600_000;
-  const docProjectWhere = tenantId ? 'AND project = ?' : '';
-  const learnProjectWhere = tenantId ? 'AND project = ?' : '';
-  const traceProjectWhere = tenantId ? 'AND project = ?' : '';
-  const forumProjectWhere = tenantId ? 'AND forum_threads.project = ?' : '';
+  const docProjectWhere = tenantId ? 'AND tenant_id = ?' : '';
+  const learnProjectWhere = tenantId ? 'AND tenant_id = ?' : '';
+  const traceProjectWhere = tenantId ? 'AND tenant_id = ?' : '';
+  const forumProjectWhere = tenantId ? 'AND forum_threads.tenant_id = ?' : '';
   const tenantArg = tenantId ? [tenantId] : [];
   const identities = sqlite.prepare(`
     SELECT oracle_name, source, max(last_seen) as last_seen, sum(actions) as actions
@@ -104,7 +104,7 @@ export const oraclesEndpoint = new Elysia().get('/oracles', ({ query }) => {
     total_projects: projects.length,
     total_identities: identities.length,
     window_hours: hours,
-    tenant: tenantId ? { id: tenantId, scope: 'project' } : undefined,
+    tenant: tenantId ? { id: tenantId, scope: 'tenant_id' } : undefined,
     cached_at: new Date().toISOString(),
   };
   oracleCache = { data: result, ts: now, key: cacheKey };

--- a/src/routes/health/tenant-stats.ts
+++ b/src/routes/health/tenant-stats.ts
@@ -6,7 +6,7 @@ export function tenantStats() {
   const tenantId = currentTenantId();
   if (!tenantId) return null;
 
-  const projectScope = eq(oracleDocuments.project, tenantId);
+  const projectScope = eq(oracleDocuments.tenantId, tenantId);
   const total = db.select({ count: count() })
     .from(oracleDocuments)
     .where(projectScope)
@@ -30,6 +30,6 @@ export function tenantStats() {
     by_type: Object.fromEntries(byTypeRows.map((row) => [row.type, row.count])),
     last_indexed: last ? new Date(last).toISOString() : null,
     indexing: Boolean(indexing?.isIndexing),
-    tenant: { id: tenantId, scope: 'project' },
+    tenant: { id: tenantId, scope: 'tenant_id' },
   };
 }

--- a/src/routes/learn/crud.ts
+++ b/src/routes/learn/crud.ts
@@ -5,6 +5,7 @@ import fs from 'fs';
 import path from 'path';
 import { REPO_ROOT } from '../../config.ts';
 import { db, learnLog, oracleDocuments } from '../../db/index.ts';
+import { currentTenantId, tenantIdForWrite } from '../../middleware/tenant.ts';
 type LearnDoc = typeof oracleDocuments.$inferSelect;
 const oracleFts = sqliteTable('oracle_fts', {
   id: text('id'),
@@ -131,8 +132,10 @@ function nextIdentity(pattern: string, requestedId?: string, requestedSourceFile
   }
 }
 function rowById(id: string): LearnDoc | undefined {
+  const tenantId = currentTenantId();
+  const base = and(eq(oracleDocuments.id, id), eq(oracleDocuments.type, 'learning'));
   return db.select().from(oracleDocuments)
-    .where(and(eq(oracleDocuments.id, id), eq(oracleDocuments.type, 'learning')))
+    .where(tenantId ? and(base, eq(oracleDocuments.tenantId, tenantId)) : base)
     .get();
 }
 function responseRow(row: LearnDoc) {
@@ -147,8 +150,10 @@ function createLearning(body: LearnCreateBody) {
   if (rowById(identity.id)) return { status: 409, body: { error: 'Learning already exists' } };
   const content = learningContent(pattern, concepts, body.source);
   writeLearningFile(identity.sourceFile, content);
+  const tenantId = tenantIdForWrite();
   db.insert(oracleDocuments).values({
     id: identity.id,
+    tenantId,
     type: 'learning',
     sourceFile: identity.sourceFile,
     concepts: JSON.stringify(concepts),
@@ -162,6 +167,7 @@ function createLearning(body: LearnCreateBody) {
   upsertFts(identity.id, content, concepts);
   db.insert(learnLog).values({
     documentId: identity.id,
+    tenantId,
     patternPreview: pattern.slice(0, 200),
     source: body.source ?? 'Oracle Learn',
     concepts: JSON.stringify(concepts),
@@ -188,7 +194,8 @@ function updateLearning(id: string, body: LearnUpdateBody) {
   upsertFts(id, content, nextConcepts);
   const row = db.update(oracleDocuments)
     .set(set)
-    .where(and(eq(oracleDocuments.id, id), eq(oracleDocuments.type, 'learning')))
+    .where(and(eq(oracleDocuments.id, id), eq(oracleDocuments.type, 'learning'),
+      ...(currentTenantId() ? [eq(oracleDocuments.tenantId, currentTenantId()!)] : [])))
     .returning()
     .get();
   return { status: 200, body: responseRow(row) };
@@ -204,7 +211,8 @@ function softDeleteLearning(id: string) {
       supersededAt: now,
       supersededReason: existing.supersededReason ?? 'soft-deleted via DELETE /api/learn/:id',
     })
-    .where(and(eq(oracleDocuments.id, id), eq(oracleDocuments.type, 'learning')))
+    .where(and(eq(oracleDocuments.id, id), eq(oracleDocuments.type, 'learning'),
+      ...(currentTenantId() ? [eq(oracleDocuments.tenantId, currentTenantId()!)] : [])))
     .returning()
     .get();
   db.delete(oracleFts).where(eq(oracleFts.id, id)).run();

--- a/src/routes/search/search.ts
+++ b/src/routes/search/search.ts
@@ -5,6 +5,7 @@
 import { Elysia } from 'elysia';
 import { handleSearch } from '../../server/handlers.ts';
 import { SearchQuery } from './model.ts';
+import { handleTenantSearch } from './tenant-search.ts';
 
 export const searchEndpoint = new Elysia().get(
   '/search',
@@ -33,7 +34,8 @@ export const searchEndpoint = new Elysia().get(
     const model = query.model;
 
     try {
-      const result = await handleSearch(sanitizedQ, type, limit, offset, mode, project, cwd, model);
+      const result = handleTenantSearch(sanitizedQ, type, limit, offset)
+        ?? await handleSearch(sanitizedQ, type, limit, offset, mode, project, cwd, model);
       return { ...result, query: sanitizedQ };
     } catch {
       set.status = 400;

--- a/src/routes/search/tenant-search.ts
+++ b/src/routes/search/tenant-search.ts
@@ -1,0 +1,61 @@
+import { sqlite } from '../../db/index.ts';
+import { currentTenantId } from '../../middleware/tenant.ts';
+import type { SearchResponse } from '../../server/types.ts';
+
+function normalizeRank(rank: number): number {
+  return Math.min(1, Math.max(0, 1 / (1 + Math.abs(rank))));
+}
+
+export function handleTenantSearch(
+  query: string,
+  type = 'all',
+  limit = 10,
+  offset = 0,
+): SearchResponse & { mode: string; warning?: string; vectorAvailable: boolean } | null {
+  const tenantId = currentTenantId();
+  if (!tenantId) return null;
+
+  const safeQuery = query
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/[?*+\-()^~"':;<>{}[\]\\/]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!safeQuery) return { results: [], total: 0, limit, offset, query, mode: 'fts', vectorAvailable: false };
+
+  const typeClause = type === 'all' ? '' : 'AND d.type = ?';
+  const params = type === 'all' ? [safeQuery, tenantId] : [safeQuery, type, tenantId];
+  const count = sqlite.prepare(`
+    SELECT COUNT(*) as total
+    FROM oracle_fts f
+    JOIN oracle_documents d ON f.id = d.id
+    WHERE oracle_fts MATCH ? ${typeClause} AND d.tenant_id = ?
+  `).get(...params) as { total: number };
+  const rows = sqlite.prepare(`
+    SELECT f.id, f.content, d.type, d.source_file, d.concepts, d.project, rank as score
+    FROM oracle_fts f
+    JOIN oracle_documents d ON f.id = d.id
+    WHERE oracle_fts MATCH ? ${typeClause} AND d.tenant_id = ?
+    ORDER BY rank
+    LIMIT ? OFFSET ?
+  `).all(...params, limit, offset) as Array<Record<string, any>>;
+
+  return {
+    results: rows.map((row) => ({
+      id: row.id,
+      type: row.type,
+      content: row.content,
+      source_file: row.source_file,
+      concepts: JSON.parse(row.concepts || '[]'),
+      project: row.project,
+      source: 'fts' as const,
+      score: normalizeRank(row.score),
+    })),
+    total: count.total,
+    offset,
+    limit,
+    query,
+    mode: 'fts',
+    vectorAvailable: false,
+    warning: 'Tenant-scoped HTTP search uses SQLite/FTS isolation for this request',
+  };
+}

--- a/src/routes/tenants/index.ts
+++ b/src/routes/tenants/index.ts
@@ -1,0 +1,51 @@
+import { Elysia, t } from 'elysia';
+import { eq } from 'drizzle-orm';
+import { db, tenants } from '../../db/index.ts';
+import { DEFAULT_TENANT_ID } from '../../middleware/tenant.ts';
+
+const TenantBody = t.Object({
+  id: t.String({ minLength: 1 }),
+  name: t.Optional(t.String()),
+  status: t.Optional(t.Union([t.Literal('active'), t.Literal('disabled')])),
+});
+
+function now() { return Date.now(); }
+
+function ensureDefaultTenant() {
+  db.insert(tenants).values({
+    id: DEFAULT_TENANT_ID,
+    name: 'Default tenant',
+    status: 'active',
+    createdAt: now(),
+    updatedAt: now(),
+  }).onConflictDoNothing().run();
+}
+
+export const tenantsRoutes = new Elysia({ prefix: '/api' })
+  .get('/tenants', () => {
+    ensureDefaultTenant();
+    const data = db.select().from(tenants).all();
+    return { tenants: data, count: data.length };
+  }, { detail: { tags: ['tenants'], summary: 'List tenants' } })
+  .post('/tenants', ({ body }) => {
+    const input = body as { id: string; name?: string; status?: 'active' | 'disabled' };
+    const row = {
+      id: input.id.trim(),
+      name: input.name?.trim() || input.id.trim(),
+      status: input.status ?? 'active',
+      createdAt: now(),
+      updatedAt: now(),
+    };
+    db.insert(tenants).values(row)
+      .onConflictDoUpdate({ target: tenants.id, set: { name: row.name, status: row.status, updatedAt: row.updatedAt } })
+      .run();
+    return { success: true, tenant: db.select().from(tenants).where(eq(tenants.id, row.id)).get() };
+  }, { body: TenantBody, detail: { tags: ['tenants'], summary: 'Create or update a tenant' } })
+  .get('/tenants/:id', ({ params, set }) => {
+    const tenant = db.select().from(tenants).where(eq(tenants.id, params.id)).get();
+    if (!tenant) {
+      set.status = 404;
+      return { error: `Tenant not found: ${params.id}` };
+    }
+    return { tenant };
+  }, { params: t.Object({ id: t.String({ minLength: 1 }) }) });

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,7 +34,6 @@ import { createCompressMiddleware } from './middleware/compress.ts';
 import { createRequestDedupFetch } from './middleware/dedup.ts';
 import { createDbContextFetch } from './middleware/db-context.ts';
 import { createTenantFetch, createTenantMiddleware } from './middleware/tenant.ts';
-
 import { authRoutes } from './routes/auth/index.ts';
 import { settingsRoutes } from './routes/settings/index.ts';
 import { feedRoutes } from './routes/feed/index.ts';
@@ -58,6 +57,7 @@ import { createMcpRoutes } from './routes/mcp/index.ts';
 import { createMetricsLifecycle, metricsRoutes } from './routes/metrics/index.ts';
 import { memoryRoutes } from './routes/memory/index.ts';
 import { canvasRoutes } from './routes/canvas/index.ts';
+import { tenantsRoutes } from './routes/tenants/index.ts';
 
 let indexerRoutes: any = null;
 try {
@@ -66,11 +66,9 @@ try {
   console.log('[Indexer] Routes not loaded — indexer is optional');
 }
 import { gatewayPlugin } from './gateway/index.ts';
-
 import pkg from '../package.json' with { type: 'json' };
 
 const startupConfig = validateStartupEnv();
-
 try {
   db.update(indexingStatus).set({ isIndexing: 0 }).where(eq(indexingStatus.id, 1)).run();
   console.log('🔮 Reset indexing status on startup');
@@ -117,7 +115,6 @@ registerGracefulShutdown({
 });
 
 const requestLogger = createRequestLogger();
-
 const app = new Elysia()
   .onRequest(requestLogger.onRequest)
   .use(createCorrelationMiddleware())
@@ -200,6 +197,7 @@ const apiModules = [
   metricsRoutes,
   memoryRoutes,
   canvasRoutes,
+  tenantsRoutes,
   ...(indexerRoutes ? [indexerRoutes] : []),
   ...unifiedPlugins.routes,
 ];
@@ -241,7 +239,6 @@ await runStartupSelfTest({
     healthFetch: () => app.fetch(new Request(`http://127.0.0.1:${PORT}/api/health`)),
   }),
 });
-
 const serverFetch = createRequestTimeoutFetch(
   createRequestDedupFetch(createApiVersionedFetch(createTenantFetch(createDbContextFetch((request: Request) => app.fetch(request))))),
 );

--- a/src/server/logging.ts
+++ b/src/server/logging.ts
@@ -6,6 +6,7 @@
 
 import { db, searchLog, documentAccess, learnLog } from '../db/index.ts';
 import type { SearchResult } from './types.ts';
+import { tenantIdForWrite } from '../middleware/tenant.ts';
 
 /**
  * Log search query with full details
@@ -37,6 +38,7 @@ export function logSearch(
       resultsCount,
       searchTimeMs,
       createdAt: Date.now(),
+      tenantId: tenantIdForWrite(),
       project: project || null,
       results: resultsJson,
     }).run();
@@ -81,6 +83,7 @@ export function logDocumentAccess(documentId: string, accessType: string, projec
       documentId,
       accessType,
       createdAt: Date.now(),
+      tenantId: tenantIdForWrite(),
       project: project || null,
     }).run();
   } catch (e) {
@@ -99,6 +102,7 @@ export function logLearning(documentId: string, patternPreview: string, source: 
       source: source || 'Oracle Learn',
       concepts: JSON.stringify(concepts),
       createdAt: Date.now(),
+      tenantId: tenantIdForWrite(),
       project: project || null,
     }).run();
   } catch (e) {

--- a/src/tools/__tests__/learn-enqueue.test.ts
+++ b/src/tools/__tests__/learn-enqueue.test.ts
@@ -36,6 +36,7 @@ CREATE TABLE oracle_documents (
   superseded_reason TEXT,
   origin TEXT,
   project TEXT,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
   created_by TEXT
 );
 CREATE VIRTUAL TABLE oracle_fts USING fts5(id UNINDEXED, content, concepts, tokenize='porter unicode61');

--- a/src/tools/__tests__/learn-vault-frontmatter.test.ts
+++ b/src/tools/__tests__/learn-vault-frontmatter.test.ts
@@ -24,6 +24,7 @@ CREATE TABLE oracle_documents (
   superseded_reason TEXT,
   origin TEXT,
   project TEXT,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
   created_by TEXT
 );
 CREATE VIRTUAL TABLE oracle_fts USING fts5(id UNINDEXED, content, concepts, tokenize='porter unicode61');

--- a/src/tools/list.ts
+++ b/src/tools/list.ts
@@ -4,9 +4,10 @@
  * List documents without search query, with pagination and type filtering.
  */
 
-import { eq, sql } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { oracleDocuments } from '../db/schema.ts';
 import type { ToolContext, ToolResponse, OracleListInput } from './types.ts';
+import { currentTenantId, tenantSql } from '../middleware/tenant.ts';
 
 export const listToolDef = {
   name: 'oracle_list',
@@ -50,16 +51,21 @@ export async function handleList(ctx: ToolContext, input: OracleListInput): Prom
     throw new Error(`Invalid type: ${type}. Must be one of: ${validTypes.join(', ')}`);
   }
 
-  const countResult = type === 'all'
-    ? ctx.db.select({ total: sql<number>`count(*)` }).from(oracleDocuments).get()
-    : ctx.db.select({ total: sql<number>`count(*)` }).from(oracleDocuments).where(eq(oracleDocuments.type, type)).get();
+  const tenantId = currentTenantId();
+  const countWhere = type === 'all'
+    ? tenantId ? eq(oracleDocuments.tenantId, tenantId) : undefined
+    : tenantId ? and(eq(oracleDocuments.type, type), eq(oracleDocuments.tenantId, tenantId)) : eq(oracleDocuments.type, type);
+  const countQuery = ctx.db.select({ total: sql<number>`count(*)` }).from(oracleDocuments);
+  const countResult = countWhere ? countQuery.where(countWhere).get() : countQuery.get();
   const total = countResult?.total ?? 0;
 
+  const tenantFilter = tenantSql('d');
   const listStmt = type === 'all'
     ? ctx.sqlite.prepare(`
         SELECT d.id, d.type, d.source_file, d.concepts, d.indexed_at, f.content
         FROM oracle_documents d
         JOIN oracle_fts f ON d.id = f.id
+        WHERE 1=1 ${tenantFilter.clause}
         ORDER BY d.indexed_at DESC
         LIMIT ? OFFSET ?
       `)
@@ -67,14 +73,14 @@ export async function handleList(ctx: ToolContext, input: OracleListInput): Prom
         SELECT d.id, d.type, d.source_file, d.concepts, d.indexed_at, f.content
         FROM oracle_documents d
         JOIN oracle_fts f ON d.id = f.id
-        WHERE d.type = ?
+        WHERE d.type = ? ${tenantFilter.clause}
         ORDER BY d.indexed_at DESC
         LIMIT ? OFFSET ?
       `);
 
   const rows = type === 'all'
-    ? listStmt.all(limit, offset)
-    : listStmt.all(type, limit, offset);
+    ? listStmt.all(...tenantFilter.params, limit, offset)
+    : listStmt.all(type, ...tenantFilter.params, limit, offset);
 
   const documents = (rows as any[]).map((row) => ({
     id: row.id,

--- a/src/vector/adapters/proxy.ts
+++ b/src/vector/adapters/proxy.ts
@@ -13,6 +13,7 @@ import type {
   VectorDocument,
   VectorQueryResult,
 } from '../types.ts';
+import { currentTenantId, TENANT_HEADER } from '../../middleware/tenant.ts';
 
 interface ProxyQueryRequest {
   text: string;
@@ -36,6 +37,13 @@ interface ProxyQueryResponse {
   documents: string[];
   distances: number[];
   metadatas: any[];
+}
+
+function tenantHeaders(json = false): Record<string, string> {
+  const headers: Record<string, string> = json ? { 'Content-Type': 'application/json' } : {};
+  const tenantId = currentTenantId();
+  if (tenantId) headers[TENANT_HEADER] = tenantId;
+  return headers;
 }
 
 function toQueryUrl(base: string, path: string): string {
@@ -123,7 +131,7 @@ export class ProxyVectorAdapter implements VectorStoreAdapter {
   private async post(path: string, body: Record<string, any>): Promise<void> {
     const res = await fetch(toQueryUrl(this.endpoint, path), {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: tenantHeaders(true),
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(this.requestTimeoutMs),
     });
@@ -133,7 +141,7 @@ export class ProxyVectorAdapter implements VectorStoreAdapter {
   private async postJson<T>(path: string, body: Record<string, any>): Promise<T> {
     const res = await fetch(toQueryUrl(this.endpoint, path), {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: tenantHeaders(true),
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(this.requestTimeoutMs),
     });
@@ -144,6 +152,7 @@ export class ProxyVectorAdapter implements VectorStoreAdapter {
   private async del(path: string): Promise<void> {
     const res = await fetch(toQueryUrl(this.endpoint, path), {
       method: 'DELETE',
+      headers: tenantHeaders(),
       signal: AbortSignal.timeout(this.requestTimeoutMs),
     });
     await this.assertResponse(res);
@@ -152,6 +161,7 @@ export class ProxyVectorAdapter implements VectorStoreAdapter {
   private async fetchJson<T>(path: string, timeoutMs = this.requestTimeoutMs): Promise<T> {
     const res = await fetch(toQueryUrl(this.endpoint, path), {
       method: 'GET',
+      headers: tenantHeaders(),
       signal: AbortSignal.timeout(timeoutMs),
     });
     await this.assertResponse(res);

--- a/src/vector/factory.ts
+++ b/src/vector/factory.ts
@@ -15,6 +15,7 @@ import { ProxyVectorAdapter } from './adapters/proxy.ts';
 import { createEmbeddingProvider } from './embeddings.ts';
 import { resolveEmbeddingFallbackChain, resolveEmbeddingModel, resolveEmbeddingProviderType } from './embedder-config.ts';
 import { configPath, loadVectorConfig, resolveServiceEndpoint, configToModels, fallbackCollectionsFor } from './config.ts';
+import { tenantDataPath } from '../middleware/tenant.ts';
 
 export interface VectorStoreConfig {
   type?: VectorDBType;
@@ -62,16 +63,16 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
   const collectionName = config.collectionName || COLLECTION_NAME;
   switch (type) {
     case 'sqlite-vec': {
-      const dbPath = config.dataPath
+      const dbPath = tenantDataPath(config.dataPath
         || process.env.ORACLE_VECTOR_DB_PATH
-        || VECTORS_DB_PATH;
+        || VECTORS_DB_PATH);
 
       return new SqliteVecAdapter(collectionName, dbPath, createConfiguredEmbedder(config));
     }
     case 'lancedb': {
-      const dbPath = config.dataPath
+      const dbPath = tenantDataPath(config.dataPath
         || process.env.ORACLE_VECTOR_DB_PATH
-        || LANCEDB_DIR;
+        || LANCEDB_DIR);
 
       return new LanceDBAdapter(collectionName, dbPath, createConfiguredEmbedder(config));
     }
@@ -106,7 +107,7 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
     }
     case 'chroma':
     default: {
-      const dataPath = config.dataPath || CHROMADB_DIR;
+      const dataPath = tenantDataPath(config.dataPath || CHROMADB_DIR);
       const pythonVersion = config.pythonVersion || '3.12';
       return new ChromaMcpAdapter(collectionName, dataPath, pythonVersion);
     }
@@ -125,7 +126,7 @@ export function getEmbeddingModels(
 
   if (cfg && Object.keys(cfg.collections).length > 0) return configToModels(cfg);
 
-    if (cfg && fallbackFromFallbackCollections.length > 0) {
+  if (cfg && fallbackFromFallbackCollections.length > 0) {
     const modelMap: Record<string, EmbeddingModelConfig> = {};
     for (const col of fallbackFromFallbackCollections) {
       const serviceName = col.service;

--- a/tests/http/health/tenant-scope.test.ts
+++ b/tests/http/health/tenant-scope.test.ts
@@ -10,7 +10,7 @@ const tenantB = `tenant-b-${stamp}`;
 const ids = [`tenant-doc-a-${stamp}`, `tenant-doc-b-${stamp}`];
 const now = Date.now();
 
-function insertDoc(id: string, project: string) {
+function insertDoc(id: string, tenantId: string) {
   db.insert(oracleDocuments).values({
     id,
     type: 'learning',
@@ -19,7 +19,8 @@ function insertDoc(id: string, project: string) {
     createdAt: now,
     updatedAt: now,
     indexedAt: now,
-    project,
+    tenantId,
+    project: tenantId,
   }).run();
 }
 
@@ -44,7 +45,7 @@ test('GET /api/stats scopes document counts by tenant header', async () => {
   const body = await res.json() as Record<string, any>;
 
   expect(res.status).toBe(200);
-  expect(body.tenant).toEqual({ id: tenantA, scope: 'project' });
+  expect(body.tenant).toEqual({ id: tenantA, scope: 'tenant_id' });
   expect(body.total).toBe(1);
   expect(body.by_type.learning).toBe(1);
 });
@@ -56,7 +57,7 @@ test('GET /api/oracles scopes project list by tenant header', async () => {
   const body = await res.json() as Record<string, any>;
 
   expect(res.status).toBe(200);
-  expect(body.tenant).toEqual({ id: tenantB, scope: 'project' });
+  expect(body.tenant).toEqual({ id: tenantB, scope: 'tenant_id' });
   expect(body.projects.map((item: { project: string }) => item.project)).toContain(tenantB);
   expect(body.projects.map((item: { project: string }) => item.project)).not.toContain(tenantA);
 });

--- a/tests/http/tenant/admin.test.ts
+++ b/tests/http/tenant/admin.test.ts
@@ -1,0 +1,24 @@
+import { afterAll, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { db, tenants } from '../../../src/db/index.ts';
+import { tenantsRoutes } from '../../../src/routes/tenants/index.ts';
+
+const tenantId = `admin-tenant-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+afterAll(() => {
+  db.delete(tenants).where(eq(tenants.id, tenantId)).run();
+});
+
+test('tenant admin API creates and lists tenants', async () => {
+  const created = await tenantsRoutes.handle(new Request('http://local/api/tenants', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ id: tenantId, name: 'Admin Tenant' }),
+  }));
+  expect(created.status).toBe(200);
+  expect(await created.json()).toMatchObject({ success: true, tenant: { id: tenantId, status: 'active' } });
+
+  const listed = await tenantsRoutes.handle(new Request('http://local/api/tenants'));
+  const body = await listed.json() as { tenants: Array<{ id: string }> };
+  expect(body.tenants.map((tenant) => tenant.id)).toContain(tenantId);
+});

--- a/tests/http/tenant/isolation.test.ts
+++ b/tests/http/tenant/isolation.test.ts
@@ -20,7 +20,7 @@ function createTenantAwareHealthApp() {
     .get('/stats', () => {
       const scoped = tenantDocs();
       return {
-        tenant: { id: currentTenantId(), scope: 'project' },
+        tenant: { id: currentTenantId(), scope: 'tenant_id' },
         total_docs: scoped.length,
         by_type: scoped.reduce<Record<string, number>>((counts, doc) => {
           counts[doc.type] = (counts[doc.type] ?? 0) + 1;
@@ -35,7 +35,7 @@ function createTenantAwareHealthApp() {
         types: 1,
         last_indexed: doc.createdAt,
       }));
-      return { tenant: { id: currentTenantId(), scope: 'project' }, projects };
+      return { tenant: { id: currentTenantId(), scope: 'tenant_id' }, projects };
     });
 }
 
@@ -51,7 +51,7 @@ test('tenant A stats do not include tenant B documents', async () => {
   const body = await res.json() as Record<string, any>;
 
   expect(res.status).toBe(200);
-  expect(body.tenant).toEqual({ id: tenantA, scope: 'project' });
+  expect(body.tenant).toEqual({ id: tenantA, scope: 'tenant_id' });
   expect(body.total_docs).toBe(1);
   expect(body.by_type.learning).toBe(1);
 });
@@ -62,7 +62,7 @@ test('tenant B oracle project list does not include tenant A project', async () 
   const projects = body.projects.map((item: { project: string }) => item.project);
 
   expect(res.status).toBe(200);
-  expect(body.tenant).toEqual({ id: tenantB, scope: 'project' });
+  expect(body.tenant).toEqual({ id: tenantB, scope: 'tenant_id' });
   expect(projects).toContain(tenantB);
   expect(projects).not.toContain(tenantA);
 });

--- a/tests/http/tenant/learn-isolation.test.ts
+++ b/tests/http/tenant/learn-isolation.test.ts
@@ -1,0 +1,47 @@
+import { afterAll, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { db, oracleDocuments, sqlite } from '../../../src/db/index.ts';
+import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
+import { createLearnCrudRoutes } from '../../../src/routes/learn/crud.ts';
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-tenant-learn-'));
+const previousRoot = process.env.ORACLE_REPO_ROOT;
+process.env.ORACLE_REPO_ROOT = tempRoot;
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantA = `tenant-a-${stamp}`;
+const tenantB = `tenant-b-${stamp}`;
+const id = `tenant-learning-${stamp}`;
+
+function fetchLearn(tenantId: string, path: string, init: RequestInit = {}) {
+  return createTenantFetch((request) => createLearnCrudRoutes().handle(request))(new Request(`http://local${path}`, {
+    ...init,
+    headers: { 'content-type': 'application/json', [TENANT_HEADER]: tenantId, ...(init.headers ?? {}) },
+  }));
+}
+
+afterAll(() => {
+  db.delete(oracleDocuments).where(eq(oracleDocuments.id, id)).run();
+  sqlite.prepare('DELETE FROM oracle_fts WHERE id = ?').run(id);
+  if (previousRoot === undefined) delete process.env.ORACLE_REPO_ROOT;
+  else process.env.ORACLE_REPO_ROOT = previousRoot;
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+test('learn CRUD stamps tenant_id and hides rows from other tenants', async () => {
+  const created = await fetchLearn(tenantA, '/learn', {
+    method: 'POST',
+    body: JSON.stringify({ id, pattern: `tenant scoped learning ${stamp}`, concepts: ['tenant'] }),
+  });
+  expect(created.status).toBe(200);
+  expect(db.select({ tenantId: oracleDocuments.tenantId }).from(oracleDocuments).where(eq(oracleDocuments.id, id)).get()?.tenantId).toBe(tenantA);
+
+  const denied = await fetchLearn(tenantB, `/learn/${id}`);
+  expect(denied.status).toBe(404);
+
+  const allowed = await fetchLearn(tenantA, `/learn/${id}`);
+  expect(allowed.status).toBe(200);
+  expect((await allowed.json() as { id: string }).id).toBe(id);
+});

--- a/tests/http/tenant/search-isolation.test.ts
+++ b/tests/http/tenant/search-isolation.test.ts
@@ -1,0 +1,44 @@
+import { afterAll, expect, test } from 'bun:test';
+import { inArray } from 'drizzle-orm';
+import { db, oracleDocuments, sqlite } from '../../../src/db/index.ts';
+import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
+import { searchRoutes } from '../../../src/routes/search/index.ts';
+
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantA = `tenant-a-${stamp}`;
+const tenantB = `tenant-b-${stamp}`;
+const ids = [`tenant-search-a-${stamp}`, `tenant-search-b-${stamp}`];
+const now = Date.now();
+
+function insertDoc(id: string, tenantId: string, content: string) {
+  db.insert(oracleDocuments).values({
+    id, tenantId, type: 'learning', sourceFile: `ψ/memory/${id}.md`,
+    concepts: '[]', createdAt: now, updatedAt: now, indexedAt: now,
+    project: tenantId, createdBy: 'test',
+  }).run();
+  sqlite.prepare('DELETE FROM oracle_fts WHERE id = ?').run(id);
+  sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)').run(id, content, 'tenant');
+}
+
+insertDoc(ids[0], tenantA, `alpha-only-${stamp} sharedterm`);
+insertDoc(ids[1], tenantB, `beta-only-${stamp} sharedterm`);
+
+afterAll(() => {
+  db.delete(oracleDocuments).where(inArray(oracleDocuments.id, ids)).run();
+  for (const id of ids) sqlite.prepare('DELETE FROM oracle_fts WHERE id = ?').run(id);
+});
+
+function requestSearch(tenantId: string) {
+  return createTenantFetch((request) => searchRoutes.handle(request))(new Request('http://local/api/search?q=sharedterm&mode=fts', {
+    headers: { [TENANT_HEADER]: tenantId },
+  }));
+}
+
+test('GET /api/search returns only documents for the selected tenant', async () => {
+  const res = await requestSearch(tenantA);
+  const body = await res.json() as { results: Array<{ id: string }> };
+
+  expect(res.status).toBe(200);
+  expect(body.results.map((item) => item.id)).toContain(ids[0]);
+  expect(body.results.map((item) => item.id)).not.toContain(ids[1]);
+});


### PR DESCRIPTION
Closes #1650

## Changes
- Added tenant_id schema/migration coverage with a default tenant row
- Added tenant admin routes for listing/upserting/fetching tenants
- Scoped HTTP-visible health stats, oracle project stats, learn CRUD, tenant search, logs, and tool listing by tenant context
- Added tenant-aware local vector data paths and proxy tenant header forwarding

## Test
- bun test tests/http/tenant/
- bun test tests/http/health/ tests/http/learn/
- bun test src/db/__tests__/fresh-install.test.ts
- bunx tsc --noEmit
