### PR TITLE
fix(maw): tighten vector config read output

### DIFF
--- a/maw-plugin/__tests__/index.test.ts
+++ b/maw-plugin/__tests__/index.test.ts
@@ -134,6 +134,7 @@ describe('maw arra plugin', () => {
       [['feed'], 'GET', '/api/feed'],
       [['menu'], 'GET', '/api/menu'],
       [['vector'], 'GET', '/api/vector/config'],
+      [['vector-config'], 'GET', '/api/v1/vector/config'],
       [['vector_status'], 'GET', '/api/vector/index/status'],
       [['vector_models'], 'GET', '/api/vector/index/models'],
       [['health'], 'GET', '/api/health'],

--- a/maw-plugin/__tests__/vector-config.test.ts
+++ b/maw-plugin/__tests__/vector-config.test.ts
@@ -35,10 +35,10 @@ describe('maw arra vector-config', () => {
 
     expect(result.ok).toBe(true);
     expect(calls.map(call => [call.init?.method, call.path])).toEqual([['GET', '/api/v1/vector/config']]);
-    expect(result.output).toContain('Collection | Adapter | Model | Enabled | Docs | Status');
-    expect(result.output).toContain('oracle_knowledge_bge_m3 ★ | lancedb | bge-m3 | true | 42 | ok');
+    expect(result.output).toContain('Collection | Adapter | Model | Docs | Status');
+    expect(result.output).toContain('oracle_knowledge_bge_m3 ★ | lancedb | bge-m3 | 42 | ok');
     expect(result.output).toContain('★ = primary');
-    expect(result.output).toContain('oracle_knowledge_nomic | lancedb | nomic-embed-text | true | 7 | down');
+    expect(result.output).toContain('oracle_knowledge_nomic | lancedb | nomic-embed-text | 7 | down');
   });
 
   test('prints raw config payload with --json', async () => {

--- a/maw-plugin/vector-config.ts
+++ b/maw-plugin/vector-config.ts
@@ -92,12 +92,12 @@ function pickCollection(data: any, collection: string): any | undefined {
 }
 
 function formatList(data: any): string {
-  const lines = ['Collection | Adapter | Model | Enabled | Docs | Status'];
+  const lines = ['Collection | Adapter | Model | Docs | Status'];
   for (const row of rows(data)) {
     const label = `${row.collection ?? row.key}${row.primary ? ' ★' : ''}`;
-    lines.push(`${label} | ${row.adapter ?? 'lancedb'} | ${row.model ?? row.key} | ${row.enabled !== false} | ${row.count ?? 0} | ${row.status ?? (row.ok === false ? 'down' : 'ok')}`);
+    lines.push(`${label} | ${row.adapter ?? 'lancedb'} | ${row.model ?? row.key} | ${row.count ?? 0} | ${row.status ?? (row.ok === false ? 'down' : 'ok')}`);
   }
-  if (lines.length === 1) lines.push('(none) | - | - | true | 0 | unknown');
+  if (lines.length === 1) lines.push('(none) | - | - | 0 | unknown');
   return [lines.join('\n'), '★ = primary'].join('\n');
 }
 


### PR DESCRIPTION
## Summary
- keep maw arra vector-config as a GET /api/v1/vector/config read command
- make the default table match collection, adapter, model, docs, status
- cover the hyphenated vector-config route through the main maw arra entrypoint

## Verification
- bun test maw-plugin/__tests__/vector-config.test.ts maw-plugin/__tests__/index.test.ts
- bunx tsc --noEmit
- git diff --check
- wc -l maw-plugin/vector-config.ts maw-plugin/__tests__/vector-config.test.ts maw-plugin/__tests__/index.test.ts