### PR TITLE
docs: add export recovery guidance

### DIFF
--- a/frontend/src/components/export/ExportHelp.tsx
+++ b/frontend/src/components/export/ExportHelp.tsx
@@ -28,6 +28,12 @@ const examples = [
   'bun run tools/export-app/index.ts --output ./backup/export-app --db ./oracle.db',
 ];
 
+const recoverySteps = [
+  'Run Test connection first; it verifies the backend URL and collection counts before any export starts.',
+  'If an export fails, keep the same backend URL and payload, then use Retry before changing settings.',
+  'Keep the generated manifest.json with each backup so migrations can confirm collection and graph coverage.',
+];
+
 function CodeLine({ children }: { children: string }) {
   return (
     <code className="block overflow-x-auto rounded-xl border border-white/10 bg-black/30 px-3 py-2 font-mono text-xs text-slate-100">
@@ -98,6 +104,12 @@ export function ExportHelp({
           <ul className="grid gap-2 text-sm text-slate-300">
             {batchFiles.map((file) => <li key={file} className="font-mono text-xs">{file}</li>)}
           </ul>
+        </HelpBlock>
+
+        <HelpBlock title="Recovery & retry">
+          <ol className="grid gap-2 text-sm text-slate-300">
+            {recoverySteps.map((step) => <li key={step}>{step}</li>)}
+          </ol>
         </HelpBlock>
       </div>
 

--- a/tests/frontend/components/export/export-help.test.tsx
+++ b/tests/frontend/components/export/export-help.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'bun:test';
+import { ExportHelp } from '../../../../frontend/src/components/export/ExportHelp';
+import { htmlFor } from '../../_render';
+
+describe('ExportHelp', () => {
+  test('documents recovery and retry steps for migration-safe exports', () => {
+    const html = htmlFor(<ExportHelp backendUrl="http://oracle.local:47778" />);
+
+    expect(html).toContain('Recovery &amp; retry');
+    expect(html).toContain('Run Test connection first');
+    expect(html).toContain('use Retry before changing settings');
+    expect(html).toContain('manifest.json');
+    expect(html).toContain('export ORACLE_API=http://oracle.local:47778');
+  });
+});


### PR DESCRIPTION
## Summary
- Add Recovery & retry guidance to the Export app guide for #1783 docs sub-task.
- Cover the guide copy with a frontend render test.

## Validation
- `bun test tests/frontend/components/export tests/frontend/components/export-progress.test.tsx tests/http/export`
- `bunx tsc --noEmit`
- `wc -l frontend/src/components/export/ExportHelp.tsx tests/frontend/components/export/export-help.test.tsx`

Refs #1783
