### PR TITLE
fix: scope schedule routes by tenant

### DIFF
--- a/src/db/logistics-schema.ts
+++ b/src/db/logistics-schema.ts
@@ -52,6 +52,7 @@ export const activityLog = sqliteTable('activity_log', {
 
 export const schedule = sqliteTable('schedule', {
   id: integer('id').primaryKey({ autoIncrement: true }),
+  tenantId: text('tenant_id').default('default').notNull(),
   date: text('date').notNull(),
   dateRaw: text('date_raw'),
   time: text('time'),
@@ -62,6 +63,7 @@ export const schedule = sqliteTable('schedule', {
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
 }, (table) => [
+  index('idx_schedule_tenant_date').on(table.tenantId, table.date),
   index('idx_schedule_date').on(table.date),
   index('idx_schedule_status').on(table.status),
 ]);

--- a/src/db/migrations/0027_schedule_tenant.sql
+++ b/src/db/migrations/0027_schedule_tenant.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `schedule` ADD `tenant_id` text DEFAULT 'default' NOT NULL;--> statement-breakpoint
+CREATE INDEX `idx_schedule_tenant_date` ON `schedule` (`tenant_id`,`date`);

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1781628166154,
       "tag": "0026_oracle_memories_tenant",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "6",
+      "when": 1781631000000,
+      "tag": "0027_schedule_tenant",
+      "breakpoints": true
     }
   ]
 }

--- a/src/routes/schedule/create.ts
+++ b/src/routes/schedule/create.ts
@@ -1,15 +1,35 @@
 import { Elysia } from 'elysia';
-import { REPO_ROOT } from '../../config.ts';
-import { db, sqlite } from '../../db/index.ts';
-import { handleScheduleAdd } from '../../tools/schedule.ts';
-import type { ToolContext } from '../../tools/types.ts';
+import { db, schedule } from '../../db/index.ts';
+import { tenantIdForWrite } from '../../middleware/tenant.ts';
+import { parseDate } from '../../tools/schedule.ts';
 import { createBody } from './model.ts';
 
 export const scheduleCreateRoute = new Elysia().post('/api/schedule', async ({ body }) => {
-  const ctx = { db, sqlite, repoRoot: REPO_ROOT } as Pick<ToolContext, 'db' | 'sqlite' | 'repoRoot'>;
-  const result = await handleScheduleAdd(ctx as ToolContext, body as any);
-  const text = result.content[0]?.text || '{}';
-  return JSON.parse(text);
+  const data = body as any;
+  const date = parseDate(data.date);
+  const now = Date.now();
+  const row = db.insert(schedule).values({
+    tenantId: tenantIdForWrite(),
+    date,
+    dateRaw: data.date,
+    time: data.time || null,
+    event: data.event,
+    notes: data.notes || null,
+    recurring: data.recurring || null,
+    status: 'pending',
+    createdAt: now,
+    updatedAt: now,
+  }).returning({ id: schedule.id }).get();
+  return {
+    success: true,
+    id: row.id,
+    date,
+    dateRaw: data.date,
+    event: data.event,
+    time: data.time || 'TBD',
+    notes: data.notes || '',
+    message: 'Event added to schedule',
+  };
 }, {
   body: createBody,
   detail: {

--- a/src/routes/schedule/list.ts
+++ b/src/routes/schedule/list.ts
@@ -1,22 +1,51 @@
 import { Elysia } from 'elysia';
-import { REPO_ROOT } from '../../config.ts';
-import { db, sqlite } from '../../db/index.ts';
-import { handleScheduleList } from '../../tools/schedule.ts';
-import type { ToolContext } from '../../tools/types.ts';
+import { and, asc, eq, gte, like, lte, or, type SQL } from 'drizzle-orm';
+import { db, schedule } from '../../db/index.ts';
+import { currentTenantId } from '../../middleware/tenant.ts';
+import { parseDate } from '../../tools/schedule.ts';
 import { listQuery } from './model.ts';
 
 export const scheduleListRoute = new Elysia().get('/api/schedule', async ({ query }) => {
-  const ctx = { db, sqlite, repoRoot: REPO_ROOT } as Pick<ToolContext, 'db' | 'sqlite' | 'repoRoot'>;
-  const result = await handleScheduleList(ctx as ToolContext, {
-    date: query.date,
-    from: query.from,
-    to: query.to,
-    filter: query.filter,
-    status: query.status as 'pending' | 'done' | 'cancelled' | 'all' | undefined,
-    limit: query.limit ? parseInt(query.limit) : undefined,
-  });
-  const text = result.content[0]?.text || '{}';
-  return JSON.parse(text);
+  const limit = query.limit ? parseInt(query.limit) : 50;
+  const conditions: SQL[] = [];
+  const tenantId = currentTenantId();
+  if (tenantId) conditions.push(eq(schedule.tenantId, tenantId));
+  if ((query.status || 'pending') !== 'all') conditions.push(eq(schedule.status, query.status || 'pending'));
+  if (query.date) {
+    conditions.push(eq(schedule.date, parseDate(query.date)));
+  } else {
+    const from = query.from ? parseDate(query.from) : new Date().toISOString().slice(0, 10);
+    const to = query.to ? parseDate(query.to) : (() => {
+      const d = new Date();
+      d.setDate(d.getDate() + 14);
+      return d.toISOString().slice(0, 10);
+    })();
+    conditions.push(gte(schedule.date, from), lte(schedule.date, to));
+  }
+  if (query.filter) {
+    conditions.push(or(like(schedule.event, `%${query.filter}%`), like(schedule.notes, `%${query.filter}%`))!);
+  }
+  const events = db.select().from(schedule)
+    .where(conditions.length ? and(...conditions) : undefined)
+    .orderBy(asc(schedule.date), asc(schedule.time))
+    .limit(limit)
+    .all();
+  const byDate: Record<string, typeof events> = {};
+  for (const event of events) (byDate[event.date] ??= []).push(event);
+  return {
+    total: events.length,
+    events: events.map((event) => ({
+      id: event.id,
+      date: event.date,
+      dateRaw: event.dateRaw,
+      time: event.time || 'TBD',
+      event: event.event,
+      notes: event.notes,
+      recurring: event.recurring,
+      status: event.status,
+    })),
+    byDate,
+  };
 }, {
   query: listQuery,
   detail: {

--- a/src/routes/schedule/md.ts
+++ b/src/routes/schedule/md.ts
@@ -1,8 +1,31 @@
 import { Elysia } from 'elysia';
+import { asc, eq } from 'drizzle-orm';
 import fs from 'fs';
 import { SCHEDULE_PATH } from '../../config.ts';
+import { db, schedule } from '../../db/index.ts';
+import { currentTenantId } from '../../middleware/tenant.ts';
+
+function tenantMarkdown(tenantId: string): string {
+  const events = db.select().from(schedule)
+    .where(eq(schedule.tenantId, tenantId))
+    .orderBy(asc(schedule.date), asc(schedule.time))
+    .all();
+  const rows = events.map((ev) => `| ${ev.dateRaw || ev.date} | ${ev.time || 'TBD'} | ${ev.event} | ${ev.notes || ''} |`);
+  return [
+    '# Schedule',
+    '',
+    `**Tenant**: ${tenantId}`,
+    '',
+    '| Date | Time | Event | Notes |',
+    '|------|------|-------|-------|',
+    ...rows,
+    '',
+  ].join('\n');
+}
 
 export const scheduleMdRoute = new Elysia().get('/api/schedule/md', ({ set }) => {
+  const tenantId = currentTenantId();
+  if (tenantId) return tenantMarkdown(tenantId);
   if (fs.existsSync(SCHEDULE_PATH)) {
     return fs.readFileSync(SCHEDULE_PATH, 'utf-8');
   }

--- a/src/routes/schedule/update.ts
+++ b/src/routes/schedule/update.ts
@@ -1,15 +1,23 @@
 import { Elysia } from 'elysia';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { db, schedule } from '../../db/index.ts';
+import { currentTenantId } from '../../middleware/tenant.ts';
 import { scheduleIdParam, updateBody } from './model.ts';
 
-export const scheduleUpdateRoute = new Elysia().patch('/api/schedule/:id', async ({ params, body }) => {
+export const scheduleUpdateRoute = new Elysia().patch('/api/schedule/:id', async ({ params, body, set }) => {
   const id = parseInt(params.id);
   const now = Date.now();
-  db.update(schedule)
+  const tenantId = currentTenantId();
+  const where = tenantId ? and(eq(schedule.id, id), eq(schedule.tenantId, tenantId)) : eq(schedule.id, id);
+  const row = db.update(schedule)
     .set({ ...(body as any), updatedAt: now })
-    .where(eq(schedule.id, id))
-    .run();
+    .where(where)
+    .returning({ id: schedule.id })
+    .get();
+  if (!row) {
+    set.status = 404;
+    return { success: false, error: 'Schedule entry not found' };
+  }
   return { success: true, id };
 }, {
   params: scheduleIdParam,

--- a/tests/http/schedule/tenant-isolation.test.ts
+++ b/tests/http/schedule/tenant-isolation.test.ts
@@ -1,0 +1,85 @@
+import { afterAll, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const root = mkdtempSync(join(tmpdir(), 'arra-schedule-tenant-'));
+const previousDataDir = process.env.ORACLE_DATA_DIR;
+const previousDbPath = process.env.ORACLE_DB_PATH;
+const previousRepoRoot = process.env.ORACLE_REPO_ROOT;
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = join(root, 'oracle.db');
+process.env.ORACLE_REPO_ROOT = root;
+
+const dbMod = await import('../../../src/db/index.ts');
+const tenantMod = await import('../../../src/middleware/tenant.ts');
+const routeMod = await import('../../../src/routes/schedule/index.ts');
+
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantA = `tenant-a-${stamp}`;
+const tenantB = `tenant-b-${stamp}`;
+const eventA = `tenant A planning ${stamp}`;
+const eventB = `tenant B planning ${stamp}`;
+const date = '2036-04-05';
+
+type Json = Record<string, any>;
+
+function scheduleRequest(tenantId: string, path: string, init: RequestInit = {}) {
+  return tenantMod.createTenantFetch((request) => routeMod.scheduleApi.handle(request))(new Request(`http://local${path}`, {
+    ...init,
+    headers: { 'content-type': 'application/json', [tenantMod.TENANT_HEADER]: tenantId, ...(init.headers ?? {}) },
+  }));
+}
+
+async function json(res: Response): Promise<Json> {
+  return await res.json() as Json;
+}
+
+async function createEvent(tenantId: string, event: string): Promise<number> {
+  const res = await scheduleRequest(tenantId, '/api/schedule', {
+    method: 'POST',
+    body: JSON.stringify({ date, event, time: '10:00', notes: tenantId }),
+  });
+  expect(res.status).toBe(200);
+  return (await json(res)).id as number;
+}
+
+afterAll(() => {
+  try { dbMod.closeDb(); } catch {}
+  if (previousDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = previousDataDir;
+  if (previousDbPath === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = previousDbPath;
+  if (previousRepoRoot === undefined) delete process.env.ORACLE_REPO_ROOT;
+  else process.env.ORACLE_REPO_ROOT = previousRepoRoot;
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('schedule HTTP routes isolate create/list/update/markdown by tenant', async () => {
+  const idA = await createEvent(tenantA, eventA);
+  const idB = await createEvent(tenantB, eventB);
+
+  const rows = dbMod.sqlite.prepare('SELECT id, tenant_id FROM schedule WHERE id IN (?, ?) ORDER BY id').all(idA, idB) as Array<{ tenant_id: string }>;
+  expect(rows.map((row) => row.tenant_id).sort()).toEqual([tenantA, tenantB].sort());
+
+  const listA = await json(await scheduleRequest(tenantA, `/api/schedule?date=${date}&status=all`));
+  const listB = await json(await scheduleRequest(tenantB, `/api/schedule?date=${date}&status=all`));
+  expect(listA.events.map((event: Json) => event.event)).toEqual([eventA]);
+  expect(listB.events.map((event: Json) => event.event)).toEqual([eventB]);
+
+  const deniedPatch = await scheduleRequest(tenantB, `/api/schedule/${idA}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ status: 'done' }),
+  });
+  expect(deniedPatch.status).toBe(404);
+
+  const allowedPatch = await scheduleRequest(tenantA, `/api/schedule/${idA}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ status: 'done' }),
+  });
+  expect(allowedPatch.status).toBe(200);
+
+  const mdA = await (await scheduleRequest(tenantA, '/api/schedule/md')).text();
+  expect(mdA).toContain(eventA);
+  expect(mdA).not.toContain(eventB);
+});


### PR DESCRIPTION
## Summary
- add `tenant_id` storage for schedule rows with tenant/date index
- stamp schedule creates with the active tenant and filter list/update/markdown routes by tenant
- add schedule HTTP regression proving tenant A/B create, list, update, and markdown isolation

## Validation
- `bunx tsc --noEmit`
- `bun test tests/http/schedule/` (1 pass)
- changed files <=250 lines

Refs #1650
