### PR TITLE
feat: add vector collection management API

### DIFF
--- a/src/routes/vector/collections.ts
+++ b/src/routes/vector/collections.ts
@@ -1,0 +1,157 @@
+import { Elysia, t } from 'elysia';
+import { reloadCachedVectorStores } from '../../vector/factory.ts';
+import { configToModels, type VectorServerConfig } from '../../vector/config.ts';
+import {
+  activeConfig,
+  atomicWriteVectorConfig,
+  normalizedCreate,
+  resolveCollection,
+  withPrimary,
+  withoutCollection,
+} from './config-api-utils.ts';
+
+const adapterSchema = t.Union([
+  t.Literal('chroma'),
+  t.Literal('sqlite-vec'),
+  t.Literal('lancedb'),
+  t.Literal('qdrant'),
+  t.Literal('cloudflare-vectorize'),
+  t.Literal('proxy'),
+]);
+
+const createSchema = t.Object({
+  name: t.String({ minLength: 1 }),
+  collection: t.Optional(t.String()),
+  adapter: t.Optional(adapterSchema),
+  model: t.String({ minLength: 1 }),
+  provider: t.Optional(t.String()),
+  service: t.Optional(t.String()),
+  endpoint: t.Optional(t.String()),
+  enabled: t.Optional(t.Boolean()),
+  primary: t.Optional(t.Boolean()),
+  embedder: t.Optional(t.Any()),
+});
+
+const renameSchema = t.Object({
+  name: t.Optional(t.String({ minLength: 1 })),
+  newName: t.Optional(t.String({ minLength: 1 })),
+});
+
+type RenameBody = { name?: string; newName?: string };
+
+function cleanName(value: string | undefined): string | { error: string } {
+  const name = value?.trim();
+  if (!name) return { error: 'name must be a non-empty string' };
+  return name;
+}
+
+async function persistConfig(config: VectorServerConfig) {
+  const path = atomicWriteVectorConfig(config);
+  await reloadCachedVectorStores(configToModels(config));
+  return path;
+}
+
+function collectionConflict(config: VectorServerConfig, name: string, except?: string): boolean {
+  const match = resolveCollection(config, name);
+  return Boolean(match && match[0] !== except);
+}
+
+function renamedConfig(config: VectorServerConfig, from: string, to: string): VectorServerConfig {
+  return {
+    ...config,
+    collections: Object.fromEntries(Object.entries(config.collections).map(([key, value]) => (
+      key === from ? [to, value] : [key, value]
+    ))),
+  };
+}
+
+export const vectorCollectionsEndpoint = new Elysia()
+  .post('/vector/collections', async ({ body, set }) => {
+    const name = cleanName(body.name);
+    if (typeof name !== 'string') {
+      set.status = 400;
+      return { success: false, error: name.error };
+    }
+
+    const { source, config } = activeConfig();
+    if (collectionConflict(config, name)) {
+      set.status = 409;
+      return { success: false, error: `Vector collection already exists: ${name}` };
+    }
+
+    const created = normalizedCreate(name, body);
+    if ('error' in created) {
+      set.status = 400;
+      return { success: false, error: created.error };
+    }
+    if (collectionConflict(config, created.collection)) {
+      set.status = 409;
+      return { success: false, error: `Vector collection already exists: ${created.collection}` };
+    }
+
+    const nextBase: VectorServerConfig = {
+      ...config,
+      collections: { ...config.collections, [name]: created },
+    };
+    const next = created.primary ? withPrimary(nextBase, name) : nextBase;
+    const path = await persistConfig(next);
+    set.status = 201;
+    return { success: true, reloaded: true, source, path, collection: name, config: next };
+  }, {
+    body: createSchema,
+    detail: { tags: ['vector'], summary: 'Create a vector collection config' },
+  })
+  .delete('/vector/collections/:name', async ({ params, set }) => {
+    const { source, config } = activeConfig();
+    const resolved = resolveCollection(config, params.name);
+    if (!resolved) {
+      set.status = 404;
+      return { success: false, error: `Vector collection not found: ${params.name}` };
+    }
+
+    const [key] = resolved;
+    const next = withoutCollection(config, key);
+    const path = await persistConfig(next);
+    return { success: true, reloaded: true, source, path, removed: key, config: next };
+  }, {
+    params: t.Object({ name: t.String({ minLength: 1 }) }),
+    detail: { tags: ['vector'], summary: 'Delete a vector collection config' },
+  })
+  .patch('/vector/collections/:name', async ({ params, body, set }) => {
+    const nextName = cleanName((body as RenameBody).newName ?? (body as RenameBody).name);
+    if (typeof nextName !== 'string') {
+      set.status = 400;
+      return { success: false, error: nextName.error };
+    }
+
+    const { source, config } = activeConfig();
+    const resolved = resolveCollection(config, params.name);
+    if (!resolved) {
+      set.status = 404;
+      return { success: false, error: `Vector collection not found: ${params.name}` };
+    }
+
+    const [key] = resolved;
+    if (collectionConflict(config, nextName, key)) {
+      set.status = 409;
+      return { success: false, error: `Vector collection already exists: ${nextName}` };
+    }
+
+    const next = key === nextName ? config : renamedConfig(config, key, nextName);
+    const path = await persistConfig(next);
+    return {
+      success: true,
+      reloaded: true,
+      source,
+      path,
+      collection: nextName,
+      renamed: { from: key, to: nextName },
+      config: next,
+    };
+  }, {
+    params: t.Object({ name: t.String({ minLength: 1 }) }),
+    body: renameSchema,
+    detail: { tags: ['vector'], summary: 'Rename a vector collection config key' },
+  });
+
+export const vectorCollectionsRoutes = new Elysia({ prefix: '/api' }).use(vectorCollectionsEndpoint);

--- a/src/routes/vector/index.ts
+++ b/src/routes/vector/index.ts
@@ -39,6 +39,7 @@ import { vectorProvidersEndpoint } from './providers.ts';
 import { vectorCostEndpoint } from './cost.ts';
 import { vectorCostsEndpoint } from './costs.ts';
 import { vectorConfigApiEndpoint } from './config-api.ts';
+import { vectorCollectionsEndpoint } from './collections.ts';
 
 export const vectorRoutes = new Elysia({ prefix: '/api' })
   .use(vectorProxyEndpoint)
@@ -56,5 +57,6 @@ export const vectorRoutes = new Elysia({ prefix: '/api' })
   .use(vectorCostEndpoint)
   .use(vectorCostsEndpoint)
   .use(vectorConfigApiEndpoint)
+  .use(vectorCollectionsEndpoint)
   .use(vectorServicesApiEndpoint)
   .use(vectorIndexerEndpoints);

--- a/tests/http/vector/collections.test.ts
+++ b/tests/http/vector/collections.test.ts
@@ -1,0 +1,109 @@
+import { afterAll, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const root = mkdtempSync(join(tmpdir(), 'vector-collections-api-'));
+process.env.ORACLE_DATA_DIR = root;
+
+const vectorConfig = await import('../../../src/vector/config.ts');
+const { vectorCollectionsRoutes } = await import('../../../src/routes/vector/collections.ts');
+const versionedFetch = createApiVersionedFetch((request) => vectorCollectionsRoutes.handle(request));
+
+function seedConfig() {
+  const config = vectorConfig.generateDefaultConfig();
+  config.dataPath = join(root, 'lance');
+  config.collections = {
+    phase1: {
+      collection: 'phase1_collection',
+      model: 'phase1-model',
+      provider: 'none',
+      adapter: 'lancedb',
+      primary: true,
+    },
+  };
+  vectorConfig.writeVectorConfig(config, vectorConfig.configPath(root));
+  return config;
+}
+
+async function call(path: string, init: RequestInit = {}) {
+  const res = await versionedFetch(new Request(`http://local${path}`, init));
+  const text = await res.text();
+  return { status: res.status, body: text ? JSON.parse(text) : null };
+}
+
+afterAll(() => {
+  if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = savedDataDir;
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('POST, PATCH, and DELETE /api/v1/vector/collections manage vector config collections', async () => {
+  seedConfig();
+
+  const createRes = await call('/api/v1/vector/collections', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      name: 'phase2',
+      collection: 'phase2_collection',
+      model: 'phase2-model',
+      provider: 'none',
+      primary: true,
+      embedder: { backend: 'none' },
+    }),
+  });
+  expect(createRes.status).toBe(201);
+  expect(createRes.body).toMatchObject({ success: true, reloaded: true, collection: 'phase2' });
+  expect(createRes.body.config.collections.phase2).toMatchObject({
+    collection: 'phase2_collection',
+    model: 'phase2-model',
+    provider: 'none',
+    adapter: 'lancedb',
+    primary: true,
+  });
+  expect(createRes.body.config.collections.phase1.primary).toBe(false);
+
+  const duplicateRes = await call('/api/v1/vector/collections', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ name: 'phase2', model: 'dup-model' }),
+  });
+  expect(duplicateRes.status).toBe(409);
+
+  const renameRes = await call('/api/v1/vector/collections/phase2', {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ name: 'phase-renamed' }),
+  });
+  expect(renameRes.status).toBe(200);
+  expect(renameRes.body.renamed).toEqual({ from: 'phase2', to: 'phase-renamed' });
+  expect(renameRes.body.config.collections.phase2).toBeUndefined();
+  expect(renameRes.body.config.collections['phase-renamed']).toMatchObject({
+    collection: 'phase2_collection',
+    model: 'phase2-model',
+    primary: true,
+  });
+
+  const conflictRes = await call('/api/v1/vector/collections/phase-renamed', {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ newName: 'phase1' }),
+  });
+  expect(conflictRes.status).toBe(409);
+
+  const persistedAfterRename = vectorConfig.loadVectorConfig(vectorConfig.configPath(root));
+  expect(persistedAfterRename?.collections['phase-renamed'].collection).toBe('phase2_collection');
+  expect(persistedAfterRename?.collections.phase2).toBeUndefined();
+
+  const deleteRes = await call('/api/v1/vector/collections/phase2_collection', { method: 'DELETE' });
+  expect(deleteRes.status).toBe(200);
+  expect(deleteRes.body.removed).toBe('phase-renamed');
+  expect(deleteRes.body.config.collections['phase-renamed']).toBeUndefined();
+  expect(deleteRes.body.config.collections.phase1.primary).toBe(true);
+
+  const missingDelete = await call('/api/v1/vector/collections/missing', { method: 'DELETE' });
+  expect(missingDelete.status).toBe(404);
+});


### PR DESCRIPTION
## Summary
- Add /api/v1/vector/collections create, delete, and rename endpoints backed by vector-server config
- Mount the collection management route in the vector route cluster
- Add HTTP coverage for create, duplicate conflict, rename conflict, delete by physical collection name, and persistence

## Verification
- bunx tsc --noEmit
- bun test tests/http/vector/
- wc -l src/routes/vector/collections.ts tests/http/vector/collections.test.ts src/routes/vector/index.ts