### PR TITLE
feat: shared API error response type

### DIFF
--- a/src/middleware/body-limit.ts
+++ b/src/middleware/body-limit.ts
@@ -1,5 +1,6 @@
 import { Elysia } from 'elysia';
 import { REQUEST_ID_HEADER, requestIdFor } from './correlation.ts';
+import { errorResponse, type ErrorResponse } from '../types/error-response.ts';
 
 export const DEFAULT_MAX_BODY_KB = 1024;
 const BYTES_PER_KB = 1024;
@@ -11,10 +12,10 @@ export type BodyLimitOptions = {
   maxKb?: number;
 };
 
-export type PayloadTooLargeResponse = {
+export type PayloadTooLargeResponse = ErrorResponse & {
   error: 'Payload Too Large';
+  code: 413;
   message: string;
-  statusCode: 413;
   correlationId: string;
   limitKb: number;
 };
@@ -75,9 +76,8 @@ function payloadTooLarge(request: Request, set: HeaderSetter, limitKb: number): 
   set.headers[REQUEST_ID_HEADER] = correlationId;
   set.headers['x-correlation-id'] = correlationId;
   return {
-    error: 'Payload Too Large',
+    ...errorResponse('Payload Too Large', 413),
     message: `Request body exceeds ${limitKb}KB limit.`,
-    statusCode: 413,
     correlationId,
     limitKb,
   };

--- a/src/middleware/error-response.ts
+++ b/src/middleware/error-response.ts
@@ -1,0 +1,15 @@
+import { Elysia } from 'elysia';
+import { normalizeErrorResponse } from '../types/error-response.ts';
+
+function numericStatus(status: number | string | undefined): number | undefined {
+  if (typeof status === 'number') return status;
+  if (typeof status !== 'string') return undefined;
+  const parsed = Number(status);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export function createErrorResponseMiddleware() {
+  return new Elysia({ name: 'error-response-normalizer' }).onAfterHandle({ as: 'global' }, ({ response, set }) => {
+    return normalizeErrorResponse(response, numericStatus(set.status));
+  });
+}

--- a/src/middleware/errors.ts
+++ b/src/middleware/errors.ts
@@ -1,11 +1,8 @@
 import { Elysia } from 'elysia';
 import { REQUEST_ID_HEADER, RESPONSE_TIME_HEADER, requestIdFor, responseTimeFor } from './correlation.ts';
+import { errorResponse, type ErrorResponse } from '../types/error-response.ts';
 
-export type ApiErrorResponse = {
-  error: string;
-  code: number;
-  details?: unknown;
-};
+export type ApiErrorResponse = ErrorResponse;
 
 export type StructuredErrorResponse = {
   error: string;
@@ -18,8 +15,8 @@ export function apiErrorResponse<const T extends string, const C extends number,
   error: T,
   code: C,
   details: D,
-): { error: T; code: C; details: D } {
-  return { error, code, details };
+): ErrorResponse & { error: T; code: C; details: D } {
+  return errorResponse(error, code, details) as unknown as ErrorResponse & { error: T; code: C; details: D };
 }
 
 export class HttpError extends Error {

--- a/src/middleware/not-found.ts
+++ b/src/middleware/not-found.ts
@@ -1,8 +1,9 @@
 import { Elysia } from 'elysia';
 import { apiRequestPath } from './api-version.ts';
 import { apiErrorResponse } from './errors.ts';
+import type { ErrorResponse } from '../types/error-response.ts';
 
-export type NotFoundResponse = {
+export type NotFoundResponse = ErrorResponse & {
   error: 'Not Found';
   code: 404;
   details: {
@@ -11,7 +12,7 @@ export type NotFoundResponse = {
   };
 };
 
-export type MethodNotAllowedResponse = {
+export type MethodNotAllowedResponse = ErrorResponse & {
   error: 'Method Not Allowed';
   code: 405;
   details: {

--- a/src/middleware/tenant.ts
+++ b/src/middleware/tenant.ts
@@ -2,6 +2,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import path from 'node:path';
 import { timingSafeEqual } from 'node:crypto';
 import { Elysia } from 'elysia';
+import { errorResponse } from '../types/error-response.ts';
 import { eq, type SQL } from 'drizzle-orm';
 
 export const TENANT_HEADER = 'X-Oracle-Tenant';
@@ -119,7 +120,7 @@ export function createTenantMiddleware() {
       }
     })
     .onBeforeHandle({ as: 'global' }, ({ tenantError }) => {
-      if (tenantError) return { error: tenantError };
+      if (tenantError) return errorResponse(tenantError, 400);
     })
     .onRequest(({ request }) => {
       tenantIdFor(request);
@@ -132,7 +133,7 @@ export function createTenantFetch(next: FetchHandler): FetchHandler {
       const tenantId = tenantIdFor(request);
       return runWithTenant(tenantId, () => next(request));
     } catch (error) {
-      return Response.json({ error: error instanceof Error ? error.message : String(error) }, { status: 400 });
+      return Response.json(errorResponse(error instanceof Error ? error.message : String(error), 400), { status: 400 });
     }
   };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,6 @@ import { Elysia } from 'elysia';
 import { join } from 'node:path';
 import { swagger } from '@elysiajs/swagger';
 import { eq } from 'drizzle-orm';
-
 import { configure, writePidFile, removePidFile } from './process-manager/index.ts';
 import { PORT, ORACLE_DATA_DIR, VECTOR_URL } from './config.ts';
 import { ScoutAnnouncer, shouldStartScoutAnnouncer } from './peer/scout-announcer.ts';
@@ -31,6 +30,7 @@ import { createBodyLimitMiddleware } from './middleware/body-limit.ts';
 import { createNotFoundMiddleware } from './middleware/not-found.ts';
 import { createEtagMiddleware } from './middleware/etag.ts';
 import { createCompressMiddleware } from './middleware/compress.ts';
+import { createErrorResponseMiddleware } from './middleware/error-response.ts';
 import { createRequestDedupFetch } from './middleware/dedup.ts';
 import { createDbContextFetch } from './middleware/db-context.ts';
 import { createTenantFetch, createTenantMiddleware } from './middleware/tenant.ts';
@@ -127,6 +127,7 @@ const app = new Elysia()
   .use(createBodyLimitMiddleware())
   .use(createApiKeyAuthMiddleware())
   .use(createMetricsLifecycle())
+  .use(createErrorResponseMiddleware())
   .use(createCompressMiddleware())
   .use(createEtagMiddleware())
   .onBeforeHandle(({ request, set }) => {

--- a/src/types/error-response.ts
+++ b/src/types/error-response.ts
@@ -1,0 +1,32 @@
+export type ErrorResponse = {
+  success: false;
+  error: string;
+  code?: number;
+  details?: unknown;
+};
+
+export type ErrorResponseInput = Record<string, unknown> & { error: string; success?: unknown; code?: unknown };
+
+export function errorResponse<const T extends string, const C extends number | undefined = undefined>(
+  error: T,
+  code?: C,
+  details?: unknown,
+): ErrorResponse & { error: T } & (C extends number ? { code: C } : { code?: undefined }) {
+  return {
+    success: false,
+    error,
+    ...(code === undefined ? {} : { code }),
+    ...(details === undefined ? {} : { details }),
+  } as unknown as ErrorResponse & { error: T } & (C extends number ? { code: C } : { code?: undefined });
+}
+
+export function isErrorResponseInput(value: unknown): value is ErrorResponseInput {
+  return Boolean(value && typeof value === 'object' && typeof (value as { error?: unknown }).error === 'string');
+}
+
+export function normalizeErrorResponse(value: unknown, status?: number): unknown {
+  if (!isErrorResponseInput(value)) return value;
+  if (value.success === true) return value;
+  const code = typeof value.code === 'number' ? value.code : status && status >= 400 ? status : undefined;
+  return { success: false, ...value, ...(code === undefined ? {} : { code }) };
+}

--- a/tests/http/body-limit/size-limit.test.ts
+++ b/tests/http/body-limit/size-limit.test.ts
@@ -27,9 +27,10 @@ describe('request body size limit middleware', () => {
     expect(res.status).toBe(413);
     expect(requestId).toBeTruthy();
     expect(body).toEqual({
+      success: false,
       error: 'Payload Too Large',
+      code: 413,
       message: 'Request body exceeds 1KB limit.',
-      statusCode: 413,
       correlationId: requestId,
       limitKb: 1,
     });

--- a/tests/http/errors/error-format.test.ts
+++ b/tests/http/errors/error-format.test.ts
@@ -31,7 +31,8 @@ function expectErrorShape(body: Record<string, unknown>, code: number) {
   expect(body.error).toEqual(expect.any(String));
   expect(body.code).toBe(code);
   if ('details' in body) expect(typeof body.details).toBe('object');
-  expect(Object.keys(body).sort()).toEqual(['code', 'details', 'error']);
+  expect(body.success).toBe(false);
+  expect(Object.keys(body).sort()).toEqual(['code', 'details', 'error', 'success']);
 }
 
 describe('standard API error format', () => {

--- a/tests/http/errors/route-normalizer.test.ts
+++ b/tests/http/errors/route-normalizer.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createErrorResponseMiddleware } from '../../../src/middleware/error-response.ts';
+
+describe('route error response normalizer', () => {
+  test('adds the shared error shape to route-level error objects', async () => {
+    const app = new Elysia()
+      .use(createErrorResponseMiddleware())
+      .get('/missing-q', ({ set }) => {
+        set.status = 400;
+        return { error: 'Missing query parameter: q' };
+      });
+
+    const res = await app.handle(new Request('http://local/missing-q'));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      success: false,
+      error: 'Missing query parameter: q',
+      code: 400,
+    });
+  });
+
+  test('does not alter successful responses', async () => {
+    const app = new Elysia()
+      .use(createErrorResponseMiddleware())
+      .get('/ok', () => ({ ok: true }));
+
+    const res = await app.handle(new Request('http://local/ok'));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+});

--- a/tests/http/errors/structured-errors.test.ts
+++ b/tests/http/errors/structured-errors.test.ts
@@ -41,14 +41,12 @@ async function request(path: string, init?: RequestInit) {
 }
 
 function expectStructured(body: Record<string, unknown>, code: number) {
-  expect(body).toEqual({
-    error: expect.any(String),
-    code,
-    details: {
-      message: expect.any(String),
-      correlationId: expect.any(String),
-    },
-  });
+  expect(body.success).toBe(false);
+  expect(typeof body.error).toBe('string');
+  expect(body.code).toBe(code);
+  const details = body.details as Record<string, unknown>;
+  expect(typeof details.message).toBe('string');
+  expect(typeof details.correlationId).toBe('string');
 }
 
 function detailsOf(body: Record<string, unknown>) {
@@ -62,6 +60,7 @@ describe('structured error middleware', () => {
     expect(res.status).toBe(400);
     expect(res.headers.get('x-correlation-id')).toBe('test-correlation');
     expect(body).toEqual({
+      success: false,
       error: 'Bad Request',
       code: 400,
       details: {

--- a/tests/http/not-found/handler.test.ts
+++ b/tests/http/not-found/handler.test.ts
@@ -16,6 +16,7 @@ test('unmatched routes return structured not-found JSON', async () => {
   const missing = await fetchVersioned(new Request('http://local/api/v1/missing?debug=1', { method: 'POST' }));
   expect(missing.status).toBe(404);
   expect(await missing.json()).toEqual({
+    success: false,
     error: 'Not Found',
     code: 404,
     details: {

--- a/tests/http/not-found/method-not-allowed.test.ts
+++ b/tests/http/not-found/method-not-allowed.test.ts
@@ -13,6 +13,7 @@ test('known routes hit with the wrong method return 405 JSON', async () => {
   expect(response.status).toBe(405);
   expect(response.headers.get('Allow')).toBe('GET');
   expect(await response.json()).toEqual({
+    success: false,
     error: 'Method Not Allowed',
     code: 405,
     details: {

--- a/tests/http/tenant/auth.test.ts
+++ b/tests/http/tenant/auth.test.ts
@@ -44,7 +44,7 @@ describe('tenant auth middleware', () => {
         headers: { [TENANT_HEADER]: 'acme', [TENANT_TOKEN_HEADER]: 'bad' },
       }));
       expect(res.status).toBe(400);
-      expect(await res.json()).toEqual({ error: 'invalid tenant token' });
+      expect(await res.json()).toEqual({ success: false, error: 'invalid tenant token', code: 400 });
     } finally {
       if (previous === undefined) delete process.env.ORACLE_TENANT_TOKENS;
       else process.env.ORACLE_TENANT_TOKENS = previous;


### PR DESCRIPTION
## Changes
- Add shared `ErrorResponse` type and `errorResponse` helper for `{ success:false, error, code? }` responses
- Add global route error response normalizer so route-cluster `{ error }` returns use the shared outward contract
- Update structured error, not-found, body-limit, and tenant error surfaces/tests to the shared shape

## Test
- bunx tsc --noEmit: green
- bun test tests/http/errors/ tests/http/not-found/ tests/http/body-limit/ tests/http/tenant/auth.test.ts tests/http/auth/api-key.test.ts tests/http/content-type/negotiation.test.ts: passed