### PR TITLE
feat: add vector cost usage API

### DIFF
--- a/src/routes/vector/costs.ts
+++ b/src/routes/vector/costs.ts
@@ -1,0 +1,21 @@
+import { Elysia } from 'elysia';
+import { CostEstimator } from '../../vector/cost-estimator.ts';
+
+export interface VectorCostsEndpointOptions {
+  estimator?: CostEstimator;
+}
+
+export const vectorCostEstimator = new CostEstimator();
+
+export function createVectorCostsEndpoint(options: VectorCostsEndpointOptions = {}) {
+  const estimator = options.estimator ?? vectorCostEstimator;
+  return new Elysia().get('/vector/costs', () => ({
+    breakdown: estimator.getBreakdown(),
+    rates: estimator.getRates(),
+    usage: estimator.getUsage(),
+  }), {
+    detail: { tags: ['vector'], summary: 'Embedding provider usage costs by time window' },
+  });
+}
+
+export const vectorCostsEndpoint = createVectorCostsEndpoint();

--- a/src/routes/vector/index.ts
+++ b/src/routes/vector/index.ts
@@ -11,6 +11,7 @@
  *   GET /api/vector/stats    — per-engine collection counts
  *   GET /api/vector/health   — adapter liveness probe
  *   GET /api/vector/cost-estimate — estimate remote embedding cost
+ *   GET /api/vector/costs    — embedding provider usage costs
  *   GET /api/vector/documents — browse indexed vector documents
  *   GET /api/vector/providers — detected embedding providers and capabilities
  *   POST /api/vector/providers/test — probe one embedding provider config
@@ -36,6 +37,7 @@ import { vectorExportEndpoint } from './export.ts';
 import { vectorServicesApiEndpoint } from './services.ts';
 import { vectorProvidersEndpoint } from './providers.ts';
 import { vectorCostEndpoint } from './cost.ts';
+import { vectorCostsEndpoint } from './costs.ts';
 import { vectorConfigApiEndpoint } from './config-api.ts';
 
 export const vectorRoutes = new Elysia({ prefix: '/api' })
@@ -52,6 +54,7 @@ export const vectorRoutes = new Elysia({ prefix: '/api' })
   .use(vectorExportEndpoint)
   .use(vectorProvidersEndpoint)
   .use(vectorCostEndpoint)
+  .use(vectorCostsEndpoint)
   .use(vectorConfigApiEndpoint)
   .use(vectorServicesApiEndpoint)
   .use(vectorIndexerEndpoints);

--- a/src/vector/cost-estimator.ts
+++ b/src/vector/cost-estimator.ts
@@ -1,0 +1,128 @@
+import type { EmbeddingProviderType } from './types.ts';
+
+export type CostWindow = 'daily' | 'weekly' | 'monthly';
+export type CostProvider = Extract<EmbeddingProviderType, 'openai' | 'gemini' | 'ollama' | 'local' | 'remote' | 'cloudflare-ai'>;
+
+export interface UsageEvent {
+  apiCalls: number;
+  inputTokens: number;
+  provider: CostProvider;
+  timestamp: string;
+}
+
+export interface UsageRecordInput {
+  apiCalls?: number;
+  inputTokens: number;
+  provider: CostProvider;
+  timestamp?: Date | string;
+}
+
+export interface ProviderCostSummary {
+  apiCalls: number;
+  estimatedUsd: number;
+  inputTokens: number;
+  provider: CostProvider;
+}
+
+export interface CostBreakdown {
+  apiCalls: number;
+  estimatedUsd: number;
+  inputTokens: number;
+  providers: Record<string, ProviderCostSummary>;
+  window: CostWindow;
+}
+
+const DEFAULT_RATES: Record<CostProvider, number> = {
+  openai: 0.02,
+  gemini: 0,
+  ollama: 0,
+  local: 0,
+  remote: 0,
+  'cloudflare-ai': 0.008,
+};
+
+export class CostEstimator {
+  private readonly events: UsageEvent[] = [];
+  private readonly now: () => Date;
+  private readonly rates: Record<CostProvider, number>;
+
+  constructor(options: { now?: () => Date; rates?: Partial<Record<CostProvider, number>> } = {}) {
+    this.now = options.now ?? (() => new Date());
+    this.rates = { ...DEFAULT_RATES, ...options.rates };
+  }
+
+  record(input: UsageRecordInput): UsageEvent {
+    const event = {
+      provider: input.provider,
+      inputTokens: Math.max(0, Math.floor(input.inputTokens)),
+      apiCalls: Math.max(1, Math.floor(input.apiCalls ?? 1)),
+      timestamp: normalizeDate(input.timestamp ?? this.now()).toISOString(),
+    };
+    this.events.push(event);
+    return event;
+  }
+
+  getBreakdown(reference = this.now()): Record<CostWindow, CostBreakdown> {
+    return {
+      daily: this.summarize('daily', startOfDay(reference)),
+      weekly: this.summarize('weekly', daysAgo(reference, 7)),
+      monthly: this.summarize('monthly', daysAgo(reference, 30)),
+    };
+  }
+
+  getRates(): Record<CostProvider, number> {
+    return { ...this.rates };
+  }
+
+  getUsage(): UsageEvent[] {
+    return this.events.map((event) => ({ ...event }));
+  }
+
+  private summarize(window: CostWindow, since: Date): CostBreakdown {
+    const providers: Record<string, ProviderCostSummary> = {};
+    for (const event of this.events) {
+      if (normalizeDate(event.timestamp) < since) continue;
+      const summary = providers[event.provider] ??= {
+        provider: event.provider,
+        inputTokens: 0,
+        apiCalls: 0,
+        estimatedUsd: 0,
+      };
+      summary.inputTokens += event.inputTokens;
+      summary.apiCalls += event.apiCalls;
+      summary.estimatedUsd = costFor(summary.inputTokens, this.rates[event.provider]);
+    }
+    const totals = Object.values(providers).reduce((acc, item) => ({
+      inputTokens: acc.inputTokens + item.inputTokens,
+      apiCalls: acc.apiCalls + item.apiCalls,
+      estimatedUsd: acc.estimatedUsd + item.estimatedUsd,
+    }), { inputTokens: 0, apiCalls: 0, estimatedUsd: 0 });
+    return {
+      window,
+      inputTokens: totals.inputTokens,
+      apiCalls: totals.apiCalls,
+      estimatedUsd: roundUsd(totals.estimatedUsd),
+      providers,
+    };
+  }
+}
+
+function costFor(tokens: number, ratePerMillion: number): number {
+  return roundUsd((tokens / 1_000_000) * ratePerMillion);
+}
+
+function daysAgo(reference: Date, days: number): Date {
+  return new Date(reference.getTime() - days * 24 * 60 * 60 * 1000);
+}
+
+function normalizeDate(value: Date | string): Date {
+  return value instanceof Date ? value : new Date(value);
+}
+
+function roundUsd(value: number): number {
+  return Number(value.toFixed(6));
+}
+
+function startOfDay(reference: Date): Date {
+  return new Date(reference.getFullYear(), reference.getMonth(), reference.getDate());
+}

--- a/tests/http/vector/costs.test.ts
+++ b/tests/http/vector/costs.test.ts
@@ -1,0 +1,96 @@
+import { expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { CostEstimator } from '../../../src/vector/cost-estimator.ts';
+import { createVectorCostsEndpoint } from '../../../src/routes/vector/costs.ts';
+
+const now = new Date('2026-06-16T12:00:00Z');
+
+function fetcher(estimator: CostEstimator) {
+  const app = new Elysia({ prefix: '/api' }).use(createVectorCostsEndpoint({ estimator }));
+  return createApiVersionedFetch((request) => app.handle(request));
+}
+
+test('CostEstimator tracks usage and priced provider breakdowns', () => {
+  const estimator = new CostEstimator({
+    now: () => now,
+    rates: { openai: 0.1, gemini: 0.02 },
+  });
+
+  estimator.record({
+    provider: 'openai',
+    inputTokens: 1_000_000,
+    apiCalls: 2,
+    timestamp: '2026-06-16T08:00:00Z',
+  });
+  estimator.record({
+    provider: 'gemini',
+    inputTokens: 500_000,
+    timestamp: '2026-06-15T08:00:00Z',
+  });
+  estimator.record({
+    provider: 'cloudflare-ai',
+    inputTokens: 250_000,
+    apiCalls: 3,
+    timestamp: '2026-05-25T08:00:00Z',
+  });
+  estimator.record({
+    provider: 'remote',
+    inputTokens: 10_000,
+    timestamp: '2026-05-01T08:00:00Z',
+  });
+
+  const breakdown = estimator.getBreakdown(now);
+  expect(breakdown.daily).toMatchObject({
+    window: 'daily',
+    inputTokens: 1_000_000,
+    apiCalls: 2,
+    estimatedUsd: 0.1,
+    providers: { openai: { inputTokens: 1_000_000, apiCalls: 2, estimatedUsd: 0.1 } },
+  });
+  expect(breakdown.weekly).toMatchObject({
+    inputTokens: 1_500_000,
+    apiCalls: 3,
+    estimatedUsd: 0.11,
+  });
+  expect(breakdown.weekly.providers.gemini).toMatchObject({
+    inputTokens: 500_000,
+    apiCalls: 1,
+    estimatedUsd: 0.01,
+  });
+  expect(breakdown.monthly).toMatchObject({
+    inputTokens: 1_750_000,
+    apiCalls: 6,
+    estimatedUsd: 0.112,
+  });
+  expect(breakdown.monthly.providers.remote).toBeUndefined();
+});
+
+test('GET /api/v1/vector/costs returns usage, rates, and time windows', async () => {
+  const estimator = new CostEstimator({ now: () => now, rates: { openai: 0.1 } });
+  estimator.record({ provider: 'openai', inputTokens: 250_000, apiCalls: 4 });
+  estimator.record({
+    provider: 'ollama',
+    inputTokens: 50_000,
+    timestamp: '2026-06-10T12:00:00Z',
+  });
+
+  const res = await fetcher(estimator)(new Request('http://local/api/v1/vector/costs'));
+  const body = await res.json() as Record<string, any>;
+
+  expect(res.status).toBe(200);
+  expect(body.rates.openai).toBe(0.1);
+  expect(body.usage).toHaveLength(2);
+  expect(body.breakdown.daily).toMatchObject({
+    window: 'daily',
+    inputTokens: 250_000,
+    apiCalls: 4,
+    estimatedUsd: 0.025,
+  });
+  expect(body.breakdown.weekly.providers.ollama).toMatchObject({
+    inputTokens: 50_000,
+    apiCalls: 1,
+    estimatedUsd: 0,
+  });
+  expect(body.breakdown.monthly.inputTokens).toBe(300_000);
+});


### PR DESCRIPTION
## Summary

- Add `CostEstimator` for per-provider embedding usage accounting.
- Track input tokens and API calls, with configurable per-million token rates.
- Expose `GET /api/v1/vector/costs` via a new Elysia sub-app.
- Return daily, weekly, and monthly usage/cost breakdowns.
- Add HTTP vector tests for estimator math and endpoint response shape.

## Verification

- `rtk bunx tsc --noEmit`
- `rtk bun test tests/http/vector/` — 45 pass, 0 fail
- File sizes: `src/vector/cost-estimator.ts` 128 lines, `src/routes/vector/costs.ts` 21 lines, `tests/http/vector/costs.test.ts` 96 lines.

## Git Safety

- Merged latest `origin/alpha` before push without conflicts.
- No force push used.
- PR targets `alpha`; no `main` changes.