### PR TITLE
feat: expose vector config through maw arra

### DIFF
--- a/src/plugins/__tests__/arra-plugin.test.ts
+++ b/src/plugins/__tests__/arra-plugin.test.ts
@@ -1,41 +1,121 @@
-import { describe, expect, test } from 'bun:test';
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { Elysia } from 'elysia';
-import { loadUnifiedPlugins } from '../unified-loader.ts';
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { Elysia } from "elysia";
+import { loadUnifiedPlugins } from "../unified-loader.ts";
 
-const pluginRoot = join(process.cwd(), 'src/plugins');
+const pluginRoot = join(process.cwd(), "src/plugins");
 
-describe('built-in arra plugin', () => {
-  test('declares modern maw-js CLI, menu, and HTTP surfaces', () => {
-    const manifest = JSON.parse(readFileSync(join(pluginRoot, 'arra/plugin.json'), 'utf8'));
+describe("built-in arra plugin", () => {
+  test("declares modern maw-js CLI, menu, and HTTP surfaces", () => {
+    const manifest = JSON.parse(
+      readFileSync(join(pluginRoot, "arra/plugin.json"), "utf8"),
+    );
 
-    expect(manifest.name).toBe('arra');
-    expect(manifest.entry).toBe('./index.ts');
-    expect(manifest.cli.command).toBe('arra');
-    expect(manifest.cli.handler).toBe('arraCli');
-    expect(manifest.verbs).toEqual(['help', 'version', 'menu', 'status']);
-    expect(manifest.httpRoutes[0].path).toBe('/api/plugins/arra');
+    expect(manifest.name).toBe("arra");
+    expect(manifest.entry).toBe("./index.ts");
+    expect(manifest.cli.command).toBe("arra");
+    expect(manifest.cli.handler).toBe("arraCli");
+    expect(manifest.verbs).toEqual([
+      "help",
+      "version",
+      "menu",
+      "status",
+      "vector-config",
+    ]);
+    expect(manifest.httpRoutes[0].path).toBe("/api/plugins/arra");
   });
 
-  test('loads and serves the shared ARRA plugin registry route', async () => {
+  test("loads and serves the shared ARRA plugin registry route", async () => {
     const runtime = await loadUnifiedPlugins({ dirs: [pluginRoot] });
-    const arra = runtime.pluginRegistry().find((plugin) => plugin.name === 'arra');
+    const arra = runtime
+      .pluginRegistry()
+      .find((plugin) => plugin.name === "arra");
 
-    expect(arra?.surfaces).toEqual(['apiRoutes', 'menu', 'cliSubcommands']);
-    expect(runtime.menu.find((item) => item.plugin === 'arra')?.path).toBe('/plugins/arra');
-    const command = runtime.cliSubcommands.find((item) => item.plugin === 'arra');
-    expect(command?.command).toBe('arra');
-    expect(command?.handler).toBe('arraCli');
+    expect(arra?.surfaces).toEqual(["apiRoutes", "menu", "cliSubcommands"]);
+    expect(runtime.menu.find((item) => item.plugin === "arra")?.path).toBe(
+      "/plugins/arra",
+    );
+    const command = runtime.cliSubcommands.find(
+      (item) => item.plugin === "arra",
+    );
+    expect(command?.command).toBe("arra");
+    expect(command?.handler).toBe("arraCli");
 
     const app = new Elysia();
     for (const route of runtime.routes) app.use(route as never);
-    const response = await app.handle(new Request('http://local/api/plugins/arra'));
-    const body = await response.json() as { plugin: string; embedderRequired: boolean; verbs: Array<{ name: string }> };
+    const response = await app.handle(
+      new Request("http://local/api/plugins/arra"),
+    );
+    const body = (await response.json()) as {
+      plugin: string;
+      embedderRequired: boolean;
+      verbs: Array<{ name: string }>;
+    };
 
     expect(response.status).toBe(200);
-    expect(body.plugin).toBe('arra');
+    expect(body.plugin).toBe("arra");
     expect(body.embedderRequired).toBe(false);
-    expect(body.verbs.map((verb) => verb.name)).toEqual(['help', 'version', 'menu', 'status']);
+    expect(body.verbs.map((verb) => verb.name)).toEqual([
+      "help",
+      "version",
+      "menu",
+      "status",
+      "vector-config",
+    ]);
+  });
+
+  test("delegates maw arra vector-config to the vector config CLI", async () => {
+    const { arraCli } = await import("../arra/index.ts");
+    const state = {
+      source: "file",
+      config: {
+        collections: {
+          phase1: {
+            collection: "phase1_collection",
+            model: "bge-m3",
+            provider: "none",
+            adapter: "lancedb",
+          },
+        },
+      },
+      doc_counts: { phase1: 3 },
+      health: {
+        phase1: {
+          ok: true,
+          status: "ok",
+          collection: "phase1_collection",
+          adapter: "lancedb",
+        },
+      },
+    };
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/api/v1/vector/config")
+          return Response.json(state);
+        return Response.json({ error: "not found" }, { status: 404 });
+      },
+    });
+    const saved = process.env.ORACLE_API;
+    process.env.ORACLE_API = String(server.url);
+    try {
+      const result = await arraCli({
+        source: "cli",
+        plugin: "arra",
+        args: ["vector-config", "list", "--json"],
+      });
+      const payload = JSON.parse(result.output);
+      expect(payload.collections[0]).toMatchObject({
+        key: "phase1",
+        docs: 3,
+        status: "ok",
+      });
+    } finally {
+      if (saved === undefined) delete process.env.ORACLE_API;
+      else process.env.ORACLE_API = saved;
+      server.stop();
+    }
   });
 });

--- a/src/plugins/arra/index.ts
+++ b/src/plugins/arra/index.ts
@@ -1,5 +1,7 @@
+import { vectorConfigCli } from "./vector-config-cli.ts";
+
 type ArraPluginContext = {
-  source: 'api' | 'mcp' | 'cli' | 'server' | 'init' | 'destroy';
+  source: "api" | "mcp" | "cli" | "server" | "init" | "destroy";
   plugin: string;
   args?: unknown[];
   request?: Request;
@@ -11,56 +13,110 @@ type ArraVerb = {
   menuPath: string;
   httpPath: string;
   requiresEmbedder: boolean;
-  storage: 'swappable';
+  storage: "swappable";
 };
 
-const VERSION = '1.0.0';
-const MENU_PATH = '/plugins/arra';
-const HTTP_PATH = '/api/plugins/arra';
+type CliResult = { ok: boolean; output?: string; error?: string };
+
+const VERSION = "1.0.0";
+const MENU_PATH = "/plugins/arra";
+const HTTP_PATH = "/api/plugins/arra";
 
 const VERBS: ArraVerb[] = [
-  { name: 'help', help: 'Show ARRA plugin commands', menuPath: MENU_PATH, httpPath: HTTP_PATH, requiresEmbedder: false, storage: 'swappable' },
-  { name: 'version', help: 'Print ARRA plugin version', menuPath: MENU_PATH, httpPath: HTTP_PATH, requiresEmbedder: false, storage: 'swappable' },
-  { name: 'menu', help: 'Describe the ARRA menu surface', menuPath: MENU_PATH, httpPath: HTTP_PATH, requiresEmbedder: false, storage: 'swappable' },
-  { name: 'status', help: 'Describe optional backend capabilities', menuPath: MENU_PATH, httpPath: HTTP_PATH, requiresEmbedder: false, storage: 'swappable' },
+  {
+    name: "help",
+    help: "Show ARRA plugin commands",
+    menuPath: MENU_PATH,
+    httpPath: HTTP_PATH,
+    requiresEmbedder: false,
+    storage: "swappable",
+  },
+  {
+    name: "version",
+    help: "Print ARRA plugin version",
+    menuPath: MENU_PATH,
+    httpPath: HTTP_PATH,
+    requiresEmbedder: false,
+    storage: "swappable",
+  },
+  {
+    name: "menu",
+    help: "Describe the ARRA menu surface",
+    menuPath: MENU_PATH,
+    httpPath: HTTP_PATH,
+    requiresEmbedder: false,
+    storage: "swappable",
+  },
+  {
+    name: "status",
+    help: "Describe optional backend capabilities",
+    menuPath: MENU_PATH,
+    httpPath: HTTP_PATH,
+    requiresEmbedder: false,
+    storage: "swappable",
+  },
+  {
+    name: "vector-config",
+    help: "Inspect and manage vector backend config",
+    menuPath: MENU_PATH,
+    httpPath: "/api/v1/vector/config",
+    requiresEmbedder: false,
+    storage: "swappable",
+  },
 ];
 
 function commandName(ctx: ArraPluginContext): string {
   const arg = ctx.args?.[0];
-  return typeof arg === 'string' && arg.trim() ? arg.trim().toLowerCase() : 'help';
+  return typeof arg === "string" && arg.trim()
+    ? arg.trim().toLowerCase()
+    : "help";
 }
 
 function pluginBody(ctx: ArraPluginContext) {
   return {
-    plugin: ctx.plugin || 'arra',
+    plugin: ctx.plugin || "arra",
     version: VERSION,
     surface: ctx.source,
     menuPath: MENU_PATH,
     httpPath: HTTP_PATH,
-    cliCommand: 'arra',
+    cliCommand: "arra",
     embedderRequired: false,
-    storageBackend: 'swappable',
+    storageBackend: "swappable",
     verbs: VERBS,
   };
 }
 
-function renderCli(ctx: ArraPluginContext): string {
+async function renderCli(ctx: ArraPluginContext): Promise<CliResult> {
   const command = commandName(ctx);
-  if (command === 'version') return `arra ${VERSION}`;
-  if (command === 'menu') return `arra menu: ${MENU_PATH}`;
-  if (command === 'status') return 'arra status: ok (embedder optional, storage swappable)';
-  if (command !== 'help') return `unknown arra command: ${command}\n${renderCli({ ...ctx, args: ['help'] })}`;
-  return ['maw arra <command>', ...VERBS.map((verb) => `  ${verb.name.padEnd(8)} ${verb.help}`)].join('\n');
+  if (command === "version") return { ok: true, output: `arra ${VERSION}` };
+  if (command === "menu")
+    return { ok: true, output: `arra menu: ${MENU_PATH}` };
+  if (command === "status")
+    return {
+      ok: true,
+      output: "arra status: ok (embedder optional, storage swappable)",
+    };
+  if (command === "vector-config")
+    return vectorConfigCli((ctx.args ?? []).slice(1).map(String));
+  if (command !== "help")
+    return { ok: false, error: `unknown arra command: ${command}` };
+  return {
+    ok: true,
+    output: [
+      "maw arra <command>",
+      ...VERBS.map((verb) => `  ${verb.name.padEnd(14)} ${verb.help}`),
+    ].join("\n"),
+  };
 }
 
 export function arraHttpRoute(ctx: ArraPluginContext) {
   return { ok: true, body: pluginBody(ctx) };
 }
 
-export function arraCli(ctx: ArraPluginContext) {
-  return { ok: true, output: renderCli(ctx) };
+export async function arraCli(ctx: ArraPluginContext) {
+  return renderCli(ctx);
 }
 
 export default function handler(ctx: ArraPluginContext) {
-  return ctx.source === 'cli' ? arraCli(ctx) : arraHttpRoute(ctx);
+  return ctx.source === "cli" ? arraCli(ctx) : arraHttpRoute(ctx);
 }

--- a/src/plugins/arra/plugin.json
+++ b/src/plugins/arra/plugin.json
@@ -5,12 +5,7 @@
   "sdk": "^0.1.0",
   "enabled": true,
   "description": "ARRA Oracle V3 maw-js plugin surface for CLI, menu, and HTTP discovery.",
-  "verbs": [
-    "help",
-    "version",
-    "menu",
-    "status"
-  ],
+  "verbs": ["help", "version", "menu", "status", "vector-config"],
   "httpRoutes": [
     {
       "path": "/api/plugins/arra",
@@ -35,7 +30,7 @@
   ],
   "cli": {
     "command": "arra",
-    "help": "maw arra <help|version|menu|status>",
+    "help": "maw arra <help|version|menu|status|vector-config>",
     "handler": "arraCli"
   }
 }

--- a/src/plugins/arra/vector-config-cli.ts
+++ b/src/plugins/arra/vector-config-cli.ts
@@ -1,0 +1,203 @@
+type CliResult = { ok: boolean; output?: string; error?: string };
+const VECTOR_ENDPOINT = "/api/v1/vector/config";
+
+function apiBase(): string {
+  const raw =
+    process.env.ORACLE_API ??
+    process.env.NEO_ARRA_API ??
+    "http://localhost:47778";
+  return String(raw).replace(/\/$/, "");
+}
+function json(data: unknown): string {
+  return JSON.stringify(data, null, 2);
+}
+function bool(value: string | undefined): boolean {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  throw new Error("enabled must be true or false");
+}
+function requireArg(value: string | undefined, usage: string): string {
+  if (!value || value.startsWith("-")) throw new Error(usage);
+  return value;
+}
+function clean(args: string[]): string[] {
+  return args.filter(
+    (arg) => !["--json", "--yml", "--yaml", "--yes", "-y"].includes(arg),
+  );
+}
+
+async function request(
+  path: string,
+  method = "GET",
+  body?: unknown,
+): Promise<any> {
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.headers = { "content-type": "application/json" };
+    init.body = JSON.stringify(body);
+  }
+  const response = await fetch(`${apiBase()}${path}`, init);
+  if (!response.ok)
+    throw new Error(
+      `${method} ${path} failed: HTTP ${response.status} ${await response.text()}`,
+    );
+  return response.json();
+}
+
+function resolveKey(payload: any, collection: string): string | undefined {
+  if (payload.config.collections[collection]) return collection;
+  return Object.entries(payload.config.collections).find(
+    ([, item]: any) => item.collection === collection,
+  )?.[0] as string | undefined;
+}
+
+function rows(payload: any) {
+  return Object.entries(payload.config.collections).map(([key, item]: any) => ({
+    key,
+    collection: item.collection,
+    model: item.model,
+    provider: item.provider,
+    adapter: item.adapter,
+    enabled: item.enabled !== false,
+    primary: item.primary,
+    docs: payload.doc_counts?.[key] ?? 0,
+    status: payload.health?.[key]?.status ?? "unknown",
+    source: payload.source,
+  }));
+}
+
+function fieldPayload(args: string[]): Record<string, unknown> {
+  const rest = clean(args);
+  const payload: Record<string, unknown> = {};
+  if (rest[0]?.startsWith("--") || rest.some((arg) => arg.startsWith("--"))) {
+    for (let i = 0; i < rest.length; i += 2) {
+      const field = rest[i]?.replace(/^--/, "").replace(/^url$/, "endpoint");
+      const value = rest[i + 1];
+      if (!field || !value)
+        throw new Error(
+          "usage: vector-config set <collection> --field <value>",
+        );
+      payload[field] = field === "enabled" ? bool(value) : value;
+    }
+    return payload;
+  }
+  for (let i = 0; i < rest.length; i += 2) {
+    const field = rest[i];
+    const value = rest[i + 1];
+    if (!field || !value)
+      throw new Error("usage: vector-config set <collection> <field> <value>");
+    payload[field] = field === "enabled" ? bool(value) : value;
+  }
+  return payload;
+}
+
+async function readOne(sub: string, rest: string[]): Promise<CliResult> {
+  const payload = await request(VECTOR_ENDPOINT);
+  const collection =
+    sub === "get"
+      ? requireArg(rest[0], "usage: vector-config get <collection>")
+      : rest[0];
+  if (!collection)
+    return {
+      ok: true,
+      output: json({ source: payload.source, collections: rows(payload) }),
+    };
+  const key = resolveKey(payload, collection);
+  if (!key) throw new Error(`unknown collection: ${collection}`);
+  const row = rows(payload).find((item) => item.key === key) ?? {};
+  const body =
+    sub === "get"
+      ? {
+          source: payload.source,
+          key,
+          config: payload.config.collections[key],
+          count: (row as any).docs,
+          health: payload.health?.[key],
+        }
+      : { source: payload.source, ...(row as object) };
+  return { ok: true, output: json(body) };
+}
+
+export async function vectorConfigCli(args: string[]): Promise<CliResult> {
+  try {
+    const [raw = "list", ...rest] = args;
+    const sub = raw.toLowerCase();
+    if (sub === "list") {
+      const payload = await request(VECTOR_ENDPOINT);
+      return {
+        ok: true,
+        output: json({
+          source: payload.source,
+          count: rows(payload).length,
+          collections: rows(payload),
+        }),
+      };
+    }
+    if (sub === "stats" || sub === "get") return readOne(sub, rest);
+    if (sub === "set")
+      return {
+        ok: true,
+        output: json(
+          await request(
+            `${VECTOR_ENDPOINT}/${encodeURIComponent(requireArg(rest[0], "usage: vector-config set <collection>"))}`,
+            "PUT",
+            fieldPayload(rest.slice(1)),
+          ),
+        ),
+      };
+    if (sub === "add")
+      return {
+        ok: true,
+        output: json(
+          await request(
+            `${VECTOR_ENDPOINT}/${encodeURIComponent(requireArg(rest[0], "usage: vector-config add <collection>"))}`,
+            "POST",
+            fieldPayload(rest.slice(1)),
+          ),
+        ),
+      };
+    if (sub === "remove" || sub === "rm")
+      return {
+        ok: true,
+        output: json(
+          await request(
+            `${VECTOR_ENDPOINT}/${encodeURIComponent(requireArg(rest[0], "usage: vector-config remove <collection>"))}`,
+            "DELETE",
+          ),
+        ),
+      };
+    if (sub === "set-primary" || sub === "primary")
+      return {
+        ok: true,
+        output: json(
+          await request(
+            `${VECTOR_ENDPOINT}/${encodeURIComponent(requireArg(rest[0], "usage: vector-config set-primary <collection>"))}/primary`,
+            "POST",
+          ),
+        ),
+      };
+    if (sub === "reload")
+      return {
+        ok: true,
+        output: json(await request(`${VECTOR_ENDPOINT}/reload`, "POST")),
+      };
+    if (sub === "test")
+      return {
+        ok: true,
+        output: json(
+          await request(
+            `${VECTOR_ENDPOINT}/${encodeURIComponent(requireArg(rest[0], "usage: vector-config test <collection>"))}/test`,
+            "POST",
+          ),
+        ),
+      };
+    throw new Error(
+      "try: vector-config list|get|stats|set|add|remove|set-primary|reload|test",
+    );
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- adds maw arra vector-config to the built-in ARRA plugin verbs
- routes read/write/ops subcommands to /api/v1/vector/config
- covers plugin delegation to vector-config list output

## Tests
- bunx tsc --noEmit
- bun test tests/http/vector/
- bun test src/plugins/__tests__/arra-plugin.test.ts tests/cli/vector-config/cli.test.ts

Closes #1596