### PR TITLE
Harden CORS configuration

### DIFF
--- a/docs/MIDDLEWARE.md
+++ b/docs/MIDDLEWARE.md
@@ -25,10 +25,12 @@ Keep this order stable unless a middleware explicitly needs to run earlier for s
    - Config: none. Accepts inbound `X-Request-Id` / `x-correlation-id` only when needed by helpers.
 3. `createPrivateNetworkPreflightMiddleware` (`src/middleware/cors.ts`)
    - Handles Private Network Access preflight before route/auth work.
-   - Config: `ARRA_CORS_ORIGINS` (default `*`).
+   - Config: `ARRA_CORS_ORIGINS` (or legacy `ORACLE_CORS_ORIGIN` / `CORS_ORIGIN`);
+     defaults to explicit local development origins, not `*`.
 4. `createCorsMiddleware` (`src/middleware/cors.ts`)
    - Handles normal CORS preflight and response CORS headers.
-   - Config: `ARRA_CORS_ORIGINS` (default `*`).
+   - Config: `ARRA_CORS_ORIGINS` (or legacy `ORACLE_CORS_ORIGIN` / `CORS_ORIGIN`);
+     defaults to explicit local development origins, not `*`.
 5. `createApiVersionHeaderMiddleware` (`src/middleware/api-version.ts`)
    - Adds `X-API-Version: v1` to responses and errors.
    - Config: none.

--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -1,26 +1,60 @@
 import { Elysia } from 'elysia';
 
-const DEFAULT_ORIGINS = '*';
-const DEFAULT_METHODS = 'GET,POST,PUT,PATCH,DELETE,OPTIONS';
-const DEFAULT_HEADERS = 'content-type,authorization,x-requested-with,x-correlation-id';
+const DEFAULT_ORIGINS = [
+  'http://localhost:3000',
+  'http://127.0.0.1:3000',
+  'http://localhost:4321',
+  'http://127.0.0.1:4321',
+] as const;
+const ALLOWED_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'] as const;
+const ALLOWED_HEADERS = [
+  'authorization',
+  'content-type',
+  'x-correlation-id',
+  'x-request-id',
+  'x-requested-with',
+  'x-tenant-id',
+] as const;
 const MAX_AGE_SECONDS = '86400';
 
 export interface CorsPolicy {
-  wildcard: boolean;
+  wildcard: false;
   origins: string[];
 }
 
-export function parseCorsOrigins(value = process.env.ARRA_CORS_ORIGINS): CorsPolicy {
-  const raw = value?.trim() || DEFAULT_ORIGINS;
-  const origins = raw.split(',').map(origin => origin.trim()).filter(Boolean);
+function configuredOrigins(): string | undefined {
+  return process.env.ARRA_CORS_ORIGINS
+    ?? process.env.ORACLE_CORS_ORIGIN
+    ?? process.env.CORS_ORIGIN;
+}
+
+function splitCsv(value: string): string[] {
+  return value.split(',').map((item) => item.trim()).filter(Boolean);
+}
+
+function allowedRequestHeaders(request: Request): string[] | null {
+  const requested = request.headers.get('access-control-request-headers');
+  if (!requested) return [...ALLOWED_HEADERS];
+  const headers = splitCsv(requested).map((header) => header.toLowerCase());
+  const allowed = new Set<string>(ALLOWED_HEADERS);
+  return headers.every((header) => allowed.has(header)) ? headers : null;
+}
+
+function allowsRequestMethod(request: Request): boolean {
+  const requested = request.headers.get('access-control-request-method');
+  if (!requested) return true;
+  return ALLOWED_METHODS.includes(requested.toUpperCase() as typeof ALLOWED_METHODS[number]);
+}
+
+export function parseCorsOrigins(value = configuredOrigins()): CorsPolicy {
+  const origins = value?.trim() ? splitCsv(value) : [...DEFAULT_ORIGINS];
   return {
-    wildcard: origins.length === 0 || origins.includes('*'),
-    origins: origins.filter(origin => origin !== '*'),
+    wildcard: false,
+    origins: origins.filter((origin) => origin !== '*'),
   };
 }
 
 export function allowedCorsOrigin(origin: string | null | undefined, policy = parseCorsOrigins()): string | null {
-  if (policy.wildcard) return '*';
   if (!origin) return null;
   return policy.origins.includes(origin) ? origin : null;
 }
@@ -29,7 +63,7 @@ type MutableHeaders = Record<string, string | number | string[]>;
 
 function appendVary(headers: MutableHeaders, value: string): void {
   const current = headers.Vary ?? headers.vary;
-  const currentValue = Array.isArray(current) ? current.join(', ') : String(current);
+  const currentValue = current == null ? '' : Array.isArray(current) ? current.join(', ') : String(current);
   if (!currentValue) {
     headers.Vary = value;
     return;
@@ -44,15 +78,14 @@ function applyCorsHeaders(
   policy: CorsPolicy,
 ): boolean {
   const origin = allowedCorsOrigin(request.headers.get('origin'), policy);
-  if (!origin) return false;
+  const allowedHeaders = allowedRequestHeaders(request);
+  if (!origin || !allowedHeaders || !allowsRequestMethod(request)) return false;
 
   headers['Access-Control-Allow-Origin'] = origin;
-  headers['Access-Control-Allow-Methods'] = DEFAULT_METHODS;
-  headers['Access-Control-Allow-Headers'] = request.headers.get('access-control-request-headers') ?? DEFAULT_HEADERS;
-  if (origin !== '*') {
-    headers['Access-Control-Allow-Credentials'] = 'true';
-    appendVary(headers, 'Origin');
-  }
+  headers['Access-Control-Allow-Methods'] = ALLOWED_METHODS.join(',');
+  headers['Access-Control-Allow-Headers'] = allowedHeaders.join(',');
+  headers['Access-Control-Allow-Credentials'] = 'true';
+  appendVary(headers, 'Origin');
   return true;
 }
 

--- a/src/vector-server.ts
+++ b/src/vector-server.ts
@@ -12,9 +12,9 @@
  */
 
 import { Elysia } from 'elysia';
-import { cors } from '@elysiajs/cors';
 import { swagger } from '@elysiajs/swagger';
 
+import { createCorsMiddleware } from './middleware/cors.ts';
 import { loadVectorConfig, generateDefaultConfig } from './vector/config.ts';
 import { vectorRoutes } from './routes/vector/index.ts';
 
@@ -26,7 +26,7 @@ const PORT = Number(process.env.VECTOR_PORT ?? config.port);
 
 // ── App ─────────────────────────────────────────────────────────────
 const app = new Elysia()
-  .use(cors())                           // permissive — internal sidecar
+  .use(createCorsMiddleware())
   .use(
     swagger({
       path: '/swagger',

--- a/tests/http/cors/origins.test.ts
+++ b/tests/http/cors/origins.test.ts
@@ -21,15 +21,17 @@ function request(path: string, init?: RequestInit) {
 }
 
 describe('CORS middleware origins', () => {
-  test('uses wildcard Access-Control-Allow-Origin by default', async () => {
+  test('uses explicit local development origins by default', async () => {
     delete process.env.ARRA_CORS_ORIGINS;
 
-    const res = await request('/api/ping', { headers: { origin: 'https://any.example' } });
+    const allowed = await request('/api/ping', { headers: { origin: 'http://localhost:3000' } });
+    const denied = await request('/api/ping', { headers: { origin: 'https://any.example' } });
 
-    expect(res.status).toBe(200);
-    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*');
-    expect(res.headers.get('Access-Control-Allow-Methods')).toContain('GET');
-    expect(res.headers.get('Access-Control-Allow-Credentials')).toBeNull();
+    expect(allowed.status).toBe(200);
+    expect(allowed.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:3000');
+    expect(allowed.headers.get('Access-Control-Allow-Methods')).toContain('GET');
+    expect(allowed.headers.get('Access-Control-Allow-Credentials')).toBe('true');
+    expect(denied.headers.get('Access-Control-Allow-Origin')).toBeNull();
   });
 
   test('reflects configured origins and rejects unlisted origins', async () => {
@@ -44,7 +46,16 @@ describe('CORS middleware origins', () => {
     expect(denied.headers.get('Access-Control-Allow-Origin')).toBeNull();
   });
 
-  test('answers preflight OPTIONS with allowed methods and requested headers', async () => {
+  test('rejects wildcard configured origins', async () => {
+    process.env.ARRA_CORS_ORIGINS = '*';
+
+    const res = await request('/api/ping', { headers: { origin: 'https://studio.example' } });
+
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull();
+    expect(res.headers.get('Access-Control-Allow-Credentials')).toBeNull();
+  });
+
+  test('answers preflight OPTIONS with restricted methods and headers', async () => {
     process.env.ARRA_CORS_ORIGINS = 'https://studio.example';
 
     const res = await request('/api/ping', {
@@ -52,14 +63,38 @@ describe('CORS middleware origins', () => {
       headers: {
         origin: 'https://studio.example',
         'access-control-request-method': 'POST',
-        'access-control-request-headers': 'authorization,x-test',
+        'access-control-request-headers': 'authorization,content-type',
       },
     });
 
     expect(res.status).toBe(204);
     expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://studio.example');
     expect(res.headers.get('Access-Control-Allow-Methods')).toContain('POST');
-    expect(res.headers.get('Access-Control-Allow-Headers')).toBe('authorization,x-test');
+    expect(res.headers.get('Access-Control-Allow-Headers')).toBe('authorization,content-type');
     expect(res.headers.get('Access-Control-Max-Age')).toBe('86400');
+  });
+
+  test('denies preflight for disallowed methods or headers', async () => {
+    process.env.ARRA_CORS_ORIGINS = 'https://studio.example';
+
+    const trace = await request('/api/ping', {
+      method: 'OPTIONS',
+      headers: {
+        origin: 'https://studio.example',
+        'access-control-request-method': 'TRACE',
+      },
+    });
+    const unsafeHeader = await request('/api/ping', {
+      method: 'OPTIONS',
+      headers: {
+        origin: 'https://studio.example',
+        'access-control-request-method': 'POST',
+        'access-control-request-headers': 'authorization,x-unsafe',
+      },
+    });
+
+    expect(trace.status).toBe(204);
+    expect(trace.headers.get('Access-Control-Allow-Origin')).toBeNull();
+    expect(unsafeHeader.headers.get('Access-Control-Allow-Origin')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- replace wildcard CORS default with explicit local development origins
- reject configured `*` origins and deny preflight for disallowed methods or headers
- keep credentials only on matched explicit origins and reuse hardened middleware for vector sidecar
- update middleware docs for CORS env aliases/defaults

## Tests
- bunx tsc --noEmit
- bun test tests/http/cors/ tests/http/security/auth-and-cors.test.ts

## Notes
- PR targets alpha; no main changes.
- Changed files are ≤250 lines.
