### PR TITLE
feat(export): add Oracle v2 markdown artifacts

### DIFF
--- a/src/routes/export/history.ts
+++ b/src/routes/export/history.ts
@@ -7,6 +7,7 @@ import { ORACLE_DATA_DIR } from '../../config.ts';
 import { db, exportJobs } from '../../db/index.ts';
 import { createOracleV2Client, type OracleV2Document } from '../../lib/oracle-v2-client.ts';
 import { exportHistoryRunBody, type ExportHistoryJob } from './model.ts';
+import { formatOracleV2DocumentsMarkdown } from './oracle-v2-markdown.ts';
 
 function clean(value: string): string {
   return value.trim();
@@ -34,21 +35,25 @@ async function writeOracleV2Export(
   if (!names.includes(job.collection)) throw new Error(`Oracle v2 collection not found: ${job.collection}`);
 
   const documents = await client.listDocuments(job.collection);
-  const filename = `${safeName(job.collection)}-${job.id}.json`;
+  const exportedAt = new Date(job.timestamp).toISOString();
+  const isMarkdown = job.format === 'markdown';
+  const filename = `${safeName(job.collection)}-${job.id}.${isMarkdown ? 'md' : 'json'}`;
   const filePath = path.join(ORACLE_DATA_DIR, 'exports', 'oracle-v2', filename);
-  const payload = {
-    version: 1,
-    source: 'oracle-v2',
-    baseUrl,
-    exportedAt: new Date(job.timestamp).toISOString(),
-    collection: job.collection,
-    documentCount: documents.length,
-    collections,
-    documents,
-  };
+  const payload = isMarkdown
+    ? formatOracleV2DocumentsMarkdown({ baseUrl, collection: job.collection, exportedAt, documents, collections })
+    : `${JSON.stringify({
+      version: 1,
+      source: 'oracle-v2',
+      baseUrl,
+      exportedAt,
+      collection: job.collection,
+      documentCount: documents.length,
+      collections,
+      documents,
+    }, null, 2)}\n`;
 
   await mkdir(path.dirname(filePath), { recursive: true });
-  await writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  await writeFile(filePath, payload, 'utf8');
   return { filePath, filename, documents, collections: names };
 }
 
@@ -64,9 +69,9 @@ export function createExportHistoryRoutes() {
       }
 
       const baseUrl = oracleV2Url(body);
-      if (baseUrl && format !== 'json') {
+      if (baseUrl && format !== 'json' && format !== 'markdown') {
         set.status = 400;
-        return { error: 'Oracle v2 export supports json format only', format };
+        return { error: 'Oracle v2 export supports json or markdown format only', format };
       }
 
       const job: ExportHistoryJob = {
@@ -87,7 +92,7 @@ export function createExportHistoryRoutes() {
             artifact: {
               filePath: artifact.filePath,
               filename: artifact.filename,
-              contentType: 'application/json; charset=utf-8',
+              contentType: format === 'markdown' ? 'text/markdown; charset=utf-8' : 'application/json; charset=utf-8',
               documentCount: artifact.documents.length,
             },
             collections: artifact.collections,

--- a/src/routes/export/oracle-v2-markdown.ts
+++ b/src/routes/export/oracle-v2-markdown.ts
@@ -1,0 +1,88 @@
+import type { OracleV2Collection, OracleV2Document, OracleV2Record } from '../../lib/oracle-v2-client.ts';
+
+export interface OracleV2MarkdownInput {
+  baseUrl: string;
+  collection: string;
+  exportedAt: string;
+  documents: OracleV2Document[];
+  collections: OracleV2Collection[];
+}
+
+export function formatOracleV2DocumentsMarkdown(input: OracleV2MarkdownInput): string {
+  const lines = [
+    `# Oracle v2 export: ${input.collection}`,
+    '',
+    `- Source: ${input.baseUrl}`,
+    `- Exported: ${input.exportedAt}`,
+    `- Documents: ${input.documents.length}`,
+    `- Collections: ${input.collections.map((item) => item.name).join(', ') || 'unknown'}`,
+    '',
+  ];
+
+  input.documents.forEach((doc, index) => {
+    lines.push(...documentSection(doc, input.collection, index), '');
+  });
+  return lines.join('\n').trimEnd() + '\n';
+}
+
+function documentSection(doc: OracleV2Document, collection: string, index: number): string[] {
+  const meta = metadata(doc);
+  const id = firstText(doc.id, meta.id, `document-${index + 1}`);
+  const source = firstText(doc.source_file, doc.source, doc.sourceFile, meta.source_file, meta.sourceFile, meta.source);
+  const concepts = parseConcepts(doc.concepts ?? meta.concepts);
+  const body = firstText(doc.content, doc.document, doc.text, meta.content, meta.document);
+  const title = firstText(doc.title, meta.title, source, id);
+
+  return [
+    `## ${title}`,
+    '',
+    '```yaml',
+    `id: ${yamlScalar(id)}`,
+    `collection: ${yamlScalar(collection)}`,
+    `source_file: ${yamlScalar(source)}`,
+    conceptsYaml(concepts),
+    '```',
+    '',
+    body || '_No document body returned._',
+  ];
+}
+
+function metadata(doc: OracleV2Document): OracleV2Record {
+  return isRecord(doc.metadata) ? doc.metadata : {};
+}
+
+function isRecord(value: unknown): value is OracleV2Record {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function firstText(...values: unknown[]): string {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value.trim();
+    if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  }
+  return '';
+}
+
+function parseConcepts(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map((item) => firstText(item)).filter(Boolean);
+  if (typeof value !== 'string' || !value.trim()) return [];
+  try {
+    const parsed = JSON.parse(value);
+    if (Array.isArray(parsed)) return parsed.map((item) => firstText(item)).filter(Boolean);
+  } catch {
+    // fall through to legacy comma/space separated concept strings
+  }
+  return value.split(/[, ]+/).map((item) => item.trim()).filter(Boolean);
+}
+
+function conceptsYaml(concepts: string[]): string {
+  if (concepts.length === 0) return 'concepts: []';
+  return ['concepts:', ...concepts.map((concept) => `  - ${yamlScalar(concept)}`)].join('\n');
+}
+
+function yamlScalar(value: unknown): string {
+  if (value == null || value === '') return 'null';
+  if (typeof value === 'number') return Number.isFinite(value) ? String(value) : 'null';
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  return JSON.stringify(String(value));
+}

--- a/tests/http/export/oracle-v2-markdown.test.ts
+++ b/tests/http/export/oracle-v2-markdown.test.ts
@@ -1,0 +1,111 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const root = mkdtempSync(join(tmpdir(), 'arra-export-v2-md-'));
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = join(root, 'oracle.db');
+
+const dbMod = await import('../../../src/db/index.ts');
+dbMod.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+const { exportRoutes } = await import('../../../src/routes/export/index.ts');
+
+function legacyOracle() {
+  const seen: string[] = [];
+  const server = Bun.serve({
+    hostname: '127.0.0.1',
+    port: 0,
+    fetch: (req) => {
+      const url = new URL(req.url);
+      seen.push(`${url.pathname}${url.search}`);
+      if (url.pathname === '/api/collections') {
+        return Response.json({ collections: [{ name: 'oracle_documents', count: 2 }] });
+      }
+      if (url.pathname === '/api/documents' && url.searchParams.get('collection') === 'oracle_documents') {
+        return Response.json({ documents: [
+          {
+            id: 'legacy-a',
+            title: 'Alpha note',
+            content: '# Alpha\n\nAlpha legacy body',
+            metadata: { source_file: 'psi/a.md', concepts: ['alpha', 'backup'] },
+          },
+          { id: 'legacy-b', document: 'Bravo legacy body', source_file: 'psi/b.md', concepts: 'bravo migrate' },
+        ] });
+      }
+      return Response.json({ error: 'not found' }, { status: 404 });
+    },
+  });
+  return { server, seen };
+}
+
+async function postExport(body: Record<string, unknown>): Promise<Response> {
+  const api = new Elysia().use(exportRoutes);
+  return api.handle(new Request('http://local/api/export/run', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+}
+
+afterAll(() => {
+  dbMod.closeDb();
+  if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = savedDataDir;
+  if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = savedDbPath;
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('Oracle v2 markdown export history route', () => {
+  test('writes a Markdown artifact for Oracle v2 documents', async () => {
+    const legacy = legacyOracle();
+    try {
+      const res = await postExport({
+        collection: 'oracle_documents',
+        format: 'markdown',
+        oracleV2Url: `http://127.0.0.1:${legacy.server.port}`,
+      });
+      const body = await res.json() as Record<string, any>;
+      const artifact = body.artifact as { filename: string; filePath: string };
+      const filename = artifact.filename;
+      const filePath = artifact.filePath;
+
+      expect(res.status).toBe(201);
+      expect(body.job).toMatchObject({ collection: 'oracle_documents', format: 'markdown' });
+      expect(body.artifact).toMatchObject({
+        filename: expect.stringContaining('oracle_documents'),
+        contentType: 'text/markdown; charset=utf-8',
+        documentCount: 2,
+      });
+      expect(filename.endsWith('.md')).toBe(true);
+      expect(existsSync(filePath)).toBe(true);
+
+      const markdown = readFileSync(filePath, 'utf8');
+      expect(markdown).toContain('# Oracle v2 export: oracle_documents');
+      expect(markdown).toContain('source_file: "psi/a.md"');
+      expect(markdown).toContain('- "alpha"');
+      expect(markdown).toContain('Alpha legacy body');
+      expect(markdown).toContain('Bravo legacy body');
+      expect(legacy.seen).toEqual(['/api/collections', '/api/documents?collection=oracle_documents']);
+    } finally {
+      legacy.server.stop(true);
+    }
+  });
+
+  test('keeps unsupported Oracle v2 formats rejected', async () => {
+    const res = await postExport({
+      collection: 'oracle_documents',
+      format: 'csv',
+      oracleV2Url: 'http://127.0.0.1:1',
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      error: 'Oracle v2 export supports json or markdown format only',
+      format: 'csv',
+    });
+  });
+});

--- a/tools/export-app/README.md
+++ b/tools/export-app/README.md
@@ -37,6 +37,9 @@ content while JSON keeps the full database metadata.
 The vector HTTP exporter advertises formats from
 `GET /api/v1/vector/export/formats`. The local batch exporter writes collection
 files under `collections/` and a top-level relationship export.
+When `/api/export/run` is pointed at a legacy Oracle v2 backend with
+`oracleV2Url`, `format: "json"` writes the metadata dump and
+`format: "markdown"` writes a readable document vault file.
 
 ## Graph Export
 


### PR DESCRIPTION
## Summary
- add Markdown artifact generation for `/api/export/run` when exporting from a legacy Oracle v2 backend
- preserve document body, source file, concepts, collection, and export metadata in a readable vault-style Markdown file
- document JSON vs Markdown behavior and cover unsupported Oracle v2 formats

Refs #1783

## Validation
- bunx tsc --noEmit
- bun test tests/http/export tests/tools/export-app.test.ts tests/tools/export-app/export-app.test.ts
- wc -l src/routes/export/history.ts src/routes/export/oracle-v2-markdown.ts tests/http/export/oracle-v2-markdown.test.ts tools/export-app/README.md
- git diff --check