### PR TITLE
feat: add export app HTTP routes

### DIFF
--- a/src/routes/export/app.ts
+++ b/src/routes/export/app.ts
@@ -1,0 +1,180 @@
+import { getTableName } from 'drizzle-orm';
+import { Elysia, t } from 'elysia';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+import { ORACLE_DATA_DIR } from '../../config.ts';
+import { db as defaultDb, type DatabaseConnection } from '../../db/index.ts';
+import { introspectDrizzleTables } from '../../cli/commands/backup.ts';
+
+type ExportRecord = Record<string, unknown>;
+type ExportFormat = 'json' | 'csv' | 'markdown';
+type DumpTable = ReturnType<typeof introspectDrizzleTables>[number];
+type QueryConnection = Pick<DatabaseConnection, 'db'>;
+
+interface ExportTools {
+  EXPORT_FORMATS: readonly ExportFormat[];
+  extensionFor(format: ExportFormat): string;
+  formatCollection(name: string, rows: ExportRecord[], format: ExportFormat): string;
+  normalizeRecords(rows: ExportRecord[]): ExportRecord[];
+  graphRelationships(collections: Record<string, ExportRecord[]>): ExportRecord[];
+}
+
+interface ExportJob {
+  jobId: string;
+  collection: string;
+  format: ExportFormat;
+  includeGraph: boolean;
+  filePath: string;
+  filename: string;
+  mimeType: string;
+  rowCount: number;
+  relationshipCount: number;
+  createdAt: string;
+}
+
+export interface ExportAppDeps {
+  connection?: QueryConnection;
+  outputDir?: string;
+  now?: () => Date;
+  idGenerator?: () => string;
+}
+
+const formatsUrl = new URL('../../../tools/export-app/formats.ts', import.meta.url).href;
+const graphUrl = new URL('../../../tools/export-app/graph.ts', import.meta.url).href;
+
+async function loadExportTools(): Promise<ExportTools> {
+  const [formats, graph] = await Promise.all([import(formatsUrl), import(graphUrl)]) as any[];
+  return { ...formats, graphRelationships: graph.graphRelationships } as ExportTools;
+}
+
+function connectionFrom(deps: ExportAppDeps): QueryConnection {
+  return deps.connection ?? { db: defaultDb };
+}
+
+function tableMap(): Map<string, DumpTable> {
+  return new Map(introspectDrizzleTables().map((table) => [getTableName(table), table]));
+}
+
+function selectRows(connection: QueryConnection, table: DumpTable): ExportRecord[] {
+  return (connection.db as any).select().from(table).all() as ExportRecord[];
+}
+
+function safeName(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+function mimeType(format: ExportFormat): string {
+  if (format === 'csv') return 'text/csv; charset=utf-8';
+  if (format === 'markdown') return 'text/markdown; charset=utf-8';
+  return 'application/json; charset=utf-8';
+}
+
+function csvCell(value: unknown): string {
+  const text = value == null ? '' : typeof value === 'object' ? JSON.stringify(value) : String(value);
+  return `"${text.replaceAll('"', '""')}"`;
+}
+
+async function allCollections(connection: QueryConnection, tools: ExportTools): Promise<Record<string, ExportRecord[]>> {
+  return Object.fromEntries([...tableMap()].map(([name, table]) => [
+    name,
+    tools.normalizeRecords(selectRows(connection, table)),
+  ]));
+}
+
+function attachGraph(content: string, format: ExportFormat, relationships: ExportRecord[]): string {
+  if (relationships.length === 0) return content;
+  if (format === 'json') {
+    const payload = JSON.parse(content);
+    payload.graph = { relationshipCount: relationships.length, relationships };
+    return `${JSON.stringify(payload, null, 2)}\n`;
+  }
+  if (format === 'markdown') {
+    const lines = ['# graph_relationships', '', `Rows: ${relationships.length}`, ''];
+    relationships.forEach((row, index) => lines.push(`## relationship-${index + 1}`, '', `- **type**: ${row.type}`, `- **from**: ${row.from}`, `- **to**: ${row.to}`, `- **metadata**: \`${JSON.stringify(row.metadata ?? {})}\``, ''));
+    return `${content}\n\n${lines.join('\n')}`;
+  }
+  const header = 'relationship_type,from,to,metadata';
+  const rows = relationships.map((row) => [row.type, row.from, row.to, row.metadata].map(csvCell).join(','));
+  return `${content}\n${header}\n${rows.join('\n')}\n`;
+}
+
+export function createExportAppRoutes(deps: ExportAppDeps = {}) {
+  const jobs = new Map<string, ExportJob>();
+
+  return new Elysia()
+    .get('/export/app/collections', async () => {
+      const connection = connectionFrom(deps);
+      const collections = [...tableMap()].map(([name, table]) => ({
+        name,
+        rowCount: selectRows(connection, table).length,
+      }));
+      const tools = await loadExportTools();
+      return { collections, formats: tools.EXPORT_FORMATS, graph: { collection: 'relationships' } };
+    })
+    .post('/export/app/run', async ({ body, set }) => {
+      const tools = await loadExportTools();
+      const format = (body.format ?? 'json') as ExportFormat;
+      if (!tools.EXPORT_FORMATS.includes(format)) {
+        set.status = 400;
+        return { error: `Unsupported export format: ${format}`, formats: tools.EXPORT_FORMATS };
+      }
+
+      const connection = connectionFrom(deps);
+      const tables = tableMap();
+      const isGraph = body.collection === 'relationships';
+      const table = tables.get(body.collection);
+      if (!isGraph && !table) {
+        set.status = 404;
+        return { error: `Unknown export collection: ${body.collection}` };
+      }
+
+      const collections = body.includeGraph || isGraph ? await allCollections(connection, tools) : {};
+      const relationships = body.includeGraph || isGraph ? tools.graphRelationships(collections) : [];
+      const rows = isGraph ? relationships : tools.normalizeRecords(selectRows(connection, table!));
+      const base = tools.formatCollection(body.collection, rows, format);
+      const content = !isGraph && body.includeGraph ? attachGraph(base, format, relationships) : base;
+      const jobId = deps.idGenerator?.() ?? randomUUID();
+      const outputDir = deps.outputDir ?? path.join(ORACLE_DATA_DIR, 'export-app', 'http');
+      const filename = `${safeName(body.collection)}-${jobId}.${tools.extensionFor(format)}`;
+      const filePath = path.join(outputDir, filename);
+      await mkdir(outputDir, { recursive: true });
+      await writeFile(filePath, content, 'utf8');
+
+      const job: ExportJob = {
+        jobId,
+        collection: body.collection,
+        format,
+        includeGraph: Boolean(body.includeGraph),
+        filePath,
+        filename,
+        mimeType: mimeType(format),
+        rowCount: rows.length,
+        relationshipCount: relationships.length,
+        createdAt: (deps.now?.() ?? new Date()).toISOString(),
+      };
+      jobs.set(jobId, job);
+      return { ...job, filePath: undefined, downloadUrl: `/api/v1/export/app/download/${jobId}` };
+    }, {
+      body: t.Object({
+        collection: t.String(),
+        format: t.Optional(t.Union([t.Literal('json'), t.Literal('csv'), t.Literal('markdown')])),
+        includeGraph: t.Optional(t.Boolean()),
+      }),
+    })
+    .get('/export/app/download/:jobId', async ({ params, set }) => {
+      const job = jobs.get(params.jobId);
+      if (!job) {
+        set.status = 404;
+        return { error: `Unknown export job: ${params.jobId}` };
+      }
+      return new Response(await readFile(job.filePath), {
+        headers: {
+          'Content-Type': job.mimeType,
+          'Content-Disposition': `attachment; filename="${job.filename}"`,
+        },
+      });
+    }, { params: t.Object({ jobId: t.String() }) });
+}
+
+export const exportAppRoutes = new Elysia({ prefix: '/api' }).use(createExportAppRoutes());

--- a/src/server.ts
+++ b/src/server.ts
@@ -60,6 +60,7 @@ import { createMetricsLifecycle, metricsRoutes } from './routes/metrics/index.ts
 import { memoryRoutes } from './routes/memory/index.ts';
 import { canvasRoutes } from './routes/canvas/index.ts';
 import { tenantsRoutes } from './routes/tenants/index.ts';
+import { exportAppRoutes } from './routes/export/app.ts';
 
 let indexerRoutes: any = null;
 try {
@@ -81,10 +82,8 @@ try {
 console.log('[Vector] mode:', VECTOR_URL ? 'proxy → ' + VECTOR_URL : 'local');
 
 try {
-  const bt = sqlite.prepare('PRAGMA busy_timeout').get();
-  console.log(`[DB] busy_timeout = ${JSON.stringify(bt)}`);
+  console.log(`[DB] busy_timeout = ${JSON.stringify(sqlite.prepare('PRAGMA busy_timeout').get())}`);
 } catch {}
-
 configure({ dataDir: ORACLE_DATA_DIR, pidFileName: 'oracle-http.pid' });
 writePidFile({
   pid: process.pid,
@@ -199,6 +198,7 @@ const apiModules = [
   memoryRoutes,
   canvasRoutes,
   tenantsRoutes,
+  exportAppRoutes,
   ...(indexerRoutes ? [indexerRoutes] : []),
   ...unifiedPlugins.routes,
 ];
@@ -217,7 +217,6 @@ const menuRoutes = createMenuRoutes(menuItemsFromUnifiedPlugins(unifiedPlugins.m
 const mcpRoutes = createMcpRoutes(unifiedPlugins.mcpTools);
 
 const modules = [...apiModules, mcpRoutes, menuRoutes];
-
 for (const mod of modules) app.use(mod as any);
 app.use(createNotFoundMiddleware(app.routes));
 

--- a/tests/http/export/app.test.ts
+++ b/tests/http/export/app.test.ts
@@ -1,0 +1,143 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const root = mkdtempSync(join(tmpdir(), 'arra-export-http-'));
+const dbPath = join(root, 'oracle.db');
+const outputDir = join(root, 'http-export');
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = dbPath;
+
+const dbModule = await import('../../../src/db/index.ts');
+const { Elysia } = await import('elysia');
+const { createApiVersionedFetch } = await import('../../../src/middleware/api-version.ts');
+const { createExportAppRoutes } = await import('../../../src/routes/export/app.ts');
+
+const { createDatabase, oracleDocuments, supersedeLog, traceLog, resetDefaultDatabaseForTests } = dbModule;
+const connection = createDatabase(dbPath);
+
+function restoreDbPath() {
+  return savedDbPath ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
+}
+
+function seed() {
+  const now = 1_766_000_000_000;
+  connection.db.insert(oracleDocuments).values([
+    {
+      id: 'doc-old', type: 'learning', sourceFile: 'psi/learn/old.md', concepts: '["backup"]',
+      createdAt: now, updatedAt: now, indexedAt: now, supersededBy: 'doc-new', supersededReason: 'refresh', createdBy: 'test',
+    },
+    {
+      id: 'doc-new', type: 'learning', sourceFile: 'psi/learn/new.md', concepts: '["backup","safe"]',
+      createdAt: now + 1, updatedAt: now + 1, indexedAt: now + 1, createdBy: 'test',
+    },
+  ]).run();
+  connection.db.insert(traceLog).values([
+    { traceId: 'trace-a', query: 'backup root', childTraceIds: '["trace-b"]', nextTraceId: 'trace-b', createdAt: now, updatedAt: now },
+    { traceId: 'trace-b', query: 'backup child', parentTraceId: 'trace-a', prevTraceId: 'trace-a', createdAt: now, updatedAt: now },
+  ]).run();
+  connection.db.insert(supersedeLog).values({
+    oldPath: 'psi/learn/old.md', oldId: 'doc-old', oldTitle: 'Old',
+    newPath: 'psi/learn/new.md', newId: 'doc-new', newTitle: 'New',
+    reason: 'refresh', supersededAt: now + 2, supersededBy: 'test', project: 'demo',
+  }).run();
+}
+
+let job = 0;
+seed();
+const app = new Elysia({ prefix: '/api' }).use(createExportAppRoutes({
+  connection,
+  outputDir,
+  idGenerator: () => `job-${++job}`,
+  now: () => new Date('2026-01-02T03:04:05.006Z'),
+}));
+const fetcher = createApiVersionedFetch((request) => app.handle(request));
+
+async function postRun(body: Record<string, unknown>) {
+  return fetcher(new Request('http://local/api/v1/export/app/run', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+}
+
+afterAll(() => {
+  connection.storage.close();
+  if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = savedDataDir;
+  if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = savedDbPath;
+  resetDefaultDatabaseForTests(restoreDbPath());
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('export app HTTP routes', () => {
+  test('lists available collections and formats', async () => {
+    const res = await fetcher(new Request('http://local/api/v1/export/app/collections'));
+    const body = await res.json() as {
+      collections: Array<{ name: string; rowCount: number }>;
+      formats: string[];
+      graph: { collection: string };
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.collections).toContainEqual(expect.objectContaining({ name: 'oracle_documents', rowCount: 2 }));
+    expect(body.formats).toEqual(['json', 'csv', 'markdown']);
+    expect(body.graph).toEqual({ collection: 'relationships' });
+  });
+
+  test('runs a JSON export with graph relationships and downloads it', async () => {
+    const res = await postRun({ collection: 'oracle_documents', format: 'json', includeGraph: true });
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      jobId: 'job-1',
+      collection: 'oracle_documents',
+      format: 'json',
+      rowCount: 2,
+      includeGraph: true,
+      createdAt: '2026-01-02T03:04:05.006Z',
+      downloadUrl: '/api/v1/export/app/download/job-1',
+    });
+    expect(body.relationshipCount).toBeGreaterThanOrEqual(4);
+    expect('filePath' in body).toBe(false);
+    expect(existsSync(join(outputDir, 'oracle_documents-job-1.json'))).toBe(true);
+
+    const download = await fetcher(new Request(`http://local${body.downloadUrl}`));
+    const payload = await download.json() as Record<string, any>;
+
+    expect(download.status).toBe(200);
+    expect(download.headers.get('content-type')).toContain('application/json');
+    expect(download.headers.get('content-disposition')).toBe('attachment; filename="oracle_documents-job-1.json"');
+    expect(payload.rows.map((row: { id: string }) => row.id)).toEqual(['doc-old', 'doc-new']);
+    expect(payload.graph.relationships).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: 'document_superseded_by', from: 'doc-old', to: 'doc-new' }),
+      expect.objectContaining({ type: 'trace_next', from: 'trace-a', to: 'trace-b' }),
+    ]));
+  });
+
+  test('runs a CSV export with the fixed tabular columns', async () => {
+    const res = await postRun({ collection: 'oracle_documents', format: 'csv' });
+    const body = await res.json() as { downloadUrl: string };
+    const download = await fetcher(new Request(`http://local${body.downloadUrl}`));
+    const csv = await download.text();
+
+    expect(res.status).toBe(200);
+    expect(download.status).toBe(200);
+    expect(download.headers.get('content-type')).toContain('text/csv');
+    expect(csv.split('\n')[0]).toBe('id,title,content_preview,collection,created_at');
+    expect(csv).toContain('"doc-new"');
+  });
+
+  test('rejects unknown collections', async () => {
+    const res = await postRun({ collection: 'missing_collection', format: 'json' });
+    const body = await res.json() as { error: string };
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe('Unknown export collection: missing_collection');
+  });
+});


### PR DESCRIPTION
## Summary
- add the export app Elysia sub-app for collection listing, export run jobs, and job downloads
- mount the app export API in the HTTP server
- cover versioned HTTP collection, JSON+graph download, CSV download, and unknown collection behavior

## Validation
- bun test tests/http/export/
- bunx tsc --noEmit
- wc -l src/routes/export/app.ts tests/http/export/app.test.ts src/server.ts (180, 143, 248)
- merged current origin/alpha before final validation