### PR TITLE
fix(indexer): include psi learn scan path

### DIFF
--- a/src/indexer/cli.ts
+++ b/src/indexer/cli.ts
@@ -13,45 +13,53 @@ import { OracleIndexer } from './index.ts';
 const scriptDir = import.meta.dirname || path.dirname(new URL(import.meta.url).pathname);
 const projectRoot = path.resolve(scriptDir, '..', '..');
 
-const vaultResult = getVaultPsiRoot();
-const vaultRoot = 'path' in vaultResult ? vaultResult.path : null;
+function resolveRepoRoot(repoRootOverride = process.env.ORACLE_REPO_ROOT): string {
+  if (repoRootOverride) return repoRootOverride;
 
-// Vault may have project-first layout (github.com/org/repo/psi/) without a root psi/
-const vaultHasContent = vaultRoot && (
-  fs.existsSync(path.join(vaultRoot, '\u03c8')) ||
-  fs.existsSync(path.join(vaultRoot, 'github.com'))
-);
-const repoRoot = process.env.ORACLE_REPO_ROOT ||
-  (vaultHasContent ? vaultRoot :
-   fs.existsSync(path.join(projectRoot, '\u03c8')) ? projectRoot : process.cwd());
+  const vaultResult = getVaultPsiRoot();
+  const vaultRoot = 'path' in vaultResult ? vaultResult.path : null;
 
-const config: IndexerConfig = {
-  repoRoot,
-  dbPath: DB_PATH,
-  chromaPath: CHROMADB_DIR,
-  sourcePaths: {
-    resonance: '\u03c8/memory/resonance',
-    learnings: '\u03c8/memory/learnings',
-    retrospectives: '\u03c8/memory/retrospectives',
-    distillations: '\u03c8/memory/distillations',
-    learn: '\u03c8/learn',
-    // Opt-in: set ORACLE_INDEX_SECURITY_CORPUS=1 to include \u03c8/learn/security-corpus/.
-    // Default OFF because the corpus has ~36k files (one-time index ~10-30 min).
-    security_corpus: process.env.ORACLE_INDEX_SECURITY_CORPUS === '1'
-      ? '\u03c8/learn/security-corpus'
-      : undefined,
-  }
-};
+  // Vault may have project-first layout (github.com/org/repo/psi/) without a root psi/
+  const vaultHasContent = vaultRoot && (
+    fs.existsSync(path.join(vaultRoot, '\u03c8')) ||
+    fs.existsSync(path.join(vaultRoot, 'github.com'))
+  );
 
-const indexer = new OracleIndexer(config);
+  return vaultHasContent ? vaultRoot :
+    fs.existsSync(path.join(projectRoot, '\u03c8')) ? projectRoot : process.cwd();
+}
 
-indexer.index()
-  .then(async () => {
-    console.log('Indexing complete!');
-    await indexer.close();
-  })
-  .catch(async err => {
-    console.error('Indexing failed:', err);
-    await indexer.close();
-    process.exit(1);
-  });
+export function createIndexerConfig(repoRootOverride = process.env.ORACLE_REPO_ROOT): IndexerConfig {
+  return {
+    repoRoot: resolveRepoRoot(repoRootOverride),
+    dbPath: DB_PATH,
+    chromaPath: CHROMADB_DIR,
+    sourcePaths: {
+      resonance: '\u03c8/memory/resonance',
+      learnings: '\u03c8/memory/learnings',
+      retrospectives: '\u03c8/memory/retrospectives',
+      distillations: '\u03c8/memory/distillations',
+      learn: '\u03c8/learn',
+      // Opt-in: set ORACLE_INDEX_SECURITY_CORPUS=1 to include \u03c8/learn/security-corpus/.
+      // Default OFF because the corpus has ~36k files (one-time index ~10-30 min).
+      security_corpus: process.env.ORACLE_INDEX_SECURITY_CORPUS === '1'
+        ? '\u03c8/learn/security-corpus'
+        : undefined,
+    }
+  };
+}
+
+if (import.meta.main) {
+  const indexer = new OracleIndexer(createIndexerConfig());
+
+  indexer.index()
+    .then(async () => {
+      console.log('Indexing complete!');
+      await indexer.close();
+    })
+    .catch(async err => {
+      console.error('Indexing failed:', err);
+      await indexer.close();
+      process.exit(1);
+    });
+}

--- a/tests/http/learn/auto-index.test.ts
+++ b/tests/http/learn/auto-index.test.ts
@@ -4,6 +4,7 @@ import os from 'os';
 import path from 'path';
 import type { IndexerConfig } from '../../../src/types.ts';
 import { collectPsiLearn } from '../../../src/indexer/collectors.ts';
+import { createIndexerConfig } from '../../../src/indexer/cli.ts';
 
 let repoRoot = '';
 
@@ -28,6 +29,13 @@ afterEach(() => {
 });
 
 describe('ψ/learn auto-index source discovery', () => {
+  test('CLI indexer config includes ψ/learn in scan paths', () => {
+    const config = createIndexerConfig('/tmp/arra-psi-learn-config-test');
+
+    expect(config.sourcePaths.learn).toBe('ψ/learn');
+    expect(Object.values(config.sourcePaths)).toContain('ψ/learn');
+  });
+
   test('standard index scan includes ψ/learn markdown by default', () => {
     const config = makeConfig();
     const learnDir = path.join(repoRoot, 'ψ', 'learn', 'github.com', 'owner', 'repo');


### PR DESCRIPTION
## Summary
- expose the indexer CLI config through createIndexerConfig without running the indexer on import
- verify the real CLI IndexerConfig includes the ψ/learn scan path
- keep ψ/learn source discovery coverage for standard indexing

## Verification
- bun test tests/http/learn/auto-index.test.ts
- bun test tests/http/learn/
- bunx tsc --noEmit
- wc -l src/indexer/cli.ts tests/http/learn/auto-index.test.ts