### PR TITLE
test: add HTTP route coverage for missing clusters

### DIFF
--- a/tests/http/indexer/basic.test.ts
+++ b/tests/http/indexer/basic.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { indexerRoutes } from '../../../src/routes/indexer/index.ts';
+
+function request(path: string, init: RequestInit = {}) {
+  return indexerRoutes.handle(new Request(`http://local${path}`, init));
+}
+
+function post(path: string, body: unknown) {
+  return request(path, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('indexer HTTP routes', () => {
+  test('GET /api/indexer/config returns adapters and model metadata', async () => {
+    const res = await request('/api/indexer/config');
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(body.adapters)).toBe(true);
+    expect(body.adapters).toContain('lancedb');
+    expect(Array.isArray(body.models)).toBe(true);
+    expect(body.models.length).toBeGreaterThan(0);
+  });
+
+  test('POST /api/indexer/scan reports markdown files by type', async () => {
+    const root = join(tmpdir(), `indexer-scan-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+    const learnDir = join(root, 'memory', 'learnings');
+    mkdirSync(learnDir, { recursive: true });
+    writeFileSync(join(learnDir, 'lesson.md'), '# Lesson\n\nBody');
+    writeFileSync(join(learnDir, 'skip.txt'), 'not markdown');
+
+    try {
+      const res = await post('/api/indexer/scan', { sourcePath: root, types: ['learning'] });
+      const body = await res.json() as Record<string, any>;
+
+      expect(res.status).toBe(200);
+      expect(body.total).toBe(1);
+      expect(body.byType.learning).toBe(1);
+      expect(body.files[0].relativePath).toContain('lesson.md');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('POST /api/indexer/scan returns empty payload for missing path', async () => {
+    const missing = join(tmpdir(), `missing-indexer-${Date.now()}`);
+    const res = await post('/api/indexer/scan', { sourcePath: missing });
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(body.error).toContain('Path not found');
+    expect(body.total).toBe(0);
+    expect(body.files).toEqual([]);
+  });
+
+  test('POST /api/indexer/stop toggles the stop contract', async () => {
+    const res = await post('/api/indexer/stop', {});
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ stopped: true });
+  });
+});

--- a/tests/http/peer/basic.test.ts
+++ b/tests/http/peer/basic.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { peerRoutes } from '../../../src/routes/peer/index.ts';
+
+const savedPeerToken = process.env.ARRA_PEER_TOKEN;
+
+afterEach(() => {
+  if (savedPeerToken === undefined) delete process.env.ARRA_PEER_TOKEN;
+  else process.env.ARRA_PEER_TOKEN = savedPeerToken;
+});
+
+function request(path: string, init: RequestInit = {}) {
+  return peerRoutes.handle(new Request(`http://local${path}`, init));
+}
+
+describe('peer HTTP routes', () => {
+  test('GET /info exposes federation capabilities', async () => {
+    const res = await request('/info');
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(body.oracle).toBe('arra');
+    expect(body.maw.capabilities).toContain('arra-search');
+  });
+
+  test('GET /api/identity returns a stable identity document shape', async () => {
+    const res = await request('/api/identity');
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(typeof body.pubkey).toBe('string');
+    expect(body.oracle).toBe('arra');
+    expect(typeof body.clockUtc).toBe('string');
+  });
+
+  test('peer-protected endpoints reject missing bearer token when configured', async () => {
+    process.env.ARRA_PEER_TOKEN = 'secret';
+
+    const feed = await request('/api/peer/feed');
+    expect(feed.status).toBe(401);
+    expect(await feed.json()).toMatchObject({ error: 'peer_auth_required' });
+
+    const search = await request('/api/peer/search', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ q: 'oracle' }),
+    });
+    expect(search.status).toBe(401);
+  });
+});

--- a/tests/http/sessions/summary.test.ts
+++ b/tests/http/sessions/summary.test.ts
@@ -1,0 +1,66 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const savedRepoRoot = process.env.ORACLE_REPO_ROOT;
+const root = join(tmpdir(), `session-summary-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+const dbPath = join(root, 'oracle.db');
+
+mkdirSync(root, { recursive: true });
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = dbPath;
+process.env.ORACLE_REPO_ROOT = root;
+
+const dbMod = await import('../../../src/db/index.ts');
+dbMod.resetDefaultDatabaseForTests(dbPath);
+const { sessionsRoutes } = await import('../../../src/routes/sessions/index.ts');
+
+function restore(name: string, value: string | undefined) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+function post(id: string, body: unknown) {
+  return sessionsRoutes.handle(new Request(`http://local/api/session/${id}/summary`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+}
+
+afterAll(() => {
+  restore('ORACLE_DATA_DIR', savedDataDir);
+  restore('ORACLE_DB_PATH', savedDbPath);
+  restore('ORACLE_REPO_ROOT', savedRepoRoot);
+  dbMod.resetDefaultDatabaseForTests();
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('session summary HTTP route', () => {
+  test('rejects an empty summary before writing a document', async () => {
+    const res = await post('empty-session', { summary: '   ' });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'Missing required field: summary' });
+  });
+
+  test('persists a valid session summary as a learning document', async () => {
+    const sessionId = `session-${Date.now()}`;
+    const res = await post(sessionId, { summary: 'Session captured useful route test coverage.', oracle: 'codex' });
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(201);
+    expect(body.ok).toBe(true);
+    expect(body.source_file).toBe(`ψ/memory/session-summaries/${sessionId}.md`);
+    expect(body.learning_id).toBe(`session-summary_${sessionId}`);
+
+    const row = dbMod.db.select({ createdBy: dbMod.oracleDocuments.createdBy })
+      .from(dbMod.oracleDocuments)
+      .where(eq(dbMod.oracleDocuments.id, body.learning_id))
+      .get();
+    expect(row?.createdBy).toBe('session_summary');
+  });
+});

--- a/tests/http/vault/sync.test.ts
+++ b/tests/http/vault/sync.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createVaultSyncRoute } from '../../../src/routes/vault/sync.ts';
+import type { MigrateResult } from '../../../src/vault/migrate.ts';
+
+const emptyMigrate: MigrateResult = {
+  reposFound: 0,
+  filesCopied: 0,
+  repos: [],
+  skipped: [],
+  symlinked: [],
+};
+
+function appWith(migrate: (opts: { dryRun: boolean }) => MigrateResult, spawnIndexer = mock(() => {})) {
+  return new Elysia({ prefix: '/api/vault' })
+    .use(createVaultSyncRoute({ migrate, spawnIndexer }));
+}
+
+function post(app: Elysia, body: unknown) {
+  return app.handle(new Request('http://local/api/vault/sync', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+}
+
+describe('vault sync HTTP route', () => {
+  test('dry-run sync returns migrate result without spawning reindex', async () => {
+    const migrate = mock(() => ({ ...emptyMigrate, reposFound: 2, filesCopied: 5 }));
+    const spawnIndexer = mock(() => {});
+    const res = await post(appWith(migrate, spawnIndexer), { dryRun: true, reindex: true });
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.dryRun).toBe(true);
+    expect(body.reindex).toBe(false);
+    expect(body.migrate.filesCopied).toBe(5);
+    expect(spawnIndexer).not.toHaveBeenCalled();
+  });
+
+  test('reindex spawns only when copied files exist', async () => {
+    const migrate = mock(() => ({ ...emptyMigrate, filesCopied: 1 }));
+    const spawnIndexer = mock(() => {});
+    const res = await post(appWith(migrate, spawnIndexer), { reindex: true });
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(body.reindex).toBe(true);
+    expect(spawnIndexer).toHaveBeenCalledTimes(1);
+  });
+
+  test('migrate failures surface as 500 JSON', async () => {
+    const migrate = mock(() => { throw new Error('vault not initialized'); });
+    const res = await post(appWith(migrate), {});
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(500);
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('vault not initialized');
+  });
+});


### PR DESCRIPTION
## Changes
- Added fetch-based HTTP contract tests for indexer routes
- Added peer route coverage for info, identity, and auth rejection
- Added session summary route persistence/rejection coverage
- Added vault sync route dry-run, reindex, and failure coverage

## Test
- bunx tsc --noEmit: green
- bun test tests/http/indexer/basic.test.ts tests/http/peer/basic.test.ts tests/http/sessions/summary.test.ts tests/http/vault/sync.test.ts: green