### PR TITLE
feat: align plugin UI registry surface

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -41,7 +41,7 @@ export async function fetchMenu(): Promise<MenuResponse> {
 }
 
 export async function fetchPlugins(): Promise<PluginsResponse> {
-  const data = await getJson<PluginsResponse>('/api/v1/plugins');
+  const data = await getJson<PluginsResponse>('/api/plugins');
   return {
     dir: typeof data.dir === 'string' ? data.dir : '',
     plugins: Array.isArray(data.plugins) ? data.plugins : [],

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -75,7 +75,7 @@ export interface ApiRouteResponses {
   '/api/vector/index/models': VectorIndexModelsResponse;
   '/api/vector/index/status': VectorIndexStatusResponse;
   '/api/vector/health': VectorHealthResponse;
-  '/api/v1/plugins': PluginsResponse;
+  '/api/plugins': PluginsResponse;
   '/api/v1/learn': LearnListResponse;
 }
 
@@ -168,7 +168,7 @@ export class ApiClient {
   }
 
   plugins(): Promise<PluginsResponse> {
-    return this.request('/api/v1/plugins');
+    return this.request('/api/plugins');
   }
 
   learn(): Promise<LearnListResponse> {

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -110,7 +110,7 @@ export function AppShell({
 
           <section className="grid gap-3 sm:grid-cols-2 sm:gap-4 xl:grid-cols-5" aria-label="Summary">
             <StatCard label="Menu items" value={loading ? <Spinner label="Loading" /> : menuCount} detail="from /api/menu" />
-            <StatCard label="Plugins" value={loading ? <Spinner label="Loading" /> : pluginCount} detail="from /api/v1/plugins" />
+            <StatCard label="Plugins" value={loading ? <Spinner label="Loading" /> : pluginCount} detail="from /api/plugins" />
             <StatCard label="Surfaces" value={loading ? <Spinner label="Loading" /> : surfaceCount} detail={`updated ${updatedAt}`} />
             <StatCard label="Requests" value={requestValue} detail={metricsDetail} />
             <StatCard label="Avg response" value={responseValue} detail="real-time backend latency" />

--- a/frontend/src/components/PluginList.tsx
+++ b/frontend/src/components/PluginList.tsx
@@ -29,7 +29,7 @@ export function PluginList({
   enabledState?: PluginEnabledState;
   onToggle?: (name: string) => void;
 }) {
-  if (!plugins.length) return <EmptyState text="No plugins registered in /api/v1/plugins." />;
+  if (!plugins.length) return <EmptyState text="No plugins registered in /api/plugins." />;
 
   return (
     <div className="grid gap-4">

--- a/frontend/src/pages/PluginsPage.tsx
+++ b/frontend/src/pages/PluginsPage.tsx
@@ -213,11 +213,11 @@ export function PluginsPage({ plugins: initialPlugins = [], loading = true, clie
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Plugin admin</p>
             <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Plugin list</p>
             <h2 id="plugins-page-title" className="mt-2 text-2xl font-semibold text-white">Registered plugins</h2>
-            <p className="mt-2 text-sm text-slate-400">Canvas view for unified backend surfaces from GET /api/v1/plugins, with register/unregister controls.</p>
+            <p className="mt-2 text-sm text-slate-400">Canvas view for unified backend surfaces from GET /api/plugins, with register/unregister controls.</p>
           </div>
           <div className="flex flex-wrap gap-2"><p className="rounded-full border border-white/10 px-3 py-2 text-sm text-slate-300">{summary}</p><p className="rounded-full border border-white/10 px-3 py-2 text-sm text-slate-300">{surfaceCount} surfaces</p></div>
         </div>
-        {isLoading ? <LoadingPanel title="Loading plugins…" detail="Fetching /api/v1/plugins and plugin server manifests." /> : null}
+        {isLoading ? <LoadingPanel title="Loading plugins…" detail="Fetching /api/plugins and plugin server manifests." /> : null}
         {state === 'error' ? <ErrorMessage title="Could not load plugins." message={error} /> : null}
         {state !== 'error' && error ? <ErrorMessage title="Plugin action failed." message={error} /> : null}
         {actionMessage ? <p className="mt-3 text-sm text-amber-200">{actionMessage}</p> : null}

--- a/tests/frontend/api-client.test.ts
+++ b/tests/frontend/api-client.test.ts
@@ -43,7 +43,7 @@ describe('frontend API client', () => {
         docsPerSec: 2.5,
         eta: 3,
       },
-      '/api/v1/plugins': {
+      '/api/plugins': {
         dir: '/tmp/plugins',
         plugins: [{ name: 'echo', file: 'echo.wasm', size: 12, modified: '2026-06-16T00:00:00.000Z' }],
       },
@@ -73,7 +73,7 @@ describe('frontend API client', () => {
       '/api/v1/vector/search?q=oracle+memory&limit=5&type=docs',
       '/api/vector/index/models',
       '/api/vector/index/status',
-      '/api/v1/plugins',
+      '/api/plugins',
     ]);
     for (const call of calls) {
       expect(new Headers(call.init?.headers).get('accept')).toBe('application/json');
@@ -114,8 +114,8 @@ describe('frontend API client', () => {
     const invalidClient = createApiClient({ fetch: () => new Response('{nope', { status: 200 }) });
     await expect(invalidClient.plugins()).rejects.toMatchObject({
       status: 200,
-      path: '/api/v1/plugins',
-      message: '/api/v1/plugins returned invalid JSON',
+      path: '/api/plugins',
+      message: '/api/plugins returned invalid JSON',
     } as ApiClientError);
 
     const errorClient = createApiClient({ fetch: () => jsonResponse({ error: 'offline' }, { status: 503, statusText: 'Unavailable' }) });

--- a/tests/frontend/components/plugin-list-empty.test.tsx
+++ b/tests/frontend/components/plugin-list-empty.test.tsx
@@ -4,6 +4,6 @@ import { htmlFor } from '../_render';
 
 describe('PluginList empty state', () => {
   test('renders an empty state when no plugins are registered', () => {
-    expect(htmlFor(<PluginList plugins={[]} />)).toContain('No plugins registered in /api/v1/plugins.');
+    expect(htmlFor(<PluginList plugins={[]} />)).toContain('No plugins registered in /api/plugins.');
   });
 });

--- a/tests/frontend/pages/plugins-page-admin.test.tsx
+++ b/tests/frontend/pages/plugins-page-admin.test.tsx
@@ -8,7 +8,7 @@ describe('PluginsPage admin view', () => {
     const html = htmlFor(<PluginsPage plugins={plugins} loading={false} />);
 
     expect(pluginAdminSummary(plugins, enabledStateForPlugins(plugins))).toBe('1 enabled · 0 disabled · 1 registered');
-    expect(html).toContain('GET /api/v1/plugins');
+    expect(html).toContain('GET /api/plugins');
     expect(html).toContain('canvas');
     expect(html).toContain('1.2.3');
     expect(html).toContain('ok');


### PR DESCRIPTION
## Summary
- point frontend plugin registry reads at the canonical /api/plugins backend surface
- update plugin admin, app shell, and empty-state copy to match #1484 acceptance text
- keep typed API client and plugin page tests aligned with the unified-plugin backend contract

## Validation
- bunx tsc --noEmit
- bun test tests/frontend/api-client.test.ts tests/frontend/pages/plugins-page-admin.test.tsx tests/frontend/components/plugin-list-empty.test.tsx tests/frontend/components/plugin-list-surfaces.test.tsx tests/frontend/pages/unified-plugin-overview.test.tsx tests/frontend/pages/canvas-plugins-page.test.tsx tests/frontend/pages/frontend-component-coverage.test.tsx
- changed files <=250 lines

## Note
- Full tests/frontend run still has unrelated router-context failures in dashboard/search tests.