### PR TITLE
fix: harden plugin entry containment

### DIFF
--- a/cli/src/plugin/loader.ts
+++ b/cli/src/plugin/loader.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from "path";
+import { join } from "path";
 import { homedir } from "os";
 import { existsSync, readdirSync } from "fs";
 import { parseManifest, validateManifest } from "./manifest.ts";
@@ -7,6 +7,7 @@ import {
   discoverUnifiedPluginManifests,
   type LoadedUnifiedPlugin,
 } from "../../../src/plugins/unified-loader.ts";
+import { resolveContainedPluginEntry } from "../../../src/plugins/path-containment.ts";
 
 const USER_PLUGIN_DIR = join(homedir(), ".arra", "plugins");
 const BUNDLED_PLUGIN_DIR = join(import.meta.dir, "..", "plugins");
@@ -30,7 +31,7 @@ async function loadPluginDir(dir: string): Promise<LoadedPlugin | null> {
     const raw = await Bun.file(manifestPath).json();
     const manifest = parseManifest(raw);
     validateManifest(manifest);
-    const entryPath = resolve(dir, manifest.entry);
+    const entryPath = resolveContainedPluginEntry(dir, manifest.entry);
     return { manifest, dir, entryPath };
   } catch {
     return null;

--- a/src/server/__tests__/server-plugin-loader.test.ts
+++ b/src/server/__tests__/server-plugin-loader.test.ts
@@ -11,6 +11,7 @@ import {
   loadServerPlugins,
   serverPluginRoutes,
 } from '../plugin/loader.ts';
+import { discoverUnifiedManifestPlugins } from '../plugin/unified.ts';
 import type { ServerPlugin } from '../plugin/types.ts';
 
 const tmp = mkdtempSync(join(tmpdir(), 'arra-server-plugin-loader-'));
@@ -124,5 +125,31 @@ describe('server plugin loader', () => {
       plugin: 'plugin-api-example',
       mountedBy: 'server-plugin-api-manifest',
     });
+  });
+
+  test('skips unified manifest entries that escape plugin directory', async () => {
+    const userDir = join(tmp, 'unified-server-escape');
+    const pluginDir = join(userDir, 'bad-entry');
+    mkdirSync(pluginDir, { recursive: true });
+    writeFileSync(join(userDir, 'outside.ts'), 'export default () => ({ ok: true });\n');
+    writeFileSync(join(pluginDir, 'plugin.json'), JSON.stringify({
+      name: 'bad-entry',
+      version: '1.0.0',
+      entry: '../outside.ts',
+      sdk: '^0.0.1',
+      api: { path: '/api/bad-entry', methods: ['GET'] },
+    }));
+
+    const warn = console.warn;
+    console.warn = () => {};
+    try {
+      const plugins = await discoverUnifiedManifestPlugins({
+        userDir,
+        bundledDir: join(tmp, 'missing-bundled-server'),
+      });
+      expect(plugins).toEqual([]);
+    } finally {
+      console.warn = warn;
+    }
   });
 });

--- a/src/server/plugin/unified.ts
+++ b/src/server/plugin/unified.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import { Elysia } from 'elysia';
@@ -15,6 +15,7 @@ import {
   type UnifiedInvokeResult,
   type UnifiedManifestPluginOptions,
 } from './unified-types.ts';
+import { resolveContainedPluginEntry } from '../../plugins/path-containment.ts';
 import type {
   ElysiaApp,
   ServerPlugin,
@@ -27,7 +28,7 @@ async function loadPluginDir(dir: string): Promise<LoadedUnifiedManifestPlugin |
     const manifest = parseManifest(await Bun.file(manifestPath).json());
     validateUnifiedManifest(manifest);
     if (!manifest.api && !manifest.lifecycle) return null;
-    return { manifest, dir, entryPath: resolve(dir, manifest.entry) };
+    return { manifest, dir, entryPath: resolveContainedPluginEntry(dir, manifest.entry) };
   } catch (error) {
     console.warn(`[server-plugin] skipped unified manifest plugin at ${dir}: ${error instanceof Error ? error.message : String(error)}`);
     return null;

--- a/tests/cli/plugin/loader-skips-invalid-plugin.test.ts
+++ b/tests/cli/plugin/loader-skips-invalid-plugin.test.ts
@@ -15,4 +15,24 @@ describe("discoverPlugins", () => {
     const result = await discoverPlugins({ unifiedPlugins: [], userPluginDir: join(tmp, "user"), bundledPluginDir: join(tmp, "missing") });
     expect(result.plugins).toEqual([]);
   });
+
+  test("skips plugin entries that escape plugin directory", async () => {
+    const userDir = join(tmp, "escape-user");
+    const dir = join(userDir, "bad-entry");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(userDir, "outside.ts"), "export default () => ({ ok: true });\n");
+    writeFileSync(join(dir, "plugin.json"), JSON.stringify({
+      name: "bad-entry",
+      version: "1.0.0",
+      entry: "../outside.ts",
+      sdk: "^0.0.1",
+    }));
+
+    const result = await discoverPlugins({
+      unifiedPlugins: [],
+      userPluginDir: userDir,
+      bundledPluginDir: join(tmp, "missing-escape"),
+    });
+    expect(result.plugins).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary
- apply shared plugin entry path containment to legacy server unified manifest loading
- apply the same containment check to CLI plugin discovery
- add regressions for manifest entries that escape plugin directories

## Validation
- `bunx tsc --noEmit`
- `bun test src/server/__tests__/server-plugin-loader.test.ts tests/cli/plugin/loader-skips-invalid-plugin.test.ts tests/plugins/path-containment.test.ts tests/http/health/ tests/http/logging/ tests/http/logger/ tests/plugins/sandbox.test.ts` (39 pass)
- changed files <=250 lines

Closes #1597
