### PR TITLE
fix: preserve proxy service base paths

### DIFF
--- a/src/vector/registry.ts
+++ b/src/vector/registry.ts
@@ -41,6 +41,11 @@ export interface VectorServiceRegistry {
 
 const HEALTH_TIMEOUT_MS = 5_000;
 
+export function vectorServiceUrl(endpoint: string, suffix: string): string {
+  const safeBase = endpoint.replace(/\/+$/, '');
+  return `${safeBase}${suffix.startsWith('/') ? suffix : `/${suffix}`}`;
+}
+
 function activeConfigPath(): string {
   const dataDir = process.env.ORACLE_DATA_DIR;
   return dataDir ? configPath(dataDir) : configPath();
@@ -166,7 +171,7 @@ class InMemoryVectorServiceRegistry implements VectorServiceRegistry {
         if (!endpoint) {
           throw new Error('missing endpoint');
         }
-        const healthUrl = new URL('/health', endpoint);
+        const healthUrl = vectorServiceUrl(endpoint, '/health');
         const response = await fetch(healthUrl, {
           method: 'GET',
           signal: AbortSignal.timeout(HEALTH_TIMEOUT_MS),

--- a/tests/http/vector/proxy-adapter.test.ts
+++ b/tests/http/vector/proxy-adapter.test.ts
@@ -1,0 +1,53 @@
+import { afterAll, expect, test } from 'bun:test';
+import type { VectorDocument } from '../../../src/vector/types.ts';
+import { ProxyVectorAdapter } from '../../../src/vector/adapters/proxy.ts';
+import { vectorServiceUrl } from '../../../src/vector/registry.ts';
+
+const requests: Array<{ method: string; path: string; body?: unknown }> = [];
+
+const server = Bun.serve({
+  hostname: '127.0.0.1',
+  port: 0,
+  async fetch(request) {
+    const url = new URL(request.url);
+    const body = request.method === 'GET' || request.method === 'DELETE' ? undefined : await request.json();
+    requests.push({ method: request.method, path: url.pathname, body });
+    if (url.pathname === '/proxy/health') return Response.json({ status: 'ok', name: 'proxy-test', version: '1' });
+    if (url.pathname === '/proxy/vectors/stats') return Response.json({ count: 2, name: 'proxy_docs' });
+    if (url.pathname === '/proxy/vectors/add') return Response.json({ success: true });
+    if (url.pathname === '/proxy/vectors/query') return Response.json({
+      ids: ['doc-1'], documents: ['hello'], distances: [0.1], metadatas: [{ type: 'learning' }],
+    });
+    if (url.pathname === '/proxy/vectors/collection') return Response.json({ success: true });
+    return new Response('not found', { status: 404 });
+  },
+});
+
+afterAll(() => { server.stop(true); });
+
+test('ProxyVectorAdapter speaks vector proxy protocol under endpoint path prefixes', async () => {
+  requests.length = 0;
+  const adapter = new ProxyVectorAdapter('proxy_docs', `${server.url}proxy`);
+  const docs: VectorDocument[] = [{ id: 'doc-1', document: 'hello', metadata: { type: 'learning' } }];
+
+  await adapter.connect();
+  await adapter.addDocuments(docs);
+  const result = await adapter.query('hello', 3, { type: 'learning' });
+  const info = await adapter.getCollectionInfo();
+  await adapter.deleteCollection();
+
+  expect(result.ids).toEqual(['doc-1']);
+  expect(info).toEqual({ name: 'proxy_docs', count: 2 });
+  expect(requests.map((item) => `${item.method} ${item.path}`)).toEqual([
+    'GET /proxy/health',
+    'POST /proxy/vectors/add',
+    'POST /proxy/vectors/query',
+    'GET /proxy/vectors/stats',
+    'DELETE /proxy/vectors/collection',
+  ]);
+  expect(requests[2].body).toEqual({ text: 'hello', limit: 3, where: { type: 'learning' } });
+});
+
+test('vectorServiceUrl preserves path prefixes', () => {
+  expect(vectorServiceUrl('http://example.test/base/', '/health')).toBe('http://example.test/base/health');
+});


### PR DESCRIPTION
## Summary
- Preserve registered proxy service path prefixes during health checks.
- Add protocol-level regression tests for `ProxyVectorAdapter` against `/health`, `/vectors/add`, `/vectors/query`, `/vectors/stats`, and `/vectors/collection`.
- Verify path-prefixed sidecar endpoints remain compatible with the service registry.

## Tests
- `bunx tsc --noEmit`
- `bun test tests/http/vector/`

Refs #1438
