### PR TITLE
feat: add plugin inventory filters

### DIFF
--- a/frontend/src/pages/PluginsPage.tsx
+++ b/frontend/src/pages/PluginsPage.tsx
@@ -3,19 +3,22 @@ import { setPluginEnabled } from '../api/plugin-admin';
 import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
 import { isPluginEnabled, PluginList, type PluginEnabledState } from '../components/PluginList';
 import { PLUGINS_ENDPOINT, usePlugins, type PluginFetch } from '../hooks/usePlugins';
-import { countPluginSurfaces } from '../plugin-surfaces';
+import { countPluginSurfaces, surfacesFor } from '../plugin-surfaces';
 import { UnifiedPluginSurfaceOverview } from './UnifiedPluginSurfaceOverview';
 import type { PluginEntry } from '../types';
 
 const EMPTY_PLUGINS: PluginEntry[] = [];
 
 type Tone = 'ok' | 'warn' | 'bad' | 'idle';
+export type PluginVisibilityFilter = 'all' | 'enabled' | 'disabled' | 'unhealthy';
 
 export interface PluginsPageProps {
   plugins?: PluginEntry[];
   loading?: boolean;
   endpoint?: string;
   fetcher?: PluginFetch;
+  initialQuery?: string;
+  initialVisibility?: PluginVisibilityFilter;
 }
 
 export function enabledStateForPlugins(plugins: PluginEntry[]): PluginEnabledState {
@@ -29,6 +32,49 @@ export function pluginAdminSummary(plugins: PluginEntry[], enabledState: PluginE
   const enabled = plugins.filter((plugin) => isPluginEnabled(plugin, enabledState)).length;
   const disabled = plugins.length - enabled;
   return `${enabled} enabled · ${disabled} disabled · ${plugins.length} registered`;
+}
+
+
+function queryText(plugin: PluginEntry): string {
+  return [
+    plugin.name,
+    plugin.description,
+    plugin.status,
+    plugin.error,
+    plugin.version,
+    plugin.file,
+    plugin.server?.command,
+    plugin.server?.healthPath,
+    plugin.menu?.label,
+    ...surfacesFor(plugin),
+    ...(plugin.mcpTools ?? []).map((tool) => tool.name),
+    ...(plugin.apiRoutes ?? []).map((route) => route.path),
+    ...(plugin.proxy ?? []).map((proxy) => proxy.path),
+    ...(plugin.cliSubcommands ?? []).map((command) => command.command),
+    ...(plugin.exportFormats ?? []).map((format) => format.extension),
+  ].filter(Boolean).join(' ').toLowerCase();
+}
+
+function pluginMatchesVisibility(plugin: PluginEntry, enabledState: PluginEnabledState, filter: PluginVisibilityFilter): boolean {
+  const enabled = isPluginEnabled(plugin, enabledState);
+  const health = healthForPlugin(plugin, enabled).tone;
+  if (filter === 'enabled') return enabled;
+  if (filter === 'disabled') return !enabled;
+  if (filter === 'unhealthy') return health === 'bad' || health === 'warn';
+  return true;
+}
+
+export function filteredPluginsFor(
+  plugins: PluginEntry[],
+  enabledState: PluginEnabledState,
+  query: string,
+  visibility: PluginVisibilityFilter,
+): PluginEntry[] {
+  const needle = query.trim().toLowerCase();
+  return plugins.filter((plugin) => {
+    const queryMatch = !needle || queryText(plugin).includes(needle);
+    return queryMatch && pluginMatchesVisibility(plugin, enabledState, visibility);
+  });
 }
 
 function toneClass(tone: Tone): string {
@@ -66,14 +112,20 @@ export function PluginsPage({
   loading = false,
   endpoint = PLUGINS_ENDPOINT,
   fetcher,
+  initialQuery = '',
+  initialVisibility = 'all',
 }: PluginsPageProps) {
   const initialLoading = loading || initialPlugins.length === 0;
   const { plugins, loading: fetching, error, reload } = usePlugins({ initialPlugins, initialLoading, endpoint, fetcher });
   const [overrides, setOverrides] = useState<PluginEnabledState>({});
+  const [query, setQuery] = useState(initialQuery);
+  const [visibility, setVisibility] = useState<PluginVisibilityFilter>(initialVisibility);
   const [adminError, setAdminError] = useState('');
   const [adminMessage, setAdminMessage] = useState('');
   const enabledState = useMemo(() => ({ ...enabledStateForPlugins(plugins), ...overrides }), [plugins, overrides]);
   const summary = useMemo(() => pluginAdminSummary(plugins, enabledState), [plugins, enabledState]);
+  const visiblePlugins = useMemo(() => filteredPluginsFor(plugins, enabledState, query, visibility), [plugins, enabledState, query, visibility]);
+  const hasFilters = query.trim().length > 0 || visibility !== 'all';
   const metrics = useMemo(() => {
     const active = plugins.filter((plugin) => isPluginEnabled(plugin, enabledState)).length;
     const unhealthy = plugins.filter((plugin) => healthForPlugin(plugin, isPluginEnabled(plugin, enabledState)).tone === 'bad').length;
@@ -131,7 +183,56 @@ export function PluginsPage({
       {showInventory ? <UnifiedPluginSurfaceOverview plugins={plugins} /> : null}
 
       {plugins.length ? (
-        <PluginList plugins={plugins} enabledState={enabledState} onToggle={(name) => void togglePlugin(name)} />
+        <section className="rounded-2xl border border-white/10 bg-slate-950/70 p-4" aria-labelledby="plugin-filters-title">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-teal-300">Inventory filters</p>
+              <h2 id="plugin-filters-title" className="mt-1 text-lg font-semibold text-white">Find plugin surfaces</h2>
+              <p className="mt-1 text-sm text-slate-400">Showing {visiblePlugins.length} of {plugins.length} plugins · {summary}</p>
+            </div>
+            <div className="grid gap-2 sm:grid-cols-[minmax(12rem,1fr)_12rem_auto]">
+              <label className="grid gap-1 text-sm font-medium text-slate-300">
+                Search plugins
+                <input
+                  className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-slate-100"
+                  placeholder="name, route, MCP tool, surface"
+                  type="search"
+                  value={query}
+                  onChange={(event) => setQuery(event.currentTarget.value)}
+                />
+              </label>
+              <label className="grid gap-1 text-sm font-medium text-slate-300">
+                Visibility
+                <select
+                  className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-slate-100"
+                  value={visibility}
+                  onChange={(event) => setVisibility(event.currentTarget.value as PluginVisibilityFilter)}
+                >
+                  <option value="all">All plugins</option>
+                  <option value="enabled">Enabled</option>
+                  <option value="disabled">Disabled</option>
+                  <option value="unhealthy">Needs attention</option>
+                </select>
+              </label>
+              <button
+                className="focus-ring self-end rounded-xl border border-white/10 px-3 py-2 text-sm font-semibold text-slate-200 hover:border-teal-300/40 disabled:opacity-40"
+                disabled={!hasFilters}
+                type="button"
+                onClick={() => { setQuery(''); setVisibility('all'); }}
+              >
+                Clear filters
+              </button>
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      {visiblePlugins.length ? (
+        <PluginList plugins={visiblePlugins} enabledState={enabledState} onToggle={(name) => void togglePlugin(name)} />
+      ) : plugins.length && showInventory ? (
+        <p className="rounded-lg border border-white/10 bg-slate-950/70 p-5 text-sm text-slate-400">
+          No plugins match the current filters. Clear filters or reload plugin manifests.
+        </p>
       ) : showInventory ? (
         <p className="rounded-lg border border-white/10 bg-slate-950/70 p-5 text-sm text-slate-400">
           No installed plugins returned by {endpoint}.

--- a/tests/frontend/pages/plugins-page-admin.test.tsx
+++ b/tests/frontend/pages/plugins-page-admin.test.tsx
@@ -1,18 +1,49 @@
 import { describe, expect, test } from 'bun:test';
-import { PluginsPage, enabledStateForPlugins, pluginAdminSummary } from '../../../frontend/src/pages/PluginsPage';
+import {
+  PluginsPage,
+  enabledStateForPlugins,
+  filteredPluginsFor,
+  pluginAdminSummary,
+} from '../../../frontend/src/pages/PluginsPage';
+import type { PluginEntry } from '../../../frontend/src/types';
 import { htmlFor } from '../_render';
+
+const plugins: PluginEntry[] = [
+  { name: 'canvas', file: '', size: 0, modified: 'now', version: '1.2.3', status: 'ok' },
+  { name: 'echo', file: 'echo.wasm', size: 0, modified: 'now', mcpTools: [{ name: 'echo.say', description: 'Say echo' }] },
+  { name: 'archive', file: '', size: 0, modified: 'now', status: 'disabled' },
+  { name: 'broken', file: '', size: 0, modified: 'now', error: 'health check failed' },
+];
 
 describe('PluginsPage admin view', () => {
   test('renders version status and health for installed plugins', () => {
-    const plugins = [{ name: 'canvas', file: '', size: 0, modified: 'now', version: '1.2.3', status: 'ok' }];
-    const html = htmlFor(<PluginsPage plugins={plugins} loading={false} />);
+    const html = htmlFor(<PluginsPage plugins={[plugins[0]]} loading={false} />);
 
-    expect(pluginAdminSummary(plugins, enabledStateForPlugins(plugins))).toBe('1 enabled · 0 disabled · 1 registered');
+    expect(pluginAdminSummary([plugins[0]], enabledStateForPlugins([plugins[0]]))).toBe('1 enabled · 0 disabled · 1 registered');
     expect(html).toContain('GET /api/plugins');
     expect(html).toContain('canvas');
     expect(html).toContain('1.2.3');
     expect(html).toContain('ok');
     expect(html).toContain('healthy');
     expect(html).toContain('Unified backend surfaces');
+  });
+
+  test('filters plugin inventory by query, visibility, and health', () => {
+    const enabled = enabledStateForPlugins(plugins);
+    expect(filteredPluginsFor(plugins, enabled, 'echo.say', 'all').map((plugin) => plugin.name)).toEqual(['echo']);
+    expect(filteredPluginsFor(plugins, enabled, '', 'disabled').map((plugin) => plugin.name)).toEqual(['archive']);
+    expect(filteredPluginsFor(plugins, enabled, '', 'unhealthy').map((plugin) => plugin.name)).toEqual(['broken']);
+
+    const html = htmlFor(<PluginsPage plugins={plugins} loading={false} initialQuery="echo.say" />);
+    expect(html).toContain('Find plugin surfaces');
+    expect(html).toContain('Showing 1 of 4 plugins');
+    expect(html).toContain('echo');
+    expect(html).toContain('Clear filters');
+  });
+
+  test('renders a no-match state for filtered plugin inventory', () => {
+    const html = htmlFor(<PluginsPage plugins={plugins} loading={false} initialQuery="missing-plugin" />);
+    expect(html).toContain('Showing 0 of 4 plugins');
+    expect(html).toContain('No plugins match the current filters.');
   });
 });


### PR DESCRIPTION
## Summary
- Added plugin inventory search across names, descriptions, surfaces, routes, MCP tools, CLI commands, and export formats.
- Added visibility filters for all/enabled/disabled/needs-attention plugins with a no-match state and clear action.
- Covered filter helpers and rendered filter/no-match states in plugin page tests.

## Validation
- `bunx tsc --noEmit`
- `bun test tests/frontend/pages/plugins-page-admin.test.tsx tests/frontend/pages/plugins-page-ready.test.tsx tests/frontend/pages/plugins-page-loading.test.tsx tests/frontend/pages/unified-plugin-overview.test.tsx tests/frontend/components/plugin-list-empty.test.tsx tests/frontend/components/plugin-list-surfaces.test.tsx tests/frontend/components/plugin-list-toggle.test.ts`
- `git diff --check`
- `wc -l $(git diff --name-only origin/alpha...HEAD)` (all changed files ≤250 lines)
