### PR TITLE
feat: awaken Thor oracle workflow

### DIFF
--- a/docs/http-api-reference.md
+++ b/docs/http-api-reference.md
@@ -23,6 +23,9 @@ Protected routes may require API token/session auth; tenant-aware routes honor `
 | GET | `/api/health` | None. | Aggregate `{ status, uptime, version, db, vectorStatus, pluginStatus }` |
 | GET | `/api/stats` | Optional `X-Oracle-Tenant`. | Document, vector, vault, tenant-scoped counts. |
 | GET | `/api/oracles` | Optional tenant header. | Oracle identities/projects summary. |
+| GET | `/api/oracles/profiles` | None. | Code-backed Oracle profile registry. |
+| GET | `/api/oracles/profiles/:slug` | Profile slug/id. | Oracle profile detail or 404. |
+| GET | `/api/oracles/thor` | None. | Thor Oracle Stormforge profile alias. |
 | GET | `/api/metrics` | None. | Runtime metrics snapshot. |
 | GET | `/api/dashboard` | Query filters optional. | Dashboard summary cards. |
 | GET | `/api/dashboard/summary` | Query filters optional. | Same summary alias. |
@@ -156,7 +159,7 @@ Protected routes may require API token/session auth; tenant-aware routes honor `
 | GET | `/api/traces/:id/linked-chain` | `id` path. | Linked trace chain. |
 | POST | `/api/traces/:id/link` | Link body. | Link result. |
 | DELETE | `/api/traces/:id/link` | Link selector. | Unlink result. |
-| POST | `/api/traces/:id/distill` | Distill request body. | Distillation result. |
+| POST | `/api/traces/:id/distill` | Distill body; optional `finding`/`metadata`. | Distillation result. |
 | GET | `/api/schedule` | Date/query filters optional. | Schedule entries. |
 | POST | `/api/schedule` | Schedule item body. | Created event. |
 | PATCH | `/api/schedule/:id` | Partial event body. | Updated event. |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-arra-oracle-v3 exposes 24 MCP tools across 5 configurable groups + 4 standalone tools.
+arra-oracle-v3 exposes 27 MCP tools across configurable groups, Oracle profiles, and standalone tools.
 
 ## Tool Groups
 
@@ -27,13 +27,14 @@ Groups can be enabled/disabled via `arra.config.json` (repo-local) or `~/.arra-o
 | `oracle_list` | Browse all documents without searching. Supports type/date filters and pagination. |
 | `oracle_concepts` | List all concept tags with document counts. Discover topic coverage. |
 
-## Knowledge (3 tools)
+## Knowledge (4 tools)
 
 | Tool | Description |
 |------|-------------|
 | `oracle_learn` | Add a new pattern/learning. Creates markdown in `ψ/memory/learnings/` and indexes to SQLite + vectors. |
 | `oracle_stats` | Knowledge base statistics: doc counts by type, indexing status, vector DB health. |
 | `oracle_supersede` | Mark old doc as superseded by newer one. "Nothing is Deleted" — old preserved, just marked. |
+| `oracle_research_note` | Store a Thor Stormforge research/dev artifact as searchable learning memory. |
 
 ## Session (2 tools)
 
@@ -51,7 +52,13 @@ Groups can be enabled/disabled via `arra.config.json` (repo-local) or `~/.arra-o
 | `oracle_thread_read` | Read full message history from a thread. |
 | `oracle_thread_update` | Update thread status (close, reopen, mark answered). |
 
-## Trace (6 tools)
+## Oracle Profiles (1 tool)
+
+| Tool | Description |
+|------|-------------|
+| `oracle_profile` | List/read code-backed Oracle profiles such as Thor Oracle / Stormforge. |
+
+## Trace (7 tools)
 
 | Tool | Description |
 |------|-------------|
@@ -61,6 +68,7 @@ Groups can be enabled/disabled via `arra.config.json` (repo-local) or `~/.arra-o
 | `oracle_trace_link` | Link two traces as a chain (prev → next). Bidirectional. |
 | `oracle_trace_unlink` | Remove a link between traces in specified direction. |
 | `oracle_trace_chain` | Get full linked chain for a trace. |
+| `oracle_trace_distill` | Distill a trace into a Thor/Stormforge awakening and optionally promote it to learning memory. |
 
 ## Standalone (5 tools)
 
@@ -75,7 +83,7 @@ Groups can be enabled/disabled via `arra.config.json` (repo-local) or `~/.arra-o
 ## Read-Only Mode
 
 When `ORACLE_READ_ONLY=true` or `--read-only`, write tools are disabled:
-- `oracle_learn`, `oracle_thread`, `oracle_thread_update`, `oracle_trace`, `oracle_supersede`, `oracle_handoff`
+- `oracle_learn`, `oracle_research_note`, `oracle_thread`, `oracle_thread_update`, `oracle_trace`, `oracle_trace_distill`, `oracle_supersede`, `oracle_handoff`
 
 ## Installation
 

--- a/docs/oracles/thor-stormforge.md
+++ b/docs/oracles/thor-stormforge.md
@@ -1,0 +1,67 @@
+# Thor Oracle — Stormforge Workflow
+
+Thor Oracle is the Dev + Research Oracle for turning unclear context into
+implementation-grade understanding. Thor stores evidence and decisions, not
+hidden chain-of-thought.
+
+## Profile
+
+- API list: `GET /api/oracles/profiles`
+- API read: `GET /api/oracles/profiles/thor`
+- Compatibility alias: `GET /api/oracles/thor`
+- MCP read: `oracle_profile({ id: "thor" })`
+
+## Stormforge Artifact Template
+
+```md
+## Question
+
+## Evidence
+### Repo evidence
+- path: finding tied to code or docs
+
+### External sources
+- title/url: short source-backed finding
+
+## Interpretation
+- Fact:
+- Inference:
+- Risk:
+
+## Implementation plan
+1.
+2.
+3.
+
+## Verification plan
+- tests:
+- typecheck/build:
+- regression risks:
+
+## Distillable learning
+```
+
+## Distillation
+
+Use `POST /api/traces/:id/distill` or MCP `oracle_trace_distill` with a concise
+`awakening` plus optional `finding`. When `promoteToLearning` is true, the
+learning is tagged with `thor-oracle`, `stormforge`, `dev-research`, the trace
+id, and `issue-<number>` when provided.
+
+```json
+{
+  "awakening": "Thor links research hypotheses to implementation evidence.",
+  "promoteToLearning": true,
+  "finding": {
+    "issue": 1030,
+    "repo": "github.com/Soul-Brews-Studio/arra-oracle-v3",
+    "recommendation": "Promote Thor from profile alias to registry + MCP workflow."
+  }
+}
+```
+
+## Research notes
+
+Use MCP `oracle_research_note` for a standalone Stormforge note when no trace id
+exists yet. It writes a searchable learning with the same Thor concepts and a
+rendered evidence template.

--- a/src/mcp/http-proxy.ts
+++ b/src/mcp/http-proxy.ts
@@ -69,6 +69,10 @@ function proxyRequestForTool(toolName: string, args: Record<string, unknown>): P
     case 'oracle_list': return { method: 'GET', path: '/api/list', query: { ...queryFrom(args, { type: 'type', limit: 'limit', offset: 'offset' }), group: 'false' } };
     case 'oracle_concepts': return { method: 'GET', path: '/api/concepts', query: queryFrom(args, { type: 'type', limit: 'limit' }) };
     case 'oracle_supersede': return { method: 'POST', path: '/api/supersede/document', body: args };
+    case 'oracle_profile': {
+      const id = cleanQueryValue(args.id);
+      return { method: 'GET', path: id ? `/api/oracles/profiles/${encodeURIComponent(id)}` : '/api/oracles/profiles' };
+    }
     case 'oracle_inbox': return { method: 'GET', path: '/api/inbox', query: queryFrom(args, { limit: 'limit', offset: 'offset', type: 'type' }) };
     case 'oracle_handoff': return { method: 'POST', path: '/api/handoff', body: args };
     case 'oracle_thread': return { method: 'POST', path: '/api/thread', body: { message: args.message, thread_id: args.threadId, title: args.title, role: args.role ?? 'claude', model: args.model } };
@@ -82,6 +86,12 @@ function proxyRequestForTool(toolName: string, args: Record<string, unknown>): P
       return threadId ? { method: 'PATCH', path: `/api/thread/${encodeURIComponent(threadId)}/status`, body: { status: args.status } } : null;
     }
     case 'oracle_trace': return { method: 'POST', path: '/api/traces', body: args };
+    case 'oracle_trace_distill': {
+      const traceId = cleanQueryValue(args.traceId);
+      if (!traceId) return null;
+      const { traceId: _traceId, ...body } = args;
+      return { method: 'POST', path: `/api/traces/${encodeURIComponent(traceId)}/distill`, body };
+    }
     case 'oracle_trace_list': return { method: 'GET', path: '/api/traces', query: queryFrom(args, { query: 'query', status: 'status', project: 'project', limit: 'limit', offset: 'offset' }) };
     case 'oracle_trace_get': {
       const traceId = cleanQueryValue(args.traceId);

--- a/src/oracles/model.ts
+++ b/src/oracles/model.ts
@@ -1,0 +1,41 @@
+export interface OracleCapability {
+  id: string;
+  label: string;
+  description: string;
+}
+
+export interface OracleProfile {
+  id: string;
+  slug: string;
+  name: string;
+  role: string;
+  theme: string;
+  born: string;
+  human?: string;
+  motto: string;
+  principles: string[];
+  capabilities: OracleCapability[];
+  workflows: string[];
+  defaultConcepts: string[];
+}
+
+export interface StormforgeEvidence {
+  path?: string;
+  title?: string;
+  url?: string;
+  summary: string;
+}
+
+export interface StormforgeFinding {
+  issue?: number;
+  repo?: string;
+  title?: string;
+  question?: string;
+  repoEvidence?: StormforgeEvidence[];
+  externalSources?: StormforgeEvidence[];
+  hypotheses?: string[];
+  recommendation?: string;
+  implementationPlan?: string[];
+  verificationPlan?: string[];
+  openQuestions?: string[];
+}

--- a/src/oracles/registry.ts
+++ b/src/oracles/registry.ts
@@ -1,0 +1,22 @@
+import { thorOracleProfile } from './thor.ts';
+import type { OracleProfile } from './model.ts';
+
+const profiles = [thorOracleProfile] as const satisfies readonly OracleProfile[];
+
+function key(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export function listOracleProfiles(): OracleProfile[] {
+  return [...profiles];
+}
+
+export function getOracleProfile(slugOrId: string): OracleProfile | undefined {
+  const requested = key(slugOrId);
+  return profiles.find((profile) => [
+    profile.id,
+    profile.slug,
+    profile.name,
+    profile.name.replace(/\s+oracle$/i, ''),
+  ].map(key).includes(requested));
+}

--- a/src/oracles/thor.ts
+++ b/src/oracles/thor.ts
@@ -1,12 +1,18 @@
+import type { OracleProfile } from './model.ts';
+
 export const THOR_ORACLE_ID = 'thor-oracle';
 export const THOR_ORACLE_THEME = 'stormforge';
 
-export const thorOracleProfile = {
+export const THOR_ORACLE_SLUG = 'thor';
+
+export const thorOracleProfile: OracleProfile = {
   id: THOR_ORACLE_ID,
+  slug: THOR_ORACLE_SLUG,
   name: 'Thor Oracle',
   role: 'dev-research oracle',
   theme: THOR_ORACLE_THEME,
   born: '2026-04-27',
+  human: 'Alphab137',
   motto: 'ตีเหล็กจากพายุ แปลงความไม่ชัดเจนให้เป็นความเข้าใจที่ใช้งานได้',
   principles: [
     'Think like a researcher before cutting code.',
@@ -34,6 +40,11 @@ export const thorOracleProfile = {
     'trace awakening capture',
     'dev/research synthesis',
     'implementation evidence review',
+  ],
+  defaultConcepts: [
+    THOR_ORACLE_ID,
+    THOR_ORACLE_THEME,
+    'dev-research',
   ],
 };
 

--- a/src/routes/health/index.ts
+++ b/src/routes/health/index.ts
@@ -6,6 +6,7 @@ import { createHealthEndpoint, type HealthEndpointOptions } from './health.ts';
 import { createDeepHealthEndpoint } from './deep.ts';
 import { statsEndpoint } from './stats.ts';
 import { oraclesEndpoint } from './oracles.ts';
+import { oracleProfilesEndpoint } from './oracle-profiles.ts';
 import { thorOracleEndpoint } from './thor.ts';
 
 export function createHealthRoutes(options: HealthEndpointOptions = {}) {
@@ -14,6 +15,7 @@ export function createHealthRoutes(options: HealthEndpointOptions = {}) {
     .use(createDeepHealthEndpoint(options))
     .use(statsEndpoint)
     .use(oraclesEndpoint)
+    .use(oracleProfilesEndpoint)
     .use(thorOracleEndpoint);
 }
 

--- a/src/routes/health/oracle-profiles.ts
+++ b/src/routes/health/oracle-profiles.ts
@@ -1,0 +1,57 @@
+import { Elysia, t } from 'elysia';
+import { getOracleProfile, listOracleProfiles } from '../../oracles/registry.ts';
+
+export const OracleCapabilitySchema = t.Object({
+  id: t.String(),
+  label: t.String(),
+  description: t.String(),
+});
+
+export const OracleProfileSchema = t.Object({
+  id: t.String(),
+  slug: t.String(),
+  name: t.String(),
+  role: t.String(),
+  theme: t.String(),
+  born: t.String(),
+  human: t.Optional(t.String()),
+  motto: t.String(),
+  principles: t.Array(t.String()),
+  capabilities: t.Array(OracleCapabilitySchema),
+  workflows: t.Array(t.String()),
+  defaultConcepts: t.Array(t.String()),
+});
+
+const ProfilesResponseSchema = t.Object({
+  profiles: t.Array(OracleProfileSchema),
+  total: t.Number(),
+});
+
+export const oracleProfilesEndpoint = new Elysia()
+  .get('/oracles/profiles', () => {
+    const profiles = listOracleProfiles();
+    return { profiles, total: profiles.length };
+  }, {
+    response: ProfilesResponseSchema,
+    detail: {
+      tags: ['health'],
+      menu: { group: 'hidden' },
+      summary: 'List code-backed Oracle profiles',
+    },
+  })
+  .get('/oracles/profiles/:slug', ({ params, set }) => {
+    const profile = getOracleProfile(params.slug);
+    if (!profile) {
+      set.status = 404;
+      return { error: 'Oracle profile not found' };
+    }
+    return profile;
+  }, {
+    params: t.Object({ slug: t.String() }),
+    response: t.Union([OracleProfileSchema, t.Object({ error: t.String() })]),
+    detail: {
+      tags: ['health'],
+      menu: { group: 'hidden' },
+      summary: 'Read one code-backed Oracle profile',
+    },
+  });

--- a/src/routes/health/thor.ts
+++ b/src/routes/health/thor.ts
@@ -1,26 +1,9 @@
-import { Elysia, t } from 'elysia';
+import { Elysia } from 'elysia';
 import { thorOracleProfile } from '../../oracles/thor.ts';
-
-const ThorCapabilitySchema = t.Object({
-  id: t.String(),
-  label: t.String(),
-  description: t.String(),
-});
-
-const ThorProfileSchema = t.Object({
-  id: t.String(),
-  name: t.String(),
-  role: t.String(),
-  theme: t.String(),
-  born: t.String(),
-  motto: t.String(),
-  principles: t.Array(t.String()),
-  capabilities: t.Array(ThorCapabilitySchema),
-  workflows: t.Array(t.String()),
-});
+import { OracleProfileSchema } from './oracle-profiles.ts';
 
 export const thorOracleEndpoint = new Elysia().get('/oracles/thor', () => thorOracleProfile, {
-  response: ThorProfileSchema,
+  response: OracleProfileSchema,
   detail: {
     tags: ['health'],
     menu: { group: 'hidden' },

--- a/src/routes/traces/distill.ts
+++ b/src/routes/traces/distill.ts
@@ -3,6 +3,27 @@ import { distillTraceAwakening } from '../../trace/distill.ts';
 import { getTrace } from '../../trace/handler.ts';
 import { traceIdParam } from './model.ts';
 
+const evidenceBody = t.Object({
+  path: t.Optional(t.String()),
+  title: t.Optional(t.String()),
+  url: t.Optional(t.String()),
+  summary: t.String(),
+});
+
+const findingBody = t.Object({
+  issue: t.Optional(t.Number()),
+  repo: t.Optional(t.String()),
+  title: t.Optional(t.String()),
+  question: t.Optional(t.String()),
+  repoEvidence: t.Optional(t.Array(evidenceBody)),
+  externalSources: t.Optional(t.Array(evidenceBody)),
+  hypotheses: t.Optional(t.Array(t.String())),
+  recommendation: t.Optional(t.String()),
+  implementationPlan: t.Optional(t.Array(t.String())),
+  verificationPlan: t.Optional(t.Array(t.String())),
+  openQuestions: t.Optional(t.Array(t.String())),
+});
+
 const distillBody = t.Object({
   awakening: t.String({ minLength: 1 }),
   promoteToLearning: t.Optional(t.Boolean()),
@@ -10,6 +31,8 @@ const distillBody = t.Object({
   theme: t.Optional(t.String()),
   concepts: t.Optional(t.Array(t.String())),
   source: t.Optional(t.String()),
+  finding: t.Optional(findingBody),
+  metadata: t.Optional(t.Record(t.String(), t.Unknown())),
 });
 
 export const traceDistillRoute = new Elysia().post('/api/traces/:id/distill', ({ params, body, set }) => {
@@ -30,6 +53,8 @@ export const traceDistillRoute = new Elysia().post('/api/traces/:id/distill', ({
     theme: body.theme,
     concepts: body.concepts,
     source: body.source,
+    finding: body.finding,
+    metadata: body.metadata,
   });
 }, {
   params: traceIdParam,

--- a/src/tools/__tests__/mcp-manifest.test.ts
+++ b/src/tools/__tests__/mcp-manifest.test.ts
@@ -34,6 +34,13 @@ describe('runtime MCP manifest', () => {
     expect(order).toContain('oracle_mcp_call');
   });
 
+  it('exposes Thor oracle profile and distillation tools', () => {
+    expect(mcpToolByName.get('oracle_profile')?.readOnly).toBe(true);
+    expect(mcpToolByName.get('oracle_trace_distill')?.readOnly).toBe(false);
+    expect(mcpToolByName.get('oracle_research_note')?.readOnly).toBe(false);
+    expect(mcpToolByName.get('oracle_profile')?.group).toBe('oracle');
+  });
+
 
   it('does not re-enable configured-out static tools', () => {
     const order = defaultMcpToolOrder(['oracle_search']);

--- a/src/tools/__tests__/oracle-profile.test.ts
+++ b/src/tools/__tests__/oracle-profile.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'bun:test';
+import { handleOracleProfile } from '../oracle.ts';
+
+function payload(result: ReturnType<typeof handleOracleProfile>) {
+  return JSON.parse(result.content[0]!.text);
+}
+
+describe('oracle profile MCP handler', () => {
+  it('lists Thor Oracle through the registry', () => {
+    const body = payload(handleOracleProfile({}));
+    expect(body.total).toBeGreaterThanOrEqual(1);
+    expect(body.profiles.map((profile: { slug: string }) => profile.slug)).toContain('thor');
+  });
+
+  it('reads Thor by id', () => {
+    const body = payload(handleOracleProfile({ id: 'thor-oracle' }));
+    expect(body.id).toBe('thor-oracle');
+    expect(body.defaultConcepts).toContain('stormforge');
+  });
+});

--- a/src/tools/mcp-manifest.ts
+++ b/src/tools/mcp-manifest.ts
@@ -12,6 +12,14 @@ import { handoffToolDef, handleHandoff } from './handoff.ts';
 import { inboxToolDef, handleInbox } from './inbox.ts';
 import { forumToolDefs, handleThread, handleThreads, handleThreadRead, handleThreadUpdate } from './forum.ts';
 import { traceToolDefs, handleTrace, handleTraceList, handleTraceGet, handleTraceLink, handleTraceUnlink, handleTraceChain } from './trace.ts';
+import {
+  oracleProfileToolDef,
+  oracleTraceDistillToolDef,
+  oracleResearchNoteToolDef,
+  handleOracleProfile,
+  handleOracleTraceDistill,
+  handleOracleResearchNote,
+} from './oracle.ts';
 import { reflectToolDef, handleReflect } from './reflect.ts';
 import { verifyToolDef, handleVerify } from './verify.ts';
 import { mcpCallToolDef, mcpListToolsToolDef, handleMcpCall, handleMcpListTools } from './mcp-in.ts';
@@ -47,10 +55,13 @@ export const mcpTools: RuntimeMcpToolManifest[] = [
   ctxTool(statsToolDef, 'knowledge', true, 'handleStats', handleStats),
   ctxTool(conceptsToolDef, 'search', true, 'handleConcepts', handleConcepts),
   ctxTool(supersedeToolDef, 'knowledge', false, 'handleSupersede', handleSupersede),
+  ctxTool(oracleResearchNoteToolDef, 'knowledge', false, 'handleOracleResearchNote', handleOracleResearchNote),
   ctxTool(handoffToolDef, 'session', false, 'handleHandoff', handleHandoff),
   ctxTool(inboxToolDef, 'session', true, 'handleInbox', handleInbox),
   ...forumToolDefs.map((def, index) => noCtxTool(def, 'forum', index !== 0 && index !== 3, forumHandlers[index].name, forumHandlers[index])),
+  noCtxTool(oracleProfileToolDef, 'oracle', true, 'handleOracleProfile', handleOracleProfile),
   ...traceToolDefs.map((def, index) => noCtxTool(def, index === 0 ? 'trace' : 'dig', traceReadOnly[index], traceHandlers[index].name, traceHandlers[index])),
+  noCtxTool(oracleTraceDistillToolDef, 'trace', false, 'handleOracleTraceDistill', handleOracleTraceDistill),
   ctxTool(reflectToolDef, 'standalone', true, 'handleReflect', handleReflect),
   ctxTool(verifyToolDef, 'standalone', false, 'handleVerify', handleVerify),
   noCtxTool(mcpListToolsToolDef, 'mcp', true, 'handleMcpListTools', handleMcpListTools),

--- a/src/tools/oracle.ts
+++ b/src/tools/oracle.ts
@@ -1,0 +1,118 @@
+import { getOracleProfile, listOracleProfiles } from '../oracles/registry.ts';
+import { handleLearn } from './learn.ts';
+import type { StormforgeFinding } from '../oracles/model.ts';
+import type { DistillTraceInput } from '../trace/types.ts';
+import type { ToolContext, ToolResponse } from './types.ts';
+
+function text(payload: unknown, isError = false): ToolResponse {
+  return { content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }], ...(isError && { isError }) };
+}
+
+function stringList(value: unknown): string[] | undefined {
+  return Array.isArray(value) ? value.map(String).filter(Boolean) : undefined;
+}
+
+function asFinding(input: Record<string, unknown>): StormforgeFinding {
+  return {
+    issue: typeof input.issue === 'number' ? input.issue : undefined,
+    repo: typeof input.repo === 'string' ? input.repo : undefined,
+    title: typeof input.title === 'string' ? input.title : undefined,
+    question: typeof input.question === 'string' ? input.question : undefined,
+    repoEvidence: Array.isArray(input.repoEvidence) ? input.repoEvidence as StormforgeFinding['repoEvidence'] : undefined,
+    externalSources: Array.isArray(input.externalSources) ? input.externalSources as StormforgeFinding['externalSources'] : undefined,
+    hypotheses: stringList(input.hypotheses),
+    recommendation: typeof input.recommendation === 'string' ? input.recommendation : undefined,
+    implementationPlan: stringList(input.implementationPlan),
+    verificationPlan: stringList(input.verificationPlan),
+    openQuestions: stringList(input.openQuestions),
+  };
+}
+
+export const oracleProfileToolDef = {
+  name: 'oracle_profile',
+  description: 'List or read code-backed Oracle profiles such as Thor Oracle / Stormforge.',
+  inputSchema: {
+    type: 'object',
+    properties: { id: { type: 'string', description: 'Profile id, slug, or name. Omit to list profiles.' } },
+  },
+};
+
+export const oracleTraceDistillToolDef = {
+  name: 'oracle_trace_distill',
+  description: 'Distill a trace into a Thor/Stormforge awakening and optionally promote it to learning memory.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      traceId: { type: 'string' },
+      awakening: { type: 'string' },
+      promoteToLearning: { type: 'boolean' },
+      oracle: { type: 'string' },
+      theme: { type: 'string' },
+      concepts: { type: 'array', items: { type: 'string' } },
+      source: { type: 'string' },
+      finding: { type: 'object', description: 'Optional Stormforge finding artifact.' },
+      metadata: { type: 'object', description: 'Optional audit metadata.' },
+    },
+    required: ['traceId', 'awakening'],
+  },
+};
+
+export const oracleResearchNoteToolDef = {
+  name: 'oracle_research_note',
+  description: 'Store a Thor Stormforge research/dev artifact as searchable learning memory.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      title: { type: 'string' },
+      question: { type: 'string' },
+      recommendation: { type: 'string' },
+      repo: { type: 'string' },
+      issue: { type: 'number' },
+      repoEvidence: { type: 'array', items: { type: 'object' } },
+      externalSources: { type: 'array', items: { type: 'object' } },
+      hypotheses: { type: 'array', items: { type: 'string' } },
+      implementationPlan: { type: 'array', items: { type: 'string' } },
+      verificationPlan: { type: 'array', items: { type: 'string' } },
+      openQuestions: { type: 'array', items: { type: 'string' } },
+      concepts: { type: 'array', items: { type: 'string' } },
+      source: { type: 'string' },
+      project: { type: 'string' },
+    },
+    required: ['title'],
+  },
+};
+
+export function handleOracleProfile(input: { id?: string }): ToolResponse {
+  if (!input?.id) return text({ profiles: listOracleProfiles(), total: listOracleProfiles().length });
+  const profile = getOracleProfile(input.id);
+  return profile ? text(profile) : text({ success: false, error: `Oracle profile not found: ${input.id}` }, true);
+}
+
+export async function handleOracleTraceDistill(input: DistillTraceInput): Promise<ToolResponse> {
+  if (!input?.traceId || !input?.awakening?.trim()) {
+    return text({ success: false, error: 'oracle_trace_distill requires traceId and awakening' }, true);
+  }
+  const { distillTraceAwakening } = await import('../trace/distill.ts');
+  const result = distillTraceAwakening({ ...input, awakening: input.awakening.trim() });
+  return text(result, !result.success);
+}
+
+export async function handleOracleResearchNote(ctx: ToolContext, input: Record<string, unknown>): Promise<ToolResponse> {
+  if (!input || typeof input.title !== 'string' || !input.title.trim()) {
+    return text({ success: false, error: 'oracle_research_note requires title' }, true);
+  }
+  const finding = asFinding(input);
+  const { renderDistilledAwakening } = await import('../trace/distill.ts');
+  const pattern = renderDistilledAwakening({
+    traceId: 'research-note',
+    awakening: input.title.trim(),
+    finding,
+    metadata: { oracle: 'thor-oracle', theme: 'stormforge' },
+  });
+  return handleLearn(ctx, {
+    pattern,
+    source: typeof input.source === 'string' ? input.source : 'Thor Stormforge research note',
+    concepts: ['thor-oracle', 'stormforge', 'dev-research', ...(stringList(input.concepts) ?? [])],
+    project: typeof input.project === 'string' ? input.project : finding.repo,
+  });
+}

--- a/src/trace/distill.ts
+++ b/src/trace/distill.ts
@@ -1,9 +1,11 @@
 import { eq } from 'drizzle-orm';
 import { db, traceLog } from '../db/index.ts';
 import { handleLearn } from '../server/handlers.ts';
-import { getTrace } from './handler.ts';
+import { getOracleProfile } from '../oracles/registry.ts';
 import { THOR_ORACLE_ID, THOR_ORACLE_THEME } from '../oracles/thor.ts';
+import { getTrace } from './handler.ts';
 import type { DistillTraceInput } from './types.ts';
+import type { StormforgeEvidence, StormforgeFinding } from '../oracles/model.ts';
 
 const DEFAULT_ORACLE = THOR_ORACLE_ID;
 const DEFAULT_THEME = THOR_ORACLE_THEME;
@@ -18,12 +20,8 @@ export type DistillTraceResult = {
 };
 
 function conceptSlug(value: string): string {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '');
+  return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+/g, '-').replace(/^-|-$/g, '');
 }
 
 function uniqueConcepts(values: string[]): string[] {
@@ -31,18 +29,67 @@ function uniqueConcepts(values: string[]): string[] {
 }
 
 function oracleOrigin(input: DistillTraceInput): string {
-  return conceptSlug(input.oracle ?? DEFAULT_ORACLE) || DEFAULT_ORACLE;
+  const profile = getOracleProfile(input.oracle ?? DEFAULT_ORACLE);
+  const fallback = conceptSlug(input.oracle ?? DEFAULT_ORACLE);
+  return (profile?.id ?? fallback) || DEFAULT_ORACLE;
+}
+
+function defaultConcepts(input: DistillTraceInput): string[] {
+  const profile = getOracleProfile(input.oracle ?? DEFAULT_ORACLE) ?? getOracleProfile(oracleOrigin(input));
+  return profile?.defaultConcepts ?? [DEFAULT_ORACLE, DEFAULT_THEME, 'dev-research'];
 }
 
 function learningConcepts(input: DistillTraceInput): string[] {
+  const issueConcept = input.finding?.issue ? [`issue-${input.finding.issue}`] : [];
   return uniqueConcepts([
     'trace-awakening',
     oracleOrigin(input),
-    'dev-research',
     input.theme ?? DEFAULT_THEME,
     `trace-${input.traceId}`,
+    ...defaultConcepts(input),
+    ...issueConcept,
     ...(input.concepts ?? []),
   ]);
+}
+
+function evidenceLines(items: StormforgeEvidence[] | undefined, kind: 'repo' | 'external'): string[] {
+  return (items ?? []).map((item) => {
+    const label = kind === 'repo' ? item.path : item.title ?? item.url;
+    const suffix = item.url && kind === 'external' ? ` (${item.url})` : '';
+    return `- ${label ?? 'evidence'}${suffix}: ${item.summary}`;
+  });
+}
+
+function listSection(title: string, values: string[] | undefined): string[] {
+  return values?.length ? [`### ${title}`, '', ...values.map((value) => `- ${value}`), ''] : [];
+}
+
+function findingSections(finding: StormforgeFinding): string[] {
+  return [
+    '## Stormforge finding',
+    '',
+    ...(finding.title ? [`### Title`, '', finding.title, ''] : []),
+    ...(finding.question ? [`### Question`, '', finding.question, ''] : []),
+    ...(finding.issue ? [`- Issue: #${finding.issue}`] : []),
+    ...(finding.repo ? [`- Repo: ${finding.repo}`] : []),
+    ...(finding.issue || finding.repo ? [''] : []),
+    ...listSection('Repo evidence', evidenceLines(finding.repoEvidence, 'repo')),
+    ...listSection('External sources', evidenceLines(finding.externalSources, 'external')),
+    ...listSection('Hypotheses', finding.hypotheses),
+    ...(finding.recommendation ? ['### Recommendation', '', finding.recommendation, ''] : []),
+    ...listSection('Implementation plan', finding.implementationPlan),
+    ...listSection('Verification plan', finding.verificationPlan),
+    ...listSection('Open questions', finding.openQuestions),
+  ];
+}
+
+export function renderDistilledAwakening(input: DistillTraceInput): string {
+  const parts = [input.awakening.trim()];
+  if (input.finding) parts.push(findingSections(input.finding).join('\n').trim());
+  if (input.metadata && Object.keys(input.metadata).length) {
+    parts.push(['## Metadata', '', '```json', JSON.stringify(input.metadata, null, 2), '```'].join('\n'));
+  }
+  return parts.filter(Boolean).join('\n\n');
 }
 
 export function distillTraceAwakening(input: DistillTraceInput): DistillTraceResult {
@@ -51,28 +98,17 @@ export function distillTraceAwakening(input: DistillTraceInput): DistillTraceRes
 
   const origin = oracleOrigin(input);
   const concepts = learningConcepts(input);
+  const awakening = renderDistilledAwakening(input);
   const learning = input.promoteToLearning
-    ? handleLearn(
-      input.awakening,
-      input.source?.trim() || `Trace awakening ${input.traceId}`,
-      concepts,
-      origin,
-      trace.project ?? undefined,
-    )
+    ? handleLearn(awakening, input.source?.trim() || `Trace awakening ${input.traceId}`, concepts, origin, trace.project ?? undefined)
     : undefined;
   const now = Date.now();
   const update: Partial<typeof traceLog.$inferInsert> = {
-    status: 'distilled',
-    awakening: input.awakening,
-    distilledAt: now,
-    updatedAt: now,
+    status: 'distilled', awakening, distilledAt: now, updatedAt: now,
   };
   if (learning?.id) update.distilledToId = learning.id;
 
-  db.update(traceLog)
-    .set(update)
-    .where(eq(traceLog.traceId, input.traceId))
-    .run();
+  db.update(traceLog).set(update).where(eq(traceLog.traceId, input.traceId)).run();
 
   return {
     success: true,

--- a/src/trace/types.ts
+++ b/src/trace/types.ts
@@ -3,6 +3,8 @@
  * Issue #17: feat: Trace Log — Make discoveries traceable and diggable
  */
 
+import type { StormforgeFinding } from '../oracles/model.ts';
+
 // Dig Point Types
 export interface FoundFile {
   path: string;
@@ -68,6 +70,8 @@ export interface DistillTraceInput {
   theme?: string;
   concepts?: string[];
   source?: string;
+  finding?: StormforgeFinding;
+  metadata?: Record<string, unknown>;
 }
 
 // Output Types

--- a/tests/http/health/oracles.test.ts
+++ b/tests/http/health/oracles.test.ts
@@ -105,3 +105,29 @@ test('GET /api/oracles/thor exposes the dev-research Stormforge profile', async 
   expect(capabilities).toContain('stormforge-development');
   expect(capabilities).toContain('system-thinking');
 });
+
+
+test('GET /api/oracles/profiles lists Thor from the registry', async () => {
+  const app = createHealthRoutes({
+    vectorHealth: async () => ({ status: 'ok', engines: [], checked_at: '2026-06-16T00:00:00.000Z' }),
+  });
+  const res = await app.handle(new Request('http://local/api/oracles/profiles'));
+  const body = await res.json() as Record<string, any>;
+
+  expect(res.status).toBe(200);
+  expect(body.total).toBeGreaterThanOrEqual(1);
+  expect(body.profiles.map((profile: { slug: string }) => profile.slug)).toContain('thor');
+  expect(body.profiles[0].defaultConcepts).toContain('thor-oracle');
+});
+
+test('GET /api/oracles/profiles/:slug reads Thor by slug or id', async () => {
+  const app = createHealthRoutes({
+    vectorHealth: async () => ({ status: 'ok', engines: [], checked_at: '2026-06-16T00:00:00.000Z' }),
+  });
+  const res = await app.handle(new Request('http://local/api/oracles/profiles/thor-oracle'));
+  const body = await res.json() as Record<string, any>;
+
+  expect(res.status).toBe(200);
+  expect(body.slug).toBe('thor');
+  expect(body.defaultConcepts).toEqual(expect.arrayContaining(['stormforge', 'dev-research']));
+});

--- a/tests/http/traces/routes.test.ts
+++ b/tests/http/traces/routes.test.ts
@@ -158,12 +158,24 @@ describe("Trace routes", () => {
         oracle: "Thor Oracle",
         theme: "Stormforge",
         concepts: ["system thinking", "continuity"],
+        finding: {
+          issue: 1030,
+          repo: "github.com/Soul-Brews-Studio/arra-oracle-v3",
+          recommendation: "Store evidence-backed Stormforge findings as durable learning.",
+          repoEvidence: [{ path: "src/trace/distill.ts", summary: "Formats Thor findings before promotion." }],
+        },
       }),
     });
     expect(res.ok).toBe(true);
     const body = await res.json();
     expect(body.concepts).toContain("dev-research");
     expect(body.concepts).toContain("stormforge");
+    expect(body.concepts).toContain("issue-1030");
+
+    const traceRes = await fetch(`${BASE_URL}/api/traces/${traceC}`);
+    const trace = await traceRes.json();
+    expect(trace.awakening).toContain("## Stormforge finding");
+    expect(trace.awakening).toContain("src/trace/distill.ts");
 
     const learnRes = await fetch(`${BASE_URL}/api/learn/${body.learningId}`);
     expect(learnRes.ok).toBe(true);


### PR DESCRIPTION
## Summary
- add first-class Oracle profile model/registry and Thor profile endpoints
- extend trace distillation with structured Stormforge findings and issue concepts
- expose Thor profile/distill/research-note MCP tools and proxy mappings
- document the Thor Stormforge workflow

## Validation
- bunx tsc --noEmit
- bun test tests/http/health/oracles.test.ts tests/http/traces/routes.test.ts src/tools/__tests__/mcp-manifest.test.ts src/tools/__tests__/oracle-profile.test.ts

## Files
- changed files verified <=250 lines

Closes #1030