### PR TITLE
feat: add export import endpoint

### DIFF
--- a/src/routes/export/import.ts
+++ b/src/routes/export/import.ts
@@ -1,0 +1,220 @@
+/** POST /api/export/import - restore exported JSON/JSONL rows into a vector collection. */
+import { Elysia } from 'elysia';
+import { getEmbeddingModels, getVectorStoreByModel } from '../../vector/factory.ts';
+import type { VectorDocument, VectorStoreAdapter } from '../../vector/types.ts';
+
+type ImportFormat = 'json' | 'jsonl';
+type ImportRow = Record<string, unknown>;
+type ImportStore = Pick<VectorStoreAdapter, 'connect' | 'ensureCollection' | 'addDocuments'>;
+
+interface ImportPayload {
+  collection?: string;
+  filename?: string;
+  contentType?: string;
+  format?: string;
+  text: string;
+}
+
+interface ExportImportDeps {
+  getStore?: (collection?: string) => ImportStore;
+  getModels?: () => Record<string, unknown>;
+  chunkSize?: number;
+}
+
+const DEFAULT_COLLECTION = 'bge-m3';
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+}
+
+function metadataValue(value: unknown): string | number | undefined {
+  if (typeof value === 'string' || typeof value === 'number') return value;
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (value == null) return undefined;
+  return JSON.stringify(value);
+}
+
+function metadataFrom(row: ImportRow): Record<string, string | number> {
+  const metadata: Record<string, string | number> = {};
+  const nested = row.metadata;
+  if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
+    for (const [key, value] of Object.entries(nested)) {
+      const normalized = metadataValue(value);
+      if (normalized !== undefined) metadata[key] = normalized;
+    }
+  }
+  for (const [key, value] of Object.entries(row)) {
+    if (['id', 'document', 'content', 'text', 'metadata', 'vector', 'embedding'].includes(key)) continue;
+    const normalized = metadataValue(value);
+    if (normalized !== undefined) metadata[key] = normalized;
+  }
+  return metadata;
+}
+
+function vectorFrom(row: ImportRow): number[] | undefined {
+  const value = row.vector ?? row.embedding;
+  if (!Array.isArray(value) || !value.every((item) => typeof item === 'number')) return undefined;
+  return value;
+}
+
+function documentFrom(row: ImportRow): VectorDocument | null {
+  const id = stringValue(row.id);
+  const document = stringValue(row.document) ?? stringValue(row.content) ?? stringValue(row.text);
+  if (!id || !document) return null;
+  return {
+    id,
+    document,
+    metadata: metadataFrom(row),
+    ...(vectorFrom(row) ? { vector: vectorFrom(row) } : {}),
+  };
+}
+
+function normalizeRows(value: unknown): ImportRow[] {
+  if (Array.isArray(value)) return value.filter(isRecord);
+  if (!isRecord(value)) return [];
+  if (Array.isArray(value.rows)) return value.rows.filter(isRecord);
+  if (Array.isArray(value.data)) return value.data.filter(isRecord);
+  if (Array.isArray(value.documents)) {
+    return value.documents.filter(isRecord).map((doc) => ({
+      ...doc.metadata && typeof doc.metadata === 'object' ? { metadata: doc.metadata } : {},
+      id: doc.id,
+      document: doc.document ?? doc.content ?? doc.text,
+      source: doc.source,
+      vector: doc.vector ?? doc.embedding,
+    }));
+  }
+  return [];
+}
+
+function isRecord(value: unknown): value is ImportRow {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizedFormat(format?: string): ImportFormat | undefined {
+  if (!format) return undefined;
+  const value = format.toLowerCase();
+  if (value === 'json' || value === 'jsonl' || value === 'ndjson') return value === 'ndjson' ? 'jsonl' : value;
+  throw new Error(`Unsupported import format: ${format}`);
+}
+
+function inferFormat(payload: ImportPayload): ImportFormat | undefined {
+  const explicit = normalizedFormat(payload.format);
+  if (explicit) return explicit;
+  const name = payload.filename?.toLowerCase() ?? '';
+  const type = payload.contentType?.toLowerCase() ?? '';
+  if (name.endsWith('.jsonl') || name.endsWith('.ndjson') || type.includes('ndjson') || type.includes('jsonl')) {
+    return 'jsonl';
+  }
+  if (name.endsWith('.json') || type.includes('json')) return 'json';
+  return undefined;
+}
+
+function parseRows(payload: ImportPayload): { rows: ImportRow[]; format: ImportFormat } {
+  const text = payload.text.trim();
+  if (!text) throw new Error('Import file is empty');
+  const hint = inferFormat(payload);
+  if (hint === 'jsonl') return { rows: parseJsonl(text), format: 'jsonl' };
+  try {
+    return { rows: normalizeRows(JSON.parse(text)), format: 'json' };
+  } catch (error) {
+    if (hint === 'json') throw error;
+    return { rows: parseJsonl(text), format: 'jsonl' };
+  }
+}
+
+function parseJsonl(text: string): ImportRow[] {
+  return text.split(/\r?\n/).filter((line) => line.trim()).map((line) => {
+    const parsed = JSON.parse(line);
+    if (!isRecord(parsed)) throw new Error('JSONL rows must be objects');
+    return parsed;
+  });
+}
+
+async function readPayload(request: Request): Promise<ImportPayload> {
+  const url = new URL(request.url);
+  const type = request.headers.get('content-type') ?? '';
+  if (type.toLowerCase().includes('multipart/form-data')) {
+    const form = await request.formData();
+    const file = form.get('file');
+    const textField = form.get('data');
+    const text = file instanceof File ? await file.text() : typeof textField === 'string' ? textField : '';
+    return {
+      text,
+      filename: file instanceof File ? file.name : undefined,
+      contentType: file instanceof File ? file.type : type,
+      format: stringValue(form.get('format')),
+      collection: stringValue(form.get('collection')) ?? url.searchParams.get('collection') ?? undefined,
+    };
+  }
+  return {
+    text: await request.text(),
+    contentType: type,
+    format: url.searchParams.get('format') ?? undefined,
+    collection: url.searchParams.get('collection') ?? undefined,
+  };
+}
+
+function resolveCollection(collection: string | undefined, getModels: () => Record<string, unknown>): string | null {
+  const name = (collection || DEFAULT_COLLECTION).trim();
+  return name in getModels() ? name : null;
+}
+
+async function addInChunks(store: ImportStore, docs: VectorDocument[], chunkSize: number): Promise<void> {
+  for (let index = 0; index < docs.length; index += chunkSize) {
+    await store.addDocuments(docs.slice(index, index + chunkSize));
+  }
+}
+
+export function createExportImportRoutes(deps: ExportImportDeps = {}) {
+  const getModels = deps.getModels ?? getEmbeddingModels;
+  const getStore = deps.getStore ?? getVectorStoreByModel;
+  const chunkSize = deps.chunkSize ?? 500;
+
+  return new Elysia().post('/export/import', async ({ request, set }) => {
+    let payload: ImportPayload;
+    let parsed: { rows: ImportRow[]; format: ImportFormat };
+    try {
+      payload = await readPayload(request);
+      parsed = parseRows(payload);
+    } catch (error) {
+      set.status = 400;
+      return { error: 'Invalid export import payload', message: error instanceof Error ? error.message : String(error) };
+    }
+
+    const collection = resolveCollection(payload.collection, getModels);
+    if (!collection) {
+      set.status = 404;
+      return { error: `Unknown vector collection: ${payload.collection ?? DEFAULT_COLLECTION}` };
+    }
+
+    const docs = parsed.rows.map(documentFrom).filter((doc): doc is VectorDocument => Boolean(doc));
+    if (docs.length === 0) {
+      set.status = 400;
+      return { error: 'No importable documents found', parsed: parsed.rows.length, skipped: parsed.rows.length };
+    }
+
+    try {
+      const store = getStore(collection);
+      await store.connect();
+      await store.ensureCollection();
+      await addInChunks(store, docs, chunkSize);
+      return {
+        success: true,
+        collection,
+        format: parsed.format,
+        imported: docs.length,
+        skipped: parsed.rows.length - docs.length,
+      };
+    } catch (error) {
+      set.status = 500;
+      return { error: 'Export import failed', message: error instanceof Error ? error.message : String(error) };
+    }
+  }, {
+    detail: {
+      tags: ['export'],
+      summary: 'Import exported JSON or JSONL into a vector collection',
+    },
+  });
+}
+
+export const exportImportRoutes = new Elysia({ prefix: '/api' }).use(createExportImportRoutes());

--- a/src/server.ts
+++ b/src/server.ts
@@ -62,6 +62,7 @@ import { canvasRoutes } from './routes/canvas/index.ts';
 import { tenantsRoutes } from './routes/tenants/index.ts';
 import { exportAppRoutes } from './routes/export/app.ts';
 import { exportBatchRoutes } from './routes/export/batch.ts';
+import { exportImportRoutes } from './routes/export/import.ts';
 let indexerRoutes: any = null;
 try {
   indexerRoutes = (await import('./routes/indexer/index.ts')).indexerRoutes;
@@ -200,6 +201,7 @@ const apiModules = [
   tenantsRoutes,
   exportAppRoutes,
   exportBatchRoutes,
+  exportImportRoutes,
   ...(indexerRoutes ? [indexerRoutes] : []),
   ...unifiedPlugins.routes,
 ];

--- a/tests/http/export/import.test.ts
+++ b/tests/http/export/import.test.ts
@@ -1,0 +1,99 @@
+import { expect, mock, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createExportImportRoutes } from '../../../src/routes/export/import.ts';
+import type { VectorDocument } from '../../../src/vector/types.ts';
+
+function createStore() {
+  const batches: VectorDocument[][] = [];
+  const store = {
+    connect: mock(async () => {}),
+    ensureCollection: mock(async () => {}),
+    addDocuments: mock(async (docs: VectorDocument[]) => {
+      batches.push(docs);
+    }),
+  };
+  return { store, batches };
+}
+
+function createFetch(store: ReturnType<typeof createStore>['store'], collections: string[] = ['bge-m3']) {
+  const requested: string[] = [];
+  const app = new Elysia({ prefix: '/api' }).use(createExportImportRoutes({
+    getModels: () => Object.fromEntries(collections.map((name) => [name, {}])),
+    getStore: (collection) => {
+      requested.push(collection ?? '');
+      return store;
+    },
+    chunkSize: 2,
+  }));
+  return { fetcher: createApiVersionedFetch((request) => app.handle(request)), requested };
+}
+
+function multipart(file: Blob, filename: string, collection = 'bge-m3', format?: string): FormData {
+  const form = new FormData();
+  form.append('file', file, filename);
+  form.append('collection', collection);
+  if (format) form.append('format', format);
+  return form;
+}
+
+test('POST /api/v1/export/import restores uploaded JSONL rows into a vector collection', async () => {
+  const { store, batches } = createStore();
+  const { fetcher, requested } = createFetch(store);
+  const body = [
+    JSON.stringify({ id: 'doc-1', document: 'alpha', type: 'learning', source_file: 'notes/a.md', concepts: ['a'] }),
+    JSON.stringify({ id: 'doc-2', document: 'bravo', type: 'trace', sourceFile: 'traces/b.md' }),
+  ].join('\n');
+
+  const res = await fetcher(new Request('http://local/api/v1/export/import', {
+    method: 'POST',
+    body: multipart(new Blob([body], { type: 'application/x-ndjson' }), 'export.jsonl'),
+  }));
+  const payload = await res.json() as Record<string, unknown>;
+
+  expect(res.status).toBe(200);
+  expect(payload).toEqual({ success: true, collection: 'bge-m3', format: 'jsonl', imported: 2, skipped: 0 });
+  expect(requested).toEqual(['bge-m3']);
+  expect(store.connect).toHaveBeenCalledTimes(1);
+  expect(store.ensureCollection).toHaveBeenCalledTimes(1);
+  expect(batches).toEqual([[
+    { id: 'doc-1', document: 'alpha', metadata: { type: 'learning', source_file: 'notes/a.md', concepts: '["a"]' } },
+    { id: 'doc-2', document: 'bravo', metadata: { type: 'trace', sourceFile: 'traces/b.md' } },
+  ]]);
+});
+
+test('POST /api/v1/export/import accepts JSON export arrays with vectors', async () => {
+  const { store, batches } = createStore();
+  const { fetcher } = createFetch(store);
+  const rows = [
+    { id: 'doc-3', document: 'charlie', metadata: { type: 'note', rank: 3 }, vector: [0.1, 0.2, 0.3] },
+    { id: 'skip-me', metadata: { type: 'empty' } },
+  ];
+
+  const res = await fetcher(new Request('http://local/api/v1/export/import', {
+    method: 'POST',
+    body: multipart(new Blob([JSON.stringify(rows)], { type: 'application/json' }), 'export.json'),
+  }));
+
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ success: true, collection: 'bge-m3', format: 'json', imported: 1, skipped: 1 });
+  expect(batches).toEqual([[
+    { id: 'doc-3', document: 'charlie', metadata: { type: 'note', rank: 3 }, vector: [0.1, 0.2, 0.3] },
+  ]]);
+});
+
+test('POST /api/v1/export/import rejects unknown vector collections', async () => {
+  const { store, batches } = createStore();
+  const { fetcher } = createFetch(store, ['bge-m3']);
+  const file = new Blob([JSON.stringify([{ id: 'doc-1', document: 'alpha' }])], { type: 'application/json' });
+
+  const res = await fetcher(new Request('http://local/api/v1/export/import', {
+    method: 'POST',
+    body: multipart(file, 'export.json', 'missing'),
+  }));
+
+  expect(res.status).toBe(404);
+  expect(await res.json()).toEqual({ error: 'Unknown vector collection: missing' });
+  expect(batches).toEqual([]);
+  expect(store.addDocuments).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- Add `POST /api/v1/export/import` for restoring exported JSON or JSONL rows into a vector collection.
- Support multipart uploads with `file`, `collection`, and optional `format` fields.
- Normalize JSON arrays, JSONL rows, export-app `{ rows }`, and v2-style `{ documents }` payloads into `VectorDocument`s before re-indexing.

## Validation
- `bun test tests/http/export/`
- `bunx tsc --noEmit`
- `rtk wc -l src/server.ts src/routes/export/*.ts tests/http/export/*.test.ts`

## Notes
- Rebased onto current `origin/alpha` and preserved existing export app + batch route mounts.
