### PR TITLE
docs(memory): add Challenge 2 morning tape template

### DIFF
--- a/MORNING-TAPE.md
+++ b/MORNING-TAPE.md
@@ -30,7 +30,7 @@ Boot self-check:
 
 Check these before claiming certainty:
 
-- Branch/worktree: `agents/1-codex-11`; leave `.maw-engine` untouched if dirty.
+- Branch/worktree: use only your assigned `agents/1-codex-N` worktree; do not switch to another coder branch.
 - Working trunk: `alpha`; `main` is release-only.
 - Framework: Elysia route clusters under `src/routes/`.
 - Runtime: Bun commands, not Node-only scripts.
@@ -38,7 +38,7 @@ Check these before claiming certainty:
 
 ## 3. Memory system map
 
-- Human-readable durable memory: repo docs, `MORNING-TAPE.md`, and `ψ/memory/` when present.
+- Human-readable durable memory: repo docs, `MORNING-TAPE.md`, `docs/MORNING-TAPE-TEMPLATE.md`, and `ψ/memory/` when present.
 - DB memory: `oracle_memories` through `/api/memory/save`, `/api/memory/recall`, and `/api/memory/search`.
 - Morning recovery API: `/api/memory/morning-tape` renders recent persisted memories into a two-minute briefing.
 - Vector search helps recall but is not authority; verify against files before claiming done.

--- a/docs/MORNING-TAPE-TEMPLATE.md
+++ b/docs/MORNING-TAPE-TEMPLATE.md
@@ -1,0 +1,71 @@
+# MORNING-TAPE Template
+
+Use this Challenge 2 template to create a role-specific boot tape that gets future-you functional in under two minutes. Keep the filled file short, operational, and verified by a cold-read drill.
+
+## Boot self-check
+
+- [ ] Target read time is two minutes or less.
+- [ ] Wake protocol names the first safe commands.
+- [ ] Identity and repo boundaries are explicit.
+- [ ] Memory map distinguishes durable facts from hints.
+- [ ] Done and blocked reporting formats are copyable.
+- [ ] Reflection explains why this tape will still help after context death.
+
+## 0. Wake protocol
+
+1. Read the current user task and latest lead message.
+2. Run `git status --short --branch` before editing.
+3. Send the required `starting #ISSUE` ACK if a task was assigned.
+4. Preserve your assigned worktree and branch boundaries.
+5. Verify against code and tests before claiming certainty.
+
+## 1. Operating identity
+
+- Role: `<agent role and project responsibility>`.
+- Project: `<repo name and one-sentence purpose>`.
+- Runtime: `<language, framework, database, package manager>`.
+- Build gate: `<typecheck command>` plus `<scoped test command>`.
+- File discipline: `<line limit, layout, naming rule>`.
+
+## 2. Safety rails
+
+- Working trunk: `<target branch>`.
+- Forbidden branch: `<release branch or protected branch>`.
+- External actions: `<push/PR/deploy rule>`.
+- Destructive actions: `<force/clean/delete rule>`.
+- Source of truth: code, tests, and current issue over stale docs.
+
+## 3. Memory map
+
+- Human memory: `<docs, MORNING-TAPE, wiki, handoff files>`.
+- Database memory: `<tables or APIs that persist facts>`.
+- Search memory: `<vector/FTS/indexes and when to verify them>`.
+- Gaps: `<known missing context or risky assumptions>`.
+
+## 4. Two-minute recovery drill
+
+1. Read this file once without opening chat history.
+2. Inspect git state and dirty files.
+3. Locate the active issue or lead instruction.
+4. Find the relevant source and test surface.
+5. State the next safe action, execute, and verify.
+
+## 5. Default task loop
+
+1. Read the issue and current implementation.
+2. Make the smallest precise change.
+3. Run scoped tests.
+4. Run typecheck.
+5. Rebase/merge current trunk if required by the workflow.
+6. Push a branch and open a PR to the target trunk.
+7. Report `done #ISSUE — commit <sha>, build pass, PR <url>`.
+
+## 6. Blocked format
+
+```text
+blocked: <exact blocker>; tried <alternative>
+```
+
+## 7. Reflection
+
+Write two or three sentences explaining what this tape preserves, what it intentionally omits, and how you proved it can restore you within two minutes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Use this page as the one-hop map for the 2026-06-06/07 alpha docs wave.
 | [FEDERATION.md](./FEDERATION.md) | Pair and secure Arra peers | `/info`, `/api/identity`, `/api/peer/feed`, `/api/peer/search`, TOFU pins |
 | [HUGINN-MUNINN.md](./HUGINN-MUNINN.md) | Understand the capture/recall naming split | Muninn recall, Huginn capture, no `huginn_*` aliases |
 | [issues/memory-systems-ai-agents-1648.md](./issues/memory-systems-ai-agents-1648.md) | Apply the #1648 memory-systems research | provenance-first hybrid memory, confidence, validation, review-gated capture |
+| [MORNING-TAPE-TEMPLATE.md](./MORNING-TAPE-TEMPLATE.md) | Complete Challenge 2 memory bootstrapping | two-minute recovery tape, safety rails, blocked/done reporting |
 | [CONTRIBUTING.md](../CONTRIBUTING.md) | Pick the correct repo/branch for PRs | two-repo rule, source PRs to `arra-oracle-v3:alpha` |
 | [CHANGELOG.md](../CHANGELOG.md) | Review what changed in the alpha wave | release notes, tracker issues, source PRs |
 | [TONIGHT-SHIPPED.md](./TONIGHT-SHIPPED.md) | Find feature knobs and first commands | MCP modes, plugins, CLI targets, vectors, Docker, federation |

--- a/tests/docs/morning-tape-contract.test.ts
+++ b/tests/docs/morning-tape-contract.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const morningTape = readFileSync('MORNING-TAPE.md', 'utf8');
+const template = readFileSync('docs/MORNING-TAPE-TEMPLATE.md', 'utf8');
+
+function words(markdown: string): number {
+  return markdown.trim().split(/\s+/).filter(Boolean).length;
+}
+
+describe('Challenge 2 morning tape contract', () => {
+  test('repo morning tape stays operational and portable', () => {
+    for (const heading of [
+      '## 0. Wake protocol',
+      '## 1. Current operating identity',
+      '## 2. Oracle heartbeat',
+      '## 3. Memory system map',
+      '## 4. Two-minute recovery drill',
+      '## 5. Default task loop',
+      '## 6. When blocked',
+      '## 7. Reflection from Challenge 2',
+    ]) expect(morningTape).toContain(heading);
+
+    expect(words(morningTape)).toBeLessThanOrEqual(650);
+    expect(morningTape).not.toMatch(/agents\/1-codex-\d+`/);
+    expect(morningTape).toContain('docs/MORNING-TAPE-TEMPLATE.md');
+  });
+
+  test('template captures the reusable Challenge 2 structure', () => {
+    for (const phrase of [
+      'Boot self-check',
+      'Wake protocol',
+      'Operating identity',
+      'Safety rails',
+      'Memory map',
+      'Two-minute recovery drill',
+      'Default task loop',
+      'Blocked format',
+      'Reflection',
+    ]) expect(template).toContain(phrase);
+
+    expect(words(template)).toBeLessThanOrEqual(750);
+    expect(template).toContain('blocked: <exact blocker>; tried <alternative>');
+  });
+});


### PR DESCRIPTION
Refs #1457.\n\n## Summary\n- adds a reusable Challenge 2 MORNING-TAPE template under docs\n- links the template from the root morning tape and docs index\n- removes the stale hard-coded coder worktree from the shared MORNING-TAPE and locks required sections with a docs contract test\n\n## Validation\n- bun test tests/docs/morning-tape-contract.test.ts\n- bun test tests/http/memory/\n- bunx tsc --noEmit\n- wc -l changed files <=250\n