### PR TITLE
fix: auto-store new memory learning files

### DIFF
--- a/src/indexer/__tests__/learn-watcher.test.ts
+++ b/src/indexer/__tests__/learn-watcher.test.ts
@@ -125,6 +125,31 @@ describe('startLearnWatcher', () => {
     stop();
   });
 
+
+  it('stores and enqueues new ψ/memory/learnings markdown files', async () => {
+    const learnDir = path.join(repoRoot, 'ψ', 'memory', 'learnings');
+    const filePath = path.join(learnDir, 'fresh.md');
+
+    fs.mkdirSync(learnDir, { recursive: true });
+    fs.writeFileSync(filePath, '# Fresh\n\n## Lesson\n\nMemory learn files should auto-index too.', 'utf8');
+
+    const stop = startLearnWatcher({ db, models: MODELS, repoRoot, debounceMs: 20 });
+    await wait(300);
+
+    const docs = db.query<{ source_file: string }>(
+      'SELECT source_file FROM oracle_documents ORDER BY id',
+    ).all() as { source_file: string }[];
+    expect(docs).toEqual([{ source_file: 'ψ/memory/learnings/fresh.md' }]);
+
+    const fts = db.query<{ count: number }, []>('SELECT COUNT(*) AS count FROM oracle_fts').get() as { count: number };
+    expect(fts.count).toBe(1);
+
+    const jobs = db.query<{ count: number }, []>('SELECT COUNT(*) AS count FROM indexing_jobs').get() as { count: number };
+    expect(jobs.count).toBe(Object.keys(MODELS).length);
+
+    stop();
+  });
+
   it('does nothing for non-markdown files', async () => {
     const learnDir = path.join(repoRoot, 'ψ', 'memory', 'learnings');
     const filePath = path.join(learnDir, 'note.txt');

--- a/src/indexer/learn-doc-source.ts
+++ b/src/indexer/learn-doc-source.ts
@@ -9,6 +9,7 @@ import type { OracleDocument } from '../types.ts';
 import { parseLearningFile } from './parser.ts';
 
 export const PSI_LEARN_REL = path.join('ψ', 'learn');
+export const MEMORY_LEARN_REL = path.join('ψ', 'memory', 'learnings');
 
 export function normalizeSourceFile(repoRoot: string, filePath: string): string {
   return path.relative(repoRoot, filePath).split(path.sep).join('/');
@@ -24,6 +25,10 @@ export function isPsiLearnSource(sourceFile: string): boolean {
   return normalized.startsWith('ψ/learn/') && !normalized.startsWith('ψ/learn/security-corpus/');
 }
 
+export function isMemoryLearningSource(sourceFile: string): boolean {
+  return sourceFile.split(path.sep).join('/').startsWith('ψ/memory/learnings/');
+}
+
 export function parsePsiLearnFile(relativePath: string, content: string): OracleDocument[] {
   const sourceFile = relativePath.split(path.sep).join('/');
   const basename = path.basename(sourceFile);
@@ -36,13 +41,17 @@ export function parsePsiLearnFile(relativePath: string, content: string): Oracle
   }));
 }
 
-export function readPsiLearnDocuments(repoRoot: string, filePath: string): OracleDocument[] {
+export function readLearningDocuments(repoRoot: string, filePath: string): OracleDocument[] {
   const sourceFile = normalizeSourceFile(repoRoot, filePath);
-  if (!isPsiLearnSource(sourceFile) || !isMarkdownFile(filePath)) return [];
+  if (!isMarkdownFile(filePath)) return [];
   const content = fs.readFileSync(filePath, 'utf8');
   if (!content.trim()) return [];
-  return parsePsiLearnFile(sourceFile, content);
+  if (isPsiLearnSource(sourceFile)) return parsePsiLearnFile(sourceFile, content);
+  if (isMemoryLearningSource(sourceFile)) return parseLearningFile(path.basename(sourceFile), content, sourceFile);
+  return [];
 }
+
+export const readPsiLearnDocuments = readLearningDocuments;
 
 export function storeSqliteDocuments(db: Database, documents: OracleDocument[]): string[] {
   if (documents.length === 0) return [];

--- a/src/indexer/learn-watcher.ts
+++ b/src/indexer/learn-watcher.ts
@@ -2,7 +2,8 @@
  * Auto-index learn documents when files change under ψ/memory/learnings or ψ/learn.
  *
  * Existing indexed learning files are re-queued by source_file. New ψ/learn
- * Markdown files are inserted into SQLite/FTS first, then queued for vector jobs.
+ * and ψ/memory/learnings Markdown files are inserted into SQLite/FTS first,
+ * then queued for vector jobs.
  */
 
 import fs from 'fs';
@@ -11,13 +12,16 @@ import type Database from 'bun:sqlite';
 import { enqueueIndexJob } from './jobs.ts';
 import { REPO_ROOT } from '../config.ts';
 import {
+  MEMORY_LEARN_REL,
   PSI_LEARN_REL,
   isMarkdownFile,
+  isMemoryLearningSource,
   isPsiLearnSource,
   normalizeSourceFile,
-  readPsiLearnDocuments,
+  readLearningDocuments,
   storeSqliteDocuments,
 } from './learn-doc-source.ts';
+import { isWithinRoot, listDirs, listFiles, safeClearTimeout, safeClose, watchDir } from './watch-utils.ts';
 
 export interface LearnWatcherOptions {
   /** sqlite database used by enqueueIndexJob(). */
@@ -33,17 +37,6 @@ export interface LearnWatcherOptions {
 export type StopWatch = () => void;
 
 const DEFAULT_DEBOUNCE_MS = 250;
-const MEMORY_LEARN_REL = path.join('ψ', 'memory', 'learnings');
-
-function safeClose(watchers: Array<{ close: () => void }>): void {
-  for (const watcher of watchers) {
-    try { watcher.close(); } catch {}
-  }
-}
-
-function safeClearTimeout(id: ReturnType<typeof setTimeout> | undefined): void {
-  if (id !== undefined) clearTimeout(id);
-}
 
 function hasActiveJobs(db: Database, docId: string): boolean {
   const row = db.query<{ count: number }, [string]>(
@@ -57,59 +50,20 @@ function enqueueDocIds(db: Database, models: Record<string, { collection: string
   let count = 0;
   for (const id of ids) {
     if (hasActiveJobs(db, id)) continue;
-    try {
-      count += enqueueIndexJob(db, { docId: id, models }).length;
-    } catch {
-      continue;
-    }
+    try { count += enqueueIndexJob(db, { docId: id, models }).length; } catch { continue; }
   }
   return count;
 }
 
 function existingLearningIds(db: Database, sourceFile: string): string[] {
-  return db
-    .query<{ id: string }, [string]>(
-      `SELECT id
-       FROM oracle_documents
-       WHERE source_file = ? AND type = 'learning' AND superseded_at IS NULL`,
-    )
-    .all(sourceFile)
-    .map((row) => row.id);
+  return db.query<{ id: string }, [string]>(
+    `SELECT id FROM oracle_documents
+     WHERE source_file = ? AND type = 'learning' AND superseded_at IS NULL`,
+  ).all(sourceFile).map((row) => row.id);
 }
 
-function isWithinRoot(root: string, candidate: string): boolean {
-  const rel = path.relative(root, candidate);
-  return rel === '' || (rel !== '..' && !rel.startsWith(`..${path.sep}`) && !path.isAbsolute(rel));
-}
-
-function listDirs(root: string): string[] {
-  const dirs = [root];
-  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
-    if (!entry.isDirectory()) continue;
-    if (entry.name === '.git' || entry.name === 'node_modules') continue;
-    dirs.push(...listDirs(path.join(root, entry.name)));
-  }
-  return dirs;
-}
-
-function listMarkdownFiles(root: string): string[] {
-  const files: string[] = [];
-  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
-    const fullPath = path.join(root, entry.name);
-    if (entry.isDirectory()) files.push(...listMarkdownFiles(fullPath));
-    else if (entry.isFile() && isMarkdownFile(fullPath)) files.push(fullPath);
-  }
-  return files;
-}
-
-function watchDir(dir: string, onFileEvent: (filePath: string) => void): fs.FSWatcher | null {
-  try {
-    return fs.watch(dir, { persistent: false }, (_event, filename) => {
-      if (filename) onFileEvent(path.join(dir, filename));
-    });
-  } catch {
-    return null;
-  }
+function shouldAutoStore(sourceFile: string): boolean {
+  return isPsiLearnSource(sourceFile) || isMemoryLearningSource(sourceFile);
 }
 
 /**
@@ -151,9 +105,9 @@ export function startLearnWatcher({
 
     const sourceFile = normalizeSourceFile(root, fullPath);
     let ids = existingLearningIds(db, sourceFile);
-    if (ids.length === 0 && isPsiLearnSource(sourceFile)) {
+    if (ids.length === 0 && shouldAutoStore(sourceFile)) {
       try {
-        ids = storeSqliteDocuments(db, readPsiLearnDocuments(root, fullPath));
+        ids = storeSqliteDocuments(db, readLearningDocuments(root, fullPath));
       } catch (error) {
         console.warn(`[learn-watch] failed to index ${sourceFile}:`, error);
         return;
@@ -179,9 +133,8 @@ export function startLearnWatcher({
 
   for (const sourceRoot of roots) addWatchers(sourceRoot);
 
-  const psiLearnRoot = path.join(root, PSI_LEARN_REL);
-  if (fs.existsSync(psiLearnRoot)) {
-    for (const filePath of listMarkdownFiles(psiLearnRoot)) {
+  for (const sourceRoot of roots) {
+    for (const filePath of listFiles(sourceRoot, isMarkdownFile)) {
       const sourceFile = normalizeSourceFile(root, filePath);
       if (existingLearningIds(db, sourceFile).length === 0) indexOrQueue(filePath);
     }

--- a/src/indexer/watch-utils.ts
+++ b/src/indexer/watch-utils.ts
@@ -1,0 +1,47 @@
+import fs from 'fs';
+import path from 'path';
+
+export function safeClose(watchers: Array<{ close: () => void }>): void {
+  for (const watcher of watchers) {
+    try { watcher.close(); } catch {}
+  }
+}
+
+export function safeClearTimeout(id: ReturnType<typeof setTimeout> | undefined): void {
+  if (id !== undefined) clearTimeout(id);
+}
+
+export function isWithinRoot(root: string, candidate: string): boolean {
+  const rel = path.relative(root, candidate);
+  return rel === '' || (rel !== '..' && !rel.startsWith(`..${path.sep}`) && !path.isAbsolute(rel));
+}
+
+export function listDirs(root: string): string[] {
+  const dirs = [root];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name === '.git' || entry.name === 'node_modules') continue;
+    dirs.push(...listDirs(path.join(root, entry.name)));
+  }
+  return dirs;
+}
+
+export function listFiles(root: string, include: (filePath: string) => boolean): string[] {
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) files.push(...listFiles(fullPath, include));
+    else if (entry.isFile() && include(fullPath)) files.push(fullPath);
+  }
+  return files;
+}
+
+export function watchDir(dir: string, onFileEvent: (filePath: string) => void): fs.FSWatcher | null {
+  try {
+    return fs.watch(dir, { persistent: false }, (_event, filename) => {
+      if (filename) onFileEvent(path.join(dir, filename));
+    });
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Complete the watcher follow-up gap after #1719: new `ψ/memory/learnings/*.md` files now get persisted to SQLite/FTS and queued for vector indexing.
- Keep new `ψ/learn` behavior intact while extracting shared watch utilities to keep files under the 250-line limit.
- Add regression coverage for startup catch-up of new `ψ/memory/learnings` markdown.

## Tests
- `bunx tsc --noEmit`
- `bun test src/indexer/__tests__/learn-watcher.test.ts`

Refs #1423
