### PR TITLE
Add tenant-scoped database helper

### DIFF
--- a/src/db/tenant.ts
+++ b/src/db/tenant.ts
@@ -1,0 +1,59 @@
+import path from 'node:path';
+import type { DatabaseConnection } from './index.ts';
+import { createDatabase } from './index.ts';
+import { ORACLE_DATA_DIR } from '../config.ts';
+
+const DEFAULT_TENANT_ID = 'default';
+const TENANT_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/;
+
+export interface TenantDatabaseConnection extends DatabaseConnection {
+  tenantId: string;
+  dbPath: string;
+  close(): void;
+}
+
+export interface GetTenantDbOptions {
+  dataDir?: string;
+}
+
+const connections = new Map<string, TenantDatabaseConnection>();
+
+export function getTenantDb(
+  tenantId: string,
+  options: GetTenantDbOptions = {},
+): TenantDatabaseConnection {
+  const normalizedTenant = normalizeTenantId(tenantId);
+  const dbPath = tenantDbPath(normalizedTenant, options.dataDir);
+  const cached = connections.get(dbPath);
+  if (cached) return cached;
+
+  const connection = createDatabase(dbPath);
+  const tenantConnection: TenantDatabaseConnection = {
+    ...connection,
+    tenantId: normalizedTenant,
+    dbPath,
+    close() {
+      connections.delete(dbPath);
+      connection.storage.close();
+    },
+  };
+  connections.set(dbPath, tenantConnection);
+  return tenantConnection;
+}
+
+export function closeTenantDbsForTests(): void {
+  for (const connection of connections.values()) {
+    try { connection.storage.close(); } catch {}
+  }
+  connections.clear();
+}
+
+function tenantDbPath(tenantId: string, dataDir = ORACLE_DATA_DIR): string {
+  return path.join(dataDir, 'tenants', tenantId, 'oracle.db');
+}
+
+function normalizeTenantId(tenantId: string): string {
+  const trimmed = tenantId.trim() || DEFAULT_TENANT_ID;
+  if (!TENANT_PATTERN.test(trimmed)) throw new Error('invalid tenant id');
+  return trimmed;
+}

--- a/src/middleware/tenant.ts
+++ b/src/middleware/tenant.ts
@@ -6,8 +6,9 @@ import { eq, type SQL } from 'drizzle-orm';
 
 export const TENANT_HEADER = 'X-Oracle-Tenant';
 export const TENANT_TOKEN_HEADER = 'X-Oracle-Tenant-Token';
-export const LEGACY_TENANT_HEADER = 'X-Tenant-Id';
+export const LEGACY_TENANT_HEADER = 'X-Tenant-ID';
 export const ORG_HEADER = 'X-Org-Id';
+export const TENANT_API_KEY_HEADER = 'X-API-Key';
 const TENANT_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/;
 
 export const DEFAULT_TENANT_ID = 'default';
@@ -35,10 +36,31 @@ export function parseTenantTokens(raw = process.env.ORACLE_TENANT_TOKENS ?? ''):
   }).filter(([tenant, token]) => tenant && token));
 }
 
+export function parseTenantApiKeys(raw = process.env.ORACLE_TENANT_API_KEYS ?? ''): TenantTokenMap {
+  return parseTenantTokens(raw);
+}
+
+function bearerToken(headers: Headers): string {
+  const value = headers.get('authorization') ?? '';
+  return value.match(/^Bearer\s+(.+)$/i)?.[1]?.trim() ?? '';
+}
+
+function tenantIdFromApiKey(headers: Headers, apiKeys = parseTenantApiKeys()): string | undefined {
+  const actual = headers.get(TENANT_API_KEY_HEADER)?.trim() || bearerToken(headers);
+  if (!actual) return undefined;
+  for (const [tenantId, expected] of Object.entries(apiKeys)) {
+    if (expected && safeEqual(actual, expected)) {
+      if (!TENANT_PATTERN.test(tenantId)) throw new Error('invalid tenant id');
+      return tenantId;
+    }
+  }
+  return undefined;
+}
+
 export function tenantIdFromHeaders(headers: Headers): string | undefined {
   const raw = headers.get(TENANT_HEADER) ?? headers.get(LEGACY_TENANT_HEADER) ?? headers.get(ORG_HEADER);
   const tenant = raw?.trim();
-  if (!tenant) return undefined;
+  if (!tenant) return tenantIdFromApiKey(headers);
   if (!TENANT_PATTERN.test(tenant)) throw new Error('invalid tenant id');
   return tenant;
 }

--- a/tests/http/tenant/middleware.test.ts
+++ b/tests/http/tenant/middleware.test.ts
@@ -1,0 +1,105 @@
+import { afterAll, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { Elysia } from 'elysia';
+import { eq } from 'drizzle-orm';
+import { getTenantDb, closeTenantDbsForTests } from '../../../src/db/tenant.ts';
+import { settings } from '../../../src/db/index.ts';
+import {
+  createTenantMiddleware,
+  LEGACY_TENANT_HEADER,
+  TENANT_API_KEY_HEADER,
+} from '../../../src/middleware/tenant.ts';
+
+const root = mkdtempSync(path.join(tmpdir(), 'arra-tenant-middleware-'));
+const tenantA = `tenant-a-${Date.now()}`;
+const tenantB = `tenant-b-${Date.now()}`;
+
+afterAll(() => {
+  closeTenantDbsForTests();
+  rmSync(root, { recursive: true, force: true });
+});
+
+const app = new Elysia()
+  .use(createTenantMiddleware())
+  .post('/notes', ({ body, tenantId, set }) => {
+    if (!tenantId) {
+      set.status = 400;
+      return { error: 'tenant required' };
+    }
+    const value = (body as { value?: string }).value ?? '';
+    const tenantDb = getTenantDb(tenantId, { dataDir: root });
+    tenantDb.db.insert(settings)
+      .values({ key: 'tenant-note', value, updatedAt: Date.now() })
+      .onConflictDoUpdate({
+        target: settings.key,
+        set: { value, updatedAt: Date.now() },
+      })
+      .run();
+    return { tenantId, dbPath: tenantDb.dbPath, value };
+  })
+  .get('/notes', ({ tenantId, set }) => {
+    if (!tenantId) {
+      set.status = 400;
+      return { error: 'tenant required' };
+    }
+    const tenantDb = getTenantDb(tenantId, { dataDir: root });
+    const row = tenantDb.db.select({ value: settings.value })
+      .from(settings)
+      .where(eq(settings.key, 'tenant-note'))
+      .get();
+    return { tenantId, dbPath: tenantDb.dbPath, value: row?.value ?? null };
+  });
+
+function request(pathname: string, init: RequestInit = {}) {
+  return app.handle(new Request(`http://local${pathname}`, init));
+}
+
+test('tenant middleware isolates HTTP data by X-Tenant-ID header', async () => {
+  const headers = (tenantId: string) => ({
+    'content-type': 'application/json',
+    [LEGACY_TENANT_HEADER]: tenantId,
+  });
+
+  const createdA = await request('/notes', {
+    method: 'POST',
+    headers: headers(tenantA),
+    body: JSON.stringify({ value: 'alpha-only' }),
+  });
+  const createdB = await request('/notes', {
+    method: 'POST',
+    headers: headers(tenantB),
+    body: JSON.stringify({ value: 'beta-only' }),
+  });
+
+  expect(createdA.status).toBe(200);
+  expect(createdB.status).toBe(200);
+
+  const seenA = await request('/notes', { headers: headers(tenantA) });
+  const seenB = await request('/notes', { headers: headers(tenantB) });
+  const bodyA = await seenA.json() as { dbPath: string; value: string };
+  const bodyB = await seenB.json() as { dbPath: string; value: string };
+
+  expect(bodyA.value).toBe('alpha-only');
+  expect(bodyB.value).toBe('beta-only');
+  expect(bodyA.dbPath).not.toBe(bodyB.dbPath);
+});
+
+test('tenant middleware can derive tenant from configured API key', async () => {
+  const previous = process.env.ORACLE_TENANT_API_KEYS;
+  process.env.ORACLE_TENANT_API_KEYS = `${tenantA}=tenant-a-key`;
+  try {
+    const res = await request('/notes', {
+      headers: { [TENANT_API_KEY_HEADER]: 'tenant-a-key' },
+    });
+    const body = await res.json() as { tenantId: string; value: string };
+
+    expect(res.status).toBe(200);
+    expect(body.tenantId).toBe(tenantA);
+    expect(body.value).toBe('alpha-only');
+  } finally {
+    if (previous === undefined) delete process.env.ORACLE_TENANT_API_KEYS;
+    else process.env.ORACLE_TENANT_API_KEYS = previous;
+  }
+});


### PR DESCRIPTION
## Summary\n- add getTenantDb(tenantId) for per-tenant SQLite files under the data directory\n- extend tenant middleware to derive tenant IDs from configured API keys when no tenant header is present\n- add HTTP middleware isolation coverage for X-Tenant-ID and API-key-derived tenants\n\n## Validation\n- merged current origin/alpha before validation; no tenant-file conflicts\n- bun test tests/http/tenant/\n- bunx tsc --noEmit\n- wc -l src/middleware/tenant.ts src/db/tenant.ts tests/http/tenant/middleware.test.ts