### PR TITLE
feat: add export bundle README

### DIFF
--- a/tests/tools/export-app/export-app.test.ts
+++ b/tests/tools/export-app/export-app.test.ts
@@ -103,6 +103,9 @@ describe('standalone export app', () => {
       expect(exportedFile.bytes).toBeGreaterThan(0);
       expect(exportedFile.sha256).toMatch(/^[a-f0-9]{64}$/);
       expect(manifest.files.map((entry: { path: string }) => entry.path)).toContain('all-collections.json');
+      expect(manifest.files.map((entry: { path: string }) => entry.path)).toContain('README.md');
+      const bundleReadme = readFileSync(join(outputDir, 'README.md'), 'utf8');
+      expect(bundleReadme).toContain('Documents: 2');
 
       const relationships = JSON.parse(readFileSync(join(outputDir, 'relationships.json'), 'utf8'));
       expect(relationships.rows).toEqual(expect.arrayContaining([

--- a/tools/export-app/README.md
+++ b/tools/export-app/README.md
@@ -87,11 +87,14 @@ The batch output includes:
 - `all-collections.json`
 - `manifest.json`
 - `manifest.schema.json`
+- `README.md`
 
 `manifest.json` includes a `files` inventory with each artifact path, byte
 count, and SHA-256 checksum so operators can verify the bundle before migration.
 It also includes `collections.<table>.rowCount` so restore/preflight tooling can
 compare source and destination collection sizes without loading every artifact.
+The generated bundle `README.md` summarizes counts and verification steps for
+offline review before migration.
 Progress writes to stderr by default as collection counts, percentages, and row
 counts. Use `--progress json` or `--progress-json` for machine-readable events,
 `--progress silent` or `--quiet` when another wrapper owns progress display.

--- a/tools/export-app/bundle-readme.ts
+++ b/tools/export-app/bundle-readme.ts
@@ -1,0 +1,43 @@
+export interface ExportBundleReadmeInput {
+  exportedAt: string;
+  dbPath: string;
+  formats: readonly string[];
+  collectionCount: number;
+  rowCount: number;
+  relationshipCount: number;
+  documentCount: number;
+}
+
+export function exportBundleReadme(input: ExportBundleReadmeInput): string {
+  return [
+    '# Arra Oracle Export Bundle',
+    '',
+    `Generated: ${input.exportedAt}`,
+    `Source database: ${input.dbPath}`,
+    '',
+    '## Snapshot Summary',
+    '',
+    `- Collections: ${input.collectionCount}`,
+    `- Collection rows: ${input.rowCount}`,
+    `- Documents: ${input.documentCount}`,
+    `- Graph relationships: ${input.relationshipCount}`,
+    `- Formats: ${input.formats.join(', ')}`,
+    '',
+    '## Bundle Contents',
+    '',
+    '- `documents/` contains Markdown, JSON, CSV, and index artifacts.',
+    '- `collections/` contains every Drizzle collection in each export format.',
+    '- `relationships.*` contains graph edges for preview and migration checks.',
+    '- `all-collections.json` contains the full normalized collection snapshot.',
+    '- `manifest.json` contains counts plus the SHA-256 file inventory.',
+    '- `manifest.schema.json` describes the manifest contract.',
+    '',
+    '## Verification Checklist',
+    '',
+    '1. Validate `manifest.json` against `manifest.schema.json`.',
+    '2. Compare `collections.<table>.rowCount` with the source database.',
+    '3. Recompute SHA-256 for files listed in `manifest.json.files`.',
+    '4. Inspect Markdown documents before migration or restore work.',
+    '',
+  ].join('\n');
+}

--- a/tools/export-app/exporter.ts
+++ b/tools/export-app/exporter.ts
@@ -18,6 +18,7 @@ import { graphRelationships } from './graph.ts';
 import { exportOracleV2Documents } from './documents.ts';
 import { EXPORT_MANIFEST_SCHEMA } from './schema.ts';
 import { exportFileInventory } from './inventory.ts';
+import { exportBundleReadme } from './bundle-readme.ts';
 
 type ExportTable = Parameters<typeof getTableName>[0];
 type Progress = (message: string, event?: ExportProgressEvent) => void;
@@ -89,6 +90,15 @@ export async function exportOracleData(options: ExportAppOptions): Promise<Expor
     await writeCollectionFiles(outputDir, 'relationships', relationships);
     await writeJson(path.join(outputDir, 'all-collections.json'), { exportedAt, collections: allCollections });
     await writeJson(path.join(outputDir, 'manifest.schema.json'), EXPORT_MANIFEST_SCHEMA);
+    await writeFile(path.join(outputDir, 'README.md'), exportBundleReadme({
+      exportedAt,
+      dbPath: options.dbPath ?? DB_PATH,
+      formats: EXPORT_FORMATS,
+      collectionCount: tables.length,
+      rowCount,
+      relationshipCount: relationships.length,
+      documentCount: documentExport.documentCount,
+    }), 'utf8');
     const files = await exportFileInventory(outputDir, { exclude: ['manifest.json'] });
     await writeJson(path.join(outputDir, 'manifest.json'), {
       exportedAt,


### PR DESCRIPTION
## Summary
- Add a generated `README.md` to each export bundle so operators can review counts and verification steps offline before migration.
- Include the bundle README in the manifest file inventory.
- Update export-app docs and tests for the new bundle artifact.

Refs #1783

## Validation
```bash
bun test tests/tools/export-app.test.ts tests/tools/export-app/export-app.test.ts tests/tools/export-app/manifest-schema.test.ts tests/tools/export-app/csv-safety.test.ts
bunx tsc --noEmit
wc -l tools/export-app/bundle-readme.ts tools/export-app/exporter.ts tools/export-app/README.md tests/tools/export-app/export-app.test.ts tools/export-app/index.ts tests/tools/export-app.test.ts
```

## File sizes
All changed/touched export-app files are <=250 lines.
