### PR TITLE
feat: expose arra plugin command registry

### DIFF
--- a/src/plugins/__tests__/arra-plugin-commands.test.ts
+++ b/src/plugins/__tests__/arra-plugin-commands.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { arraCli, arraHttpRoute } from "../arra/index.ts";
+
+const config = {
+  dbBackend: "custom" as const,
+  embedderBackend: "remote" as const,
+  remoteEmbedderUrl: "https://example.invalid/embed",
+};
+
+describe("built-in arra plugin command registry", () => {
+  test("renders the shared CLI/menu/API registry from maw arra commands", async () => {
+    const result = await arraCli({ source: "cli", plugin: "arra", args: ["commands"] });
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("shared by CLI/menu/API");
+    expect(result.output).toContain("commands");
+    expect(result.output).toContain("/api/plugins/arra");
+    expect(result.output).toContain("vector-config");
+  });
+
+  test("commands --json mirrors the HTTP registry payload", async () => {
+    const result = await arraCli({ source: "cli", plugin: "arra", args: ["commands", "--json"], config });
+    const http = arraHttpRoute({ source: "api", plugin: "arra", config });
+    const payload = JSON.parse(result.output ?? "{}") as typeof http.body;
+
+    expect(result.ok).toBe(true);
+    expect(payload.surface).toBe("cli");
+    expect(payload.verbs.map((verb) => verb.name)).toEqual(http.body.verbs.map((verb) => verb.name));
+    expect(payload.backends).toEqual(http.body.backends);
+    expect(payload.remoteEmbedderConfigured).toBe(true);
+  });
+
+  test("normalizes modern maw help and version flags", async () => {
+    const help = await arraCli({ source: "cli", plugin: "arra", args: ["--help"] });
+    const version = await arraCli({ source: "cli", plugin: "arra", args: ["--version"] });
+
+    expect(help.output).toContain("maw arra <command>");
+    expect(help.output).toContain("commands");
+    expect(version).toEqual({ ok: true, output: "arra 1.0.0" });
+  });
+});

--- a/src/plugins/__tests__/arra-plugin.test.ts
+++ b/src/plugins/__tests__/arra-plugin.test.ts
@@ -6,7 +6,7 @@ import { Elysia } from "elysia";
 import { loadUnifiedPlugins } from "../unified-loader.ts";
 
 const pluginRoot = join(process.cwd(), "src/plugins");
-const ARRA_VERBS = ["help", "version", "menu", "status", "health", "vector-config", "serve"];
+const ARRA_VERBS = ["help", "version", "menu", "status", "commands", "health", "vector-config", "serve"];
 
 describe("built-in arra plugin", () => {
   test("declares modern maw-js CLI, menu, and HTTP surfaces", () => {

--- a/src/plugins/arra/index.ts
+++ b/src/plugins/arra/index.ts
@@ -43,14 +43,21 @@ const VERBS: ArraVerb[] = [
   { name: "version", help: "Print ARRA plugin version", menuPath: MENU_PATH, httpPath: HTTP_PATH, requiresEmbedder: false, storage: "swappable" },
   { name: "menu", help: "Describe the ARRA menu surface", menuPath: MENU_PATH, httpPath: HTTP_PATH, requiresEmbedder: false, storage: "swappable" },
   { name: "status", help: "Describe optional backend capabilities", menuPath: MENU_PATH, httpPath: HTTP_PATH, requiresEmbedder: false, storage: "swappable" },
+  { name: "commands", help: "List the shared CLI/menu/API command registry", menuPath: MENU_PATH, httpPath: HTTP_PATH, requiresEmbedder: false, storage: "swappable" },
   { name: "health", help: "Show server and vector engine health", menuPath: MENU_PATH, httpPath: "/api/health", requiresEmbedder: false, storage: "swappable" },
   { name: "vector-config", help: "Inspect and manage vector backend config", menuPath: MENU_PATH, httpPath: "/api/v1/vector/config", requiresEmbedder: false, storage: "swappable" },
   { name: "serve", help: "Start, stop, or inspect the Oracle HTTP server", menuPath: MENU_PATH, httpPath: "/api/health", requiresEmbedder: false, storage: "swappable" },
 ];
 
+function argv(ctx: ArraPluginContext): string[] {
+  return (ctx.args ?? []).map(String);
+}
+
 function commandName(ctx: ArraPluginContext): string {
-  const arg = ctx.args?.[0];
-  return typeof arg === "string" && arg.trim() ? arg.trim().toLowerCase() : "help";
+  const arg = argv(ctx)[0]?.trim().toLowerCase();
+  if (!arg || arg === "--help" || arg === "-h") return "help";
+  if (arg === "--version" || arg === "-v") return "version";
+  return arg;
 }
 
 function configFrom(ctx: ArraPluginContext): Required<ArraPluginConfig> {
@@ -78,6 +85,37 @@ function pluginBody(ctx: ArraPluginContext) {
   };
 }
 
+function commandRows(): string[] {
+  return VERBS.map((verb) => `  ${verb.name.padEnd(14)} ${verb.help}`);
+}
+
+function renderHelp(): CliResult {
+  return {
+    ok: true,
+    output: [
+      "maw arra <command>",
+      ...commandRows(),
+      "",
+      "Use `maw arra commands --json` for the shared registry payload.",
+    ].join("\n"),
+  };
+}
+
+function renderCommands(ctx: ArraPluginContext): CliResult {
+  if (argv(ctx).slice(1).includes("--json")) {
+    return { ok: true, output: JSON.stringify(pluginBody(ctx), null, 2) };
+  }
+  return {
+    ok: true,
+    output: [
+      "arra command registry (shared by CLI/menu/API):",
+      `  menu: ${MENU_PATH}`,
+      `  api:  ${HTTP_PATH}`,
+      ...VERBS.map((verb) => `  ${verb.name.padEnd(14)} ${verb.httpPath.padEnd(24)} ${verb.help}`),
+    ].join("\n"),
+  };
+}
+
 async function renderCli(ctx: ArraPluginContext): Promise<CliResult> {
   const command = commandName(ctx);
   if (command === "version") return { ok: true, output: `arra ${VERSION}` };
@@ -86,11 +124,12 @@ async function renderCli(ctx: ArraPluginContext): Promise<CliResult> {
     const config = configFrom(ctx);
     return { ok: true, output: `arra status: ok (db=${config.dbBackend}, embedder=${config.embedderBackend}, storage swappable)` };
   }
-  if (command === "health") return vectorHealthCli((ctx.args ?? []).slice(1).map(String));
-  if (command === "vector-config") return vectorConfigCli((ctx.args ?? []).slice(1).map(String));
-  if (command === "serve") return serveCli((ctx.args ?? []).slice(1).map(String));
+  if (command === "commands") return renderCommands(ctx);
+  if (command === "health") return vectorHealthCli(argv(ctx).slice(1));
+  if (command === "vector-config") return vectorConfigCli(argv(ctx).slice(1));
+  if (command === "serve") return serveCli(argv(ctx).slice(1));
   if (command !== "help") return { ok: false, error: `unknown arra command: ${command}` };
-  return { ok: true, output: ["maw arra <command>", ...VERBS.map((verb) => `  ${verb.name.padEnd(14)} ${verb.help}`)].join("\n") };
+  return renderHelp();
 }
 
 export function arraHttpRoute(ctx: ArraPluginContext) {

--- a/src/plugins/arra/plugin.json
+++ b/src/plugins/arra/plugin.json
@@ -5,7 +5,7 @@
   "sdk": "^0.1.0",
   "enabled": true,
   "description": "ARRA Oracle V3 maw-js plugin surface for CLI, menu, and HTTP discovery.",
-  "verbs": ["help", "version", "menu", "status", "health", "vector-config", "serve"],
+  "verbs": ["help", "version", "menu", "status", "commands", "health", "vector-config", "serve"],
   "httpRoutes": [
     {
       "path": "/api/plugins/arra",
@@ -34,7 +34,7 @@
   ],
   "cli": {
     "command": "arra",
-    "help": "maw arra <help|version|menu|status|health|vector-config|serve>",
+    "help": "maw arra <help|version|menu|status|commands|health|vector-config|serve>",
     "handler": "arraCli"
   },
   "config": {


### PR DESCRIPTION
## Summary
- add `maw arra commands` to expose the shared ARRA CLI/menu/API command registry
- support `maw arra commands --json` with the same registry payload shape as the plugin HTTP route
- normalize `--help` / `--version` for the modern maw InvokeContext CLI surface

## Validation
- `bunx tsc --noEmit`
- `bun test src/plugins/` (128 pass, 0 fail)
- `git diff --check origin/alpha...HEAD`
- changed files <= 250 lines
