### PR TITLE
feat(maw): add export app command

### DIFF
--- a/tests/tools/maw-plugin-arra/export.test.ts
+++ b/tests/tools/maw-plugin-arra/export.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test';
+import { runExportCommand } from '../../../tools/maw-plugin-arra/commands/export.ts';
+
+type Call = { url: string; init?: RequestInit };
+
+function json(data: unknown): Response {
+  return new Response(JSON.stringify(data), {
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('maw-plugin-arra export command', () => {
+  test('lists available app export collections', async () => {
+    const calls: Call[] = [];
+
+    const output = await runExportCommand(['export'], {
+      fetch: async (url, init) => {
+        calls.push({ url, init });
+        return json({ collections: [{ name: 'oracle_documents', docs: 2, formats: ['json', 'csv'] }] });
+      },
+    });
+
+    expect(calls).toEqual([{ url: 'http://localhost:47778/api/v1/export/app/collections', init: undefined }]);
+    expect(output).toContain('Collection | Docs | Formats');
+    expect(output).toContain('oracle_documents | 2 | json,csv');
+  });
+
+  test('runs export, downloads result, and writes output file', async () => {
+    const calls: Call[] = [];
+    const writes: Array<{ path: string; data: string }> = [];
+
+    const output = await runExportCommand([
+      'export',
+      '--collection', 'oracle_documents',
+      '--format', 'csv',
+      '--output', '/tmp/oracle-documents.csv',
+    ], {
+      fetch: async (url, init) => {
+        calls.push({ url, init });
+        if (url.endsWith('/api/v1/export/app/run')) {
+          return json({ downloadUrl: '/api/v1/export/app/downloads/job-1' });
+        }
+        return new Response('id,title\n1,Oracle\n', { headers: { 'content-type': 'text/csv' } });
+      },
+      mkdir: async () => {},
+      writeFile: async (path, data) => {
+        const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
+        writes.push({ path, data: text });
+      },
+    });
+
+    expect(calls[0]?.url).toBe('http://localhost:47778/api/v1/export/app/run');
+    expect(calls[0]?.init?.method).toBe('POST');
+    expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({ collection: 'oracle_documents', format: 'csv' });
+    expect(calls[1]?.url).toBe('http://localhost:47778/api/v1/export/app/downloads/job-1');
+    expect(writes).toEqual([{ path: '/tmp/oracle-documents.csv', data: 'id,title\n1,Oracle\n' }]);
+    expect(output).toContain('exported oracle_documents (csv) -> /tmp/oracle-documents.csv');
+  });
+});

--- a/tools/maw-plugin-arra/commands/export.ts
+++ b/tools/maw-plugin-arra/commands/export.ts
@@ -1,35 +1,206 @@
-import { flag, parseArgs, requestText } from './http.ts';
+import { mkdir, writeFile as nodeWriteFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { authHeaders, flag, parseArgs, resolveApiBase } from './http.ts';
 
-type ExportFormat = 'json' | 'csv' | 'md';
+const COLLECTIONS_PATH = '/api/v1/export/app/collections';
+const RUN_PATH = '/api/v1/export/app/run';
+const FORMATS = new Set(['json', 'csv', 'md', 'jsonl']);
 
-const allowedFormats = new Set<ExportFormat>(['json', 'csv', 'md']);
+type Fetcher = (input: string, init?: RequestInit) => Promise<Response>;
+type FilePayload = string | Uint8Array;
 
-function normalizeFormat(value: string | undefined): ExportFormat {
-  const format = (value || 'json').toLowerCase();
-  if (!allowedFormats.has(format as ExportFormat)) {
-    throw new Error('usage: maw arra export --collection X --format json|csv|md');
+export interface ExportCommandDeps {
+  apiBase?: string;
+  fetch?: Fetcher;
+  mkdir?: typeof mkdir;
+  writeFile?: (path: string, data: FilePayload) => Promise<void>;
+  env?: Record<string, string | undefined>;
+}
+
+interface ExportOptions {
+  collection?: string;
+  format?: string;
+  output?: string;
+  help: boolean;
+}
+
+export const command = {
+  name: 'export',
+  description: 'Export ARRA app collections through the local Oracle API.',
+};
+
+function normalizeArgs(args: string[]): string[] {
+  return args[0] === 'export' ? args.slice(1) : args;
+}
+
+function readShortOutput(args: string[]): string | undefined {
+  const index = args.indexOf('-o');
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+export function parseExportArgs(args: string[]): ExportOptions {
+  const clean = normalizeArgs(args);
+  const parsed = parseArgs(clean);
+  return {
+    collection: flag(parsed, 'collection') || parsed.positionals[0],
+    format: flag(parsed, 'format') || parsed.positionals[1],
+    output: flag(parsed, 'output') || readShortOutput(clean),
+    help: clean.includes('--help') || clean.includes('-h'),
+  };
+}
+
+function usage(): string {
+  return [
+    'maw arra export',
+    'maw arra export --collection NAME --format json|csv|md|jsonl --output PATH',
+    '',
+    'Without export flags, lists available export collections.',
+  ].join('\n');
+}
+
+function apiUrl(base: string, pathOrUrl: string): string {
+  if (/^https?:\/\//.test(pathOrUrl)) return pathOrUrl;
+  const normalizedBase = base.replace(/\/+$/, '');
+  return `${normalizedBase}${pathOrUrl.startsWith('/') ? pathOrUrl : `/${pathOrUrl}`}`;
+}
+
+async function errorText(response: Response): Promise<string> {
+  const text = await response.text();
+  if (!text) return response.statusText;
+  try {
+    const data = JSON.parse(text);
+    return data?.error ?? data?.message ?? text;
+  } catch {
+    return text;
   }
-  return format as ExportFormat;
 }
 
-function apiFormat(format: ExportFormat): string {
-  return format === 'md' ? 'markdown' : format;
+async function ensureOk(response: Response, action: string): Promise<void> {
+  if (response.ok) return;
+  throw new Error(`${action} failed: HTTP ${response.status} ${await errorText(response)}`);
 }
 
-function acceptHeader(format: ExportFormat): string {
-  if (format === 'csv') return 'text/csv';
-  if (format === 'md') return 'text/markdown';
-  return 'application/json';
-}
-
-export async function runExportCommand(args: string[]): Promise<string> {
-  const parsed = parseArgs(args);
-  const collection = flag(parsed, 'collection') || parsed.positionals[0];
-  if (!collection) throw new Error('usage: maw arra export --collection X --format json|csv|md');
-
-  const format = normalizeFormat(flag(parsed, 'format') || parsed.positionals[1]);
-  const query = new URLSearchParams({ collection, format: apiFormat(format) });
-  return requestText(`/api/v1/vector/export?${query.toString()}`, {
-    headers: { accept: acceptHeader(format) },
+function collectionRows(data: unknown): Array<{ name: string; docs?: unknown; formats?: unknown }> {
+  const source = Array.isArray(data)
+    ? data
+    : Array.isArray((data as { collections?: unknown[] })?.collections)
+      ? (data as { collections: unknown[] }).collections
+      : [];
+  return source.map((item) => {
+    if (typeof item === 'string') return { name: item };
+    const row = item as Record<string, unknown>;
+    return {
+      name: String(row.name ?? row.collection ?? row.key ?? row.id ?? 'unknown'),
+      docs: row.docs ?? row.count ?? row.total,
+      formats: row.formats,
+    };
   });
+}
+
+function formatCollections(data: unknown): string {
+  const rows = collectionRows(data);
+  if (!rows.length) return 'No export collections available.';
+  return [
+    'Collection | Docs | Formats',
+    ...rows.map((row) => {
+      const formats = Array.isArray(row.formats) ? row.formats.join(',') : row.formats ?? '-';
+      return `${row.name} | ${row.docs ?? '-'} | ${formats}`;
+    }),
+  ].join('\n');
+}
+
+function downloadUrl(data: Record<string, unknown>): string | undefined {
+  for (const key of ['downloadUrl', 'download_url', 'resultUrl', 'result_url', 'url', 'href', 'file', 'path']) {
+    const value = data[key];
+    if (typeof value === 'string' && value) return value;
+  }
+}
+
+function inlinePayload(data: Record<string, unknown>): FilePayload | undefined {
+  for (const key of ['content', 'result', 'data']) {
+    const value = data[key];
+    if (typeof value === 'string') return value;
+    if (value !== undefined && value !== null) return `${JSON.stringify(value, null, 2)}\n`;
+  }
+}
+
+async function resultPayload(response: Response, base: string, fetcher: Fetcher): Promise<FilePayload> {
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!contentType.includes('application/json')) {
+    return new Uint8Array(await response.arrayBuffer());
+  }
+
+  const data = await response.json() as Record<string, unknown>;
+  const inline = inlinePayload(data);
+  if (inline !== undefined) return inline;
+  const url = downloadUrl(data);
+  if (!url) throw new Error('export run response did not include a download URL or content');
+
+  const download = await fetcher(apiUrl(base, url));
+  await ensureOk(download, `GET ${url}`);
+  return new Uint8Array(await download.arrayBuffer());
+}
+
+function fullDeps(deps: ExportCommandDeps): Required<ExportCommandDeps> {
+  const env = deps.env ?? process.env;
+  return {
+    apiBase: deps.apiBase ?? resolveApiBase(env),
+    fetch: deps.fetch ?? fetch,
+    mkdir: deps.mkdir ?? mkdir,
+    writeFile: deps.writeFile ?? nodeWriteFile,
+    env,
+  };
+}
+
+async function listCollections(deps: Required<ExportCommandDeps>): Promise<string> {
+  const response = await deps.fetch(apiUrl(deps.apiBase, COLLECTIONS_PATH));
+  await ensureOk(response, `GET ${COLLECTIONS_PATH}`);
+  return formatCollections(await response.json());
+}
+
+function validateRun(options: ExportOptions): asserts options is ExportOptions & { collection: string; format: string; output: string } {
+  if (!options.collection || !options.format || !options.output) {
+    throw new Error('export requires --collection NAME --format json|csv|md|jsonl --output PATH');
+  }
+  if (!FORMATS.has(options.format)) throw new Error(`unsupported format: ${options.format}`);
+}
+
+async function runExport(options: ExportOptions, deps: Required<ExportCommandDeps>): Promise<string> {
+  validateRun(options);
+  const response = await deps.fetch(apiUrl(deps.apiBase, RUN_PATH), {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...authHeaders(deps.env) },
+    body: JSON.stringify({ collection: options.collection, format: options.format }),
+  });
+  await ensureOk(response, `POST ${RUN_PATH}`);
+
+  const payload = await resultPayload(response, deps.apiBase, deps.fetch);
+  await deps.mkdir(dirname(options.output), { recursive: true });
+  await deps.writeFile(options.output, payload);
+  return `exported ${options.collection} (${options.format}) -> ${options.output}`;
+}
+
+export async function runExportCommand(args: string[], deps: ExportCommandDeps = {}): Promise<string> {
+  const options = parseExportArgs(args);
+  if (options.help) return usage();
+  const resolvedDeps = fullDeps(deps);
+  return options.collection || options.format || options.output
+    ? runExport(options, resolvedDeps)
+    : listCollections(resolvedDeps);
+}
+
+export async function exportCommand(args: string[], deps: ExportCommandDeps = {}): Promise<number> {
+  try {
+    process.stdout.write(`${await runExportCommand(args, deps)}\n`);
+    return 0;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}
+
+export default runExportCommand;
+
+if (import.meta.main) {
+  process.exit(await exportCommand(Bun.argv.slice(2)));
 }


### PR DESCRIPTION
## Summary
- add tools/maw-plugin-arra/commands/export.ts for maw arra export
- list app export collections from GET /api/v1/export/app/collections
- run exports through POST /api/v1/export/app/run, follow returned download URLs, and write the downloaded result to --output

## Verification
- bun test tests/tools/maw-plugin-arra/export.test.ts
- bunx tsc --noEmit
- git diff --check
- wc -l tools/maw-plugin-arra/commands/export.ts tests/tools/maw-plugin-arra/export.test.ts