### PR TITLE
feat: export app json csv graph formatters

### DIFF
--- a/tests/tools/export-app/export-app.test.ts
+++ b/tests/tools/export-app/export-app.test.ts
@@ -13,10 +13,14 @@ process.env.ORACLE_DB_PATH = dbPath;
 const dbModule = await import('../../../src/db/index.ts');
 const appModule = await import('../../../tools/export-app/index.ts');
 const exporterModule = await import('../../../tools/export-app/exporter.ts');
+const csvModule = await import('../../../tools/export-app/format-csv.ts');
+const jsonModule = await import('../../../tools/export-app/format-json.ts');
 
-const { createDatabase, oracleDocuments, traceLog, resetDefaultDatabaseForTests } = dbModule;
+const { createDatabase, oracleDocuments, supersedeLog, traceLog, resetDefaultDatabaseForTests } = dbModule;
 const { runExportApp } = appModule;
 const { exportOracleData, graphRelationships } = exporterModule;
+const { formatCsvCollection } = csvModule;
+const { formatJsonCollection } = jsonModule;
 
 function restoreDbPath() {
   return savedDbPath
@@ -39,6 +43,11 @@ function seed(connection: ReturnType<typeof createDatabase>) {
     { traceId: 'trace-a', query: 'backup root', childTraceIds: '["trace-b"]', nextTraceId: 'trace-b', createdAt: now, updatedAt: now },
     { traceId: 'trace-b', query: 'backup child', parentTraceId: 'trace-a', prevTraceId: 'trace-a', createdAt: now, updatedAt: now },
   ]).run();
+  connection.db.insert(supersedeLog).values({
+    oldPath: 'ψ/learn/old.md', oldId: 'doc-old', oldTitle: 'Old',
+    newPath: 'ψ/learn/new.md', newId: 'doc-new', newTitle: 'New',
+    reason: 'refresh', supersededAt: now + 2, supersededBy: 'test', project: 'demo',
+  }).run();
 }
 
 afterAll(() => {
@@ -67,14 +76,19 @@ describe('standalone export app', () => {
 
       for (const ext of ['json', 'csv', 'md']) expect(existsSync(join(outputDir, 'collections', `oracle_documents.${ext}`))).toBe(true);
       expect(readFileSync(join(outputDir, 'collections', 'oracle_documents.md'), 'utf8')).toContain('doc-old');
-      expect(readFileSync(join(outputDir, 'collections', 'oracle_documents.csv'), 'utf8')).toContain('doc-new');
+      const csv = readFileSync(join(outputDir, 'collections', 'oracle_documents.csv'), 'utf8');
+      expect(csv.split('\n')[0]).toBe('id,title,content_preview,collection,created_at');
+      expect(csv).toContain('"doc-new"');
 
+      const documentsJson = JSON.parse(readFileSync(join(outputDir, 'collections', 'oracle_documents.json'), 'utf8'));
+      expect(documentsJson).toMatchObject({ collection: 'oracle_documents', rowCount: 2 });
       const all = JSON.parse(readFileSync(join(outputDir, 'all-collections.json'), 'utf8'));
       expect(all.collections.oracle_documents.map((row: { id: string }) => row.id)).toContain('doc-old');
 
       const relationships = JSON.parse(readFileSync(join(outputDir, 'relationships.json'), 'utf8'));
       expect(relationships.rows).toEqual(expect.arrayContaining([
         expect.objectContaining({ type: 'document_superseded_by', from: 'doc-old', to: 'doc-new' }),
+        expect.objectContaining({ type: 'supersede_log', from: 'doc-old', to: 'doc-new' }),
         expect.objectContaining({ type: 'trace_next', from: 'trace-a', to: 'trace-b' }),
       ]));
     } finally {
@@ -98,10 +112,30 @@ describe('standalone export app', () => {
   test('graph relationship extraction is deterministic for rows', () => {
     expect(graphRelationships({
       oracle_documents: [{ id: 'a', supersededBy: 'b' }],
+      supersede_log: [{ oldId: 'b', newId: 'c', oldPath: 'old.md', newPath: 'new.md', reason: 'rename', supersededAt: 2 }],
       trace_log: [{ traceId: 't1', childTraceIds: '["t2"]' }],
     })).toEqual([
       { type: 'document_superseded_by', from: 'a', to: 'b', metadata: { reason: undefined, at: undefined } },
+      { type: 'supersede_log', from: 'b', to: 'c', metadata: { oldPath: 'old.md', newPath: 'new.md', reason: 'rename', at: 2, by: undefined, project: undefined } },
       { type: 'trace_child', from: 't1', to: 't2' },
     ]);
+  });
+
+  test('json formatter keeps full metadata and embeddings', () => {
+    const payload = JSON.parse(formatJsonCollection('vectors', [
+      { id: 'vec-1', title: 'Vector row', metadata: { source: 'test' }, embeddings: [0.1, 0.2] },
+    ]));
+
+    expect(payload).toEqual({
+      collection: 'vectors',
+      rowCount: 1,
+      rows: [{ id: 'vec-1', title: 'Vector row', metadata: { source: 'test' }, embeddings: [0.1, 0.2] }],
+    });
+  });
+
+  test('csv formatter writes the fixed tabular export view', () => {
+    expect(formatCsvCollection('oracle_documents', [
+      { id: 'doc-1', title: 'Doc', content: 'Line one\nline two', createdAt: 7 },
+    ])).toBe('id,title,content_preview,collection,created_at\n"doc-1","Doc","Line one line two","oracle_documents","7"\n');
   });
 });

--- a/tools/export-app/exporter.ts
+++ b/tools/export-app/exporter.ts
@@ -12,6 +12,7 @@ import {
   normalizeRecords,
   type ExportRecord,
 } from './formats.ts';
+import { graphRelationships } from './graph.ts';
 
 type DumpTable = ReturnType<typeof introspectDrizzleTables>[number];
 type Progress = (message: string) => void;
@@ -31,12 +32,7 @@ export interface ExportAppResult {
   relationshipCount: number;
 }
 
-export type GraphRelationship = {
-  type: string;
-  from: string;
-  to: string;
-  metadata?: Record<string, unknown>;
-};
+export { graphRelationships, type GraphRelationship } from './graph.ts';
 
 export async function exportOracleData(options: ExportAppOptions): Promise<ExportAppResult> {
   const close = options.connection ? undefined : openReadonlyConnection(options.dbPath);
@@ -96,51 +92,4 @@ async function writeCollectionFiles(baseDir: string, name: string, rows: ExportR
 
 function safeName(name: string): string {
   return name.replace(/[^a-zA-Z0-9._-]/g, '_');
-}
-
-export function graphRelationships(collections: Record<string, ExportRecord[]>): GraphRelationship[] {
-  return [
-    ...documentRelationships(collections.oracle_documents ?? []),
-    ...traceRelationships(collections.trace_log ?? []),
-  ];
-}
-
-function text(value: unknown): string | undefined {
-  return typeof value === 'string' && value.length > 0 ? value : undefined;
-}
-
-function documentRelationships(rows: ExportRecord[]): GraphRelationship[] {
-  return rows.flatMap((row) => {
-    const from = text(row.id);
-    const to = text(row.supersededBy);
-    if (!from || !to) return [];
-    return [{ type: 'document_superseded_by', from, to, metadata: { reason: row.supersededReason, at: row.supersededAt } }];
-  });
-}
-
-function traceRelationships(rows: ExportRecord[]): GraphRelationship[] {
-  const out: GraphRelationship[] = [];
-  for (const row of rows) {
-    const traceId = text(row.traceId);
-    if (!traceId) continue;
-    const parent = text(row.parentTraceId);
-    const prev = text(row.prevTraceId);
-    const next = text(row.nextTraceId);
-    if (parent) out.push({ type: 'trace_parent', from: traceId, to: parent });
-    if (prev) out.push({ type: 'trace_prev', from: traceId, to: prev });
-    if (next) out.push({ type: 'trace_next', from: traceId, to: next });
-    for (const child of childTraceIds(row.childTraceIds)) out.push({ type: 'trace_child', from: traceId, to: child });
-  }
-  return out;
-}
-
-function childTraceIds(value: unknown): string[] {
-  if (Array.isArray(value)) return value.filter((item): item is string => typeof item === 'string');
-  if (typeof value !== 'string') return [];
-  try {
-    const parsed = JSON.parse(value);
-    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : [];
-  } catch {
-    return [];
-  }
 }

--- a/tools/export-app/format-csv.ts
+++ b/tools/export-app/format-csv.ts
@@ -1,0 +1,44 @@
+import type { ExportRecord } from './formats.ts';
+
+export const CSV_COLUMNS = ['id', 'title', 'content_preview', 'collection', 'created_at'] as const;
+
+function text(value: unknown): string {
+  if (value == null) return '';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+function pick(row: ExportRecord, keys: string[]): unknown {
+  for (const key of keys) {
+    const value = row[key];
+    if (value != null && value !== '') return value;
+  }
+  return undefined;
+}
+
+function preview(value: unknown): string {
+  const normalized = text(value).replace(/\s+/g, ' ').trim();
+  return normalized.length > 180 ? `${normalized.slice(0, 177)}...` : normalized;
+}
+
+function csvCell(value: unknown): string {
+  return `"${text(value).replaceAll('"', '""')}"`;
+}
+
+function csvRow(collection: string, row: ExportRecord): string[] {
+  const id = pick(row, ['id', 'traceId', 'key', 'path', 'oldId', 'oldPath']);
+  return [
+    text(id),
+    text(pick(row, ['title', 'oldTitle', 'newTitle', 'sourceFile', 'source_file', 'query', 'key', 'event', 'path']) ?? id),
+    preview(pick(row, ['content', 'document', 'text', 'patternPreview', 'query', 'event', 'notes', 'sourceFile', 'source_file'])),
+    collection,
+    text(pick(row, ['createdAt', 'created_at', 'supersededAt', 'superseded_at', 'updatedAt', 'updated_at', 'when'])),
+  ];
+}
+
+export function formatCsvCollection(collection: string, rows: ExportRecord[]): string {
+  return [
+    CSV_COLUMNS.join(','),
+    ...rows.map((row) => csvRow(collection, row).map(csvCell).join(',')),
+  ].join('\n') + '\n';
+}

--- a/tools/export-app/format-json.ts
+++ b/tools/export-app/format-json.ts
@@ -1,0 +1,11 @@
+import type { ExportRecord } from './formats.ts';
+
+export interface JsonCollectionExport {
+  collection: string;
+  rowCount: number;
+  rows: ExportRecord[];
+}
+
+export function formatJsonCollection(collection: string, rows: ExportRecord[]): string {
+  return `${JSON.stringify({ collection, rowCount: rows.length, rows } satisfies JsonCollectionExport, null, 2)}\n`;
+}

--- a/tools/export-app/formats.ts
+++ b/tools/export-app/formats.ts
@@ -1,4 +1,6 @@
 import { exportFormatInfo } from '../../src/vector/export-formats.ts';
+import { formatCsvCollection } from './format-csv.ts';
+import { formatJsonCollection } from './format-json.ts';
 
 export type ExportRecord = Record<string, unknown>;
 
@@ -25,30 +27,9 @@ export function normalizeRecords(records: ExportRecord[]): ExportRecord[] {
 }
 
 export function formatCollection(name: string, rows: ExportRecord[], format: ExportFormat): string {
-  if (format === 'json') return `${JSON.stringify({ collection: name, rowCount: rows.length, rows }, null, 2)}\n`;
-  if (format === 'csv') return toCsv(rows);
+  if (format === 'json') return formatJsonCollection(name, rows);
+  if (format === 'csv') return formatCsvCollection(name, rows);
   return toMarkdown(name, rows);
-}
-
-function allKeys(rows: ExportRecord[]): string[] {
-  const keys = new Set<string>();
-  for (const row of rows) for (const key of Object.keys(row)) keys.add(key);
-  return [...keys];
-}
-
-function csvCell(value: unknown): string {
-  if (value == null) return '';
-  const text = typeof value === 'object' ? JSON.stringify(value) : String(value);
-  return `"${text.replaceAll('"', '""')}"`;
-}
-
-function toCsv(rows: ExportRecord[]): string {
-  const keys = allKeys(rows);
-  if (keys.length === 0) return '\n';
-  return [
-    keys.map(csvCell).join(','),
-    ...rows.map((row) => keys.map((key) => csvCell(row[key])).join(',')),
-  ].join('\n') + '\n';
 }
 
 function printable(value: unknown): string {

--- a/tools/export-app/graph.ts
+++ b/tools/export-app/graph.ts
@@ -1,0 +1,77 @@
+import type { ExportRecord } from './formats.ts';
+
+export type GraphRelationship = {
+  type: string;
+  from: string;
+  to: string;
+  metadata?: Record<string, unknown>;
+};
+
+export function graphRelationships(collections: Record<string, ExportRecord[]>): GraphRelationship[] {
+  return [
+    ...documentRelationships(collections.oracle_documents ?? []),
+    ...supersedeRelationships(collections.supersede_log ?? []),
+    ...traceRelationships(collections.trace_log ?? []),
+  ];
+}
+
+function text(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function documentRelationships(rows: ExportRecord[]): GraphRelationship[] {
+  return rows.flatMap((row) => {
+    const from = text(row.id);
+    const to = text(row.supersededBy);
+    if (!from || !to) return [];
+    return [{ type: 'document_superseded_by', from, to, metadata: { reason: row.supersededReason, at: row.supersededAt } }];
+  });
+}
+
+function supersedeRelationships(rows: ExportRecord[]): GraphRelationship[] {
+  return rows.flatMap((row) => {
+    const from = text(row.oldId) ?? text(row.oldPath);
+    const to = text(row.newId) ?? text(row.newPath) ?? text(row.supersededBy);
+    if (!from || !to) return [];
+    return [{
+      type: 'supersede_log',
+      from,
+      to,
+      metadata: {
+        oldPath: row.oldPath,
+        newPath: row.newPath,
+        reason: row.reason,
+        at: row.supersededAt,
+        by: row.supersededBy,
+        project: row.project,
+      },
+    }];
+  });
+}
+
+function traceRelationships(rows: ExportRecord[]): GraphRelationship[] {
+  const out: GraphRelationship[] = [];
+  for (const row of rows) {
+    const traceId = text(row.traceId);
+    if (!traceId) continue;
+    const parent = text(row.parentTraceId);
+    const prev = text(row.prevTraceId);
+    const next = text(row.nextTraceId);
+    if (parent) out.push({ type: 'trace_parent', from: traceId, to: parent });
+    if (prev) out.push({ type: 'trace_prev', from: traceId, to: prev });
+    if (next) out.push({ type: 'trace_next', from: traceId, to: next });
+    for (const child of childTraceIds(row.childTraceIds)) out.push({ type: 'trace_child', from: traceId, to: child });
+  }
+  return out;
+}
+
+function childTraceIds(value: unknown): string[] {
+  if (Array.isArray(value)) return value.filter((item): item is string => typeof item === 'string');
+  if (typeof value !== 'string') return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : [];
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
Refs #1783

## Changes
- Added tools/export-app/format-json.ts for per-collection JSON dumps that preserve all row metadata, including embedding fields.
- Added tools/export-app/format-csv.ts with the requested fixed tabular columns: id, title, content_preview, collection, created_at.
- Moved graph relationship extraction into tools/export-app/graph.ts and included supersede_log relationships alongside document supersession and trace links.
- Wired exporter.ts through the new formatter and graph modules while preserving markdown and manifest outputs.

## Validation
- bun test tests/tools/export-app/export-app.test.ts
- bunx tsc --noEmit
- wc -l tools/export-app/*.ts tests/tools/export-app/export-app.test.ts