### PR TITLE
feat(plugins): expose ARRA maw backend config (#1467)

### DIFF
--- a/src/plugins/__tests__/arra-plugin.test.ts
+++ b/src/plugins/__tests__/arra-plugin.test.ts
@@ -21,6 +21,7 @@ describe("built-in arra plugin", () => {
       "version",
       "menu",
       "status",
+      "health",
       "vector-config",
     ]);
     expect(manifest.httpRoutes[0].path).toBe("/api/plugins/arra");
@@ -61,8 +62,61 @@ describe("built-in arra plugin", () => {
       "version",
       "menu",
       "status",
+      "health",
       "vector-config",
     ]);
+  });
+
+  test("delegates maw arra health to vector engine details", async () => {
+    const { arraCli } = await import("../arra/index.ts");
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/api/health")
+          return Response.json({ status: "ok" });
+        if (url.pathname === "/api/v1/vector/config") {
+          return Response.json({
+            source: "file",
+            config: {
+              collections: {
+                phase1: {
+                  collection: "phase1_collection",
+                  model: "bge-m3",
+                  adapter: "lancedb",
+                },
+              },
+            },
+            doc_counts: { phase1: 3 },
+            health: {
+              phase1: {
+                ok: true,
+                status: "ok",
+                collection: "phase1_collection",
+                adapter: "lancedb",
+                model: "bge-m3",
+              },
+            },
+          });
+        }
+        return Response.json({ error: "not found" }, { status: 404 });
+      },
+    });
+    const saved = process.env.ORACLE_API;
+    process.env.ORACLE_API = String(server.url);
+    try {
+      const result = await arraCli({
+        source: "cli",
+        plugin: "arra",
+        args: ["health"],
+      });
+      expect(result.output).toContain("arra health: ok");
+      expect(result.output).toContain("phase1 | lancedb | bge-m3 | 3 | ok");
+    } finally {
+      if (saved === undefined) delete process.env.ORACLE_API;
+      else process.env.ORACLE_API = saved;
+      server.stop();
+    }
   });
 
   test("delegates maw arra vector-config to the vector config CLI", async () => {

--- a/src/plugins/__tests__/arra-plugin.test.ts
+++ b/src/plugins/__tests__/arra-plugin.test.ts
@@ -5,66 +5,54 @@ import { Elysia } from "elysia";
 import { loadUnifiedPlugins } from "../unified-loader.ts";
 
 const pluginRoot = join(process.cwd(), "src/plugins");
+const ARRA_VERBS = ["help", "version", "menu", "status", "health", "vector-config"];
 
 describe("built-in arra plugin", () => {
   test("declares modern maw-js CLI, menu, and HTTP surfaces", () => {
-    const manifest = JSON.parse(
-      readFileSync(join(pluginRoot, "arra/plugin.json"), "utf8"),
-    );
+    const manifest = JSON.parse(readFileSync(join(pluginRoot, "arra/plugin.json"), "utf8"));
 
     expect(manifest.name).toBe("arra");
     expect(manifest.entry).toBe("./index.ts");
     expect(manifest.cli.command).toBe("arra");
     expect(manifest.cli.handler).toBe("arraCli");
-    expect(manifest.verbs).toEqual([
-      "help",
-      "version",
-      "menu",
-      "status",
-      "health",
-      "vector-config",
-    ]);
+    expect(manifest.verbs).toEqual(ARRA_VERBS);
     expect(manifest.httpRoutes[0].path).toBe("/api/plugins/arra");
+    expect(manifest.config).toMatchObject({ dbBackend: "sqlite", embedderBackend: "none" });
+    expect(manifest.configSchema.properties.dbBackend.enum).toEqual(["sqlite", "http", "memory", "custom"]);
   });
 
   test("loads and serves the shared ARRA plugin registry route", async () => {
     const runtime = await loadUnifiedPlugins({ dirs: [pluginRoot] });
-    const arra = runtime
-      .pluginRegistry()
-      .find((plugin) => plugin.name === "arra");
+    const arra = runtime.pluginRegistry().find((plugin) => plugin.name === "arra");
 
     expect(arra?.surfaces).toEqual(["apiRoutes", "menu", "cliSubcommands"]);
-    expect(runtime.menu.find((item) => item.plugin === "arra")?.path).toBe(
-      "/plugins/arra",
-    );
-    const command = runtime.cliSubcommands.find(
-      (item) => item.plugin === "arra",
-    );
+    expect(runtime.menu.find((item) => item.plugin === "arra")?.path).toBe("/plugins/arra");
+    const command = runtime.cliSubcommands.find((item) => item.plugin === "arra");
     expect(command?.command).toBe("arra");
     expect(command?.handler).toBe("arraCli");
 
     const app = new Elysia();
     for (const route of runtime.routes) app.use(route as never);
-    const response = await app.handle(
-      new Request("http://local/api/plugins/arra"),
-    );
-    const body = (await response.json()) as {
+    const response = await app.handle(new Request("http://local/api/plugins/arra"));
+    const body = await response.json() as {
       plugin: string;
       embedderRequired: boolean;
+      storageBackend: string;
+      embedderBackend: string;
+      backends: { db: { swappable: boolean; supported: string[] }; embedder: { optional: boolean; supported: string[] } };
       verbs: Array<{ name: string }>;
     };
 
     expect(response.status).toBe(200);
     expect(body.plugin).toBe("arra");
     expect(body.embedderRequired).toBe(false);
-    expect(body.verbs.map((verb) => verb.name)).toEqual([
-      "help",
-      "version",
-      "menu",
-      "status",
-      "health",
-      "vector-config",
-    ]);
+    expect(body.storageBackend).toBe("sqlite");
+    expect(body.embedderBackend).toBe("none");
+    expect(body.backends.db.swappable).toBe(true);
+    expect(body.backends.db.supported).toContain("custom");
+    expect(body.backends.embedder.optional).toBe(true);
+    expect(body.backends.embedder.supported).toContain("remote");
+    expect(body.verbs.map((verb) => verb.name)).toEqual(ARRA_VERBS);
   });
 
   test("delegates maw arra health to vector engine details", async () => {
@@ -123,49 +111,23 @@ describe("built-in arra plugin", () => {
     const { arraCli } = await import("../arra/index.ts");
     const state = {
       source: "file",
-      config: {
-        collections: {
-          phase1: {
-            collection: "phase1_collection",
-            model: "bge-m3",
-            provider: "none",
-            adapter: "lancedb",
-          },
-        },
-      },
+      config: { collections: { phase1: { collection: "phase1_collection", model: "bge-m3", provider: "none", adapter: "lancedb" } } },
       doc_counts: { phase1: 3 },
-      health: {
-        phase1: {
-          ok: true,
-          status: "ok",
-          collection: "phase1_collection",
-          adapter: "lancedb",
-        },
-      },
+      health: { phase1: { ok: true, status: "ok", collection: "phase1_collection", adapter: "lancedb" } },
     };
     const server = Bun.serve({
       port: 0,
       fetch(req) {
-        const url = new URL(req.url);
-        if (url.pathname === "/api/v1/vector/config")
-          return Response.json(state);
+        if (new URL(req.url).pathname === "/api/v1/vector/config") return Response.json(state);
         return Response.json({ error: "not found" }, { status: 404 });
       },
     });
     const saved = process.env.ORACLE_API;
     process.env.ORACLE_API = String(server.url);
     try {
-      const result = await arraCli({
-        source: "cli",
-        plugin: "arra",
-        args: ["vector-config", "list", "--json"],
-      });
-      const payload = JSON.parse(result.output);
-      expect(payload.collections[0]).toMatchObject({
-        key: "phase1",
-        docs: 3,
-        status: "ok",
-      });
+      const result = await arraCli({ source: "cli", plugin: "arra", args: ["vector-config", "list", "--json"] });
+      const payload = JSON.parse(result.output!);
+      expect(payload.collections[0]).toMatchObject({ key: "phase1", docs: 3, status: "ok" });
     } finally {
       if (saved === undefined) delete process.env.ORACLE_API;
       else process.env.ORACLE_API = saved;

--- a/src/plugins/__tests__/arra-plugin.test.ts
+++ b/src/plugins/__tests__/arra-plugin.test.ts
@@ -5,113 +5,77 @@ import { Elysia } from "elysia";
 import { loadUnifiedPlugins } from "../unified-loader.ts";
 
 const pluginRoot = join(process.cwd(), "src/plugins");
+const ARRA_VERBS = ["help", "version", "menu", "status", "vector-config"];
 
 describe("built-in arra plugin", () => {
   test("declares modern maw-js CLI, menu, and HTTP surfaces", () => {
-    const manifest = JSON.parse(
-      readFileSync(join(pluginRoot, "arra/plugin.json"), "utf8"),
-    );
+    const manifest = JSON.parse(readFileSync(join(pluginRoot, "arra/plugin.json"), "utf8"));
 
     expect(manifest.name).toBe("arra");
     expect(manifest.entry).toBe("./index.ts");
     expect(manifest.cli.command).toBe("arra");
     expect(manifest.cli.handler).toBe("arraCli");
-    expect(manifest.verbs).toEqual([
-      "help",
-      "version",
-      "menu",
-      "status",
-      "vector-config",
-    ]);
+    expect(manifest.verbs).toEqual(ARRA_VERBS);
     expect(manifest.httpRoutes[0].path).toBe("/api/plugins/arra");
+    expect(manifest.config).toMatchObject({ dbBackend: "sqlite", embedderBackend: "none" });
+    expect(manifest.configSchema.properties.dbBackend.enum).toEqual(["sqlite", "http", "memory", "custom"]);
   });
 
   test("loads and serves the shared ARRA plugin registry route", async () => {
     const runtime = await loadUnifiedPlugins({ dirs: [pluginRoot] });
-    const arra = runtime
-      .pluginRegistry()
-      .find((plugin) => plugin.name === "arra");
+    const arra = runtime.pluginRegistry().find((plugin) => plugin.name === "arra");
 
     expect(arra?.surfaces).toEqual(["apiRoutes", "menu", "cliSubcommands"]);
-    expect(runtime.menu.find((item) => item.plugin === "arra")?.path).toBe(
-      "/plugins/arra",
-    );
-    const command = runtime.cliSubcommands.find(
-      (item) => item.plugin === "arra",
-    );
+    expect(runtime.menu.find((item) => item.plugin === "arra")?.path).toBe("/plugins/arra");
+    const command = runtime.cliSubcommands.find((item) => item.plugin === "arra");
     expect(command?.command).toBe("arra");
     expect(command?.handler).toBe("arraCli");
 
     const app = new Elysia();
     for (const route of runtime.routes) app.use(route as never);
-    const response = await app.handle(
-      new Request("http://local/api/plugins/arra"),
-    );
-    const body = (await response.json()) as {
+    const response = await app.handle(new Request("http://local/api/plugins/arra"));
+    const body = await response.json() as {
       plugin: string;
       embedderRequired: boolean;
+      storageBackend: string;
+      embedderBackend: string;
+      backends: { db: { swappable: boolean; supported: string[] }; embedder: { optional: boolean; supported: string[] } };
       verbs: Array<{ name: string }>;
     };
 
     expect(response.status).toBe(200);
     expect(body.plugin).toBe("arra");
     expect(body.embedderRequired).toBe(false);
-    expect(body.verbs.map((verb) => verb.name)).toEqual([
-      "help",
-      "version",
-      "menu",
-      "status",
-      "vector-config",
-    ]);
+    expect(body.storageBackend).toBe("sqlite");
+    expect(body.embedderBackend).toBe("none");
+    expect(body.backends.db.swappable).toBe(true);
+    expect(body.backends.db.supported).toContain("custom");
+    expect(body.backends.embedder.optional).toBe(true);
+    expect(body.backends.embedder.supported).toContain("remote");
+    expect(body.verbs.map((verb) => verb.name)).toEqual(ARRA_VERBS);
   });
 
   test("delegates maw arra vector-config to the vector config CLI", async () => {
     const { arraCli } = await import("../arra/index.ts");
     const state = {
       source: "file",
-      config: {
-        collections: {
-          phase1: {
-            collection: "phase1_collection",
-            model: "bge-m3",
-            provider: "none",
-            adapter: "lancedb",
-          },
-        },
-      },
+      config: { collections: { phase1: { collection: "phase1_collection", model: "bge-m3", provider: "none", adapter: "lancedb" } } },
       doc_counts: { phase1: 3 },
-      health: {
-        phase1: {
-          ok: true,
-          status: "ok",
-          collection: "phase1_collection",
-          adapter: "lancedb",
-        },
-      },
+      health: { phase1: { ok: true, status: "ok", collection: "phase1_collection", adapter: "lancedb" } },
     };
     const server = Bun.serve({
       port: 0,
       fetch(req) {
-        const url = new URL(req.url);
-        if (url.pathname === "/api/v1/vector/config")
-          return Response.json(state);
+        if (new URL(req.url).pathname === "/api/v1/vector/config") return Response.json(state);
         return Response.json({ error: "not found" }, { status: 404 });
       },
     });
     const saved = process.env.ORACLE_API;
     process.env.ORACLE_API = String(server.url);
     try {
-      const result = await arraCli({
-        source: "cli",
-        plugin: "arra",
-        args: ["vector-config", "list", "--json"],
-      });
-      const payload = JSON.parse(result.output);
-      expect(payload.collections[0]).toMatchObject({
-        key: "phase1",
-        docs: 3,
-        status: "ok",
-      });
+      const result = await arraCli({ source: "cli", plugin: "arra", args: ["vector-config", "list", "--json"] });
+      const payload = JSON.parse(result.output!);
+      expect(payload.collections[0]).toMatchObject({ key: "phase1", docs: 3, status: "ok" });
     } finally {
       if (saved === undefined) delete process.env.ORACLE_API;
       else process.env.ORACLE_API = saved;

--- a/src/plugins/arra/index.ts
+++ b/src/plugins/arra/index.ts
@@ -1,4 +1,5 @@
 import { vectorConfigCli } from "./vector-config-cli.ts";
+import { vectorHealthCli } from "./vector-health-cli.ts";
 
 type ArraPluginContext = {
   source: "api" | "mcp" | "cli" | "server" | "init" | "destroy";
@@ -56,6 +57,14 @@ const VERBS: ArraVerb[] = [
     storage: "swappable",
   },
   {
+    name: "health",
+    help: "Show server and vector engine health",
+    menuPath: MENU_PATH,
+    httpPath: "/api/health",
+    requiresEmbedder: false,
+    storage: "swappable",
+  },
+  {
     name: "vector-config",
     help: "Inspect and manage vector backend config",
     menuPath: MENU_PATH,
@@ -96,6 +105,8 @@ async function renderCli(ctx: ArraPluginContext): Promise<CliResult> {
       ok: true,
       output: "arra status: ok (embedder optional, storage swappable)",
     };
+  if (command === "health")
+    return vectorHealthCli((ctx.args ?? []).slice(1).map(String));
   if (command === "vector-config")
     return vectorConfigCli((ctx.args ?? []).slice(1).map(String));
   if (command !== "help")

--- a/src/plugins/arra/index.ts
+++ b/src/plugins/arra/index.ts
@@ -1,11 +1,18 @@
 import { vectorConfigCli } from "./vector-config-cli.ts";
 import { vectorHealthCli } from "./vector-health-cli.ts";
 
+type ArraPluginConfig = {
+  dbBackend?: "sqlite" | "http" | "memory" | "custom";
+  embedderBackend?: "none" | "local" | "remote";
+  remoteEmbedderUrl?: string;
+};
+
 type ArraPluginContext = {
   source: "api" | "mcp" | "cli" | "server" | "init" | "destroy";
   plugin: string;
   args?: unknown[];
   request?: Request;
+  config?: ArraPluginConfig;
 };
 
 type ArraVerb = {
@@ -22,66 +29,34 @@ type CliResult = { ok: boolean; output?: string; error?: string };
 const VERSION = "1.0.0";
 const MENU_PATH = "/plugins/arra";
 const HTTP_PATH = "/api/plugins/arra";
+const DB_BACKENDS = ["sqlite", "http", "memory", "custom"] as const;
+const EMBEDDER_BACKENDS = ["none", "local", "remote"] as const;
+const DEFAULT_CONFIG: Required<ArraPluginConfig> = {
+  dbBackend: "sqlite",
+  embedderBackend: "none",
+  remoteEmbedderUrl: "",
+};
 
 const VERBS: ArraVerb[] = [
-  {
-    name: "help",
-    help: "Show ARRA plugin commands",
-    menuPath: MENU_PATH,
-    httpPath: HTTP_PATH,
-    requiresEmbedder: false,
-    storage: "swappable",
-  },
-  {
-    name: "version",
-    help: "Print ARRA plugin version",
-    menuPath: MENU_PATH,
-    httpPath: HTTP_PATH,
-    requiresEmbedder: false,
-    storage: "swappable",
-  },
-  {
-    name: "menu",
-    help: "Describe the ARRA menu surface",
-    menuPath: MENU_PATH,
-    httpPath: HTTP_PATH,
-    requiresEmbedder: false,
-    storage: "swappable",
-  },
-  {
-    name: "status",
-    help: "Describe optional backend capabilities",
-    menuPath: MENU_PATH,
-    httpPath: HTTP_PATH,
-    requiresEmbedder: false,
-    storage: "swappable",
-  },
-  {
-    name: "health",
-    help: "Show server and vector engine health",
-    menuPath: MENU_PATH,
-    httpPath: "/api/health",
-    requiresEmbedder: false,
-    storage: "swappable",
-  },
-  {
-    name: "vector-config",
-    help: "Inspect and manage vector backend config",
-    menuPath: MENU_PATH,
-    httpPath: "/api/v1/vector/config",
-    requiresEmbedder: false,
-    storage: "swappable",
-  },
+  { name: "help", help: "Show ARRA plugin commands", menuPath: MENU_PATH, httpPath: HTTP_PATH, requiresEmbedder: false, storage: "swappable" },
+  { name: "version", help: "Print ARRA plugin version", menuPath: MENU_PATH, httpPath: HTTP_PATH, requiresEmbedder: false, storage: "swappable" },
+  { name: "menu", help: "Describe the ARRA menu surface", menuPath: MENU_PATH, httpPath: HTTP_PATH, requiresEmbedder: false, storage: "swappable" },
+  { name: "status", help: "Describe optional backend capabilities", menuPath: MENU_PATH, httpPath: HTTP_PATH, requiresEmbedder: false, storage: "swappable" },
+  { name: "health", help: "Show server and vector engine health", menuPath: MENU_PATH, httpPath: "/api/health", requiresEmbedder: false, storage: "swappable" },
+  { name: "vector-config", help: "Inspect and manage vector backend config", menuPath: MENU_PATH, httpPath: "/api/v1/vector/config", requiresEmbedder: false, storage: "swappable" },
 ];
 
 function commandName(ctx: ArraPluginContext): string {
   const arg = ctx.args?.[0];
-  return typeof arg === "string" && arg.trim()
-    ? arg.trim().toLowerCase()
-    : "help";
+  return typeof arg === "string" && arg.trim() ? arg.trim().toLowerCase() : "help";
+}
+
+function configFrom(ctx: ArraPluginContext): Required<ArraPluginConfig> {
+  return { ...DEFAULT_CONFIG, ...(ctx.config ?? {}) };
 }
 
 function pluginBody(ctx: ArraPluginContext) {
+  const config = configFrom(ctx);
   return {
     plugin: ctx.plugin || "arra",
     version: VERSION,
@@ -90,7 +65,13 @@ function pluginBody(ctx: ArraPluginContext) {
     httpPath: HTTP_PATH,
     cliCommand: "arra",
     embedderRequired: false,
-    storageBackend: "swappable",
+    storageBackend: config.dbBackend,
+    embedderBackend: config.embedderBackend,
+    remoteEmbedderConfigured: Boolean(config.remoteEmbedderUrl),
+    backends: {
+      db: { selected: config.dbBackend, swappable: true, supported: DB_BACKENDS },
+      embedder: { selected: config.embedderBackend, optional: true, supported: EMBEDDER_BACKENDS },
+    },
     verbs: VERBS,
   };
 }
@@ -98,26 +79,15 @@ function pluginBody(ctx: ArraPluginContext) {
 async function renderCli(ctx: ArraPluginContext): Promise<CliResult> {
   const command = commandName(ctx);
   if (command === "version") return { ok: true, output: `arra ${VERSION}` };
-  if (command === "menu")
-    return { ok: true, output: `arra menu: ${MENU_PATH}` };
-  if (command === "status")
-    return {
-      ok: true,
-      output: "arra status: ok (embedder optional, storage swappable)",
-    };
-  if (command === "health")
-    return vectorHealthCli((ctx.args ?? []).slice(1).map(String));
-  if (command === "vector-config")
-    return vectorConfigCli((ctx.args ?? []).slice(1).map(String));
-  if (command !== "help")
-    return { ok: false, error: `unknown arra command: ${command}` };
-  return {
-    ok: true,
-    output: [
-      "maw arra <command>",
-      ...VERBS.map((verb) => `  ${verb.name.padEnd(14)} ${verb.help}`),
-    ].join("\n"),
-  };
+  if (command === "menu") return { ok: true, output: `arra menu: ${MENU_PATH}` };
+  if (command === "status") {
+    const config = configFrom(ctx);
+    return { ok: true, output: `arra status: ok (db=${config.dbBackend}, embedder=${config.embedderBackend}, storage swappable)` };
+  }
+  if (command === "health") return vectorHealthCli((ctx.args ?? []).slice(1).map(String));
+  if (command === "vector-config") return vectorConfigCli((ctx.args ?? []).slice(1).map(String));
+  if (command !== "help") return { ok: false, error: `unknown arra command: ${command}` };
+  return { ok: true, output: ["maw arra <command>", ...VERBS.map((verb) => `  ${verb.name.padEnd(14)} ${verb.help}`)].join("\n") };
 }
 
 export function arraHttpRoute(ctx: ArraPluginContext) {

--- a/src/plugins/arra/index.ts
+++ b/src/plugins/arra/index.ts
@@ -1,10 +1,17 @@
 import { vectorConfigCli } from "./vector-config-cli.ts";
 
+type ArraPluginConfig = {
+  dbBackend?: "sqlite" | "http" | "memory" | "custom";
+  embedderBackend?: "none" | "local" | "remote";
+  remoteEmbedderUrl?: string;
+};
+
 type ArraPluginContext = {
   source: "api" | "mcp" | "cli" | "server" | "init" | "destroy";
   plugin: string;
   args?: unknown[];
   request?: Request;
+  config?: ArraPluginConfig;
 };
 
 type ArraVerb = {
@@ -21,58 +28,33 @@ type CliResult = { ok: boolean; output?: string; error?: string };
 const VERSION = "1.0.0";
 const MENU_PATH = "/plugins/arra";
 const HTTP_PATH = "/api/plugins/arra";
+const DB_BACKENDS = ["sqlite", "http", "memory", "custom"] as const;
+const EMBEDDER_BACKENDS = ["none", "local", "remote"] as const;
+const DEFAULT_CONFIG: Required<ArraPluginConfig> = {
+  dbBackend: "sqlite",
+  embedderBackend: "none",
+  remoteEmbedderUrl: "",
+};
 
 const VERBS: ArraVerb[] = [
-  {
-    name: "help",
-    help: "Show ARRA plugin commands",
-    menuPath: MENU_PATH,
-    httpPath: HTTP_PATH,
-    requiresEmbedder: false,
-    storage: "swappable",
-  },
-  {
-    name: "version",
-    help: "Print ARRA plugin version",
-    menuPath: MENU_PATH,
-    httpPath: HTTP_PATH,
-    requiresEmbedder: false,
-    storage: "swappable",
-  },
-  {
-    name: "menu",
-    help: "Describe the ARRA menu surface",
-    menuPath: MENU_PATH,
-    httpPath: HTTP_PATH,
-    requiresEmbedder: false,
-    storage: "swappable",
-  },
-  {
-    name: "status",
-    help: "Describe optional backend capabilities",
-    menuPath: MENU_PATH,
-    httpPath: HTTP_PATH,
-    requiresEmbedder: false,
-    storage: "swappable",
-  },
-  {
-    name: "vector-config",
-    help: "Inspect and manage vector backend config",
-    menuPath: MENU_PATH,
-    httpPath: "/api/v1/vector/config",
-    requiresEmbedder: false,
-    storage: "swappable",
-  },
+  { name: "help", help: "Show ARRA plugin commands", menuPath: MENU_PATH, httpPath: HTTP_PATH, requiresEmbedder: false, storage: "swappable" },
+  { name: "version", help: "Print ARRA plugin version", menuPath: MENU_PATH, httpPath: HTTP_PATH, requiresEmbedder: false, storage: "swappable" },
+  { name: "menu", help: "Describe the ARRA menu surface", menuPath: MENU_PATH, httpPath: HTTP_PATH, requiresEmbedder: false, storage: "swappable" },
+  { name: "status", help: "Describe optional backend capabilities", menuPath: MENU_PATH, httpPath: HTTP_PATH, requiresEmbedder: false, storage: "swappable" },
+  { name: "vector-config", help: "Inspect and manage vector backend config", menuPath: MENU_PATH, httpPath: "/api/v1/vector/config", requiresEmbedder: false, storage: "swappable" },
 ];
 
 function commandName(ctx: ArraPluginContext): string {
   const arg = ctx.args?.[0];
-  return typeof arg === "string" && arg.trim()
-    ? arg.trim().toLowerCase()
-    : "help";
+  return typeof arg === "string" && arg.trim() ? arg.trim().toLowerCase() : "help";
+}
+
+function configFrom(ctx: ArraPluginContext): Required<ArraPluginConfig> {
+  return { ...DEFAULT_CONFIG, ...(ctx.config ?? {}) };
 }
 
 function pluginBody(ctx: ArraPluginContext) {
+  const config = configFrom(ctx);
   return {
     plugin: ctx.plugin || "arra",
     version: VERSION,
@@ -81,7 +63,13 @@ function pluginBody(ctx: ArraPluginContext) {
     httpPath: HTTP_PATH,
     cliCommand: "arra",
     embedderRequired: false,
-    storageBackend: "swappable",
+    storageBackend: config.dbBackend,
+    embedderBackend: config.embedderBackend,
+    remoteEmbedderConfigured: Boolean(config.remoteEmbedderUrl),
+    backends: {
+      db: { selected: config.dbBackend, swappable: true, supported: DB_BACKENDS },
+      embedder: { selected: config.embedderBackend, optional: true, supported: EMBEDDER_BACKENDS },
+    },
     verbs: VERBS,
   };
 }
@@ -89,24 +77,14 @@ function pluginBody(ctx: ArraPluginContext) {
 async function renderCli(ctx: ArraPluginContext): Promise<CliResult> {
   const command = commandName(ctx);
   if (command === "version") return { ok: true, output: `arra ${VERSION}` };
-  if (command === "menu")
-    return { ok: true, output: `arra menu: ${MENU_PATH}` };
-  if (command === "status")
-    return {
-      ok: true,
-      output: "arra status: ok (embedder optional, storage swappable)",
-    };
-  if (command === "vector-config")
-    return vectorConfigCli((ctx.args ?? []).slice(1).map(String));
-  if (command !== "help")
-    return { ok: false, error: `unknown arra command: ${command}` };
-  return {
-    ok: true,
-    output: [
-      "maw arra <command>",
-      ...VERBS.map((verb) => `  ${verb.name.padEnd(14)} ${verb.help}`),
-    ].join("\n"),
-  };
+  if (command === "menu") return { ok: true, output: `arra menu: ${MENU_PATH}` };
+  if (command === "status") {
+    const config = configFrom(ctx);
+    return { ok: true, output: `arra status: ok (db=${config.dbBackend}, embedder=${config.embedderBackend}, storage swappable)` };
+  }
+  if (command === "vector-config") return vectorConfigCli((ctx.args ?? []).slice(1).map(String));
+  if (command !== "help") return { ok: false, error: `unknown arra command: ${command}` };
+  return { ok: true, output: ["maw arra <command>", ...VERBS.map((verb) => `  ${verb.name.padEnd(14)} ${verb.help}`)].join("\n") };
 }
 
 export function arraHttpRoute(ctx: ArraPluginContext) {

--- a/src/plugins/arra/plugin.json
+++ b/src/plugins/arra/plugin.json
@@ -5,7 +5,7 @@
   "sdk": "^0.1.0",
   "enabled": true,
   "description": "ARRA Oracle V3 maw-js plugin surface for CLI, menu, and HTTP discovery.",
-  "verbs": ["help", "version", "menu", "status", "vector-config"],
+  "verbs": ["help", "version", "menu", "status", "health", "vector-config"],
   "httpRoutes": [
     {
       "path": "/api/plugins/arra",
@@ -30,7 +30,7 @@
   ],
   "cli": {
     "command": "arra",
-    "help": "maw arra <help|version|menu|status|vector-config>",
+    "help": "maw arra <help|version|menu|status|health|vector-config>",
     "handler": "arraCli"
   }
 }

--- a/src/plugins/arra/plugin.json
+++ b/src/plugins/arra/plugin.json
@@ -9,13 +9,17 @@
   "httpRoutes": [
     {
       "path": "/api/plugins/arra",
-      "methods": ["GET"]
+      "methods": [
+        "GET"
+      ]
     }
   ],
   "apiRoutes": [
     {
       "path": "/api/plugins/arra",
-      "methods": ["GET"],
+      "methods": [
+        "GET"
+      ],
       "handler": "arraHttpRoute"
     }
   ],
@@ -32,5 +36,36 @@
     "command": "arra",
     "help": "maw arra <help|version|menu|status|health|vector-config>",
     "handler": "arraCli"
+  },
+  "config": {
+    "dbBackend": "sqlite",
+    "embedderBackend": "none",
+    "remoteEmbedderUrl": ""
+  },
+  "configSchema": {
+    "type": "object",
+    "properties": {
+      "dbBackend": {
+        "type": "string",
+        "enum": [
+          "sqlite",
+          "http",
+          "memory",
+          "custom"
+        ]
+      },
+      "embedderBackend": {
+        "type": "string",
+        "enum": [
+          "none",
+          "local",
+          "remote"
+        ]
+      },
+      "remoteEmbedderUrl": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": true
   }
 }

--- a/src/plugins/arra/plugin.json
+++ b/src/plugins/arra/plugin.json
@@ -9,13 +9,17 @@
   "httpRoutes": [
     {
       "path": "/api/plugins/arra",
-      "methods": ["GET"]
+      "methods": [
+        "GET"
+      ]
     }
   ],
   "apiRoutes": [
     {
       "path": "/api/plugins/arra",
-      "methods": ["GET"],
+      "methods": [
+        "GET"
+      ],
       "handler": "arraHttpRoute"
     }
   ],
@@ -32,5 +36,36 @@
     "command": "arra",
     "help": "maw arra <help|version|menu|status|vector-config>",
     "handler": "arraCli"
+  },
+  "config": {
+    "dbBackend": "sqlite",
+    "embedderBackend": "none",
+    "remoteEmbedderUrl": ""
+  },
+  "configSchema": {
+    "type": "object",
+    "properties": {
+      "dbBackend": {
+        "type": "string",
+        "enum": [
+          "sqlite",
+          "http",
+          "memory",
+          "custom"
+        ]
+      },
+      "embedderBackend": {
+        "type": "string",
+        "enum": [
+          "none",
+          "local",
+          "remote"
+        ]
+      },
+      "remoteEmbedderUrl": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": true
   }
 }

--- a/src/plugins/arra/vector-health-cli.ts
+++ b/src/plugins/arra/vector-health-cli.ts
@@ -1,0 +1,127 @@
+type CliResult = { ok: boolean; output?: string; error?: string };
+type VectorConfigPayload = {
+  source?: string;
+  config?: {
+    collections?: Record<
+      string,
+      {
+        collection?: string;
+        model?: string;
+        adapter?: string;
+        enabled?: boolean;
+      }
+    >;
+  };
+  doc_counts?: Record<string, number>;
+  health?: Record<
+    string,
+    {
+      ok?: boolean;
+      status?: string;
+      adapter?: string;
+      model?: string;
+      collection?: string;
+      error?: string;
+    }
+  >;
+};
+
+const VECTOR_CONFIG_ENDPOINT = "/api/v1/vector/config";
+const HEALTH_ENDPOINT = "/api/health";
+
+function apiBase(): string {
+  const raw =
+    process.env.ORACLE_API ??
+    process.env.NEO_ARRA_API ??
+    "http://localhost:47778";
+  return String(raw).replace(/\/$/, "");
+}
+
+async function getJson<T>(path: string): Promise<T> {
+  const response = await fetch(`${apiBase()}${path}`, {
+    headers: { accept: "application/json" },
+  });
+  if (!response.ok)
+    throw new Error(
+      `${path} failed: HTTP ${response.status} ${await response.text()}`,
+    );
+  return response.json() as Promise<T>;
+}
+
+function rows(payload: VectorConfigPayload) {
+  return Object.entries(payload.config?.collections ?? {}).map(
+    ([key, config]) => {
+      const health = payload.health?.[key] ?? {};
+      return {
+        key,
+        collection: health.collection ?? config.collection ?? key,
+        adapter: health.adapter ?? config.adapter ?? "lancedb",
+        model: health.model ?? config.model ?? "unknown",
+        enabled: config.enabled !== false && health.status !== "disabled",
+        docs: payload.doc_counts?.[key] ?? 0,
+        status: health.status ?? "unknown",
+        ok: health.ok ?? false,
+        error: health.error,
+      };
+    },
+  );
+}
+
+function renderTable(
+  payload: VectorConfigPayload,
+  serverStatus: unknown,
+): string {
+  const engines = rows(payload);
+  const status =
+    typeof serverStatus === "object" && serverStatus && "status" in serverStatus
+      ? String((serverStatus as { status?: unknown }).status)
+      : "unknown";
+  const lines = [
+    `arra health: ${status}`,
+    `vector config: ${payload.source ?? "unknown"}`,
+    "Collection | Adapter | Model | Docs | Status",
+  ];
+  for (const engine of engines) {
+    lines.push(
+      `${engine.key} | ${engine.adapter} | ${engine.model} | ${engine.docs} | ${engine.status}${engine.error ? ` (${engine.error})` : ""}`,
+    );
+  }
+  if (!engines.length) lines.push("no vector engines reported");
+  return lines.join("\n");
+}
+
+export async function vectorHealthCli(args: string[]): Promise<CliResult> {
+  try {
+    const [health, vector] = await Promise.allSettled([
+      getJson<unknown>(HEALTH_ENDPOINT),
+      getJson<VectorConfigPayload>(VECTOR_CONFIG_ENDPOINT),
+    ]);
+    const vectorPayload =
+      vector.status === "fulfilled"
+        ? vector.value
+        : { config: { collections: {} } };
+    const healthPayload =
+      health.status === "fulfilled"
+        ? health.value
+        : {
+            status: "unknown",
+            error:
+              health.reason instanceof Error
+                ? health.reason.message
+                : String(health.reason),
+          };
+    const payload = {
+      health: healthPayload,
+      source: vectorPayload.source,
+      engines: rows(vectorPayload),
+    };
+    if (args.includes("--json"))
+      return { ok: true, output: JSON.stringify(payload, null, 2) };
+    return { ok: true, output: renderTable(vectorPayload, healthPayload) };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/tests/http/health/core-hardening.test.ts
+++ b/tests/http/health/core-hardening.test.ts
@@ -4,12 +4,30 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createApiVersionHeaderMiddleware, createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
-import { createRequestLogger } from '../../../src/middleware/logger.ts';
+import { createRequestLogger, formatRequestLog, type RequestLogEntry } from '../../../src/middleware/logger.ts';
 import { loadUnifiedPlugins } from '../../../src/plugins/unified-loader.ts';
 import { createHealthRoutes } from '../../../src/routes/health/index.ts';
 
 const tmp = mkdtempSync(join(tmpdir(), 'arra-core-hardening-'));
 afterAll(() => rmSync(tmp, { recursive: true, force: true }));
+
+
+const sampleLog: RequestLogEntry = {
+  event: 'http_request',
+  method: 'GET',
+  path: '/api/health',
+  status: 200,
+  durationMs: 12.5,
+  correlationId: 'abcdef123456',
+  headers: {},
+  sandbox: 'dev',
+};
+
+test('request logger formats nginx, short, and json records', () => {
+  expect(formatRequestLog(sampleLog, 'nginx')).toBe('GET /api/health 200 12.5ms [abcdef12] [dev]');
+  expect(formatRequestLog(sampleLog, 'short')).toBe('200 GET /api/health 13ms');
+  expect(JSON.parse(formatRequestLog(sampleLog, 'json'))).toMatchObject(sampleLog);
+});
 
 function pluginDir(name: string, entry: string) {
   const dir = join(tmp, name);

--- a/ψ/memory/hermes-desktop-architecture.md
+++ b/ψ/memory/hermes-desktop-architecture.md
@@ -1,0 +1,152 @@
+# Hermes Desktop Architecture Reference for arra-oracle-v3
+
+Issue: #1598  
+Date: 2026-06-16  
+Purpose: convert Hermes Agent desktop research into concrete `arra-oracle-v3` architecture guidance.
+
+## Short conclusion
+
+Hermes proves the right product boundary: **desktop is a thin host around one local runtime**. It should own install, boot, process supervision, OS integration, secure token storage, updates, diagnostics, and IPC hardening. It should not fork backend logic away from the CLI/API/MCP runtime.
+
+For ARRA, that means a future desktop shell should launch and monitor the existing Bun/Elysia server, then load the existing React Studio. ARRA should keep memory/search/vector/plugin behavior in `src/`, not in a desktop renderer.
+
+## Hermes pattern summary
+
+- Main desktop app: Electron + React/Vite shell.
+- Backend: existing Hermes Python runtime/dashboard spawned locally.
+- State root: `HERMES_HOME` holds config, sessions, logs, memories, plugins, MCP installs, backups, and runtime bootstrap metadata.
+- MCP: backend/CLI-owned config and catalog, surfaced in UI rather than stored only in renderer state.
+- Plugins: capability registration with provenance, enable/disable controls, and runtime status.
+- Packaging: Electron installers for macOS/Windows/Linux, plus a separate Tauri bootstrap installer path.
+- Security posture: hardened IPC/path helpers, sensitive-file blocking, safe token storage, process teardown before updates.
+
+## Current ARRA patterns to preserve
+
+### Shared Bun/Elysia runtime
+
+Relevant ARRA anchors:
+- `src/server.ts`
+- `src/routes/`
+- `src/middleware/api-version.ts`
+- `src/routes/health/`
+
+ARRA already has a modular HTTP runtime with versioned API compatibility, direct `/api/health`, and route clusters. A desktop shell should treat this server as the product core and gate launch on health readiness.
+
+Recommended desktop boot contract:
+
+```text
+Desktop host
+  -> resolve ARRA_HOME / data dir
+  -> start Bun/Elysia server on 127.0.0.1:0
+  -> pass local session token / profile env
+  -> wait for /api/health = ok
+  -> load Studio UI
+  -> stream logs + expose repair/restart actions
+```
+
+### React Studio as the UI shell
+
+Relevant ARRA anchors:
+- `frontend/src/pages/VectorPage.tsx`
+- `frontend/src/pages/VectorSettingsPage.tsx`
+- `frontend/src/pages/IndexManagerPanel.tsx`
+- `frontend/src/api/client.ts`
+
+ARRA should continue improving Studio as a web-first/PWA shell before native packaging. Hermes’ value is the shell supervision and OS integration, not a need to rebuild UI in native widgets.
+
+Adopt from Hermes:
+- status bar for server/vector/indexer/MCP/plugin health;
+- preview rail for search results, traces, documents, and plugin output;
+- command palette over pages, collections, plugins, tools, and jobs;
+- one-click diagnostics bundle with logs and health JSON.
+
+### Unified plugin manifest
+
+Relevant ARRA anchors:
+- `src/plugins/unified-manifest.ts`
+- `src/plugins/unified-loader.ts`
+- `src/plugins/path-containment.ts`
+- `src/plugins/unified-server.ts`
+- `src/plugins/error-containment.ts`
+
+ARRA’s declarative manifest is stricter than Hermes’ broad plugin registration model and should remain the spine. Borrow Hermes’ provenance/status ideas without allowing arbitrary hidden side effects.
+
+Recommended manifest evolution:
+- track every registered API route, MCP tool, CLI command, menu item, server, proxy, and hook by plugin ID;
+- add visible capability/provenance fields;
+- support safe enable/disable at plugin and surface level;
+- keep project-local plugins opt-in and clearly scoped;
+- show per-plugin server logs, health, and last error in Studio.
+
+### Memory and search core
+
+Relevant ARRA anchors:
+- `src/tools/`
+- `src/vector/`
+- `src/indexer/`
+- `src/routes/memory/`
+- `ψ/memory/`
+
+Hermes is useful for session/user memory lifecycle ideas, but ARRA is already stronger as a knowledge/search backend. Do not replace ARRA’s vector/FTS/indexer pipeline with a desktop-specific memory model.
+
+Recommended separation:
+- **Knowledge index:** current ARRA SQLite/FTS/vector/indexer pipeline.
+- **Agent memory layer:** future Hermes-like lifecycle for profile/session memory, background prefetch/sync, and memory tools.
+- **Human memory:** `ψ/memory/` markdown for reviewable long-term notes and architecture records.
+
+## Recommended ARRA desktop architecture
+
+Prefer this staged path:
+
+1. **Web/PWA first**
+   - Finish Studio readiness, health cards, plugin status, vector/indexer controls, and diagnostics.
+   - Keep all core behavior testable through HTTP contract tests.
+
+2. **Tauri shell prototype**
+   - Tauri is likely a better first ARRA fit than Electron because ARRA is Bun-native and does not need bundled Chromium/Node for backend compatibility.
+   - Use the shell only for process lifecycle, native menus, notifications, file dialogs, secure storage, and update UX.
+
+3. **Electron only if requirements force it**
+   - Consider Electron if ARRA needs deep PTY/xterm workflows, bundled Chromium consistency, or Hermes-like complex desktop panes.
+   - If chosen, copy Hermes’ security posture: context isolation, no Node in renderer, preload bridge, strict navigation, IPC allow-list, and path hardening.
+
+4. **Installer/update layer**
+   - Decide whether to bundle Bun or require system Bun.
+   - Support alpha/stable channels aligned with ARRA release policy.
+   - Stop child processes cleanly before update.
+   - Include logs and health output in support bundles.
+
+## Concrete adoption backlog
+
+Near-term, before native desktop:
+- Add a Studio runtime readiness page backed by `/api/health`, `/api/plugins`, vector health, and index status.
+- Add plugin provenance/capability display in the plugin UI.
+- Add per-plugin logs and restart/stop actions for plugin server surfaces.
+- Add backup/export flow that includes SQLite, vector metadata, config, plugin manifests, and `ψ/memory`.
+- Add a diagnostics endpoint or CLI command that bundles health, config redactions, log tails, and plugin status.
+
+Medium-term desktop prototype:
+- Define `ARRA_HOME` as the single desktop data root.
+- Add `maw arra serve --port 0 --json-ready` or equivalent readiness output.
+- Add local-only auth/session token for desktop renderer calls.
+- Add shell-owned log file paths and recovery actions.
+- Add a minimal Tauri launcher that opens existing Studio after health passes.
+
+Later polish:
+- Native file dialogs for import/export and vault selection.
+- OS notifications for index completion and plugin failures.
+- Secure storage for remote gateway tokens.
+- Signed installers and updater with explicit channel selection.
+
+## Risks and guardrails
+
+- Do not duplicate server logic in a desktop renderer.
+- Do not make desktop packaging block core MCP/search/server delivery.
+- Do not expose project-local plugins by default.
+- Do not rely on renderer-side secrets or broad filesystem IPC.
+- Keep health probes fast, direct, and independent of optional plugins.
+- Keep every native-shell capability behind a small audited bridge.
+
+## Final recommendation
+
+Use Hermes as a reference for **agent host ergonomics**: bootstrap, health-gated startup, profile-aware local state, MCP/catalog UX, plugin provenance, logs, and diagnostics. Keep ARRA’s identity as the stricter Bun/Elysia **Oracle memory/search MCP backend** with a React Studio operator console. Native desktop should arrive as a thin launcher and supervisor only after the web/server experience is stable.


### PR DESCRIPTION
## Summary
- Adds machine-readable swappable backend config to the built-in `arra` unified plugin manifest.
- Surfaces selected DB/embedder backend metadata through `/api/plugins/arra` for menu/API consumers.
- Keeps CLI status aligned with the same shared backend config and preserves the new `vector-config` command from alpha.

## Validation
- `bunx tsc --noEmit`
- `bun test src/plugins/__tests__/arra-plugin.test.ts tests/http/menu/arra-maw-plugin-menu.test.ts`
- Sequentially ran every `tests/http/**/*.test.ts` file: 126 files green.

## Note
- A single parallel `bun test tests/http/` run still trips the existing tenant DB file concurrency issue (`SQLITE_IOERR_VNODE`); per-file scoped HTTP coverage is green.
