### PR TITLE
test: isolate knowledge HTTP harness

### DIFF
--- a/tests/http/knowledge.test.ts
+++ b/tests/http/knowledge.test.ts
@@ -5,12 +5,16 @@
  */
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import type { Subprocess } from "bun";
+import fs from "fs";
+import os from "os";
 import path from "path";
 
-const BASE_URL = "http://localhost:47778";
+const PORT = 47791;
+const BASE_URL = `http://localhost:${PORT}`;
 const JSON_HEADERS = { "Content-Type": "application/json" };
 const SEED_TAG = `yellow-http-test-${Date.now()}`;
 let serverProcess: Subprocess | null = null;
+let dataDir = "";
 
 const isUp = async () => {
   try { return (await fetch(`${BASE_URL}/api/health`)).ok; } catch { return false; }
@@ -33,14 +37,25 @@ async function seedLearn(pattern: string, concepts: string[] = []) {
 describe("HTTP Contract — search / knowledge / supersede", () => {
   beforeAll(async () => {
     if (await isUp()) return;
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-http-"));
     serverProcess = Bun.spawn(["bun", "run", "src/server.ts"], {
       cwd: path.resolve(import.meta.dir, "../.."),
       stdout: "pipe", stderr: "pipe",
-      env: { ...process.env, ORACLE_CHROMA_TIMEOUT: "3000" },
+      env: {
+        ...process.env,
+        ORACLE_CHROMA_TIMEOUT: "3000",
+        ORACLE_DATA_DIR: dataDir,
+        ORACLE_DB_PATH: path.join(dataDir, "oracle.db"),
+        ORACLE_REPO_ROOT: dataDir,
+        ORACLE_PORT: String(PORT),
+      },
     });
     if (!(await waitUp())) throw new Error("Server failed to start within 15s");
   }, 30_000);
-  afterAll(() => { if (serverProcess) serverProcess.kill(); });
+  afterAll(() => {
+    if (serverProcess) serverProcess.kill();
+    if (dataDir) fs.rmSync(dataDir, { recursive: true, force: true });
+  });
 
   describe("POST /api/learn", () => {
     test("creates a learning doc", async () => {


### PR DESCRIPTION
## Changes
- Isolate tests/http/knowledge.test.ts on its own port and temp ORACLE_DATA_DIR/ORACLE_DB_PATH/ORACLE_REPO_ROOT
- Prevent fixed-port 47778 reuse from racing core/knowledge HTTP subprocess startup
- Keeps test file under 250 LOC

## Test
- bunx tsc --noEmit: green
- bun test tests/http/tenant/ tests/http/learn/: green
- bun test tests/http/knowledge.test.ts tests/http/tenant/ tests/http/learn/: green