### PR TITLE
feat: add frontend plugins and status pages

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -67,7 +67,7 @@ export interface VectorIndexStartResponse {
 }
 
 export interface ApiRouteResponses {
-  '/api/health': HealthResponse;
+  '/api/v1/health': HealthResponse;
   '/api/v1/metrics': MetricsSnapshot;
   '/api/menu': MenuResponse;
   '/api/menu/search': MenuSearchResponse;
@@ -151,7 +151,7 @@ export class ApiClient {
   }
 
   health(): Promise<HealthResponse> {
-    return this.request('/api/health');
+    return this.request('/api/v1/health');
   }
 
   metrics(): Promise<MetricsSnapshot> {

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -6,6 +6,7 @@ import { routeMeta } from '../routeMeta';
 import { PageChrome } from './PageChrome';
 import { StatCard } from './StatCard';
 import { CommandPalette } from './CommandPalette';
+import { TauriBadge } from './TauriBadge';
 import { ThemeToggle } from './ThemeToggle';
 import { GlobalSearch } from './GlobalSearch';
 import type { MetricsSnapshot } from '../../../src/server/types';
@@ -50,6 +51,7 @@ export function AppShell({
   const navItems: NavItem[] = [
     { to: '/', label: 'Menu', description: 'Navigation rows from /api/menu', badge: loading ? '…' : menuCount },
     { to: '/plugins', label: 'Plugins', description: 'Registered plugins and surfaces', badge: loading ? '…' : pluginCount },
+    { to: '/status', label: 'Status', description: 'Server health from /api/v1/health' },
     { to: '/canvas/plugins', label: 'Canvas Plugins', description: 'Canvas registry from /api/canvas/plugins' },
     { to: '/search', label: 'Search', description: 'Full-text menu search' },
     { to: '/vector', label: 'Vector Dashboard', description: 'Collection health and indexing', end: true },
@@ -95,6 +97,7 @@ export function AppShell({
               <CommandPalette onRefresh={onRefresh} />
               <GlobalSearch />
               <div className="grid gap-3 sm:flex sm:items-center sm:justify-end">
+                <TauriBadge connected={!error} />
                 <ThemeToggle />
                 <button
                   className="focus-ring rounded-xl bg-teal-300 px-5 py-3 font-semibold text-slate-950 transition hover:bg-teal-200 disabled:cursor-not-allowed disabled:opacity-60"

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -24,6 +24,7 @@ export function CommandPalette({ onRefresh }: { onRefresh: () => void }) {
       { id: 'vector', label: 'Vector', description: 'Open vector search results.', href: '/vector' },
       { id: 'metrics', label: 'Metrics', description: 'Review dashboard metrics and counts.', href: '/metrics' },
       { id: 'plugins', label: 'Plugins', description: 'Review plugins and runtime surfaces.', href: '/plugins' },
+      { id: 'status', label: 'Status', description: 'Review server health from /api/v1/health.', href: '/status' },
       { id: 'settings', label: 'Settings', description: 'Inspect runtime settings and migration status.', href: '/settings' },
       { id: 'refresh', label: 'Refresh dashboard data', description: 'Reload menu and plugin data.', onAction: onRefresh },
     ],

--- a/frontend/src/pages/PluginsPage.tsx
+++ b/frontend/src/pages/PluginsPage.tsx
@@ -28,7 +28,7 @@ export function enabledStateForPlugins(plugins: PluginEntry[]): PluginEnabledSta
 export function pluginAdminSummary(plugins: PluginEntry[], enabledState: PluginEnabledState): string {
   const enabled = plugins.filter((plugin) => isPluginEnabled(plugin, enabledState)).length;
   const disabled = plugins.length - enabled;
-  return `${enabled} enabled · ${disabled} disabled · ${plugins.length} installed`;
+  return `${enabled} enabled · ${disabled} disabled · ${plugins.length} registered`;
 }
 
 function pluginStatusClass(status: string): string {
@@ -212,7 +212,7 @@ export function PluginsPage({ plugins: initialPlugins = [], loading = true, clie
           <div>
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Plugin admin</p>
             <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Plugin list</p>
-            <h2 id="plugins-page-title" className="mt-2 text-2xl font-semibold text-white">Installed plugins</h2>
+            <h2 id="plugins-page-title" className="mt-2 text-2xl font-semibold text-white">Registered plugins</h2>
             <p className="mt-2 text-sm text-slate-400">Canvas view for unified backend surfaces from GET /api/plugins, with install/uninstall controls.</p>
           </div>
           <div className="flex flex-wrap gap-2"><p className="rounded-full border border-white/10 px-3 py-2 text-sm text-slate-300">{summary}</p><p className="rounded-full border border-white/10 px-3 py-2 text-sm text-slate-300">{surfaceCount} surfaces</p></div>

--- a/frontend/src/pages/StatusPage.tsx
+++ b/frontend/src/pages/StatusPage.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useMemo, useState } from 'react';
+import { apiClient, type ApiClient } from '../api/client';
+import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
+import type { HealthResponse } from '../../../src/server/types';
+
+type PageState = 'loading' | 'ready' | 'error';
+type StatusClient = Pick<ApiClient, 'health'>;
+
+export interface StatusPageProps {
+  client?: StatusClient;
+}
+
+function statusClass(status?: string): string {
+  if (status === 'ok' || status === 'connected') return 'border-emerald-300/30 bg-emerald-300/10 text-emerald-100';
+  if (status === 'degraded' || status === 'draining') return 'border-amber-300/30 bg-amber-300/10 text-amber-100';
+  return 'border-red-300/30 bg-red-300/10 text-red-100';
+}
+
+function formatSeconds(seconds?: number): string {
+  if (typeof seconds !== 'number' || !Number.isFinite(seconds)) return 'unknown';
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remaining = Math.round(seconds % 60);
+  return `${minutes}m ${remaining}s`;
+}
+
+function Field({ label, value }: { label: string; value: string | number | undefined }) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+      <dt className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{label}</dt>
+      <dd className="mt-2 font-mono text-sm text-slate-100">{value ?? 'unknown'}</dd>
+    </div>
+  );
+}
+
+function StatusBadge({ label, status }: { label: string; status?: string }) {
+  return (
+    <div className={`rounded-2xl border p-4 ${statusClass(status)}`}>
+      <p className="text-xs font-semibold uppercase tracking-[0.18em] opacity-80">{label}</p>
+      <p className="mt-2 text-2xl font-semibold">{status ?? 'unknown'}</p>
+    </div>
+  );
+}
+
+function PluginRows({ health }: { health: HealthResponse }) {
+  const items = health.plugins?.items ?? [];
+  if (!items.length) return <p className="text-sm text-slate-400">No plugin health rows returned.</p>;
+  return (
+    <ul className="grid gap-2">
+      {items.map((plugin) => (
+        <li key={plugin.name} className="flex flex-col gap-2 rounded-xl border border-white/10 bg-white/[0.03] p-3 sm:flex-row sm:items-center sm:justify-between">
+          <span className="font-mono text-sm text-slate-100">{plugin.name}</span>
+          <span className={`rounded-full border px-2 py-1 text-xs ${statusClass(plugin.status)}`}>{plugin.status}</span>
+          {plugin.error ? <span className="text-sm text-amber-200">{plugin.error}</span> : null}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function StatusPage({ client = apiClient }: StatusPageProps) {
+  const [state, setState] = useState<PageState>('loading');
+  const [health, setHealth] = useState<HealthResponse | null>(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    setState('loading');
+    setError('');
+    client.health()
+      .then((response) => {
+        if (cancelled) return;
+        setHealth(response);
+        setState('ready');
+      })
+      .catch((cause) => {
+        if (cancelled) return;
+        setError(cause instanceof Error ? cause.message : String(cause));
+        setState('error');
+      });
+    return () => { cancelled = true; };
+  }, [client]);
+
+  const uptime = useMemo(() => formatSeconds(health?.uptimeSeconds ?? health?.uptime?.seconds), [health]);
+  const isLoading = state === 'loading';
+
+  return (
+    <section className="grid gap-5" aria-labelledby="status-page-title">
+      <div className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Server status</p>
+        <h2 id="status-page-title" className="mt-2 text-2xl font-semibold text-white">Health overview</h2>
+        <p className="mt-2 text-sm text-slate-400">Live health from GET /api/v1/health.</p>
+      </div>
+
+      {isLoading ? <LoadingPanel title="Loading server health…" detail="Fetching /api/v1/health from the Elysia backend." /> : null}
+      {state === 'error' ? <ErrorMessage title="Could not load server health." message={error} /> : null}
+
+      {health && state === 'ready' ? (
+        <>
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            <StatusBadge label="Server" status={health.status} />
+            <StatusBadge label="Database" status={health.dbStatus ?? health.db?.status} />
+            <StatusBadge label="Vector" status={health.vectorStatus ?? health.vector?.status} />
+            <StatusBadge label="Plugins" status={health.pluginStatus ?? health.plugins?.status} />
+          </div>
+          <dl className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            <Field label="Name" value={health.server} />
+            <Field label="Version" value={health.version} />
+            <Field label="Port" value={health.port} />
+            <Field label="Uptime" value={uptime} />
+            <Field label="MCP tools" value={health.mcpToolCount ?? health.mcp?.toolCount} />
+            <Field label="Plugins" value={health.pluginCount ?? health.plugins?.count} />
+            <Field label="Oracle" value={health.oracle} />
+            <Field label="DB path" value={health.db?.path} />
+          </dl>
+          <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-label="Plugin health rows">
+            <h3 className="text-lg font-semibold text-white">Plugin health</h3>
+            <div className="mt-4"><PluginRows health={health} /></div>
+          </section>
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/routeMeta.ts
+++ b/frontend/src/routeMeta.ts
@@ -69,6 +69,7 @@ export function routeMeta(pathname: string, search = ''): RouteMeta {
   }
 
   if (pathname === '/plugins') return base('Plugin list', 'Plugins', 'Registered plugins and exposed runtime surfaces.', [{ label: 'Plugins' }]);
+  if (pathname === '/status') return base('Server status', 'Status', 'Server health from /api/v1/health.', [{ label: 'Status' }]);
   if (pathname === '/canvas/plugins') return base('Canvas plugins', 'Canvas', 'Canvas plugin registry and standalone status.', [{ label: 'Canvas plugins' }]);
   if (pathname === '/metrics') return base('Runtime metrics', 'Metrics', 'Runtime counters from /api/v1/metrics.', [{ label: 'Metrics' }]);
   if (pathname === '/search') return base('Search', 'Search', 'Search menu, plugin, and MCP tool surfaces.', [{ label: 'Search' }]);

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -10,6 +10,7 @@ import { PluginsPage } from './pages/PluginsPage';
 import { CanvasPluginsPage } from './pages/CanvasPluginsPage';
 import { SearchPage } from './pages/SearchPage';
 import { SettingsPage } from './pages/SettingsPage';
+import { StatusPage } from './pages/StatusPage';
 import { VectorPage } from './pages/VectorPage';
 import { VectorSearchPage } from './pages/VectorSearchPage';
 import { VectorDocumentsPage } from './pages/VectorDocumentsPage';
@@ -22,6 +23,7 @@ import type { MetricsSnapshot } from '../../src/server/types';
 export const frontendRoutes = [
   '/',
   '/plugins',
+  '/status',
   '/canvas/plugins',
   '/metrics',
   '/search',
@@ -74,6 +76,7 @@ export function DashboardRoutes({
     <Routes>
       <Route index element={menuPage} />
       <Route path="/plugins" element={pluginPage} />
+      <Route path="/status" element={<StatusPage />} />
       <Route path="/canvas/plugins" element={<CanvasPluginsPage />} />
       <Route path="/metrics" element={<MetricsPage metrics={metrics} loading={isRouteLoading(states.metrics)} />} />
       <Route path="/search" element={<SearchPage />} />

--- a/tests/frontend/api-client.test.ts
+++ b/tests/frontend/api-client.test.ts
@@ -12,7 +12,7 @@ function jsonResponse(data: unknown, init: ResponseInit = {}): Response {
 describe('frontend API client', () => {
   test('calls each typed backend route with JSON accept headers', async () => {
     const payloads: Record<string, unknown> = {
-      '/api/health': { status: 'ok', server: 'arra', version: '26.5.30', port: 47778 },
+      '/api/v1/health': { status: 'ok', server: 'arra', version: '26.5.30', port: 47778 },
       '/api/v1/metrics': {
         uptime: 4.2,
         requestCount: 7,
@@ -66,7 +66,7 @@ describe('frontend API client', () => {
     await expect(client.plugins()).resolves.toMatchObject({ plugins: [{ name: 'echo' }] });
 
     expect(calls.map((call) => String(call.input))).toEqual([
-      '/api/health',
+      '/api/v1/health',
       '/api/v1/metrics',
       '/api/menu',
       '/api/menu/search?q=vector',
@@ -107,8 +107,8 @@ describe('frontend API client', () => {
     const networkClient = createApiClient({ fetch: () => { throw new Error('ECONNREFUSED'); } });
     await expect(networkClient.health()).rejects.toMatchObject({
       status: 0,
-      path: '/api/health',
-      message: '/api/health is unreachable: ECONNREFUSED',
+      path: '/api/v1/health',
+      message: '/api/v1/health is unreachable: ECONNREFUSED',
     } as ApiClientError);
 
     const invalidClient = createApiClient({ fetch: () => new Response('{nope', { status: 200 }) });

--- a/tests/frontend/dashboard.test.ts
+++ b/tests/frontend/dashboard.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { createElement } from 'react';
 import App, { loadDashboardData } from '../../frontend/src/App';
-import { AppRouter } from '../../frontend/src/router';
 import { htmlFor, installBrowserLocation } from './_render';
 
 describe('dashboard data loading', () => {
@@ -34,7 +33,7 @@ describe('dashboard data loading', () => {
   test('renders dashboard metric cards with loading state before effects resolve', () => {
     const restore = installBrowserLocation('/menu');
     try {
-      const html = htmlFor(createElement(AppRouter, null, createElement(App)));
+      const html = htmlFor(createElement(App));
       expect(html).toContain('Requests');
       expect(html).toContain('Avg response');
       expect(html).toContain('Loading metrics');

--- a/tests/frontend/pages/plugins-page-admin.test.tsx
+++ b/tests/frontend/pages/plugins-page-admin.test.tsx
@@ -7,7 +7,7 @@ describe('PluginsPage admin view', () => {
     const plugins = [{ name: 'canvas', file: '', size: 0, modified: 'now', version: '1.2.3', status: 'ok' }];
     const html = htmlFor(<PluginsPage plugins={plugins} loading={false} />);
 
-    expect(pluginAdminSummary(plugins, enabledStateForPlugins(plugins))).toBe('1 enabled · 0 disabled · 1 installed');
+    expect(pluginAdminSummary(plugins, enabledStateForPlugins(plugins))).toBe('1 enabled · 0 disabled · 1 registered');
     expect(html).toContain('GET /api/plugins');
     expect(html).toContain('canvas');
     expect(html).toContain('1.2.3');

--- a/tests/frontend/pages/search-page-render.test.tsx
+++ b/tests/frontend/pages/search-page-render.test.tsx
@@ -1,10 +1,12 @@
 import { describe, expect, test } from 'bun:test';
+import { MemoryRouter } from 'react-router-dom';
 import { SearchPage } from '../../../frontend/src/pages/SearchPage';
 import { htmlFor } from '../_render';
 
 describe('Search page', () => {
   test('renders search helper text and global search form', () => {
-    expect(htmlFor(<SearchPage />)).toContain('Search surfaces');
-    expect(htmlFor(<SearchPage />)).toContain('Search all surfaces');
+    const html = htmlFor(<MemoryRouter><SearchPage /></MemoryRouter>);
+    expect(html).toContain('Full-text menu search');
+    expect(html).toContain('Search boundaries');
   });
 });

--- a/tests/frontend/router.test.ts
+++ b/tests/frontend/router.test.ts
@@ -34,6 +34,7 @@ describe('frontend router', () => {
     expect([...frontendRoutes]).toEqual([
       '/',
       '/plugins',
+      '/status',
       '/canvas/plugins',
       '/metrics',
       '/search',
@@ -50,6 +51,7 @@ describe('frontend router', () => {
   test('routes root, plugins, metrics, search, and learn surfaces', () => {
     expect(htmlAt('/')).toContain('Menu viewer');
     expect(htmlAt('/plugins')).toContain('Registered plugins');
+    expect(htmlAt('/status')).toContain('GET /api/v1/health');
     expect(htmlAt('/canvas/plugins')).toContain('Canvas plugin registry');
     expect(htmlAt('/metrics')).toContain('Metrics dashboard');
     expect(htmlAt('/metrics')).toContain('42');

--- a/tests/frontend/router.test.ts
+++ b/tests/frontend/router.test.ts
@@ -33,6 +33,7 @@ describe('frontend router', () => {
   test('declares the public dashboard route set', () => {
     expect([...frontendRoutes]).toEqual([
       '/',
+      '/menu',
       '/plugins',
       '/status',
       '/canvas/plugins',
@@ -49,7 +50,7 @@ describe('frontend router', () => {
   });
 
   test('routes root, plugins, metrics, search, and learn surfaces', () => {
-    expect(htmlAt('/')).toContain('Menu viewer');
+    expect(htmlAt('/')).toContain('Menu catalog');
     expect(htmlAt('/plugins')).toContain('Registered plugins');
     expect(htmlAt('/status')).toContain('GET /api/v1/health');
     expect(htmlAt('/canvas/plugins')).toContain('Canvas plugin registry');


### PR DESCRIPTION
## Summary
- add a frontend server status page backed by GET /api/v1/health
- wire /status into the router, sidebar, command palette, and route metadata
- keep the plugins page on GET /api/plugins and label registered plugin counts consistently

## Validation
- cd frontend && bunx tsc --noEmit
- bun test tests/frontend
- file size check: changed frontend/test files <= 250 lines

Base: alpha