### PR TITLE
fix: watch project-first learn docs

### DIFF
--- a/src/indexer/__tests__/collectors.test.ts
+++ b/src/indexer/__tests__/collectors.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { getAllMarkdownFiles } from '../collectors.ts';
+import { collectPsiLearn, getAllMarkdownFiles } from '../collectors.ts';
 
 describe('getAllMarkdownFiles', () => {
   test('skips broken symlinks instead of crashing on ENOENT', () => {
@@ -14,6 +14,40 @@ describe('getAllMarkdownFiles', () => {
 
       expect(() => getAllMarkdownFiles(tmp)).not.toThrow();
       expect(getAllMarkdownFiles(tmp)).toEqual([keep]);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('collects project-first vault ψ/learn files and skips security corpus by default', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-psi-learn-project-'));
+    try {
+      const learnDir = path.join(tmp, 'github.com', 'Soul-Brews-Studio', 'demo', 'ψ', 'learn', 'codex');
+      const corpusDir = path.join(tmp, 'github.com', 'Soul-Brews-Studio', 'demo', 'ψ', 'learn', 'security-corpus');
+      fs.mkdirSync(learnDir, { recursive: true });
+      fs.mkdirSync(corpusDir, { recursive: true });
+      fs.writeFileSync(path.join(learnDir, 'finding.md'), '# Finding\n\n## Lesson\n\nProject-first learn scan works.');
+      fs.writeFileSync(path.join(corpusDir, 'skip.md'), '# Skip\n\n## Lesson\n\nSecurity corpus remains opt-in.');
+
+      const docs = collectPsiLearn({
+        config: {
+          repoRoot: tmp,
+          dbPath: ':memory:',
+          chromaPath: '',
+          sourcePaths: {
+            resonance: 'ψ/memory/resonance',
+            learnings: 'ψ/memory/learnings',
+            retrospectives: 'ψ/memory/retrospectives',
+            distillations: 'ψ/memory/distillations',
+            learn: 'ψ/learn',
+          },
+        },
+        seenContentHashes: new Set(),
+      });
+
+      expect(docs).toHaveLength(1);
+      expect(docs[0].source_file).toBe('github.com/Soul-Brews-Studio/demo/ψ/learn/codex/finding.md');
+      expect(docs[0].project).toBe('github.com/soul-brews-studio/demo');
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/src/indexer/__tests__/learn-watcher.test.ts
+++ b/src/indexer/__tests__/learn-watcher.test.ts
@@ -179,6 +179,26 @@ describe('startLearnWatcher', () => {
     stop();
   });
 
+  it('stores project-first vault ψ/learn files', async () => {
+    const filePath = path.join(repoRoot, 'github.com', 'Soul-Brews-Studio', 'demo', 'ψ', 'learn', 'codex', 'note.md');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, '# Project Learn\n\n## Finding\n\nProject-first vault learn docs auto-index.', 'utf8');
+
+    const stop = startLearnWatcher({ db, models: MODELS, repoRoot, debounceMs: 20 });
+    await waitFor(() => {
+      const row = db.query<{ count: number }, []>('SELECT COUNT(*) AS count FROM indexing_jobs').get();
+      return row?.count === Object.keys(MODELS).length;
+    });
+
+    const doc = db.query<{ source_file: string; project: string }, []>(
+      'SELECT source_file, project FROM oracle_documents',
+    ).get();
+    expect(doc?.source_file).toBe('github.com/Soul-Brews-Studio/demo/ψ/learn/codex/note.md');
+    expect(doc?.project).toBe('github.com/soul-brews-studio/demo');
+
+    stop();
+  });
+
   it('does nothing for non-markdown files', async () => {
     const learnDir = path.join(repoRoot, 'ψ', 'memory', 'learnings');
     const filePath = path.join(learnDir, 'note.txt');

--- a/src/indexer/collectors.ts
+++ b/src/indexer/collectors.ts
@@ -133,25 +133,30 @@ export function collectPsiLearn(opts: {
   const { config, seenContentHashes } = opts;
   const documents: OracleDocument[] = [];
   const subPath = config.sourcePaths.learn ?? 'ψ/learn';
+  const roots = [
+    path.join(config.repoRoot, subPath),
+    ...discoverProjectPsiDirs(config.repoRoot).map((psiDir) => path.join(psiDir, 'learn')),
+  ].filter((dir, index, all) => all.indexOf(dir) === index && fs.existsSync(dir));
 
-  const sourcePath = path.join(config.repoRoot, subPath);
-  if (!fs.existsSync(sourcePath)) return documents;
-
-  const files = getAllMarkdownFiles(sourcePath);
   let skippedDupes = 0;
-  for (const filePath of files) {
-    const relPath = path.relative(config.repoRoot, filePath).split(path.sep).join('/');
-    if (!isPsiLearnSource(relPath)) continue;
+  let totalFiles = 0;
+  for (const sourcePath of roots) {
+    const files = getAllMarkdownFiles(sourcePath);
+    totalFiles += files.length;
+    for (const filePath of files) {
+      const relPath = path.relative(config.repoRoot, filePath).split(path.sep).join('/');
+      if (!isPsiLearnSource(relPath)) continue;
 
-    const content = fs.readFileSync(filePath, 'utf-8');
-    if (!content.trim()) continue;
-    const contentHash = Bun.hash(content).toString(36);
-    if (seenContentHashes.has(contentHash)) { skippedDupes++; continue; }
-    seenContentHashes.add(contentHash);
-    documents.push(...parsePsiLearnFile(relPath, content));
+      const content = fs.readFileSync(filePath, 'utf-8');
+      if (!content.trim()) continue;
+      const contentHash = Bun.hash(content).toString(36);
+      if (seenContentHashes.has(contentHash)) { skippedDupes++; continue; }
+      seenContentHashes.add(contentHash);
+      documents.push(...parsePsiLearnFile(relPath, content));
+    }
   }
 
-  console.log(`Indexed ${documents.length} ψ/learn documents from ${files.length} files (skipped ${skippedDupes} duplicates)`);
+  console.log(`Indexed ${documents.length} ψ/learn documents from ${totalFiles} files (skipped ${skippedDupes} duplicates)`);
   return documents;
 }
 

--- a/src/indexer/learn-doc-source.ts
+++ b/src/indexer/learn-doc-source.ts
@@ -10,6 +10,7 @@ import { parseLearningFile } from './parser.ts';
 
 export const PSI_LEARN_REL = path.join('ψ', 'learn');
 export const MEMORY_LEARN_REL = path.join('ψ', 'memory', 'learnings');
+const PROJECT_PSI_RE = /^(?:github\.com|gitlab\.com|bitbucket\.org)\/[^/]+\/[^/]+\/(ψ\/.*)$/;
 
 export function normalizeSourceFile(repoRoot: string, filePath: string): string {
   return path.relative(repoRoot, filePath).split(path.sep).join('/');
@@ -20,13 +21,18 @@ export function isMarkdownFile(filePath: string): boolean {
   return lower.endsWith('.md') || lower.endsWith('.markdown');
 }
 
-export function isPsiLearnSource(sourceFile: string): boolean {
+function localPsiPath(sourceFile: string): string {
   const normalized = sourceFile.split(path.sep).join('/');
-  return normalized.startsWith('ψ/learn/') && !normalized.startsWith('ψ/learn/security-corpus/');
+  return normalized.match(PROJECT_PSI_RE)?.[1] ?? normalized;
+}
+
+export function isPsiLearnSource(sourceFile: string): boolean {
+  const local = localPsiPath(sourceFile);
+  return local.startsWith('ψ/learn/') && !local.startsWith('ψ/learn/security-corpus/');
 }
 
 export function isMemoryLearningSource(sourceFile: string): boolean {
-  return sourceFile.split(path.sep).join('/').startsWith('ψ/memory/learnings/');
+  return localPsiPath(sourceFile).startsWith('ψ/memory/learnings/');
 }
 
 export function parsePsiLearnFile(relativePath: string, content: string): OracleDocument[] {

--- a/src/indexer/learn-watcher.ts
+++ b/src/indexer/learn-watcher.ts
@@ -22,6 +22,7 @@ import {
   storeSqliteDocuments,
 } from './learn-doc-source.ts';
 import { isWithinRoot, listDirs, listFiles, safeClearTimeout, safeClose, watchDir } from './watch-utils.ts';
+import { discoverProjectPsiDirs } from './discovery.ts';
 
 export interface LearnWatcherOptions {
   /** sqlite database used by enqueueIndexJob(). */
@@ -66,6 +67,14 @@ function shouldAutoStore(sourceFile: string): boolean {
   return isPsiLearnSource(sourceFile) || isMemoryLearningSource(sourceFile);
 }
 
+function learnRoots(root: string): string[] {
+  const roots = [path.join(root, MEMORY_LEARN_REL), path.join(root, PSI_LEARN_REL)];
+  for (const psiDir of discoverProjectPsiDirs(root)) {
+    roots.push(path.join(psiDir, 'memory', 'learnings'), path.join(psiDir, 'learn'));
+  }
+  return roots.filter((dir, index, all) => all.indexOf(dir) === index);
+}
+
 /**
  * Start a file watcher for learn-source Markdown files.
  *
@@ -78,7 +87,7 @@ export function startLearnWatcher({
   debounceMs = DEFAULT_DEBOUNCE_MS,
 }: LearnWatcherOptions): StopWatch {
   const root = path.resolve(repoRoot);
-  const roots = [path.join(root, MEMORY_LEARN_REL), path.join(root, PSI_LEARN_REL)]
+  const roots = learnRoots(root)
     .filter((dir) => {
       try { fs.mkdirSync(dir, { recursive: true }); return true; }
       catch { return false; }

--- a/src/indexer/runner.ts
+++ b/src/indexer/runner.ts
@@ -50,6 +50,7 @@ export function createIndexerConfig(repoRoot: string): IndexerConfig {
       learnings: 'ψ/memory/learnings',
       retrospectives: 'ψ/memory/retrospectives',
       distillations: 'ψ/memory/distillations',
+      learn: 'ψ/learn',
       // Opt-in: set ORACLE_INDEX_SECURITY_CORPUS=1 to include ψ/learn/security-corpus/.
       // Default OFF because the corpus has ~36k files (one-time index ~10-30 min).
       security_corpus: process.env.ORACLE_INDEX_SECURITY_CORPUS === '1'


### PR DESCRIPTION
## Summary
- extend learn-source detection to project-first vault paths like `github.com/org/repo/ψ/learn/...`
- make the learn watcher cover project-first vault `ψ/learn` and `ψ/memory/learnings` roots
- include `ψ/learn` in the shared reindex runner config and keep security corpus opt-in

## Validation
- `bunx tsc --noEmit`
- `bun test src/indexer/__tests__/learn-watcher.test.ts src/indexer/__tests__/collectors.test.ts` (8 pass, 0 fail)
- `bun test tests/http/indexer/` (4 pass, 0 fail)
- `git diff --check`
- changed files <= 250 lines
