### PR TITLE
Add embedding provider auto-detect

### DIFF
--- a/src/vector/auto-detect.ts
+++ b/src/vector/auto-detect.ts
@@ -1,0 +1,102 @@
+import type { EmbeddingProviderType } from './types.ts';
+
+export type AutoDetectProvider = Extract<
+  EmbeddingProviderType,
+  'ollama' | 'openai' | 'gemini' | 'cloudflare-ai'
+>;
+
+export type AutoDetectStatus = 'available' | 'unavailable';
+
+export interface AutoDetectedEmbeddingProvider {
+  provider: AutoDetectProvider;
+  status: AutoDetectStatus;
+  models?: string[];
+}
+
+export interface DetectEmbeddingProvidersOptions {
+  env?: Record<string, string | undefined>;
+  fetcher?: typeof fetch;
+  force?: boolean;
+  ollamaUrl?: string;
+  timeoutMs?: number;
+}
+
+let cachedProviders: AutoDetectedEmbeddingProvider[] | null = null;
+
+export async function detectEmbeddingProviders(
+  options: DetectEmbeddingProvidersOptions = {},
+): Promise<AutoDetectedEmbeddingProvider[]> {
+  if (cachedProviders && !options.force) return cloneProviders(cachedProviders);
+
+  const env = options.env ?? process.env;
+  const providers: AutoDetectedEmbeddingProvider[] = [
+    await detectOllama(options),
+    envProvider('openai', hasEnv(env, 'OPENAI_API_KEY'), [
+      'text-embedding-3-small',
+      'text-embedding-3-large',
+    ]),
+    envProvider('gemini', hasEnv(env, 'GEMINI_API_KEY'), ['text-embedding-004']),
+    envProvider('cloudflare-ai', hasCloudflareCredentials(env), ['@cf/baai/bge-m3']),
+  ];
+
+  cachedProviders = providers;
+  return cloneProviders(providers);
+}
+
+export function clearEmbeddingProviderAutoDetectCache(): void {
+  cachedProviders = null;
+}
+
+async function detectOllama(
+  options: DetectEmbeddingProvidersOptions,
+): Promise<AutoDetectedEmbeddingProvider> {
+  const fetcher = options.fetcher ?? fetch;
+  const baseUrl = options.ollamaUrl ?? 'http://localhost:11434';
+
+  try {
+    const response = await fetcher(`${baseUrl}/api/tags`, {
+      signal: AbortSignal.timeout(options.timeoutMs ?? 1500),
+    });
+    if (!response.ok) return unavailable('ollama');
+
+    const body = await response.json() as { models?: Array<{ name?: string }> };
+    const models = (body.models ?? [])
+      .map((model) => model.name)
+      .filter((name): name is string => Boolean(name?.trim()));
+
+    return { provider: 'ollama', status: 'available', models };
+  } catch {
+    return unavailable('ollama');
+  }
+}
+
+function envProvider(
+  provider: AutoDetectProvider,
+  available: boolean,
+  models: string[],
+): AutoDetectedEmbeddingProvider {
+  if (!available) return unavailable(provider);
+  return { provider, status: 'available', models };
+}
+
+function unavailable(provider: AutoDetectProvider): AutoDetectedEmbeddingProvider {
+  return { provider, status: 'unavailable' };
+}
+
+function hasCloudflareCredentials(env: Record<string, string | undefined>): boolean {
+  return (hasEnv(env, 'CF_ACCOUNT_ID') && hasEnv(env, 'CF_API_TOKEN'))
+    || (hasEnv(env, 'CLOUDFLARE_ACCOUNT_ID') && hasEnv(env, 'CLOUDFLARE_API_TOKEN'));
+}
+
+function hasEnv(env: Record<string, string | undefined>, key: string): boolean {
+  return Boolean(env[key]?.trim());
+}
+
+function cloneProviders(
+  providers: AutoDetectedEmbeddingProvider[],
+): AutoDetectedEmbeddingProvider[] {
+  return providers.map((provider) => ({
+    ...provider,
+    models: provider.models ? [...provider.models] : undefined,
+  }));
+}

--- a/tests/vector/auto-detect.test.ts
+++ b/tests/vector/auto-detect.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, expect, mock, test } from 'bun:test';
+import {
+  clearEmbeddingProviderAutoDetectCache,
+  detectEmbeddingProviders,
+} from '../../src/vector/auto-detect.ts';
+
+afterEach(() => {
+  clearEmbeddingProviderAutoDetectCache();
+});
+
+test('detects Ollama models and configured remote embedding providers', async () => {
+  const fetcher = mock(async (input: string | URL | Request) => {
+    expect(String(input)).toBe('http://localhost:11434/api/tags');
+    return Response.json({
+      models: [{ name: 'bge-m3' }, { name: 'nomic-embed-text' }],
+    });
+  }) as unknown as typeof fetch;
+
+  const providers = await detectEmbeddingProviders({
+    env: {
+      OPENAI_API_KEY: 'sk-test',
+      GEMINI_API_KEY: 'gemini-test',
+      CF_ACCOUNT_ID: 'cf-account',
+      CF_API_TOKEN: 'cf-token',
+    },
+    fetcher,
+  });
+
+  expect(providers).toEqual([
+    {
+      provider: 'ollama',
+      status: 'available',
+      models: ['bge-m3', 'nomic-embed-text'],
+    },
+    {
+      provider: 'openai',
+      status: 'available',
+      models: ['text-embedding-3-small', 'text-embedding-3-large'],
+    },
+    {
+      provider: 'gemini',
+      status: 'available',
+      models: ['text-embedding-004'],
+    },
+    {
+      provider: 'cloudflare-ai',
+      status: 'available',
+      models: ['@cf/baai/bge-m3'],
+    },
+  ]);
+  expect(fetcher).toHaveBeenCalledTimes(1);
+});
+
+test('marks providers unavailable when probes and env credentials are missing', async () => {
+  const fetcher = mock(async () => new Response('down', { status: 503 })) as unknown as typeof fetch;
+
+  const providers = await detectEmbeddingProviders({ env: {}, fetcher });
+
+  expect(providers).toEqual([
+    { provider: 'ollama', status: 'unavailable' },
+    { provider: 'openai', status: 'unavailable' },
+    { provider: 'gemini', status: 'unavailable' },
+    { provider: 'cloudflare-ai', status: 'unavailable' },
+  ]);
+});
+
+test('caches detection results until forced', async () => {
+  let calls = 0;
+  const fetcher = mock(async () => Response.json({
+    models: [{ name: `model-${++calls}` }],
+  })) as unknown as typeof fetch;
+
+  const first = await detectEmbeddingProviders({ env: {}, fetcher });
+  const cached = await detectEmbeddingProviders({
+    env: { OPENAI_API_KEY: 'new-key' },
+    fetcher,
+  });
+  const refreshed = await detectEmbeddingProviders({
+    env: { OPENAI_API_KEY: 'new-key' },
+    fetcher,
+    force: true,
+  });
+
+  expect(first[0]).toEqual({ provider: 'ollama', status: 'available', models: ['model-1'] });
+  expect(cached[0]).toEqual(first[0]);
+  expect(cached[1]).toEqual({ provider: 'openai', status: 'unavailable' });
+  expect(refreshed[0]).toEqual({ provider: 'ollama', status: 'available', models: ['model-2'] });
+  expect(refreshed[1]).toEqual({
+    provider: 'openai',
+    status: 'available',
+    models: ['text-embedding-3-small', 'text-embedding-3-large'],
+  });
+  expect(fetcher).toHaveBeenCalledTimes(2);
+});


### PR DESCRIPTION
## Summary\n- add startup-facing embedding provider auto-detection module\n- detect Ollama models, OpenAI/Gemini env keys, and Cloudflare AI credentials\n- cache detection results with forced refresh support\n\n## Validation\n- bun test tests/vector/auto-detect.test.ts\n- bun test tests/vector/\n- bunx tsc --noEmit\n- wc -l src/vector/auto-detect.ts tests/vector/auto-detect.test.ts