### PR TITLE
feat: add export stats endpoint

### DIFF
--- a/src/routes/export/app.ts
+++ b/src/routes/export/app.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { ORACLE_DATA_DIR } from '../../config.ts';
 import { db as defaultDb, type DatabaseConnection } from '../../db/index.ts';
 import { introspectDrizzleTables } from '../../cli/commands/backup.ts';
+import { createExportStatsRoutes } from './stats.ts';
 
 type ExportRecord = Record<string, unknown>;
 type ExportFormat = 'json' | 'csv' | 'markdown';
@@ -177,4 +178,4 @@ export function createExportAppRoutes(deps: ExportAppDeps = {}) {
     }, { params: t.Object({ jobId: t.String() }) });
 }
 
-export const exportAppRoutes = new Elysia({ prefix: '/api' }).use(createExportAppRoutes());
+export const exportAppRoutes = new Elysia({ prefix: '/api' }).use(createExportAppRoutes()).use(createExportStatsRoutes());

--- a/src/routes/export/stats.ts
+++ b/src/routes/export/stats.ts
@@ -1,0 +1,105 @@
+import { getTableName } from 'drizzle-orm';
+import { Elysia } from 'elysia';
+import { readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { ORACLE_DATA_DIR } from '../../config.ts';
+import { db as defaultDb, type DatabaseConnection } from '../../db/index.ts';
+import { introspectDrizzleTables } from '../../cli/commands/backup.ts';
+
+type ExportRecord = Record<string, unknown>;
+type DumpTable = ReturnType<typeof introspectDrizzleTables>[number];
+type QueryConnection = Pick<DatabaseConnection, 'db'>;
+
+export interface ExportStats {
+  collections: number;
+  totalDocs: number;
+  totalSize: string;
+  lastExport?: Date;
+}
+
+export interface ExportStatsDeps {
+  connection?: QueryConnection;
+  exportDir?: string;
+}
+
+function connectionFrom(deps: ExportStatsDeps): QueryConnection {
+  return deps.connection ?? { db: defaultDb };
+}
+
+function selectRows(connection: QueryConnection, table: DumpTable): ExportRecord[] {
+  return (connection.db as any).select().from(table).all() as ExportRecord[];
+}
+
+export function formatExportSize(bytes: number): string {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let value = Math.max(0, bytes);
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  const rounded = unitIndex === 0 ? String(Math.round(value)) : value >= 10 ? value.toFixed(0) : value.toFixed(1);
+  return `${rounded} ${units[unitIndex]}`;
+}
+
+async function newestFileMtime(dir: string): Promise<Date | undefined> {
+  let latest: Date | undefined;
+
+  async function visit(current: string): Promise<void> {
+    const entries = await readEntries(current);
+    if (!entries) return;
+
+    for (const entry of entries) {
+      const fullPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        await visit(fullPath);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      const info = await stat(fullPath);
+      if (!latest || info.mtime > latest) latest = info.mtime;
+    }
+  }
+
+  async function readEntries(current: string) {
+    try {
+      return await readdir(current, { withFileTypes: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
+      throw error;
+    }
+  }
+
+  await visit(dir);
+  return latest;
+}
+
+export async function buildExportStats(deps: ExportStatsDeps = {}): Promise<ExportStats> {
+  const connection = connectionFrom(deps);
+  const tables = introspectDrizzleTables();
+  let totalDocs = 0;
+  let totalBytes = 0;
+
+  for (const table of tables) {
+    const name = getTableName(table);
+    const rows = selectRows(connection, table);
+    totalDocs += rows.length;
+    totalBytes += Buffer.byteLength(JSON.stringify({ [name]: rows }), 'utf8');
+  }
+
+  const lastExport = await newestFileMtime(deps.exportDir ?? path.join(ORACLE_DATA_DIR, 'export-app'));
+  return {
+    collections: tables.length,
+    totalDocs,
+    totalSize: formatExportSize(totalBytes),
+    ...(lastExport ? { lastExport } : {}),
+  };
+}
+
+export function createExportStatsRoutes(deps: ExportStatsDeps = {}) {
+  return new Elysia().get('/export/stats', () => buildExportStats(deps), {
+    detail: { tags: ['export'], summary: 'Export dashboard summary statistics' },
+  });
+}
+
+export const exportStatsRoutes = new Elysia({ prefix: '/api' }).use(createExportStatsRoutes());

--- a/tests/http/export/stats.test.ts
+++ b/tests/http/export/stats.test.ts
@@ -1,0 +1,98 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const root = mkdtempSync(join(tmpdir(), 'arra-export-stats-'));
+const dbPath = join(root, 'oracle.db');
+const exportDir = join(root, 'export-app');
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = dbPath;
+
+const dbModule = await import('../../../src/db/index.ts');
+const { Elysia } = await import('elysia');
+const { createApiVersionedFetch } = await import('../../../src/middleware/api-version.ts');
+const { createExportStatsRoutes, formatExportSize } = await import('../../../src/routes/export/stats.ts');
+const { exportAppRoutes } = await import('../../../src/routes/export/app.ts');
+
+const { createDatabase, oracleDocuments, supersedeLog, traceLog, resetDefaultDatabaseForTests } = dbModule;
+const connection = createDatabase(dbPath);
+const lastExport = new Date('2026-02-03T04:05:06.007Z');
+
+function restoreDbPath() {
+  return savedDbPath ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
+}
+
+function seed() {
+  const now = 1_766_000_000_000;
+  connection.db.insert(oracleDocuments).values([
+    { id: 'doc-a', type: 'learning', sourceFile: 'psi/a.md', concepts: '[]', createdAt: now, updatedAt: now, indexedAt: now, createdBy: 'test' },
+    { id: 'doc-b', type: 'learning', sourceFile: 'psi/b.md', concepts: '[]', createdAt: now, updatedAt: now, indexedAt: now, createdBy: 'test' },
+  ]).run();
+  connection.db.insert(traceLog).values([
+    { traceId: 'trace-a', query: 'root', childTraceIds: '["trace-b"]', nextTraceId: 'trace-b', createdAt: now, updatedAt: now },
+    { traceId: 'trace-b', query: 'child', parentTraceId: 'trace-a', prevTraceId: 'trace-a', createdAt: now, updatedAt: now },
+  ]).run();
+  connection.db.insert(supersedeLog).values({
+    oldPath: 'psi/a.md', oldId: 'doc-a', oldTitle: 'A',
+    newPath: 'psi/b.md', newId: 'doc-b', newTitle: 'B',
+    reason: 'refresh', supersededAt: now + 1, supersededBy: 'test', project: 'demo',
+  }).run();
+}
+
+function writeExportArtifact() {
+  mkdirSync(exportDir, { recursive: true });
+  const file = join(exportDir, 'oracle_documents-job-1.json');
+  writeFileSync(file, '{"rows":[]}');
+  utimesSync(file, lastExport, lastExport);
+}
+
+seed();
+writeExportArtifact();
+const app = new Elysia({ prefix: '/api' }).use(createExportStatsRoutes({ connection, exportDir }));
+const fetcher = createApiVersionedFetch((request) => app.handle(request));
+const mountedApp = new Elysia().use(exportAppRoutes);
+const mountedFetcher = createApiVersionedFetch((request) => mountedApp.handle(request));
+
+afterAll(() => {
+  connection.storage.close();
+  if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = savedDataDir;
+  if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = savedDbPath;
+  resetDefaultDatabaseForTests(restoreDbPath());
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('export stats HTTP route', () => {
+  test('returns collection count, total docs, size, and last export time', async () => {
+    const res = await fetcher(new Request('http://local/api/v1/export/stats'));
+    const body = await res.json() as {
+      collections: number;
+      totalDocs: number;
+      totalSize: string;
+      lastExport: string;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.collections).toBeGreaterThan(0);
+    expect(body.totalDocs).toBeGreaterThanOrEqual(5);
+    expect(body.totalSize).toMatch(/^\d+(\.\d)? (B|KB|MB|GB|TB)$/);
+    expect(new Date(body.lastExport).toISOString()).toBe(lastExport.toISOString());
+  });
+
+  test('formats export byte sizes for dashboard display', () => {
+    expect(formatExportSize(0)).toBe('0 B');
+    expect(formatExportSize(1536)).toBe('1.5 KB');
+  });
+
+  test('mounts stats on the export app route cluster', async () => {
+    const res = await mountedFetcher(new Request('http://local/api/v1/export/stats'));
+    const body = await res.json() as { totalDocs: number };
+
+    expect(res.status).toBe(200);
+    expect(body.totalDocs).toBeGreaterThanOrEqual(5);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/export/stats` for export dashboard summary data.
- Return collection count, total document count, formatted total size, and optional `lastExport` timestamp.
- Mount stats through the existing export app route cluster and cover it with HTTP tests.

Refs #1783

## Verification
- `bunx tsc --noEmit`
- `bun test tests/http/export/`
- `git diff --check HEAD`
- changed files <= 250 lines

## Notes
- Base branch: `alpha`
- Local `.maw-engine` runtime marker remains uncommitted.
