### PR TITLE
fix(memory): scope memory APIs by tenant

### DIFF
--- a/src/db/__tests__/fresh-install.test.ts
+++ b/src/db/__tests__/fresh-install.test.ts
@@ -79,6 +79,7 @@ describe("fresh install (#1111)", () => {
 		expect(names).toContain("idx_documents_tenant_type_active_updated");
 		expect(names).toContain("idx_search_tenant_created");
 		expect(names).toContain("idx_thread_tenant_status_updated");
+		expect(names).toContain("idx_memory_tenant_created");
 		expect(names).toContain("idx_menu_path_studio");
 
 		sqlite.close();

--- a/src/db/migrations/0026_oracle_memories_tenant.sql
+++ b/src/db/migrations/0026_oracle_memories_tenant.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `oracle_memories` ADD `tenant_id` text DEFAULT 'default' NOT NULL;--> statement-breakpoint
+CREATE INDEX `idx_memory_tenant_created` ON `oracle_memories` (`tenant_id`,`created_at`);

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1781624768517,
       "tag": "0025_export_jobs_tenant",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "6",
+      "when": 1781628166154,
+      "tag": "0026_oracle_memories_tenant",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -44,6 +44,7 @@ export const oracleDocuments = sqliteTable('oracle_documents', {
 // Challenge 2 memory system persistence (#1457)
 export const oracleMemories = sqliteTable('oracle_memories', {
   id: text('id').primaryKey(),
+  tenantId: text('tenant_id').default('default').notNull(),
   content: text('content').notNull(),
   title: text('title'),
   tags: text('tags').default('[]').notNull(),
@@ -54,8 +55,8 @@ export const oracleMemories = sqliteTable('oracle_memories', {
   index('idx_memory_created').on(table.createdAt),
   index('idx_memory_title').on(table.title),
   index('idx_memory_source').on(table.source),
+  index('idx_memory_tenant_created').on(table.tenantId, table.createdAt),
 ]);
-
 // Indexing status tracking
 export const indexingStatus = sqliteTable('indexing_status', {
   id: integer('id').primaryKey(),

--- a/src/routes/memory/index.ts
+++ b/src/routes/memory/index.ts
@@ -5,6 +5,7 @@ import { memoryStore, type MemoryInput, type MemoryRecord, type MemoryStore } fr
 import { memoryVectorIndex, type MemoryVectorHit, type MemoryVectorIndex } from './vector.ts';
 import { buildMorningTape } from './morning-tape.ts';
 import { MEMORY_CONFIDENCE_STRATEGY, memoryConfidence } from './confidence.ts';
+import { currentTenantId } from '../../middleware/tenant.ts';
 
 export function createMemoryRoutes(
   store: MemoryStore = memoryStore,
@@ -66,16 +67,26 @@ export function createMemoryRoutes(
 
 function mergeHits(hits: MemoryVectorHit[], records: MemoryRecord[]) {
   const byId = new Map(records.map((record) => [record.id, record]));
-  return hits.map((hit) => {
-    const memory = memoryForHit(hit, byId.get(hit.memoryId));
-    return {
+  const tenantId = currentTenantId();
+  return hits.flatMap((hit) => {
+    const record = byId.get(hit.memoryId);
+    if (tenantId && !record) return [];
+    const hitTenantId = hitTenant(hit);
+    if (tenantId && hitTenantId && hitTenantId !== tenantId) return [];
+    const memory = memoryForHit(hit, record);
+    return [{
       ...memory,
       score: hit.score,
       distance: hit.distance,
       vectorId: hit.vectorId,
       confidence: memoryConfidence(memory, { mode: 'semantic', semanticScore: hit.score }),
-    };
+    }];
   });
+}
+
+function hitTenant(hit: MemoryVectorHit): string | undefined {
+  const value = hit.metadata.tenant_id ?? hit.metadata.tenantId ?? hit.metadata.tenant;
+  return typeof value === 'string' ? value : undefined;
 }
 
 function withKeywordConfidence(memory: MemoryRecord) {

--- a/src/routes/memory/store.ts
+++ b/src/routes/memory/store.ts
@@ -1,6 +1,7 @@
-import { desc, inArray, like, or } from 'drizzle-orm';
+import { and, desc, eq, inArray, like, or, type SQL } from 'drizzle-orm';
 import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 import { db as defaultDb, oracleMemories } from '../../db/index.ts';
+import { currentTenantId, tenantIdForWrite } from '../../middleware/tenant.ts';
 import type * as schema from '../../db/schema.ts';
 
 export type MemoryInput = {
@@ -12,6 +13,7 @@ export type MemoryInput = {
 
 export type MemoryRecord = MemoryInput & {
   id: string;
+  tenantId?: string;
   createdAt: string;
   updatedAt: string;
 };
@@ -28,6 +30,7 @@ export class MemoryStore {
     const now = Date.now();
     const row = this.database.insert(oracleMemories).values({
       id: `mem_${now.toString(36)}_${crypto.randomUUID().slice(0, 8)}`,
+      tenantId: tenantIdForWrite(),
       content,
       title: input.title?.trim() || null,
       tags: JSON.stringify(cleanTags(input.tags)),
@@ -41,27 +44,42 @@ export class MemoryStore {
   recall(query = '', limit = 10): MemoryRecord[] {
     const normalized = query.trim();
     const safeLimit = Math.min(50, Math.max(1, limit));
-    const base = this.database.select().from(oracleMemories);
-    const rows = normalized
-      ? base.where(or(
-        like(oracleMemories.content, `%${normalized}%`),
-        like(oracleMemories.title, `%${normalized}%`),
-        like(oracleMemories.tags, `%${normalized}%`),
-        like(oracleMemories.source, `%${normalized}%`),
-      )).orderBy(desc(oracleMemories.createdAt)).limit(safeLimit).all()
-      : base.orderBy(desc(oracleMemories.createdAt)).limit(safeLimit).all();
+    const where = combineWhere(tenantWhere(), searchWhere(normalized));
+    const selected = this.database.select().from(oracleMemories);
+    const rows = where
+      ? selected.where(where).orderBy(desc(oracleMemories.createdAt)).limit(safeLimit).all()
+      : selected.orderBy(desc(oracleMemories.createdAt)).limit(safeLimit).all();
     return rows.map(memoryFromRow);
   }
 
   getByIds(ids: string[]): MemoryRecord[] {
     if (!ids.length) return [];
-    const rows = this.database.select().from(oracleMemories)
-      .where(inArray(oracleMemories.id, ids))
-      .all();
+    const where = combineWhere(inArray(oracleMemories.id, ids), tenantWhere());
+    const rows = this.database.select().from(oracleMemories).where(where).all();
     const byId = new Map(rows.map((row) => [row.id, memoryFromRow(row)]));
     return ids.map((id) => byId.get(id)).filter((row): row is MemoryRecord => Boolean(row));
   }
 
+}
+
+function tenantWhere(): SQL | undefined {
+  const tenantId = currentTenantId();
+  return tenantId ? eq(oracleMemories.tenantId, tenantId) : undefined;
+}
+
+function searchWhere(query: string): SQL | undefined {
+  if (!query) return undefined;
+  return or(
+    like(oracleMemories.content, `%${query}%`),
+    like(oracleMemories.title, `%${query}%`),
+    like(oracleMemories.tags, `%${query}%`),
+    like(oracleMemories.source, `%${query}%`),
+  );
+}
+
+function combineWhere(...clauses: Array<SQL | undefined>): SQL | undefined {
+  const present = clauses.filter((clause): clause is SQL => Boolean(clause));
+  return present.length > 1 ? and(...present) : present[0];
 }
 
 function cleanTags(tags: string[] = []): string[] {
@@ -79,6 +97,7 @@ function tagsFrom(value: string): string[] {
 function memoryFromRow(row: MemoryRow): MemoryRecord {
   return {
     id: row.id,
+    tenantId: row.tenantId,
     content: row.content,
     title: row.title ?? undefined,
     tags: tagsFrom(row.tags),

--- a/src/routes/memory/vector.ts
+++ b/src/routes/memory/vector.ts
@@ -1,4 +1,5 @@
 import { ensureVectorStoreConnected } from '../../vector/factory.ts';
+import { currentTenantId } from '../../middleware/tenant.ts';
 import type { VectorDocument, VectorQueryResult, VectorStoreAdapter } from '../../vector/types.ts';
 import type { MemoryRecord } from './store.ts';
 
@@ -37,8 +38,10 @@ export class VectorMemoryIndex implements MemoryVectorIndex {
     const clean = query.trim();
     if (!clean) throw new Error('memory search query is required');
     const store = await this.resolveStore();
-    const result = await store.query(clean, limit, { type: 'memory' });
-    return hitsFrom(result);
+    const tenantId = currentTenantId();
+    const where = tenantId ? { type: 'memory', tenant_id: tenantId } : { type: 'memory' };
+    const result = await store.query(clean, limit, where);
+    return hitsFrom(result).filter((hit) => matchesTenant(hit, tenantId));
   }
 }
 
@@ -49,6 +52,7 @@ function memoryDocument(memory: MemoryRecord): VectorDocument {
     metadata: {
       type: 'memory',
       memoryId: memory.id,
+      tenant_id: memory.tenantId ?? 'default',
       title: memory.title ?? '',
       source: memory.source ?? '',
       tags: (memory.tags ?? []).join(','),
@@ -70,6 +74,12 @@ function hitsFrom(result: VectorQueryResult): MemoryVectorHit[] {
       score: Math.max(0, 1 - distance),
     };
   });
+}
+
+function matchesTenant(hit: MemoryVectorHit, tenantId: string | undefined): boolean {
+  if (!tenantId) return true;
+  const value = hit.metadata.tenant_id ?? hit.metadata.tenantId ?? hit.metadata.tenant;
+  return value === tenantId;
 }
 
 function vectorId(memoryId: string): string {

--- a/tests/http/memory/save-recall.test.ts
+++ b/tests/http/memory/save-recall.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, expect, test } from 'bun:test';
 import { inArray } from 'drizzle-orm';
 import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
 import { db, oracleMemories } from '../../../src/db/index.ts';
 import { createMemoryRoutes } from '../../../src/routes/memory/index.ts';
 import type { MemoryRecord } from '../../../src/routes/memory/store.ts';
@@ -30,7 +31,7 @@ class FakeMemoryVectorIndex implements MemoryVectorIndex {
         memoryId: memory.id,
         vectorId: `memory:${memory.id}`,
         document: memory.content,
-        metadata: { type: 'memory', memoryId: memory.id },
+        metadata: { type: 'memory', memoryId: memory.id, tenant_id: memory.tenantId ?? 'default' },
         distance: index * 0.1,
         score: 1 - index * 0.1,
       }));
@@ -40,7 +41,7 @@ class FakeMemoryVectorIndex implements MemoryVectorIndex {
 function createHarness() {
   const vectorIndex = new FakeMemoryVectorIndex();
   const app = createMemoryRoutes(undefined, vectorIndex);
-  return { fetcher: createApiVersionedFetch((request) => app.handle(request)), vectorIndex };
+  return { fetcher: createTenantFetch(createApiVersionedFetch((request) => app.handle(request))), vectorIndex };
 }
 
 async function json(res: Response) {
@@ -97,6 +98,45 @@ test('GET /api/v1/memory/search returns vector similarity hits enriched from SQL
   expect(body.results[0]).toMatchObject({ id: saved.memory.id, score: 1, vectorId: `memory:${saved.memory.id}` });
   expect(body.confidence).toMatchObject({ stored: false, strategy: 'query-time-confidence' });
   expect(body.results[0].confidence.reasons).toContain('semantic_match');
+});
+
+test('memory APIs isolate persisted memories by tenant context', async () => {
+  const { fetcher } = createHarness();
+  const unique = `tenant-memory-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const headers = (tenantId: string) => ({
+    'content-type': 'application/json',
+    [TENANT_HEADER]: tenantId,
+  });
+
+  async function saveTenantMemory(tenantId: string, title: string) {
+    const response = await fetcher(new Request('http://local/api/v1/memory/save', {
+      method: 'POST',
+      headers: headers(tenantId),
+      body: JSON.stringify({ title, content: `${title} owns ${unique}.`, tags: ['tenant'] }),
+    }));
+    const body = await json(response);
+    savedIds.push(body.memory.id);
+    return body.memory as MemoryRecord;
+  }
+
+  const memoryA = await saveTenantMemory('tenant-a', 'Tenant A memory');
+  const memoryB = await saveTenantMemory('tenant-b', 'Tenant B memory');
+
+  expect(memoryA.tenantId).toBe('tenant-a');
+  expect(memoryB.tenantId).toBe('tenant-b');
+
+  const recallA = await json(await fetcher(new Request(`http://local/api/v1/memory/recall?q=${unique}`, { headers: headers('tenant-a') })));
+  const recallB = await json(await fetcher(new Request(`http://local/api/v1/memory/recall?q=${unique}`, { headers: headers('tenant-b') })));
+
+  expect(recallA.items.map((item: MemoryRecord) => item.id)).toEqual([memoryA.id]);
+  expect(recallB.items.map((item: MemoryRecord) => item.id)).toEqual([memoryB.id]);
+
+  const searchA = await json(await fetcher(new Request(`http://local/api/v1/memory/search?q=${unique}`, { headers: headers('tenant-a') })));
+  expect(searchA.results.map((item: MemoryRecord) => item.id)).toEqual([memoryA.id]);
+
+  const tapeA = await (await fetcher(new Request('http://local/api/v1/memory/morning-tape?format=markdown', { headers: headers('tenant-a') }))).text();
+  expect(tapeA).toContain('Tenant A memory');
+  expect(tapeA).not.toContain('Tenant B memory');
 });
 
 test('memory save rejects blank content', async () => {


### PR DESCRIPTION
Refs #1650.\n\n## Summary\n- adds tenant_id persistence and migration coverage for oracle_memories\n- stamps saved memories with active tenant and scopes recall/morning-tape/getByIds by tenant context\n- adds tenant metadata filtering for memory vector indexing/search and regression coverage for cross-tenant memory isolation\n\n## Slice not taken by codex-3/11/12\n- codex-3: tenant stats surface\n- codex-12: tenant-scoped DB helper/API-key derivation\n- this PR: memory API persistence/vector scoping\n\n## Validation\n- ORACLE_DATA_DIR=/tmp/... ORACLE_DB_PATH=/tmp/... bun test tests/http/memory/ tests/http/tenant/ src/db/__tests__/fresh-install.test.ts\n- ORACLE_DATA_DIR=/tmp/... ORACLE_DB_PATH=/tmp/... bunx tsc --noEmit\n- wc -l changed files <=250\n