### PR TITLE
feat: polish vector fallback chain preflight

### DIFF
--- a/frontend/src/components/VectorIndexPanel.tsx
+++ b/frontend/src/components/VectorIndexPanel.tsx
@@ -6,14 +6,26 @@ import {
   type VectorIndexStatusResponse,
 } from '../api/client';
 import { ErrorMessage, LoadingPanel, Spinner } from './AsyncState';
+import { fetchJson } from '../pages/vectorSettingsHelpers';
 
 type VectorIndexClient = Pick<ApiClient, 'startVectorIndex' | 'vectorIndexModels' | 'vectorIndexStatus'>;
+
+type VectorCostEstimate = {
+  formula: string;
+  estimatedUsd: number;
+  provider: string;
+  recommendation?: string;
+};
 
 interface VectorIndexPanelProps {
   client?: VectorIndexClient;
   initialModels?: Record<string, VectorIndexCollection>;
   initialStatus?: VectorIndexStatusResponse | null;
+  initialCostEstimate?: VectorCostEstimate | null;
+  loadCostEstimate?: () => Promise<VectorCostEstimate>;
 }
+
+const loadDefaultCostEstimate = () => fetchJson<VectorCostEstimate>('/api/v1/vector/cost-estimate');
 
 export function formatIndexEta(seconds: number): string {
   if (!Number.isFinite(seconds) || seconds <= 0) return 'calculating';
@@ -30,6 +42,10 @@ function progressFor(status: VectorIndexStatusResponse): number {
 
 function totalVectors(models: Record<string, VectorIndexCollection>): number {
   return Object.values(models).reduce((sum, model) => sum + (model.count ?? 0), 0);
+}
+
+function formatCost(value: number): string {
+  return value === 0 ? 'Free / local' : `$${value.toFixed(4)}`;
 }
 
 function gapLabel(models: Record<string, VectorIndexCollection>, status: VectorIndexStatusResponse | null): string {
@@ -54,10 +70,18 @@ function vaultState(model: VectorIndexCollection): string {
   return (model.count ?? 0) > 0 ? 'indexed' : 'not indexed';
 }
 
-export function VectorIndexPanel({ client = apiClient, initialModels, initialStatus = null }: VectorIndexPanelProps) {
+export function VectorIndexPanel({
+  client = apiClient,
+  initialModels,
+  initialStatus = null,
+  initialCostEstimate,
+  loadCostEstimate = loadDefaultCostEstimate,
+}: VectorIndexPanelProps) {
   const [models, setModels] = useState<Record<string, VectorIndexCollection>>(initialModels ?? {});
   const [loading, setLoading] = useState(!initialModels);
   const [status, setStatus] = useState<VectorIndexStatusResponse | null>(initialStatus);
+  const [costEstimate, setCostEstimate] = useState<VectorCostEstimate | null>(initialCostEstimate ?? null);
+  const [costError, setCostError] = useState('');
   const [error, setError] = useState('');
   const [startingKey, setStartingKey] = useState<string | null>(null);
 
@@ -89,6 +113,15 @@ export function VectorIndexPanel({ client = apiClient, initialModels, initialSta
       .catch((err) => { if (active) setError(err instanceof Error ? err.message : String(err)); });
     return () => { active = false; };
   }, [client]);
+
+  useEffect(() => {
+    if (initialCostEstimate !== undefined) return;
+    let active = true;
+    loadCostEstimate()
+      .then((next) => { if (active) setCostEstimate(next); })
+      .catch((err) => { if (active) setCostError(err instanceof Error ? err.message : String(err)); });
+    return () => { active = false; };
+  }, [initialCostEstimate, loadCostEstimate]);
 
   useEffect(() => {
     if (!indexing || typeof window === 'undefined') return;
@@ -136,6 +169,14 @@ export function VectorIndexPanel({ client = apiClient, initialModels, initialSta
         <p className="mt-1 text-sm text-amber-100">Gap indicator: {gapLabel(models, status)}</p>
         {status ? <IndexProgress status={status} /> : null}
       </div>
+
+      {costEstimate ? (
+        <div className="mb-4 rounded-2xl border border-teal-200/20 bg-teal-200/10 p-4 text-sm text-teal-50/90">
+          <p className="font-semibold text-teal-100">Preflight cost before Index Now</p>
+          <p className="mt-1">{costEstimate.formula} · {costEstimate.provider}: {formatCost(costEstimate.estimatedUsd)}</p>
+          {costEstimate.recommendation ? <p className="mt-1 text-teal-100/75">{costEstimate.recommendation}</p> : null}
+        </div>
+      ) : costError ? <p className="mb-4 text-sm text-amber-100">Cost estimate unavailable: {costError}</p> : null}
 
       {loading ? <LoadingPanel title="Loading vector collections…" detail="Fetching /api/v1/vector/index/models." /> : null}
       {error ? <ErrorMessage title="Vector indexing failed." message={error} /> : null}

--- a/src/vector/embeddings.ts
+++ b/src/vector/embeddings.ts
@@ -1,5 +1,6 @@
 import type { EmbeddingProvider, EmbeddingProviderType, EmbedType } from './types.ts';
 import { NoneEmbeddings, RemoteHttpEmbeddings } from './embedding-backends.ts';
+import { EmbeddingFallbackChain } from './fallback-chain.ts';
 export type FallbackEvent = { from: string; to?: string; error: string };
 export type EmbeddingProviderOptions = { url?: string; dimensions?: number; fallbackChain?: EmbeddingProviderType[]; fallback?: EmbeddingProviderType };
 export class ChromaDBInternalEmbeddings implements EmbeddingProvider {
@@ -176,34 +177,26 @@ export class GeminiEmbeddings implements EmbeddingProvider {
 export class FallbackEmbeddings implements EmbeddingProvider {
   readonly name: string;
   readonly dimensions: number;
+  private readonly chain: EmbeddingFallbackChain;
   constructor(
-    private readonly providers: EmbeddingProvider[],
+    providers: EmbeddingProvider[],
     private readonly onFallback: (event: FallbackEvent) => void = defaultFallbackLogger,
   ) {
     if (providers.length === 0) throw new Error('FallbackEmbeddings requires at least one provider');
     this.name = providers.map((provider) => provider.name).join('>');
     this.dimensions = providers[0].dimensions;
+    this.chain = new EmbeddingFallbackChain(providers, {
+      logger: () => undefined,
+      onFallback: this.onFallback,
+    });
   }
   async embed(texts: string[], type?: EmbedType): Promise<number[][]> {
-    let lastError: unknown;
-    for (let i = 0; i < this.providers.length; i++) {
-      const provider = this.providers[i];
-      try {
-        return await provider.embed(texts, type);
-      } catch (error) {
-        lastError = error;
-        this.onFallback({ from: provider.name, to: this.providers[i + 1]?.name, error: errorMessage(error) });
-      }
-    }
-    throw lastError instanceof Error ? lastError : new Error(String(lastError));
+    return this.chain.embed(texts, type);
   }
 }
 function defaultFallbackLogger(event: FallbackEvent): void {
   if (event.to) console.warn(`[EmbedderFallback] ${event.from} failed: ${event.error}; trying ${event.to}`);
   else console.warn(`[EmbedderFallback] ${event.from} failed: ${event.error}; no fallback provider left`);
-}
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }
 export function createEmbeddingProvider(
   type: EmbeddingProviderType = 'none',

--- a/tests/frontend/components/vector-index-panel-render.test.tsx
+++ b/tests/frontend/components/vector-index-panel-render.test.tsx
@@ -18,6 +18,12 @@ describe('VectorIndexPanel', () => {
     const html = htmlFor(
       <VectorIndexPanel
         initialStatus={status}
+        initialCostEstimate={{
+          formula: '100 docs × ~500 tokens/doc ≈ 50K tokens',
+          provider: 'openai',
+          estimatedUsd: 0.001,
+          recommendation: 'Any configured embedding model should work.',
+        }}
         initialModels={{
           'bge-m3': { collection: 'oracle_bge_m3', model: 'BAAI/bge-m3', adapter: 'lancedb', count: 100 },
           qwen3: { collection: 'oracle_qwen3', model: 'Qwen3', adapter: 'lancedb', count: 80 },
@@ -30,6 +36,9 @@ describe('VectorIndexPanel', () => {
     expect(html).toContain('Vault list');
     expect(html).toContain('Vector Models');
     expect(html).toContain('75 docs need backfill');
+    expect(html).toContain('Preflight cost before Index Now');
+    expect(html).toContain('100 docs × ~500 tokens/doc ≈ 50K tokens');
+    expect(html).toContain('$0.0010');
     expect(html).toContain('Index Now');
     expect(html).toContain('Backfill Vectors');
     expect(html).toContain('Add Vault');

--- a/tests/vector/fallback-embeddings.test.ts
+++ b/tests/vector/fallback-embeddings.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'bun:test';
+import { expect, mock, test } from 'bun:test';
 import { FallbackEmbeddings } from '../../src/vector/embeddings.ts';
 import type { EmbeddingProvider } from '../../src/vector/types.ts';
 
@@ -22,4 +22,15 @@ test('fallback embedder tries the next provider and logs the fallback event', as
 
   expect(await embedder.embed(['hello'], 'passage')).toEqual([[1, 2]]);
   expect(events).toEqual([{ from: 'ollama', to: 'openai', error: 'ollama down' }]);
+});
+
+test('fallback embedder resumes from the healthy provider after failover', async () => {
+  const ollama = { name: 'ollama', dimensions: 2, embed: mock(async () => { throw new Error('ollama down'); }) };
+  const gemini = { name: 'gemini', dimensions: 2, embed: mock(async () => [[3, 4]]) };
+  const embedder = new FallbackEmbeddings([ollama, gemini], () => undefined);
+
+  expect(await embedder.embed(['first'], 'passage')).toEqual([[3, 4]]);
+  expect(await embedder.embed(['second'], 'passage')).toEqual([[3, 4]]);
+  expect(ollama.embed).toHaveBeenCalledTimes(1);
+  expect(gemini.embed).toHaveBeenCalledTimes(2);
 });


### PR DESCRIPTION
## Summary
- wire production fallback embeddings through the sticky `EmbeddingFallbackChain` so indexing resumes on the healthy provider after failover
- add a regression test for provider resume behavior after Ollama-style failure
- surface the existing vector cost estimate in the Index Manager before users click Index Now

Refs #1440

## Validation
- bunx tsc --noEmit
- bun test tests/vector/fallback-embeddings.test.ts tests/http/vector/fallback-chain.test.ts tests/http/vector/fallback-chain-resume.test.ts tests/frontend/components/vector-index-panel-render.test.tsx tests/frontend/components/vector-model-recommendation-card.test.tsx tests/frontend/pages/vector-settings-page.test.tsx
- wc -l changed files <=250
