### PR TITLE
fix: escape export csv formula cells

### DIFF
--- a/tests/tools/export-app/csv-safety.test.ts
+++ b/tests/tools/export-app/csv-safety.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'bun:test';
+import { formatCsvCollection } from '../../../tools/export-app/format-csv.ts';
+import { formatDocumentsCsv } from '../../../tools/export-app/document-csv.ts';
+
+test('collection CSV escapes spreadsheet formula prefixes', () => {
+  const csv = formatCsvCollection('oracle_documents', [{
+    id: '=cmd',
+    title: '+title',
+    content: '@body',
+    createdAt: '-1',
+  }]);
+
+  expect(csv).toContain('"\'=cmd"');
+  expect(csv).toContain(`"'+title"`);
+  expect(csv).toContain('"\'@body"');
+  expect(csv).toContain('"\'-1"');
+});
+
+test('document CSV escapes spreadsheet formula prefixes', () => {
+  const csv = formatDocumentsCsv([{
+    id: '=doc',
+    source: '+source.md',
+    content: '@content',
+    concepts: ['-concept'],
+    metadata: { type: '=learning' },
+  }]);
+
+  expect(csv).toContain('"\'=doc"');
+  expect(csv).toContain(`"'+source.md"`);
+  expect(csv).toContain('"\'@content"');
+  expect(csv).toContain('"\'-concept"');
+});

--- a/tools/export-app/document-csv.ts
+++ b/tools/export-app/document-csv.ts
@@ -4,7 +4,11 @@ const COLUMNS = ['id', 'source', 'type', 'concepts', 'content_preview', 'metadat
 
 function csvCell(value: unknown): string {
   const text = value == null ? '' : String(value);
-  return `"${text.replaceAll('"', '""')}"`;
+  return `"${spreadsheetSafe(text).replaceAll('"', '""')}"`;
+}
+
+function spreadsheetSafe(value: string): string {
+  return /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
 }
 
 function preview(content: string): string {

--- a/tools/export-app/format-csv.ts
+++ b/tools/export-app/format-csv.ts
@@ -22,7 +22,11 @@ function preview(value: unknown): string {
 }
 
 function csvCell(value: unknown): string {
-  return `"${text(value).replaceAll('"', '""')}"`;
+  return `"${spreadsheetSafe(text(value)).replaceAll('"', '""')}"`;
+}
+
+function spreadsheetSafe(value: string): string {
+  return /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
 }
 
 function csvRow(collection: string, row: ExportRecord): string[] {


### PR DESCRIPTION
## Summary
- Harden standalone export CSV writers against spreadsheet formula injection.
- Prefix cells starting with formula-trigger characters (`=`, `+`, `-`, `@`, tab, CR) in both collection CSV and document CSV exports.
- Add focused tests for collection and document CSV safety.

## Validation
- `bunx tsc --noEmit`
- `bun test tests/tools/export-app.test.ts tests/tools/export-app/export-app.test.ts tests/tools/export-app/manifest-schema.test.ts tests/tools/export-app/csv-safety.test.ts` — 16 pass, 0 fail
- `wc -l tools/export-app/format-csv.ts tools/export-app/document-csv.ts tests/tools/export-app/csv-safety.test.ts` — all <=250 lines
- `git diff --check` on changed files

Base: `alpha`
Issue: #1783
