### PR TITLE
Polish maw vector-config primary output

### DIFF
--- a/maw-plugin/__tests__/vector-config.test.ts
+++ b/maw-plugin/__tests__/vector-config.test.ts
@@ -36,7 +36,8 @@ describe('maw arra vector-config', () => {
     expect(result.ok).toBe(true);
     expect(calls.map(call => [call.init?.method, call.path])).toEqual([['GET', '/api/v1/vector/config']]);
     expect(result.output).toContain('Collection | Adapter | Model | Enabled | Docs | Status');
-    expect(result.output).toContain('oracle_knowledge_bge_m3 | lancedb | bge-m3 | true | 42 | ok');
+    expect(result.output).toContain('oracle_knowledge_bge_m3 ★ | lancedb | bge-m3 | true | 42 | ok');
+    expect(result.output).toContain('★ = primary');
     expect(result.output).toContain('oracle_knowledge_nomic | lancedb | nomic-embed-text | true | 7 | down');
   });
 

--- a/maw-plugin/vector-config.ts
+++ b/maw-plugin/vector-config.ts
@@ -74,7 +74,17 @@ function buildVectorConfig(p: Parsed): { method: Method; built: Built } | undefi
 }
 
 function rows(data: any): any[] {
-  return Array.isArray(data?.collections) ? data.collections : Object.entries(data?.config?.collections ?? {}).map(([key, col]) => ({ key, ...(col as object), count: data?.doc_counts?.[key] ?? 0, status: data?.health?.[key]?.status ?? 'unknown' }));
+  const configRows = Object.entries(data?.config?.collections ?? {}).map(([key, col]: any) => ({
+    key,
+    ...col,
+    count: data?.doc_counts?.[key] ?? 0,
+    status: data?.health?.[key]?.status ?? 'unknown',
+  }));
+  const listed = Array.isArray(data?.collections) ? data.collections : configRows;
+  return listed.map((row: any) => {
+    const configured = configRows.find((item: any) => item.key === row.key || item.collection === row.collection) ?? {};
+    return { ...configured, ...row, primary: row.primary ?? configured.primary };
+  });
 }
 
 function pickCollection(data: any, collection: string): any | undefined {
@@ -83,9 +93,12 @@ function pickCollection(data: any, collection: string): any | undefined {
 
 function formatList(data: any): string {
   const lines = ['Collection | Adapter | Model | Enabled | Docs | Status'];
-  for (const row of rows(data)) lines.push(`${row.collection ?? row.key} | ${row.adapter ?? 'lancedb'} | ${row.model ?? row.key} | ${row.enabled !== false} | ${row.count ?? 0} | ${row.status ?? (row.ok === false ? 'down' : 'ok')}`);
+  for (const row of rows(data)) {
+    const label = `${row.collection ?? row.key}${row.primary ? ' ★' : ''}`;
+    lines.push(`${label} | ${row.adapter ?? 'lancedb'} | ${row.model ?? row.key} | ${row.enabled !== false} | ${row.count ?? 0} | ${row.status ?? (row.ok === false ? 'down' : 'ok')}`);
+  }
   if (lines.length === 1) lines.push('(none) | - | - | true | 0 | unknown');
-  return lines.join('\n');
+  return [lines.join('\n'), '★ = primary'].join('\n');
 }
 
 function formatRead(data: any, p: Parsed): string {


### PR DESCRIPTION
## Summary\n- align maw arra vector-config table output with #1596 by marking the primary collection with ★\n- merge config metadata into list rows so API collection arrays preserve primary state\n- add regression coverage for the primary marker in the maw plugin vector-config output\n\n## Validation\n- bun test maw-plugin/__tests__/vector-config.test.ts src/plugins/__tests__/arra-plugin.test.ts tests/cli/vector-config/cli.test.ts tests/http/vector/\n- bunx tsc --noEmit\n\nIssue: #1596