### PR TITLE
feat: expose unified plugin capability rows

### DIFF
--- a/frontend/src/pages/UnifiedPluginSurfaceOverview.tsx
+++ b/frontend/src/pages/UnifiedPluginSurfaceOverview.tsx
@@ -42,6 +42,17 @@ function buildCards(plugins: PluginEntry[], state: SurfaceState): Card[] {
   ];
 }
 
+
+export function pluginCapabilityRows(plugins: PluginEntry[]): string[] {
+  return plugins.flatMap((plugin) => [
+    ...(plugin.apiRoutes ?? []).map((route) => `${plugin.name} api ${route.methods?.join('|') ?? 'ALL'} ${route.path}`),
+    ...(plugin.mcpTools ?? []).map((tool) => `${plugin.name} mcp ${tool.name}${tool.readOnly ? ' read-only' : ''}`),
+    ...(plugin.cliSubcommands ?? []).map((command) => `${plugin.name} cli ${command.command}`),
+    ...(plugin.exportFormats ?? []).map((format) => `${plugin.name} export ${format.extension}`),
+    ...(plugin.proxy ?? []).map((proxy) => `${plugin.name} proxy ${proxy.path}`),
+  ]);
+}
+
 export function pluginServerRows(plugins: PluginEntry[]): Array<{ name: string; status: string; health: string }> {
   return plugins
     .filter((plugin) => plugin.server || plugin.proxy?.length)
@@ -77,6 +88,7 @@ export function UnifiedPluginSurfaceOverview({ plugins }: { plugins: PluginEntry
   const cards = useMemo(() => buildCards(plugins, state), [plugins, state]);
   const counts = useMemo(() => countBySurface(plugins), [plugins]);
   const servers = useMemo(() => pluginServerRows(plugins), [plugins]);
+  const capabilities = useMemo(() => pluginCapabilityRows(plugins), [plugins]);
 
   return (
     <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="unified-surfaces-title">
@@ -90,10 +102,11 @@ export function UnifiedPluginSurfaceOverview({ plugins }: { plugins: PluginEntry
       </div>
       {error ? <p className="mb-3 text-sm text-amber-200">{error}</p> : null}
       <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">{cards.map((card) => <SurfaceCard key={card.label} card={card} />)}</div>
-      <div className="mt-4 grid gap-3 xl:grid-cols-4">
+      <div className="mt-4 grid gap-3 xl:grid-cols-5">
         <SurfaceList title="Menu items" items={state.menu.slice(0, 5).map((item) => `${item.label} → ${item.path}`)} empty="No /api/menu items loaded yet." />
         <SurfaceList title="MCP tools" items={state.tools.slice(0, 5).map((tool) => `${tool.name}${tool.plugin ? ` · ${tool.plugin}` : ''}`)} empty="No /api/mcp/tools entries loaded yet." />
         <SurfaceList title="Plugin servers" items={servers.map((server) => `${server.name} · ${server.status} · ${server.health}`)} empty="No plugin server or proxy surfaces." />
+        <SurfaceList title="Capabilities" items={capabilities.slice(0, 6)} empty="No API, CLI, proxy, export, or MCP capabilities." />
         <SurfaceList title="Storage" items={[state.settings ? `${state.settings.storage.activeBackend} · ${formatPath(state.settings.storage.dbPath)}` : 'Storage config not loaded yet.']} empty="Storage config not loaded yet." />
       </div>
     </section>

--- a/tests/frontend/pages/unified-plugin-overview.test.tsx
+++ b/tests/frontend/pages/unified-plugin-overview.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { UnifiedPluginSurfaceOverview, pluginServerRows } from '../../../frontend/src/pages/UnifiedPluginSurfaceOverview';
+import { UnifiedPluginSurfaceOverview, pluginCapabilityRows, pluginServerRows } from '../../../frontend/src/pages/UnifiedPluginSurfaceOverview';
 import { htmlFor } from '../_render';
 
 describe('UnifiedPluginSurfaceOverview', () => {
@@ -12,13 +12,22 @@ describe('UnifiedPluginSurfaceOverview', () => {
       status: 'ok',
       server: { command: 'bun', healthPath: '/health' },
       proxy: [{ path: '/api/plugins/echo/server', targetEnv: 'ECHO_URL' }],
+      apiRoutes: [{ path: '/api/plugins/echo/ping', methods: ['GET'] }],
+      mcpTools: [{ name: 'echo_tool', description: 'Echo', inputSchema: {}, source: 'plugin', readOnly: true }],
+      cliSubcommands: [{ command: 'echo', help: 'Echo input' }],
+      exportFormats: [{ extension: 'echo' }],
     }];
 
     expect(pluginServerRows(plugins)).toEqual([{ name: 'echo', status: 'ok', health: '/health' }]);
+    expect(pluginCapabilityRows(plugins)).toContain('echo api GET /api/plugins/echo/ping');
+    expect(pluginCapabilityRows(plugins)).toContain('echo mcp echo_tool read-only');
     const html = htmlFor(<UnifiedPluginSurfaceOverview plugins={plugins} />);
     expect(html).toContain('Menu items');
     expect(html).toContain('MCP tools');
     expect(html).toContain('Plugin servers');
     expect(html).toContain('echo · ok · /health');
+    expect(html).toContain('Capabilities');
+    expect(html).toContain('echo cli echo');
+    expect(html).toContain('echo export echo');
   });
 });


### PR DESCRIPTION
## Summary
- fill remaining unified-plugin UI gaps after #1728 by exposing API, MCP, CLI, export, and proxy capability rows in the backend surface overview
- keep `PluginsPage.tsx` under the 250-line rule by extending `UnifiedPluginSurfaceOverview.tsx`
- update frontend regression coverage for the expanded capability map

## Verification
- `bun test tests/frontend/pages/unified-plugin-overview.test.tsx tests/frontend/pages/plugins-page-admin.test.tsx tests/frontend/pages/plugins-page-ready.test.tsx tests/frontend/pages/plugins-page-loading.test.tsx` — 4 pass
- `bunx tsc --noEmit` — green
