### PR TITLE
feat: add standalone data export app (#1783)

### DIFF
--- a/tests/tools/export-app/export-app.test.ts
+++ b/tests/tools/export-app/export-app.test.ts
@@ -1,0 +1,107 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const root = mkdtempSync(join(tmpdir(), 'arra-export-app-'));
+const dbPath = join(root, 'oracle.db');
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = dbPath;
+
+const dbModule = await import('../../../src/db/index.ts');
+const appModule = await import('../../../tools/export-app/index.ts');
+const exporterModule = await import('../../../tools/export-app/exporter.ts');
+
+const { createDatabase, oracleDocuments, traceLog, resetDefaultDatabaseForTests } = dbModule;
+const { runExportApp } = appModule;
+const { exportOracleData, graphRelationships } = exporterModule;
+
+function restoreDbPath() {
+  return savedDbPath
+    ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
+}
+
+function seed(connection: ReturnType<typeof createDatabase>) {
+  const now = 1_766_000_000_000;
+  connection.db.insert(oracleDocuments).values([
+    {
+      id: 'doc-old', type: 'learning', sourceFile: 'ψ/learn/old.md', concepts: '["backup"]',
+      createdAt: now, updatedAt: now, indexedAt: now, supersededBy: 'doc-new', supersededReason: 'refresh', createdBy: 'test',
+    },
+    {
+      id: 'doc-new', type: 'learning', sourceFile: 'ψ/learn/new.md', concepts: '["backup","safe"]',
+      createdAt: now + 1, updatedAt: now + 1, indexedAt: now + 1, createdBy: 'test',
+    },
+  ]).run();
+  connection.db.insert(traceLog).values([
+    { traceId: 'trace-a', query: 'backup root', childTraceIds: '["trace-b"]', nextTraceId: 'trace-b', createdAt: now, updatedAt: now },
+    { traceId: 'trace-b', query: 'backup child', parentTraceId: 'trace-a', prevTraceId: 'trace-a', createdAt: now, updatedAt: now },
+  ]).run();
+}
+
+afterAll(() => {
+  if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = savedDataDir;
+  if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = savedDbPath;
+  resetDefaultDatabaseForTests(restoreDbPath());
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('standalone export app', () => {
+  test('exports every Drizzle collection as json, csv, markdown plus graph relationships', async () => {
+    const connection = createDatabase(dbPath);
+    const outputDir = join(root, 'backup');
+    const progress: string[] = [];
+    seed(connection);
+
+    try {
+      const result = await exportOracleData({ connection, outputDir, progress: (message) => progress.push(message), now: () => new Date('2026-01-02T03:04:05.006Z') });
+
+      expect(result.collectionCount).toBeGreaterThan(5);
+      expect(result.rowCount).toBeGreaterThanOrEqual(4);
+      expect(result.relationshipCount).toBeGreaterThanOrEqual(4);
+      expect(progress.some((line) => line.includes('oracle_documents'))).toBe(true);
+
+      for (const ext of ['json', 'csv', 'md']) expect(existsSync(join(outputDir, 'collections', `oracle_documents.${ext}`))).toBe(true);
+      expect(readFileSync(join(outputDir, 'collections', 'oracle_documents.md'), 'utf8')).toContain('doc-old');
+      expect(readFileSync(join(outputDir, 'collections', 'oracle_documents.csv'), 'utf8')).toContain('doc-new');
+
+      const all = JSON.parse(readFileSync(join(outputDir, 'all-collections.json'), 'utf8'));
+      expect(all.collections.oracle_documents.map((row: { id: string }) => row.id)).toContain('doc-old');
+
+      const relationships = JSON.parse(readFileSync(join(outputDir, 'relationships.json'), 'utf8'));
+      expect(relationships.rows).toEqual(expect.arrayContaining([
+        expect.objectContaining({ type: 'document_superseded_by', from: 'doc-old', to: 'doc-new' }),
+        expect.objectContaining({ type: 'trace_next', from: 'trace-a', to: 'trace-b' }),
+      ]));
+    } finally {
+      connection.storage.close();
+    }
+  });
+
+  test('CLI writes a success summary and progress output', async () => {
+    const outputDir = join(root, 'backup-cli');
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+
+    const code = await runExportApp(['--output', outputDir, '--db', dbPath], (msg) => stdout.push(msg), (msg) => stderr.push(msg));
+
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout.join('')).success).toBe(true);
+    expect(stderr.join('')).toContain('oracle_documents');
+    expect(existsSync(join(outputDir, 'manifest.json'))).toBe(true);
+  });
+
+  test('graph relationship extraction is deterministic for rows', () => {
+    expect(graphRelationships({
+      oracle_documents: [{ id: 'a', supersededBy: 'b' }],
+      trace_log: [{ traceId: 't1', childTraceIds: '["t2"]' }],
+    })).toEqual([
+      { type: 'document_superseded_by', from: 'a', to: 'b', metadata: { reason: undefined, at: undefined } },
+      { type: 'trace_child', from: 't1', to: 't2' },
+    ]);
+  });
+});

--- a/tools/export-app/exporter.ts
+++ b/tools/export-app/exporter.ts
@@ -1,0 +1,146 @@
+import { getTableName } from 'drizzle-orm';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { DB_PATH } from '../../src/config.ts';
+import type { DatabaseConnection } from '../../src/db/index.ts';
+import { introspectDrizzleTables } from '../../src/cli/commands/backup.ts';
+import { createStorageBackend } from '../../src/storage/registry.ts';
+import {
+  EXPORT_FORMATS,
+  extensionFor,
+  formatCollection,
+  normalizeRecords,
+  type ExportRecord,
+} from './formats.ts';
+
+type DumpTable = ReturnType<typeof introspectDrizzleTables>[number];
+type Progress = (message: string) => void;
+
+export interface ExportAppOptions {
+  outputDir: string;
+  dbPath?: string;
+  connection?: DatabaseConnection;
+  progress?: Progress;
+  now?: () => Date;
+}
+
+export interface ExportAppResult {
+  outputDir: string;
+  collectionCount: number;
+  rowCount: number;
+  relationshipCount: number;
+}
+
+export type GraphRelationship = {
+  type: string;
+  from: string;
+  to: string;
+  metadata?: Record<string, unknown>;
+};
+
+export async function exportOracleData(options: ExportAppOptions): Promise<ExportAppResult> {
+  const close = options.connection ? undefined : openReadonlyConnection(options.dbPath);
+  const connection = options.connection ?? close!.connection;
+  const tables = introspectDrizzleTables();
+  const outputDir = path.resolve(options.outputDir);
+  const collectionsDir = path.join(outputDir, 'collections');
+  const progress = options.progress ?? ((message) => console.error(message));
+  const exportedAt = (options.now?.() ?? new Date()).toISOString();
+  const allCollections: Record<string, ExportRecord[]> = {};
+  let rowCount = 0;
+
+  try {
+    await mkdir(collectionsDir, { recursive: true });
+    for (let i = 0; i < tables.length; i += 1) {
+      const table = tables[i]!;
+      const name = getTableName(table);
+      const rows = normalizeRecords(selectRows(connection, table));
+      allCollections[name] = rows;
+      rowCount += rows.length;
+      progress(`[${i + 1}/${tables.length}] ${name}: ${rows.length} rows`);
+      await writeCollectionFiles(collectionsDir, name, rows);
+    }
+
+    const relationships = graphRelationships(allCollections);
+    await writeCollectionFiles(outputDir, 'relationships', relationships);
+    await writeFile(path.join(outputDir, 'all-collections.json'), JSON.stringify({ exportedAt, collections: allCollections }, null, 2) + '\n');
+    await writeFile(path.join(outputDir, 'manifest.json'), JSON.stringify({
+      exportedAt,
+      dbPath: options.dbPath ?? DB_PATH,
+      formats: EXPORT_FORMATS,
+      collectionCount: tables.length,
+      rowCount,
+      relationshipCount: relationships.length,
+    }, null, 2) + '\n');
+    return { outputDir, collectionCount: tables.length, rowCount, relationshipCount: relationships.length };
+  } finally {
+    close?.connection.storage.close();
+  }
+}
+
+function openReadonlyConnection(dbPath = DB_PATH): { connection: DatabaseConnection } {
+  const storage = createStorageBackend({ dbPath, readonly: true });
+  return { connection: { sqlite: storage.sqlite, db: storage.db, storage } };
+}
+
+function selectRows(connection: DatabaseConnection, table: DumpTable): ExportRecord[] {
+  return (connection.db as any).select().from(table).all() as ExportRecord[];
+}
+
+async function writeCollectionFiles(baseDir: string, name: string, rows: ExportRecord[]): Promise<void> {
+  for (const format of EXPORT_FORMATS) {
+    const file = path.join(baseDir, `${safeName(name)}.${extensionFor(format)}`);
+    await writeFile(file, formatCollection(name, rows, format), 'utf8');
+  }
+}
+
+function safeName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+export function graphRelationships(collections: Record<string, ExportRecord[]>): GraphRelationship[] {
+  return [
+    ...documentRelationships(collections.oracle_documents ?? []),
+    ...traceRelationships(collections.trace_log ?? []),
+  ];
+}
+
+function text(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function documentRelationships(rows: ExportRecord[]): GraphRelationship[] {
+  return rows.flatMap((row) => {
+    const from = text(row.id);
+    const to = text(row.supersededBy);
+    if (!from || !to) return [];
+    return [{ type: 'document_superseded_by', from, to, metadata: { reason: row.supersededReason, at: row.supersededAt } }];
+  });
+}
+
+function traceRelationships(rows: ExportRecord[]): GraphRelationship[] {
+  const out: GraphRelationship[] = [];
+  for (const row of rows) {
+    const traceId = text(row.traceId);
+    if (!traceId) continue;
+    const parent = text(row.parentTraceId);
+    const prev = text(row.prevTraceId);
+    const next = text(row.nextTraceId);
+    if (parent) out.push({ type: 'trace_parent', from: traceId, to: parent });
+    if (prev) out.push({ type: 'trace_prev', from: traceId, to: prev });
+    if (next) out.push({ type: 'trace_next', from: traceId, to: next });
+    for (const child of childTraceIds(row.childTraceIds)) out.push({ type: 'trace_child', from: traceId, to: child });
+  }
+  return out;
+}
+
+function childTraceIds(value: unknown): string[] {
+  if (Array.isArray(value)) return value.filter((item): item is string => typeof item === 'string');
+  if (typeof value !== 'string') return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : [];
+  } catch {
+    return [];
+  }
+}

--- a/tools/export-app/formats.ts
+++ b/tools/export-app/formats.ts
@@ -1,0 +1,73 @@
+import { exportFormatInfo } from '../../src/vector/export-formats.ts';
+
+export type ExportRecord = Record<string, unknown>;
+
+export const EXPORT_FORMATS = ['json', 'csv', 'markdown'] as const;
+export type ExportFormat = typeof EXPORT_FORMATS[number];
+
+export function extensionFor(format: ExportFormat): string {
+  return exportFormatInfo(format)?.extension ?? (format === 'markdown' ? 'md' : format);
+}
+
+export function normalizeValue(value: unknown): unknown {
+  if (typeof value === 'bigint') return value.toString();
+  if (value instanceof Date) return value.toISOString();
+  if (value instanceof Uint8Array) return Array.from(value);
+  return value;
+}
+
+export function normalizeRecord(record: ExportRecord): ExportRecord {
+  return Object.fromEntries(Object.entries(record).map(([key, value]) => [key, normalizeValue(value)]));
+}
+
+export function normalizeRecords(records: ExportRecord[]): ExportRecord[] {
+  return records.map(normalizeRecord);
+}
+
+export function formatCollection(name: string, rows: ExportRecord[], format: ExportFormat): string {
+  if (format === 'json') return `${JSON.stringify({ collection: name, rowCount: rows.length, rows }, null, 2)}\n`;
+  if (format === 'csv') return toCsv(rows);
+  return toMarkdown(name, rows);
+}
+
+function allKeys(rows: ExportRecord[]): string[] {
+  const keys = new Set<string>();
+  for (const row of rows) for (const key of Object.keys(row)) keys.add(key);
+  return [...keys];
+}
+
+function csvCell(value: unknown): string {
+  if (value == null) return '';
+  const text = typeof value === 'object' ? JSON.stringify(value) : String(value);
+  return `"${text.replaceAll('"', '""')}"`;
+}
+
+function toCsv(rows: ExportRecord[]): string {
+  const keys = allKeys(rows);
+  if (keys.length === 0) return '\n';
+  return [
+    keys.map(csvCell).join(','),
+    ...rows.map((row) => keys.map((key) => csvCell(row[key])).join(',')),
+  ].join('\n') + '\n';
+}
+
+function printable(value: unknown): string {
+  if (value == null) return '';
+  if (typeof value === 'object') return `\`${JSON.stringify(value)}\``;
+  return String(value);
+}
+
+function rowTitle(row: ExportRecord, index: number): string {
+  const id = row.id ?? row.traceId ?? row.path ?? row.key;
+  return id == null ? `row-${index + 1}` : String(id);
+}
+
+function toMarkdown(name: string, rows: ExportRecord[]): string {
+  const lines = [`# ${name}`, '', `Rows: ${rows.length}`, ''];
+  rows.forEach((row, index) => {
+    lines.push(`## ${rowTitle(row, index)}`, '');
+    for (const [key, value] of Object.entries(row)) lines.push(`- **${key}**: ${printable(value)}`);
+    lines.push('');
+  });
+  return lines.join('\n');
+}

--- a/tools/export-app/index.ts
+++ b/tools/export-app/index.ts
@@ -1,0 +1,57 @@
+import { exportOracleData } from './exporter.ts';
+
+type Writer = (message: string) => void;
+
+interface CliOptions {
+  outputDir: string;
+  dbPath?: string;
+}
+
+function readValue(args: string[], flag: string): string | undefined {
+  const index = args.indexOf(flag);
+  if (index >= 0) return args[index + 1];
+  const prefix = `${flag}=`;
+  return args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+}
+
+export function parseArgs(args: string[]): CliOptions {
+  const outputDir = readValue(args, '--output') ?? readValue(args, '-o');
+  if (!outputDir) throw new Error('missing required --output <dir>');
+  return { outputDir, dbPath: readValue(args, '--db') };
+}
+
+function printHelp(write: Writer): void {
+  write([
+    'bun run tools/export-app/index.ts --output ./backup/ [--db ./oracle.db]',
+    '',
+    'Exports all Drizzle-known Oracle collections as markdown, JSON, and CSV.',
+    'Also writes all-collections.json, graph relationships, and manifest.json.',
+    '',
+    'Flags:',
+    '  --output, -o <dir>   destination backup directory',
+    '  --db <path>          SQLite database path (defaults to ORACLE_DB_PATH)',
+    '  --help, -h           show this help',
+    '',
+  ].join('\n'));
+}
+
+export async function runExportApp(args: string[], stdout: Writer = process.stdout.write.bind(process.stdout), stderr: Writer = process.stderr.write.bind(process.stderr)): Promise<number> {
+  try {
+    if (args.includes('--help') || args.includes('-h')) {
+      printHelp(stdout);
+      return 0;
+    }
+    const options = parseArgs(args);
+    const result = await exportOracleData({ ...options, progress: (message) => stderr(`${message}\n`) });
+    stdout(`${JSON.stringify({ success: true, ...result }, null, 2)}\n`);
+    return 0;
+  } catch (error) {
+    stderr(`${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+if (import.meta.main) {
+  const code = await runExportApp(Bun.argv.slice(2));
+  process.exit(code);
+}


### PR DESCRIPTION
Closes #1783

## Changes
- Added standalone tools/export-app CLI for backups without starting the server
- Exports every Drizzle-known collection to JSON, CSV, and Markdown
- Writes graph relationships, all-collections.json, manifest.json, and progress output
- Reuses existing vector export format metadata for output extensions

## Test
- bunx tsc --noEmit: green
- bun test tests/tools/export-app/: green