### PR TITLE
feat: codify vector proxy protocol

### DIFF
--- a/sidecar/turbovec/README.md
+++ b/sidecar/turbovec/README.md
@@ -9,6 +9,9 @@ It exposes the standard HTTP contract used by `ProxyVectorAdapter`:
 - `DELETE /vectors/collection`
 - `GET /health`
 
+`GET /health` includes `protocol: "vector-proxy-v1"` so Arra can verify the
+service speaks the #1438 proxy contract.
+
 Run locally:
 
 ```bash

--- a/sidecar/turbovec/server.py
+++ b/sidecar/turbovec/server.py
@@ -24,6 +24,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 
 VERSION = "0.1.0"
+PROTOCOL = "vector-proxy-v1"
 DIMENSIONS = 64
 
 
@@ -112,7 +113,7 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_GET(self) -> None:
         if self.path == "/health":
-            return self.send_json({"status": "ok", "name": self.index.name, "version": VERSION})
+            return self.send_json({"status": "ok", "name": self.index.name, "version": VERSION, "protocol": PROTOCOL})
         if self.path == "/vectors/stats":
             return self.send_json({"count": len(self.index.docs), "name": self.index.name})
         self.send_json({"error": "not found"}, 404)

--- a/src/vector/adapters/proxy.ts
+++ b/src/vector/adapters/proxy.ts
@@ -14,42 +14,22 @@ import type {
   VectorQueryResult,
 } from '../types.ts';
 import { currentTenantId, TENANT_HEADER } from '../../middleware/tenant.ts';
-
-interface ProxyQueryRequest {
-  text: string;
-  limit?: number;
-  where?: Record<string, any>;
-}
-
-interface ProxyStatsResponse {
-  count: number;
-  name: string;
-}
-
-interface ProxyHealthResponse {
-  status: 'ok' | 'degraded' | 'down';
-  name: string;
-  version: string;
-}
-
-interface ProxyQueryResponse {
-  ids: string[];
-  documents: string[];
-  distances: number[];
-  metadatas: any[];
-}
+import {
+  VECTOR_PROXY_ROUTES,
+  buildVectorProxyUrl,
+  isHealthyVectorProxy,
+  type VectorProxyAddRequest,
+  type VectorProxyHealthResponse,
+  type VectorProxyQueryRequest,
+  type VectorProxyQueryResponse,
+  type VectorProxyStatsResponse,
+} from '../proxy-protocol.ts';
 
 function tenantHeaders(json = false): Record<string, string> {
   const headers: Record<string, string> = json ? { 'Content-Type': 'application/json' } : {};
   const tenantId = currentTenantId();
   if (tenantId) headers[TENANT_HEADER] = tenantId;
   return headers;
-}
-
-function toQueryUrl(base: string, path: string): string {
-  const safeBase = base.replace(/\/+$/, '');
-  if (!path.startsWith('/')) return `${safeBase}/${path}`;
-  return `${safeBase}${path}`;
 }
 
 export class ProxyVectorAdapter implements VectorStoreAdapter {
@@ -63,7 +43,7 @@ export class ProxyVectorAdapter implements VectorStoreAdapter {
 
   async connect(): Promise<void> {
     const health = await this.health();
-    if (!health || health.status !== 'ok') {
+    if (!isHealthyVectorProxy(health)) {
       throw new Error('Proxy vector service unavailable');
     }
   }
@@ -77,16 +57,17 @@ export class ProxyVectorAdapter implements VectorStoreAdapter {
   }
 
   async deleteCollection(): Promise<void> {
-    await this.del('/vectors/collection');
+    await this.del(VECTOR_PROXY_ROUTES.collection);
   }
 
   async addDocuments(docs: VectorDocument[]): Promise<void> {
-    await this.post('/vectors/add', { documents: docs });
+    const body: VectorProxyAddRequest = { documents: docs };
+    await this.post(VECTOR_PROXY_ROUTES.add, body);
   }
 
   async query(text: string, limit: number = 10, where?: Record<string, any>): Promise<VectorQueryResult> {
-    const body: ProxyQueryRequest = { text, limit, ...(where ? { where } : {}) };
-    return this.postJson<ProxyQueryResponse>('/vectors/query', body);
+    const body: VectorProxyQueryRequest = { text, limit, ...(where ? { where } : {}) };
+    return this.postJson<VectorProxyQueryResponse>(VECTOR_PROXY_ROUTES.query, body);
   }
 
   async queryById(id: string, nResults: number = 5): Promise<VectorQueryResult> {
@@ -119,13 +100,13 @@ export class ProxyVectorAdapter implements VectorStoreAdapter {
     };
   }
 
-  private async proxyStats(): Promise<ProxyStatsResponse> {
-    const stats = await this.fetchJson<ProxyStatsResponse>('/vectors/stats');
+  private async proxyStats(): Promise<VectorProxyStatsResponse> {
+    const stats = await this.fetchJson<VectorProxyStatsResponse>(VECTOR_PROXY_ROUTES.stats);
     return { count: stats?.count ?? 0, name: stats?.name || this.collectionName };
   }
 
-  private async health(): Promise<ProxyHealthResponse> {
-    const result = await this.fetchJson<ProxyHealthResponse>('/health', 5_000);
+  private async health(): Promise<VectorProxyHealthResponse> {
+    const result = await this.fetchJson<VectorProxyHealthResponse>(VECTOR_PROXY_ROUTES.health, 5_000);
     if (!result) {
       return { status: 'down', name: this.collectionName, version: 'unknown' };
     }
@@ -133,7 +114,7 @@ export class ProxyVectorAdapter implements VectorStoreAdapter {
   }
 
   private async post(path: string, body: Record<string, any>): Promise<void> {
-    const res = await fetch(toQueryUrl(this.endpoint, path), {
+    const res = await fetch(buildVectorProxyUrl(this.endpoint, path), {
       method: 'POST',
       headers: tenantHeaders(true),
       body: JSON.stringify(body),
@@ -143,7 +124,7 @@ export class ProxyVectorAdapter implements VectorStoreAdapter {
   }
 
   private async postJson<T>(path: string, body: Record<string, any>): Promise<T> {
-    const res = await fetch(toQueryUrl(this.endpoint, path), {
+    const res = await fetch(buildVectorProxyUrl(this.endpoint, path), {
       method: 'POST',
       headers: tenantHeaders(true),
       body: JSON.stringify(body),
@@ -154,7 +135,7 @@ export class ProxyVectorAdapter implements VectorStoreAdapter {
   }
 
   private async del(path: string): Promise<void> {
-    const res = await fetch(toQueryUrl(this.endpoint, path), {
+    const res = await fetch(buildVectorProxyUrl(this.endpoint, path), {
       method: 'DELETE',
       headers: tenantHeaders(),
       signal: AbortSignal.timeout(this.requestTimeoutMs),
@@ -163,7 +144,7 @@ export class ProxyVectorAdapter implements VectorStoreAdapter {
   }
 
   private async fetchJson<T>(path: string, timeoutMs = this.requestTimeoutMs): Promise<T> {
-    const res = await fetch(toQueryUrl(this.endpoint, path), {
+    const res = await fetch(buildVectorProxyUrl(this.endpoint, path), {
       method: 'GET',
       headers: tenantHeaders(),
       signal: AbortSignal.timeout(timeoutMs),

--- a/src/vector/proxy-protocol.ts
+++ b/src/vector/proxy-protocol.ts
@@ -1,0 +1,48 @@
+import type { VectorDocument, VectorQueryResult } from './types.ts';
+
+export const VECTOR_PROXY_PROTOCOL_VERSION = 'vector-proxy-v1';
+
+export const VECTOR_PROXY_ROUTES = {
+  add: '/vectors/add',
+  query: '/vectors/query',
+  stats: '/vectors/stats',
+  collection: '/vectors/collection',
+  health: '/health',
+} as const;
+
+export type VectorProxyRoute = typeof VECTOR_PROXY_ROUTES[keyof typeof VECTOR_PROXY_ROUTES];
+
+export interface VectorProxyAddRequest {
+  documents: VectorDocument[];
+}
+
+export interface VectorProxyQueryRequest {
+  text: string;
+  limit?: number;
+  where?: Record<string, unknown>;
+}
+
+export type VectorProxyQueryResponse = VectorQueryResult;
+
+export interface VectorProxyStatsResponse {
+  count: number;
+  name: string;
+}
+
+export type VectorProxyHealthStatus = 'ok' | 'degraded' | 'down';
+
+export interface VectorProxyHealthResponse {
+  status: VectorProxyHealthStatus;
+  name: string;
+  version: string;
+  protocol?: typeof VECTOR_PROXY_PROTOCOL_VERSION | string;
+}
+
+export function buildVectorProxyUrl(endpoint: string, route: VectorProxyRoute | string): string {
+  const safeBase = endpoint.replace(/\/+$/, '');
+  return `${safeBase}${route.startsWith('/') ? route : `/${route}`}`;
+}
+
+export function isHealthyVectorProxy(health: Pick<VectorProxyHealthResponse, 'status'> | undefined): boolean {
+  return health?.status === 'ok';
+}

--- a/src/vector/service-registry.ts
+++ b/src/vector/service-registry.ts
@@ -15,8 +15,10 @@ import {
   type VectorStorageConfig,
   type VectorStorageService,
 } from './config.ts';
+import { VECTOR_PROXY_ROUTES, buildVectorProxyUrl } from './proxy-protocol.ts';
 
 export type RegisteredServiceType = 'builtin' | 'proxy';
+export { buildVectorProxyUrl as vectorServiceUrl } from './proxy-protocol.ts';
 
 export interface RegisteredVectorService {
   name: string;
@@ -42,11 +44,6 @@ export interface VectorServiceRegistryClient {
 }
 
 const HEALTH_TIMEOUT_MS = 5_000;
-
-export function vectorServiceUrl(endpoint: string, suffix: string): string {
-  const safeBase = endpoint.replace(/\/+$/, '');
-  return `${safeBase}${suffix.startsWith('/') ? suffix : `/${suffix}`}`;
-}
 
 function record(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
@@ -198,7 +195,7 @@ export class VectorServiceRegistry implements VectorServiceRegistryClient {
         if (!endpoint) {
           throw new Error('missing endpoint');
         }
-        const healthUrl = vectorServiceUrl(endpoint, '/health');
+        const healthUrl = buildVectorProxyUrl(endpoint, VECTOR_PROXY_ROUTES.health);
         const response = await fetch(healthUrl, {
           method: 'GET',
           signal: AbortSignal.timeout(HEALTH_TIMEOUT_MS),

--- a/tests/http/vector/proxy-protocol.test.ts
+++ b/tests/http/vector/proxy-protocol.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'bun:test';
+import {
+  VECTOR_PROXY_PROTOCOL_VERSION,
+  VECTOR_PROXY_ROUTES,
+  buildVectorProxyUrl,
+  isHealthyVectorProxy,
+} from '../../../src/vector/proxy-protocol.ts';
+
+test('vector proxy protocol exports the #1438 HTTP contract', () => {
+  expect(VECTOR_PROXY_PROTOCOL_VERSION).toBe('vector-proxy-v1');
+  expect(VECTOR_PROXY_ROUTES).toEqual({
+    add: '/vectors/add',
+    query: '/vectors/query',
+    stats: '/vectors/stats',
+    collection: '/vectors/collection',
+    health: '/health',
+  });
+});
+
+test('vector proxy protocol helpers preserve endpoint path prefixes', () => {
+  expect(buildVectorProxyUrl('http://127.0.0.1:8082/base/', '/health')).toBe(
+    'http://127.0.0.1:8082/base/health',
+  );
+  expect(isHealthyVectorProxy({ status: 'ok' })).toBe(true);
+  expect(isHealthyVectorProxy({ status: 'degraded' })).toBe(false);
+});

--- a/tests/http/vector/section-v2-closeout.test.ts
+++ b/tests/http/vector/section-v2-closeout.test.ts
@@ -72,6 +72,7 @@ beforeAll(async () => {
   const vectorConfig = await import('../../../src/vector/config.ts');
   const config = vectorConfig.generateDefaultConfig();
   config.version = '2.0';
+  config.enabled = true;
   config.dataPath = join(root, 'lancedb');
   config.embedder = { default: 'ollama', fallback: 'gemini', model: 'bge-m3' };
   config.storage = {

--- a/tests/http/vector/turbovec-sidecar.test.ts
+++ b/tests/http/vector/turbovec-sidecar.test.ts
@@ -51,7 +51,11 @@ test('TurboVec sidecar reference speaks the vector proxy protocol', async () => 
   sidecar.on('error', (error) => { throw error; });
   await waitForHealth(base);
 
-  expect(await json(`${base}/health`)).toMatchObject({ status: 'ok', name: 'turbovec-test' });
+  expect(await json(`${base}/health`)).toMatchObject({
+    status: 'ok',
+    name: 'turbovec-test',
+    protocol: 'vector-proxy-v1',
+  });
   expect(await json(`${base}/vectors/stats`)).toMatchObject({ count: 0, name: 'turbovec-test' });
 
   const docs = [


### PR DESCRIPTION
Refs #1438.

## Summary
- adds a reusable `vector-proxy-v1` protocol contract with route constants, typed requests/responses, and URL/health helpers
- rewires `ProxyVectorAdapter` and the service registry to use the shared protocol contract
- advertises `protocol: vector-proxy-v1` from the TurboVec reference sidecar health endpoint
- fixes the Vector Section v2 closeout fixture to enable the section before expecting proxy collection health

## Validation
- `bunx tsc --noEmit`
- `bun test tests/http/vector/`
- `git diff --check`
- changed-file line counts all <=250 lines
