### PR TITLE
fix(knowledge): scope routes by tenant

### DIFF
--- a/src/routes/knowledge/handoff.ts
+++ b/src/routes/knowledge/handoff.ts
@@ -6,7 +6,12 @@ import { Elysia } from 'elysia';
 import fs from 'fs';
 import path from 'path';
 import { REPO_ROOT } from '../../config.ts';
+import { tenantDataPath } from '../../middleware/tenant.ts';
 import { HandoffBody } from './model.ts';
+
+const repoRoot = () => process.env.ORACLE_REPO_ROOT || REPO_ROOT;
+const relativePath = (filePath: string) => path.relative(repoRoot(), filePath).split(path.sep).join('/');
+const inboxDir = () => tenantDataPath(path.join(repoRoot(), 'ψ/inbox'));
 
 export const handoffEndpoint = new Elysia().post(
   '/handoff',
@@ -31,7 +36,7 @@ export const handoffEndpoint = new Elysia().post(
         .replace(/^-|-$/g, '') || 'handoff';
 
       const filename = `${dateStr}_${timeStr}_${slug}.md`;
-      const dirPath = path.join(REPO_ROOT, 'ψ/inbox/handoff');
+      const dirPath = path.join(inboxDir(), 'handoff');
       const filePath = path.join(dirPath, filename);
 
       fs.mkdirSync(dirPath, { recursive: true });
@@ -40,7 +45,7 @@ export const handoffEndpoint = new Elysia().post(
       set.status = 201;
       return {
         success: true,
-        file: `ψ/inbox/handoff/${filename}`,
+        file: relativePath(filePath),
         message: 'Handoff written.',
       };
     } catch (error) {

--- a/src/routes/knowledge/inbox.ts
+++ b/src/routes/knowledge/inbox.ts
@@ -6,7 +6,12 @@ import { Elysia } from 'elysia';
 import fs from 'fs';
 import path from 'path';
 import { REPO_ROOT } from '../../config.ts';
+import { tenantDataPath } from '../../middleware/tenant.ts';
 import { InboxQuery } from './model.ts';
+
+const repoRoot = () => process.env.ORACLE_REPO_ROOT || REPO_ROOT;
+const relativePath = (filePath: string) => path.relative(repoRoot(), filePath).split(path.sep).join('/');
+const inboxDir = () => tenantDataPath(path.join(repoRoot(), 'ψ/inbox'));
 
 export const inboxEndpoint = new Elysia().get(
   '/inbox',
@@ -15,11 +20,10 @@ export const inboxEndpoint = new Elysia().get(
     const offset = parseInt(query.offset ?? '0');
     const type = query.type ?? 'all';
 
-    const inboxDir = path.join(REPO_ROOT, 'ψ/inbox');
     const results: Array<{ filename: string; path: string; created: string; preview: string; type: string }> = [];
 
     if (type === 'all' || type === 'handoff') {
-      const handoffDir = path.join(inboxDir, 'handoff');
+      const handoffDir = path.join(inboxDir(), 'handoff');
       if (fs.existsSync(handoffDir)) {
         const files = fs.readdirSync(handoffDir)
           .filter(f => f.endsWith('.md'))
@@ -36,7 +40,7 @@ export const inboxEndpoint = new Elysia().get(
 
           results.push({
             filename: file,
-            path: `ψ/inbox/handoff/${file}`,
+            path: relativePath(filePath),
             created,
             preview: content.substring(0, 500),
             type: 'handoff',

--- a/src/routes/learn/list.ts
+++ b/src/routes/learn/list.ts
@@ -1,7 +1,8 @@
 import { Elysia } from 'elysia';
-import { and, desc, eq, isNull } from 'drizzle-orm';
+import { and, desc, eq, isNull, type SQL } from 'drizzle-orm';
 import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
 import { db, oracleDocuments } from '../../db/index.ts';
+import { currentTenantId } from '../../middleware/tenant.ts';
 
 type LearnDoc = typeof oracleDocuments.$inferSelect;
 
@@ -59,8 +60,11 @@ function learnEntry(row: LearnDoc) {
 }
 
 function listLearnEntries() {
+  const filters: SQL[] = [eq(oracleDocuments.type, 'learning'), isNull(oracleDocuments.supersededAt)];
+  const tenantId = currentTenantId();
+  if (tenantId) filters.push(eq(oracleDocuments.tenantId, tenantId));
   const rows = db.select().from(oracleDocuments)
-    .where(and(eq(oracleDocuments.type, 'learning'), isNull(oracleDocuments.supersededAt)))
+    .where(and(...filters))
     .orderBy(desc(oracleDocuments.updatedAt))
     .all();
   const items = rows.map(learnEntry);

--- a/tests/http/knowledge/tenant-isolation.test.ts
+++ b/tests/http/knowledge/tenant-isolation.test.ts
@@ -1,0 +1,90 @@
+import { afterAll, expect, test } from 'bun:test';
+import { inArray } from 'drizzle-orm';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tempData = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-knowledge-db-'));
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-knowledge-tenant-'));
+const previousData = process.env.ORACLE_DATA_DIR;
+const previousDb = process.env.ORACLE_DB_PATH;
+const previousRoot = process.env.ORACLE_REPO_ROOT;
+process.env.ORACLE_DATA_DIR = tempData;
+process.env.ORACLE_DB_PATH = path.join(tempData, 'oracle.db');
+process.env.ORACLE_REPO_ROOT = tempRoot;
+
+const dbModule = await import('../../../src/db/index.ts');
+dbModule.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+const { oracleDocuments } = dbModule;
+const { createTenantFetch, TENANT_HEADER } = await import('../../../src/middleware/tenant.ts');
+const { knowledgeRoutes } = await import('../../../src/routes/knowledge/index.ts');
+
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantA = `tenant-a-${stamp}`;
+const tenantB = `tenant-b-${stamp}`;
+const ids = [`knowledge-a-${stamp}`, `knowledge-b-${stamp}`];
+
+function requestKnowledge(tenantId: string, pathname: string, init: RequestInit = {}) {
+  return createTenantFetch((request) => knowledgeRoutes.handle(request))(new Request(`http://local${pathname}`, {
+    ...init,
+    headers: { 'content-type': 'application/json', [TENANT_HEADER]: tenantId, ...(init.headers ?? {}) },
+  }));
+}
+
+async function createLearn(tenantId: string, id: string, pattern: string) {
+  const res = await requestKnowledge(tenantId, '/api/learn', {
+    method: 'POST',
+    body: JSON.stringify({ id, pattern, concepts: ['tenant'] }),
+  });
+  expect(res.status).toBe(200);
+}
+
+afterAll(() => {
+  dbModule.db.delete(oracleDocuments).where(inArray(oracleDocuments.id, ids)).run();
+  for (const id of ids) dbModule.sqlite.prepare('DELETE FROM oracle_fts WHERE id = ?').run(id);
+  dbModule.closeDb();
+  if (previousData === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = previousData;
+  if (previousDb === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = previousDb;
+  if (previousRoot === undefined) delete process.env.ORACLE_REPO_ROOT;
+  else process.env.ORACLE_REPO_ROOT = previousRoot;
+  fs.rmSync(tempData, { recursive: true, force: true });
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+test('GET /api/learn lists only rows for the selected tenant', async () => {
+  await createLearn(tenantA, ids[0], `tenant A learning ${stamp}`);
+  await createLearn(tenantB, ids[1], `tenant B learning ${stamp}`);
+
+  const res = await requestKnowledge(tenantA, '/api/learn');
+  const body = await res.json() as { items: Array<{ id: string }> };
+  const listed = body.items.map((item) => item.id);
+
+  expect(res.status).toBe(200);
+  expect(listed).toContain(ids[0]);
+  expect(listed).not.toContain(ids[1]);
+});
+
+test('handoff inbox reads only files for the selected tenant', async () => {
+  const slugA = `handoff-a-${stamp}`;
+  const slugB = `handoff-b-${stamp}`;
+
+  expect((await requestKnowledge(tenantA, '/api/handoff', {
+    method: 'POST',
+    body: JSON.stringify({ content: `tenant A handoff ${stamp}`, slug: slugA }),
+  })).status).toBe(201);
+  expect((await requestKnowledge(tenantB, '/api/handoff', {
+    method: 'POST',
+    body: JSON.stringify({ content: `tenant B handoff ${stamp}`, slug: slugB }),
+  })).status).toBe(201);
+
+  const res = await requestKnowledge(tenantA, '/api/inbox?type=handoff&limit=50');
+  const body = await res.json() as { files: Array<{ filename: string; path: string }> };
+  const filenames = body.files.map((file) => file.filename);
+
+  expect(res.status).toBe(200);
+  expect(filenames.some((name) => name.includes(slugA))).toBe(true);
+  expect(filenames.some((name) => name.includes(slugB))).toBe(false);
+  expect(body.files.every((file) => file.path.includes(`/tenants/${tenantA}/`))).toBe(true);
+});


### PR DESCRIPTION
## Summary
- filter GET /api/learn by the active tenant_id when a tenant header is present
- store and list handoff inbox files under tenant-scoped inbox paths
- add knowledge tenant isolation regressions for learn list and inbox handoffs

## Tests
- bun test tests/http/knowledge/
- bunx tsc --noEmit
- wc -l src/routes/learn/list.ts src/routes/knowledge/handoff.ts src/routes/knowledge/inbox.ts tests/http/knowledge/tenant-isolation.test.ts