### PR TITLE
feat: show vector engine health from maw arra

### DIFF
--- a/src/plugins/__tests__/arra-plugin.test.ts
+++ b/src/plugins/__tests__/arra-plugin.test.ts
@@ -21,6 +21,7 @@ describe("built-in arra plugin", () => {
       "version",
       "menu",
       "status",
+      "health",
       "vector-config",
     ]);
     expect(manifest.httpRoutes[0].path).toBe("/api/plugins/arra");
@@ -61,8 +62,61 @@ describe("built-in arra plugin", () => {
       "version",
       "menu",
       "status",
+      "health",
       "vector-config",
     ]);
+  });
+
+  test("delegates maw arra health to vector engine details", async () => {
+    const { arraCli } = await import("../arra/index.ts");
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/api/health")
+          return Response.json({ status: "ok" });
+        if (url.pathname === "/api/v1/vector/config") {
+          return Response.json({
+            source: "file",
+            config: {
+              collections: {
+                phase1: {
+                  collection: "phase1_collection",
+                  model: "bge-m3",
+                  adapter: "lancedb",
+                },
+              },
+            },
+            doc_counts: { phase1: 3 },
+            health: {
+              phase1: {
+                ok: true,
+                status: "ok",
+                collection: "phase1_collection",
+                adapter: "lancedb",
+                model: "bge-m3",
+              },
+            },
+          });
+        }
+        return Response.json({ error: "not found" }, { status: 404 });
+      },
+    });
+    const saved = process.env.ORACLE_API;
+    process.env.ORACLE_API = String(server.url);
+    try {
+      const result = await arraCli({
+        source: "cli",
+        plugin: "arra",
+        args: ["health"],
+      });
+      expect(result.output).toContain("arra health: ok");
+      expect(result.output).toContain("phase1 | lancedb | bge-m3 | 3 | ok");
+    } finally {
+      if (saved === undefined) delete process.env.ORACLE_API;
+      else process.env.ORACLE_API = saved;
+      server.stop();
+    }
   });
 
   test("delegates maw arra vector-config to the vector config CLI", async () => {

--- a/src/plugins/arra/index.ts
+++ b/src/plugins/arra/index.ts
@@ -1,4 +1,5 @@
 import { vectorConfigCli } from "./vector-config-cli.ts";
+import { vectorHealthCli } from "./vector-health-cli.ts";
 
 type ArraPluginContext = {
   source: "api" | "mcp" | "cli" | "server" | "init" | "destroy";
@@ -56,6 +57,14 @@ const VERBS: ArraVerb[] = [
     storage: "swappable",
   },
   {
+    name: "health",
+    help: "Show server and vector engine health",
+    menuPath: MENU_PATH,
+    httpPath: "/api/health",
+    requiresEmbedder: false,
+    storage: "swappable",
+  },
+  {
     name: "vector-config",
     help: "Inspect and manage vector backend config",
     menuPath: MENU_PATH,
@@ -96,6 +105,8 @@ async function renderCli(ctx: ArraPluginContext): Promise<CliResult> {
       ok: true,
       output: "arra status: ok (embedder optional, storage swappable)",
     };
+  if (command === "health")
+    return vectorHealthCli((ctx.args ?? []).slice(1).map(String));
   if (command === "vector-config")
     return vectorConfigCli((ctx.args ?? []).slice(1).map(String));
   if (command !== "help")

--- a/src/plugins/arra/plugin.json
+++ b/src/plugins/arra/plugin.json
@@ -5,7 +5,7 @@
   "sdk": "^0.1.0",
   "enabled": true,
   "description": "ARRA Oracle V3 maw-js plugin surface for CLI, menu, and HTTP discovery.",
-  "verbs": ["help", "version", "menu", "status", "vector-config"],
+  "verbs": ["help", "version", "menu", "status", "health", "vector-config"],
   "httpRoutes": [
     {
       "path": "/api/plugins/arra",
@@ -30,7 +30,7 @@
   ],
   "cli": {
     "command": "arra",
-    "help": "maw arra <help|version|menu|status|vector-config>",
+    "help": "maw arra <help|version|menu|status|health|vector-config>",
     "handler": "arraCli"
   }
 }

--- a/src/plugins/arra/vector-health-cli.ts
+++ b/src/plugins/arra/vector-health-cli.ts
@@ -1,0 +1,127 @@
+type CliResult = { ok: boolean; output?: string; error?: string };
+type VectorConfigPayload = {
+  source?: string;
+  config?: {
+    collections?: Record<
+      string,
+      {
+        collection?: string;
+        model?: string;
+        adapter?: string;
+        enabled?: boolean;
+      }
+    >;
+  };
+  doc_counts?: Record<string, number>;
+  health?: Record<
+    string,
+    {
+      ok?: boolean;
+      status?: string;
+      adapter?: string;
+      model?: string;
+      collection?: string;
+      error?: string;
+    }
+  >;
+};
+
+const VECTOR_CONFIG_ENDPOINT = "/api/v1/vector/config";
+const HEALTH_ENDPOINT = "/api/health";
+
+function apiBase(): string {
+  const raw =
+    process.env.ORACLE_API ??
+    process.env.NEO_ARRA_API ??
+    "http://localhost:47778";
+  return String(raw).replace(/\/$/, "");
+}
+
+async function getJson<T>(path: string): Promise<T> {
+  const response = await fetch(`${apiBase()}${path}`, {
+    headers: { accept: "application/json" },
+  });
+  if (!response.ok)
+    throw new Error(
+      `${path} failed: HTTP ${response.status} ${await response.text()}`,
+    );
+  return response.json() as Promise<T>;
+}
+
+function rows(payload: VectorConfigPayload) {
+  return Object.entries(payload.config?.collections ?? {}).map(
+    ([key, config]) => {
+      const health = payload.health?.[key] ?? {};
+      return {
+        key,
+        collection: health.collection ?? config.collection ?? key,
+        adapter: health.adapter ?? config.adapter ?? "lancedb",
+        model: health.model ?? config.model ?? "unknown",
+        enabled: config.enabled !== false && health.status !== "disabled",
+        docs: payload.doc_counts?.[key] ?? 0,
+        status: health.status ?? "unknown",
+        ok: health.ok ?? false,
+        error: health.error,
+      };
+    },
+  );
+}
+
+function renderTable(
+  payload: VectorConfigPayload,
+  serverStatus: unknown,
+): string {
+  const engines = rows(payload);
+  const status =
+    typeof serverStatus === "object" && serverStatus && "status" in serverStatus
+      ? String((serverStatus as { status?: unknown }).status)
+      : "unknown";
+  const lines = [
+    `arra health: ${status}`,
+    `vector config: ${payload.source ?? "unknown"}`,
+    "Collection | Adapter | Model | Docs | Status",
+  ];
+  for (const engine of engines) {
+    lines.push(
+      `${engine.key} | ${engine.adapter} | ${engine.model} | ${engine.docs} | ${engine.status}${engine.error ? ` (${engine.error})` : ""}`,
+    );
+  }
+  if (!engines.length) lines.push("no vector engines reported");
+  return lines.join("\n");
+}
+
+export async function vectorHealthCli(args: string[]): Promise<CliResult> {
+  try {
+    const [health, vector] = await Promise.allSettled([
+      getJson<unknown>(HEALTH_ENDPOINT),
+      getJson<VectorConfigPayload>(VECTOR_CONFIG_ENDPOINT),
+    ]);
+    const vectorPayload =
+      vector.status === "fulfilled"
+        ? vector.value
+        : { config: { collections: {} } };
+    const healthPayload =
+      health.status === "fulfilled"
+        ? health.value
+        : {
+            status: "unknown",
+            error:
+              health.reason instanceof Error
+                ? health.reason.message
+                : String(health.reason),
+          };
+    const payload = {
+      health: healthPayload,
+      source: vectorPayload.source,
+      engines: rows(vectorPayload),
+    };
+    if (args.includes("--json"))
+      return { ok: true, output: JSON.stringify(payload, null, 2) };
+    return { ok: true, output: renderTable(vectorPayload, healthPayload) };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- adds maw arra health as a built-in ARRA plugin verb
- reports server health plus vector collection adapter, model, doc count, and status
- adds plugin coverage for the health delegation

## Existing #1595 surfaces on alpha
- vector-config CLI get/set adapter/enabled state is present
- Settings UI includes vector adapter switching and health display

## Tests
- bunx tsc --noEmit
- bun test tests/http/vector/
- bun test src/plugins/__tests__/arra-plugin.test.ts

Closes #1595