### PR TITLE
fix(vector): expose service registry class

### DIFF
--- a/src/routes/vector/services.ts
+++ b/src/routes/vector/services.ts
@@ -4,12 +4,12 @@ import {
   vectorServiceRegistry,
   type HealthStatus,
   type RegisteredVectorService,
-  type VectorServiceRegistry,
+  type VectorServiceRegistryClient,
 } from '../../vector/registry.ts';
 
 const capabilitySchema = t.Record(t.String(), t.Unknown());
 
-export function createVectorServicesApiEndpoint(registry: VectorServiceRegistry = vectorServiceRegistry) {
+export function createVectorServicesApiEndpoint(registry: VectorServiceRegistryClient = vectorServiceRegistry) {
   return new Elysia()
     .get('/vector/services', async () => {
       const services = await registry.discover();

--- a/src/server.ts
+++ b/src/server.ts
@@ -226,7 +226,6 @@ const middleware = runtimeMiddleware({
   rateLimitTokensPerWindow: startupConfig.profile.rateLimit.tokensPerWindow,
   gatewayEnabled: Boolean(VECTOR_URL) || process.env.ORACLE_GATEWAY_HOT_RELOAD !== '0',
 });
-
 printStartupBanner({
   version: pkg.version,
   port: Number(PORT),

--- a/src/vector/registry.ts
+++ b/src/vector/registry.ts
@@ -32,7 +32,7 @@ export interface HealthStatus {
   error?: string;
 }
 
-export interface VectorServiceRegistry {
+export interface VectorServiceRegistryClient {
   register(service: Omit<RegisteredVectorService, 'name'> & { name: string }): Promise<RegisteredVectorService>;
   discover(): Promise<RegisteredVectorService[]>;
   unregister(name: string): Promise<boolean>;
@@ -54,9 +54,6 @@ function activeConfigPath(): string {
 function loadActiveConfig(): VectorServerConfig | null {
   return loadVectorConfig(activeConfigPath());
 }
-
-let currentConfig: VectorServerConfig = loadActiveConfig() ?? generateDefaultConfig();
-let registry = seedFromConfig(currentConfig);
 
 function seedFromConfig(config: VectorServerConfig): Map<string, RegisteredVectorService> {
   const services = config.storage?.services ?? {
@@ -80,7 +77,10 @@ function seedFromConfig(config: VectorServerConfig): Map<string, RegisteredVecto
   return out;
 }
 
-function normalizeStorage(services: Map<string, RegisteredVectorService>): VectorStorageConfig {
+function normalizeStorage(
+  config: VectorServerConfig,
+  services: Map<string, RegisteredVectorService>,
+): VectorStorageConfig {
   const storageServices: Record<string, VectorStorageService> = {};
   for (const [name, service] of services) {
     storageServices[name] = {
@@ -90,9 +90,9 @@ function normalizeStorage(services: Map<string, RegisteredVectorService>): Vecto
     };
   }
 
-  const defaultService = currentConfig.storage?.default
-    && services.has(currentConfig.storage.default)
-    ? currentConfig.storage.default
+  const defaultService = config.storage?.default
+    && services.has(config.storage.default)
+    ? config.storage.default
     : 'lancedb';
 
   return {
@@ -101,20 +101,13 @@ function normalizeStorage(services: Map<string, RegisteredVectorService>): Vecto
   };
 }
 
-function syncConfig(services: Map<string, RegisteredVectorService>): void {
-  if (!currentConfig.storage) {
-    currentConfig.storage = { default: 'lancedb', services: {} };
-  }
-  currentConfig.storage = normalizeStorage(services);
-  writeVectorConfig(currentConfig, activeConfigPath());
-}
-
-function ensureConfigRefreshed(): void {
-  const latest = loadActiveConfig() ?? currentConfig;
-  if (latest) {
-    currentConfig = latest;
-    registry = seedFromConfig(latest);
-  }
+function syncConfig(
+  config: VectorServerConfig,
+  services: Map<string, RegisteredVectorService>,
+): VectorServerConfig {
+  const next = { ...config, storage: normalizeStorage(config, services) };
+  writeVectorConfig(next, activeConfigPath());
+  return next;
 }
 
 function validateService(service: RegisteredVectorService): RegisteredVectorService {
@@ -132,26 +125,39 @@ function validateService(service: RegisteredVectorService): RegisteredVectorServ
   };
 }
 
-class InMemoryVectorServiceRegistry implements VectorServiceRegistry {
+export class VectorServiceRegistry implements VectorServiceRegistryClient {
+  private currentConfig: VectorServerConfig;
+  private registry: Map<string, RegisteredVectorService>;
+
+  constructor(config: VectorServerConfig = loadActiveConfig() ?? generateDefaultConfig()) {
+    this.currentConfig = config;
+    this.registry = seedFromConfig(config);
+  }
+
+  private refresh(): void {
+    this.currentConfig = loadActiveConfig() ?? this.currentConfig;
+    this.registry = seedFromConfig(this.currentConfig);
+  }
+
   async register(service: RegisteredVectorService): Promise<RegisteredVectorService> {
-    ensureConfigRefreshed();
+    this.refresh();
     const normalized = validateService(service);
-    registry.set(normalized.name, normalized);
-    syncConfig(registry);
+    this.registry.set(normalized.name, normalized);
+    this.currentConfig = syncConfig(this.currentConfig, this.registry);
     return normalized;
   }
 
   async discover(): Promise<RegisteredVectorService[]> {
-    ensureConfigRefreshed();
-    if (registry.size === 0) registry = seedFromConfig(currentConfig);
+    this.refresh();
+    if (this.registry.size === 0) this.registry = seedFromConfig(this.currentConfig);
 
-    return [...registry.values()].sort((a, b) => a.name.localeCompare(b.name));
+    return [...this.registry.values()].sort((a, b) => a.name.localeCompare(b.name));
   }
 
   async unregister(name: string): Promise<boolean> {
-    ensureConfigRefreshed();
-    const removed = registry.delete(name);
-    if (removed) syncConfig(registry);
+    this.refresh();
+    const removed = this.registry.delete(name);
+    if (removed) this.currentConfig = syncConfig(this.currentConfig, this.registry);
     return removed;
   }
 
@@ -167,7 +173,7 @@ class InMemoryVectorServiceRegistry implements VectorServiceRegistry {
 
       const started = Date.now();
       try {
-        const endpoint = resolveServiceEndpoint(currentConfig, service.name) || service.endpoint;
+        const endpoint = resolveServiceEndpoint(this.currentConfig, service.name) || service.endpoint;
         if (!endpoint) {
           throw new Error('missing endpoint');
         }
@@ -196,11 +202,10 @@ class InMemoryVectorServiceRegistry implements VectorServiceRegistry {
   }
 }
 
-export const vectorServiceRegistry = new InMemoryVectorServiceRegistry();
+export const vectorServiceRegistry = new VectorServiceRegistry();
 
 export async function getRegisteredServiceEndpoint(name: string): Promise<string | undefined> {
   const services = await vectorServiceRegistry.discover();
   const match = services.find((item) => item.name === name);
   return match?.type === 'proxy' ? match.endpoint : undefined;
 }
-

--- a/tests/http/vector/services.test.ts
+++ b/tests/http/vector/services.test.ts
@@ -1,10 +1,19 @@
 import { expect, test } from 'bun:test';
 import { Elysia } from 'elysia';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
 import { createVectorServicesApiEndpoint } from '../../../src/routes/vector/services.ts';
-import type { HealthStatus, RegisteredVectorService, VectorServiceRegistry } from '../../../src/vector/registry.ts';
+import { configPath, loadVectorConfig } from '../../../src/vector/config.ts';
+import {
+  VectorServiceRegistry,
+  type HealthStatus,
+  type RegisteredVectorService,
+  type VectorServiceRegistryClient,
+} from '../../../src/vector/registry.ts';
 
-class FakeRegistry implements VectorServiceRegistry {
+class FakeRegistry implements VectorServiceRegistryClient {
   services = new Map<string, RegisteredVectorService>([
     ['lancedb', { name: 'lancedb', type: 'builtin' }],
   ]);
@@ -59,6 +68,10 @@ test('vector service registry API registers, tests, lists, and removes proxy ser
   expect(body.count).toBe(2);
   expect(body.services.map((item: { name: string }) => item.name)).toEqual(['lancedb', 'turbovec']);
 
+  const directList = await fetcher(new Request('http://local/api/vector/services'));
+  expect(directList.status).toBe(308);
+  expect(directList.headers.get('location')).toBe('http://local/api/v1/vector/services');
+
   const removed = await fetcher(new Request('http://local/api/v1/vector/services/turbovec', { method: 'DELETE' }));
   expect(await json(removed)).toEqual({ success: true, removed: 'turbovec' });
 
@@ -76,4 +89,47 @@ test('vector service registry API rejects proxy registration without endpoint', 
 
   expect(res.status).toBe(400);
   expect(await json(res)).toMatchObject({ success: false, error: 'proxy service requires endpoint' });
+});
+
+test('VectorServiceRegistry persists services and probes proxy health', async () => {
+  const savedDataDir = process.env.ORACLE_DATA_DIR;
+  const root = mkdtempSync(join(tmpdir(), 'vector-services-registry-'));
+  const proxy = Bun.serve({
+    hostname: '127.0.0.1',
+    port: 0,
+    fetch(request) {
+      if (new URL(request.url).pathname === '/health') {
+        return Response.json({ status: 'ok', name: 'live-proxy', version: 'test' });
+      }
+      return new Response('missing', { status: 404 });
+    },
+  });
+
+  try {
+    process.env.ORACLE_DATA_DIR = root;
+    const registry = new VectorServiceRegistry();
+    const endpoint = String(proxy.url).replace(/\/$/, '');
+
+    await registry.register({ name: 'live-proxy', type: 'proxy', endpoint });
+    expect(await registry.discover()).toContainEqual(expect.objectContaining({
+      name: 'live-proxy',
+      type: 'proxy',
+      endpoint,
+    }));
+
+    const health = await registry.healthCheck();
+    expect(health.get('live-proxy')).toMatchObject({ status: 'up' });
+    expect(loadVectorConfig(configPath(root))?.storage?.services['live-proxy']).toMatchObject({
+      type: 'proxy',
+      endpoint,
+    });
+
+    expect(await registry.unregister('live-proxy')).toBe(true);
+    expect(loadVectorConfig(configPath(root))?.storage?.services['live-proxy']).toBeUndefined();
+  } finally {
+    proxy.stop(true);
+    if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+    else process.env.ORACLE_DATA_DIR = savedDataDir;
+    rmSync(root, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary
- Export VectorServiceRegistry as the concrete registry class with instance-scoped config/service state
- Keep route tests injectable via VectorServiceRegistryClient while mounting services explicitly in server.ts
- Extend services HTTP tests to cover register/list/test/delete, API version redirect, persisted registry config, and live proxy health probes

## Validation
- bun test tests/http/vector/services.test.ts
- bunx tsc --noEmit
- changed files <=250 lines