### PR TITLE
fix: auto-index learn files in new watcher dirs

### DIFF
--- a/src/indexer/__tests__/learn-watcher.test.ts
+++ b/src/indexer/__tests__/learn-watcher.test.ts
@@ -50,6 +50,15 @@ function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+async function waitFor(check: () => boolean, timeoutMs = 1_500): Promise<void> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    if (check()) return;
+    await wait(25);
+  }
+  throw new Error('timed out waiting for learn watcher');
+}
+
 describe('startLearnWatcher', () => {
   let repoRoot: string;
   let db: Database;
@@ -147,6 +156,25 @@ describe('startLearnWatcher', () => {
 
     const jobs = db.query<{ count: number }, []>('SELECT COUNT(*) AS count FROM indexing_jobs').get() as { count: number };
     expect(jobs.count).toBe(Object.keys(MODELS).length);
+
+    stop();
+  });
+
+  it('stores files created under new ψ/learn directories after start', async () => {
+    const filePath = path.join(repoRoot, 'ψ', 'learn', 'Soul-Brews-Studio', 'demo', 'new-tree.md');
+
+    const stop = startLearnWatcher({ db, models: MODELS, repoRoot, debounceMs: 20 });
+    await wait(50);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, '# New Tree\n\n## Finding\n\nWatcher scans directories created after startup.', 'utf8');
+
+    await waitFor(() => {
+      const jobs = db.query<{ count: number }, []>('SELECT COUNT(*) AS count FROM indexing_jobs').get();
+      return jobs?.count === Object.keys(MODELS).length;
+    }, 2_500);
+
+    const doc = db.query<{ source_file: string }, []>('SELECT source_file FROM oracle_documents').get();
+    expect(doc?.source_file).toBe('ψ/learn/Soul-Brews-Studio/demo/new-tree.md');
 
     stop();
   });

--- a/src/indexer/learn-watcher.ts
+++ b/src/indexer/learn-watcher.ts
@@ -79,7 +79,10 @@ export function startLearnWatcher({
 }: LearnWatcherOptions): StopWatch {
   const root = path.resolve(repoRoot);
   const roots = [path.join(root, MEMORY_LEARN_REL), path.join(root, PSI_LEARN_REL)]
-    .filter((dir) => fs.existsSync(dir));
+    .filter((dir) => {
+      try { fs.mkdirSync(dir, { recursive: true }); return true; }
+      catch { return false; }
+    });
 
   if (roots.length === 0) return () => {};
 
@@ -100,7 +103,7 @@ export function startLearnWatcher({
 
     let stat: fs.Stats;
     try { stat = fs.statSync(fullPath); } catch { return; }
-    if (stat.isDirectory()) { addWatchers(fullPath); return; }
+    if (stat.isDirectory()) { addWatchers(fullPath); indexTree(fullPath); return; }
     if (!stat.isFile() || !isMarkdownFile(fullPath)) return;
 
     const sourceFile = normalizeSourceFile(root, fullPath);
@@ -120,6 +123,10 @@ export function startLearnWatcher({
     }
     enqueueDocIds(db, models, ids);
   };
+
+  function indexTree(dir: string): void {
+    for (const filePath of listFiles(dir, isMarkdownFile)) indexOrQueue(filePath);
+  }
 
   function addWatchers(dir: string): void {
     for (const childDir of listDirs(dir)) {

--- a/src/services/file-watcher.ts
+++ b/src/services/file-watcher.ts
@@ -13,7 +13,7 @@ import {
   readPsiLearnDocuments,
   storeSqliteDocuments,
 } from '../indexer/learn-doc-source.ts';
-import { isWithinRoot, listDirs, safeClearTimeout, safeClose, watchDir } from '../indexer/watch-utils.ts';
+import { isWithinRoot, listDirs, listFiles, safeClearTimeout, safeClose, watchDir } from '../indexer/watch-utils.ts';
 
 type ModelRegistry = Record<string, { collection: string }>;
 type WatcherEventType = 'started' | 'stopped' | 'scheduled' | 'indexed' | 'skipped' | 'error';
@@ -136,6 +136,7 @@ export class FileWatcherService {
     const stat = fs.statSync(filePath);
     if (stat.isDirectory()) {
       this.addWatchers(filePath);
+      this.indexMarkdownTree(filePath);
       return;
     }
 
@@ -153,6 +154,10 @@ export class FileWatcherService {
       this.record('error', `failed to re-index ${sourceFile}: ${errorText(error)}`, sourceFile);
       this.logger.warn(`[file-watcher] failed to re-index ${sourceFile}:`, error);
     }
+  }
+
+  private indexMarkdownTree(dir: string): void {
+    for (const filePath of listFiles(dir, isMarkdownFile)) this.reindexPath(filePath);
   }
 
   private enqueue(ids: string[]): number {

--- a/tests/http/watcher/file-watcher.test.ts
+++ b/tests/http/watcher/file-watcher.test.ts
@@ -123,7 +123,23 @@ describe('watcher HTTP routes', () => {
     expect(logs.some((line) => line.includes('re-indexed ψ/learn/github.com/owner/repo/watch.md'))).toBe(true);
 
     const status = await call('/api/v1/watcher/status');
-    expect(status.body.events[0]).toMatchObject({ type: 'indexed', docs: 1, jobs: 2 });
+    expect(status.body.events.some((event: any) =>
+      event.type === 'indexed' && event.docs === 1 && event.jobs === 2,
+    )).toBe(true);
+  });
+
+  test('discovers nested ψ/learn directories created after start', async () => {
+    const filePath = path.join(repoRoot, 'ψ', 'learn', 'github.com', 'owner', 'repo', 'fresh.md');
+
+    await call('/api/v1/watcher/start', { method: 'POST' });
+    await sleep(50);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, '# Fresh\n\n## Finding\n\nNew directory trees must be scanned.', 'utf8');
+
+    await waitFor(() => count('indexing_jobs') === Object.keys(MODELS).length, 2_500);
+
+    const row = db.query<{ source_file: string }, []>('SELECT source_file FROM oracle_documents').get();
+    expect(row?.source_file).toBe('ψ/learn/github.com/owner/repo/fresh.md');
   });
 
   test('debounces bursty writes into one re-index event', async () => {


### PR DESCRIPTION
## Summary
- ensure the learn watcher creates ψ learn roots so new /learn output has a watched parent
- scan newly discovered watcher directories for existing Markdown files before waiting for future fs events
- cover nested ψ/learn directories created after watcher startup in HTTP and daemon watcher tests

## Validation
- ✅ `bunx tsc --noEmit` (verified against alpha-based commit tree)
- ✅ `bun test tests/http/learn/auto-index.test.ts tests/http/watcher/file-watcher.test.ts src/indexer/__tests__/learn-watcher.test.ts`
- ✅ changed files ≤250 lines
- ⚠️ `bun test` full suite currently fails on unrelated pre-existing suites (56 failed / 1676 passed / 8 skipped in alpha-based commit tree); watcher/learn tests above are green.
