### PR TITLE
feat: add unified plugin management UI

### DIFF
--- a/frontend/src/components/PluginList.tsx
+++ b/frontend/src/components/PluginList.tsx
@@ -16,6 +16,14 @@ export function pluginStatusLabel(plugin: PluginEntry, enabled: boolean): string
   return plugin.status || 'ok';
 }
 
+export function pluginHealthLabel(plugin: PluginEntry, enabled: boolean): string {
+  if (!enabled) return 'inactive';
+  if (plugin.error) return 'unhealthy';
+  if (plugin.status === 'degraded') return 'degraded';
+  if (plugin.status && plugin.status !== 'ok') return plugin.status;
+  return 'healthy';
+}
+
 export function togglePluginEnabled(state: PluginEnabledState, name: string): PluginEnabledState {
   return { ...state, [name]: !(state[name] ?? true) };
 }
@@ -37,6 +45,7 @@ export function PluginList({
         const surfaces = surfacesFor(plugin);
         const enabled = isPluginEnabled(plugin, enabledState);
         const status = pluginStatusLabel(plugin, enabled);
+        const health = pluginHealthLabel(plugin, enabled);
         return (
           <article key={plugin.name} className="rounded-2xl border border-white/10 bg-slate-950/60 p-5">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -46,6 +55,7 @@ export function PluginList({
               </div>
               <div className="flex flex-wrap items-center gap-2">
                 <Badge>{status}</Badge>
+                <Badge>{health}</Badge>
                 {surfaces.length
                   ? surfaces.map((surface) => <Badge key={surface}>{surface}</Badge>)
                   : <Badge>metadata</Badge>}
@@ -59,6 +69,10 @@ export function PluginList({
               <div>
                 <dt className="text-slate-500">Status</dt>
                 <dd className="font-mono text-slate-200">{status}</dd>
+              </div>
+              <div>
+                <dt className="text-slate-500">Health</dt>
+                <dd className="font-mono text-slate-200">{health}</dd>
               </div>
               <div>
                 <dt className="text-slate-500">Artifact</dt>

--- a/frontend/src/hooks/usePlugins.ts
+++ b/frontend/src/hooks/usePlugins.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { apiUrl } from '../api/oracle';
 import type { PluginEntry, PluginsResponse } from '../types';
 
-export const PLUGINS_ENDPOINT = '/api/v1/plugins';
+export const PLUGINS_ENDPOINT = '/api/plugins';
 const EMPTY_PLUGINS: PluginEntry[] = [];
 
 export type PluginFetch = (input: RequestInfo | URL, init?: RequestInit) => Response | Promise<Response>;

--- a/frontend/src/pages/PluginsPage.tsx
+++ b/frontend/src/pages/PluginsPage.tsx
@@ -1,8 +1,10 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
+import { setPluginEnabled } from '../api/plugin-admin';
 import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
-import { isPluginEnabled, pluginStatusLabel, type PluginEnabledState } from '../components/PluginList';
+import { isPluginEnabled, PluginList, type PluginEnabledState } from '../components/PluginList';
 import { PLUGINS_ENDPOINT, usePlugins, type PluginFetch } from '../hooks/usePlugins';
-import { surfacesFor } from '../plugin-surfaces';
+import { countPluginSurfaces } from '../plugin-surfaces';
+import { UnifiedPluginSurfaceOverview } from './UnifiedPluginSurfaceOverview';
 import type { PluginEntry } from '../types';
 
 const EMPTY_PLUGINS: PluginEntry[] = [];
@@ -49,57 +51,12 @@ function healthForPlugin(plugin: PluginEntry, enabled: boolean): { label: string
   return { label: 'healthy', detail: plugin.server?.healthPath ?? 'manifest ok', tone: 'ok' };
 }
 
-function Pill({ children, tone = 'idle' }: { children: string; tone?: Tone }) {
-  return <span className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${toneClass(tone)}`}>{children}</span>;
-}
-
 function MetricCard({ label, value, detail, tone = 'idle' }: { label: string; value: string | number; detail: string; tone?: Tone }) {
   return (
     <article className={`rounded-lg border p-4 ${toneClass(tone)}`}>
       <p className="text-xs font-semibold uppercase tracking-[0.18em] opacity-80">{label}</p>
       <p className="mt-2 text-2xl font-semibold">{value}</p>
       <p className="mt-1 text-sm opacity-75">{detail}</p>
-    </article>
-  );
-}
-
-function Detail({ label, value, detail }: { label: string; value: string; detail?: string }) {
-  return (
-    <div>
-      <dt className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">{label}</dt>
-      <dd className="mt-1 font-mono text-sm text-slate-100">{value}</dd>
-      {detail ? <dd className="mt-1 text-xs text-slate-500">{detail}</dd> : null}
-    </div>
-  );
-}
-
-function PluginCard({ plugin, enabled }: { plugin: PluginEntry; enabled: boolean }) {
-  const health = healthForPlugin(plugin, enabled);
-  const surfaces = surfacesFor(plugin);
-  const status = enabled ? 'active' : 'inactive';
-
-  return (
-    <article className="rounded-lg border border-white/10 bg-slate-950/70 p-5">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <h2 className="text-lg font-semibold text-white">{plugin.name}</h2>
-          <p className="mt-1 text-sm text-slate-400">{plugin.description ?? 'Installed plugin manifest.'}</p>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <Pill tone={enabled ? 'ok' : 'idle'}>{status}</Pill>
-          <Pill tone={health.tone}>{health.label}</Pill>
-        </div>
-      </div>
-
-      <dl className="mt-5 grid gap-4 sm:grid-cols-3">
-        <Detail label="Status" value={status} detail={pluginStatusLabel(plugin, enabled)} />
-        <Detail label="Version" value={plugin.version ?? 'unknown'} />
-        <Detail label="Health" value={health.label} detail={health.detail} />
-      </dl>
-
-      <div className="mt-5 flex flex-wrap gap-2">
-        {surfaces.length ? surfaces.map((surface) => <Pill key={surface}>{surface}</Pill>) : <Pill>metadata</Pill>}
-      </div>
     </article>
   );
 }
@@ -111,42 +68,70 @@ export function PluginsPage({
   fetcher,
 }: PluginsPageProps) {
   const initialLoading = loading || initialPlugins.length === 0;
-  const { plugins, loading: fetching, error } = usePlugins({ initialPlugins, initialLoading, endpoint, fetcher });
-  const enabledState = useMemo(() => enabledStateForPlugins(plugins), [plugins]);
+  const { plugins, loading: fetching, error, reload } = usePlugins({ initialPlugins, initialLoading, endpoint, fetcher });
+  const [overrides, setOverrides] = useState<PluginEnabledState>({});
+  const [adminError, setAdminError] = useState('');
+  const [adminMessage, setAdminMessage] = useState('');
+  const enabledState = useMemo(() => ({ ...enabledStateForPlugins(plugins), ...overrides }), [plugins, overrides]);
   const summary = useMemo(() => pluginAdminSummary(plugins, enabledState), [plugins, enabledState]);
   const metrics = useMemo(() => {
     const active = plugins.filter((plugin) => isPluginEnabled(plugin, enabledState)).length;
     const unhealthy = plugins.filter((plugin) => healthForPlugin(plugin, isPluginEnabled(plugin, enabledState)).tone === 'bad').length;
-    return { active, inactive: plugins.length - active, unhealthy };
+    const surfaces = countPluginSurfaces(plugins);
+    return { active, inactive: plugins.length - active, unhealthy, surfaces };
   }, [plugins, enabledState]);
   const showInventory = plugins.length > 0 || !fetching;
+
+  async function togglePlugin(name: string) {
+    const plugin = plugins.find((item) => item.name === name);
+    if (!plugin) return;
+    const next = !isPluginEnabled(plugin, enabledState);
+    setAdminError('');
+    setAdminMessage(`Saving ${name}…`);
+    setOverrides((current) => ({ ...current, [name]: next }));
+    try {
+      const result = await setPluginEnabled(name, next);
+      setAdminMessage(result.message);
+      reload();
+    } catch (cause) {
+      setOverrides((current) => {
+        const copy = { ...current };
+        delete copy[name];
+        return copy;
+      });
+      setAdminError(cause instanceof Error ? cause.message : String(cause));
+      setAdminMessage('');
+    }
+  }
 
   return (
     <section className="grid gap-5" aria-labelledby="plugins-page-title">
       <header>
-        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Plugin list</p>
-        <h1 id="plugins-page-title" className="mt-2 text-3xl font-semibold text-white">Installed plugin status</h1>
-        <p className="mt-2 text-sm text-slate-400">Registered plugins and live installed inventory from GET {endpoint}.</p>
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Plugin management</p>
+        <h1 id="plugins-page-title" className="mt-2 text-3xl font-semibold text-white">Unified plugin surfaces</h1>
+        <p className="mt-2 text-sm text-slate-400">Registered plugins, backend surfaces, and enable/disable controls from GET {endpoint}.</p>
       </header>
 
       {fetching ? <LoadingPanel title="Loading plugins…" detail={`Fetching ${endpoint} and plugin health metadata.`} /> : null}
       {error ? <ErrorMessage title="Could not load plugins." message={error} /> : null}
 
       {showInventory ? (
-        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
           <MetricCard label="Installed" value={plugins.length} detail={summary} />
           <MetricCard label="Active" value={metrics.active} detail="ready to serve surfaces" tone="ok" />
           <MetricCard label="Inactive" value={metrics.inactive} detail="disabled or unavailable" />
+          <MetricCard label="Surfaces" value={metrics.surfaces} detail="menu, server, MCP, API, proxy, CLI, export" />
           <MetricCard label="Health" value={metrics.unhealthy ? `${metrics.unhealthy} alert` : 'ok'} detail="manifest and server signal" tone={metrics.unhealthy ? 'bad' : 'ok'} />
         </div>
       ) : null}
 
+      {adminMessage ? <p className="rounded-lg border border-teal-300/20 bg-teal-300/10 p-3 text-sm text-teal-100">{adminMessage}</p> : null}
+      {adminError ? <ErrorMessage title="Could not update plugin state." message={adminError} /> : null}
+
+      {showInventory ? <UnifiedPluginSurfaceOverview plugins={plugins} /> : null}
+
       {plugins.length ? (
-        <div className="grid gap-4 xl:grid-cols-2">
-          {plugins.map((plugin) => (
-            <PluginCard key={plugin.name} plugin={plugin} enabled={isPluginEnabled(plugin, enabledState)} />
-          ))}
-        </div>
+        <PluginList plugins={plugins} enabledState={enabledState} onToggle={(name) => void togglePlugin(name)} />
       ) : showInventory ? (
         <p className="rounded-lg border border-white/10 bg-slate-950/70 p-5 text-sm text-slate-400">
           No installed plugins returned by {endpoint}.

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -37,6 +37,8 @@ export const frontendRoutes = [
   '/vector/results',
   '/vector/export',
   '/vector/settings',
+  '/mcp',
+  '/settings',
 ] as const;
 export type FrontendRoute = typeof frontendRoutes[number];
 

--- a/tests/frontend/components/app-shell-vector-nav.test.tsx
+++ b/tests/frontend/components/app-shell-vector-nav.test.tsx
@@ -17,7 +17,7 @@ describe('AppShell Vector navigation', () => {
       expect(html).toContain('aria-label="Vector Dashboard: Collection health and indexing"');
       expect(html).toContain('aria-label="Document Browser: Browse indexed vector documents"');
       expect(html).toContain('aria-label="Vector Search: Semantic preview by collection"');
-      expect(html).toContain('aria-label="Export App: Download app collections"');
+      expect(html).toContain('aria-label="Export App: Legacy v2 JSON/Markdown backups"');
       expect(html).toContain('aria-label="Export: Download vector collections"');
     } finally {
       restore();

--- a/tests/frontend/pages/frontend-component-coverage.test.tsx
+++ b/tests/frontend/pages/frontend-component-coverage.test.tsx
@@ -22,8 +22,8 @@ describe('frontend component coverage', () => {
     }]} loading={false} />);
 
     expect(html).toContain('1 enabled · 0 disabled · 1 registered');
-    expect(html).toContain('Installed plugin status');
-    expect(html).toContain('active');
+    expect(html).toContain('Unified plugin surfaces');
+    expect(html).toContain('ok');
     expect(html).toContain('2.0.0');
     expect(html).toContain('apiRoutes');
     expect(html).toContain('proxy');

--- a/tests/frontend/pages/plugins-page-admin.test.tsx
+++ b/tests/frontend/pages/plugins-page-admin.test.tsx
@@ -8,10 +8,11 @@ describe('PluginsPage admin view', () => {
     const html = htmlFor(<PluginsPage plugins={plugins} loading={false} />);
 
     expect(pluginAdminSummary(plugins, enabledStateForPlugins(plugins))).toBe('1 enabled · 0 disabled · 1 registered');
-    expect(html).toContain('GET /api/v1/plugins');
+    expect(html).toContain('GET /api/plugins');
     expect(html).toContain('canvas');
     expect(html).toContain('1.2.3');
-    expect(html).toContain('active');
+    expect(html).toContain('ok');
     expect(html).toContain('healthy');
+    expect(html).toContain('Unified backend surfaces');
   });
 });

--- a/tests/frontend/pages/plugins-page-loading.test.tsx
+++ b/tests/frontend/pages/plugins-page-loading.test.tsx
@@ -5,7 +5,7 @@ import { htmlFor } from '../_render';
 describe('PluginsPage loading state', () => {
   test('shows a loading panel while plugin manifests load', () => {
     const html = htmlFor(<PluginsPage plugins={[]} loading={true} />);
-    expect(html).toContain('Plugin list');
+    expect(html).toContain('Plugin management');
     expect(html).toContain('Loading plugins…');
   });
 });

--- a/tests/frontend/router.test.ts
+++ b/tests/frontend/router.test.ts
@@ -47,6 +47,8 @@ describe('frontend router', () => {
       '/vector/results',
       '/vector/export',
       '/vector/settings',
+      '/mcp',
+      '/settings',
     ]);
   });
 
@@ -59,7 +61,7 @@ describe('frontend router', () => {
     expect(htmlAt('/metrics')).toContain('42');
     expect(htmlAt('/metrics')).toContain('Memory usage');
     expect(htmlAt('/search')).toContain('Full-text menu search');
-    expect(htmlAt('/export')).toContain('Export collections');
+    expect(htmlAt('/export')).toContain('Export app');
     expect(htmlAt('/learn')).toContain('Learn entries');
     expect(htmlAt('/vector')).toContain('Vector dashboard');
     expect(htmlAt('/vector/search')).toContain('Vector search preview');
@@ -67,6 +69,8 @@ describe('frontend router', () => {
     expect(htmlAt('/vector/results')).toContain('Vector search results');
     expect(htmlAt('/vector/export')).toContain('Vector export');
     expect(htmlAt('/vector/settings')).toContain('Configure adapters, embedding models');
+    expect(htmlAt('/mcp')).toContain('Tool browser');
+    expect(htmlAt('/settings')).toContain('Runtime configuration');
   });
 
   test('wraps routed children in the browser router and error boundary shell', () => {


### PR DESCRIPTION
## Summary
- upgrade the Plugins page into a unified plugin management surface with /api/plugins inventory, surface metrics, health/status, and enable/disable controls
- embed the unified backend surfaces overview for menu, MCP tools, vector config, server health, and storage config
- align frontend route/test coverage with current /mcp, /settings, export, and plugin UI copy

## Validation
- bunx tsc --noEmit
- cd frontend && bun run build
- bun test tests/frontend
- bun test tests/http/
- changed files <=250 lines; git diff --check clean