### PR TITLE
Polish vector fan-out status and cache behavior

### DIFF
--- a/src/routes/vector/fanout.ts
+++ b/src/routes/vector/fanout.ts
@@ -10,6 +10,7 @@ const cache = new QueryCache<unknown>();
 export interface FanoutEndpointOptions {
   getModels?: () => Record<string, EmbeddingModelConfig>;
   getStore?: (key: string, models: Record<string, EmbeddingModelConfig>) => Promise<Pick<VectorStoreAdapter, 'query'>>;
+  cache?: QueryCache<unknown>;
 }
 
 function sanitize(q: string): string {
@@ -22,9 +23,10 @@ function requestedBackends(raw: string | undefined, enabled: string[]): string[]
 }
 
 export function createFanoutEndpoint(options: FanoutEndpointOptions = {}) {
+  const endpointCache = options.cache ?? cache;
   return new Elysia()
-    .get('/vector/fanout/cache', () => ({ cache: cache.stats() }), { detail: { tags: ['vector'], summary: 'Fan-out query cache stats' } })
-    .delete('/vector/fanout/cache', () => { cache.clear(); return { success: true, cache: cache.stats() }; }, { detail: { tags: ['vector'], summary: 'Clear fan-out query cache' } })
+    .get('/vector/fanout/cache', () => ({ cache: endpointCache.stats() }), { detail: { tags: ['vector'], summary: 'Fan-out query cache stats' } })
+    .delete('/vector/fanout/cache', () => { endpointCache.clear(); return { success: true, cache: endpointCache.stats() }; }, { detail: { tags: ['vector'], summary: 'Clear fan-out query cache' } })
     .get(
       '/vector/fanout',
       async ({ query, set }) => {
@@ -45,7 +47,7 @@ export function createFanoutEndpoint(options: FanoutEndpointOptions = {}) {
 
     const cacheKey = stableCacheKey({ q, backends, limit, type: query.type ?? 'all' });
     if (query.cache !== 'false') {
-      const cached = cache.get(cacheKey);
+      const cached = endpointCache.get(cacheKey);
       if (cached) return { ...(cached as Record<string, unknown>), cached: true };
     }
 
@@ -55,7 +57,7 @@ export function createFanoutEndpoint(options: FanoutEndpointOptions = {}) {
       store: await (options.getStore?.(key, models) ?? ensureVectorStoreConnected(key, models)),
     })));
     const result = { query: q, ...(await queryFanout({ text: q, limit, where, targets })) };
-    if (query.cache !== 'false') cache.set(cacheKey, result);
+    if (query.cache !== 'false') endpointCache.set(cacheKey, result);
     return result;
       },
       {

--- a/src/vector/fanout-query.ts
+++ b/src/vector/fanout-query.ts
@@ -19,28 +19,51 @@ export interface FanoutQueryOptions {
 export interface FanoutQueryResponse {
   strategy: FanoutStrategy;
   backends: string[];
+  backendStats: Record<string, { ok: boolean; elapsedMs: number; error?: string }>;
   results: SearchResult[];
   errors: Record<string, string>;
 }
 
 export async function queryFanout(options: FanoutQueryOptions): Promise<FanoutQueryResponse> {
-  const settled = await Promise.allSettled(options.targets.map(async (target) => ({
-    key: target.key,
-    result: await target.store.query(options.text, options.limit, options.where),
-  })));
+  const settled = await Promise.allSettled(options.targets.map(async (target) => {
+    const startedAt = Date.now();
+    try {
+      const result = await target.store.query(options.text, options.limit, options.where);
+      return {
+        key: target.key,
+        elapsedMs: Math.max(0, Date.now() - startedAt),
+        result,
+      };
+    } catch (error) {
+      throw {
+        key: target.key,
+        elapsedMs: Math.max(0, Date.now() - startedAt),
+        error,
+      };
+    }
+  }));
   const errors: Record<string, string> = {};
+  const backendStats: FanoutQueryResponse['backendStats'] = {};
   const results: SearchResult[] = [];
   settled.forEach((item, index) => {
     const key = options.targets[index].key;
     if (item.status === 'rejected') {
-      errors[key] = item.reason instanceof Error ? item.reason.message : String(item.reason);
+      const reason = item.reason as { error?: unknown; elapsedMs?: number } | unknown;
+      const error = typeof reason === 'object' && reason && 'error' in reason ? reason.error : reason;
+      errors[key] = error instanceof Error ? error.message : String(error);
+      const elapsedMs = typeof reason === 'object' && reason && 'elapsedMs' in reason
+        ? Number(reason.elapsedMs)
+        : 0;
+      backendStats[key] = { ok: false, elapsedMs: Math.max(0, elapsedMs), error: errors[key] };
       return;
     }
+    backendStats[key] = { ok: true, elapsedMs: item.value.elapsedMs };
     results.push(...toSearchResults(key, item.value.result));
   });
   return {
     strategy: options.strategy ?? 'merge',
     backends: options.targets.map((target) => target.key),
+    backendStats,
     results: mergeFanoutResults(results).slice(0, options.limit),
     errors,
   };

--- a/tests/http/vector/phase4-polish.test.ts
+++ b/tests/http/vector/phase4-polish.test.ts
@@ -1,6 +1,7 @@
 import { expect, mock, test } from 'bun:test';
 import { Elysia } from 'elysia';
 import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { QueryCache } from '../../../src/vector/query-cache.ts';
 import type { EmbeddingProvider, VectorQueryResult } from '../../../src/vector/types.ts';
 
 const models = {
@@ -30,21 +31,57 @@ test('GET /api/v1/vector/fanout merges and deduplicates parallel backend results
   const res = await createApiVersionedFetch((request) => app.handle(request))(
     new Request('http://local/api/v1/vector/fanout?q=oracle&fanout=local,remote&limit=5&cache=false'),
   );
-  const body = await res.json() as { backends: string[]; results: Array<{ id: string; source: string }>; errors: Record<string, string> };
+  const body = await res.json() as {
+    backends: string[];
+    backendStats: Record<string, { ok: boolean }>;
+    results: Array<{ id: string; source: string }>;
+    errors: Record<string, string>;
+  };
 
   expect(res.status).toBe(200);
   expect(body.backends).toEqual(['local', 'remote']);
+  expect(body.backendStats.local.ok).toBe(true);
+  expect(body.backendStats.remote.ok).toBe(true);
   expect(body.results.map((item) => item.id)).toEqual(['same', 'local-only', 'remote-only']);
   expect(body.results[0].source).toBe('hybrid');
   expect(body.errors).toEqual({});
 });
 
+test('GET /api/v1/vector/fanout returns partial results and backend errors', async () => {
+  const { createFanoutEndpoint } = await import('../../../src/routes/vector/fanout.ts');
+  const app = new Elysia({ prefix: '/api' }).use(createFanoutEndpoint({
+    getModels: () => models,
+    getStore: async (key) => ({
+      query: mock(async () => {
+        if (key === 'remote') throw new Error('remote unavailable');
+        return queryResult(['local-only'], [3]);
+      }),
+    }),
+  }));
+  const res = await createApiVersionedFetch((request) => app.handle(request))(
+    new Request('http://local/api/v1/vector/fanout?q=oracle&fanout=local,remote&cache=false'),
+  );
+  const body = await res.json() as {
+    backendStats: Record<string, { ok: boolean; error?: string }>;
+    results: Array<{ id: string }>;
+    errors: Record<string, string>;
+  };
+
+  expect(res.status).toBe(200);
+  expect(body.results.map((item) => item.id)).toEqual(['local-only']);
+  expect(body.errors.remote).toBe('remote unavailable');
+  expect(body.backendStats.local.ok).toBe(true);
+  expect(body.backendStats.remote).toMatchObject({ ok: false, error: 'remote unavailable' });
+});
+
 test('GET /api/v1/vector/fanout caches and clears query results', async () => {
   const { createFanoutEndpoint } = await import('../../../src/routes/vector/fanout.ts');
+  const cache = new QueryCache<unknown>();
   const query = mock(async () => queryResult(['cached'], [1]));
   const app = new Elysia({ prefix: '/api' }).use(createFanoutEndpoint({
     getModels: () => ({ local: models.local }),
     getStore: async () => ({ query }),
+    cache,
   }));
   const fetch = createApiVersionedFetch((request) => app.handle(request));
 


### PR DESCRIPTION
## Summary
- expose per-backend fan-out query metadata (`backendStats`) with success/error/timing for dashboard polish
- preserve partial fan-out results when one backend fails while returning backend-specific errors
- make fan-out cache injectable so scoped HTTP tests are isolated and cache behavior is explicit

## Tests
- bunx tsc --noEmit
- bun test tests/http/vector/

## Notes
- PR targets alpha; no main changes.
- Changed files are ≤250 lines.
- Live multi-backend vector services were not used; fan-out behavior is covered with mocked stores.
