### PR TITLE
fix: expose vector details in health endpoint

### DIFF
--- a/src/routes/health/health.ts
+++ b/src/routes/health/health.ts
@@ -22,16 +22,23 @@ type DiskHealth = {
   error?: string;
 };
 
+const HealthVectorEngineSchema = t.Object({
+  key: t.String(),
+  model: t.String(),
+  collection: t.String(),
+  adapter: t.Optional(t.String()),
+  embeddingProvider: t.Optional(t.String()),
+  connectionStatus: t.Optional(t.Union([t.Literal('connected'), t.Literal('error')])),
+  count: t.Optional(t.Number()),
+  ok: t.Boolean(),
+  error: t.Optional(t.String()),
+});
+
 const HealthVectorSchema = t.Object({
   status: t.Union([t.Literal('ok'), t.Literal('degraded'), t.Literal('down')]),
   checked_at: t.String(),
-  engines: t.Array(t.Object({
-    key: t.String(),
-    model: t.String(),
-    collection: t.String(),
-    ok: t.Boolean(),
-    error: t.Optional(t.String()),
-  })),
+  engines: t.Array(HealthVectorEngineSchema),
+  collections: t.Optional(t.Array(HealthVectorEngineSchema)),
   error: t.Optional(t.String()),
 });
 
@@ -113,11 +120,13 @@ async function defaultDbPing(): Promise<DbStatus> {
 
 async function readVectorStatus(check = readVectorBackendHealth): Promise<VectorHealth> {
   try {
-    return await check();
+    const vector = await check();
+    return { ...vector, collections: vector.collections ?? vector.engines };
   } catch (error) {
     return {
       status: 'down',
       engines: [],
+      collections: [],
       checked_at: new Date().toISOString(),
       error: errorMessage(error),
     } as VectorHealth & { error: string };

--- a/src/vector/health.ts
+++ b/src/vector/health.ts
@@ -1,10 +1,17 @@
-import { ensureVectorStoreConnected, getEmbeddingModels } from './factory.ts';
+import {
+  ensureVectorStoreConnected,
+  getEmbeddingModels,
+  type EmbeddingModelConfig,
+} from './factory.ts';
+import { resolveEmbeddingProviderType } from './embedder-config.ts';
 
 export type VectorBackendEngine = {
   key: string;
   model: string;
   collection: string;
-  adapter?: string;
+  adapter: string;
+  embeddingProvider: string;
+  connectionStatus: 'connected' | 'error';
   count: number;
   ok: boolean;
   error?: string;
@@ -27,6 +34,7 @@ export type VectorFreshness = {
 export type VectorBackendHealth = {
   status: 'ok' | 'degraded' | 'down';
   engines: VectorBackendEngine[];
+  collections?: VectorBackendEngine[];
   checked_at: string;
   providers?: VectorProviderHealth[];
   freshness?: VectorFreshness;
@@ -40,6 +48,7 @@ export function attachVectorDashboardHealth(
   const totalIndexed = health.engines.reduce((sum, engine) => sum + (engine.count || 0), 0);
   return {
     ...health,
+    collections: health.collections ?? health.engines,
     providers: providers.map((provider) => ({
       type: provider.type,
       available: provider.available,
@@ -61,37 +70,46 @@ function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   return Promise.race([promise, timeout]).finally(() => { if (timer) clearTimeout(timer); });
 }
 
+function vectorEngineDetails(preset: EmbeddingModelConfig) {
+  return {
+    adapter: preset.adapter || 'lancedb',
+    embeddingProvider: preset.embedder?.backend ?? resolveEmbeddingProviderType(),
+  };
+}
+
 export async function readVectorBackendHealth(): Promise<VectorBackendHealth> {
   const timeout = parseInt(process.env.ORACLE_VECTOR_HEALTH_TIMEOUT || '2000', 10);
   const models = getEmbeddingModels();
-  const engines: VectorBackendEngine[] = [];
 
-  await Promise.all(Object.entries(models).map(async ([key, preset]) => {
+  const engines = await Promise.all(Object.entries(models).map(async ([key, preset]) => {
+    const details = vectorEngineDetails(preset);
     try {
       const store = await ensureVectorStoreConnected(key);
       const stats = await withTimeout(store.getStats(), timeout);
-      engines.push({
+      return {
         key,
         model: preset.model,
         collection: preset.collection,
-        adapter: preset.adapter,
+        ...details,
+        connectionStatus: 'connected' as const,
         count: stats.count,
         ok: true,
-      });
+      };
     } catch (error) {
-      engines.push({
+      return {
         key,
         model: preset.model,
         collection: preset.collection,
-        adapter: preset.adapter,
+        ...details,
+        connectionStatus: 'error' as const,
         count: 0,
         ok: false,
         error: error instanceof Error ? error.message : String(error),
-      });
+      };
     }
   }));
 
   const okCount = engines.filter((engine) => engine.ok).length;
   const status = okCount === engines.length ? 'ok' : okCount === 0 ? 'down' : 'degraded';
-  return { status, engines, checked_at: new Date().toISOString() };
+  return { status, engines, collections: engines, checked_at: new Date().toISOString() };
 }

--- a/tests/http/health/vector-details.test.ts
+++ b/tests/http/health/vector-details.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import {
+  API_VERSION_HEADER,
+  createApiVersionHeaderMiddleware,
+  createApiVersionedFetch,
+} from '../../../src/middleware/api-version.ts';
+import { createHealthRoutes } from '../../../src/routes/health/index.ts';
+
+test('GET /api/v1/health includes vector per-collection details', async () => {
+  const app = new Elysia()
+    .use(createApiVersionHeaderMiddleware())
+    .use(createHealthRoutes({
+      pluginCount: 0,
+      uptimeSeconds: () => 2,
+      dbPing: () => ({ status: 'connected' }),
+      vectorHealth: async () => ({
+        status: 'degraded',
+        checked_at: '2026-06-16T00:00:00.000Z',
+        engines: [
+          {
+            key: 'bge-m3',
+            model: 'bge-m3',
+            collection: 'oracle_knowledge_bge_m3',
+            adapter: 'lancedb',
+            embeddingProvider: 'ollama',
+            connectionStatus: 'connected',
+            count: 42,
+            ok: true,
+          },
+          {
+            key: 'qwen3',
+            model: 'qwen3-embedding',
+            collection: 'oracle_knowledge_qwen3',
+            adapter: 'qdrant',
+            embeddingProvider: 'remote',
+            connectionStatus: 'error',
+            count: 0,
+            ok: false,
+            error: 'timeout',
+          },
+        ],
+      }),
+    }));
+  const fetchVersioned = createApiVersionedFetch((request) => app.handle(request));
+
+  const res = await fetchVersioned(new Request('http://local/api/v1/health'));
+  const body = await res.json() as Record<string, any>;
+
+  expect(res.status).toBe(200);
+  expect(res.headers.get(API_VERSION_HEADER)).toBe('v1');
+  expect(body.vectorStatus).toBe('degraded');
+  expect(body.vector.collections).toEqual(body.vector.engines);
+  expect(body.vector.collections).toMatchObject([
+    {
+      collection: 'oracle_knowledge_bge_m3',
+      adapter: 'lancedb',
+      connectionStatus: 'connected',
+      count: 42,
+      embeddingProvider: 'ollama',
+      model: 'bge-m3',
+    },
+    {
+      collection: 'oracle_knowledge_qwen3',
+      adapter: 'qdrant',
+      connectionStatus: 'error',
+      count: 0,
+      embeddingProvider: 'remote',
+      model: 'qwen3-embedding',
+      error: 'timeout',
+    },
+  ]);
+});


### PR DESCRIPTION
## Summary
- add adapter, embedding provider, connection status, and document count to vector health engines
- expose normalized vector.collections details on GET /api/v1/health
- add health contract coverage for the versioned endpoint

## Tests
- bunx tsc --noEmit
- bun test tests/http/health/