### PR TITLE
fix: scope dashboard and supersede by tenant (#1650)

### DIFF
--- a/src/routes/supersede/chain.ts
+++ b/src/routes/supersede/chain.ts
@@ -3,18 +3,23 @@
  */
 
 import { Elysia } from 'elysia';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/sqlite-core';
 import { db, oracleDocuments } from '../../db/index.ts';
+import { currentTenantId } from '../../middleware/tenant.ts';
 
 export const supersedeChainEndpoint = new Elysia().get(
   '/supersede/chain/:path',
   ({ params }) => {
     const docPath = decodeURIComponent(params.path);
+    const tenantId = currentTenantId();
+    const targetWhere = tenantId
+      ? and(eq(oracleDocuments.sourceFile, docPath), eq(oracleDocuments.tenantId, tenantId))
+      : eq(oracleDocuments.sourceFile, docPath);
 
     const target = db.select({ id: oracleDocuments.id })
       .from(oracleDocuments)
-      .where(eq(oracleDocuments.sourceFile, docPath))
+      .where(targetWhere)
       .get();
 
     if (!target) {
@@ -23,14 +28,24 @@ export const supersedeChainEndpoint = new Elysia().get(
 
     const newDoc = alias(oracleDocuments, 'new_doc');
 
+    const newDocJoin = tenantId
+      ? and(eq(oracleDocuments.supersededBy, newDoc.id), eq(newDoc.tenantId, tenantId))
+      : eq(oracleDocuments.supersededBy, newDoc.id);
+    const oldWhere = tenantId
+      ? and(eq(oracleDocuments.id, target.id), eq(oracleDocuments.tenantId, tenantId))
+      : eq(oracleDocuments.id, target.id);
+    const newWhere = tenantId
+      ? and(eq(oracleDocuments.supersededBy, target.id), eq(oracleDocuments.tenantId, tenantId))
+      : eq(oracleDocuments.supersededBy, target.id);
+
     const asOld = db.select({
       newPath: newDoc.sourceFile,
       reason: oracleDocuments.supersededReason,
       supersededAt: oracleDocuments.supersededAt,
     })
       .from(oracleDocuments)
-      .leftJoin(newDoc, eq(oracleDocuments.supersededBy, newDoc.id))
-      .where(eq(oracleDocuments.id, target.id))
+      .leftJoin(newDoc, newDocJoin)
+      .where(oldWhere)
       .orderBy(oracleDocuments.supersededAt)
       .all()
       .filter(r => r.newPath !== null);
@@ -41,7 +56,7 @@ export const supersedeChainEndpoint = new Elysia().get(
       supersededAt: oracleDocuments.supersededAt,
     })
       .from(oracleDocuments)
-      .where(eq(oracleDocuments.supersededBy, target.id))
+      .where(newWhere)
       .orderBy(oracleDocuments.supersededAt)
       .all();
 

--- a/src/routes/supersede/list.ts
+++ b/src/routes/supersede/list.ts
@@ -7,6 +7,7 @@ import { eq, isNotNull, desc, sql, and } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/sqlite-core';
 import { db, oracleDocuments } from '../../db/index.ts';
 import { SupersedeQuery } from './model.ts';
+import { currentTenantId } from '../../middleware/tenant.ts';
 
 export const supersedeListEndpoint = new Elysia().get(
   '/supersede',
@@ -15,10 +16,11 @@ export const supersedeListEndpoint = new Elysia().get(
     const limit = parseInt(query.limit ?? '50');
     const offset = parseInt(query.offset ?? '0');
 
-    const projectFilter = project ? eq(oracleDocuments.project, project) : undefined;
-    const whereClause = projectFilter
-      ? and(isNotNull(oracleDocuments.supersededBy), projectFilter)
-      : isNotNull(oracleDocuments.supersededBy);
+    const tenantId = currentTenantId();
+    const filters = [isNotNull(oracleDocuments.supersededBy)];
+    if (project) filters.push(eq(oracleDocuments.project, project));
+    if (tenantId) filters.push(eq(oracleDocuments.tenantId, tenantId));
+    const whereClause = and(...filters);
 
     const countResult = db.select({ total: sql<number>`count(*)` })
       .from(oracleDocuments)
@@ -27,6 +29,9 @@ export const supersedeListEndpoint = new Elysia().get(
     const total = countResult?.total || 0;
 
     const newDoc = alias(oracleDocuments, 'new_doc');
+    const newDocJoin = tenantId
+      ? and(eq(oracleDocuments.supersededBy, newDoc.id), eq(newDoc.tenantId, tenantId))
+      : eq(oracleDocuments.supersededBy, newDoc.id);
     const rows = db.select({
       oldId: oracleDocuments.id,
       oldPath: oracleDocuments.sourceFile,
@@ -39,7 +44,7 @@ export const supersedeListEndpoint = new Elysia().get(
       project: oracleDocuments.project,
     })
       .from(oracleDocuments)
-      .leftJoin(newDoc, eq(oracleDocuments.supersededBy, newDoc.id))
+      .leftJoin(newDoc, newDocJoin)
       .where(whereClause)
       .orderBy(desc(oracleDocuments.supersededAt))
       .limit(limit)

--- a/src/server/dashboard.ts
+++ b/src/server/dashboard.ts
@@ -4,35 +4,48 @@
  * Refactored to use Drizzle ORM for type-safe queries.
  */
 
-import { sql, gt, and, gte, lt, desc } from 'drizzle-orm';
+import { sql, gt, and, gte, lt, desc, eq, type SQL } from 'drizzle-orm';
 import { db, oracleDocuments, searchLog, learnLog } from '../db/index.ts';
 import type { DashboardSummary, DashboardActivity, DashboardGrowth } from './types.ts';
+import { currentTenantId } from '../middleware/tenant.ts';
+
+
+type TenantTable = { tenantId: unknown };
+
+function scoped<T extends TenantTable>(table: T, condition?: SQL): SQL | undefined {
+  const tenantId = currentTenantId();
+  const tenantFilter = tenantId ? eq(table.tenantId as never, tenantId) : undefined;
+  return tenantFilter && condition ? and(condition, tenantFilter) : tenantFilter ?? condition;
+}
 
 /**
  * Dashboard summary - aggregated stats for the dashboard
  */
 export function handleDashboardSummary(): DashboardSummary {
   // Document counts
-  const totalDocsResult = db.select({ count: sql<number>`count(*)` })
-    .from(oracleDocuments)
-    .get();
+  const docScope = scoped(oracleDocuments);
+  const totalDocsQuery = db.select({ count: sql<number>`count(*)` }).from(oracleDocuments);
+  const totalDocsResult = (docScope ? totalDocsQuery.where(docScope) : totalDocsQuery).get();
   const totalDocs = totalDocsResult?.count || 0;
 
-  const byTypeResults = db.select({
+  const byTypeQuery = db.select({
     type: oracleDocuments.type,
     count: sql<number>`count(*)`
   })
     .from(oracleDocuments)
+    .$dynamic();
+  const byTypeResults = (docScope ? byTypeQuery.where(docScope) : byTypeQuery)
     .groupBy(oracleDocuments.type)
     .all();
 
   // Concept counts - need to parse JSON concepts from all documents
+  const conceptsFilter = and(
+    sql`${oracleDocuments.concepts} IS NOT NULL`,
+    sql`${oracleDocuments.concepts} != '[]'`
+  );
   const conceptsResult = db.select({ concepts: oracleDocuments.concepts })
     .from(oracleDocuments)
-    .where(and(
-      sql`${oracleDocuments.concepts} IS NOT NULL`,
-      sql`${oracleDocuments.concepts} != '[]'`
-    ))
+    .where(scoped(oracleDocuments, conceptsFilter))
     .all();
 
   const conceptCounts = new Map<string, number>();
@@ -61,7 +74,7 @@ export function handleDashboardSummary(): DashboardSummary {
   try {
     const searchResult = db.select({ count: sql<number>`count(*)` })
       .from(searchLog)
-      .where(gt(searchLog.createdAt, sevenDaysAgo))
+      .where(scoped(searchLog, gt(searchLog.createdAt, sevenDaysAgo)))
       .get();
     searches7d = searchResult?.count || 0;
   } catch {}
@@ -69,15 +82,14 @@ export function handleDashboardSummary(): DashboardSummary {
   try {
     const learnResult = db.select({ count: sql<number>`count(*)` })
       .from(learnLog)
-      .where(gt(learnLog.createdAt, sevenDaysAgo))
+      .where(scoped(learnLog, gt(learnLog.createdAt, sevenDaysAgo)))
       .get();
     learnings7d = learnResult?.count || 0;
   } catch {}
 
   // Health status
-  const lastIndexedResult = db.select({ lastIndexed: sql<number | null>`max(${oracleDocuments.indexedAt})` })
-    .from(oracleDocuments)
-    .get();
+  const lastIndexedQuery = db.select({ lastIndexed: sql<number | null>`max(${oracleDocuments.indexedAt})` }).from(oracleDocuments);
+  const lastIndexedResult = (docScope ? lastIndexedQuery.where(docScope) : lastIndexedQuery).get();
 
   return {
     documents: {
@@ -118,7 +130,7 @@ export function handleDashboardActivity(days: number = 7): DashboardActivity {
       createdAt: searchLog.createdAt
     })
       .from(searchLog)
-      .where(gt(searchLog.createdAt, since))
+      .where(scoped(searchLog, gt(searchLog.createdAt, since)))
       .orderBy(desc(searchLog.createdAt))
       .limit(20)
       .all();
@@ -143,7 +155,7 @@ export function handleDashboardActivity(days: number = 7): DashboardActivity {
       createdAt: learnLog.createdAt
     })
       .from(learnLog)
-      .where(gt(learnLog.createdAt, since))
+      .where(scoped(learnLog, gt(learnLog.createdAt, since)))
       .orderBy(desc(learnLog.createdAt))
       .limit(20)
       .all();
@@ -182,10 +194,10 @@ export function handleDashboardGrowth(period: string = 'week'): DashboardGrowth 
     // Documents created that day
     const docsResult = db.select({ count: sql<number>`count(*)` })
       .from(oracleDocuments)
-      .where(and(
+      .where(scoped(oracleDocuments, and(
         gte(oracleDocuments.createdAt, dayStart),
         lt(oracleDocuments.createdAt, dayEnd)
-      ))
+      )))
       .get();
 
     // Searches that day
@@ -193,10 +205,10 @@ export function handleDashboardGrowth(period: string = 'week'): DashboardGrowth 
     try {
       const searchResult = db.select({ count: sql<number>`count(*)` })
         .from(searchLog)
-        .where(and(
+        .where(scoped(searchLog, and(
           gte(searchLog.createdAt, dayStart),
           lt(searchLog.createdAt, dayEnd)
-        ))
+        )))
         .get();
       searchCount = searchResult?.count || 0;
     } catch {}

--- a/tests/http/tenant/dashboard-supersede-isolation.test.ts
+++ b/tests/http/tenant/dashboard-supersede-isolation.test.ts
@@ -1,0 +1,96 @@
+import { afterAll, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { inArray, like } from 'drizzle-orm';
+import { db, learnLog, oracleDocuments, searchLog } from '../../../src/db/index.ts';
+import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
+import { dashboardRoutes } from '../../../src/routes/dashboard/index.ts';
+import { supersedeRoutes } from '../../../src/routes/supersede/index.ts';
+
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantA = `tenant-a-${stamp}`;
+const tenantB = `tenant-b-${stamp}`;
+const ids = {
+  aOld: `tenant-sup-a-old-${stamp}`,
+  aNew: `tenant-sup-a-new-${stamp}`,
+  bOld: `tenant-sup-b-old-${stamp}`,
+  bNew: `tenant-sup-b-new-${stamp}`,
+};
+const now = Date.now();
+const paths = Object.fromEntries(Object.entries(ids).map(([key, id]) => [key, `ψ/memory/${id}.md`])) as Record<keyof typeof ids, string>;
+
+function appRequest(app: Elysia, tenantId: string, path: string) {
+  return createTenantFetch((request) => app.handle(request))(new Request(`http://local${path}`, {
+    headers: { [TENANT_HEADER]: tenantId },
+  }));
+}
+
+function insertDoc(id: string, tenantId: string, path: string, supersededBy?: string) {
+  db.insert(oracleDocuments).values({
+    id,
+    tenantId,
+    type: 'learning',
+    sourceFile: path,
+    concepts: JSON.stringify([tenantId]),
+    createdAt: now,
+    updatedAt: now,
+    indexedAt: now,
+    supersededBy,
+    supersededAt: supersededBy ? now : null,
+    supersededReason: supersededBy ? 'tenant isolation test' : null,
+    project: `project-${tenantId}`,
+    createdBy: 'tenant-test',
+  }).run();
+}
+
+insertDoc(ids.aOld, tenantA, paths.aOld, ids.aNew);
+insertDoc(ids.aNew, tenantA, paths.aNew);
+insertDoc(ids.bOld, tenantB, paths.bOld, ids.bNew);
+insertDoc(ids.bNew, tenantB, paths.bNew);
+
+db.insert(searchLog).values([
+  { query: `tenant dashboard ${stamp} a`, tenantId: tenantA, mode: 'fts', resultsCount: 1, searchTimeMs: 1, createdAt: now },
+  { query: `tenant dashboard ${stamp} b`, tenantId: tenantB, mode: 'fts', resultsCount: 1, searchTimeMs: 1, createdAt: now },
+]).run();
+db.insert(learnLog).values([
+  { documentId: ids.aOld, tenantId: tenantA, patternPreview: `learn a ${stamp}`, concepts: '[]', createdAt: now },
+  { documentId: ids.bOld, tenantId: tenantB, patternPreview: `learn b ${stamp}`, concepts: '[]', createdAt: now },
+]).run();
+
+afterAll(() => {
+  db.delete(oracleDocuments).where(inArray(oracleDocuments.id, Object.values(ids))).run();
+  db.delete(searchLog).where(like(searchLog.query, `%${stamp}%`)).run();
+  db.delete(learnLog).where(inArray(learnLog.documentId, [ids.aOld, ids.bOld])).run();
+});
+
+test('dashboard summary and activity are scoped to selected tenant', async () => {
+  const summary = await appRequest(dashboardRoutes, tenantA, '/api/dashboard/summary');
+  const activity = await appRequest(dashboardRoutes, tenantA, '/api/dashboard/activity?days=1');
+  const summaryBody = await summary.json() as { documents: { total: number }; concepts: { top: Array<{ name: string }> } };
+  const activityBody = await activity.json() as { searches: Array<{ query: string }>; learnings: Array<{ document_id: string }> };
+
+  expect(summary.status).toBe(200);
+  expect(summaryBody.documents.total).toBe(2);
+  expect(summaryBody.concepts.top.map((item) => item.name)).toContain(tenantA);
+  expect(summaryBody.concepts.top.map((item) => item.name)).not.toContain(tenantB);
+  expect(activityBody.searches.map((item) => item.query)).toContain(`tenant dashboard ${stamp} a`);
+  expect(activityBody.searches.map((item) => item.query)).not.toContain(`tenant dashboard ${stamp} b`);
+  expect(activityBody.learnings.map((item) => item.document_id)).toContain(ids.aOld);
+  expect(activityBody.learnings.map((item) => item.document_id)).not.toContain(ids.bOld);
+});
+
+test('supersede list and chain do not cross tenant boundaries', async () => {
+  const app = supersedeRoutes;
+  const list = await appRequest(app, tenantA, '/api/supersede?limit=10');
+  const deniedChain = await appRequest(app, tenantB, `/api/supersede/chain/${encodeURIComponent(paths.aOld)}`);
+  const allowedChain = await appRequest(app, tenantA, `/api/supersede/chain/${encodeURIComponent(paths.aOld)}`);
+  const listBody = await list.json() as { supersessions: Array<{ old_id: string; new_path: string | null }> };
+  const deniedBody = await deniedChain.json() as { superseded_by: unknown[]; supersedes: unknown[] };
+  const allowedBody = await allowedChain.json() as { superseded_by: Array<{ new_path: string }>; supersedes: unknown[] };
+
+  expect(list.status).toBe(200);
+  expect(listBody.supersessions.map((item) => item.old_id)).toContain(ids.aOld);
+  expect(listBody.supersessions.map((item) => item.old_id)).not.toContain(ids.bOld);
+  expect(listBody.supersessions.find((item) => item.old_id === ids.aOld)?.new_path).toBe(paths.aNew);
+  expect(deniedBody).toEqual({ superseded_by: [], supersedes: [] });
+  expect(allowedBody.superseded_by.map((item) => item.new_path)).toContain(paths.aNew);
+});


### PR DESCRIPTION
Closes #1650

## Changes
- Scoped dashboard document, concept, activity, and growth queries to active tenant context
- Scoped supersede list and chain routes to active tenant, including joined replacement docs
- Added tenant HTTP regression tests covering dashboard and supersede isolation

## Test
- bunx tsc --noEmit: green
- bun test tests/http/tenant/: green