### PR TITLE
test: lock /api/learn malformed JSON contract (#1718)

### DIFF
--- a/tests/http/learn/crud.test.ts
+++ b/tests/http/learn/crud.test.ts
@@ -67,7 +67,10 @@ describe('POST/GET/PUT/DELETE /api/learn', () => {
     }));
     expect(res.status).toBe(400);
     expect(res.headers.get('content-type')).toContain('application/json');
-    expect(await res.json()).toMatchObject({ success: false, error: 'Bad Request', code: 400 });
+    const body = await res.json();
+    expect(body).toMatchObject({ success: false, error: 'Bad Request', code: 400 });
+    expect(body.details.message).toBe('Bad Request');
+    expect(typeof body.details.correlationId).toBe('string');
   });
 
   test('rejects malformed JSON on versioned route with 400 contract', async () => {
@@ -78,7 +81,10 @@ describe('POST/GET/PUT/DELETE /api/learn', () => {
     }));
     expect(res.status).toBe(400);
     expect(res.headers.get('content-type')).toContain('application/json');
-    expect(await res.json()).toMatchObject({ success: false, error: 'Bad Request', code: 400 });
+    const body = await res.json();
+    expect(body).toMatchObject({ success: false, error: 'Bad Request', code: 400 });
+    expect(body.details.message).toBe('Bad Request');
+    expect(typeof body.details.correlationId).toBe('string');
   });
 
   test('creates, reads, updates, and soft-deletes a learning through Drizzle rows', async () => {


### PR DESCRIPTION
Closes #1718

## Changes
- Confirmed malformed /api/learn JSON is a structured 400 Bad Request, not 500
- Strengthened legacy and versioned learn CRUD tests to assert error code/message and correlation details

## Test
- bunx tsc --noEmit: green
- bun test tests/http/learn/: green