### PR TITLE
feat: serve morning tape as markdown

### DIFF
--- a/src/routes/memory/index.ts
+++ b/src/routes/memory/index.ts
@@ -26,7 +26,11 @@ export function createMemoryRoutes(
     .use(createMemoryFanoutEndpoint())
     .get('/memory/morning-tape', ({ query }) => {
       const limit = Math.min(25, Math.max(1, parseInt(query.limit ?? '8')));
-      return buildMorningTape(store.recall('', limit));
+      const tape = buildMorningTape(store.recall('', limit));
+      if (query.format === 'markdown' || query.format === 'md') {
+        return new Response(tape.markdown, { headers: { 'content-type': 'text/markdown; charset=utf-8' } });
+      }
+      return tape;
     }, {
       query: MorningTapeQuery,
       detail: { tags: ['memory'], menu: { group: 'hidden' }, summary: 'Render a two-minute morning recovery tape from persisted memories' },

--- a/src/routes/memory/model.ts
+++ b/src/routes/memory/model.ts
@@ -19,6 +19,7 @@ export const SemanticMemoryQuery = t.Object({
 
 export const MorningTapeQuery = t.Object({
   limit: t.Optional(t.String()),
+  format: t.Optional(t.String()),
 });
 
 export const MemoryFanoutQuery = t.Object({

--- a/tests/http/memory/morning-tape.test.ts
+++ b/tests/http/memory/morning-tape.test.ts
@@ -61,3 +61,25 @@ test('GET /api/v1/memory/morning-tape includes recent persisted memories', async
   expect(body.markdown).toContain(unique);
   expect(body.sections.map((section: { title: string }) => section.title)).toContain('Fresh memory');
 });
+
+test('GET /api/v1/memory/morning-tape can return direct Markdown for boot reading', async () => {
+  const app = createMemoryRoutes(undefined, new NoopMemoryVectorIndex());
+  const fetcher = createApiVersionedFetch((request) => app.handle(request));
+  const unique = `markdown-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const save = await fetcher(new Request('http://local/api/v1/memory/save', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ title: 'Markdown boot', content: `Read ${unique} in raw markdown.`, tags: ['boot'] }),
+  }));
+  const saved = await json(save);
+  savedIds.push(saved.memory.id);
+
+  const response = await fetcher(new Request('http://local/api/v1/memory/morning-tape?format=markdown&limit=3'));
+  const markdown = await response.text();
+
+  expect(response.status).toBe(200);
+  expect(response.headers.get('content-type')).toContain('text/markdown');
+  expect(markdown).toStartWith('# MORNING-TAPE');
+  expect(markdown).toContain(unique);
+});
+


### PR DESCRIPTION
## Summary
- add `format=markdown` / `format=md` support to the morning-tape memory endpoint
- return `text/markdown` so fresh agents can boot from the tape directly
- cover the markdown response with a fetch-based HTTP test

## Verification
- `bun test tests/http/memory/` — 8 pass
- `bunx tsc --noEmit` — green