### PR TITLE
Optimize database query paths and indexes

### DIFF
--- a/src/db/__tests__/fresh-install.test.ts
+++ b/src/db/__tests__/fresh-install.test.ts
@@ -63,4 +63,26 @@ describe("fresh install (#1111)", () => {
 		sqlite.close();
 		rmSync(dir, { recursive: true });
 	});
+	test("query optimization indexes are installed on fresh DB", () => {
+		const dir = mkdtempSync(join(tmpdir(), "oracle-indexes-"));
+		const dbPath = join(dir, "test.db");
+		const sqlite = new Database(dbPath);
+		const db = drizzle(sqlite, { schema });
+		const migrationsFolder = join(import.meta.dir, "../migrations");
+
+		migrate(db, { migrationsFolder });
+		const rows = sqlite
+			.prepare("SELECT name FROM sqlite_master WHERE type='index'")
+			.all() as Array<{ name: string }>;
+		const names = rows.map((row) => row.name);
+
+		expect(names).toContain("idx_documents_tenant_type_active_updated");
+		expect(names).toContain("idx_search_tenant_created");
+		expect(names).toContain("idx_thread_tenant_status_updated");
+		expect(names).toContain("idx_menu_path_studio");
+
+		sqlite.close();
+		rmSync(dir, { recursive: true });
+	});
+
 });

--- a/src/db/logistics-schema.ts
+++ b/src/db/logistics-schema.ts
@@ -104,4 +104,5 @@ export const menuItems = sqliteTable('menu_items', {
   index('idx_menu_parent').on(table.parentId, table.position),
   index('idx_menu_group').on(table.groupKey, table.position),
   index('idx_menu_deleted_at').on(table.deletedAt),
+  index('idx_menu_path_studio').on(table.path, table.studio),
 ]);

--- a/src/db/migrations/0023_query_optimization_indexes.sql
+++ b/src/db/migrations/0023_query_optimization_indexes.sql
@@ -1,0 +1,7 @@
+CREATE INDEX `idx_documents_tenant_type_active_updated` ON `oracle_documents` (`tenant_id`,`type`,`superseded_at`,`updated_at`);
+--> statement-breakpoint
+CREATE INDEX `idx_search_tenant_created` ON `search_log` (`tenant_id`,`created_at`);
+--> statement-breakpoint
+CREATE INDEX `idx_thread_tenant_status_updated` ON `forum_threads` (`tenant_id`,`status`,`updated_at`);
+--> statement-breakpoint
+CREATE INDEX `idx_menu_path_studio` ON `menu_items` (`path`,`studio`);

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1781595000000,
       "tag": "0022_tenant_isolation",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "6",
+      "when": 1781597100000,
+      "tag": "0023_query_optimization_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -39,9 +39,8 @@ export const oracleDocuments = sqliteTable('oracle_documents', {
   index('idx_origin').on(table.origin),
   index('idx_project').on(table.project),
   index('idx_documents_tenant').on(table.tenantId),
+  index('idx_documents_tenant_type_active_updated').on(table.tenantId, table.type, table.supersededAt, table.updatedAt),
 ]);
-
-
 // Challenge 2 memory system persistence (#1457)
 export const oracleMemories = sqliteTable('oracle_memories', {
   id: text('id').primaryKey(),
@@ -106,6 +105,7 @@ export const searchLog = sqliteTable('search_log', {
   index('idx_search_project').on(table.project),
   index('idx_search_tenant').on(table.tenantId),
   index('idx_search_created').on(table.createdAt),
+  index('idx_search_tenant_created').on(table.tenantId, table.createdAt),
 ]);
 
 // Consult log — legacy table kept for backward compat (pre-0007 snapshot had it).
@@ -173,6 +173,7 @@ export const forumThreads = sqliteTable('forum_threads', {
   index('idx_thread_project').on(table.project),
   index('idx_thread_tenant').on(table.tenantId),
   index('idx_thread_created').on(table.createdAt),
+  index('idx_thread_tenant_status_updated').on(table.tenantId, table.status, table.updatedAt),
 ]);
 
 export const forumMessages = sqliteTable('forum_messages', {
@@ -191,10 +192,8 @@ export const forumMessages = sqliteTable('forum_messages', {
   index('idx_message_role').on(table.role),
   index('idx_message_created').on(table.createdAt),
 ]);
-
 // Note: FTS5 virtual table (oracle_fts) is managed via raw SQL
 // since Drizzle doesn't natively support FTS5
-
 // Trace Log Tables (discovery tracing with dig points)
 
 export const traceLog = sqliteTable('trace_log', {

--- a/src/db/seeders/menu-seeder.ts
+++ b/src/db/seeders/menu-seeder.ts
@@ -8,7 +8,7 @@
  *   - touchedAt != null        → PRESERVE (user edit wins); log drift
  */
 
-import { and, eq, isNull } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm';
 import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 import * as schema from '../schema.ts';
 import { db as defaultDb } from '../index.ts';
@@ -29,6 +29,7 @@ export interface RouteMenuRow {
 }
 
 type SeenRouteMenuRow = RouteMenuRow & { apiPath: string };
+type MenuItemRow = typeof schema.menuItems.$inferSelect;
 
 function studioPathFor(apiPath: string): string | null {
   for (const [prefix, studio] of API_TO_STUDIO) {
@@ -146,22 +147,18 @@ export function seedMenuItems(
   let preserved = 0;
 
   db.transaction((tx) => {
+    const paths = [...new Set([...rows.map((row) => row.path), ...Object.entries(CHILD_PARENTS).flat()])];
+    const existingRows = paths.length
+      ? tx.select().from(schema.menuItems).where(inArray(schema.menuItems.path, paths)).all()
+      : [];
+    const byKey = new Map<string, MenuItemRow>();
+    for (const item of existingRows) byKey.set(routeMenuKey(item.path, item.studio), item);
+
     for (const row of rows) {
-      const existing = tx
-        .select()
-        .from(schema.menuItems)
-        .where(
-          and(
-            eq(schema.menuItems.path, row.path),
-            row.studio == null
-              ? isNull(schema.menuItems.studio)
-              : eq(schema.menuItems.studio, row.studio),
-          ),
-        )
-        .get();
+      const existing = byKey.get(routeMenuKey(row.path, row.studio));
 
       if (!existing) {
-        tx.insert(schema.menuItems)
+        const created = tx.insert(schema.menuItems)
           .values({
             path: row.path,
             label: row.label,
@@ -176,7 +173,9 @@ export function seedMenuItems(
             createdAt: now,
             updatedAt: now,
           })
-          .run();
+          .returning()
+          .get();
+        byKey.set(routeMenuKey(created.path, created.studio), created);
         inserted += 1;
         continue;
       }
@@ -209,22 +208,14 @@ export function seedMenuItems(
     }
 
     for (const [childPath, parentPath] of Object.entries(CHILD_PARENTS)) {
-      const parent = tx
-        .select()
-        .from(schema.menuItems)
-        .where(and(eq(schema.menuItems.path, parentPath), isNull(schema.menuItems.studio)))
-        .get();
-      if (!parent) continue;
-      const child = tx
-        .select()
-        .from(schema.menuItems)
-        .where(and(eq(schema.menuItems.path, childPath), isNull(schema.menuItems.studio)))
-        .get();
-      if (!child || child.parentId === parent.id) continue;
+      const parent = byKey.get(routeMenuKey(parentPath, null));
+      const child = byKey.get(routeMenuKey(childPath, null));
+      if (!parent || !child || child.parentId === parent.id) continue;
       tx.update(schema.menuItems)
         .set({ parentId: parent.id, updatedAt: now })
         .where(eq(schema.menuItems.id, child.id))
         .run();
+      byKey.set(routeMenuKey(child.path, child.studio), { ...child, parentId: parent.id, updatedAt: now });
     }
   });
 


### PR DESCRIPTION
## Summary
- batch menu seeder lookups to remove per-row and parent/child N+1 queries
- add composite indexes for tenant document/search/forum lookups and menu path+studio reads
- verify fresh migrations install the new optimization indexes

## Tests
- bunx tsc --noEmit
- bun test src/db/__tests__/fresh-install.test.ts tests/http/menu/ tests/http/tenant/ src/routes/menu/__tests__/menu-reorg.test.ts src/routes/menu/__tests__/menu-seeder-composite.test.ts

## Notes
- PR targets alpha; no main changes.
- Full monolithic tests/http run still exposes the pre-existing cross-file shared-DB teardown issue; scoped relevant HTTP suites pass.