### PR TITLE
feat(cli): accept primary flag for vector config add

### DIFF
--- a/src/plugins/__tests__/arra-plugin.test.ts
+++ b/src/plugins/__tests__/arra-plugin.test.ts
@@ -147,6 +147,10 @@ describe("built-in arra plugin", () => {
       expect(set.ok).toBe(true);
       expect(calls.at(-1)).toMatchObject({ method: "PUT", path: "/api/v1/vector/config/phase1", body: { adapter: "qdrant", endpoint: "http://localhost:6333" } });
 
+      const added = await arraCli({ source: "cli", plugin: "arra", args: ["vector-config", "add", "qwen3", "--model", "qwen3-embedding", "--primary"] });
+      expect(added.ok).toBe(true);
+      expect(calls.at(-1)).toMatchObject({ method: "POST", path: "/api/v1/vector/config/qwen3", body: { model: "qwen3-embedding", primary: true } });
+
       const blocked = await arraCli({ source: "cli", plugin: "arra", args: ["vector-config", "remove", "phase1"] });
       expect(blocked).toEqual({ ok: false, error: "remove requires --yes" });
 

--- a/src/plugins/arra/vector-config-cli.ts
+++ b/src/plugins/arra/vector-config-cli.ts
@@ -101,14 +101,17 @@ function fieldPayload(args: string[]): Record<string, unknown> {
   const rest = clean(args);
   const payload: Record<string, unknown> = {};
   if (rest[0]?.startsWith("--") || rest.some((arg) => arg.startsWith("--"))) {
-    for (let i = 0; i < rest.length; i += 2) {
+    for (let i = 0; i < rest.length; i += 1) {
       const field = rest[i]?.replace(/^--/, "").replace(/^url$/, "endpoint");
-      const value = rest[i + 1];
-      if (!field || !value)
-        throw new Error(
-          "usage: vector-config set <collection> --field <value>",
-        );
-      payload[field] = field === "enabled" ? bool(value) : value;
+      const next = rest[i + 1];
+      if (!field) throw new Error("usage: vector-config set <collection> --field <value>");
+      if (field === "primary" && (next === undefined || next.startsWith("--"))) {
+        payload.primary = true;
+        continue;
+      }
+      if (!next || next.startsWith("--")) throw new Error("usage: vector-config set <collection> --field <value>");
+      payload[field] = field === "enabled" || field === "primary" ? bool(next) : next;
+      i += 1;
     }
     return payload;
   }

--- a/tests/tools/maw-plugin-arra/vector-config-ops.test.ts
+++ b/tests/tools/maw-plugin-arra/vector-config-ops.test.ts
@@ -31,7 +31,7 @@ afterEach(() => {
 describe('maw arra vector-config ops commands', () => {
   test('adds a configured vector collection', async () => {
     const { result, calls, body } = await run([
-      'vector-config', 'add', 'qwen3', '--model', 'qwen3-embedding', '--adapter', 'lancedb', '--collection', 'oracle_qwen3', '--primary', 'true',
+      'vector-config', 'add', 'qwen3', '--model', 'qwen3-embedding', '--adapter', 'lancedb', '--collection', 'oracle_qwen3', '--primary',
     ], { success: true, collection: 'qwen3' });
 
     expect(result.ok).toBe(true);


### PR DESCRIPTION
## Summary
- make bundled `maw arra vector-config add` accept bare `--primary` as designed
- keep explicit `primary true|false` parsing for write commands
- add regression coverage for bundled and tools maw vector-config ops paths

## Validation
- `bunx tsc --noEmit`
- `bun test tests/http/vector/` (69 pass)
- `bun test src/plugins/__tests__/arra-plugin.test.ts tests/tools/maw-plugin-arra/vector-config-ops.test.ts tests/tools/maw-plugin-arra/vector-config.test.ts` (14 pass)
- `git diff --check origin/alpha..HEAD`
- changed file line-count gate: all changed files <=250 lines

Refs #1596