### PR TITLE
feat(plugin): add maw arra serve command

### DIFF
--- a/src/plugins/__tests__/arra-plugin.test.ts
+++ b/src/plugins/__tests__/arra-plugin.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Elysia } from "elysia";
 import { loadUnifiedPlugins } from "../unified-loader.ts";
 
 const pluginRoot = join(process.cwd(), "src/plugins");
-const ARRA_VERBS = ["help", "version", "menu", "status", "health", "vector-config"];
+const ARRA_VERBS = ["help", "version", "menu", "status", "health", "vector-config", "serve"];
 
 describe("built-in arra plugin", () => {
   test("declares modern maw-js CLI, menu, and HTTP surfaces", () => {
@@ -132,6 +133,41 @@ describe("built-in arra plugin", () => {
       if (saved === undefined) delete process.env.ORACLE_API;
       else process.env.ORACLE_API = saved;
       server.stop();
+    }
+  });
+
+  test("handles maw arra serve status without a running server", async () => {
+    const { arraCli } = await import("../arra/index.ts");
+    const savedDataDir = process.env.ORACLE_DATA_DIR;
+    process.env.ORACLE_DATA_DIR = mkdtempSync(join(tmpdir(), "arra-serve-status-"));
+    try {
+      const result = await arraCli({ source: "cli", plugin: "arra", args: ["serve", "--status", "--port", "59999"] });
+      expect(result.ok).toBe(true);
+      expect(result.output).toContain("Oracle server not running on http://127.0.0.1:59999");
+    } finally {
+      if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+      else process.env.ORACLE_DATA_DIR = savedDataDir;
+    }
+  });
+
+  test("maw arra serve starts server in background with requested port", async () => {
+    const { serveCli } = await import("../arra/serve-cli.ts");
+    const savedDataDir = process.env.ORACLE_DATA_DIR;
+    process.env.ORACLE_DATA_DIR = mkdtempSync(join(tmpdir(), "arra-serve-start-"));
+    const calls: unknown[] = [];
+    const spawn = ((cmd: string[], options: object) => {
+      calls.push({ cmd, options });
+      return { pid: 4242, unref() {} };
+    }) as typeof Bun.spawn;
+    try {
+      const result = await serveCli(["--port", "59998"], { spawn, fetch: async () => new Response("no", { status: 503 }) });
+      expect(result.ok).toBe(true);
+      expect(result.output).toContain("pid=4242");
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toMatchObject({ cmd: ["bun", "run", "server"] });
+    } finally {
+      if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+      else process.env.ORACLE_DATA_DIR = savedDataDir;
     }
   });
 });

--- a/src/plugins/arra/index.ts
+++ b/src/plugins/arra/index.ts
@@ -1,5 +1,6 @@
 import { vectorConfigCli } from "./vector-config-cli.ts";
 import { vectorHealthCli } from "./vector-health-cli.ts";
+import { serveCli } from "./serve-cli.ts";
 
 type ArraPluginConfig = {
   dbBackend?: "sqlite" | "http" | "memory" | "custom";
@@ -44,6 +45,7 @@ const VERBS: ArraVerb[] = [
   { name: "status", help: "Describe optional backend capabilities", menuPath: MENU_PATH, httpPath: HTTP_PATH, requiresEmbedder: false, storage: "swappable" },
   { name: "health", help: "Show server and vector engine health", menuPath: MENU_PATH, httpPath: "/api/health", requiresEmbedder: false, storage: "swappable" },
   { name: "vector-config", help: "Inspect and manage vector backend config", menuPath: MENU_PATH, httpPath: "/api/v1/vector/config", requiresEmbedder: false, storage: "swappable" },
+  { name: "serve", help: "Start, stop, or inspect the Oracle HTTP server", menuPath: MENU_PATH, httpPath: "/api/health", requiresEmbedder: false, storage: "swappable" },
 ];
 
 function commandName(ctx: ArraPluginContext): string {
@@ -86,6 +88,7 @@ async function renderCli(ctx: ArraPluginContext): Promise<CliResult> {
   }
   if (command === "health") return vectorHealthCli((ctx.args ?? []).slice(1).map(String));
   if (command === "vector-config") return vectorConfigCli((ctx.args ?? []).slice(1).map(String));
+  if (command === "serve") return serveCli((ctx.args ?? []).slice(1).map(String));
   if (command !== "help") return { ok: false, error: `unknown arra command: ${command}` };
   return { ok: true, output: ["maw arra <command>", ...VERBS.map((verb) => `  ${verb.name.padEnd(14)} ${verb.help}`)].join("\n") };
 }

--- a/src/plugins/arra/plugin.json
+++ b/src/plugins/arra/plugin.json
@@ -5,7 +5,7 @@
   "sdk": "^0.1.0",
   "enabled": true,
   "description": "ARRA Oracle V3 maw-js plugin surface for CLI, menu, and HTTP discovery.",
-  "verbs": ["help", "version", "menu", "status", "health", "vector-config"],
+  "verbs": ["help", "version", "menu", "status", "health", "vector-config", "serve"],
   "httpRoutes": [
     {
       "path": "/api/plugins/arra",
@@ -34,7 +34,7 @@
   ],
   "cli": {
     "command": "arra",
-    "help": "maw arra <help|version|menu|status|health|vector-config>",
+    "help": "maw arra <help|version|menu|status|health|vector-config|serve>",
     "handler": "arraCli"
   },
   "config": {

--- a/src/plugins/arra/serve-cli.ts
+++ b/src/plugins/arra/serve-cli.ts
@@ -1,0 +1,115 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { ORACLE_DATA_DIR_NAME, ORACLE_DEFAULT_PORT, PID_FILE_NAME } from '../../const.ts';
+import { configure, isProcessAlive, readPidFile, removePidFile, waitForProcessesExit, writePidFile } from '../../process-manager/index.ts';
+
+type CliResult = { ok: boolean; output?: string; error?: string };
+type ServeAction = 'start' | 'stop' | 'status';
+
+type ServeOptions = {
+  action: ServeAction;
+  port: number;
+  json: boolean;
+};
+
+type ServeDeps = {
+  spawn?: typeof Bun.spawn;
+  fetch?: typeof fetch;
+  cwd?: string;
+};
+
+const DEFAULT_HOST = '127.0.0.1';
+
+export async function serveCli(args: string[], deps: ServeDeps = {}): Promise<CliResult> {
+  const parsed = parseServeArgs(args);
+  if ('error' in parsed) return { ok: false, error: parsed.error };
+  configure({ dataDir: oracleDataDir(), pidFileName: PID_FILE_NAME });
+  if (parsed.action === 'status') return renderStatus(parsed, deps);
+  if (parsed.action === 'stop') return stopServer(parsed);
+  return startServer(parsed, deps);
+}
+
+function parseServeArgs(args: string[]): ServeOptions | { error: string } {
+  let action: ServeAction = 'start';
+  let port = Number(process.env.ORACLE_PORT || process.env.PORT || ORACLE_DEFAULT_PORT);
+  let json = false;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === 'start') action = 'start';
+    else if (arg === 'status' || arg === '--status') action = 'status';
+    else if (arg === 'stop' || arg === '--stop') action = 'stop';
+    else if (arg === '--json') json = true;
+    else if (arg === '--port') {
+      const value = Number(args[++i]);
+      if (!Number.isInteger(value) || value < 1 || value > 65_535) return { error: '--port must be an integer from 1 to 65535' };
+      port = value;
+    } else return { error: `unknown serve option: ${arg}` };
+  }
+  return { action, port, json };
+}
+
+async function renderStatus(options: ServeOptions, deps: ServeDeps): Promise<CliResult> {
+  const status = await serverStatus(options.port, deps.fetch);
+  if (options.json) return { ok: true, output: JSON.stringify(status, null, 2) };
+  if (!status.running) return { ok: true, output: `Oracle server not running on ${status.url}` };
+  const health = status.healthy ? 'healthy' : 'not healthy';
+  return { ok: true, output: `Oracle server running on ${status.url} (pid=${status.pid ?? 'unknown'}, ${health})` };
+}
+
+async function startServer(options: ServeOptions, deps: ServeDeps): Promise<CliResult> {
+  const status = await serverStatus(options.port, deps.fetch);
+  if (status.running) return { ok: true, output: `Oracle server already running on ${status.url} (pid=${status.pid ?? 'unknown'})` };
+  const child = (deps.spawn ?? Bun.spawn)(['bun', 'run', 'server'], {
+    cwd: deps.cwd ?? process.env.ORACLE_REPO_ROOT ?? process.cwd(),
+    detached: true,
+    stdio: ['ignore', 'ignore', 'ignore'],
+    env: { ...process.env, PORT: String(options.port), ORACLE_PORT: String(options.port) },
+  });
+  if (!child.pid) return { ok: false, error: 'failed to spawn Oracle server' };
+  child.unref?.();
+  writePidFile({ pid: child.pid, port: options.port, startedAt: new Date().toISOString(), name: 'oracle-http' });
+  return { ok: true, output: `Oracle server started on http://${DEFAULT_HOST}:${options.port} (pid=${child.pid})` };
+}
+
+async function stopServer(options: ServeOptions): Promise<CliResult> {
+  const info = readPidFile();
+  if (!info?.pid) return { ok: true, output: `Oracle server not running on http://${DEFAULT_HOST}:${options.port}` };
+  if (!isProcessAlive(info.pid)) {
+    removePidFile();
+    return { ok: true, output: `Removed stale PID file (pid=${info.pid})` };
+  }
+  try { process.kill(info.pid, 'SIGTERM'); } catch (error) {
+    return { ok: false, error: `Failed to stop server pid=${info.pid}: ${error instanceof Error ? error.message : String(error)}` };
+  }
+  const stopped = await waitForProcessesExit([info.pid], 5000);
+  if (stopped) removePidFile();
+  return stopped
+    ? { ok: true, output: `Stopped Oracle server (pid=${info.pid})` }
+    : { ok: false, error: `Timed out waiting for Oracle server to stop (pid=${info.pid})` };
+}
+
+async function serverStatus(port: number, fetcher: typeof fetch = fetch) {
+  const info = readPidFile();
+  const processAlive = info?.pid ? isProcessAlive(info.pid) : false;
+  const healthy = await isHealthy(port, fetcher);
+  return {
+    running: processAlive || healthy,
+    pid: info?.pid,
+    port,
+    healthy,
+    url: `http://${DEFAULT_HOST}:${port}`,
+  };
+}
+
+async function isHealthy(port: number, fetcher: typeof fetch): Promise<boolean> {
+  try {
+    const response = await fetcher(`http://${DEFAULT_HOST}:${port}/api/health`, { signal: AbortSignal.timeout(1200) });
+    if (!response.ok) return false;
+    const body = await response.json() as { status?: string };
+    return body.status === 'ok';
+  } catch { return false; }
+}
+
+function oracleDataDir(): string {
+  return process.env.ORACLE_DATA_DIR || join(homedir(), ORACLE_DATA_DIR_NAME);
+}


### PR DESCRIPTION
## Summary
- Adds `maw arra serve` to the built-in ARRA plugin manifest and CLI dispatcher.
- Supports `maw arra serve` start, `--status`, `--stop`, and `--port N`.
- Starts `bun run server` in the background and tracks the HTTP server PID file.

## Validation
- `bunx tsc --noEmit`
- `bun test src/plugins/__tests__/arra-plugin.test.ts`

## Notes
- Also attempted `bun test tests/`; it is not green on current alpha due unrelated existing failures in frontend/router/vector/trace/plugin-server suites.
