### PR TITLE
feat: scaffold maw arra plugin

### DIFF
--- a/tools/maw-plugin-arra/commands/export.ts
+++ b/tools/maw-plugin-arra/commands/export.ts
@@ -1,0 +1,35 @@
+import { flag, parseArgs, requestText } from './http.ts';
+
+type ExportFormat = 'json' | 'csv' | 'md';
+
+const allowedFormats = new Set<ExportFormat>(['json', 'csv', 'md']);
+
+function normalizeFormat(value: string | undefined): ExportFormat {
+  const format = (value || 'json').toLowerCase();
+  if (!allowedFormats.has(format as ExportFormat)) {
+    throw new Error('usage: maw arra export --collection X --format json|csv|md');
+  }
+  return format as ExportFormat;
+}
+
+function apiFormat(format: ExportFormat): string {
+  return format === 'md' ? 'markdown' : format;
+}
+
+function acceptHeader(format: ExportFormat): string {
+  if (format === 'csv') return 'text/csv';
+  if (format === 'md') return 'text/markdown';
+  return 'application/json';
+}
+
+export async function runExportCommand(args: string[]): Promise<string> {
+  const parsed = parseArgs(args);
+  const collection = flag(parsed, 'collection') || parsed.positionals[0];
+  if (!collection) throw new Error('usage: maw arra export --collection X --format json|csv|md');
+
+  const format = normalizeFormat(flag(parsed, 'format') || parsed.positionals[1]);
+  const query = new URLSearchParams({ collection, format: apiFormat(format) });
+  return requestText(`/api/v1/vector/export?${query.toString()}`, {
+    headers: { accept: acceptHeader(format) },
+  });
+}

--- a/tools/maw-plugin-arra/commands/http.ts
+++ b/tools/maw-plugin-arra/commands/http.ts
@@ -1,0 +1,74 @@
+const DEFAULT_API_BASE = 'http://localhost:47778';
+
+export type Args = string[];
+export type Flags = Record<string, string | boolean>;
+export type ParsedArgs = { flags: Flags; positionals: string[] };
+
+export function parseArgs(args: Args): ParsedArgs {
+  const flags: Flags = {};
+  const positionals: string[] = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const value = args[i];
+    if (!value.startsWith('--')) {
+      positionals.push(value);
+      continue;
+    }
+    const raw = value.slice(2);
+    const equals = raw.indexOf('=');
+    const key = (equals >= 0 ? raw.slice(0, equals) : raw).replace(/-/g, '_');
+    if (equals >= 0) flags[key] = raw.slice(equals + 1);
+    else if (args[i + 1] && !args[i + 1].startsWith('--')) flags[key] = args[++i];
+    else flags[key] = true;
+  }
+  return { flags, positionals };
+}
+
+export function flag(parsed: ParsedArgs, name: string): string | undefined {
+  const value = parsed.flags[name.replace(/-/g, '_')];
+  if (value === undefined || value === false) return undefined;
+  return value === true ? 'true' : String(value);
+}
+
+export function resolveApiBase(env: Record<string, string | undefined> = process.env): string {
+  return (env.ARRA_API || env.ORACLE_API || DEFAULT_API_BASE).replace(/\/+$/, '');
+}
+
+export function authHeaders(env: Record<string, string | undefined> = process.env): Record<string, string> {
+  const token = env.ARRA_API_TOKEN?.trim();
+  return token ? { authorization: `Bearer ${token}` } : {};
+}
+
+function messageFromPayload(payload: unknown, fallback: string): string {
+  if (!payload || typeof payload !== 'object') return fallback;
+  const record = payload as Record<string, unknown>;
+  if (typeof record.error === 'string') return record.error;
+  if (typeof record.message === 'string') return record.message;
+  return fallback;
+}
+
+export async function requestText(path: string, init: RequestInit = {}): Promise<string> {
+  const base = resolveApiBase();
+  let response: Response;
+  try {
+    response = await fetch(`${base}${path}`, {
+      ...init,
+      headers: { accept: '*/*', ...authHeaders(), ...(init.headers as Record<string, string> | undefined) },
+    });
+  } catch (error) {
+    throw new Error(`Cannot reach ARRA at ${base}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  const text = await response.text();
+  if (response.ok) return text;
+  let payload: unknown = null;
+  try {
+    payload = text ? JSON.parse(text) : null;
+  } catch {
+    payload = null;
+  }
+  throw new Error(`${path} returned ${response.status}: ${messageFromPayload(payload, text || response.statusText)}`);
+}
+
+export async function requestJson<T>(path: string): Promise<T> {
+  const text = await requestText(path, { headers: { accept: 'application/json' } });
+  return (text ? JSON.parse(text) : {}) as T;
+}

--- a/tools/maw-plugin-arra/commands/status.ts
+++ b/tools/maw-plugin-arra/commands/status.ts
@@ -1,0 +1,94 @@
+import { requestJson, resolveApiBase } from './http.ts';
+
+type CollectionHealth = {
+  ok?: boolean;
+  status?: string;
+  adapter?: string;
+  model?: string;
+  enabled?: boolean;
+  error?: string;
+};
+
+type ConfigCollection = {
+  key?: string;
+  collection?: string;
+  count?: number;
+  adapter?: string;
+  model?: string;
+  enabled?: boolean;
+  status?: string;
+  ok?: boolean;
+  error?: string;
+};
+
+type ConfigResponse = {
+  collections?: ConfigCollection[];
+  doc_counts?: Record<string, number>;
+  health?: Record<string, CollectionHealth>;
+  checked_at?: string;
+};
+
+type ModelsResponse = {
+  models?: Record<string, { collection?: string; model?: string; adapter?: string; count?: number }>;
+};
+
+type HealthResponse = {
+  status?: string;
+  checked_at?: string;
+};
+
+function healthLabel(entry: CollectionHealth | undefined): string {
+  if (!entry) return 'unknown';
+  if (entry.status) return entry.status;
+  return entry.ok === false ? 'down' : 'ok';
+}
+
+function collectionRows(config: ConfigResponse, models: ModelsResponse): string[] {
+  const rows = (config.collections ?? []).map((item) => {
+    const key = item.key || item.collection || 'unknown';
+    const health = config.health?.[key];
+    const docs = config.doc_counts?.[key] ?? item.count ?? 0;
+    return {
+      key,
+      docs,
+      adapter: item.adapter || health?.adapter || 'unknown',
+      model: item.model || health?.model || 'unknown',
+      enabled: item.enabled ?? health?.enabled,
+      health: healthLabel(health ?? item),
+      error: health?.error || item.error,
+    };
+  });
+
+  if (rows.length) {
+    return rows.map((row) => [
+      `${row.key}: docs=${row.docs}`,
+      `health=${row.health}`,
+      `adapter=${row.adapter}`,
+      `model=${row.model}`,
+      row.enabled === false ? 'disabled' : '',
+      row.error ? `error=${row.error}` : '',
+    ].filter(Boolean).join(' '));
+  }
+
+  return Object.entries(models.models ?? {}).map(([key, item]) =>
+    `${key}: docs=${item.count ?? 0} health=unknown adapter=${item.adapter ?? 'unknown'} model=${item.model ?? 'unknown'}`
+  );
+}
+
+export async function runStatusCommand(): Promise<string> {
+  const [config, models, health] = await Promise.all([
+    requestJson<ConfigResponse>('/api/v1/vector/config'),
+    requestJson<ModelsResponse>('/api/v1/vector/index/models'),
+    requestJson<HealthResponse>('/api/v1/vector/health').catch((): HealthResponse => ({ status: 'unknown' })),
+  ]);
+
+  const lines = [
+    `arra status: ${health.status ?? 'unknown'}`,
+    `api: ${resolveApiBase()}`,
+    config.checked_at || health.checked_at ? `checked: ${config.checked_at ?? health.checked_at}` : '',
+    'collections:',
+    ...collectionRows(config, models).map((line) => `  - ${line}`),
+  ].filter(Boolean);
+
+  return lines.join('\n');
+}

--- a/tools/maw-plugin-arra/index.ts
+++ b/tools/maw-plugin-arra/index.ts
@@ -1,0 +1,62 @@
+import { runExportCommand } from './commands/export.ts';
+import { runStatusCommand } from './commands/status.ts';
+
+type InvokeContext = {
+  source?: string;
+  args?: string[] | Record<string, unknown>;
+  writer?: (line?: string) => void;
+};
+
+type InvokeResult = { ok: boolean; output?: string; error?: string };
+type CommandHandler = (args: string[]) => Promise<string>;
+
+const commandHandlers: Record<string, CommandHandler> = {
+  export: runExportCommand,
+  status: () => runStatusCommand(),
+};
+
+export const command = {
+  name: 'arra',
+  description: 'ARRA Oracle CLI bridge — export vector collections and inspect status.',
+};
+
+function argsFromContext(args: InvokeContext['args']): string[] {
+  if (Array.isArray(args)) return args;
+  if (!args || typeof args !== 'object') return [];
+  const sub = typeof args.sub === 'string' ? [args.sub] : [];
+  const rest = Object.entries(args).flatMap(([key, value]) => {
+    if (key === 'sub' || value === undefined || value === null || value === false) return [];
+    if (value === true) return [`--${key.replace(/_/g, '-')}`];
+    return [`--${key.replace(/_/g, '-')}`, String(value)];
+  });
+  return [...sub, ...rest];
+}
+
+function help(): string {
+  return [
+    'maw arra — ARRA Oracle CLI bridge',
+    '  status',
+    '      show vector collections, doc counts, and health from localhost:47778',
+    '  export --collection X --format json|csv|md',
+    '      stream a vector collection export from localhost:47778',
+  ].join('\n');
+}
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const args = argsFromContext(ctx.args);
+  const subcommand = (args[0] || '').toLowerCase();
+  if (!subcommand || subcommand === 'help' || subcommand === '--help' || subcommand === '-h') {
+    return { ok: true, output: help() };
+  }
+
+  const run = commandHandlers[subcommand];
+  if (!run) return { ok: false, error: help() };
+
+  try {
+    const output = await run(args.slice(1));
+    if (ctx.writer) ctx.writer(output);
+    return { ok: true, output };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}

--- a/tools/maw-plugin-arra/plugin.json
+++ b/tools/maw-plugin-arra/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "arra",
+  "version": "0.1.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "ARRA Oracle CLI bridge for vector export and status commands.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "arra",
+    "help": "maw arra <status|export --collection X --format json|csv|md>"
+  },
+  "weight": 10,
+  "license": "BUSL-1.1",
+  "schemaVersion": 1
+}

--- a/tools/maw-plugin-arra/tsconfig.json
+++ b/tools/maw-plugin-arra/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM"],
+    "moduleResolution": "bundler",
+    "types": ["bun-types"],
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["index.ts", "commands/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add tools/maw-plugin-arra maw-js plugin scaffold with manifest and entrypoint
- add maw arra export --collection X --format json|csv|md against localhost:47778 vector export API
- add maw arra status summary for collections, doc counts, and health
- add plugin-local tsconfig for tool typechecking

Refs #1467

## Verification
- bunx tsc --noEmit
- bunx tsc --noEmit -p tools/maw-plugin-arra/tsconfig.json
- mocked smoke import confirms /api/v1/vector/config, /api/v1/vector/index/models, /api/v1/vector/health, and /api/v1/vector/export?collection=bge-m3&format=markdown
- git diff --check
- changed files <= 250 lines

## Notes
- .maw-engine local runtime marker remains uncommitted.