### PR TITLE
fix: isolate request dedup by tenant

### DIFF
--- a/src/middleware/dedup.ts
+++ b/src/middleware/dedup.ts
@@ -1,3 +1,11 @@
+import {
+  LEGACY_TENANT_HEADER,
+  ORG_HEADER,
+  TENANT_API_KEY_HEADER,
+  TENANT_HEADER,
+  TENANT_TOKEN_HEADER,
+} from './tenant.ts';
+
 type FetchHandler = (request: Request) => Response | Promise<Response>;
 type DedupKey = string | null;
 type DedupKeyFn = (request: Request) => DedupKey;
@@ -15,11 +23,23 @@ export type RequestDedupOptions = {
 };
 
 const COALESCED_METHODS = new Set(['GET', 'HEAD']);
-const VARIANT_HEADERS = ['accept', 'accept-encoding', 'accept-language', 'authorization', 'cookie', 'range'];
+const VARIANT_HEADERS = [
+  'accept',
+  'accept-encoding',
+  'accept-language',
+  'authorization',
+  'cookie',
+  'range',
+  TENANT_HEADER,
+  LEGACY_TENANT_HEADER,
+  ORG_HEADER,
+  TENANT_TOKEN_HEADER,
+  TENANT_API_KEY_HEADER,
+];
 const defaultStore = new Map<string, Promise<ResponseSnapshot>>();
 
 function variantScope(request: Request): string {
-  return VARIANT_HEADERS.map((name) => `${name}:${request.headers.get(name) ?? ''}`).join('\n');
+  return VARIANT_HEADERS.map((name) => `${name.toLowerCase()}:${request.headers.get(name) ?? ''}`).join('\n');
 }
 
 export function requestDedupKey(request: Request): DedupKey {

--- a/tests/http/dedup/coalesce.test.ts
+++ b/tests/http/dedup/coalesce.test.ts
@@ -5,6 +5,12 @@ import {
   handleRequestDedup,
   requestDedupKey,
 } from '../../../src/middleware/dedup.ts';
+import {
+  LEGACY_TENANT_HEADER,
+  ORG_HEADER,
+  TENANT_API_KEY_HEADER,
+  TENANT_HEADER,
+} from '../../../src/middleware/tenant.ts';
 
 type Gate = { promise: Promise<void>; release: () => void };
 
@@ -114,6 +120,25 @@ describe('request deduplication middleware', () => {
     await Promise.all([plain, gzip, authorized]);
 
     expect(hits.count).toBe(3);
+  });
+
+  test('keeps tenant selector variants isolated', async () => {
+    const block = gate();
+    const hits = { count: 0 };
+    const app = slowApp(block, hits);
+    const fetchDedup = createRequestDedupFetch((req) => app.handle(req));
+
+    const tenantA = fetchDedup(request('/slow?item=tenant', { headers: { [TENANT_HEADER]: 'tenant-a' } }));
+    const tenantB = fetchDedup(request('/slow?item=tenant', { headers: { [TENANT_HEADER]: 'tenant-b' } }));
+    const legacyTenant = fetchDedup(request('/slow?item=tenant', { headers: { [LEGACY_TENANT_HEADER]: 'tenant-a' } }));
+    const orgTenant = fetchDedup(request('/slow?item=tenant', { headers: { [ORG_HEADER]: 'tenant-a' } }));
+    const apiKeyTenant = fetchDedup(request('/slow?item=tenant', { headers: { [TENANT_API_KEY_HEADER]: 'tenant-key' } }));
+    await waitFor(() => hits.count === 5);
+
+    block.release();
+    await Promise.all([tenantA, tenantB, legacyTenant, orgTenant, apiKeyTenant]);
+
+    expect(hits.count).toBe(5);
   });
 
   test('coalesces HEAD responses without materializing a body', async () => {


### PR DESCRIPTION
## Summary
- include tenant selector headers in request dedup variant keys
- prevent same-URL in-flight GET/HEAD coalescing across `X-Oracle-Tenant`, legacy tenant/org headers, tenant tokens, or tenant API keys
- add regression coverage for cross-tenant dedup isolation

## Validation
- `bunx tsc --noEmit`
- `bun test tests/http/dedup/coalesce.test.ts tests/http/tenant/` (26 pass)
- changed files <=250 lines

Refs #1650
