### PR TITLE
feat: expose vector health dashboard status

### DIFF
--- a/frontend/src/pages/VectorPage.tsx
+++ b/frontend/src/pages/VectorPage.tsx
@@ -15,12 +15,16 @@ import {
   VectorCollectionCards,
   VectorStatsCard,
   QuickExportCard,
+  VectorHealthDashboardCard,
   type VectorCollectionCard,
+  type VectorFreshnessCard,
+  type VectorProviderHealthCard,
 } from './vector-dashboard-cards';
 
 type PageState = 'loading' | 'ready' | 'error';
 type VectorStatusClient = Pick<ApiClient, 'vectorIndexModels' | 'vectorHealth'>;
 type DownloadByCollection = Record<string, VectorExportFormat | undefined>;
+type VectorDashboardHealth = VectorHealthResponse & { providers?: VectorProviderHealthCard[]; freshness?: VectorFreshnessCard };
 
 export interface VectorPageProps {
   modelsResponse?: VectorIndexModelsResponse | null;
@@ -135,6 +139,7 @@ export function VectorPage({
   }
 
   const cards = useMemo(() => buildVectorCollectionCards(models, health), [models, health]);
+  const dashboardHealth = health as VectorDashboardHealth | null;
   const summary = vectorDashboardSummary(cards, state);
   const isLoading = state === 'loading';
 
@@ -166,6 +171,7 @@ export function VectorPage({
 
         <div className="grid gap-4">
           <VectorStatsCard cards={cards} />
+          <VectorHealthDashboardCard providers={dashboardHealth?.providers} freshness={dashboardHealth?.freshness} />
           <QuickExportCard cards={cards} formats={formats} downloads={downloads} onExport={onExport} />
           <VectorIndexPanel />
         </div>

--- a/frontend/src/pages/vector-dashboard-cards.tsx
+++ b/frontend/src/pages/vector-dashboard-cards.tsx
@@ -13,6 +13,9 @@ export interface VectorCollectionCard {
   healthDetail?: string;
 }
 
+export type VectorProviderHealthCard = { type: string; status: 'green' | 'red'; available: boolean; detail?: string };
+export type VectorFreshnessCard = { status: 'fresh' | 'empty'; totalIndexed: number; docsPending?: number; lastIndexed?: string };
+
 type DownloadByCollection = Record<string, VectorExportFormat | undefined>;
 
 type VectorTotals = {
@@ -116,6 +119,30 @@ export function VectorStatsCard({ cards }: { cards: VectorCollectionCard[] }) {
         <div><dt className="text-slate-500">Total docs</dt><dd className="text-lg font-semibold text-white">{docsLabel(cards)}</dd></div>
         <div><dt className="text-slate-500">Models</dt><dd className="text-lg font-semibold text-white">{vectorTotals(cards).collections}</dd></div>
       </dl>
+    </section>
+  );
+}
+
+
+export function VectorHealthDashboardCard({
+  providers = [],
+  freshness,
+}: {
+  providers?: VectorProviderHealthCard[];
+  freshness?: VectorFreshnessCard;
+}) {
+  const providerSummary = providers.length
+    ? `${providers.filter((item) => item.available).length}/${providers.length} providers available`
+    : 'Provider detection unavailable';
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-health-dashboard-title">
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Health</p>
+      <h2 id="vector-health-dashboard-title" className="mt-2 text-2xl font-semibold text-white">Vector health dashboard</h2>
+      <dl className="mt-4 grid gap-3 text-sm text-slate-300">
+        <div><dt className="text-slate-500">Embedding providers</dt><dd className="text-lg font-semibold text-white">{providerSummary}</dd></div>
+        <div><dt className="text-slate-500">Index freshness</dt><dd className="text-lg font-semibold text-white">{freshness ? `${freshness.status} · ${freshness.totalIndexed.toLocaleString()} indexed` : 'Unknown'}</dd></div>
+      </dl>
+      {providers.length ? <div className="mt-4 flex flex-wrap gap-2">{providers.map((provider) => <span key={provider.type} className={`rounded-full border px-2 py-1 text-xs font-semibold ${statusClasses(provider.available)}`}>{provider.type}: {provider.status}</span>)}</div> : null}
     </section>
   );
 }

--- a/src/routes/vector/health.ts
+++ b/src/routes/vector/health.ts
@@ -12,7 +12,8 @@
 import { Elysia } from 'elysia';
 import { createVectorProxy } from '../../server/vector-proxy.ts';
 import { VECTOR_URL } from '../../config.ts';
-import { readVectorBackendHealth } from '../../vector/health.ts';
+import { getDetectedEmbeddingProviders } from '../../vector/provider-detection.ts';
+import { attachVectorDashboardHealth, readVectorBackendHealth } from '../../vector/health.ts';
 
 const defaultProxy = createVectorProxy(VECTOR_URL);
 
@@ -20,26 +21,33 @@ type VectorHealthResult = Awaited<ReturnType<typeof readVectorBackendHealth>>;
 
 export interface VectorHealthEndpointOptions {
   vectorHealth?: () => Promise<VectorHealthResult>;
+  detectProviders?: () => Promise<{ providers: Array<{ type: string; available: boolean; error?: string; detail?: string }> }>;
   proxy?: typeof defaultProxy;
 }
 
 export function createVectorHealthEndpoint(options: VectorHealthEndpointOptions = {}) {
   const proxy = options.proxy === undefined ? defaultProxy : options.proxy;
   const vectorHealth = options.vectorHealth ?? readVectorBackendHealth;
+  const detectProviders = options.detectProviders ?? (() => getDetectedEmbeddingProviders(false));
 
   async function readHealth({ set }: { set: { status?: number | string } }) {
     if (proxy) {
       const ok = await proxy.available();
       if (ok) {
-        return { status: 'ok' as const, engines: [], checked_at: new Date().toISOString(), proxy: VECTOR_URL };
+        const detected = await detectProviders().catch(() => ({ providers: [] }));
+        return { ...attachVectorDashboardHealth({ status: 'ok' as const, engines: [], checked_at: new Date().toISOString() }, detected.providers), proxy: VECTOR_URL };
       }
       set.status = 503;
-      return { status: 'down' as const, engines: [], checked_at: new Date().toISOString(), proxy: VECTOR_URL };
+      const detected = await detectProviders().catch(() => ({ providers: [] }));
+      return { ...attachVectorDashboardHealth({ status: 'down' as const, engines: [], checked_at: new Date().toISOString() }, detected.providers), proxy: VECTOR_URL };
     }
     try {
-      const result = await vectorHealth();
+      const [result, detected] = await Promise.all([
+        vectorHealth(),
+        detectProviders().catch(() => ({ providers: [] })),
+      ]);
       if (result.status === 'down') set.status = 503;
-      return result;
+      return attachVectorDashboardHealth(result, detected.providers);
     } catch (e: any) {
       set.status = 500;
       return { error: e.message, status: 'down', engines: [], checked_at: new Date().toISOString() };

--- a/src/vector/health.ts
+++ b/src/vector/health.ts
@@ -10,11 +10,48 @@ export type VectorBackendEngine = {
   error?: string;
 };
 
+export type VectorProviderHealth = {
+  type: string;
+  status: 'green' | 'red';
+  available: boolean;
+  detail?: string;
+};
+
+export type VectorFreshness = {
+  status: 'fresh' | 'empty';
+  totalIndexed: number;
+  docsPending?: number;
+  lastIndexed?: string;
+};
+
 export type VectorBackendHealth = {
   status: 'ok' | 'degraded' | 'down';
   engines: VectorBackendEngine[];
   checked_at: string;
+  providers?: VectorProviderHealth[];
+  freshness?: VectorFreshness;
 };
+
+
+export function attachVectorDashboardHealth(
+  health: VectorBackendHealth,
+  providers: Array<{ type: string; available: boolean; error?: string; detail?: string }> = [],
+): VectorBackendHealth {
+  const totalIndexed = health.engines.reduce((sum, engine) => sum + (engine.count || 0), 0);
+  return {
+    ...health,
+    providers: providers.map((provider) => ({
+      type: provider.type,
+      available: provider.available,
+      status: provider.available ? 'green' : 'red',
+      detail: provider.error ?? provider.detail,
+    })),
+    freshness: {
+      status: totalIndexed > 0 ? 'fresh' : 'empty',
+      totalIndexed,
+    },
+  };
+}
 
 function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;

--- a/tests/http/vector/status.test.ts
+++ b/tests/http/vector/status.test.ts
@@ -14,12 +14,16 @@ function createFetch() {
   const app = new Elysia({ prefix: '/api' })
     .use(createVectorHealthEndpoint({
       proxy: null,
+      detectProviders: async () => ({ providers: [
+        { type: 'ollama', available: true },
+        { type: 'openai', available: false, detail: 'missing OPENAI_API_KEY' },
+      ] }),
       vectorHealth: async () => ({
         status: 'ok',
         checked_at: '2026-06-16T00:00:00.000Z',
         engines: [
-          { key: 'bge-m3', model: 'bge-m3', collection: 'oracle_bge', ok: true },
-          { key: 'qdrant', model: 'qdrant-embed', collection: 'oracle_qdrant', ok: true },
+          { key: 'bge-m3', model: 'bge-m3', collection: 'oracle_bge', count: 12, ok: true },
+          { key: 'qdrant', model: 'qdrant-embed', collection: 'oracle_qdrant', count: 3, ok: true },
         ],
       }),
     }))
@@ -46,9 +50,14 @@ test('GET /api/v1/vector/status and /api/v1/vector/models return vector status s
     status: 'ok',
     checked_at: '2026-06-16T00:00:00.000Z',
     engines: [
-      { key: 'bge-m3', model: 'bge-m3', collection: 'oracle_bge', ok: true },
-      { key: 'qdrant', model: 'qdrant-embed', collection: 'oracle_qdrant', ok: true },
+      { key: 'bge-m3', model: 'bge-m3', collection: 'oracle_bge', count: 12, ok: true },
+      { key: 'qdrant', model: 'qdrant-embed', collection: 'oracle_qdrant', count: 3, ok: true },
     ],
+    providers: [
+      { type: 'ollama', available: true, status: 'green' },
+      { type: 'openai', available: false, status: 'red', detail: 'missing OPENAI_API_KEY' },
+    ],
+    freshness: { status: 'fresh', totalIndexed: 15 },
   });
 
   const modelsRes = await fetcher(new Request('http://local/api/v1/vector/models'));


### PR DESCRIPTION
## Summary
- extend `/vector/health` and `/vector/status` with additive provider availability and index freshness metadata
- surface that Phase 4 health dashboard data on the Vector overview bento card
- update vector status HTTP coverage for provider status and freshness

## Verification
- `bun test tests/http/vector/` — 28 pass
- `bunx tsc --noEmit` — green
