### PR TITLE
feat(canvas): serve registry from subdomain worker (#1403)

### DIFF
--- a/src/canvas/registry.ts
+++ b/src/canvas/registry.ts
@@ -1,0 +1,33 @@
+import { findCanvasPlugin, listCanvasPlugins, type CanvasPluginKind } from './plugins.ts';
+
+const kinds = new Set<CanvasPluginKind>(['three', 'react']);
+
+export function parseCanvasKind(value: unknown): CanvasPluginKind | undefined {
+  return typeof value === 'string' && kinds.has(value as CanvasPluginKind) ? value as CanvasPluginKind : undefined;
+}
+
+export function canvasPluginUrl(id: string): string {
+  return id === 'map' || id === 'planets' ? `/${id}` : `/?plugin=${id}`;
+}
+
+export function canvasRegistry(kind?: CanvasPluginKind) {
+  const plugins = listCanvasPlugins(kind).map((plugin) => ({
+    ...plugin,
+    standalonePath: canvasPluginUrl(plugin.id),
+  }));
+  return {
+    plugins,
+    count: plugins.length,
+    kind: kind ?? 'all',
+    standalone: {
+      host: 'canvas.buildwithoracle.com',
+      defaultPlugin: 'wave',
+      serveCommand: 'bun run src/cli/index.ts canvas-serve --port 47779',
+    },
+  };
+}
+
+export function canvasPluginEntry(id: string) {
+  const plugin = findCanvasPlugin(id);
+  return plugin ? { plugin: { ...plugin, standalonePath: canvasPluginUrl(plugin.id) } } : null;
+}

--- a/src/routes/canvas/index.ts
+++ b/src/routes/canvas/index.ts
@@ -1,43 +1,23 @@
 import { Elysia, t } from 'elysia';
-import { findCanvasPlugin, listCanvasPlugins, type CanvasPluginKind } from '../../canvas/plugins.ts';
-
-const kinds = new Set<CanvasPluginKind>(['three', 'react']);
-
-function parseKind(value: unknown): CanvasPluginKind | undefined {
-  return typeof value === 'string' && kinds.has(value as CanvasPluginKind) ? value as CanvasPluginKind : undefined;
-}
-
-function registry(kind?: CanvasPluginKind) {
-  const plugins = listCanvasPlugins(kind);
-  return {
-    plugins,
-    count: plugins.length,
-    kind: kind ?? 'all',
-    standalone: {
-      host: 'canvas.buildwithoracle.com',
-      defaultPlugin: 'wave',
-      serveCommand: 'bun run src/cli/index.ts canvas-serve --port 47779',
-    },
-  };
-}
+import { canvasPluginEntry, canvasRegistry, parseCanvasKind } from '../../canvas/registry.ts';
 
 export const canvasRoutes = new Elysia({ name: 'canvas-routes' })
-  .get('/api/canvas/plugins', ({ query }) => registry(parseKind(query.kind)), {
+  .get('/api/canvas/plugins', ({ query }) => canvasRegistry(parseCanvasKind(query.kind)), {
     query: t.Object({ kind: t.Optional(t.String()) }),
     detail: { tags: ['canvas'], summary: 'List canvas plugin registry entries' },
   })
   .get('/api/canvas/plugins/:id', ({ params, set }) => {
-    const plugin = findCanvasPlugin(params.id);
-    if (!plugin) {
+    const entry = canvasPluginEntry(params.id);
+    if (!entry) {
       set.status = 404;
       return { error: 'canvas plugin not found', id: params.id };
     }
-    return { plugin };
+    return entry;
   }, {
     params: t.Object({ id: t.String({ minLength: 1 }) }),
     detail: { tags: ['canvas'], summary: 'Get one canvas plugin registry entry' },
   })
-  .get('/api/canvas/registry', ({ query }) => registry(parseKind(query.kind)), {
+  .get('/api/canvas/registry', ({ query }) => canvasRegistry(parseCanvasKind(query.kind)), {
     query: t.Object({ kind: t.Optional(t.String()) }),
     detail: { tags: ['canvas'], summary: 'Canvas standalone registry manifest' },
   });

--- a/src/workers/canvas/index.ts
+++ b/src/workers/canvas/index.ts
@@ -1,3 +1,4 @@
+import { canvasPluginEntry, canvasRegistry, parseCanvasKind } from '../../canvas/registry.ts';
 import { normalizePlugin, renderCanvasApp } from './render.ts';
 
 export interface CanvasWorkerEnv {
@@ -14,6 +15,12 @@ const API_CACHE_HEADERS = {
 const HTML_HEADERS = {
   'Content-Type': 'text/html; charset=utf-8',
   'Cache-Control': 'public, max-age=60, stale-while-revalidate=300',
+};
+
+const REGISTRY_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Cache-Control': 'public, max-age=60, stale-while-revalidate=300',
+  'Content-Type': 'application/json; charset=utf-8',
 };
 
 function apiBase(env: CanvasWorkerEnv): string {
@@ -36,6 +43,18 @@ async function proxyApi(request: Request, env: CanvasWorkerEnv): Promise<Respons
   return new Response(upstream.body, { status: upstream.status, statusText: upstream.statusText, headers: responseHeaders });
 }
 
+
+function registryResponse(url: URL): Response | null {
+  if (url.pathname === '/api/canvas/plugins' || url.pathname === '/api/canvas/registry') {
+    return Response.json(canvasRegistry(parseCanvasKind(url.searchParams.get('kind'))), { headers: REGISTRY_HEADERS });
+  }
+  const match = url.pathname.match(/^\/api\/canvas\/plugins\/([^/]+)$/);
+  if (!match) return null;
+  const entry = canvasPluginEntry(decodeURIComponent(match[1]));
+  if (!entry) return Response.json({ error: 'canvas plugin not found', id: match[1] }, { status: 404, headers: REGISTRY_HEADERS });
+  return Response.json(entry, { headers: REGISTRY_HEADERS });
+}
+
 function pluginFrom(url: URL) {
   const pathPlugin = url.pathname.length > 1 ? url.pathname.slice(1).split('/')[0] : null;
   return normalizePlugin(url.searchParams.get('plugin') ?? pathPlugin);
@@ -43,6 +62,10 @@ function pluginFrom(url: URL) {
 
 export async function handleCanvasRequest(request: Request, env: CanvasWorkerEnv = {}): Promise<Response> {
   const url = new URL(request.url);
+  if (url.pathname.startsWith('/api/canvas/') && request.method === 'GET') {
+    const registry = registryResponse(url);
+    if (registry) return registry;
+  }
   if (url.pathname.startsWith('/api/') && request.method === 'OPTIONS') return new Response(null, { status: 204, headers: API_CACHE_HEADERS });
   if (url.pathname.startsWith('/api/')) return proxyApi(request, env);
   if (request.method !== 'GET' && request.method !== 'HEAD') return new Response('Method not allowed', { status: 405 });

--- a/tests/http/canvas-worker.test.ts
+++ b/tests/http/canvas-worker.test.ts
@@ -24,6 +24,25 @@ describe('canvas subdomain worker app', () => {
     expect(preflight.headers.get('cache-control')).toBe('no-store');
   });
 
+  test('serves canvas registry locally on the subdomain worker', async () => {
+    const res = await handleCanvasRequest(new Request('https://canvas.buildwithoracle.com/api/canvas/plugins?kind=react'));
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('cache-control')).toContain('stale-while-revalidate');
+    expect(body.kind).toBe('react');
+    expect(body.plugins.map((plugin: { id: string }) => plugin.id)).toEqual(['map', 'planets']);
+    expect(body.plugins[0].standalonePath).toBe('/map');
+  });
+
+  test('serves one local canvas plugin and leaves other api routes proxied', async () => {
+    const plugin = await handleCanvasRequest(new Request('https://canvas.buildwithoracle.com/api/canvas/plugins/wave'));
+    expect(await plugin.json()).toMatchObject({ plugin: { id: 'wave', standalonePath: '/?plugin=wave' } });
+
+    const missing = await handleCanvasRequest(new Request('https://canvas.buildwithoracle.com/api/canvas/plugins/missing'));
+    expect(missing.status).toBe(404);
+  });
+
   test('wrangler custom domain runs worker first', () => {
     const config = readFileSync('workers/canvas/wrangler.toml', 'utf8');
     expect(config).toContain('canvas.buildwithoracle.com');

--- a/tests/workers/canvas-worker.test.ts
+++ b/tests/workers/canvas-worker.test.ts
@@ -42,6 +42,19 @@ describe('canvas Cloudflare Worker', () => {
     expect(response.headers.get('access-control-allow-origin')).toBe('*');
   });
 
+  test('serves local canvas registry without upstream fetch', async () => {
+    globalThis.fetch = (async () => {
+      throw new Error('registry should not proxy');
+    }) as typeof fetch;
+
+    const response = await handleCanvasRequest(new Request('https://canvas.buildwithoracle.com/api/canvas/registry'));
+    const body = await response.json() as { count: number; standalone: { host: string } };
+
+    expect(response.status).toBe(200);
+    expect(body.count).toBeGreaterThanOrEqual(3);
+    expect(body.standalone.host).toBe('canvas.buildwithoracle.com');
+  });
+
   test('proxies api requests to configured oracle backend without caching', async () => {
     const seen: string[] = [];
     globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {


### PR DESCRIPTION
## Summary
- Continues #1403 after PR #1722 by making the canvas subdomain Worker serve its own canvas registry API.
- Shares registry construction between Studio HTTP routes and the Worker so `/api/canvas/plugins`, `/api/canvas/plugins/:id`, and `/api/canvas/registry` stay aligned.
- Keeps other `/api/*` requests proxied to the Oracle backend with no-store cache behavior.
- Adds cache/API coverage proving registry requests are local to the Worker and not upstream-proxied.

## Validation
- `bunx tsc --noEmit`
- `bun test tests/http/canvas-worker.test.ts tests/workers/canvas-worker.test.ts tests/canvas/phase2.test.ts`

## Notes
- Live Cloudflare deployment not exercised locally.
