### PR TITLE
feat: add export app progress json

### DIFF
--- a/tests/tools/export-app.test.ts
+++ b/tests/tools/export-app.test.ts
@@ -141,6 +141,30 @@ test('CLI quiet flag suppresses progress output', async () => {
   expect(existsSync(join(outputDir, 'manifest.json'))).toBe(true);
 });
 
+test('CLI progress-json flag emits machine-readable progress', async () => {
+  const dbPath = join(root, 'progress-json.db');
+  const outputDir = join(root, 'progress-json-export');
+  const connection = createDatabase(dbPath);
+  seed(connection);
+  connection.storage.close();
+
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const code = await runExportApp(
+    ['--output', outputDir, '--db', dbPath, '--progress-json'],
+    (message) => stdout.push(message),
+    (message) => stderr.push(message),
+  );
+  const events = stderr.join('').trim().split('\n').map((line) => JSON.parse(line));
+
+  expect(code).toBe(0);
+  expect(JSON.parse(stdout.join('')).success).toBe(true);
+  expect(events).toContainEqual(expect.objectContaining({
+    event: 'export_progress',
+    message: expect.stringContaining('oracle_documents'),
+  }));
+});
+
 test('CLI rejects unknown flags before exporting', () => {
   expect(() => parseArgs(['--output', './backup', '--bogus'])).toThrow('unknown flag: --bogus');
   expect(() => parseArgs(['--output'])).toThrow('missing value for --output');

--- a/tools/export-app/index.ts
+++ b/tools/export-app/index.ts
@@ -8,6 +8,7 @@ interface CliOptions {
   outputDir: string;
   dbPath?: string;
   quiet: boolean;
+  progressJson: boolean;
 }
 
 function flagValue(args: string[], index: number, flag: string): string {
@@ -28,6 +29,7 @@ export function parseArgs(args: string[]): CliOptions {
   let outputDir: string | undefined;
   let dbPath: string | undefined;
   let quiet = false;
+  let progressJson = false;
 
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i]!;
@@ -38,12 +40,13 @@ export function parseArgs(args: string[]): CliOptions {
     if (arg === '--output' || arg === '-o') { outputDir = flagValue(args, i, arg); i += 1; continue; }
     if (arg === '--db') { dbPath = flagValue(args, i, arg); i += 1; continue; }
     if (arg === '--quiet' || arg === '--no-progress') { quiet = true; continue; }
+    if (arg === '--progress-json') { progressJson = true; continue; }
     if (arg === '--help' || arg === '-h') continue;
     throw new Error(arg.startsWith('-') ? `unknown flag: ${arg}` : `unexpected argument: ${arg}`);
   }
 
   if (!outputDir) throw new Error('missing required --output <dir>');
-  return { outputDir, dbPath, quiet };
+  return { outputDir, dbPath, quiet, progressJson };
 }
 
 function requireFile(path: string): void {
@@ -75,6 +78,7 @@ function printHelp(write: Writer): void {
     '  --db <path>          SQLite database path (defaults to ORACLE_DB_PATH)',
     '  --quiet              suppress progress output',
     '  --no-progress        alias for --quiet',
+    '  --progress-json      emit progress as JSON lines on stderr',
     '  --help, -h           show this help',
     '',
   ].join('\n'));
@@ -88,7 +92,11 @@ export async function runExportApp(args: string[], stdout: Writer = process.stdo
     }
     const options = parseArgs(args);
     validateCliOptions(options);
-    const progress = options.quiet ? () => {} : (message: string) => stderr(`${message}\n`);
+    const progress = options.quiet
+      ? () => {}
+      : options.progressJson
+        ? (message: string) => stderr(`${JSON.stringify({ event: 'export_progress', message })}\n`)
+        : (message: string) => stderr(`${message}\n`);
     const result = await exportOracleData({
       outputDir: options.outputDir,
       dbPath: options.dbPath,


### PR DESCRIPTION
## Summary
- Add `--progress-json` to the standalone export app CLI.
- Emit progress messages as JSON lines on stderr for machine-readable monitoring.
- Keep `--quiet` as the suppressor, overriding progress output.
- Cover JSON progress events in scoped CLI tests.

## Validation
- `bunx tsc --noEmit`
- `bun test tests/tools/export-app.test.ts tests/tools/export-app/export-app.test.ts tests/tools/export-app/manifest-schema.test.ts` — 14 pass, 0 fail
- `wc -l tools/export-app/index.ts tests/tools/export-app.test.ts tools/export-app/exporter.ts tools/export-app/documents.ts tools/export-app/schema.ts tools/export-app/document-csv.ts tests/tools/export-app/export-app.test.ts tests/tools/export-app/manifest-schema.test.ts` — all <=250 lines
- `git diff --check` on changed files

Base: `alpha`
Issue: #1783
