### PR TITLE
docs: add export app help guide

### DIFF
--- a/frontend/src/components/export/ExportHelp.tsx
+++ b/frontend/src/components/export/ExportHelp.tsx
@@ -1,0 +1,115 @@
+import type { ReactNode } from 'react';
+
+export interface ExportHelpProps {
+  backendUrl?: string;
+  command?: string;
+}
+
+const formats = [
+  { name: 'JSON', detail: 'Structured records for automation and restore tooling.' },
+  { name: 'JSONL', detail: 'Newline-delimited vector records for streaming large collections.' },
+  { name: 'CSV', detail: 'Spreadsheet-friendly rows with stable columns where available.' },
+  { name: 'MD', detail: 'Readable Markdown snapshots for vault handoffs.' },
+];
+
+const batchFiles = [
+  'collections/<collection>.json',
+  'collections/<collection>.csv',
+  'collections/<collection>.md',
+  'relationships.<ext>',
+  'all-collections.json',
+  'manifest.json',
+];
+
+const examples = [
+  'maw arra export --format json --out vault-export.json',
+  'maw arra export --format markdown --out vault.md',
+  'maw arra export --source vector --collection bge-m3 --format jsonl --out bge-m3.jsonl',
+  'bun run tools/export-app/index.ts --output ./backup/export-app --db ./oracle.db',
+];
+
+function CodeLine({ children }: { children: string }) {
+  return (
+    <code className="block overflow-x-auto rounded-xl border border-white/10 bg-black/30 px-3 py-2 font-mono text-xs text-slate-100">
+      {children}
+    </code>
+  );
+}
+
+function Badge({ children }: { children: string }) {
+  return (
+    <span className="rounded-full border border-teal-300/20 bg-teal-300/10 px-2.5 py-1 text-xs font-medium text-teal-200">
+      {children}
+    </span>
+  );
+}
+
+function HelpBlock({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="rounded-2xl border border-white/10 bg-white/[0.03] p-4" aria-label={title}>
+      <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-500">{title}</h3>
+      <div className="mt-3">{children}</div>
+    </section>
+  );
+}
+
+export function ExportHelp({
+  backendUrl = 'http://localhost:47778',
+  command = 'maw arra export',
+}: ExportHelpProps) {
+  return (
+    <aside className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="export-help-title">
+      <div className="mb-5">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Export help</p>
+        <h2 id="export-help-title" className="mt-2 text-2xl font-semibold text-white">Export app guide</h2>
+        <p className="mt-2 text-sm text-slate-400">
+          Export local database snapshots, vector collections, and graph relationships for review or transfer.
+        </p>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <HelpBlock title="Backend">
+          <div className="grid gap-2 text-sm text-slate-300">
+            <p>Use <span className="font-mono text-slate-100">ORACLE_API</span> for backend-connected UI and API commands.</p>
+            <CodeLine>{`export ORACLE_API=${backendUrl}`}</CodeLine>
+            <CodeLine>{`https://studio.buildwithoracle.com/?api=${backendUrl}`}</CodeLine>
+          </div>
+        </HelpBlock>
+
+        <HelpBlock title="Formats">
+          <dl className="grid gap-3">
+            {formats.map((format) => (
+              <div key={format.name} className="grid gap-1">
+                <dt><Badge>{format.name}</Badge></dt>
+                <dd className="text-sm text-slate-400">{format.detail}</dd>
+              </div>
+            ))}
+          </dl>
+        </HelpBlock>
+
+        <HelpBlock title="Graph">
+          <div className="grid gap-2 text-sm text-slate-300">
+            <p>Full exports include relationship edges from supersession, supersede logs, and trace links.</p>
+            <p className="font-mono text-xs text-slate-400">{'{ type, from, to, metadata? }'}</p>
+          </div>
+        </HelpBlock>
+
+        <HelpBlock title="Batch mode">
+          <ul className="grid gap-2 text-sm text-slate-300">
+            {batchFiles.map((file) => <li key={file} className="font-mono text-xs">{file}</li>)}
+          </ul>
+        </HelpBlock>
+      </div>
+
+      <div className="mt-4 rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+        <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-500">CLI</h3>
+        <p className="mt-2 text-sm text-slate-400">
+          Use <span className="font-mono text-slate-100">{command}</span> for one-off exports or the batch app for full snapshots.
+        </p>
+        <div className="mt-3 grid gap-2">
+          {examples.map((example) => <CodeLine key={example}>{example}</CodeLine>)}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/pages/ExportPage.tsx
+++ b/frontend/src/pages/ExportPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
 import { ConnectionTest } from '../components/export/ConnectionTest';
+import { ExportHelp } from '../components/export/ExportHelp';
 import { apiUrl } from '../api/oracle';
 
 type LoadState = 'loading' | 'ready' | 'error';
@@ -114,6 +115,8 @@ export function ExportPage() {
         <h1 id="export-page-title" className="mt-2 text-3xl font-semibold text-white">Export collections</h1>
         <p className="mt-2 text-sm text-slate-400">Prepare database collection downloads from /api/v1/export/app.</p>
       </section>
+
+      <ExportHelp />
 
       {state === 'loading' ? <LoadingPanel title="Loading collections" detail="Fetching /api/v1/export/app/collections." /> : null}
       {state === 'error' ? <ErrorMessage title="Could not load export collections." message={error} /> : null}

--- a/tools/export-app/README.md
+++ b/tools/export-app/README.md
@@ -1,0 +1,93 @@
+# Export App
+
+The export app gives operators a portable snapshot of Arra Oracle data. It can
+dump local database collections in batch mode, export vector collections through
+the HTTP/UI surface, and emit graph relationship data for preview or downstream
+analysis.
+
+## Connect To A Backend
+
+The browser UI and `maw arra` API commands use the Arra Oracle backend URL.
+
+```sh
+export ORACLE_API=http://localhost:47778
+maw arra health
+maw arra frontend --no-open
+```
+
+The hosted or local frontend can also receive the backend URL in the page URL:
+
+```text
+https://studio.buildwithoracle.com/?api=http://localhost:47778
+```
+
+Local batch exports under `tools/export-app` read SQLite directly. Use `--db`
+when the database is not at the default `ORACLE_DB_PATH` / configured data dir.
+
+## Supported Formats
+
+- JSON: structured records for automation and restore tooling.
+- JSONL: newline-delimited vector records for streaming and large collections.
+- CSV: spreadsheet-friendly rows with stable columns where available.
+- Markdown / MD: readable knowledge snapshots and vault handoff files.
+
+The vector HTTP exporter advertises formats from
+`GET /api/v1/vector/export/formats`. The local batch exporter writes collection
+files under `collections/` and a top-level relationship export.
+
+## Graph Export
+
+Batch export builds graph relationships from document supersession, supersede
+logs, and trace links. The output is written as `relationships.<ext>` beside
+`all-collections.json` and `manifest.json`.
+
+Each relationship has:
+
+```ts
+{ type: string; from: string; to: string; metadata?: Record<string, unknown> }
+```
+
+Use this data with the UI graph preview to inspect node labels and edge
+connections before moving the export bundle elsewhere.
+
+## Batch Mode
+
+Batch mode exports all schema collections from a local readonly database
+connection.
+
+```sh
+bun run tools/export-app/index.ts --output ./backup/export-app
+bun run tools/export-app/index.ts --output ./backup/export-app --db ./oracle.db
+```
+
+The batch output includes:
+
+- `collections/<collection>.json`
+- `collections/<collection>.csv`
+- `collections/<collection>.md`
+- `relationships.<ext>`
+- `all-collections.json`
+- `manifest.json`
+
+## CLI Usage
+
+Use `maw arra export` for the operator-facing CLI bridge.
+
+```sh
+maw arra export --format json --out vault-export.json
+maw arra export --format markdown --out vault.md
+maw arra export --source vector --collection bge-m3 --format jsonl --out bge-m3.jsonl
+maw arra export --source vector --collection bge-m3 --format csv --out bge-m3.csv
+```
+
+`maw arra export` resolves the repository through `ORACLE_ROOT` or `ghq locate`
+and delegates to the repo CLI. Set `ORACLE_API` for backend-connected UI/API
+commands; set `ORACLE_ROOT` when the local CLI should run from a specific clone.
+
+## Recommended Flow
+
+1. Point the UI or `maw arra` at the backend with `ORACLE_API`.
+2. Check `/api/v1/health` or run `maw arra health`.
+3. Review collection counts and estimated size in the UI.
+4. Preview graph relationships when exporting a full bundle.
+5. Run `maw arra export` for one collection or batch mode for full snapshots.


### PR DESCRIPTION
Summary:
- add export app README covering backend connection, formats, graph export, batch mode, and maw arra export usage
- add inline ExportHelp panel and surface it on the export page

Tests:
- cd frontend && bunx tsc --noEmit
- bunx tsc --noEmit
- wc -l tools/export-app/README.md frontend/src/components/export/ExportHelp.tsx frontend/src/pages/ExportPage.tsx