### PR TITLE
feat: filter export app collections

### DIFF
--- a/tests/tools/export-app/export-app.test.ts
+++ b/tests/tools/export-app/export-app.test.ts
@@ -149,6 +149,28 @@ describe('standalone export app', () => {
     expect(existsSync(join(outputDir, 'collections', 'oracle_documents.json'))).toBe(true);
   });
 
+  test('CLI filters batch exports to selected collections', async () => {
+    const filterDbPath = join(root, 'filter.db');
+    const outputDir = join(root, 'backup-filter');
+    const connection = createDatabase(filterDbPath);
+    const stdout: string[] = [];
+    seed(connection);
+    connection.storage.close();
+
+    const code = await runExportApp(
+      ['--output', outputDir, '--db', filterDbPath, '--collection', 'oracle_documents'],
+      (msg) => stdout.push(msg),
+      () => {},
+    );
+
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout.join('')).collectionCount).toBe(1);
+    expect(existsSync(join(outputDir, 'collections', 'oracle_documents.json'))).toBe(true);
+    expect(existsSync(join(outputDir, 'collections', 'trace_log.json'))).toBe(false);
+    const manifest = JSON.parse(readFileSync(join(outputDir, 'manifest.json'), 'utf8'));
+    expect(Object.keys(manifest.collections)).toEqual(['oracle_documents']);
+  });
+
   test('document engine reads a legacy Oracle v2 database with only docs and FTS', async () => {
     const legacyDbPath = join(root, 'legacy-v2.db');
     const legacyOutput = join(root, 'legacy-v2-export');

--- a/tools/export-app/README.md
+++ b/tools/export-app/README.md
@@ -67,6 +67,7 @@ connection.
 ```sh
 bun run tools/export-app/index.ts --output ./backup/export-app
 bun run tools/export-app/index.ts --output ./backup/export-app --db ./oracle.db
+bun run tools/export-app/index.ts --output ./backup/docs --collection oracle_documents
 bun run tools/export-app/index.ts --output ./backup/export-app --dry-run
 bun run tools/export-app/index.ts --output ./backup/export-app --progress json
 bun run tools/export-app/index.ts --verify ./backup/export-app
@@ -74,6 +75,8 @@ bun run tools/export-app/index.ts --verify ./backup/export-app
 
 Use `--dry-run` to print collection, row, relationship, and document counts
 without creating files. It is a safe preflight before long-running exports.
+Use `--collection <name>` repeatedly or `--collections a,b` to write only
+selected Drizzle collections when testing a narrow migration path.
 
 The batch output includes:
 

--- a/tools/export-app/collections.ts
+++ b/tools/export-app/collections.ts
@@ -1,0 +1,40 @@
+import { getTableName } from 'drizzle-orm';
+
+type ExportTable = Parameters<typeof getTableName>[0];
+
+export function parseCollectionFilter(value: string): string[] {
+  const names = value.split(',').map((name) => name.trim()).filter(Boolean);
+  if (names.length === 0) throw new Error('missing value for --collection');
+  return names;
+}
+
+export function appendCollectionFilter(current: string[], value: string): string[] {
+  return [...current, ...parseCollectionFilter(value)];
+}
+
+export function selectExportTables<T extends ExportTable>(
+  tables: T[],
+  collections: readonly string[] = [],
+): T[] {
+  if (collections.length === 0) return tables;
+
+  const byName = new Map(tables.map((table) => [getTableName(table), table]));
+  const selected: T[] = [];
+  const seen = new Set<string>();
+
+  for (const collection of collections) {
+    if (seen.has(collection)) continue;
+    const table = byName.get(collection);
+    if (!table) {
+      throw new Error(`unknown export collection: ${collection}. Available: ${[...byName.keys()].join(', ')}`);
+    }
+    selected.push(table);
+    seen.add(collection);
+  }
+
+  return selected;
+}
+
+export function shouldExportDocuments(collections: readonly string[] = []): boolean {
+  return collections.length === 0 || collections.includes('oracle_documents');
+}

--- a/tools/export-app/exporter.ts
+++ b/tools/export-app/exporter.ts
@@ -19,6 +19,7 @@ import { exportOracleV2Documents } from './documents.ts';
 import { EXPORT_MANIFEST_SCHEMA } from './schema.ts';
 import { exportFileInventory } from './inventory.ts';
 import { exportBundleReadme } from './bundle-readme.ts';
+import { selectExportTables, shouldExportDocuments } from './collections.ts';
 
 type ExportTable = Parameters<typeof getTableName>[0];
 type Progress = (message: string, event?: ExportProgressEvent) => void;
@@ -37,6 +38,7 @@ export interface ExportAppOptions {
   connection?: DatabaseConnection;
   progress?: Progress;
   now?: () => Date;
+  collections?: readonly string[];
 }
 
 export interface ExportOracleDataResult {
@@ -65,7 +67,7 @@ export function schemaTables(): ExportTable[] {
 export async function exportOracleData(options: ExportAppOptions): Promise<ExportOracleDataResult> {
   const close = options.connection ? undefined : openReadonlyConnection(options.dbPath);
   const connection = options.connection ?? close!.connection;
-  const tables = introspectDrizzleTables();
+  const tables = selectExportTables(introspectDrizzleTables(), options.collections);
   const outputDir = path.resolve(options.outputDir);
   const collectionsDir = path.join(outputDir, 'collections');
   const progress = options.progress ?? ((message) => console.error(message));
@@ -86,7 +88,9 @@ export async function exportOracleData(options: ExportAppOptions): Promise<Expor
     }
 
     const relationships = graphRelationships(allCollections);
-    const documentExport = await exportOracleV2Documents({ ...options, outputDir, connection, progress });
+    const documentExport = shouldExportDocuments(options.collections)
+      ? await exportOracleV2Documents({ ...options, outputDir, connection, progress })
+      : { documentCount: 0 };
     await writeCollectionFiles(outputDir, 'relationships', relationships);
     await writeJson(path.join(outputDir, 'all-collections.json'), { exportedAt, collections: allCollections });
     await writeJson(path.join(outputDir, 'manifest.schema.json'), EXPORT_MANIFEST_SCHEMA);
@@ -126,7 +130,7 @@ export async function exportOracleData(options: ExportAppOptions): Promise<Expor
 export async function exportMarkdownData(options: ExportAppOptions): Promise<ExportMarkdownResult> {
   const close = options.connection ? undefined : openReadonlyConnection(options.dbPath);
   const connection = options.connection ?? close!.connection;
-  const tables = schemaTables();
+  const tables = selectExportTables(schemaTables(), options.collections);
   const outputDir = path.resolve(options.outputDir);
   const progress = options.progress ?? ((message) => console.error(message));
   let fileCount = 0;

--- a/tools/export-app/index.ts
+++ b/tools/export-app/index.ts
@@ -2,6 +2,7 @@ import { existsSync, statSync } from 'node:fs';
 import { DB_PATH } from '../../src/config.ts';
 import { exportOracleData, type ExportProgressEvent } from './exporter.ts';
 import { previewOracleExport } from './summary.ts';
+import { appendCollectionFilter } from './collections.ts';
 import { verifyExportBundle } from './verify.ts';
 
 type Writer = (message: string) => void;
@@ -14,6 +15,7 @@ interface CliOptions {
   progressMode: ProgressMode;
   dryRun: boolean;
   verifyDir?: string;
+  collections: string[];
 }
 
 function flagValue(args: string[], index: number, flag: string): string {
@@ -37,6 +39,7 @@ export function parseArgs(args: string[]): CliOptions {
   let progressMode: ProgressMode = 'text';
   let dryRun = false;
   let verifyDir: string | undefined;
+  let collections: string[] = [];
 
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i]!;
@@ -44,14 +47,21 @@ export function parseArgs(args: string[]): CliOptions {
     const dbAssigned = assignedValue(arg, '--db');
     const progressAssigned = assignedValue(arg, '--progress');
     const verifyAssigned = assignedValue(arg, '--verify');
+    const collectionAssigned = assignedValue(arg, '--collection') ?? assignedValue(arg, '--collections');
     if (outputAssigned !== undefined) { outputDir = outputAssigned; continue; }
     if (dbAssigned !== undefined) { dbPath = dbAssigned; continue; }
     if (progressAssigned !== undefined) { progressMode = readProgressMode(progressAssigned); continue; }
     if (verifyAssigned !== undefined) { verifyDir = verifyAssigned; continue; }
+    if (collectionAssigned !== undefined) { collections = appendCollectionFilter(collections, collectionAssigned); continue; }
     if (arg === '--output' || arg === '-o') { outputDir = flagValue(args, i, arg); i += 1; continue; }
     if (arg === '--db') { dbPath = flagValue(args, i, arg); i += 1; continue; }
     if (arg === '--progress') { progressMode = readProgressMode(flagValue(args, i, arg)); i += 1; continue; }
     if (arg === '--verify') { verifyDir = flagValue(args, i, arg); i += 1; continue; }
+    if (arg === '--collection' || arg === '--collections') {
+      collections = appendCollectionFilter(collections, flagValue(args, i, arg));
+      i += 1;
+      continue;
+    }
     if (arg === '--quiet' || arg === '--no-progress') { quiet = true; continue; }
     if (arg === '--progress-json') { progressMode = 'json'; continue; }
     if (arg === '--dry-run') { dryRun = true; continue; }
@@ -60,7 +70,7 @@ export function parseArgs(args: string[]): CliOptions {
   }
 
   if (!outputDir && !verifyDir) throw new Error('missing required --output <dir>');
-  return { outputDir: outputDir ?? verifyDir!, dbPath, quiet, progressMode, dryRun, verifyDir };
+  return { outputDir: outputDir ?? verifyDir!, dbPath, quiet, progressMode, dryRun, verifyDir, collections };
 }
 
 function readProgressMode(value: string): ProgressMode {
@@ -95,6 +105,7 @@ function printHelp(write: Writer): void {
     'Flags:',
     '  --output, -o <dir>   destination backup directory',
     '  --db <path>          SQLite database path (defaults to ORACLE_DB_PATH)',
+    '  --collection <name>  export only matching collection; repeat or comma-separate',
     '  --progress <mode>    progress output: text, json, or silent',
     '  --dry-run            print collection counts without writing files',
     '  --verify <dir>       verify manifest file sizes and SHA-256 checksums',
@@ -133,13 +144,14 @@ export async function runExportApp(args: string[], stdout: Writer = process.stdo
     }
     validateCliOptions(options);
     if (options.dryRun) {
-      stdout(`${JSON.stringify({ success: true, dryRun: true, ...previewOracleExport({ dbPath: options.dbPath }) }, null, 2)}\n`);
+      stdout(`${JSON.stringify({ success: true, dryRun: true, ...previewOracleExport({ dbPath: options.dbPath, collections: options.collections }) }, null, 2)}\n`);
       return 0;
     }
     const progress = progressWriter(options, stderr);
     const result = await exportOracleData({
       outputDir: options.outputDir,
       dbPath: options.dbPath,
+      collections: options.collections,
       progress,
     });
     stdout(`${JSON.stringify({ success: true, ...result }, null, 2)}\n`);

--- a/tools/export-app/summary.ts
+++ b/tools/export-app/summary.ts
@@ -6,12 +6,14 @@ import { createStorageBackend } from '../../src/storage/registry.ts';
 import { graphRelationships } from './graph.ts';
 import { normalizeRecords, type ExportRecord } from './formats.ts';
 import { readOracleV2Documents } from './documents.ts';
+import { selectExportTables, shouldExportDocuments } from './collections.ts';
 
 type ExportTable = ReturnType<typeof introspectDrizzleTables>[number];
 
 export interface ExportPreviewOptions {
   dbPath?: string;
   connection?: DatabaseConnection;
+  collections?: readonly string[];
 }
 
 export interface ExportPreviewCollection {
@@ -31,7 +33,7 @@ export interface ExportPreviewResult {
 export function previewOracleExport(options: ExportPreviewOptions = {}): ExportPreviewResult {
   const close = options.connection ? undefined : openReadonlyConnection(options.dbPath);
   const connection = options.connection ?? close!.connection;
-  const tables = introspectDrizzleTables();
+  const tables = selectExportTables(introspectDrizzleTables(), options.collections);
   const allCollections: Record<string, ExportRecord[]> = {};
   const collections: ExportPreviewCollection[] = [];
   let rowCount = 0;
@@ -49,7 +51,7 @@ export function previewOracleExport(options: ExportPreviewOptions = {}): ExportP
       collectionCount: collections.length,
       rowCount,
       relationshipCount: graphRelationships(allCollections).length,
-      documentCount: readOracleV2Documents(connection).length,
+      documentCount: shouldExportDocuments(options.collections) ? readOracleV2Documents(connection).length : 0,
       collections,
     };
   } finally {


### PR DESCRIPTION
## Summary
- Add `--collection` / `--collections` filtering for local export-app batch runs.
- Apply the same filter to dry-run previews, manifest counts, graph relationships, and markdown-only export helpers.
- Document the narrow-export flow and cover it with an export-app CLI test.

Refs #1783

## Validation
```bash
bun test tests/tools/export-app.test.ts tests/tools/export-app/export-app.test.ts tests/tools/export-app/manifest-schema.test.ts tests/tools/export-app/csv-safety.test.ts
bunx tsc --noEmit
wc -l tools/export-app/collections.ts tools/export-app/bundle-readme.ts tools/export-app/index.ts tools/export-app/exporter.ts tools/export-app/summary.ts tools/export-app/README.md tests/tools/export-app/export-app.test.ts tests/tools/export-app.test.ts
```

## File sizes
All changed/touched export-app files are <=250 lines.
