### PR TITLE
feat: add vector-config CLI ops

### DIFF
--- a/tests/http/vector/config-format.test.ts
+++ b/tests/http/vector/config-format.test.ts
@@ -50,7 +50,7 @@ test('loadVectorConfig preserves v1 collection configs', () => {
     model: 'nomic-embed-text',
     adapter: 'lancedb',
     dataPath: '/tmp/vector-v1',
-    embedder: { backend: 'local', model: 'nomic-embed-text' },
+    embedder: { backend: 'ollama', model: 'nomic-embed-text' },
   });
 });
 

--- a/tests/tools/maw-plugin-arra/vector-config-ops.test.ts
+++ b/tests/tools/maw-plugin-arra/vector-config-ops.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import handler from '../../../tools/maw-plugin-arra/index.ts';
+
+type Call = { url: string; init?: RequestInit; body?: unknown };
+
+const originalFetch = globalThis.fetch;
+const originalApi = process.env.ARRA_API;
+
+function installFetch(response: unknown = { success: true, collection: 'nomic' }): Call[] {
+  const calls: Call[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ url: String(input), init, body: init?.body ? JSON.parse(String(init.body)) : undefined });
+    return new Response(JSON.stringify(response), { status: 200, headers: { 'content-type': 'application/json' } });
+  }) as typeof fetch;
+  return calls;
+}
+
+async function run(args: string[], response?: unknown) {
+  process.env.ARRA_API = 'http://arra.test/';
+  const calls = installFetch(response);
+  const result = await handler({ args });
+  return { result, calls, body: result.output ? JSON.parse(result.output) as Record<string, unknown> : {} };
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalApi === undefined) delete process.env.ARRA_API;
+  else process.env.ARRA_API = originalApi;
+});
+
+describe('maw arra vector-config ops commands', () => {
+  test('adds a configured vector collection', async () => {
+    const { result, calls, body } = await run([
+      'vector-config', 'add', 'qwen3', '--model', 'qwen3-embedding', '--adapter', 'lancedb', '--collection', 'oracle_qwen3', '--primary', 'true',
+    ], { success: true, collection: 'qwen3' });
+
+    expect(result.ok).toBe(true);
+    expect(calls[0].url).toBe('http://arra.test/api/v1/vector/config/qwen3');
+    expect(calls[0].init?.method).toBe('POST');
+    expect(calls[0].body).toEqual({ model: 'qwen3-embedding', adapter: 'lancedb', collection: 'oracle_qwen3', primary: true });
+    expect(body).toMatchObject({ success: true, collection: 'qwen3' });
+  });
+
+  test('removes a vector collection config', async () => {
+    const { result, calls } = await run(['vector-config', 'remove', 'nomic'], { success: true, removed: 'nomic' });
+
+    expect(result.ok).toBe(true);
+    expect(calls[0].url).toBe('http://arra.test/api/v1/vector/config/nomic');
+    expect(calls[0].init?.method).toBe('DELETE');
+  });
+
+  test('sets primary, tests, and reloads vector config', async () => {
+    const primary = await run(['vector-config', 'set-primary', 'qwen3'], { success: true, collection: 'qwen3' });
+    const testRes = await run(['vector-config', 'test', 'qwen3'], { success: true, key: 'qwen3' });
+    const reload = await run(['vector-config', 'reload'], { success: true, reloaded: true });
+
+    expect(primary.calls[0].url).toBe('http://arra.test/api/v1/vector/config/qwen3/primary');
+    expect(primary.calls[0].init?.method).toBe('POST');
+    expect(testRes.calls[0].url).toBe('http://arra.test/api/v1/vector/config/qwen3/test');
+    expect(testRes.calls[0].init?.method).toBe('POST');
+    expect(reload.calls[0].url).toBe('http://arra.test/api/v1/vector/config/reload');
+    expect(reload.calls[0].init?.method).toBe('POST');
+  });
+
+  test('requires a model when adding a collection', async () => {
+    const { result, calls } = await run(['vector-config', 'add', 'missing-model']);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('add requires --model <model>');
+    expect(calls).toEqual([]);
+  });
+});

--- a/tools/maw-plugin-arra/commands/vector-config.ts
+++ b/tools/maw-plugin-arra/commands/vector-config.ts
@@ -1,8 +1,15 @@
 import { flag, parseArgs, requestJson, requestText, type ParsedArgs } from './http.ts';
 
-const usage = 'usage: maw arra vector-config list|get [collection]|set <collection> <field> <value>';
+const usage = [
+  'usage: maw arra vector-config list|get [collection]',
+  '       maw arra vector-config set <collection> <field> <value>',
+  '       maw arra vector-config add <collection> --model <model> [--adapter <adapter>]',
+  '       maw arra vector-config remove|set-primary|test <collection>',
+  '       maw arra vector-config reload',
+].join('\n');
 const adapters = new Set(['chroma', 'sqlite-vec', 'lancedb', 'qdrant', 'cloudflare-vectorize', 'proxy', 'turbovec']);
-const updateFields = new Set(['adapter', 'model', 'provider', 'service', 'endpoint', 'enabled', 'primary', 'embedder', 'collection']);
+const updateFields = new Set(['adapter', 'model', 'provider', 'service', 'endpoint', 'enabled', 'primary', 'embedder']);
+const createFields = new Set([...updateFields, 'collection']);
 
 type JsonObject = Record<string, unknown>;
 
@@ -52,9 +59,9 @@ function listPayload(payload: JsonObject): JsonObject {
   return { source: payload.source, collections };
 }
 
-function flagUpdates(parsed: ParsedArgs): JsonObject {
+function flagUpdates(parsed: ParsedArgs, fields = updateFields): JsonObject {
   const updates: JsonObject = {};
-  for (const field of updateFields) {
+  for (const field of fields) {
     const raw = flag(parsed, field === 'endpoint' ? 'url' : field) ?? flag(parsed, field);
     if (raw !== undefined) updates[field] = parseValue(field, raw);
   }
@@ -86,6 +93,34 @@ async function writeCollection(collection: string, body: JsonObject): Promise<Js
   return text ? JSON.parse(text) as JsonObject : {};
 }
 
+async function createCollection(collection: string, body: JsonObject): Promise<JsonObject> {
+  const text = await requestText(`/api/v1/vector/config/${encodeURIComponent(collection)}`, {
+    method: 'POST',
+    headers: { accept: 'application/json', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return text ? JSON.parse(text) as JsonObject : {};
+}
+
+async function postAction(path: string): Promise<JsonObject> {
+  const text = await requestText(path, { method: 'POST', headers: { accept: 'application/json' } });
+  return text ? JSON.parse(text) as JsonObject : {};
+}
+
+async function removeCollection(collection: string): Promise<JsonObject> {
+  const text = await requestText(`/api/v1/vector/config/${encodeURIComponent(collection)}`, {
+    method: 'DELETE',
+    headers: { accept: 'application/json' },
+  });
+  return text ? JSON.parse(text) as JsonObject : {};
+}
+
+function requiredCollection(parsed: ParsedArgs): string {
+  const collection = parsed.positionals[1];
+  if (!collection) throw new Error(usage);
+  return collection;
+}
+
 export async function runVectorConfigCommand(args: string[]): Promise<string> {
   const parsed = parseArgs(args);
   const action = (parsed.positionals[0] ?? 'list').toLowerCase().replace(/-/g, '_');
@@ -96,11 +131,25 @@ export async function runVectorConfigCommand(args: string[]): Promise<string> {
     return json(collection ? collectionPayload(payload, collection) : payload);
   }
   if (action === 'set') {
-    const collection = parsed.positionals[1];
-    if (!collection) throw new Error(usage);
-    return json(await writeCollection(collection, updateBody(parsed)));
+    return json(await writeCollection(requiredCollection(parsed), updateBody(parsed)));
   }
+  if (action === 'add') {
+    const collection = requiredCollection(parsed);
+    const body = flagUpdates(parsed, createFields);
+    if (!body.model) throw new Error('add requires --model <model>');
+    return json(await createCollection(collection, body));
+  }
+  if (action === 'remove') return json(await removeCollection(requiredCollection(parsed)));
+  if (action === 'set_primary' || action === 'primary') {
+    const collection = requiredCollection(parsed);
+    return json(await postAction(`/api/v1/vector/config/${encodeURIComponent(collection)}/primary`));
+  }
+  if (action === 'test') {
+    const collection = requiredCollection(parsed);
+    return json(await postAction(`/api/v1/vector/config/${encodeURIComponent(collection)}/test`));
+  }
+  if (action === 'reload') return json(await postAction('/api/v1/vector/config/reload'));
   throw new Error(usage);
 }
 
-export const VECTOR_CONFIG_HELP = 'vector-config list|get [collection]|set <collection> <field> <value>';
+export const VECTOR_CONFIG_HELP = 'vector-config list|get|set|add|remove|set-primary|reload|test';

--- a/tools/maw-plugin-arra/plugin.json
+++ b/tools/maw-plugin-arra/plugin.json
@@ -7,7 +7,7 @@
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "arra",
-    "help": "maw arra <status|export --collection X --format json|csv|md|vector-config list|get|set>"
+    "help": "maw arra <status|export --collection X --format json|csv|md|vector-config list|get|set|add|remove|set-primary|reload|test>"
   },
   "weight": 10,
   "license": "BUSL-1.1",


### PR DESCRIPTION
## Summary
- extend `maw arra vector-config` with add/remove/set-primary/reload/test operations backed by existing vector config API endpoints
- update plugin help metadata to advertise the complete command set
- add regression tests for vector-config ops and refresh vector config-format expectation for current zero-config Ollama embedder behavior

## Validation
- bunx tsc --noEmit
- bunx bun@1.3.14 test --isolate tests/tools/maw-plugin-arra/vector-config.test.ts tests/tools/maw-plugin-arra/vector-config-ops.test.ts tests/http/vector/config-api.test.ts tests/http/vector/config-hot-reload.test.ts tests/http/vector/config-format.test.ts
- changed file line-count gate: all changed files <=250 lines

Closes #1596