### PR TITLE
feat: add vector embedding provider API

### DIFF
--- a/src/routes/vector/providers.ts
+++ b/src/routes/vector/providers.ts
@@ -1,14 +1,11 @@
 import { Elysia, t } from 'elysia';
-import { createEmbeddingProvider } from '../../vector/embeddings.ts';
 import {
-  getDetectedEmbeddingProviders,
-  type ProviderDetectionOptions,
-} from '../../vector/provider-detection.ts';
-import type { EmbeddingProviderType } from '../../vector/types.ts';
+  createEmbeddingProviderApi,
+  type ProviderApiOptions,
+  type ProviderTestRequest,
+} from '../../vector/provider-api.ts';
 
-export interface VectorProvidersEndpointOptions extends ProviderDetectionOptions {
-  createProvider?: typeof createEmbeddingProvider;
-}
+export type VectorProvidersEndpointOptions = ProviderApiOptions;
 
 const providerSchema = t.Union([
   t.Literal('none'),
@@ -22,41 +19,16 @@ const providerSchema = t.Union([
 ]);
 
 export function createVectorProvidersEndpoint(options: VectorProvidersEndpointOptions = {}) {
+  const api = createEmbeddingProviderApi(options);
+
   return new Elysia()
-    .get('/vector/providers', async () => {
-      const result = await getDetectedEmbeddingProviders(true, options);
-      return {
-        ...result,
-        providers: result.providers.map((provider) => ({
-          ...provider,
-          status: provider.available ? 'available' : 'unavailable',
-        })),
-      };
-    }, {
+    .get('/vector/providers', async () => api.detect({ force: true }), {
       detail: { tags: ['vector'], summary: 'Detected embedding providers and capabilities' },
     })
     .post('/vector/providers/test', async ({ body, set }) => {
-      const createProvider = options.createProvider ?? createEmbeddingProvider;
-      try {
-        const provider = createProvider(body.provider, body.model, {
-          url: body.url,
-          dimensions: body.dimensions,
-        });
-        const vectors = await provider.embed([body.text ?? 'oracle provider probe'], 'query');
-        return {
-          success: true,
-          provider: provider.name,
-          dimensions: vectors[0]?.length ?? provider.dimensions,
-          model: body.model,
-        };
-      } catch (error) {
-        set.status = 503;
-        return {
-          success: false,
-          provider: body.provider,
-          error: error instanceof Error ? error.message : String(error),
-        };
-      }
+      const result = await api.test(body as ProviderTestRequest);
+      if (!result.success) set.status = 503;
+      return result;
     }, {
       body: t.Object({
         provider: providerSchema,

--- a/src/vector/provider-api.ts
+++ b/src/vector/provider-api.ts
@@ -1,0 +1,125 @@
+import { createEmbeddingProvider as defaultCreateProvider } from './embeddings.ts';
+import {
+  clearProviderDetectionCache,
+  getDetectedEmbeddingProviders,
+  type DetectedEmbeddingProvider,
+  type ProviderDetectionOptions,
+} from './provider-detection.ts';
+import type { EmbeddingProvider, EmbeddingProviderType } from './types.ts';
+
+export type ProviderScope = 'local' | 'remote' | 'internal' | 'disabled';
+export type ProviderStatus = 'available' | 'unavailable';
+
+export type CreateEmbeddingProvider = (
+  type?: EmbeddingProviderType,
+  model?: string,
+  options?: { url?: string; dimensions?: number },
+) => EmbeddingProvider;
+
+export interface ProviderApiOptions extends ProviderDetectionOptions {
+  createProvider?: CreateEmbeddingProvider;
+  force?: boolean;
+  probeText?: string;
+}
+
+export type ProviderInfo = DetectedEmbeddingProvider & {
+  provider: EmbeddingProviderType;
+  status: ProviderStatus;
+  scope: ProviderScope;
+  local: boolean;
+  remote: boolean;
+};
+
+export interface ProviderListResult {
+  checkedAt: string;
+  providers: ProviderInfo[];
+}
+
+export interface ProviderTestRequest {
+  provider: EmbeddingProviderType;
+  model?: string;
+  url?: string;
+  dimensions?: number;
+  text?: string;
+}
+
+export type ProviderTestResult =
+  | { success: true; provider: string; dimensions: number; model?: string }
+  | { success: false; provider: string; error: string };
+
+export interface EmbeddingProviderApi {
+  detect(options?: ProviderApiOptions): Promise<ProviderListResult>;
+  create(request: ProviderTestRequest): EmbeddingProvider;
+  test(request: ProviderTestRequest): Promise<ProviderTestResult>;
+}
+
+export function createEmbeddingProviderApi(defaults: ProviderApiOptions = {}): EmbeddingProviderApi {
+  const createProvider = defaults.createProvider ?? defaultCreateProvider;
+
+  return {
+    async detect(options = {}) {
+      const merged = { ...defaults, ...options };
+      const { force, createProvider: _createProvider, probeText: _probeText, ...detectOptions } = merged;
+      const result = await getDetectedEmbeddingProviders(Boolean(force), detectOptions);
+      return {
+        checkedAt: result.checkedAt,
+        providers: result.providers.map(toProviderInfo),
+      };
+    },
+
+    create(request) {
+      return createProvider(request.provider, request.model, {
+        url: request.url,
+        dimensions: request.dimensions,
+      });
+    },
+
+    async test(request) {
+      try {
+        const provider = this.create(request);
+        const vectors = await provider.embed([request.text ?? defaults.probeText ?? 'oracle provider probe'], 'query');
+        return {
+          success: true,
+          provider: provider.name,
+          dimensions: vectors[0]?.length ?? provider.dimensions,
+          model: request.model,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          provider: request.provider,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+  };
+}
+
+export async function detectEmbeddingProviderApi(
+  options: ProviderApiOptions = {},
+): Promise<ProviderListResult> {
+  return createEmbeddingProviderApi(options).detect(options);
+}
+
+export function clearEmbeddingProviderApiCache(): void {
+  clearProviderDetectionCache();
+}
+
+function toProviderInfo(provider: DetectedEmbeddingProvider): ProviderInfo {
+  const scope = providerScope(provider.type);
+  return {
+    ...provider,
+    provider: provider.type,
+    status: provider.available ? 'available' : 'unavailable',
+    scope,
+    local: scope === 'local',
+    remote: scope === 'remote',
+  };
+}
+
+function providerScope(type: EmbeddingProviderType): ProviderScope {
+  if (type === 'none') return 'disabled';
+  if (type === 'local' || type === 'ollama') return 'local';
+  if (type === 'remote' || type === 'openai' || type === 'gemini' || type === 'cloudflare-ai') return 'remote';
+  return 'internal';
+}

--- a/tests/vector/provider-api.test.ts
+++ b/tests/vector/provider-api.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, expect, mock, test } from 'bun:test';
+import {
+  clearEmbeddingProviderApiCache,
+  createEmbeddingProviderApi,
+  detectEmbeddingProviderApi,
+} from '../../src/vector/provider-api.ts';
+import type { EmbeddingProvider } from '../../src/vector/types.ts';
+
+afterEach(() => clearEmbeddingProviderApiCache());
+
+test('provider API auto-detects local Ollama and remote credentials', async () => {
+  const fetcher = mock(async () => Response.json({
+    models: [{ name: 'bge-m3' }, { name: 'nomic-embed-text' }],
+  })) as unknown as typeof fetch;
+
+  const result = await detectEmbeddingProviderApi({
+    force: true,
+    fetcher,
+    env: {
+      OPENAI_API_KEY: 'sk-test',
+      GOOGLE_API_KEY: 'gemini-test',
+      CF_ACCOUNT_ID: 'cf-account',
+      CF_API_TOKEN: 'cf-token',
+    },
+  });
+
+  expect(result.providers).toContainEqual(expect.objectContaining({
+    type: 'ollama',
+    provider: 'ollama',
+    status: 'available',
+    scope: 'local',
+    local: true,
+    models: ['bge-m3', 'nomic-embed-text'],
+  }));
+  expect(result.providers).toContainEqual(expect.objectContaining({
+    type: 'openai',
+    status: 'available',
+    scope: 'remote',
+    remote: true,
+  }));
+  expect(result.providers).toContainEqual(expect.objectContaining({
+    type: 'gemini',
+    status: 'available',
+    models: ['text-embedding-004'],
+  }));
+  expect(result.providers).toContainEqual(expect.objectContaining({
+    type: 'cloudflare-ai',
+    scope: 'remote',
+    available: true,
+  }));
+});
+
+test('provider API caches detection until force refresh', async () => {
+  let calls = 0;
+  const fetcher = mock(async () => Response.json({ models: [{ name: `model-${++calls}` }] })) as unknown as typeof fetch;
+  const api = createEmbeddingProviderApi({ env: {}, fetcher });
+
+  const first = await api.detect({ force: true });
+  const cached = await api.detect();
+  const refreshed = await api.detect({ force: true });
+
+  expect(first.providers[0].models).toEqual(['model-1']);
+  expect(cached.providers[0].models).toEqual(['model-1']);
+  expect(refreshed.providers[0].models).toEqual(['model-2']);
+  expect(fetcher).toHaveBeenCalledTimes(2);
+});
+
+test('provider API probes an embedding provider config', async () => {
+  const createProvider = mock((provider): EmbeddingProvider => ({
+    name: provider,
+    dimensions: 2,
+    embed: mock(async () => [[0.1, 0.2, 0.3]]),
+  }));
+  const api = createEmbeddingProviderApi({ createProvider });
+
+  const result = await api.test({ provider: 'remote', model: 'bge-m3', url: 'http://embed.local' });
+
+  expect(result).toEqual({
+    success: true,
+    provider: 'remote',
+    dimensions: 3,
+    model: 'bge-m3',
+  });
+  expect(createProvider).toHaveBeenCalledWith('remote', 'bge-m3', {
+    url: 'http://embed.local',
+    dimensions: undefined,
+  });
+});
+
+test('provider API reports provider probe failures without throwing', async () => {
+  const api = createEmbeddingProviderApi({
+    createProvider: (provider): EmbeddingProvider => ({
+      name: provider,
+      dimensions: 0,
+      embed: async () => { throw new Error('provider down'); },
+    }),
+  });
+
+  await expect(api.test({ provider: 'ollama' })).resolves.toEqual({
+    success: false,
+    provider: 'ollama',
+    error: 'provider down',
+  });
+});


### PR DESCRIPTION
## Summary
- add src/vector/provider-api.ts as the stable provider façade for auto-detection and provider probes
- classify local vs remote embedding providers and expose provider/status aliases for API consumers
- route /api/vector/providers and /api/vector/providers/test through the shared provider API

## Tests
- bunx tsc --noEmit
- bun test tests/vector/provider-api.test.ts tests/http/vector/providers.test.ts tests/vector/provider-detection.test.ts

Refs #1437