### PR TITLE
feat(export): verify export bundle inventory

### DIFF
--- a/tests/tools/export-app/verify.test.ts
+++ b/tests/tools/export-app/verify.test.ts
@@ -1,0 +1,74 @@
+import { afterAll, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const root = mkdtempSync(join(tmpdir(), 'arra-export-verify-'));
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = join(root, 'oracle.db');
+
+const dbModule = await import('../../../src/db/index.ts');
+const exporterModule = await import('../../../tools/export-app/exporter.ts');
+const appModule = await import('../../../tools/export-app/index.ts');
+const verifyModule = await import('../../../tools/export-app/verify.ts');
+
+const { createDatabase, resetDefaultDatabaseForTests } = dbModule;
+const { exportOracleData } = exporterModule;
+const { runExportApp } = appModule;
+const { verifyExportBundle } = verifyModule;
+
+function restoreDbPath(): string {
+  return savedDbPath
+    ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
+}
+
+afterAll(() => {
+  if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = savedDataDir;
+  if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = savedDbPath;
+  resetDefaultDatabaseForTests(restoreDbPath());
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('export bundle verifier checks manifest file inventory checksums', async () => {
+  const connection = createDatabase(join(root, 'verify.db'));
+  const outputDir = join(root, 'verify-export');
+  try {
+    await exportOracleData({ connection, outputDir, progress: () => {} });
+  } finally {
+    connection.storage.close();
+  }
+
+  await expect(verifyExportBundle(outputDir)).resolves.toMatchObject({
+    ok: true,
+    fileCount: expect.any(Number),
+    errors: [],
+  });
+
+  writeFileSync(join(outputDir, 'README.md'), 'corrupted export bundle');
+  const broken = await verifyExportBundle(outputDir);
+  expect(broken.ok).toBe(false);
+  expect(broken.errors.some((line) => line.includes('README.md: sha256'))).toBe(true);
+});
+
+test('CLI --verify reports structured success and failure', async () => {
+  const connection = createDatabase(join(root, 'verify-cli.db'));
+  const outputDir = join(root, 'verify-cli-export');
+  const stdout: string[] = [];
+  try {
+    await exportOracleData({ connection, outputDir, progress: () => {} });
+  } finally {
+    connection.storage.close();
+  }
+
+  expect(await runExportApp(['--verify', outputDir], (msg) => stdout.push(msg), () => {})).toBe(0);
+  expect(JSON.parse(stdout.join(''))).toMatchObject({ success: true, verified: true });
+
+  stdout.length = 0;
+  writeFileSync(join(outputDir, 'README.md'), 'broken');
+  expect(await runExportApp(['--verify', outputDir], (msg) => stdout.push(msg), () => {})).toBe(1);
+  expect(JSON.parse(stdout.join(''))).toMatchObject({ success: false, verified: false });
+});

--- a/tools/export-app/README.md
+++ b/tools/export-app/README.md
@@ -69,6 +69,7 @@ bun run tools/export-app/index.ts --output ./backup/export-app
 bun run tools/export-app/index.ts --output ./backup/export-app --db ./oracle.db
 bun run tools/export-app/index.ts --output ./backup/export-app --dry-run
 bun run tools/export-app/index.ts --output ./backup/export-app --progress json
+bun run tools/export-app/index.ts --verify ./backup/export-app
 ```
 
 Use `--dry-run` to print collection, row, relationship, and document counts
@@ -95,6 +96,8 @@ It also includes `collections.<table>.rowCount` so restore/preflight tooling can
 compare source and destination collection sizes without loading every artifact.
 The generated bundle `README.md` summarizes counts and verification steps for
 offline review before migration.
+Run `--verify <dir>` after copying an export bundle to recompute every
+manifest-listed file size and SHA-256 checksum.
 Progress writes to stderr by default as collection counts, percentages, and row
 counts. Use `--progress json` or `--progress-json` for machine-readable events,
 `--progress silent` or `--quiet` when another wrapper owns progress display.

--- a/tools/export-app/index.ts
+++ b/tools/export-app/index.ts
@@ -2,6 +2,7 @@ import { existsSync, statSync } from 'node:fs';
 import { DB_PATH } from '../../src/config.ts';
 import { exportOracleData, type ExportProgressEvent } from './exporter.ts';
 import { previewOracleExport } from './summary.ts';
+import { verifyExportBundle } from './verify.ts';
 
 type Writer = (message: string) => void;
 type ProgressMode = 'text' | 'json' | 'silent';
@@ -12,6 +13,7 @@ interface CliOptions {
   quiet: boolean;
   progressMode: ProgressMode;
   dryRun: boolean;
+  verifyDir?: string;
 }
 
 function flagValue(args: string[], index: number, flag: string): string {
@@ -34,18 +36,22 @@ export function parseArgs(args: string[]): CliOptions {
   let quiet = false;
   let progressMode: ProgressMode = 'text';
   let dryRun = false;
+  let verifyDir: string | undefined;
 
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i]!;
     const outputAssigned = assignedValue(arg, '--output');
     const dbAssigned = assignedValue(arg, '--db');
     const progressAssigned = assignedValue(arg, '--progress');
+    const verifyAssigned = assignedValue(arg, '--verify');
     if (outputAssigned !== undefined) { outputDir = outputAssigned; continue; }
     if (dbAssigned !== undefined) { dbPath = dbAssigned; continue; }
     if (progressAssigned !== undefined) { progressMode = readProgressMode(progressAssigned); continue; }
+    if (verifyAssigned !== undefined) { verifyDir = verifyAssigned; continue; }
     if (arg === '--output' || arg === '-o') { outputDir = flagValue(args, i, arg); i += 1; continue; }
     if (arg === '--db') { dbPath = flagValue(args, i, arg); i += 1; continue; }
     if (arg === '--progress') { progressMode = readProgressMode(flagValue(args, i, arg)); i += 1; continue; }
+    if (arg === '--verify') { verifyDir = flagValue(args, i, arg); i += 1; continue; }
     if (arg === '--quiet' || arg === '--no-progress') { quiet = true; continue; }
     if (arg === '--progress-json') { progressMode = 'json'; continue; }
     if (arg === '--dry-run') { dryRun = true; continue; }
@@ -53,8 +59,8 @@ export function parseArgs(args: string[]): CliOptions {
     throw new Error(arg.startsWith('-') ? `unknown flag: ${arg}` : `unexpected argument: ${arg}`);
   }
 
-  if (!outputDir) throw new Error('missing required --output <dir>');
-  return { outputDir, dbPath, quiet, progressMode, dryRun };
+  if (!outputDir && !verifyDir) throw new Error('missing required --output <dir>');
+  return { outputDir: outputDir ?? verifyDir!, dbPath, quiet, progressMode, dryRun, verifyDir };
 }
 
 function readProgressMode(value: string): ProgressMode {
@@ -91,6 +97,7 @@ function printHelp(write: Writer): void {
     '  --db <path>          SQLite database path (defaults to ORACLE_DB_PATH)',
     '  --progress <mode>    progress output: text, json, or silent',
     '  --dry-run            print collection counts without writing files',
+    '  --verify <dir>       verify manifest file sizes and SHA-256 checksums',
     '  --quiet              suppress progress output',
     '  --no-progress        alias for --quiet',
     '  --progress-json      emit progress as JSON lines on stderr',
@@ -119,6 +126,11 @@ export async function runExportApp(args: string[], stdout: Writer = process.stdo
       return 0;
     }
     const options = parseArgs(args);
+    if (options.verifyDir) {
+      const result = await verifyExportBundle(options.verifyDir);
+      stdout(`${JSON.stringify({ success: result.ok, verified: result.ok, ...result }, null, 2)}\n`);
+      return result.ok ? 0 : 1;
+    }
     validateCliOptions(options);
     if (options.dryRun) {
       stdout(`${JSON.stringify({ success: true, dryRun: true, ...previewOracleExport({ dbPath: options.dbPath }) }, null, 2)}\n`);

--- a/tools/export-app/verify.ts
+++ b/tools/export-app/verify.ts
@@ -1,0 +1,73 @@
+import { createHash } from 'node:crypto';
+import { readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+
+type ManifestFile = {
+  path: string;
+  bytes: number;
+  sha256: string;
+};
+
+export interface ExportBundleVerification {
+  ok: boolean;
+  bundleDir: string;
+  fileCount: number;
+  errors: string[];
+}
+
+function containedPath(baseDir: string, relativePath: string): string | null {
+  const resolvedBase = path.resolve(baseDir);
+  const resolved = path.resolve(resolvedBase, relativePath);
+  return resolved === resolvedBase || resolved.startsWith(`${resolvedBase}${path.sep}`) ? resolved : null;
+}
+
+async function sha256(filePath: string): Promise<string> {
+  return createHash('sha256').update(await readFile(filePath)).digest('hex');
+}
+
+function manifestFiles(value: unknown): ManifestFile[] {
+  if (!value || typeof value !== 'object' || !Array.isArray((value as { files?: unknown }).files)) {
+    throw new Error('manifest.json missing files inventory');
+  }
+  return (value as { files: ManifestFile[] }).files;
+}
+
+export async function verifyExportBundle(bundleDir: string): Promise<ExportBundleVerification> {
+  const root = path.resolve(bundleDir);
+  const errors: string[] = [];
+  let files: ManifestFile[] = [];
+
+  try {
+    files = manifestFiles(JSON.parse(await readFile(path.join(root, 'manifest.json'), 'utf8')));
+  } catch (error) {
+    return {
+      ok: false,
+      bundleDir: root,
+      fileCount: 0,
+      errors: [error instanceof Error ? error.message : String(error)],
+    };
+  }
+
+  for (let index = 0; index < files.length; index += 1) {
+    const file = files[index]!;
+    if (!file || typeof file.path !== 'string' || typeof file.bytes !== 'number' || typeof file.sha256 !== 'string') {
+      errors.push(`files[${index}]: invalid inventory entry`);
+      continue;
+    }
+    const target = containedPath(root, file.path);
+    if (!target) {
+      errors.push(`${file.path}: escapes export bundle`);
+      continue;
+    }
+    try {
+      const [info, digest] = await Promise.all([stat(target), sha256(target)]);
+      if (!info.isFile()) errors.push(`${file.path}: not a file`);
+      if (info.size !== file.bytes) errors.push(`${file.path}: bytes ${info.size} !== ${file.bytes}`);
+      if (digest !== file.sha256) errors.push(`${file.path}: sha256 ${digest} !== ${file.sha256}`);
+    } catch (error) {
+      errors.push(`${file.path}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  return { ok: errors.length === 0, bundleDir: root, fileCount: files.length, errors };
+}


### PR DESCRIPTION
## Summary
- add standalone export bundle verifier for manifest-listed file sizes and SHA-256 checksums
- add CLI `--verify <dir>` mode that returns structured success/failure JSON
- document verification flow for migration-safe backups

## Tests
- bun test tests/tools/export-app/ tests/tools/export-app.test.ts
- bunx tsc --noEmit

Refs #1783