### PR TITLE
feat: support vector config v2 format

### DIFF
--- a/src/routes/vector/index.ts
+++ b/src/routes/vector/index.ts
@@ -36,6 +36,7 @@ import { vectorExportEndpoint } from './export.ts';
 import { vectorServicesApiEndpoint } from './services.ts';
 import { vectorProvidersEndpoint } from './providers.ts';
 import { vectorCostEndpoint } from './cost.ts';
+import { vectorConfigApiEndpoint } from './config-api.ts';
 
 export const vectorRoutes = new Elysia({ prefix: '/api' })
   .use(vectorProxyEndpoint)
@@ -51,5 +52,6 @@ export const vectorRoutes = new Elysia({ prefix: '/api' })
   .use(vectorExportEndpoint)
   .use(vectorProvidersEndpoint)
   .use(vectorCostEndpoint)
+  .use(vectorConfigApiEndpoint)
   .use(vectorServicesApiEndpoint)
   .use(vectorIndexerEndpoints);

--- a/src/vector/config-normalize.ts
+++ b/src/vector/config-normalize.ts
@@ -1,0 +1,48 @@
+import type { VectorServerConfig, VectorStorageConfig } from './config.ts';
+
+type RawVectorConfig = Partial<Omit<VectorServerConfig, 'version' | 'storage'>> & {
+  version?: string;
+  storage?: Partial<VectorStorageConfig>;
+};
+
+const VALID_VERSIONS = new Set(['1', '1.0', '2', '2.0', 'legacy']);
+
+export function normalizeVectorConfig(raw: unknown, defaults: VectorServerConfig): VectorServerConfig {
+  const parsed = record(raw) as RawVectorConfig;
+  const { storage: rawStorage, ...rest } = parsed;
+  const version = normalizeVersion(parsed.version);
+  const config: VectorServerConfig = {
+    ...defaults,
+    ...rest,
+    version,
+    host: parsed.host ?? defaults.host,
+    port: parsed.port ?? defaults.port,
+    collections: parsed.collections ?? (version.startsWith('2') ? {} : defaults.collections),
+    dataPath: parsed.dataPath ?? defaults.dataPath,
+    embeddingEndpoint: parsed.embeddingEndpoint ?? defaults.embeddingEndpoint,
+    proxy: parsed.proxy ?? defaults.proxy,
+  };
+  const storage = normalizeStorage(rawStorage, version.startsWith('2') ? defaults.storage : undefined);
+  if (storage) config.storage = storage;
+  else delete config.storage;
+  return config;
+}
+
+function normalizeVersion(version: string | undefined): VectorServerConfig['version'] {
+  return VALID_VERSIONS.has(version ?? '') ? version as VectorServerConfig['version'] : 'legacy';
+}
+
+function normalizeStorage(
+  storage: Partial<VectorStorageConfig> | undefined,
+  fallback: VectorStorageConfig | undefined,
+): VectorStorageConfig | undefined {
+  if (!storage && !fallback) return undefined;
+  const services = storage?.services ?? fallback?.services ?? {};
+  const defaultService = storage?.default ?? fallback?.default ?? Object.keys(services)[0];
+  if (!defaultService) return undefined;
+  return { default: defaultService, services };
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}

--- a/src/vector/config.ts
+++ b/src/vector/config.ts
@@ -15,6 +15,7 @@ import { COLLECTION_NAME } from '../const.ts';
 import type { UnifiedProxyManifest } from '../plugins/unified-manifest.ts';
 import type { EmbedderConfig, VectorDBType } from './types.ts';
 import { zeroConfigEmbedder } from './default-embedder.ts';
+import { normalizeVectorConfig } from './config-normalize.ts';
 
 export const VECTOR_CONFIG_FILE = 'vector-server.json';
 
@@ -128,7 +129,7 @@ export function loadVectorConfig(fp = configPath()): VectorServerConfig | null {
   if (!fs.existsSync(fp)) return null;
   try {
     const raw = fs.readFileSync(fp, 'utf-8');
-    return JSON.parse(raw) as VectorServerConfig;
+    return normalizeVectorConfig(JSON.parse(raw), generateDefaultConfig());
   } catch (e) {
     console.warn('[VectorConfig] Failed to parse ' + fp + ':', e instanceof Error ? e.message : e);
     return null;

--- a/tests/http/vector/config-format.test.ts
+++ b/tests/http/vector/config-format.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  configPath,
+  configToModels,
+  fallbackCollectionsFor,
+  loadVectorConfig,
+  resolveServiceEndpoint,
+} from '../../../src/vector/config.ts';
+
+let root: string | undefined;
+
+afterEach(() => {
+  if (root) rmSync(root, { recursive: true, force: true });
+  root = undefined;
+});
+
+function writeConfig(config: unknown): string {
+  root = mkdtempSync(join(tmpdir(), 'vector-config-format-'));
+  const fp = configPath(root);
+  writeFileSync(fp, JSON.stringify(config, null, 2));
+  return fp;
+}
+
+test('loadVectorConfig preserves v1 collection configs', () => {
+  const config = loadVectorConfig(writeConfig({
+    version: '1',
+    host: '127.0.0.1',
+    port: 9090,
+    dataPath: '/tmp/vector-v1',
+    embeddingEndpoint: '',
+    collections: {
+      docs: {
+        collection: 'docs_v1',
+        model: 'nomic-embed-text',
+        provider: 'ollama',
+        adapter: 'lancedb',
+        primary: true,
+      },
+    },
+  }));
+
+  expect(config).toMatchObject({ version: '1', host: '127.0.0.1', port: 9090 });
+  expect(config?.storage).toBeUndefined();
+  expect(config?.collections.docs).toMatchObject({ collection: 'docs_v1', provider: 'ollama' });
+  expect(configToModels(config!).docs).toMatchObject({
+    collection: 'docs_v1',
+    model: 'nomic-embed-text',
+    adapter: 'lancedb',
+    dataPath: '/tmp/vector-v1',
+    embedder: { backend: 'local', model: 'nomic-embed-text' },
+  });
+});
+
+test('loadVectorConfig supports v2 storage service configs', () => {
+  const config = loadVectorConfig(writeConfig({
+    version: '2',
+    storage: {
+      default: 'lancedb',
+      services: {
+        lancedb: { type: 'builtin' },
+        turbovec: { type: 'proxy', endpoint: 'http://localhost:8082' },
+      },
+    },
+  }));
+
+  expect(config).toMatchObject({
+    version: '2',
+    host: '0.0.0.0',
+    port: 8081,
+    collections: {},
+    embeddingEndpoint: '',
+  });
+  expect(config?.storage?.services.turbovec).toEqual({
+    type: 'proxy',
+    endpoint: 'http://localhost:8082',
+  });
+  expect(resolveServiceEndpoint(config!, 'turbovec')).toBe('http://localhost:8082');
+  expect(fallbackCollectionsFor(config!)).toEqual([
+    expect.objectContaining({
+      collection: 'oracle_knowledge_lancedb',
+      adapter: 'lancedb',
+      service: 'lancedb',
+      primary: true,
+    }),
+  ]);
+});


### PR DESCRIPTION
## Summary
- normalize loaded vector config files so legacy v1 collection configs and v2 storage-service configs both load into the runtime shape
- preserve v1 configs without injecting storage, while v2 storage-only configs default host/port/data fields and leave collections empty for storage fallback generation
- mount the vector config API in the composed vector routes so v2 config HTTP smoke paths resolve through vectorRoutes
- add direct v1/v2 config format regression tests

## Conflict check
- cherry-picked the task commit onto a clean worktree from current origin/alpha without conflicts
- merged latest origin/alpha before push without conflicts

## Verification
- rtk bunx tsc --noEmit
- rtk bun test tests/http/vector/
- file size check: changed files are 57, 247, 48, and 89 lines (all <= 250)