### PR TITLE
feat: guide Studio vector first-run setup

### DIFF
--- a/frontend/src/components/BackendGate.tsx
+++ b/frontend/src/components/BackendGate.tsx
@@ -1,7 +1,8 @@
-import { invoke } from '@tauri-apps/api/core';
-import { useCallback, useEffect, useState, type ReactNode } from 'react';
+import { invoke } from "@tauri-apps/api/core";
+import { SetupWizard } from "./SetupWizard";
+import { useCallback, useEffect, useState, type ReactNode } from "react";
 
-type GateState = 'checking' | 'ready' | 'unreachable';
+type GateState = "checking" | "ready" | "unreachable";
 
 declare global {
   interface Window {
@@ -10,40 +11,43 @@ declare global {
 }
 
 function isTauriRuntime(): boolean {
-  return typeof window !== 'undefined' && Boolean(window.__TAURI__);
+  return typeof window !== "undefined" && Boolean(window.__TAURI__);
 }
 
 function okStatus(value: unknown): boolean {
-  if (typeof value === 'string') return value.trim().startsWith('2');
-  if (typeof value === 'number') return value >= 200 && value < 300;
+  if (typeof value === "string") return value.trim().startsWith("2");
+  if (typeof value === "number") return value >= 200 && value < 300;
   return false;
 }
 
 async function browserHealthCheck(): Promise<void> {
-  const response = await fetch('/api/health', { headers: { accept: 'application/json' } });
+  const response = await fetch("/api/health", {
+    headers: { accept: "application/json" },
+  });
   if (!response.ok) throw new Error(`/api/health returned ${response.status}`);
 }
 
 async function tauriHealthCheck(): Promise<void> {
-  const status = await invoke<string>('health_check');
-  if (!okStatus(status)) throw new Error(`health_check returned ${String(status)}`);
+  const status = await invoke<string>("health_check");
+  if (!okStatus(status))
+    throw new Error(`health_check returned ${String(status)}`);
 }
 
 export function BackendGate({ children }: { children: ReactNode }) {
-  const [state, setState] = useState<GateState>('checking');
-  const [message, setMessage] = useState('Checking backend health…');
+  const [state, setState] = useState<GateState>("checking");
+  const [message, setMessage] = useState("Checking backend health…");
   const [starting, setStarting] = useState(false);
   const isTauri = isTauriRuntime();
 
   const check = useCallback(async () => {
-    setState('checking');
-    setMessage('Checking backend health…');
+    setState("checking");
+    setMessage("Checking backend health…");
     try {
       if (isTauri) await tauriHealthCheck();
       else await browserHealthCheck();
-      setState('ready');
+      setState("ready");
     } catch (error) {
-      setState('unreachable');
+      setState("unreachable");
       setMessage(error instanceof Error ? error.message : String(error));
     }
   }, [isTauri]);
@@ -54,37 +58,41 @@ export function BackendGate({ children }: { children: ReactNode }) {
 
   async function startBackend() {
     setStarting(true);
-    setMessage('Starting backend…');
+    setMessage("Starting backend…");
     try {
-      await invoke('start_backend');
+      await invoke("start_backend");
       await check();
     } catch (error) {
-      setState('unreachable');
+      setState("unreachable");
       setMessage(error instanceof Error ? error.message : String(error));
     } finally {
       setStarting(false);
     }
   }
 
-  if (state === 'ready') return <>{children}</>;
+  if (state === "ready") return <SetupWizard>{children}</SetupWizard>;
 
   return (
     <main className="flex min-h-screen items-center justify-center bg-slate-950 p-6 text-slate-100">
       <section className="w-full max-w-lg rounded-3xl border border-white/10 bg-white/[0.04] p-8 shadow-2xl">
-        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-teal-300">ARRA Oracle</p>
+        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-teal-300">
+          ARRA Oracle
+        </p>
         <h1 className="mt-3 text-3xl font-bold">Backend unavailable</h1>
         <p className="mt-4 text-sm text-slate-300">
-          {state === 'checking' ? 'Checking whether the local Oracle API is ready.' : message}
+          {state === "checking"
+            ? "Checking whether the local Oracle API is ready."
+            : message}
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
-          {state === 'unreachable' && isTauri && (
+          {state === "unreachable" && isTauri && (
             <button
               className="focus-ring rounded-full bg-teal-400 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-teal-300 disabled:opacity-60"
               disabled={starting}
               type="button"
               onClick={() => void startBackend()}
             >
-              {starting ? 'Starting…' : 'Start Backend'}
+              {starting ? "Starting…" : "Start Backend"}
             </button>
           )}
           <button

--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { apiUrl } from "../api";
+import { Spinner } from "./AsyncState";
+import { StepBody, setupSteps } from "./SetupWizardContent";
+import { shouldShowSetupWizard } from "./setupWizardDetection";
+import type { Provider, Stats, Step, VectorConfig } from "./setupWizardTypes";
+
+export { shouldShowSetupWizard } from "./setupWizardDetection";
+
+type SetupState = "checking" | "hidden" | "visible";
+const DISMISS_KEY = "arra.vector.setup.dismissed";
+
+async function getJson<T>(path: string): Promise<T> {
+  const response = await fetch(apiUrl(path), {
+    headers: { accept: "application/json" },
+  });
+  if (!response.ok) throw new Error(`${path} returned ${response.status}`);
+  return response.json() as Promise<T>;
+}
+
+export function SetupWizard({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<SetupState>("checking");
+  const [step, setStep] = useState<Step>(0);
+  const [providers, setProviders] = useState<Provider[]>([]);
+  const [config, setConfig] = useState<VectorConfig | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    if (
+      typeof window !== "undefined" &&
+      window.localStorage?.getItem(DISMISS_KEY) === "1"
+    ) {
+      setState("hidden");
+      return;
+    }
+    let active = true;
+    Promise.allSettled([
+      getJson<Stats>("/api/stats"),
+      getJson<VectorConfig>("/api/v1/vector/config"),
+      getJson<{ providers?: Provider[] }>("/api/v1/vector/providers"),
+    ])
+      .then(([statsResult, configResult, providersResult]) => {
+        if (!active) return;
+        const stats =
+          statsResult.status === "fulfilled" ? statsResult.value : null;
+        const vectorConfig =
+          configResult.status === "fulfilled" ? configResult.value : null;
+        if (providersResult.status === "fulfilled")
+          setProviders(providersResult.value.providers ?? []);
+        if (vectorConfig) setConfig(vectorConfig);
+        setState(
+          shouldShowSetupWizard(stats, vectorConfig) ? "visible" : "hidden",
+        );
+      })
+      .catch(() => {
+        if (active) setState("hidden");
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const recommended = useMemo(
+    () =>
+      providers.find((provider) => provider.available || provider.configured) ??
+      providers[0],
+    [providers],
+  );
+
+  async function refreshDetection() {
+    setBusy(true);
+    try {
+      const [providerBody, vectorConfig] = await Promise.all([
+        getJson<{ providers?: Provider[] }>("/api/v1/vector/providers"),
+        getJson<VectorConfig>("/api/v1/vector/config"),
+      ]);
+      setProviders(providerBody.providers ?? []);
+      setConfig(vectorConfig);
+      setMessage("Auto-detect refreshed. Choose a provider and continue.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function startIndex() {
+    const collections = Object.entries(config?.config?.collections ?? {});
+    const key =
+      collections.find(([, item]) => item.enabled !== false)?.[0] ??
+      collections[0]?.[0];
+    if (!key)
+      return setMessage(
+        "No vector collection is configured yet. Open Vector Settings to add one.",
+      );
+    setBusy(true);
+    try {
+      await fetch(apiUrl("/api/vector/index/start"), {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ model: key }),
+      });
+      setStep(3);
+      setMessage(
+        `Started indexing ${key}. Continue to the dashboard or watch /vector/settings.`,
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function dismiss() {
+    if (typeof window !== "undefined")
+      window.localStorage?.setItem(DISMISS_KEY, "1");
+    setState("hidden");
+  }
+
+  if (state !== "visible") return <>{children}</>;
+  return (
+    <main className="min-h-screen bg-slate-950 p-6 text-slate-100">
+      <section className="mx-auto max-w-4xl rounded-3xl border border-purple-300/20 bg-purple-300/10 p-6 shadow-2xl">
+        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-purple-200">
+          First-run wizard
+        </p>
+        <h1 className="mt-3 text-3xl font-bold">Set up vector search</h1>
+        <p className="mt-3 text-sm text-purple-100/80">
+          No full-text documents and no active vector index were detected.
+          Configure a provider, choose the initial vault source, then start
+          indexing.
+        </p>
+        <ol className="mt-5 flex gap-2" aria-label="Setup steps">
+          {setupSteps.map((label, index) => (
+            <li
+              key={label}
+              className={`h-2 flex-1 rounded-full ${index <= step ? "bg-purple-200" : "bg-white/20"}`}
+            />
+          ))}
+        </ol>
+        <div className="mt-6 rounded-2xl border border-white/10 bg-slate-950/60 p-5">
+          <h2 className="text-xl font-semibold text-white">
+            {setupSteps[step]}
+          </h2>
+          <StepBody
+            step={step}
+            providers={providers}
+            recommended={recommended}
+            config={config}
+          />
+        </div>
+        {message ? (
+          <p className="mt-4 rounded-2xl border border-white/10 bg-slate-950/60 p-3 text-sm text-purple-100">
+            {message}
+          </p>
+        ) : null}
+        <div className="mt-5 flex flex-wrap gap-3">
+          <button
+            className="focus-ring rounded-xl border border-white/10 px-4 py-2 text-sm text-purple-100 disabled:opacity-50"
+            disabled={step === 0}
+            type="button"
+            onClick={() => setStep((step - 1) as Step)}
+          >
+            Back
+          </button>
+          {step === 0 ? (
+            <button
+              className="focus-ring rounded-xl bg-purple-200 px-4 py-2 text-sm font-semibold text-slate-950"
+              type="button"
+              onClick={() => void refreshDetection()}
+            >
+              {busy ? <Spinner label="Detecting" /> : "Auto-detect providers"}
+            </button>
+          ) : null}
+          {step === 2 ? (
+            <button
+              className="focus-ring rounded-xl bg-teal-200 px-4 py-2 text-sm font-semibold text-slate-950"
+              type="button"
+              onClick={() => void startIndex()}
+            >
+              {busy ? <Spinner label="Starting" /> : "Start indexing"}
+            </button>
+          ) : null}
+          <button
+            className="focus-ring rounded-xl border border-purple-200/40 px-4 py-2 text-sm font-semibold text-purple-100 disabled:opacity-50"
+            disabled={step === 3}
+            type="button"
+            onClick={() => setStep((step + 1) as Step)}
+          >
+            Next
+          </button>
+          <a
+            className="focus-ring rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200"
+            href="/vector/settings"
+          >
+            Open Vector Settings
+          </a>
+          <button
+            className="focus-ring rounded-xl px-4 py-2 text-sm text-slate-400 hover:text-slate-100"
+            type="button"
+            onClick={dismiss}
+          >
+            Skip setup
+          </button>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/components/SetupWizardContent.tsx
+++ b/frontend/src/components/SetupWizardContent.tsx
@@ -1,0 +1,97 @@
+import type { Provider, Step, VectorConfig } from "./setupWizardTypes";
+
+export const setupSteps = [
+  "Welcome",
+  "Provider",
+  "Vault path",
+  "Index",
+] as const;
+
+export function StepBody({
+  step,
+  providers,
+  recommended,
+  config,
+}: {
+  step: Step;
+  providers: Provider[];
+  recommended?: Provider;
+  config: VectorConfig | null;
+}) {
+  if (step === 0)
+    return (
+      <p className="mt-2 text-sm text-slate-300">
+        Run auto-detect to check Ollama, OpenAI, Gemini, Cloudflare, and
+        registered vector services.
+      </p>
+    );
+  if (step === 1)
+    return <ProviderList providers={providers} recommended={recommended} />;
+  if (step === 2) return <VaultPlan config={config} />;
+  return (
+    <p className="mt-2 text-sm text-slate-300">
+      Done. Continue to the dashboard or watch live progress in Vector Settings.
+    </p>
+  );
+}
+
+function ProviderList({
+  providers,
+  recommended,
+}: {
+  providers: Provider[];
+  recommended?: Provider;
+}) {
+  if (!providers.length)
+    return (
+      <p className="mt-2 text-sm text-slate-300">
+        No provider report yet. Configure API keys or start Ollama, then
+        auto-detect again.
+      </p>
+    );
+  return (
+    <div className="mt-3 grid gap-3 sm:grid-cols-2">
+      {providers.map((provider) => (
+        <article
+          key={provider.type}
+          className="rounded-xl border border-white/10 bg-white/[0.03] p-3"
+        >
+          <p className="font-semibold text-purple-100">
+            {provider.type}
+            {recommended?.type === provider.type ? " · recommended" : ""}
+          </p>
+          <p className="text-sm text-slate-400">
+            {provider.available ? "available" : "unavailable"} ·{" "}
+            {(provider.models ?? []).slice(0, 3).join(", ") ||
+              provider.status ||
+              provider.error ||
+              "no models"}
+          </p>
+          {provider.type.toLowerCase().includes("gemini") ? (
+            <p className="mt-2 text-xs font-semibold text-teal-200">
+              Free tier available!
+            </p>
+          ) : null}
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function VaultPlan({ config }: { config: VectorConfig | null }) {
+  const collections = Object.entries(config?.config?.collections ?? {});
+  return (
+    <div className="mt-2 text-sm text-slate-300">
+      <p>
+        Select the vault path you want to index, then seed the primary vector
+        collection.
+      </p>
+      <p className="mt-2 text-slate-400">
+        Configured collections:{" "}
+        {collections.length
+          ? collections.map(([key]) => key).join(", ")
+          : "none yet"}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/setupWizardDetection.ts
+++ b/frontend/src/components/setupWizardDetection.ts
@@ -1,0 +1,34 @@
+import type { Stats, VectorConfig } from "./setupWizardTypes";
+
+function docsCount(stats: Stats | null): number {
+  return stats?.total_docs ?? stats?.total ?? 0;
+}
+
+function vectorCount(stats: Stats | null, config: VectorConfig | null): number {
+  const statsCount = stats?.vector?.count;
+  if (typeof statsCount === "number") return statsCount;
+  return Object.values(config?.doc_counts ?? {}).reduce(
+    (sum, count) => sum + count,
+    0,
+  );
+}
+
+function allCollectionsDisabled(config: VectorConfig | null): boolean {
+  const collections = Object.values(config?.config?.collections ?? {});
+  return (
+    collections.length > 0 &&
+    collections.every((collection) => collection.enabled === false)
+  );
+}
+
+export function shouldShowSetupWizard(
+  stats: Stats | null,
+  config: VectorConfig | null,
+): boolean {
+  return (
+    docsCount(stats) === 0 &&
+    (stats?.vector?.enabled === false ||
+      vectorCount(stats, config) === 0 ||
+      allCollectionsDisabled(config))
+  );
+}

--- a/frontend/src/components/setupWizardTypes.ts
+++ b/frontend/src/components/setupWizardTypes.ts
@@ -1,0 +1,28 @@
+export type Step = 0 | 1 | 2 | 3;
+export type Stats = {
+  total?: number;
+  total_docs?: number;
+  vector?: { enabled?: boolean; count?: number };
+};
+export type VectorConfig = {
+  config?: {
+    collections?: Record<
+      string,
+      {
+        enabled?: boolean;
+        collection?: string;
+        model?: string;
+        provider?: string;
+      }
+    >;
+  };
+  doc_counts?: Record<string, number>;
+};
+export type Provider = {
+  type: string;
+  available?: boolean;
+  configured?: boolean;
+  models?: string[];
+  status?: string;
+  error?: string;
+};

--- a/tests/frontend/components/setup-wizard-first-run.test.tsx
+++ b/tests/frontend/components/setup-wizard-first-run.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { shouldShowSetupWizard } from "../../../frontend/src/components/SetupWizard";
+
+describe("SetupWizard first-run detection", () => {
+  test("shows only when docs are empty and vector index is disabled or empty", () => {
+    expect(
+      shouldShowSetupWizard(
+        { total_docs: 0, vector: { enabled: false, count: 0 } },
+        { config: { collections: {} }, doc_counts: {} },
+      ),
+    ).toBe(true);
+    expect(
+      shouldShowSetupWizard(
+        { total_docs: 7, vector: { enabled: false, count: 0 } },
+        { config: { collections: {} }, doc_counts: {} },
+      ),
+    ).toBe(false);
+    expect(
+      shouldShowSetupWizard(
+        { total_docs: 0, vector: { enabled: true, count: 5 } },
+        { config: { collections: {} }, doc_counts: {} },
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- integrates a first-run vector setup wizard into BackendGate after backend readiness
- detects empty installs with /api/stats + /api/v1/vector/config
- lets users auto-detect providers, open Vector Settings, and start the first index
- adds focused first-run detection coverage

## Tests
- bunx tsc --noEmit
- bun test tests/http/vector/
- bun test tests/frontend/components/setup-wizard-first-run.test.tsx

Closes #1439