### PR TITLE
feat: harden graceful shutdown draining

### DIFF
--- a/src/lifecycle/shutdown.ts
+++ b/src/lifecycle/shutdown.ts
@@ -1,11 +1,19 @@
 type SignalName = 'SIGTERM' | 'SIGINT';
 
+type ShutdownStep = { name: string; run: () => void | Promise<void> };
+
 export interface ShutdownOptions {
   timeoutMs?: number;
   minDrainMs?: number;
   close: () => Promise<void>;
   log?: (message: string) => void;
   exit?: (code: number) => never;
+}
+
+export interface DrainingResponseOptions {
+  draining?: boolean;
+  healthPaths?: readonly string[];
+  retryAfterSeconds?: number;
 }
 
 let draining = false;
@@ -36,10 +44,7 @@ export async function trackRequest<T>(handler: () => T | Promise<T>): Promise<T>
   }
 }
 
-export async function waitForActiveRequests(
-  timeoutMs = 10_000,
-  minDrainMs = 250,
-): Promise<boolean> {
+export async function waitForActiveRequests(timeoutMs = 10_000, minDrainMs = 250): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   if (minDrainMs > 0) await sleep(minDrainMs);
   while (activeRequests > 0) {
@@ -47,6 +52,37 @@ export async function waitForActiveRequests(
     await sleep(25);
   }
   return true;
+}
+
+export function drainingResponseFor(
+  request: Request,
+  options: DrainingResponseOptions = {},
+): Response | null {
+  if (!(options.draining ?? draining)) return null;
+  const healthPaths = options.healthPaths ?? ['/api/health', '/api/v1/health'];
+  const pathname = new URL(request.url).pathname;
+  if (healthPaths.includes(pathname)) return null;
+  return Response.json(
+    { error: 'server is draining', status: 'draining', draining: true },
+    { status: 503, headers: { 'Retry-After': String(options.retryAfterSeconds ?? 5) } },
+  );
+}
+
+export async function runShutdownSteps(
+  steps: readonly ShutdownStep[],
+  log: (message: string) => void = console.warn,
+): Promise<void> {
+  const errors: string[] = [];
+  for (const step of steps) {
+    try {
+      await step.run();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      errors.push(`${step.name}: ${message}`);
+      log(`[Shutdown] ${step.name} cleanup failed: ${message}`);
+    }
+  }
+  if (errors.length) throw new Error(`shutdown cleanup failed (${errors.join('; ')})`);
 }
 
 export function registerGracefulShutdown(options: ShutdownOptions): void {

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,7 +17,7 @@ import { createCorrelationMiddleware } from './middleware/correlation.ts';
 import { defaultUnifiedPluginDirs, loadUnifiedPlugins, seedUnifiedPluginMenuItems } from './plugins/unified-loader.ts';
 import { startUnifiedPluginServers } from './plugins/unified-server.ts';
 import { closeCachedVectorStores } from './vector/factory.ts';
-import { isDraining, registerGracefulShutdown, trackRequest } from './lifecycle/shutdown.ts';
+import { drainingResponseFor, isDraining, registerGracefulShutdown, runShutdownSteps, trackRequest } from './lifecycle/shutdown.ts';
 import { createErrorMiddleware } from './middleware/errors.ts';
 import { validateStartupEnv } from './config/validate.ts';
 import { printStartupBanner } from './lifecycle/banner.ts';
@@ -100,16 +100,17 @@ const unifiedPlugins = await loadUnifiedPlugins({
 });
 await unifiedPlugins.init();
 const unifiedServers = await startUnifiedPluginServers(unifiedPlugins.servers);
-
 registerGracefulShutdown({
   close: async () => {
     console.log('\n🔮 Shutting down gracefully...');
-    scoutAnnouncer?.stop();
-    await unifiedPlugins.stop();
-    await unifiedServers.stop();
-    await closeCachedVectorStores();
-    closeDb();
-    removePidFile();
+    await runShutdownSteps([
+      { name: 'scout-announcer', run: () => scoutAnnouncer?.stop() },
+      { name: 'unified-plugins', run: () => unifiedPlugins.stop() },
+      { name: 'unified-plugin-servers', run: () => unifiedServers.stop() },
+      { name: 'vector-stores', run: () => closeCachedVectorStores() },
+      { name: 'database', run: () => closeDb() },
+      { name: 'pid-file', run: () => removePidFile() },
+    ], console.warn);
     console.log('👋 Arra Oracle HTTP Server stopped.');
   },
 });
@@ -245,5 +246,5 @@ const serverFetch = createRequestTimeoutFetch(
 
 export default {
   port: Number(PORT),
-  fetch: (request: Request) => trackRequest(() => serverFetch(request)),
+  fetch: (request: Request) => drainingResponseFor(request) ?? trackRequest(() => serverFetch(request)),
 };

--- a/tests/lifecycle/shutdown-controller.test.ts
+++ b/tests/lifecycle/shutdown-controller.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  activeRequestCount,
+  drainingResponseFor,
+  runShutdownSteps,
+  trackRequest,
+  waitForActiveRequests,
+} from '../../src/lifecycle/shutdown.ts';
+
+describe('shutdown controller', () => {
+  test('waits for tracked in-flight requests before reporting drained', async () => {
+    let release!: () => void;
+    const pending = trackRequest(() => new Promise<void>((resolve) => { release = resolve; }));
+
+    expect(activeRequestCount()).toBe(1);
+    const waiting = waitForActiveRequests(250, 0);
+    await sleep(30);
+    expect(activeRequestCount()).toBe(1);
+    release();
+    await pending;
+    expect(await waiting).toBe(true);
+    expect(activeRequestCount()).toBe(0);
+  });
+
+  test('returns 503 for new non-health requests while draining', async () => {
+    const blocked = drainingResponseFor(new Request('http://local/api/search?q=x'), { draining: true });
+    const health = drainingResponseFor(new Request('http://local/api/health'), { draining: true });
+
+    expect(blocked?.status).toBe(503);
+    expect(blocked?.headers.get('Retry-After')).toBe('5');
+    expect(await blocked?.json()).toMatchObject({ status: 'draining', draining: true });
+    expect(health).toBeNull();
+  });
+
+  test('runs every cleanup step and reports any cleanup failures', async () => {
+    const calls: string[] = [];
+    const warnings: string[] = [];
+
+    await expect(runShutdownSteps([
+      { name: 'first', run: () => calls.push('first') },
+      { name: 'second', run: () => { calls.push('second'); throw new Error('boom'); } },
+      { name: 'third', run: async () => { calls.push('third'); } },
+    ], (message) => warnings.push(message))).rejects.toThrow('second: boom');
+
+    expect(calls).toEqual(['first', 'second', 'third']);
+    expect(warnings.join('\n')).toContain('second cleanup failed: boom');
+  });
+});
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary\n- reject new non-health requests with 503 while shutdown is draining\n- keep health endpoint available to report draining state\n- run cleanup steps for scout, unified plugins/servers, vector stores, DB, and PID file even if one step fails\n- add lifecycle tests for in-flight draining, 503 behavior, and cleanup ordering\n\n## Verification\n- bun test tests/lifecycle/shutdown-controller.test.ts tests/lifecycle/shutdown.test.ts tests/http/health/draining.test.ts\n- bunx tsc --noEmit