### PR TITLE
feat: preserve Thor dev-research trace context

### DIFF
--- a/src/routes/traces/distill.ts
+++ b/src/routes/traces/distill.ts
@@ -6,6 +6,10 @@ import { traceIdParam } from './model.ts';
 const distillBody = t.Object({
   awakening: t.String({ minLength: 1 }),
   promoteToLearning: t.Optional(t.Boolean()),
+  oracle: t.Optional(t.String()),
+  theme: t.Optional(t.String()),
+  concepts: t.Optional(t.Array(t.String())),
+  source: t.Optional(t.String()),
 });
 
 export const traceDistillRoute = new Elysia().post('/api/traces/:id/distill', ({ params, body, set }) => {
@@ -22,6 +26,10 @@ export const traceDistillRoute = new Elysia().post('/api/traces/:id/distill', ({
     traceId: params.id,
     awakening,
     promoteToLearning: body.promoteToLearning,
+    oracle: body.oracle,
+    theme: body.theme,
+    concepts: body.concepts,
+    source: body.source,
   });
 }, {
   params: traceIdParam,

--- a/src/trace/distill.ts
+++ b/src/trace/distill.ts
@@ -4,27 +4,58 @@ import { handleLearn } from '../server/handlers.ts';
 import { getTrace } from './handler.ts';
 import type { DistillTraceInput } from './types.ts';
 
+const DEFAULT_ORACLE = 'thor-oracle';
+const DEFAULT_THEME = 'stormforge';
+
 export type DistillTraceResult = {
   success: boolean;
   status: string;
   learningId?: string;
+  origin?: string;
+  concepts?: string[];
   error?: string;
 };
 
-function learningConcepts(traceId: string): string[] {
-  return ['trace-awakening', 'thor-oracle', 'dev-research', `trace-${traceId}`];
+function conceptSlug(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function uniqueConcepts(values: string[]): string[] {
+  return [...new Set(values.map(conceptSlug).filter(Boolean))];
+}
+
+function oracleOrigin(input: DistillTraceInput): string {
+  return conceptSlug(input.oracle ?? DEFAULT_ORACLE) || DEFAULT_ORACLE;
+}
+
+function learningConcepts(input: DistillTraceInput): string[] {
+  return uniqueConcepts([
+    'trace-awakening',
+    oracleOrigin(input),
+    'dev-research',
+    input.theme ?? DEFAULT_THEME,
+    `trace-${input.traceId}`,
+    ...(input.concepts ?? []),
+  ]);
 }
 
 export function distillTraceAwakening(input: DistillTraceInput): DistillTraceResult {
   const trace = getTrace(input.traceId);
   if (!trace) return { success: false, status: 'not_found', error: 'Trace not found' };
 
+  const origin = oracleOrigin(input);
+  const concepts = learningConcepts(input);
   const learning = input.promoteToLearning
     ? handleLearn(
       input.awakening,
-      `Trace awakening ${input.traceId}`,
-      learningConcepts(input.traceId),
-      'thor-oracle',
+      input.source?.trim() || `Trace awakening ${input.traceId}`,
+      concepts,
+      origin,
       trace.project ?? undefined,
     )
     : undefined;
@@ -46,5 +77,7 @@ export function distillTraceAwakening(input: DistillTraceInput): DistillTraceRes
     success: true,
     status: 'distilled',
     learningId: learning?.id,
+    origin: learning?.id ? origin : undefined,
+    concepts: learning?.id ? concepts : undefined,
   };
 }

--- a/src/trace/types.ts
+++ b/src/trace/types.ts
@@ -64,6 +64,10 @@ export interface DistillTraceInput {
   traceId: string;
   awakening: string;
   promoteToLearning?: boolean;
+  oracle?: string;
+  theme?: string;
+  concepts?: string[];
+  source?: string;
 }
 
 // Output Types

--- a/tests/http/traces/routes.test.ts
+++ b/tests/http/traces/routes.test.ts
@@ -50,10 +50,12 @@ afterAll(() => {
 describe("Trace routes", () => {
   let traceA: string;
   let traceB: string;
+  let traceC: string;
 
   beforeAll(() => {
     traceA = randomUUID();
     traceB = randomUUID();
+    traceC = randomUUID();
     const db = new Database(dbPath);
     try {
       const now = Date.now();
@@ -70,6 +72,7 @@ describe("Trace routes", () => {
       `);
       insert.run(traceA, "contract-test trace A", now, now);
       insert.run(traceB, "contract-test trace B", now, now);
+      insert.run(traceC, "contract-test trace C", now, now);
     } finally {
       db.close();
     }
@@ -143,6 +146,31 @@ describe("Trace routes", () => {
     const learning = await learnRes.json();
     expect(learning.concepts).toContain("thor-oracle");
     expect(learning.origin).toBe("thor-oracle");
+  });
+
+  test("POST /api/traces/:id/distill keeps Thor dev-research metadata searchable", async () => {
+    const res = await fetch(`${BASE_URL}/api/traces/${traceC}/distill`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        awakening: "Thor links research hypotheses to implementation evidence.",
+        promoteToLearning: true,
+        oracle: "Thor Oracle",
+        theme: "Stormforge",
+        concepts: ["system thinking", "continuity"],
+      }),
+    });
+    expect(res.ok).toBe(true);
+    const body = await res.json();
+    expect(body.concepts).toContain("dev-research");
+    expect(body.concepts).toContain("stormforge");
+
+    const learnRes = await fetch(`${BASE_URL}/api/learn/${body.learningId}`);
+    expect(learnRes.ok).toBe(true);
+    const learning = await learnRes.json();
+    expect(learning.origin).toBe("thor-oracle");
+    expect(learning.concepts).toContain("system-thinking");
+    expect(learning.concepts).toContain("continuity");
   });
 
   test("POST /api/traces/:prevId/link without body returns 400", async () => {


### PR DESCRIPTION
## Summary\n- Add Thor/Stormforge dev-research metadata to trace distill promotion\n- Allow distill callers to pass oracle/theme/source/concepts\n- Keep promoted awakenings searchable via normalized concepts and origin\n\n## Verification\n- bunx tsc --noEmit\n- bun test tests/http/traces/\n- bun test tests/http/ attempted locally; existing suite isolation issues fail outside this change (shared DB/port tests), while affected trace coverage is green\n\n## Notes\n- Files remain under 250 lines\n