### PR TITLE
feat: auto-index ψ learn docs (#1423)

### DIFF
--- a/src/indexer/collectors.ts
+++ b/src/indexer/collectors.ts
@@ -115,9 +115,9 @@ function getSecurityCorpusFiles(dir: string): string[] {
 }
 
 /**
- * Collect security-corpus documents from ψ/learn/security-corpus/.
- * OPT-IN: only runs when config.sourcePaths.security_corpus is set.
- * Reference: ψ/memory/learnings/2026-04-26_arra-v3-indexer-extension.md
+ * Collect repo exploration documents from ψ/learn/.
+ * Defaults on so /learn output is part of the standard indexer scan.
+ * ψ/learn/security-corpus remains excluded unless collectSecurityCorpus runs.
  */
 export function collectPsiLearn(opts: {
   config: IndexerConfig;
@@ -125,8 +125,7 @@ export function collectPsiLearn(opts: {
 }): OracleDocument[] {
   const { config, seenContentHashes } = opts;
   const documents: OracleDocument[] = [];
-  const subPath = config.sourcePaths.learn;
-  if (!subPath) return documents;
+  const subPath = config.sourcePaths.learn ?? 'ψ/learn';
 
   const sourcePath = path.join(config.repoRoot, subPath);
   if (!fs.existsSync(sourcePath)) return documents;

--- a/src/routes/indexer/start.ts
+++ b/src/routes/indexer/start.ts
@@ -27,6 +27,7 @@ export const startEndpoint = new Elysia().post('/indexer/start', async ({ body }
       learnings: `${sourcePath || REPO_ROOT}/memory/learnings`,
       retrospectives: `${sourcePath || REPO_ROOT}/memory/retrospectives`,
       distillations: `${sourcePath || REPO_ROOT}/memory/distillations`,
+      learn: `${sourcePath || REPO_ROOT}/learn`,
     },
   };
 

--- a/src/verify/handler.ts
+++ b/src/verify/handler.ts
@@ -67,7 +67,12 @@ export function verifyKnowledgeBase(opts: {
   const { check = true, type, repoRoot } = opts;
 
   // 1. Walk indexed directories on disk
-  const indexedDirs = ['ψ/memory/resonance', 'ψ/memory/learnings', 'ψ/memory/retrospectives'];
+  const indexedDirs = [
+    'ψ/memory/resonance',
+    'ψ/memory/learnings',
+    'ψ/memory/retrospectives',
+    'ψ/learn',
+  ];
   const diskFiles = new Map<string, number>(); // relativePath -> mtimeMs
 
   for (const dir of indexedDirs) {
@@ -148,7 +153,7 @@ export function verifyKnowledgeBase(opts: {
     }
   }
 
-  // 4. Count untracked files (ψ/inbox/, ψ/learn/, etc. — outside indexed dirs)
+  // 4. Count untracked files outside indexed dirs.
   const untrackedDirs = ['ψ/inbox'];
   const untracked: string[] = [];
   for (const dir of untrackedDirs) {

--- a/tests/http/learn/auto-index.test.ts
+++ b/tests/http/learn/auto-index.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type { IndexerConfig } from '../../../src/types.ts';
+import { collectPsiLearn } from '../../../src/indexer/collectors.ts';
+
+let repoRoot = '';
+
+function makeConfig(): IndexerConfig {
+  repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-psi-learn-'));
+  return {
+    repoRoot,
+    dbPath: path.join(repoRoot, 'oracle.db'),
+    chromaPath: path.join(repoRoot, 'chroma'),
+    sourcePaths: {
+      resonance: 'ψ/memory/resonance',
+      learnings: 'ψ/memory/learnings',
+      retrospectives: 'ψ/memory/retrospectives',
+      distillations: 'ψ/memory/distillations',
+    },
+  };
+}
+
+afterEach(() => {
+  if (repoRoot) fs.rmSync(repoRoot, { recursive: true, force: true });
+  repoRoot = '';
+});
+
+describe('ψ/learn auto-index source discovery', () => {
+  test('standard index scan includes ψ/learn markdown by default', () => {
+    const config = makeConfig();
+    const learnDir = path.join(repoRoot, 'ψ', 'learn', 'github.com', 'owner', 'repo');
+    const corpusDir = path.join(repoRoot, 'ψ', 'learn', 'security-corpus', 'web', 'docs');
+    fs.mkdirSync(learnDir, { recursive: true });
+    fs.mkdirSync(corpusDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(learnDir, 'exploration.md'),
+      '# Exploration\n\n## Finding\n\nThe watcher and indexer should ingest learn docs.',
+    );
+    fs.writeFileSync(path.join(corpusDir, 'ignored.md'), 'security corpus is opt-in');
+
+    const docs = collectPsiLearn({ config, seenContentHashes: new Set() });
+
+    expect(docs).toHaveLength(1);
+    expect(docs[0].type).toBe('learning');
+    expect(docs[0].source_file).toBe('ψ/learn/github.com/owner/repo/exploration.md');
+    expect(docs[0].id.startsWith('learning_psi_learn_')).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #1423

## Changes
- Includes ψ/learn markdown in default indexer collection even when no explicit learn source path is configured
- Keeps ψ/learn/security-corpus excluded from default scans unless the opt-in corpus collector runs
- Adds ψ/learn to verify/indexer source path coverage
- Adds HTTP-scoped regression coverage for ψ/learn auto-index discovery

## Test
- bunx tsc --noEmit: green
- bun test --isolate tests/http/tenant/ tests/http/learn/ src/indexer/__tests__/learn-watcher.test.ts: green
- bun test tests/http/: not green locally due existing alpha/shared harness issues (tenant SQLite IOERR_VNODE under parallel shared DB; after stopping external server, knowledge.test server startup race + same tenant I/O). Scoped affected suites are green.