### PR TITLE
feat: enrich export app progress output

### DIFF
--- a/tests/tools/export-app.test.ts
+++ b/tests/tools/export-app.test.ts
@@ -161,7 +161,11 @@ test('CLI progress-json flag emits machine-readable progress', async () => {
   expect(JSON.parse(stdout.join('')).success).toBe(true);
   expect(events).toContainEqual(expect.objectContaining({
     event: 'export_progress',
+    type: 'export-progress',
     message: expect.stringContaining('oracle_documents'),
+    collection: 'oracle_documents',
+    rows: 2,
+    percent: expect.any(Number),
   }));
 });
 
@@ -193,6 +197,8 @@ test('CLI dry-run reports counts without writing a backup bundle', async () => {
 test('CLI rejects unknown flags before exporting', () => {
   expect(() => parseArgs(['--output', './backup', '--bogus'])).toThrow('unknown flag: --bogus');
   expect(() => parseArgs(['--output'])).toThrow('missing value for --output');
+  expect(parseArgs(['--output', './backup', '--progress=json']).progressMode).toBe('json');
+  expect(() => parseArgs(['--output', './backup', '--progress', 'xml'])).toThrow('invalid --progress');
 });
 
 test('CLI reports missing database path before exporting', async () => {

--- a/tools/export-app/README.md
+++ b/tools/export-app/README.md
@@ -68,6 +68,7 @@ connection.
 bun run tools/export-app/index.ts --output ./backup/export-app
 bun run tools/export-app/index.ts --output ./backup/export-app --db ./oracle.db
 bun run tools/export-app/index.ts --output ./backup/export-app --dry-run
+bun run tools/export-app/index.ts --output ./backup/export-app --progress json
 ```
 
 Use `--dry-run` to print collection, row, relationship, and document counts
@@ -91,6 +92,9 @@ The batch output includes:
 count, and SHA-256 checksum so operators can verify the bundle before migration.
 It also includes `collections.<table>.rowCount` so restore/preflight tooling can
 compare source and destination collection sizes without loading every artifact.
+Progress writes to stderr by default as collection counts, percentages, and row
+counts. Use `--progress json` or `--progress-json` for machine-readable events,
+`--progress silent` or `--quiet` when another wrapper owns progress display.
 
 ## CLI Usage
 

--- a/tools/export-app/exporter.ts
+++ b/tools/export-app/exporter.ts
@@ -20,7 +20,15 @@ import { EXPORT_MANIFEST_SCHEMA } from './schema.ts';
 import { exportFileInventory } from './inventory.ts';
 
 type ExportTable = Parameters<typeof getTableName>[0];
-type Progress = (message: string) => void;
+type Progress = (message: string, event?: ExportProgressEvent) => void;
+
+export interface ExportProgressEvent {
+  current: number;
+  total: number;
+  percent: number;
+  collection: string;
+  rows: number;
+}
 
 export interface ExportAppOptions {
   outputDir: string;
@@ -72,7 +80,7 @@ export async function exportOracleData(options: ExportAppOptions): Promise<Expor
       const rows = normalizeRecords(selectRows(connection, table));
       allCollections[name] = rows;
       rowCount += rows.length;
-      progress(`[${i + 1}/${tables.length}] ${name}: ${rows.length} rows`);
+      reportProgress(progress, { current: i + 1, total: tables.length, collection: name, rows: rows.length });
       await writeCollectionFiles(collectionsDir, name, rows);
     }
 
@@ -119,7 +127,7 @@ export async function exportMarkdownData(options: ExportAppOptions): Promise<Exp
       const table = tables[i]!;
       const name = getTableName(table);
       const rows = selectRows(connection, table).map(normalizeRecord);
-      progress(`[${i + 1}/${tables.length}] ${name}: ${rows.length} rows`);
+      reportProgress(progress, { current: i + 1, total: tables.length, collection: name, rows: rows.length });
       fileCount += await writeCollectionMarkdown(outputDir, name, rows);
     }
     return { outputDir, collectionCount: tables.length, fileCount };
@@ -135,6 +143,11 @@ function openReadonlyConnection(dbPath = DB_PATH): { connection: DatabaseConnect
 
 function selectRows(connection: DatabaseConnection, table: ExportTable): ExportRecord[] {
   return (connection.db as any).select().from(table).all() as ExportRecord[];
+}
+
+function reportProgress(progress: Progress, event: Omit<ExportProgressEvent, 'percent'>): void {
+  const percent = Math.round((event.current / event.total) * 100);
+  progress(`[${event.current}/${event.total}] ${percent}% ${event.collection}: ${event.rows} rows`, { ...event, percent });
 }
 
 function collectionManifest(collections: Record<string, ExportRecord[]>): Record<string, { rowCount: number }> {

--- a/tools/export-app/index.ts
+++ b/tools/export-app/index.ts
@@ -1,15 +1,16 @@
 import { existsSync, statSync } from 'node:fs';
 import { DB_PATH } from '../../src/config.ts';
-import { exportOracleData } from './exporter.ts';
+import { exportOracleData, type ExportProgressEvent } from './exporter.ts';
 import { previewOracleExport } from './summary.ts';
 
 type Writer = (message: string) => void;
+type ProgressMode = 'text' | 'json' | 'silent';
 
 interface CliOptions {
   outputDir: string;
   dbPath?: string;
   quiet: boolean;
-  progressJson: boolean;
+  progressMode: ProgressMode;
   dryRun: boolean;
 }
 
@@ -31,26 +32,34 @@ export function parseArgs(args: string[]): CliOptions {
   let outputDir: string | undefined;
   let dbPath: string | undefined;
   let quiet = false;
-  let progressJson = false;
+  let progressMode: ProgressMode = 'text';
   let dryRun = false;
 
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i]!;
     const outputAssigned = assignedValue(arg, '--output');
     const dbAssigned = assignedValue(arg, '--db');
+    const progressAssigned = assignedValue(arg, '--progress');
     if (outputAssigned !== undefined) { outputDir = outputAssigned; continue; }
     if (dbAssigned !== undefined) { dbPath = dbAssigned; continue; }
+    if (progressAssigned !== undefined) { progressMode = readProgressMode(progressAssigned); continue; }
     if (arg === '--output' || arg === '-o') { outputDir = flagValue(args, i, arg); i += 1; continue; }
     if (arg === '--db') { dbPath = flagValue(args, i, arg); i += 1; continue; }
+    if (arg === '--progress') { progressMode = readProgressMode(flagValue(args, i, arg)); i += 1; continue; }
     if (arg === '--quiet' || arg === '--no-progress') { quiet = true; continue; }
-    if (arg === '--progress-json') { progressJson = true; continue; }
+    if (arg === '--progress-json') { progressMode = 'json'; continue; }
     if (arg === '--dry-run') { dryRun = true; continue; }
     if (arg === '--help' || arg === '-h') continue;
     throw new Error(arg.startsWith('-') ? `unknown flag: ${arg}` : `unexpected argument: ${arg}`);
   }
 
   if (!outputDir) throw new Error('missing required --output <dir>');
-  return { outputDir, dbPath, quiet, progressJson, dryRun };
+  return { outputDir, dbPath, quiet, progressMode, dryRun };
+}
+
+function readProgressMode(value: string): ProgressMode {
+  if (value === 'text' || value === 'json' || value === 'silent') return value;
+  throw new Error('invalid --progress: expected text, json, or silent');
 }
 
 function requireFile(path: string): void {
@@ -80,6 +89,7 @@ function printHelp(write: Writer): void {
     'Flags:',
     '  --output, -o <dir>   destination backup directory',
     '  --db <path>          SQLite database path (defaults to ORACLE_DB_PATH)',
+    '  --progress <mode>    progress output: text, json, or silent',
     '  --dry-run            print collection counts without writing files',
     '  --quiet              suppress progress output',
     '  --no-progress        alias for --quiet',
@@ -87,6 +97,19 @@ function printHelp(write: Writer): void {
     '  --help, -h           show this help',
     '',
   ].join('\n'));
+}
+
+function progressWriter(options: CliOptions, write: Writer) {
+  if (options.quiet || options.progressMode === 'silent') return () => {};
+  if (options.progressMode === 'json') {
+    return (message: string, event?: ExportProgressEvent) => {
+      const payload = event
+        ? { event: 'export_progress', type: 'export-progress', message, ...event }
+        : { event: 'export_progress', type: 'export-progress', message };
+      write(`${JSON.stringify(payload)}\n`);
+    };
+  }
+  return (message: string) => write(`${message}\n`);
 }
 
 export async function runExportApp(args: string[], stdout: Writer = process.stdout.write.bind(process.stdout), stderr: Writer = process.stderr.write.bind(process.stderr)): Promise<number> {
@@ -101,11 +124,7 @@ export async function runExportApp(args: string[], stdout: Writer = process.stdo
       stdout(`${JSON.stringify({ success: true, dryRun: true, ...previewOracleExport({ dbPath: options.dbPath }) }, null, 2)}\n`);
       return 0;
     }
-    const progress = options.quiet
-      ? () => {}
-      : options.progressJson
-        ? (message: string) => stderr(`${JSON.stringify({ event: 'export_progress', message })}\n`)
-        : (message: string) => stderr(`${message}\n`);
+    const progress = progressWriter(options, stderr);
     const result = await exportOracleData({
       outputDir: options.outputDir,
       dbPath: options.dbPath,


### PR DESCRIPTION
## Summary
- Enrich standalone Export App CLI progress output with collection percentages and structured JSON event fields.
- Add `--progress silent` for wrappers that own progress rendering.
- Document the progress modes and cover JSON progress events in the standalone export app tests.

## Validation
- `bun test tests/tools/export-app.test.ts tests/tools/export-app/export-app.test.ts`
- `bun test tests/http/export`
- `bunx tsc --noEmit`
- `wc -l tools/export-app/index.ts tools/export-app/exporter.ts tools/export-app/README.md tests/tools/export-app/export-app.test.ts`

Refs #1783
