### PR TITLE
feat: harden vector service registry

### DIFF
--- a/src/vector/service-registry.ts
+++ b/src/vector/service-registry.ts
@@ -1,10 +1,3 @@
-/**
- * Service registry for external vector services.
- *
- * Keeps runtime-registered services in-memory and syncs them to
- * vector-server.json under `storage.services`.
- */
-
 import {
   configPath,
   generateDefaultConfig,
@@ -15,7 +8,7 @@ import {
   type VectorStorageConfig,
   type VectorStorageService,
 } from './config.ts';
-import { VECTOR_PROXY_ROUTES, buildVectorProxyUrl } from './proxy-protocol.ts';
+import { VECTOR_PROXY_PROTOCOL_VERSION, VECTOR_PROXY_ROUTES, buildVectorProxyUrl } from './proxy-protocol.ts';
 
 export type RegisteredServiceType = 'builtin' | 'proxy';
 export { buildVectorProxyUrl as vectorServiceUrl } from './proxy-protocol.ts';
@@ -34,6 +27,8 @@ export interface HealthStatus {
   error?: string;
   name?: string;
   version?: string;
+  protocol?: string;
+  compatible?: boolean;
 }
 
 export interface VectorServiceRegistryClient {
@@ -53,13 +48,17 @@ function record(value: unknown): Record<string, unknown> {
 
 async function readProxyHealth(response: Response): Promise<Partial<HealthStatus>> {
   const body = record(await response.json().catch(() => ({})));
-  const proxyOk = body.status === 'ok';
+  const protocol = typeof body.protocol === 'string' ? body.protocol : undefined;
+  const compatible = !protocol || protocol === VECTOR_PROXY_PROTOCOL_VERSION;
+  const proxyOk = body.status === 'ok' && compatible;
   return {
     status: response.ok && proxyOk ? 'up' : 'down',
     name: typeof body.name === 'string' ? body.name : undefined,
     version: typeof body.version === 'string' ? body.version : undefined,
+    protocol,
+    compatible,
     error: response.ok && !proxyOk
-      ? `health status ${String(body.status ?? 'missing')}`
+      ? compatible ? `health status ${String(body.status ?? 'missing')}` : `unsupported proxy protocol ${protocol}`
       : response.ok ? undefined : `HTTP ${response.status}`,
   };
 }
@@ -123,7 +122,8 @@ function syncConfig(
   config: VectorServerConfig,
   services: Map<string, RegisteredVectorService>,
 ): VectorServerConfig {
-  const next = { ...config, storage: normalizeStorage(config, services) };
+  const version: VectorServerConfig['version'] = config.version.startsWith('2') ? config.version : '2.0';
+  const next = { ...config, version, storage: normalizeStorage(config, services) };
   writeVectorConfig(next, activeConfigPath());
   return next;
 }
@@ -131,14 +131,25 @@ function syncConfig(
 function validateService(service: RegisteredVectorService): RegisteredVectorService {
   const name = service.name?.trim();
   if (!name) throw new Error('service name is required');
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(name)) {
+    throw new Error(`invalid service name: ${name}`);
+  }
   if (!service.type) throw new Error(`service ${name} missing type`);
-  if (service.type === 'proxy' && !service.endpoint) {
-    throw new Error(`proxy service ${name} requires endpoint`);
+  if (service.type !== 'builtin' && service.type !== 'proxy') throw new Error(`unsupported service type: ${String(service.type)}`);
+  const endpoint = service.endpoint?.trim().replace(/\/+$/, '');
+  if (service.type === 'proxy') {
+    if (!endpoint) throw new Error(`proxy service ${name} requires endpoint`);
+    try {
+      const protocol = new URL(endpoint).protocol;
+      if (protocol !== 'http:' && protocol !== 'https:') throw new Error('bad protocol');
+    } catch {
+      throw new Error(`proxy service ${name} requires http(s) endpoint`);
+    }
   }
   return {
     name,
     type: service.type,
-    endpoint: service.endpoint,
+    endpoint,
     capabilities: service.capabilities,
   };
 }
@@ -208,6 +219,8 @@ export class VectorServiceRegistry implements VectorServiceRegistryClient {
           error: proxyHealth.error,
           name: proxyHealth.name,
           version: proxyHealth.version,
+          protocol: proxyHealth.protocol,
+          compatible: proxyHealth.compatible,
         });
       } catch (error) {
         results.set(service.name, {

--- a/tests/http/vector/services.test.ts
+++ b/tests/http/vector/services.test.ts
@@ -110,7 +110,7 @@ test('VectorServiceRegistry persists services and probes proxy health', async ()
     const registry = new VectorServiceRegistry();
     const endpoint = String(proxy.url).replace(/\/$/, '');
 
-    await registry.register({ name: 'live-proxy', type: 'proxy', endpoint });
+    await registry.register({ name: 'live-proxy', type: 'proxy', endpoint: `${endpoint}/` });
     expect(await registry.discover()).toContainEqual(expect.objectContaining({
       name: 'live-proxy',
       type: 'proxy',
@@ -119,13 +119,57 @@ test('VectorServiceRegistry persists services and probes proxy health', async ()
 
     const health = await registry.healthCheck();
     expect(health.get('live-proxy')).toMatchObject({ status: 'up' });
-    expect(loadVectorConfig(configPath(root))?.storage?.services['live-proxy']).toMatchObject({
+    const config = loadVectorConfig(configPath(root));
+    expect(config?.version).toBe('2.0');
+    expect(config?.storage?.services['live-proxy']).toMatchObject({
       type: 'proxy',
       endpoint,
     });
 
     expect(await registry.unregister('live-proxy')).toBe(true);
     expect(loadVectorConfig(configPath(root))?.storage?.services['live-proxy']).toBeUndefined();
+  } finally {
+    proxy.stop(true);
+    if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+    else process.env.ORACLE_DATA_DIR = savedDataDir;
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('VectorServiceRegistry rejects invalid proxy service names and endpoints', async () => {
+  const registry = new VectorServiceRegistry();
+
+  await expect(registry.register({ name: '../bad', type: 'proxy', endpoint: 'http://127.0.0.1:8082' }))
+    .rejects.toThrow('invalid service name');
+  await expect(registry.register({ name: 'bad-url', type: 'proxy', endpoint: 'ftp://127.0.0.1' }))
+    .rejects.toThrow('requires http(s) endpoint');
+});
+
+test('VectorServiceRegistry reports incompatible proxy protocol as down', async () => {
+  const savedDataDir = process.env.ORACLE_DATA_DIR;
+  const root = mkdtempSync(join(tmpdir(), 'vector-services-protocol-'));
+  const proxy = Bun.serve({
+    hostname: '127.0.0.1',
+    port: 0,
+    fetch(request) {
+      if (new URL(request.url).pathname === '/health') {
+        return Response.json({ status: 'ok', name: 'old-proxy', version: '0.1', protocol: 'legacy-proxy' });
+      }
+      return new Response('missing', { status: 404 });
+    },
+  });
+
+  try {
+    process.env.ORACLE_DATA_DIR = root;
+    const registry = new VectorServiceRegistry();
+    await registry.register({ name: 'old-proxy', type: 'proxy', endpoint: String(proxy.url) });
+    const health = await registry.healthCheck();
+    expect(health.get('old-proxy')).toMatchObject({
+      status: 'down',
+      compatible: false,
+      protocol: 'legacy-proxy',
+      error: 'unsupported proxy protocol legacy-proxy',
+    });
   } finally {
     proxy.stop(true);
     if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;


### PR DESCRIPTION
Refs #1438.

## Summary
- upgrades service-registry writes to vector-server.json v2 storage format
- normalizes proxy endpoints, rejects invalid service names/endpoints/types, and persists trimmed endpoints
- surfaces proxy protocol compatibility in health checks and marks incompatible proxy protocols down
- adds regression coverage for v2 persistence, validation, and protocol mismatch health

## Validation
- `bunx tsc --noEmit`
- `bun test tests/http/vector/`
- `git diff --check`
- changed-file line counts all <=250