### PR TITLE
feat: add deep health diagnostics endpoint

### DIFF
--- a/src/routes/health/deep.ts
+++ b/src/routes/health/deep.ts
@@ -1,0 +1,132 @@
+import { Elysia, t } from 'elysia';
+import { statfsSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { DB_PATH, ORACLE_DATA_DIR } from '../../config.ts';
+import { sqlite } from '../../db/index.ts';
+import { readVectorBackendHealth } from '../../vector/health.ts';
+import type { HealthEndpointOptions } from './health.ts';
+
+type ComponentStatus = 'ok' | 'degraded' | 'down';
+type DbStatus = { status: 'connected' } | { status: 'error'; error: string };
+type DeepHealthOptions = Pick<HealthEndpointOptions, 'dbPing' | 'vectorHealth'> & {
+  diskPath?: string;
+  diskUsage?: () => DiskHealth;
+  memoryUsage?: () => NodeJS.MemoryUsage;
+};
+
+type DiskHealth = {
+  status: 'ok' | 'warning' | 'error';
+  path: string;
+  totalBytes: number;
+  freeBytes: number;
+  usedBytes: number;
+  usedPercent: number;
+  error?: string;
+};
+
+const DeepHealthResponseSchema = t.Object({
+  status: t.Union([t.Literal('ok'), t.Literal('degraded'), t.Literal('down')]),
+  checked_at: t.String(),
+  db: t.Object({
+    status: t.Union([t.Literal('connected'), t.Literal('error')]),
+    path: t.String(),
+    latencyMs: t.Number(),
+    error: t.Optional(t.String()),
+  }),
+  vector: t.Object({
+    status: t.Union([t.Literal('ok'), t.Literal('degraded'), t.Literal('down')]),
+    checked_at: t.String(),
+    engines: t.Array(t.Any()),
+    error: t.Optional(t.String()),
+  }),
+  disk: t.Object({
+    status: t.Union([t.Literal('ok'), t.Literal('warning'), t.Literal('error')]),
+    path: t.String(),
+    totalBytes: t.Number(),
+    freeBytes: t.Number(),
+    usedBytes: t.Number(),
+    usedPercent: t.Number(),
+    error: t.Optional(t.String()),
+  }),
+  memory: t.Object({
+    rss: t.Number(),
+    heapTotal: t.Number(),
+    heapUsed: t.Number(),
+    external: t.Number(),
+    arrayBuffers: t.Number(),
+  }),
+});
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function timedDbCheck(ping?: HealthEndpointOptions['dbPing']) {
+  const started = performance.now();
+  let result: DbStatus;
+  try {
+    result = ping ? await ping() : defaultDbPing();
+  } catch (error) {
+    result = { status: 'error', error: errorMessage(error) };
+  }
+  return { ...result, path: DB_PATH, latencyMs: Math.round((performance.now() - started) * 100) / 100 };
+}
+
+function defaultDbPing(): DbStatus {
+  try {
+    sqlite.prepare('SELECT 1 as ok').get();
+    return { status: 'connected' };
+  } catch (error) {
+    return { status: 'error', error: errorMessage(error) };
+  }
+}
+
+function numeric(value: number | bigint): number {
+  return typeof value === 'bigint' ? Number(value) : value;
+}
+
+function readDisk(path = ORACLE_DATA_DIR || dirname(DB_PATH)): DiskHealth {
+  try {
+    const stats = statfsSync(path);
+    const blockSize = numeric(stats.bsize);
+    const totalBytes = numeric(stats.blocks) * blockSize;
+    const freeBytes = numeric(stats.bavail) * blockSize;
+    const usedBytes = Math.max(0, totalBytes - freeBytes);
+    const usedPercent = totalBytes > 0 ? Math.round((usedBytes / totalBytes) * 10_000) / 100 : 0;
+    return { status: usedPercent >= 90 ? 'warning' : 'ok', path, totalBytes, freeBytes, usedBytes, usedPercent };
+  } catch (error) {
+    return { status: 'error', path, totalBytes: 0, freeBytes: 0, usedBytes: 0, usedPercent: 0, error: errorMessage(error) };
+  }
+}
+
+async function readVector(check = readVectorBackendHealth) {
+  try {
+    return await check();
+  } catch (error) {
+    return { status: 'down' as const, checked_at: new Date().toISOString(), engines: [], error: errorMessage(error) };
+  }
+}
+
+function overallStatus(db: { status: string }, vector: { status: ComponentStatus }, disk: DiskHealth): ComponentStatus {
+  if (db.status === 'error') return 'down';
+  if (vector.status === 'down' || disk.status === 'error') return 'degraded';
+  if (vector.status === 'degraded' || disk.status === 'warning') return 'degraded';
+  return 'ok';
+}
+
+export function createDeepHealthEndpoint(options: DeepHealthOptions = {}) {
+  return new Elysia().get('/health/deep', async () => {
+    const [db, vector] = await Promise.all([timedDbCheck(options.dbPing), readVector(options.vectorHealth)]);
+    const disk = options.diskUsage?.() ?? readDisk(options.diskPath);
+    const memory = options.memoryUsage?.() ?? process.memoryUsage();
+    return { status: overallStatus(db, vector, disk), checked_at: new Date().toISOString(), db, vector, disk, memory };
+  }, {
+    response: DeepHealthResponseSchema,
+    detail: {
+      tags: ['health'],
+      menu: { group: 'hidden' },
+      description: 'Runs a deep health check for database connectivity, vector backend status, disk space, and process memory usage.',
+      summary: 'Deep dependency and resource health check',
+    },
+  });
+}

--- a/src/routes/health/health.ts
+++ b/src/routes/health/health.ts
@@ -12,6 +12,16 @@ type VectorHealth = Awaited<ReturnType<typeof readVectorBackendHealth>>;
 type DbStatus = { status: 'connected' } | { status: 'error'; error: string };
 type DbPing = () => DbStatus | Promise<DbStatus>;
 
+type DiskHealth = {
+  status: 'ok' | 'warning' | 'error';
+  path: string;
+  totalBytes: number;
+  freeBytes: number;
+  usedBytes: number;
+  usedPercent: number;
+  error?: string;
+};
+
 const HealthVectorSchema = t.Object({
   status: t.Union([t.Literal('ok'), t.Literal('degraded'), t.Literal('down')]),
   checked_at: t.String(),
@@ -75,6 +85,9 @@ export interface HealthEndpointOptions {
   vectorHealth?: () => Promise<VectorHealth>;
   pluginStatuses?: () => UnifiedPluginStatus[] | Promise<UnifiedPluginStatus[]>;
   dbPing?: DbPing;
+  diskPath?: string;
+  diskUsage?: () => DiskHealth;
+  memoryUsage?: () => NodeJS.MemoryUsage;
 }
 
 function errorMessage(error: unknown): string {

--- a/src/routes/health/index.ts
+++ b/src/routes/health/index.ts
@@ -3,12 +3,14 @@
  */
 import { Elysia } from 'elysia';
 import { createHealthEndpoint, type HealthEndpointOptions } from './health.ts';
+import { createDeepHealthEndpoint } from './deep.ts';
 import { statsEndpoint } from './stats.ts';
 import { oraclesEndpoint } from './oracles.ts';
 
 export function createHealthRoutes(options: HealthEndpointOptions = {}) {
   return new Elysia({ prefix: '/api' })
     .use(createHealthEndpoint(options))
+    .use(createDeepHealthEndpoint(options))
     .use(statsEndpoint)
     .use(oraclesEndpoint);
 }

--- a/tests/http/health/deep.test.ts
+++ b/tests/http/health/deep.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'bun:test';
+import { createHealthRoutes } from '../../../src/routes/health/index.ts';
+
+describe('GET /api/health/deep', () => {
+  test('returns DB, vector, disk, and memory details', async () => {
+    const app = createHealthRoutes({
+      dbPing: () => ({ status: 'connected' }),
+      vectorHealth: async () => ({
+        status: 'ok',
+        checked_at: '2026-06-16T00:00:00.000Z',
+        engines: [{ key: 'bge', model: 'bge-m3', collection: 'oracle_bge', ok: true, count: 7 }],
+      }),
+      diskUsage: () => ({
+        status: 'ok',
+        path: '/tmp/oracle',
+        totalBytes: 1000,
+        freeBytes: 400,
+        usedBytes: 600,
+        usedPercent: 60,
+      }),
+      memoryUsage: () => ({ rss: 100, heapTotal: 80, heapUsed: 40, external: 5, arrayBuffers: 2 }),
+    });
+
+    const res = await app.handle(new Request('http://local/api/health/deep'));
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe('ok');
+    expect(body.db).toMatchObject({ status: 'connected' });
+    expect(body.db.path).toBeTypeOf('string');
+    expect(body.db.latencyMs).toBeTypeOf('number');
+    expect(body.vector).toMatchObject({ status: 'ok', engines: [{ key: 'bge', count: 7 }] });
+    expect(body.disk).toMatchObject({ status: 'ok', path: '/tmp/oracle', usedPercent: 60 });
+    expect(body.memory).toMatchObject({ rss: 100, heapUsed: 40, arrayBuffers: 2 });
+    expect(body.checked_at).toBeTypeOf('string');
+  });
+
+  test('marks response degraded/down when dependencies report errors', async () => {
+    const app = createHealthRoutes({
+      dbPing: () => ({ status: 'error', error: 'db offline' }),
+      vectorHealth: async () => ({ status: 'down', checked_at: 'now', engines: [], error: 'vector offline' }),
+      diskUsage: () => ({
+        status: 'warning',
+        path: '/tmp/oracle',
+        totalBytes: 100,
+        freeBytes: 5,
+        usedBytes: 95,
+        usedPercent: 95,
+      }),
+      memoryUsage: () => ({ rss: 1, heapTotal: 1, heapUsed: 1, external: 0, arrayBuffers: 0 }),
+    });
+
+    const res = await app.handle(new Request('http://local/api/health/deep'));
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe('down');
+    expect(body.db).toMatchObject({ status: 'error', error: 'db offline' });
+    expect(body.vector).toMatchObject({ status: 'down', error: 'vector offline' });
+    expect(body.disk).toMatchObject({ status: 'warning', usedPercent: 95 });
+  });
+});


### PR DESCRIPTION
## Summary\n- add /api/health/deep with DB connectivity, vector backend status, disk space, and process memory details\n- keep existing /api/health lightweight and unchanged\n- add scoped health route coverage for healthy and degraded/down dependency states\n\n## Verification\n- bun test tests/http/health/\n- bunx tsc --noEmit