### PR TITLE
feat: add structured request logging middleware

### DIFF
--- a/src/middleware/request-logger.ts
+++ b/src/middleware/request-logger.ts
@@ -1,0 +1,68 @@
+import { Elysia } from 'elysia';
+
+export type StructuredRequestLogEntry = {
+  method: string;
+  path: string;
+  status: number;
+  durationMs: number;
+  timestamp: string;
+};
+
+type RequestMeta = { startedAt: number };
+type LogSink = (entry: StructuredRequestLogEntry) => void;
+
+type RequestLoggingOptions = {
+  log?: LogSink;
+  now?: () => number;
+  timestamp?: () => string;
+};
+
+function nowMs(): number {
+  return performance.now();
+}
+
+function isoTimestamp(): string {
+  return new Date().toISOString();
+}
+
+function requestPath(request: Request): string {
+  try {
+    return new URL(request.url).pathname;
+  } catch {
+    return request.url;
+  }
+}
+
+function responseStatus(response: unknown, setStatus: unknown): number {
+  if (response instanceof Response) return response.status;
+  if (typeof setStatus === 'number') return setStatus;
+  return 200;
+}
+
+function roundedDurationMs(startedAt: number, endedAt: number): number {
+  return Math.max(0, Math.round((endedAt - startedAt) * 100) / 100);
+}
+
+export function createRequestLoggingMiddleware(options: RequestLoggingOptions = {}) {
+  const meta = new WeakMap<Request, RequestMeta>();
+  const now = options.now ?? nowMs;
+  const timestamp = options.timestamp ?? isoTimestamp;
+  const log = options.log ?? ((entry: StructuredRequestLogEntry) => console.log(JSON.stringify(entry)));
+
+  return new Elysia({ name: 'structured-request-logger' })
+    .onRequest(({ request }) => {
+      meta.set(request, { startedAt: now() });
+    })
+    .onAfterResponse({ as: 'global' }, ({ request, responseValue, set }) => {
+      const endedAt = now();
+      const startedAt = meta.get(request)?.startedAt ?? endedAt;
+      log({
+        method: request.method,
+        path: requestPath(request),
+        status: responseStatus(responseValue, set.status),
+        durationMs: roundedDurationMs(startedAt, endedAt),
+        timestamp: timestamp(),
+      });
+      meta.delete(request);
+    });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,7 +23,7 @@ import { validateStartupEnv } from './config/validate.ts';
 import { printStartupBanner } from './lifecycle/banner.ts';
 import { createStartupSelfTest, runStartupSelfTest } from './lifecycle/self-test.ts';
 import { readStartupDbStatus, runtimeMiddleware } from './lifecycle/startup-context.ts';
-import { createRequestLogger } from './middleware/logger.ts';
+import { createRequestLoggingMiddleware } from './middleware/request-logger.ts';
 import { createApiVersionHeaderMiddleware, createApiVersionedFetch } from './middleware/api-version.ts';
 import { createSecurityHeadersMiddleware } from './middleware/security-headers.ts';
 import { createRequestTimeoutFetch } from './middleware/timeout.ts';
@@ -114,9 +114,8 @@ registerGracefulShutdown({
   },
 });
 
-const requestLogger = createRequestLogger();
 const app = new Elysia()
-  .onRequest(requestLogger.onRequest)
+  .use(createRequestLoggingMiddleware())
   .use(createCorrelationMiddleware())
   .use(createTenantMiddleware())
   .use(createPrivateNetworkPreflightMiddleware())
@@ -141,7 +140,6 @@ const app = new Elysia()
     set.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate';
     set.headers['Referrer-Policy'] = 'strict-origin-when-cross-origin';
   })
-  .onAfterResponse(requestLogger.onAfterResponse)
   .use(createErrorMiddleware())
   .use(
     swagger({

--- a/tests/http/logging/request-logger-middleware.test.ts
+++ b/tests/http/logging/request-logger-middleware.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import {
+  createRequestLoggingMiddleware,
+  type StructuredRequestLogEntry,
+} from '../../../src/middleware/request-logger.ts';
+
+async function waitForLog(logs: StructuredRequestLogEntry[]) {
+  const deadline = Date.now() + 500;
+  while (Date.now() < deadline) {
+    if (logs[0]) return logs[0];
+    await Bun.sleep(5);
+  }
+  throw new Error('request log was not emitted');
+}
+
+function app(logs: StructuredRequestLogEntry[], ticks = [10, 14.25]) {
+  return new Elysia()
+    .use(createRequestLoggingMiddleware({
+      log: (entry) => logs.push(entry),
+      now: () => ticks.shift() ?? 14.25,
+      timestamp: () => '2026-06-16T00:00:00.000Z',
+    }))
+    .get('/ok', ({ set }) => {
+      set.status = 201;
+      return { ok: true };
+    })
+    .get('/raw', () => new Response('raw', { status: 202 }));
+}
+
+describe('structured request logging middleware', () => {
+  test('logs method, path, status, duration, and timestamp', async () => {
+    const logs: StructuredRequestLogEntry[] = [];
+
+    const res = await app(logs).fetch(new Request('http://local/ok?secret=hidden'));
+
+    expect(res.status).toBe(201);
+    expect(await waitForLog(logs)).toEqual({
+      method: 'GET',
+      path: '/ok',
+      status: 201,
+      durationMs: 4.25,
+      timestamp: '2026-06-16T00:00:00.000Z',
+    });
+  });
+
+  test('uses Response status for raw responses', async () => {
+    const logs: StructuredRequestLogEntry[] = [];
+
+    const res = await app(logs).fetch(new Request('http://local/raw'));
+
+    expect(res.status).toBe(202);
+    const entry = await waitForLog(logs);
+    expect(entry).toMatchObject({ method: 'GET', path: '/raw', status: 202 });
+    expect(entry.durationMs).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
## Changes
- Added `src/middleware/request-logger.ts` as an Elysia plugin that logs method, path, status, durationMs, and timestamp for every request
- Wired the new structured request logger into `src/server.ts`
- Added scoped HTTP tests for JSON-compatible structured log entries and raw Response status handling

## Test
- bunx tsc --noEmit: green
- bun test tests/http/logging/request-logger-middleware.test.ts tests/http/logging/request-log.test.ts tests/http/logger/format.test.ts tests/http/health/core-hardening.test.ts tests/http/core.test.ts: green