### PR TITLE
feat: add markdown export app core

### DIFF
--- a/tests/tools/export-app.test.ts
+++ b/tests/tools/export-app.test.ts
@@ -1,0 +1,108 @@
+import { afterAll, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const root = mkdtempSync(join(tmpdir(), 'arra-export-app-'));
+const defaultDbPath = join(root, 'oracle.db');
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = defaultDbPath;
+
+const dbModule = await import('../../src/db/index.ts');
+const appModule = await import('../../tools/export-app/index.ts');
+const exporterModule = await import('../../tools/export-app/exporter.ts');
+
+const { createDatabase, oracleDocuments, oracleMemories, resetDefaultDatabaseForTests } = dbModule;
+const { runExportApp } = appModule;
+const { exportMarkdownData, schemaTables } = exporterModule;
+
+function restoreDbPath(): string {
+  return savedDbPath
+    ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
+}
+
+function seed(connection: ReturnType<typeof createDatabase>): void {
+  const now = 1_766_000_000_000;
+  connection.db.insert(oracleDocuments).values([
+    {
+      id: 'doc-old', type: 'learning', sourceFile: 'psi/learn/old.md', concepts: '["backup"]',
+      createdAt: now, updatedAt: now + 1, indexedAt: now + 2, createdBy: 'test',
+    },
+    {
+      id: 'doc-new', type: 'learning', sourceFile: 'psi/learn/new.md', concepts: '["safe"]',
+      createdAt: now + 3, updatedAt: now + 4, indexedAt: now + 5, createdBy: 'test',
+    },
+  ]).run();
+  connection.db.insert(oracleMemories).values({
+    id: 'mem-1',
+    content: 'Memory export body',
+    title: 'Export memory',
+    createdAt: now,
+    updatedAt: now,
+  }).run();
+}
+
+afterAll(() => {
+  if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = savedDataDir;
+  if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = savedDbPath;
+  resetDefaultDatabaseForTests(restoreDbPath());
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('exports every schema collection as per-row markdown with frontmatter', async () => {
+  const connection = createDatabase(join(root, 'direct.db'));
+  const outputDir = join(root, 'direct-export');
+  const progress: string[] = [];
+  seed(connection);
+
+  try {
+    const result = await exportMarkdownData({
+      connection,
+      outputDir,
+      progress: (message) => progress.push(message),
+    });
+
+    expect(result.collectionCount).toBe(schemaTables().length);
+    expect(result.fileCount).toBeGreaterThanOrEqual(3);
+    expect(progress.some((line) => line.includes('oracle_documents'))).toBe(true);
+
+    const docFiles = readdirSync(join(outputDir, 'oracle_documents'));
+    expect(docFiles).toEqual(expect.arrayContaining(['doc-old.md', 'doc-new.md']));
+
+    const doc = readFileSync(join(outputDir, 'oracle_documents', 'doc-old.md'), 'utf8');
+    expect(doc.startsWith('---\n')).toBe(true);
+    expect(doc).toContain('id: "doc-old"');
+    expect(doc).toContain('collection: "oracle_documents"');
+    expect(doc).toContain('timestamps:\n  createdAt: 1766000000000');
+    expect(doc).toContain('"sourceFile": "psi/learn/old.md"');
+    expect(readFileSync(join(outputDir, 'oracle_memories', 'mem-1.md'), 'utf8'))
+      .toContain('Memory export body');
+  } finally {
+    connection.storage.close();
+  }
+});
+
+test('CLI exports markdown files from --db without starting the server', async () => {
+  const dbPath = join(root, 'cli.db');
+  const outputDir = join(root, 'cli-export');
+  const connection = createDatabase(dbPath);
+  seed(connection);
+  connection.storage.close();
+
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const code = await runExportApp(
+    ['--output', outputDir, '--db', dbPath],
+    (message) => stdout.push(message),
+    (message) => stderr.push(message),
+  );
+
+  expect(code).toBe(0);
+  expect(JSON.parse(stdout.join('')).success).toBe(true);
+  expect(stderr.join('')).toContain('oracle_documents');
+  expect(existsSync(join(outputDir, 'oracle_documents', 'doc-new.md'))).toBe(true);
+});

--- a/tests/tools/export-app/export-app.test.ts
+++ b/tests/tools/export-app/export-app.test.ts
@@ -96,7 +96,7 @@ describe('standalone export app', () => {
     }
   });
 
-  test('CLI writes a success summary and progress output', async () => {
+  test('CLI writes per-row markdown files and progress output', async () => {
     const outputDir = join(root, 'backup-cli');
     const stdout: string[] = [];
     const stderr: string[] = [];
@@ -106,7 +106,7 @@ describe('standalone export app', () => {
     expect(code).toBe(0);
     expect(JSON.parse(stdout.join('')).success).toBe(true);
     expect(stderr.join('')).toContain('oracle_documents');
-    expect(existsSync(join(outputDir, 'manifest.json'))).toBe(true);
+    expect(existsSync(join(outputDir, 'oracle_documents', 'doc-new.md'))).toBe(true);
   });
 
   test('graph relationship extraction is deterministic for rows', () => {

--- a/tools/export-app/exporter.ts
+++ b/tools/export-app/exporter.ts
@@ -1,20 +1,22 @@
-import { getTableName } from 'drizzle-orm';
+import { getTableName, isTable } from 'drizzle-orm';
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { DB_PATH } from '../../src/config.ts';
-import type { DatabaseConnection } from '../../src/db/index.ts';
 import { introspectDrizzleTables } from '../../src/cli/commands/backup.ts';
+import type { DatabaseConnection } from '../../src/db/index.ts';
+import * as schema from '../../src/db/schema.ts';
 import { createStorageBackend } from '../../src/storage/registry.ts';
 import {
   EXPORT_FORMATS,
   extensionFor,
   formatCollection,
+  normalizeRecord,
   normalizeRecords,
   type ExportRecord,
 } from './formats.ts';
 import { graphRelationships } from './graph.ts';
 
-type DumpTable = ReturnType<typeof introspectDrizzleTables>[number];
+type ExportTable = Parameters<typeof getTableName>[0];
 type Progress = (message: string) => void;
 
 export interface ExportAppOptions {
@@ -25,16 +27,27 @@ export interface ExportAppOptions {
   now?: () => Date;
 }
 
-export interface ExportAppResult {
+export interface ExportOracleDataResult {
   outputDir: string;
   collectionCount: number;
   rowCount: number;
   relationshipCount: number;
 }
 
+export interface ExportMarkdownResult {
+  outputDir: string;
+  collectionCount: number;
+  fileCount: number;
+}
+
 export { graphRelationships, type GraphRelationship } from './graph.ts';
 
-export async function exportOracleData(options: ExportAppOptions): Promise<ExportAppResult> {
+export function schemaTables(): ExportTable[] {
+  return (Object.values(schema).filter(isTable) as ExportTable[])
+    .sort((a, b) => getTableName(a).localeCompare(getTableName(b)));
+}
+
+export async function exportOracleData(options: ExportAppOptions): Promise<ExportOracleDataResult> {
   const close = options.connection ? undefined : openReadonlyConnection(options.dbPath);
   const connection = options.connection ?? close!.connection;
   const tables = introspectDrizzleTables();
@@ -59,16 +72,39 @@ export async function exportOracleData(options: ExportAppOptions): Promise<Expor
 
     const relationships = graphRelationships(allCollections);
     await writeCollectionFiles(outputDir, 'relationships', relationships);
-    await writeFile(path.join(outputDir, 'all-collections.json'), JSON.stringify({ exportedAt, collections: allCollections }, null, 2) + '\n');
-    await writeFile(path.join(outputDir, 'manifest.json'), JSON.stringify({
+    await writeJson(path.join(outputDir, 'all-collections.json'), { exportedAt, collections: allCollections });
+    await writeJson(path.join(outputDir, 'manifest.json'), {
       exportedAt,
       dbPath: options.dbPath ?? DB_PATH,
       formats: EXPORT_FORMATS,
       collectionCount: tables.length,
       rowCount,
       relationshipCount: relationships.length,
-    }, null, 2) + '\n');
+    });
     return { outputDir, collectionCount: tables.length, rowCount, relationshipCount: relationships.length };
+  } finally {
+    close?.connection.storage.close();
+  }
+}
+
+export async function exportMarkdownData(options: ExportAppOptions): Promise<ExportMarkdownResult> {
+  const close = options.connection ? undefined : openReadonlyConnection(options.dbPath);
+  const connection = options.connection ?? close!.connection;
+  const tables = schemaTables();
+  const outputDir = path.resolve(options.outputDir);
+  const progress = options.progress ?? ((message) => console.error(message));
+  let fileCount = 0;
+
+  try {
+    await mkdir(outputDir, { recursive: true });
+    for (let i = 0; i < tables.length; i += 1) {
+      const table = tables[i]!;
+      const name = getTableName(table);
+      const rows = selectRows(connection, table).map(normalizeRecord);
+      progress(`[${i + 1}/${tables.length}] ${name}: ${rows.length} rows`);
+      fileCount += await writeCollectionMarkdown(outputDir, name, rows);
+    }
+    return { outputDir, collectionCount: tables.length, fileCount };
   } finally {
     close?.connection.storage.close();
   }
@@ -79,7 +115,7 @@ function openReadonlyConnection(dbPath = DB_PATH): { connection: DatabaseConnect
   return { connection: { sqlite: storage.sqlite, db: storage.db, storage } };
 }
 
-function selectRows(connection: DatabaseConnection, table: DumpTable): ExportRecord[] {
+function selectRows(connection: DatabaseConnection, table: ExportTable): ExportRecord[] {
   return (connection.db as any).select().from(table).all() as ExportRecord[];
 }
 
@@ -90,6 +126,68 @@ async function writeCollectionFiles(baseDir: string, name: string, rows: ExportR
   }
 }
 
+async function writeCollectionMarkdown(baseDir: string, name: string, rows: ExportRecord[]): Promise<number> {
+  const collectionDir = path.join(baseDir, safeName(name));
+  const usedNames = new Map<string, number>();
+  await mkdir(collectionDir, { recursive: true });
+  for (let index = 0; index < rows.length; index += 1) {
+    const row = rows[index]!;
+    const id = rowIdentity(row, index);
+    const fileName = uniqueFileName(safeName(id), usedNames);
+    await writeFile(path.join(collectionDir, `${fileName}.md`), documentMarkdown(name, id, row), 'utf8');
+  }
+  return rows.length;
+}
+
+async function writeJson(file: string, value: unknown): Promise<void> {
+  await writeFile(file, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
 function safeName(name: string): string {
-  return name.replace(/[^a-zA-Z0-9._-]/g, '_');
+  return name.replace(/[^a-zA-Z0-9._-]/g, '_').replace(/^_+|_+$/g, '') || 'row';
+}
+
+function uniqueFileName(base: string, usedNames: Map<string, number>): string {
+  const count = usedNames.get(base) ?? 0;
+  usedNames.set(base, count + 1);
+  return count === 0 ? base : `${base}-${count + 1}`;
+}
+
+function rowIdentity(row: ExportRecord, index: number): string {
+  const id = row.id ?? row.traceId ?? row.key ?? row.documentId;
+  return id == null || id === '' ? `row-${index + 1}` : String(id);
+}
+
+function documentMarkdown(collection: string, id: string, row: ExportRecord): string {
+  return [
+    '---',
+    `id: ${yamlScalar(id)}`,
+    `collection: ${yamlScalar(collection)}`,
+    timestampsYaml(row),
+    '---',
+    '',
+    `# ${collection}/${id}`,
+    '',
+    '```json',
+    JSON.stringify(row, null, 2),
+    '```',
+    '',
+  ].join('\n');
+}
+
+function timestampsYaml(row: ExportRecord): string {
+  const entries = Object.entries(row).filter(([key, value]) => isTimestampKey(key) && value != null);
+  if (entries.length === 0) return 'timestamps: {}';
+  return ['timestamps:', ...entries.map(([key, value]) => `  ${key}: ${yamlScalar(value)}`)].join('\n');
+}
+
+function isTimestampKey(key: string): boolean {
+  return key.endsWith('At') || key.endsWith('_at');
+}
+
+function yamlScalar(value: unknown): string {
+  if (value == null) return 'null';
+  if (typeof value === 'number') return Number.isFinite(value) ? String(value) : 'null';
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  return JSON.stringify(String(value));
 }

--- a/tools/export-app/index.ts
+++ b/tools/export-app/index.ts
@@ -1,4 +1,4 @@
-import { exportOracleData } from './exporter.ts';
+import { exportMarkdownData } from './exporter.ts';
 
 type Writer = (message: string) => void;
 
@@ -9,9 +9,15 @@ interface CliOptions {
 
 function readValue(args: string[], flag: string): string | undefined {
   const index = args.indexOf(flag);
-  if (index >= 0) return args[index + 1];
+  if (index >= 0) {
+    const value = args[index + 1];
+    if (!value || value.startsWith('-')) throw new Error(`missing value for ${flag}`);
+    return value;
+  }
   const prefix = `${flag}=`;
-  return args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+  const value = args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+  if (value === '') throw new Error(`missing value for ${flag}`);
+  return value;
 }
 
 export function parseArgs(args: string[]): CliOptions {
@@ -24,8 +30,7 @@ function printHelp(write: Writer): void {
   write([
     'bun run tools/export-app/index.ts --output ./backup/ [--db ./oracle.db]',
     '',
-    'Exports all Drizzle-known Oracle collections as markdown, JSON, and CSV.',
-    'Also writes all-collections.json, graph relationships, and manifest.json.',
+    'Exports all Drizzle schema collections as per-row Markdown files.',
     '',
     'Flags:',
     '  --output, -o <dir>   destination backup directory',
@@ -42,7 +47,7 @@ export async function runExportApp(args: string[], stdout: Writer = process.stdo
       return 0;
     }
     const options = parseArgs(args);
-    const result = await exportOracleData({ ...options, progress: (message) => stderr(`${message}\n`) });
+    const result = await exportMarkdownData({ ...options, progress: (message) => stderr(`${message}\n`) });
     stdout(`${JSON.stringify({ success: true, ...result }, null, 2)}\n`);
     return 0;
   } catch (error) {


### PR DESCRIPTION
## Summary
- Rework the standalone export app core to enumerate Drizzle tables from src/db/schema.ts and export one Markdown file per row under <output>/<collection>/<id>.md.
- Add YAML frontmatter with id, collection, and timestamp fields, with full row metadata in the Markdown body.
- Replace the older multi-format export-app test with tests/tools/export-app.test.ts for the part-1 Markdown contract.

Refs #1783

## Validation
- rtk proxy bun test tests/tools/export-app.test.ts
- rtk test bun test tests/tools/
- rtk proxy bunx tsc --noEmit
- rtk wc -l tools/export-app/index.ts tools/export-app/exporter.ts tests/tools/export-app.test.ts