### PR TITLE
fix: harden core request and plugin surfaces

### DIFF
--- a/src/middleware/logger.ts
+++ b/src/middleware/logger.ts
@@ -1,4 +1,7 @@
 import { randomUUID } from 'node:crypto';
+import { SANDBOX_LABEL_HEADER, sandboxLabel } from '../runtime/sandbox-label.ts';
+
+export { SANDBOX_LABEL_HEADER, sandboxLabel } from '../runtime/sandbox-label.ts';
 
 type RequestMeta = {
   startedAt: number;
@@ -34,8 +37,6 @@ export type RequestLoggerOptions = {
   log?: (entry: RequestLogEntry) => void;
   now?: () => number;
 };
-
-export const SANDBOX_LABEL_HEADER = 'X-Sandbox-Label';
 
 const REDACTED = '[REDACTED]';
 const sensitiveHeaders = new Set(['authorization', 'proxy-authorization']);
@@ -75,13 +76,6 @@ function responseStatus(responseValue: unknown, setStatus?: number | string): nu
 function requestLogFormat(): RequestLogFormat {
   const requested = process.env.LOG_FORMAT as RequestLogFormat | undefined;
   return requested && logFormats.has(requested) ? requested : 'nginx';
-}
-
-function sandboxLabel(env = process.env.ARRA_ENV): string {
-  const value = env?.trim().toLowerCase();
-  if (value === 'production') return 'prod';
-  if (value === 'staging') return 'staging';
-  return 'dev';
 }
 
 function formatDurationMs(durationMs: number): string {

--- a/src/middleware/request-logger.ts
+++ b/src/middleware/request-logger.ts
@@ -1,14 +1,25 @@
+import { randomUUID } from 'node:crypto';
 import { Elysia } from 'elysia';
+import { SANDBOX_LABEL_HEADER, sandboxLabel } from '../runtime/sandbox-label.ts';
 
 export type StructuredRequestLogEntry = {
+  event: 'http_request';
   method: string;
   path: string;
   status: number;
   durationMs: number;
   timestamp: string;
+  correlationId: string;
+  headers: Record<string, string>;
+  sandbox: string;
 };
 
-type RequestMeta = { startedAt: number };
+type RequestMeta = {
+  startedAt: number;
+  correlationId: string;
+  headers: Record<string, string>;
+  sandbox: string;
+};
 type LogSink = (entry: StructuredRequestLogEntry) => void;
 
 type RequestLoggingOptions = {
@@ -33,6 +44,22 @@ function requestPath(request: Request): string {
   }
 }
 
+const REDACTED = '[REDACTED]';
+const sensitiveHeaders = new Set(['authorization', 'proxy-authorization']);
+
+function redactHeaders(headers: Headers): Record<string, string> {
+  const redacted: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    const normalized = key.toLowerCase();
+    redacted[normalized] = sensitiveHeaders.has(normalized) ? REDACTED : value;
+  });
+  return redacted;
+}
+
+function requestCorrelationId(request: Request): string {
+  return request.headers.get('x-correlation-id') || request.headers.get('x-request-id') || randomUUID();
+}
+
 function responseStatus(response: unknown, setStatus: unknown): number {
   if (response instanceof Response) return response.status;
   if (typeof setStatus === 'number') return setStatus;
@@ -50,18 +77,28 @@ export function createRequestLoggingMiddleware(options: RequestLoggingOptions = 
   const log = options.log ?? ((entry: StructuredRequestLogEntry) => console.log(JSON.stringify(entry)));
 
   return new Elysia({ name: 'structured-request-logger' })
-    .onRequest(({ request }) => {
-      meta.set(request, { startedAt: now() });
+    .onRequest(({ request, set }) => {
+      const correlationId = requestCorrelationId(request);
+      const sandbox = sandboxLabel();
+      meta.set(request, { startedAt: now(), correlationId, headers: redactHeaders(request.headers), sandbox });
+      set.headers['X-Correlation-Id'] = correlationId;
+      set.headers[SANDBOX_LABEL_HEADER] = sandbox;
     })
     .onAfterResponse({ as: 'global' }, ({ request, responseValue, set }) => {
       const endedAt = now();
-      const startedAt = meta.get(request)?.startedAt ?? endedAt;
+      const requestMeta = meta.get(request);
+      const startedAt = requestMeta?.startedAt ?? endedAt;
+      set.headers[SANDBOX_LABEL_HEADER] = requestMeta?.sandbox ?? sandboxLabel();
       log({
+        event: 'http_request',
         method: request.method,
         path: requestPath(request),
         status: responseStatus(responseValue, set.status),
         durationMs: roundedDurationMs(startedAt, endedAt),
         timestamp: timestamp(),
+        correlationId: requestMeta?.correlationId ?? requestCorrelationId(request),
+        headers: requestMeta?.headers ?? redactHeaders(request.headers),
+        sandbox: requestMeta?.sandbox ?? sandboxLabel(),
       });
       meta.delete(request);
     });

--- a/src/routes/health/health.ts
+++ b/src/routes/health/health.ts
@@ -6,6 +6,7 @@ import { scanPlugins } from '../plugins/model.ts';
 import { readVectorBackendHealth } from '../../vector/health.ts';
 import { mcpTools } from '../../tools/mcp-manifest.ts';
 import type { UnifiedPluginStatus } from '../../plugins/unified-loader.ts';
+import { sandboxLabel } from '../../runtime/sandbox-label.ts';
 import pkg from '../../../package.json' with { type: 'json' };
 
 type VectorHealth = Awaited<ReturnType<typeof readVectorBackendHealth>>;
@@ -47,6 +48,7 @@ const HealthResponseSchema = t.Object({
   server: t.String(),
   version: t.String(),
   port: t.Optional(t.Number()),
+  sandbox: t.Optional(t.String()),
   oracle: t.Optional(t.Union([t.Literal('connected'), t.Literal('degraded')])),
   uptimeSeconds: t.Optional(t.Number()),
   dbStatus: t.Optional(t.Union([t.Literal('connected'), t.Literal('error')])),
@@ -149,6 +151,7 @@ export function createHealthEndpoint(options: HealthEndpointOptions = {}) {
         status: 'draining',
         server: MCP_SERVER_NAME,
         version: pkg.version,
+        sandbox: sandboxLabel(),
         draining: true,
       };
     }
@@ -167,6 +170,7 @@ export function createHealthEndpoint(options: HealthEndpointOptions = {}) {
       server: MCP_SERVER_NAME,
       version: pkg.version,
       port: Number(PORT),
+      sandbox: sandboxLabel(),
       uptime: serviceUptime,
       uptimeSeconds: serviceUptime,
       db: dbStatus.status,

--- a/src/routes/plugins/model.ts
+++ b/src/routes/plugins/model.ts
@@ -14,6 +14,7 @@ import {
   publicUnifiedServerManifest,
   type PublicUnifiedServerManifest,
 } from '../../plugins/unified-manifest.ts';
+import { resolveContainedPluginEntry } from '../../plugins/path-containment.ts';
 
 export const PLUGIN_DIR = join(homedir(), '.oracle', 'plugins');
 
@@ -105,6 +106,7 @@ export function readNestedPlugin(
   if (!manifest) return null;
 
   const server = serverEntry(manifest);
+  if (manifest.server && !server) return null;
   const base = {
     name: typeof manifest.name === 'string' && manifest.name ? manifest.name : entryName,
     version: typeof manifest.version === 'string' ? manifest.version : undefined,
@@ -122,11 +124,16 @@ export function readNestedPlugin(
 
   // Try manifest path as-is, then fall back to basename (plugins copied flat
   // by `arra-cli plugin install` keep the source path in manifest.wasm).
-  let wasmPath = join(dir, wasmName);
+  let wasmPath: string;
   let resolvedName = wasmName;
+  try {
+    wasmPath = resolveContainedPluginEntry(dir, wasmName);
+  } catch {
+    return null;
+  }
   if (!existsSync(wasmPath)) {
     const baseName = basename(wasmName);
-    const basePath = join(dir, baseName);
+    const basePath = resolveContainedPluginEntry(dir, baseName);
     if (!existsSync(basePath)) {
       if (!server) return null;
       const st = statSync(manifestPath);
@@ -161,9 +168,10 @@ export function resolveWasmPath(name: string): string | null {
     try {
       const manifest = JSON.parse(readFileSync(nestedManifest, 'utf8'));
       if (manifest.wasm && typeof manifest.wasm === 'string') {
-        const full = join(PLUGIN_DIR, name, manifest.wasm);
+        const pluginDir = join(PLUGIN_DIR, name);
+        const full = resolveContainedPluginEntry(pluginDir, manifest.wasm);
         if (existsSync(full)) return full;
-        const base = join(PLUGIN_DIR, name, basename(manifest.wasm));
+        const base = resolveContainedPluginEntry(pluginDir, basename(manifest.wasm));
         if (existsSync(base)) return base;
       }
     } catch {

--- a/src/runtime/sandbox-label.ts
+++ b/src/runtime/sandbox-label.ts
@@ -1,0 +1,8 @@
+export const SANDBOX_LABEL_HEADER = 'X-Sandbox-Label';
+
+export function sandboxLabel(env = process.env.ARRA_ENV): string {
+  const value = env?.trim().toLowerCase();
+  if (value === 'production') return 'prod';
+  if (value === 'staging') return 'staging';
+  return 'dev';
+}

--- a/tests/http/health/core-hardening.test.ts
+++ b/tests/http/health/core-hardening.test.ts
@@ -4,8 +4,10 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createApiVersionHeaderMiddleware, createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
-import { createRequestLogger, formatRequestLog, type RequestLogEntry } from '../../../src/middleware/logger.ts';
+import { formatRequestLog, type RequestLogEntry } from '../../../src/middleware/logger.ts';
+import { createRequestLoggingMiddleware, type StructuredRequestLogEntry } from '../../../src/middleware/request-logger.ts';
 import { loadUnifiedPlugins } from '../../../src/plugins/unified-loader.ts';
+import { readNestedPlugin } from '../../../src/routes/plugins/model.ts';
 import { createHealthRoutes } from '../../../src/routes/health/index.ts';
 
 const tmp = mkdtempSync(join(tmpdir(), 'arra-core-hardening-'));
@@ -37,36 +39,48 @@ function pluginDir(name: string, entry: string) {
   return dir;
 }
 
-test('core hardening keeps versioned health reachable, logs configurable, and rejects escaping plugin entries', async () => {
-  const oldFormat = process.env.LOG_FORMAT;
-  process.env.LOG_FORMAT = 'short';
-  const lines: string[] = [];
-  const logger = createRequestLogger({ now: () => 10, log: (entry) => lines.push(`${entry.status} ${entry.method} ${entry.path}`) });
+test('core hardening keeps versioned health reachable, logs JSON, and rejects escaping plugin entries', async () => {
+  const logs: StructuredRequestLogEntry[] = [];
+  const ticks = [10, 14.5];
   const app = new Elysia()
-    .onRequest(logger.onRequest)
-    .onAfterResponse(logger.onAfterResponse)
+    .use(createRequestLoggingMiddleware({
+      now: () => ticks.shift() ?? 14.5,
+      timestamp: () => '2026-06-16T00:00:00.000Z',
+      log: (entry) => logs.push(entry),
+    }))
     .use(createApiVersionHeaderMiddleware())
     .use(createHealthRoutes({ vectorHealth: async () => ({ status: 'ok', engines: [], checked_at: '2026-06-16T00:00:00.000Z' }) }));
   const fetcher = createApiVersionedFetch((request) => app.handle(request));
 
-  try {
-    const res = await fetcher(new Request('http://local/api/v1/health'));
-    const body = await res.json() as Record<string, unknown>;
-    expect(res.status).toBe(200);
-    expect(res.headers.get('location')).toBeNull();
-    expect(body).toMatchObject({ status: 'ok', db: 'connected' });
-    expect(typeof body.uptime).toBe('number');
-    expect(typeof body.version).toBe('string');
-    for (let i = 0; i < 20 && !lines[0]; i += 1) await Bun.sleep(5);
-    expect(lines[0]).toBe('200 GET /api/health');
-  } finally {
-    if (oldFormat === undefined) delete process.env.LOG_FORMAT;
-    else process.env.LOG_FORMAT = oldFormat;
-  }
+  const res = await fetcher(new Request('http://local/api/v1/health'));
+  const body = await res.json() as Record<string, unknown>;
+  expect(res.status).toBe(200);
+  expect(res.headers.get('location')).toBeNull();
+  expect(body).toMatchObject({ status: 'ok', db: 'connected', sandbox: 'dev' });
+  expect(typeof body.uptime).toBe('number');
+  expect(typeof body.version).toBe('string');
+  for (let i = 0; i < 20 && !logs[0]; i += 1) await Bun.sleep(5);
+  expect(logs[0]).toMatchObject({
+    event: 'http_request',
+    method: 'GET',
+    path: '/api/health',
+    status: 200,
+    sandbox: 'dev',
+  });
 
   const warnings: string[] = [];
   pluginDir('escape', '../outside.ts');
   const runtime = await loadUnifiedPlugins({ dirs: [tmp], warn: (message) => warnings.push(message) });
   expect(runtime.pluginCount).toBe(0);
   expect(warnings.join('\n')).toContain('plugin entry escapes plugin directory');
+
+  const legacyDir = join(tmp, 'legacy-escape');
+  mkdirSync(legacyDir, { recursive: true });
+  writeFileSync(join(tmp, 'outside.wasm'), 'not a real wasm');
+  writeFileSync(join(legacyDir, 'plugin.json'), JSON.stringify({
+    name: 'legacy-escape',
+    version: '1.0.0',
+    wasm: '../outside.wasm',
+  }));
+  expect(readNestedPlugin(legacyDir, 'legacy-escape')).toBeNull();
 });

--- a/tests/http/health/draining.test.ts
+++ b/tests/http/health/draining.test.ts
@@ -7,5 +7,5 @@ test('GET /api/health reports draining state before dependency checks', async ()
   const body = await res.json() as Record<string, unknown>;
 
   expect(res.status).toBe(503);
-  expect(body).toMatchObject({ status: 'draining', draining: true });
+  expect(body).toMatchObject({ status: 'draining', sandbox: 'dev', draining: true });
 });

--- a/tests/http/health/status.test.ts
+++ b/tests/http/health/status.test.ts
@@ -20,6 +20,7 @@ test('GET /api/health reports uptime, DB, vector, MCP, and plugin status', async
   const body = await res.json() as Record<string, any>;
 
   expect(body.status).toBe('ok');
+  expect(body.sandbox).toBe('dev');
   expect(body.uptime).toBe(42.125);
   expect(body.uptimeSeconds).toBe(42.125);
   expect(body.db).toBe('connected');

--- a/tests/http/logging/request-logger-middleware.test.ts
+++ b/tests/http/logging/request-logger-middleware.test.ts
@@ -14,6 +14,15 @@ async function waitForLog(logs: StructuredRequestLogEntry[]) {
   throw new Error('request log was not emitted');
 }
 
+async function waitForLine(lines: string[]) {
+  const deadline = Date.now() + 500;
+  while (Date.now() < deadline) {
+    if (lines[0]) return lines[0];
+    await Bun.sleep(5);
+  }
+  throw new Error('request log line was not emitted');
+}
+
 function app(logs: StructuredRequestLogEntry[], ticks = [10, 14.25]) {
   return new Elysia()
     .use(createRequestLoggingMiddleware({
@@ -29,18 +38,54 @@ function app(logs: StructuredRequestLogEntry[], ticks = [10, 14.25]) {
 }
 
 describe('structured request logging middleware', () => {
-  test('logs method, path, status, duration, and timestamp', async () => {
+  test('default sink emits a JSON request log line', async () => {
+    const original = console.log;
+    const lines: string[] = [];
+    console.log = (message?: unknown) => { lines.push(String(message)); };
+    try {
+      const res = await new Elysia()
+        .use(createRequestLoggingMiddleware({
+          now: () => 1,
+          timestamp: () => '2026-06-16T00:00:00.000Z',
+        }))
+        .get('/json-log', () => ({ ok: true }))
+        .fetch(new Request('http://local/json-log', { headers: { 'x-correlation-id': 'json-1' } }));
+
+      expect(res.status).toBe(200);
+      const entry = JSON.parse(await waitForLine(lines)) as StructuredRequestLogEntry;
+      expect(entry).toMatchObject({
+        event: 'http_request',
+        method: 'GET',
+        path: '/json-log',
+        status: 200,
+        correlationId: 'json-1',
+        sandbox: 'dev',
+      });
+    } finally {
+      console.log = original;
+    }
+  });
+
+  test('logs structured JSON request metadata with redacted headers', async () => {
     const logs: StructuredRequestLogEntry[] = [];
 
-    const res = await app(logs).fetch(new Request('http://local/ok?secret=hidden'));
+    const res = await app(logs).fetch(new Request('http://local/ok?secret=hidden', {
+      headers: { authorization: 'Bearer secret', 'x-correlation-id': 'req-1' },
+    }));
 
     expect(res.status).toBe(201);
-    expect(await waitForLog(logs)).toEqual({
+    expect(res.headers.get('x-correlation-id')).toBe('req-1');
+    expect(res.headers.get('x-sandbox-label')).toBe('dev');
+    expect(await waitForLog(logs)).toMatchObject({
+      event: 'http_request',
       method: 'GET',
       path: '/ok',
       status: 201,
       durationMs: 4.25,
       timestamp: '2026-06-16T00:00:00.000Z',
+      correlationId: 'req-1',
+      headers: { authorization: '[REDACTED]', 'x-correlation-id': 'req-1' },
+      sandbox: 'dev',
     });
   });
 
@@ -51,7 +96,7 @@ describe('structured request logging middleware', () => {
 
     expect(res.status).toBe(202);
     const entry = await waitForLog(logs);
-    expect(entry).toMatchObject({ method: 'GET', path: '/raw', status: 202 });
+    expect(entry).toMatchObject({ event: 'http_request', method: 'GET', path: '/raw', status: 202 });
     expect(entry.durationMs).toBeGreaterThanOrEqual(0);
   });
 });


### PR DESCRIPTION
## Summary
- Harden active server request logging so the default sink emits structured JSON request records with event, correlation ID, redacted headers, timestamp, status, duration, and sandbox label.
- Add `sandbox` to `/api/health` responses, including draining responses, using the same runtime sandbox label helper as request logging.
- Validate plugin manifest server fields and legacy wasm paths before listing/loading nested plugins, rejecting paths that escape the plugin directory.

## Validation
- `bunx tsc --noEmit`
- `bun test tests/http/health/` — 17 pass, 0 fail
- Adjacent: `bun test tests/http/logging/ tests/http/logger/ tests/http/plugins/model-invalid-server.test.ts tests/http/plugins/model-server-missing-wasm.test.ts tests/http/plugins/model-server-only.test.ts` — 9 pass, 0 fail
- File sizes under 250 lines for all PR files

Base: `alpha`
Feature commit: `4b24080`
Branch head: `48e935d`