### PR TITLE
feat: complete vector config settings UI

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -77,7 +77,10 @@ export async function fetchVectorConfig(): Promise<VectorConfigResponse> {
   return getJson<VectorConfigResponse>('/api/v1/vector/config');
 }
 
-export async function updateVectorCollection(collection: string, patch: { adapter?: string; enabled?: boolean; provider?: string }): Promise<VectorConfigUpdateResponse> {
+export async function updateVectorCollection(
+  collection: string,
+  patch: { adapter?: string; enabled?: boolean; provider?: string; model?: string; primary?: boolean },
+): Promise<VectorConfigUpdateResponse> {
   return getJson<VectorConfigUpdateResponse>(`/api/v1/vector/config/${encodeURIComponent(collection)}`, {
     method: 'PUT',
     body: JSON.stringify(patch),

--- a/frontend/src/components/VectorConfigPanel.tsx
+++ b/frontend/src/components/VectorConfigPanel.tsx
@@ -3,10 +3,10 @@ import { apiUrl, fetchVectorConfig, reloadVectorConfig, updateVectorCollection }
 import { ErrorMessage, Spinner } from './AsyncState';
 import type { SettingsEmbedderCollection, VectorConfigResponse } from '../types';
 
-const ADAPTERS = ['lancedb', 'qdrant', 'chroma', 'sqlite-vec', 'cloudflare-vectorize', 'proxy'] as const;
+const ADAPTERS = ['lancedb', 'qdrant', 'chroma', 'sqlite-vec', 'cloudflare-vectorize', 'proxy', 'turbovec'] as const;
 export const VECTOR_PROVIDERS = ['none', 'ollama', 'gemini', 'openai', 'local', 'remote'] as const;
-type SaveState = Record<string, 'idle' | 'saving' | 'testing'>;
-type Drafts = Record<string, { adapter: string; enabled: boolean; provider: string }>;
+type SaveState = Record<string, 'idle' | 'saving' | 'testing' | 'primary'>;
+type Drafts = Record<string, { adapter: string; enabled: boolean; provider: string; model: string }>;
 
 function statusClass(status: string) {
   if (status === 'ok') return 'border-emerald-400/30 bg-emerald-400/10 text-emerald-200';
@@ -41,7 +41,7 @@ export function VectorConfigPanel() {
       setState(next);
       setDrafts(Object.fromEntries(Object.entries(next.config.collections).map(([key, item]) => [
         key,
-        { adapter: item.adapter ?? 'lancedb', enabled: collectionEnabled(item), provider: item.provider },
+        { adapter: item.adapter ?? 'lancedb', enabled: collectionEnabled(item), provider: item.provider, model: item.model },
       ])));
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause));
@@ -60,7 +60,7 @@ export function VectorConfigPanel() {
   }, [rows, state]);
 
   function updateDraft(key: string, patch: Partial<Drafts[string]>) {
-    setDrafts((current) => ({ ...current, [key]: { ...(current[key] ?? { adapter: 'lancedb', enabled: true, provider: 'none' }), ...patch } }));
+    setDrafts((current) => ({ ...current, [key]: { ...(current[key] ?? { adapter: 'lancedb', enabled: true, provider: 'none', model: key }), ...patch } }));
   }
 
   async function saveAdapter(key: string) {
@@ -70,10 +70,10 @@ export function VectorConfigPanel() {
     setError('');
     setMessage('');
     try {
-      await updateVectorCollection(key, { adapter: draft.adapter, enabled: draft.enabled, provider: draft.provider });
+      await updateVectorCollection(key, { adapter: draft.adapter, enabled: draft.enabled, provider: draft.provider, model: draft.model });
       await reloadVectorConfig();
       await load();
-      setMessage(`Saved ${key}: ${draft.enabled ? `${draft.adapter} · ${draft.provider}` : 'disabled'}.`);
+      setMessage(`Saved ${key}: ${draft.enabled ? `${draft.adapter} · ${draft.provider} · ${draft.model}` : 'disabled'}.`);
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause));
     } finally {
@@ -89,6 +89,22 @@ export function VectorConfigPanel() {
       const result = await testVectorCollection(key);
       setMessage(`${key} ${result.success ? 'ok' : result.status ?? 'failed'} · ${result.count ?? 0} docs`);
       await load();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setSaving((current) => ({ ...current, [key]: 'idle' }));
+    }
+  }
+
+  async function setPrimary(key: string) {
+    setSaving((current) => ({ ...current, [key]: 'primary' }));
+    setError('');
+    setMessage('');
+    try {
+      await updateVectorCollection(key, { primary: true });
+      await reloadVectorConfig();
+      await load();
+      setMessage(`Set ${key} as primary vector collection.`);
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause));
     } finally {
@@ -115,7 +131,7 @@ export function VectorConfigPanel() {
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-teal-300">Vector config</p>
           <h3 className="mt-2 text-lg font-semibold text-white">Active vector adapters</h3>
-          <p className="mt-2 text-sm text-slate-400">Switch each collection between LanceDB, Qdrant, Chroma, sqlite-vec, Cloudflare, or proxy adapters.</p>
+          <p className="mt-2 text-sm text-slate-400">Get current config, edit model/provider, switch adapters, enable rows, set primary, and test health.</p>
           <p className="mt-2 text-xs text-slate-500">{summary}</p>
         </div>
         <button className="focus-ring rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-teal-300/40" type="button" onClick={reload}>
@@ -128,10 +144,10 @@ export function VectorConfigPanel() {
 
       <div className="mt-5 grid gap-3">
         {rows.map(([key, item]) => {
-          const draft = drafts[key] ?? { adapter: item.adapter ?? 'lancedb', enabled: collectionEnabled(item), provider: item.provider };
+          const draft = drafts[key] ?? { adapter: item.adapter ?? 'lancedb', enabled: collectionEnabled(item), provider: item.provider, model: item.model };
           const health = state?.health[key];
           const status = health?.status ?? (draft.enabled ? 'unknown' : 'disabled');
-          const dirty = draft.adapter !== (item.adapter ?? 'lancedb') || draft.enabled !== collectionEnabled(item) || draft.provider !== item.provider;
+          const dirty = draft.adapter !== (item.adapter ?? 'lancedb') || draft.enabled !== collectionEnabled(item) || draft.provider !== item.provider || draft.model !== item.model;
           return (
             <article key={key} className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
               <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
@@ -146,6 +162,10 @@ export function VectorConfigPanel() {
                   {health?.error ? <p className="mt-2 text-xs text-rose-300">{health.error}</p> : null}
                 </div>
                 <div className="flex flex-wrap items-center gap-3">
+                  <label className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                    Model
+                    <input className="mt-1 block rounded-xl border border-white/10 bg-slate-900 px-3 py-2 text-sm text-slate-100" value={draft.model} onChange={(event) => updateDraft(key, { model: event.target.value })} />
+                  </label>
                   <label className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
                     Active adapter
                     <select className="mt-1 block rounded-xl border border-white/10 bg-slate-900 px-3 py-2 text-sm text-slate-100" value={draft.adapter} onChange={(event) => updateDraft(key, { adapter: event.target.value })}>
@@ -164,6 +184,7 @@ export function VectorConfigPanel() {
                   </label>
                   <button className="focus-ring rounded-xl border border-teal-300/30 px-3 py-2 text-sm font-semibold text-teal-100 disabled:opacity-50" disabled={!dirty || saving[key] === 'saving'} type="button" onClick={() => void saveAdapter(key)}>{saving[key] === 'saving' ? <Spinner label="Saving" /> : 'Save switch'}</button>
                   <button className="focus-ring rounded-xl border border-purple-300/30 px-3 py-2 text-sm font-semibold text-purple-100 disabled:opacity-50" disabled={saving[key] === 'testing'} type="button" onClick={() => void testAdapter(key)}>{saving[key] === 'testing' ? <Spinner label="Testing" /> : 'Test'}</button>
+                  <button className="focus-ring rounded-xl border border-cyan-300/30 px-3 py-2 text-sm font-semibold text-cyan-100 disabled:opacity-50" disabled={item.primary || saving[key] === 'primary'} type="button" onClick={() => void setPrimary(key)}>{saving[key] === 'primary' ? <Spinner label="Setting primary" /> : 'Set primary'}</button>
                 </div>
               </div>
             </article>

--- a/frontend/src/pages/vectorSettingsHelpers.ts
+++ b/frontend/src/pages/vectorSettingsHelpers.ts
@@ -1,6 +1,6 @@
 import { apiUrl } from '../api/oracle';
 
-export const ADAPTER_OPTIONS = ['chroma', 'sqlite-vec', 'lancedb', 'qdrant', 'cloudflare-vectorize', 'proxy'] as const;
+export const ADAPTER_OPTIONS = ['chroma', 'sqlite-vec', 'lancedb', 'qdrant', 'cloudflare-vectorize', 'proxy', 'turbovec'] as const;
 export type VectorConfigAdapter = (typeof ADAPTER_OPTIONS)[number];
 
 export type LoadState = 'loading' | 'ready' | 'error';

--- a/tests/frontend/api/update-vector-collection-provider.test.ts
+++ b/tests/frontend/api/update-vector-collection-provider.test.ts
@@ -7,11 +7,21 @@ describe('updateVectorCollection provider switching', () => {
   test('sends adapter, enabled, and provider fields to vector config API', async () => {
     const fetchMock = installFetch(() => jsonResponse({ success: true, source: 'file', config: { collections: {} } }));
 
-    await updateVectorCollection('bge-m3', { adapter: 'qdrant', enabled: false, provider: 'remote' });
+    await updateVectorCollection('bge-m3', { adapter: 'qdrant', enabled: false, provider: 'remote', model: 'bge-m3:latest' });
 
     expect(VECTOR_PROVIDERS).toContain('remote');
     expect(fetchMock.calls[0]?.input).toBe('/api/v1/vector/config/bge-m3');
     expect(fetchMock.calls[0]?.init?.method).toBe('PUT');
-    expect(JSON.parse(String(fetchMock.calls[0]?.init?.body))).toEqual({ adapter: 'qdrant', enabled: false, provider: 'remote' });
+    expect(JSON.parse(String(fetchMock.calls[0]?.init?.body))).toEqual({ adapter: 'qdrant', enabled: false, provider: 'remote', model: 'bge-m3:latest' });
+  });
+
+  test('sends primary switch payload to vector config API', async () => {
+    const fetchMock = installFetch(() => jsonResponse({ success: true, source: 'file', config: { collections: {} } }));
+
+    await updateVectorCollection('qwen3', { primary: true });
+
+    expect(fetchMock.calls[0]?.input).toBe('/api/v1/vector/config/qwen3');
+    expect(fetchMock.calls[0]?.init?.method).toBe('PUT');
+    expect(JSON.parse(String(fetchMock.calls[0]?.init?.body))).toEqual({ primary: true });
   });
 });

--- a/tests/frontend/pages/vector-settings-page.test.tsx
+++ b/tests/frontend/pages/vector-settings-page.test.tsx
@@ -11,6 +11,8 @@ describe('VectorSettingsPage', () => {
     expect(html).toContain('Embedding providers and storage services');
     expect(html).toContain('Model recommendation');
     expect(html).toContain('Active vector adapters');
+    expect(html).toContain('edit model/provider');
+    expect(html).toContain('set primary');
     expect(html).toContain('Index jobs and collections');
   });
 });


### PR DESCRIPTION
## Summary
- complete the frontend vector config settings panel with model editing, adapter switching, enable toggles, and set-primary action
- add turbovec to frontend adapter options
- expand frontend API tests for model and primary update payloads

## Validation
- bunx tsc --noEmit
- bunx bun@1.3.14 test --isolate tests/frontend/api/update-vector-collection-provider.test.ts tests/frontend/api/fetch-settings-system-passthrough.test.ts tests/frontend/pages/vector-settings-page.test.tsx tests/frontend/pages/settings-page-summary.test.tsx tests/frontend/components/vector-adapter-switcher.test.tsx
- git diff --check origin/alpha..HEAD
- changed file line-count gate: all changed files <=250 lines

Closes #1595