### PR TITLE
fix: honor proxy vector collection names

### DIFF
--- a/src/vector/adapters/proxy.ts
+++ b/src/vector/adapters/proxy.ts
@@ -94,13 +94,13 @@ export class ProxyVectorAdapter implements VectorStoreAdapter {
   }
 
   async getStats(): Promise<{ count: number }> {
-    const stats = await this.fetchJson<ProxyStatsResponse>('/vectors/stats');
-    return { count: stats?.count ?? 0 };
+    const stats = await this.proxyStats();
+    return { count: stats.count };
   }
 
   async getCollectionInfo(): Promise<{ count: number; name: string }> {
-    const all = await this.getStats();
-    return { name: this.collectionName, count: all.count };
+    const stats = await this.proxyStats();
+    return { name: stats.name || this.collectionName, count: stats.count };
   }
 
   async getAllEmbeddings(limit?: number): Promise<{
@@ -111,13 +111,17 @@ export class ProxyVectorAdapter implements VectorStoreAdapter {
   }> {
     // Not part of proxy protocol. Return empty to preserve compatibility
     // when callers can proceed without full embedding matrices.
-    const count = await this.getStats();
     return {
       ids: [],
       embeddings: [],
       metadatas: [],
       documents: [],
     };
+  }
+
+  private async proxyStats(): Promise<ProxyStatsResponse> {
+    const stats = await this.fetchJson<ProxyStatsResponse>('/vectors/stats');
+    return { count: stats?.count ?? 0, name: stats?.name || this.collectionName };
   }
 
   private async health(): Promise<ProxyHealthResponse> {

--- a/tests/http/vector/proxy-adapter.test.ts
+++ b/tests/http/vector/proxy-adapter.test.ts
@@ -13,7 +13,7 @@ const server = Bun.serve({
     const body = request.method === 'GET' || request.method === 'DELETE' ? undefined : await request.json();
     requests.push({ method: request.method, path: url.pathname, body });
     if (url.pathname === '/proxy/health') return Response.json({ status: 'ok', name: 'proxy-test', version: '1' });
-    if (url.pathname === '/proxy/vectors/stats') return Response.json({ count: 2, name: 'proxy_docs' });
+    if (url.pathname === '/proxy/vectors/stats') return Response.json({ count: 2, name: 'remote_proxy_docs' });
     if (url.pathname === '/proxy/vectors/add') return Response.json({ success: true });
     if (url.pathname === '/proxy/vectors/query') return Response.json({
       ids: ['doc-1'], documents: ['hello'], distances: [0.1], metadatas: [{ type: 'learning' }],
@@ -37,7 +37,7 @@ test('ProxyVectorAdapter speaks vector proxy protocol under endpoint path prefix
   await adapter.deleteCollection();
 
   expect(result.ids).toEqual(['doc-1']);
-  expect(info).toEqual({ name: 'proxy_docs', count: 2 });
+  expect(info).toEqual({ name: 'remote_proxy_docs', count: 2 });
   expect(requests.map((item) => `${item.method} ${item.path}`)).toEqual([
     'GET /proxy/health',
     'POST /proxy/vectors/add',


### PR DESCRIPTION
## Summary
- use /vectors/stats name from proxy protocol for ProxyVectorAdapter collection info
- keep count handling in a shared stats helper
- update proxy adapter test so remote collection identity is asserted independently from constructor config

## Validation
- bunx tsc --noEmit
- bun test tests/http/vector/
- changed files <=250 lines