### PR TITLE
feat(studio): wire vector setup panels

### DIFF
--- a/frontend/src/pages/IndexManagerPanel.tsx
+++ b/frontend/src/pages/IndexManagerPanel.tsx
@@ -1,110 +1,16 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
 import { apiClient, type ApiClient, type VectorIndexCollection, type VectorIndexStatusResponse } from '../api/client';
-import { ErrorMessage, LoadingPanel, Spinner } from '../components/AsyncState';
+import { VectorIndexPanel } from '../components/VectorIndexPanel';
 
 type VectorIndexClient = Pick<ApiClient, 'startVectorIndex' | 'vectorIndexModels' | 'vectorIndexStatus'>;
 
-function progressFor(status: VectorIndexStatusResponse): number {
-  if (status.total <= 0) return status.status === 'completed' ? 100 : 0;
-  return Math.min(100, Math.round((status.current / status.total) * 100));
-}
-
-function gapLabel(models: Record<string, VectorIndexCollection>): string {
-  const total = Object.values(models).reduce((sum, model) => sum + (model.count ?? 0), 0);
-  if (!total) return 'No vectors indexed yet — first backfill recommended.';
-  return `${total.toLocaleString()} vectors tracked across ${Object.keys(models).length} models.`;
-}
-
-function statusSummary(status: VectorIndexStatusResponse | null): string {
-  if (!status || status.status === 'idle') return 'No active index job.';
-  if (status.status === 'completed') return `Completed ${status.model} reindex.`;
-  if (status.status === 'error') return `Failed ${status.model} reindex.`;
-  return `⏳ Backfilling ${status.model}... ${status.current.toLocaleString()}/${status.total.toLocaleString()} (${progressFor(status)}%)`;
-}
-
-export function IndexManagerPanel({ client = apiClient }: { client?: VectorIndexClient }) {
-  const [models, setModels] = useState<Record<string, VectorIndexCollection>>({});
-  const [loading, setLoading] = useState(true);
-  const [status, setStatus] = useState<VectorIndexStatusResponse | null>(null);
-  const [error, setError] = useState('');
-  const [startingKey, setStartingKey] = useState<string | null>(null);
-  const modelEntries = useMemo(() => Object.entries(models).sort(([a], [b]) => a.localeCompare(b)), [models]);
-  const indexing = status?.status === 'indexing';
-
-  const refreshStatus = useCallback(async () => {
-    const next = await client.vectorIndexStatus();
-    setStatus(next);
-    return next;
-  }, [client]);
-
-  async function refreshAll() {
-    setError('');
-    try {
-      const [modelResponse, nextStatus] = await Promise.all([client.vectorIndexModels(), client.vectorIndexStatus()]);
-      setModels(modelResponse.models);
-      setStatus(nextStatus);
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  useEffect(() => { void refreshAll(); }, [client]);
-  useEffect(() => {
-    if (!indexing || typeof window === 'undefined') return;
-    const timer = window.setInterval(() => void refreshStatus().catch((err) => setError(err instanceof Error ? err.message : String(err))), 2000);
-    return () => window.clearInterval(timer);
-  }, [indexing, refreshStatus]);
-
-  async function startReindex(key: string) {
-    setStartingKey(key);
-    setError('');
-    try {
-      await client.startVectorIndex(key);
-      await refreshStatus();
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
-    } finally {
-      setStartingKey(null);
-    }
-  }
-
-  return (
-    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-index-title">
-      <div className="mb-5 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-300">Index Manager</p>
-          <h2 id="vector-index-title" className="mt-2 text-2xl font-semibold text-white">Reindex and backfill vectors</h2>
-          <p className="mt-2 text-sm text-slate-400">Trigger model rebuilds and poll active progress.</p>
-        </div>
-        <button className="focus-ring rounded-xl border border-white/10 px-3 py-2 text-sm text-slate-200" type="button" onClick={() => void refreshAll()}>Refresh</button>
-      </div>
-
-      <div className="mb-4 rounded-2xl border border-white/10 bg-white/[0.03] p-4">
-        <p className="text-sm font-semibold text-slate-200">{statusSummary(status)}</p>
-        <p className="mt-1 text-sm text-slate-500">{gapLabel(models)}</p>
-        {status ? <IndexProgress status={status} /> : null}
-      </div>
-
-      {loading ? <LoadingPanel title="Loading vector collections…" detail="Fetching /api/v1/vector/index/models." /> : null}
-      {error ? <ErrorMessage title="Vector indexing failed." message={error} /> : null}
-      <div className="grid gap-3 md:grid-cols-2">
-        {modelEntries.map(([key, model]) => (
-          <article key={key} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
-            <div className="flex items-start justify-between gap-3">
-              <div><h3 className="font-mono text-base font-semibold text-teal-200">{key}</h3><p className="mt-1 text-sm text-slate-300">{model.collection}</p></div>
-              <button className="focus-ring rounded-xl bg-purple-300 px-3 py-2 text-sm font-semibold text-slate-950 disabled:opacity-50" disabled={Boolean(startingKey) || indexing} type="button" onClick={() => void startReindex(key)}>{startingKey === key ? <Spinner label="Starting" /> : 'Index now'}</button>
-            </div>
-            <dl className="mt-4 grid gap-2 text-sm text-slate-400"><div><dt className="inline text-slate-500">Model: </dt><dd className="inline">{model.model}</dd></div><div><dt className="inline text-slate-500">Adapter: </dt><dd className="inline">{model.adapter}</dd></div><div><dt className="inline text-slate-500">Vectors: </dt><dd className="inline">{model.count ?? 0}</dd></div></dl>
-          </article>
-        ))}
-      </div>
-    </section>
-  );
-}
-
-function IndexProgress({ status }: { status: VectorIndexStatusResponse }) {
-  const progress = progressFor(status);
-  return <div className="mt-3"><div className="h-2 overflow-hidden rounded-full bg-slate-800" role="progressbar" aria-valuemin={0} aria-valuemax={100} aria-valuenow={progress}><div className="h-full rounded-full bg-purple-300 transition-all" style={{ width: `${progress}%` }} /></div>{status.error ? <p className="mt-2 text-sm text-red-200">{status.error}</p> : null}</div>;
+export function IndexManagerPanel({
+  client = apiClient,
+  initialModels,
+  initialStatus = null,
+}: {
+  client?: VectorIndexClient;
+  initialModels?: Record<string, VectorIndexCollection>;
+  initialStatus?: VectorIndexStatusResponse | null;
+}) {
+  return <VectorIndexPanel client={client} initialModels={initialModels} initialStatus={initialStatus} />;
 }

--- a/frontend/src/pages/VectorSettingsPage.tsx
+++ b/frontend/src/pages/VectorSettingsPage.tsx
@@ -1,23 +1,39 @@
-import { Link } from 'react-router-dom';
+import { useCallback, useEffect, useState } from 'react';
+import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
 import { VectorConfigPanel } from '../components/VectorConfigPanel';
+import { VectorFirstRunWizard } from '../components/VectorFirstRunWizard';
 import { VectorIndexPanel } from '../components/VectorIndexPanel';
 import { VectorModelRecommendationCard } from '../components/VectorModelRecommendationCard';
 import { VectorProviderServicePanel } from '../components/VectorProviderServicePanel';
 import { VectorSearchToggle } from '../components/VectorSearchToggle';
-import { vectorIndexPath } from '../routePaths';
+import { fetchJson, parseVectorConfigResponse, toRows, type VectorConfigRow } from './vectorSettingsHelpers';
 
-function FirstRunWizardCard() {
+function VectorFirstRunWizardSection() {
+  const [rows, setRows] = useState<VectorConfigRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const refresh = useCallback(async () => {
+    setError('');
+    setLoading(true);
+    try {
+      const body = await fetchJson<unknown>('/api/v1/vector/config');
+      setRows(toRows(parseVectorConfigResponse(body)));
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void refresh(); }, [refresh]);
+
   return (
-    <section className="rounded-3xl border border-purple-300/20 bg-purple-300/10 p-5 sm:p-6" aria-labelledby="vector-first-run-title">
-      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-200">First-run wizard</p>
-      <h2 id="vector-first-run-title" className="mt-2 text-2xl font-semibold text-white">Provider → vault → first index</h2>
-      <p className="mt-2 text-sm text-purple-100/80">
-        The setup wizard appears automatically when FTS docs are empty and vector search is disabled. Use the Index Manager to watch first-run backfill progress.
-      </p>
-      <Link className="focus-ring mt-4 inline-flex rounded-xl border border-purple-200/40 px-4 py-2 text-sm font-semibold text-purple-100 hover:bg-purple-200/10" to={vectorIndexPath()}>
-        Open Index Manager
-      </Link>
-    </section>
+    <div className="grid gap-3">
+      <VectorFirstRunWizard rows={rows} onRefresh={refresh} />
+      {loading ? <LoadingPanel title="Loading first-run collections…" detail="Fetching /api/v1/vector/config." /> : null}
+      {error ? <ErrorMessage title="Could not load first-run vector config." message={error} /> : null}
+    </div>
   );
 }
 
@@ -28,12 +44,12 @@ export function VectorSettingsPage() {
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Vector settings</p>
         <h1 id="vector-settings-title" className="mt-2 text-3xl font-semibold text-white">Vector settings</h1>
         <p className="mt-2 text-sm text-slate-400">
-          Configure adapters, embedding models, vector search, storage services, and backfill jobs.
+          Configure adapters, embedding models and providers, storage services, first-run indexing, and backfill jobs.
         </p>
       </header>
 
       <VectorSearchToggle />
-      <FirstRunWizardCard />
+      <VectorFirstRunWizardSection />
       <VectorProviderServicePanel />
       <VectorModelRecommendationCard />
       <VectorConfigPanel />

--- a/tests/frontend/pages/vector-settings-page.test.tsx
+++ b/tests/frontend/pages/vector-settings-page.test.tsx
@@ -10,8 +10,8 @@ describe('VectorSettingsPage', () => {
     expect(html).toContain('Enable vector search');
     expect(html).toContain('PATCH /api/v1/vector/config');
     expect(html).toContain('First-run wizard');
-    expect(html).toContain('Provider → vault → first index');
-    expect(html).toContain('Open Index Manager');
+    expect(html).toContain('Choose a storage adapter');
+    expect(html).toContain('No collections loaded yet.');
     expect(html).toContain('Embedding providers and storage services');
     expect(html).toContain('Model recommendation');
     expect(html).toContain('Active vector adapters');


### PR DESCRIPTION
## Summary
- replace the standalone Index Manager route implementation with the fuller shared VectorIndexPanel, including vault list, gap indicator, backfill actions, active job progress, and per-model sync state
- embed the live VectorFirstRunWizard into Vector Settings with collection loading from /api/v1/vector/config
- update Vector Settings coverage for the real wizard state instead of the previous static callout card

## Tests
- `bunx tsc --noEmit`
- `bun test tests/frontend/`
- `git diff --check`
- changed-file line count: all <=250

Document-refresh: not-needed | frontend route composition only; no operator docs or CLI contracts changed.