### PR TITLE
feat: add query-time memory confidence

### DIFF
--- a/src/routes/memory/confidence.ts
+++ b/src/routes/memory/confidence.ts
@@ -1,0 +1,76 @@
+import type { MemoryRecord } from './store.ts';
+
+export type MemoryConfidence = {
+  score: number;
+  label: 'high' | 'medium' | 'low';
+  ageDays: number;
+  freshness: number;
+  reasons: string[];
+};
+
+type ConfidenceMode = 'keyword' | 'semantic';
+
+type MemoryConfidenceOptions = {
+  mode?: ConfidenceMode;
+  now?: Date;
+  semanticScore?: number;
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const ANCHORED_HALF_LIFE_DAYS = 139;
+const UNVALIDATED_HALF_LIFE_DAYS = 30;
+
+export function memoryConfidence(
+  memory: MemoryRecord,
+  options: MemoryConfidenceOptions = {},
+): MemoryConfidence {
+  const now = options.now ?? new Date();
+  const ageDays = daysSince(memory.updatedAt || memory.createdAt, now);
+  const hasSource = Boolean(memory.source);
+  const hasTags = Boolean(memory.tags?.length);
+  const hasTitle = Boolean(memory.title);
+  const halfLife = hasSource || hasTags ? ANCHORED_HALF_LIFE_DAYS : UNVALIDATED_HALF_LIFE_DAYS;
+  const freshness = clamp(0.5 ** (ageDays / halfLife));
+  const match = clamp(options.semanticScore ?? (options.mode === 'semantic' ? 0.6 : 0.65));
+  const provenance = Math.min(1, (hasSource ? 0.45 : 0) + (hasTags ? 0.35 : 0) + (hasTitle ? 0.2 : 0));
+  const score = round(clamp((match * 0.5) + (freshness * 0.3) + (provenance * 0.2)));
+
+  return {
+    score,
+    label: score >= 0.75 ? 'high' : score >= 0.45 ? 'medium' : 'low',
+    ageDays: round(ageDays),
+    freshness: round(freshness),
+    reasons: reasons(options.mode ?? 'keyword', hasSource, hasTags, halfLife),
+  };
+}
+
+export const MEMORY_CONFIDENCE_STRATEGY = {
+  stored: false,
+  strategy: 'query-time-confidence',
+  signals: ['match_score', 'freshness_decay', 'source', 'tags', 'title'],
+};
+
+function daysSince(value: string, now: Date): number {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) return 0;
+  return Math.max(0, (now.getTime() - timestamp) / DAY_MS);
+}
+
+function reasons(mode: ConfidenceMode, hasSource: boolean, hasTags: boolean, halfLifeDays: number): string[] {
+  return [
+    'computed_at_query_time',
+    `${mode}_match`,
+    hasSource ? 'source_present' : 'source_missing',
+    hasTags ? 'tags_present' : 'tags_missing',
+    `freshness_half_life_${halfLifeDays}d`,
+  ];
+}
+
+function clamp(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
+function round(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}

--- a/src/routes/memory/index.ts
+++ b/src/routes/memory/index.ts
@@ -4,6 +4,7 @@ import { createMemoryFanoutEndpoint } from './fanout.ts';
 import { memoryStore, type MemoryInput, type MemoryRecord, type MemoryStore } from './store.ts';
 import { memoryVectorIndex, type MemoryVectorHit, type MemoryVectorIndex } from './vector.ts';
 import { buildMorningTape } from './morning-tape.ts';
+import { MEMORY_CONFIDENCE_STRATEGY, memoryConfidence } from './confidence.ts';
 
 export function createMemoryRoutes(
   store: MemoryStore = memoryStore,
@@ -38,7 +39,7 @@ export function createMemoryRoutes(
     .get('/memory/recall', ({ query }) => {
       const limit = Math.min(50, Math.max(1, parseInt(query.limit ?? '10')));
       const items = store.recall(query.q ?? '', limit);
-      return { query: query.q ?? '', total: items.length, items };
+      return { query: query.q ?? '', total: items.length, confidence: MEMORY_CONFIDENCE_STRATEGY, items: items.map(withKeywordConfidence) };
     }, {
       query: RecallMemoryQuery,
       detail: { tags: ['memory'], menu: { group: 'hidden' }, summary: 'Recall persisted memories by keyword' },
@@ -52,7 +53,7 @@ export function createMemoryRoutes(
       try {
         const hits = await vectorIndex.search(query.q, limit);
         const records = store.getByIds(hits.map((hit) => hit.memoryId));
-        return { success: true, query: query.q, total: hits.length, results: mergeHits(hits, records) };
+        return { success: true, query: query.q, total: hits.length, confidence: MEMORY_CONFIDENCE_STRATEGY, results: mergeHits(hits, records) };
       } catch (error) {
         set.status = 503;
         return { success: false, error: error instanceof Error ? error.message : 'memory vector search failed', results: [] };
@@ -65,12 +66,32 @@ export function createMemoryRoutes(
 
 function mergeHits(hits: MemoryVectorHit[], records: MemoryRecord[]) {
   const byId = new Map(records.map((record) => [record.id, record]));
-  return hits.map((hit) => ({
-    ...(byId.get(hit.memoryId) ?? { id: hit.memoryId, content: hit.document }),
-    score: hit.score,
-    distance: hit.distance,
-    vectorId: hit.vectorId,
-  }));
+  return hits.map((hit) => {
+    const memory = memoryForHit(hit, byId.get(hit.memoryId));
+    return {
+      ...memory,
+      score: hit.score,
+      distance: hit.distance,
+      vectorId: hit.vectorId,
+      confidence: memoryConfidence(memory, { mode: 'semantic', semanticScore: hit.score }),
+    };
+  });
+}
+
+function withKeywordConfidence(memory: MemoryRecord) {
+  return { ...memory, confidence: memoryConfidence(memory, { mode: 'keyword' }) };
+}
+
+function memoryForHit(hit: MemoryVectorHit, record?: MemoryRecord): MemoryRecord {
+  if (record) return record;
+  const createdAt = typeof hit.metadata.createdAt === 'string' ? hit.metadata.createdAt : new Date().toISOString();
+  return {
+    id: hit.memoryId,
+    content: hit.document,
+    tags: [],
+    createdAt,
+    updatedAt: createdAt,
+  };
 }
 
 export const memoryRoutes = createMemoryRoutes();

--- a/tests/http/memory/confidence.test.ts
+++ b/tests/http/memory/confidence.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from 'bun:test';
+import { memoryConfidence } from '../../../src/routes/memory/confidence.ts';
+import type { MemoryRecord } from '../../../src/routes/memory/store.ts';
+
+const now = new Date('2026-06-16T00:00:00.000Z');
+
+function memory(overrides: Partial<MemoryRecord>): MemoryRecord {
+  return {
+    id: 'mem_confidence',
+    content: 'Recover context before coding.',
+    createdAt: now.toISOString(),
+    updatedAt: now.toISOString(),
+    ...overrides,
+  };
+}
+
+test('memoryConfidence is computed at query time from match, freshness, and provenance', () => {
+  const confidence = memoryConfidence(memory({
+    title: 'Boot context',
+    tags: ['challenge-2'],
+    source: 'morning-tape',
+  }), { now, mode: 'semantic', semanticScore: 0.92 });
+
+  expect(confidence).toMatchObject({
+    label: 'high',
+    score: 0.96,
+    ageDays: 0,
+    freshness: 1,
+  });
+  expect(confidence.reasons).toContain('computed_at_query_time');
+  expect(confidence.reasons).toContain('freshness_half_life_139d');
+});
+
+test('unanchored old memory decays without storing a confidence column', () => {
+  const stale = memoryConfidence(memory({
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  }), { now, mode: 'keyword' });
+
+  expect(stale.label).toBe('low');
+  expect(stale.freshness).toBeLessThan(0.05);
+  expect(stale.reasons).toContain('source_missing');
+  expect(stale.reasons).toContain('freshness_half_life_30d');
+});

--- a/tests/http/memory/save-recall.test.ts
+++ b/tests/http/memory/save-recall.test.ts
@@ -74,6 +74,8 @@ test('POST /api/v1/memory/save persists a memory, indexes it, and recall finds i
   expect(recall.status).toBe(200);
   expect(body).toMatchObject({ query: unique, total: 1 });
   expect(body.items[0]).toMatchObject({ id: saved.memory.id, content: `Read the ${unique} context before coding.` });
+  expect(body.confidence).toMatchObject({ stored: false, strategy: 'query-time-confidence' });
+  expect(body.items[0].confidence).toMatchObject({ label: 'high' });
 });
 
 test('GET /api/v1/memory/search returns vector similarity hits enriched from SQLite', async () => {
@@ -93,6 +95,8 @@ test('GET /api/v1/memory/search returns vector similarity hits enriched from SQL
   expect(search.status).toBe(200);
   expect(body).toMatchObject({ success: true, query: phrase, total: 1 });
   expect(body.results[0]).toMatchObject({ id: saved.memory.id, score: 1, vectorId: `memory:${saved.memory.id}` });
+  expect(body.confidence).toMatchObject({ stored: false, strategy: 'query-time-confidence' });
+  expect(body.results[0].confidence.reasons).toContain('semantic_match');
 });
 
 test('memory save rejects blank content', async () => {


### PR DESCRIPTION
Refs #1648

## Summary
- add query-time confidence scoring for lightweight memory recall/search without a schema change
- expose confidence strategy metadata plus per-memory confidence labels/reasons
- cover fresh anchored memories and stale unanchored decay in scoped memory tests

## Validation
- bunx tsc --noEmit
- bun test tests/http/memory/save-recall.test.ts tests/http/memory/confidence.test.ts tests/http/memory/morning-tape.test.ts tests/http/memory/fanout.test.ts tests/http/memory/integration-closeout.test.ts
- git diff --check
- wc -l src/routes/memory/confidence.ts src/routes/memory/index.ts tests/http/memory/confidence.test.ts tests/http/memory/save-recall.test.ts