### PR TITLE
feat: expose vector index manager in studio

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -57,6 +57,7 @@ export function AppShell({
     { to: '/export', label: 'Export App', description: 'Legacy v2 JSON/Markdown backups' },
     { to: '/vector', label: 'Vector Dashboard', description: 'Collection health and indexing', end: true },
     { to: '/vector/documents', label: 'Document Browser', description: 'Browse indexed vector documents' },
+    { to: '/vector/index', label: 'Index Manager', description: 'Backfill vectors and watch jobs' },
     { to: '/vector/search', label: 'Vector Search', description: 'Semantic preview by collection' },
     { to: '/vector/settings', label: 'Vector settings', description: 'Collection config and index controls' },
     { to: '/vector/export', label: 'Export', description: 'Download vector collections' },

--- a/frontend/src/pages/VectorSettingsPage.tsx
+++ b/frontend/src/pages/VectorSettingsPage.tsx
@@ -1,8 +1,25 @@
+import { Link } from 'react-router-dom';
 import { VectorConfigPanel } from '../components/VectorConfigPanel';
 import { VectorIndexPanel } from '../components/VectorIndexPanel';
 import { VectorModelRecommendationCard } from '../components/VectorModelRecommendationCard';
 import { VectorProviderServicePanel } from '../components/VectorProviderServicePanel';
 import { VectorSearchToggle } from '../components/VectorSearchToggle';
+import { vectorIndexPath } from '../routePaths';
+
+function FirstRunWizardCard() {
+  return (
+    <section className="rounded-3xl border border-purple-300/20 bg-purple-300/10 p-5 sm:p-6" aria-labelledby="vector-first-run-title">
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-200">First-run wizard</p>
+      <h2 id="vector-first-run-title" className="mt-2 text-2xl font-semibold text-white">Provider → vault → first index</h2>
+      <p className="mt-2 text-sm text-purple-100/80">
+        The setup wizard appears automatically when FTS docs are empty and vector search is disabled. Use the Index Manager to watch first-run backfill progress.
+      </p>
+      <Link className="focus-ring mt-4 inline-flex rounded-xl border border-purple-200/40 px-4 py-2 text-sm font-semibold text-purple-100 hover:bg-purple-200/10" to={vectorIndexPath()}>
+        Open Index Manager
+      </Link>
+    </section>
+  );
+}
 
 export function VectorSettingsPage() {
   return (
@@ -16,6 +33,7 @@ export function VectorSettingsPage() {
       </header>
 
       <VectorSearchToggle />
+      <FirstRunWizardCard />
       <VectorProviderServicePanel />
       <VectorModelRecommendationCard />
       <VectorConfigPanel />

--- a/frontend/src/routeMeta.ts
+++ b/frontend/src/routeMeta.ts
@@ -46,6 +46,13 @@ export function routeMeta(pathname: string, search = ''): RouteMeta {
     ]);
   }
 
+  if (pathname === '/vector/index') {
+    return base('Index Manager', 'Vector', 'Track vector backfill jobs and reindex collections.', [
+      { label: 'Vector dashboard', to: '/vector' },
+      { label: 'Index Manager' },
+    ]);
+  }
+
   if (pathname === '/vector/results') {
     const query = new URLSearchParams(search).get('q')?.trim();
     return base('Vector search results', 'Vector', query ? `Semantic matches for “${query}”.` : 'Full-page vector search results.', [

--- a/frontend/src/routePaths.ts
+++ b/frontend/src/routePaths.ts
@@ -32,6 +32,10 @@ export function vectorDocumentsPath(): string {
   return '/vector/documents';
 }
 
+export function vectorIndexPath(): string {
+  return '/vector/index';
+}
+
 export function vectorExportPagePath(): string {
   return '/vector/export';
 }

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -19,6 +19,7 @@ import { VectorDocumentsPage } from './pages/VectorDocumentsPage';
 import { VectorSearchResultsPage } from './pages/VectorSearchResultsPage';
 import { VectorExportPage } from './pages/VectorExportPage';
 import { VectorSettingsPage } from './pages/VectorSettingsPage';
+import { IndexManagerPanel } from './pages/IndexManagerPanel';
 import type { LoadState, MenuItem, PluginEntry } from './types';
 import type { MetricsSnapshot } from '../../src/server/types';
 
@@ -35,6 +36,7 @@ export const frontendRoutes = [
   '/vector',
   '/vector/search',
   '/vector/documents',
+  '/vector/index',
   '/vector/results',
   '/vector/export',
   '/vector/settings',
@@ -93,6 +95,7 @@ export function DashboardRoutes({
       <Route path="/vector" element={<VectorPage />} />
       <Route path="/vector/search" element={<VectorSearchPage />} />
       <Route path="/vector/documents" element={<VectorDocumentsPage />} />
+      <Route path="/vector/index" element={<IndexManagerPanel />} />
       <Route path="/vector/results" element={<VectorSearchResultsPage />} />
       <Route path="/vector/export" element={<VectorExportPage />} />
       <Route path="/vector/settings" element={<VectorSettingsPage />} />

--- a/tests/frontend/components/app-shell-vector-nav.test.tsx
+++ b/tests/frontend/components/app-shell-vector-nav.test.tsx
@@ -16,6 +16,7 @@ describe('AppShell Vector navigation', () => {
       );
       expect(html).toContain('aria-label="Vector Dashboard: Collection health and indexing"');
       expect(html).toContain('aria-label="Document Browser: Browse indexed vector documents"');
+      expect(html).toContain('aria-label="Index Manager: Backfill vectors and watch jobs"');
       expect(html).toContain('aria-label="Vector Search: Semantic preview by collection"');
       expect(html).toContain('aria-label="Export App: Legacy v2 JSON/Markdown backups"');
       expect(html).toContain('aria-label="Export: Download vector collections"');

--- a/tests/frontend/pages/vector-settings-page.test.tsx
+++ b/tests/frontend/pages/vector-settings-page.test.tsx
@@ -1,13 +1,17 @@
 import { describe, expect, test } from 'bun:test';
+import { MemoryRouter } from 'react-router-dom';
 import { VectorSettingsPage } from '../../../frontend/src/pages/VectorSettingsPage';
 import { htmlFor } from '../_render';
 
 describe('VectorSettingsPage', () => {
   test('composes vector search, provider, storage, adapter, model guidance, and index panels', () => {
-    const html = htmlFor(<VectorSettingsPage />);
+    const html = htmlFor(<MemoryRouter><VectorSettingsPage /></MemoryRouter>);
     expect(html).toContain('Vector settings');
     expect(html).toContain('Enable vector search');
     expect(html).toContain('PATCH /api/v1/vector/config');
+    expect(html).toContain('First-run wizard');
+    expect(html).toContain('Provider → vault → first index');
+    expect(html).toContain('Open Index Manager');
     expect(html).toContain('Embedding providers and storage services');
     expect(html).toContain('Model recommendation');
     expect(html).toContain('Active vector adapters');

--- a/tests/frontend/router.test.ts
+++ b/tests/frontend/router.test.ts
@@ -44,6 +44,7 @@ describe('frontend router', () => {
       '/vector',
       '/vector/search',
       '/vector/documents',
+      '/vector/index',
       '/vector/results',
       '/vector/export',
       '/vector/settings',
@@ -67,6 +68,7 @@ describe('frontend router', () => {
     expect(htmlAt('/vector')).toContain('Vector dashboard');
     expect(htmlAt('/vector/search')).toContain('Vector search preview');
     expect(htmlAt('/vector/documents')).toContain('Vector documents');
+    expect(htmlAt('/vector/index')).toContain('Index Manager');
     expect(htmlAt('/vector/results')).toContain('Vector search results');
     expect(htmlAt('/vector/export')).toContain('Vector export');
     expect(htmlAt('/vector/settings')).toContain('Configure adapters, embedding models');

--- a/tests/frontend/routes/vector-meta.test.ts
+++ b/tests/frontend/routes/vector-meta.test.ts
@@ -8,5 +8,9 @@ describe('vector route metadata', () => {
       title: 'Vector export',
       description: 'Download vector collections in available formats.',
     });
+    expect(routeMeta('/vector/index')).toMatchObject({
+      title: 'Index Manager',
+      description: 'Track vector backfill jobs and reindex collections.',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add a dedicated Studio route for the vector Index Manager at /vector/index
- add the Index Manager sidebar item, route metadata, and path helper
- add a Vector Settings first-run wizard card that points operators to backfill progress

## Validation
- bunx tsc --noEmit
- bunx bun@1.3.14 test --isolate tests/frontend/router.test.ts tests/frontend/routes/vector-meta.test.ts tests/frontend/components/app-shell-vector-nav.test.tsx tests/frontend/pages/vector-settings-page.test.tsx tests/frontend/components/vector-index-panel-render.test.tsx tests/frontend/components/setup-wizard-first-run.test.tsx tests/frontend/components/vector-provider-service-panel.test.tsx
- git diff --check origin/alpha..HEAD
- changed file line-count gate: all changed files <=250 lines

Closes #1439