### PR TITLE
feat: expose unified plugin surface details

### DIFF
--- a/frontend/src/plugin-surfaces.ts
+++ b/frontend/src/plugin-surfaces.ts
@@ -11,6 +11,10 @@ export type Surface =
   | 'exportFormats';
 
 function add(surfaceSet: Set<Surface>, surface: unknown): void {
+  if (surface === 'mcpTools') {
+    surfaceSet.add('mcp');
+    return;
+  }
   if (surface === 'wasm' || surface === 'menu' || surface === 'server' || surface === 'mcp' || surface === 'apiRoutes' || surface === 'proxy' || surface === 'cliSubcommands' || surface === 'exportFormats') {
     surfaceSet.add(surface);
   }

--- a/src/plugins/__tests__/unified-loader.test.ts
+++ b/src/plugins/__tests__/unified-loader.test.ts
@@ -43,12 +43,16 @@ describe('unified plugin loader', () => {
       server: { command: 'bun', args: ['--version'], autostart: false },
       menu: [{ label: 'Surface Pack', path: '/surface-pack', group: 'tools', order: 42 }],
       cliSubcommands: [{ command: 'surface-pack', help: 'surface cli', handler: 'cli' }],
+      exportFormats: [{ name: 'surface-pack', handler: 'exporter' }],
     }, `
       export function api(ctx) {
         return { ok: true, body: { plugin: ctx.plugin, method: ctx.request.method, body: ctx.body } };
       }
       export function tool(ctx) {
         return { ok: true, body: { plugin: ctx.plugin, source: ctx.source, args: ctx.args } };
+      }
+      export function exporter() {
+        return { data: 'surface-pack' };
       }
     `);
 
@@ -62,6 +66,16 @@ describe('unified plugin loader', () => {
     expect(runtime.cliSubcommands.map((cmd) => cmd.command)).toEqual(['surface-pack']);
     expect(runtime.servers.map((server) => server.plugin)).toEqual(['surface-pack']);
     expect(runtime.routes).toHaveLength(3);
+    const registryEntry = runtime.pluginRegistry().find((plugin) => plugin.name === 'surface-pack');
+    expect(registryEntry).toMatchObject({
+      surfaces: ['mcpTools', 'apiRoutes', 'proxy', 'server', 'menu', 'cliSubcommands', 'exportFormats'],
+      mcpTools: [{ name: 'oracle_surface_pack', source: 'plugin', plugin: 'surface-pack' }],
+      apiRoutes: [{ path: '/api/surface-pack', methods: ['POST'] }],
+      proxy: [{ path: '/api/surface-proxy', targetEnv: 'SURFACE_PROXY_URL' }],
+      cliSubcommands: [{ command: 'surface-pack', help: 'surface cli' }],
+      exportFormats: [{ name: 'surface-pack', extension: 'surface-pack' }],
+    });
+    expect(registryEntry?.mcpTools[0]).not.toHaveProperty('handler');
 
     const app = new Elysia();
     for (const route of runtime.routes) app.use(route as any);

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -9,6 +9,12 @@ import {
 } from './unified-manifest.ts';
 import type { LoadedUnifiedPlugin, UnifiedPluginStatus } from './unified-loader.ts';
 
+type PluginManifest = LoadedUnifiedPlugin['manifest'];
+type PublicMcpTool = Omit<PluginManifest['mcpTools'][number], 'handler'> & { source: 'plugin'; plugin: string };
+type PublicApiRoute = Omit<PluginManifest['apiRoutes'][number], 'handler'>;
+type PublicCliSubcommand = Omit<PluginManifest['cliSubcommands'][number], 'handler'>;
+type PublicExportFormat = { name: string; extension: string };
+
 export interface LoadedPluginRegistryEntry {
   name: string;
   version: string;
@@ -19,6 +25,11 @@ export interface LoadedPluginRegistryEntry {
   description?: string;
   menu?: UnifiedMenuManifest;
   server?: ReturnType<typeof publicUnifiedServerManifest>;
+  mcpTools: PublicMcpTool[];
+  apiRoutes: PublicApiRoute[];
+  proxy: PluginManifest['proxy'];
+  cliSubcommands: PublicCliSubcommand[];
+  exportFormats: PublicExportFormat[];
   file: string;
   size: number;
   modified: string;
@@ -26,6 +37,22 @@ export interface LoadedPluginRegistryEntry {
 
 function manifestModified(plugin: LoadedUnifiedPlugin): string {
   return statSync(join(plugin.dir, 'plugin.json')).mtime.toISOString();
+}
+
+function publicMcpTools(manifest: PluginManifest): PublicMcpTool[] {
+  return manifest.mcpTools.map(({ handler, ...tool }) => ({ ...tool, source: 'plugin', plugin: manifest.name }));
+}
+
+function publicApiRoutes(manifest: PluginManifest): PublicApiRoute[] {
+  return manifest.apiRoutes.map(({ handler, ...route }) => route);
+}
+
+function publicCliSubcommands(manifest: PluginManifest): PublicCliSubcommand[] {
+  return manifest.cliSubcommands.map(({ handler, ...command }) => command);
+}
+
+function publicExportFormats(manifest: PluginManifest): PublicExportFormat[] {
+  return manifest.exportFormats.map((format) => ({ name: format.name, extension: format.name }));
 }
 
 export function pluginRegistryFromLoadedPlugins(
@@ -45,6 +72,11 @@ export function pluginRegistryFromLoadedPlugins(
       description: plugin.manifest.description,
       menu: plugin.manifest.menu[0],
       server: publicUnifiedServerManifest(plugin.manifest.server),
+      mcpTools: publicMcpTools(plugin.manifest),
+      apiRoutes: publicApiRoutes(plugin.manifest),
+      proxy: plugin.manifest.proxy,
+      cliSubcommands: publicCliSubcommands(plugin.manifest),
+      exportFormats: publicExportFormats(plugin.manifest),
       file: '',
       size: 0,
       modified: manifestModified(plugin),

--- a/tests/frontend/components/plugin-list-surfaces.test.tsx
+++ b/tests/frontend/components/plugin-list-surfaces.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { PluginList } from '../../../frontend/src/components/PluginList';
+import { surfacesFor } from '../../../frontend/src/plugin-surfaces';
 import { htmlFor } from '../_render';
 
 describe('PluginList surfaces', () => {
@@ -37,5 +38,9 @@ describe('PluginList surfaces', () => {
     expect(html).toContain('GET /proxy/echo → $ECHO_URL');
     expect(html).toContain('CLI subcommands');
     expect(html).toContain('.echo');
+  });
+
+  test('normalizes backend mcpTools surface names for badges', () => {
+    expect(surfacesFor({ name: 'echo', file: '', size: 0, modified: 'now', surfaces: ['mcpTools'] })).toEqual(['mcp']);
   });
 });


### PR DESCRIPTION
Refs #1484

## Summary
- expose public unified-plugin surface descriptors from /api/plugins: MCP tools, API routes, proxy routes, CLI subcommands, and export formats
- omit handler internals from registry payloads while preserving UI-safe route/tool metadata
- normalize backend mcpTools surface names to the frontend MCP badge so the plugin UI reflects all backend surfaces

## Verification
- bun test src/plugins/__tests__/unified-loader.test.ts tests/frontend/components/plugin-list-surfaces.test.tsx tests/frontend/pages/unified-plugin-overview.test.tsx tests/frontend/pages/plugins-page-admin.test.tsx
- bunx tsc --noEmit
- wc -l src/plugins/registry.ts src/plugins/__tests__/unified-loader.test.ts frontend/src/plugin-surfaces.ts tests/frontend/components/plugin-list-surfaces.test.tsx