### PR TITLE
fix: preflight export app cli paths

### DIFF
--- a/tests/tools/export-app.test.ts
+++ b/tests/tools/export-app.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, expect, test } from 'bun:test';
-import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -144,4 +144,39 @@ test('CLI quiet flag suppresses progress output', async () => {
 test('CLI rejects unknown flags before exporting', () => {
   expect(() => parseArgs(['--output', './backup', '--bogus'])).toThrow('unknown flag: --bogus');
   expect(() => parseArgs(['--output'])).toThrow('missing value for --output');
+});
+
+test('CLI reports missing database path before exporting', async () => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const outputDir = join(root, 'missing-db-export');
+  const code = await runExportApp(
+    ['--output', outputDir, '--db', join(root, 'missing.db')],
+    (message) => stdout.push(message),
+    (message) => stderr.push(message),
+  );
+
+  expect(code).toBe(1);
+  expect(stdout.join('')).toBe('');
+  expect(stderr.join('')).toContain('database file not found:');
+  expect(existsSync(outputDir)).toBe(false);
+});
+
+test('CLI rejects output paths that are files', async () => {
+  const dbPath = join(root, 'output-conflict.db');
+  const outputFile = join(root, 'already-a-file');
+  const connection = createDatabase(dbPath);
+  seed(connection);
+  connection.storage.close();
+  writeFileSync(outputFile, 'not a directory');
+
+  const stderr: string[] = [];
+  const code = await runExportApp(
+    ['--output', outputFile, '--db', dbPath],
+    () => {},
+    (message) => stderr.push(message),
+  );
+
+  expect(code).toBe(1);
+  expect(stderr.join('')).toContain('output path exists but is not a directory:');
 });

--- a/tools/export-app/index.ts
+++ b/tools/export-app/index.ts
@@ -1,4 +1,6 @@
 import { exportOracleData } from './exporter.ts';
+import { existsSync, statSync } from 'node:fs';
+import { DB_PATH } from '../../src/config.ts';
 
 type Writer = (message: string) => void;
 
@@ -44,6 +46,24 @@ export function parseArgs(args: string[]): CliOptions {
   return { outputDir, dbPath, quiet };
 }
 
+function requireFile(path: string): void {
+  if (!existsSync(path)) {
+    throw new Error(`database file not found: ${path}. Pass --db <path> for an existing Oracle database.`);
+  }
+  if (!statSync(path).isFile()) throw new Error(`database path is not a file: ${path}`);
+}
+
+function requireOutputTarget(path: string): void {
+  if (existsSync(path) && !statSync(path).isDirectory()) {
+    throw new Error(`output path exists but is not a directory: ${path}`);
+  }
+}
+
+export function validateCliOptions(options: CliOptions): void {
+  requireFile(options.dbPath ?? DB_PATH);
+  requireOutputTarget(options.outputDir);
+}
+
 function printHelp(write: Writer): void {
   write([
     'bun run tools/export-app/index.ts --output ./backup/ [--db ./oracle.db]',
@@ -67,6 +87,7 @@ export async function runExportApp(args: string[], stdout: Writer = process.stdo
       return 0;
     }
     const options = parseArgs(args);
+    validateCliOptions(options);
     const progress = options.quiet ? () => {} : (message: string) => stderr(`${message}\n`);
     const result = await exportOracleData({
       outputDir: options.outputDir,


### PR DESCRIPTION
## Summary
- Add export-app CLI preflight checks for missing database files before opening SQLite.
- Reject output targets that already exist as files before writing export output.
- Cover both error paths with focused CLI tests to keep failures actionable and side-effect free.

## Validation
- `bunx tsc --noEmit`
- `bun test tests/tools/export-app.test.ts tests/tools/export-app/export-app.test.ts tests/tools/export-app/manifest-schema.test.ts` — 13 pass, 0 fail
- `wc -l tools/export-app/index.ts tests/tools/export-app.test.ts tools/export-app/exporter.ts tools/export-app/documents.ts tools/export-app/schema.ts tools/export-app/document-csv.ts tests/tools/export-app/export-app.test.ts tests/tools/export-app/manifest-schema.test.ts` — all <=250 lines
- `git diff --check` on changed files

Base: `alpha`
Issue: #1783
