### PR TITLE
feat: Thor Oracle dev research profile (#1030)

### DIFF
--- a/src/oracles/thor.ts
+++ b/src/oracles/thor.ts
@@ -1,0 +1,40 @@
+export const THOR_ORACLE_ID = 'thor-oracle';
+export const THOR_ORACLE_THEME = 'stormforge';
+
+export const thorOracleProfile = {
+  id: THOR_ORACLE_ID,
+  name: 'Thor Oracle',
+  role: 'dev-research oracle',
+  theme: THOR_ORACLE_THEME,
+  born: '2026-04-27',
+  motto: 'ตีเหล็กจากพายุ แปลงความไม่ชัดเจนให้เป็นความเข้าใจที่ใช้งานได้',
+  principles: [
+    'Think like a researcher before cutting code.',
+    'Turn ambiguity into usable understanding.',
+    'Keep long-horizon context attached to implementation evidence.',
+  ],
+  capabilities: [
+    {
+      id: 'research-distillation',
+      label: 'Research distillation',
+      description: 'Convert traces, hypotheses, and findings into durable learnings.',
+    },
+    {
+      id: 'stormforge-development',
+      label: 'Stormforge development',
+      description: 'Forge implementation plans from uncertain or noisy context.',
+    },
+    {
+      id: 'system-thinking',
+      label: 'System thinking',
+      description: 'Connect local code changes to architecture, operations, and memory.',
+    },
+  ],
+  workflows: [
+    'trace awakening capture',
+    'dev/research synthesis',
+    'implementation evidence review',
+  ],
+};
+
+export type ThorOracleProfile = typeof thorOracleProfile;

--- a/src/routes/health/index.ts
+++ b/src/routes/health/index.ts
@@ -6,13 +6,15 @@ import { createHealthEndpoint, type HealthEndpointOptions } from './health.ts';
 import { createDeepHealthEndpoint } from './deep.ts';
 import { statsEndpoint } from './stats.ts';
 import { oraclesEndpoint } from './oracles.ts';
+import { thorOracleEndpoint } from './thor.ts';
 
 export function createHealthRoutes(options: HealthEndpointOptions = {}) {
   return new Elysia({ prefix: '/api' })
     .use(createHealthEndpoint(options))
     .use(createDeepHealthEndpoint(options))
     .use(statsEndpoint)
-    .use(oraclesEndpoint);
+    .use(oraclesEndpoint)
+    .use(thorOracleEndpoint);
 }
 
 export const healthRoutes = createHealthRoutes();

--- a/src/routes/health/thor.ts
+++ b/src/routes/health/thor.ts
@@ -1,0 +1,30 @@
+import { Elysia, t } from 'elysia';
+import { thorOracleProfile } from '../../oracles/thor.ts';
+
+const ThorCapabilitySchema = t.Object({
+  id: t.String(),
+  label: t.String(),
+  description: t.String(),
+});
+
+const ThorProfileSchema = t.Object({
+  id: t.String(),
+  name: t.String(),
+  role: t.String(),
+  theme: t.String(),
+  born: t.String(),
+  motto: t.String(),
+  principles: t.Array(t.String()),
+  capabilities: t.Array(ThorCapabilitySchema),
+  workflows: t.Array(t.String()),
+});
+
+export const thorOracleEndpoint = new Elysia().get('/oracles/thor', () => thorOracleProfile, {
+  response: ThorProfileSchema,
+  detail: {
+    tags: ['health'],
+    menu: { group: 'hidden' },
+    description: 'Returns the Thor Oracle dev/research awakening profile and Stormforge capabilities.',
+    summary: 'Thor Oracle dev/research profile',
+  },
+});

--- a/src/trace/distill.ts
+++ b/src/trace/distill.ts
@@ -2,10 +2,11 @@ import { eq } from 'drizzle-orm';
 import { db, traceLog } from '../db/index.ts';
 import { handleLearn } from '../server/handlers.ts';
 import { getTrace } from './handler.ts';
+import { THOR_ORACLE_ID, THOR_ORACLE_THEME } from '../oracles/thor.ts';
 import type { DistillTraceInput } from './types.ts';
 
-const DEFAULT_ORACLE = 'thor-oracle';
-const DEFAULT_THEME = 'stormforge';
+const DEFAULT_ORACLE = THOR_ORACLE_ID;
+const DEFAULT_THEME = THOR_ORACLE_THEME;
 
 export type DistillTraceResult = {
   success: boolean;

--- a/tests/http/health/oracles.test.ts
+++ b/tests/http/health/oracles.test.ts
@@ -85,3 +85,23 @@ test('GET /api/oracles aggregates active identities and projects', async () => {
   expect(body.projects.map((item: { project: string }) => item.project)).toContain(project);
   expect(body.window_hours).toBe(1);
 });
+
+
+test('GET /api/oracles/thor exposes the dev-research Stormforge profile', async () => {
+  const app = createHealthRoutes({
+    vectorHealth: async () => ({ status: 'ok', engines: [], checked_at: '2026-06-16T00:00:00.000Z' }),
+  });
+  const res = await app.handle(new Request('http://local/api/oracles/thor'));
+  const body = await res.json() as Record<string, any>;
+  const capabilities = body.capabilities.map((item: { id: string }) => item.id);
+
+  expect(res.status).toBe(200);
+  expect(body.id).toBe('thor-oracle');
+  expect(body.name).toBe('Thor Oracle');
+  expect(body.role).toBe('dev-research oracle');
+  expect(body.theme).toBe('stormforge');
+  expect(body.motto).toContain('ตีเหล็กจากพายุ');
+  expect(capabilities).toContain('research-distillation');
+  expect(capabilities).toContain('stormforge-development');
+  expect(capabilities).toContain('system-thinking');
+});


### PR DESCRIPTION
Closes #1030

## Changes
- Added Thor Oracle dev/research Stormforge profile metadata
- Exposed `/api/oracles/thor` through the health routes
- Reused Thor profile constants for trace awakening distillation defaults
- Added HTTP contract coverage for the Thor profile endpoint

## Test
- bunx tsc --noEmit: green
- bun test tests/http/health/oracles.test.ts tests/http/traces/routes.test.ts: green