### PR TITLE
feat: add export app page

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -52,6 +52,7 @@ export function AppShell({
     { to: '/plugins', label: 'Plugins', description: 'Registered plugins and surfaces', badge: loading ? '…' : pluginCount },
     { to: '/canvas/plugins', label: 'Canvas Plugins', description: 'Canvas registry from /api/canvas/plugins' },
     { to: '/search', label: 'Search', description: 'Full-text menu search' },
+    { to: '/export', label: 'Export App', description: 'Download app collections' },
     { to: '/vector', label: 'Vector Dashboard', description: 'Collection health and indexing', end: true },
     { to: '/vector/documents', label: 'Document Browser', description: 'Browse indexed vector documents' },
     { to: '/vector/search', label: 'Vector Search', description: 'Semantic preview by collection' },

--- a/frontend/src/pages/ExportPage.tsx
+++ b/frontend/src/pages/ExportPage.tsx
@@ -1,0 +1,197 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
+import { apiUrl } from '../api/oracle';
+
+type LoadState = 'loading' | 'ready' | 'error';
+type ExportFormat = 'json' | 'csv' | 'markdown' | 'jsonl';
+
+type ExportCollection = {
+  id: string;
+  label: string;
+  rowCount?: number;
+};
+
+const formats: Array<{ value: ExportFormat; label: string }> = [
+  { value: 'json', label: 'JSON' },
+  { value: 'csv', label: 'CSV' },
+  { value: 'markdown', label: 'Markdown' },
+  { value: 'jsonl', label: 'JSONL' },
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function text(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+export function normalizeExportCollections(payload: unknown): ExportCollection[] {
+  const raw = isRecord(payload) ? payload.collections : payload;
+  if (!Array.isArray(raw)) return [];
+
+  return raw
+    .map((item): ExportCollection | null => {
+      if (typeof item === 'string') return { id: item, label: item };
+      if (!isRecord(item)) return null;
+      const id = text(item.key) || text(item.name) || text(item.collection);
+      if (!id) return null;
+      const label = text(item.label) || text(item.name) || text(item.collection) || id;
+      const rowCount = numberValue(item.rowCount) ?? numberValue(item.count);
+      return { id, label, rowCount };
+    })
+    .filter((item): item is ExportCollection => Boolean(item))
+    .sort((left, right) => left.label.localeCompare(right.label));
+}
+
+function collectionLabel(collection: ExportCollection): string {
+  const rows = typeof collection.rowCount === 'number' ? ` · ${collection.rowCount.toLocaleString()} rows` : '';
+  return `${collection.label}${rows}`;
+}
+
+function exportUrl(collection: string, format: ExportFormat, includeGraph: boolean, includeMetadata: boolean): string {
+  const query = new URLSearchParams({
+    collection,
+    format,
+    includeGraph: String(includeGraph),
+    includeMetadata: String(includeMetadata),
+  });
+  return apiUrl(`/api/v1/export/app?${query.toString()}`);
+}
+
+export function ExportPage() {
+  const [state, setState] = useState<LoadState>('loading');
+  const [error, setError] = useState('');
+  const [collections, setCollections] = useState<ExportCollection[]>([]);
+  const [collection, setCollection] = useState('');
+  const [format, setFormat] = useState<ExportFormat>('json');
+  const [includeGraph, setIncludeGraph] = useState(true);
+  const [includeMetadata, setIncludeMetadata] = useState(true);
+  const [downloadUrl, setDownloadUrl] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    setState('loading');
+    setError('');
+    fetch(apiUrl('/api/v1/export/app/collections'), { headers: { accept: 'application/json' } })
+      .then(async (response) => {
+        if (!response.ok) throw new Error(`/api/v1/export/app/collections returned ${response.status}`);
+        return response.json();
+      })
+      .then((payload) => {
+        if (cancelled) return;
+        const next = normalizeExportCollections(payload);
+        setCollections(next);
+        setCollection((current) => current || next[0]?.id || '');
+        setState('ready');
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+        setState('error');
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  const currentUrl = useMemo(
+    () => collection ? exportUrl(collection, format, includeGraph, includeMetadata) : '',
+    [collection, format, includeGraph, includeMetadata],
+  );
+
+  function prepareDownload() {
+    setDownloadUrl(currentUrl);
+  }
+
+  return (
+    <div className="grid gap-5">
+      <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="export-page-title">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Export app</p>
+        <h1 id="export-page-title" className="mt-2 text-3xl font-semibold text-white">Export collections</h1>
+        <p className="mt-2 text-sm text-slate-400">Prepare database collection downloads from /api/v1/export/app.</p>
+      </section>
+
+      {state === 'loading' ? <LoadingPanel title="Loading collections" detail="Fetching /api/v1/export/app/collections." /> : null}
+      {state === 'error' ? <ErrorMessage title="Could not load export collections." message={error} /> : null}
+
+      <div className="grid gap-4 lg:grid-cols-4">
+        <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6 lg:col-span-2" aria-labelledby="export-collection-title">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Collection</p>
+          <h2 id="export-collection-title" className="mt-2 text-2xl font-semibold text-white">Collection picker</h2>
+          <label className="mt-5 grid gap-2 text-sm font-medium text-slate-300">
+            Collection
+            <select
+              aria-label="Export collection"
+              className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-4 py-3 text-slate-100"
+              disabled={state !== 'ready' || collections.length === 0}
+              value={collection}
+              onChange={(event) => { setCollection(event.target.value); setDownloadUrl(''); }}
+            >
+              {collections.length ? collections.map((item) => (
+                <option key={item.id} value={item.id}>{collectionLabel(item)}</option>
+              )) : <option value="">No collections loaded</option>}
+            </select>
+          </label>
+        </section>
+
+        <section className="rounded-3xl border border-white/10 bg-white/[0.03] p-5 sm:p-6 lg:col-span-2" aria-labelledby="export-format-title">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Format</p>
+          <h2 id="export-format-title" className="mt-2 text-2xl font-semibold text-white">Format selector</h2>
+          <div className="mt-5 grid gap-2 sm:grid-cols-2" role="radiogroup" aria-label="Export format">
+            {formats.map((item) => (
+              <label key={item.value} className="flex min-h-12 items-center gap-3 rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-slate-200">
+                <input
+                  className="h-4 w-4 accent-teal-300"
+                  checked={format === item.value}
+                  name="export-format"
+                  type="radio"
+                  value={item.value}
+                  onChange={() => { setFormat(item.value); setDownloadUrl(''); }}
+                />
+                <span className="font-semibold">{item.label}</span>
+              </label>
+            ))}
+          </div>
+        </section>
+
+        <section className="rounded-3xl border border-white/10 bg-white/[0.03] p-5 sm:p-6 lg:col-span-2" aria-labelledby="export-options-title">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Options</p>
+          <h2 id="export-options-title" className="mt-2 text-2xl font-semibold text-white">Export options</h2>
+          <div className="mt-5 grid gap-3">
+            <label className="flex items-center justify-between gap-4 rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-slate-200">
+              <span className="font-semibold">Include graph</span>
+              <input className="h-5 w-5 accent-teal-300" checked={includeGraph} type="checkbox" onChange={(event) => { setIncludeGraph(event.target.checked); setDownloadUrl(''); }} />
+            </label>
+            <label className="flex items-center justify-between gap-4 rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-slate-200">
+              <span className="font-semibold">Include metadata</span>
+              <input className="h-5 w-5 accent-teal-300" checked={includeMetadata} type="checkbox" onChange={(event) => { setIncludeMetadata(event.target.checked); setDownloadUrl(''); }} />
+            </label>
+          </div>
+        </section>
+
+        <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6 lg:col-span-2" aria-labelledby="export-action-title">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Download</p>
+          <h2 id="export-action-title" className="mt-2 text-2xl font-semibold text-white">Export action</h2>
+          <div className="mt-5 flex flex-wrap items-center gap-3">
+            <button
+              className="focus-ring rounded-xl bg-teal-300 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-teal-200 disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={!currentUrl || state !== 'ready'}
+              type="button"
+              onClick={prepareDownload}
+            >
+              Prepare export
+            </button>
+            {downloadUrl ? (
+              <a className="focus-ring rounded-xl border border-teal-300/30 px-5 py-3 text-sm font-semibold text-teal-100 hover:bg-teal-300/10" href={downloadUrl} download>
+                Download link
+              </a>
+            ) : null}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/routeMeta.ts
+++ b/frontend/src/routeMeta.ts
@@ -72,6 +72,7 @@ export function routeMeta(pathname: string, search = ''): RouteMeta {
   if (pathname === '/canvas/plugins') return base('Canvas plugins', 'Canvas', 'Canvas plugin registry and standalone status.', [{ label: 'Canvas plugins' }]);
   if (pathname === '/metrics') return base('Runtime metrics', 'Metrics', 'Runtime counters from /api/v1/metrics.', [{ label: 'Metrics' }]);
   if (pathname === '/search') return base('Search', 'Search', 'Search menu, plugin, and MCP tool surfaces.', [{ label: 'Search' }]);
+  if (pathname === '/export') return base('Export app', 'Export', 'Download app collections in JSON, CSV, Markdown, or JSONL.', [{ label: 'Export app' }]);
   if (pathname === '/learn') return base('Learn entries', 'Learn', 'Capture and edit Oracle learnings.', [{ label: 'Learn' }]);
   if (pathname === '/vector') return base('Vector dashboard', 'Vector', 'Collection health, search, and export status.', [{ label: 'Vector dashboard' }]);
   if (pathname === '/mcp') return base('MCP tools', 'MCP', 'Browse available MCP tool schemas and groups.', [{ label: 'MCP tools' }]);

--- a/frontend/src/routePaths.ts
+++ b/frontend/src/routePaths.ts
@@ -24,6 +24,10 @@ export function vectorResultsPath(query: string): string {
   return qs.toString() ? `/vector/results?${qs}` : '/vector/results';
 }
 
+export function exportPagePath(): string {
+  return '/export';
+}
+
 export function vectorDocumentsPath(): string {
   return '/vector/documents';
 }

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -4,6 +4,7 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 import { McpPage } from './pages/McpPage';
 import { MetricsPage } from './pages/MetricsPage';
 import { McpToolDetailPage } from './pages/McpToolDetailPage';
+import { ExportPage } from './pages/ExportPage';
 import { LearnPage } from './pages/LearnPage';
 import { MenuPage } from './pages/MenuPage';
 import { PluginsPage } from './pages/PluginsPage';
@@ -26,6 +27,7 @@ export const frontendRoutes = [
   '/canvas/plugins',
   '/metrics',
   '/search',
+  '/export',
   '/learn',
   '/vector',
   '/vector/search',
@@ -78,6 +80,7 @@ export function DashboardRoutes({
       <Route path="/canvas/plugins" element={<CanvasPluginsPage />} />
       <Route path="/metrics" element={<MetricsPage metrics={metrics} loading={isRouteLoading(states.metrics)} />} />
       <Route path="/search" element={<SearchPage />} />
+      <Route path="/export" element={<ExportPage />} />
       <Route path="/learn" element={<LearnPage />} />
       <Route path="/menu" element={menuPage} />
       <Route path="/vector" element={<VectorPage />} />

--- a/tests/frontend/components/app-shell-vector-nav.test.tsx
+++ b/tests/frontend/components/app-shell-vector-nav.test.tsx
@@ -17,6 +17,7 @@ describe('AppShell Vector navigation', () => {
       expect(html).toContain('aria-label="Vector Dashboard: Collection health and indexing"');
       expect(html).toContain('aria-label="Document Browser: Browse indexed vector documents"');
       expect(html).toContain('aria-label="Vector Search: Semantic preview by collection"');
+      expect(html).toContain('aria-label="Export App: Download app collections"');
       expect(html).toContain('aria-label="Export: Download vector collections"');
     } finally {
       restore();

--- a/tests/frontend/router.test.ts
+++ b/tests/frontend/router.test.ts
@@ -33,10 +33,12 @@ describe('frontend router', () => {
   test('declares the public dashboard route set', () => {
     expect([...frontendRoutes]).toEqual([
       '/',
+      '/menu',
       '/plugins',
       '/canvas/plugins',
       '/metrics',
       '/search',
+      '/export',
       '/learn',
       '/vector',
       '/vector/search',
@@ -48,13 +50,14 @@ describe('frontend router', () => {
   });
 
   test('routes root, plugins, metrics, search, and learn surfaces', () => {
-    expect(htmlAt('/')).toContain('Menu viewer');
-    expect(htmlAt('/plugins')).toContain('Registered plugins');
+    expect(htmlAt('/')).toContain('Menu catalog');
+    expect(htmlAt('/plugins')).toContain('Installed plugins');
     expect(htmlAt('/canvas/plugins')).toContain('Canvas plugin registry');
     expect(htmlAt('/metrics')).toContain('Metrics dashboard');
     expect(htmlAt('/metrics')).toContain('42');
     expect(htmlAt('/metrics')).toContain('Memory usage');
     expect(htmlAt('/search')).toContain('Full-text menu search');
+    expect(htmlAt('/export')).toContain('Export collections');
     expect(htmlAt('/learn')).toContain('Learn entries');
     expect(htmlAt('/vector')).toContain('Vector dashboard');
     expect(htmlAt('/vector/search')).toContain('Vector search preview');


### PR DESCRIPTION
## Summary
- add a new /export frontend page at frontend/src/pages/ExportPage.tsx
- load export app collections from GET /api/v1/export/app/collections
- add bento cards for collection, format, export options, and prepared download link
- wire route metadata, sidebar nav, and frontend route tests

## Verification
- bunx tsc --noEmit
- bun test tests/frontend/router.test.ts tests/frontend/components/app-shell-vector-nav.test.tsx
- wc -l frontend/src/pages/ExportPage.tsx frontend/src/router.tsx frontend/src/components/AppShell.tsx frontend/src/routeMeta.ts frontend/src/routePaths.ts tests/frontend/router.test.ts tests/frontend/components/app-shell-vector-nav.test.tsx