### PR TITLE
security: tighten HTTP route validation and auth contracts

### DIFF
--- a/src/routes/forum/model.ts
+++ b/src/routes/forum/model.ts
@@ -8,6 +8,13 @@ export const threadsQuery = t.Object({
   offset: t.Optional(t.String()),
 });
 
-export const threadCreateBody = t.Unknown();
+export const threadCreateBody = t.Object({
+  message: t.String({ minLength: 1 }),
+  thread_id: t.Optional(t.Union([t.Number(), t.String()])),
+  title: t.Optional(t.String()),
+  role: t.Optional(t.String()),
+});
 
-export const threadStatusBody = t.Unknown();
+export const threadStatusBody = t.Object({
+  status: t.String({ minLength: 1 }),
+});

--- a/src/routes/schedule/model.ts
+++ b/src/routes/schedule/model.ts
@@ -11,5 +11,22 @@ export const listQuery = t.Object({
   limit: t.Optional(t.String()),
 });
 
-export const createBody = t.Unknown();
-export const updateBody = t.Unknown();
+const scheduleStatus = t.Union([t.Literal('pending'), t.Literal('done'), t.Literal('cancelled')]);
+const recurring = t.Union([t.Literal('daily'), t.Literal('weekly'), t.Literal('monthly')]);
+
+export const createBody = t.Object({
+  date: t.String({ minLength: 1 }),
+  event: t.String({ minLength: 1 }),
+  time: t.Optional(t.String()),
+  notes: t.Optional(t.String()),
+  recurring: t.Optional(recurring),
+});
+
+export const updateBody = t.Object({
+  date: t.Optional(t.String({ minLength: 1 })),
+  event: t.Optional(t.String({ minLength: 1 })),
+  time: t.Optional(t.String()),
+  notes: t.Optional(t.String()),
+  recurring: t.Optional(recurring),
+  status: t.Optional(scheduleStatus),
+});

--- a/src/routes/traces/model.ts
+++ b/src/routes/traces/model.ts
@@ -15,7 +15,9 @@ export const chainQuery = t.Object({
 });
 
 export const unlinkQuery = t.Object({
-  direction: t.Optional(t.String()),
+  direction: t.Optional(t.Union([t.Literal('prev'), t.Literal('next')])),
 });
 
-export const linkBody = t.Unknown();
+export const linkBody = t.Object({
+  nextId: t.String({ minLength: 1 }),
+});

--- a/src/server/api-token-auth.ts
+++ b/src/server/api-token-auth.ts
@@ -25,8 +25,7 @@ export function isApiAuthorized(request: Request) {
   if (!configured) return true;
   const auth = request.headers.get('authorization') ?? '';
   const bearer = auth.match(/^Bearer\s+(.+)$/i)?.[1]?.trim();
-  const urlToken = new URL(request.url).searchParams.get('token')?.trim();
-  return Boolean((bearer && safeEqual(bearer, configured)) || (urlToken && safeEqual(urlToken, configured)));
+  return Boolean(bearer && safeEqual(bearer, configured));
 }
 
 export function unauthorizedApiResponse() {

--- a/tests/http/forum-traces.test.ts
+++ b/tests/http/forum-traces.test.ts
@@ -65,13 +65,13 @@ describe("Forum routes", () => {
     createdThreadId = data.thread_id;
   }, 30_000);
 
-  test("POST /api/thread without message returns 400", async () => {
+  test("POST /api/thread without message is rejected", async () => {
     const res = await fetch(`${BASE_URL}/api/thread`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({}),
     });
-    expect(res.status).toBe(400);
+    expect([400, 422]).toContain(res.status);
   });
 
   test("GET /api/thread/:id returns thread with messages", async () => {
@@ -92,6 +92,16 @@ describe("Forum routes", () => {
   test("GET /api/thread/:id with missing id returns 404", async () => {
     const res = await fetch(`${BASE_URL}/api/thread/99999999`);
     expect(res.status).toBe(404);
+  });
+
+  test("PATCH /api/thread/:id/status rejects non-string status", async () => {
+    expect(createdThreadId).not.toBeNull();
+    const res = await fetch(`${BASE_URL}/api/thread/${createdThreadId}/status`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ status: 123 }),
+    });
+    expect(res.status).toBe(422);
   });
 
   test("PATCH /api/thread/:id/status updates status", async () => {
@@ -144,11 +154,30 @@ describe("Schedule routes", () => {
     createdEventId = data.id;
   });
 
+  test("POST /api/schedule rejects missing event", async () => {
+    const res = await fetch(`${BASE_URL}/api/schedule`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ date: "2099-01-01" }),
+    });
+    expect(res.status).toBe(422);
+  });
+
   test("GET /api/schedule lists events", async () => {
     const res = await fetch(`${BASE_URL}/api/schedule?status=all&limit=50`);
     expect(res.ok).toBe(true);
     const data = await res.json();
     expect(typeof data).toBe("object");
+  });
+
+  test("PATCH /api/schedule/:id rejects invalid status", async () => {
+    expect(createdEventId).not.toBeNull();
+    const res = await fetch(`${BASE_URL}/api/schedule/${createdEventId}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ status: "sideways" }),
+    });
+    expect(res.status).toBe(422);
   });
 
   test("PATCH /api/schedule/:id updates status", async () => {

--- a/tests/http/indexer/basic.test.ts
+++ b/tests/http/indexer/basic.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { indexerRoutes } from '../../../src/routes/indexer/index.ts';
+
+function request(path: string, init: RequestInit = {}) {
+  return indexerRoutes.handle(new Request(`http://local${path}`, init));
+}
+
+function post(path: string, body: unknown) {
+  return request(path, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('indexer HTTP routes', () => {
+  test('GET /api/indexer/config returns adapters and model metadata', async () => {
+    const res = await request('/api/indexer/config');
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(body.adapters)).toBe(true);
+    expect(body.adapters).toContain('lancedb');
+    expect(Array.isArray(body.models)).toBe(true);
+    expect(body.models.length).toBeGreaterThan(0);
+  });
+
+  test('POST /api/indexer/scan reports markdown files by type', async () => {
+    const root = join(tmpdir(), `indexer-scan-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+    const learnDir = join(root, 'memory', 'learnings');
+    mkdirSync(learnDir, { recursive: true });
+    writeFileSync(join(learnDir, 'lesson.md'), '# Lesson\n\nBody');
+    writeFileSync(join(learnDir, 'skip.txt'), 'not markdown');
+
+    try {
+      const res = await post('/api/indexer/scan', { sourcePath: root, types: ['learning'] });
+      const body = await res.json() as Record<string, any>;
+
+      expect(res.status).toBe(200);
+      expect(body.total).toBe(1);
+      expect(body.byType.learning).toBe(1);
+      expect(body.files[0].relativePath).toContain('lesson.md');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('POST /api/indexer/scan returns empty payload for missing path', async () => {
+    const missing = join(tmpdir(), `missing-indexer-${Date.now()}`);
+    const res = await post('/api/indexer/scan', { sourcePath: missing });
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(body.error).toContain('Path not found');
+    expect(body.total).toBe(0);
+    expect(body.files).toEqual([]);
+  });
+
+  test('POST /api/indexer/stop toggles the stop contract', async () => {
+    const res = await post('/api/indexer/stop', {});
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ stopped: true });
+  });
+});

--- a/tests/http/peer/basic.test.ts
+++ b/tests/http/peer/basic.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { peerRoutes } from '../../../src/routes/peer/index.ts';
+
+const savedPeerToken = process.env.ARRA_PEER_TOKEN;
+
+afterEach(() => {
+  if (savedPeerToken === undefined) delete process.env.ARRA_PEER_TOKEN;
+  else process.env.ARRA_PEER_TOKEN = savedPeerToken;
+});
+
+function request(path: string, init: RequestInit = {}) {
+  return peerRoutes.handle(new Request(`http://local${path}`, init));
+}
+
+describe('peer HTTP routes', () => {
+  test('GET /info exposes federation capabilities', async () => {
+    const res = await request('/info');
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(body.oracle).toBe('arra');
+    expect(body.maw.capabilities).toContain('arra-search');
+  });
+
+  test('GET /api/identity returns a stable identity document shape', async () => {
+    const res = await request('/api/identity');
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(typeof body.pubkey).toBe('string');
+    expect(body.oracle).toBe('arra');
+    expect(typeof body.clockUtc).toBe('string');
+  });
+
+  test('peer-protected endpoints reject missing bearer token when configured', async () => {
+    process.env.ARRA_PEER_TOKEN = 'secret';
+
+    const feed = await request('/api/peer/feed');
+    expect(feed.status).toBe(401);
+    expect(await feed.json()).toMatchObject({ error: 'peer_auth_required' });
+
+    const search = await request('/api/peer/search', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ q: 'oracle' }),
+    });
+    expect(search.status).toBe(401);
+  });
+});

--- a/tests/http/security/auth-and-cors.test.ts
+++ b/tests/http/security/auth-and-cors.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createCorsMiddleware, createPrivateNetworkPreflightMiddleware } from '../../../src/middleware/cors.ts';
+import { isApiAuthorized } from '../../../src/server/api-token-auth.ts';
+
+const previousApiToken = process.env.ARRA_API_TOKEN;
+const previousCorsOrigins = process.env.ARRA_CORS_ORIGINS;
+
+function restoreEnv() {
+  if (previousApiToken === undefined) delete process.env.ARRA_API_TOKEN;
+  else process.env.ARRA_API_TOKEN = previousApiToken;
+  if (previousCorsOrigins === undefined) delete process.env.ARRA_CORS_ORIGINS;
+  else process.env.ARRA_CORS_ORIGINS = previousCorsOrigins;
+}
+
+function corsApp() {
+  return new Elysia()
+    .use(createPrivateNetworkPreflightMiddleware())
+    .use(createCorsMiddleware())
+    .get('/api/ping', () => ({ ok: true }));
+}
+
+describe('HTTP auth and CORS security contracts', () => {
+  test('ARRA_API_TOKEN requires bearer auth and rejects URL query tokens', () => {
+    process.env.ARRA_API_TOKEN = 'secret';
+    try {
+      const queryToken = new Request('http://local/api/search?token=secret');
+      const bearer = new Request('http://local/api/search', {
+        headers: { authorization: 'Bearer secret' },
+      });
+      expect(isApiAuthorized(queryToken)).toBe(false);
+      expect(isApiAuthorized(bearer)).toBe(true);
+    } finally {
+      restoreEnv();
+    }
+  });
+
+  test('private-network preflight does not grant disallowed origins', async () => {
+    process.env.ARRA_CORS_ORIGINS = 'https://studio.example';
+    try {
+      const res = await corsApp().handle(new Request('http://local/api/ping', {
+        method: 'OPTIONS',
+        headers: {
+          origin: 'https://evil.example',
+          'access-control-request-method': 'GET',
+          'access-control-request-private-network': 'true',
+        },
+      }));
+      expect(res.status).toBe(204);
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull();
+      expect(res.headers.get('Access-Control-Allow-Private-Network')).toBeNull();
+    } finally {
+      restoreEnv();
+    }
+  });
+});

--- a/tests/http/sessions/summary.test.ts
+++ b/tests/http/sessions/summary.test.ts
@@ -1,0 +1,66 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const savedRepoRoot = process.env.ORACLE_REPO_ROOT;
+const root = join(tmpdir(), `session-summary-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+const dbPath = join(root, 'oracle.db');
+
+mkdirSync(root, { recursive: true });
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = dbPath;
+process.env.ORACLE_REPO_ROOT = root;
+
+const dbMod = await import('../../../src/db/index.ts');
+dbMod.resetDefaultDatabaseForTests(dbPath);
+const { sessionsRoutes } = await import('../../../src/routes/sessions/index.ts');
+
+function restore(name: string, value: string | undefined) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+function post(id: string, body: unknown) {
+  return sessionsRoutes.handle(new Request(`http://local/api/session/${id}/summary`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+}
+
+afterAll(() => {
+  restore('ORACLE_DATA_DIR', savedDataDir);
+  restore('ORACLE_DB_PATH', savedDbPath);
+  restore('ORACLE_REPO_ROOT', savedRepoRoot);
+  dbMod.resetDefaultDatabaseForTests();
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('session summary HTTP route', () => {
+  test('rejects an empty summary before writing a document', async () => {
+    const res = await post('empty-session', { summary: '   ' });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'Missing required field: summary' });
+  });
+
+  test('persists a valid session summary as a learning document', async () => {
+    const sessionId = `session-${Date.now()}`;
+    const res = await post(sessionId, { summary: 'Session captured useful route test coverage.', oracle: 'codex' });
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(201);
+    expect(body.ok).toBe(true);
+    expect(body.source_file).toBe(`ψ/memory/session-summaries/${sessionId}.md`);
+    expect(body.learning_id).toBe(`session-summary_${sessionId}`);
+
+    const row = dbMod.db.select({ createdBy: dbMod.oracleDocuments.createdBy })
+      .from(dbMod.oracleDocuments)
+      .where(eq(dbMod.oracleDocuments.id, body.learning_id))
+      .get();
+    expect(row?.createdBy).toBe('session_summary');
+  });
+});

--- a/tests/http/traces/routes.test.ts
+++ b/tests/http/traces/routes.test.ts
@@ -173,13 +173,13 @@ describe("Trace routes", () => {
     expect(learning.concepts).toContain("continuity");
   });
 
-  test("POST /api/traces/:prevId/link without body returns 400", async () => {
+  test("POST /api/traces/:prevId/link without body is rejected", async () => {
     const res = await fetch(`${BASE_URL}/api/traces/${traceA}/link`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({}),
     });
-    expect(res.status).toBe(400);
+    expect([400, 422]).toContain(res.status);
   });
 
   test("POST /api/traces/:prevId/link links prev→next", async () => {

--- a/tests/http/traces/validation.test.ts
+++ b/tests/http/traces/validation.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test';
+import { traceLinkRoute } from '../../../src/routes/traces/link.ts';
+import { traceUnlinkRoute } from '../../../src/routes/traces/unlink.ts';
+
+function postLink(body: unknown) {
+  return traceLinkRoute.handle(new Request('http://local/api/traces/a/link', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+}
+
+function deleteLink(query = '') {
+  return traceUnlinkRoute.handle(new Request(`http://local/api/traces/a/link${query}`, {
+    method: 'DELETE',
+  }));
+}
+
+describe('trace link route input validation', () => {
+  test('rejects missing or non-string nextId before link handling', async () => {
+    expect((await postLink({})).status).toBe(422);
+    expect((await postLink({ nextId: 42 })).status).toBe(422);
+  });
+
+  test('rejects unlink directions outside the prev|next allowlist', async () => {
+    expect((await deleteLink()).status).toBe(400);
+    expect((await deleteLink('?direction=sideways')).status).toBe(422);
+  });
+});

--- a/tests/http/vault/sync.test.ts
+++ b/tests/http/vault/sync.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createVaultSyncRoute } from '../../../src/routes/vault/sync.ts';
+import type { MigrateResult } from '../../../src/vault/migrate.ts';
+
+const emptyMigrate: MigrateResult = {
+  reposFound: 0,
+  filesCopied: 0,
+  repos: [],
+  skipped: [],
+  symlinked: [],
+};
+
+function appWith(migrate: (opts: { dryRun: boolean }) => MigrateResult, spawnIndexer = mock(() => {})) {
+  return new Elysia({ prefix: '/api/vault' })
+    .use(createVaultSyncRoute({ migrate, spawnIndexer }));
+}
+
+function post(app: Elysia, body: unknown) {
+  return app.handle(new Request('http://local/api/vault/sync', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+}
+
+describe('vault sync HTTP route', () => {
+  test('dry-run sync returns migrate result without spawning reindex', async () => {
+    const migrate = mock(() => ({ ...emptyMigrate, reposFound: 2, filesCopied: 5 }));
+    const spawnIndexer = mock(() => {});
+    const res = await post(appWith(migrate, spawnIndexer), { dryRun: true, reindex: true });
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.dryRun).toBe(true);
+    expect(body.reindex).toBe(false);
+    expect(body.migrate.filesCopied).toBe(5);
+    expect(spawnIndexer).not.toHaveBeenCalled();
+  });
+
+  test('reindex spawns only when copied files exist', async () => {
+    const migrate = mock(() => ({ ...emptyMigrate, filesCopied: 1 }));
+    const spawnIndexer = mock(() => {});
+    const res = await post(appWith(migrate, spawnIndexer), { reindex: true });
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(body.reindex).toBe(true);
+    expect(spawnIndexer).toHaveBeenCalledTimes(1);
+  });
+
+  test('migrate failures surface as 500 JSON', async () => {
+    const migrate = mock(() => { throw new Error('vault not initialized'); });
+    const res = await post(appWith(migrate), {});
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(500);
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('vault not initialized');
+  });
+});


### PR DESCRIPTION
## Changes
- Replaced remaining loose route body schemas for forum, schedule, and trace link routes with explicit TypeBox validation
- Removed URL query-token authorization from protected ARRA_API_TOKEN routes; bearer token remains required
- Added CORS/private-network and API-token security contract tests
- Added missing validation tests for trace link/unlink, forum status, and schedule payloads

## Test
- bunx tsc --noEmit: green
- bun test tests/http/forum-traces.test.ts tests/http/security/auth-and-cors.test.ts tests/http/traces/validation.test.ts src/integration/api-token-auth.test.ts tests/http/cors/origins.test.ts tests/http/traces/routes.test.ts tests/http/tenant/: green

Note: full bun test tests/http/ still exposed the known parallel tenant SQLite IOERR_VNODE flake; scoped tests/http/tenant/ is green.