### PR TITLE
feat: standardize HTTP JSON response format

### DIFF
--- a/src/middleware/errors.ts
+++ b/src/middleware/errors.ts
@@ -2,12 +2,14 @@ import { Elysia } from 'elysia';
 import { REQUEST_ID_HEADER, RESPONSE_TIME_HEADER, requestIdFor, responseTimeFor } from './correlation.ts';
 
 export type ApiErrorResponse = {
+  success: false;
   error: string;
   code: number;
   details?: unknown;
 };
 
 export type StructuredErrorResponse = {
+  success: false;
   error: string;
   message: string;
   statusCode: number;
@@ -18,8 +20,8 @@ export function apiErrorResponse<const T extends string, const C extends number,
   error: T,
   code: C,
   details: D,
-): { error: T; code: C; details: D } {
-  return { error, code, details };
+): { success: false; error: T; code: C; details: D } {
+  return { success: false, error, code, details };
 }
 
 export class HttpError extends Error {

--- a/src/middleware/response-format.ts
+++ b/src/middleware/response-format.ts
@@ -1,0 +1,47 @@
+import { Elysia } from 'elysia';
+
+type StandardBody = {
+  success: boolean;
+  data?: unknown;
+  error?: string;
+  [key: string]: unknown;
+};
+
+function statusCode(response: unknown, status: unknown): number {
+  if (response instanceof Response) return response.status;
+  return typeof status === 'number' ? status : 200;
+}
+
+function errorText(payload: Record<string, unknown>): string {
+  const error = payload.error;
+  if (typeof error === 'string') return error;
+  if (error != null) return String(error);
+  const message = payload.message;
+  return typeof message === 'string' ? message : 'Request failed';
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object'
+    && value !== null
+    && !Array.isArray(value)
+    && !(value instanceof Response)
+    && !(value instanceof Uint8Array);
+}
+
+export function standardizeJsonResponse(response: unknown, status: unknown): StandardBody | undefined {
+  if (response === undefined || response instanceof Response || typeof response === 'string' || response instanceof Uint8Array) return;
+
+  const code = statusCode(response, status);
+  const success = code < 400;
+  if (Array.isArray(response)) return { success, data: response, ...(success ? {} : { error: 'Request failed' }) };
+  if (!isPlainObject(response)) return { success, data: response };
+
+  if (typeof response.success === 'boolean') return response as StandardBody;
+  if (!success || typeof response.error === 'string') return { success: false, error: errorText(response), ...response };
+  return { success: true, data: response, ...response };
+}
+
+export function createResponseFormatMiddleware() {
+  return new Elysia({ name: 'standard-response-format' })
+    .onAfterHandle({ as: 'global' }, ({ response, set }) => standardizeJsonResponse(response, set.status));
+}

--- a/src/middleware/tenant.ts
+++ b/src/middleware/tenant.ts
@@ -132,7 +132,7 @@ export function createTenantFetch(next: FetchHandler): FetchHandler {
       const tenantId = tenantIdFor(request);
       return runWithTenant(tenantId, () => next(request));
     } catch (error) {
-      return Response.json({ error: error instanceof Error ? error.message : String(error) }, { status: 400 });
+      return Response.json({ success: false, error: error instanceof Error ? error.message : String(error) }, { status: 400 });
     }
   };
 }

--- a/src/middleware/timeout.ts
+++ b/src/middleware/timeout.ts
@@ -12,6 +12,7 @@ export function requestTimeoutMsFromEnv(value = process.env.ARRA_REQUEST_TIMEOUT
 
 function timeoutBody(request: Request, timeoutMs: number): StructuredErrorResponse {
   return {
+    success: false,
     error: 'Request Timeout',
     message: `Request exceeded ${timeoutMs}ms timeout`,
     statusCode: 408,

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,6 +28,7 @@ import { createApiVersionHeaderMiddleware, createApiVersionedFetch } from './mid
 import { createSecurityHeadersMiddleware } from './middleware/security-headers.ts';
 import { createRequestTimeoutFetch } from './middleware/timeout.ts';
 import { createBodyLimitMiddleware } from './middleware/body-limit.ts';
+import { createResponseFormatMiddleware } from './middleware/response-format.ts';
 import { createNotFoundMiddleware } from './middleware/not-found.ts';
 import { createEtagMiddleware } from './middleware/etag.ts';
 import { createCompressMiddleware } from './middleware/compress.ts';
@@ -90,7 +91,6 @@ writePidFile({
   startedAt: new Date().toISOString(),
   name: 'oracle-http',
 });
-
 const scoutAnnouncer = shouldStartScoutAnnouncer() ? new ScoutAnnouncer() : null;
 scoutAnnouncer?.start();
 
@@ -127,6 +127,7 @@ const app = new Elysia()
   .use(createBodyLimitMiddleware())
   .use(createApiKeyAuthMiddleware())
   .use(createMetricsLifecycle())
+  .use(createResponseFormatMiddleware())
   .use(createCompressMiddleware())
   .use(createEtagMiddleware())
   .onBeforeHandle(({ request, set }) => {

--- a/tests/http/errors/error-format.test.ts
+++ b/tests/http/errors/error-format.test.ts
@@ -31,7 +31,8 @@ function expectErrorShape(body: Record<string, unknown>, code: number) {
   expect(body.error).toEqual(expect.any(String));
   expect(body.code).toBe(code);
   if ('details' in body) expect(typeof body.details).toBe('object');
-  expect(Object.keys(body).sort()).toEqual(['code', 'details', 'error']);
+  expect(body.success).toBe(false);
+  expect(Object.keys(body).sort()).toEqual(['code', 'details', 'error', 'success']);
 }
 
 describe('standard API error format', () => {

--- a/tests/http/errors/structured-errors.test.ts
+++ b/tests/http/errors/structured-errors.test.ts
@@ -42,6 +42,7 @@ async function request(path: string, init?: RequestInit) {
 
 function expectStructured(body: Record<string, unknown>, code: number) {
   expect(body).toEqual({
+    success: false,
     error: expect.any(String),
     code,
     details: {
@@ -62,6 +63,7 @@ describe('structured error middleware', () => {
     expect(res.status).toBe(400);
     expect(res.headers.get('x-correlation-id')).toBe('test-correlation');
     expect(body).toEqual({
+      success: false,
       error: 'Bad Request',
       code: 400,
       details: {

--- a/tests/http/not-found/handler.test.ts
+++ b/tests/http/not-found/handler.test.ts
@@ -16,6 +16,7 @@ test('unmatched routes return structured not-found JSON', async () => {
   const missing = await fetchVersioned(new Request('http://local/api/v1/missing?debug=1', { method: 'POST' }));
   expect(missing.status).toBe(404);
   expect(await missing.json()).toEqual({
+    success: false,
     error: 'Not Found',
     code: 404,
     details: {

--- a/tests/http/not-found/method-not-allowed.test.ts
+++ b/tests/http/not-found/method-not-allowed.test.ts
@@ -13,6 +13,7 @@ test('known routes hit with the wrong method return 405 JSON', async () => {
   expect(response.status).toBe(405);
   expect(response.headers.get('Allow')).toBe('GET');
   expect(await response.json()).toEqual({
+    success: false,
     error: 'Method Not Allowed',
     code: 405,
     details: {

--- a/tests/http/response-format/standard.test.ts
+++ b/tests/http/response-format/standard.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import {
+  createResponseFormatMiddleware,
+  standardizeJsonResponse,
+} from '../../../src/middleware/response-format.ts';
+import { createErrorMiddleware } from '../../../src/middleware/errors.ts';
+
+function app() {
+  return new Elysia()
+    .use(createResponseFormatMiddleware())
+    .use(createErrorMiddleware(() => undefined))
+    .get('/object', () => ({ value: 1 }))
+    .get('/array', () => [1, 2])
+    .get('/ready', () => ({ success: true, data: { ok: true } }))
+    .get('/text', () => new Response('plain text'))
+    .get('/boom', ({ set }) => {
+      set.status = 400;
+      return { error: 'bad input', field: 'name' };
+    });
+}
+
+async function json(path: string) {
+  return app().handle(new Request(`http://local${path}`)).then((res) => res.json());
+}
+
+describe('standard JSON response format', () => {
+  test('adds success and data while preserving existing object fields', async () => {
+    expect(await json('/object')).toEqual({ success: true, data: { value: 1 }, value: 1 });
+  });
+
+  test('wraps array payloads in data', async () => {
+    expect(await json('/array')).toEqual({ success: true, data: [1, 2] });
+  });
+
+  test('does not double-wrap already-standard payloads', async () => {
+    expect(await json('/ready')).toEqual({ success: true, data: { ok: true } });
+  });
+
+  test('normalizes error objects with success false', async () => {
+    expect(await json('/boom')).toEqual({ success: false, error: 'bad input', field: 'name' });
+  });
+
+  test('leaves raw Response bodies unchanged', async () => {
+    const res = await app().handle(new Request('http://local/text'));
+    expect(await res.text()).toBe('plain text');
+  });
+
+  test('utility treats status codes as the success boundary', () => {
+    expect(standardizeJsonResponse({ ok: true }, 201)?.success).toBe(true);
+    expect(standardizeJsonResponse({ error: 'nope' }, 404)).toMatchObject({ success: false });
+  });
+});

--- a/tests/http/tenant/auth.test.ts
+++ b/tests/http/tenant/auth.test.ts
@@ -44,7 +44,7 @@ describe('tenant auth middleware', () => {
         headers: { [TENANT_HEADER]: 'acme', [TENANT_TOKEN_HEADER]: 'bad' },
       }));
       expect(res.status).toBe(400);
-      expect(await res.json()).toEqual({ error: 'invalid tenant token' });
+      expect(await res.json()).toEqual({ success: false, error: 'invalid tenant token' });
     } finally {
       if (previous === undefined) delete process.env.ORACLE_TENANT_TOKENS;
       else process.env.ORACLE_TENANT_TOKENS = previous;

--- a/tests/http/timeout/request-timeout.test.ts
+++ b/tests/http/timeout/request-timeout.test.ts
@@ -52,6 +52,7 @@ describe('request timeout fetch middleware', () => {
     expect(res.headers.get('X-Request-Id')).toBe('timeout-test');
     expect(res.headers.get('x-correlation-id')).toBe('timeout-test');
     expect(await body(res)).toEqual({
+      success: false,
       error: 'Request Timeout',
       message: 'Request exceeded 5ms timeout',
       statusCode: 408,
@@ -76,6 +77,7 @@ describe('request timeout fetch middleware', () => {
 
     expect(res.status).toBe(408);
     expect(await body(res)).toMatchObject({
+      success: false,
       error: 'Request Timeout',
       message: 'Request exceeded 5ms timeout',
       statusCode: 408,


### PR DESCRIPTION
## Changes
- Added a standard response-format middleware that adds `{ success, data?, error? }` to JSON object/array responses while preserving existing top-level fields
- Standardized shared API error, timeout, and tenant fetch error bodies with `success: false`
- Added response-format contract coverage and updated error/not-found/timeout/tenant expectations

## Test
- bunx tsc --noEmit: green
- bun test tests/http/response-format/standard.test.ts tests/http/errors/error-format.test.ts tests/http/errors/structured-errors.test.ts tests/http/not-found/handler.test.ts tests/http/not-found/method-not-allowed.test.ts tests/http/body-limit/size-limit.test.ts tests/http/timeout/request-timeout.test.ts tests/http/tenant/auth.test.ts tests/http/core.test.ts tests/http/auth-settings.test.ts tests/http/knowledge.test.ts: green