### PR TITLE
Fix #1718 malformed JSON test contract

### DIFF
--- a/tests/http/knowledge.test.ts
+++ b/tests/http/knowledge.test.ts
@@ -74,7 +74,7 @@ describe("HTTP Contract — search / knowledge / supersede", () => {
       expect((await res.json()).error).toMatch(/pattern/i);
     });
 
-    test("rejects malformed JSON body as 400, not 500", async () => {
+    test("rejects malformed JSON body as 400", async () => {
       const res = await fetch(`${BASE_URL}/api/learn`, { method: "POST", headers: JSON_HEADERS, body: "{not json" });
       const body = await res.json();
       expect(res.status).toBe(400);

--- a/tests/http/learn/crud.test.ts
+++ b/tests/http/learn/crud.test.ts
@@ -59,7 +59,7 @@ afterAll(() => {
 });
 
 describe('POST/GET/PUT/DELETE /api/learn', () => {
-  test('rejects malformed JSON body as 400, not 500', async () => {
+  test('rejects malformed JSON body as 400', async () => {
     const res = await app().handle(new Request('http://local/api/learn', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },


### PR DESCRIPTION
Summary
- Keep /api/learn malformed JSON tests aligned on the 400 Bad Request contract.
- Remove remaining test-name references to the old 500 malformed JSON contract in knowledge and learn CRUD coverage.
- Confirm no remaining malformed JSON 500 references under tests/http.

Tests
- bunx tsc --noEmit
- bun test tests/http/knowledge.test.ts
- bun test tests/http/learn/crud.test.ts

Closes #1718