### PR TITLE
feat: add export batch endpoint

### DIFF
--- a/src/routes/export/batch.ts
+++ b/src/routes/export/batch.ts
@@ -1,0 +1,224 @@
+/** POST /api/export/batch - export multiple collections as a ZIP archive. */
+import { Elysia, t } from 'elysia';
+import { getTableName, isTable } from 'drizzle-orm';
+import { DB_PATH } from '../../config.ts';
+import * as schema from '../../db/schema.ts';
+import { createStorageBackend } from '../../storage/registry.ts';
+import {
+  EXPORT_FORMATS,
+  extensionFor,
+  formatCollection,
+  graphRelationships,
+  normalizeRecords,
+  type ExportFormat,
+  type ExportRecord,
+} from './format.ts';
+
+type CollectionMap = Record<string, ExportRecord[]>;
+type LoadCollections = (collections: string[]) => CollectionMap | Promise<CollectionMap>;
+type ExportTable = Parameters<typeof getTableName>[0];
+
+interface ExportBatchDeps {
+  availableCollections?: () => string[];
+  loadCollections?: LoadCollections;
+  graph?: (collections: CollectionMap) => ExportRecord[];
+}
+
+interface BatchBody {
+  collections: string[];
+  format: ExportFormat;
+  includeGraph?: boolean;
+}
+
+interface ZipFile {
+  name: string;
+  data: Uint8Array;
+}
+
+const encoder = new TextEncoder();
+const crcTable = createCrcTable();
+
+function schemaTables(): ExportTable[] {
+  return (Object.values(schema).filter(isTable) as ExportTable[])
+    .sort((a, b) => getTableName(a).localeCompare(getTableName(b)));
+}
+
+function tableByName() {
+  return new Map(schemaTables().map((table) => [getTableName(table), table]));
+}
+
+function defaultAvailableCollections(): string[] {
+  return [...tableByName().keys()];
+}
+
+function readCollections(names: string[]): CollectionMap {
+  const tables = tableByName();
+  const storage = createStorageBackend({ dbPath: DB_PATH, readonly: true });
+  try {
+    const out: CollectionMap = {};
+    for (const name of names) {
+      const table = tables.get(name);
+      if (!table) throw new Error(`Unknown export collection: ${name}`);
+      out[name] = normalizeRecords(storage.db.select().from(table).all() as ExportRecord[]);
+    }
+    return out;
+  } finally {
+    storage.close();
+  }
+}
+
+function normalizeCollectionNames(input: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const name of input) {
+    const trimmed = name.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+function safeFileName(collection: string): string {
+  return collection.replace(/[^a-zA-Z0-9._-]+/g, '_').replace(/^_+|_+$/g, '') || 'collection';
+}
+
+function makeFiles(collections: CollectionMap, names: string[], format: ExportFormat, includeGraph: boolean, graph: ExportBatchDeps['graph']): ZipFile[] {
+  const extension = extensionFor(format);
+  const files = names.map((name) => ({
+    name: `${safeFileName(name)}.${extension}`,
+    data: encoder.encode(formatCollection(name, collections[name] ?? [], format)),
+  }));
+
+  if (includeGraph) {
+    const rows = graph ? graph(collections) : graphRelationships(collections);
+    files.push({
+      name: `relationships.${extension}`,
+      data: encoder.encode(formatCollection('relationships', rows, format)),
+    });
+  }
+
+  return files;
+}
+
+function createCrcTable(): Uint32Array {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n += 1) {
+    let crc = n;
+    for (let k = 0; k < 8; k += 1) crc = crc & 1 ? 0xedb88320 ^ (crc >>> 1) : crc >>> 1;
+    table[n] = crc >>> 0;
+  }
+  return table;
+}
+
+function crc32(data: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of data) crc = crcTable[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function concat(chunks: Uint8Array[]): Uint8Array {
+  const total = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+}
+
+function zip(files: ZipFile[]): Uint8Array {
+  const chunks: Uint8Array[] = [];
+  const central: Uint8Array[] = [];
+  let offset = 0;
+
+  for (const file of files) {
+    const name = encoder.encode(file.name);
+    const crc = crc32(file.data);
+    const local = new Uint8Array(30 + name.length);
+    const view = new DataView(local.buffer);
+    view.setUint32(0, 0x04034b50, true);
+    view.setUint16(4, 20, true);
+    view.setUint16(8, 0, true);
+    view.setUint32(14, crc, true);
+    view.setUint32(18, file.data.length, true);
+    view.setUint32(22, file.data.length, true);
+    view.setUint16(26, name.length, true);
+    local.set(name, 30);
+    chunks.push(local, file.data);
+
+    const dir = new Uint8Array(46 + name.length);
+    const dirView = new DataView(dir.buffer);
+    dirView.setUint32(0, 0x02014b50, true);
+    dirView.setUint16(4, 20, true);
+    dirView.setUint16(6, 20, true);
+    dirView.setUint32(16, crc, true);
+    dirView.setUint32(20, file.data.length, true);
+    dirView.setUint32(24, file.data.length, true);
+    dirView.setUint16(28, name.length, true);
+    dirView.setUint32(42, offset, true);
+    dir.set(name, 46);
+    central.push(dir);
+    offset += local.length + file.data.length;
+  }
+
+  const centralOffset = offset;
+  const centralBytes = concat(central);
+  const end = new Uint8Array(22);
+  const endView = new DataView(end.buffer);
+  endView.setUint32(0, 0x06054b50, true);
+  endView.setUint16(8, files.length, true);
+  endView.setUint16(10, files.length, true);
+  endView.setUint32(12, centralBytes.length, true);
+  endView.setUint32(16, centralOffset, true);
+  return concat([...chunks, centralBytes, end]);
+}
+
+export function createExportBatchRoutes(deps: ExportBatchDeps = {}) {
+  const availableCollections = deps.availableCollections ?? defaultAvailableCollections;
+  const loadCollections = deps.loadCollections ?? readCollections;
+
+  return new Elysia({ prefix: '/api' }).post('/export/batch', async ({ body, set }) => {
+    const input = body as BatchBody;
+    const names = normalizeCollectionNames(input.collections);
+    if (names.length === 0) {
+      set.status = 400;
+      return { error: 'At least one collection is required' };
+    }
+
+    const available = new Set(availableCollections());
+    const missing = names.find((name) => !available.has(name));
+    if (missing) {
+      set.status = 404;
+      return { error: `Unknown export collection: ${missing}`, collections: [...available].sort() };
+    }
+
+    const collections = await loadCollections(names);
+    const archive = zip(makeFiles(collections, names, input.format, Boolean(input.includeGraph), deps.graph));
+    return new Response(archive, {
+      headers: {
+        'Content-Type': 'application/zip',
+        'Content-Disposition': 'attachment; filename="arra-export-batch.zip"',
+        'X-Export-Collections': names.join(','),
+      },
+    });
+  }, {
+    body: t.Object({
+      collections: t.Array(t.String(), { minItems: 1 }),
+      format: t.Union(EXPORT_FORMATS.map((format) => t.Literal(format)) as [
+        ReturnType<typeof t.Literal>,
+        ReturnType<typeof t.Literal>,
+        ReturnType<typeof t.Literal>,
+      ]),
+      includeGraph: t.Optional(t.Boolean()),
+    }),
+    detail: {
+      tags: ['export'],
+      menu: { group: 'tools', order: 68 },
+      summary: 'Export multiple collections as one ZIP archive',
+    },
+  });
+}
+
+export const exportBatchRoutes = createExportBatchRoutes();

--- a/src/routes/export/format.ts
+++ b/src/routes/export/format.ts
@@ -1,0 +1,154 @@
+import { exportFormatInfo } from '../../vector/export-formats.ts';
+
+export type ExportRecord = Record<string, unknown>;
+export const EXPORT_FORMATS = ['json', 'csv', 'markdown'] as const;
+export type ExportFormat = typeof EXPORT_FORMATS[number];
+
+const CSV_COLUMNS = ['id', 'title', 'content_preview', 'collection', 'created_at'] as const;
+
+export function extensionFor(format: ExportFormat): string {
+  return exportFormatInfo(format)?.extension ?? (format === 'markdown' ? 'md' : format);
+}
+
+function normalizeValue(value: unknown): unknown {
+  if (typeof value === 'bigint') return value.toString();
+  if (value instanceof Date) return value.toISOString();
+  if (value instanceof Uint8Array) return Array.from(value);
+  return value;
+}
+
+function normalizeRecord(record: ExportRecord): ExportRecord {
+  return Object.fromEntries(Object.entries(record).map(([key, value]) => [key, normalizeValue(value)]));
+}
+
+export function normalizeRecords(records: ExportRecord[]): ExportRecord[] {
+  return records.map(normalizeRecord);
+}
+
+export function formatCollection(name: string, rows: ExportRecord[], format: ExportFormat): string {
+  if (format === 'json') {
+    return `${JSON.stringify({ collection: name, rowCount: rows.length, rows }, null, 2)}\n`;
+  }
+  if (format === 'csv') return formatCsvCollection(name, rows);
+  return toMarkdown(name, rows);
+}
+
+function text(value: unknown): string {
+  if (value == null) return '';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+function pick(row: ExportRecord, keys: string[]): unknown {
+  for (const key of keys) {
+    const value = row[key];
+    if (value != null && value !== '') return value;
+  }
+  return undefined;
+}
+
+function preview(value: unknown): string {
+  const normalized = text(value).replace(/\s+/g, ' ').trim();
+  return normalized.length > 180 ? `${normalized.slice(0, 177)}...` : normalized;
+}
+
+function csvCell(value: unknown): string {
+  return `"${text(value).replaceAll('"', '""')}"`;
+}
+
+function csvRow(collection: string, row: ExportRecord): string[] {
+  const id = pick(row, ['id', 'traceId', 'key', 'path', 'oldId', 'oldPath']);
+  return [
+    text(id),
+    text(pick(row, ['title', 'oldTitle', 'newTitle', 'sourceFile', 'source_file', 'query', 'key', 'event', 'path']) ?? id),
+    preview(pick(row, ['content', 'document', 'text', 'patternPreview', 'query', 'event', 'notes', 'sourceFile', 'source_file'])),
+    collection,
+    text(pick(row, ['createdAt', 'created_at', 'supersededAt', 'superseded_at', 'updatedAt', 'updated_at', 'when'])),
+  ];
+}
+
+function formatCsvCollection(collection: string, rows: ExportRecord[]): string {
+  return [
+    CSV_COLUMNS.join(','),
+    ...rows.map((row) => csvRow(collection, row).map(csvCell).join(',')),
+  ].join('\n') + '\n';
+}
+
+function printable(value: unknown): string {
+  if (value == null) return '';
+  if (typeof value === 'object') return `\`${JSON.stringify(value)}\``;
+  return String(value);
+}
+
+function rowTitle(row: ExportRecord, index: number): string {
+  const id = row.id ?? row.traceId ?? row.path ?? row.key;
+  return id == null ? `row-${index + 1}` : String(id);
+}
+
+function toMarkdown(name: string, rows: ExportRecord[]): string {
+  const lines = [`# ${name}`, '', `Rows: ${rows.length}`, ''];
+  rows.forEach((row, index) => {
+    lines.push(`## ${rowTitle(row, index)}`, '');
+    for (const [key, value] of Object.entries(row)) lines.push(`- **${key}**: ${printable(value)}`);
+    lines.push('');
+  });
+  return lines.join('\n');
+}
+
+export function graphRelationships(collections: Record<string, ExportRecord[]>): ExportRecord[] {
+  return [
+    ...documentRelationships(collections.oracle_documents ?? []),
+    ...supersedeRelationships(collections.supersede_log ?? []),
+    ...traceRelationships(collections.trace_log ?? []),
+  ];
+}
+
+function valueText(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function documentRelationships(rows: ExportRecord[]): ExportRecord[] {
+  return rows.flatMap((row) => {
+    const from = valueText(row.id);
+    const to = valueText(row.supersededBy);
+    return from && to ? [{ type: 'document_superseded_by', from, to, metadata: { reason: row.supersededReason, at: row.supersededAt } }] : [];
+  });
+}
+
+function supersedeRelationships(rows: ExportRecord[]): ExportRecord[] {
+  return rows.flatMap((row) => {
+    const from = valueText(row.oldId) ?? valueText(row.oldPath);
+    const to = valueText(row.newId) ?? valueText(row.newPath) ?? valueText(row.supersededBy);
+    return from && to ? [{ type: 'supersede_log', from, to, metadata: row }] : [];
+  });
+}
+
+function traceRelationships(rows: ExportRecord[]): ExportRecord[] {
+  const out: ExportRecord[] = [];
+  for (const row of rows) {
+    const traceId = valueText(row.traceId);
+    if (!traceId) continue;
+    const links = [
+      ['trace_parent', row.parentTraceId],
+      ['trace_prev', row.prevTraceId],
+      ['trace_next', row.nextTraceId],
+    ] as const;
+    for (const [type, value] of links) {
+      const to = valueText(value);
+      if (to) out.push({ type, from: traceId, to });
+    }
+    for (const child of childTraceIds(row.childTraceIds)) out.push({ type: 'trace_child', from: traceId, to: child });
+  }
+  return out;
+}
+
+function childTraceIds(value: unknown): string[] {
+  if (Array.isArray(value)) return value.filter((item): item is string => typeof item === 'string');
+  if (typeof value !== 'string') return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : [];
+  } catch {
+    return [];
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -61,7 +61,7 @@ import { memoryRoutes } from './routes/memory/index.ts';
 import { canvasRoutes } from './routes/canvas/index.ts';
 import { tenantsRoutes } from './routes/tenants/index.ts';
 import { exportAppRoutes } from './routes/export/app.ts';
-
+import { exportBatchRoutes } from './routes/export/batch.ts';
 let indexerRoutes: any = null;
 try {
   indexerRoutes = (await import('./routes/indexer/index.ts')).indexerRoutes;
@@ -199,6 +199,7 @@ const apiModules = [
   canvasRoutes,
   tenantsRoutes,
   exportAppRoutes,
+  exportBatchRoutes,
   ...(indexerRoutes ? [indexerRoutes] : []),
   ...unifiedPlugins.routes,
 ];
@@ -215,7 +216,6 @@ try {
 
 const menuRoutes = createMenuRoutes(menuItemsFromUnifiedPlugins(unifiedPlugins.menu));
 const mcpRoutes = createMcpRoutes(unifiedPlugins.mcpTools);
-
 const modules = [...apiModules, mcpRoutes, menuRoutes];
 for (const mod of modules) app.use(mod as any);
 app.use(createNotFoundMiddleware(app.routes));

--- a/tests/http/export/batch.test.ts
+++ b/tests/http/export/batch.test.ts
@@ -1,0 +1,105 @@
+import { expect, test } from 'bun:test';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createExportBatchRoutes } from '../../../src/routes/export/batch.ts';
+import type { ExportRecord } from '../../../src/routes/export/format.ts';
+
+const decoder = new TextDecoder();
+
+function entries(buffer: ArrayBuffer): Map<string, string> {
+  const bytes = new Uint8Array(buffer);
+  const view = new DataView(buffer);
+  const out = new Map<string, string>();
+  let offset = 0;
+
+  while (offset + 4 <= bytes.length && view.getUint32(offset, true) === 0x04034b50) {
+    const size = view.getUint32(offset + 18, true);
+    const nameLength = view.getUint16(offset + 26, true);
+    const extraLength = view.getUint16(offset + 28, true);
+    const nameStart = offset + 30;
+    const dataStart = nameStart + nameLength + extraLength;
+    const name = decoder.decode(bytes.slice(nameStart, nameStart + nameLength));
+    out.set(name, decoder.decode(bytes.slice(dataStart, dataStart + size)));
+    offset = dataStart + size;
+  }
+
+  return out;
+}
+
+function post(body: unknown) {
+  return new Request('http://local/api/v1/export/batch', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+async function json(res: Response) {
+  return JSON.parse(await res.text());
+}
+
+function fetcher(collections: Record<string, ExportRecord[]>) {
+  const app = createExportBatchRoutes({
+    availableCollections: () => Object.keys(collections),
+    loadCollections: (names) => Object.fromEntries(names.map((name) => [name, collections[name] ?? []])),
+  });
+  return createApiVersionedFetch((request) => app.handle(request));
+}
+
+test('export batch returns a zip with one file per collection and optional graph relationships', async () => {
+  const fetch = fetcher({
+    oracle_documents: [{
+      id: 'doc-a',
+      title: 'Alpha',
+      content: 'First document',
+      supersededBy: 'doc-b',
+      createdAt: new Date('2026-06-16T00:00:00.000Z'),
+    }],
+    trace_log: [{ traceId: 'trace-a', parentTraceId: 'trace-root', event: 'exported' }],
+  });
+
+  const res = await fetch(post({
+    collections: ['oracle_documents', 'trace_log'],
+    format: 'json',
+    includeGraph: true,
+  }));
+
+  expect(res.status).toBe(200);
+  expect(res.headers.get('content-type')).toBe('application/zip');
+  expect(res.headers.get('content-disposition')).toBe('attachment; filename="arra-export-batch.zip"');
+  expect(res.headers.get('x-export-collections')).toBe('oracle_documents,trace_log');
+
+  const zipEntries = entries(await res.arrayBuffer());
+  expect([...zipEntries.keys()].sort()).toEqual([
+    'oracle_documents.json',
+    'relationships.json',
+    'trace_log.json',
+  ]);
+
+  const docs = JSON.parse(zipEntries.get('oracle_documents.json') ?? '{}');
+  expect(docs).toMatchObject({
+    collection: 'oracle_documents',
+    rowCount: 1,
+    rows: [{ id: 'doc-a', createdAt: '2026-06-16T00:00:00.000Z' }],
+  });
+
+  const graph = JSON.parse(zipEntries.get('relationships.json') ?? '{}');
+  expect(graph.rows).toContainEqual(expect.objectContaining({
+    type: 'document_superseded_by',
+    from: 'doc-a',
+    to: 'doc-b',
+  }));
+});
+
+test('export batch rejects unknown collections before loading data', async () => {
+  const res = await fetcher({ oracle_documents: [] })(post({
+    collections: ['missing'],
+    format: 'json',
+    includeGraph: false,
+  }));
+
+  expect(res.status).toBe(404);
+  expect(await json(res)).toEqual({
+    error: 'Unknown export collection: missing',
+    collections: ['oracle_documents'],
+  });
+});


### PR DESCRIPTION
## Summary
- Add `POST /api/v1/export/batch` for exporting multiple collections in one ZIP response.
- Include one formatted file per requested collection, plus optional `relationships.*` graph export when `includeGraph` is true.
- Mount the batch export sub-app in `src/server.ts` next to the export app routes.

## Validation
- `bun test tests/http/export/`
- `bunx tsc --noEmit`
- `rtk wc -l src/server.ts src/routes/export/batch.ts src/routes/export/format.ts tests/http/export/batch.test.ts`

## Notes
- Rebasing onto current `origin/alpha` preserved the existing `exportAppRoutes` mount and added `exportBatchRoutes` alongside it.
