### PR TITLE
test(learn): lock malformed JSON contract (#1718)

### DIFF
--- a/tests/http/knowledge.test.ts
+++ b/tests/http/knowledge.test.ts
@@ -77,7 +77,10 @@ describe("HTTP Contract — search / knowledge / supersede", () => {
 
     test("rejects malformed JSON body", async () => {
       const res = await fetch(`${BASE_URL}/api/learn`, { method: "POST", headers: JSON_HEADERS, body: "{not json" });
+      const body = await res.json();
       expect(res.status).toBe(400);
+      expect(res.headers.get("content-type")).toContain("application/json");
+      expect(body).toMatchObject({ error: "Bad Request", code: 400 });
     });
   });
 

--- a/tests/http/learn/crud.test.ts
+++ b/tests/http/learn/crud.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
 import { Elysia } from 'elysia';
 import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createErrorMiddleware } from '../../../src/middleware/errors.ts';
 import { eq } from 'drizzle-orm';
 import { mkdirSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
@@ -21,7 +22,9 @@ dbMod.resetDefaultDatabaseForTests(dbPath);
 const { createLearnCrudRoutes } = await import('../../../src/routes/learn/index.ts');
 
 function app() {
-  return new Elysia({ prefix: '/api' }).use(createLearnCrudRoutes());
+  return new Elysia({ prefix: '/api' })
+    .use(createErrorMiddleware(() => undefined))
+    .use(createLearnCrudRoutes());
 }
 
 function versionedHandle(request: Request) {
@@ -63,7 +66,8 @@ describe('POST/GET/PUT/DELETE /api/learn', () => {
       body: '{not json',
     }));
     expect(res.status).toBe(400);
-    expect(await res.text()).toMatch(/bad request/i);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    expect(await res.json()).toMatchObject({ error: 'Bad Request', code: 400 });
   });
 
   test('rejects malformed JSON on versioned route with 400 contract', async () => {
@@ -73,7 +77,8 @@ describe('POST/GET/PUT/DELETE /api/learn', () => {
       body: '{not json',
     }));
     expect(res.status).toBe(400);
-    expect(await res.text()).toMatch(/bad request/i);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    expect(await res.json()).toMatchObject({ error: 'Bad Request', code: 400 });
   });
 
   test('creates, reads, updates, and soft-deletes a learning through Drizzle rows', async () => {


### PR DESCRIPTION
## Summary
- Locks `/api/learn` malformed JSON behavior to the intended 400 Bad Request contract.
- Asserts JSON content type and the standard structured error envelope instead of checking status alone.
- Aligns direct learn route tests with the same structured error middleware used by the full API server.

## Validation
- `bunx tsc --noEmit`
- `bun test tests/http/learn/`
- `bun test tests/http/learn/ tests/http/knowledge.test.ts`
- File sizes: `tests/http/learn/crud.test.ts` 133 lines, `tests/http/knowledge.test.ts` 248 lines
