### PR TITLE
test: add export app HTTP integration

### DIFF
--- a/src/routes/export/app.ts
+++ b/src/routes/export/app.ts
@@ -8,14 +8,14 @@ import { db as defaultDb, type DatabaseConnection } from '../../db/index.ts';
 import { introspectDrizzleTables } from '../../cli/commands/backup.ts';
 
 type ExportRecord = Record<string, unknown>;
-type ExportFormat = 'json' | 'csv' | 'markdown';
+type BaseExportFormat = 'json' | 'csv' | 'markdown';
+type ExportFormat = BaseExportFormat | 'jsonl';
 type DumpTable = ReturnType<typeof introspectDrizzleTables>[number];
 type QueryConnection = Pick<DatabaseConnection, 'db'>;
 
 interface ExportTools {
-  EXPORT_FORMATS: readonly ExportFormat[];
-  extensionFor(format: ExportFormat): string;
-  formatCollection(name: string, rows: ExportRecord[], format: ExportFormat): string;
+  extensionFor(format: BaseExportFormat): string;
+  formatCollection(name: string, rows: ExportRecord[], format: BaseExportFormat): string;
   normalizeRecords(rows: ExportRecord[]): ExportRecord[];
   graphRelationships(collections: Record<string, ExportRecord[]>): ExportRecord[];
 }
@@ -40,6 +40,7 @@ export interface ExportAppDeps {
   idGenerator?: () => string;
 }
 
+const APP_EXPORT_FORMATS = ['json', 'csv', 'markdown', 'jsonl'] as const;
 const formatsUrl = new URL('../../../tools/export-app/formats.ts', import.meta.url).href;
 const graphUrl = new URL('../../../tools/export-app/graph.ts', import.meta.url).href;
 
@@ -67,7 +68,24 @@ function safeName(value: string): string {
 function mimeType(format: ExportFormat): string {
   if (format === 'csv') return 'text/csv; charset=utf-8';
   if (format === 'markdown') return 'text/markdown; charset=utf-8';
+  if (format === 'jsonl') return 'application/x-ndjson; charset=utf-8';
   return 'application/json; charset=utf-8';
+}
+
+function isExportFormat(value: unknown): value is ExportFormat {
+  return typeof value === 'string' && APP_EXPORT_FORMATS.includes(value as ExportFormat);
+}
+
+function extensionFor(format: ExportFormat, tools: ExportTools): string {
+  return format === 'jsonl' ? 'jsonl' : tools.extensionFor(format);
+}
+
+function formatJsonl(rows: ExportRecord[]): string {
+  return rows.map((row) => JSON.stringify(row)).join('\n') + '\n';
+}
+
+function formatRows(name: string, rows: ExportRecord[], format: ExportFormat, tools: ExportTools): string {
+  return format === 'jsonl' ? formatJsonl(rows) : tools.formatCollection(name, rows, format);
 }
 
 function csvCell(value: unknown): string {
@@ -89,6 +107,10 @@ function attachGraph(content: string, format: ExportFormat, relationships: Expor
     payload.graph = { relationshipCount: relationships.length, relationships };
     return `${JSON.stringify(payload, null, 2)}\n`;
   }
+  if (format === 'jsonl') {
+    const graphRows = relationships.map((row) => JSON.stringify({ collection: 'relationships', ...row }));
+    return `${content}${graphRows.join('\n')}\n`;
+  }
   if (format === 'markdown') {
     const lines = ['# graph_relationships', '', `Rows: ${relationships.length}`, ''];
     relationships.forEach((row, index) => lines.push(`## relationship-${index + 1}`, '', `- **type**: ${row.type}`, `- **from**: ${row.from}`, `- **to**: ${row.to}`, `- **metadata**: \`${JSON.stringify(row.metadata ?? {})}\``, ''));
@@ -109,15 +131,14 @@ export function createExportAppRoutes(deps: ExportAppDeps = {}) {
         name,
         rowCount: selectRows(connection, table).length,
       }));
-      const tools = await loadExportTools();
-      return { collections, formats: tools.EXPORT_FORMATS, graph: { collection: 'relationships' } };
+      return { collections, formats: APP_EXPORT_FORMATS, graph: { collection: 'relationships' } };
     })
     .post('/export/app/run', async ({ body, set }) => {
       const tools = await loadExportTools();
-      const format = (body.format ?? 'json') as ExportFormat;
-      if (!tools.EXPORT_FORMATS.includes(format)) {
+      const format = body.format ?? 'json';
+      if (!isExportFormat(format)) {
         set.status = 400;
-        return { error: `Unsupported export format: ${format}`, formats: tools.EXPORT_FORMATS };
+        return { error: 'Invalid format', format, formats: APP_EXPORT_FORMATS };
       }
 
       const connection = connectionFrom(deps);
@@ -132,11 +153,15 @@ export function createExportAppRoutes(deps: ExportAppDeps = {}) {
       const collections = body.includeGraph || isGraph ? await allCollections(connection, tools) : {};
       const relationships = body.includeGraph || isGraph ? tools.graphRelationships(collections) : [];
       const rows = isGraph ? relationships : tools.normalizeRecords(selectRows(connection, table!));
-      const base = tools.formatCollection(body.collection, rows, format);
+      if (!isGraph && rows.length === 0) {
+        set.status = 404;
+        return { error: 'Collection is empty', collection: body.collection };
+      }
+      const base = formatRows(body.collection, rows, format, tools);
       const content = !isGraph && body.includeGraph ? attachGraph(base, format, relationships) : base;
       const jobId = deps.idGenerator?.() ?? randomUUID();
       const outputDir = deps.outputDir ?? path.join(ORACLE_DATA_DIR, 'export-app', 'http');
-      const filename = `${safeName(body.collection)}-${jobId}.${tools.extensionFor(format)}`;
+      const filename = `${safeName(body.collection)}-${jobId}.${extensionFor(format, tools)}`;
       const filePath = path.join(outputDir, filename);
       await mkdir(outputDir, { recursive: true });
       await writeFile(filePath, content, 'utf8');
@@ -158,7 +183,7 @@ export function createExportAppRoutes(deps: ExportAppDeps = {}) {
     }, {
       body: t.Object({
         collection: t.String(),
-        format: t.Optional(t.Union([t.Literal('json'), t.Literal('csv'), t.Literal('markdown')])),
+        format: t.Optional(t.String()),
         includeGraph: t.Optional(t.Boolean()),
       }),
     })

--- a/src/server.ts
+++ b/src/server.ts
@@ -203,7 +203,6 @@ const apiModules = [
   ...(indexerRoutes ? [indexerRoutes] : []),
   ...unifiedPlugins.routes,
 ];
-
 try {
   const result = seedMenuItems(apiModules as unknown as SeedHasRoutes[]);
   await seedUnifiedPluginMenuItems(unifiedPlugins.menu);

--- a/tests/http/export/app.test.ts
+++ b/tests/http/export/app.test.ts
@@ -85,7 +85,7 @@ describe('export app HTTP routes', () => {
 
     expect(res.status).toBe(200);
     expect(body.collections).toContainEqual(expect.objectContaining({ name: 'oracle_documents', rowCount: 2 }));
-    expect(body.formats).toEqual(['json', 'csv', 'markdown']);
+    expect(body.formats).toEqual(['json', 'csv', 'markdown', 'jsonl']);
     expect(body.graph).toEqual({ collection: 'relationships' });
   });
 

--- a/tests/http/export/integration.test.ts
+++ b/tests/http/export/integration.test.ts
@@ -1,0 +1,167 @@
+import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const savedRepoRoot = process.env.ORACLE_REPO_ROOT;
+const root = join(tmpdir(), `arra-export-http-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+const dbPath = join(root, 'oracle.db');
+mkdirSync(root, { recursive: true });
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = dbPath;
+process.env.ORACLE_REPO_ROOT = root;
+
+const dbMod = await import('../../../src/db/index.ts');
+dbMod.resetDefaultDatabaseForTests(dbPath);
+const { createLearnCrudRoutes } = await import('../../../src/routes/learn/index.ts');
+const { createExportAppRoutes } = await import('../../../src/routes/export/app.ts');
+
+const restoreDbPath = savedDbPath
+  ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
+
+const app = new Elysia({ prefix: '/api' })
+  .use(createLearnCrudRoutes())
+  .use(createExportAppRoutes());
+
+function request(method: string, path: string, body?: unknown): Promise<Response> {
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.headers = { 'content-type': 'application/json' };
+    init.body = JSON.stringify(body);
+  }
+  return createApiVersionedFetch((next) => app.handle(next))(new Request(`http://local${path}`, init));
+}
+
+async function createLearning(id: string, pattern: string): Promise<void> {
+  const res = await request('POST', '/api/v1/learn', {
+    id,
+    pattern,
+    concepts: ['export', id],
+    source: 'export-integration-test',
+    sourceFile: `psi/export/${id}.md`,
+  });
+  expect(res.status).toBe(200);
+}
+
+async function seedLearnings(): Promise<void> {
+  await createLearning('export-doc-alpha', 'Alpha export integration body');
+  await createLearning('export-doc-bravo', 'Bravo export integration body');
+}
+
+interface ExportJobResponse {
+  downloadUrl: string;
+  filename: string;
+  rowCount: number;
+  relationshipCount: number;
+}
+
+async function downloadExport(
+  collection: string,
+  format: string,
+  extra: Record<string, unknown> = {},
+): Promise<{ run: Response; job: ExportJobResponse; download: Response }> {
+  const run = await request('POST', '/api/v1/export/app/run', { collection, format, ...extra });
+  const job = await run.json() as ExportJobResponse;
+  const download = await request('GET', job.downloadUrl);
+  return { run, job, download };
+}
+
+function exportCollection(format: string, extra: Record<string, unknown> = {}) {
+  return downloadExport('learn_log', format, extra);
+}
+
+beforeEach(() => {
+  dbMod.db.delete(dbMod.learnLog).run();
+  dbMod.db.delete(dbMod.oracleDocuments).run();
+  dbMod.db.delete(dbMod.oracleMemories).run();
+  dbMod.sqlite.exec('DELETE FROM oracle_fts');
+});
+
+afterAll(() => {
+  if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = savedDataDir;
+  if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = savedDbPath;
+  if (savedRepoRoot === undefined) delete process.env.ORACLE_REPO_ROOT;
+  else process.env.ORACLE_REPO_ROOT = savedRepoRoot;
+  dbMod.resetDefaultDatabaseForTests(restoreDbPath);
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('POST /api/v1/export/app/run', () => {
+  test('exports API-created docs as JSON, CSV, Markdown, and JSONL downloads', async () => {
+    await seedLearnings();
+
+    const jsonExport = await exportCollection('json');
+    const json = await jsonExport.download.json() as { collection: string; rowCount: number; rows: Array<Record<string, unknown>> };
+    expect(jsonExport.run.status).toBe(200);
+    expect(jsonExport.download.headers.get('content-disposition')).toContain(jsonExport.job.filename);
+    expect(jsonExport.job.rowCount).toBe(2);
+    expect(json.collection).toBe('learn_log');
+    expect(json.rowCount).toBe(2);
+    expect(json.rows.map((row) => row.patternPreview)).toEqual(expect.arrayContaining([
+      'Alpha export integration body',
+      'Bravo export integration body',
+    ]));
+
+    const csvExport = await exportCollection('csv');
+    const csv = await csvExport.download.text();
+    expect(csvExport.download.status).toBe(200);
+    expect(csv.split('\n')[0]).toBe('id,title,content_preview,collection,created_at');
+    expect(csv).toContain('"Alpha export integration body"');
+    expect(csv).toContain('"Bravo export integration body"');
+
+    const markdown = await (await exportCollection('markdown')).download.text();
+    expect(markdown).toContain('# learn_log');
+    expect(markdown).toContain('Alpha export integration body');
+    expect(markdown).toContain('Bravo export integration body');
+
+    const jsonlExport = await exportCollection('jsonl');
+    const jsonl = await jsonlExport.download.text();
+    expect(jsonlExport.job.filename.endsWith('.jsonl')).toBe(true);
+    const lines = jsonl.trim().split('\n').map((line) => JSON.parse(line));
+    expect(lines).toHaveLength(2);
+    expect(lines.map((row) => row.patternPreview)).toContain('Alpha export integration body');
+  });
+
+  test('includes graph relationships when requested', async () => {
+    await seedLearnings();
+    const update = await request('PUT', '/api/v1/learn/export-doc-alpha', {
+      supersededBy: 'export-doc-bravo',
+      supersededReason: 'integration graph edge',
+    });
+    expect(update.status).toBe(200);
+
+    const { run, job, download } = await downloadExport('oracle_documents', 'json', { includeGraph: true });
+    const body = await download.json() as { graph: { relationships: Array<Record<string, unknown>> } };
+    expect(run.status).toBe(200);
+    expect(job.relationshipCount).toBeGreaterThanOrEqual(1);
+    expect(body.graph.relationships).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'document_superseded_by',
+        from: 'export-doc-alpha',
+        to: 'export-doc-bravo',
+      }),
+    ]));
+  });
+
+  test('returns errors for empty collection and invalid format', async () => {
+    const empty = await request('POST', '/api/v1/export/app/run', {
+      collection: 'oracle_memories',
+      format: 'json',
+    });
+    expect(empty.status).toBe(404);
+    expect(await empty.json()).toMatchObject({ error: 'Collection is empty', collection: 'oracle_memories' });
+
+    const invalid = await request('POST', '/api/v1/export/app/run', {
+      collection: 'learn_log',
+      format: 'yaml',
+    });
+    expect(invalid.status).toBe(400);
+    expect(await invalid.json()).toMatchObject({ error: 'Invalid format' });
+  });
+});


### PR DESCRIPTION
## Summary
- add end-to-end export app integration tests through the Elysia API flow
- cover JSON, CSV, Markdown, JSONL downloads, graph export, empty collection, and invalid format cases
- extend export app route support for JSONL plus explicit empty/invalid error responses

## Validation
- bun test tests/http/export/
- bunx tsc --noEmit
- file size check: changed files <= 250 lines