### PR TITLE
test: lock learn malformed JSON status

### DIFF
--- a/tests/http/knowledge.test.ts
+++ b/tests/http/knowledge.test.ts
@@ -78,6 +78,7 @@ describe("HTTP Contract — search / knowledge / supersede", () => {
       const res = await fetch(`${BASE_URL}/api/learn`, { method: "POST", headers: JSON_HEADERS, body: "{not json" });
       const body = await res.json();
       expect(res.status).toBe(400);
+      expect(res.status).not.toBe(500);
       expect(res.headers.get("content-type")).toContain("application/json");
       expect(body).toMatchObject({ success: false, error: "Bad Request", code: 400 });
     });


### PR DESCRIPTION
Refs #1718

## Summary
- strengthen the HTTP knowledge contract test so malformed `/api/learn` JSON is explicitly not treated as a 500
- preserves the current structured 400 Bad Request response contract

## Validation
- bunx tsc --noEmit
- bun test tests/http/knowledge.test.ts tests/http/learn/crud.test.ts tests/http/errors/structured-errors.test.ts
- git diff --check
- wc -l tests/http/knowledge.test.ts