### PR TITLE
feat: complete maw arra CLI verb coverage

### DIFF
--- a/maw-plugin/README.md
+++ b/maw-plugin/README.md
@@ -17,6 +17,20 @@ Read commands are open. Write commands attach `Authorization: Bearer $ARRA_API_T
 
 ```sh
 maw arra help
+maw arra config show
+maw arra doctor --json
+maw arra session list
+maw arra plugin list
+maw arra export --format markdown --out vault.md
+maw arra import --format json --in vault-export.json
+maw arra export-obsidian --out ./vault --dry-run
+maw arra import-obsidian --in ./vault --dry-run
+maw arra backup --out-dir ./backups
+maw arra migrate
+maw arra seed
+maw arra changelog --stdout
+maw arra canvas-plugins --json
+maw arra canvas-serve --port 47779
 maw arra frontend          # opens https://studio.buildwithoracle.com/?api=<backend>
 maw arra ui --no-open      # prints the link only
 maw arra serve             # starts bun run server in the background
@@ -56,13 +70,21 @@ maw arra list --type learning --limit 20
 maw arra read --id <docId>
 maw arra reflect
 maw arra supersede <oldId> <newId> --reason "merged duplicate"
+maw arra supersede-list --limit 20
+maw arra supersede-chain ψ/learnings/demo.md
 
 maw arra thread "message" --thread-id 42 --title "Investigation"
 maw arra threads --status active --limit 10
 maw arra thread_read 42
 maw arra thread_update 42 --status closed
+maw arra schedule --status pending --limit 10
+maw arra schedule-add "daily standup" --date 2026-06-16
+maw arra vault-sync --dry-run --reindex
+maw arra mcp-tools
 maw arra verify --check false --type learning
 ```
+
+Local maintenance commands (`config`, `doctor`, `session`, `plugin`, `export`, `import`, `export-obsidian`, `import-obsidian`, `backup`, `migrate`, `seed`, `changelog`, `release`, `canvas-plugins`, `canvas-serve`, and `vault`) delegate to the repo CLI entrypoint through `ORACLE_ROOT` or `ghq locate`, so `maw arra` can cover the remaining built-in CLI verbs without duplicating implementation.
 
 `serve` accepts `start`/`stop`/`status` positionals or `--stop`/`--status` flags. It resolves the repo root from `ORACLE_ROOT` or `ghq locate`, writes `~/.arra-oracle-v2/server.pid`, and passes `--port` as `ORACLE_PORT`.
 

--- a/maw-plugin/__tests__/index.test.ts
+++ b/maw-plugin/__tests__/index.test.ts
@@ -27,50 +27,32 @@ describe('maw arra plugin', () => {
   });
 
   test('help lists the full compact MCP surface', async () => {
-    expect(listSubcommands()).toEqual([
-      'concepts',
-      'feed',
-      'frontend',
-      'handoff',
-      'health',
-      'inbox',
-      'index',
-      'learn',
-      'list',
-      'menu',
-      'open',
-      'plugins',
-      'read',
-      'reflect',
-      'scan',
-      'search',
-      'serve',
-      'settings',
-      'stats',
-      'studio',
-      'supersede',
-      'thread',
-      'thread_read',
-      'thread_update',
-      'threads',
-      'trace',
-      'trace_chain',
-      'trace_get',
-      'trace_link',
-      'trace_list',
-      'trace_unlink',
-      'ui',
-      'vector',
+    const subcommands = listSubcommands();
+    expect(subcommands).toEqual([...subcommands].sort());
+    expect(subcommands).toEqual(expect.arrayContaining([
+      'backup',
+      'canvas-plugins',
+      'canvas-serve',
+      'changelog',
+      'config',
+      'export',
+      'export-obsidian',
+      'import',
+      'import-obsidian',
+      'mcp_tools',
+      'migrate',
+      'schedule',
+      'schedule_add',
+      'supersede_chain',
+      'supersede_list',
+      'vault',
+      'vault_sync',
       'vector_config',
-      'vector_index',
-      'vector_models',
-      'vector_status',
-      'vector_stop',
-      'verify',
-    ]);
+    ]));
 
     const help = await runArra(['help']);
     expect(help.output).toContain('frontend');
+    expect(help.output).toContain('export --format json|markdown');
     expect(help.output).toContain('index');
     expect(help.output).toContain('vector');
     expect(help.output).toContain('vector-config [--json]');
@@ -79,6 +61,8 @@ describe('maw arra plugin', () => {
     expect(help.output).toContain('trace_chain');
     expect(help.output).toContain('thread_update');
     expect(help.output).toContain('serve [--stop|--status] [--port N]');
+    expect(help.output).toContain('schedule-add');
+    expect(help.output).toContain('vault-sync');
     expect(help.output).toContain('verify');
   });
 
@@ -158,6 +142,10 @@ describe('maw arra plugin', () => {
       [['list', '--type', 'learning', '--limit', '7'], 'GET', '/api/list?type=learning&limit=7&group=false'],
       [['read', '--id', 'doc1'], 'GET', '/api/read?id=doc1'],
       [['reflect'], 'GET', '/api/reflect'],
+      [['schedule', '--status', 'pending', '--limit', '2'], 'GET', '/api/schedule?status=pending&limit=2'],
+      [['supersede-list', '--limit', '2'], 'GET', '/api/supersede?limit=2'],
+      [['supersede-chain', 'ψ/demo.md'], 'GET', '/api/supersede/chain/%CF%88%2Fdemo.md'],
+      [['mcp-tools'], 'GET', '/api/mcp/tools'],
       [['threads', '--status', 'active', '--limit', '5'], 'GET', '/api/threads?status=active&limit=5'],
       [['thread_read', '42'], 'GET', '/api/thread/42'],
     ];
@@ -187,6 +175,8 @@ describe('maw arra plugin', () => {
       [['vector-config', 'set', 'bge-m3', 'enabled', 'false'], 'PUT', '/api/v1/vector/config/bge-m3', { enabled: false }],
       [['vector-config', 'reload'], 'POST', '/api/v1/vector/config/reload', undefined],
       [['vector-config', 'test', 'bge-m3'], 'POST', '/api/v1/vector/config/bge-m3/test', undefined],
+      [['schedule-add', 'standup', '--date', '2026-06-16'], 'POST', '/api/schedule', { event: 'standup', date: '2026-06-16' }],
+      [['vault-sync', '--dry-run', '--reindex'], 'POST', '/api/vault/sync', { dryRun: true, reindex: true }],
       [['verify', '--check', 'false', '--type', 'learning'], 'POST', '/api/verify', { check: false, type: 'learning' }],
     ];
 

--- a/maw-plugin/__tests__/local-cli.test.ts
+++ b/maw-plugin/__tests__/local-cli.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+import { runArra } from '../index.ts';
+
+describe('maw arra local CLI verb bridge', () => {
+  test('delegates remaining built-in CLI verbs through the repo CLI entrypoint', async () => {
+    const calls: any[] = [];
+    const runner = async (cmd: string, args: string[], options?: any) => {
+      calls.push({ cmd, args, options });
+      if (cmd === 'ghq') return { code: 0, stdout: '/repo/arra-oracle-v3\n', stderr: '' };
+      return { code: 0, stdout: 'exported markdown\n', stderr: '' };
+    };
+
+    const result = await runArra(['export', '--format', 'markdown'], async () => ({}), () => {}, {}, runner);
+
+    expect(result).toEqual({ ok: true, output: 'exported markdown' });
+    expect(calls).toContainEqual(expect.objectContaining({ cmd: 'ghq' }));
+    expect(calls.at(-1)).toMatchObject({
+      cmd: 'bun',
+      args: ['run', 'cli/src/cli.ts', 'export', '--format', 'markdown'],
+      options: expect.objectContaining({ cwd: '/repo/arra-oracle-v3', capture: true }),
+    });
+  });
+
+  test('surfaces non-zero delegated CLI failures', async () => {
+    const runner = async (cmd: string) => cmd === 'ghq'
+      ? { code: 0, stdout: '/repo/arra-oracle-v3\n', stderr: '' }
+      : { code: 2, stdout: '', stderr: 'bad export' };
+    const result = await runArra(['export'], async () => ({}), () => {}, {}, runner);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('bad export');
+  });
+});

--- a/maw-plugin/index.ts
+++ b/maw-plugin/index.ts
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process';
 import { join } from 'node:path';
 import { apiArgsToCliArgs } from './api.ts';
 import { runServe, type ServeDeps } from './serve.ts';
+import { LOCAL_CLI_HELP, resolveLocalCliName, runLocalCli } from './local-cli.ts';
 import { runVectorConfig, VECTOR_CONFIG_HELP } from './vector-config.ts';
 type InvokeContext = { source?: string; args?: string[] | Record<string, unknown>; writer?: (...args: unknown[]) => void };
 type InvokeResult = { ok: boolean; output?: string; error?: string };
@@ -160,14 +161,20 @@ export const COMMANDS: Record<string, Spec> = {
   read: { tool: 'oracle_read', method: 'GET', help: 'read <file-or-id> [--file F|--id ID]', build: p => route('/api/read', { file: f(p, 'file') || (!f(p, 'id') ? p.pos[0] : undefined), id: f(p, 'id') }), format: d => one(d?.content ?? d?.text ?? preview(d), 900) },
   reflect: { tool: 'oracle_reflect', method: 'GET', help: 'reflect', build: () => route('/api/reflect'), format: d => `arra reflect: ${one(d?.text ?? d?.reflection ?? preview(d), 500)}` },
   supersede: { tool: 'oracle_supersede', method: 'POST', write: true, help: 'supersede <oldId> <newId> [--reason R]', build: p => { const oldId = first(p, 'old_id', 'oldId'); const newId = f(p, 'new_id') || p.pos[1]; if (!newId) throw new Error('newId required'); return route('/api/supersede/document', undefined, { oldId, newId, reason: f(p, 'reason') }); }, format: formatOk('supersede') },
+  supersede_list: { tool: 'oracle_supersede_list', method: 'GET', help: 'supersede-list [--project P] [--limit N]', build: p => route('/api/supersede', { project: f(p, 'project'), limit: f(p, 'limit'), offset: f(p, 'offset') }), format: formatRows('supersede-list', ['supersessions']) },
+  supersede_chain: { tool: 'oracle_supersede_chain', method: 'GET', help: 'supersede-chain <path>', build: p => route(`/api/supersede/chain/${enc(first(p, 'path', 'path'))}`), format: d => `arra supersede-chain: ${preview(d, 700)}` },
   thread: { tool: 'oracle_thread', method: 'POST', write: true, help: 'thread <message> [--thread-id N] [--title T]', build: p => route('/api/thread', undefined, { message: text(p, 'message', 'message'), thread_id: n(p, 'thread_id'), title: f(p, 'title'), role: f(p, 'role') || 'human', model: f(p, 'model') }), format: formatOk('thread') },
   threads: { tool: 'oracle_threads', method: 'GET', help: 'threads [--status active|closed] [--limit N]', build: p => route('/api/threads', { status: f(p, 'status'), limit: f(p, 'limit'), offset: f(p, 'offset') }), format: formatRows('threads', ['threads']) },
   thread_read: { tool: 'oracle_thread_read', method: 'GET', help: 'thread_read <threadId>', build: p => route(`/api/thread/${enc(first(p, 'thread_id', 'threadId'))}`), format: d => [`arra thread: ${d?.thread?.id ?? d?.thread_id ?? '?'}`, d?.thread?.title && `title: ${d.thread.title}`, Array.isArray(d?.messages) && `messages: ${d.messages.length}`].filter(Boolean).join('\n') },
   thread_update: { tool: 'oracle_thread_update', method: 'PATCH', write: true, help: 'thread_update <threadId> --status active|closed|answered|pending', build: p => route(`/api/thread/${enc(first(p, 'thread_id', 'threadId'))}/status`, undefined, { status: f(p, 'status') || p.pos[1] }), format: formatOk('thread_update') },
+  schedule: { tool: 'oracle_schedule_list', method: 'GET', help: 'schedule [--date YYYY-MM-DD] [--from D] [--to D] [--status S]', build: p => route('/api/schedule', { date: f(p, 'date'), from: f(p, 'from'), to: f(p, 'to'), filter: f(p, 'filter'), status: f(p, 'status'), limit: f(p, 'limit') }), format: formatRows('schedule', ['events', 'items', 'schedule']) },
+  schedule_add: { tool: 'oracle_schedule_add', method: 'POST', write: true, help: 'schedule-add <event> --date D [--time T]', build: p => route('/api/schedule', undefined, { event: text(p, 'event', 'event'), date: f(p, 'date'), time: f(p, 'time'), notes: f(p, 'notes'), recurring: f(p, 'recurring') }), format: formatOk('schedule-add') },
+  vault_sync: { tool: 'oracle_vault_sync', method: 'POST', write: true, help: 'vault-sync [--dry-run] [--reindex]', build: p => route('/api/vault/sync', undefined, { dryRun: b(p, 'dry_run'), reindex: b(p, 'reindex') }), format: formatOk('vault-sync') },
+  mcp_tools: { tool: 'oracle_mcp_tools', method: 'GET', help: 'mcp-tools', build: () => route('/api/mcp/tools'), format: formatRows('mcp-tools', ['tools']) },
   verify: { tool: 'oracle_verify', method: 'POST', write: true, help: 'verify [--check true|false] [--type all|learning|pattern]', build: p => route('/api/verify', undefined, { check: b(p, 'check'), type: f(p, 'type') }), format: d => `arra verify: ${preview(d, 500)}` },
 };
 
-const LOCAL_COMMANDS = { frontend: 'frontend [--no-open]', ui: 'ui [--no-open]', open: 'open [--no-open]', serve: 'serve [--stop|--status] [--port N]', studio: 'studio [--port N]' } as const;
+const LOCAL_COMMANDS = { frontend: 'frontend [--no-open]', ui: 'ui [--no-open]', open: 'open [--no-open]', serve: 'serve [--stop|--status] [--port N]', server: 'server [start|stop|status]', studio: 'studio [--port N]', ...LOCAL_CLI_HELP } as const;
 function usage(): InvokeResult {
   const commandNames = [...Object.keys(COMMANDS), ...Object.keys(LOCAL_COMMANDS)].sort();
   return { ok: false, error: 'usage', output: ['usage: maw arra <subcommand> [args]', `subcommands: ${commandNames.join('|')}`, '', ...Object.entries(LOCAL_COMMANDS).sort().map(([name, help]) => `  ${name}  ${help}`), ...Object.entries(COMMANDS).sort().map(([name, spec]) => `  ${name}  ${spec.help}`)].join('\n') };
@@ -200,7 +207,8 @@ export async function runArra(args: string[], request: Requester = requestJson, 
   const parsed = parse(args.slice(1));
   if (sub === 'frontend' || sub === 'ui' || sub === 'open') return runFrontend(parsed, opener, env);
   if (sub === 'studio') return runStudio(parsed, runner, env);
-  if (sub === 'serve') return runServe(parsed, runner, env, serveDeps);
+  if (sub === 'serve' || sub === 'server') return runServe(parsed, runner, env, serveDeps);
+  if (resolveLocalCliName(sub)) return runLocalCli(sub, args.slice(1), runner, env);
   if (sub === 'vector_config') return runVectorConfig(parsed, request, authHeaders);
   const spec = COMMANDS[sub];
   if (!spec) return usage();

--- a/maw-plugin/local-cli.ts
+++ b/maw-plugin/local-cli.ts
@@ -1,0 +1,68 @@
+import { join } from 'node:path';
+import type { InvokeResult, Runner } from './serve.ts';
+
+export const LOCAL_CLI_HELP: Record<string, string> = {
+  backup: 'backup [--out-dir DIR]',
+  changelog: 'changelog [--since TAG] [--out FILE] [--stdout]',
+  completions: 'completions <bash|zsh|fish>',
+  config: 'config [show|path|use NAME]',
+  'canvas-plugins': 'canvas-plugins [--kind three|react] [--id ID] [--json]',
+  'canvas-serve': 'canvas-serve [--port N] [--api-base URL]',
+  doctor: 'doctor [--json]',
+  export: 'export --format json|markdown [--out FILE]',
+  'export-obsidian': 'export-obsidian --out PATH [--dry-run]',
+  huginn: 'huginn sweep [--json]',
+  import: 'import --format json [--in FILE]',
+  'import-obsidian': 'import-obsidian --in PATH [--dry-run]',
+  migrate: 'migrate',
+  peers: 'peers [--json]',
+  plugin: 'plugin <list|info|install|remove>',
+  release: 'release [--beta|--stable] [--dry-run]',
+  seed: 'seed',
+  session: 'session <list|show|context>',
+  use: 'use <target>',
+  vault: 'vault [sync|status|pull] [--dry-run]',
+};
+
+const REPO_SLUGS = ['Soul-Brews-Studio/arra-oracle-v3', 'github.com/Soul-Brews-Studio/arra-oracle-v3'];
+const CANONICAL: Record<string, string> = Object.fromEntries(
+  Object.keys(LOCAL_CLI_HELP).flatMap(name => [[name, name], [name.replace(/-/g, '_'), name]]),
+);
+
+export function resolveLocalCliName(name: string): string | undefined {
+  return CANONICAL[name.toLowerCase().replace(/-/g, '_')];
+}
+
+async function resolveRoot(env: Record<string, string | undefined>, runner: Runner): Promise<string> {
+  const explicit = env.ORACLE_ROOT?.trim();
+  if (explicit) return explicit;
+  for (const slug of REPO_SLUGS) {
+    const result = await runner('ghq', ['locate', slug], { capture: true });
+    if (result.code === 0 && result.stdout?.trim()) return result.stdout.trim();
+  }
+  return process.cwd();
+}
+
+export async function runLocalCli(
+  command: string,
+  args: string[],
+  runner: Runner,
+  env: Record<string, string | undefined>,
+): Promise<InvokeResult> {
+  const name = resolveLocalCliName(command);
+  if (!name) return { ok: false, error: `unknown local CLI command: ${command}` };
+  try {
+    const cwd = await resolveRoot(env, runner);
+    const result = await runner('bun', ['run', join('cli', 'src', 'cli.ts'), name, ...args], {
+      cwd,
+      env,
+      capture: true,
+    });
+    const output = [result.stdout?.trim(), result.stderr?.trim()].filter(Boolean).join('\n');
+    return result.code === 0
+      ? { ok: true, output: output || `arra ${name}: ok` }
+      : { ok: false, error: output || `arra ${name} failed${result.code === null ? '' : ` (${result.code})`}` };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}

--- a/maw-plugin/plugin.json
+++ b/maw-plugin/plugin.json
@@ -9,14 +9,16 @@
     "aliases": [
       "or"
     ],
-    "help": "maw arra <frontend|ui|open|serve|studio|search|learn|stats|health|index|scan|plugins|settings|feed|menu|vector|vector-config|vector_index|vector_status|vector_stop|vector_models|trace|trace_list|trace_get|trace_link|trace_unlink|trace_chain|concepts|handoff|inbox|list|read|reflect|supersede|thread|thread_read|thread_update|threads|verify>"
+    "help": "maw arra <backup|canvas-plugins|canvas-serve|changelog|completions|config|doctor|export|export-obsidian|huginn|import|import-obsidian|migrate|peers|plugin|release|seed|session|use|vault|frontend|ui|open|serve|server|studio|search|learn|stats|health|index|scan|plugins|settings|feed|menu|vector|vector-config|vector_index|vector_status|vector_stop|vector_models|trace|trace_list|trace_get|trace_link|trace_unlink|trace_chain|concepts|handoff|inbox|list|read|reflect|supersede|supersede_list|supersede_chain|thread|thread_read|thread_update|threads|schedule|schedule_add|vault_sync|mcp_tools|verify>"
   },
   "capabilities": [
-    "net:http"
+    "net:http",
+    "proc",
+    "shell"
   ],
   "weight": 50,
   "schemaVersion": 1,
-  "help": "maw arra <frontend|ui|open|serve|studio|search|learn|stats|health|index|scan|plugins|settings|feed|menu|vector|vector-config|vector_index|vector_status|vector_stop|vector_models|trace|trace_list|trace_get|trace_link|trace_unlink|trace_chain|concepts|handoff|inbox|list|read|reflect|supersede|thread|thread_read|thread_update|threads|verify>",
+  "help": "maw arra <backup|canvas-plugins|canvas-serve|changelog|completions|config|doctor|export|export-obsidian|huginn|import|import-obsidian|migrate|peers|plugin|release|seed|session|use|vault|frontend|ui|open|serve|server|studio|search|learn|stats|health|index|scan|plugins|settings|feed|menu|vector|vector-config|vector_index|vector_status|vector_stop|vector_models|trace|trace_list|trace_get|trace_link|trace_unlink|trace_chain|concepts|handoff|inbox|list|read|reflect|supersede|supersede_list|supersede_chain|thread|thread_read|thread_update|threads|schedule|schedule_add|vault_sync|mcp_tools|verify>",
   "api": {
     "path": "/api/arra",
     "methods": [


### PR DESCRIPTION
## Summary
- Extend `maw arra` to cover remaining CLI maintenance verbs via a shared local CLI bridge instead of duplicating existing implementations.
- Add direct maw-plugin routes for remaining API-backed verbs: schedule list/add, supersede list/chain, vault sync, and MCP tool listing.
- Update plugin manifest/help/README and regression coverage for the expanded command registry.

## Verification
- `bun test maw-plugin/__tests__/ tests/http/menu/arra-maw-plugin-menu.test.ts`
- `bunx tsc --noEmit`
- `git diff --check`
- `wc -l` on changed files (all ≤250)

## Notes
- Local maintenance verbs resolve the repo through `ORACLE_ROOT` or `ghq locate` and run `bun run cli/src/cli.ts ...` so behavior stays centralized.
