### PR TITLE
feat: warm embedding provider detection

### DIFF
--- a/src/routes/vector/config.ts
+++ b/src/routes/vector/config.ts
@@ -87,7 +87,7 @@ function configResponse(
     state: vectorConfigState(config, collections),
     options: {
       localEngines: LOCAL_VECTOR_ENGINES,
-      embeddingProviders: ['ollama', 'openai', 'cloudflare-ai', 'chromadb-internal'],
+      embeddingProviders: ['ollama', 'openai', 'gemini', 'cloudflare-ai', 'chromadb-internal'],
     },
     config,
     collections,

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import { createCorrelationMiddleware } from './middleware/correlation.ts';
 import { defaultUnifiedPluginDirs, loadUnifiedPlugins, seedUnifiedPluginMenuItems } from './plugins/unified-loader.ts';
 import { startUnifiedPluginServers } from './plugins/unified-server.ts';
 import { closeCachedVectorStores } from './vector/factory.ts';
+import { warmEmbeddingProviderDetection } from './vector/provider-detection.ts';
 import { drainingResponseFor, isDraining, registerGracefulShutdown, runShutdownSteps, trackRequest } from './lifecycle/shutdown.ts';
 import { createErrorMiddleware } from './middleware/errors.ts';
 import { validateStartupEnv } from './config/validate.ts';
@@ -80,6 +81,8 @@ try {
 }
 
 console.log('[Vector] mode:', VECTOR_URL ? 'proxy → ' + VECTOR_URL : 'local');
+void warmEmbeddingProviderDetection().catch((error) =>
+  console.warn('[Vector] embedding provider auto-detect failed:', error instanceof Error ? error.message : String(error)));
 
 try {
   console.log(`[DB] busy_timeout = ${JSON.stringify(sqlite.prepare('PRAGMA busy_timeout').get())}`);

--- a/src/vector-server.ts
+++ b/src/vector-server.ts
@@ -16,6 +16,7 @@ import { swagger } from '@elysiajs/swagger';
 
 import { createCorsMiddleware } from './middleware/cors.ts';
 import { loadVectorConfig, generateDefaultConfig } from './vector/config.ts';
+import { warmEmbeddingProviderDetection } from './vector/provider-detection.ts';
 import { vectorRoutes } from './routes/vector/index.ts';
 import { searchEndpoint } from './routes/search/search.ts';
 
@@ -24,6 +25,8 @@ import pkg from '../package.json' with { type: 'json' };
 // ── Config ──────────────────────────────────────────────────────────
 const config = loadVectorConfig() ?? generateDefaultConfig();
 const PORT = Number(process.env.VECTOR_PORT ?? config.port);
+void warmEmbeddingProviderDetection().catch((error) =>
+  console.warn('[Vector] embedding provider auto-detect failed:', error instanceof Error ? error.message : String(error)));
 
 // ── App ─────────────────────────────────────────────────────────────
 export function createVectorServerApp() {

--- a/src/vector/provider-detection.ts
+++ b/src/vector/provider-detection.ts
@@ -96,6 +96,12 @@ export async function getDetectedEmbeddingProviders(
   return cached;
 }
 
+export async function warmEmbeddingProviderDetection(
+  options: ProviderDetectionOptions = {},
+): Promise<{ checkedAt: string; providers: DetectedEmbeddingProvider[] }> {
+  return getDetectedEmbeddingProviders(false, options);
+}
+
 export function clearProviderDetectionCache(): void {
   cached = null;
 }

--- a/tests/http/vector/config-api.test.ts
+++ b/tests/http/vector/config-api.test.ts
@@ -64,6 +64,7 @@ test('GET and PUT /api/v1/vector/config expose and update vector-server.json', a
     adapter: 'lancedb',
   });
   expect(getRes.body.collections[0].count).toEqual(expect.any(Number));
+  expect(getRes.body.options.embeddingProviders).toContain('gemini');
 
   const testRes = await call('/api/v1/vector/config/phase1/test', { method: 'POST' });
   expect(testRes.status).toBe(200);

--- a/tests/vector/provider-detection.test.ts
+++ b/tests/vector/provider-detection.test.ts
@@ -1,5 +1,9 @@
 import { expect, mock, test } from 'bun:test';
-import { clearProviderDetectionCache, getDetectedEmbeddingProviders } from '../../src/vector/provider-detection.ts';
+import {
+  clearProviderDetectionCache,
+  getDetectedEmbeddingProviders,
+  warmEmbeddingProviderDetection,
+} from '../../src/vector/provider-detection.ts';
 
 test('provider detection caches probes until force refresh', async () => {
   clearProviderDetectionCache();
@@ -15,5 +19,20 @@ test('provider detection caches probes until force refresh', async () => {
   expect(cached.providers[0].models).toEqual(['model-1']);
   expect(forced.providers[0].models).toEqual(['model-2']);
   expect(fetcher).toHaveBeenCalledTimes(2);
+  clearProviderDetectionCache();
+});
+
+test('provider detection warmup seeds startup cache', async () => {
+  clearProviderDetectionCache();
+  let n = 0;
+  const fetcher = mock(async () => Response.json({ models: [{ name: `startup-${++n}` }] })) as unknown as typeof fetch;
+  const options = { env: {}, fetcher };
+
+  const warmed = await warmEmbeddingProviderDetection(options);
+  const cached = await getDetectedEmbeddingProviders(false, options);
+
+  expect(warmed.providers[0].models).toEqual(['startup-1']);
+  expect(cached.providers[0].models).toEqual(['startup-1']);
+  expect(fetcher).toHaveBeenCalledTimes(1);
   clearProviderDetectionCache();
 });


### PR DESCRIPTION
## Summary
- warm embedding provider detection during main and vector sidecar startup
- expose Gemini in vector config provider options
- add regression tests for provider-detection warmup and config provider options

## Tests
- bun test tests/vector/provider-detection.test.ts tests/http/vector/config-api.test.ts
- bunx tsc --noEmit
- ORACLE_DATA_DIR=/var/folders/lf/s98q6y892sl__0brv1tyn0ch0000gn/T/arra-http-XXXXXX.Dx8RxTrKve bun test tests/http/