### PR TITLE
Integrate vector Studio clients with v1 API routes

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -72,9 +72,9 @@ export interface ApiRouteResponses {
   '/api/menu': MenuResponse;
   '/api/menu/search': MenuSearchResponse;
   '/api/v1/vector/search': VectorSearchResponse;
-  '/api/vector/index/models': VectorIndexModelsResponse;
-  '/api/vector/index/status': VectorIndexStatusResponse;
-  '/api/vector/health': VectorHealthResponse;
+  '/api/v1/vector/index/models': VectorIndexModelsResponse;
+  '/api/v1/vector/index/status': VectorIndexStatusResponse;
+  '/api/v1/vector/health': VectorHealthResponse;
   '/api/plugins': PluginsResponse;
   '/api/v1/learn': LearnListResponse;
 }
@@ -188,11 +188,11 @@ export class ApiClient {
   }
 
   vectorIndexModels(): Promise<VectorIndexModelsResponse> {
-    return this.request('/api/vector/index/models');
+    return this.request('/api/v1/vector/index/models');
   }
 
   vectorHealth(): Promise<VectorHealthResponse> {
-    return this.request('/api/vector/health');
+    return this.request('/api/v1/vector/health');
   }
 
   vectorSearch(query: string, limit?: number): Promise<VectorSearchResponse>;
@@ -211,11 +211,11 @@ export class ApiClient {
   }
 
   vectorIndexStatus(): Promise<VectorIndexStatusResponse> {
-    return this.request('/api/vector/index/status');
+    return this.request('/api/v1/vector/index/status');
   }
 
   startVectorIndex(model: string): Promise<VectorIndexStartResponse> {
-    return this.fetchJson('/api/vector/index/start', { method: 'POST', body: JSON.stringify({ model }) });
+    return this.fetchJson('/api/v1/vector/index/start', { method: 'POST', body: JSON.stringify({ model }) });
   }
 
   private async fetchJson<T>(path: string, init: RequestInit = {}): Promise<T> {

--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -94,7 +94,7 @@ export function SetupWizard({ children }: { children: ReactNode }) {
       );
     setBusy(true);
     try {
-      await fetch(apiUrl("/api/vector/index/start"), {
+      await fetch(apiUrl("/api/v1/vector/index/start"), {
         method: "POST",
         headers: {
           accept: "application/json",

--- a/frontend/src/components/VectorFirstRunWizard.tsx
+++ b/frontend/src/components/VectorFirstRunWizard.tsx
@@ -66,7 +66,7 @@ export function VectorFirstRunWizard({ rows, onRefresh }: WizardProps) {
     setBusy(true);
     setError('');
     try {
-      await fetchJson('/api/vector/index/start', { method: 'POST', body: JSON.stringify({ model }) });
+      await fetchJson('/api/v1/vector/index/start', { method: 'POST', body: JSON.stringify({ model }) });
       setMessage(`Started first index for ${model}. Watch progress in the Index Manager.`);
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause));

--- a/frontend/src/components/VectorIndexPanel.tsx
+++ b/frontend/src/components/VectorIndexPanel.tsx
@@ -97,7 +97,7 @@ export function VectorIndexPanel({ client = apiClient, initialModels, initialSta
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-300">Index Manager</p>
           <h2 id="vector-index-title" className="mt-2 text-2xl font-semibold text-white">Index jobs and collections</h2>
-          <p className="mt-2 text-sm text-slate-400">Start, poll, and audit embedding rebuilds through /api/vector/index/start.</p>
+          <p className="mt-2 text-sm text-slate-400">Start, poll, and audit embedding rebuilds through /api/v1/vector/index/start.</p>
         </div>
         <button
           className="focus-ring rounded-xl border border-white/10 px-3 py-2 text-sm text-slate-200 hover:border-purple-300/40"
@@ -113,7 +113,7 @@ export function VectorIndexPanel({ client = apiClient, initialModels, initialSta
         {status ? <IndexProgress status={status} /> : null}
       </div>
 
-      {loading ? <LoadingPanel title="Loading vector collections…" detail="Fetching /api/vector/index/models." /> : null}
+      {loading ? <LoadingPanel title="Loading vector collections…" detail="Fetching /api/v1/vector/index/models." /> : null}
       {error ? <ErrorMessage title="Vector indexing failed." message={error} /> : null}
       {!loading && !modelEntries.length ? <p className="text-sm text-slate-500">No vector collections reported.</p> : null}
 

--- a/frontend/src/pages/IndexManagerPanel.tsx
+++ b/frontend/src/pages/IndexManagerPanel.tsx
@@ -87,7 +87,7 @@ export function IndexManagerPanel({ client = apiClient }: { client?: VectorIndex
         {status ? <IndexProgress status={status} /> : null}
       </div>
 
-      {loading ? <LoadingPanel title="Loading vector collections…" detail="Fetching /api/vector/index/models." /> : null}
+      {loading ? <LoadingPanel title="Loading vector collections…" detail="Fetching /api/v1/vector/index/models." /> : null}
       {error ? <ErrorMessage title="Vector indexing failed." message={error} /> : null}
       <div className="grid gap-3 md:grid-cols-2">
         {modelEntries.map(([key, model]) => (

--- a/frontend/src/pages/VectorDocumentsPage.tsx
+++ b/frontend/src/pages/VectorDocumentsPage.tsx
@@ -116,7 +116,7 @@ export function VectorDocumentsPage() {
 
   useEffect(() => {
     const controller = new AbortController();
-    fetchJson('/api/vector/index/models', controller.signal)
+    fetchJson('/api/v1/vector/index/models', controller.signal)
       .then((data) => {
         const next = normalizeVectorCollections(data);
         setCollections(next);
@@ -132,7 +132,7 @@ export function VectorDocumentsPage() {
     const qs = new URLSearchParams({ collection, page: String(page), limit: String(PAGE_LIMIT) });
     setState('loading');
     setError('');
-    fetchJson(`/api/vector/documents?${qs}`, controller.signal)
+    fetchJson(`/api/v1/vector/documents?${qs}`, controller.signal)
       .then((data) => {
         const next = normalizeVectorDocuments(data, page, PAGE_LIMIT);
         setDocuments(next.documents);

--- a/frontend/src/pages/VectorExportPage.tsx
+++ b/frontend/src/pages/VectorExportPage.tsx
@@ -117,7 +117,7 @@ export function VectorExportPage({
         <p className="mt-2 text-sm text-slate-400">Download vector collections from /api/v1/vector/export in any available format.</p>
       </div>
 
-      {state === 'loading' ? <LoadingPanel title="Loading vector collections…" detail="Fetching /api/vector/index/models." /> : null}
+      {state === 'loading' ? <LoadingPanel title="Loading vector collections…" detail="Fetching /api/v1/vector/index/models." /> : null}
       {state === 'error' ? <ErrorMessage title="Could not load vector export options." message={error} /> : null}
 
       <div className="mt-5 grid gap-4 rounded-2xl border border-white/10 bg-white/[0.03] p-4">

--- a/frontend/src/pages/VectorPage.tsx
+++ b/frontend/src/pages/VectorPage.tsx
@@ -150,12 +150,12 @@ export function VectorPage({
           <div>
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Vector status</p>
             <h1 id="vector-status-title" className="mt-2 text-3xl font-semibold text-white">Vector dashboard</h1>
-            <p className="mt-2 text-sm text-slate-400">Collection health from /api/vector/index/models and /api/vector/health.</p>
+            <p className="mt-2 text-sm text-slate-400">Collection health from /api/v1/vector/index/models and /api/v1/vector/health.</p>
           </div>
           <p className="rounded-full border border-white/10 px-3 py-2 text-sm text-slate-300">{summary}</p>
         </div>
 
-        {isLoading ? <LoadingPanel title="Loading vector status…" detail="Fetching /api/vector/index/models and /api/vector/health." /> : null}
+        {isLoading ? <LoadingPanel title="Loading vector status…" detail="Fetching /api/v1/vector/index/models and /api/v1/vector/health." /> : null}
         {state === 'error' ? <ErrorMessage title="Could not load vector status." message={error} /> : null}
         {downloadError ? <div className="mb-4"><ErrorMessage title="Vector export failed." message={downloadError} /></div> : null}
       </section>

--- a/tests/frontend/api-client.test.ts
+++ b/tests/frontend/api-client.test.ts
@@ -30,10 +30,10 @@ describe('frontend API client', () => {
         limit: 5,
         query: 'oracle memory',
       },
-      '/api/vector/index/models': {
+      '/api/v1/vector/index/models': {
         models: { 'bge-m3': { collection: 'oracle_bge_m3', model: 'bge-m3', adapter: 'lancedb', count: 12 } },
       },
-      '/api/vector/index/status': {
+      '/api/v1/vector/index/status': {
         jobId: 'vidx-1',
         model: 'bge-m3',
         status: 'indexing',
@@ -71,8 +71,8 @@ describe('frontend API client', () => {
       '/api/menu',
       '/api/menu/search?q=vector',
       '/api/v1/vector/search?q=oracle+memory&limit=5&type=docs',
-      '/api/vector/index/models',
-      '/api/vector/index/status',
+      '/api/v1/vector/index/models',
+      '/api/v1/vector/index/status',
       '/api/plugins',
     ]);
     for (const call of calls) {
@@ -98,7 +98,7 @@ describe('frontend API client', () => {
     const headers = new Headers(calls[0]?.init?.headers);
     expect(headers.get('x-client')).toBe('studio');
     expect(headers.get('content-type')).toBe('application/json');
-    expect(String(calls[1]?.input)).toBe('http://localhost:47778/api/vector/index/start');
+    expect(String(calls[1]?.input)).toBe('http://localhost:47778/api/v1/vector/index/start');
     expect(calls[1]?.init?.method).toBe('POST');
     expect(calls[1]?.init?.body).toBe(JSON.stringify({ model: 'qwen3' }));
   });

--- a/tests/frontend/api/vector-health-client.test.ts
+++ b/tests/frontend/api/vector-health-client.test.ts
@@ -16,6 +16,6 @@ describe('ApiClient vectorHealth', () => {
     });
 
     await expect(client.vectorHealth()).resolves.toMatchObject({ status: 'ok', engines: [{ key: 'bge', ok: true }] });
-    expect(String(calls[0]?.input)).toBe('/api/vector/health');
+    expect(String(calls[0]?.input)).toBe('/api/v1/vector/health');
   });
 });

--- a/tests/frontend/api/vector-index-models-client.test.ts
+++ b/tests/frontend/api/vector-index-models-client.test.ts
@@ -16,7 +16,7 @@ describe('ApiClient vectorIndexModels', () => {
     });
 
     await expect(client.vectorIndexModels()).resolves.toMatchObject({ models: { bge: { count: 4 } } });
-    expect(String(calls[0]?.input)).toBe('/api/vector/index/models');
+    expect(String(calls[0]?.input)).toBe('/api/v1/vector/index/models');
     expect(new Headers(calls[0]?.init?.headers).get('accept')).toBe('application/json');
   });
 });

--- a/tests/frontend/pages/vector-dashboard-loading.test.tsx
+++ b/tests/frontend/pages/vector-dashboard-loading.test.tsx
@@ -7,6 +7,6 @@ describe('VectorPage loading state', () => {
   test('shows the vector status endpoints while loading', () => {
     const html = htmlFor(<MemoryRouter><VectorPage /></MemoryRouter>);
     expect(html).toContain('Loading vector status');
-    expect(html).toContain('/api/vector/index/models and /api/vector/health');
+    expect(html).toContain('/api/v1/vector/index/models and /api/v1/vector/health');
   });
 });


### PR DESCRIPTION
## Summary
- route Vector Section v2 Studio clients through `/api/v1/vector/` endpoints for health, index models/status/start, and document browsing
- update Vector dashboard/index manager copy to show the versioned endpoints users and tests now exercise
- adjust frontend API/client coverage to lock the versioned integration path while server backward compatibility remains available

## Validation
- bun test tests/frontend/api-client.test.ts tests/frontend/api/vector-health-client.test.ts tests/frontend/api/vector-index-models-client.test.ts tests/frontend/pages/vector-dashboard-loading.test.tsx tests/frontend/pages/vector-documents-page.test.tsx tests/frontend/components/vector-first-run-wizard.test.tsx tests/frontend/components/vector-index-panel-render.test.tsx tests/http/vector/
- bunx tsc --noEmit

Issue: #1436
