### PR TITLE
fix: persist maw serve port through API commands (#1603)

### DIFF
--- a/maw-plugin/__tests__/index.test.ts
+++ b/maw-plugin/__tests__/index.test.ts
@@ -105,11 +105,15 @@ describe('maw arra plugin', () => {
     expect(calls).toContainEqual(expect.objectContaining({ cmd: 'ghq', args: ['locate', 'Soul-Brews-Studio/arra-oracle-v3'] }));
     expect(calls).toContainEqual(expect.objectContaining({ cmd: 'start', cwd: '/repo/arra-oracle-v3' }));
 
-    const status = await runArra(['serve', '--status', '--port', '49999'], async () => ({}), () => {}, env, runner, {
+    expect(resolveBaseUrl(env)).toBe('http://localhost:49999');
+    expect(resolveBaseUrl({ ...env, ORACLE_API: 'http://localhost:47778' })).toBe('http://localhost:47778');
+
+    const status = await runArra(['serve', '--status'], async () => ({}), () => {}, env, runner, {
       isAlive: () => true,
       fetch: async () => new Response('{"status":"ok"}', { status: 200 }),
     });
     expect(status.output).toContain('alive pid=12345');
+    expect(status.output).toContain('port: 49999');
     expect(status.output).toContain('health: ok 200');
 
     const stop = await runArra(['serve', '--stop'], async () => ({}), () => {}, env, runner, {

--- a/maw-plugin/index.ts
+++ b/maw-plugin/index.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
 import { join } from 'node:path';
 import { apiArgsToCliArgs } from './api.ts';
-import { runServe, type ServeDeps } from './serve.ts';
+import { resolveServePort, runServe, type ServeDeps } from './serve.ts';
 import { LOCAL_CLI_HELP, resolveLocalCliName, runLocalCli } from './local-cli.ts';
 import { runVectorConfig, VECTOR_CONFIG_HELP } from './vector-config.ts';
 type InvokeContext = { source?: string; args?: string[] | Record<string, unknown>; writer?: (...args: unknown[]) => void };
@@ -22,7 +22,9 @@ const normalizeApiBase = (url: string) => url.replace(/\/+$/, '');
 export const command = { name: 'arra', description: 'ARRA Oracle HTTP helper — 1:1 maw CLI surface for ARRA MCP tools.' };
 
 export function resolveBaseUrl(env: Record<string, string | undefined> = process.env): string {
-  return normalizeApiBase(env.ORACLE_API?.trim() || DEFAULT_ORACLE_API);
+  const explicit = env.ORACLE_API?.trim();
+  if (explicit) return normalizeApiBase(explicit);
+  return normalizeApiBase(`http://localhost:${resolveServePort(env, DEFAULT_ORACLE_API.split(':').at(-1) ?? '47778')}`);
 }
 
 export function resolveFrontendUrl(env: Record<string, string | undefined> = process.env): string {

--- a/maw-plugin/serve.ts
+++ b/maw-plugin/serve.ts
@@ -69,6 +69,10 @@ function writeState(path: string, state: ServeState): void {
   writeFileSync(path, `${JSON.stringify(state)}\n`);
 }
 
+export function resolveServePort(env: Record<string, string | undefined>, fallback = DEFAULT_PORT): string {
+  return readState(pidFile(env))?.port ?? fallback;
+}
+
 function alive(pid: number): boolean {
   try { process.kill(pid, 0); return true; }
   catch (error: any) { return error?.code === 'EPERM'; }

--- a/tests/http/core.test.ts
+++ b/tests/http/core.test.ts
@@ -63,9 +63,11 @@ describe("HTTP Contract — Core Routes", () => {
     console.log("Server ready");
   }, 30_000);
 
-  afterAll(() => {
+  afterAll(async () => {
     if (serverProcess) {
       serverProcess.kill();
+      await serverProcess.exited;
+      await Bun.sleep(500);
       console.log("Server stopped");
     }
   });

--- a/tests/http/knowledge.test.ts
+++ b/tests/http/knowledge.test.ts
@@ -52,8 +52,12 @@ describe("HTTP Contract — search / knowledge / supersede", () => {
     });
     if (!(await waitUp())) throw new Error("Server failed to start within 15s");
   }, 30_000);
-  afterAll(() => {
-    if (serverProcess) serverProcess.kill();
+  afterAll(async () => {
+    if (serverProcess) {
+      serverProcess.kill();
+      await serverProcess.exited;
+      await Bun.sleep(500);
+    }
     if (dataDir) fs.rmSync(dataDir, { recursive: true, force: true });
   });
 

--- a/tests/http/tenant/admin.test.ts
+++ b/tests/http/tenant/admin.test.ts
@@ -1,6 +1,8 @@
 import { afterAll, expect, test } from 'bun:test';
 import { eq } from 'drizzle-orm';
-import { db, tenants } from '../../../src/db/index.ts';
+import { db, resetDefaultDatabaseForTests, tenants } from '../../../src/db/index.ts';
+
+resetDefaultDatabaseForTests();
 import { tenantsRoutes } from '../../../src/routes/tenants/index.ts';
 
 const tenantId = `admin-tenant-${Date.now()}-${Math.random().toString(16).slice(2)}`;

--- a/tests/http/tenant/learn-isolation.test.ts
+++ b/tests/http/tenant/learn-isolation.test.ts
@@ -3,7 +3,9 @@ import { eq } from 'drizzle-orm';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { db, oracleDocuments, sqlite } from '../../../src/db/index.ts';
+import { db, oracleDocuments, resetDefaultDatabaseForTests, sqlite } from '../../../src/db/index.ts';
+
+resetDefaultDatabaseForTests();
 import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
 import { createLearnCrudRoutes } from '../../../src/routes/learn/crud.ts';
 

--- a/tests/http/tenant/search-isolation.test.ts
+++ b/tests/http/tenant/search-isolation.test.ts
@@ -1,6 +1,8 @@
 import { afterAll, expect, test } from 'bun:test';
 import { inArray } from 'drizzle-orm';
-import { db, oracleDocuments, sqlite } from '../../../src/db/index.ts';
+import { db, oracleDocuments, resetDefaultDatabaseForTests, sqlite } from '../../../src/db/index.ts';
+
+resetDefaultDatabaseForTests();
 import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
 import { searchRoutes } from '../../../src/routes/search/index.ts';
 


### PR DESCRIPTION
Closes #1603

## Changes
- Reuse persisted `maw arra serve --port` state when resolving the default maw API base URL
- Preserve `ORACLE_API` as the explicit override
- Cover status without repeated `--port` and API base resolution from serve state
- Stabilize full HTTP sweep by awaiting spawned server teardown and reopening tenant test DB handles

## Test
- bunx tsc --noEmit: green
- bun test tests/http/: passed
- bun test maw-plugin/__tests__/serve.test.ts maw-plugin/__tests__/index.test.ts: passed