### PR TITLE
feat: add export CLI version and standalone docs

### DIFF
--- a/src/cli/commands/export.ts
+++ b/src/cli/commands/export.ts
@@ -6,6 +6,7 @@ import {
   buildVectorExportPayload,
   exportCommand as legacyExportCommand,
 } from "./export-legacy.ts";
+import { CLI_VERSION } from "../help.ts";
 
 export { buildMarkdownExportPayload, buildVaultJsonExport, buildVectorExportPayload };
 
@@ -35,8 +36,8 @@ export interface RemoteExportDeps {
   env?: Record<string, string | undefined>;
 }
 
-function printHelp(): void {
-  console.log([
+export function renderRemoteExportHelp(): string {
+  return [
     "bun run export -- --url <oracle-v2-url> --collection <name> --format markdown|json|jsonl|csv --output <path>",
     "",
     "Exports one collection through the Oracle v2 export-app engine.",
@@ -50,9 +51,18 @@ function printHelp(): void {
     "  --graph              alias for --include-graph",
     "  --retries <count>    retry transient HTTP/network failures",
     "  --retry-delay-ms <n> delay between retry attempts (default 250)",
+    "  --version, -v, -V    show export CLI version",
     "  --help, -h           show this help",
     "",
-  ].join("\n"));
+  ].join("\n");
+}
+
+export function renderRemoteExportVersion(): string {
+  return `arra export v${CLI_VERSION}`;
+}
+
+function printHelp(): void {
+  console.log(renderRemoteExportHelp());
 }
 
 function readValue(args: string[], flag: string): string | undefined {
@@ -204,6 +214,10 @@ export async function runRemoteExportCommand(args: string[], deps: RemoteExportD
 }
 
 export async function exportCommand(args: string[]): Promise<number> {
+  if (args.includes("--version") || args.includes("-v") || args.includes("-V")) {
+    process.stdout.write(`${renderRemoteExportVersion()}\n`);
+    return 0;
+  }
   if (args.includes("--help") || args.includes("-h")) {
     printHelp();
     return 0;

--- a/tests/cli/export/help-version.test.ts
+++ b/tests/cli/export/help-version.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import {
+  exportCommand,
+  renderRemoteExportHelp,
+  renderRemoteExportVersion,
+} from "../../../src/cli/commands/export.ts";
+
+async function captureOutput(action: () => Promise<number>): Promise<{
+  code: number;
+  stdout: string;
+  stderr: string;
+}> {
+  const originalWrite = process.stdout.write;
+  const originalLog = console.log;
+  const originalError = console.error;
+  let stdout = "";
+  let stderr = "";
+  (process.stdout as unknown as { write: (chunk: unknown) => boolean }).write = (chunk) => {
+    stdout += String(chunk);
+    return true;
+  };
+  console.log = (...parts: unknown[]) => { stdout += `${parts.join(" ")}\n`; };
+  console.error = (...parts: unknown[]) => { stderr += `${parts.join(" ")}\n`; };
+  try {
+    const code = await action();
+    return { code, stdout, stderr };
+  } finally {
+    process.stdout.write = originalWrite;
+    console.log = originalLog;
+    console.error = originalError;
+  }
+}
+
+describe("export CLI help and version", () => {
+  test("renders standalone remote export help with graph, retry, and version flags", () => {
+    const help = renderRemoteExportHelp();
+    expect(help).toContain("bun run export -- --url <oracle-v2-url>");
+    expect(help).toContain("--include-graph");
+    expect(help).toContain("--retries <count>");
+    expect(help).toContain("--version, -v, -V");
+  });
+
+  test("prints version without requiring export flags", async () => {
+    const version = renderRemoteExportVersion();
+    const result = await captureOutput(() => exportCommand(["--version"]));
+    expect(result).toEqual({ code: 0, stdout: `${version}\n`, stderr: "" });
+    expect(version).toStartWith("arra export v");
+  });
+});

--- a/tests/tools/export-app.test.ts
+++ b/tests/tools/export-app.test.ts
@@ -208,7 +208,11 @@ test('CLI rejects output paths that are files', async () => {
 test('README documents standalone remote export CLI flags', () => {
   const readme = readFileSync(join(process.cwd(), 'tools/export-app/README.md'), 'utf8');
   expect(readme).toContain('bun run export -- --url http://localhost:47778');
+  expect(readme).toContain('--format json --output ./backup/docs.json');
+  expect(readme).toContain('--format markdown --output ./backup/docs.md');
+  expect(readme).toContain('--format jsonl --output ./backup/docs.jsonl');
   expect(readme).toContain('--include-graph');
   expect(readme).toContain('--retries <count>');
+  expect(readme).toContain('--graph --retries 3 --retry-delay-ms 500');
   expect(readme).toContain('--version');
 });

--- a/tests/tools/export-app.test.ts
+++ b/tests/tools/export-app.test.ts
@@ -204,3 +204,11 @@ test('CLI rejects output paths that are files', async () => {
   expect(code).toBe(1);
   expect(stderr.join('')).toContain('output path exists but is not a directory:');
 });
+
+test('README documents standalone remote export CLI flags', () => {
+  const readme = readFileSync(join(process.cwd(), 'tools/export-app/README.md'), 'utf8');
+  expect(readme).toContain('bun run export -- --url http://localhost:47778');
+  expect(readme).toContain('--include-graph');
+  expect(readme).toContain('--retries <count>');
+  expect(readme).toContain('--version');
+});

--- a/tools/export-app/README.md
+++ b/tools/export-app/README.md
@@ -101,6 +101,27 @@ maw arra export --source vector --collection bge-m3 --format csv --out bge-m3.cs
 and delegates to the repo CLI. Set `ORACLE_API` for backend-connected UI/API
 commands; set `ORACLE_ROOT` when the local CLI should run from a specific clone.
 
+### Standalone Remote CLI
+
+Use the repo-local `bun run export` command when you need a portable export from
+an Oracle v2-compatible HTTP backend without going through `maw`:
+
+```sh
+bun run export -- --url http://localhost:47778 \
+  --collection oracle_documents \
+  --format jsonl \
+  --output ./backup/oracle_documents.jsonl
+```
+
+Useful flags:
+
+- `--include-graph` / `--graph` includes relationship graph rows when the
+  backend supports them.
+- `--retries <count>` and `--retry-delay-ms <ms>` retry transient network,
+  408, 429, and 5xx failures during export start or artifact download.
+- `--version` / `-v` / `-V` prints the standalone export CLI version.
+- `--help` / `-h` prints the complete flag reference.
+
 ## Recommended Flow
 
 1. Point the UI or `maw arra` at the backend with `ORACLE_API`.

--- a/tools/export-app/README.md
+++ b/tools/export-app/README.md
@@ -113,6 +113,14 @@ bun run export -- --url http://localhost:47778 \
   --output ./backup/oracle_documents.jsonl
 ```
 
+Format-specific examples:
+
+```sh
+bun run export -- --url http://localhost:47778 --collection oracle_documents --format json --output ./backup/docs.json
+bun run export -- --url http://localhost:47778 --collection oracle_documents --format markdown --output ./backup/docs.md
+bun run export -- --url http://localhost:47778 --collection oracle_documents --format jsonl --output ./backup/docs.jsonl
+```
+
 Useful flags:
 
 - `--include-graph` / `--graph` includes relationship graph rows when the
@@ -121,6 +129,14 @@ Useful flags:
   408, 429, and 5xx failures during export start or artifact download.
 - `--version` / `-v` / `-V` prints the standalone export CLI version.
 - `--help` / `-h` prints the complete flag reference.
+
+Example with graph relationships and retry hardening:
+
+```sh
+bun run export -- --url http://localhost:47778 --collection oracle_documents \
+  --format json --output ./backup/docs-with-graph.json \
+  --graph --retries 3 --retry-delay-ms 500
+```
 
 ## Recommended Flow
 


### PR DESCRIPTION
## Summary
- Add `--version` / `-v` / `-V` to the standalone export CLI.
- Expose renderable help/version helpers and cover help/version output.
- Document standalone `bun run export -- --url ...` usage with JSON, Markdown, JSONL, graph, retry, version, and help examples.
- Add a README contract test for the standalone remote export CLI docs.

Refs #1783

## Validation
- bunx tsc --noEmit
- bun test tests/tools/export-app.test.ts tests/cli/export/ tests/http/export/

## File sizes
- src/cli/commands/export.ts: 236 lines
- tests/cli/export/help-version.test.ts: 49 lines
- tests/tools/export-app.test.ts: 195 lines
- tools/export-app/README.md: 164 lines