### PR TITLE
feat: add vector model recommendation card

### DIFF
--- a/frontend/src/components/VectorModelRecommendationCard.tsx
+++ b/frontend/src/components/VectorModelRecommendationCard.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ErrorMessage, Spinner } from './AsyncState';
+import { fetchJson } from '../pages/vectorSettingsHelpers';
+
+type ProviderCost = {
+  provider?: string;
+  model?: string;
+  estimatedUsd?: number;
+  note?: string;
+};
+
+type CostEstimate = ProviderCost & {
+  docs: number;
+  tokensPerDoc: number;
+  totalTokens: number;
+  provider: string;
+  model: string;
+  estimatedUsd: number;
+  formula: string;
+  note: string;
+  recommendation: string;
+  availableProviders?: string[];
+  providerEstimates?: Record<string, ProviderCost>;
+  trackingEndpoint?: string;
+};
+
+type Props = {
+  defaultProvider?: string;
+  initialEstimate?: CostEstimate | null;
+};
+
+function formatUsd(value?: number): string {
+  if (typeof value !== 'number') return 'unknown';
+  return value === 0 ? 'Free / local' : `$${value.toFixed(4)}`;
+}
+
+function providerSummary(providers?: string[]): string {
+  return providers?.length ? `${providers.join(', ')} available` : 'Provider availability pending auto-detect';
+}
+
+export function VectorModelRecommendationCard({ defaultProvider = 'openai', initialEstimate }: Props) {
+  const [estimate, setEstimate] = useState<CostEstimate | null>(initialEstimate ?? null);
+  const [loading, setLoading] = useState(initialEstimate === undefined);
+  const [error, setError] = useState('');
+  const estimates = useMemo(() => Object.entries(estimate?.providerEstimates ?? {}), [estimate]);
+
+  useEffect(() => {
+    if (initialEstimate !== undefined) return;
+    let active = true;
+    setLoading(true);
+    fetchJson<CostEstimate>(`/api/v1/vector/cost-estimate?provider=${encodeURIComponent(defaultProvider)}`)
+      .then((next) => { if (active) setEstimate(next); })
+      .catch((cause) => { if (active) setError(cause instanceof Error ? cause.message : String(cause)); })
+      .finally(() => { if (active) setLoading(false); });
+    return () => { active = false; };
+  }, [defaultProvider, initialEstimate]);
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-model-recommendation-title">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-300">Model recommendation</p>
+          <h2 id="vector-model-recommendation-title" className="mt-2 text-2xl font-semibold text-white">Pick the best embedding model</h2>
+          <p className="mt-2 text-sm text-slate-400">Uses corpus size, detected providers, and estimated remote cost before indexing.</p>
+        </div>
+        {loading ? <Spinner label="Loading recommendation" /> : null}
+      </div>
+
+      {error ? <div className="mt-4"><ErrorMessage title="Model recommendation unavailable." message={error} /></div> : null}
+      {!loading && !estimate ? <p className="mt-4 text-sm text-slate-500">Run provider auto-detect to load a recommendation.</p> : null}
+      {estimate ? (
+        <div className="mt-4 grid gap-4 lg:grid-cols-[1.2fr_1fr]">
+          <div className="rounded-2xl border border-cyan-300/20 bg-cyan-300/10 p-4 text-sm text-cyan-50/90">
+            <p className="font-semibold text-cyan-100">Recommendation</p>
+            <p className="mt-2">{estimate.recommendation}</p>
+            <p className="mt-2 text-cyan-100/75">{estimate.formula}</p>
+            <p className="mt-2 text-cyan-100/75">{providerSummary(estimate.availableProviders)}</p>
+            {estimate.trackingEndpoint ? <p className="mt-2 text-cyan-100/70">Live usage: {estimate.trackingEndpoint}</p> : null}
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+            <p className="text-sm font-semibold text-white">Cost comparison</p>
+            <div className="mt-3 grid gap-2">
+              {(estimates.length ? estimates : [[estimate.provider, estimate]]).map(([provider, item]) => (
+                <p key={provider} className="rounded-xl border border-white/10 bg-slate-950/60 p-3 text-sm text-slate-300">
+                  <span className="font-semibold text-teal-100">{provider}</span> · {item.model ?? 'default model'} · {formatUsd(item.estimatedUsd)}
+                </p>
+              ))}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/pages/VectorSettingsPage.tsx
+++ b/frontend/src/pages/VectorSettingsPage.tsx
@@ -1,5 +1,6 @@
 import { VectorConfigPanel } from '../components/VectorConfigPanel';
 import { VectorIndexPanel } from '../components/VectorIndexPanel';
+import { VectorModelRecommendationCard } from '../components/VectorModelRecommendationCard';
 import { VectorProviderServicePanel } from '../components/VectorProviderServicePanel';
 import { VectorSearchToggle } from '../components/VectorSearchToggle';
 
@@ -16,6 +17,7 @@ export function VectorSettingsPage() {
 
       <VectorSearchToggle />
       <VectorProviderServicePanel />
+      <VectorModelRecommendationCard />
       <VectorConfigPanel />
       <VectorIndexPanel />
     </section>

--- a/tests/frontend/components/vector-model-recommendation-card.test.tsx
+++ b/tests/frontend/components/vector-model-recommendation-card.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+import { VectorModelRecommendationCard } from '../../../frontend/src/components/VectorModelRecommendationCard';
+import { htmlFor } from '../_render';
+
+const estimate = {
+  docs: 34_822,
+  tokensPerDoc: 500,
+  totalTokens: 17_411_000,
+  provider: 'openai',
+  model: 'text-embedding-3-small',
+  estimatedUsd: 0.3482,
+  formula: '34,822 docs × ~500 tokens/doc ≈ 17.4M tokens',
+  note: 'Estimate only.',
+  recommendation: 'Gemini free tier is recommended before paid remote embedding.',
+  availableProviders: ['gemini', 'ollama'],
+  providerEstimates: {
+    openai: { model: 'text-embedding-3-small', estimatedUsd: 0.3482 },
+    gemini: { model: 'text-embedding-004', estimatedUsd: 0 },
+    ollama: { model: 'nomic-embed-text', estimatedUsd: 0 },
+  },
+  trackingEndpoint: '/api/v1/vector/costs',
+};
+
+describe('VectorModelRecommendationCard', () => {
+  test('renders model guidance, cost comparison, and tracking endpoint', () => {
+    const html = htmlFor(<VectorModelRecommendationCard initialEstimate={estimate} />);
+
+    expect(html).toContain('Model recommendation');
+    expect(html).toContain('Gemini free tier is recommended');
+    expect(html).toContain('34,822 docs × ~500 tokens/doc ≈ 17.4M tokens');
+    expect(html).toContain('gemini, ollama available');
+    expect(html).toContain('openai');
+    expect(html).toContain('$0.3482');
+    expect(html).toContain('gemini');
+    expect(html).toContain('Free / local');
+    expect(html).toContain('/api/v1/vector/costs');
+  });
+});

--- a/tests/frontend/pages/vector-settings-page.test.tsx
+++ b/tests/frontend/pages/vector-settings-page.test.tsx
@@ -9,6 +9,7 @@ describe('VectorSettingsPage', () => {
     expect(html).toContain('Enable vector search');
     expect(html).toContain('PATCH /api/v1/vector/config');
     expect(html).toContain('Embedding providers and storage services');
+    expect(html).toContain('Model recommendation');
     expect(html).toContain('Active vector adapters');
     expect(html).toContain('Index jobs and collections');
   });

--- a/tests/vector/model-recommendation.test.ts
+++ b/tests/vector/model-recommendation.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'bun:test';
+import { recommendEmbeddingModel } from '../../src/vector/cost-estimation.ts';
+
+test('recommendEmbeddingModel follows Vector Section v2 corpus-size guidance', () => {
+  expect(recommendEmbeddingModel(9_999, [])).toContain('Any configured');
+  expect(recommendEmbeddingModel(50_000, ['gemini'])).toContain('Gemini free tier');
+  expect(recommendEmbeddingModel(50_000, ['ollama'])).toContain('Ollama/local');
+  expect(recommendEmbeddingModel(50_000, [])).toContain('OpenAI small');
+  expect(recommendEmbeddingModel(100_001, ['openai'])).toContain('GPU acceleration');
+});


### PR DESCRIPTION
## Summary
- adds a Vector Settings model recommendation card backed by /api/v1/vector/cost-estimate
- surfaces corpus-size guidance, provider availability, provider cost comparison, and live cost tracking endpoint
- adds focused frontend and recommendation-threshold coverage

Refs #1436
Refs #1440

## Validation
- bunx tsc --noEmit
- bun test tests/frontend/components/vector-model-recommendation-card.test.tsx tests/frontend/pages/vector-settings-page.test.tsx tests/vector/model-recommendation.test.ts tests/http/vector/cost-estimate-comparison.test.ts tests/http/vector/phase4-polish.test.ts tests/frontend/components/vector-provider-service-panel.test.tsx tests/frontend/components/vector-index-panel-render.test.tsx tests/frontend/pages/first-run-wizard-cost.test.ts (16 pass)
- wc -l changed files: all <=250