### PR TITLE
feat(plugin): dispatch ARRA API commands

### DIFF
--- a/src/plugins/__tests__/arra-plugin-commands.test.ts
+++ b/src/plugins/__tests__/arra-plugin-commands.test.ts
@@ -20,14 +20,32 @@ describe("built-in arra plugin command registry", () => {
 
   test("commands --json mirrors the HTTP registry payload", async () => {
     const result = await arraCli({ source: "cli", plugin: "arra", args: ["commands", "--json"], config });
-    const http = arraHttpRoute({ source: "api", plugin: "arra", config });
-    const payload = JSON.parse(result.output ?? "{}") as typeof http.body;
+    const http = await arraHttpRoute({ source: "api", plugin: "arra", config });
+    type RegistryBody = { surface: string; verbs: Array<{ name: string }>; backends: unknown; remoteEmbedderConfigured: boolean };
+    const payload = JSON.parse(result.output ?? "{}") as RegistryBody;
+    const httpBody = http.body as RegistryBody;
 
     expect(result.ok).toBe(true);
     expect(payload.surface).toBe("cli");
-    expect(payload.verbs.map((verb) => verb.name)).toEqual(http.body.verbs.map((verb) => verb.name));
-    expect(payload.backends).toEqual(http.body.backends);
+    expect(payload.verbs.map((verb) => verb.name)).toEqual(httpBody.verbs.map((verb) => verb.name));
+    expect(payload.backends).toEqual(httpBody.backends);
     expect(payload.remoteEmbedderConfigured).toBe(true);
+  });
+
+  test("runs shared commands through the menu API payload", async () => {
+    const version = await arraHttpRoute({ source: "api", plugin: "arra", args: { command: "version" } });
+    const registry = await arraHttpRoute({
+      source: "api",
+      plugin: "arra",
+      args: { command: "commands", json: true },
+      config,
+    });
+    const unknown = await arraHttpRoute({ source: "api", plugin: "arra", args: { command: "missing" } });
+
+    expect(version.body).toEqual({ ok: true, command: "version", output: "arra 1.0.0" });
+    expect((registry.body as { surface: string }).surface).toBe("api");
+    expect((registry.body as { verbs: Array<{ name: string }> }).verbs.map((verb) => verb.name)).toContain("commands");
+    expect(unknown).toEqual({ ok: false, status: 400, error: "unknown arra command: missing" });
   });
 
   test("normalizes modern maw help and version flags", async () => {

--- a/src/plugins/__tests__/arra-plugin.test.ts
+++ b/src/plugins/__tests__/arra-plugin.test.ts
@@ -18,6 +18,7 @@ describe("built-in arra plugin", () => {
     expect(manifest.cli.handler).toBe("arraCli");
     expect(manifest.verbs).toEqual(ARRA_VERBS);
     expect(manifest.httpRoutes[0].path).toBe("/api/plugins/arra");
+    expect(manifest.apiRoutes[0].methods).toEqual(["GET", "POST"]);
     expect(manifest.config).toMatchObject({ dbBackend: "sqlite", embedderBackend: "none" });
     expect(manifest.configSchema.properties.dbBackend.enum).toEqual(["sqlite", "http", "memory", "custom"]);
   });
@@ -54,6 +55,18 @@ describe("built-in arra plugin", () => {
     expect(body.backends.embedder.optional).toBe(true);
     expect(body.backends.embedder.supported).toContain("remote");
     expect(body.verbs.map((verb) => verb.name)).toEqual(ARRA_VERBS);
+
+    const version = await app.handle(new Request("http://local/api/plugins/arra?command=version"));
+    expect(await version.json()).toEqual({ ok: true, command: "version", output: "arra 1.0.0" });
+
+    const commands = await app.handle(new Request("http://local/api/plugins/arra", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ command: "commands", json: true }),
+    }));
+    const commandsBody = await commands.json() as { surface: string; verbs: Array<{ name: string }> };
+    expect(commandsBody.surface).toBe("api");
+    expect(commandsBody.verbs.map((verb) => verb.name)).toEqual(ARRA_VERBS);
   });
 
   test("delegates maw arra health to vector engine details", async () => {

--- a/src/plugins/arra/index.ts
+++ b/src/plugins/arra/index.ts
@@ -11,7 +11,8 @@ type ArraPluginConfig = {
 type ArraPluginContext = {
   source: "api" | "mcp" | "cli" | "server" | "init" | "destroy";
   plugin: string;
-  args?: unknown[];
+  args?: unknown[] | Record<string, unknown>;
+  body?: unknown;
   request?: Request;
   config?: ArraPluginConfig;
 };
@@ -26,6 +27,7 @@ type ArraVerb = {
 };
 
 type CliResult = { ok: boolean; output?: string; error?: string };
+type ArraApiResult = { ok: boolean; body?: unknown; error?: string; status?: number };
 
 const VERSION = "1.0.0";
 const MENU_PATH = "/plugins/arra";
@@ -50,7 +52,21 @@ const VERBS: ArraVerb[] = [
 ];
 
 function argv(ctx: ArraPluginContext): string[] {
-  return (ctx.args ?? []).map(String);
+  const args = inputArgv(ctx.args);
+  return args.length ? args : inputArgv(ctx.body);
+}
+
+function inputArgv(input: unknown): string[] {
+  if (Array.isArray(input)) return input.map(String);
+  if (!input || typeof input !== "object") return [];
+  const record = input as Record<string, unknown>;
+  if (Array.isArray(record.args)) return record.args.map(String);
+  const command = record.command ?? record.cmd;
+  if (typeof command !== "string" || !command.trim()) return [];
+  const args = [command.trim()];
+  if (Array.isArray(record.argv)) args.push(...record.argv.map(String));
+  if (record.json === true || record.json === "true" || record.format === "json") args.push("--json");
+  return args;
 }
 
 function commandName(ctx: ArraPluginContext): string {
@@ -132,8 +148,23 @@ async function renderCli(ctx: ArraPluginContext): Promise<CliResult> {
   return renderHelp();
 }
 
-export function arraHttpRoute(ctx: ArraPluginContext) {
-  return { ok: true, body: pluginBody(ctx) };
+function jsonOutput(result: CliResult): unknown | undefined {
+  if (!result.output) return undefined;
+  try {
+    return JSON.parse(result.output);
+  } catch {
+    return undefined;
+  }
+}
+
+export async function arraHttpRoute(ctx: ArraPluginContext): Promise<ArraApiResult> {
+  if (!argv(ctx).length) return { ok: true, body: pluginBody(ctx) };
+  const result = await renderCli(ctx);
+  if (!result.ok) return { ok: false, status: 400, error: result.error };
+  return {
+    ok: true,
+    body: jsonOutput(result) ?? { ok: true, command: commandName(ctx), output: result.output },
+  };
 }
 
 export async function arraCli(ctx: ArraPluginContext) {

--- a/src/plugins/arra/plugin.json
+++ b/src/plugins/arra/plugin.json
@@ -10,7 +10,8 @@
     {
       "path": "/api/plugins/arra",
       "methods": [
-        "GET"
+        "GET",
+        "POST"
       ]
     }
   ],
@@ -18,7 +19,8 @@
     {
       "path": "/api/plugins/arra",
       "methods": [
-        "GET"
+        "GET",
+        "POST"
       ],
       "handler": "arraHttpRoute"
     }


### PR DESCRIPTION
## Summary\n- enable the built-in ARRA maw-js plugin API surface for GET and POST command payloads\n- reuse the shared CLI command dispatcher for menu/API invocations\n- add coverage for query/body API command dispatch and shared registry parity\n\n## Verification\n- bunx tsc --noEmit\n- bun test maw-plugin/__tests__ src/plugins/__tests__ tests/http/plugins/maw-plugin-api.test.ts\n- git diff --check\n- wc -l changed files (all <=250)