### PR TITLE
fix: scope activity logs by tenant

### DIFF
--- a/src/routes/dashboard/session-stats.ts
+++ b/src/routes/dashboard/session-stats.ts
@@ -1,7 +1,16 @@
 import { Elysia } from 'elysia';
-import { gt, sql } from 'drizzle-orm';
+import { and, eq, gt, sql, type SQL } from 'drizzle-orm';
 import { db, searchLog, learnLog, isDbLockError } from '../../db/index.ts';
 import { SessionStatsQuery } from './model.ts';
+import { currentTenantId } from '../../middleware/tenant.ts';
+
+type TenantLogTable = { tenantId: unknown };
+
+function scoped<T extends TenantLogTable>(table: T, condition: SQL): SQL {
+  const tenantId = currentTenantId();
+  const tenantFilter = tenantId ? eq(table.tenantId as never, tenantId) : undefined;
+  return tenantFilter ? and(condition, tenantFilter)! : condition;
+}
 
 export const sessionStatsEndpoint = new Elysia().get('/session/stats', ({ query }) => {
   const since = query.since;
@@ -10,12 +19,12 @@ export const sessionStatsEndpoint = new Elysia().get('/session/stats', ({ query 
   try {
     const searches = db.select({ count: sql<number>`count(*)` })
       .from(searchLog)
-      .where(gt(searchLog.createdAt, sinceTime))
+      .where(scoped(searchLog, gt(searchLog.createdAt, sinceTime)))
       .get();
 
     const learnings = db.select({ count: sql<number>`count(*)` })
       .from(learnLog)
-      .where(gt(learnLog.createdAt, sinceTime))
+      .where(scoped(learnLog, gt(learnLog.createdAt, sinceTime)))
       .get();
 
     return {

--- a/src/routes/files/logs.ts
+++ b/src/routes/files/logs.ts
@@ -1,13 +1,15 @@
 import { Elysia } from 'elysia';
-import { desc } from 'drizzle-orm';
+import { desc, eq } from 'drizzle-orm';
 import { db, searchLog } from '../../db/index.ts';
 import { logsQuery } from './model.ts';
+import { currentTenantId } from '../../middleware/tenant.ts';
 
 export const logsRoute = new Elysia().get(
   '/api/logs',
   ({ query }) => {
     try {
       const limit = parseInt(query.limit || '20');
+      const tenantId = currentTenantId();
       const logs = db
         .select({
           id: searchLog.id,
@@ -21,6 +23,7 @@ export const logsRoute = new Elysia().get(
           results: searchLog.results,
         })
         .from(searchLog)
+        .where(tenantId ? eq(searchLog.tenantId, tenantId) : undefined)
         .orderBy(desc(searchLog.createdAt))
         .limit(limit)
         .all();

--- a/tests/http/tenant/logs-session-isolation.test.ts
+++ b/tests/http/tenant/logs-session-isolation.test.ts
@@ -1,0 +1,57 @@
+import { afterAll, expect, test } from 'bun:test';
+import { inArray } from 'drizzle-orm';
+import { db, learnLog, resetDefaultDatabaseForTests, searchLog } from '../../../src/db/index.ts';
+import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
+import { sessionStatsEndpoint } from '../../../src/routes/dashboard/session-stats.ts';
+import { logsRoute } from '../../../src/routes/files/logs.ts';
+
+resetDefaultDatabaseForTests();
+
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantA = `tenant-a-${stamp}`;
+const tenantB = `tenant-b-${stamp}`;
+const queryA = `tenant log a ${stamp}`;
+const queryB = `tenant log b ${stamp}`;
+const docA = `tenant-log-doc-a-${stamp}`;
+const docB = `tenant-log-doc-b-${stamp}`;
+const future = Date.now() + 60_000;
+
+function tenantRequest(handler: { handle: (request: Request) => Response | Promise<Response> }, tenantId: string, path: string) {
+  return createTenantFetch((request) => handler.handle(request))(new Request(`http://local${path}`, {
+    headers: { [TENANT_HEADER]: tenantId },
+  }));
+}
+
+db.insert(searchLog).values([
+  { query: queryA, tenantId: tenantA, mode: 'fts', resultsCount: 1, searchTimeMs: 3, createdAt: future },
+  { query: queryB, tenantId: tenantB, mode: 'fts', resultsCount: 1, searchTimeMs: 4, createdAt: future },
+]).run();
+
+db.insert(learnLog).values([
+  { documentId: docA, tenantId: tenantA, patternPreview: queryA, concepts: '[]', createdAt: future },
+  { documentId: docB, tenantId: tenantB, patternPreview: queryB, concepts: '[]', createdAt: future },
+]).run();
+
+afterAll(() => {
+  db.delete(searchLog).where(inArray(searchLog.query, [queryA, queryB])).run();
+  db.delete(learnLog).where(inArray(learnLog.documentId, [docA, docB])).run();
+});
+
+test('/api/logs returns only the selected tenant search log rows', async () => {
+  const res = await tenantRequest(logsRoute, tenantA, '/api/logs?limit=20');
+  const body = await res.json() as { logs: Array<{ query: string }> };
+  const queries = body.logs.map((log) => log.query);
+
+  expect(res.status).toBe(200);
+  expect(queries).toContain(queryA);
+  expect(queries).not.toContain(queryB);
+});
+
+test('/session/stats counts only selected tenant search and learn logs', async () => {
+  const since = future - 1;
+  const resA = await tenantRequest(sessionStatsEndpoint, tenantA, `/session/stats?since=${since}`);
+  const resB = await tenantRequest(sessionStatsEndpoint, tenantB, `/session/stats?since=${since}`);
+
+  expect(await resA.json()).toMatchObject({ searches: 1, learnings: 1, since });
+  expect(await resB.json()).toMatchObject({ searches: 1, learnings: 1, since });
+});


### PR DESCRIPTION
## Summary
- scope `/api/logs` search-log history by the active tenant context
- scope `/session/stats` search/learn counts by tenant-owned log rows
- add regression coverage proving tenant A cannot see tenant B log/session activity

## Validation
- `bunx tsc --noEmit`
- `ORACLE_DATA_DIR=$(mktemp -d) ORACLE_DB_PATH=$ORACLE_DATA_DIR/oracle.db ORACLE_REPO_ROOT=$ORACLE_DATA_DIR bun test tests/http/tenant/logs-session-isolation.test.ts tests/http/tenant/` (21 pass)
- changed files <=250 lines

Refs #1650
