### PR TITLE
feat: add turbovec vector adapter

### DIFF
--- a/maw-plugin/vector-config.ts
+++ b/maw-plugin/vector-config.ts
@@ -26,8 +26,8 @@ function collectionName(p: Parsed): string {
 function adapter(value: string | undefined): string | undefined {
   if (!value) return undefined;
   const normalized = key(value) === 'cloudflare' ? 'cloudflare-vectorize' : value;
-  if (!['lancedb', 'qdrant', 'sqlite-vec', 'chroma', 'cloudflare-vectorize', 'proxy'].includes(normalized)) {
-    throw new Error('adapter must be lancedb, qdrant, sqlite-vec, chroma, cloudflare-vectorize, or proxy');
+  if (!['lancedb', 'qdrant', 'sqlite-vec', 'chroma', 'cloudflare-vectorize', 'proxy', 'turbovec'].includes(normalized)) {
+    throw new Error('adapter must be lancedb, qdrant, sqlite-vec, chroma, cloudflare-vectorize, proxy, or turbovec');
   }
   return normalized;
 }

--- a/src/routes/vector/config-api.ts
+++ b/src/routes/vector/config-api.ts
@@ -19,6 +19,7 @@ const adapterSchema = t.Union([
   t.Literal('qdrant'),
   t.Literal('cloudflare-vectorize'),
   t.Literal('proxy'),
+  t.Literal('turbovec'),
 ]);
 
 const updateSchema = t.Object({

--- a/src/vector/adapters/index.ts
+++ b/src/vector/adapters/index.ts
@@ -4,3 +4,4 @@ export { LanceDBAdapter } from './lancedb.ts';
 export { QdrantAdapter } from './qdrant.ts';
 export { CloudflareVectorizeAdapter, CloudflareAIEmbeddings } from './cloudflare-vectorize.ts';
 export { ProxyVectorAdapter } from './proxy.ts';
+export { TurboVecAdapter } from './turbovec.ts';

--- a/src/vector/adapters/proxy.ts
+++ b/src/vector/adapters/proxy.ts
@@ -53,7 +53,7 @@ function toQueryUrl(base: string, path: string): string {
 }
 
 export class ProxyVectorAdapter implements VectorStoreAdapter {
-  readonly name = 'proxy';
+  readonly name: string = 'proxy';
 
   constructor(
     private readonly collectionName: string,

--- a/src/vector/adapters/turbovec.ts
+++ b/src/vector/adapters/turbovec.ts
@@ -1,0 +1,22 @@
+/**
+ * TurboVec Adapter
+ *
+ * Sidecar vector DB that speaks the vector proxy protocol. Storage and
+ * embedding behavior live in the external TurboVec service.
+ */
+
+import { ProxyVectorAdapter } from './proxy.ts';
+
+export function resolveTurboVecEndpoint(endpoint?: string): string {
+  const resolved = endpoint || process.env.ORACLE_TURBOVEC_URL || process.env.TURBOVEC_URL;
+  if (!resolved) throw new Error('turbovec adapter requires endpoint, ORACLE_TURBOVEC_URL, or TURBOVEC_URL');
+  return resolved;
+}
+
+export class TurboVecAdapter extends ProxyVectorAdapter {
+  readonly name = 'turbovec';
+
+  constructor(collectionName: string, endpoint?: string, requestTimeoutMs?: number) {
+    super(collectionName, resolveTurboVecEndpoint(endpoint), requestTimeoutMs);
+  }
+}

--- a/src/vector/factory.ts
+++ b/src/vector/factory.ts
@@ -7,6 +7,7 @@ import { LanceDBAdapter } from './adapters/lancedb.ts';
 import { QdrantAdapter } from './adapters/qdrant.ts';
 import { CloudflareVectorizeAdapter, CloudflareAIEmbeddings } from './adapters/cloudflare-vectorize.ts';
 import { ProxyVectorAdapter } from './adapters/proxy.ts';
+import { TurboVecAdapter } from './adapters/turbovec.ts';
 import { createEmbeddingProvider, FallbackEmbeddings } from './embeddings.ts';
 import { GeminiEmbeddings } from './providers/gemini.ts';
 import { resolveEmbeddingFallbackChain, resolveEmbeddingModel, resolveEmbeddingProviderType } from './embedder-config.ts';
@@ -106,6 +107,9 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
         throw new Error('proxy vector adapter requires proxyEndpoint or ORACLE_PROXY_VECTOR_URL');
       }
       return new ProxyVectorAdapter(collectionName, proxyUrl);
+    }
+    case 'turbovec': {
+      return new TurboVecAdapter(collectionName, config.proxyEndpoint);
     }
     case 'chroma':
     default: {

--- a/src/vector/types.ts
+++ b/src/vector/types.ts
@@ -84,7 +84,8 @@ export type VectorDBType =
   | 'lancedb'
   | 'qdrant'
   | 'cloudflare-vectorize'
-  | 'proxy';
+  | 'proxy'
+  | 'turbovec';
 export type EmbeddingProviderType =
   | 'none'
   | 'local'

--- a/tests/http/vector/turbovec.test.ts
+++ b/tests/http/vector/turbovec.test.ts
@@ -1,0 +1,83 @@
+import { afterAll, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { vectorConfigApiRoutes } from '../../../src/routes/vector/config-api.ts';
+import { createVectorStore } from '../../../src/vector/factory.ts';
+import { TurboVecAdapter } from '../../../src/vector/adapters/turbovec.ts';
+import type { VectorDocument } from '../../../src/vector/types.ts';
+
+const requests: Array<{ method: string; path: string; body?: unknown }> = [];
+const savedUrl = process.env.ORACLE_TURBOVEC_URL;
+
+const server = Bun.serve({
+  hostname: '127.0.0.1',
+  port: 0,
+  async fetch(request) {
+    const url = new URL(request.url);
+    const body = request.method === 'GET' || request.method === 'DELETE' ? undefined : await request.json();
+    requests.push({ method: request.method, path: url.pathname, body });
+    if (url.pathname === '/turbo/health') return Response.json({ status: 'ok', name: 'turbovec-test', version: '1' });
+    if (url.pathname === '/turbo/vectors/stats') return Response.json({ count: 3, name: 'turbo_docs' });
+    if (url.pathname === '/turbo/vectors/add') return Response.json({ success: true, count: 1 });
+    if (url.pathname === '/turbo/vectors/query') return Response.json({
+      ids: ['doc-1'], documents: ['hello turbo'], distances: [0.05], metadatas: [{ type: 'learning' }],
+    });
+    if (url.pathname === '/turbo/vectors/collection') return Response.json({ success: true });
+    return new Response('not found', { status: 404 });
+  },
+});
+
+afterAll(() => {
+  server.stop(true);
+  if (savedUrl === undefined) delete process.env.ORACLE_TURBOVEC_URL;
+  else process.env.ORACLE_TURBOVEC_URL = savedUrl;
+});
+
+test('TurboVecAdapter forwards vector operations to a TurboVec sidecar', async () => {
+  requests.length = 0;
+  const adapter = new TurboVecAdapter('turbo_docs', `${server.url}turbo`);
+  const docs: VectorDocument[] = [{ id: 'doc-1', document: 'hello turbo', metadata: { type: 'learning' }, vector: [1, 2, 3] }];
+
+  await adapter.connect();
+  await adapter.addDocuments(docs);
+  const result = await adapter.query('hello', 2, { type: 'learning' });
+  const byId = await adapter.queryById('doc-1', 1);
+  const info = await adapter.getCollectionInfo();
+  await adapter.deleteCollection();
+
+  expect(adapter.name).toBe('turbovec');
+  expect(result.ids).toEqual(['doc-1']);
+  expect(byId.ids).toEqual(['doc-1']);
+  expect(info).toEqual({ name: 'turbo_docs', count: 3 });
+  expect(requests.map((item) => `${item.method} ${item.path}`)).toEqual([
+    'GET /turbo/health',
+    'POST /turbo/vectors/add',
+    'POST /turbo/vectors/query',
+    'POST /turbo/vectors/query',
+    'GET /turbo/vectors/stats',
+    'DELETE /turbo/vectors/collection',
+  ]);
+  expect(requests[1].body).toEqual({ documents: docs });
+  expect(requests[2].body).toEqual({ text: 'hello', limit: 2, where: { type: 'learning' } });
+  expect(requests[3].body).toEqual({ text: '', limit: 1, where: { id: 'doc-1' } });
+});
+
+test('factory registers turbovec vector stores with endpoint env fallback', async () => {
+  process.env.ORACLE_TURBOVEC_URL = `${server.url}turbo`;
+  const adapter = createVectorStore({ type: 'turbovec', collectionName: 'turbo_docs' });
+
+  expect(adapter).toBeInstanceOf(TurboVecAdapter);
+  await expect(adapter.getCollectionInfo()).resolves.toEqual({ name: 'turbo_docs', count: 3 });
+});
+
+test('config API accepts turbovec as a collection adapter', async () => {
+  const app = new Elysia().use(vectorConfigApiRoutes);
+  const fetcher = createApiVersionedFetch((request) => app.handle(request));
+  const res = await fetcher(new Request('http://local/api/v1/vector/config/turbo', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ adapter: 'turbovec', endpoint: `${server.url}turbo` }),
+  }));
+
+  expect(res.status).not.toBe(422);
+});

--- a/tests/tools/maw-plugin-arra/vector-config.test.ts
+++ b/tests/tools/maw-plugin-arra/vector-config.test.ts
@@ -98,8 +98,8 @@ describe('tools maw arra vector-config command', () => {
 
   test('sets one vector backend config field with JSON output', async () => {
     process.env.ARRA_API_TOKEN = 'secret';
-    const response = { success: true, collection: 'bge-m3', config: { collections: { 'bge-m3': { adapter: 'proxy' } } } };
-    const { result, calls } = await run(['vector-config', 'set', 'bge-m3', 'adapter', 'proxy', '--endpoint', 'http://proxy.test'], response);
+    const response = { success: true, collection: 'bge-m3', config: { collections: { 'bge-m3': { adapter: 'turbovec' } } } };
+    const { result, calls } = await run(['vector-config', 'set', 'bge-m3', 'adapter', 'turbovec', '--endpoint', 'http://turbo.test'], response);
     const body = JSON.parse(result.output ?? '');
 
     expect(result.ok).toBe(true);
@@ -109,7 +109,7 @@ describe('tools maw arra vector-config command', () => {
       authorization: 'Bearer secret',
       'content-type': 'application/json',
     });
-    expect(calls[0].body).toEqual({ adapter: 'proxy', endpoint: 'http://proxy.test' });
+    expect(calls[0].body).toEqual({ adapter: 'turbovec', endpoint: 'http://turbo.test' });
     expect(body).toMatchObject({ success: true, collection: 'bge-m3' });
   });
 

--- a/tools/maw-plugin-arra/commands/vector-config.ts
+++ b/tools/maw-plugin-arra/commands/vector-config.ts
@@ -1,7 +1,7 @@
 import { flag, parseArgs, requestJson, requestText, type ParsedArgs } from './http.ts';
 
 const usage = 'usage: maw arra vector-config list|get [collection]|set <collection> <field> <value>';
-const adapters = new Set(['chroma', 'sqlite-vec', 'lancedb', 'qdrant', 'cloudflare-vectorize', 'proxy']);
+const adapters = new Set(['chroma', 'sqlite-vec', 'lancedb', 'qdrant', 'cloudflare-vectorize', 'proxy', 'turbovec']);
 const updateFields = new Set(['adapter', 'model', 'provider', 'service', 'endpoint', 'enabled', 'primary', 'embedder', 'collection']);
 
 type JsonObject = Record<string, unknown>;


### PR DESCRIPTION
## Summary
- add TurboVec sidecar adapter that forwards vector operations through the proxy vector protocol
- register turbovec in vector type/factory/config schema and adapter exports
- allow turbovec in maw vector-config CLI surfaces and cover forwarding/factory behavior

## Validation
- bun test tests/http/vector/ (55 pass, 0 fail)
- bunx tsc --noEmit
- bun test tests/tools/maw-plugin-arra/ (6 pass, 0 fail)
- git diff --check origin/alpha...HEAD
- files <=250 lines for all PR files
- merged current origin/alpha before final validation