### PR TITLE
feat: add plugin status bento page

### DIFF
--- a/frontend/src/hooks/usePlugins.ts
+++ b/frontend/src/hooks/usePlugins.ts
@@ -1,0 +1,121 @@
+import { useCallback, useEffect, useState } from 'react';
+import { apiUrl } from '../api/oracle';
+import type { PluginEntry, PluginsResponse } from '../types';
+
+export const PLUGINS_ENDPOINT = '/api/v1/plugins';
+const EMPTY_PLUGINS: PluginEntry[] = [];
+
+export type PluginFetch = (input: RequestInfo | URL, init?: RequestInit) => Response | Promise<Response>;
+
+export interface UsePluginsOptions {
+  initialPlugins?: PluginEntry[];
+  initialLoading?: boolean;
+  endpoint?: string;
+  fetcher?: PluginFetch;
+}
+
+export interface UsePluginsResult {
+  plugins: PluginEntry[];
+  dir: string;
+  count: number;
+  loading: boolean;
+  error: string | null;
+  reload: () => void;
+}
+
+function messageFor(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function normalizePlugins(response: PluginsResponse): PluginsResponse {
+  const plugins = Array.isArray(response.plugins) ? response.plugins : [];
+  return {
+    dir: typeof response.dir === 'string' ? response.dir : '',
+    count: Number.isFinite(response.count) ? response.count : plugins.length,
+    plugins,
+  };
+}
+
+export async function fetchPluginsFromEndpoint({
+  endpoint = PLUGINS_ENDPOINT,
+  fetcher,
+}: {
+  endpoint?: string;
+  fetcher?: PluginFetch;
+} = {}): Promise<PluginsResponse> {
+  const request = fetcher ?? globalThis.fetch?.bind(globalThis);
+  if (!request) throw new Error(`${endpoint} is unreachable: fetch is unavailable`);
+
+  let response: Response;
+  try {
+    response = await request(apiUrl(endpoint), { headers: { accept: 'application/json' } });
+  } catch (error) {
+    throw new Error(`${endpoint} is unreachable: ${messageFor(error)}`);
+  }
+
+  const text = await response.text();
+  let payload: unknown = {};
+  try {
+    payload = text ? JSON.parse(text) : {};
+  } catch {
+    throw new Error(`${endpoint} returned invalid JSON`);
+  }
+
+  if (!response.ok) {
+    const detail = payload && typeof payload === 'object' && 'error' in payload ? String(payload.error) : response.statusText;
+    throw new Error(`${endpoint} returned ${response.status}${detail ? `: ${detail}` : ''}`);
+  }
+  return normalizePlugins(payload as PluginsResponse);
+}
+
+export function usePlugins({
+  initialPlugins = EMPTY_PLUGINS,
+  initialLoading = true,
+  endpoint = PLUGINS_ENDPOINT,
+  fetcher,
+}: UsePluginsOptions = {}): UsePluginsResult {
+  const [reloadKey, setReloadKey] = useState(0);
+  const reload = useCallback(() => setReloadKey((key) => key + 1), []);
+  const [result, setResult] = useState<Omit<UsePluginsResult, 'reload'>>({
+    plugins: initialPlugins,
+    dir: '',
+    count: initialPlugins.length,
+    loading: initialLoading,
+    error: null,
+  });
+
+  useEffect(() => {
+    if (initialLoading) return;
+    setResult((current) => ({
+      ...current,
+      plugins: initialPlugins,
+      count: initialPlugins.length,
+      loading: false,
+    }));
+  }, [initialLoading, initialPlugins]);
+
+  useEffect(() => {
+    let active = true;
+    setResult((current) => ({ ...current, loading: true, error: null }));
+    fetchPluginsFromEndpoint({ endpoint, fetcher })
+      .then((response) => {
+        if (!active) return;
+        setResult((current) => ({
+          ...current,
+          plugins: response.plugins,
+          dir: response.dir,
+          count: response.count ?? response.plugins.length,
+          loading: false,
+        }));
+      })
+      .catch((error) => {
+        if (!active) return;
+        setResult((current) => ({ ...current, loading: false, error: messageFor(error) }));
+      });
+    return () => {
+      active = false;
+    };
+  }, [endpoint, fetcher, reloadKey]);
+
+  return { ...result, reload };
+}

--- a/frontend/src/pages/PluginsPage.tsx
+++ b/frontend/src/pages/PluginsPage.tsx
@@ -1,27 +1,25 @@
-import { useEffect, useMemo, useState } from 'react';
-import { apiClient, type ApiClient } from '../api/client';
-import { setPluginEnabled } from '../api/plugin-admin';
+import { useMemo } from 'react';
 import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
-import { VectorSearchWidget } from '../components/VectorSearchWidget';
-import { pluginStatusLabel, isPluginEnabled, type PluginEnabledState } from '../components/PluginList';
+import { isPluginEnabled, pluginStatusLabel, type PluginEnabledState } from '../components/PluginList';
+import { PLUGINS_ENDPOINT, usePlugins, type PluginFetch } from '../hooks/usePlugins';
 import { surfacesFor } from '../plugin-surfaces';
 import type { PluginEntry } from '../types';
-import { UnifiedPluginSurfaceOverview } from './UnifiedPluginSurfaceOverview';
 
-type PageState = 'loading' | 'ready' | 'error';
-type PluginsClient = Pick<ApiClient, 'plugins'>;
-type PluginAction = 'install' | 'uninstall';
+const EMPTY_PLUGINS: PluginEntry[] = [];
+
+type Tone = 'ok' | 'warn' | 'bad' | 'idle';
 
 export interface PluginsPageProps {
   plugins?: PluginEntry[];
   loading?: boolean;
-  client?: PluginsClient;
+  endpoint?: string;
+  fetcher?: PluginFetch;
 }
 
 export function enabledStateForPlugins(plugins: PluginEntry[]): PluginEnabledState {
   return Object.fromEntries(plugins.map((plugin) => [
     plugin.name,
-    typeof plugin.enabled === 'boolean' ? plugin.enabled : plugin.status !== 'disabled',
+    plugin.enabled ?? plugin.status !== 'disabled',
   ]));
 }
 
@@ -31,218 +29,129 @@ export function pluginAdminSummary(plugins: PluginEntry[], enabledState: PluginE
   return `${enabled} enabled · ${disabled} disabled · ${plugins.length} registered`;
 }
 
-function pluginStatusClass(status: string): string {
-  if (status === 'ok') return 'border-emerald-300/30 bg-emerald-300/10 text-emerald-200';
-  if (status === 'disabled') return 'border-slate-300/30 bg-slate-900/70 text-slate-200';
-  return 'border-amber-300/30 bg-amber-300/10 text-amber-100';
+function toneClass(tone: Tone): string {
+  const tones: Record<Tone, string> = {
+    ok: 'border-emerald-300/30 bg-emerald-400/10 text-emerald-100',
+    warn: 'border-amber-300/30 bg-amber-400/10 text-amber-100',
+    bad: 'border-red-300/30 bg-red-400/10 text-red-100',
+    idle: 'border-slate-500/40 bg-slate-800 text-slate-200',
+  };
+  return tones[tone];
 }
 
-function surfaceClass(surface: string): string {
-  if (surface === 'server' || surface === 'proxy') return 'border-purple-300/30 bg-purple-300/10 text-purple-100';
-  if (surface === 'mcp' || surface === 'apiRoutes') return 'border-teal-300/30 bg-teal-300/10 text-teal-100';
-  return 'border-white/10 bg-slate-900/70 text-slate-200';
+function healthForPlugin(plugin: PluginEntry, enabled: boolean): { label: string; detail: string; tone: Tone } {
+  if (!enabled) return { label: 'inactive', detail: 'disabled in plugin state', tone: 'idle' };
+  if (plugin.error) return { label: 'unhealthy', detail: plugin.error, tone: 'bad' };
+  if (plugin.status === 'degraded') return { label: 'degraded', detail: 'reported by plugin manifest', tone: 'warn' };
+  if (plugin.status && plugin.status !== 'ok') {
+    return { label: plugin.status, detail: plugin.server?.healthPath ?? 'reported by plugin manifest', tone: 'warn' };
+  }
+  return { label: 'healthy', detail: plugin.server?.healthPath ?? 'manifest ok', tone: 'ok' };
 }
 
-function PluginsCards({
-  plugins,
-  enabledState,
-  onToggle,
-  pending,
-  selected,
-  onSelect,
-}: {
-  plugins: PluginEntry[];
-  enabledState: PluginEnabledState;
-  onToggle: (name: string, enabled: boolean) => void;
-  pending: string | null;
-  selected: string | null;
-  onSelect: (plugin: PluginEntry) => void;
-}) {
-  if (!plugins.length) return <p className="text-sm text-slate-400">No plugins are registered.</p>;
+function Pill({ children, tone = 'idle' }: { children: string; tone?: Tone }) {
+  return <span className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${toneClass(tone)}`}>{children}</span>;
+}
 
+function MetricCard({ label, value, detail, tone = 'idle' }: { label: string; value: string | number; detail: string; tone?: Tone }) {
   return (
-    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-      {plugins.map((plugin) => {
-        const enabled = isPluginEnabled(plugin, enabledState);
-        const status = pluginStatusLabel(plugin, enabled);
-        const surfaces = surfacesFor(plugin);
-        return (
-          <article key={plugin.name} className={`rounded-3xl border bg-slate-950/70 p-4 sm:p-5 ${selected === plugin.name ? 'border-teal-300/50 shadow-lg shadow-teal-950/20' : 'border-white/10'}`}> 
-            <div className="mb-3 flex items-start justify-between gap-3">
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Plugin</p>
-                <h3 className="mt-1 text-lg font-semibold text-white">{plugin.name}</h3>
-              </div>
-              <span className={`inline-flex rounded-full border px-2 py-1 text-xs font-semibold ${pluginStatusClass(status)}`}>
-                {status}
-              </span>
-            </div>
+    <article className={`rounded-lg border p-4 ${toneClass(tone)}`}>
+      <p className="text-xs font-semibold uppercase tracking-[0.18em] opacity-80">{label}</p>
+      <p className="mt-2 text-2xl font-semibold">{value}</p>
+      <p className="mt-1 text-sm opacity-75">{detail}</p>
+    </article>
+  );
+}
 
-            <p className="text-sm text-slate-300">{plugin.description ?? 'No description supplied.'}</p>
-
-            <div className="mt-4 flex flex-wrap gap-2" aria-label={`${plugin.name} surfaces`}>
-              {surfaces.length ? surfaces.map((surface) => (
-                <span key={surface} className={`rounded-full border px-2 py-1 text-xs ${surfaceClass(surface)}`}>{surface}</span>
-              )) : <span className="rounded-full border border-white/10 px-2 py-1 text-xs text-slate-400">metadata</span>}
-            </div>
-
-            <dl className="mt-4 grid gap-3 text-sm">
-              <div>
-                <dt className="text-slate-500">Version</dt>
-                <dd className="font-mono text-slate-100">{plugin.version ?? 'unknown'}</dd>
-              </div>
-              <div>
-                <dt className="text-slate-500">Artifact</dt>
-                <dd className="font-mono text-slate-100">{plugin.file || 'server-only'}</dd>
-              </div>
-              <div>
-                <dt className="text-slate-500">Surfaces</dt>
-                <dd className="text-slate-200">{surfaces.length ? surfaces.join(', ') : 'metadata'}</dd>
-              </div>
-            </dl>
-
-            <div className="mt-4 flex flex-wrap justify-end gap-2">
-              <button
-                className="focus-ring rounded-lg border border-white/10 px-3 py-2 text-sm font-semibold text-slate-100 transition hover:bg-white/5"
-                type="button"
-                onClick={() => onSelect(plugin)}
-              >
-                Status panel
-              </button>
-              <button
-                aria-label={`${enabled ? 'Uninstall' : 'Install'} ${plugin.name}`}
-                aria-pressed={enabled}
-                className="focus-ring rounded-lg border border-teal-300/30 px-3 py-2 text-sm font-semibold text-teal-100 transition hover:bg-teal-300/10 disabled:cursor-not-allowed disabled:opacity-50"
-                disabled={pending === plugin.name}
-                type="button"
-                onClick={() => onToggle(plugin.name, !enabled)}
-              >
-                {pending === plugin.name ? 'Saving…' : enabled ? 'Uninstall' : 'Install'}
-              </button>
-            </div>
-          </article>
-        );
-      })}
+function Detail({ label, value, detail }: { label: string; value: string; detail?: string }) {
+  return (
+    <div>
+      <dt className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">{label}</dt>
+      <dd className="mt-1 font-mono text-sm text-slate-100">{value}</dd>
+      {detail ? <dd className="mt-1 text-xs text-slate-500">{detail}</dd> : null}
     </div>
   );
 }
 
-function pluginActionMessage(name: string, action: PluginAction): string {
-  return action === 'install'
-    ? `${name} installed/enabled; reload may be required for runtime surfaces.`
-    : `${name} uninstalled/disabled from active UI surfaces; manifest remains on disk.`;
-}
-
-function PluginStatusPanel({ plugin, enabled }: { plugin: PluginEntry | null; enabled: boolean }) {
-  if (!plugin) return <p className="text-sm text-slate-400">Select a plugin card to inspect surfaces and status.</p>;
+function PluginCard({ plugin, enabled }: { plugin: PluginEntry; enabled: boolean }) {
+  const health = healthForPlugin(plugin, enabled);
   const surfaces = surfacesFor(plugin);
+  const status = enabled ? 'active' : 'inactive';
+
   return (
-    <article className="grid gap-4 rounded-3xl border border-white/10 bg-slate-950/70 p-5" aria-label="Per-plugin status panel">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-        <div><p className="text-xs font-semibold uppercase tracking-[0.2em] text-purple-300">Status panel</p><h3 className="mt-1 text-xl font-semibold text-white">{plugin.name}</h3></div>
-        <span className={`rounded-full border px-2 py-1 text-xs ${pluginStatusClass(pluginStatusLabel(plugin, enabled))}`}>{pluginStatusLabel(plugin, enabled)}</span>
+    <article className="rounded-lg border border-white/10 bg-slate-950/70 p-5">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-white">{plugin.name}</h2>
+          <p className="mt-1 text-sm text-slate-400">{plugin.description ?? 'Installed plugin manifest.'}</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Pill tone={enabled ? 'ok' : 'idle'}>{status}</Pill>
+          <Pill tone={health.tone}>{health.label}</Pill>
+        </div>
       </div>
-      <p className="text-sm text-slate-300">{plugin.description ?? 'No plugin description provided.'}</p>
-      <dl className="grid gap-3 text-sm sm:grid-cols-2">
-        <div><dt className="text-slate-500">Version</dt><dd className="font-mono text-slate-100">{plugin.version ?? 'unknown'}</dd></div>
-        <div><dt className="text-slate-500">Artifact</dt><dd className="font-mono text-slate-100">{plugin.file || 'server-only'}</dd></div>
-        <div><dt className="text-slate-500">Server</dt><dd className="font-mono text-slate-100">{plugin.server?.healthPath ?? 'none'}</dd></div>
-        <div><dt className="text-slate-500">Menu</dt><dd className="font-mono text-slate-100">{plugin.menu?.path ?? 'none'}</dd></div>
+
+      <dl className="mt-5 grid gap-4 sm:grid-cols-3">
+        <Detail label="Status" value={status} detail={pluginStatusLabel(plugin, enabled)} />
+        <Detail label="Version" value={plugin.version ?? 'unknown'} />
+        <Detail label="Health" value={health.label} detail={health.detail} />
       </dl>
-      <div className="grid gap-2">
-        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Unified surfaces</p>
-        <div className="flex flex-wrap gap-2">{surfaces.length ? surfaces.map((surface) => <span key={surface} className={`rounded-full border px-2 py-1 text-xs ${surfaceClass(surface)}`}>{surface}</span>) : <span className="text-sm text-slate-400">metadata only</span>}</div>
+
+      <div className="mt-5 flex flex-wrap gap-2">
+        {surfaces.length ? surfaces.map((surface) => <Pill key={surface}>{surface}</Pill>) : <Pill>metadata</Pill>}
       </div>
     </article>
   );
 }
 
-export function PluginsPage({ plugins: initialPlugins = [], loading = true, client = apiClient }: PluginsPageProps) {
-  const [plugins, setPlugins] = useState(initialPlugins);
-  const [state, setState] = useState<PageState>(loading ? 'loading' : 'ready');
-  const [error, setError] = useState('');
-  const [actionMessage, setActionMessage] = useState('');
-  const [pendingPlugin, setPendingPlugin] = useState<string | null>(null);
-  const [enabledState, setEnabledState] = useState<PluginEnabledState>(() => enabledStateForPlugins(initialPlugins));
-  const [selectedPlugin, setSelectedPlugin] = useState<string | null>(initialPlugins[0]?.name ?? null);
-
-  useEffect(() => {
-    let cancelled = false;
-    setState('loading');
-    setError('');
-    client.plugins()
-      .then((response) => {
-        if (cancelled) return;
-        setPlugins(response.plugins);
-        setEnabledState(enabledStateForPlugins(response.plugins));
-        setSelectedPlugin((current) => current ?? response.plugins[0]?.name ?? null);
-        setState('ready');
-      })
-      .catch((cause) => {
-        if (cancelled) return;
-        setError(cause instanceof Error ? cause.message : String(cause));
-        setState(initialPlugins.length ? 'ready' : 'error');
-      });
-    return () => { cancelled = true; };
-  }, [client]);
-
+export function PluginsPage({
+  plugins: initialPlugins = EMPTY_PLUGINS,
+  loading = false,
+  endpoint = PLUGINS_ENDPOINT,
+  fetcher,
+}: PluginsPageProps) {
+  const initialLoading = loading || initialPlugins.length === 0;
+  const { plugins, loading: fetching, error } = usePlugins({ initialPlugins, initialLoading, endpoint, fetcher });
+  const enabledState = useMemo(() => enabledStateForPlugins(plugins), [plugins]);
   const summary = useMemo(() => pluginAdminSummary(plugins, enabledState), [plugins, enabledState]);
-  const selected = useMemo(() => plugins.find((plugin) => plugin.name === selectedPlugin) ?? plugins[0] ?? null, [plugins, selectedPlugin]);
-  const surfaceCount = useMemo(() => plugins.reduce((total, plugin) => total + Math.max(1, surfacesFor(plugin).length), 0), [plugins]);
-  const isLoading = state === 'loading';
-
-  async function togglePlugin(name: string, enabled: boolean) {
-    setPendingPlugin(name);
-    setActionMessage('');
-    try {
-      const response = await setPluginEnabled(name, enabled);
-      setEnabledState((current) => ({ ...current, [name]: response.enabled }));
-      setActionMessage(`${pluginActionMessage(name, enabled ? 'install' : 'uninstall')} ${response.message}`);
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
-    } finally {
-      setPendingPlugin(null);
-    }
-  }
+  const metrics = useMemo(() => {
+    const active = plugins.filter((plugin) => isPluginEnabled(plugin, enabledState)).length;
+    const unhealthy = plugins.filter((plugin) => healthForPlugin(plugin, isPluginEnabled(plugin, enabledState)).tone === 'bad').length;
+    return { active, inactive: plugins.length - active, unhealthy };
+  }, [plugins, enabledState]);
+  const showInventory = plugins.length > 0 || !fetching;
 
   return (
-    <div className="grid gap-5">
-      <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="plugins-page-title">
-        <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Plugin admin</p>
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Plugin list</p>
-            <h2 id="plugins-page-title" className="mt-2 text-2xl font-semibold text-white">Registered plugins</h2>
-            <p className="mt-2 text-sm text-slate-400">Canvas view for unified backend surfaces from GET /api/plugins, with install/uninstall controls.</p>
-          </div>
-          <div className="flex flex-wrap gap-2"><p className="rounded-full border border-white/10 px-3 py-2 text-sm text-slate-300">{summary}</p><p className="rounded-full border border-white/10 px-3 py-2 text-sm text-slate-300">{surfaceCount} surfaces</p></div>
+    <section className="grid gap-5" aria-labelledby="plugins-page-title">
+      <header>
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Plugin list</p>
+        <h1 id="plugins-page-title" className="mt-2 text-3xl font-semibold text-white">Installed plugin status</h1>
+        <p className="mt-2 text-sm text-slate-400">Live installed plugin inventory from GET {endpoint}.</p>
+      </header>
+
+      {fetching ? <LoadingPanel title="Loading plugins…" detail={`Fetching ${endpoint} and plugin health metadata.`} /> : null}
+      {error ? <ErrorMessage title="Could not load plugins." message={error} /> : null}
+
+      {showInventory ? (
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <MetricCard label="Installed" value={plugins.length} detail={summary} />
+          <MetricCard label="Active" value={metrics.active} detail="ready to serve surfaces" tone="ok" />
+          <MetricCard label="Inactive" value={metrics.inactive} detail="disabled or unavailable" />
+          <MetricCard label="Health" value={metrics.unhealthy ? `${metrics.unhealthy} alert` : 'ok'} detail="manifest and server signal" tone={metrics.unhealthy ? 'bad' : 'ok'} />
         </div>
-        {isLoading ? <LoadingPanel title="Loading plugins…" detail="Fetching /api/plugins and plugin server manifests." /> : null}
-        {state === 'error' ? <ErrorMessage title="Could not load plugins." message={error} /> : null}
-        {state !== 'error' && error ? <ErrorMessage title="Plugin action failed." message={error} /> : null}
-        {actionMessage ? <p className="mt-3 text-sm text-amber-200">{actionMessage}</p> : null}
-      </section>
+      ) : null}
 
-      {isLoading || state === 'error' ? null : <UnifiedPluginSurfaceOverview plugins={plugins} />}
-
-      {isLoading || state === 'error' ? null : <VectorSearchWidget />}
-
-      {isLoading || state === 'error' ? null : (
-        <section className="grid gap-5 xl:grid-cols-[minmax(0,1.5fr)_minmax(320px,0.8fr)]">
-          <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-label="Plugin canvas list">
-            <div className="mb-4"><p className="text-xs font-semibold uppercase tracking-[0.2em] text-teal-300">Canvas plugin list</p><h3 className="mt-2 text-xl font-semibold text-white">Backend surfaces</h3></div>
-            <PluginsCards
-              plugins={plugins}
-              enabledState={enabledState}
-              onToggle={(name, enabled) => void togglePlugin(name, enabled)}
-              pending={pendingPlugin}
-              selected={selectedPlugin}
-              onSelect={(plugin) => setSelectedPlugin(plugin.name)}
-            />
-          </section>
-          <PluginStatusPanel plugin={selected} enabled={selected ? isPluginEnabled(selected, enabledState) : false} />
-        </section>
-      )}
-    </div>
+      {plugins.length ? (
+        <div className="grid gap-4 xl:grid-cols-2">
+          {plugins.map((plugin) => (
+            <PluginCard key={plugin.name} plugin={plugin} enabled={isPluginEnabled(plugin, enabledState)} />
+          ))}
+        </div>
+      ) : showInventory ? (
+        <p className="rounded-lg border border-white/10 bg-slate-950/70 p-5 text-sm text-slate-400">
+          No installed plugins returned by {endpoint}.
+        </p>
+      ) : null}
+    </section>
   );
 }

--- a/tests/frontend/pages/frontend-component-coverage.test.tsx
+++ b/tests/frontend/pages/frontend-component-coverage.test.tsx
@@ -5,7 +5,7 @@ import { VectorHealthDashboardCard } from '../../../frontend/src/pages/vector-da
 import { htmlFor } from '../_render';
 
 describe('frontend component coverage', () => {
-  test('renders plugin admin surfaces and selected status panel', () => {
+  test('renders plugin status bento details', () => {
     const html = htmlFor(<PluginsPage plugins={[{
       name: 'hermes',
       file: 'hermes.json',
@@ -22,10 +22,11 @@ describe('frontend component coverage', () => {
     }]} loading={false} />);
 
     expect(html).toContain('1 enabled · 0 disabled · 1 registered');
-    expect(html).toContain('Plugin system map');
-    expect(html).toContain('hermes api GET /api/plugins/hermes/ping');
-    expect(html).toContain('/api/plugins/hermes/server');
-    expect(html).toContain('Per-plugin status panel');
+    expect(html).toContain('Installed plugin status');
+    expect(html).toContain('active');
+    expect(html).toContain('2.0.0');
+    expect(html).toContain('apiRoutes');
+    expect(html).toContain('proxy');
     expect(html).toContain('/health');
   });
 

--- a/tests/frontend/pages/plugins-page-admin.test.tsx
+++ b/tests/frontend/pages/plugins-page-admin.test.tsx
@@ -3,16 +3,15 @@ import { PluginsPage, enabledStateForPlugins, pluginAdminSummary } from '../../.
 import { htmlFor } from '../_render';
 
 describe('PluginsPage admin view', () => {
-  test('renders version status and toggle controls for registered plugins', () => {
+  test('renders version status and health for installed plugins', () => {
     const plugins = [{ name: 'canvas', file: '', size: 0, modified: 'now', version: '1.2.3', status: 'ok' }];
     const html = htmlFor(<PluginsPage plugins={plugins} loading={false} />);
 
     expect(pluginAdminSummary(plugins, enabledStateForPlugins(plugins))).toBe('1 enabled · 0 disabled · 1 registered');
-    expect(html).toContain('GET /api/plugins');
+    expect(html).toContain('GET /api/v1/plugins');
     expect(html).toContain('canvas');
     expect(html).toContain('1.2.3');
-    expect(html).toContain('ok');
-    expect(html).toContain('Uninstall canvas');
-    expect(html).toContain('Vector search');
+    expect(html).toContain('active');
+    expect(html).toContain('healthy');
   });
 });


### PR DESCRIPTION
## Summary
- Add usePlugins hook fetching GET /api/v1/plugins.
- Replace the plugin page with installed-plugin bento cards for active/inactive status, version, and health.
- Update frontend page coverage for the new status UI.

## Validation
- bunx tsc --noEmit
- bun test tests/frontend/pages/plugins-page-admin.test.tsx tests/frontend/pages/plugins-page-ready.test.tsx tests/frontend/pages/plugins-page-loading.test.tsx tests/frontend/pages/frontend-component-coverage.test.tsx
- wc -l changed files: all <= 250 lines