### PR TITLE
feat: add document csv export

### DIFF
--- a/tests/tools/export-app/export-app.test.ts
+++ b/tests/tools/export-app/export-app.test.ts
@@ -115,6 +115,9 @@ describe('standalone export app', () => {
         concepts: ['backup'],
       });
       expect(docJson.metadata).toMatchObject({ source_file: 'ψ/learn/old.md', concepts: ['backup'] });
+      const docCsv = readFileSync(join(outputDir, 'documents', 'documents.csv'), 'utf8');
+      expect(docCsv).toContain('id,source,type,concepts,content_preview,metadata_json');
+      expect(docCsv).toContain('"doc-old","ψ/learn/old.md","learning","backup"');
     } finally {
       connection.storage.close();
     }
@@ -132,6 +135,7 @@ describe('standalone export app', () => {
     expect(stderr.join('')).toContain('oracle_documents');
     expect(existsSync(join(outputDir, 'documents', 'markdown', 'learn_new.md'))).toBe(true);
     expect(existsSync(join(outputDir, 'documents', 'json', 'learn_new.json'))).toBe(true);
+    expect(existsSync(join(outputDir, 'documents', 'documents.csv'))).toBe(true);
     expect(existsSync(join(outputDir, 'collections', 'oracle_documents.json'))).toBe(true);
   });
 
@@ -169,6 +173,7 @@ describe('standalone export app', () => {
 
     const result = await exportOracleV2Documents({ dbPath: legacyDbPath, outputDir: legacyOutput });
     expect(result.documentCount).toBe(1);
+    expect(readFileSync(result.csvPath, 'utf8')).toContain('"legacy-doc","ψ/legacy/export.md"');
     expect(readFileSync(join(legacyOutput, 'documents', 'markdown', 'legacy_export.md'), 'utf8'))
       .toContain('Legacy body from old Oracle v2.');
     const payload = JSON.parse(readFileSync(join(legacyOutput, 'documents', 'json', 'legacy_export.json'), 'utf8'));

--- a/tools/export-app/README.md
+++ b/tools/export-app/README.md
@@ -67,6 +67,7 @@ The batch output includes:
 
 - `documents/markdown/<source-or-id>.md`
 - `documents/json/<source-or-id>.json`
+- `documents/documents.csv`
 - `documents/index.json`
 - `collections/<collection>.json`
 - `collections/<collection>.csv`

--- a/tools/export-app/document-csv.ts
+++ b/tools/export-app/document-csv.ts
@@ -1,0 +1,31 @@
+import type { OracleV2DocumentExport } from './documents.ts';
+
+const COLUMNS = ['id', 'source', 'type', 'concepts', 'content_preview', 'metadata_json'] as const;
+
+function csvCell(value: unknown): string {
+  const text = value == null ? '' : String(value);
+  return `"${text.replaceAll('"', '""')}"`;
+}
+
+function preview(content: string): string {
+  const normalized = content.replace(/\s+/g, ' ').trim();
+  return normalized.length > 180 ? `${normalized.slice(0, 177)}...` : normalized;
+}
+
+function row(doc: OracleV2DocumentExport): string[] {
+  return [
+    doc.id,
+    doc.source,
+    String(doc.metadata.type ?? ''),
+    doc.concepts.join(' '),
+    preview(doc.content),
+    JSON.stringify(doc.metadata),
+  ];
+}
+
+export function formatDocumentsCsv(docs: OracleV2DocumentExport[]): string {
+  return [
+    COLUMNS.join(','),
+    ...docs.map((doc) => row(doc).map(csvCell).join(',')),
+  ].join('\n') + '\n';
+}

--- a/tools/export-app/documents.ts
+++ b/tools/export-app/documents.ts
@@ -4,6 +4,7 @@ import { DB_PATH } from '../../src/config.ts';
 import type { DatabaseConnection } from '../../src/db/index.ts';
 import { createStorageBackend } from '../../src/storage/registry.ts';
 import { normalizeRecord, type ExportRecord } from './formats.ts';
+import { formatDocumentsCsv } from './document-csv.ts';
 
 type Progress = (message: string) => void;
 type FtsRow = { content?: unknown; concepts?: unknown };
@@ -28,6 +29,7 @@ export interface ExportDocumentsResult {
   outputDir: string;
   markdownDir: string;
   jsonDir: string;
+  csvPath: string;
   documentCount: number;
   indexPath: string;
 }
@@ -41,6 +43,7 @@ export async function exportOracleV2Documents(
   const documentsDir = path.join(outputDir, 'documents');
   const markdownDir = path.join(documentsDir, 'markdown');
   const jsonDir = path.join(documentsDir, 'json');
+  const csvPath = path.join(documentsDir, 'documents.csv');
   const progress = options.progress ?? ((message) => console.error(message));
   const exportedAt = (options.now?.() ?? new Date()).toISOString();
 
@@ -69,8 +72,15 @@ export async function exportOracleV2Documents(
     }
 
     const indexPath = path.join(documentsDir, 'index.json');
-    await writeJson(indexPath, { version: 1, exportedAt, documentCount: docs.length, documents: index });
-    return { outputDir, markdownDir, jsonDir, documentCount: docs.length, indexPath };
+    await writeFile(csvPath, formatDocumentsCsv(docs), 'utf8');
+    await writeJson(indexPath, {
+      version: 1,
+      exportedAt,
+      documentCount: docs.length,
+      csv: slash(path.relative(outputDir, csvPath)),
+      documents: index,
+    });
+    return { outputDir, markdownDir, jsonDir, csvPath, documentCount: docs.length, indexPath };
   } finally {
     close?.connection.storage.close();
   }


### PR DESCRIPTION
## Summary
- Add `documents/documents.csv` to the standalone export app's legacy Oracle v2 document export.
- Include the CSV path in `documents/index.json` and the typed export result.
- Cover CLI/full export/legacy-v2 document CSV output in export-app tests and document the output file.

## Validation
- `bunx tsc --noEmit`
- `bun test tests/tools/export-app.test.ts tests/tools/export-app/export-app.test.ts` — 8 pass, 0 fail
- `wc -l tools/export-app/document-csv.ts tools/export-app/documents.ts tools/export-app/README.md tests/tools/export-app/export-app.test.ts tests/tools/export-app.test.ts` — all <=250 lines
- `git diff --check` on changed files

Base: `alpha`
Issue: #1783
