### PR TITLE
fix: preserve Swagger docs content type

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -127,21 +127,6 @@ const app = new Elysia()
   .use(createBodyLimitMiddleware())
   .use(createApiKeyAuthMiddleware())
   .use(createMetricsLifecycle())
-  .use(createResponseFormatMiddleware())
-  .use(createCompressMiddleware())
-  .use(createEtagMiddleware())
-  .onBeforeHandle(({ request, set }) => {
-    const pathname = new URL(request.url).pathname;
-    if (isApiPathProtected(pathname) && !isApiAuthorized(request)) {
-      set.status = 401;
-      return unauthorizedApiResponse();
-    }
-  })
-  .onAfterHandle(({ set }) => {
-    set.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate';
-    set.headers['Referrer-Policy'] = 'strict-origin-when-cross-origin';
-  })
-  .use(createErrorMiddleware())
   .use(
     swagger({
       provider: 'swagger-ui',
@@ -157,6 +142,21 @@ const app = new Elysia()
       },
     }),
   )
+  .use(createResponseFormatMiddleware())
+  .use(createCompressMiddleware())
+  .use(createEtagMiddleware())
+  .onBeforeHandle(({ request, set }) => {
+    const pathname = new URL(request.url).pathname;
+    if (isApiPathProtected(pathname) && !isApiAuthorized(request)) {
+      set.status = 401;
+      return unauthorizedApiResponse();
+    }
+  })
+  .onAfterHandle(({ set }) => {
+    set.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate';
+    set.headers['Referrer-Policy'] = 'strict-origin-when-cross-origin';
+  })
+  .use(createErrorMiddleware())
   .use(gatewayPlugin(ORACLE_DATA_DIR, VECTOR_URL || undefined))
   .use(peerRoutes)
   .get('/swagger', () => Response.redirect('/api/docs', 308), { detail: { hide: true } })


### PR DESCRIPTION
## Summary
- move @elysiajs/swagger registration before the standard JSON response formatter
- preserve /api/docs as text/html while keeping API routes behind response formatting

## Validation
- bunx tsc --noEmit
- bun test tests/http/docs/ tests/http/swagger/
- src/server.ts is 250 lines