### PR TITLE
test: cover proxy adapter factory registration

### DIFF
--- a/tests/http/vector/proxy-adapter.test.ts
+++ b/tests/http/vector/proxy-adapter.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, expect, test } from 'bun:test';
 import type { VectorDocument } from '../../../src/vector/types.ts';
 import { ProxyVectorAdapter } from '../../../src/vector/adapters/proxy.ts';
+import { createVectorStore } from '../../../src/vector/factory.ts';
 import { vectorServiceUrl } from '../../../src/vector/registry.ts';
 
 const requests: Array<{ method: string; path: string; body?: unknown }> = [];
@@ -50,4 +51,15 @@ test('ProxyVectorAdapter speaks vector proxy protocol under endpoint path prefix
 
 test('vectorServiceUrl preserves path prefixes', () => {
   expect(vectorServiceUrl('http://example.test/base/', '/health')).toBe('http://example.test/base/health');
+});
+
+test('factory registers proxy vector stores', async () => {
+  const adapter = createVectorStore({
+    type: 'proxy',
+    collectionName: 'proxy_docs',
+    proxyEndpoint: `${server.url}proxy`,
+  });
+
+  expect(adapter).toBeInstanceOf(ProxyVectorAdapter);
+  await expect(adapter.getCollectionInfo()).resolves.toEqual({ name: 'remote_proxy_docs', count: 2 });
 });


### PR DESCRIPTION
Refs #1438

## Changes
- Verified `src/vector/adapters/proxy.ts`, `VectorDBType` proxy support, and factory registration already exist on current `origin/alpha`.
- Added focused regression coverage in `tests/http/vector/proxy-adapter.test.ts` proving `createVectorStore({ type: "proxy" })` returns `ProxyVectorAdapter` and can use the registered endpoint.

## Validation
- bun test tests/http/vector/proxy-adapter.test.ts
- bunx tsc --noEmit
- wc -l src/vector/adapters/proxy.ts src/vector/factory.ts src/vector/types.ts tests/http/vector/proxy-adapter.test.ts

Note: implementation was already present on alpha when this subtask arrived; this PR covers the factory registration requirement without duplicating existing code.