### PR TITLE
test: lock learn malformed JSON contract

### DIFF
--- a/tests/http/learn/crud.test.ts
+++ b/tests/http/learn/crud.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
 import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
 import { eq } from 'drizzle-orm';
 import { mkdirSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
@@ -21,6 +22,10 @@ const { createLearnCrudRoutes } = await import('../../../src/routes/learn/index.
 
 function app() {
   return new Elysia({ prefix: '/api' }).use(createLearnCrudRoutes());
+}
+
+function versionedHandle(request: Request) {
+  return createApiVersionedFetch((next) => app().handle(next))(request);
 }
 
 async function call(method: string, path: string, body?: unknown) {
@@ -53,6 +58,16 @@ afterAll(() => {
 describe('POST/GET/PUT/DELETE /api/learn', () => {
   test('rejects malformed JSON body with bad request status', async () => {
     const res = await app().handle(new Request('http://local/api/learn', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{not json',
+    }));
+    expect(res.status).toBe(400);
+    expect(await res.text()).toMatch(/bad request/i);
+  });
+
+  test('rejects malformed JSON on versioned route with 400 contract', async () => {
+    const res = await versionedHandle(new Request('http://local/api/v1/learn', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: '{not json',


### PR DESCRIPTION
## Summary
- lock `/api/v1/learn` malformed JSON behavior to the 400 bad-request contract
- keep the route behavior unchanged; this fixes the stale 500 expectation with regression coverage

## Verification
- `bun test tests/http/learn/` — 5 pass
- `bunx tsc --noEmit` — green
