### PR TITLE
feat(export): add dry-run preflight

### DIFF
--- a/tests/tools/export-app.test.ts
+++ b/tests/tools/export-app.test.ts
@@ -165,6 +165,31 @@ test('CLI progress-json flag emits machine-readable progress', async () => {
   }));
 });
 
+test('CLI dry-run reports counts without writing a backup bundle', async () => {
+  const dbPath = join(root, 'dry-run.db');
+  const outputDir = join(root, 'dry-run-export');
+  const connection = createDatabase(dbPath);
+  seed(connection);
+  connection.storage.close();
+
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const code = await runExportApp(
+    ['--output', outputDir, '--db', dbPath, '--dry-run'],
+    (message) => stdout.push(message),
+    (message) => stderr.push(message),
+  );
+  const payload = JSON.parse(stdout.join(''));
+
+  expect(code).toBe(0);
+  expect(stderr.join('')).toBe('');
+  expect(payload).toMatchObject({ success: true, dryRun: true, dbPath, documentCount: 2 });
+  expect(payload.collectionCount).toBeGreaterThan(5);
+  expect(payload.rowCount).toBeGreaterThanOrEqual(3);
+  expect(payload.collections).toContainEqual(expect.objectContaining({ name: 'oracle_documents', rowCount: 2 }));
+  expect(existsSync(outputDir)).toBe(false);
+});
+
 test('CLI rejects unknown flags before exporting', () => {
   expect(() => parseArgs(['--output', './backup', '--bogus'])).toThrow('unknown flag: --bogus');
   expect(() => parseArgs(['--output'])).toThrow('missing value for --output');

--- a/tools/export-app/README.md
+++ b/tools/export-app/README.md
@@ -67,7 +67,11 @@ connection.
 ```sh
 bun run tools/export-app/index.ts --output ./backup/export-app
 bun run tools/export-app/index.ts --output ./backup/export-app --db ./oracle.db
+bun run tools/export-app/index.ts --output ./backup/export-app --dry-run
 ```
+
+Use `--dry-run` to print collection, row, relationship, and document counts
+without creating files. It is a safe preflight before long-running exports.
 
 The batch output includes:
 

--- a/tools/export-app/index.ts
+++ b/tools/export-app/index.ts
@@ -1,6 +1,7 @@
-import { exportOracleData } from './exporter.ts';
 import { existsSync, statSync } from 'node:fs';
 import { DB_PATH } from '../../src/config.ts';
+import { exportOracleData } from './exporter.ts';
+import { previewOracleExport } from './summary.ts';
 
 type Writer = (message: string) => void;
 
@@ -9,6 +10,7 @@ interface CliOptions {
   dbPath?: string;
   quiet: boolean;
   progressJson: boolean;
+  dryRun: boolean;
 }
 
 function flagValue(args: string[], index: number, flag: string): string {
@@ -30,6 +32,7 @@ export function parseArgs(args: string[]): CliOptions {
   let dbPath: string | undefined;
   let quiet = false;
   let progressJson = false;
+  let dryRun = false;
 
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i]!;
@@ -41,12 +44,13 @@ export function parseArgs(args: string[]): CliOptions {
     if (arg === '--db') { dbPath = flagValue(args, i, arg); i += 1; continue; }
     if (arg === '--quiet' || arg === '--no-progress') { quiet = true; continue; }
     if (arg === '--progress-json') { progressJson = true; continue; }
+    if (arg === '--dry-run') { dryRun = true; continue; }
     if (arg === '--help' || arg === '-h') continue;
     throw new Error(arg.startsWith('-') ? `unknown flag: ${arg}` : `unexpected argument: ${arg}`);
   }
 
   if (!outputDir) throw new Error('missing required --output <dir>');
-  return { outputDir, dbPath, quiet, progressJson };
+  return { outputDir, dbPath, quiet, progressJson, dryRun };
 }
 
 function requireFile(path: string): void {
@@ -76,6 +80,7 @@ function printHelp(write: Writer): void {
     'Flags:',
     '  --output, -o <dir>   destination backup directory',
     '  --db <path>          SQLite database path (defaults to ORACLE_DB_PATH)',
+    '  --dry-run            print collection counts without writing files',
     '  --quiet              suppress progress output',
     '  --no-progress        alias for --quiet',
     '  --progress-json      emit progress as JSON lines on stderr',
@@ -92,6 +97,10 @@ export async function runExportApp(args: string[], stdout: Writer = process.stdo
     }
     const options = parseArgs(args);
     validateCliOptions(options);
+    if (options.dryRun) {
+      stdout(`${JSON.stringify({ success: true, dryRun: true, ...previewOracleExport({ dbPath: options.dbPath }) }, null, 2)}\n`);
+      return 0;
+    }
     const progress = options.quiet
       ? () => {}
       : options.progressJson

--- a/tools/export-app/summary.ts
+++ b/tools/export-app/summary.ts
@@ -1,0 +1,67 @@
+import { getTableName } from 'drizzle-orm';
+import { DB_PATH } from '../../src/config.ts';
+import { introspectDrizzleTables } from '../../src/cli/commands/backup.ts';
+import type { DatabaseConnection } from '../../src/db/index.ts';
+import { createStorageBackend } from '../../src/storage/registry.ts';
+import { graphRelationships } from './graph.ts';
+import { normalizeRecords, type ExportRecord } from './formats.ts';
+import { readOracleV2Documents } from './documents.ts';
+
+type ExportTable = ReturnType<typeof introspectDrizzleTables>[number];
+
+export interface ExportPreviewOptions {
+  dbPath?: string;
+  connection?: DatabaseConnection;
+}
+
+export interface ExportPreviewCollection {
+  name: string;
+  rowCount: number;
+}
+
+export interface ExportPreviewResult {
+  dbPath: string;
+  collectionCount: number;
+  rowCount: number;
+  relationshipCount: number;
+  documentCount: number;
+  collections: ExportPreviewCollection[];
+}
+
+export function previewOracleExport(options: ExportPreviewOptions = {}): ExportPreviewResult {
+  const close = options.connection ? undefined : openReadonlyConnection(options.dbPath);
+  const connection = options.connection ?? close!.connection;
+  const tables = introspectDrizzleTables();
+  const allCollections: Record<string, ExportRecord[]> = {};
+  const collections: ExportPreviewCollection[] = [];
+  let rowCount = 0;
+
+  try {
+    for (const table of tables) {
+      const name = getTableName(table);
+      const rows = normalizeRecords(selectRows(connection, table));
+      allCollections[name] = rows;
+      rowCount += rows.length;
+      collections.push({ name, rowCount: rows.length });
+    }
+    return {
+      dbPath: options.dbPath ?? DB_PATH,
+      collectionCount: collections.length,
+      rowCount,
+      relationshipCount: graphRelationships(allCollections).length,
+      documentCount: readOracleV2Documents(connection).length,
+      collections,
+    };
+  } finally {
+    close?.connection.storage.close();
+  }
+}
+
+function openReadonlyConnection(dbPath = DB_PATH): { connection: DatabaseConnection } {
+  const storage = createStorageBackend({ dbPath, readonly: true });
+  return { connection: { sqlite: storage.sqlite, db: storage.db, storage } };
+}
+
+function selectRows(connection: DatabaseConnection, table: ExportTable): ExportRecord[] {
+  return (connection.db as any).select().from(table).all() as ExportRecord[];
+}


### PR DESCRIPTION
## Summary
- add `--dry-run` to the standalone export app CLI for a safe preflight summary
- report db path, collection count, row count, relationship count, document count, and per-collection row counts without writing files
- document the dry-run flow and cover it with scoped export-app tests

Refs #1783

## Validation
- bunx tsc --noEmit
- bun test tests/tools/export-app.test.ts tests/tools/export-app/export-app.test.ts tests/tools/export-app/manifest-schema.test.ts tests/http/export tests/frontend/pages/export-app.test.tsx
- wc -l tools/export-app/summary.ts tools/export-app/index.ts tests/tools/export-app.test.ts tools/export-app/README.md
- git diff --check