### PR TITLE
feat: surface vector storage backend health

### DIFF
--- a/frontend/src/pages/VectorPage.tsx
+++ b/frontend/src/pages/VectorPage.tsx
@@ -19,12 +19,13 @@ import {
   type VectorCollectionCard,
   type VectorFreshnessCard,
   type VectorProviderHealthCard,
+  type VectorStorageHealthCard,
 } from './vector-dashboard-cards';
 
 type PageState = 'loading' | 'ready' | 'error';
 type VectorStatusClient = Pick<ApiClient, 'vectorIndexModels' | 'vectorHealth'>;
 type DownloadByCollection = Record<string, VectorExportFormat | undefined>;
-type VectorDashboardHealth = VectorHealthResponse & { providers?: VectorProviderHealthCard[]; freshness?: VectorFreshnessCard };
+type VectorDashboardHealth = VectorHealthResponse & { providers?: VectorProviderHealthCard[]; freshness?: VectorFreshnessCard; storage?: VectorStorageHealthCard[] };
 
 export interface VectorPageProps {
   modelsResponse?: VectorIndexModelsResponse | null;
@@ -171,7 +172,7 @@ export function VectorPage({
 
         <div className="grid gap-4">
           <VectorStatsCard cards={cards} />
-          <VectorHealthDashboardCard providers={dashboardHealth?.providers} freshness={dashboardHealth?.freshness} />
+          <VectorHealthDashboardCard providers={dashboardHealth?.providers} storage={dashboardHealth?.storage} freshness={dashboardHealth?.freshness} />
           <QuickExportCard cards={cards} formats={formats} downloads={downloads} onExport={onExport} />
           <VectorIndexPanel />
         </div>

--- a/frontend/src/pages/vector-dashboard-cards.tsx
+++ b/frontend/src/pages/vector-dashboard-cards.tsx
@@ -14,6 +14,7 @@ export interface VectorCollectionCard {
 }
 
 export type VectorProviderHealthCard = { type: string; status: 'green' | 'red'; available: boolean; detail?: string };
+export type VectorStorageHealthCard = { adapter: string; status: 'green' | 'red'; healthy: number; total: number; detail?: string };
 export type VectorFreshnessCard = {
   status: 'fresh' | 'empty' | 'stale';
   totalIndexed: number;
@@ -142,25 +143,30 @@ export function VectorStatsCard({ cards }: { cards: VectorCollectionCard[] }) {
 
 export function VectorHealthDashboardCard({
   providers = [],
+  storage = [],
   freshness,
 }: {
   providers?: VectorProviderHealthCard[];
+  storage?: VectorStorageHealthCard[];
   freshness?: VectorFreshnessCard;
 }) {
   const providerSummary = providers.length
     ? `${providers.filter((item) => item.available).length}/${providers.length} providers available`
     : 'Provider detection unavailable';
+  const storageSummary = storage.length ? `${storage.filter((item) => item.status === 'green').length}/${storage.length} storage backends healthy` : 'Storage status unavailable';
   return (
     <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-health-dashboard-title">
       <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Health</p>
       <h2 id="vector-health-dashboard-title" className="mt-2 text-2xl font-semibold text-white">Vector health dashboard</h2>
       <dl className="mt-4 grid gap-3 text-sm text-slate-300">
         <div><dt className="text-slate-500">Embedding providers</dt><dd className="text-lg font-semibold text-white">{providerSummary}</dd></div>
+        <div><dt className="text-slate-500">Storage backends</dt><dd className="text-lg font-semibold text-white">{storageSummary}</dd></div>
         <div><dt className="text-slate-500">Index freshness</dt><dd className="text-lg font-semibold text-white">{freshness ? freshnessLine(freshness) : 'Unknown'}</dd></div>
         <div><dt className="text-slate-500">Docs pending</dt><dd className="text-lg font-semibold text-white">{pendingLine(freshness)}</dd></div>
         <div><dt className="text-slate-500">Last indexed</dt><dd className="text-lg font-semibold text-white">{freshness?.lastIndexed ?? 'Unknown'}</dd></div>
       </dl>
       {providers.length ? <div className="mt-4 flex flex-wrap gap-2">{providers.map((provider) => <span key={provider.type} className={`rounded-full border px-2 py-1 text-xs font-semibold ${statusClasses(provider.available)}`}>{provider.type}: {provider.status}</span>)}</div> : null}
+      {storage.length ? <div className="mt-2 flex flex-wrap gap-2">{storage.map((item) => <span key={item.adapter} className={`rounded-full border px-2 py-1 text-xs font-semibold ${statusClasses(item.status === 'green')}`}>{item.adapter}: {item.healthy}/{item.total}</span>)}</div> : null}
     </section>
   );
 }

--- a/src/vector/health.ts
+++ b/src/vector/health.ts
@@ -26,6 +26,14 @@ export type VectorProviderHealth = {
   detail?: string;
 };
 
+export type VectorStorageHealth = {
+  adapter: string;
+  status: 'green' | 'red';
+  healthy: number;
+  total: number;
+  detail?: string;
+};
+
 export type VectorFreshness = {
   status: 'fresh' | 'empty' | 'stale';
   totalIndexed: number;
@@ -41,6 +49,7 @@ export type VectorBackendHealth = {
   checked_at: string;
   providers?: VectorProviderHealth[];
   freshness?: VectorFreshness;
+  storage?: VectorStorageHealth[];
 };
 
 
@@ -58,7 +67,29 @@ export function attachVectorDashboardHealth(
       detail: provider.error ?? provider.detail,
     })),
     freshness: health.freshness ?? buildVectorFreshness(health.engines),
+    storage: health.storage ?? buildVectorStorageHealth(health.engines),
   };
+}
+
+export function buildVectorStorageHealth(
+  engines: Array<Pick<VectorBackendEngine, 'adapter' | 'ok' | 'error'>>,
+): VectorStorageHealth[] {
+  const byAdapter = new Map<string, { healthy: number; total: number; errors: string[] }>();
+  for (const engine of engines) {
+    const adapter = engine.adapter || 'unknown';
+    const entry = byAdapter.get(adapter) ?? { healthy: 0, total: 0, errors: [] };
+    entry.total += 1;
+    if (engine.ok) entry.healthy += 1;
+    else if (engine.error) entry.errors.push(engine.error);
+    byAdapter.set(adapter, entry);
+  }
+  return Array.from(byAdapter.entries()).map(([adapter, entry]) => ({
+    adapter,
+    healthy: entry.healthy,
+    total: entry.total,
+    status: entry.healthy === entry.total ? 'green' as const : 'red' as const,
+    ...(entry.errors.length && { detail: entry.errors[0] }),
+  }));
 }
 
 export function buildVectorFreshness(
@@ -133,6 +164,7 @@ export async function readVectorBackendHealth(): Promise<VectorBackendHealth> {
     collections: engines,
     checked_at: new Date().toISOString(),
     freshness: buildVectorFreshness(engines, readSourceDocumentStats()),
+    storage: buildVectorStorageHealth(engines),
   };
 }
 

--- a/tests/frontend/pages/frontend-component-coverage.test.tsx
+++ b/tests/frontend/pages/frontend-component-coverage.test.tsx
@@ -36,11 +36,18 @@ describe('frontend component coverage', () => {
         { type: 'ollama', status: 'green', available: true, detail: 'local' },
         { type: 'openai', status: 'red', available: false, detail: 'missing key' },
       ]}
+      storage={[
+        { adapter: 'lancedb', status: 'green', healthy: 2, total: 2 },
+        { adapter: 'qdrant', status: 'red', healthy: 0, total: 1, detail: 'down' },
+      ]}
       freshness={{ status: 'stale', totalIndexed: 1532, sourceDocs: 1600, docsPending: 68, lastIndexed: '2026-06-16T00:00:00Z' }}
     />);
 
     expect(html).toContain('Vector health dashboard');
     expect(html).toContain('1/2 providers available');
+    expect(html).toContain('1/2 storage backends healthy');
+    expect(html).toContain('lancedb: 2/2');
+    expect(html).toContain('qdrant: 0/1');
     expect(html).toContain('stale · 1,532 indexed');
     expect(html).toContain('68 pending of 1,600 source docs');
     expect(html).toContain('2026-06-16T00:00:00Z');

--- a/tests/http/vector/phase4-polish.test.ts
+++ b/tests/http/vector/phase4-polish.test.ts
@@ -134,6 +134,20 @@ test('buildVectorFreshness reports pending source documents', async () => {
   });
 });
 
+test('buildVectorStorageHealth aggregates adapter health', async () => {
+  const { buildVectorStorageHealth } = await import('../../../src/vector/health.ts');
+  const storage = buildVectorStorageHealth([
+    { adapter: 'lancedb', ok: true },
+    { adapter: 'lancedb', ok: false, error: 'disk unavailable' },
+    { adapter: 'proxy', ok: true },
+  ]);
+
+  expect(storage).toEqual([
+    { adapter: 'lancedb', healthy: 1, total: 2, status: 'red', detail: 'disk unavailable' },
+    { adapter: 'proxy', healthy: 1, total: 1, status: 'green' },
+  ]);
+});
+
 test('FallbackEmbeddings switches to the next provider after primary failure', async () => {
   const { FallbackEmbeddings } = await import('../../../src/vector/embeddings.ts');
   const events: Array<{ from: string; to?: string }> = [];

--- a/tests/http/vector/status.test.ts
+++ b/tests/http/vector/status.test.ts
@@ -26,6 +26,10 @@ function createFetch() {
           { key: 'qdrant', model: 'qdrant-embed', collection: 'oracle_qdrant', count: 3, ok: true },
         ],
         freshness: { status: 'stale', totalIndexed: 15, sourceDocs: 20, docsPending: 8, lastIndexed: '2026-06-15T00:00:00.000Z' },
+        storage: [
+          { adapter: 'lancedb', status: 'green', healthy: 1, total: 1 },
+          { adapter: 'qdrant', status: 'green', healthy: 1, total: 1 },
+        ],
       }),
     }))
     .use(createVectorModelEndpoints({
@@ -59,6 +63,10 @@ test('GET /api/v1/vector/status and /api/v1/vector/models return vector status s
       { type: 'openai', available: false, status: 'red', detail: 'missing OPENAI_API_KEY' },
     ],
     freshness: { status: 'stale', totalIndexed: 15, sourceDocs: 20, docsPending: 8 },
+    storage: [
+      { adapter: 'lancedb', status: 'green', healthy: 1, total: 1 },
+      { adapter: 'qdrant', status: 'green', healthy: 1, total: 1 },
+    ],
   });
 
   const modelsRes = await fetcher(new Request('http://local/api/v1/vector/models'));


### PR DESCRIPTION
Refs #1436.

## Summary
- picked the next small Vector Section v2 subtask from #1440: health dashboard storage backend status
- aggregates vector engine health by storage adapter and includes it in `/api/v1/vector/health`
- renders storage backend health summary/pills in the Vector health dashboard card

## Validation
- `bunx tsc --noEmit`
- `bun test tests/http/vector/`
- `bun test tests/http/vector/status.test.ts tests/http/vector/phase4-polish.test.ts tests/frontend/pages/frontend-component-coverage.test.tsx`
- `git diff --check`
- file-size check: all changed files ≤250 lines

Note: this PR was built from `origin/alpha` on an isolated branch without switching the current worktree branch.
