### PR TITLE
feat(vector): verify proxy protocol capability

### DIFF
--- a/src/vector/service-registry.ts
+++ b/src/vector/service-registry.ts
@@ -34,6 +34,7 @@ export interface HealthStatus {
   error?: string;
   name?: string;
   version?: string;
+  protocol?: string;
 }
 
 export interface VectorServiceRegistryClient {
@@ -51,16 +52,21 @@ function record(value: unknown): Record<string, unknown> {
     : {};
 }
 
-async function readProxyHealth(response: Response): Promise<Partial<HealthStatus>> {
+async function readProxyHealth(response: Response, expectedProtocol?: string): Promise<Partial<HealthStatus>> {
   const body = record(await response.json().catch(() => ({})));
   const proxyOk = body.status === 'ok';
+  const protocol = typeof body.protocol === 'string' ? body.protocol : undefined;
+  const protocolError = expectedProtocol && protocol !== expectedProtocol
+    ? `protocol mismatch: expected ${expectedProtocol}, got ${protocol ?? 'missing'}`
+    : undefined;
   return {
-    status: response.ok && proxyOk ? 'up' : 'down',
+    status: response.ok && proxyOk && !protocolError ? 'up' : 'down',
     name: typeof body.name === 'string' ? body.name : undefined,
     version: typeof body.version === 'string' ? body.version : undefined,
-    error: response.ok && !proxyOk
+    protocol,
+    error: protocolError ?? (response.ok && !proxyOk
       ? `health status ${String(body.status ?? 'missing')}`
-      : response.ok ? undefined : `HTTP ${response.status}`,
+      : response.ok ? undefined : `HTTP ${response.status}`),
   };
 }
 
@@ -195,12 +201,15 @@ export class VectorServiceRegistry implements VectorServiceRegistryClient {
         if (!endpoint) {
           throw new Error('missing endpoint');
         }
+        const expectedProtocol = typeof service.capabilities?.protocol === 'string'
+          ? service.capabilities.protocol
+          : undefined;
         const healthUrl = buildVectorProxyUrl(endpoint, VECTOR_PROXY_ROUTES.health);
         const response = await fetch(healthUrl, {
           method: 'GET',
           signal: AbortSignal.timeout(HEALTH_TIMEOUT_MS),
         });
-        const proxyHealth = await readProxyHealth(response);
+        const proxyHealth = await readProxyHealth(response, expectedProtocol);
         results.set(service.name, {
           status: proxyHealth.status ?? 'unknown',
           checkedAt: new Date().toISOString(),
@@ -208,6 +217,7 @@ export class VectorServiceRegistry implements VectorServiceRegistryClient {
           error: proxyHealth.error,
           name: proxyHealth.name,
           version: proxyHealth.version,
+          protocol: proxyHealth.protocol,
         });
       } catch (error) {
         results.set(service.name, {

--- a/tests/vector/service-registry.test.ts
+++ b/tests/vector/service-registry.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { configPath, loadVectorConfig } from '../../src/vector/config.ts';
+import { VECTOR_PROXY_PROTOCOL_VERSION } from '../../src/vector/proxy-protocol.ts';
 import { VectorServiceRegistry } from '../../src/vector/service-registry.ts';
 
 const savedDataDir = process.env.ORACLE_DATA_DIR;
@@ -67,6 +68,44 @@ test('VectorServiceRegistry healthCheck follows proxy /health status contract', 
       name: 'proxy-a',
       version: 'test',
       error: 'health status degraded',
+    });
+  } finally {
+    server.stop(true);
+  }
+});
+
+test('VectorServiceRegistry verifies declared proxy protocol capability', async () => {
+  useTempDataDir();
+  let protocol = 'legacy-proxy';
+  const server = Bun.serve({
+    hostname: '127.0.0.1',
+    port: 0,
+    fetch() {
+      return Response.json({ status: 'ok', name: 'proxy-a', version: 'test', protocol });
+    },
+  });
+
+  try {
+    const registry = new VectorServiceRegistry();
+    await registry.register({
+      name: 'proxy-a',
+      type: 'proxy',
+      endpoint: String(server.url).replace(/\/$/, ''),
+      capabilities: { protocol: VECTOR_PROXY_PROTOCOL_VERSION },
+    });
+
+    const mismatch = await registry.healthCheck();
+    expect(mismatch.get('proxy-a')).toMatchObject({
+      status: 'down',
+      protocol: 'legacy-proxy',
+      error: `protocol mismatch: expected ${VECTOR_PROXY_PROTOCOL_VERSION}, got legacy-proxy`,
+    });
+
+    protocol = VECTOR_PROXY_PROTOCOL_VERSION;
+    const healthy = await registry.healthCheck();
+    expect(healthy.get('proxy-a')).toMatchObject({
+      status: 'up',
+      protocol: VECTOR_PROXY_PROTOCOL_VERSION,
     });
   } finally {
     server.stop(true);


### PR DESCRIPTION
## Summary
- validate declared proxy protocol capabilities during vector service health checks
- expose reported protocol in service health results
- add regression coverage for mismatched and matching vector-proxy-v1 sidecars

## Tests
- bun test tests/vector/service-registry.test.ts tests/http/vector/services.test.ts tests/http/vector/proxy-protocol.test.ts tests/http/vector/proxy-adapter.test.ts tests/http/vector/turbovec-sidecar.test.ts tests/http/vector/turbovec.test.ts
- bunx tsc --noEmit

Refs #1438