### PR TITLE
feat: harden canvas subdomain worker health

### DIFF
--- a/src/workers/canvas/index.ts
+++ b/src/workers/canvas/index.ts
@@ -1,4 +1,5 @@
 import { canvasPluginEntry, canvasRegistry, parseCanvasKind } from '../../canvas/registry.ts';
+import { listCanvasPlugins } from '../../canvas/plugins.ts';
 import { normalizePlugin, renderCanvasApp } from './render.ts';
 
 export interface CanvasWorkerEnv {
@@ -12,12 +13,18 @@ const API_CACHE_HEADERS = {
   'Access-Control-Allow-Origin': '*',
   'Cache-Control': 'no-store',
 };
+const SECURITY_HEADERS = {
+  'Referrer-Policy': 'strict-origin-when-cross-origin',
+  'X-Content-Type-Options': 'nosniff',
+};
 const HTML_HEADERS = {
+  ...SECURITY_HEADERS,
   'Content-Type': 'text/html; charset=utf-8',
   'Cache-Control': 'public, max-age=60, stale-while-revalidate=300',
 };
 
 const REGISTRY_HEADERS = {
+  ...SECURITY_HEADERS,
   'Access-Control-Allow-Origin': '*',
   'Cache-Control': 'public, max-age=60, stale-while-revalidate=300',
   'Content-Type': 'application/json; charset=utf-8',
@@ -44,6 +51,18 @@ async function proxyApi(request: Request, env: CanvasWorkerEnv): Promise<Respons
 }
 
 
+
+function healthResponse(env: CanvasWorkerEnv): Response {
+  return Response.json({
+    ok: true,
+    app: 'ui-canvas-oracle-studio',
+    host: 'canvas.buildwithoracle.com',
+    apiBase: apiBase(env),
+    defaultPlugin: 'wave',
+    pluginCount: listCanvasPlugins().length,
+  }, { headers: { ...SECURITY_HEADERS, 'Cache-Control': 'no-store' } });
+}
+
 function registryResponse(url: URL): Response | null {
   if (url.pathname === '/api/canvas/plugins' || url.pathname === '/api/canvas/registry') {
     return Response.json(canvasRegistry(parseCanvasKind(url.searchParams.get('kind'))), { headers: REGISTRY_HEADERS });
@@ -62,6 +81,7 @@ function pluginFrom(url: URL) {
 
 export async function handleCanvasRequest(request: Request, env: CanvasWorkerEnv = {}): Promise<Response> {
   const url = new URL(request.url);
+  if (url.pathname === '/__health' || url.pathname === '/healthz') return healthResponse(env);
   if (url.pathname.startsWith('/api/canvas/') && request.method === 'GET') {
     const registry = registryResponse(url);
     if (registry) return registry;

--- a/tests/http/canvas-worker.test.ts
+++ b/tests/http/canvas-worker.test.ts
@@ -10,6 +10,7 @@ describe('canvas subdomain worker app', () => {
 
       expect(response.status, plugin).toBe(200);
       expect(response.headers.get('content-type'), plugin).toContain('text/html');
+      expect(response.headers.get('x-content-type-options'), plugin).toBe('nosniff');
       expect(html, plugin).toContain(`plugin=${plugin}`);
       expect(html, plugin).toContain('canvas.buildwithoracle.com');
     }

--- a/tests/workers/canvas-worker.test.ts
+++ b/tests/workers/canvas-worker.test.ts
@@ -47,6 +47,23 @@ describe('canvas Cloudflare Worker', () => {
     expect(await response.text()).toContain('plugin=wave');
   });
 
+
+  test('serves worker-native health for custom domain monitoring', async () => {
+    globalThis.fetch = (async () => { throw new Error('health should not proxy'); }) as typeof fetch;
+
+    const response = await handleCanvasRequest(
+      new Request('https://canvas.buildwithoracle.com/__health'),
+      { ORACLE_API_BASE: 'https://oracle.example.test' },
+    );
+    const body = await response.json() as Record<string, unknown>;
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(response.headers.get('x-content-type-options')).toBe('nosniff');
+    expect(body).toMatchObject({ ok: true, app: 'ui-canvas-oracle-studio', apiBase: 'https://oracle.example.test' });
+    expect(Number(body.pluginCount)).toBeGreaterThanOrEqual(9);
+  });
+
   test('handles api preflight without upstream fetch', async () => {
     const response = await handleCanvasRequest(new Request('https://canvas.buildwithoracle.com/api/health', { method: 'OPTIONS' }));
     expect(response.status).toBe(204);


### PR DESCRIPTION
## Summary
- Add worker-native `/__health` and `/healthz` responses for canvas.buildwithoracle.com custom-domain monitoring without proxying to the backend.
- Add security headers to canvas HTML/registry responses.
- Extend worker/subdomain tests for health, cache headers, and hardened HTML responses.

## Verification
- `bun test tests/workers/canvas-worker.test.ts tests/http/canvas-worker.test.ts tests/canvas/phase2.test.ts`
- `bunx tsc --noEmit`
- `git diff --check`
- `wc -l` on changed files (all ≤250)

## Notes
- Live Cloudflare deployment was not run from this branch.
