### PR TITLE
fix: harden export app loading errors

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -54,7 +54,7 @@ export function AppShell({
     { to: '/status', label: 'Status', description: 'Server health from /api/v1/health' },
     { to: '/canvas/plugins', label: 'Canvas Plugins', description: 'Canvas registry from /api/canvas/plugins' },
     { to: '/search', label: 'Search', description: 'Full-text menu search' },
-    { to: '/export', label: 'Export App', description: 'Download app collections' },
+    { to: '/export', label: 'Export App', description: 'Legacy v2 JSON/Markdown backups' },
     { to: '/vector', label: 'Vector Dashboard', description: 'Collection health and indexing', end: true },
     { to: '/vector/documents', label: 'Document Browser', description: 'Browse indexed vector documents' },
     { to: '/vector/search', label: 'Vector Search', description: 'Semantic preview by collection' },

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -54,7 +54,7 @@ export function AppShell({
     { to: '/status', label: 'Status', description: 'Server health from /api/v1/health' },
     { to: '/canvas/plugins', label: 'Canvas Plugins', description: 'Canvas registry from /api/canvas/plugins' },
     { to: '/search', label: 'Search', description: 'Full-text menu search' },
-    { to: '/export', label: 'Export App', description: 'Legacy v2 JSON/Markdown backups' },
+    { to: '/export', label: 'Export App', description: 'Download app collections' },
     { to: '/vector', label: 'Vector Dashboard', description: 'Collection health and indexing', end: true },
     { to: '/vector/documents', label: 'Document Browser', description: 'Browse indexed vector documents' },
     { to: '/vector/search', label: 'Vector Search', description: 'Semantic preview by collection' },

--- a/frontend/src/pages/ExportApp.tsx
+++ b/frontend/src/pages/ExportApp.tsx
@@ -4,11 +4,14 @@ import { BackendSelector, DEFAULT_BACKEND_URL, normalizeBackendUrl } from '../co
 import { ExportProgress } from '../components/export/ExportProgress';
 import {
   backendApiUrl,
+  exportResponseError,
   exportAppFormats,
   exportProgressUrl,
   legacyDirectExportLink,
+  messageFromPayload,
   normalizeExportAppCollections,
   progressPatchFromExportPayload,
+  readExportPayload,
   resolveDownloadLink,
   type ExportAppFormat,
   type ExportDownloadLink,
@@ -25,11 +28,6 @@ type ExportAppProps = {
   fetcher?: Fetcher;
   autoLoad?: boolean;
 };
-
-async function jsonPayload(response: Response): Promise<unknown> {
-  const text = await response.text();
-  return text ? JSON.parse(text) : {};
-}
 
 function collectionLabel(collection: LegacyExportCollection): string {
   const count = typeof collection.count === 'number' ? ` · ${collection.count.toLocaleString()} rows` : '';
@@ -94,7 +92,6 @@ export function ExportApp({ initialBackendUrl = DEFAULT_BACKEND_URL, fetcher = g
   }
 
   async function loadCollections(targetUrl = backendUrl) {
-    if (!fetcher) throw new Error('fetch is unavailable in this runtime.');
     const normalized = normalizeBackendUrl(targetUrl);
     setBackendUrl(normalized);
     setLoadState('loading');
@@ -104,11 +101,13 @@ export function ExportApp({ initialBackendUrl = DEFAULT_BACKEND_URL, fetcher = g
     closeProgress();
     setProgress({ status: 'idle', jobId: null, progress: 0 });
     try {
+      if (!fetcher) throw new Error('fetch is unavailable in this runtime.');
+      const path = '/api/v1/export/app/collections';
       const response = await fetcher(backendApiUrl(normalized, '/api/v1/export/app/collections'), {
         headers: { accept: 'application/json' },
       });
-      if (!response.ok) throw new Error(`/api/v1/export/app/collections returned ${response.status}`);
-      const next = normalizeExportAppCollections(await jsonPayload(response));
+      if (!response.ok) throw new Error(await exportResponseError(response, path));
+      const next = normalizeExportAppCollections(await readExportPayload(response, path));
       setCollections(next);
       setCollection((current) => next.find((item) => item.id === current)?.id ?? next[0]?.id ?? '');
       setLoadState('ready');
@@ -121,7 +120,11 @@ export function ExportApp({ initialBackendUrl = DEFAULT_BACKEND_URL, fetcher = g
   }
 
   async function triggerExport() {
-    if (!fetcher || !selected) return;
+    if (!fetcher || !selected) {
+      setError(!fetcher ? 'fetch is unavailable in this runtime.' : 'Load a collection before starting export.');
+      setExportState('error');
+      return;
+    }
     setExportState('exporting');
     setError('');
     setDownload(null);
@@ -130,6 +133,7 @@ export function ExportApp({ initialBackendUrl = DEFAULT_BACKEND_URL, fetcher = g
     const normalized = normalizeBackendUrl(backendUrl);
     const payload = { collection: selected.id, format, includeGraph: true, includeMetadata: true };
     try {
+      const path = '/api/v1/export/app/run';
       const response = await fetcher(backendApiUrl(normalized, '/api/v1/export/app/run'), {
         method: 'POST',
         headers: { accept: 'application/json', 'content-type': 'application/json' },
@@ -142,8 +146,11 @@ export function ExportApp({ initialBackendUrl = DEFAULT_BACKEND_URL, fetcher = g
         setExportState('ready');
         return;
       }
-      const body = await jsonPayload(response);
-      if (!response.ok) throw new Error(progressPatchFromExportPayload(body).error ?? `/api/v1/export/app/run returned ${response.status}`);
+      const body = await readExportPayload(response, path);
+      if (!response.ok) {
+        const detail = progressPatchFromExportPayload(body).error ?? messageFromPayload(body);
+        throw new Error(`${path} returned ${response.status}${detail ? `: ${detail}` : ''}`);
+      }
       const link = resolveDownloadLink(normalized, body, selected.id, format);
       if (!link) throw new Error('Export response did not include a download URL or job id.');
       const patch = progressPatchFromExportPayload(body);
@@ -166,10 +173,7 @@ export function ExportApp({ initialBackendUrl = DEFAULT_BACKEND_URL, fetcher = g
     }
   }
 
-  useEffect(() => {
-    if (autoLoad) void loadCollections(backendUrl);
-  }, [autoLoad]);
-
+  useEffect(() => { if (autoLoad) void loadCollections(backendUrl); }, [autoLoad]);
   useEffect(() => () => closeProgress(), []);
 
   return (
@@ -195,7 +199,13 @@ export function ExportApp({ initialBackendUrl = DEFAULT_BACKEND_URL, fetcher = g
       </section>
 
       {loadState === 'loading' ? <LoadingPanel title="Loading export collections" detail="Calling /api/v1/export/app/collections on the selected backend." /> : null}
-      {loadState === 'error' ? <ErrorMessage title="Could not load legacy backend collections." message={error} /> : null}
+      {loadState === 'error' ? (
+        <ErrorMessage
+          title="Could not load legacy backend collections."
+          message={error}
+          action={<button className="focus-ring rounded-lg border border-red-200/30 px-3 py-2 font-semibold text-red-50 hover:bg-red-200/10" type="button" onClick={() => void loadCollections()}>Retry loading collections</button>}
+        />
+      ) : null}
       {exportState === 'error' ? <ErrorMessage title="Could not start export." message={error} /> : null}
 
       <section className="grid gap-4 lg:grid-cols-2">
@@ -211,6 +221,9 @@ export function ExportApp({ initialBackendUrl = DEFAULT_BACKEND_URL, fetcher = g
           <ul className="mt-4 grid max-h-72 gap-2 overflow-auto" aria-label="Legacy export collections">
             {collections.map((item) => <li key={item.id} className="rounded-xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-slate-300">{collectionLabel(item)}</li>)}
           </ul>
+          {loadState === 'ready' && !collections.length ? (
+            <p className="mt-4 rounded-xl border border-dashed border-white/10 p-4 text-sm text-slate-500">No collections are available from this backend. Check the URL, then reload collections.</p>
+          ) : null}
         </div>
 
         <div className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="format-title">

--- a/frontend/src/pages/VectorSettingsPage.tsx
+++ b/frontend/src/pages/VectorSettingsPage.tsx
@@ -10,7 +10,7 @@ export function VectorSettingsPage() {
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Vector settings</p>
         <h1 id="vector-settings-title" className="mt-2 text-3xl font-semibold text-white">Vector settings</h1>
         <p className="mt-2 text-sm text-slate-400">
-          Configure vector search, embedding providers, storage services, adapters, and backfill jobs.
+          Configure adapters, embedding models, vector search, storage services, and backfill jobs.
         </p>
       </header>
 

--- a/frontend/src/pages/exportAppHelpers.ts
+++ b/frontend/src/pages/exportAppHelpers.ts
@@ -138,3 +138,30 @@ export function progressPatchFromExportPayload(payload: unknown): Partial<Export
     error: stringField(job, ['error', 'message']) || undefined,
   };
 }
+
+export async function readExportPayload(response: Response, path: string): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`${path} returned invalid JSON`);
+  }
+}
+
+export function messageFromPayload(payload: unknown): string {
+  if (!isRecord(payload)) return '';
+  const direct = text(payload.error, payload.message, payload.detail);
+  if (direct) return direct;
+  const nested = payload.data;
+  return isRecord(nested) ? text(nested.error, nested.message, nested.detail) : '';
+}
+
+export async function exportResponseError(response: Response, path: string): Promise<string> {
+  try {
+    const detail = messageFromPayload(await readExportPayload(response, path));
+    return `${path} returned ${response.status}${detail ? `: ${detail}` : ''}`;
+  } catch (error) {
+    return error instanceof Error ? error.message : `${path} returned ${response.status}`;
+  }
+}

--- a/frontend/src/routeMeta.ts
+++ b/frontend/src/routeMeta.ts
@@ -73,7 +73,7 @@ export function routeMeta(pathname: string, search = ''): RouteMeta {
   if (pathname === '/canvas/plugins') return base('Canvas plugins', 'Canvas', 'Canvas plugin registry and standalone status.', [{ label: 'Canvas plugins' }]);
   if (pathname === '/metrics') return base('Runtime metrics', 'Metrics', 'Runtime counters from /api/v1/metrics.', [{ label: 'Metrics' }]);
   if (pathname === '/search') return base('Search', 'Search', 'Search menu, plugin, and MCP tool surfaces.', [{ label: 'Search' }]);
-  if (pathname === '/export') return base('Export app', 'Export', 'Connect to an old Oracle v2 backend and download JSON or Markdown backups.', [{ label: 'Export app' }]);
+  if (pathname === '/export') return base('Export app', 'Export', 'Connect to an old Oracle v2 backend and download JSON, CSV, or Markdown backups.', [{ label: 'Export app' }]);
   if (pathname === '/learn') return base('Learn entries', 'Learn', 'Capture and edit Oracle learnings.', [{ label: 'Learn' }]);
   if (pathname === '/vector') return base('Vector dashboard', 'Vector', 'Collection health, search, and export status.', [{ label: 'Vector dashboard' }]);
   if (pathname === '/mcp') return base('MCP tools', 'MCP', 'Browse available MCP tool schemas and groups.', [{ label: 'MCP tools' }]);

--- a/tests/frontend/pages/export-app.test.tsx
+++ b/tests/frontend/pages/export-app.test.tsx
@@ -2,8 +2,11 @@ import { describe, expect, test } from 'bun:test';
 import { ExportApp } from '../../../frontend/src/pages/ExportApp';
 import {
   backendApiUrl,
+  exportResponseError,
   legacyDirectExportLink,
+  messageFromPayload,
   normalizeExportAppCollections,
+  readExportPayload,
   resolveDownloadLink,
 } from '../../../frontend/src/pages/exportAppHelpers';
 import { htmlFor } from '../_render';
@@ -33,6 +36,17 @@ describe('ExportApp legacy v2 UI', () => {
       .toBe('oracle_documents.csv');
     expect(legacyDirectExportLink('localhost:47778', 'oracle_documents', 'markdown').url)
       .toContain('/api/v1/export/app?collection=oracle_documents&format=markdown');
+    expect(legacyDirectExportLink('localhost:47778', 'oracle_documents', 'csv').filename)
+      .toBe('oracle_documents.csv');
+  });
+
+  test('extracts backend error payloads and invalid JSON failures', async () => {
+    const unavailable = new Response(JSON.stringify({ error: 'database offline' }), { status: 503 });
+    expect(await exportResponseError(unavailable, '/api/v1/export/app/run'))
+      .toBe('/api/v1/export/app/run returned 503: database offline');
+    expect(messageFromPayload({ data: { message: 'nested failure' } })).toBe('nested failure');
+    await expect(readExportPayload(new Response('{bad'), '/api/v1/export/app/collections'))
+      .rejects.toThrow('/api/v1/export/app/collections returned invalid JSON');
   });
 
   test('renders configurable backend and JSON/CSV/Markdown export controls', () => {

--- a/tools/export-app/README.md
+++ b/tools/export-app/README.md
@@ -98,3 +98,21 @@ commands; set `ORACLE_ROOT` when the local CLI should run from a specific clone.
 3. Review collection counts and estimated size in the UI.
 4. Preview graph relationships when exporting a full bundle.
 5. Run `maw arra export` for one collection or batch mode for full snapshots.
+
+## UI Loading And Error States
+
+The React export app is intentionally safe to use before a migration:
+
+- **Loading collections** calls `GET /api/v1/export/app/collections` on the
+  selected backend and disables the reload button while the request is active.
+- **Backend errors** display the backend `error`, `message`, or nested
+  `data.message` value when one is returned; invalid JSON is reported as a
+  response-shape problem so operators do not mistake it for an empty export.
+- **Empty collection lists** show a no-data state instead of enabling an export
+  button against an unknown collection.
+- **Older Oracle v2 backends** that do not implement `POST
+  /api/v1/export/app/run` fall back to the direct download URL with the selected
+  collection, format, graph, and metadata query parameters.
+
+If the UI cannot reach the backend, verify the backend URL, check CORS/proxy
+configuration, then retry loading collections before starting migration work.


### PR DESCRIPTION
## Summary
- Hardened Export App collection loading and export start failures with backend error payload parsing, invalid-JSON messaging, retry action, and empty collection state.
- Added CSV as an Export App UI/direct-download format and documented loading/error/retry operator guidance.
- Kept latest alpha frontend route copy green for vector settings after merging current alpha.

## Validation
- `bunx tsc --noEmit`
- `bun test tests/frontend/`
- `bun test tests/http/export tests/tools/export-app.test.ts tests/tools/export-app/export-app.test.ts`
- `(cd frontend && bun run build)`
- `git diff --check`
- `git diff --name-only origin/alpha...HEAD | xargs wc -l` (all changed files ≤250 lines)
