### PR TITLE
feat(export): add database connection test

### DIFF
--- a/frontend/src/components/export/ConnectionTest.tsx
+++ b/frontend/src/components/export/ConnectionTest.tsx
@@ -22,6 +22,7 @@ type RawCollection = {
   collection?: unknown;
   title?: unknown;
   count?: unknown;
+  rowCount?: unknown;
   docs?: unknown;
   docCount?: unknown;
   documentCount?: unknown;
@@ -45,7 +46,7 @@ function readCollection(raw: RawCollection, index: number): ExportAppCollection 
   const name = text(raw.name) || text(raw.key) || text(raw.collection) || text(raw.title) || `collection-${index + 1}`;
   return {
     name,
-    count: numberValue(raw.count ?? raw.docs ?? raw.docCount ?? raw.documentCount),
+    count: numberValue(raw.count ?? raw.rowCount ?? raw.docs ?? raw.docCount ?? raw.documentCount),
     description: text(raw.description) || undefined,
   };
 }
@@ -119,18 +120,22 @@ export function ConnectionTest({ initialBackendUrl = DEFAULT_BACKEND_URL, fetche
     setState('testing');
     setMessage(`Testing ${normalized}...`);
     try {
-      const health = await fetcher(apiUrl(normalized, '/api/v1/health'), { headers: { accept: 'application/json' } });
-      if (!health.ok) throw new Error(`/api/v1/health returned ${health.status}`);
-
-      const collectionResponse = await fetcher(apiUrl(normalized, '/api/v1/export/app/collections'), {
-        headers: { accept: 'application/json' },
+      const response = await fetcher(apiUrl(normalized, '/api/v1/export/test-connection'), {
+        method: 'POST',
+        headers: { accept: 'application/json', 'content-type': 'application/json' },
+        body: JSON.stringify({}),
       });
-      if (!collectionResponse.ok) throw new Error(`/api/v1/export/app/collections returned ${collectionResponse.status}`);
+      const payload = await readJson(response);
+      if (!response.ok) throw new Error(`/api/v1/export/test-connection returned ${response.status}`);
+      if (payload && typeof payload === 'object' && (payload as { ok?: unknown }).ok === false) {
+        throw new Error(text((payload as { error?: unknown }).error) || 'Export database connection failed');
+      }
 
-      const nextCollections = normalizeCollections(await readJson(collectionResponse));
+      const nextCollections = normalizeCollections(payload);
+      const rowTotal = nextCollections.reduce((total, item) => total + item.count, 0);
       setCollections(nextCollections);
       setState('connected');
-      setMessage(`Connected to ${normalized}.`);
+      setMessage(`Connected to ${normalized}; ${nextCollections.length} collections, ${rowTotal.toLocaleString()} rows.`);
     } catch (error) {
       setCollections([]);
       setState('failed');
@@ -168,7 +173,7 @@ export function ConnectionTest({ initialBackendUrl = DEFAULT_BACKEND_URL, fetche
         <p className="text-sm text-slate-500">{message}</p>
       </div>
 
-      {state === 'testing' ? <LoadingPanel title="Testing backend..." detail="Checking /api/v1/health and loading export collections." /> : null}
+      {state === 'testing' ? <LoadingPanel title="Testing backend..." detail="Checking /api/v1/export/test-connection." /> : null}
       {state === 'failed' ? <ErrorMessage title="Connection failed." message={message} /> : null}
 
       <section className="grid gap-3 rounded-2xl border border-white/10 bg-white/[0.03] p-4" aria-label="Export collections">

--- a/src/routes/export/app.ts
+++ b/src/routes/export/app.ts
@@ -7,6 +7,7 @@ import { ORACLE_DATA_DIR } from '../../config.ts';
 import { db as defaultDb, type DatabaseConnection } from '../../db/index.ts';
 import { introspectDrizzleTables } from '../../cli/commands/backup.ts';
 import { createExportStatsRoutes } from './stats.ts';
+import { createExportTestConnectionRoutes } from './test-connection.ts';
 
 type ExportRecord = Record<string, unknown>;
 type BaseExportFormat = 'json' | 'csv' | 'markdown';
@@ -203,4 +204,7 @@ export function createExportAppRoutes(deps: ExportAppDeps = {}) {
     }, { params: t.Object({ jobId: t.String() }) });
 }
 
-export const exportAppRoutes = new Elysia({ prefix: '/api' }).use(createExportAppRoutes()).use(createExportStatsRoutes());
+export const exportAppRoutes = new Elysia({ prefix: '/api' })
+  .use(createExportAppRoutes())
+  .use(createExportStatsRoutes())
+  .use(createExportTestConnectionRoutes());

--- a/src/routes/export/test-connection.ts
+++ b/src/routes/export/test-connection.ts
@@ -1,0 +1,118 @@
+import { getTableName } from 'drizzle-orm';
+import { Elysia, t } from 'elysia';
+import { DB_PATH } from '../../config.ts';
+import {
+  db as defaultDb,
+  sqlite as defaultSqlite,
+  storage as defaultStorage,
+  type DatabaseConnection,
+} from '../../db/index.ts';
+import { introspectDrizzleTables } from '../../cli/commands/backup.ts';
+import { createStorageBackend } from '../../storage/registry.ts';
+
+type ConnectionLike = Pick<DatabaseConnection, 'db' | 'sqlite'> & Partial<Pick<DatabaseConnection, 'storage'>>;
+
+type CollectionSummary = {
+  name: string;
+  rowCount: number;
+};
+
+export interface ExportTestConnectionDeps {
+  connection?: ConnectionLike;
+  dbPath?: string;
+  now?: () => Date;
+  clock?: () => number;
+  openConnection?: (dbPath: string) => DatabaseConnection;
+}
+
+function defaultConnection(): ConnectionLike {
+  return { db: defaultDb, sqlite: defaultSqlite, storage: defaultStorage };
+}
+
+function openReadonlyConnection(dbPath: string): DatabaseConnection {
+  const storage = createStorageBackend({ dbPath, readonly: true });
+  return { sqlite: storage.sqlite, db: storage.db, storage };
+}
+
+function quoteIdent(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+function dbTables(connection: ConnectionLike): string[] {
+  const rows = connection.sqlite.prepare(
+    "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+  ).all() as Array<{ name: string }>;
+  return rows.map((row) => row.name);
+}
+
+function countRows(connection: ConnectionLike, table: string): number {
+  const row = connection.sqlite.prepare(`SELECT COUNT(*) AS rowCount FROM ${quoteIdent(table)}`).get() as { rowCount?: number };
+  return row.rowCount ?? 0;
+}
+
+function drizzleTableNames(): string[] {
+  return introspectDrizzleTables().map((table) => getTableName(table)).sort();
+}
+
+function buildSummary(connection: ConnectionLike, dbPath: string, checkedAt: Date, latencyMs: number) {
+  const actualTables = new Set(dbTables(connection));
+  const knownTables = drizzleTableNames();
+  const collections: CollectionSummary[] = knownTables
+    .filter((name) => actualTables.has(name))
+    .map((name) => ({ name, rowCount: countRows(connection, name) }));
+  const totalRows = collections.reduce((total, item) => total + item.rowCount, 0);
+
+  return {
+    ok: true,
+    status: 'connected',
+    dbPath,
+    checkedAt: checkedAt.toISOString(),
+    latencyMs,
+    collectionCount: collections.length,
+    totalRows,
+    collections,
+    missingTables: knownTables.filter((name) => !actualTables.has(name)),
+  };
+}
+
+function bodyDbPath(body: unknown): string | undefined {
+  if (!body || typeof body !== 'object') return undefined;
+  const value = (body as { dbPath?: unknown }).dbPath;
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+export function createExportTestConnectionRoutes(deps: ExportTestConnectionDeps = {}) {
+  const clock = deps.clock ?? (() => performance.now());
+  const now = deps.now ?? (() => new Date());
+  const open = deps.openConnection ?? openReadonlyConnection;
+
+  return new Elysia().post('/export/test-connection', ({ body }) => {
+    const requestedPath = bodyDbPath(body);
+    const dbPath = requestedPath ?? deps.dbPath ?? DB_PATH;
+    const shouldOpen = Boolean(requestedPath || (!deps.connection && deps.dbPath));
+    const started = clock();
+    let opened: DatabaseConnection | undefined;
+
+    try {
+      opened = shouldOpen ? open(dbPath) : undefined;
+      const connection = opened ?? deps.connection ?? defaultConnection();
+      return buildSummary(connection, dbPath, now(), Math.max(0, Math.round(clock() - started)));
+    } catch (error) {
+      return {
+        ok: false,
+        status: 'error',
+        dbPath,
+        checkedAt: now().toISOString(),
+        latencyMs: Math.max(0, Math.round(clock() - started)),
+        error: error instanceof Error ? error.message : String(error),
+      };
+    } finally {
+      opened?.storage.close();
+    }
+  }, {
+    body: t.Optional(t.Object({ dbPath: t.Optional(t.String()) })),
+    detail: { tags: ['export'], summary: 'Test export database connectivity' },
+  });
+}
+
+export const exportTestConnectionRoutes = new Elysia({ prefix: '/api' }).use(createExportTestConnectionRoutes());

--- a/tests/frontend/components/export/connection-test.test.tsx
+++ b/tests/frontend/components/export/connection-test.test.tsx
@@ -7,7 +7,7 @@ describe('export ConnectionTest', () => {
     expect(normalizeCollections({
       collections: [
         { key: 'nomic', docs: '7' },
-        { name: 'bge-m3', docCount: 42 },
+        { name: 'bge-m3', rowCount: 42 },
       ],
     })).toEqual([
       { name: 'bge-m3', count: 42, description: undefined },

--- a/tests/http/export/test-connection.test.ts
+++ b/tests/http/export/test-connection.test.ts
@@ -1,0 +1,88 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createDatabase, oracleDocuments } from '../../../src/db/index.ts';
+import { createExportTestConnectionRoutes } from '../../../src/routes/export/test-connection.ts';
+
+const root = mkdtempSync(join(tmpdir(), 'arra-export-conn-'));
+const dbPath = join(root, 'oracle.db');
+const connection = createDatabase(dbPath);
+
+connection.db.insert(oracleDocuments).values({
+  id: 'doc-conn-test',
+  type: 'learning',
+  sourceFile: 'psi/learn/conn.md',
+  concepts: '["export"]',
+  createdAt: 1_766_000_000_000,
+  updatedAt: 1_766_000_000_000,
+  indexedAt: 1_766_000_000_000,
+  createdBy: 'test',
+}).run();
+
+function apiFor(app: Elysia) {
+  return createApiVersionedFetch((request) => app.handle(request));
+}
+
+function post(body: Record<string, unknown>, api = fetcher) {
+  return api(new Request('http://local/api/v1/export/test-connection', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+}
+
+let tick = 10;
+const fetcher = apiFor(new Elysia({ prefix: '/api' }).use(createExportTestConnectionRoutes({
+  connection,
+  dbPath,
+  now: () => new Date('2026-01-02T03:04:05.006Z'),
+  clock: () => tick += 5,
+})));
+
+afterAll(() => {
+  connection.storage.close();
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('POST /api/v1/export/test-connection', () => {
+  test('checks the configured Oracle database and returns exportable collections', async () => {
+    const res = await post({});
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      ok: true,
+      status: 'connected',
+      dbPath,
+      checkedAt: '2026-01-02T03:04:05.006Z',
+      latencyMs: 5,
+    });
+    expect(body.collectionCount).toBeGreaterThan(0);
+    expect(body.totalRows).toBeGreaterThanOrEqual(1);
+    expect(body.collections).toContainEqual(expect.objectContaining({ name: 'oracle_documents', rowCount: 1 }));
+  });
+
+  test('returns ok false when the legacy database cannot be opened', async () => {
+    const failing = apiFor(new Elysia({ prefix: '/api' }).use(createExportTestConnectionRoutes({
+      dbPath: join(root, 'missing.db'),
+      now: () => new Date('2026-01-02T03:04:05.006Z'),
+      clock: () => 20,
+      openConnection: () => { throw new Error('legacy database unavailable'); },
+    })));
+
+    const res = await post({}, failing);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      ok: false,
+      status: 'error',
+      checkedAt: '2026-01-02T03:04:05.006Z',
+      latencyMs: 0,
+      error: 'legacy database unavailable',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `POST /api/v1/export/test-connection` for export app database connectivity checks.
- Return DB path, checked timestamp, latency, exportable collection row counts, total rows, and missing Drizzle-known tables.
- Wire the Export Data App connection button to the new POST endpoint and normalize `rowCount` payloads.

Refs #1783

## Verification
- `git diff --check origin/alpha 8a8710ba87a5f40ff8009f459c493f0840160a3f`
- `bun test tests/frontend/components/export/ tests/http/export/` — 21 pass
- `bun run build` — `tsc --noEmit` pass
- Changed files are all ≤250 lines.
