### PR TITLE
feat: link canvas registry to standalone host

### DIFF
--- a/frontend/src/api/canvas-plugins.ts
+++ b/frontend/src/api/canvas-plugins.ts
@@ -9,6 +9,7 @@ interface BaseCanvasPluginEntry {
   kind: CanvasPluginKind;
   path: string;
   query: { plugin: string };
+  standalonePath?: string;
 }
 
 export interface ThreeCanvasPluginEntry extends BaseCanvasPluginEntry {
@@ -28,6 +29,11 @@ export interface CanvasPluginsResponse {
   plugins: CanvasPluginEntry[];
   count: number;
   kind: CanvasPluginKind | 'all';
+  standalone?: {
+    host: string;
+    defaultPlugin: string;
+    serveCommand?: string;
+  };
 }
 
 function urlFor(path: string): string {

--- a/frontend/src/pages/CanvasPluginsPage.tsx
+++ b/frontend/src/pages/CanvasPluginsPage.tsx
@@ -10,11 +10,19 @@ export interface CanvasPluginsPageProps {
   plugins?: CanvasPluginEntry[];
   loading?: boolean;
   client?: CanvasClient;
+  standaloneHost?: string;
 }
 
-function pluginHref(plugin: CanvasPluginEntry): string {
+function withCanvasHost(path: string, host?: string): string {
+  if (!host) return path;
+  const origin = host.startsWith('http') ? host : `https://${host}`;
+  return new URL(path.startsWith('/') ? path : `/${path}`, origin).toString();
+}
+
+function pluginHref(plugin: CanvasPluginEntry, host?: string): string {
+  if (plugin.standalonePath) return withCanvasHost(plugin.standalonePath, host);
   const qs = new URLSearchParams(plugin.query ?? { plugin: plugin.id });
-  return `${plugin.path || '/canvas'}?${qs.toString()}`;
+  return withCanvasHost(`${plugin.path || '/canvas'}?${qs.toString()}`, host);
 }
 
 function statusClass(plugin: CanvasPluginEntry): string {
@@ -22,8 +30,8 @@ function statusClass(plugin: CanvasPluginEntry): string {
   return 'border-teal-300/30 bg-teal-300/10 text-teal-100';
 }
 
-function PluginCard({ plugin }: { plugin: CanvasPluginEntry }) {
-  const target = pluginHref(plugin);
+function PluginCard({ plugin, host }: { plugin: CanvasPluginEntry; host?: string }) {
+  const target = pluginHref(plugin, host);
   return (
     <article className="rounded-3xl border border-white/10 bg-slate-950/70 p-5" aria-label={`${plugin.label} canvas plugin`}>
       <div className="mb-4 flex items-start justify-between gap-3">
@@ -45,8 +53,9 @@ function PluginCard({ plugin }: { plugin: CanvasPluginEntry }) {
   );
 }
 
-export function CanvasPluginsPage({ plugins: initialPlugins = [], loading = true, client = defaultClient }: CanvasPluginsPageProps) {
+export function CanvasPluginsPage({ plugins: initialPlugins = [], loading = true, client = defaultClient, standaloneHost = '' }: CanvasPluginsPageProps) {
   const [plugins, setPlugins] = useState(initialPlugins);
+  const [host, setHost] = useState(standaloneHost);
   const [state, setState] = useState<PageState>(loading ? 'loading' : 'ready');
   const [error, setError] = useState('');
 
@@ -58,6 +67,7 @@ export function CanvasPluginsPage({ plugins: initialPlugins = [], loading = true
       .then((response) => {
         if (cancelled) return;
         setPlugins(response.plugins);
+        setHost(response.standalone?.host ?? standaloneHost);
         setState('ready');
       })
       .catch((cause) => {
@@ -66,7 +76,7 @@ export function CanvasPluginsPage({ plugins: initialPlugins = [], loading = true
         setState(initialPlugins.length ? 'ready' : 'error');
       });
     return () => { cancelled = true; };
-  }, [client, initialPlugins.length]);
+  }, [client, initialPlugins.length, standaloneHost]);
 
   const summary = useMemo(() => {
     const react = plugins.filter((plugin) => plugin.kind === 'react').length;
@@ -86,7 +96,7 @@ export function CanvasPluginsPage({ plugins: initialPlugins = [], loading = true
       {state === 'loading' ? <LoadingPanel title="Loading canvas plugins" detail="Reading /api/canvas/plugins." /> : null}
       {state === 'error' ? <ErrorMessage title="Could not load canvas plugins." message={error} /> : null}
       {state !== 'error' && error ? <ErrorMessage title="Canvas plugin warning" message={error} /> : null}
-      {state !== 'error' ? <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">{plugins.map((plugin) => <PluginCard key={plugin.id} plugin={plugin} />)}</div> : null}
+      {state !== 'error' ? <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">{plugins.map((plugin) => <PluginCard key={plugin.id} plugin={plugin} host={host} />)}</div> : null}
     </section>
   );
 }

--- a/tests/frontend/api/canvas-plugins-standalone.test.ts
+++ b/tests/frontend/api/canvas-plugins-standalone.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+import { fetchCanvasPlugins } from '../../../frontend/src/api/canvas-plugins';
+import { installFetch, jsonResponse } from './_fetch';
+
+describe('fetchCanvasPlugins standalone metadata', () => {
+  test('preserves canvas host and standalone plugin paths', async () => {
+    const fetchMock = installFetch(() => jsonResponse({
+      plugins: [{
+        id: 'map',
+        label: 'Knowledge Map',
+        description: 'React map.',
+        kind: 'react',
+        renderer: 'KnowledgeMapCanvas',
+        path: '/map',
+        query: { plugin: 'map' },
+        standalonePath: '/map',
+      }],
+      count: 1,
+      kind: 'all',
+      standalone: { host: 'canvas.buildwithoracle.com', defaultPlugin: 'wave' },
+    }));
+    try {
+      await expect(fetchCanvasPlugins()).resolves.toMatchObject({
+        plugins: [{ id: 'map', standalonePath: '/map' }],
+        standalone: { host: 'canvas.buildwithoracle.com' },
+      });
+      expect(fetchMock.calls[0]?.input).toBe('/api/canvas/plugins');
+    } finally {
+      fetchMock.restore();
+    }
+  });
+});

--- a/tests/frontend/pages/canvas-plugins-page.test.tsx
+++ b/tests/frontend/pages/canvas-plugins-page.test.tsx
@@ -3,13 +3,13 @@ import { CanvasPluginsPage } from '../../../frontend/src/pages/CanvasPluginsPage
 import { htmlFor } from '../_render';
 
 const plugins = [
-  { id: 'wave', label: 'Wave', description: 'Wave field scene.', kind: 'three' as const, mount: 'waveScene', path: '/canvas', query: { plugin: 'wave' } },
-  { id: 'map', label: 'Knowledge Map', description: 'React map.', kind: 'react' as const, renderer: 'KnowledgeMapCanvas', path: '/map', query: { plugin: 'map' }, apiPath: '/api/map3d' },
+  { id: 'wave', label: 'Wave', description: 'Wave field scene.', kind: 'three' as const, mount: 'waveScene', path: '/canvas', query: { plugin: 'wave' }, standalonePath: '/?plugin=wave' },
+  { id: 'map', label: 'Knowledge Map', description: 'React map.', kind: 'react' as const, renderer: 'KnowledgeMapCanvas', path: '/map', query: { plugin: 'map' }, standalonePath: '/map', apiPath: '/api/map3d' },
 ];
 
 describe('CanvasPluginsPage', () => {
   test('renders canvas plugin list and status from initial data', () => {
-    const html = htmlFor(<CanvasPluginsPage plugins={plugins} loading={false} />);
+    const html = htmlFor(<CanvasPluginsPage plugins={plugins} loading={false} standaloneHost="canvas.buildwithoracle.com" />);
 
     expect(html).toContain('Canvas plugin registry');
     expect(html).toContain('2 registered · 1 three · 1 react');
@@ -17,5 +17,7 @@ describe('CanvasPluginsPage', () => {
     expect(html).toContain('Knowledge Map');
     expect(html).toContain('registered');
     expect(html).toContain('/api/map3d');
+    expect(html).toContain('https://canvas.buildwithoracle.com/?plugin=wave');
+    expect(html).toContain('https://canvas.buildwithoracle.com/map');
   });
 });


### PR DESCRIPTION
Refs #950.

## Summary
- teaches the frontend Canvas plugin API type about standalone host/path metadata
- makes CanvasPluginsPage open plugins on canvas.buildwithoracle.com using registry-provided standalone paths
- adds coverage for preserving standalone metadata and rendering clean canvas links

## Validation
- `bunx tsc --noEmit`
- `bun test tests/frontend/`
- `bun test tests/http/canvas-worker.test.ts tests/http/canvas/ tests/workers/canvas-worker.test.ts tests/canvas/`
- `git diff --check`
- changed-file line counts all <=250