### PR TITLE
fix: return 404 for missing vector service tests (#1438)

### DIFF
--- a/src/routes/vector/services.ts
+++ b/src/routes/vector/services.ts
@@ -50,7 +50,12 @@ export function createVectorServicesApiEndpoint(registry: VectorServiceRegistry 
       params: t.Object({ name: t.String({ minLength: 1 }) }),
       detail: { tags: ['vector-registry'], summary: 'Unregister one vector service' },
     })
-    .post('/vector/services/:name/test', async ({ params }) => {
+    .post('/vector/services/:name/test', async ({ params, set }) => {
+      const services = await registry.discover();
+      if (!services.some((service) => service.name === params.name)) {
+        set.status = 404;
+        return { success: false, error: `Service not found: ${params.name}` };
+      }
       const health = await registry.healthCheck();
       const result = health.get(params.name);
       return {

--- a/tests/http/vector/services.test.ts
+++ b/tests/http/vector/services.test.ts
@@ -61,6 +61,10 @@ test('vector service registry API registers, tests, lists, and removes proxy ser
 
   const removed = await fetcher(new Request('http://local/api/v1/vector/services/turbovec', { method: 'DELETE' }));
   expect(await json(removed)).toEqual({ success: true, removed: 'turbovec' });
+
+  const missingTest = await fetcher(new Request('http://local/api/v1/vector/services/turbovec/test', { method: 'POST' }));
+  expect(missingTest.status).toBe(404);
+  expect(await json(missingTest)).toEqual({ success: false, error: 'Service not found: turbovec' });
 });
 
 test('vector service registry API rejects proxy registration without endpoint', async () => {


### PR DESCRIPTION
Closes part of #1438

## Changes
- Treat service-registry test requests for unregistered services as 404
- Keep existing registered service health-check behavior unchanged
- Add scoped vector regression coverage after unregistering a proxy service

## Test
- bunx tsc --noEmit: green
- bun test tests/http/vector/: passed