### PR TITLE
feat(vector): add backend switch controls

### DIFF
--- a/cli/src/commands/catalog.ts
+++ b/cli/src/commands/catalog.ts
@@ -17,7 +17,7 @@ export const BUILTIN_COMMANDS: CommandSpec[] = [
   { command: "use", help: "set the global default API target" },
   { command: "completions", help: "print shell completion scripts", subcommands: ["bash", "zsh", "fish"], flags: ["--help", "-h"] },
   { command: "huginn", help: "run Huginn capture utilities", subcommands: ["sweep"], flags: ["--sessions-dir", "--repo-root", "--lookback-hours", "--max-files", "--json", "--help", "-h"] },
-  { command: "vector-config", help: "inspect and manage vector embedding collection config", subcommands: ["list", "get", "stats", "set", "reload", "test"], flags: ["--json", "--yml", "--help", "-h", "--model", "--provider", "--adapter", "--enabled"] },
+  { command: "vector-config", help: "inspect and manage vector embedding collection config", subcommands: ["list", "get", "stats", "set", "switch", "reload", "test"], flags: ["--json", "--yml", "--help", "-h", "--model", "--provider", "--adapter", "--enabled"] },
   { command: "migrate", help: "run Drizzle migration generate and push", flags: ["--help", "-h"] },
   { command: "seed", help: "populate development DB sample data", flags: ["--help", "-h"] },
   { command: "backup", help: "dump SQLite DB to timestamped SQL", flags: ["--out-dir", "--help", "-h"] },

--- a/cli/src/commands/vector-config.ts
+++ b/cli/src/commands/vector-config.ts
@@ -22,8 +22,8 @@ type VectorPayload = {
 type UpdatePayload = Partial<CollectionEntry>;
 
 const HELP = `arra-cli vector-config <subcommand>\n
-Subcommands:\n  list                                      list known vector collections\n  get <collection-key-or-name>              show config for one collection\n  stats [<collection-key-or-name>]          show doc count for collections\n  set <collection> <field> <value>          set model|provider|adapter|enabled|service|endpoint\n  set <collection> [--model <name>] [--provider <name>] [--adapter <name>] [--enabled <true|false>]\n  add <name> --model <name> [--collection <name>] [--adapter <name>] [--primary]\n  remove <collection> [--yes]               remove a collection config\n  set-primary <collection>                  mark collection as primary\n  reload                                    reload server vector config cache\n  test <collection-key-or-name>             probe adapter for one collection\n
-Examples:\n  arra-cli vector-config list\n  arra-cli vector-config add qwen4 --model qwen4-embedding --adapter lancedb\n  arra-cli vector-config set bge-m3 enabled false\n  arra-cli vector-config set bge-m3 --adapter qdrant --provider remote\n  arra-cli vector-config set-primary bge-m3\n\nOutput format: default JSON; pass --json or --yml for explicit format.`;
+Subcommands:\n  list                                      list known vector collections\n  get <collection-key-or-name>              show config for one collection\n  stats [<collection-key-or-name>]          show doc count for collections\n  set <collection> <field> <value>          set model|provider|adapter|enabled|service|endpoint\n  set <collection> [--model <name>] [--provider <name>] [--adapter <name>] [--enabled <true|false>]\n  switch <adapter> [--enabled <true|false>]    set all collection adapters\n  add <name> --model <name> [--collection <name>] [--adapter <name>] [--primary]\n  remove <collection> [--yes]               remove a collection config\n  set-primary <collection>                  mark collection as primary\n  reload                                    reload server vector config cache\n  test <collection-key-or-name>             probe adapter for one collection\n
+Examples:\n  arra-cli vector-config list\n  arra-cli vector-config add qwen4 --model qwen4-embedding --adapter lancedb\n  arra-cli vector-config set bge-m3 enabled false\n  arra-cli vector-config set bge-m3 --adapter qdrant --provider remote\n  arra-cli vector-config switch sqlite-vec --enabled true\n  arra-cli vector-config set-primary bge-m3\n\nOutput format: default JSON; pass --json or --yml for explicit format.`;
 
 function usage(message: string): never { throw new Error(message); }
 function hasHelpFlag(args: string[]): boolean { return args.includes("--help") || args.includes("-h"); }
@@ -73,6 +73,19 @@ function parseSetPayload(args: string[]): UpdatePayload {
   }
   if (!Object.keys(payload).length) usage("usage: arra-cli vector-config set ... (model|provider|adapter|enabled)");
   return payload;
+}
+
+function parseSwitchPayload(adapter: string | undefined, args: string[], state: VectorPayload): { collections: Record<string, CollectionEntry> } {
+  if (!adapter) usage('usage: arra-cli vector-config switch <adapter>');
+  if (!['lancedb', 'qdrant', 'chroma', 'sqlite-vec'].includes(adapter)) usage('switch adapter must be lancedb, qdrant, chroma, or sqlite-vec');
+  const enabledIndex = args.indexOf('--enabled');
+  const enabled = enabledIndex >= 0 ? parseBoolean(args[enabledIndex + 1]) : undefined;
+  return {
+    collections: Object.fromEntries(Object.entries(state.config.collections).map(([key, collection]) => [
+      key,
+      { ...collection, adapter, ...(enabled !== undefined && { enabled }) },
+    ])),
+  };
 }
 
 function parseAddPayload(args: string[]): UpdatePayload {
@@ -149,6 +162,7 @@ export async function vectorConfigCommand(args: string[]): Promise<number> {
     if (sub === "stats") { emitStats(await fetchPayload(), rest[0], args); return 0; }
     if (sub === "get") { emitOne(await fetchPayload(), requireCollection(rest, "get"), args); return 0; }
     if (sub === "set") return request(`${ENDPOINT}/${encodeURIComponent(requireCollection(rest, "set"))}`, "PUT", args, parseSetPayload(rest.slice(1)));
+    if (sub === "switch" || sub === "backend") return request(ENDPOINT, "PATCH", args, parseSwitchPayload(rest[0], rest.slice(1), await fetchPayload()));
     if (sub === "add") return request(`${ENDPOINT}/${encodeURIComponent(requireCollection(rest, "add"))}`, "POST", args, parseAddPayload(rest.slice(1)));
     if (sub === "remove" || sub === "rm") {
       const collection = requireCollection(rest, "remove");
@@ -159,7 +173,7 @@ export async function vectorConfigCommand(args: string[]): Promise<number> {
     if (sub === "reload") { if (rest.length) usage("usage: arra-cli vector-config reload"); return request(`${ENDPOINT}/reload`, "POST", args); }
     if (sub === "test") return testCollection(await fetchPayload(), requireCollection(rest, "test"), args);
     console.error(`unknown vector-config subcommand: ${sub}`);
-    console.error("try: arra-cli vector-config list|get|stats|set|add|remove|set-primary|reload|test");
+    console.error("try: arra-cli vector-config list|get|stats|set|switch|add|remove|set-primary|reload|test");
     return 1;
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));

--- a/frontend/src/components/VectorSearchToggle.tsx
+++ b/frontend/src/components/VectorSearchToggle.tsx
@@ -1,11 +1,17 @@
 import { useEffect, useMemo, useState } from 'react';
 import { ErrorMessage, Spinner } from './AsyncState';
 import {
+  ADAPTER_OPTIONS,
+  type VectorConfigAdapter,
   type VectorConfigResponse,
   fetchJson,
   parseVectorConfigResponse,
   toRows,
 } from '../pages/vectorSettingsHelpers';
+
+const SWITCHABLE_BACKENDS = ADAPTER_OPTIONS.filter((adapter) =>
+  ['lancedb', 'qdrant', 'chroma', 'sqlite-vec'].includes(adapter),
+);
 
 function enabledSummary(config: VectorConfigResponse | null): string {
   const rows = config ? toRows(config) : [];
@@ -23,14 +29,25 @@ function patchCollections(config: VectorConfigResponse, enabled: boolean) {
   );
 }
 
+function patchBackend(config: VectorConfigResponse, adapter: VectorConfigAdapter) {
+  return Object.fromEntries(
+    Object.entries(config.config.collections).map(([key, collection]) => [
+      key,
+      { ...collection, adapter },
+    ]),
+  );
+}
+
 export function VectorSearchToggle() {
   const [config, setConfig] = useState<VectorConfigResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [switching, setSwitching] = useState(false);
   const [error, setError] = useState('');
   const [message, setMessage] = useState('');
   const rows = useMemo(() => config ? toRows(config) : [], [config]);
   const enabled = rows.length > 0 && rows.every((row) => row.enabled);
+  const backend = SWITCHABLE_BACKENDS.includes(config?.engine ?? 'lancedb') ? config?.engine ?? 'lancedb' : 'lancedb';
 
   async function load() {
     setError('');
@@ -45,6 +62,26 @@ export function VectorSearchToggle() {
   }
 
   useEffect(() => { void load(); }, []);
+
+  async function switchBackend(nextAdapter: VectorConfigAdapter) {
+    if (!config) return;
+    setSwitching(true);
+    setError('');
+    setMessage('');
+    try {
+      await fetchJson('/api/v1/vector/config', {
+        method: 'PATCH',
+        body: JSON.stringify({ collections: patchBackend(config, nextAdapter) }),
+      });
+      await fetchJson('/api/v1/vector/config/reload', { method: 'POST' });
+      await load();
+      setMessage(`Switched configured vector collections to ${nextAdapter}.`);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setSwitching(false);
+    }
+  }
 
   async function toggle(nextEnabled: boolean) {
     if (!config) return;
@@ -72,18 +109,31 @@ export function VectorSearchToggle() {
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Vector Search panel</p>
           <h2 id="vector-search-toggle-title" className="mt-2 text-2xl font-semibold text-white">Enable vector search</h2>
-          <p className="mt-2 text-sm text-slate-400">Toggle collection indexing and hot-reload adapters through PATCH /api/v1/vector/config.</p>
+          <p className="mt-2 text-sm text-slate-400">Toggle collection indexing, switch all collection backends, and hot-reload adapters through PATCH /api/v1/vector/config.</p>
           <p className="mt-2 text-xs text-slate-500">{loading ? 'Loading vector search switch…' : enabledSummary(config)}</p>
         </div>
-        <label className="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3 text-sm font-semibold text-slate-100">
-          <input
-            checked={enabled}
-            disabled={loading || saving || !config || rows.length === 0}
-            type="checkbox"
-            onChange={(event) => void toggle(event.target.checked)}
-          />
-          {saving ? <Spinner label="Saving" /> : enabled ? 'Enabled' : 'Disabled'}
-        </label>
+        <div className="flex flex-wrap items-center gap-3">
+          <label className="grid gap-2 text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+            Backend adapter
+            <select
+              className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm text-slate-100"
+              disabled={loading || switching || !config || rows.length === 0}
+              value={backend}
+              onChange={(event) => void switchBackend(event.target.value as VectorConfigAdapter)}
+            >
+              {SWITCHABLE_BACKENDS.map((adapter) => <option key={adapter} value={adapter}>{adapter}</option>)}
+            </select>
+          </label>
+          <label className="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3 text-sm font-semibold text-slate-100">
+            <input
+              checked={enabled}
+              disabled={loading || saving || !config || rows.length === 0}
+              type="checkbox"
+              onChange={(event) => void toggle(event.target.checked)}
+            />
+            {saving ? <Spinner label="Saving" /> : enabled ? 'Enabled' : 'Disabled'}
+          </label>
+        </div>
       </div>
       {message ? <p className="mt-4 rounded-2xl border border-teal-300/20 bg-teal-300/10 p-3 text-sm text-teal-100">{message}</p> : null}
       {error ? <div className="mt-4"><ErrorMessage title="Vector search toggle failed." message={error} /></div> : null}

--- a/frontend/src/pages/vectorSettingsHelpers.ts
+++ b/frontend/src/pages/vectorSettingsHelpers.ts
@@ -37,6 +37,9 @@ export type VectorConfigHealth = {
 
 export type VectorConfigResponse = {
   source: 'file' | 'defaults';
+  engine: VectorConfigAdapter;
+  enabled: boolean;
+  options: { localEngines: VectorConfigAdapter[] };
   config: VectorServerConfig;
   doc_counts: Record<string, number>;
   health: Record<string, VectorConfigHealth>;
@@ -93,6 +96,9 @@ export function parseVectorConfigResponse(value: unknown): VectorConfigResponse 
       embeddingEndpoint: '',
       embedder: { backend: 'unknown' },
     },
+    engine: 'lancedb' as VectorConfigAdapter,
+    enabled: false,
+    options: { localEngines: ['lancedb', 'qdrant', 'sqlite-vec'] as VectorConfigAdapter[] },
     doc_counts: {},
     health: {},
     checked_at: new Date().toISOString(),
@@ -101,6 +107,10 @@ export function parseVectorConfigResponse(value: unknown): VectorConfigResponse 
   if (!isRecord(value)) return fallback;
   const configValue = isRecord(value.config) ? value.config : {};
   const rawCollections = isRecord(configValue.collections) ? configValue.collections : {};
+  const rawOptions = isRecord(value.options) ? value.options : {};
+  const localEngines = Array.isArray(rawOptions.localEngines)
+    ? rawOptions.localEngines.filter(isAdapter)
+    : fallback.options.localEngines;
   const safeCollections: Record<string, VectorServerCollection> = {};
 
   Object.entries(rawCollections).forEach(([key, item]) => {
@@ -118,6 +128,9 @@ export function parseVectorConfigResponse(value: unknown): VectorConfigResponse 
 
   return {
     source: value.source === 'file' ? 'file' : 'defaults',
+    engine: safeAdapter(value.engine),
+    enabled: value.enabled === true,
+    options: { localEngines },
     config: {
       version: typeof configValue.version === 'string' ? configValue.version : fallback.config.version,
       host: typeof configValue.host === 'string' ? configValue.host : fallback.config.host,

--- a/src/cli/commands/vector-config.ts
+++ b/src/cli/commands/vector-config.ts
@@ -1,4 +1,5 @@
 import { closeCachedVectorStores } from '../../vector/factory.ts';
+import type { VectorDBType } from '../../vector/types.ts';
 import {
   activeConfig,
   atomicWriteVectorConfig,
@@ -19,6 +20,7 @@ function usage(out: Writer): void {
     '       bun run src/cli/index.ts vector-config get [collection] [--json]',
     '       bun run src/cli/index.ts vector-config set <collection> <field> <value> [--json]',
     '       bun run src/cli/index.ts vector-config set <collection> --adapter <name> [--url <url>]',
+    '       bun run src/cli/index.ts vector-config switch <adapter> [--enabled true|false]',
     '       bun run src/cli/index.ts vector-config test <collection>',
     '       bun run src/cli/index.ts vector-config reload',
   ].join('\n') + '\n');
@@ -110,6 +112,30 @@ async function getCollection(args: string[], jsonOut: boolean, out: Writer): Pro
   return 0;
 }
 
+async function switchBackend(args: string[], jsonOut: boolean, out: Writer): Promise<number> {
+  const requested = args[1];
+  if (!requested) throw new Error('switch requires <adapter>');
+  const adapter = parseValue('adapter', requested) as VectorDBType;
+  if (!['lancedb', 'qdrant', 'chroma', 'sqlite-vec'].includes(adapter)) {
+    throw new Error('switch adapter must be lancedb, qdrant, chroma, or sqlite-vec');
+  }
+  const enabledIndex = args.indexOf('--enabled');
+  const enabledValue = args[enabledIndex + 1];
+  if (enabledIndex >= 0 && (!enabledValue || enabledValue.startsWith('--'))) throw new Error('--enabled value required');
+  const enabled = enabledIndex >= 0 ? parseValue('enabled', enabledValue) as boolean : undefined;
+  const { source, config } = activeConfig();
+  const collections = Object.fromEntries(Object.entries(config.collections).map(([key, current]) => [
+    key,
+    { ...current, adapter, ...(enabled !== undefined && { enabled }) },
+  ]));
+  const next: typeof config = { ...config, collections };
+  const path = atomicWriteVectorConfig(next);
+  await closeCachedVectorStores();
+  if (jsonOut) out(JSON.stringify({ success: true, source, path, adapter, config: next }, null, 2) + '\n');
+  else out(`switched vector backend adapter to ${adapter} across ${Object.keys(collections).length} collections\npath: ${path}\n`);
+  return 0;
+}
+
 async function setField(args: string[], jsonOut: boolean, out: Writer): Promise<number> {
   const [, collection, ...rawUpdates] = args;
   if (!collection) throw new Error('set requires <collection>');
@@ -145,6 +171,7 @@ export async function vectorConfigCommand(args: string[], stdout: Writer = proce
     if (command === 'list') return readState(flag(rest, '--json'), stdout);
     if (command === 'get') return getCollection(cleanArgs(rest), flag(rest, '--json'), stdout);
     if (command === 'set') return setField(cleanArgs(rest), flag(rest, '--json'), stdout);
+    if (command === 'switch' || command === 'backend') return switchBackend(cleanArgs(rest), flag(rest, '--json'), stdout);
     if (command === 'test') return testCollection(cleanArgs(rest), stdout);
     if (command === 'reload') { await closeCachedVectorStores(); stdout('vector config runtime cache reloaded\n'); return 0; }
     throw new Error(`unknown vector-config command: ${command}`);

--- a/tests/cli/vector-config/cli.test.ts
+++ b/tests/cli/vector-config/cli.test.ts
@@ -73,8 +73,13 @@ describe("arra-cli vector-config", () => {
       async fetch(req) {
         const url = new URL(req.url);
         if (url.pathname === "/api/v1/vector/config") {
-          if (req.method !== "GET") return payload({ error: "method not allowed" }, 405);
-          return payload(state);
+          if (req.method === "GET") return payload(state);
+          if (req.method === "PATCH") {
+            const patch = (await req.json()) as Partial<VectorState["config"]>;
+            state.config = { ...state.config, ...patch };
+            return payload({ success: true, source: state.source, path: "/tmp/vector-server.json", config: state.config });
+          }
+          return payload({ error: "method not allowed" }, 405);
         }
 
         if (url.pathname === "/api/v1/vector/config/reload" && req.method === "POST") {
@@ -180,6 +185,12 @@ describe("arra-cli vector-config", () => {
     expect(disable.code).toBe(0);
     const disabled = await runCli(["vector-config", "get", "phase2"], env);
     expect(tryParseJson(disabled.stdout)?.config?.enabled).toBe(false);
+
+    const switched = await runCli(["vector-config", "switch", "sqlite-vec", "--enabled", "true"], env);
+    expect(switched.code).toBe(0);
+    const switchedPayload = tryParseJson(switched.stdout);
+    expect(switchedPayload?.config?.collections?.phase2?.adapter).toBe("sqlite-vec");
+    expect(switchedPayload?.config?.collections?.phase2?.enabled).toBe(true);
   });
 
   test("supports collection ops", async () => {

--- a/tests/cli/vector-config/source-command.test.ts
+++ b/tests/cli/vector-config/source-command.test.ts
@@ -105,5 +105,11 @@ describe('src vector-config command get/set', () => {
       primary: true,
     });
     expect(written.collections['bge-m3'].primary).toBe(false);
+
+    const switched = await run(['switch', 'sqlite-vec', '--enabled', 'true', '--json']);
+    expect(switched.code).toBe(0);
+    const afterSwitch = diskConfig();
+    expect(afterSwitch.collections.phase2).toMatchObject({ adapter: 'sqlite-vec', enabled: true });
+    expect(afterSwitch.collections['bge-m3']).toMatchObject({ adapter: 'sqlite-vec', enabled: true });
   });
 });

--- a/tests/frontend/pages/vector-settings-page.test.tsx
+++ b/tests/frontend/pages/vector-settings-page.test.tsx
@@ -15,6 +15,7 @@ describe('VectorSettingsPage', () => {
     expect(html).toContain('Embedding providers and storage services');
     expect(html).toContain('Model recommendation');
     expect(html).toContain('Active vector adapters');
+    expect(html).toContain('switch all collection backends');
     expect(html).toContain('edit model/provider');
     expect(html).toContain('set primary');
     expect(html).toContain('Index jobs and collections');

--- a/tests/http/vector/config-api.test.ts
+++ b/tests/http/vector/config-api.test.ts
@@ -110,6 +110,20 @@ test('GET and PUT /api/v1/vector/config expose and update vector-server.json', a
     adapter: 'qdrant',
   });
 
+  const switchRes = await call('/api/v1/vector/config', {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      collections: Object.fromEntries(Object.entries(putRes.body.config.collections).map(([key, value]) => [
+        key,
+        { ...(value as Record<string, unknown>), adapter: 'sqlite-vec', enabled: true },
+      ])),
+    }),
+  });
+  expect(switchRes.status).toBe(200);
+  expect(switchRes.body.config.collections.phase1).toMatchObject({ adapter: 'sqlite-vec', enabled: true });
+  expect(vectorConfig.loadVectorConfig(vectorConfig.configPath(root))?.collections.phase1.adapter).toBe('sqlite-vec');
+
   const disabledRes = await call('/api/v1/vector/config/phase1', {
     method: 'PUT',
     headers: { 'content-type': 'application/json' },
@@ -165,6 +179,6 @@ test('GET and PUT /api/v1/vector/config expose and update vector-server.json', a
   const reloadRes = await call('/api/v1/vector/config/reload', { method: 'POST' });
   expect(reloadRes.status).toBe(200);
   expect(reloadRes.body).toMatchObject({ success: true, reloaded: true, source: 'file' });
-  expect(reloadRes.body.config.collections.phase1.adapter).toBe('qdrant');
+  expect(reloadRes.body.config.collections.phase1.adapter).toBe('sqlite-vec');
   expect(readdirSync(root).some((name) => name.includes('.tmp'))).toBe(false);
 });

--- a/tests/tools/maw-plugin-arra/vector-config.test.ts
+++ b/tests/tools/maw-plugin-arra/vector-config.test.ts
@@ -120,4 +120,21 @@ describe('tools maw arra vector-config command', () => {
     expect(calls[0].url).toBe('http://arra.test/api/v1/vector/config/nomic');
     expect(calls[0].body).toEqual({ enabled: false });
   });
+
+  test('switches all collection adapters through the config patch API', async () => {
+    const { result, calls } = await run(['vector-config', 'switch', 'sqlite-vec', '--enabled', 'true']);
+
+    expect(result.ok).toBe(true);
+    expect(calls.map((call) => call.url)).toEqual([
+      'http://arra.test/api/v1/vector/config',
+      'http://arra.test/api/v1/vector/config',
+    ]);
+    expect(calls[1].init?.method).toBe('PATCH');
+    expect(calls[1].body).toMatchObject({
+      collections: {
+        'bge-m3': { adapter: 'sqlite-vec', enabled: true },
+        nomic: { adapter: 'sqlite-vec', enabled: true },
+      },
+    });
+  });
 });

--- a/tools/maw-plugin-arra/commands/vector-config.ts
+++ b/tools/maw-plugin-arra/commands/vector-config.ts
@@ -4,10 +4,12 @@ const usage = [
   'usage: maw arra vector-config list|get [collection]',
   '       maw arra vector-config set <collection> <field> <value>',
   '       maw arra vector-config add <collection> --model <model> [--adapter <adapter>]',
+  '       maw arra vector-config switch <lancedb|qdrant|chroma|sqlite-vec> [--enabled true|false]',
   '       maw arra vector-config remove|set-primary|test <collection>',
   '       maw arra vector-config reload',
 ].join('\n');
 const adapters = new Set(['chroma', 'sqlite-vec', 'lancedb', 'qdrant', 'cloudflare-vectorize', 'proxy', 'turbovec']);
+const switchableAdapters = new Set(['chroma', 'sqlite-vec', 'lancedb', 'qdrant']);
 const updateFields = new Set(['adapter', 'model', 'provider', 'service', 'endpoint', 'enabled', 'primary', 'embedder']);
 const createFields = new Set([...updateFields, 'collection']);
 
@@ -93,6 +95,15 @@ async function writeCollection(collection: string, body: JsonObject): Promise<Js
   return text ? JSON.parse(text) as JsonObject : {};
 }
 
+async function patchConfig(body: JsonObject): Promise<JsonObject> {
+  const text = await requestText('/api/v1/vector/config', {
+    method: 'PATCH',
+    headers: { accept: 'application/json', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return text ? JSON.parse(text) as JsonObject : {};
+}
+
 async function createCollection(collection: string, body: JsonObject): Promise<JsonObject> {
   const text = await requestText(`/api/v1/vector/config/${encodeURIComponent(collection)}`, {
     method: 'POST',
@@ -121,6 +132,22 @@ function requiredCollection(parsed: ParsedArgs): string {
   return collection;
 }
 
+async function switchBackend(parsed: ParsedArgs): Promise<JsonObject> {
+  const adapter = parseValue('adapter', requiredCollection(parsed));
+  if (typeof adapter !== 'string' || !switchableAdapters.has(adapter)) {
+    throw new Error('switch adapter must be lancedb, qdrant, chroma, or sqlite-vec');
+  }
+  const enabledRaw = flag(parsed, 'enabled');
+  const enabled = enabledRaw === undefined ? undefined : bool(enabledRaw);
+  const payload = await readConfig();
+  const collections = Object.fromEntries(Object.entries(configCollections(payload)).map(([key, value]) => [
+    key,
+    { ...object(value), adapter, ...(enabled !== undefined && { enabled }) },
+  ]));
+  if (Object.keys(collections).length === 0) throw new Error('no vector collections configured');
+  return patchConfig({ collections });
+}
+
 export async function runVectorConfigCommand(args: string[]): Promise<string> {
   const parsed = parseArgs(args);
   const action = (parsed.positionals[0] ?? 'list').toLowerCase().replace(/-/g, '_');
@@ -133,6 +160,7 @@ export async function runVectorConfigCommand(args: string[]): Promise<string> {
   if (action === 'set') {
     return json(await writeCollection(requiredCollection(parsed), updateBody(parsed)));
   }
+  if (action === 'switch' || action === 'backend') return json(await switchBackend(parsed));
   if (action === 'add') {
     const collection = requiredCollection(parsed);
     const body = flagUpdates(parsed, createFields);
@@ -152,4 +180,4 @@ export async function runVectorConfigCommand(args: string[]): Promise<string> {
   throw new Error(usage);
 }
 
-export const VECTOR_CONFIG_HELP = 'vector-config list|get|set|add|remove|set-primary|reload|test';
+export const VECTOR_CONFIG_HELP = 'vector-config list|get|set|switch|add|remove|set-primary|reload|test';


### PR DESCRIPTION
## Summary
- add one-shot vector backend switching across configured collections to maw/arra vector-config CLIs
- add a Vector Settings backend adapter selector that PATCHes vector config and reloads adapters
- cover backend-switch persistence through vector HTTP tests plus CLI/UI tests

## Validation
- bun test tests/http/vector/ tests/tools/maw-plugin-arra/vector-config.test.ts tests/cli/vector-config/cli.test.ts tests/cli/vector-config/source-command.test.ts tests/frontend/pages/vector-settings-page.test.tsx
- bunx tsc --noEmit
- changed files <=250 lines

Resolves #1595