### PR TITLE
feat: mount vector config api route

### DIFF
--- a/src/routes/vector/config-api.ts
+++ b/src/routes/vector/config-api.ts
@@ -218,3 +218,5 @@ export const vectorConfigApiEndpoint = new Elysia()
     body: updateSchema,
     detail: { tags: ['vector'], summary: 'Update one vector collection config' },
   });
+
+export const vectorConfigApiRoutes = new Elysia({ prefix: '/api' }).use(vectorConfigApiEndpoint);

--- a/src/routes/vector/index.ts
+++ b/src/routes/vector/index.ts
@@ -14,11 +14,6 @@
  *   GET /api/vector/documents — browse indexed vector documents
  *   GET /api/v1/vector/export/formats — available export formats
  *   GET /api/v1/vector/export — stream vector docs in a registered format
- *   GET /api/v1/vector/config — config + per-collection health/counts
- *   PUT /api/v1/vector/config/:collection — update collection adapter/model/provider
- *   POST /api/v1/vector/config/reload — clear cached vector stores
- *   POST /api/v1/vector/config/:collection/test — probe one collection
- *
  * Mounted with the `/api` prefix from server.ts. Phase 1 of #1071: separating
  * the vector layer from FTS/hybrid so it can later move behind VECTOR_URL.
  */
@@ -32,7 +27,6 @@ import { mapEndpoint } from './map.ts';
 import { map3dEndpoint } from './map3d.ts';
 import { vectorStatsEndpoint } from './stats.ts';
 import { vectorHealthEndpoint } from './health.ts';
-import { vectorConfigApiEndpoint } from './config-api.ts';
 import { vectorIndexerEndpoints } from './indexer.ts';
 import { vectorProxyEndpoint } from './proxy.ts';
 import { vectorDocumentsEndpoint } from './documents.ts';
@@ -53,7 +47,6 @@ export const vectorRoutes = new Elysia({ prefix: '/api' })
   .use(vectorHealthEndpoint)
   .use(vectorDocumentsEndpoint)
   .use(vectorExportEndpoint)
-  .use(vectorConfigApiEndpoint)
   .use(vectorProvidersEndpoint)
   .use(vectorCostEndpoint)
   .use(vectorServicesApiEndpoint)

--- a/src/server.ts
+++ b/src/server.ts
@@ -42,6 +42,7 @@ import { createHealthRoutes } from './routes/health/index.ts';
 import { dashboardRoutes } from './routes/dashboard/index.ts';
 import { searchRoutes } from './routes/search/index.ts';
 import { vectorRoutes } from './routes/vector/index.ts';
+import { vectorConfigApiRoutes } from './routes/vector/config-api.ts';
 import { knowledgeRoutes } from './routes/knowledge/index.ts';
 import { supersedeRoutes } from './routes/supersede/index.ts';
 import { forumApi } from './routes/forum/index.ts';
@@ -169,14 +170,12 @@ const app = new Elysia()
     docs: '/api/docs',
     api: '/api/v1',
   }));
-
 const healthRoutes = createHealthRoutes({
   pluginCount: unifiedPlugins.pluginCount,
   pluginMcpToolCount: unifiedPlugins.mcpTools.length,
   pluginStatuses: unifiedPlugins.pluginStatuses,
   isDraining,
 });
-
 const apiModules = [
   authRoutes,
   settingsRoutes,
@@ -185,6 +184,7 @@ const apiModules = [
   dashboardRoutes,
   searchRoutes,
   vectorRoutes,
+  vectorConfigApiRoutes,
   knowledgeRoutes,
   supersedeRoutes,
   forumApi,

--- a/tests/http/vector/config-api.test.ts
+++ b/tests/http/vector/config-api.test.ts
@@ -1,5 +1,4 @@
 import { afterAll, expect, test } from 'bun:test';
-import { Elysia } from 'elysia';
 import { mkdtempSync, readdirSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -12,10 +11,9 @@ process.env.ORACLE_DATA_DIR = root;
 process.env.ORACLE_VECTOR_HEALTH_TIMEOUT = '1500';
 
 const vectorConfig = await import('../../../src/vector/config.ts');
-const { vectorConfigApiEndpoint } = await import('../../../src/routes/vector/config-api.ts');
+const { vectorConfigApiRoutes } = await import('../../../src/routes/vector/config-api.ts');
 
-const app = new Elysia({ prefix: '/api' }).use(vectorConfigApiEndpoint);
-const versionedFetch = createApiVersionedFetch((request) => app.handle(request));
+const versionedFetch = createApiVersionedFetch((request) => vectorConfigApiRoutes.handle(request));
 
 function seedConfig() {
   const config = vectorConfig.generateDefaultConfig();
@@ -155,7 +153,7 @@ test('GET and PUT /api/v1/vector/config expose and update vector-server.json', a
   expect(removeRes.body.removed).toBe('phase2');
   expect(removeRes.body.config.collections.phase2).toBeUndefined();
 
-const patchRes = await call('/api/v1/vector/config', {
+  const patchRes = await call('/api/v1/vector/config', {
     method: 'PATCH',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ embedder: { default: 'ollama', fallback: 'openai' } }),


### PR DESCRIPTION
## Summary
- expose the vector config API as a directly server-mounted Elysia route cluster
- keep the existing vector route composer focused on vector data/search/export endpoints
- update the focused HTTP test to exercise the server-mounted route export

## Verification
- bunx tsc --noEmit
- bun test tests/http/vector/config-api.test.ts
- wc -l src/routes/vector/config-api.ts src/routes/vector/config-api-utils.ts tests/http/vector/config-api.test.ts src/server.ts src/vector/factory.ts src/routes/vector/index.ts