### PR TITLE
feat: surface vector freshness pending docs

### DIFF
--- a/frontend/src/pages/vector-dashboard-cards.tsx
+++ b/frontend/src/pages/vector-dashboard-cards.tsx
@@ -14,7 +14,13 @@ export interface VectorCollectionCard {
 }
 
 export type VectorProviderHealthCard = { type: string; status: 'green' | 'red'; available: boolean; detail?: string };
-export type VectorFreshnessCard = { status: 'fresh' | 'empty'; totalIndexed: number; docsPending?: number; lastIndexed?: string };
+export type VectorFreshnessCard = {
+  status: 'fresh' | 'empty' | 'stale';
+  totalIndexed: number;
+  sourceDocs?: number;
+  docsPending?: number;
+  lastIndexed?: string;
+};
 
 type DownloadByCollection = Record<string, VectorExportFormat | undefined>;
 
@@ -46,6 +52,16 @@ function docsLabel(cards: VectorCollectionCard[]): string {
   if (!collections) return 'No collection data yet';
   if (hasUnknownDocs) return `${knownDocs.toLocaleString()}+ docs across ${collections} collections`;
   return `${knownDocs.toLocaleString()} docs · ${collections} collections`;
+}
+
+function freshnessLine(freshness: VectorFreshnessCard): string {
+  return `${freshness.status} · ${freshness.totalIndexed.toLocaleString()} indexed`;
+}
+
+function pendingLine(freshness?: VectorFreshnessCard): string {
+  if (!freshness || typeof freshness.docsPending !== 'number') return 'Pending count unavailable';
+  const source = typeof freshness.sourceDocs === 'number' ? ` of ${freshness.sourceDocs.toLocaleString()} source docs` : '';
+  return `${freshness.docsPending.toLocaleString()} pending${source}`;
 }
 
 export function VectorCollectionCards({
@@ -140,7 +156,9 @@ export function VectorHealthDashboardCard({
       <h2 id="vector-health-dashboard-title" className="mt-2 text-2xl font-semibold text-white">Vector health dashboard</h2>
       <dl className="mt-4 grid gap-3 text-sm text-slate-300">
         <div><dt className="text-slate-500">Embedding providers</dt><dd className="text-lg font-semibold text-white">{providerSummary}</dd></div>
-        <div><dt className="text-slate-500">Index freshness</dt><dd className="text-lg font-semibold text-white">{freshness ? `${freshness.status} · ${freshness.totalIndexed.toLocaleString()} indexed` : 'Unknown'}</dd></div>
+        <div><dt className="text-slate-500">Index freshness</dt><dd className="text-lg font-semibold text-white">{freshness ? freshnessLine(freshness) : 'Unknown'}</dd></div>
+        <div><dt className="text-slate-500">Docs pending</dt><dd className="text-lg font-semibold text-white">{pendingLine(freshness)}</dd></div>
+        <div><dt className="text-slate-500">Last indexed</dt><dd className="text-lg font-semibold text-white">{freshness?.lastIndexed ?? 'Unknown'}</dd></div>
       </dl>
       {providers.length ? <div className="mt-4 flex flex-wrap gap-2">{providers.map((provider) => <span key={provider.type} className={`rounded-full border px-2 py-1 text-xs font-semibold ${statusClasses(provider.available)}`}>{provider.type}: {provider.status}</span>)}</div> : null}
     </section>

--- a/src/vector/health.ts
+++ b/src/vector/health.ts
@@ -4,6 +4,8 @@ import {
   type EmbeddingModelConfig,
 } from './factory.ts';
 import { resolveEmbeddingProviderType } from './embedder-config.ts';
+import { Database } from 'bun:sqlite';
+import { DB_PATH } from '../config.ts';
 
 export type VectorBackendEngine = {
   key: string;
@@ -25,8 +27,9 @@ export type VectorProviderHealth = {
 };
 
 export type VectorFreshness = {
-  status: 'fresh' | 'empty';
+  status: 'fresh' | 'empty' | 'stale';
   totalIndexed: number;
+  sourceDocs?: number;
   docsPending?: number;
   lastIndexed?: string;
 };
@@ -45,7 +48,6 @@ export function attachVectorDashboardHealth(
   health: VectorBackendHealth,
   providers: Array<{ type: string; available: boolean; error?: string; detail?: string }> = [],
 ): VectorBackendHealth {
-  const totalIndexed = health.engines.reduce((sum, engine) => sum + (engine.count || 0), 0);
   return {
     ...health,
     collections: health.collections ?? health.engines,
@@ -55,10 +57,24 @@ export function attachVectorDashboardHealth(
       status: provider.available ? 'green' : 'red',
       detail: provider.error ?? provider.detail,
     })),
-    freshness: {
-      status: totalIndexed > 0 ? 'fresh' : 'empty',
-      totalIndexed,
-    },
+    freshness: health.freshness ?? buildVectorFreshness(health.engines),
+  };
+}
+
+export function buildVectorFreshness(
+  engines: Array<Pick<VectorBackendEngine, 'count'>>,
+  source?: { docs?: number; lastIndexed?: string },
+): VectorFreshness {
+  const counts = engines.map((engine) => engine.count || 0);
+  const totalIndexed = counts.reduce((sum, count) => sum + count, 0);
+  const maxIndexed = counts.reduce((max, count) => Math.max(max, count), 0);
+  const docsPending = source?.docs === undefined ? undefined : Math.max(0, source.docs - maxIndexed);
+  const status = totalIndexed === 0 ? 'empty' : docsPending && docsPending > 0 ? 'stale' : 'fresh';
+  return {
+    status,
+    totalIndexed,
+    ...(source?.docs !== undefined && { sourceDocs: source.docs, docsPending }),
+    ...(source?.lastIndexed && { lastIndexed: source.lastIndexed }),
   };
 }
 
@@ -111,5 +127,30 @@ export async function readVectorBackendHealth(): Promise<VectorBackendHealth> {
 
   const okCount = engines.filter((engine) => engine.ok).length;
   const status = okCount === engines.length ? 'ok' : okCount === 0 ? 'down' : 'degraded';
-  return { status, engines, collections: engines, checked_at: new Date().toISOString() };
+  return {
+    status,
+    engines,
+    collections: engines,
+    checked_at: new Date().toISOString(),
+    freshness: buildVectorFreshness(engines, readSourceDocumentStats()),
+  };
+}
+
+function readSourceDocumentStats(): { docs?: number; lastIndexed?: string } {
+  let db: Database | undefined;
+  try {
+    db = new Database(DB_PATH, { readonly: true });
+    const row = db.query<{ docs: number; lastIndexed: string | null }, []>(`
+      SELECT COUNT(DISTINCT id) AS docs, MAX(indexed_at) AS lastIndexed
+      FROM oracle_documents
+    `).get();
+    return {
+      docs: row?.docs ?? 0,
+      ...(row?.lastIndexed && { lastIndexed: row.lastIndexed }),
+    };
+  } catch {
+    return {};
+  } finally {
+    db?.close();
+  }
 }

--- a/tests/frontend/pages/frontend-component-coverage.test.tsx
+++ b/tests/frontend/pages/frontend-component-coverage.test.tsx
@@ -36,12 +36,14 @@ describe('frontend component coverage', () => {
         { type: 'ollama', status: 'green', available: true, detail: 'local' },
         { type: 'openai', status: 'red', available: false, detail: 'missing key' },
       ]}
-      freshness={{ status: 'fresh', totalIndexed: 1532, docsPending: 0, lastIndexed: '2026-06-16T00:00:00Z' }}
+      freshness={{ status: 'stale', totalIndexed: 1532, sourceDocs: 1600, docsPending: 68, lastIndexed: '2026-06-16T00:00:00Z' }}
     />);
 
     expect(html).toContain('Vector health dashboard');
     expect(html).toContain('1/2 providers available');
-    expect(html).toContain('fresh · 1,532 indexed');
+    expect(html).toContain('stale · 1,532 indexed');
+    expect(html).toContain('68 pending of 1,600 source docs');
+    expect(html).toContain('2026-06-16T00:00:00Z');
     expect(html).toContain('ollama: green');
     expect(html).toContain('openai: red');
   });

--- a/tests/http/vector/phase4-polish.test.ts
+++ b/tests/http/vector/phase4-polish.test.ts
@@ -118,6 +118,22 @@ test('GET /api/v1/vector/cost-estimate returns token cost and recommendation', a
   expect(String(body.recommendation)).toContain('Any configured');
 });
 
+test('buildVectorFreshness reports pending source documents', async () => {
+  const { buildVectorFreshness } = await import('../../../src/vector/health.ts');
+  const freshness = buildVectorFreshness([
+    { count: 12 },
+    { count: 3 },
+  ], { docs: 20, lastIndexed: '2026-06-16T00:00:00Z' });
+
+  expect(freshness).toEqual({
+    status: 'stale',
+    totalIndexed: 15,
+    sourceDocs: 20,
+    docsPending: 8,
+    lastIndexed: '2026-06-16T00:00:00Z',
+  });
+});
+
 test('FallbackEmbeddings switches to the next provider after primary failure', async () => {
   const { FallbackEmbeddings } = await import('../../../src/vector/embeddings.ts');
   const events: Array<{ from: string; to?: string }> = [];

--- a/tests/http/vector/status.test.ts
+++ b/tests/http/vector/status.test.ts
@@ -25,6 +25,7 @@ function createFetch() {
           { key: 'bge-m3', model: 'bge-m3', collection: 'oracle_bge', count: 12, ok: true },
           { key: 'qdrant', model: 'qdrant-embed', collection: 'oracle_qdrant', count: 3, ok: true },
         ],
+        freshness: { status: 'stale', totalIndexed: 15, sourceDocs: 20, docsPending: 8, lastIndexed: '2026-06-15T00:00:00.000Z' },
       }),
     }))
     .use(createVectorModelEndpoints({
@@ -57,7 +58,7 @@ test('GET /api/v1/vector/status and /api/v1/vector/models return vector status s
       { type: 'ollama', available: true, status: 'green' },
       { type: 'openai', available: false, status: 'red', detail: 'missing OPENAI_API_KEY' },
     ],
-    freshness: { status: 'fresh', totalIndexed: 15 },
+    freshness: { status: 'stale', totalIndexed: 15, sourceDocs: 20, docsPending: 8 },
   });
 
   const modelsRes = await fetcher(new Request('http://local/api/v1/vector/models'));


### PR DESCRIPTION
Refs #1436.

## Summary
- picked a small Phase 4 Vector Section v2 subtask: health dashboard index-freshness detail
- reports vector freshness with source-doc count and docs-pending from `oracle_documents` vs indexed vector collection counts
- surfaces docs pending and last-indexed metadata in the Vector health dashboard card

## Validation
- `bunx tsc --noEmit`
- `bun test tests/http/vector/status.test.ts tests/http/vector/phase4-polish.test.ts tests/frontend/pages/frontend-component-coverage.test.tsx`
- `git diff --check`
- file-size check: all changed files ≤250 lines

Note: `agents/1-codex-4` already has open PR #1875, so this PR was built from `origin/alpha` on an isolated branch without switching the current worktree.
