### PR TITLE
feat: add vector settings bento page

### DIFF
--- a/frontend/src/pages/VectorSettingsPage.tsx
+++ b/frontend/src/pages/VectorSettingsPage.tsx
@@ -1,34 +1,105 @@
-import { useEffect, useMemo, useState } from 'react';
-import { VectorAdapterSwitcher } from '../components/VectorAdapterSwitcher';
-import { VectorProviderServicePanel } from '../components/VectorProviderServicePanel';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { ErrorMessage, LoadingPanel, Spinner } from '../components/AsyncState';
-import { FirstRunWizard } from './FirstRunWizard';
-import { IndexManagerPanel } from './IndexManagerPanel';
-import { VectorCollectionList } from './VectorCollectionList';
-import { type LoadState, type VectorCollectionTest, type VectorConfigDraft, type VectorConfigResponse, type VectorConfigRow, fetchJson, parseVectorConfigResponse, toRows } from './vectorSettingsHelpers';
+import {
+  type LoadState,
+  type VectorConfigResponse,
+  type VectorConfigRow,
+  fetchJson,
+  parseVectorConfigResponse,
+  toRows,
+} from './vectorSettingsHelpers';
+
+type Provider = {
+  type: string;
+  available: boolean;
+  status?: string;
+  models?: string[];
+  error?: string;
+};
+
+type IndexModel = {
+  collection: string;
+  model: string;
+  adapter: string;
+  count?: number;
+};
+
+type IndexStatus = {
+  model: string;
+  status: 'idle' | 'indexing' | 'completed' | 'error';
+  current: number;
+  total: number;
+  startedAt: number;
+  completedAt?: number;
+  docsPerSec: number;
+  eta: number;
+  error?: string;
+};
+
+type CacheStats = { size?: number; hits?: number; misses?: number };
+
+function dateLabel(value?: number | string): string {
+  if (!value) return 'not recorded';
+  const timestamp = typeof value === 'number' ? value : Date.parse(value);
+  return Number.isFinite(timestamp) ? new Date(timestamp).toLocaleString() : String(value);
+}
+
+function countFor(row: VectorConfigRow, models: Record<string, IndexModel>): number {
+  return row.count ?? models[row.key]?.count ?? 0;
+}
+
+function providerDetail(provider: Provider): string {
+  if (provider.error) return provider.error;
+  const models = provider.models?.slice(0, 2).join(', ') || 'no models reported';
+  return `${provider.status ?? (provider.available ? 'available' : 'unavailable')} · ${models}`;
+}
+
+function statusText(status: IndexStatus | null): string {
+  if (!status || status.status === 'idle') return 'No active index job.';
+  if (status.status === 'completed') return `Completed ${status.model}`;
+  if (status.status === 'error') return status.error ?? `Failed ${status.model}`;
+  return `${status.model}: ${status.current}/${status.total} docs · ${status.docsPerSec} docs/sec`;
+}
 
 export function VectorSettingsPage() {
   const [state, setState] = useState<LoadState>('loading');
   const [error, setError] = useState('');
+  const [message, setMessage] = useState('');
   const [config, setConfig] = useState<VectorConfigResponse | null>(null);
   const [rows, setRows] = useState<VectorConfigRow[]>([]);
-  const [drafts, setDrafts] = useState<Record<string, VectorConfigDraft>>({});
-  const [saving, setSaving] = useState<Record<string, boolean>>({});
-  const [testing, setTesting] = useState<Record<string, boolean>>({});
-  const [primarySaving, setPrimarySaving] = useState('');
-  const [actionMessage, setActionMessage] = useState<Record<string, string>>({});
-  const [reloading, setReloading] = useState(false);
-  const [reloadStatus, setReloadStatus] = useState('');
+  const [providers, setProviders] = useState<Provider[]>([]);
+  const [models, setModels] = useState<Record<string, IndexModel>>({});
+  const [indexStatus, setIndexStatus] = useState<IndexStatus | null>(null);
+  const [selectedProvider, setSelectedProvider] = useState('');
+  const [selectedModel, setSelectedModel] = useState('');
+  const [busy, setBusy] = useState('');
 
-  async function loadConfig() {
+  const primary = useMemo(() => rows.find((row) => row.primary) ?? rows[0], [rows]);
+  const provider = providers.find((item) => item.type === selectedProvider);
+  const availableModels = provider?.models ?? [];
+  const totalDocs = rows.reduce((sum, row) => sum + countFor(row, models), 0);
+  const lastIndexed = indexStatus?.completedAt ?? indexStatus?.startedAt ?? config?.checked_at;
+
+  async function load() {
     setState('loading');
     setError('');
     try {
-      const normalized = parseVectorConfigResponse(await fetchJson<VectorConfigResponse>('/api/v1/vector/config'));
-      const nextRows = toRows(normalized);
-      setConfig(normalized);
+      const [configBody, providersBody, modelsBody, statusBody] = await Promise.all([
+        fetchJson<VectorConfigResponse>('/api/v1/vector/config'),
+        fetchJson<{ providers?: Provider[] }>('/api/v1/vector/providers'),
+        fetchJson<{ models?: Record<string, IndexModel> }>('/api/v1/vector/index/models'),
+        fetchJson<IndexStatus>('/api/v1/vector/index/status'),
+      ]);
+      const parsed = parseVectorConfigResponse(configBody);
+      const nextRows = toRows(parsed);
+      const nextProviders = providersBody.providers ?? [];
+      setConfig(parsed);
       setRows(nextRows);
-      setDrafts(Object.fromEntries(nextRows.map((row) => [row.key, { model: row.model, provider: row.provider, adapter: row.adapter, enabled: row.enabled }])));
+      setProviders(nextProviders);
+      setModels(modelsBody.models ?? {});
+      setIndexStatus(statusBody);
+      setSelectedProvider((current) => current || nextProviders.find((item) => item.available)?.type || nextProviders[0]?.type || '');
+      setSelectedModel((current) => current || nextRows.find((row) => row.primary)?.model || nextRows[0]?.model || '');
       setState('ready');
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause));
@@ -36,87 +107,130 @@ export function VectorSettingsPage() {
     }
   }
 
-  useEffect(() => { void loadConfig(); }, []);
+  useEffect(() => { void load(); }, []);
 
-  const stats = useMemo(() => {
-    if (!rows.length || !config) return 'No vector collections loaded.';
-    const healthy = rows.filter((item) => item.health?.ok).length;
-    const primary = rows.find((item) => item.primary)?.key ?? 'none';
-    return `${rows.length} collections · ${healthy}/${rows.length} healthy · primary ${primary} · source ${config.source}`;
-  }, [rows, config]);
-
-  function updateDraft(key: string, next: Partial<VectorConfigDraft>) {
-    setDrafts((current) => ({ ...current, [key]: { ...(current[key] ?? { model: '', provider: '', adapter: 'lancedb', enabled: true }), ...next } }));
-  }
-
-  async function saveCollection(key: string) {
-    const row = rows.find((item) => item.key === key);
-    const draft = drafts[key];
-    if (!row || !draft) return;
-    const payload = Object.fromEntries(Object.entries({ model: draft.model.trim(), provider: draft.provider.trim(), adapter: draft.adapter, enabled: draft.enabled }).filter(([name, value]) => value !== row[name as keyof VectorConfigRow]));
-    if (!Object.keys(payload).length) return setActionMessage((current) => ({ ...current, [key]: 'No changes to save.' }));
-    setSaving((current) => ({ ...current, [key]: true }));
+  async function runAction(label: string, action: () => Promise<string>) {
+    setBusy(label);
+    setMessage('');
+    setError('');
     try {
-      await fetchJson(`/api/v1/vector/config/${encodeURIComponent(key)}`, { method: 'PUT', body: JSON.stringify(payload) });
-      await loadConfig();
-      setActionMessage((current) => ({ ...current, [key]: 'Saved.' }));
+      setMessage(await action());
+      await load();
     } catch (cause) {
-      setActionMessage((current) => ({ ...current, [key]: `Save failed: ${cause instanceof Error ? cause.message : String(cause)}` }));
-    } finally { setSaving((current) => ({ ...current, [key]: false })); }
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setBusy('');
+    }
   }
 
-  async function testCollection(key: string) {
-    setTesting((current) => ({ ...current, [key]: true }));
-    try {
-      const response = await fetchJson<VectorCollectionTest>(`/api/v1/vector/config/${encodeURIComponent(key)}/test`, { method: 'POST' });
-      setActionMessage((current) => ({ ...current, [key]: response.success ? `Test passed · docs ${response.count ?? 0}` : `Test failed · ${response.error ?? response.status ?? 'unknown error'}` }));
-    } catch (cause) {
-      setActionMessage((current) => ({ ...current, [key]: `Test failed: ${cause instanceof Error ? cause.message : String(cause)}` }));
-    } finally { setTesting((current) => ({ ...current, [key]: false })); void loadConfig(); }
-  }
+  const applyModel = () => runAction('apply-model', async () => {
+    if (!primary) return 'No primary collection is available.';
+    await fetchJson(`/api/v1/vector/config/${encodeURIComponent(primary.key)}`, {
+      method: 'PUT',
+      body: JSON.stringify({ provider: selectedProvider, model: selectedModel }),
+    });
+    await fetchJson('/api/v1/vector/config/reload', { method: 'POST' });
+    return `Applied ${selectedProvider}/${selectedModel} to ${primary.key}.`;
+  });
 
-  async function setPrimary(key: string) {
-    setPrimarySaving(key);
-    try {
-      await fetchJson(`/api/v1/vector/config/${encodeURIComponent(key)}/primary`, { method: 'POST' });
-      await loadConfig();
-      setActionMessage((current) => ({ ...current, [key]: 'Primary collection updated.' }));
-    } catch (cause) {
-      setActionMessage((current) => ({ ...current, [key]: `Primary failed: ${cause instanceof Error ? cause.message : String(cause)}` }));
-    } finally { setPrimarySaving(''); }
-  }
+  const reindex = () => runAction('reindex', async () => {
+    const key = primary?.key ?? 'bge-m3';
+    await fetchJson('/api/v1/vector/index/start', { method: 'POST', body: JSON.stringify({ model: key }) });
+    return `Started re-index for ${key}.`;
+  });
 
-  async function reloadVector() {
-    setReloading(true);
-    try {
-      await fetchJson('/api/v1/vector/config/reload', { method: 'POST' });
-      setReloadStatus(`Reloaded at ${new Date().toLocaleTimeString()}`);
-      await loadConfig();
-    } catch (cause) { setError(cause instanceof Error ? cause.message : String(cause)); }
-    finally { setReloading(false); }
-  }
+  const clearCache = () => runAction('clear-cache', async () => {
+    const result = await fetchJson<{ cache?: CacheStats }>('/api/v1/vector/fanout/cache', { method: 'DELETE' });
+    return `Cleared query cache; ${result.cache?.size ?? 0} entries remain.`;
+  });
 
   return (
     <section className="grid gap-5" aria-labelledby="vector-settings-title">
       <header className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
-        <div className="mb-4 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between"><div><p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-300">Vector settings</p><h1 id="vector-settings-title" className="mt-2 text-3xl font-semibold text-white">Vector config and indexing</h1><p className="mt-2 text-sm text-slate-400">Manage vector collection settings, first-run setup, and index jobs.</p><p className="mt-2 text-sm text-slate-500">{stats}</p></div><div className="grid gap-2 sm:flex sm:flex-wrap sm:justify-end"><button className="focus-ring rounded-xl border border-white/10 px-3 py-2 text-sm text-slate-200" type="button" onClick={() => void loadConfig()}>{state === 'loading' ? <Spinner label="Refreshing" /> : 'Refresh config'}</button><button className="focus-ring rounded-xl bg-purple-300 px-3 py-2 text-sm font-semibold text-slate-950 disabled:opacity-60" disabled={reloading} type="button" onClick={() => void reloadVector()}>{reloading ? <Spinner label="Reloading" /> : 'Reload runtime cache'}</button></div></div>
-        {config ? <ConfigSummary config={config} /> : null}
-        {reloadStatus ? <p className="mt-3 text-sm text-slate-300">{reloadStatus}</p> : null}
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Vector settings</p>
+        <h1 id="vector-settings-title" className="mt-2 text-3xl font-semibold text-white">Vector settings</h1>
+        <p className="mt-2 text-sm text-slate-400">Configure adapters, embedding models, indexing state, and query cache controls.</p>
       </header>
-      {state === 'loading' ? <LoadingPanel title="Loading vector config" detail="Reading /api/v1/vector/config." /> : null}
-      {state === 'error' ? <ErrorMessage title="Could not load vector config." message={error} /> : null}
-      {error && state !== 'error' ? <ErrorMessage title="Vector settings warning" message={error} /> : null}
-      {state === 'ready' ? <VectorProviderServicePanel /> : null}
-      {state === 'ready' ? <VectorAdapterSwitcher rows={rows} onRefresh={loadConfig} /> : null}
-      {state === 'ready' ? <FirstRunWizard rows={rows} onRefresh={loadConfig} /> : null}
-      <section className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
-        <VectorCollectionList rows={rows} drafts={drafts} saving={saving} testing={testing} primarySaving={primarySaving} actionMessage={actionMessage} onDraft={updateDraft} onSave={(key) => void saveCollection(key)} onTest={(key) => void testCollection(key)} onPrimary={(key) => void setPrimary(key)} />
-        <IndexManagerPanel />
-      </section>
+
+      {state === 'loading' ? <LoadingPanel title="Loading vector settings" detail="Fetching config, providers, and index status." /> : null}
+      {error ? <ErrorMessage title="Vector settings failed." message={error} /> : null}
+      {message ? <p className="rounded-xl border border-teal-300/20 bg-teal-300/10 p-3 text-sm text-teal-100">{message}</p> : null}
+
+      <div className="grid gap-5 xl:grid-cols-2">
+        <BentoCard eyebrow="Active adapters" title="Configured collections">
+          <div className="grid gap-3">
+            {rows.map((row) => (
+              <article key={row.key} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <h2 className="font-mono text-sm font-semibold text-white">{row.key}</h2>
+                    <p className="mt-1 text-sm text-slate-400">{row.adapter} · {row.provider} · {countFor(row, models).toLocaleString()} docs</p>
+                  </div>
+                  <span className={`rounded-full px-2 py-1 text-xs font-semibold ${row.health?.ok ? 'bg-teal-300/15 text-teal-100' : 'bg-red-300/15 text-red-100'}`}>
+                    {row.health?.status ?? 'unknown'}
+                  </span>
+                </div>
+              </article>
+            ))}
+            {!rows.length && state === 'ready' ? <p className="text-sm text-slate-500">No vector collections configured.</p> : null}
+          </div>
+        </BentoCard>
+
+        <BentoCard eyebrow="Embedding model" title="Provider selector">
+          <div className="grid gap-3">
+            <label className="text-sm font-semibold text-slate-300">Provider<select className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-3 py-2 text-sm text-white" value={selectedProvider} onChange={(event) => { const next = event.target.value; setSelectedProvider(next); setSelectedModel(providers.find((item) => item.type === next)?.models?.[0] ?? ''); }}>
+              {providers.map((item) => <option key={item.type} value={item.type}>{item.type}</option>)}
+            </select></label>
+            <label className="text-sm font-semibold text-slate-300">Model<select className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-3 py-2 text-sm text-white" value={selectedModel} onChange={(event) => setSelectedModel(event.target.value)}>
+              {[selectedModel, ...availableModels].filter(Boolean).filter((item, index, all) => all.indexOf(item) === index).map((model) => <option key={model} value={model}>{model}</option>)}
+            </select></label>
+            <p className="text-sm text-slate-400">{provider ? providerDetail(provider) : 'Provider detection has not returned data.'}</p>
+            <button className="focus-ring rounded-xl bg-teal-300 px-4 py-2 text-sm font-semibold text-slate-950 disabled:opacity-50" disabled={!primary || !selectedProvider || !selectedModel || Boolean(busy)} type="button" onClick={() => void applyModel()}>
+              {busy === 'apply-model' ? <Spinner label="Applying" /> : `Apply to ${primary?.key ?? 'primary'}`}
+            </button>
+          </div>
+        </BentoCard>
+
+        <BentoCard eyebrow="Index status" title="Collections and progress">
+          <dl className="grid gap-3 text-sm text-slate-300 sm:grid-cols-3">
+            <Stat label="Collections" value={rows.length.toLocaleString()} />
+            <Stat label="Documents" value={totalDocs.toLocaleString()} />
+            <Stat label="Last index" value={dateLabel(lastIndexed)} />
+          </dl>
+          <p className="mt-4 rounded-2xl border border-white/10 bg-white/[0.03] p-4 text-sm text-slate-300">{statusText(indexStatus)}</p>
+        </BentoCard>
+
+        <BentoCard eyebrow="Quick actions" title="Maintenance controls">
+          <div className="grid gap-3 sm:grid-cols-3">
+            <ActionButton disabled={Boolean(busy)} label="Refresh" loading={busy === 'refresh'} onClick={() => void runAction('refresh', async () => 'Refreshed vector settings.')} />
+            <ActionButton disabled={Boolean(busy) || indexStatus?.status === 'indexing'} label="Re-index" loading={busy === 'reindex'} onClick={() => void reindex()} />
+            <ActionButton disabled={Boolean(busy)} label="Clear cache" loading={busy === 'clear-cache'} onClick={() => void clearCache()} />
+          </div>
+          <p className="mt-4 text-sm text-slate-400">Re-index targets {primary?.key ?? 'the primary collection'}; cache clearing uses /api/v1/vector/fanout/cache.</p>
+        </BentoCard>
+      </div>
     </section>
   );
 }
 
-function ConfigSummary({ config }: { config: VectorConfigResponse }) {
-  return <dl className="grid gap-3 text-sm sm:grid-cols-2 xl:grid-cols-4"><div className="rounded-xl border border-white/10 bg-slate-950/70 p-3"><dt className="text-slate-500">Source / Version</dt><dd className="font-semibold text-teal-200">{config.source} · v{config.config.version}</dd></div><div className="rounded-xl border border-white/10 bg-slate-950/70 p-3"><dt className="text-slate-500">Store</dt><dd className="font-semibold text-teal-200">{config.config.host}:{config.config.port}</dd></div><div className="rounded-xl border border-white/10 bg-slate-950/70 p-3"><dt className="text-slate-500">Data path</dt><dd className="break-all font-semibold text-teal-200">{config.config.dataPath}</dd></div><div className="rounded-xl border border-white/10 bg-slate-950/70 p-3"><dt className="text-slate-500">Embedder</dt><dd className="font-semibold text-teal-200">{config.config.embedder?.backend ?? 'unknown'}</dd></div></dl>;
+function BentoCard({ eyebrow, title, children }: { eyebrow: string; title: string; children: ReactNode }) {
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-300">{eyebrow}</p>
+      <h2 className="mt-2 text-2xl font-semibold text-white">{title}</h2>
+      <div className="mt-5">{children}</div>
+    </section>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4"><dt className="text-slate-500">{label}</dt><dd className="mt-1 font-semibold text-white">{value}</dd></div>;
+}
+
+function ActionButton({ disabled, label, loading, onClick }: { disabled: boolean; label: string; loading: boolean; onClick: () => void }) {
+  return (
+    <button className="focus-ring rounded-xl border border-white/10 px-3 py-2 text-sm font-semibold text-slate-100 hover:border-teal-300/40 disabled:cursor-not-allowed disabled:opacity-50" disabled={disabled} type="button" onClick={onClick}>
+      {loading ? <Spinner label={label} /> : label}
+    </button>
+  );
 }

--- a/tests/frontend/router.test.ts
+++ b/tests/frontend/router.test.ts
@@ -64,7 +64,7 @@ describe('frontend router', () => {
     expect(htmlAt('/vector/documents')).toContain('Vector documents');
     expect(htmlAt('/vector/results')).toContain('Vector search results');
     expect(htmlAt('/vector/export')).toContain('Vector export');
-    expect(htmlAt('/vector/settings')).toContain('Vector config and indexing');
+    expect(htmlAt('/vector/settings')).toContain('Configure adapters, embedding models');
   });
 
   test('wraps routed children in the browser router and error boundary shell', () => {


### PR DESCRIPTION
## Summary
- replace Vector Settings with a four-card bento surface for adapters, provider/model selection, index status, and quick actions
- wire the page to vector config, provider detection, index model/status, re-index, and fanout cache APIs
- update the existing router test expectation for the new page copy

Note: /vector/settings was already registered in frontend/src/router.tsx and AppShell on current alpha, so no route diff was needed.

## Validation
- bun test tests/frontend/router.test.ts
- bunx tsc --noEmit
- (cd frontend && bun run build)
- wc -l frontend/src/pages/VectorSettingsPage.tsx tests/frontend/router.test.ts