### PR TITLE
feat: add maw vector config command

### DIFF
--- a/tests/tools/maw-plugin-arra/vector-config.test.ts
+++ b/tests/tools/maw-plugin-arra/vector-config.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import handler from '../../../tools/maw-plugin-arra/index.ts';
+
+type Call = { url: string; init?: RequestInit; body?: unknown };
+
+const originalFetch = globalThis.fetch;
+const originalApi = process.env.ARRA_API;
+const originalToken = process.env.ARRA_API_TOKEN;
+
+const configPayload = {
+  source: 'file',
+  config: {
+    collections: {
+      'bge-m3': {
+        collection: 'oracle_knowledge_bge_m3',
+        adapter: 'lancedb',
+        model: 'bge-m3',
+        provider: 'ollama',
+        primary: true,
+      },
+      nomic: {
+        collection: 'oracle_knowledge_nomic',
+        adapter: 'qdrant',
+        model: 'nomic-embed-text',
+        provider: 'remote',
+      },
+    },
+  },
+  collections: [
+    { key: 'bge-m3', collection: 'oracle_knowledge_bge_m3', adapter: 'lancedb', model: 'bge-m3', count: 42, status: 'ok' },
+    { key: 'nomic', collection: 'oracle_knowledge_nomic', adapter: 'qdrant', model: 'nomic-embed-text', count: 7, status: 'ok' },
+  ],
+};
+
+function installFetch(response: unknown = configPayload): Call[] {
+  const calls: Call[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({
+      url: String(input),
+      init,
+      body: init?.body ? JSON.parse(String(init.body)) : undefined,
+    });
+    return new Response(JSON.stringify(response), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+  return calls;
+}
+
+async function run(args: string[], response?: unknown) {
+  process.env.ARRA_API = 'http://arra.test/';
+  const calls = installFetch(response);
+  const result = await handler({ args });
+  return { result, calls };
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalApi === undefined) delete process.env.ARRA_API;
+  else process.env.ARRA_API = originalApi;
+  if (originalToken === undefined) delete process.env.ARRA_API_TOKEN;
+  else process.env.ARRA_API_TOKEN = originalToken;
+});
+
+describe('tools maw arra vector-config command', () => {
+  test('lists vector backend config collections as JSON', async () => {
+    const { result, calls } = await run(['vector-config', 'list']);
+    const body = JSON.parse(result.output ?? '');
+
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('http://arra.test/api/v1/vector/config');
+    expect(calls[0].init?.method).toBeUndefined();
+    expect(body).toMatchObject({
+      source: 'file',
+      collections: [
+        { key: 'bge-m3', adapter: 'lancedb', count: 42 },
+        { key: 'nomic', adapter: 'qdrant', count: 7 },
+      ],
+    });
+  });
+
+  test('gets one vector collection from the config response', async () => {
+    const { result, calls } = await run(['vector-config', 'get', 'bge-m3']);
+    const body = JSON.parse(result.output ?? '');
+
+    expect(result.ok).toBe(true);
+    expect(calls[0].url).toBe('http://arra.test/api/v1/vector/config');
+    expect(body).toMatchObject({
+      key: 'bge-m3',
+      collection: 'oracle_knowledge_bge_m3',
+      adapter: 'lancedb',
+      model: 'bge-m3',
+      count: 42,
+    });
+  });
+
+  test('sets one vector backend config field with JSON output', async () => {
+    process.env.ARRA_API_TOKEN = 'secret';
+    const response = { success: true, collection: 'bge-m3', config: { collections: { 'bge-m3': { adapter: 'proxy' } } } };
+    const { result, calls } = await run(['vector-config', 'set', 'bge-m3', 'adapter', 'proxy', '--endpoint', 'http://proxy.test'], response);
+    const body = JSON.parse(result.output ?? '');
+
+    expect(result.ok).toBe(true);
+    expect(calls[0].url).toBe('http://arra.test/api/v1/vector/config/bge-m3');
+    expect(calls[0].init?.method).toBe('PUT');
+    expect(calls[0].init?.headers).toMatchObject({
+      authorization: 'Bearer secret',
+      'content-type': 'application/json',
+    });
+    expect(calls[0].body).toEqual({ adapter: 'proxy', endpoint: 'http://proxy.test' });
+    expect(body).toMatchObject({ success: true, collection: 'bge-m3' });
+  });
+
+  test('sets boolean fields and supports underscore alias', async () => {
+    const { result, calls } = await run(['vector_config', 'set', 'nomic', 'enabled', 'false']);
+
+    expect(result.ok).toBe(true);
+    expect(calls[0].url).toBe('http://arra.test/api/v1/vector/config/nomic');
+    expect(calls[0].body).toEqual({ enabled: false });
+  });
+});

--- a/tools/maw-plugin-arra/commands/vector-config.ts
+++ b/tools/maw-plugin-arra/commands/vector-config.ts
@@ -1,0 +1,106 @@
+import { flag, parseArgs, requestJson, requestText, type ParsedArgs } from './http.ts';
+
+const usage = 'usage: maw arra vector-config list|get [collection]|set <collection> <field> <value>';
+const adapters = new Set(['chroma', 'sqlite-vec', 'lancedb', 'qdrant', 'cloudflare-vectorize', 'proxy']);
+const updateFields = new Set(['adapter', 'model', 'provider', 'service', 'endpoint', 'enabled', 'primary', 'embedder', 'collection']);
+
+type JsonObject = Record<string, unknown>;
+
+function json(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function object(value: unknown): JsonObject | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as JsonObject : undefined;
+}
+
+function bool(value: string): boolean {
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  throw new Error('boolean values must be true or false');
+}
+
+function parseValue(field: string, value: string): unknown {
+  if (field === 'enabled' || field === 'primary') return bool(value);
+  if (field === 'embedder') return JSON.parse(value) as unknown;
+  if (field === 'adapter') {
+    const normalized = value === 'cloudflare' ? 'cloudflare-vectorize' : value;
+    if (!adapters.has(normalized)) throw new Error('unsupported vector adapter');
+    return normalized;
+  }
+  return value;
+}
+
+function configCollections(payload: JsonObject): JsonObject {
+  return object(object(payload.config)?.collections) ?? {};
+}
+
+function collectionPayload(payload: JsonObject, collection: string): JsonObject {
+  const configured = object(configCollections(payload)[collection]);
+  const listed = Array.isArray(payload.collections)
+    ? payload.collections.find((row) => object(row)?.key === collection || object(row)?.collection === collection)
+    : undefined;
+  const row = object(listed);
+  if (!configured && !row) throw new Error(`unknown vector collection: ${collection}`);
+  return { key: collection, ...configured, ...row };
+}
+
+function listPayload(payload: JsonObject): JsonObject {
+  const collections = Array.isArray(payload.collections)
+    ? payload.collections
+    : Object.entries(configCollections(payload)).map(([key, value]) => ({ key, ...object(value) }));
+  return { source: payload.source, collections };
+}
+
+function flagUpdates(parsed: ParsedArgs): JsonObject {
+  const updates: JsonObject = {};
+  for (const field of updateFields) {
+    const raw = flag(parsed, field === 'endpoint' ? 'url' : field) ?? flag(parsed, field);
+    if (raw !== undefined) updates[field] = parseValue(field, raw);
+  }
+  return updates;
+}
+
+function updateBody(parsed: ParsedArgs): JsonObject {
+  const [, , field, value] = parsed.positionals;
+  const updates = flagUpdates(parsed);
+  if (field !== undefined) {
+    if (value === undefined) throw new Error('set field value required');
+    if (!updateFields.has(field)) throw new Error(`unsupported vector config field: ${field}`);
+    updates[field] = parseValue(field, value);
+  }
+  if (Object.keys(updates).length === 0) throw new Error(usage);
+  return updates;
+}
+
+async function readConfig(): Promise<JsonObject> {
+  return await requestJson<JsonObject>('/api/v1/vector/config');
+}
+
+async function writeCollection(collection: string, body: JsonObject): Promise<JsonObject> {
+  const text = await requestText(`/api/v1/vector/config/${encodeURIComponent(collection)}`, {
+    method: 'PUT',
+    headers: { accept: 'application/json', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return text ? JSON.parse(text) as JsonObject : {};
+}
+
+export async function runVectorConfigCommand(args: string[]): Promise<string> {
+  const parsed = parseArgs(args);
+  const action = (parsed.positionals[0] ?? 'list').toLowerCase().replace(/-/g, '_');
+  if (action === 'list') return json(listPayload(await readConfig()));
+  if (action === 'get') {
+    const payload = await readConfig();
+    const collection = parsed.positionals[1];
+    return json(collection ? collectionPayload(payload, collection) : payload);
+  }
+  if (action === 'set') {
+    const collection = parsed.positionals[1];
+    if (!collection) throw new Error(usage);
+    return json(await writeCollection(collection, updateBody(parsed)));
+  }
+  throw new Error(usage);
+}
+
+export const VECTOR_CONFIG_HELP = 'vector-config list|get [collection]|set <collection> <field> <value>';

--- a/tools/maw-plugin-arra/index.ts
+++ b/tools/maw-plugin-arra/index.ts
@@ -1,5 +1,6 @@
 import { runExportCommand } from './commands/export.ts';
 import { runStatusCommand } from './commands/status.ts';
+import { runVectorConfigCommand, VECTOR_CONFIG_HELP } from './commands/vector-config.ts';
 
 type InvokeContext = {
   source?: string;
@@ -13,11 +14,13 @@ type CommandHandler = (args: string[]) => Promise<string>;
 const commandHandlers: Record<string, CommandHandler> = {
   export: runExportCommand,
   status: () => runStatusCommand(),
+  'vector-config': runVectorConfigCommand,
+  vector_config: runVectorConfigCommand,
 };
 
 export const command = {
   name: 'arra',
-  description: 'ARRA Oracle CLI bridge — export vector collections and inspect status.',
+  description: 'ARRA Oracle CLI bridge — export vectors, inspect status, and manage vector config.',
 };
 
 function argsFromContext(args: InvokeContext['args']): string[] {
@@ -39,6 +42,8 @@ function help(): string {
     '      show vector collections, doc counts, and health from localhost:47778',
     '  export --collection X --format json|csv|md',
     '      stream a vector collection export from localhost:47778',
+    `  ${VECTOR_CONFIG_HELP}`,
+    '      read and write vector backend config as JSON',
   ].join('\n');
 }
 

--- a/tools/maw-plugin-arra/plugin.json
+++ b/tools/maw-plugin-arra/plugin.json
@@ -3,11 +3,11 @@
   "version": "0.1.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "ARRA Oracle CLI bridge for vector export and status commands.",
+  "description": "ARRA Oracle CLI bridge for vector export, status, and vector config commands.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "arra",
-    "help": "maw arra <status|export --collection X --format json|csv|md>"
+    "help": "maw arra <status|export --collection X --format json|csv|md|vector-config list|get|set>"
   },
   "weight": 10,
   "license": "BUSL-1.1",


### PR DESCRIPTION
## Summary
- add tools/maw-plugin-arra vector-config command support for list, get, and set
- wire vector-config and vector_config aliases into the maw arra plugin handler and manifest help
- cover JSON list/get/set behavior, auth headers, boolean values, and alias routing

## Validation
- bun test tests/tools/maw-plugin-arra/
- bunx tsc --noEmit
- wc -l tools/maw-plugin-arra/commands/vector-config.ts tools/maw-plugin-arra/index.ts tools/maw-plugin-arra/plugin.json tests/tools/maw-plugin-arra/vector-config.test.ts (106, 67, 15, 123)
- merged current origin/alpha before final validation