### PR TITLE
feat(export): add direct markdown export link

### DIFF
--- a/src/routes/export/app.ts
+++ b/src/routes/export/app.ts
@@ -80,6 +80,8 @@ function isExportFormat(value: unknown): value is ExportFormat {
   return typeof value === 'string' && APP_EXPORT_FORMATS.includes(value as ExportFormat);
 }
 
+function truthy(value: unknown): boolean { return value === true || value === 'true' || value === '1'; }
+
 function extensionFor(format: ExportFormat, tools: ExportTools): string {
   return format === 'jsonl' ? 'jsonl' : tools.extensionFor(format);
 }
@@ -98,10 +100,7 @@ function csvCell(value: unknown): string {
 }
 
 async function allCollections(connection: QueryConnection, tools: ExportTools): Promise<Record<string, ExportRecord[]>> {
-  return Object.fromEntries([...tableMap()].map(([name, table]) => [
-    name,
-    tools.normalizeRecords(selectRows(connection, table)),
-  ]));
+  return Object.fromEntries([...tableMap()].map(([name, table]) => [name, tools.normalizeRecords(selectRows(connection, table))]));
 }
 
 function attachGraph(content: string, format: ExportFormat, relationships: ExportRecord[]): string {
@@ -131,11 +130,43 @@ export function createExportAppRoutes(deps: ExportAppDeps = {}) {
   return new Elysia()
     .get('/export/app/collections', async () => {
       const connection = connectionFrom(deps);
-      const collections = [...tableMap()].map(([name, table]) => ({
-        name,
-        rowCount: selectRows(connection, table).length,
-      }));
+      const collections = [...tableMap()].map(([name, table]) => ({ name, rowCount: selectRows(connection, table).length }));
       return { collections, formats: APP_EXPORT_FORMATS, graph: { collection: 'relationships' } };
+    })
+    .get('/export/app', async ({ query, set }) => {
+      const tools = await loadExportTools();
+      const format = query.format ?? 'json';
+      if (!isExportFormat(format)) {
+        set.status = 400;
+        return { error: 'Invalid format', format, formats: APP_EXPORT_FORMATS };
+      }
+
+      const connection = connectionFrom(deps);
+      const tables = tableMap();
+      const isGraph = query.collection === 'relationships';
+      const table = tables.get(query.collection);
+      if (!isGraph && !table) {
+        set.status = 404;
+        return { error: `Unknown export collection: ${query.collection}` };
+      }
+
+      const includeGraph = truthy(query.includeGraph);
+      const collections = includeGraph || isGraph ? await allCollections(connection, tools) : {};
+      const relationships = includeGraph || isGraph ? tools.graphRelationships(collections) : [];
+      const rows = isGraph ? relationships : tools.normalizeRecords(selectRows(connection, table!));
+      if (!isGraph && rows.length === 0) {
+        set.status = 404;
+        return { error: 'Collection is empty', collection: query.collection };
+      }
+
+      const base = formatRows(query.collection, rows, format, tools);
+      const content = !isGraph && includeGraph ? attachGraph(base, format, relationships) : base;
+      const filename = `${safeName(query.collection)}.${extensionFor(format, tools)}`;
+      return new Response(content, {
+        headers: { 'Content-Type': mimeType(format), 'Content-Disposition': `attachment; filename="${filename}"` },
+      });
+    }, {
+      query: t.Object({ collection: t.String(), format: t.Optional(t.String()), includeGraph: t.Optional(t.String()), includeMetadata: t.Optional(t.String()) }),
     })
     .post('/export/app/run', async ({ body, set }) => {
       const tools = await loadExportTools();
@@ -186,24 +217,10 @@ export function createExportAppRoutes(deps: ExportAppDeps = {}) {
         createdAt: (deps.now?.() ?? new Date()).toISOString(),
       };
       jobs.set(jobId, job);
-      rememberExportProgress({
-        id: jobId,
-        jobId,
-        status: 'completed',
-        progress: 100,
-        updatedAt: job.createdAt,
-        downloadUrl,
-        filename,
-        fileSizeEstimate: sizeBytes,
-        sizeBytes,
-      });
+      rememberExportProgress({ id: jobId, jobId, status: 'completed', progress: 100, updatedAt: job.createdAt, downloadUrl, filename, fileSizeEstimate: sizeBytes, sizeBytes });
       return { ...job, filePath: undefined, status: 'completed', progress: 100, downloadUrl };
     }, {
-      body: t.Object({
-        collection: t.String(),
-        format: t.Optional(t.String()),
-        includeGraph: t.Optional(t.Boolean()),
-      }),
+      body: t.Object({ collection: t.String(), format: t.Optional(t.String()), includeGraph: t.Optional(t.Boolean()) }),
     })
     .get('/export/app/download/:jobId', async ({ params, set }) => {
       const job = jobs.get(params.jobId);
@@ -212,10 +229,7 @@ export function createExportAppRoutes(deps: ExportAppDeps = {}) {
         return { error: `Unknown export job: ${params.jobId}` };
       }
       return new Response(await readFile(job.filePath), {
-        headers: {
-          'Content-Type': job.mimeType,
-          'Content-Disposition': `attachment; filename="${job.filename}"`,
-        },
+        headers: { 'Content-Type': job.mimeType, 'Content-Disposition': `attachment; filename="${job.filename}"` },
       });
     }, { params: t.Object({ jobId: t.String() }) });
 }

--- a/tests/http/export/app.test.ts
+++ b/tests/http/export/app.test.ts
@@ -147,6 +147,20 @@ describe('export app HTTP routes', () => {
     expect(csv).toContain('"doc-new"');
   });
 
+  test('serves direct Markdown export downloads for fallback links', async () => {
+    const res = await fetcher(new Request(
+      'http://local/api/v1/export/app?collection=oracle_documents&format=markdown&includeGraph=true',
+    ));
+    const markdown = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/markdown');
+    expect(res.headers.get('content-disposition')).toBe('attachment; filename="oracle_documents.md"');
+    expect(markdown).toContain('# oracle_documents');
+    expect(markdown).toContain('doc-old');
+    expect(markdown).toContain('# graph_relationships');
+  });
+
   test('rejects unknown collections', async () => {
     const res = await postRun({ collection: 'missing_collection', format: 'json' });
     const body = await res.json() as { error: string };

--- a/tools/export-app/README.md
+++ b/tools/export-app/README.md
@@ -40,6 +40,8 @@ files under `collections/` and a top-level relationship export.
 When `/api/export/run` is pointed at a legacy Oracle v2 backend with
 `oracleV2Url`, `format: "json"` writes the metadata dump and
 `format: "markdown"` writes a readable document vault file.
+The direct fallback download path is
+`/api/v1/export/app?collection=oracle_documents&format=markdown`.
 
 ## Graph Export
 


### PR DESCRIPTION
## Summary
- add direct `/api/v1/export/app` download endpoint for export-app fallback links
- support Markdown downloads with optional graph relationships via query params
- document the direct Markdown fallback path and cover it in HTTP export tests

Refs #1783

## Validation
- bunx tsc --noEmit
- bun test tests/http/export tests/frontend/pages/export-app.test.tsx tests/tools/export-app.test.ts tests/tools/export-app/export-app.test.ts
- wc -l src/routes/export/app.ts tests/http/export/app.test.ts tools/export-app/README.md
- git diff --check