### PR TITLE
fix: scope files doc route by tenant

### DIFF
--- a/src/routes/files/doc.ts
+++ b/src/routes/files/doc.ts
@@ -1,7 +1,8 @@
 import { Elysia, t } from 'elysia';
 import { sqlite, db, oracleDocuments } from '../../db/index.ts';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { docParams } from './model.ts';
+import { currentTenantId, tenantIdForWrite } from '../../middleware/tenant.ts';
 
 // Body schemas for PATCH/POST.
 const PatchDocBody = t.Object({
@@ -19,21 +20,34 @@ const PostDocBody = t.Object({
   project: t.Optional(t.String()),
 });
 
+function tenantFilter(alias = 'd'): { clause: string; params: string[] } {
+  const tenantId = currentTenantId();
+  return tenantId ? { clause: `AND ${alias}.tenant_id = ?`, params: [tenantId] } : { clause: '', params: [] };
+}
+
+function docWhere(id: string) {
+  const tenantId = currentTenantId();
+  return tenantId
+    ? and(eq(oracleDocuments.id, id), eq(oracleDocuments.tenantId, tenantId))
+    : eq(oracleDocuments.id, id);
+}
+
 export const docRoute = new Elysia()
   .get(
     '/api/doc/:id',
     ({ params, set }) => {
       try {
+        const filter = tenantFilter('d');
         const row = sqlite
           .prepare(
             `
         SELECT d.id, d.type, d.source_file, d.concepts, d.project, f.content
         FROM oracle_documents d
         JOIN oracle_fts f ON d.id = f.id
-        WHERE d.id = ?
+        WHERE d.id = ? ${filter.clause}
       `,
           )
-          .get(params.id) as any;
+          .get(params.id, ...filter.params) as any;
 
         if (!row) {
           set.status = 404;
@@ -66,9 +80,10 @@ export const docRoute = new Elysia()
     '/api/doc/:id',
     ({ params, body, set }) => {
       try {
+        const filter = tenantFilter('d');
         const existing = sqlite
-          .prepare(`SELECT id FROM oracle_documents WHERE id = ?`)
-          .get(params.id) as { id: string } | undefined;
+          .prepare(`SELECT id FROM oracle_documents d WHERE d.id = ? ${filter.clause}`)
+          .get(params.id, ...filter.params) as { id: string } | undefined;
         if (!existing) {
           set.status = 404;
           return { error: 'Document not found' };
@@ -85,10 +100,12 @@ export const docRoute = new Elysia()
           patch.concepts = JSON.stringify(dedup);
         }
 
-        db.update(oracleDocuments).set(patch).where(eq(oracleDocuments.id, params.id)).run();
+        db.update(oracleDocuments).set(patch).where(docWhere(params.id)).run();
 
         if (typeof data.content === 'string') {
-          const conceptsRow = sqlite.prepare(`SELECT concepts FROM oracle_documents WHERE id = ?`).get(params.id) as { concepts: string };
+          const conceptsRow = sqlite
+            .prepare(`SELECT concepts FROM oracle_documents d WHERE d.id = ? ${filter.clause}`)
+            .get(params.id, ...filter.params) as { concepts: string };
           const conceptsArr: string[] = conceptsRow ? JSON.parse(conceptsRow.concepts || '[]') : [];
           sqlite.prepare(`DELETE FROM oracle_fts WHERE id = ?`).run(params.id);
           sqlite
@@ -134,6 +151,7 @@ export const docRoute = new Elysia()
 
         db.insert(oracleDocuments).values({
           id,
+          tenantId: tenantIdForWrite(),
           type: data.type,
           sourceFile: data.source_file ?? `imported/${id}.md`,
           concepts: JSON.stringify(conceptsArr),

--- a/tests/http/tenant/files-doc-isolation.test.ts
+++ b/tests/http/tenant/files-doc-isolation.test.ts
@@ -1,0 +1,64 @@
+import { afterAll, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { db, oracleDocuments, resetDefaultDatabaseForTests, sqlite } from '../../../src/db/index.ts';
+import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
+import { docRoute } from '../../../src/routes/files/doc.ts';
+
+resetDefaultDatabaseForTests();
+
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantA = `tenant-a-${stamp}`;
+const tenantB = `tenant-b-${stamp}`;
+const docId = `tenant-doc-file-${stamp}`;
+
+function docRequest(tenantId: string, path: string, init: RequestInit = {}) {
+  return createTenantFetch((request) => docRoute.handle(request))(new Request(`http://local${path}`, {
+    ...init,
+    headers: { 'content-type': 'application/json', [TENANT_HEADER]: tenantId, ...(init.headers ?? {}) },
+  }));
+}
+
+async function json(res: Response) {
+  return await res.json() as Record<string, unknown>;
+}
+
+afterAll(() => {
+  db.delete(oracleDocuments).where(eq(oracleDocuments.id, docId)).run();
+  sqlite.prepare('DELETE FROM oracle_fts WHERE id = ?').run(docId);
+});
+
+test('/api/doc stamps tenant_id and hides document ids from other tenants', async () => {
+  const created = await docRequest(tenantA, '/api/doc', {
+    method: 'POST',
+    body: JSON.stringify({
+      id: docId,
+      type: 'learning',
+      content: `tenant A body ${stamp}`,
+      concepts: ['TenantDoc'],
+      source_file: `ψ/memory/${docId}.md`,
+    }),
+  });
+  expect(created.status).toBe(200);
+  expect(db.select({ tenantId: oracleDocuments.tenantId }).from(oracleDocuments)
+    .where(eq(oracleDocuments.id, docId)).get()?.tenantId).toBe(tenantA);
+
+  const deniedGet = await docRequest(tenantB, `/api/doc/${docId}`);
+  const deniedPatch = await docRequest(tenantB, `/api/doc/${docId}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ content: 'tenant B overwrite attempt' }),
+  });
+  expect(deniedGet.status).toBe(404);
+  expect(deniedPatch.status).toBe(404);
+
+  const allowedPatch = await docRequest(tenantA, `/api/doc/${docId}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ content: `tenant A updated ${stamp}`, concepts: ['updated'] }),
+  });
+  const allowedGet = await docRequest(tenantA, `/api/doc/${docId}`);
+  const body = await json(allowedGet);
+
+  expect(allowedPatch.status).toBe(200);
+  expect(allowedGet.status).toBe(200);
+  expect(body.content).toBe(`tenant A updated ${stamp}`);
+  expect(body.concepts).toEqual(['updated']);
+});


### PR DESCRIPTION
## Summary
- scope `/api/doc/:id` GET/PATCH lookups by the validated tenant context
- stamp `/api/doc` creates with `tenant_id` from the tenant middleware
- add regression coverage that tenant B gets 404 for tenant A document IDs and cannot patch them

## Validation
- `bunx tsc --noEmit`
- `bun test tests/http/tenant/files-doc-isolation.test.ts tests/http/tenant/` (20 pass)
- changed files <=250 lines

Refs #1650
