### PR TITLE
Complete Vector Phase 1 provider reload semantics

### DIFF
--- a/src/routes/vector/config-api.ts
+++ b/src/routes/vector/config-api.ts
@@ -1,5 +1,5 @@
 import { Elysia, t } from 'elysia';
-import { closeCachedVectorStores } from '../../vector/factory.ts';
+import { reloadCachedVectorStores } from '../../vector/factory.ts';
 import type { VectorServerConfig } from '../../vector/config.ts';
 import {
   activeConfig,
@@ -98,10 +98,10 @@ export const vectorConfigApiEndpoint = new Elysia()
     };
   }, { detail: { tags: ['vector'], summary: 'Vector server config with collection health' } })
   .post('/vector/config/reload', async () => {
-    await closeCachedVectorStores();
+    await reloadCachedVectorStores();
     const { source, config } = activeConfig();
     return { success: true, reloaded: true, source, config };
-  }, { detail: { tags: ['vector'], summary: 'Reload vector config and clear cached vector stores' } })
+  }, { detail: { tags: ['vector'], summary: 'Reload vector config and reconnect cached vector stores' } })
   .patch('/vector/config', async ({ body, set }) => {
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
       set.status = 422;
@@ -115,7 +115,7 @@ export const vectorConfigApiEndpoint = new Elysia()
     const { source, config } = activeConfig();
     const next = { ...config, ...(body as Partial<VectorServerConfig>) };
     const path = atomicWriteVectorConfig(next);
-    await closeCachedVectorStores();
+    await reloadCachedVectorStores();
     return { success: true, reloaded: true, source, path, config: next };
   }, {
     body: configPatchSchema,
@@ -153,7 +153,7 @@ export const vectorConfigApiEndpoint = new Elysia()
     };
     const next = created.primary ? withPrimary(nextBase, params.collection) : nextBase;
     const path = atomicWriteVectorConfig(next);
-    await closeCachedVectorStores();
+    await reloadCachedVectorStores();
     return { success: true, reloaded: true, source, path, collection: params.collection, config: next };
   }, {
     params: t.Object({ collection: t.String({ minLength: 1 }) }),
@@ -170,7 +170,7 @@ export const vectorConfigApiEndpoint = new Elysia()
     const [key] = resolved;
     const next = withPrimary(config, key);
     const path = atomicWriteVectorConfig(next);
-    await closeCachedVectorStores();
+    await reloadCachedVectorStores();
     return { success: true, reloaded: true, source, path, collection: key, config: next };
   }, {
     params: t.Object({ collection: t.String({ minLength: 1 }) }),
@@ -186,7 +186,7 @@ export const vectorConfigApiEndpoint = new Elysia()
     const [key] = resolved;
     const next = withoutCollection(config, key);
     const path = atomicWriteVectorConfig(next);
-    await closeCachedVectorStores();
+    await reloadCachedVectorStores();
     return { success: true, reloaded: true, source, path, removed: key, config: next };
   }, {
     params: t.Object({ collection: t.String({ minLength: 1 }) }),
@@ -211,7 +211,7 @@ export const vectorConfigApiEndpoint = new Elysia()
     };
     const next = update.primary ? withPrimary(nextBase, key) : nextBase;
     const path = atomicWriteVectorConfig(next);
-    await closeCachedVectorStores();
+    await reloadCachedVectorStores();
     return { success: true, reloaded: true, source, path, collection: key, config: next };
   }, {
     params: t.Object({ collection: t.String({ minLength: 1 }) }),

--- a/src/vector/config.ts
+++ b/src/vector/config.ts
@@ -145,7 +145,9 @@ export function writeVectorConfig(config: VectorServerConfig, fp = configPath())
 }
 
 function embedderFor(config: VectorServerConfig, col: VectorCollectionConfig): EmbedderConfig | undefined {
-  const merged = config.embedder || col.embedder ? { ...config.embedder, ...col.embedder } : undefined;
+  const generated = col.embedder?.backend === 'ollama' && col.embedder.model === col.model && col.provider === 'ollama';
+  const merged = config.embedder && generated ? { ...col.embedder, ...config.embedder }
+    : config.embedder || col.embedder ? { ...config.embedder, ...col.embedder } : undefined;
   if (merged) return {
     ...merged,
     backend: merged.backend ?? merged.default ?? 'none',

--- a/src/vector/embeddings.ts
+++ b/src/vector/embeddings.ts
@@ -139,19 +139,18 @@ export class GeminiEmbeddings implements EmbeddingProvider {
   }
 
   async embed(texts: string[], _type?: EmbedType): Promise<number[][]> {
-    const url = `https://generativelanguage.googleapis.com/v1beta/models/${this.model}:batchEmbedContents?key=${this.apiKey}`;
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ requests: texts.map((text) => ({ model: `models/${this.model}`, content: { parts: [{ text }] } })) }),
-    });
-    if (!response.ok) throw new Error(`Gemini API error: ${await response.text()}`);
-    const data = await response.json() as { embeddings?: Array<{ values?: number[] }> };
-    const vectors = data.embeddings?.map((item) => item.values);
-    if (!vectors || vectors.length !== texts.length || vectors.some((v) => !Array.isArray(v))) {
-      throw new Error('Gemini API error: invalid embedding payload');
-    }
-    return vectors as number[][];
+    return Promise.all(texts.map(async (text) => {
+      const url = `https://generativelanguage.googleapis.com/v1beta/models/${this.model}:embedContent?key=${this.apiKey}`;
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: { parts: [{ text }] } }),
+      });
+      if (!response.ok) throw new Error(`Gemini API error: ${await response.text()}`);
+      const data = await response.json() as { embedding?: { values?: number[] } };
+      if (!Array.isArray(data.embedding?.values)) throw new Error('Gemini API error: invalid embedding payload');
+      return data.embedding.values;
+    }));
   }
 }
 

--- a/src/vector/factory.ts
+++ b/src/vector/factory.ts
@@ -228,3 +228,19 @@ export async function closeCachedVectorStores(): Promise<void> {
     console.warn(`[VectorRegistry] Failed to close ${store.name}:`, e instanceof Error ? e.message : String(e))
   )));
 }
+
+export async function reloadCachedVectorStores(
+  models = getEmbeddingModels(),
+  connectStore: (store: VectorStoreAdapter) => Promise<void> = (store) => store.connect(),
+): Promise<{ reloaded: number }> {
+  const keys = [...modelStoreCache.keys()];
+  await closeCachedVectorStores();
+  const reloadKeys = keys.filter((key) => key in models);
+  await Promise.all(reloadKeys.map(async (key) => {
+    const store = getVectorStoreByModel(key, models, connectStore);
+    const pending = connectPromises.get(key);
+    if (pending) await pending;
+    return store;
+  }));
+  return { reloaded: reloadKeys.length };
+}

--- a/tests/http/vector/default-config.test.ts
+++ b/tests/http/vector/default-config.test.ts
@@ -25,6 +25,10 @@ function restore(key: string, value: string | undefined): void {
 test('default vector config uses zero-config Ollama with detected remote fallbacks', () => {
   process.env.OPENAI_API_KEY = 'sk-test';
   process.env.GOOGLE_API_KEY = 'gemini-test';
+  delete process.env.CF_ACCOUNT_ID;
+  delete process.env.CF_API_TOKEN;
+  delete process.env.CLOUDFLARE_ACCOUNT_ID;
+  delete process.env.CLOUDFLARE_API_TOKEN;
 
   const models = configToModels(generateDefaultConfig());
 

--- a/tests/vector/config-defaults.test.ts
+++ b/tests/vector/config-defaults.test.ts
@@ -4,7 +4,8 @@ import { defaultVectorProxyManifest, generateDefaultConfig } from '../../src/vec
 test('vector config defaults stay FTS-first with a sidecar proxy manifest', () => {
   const defaults = generateDefaultConfig();
 
-  expect(defaults.embedder).toEqual({ backend: 'none' });
+  expect(defaults.embedder).toBeUndefined();
   expect(defaults.proxy).toEqual(defaultVectorProxyManifest());
-  expect(defaults.collections['bge-m3'].provider).toBe('none');
+  expect(defaults.collections['bge-m3'].provider).toBe('ollama');
+  expect(defaults.collections['bge-m3'].embedder).toMatchObject({ backend: 'ollama', model: 'bge-m3' });
 });

--- a/tests/vector/embeddings-gemini.test.ts
+++ b/tests/vector/embeddings-gemini.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, expect, mock, test } from 'bun:test';
+import { GeminiEmbeddings } from '../../src/vector/embeddings.ts';
+
+const originalFetch = globalThis.fetch;
+const originalKey = process.env.GEMINI_API_KEY;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalKey === undefined) delete process.env.GEMINI_API_KEY;
+  else process.env.GEMINI_API_KEY = originalKey;
+});
+
+test('GeminiEmbeddings calls embedContent and returns vectors in input order', async () => {
+  process.env.GEMINI_API_KEY = 'gemini-key';
+  const calls: Array<{ url: string; body: any }> = [];
+  globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ url: String(input), body: JSON.parse(String(init?.body)) });
+    return Response.json({ embedding: { values: [calls.length, 0.5] } });
+  }) as unknown as typeof fetch;
+
+  const vectors = await new GeminiEmbeddings().embed(['first', 'second'], 'query');
+
+  expect(vectors).toEqual([[1, 0.5], [2, 0.5]]);
+  expect(calls.every((call) => call.url.includes(':embedContent?key=gemini-key'))).toBe(true);
+  expect(calls.map((call) => call.body.content.parts[0].text)).toEqual(['first', 'second']);
+});
+
+test('GeminiEmbeddings rejects malformed embedding payloads', async () => {
+  globalThis.fetch = mock(async () => Response.json({ embedding: {} })) as unknown as typeof fetch;
+
+  await expect(new GeminiEmbeddings({ apiKey: 'k' }).embed(['hello'])).rejects.toThrow('invalid embedding payload');
+});

--- a/tests/vector/factory-reload-cache.test.ts
+++ b/tests/vector/factory-reload-cache.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'bun:test';
+import { closeCachedVectorStores, getVectorStoreByModel, reloadCachedVectorStores } from '../../src/vector/factory.ts';
+import type { VectorStoreAdapter } from '../../src/vector/types.ts';
+
+function models(collection: string) {
+  return {
+    reload_model: {
+      collection,
+      model: 'reload-model',
+      adapter: 'proxy' as const,
+      endpoint: 'http://example.invalid',
+    },
+  };
+}
+
+test('reloadCachedVectorStores closes, recreates, and reconnects running adapters', async () => {
+  const oldStore = getVectorStoreByModel('reload_model', models('before'), async () => {});
+  const connected: string[] = [];
+
+  try {
+    const result = await reloadCachedVectorStores(models('after'), async (store: VectorStoreAdapter) => {
+      connected.push(store.name);
+    });
+    const newStore = getVectorStoreByModel('reload_model', models('after'), async () => {});
+
+    expect(result).toEqual({ reloaded: 1 });
+    expect(newStore).not.toBe(oldStore);
+    expect(connected).toEqual(['proxy']);
+  } finally {
+    await closeCachedVectorStores();
+  }
+});

--- a/tests/vector/provider-detection.test.ts
+++ b/tests/vector/provider-detection.test.ts
@@ -1,0 +1,19 @@
+import { expect, mock, test } from 'bun:test';
+import { clearProviderDetectionCache, getDetectedEmbeddingProviders } from '../../src/vector/provider-detection.ts';
+
+test('provider detection caches probes until force refresh', async () => {
+  clearProviderDetectionCache();
+  let n = 0;
+  const fetcher = mock(async () => Response.json({ models: [{ name: `model-${++n}` }] })) as unknown as typeof fetch;
+  const options = { env: {}, fetcher };
+
+  const first = await getDetectedEmbeddingProviders(false, options);
+  const cached = await getDetectedEmbeddingProviders(false, options);
+  const forced = await getDetectedEmbeddingProviders(true, options);
+
+  expect(first.providers[0].models).toEqual(['model-1']);
+  expect(cached.providers[0].models).toEqual(['model-1']);
+  expect(forced.providers[0].models).toEqual(['model-2']);
+  expect(fetcher).toHaveBeenCalledTimes(2);
+  clearProviderDetectionCache();
+});


### PR DESCRIPTION
## Summary
- align Gemini embeddings with the issue-specified `:embedContent` API and add mocked coverage
- add provider detection cache/force-refresh coverage for `/api/vector/providers`
- make vector config reload close, recreate, and reconnect already-running cached adapters
- fix embedder precedence so explicit global config overrides generated zero-config collection defaults while keeping stale cache keys closed
- refresh default config tests for current zero-config Ollama behavior and ambient provider env isolation

## Tests
- bunx tsc --noEmit
- bun test tests/vector/ tests/http/vector/

## Notes
- PR targets alpha; no main changes.
- Changed files are ≤250 lines.
- Live external provider credentials were not used; external calls are mocked in tests.
