### PR TITLE
fix: return 400 for malformed learn JSON

### DIFF
--- a/src/middleware/errors.ts
+++ b/src/middleware/errors.ts
@@ -1,5 +1,4 @@
 import { Elysia } from 'elysia';
-import { apiRequestPath } from './api-version.ts';
 import { REQUEST_ID_HEADER, RESPONSE_TIME_HEADER, requestIdFor, responseTimeFor } from './correlation.ts';
 
 export type ApiErrorResponse = {
@@ -75,21 +74,12 @@ function errorName(error: unknown): string {
   return error instanceof Error ? error.name : '';
 }
 
-function normalizedPath(pathname: string): string {
-  return pathname.replace(/^\/api\/v[^/]+(?=\/)/, '/api');
-}
-
-function isLearnPath(pathname: string): boolean {
-  const path = normalizedPath(pathname);
-  return path === '/api/learn' || path.startsWith('/api/learn/');
-}
 
 function isParseError(code: string, error: unknown): boolean {
   return code === 'PARSE' || errorName(error) === 'BadRequestError' || error instanceof SyntaxError;
 }
 
-function knownStatus(code: string, error: unknown, pathname: string): number {
-  if (isLearnPath(pathname) && (code === 'PARSE' || error instanceof SyntaxError)) return 500;
+function knownStatus(code: string, error: unknown): number {
   if (error instanceof HttpError) return error.statusCode;
   const explicit = numericStatus((error as { status?: unknown })?.status) ?? numericStatus((error as { statusCode?: unknown })?.statusCode);
   if (explicit) return explicit;
@@ -110,7 +100,7 @@ function defaultErrorLogger(entry: { requestId: string; statusCode: number; code
 
 export function createErrorMiddleware(logger: ErrorLogger = defaultErrorLogger) {
   return new Elysia({ name: 'structured-errors' }).onError({ as: 'global' }, ({ code, error, request, set }) => {
-    const statusCode = knownStatus(String(code), error, apiRequestPath(request));
+    const statusCode = knownStatus(String(code), error);
     const id = requestIdFor(request);
     const message = statusCode === 404 && code === 'NOT_FOUND' ? 'Route not found' : errorMessage(error);
     set.status = statusCode;

--- a/src/routes/knowledge/index.ts
+++ b/src/routes/knowledge/index.ts
@@ -1,8 +1,8 @@
 /**
  * Knowledge Routes (Elysia) — composes /api/{learn,handoff,inbox}.
  *
- * Malformed JSON parse failures on /api/learn preserve the historical 500
- * contract through the structured error middleware's learn-path override.
+ * Malformed JSON parse failures on /api/learn use the shared structured
+ * 400 Bad Request contract from the error middleware.
  */
 
 import { Elysia } from 'elysia';

--- a/tests/http/knowledge.test.ts
+++ b/tests/http/knowledge.test.ts
@@ -74,12 +74,12 @@ describe("HTTP Contract — search / knowledge / supersede", () => {
       expect((await res.json()).error).toMatch(/pattern/i);
     });
 
-    test("rejects malformed JSON body as 500", async () => {
+    test("rejects malformed JSON body as 400", async () => {
       const res = await fetch(`${BASE_URL}/api/learn`, { method: "POST", headers: JSON_HEADERS, body: "{not json" });
       const body = await res.json();
-      expect(res.status).toBe(500);
+      expect(res.status).toBe(400);
       expect(res.headers.get("content-type")).toContain("application/json");
-      expect(body).toMatchObject({ success: false, error: "Internal Server Error", code: 500 });
+      expect(body).toMatchObject({ success: false, error: "Bad Request", code: 400 });
     });
   });
 

--- a/tests/http/learn/crud.test.ts
+++ b/tests/http/learn/crud.test.ts
@@ -59,30 +59,30 @@ afterAll(() => {
 });
 
 describe('POST/GET/PUT/DELETE /api/learn', () => {
-  test('rejects malformed JSON body as 500', async () => {
+  test('rejects malformed JSON body as 400', async () => {
     const res = await app().handle(new Request('http://local/api/learn', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: '{not json',
     }));
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(400);
     expect(res.headers.get('content-type')).toContain('application/json');
     const body = await res.json();
-    expect(body).toMatchObject({ success: false, error: 'Internal Server Error', code: 500 });
+    expect(body).toMatchObject({ success: false, error: 'Bad Request', code: 400 });
     expect(body.details.message).toBe('Bad Request');
     expect(typeof body.details.correlationId).toBe('string');
   });
 
-  test('rejects malformed JSON on versioned route with 500 contract', async () => {
+  test('rejects malformed JSON on versioned route with 400 contract', async () => {
     const res = await versionedHandle(new Request('http://local/api/v1/learn', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: '{not json',
     }));
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(400);
     expect(res.headers.get('content-type')).toContain('application/json');
     const body = await res.json();
-    expect(body).toMatchObject({ success: false, error: 'Internal Server Error', code: 500 });
+    expect(body).toMatchObject({ success: false, error: 'Bad Request', code: 400 });
     expect(body.details.message).toBe('Bad Request');
     expect(typeof body.details.correlationId).toBe('string');
   });


### PR DESCRIPTION
## Summary
- Removed the `/api/learn` parse-error exception from structured error handling.
- Standardized malformed JSON bodies on `/api/learn` and `/api/v1/learn` to `400 Bad Request`.
- Updated knowledge/learn HTTP contract tests and route docs to match the shared structured error contract.

## Validation
- `bunx tsc --noEmit`
- `bun test tests/http/learn/crud.test.ts tests/http/knowledge.test.ts tests/http/errors/structured-errors.test.ts tests/http/correlation/request-id.test.ts`
- `git diff --check`
- `wc -l src/middleware/errors.ts src/routes/knowledge/index.ts tests/http/learn/crud.test.ts tests/http/knowledge.test.ts` (all changed files ≤250 lines)

Closes #1718.
