### PR TITLE
test: cover tenant isolation across HTTP data surfaces

### DIFF
--- a/src/forum/handler.ts
+++ b/src/forum/handler.ts
@@ -1,16 +1,6 @@
-/**
- * Oracle Forum Handler
- *
- * DB-first threaded discussions with Oracle.
- * - Create threads, add messages
- * - Oracle auto-responds from knowledge base
- * - Logs unanswered questions for later
- *
- * Refactored to use Drizzle ORM for type-safe queries.
- */
-
 import { eq, desc, and, sql } from 'drizzle-orm';
 import { db, forumThreads, forumMessages } from '../db/index.ts';
+import { currentTenantId, tenantIdForWrite } from '../middleware/tenant.ts';
 import { getProjectContext } from '../server/context.ts';
 import type {
   ForumThread,
@@ -21,59 +11,17 @@ import type {
   OracleThreadOutput,
 } from './types.ts';
 
-/**
- * Get project context from environment (ghq path detection)
- */
 function getProjectContext_(): string | undefined {
   const projectCtx = getProjectContext(process.cwd());
   return projectCtx && 'repo' in projectCtx ? projectCtx.repo : undefined;
 }
 
-// ============================================================================
-// Thread Operations
-// ============================================================================
-
-/**
- * Create a new thread
- */
-export function createThread(
-  title: string,
-  createdBy: string = 'user',
-  project?: string
-): ForumThread {
-  const now = Date.now();
-
-  const result = db.insert(forumThreads).values({
-    title,
-    createdBy,
-    status: 'active',
-    project: project || null,
-    createdAt: now,
-    updatedAt: now,
-  }).returning({ id: forumThreads.id }).get();
-
-  return {
-    id: result.id,
-    title,
-    createdBy,
-    status: 'active',
-    project,
-    createdAt: now,
-    updatedAt: now,
-  };
+function threadWhere(threadId: number) {
+  const tenantId = currentTenantId();
+  return tenantId ? and(eq(forumThreads.id, threadId), eq(forumThreads.tenantId, tenantId)) : eq(forumThreads.id, threadId);
 }
 
-/**
- * Get thread by ID
- */
-export function getThread(threadId: number): ForumThread | null {
-  const row = db.select()
-    .from(forumThreads)
-    .where(eq(forumThreads.id, threadId))
-    .get();
-
-  if (!row) return null;
-
+function toForumThread(row: typeof forumThreads.$inferSelect): ForumThread {
   return {
     id: row.id,
     title: row.title,
@@ -88,19 +36,44 @@ export function getThread(threadId: number): ForumThread | null {
   };
 }
 
-/**
- * Update thread status
- */
-export function updateThreadStatus(threadId: number, status: ThreadStatus): void {
-  db.update(forumThreads)
-    .set({ status, updatedAt: Date.now() })
-    .where(eq(forumThreads.id, threadId))
-    .run();
+function toForumMessage(row: typeof forumMessages.$inferSelect): ForumMessage {
+  return {
+    id: row.id,
+    threadId: row.threadId,
+    role: row.role as MessageRole,
+    content: row.content,
+    author: row.author || undefined,
+    principlesFound: row.principlesFound || undefined,
+    patternsFound: row.patternsFound || undefined,
+    searchQuery: row.searchQuery || undefined,
+    commentId: row.commentId || undefined,
+    createdAt: row.createdAt,
+  };
 }
 
-/**
- * List threads with optional filters
- */
+export function createThread(title: string, createdBy = 'user', project?: string): ForumThread {
+  const now = Date.now();
+  const result = db.insert(forumThreads).values({
+    title,
+    tenantId: tenantIdForWrite(),
+    createdBy,
+    status: 'active',
+    project: project || null,
+    createdAt: now,
+    updatedAt: now,
+  }).returning({ id: forumThreads.id }).get();
+  return { id: result.id, title, createdBy, status: 'active', project, createdAt: now, updatedAt: now };
+}
+
+export function getThread(threadId: number): ForumThread | null {
+  const row = db.select().from(forumThreads).where(threadWhere(threadId)).get();
+  return row ? toForumThread(row) : null;
+}
+
+export function updateThreadStatus(threadId: number, status: ThreadStatus): void {
+  db.update(forumThreads).set({ status, updatedAt: Date.now() }).where(threadWhere(threadId)).run();
+}
+
 export function listThreads(options: {
   status?: ThreadStatus;
   project?: string;
@@ -108,26 +81,13 @@ export function listThreads(options: {
   offset?: number;
 } = {}): { threads: ForumThread[]; total: number } {
   const { status, project, limit = 20, offset = 0 } = options;
-
-  // Build conditions array
   const conditions = [];
-  if (status) {
-    conditions.push(eq(forumThreads.status, status));
-  }
-  if (project) {
-    conditions.push(eq(forumThreads.project, project));
-  }
-
+  if (status) conditions.push(eq(forumThreads.status, status));
+  if (project) conditions.push(eq(forumThreads.project, project));
+  const tenantId = currentTenantId();
+  if (tenantId) conditions.push(eq(forumThreads.tenantId, tenantId));
   const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
-
-  // Get count
-  const countResult = db.select({ count: sql<number>`count(*)` })
-    .from(forumThreads)
-    .where(whereClause)
-    .get();
-  const total = countResult?.count || 0;
-
-  // Get threads
+  const countResult = db.select({ count: sql<number>`count(*)` }).from(forumThreads).where(whereClause).get();
   const rows = db.select()
     .from(forumThreads)
     .where(whereClause)
@@ -135,44 +95,16 @@ export function listThreads(options: {
     .limit(limit)
     .offset(offset)
     .all();
-
-  return {
-    threads: rows.map(row => ({
-      id: row.id,
-      title: row.title,
-      createdBy: row.createdBy || 'unknown',
-      status: (row.status || 'active') as ThreadStatus,
-      issueUrl: row.issueUrl || undefined,
-      issueNumber: row.issueNumber || undefined,
-      project: row.project || undefined,
-      createdAt: row.createdAt,
-      updatedAt: row.updatedAt,
-      syncedAt: row.syncedAt || undefined,
-    })),
-    total,
-  };
+  return { threads: rows.map(toForumThread), total: countResult?.count || 0 };
 }
 
-// ============================================================================
-// Message Operations
-// ============================================================================
-
-/**
- * Add a message to a thread
- */
 export function addMessage(
   threadId: number,
   role: MessageRole,
   content: string,
-  options: {
-    author?: string;
-    principlesFound?: number;
-    patternsFound?: number;
-    searchQuery?: string;
-  } = {}
+  options: { author?: string; principlesFound?: number; patternsFound?: number; searchQuery?: string } = {},
 ): ForumMessage {
   const now = Date.now();
-
   const result = db.insert(forumMessages).values({
     threadId,
     role,
@@ -183,13 +115,7 @@ export function addMessage(
     searchQuery: options.searchQuery || null,
     createdAt: now,
   }).returning({ id: forumMessages.id }).get();
-
-  // Update thread timestamp
-  db.update(forumThreads)
-    .set({ updatedAt: now })
-    .where(eq(forumThreads.id, threadId))
-    .run();
-
+  db.update(forumThreads).set({ updatedAt: now }).where(threadWhere(threadId)).run();
   return {
     id: result.id,
     threadId,
@@ -203,107 +129,38 @@ export function addMessage(
   };
 }
 
-/**
- * Get messages for a thread
- */
 export function getMessages(threadId: number): ForumMessage[] {
-  const rows = db.select()
+  return db.select()
     .from(forumMessages)
     .where(eq(forumMessages.threadId, threadId))
     .orderBy(forumMessages.createdAt)
-    .all();
-
-  return rows.map(row => ({
-    id: row.id,
-    threadId: row.threadId,
-    role: row.role as MessageRole,
-    content: row.content,
-    author: row.author || undefined,
-    principlesFound: row.principlesFound || undefined,
-    patternsFound: row.patternsFound || undefined,
-    searchQuery: row.searchQuery || undefined,
-    commentId: row.commentId || undefined,
-    createdAt: row.createdAt,
-  }));
+    .all()
+    .map(toForumMessage);
 }
 
-// ============================================================================
-// Main Thread API (MCP Tool Interface)
-// ============================================================================
-
-/**
- * Main entry point: Send message to thread, Oracle auto-responds
- */
-export async function handleThreadMessage(
-  input: OracleThreadInput
-): Promise<OracleThreadOutput> {
+export async function handleThreadMessage(input: OracleThreadInput): Promise<OracleThreadOutput> {
   const { message, threadId, title, role = 'human', model } = input;
-
-  // Get project context
   const project = getProjectContext_();
-
-  // Determine author based on role and model
-  // - role='human' (HTTP) -> author='user'
-  // - role='claude' (MCP) -> author='opus'/'sonnet'/'claude' + project
-  let author: string;
-  if (role === 'human') {
-    author = 'user';
-  } else {
-    // Use model name if provided (opus, sonnet), else 'claude'
-    author = model || 'claude';
-  }
-
-  // Add project context if available
-  if (project) {
-    author = `${author}@${project}`;
-  }
-
+  const baseAuthor = role === 'human' ? 'user' : model || 'claude';
+  const author = project ? `${baseAuthor}@${project}` : baseAuthor;
   let thread: ForumThread;
 
-  // Create or get thread
   if (threadId) {
     const existing = getThread(threadId);
-    if (!existing) {
-      throw new Error(`Thread ${threadId} not found`);
-    }
+    if (!existing) throw new Error(`Thread ${threadId} not found`);
     thread = existing;
   } else {
-    // New thread - use title or first 50 chars of message
     const threadTitle = title || message.slice(0, 50) + (message.length > 50 ? '...' : '');
     thread = createThread(threadTitle, author, project);
   }
 
-  // Add the user's message
-  const userMessage = addMessage(thread.id, role, message, {
-    author,
-  });
-
-  // Mark as pending (no auto-response engine currently)
-  if (role === 'human' || role === 'claude') {
-    updateThreadStatus(thread.id, 'pending');
-  }
-
-  // Get updated thread status
+  const userMessage = addMessage(thread.id, role, message, { author });
+  if (role === 'human' || role === 'claude') updateThreadStatus(thread.id, 'pending');
   const updatedThread = getThread(thread.id)!;
-
-  return {
-    threadId: thread.id,
-    messageId: userMessage.id,
-    status: updatedThread.status as ThreadStatus,
-    issueUrl: updatedThread.issueUrl,
-  };
+  return { threadId: thread.id, messageId: userMessage.id, status: updatedThread.status as ThreadStatus, issueUrl: updatedThread.issueUrl };
 }
 
-/**
- * Get full thread with all messages
- */
-export function getFullThread(threadId: number): {
-  thread: ForumThread;
-  messages: ForumMessage[];
-} | null {
+export function getFullThread(threadId: number): { thread: ForumThread; messages: ForumMessage[] } | null {
   const thread = getThread(threadId);
-  if (!thread) return null;
-
-  const messages = getMessages(threadId);
-  return { thread, messages };
+  return thread ? { thread, messages: getMessages(threadId) } : null;
 }

--- a/src/routes/vector/documents.ts
+++ b/src/routes/vector/documents.ts
@@ -3,6 +3,7 @@
  */
 
 import { Elysia, t } from 'elysia';
+import { currentTenantId } from '../../middleware/tenant.ts';
 import { getVectorStoreByModel } from '../../vector/factory.ts';
 import type { VectorQueryResult, VectorStoreAdapter } from '../../vector/types.ts';
 
@@ -49,8 +50,8 @@ function pageItems(
   ids: string[],
   documents: unknown[],
   metadatas: unknown[],
-  offset: number,
-  limit: number,
+  offset = 0,
+  limit = ids.length,
 ): DocumentItem[] {
   return ids.slice(offset, offset + limit).map((id, index) => {
     const sourceIndex = offset + index;
@@ -62,15 +63,28 @@ function pageItems(
   });
 }
 
+function tenantFor(metadata: Record<string, unknown>): string | undefined {
+  const value = metadata.tenant_id ?? metadata.tenantId ?? metadata.tenant;
+  return typeof value === 'string' ? value : undefined;
+}
+
+function filterTenantItems(items: DocumentItem[]): DocumentItem[] {
+  const tenantId = currentTenantId();
+  if (!tenantId) return items;
+  return items.filter((item) => tenantFor(item.metadata) === tenantId);
+}
+
 async function listWithQuery(
   store: VectorStoreAdapter,
   offset: number,
   limit: number,
 ): Promise<{ items: DocumentItem[]; totalFallback: number }> {
-  const result: VectorQueryResult = await store.query('', offset + limit);
+  const tenantId = currentTenantId();
+  const result: VectorQueryResult = await store.query('', tenantId ? MAX_LIMIT : offset + limit);
+  const scoped = filterTenantItems(pageItems(result.ids, result.documents, result.metadatas));
   return {
-    items: pageItems(result.ids, result.documents, result.metadatas, offset, limit),
-    totalFallback: result.ids.length,
+    items: scoped.slice(offset, offset + limit),
+    totalFallback: scoped.length,
   };
 }
 
@@ -95,19 +109,20 @@ export function createVectorDocumentsEndpoint(deps: VectorDocumentsDeps = {}) {
         let listed: { items: DocumentItem[]; totalFallback: number };
 
         if (store.getAllEmbeddings) {
-          const all = await store.getAllEmbeddings(offset + limit);
+          const all = await store.getAllEmbeddings(currentTenantId() ? MAX_LIMIT : offset + limit);
           const docs = (all as { documents?: unknown[] }).documents;
           listed = Array.isArray(docs)
-            ? {
-                items: pageItems(all.ids, docs, all.metadatas, offset, limit),
-                totalFallback: all.ids.length,
-              }
+            ? (() => {
+                const scoped = filterTenantItems(pageItems(all.ids, docs, all.metadatas));
+                return { items: scoped.slice(offset, offset + limit), totalFallback: scoped.length };
+              })()
             : await listWithQuery(store, offset, limit);
         } else {
           listed = await listWithQuery(store, offset, limit);
         }
 
-        return { items: listed.items, total: stats.count || listed.totalFallback, page, limit, offset };
+        const total = currentTenantId() ? listed.totalFallback : stats.count || listed.totalFallback;
+        return { items: listed.items, total, page, limit, offset };
       } catch (error) {
         set.status = 500;
         const message = error instanceof Error ? error.message : String(error);

--- a/tests/http/tenant/http-isolation.test.ts
+++ b/tests/http/tenant/http-isolation.test.ts
@@ -1,0 +1,121 @@
+import { afterAll, expect, mock, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { inArray } from 'drizzle-orm';
+import { db, forumMessages, forumThreads, oracleDocuments, sqlite } from '../../../src/db/index.ts';
+import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
+import { forumApi } from '../../../src/routes/forum/index.ts';
+import { searchRoutes } from '../../../src/routes/search/index.ts';
+import { createVectorDocumentsEndpoint } from '../../../src/routes/vector/documents.ts';
+import type { VectorStoreAdapter } from '../../../src/vector/types.ts';
+
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantA = `tenant-a-${stamp}`;
+const tenantB = `tenant-b-${stamp}`;
+const docIds = [`tenant-http-a-${stamp}`, `tenant-http-b-${stamp}`];
+const threadIds: number[] = [];
+
+function tenantRequest(app: Elysia, tenantId: string, path: string, init: RequestInit = {}) {
+  return createTenantFetch((request) => app.handle(request))(new Request(`http://local${path}`, {
+    ...init,
+    headers: { 'content-type': 'application/json', [TENANT_HEADER]: tenantId, ...(init.headers ?? {}) },
+  }));
+}
+
+function insertSearchDoc(id: string, tenantId: string, content: string) {
+  const now = Date.now();
+  db.insert(oracleDocuments).values({
+    id,
+    tenantId,
+    type: 'learning',
+    sourceFile: `ψ/memory/${id}.md`,
+    concepts: '[]',
+    createdAt: now,
+    updatedAt: now,
+    indexedAt: now,
+    project: tenantId,
+    createdBy: 'tenant-test',
+  }).run();
+  sqlite.prepare('DELETE FROM oracle_fts WHERE id = ?').run(id);
+  sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)').run(id, content, 'tenant');
+}
+
+function createVectorStore(): VectorStoreAdapter {
+  const docs = [
+    { id: docIds[0], document: `alpha vector ${stamp}`, metadata: { tenant_id: tenantA, type: 'learning' } },
+    { id: docIds[1], document: `beta vector ${stamp}`, metadata: { tenant_id: tenantB, type: 'learning' } },
+  ];
+  return {
+    name: 'tenant-vector',
+    connect: mock(async () => {}),
+    close: mock(async () => {}),
+    ensureCollection: mock(async () => {}),
+    deleteCollection: mock(async () => {}),
+    addDocuments: mock(async () => {}),
+    query: mock(async () => ({
+      ids: docs.map((doc) => doc.id),
+      documents: docs.map((doc) => doc.document),
+      distances: docs.map(() => 0),
+      metadatas: docs.map((doc) => doc.metadata),
+    })),
+    queryById: mock(async () => ({ ids: [], documents: [], distances: [], metadatas: [] })),
+    getStats: mock(async () => ({ count: docs.length })),
+    getCollectionInfo: mock(async () => ({ count: docs.length, name: 'tenant-vector' })),
+    getAllEmbeddings: mock(async () => ({
+      ids: docs.map((doc) => doc.id),
+      documents: docs.map((doc) => doc.document),
+      embeddings: docs.map(() => [0, 0, 0]),
+      metadatas: docs.map((doc) => doc.metadata),
+    })),
+  };
+}
+
+insertSearchDoc(docIds[0], tenantA, `alpha-only-${stamp} shared-tenant-term`);
+insertSearchDoc(docIds[1], tenantB, `beta-only-${stamp} shared-tenant-term`);
+
+afterAll(() => {
+  db.delete(oracleDocuments).where(inArray(oracleDocuments.id, docIds)).run();
+  for (const id of docIds) sqlite.prepare('DELETE FROM oracle_fts WHERE id = ?').run(id);
+  if (threadIds.length) {
+    db.delete(forumMessages).where(inArray(forumMessages.threadId, threadIds)).run();
+    db.delete(forumThreads).where(inArray(forumThreads.id, threadIds)).run();
+  }
+});
+
+test('GET /api/vector/documents hides tenant B vector documents from tenant A', async () => {
+  const app = new Elysia({ prefix: '/api' }).use(createVectorDocumentsEndpoint({ getStore: () => createVectorStore() }));
+  const res = await tenantRequest(app, tenantA, '/api/vector/documents?collection=bge-m3&limit=10');
+  const body = await res.json() as { items: Array<{ id: string }>; total: number };
+
+  expect(res.status).toBe(200);
+  expect(body.total).toBe(1);
+  expect(body.items.map((item) => item.id)).toContain(docIds[0]);
+  expect(body.items.map((item) => item.id)).not.toContain(docIds[1]);
+});
+
+test('GET /api/search hides tenant B FTS rows from tenant A', async () => {
+  const res = await tenantRequest(searchRoutes, tenantA, '/api/search?q=shared-tenant-term&mode=fts');
+  const body = await res.json() as { results: Array<{ id: string }> };
+
+  expect(res.status).toBe(200);
+  expect(body.results.map((item) => item.id)).toContain(docIds[0]);
+  expect(body.results.map((item) => item.id)).not.toContain(docIds[1]);
+});
+
+test('forum thread HTTP endpoints hide tenant A thread from tenant B', async () => {
+  const created = await tenantRequest(forumApi, tenantA, '/api/thread', {
+    method: 'POST',
+    body: JSON.stringify({ title: `tenant thread ${stamp}`, message: `hello ${stamp}` }),
+  });
+  const createdBody = await created.json() as { thread_id: number };
+  threadIds.push(createdBody.thread_id);
+
+  const denied = await tenantRequest(forumApi, tenantB, `/api/thread/${createdBody.thread_id}`);
+  const listed = await tenantRequest(forumApi, tenantB, '/api/threads?limit=20');
+  const allowed = await tenantRequest(forumApi, tenantA, `/api/thread/${createdBody.thread_id}`);
+  const listedBody = await listed.json() as { threads: Array<{ id: number }> };
+
+  expect(created.status).toBe(200);
+  expect(denied.status).toBe(404);
+  expect(allowed.status).toBe(200);
+  expect(listedBody.threads.map((thread) => thread.id)).not.toContain(createdBody.thread_id);
+});


### PR DESCRIPTION
## Summary\n- add tenant HTTP isolation tests for vector documents, FTS search, and forum threads\n- scope vector document browsing by tenant metadata when a tenant header is active\n- stamp and filter forum threads by active tenant context\n\n## Verification\n- bun test tests/http/forum-traces.test.ts tests/http/tenant/\n- bunx tsc --noEmit