### PR TITLE
feat: write export manifest schema

### DIFF
--- a/tests/tools/export-app/manifest-schema.test.ts
+++ b/tests/tools/export-app/manifest-schema.test.ts
@@ -1,0 +1,52 @@
+import { afterAll, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const root = mkdtempSync(join(tmpdir(), 'arra-export-schema-'));
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = join(root, 'oracle.db');
+
+const dbModule = await import('../../../src/db/index.ts');
+const exporterModule = await import('../../../tools/export-app/exporter.ts');
+
+const { createDatabase, resetDefaultDatabaseForTests } = dbModule;
+const { exportOracleData, EXPORT_MANIFEST_SCHEMA } = exporterModule;
+
+function restoreDbPath(): string {
+  return savedDbPath
+    ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
+}
+
+afterAll(() => {
+  if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = savedDataDir;
+  if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = savedDbPath;
+  resetDefaultDatabaseForTests(restoreDbPath());
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('writes a manifest JSON schema with required export fields', async () => {
+  const connection = createDatabase(join(root, 'schema.db'));
+  const outputDir = join(root, 'schema-export');
+
+  try {
+    await exportOracleData({
+      connection,
+      outputDir,
+      progress: () => {},
+      now: () => new Date('2026-01-02T03:04:05.006Z'),
+    });
+  } finally {
+    connection.storage.close();
+  }
+
+  const manifest = JSON.parse(readFileSync(join(outputDir, 'manifest.json'), 'utf8'));
+  const schema = JSON.parse(readFileSync(join(outputDir, 'manifest.schema.json'), 'utf8'));
+  expect(schema).toEqual(EXPORT_MANIFEST_SCHEMA);
+  expect(schema.required).toEqual(Object.keys(manifest));
+  expect(schema.properties.formats.items.enum).toEqual(['json', 'csv', 'markdown']);
+});

--- a/tools/export-app/exporter.ts
+++ b/tools/export-app/exporter.ts
@@ -16,6 +16,7 @@ import {
 } from './formats.ts';
 import { graphRelationships } from './graph.ts';
 import { exportOracleV2Documents } from './documents.ts';
+import { EXPORT_MANIFEST_SCHEMA } from './schema.ts';
 
 type ExportTable = Parameters<typeof getTableName>[0];
 type Progress = (message: string) => void;
@@ -44,6 +45,7 @@ export interface ExportMarkdownResult {
 
 export { graphRelationships, type GraphRelationship } from './graph.ts';
 export { exportOracleV2Documents, readOracleV2Documents } from './documents.ts';
+export { EXPORT_MANIFEST_SCHEMA } from './schema.ts';
 
 export function schemaTables(): ExportTable[] {
   return (Object.values(schema).filter(isTable) as ExportTable[])
@@ -77,6 +79,7 @@ export async function exportOracleData(options: ExportAppOptions): Promise<Expor
     const documentExport = await exportOracleV2Documents({ ...options, outputDir, connection, progress });
     await writeCollectionFiles(outputDir, 'relationships', relationships);
     await writeJson(path.join(outputDir, 'all-collections.json'), { exportedAt, collections: allCollections });
+    await writeJson(path.join(outputDir, 'manifest.schema.json'), EXPORT_MANIFEST_SCHEMA);
     await writeJson(path.join(outputDir, 'manifest.json'), {
       exportedAt,
       dbPath: options.dbPath ?? DB_PATH,

--- a/tools/export-app/schema.ts
+++ b/tools/export-app/schema.ts
@@ -1,0 +1,35 @@
+import { EXPORT_FORMATS } from './formats.ts';
+
+const manifestRequired = [
+  'exportedAt',
+  'dbPath',
+  'formats',
+  'collectionCount',
+  'rowCount',
+  'relationshipCount',
+  'documentCount',
+] as const;
+
+const nonNegativeInteger = { type: 'integer', minimum: 0 } as const;
+
+export const EXPORT_MANIFEST_SCHEMA = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'https://buildwithoracle.com/schemas/arra-oracle/export-manifest.schema.json',
+  title: 'Arra Oracle Export Manifest',
+  type: 'object',
+  additionalProperties: false,
+  required: manifestRequired,
+  properties: {
+    exportedAt: { type: 'string', format: 'date-time' },
+    dbPath: { type: 'string', minLength: 1 },
+    formats: {
+      type: 'array',
+      minItems: 1,
+      items: { enum: EXPORT_FORMATS },
+    },
+    collectionCount: nonNegativeInteger,
+    rowCount: nonNegativeInteger,
+    relationshipCount: nonNegativeInteger,
+    documentCount: nonNegativeInteger,
+  },
+} as const;


### PR DESCRIPTION
## Summary
- Add a versioned JSON Schema for the standalone export app `manifest.json` contract.
- Write `manifest.schema.json` next to every export manifest.
- Add a focused export-app test covering schema output, required fields, and advertised formats.

## Validation
- `bunx tsc --noEmit`
- `bun test tests/tools/export-app.test.ts tests/tools/export-app/export-app.test.ts tests/tools/export-app/manifest-schema.test.ts` — 9 pass, 0 fail
- `wc -l tools/export-app/schema.ts tools/export-app/exporter.ts tests/tools/export-app/manifest-schema.test.ts` — all <=250 lines
- `git diff --check` on changed files

Base: `alpha`
Issue: #1783
