### PR TITLE
docs: file AI memory systems research (#1648)

### DIFF
--- a/ψ/memory/ai-memory-product-patterns-2026.md
+++ b/ψ/memory/ai-memory-product-patterns-2026.md
@@ -1,0 +1,42 @@
+# AI Product Memory Patterns — 2026 Filing
+
+Source: issue #1648 comments. Purpose: preserve product-level patterns separately from ARRA architecture recommendations.
+
+## Pattern A — static rule files
+
+Most coding tools converge on explicit files that are loaded into context or used as routing hints.
+
+| Tool | File/scope pattern | Retrieval behavior | ARRA lesson |
+| --- | --- | --- | --- |
+| Cursor | `.cursor/rules/*.mdc`, legacy `.cursorrules`, user rules | Always, glob, agent-requested, or manual attachment | Use frontmatter + globs for portable memory rules |
+| GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md`, user/org scopes | Applicable instructions combined client-side; memory validates citations | Add citation validation for repo facts |
+| Zed | `.rules`, `.cursorrules`, `.windsurfrules`, AGENTS/CLAUDE/GEMINI docs | Reads known rule files at session start | Support common rule-file imports |
+| Aider | `CONVENTIONS.md` or config-loaded files | Manual `/read` style memory | Keep operator-controlled import/export |
+| Continue.dev | `.continue/rules/*.md` | Rule files loaded by trigger mode | Rules need predictable precedence |
+
+## Pattern B — auto-extracted or managed memories
+
+Auto memory is useful but riskier than rules files because it can be opaque, stale, or poisoned.
+
+| Tool | Memory behavior | Risk | ARRA stance |
+| --- | --- | --- | --- |
+| ChatGPT | Bio-style stored memories injected into prompts | Unsupported inferences, stale entries, poisoning | Never silently promote permanent memory |
+| Windsurf | Workspace-local auto memories plus rules | Local, non-git, intended as temporary | Treat auto notes as candidates for review |
+| GitHub Copilot Memory | Repo/user memory with citations and expiry | Scope differences and hidden exclusion rules | Copy the validation/expiry idea, not opaque storage |
+| Claude Projects | Project files direct-injected, then automatic RAG when too large | Retrieval switch is hidden from users | Be explicit when ARRA changes retrieval mode |
+| Gemini Gems/Memory | Gems are stateless instructions/files; Memory is separate | Easy to conflate surfaces | Keep rules, memory, and indexed corpus separate |
+
+## Cross-tool principles
+
+1. **Files are the portability layer.** They survive tool churn and can be reviewed in PRs.
+2. **Retrieval is the scale layer.** It should return citations, not just text.
+3. **Validation is the trust layer.** Repo facts should be rechecked against current files.
+4. **Expiry is a safety layer.** Unused or unvalidated memories should decay.
+5. **Surface separation matters.** CLI, HTTP, MCP, and UI should share storage contracts but expose different permissions.
+
+## ARRA filing requirements
+
+- Keep `ψ/memory/ai-memory-systems-research.md` as the architecture synthesis.
+- Keep this product-pattern file as the market/reference filing.
+- Keep `ψ/memory/ai-memory-systems-claims-ledger.md` as the adversarial claim ledger.
+- Future implementation issues should cite the specific filing they depend on instead of re-reading the whole issue thread.

--- a/ψ/memory/ai-memory-systems-claims-ledger.md
+++ b/ψ/memory/ai-memory-systems-claims-ledger.md
@@ -1,0 +1,44 @@
+# AI Memory Systems Claims Ledger — #1648
+
+Source: issue #1648 and verified issue comments from 2026-06-16. This file is the compact claim ledger for future implementation decisions.
+
+## Confirmed findings
+
+| Claim | Confidence | Evidence | ARRA consequence |
+| --- | --- | --- | --- |
+| Official MCP memory is local graph + substring search, not vector memory | High | `@modelcontextprotocol/server-memory` source and package docs | Expose ARRA through MCP; do not copy the official server as backend |
+| Retrieval store + context injection is the practical baseline | Medium | 2026 agent memory survey cited in #1648 | Improve hybrid FTS/vector retrieval before graph complexity |
+| Query-time confidence is safer than static stored confidence | Low/medium | Memex-style confidence formula and issue verification | Store provenance and validation fields; derive confidence at read time |
+| LangMem demonstrates self-hostable background extraction | Medium | LangMem upstream docs | Treat as an interoperability/reference pattern, not a required dependency |
+| Citation validation prevents stale coding memories | Medium/high | GitHub Copilot Memory pattern from issue comments | Validate path/hash/symbol anchors before ranking memory highly |
+| Static rules files are the coding-assistant common denominator | High | Cursor, Copilot, Zed, Aider, Continue, Windsurf comments | Keep `ψ/memory/`, AGENTS/CLAUDE docs, and rules files as durable source of truth |
+
+## Refuted or unsafe claims
+
+| Claim | Verdict | Reason to avoid |
+| --- | --- | --- |
+| Mem0 80% token reduction | Refuted | Marketing claim without independent benchmark in issue evidence |
+| codebase-memory-mcp 99.2% token reduction | Refuted | Unverifiable and too precise for planning |
+| Eve Memory 94.4% LongMemEval | Refuted | Marketing copy; not a product baseline |
+| Long context always loses to dedicated memory | Refuted | Overstated; context injection remains valid for small/medium memory |
+| RAG beats pure long-context across the board | Refuted | Depends on corpus size, task, retrieval quality, and context budget |
+| File markdown is always optimal | Refuted | Files are best for ground truth, not for ranked semantic recall |
+| Vector DBs degrade 25% at 10x scale | Refuted | No primary source in the issue |
+| Episodic+semantic+procedural split is mandatory | Refuted | Useful taxonomy, but premature as a storage mandate |
+
+## Decision rules for ARRA
+
+1. Prefer **retrieval-first memory**: hybrid FTS/vector with citations.
+2. Promote durable memories into **files first**, then index them.
+3. Keep SQLite as metadata ledger: tenant, validation, provenance, access stats.
+4. Make MCP a typed facade over ARRA, not the storage engine.
+5. Keep automatic extraction review-gated to reduce poisoning and stale facts.
+6. Add graph/tiered memory only when retrieval logs show ranked chunks cannot answer recurring agent questions.
+
+## Implementation hooks
+
+- `memory_search`: cited chunks + validation state + confidence explanation.
+- `memory_propose`: unvalidated candidate with full provenance.
+- `memory_validate`: path/hash/URL validation and stale marking.
+- `memory_promote`: approved candidate to markdown under `ψ/memory/`.
+- `memory_reindex`: tenant/project scoped index refresh.

--- a/ψ/memory/ai-memory-systems-research.md
+++ b/ψ/memory/ai-memory-systems-research.md
@@ -2,6 +2,14 @@
 
 Source: GitHub issue #1648, "Memory Systems for AI Agents — Deep Research Findings (2026)", plus issue comments with product-by-product memory architecture notes.
 
+## Filing map
+
+This research is split into three reviewable files:
+
+- `ψ/memory/ai-memory-systems-research.md` — ARRA architecture synthesis and roadmap.
+- `ψ/memory/ai-memory-systems-claims-ledger.md` — confirmed/refuted claim ledger from #1648.
+- `ψ/memory/ai-memory-product-patterns-2026.md` — product-by-product memory pattern filing.
+
 ## Executive summary
 
 ARRA Oracle V3 should treat memory as a layered system, not a single feature. The strongest pattern for coding assistants is:


### PR DESCRIPTION
Closes #1648

## Changes
- Added a filing map to the AI memory systems synthesis
- Added a compact confirmed/refuted claims ledger for #1648
- Added a 2026 product-pattern filing for coding-assistant memory systems

## Test
- bunx tsc --noEmit
