### PR TITLE
Add vector embedding fallback config coverage

### DIFF
--- a/src/routes/vector/index.ts
+++ b/src/routes/vector/index.ts
@@ -36,6 +36,7 @@ import { vectorExportEndpoint } from './export.ts';
 import { vectorServicesApiEndpoint } from './services.ts';
 import { vectorProvidersEndpoint } from './providers.ts';
 import { vectorCostEndpoint } from './cost.ts';
+import { vectorConfigApiEndpoint } from './config-api.ts';
 
 export const vectorRoutes = new Elysia({ prefix: '/api' })
   .use(vectorProxyEndpoint)
@@ -51,5 +52,6 @@ export const vectorRoutes = new Elysia({ prefix: '/api' })
   .use(vectorExportEndpoint)
   .use(vectorProvidersEndpoint)
   .use(vectorCostEndpoint)
+  .use(vectorConfigApiEndpoint)
   .use(vectorServicesApiEndpoint)
   .use(vectorIndexerEndpoints);

--- a/src/vector/config.ts
+++ b/src/vector/config.ts
@@ -148,9 +148,12 @@ function embedderFor(config: VectorServerConfig, col: VectorCollectionConfig): E
   const generated = col.embedder?.backend === 'ollama' && col.embedder.model === col.model && col.provider === 'ollama';
   const merged = config.embedder && generated ? { ...col.embedder, ...config.embedder }
     : config.embedder || col.embedder ? { ...config.embedder, ...col.embedder } : undefined;
+  const primary = col.embedder && !generated
+    ? col.embedder.backend ?? col.embedder.default ?? config.embedder?.backend ?? config.embedder?.default
+    : config.embedder?.backend ?? config.embedder?.default ?? col.embedder?.backend ?? col.embedder?.default;
   if (merged) return {
     ...merged,
-    backend: merged.backend ?? merged.default ?? 'none',
+    backend: primary ?? 'none',
     model: merged.model ?? col.model,
   };
   const provider = col.provider.toLowerCase();

--- a/src/vector/embeddings.ts
+++ b/src/vector/embeddings.ts
@@ -2,6 +2,7 @@ import type { EmbeddingProvider, EmbeddingProviderType, EmbedType } from './type
 import { NoneEmbeddings, RemoteHttpEmbeddings } from './embedding-backends.ts';
 
 export type FallbackEvent = { from: string; to?: string; error: string };
+export type EmbeddingProviderOptions = { url?: string; dimensions?: number; fallbackChain?: EmbeddingProviderType[]; fallback?: EmbeddingProviderType };
 
 export class ChromaDBInternalEmbeddings implements EmbeddingProvider {
   readonly name = 'chromadb-internal';
@@ -194,9 +195,10 @@ function errorMessage(error: unknown): string {
 export function createEmbeddingProvider(
   type: EmbeddingProviderType = 'none',
   model?: string,
-  options: { url?: string; dimensions?: number; fallbackChain?: EmbeddingProviderType[] } = {},
+  options: EmbeddingProviderOptions = {},
 ): EmbeddingProvider {
-  const chain = [type, ...(options.fallbackChain ?? [])].filter((item, index, all) =>
+  const fallbacks = options.fallbackChain ?? (options.fallback ? [options.fallback] : []);
+  const chain = [type, ...fallbacks].filter((item, index, all) =>
     item !== 'none' && all.indexOf(item) === index
   );
   if (chain.length > 1) return new FallbackEmbeddings(chain.map((item) => createSingleEmbeddingProvider(item, model, options)));

--- a/tests/http/vector/embedding-fallback.test.ts
+++ b/tests/http/vector/embedding-fallback.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, expect, mock, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { configToModels, generateDefaultConfig, loadVectorConfig, writeVectorConfig } from '../../../src/vector/config.ts';
+import { createEmbeddingProvider, FallbackEmbeddings } from '../../../src/vector/embeddings.ts';
+import type { EmbeddingProvider } from '../../../src/vector/types.ts';
+
+const savedOpenAiKey = process.env.OPENAI_API_KEY;
+
+afterEach(() => {
+  if (savedOpenAiKey === undefined) delete process.env.OPENAI_API_KEY;
+  else process.env.OPENAI_API_KEY = savedOpenAiKey;
+});
+
+test('FallbackEmbeddings logs and uses fallback when primary embed fails', async () => {
+  const events: Array<{ from: string; to?: string; error: string }> = [];
+  const failing: EmbeddingProvider = {
+    name: 'ollama',
+    dimensions: 3,
+    embed: mock(async () => { throw new Error('ollama down'); }),
+  };
+  const fallback: EmbeddingProvider = {
+    name: 'openai',
+    dimensions: 3,
+    embed: mock(async () => [[1, 2, 3]]),
+  };
+
+  const provider = new FallbackEmbeddings([failing, fallback], (event) => events.push(event));
+
+  await expect(provider.embed(['oracle'], 'query')).resolves.toEqual([[1, 2, 3]]);
+  expect(failing.embed).toHaveBeenCalledWith(['oracle'], 'query');
+  expect(fallback.embed).toHaveBeenCalledWith(['oracle'], 'query');
+  expect(events).toEqual([{ from: 'ollama', to: 'openai', error: 'ollama down' }]);
+});
+
+test('createEmbeddingProvider accepts compact fallback config', () => {
+  process.env.OPENAI_API_KEY = 'sk-test';
+
+  const provider = createEmbeddingProvider('ollama', 'bge-m3', { fallback: 'openai' });
+
+  expect(provider.name).toBe('ollama>openai');
+});
+
+test('vector-server embedder defaults persist and collection overrides win', () => {
+  const root = mkdtempSync(join(tmpdir(), 'vector-fallback-config-'));
+  try {
+    const config = generateDefaultConfig();
+    config.embedder = { default: 'openai', fallback: 'ollama', model: 'text-embedding-3-small' };
+    config.collections.qwen3.embedder = {
+      default: 'gemini',
+      fallback: 'openai',
+      model: 'text-embedding-004',
+    };
+
+    const fp = writeVectorConfig(config, join(root, 'vector-server.json'));
+    const models = configToModels(loadVectorConfig(fp)!);
+
+    expect(models['bge-m3'].embedder).toMatchObject({
+      backend: 'openai',
+      fallback: 'ollama',
+      model: 'text-embedding-3-small',
+    });
+    expect(models.qwen3.embedder).toMatchObject({
+      backend: 'gemini',
+      fallback: 'openai',
+      model: 'text-embedding-004',
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Summary
- Support compact embedding provider fallback config in createEmbeddingProvider.
- Resolve vector-server.json embedder.default correctly across global defaults and per-collection overrides.
- Add tests proving fallback events trigger and persisted vector config overrides resolve.
- Mount the vector config API in vectorRoutes so current alpha vector route tests pass when vectorRoutes is mounted directly.

Validation
- git merge-tree --write-tree HEAD origin/alpha
- bunx tsc --noEmit
- bun test tests/http/vector/
- files <=250 lines

Refs #1437