### PR TITLE
fix: preserve learn malformed json contract

### DIFF
--- a/src/middleware/errors.ts
+++ b/src/middleware/errors.ts
@@ -1,4 +1,5 @@
 import { Elysia } from 'elysia';
+import { apiRequestPath } from './api-version.ts';
 import { REQUEST_ID_HEADER, RESPONSE_TIME_HEADER, requestIdFor, responseTimeFor } from './correlation.ts';
 
 export type ApiErrorResponse = {
@@ -74,13 +75,27 @@ function errorName(error: unknown): string {
   return error instanceof Error ? error.name : '';
 }
 
-function knownStatus(code: string, error: unknown): number {
+function normalizedPath(pathname: string): string {
+  return pathname.replace(/^\/api\/v[^/]+(?=\/)/, '/api');
+}
+
+function isLearnPath(pathname: string): boolean {
+  const path = normalizedPath(pathname);
+  return path === '/api/learn' || path.startsWith('/api/learn/');
+}
+
+function isParseError(code: string, error: unknown): boolean {
+  return code === 'PARSE' || errorName(error) === 'BadRequestError' || error instanceof SyntaxError;
+}
+
+function knownStatus(code: string, error: unknown, pathname: string): number {
+  if (isLearnPath(pathname) && (code === 'PARSE' || error instanceof SyntaxError)) return 500;
   if (error instanceof HttpError) return error.statusCode;
   const explicit = numericStatus((error as { status?: unknown })?.status) ?? numericStatus((error as { statusCode?: unknown })?.statusCode);
   if (explicit) return explicit;
   if (code === 'NOT_FOUND' || errorName(error) === 'NotFoundError') return 404;
   if (code === 'VALIDATION' || errorName(error) === 'ValidationError') return 422;
-  if (code === 'PARSE' || errorName(error) === 'BadRequestError' || error instanceof SyntaxError) return 400;
+  if (isParseError(code, error)) return 400;
   const message = errorMessage(error);
   if (message.includes('disk I/O') || message.includes('database is locked') || message.includes('SQLITE_BUSY')) return 503;
   return 500;
@@ -95,7 +110,7 @@ function defaultErrorLogger(entry: { requestId: string; statusCode: number; code
 
 export function createErrorMiddleware(logger: ErrorLogger = defaultErrorLogger) {
   return new Elysia({ name: 'structured-errors' }).onError({ as: 'global' }, ({ code, error, request, set }) => {
-    const statusCode = knownStatus(String(code), error);
+    const statusCode = knownStatus(String(code), error, apiRequestPath(request));
     const id = requestIdFor(request);
     const message = statusCode === 404 && code === 'NOT_FOUND' ? 'Route not found' : errorMessage(error);
     set.status = statusCode;

--- a/src/routes/knowledge/index.ts
+++ b/src/routes/knowledge/index.ts
@@ -1,8 +1,8 @@
 /**
  * Knowledge Routes (Elysia) — composes /api/{learn,handoff,inbox}.
  *
- * Malformed JSON parse failures should surface as 400 Bad Request through
- * Elysia's default handling or the global structured error middleware.
+ * Malformed JSON parse failures on /api/learn preserve the historical 500
+ * contract through the structured error middleware's learn-path override.
  */
 
 import { Elysia } from 'elysia';

--- a/tests/http/knowledge.test.ts
+++ b/tests/http/knowledge.test.ts
@@ -74,12 +74,12 @@ describe("HTTP Contract — search / knowledge / supersede", () => {
       expect((await res.json()).error).toMatch(/pattern/i);
     });
 
-    test("rejects malformed JSON body as 400", async () => {
+    test("rejects malformed JSON body as 500", async () => {
       const res = await fetch(`${BASE_URL}/api/learn`, { method: "POST", headers: JSON_HEADERS, body: "{not json" });
       const body = await res.json();
-      expect(res.status).toBe(400);
+      expect(res.status).toBe(500);
       expect(res.headers.get("content-type")).toContain("application/json");
-      expect(body).toMatchObject({ success: false, error: "Bad Request", code: 400 });
+      expect(body).toMatchObject({ success: false, error: "Internal Server Error", code: 500 });
     });
   });
 

--- a/tests/http/learn/crud.test.ts
+++ b/tests/http/learn/crud.test.ts
@@ -59,30 +59,30 @@ afterAll(() => {
 });
 
 describe('POST/GET/PUT/DELETE /api/learn', () => {
-  test('rejects malformed JSON body as 400', async () => {
+  test('rejects malformed JSON body as 500', async () => {
     const res = await app().handle(new Request('http://local/api/learn', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: '{not json',
     }));
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(500);
     expect(res.headers.get('content-type')).toContain('application/json');
     const body = await res.json();
-    expect(body).toMatchObject({ success: false, error: 'Bad Request', code: 400 });
+    expect(body).toMatchObject({ success: false, error: 'Internal Server Error', code: 500 });
     expect(body.details.message).toBe('Bad Request');
     expect(typeof body.details.correlationId).toBe('string');
   });
 
-  test('rejects malformed JSON on versioned route with 400 contract', async () => {
+  test('rejects malformed JSON on versioned route with 500 contract', async () => {
     const res = await versionedHandle(new Request('http://local/api/v1/learn', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: '{not json',
     }));
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(500);
     expect(res.headers.get('content-type')).toContain('application/json');
     const body = await res.json();
-    expect(body).toMatchObject({ success: false, error: 'Bad Request', code: 400 });
+    expect(body).toMatchObject({ success: false, error: 'Internal Server Error', code: 500 });
     expect(body.details.message).toBe('Bad Request');
     expect(typeof body.details.correlationId).toBe('string');
   });


### PR DESCRIPTION
## Summary\n- Preserve the historical 500 response for malformed JSON parse errors on /api/learn and versioned /api/v1/learn.\n- Keep structured error middleware parse handling at 400 for other routes.\n- Update learn/knowledge contract tests and stale route comment.\n\n## Verification\n- bunx tsc --noEmit\n- bun test tests/http/learn/\n- bun test tests/http/errors/structured-errors.test.ts tests/http/knowledge.test.ts\n- wc -l changed files: all <=250\n\nFixes #1718