### PR TITLE
feat(vector): support proxy collection replacement

### DIFF
--- a/src/vector/adapters/proxy.ts
+++ b/src/vector/adapters/proxy.ts
@@ -84,6 +84,11 @@ export class ProxyVectorAdapter implements VectorStoreAdapter {
     await this.post('/vectors/add', { documents: docs });
   }
 
+  async replaceDocuments(docs: VectorDocument[]): Promise<void> {
+    await this.deleteCollection();
+    if (docs.length > 0) await this.addDocuments(docs);
+  }
+
   async query(text: string, limit: number = 10, where?: Record<string, any>): Promise<VectorQueryResult> {
     const body: ProxyQueryRequest = { text, limit, ...(where ? { where } : {}) };
     return this.postJson<ProxyQueryResponse>('/vectors/query', body);

--- a/tests/http/vector/proxy-adapter.test.ts
+++ b/tests/http/vector/proxy-adapter.test.ts
@@ -35,6 +35,7 @@ test('ProxyVectorAdapter speaks vector proxy protocol under endpoint path prefix
   await adapter.addDocuments(docs);
   const result = await adapter.query('hello', 3, { type: 'learning' });
   const info = await adapter.getCollectionInfo();
+  await adapter.replaceDocuments(docs);
   await adapter.deleteCollection();
 
   expect(result.ids).toEqual(['doc-1']);
@@ -45,8 +46,11 @@ test('ProxyVectorAdapter speaks vector proxy protocol under endpoint path prefix
     'POST /proxy/vectors/query',
     'GET /proxy/vectors/stats',
     'DELETE /proxy/vectors/collection',
+    'POST /proxy/vectors/add',
+    'DELETE /proxy/vectors/collection',
   ]);
   expect(requests[2].body).toEqual({ text: 'hello', limit: 3, where: { type: 'learning' } });
+  expect(requests[5].body).toEqual({ documents: docs });
 });
 
 test('vectorServiceUrl preserves path prefixes', () => {


### PR DESCRIPTION
## Summary
- Implement `replaceDocuments` for `ProxyVectorAdapter` by clearing the remote collection and re-adding docs through the vector proxy protocol
- Cover the replace path in the proxy adapter HTTP contract test
- Keeps TurboVec/proxy backends compatible with reindex refresh flows

## Validation
- bun test tests/http/vector/proxy-adapter.test.ts tests/http/vector/turbovec.test.ts tests/http/vector/turbovec-sidecar.test.ts tests/http/vector/services.test.ts tests/vector/service-registry.test.ts
- bunx tsc --noEmit
- wc -l src/vector/adapters/proxy.ts tests/http/vector/proxy-adapter.test.ts

Refs #1438