### PR TITLE
fix: scope vector search by tenant

### DIFF
--- a/src/routes/vector/search.ts
+++ b/src/routes/vector/search.ts
@@ -1,5 +1,5 @@
-/** GET /api/vector/search - vector search with filters, pagination, and sort. */
 import { Elysia, t } from 'elysia';
+import { currentTenantId } from '../../middleware/tenant.ts';
 import { getEmbeddingModels, getVectorStoreByModel } from '../../vector/factory.ts';
 import type { VectorQueryResult, VectorStoreAdapter } from '../../vector/types.ts';
 import type { SearchResult } from '../../server/types.ts';
@@ -15,9 +15,7 @@ interface VectorSearchDeps {
 
 type SearchHit = SearchResult & { metadata: Record<string, unknown> };
 
-const DEFAULT_COLLECTION = 'bge-m3';
-const MAX_LIMIT = 100;
-const MAX_FETCH = 1_000;
+const DEFAULT_COLLECTION = 'bge-m3', MAX_LIMIT = 100, MAX_FETCH = 1_000;
 const dateKeys = ['created_at', 'createdAt', 'updated_at', 'updatedAt', 'indexed_at', 'indexedAt', 'date'];
 const sortFields = new Set<SortField>(['score', 'distance', 'date', 'id', 'type', 'source_file']);
 const stringQuery = t.Optional(t.String());
@@ -201,6 +199,8 @@ export function createVectorSearchEndpoint(deps: VectorSearchDeps = {}) {
     let metadata: Record<string, unknown>;
     try {
       metadata = metadataFilters(request, query.type);
+      const tenantId = currentTenantId();
+      if (tenantId) metadata.tenant_id = tenantId;
     } catch (error) {
       set.status = 400;
       return { error: 'Invalid metadata filter', message: error instanceof Error ? error.message : String(error) };

--- a/tests/http/vector/search.test.ts
+++ b/tests/http/vector/search.test.ts
@@ -1,6 +1,7 @@
 import { expect, mock, test } from 'bun:test';
 import { Elysia } from 'elysia';
 import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
 import { createVectorSearchEndpoint } from '../../../src/routes/vector/search.ts';
 import type { VectorQueryResult } from '../../../src/vector/types.ts';
 
@@ -81,6 +82,30 @@ test('GET /api/v1/vector/search accepts JSON metadata filters and distance sort'
   expect(res.status).toBe(200);
   expect(body.sort).toEqual({ field: 'distance', order: 'asc' });
   expect(body.results.map((item) => item.id)).toEqual(['doc-b', 'doc-a']);
+});
+
+test('GET /api/v1/vector/search scopes results by resolved tenant', async () => {
+  const tenantResult: VectorQueryResult = {
+    ids: ['doc-a', 'doc-b'],
+    documents: ['alpha tenant', 'beta tenant'],
+    distances: [0.1, 0.2],
+    metadatas: [
+      { type: 'note', tenant_id: 'tenant-a', source_file: 'notes/a.md' },
+      { type: 'note', tenant_id: 'tenant-b', source_file: 'notes/b.md' },
+    ],
+  };
+  const { fetcher, store } = createFetch(tenantResult);
+  const tenantFetch = createTenantFetch(fetcher);
+  const res = await tenantFetch(new Request(
+    'http://local/api/v1/vector/search?q=oracle&metadata.tenant_id=tenant-b',
+    { headers: { [TENANT_HEADER]: 'tenant-a' } },
+  ));
+  const body = await res.json() as { results: Array<{ id: string }>; filters: { metadata: Record<string, string> } };
+
+  expect(res.status).toBe(200);
+  expect(store.query).toHaveBeenCalledWith('oracle', 50, { tenant_id: 'tenant-a' });
+  expect(body.filters.metadata).toEqual({ tenant_id: 'tenant-a' });
+  expect(body.results.map((item) => item.id)).toEqual(['doc-a']);
 });
 
 test('GET /api/v1/vector/search rejects bad filters and unknown collections', async () => {


### PR DESCRIPTION
## Summary
- derive the validated tenant context inside /api/v1/vector/search
- force tenant_id into vector metadata filters so request metadata cannot override it
- add regression coverage proving tenant A vector search cannot return tenant B hits

## Verification
- ORACLE_DB_PATH=$(mktemp -d)/oracle.db bun test tests/http/vector/search.test.ts tests/http/tenant/http-isolation.test.ts tests/http/tenant/isolation.test.ts
- bunx tsc --noEmit
- wc -l src/routes/vector/search.ts tests/http/vector/search.test.ts