### PR TITLE
test: lock malformed learn JSON contract (#1718)

### DIFF
--- a/tests/http/knowledge.test.ts
+++ b/tests/http/knowledge.test.ts
@@ -1,8 +1,3 @@
-/**
- * HTTP Contract Tests — search, knowledge (learn/handoff/inbox), supersede.
- * Covers src/routes/{search,knowledge,supersede}.ts. Seeds via POST /api/learn,
- * reuses an already-running server on BASE_URL or spawns src/server.ts.
- */
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import type { Subprocess } from "bun";
 import fs from "fs";
@@ -79,12 +74,12 @@ describe("HTTP Contract — search / knowledge / supersede", () => {
       expect((await res.json()).error).toMatch(/pattern/i);
     });
 
-    test("rejects malformed JSON body", async () => {
+    test("rejects malformed JSON body as 400, not 500", async () => {
       const res = await fetch(`${BASE_URL}/api/learn`, { method: "POST", headers: JSON_HEADERS, body: "{not json" });
       const body = await res.json();
       expect(res.status).toBe(400);
       expect(res.headers.get("content-type")).toContain("application/json");
-      expect(body).toMatchObject({ error: "Bad Request", code: 400 });
+      expect(body).toMatchObject({ success: false, error: "Bad Request", code: 400 });
     });
   });
 

--- a/tests/http/learn/crud.test.ts
+++ b/tests/http/learn/crud.test.ts
@@ -59,7 +59,7 @@ afterAll(() => {
 });
 
 describe('POST/GET/PUT/DELETE /api/learn', () => {
-  test('rejects malformed JSON body with bad request status', async () => {
+  test('rejects malformed JSON body as 400, not 500', async () => {
     const res = await app().handle(new Request('http://local/api/learn', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -67,7 +67,7 @@ describe('POST/GET/PUT/DELETE /api/learn', () => {
     }));
     expect(res.status).toBe(400);
     expect(res.headers.get('content-type')).toContain('application/json');
-    expect(await res.json()).toMatchObject({ error: 'Bad Request', code: 400 });
+    expect(await res.json()).toMatchObject({ success: false, error: 'Bad Request', code: 400 });
   });
 
   test('rejects malformed JSON on versioned route with 400 contract', async () => {
@@ -78,7 +78,7 @@ describe('POST/GET/PUT/DELETE /api/learn', () => {
     }));
     expect(res.status).toBe(400);
     expect(res.headers.get('content-type')).toContain('application/json');
-    expect(await res.json()).toMatchObject({ error: 'Bad Request', code: 400 });
+    expect(await res.json()).toMatchObject({ success: false, error: 'Bad Request', code: 400 });
   });
 
   test('creates, reads, updates, and soft-deletes a learning through Drizzle rows', async () => {


### PR DESCRIPTION
Closes #1718

## Changes
- Clarify `/api/learn` malformed JSON should return 400 Bad Request, not 500
- Assert the shared error body shape includes `success:false`, `error`, and `code`
- Cover direct, versioned, and spawned HTTP learn routes

## Test
- bunx tsc --noEmit: green
- bun test tests/http/learn/: passed
- bun test tests/http/learn/ tests/http/knowledge.test.ts: passed