### PR TITLE
feat: add storage backend frontend surface

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -63,6 +63,7 @@ export function AppShell({
     { to: '/learn', label: 'Learn', description: 'Create and edit learnings' },
     { to: '/metrics', label: 'Metrics', description: 'Runtime counters from /api/v1/metrics' },
     { to: '/mcp', label: 'MCP', description: 'Tool schemas and groups' },
+    { to: '/storage', label: 'Storage', description: 'Backend config from /api/settings/system' },
     { to: '/settings', label: 'Settings', description: 'Storage, embedder, and DB status' },
   ];
   const requestValue = metricsLoading ? <Spinner label="Loading metrics" /> : metrics?.requestCount ?? '—';

--- a/frontend/src/components/VectorModelRecommendationCard.tsx
+++ b/frontend/src/components/VectorModelRecommendationCard.tsx
@@ -42,7 +42,11 @@ export function VectorModelRecommendationCard({ defaultProvider = 'openai', init
   const [estimate, setEstimate] = useState<CostEstimate | null>(initialEstimate ?? null);
   const [loading, setLoading] = useState(initialEstimate === undefined);
   const [error, setError] = useState('');
-  const estimates = useMemo(() => Object.entries(estimate?.providerEstimates ?? {}), [estimate]);
+  const estimates = useMemo<Array<[string, ProviderCost]>>(() => Object.entries(estimate?.providerEstimates ?? {}), [estimate]);
+  const comparisonRows = useMemo<Array<[string, ProviderCost]>>(() => {
+    if (estimates.length) return estimates;
+    return estimate ? [[estimate.provider, estimate]] : [];
+  }, [estimate, estimates]);
 
   useEffect(() => {
     if (initialEstimate !== undefined) return;
@@ -80,7 +84,7 @@ export function VectorModelRecommendationCard({ defaultProvider = 'openai', init
           <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
             <p className="text-sm font-semibold text-white">Cost comparison</p>
             <div className="mt-3 grid gap-2">
-              {(estimates.length ? estimates : [[estimate.provider, estimate]]).map(([provider, item]) => (
+              {comparisonRows.map(([provider, item]) => (
                 <p key={provider} className="rounded-xl border border-white/10 bg-slate-950/60 p-3 text-sm text-slate-300">
                   <span className="font-semibold text-teal-100">{provider}</span> · {item.model ?? 'default model'} · {formatUsd(item.estimatedUsd)}
                 </p>

--- a/frontend/src/pages/StoragePage.tsx
+++ b/frontend/src/pages/StoragePage.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useMemo, useState } from 'react';
+import { fetchSettingsSystem } from '../api';
+import { ErrorMessage, LoadingPanel, Spinner } from '../components/AsyncState';
+import type { SettingsSystemResponse } from '../types';
+
+type StoragePageProps = {
+  initialSettings?: SettingsSystemResponse;
+  fetcher?: () => Promise<SettingsSystemResponse>;
+};
+
+type DetailRow = {
+  label: string;
+  value: string | number;
+  detail: string;
+};
+
+function display(value: string | number | null | undefined): string | number {
+  return value === null || value === undefined || value === '' ? 'not configured' : value;
+}
+
+function migrationLabel(settings: SettingsSystemResponse): string {
+  if (!settings.migrations.tablePresent) return 'table missing';
+  return settings.migrations.status === 'current' ? 'current' : `${settings.migrations.pendingCount} pending`;
+}
+
+export function storageSummaryRows(settings: SettingsSystemResponse): DetailRow[] {
+  return [
+    {
+      label: 'Active backend',
+      value: display(settings.storage.activeBackend),
+      detail: `Configured ${display(settings.storage.configuredBackend)}; default ${display(settings.storage.defaultBackend)}.`,
+    },
+    {
+      label: 'Database path',
+      value: display(settings.storage.dbPath),
+      detail: 'SQLite or remote-backed database location reported by the runtime.',
+    },
+    {
+      label: 'Data directory',
+      value: display(settings.storage.dataDir),
+      detail: 'Directory used for local files, indexes, and runtime storage state.',
+    },
+    {
+      label: 'Repository root',
+      value: display(settings.storage.repoRoot),
+      detail: 'Resolved project root used when storage paths are relative.',
+    },
+    {
+      label: 'Migration state',
+      value: migrationLabel(settings),
+      detail: `${settings.migrations.appliedCount}/${settings.migrations.availableCount} migrations applied.`,
+    },
+    {
+      label: 'Latest known',
+      value: display(settings.migrations.latestKnown),
+      detail: `Latest applied at ${display(settings.migrations.latestAppliedAt)}.`,
+    },
+  ];
+}
+
+function DetailCard({ row }: { row: DetailRow }) {
+  return (
+    <article className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{row.label}</p>
+      <p className="mt-2 break-words font-mono text-sm text-teal-200">{row.value}</p>
+      <p className="mt-2 text-sm leading-6 text-slate-400">{row.detail}</p>
+    </article>
+  );
+}
+
+export function StoragePage({ initialSettings, fetcher = fetchSettingsSystem }: StoragePageProps) {
+  const [settings, setSettings] = useState<SettingsSystemResponse | null>(initialSettings ?? null);
+  const [loading, setLoading] = useState(!initialSettings);
+  const [error, setError] = useState('');
+
+  async function loadStorageConfig() {
+    setLoading(true);
+    setError('');
+    try {
+      setSettings(await fetcher());
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (!initialSettings) void loadStorageConfig();
+  }, []);
+
+  const rows = useMemo(() => (settings ? storageSummaryRows(settings) : []), [settings]);
+  const refresh = () => { void loadStorageConfig(); };
+
+  return (
+    <div className="grid gap-5">
+      <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="storage-page-title">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-300">Storage</p>
+            <h2 id="storage-page-title" className="mt-2 text-2xl font-semibold text-white">Storage backend</h2>
+            <p className="mt-2 text-sm text-slate-400">Backend config viewer for /api/settings/system.</p>
+            <p className="mt-2 text-sm text-slate-500">Review active backend, resolved paths, and migration readiness before enabling plugins.</p>
+          </div>
+          <button
+            aria-label="Refresh storage backend config"
+            className="focus-ring rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-teal-300/40"
+            type="button"
+            onClick={refresh}
+          >
+            {loading ? <Spinner label="Refreshing storage" /> : 'Refresh storage'}
+          </button>
+        </div>
+      </section>
+
+      {loading && !settings ? <LoadingPanel title="Loading storage backend…" detail="Fetching /api/settings/system." /> : null}
+      {error ? <ErrorMessage title="Could not load storage backend." message={error} /> : null}
+
+      {settings ? (
+        <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3" aria-label="Storage backend details">
+          {rows.map((row) => <DetailCard key={row.label} row={row} />)}
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/routeMeta.ts
+++ b/frontend/src/routeMeta.ts
@@ -77,6 +77,7 @@ export function routeMeta(pathname: string, search = ''): RouteMeta {
   if (pathname === '/learn') return base('Learn entries', 'Learn', 'Capture and edit Oracle learnings.', [{ label: 'Learn' }]);
   if (pathname === '/vector') return base('Vector dashboard', 'Vector', 'Collection health, search, and export status.', [{ label: 'Vector dashboard' }]);
   if (pathname === '/mcp') return base('MCP tools', 'MCP', 'Browse available MCP tool schemas and groups.', [{ label: 'MCP tools' }]);
+  if (pathname === '/storage') return base('Storage backend', 'Storage', 'Backend config viewer from /api/settings/system.', [{ label: 'Storage' }]);
   if (pathname === '/settings') return base('Runtime settings', 'Settings', 'Storage, embedder, and DB status.', [{ label: 'Settings' }]);
   return base('Menu viewer', 'Menu', 'Navigation rows from /api/menu.', [{ label: 'Menu' }]);
 }

--- a/frontend/src/routePaths.ts
+++ b/frontend/src/routePaths.ts
@@ -43,3 +43,7 @@ export function vectorSettingsPath(): string {
 export function canvasPluginsPath(): string {
   return '/canvas/plugins';
 }
+
+export function storagePath(): string {
+  return '/storage';
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -12,6 +12,7 @@ import { CanvasPluginsPage } from './pages/CanvasPluginsPage';
 import { SearchPage } from './pages/SearchPage';
 import { SettingsPage } from './pages/SettingsPage';
 import { StatusPage } from './pages/StatusPage';
+import { StoragePage } from './pages/StoragePage';
 import { VectorPage } from './pages/VectorPage';
 import { VectorSearchPage } from './pages/VectorSearchPage';
 import { VectorDocumentsPage } from './pages/VectorDocumentsPage';
@@ -38,6 +39,7 @@ export const frontendRoutes = [
   '/vector/export',
   '/vector/settings',
   '/mcp',
+  '/storage',
   '/settings',
 ] as const;
 export type FrontendRoute = typeof frontendRoutes[number];
@@ -95,6 +97,7 @@ export function DashboardRoutes({
       <Route path="/vector/export" element={<VectorExportPage />} />
       <Route path="/vector/settings" element={<VectorSettingsPage />} />
       <Route path="/mcp" element={<McpPage />} />
+      <Route path="/storage" element={<StoragePage />} />
       <Route path="/mcp/tools/:name" element={<McpToolDetailPage />} />
       <Route
         path="/settings"

--- a/tests/frontend/components/app-shell-storage-nav.test.tsx
+++ b/tests/frontend/components/app-shell-storage-nav.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+import { MemoryRouter } from 'react-router-dom';
+import { AppShell } from '../../../frontend/src/components/AppShell';
+import { htmlFor, installBrowserLocation } from '../_render';
+
+describe('AppShell storage navigation', () => {
+  test('links to the storage backend viewer from the sidebar', () => {
+    const restore = installBrowserLocation('/storage');
+    try {
+      const html = htmlFor(
+        <MemoryRouter initialEntries={['/storage']}>
+          <AppShell error="" loading={false} menuCount={0} pluginCount={0} surfaceCount={0} updatedAt="never" onRefresh={() => {}}>
+            <p>child</p>
+          </AppShell>
+        </MemoryRouter>,
+      );
+      expect(html).toContain('aria-label="Storage: Backend config from /api/settings/system"');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/tests/frontend/pages/storage-page.test.tsx
+++ b/tests/frontend/pages/storage-page.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test';
+import { StoragePage, storageSummaryRows } from '../../../frontend/src/pages/StoragePage';
+import type { SettingsSystemResponse } from '../../../frontend/src/types';
+import { htmlFor } from '../_render';
+
+const settings: SettingsSystemResponse = {
+  storage: {
+    activeBackend: 'sqlite',
+    configuredBackend: 'sqlite',
+    defaultBackend: 'sqlite',
+    dbPath: '/data/oracle.sqlite',
+    dataDir: '/data/oracle',
+    repoRoot: '/repo/arra-oracle-v3',
+  },
+  embedder: {
+    source: 'defaults',
+    backend: 'ollama',
+    model: 'bge-m3',
+    url: 'http://localhost:11434',
+    dimensions: 1024,
+    embeddingEndpoint: '/api/embeddings',
+    collections: [],
+  },
+  migrations: {
+    status: 'current',
+    tablePresent: true,
+    appliedCount: 12,
+    availableCount: 12,
+    pendingCount: 0,
+    latestKnown: '0012_storage.sql',
+    latestAppliedAt: '2026-06-16T00:00:00.000Z',
+  },
+};
+
+describe('StoragePage', () => {
+  test('renders the storage backend config from settings system data', () => {
+    const html = htmlFor(<StoragePage initialSettings={settings} />);
+    expect(html).toContain('Storage backend');
+    expect(html).toContain('/api/settings/system');
+    expect(html).toContain('/data/oracle.sqlite');
+    expect(html).toContain('current');
+    expect(html).toContain('12/12 migrations applied');
+  });
+
+  test('summarizes active backend and migrations for dashboard cards', () => {
+    const rows = storageSummaryRows(settings);
+    expect(rows.map((row) => row.label)).toContain('Active backend');
+    expect(rows.find((row) => row.label === 'Migration state')?.value).toBe('current');
+  });
+});

--- a/tests/frontend/router.test.ts
+++ b/tests/frontend/router.test.ts
@@ -48,6 +48,7 @@ describe('frontend router', () => {
       '/vector/export',
       '/vector/settings',
       '/mcp',
+      '/storage',
       '/settings',
     ]);
   });
@@ -70,6 +71,7 @@ describe('frontend router', () => {
     expect(htmlAt('/vector/export')).toContain('Vector export');
     expect(htmlAt('/vector/settings')).toContain('Configure adapters, embedding models');
     expect(htmlAt('/mcp')).toContain('Tool browser');
+    expect(htmlAt('/storage')).toContain('Storage backend');
     expect(htmlAt('/settings')).toContain('Runtime configuration');
   });
 

--- a/tests/frontend/routes/storage-route.test.ts
+++ b/tests/frontend/routes/storage-route.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test';
+import { routeMeta } from '../../../frontend/src/routeMeta';
+import { storagePath } from '../../../frontend/src/routePaths';
+
+describe('storage route helpers', () => {
+  test('points to the storage backend viewer route', () => {
+    expect(storagePath()).toBe('/storage');
+  });
+
+  test('describes storage backend page chrome', () => {
+    expect(routeMeta('/storage')).toMatchObject({
+      title: 'Storage backend',
+      eyebrow: 'Storage',
+      description: 'Backend config viewer from /api/settings/system.',
+    });
+  });
+});


### PR DESCRIPTION
Refs #1484.\n\n## Summary\n- adds a first-class /storage frontend route for the unified-plugin storage backend surface\n- links the storage backend viewer from sidebar nav, route metadata, and route helper APIs\n- covers storage rendering/navigation and fixes vector recommendation row typing so tsc remains green\n\n## Validation\n- bunx tsc --noEmit\n- cd frontend && bunx tsc --noEmit\n- bun test tests/frontend/components/vector-model-recommendation-card.test.tsx tests/frontend/pages/storage-page.test.tsx tests/frontend/routes/storage-route.test.ts tests/frontend/components/app-shell-storage-nav.test.tsx tests/frontend/router.test.ts\n- wc -l changed files <=250\n