### PR TITLE
feat: add export app progress UI

### DIFF
--- a/frontend/src/components/export/ExportProgress.tsx
+++ b/frontend/src/components/export/ExportProgress.tsx
@@ -1,0 +1,92 @@
+import { ErrorMessage, Spinner } from '../AsyncState';
+import type { ExportProgressState } from '../../hooks/useExport';
+
+export interface ExportProgressProps {
+  state: ExportProgressState;
+  title?: string;
+  onRetry?: () => void;
+  onDownload?: () => void;
+  className?: string;
+}
+
+function formatBytes(bytes?: number): string {
+  if (!Number.isFinite(bytes)) return 'estimating';
+  const units = ['B', 'KB', 'MB', 'GB'] as const;
+  let value = bytes ?? 0;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  const precision = unitIndex === 0 || value >= 10 ? 0 : 1;
+  return `${value.toFixed(precision)} ${units[unitIndex]}`;
+}
+
+function statusText(state: ExportProgressState): string {
+  if (state.status === 'starting') return 'Starting export job';
+  if (state.status === 'running') return `Exporting ${Math.round(state.progress)}%`;
+  if (state.status === 'done') return 'Export ready';
+  if (state.status === 'error') return 'Export failed';
+  return 'Ready to export';
+}
+
+function retryButton(onRetry?: () => void) {
+  if (!onRetry) return null;
+  return (
+    <button className="focus-ring rounded-lg border border-red-200/30 px-3 py-2 font-semibold text-red-50 hover:bg-red-200/10" type="button" onClick={onRetry}>
+      Retry
+    </button>
+  );
+}
+
+function downloadControl(state: ExportProgressState, onDownload?: () => void) {
+  if (state.status !== 'done') return null;
+  const classes = 'focus-ring rounded-xl bg-teal-300 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-teal-200 disabled:cursor-not-allowed disabled:opacity-50';
+  if (onDownload) {
+    return <button className={classes} type="button" onClick={onDownload}>Download export</button>;
+  }
+  return (
+    <a className={classes} href={state.downloadUrl} download={state.filename ?? 'arra-oracle-export.zip'} aria-disabled={!state.downloadUrl}>
+      Download export
+    </a>
+  );
+}
+
+export function ExportProgress({ state, title = 'Export app', onRetry, onDownload, className = '' }: ExportProgressProps) {
+  const active = state.status === 'starting' || state.status === 'running';
+  const progress = Math.min(100, Math.max(0, state.progress));
+
+  return (
+    <section className={`rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6 ${className}`} aria-labelledby="export-progress-title">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Export</p>
+          <h3 id="export-progress-title" className="mt-2 text-xl font-semibold text-white">{title}</h3>
+          <p className="mt-2 text-sm text-slate-400">{statusText(state)}</p>
+        </div>
+        {active ? <Spinner label="Exporting" /> : downloadControl(state, onDownload)}
+      </div>
+
+      <div className="mt-5 grid gap-3 rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-slate-400">Progress</span>
+          <span className="font-medium text-slate-100">{active || state.status === 'done' ? `${Math.round(progress)}%` : 'idle'}</span>
+        </div>
+        <div className="h-2 rounded-full border border-white/10 bg-white/[0.06]" role="progressbar" aria-valuemin={0} aria-valuemax={100} aria-valuenow={Math.round(progress)}>
+          <div className="h-full rounded-full bg-teal-300/70 transition-all" style={{ width: `${active || state.status === 'done' ? progress : 0}%` }} />
+        </div>
+        <dl className="grid gap-3 text-sm sm:grid-cols-3">
+          <div><dt className="text-slate-500">Job</dt><dd className="break-all font-mono text-slate-100">{state.jobId ?? 'not started'}</dd></div>
+          <div><dt className="text-slate-500">File size estimate</dt><dd className="font-medium text-slate-100">{formatBytes(state.fileSizeEstimate)}</dd></div>
+          <div><dt className="text-slate-500">File</dt><dd className="break-all font-medium text-slate-100">{state.filename ?? 'pending'}</dd></div>
+        </dl>
+      </div>
+
+      {state.status === 'error' ? (
+        <div className="mt-4">
+          <ErrorMessage title="Export failed." message={state.error ?? 'The export job failed.'} action={retryButton(onRetry)} />
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/hooks/useExport.ts
+++ b/frontend/src/hooks/useExport.ts
@@ -1,0 +1,192 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { apiUrl } from '../api/oracle';
+
+export type ExportStatus = 'idle' | 'starting' | 'running' | 'done' | 'error';
+export type ExportRunPayload = Record<string, unknown>;
+type ExportFetch = (input: RequestInfo | URL, init?: RequestInit) => Response | Promise<Response>;
+
+export interface ExportProgressState {
+  status: ExportStatus;
+  jobId: string | null;
+  progress: number;
+  fileSizeEstimate?: number;
+  downloadUrl?: string;
+  filename?: string;
+  error?: string;
+}
+
+export interface UseExportOptions {
+  fetcher?: ExportFetch;
+  pollMs?: number;
+}
+
+export interface UseExportResult extends ExportProgressState {
+  start: (payload?: ExportRunPayload) => Promise<void>;
+  retry: () => Promise<void>;
+  reset: () => void;
+}
+
+const initialState: ExportProgressState = {
+  status: 'idle',
+  jobId: null,
+  progress: 0,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function numberValue(...values: unknown[]): number | undefined {
+  for (const value of values) {
+    const next = typeof value === 'number' ? value : Number(value);
+    if (Number.isFinite(next)) return next;
+  }
+}
+
+function textValue(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value;
+  }
+}
+
+async function jsonOrEmpty(response: Response): Promise<Record<string, unknown>> {
+  try {
+    const value = await response.clone().json();
+    return isRecord(value) ? value : {};
+  } catch {
+    return {};
+  }
+}
+
+function progressFrom(payload: Record<string, unknown>): number | undefined {
+  const direct = numberValue(payload.progress, payload.percent, payload.progressPercent);
+  if (direct !== undefined) return direct <= 1 ? direct * 100 : direct;
+  const current = numberValue(payload.current, payload.completed, payload.bytesWritten);
+  const total = numberValue(payload.total, payload.totalBytes, payload.sizeBytes);
+  return current !== undefined && total ? (current / total) * 100 : undefined;
+}
+
+function estimateFrom(payload: Record<string, unknown>): number | undefined {
+  return numberValue(payload.fileSizeEstimate, payload.estimatedBytes, payload.estimateBytes, payload.sizeBytes, payload.bytes);
+}
+
+function filenameFrom(response: Response, payload: Record<string, unknown>): string {
+  const fromPayload = textValue(payload.filename, payload.fileName, payload.name);
+  if (fromPayload) return fromPayload;
+  const disposition = response.headers.get('content-disposition') ?? '';
+  const match = /filename\*?=(?:UTF-8'')?"?([^";]+)"?/i.exec(disposition);
+  return match?.[1] ? decodeURIComponent(match[1]) : 'arra-oracle-export.zip';
+}
+
+function statusFrom(payload: Record<string, unknown>): ExportStatus | undefined {
+  const status = textValue(payload.status, payload.state)?.toLowerCase();
+  if (status === 'done' || status === 'ready' || status === 'complete' || status === 'completed') return 'done';
+  if (status === 'error' || status === 'failed') return 'error';
+  if (status === 'running' || status === 'pending' || status === 'queued' || status === 'starting') return 'running';
+}
+
+function wait(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const id = setTimeout(resolve, ms);
+    signal.addEventListener('abort', () => {
+      clearTimeout(id);
+      reject(new DOMException('Aborted', 'AbortError'));
+    }, { once: true });
+  });
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function useExport({ fetcher = globalThis.fetch?.bind(globalThis), pollMs = 1500 }: UseExportOptions = {}): UseExportResult {
+  const [state, setState] = useState<ExportProgressState>(initialState);
+  const abortRef = useRef<AbortController | null>(null);
+  const urlRef = useRef<string | null>(null);
+  const lastPayloadRef = useRef<ExportRunPayload | undefined>();
+
+  const revokeDownload = useCallback(() => {
+    if (urlRef.current && globalThis.URL?.revokeObjectURL) URL.revokeObjectURL(urlRef.current);
+    urlRef.current = null;
+  }, []);
+
+  const pollDownload = useCallback(async (jobId: string, signal: AbortSignal) => {
+    if (!fetcher) throw new Error('fetch is unavailable');
+    const path = `/api/v1/export/app/download/${encodeURIComponent(jobId)}`;
+    while (!signal.aborted) {
+      const response = await fetcher(apiUrl(path), { headers: { accept: 'application/json, application/octet-stream' }, signal });
+      const payload = await jsonOrEmpty(response);
+      const jobStatus = statusFrom(payload);
+      const progress = Math.min(100, Math.max(0, progressFrom(payload) ?? 0));
+      const fileSizeEstimate = estimateFrom(payload);
+      if (jobStatus === 'error') throw new Error(textValue(payload.error, payload.message) ?? 'Export job failed');
+      if (response.status === 202 || response.status === 204 || jobStatus === 'running') {
+        setState((current) => ({ ...current, status: 'running', progress, fileSizeEstimate: fileSizeEstimate ?? current.fileSizeEstimate }));
+        await wait(pollMs, signal);
+        continue;
+      }
+      if (!response.ok) throw new Error(`${path} returned ${response.status}`);
+      const downloadUrl = textValue(payload.downloadUrl, payload.url, payload.href);
+      if (downloadUrl) {
+        setState((current) => ({ ...current, status: 'done', progress: 100, fileSizeEstimate: fileSizeEstimate ?? current.fileSizeEstimate, downloadUrl, filename: filenameFrom(response, payload) }));
+        return;
+      }
+      const blob = await response.blob();
+      revokeDownload();
+      const url = globalThis.URL?.createObjectURL ? URL.createObjectURL(blob) : undefined;
+      urlRef.current = url ?? null;
+      setState((current) => ({ ...current, status: 'done', progress: 100, fileSizeEstimate: blob.size || fileSizeEstimate || current.fileSizeEstimate, downloadUrl: url, filename: filenameFrom(response, payload) }));
+      return;
+    }
+  }, [fetcher, pollMs, revokeDownload]);
+
+  const start = useCallback(async (payload: ExportRunPayload = {}) => {
+    if (!fetcher) throw new Error('fetch is unavailable');
+    abortRef.current?.abort();
+    revokeDownload();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    lastPayloadRef.current = payload;
+    setState({ status: 'starting', jobId: null, progress: 0 });
+    try {
+      const response = await fetcher(apiUrl('/api/v1/export/app/run'), {
+        method: 'POST',
+        headers: { accept: 'application/json', 'content-type': 'application/json' },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+      const body = await jsonOrEmpty(response);
+      if (!response.ok) throw new Error(`/api/v1/export/app/run returned ${response.status}`);
+      const jobId = textValue(body.jobId, body.id);
+      if (!jobId) throw new Error('/api/v1/export/app/run did not return a jobId');
+      setState({
+        status: 'running',
+        jobId,
+        progress: Math.min(100, Math.max(0, progressFrom(body) ?? 0)),
+        fileSizeEstimate: estimateFrom(body),
+      });
+      await pollDownload(jobId, controller.signal);
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      setState((current) => ({ ...current, status: 'error', error: errorMessage(error) }));
+    }
+  }, [fetcher, pollDownload, revokeDownload]);
+
+  const reset = useCallback(() => {
+    abortRef.current?.abort();
+    revokeDownload();
+    setState(initialState);
+  }, [revokeDownload]);
+
+  useEffect(() => () => {
+    abortRef.current?.abort();
+    revokeDownload();
+  }, [revokeDownload]);
+
+  return {
+    ...state,
+    start,
+    retry: () => start(lastPayloadRef.current),
+    reset,
+  };
+}

--- a/tests/frontend/components/export-progress.test.tsx
+++ b/tests/frontend/components/export-progress.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+import { ExportProgress } from '../../../frontend/src/components/export/ExportProgress';
+import type { ExportProgressState } from '../../../frontend/src/hooks/useExport';
+import { htmlFor } from '../_render';
+
+const running: ExportProgressState = {
+  status: 'running',
+  jobId: 'exp-1',
+  progress: 42,
+  fileSizeEstimate: 1536,
+};
+
+describe('ExportProgress', () => {
+  test('renders active export progress with a spinner and size estimate', () => {
+    const html = htmlFor(<ExportProgress state={running} />);
+
+    expect(html).toContain('Exporting 42%');
+    expect(html).toContain('role="status"');
+    expect(html).toContain('1.5 KB');
+    expect(html).toContain('exp-1');
+  });
+
+  test('renders download and retry states', () => {
+    const done = htmlFor(<ExportProgress state={{ ...running, status: 'done', progress: 100, downloadUrl: '/download/exp-1', filename: 'export.zip' }} />);
+    const failed = htmlFor(<ExportProgress state={{ ...running, status: 'error', error: 'disk full' }} onRetry={() => {}} />);
+
+    expect(done).toContain('Download export');
+    expect(done).toContain('href="/download/exp-1"');
+    expect(failed).toContain('Export failed.');
+    expect(failed).toContain('disk full');
+    expect(failed).toContain('Retry');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `ExportProgress` for export app job states: active spinner, progress bar, file size estimate, ready download control, and retryable error state.
- Add `useExport` to start export app jobs with `POST /api/v1/export/app/run` and poll `GET /api/v1/export/app/download/:jobId` with `fetch()`.
- Add focused frontend render coverage for active, done, and error states.

## Validation

```bash
bunx tsc --noEmit
bun test tests/frontend/components/export-progress.test.tsx
wc -l frontend/src/components/export/ExportProgress.tsx frontend/src/hooks/useExport.ts tests/frontend/components/export-progress.test.tsx
git merge-tree --write-tree HEAD origin/alpha
```

## Notes

- PR targets `alpha`.
- Changed files are all under the 250-line limit.
