### PR TITLE
fix: serve health probes without version redirect (#1597)

### DIFF
--- a/src/middleware/api-version.ts
+++ b/src/middleware/api-version.ts
@@ -4,6 +4,7 @@ export const API_VERSION = 'v1';
 export const API_VERSION_HEADER = 'X-API-Version';
 const API_PREFIX = '/api';
 const VERSIONED_PREFIX = `${API_PREFIX}/${API_VERSION}`;
+const INFRASTRUCTURE_PREFIXES = ['/api/health'];
 const publicPaths = new WeakMap<Request, string>();
 
 type FetchHandler = (request: Request) => Response | Promise<Response>;
@@ -22,6 +23,10 @@ function isVersionedApiPath(pathname: string): boolean {
   return pathname === VERSIONED_PREFIX || pathname.startsWith(`${VERSIONED_PREFIX}/`);
 }
 
+function isInfrastructurePath(pathname: string): boolean {
+  return INFRASTRUCTURE_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
+}
+
 export function apiRequestPath(request: Request): string {
   return publicPaths.get(request) ?? new URL(request.url).pathname;
 }
@@ -31,6 +36,7 @@ function versionedLocation(request: Request): string | null {
   if (
     !isApiPath(url.pathname)
     || isVersionedApiPath(url.pathname)
+    || isInfrastructurePath(url.pathname)
   ) return null;
   const suffix = url.pathname.slice(API_PREFIX.length);
   url.pathname = `${VERSIONED_PREFIX}${suffix}`;

--- a/tests/http/health/unversioned.test.ts
+++ b/tests/http/health/unversioned.test.ts
@@ -17,11 +17,14 @@ function createFetch() {
   return createApiVersionedFetch((request) => app.handle(request));
 }
 
-test('GET /api/health redirects to the canonical versioned health route', async () => {
+test('GET /api/health responds directly for infrastructure probes', async () => {
   const res = await createFetch()(new Request('http://local/api/health'));
+  const body = await res.json() as { status: string };
 
-  expect(res.status).toBe(308);
-  expect(res.headers.get('location')).toBe('http://local/api/v1/health');
+  expect(res.status).toBe(200);
+  expect(res.headers.get('location')).toBeNull();
+  expect(res.headers.get('x-api-version')).toBe('v1');
+  expect(body.status).toBe('ok');
 });
 
 test('GET /api/v1/health still rewrites to the health route', async () => {

--- a/tests/http/versioning/prefix.test.ts
+++ b/tests/http/versioning/prefix.test.ts
@@ -26,8 +26,9 @@ test('API routes are served under /api/v1 and legacy /api paths redirect', async
   expect(legacy.headers.get(API_VERSION_HEADER)).toBe('v1');
 
   const health = await fetchVersioned(new Request('http://local/api/health'));
-  expect(health.status).toBe(308);
-  expect(health.headers.get('location')).toBe('http://local/api/v1/health');
+  expect(health.status).toBe(200);
+  expect(health.headers.get('location')).toBeNull();
+  expect(health.headers.get(API_VERSION_HEADER)).toBe('v1');
 
   const apiRoot = await fetchVersioned(new Request('http://local/api'));
   expect(apiRoot.status).toBe(308);


### PR DESCRIPTION
Closes #1597

## Changes
- Exempted /api/health infrastructure probes from API version redirects so they return 200 directly
- Preserved /api/v1/health rewrite behavior and legacy redirects for non-infrastructure API paths
- Updated versioning/health regression tests for the direct health response

## Test
- bunx tsc --noEmit: green
- bun test tests/http/health/ tests/http/logger/ tests/http/versioning/ tests/plugins/path-containment.test.ts tests/plugins/sandbox.test.ts: green