### PR TITLE
fix: make vector defaults zero-config

### DIFF
--- a/src/vector/config.ts
+++ b/src/vector/config.ts
@@ -14,6 +14,7 @@ import { ORACLE_DATA_DIR, LANCEDB_DIR } from '../config.ts';
 import { COLLECTION_NAME } from '../const.ts';
 import type { UnifiedProxyManifest } from '../plugins/unified-manifest.ts';
 import type { EmbedderConfig, VectorDBType } from './types.ts';
+import { zeroConfigEmbedder } from './default-embedder.ts';
 
 export const VECTOR_CONFIG_FILE = 'vector-server.json';
 
@@ -79,25 +80,27 @@ export function generateDefaultConfig(): VectorServerConfig {
       'bge-m3': {
         collection: 'oracle_knowledge_bge_m3',
         model: 'bge-m3',
-        provider: 'none',
+        provider: 'ollama',
         adapter: 'lancedb',
         primary: true,
+        embedder: zeroConfigEmbedder('bge-m3'),
       },
       nomic: {
         collection: COLLECTION_NAME,
         model: 'nomic-embed-text',
-        provider: 'none',
+        provider: 'ollama',
         adapter: 'lancedb',
+        embedder: zeroConfigEmbedder('nomic-embed-text'),
       },
       qwen3: {
         collection: 'oracle_knowledge_qwen3',
         model: 'qwen3-embedding',
-        provider: 'none',
+        provider: 'ollama',
         adapter: 'lancedb',
+        embedder: zeroConfigEmbedder('qwen3-embedding'),
       },
     },
     dataPath: LANCEDB_DIR,
-    embedder: { backend: 'none' },
     embeddingEndpoint: '',
     storage: {
       default: 'lancedb',

--- a/src/vector/default-embedder.ts
+++ b/src/vector/default-embedder.ts
@@ -1,0 +1,20 @@
+import type { EmbedderConfig, EmbeddingProviderType } from './types.ts';
+
+function has(...keys: string[]): boolean {
+  return keys.some((key) => Boolean(process.env[key]?.trim()));
+}
+
+export function zeroConfigEmbedder(model: string): EmbedderConfig {
+  const fallbackChain: EmbeddingProviderType[] = [];
+  if (has('OPENAI_API_KEY')) fallbackChain.push('openai');
+  if (has('GEMINI_API_KEY', 'GOOGLE_API_KEY')) fallbackChain.push('gemini');
+  if (has('CF_ACCOUNT_ID', 'CLOUDFLARE_ACCOUNT_ID') && has('CF_API_TOKEN', 'CLOUDFLARE_API_TOKEN')) {
+    fallbackChain.push('cloudflare-ai');
+  }
+
+  return {
+    backend: 'ollama',
+    model,
+    ...(fallbackChain.length > 0 && { fallbackChain }),
+  };
+}

--- a/tests/http/vector/default-config.test.ts
+++ b/tests/http/vector/default-config.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, expect, test } from 'bun:test';
+import { configToModels, generateDefaultConfig } from '../../../src/vector/config.ts';
+
+const savedEnv = {
+  openai: process.env.OPENAI_API_KEY,
+  gemini: process.env.GEMINI_API_KEY,
+  google: process.env.GOOGLE_API_KEY,
+  cfAccount: process.env.CF_ACCOUNT_ID,
+  cfToken: process.env.CF_API_TOKEN,
+};
+
+afterEach(() => {
+  restore('OPENAI_API_KEY', savedEnv.openai);
+  restore('GEMINI_API_KEY', savedEnv.gemini);
+  restore('GOOGLE_API_KEY', savedEnv.google);
+  restore('CF_ACCOUNT_ID', savedEnv.cfAccount);
+  restore('CF_API_TOKEN', savedEnv.cfToken);
+});
+
+function restore(key: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+test('default vector config uses zero-config Ollama with detected remote fallbacks', () => {
+  process.env.OPENAI_API_KEY = 'sk-test';
+  process.env.GOOGLE_API_KEY = 'gemini-test';
+
+  const models = configToModels(generateDefaultConfig());
+
+  expect(models['bge-m3'].embedder).toMatchObject({
+    backend: 'ollama',
+    model: 'bge-m3',
+    fallbackChain: ['openai', 'gemini'],
+  });
+  expect(models.nomic.embedder).toMatchObject({ backend: 'ollama', model: 'nomic-embed-text' });
+});
+
+test('explicit provider none remains a disabled power-user override', () => {
+  const config = generateDefaultConfig();
+  config.embedder = undefined;
+  config.collections = {
+    ftsOnly: { collection: 'fts_only', model: 'manual', provider: 'none', adapter: 'lancedb' },
+  };
+
+  expect(configToModels(config).ftsOnly.embedder).toEqual({ backend: 'none' });
+});


### PR DESCRIPTION
## Summary
- Audited merged Vector Section v2 phases and found the remaining zero-config gap: generated defaults still disabled embeddings.
- Default LanceDB collections now use Ollama embeddings out of the box.
- Generated defaults include remote fallback providers only when matching credentials exist.
- Added regression coverage that explicit `provider: none` remains a power-user/FTS-only override.

## Tests
- `bunx tsc --noEmit`
- `bun test tests/http/vector/`

Refs #1436
