### PR TITLE
feat: add psi learn file watcher

### DIFF
--- a/src/routes/watcher/index.ts
+++ b/src/routes/watcher/index.ts
@@ -1,0 +1,17 @@
+import { Elysia } from 'elysia';
+import { fileWatcherService, type FileWatcherService } from '../../services/file-watcher.ts';
+
+export function createWatcherRoutes(service: FileWatcherService = fileWatcherService) {
+  return new Elysia({ prefix: '/api' })
+    .get('/watcher/status', () => service.status(), {
+      detail: { tags: ['watcher'], summary: 'File watcher daemon status' },
+    })
+    .post('/watcher/start', () => service.start(), {
+      detail: { tags: ['watcher'], summary: 'Start the ψ/learn file watcher daemon' },
+    })
+    .post('/watcher/stop', () => service.stop(), {
+      detail: { tags: ['watcher'], summary: 'Stop the ψ/learn file watcher daemon' },
+    });
+}
+
+export const watcherRoutes = createWatcherRoutes();

--- a/src/server.ts
+++ b/src/server.ts
@@ -60,6 +60,8 @@ import { createMetricsLifecycle, metricsRoutes } from './routes/metrics/index.ts
 import { memoryRoutes } from './routes/memory/index.ts';
 import { canvasRoutes } from './routes/canvas/index.ts';
 import { tenantsRoutes } from './routes/tenants/index.ts';
+import { watcherRoutes } from './routes/watcher/index.ts';
+import { fileWatcherService } from './services/file-watcher.ts';
 
 let indexerRoutes: any = null;
 try {
@@ -86,14 +88,10 @@ try {
 } catch {}
 
 configure({ dataDir: ORACLE_DATA_DIR, pidFileName: 'oracle-http.pid' });
-writePidFile({
-  pid: process.pid,
-  port: Number(PORT),
-  startedAt: new Date().toISOString(),
-  name: 'oracle-http',
-});
+writePidFile({ pid: process.pid, port: Number(PORT), startedAt: new Date().toISOString(), name: 'oracle-http' });
 const scoutAnnouncer = shouldStartScoutAnnouncer() ? new ScoutAnnouncer() : null;
 scoutAnnouncer?.start();
+if (process.env.ORACLE_FILE_WATCHER !== '0') fileWatcherService.start();
 
 const unifiedPlugins = await loadUnifiedPlugins({
   dirs: defaultUnifiedPluginDirs([join(import.meta.dir, 'plugins')]),
@@ -106,6 +104,7 @@ registerGracefulShutdown({
     console.log('\n🔮 Shutting down gracefully...');
     await runShutdownSteps([
       { name: 'scout-announcer', run: () => scoutAnnouncer?.stop() },
+      { name: 'file-watcher', run: () => { fileWatcherService.stop(); } },
       { name: 'unified-plugins', run: () => unifiedPlugins.stop() },
       { name: 'unified-plugin-servers', run: () => unifiedServers.stop() },
       { name: 'vector-stores', run: () => closeCachedVectorStores() },
@@ -199,6 +198,7 @@ const apiModules = [
   memoryRoutes,
   canvasRoutes,
   tenantsRoutes,
+  watcherRoutes,
   ...(indexerRoutes ? [indexerRoutes] : []),
   ...unifiedPlugins.routes,
 ];

--- a/src/services/file-watcher.ts
+++ b/src/services/file-watcher.ts
@@ -1,0 +1,191 @@
+import fs from 'fs';
+import path from 'path';
+import type { Database } from 'bun:sqlite';
+import { sqlite } from '../db/index.ts';
+import { REPO_ROOT } from '../config.ts';
+import { getEmbeddingModels } from '../vector/factory.ts';
+import { enqueueIndexJob } from '../indexer/jobs.ts';
+import {
+  PSI_LEARN_REL,
+  isMarkdownFile,
+  isPsiLearnSource,
+  normalizeSourceFile,
+  readPsiLearnDocuments,
+  storeSqliteDocuments,
+} from '../indexer/learn-doc-source.ts';
+import { isWithinRoot, listDirs, safeClearTimeout, safeClose, watchDir } from '../indexer/watch-utils.ts';
+
+type ModelRegistry = Record<string, { collection: string }>;
+type WatcherEventType = 'started' | 'stopped' | 'scheduled' | 'indexed' | 'skipped' | 'error';
+
+export interface WatcherEvent {
+  type: WatcherEventType;
+  at: string;
+  path?: string;
+  message: string;
+  docs?: number;
+  jobs?: number;
+}
+
+export interface FileWatcherStatus {
+  running: boolean;
+  watchRoot: string;
+  debounceMs: number;
+  watchedDirs: number;
+  pending: number;
+  events: WatcherEvent[];
+}
+
+export interface FileWatcherOptions {
+  db?: Database;
+  repoRoot?: string;
+  debounceMs?: number;
+  models?: ModelRegistry | (() => ModelRegistry);
+  logger?: Pick<Console, 'log' | 'warn'>;
+  maxEvents?: number;
+}
+
+const DEFAULT_DEBOUNCE_MS = 2_000;
+
+export class FileWatcherService {
+  private readonly db: Database;
+  private readonly models: () => ModelRegistry;
+  private readonly logger: Pick<Console, 'log' | 'warn'>;
+  private readonly maxEvents: number;
+  private readonly repoRoot: string;
+  private readonly watchRoot: string;
+  private debounceMs: number;
+  private running = false;
+  private watchers: fs.FSWatcher[] = [];
+  private watchedDirs = new Set<string>();
+  private pending = new Map<string, ReturnType<typeof setTimeout>>();
+  private events: WatcherEvent[] = [];
+
+  constructor(options: FileWatcherOptions = {}) {
+    this.db = options.db ?? sqlite;
+    const source = options.models ?? getEmbeddingModels;
+    this.models = typeof source === 'function' ? source : () => source;
+    this.logger = options.logger ?? console;
+    this.maxEvents = options.maxEvents ?? 50;
+    this.repoRoot = path.resolve(options.repoRoot ?? REPO_ROOT);
+    this.watchRoot = path.join(this.repoRoot, PSI_LEARN_REL);
+    this.debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+  }
+
+  start(): FileWatcherStatus {
+    if (this.running) return this.status();
+    try {
+      fs.mkdirSync(this.watchRoot, { recursive: true });
+      this.addWatchers(this.watchRoot);
+      this.running = this.watchers.length > 0;
+      this.record('started', `watching ${this.watchRoot}`);
+      this.logger.log(`[file-watcher] watching ${this.watchRoot}`);
+    } catch (error) {
+      this.record('error', `failed to start watcher: ${errorText(error)}`);
+      this.logger.warn('[file-watcher] failed to start:', error);
+    }
+    return this.status();
+  }
+
+  stop(): FileWatcherStatus {
+    for (const timer of this.pending.values()) safeClearTimeout(timer);
+    this.pending.clear();
+    safeClose(this.watchers);
+    this.watchers = [];
+    this.watchedDirs.clear();
+    if (this.running) this.record('stopped', `stopped watching ${this.watchRoot}`);
+    this.running = false;
+    return this.status();
+  }
+
+  status(): FileWatcherStatus {
+    return {
+      running: this.running,
+      watchRoot: this.watchRoot,
+      debounceMs: this.debounceMs,
+      watchedDirs: this.watchedDirs.size,
+      pending: this.pending.size,
+      events: [...this.events],
+    };
+  }
+
+  schedule(filePath: string): void {
+    const fullPath = path.resolve(filePath);
+    if (!isWithinRoot(this.watchRoot, fullPath)) return;
+    safeClearTimeout(this.pending.get(fullPath));
+    const sourceFile = normalizeSourceFile(this.repoRoot, fullPath);
+    this.record('scheduled', `scheduled re-index for ${sourceFile}`, sourceFile);
+    this.pending.set(fullPath, setTimeout(() => {
+      this.pending.delete(fullPath);
+      this.reindexPath(fullPath);
+    }, this.debounceMs));
+  }
+
+  private addWatchers(dir: string): void {
+    for (const childDir of listDirs(dir)) {
+      if (this.watchedDirs.has(childDir)) continue;
+      const watcher = watchDir(childDir, (candidate) => this.schedule(candidate));
+      if (!watcher) continue;
+      this.watchers.push(watcher);
+      this.watchedDirs.add(childDir);
+    }
+  }
+
+  private reindexPath(filePath: string): void {
+    if (!fs.existsSync(filePath)) return this.skip(filePath, 'path no longer exists');
+    const stat = fs.statSync(filePath);
+    if (stat.isDirectory()) {
+      this.addWatchers(filePath);
+      return;
+    }
+
+    const sourceFile = normalizeSourceFile(this.repoRoot, filePath);
+    if (!stat.isFile() || !isMarkdownFile(filePath) || !isPsiLearnSource(sourceFile)) {
+      return this.skip(filePath, 'not a ψ/learn markdown file');
+    }
+
+    try {
+      const ids = storeSqliteDocuments(this.db, readPsiLearnDocuments(this.repoRoot, filePath));
+      const jobs = this.enqueue(ids);
+      this.record('indexed', `re-indexed ${sourceFile}: ${ids.length} docs, ${jobs} jobs`, sourceFile, ids.length, jobs);
+      this.logger.log(`[file-watcher] re-indexed ${sourceFile}: ${ids.length} docs, ${jobs} jobs`);
+    } catch (error) {
+      this.record('error', `failed to re-index ${sourceFile}: ${errorText(error)}`, sourceFile);
+      this.logger.warn(`[file-watcher] failed to re-index ${sourceFile}:`, error);
+    }
+  }
+
+  private enqueue(ids: string[]): number {
+    const models = this.models();
+    let count = 0;
+    for (const id of ids) {
+      if (this.hasActiveJob(id)) continue;
+      count += enqueueIndexJob(this.db, { docId: id, models }).length;
+    }
+    return count;
+  }
+
+  private hasActiveJob(docId: string): boolean {
+    const row = this.db.query<{ count: number }, [string]>(
+      `SELECT COUNT(*) AS count FROM indexing_jobs
+       WHERE doc_id = ? AND status IN ('pending', 'claimed')`,
+    ).get(docId);
+    return (row?.count ?? 0) > 0;
+  }
+
+  private skip(filePath: string, reason: string): void {
+    const sourceFile = normalizeSourceFile(this.repoRoot, filePath);
+    this.record('skipped', `${reason}: ${sourceFile}`, sourceFile);
+  }
+
+  private record(type: WatcherEventType, message: string, sourceFile?: string, docs?: number, jobs?: number): void {
+    this.events.unshift({ type, at: new Date().toISOString(), path: sourceFile, message, docs, jobs });
+    this.events = this.events.slice(0, this.maxEvents);
+  }
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export const fileWatcherService = new FileWatcherService();

--- a/tests/http/watcher/file-watcher.test.ts
+++ b/tests/http/watcher/file-watcher.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import Database from 'bun:sqlite';
+import { Elysia } from 'elysia';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createWatcherRoutes } from '../../../src/routes/watcher/index.ts';
+import { FileWatcherService } from '../../../src/services/file-watcher.ts';
+
+const SCHEMA = `
+CREATE TABLE oracle_documents (
+  id TEXT PRIMARY KEY,
+  type TEXT NOT NULL,
+  source_file TEXT NOT NULL,
+  concepts TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  indexed_at INTEGER NOT NULL,
+  superseded_by TEXT,
+  superseded_at INTEGER,
+  superseded_reason TEXT,
+  origin TEXT,
+  project TEXT,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  created_by TEXT
+);
+CREATE VIRTUAL TABLE oracle_fts USING fts5(id UNINDEXED, content, concepts, tokenize='porter unicode61');
+CREATE TABLE indexing_jobs (
+  id TEXT PRIMARY KEY,
+  doc_id TEXT NOT NULL,
+  model_key TEXT NOT NULL,
+  collection TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  attempts INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')*1000),
+  claimed_at INTEGER,
+  finished_at INTEGER,
+  error TEXT
+);`;
+
+const MODELS = {
+  'bge-m3': { collection: 'oracle_knowledge_bge_m3' },
+  qwen3: { collection: 'oracle_knowledge_qwen3' },
+};
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(check: () => boolean, timeoutMs = 1_500): Promise<void> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    if (check()) return;
+    await sleep(25);
+  }
+  throw new Error('timed out waiting for watcher event');
+}
+
+describe('watcher HTTP routes', () => {
+  let repoRoot = '';
+  let db: Database;
+  let service: FileWatcherService;
+  let logs: string[];
+
+  beforeEach(() => {
+    repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-watcher-'));
+    db = new Database(':memory:');
+    db.exec(SCHEMA);
+    logs = [];
+    service = new FileWatcherService({
+      db,
+      repoRoot,
+      models: MODELS,
+      debounceMs: 25,
+      logger: { log: (msg) => logs.push(msg), warn: (msg) => logs.push(String(msg)) },
+    });
+  });
+
+  afterEach(() => {
+    service.stop();
+    db.close();
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  function fetcher() {
+    const app = new Elysia().use(createWatcherRoutes(service));
+    return createApiVersionedFetch((request) => app.handle(request));
+  }
+
+  async function call(pathname: string, init: RequestInit = {}) {
+    const res = await fetcher()(new Request(`http://local${pathname}`, init));
+    return { status: res.status, body: await res.json() as Record<string, any> };
+  }
+
+  test('starts, reports, and stops the watcher daemon', async () => {
+    const started = await call('/api/v1/watcher/start', { method: 'POST' });
+    expect(started.status).toBe(200);
+    expect(started.body.running).toBe(true);
+    expect(started.body.watchRoot).toEndWith(path.join('ψ', 'learn'));
+
+    const status = await call('/api/v1/watcher/status');
+    expect(status.body.watchedDirs).toBeGreaterThan(0);
+    expect(status.body.events[0]).toMatchObject({ type: 'started' });
+
+    const stopped = await call('/api/v1/watcher/stop', { method: 'POST' });
+    expect(stopped.body.running).toBe(false);
+  });
+
+  test('auto re-indexes changed ψ/learn markdown after debounce', async () => {
+    const learnDir = path.join(repoRoot, 'ψ', 'learn', 'github.com', 'owner', 'repo');
+    const filePath = path.join(learnDir, 'watch.md');
+    fs.mkdirSync(learnDir, { recursive: true });
+
+    await call('/api/v1/watcher/start', { method: 'POST' });
+    fs.writeFileSync(filePath, '# Watch\n\n## Finding\n\nWatcher routes queue vector indexing jobs.', 'utf8');
+
+    await waitFor(() => count('indexing_jobs') === Object.keys(MODELS).length);
+
+    expect(db.query<{ source_file: string }, []>('SELECT source_file FROM oracle_documents').get()?.source_file)
+      .toBe('ψ/learn/github.com/owner/repo/watch.md');
+    expect(count('oracle_fts')).toBe(1);
+    expect(logs.some((line) => line.includes('re-indexed ψ/learn/github.com/owner/repo/watch.md'))).toBe(true);
+
+    const status = await call('/api/v1/watcher/status');
+    expect(status.body.events[0]).toMatchObject({ type: 'indexed', docs: 1, jobs: 2 });
+  });
+
+  test('debounces bursty writes into one re-index event', async () => {
+    const learnDir = path.join(repoRoot, 'ψ', 'learn', 'github.com', 'owner', 'repo');
+    const filePath = path.join(learnDir, 'burst.md');
+    fs.mkdirSync(learnDir, { recursive: true });
+
+    await call('/api/v1/watcher/start', { method: 'POST' });
+    fs.writeFileSync(filePath, '# Burst\n\n## Finding\n\nFirst write.', 'utf8');
+    fs.writeFileSync(filePath, '# Burst\n\n## Finding\n\nSecond write.', 'utf8');
+    fs.writeFileSync(filePath, '# Burst\n\n## Finding\n\nThird write.', 'utf8');
+
+    await waitFor(() => count('indexing_jobs') === Object.keys(MODELS).length);
+
+    expect(count('oracle_documents')).toBe(1);
+    expect(count('indexing_jobs')).toBe(Object.keys(MODELS).length);
+  });
+
+  function count(table: string): number {
+    return db.query<{ count: number }, []>(`SELECT COUNT(*) AS count FROM ${table}`).get()?.count ?? 0;
+  }
+});


### PR DESCRIPTION
## Summary
- add a file watcher daemon for ψ/learn with fs.watch, recursive directory registration, 2s debounce, and bounded re-index event logging
- expose watcher status/start/stop routes under /api/v1/watcher/*
- start the watcher with the HTTP server and stop it during graceful shutdown
- add HTTP watcher tests covering start/stop, debounce, SQLite document storage, and vector job queueing

## Validation
- bun test tests/http/watcher/
- bun test src/indexer/__tests__/learn-watcher.test.ts
- bunx tsc --noEmit
- wc -l src/server.ts src/services/file-watcher.ts src/routes/watcher/index.ts tests/http/watcher/file-watcher.test.ts