### PR TITLE
feat: vector-config CLI parity (#1596)

### DIFF
--- a/src/plugins/__tests__/arra-plugin.test.ts
+++ b/src/plugins/__tests__/arra-plugin.test.ts
@@ -107,27 +107,51 @@ describe("built-in arra plugin", () => {
     }
   });
 
-  test("delegates maw arra vector-config to the vector config CLI", async () => {
+  test("delegates maw arra vector-config read and write commands", async () => {
     const { arraCli } = await import("../arra/index.ts");
+    const calls: Array<{ method: string; path: string; body?: any }> = [];
     const state = {
       source: "file",
-      config: { collections: { phase1: { collection: "phase1_collection", model: "bge-m3", provider: "none", adapter: "lancedb" } } },
+      config: {
+        dataPath: "/tmp/lancedb",
+        collections: {
+          phase1: { collection: "phase1_collection", model: "bge-m3", provider: "none", adapter: "lancedb", primary: true },
+        },
+      },
       doc_counts: { phase1: 3 },
       health: { phase1: { ok: true, status: "ok", collection: "phase1_collection", adapter: "lancedb" } },
     };
     const server = Bun.serve({
       port: 0,
-      fetch(req) {
-        if (new URL(req.url).pathname === "/api/v1/vector/config") return Response.json(state);
+      async fetch(req) {
+        const url = new URL(req.url);
+        calls.push({ method: req.method, path: url.pathname, body: req.body ? await req.json() : undefined });
+        if (url.pathname === "/api/v1/vector/config" && req.method === "GET") return Response.json(state);
+        if (url.pathname.startsWith("/api/v1/vector/config/")) return Response.json({ success: true, collection: "phase1" });
+        if (url.pathname === "/api/v1/vector/config/reload") return Response.json({ success: true, reloaded: true });
         return Response.json({ error: "not found" }, { status: 404 });
       },
     });
     const saved = process.env.ORACLE_API;
     process.env.ORACLE_API = String(server.url);
     try {
-      const result = await arraCli({ source: "cli", plugin: "arra", args: ["vector-config", "list", "--json"] });
-      const payload = JSON.parse(result.output!);
-      expect(payload.collections[0]).toMatchObject({ key: "phase1", docs: 3, status: "ok" });
+      const table = await arraCli({ source: "cli", plugin: "arra", args: ["vector-config"] });
+      expect(table.output).toContain("Collection | Adapter | Model | Enabled | Docs | Status");
+      expect(table.output).toContain("phase1_collection ★ | lancedb | bge-m3 | true | 3 | ok");
+
+      const raw = await arraCli({ source: "cli", plugin: "arra", args: ["vector-config", "list", "--json"] });
+      expect(JSON.parse(raw.output!).collections[0]).toMatchObject({ key: "phase1", docs: 3, status: "ok" });
+
+      const set = await arraCli({ source: "cli", plugin: "arra", args: ["vector-config", "set", "phase1", "adapter", "qdrant", "--url", "http://localhost:6333"] });
+      expect(set.ok).toBe(true);
+      expect(calls.at(-1)).toMatchObject({ method: "PUT", path: "/api/v1/vector/config/phase1", body: { adapter: "qdrant", endpoint: "http://localhost:6333" } });
+
+      const blocked = await arraCli({ source: "cli", plugin: "arra", args: ["vector-config", "remove", "phase1"] });
+      expect(blocked).toEqual({ ok: false, error: "remove requires --yes" });
+
+      const removed = await arraCli({ source: "cli", plugin: "arra", args: ["vector-config", "remove", "phase1", "--yes"] });
+      expect(removed.ok).toBe(true);
+      expect(calls.at(-1)).toMatchObject({ method: "DELETE", path: "/api/v1/vector/config/phase1" });
     } finally {
       if (saved === undefined) delete process.env.ORACLE_API;
       else process.env.ORACLE_API = saved;

--- a/src/plugins/arra/vector-config-cli.ts
+++ b/src/plugins/arra/vector-config-cli.ts
@@ -11,6 +11,12 @@ function apiBase(): string {
 function json(data: unknown): string {
   return JSON.stringify(data, null, 2);
 }
+function wantsJson(args: string[]): boolean {
+  return args.includes("--json");
+}
+function compact(value: unknown): string {
+  return String(value ?? "").replace(/\s+/g, " ").trim();
+}
 function bool(value: string | undefined): boolean {
   if (value === "true") return true;
   if (value === "false") return false;
@@ -66,6 +72,31 @@ function rows(payload: any) {
   }));
 }
 
+function formatTable(payload: any): string {
+  const lines = ["Collection | Adapter | Model | Enabled | Docs | Status"];
+  for (const row of rows(payload)) {
+    const mark = row.primary ? " ★" : "";
+    lines.push(`${row.collection ?? row.key}${mark} | ${row.adapter ?? "lancedb"} | ${row.model ?? row.key} | ${row.enabled} | ${row.docs} | ${row.status}`);
+  }
+  if (lines.length === 1) lines.push("(none) | - | - | true | 0 | unknown");
+  const embedder = payload.config?.embedder ? `Embedder: ${compact(JSON.stringify(payload.config.embedder))}` : undefined;
+  const data = payload.config?.dataPath ? `Data: ${payload.config.dataPath}` : undefined;
+  return [lines.join("\n"), "★ = primary", embedder, data].filter(Boolean).join("\n");
+}
+
+function formatCollection(payload: any, key: string): string {
+  const row = rows(payload).find((item) => item.key === key) ?? {};
+  return [
+    `collection: ${(row as any).collection ?? key}`,
+    `key: ${key}`,
+    `adapter: ${(row as any).adapter ?? "lancedb"}`,
+    `model: ${(row as any).model ?? key}`,
+    `enabled: ${(row as any).enabled ?? true}`,
+    `docs: ${(row as any).docs ?? 0}`,
+    `status: ${(row as any).status ?? "unknown"}`,
+  ].join("\n");
+}
+
 function fieldPayload(args: string[]): Record<string, unknown> {
   const rest = clean(args);
   const payload: Record<string, unknown> = {};
@@ -96,12 +127,11 @@ async function readOne(sub: string, rest: string[]): Promise<CliResult> {
   const collection =
     sub === "get"
       ? requireArg(rest[0], "usage: vector-config get <collection>")
-      : rest[0];
-  if (!collection)
-    return {
-      ok: true,
-      output: json({ source: payload.source, collections: rows(payload) }),
-    };
+      : rest.find((arg) => !arg.startsWith("--"));
+  if (!collection) {
+    const body = { source: payload.source, collections: rows(payload) };
+    return { ok: true, output: wantsJson(rest) ? json(body) : formatTable(payload) };
+  }
   const key = resolveKey(payload, collection);
   if (!key) throw new Error(`unknown collection: ${collection}`);
   const row = rows(payload).find((item) => item.key === key) ?? {};
@@ -115,7 +145,7 @@ async function readOne(sub: string, rest: string[]): Promise<CliResult> {
           health: payload.health?.[key],
         }
       : { source: payload.source, ...(row as object) };
-  return { ok: true, output: json(body) };
+  return { ok: true, output: wantsJson(rest) ? json(body) : formatCollection(payload, key) };
 }
 
 export async function vectorConfigCli(args: string[]): Promise<CliResult> {
@@ -124,14 +154,8 @@ export async function vectorConfigCli(args: string[]): Promise<CliResult> {
     const sub = raw.toLowerCase();
     if (sub === "list") {
       const payload = await request(VECTOR_ENDPOINT);
-      return {
-        ok: true,
-        output: json({
-          source: payload.source,
-          count: rows(payload).length,
-          collections: rows(payload),
-        }),
-      };
+      const body = { source: payload.source, count: rows(payload).length, collections: rows(payload) };
+      return { ok: true, output: wantsJson(rest) ? json(body) : formatTable(payload) };
     }
     if (sub === "stats" || sub === "get") return readOne(sub, rest);
     if (sub === "set")
@@ -156,7 +180,8 @@ export async function vectorConfigCli(args: string[]): Promise<CliResult> {
           ),
         ),
       };
-    if (sub === "remove" || sub === "rm")
+    if (sub === "remove" || sub === "rm") {
+      if (!rest.includes("--yes") && !rest.includes("-y")) throw new Error("remove requires --yes");
       return {
         ok: true,
         output: json(
@@ -166,6 +191,7 @@ export async function vectorConfigCli(args: string[]): Promise<CliResult> {
           ),
         ),
       };
+    }
     if (sub === "set-primary" || sub === "primary")
       return {
         ok: true,


### PR DESCRIPTION
Closes #1596

## Changes
- Improved maw-js ARRA vector-config CLI default read output with compact table and primary marker
- Preserved --json raw output for automation
- Added write-op coverage for set/remove and guarded remove behind --yes

## Test
- bunx tsc --noEmit: green
- bun test src/plugins/__tests__/arra-plugin.test.ts maw-plugin/__tests__/vector-config.test.ts tests/http/vector/config-api.test.ts: green