### PR TITLE
feat: canonicalize API v1 routing

### DIFF
--- a/src/middleware/api-version.ts
+++ b/src/middleware/api-version.ts
@@ -4,7 +4,6 @@ export const API_VERSION = 'v1';
 export const API_VERSION_HEADER = 'X-API-Version';
 const API_PREFIX = '/api';
 const VERSIONED_PREFIX = `${API_PREFIX}/${API_VERSION}`;
-const UNVERSIONED_INFRASTRUCTURE_PATHS = new Set(['/api/health', '/api/ready']);
 const publicPaths = new WeakMap<Request, string>();
 
 type FetchHandler = (request: Request) => Response | Promise<Response>;
@@ -23,10 +22,6 @@ function isVersionedApiPath(pathname: string): boolean {
   return pathname === VERSIONED_PREFIX || pathname.startsWith(`${VERSIONED_PREFIX}/`);
 }
 
-function isUnversionedInfrastructurePath(pathname: string): boolean {
-  return UNVERSIONED_INFRASTRUCTURE_PATHS.has(pathname);
-}
-
 export function apiRequestPath(request: Request): string {
   return publicPaths.get(request) ?? new URL(request.url).pathname;
 }
@@ -36,7 +31,6 @@ function versionedLocation(request: Request): string | null {
   if (
     !isApiPath(url.pathname)
     || isVersionedApiPath(url.pathname)
-    || isUnversionedInfrastructurePath(url.pathname)
   ) return null;
   const suffix = url.pathname.slice(API_PREFIX.length);
   url.pathname = `${VERSIONED_PREFIX}${suffix}`;

--- a/tests/http/docs/swagger-ui.test.ts
+++ b/tests/http/docs/swagger-ui.test.ts
@@ -7,7 +7,7 @@ import { createServer } from 'node:net';
 const REPO_ROOT = new URL('../../../', import.meta.url).pathname.replace(/\/$/, '');
 
 describe('GET /api/docs', () => {
-  test('serves interactive Swagger UI HTML', async () => {
+  test('redirects legacy docs path to canonical API version', async () => {
     const scratch = mkdtempSync(join(tmpdir(), 'arra-docs-test-'));
     const port = String(await freePort());
     const proc = Bun.spawn(['bun', 'src/server.ts'], {
@@ -28,12 +28,10 @@ describe('GET /api/docs', () => {
     });
 
     try {
-      const response = await waitForOk(`http://127.0.0.1:${port}/api/docs`);
-      const html = await response.text();
+      const response = await waitForOk(`http://127.0.0.1:${port}/api/docs`, 'manual');
 
-      expect(response.headers.get('content-type')).toContain('text/html');
-      expect(html).toContain('SwaggerUIBundle');
-      expect(html).toContain('/api/docs/json');
+      expect(response.status).toBe(308);
+      expect(response.headers.get('location')).toBe(`http://127.0.0.1:${port}/api/v1/docs`);
     } finally {
       proc.kill('SIGTERM');
       await Promise.race([proc.exited, Bun.sleep(3000)]);
@@ -42,12 +40,12 @@ describe('GET /api/docs', () => {
   }, 30_000);
 });
 
-async function waitForOk(url: string): Promise<Response> {
+async function waitForOk(url: string, redirect: RequestRedirect = 'follow'): Promise<Response> {
   const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
     try {
-      const response = await fetch(url);
-      if (response.ok) return response;
+      const response = await fetch(url, { redirect });
+      if (response.ok || response.status === 308) return response;
     } catch {}
     await Bun.sleep(200);
   }

--- a/tests/http/health/core-hardening.test.ts
+++ b/tests/http/health/core-hardening.test.ts
@@ -37,7 +37,7 @@ function pluginDir(name: string, entry: string) {
   return dir;
 }
 
-test('core hardening keeps health direct, logs configurable, and rejects escaping plugin entries', async () => {
+test('core hardening keeps versioned health reachable, logs configurable, and rejects escaping plugin entries', async () => {
   const oldFormat = process.env.LOG_FORMAT;
   process.env.LOG_FORMAT = 'short';
   const lines: string[] = [];
@@ -50,7 +50,7 @@ test('core hardening keeps health direct, logs configurable, and rejects escapin
   const fetcher = createApiVersionedFetch((request) => app.handle(request));
 
   try {
-    const res = await fetcher(new Request('http://local/api/health'));
+    const res = await fetcher(new Request('http://local/api/v1/health'));
     const body = await res.json() as Record<string, unknown>;
     expect(res.status).toBe(200);
     expect(res.headers.get('location')).toBeNull();

--- a/tests/http/health/unversioned.test.ts
+++ b/tests/http/health/unversioned.test.ts
@@ -17,13 +17,11 @@ function createFetch() {
   return createApiVersionedFetch((request) => app.handle(request));
 }
 
-test('GET /api/health returns ok directly without a version redirect', async () => {
+test('GET /api/health redirects to the canonical versioned health route', async () => {
   const res = await createFetch()(new Request('http://local/api/health'));
-  const body = await res.json() as { status: string };
 
-  expect(res.status).toBe(200);
-  expect(res.headers.get('location')).toBeNull();
-  expect(body.status).toBe('ok');
+  expect(res.status).toBe(308);
+  expect(res.headers.get('location')).toBe('http://local/api/v1/health');
 });
 
 test('GET /api/v1/health still rewrites to the health route', async () => {

--- a/tests/http/versioning/prefix.test.ts
+++ b/tests/http/versioning/prefix.test.ts
@@ -10,6 +10,8 @@ test('API routes are served under /api/v1 and legacy /api paths redirect', async
   const app = new Elysia()
     .use(createApiVersionHeaderMiddleware())
     .get('/api/search', () => ({ status: 'ok' }))
+    .get('/api/health', () => ({ status: 'ok' }))
+    .post('/api/thread', () => ({ created: true }))
     .get('/public', () => ({ public: true }));
   const fetchVersioned = createApiVersionedFetch((request) => app.handle(request));
 
@@ -22,6 +24,18 @@ test('API routes are served under /api/v1 and legacy /api paths redirect', async
   expect(legacy.status).toBe(308);
   expect(legacy.headers.get('location')).toBe('http://local/api/v1/search?probe=1');
   expect(legacy.headers.get(API_VERSION_HEADER)).toBe('v1');
+
+  const health = await fetchVersioned(new Request('http://local/api/health'));
+  expect(health.status).toBe(308);
+  expect(health.headers.get('location')).toBe('http://local/api/v1/health');
+
+  const apiRoot = await fetchVersioned(new Request('http://local/api'));
+  expect(apiRoot.status).toBe(308);
+  expect(apiRoot.headers.get('location')).toBe('http://local/api/v1');
+
+  const legacyPost = await fetchVersioned(new Request('http://local/api/thread', { method: 'POST' }));
+  expect(legacyPost.status).toBe(308);
+  expect(legacyPost.headers.get('location')).toBe('http://local/api/v1/thread');
 
   const publicRoute = await fetchVersioned(new Request('http://local/public'));
   expect(publicRoute.status).toBe(200);


### PR DESCRIPTION
## Summary\n- make every legacy /api request redirect to canonical /api/v1 paths\n- keep /api/v1 requests served by rewriting them to existing route handlers\n- expand versioning coverage for health, API root, POST routes, docs redirects, and existing HTTP route suites\n\n## Verification\n- bun test tests/http/\n- bunx tsc --noEmit