### PR TITLE
feat: add per-route rate limiter middleware

### DIFF
--- a/src/middleware/rate-limiter.ts
+++ b/src/middleware/rate-limiter.ts
@@ -1,0 +1,82 @@
+import { Elysia } from 'elysia';
+import { apiRequestPath } from './api-version.ts';
+import { apiErrorResponse } from './errors.ts';
+
+export type RateLimitRule = {
+  path: string | RegExp;
+  limit: number;
+  windowMs: number;
+  methods?: string[];
+};
+
+export type RateLimitOptions = {
+  rules?: RateLimitRule[];
+  now?: () => number;
+  key?: (request: Request) => string;
+};
+
+type Bucket = { count: number; resetAt: number };
+type HeaderSetter = { status?: number | string; headers: Record<string, string | number> };
+
+export const DEFAULT_RATE_LIMIT_RULES: RateLimitRule[] = [
+  { path: '/api/search', limit: 30, windowMs: 60_000 },
+  { path: '/api/learn', limit: 10, windowMs: 60_000 },
+];
+
+function methodAllowed(rule: RateLimitRule, method: string): boolean {
+  return !rule.methods || rule.methods.map((m) => m.toUpperCase()).includes(method.toUpperCase());
+}
+
+function pathMatches(rule: RateLimitRule, pathname: string): boolean {
+  return typeof rule.path === 'string' ? pathname === rule.path : rule.path.test(pathname);
+}
+
+export function matchingRateLimitRule(request: Request, rules = DEFAULT_RATE_LIMIT_RULES): RateLimitRule | undefined {
+  const pathname = apiRequestPath(request);
+  return rules.find((rule) => methodAllowed(rule, request.method) && pathMatches(rule, pathname));
+}
+
+export function clientRateLimitKey(request: Request): string {
+  const forwarded = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim();
+  const clientIp = request.headers.get('cf-connecting-ip')?.trim() || forwarded || 'local';
+  return `${request.method.toUpperCase()} ${apiRequestPath(request)} ${clientIp}`;
+}
+
+function secondsUntil(resetAt: number, now: number): number {
+  return Math.max(0, Math.ceil((resetAt - now) / 1000));
+}
+
+function setHeaders(set: HeaderSetter, rule: RateLimitRule, bucket: Bucket, now: number) {
+  set.headers['RateLimit-Limit'] = rule.limit;
+  set.headers['RateLimit-Remaining'] = Math.max(0, rule.limit - bucket.count);
+  set.headers['RateLimit-Reset'] = secondsUntil(bucket.resetAt, now);
+}
+
+export function createRateLimiterMiddleware(options: RateLimitOptions = {}) {
+  const rules = options.rules ?? DEFAULT_RATE_LIMIT_RULES;
+  const now = options.now ?? Date.now;
+  const keyFor = options.key ?? clientRateLimitKey;
+  const buckets = new Map<string, Bucket>();
+
+  return new Elysia({ name: 'rate-limiter' }).onBeforeHandle({ as: 'global' }, ({ request, set }) => {
+    const rule = matchingRateLimitRule(request, rules);
+    if (!rule) return;
+
+    const at = now();
+    const key = keyFor(request);
+    const current = buckets.get(key);
+    const bucket = !current || current.resetAt <= at ? { count: 0, resetAt: at + rule.windowMs } : current;
+    bucket.count += 1;
+    buckets.set(key, bucket);
+    setHeaders(set, rule, bucket, at);
+
+    if (bucket.count <= rule.limit) return;
+    set.status = 429;
+    set.headers['Retry-After'] = secondsUntil(bucket.resetAt, at);
+    return apiErrorResponse('rate_limit_exceeded', 429, {
+      limit: rule.limit,
+      windowMs: rule.windowMs,
+      retryAfterSeconds: secondsUntil(bucket.resetAt, at),
+    });
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,6 @@ import { Elysia } from 'elysia';
 import { join } from 'node:path';
 import { swagger } from '@elysiajs/swagger';
 import { eq } from 'drizzle-orm';
-
 import { configure, writePidFile, removePidFile } from './process-manager/index.ts';
 import { PORT, ORACLE_DATA_DIR, VECTOR_URL } from './config.ts';
 import { ScoutAnnouncer, shouldStartScoutAnnouncer } from './peer/scout-announcer.ts';
@@ -28,6 +27,7 @@ import { createApiVersionHeaderMiddleware, createApiVersionedFetch } from './mid
 import { createSecurityHeadersMiddleware } from './middleware/security-headers.ts';
 import { createRequestTimeoutFetch } from './middleware/timeout.ts';
 import { createBodyLimitMiddleware } from './middleware/body-limit.ts';
+import { createRateLimiterMiddleware } from './middleware/rate-limiter.ts';
 import { createResponseFormatMiddleware } from './middleware/response-format.ts';
 import { createNotFoundMiddleware } from './middleware/not-found.ts';
 import { createEtagMiddleware } from './middleware/etag.ts';
@@ -114,7 +114,6 @@ registerGracefulShutdown({
     console.log('👋 Arra Oracle HTTP Server stopped.');
   },
 });
-
 const app = new Elysia()
   .use(createRequestLoggingMiddleware())
   .use(createCorrelationMiddleware())
@@ -126,6 +125,7 @@ const app = new Elysia()
   .use(createContentTypeMiddleware())
   .use(createBodyLimitMiddleware())
   .use(createApiKeyAuthMiddleware())
+  .use(createRateLimiterMiddleware())
   .use(createMetricsLifecycle())
   .use(createResponseFormatMiddleware())
   .use(createCompressMiddleware())

--- a/tests/http/rate-limiter/rate-limiter.test.ts
+++ b/tests/http/rate-limiter/rate-limiter.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import {
+  DEFAULT_RATE_LIMIT_RULES,
+  clientRateLimitKey,
+  createRateLimiterMiddleware,
+  matchingRateLimitRule,
+} from '../../../src/middleware/rate-limiter.ts';
+
+function app(now: () => number, key?: (request: Request) => string) {
+  return new Elysia()
+    .use(createRateLimiterMiddleware({
+      now,
+      key,
+      rules: [
+        { path: '/api/search', limit: 2, windowMs: 1_000 },
+        { path: '/api/learn', limit: 1, windowMs: 1_000, methods: ['POST'] },
+      ],
+    }))
+    .get('/api/search', () => ({ ok: true }))
+    .post('/api/learn', () => ({ ok: true }))
+    .get('/api/health', () => ({ ok: true }));
+}
+
+async function json(res: Response) {
+  return await res.json() as Record<string, unknown>;
+}
+
+describe('rate limiter middleware', () => {
+  test('limits configured routes and returns standard 429 JSON', async () => {
+    let clock = 1_000;
+    const local = app(() => clock);
+
+    expect((await local.handle(new Request('http://local/api/search'))).status).toBe(200);
+    expect((await local.handle(new Request('http://local/api/search'))).headers.get('RateLimit-Remaining')).toBe('0');
+
+    const limited = await local.handle(new Request('http://local/api/search'));
+    expect(limited.status).toBe(429);
+    expect(limited.headers.get('Retry-After')).toBe('1');
+    expect(await json(limited)).toMatchObject({
+      success: false,
+      error: 'rate_limit_exceeded',
+      code: 429,
+      details: { limit: 2, windowMs: 1_000, retryAfterSeconds: 1 },
+    });
+
+    clock = 2_001;
+    expect((await local.handle(new Request('http://local/api/search'))).status).toBe(200);
+  });
+
+  test('uses per-route and per-client buckets', async () => {
+    const local = app(() => 1_000);
+
+    expect((await local.handle(new Request('http://local/api/learn', { method: 'POST' }))).status).toBe(200);
+    expect((await local.handle(new Request('http://local/api/learn', { method: 'POST' }))).status).toBe(429);
+    expect((await local.handle(new Request('http://local/api/health'))).status).toBe(200);
+
+    const otherClient = await local.handle(new Request('http://local/api/learn', {
+      method: 'POST',
+      headers: { 'x-forwarded-for': '203.0.113.9' },
+    }));
+    expect(otherClient.status).toBe(200);
+  });
+
+  test('exposes default matching and client key helpers', () => {
+    const search = new Request('http://local/api/search', { headers: { 'cf-connecting-ip': '198.51.100.3' } });
+    const learn = new Request('http://local/api/learn', { method: 'POST' });
+
+    expect(DEFAULT_RATE_LIMIT_RULES.map((rule) => rule.limit)).toEqual([30, 10]);
+    expect(matchingRateLimitRule(search)?.limit).toBe(30);
+    expect(matchingRateLimitRule(learn)?.limit).toBe(10);
+    expect(clientRateLimitKey(search)).toBe('GET /api/search 198.51.100.3');
+  });
+});


### PR DESCRIPTION
## Changes
- Add `src/middleware/rate-limiter.ts` Elysia plugin with in-memory fixed-window buckets
- Configure default per-route limits: `/api/search` 30 req/min and `/api/learn` 10 req/min
- Return standard 429 JSON errors plus `RateLimit-*` and `Retry-After` headers
- Wire limiter into the HTTP middleware stack after API auth

## Test
- bunx tsc --noEmit: green
- bun test tests/http/rate-limiter/: passed
- bun test tests/http/rate-limiter/ tests/http/auth/api-key.test.ts tests/http/response-format/ tests/http/errors/: passed