### PR TITLE
feat(export): verify standalone backup bundles

### DIFF
--- a/tests/tools/export-app/verify.test.ts
+++ b/tests/tools/export-app/verify.test.ts
@@ -1,0 +1,99 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const root = mkdtempSync(join(tmpdir(), 'arra-export-verify-'));
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = join(root, 'oracle.db');
+
+const dbModule = await import('../../../src/db/index.ts');
+const appModule = await import('../../../tools/export-app/index.ts');
+const exporterModule = await import('../../../tools/export-app/exporter.ts');
+const verifyModule = await import('../../../tools/export-app/verify.ts');
+
+const { createDatabase, oracleDocuments, resetDefaultDatabaseForTests } = dbModule;
+const { runExportApp, parseArgs } = appModule;
+const { exportOracleData } = exporterModule;
+const { verifyExportBundle } = verifyModule;
+
+function restoreDbPath(): string {
+  return savedDbPath
+    ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
+}
+
+async function writeBundle(outputDir: string): Promise<void> {
+  const connection = createDatabase(join(root, `${outputDir.split('/').pop()}.db`));
+  connection.db.insert(oracleDocuments).values({
+    id: 'doc-verify',
+    type: 'learning',
+    sourceFile: 'ψ/learn/verify.md',
+    concepts: '["backup"]',
+    createdAt: 1,
+    updatedAt: 2,
+    indexedAt: 3,
+  }).run();
+  connection.sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)').run(
+    'doc-verify',
+    'Verifier body',
+    'backup',
+  );
+  try {
+    await exportOracleData({ connection, outputDir, progress: () => {} });
+  } finally {
+    connection.storage.close();
+  }
+}
+
+afterAll(() => {
+  if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = savedDataDir;
+  if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = savedDbPath;
+  resetDefaultDatabaseForTests(restoreDbPath());
+  if (existsSync(root)) rmSync(root, { recursive: true });
+});
+
+describe('export bundle verifier', () => {
+  test('passes for a fresh export bundle and the CLI verify flag', async () => {
+    const outputDir = join(root, 'ok-bundle');
+    await writeBundle(outputDir);
+
+    await expect(verifyExportBundle(outputDir)).resolves.toMatchObject({
+      ok: true,
+      checkedFiles: expect.any(Number),
+      errors: [],
+      documentCount: 1,
+    });
+
+    const stdout: string[] = [];
+    const code = await runExportApp(['--verify', outputDir], (message) => stdout.push(message), () => {});
+    const payload = JSON.parse(stdout.join(''));
+    expect(code).toBe(0);
+    expect(payload).toMatchObject({ success: true, ok: true, documentCount: 1 });
+  });
+
+  test('fails when a listed file no longer matches manifest checksums', async () => {
+    const outputDir = join(root, 'corrupt-bundle');
+    await writeBundle(outputDir);
+    writeFileSync(join(outputDir, 'README.md'), `${readFileSync(join(outputDir, 'README.md'), 'utf8')}\ncorrupt`);
+
+    const result = await verifyExportBundle(outputDir);
+    expect(result.ok).toBe(false);
+    expect(result.errors.join('\n')).toContain('README.md');
+    expect(result.errors.join('\n')).toContain('sha256 mismatch');
+
+    const stderr: string[] = [];
+    const code = await runExportApp(['--verify', outputDir], () => {}, (message) => stderr.push(message));
+    expect(code).toBe(1);
+    expect(stderr.join('')).toBe('');
+  });
+
+  test('parses verify mode without requiring output', () => {
+    expect(parseArgs(['--verify', './backup'])).toMatchObject({ verifyDir: './backup' });
+    expect(() => parseArgs(['--verify', './backup', '--output', './other']))
+      .toThrow('--verify cannot be combined with --output');
+  });
+});

--- a/tools/export-app/README.md
+++ b/tools/export-app/README.md
@@ -69,6 +69,7 @@ bun run tools/export-app/index.ts --output ./backup/export-app
 bun run tools/export-app/index.ts --output ./backup/export-app --db ./oracle.db
 bun run tools/export-app/index.ts --output ./backup/export-app --dry-run
 bun run tools/export-app/index.ts --output ./backup/export-app --progress json
+bun run tools/export-app/index.ts --verify ./backup/export-app
 ```
 
 Use `--dry-run` to print collection, row, relationship, and document counts
@@ -95,6 +96,9 @@ It also includes `collections.<table>.rowCount` so restore/preflight tooling can
 compare source and destination collection sizes without loading every artifact.
 The generated bundle `README.md` summarizes counts and verification steps for
 offline review before migration.
+Run `--verify <bundle-dir>` after export to re-read `manifest.json`, recompute
+each listed file's byte count and SHA-256 checksum, and fail if a required
+bundle artifact is missing.
 Progress writes to stderr by default as collection counts, percentages, and row
 counts. Use `--progress json` or `--progress-json` for machine-readable events,
 `--progress silent` or `--quiet` when another wrapper owns progress display.

--- a/tools/export-app/bundle-readme.ts
+++ b/tools/export-app/bundle-readme.ts
@@ -39,5 +39,7 @@ export function exportBundleReadme(input: ExportBundleReadmeInput): string {
     '3. Recompute SHA-256 for files listed in `manifest.json.files`.',
     '4. Inspect Markdown documents before migration or restore work.',
     '',
+    'CLI shortcut: `bun run tools/export-app/index.ts --verify <bundle-dir>`.',
+    '',
   ].join('\n');
 }

--- a/tools/export-app/index.ts
+++ b/tools/export-app/index.ts
@@ -2,13 +2,15 @@ import { existsSync, statSync } from 'node:fs';
 import { DB_PATH } from '../../src/config.ts';
 import { exportOracleData, type ExportProgressEvent } from './exporter.ts';
 import { previewOracleExport } from './summary.ts';
+import { verifyExportBundle } from './verify.ts';
 
 type Writer = (message: string) => void;
 type ProgressMode = 'text' | 'json' | 'silent';
 
 interface CliOptions {
-  outputDir: string;
+  outputDir?: string;
   dbPath?: string;
+  verifyDir?: string;
   quiet: boolean;
   progressMode: ProgressMode;
   dryRun: boolean;
@@ -31,6 +33,7 @@ function assignedValue(arg: string, flag: string): string | undefined {
 export function parseArgs(args: string[]): CliOptions {
   let outputDir: string | undefined;
   let dbPath: string | undefined;
+  let verifyDir: string | undefined;
   let quiet = false;
   let progressMode: ProgressMode = 'text';
   let dryRun = false;
@@ -39,12 +42,15 @@ export function parseArgs(args: string[]): CliOptions {
     const arg = args[i]!;
     const outputAssigned = assignedValue(arg, '--output');
     const dbAssigned = assignedValue(arg, '--db');
+    const verifyAssigned = assignedValue(arg, '--verify');
     const progressAssigned = assignedValue(arg, '--progress');
     if (outputAssigned !== undefined) { outputDir = outputAssigned; continue; }
     if (dbAssigned !== undefined) { dbPath = dbAssigned; continue; }
+    if (verifyAssigned !== undefined) { verifyDir = verifyAssigned; continue; }
     if (progressAssigned !== undefined) { progressMode = readProgressMode(progressAssigned); continue; }
     if (arg === '--output' || arg === '-o') { outputDir = flagValue(args, i, arg); i += 1; continue; }
     if (arg === '--db') { dbPath = flagValue(args, i, arg); i += 1; continue; }
+    if (arg === '--verify') { verifyDir = flagValue(args, i, arg); i += 1; continue; }
     if (arg === '--progress') { progressMode = readProgressMode(flagValue(args, i, arg)); i += 1; continue; }
     if (arg === '--quiet' || arg === '--no-progress') { quiet = true; continue; }
     if (arg === '--progress-json') { progressMode = 'json'; continue; }
@@ -53,8 +59,9 @@ export function parseArgs(args: string[]): CliOptions {
     throw new Error(arg.startsWith('-') ? `unknown flag: ${arg}` : `unexpected argument: ${arg}`);
   }
 
-  if (!outputDir) throw new Error('missing required --output <dir>');
-  return { outputDir, dbPath, quiet, progressMode, dryRun };
+  if (verifyDir && outputDir) throw new Error('--verify cannot be combined with --output');
+  if (!verifyDir && !outputDir) throw new Error('missing required --output <dir>');
+  return { outputDir, dbPath, verifyDir, quiet, progressMode, dryRun };
 }
 
 function readProgressMode(value: string): ProgressMode {
@@ -76,8 +83,9 @@ function requireOutputTarget(path: string): void {
 }
 
 export function validateCliOptions(options: CliOptions): void {
+  if (options.verifyDir) return;
   requireFile(options.dbPath ?? DB_PATH);
-  requireOutputTarget(options.outputDir);
+  requireOutputTarget(options.outputDir!);
 }
 
 function printHelp(write: Writer): void {
@@ -89,6 +97,7 @@ function printHelp(write: Writer): void {
     'Flags:',
     '  --output, -o <dir>   destination backup directory',
     '  --db <path>          SQLite database path (defaults to ORACLE_DB_PATH)',
+    '  --verify <dir>       verify an existing export bundle manifest/checksums',
     '  --progress <mode>    progress output: text, json, or silent',
     '  --dry-run            print collection counts without writing files',
     '  --quiet              suppress progress output',
@@ -120,13 +129,18 @@ export async function runExportApp(args: string[], stdout: Writer = process.stdo
     }
     const options = parseArgs(args);
     validateCliOptions(options);
+    if (options.verifyDir) {
+      const result = await verifyExportBundle(options.verifyDir);
+      stdout(`${JSON.stringify({ success: result.ok, ...result }, null, 2)}\n`);
+      return result.ok ? 0 : 1;
+    }
     if (options.dryRun) {
       stdout(`${JSON.stringify({ success: true, dryRun: true, ...previewOracleExport({ dbPath: options.dbPath }) }, null, 2)}\n`);
       return 0;
     }
     const progress = progressWriter(options, stderr);
     const result = await exportOracleData({
-      outputDir: options.outputDir,
+      outputDir: options.outputDir!,
       dbPath: options.dbPath,
       progress,
     });

--- a/tools/export-app/verify.ts
+++ b/tools/export-app/verify.ts
@@ -1,0 +1,106 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { exportFileInventory, type ExportFileInventoryEntry } from './inventory.ts';
+
+export interface ExportBundleVerification {
+  ok: boolean;
+  bundleDir: string;
+  checkedFiles: number;
+  errors: string[];
+  exportedAt?: string;
+  collectionCount?: number;
+  rowCount?: number;
+  relationshipCount?: number;
+  documentCount?: number;
+}
+
+type Manifest = {
+  exportedAt?: string;
+  files?: ExportFileInventoryEntry[];
+  collectionCount?: number;
+  rowCount?: number;
+  relationshipCount?: number;
+  documentCount?: number;
+};
+
+export async function verifyExportBundle(bundleDir: string): Promise<ExportBundleVerification> {
+  const root = path.resolve(bundleDir);
+  const errors: string[] = [];
+  const manifest = await readManifest(path.join(root, 'manifest.json'), errors);
+  if (!manifest) return result(root, errors, 0);
+
+  const expected = Array.isArray(manifest.files) ? manifest.files : [];
+  if (!Array.isArray(manifest.files)) errors.push('manifest.files must be an array');
+  const actual = await inventory(root, errors);
+  const actualByPath = new Map(actual.map((entry) => [entry.path, entry]));
+  const expectedPaths = new Set(expected.map((entry) => entry.path));
+
+  for (const entry of expected) verifyEntry(entry, actualByPath.get(entry.path), errors);
+  for (const entry of actual) {
+    if (!expectedPaths.has(entry.path)) errors.push(`unexpected file not listed in manifest: ${entry.path}`);
+  }
+  for (const file of requiredFiles(manifest)) {
+    if (!expectedPaths.has(file)) errors.push(`required file missing from manifest: ${file}`);
+  }
+
+  return {
+    ...result(root, errors, expected.length),
+    exportedAt: manifest.exportedAt,
+    collectionCount: manifest.collectionCount,
+    rowCount: manifest.rowCount,
+    relationshipCount: manifest.relationshipCount,
+    documentCount: manifest.documentCount,
+  };
+}
+
+async function readManifest(file: string, errors: string[]): Promise<Manifest | null> {
+  try {
+    const manifest = JSON.parse(await readFile(file, 'utf8')) as Manifest;
+    if (!manifest || typeof manifest !== 'object') {
+      errors.push('manifest.json must contain an object');
+      return null;
+    }
+    return manifest;
+  } catch (cause) {
+    errors.push(`cannot read manifest.json: ${cause instanceof Error ? cause.message : String(cause)}`);
+    return null;
+  }
+}
+
+async function inventory(root: string, errors: string[]): Promise<ExportFileInventoryEntry[]> {
+  try {
+    return await exportFileInventory(root, { exclude: ['manifest.json'] });
+  } catch (cause) {
+    errors.push(`cannot inventory bundle: ${cause instanceof Error ? cause.message : String(cause)}`);
+    return [];
+  }
+}
+
+function verifyEntry(expected: ExportFileInventoryEntry, actual: ExportFileInventoryEntry | undefined, errors: string[]): void {
+  if (!actual) {
+    errors.push(`missing file: ${expected.path}`);
+    return;
+  }
+  if (actual.bytes !== expected.bytes) {
+    errors.push(`byte mismatch for ${expected.path}: expected ${expected.bytes}, got ${actual.bytes}`);
+  }
+  if (actual.sha256 !== expected.sha256) {
+    errors.push(`sha256 mismatch for ${expected.path}`);
+  }
+}
+
+function requiredFiles(manifest: Manifest): string[] {
+  const formats = ['json', 'csv', 'md'];
+  return [
+    'README.md',
+    'all-collections.json',
+    'manifest.schema.json',
+    'documents/index.json',
+    'documents/documents.csv',
+    ...formats.map((format) => `relationships.${format}`),
+  ].filter((file) => manifest.documentCount !== 0 || !file.startsWith('documents/'));
+}
+
+function result(root: string, errors: string[], checkedFiles: number): ExportBundleVerification {
+  return { ok: errors.length === 0, bundleDir: root, checkedFiles, errors };
+}


### PR DESCRIPTION
## Summary
- add standalone export bundle verifier for manifest file inventory, byte counts, checksums, and required artifacts
- expose `tools/export-app` CLI `--verify <bundle-dir>` mode
- document the verification shortcut in export-app docs and generated bundle README

## Validation
- `bunx tsc --noEmit`
- `ORACLE_DATA_DIR=$(mktemp -d) ORACLE_DB_PATH=$ORACLE_DATA_DIR/oracle.db bun test --isolate tests/tools/export-app/verify.test.ts tests/tools/export-app/export-app.test.ts tests/tools/export-app/manifest-schema.test.ts tests/tools/export-app/csv-safety.test.ts tests/tools/export-app.test.ts tests/cli/export/help-version.test.ts` (23 pass)
- `git diff --check HEAD~1..HEAD`
- changed file line-count gate: all changed files <=250 lines

Refs #1783