### PR TITLE
fix: stabilize export verifier CI

### DIFF
--- a/cli/src/commands/catalog.ts
+++ b/cli/src/commands/catalog.ts
@@ -17,7 +17,7 @@ export const BUILTIN_COMMANDS: CommandSpec[] = [
   { command: "use", help: "set the global default API target" },
   { command: "completions", help: "print shell completion scripts", subcommands: ["bash", "zsh", "fish"], flags: ["--help", "-h"] },
   { command: "huginn", help: "run Huginn capture utilities", subcommands: ["sweep"], flags: ["--sessions-dir", "--repo-root", "--lookback-hours", "--max-files", "--json", "--help", "-h"] },
-  { command: "vector-config", help: "inspect and manage vector embedding collection config", subcommands: ["list", "get", "stats", "set", "reload", "test"], flags: ["--json", "--yml", "--help", "-h", "--model", "--provider", "--adapter", "--enabled"] },
+  { command: "vector-config", help: "inspect and manage vector embedding collection config", subcommands: ["list", "get", "stats", "set", "switch", "reload", "test"], flags: ["--json", "--yml", "--help", "-h", "--model", "--provider", "--adapter", "--enabled"] },
   { command: "migrate", help: "run Drizzle migration generate and push", flags: ["--help", "-h"] },
   { command: "seed", help: "populate development DB sample data", flags: ["--help", "-h"] },
   { command: "backup", help: "dump SQLite DB to timestamped SQL", flags: ["--out-dir", "--help", "-h"] },

--- a/cli/src/commands/vector-config.ts
+++ b/cli/src/commands/vector-config.ts
@@ -22,8 +22,8 @@ type VectorPayload = {
 type UpdatePayload = Partial<CollectionEntry>;
 
 const HELP = `arra-cli vector-config <subcommand>\n
-Subcommands:\n  list                                      list known vector collections\n  get <collection-key-or-name>              show config for one collection\n  stats [<collection-key-or-name>]          show doc count for collections\n  set <collection> <field> <value>          set model|provider|adapter|enabled|service|endpoint\n  set <collection> [--model <name>] [--provider <name>] [--adapter <name>] [--enabled <true|false>]\n  add <name> --model <name> [--collection <name>] [--adapter <name>] [--primary]\n  remove <collection> [--yes]               remove a collection config\n  set-primary <collection>                  mark collection as primary\n  reload                                    reload server vector config cache\n  test <collection-key-or-name>             probe adapter for one collection\n
-Examples:\n  arra-cli vector-config list\n  arra-cli vector-config add qwen4 --model qwen4-embedding --adapter lancedb\n  arra-cli vector-config set bge-m3 enabled false\n  arra-cli vector-config set bge-m3 --adapter qdrant --provider remote\n  arra-cli vector-config set-primary bge-m3\n\nOutput format: default JSON; pass --json or --yml for explicit format.`;
+Subcommands:\n  list                                      list known vector collections\n  get <collection-key-or-name>              show config for one collection\n  stats [<collection-key-or-name>]          show doc count for collections\n  set <collection> <field> <value>          set model|provider|adapter|enabled|service|endpoint\n  set <collection> [--model <name>] [--provider <name>] [--adapter <name>] [--enabled <true|false>]\n  switch <adapter> [--enabled <true|false>]    set all collection adapters\n  add <name> --model <name> [--collection <name>] [--adapter <name>] [--primary]\n  remove <collection> [--yes]               remove a collection config\n  set-primary <collection>                  mark collection as primary\n  reload                                    reload server vector config cache\n  test <collection-key-or-name>             probe adapter for one collection\n
+Examples:\n  arra-cli vector-config list\n  arra-cli vector-config add qwen4 --model qwen4-embedding --adapter lancedb\n  arra-cli vector-config set bge-m3 enabled false\n  arra-cli vector-config set bge-m3 --adapter qdrant --provider remote\n  arra-cli vector-config switch sqlite-vec --enabled true\n  arra-cli vector-config set-primary bge-m3\n\nOutput format: default JSON; pass --json or --yml for explicit format.`;
 
 function usage(message: string): never { throw new Error(message); }
 function hasHelpFlag(args: string[]): boolean { return args.includes("--help") || args.includes("-h"); }
@@ -73,6 +73,19 @@ function parseSetPayload(args: string[]): UpdatePayload {
   }
   if (!Object.keys(payload).length) usage("usage: arra-cli vector-config set ... (model|provider|adapter|enabled)");
   return payload;
+}
+
+function parseSwitchPayload(adapter: string | undefined, args: string[], state: VectorPayload): { collections: Record<string, CollectionEntry> } {
+  if (!adapter) usage('usage: arra-cli vector-config switch <adapter>');
+  if (!['lancedb', 'qdrant', 'chroma', 'sqlite-vec'].includes(adapter)) usage('switch adapter must be lancedb, qdrant, chroma, or sqlite-vec');
+  const enabledIndex = args.indexOf('--enabled');
+  const enabled = enabledIndex >= 0 ? parseBoolean(args[enabledIndex + 1]) : undefined;
+  return {
+    collections: Object.fromEntries(Object.entries(state.config.collections).map(([key, collection]) => [
+      key,
+      { ...collection, adapter, ...(enabled !== undefined && { enabled }) },
+    ])),
+  };
 }
 
 function parseAddPayload(args: string[]): UpdatePayload {
@@ -149,6 +162,7 @@ export async function vectorConfigCommand(args: string[]): Promise<number> {
     if (sub === "stats") { emitStats(await fetchPayload(), rest[0], args); return 0; }
     if (sub === "get") { emitOne(await fetchPayload(), requireCollection(rest, "get"), args); return 0; }
     if (sub === "set") return request(`${ENDPOINT}/${encodeURIComponent(requireCollection(rest, "set"))}`, "PUT", args, parseSetPayload(rest.slice(1)));
+    if (sub === "switch" || sub === "backend") return request(ENDPOINT, "PATCH", args, parseSwitchPayload(rest[0], rest.slice(1), await fetchPayload()));
     if (sub === "add") return request(`${ENDPOINT}/${encodeURIComponent(requireCollection(rest, "add"))}`, "POST", args, parseAddPayload(rest.slice(1)));
     if (sub === "remove" || sub === "rm") {
       const collection = requireCollection(rest, "remove");
@@ -159,7 +173,7 @@ export async function vectorConfigCommand(args: string[]): Promise<number> {
     if (sub === "reload") { if (rest.length) usage("usage: arra-cli vector-config reload"); return request(`${ENDPOINT}/reload`, "POST", args); }
     if (sub === "test") return testCollection(await fetchPayload(), requireCollection(rest, "test"), args);
     console.error(`unknown vector-config subcommand: ${sub}`);
-    console.error("try: arra-cli vector-config list|get|stats|set|add|remove|set-primary|reload|test");
+    console.error("try: arra-cli vector-config list|get|stats|set|switch|add|remove|set-primary|reload|test");
     return 1;
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));

--- a/frontend/src/components/VectorIndexPanel.tsx
+++ b/frontend/src/components/VectorIndexPanel.tsx
@@ -6,14 +6,26 @@ import {
   type VectorIndexStatusResponse,
 } from '../api/client';
 import { ErrorMessage, LoadingPanel, Spinner } from './AsyncState';
+import { fetchJson } from '../pages/vectorSettingsHelpers';
 
 type VectorIndexClient = Pick<ApiClient, 'startVectorIndex' | 'vectorIndexModels' | 'vectorIndexStatus'>;
+
+type VectorCostEstimate = {
+  formula: string;
+  estimatedUsd: number;
+  provider: string;
+  recommendation?: string;
+};
 
 interface VectorIndexPanelProps {
   client?: VectorIndexClient;
   initialModels?: Record<string, VectorIndexCollection>;
   initialStatus?: VectorIndexStatusResponse | null;
+  initialCostEstimate?: VectorCostEstimate | null;
+  loadCostEstimate?: () => Promise<VectorCostEstimate>;
 }
+
+const loadDefaultCostEstimate = () => fetchJson<VectorCostEstimate>('/api/v1/vector/cost-estimate');
 
 export function formatIndexEta(seconds: number): string {
   if (!Number.isFinite(seconds) || seconds <= 0) return 'calculating';
@@ -30,6 +42,10 @@ function progressFor(status: VectorIndexStatusResponse): number {
 
 function totalVectors(models: Record<string, VectorIndexCollection>): number {
   return Object.values(models).reduce((sum, model) => sum + (model.count ?? 0), 0);
+}
+
+function formatCost(value: number): string {
+  return value === 0 ? 'Free / local' : `$${value.toFixed(4)}`;
 }
 
 function gapLabel(models: Record<string, VectorIndexCollection>, status: VectorIndexStatusResponse | null): string {
@@ -54,10 +70,18 @@ function vaultState(model: VectorIndexCollection): string {
   return (model.count ?? 0) > 0 ? 'indexed' : 'not indexed';
 }
 
-export function VectorIndexPanel({ client = apiClient, initialModels, initialStatus = null }: VectorIndexPanelProps) {
+export function VectorIndexPanel({
+  client = apiClient,
+  initialModels,
+  initialStatus = null,
+  initialCostEstimate,
+  loadCostEstimate = loadDefaultCostEstimate,
+}: VectorIndexPanelProps) {
   const [models, setModels] = useState<Record<string, VectorIndexCollection>>(initialModels ?? {});
   const [loading, setLoading] = useState(!initialModels);
   const [status, setStatus] = useState<VectorIndexStatusResponse | null>(initialStatus);
+  const [costEstimate, setCostEstimate] = useState<VectorCostEstimate | null>(initialCostEstimate ?? null);
+  const [costError, setCostError] = useState('');
   const [error, setError] = useState('');
   const [startingKey, setStartingKey] = useState<string | null>(null);
 
@@ -89,6 +113,15 @@ export function VectorIndexPanel({ client = apiClient, initialModels, initialSta
       .catch((err) => { if (active) setError(err instanceof Error ? err.message : String(err)); });
     return () => { active = false; };
   }, [client]);
+
+  useEffect(() => {
+    if (initialCostEstimate !== undefined) return;
+    let active = true;
+    loadCostEstimate()
+      .then((next) => { if (active) setCostEstimate(next); })
+      .catch((err) => { if (active) setCostError(err instanceof Error ? err.message : String(err)); });
+    return () => { active = false; };
+  }, [initialCostEstimate, loadCostEstimate]);
 
   useEffect(() => {
     if (!indexing || typeof window === 'undefined') return;
@@ -136,6 +169,14 @@ export function VectorIndexPanel({ client = apiClient, initialModels, initialSta
         <p className="mt-1 text-sm text-amber-100">Gap indicator: {gapLabel(models, status)}</p>
         {status ? <IndexProgress status={status} /> : null}
       </div>
+
+      {costEstimate ? (
+        <div className="mb-4 rounded-2xl border border-teal-200/20 bg-teal-200/10 p-4 text-sm text-teal-50/90">
+          <p className="font-semibold text-teal-100">Preflight cost before Index Now</p>
+          <p className="mt-1">{costEstimate.formula} · {costEstimate.provider}: {formatCost(costEstimate.estimatedUsd)}</p>
+          {costEstimate.recommendation ? <p className="mt-1 text-teal-100/75">{costEstimate.recommendation}</p> : null}
+        </div>
+      ) : costError ? <p className="mb-4 text-sm text-amber-100">Cost estimate unavailable: {costError}</p> : null}
 
       {loading ? <LoadingPanel title="Loading vector collections…" detail="Fetching /api/v1/vector/index/models." /> : null}
       {error ? <ErrorMessage title="Vector indexing failed." message={error} /> : null}

--- a/frontend/src/components/VectorSearchToggle.tsx
+++ b/frontend/src/components/VectorSearchToggle.tsx
@@ -1,11 +1,17 @@
 import { useEffect, useMemo, useState } from 'react';
 import { ErrorMessage, Spinner } from './AsyncState';
 import {
+  ADAPTER_OPTIONS,
+  type VectorConfigAdapter,
   type VectorConfigResponse,
   fetchJson,
   parseVectorConfigResponse,
   toRows,
 } from '../pages/vectorSettingsHelpers';
+
+const SWITCHABLE_BACKENDS = ADAPTER_OPTIONS.filter((adapter) =>
+  ['lancedb', 'qdrant', 'chroma', 'sqlite-vec'].includes(adapter),
+);
 
 function enabledSummary(config: VectorConfigResponse | null): string {
   const rows = config ? toRows(config) : [];
@@ -23,14 +29,25 @@ function patchCollections(config: VectorConfigResponse, enabled: boolean) {
   );
 }
 
+function patchBackend(config: VectorConfigResponse, adapter: VectorConfigAdapter) {
+  return Object.fromEntries(
+    Object.entries(config.config.collections).map(([key, collection]) => [
+      key,
+      { ...collection, adapter },
+    ]),
+  );
+}
+
 export function VectorSearchToggle() {
   const [config, setConfig] = useState<VectorConfigResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [switching, setSwitching] = useState(false);
   const [error, setError] = useState('');
   const [message, setMessage] = useState('');
   const rows = useMemo(() => config ? toRows(config) : [], [config]);
   const enabled = rows.length > 0 && rows.every((row) => row.enabled);
+  const backend = SWITCHABLE_BACKENDS.includes(config?.engine ?? 'lancedb') ? config?.engine ?? 'lancedb' : 'lancedb';
 
   async function load() {
     setError('');
@@ -45,6 +62,26 @@ export function VectorSearchToggle() {
   }
 
   useEffect(() => { void load(); }, []);
+
+  async function switchBackend(nextAdapter: VectorConfigAdapter) {
+    if (!config) return;
+    setSwitching(true);
+    setError('');
+    setMessage('');
+    try {
+      await fetchJson('/api/v1/vector/config', {
+        method: 'PATCH',
+        body: JSON.stringify({ collections: patchBackend(config, nextAdapter) }),
+      });
+      await fetchJson('/api/v1/vector/config/reload', { method: 'POST' });
+      await load();
+      setMessage(`Switched configured vector collections to ${nextAdapter}.`);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setSwitching(false);
+    }
+  }
 
   async function toggle(nextEnabled: boolean) {
     if (!config) return;
@@ -72,18 +109,31 @@ export function VectorSearchToggle() {
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Vector Search panel</p>
           <h2 id="vector-search-toggle-title" className="mt-2 text-2xl font-semibold text-white">Enable vector search</h2>
-          <p className="mt-2 text-sm text-slate-400">Toggle collection indexing and hot-reload adapters through PATCH /api/v1/vector/config.</p>
+          <p className="mt-2 text-sm text-slate-400">Toggle collection indexing, switch all collection backends, and hot-reload adapters through PATCH /api/v1/vector/config.</p>
           <p className="mt-2 text-xs text-slate-500">{loading ? 'Loading vector search switch…' : enabledSummary(config)}</p>
         </div>
-        <label className="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3 text-sm font-semibold text-slate-100">
-          <input
-            checked={enabled}
-            disabled={loading || saving || !config || rows.length === 0}
-            type="checkbox"
-            onChange={(event) => void toggle(event.target.checked)}
-          />
-          {saving ? <Spinner label="Saving" /> : enabled ? 'Enabled' : 'Disabled'}
-        </label>
+        <div className="flex flex-wrap items-center gap-3">
+          <label className="grid gap-2 text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+            Backend adapter
+            <select
+              className="focus-ring rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm text-slate-100"
+              disabled={loading || switching || !config || rows.length === 0}
+              value={backend}
+              onChange={(event) => void switchBackend(event.target.value as VectorConfigAdapter)}
+            >
+              {SWITCHABLE_BACKENDS.map((adapter) => <option key={adapter} value={adapter}>{adapter}</option>)}
+            </select>
+          </label>
+          <label className="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3 text-sm font-semibold text-slate-100">
+            <input
+              checked={enabled}
+              disabled={loading || saving || !config || rows.length === 0}
+              type="checkbox"
+              onChange={(event) => void toggle(event.target.checked)}
+            />
+            {saving ? <Spinner label="Saving" /> : enabled ? 'Enabled' : 'Disabled'}
+          </label>
+        </div>
       </div>
       {message ? <p className="mt-4 rounded-2xl border border-teal-300/20 bg-teal-300/10 p-3 text-sm text-teal-100">{message}</p> : null}
       {error ? <div className="mt-4"><ErrorMessage title="Vector search toggle failed." message={error} /></div> : null}

--- a/frontend/src/pages/IndexManagerPanel.tsx
+++ b/frontend/src/pages/IndexManagerPanel.tsx
@@ -1,110 +1,16 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
 import { apiClient, type ApiClient, type VectorIndexCollection, type VectorIndexStatusResponse } from '../api/client';
-import { ErrorMessage, LoadingPanel, Spinner } from '../components/AsyncState';
+import { VectorIndexPanel } from '../components/VectorIndexPanel';
 
 type VectorIndexClient = Pick<ApiClient, 'startVectorIndex' | 'vectorIndexModels' | 'vectorIndexStatus'>;
 
-function progressFor(status: VectorIndexStatusResponse): number {
-  if (status.total <= 0) return status.status === 'completed' ? 100 : 0;
-  return Math.min(100, Math.round((status.current / status.total) * 100));
-}
-
-function gapLabel(models: Record<string, VectorIndexCollection>): string {
-  const total = Object.values(models).reduce((sum, model) => sum + (model.count ?? 0), 0);
-  if (!total) return 'No vectors indexed yet — first backfill recommended.';
-  return `${total.toLocaleString()} vectors tracked across ${Object.keys(models).length} models.`;
-}
-
-function statusSummary(status: VectorIndexStatusResponse | null): string {
-  if (!status || status.status === 'idle') return 'No active index job.';
-  if (status.status === 'completed') return `Completed ${status.model} reindex.`;
-  if (status.status === 'error') return `Failed ${status.model} reindex.`;
-  return `⏳ Backfilling ${status.model}... ${status.current.toLocaleString()}/${status.total.toLocaleString()} (${progressFor(status)}%)`;
-}
-
-export function IndexManagerPanel({ client = apiClient }: { client?: VectorIndexClient }) {
-  const [models, setModels] = useState<Record<string, VectorIndexCollection>>({});
-  const [loading, setLoading] = useState(true);
-  const [status, setStatus] = useState<VectorIndexStatusResponse | null>(null);
-  const [error, setError] = useState('');
-  const [startingKey, setStartingKey] = useState<string | null>(null);
-  const modelEntries = useMemo(() => Object.entries(models).sort(([a], [b]) => a.localeCompare(b)), [models]);
-  const indexing = status?.status === 'indexing';
-
-  const refreshStatus = useCallback(async () => {
-    const next = await client.vectorIndexStatus();
-    setStatus(next);
-    return next;
-  }, [client]);
-
-  async function refreshAll() {
-    setError('');
-    try {
-      const [modelResponse, nextStatus] = await Promise.all([client.vectorIndexModels(), client.vectorIndexStatus()]);
-      setModels(modelResponse.models);
-      setStatus(nextStatus);
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  useEffect(() => { void refreshAll(); }, [client]);
-  useEffect(() => {
-    if (!indexing || typeof window === 'undefined') return;
-    const timer = window.setInterval(() => void refreshStatus().catch((err) => setError(err instanceof Error ? err.message : String(err))), 2000);
-    return () => window.clearInterval(timer);
-  }, [indexing, refreshStatus]);
-
-  async function startReindex(key: string) {
-    setStartingKey(key);
-    setError('');
-    try {
-      await client.startVectorIndex(key);
-      await refreshStatus();
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
-    } finally {
-      setStartingKey(null);
-    }
-  }
-
-  return (
-    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-index-title">
-      <div className="mb-5 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-300">Index Manager</p>
-          <h2 id="vector-index-title" className="mt-2 text-2xl font-semibold text-white">Reindex and backfill vectors</h2>
-          <p className="mt-2 text-sm text-slate-400">Trigger model rebuilds and poll active progress.</p>
-        </div>
-        <button className="focus-ring rounded-xl border border-white/10 px-3 py-2 text-sm text-slate-200" type="button" onClick={() => void refreshAll()}>Refresh</button>
-      </div>
-
-      <div className="mb-4 rounded-2xl border border-white/10 bg-white/[0.03] p-4">
-        <p className="text-sm font-semibold text-slate-200">{statusSummary(status)}</p>
-        <p className="mt-1 text-sm text-slate-500">{gapLabel(models)}</p>
-        {status ? <IndexProgress status={status} /> : null}
-      </div>
-
-      {loading ? <LoadingPanel title="Loading vector collections…" detail="Fetching /api/v1/vector/index/models." /> : null}
-      {error ? <ErrorMessage title="Vector indexing failed." message={error} /> : null}
-      <div className="grid gap-3 md:grid-cols-2">
-        {modelEntries.map(([key, model]) => (
-          <article key={key} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
-            <div className="flex items-start justify-between gap-3">
-              <div><h3 className="font-mono text-base font-semibold text-teal-200">{key}</h3><p className="mt-1 text-sm text-slate-300">{model.collection}</p></div>
-              <button className="focus-ring rounded-xl bg-purple-300 px-3 py-2 text-sm font-semibold text-slate-950 disabled:opacity-50" disabled={Boolean(startingKey) || indexing} type="button" onClick={() => void startReindex(key)}>{startingKey === key ? <Spinner label="Starting" /> : 'Index now'}</button>
-            </div>
-            <dl className="mt-4 grid gap-2 text-sm text-slate-400"><div><dt className="inline text-slate-500">Model: </dt><dd className="inline">{model.model}</dd></div><div><dt className="inline text-slate-500">Adapter: </dt><dd className="inline">{model.adapter}</dd></div><div><dt className="inline text-slate-500">Vectors: </dt><dd className="inline">{model.count ?? 0}</dd></div></dl>
-          </article>
-        ))}
-      </div>
-    </section>
-  );
-}
-
-function IndexProgress({ status }: { status: VectorIndexStatusResponse }) {
-  const progress = progressFor(status);
-  return <div className="mt-3"><div className="h-2 overflow-hidden rounded-full bg-slate-800" role="progressbar" aria-valuemin={0} aria-valuemax={100} aria-valuenow={progress}><div className="h-full rounded-full bg-purple-300 transition-all" style={{ width: `${progress}%` }} /></div>{status.error ? <p className="mt-2 text-sm text-red-200">{status.error}</p> : null}</div>;
+export function IndexManagerPanel({
+  client = apiClient,
+  initialModels,
+  initialStatus = null,
+}: {
+  client?: VectorIndexClient;
+  initialModels?: Record<string, VectorIndexCollection>;
+  initialStatus?: VectorIndexStatusResponse | null;
+}) {
+  return <VectorIndexPanel client={client} initialModels={initialModels} initialStatus={initialStatus} />;
 }

--- a/frontend/src/pages/VectorSettingsPage.tsx
+++ b/frontend/src/pages/VectorSettingsPage.tsx
@@ -1,23 +1,39 @@
-import { Link } from 'react-router-dom';
+import { useCallback, useEffect, useState } from 'react';
+import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
 import { VectorConfigPanel } from '../components/VectorConfigPanel';
+import { VectorFirstRunWizard } from '../components/VectorFirstRunWizard';
 import { VectorIndexPanel } from '../components/VectorIndexPanel';
 import { VectorModelRecommendationCard } from '../components/VectorModelRecommendationCard';
 import { VectorProviderServicePanel } from '../components/VectorProviderServicePanel';
 import { VectorSearchToggle } from '../components/VectorSearchToggle';
-import { vectorIndexPath } from '../routePaths';
+import { fetchJson, parseVectorConfigResponse, toRows, type VectorConfigRow } from './vectorSettingsHelpers';
 
-function FirstRunWizardCard() {
+function VectorFirstRunWizardSection() {
+  const [rows, setRows] = useState<VectorConfigRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const refresh = useCallback(async () => {
+    setError('');
+    setLoading(true);
+    try {
+      const body = await fetchJson<unknown>('/api/v1/vector/config');
+      setRows(toRows(parseVectorConfigResponse(body)));
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void refresh(); }, [refresh]);
+
   return (
-    <section className="rounded-3xl border border-purple-300/20 bg-purple-300/10 p-5 sm:p-6" aria-labelledby="vector-first-run-title">
-      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-200">First-run wizard</p>
-      <h2 id="vector-first-run-title" className="mt-2 text-2xl font-semibold text-white">Provider → vault → first index</h2>
-      <p className="mt-2 text-sm text-purple-100/80">
-        The setup wizard appears automatically when FTS docs are empty and vector search is disabled. Use the Index Manager to watch first-run backfill progress.
-      </p>
-      <Link className="focus-ring mt-4 inline-flex rounded-xl border border-purple-200/40 px-4 py-2 text-sm font-semibold text-purple-100 hover:bg-purple-200/10" to={vectorIndexPath()}>
-        Open Index Manager
-      </Link>
-    </section>
+    <div className="grid gap-3">
+      <VectorFirstRunWizard rows={rows} onRefresh={refresh} />
+      {loading ? <LoadingPanel title="Loading first-run collections…" detail="Fetching /api/v1/vector/config." /> : null}
+      {error ? <ErrorMessage title="Could not load first-run vector config." message={error} /> : null}
+    </div>
   );
 }
 
@@ -28,12 +44,12 @@ export function VectorSettingsPage() {
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Vector settings</p>
         <h1 id="vector-settings-title" className="mt-2 text-3xl font-semibold text-white">Vector settings</h1>
         <p className="mt-2 text-sm text-slate-400">
-          Configure adapters, embedding models, vector search, storage services, and backfill jobs.
+          Configure adapters, embedding models and providers, storage services, first-run indexing, and backfill jobs.
         </p>
       </header>
 
       <VectorSearchToggle />
-      <FirstRunWizardCard />
+      <VectorFirstRunWizardSection />
       <VectorProviderServicePanel />
       <VectorModelRecommendationCard />
       <VectorConfigPanel />

--- a/frontend/src/pages/vectorSettingsHelpers.ts
+++ b/frontend/src/pages/vectorSettingsHelpers.ts
@@ -37,6 +37,9 @@ export type VectorConfigHealth = {
 
 export type VectorConfigResponse = {
   source: 'file' | 'defaults';
+  engine: VectorConfigAdapter;
+  enabled: boolean;
+  options: { localEngines: VectorConfigAdapter[] };
   config: VectorServerConfig;
   doc_counts: Record<string, number>;
   health: Record<string, VectorConfigHealth>;
@@ -93,6 +96,9 @@ export function parseVectorConfigResponse(value: unknown): VectorConfigResponse 
       embeddingEndpoint: '',
       embedder: { backend: 'unknown' },
     },
+    engine: 'lancedb' as VectorConfigAdapter,
+    enabled: false,
+    options: { localEngines: ['lancedb', 'qdrant', 'sqlite-vec'] as VectorConfigAdapter[] },
     doc_counts: {},
     health: {},
     checked_at: new Date().toISOString(),
@@ -101,6 +107,10 @@ export function parseVectorConfigResponse(value: unknown): VectorConfigResponse 
   if (!isRecord(value)) return fallback;
   const configValue = isRecord(value.config) ? value.config : {};
   const rawCollections = isRecord(configValue.collections) ? configValue.collections : {};
+  const rawOptions = isRecord(value.options) ? value.options : {};
+  const localEngines = Array.isArray(rawOptions.localEngines)
+    ? rawOptions.localEngines.filter(isAdapter)
+    : fallback.options.localEngines;
   const safeCollections: Record<string, VectorServerCollection> = {};
 
   Object.entries(rawCollections).forEach(([key, item]) => {
@@ -118,6 +128,9 @@ export function parseVectorConfigResponse(value: unknown): VectorConfigResponse 
 
   return {
     source: value.source === 'file' ? 'file' : 'defaults',
+    engine: safeAdapter(value.engine),
+    enabled: value.enabled === true,
+    options: { localEngines },
     config: {
       version: typeof configValue.version === 'string' ? configValue.version : fallback.config.version,
       host: typeof configValue.host === 'string' ? configValue.host : fallback.config.host,

--- a/frontend/src/plugin-surfaces.ts
+++ b/frontend/src/plugin-surfaces.ts
@@ -11,6 +11,10 @@ export type Surface =
   | 'exportFormats';
 
 function add(surfaceSet: Set<Surface>, surface: unknown): void {
+  if (surface === 'mcpTools') {
+    surfaceSet.add('mcp');
+    return;
+  }
   if (surface === 'wasm' || surface === 'menu' || surface === 'server' || surface === 'mcp' || surface === 'apiRoutes' || surface === 'proxy' || surface === 'cliSubcommands' || surface === 'exportFormats') {
     surfaceSet.add(surface);
   }

--- a/src/cli/commands/vector-config.ts
+++ b/src/cli/commands/vector-config.ts
@@ -1,4 +1,5 @@
 import { closeCachedVectorStores } from '../../vector/factory.ts';
+import type { VectorDBType } from '../../vector/types.ts';
 import {
   activeConfig,
   atomicWriteVectorConfig,
@@ -19,6 +20,7 @@ function usage(out: Writer): void {
     '       bun run src/cli/index.ts vector-config get [collection] [--json]',
     '       bun run src/cli/index.ts vector-config set <collection> <field> <value> [--json]',
     '       bun run src/cli/index.ts vector-config set <collection> --adapter <name> [--url <url>]',
+    '       bun run src/cli/index.ts vector-config switch <adapter> [--enabled true|false]',
     '       bun run src/cli/index.ts vector-config test <collection>',
     '       bun run src/cli/index.ts vector-config reload',
   ].join('\n') + '\n');
@@ -110,6 +112,30 @@ async function getCollection(args: string[], jsonOut: boolean, out: Writer): Pro
   return 0;
 }
 
+async function switchBackend(args: string[], jsonOut: boolean, out: Writer): Promise<number> {
+  const requested = args[1];
+  if (!requested) throw new Error('switch requires <adapter>');
+  const adapter = parseValue('adapter', requested) as VectorDBType;
+  if (!['lancedb', 'qdrant', 'chroma', 'sqlite-vec'].includes(adapter)) {
+    throw new Error('switch adapter must be lancedb, qdrant, chroma, or sqlite-vec');
+  }
+  const enabledIndex = args.indexOf('--enabled');
+  const enabledValue = args[enabledIndex + 1];
+  if (enabledIndex >= 0 && (!enabledValue || enabledValue.startsWith('--'))) throw new Error('--enabled value required');
+  const enabled = enabledIndex >= 0 ? parseValue('enabled', enabledValue) as boolean : undefined;
+  const { source, config } = activeConfig();
+  const collections = Object.fromEntries(Object.entries(config.collections).map(([key, current]) => [
+    key,
+    { ...current, adapter, ...(enabled !== undefined && { enabled }) },
+  ]));
+  const next: typeof config = { ...config, collections };
+  const path = atomicWriteVectorConfig(next);
+  await closeCachedVectorStores();
+  if (jsonOut) out(JSON.stringify({ success: true, source, path, adapter, config: next }, null, 2) + '\n');
+  else out(`switched vector backend adapter to ${adapter} across ${Object.keys(collections).length} collections\npath: ${path}\n`);
+  return 0;
+}
+
 async function setField(args: string[], jsonOut: boolean, out: Writer): Promise<number> {
   const [, collection, ...rawUpdates] = args;
   if (!collection) throw new Error('set requires <collection>');
@@ -145,6 +171,7 @@ export async function vectorConfigCommand(args: string[], stdout: Writer = proce
     if (command === 'list') return readState(flag(rest, '--json'), stdout);
     if (command === 'get') return getCollection(cleanArgs(rest), flag(rest, '--json'), stdout);
     if (command === 'set') return setField(cleanArgs(rest), flag(rest, '--json'), stdout);
+    if (command === 'switch' || command === 'backend') return switchBackend(cleanArgs(rest), flag(rest, '--json'), stdout);
     if (command === 'test') return testCollection(cleanArgs(rest), stdout);
     if (command === 'reload') { await closeCachedVectorStores(); stdout('vector config runtime cache reloaded\n'); return 0; }
     throw new Error(`unknown vector-config command: ${command}`);

--- a/src/forum/handler.ts
+++ b/src/forum/handler.ts
@@ -70,8 +70,10 @@ export function getThread(threadId: number): ForumThread | null {
   return row ? toForumThread(row) : null;
 }
 
-export function updateThreadStatus(threadId: number, status: ThreadStatus): void {
+export function updateThreadStatus(threadId: number, status: ThreadStatus): boolean {
+  if (!getThread(threadId)) return false;
   db.update(forumThreads).set({ status, updatedAt: Date.now() }).where(threadWhere(threadId)).run();
+  return true;
 }
 
 export function listThreads(options: {
@@ -104,6 +106,7 @@ export function addMessage(
   content: string,
   options: { author?: string; principlesFound?: number; patternsFound?: number; searchQuery?: string } = {},
 ): ForumMessage {
+  if (!getThread(threadId)) throw new Error(`Thread ${threadId} not found`);
   const now = Date.now();
   const result = db.insert(forumMessages).values({
     threadId,
@@ -130,6 +133,7 @@ export function addMessage(
 }
 
 export function getMessages(threadId: number): ForumMessage[] {
+  if (!getThread(threadId)) return [];
   return db.select()
     .from(forumMessages)
     .where(eq(forumMessages.threadId, threadId))

--- a/src/indexer/__tests__/append-reindex.test.ts
+++ b/src/indexer/__tests__/append-reindex.test.ts
@@ -24,19 +24,21 @@ process.env.ORACLE_DATA_DIR = dataDir;
 process.env.ORACLE_DB_PATH = path.join(dataDir, 'oracle.db');
 delete process.env.ORACLE_REPO_ROOT;
 
+const { createDatabase, closeDb, resetDefaultDatabaseForTests } = await import('../../db/index.ts');
+resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
 const { runOracleReindex } = await import('../runner.ts');
-const { createDatabase, closeDb } = await import('../../db/index.ts');
 
 describe('append reindex mode', () => {
   afterAll(() => {
     try { closeDb(); } catch {}
-    fs.rmSync(tmp, { recursive: true, force: true });
     if (originalDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
     else process.env.ORACLE_DATA_DIR = originalDataDir;
     if (originalDbPath === undefined) delete process.env.ORACLE_DB_PATH;
     else process.env.ORACLE_DB_PATH = originalDbPath;
     if (originalRepoRoot === undefined) delete process.env.ORACLE_REPO_ROOT;
     else process.env.ORACLE_REPO_ROOT = originalRepoRoot;
+    resetDefaultDatabaseForTests(':memory:');
+    fs.rmSync(tmp, { recursive: true, force: true });
   });
 
   test('upserts from a new repo root without deleting older indexed docs', async () => {

--- a/src/indexer/__tests__/psi-fts-index.test.ts
+++ b/src/indexer/__tests__/psi-fts-index.test.ts
@@ -23,19 +23,21 @@ process.env.ORACLE_DATA_DIR = dataDir;
 process.env.ORACLE_DB_PATH = path.join(dataDir, 'oracle.db');
 delete process.env.ORACLE_REPO_ROOT;
 
+const { createDatabase, closeDb, resetDefaultDatabaseForTests } = await import('../../db/index.ts');
+resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
 const { normalizeIndexerRepoRoot, runOracleReindex } = await import('../runner.ts');
-const { createDatabase, closeDb } = await import('../../db/index.ts');
 
 describe('ψ-folder detection → FTS indexing', () => {
   afterAll(() => {
     try { closeDb(); } catch {}
-    fs.rmSync(tmp, { recursive: true, force: true });
     if (originalDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
     else process.env.ORACLE_DATA_DIR = originalDataDir;
     if (originalDbPath === undefined) delete process.env.ORACLE_DB_PATH;
     else process.env.ORACLE_DB_PATH = originalDbPath;
     if (originalRepoRoot === undefined) delete process.env.ORACLE_REPO_ROOT;
     else process.env.ORACLE_REPO_ROOT = originalRepoRoot;
+    resetDefaultDatabaseForTests(':memory:');
+    fs.rmSync(tmp, { recursive: true, force: true });
   });
 
   test('normalizes an explicit ψ path to its repo root', () => {

--- a/src/indexer/runner.ts
+++ b/src/indexer/runner.ts
@@ -43,7 +43,7 @@ export function resolveIndexerRepoRoot(explicitRoot?: string | null): string {
 export function createIndexerConfig(repoRoot: string): IndexerConfig {
   return {
     repoRoot,
-    dbPath: DB_PATH,
+    dbPath: process.env.ORACLE_DB_PATH || DB_PATH,
     chromaPath: CHROMADB_DIR,
     sourcePaths: {
       resonance: 'ψ/memory/resonance',

--- a/src/plugins/__tests__/arra-plugin-commands.test.ts
+++ b/src/plugins/__tests__/arra-plugin-commands.test.ts
@@ -20,14 +20,32 @@ describe("built-in arra plugin command registry", () => {
 
   test("commands --json mirrors the HTTP registry payload", async () => {
     const result = await arraCli({ source: "cli", plugin: "arra", args: ["commands", "--json"], config });
-    const http = arraHttpRoute({ source: "api", plugin: "arra", config });
-    const payload = JSON.parse(result.output ?? "{}") as typeof http.body;
+    const http = await arraHttpRoute({ source: "api", plugin: "arra", config });
+    type RegistryBody = { surface: string; verbs: Array<{ name: string }>; backends: unknown; remoteEmbedderConfigured: boolean };
+    const payload = JSON.parse(result.output ?? "{}") as RegistryBody;
+    const httpBody = http.body as RegistryBody;
 
     expect(result.ok).toBe(true);
     expect(payload.surface).toBe("cli");
-    expect(payload.verbs.map((verb) => verb.name)).toEqual(http.body.verbs.map((verb) => verb.name));
-    expect(payload.backends).toEqual(http.body.backends);
+    expect(payload.verbs.map((verb) => verb.name)).toEqual(httpBody.verbs.map((verb) => verb.name));
+    expect(payload.backends).toEqual(httpBody.backends);
     expect(payload.remoteEmbedderConfigured).toBe(true);
+  });
+
+  test("runs shared commands through the menu API payload", async () => {
+    const version = await arraHttpRoute({ source: "api", plugin: "arra", args: { command: "version" } });
+    const registry = await arraHttpRoute({
+      source: "api",
+      plugin: "arra",
+      args: { command: "commands", json: true },
+      config,
+    });
+    const unknown = await arraHttpRoute({ source: "api", plugin: "arra", args: { command: "missing" } });
+
+    expect(version.body).toEqual({ ok: true, command: "version", output: "arra 1.0.0" });
+    expect((registry.body as { surface: string }).surface).toBe("api");
+    expect((registry.body as { verbs: Array<{ name: string }> }).verbs.map((verb) => verb.name)).toContain("commands");
+    expect(unknown).toEqual({ ok: false, status: 400, error: "unknown arra command: missing" });
   });
 
   test("normalizes modern maw help and version flags", async () => {

--- a/src/plugins/__tests__/arra-plugin.test.ts
+++ b/src/plugins/__tests__/arra-plugin.test.ts
@@ -18,6 +18,7 @@ describe("built-in arra plugin", () => {
     expect(manifest.cli.handler).toBe("arraCli");
     expect(manifest.verbs).toEqual(ARRA_VERBS);
     expect(manifest.httpRoutes[0].path).toBe("/api/plugins/arra");
+    expect(manifest.apiRoutes[0].methods).toEqual(["GET", "POST"]);
     expect(manifest.config).toMatchObject({ dbBackend: "sqlite", embedderBackend: "none" });
     expect(manifest.configSchema.properties.dbBackend.enum).toEqual(["sqlite", "http", "memory", "custom"]);
   });
@@ -54,6 +55,18 @@ describe("built-in arra plugin", () => {
     expect(body.backends.embedder.optional).toBe(true);
     expect(body.backends.embedder.supported).toContain("remote");
     expect(body.verbs.map((verb) => verb.name)).toEqual(ARRA_VERBS);
+
+    const version = await app.handle(new Request("http://local/api/plugins/arra?command=version"));
+    expect(await version.json()).toEqual({ ok: true, command: "version", output: "arra 1.0.0" });
+
+    const commands = await app.handle(new Request("http://local/api/plugins/arra", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ command: "commands", json: true }),
+    }));
+    const commandsBody = await commands.json() as { surface: string; verbs: Array<{ name: string }> };
+    expect(commandsBody.surface).toBe("api");
+    expect(commandsBody.verbs.map((verb) => verb.name)).toEqual(ARRA_VERBS);
   });
 
   test("delegates maw arra health to vector engine details", async () => {

--- a/src/plugins/__tests__/unified-loader.test.ts
+++ b/src/plugins/__tests__/unified-loader.test.ts
@@ -43,12 +43,16 @@ describe('unified plugin loader', () => {
       server: { command: 'bun', args: ['--version'], autostart: false },
       menu: [{ label: 'Surface Pack', path: '/surface-pack', group: 'tools', order: 42 }],
       cliSubcommands: [{ command: 'surface-pack', help: 'surface cli', handler: 'cli' }],
+      exportFormats: [{ name: 'surface-pack', handler: 'exporter' }],
     }, `
       export function api(ctx) {
         return { ok: true, body: { plugin: ctx.plugin, method: ctx.request.method, body: ctx.body } };
       }
       export function tool(ctx) {
         return { ok: true, body: { plugin: ctx.plugin, source: ctx.source, args: ctx.args } };
+      }
+      export function exporter() {
+        return { data: 'surface-pack' };
       }
     `);
 
@@ -62,6 +66,16 @@ describe('unified plugin loader', () => {
     expect(runtime.cliSubcommands.map((cmd) => cmd.command)).toEqual(['surface-pack']);
     expect(runtime.servers.map((server) => server.plugin)).toEqual(['surface-pack']);
     expect(runtime.routes).toHaveLength(3);
+    const registryEntry = runtime.pluginRegistry().find((plugin) => plugin.name === 'surface-pack');
+    expect(registryEntry).toMatchObject({
+      surfaces: ['mcpTools', 'apiRoutes', 'proxy', 'server', 'menu', 'cliSubcommands', 'exportFormats'],
+      mcpTools: [{ name: 'oracle_surface_pack', source: 'plugin', plugin: 'surface-pack' }],
+      apiRoutes: [{ path: '/api/surface-pack', methods: ['POST'] }],
+      proxy: [{ path: '/api/surface-proxy', targetEnv: 'SURFACE_PROXY_URL' }],
+      cliSubcommands: [{ command: 'surface-pack', help: 'surface cli' }],
+      exportFormats: [{ name: 'surface-pack', extension: 'surface-pack' }],
+    });
+    expect(registryEntry?.mcpTools[0]).not.toHaveProperty('handler');
 
     const app = new Elysia();
     for (const route of runtime.routes) app.use(route as any);

--- a/src/plugins/arra/index.ts
+++ b/src/plugins/arra/index.ts
@@ -11,7 +11,8 @@ type ArraPluginConfig = {
 type ArraPluginContext = {
   source: "api" | "mcp" | "cli" | "server" | "init" | "destroy";
   plugin: string;
-  args?: unknown[];
+  args?: unknown[] | Record<string, unknown>;
+  body?: unknown;
   request?: Request;
   config?: ArraPluginConfig;
 };
@@ -26,6 +27,7 @@ type ArraVerb = {
 };
 
 type CliResult = { ok: boolean; output?: string; error?: string };
+type ArraApiResult = { ok: boolean; body?: unknown; error?: string; status?: number };
 
 const VERSION = "1.0.0";
 const MENU_PATH = "/plugins/arra";
@@ -50,7 +52,21 @@ const VERBS: ArraVerb[] = [
 ];
 
 function argv(ctx: ArraPluginContext): string[] {
-  return (ctx.args ?? []).map(String);
+  const args = inputArgv(ctx.args);
+  return args.length ? args : inputArgv(ctx.body);
+}
+
+function inputArgv(input: unknown): string[] {
+  if (Array.isArray(input)) return input.map(String);
+  if (!input || typeof input !== "object") return [];
+  const record = input as Record<string, unknown>;
+  if (Array.isArray(record.args)) return record.args.map(String);
+  const command = record.command ?? record.cmd;
+  if (typeof command !== "string" || !command.trim()) return [];
+  const args = [command.trim()];
+  if (Array.isArray(record.argv)) args.push(...record.argv.map(String));
+  if (record.json === true || record.json === "true" || record.format === "json") args.push("--json");
+  return args;
 }
 
 function commandName(ctx: ArraPluginContext): string {
@@ -132,8 +148,23 @@ async function renderCli(ctx: ArraPluginContext): Promise<CliResult> {
   return renderHelp();
 }
 
-export function arraHttpRoute(ctx: ArraPluginContext) {
-  return { ok: true, body: pluginBody(ctx) };
+function jsonOutput(result: CliResult): unknown | undefined {
+  if (!result.output) return undefined;
+  try {
+    return JSON.parse(result.output);
+  } catch {
+    return undefined;
+  }
+}
+
+export async function arraHttpRoute(ctx: ArraPluginContext): Promise<ArraApiResult> {
+  if (!argv(ctx).length) return { ok: true, body: pluginBody(ctx) };
+  const result = await renderCli(ctx);
+  if (!result.ok) return { ok: false, status: 400, error: result.error };
+  return {
+    ok: true,
+    body: jsonOutput(result) ?? { ok: true, command: commandName(ctx), output: result.output },
+  };
 }
 
 export async function arraCli(ctx: ArraPluginContext) {

--- a/src/plugins/arra/plugin.json
+++ b/src/plugins/arra/plugin.json
@@ -10,7 +10,8 @@
     {
       "path": "/api/plugins/arra",
       "methods": [
-        "GET"
+        "GET",
+        "POST"
       ]
     }
   ],
@@ -18,7 +19,8 @@
     {
       "path": "/api/plugins/arra",
       "methods": [
-        "GET"
+        "GET",
+        "POST"
       ],
       "handler": "arraHttpRoute"
     }

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -9,6 +9,12 @@ import {
 } from './unified-manifest.ts';
 import type { LoadedUnifiedPlugin, UnifiedPluginStatus } from './unified-loader.ts';
 
+type PluginManifest = LoadedUnifiedPlugin['manifest'];
+type PublicMcpTool = Omit<PluginManifest['mcpTools'][number], 'handler'> & { source: 'plugin'; plugin: string };
+type PublicApiRoute = Omit<PluginManifest['apiRoutes'][number], 'handler'>;
+type PublicCliSubcommand = Omit<PluginManifest['cliSubcommands'][number], 'handler'>;
+type PublicExportFormat = { name: string; extension: string };
+
 export interface LoadedPluginRegistryEntry {
   name: string;
   version: string;
@@ -19,6 +25,11 @@ export interface LoadedPluginRegistryEntry {
   description?: string;
   menu?: UnifiedMenuManifest;
   server?: ReturnType<typeof publicUnifiedServerManifest>;
+  mcpTools: PublicMcpTool[];
+  apiRoutes: PublicApiRoute[];
+  proxy: PluginManifest['proxy'];
+  cliSubcommands: PublicCliSubcommand[];
+  exportFormats: PublicExportFormat[];
   file: string;
   size: number;
   modified: string;
@@ -26,6 +37,22 @@ export interface LoadedPluginRegistryEntry {
 
 function manifestModified(plugin: LoadedUnifiedPlugin): string {
   return statSync(join(plugin.dir, 'plugin.json')).mtime.toISOString();
+}
+
+function publicMcpTools(manifest: PluginManifest): PublicMcpTool[] {
+  return manifest.mcpTools.map(({ handler, ...tool }) => ({ ...tool, source: 'plugin', plugin: manifest.name }));
+}
+
+function publicApiRoutes(manifest: PluginManifest): PublicApiRoute[] {
+  return manifest.apiRoutes.map(({ handler, ...route }) => route);
+}
+
+function publicCliSubcommands(manifest: PluginManifest): PublicCliSubcommand[] {
+  return manifest.cliSubcommands.map(({ handler, ...command }) => command);
+}
+
+function publicExportFormats(manifest: PluginManifest): PublicExportFormat[] {
+  return manifest.exportFormats.map((format) => ({ name: format.name, extension: format.name }));
 }
 
 export function pluginRegistryFromLoadedPlugins(
@@ -45,6 +72,11 @@ export function pluginRegistryFromLoadedPlugins(
       description: plugin.manifest.description,
       menu: plugin.manifest.menu[0],
       server: publicUnifiedServerManifest(plugin.manifest.server),
+      mcpTools: publicMcpTools(plugin.manifest),
+      apiRoutes: publicApiRoutes(plugin.manifest),
+      proxy: plugin.manifest.proxy,
+      cliSubcommands: publicCliSubcommands(plugin.manifest),
+      exportFormats: publicExportFormats(plugin.manifest),
       file: '',
       size: 0,
       modified: manifestModified(plugin),

--- a/src/routes/forum/thread-create.ts
+++ b/src/routes/forum/thread-create.ts
@@ -23,7 +23,7 @@ export const threadCreateRoute = new Elysia().post('/api/thread', async ({ body,
       issue_url: result.issueUrl,
     };
   } catch (error) {
-    set.status = 500;
+    set.status = error instanceof Error && /Thread \d+ not found/.test(error.message) ? 404 : 500;
     return { error: error instanceof Error ? error.message : 'Unknown error' };
   }
 }, {

--- a/src/routes/forum/thread-status.ts
+++ b/src/routes/forum/thread-status.ts
@@ -4,13 +4,20 @@ import { threadIdParam, threadStatusBody } from './model.ts';
 
 export const threadStatusRoute = new Elysia().patch('/api/thread/:id/status', async ({ params, body, set }) => {
   const threadId = parseInt(params.id, 10);
+  if (Number.isNaN(threadId)) {
+    set.status = 400;
+    return { error: 'Invalid thread ID' };
+  }
   try {
     const data = body as any;
     if (!data.status) {
       set.status = 400;
       return { error: 'Missing required field: status' };
     }
-    updateThreadStatus(threadId, data.status);
+    if (!updateThreadStatus(threadId, data.status)) {
+      set.status = 404;
+      return { error: 'Thread not found' };
+    }
     return { success: true, thread_id: threadId, status: data.status };
   } catch (e) {
     set.status = 400;

--- a/src/routes/knowledge/handoff.ts
+++ b/src/routes/knowledge/handoff.ts
@@ -6,7 +6,12 @@ import { Elysia } from 'elysia';
 import fs from 'fs';
 import path from 'path';
 import { REPO_ROOT } from '../../config.ts';
+import { tenantDataPath } from '../../middleware/tenant.ts';
 import { HandoffBody } from './model.ts';
+
+const repoRoot = () => process.env.ORACLE_REPO_ROOT || REPO_ROOT;
+const relativePath = (filePath: string) => path.relative(repoRoot(), filePath).split(path.sep).join('/');
+const inboxDir = () => tenantDataPath(path.join(repoRoot(), 'ψ/inbox'));
 
 export const handoffEndpoint = new Elysia().post(
   '/handoff',
@@ -31,7 +36,7 @@ export const handoffEndpoint = new Elysia().post(
         .replace(/^-|-$/g, '') || 'handoff';
 
       const filename = `${dateStr}_${timeStr}_${slug}.md`;
-      const dirPath = path.join(REPO_ROOT, 'ψ/inbox/handoff');
+      const dirPath = path.join(inboxDir(), 'handoff');
       const filePath = path.join(dirPath, filename);
 
       fs.mkdirSync(dirPath, { recursive: true });
@@ -40,7 +45,7 @@ export const handoffEndpoint = new Elysia().post(
       set.status = 201;
       return {
         success: true,
-        file: `ψ/inbox/handoff/${filename}`,
+        file: relativePath(filePath),
         message: 'Handoff written.',
       };
     } catch (error) {

--- a/src/routes/knowledge/inbox.ts
+++ b/src/routes/knowledge/inbox.ts
@@ -6,7 +6,12 @@ import { Elysia } from 'elysia';
 import fs from 'fs';
 import path from 'path';
 import { REPO_ROOT } from '../../config.ts';
+import { tenantDataPath } from '../../middleware/tenant.ts';
 import { InboxQuery } from './model.ts';
+
+const repoRoot = () => process.env.ORACLE_REPO_ROOT || REPO_ROOT;
+const relativePath = (filePath: string) => path.relative(repoRoot(), filePath).split(path.sep).join('/');
+const inboxDir = () => tenantDataPath(path.join(repoRoot(), 'ψ/inbox'));
 
 export const inboxEndpoint = new Elysia().get(
   '/inbox',
@@ -15,11 +20,10 @@ export const inboxEndpoint = new Elysia().get(
     const offset = parseInt(query.offset ?? '0');
     const type = query.type ?? 'all';
 
-    const inboxDir = path.join(REPO_ROOT, 'ψ/inbox');
     const results: Array<{ filename: string; path: string; created: string; preview: string; type: string }> = [];
 
     if (type === 'all' || type === 'handoff') {
-      const handoffDir = path.join(inboxDir, 'handoff');
+      const handoffDir = path.join(inboxDir(), 'handoff');
       if (fs.existsSync(handoffDir)) {
         const files = fs.readdirSync(handoffDir)
           .filter(f => f.endsWith('.md'))
@@ -36,7 +40,7 @@ export const inboxEndpoint = new Elysia().get(
 
           results.push({
             filename: file,
-            path: `ψ/inbox/handoff/${file}`,
+            path: relativePath(filePath),
             created,
             preview: content.substring(0, 500),
             type: 'handoff',

--- a/src/routes/learn/list.ts
+++ b/src/routes/learn/list.ts
@@ -1,7 +1,8 @@
 import { Elysia } from 'elysia';
-import { and, desc, eq, isNull } from 'drizzle-orm';
+import { and, desc, eq, isNull, type SQL } from 'drizzle-orm';
 import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
 import { db, oracleDocuments } from '../../db/index.ts';
+import { currentTenantId } from '../../middleware/tenant.ts';
 
 type LearnDoc = typeof oracleDocuments.$inferSelect;
 
@@ -59,8 +60,11 @@ function learnEntry(row: LearnDoc) {
 }
 
 function listLearnEntries() {
+  const filters: SQL[] = [eq(oracleDocuments.type, 'learning'), isNull(oracleDocuments.supersededAt)];
+  const tenantId = currentTenantId();
+  if (tenantId) filters.push(eq(oracleDocuments.tenantId, tenantId));
   const rows = db.select().from(oracleDocuments)
-    .where(and(eq(oracleDocuments.type, 'learning'), isNull(oracleDocuments.supersededAt)))
+    .where(and(...filters))
     .orderBy(desc(oracleDocuments.updatedAt))
     .all();
   const items = rows.map(learnEntry);

--- a/src/routes/vault/sync.ts
+++ b/src/routes/vault/sync.ts
@@ -9,10 +9,11 @@
  */
 
 import { Elysia, t } from 'elysia';
-import { migrate as runMigrate, type MigrateResult } from '../../vault/migrate.ts';
+import { migrate as runMigrate, type MigrateOptions, type MigrateResult } from '../../vault/migrate.ts';
+import { currentTenantId } from '../../middleware/tenant.ts';
 
 export interface SyncDeps {
-  migrate: (opts: { dryRun: boolean }) => MigrateResult;
+  migrate: (opts: MigrateOptions) => MigrateResult;
   spawnIndexer: () => void;
 }
 
@@ -35,7 +36,9 @@ export function createVaultSyncRoute(deps: SyncDeps = defaultDeps) {
       const reindex = body?.reindex === true;
 
       try {
-        const result = deps.migrate({ dryRun });
+        const tenantId = currentTenantId();
+        const migrateOpts = tenantId ? { dryRun, tenantId } : { dryRun };
+        const result = deps.migrate(migrateOpts);
 
         let reindexSpawned = false;
         if (reindex && !dryRun && result.filesCopied > 0) {
@@ -47,6 +50,7 @@ export function createVaultSyncRoute(deps: SyncDeps = defaultDeps) {
           ok: true,
           dryRun,
           reindex: reindexSpawned,
+          tenant: tenantId ? { id: tenantId, scope: 'vault_project' } : undefined,
           migrate: result,
         };
       } catch (err) {

--- a/src/routes/vector/config.ts
+++ b/src/routes/vector/config.ts
@@ -87,7 +87,7 @@ function configResponse(
     state: vectorConfigState(config, collections),
     options: {
       localEngines: LOCAL_VECTOR_ENGINES,
-      embeddingProviders: ['ollama', 'openai', 'cloudflare-ai', 'chromadb-internal'],
+      embeddingProviders: ['ollama', 'openai', 'gemini', 'cloudflare-ai', 'chromadb-internal'],
     },
     config,
     collections,

--- a/src/routes/verify/index.ts
+++ b/src/routes/verify/index.ts
@@ -41,8 +41,12 @@ function bodyToInput(body: { check?: boolean; type?: string }): OracleVerifyInpu
   };
 }
 
+function currentRepoRoot(): string {
+  return process.env.ORACLE_REPO_ROOT || REPO_ROOT;
+}
+
 export const verifyRoutes = new Elysia({ prefix: '/api' })
-  .get('/verify', async ({ query }) => runVerify(queryToInput(query), REPO_ROOT), {
+  .get('/verify', async ({ query }) => runVerify(queryToInput(query), currentRepoRoot()), {
     query: VerifyQuery,
     detail: {
       tags: ['search'],
@@ -50,7 +54,7 @@ export const verifyRoutes = new Elysia({ prefix: '/api' })
       summary: 'Verify knowledge base disk files against the DB index',
     },
   })
-  .post('/verify', async ({ body }) => runVerify(bodyToInput(body), REPO_ROOT), {
+  .post('/verify', async ({ body }) => runVerify(bodyToInput(body), currentRepoRoot()), {
     body: VerifyBody,
     detail: {
       tags: ['search'],

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import { createCorrelationMiddleware } from './middleware/correlation.ts';
 import { defaultUnifiedPluginDirs, loadUnifiedPlugins, seedUnifiedPluginMenuItems } from './plugins/unified-loader.ts';
 import { startUnifiedPluginServers } from './plugins/unified-server.ts';
 import { closeCachedVectorStores } from './vector/factory.ts';
+import { warmEmbeddingProviderDetection } from './vector/provider-detection.ts';
 import { drainingResponseFor, isDraining, registerGracefulShutdown, runShutdownSteps, trackRequest } from './lifecycle/shutdown.ts';
 import { createErrorMiddleware } from './middleware/errors.ts';
 import { validateStartupEnv } from './config/validate.ts';
@@ -80,6 +81,8 @@ try {
 }
 
 console.log('[Vector] mode:', VECTOR_URL ? 'proxy → ' + VECTOR_URL : 'local');
+void warmEmbeddingProviderDetection().catch((error) =>
+  console.warn('[Vector] embedding provider auto-detect failed:', error instanceof Error ? error.message : String(error)));
 
 try {
   console.log(`[DB] busy_timeout = ${JSON.stringify(sqlite.prepare('PRAGMA busy_timeout').get())}`);

--- a/src/server/__tests__/concepts-route.test.ts
+++ b/src/server/__tests__/concepts-route.test.ts
@@ -11,7 +11,9 @@ const originalDbPath = process.env.ORACLE_DB_PATH;
 process.env.ORACLE_DATA_DIR = dataDir;
 process.env.ORACLE_DB_PATH = path.join(dataDir, 'oracle.db');
 
-const { db, oracleDocuments } = await import('../../db/index.ts');
+const dbModule = await import('../../db/index.ts');
+dbModule.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+const { db, oracleDocuments } = dbModule;
 const { conceptsRoutes } = await import('../../routes/concepts/index.ts');
 
 describe('GET /api/concepts', () => {
@@ -58,9 +60,10 @@ describe('GET /api/concepts', () => {
 });
 
 afterAll(() => {
-  fs.rmSync(dataDir, { recursive: true, force: true });
   if (originalDataDir) process.env.ORACLE_DATA_DIR = originalDataDir;
   else delete process.env.ORACLE_DATA_DIR;
   if (originalDbPath) process.env.ORACLE_DB_PATH = originalDbPath;
   else delete process.env.ORACLE_DB_PATH;
+  dbModule.resetDefaultDatabaseForTests(':memory:');
+  fs.rmSync(dataDir, { recursive: true, force: true });
 });

--- a/src/server/__tests__/search-fts-query.test.ts
+++ b/src/server/__tests__/search-fts-query.test.ts
@@ -13,7 +13,9 @@ process.env.ORACLE_DATA_DIR = dataDir;
 process.env.ORACLE_DB_PATH = path.join(dataDir, 'oracle.db');
 delete process.env.VECTOR_URL;
 
-const { sqlite } = await import('../../db/index.ts');
+const dbModule = await import('../../db/index.ts');
+dbModule.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+const { sqlite } = dbModule;
 const { buildFtsQuery, handleSearch } = await import('../handlers.ts');
 const { sanitizeFtsQuery } = await import('../../tools/search.ts');
 
@@ -57,11 +59,12 @@ describe('FTS query sanitation and recall behavior', () => {
 
 afterAll(() => {
   sqlite.close();
-  fs.rmSync(tmpRoot, { recursive: true, force: true });
   if (originalDataDir !== undefined) process.env.ORACLE_DATA_DIR = originalDataDir;
   else delete process.env.ORACLE_DATA_DIR;
   if (originalDbPath !== undefined) process.env.ORACLE_DB_PATH = originalDbPath;
   else delete process.env.ORACLE_DB_PATH;
   if (originalVectorUrl !== undefined) process.env.VECTOR_URL = originalVectorUrl;
   else delete process.env.VECTOR_URL;
+  dbModule.resetDefaultDatabaseForTests(':memory:');
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
 });

--- a/src/server/__tests__/search-vector-opt-in.test.ts
+++ b/src/server/__tests__/search-vector-opt-in.test.ts
@@ -14,7 +14,9 @@ process.env.ORACLE_DB_PATH = path.join(tmpRoot, 'data', 'oracle.db');
 process.env.ORACLE_REPO_ROOT = tmpRoot;
 delete process.env.ORACLE_VECTOR_ENABLED;
 
-const { sqlite, closeDb } = await import('../../db/index.ts');
+const dbModule = await import('../../db/index.ts');
+dbModule.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+const { sqlite, closeDb, resetDefaultDatabaseForTests } = dbModule;
 const { generateDefaultConfig, writeVectorConfig } = await import('../../vector/config.ts');
 const { handleSearch } = await import('../handlers.ts');
 
@@ -48,7 +50,6 @@ describe('handleSearch vector opt-in gate', () => {
 
 afterAll(() => {
   try { closeDb(); } catch {}
-  fs.rmSync(tmpRoot, { recursive: true, force: true });
   if (originalDataDir !== undefined) process.env.ORACLE_DATA_DIR = originalDataDir;
   else delete process.env.ORACLE_DATA_DIR;
   if (originalDbPath !== undefined) process.env.ORACLE_DB_PATH = originalDbPath;
@@ -57,4 +58,6 @@ afterAll(() => {
   else delete process.env.ORACLE_REPO_ROOT;
   if (originalVectorEnabled !== undefined) process.env.ORACLE_VECTOR_ENABLED = originalVectorEnabled;
   else delete process.env.ORACLE_VECTOR_ENABLED;
+  resetDefaultDatabaseForTests(':memory:');
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
 });

--- a/src/server/__tests__/search-vector-proxy-fallback.test.ts
+++ b/src/server/__tests__/search-vector-proxy-fallback.test.ts
@@ -5,9 +5,7 @@ import path from 'node:path';
 
 const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-search-vector-proxy-fallback-'));
 const dataDir = path.join(tmpRoot, 'data');
-const originalDataDir = process.env.ORACLE_DATA_DIR;
-const originalDbPath = process.env.ORACLE_DB_PATH;
-const originalVectorUrl = process.env.VECTOR_URL;
+const dbPath = path.join(dataDir, 'oracle.db');
 
 const remote = Bun.serve({
   port: 0,
@@ -19,17 +17,41 @@ const remote = Bun.serve({
   },
 });
 
-process.env.ORACLE_DATA_DIR = dataDir;
-process.env.ORACLE_DB_PATH = path.join(dataDir, 'oracle.db');
-process.env.VECTOR_URL = `http://127.0.0.1:${remote.port}`;
-
-const { handleLearn, handleSearch } = await import('../handlers.ts');
+function runFallbackInFreshProcess() {
+  const script = `
+    const { handleLearn, handleSearch } = await import('./src/server/handlers.ts');
+    handleLearn('cloudproxy1378 local fts ground truth survives remote vector outage', 'test', ['cloudproxy1378']);
+    const result = await handleSearch('cloudproxy1378', 'all', 5, 0, 'hybrid');
+    console.log('RESULT_JSON:' + JSON.stringify(result));
+  `;
+  const proc = Bun.spawnSync({
+    cmd: [process.execPath, '--eval', script],
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      ORACLE_DATA_DIR: dataDir,
+      ORACLE_DB_PATH: dbPath,
+      ORACLE_REPO_ROOT: tmpRoot,
+      VECTOR_URL: `http://127.0.0.1:${remote.port}`,
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const stdout = new TextDecoder().decode(proc.stdout);
+  const stderr = new TextDecoder().decode(proc.stderr);
+  if (proc.exitCode !== 0) throw new Error(stderr || stdout);
+  const line = stdout.split('\n').reverse().find((item) => item.startsWith('RESULT_JSON:'));
+  if (!line) throw new Error(`Missing RESULT_JSON marker.\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+  return JSON.parse(line.slice('RESULT_JSON:'.length)) as {
+    results: Array<{ content: string }>;
+    vectorAvailable?: boolean;
+    warning?: string;
+  };
+}
 
 describe('handleSearch cloud vector proxy fallback', () => {
   test('keeps local FTS as ground truth when remote vector proxy is down', async () => {
-    handleLearn('cloudproxy1378 local fts ground truth survives remote vector outage', 'test', ['cloudproxy1378']);
-
-    const result = await handleSearch('cloudproxy1378', 'all', 5, 0, 'hybrid');
+    const result = runFallbackInFreshProcess();
 
     expect(result.results.length).toBeGreaterThan(0);
     expect(result.results[0].content).toContain('cloudproxy1378');
@@ -41,10 +63,4 @@ describe('handleSearch cloud vector proxy fallback', () => {
 afterAll(() => {
   remote.stop(true);
   fs.rmSync(tmpRoot, { recursive: true, force: true });
-  if (originalDataDir !== undefined) process.env.ORACLE_DATA_DIR = originalDataDir;
-  else delete process.env.ORACLE_DATA_DIR;
-  if (originalDbPath !== undefined) process.env.ORACLE_DB_PATH = originalDbPath;
-  else delete process.env.ORACLE_DB_PATH;
-  if (originalVectorUrl !== undefined) process.env.VECTOR_URL = originalVectorUrl;
-  else delete process.env.VECTOR_URL;
 });

--- a/src/server/__tests__/search-vector-proxy-total.test.ts
+++ b/src/server/__tests__/search-vector-proxy-total.test.ts
@@ -5,9 +5,7 @@ import path from 'node:path';
 
 const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-search-vector-proxy-'));
 const dataDir = path.join(tmpRoot, 'data');
-const originalDataDir = process.env.ORACLE_DATA_DIR;
-const originalDbPath = process.env.ORACLE_DB_PATH;
-const originalVectorUrl = process.env.VECTOR_URL;
+const dbPath = path.join(dataDir, 'oracle.db');
 
 const fakeVector = Bun.serve({
   port: 0,
@@ -33,22 +31,41 @@ const fakeVector = Bun.serve({
   },
 });
 
-process.env.ORACLE_DATA_DIR = dataDir;
-process.env.ORACLE_DB_PATH = path.join(dataDir, 'oracle.db');
-process.env.VECTOR_URL = `http://127.0.0.1:${fakeVector.port}`;
-
-const warnMessages: string[] = [];
-const originalWarn = console.warn;
-console.warn = (...args: unknown[]) => {
-  warnMessages.push(args.map(String).join(' '));
-};
-
-// Dynamic import after env is set because config/db/handlers freeze env at module load.
-const { handleSearch } = await import('../handlers.ts');
+function runSearchInFreshProcess() {
+  const script = `
+    const warnMessages = [];
+    console.warn = (...args) => warnMessages.push(args.map(String).join(' '));
+    const { handleSearch } = await import('./src/server/handlers.ts');
+    const result = await handleSearch('oracle', 'all', 1, 0, 'vector');
+    console.log('RESULT_JSON:' + JSON.stringify({ result, warnMessages }));
+  `;
+  const proc = Bun.spawnSync({
+    cmd: [process.execPath, '--eval', script],
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      ORACLE_DATA_DIR: dataDir,
+      ORACLE_DB_PATH: dbPath,
+      ORACLE_REPO_ROOT: tmpRoot,
+      VECTOR_URL: `http://127.0.0.1:${fakeVector.port}`,
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const stdout = new TextDecoder().decode(proc.stdout);
+  const stderr = new TextDecoder().decode(proc.stderr);
+  if (proc.exitCode !== 0) throw new Error(stderr || stdout);
+  const line = stdout.split('\n').reverse().find((item) => item.startsWith('RESULT_JSON:'));
+  if (!line) throw new Error(`Missing RESULT_JSON marker.\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+  return JSON.parse(line.slice('RESULT_JSON:'.length)) as {
+    result: { total: number; results: Array<{ id: string }>; vectorAvailable?: boolean };
+    warnMessages: string[];
+  };
+}
 
 describe('handleSearch VECTOR_URL proxy totals', () => {
   test('uses remote vector total without opening local vector stats in core proxy mode', async () => {
-    const result = await handleSearch('oracle', 'all', 1, 0, 'vector');
+    const { result, warnMessages } = runSearchInFreshProcess();
 
     expect(result.total).toBe(42);
     expect(result.results).toHaveLength(1);
@@ -60,12 +77,5 @@ describe('handleSearch VECTOR_URL proxy totals', () => {
 
 afterAll(() => {
   fakeVector.stop(true);
-  console.warn = originalWarn;
   fs.rmSync(tmpRoot, { recursive: true, force: true });
-  if (originalDataDir !== undefined) process.env.ORACLE_DATA_DIR = originalDataDir;
-  else delete process.env.ORACLE_DATA_DIR;
-  if (originalDbPath !== undefined) process.env.ORACLE_DB_PATH = originalDbPath;
-  else delete process.env.ORACLE_DB_PATH;
-  if (originalVectorUrl !== undefined) process.env.VECTOR_URL = originalVectorUrl;
-  else delete process.env.VECTOR_URL;
 });

--- a/src/server/__tests__/supersede-document-route.test.ts
+++ b/src/server/__tests__/supersede-document-route.test.ts
@@ -13,7 +13,9 @@ const originalDbPath = process.env.ORACLE_DB_PATH;
 process.env.ORACLE_DATA_DIR = dataDir;
 process.env.ORACLE_DB_PATH = path.join(dataDir, 'oracle.db');
 
-const { db, oracleDocuments } = await import('../../db/index.ts');
+const dbModule = await import('../../db/index.ts');
+dbModule.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+const { db, oracleDocuments } = dbModule;
 const { supersedeRoutes } = await import('../../routes/supersede/index.ts');
 
 describe('POST /api/supersede/document', () => {
@@ -65,9 +67,10 @@ describe('POST /api/supersede/document', () => {
 });
 
 afterAll(() => {
-  fs.rmSync(dataDir, { recursive: true, force: true });
   if (originalDataDir) process.env.ORACLE_DATA_DIR = originalDataDir;
   else delete process.env.ORACLE_DATA_DIR;
   if (originalDbPath) process.env.ORACLE_DB_PATH = originalDbPath;
   else delete process.env.ORACLE_DB_PATH;
+  dbModule.resetDefaultDatabaseForTests(':memory:');
+  fs.rmSync(dataDir, { recursive: true, force: true });
 });

--- a/src/server/__tests__/verify-route.test.ts
+++ b/src/server/__tests__/verify-route.test.ts
@@ -17,7 +17,9 @@ process.env.ORACLE_REPO_ROOT = repoRoot;
 fs.mkdirSync(path.join(repoRoot, 'ψ/memory/learnings'), { recursive: true });
 fs.writeFileSync(path.join(repoRoot, 'ψ/memory/learnings/healthy.md'), '# Healthy\n');
 
-const { db, oracleDocuments } = await import('../../db/index.ts');
+const dbModule = await import('../../db/index.ts');
+dbModule.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+const { db, oracleDocuments } = dbModule;
 const { verifyRoutes } = await import('../../routes/verify/index.ts');
 
 describe('GET/POST /api/verify', () => {
@@ -65,12 +67,13 @@ describe('GET/POST /api/verify', () => {
 });
 
 afterAll(() => {
-  fs.rmSync(dataDir, { recursive: true, force: true });
-  fs.rmSync(repoRoot, { recursive: true, force: true });
   if (originalDataDir) process.env.ORACLE_DATA_DIR = originalDataDir;
   else delete process.env.ORACLE_DATA_DIR;
   if (originalDbPath) process.env.ORACLE_DB_PATH = originalDbPath;
   else delete process.env.ORACLE_DB_PATH;
   if (originalRepoRoot) process.env.ORACLE_REPO_ROOT = originalRepoRoot;
   else delete process.env.ORACLE_REPO_ROOT;
+  dbModule.resetDefaultDatabaseForTests(':memory:');
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  fs.rmSync(repoRoot, { recursive: true, force: true });
 });

--- a/src/tools/__tests__/learn-enqueue.test.ts
+++ b/src/tools/__tests__/learn-enqueue.test.ts
@@ -89,6 +89,28 @@ function cleanupHarness(h: Harness): void {
 // import below — main's REPO_ROOT is module-frozen at first import.
 const SHARED_REPO_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-learn-m5-root-'));
 process.env.ORACLE_REPO_ROOT = SHARED_REPO_ROOT;
+const createdMarkdownFiles = new Set<string>();
+
+function markdownPathCandidates(relativePath: string): string[] {
+  return [SHARED_REPO_ROOT, process.cwd()]
+    .map((root) => path.join(root, relativePath));
+}
+
+function rememberMarkdown(relativePath: string): void {
+  for (const candidate of markdownPathCandidates(relativePath)) {
+    if (fs.existsSync(candidate)) createdMarkdownFiles.add(candidate);
+  }
+}
+
+function readMarkdown(relativePath: string): string {
+  for (const candidate of markdownPathCandidates(relativePath)) {
+    if (fs.existsSync(candidate)) {
+      createdMarkdownFiles.add(candidate);
+      return fs.readFileSync(candidate, 'utf-8');
+    }
+  }
+  throw new Error(`Missing learning markdown file: ${relativePath}`);
+}
 
 // Dynamic import after env is set. Top-level await is supported in Bun.
 const { handleLearn } = await import('../learn.ts');
@@ -103,6 +125,10 @@ describe('handleLearn — M5 enqueue branch', () => {
 
   afterEach(() => {
     cleanupHarness(h);
+    for (const file of createdMarkdownFiles) {
+      try { fs.rmSync(file, { force: true }); } catch {}
+    }
+    createdMarkdownFiles.clear();
     if (ORIGINAL_ENQUEUE) process.env.ORACLE_INDEXER_ENQUEUE = ORIGINAL_ENQUEUE;
     else delete process.env.ORACLE_INDEXER_ENQUEUE;
   });
@@ -111,6 +137,7 @@ describe('handleLearn — M5 enqueue branch', () => {
     const res = await handleLearn(h.ctx, { pattern: `test pattern A ${Date.now()}-${Math.random()}` });
     const parsed = JSON.parse(res.content[0].text);
     expect(parsed.success).toBe(true);
+    rememberMarkdown(parsed.file);
 
     const count = h.sqlite.query('SELECT COUNT(*) as c FROM indexing_jobs').get() as { c: number };
     expect(count.c).toBe(0);
@@ -132,7 +159,7 @@ describe('handleLearn — M5 enqueue branch', () => {
     const parsed = JSON.parse(res.content[0].text);
     expect(parsed.success).toBe(true);
 
-    const markdown = fs.readFileSync(path.join(SHARED_REPO_ROOT, parsed.file), 'utf-8');
+    const markdown = readMarkdown(parsed.file);
     expect(markdown).toContain(`id: ${parsed.id}`);
     expect(markdown).toContain('type: learning');
     expect(markdown).toContain('concepts: [frontmatter, vector]');
@@ -150,6 +177,7 @@ describe('handleLearn — M5 enqueue branch', () => {
     const res = await handleLearn(h.ctx, { pattern: `test pattern B ${Date.now()}-${Math.random()}` });
     const parsed = JSON.parse(res.content[0].text);
     expect(parsed.success).toBe(true);
+    rememberMarkdown(parsed.file);
 
     const rows = h.sqlite
       .query<{ doc_id: string; model_key: string; status: string }, []>(
@@ -171,6 +199,7 @@ describe('handleLearn — M5 enqueue branch', () => {
     const res = await handleLearn(h.ctx, { pattern: `test pattern C ${Date.now()}-${Math.random()}` });
     const parsed = JSON.parse(res.content[0].text);
     expect(parsed.success).toBe(true);
+    rememberMarkdown(parsed.file);
 
     const fts = h.sqlite.query('SELECT COUNT(*) as c FROM oracle_fts').get() as { c: number };
     expect(fts.c).toBe(1);
@@ -178,7 +207,8 @@ describe('handleLearn — M5 enqueue branch', () => {
 
   it('value other than "1" does NOT enqueue (strict equality, not truthiness)', async () => {
     process.env.ORACLE_INDEXER_ENQUEUE = 'true';
-    await handleLearn(h.ctx, { pattern: `test pattern D ${Date.now()}-${Math.random()}` });
+    const res = await handleLearn(h.ctx, { pattern: `test pattern D ${Date.now()}-${Math.random()}` });
+    rememberMarkdown(JSON.parse(res.content[0].text).file);
     const count = h.sqlite.query('SELECT COUNT(*) as c FROM indexing_jobs').get() as { c: number };
     expect(count.c).toBe(0);
   });

--- a/src/tools/__tests__/mcp-vector-guard.test.ts
+++ b/src/tools/__tests__/mcp-vector-guard.test.ts
@@ -12,7 +12,8 @@ process.env.ORACLE_DATA_DIR = path.join(tmp, 'data');
 process.env.ORACLE_DB_PATH = path.join(tmp, 'data', 'oracle.db');
 delete process.env.ORACLE_VECTOR_ENABLED;
 
-const { createDatabase, closeDb } = await import('../../db/index.ts');
+const { createDatabase, closeDb, resetDefaultDatabaseForTests } = await import('../../db/index.ts');
+resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
 const { oracleDocuments } = await import('../../db/schema.ts');
 const { handleSearch } = await import('../search.ts');
 
@@ -53,13 +54,14 @@ function makeCtx() {
 
 afterAll(() => {
   try { closeDb(); } catch {}
-  fs.rmSync(tmp, { recursive: true, force: true });
   if (originalDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
   else process.env.ORACLE_DATA_DIR = originalDataDir;
   if (originalDbPath === undefined) delete process.env.ORACLE_DB_PATH;
   else process.env.ORACLE_DB_PATH = originalDbPath;
   if (originalVectorEnabled === undefined) delete process.env.ORACLE_VECTOR_ENABLED;
   else process.env.ORACLE_VECTOR_ENABLED = originalVectorEnabled;
+  resetDefaultDatabaseForTests(':memory:');
+  fs.rmSync(tmp, { recursive: true, force: true });
 });
 
 describe('MCP muninn_search vector section guard', () => {

--- a/src/vault/migrate-cli.ts
+++ b/src/vault/migrate-cli.ts
@@ -1,0 +1,24 @@
+import fs from 'fs';
+import { detectProject } from '../server/project-detect.ts';
+import { findPsiRepos, migrate, walkFiles } from './migrate.ts';
+
+export function runVaultMigrateCli(args = process.argv.slice(2)): void {
+  if (args.includes('--list')) {
+    const repos = findPsiRepos();
+    console.log(`Found ${repos.length} repos with ψ/ directories:\n`);
+    for (const { repoPath, psiDir } of repos) {
+      const project = detectProject(repoPath) ?? '(unknown)';
+      const isSymlink = fs.lstatSync(psiDir).isSymbolicLink();
+      if (isSymlink) console.log(`  ${project} ✓ symlinked`);
+      else console.log(`  ${project} (${walkFiles(psiDir, repoPath).length} files) ← local`);
+      console.log(`    ${repoPath}`);
+    }
+    return;
+  }
+
+  const dryRun = args.includes('--dry-run');
+  const symlink = args.includes('--symlink');
+  if (dryRun) console.error('[Vault] DRY RUN — no files will be copied\n');
+  if (symlink) console.error('[Vault] SYMLINK MODE — local ψ/ will be replaced with symlinks\n');
+  console.log(JSON.stringify(migrate({ dryRun, symlink }), null, 2));
+}

--- a/src/vault/migrate.ts
+++ b/src/vault/migrate.ts
@@ -1,14 +1,4 @@
-/**
- * Oracle Vault Migration Tool
- *
- * Scans ghq repos for ψ/ directories and copies knowledge
- * to the central brain vault with project-first paths.
- *
- * Usage:
- *   bun run vault:migrate              # scan + copy all ψ/ to vault
- *   bun run vault:migrate --dry-run    # preview what would be copied
- *   bun run vault:migrate --list       # just list repos with ψ/
- */
+/** Oracle Vault Migration Tool — copies ghq ψ/ knowledge into a central vault. */
 
 import fs from 'fs';
 import path from 'path';
@@ -17,20 +7,13 @@ import { getSetting } from '../db/index.ts';
 import { detectProject } from '../server/project-detect.ts';
 import { mapToVaultPath, ensureFrontmatterProject } from './handler.ts';
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 function resolveVaultPath(repo: string): string {
   const output = execSync(`ghq list -p ${repo}`, { encoding: 'utf-8' }).trim();
   if (!output) throw new Error(`Vault repo "${repo}" not found via ghq.`);
   return output.split('\n')[0].trim();
 }
 
-function walkFiles(
-  dir: string,
-  baseDir: string,
-): Array<{ relativePath: string; fullPath: string }> {
+function walkFiles(dir: string, baseDir: string): Array<{ relativePath: string; fullPath: string }> {
   const results: Array<{ relativePath: string; fullPath: string }> = [];
   if (!fs.existsSync(dir)) return results;
 
@@ -38,36 +21,20 @@ function walkFiles(
     const fullPath = path.join(dir, item);
     const stat = fs.lstatSync(fullPath);
     if (stat.isSymbolicLink()) continue;
-    if (stat.isDirectory()) {
-      results.push(...walkFiles(fullPath, baseDir));
-    } else {
-      results.push({ relativePath: path.relative(baseDir, fullPath), fullPath });
-    }
+    if (stat.isDirectory()) results.push(...walkFiles(fullPath, baseDir));
+    else results.push({ relativePath: path.relative(baseDir, fullPath), fullPath });
   }
   return results;
 }
 
-// Categories that get project-nested
-const PROJECT_CATEGORIES = [
-  'ψ/memory/learnings/',
-  'ψ/memory/retrospectives/',
-  'ψ/inbox/handoff/',
-];
+const PROJECT_CATEGORIES = ['ψ/memory/learnings/', 'ψ/memory/retrospectives/', 'ψ/inbox/handoff/'];
 
 function isProjectCategory(relativePath: string): boolean {
   return PROJECT_CATEGORIES.some((cat) => relativePath.startsWith(cat));
 }
 
-// ---------------------------------------------------------------------------
-// Core
-// ---------------------------------------------------------------------------
-
-interface RepoInfo {
-  repoPath: string;
-  project: string;
-  fileCount: number;
-}
-
+interface RepoInfo { repoPath: string; project: string; fileCount: number }
+interface MigrateOptions { dryRun: boolean; symlink?: boolean; tenantId?: string }
 interface MigrateResult {
   reposFound: number;
   filesCopied: number;
@@ -76,9 +43,14 @@ interface MigrateResult {
   symlinked: string[];
 }
 
-/**
- * Find all ghq repos that have a ψ/ directory
- */
+function projectMatchesTenant(project: string, tenantId: string): boolean {
+  const tenant = tenantId.trim().toLowerCase();
+  const normalizedProject = project.trim().toLowerCase();
+  if (!tenant) return true;
+  if (normalizedProject === tenant) return true;
+  return normalizedProject.split(/[\\/]+/).filter(Boolean).includes(tenant);
+}
+
 function findPsiRepos(): Array<{ repoPath: string; psiDir: string }> {
   try {
     execSync('ghq root', { encoding: 'utf-8' });
@@ -87,51 +59,44 @@ function findPsiRepos(): Array<{ repoPath: string; psiDir: string }> {
   }
 
   const results: Array<{ repoPath: string; psiDir: string }> = [];
-
-  // List all ghq repos and check for ψ/ in each
   const repos = execSync('ghq list -p', { encoding: 'utf-8' }).trim().split('\n');
-
   for (const repoPath of repos) {
     if (!repoPath) continue;
     const psiDir = path.join(repoPath, 'ψ');
-    if (fs.existsSync(psiDir) && fs.statSync(psiDir).isDirectory()) {
-      results.push({ repoPath, psiDir });
-    }
+    if (fs.existsSync(psiDir) && fs.statSync(psiDir).isDirectory()) results.push({ repoPath, psiDir });
   }
-
   return results;
 }
 
-/**
- * Migrate all ψ/ directories to the central vault
- */
-function migrate(opts: { dryRun: boolean; symlink?: boolean }): MigrateResult {
-  const { dryRun, symlink } = opts;
-
+function migrate(opts: MigrateOptions): MigrateResult {
+  const { dryRun, symlink, tenantId } = opts;
   const repo = getSetting('vault_repo');
   if (!repo) throw new Error('Vault not initialized. Run vault:init first.');
 
   const vaultPath = resolveVaultPath(repo);
   const psiRepos = findPsiRepos();
   const result: MigrateResult = {
-    reposFound: psiRepos.length,
+    reposFound: tenantId ? 0 : psiRepos.length,
     filesCopied: 0,
     repos: [],
     skipped: [],
     symlinked: [],
   };
-
-  // Skip the vault repo itself
   const vaultRealPath = fs.realpathSync(vaultPath);
 
   for (const { repoPath, psiDir } of psiRepos) {
-    // Skip worktrees
+    const project = detectProject(repoPath) ?? null;
+    if (!project) {
+      if (!tenantId) result.skipped.push(`${repoPath} (cannot detect project)`);
+      continue;
+    }
+    if (tenantId && !projectMatchesTenant(project, tenantId)) continue;
+    if (tenantId) result.reposFound++;
+
     if (repoPath.match(/\.wt[-/]/)) {
       result.skipped.push(`${repoPath} (worktree)`);
       continue;
     }
-
-    // Skip already-symlinked repos (nothing to copy)
     try {
       if (fs.lstatSync(psiDir).isSymbolicLink()) {
         result.skipped.push(`${repoPath} (already symlinked)`);
@@ -145,29 +110,17 @@ function migrate(opts: { dryRun: boolean; symlink?: boolean }): MigrateResult {
       continue;
     }
 
-    const project = detectProject(repoPath) ?? null;
-    if (!project) {
-      result.skipped.push(`${repoPath} (cannot detect project)`);
-      continue;
-    }
-
     const files = walkFiles(psiDir, repoPath);
     let fileCount = 0;
-
     for (const { relativePath, fullPath } of files) {
-      // Skip .gitkeep files
       if (path.basename(relativePath) === '.gitkeep') continue;
-
       const vaultRelPath = mapToVaultPath(relativePath, project);
       const dest = path.join(vaultPath, vaultRelPath);
 
       if (!dryRun) {
         fs.mkdirSync(path.dirname(dest), { recursive: true });
-
         if (fullPath.endsWith('.md') && isProjectCategory(relativePath)) {
-          const content = fs.readFileSync(fullPath, 'utf-8');
-          const tagged = ensureFrontmatterProject(content, project);
-          fs.writeFileSync(dest, tagged);
+          fs.writeFileSync(dest, ensureFrontmatterProject(fs.readFileSync(fullPath, 'utf-8'), project));
         } else {
           fs.copyFileSync(fullPath, dest);
         }
@@ -177,30 +130,21 @@ function migrate(opts: { dryRun: boolean; symlink?: boolean }): MigrateResult {
 
     result.repos.push({ repoPath, project, fileCount });
     result.filesCopied += fileCount;
-
-    // Create symlink if requested
     if (symlink) {
       const vaultPsiDir = path.join(vaultPath, project, 'ψ');
       if (!dryRun) {
-        // Ensure vault destination exists
         fs.mkdirSync(vaultPsiDir, { recursive: true });
-        // Remove local ψ/ directory
         fs.rmSync(psiDir, { recursive: true });
-        // Create symlink: repo/ψ → vault/{project}/ψ
         fs.symlinkSync(vaultPsiDir, psiDir);
       }
       result.symlinked.push(project);
     }
   }
 
-  // Git commit if not dry-run and there are changes
   if (!dryRun && result.filesCopied > 0) {
     try {
       execSync('git add -A', { cwd: vaultPath, stdio: 'pipe' });
-      const status = execSync('git status --porcelain', {
-        cwd: vaultPath,
-        encoding: 'utf-8',
-      }).trim();
+      const status = execSync('git status --porcelain', { cwd: vaultPath, encoding: 'utf-8' }).trim();
 
       if (status) {
         const projectList = result.repos.map((r) => r.project).join(', ');
@@ -209,51 +153,20 @@ function migrate(opts: { dryRun: boolean; symlink?: boolean }): MigrateResult {
           { cwd: vaultPath, stdio: 'pipe' },
         );
         execSync('git push', { cwd: vaultPath, stdio: 'pipe' });
-        console.error(`[Vault] Migration committed and pushed`);
+        console.error('[Vault] Migration committed and pushed');
       }
     } catch (e) {
-      console.error(`[Vault] Git commit/push failed:`, e instanceof Error ? e.message : e);
+      console.error('[Vault] Git commit/push failed:', e instanceof Error ? e.message : e);
     }
   }
 
   return result;
 }
 
-// ---------------------------------------------------------------------------
-// Exported API
-// ---------------------------------------------------------------------------
-
-export { findPsiRepos, migrate };
-export type { MigrateResult, RepoInfo };
-
-// ---------------------------------------------------------------------------
-// CLI (when run directly)
-// ---------------------------------------------------------------------------
+export { findPsiRepos, migrate, projectMatchesTenant, walkFiles };
+export type { MigrateOptions, MigrateResult, RepoInfo };
 
 if (import.meta.main) {
-  const args = process.argv.slice(2);
-
-  if (args.includes('--list')) {
-    const repos = findPsiRepos();
-    console.log(`Found ${repos.length} repos with ψ/ directories:\n`);
-    for (const { repoPath, psiDir } of repos) {
-      const project = detectProject(repoPath) ?? '(unknown)';
-      const isSymlink = fs.lstatSync(psiDir).isSymbolicLink();
-      if (isSymlink) {
-        console.log(`  ${project} ✓ symlinked`);
-      } else {
-        const files = walkFiles(psiDir, repoPath);
-        console.log(`  ${project} (${files.length} files) ← local`);
-      }
-      console.log(`    ${repoPath}`);
-    }
-  } else {
-    const dryRun = args.includes('--dry-run');
-    const symlink = args.includes('--symlink');
-    if (dryRun) console.error('[Vault] DRY RUN — no files will be copied\n');
-    if (symlink) console.error('[Vault] SYMLINK MODE — local ψ/ will be replaced with symlinks\n');
-
-    const result = migrate({ dryRun, symlink });
-    console.log(JSON.stringify(result, null, 2));
-  }
+  const { runVaultMigrateCli } = await import('./migrate-cli.ts');
+  runVaultMigrateCli();
 }

--- a/src/vector-server.ts
+++ b/src/vector-server.ts
@@ -16,6 +16,7 @@ import { swagger } from '@elysiajs/swagger';
 
 import { createCorsMiddleware } from './middleware/cors.ts';
 import { loadVectorConfig, generateDefaultConfig } from './vector/config.ts';
+import { warmEmbeddingProviderDetection } from './vector/provider-detection.ts';
 import { vectorRoutes } from './routes/vector/index.ts';
 import { searchEndpoint } from './routes/search/search.ts';
 
@@ -24,6 +25,8 @@ import pkg from '../package.json' with { type: 'json' };
 // ── Config ──────────────────────────────────────────────────────────
 const config = loadVectorConfig() ?? generateDefaultConfig();
 const PORT = Number(process.env.VECTOR_PORT ?? config.port);
+void warmEmbeddingProviderDetection().catch((error) =>
+  console.warn('[Vector] embedding provider auto-detect failed:', error instanceof Error ? error.message : String(error)));
 
 // ── App ─────────────────────────────────────────────────────────────
 export function createVectorServerApp() {

--- a/src/vector/embeddings.ts
+++ b/src/vector/embeddings.ts
@@ -1,5 +1,6 @@
 import type { EmbeddingProvider, EmbeddingProviderType, EmbedType } from './types.ts';
 import { NoneEmbeddings, RemoteHttpEmbeddings } from './embedding-backends.ts';
+import { EmbeddingFallbackChain } from './fallback-chain.ts';
 export type FallbackEvent = { from: string; to?: string; error: string };
 export type EmbeddingProviderOptions = { url?: string; dimensions?: number; fallbackChain?: EmbeddingProviderType[]; fallback?: EmbeddingProviderType };
 export class ChromaDBInternalEmbeddings implements EmbeddingProvider {
@@ -176,34 +177,26 @@ export class GeminiEmbeddings implements EmbeddingProvider {
 export class FallbackEmbeddings implements EmbeddingProvider {
   readonly name: string;
   readonly dimensions: number;
+  private readonly chain: EmbeddingFallbackChain;
   constructor(
-    private readonly providers: EmbeddingProvider[],
+    providers: EmbeddingProvider[],
     private readonly onFallback: (event: FallbackEvent) => void = defaultFallbackLogger,
   ) {
     if (providers.length === 0) throw new Error('FallbackEmbeddings requires at least one provider');
     this.name = providers.map((provider) => provider.name).join('>');
     this.dimensions = providers[0].dimensions;
+    this.chain = new EmbeddingFallbackChain(providers, {
+      logger: () => undefined,
+      onFallback: this.onFallback,
+    });
   }
   async embed(texts: string[], type?: EmbedType): Promise<number[][]> {
-    let lastError: unknown;
-    for (let i = 0; i < this.providers.length; i++) {
-      const provider = this.providers[i];
-      try {
-        return await provider.embed(texts, type);
-      } catch (error) {
-        lastError = error;
-        this.onFallback({ from: provider.name, to: this.providers[i + 1]?.name, error: errorMessage(error) });
-      }
-    }
-    throw lastError instanceof Error ? lastError : new Error(String(lastError));
+    return this.chain.embed(texts, type);
   }
 }
 function defaultFallbackLogger(event: FallbackEvent): void {
   if (event.to) console.warn(`[EmbedderFallback] ${event.from} failed: ${event.error}; trying ${event.to}`);
   else console.warn(`[EmbedderFallback] ${event.from} failed: ${event.error}; no fallback provider left`);
-}
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }
 export function createEmbeddingProvider(
   type: EmbeddingProviderType = 'none',

--- a/src/vector/provider-detection.ts
+++ b/src/vector/provider-detection.ts
@@ -96,6 +96,12 @@ export async function getDetectedEmbeddingProviders(
   return cached;
 }
 
+export async function warmEmbeddingProviderDetection(
+  options: ProviderDetectionOptions = {},
+): Promise<{ checkedAt: string; providers: DetectedEmbeddingProvider[] }> {
+  return getDetectedEmbeddingProviders(false, options);
+}
+
 export function clearProviderDetectionCache(): void {
   cached = null;
 }

--- a/tests/cli/vector-config/cli.test.ts
+++ b/tests/cli/vector-config/cli.test.ts
@@ -73,8 +73,13 @@ describe("arra-cli vector-config", () => {
       async fetch(req) {
         const url = new URL(req.url);
         if (url.pathname === "/api/v1/vector/config") {
-          if (req.method !== "GET") return payload({ error: "method not allowed" }, 405);
-          return payload(state);
+          if (req.method === "GET") return payload(state);
+          if (req.method === "PATCH") {
+            const patch = (await req.json()) as Partial<VectorState["config"]>;
+            state.config = { ...state.config, ...patch };
+            return payload({ success: true, source: state.source, path: "/tmp/vector-server.json", config: state.config });
+          }
+          return payload({ error: "method not allowed" }, 405);
         }
 
         if (url.pathname === "/api/v1/vector/config/reload" && req.method === "POST") {
@@ -180,6 +185,12 @@ describe("arra-cli vector-config", () => {
     expect(disable.code).toBe(0);
     const disabled = await runCli(["vector-config", "get", "phase2"], env);
     expect(tryParseJson(disabled.stdout)?.config?.enabled).toBe(false);
+
+    const switched = await runCli(["vector-config", "switch", "sqlite-vec", "--enabled", "true"], env);
+    expect(switched.code).toBe(0);
+    const switchedPayload = tryParseJson(switched.stdout);
+    expect(switchedPayload?.config?.collections?.phase2?.adapter).toBe("sqlite-vec");
+    expect(switchedPayload?.config?.collections?.phase2?.enabled).toBe(true);
   });
 
   test("supports collection ops", async () => {

--- a/tests/cli/vector-config/source-command.test.ts
+++ b/tests/cli/vector-config/source-command.test.ts
@@ -105,5 +105,11 @@ describe('src vector-config command get/set', () => {
       primary: true,
     });
     expect(written.collections['bge-m3'].primary).toBe(false);
+
+    const switched = await run(['switch', 'sqlite-vec', '--enabled', 'true', '--json']);
+    expect(switched.code).toBe(0);
+    const afterSwitch = diskConfig();
+    expect(afterSwitch.collections.phase2).toMatchObject({ adapter: 'sqlite-vec', enabled: true });
+    expect(afterSwitch.collections['bge-m3']).toMatchObject({ adapter: 'sqlite-vec', enabled: true });
   });
 });

--- a/tests/frontend/components/plugin-list-surfaces.test.tsx
+++ b/tests/frontend/components/plugin-list-surfaces.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { PluginList } from '../../../frontend/src/components/PluginList';
+import { surfacesFor } from '../../../frontend/src/plugin-surfaces';
 import { htmlFor } from '../_render';
 
 describe('PluginList surfaces', () => {
@@ -37,5 +38,9 @@ describe('PluginList surfaces', () => {
     expect(html).toContain('GET /proxy/echo → $ECHO_URL');
     expect(html).toContain('CLI subcommands');
     expect(html).toContain('.echo');
+  });
+
+  test('normalizes backend mcpTools surface names for badges', () => {
+    expect(surfacesFor({ name: 'echo', file: '', size: 0, modified: 'now', surfaces: ['mcpTools'] })).toEqual(['mcp']);
   });
 });

--- a/tests/frontend/components/vector-index-panel-render.test.tsx
+++ b/tests/frontend/components/vector-index-panel-render.test.tsx
@@ -18,6 +18,12 @@ describe('VectorIndexPanel', () => {
     const html = htmlFor(
       <VectorIndexPanel
         initialStatus={status}
+        initialCostEstimate={{
+          formula: '100 docs × ~500 tokens/doc ≈ 50K tokens',
+          provider: 'openai',
+          estimatedUsd: 0.001,
+          recommendation: 'Any configured embedding model should work.',
+        }}
         initialModels={{
           'bge-m3': { collection: 'oracle_bge_m3', model: 'BAAI/bge-m3', adapter: 'lancedb', count: 100 },
           qwen3: { collection: 'oracle_qwen3', model: 'Qwen3', adapter: 'lancedb', count: 80 },
@@ -30,6 +36,9 @@ describe('VectorIndexPanel', () => {
     expect(html).toContain('Vault list');
     expect(html).toContain('Vector Models');
     expect(html).toContain('75 docs need backfill');
+    expect(html).toContain('Preflight cost before Index Now');
+    expect(html).toContain('100 docs × ~500 tokens/doc ≈ 50K tokens');
+    expect(html).toContain('$0.0010');
     expect(html).toContain('Index Now');
     expect(html).toContain('Backfill Vectors');
     expect(html).toContain('Add Vault');

--- a/tests/frontend/pages/vector-settings-page.test.tsx
+++ b/tests/frontend/pages/vector-settings-page.test.tsx
@@ -15,6 +15,7 @@ describe('VectorSettingsPage', () => {
     expect(html).toContain('Embedding providers and storage services');
     expect(html).toContain('Model recommendation');
     expect(html).toContain('Active vector adapters');
+    expect(html).toContain('switch all collection backends');
     expect(html).toContain('edit model/provider');
     expect(html).toContain('set primary');
     expect(html).toContain('Index jobs and collections');

--- a/tests/frontend/pages/vector-settings-page.test.tsx
+++ b/tests/frontend/pages/vector-settings-page.test.tsx
@@ -10,8 +10,8 @@ describe('VectorSettingsPage', () => {
     expect(html).toContain('Enable vector search');
     expect(html).toContain('PATCH /api/v1/vector/config');
     expect(html).toContain('First-run wizard');
-    expect(html).toContain('Provider → vault → first index');
-    expect(html).toContain('Open Index Manager');
+    expect(html).toContain('Choose a storage adapter');
+    expect(html).toContain('No collections loaded yet.');
     expect(html).toContain('Embedding providers and storage services');
     expect(html).toContain('Model recommendation');
     expect(html).toContain('Active vector adapters');

--- a/tests/http/export/history.test.ts
+++ b/tests/http/export/history.test.ts
@@ -41,6 +41,7 @@ afterAll(() => {
   else process.env.ORACLE_DATA_DIR = savedDataDir;
   if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
   else process.env.ORACLE_DB_PATH = savedDbPath;
+  dbMod.resetDefaultDatabaseForTests(':memory:');
   rmSync(root, { recursive: true, force: true });
 });
 

--- a/tests/http/export/oracle-v2-markdown.test.ts
+++ b/tests/http/export/oracle-v2-markdown.test.ts
@@ -57,6 +57,7 @@ afterAll(() => {
   else process.env.ORACLE_DATA_DIR = savedDataDir;
   if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
   else process.env.ORACLE_DB_PATH = savedDbPath;
+  dbMod.resetDefaultDatabaseForTests(':memory:');
   rmSync(root, { recursive: true, force: true });
 });
 

--- a/tests/http/forum/tenant-isolation.test.ts
+++ b/tests/http/forum/tenant-isolation.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, expect, test } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tempData = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-forum-db-'));
+const previousData = process.env.ORACLE_DATA_DIR;
+const previousDb = process.env.ORACLE_DB_PATH;
+process.env.ORACLE_DATA_DIR = tempData;
+process.env.ORACLE_DB_PATH = path.join(tempData, 'oracle.db');
+
+const dbModule = await import('../../../src/db/index.ts');
+dbModule.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+const { createTenantFetch, TENANT_HEADER } = await import('../../../src/middleware/tenant.ts');
+const { forumApi } = await import('../../../src/routes/forum/index.ts');
+
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantA = `tenant-a-${stamp}`;
+const tenantB = `tenant-b-${stamp}`;
+const threadIds: number[] = [];
+
+function requestForum(tenantId: string, pathname: string, init: RequestInit = {}) {
+  return createTenantFetch((request) => forumApi.handle(request))(new Request(`http://local${pathname}`, {
+    ...init,
+    headers: { 'content-type': 'application/json', [TENANT_HEADER]: tenantId, ...(init.headers ?? {}) },
+  }));
+}
+
+async function createThread(tenantId: string, title: string) {
+  const res = await requestForum(tenantId, '/api/thread', {
+    method: 'POST',
+    body: JSON.stringify({ message: title, title }),
+  });
+  const body = await res.json() as { thread_id: number };
+  expect(res.status).toBe(200);
+  threadIds.push(body.thread_id);
+  return body.thread_id;
+}
+
+async function threadTitles(tenantId: string) {
+  const res = await requestForum(tenantId, '/api/threads');
+  const body = await res.json() as { threads: Array<{ title: string }> };
+  expect(res.status).toBe(200);
+  return body.threads.map((thread) => thread.title);
+}
+
+afterAll(() => {
+  for (const id of threadIds) {
+    dbModule.sqlite.prepare('DELETE FROM forum_messages WHERE thread_id = ?').run(id);
+    dbModule.sqlite.prepare('DELETE FROM forum_threads WHERE id = ?').run(id);
+  }
+  dbModule.closeDb();
+  if (previousData === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = previousData;
+  if (previousDb === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = previousDb;
+  fs.rmSync(tempData, { recursive: true, force: true });
+});
+
+test('forum routes list and read only the selected tenant threads', async () => {
+  const titleA = `tenant A forum ${stamp}`;
+  const titleB = `tenant B forum ${stamp}`;
+  const threadA = await createThread(tenantA, titleA);
+  const threadB = await createThread(tenantB, titleB);
+
+  expect(await threadTitles(tenantA)).toContain(titleA);
+  expect(await threadTitles(tenantA)).not.toContain(titleB);
+  expect((await requestForum(tenantA, `/api/thread/${threadA}`)).status).toBe(200);
+  expect((await requestForum(tenantA, `/api/thread/${threadB}`)).status).toBe(404);
+});
+
+test('forum routes reject cross-tenant updates and follow-up messages', async () => {
+  const threadB = threadIds[1] ?? await createThread(tenantB, `tenant B guarded ${stamp}`);
+  const beforeCount = messageCount(threadB);
+
+  const deniedMessage = await requestForum(tenantA, '/api/thread', {
+    method: 'POST',
+    body: JSON.stringify({ thread_id: threadB, message: `cross tenant append ${stamp}` }),
+  });
+  expect(deniedMessage.status).toBe(404);
+  expect(messageCount(threadB)).toBe(beforeCount);
+
+  const deniedStatus = await requestForum(tenantA, `/api/thread/${threadB}/status`, {
+    method: 'PATCH',
+    body: JSON.stringify({ status: 'closed' }),
+  });
+  expect(deniedStatus.status).toBe(404);
+});
+
+function messageCount(threadId: number): number {
+  const row = dbModule.sqlite.prepare('SELECT COUNT(*) AS count FROM forum_messages WHERE thread_id = ?')
+    .get(threadId) as { count: number };
+  return row.count;
+}

--- a/tests/http/knowledge/tenant-isolation.test.ts
+++ b/tests/http/knowledge/tenant-isolation.test.ts
@@ -1,0 +1,90 @@
+import { afterAll, expect, test } from 'bun:test';
+import { inArray } from 'drizzle-orm';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tempData = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-knowledge-db-'));
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-knowledge-tenant-'));
+const previousData = process.env.ORACLE_DATA_DIR;
+const previousDb = process.env.ORACLE_DB_PATH;
+const previousRoot = process.env.ORACLE_REPO_ROOT;
+process.env.ORACLE_DATA_DIR = tempData;
+process.env.ORACLE_DB_PATH = path.join(tempData, 'oracle.db');
+process.env.ORACLE_REPO_ROOT = tempRoot;
+
+const dbModule = await import('../../../src/db/index.ts');
+dbModule.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+const { oracleDocuments } = dbModule;
+const { createTenantFetch, TENANT_HEADER } = await import('../../../src/middleware/tenant.ts');
+const { knowledgeRoutes } = await import('../../../src/routes/knowledge/index.ts');
+
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantA = `tenant-a-${stamp}`;
+const tenantB = `tenant-b-${stamp}`;
+const ids = [`knowledge-a-${stamp}`, `knowledge-b-${stamp}`];
+
+function requestKnowledge(tenantId: string, pathname: string, init: RequestInit = {}) {
+  return createTenantFetch((request) => knowledgeRoutes.handle(request))(new Request(`http://local${pathname}`, {
+    ...init,
+    headers: { 'content-type': 'application/json', [TENANT_HEADER]: tenantId, ...(init.headers ?? {}) },
+  }));
+}
+
+async function createLearn(tenantId: string, id: string, pattern: string) {
+  const res = await requestKnowledge(tenantId, '/api/learn', {
+    method: 'POST',
+    body: JSON.stringify({ id, pattern, concepts: ['tenant'] }),
+  });
+  expect(res.status).toBe(200);
+}
+
+afterAll(() => {
+  dbModule.db.delete(oracleDocuments).where(inArray(oracleDocuments.id, ids)).run();
+  for (const id of ids) dbModule.sqlite.prepare('DELETE FROM oracle_fts WHERE id = ?').run(id);
+  dbModule.closeDb();
+  if (previousData === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = previousData;
+  if (previousDb === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = previousDb;
+  if (previousRoot === undefined) delete process.env.ORACLE_REPO_ROOT;
+  else process.env.ORACLE_REPO_ROOT = previousRoot;
+  fs.rmSync(tempData, { recursive: true, force: true });
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+test('GET /api/learn lists only rows for the selected tenant', async () => {
+  await createLearn(tenantA, ids[0], `tenant A learning ${stamp}`);
+  await createLearn(tenantB, ids[1], `tenant B learning ${stamp}`);
+
+  const res = await requestKnowledge(tenantA, '/api/learn');
+  const body = await res.json() as { items: Array<{ id: string }> };
+  const listed = body.items.map((item) => item.id);
+
+  expect(res.status).toBe(200);
+  expect(listed).toContain(ids[0]);
+  expect(listed).not.toContain(ids[1]);
+});
+
+test('handoff inbox reads only files for the selected tenant', async () => {
+  const slugA = `handoff-a-${stamp}`;
+  const slugB = `handoff-b-${stamp}`;
+
+  expect((await requestKnowledge(tenantA, '/api/handoff', {
+    method: 'POST',
+    body: JSON.stringify({ content: `tenant A handoff ${stamp}`, slug: slugA }),
+  })).status).toBe(201);
+  expect((await requestKnowledge(tenantB, '/api/handoff', {
+    method: 'POST',
+    body: JSON.stringify({ content: `tenant B handoff ${stamp}`, slug: slugB }),
+  })).status).toBe(201);
+
+  const res = await requestKnowledge(tenantA, '/api/inbox?type=handoff&limit=50');
+  const body = await res.json() as { files: Array<{ filename: string; path: string }> };
+  const filenames = body.files.map((file) => file.filename);
+
+  expect(res.status).toBe(200);
+  expect(filenames.some((name) => name.includes(slugA))).toBe(true);
+  expect(filenames.some((name) => name.includes(slugB))).toBe(false);
+  expect(body.files.every((file) => file.path.includes(`/tenants/${tenantA}/`))).toBe(true);
+});

--- a/tests/http/tenant/export-isolation.test.ts
+++ b/tests/http/tenant/export-isolation.test.ts
@@ -66,6 +66,7 @@ afterAll(() => {
   else process.env.ORACLE_DATA_DIR = savedDataDir;
   if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
   else process.env.ORACLE_DB_PATH = savedDbPath;
+  dbMod.resetDefaultDatabaseForTests(':memory:');
   rmSync(root, { recursive: true, force: true });
 });
 

--- a/tests/http/vault/sync.test.ts
+++ b/tests/http/vault/sync.test.ts
@@ -1,7 +1,34 @@
-import { describe, expect, mock, test } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { beforeAll, describe, expect, mock, test } from 'bun:test';
 import { Elysia } from 'elysia';
-import { createVaultSyncRoute } from '../../../src/routes/vault/sync.ts';
-import type { MigrateResult } from '../../../src/vault/migrate.ts';
+import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
+
+type MigrateOptions = { dryRun: boolean; symlink?: boolean; tenantId?: string };
+interface MigrateResult {
+  reposFound: number;
+  filesCopied: number;
+  repos: Array<{ repoPath: string; project: string; fileCount: number }>;
+  skipped: string[];
+  symlinked: string[];
+}
+
+type VaultRouteFactory = (deps: {
+  migrate: (opts: MigrateOptions) => MigrateResult;
+  spawnIndexer: () => void;
+}) => Elysia;
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-vault-http-'));
+let createVaultSyncRoute: VaultRouteFactory;
+let projectMatchesTenant: (project: string, tenantId: string) => boolean;
+
+beforeAll(async () => {
+  process.env.ORACLE_DATA_DIR = tempRoot;
+  process.env.ORACLE_DB_PATH = path.join(tempRoot, 'oracle.db');
+  ({ createVaultSyncRoute } = await import('../../../src/routes/vault/sync.ts'));
+  ({ projectMatchesTenant } = await import('../../../src/vault/migrate.ts'));
+});
 
 const emptyMigrate: MigrateResult = {
   reposFound: 0,
@@ -11,9 +38,8 @@ const emptyMigrate: MigrateResult = {
   symlinked: [],
 };
 
-function appWith(migrate: (opts: { dryRun: boolean }) => MigrateResult, spawnIndexer = mock(() => {})) {
-  return new Elysia({ prefix: '/api/vault' })
-    .use(createVaultSyncRoute({ migrate, spawnIndexer }));
+function appWith(migrate: (opts: MigrateOptions) => MigrateResult, spawnIndexer = mock(() => {})) {
+  return new Elysia({ prefix: '/api/vault' }).use(createVaultSyncRoute({ migrate, spawnIndexer }));
 }
 
 function post(app: Elysia, body: unknown) {
@@ -48,6 +74,27 @@ describe('vault sync HTTP route', () => {
     expect(res.status).toBe(200);
     expect(body.reindex).toBe(true);
     expect(spawnIndexer).toHaveBeenCalledTimes(1);
+  });
+
+  test('matches vault projects to tenant ids before migration filtering', () => {
+    expect(projectMatchesTenant('github.com/soul-brews-studio/arra-oracle-v3', 'soul-brews-studio')).toBe(true);
+    expect(projectMatchesTenant('tenant-a', 'tenant-a')).toBe(true);
+    expect(projectMatchesTenant('github.com/tenant-b/oracle', 'tenant-a')).toBe(false);
+  });
+
+  test('passes resolved tenant to migrate and returns tenant scope', async () => {
+    const migrate = mock((opts: MigrateOptions) => ({ ...emptyMigrate, reposFound: opts.tenantId ? 1 : 0 }));
+    const fetcher = createTenantFetch((request) => appWith(migrate).handle(request));
+    const res = await fetcher(new Request('http://local/api/vault/sync', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', [TENANT_HEADER]: 'tenant-a' },
+      body: JSON.stringify({ dryRun: true }),
+    }));
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(migrate).toHaveBeenCalledWith({ dryRun: true, tenantId: 'tenant-a' });
+    expect(body.tenant).toEqual({ id: 'tenant-a', scope: 'vault_project' });
   });
 
   test('migrate failures surface as 500 JSON', async () => {

--- a/tests/http/vector/config-api.test.ts
+++ b/tests/http/vector/config-api.test.ts
@@ -110,6 +110,20 @@ test('GET and PUT /api/v1/vector/config expose and update vector-server.json', a
     adapter: 'qdrant',
   });
 
+  const switchRes = await call('/api/v1/vector/config', {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      collections: Object.fromEntries(Object.entries(putRes.body.config.collections).map(([key, value]) => [
+        key,
+        { ...(value as Record<string, unknown>), adapter: 'sqlite-vec', enabled: true },
+      ])),
+    }),
+  });
+  expect(switchRes.status).toBe(200);
+  expect(switchRes.body.config.collections.phase1).toMatchObject({ adapter: 'sqlite-vec', enabled: true });
+  expect(vectorConfig.loadVectorConfig(vectorConfig.configPath(root))?.collections.phase1.adapter).toBe('sqlite-vec');
+
   const disabledRes = await call('/api/v1/vector/config/phase1', {
     method: 'PUT',
     headers: { 'content-type': 'application/json' },
@@ -165,6 +179,6 @@ test('GET and PUT /api/v1/vector/config expose and update vector-server.json', a
   const reloadRes = await call('/api/v1/vector/config/reload', { method: 'POST' });
   expect(reloadRes.status).toBe(200);
   expect(reloadRes.body).toMatchObject({ success: true, reloaded: true, source: 'file' });
-  expect(reloadRes.body.config.collections.phase1.adapter).toBe('qdrant');
+  expect(reloadRes.body.config.collections.phase1.adapter).toBe('sqlite-vec');
   expect(readdirSync(root).some((name) => name.includes('.tmp'))).toBe(false);
 });

--- a/tests/http/vector/config-api.test.ts
+++ b/tests/http/vector/config-api.test.ts
@@ -64,6 +64,7 @@ test('GET and PUT /api/v1/vector/config expose and update vector-server.json', a
     adapter: 'lancedb',
   });
   expect(getRes.body.collections[0].count).toEqual(expect.any(Number));
+  expect(getRes.body.options.embeddingProviders).toContain('gemini');
 
   const testRes = await call('/api/v1/vector/config/phase1/test', { method: 'POST' });
   expect(testRes.status).toBe(200);

--- a/tests/plugins/unified-loader-seed-menu-drizzle.test.ts
+++ b/tests/plugins/unified-loader-seed-menu-drizzle.test.ts
@@ -8,6 +8,7 @@ const tmp = mkdtempSync(join(tmpdir(), "arra-unified-menu-db-"));
 const previousDbPath = process.env.ORACLE_DB_PATH;
 const previousDataDir = process.env.ORACLE_DATA_DIR;
 let closeDb: (() => void) | undefined;
+let resetDefaultDatabaseForTests: (() => void) | undefined;
 
 afterAll(() => {
   closeDb?.();
@@ -15,6 +16,7 @@ afterAll(() => {
   else process.env.ORACLE_DB_PATH = previousDbPath;
   if (previousDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
   else process.env.ORACLE_DATA_DIR = previousDataDir;
+  resetDefaultDatabaseForTests?.(':memory:');
   rmSync(tmp, { recursive: true, force: true });
 });
 
@@ -24,8 +26,10 @@ describe("seedUnifiedPluginMenuItems", () => {
     process.env.ORACLE_DB_PATH = join(tmp, "oracle.db");
     const { seedUnifiedPluginMenuItems } = await import("../../src/plugins/unified-loader.ts");
     const dbModule = await import("../../src/db/index.ts");
+    dbModule.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
     const { db, menuItems } = dbModule;
     closeDb = dbModule.closeDb;
+    resetDefaultDatabaseForTests = dbModule.resetDefaultDatabaseForTests;
     const now = new Date();
 
     await seedUnifiedPluginMenuItems([

--- a/tests/tools/export-app.test.ts
+++ b/tests/tools/export-app.test.ts
@@ -18,10 +18,6 @@ const { createDatabase, oracleDocuments, oracleMemories, resetDefaultDatabaseFor
 const { parseArgs, runExportApp } = appModule;
 const { exportMarkdownData, schemaTables } = exporterModule;
 
-function restoreDbPath(): string {
-  return savedDbPath
-    ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
-}
 
 function seed(connection: ReturnType<typeof createDatabase>): void {
   const now = 1_766_000_000_000;
@@ -59,7 +55,7 @@ afterAll(() => {
   else process.env.ORACLE_DATA_DIR = savedDataDir;
   if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
   else process.env.ORACLE_DB_PATH = savedDbPath;
-  resetDefaultDatabaseForTests(restoreDbPath());
+  resetDefaultDatabaseForTests(':memory:');
   rmSync(root, { recursive: true, force: true });
 });
 

--- a/tests/tools/export-app/export-app.test.ts
+++ b/tests/tools/export-app/export-app.test.ts
@@ -23,10 +23,6 @@ const { exportOracleData, exportOracleV2Documents, graphRelationships } = export
 const { formatCsvCollection } = csvModule;
 const { formatJsonCollection } = jsonModule;
 
-function restoreDbPath() {
-  return savedDbPath
-    ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
-}
 
 function seed(connection: ReturnType<typeof createDatabase>) {
   const now = 1_766_000_000_000;
@@ -66,7 +62,7 @@ afterAll(() => {
   else process.env.ORACLE_DATA_DIR = savedDataDir;
   if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
   else process.env.ORACLE_DB_PATH = savedDbPath;
-  resetDefaultDatabaseForTests(restoreDbPath());
+  resetDefaultDatabaseForTests(':memory:');
   rmSync(root, { recursive: true, force: true });
 });
 

--- a/tests/tools/export-app/manifest-schema.test.ts
+++ b/tests/tools/export-app/manifest-schema.test.ts
@@ -15,17 +15,13 @@ const exporterModule = await import('../../../tools/export-app/exporter.ts');
 const { createDatabase, resetDefaultDatabaseForTests } = dbModule;
 const { exportOracleData, EXPORT_MANIFEST_SCHEMA } = exporterModule;
 
-function restoreDbPath(): string {
-  return savedDbPath
-    ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
-}
 
 afterAll(() => {
   if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
   else process.env.ORACLE_DATA_DIR = savedDataDir;
   if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
   else process.env.ORACLE_DB_PATH = savedDbPath;
-  resetDefaultDatabaseForTests(restoreDbPath());
+  resetDefaultDatabaseForTests(':memory:');
   rmSync(root, { recursive: true, force: true });
 });
 

--- a/tests/tools/export-app/verify.test.ts
+++ b/tests/tools/export-app/verify.test.ts
@@ -1,5 +1,5 @@
-import { afterAll, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { afterAll, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -10,18 +10,41 @@ process.env.ORACLE_DATA_DIR = root;
 process.env.ORACLE_DB_PATH = join(root, 'oracle.db');
 
 const dbModule = await import('../../../src/db/index.ts');
-const exporterModule = await import('../../../tools/export-app/exporter.ts');
 const appModule = await import('../../../tools/export-app/index.ts');
+const exporterModule = await import('../../../tools/export-app/exporter.ts');
 const verifyModule = await import('../../../tools/export-app/verify.ts');
 
-const { createDatabase, resetDefaultDatabaseForTests } = dbModule;
+const { createDatabase, oracleDocuments, resetDefaultDatabaseForTests } = dbModule;
+const { runExportApp, parseArgs } = appModule;
 const { exportOracleData } = exporterModule;
-const { runExportApp } = appModule;
 const { verifyExportBundle } = verifyModule;
 
 function restoreDbPath(): string {
   return savedDbPath
     ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
+}
+
+async function writeBundle(outputDir: string): Promise<void> {
+  const connection = createDatabase(join(root, `${outputDir.split('/').pop()}.db`));
+  connection.db.insert(oracleDocuments).values({
+    id: 'doc-verify',
+    type: 'learning',
+    sourceFile: 'ψ/learn/verify.md',
+    concepts: '["backup"]',
+    createdAt: 1,
+    updatedAt: 2,
+    indexedAt: 3,
+  }).run();
+  connection.sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)').run(
+    'doc-verify',
+    'Verifier body',
+    'backup',
+  );
+  try {
+    await exportOracleData({ connection, outputDir, progress: () => {} });
+  } finally {
+    connection.storage.close();
+  }
 }
 
 afterAll(() => {
@@ -30,45 +53,48 @@ afterAll(() => {
   if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
   else process.env.ORACLE_DB_PATH = savedDbPath;
   resetDefaultDatabaseForTests(restoreDbPath());
-  rmSync(root, { recursive: true, force: true });
+  if (existsSync(root)) rmSync(root, { recursive: true });
 });
 
-test('export bundle verifier checks manifest file inventory checksums', async () => {
-  const connection = createDatabase(join(root, 'verify.db'));
-  const outputDir = join(root, 'verify-export');
-  try {
-    await exportOracleData({ connection, outputDir, progress: () => {} });
-  } finally {
-    connection.storage.close();
-  }
+describe('export bundle verifier', () => {
+  test('passes for a fresh export bundle and the CLI verify flag', async () => {
+    const outputDir = join(root, 'ok-bundle');
+    await writeBundle(outputDir);
 
-  await expect(verifyExportBundle(outputDir)).resolves.toMatchObject({
-    ok: true,
-    fileCount: expect.any(Number),
-    errors: [],
+    await expect(verifyExportBundle(outputDir)).resolves.toMatchObject({
+      ok: true,
+      checkedFiles: expect.any(Number),
+      fileCount: expect.any(Number),
+      errors: [],
+      documentCount: 1,
+    });
+
+    const stdout: string[] = [];
+    const code = await runExportApp(['--verify', outputDir], (message) => stdout.push(message), () => {});
+    const payload = JSON.parse(stdout.join(''));
+    expect(code).toBe(0);
+    expect(payload).toMatchObject({ success: true, verified: true, ok: true, documentCount: 1 });
   });
 
-  writeFileSync(join(outputDir, 'README.md'), 'corrupted export bundle');
-  const broken = await verifyExportBundle(outputDir);
-  expect(broken.ok).toBe(false);
-  expect(broken.errors.some((line) => line.includes('README.md: sha256'))).toBe(true);
-});
+  test('fails when a listed file no longer matches manifest checksums', async () => {
+    const outputDir = join(root, 'corrupt-bundle');
+    await writeBundle(outputDir);
+    writeFileSync(join(outputDir, 'README.md'), `${readFileSync(join(outputDir, 'README.md'), 'utf8')}\ncorrupt`);
 
-test('CLI --verify reports structured success and failure', async () => {
-  const connection = createDatabase(join(root, 'verify-cli.db'));
-  const outputDir = join(root, 'verify-cli-export');
-  const stdout: string[] = [];
-  try {
-    await exportOracleData({ connection, outputDir, progress: () => {} });
-  } finally {
-    connection.storage.close();
-  }
+    const result = await verifyExportBundle(outputDir);
+    expect(result.ok).toBe(false);
+    expect(result.errors.join('\n')).toContain('README.md');
+    expect(result.errors.join('\n')).toContain('sha256 mismatch');
 
-  expect(await runExportApp(['--verify', outputDir], (msg) => stdout.push(msg), () => {})).toBe(0);
-  expect(JSON.parse(stdout.join(''))).toMatchObject({ success: true, verified: true });
+    const stdout: string[] = [];
+    const code = await runExportApp(['--verify', outputDir], (message) => stdout.push(message), () => {});
+    expect(code).toBe(1);
+    expect(JSON.parse(stdout.join(''))).toMatchObject({ success: false, verified: false });
+  });
 
-  stdout.length = 0;
-  writeFileSync(join(outputDir, 'README.md'), 'broken');
-  expect(await runExportApp(['--verify', outputDir], (msg) => stdout.push(msg), () => {})).toBe(1);
-  expect(JSON.parse(stdout.join(''))).toMatchObject({ success: false, verified: false });
+  test('parses verify mode without requiring output', () => {
+    expect(parseArgs(['--verify', './backup'])).toMatchObject({ verifyDir: './backup' });
+    expect(() => parseArgs(['--verify', './backup', '--output', './other']))
+      .toThrow('--verify cannot be combined with --output');
+  });
 });

--- a/tests/tools/export-app/verify.test.ts
+++ b/tests/tools/export-app/verify.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, test } from 'bun:test';
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -19,26 +19,14 @@ const { runExportApp, parseArgs } = appModule;
 const { exportOracleData } = exporterModule;
 const { verifyExportBundle } = verifyModule;
 
-function restoreDbPath(): string {
-  return savedDbPath
-    ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
-}
-
 async function writeBundle(outputDir: string): Promise<void> {
   const connection = createDatabase(join(root, `${outputDir.split('/').pop()}.db`));
   connection.db.insert(oracleDocuments).values({
-    id: 'doc-verify',
-    type: 'learning',
-    sourceFile: 'ψ/learn/verify.md',
-    concepts: '["backup"]',
-    createdAt: 1,
-    updatedAt: 2,
-    indexedAt: 3,
+    id: 'doc-verify', type: 'learning', sourceFile: 'ψ/learn/verify.md',
+    concepts: '["backup"]', createdAt: 1, updatedAt: 2, indexedAt: 3,
   }).run();
   connection.sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)').run(
-    'doc-verify',
-    'Verifier body',
-    'backup',
+    'doc-verify', 'Verifier body', 'backup',
   );
   try {
     await exportOracleData({ connection, outputDir, progress: () => {} });
@@ -52,8 +40,8 @@ afterAll(() => {
   else process.env.ORACLE_DATA_DIR = savedDataDir;
   if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
   else process.env.ORACLE_DB_PATH = savedDbPath;
-  resetDefaultDatabaseForTests(restoreDbPath());
-  if (existsSync(root)) rmSync(root, { recursive: true });
+  resetDefaultDatabaseForTests(':memory:');
+  if (existsSync(root)) rmSync(root, { recursive: true, force: true });
 });
 
 describe('export bundle verifier', () => {
@@ -61,19 +49,16 @@ describe('export bundle verifier', () => {
     const outputDir = join(root, 'ok-bundle');
     await writeBundle(outputDir);
 
-    await expect(verifyExportBundle(outputDir)).resolves.toMatchObject({
-      ok: true,
-      checkedFiles: expect.any(Number),
-      fileCount: expect.any(Number),
-      errors: [],
-      documentCount: 1,
-    });
+    const verified = await verifyExportBundle(outputDir);
+    expect(verified).toMatchObject({ ok: true, errors: [], documentCount: 1, relationshipFileCount: 3 });
+    expect(verified.collectionCount).toBeGreaterThan(5);
+    expect(verified.checkedFiles).toBeGreaterThan(verified.collectionCount ?? 0);
+    expect(verified.bytes).toBeGreaterThan(0);
 
     const stdout: string[] = [];
     const code = await runExportApp(['--verify', outputDir], (message) => stdout.push(message), () => {});
-    const payload = JSON.parse(stdout.join(''));
     expect(code).toBe(0);
-    expect(payload).toMatchObject({ success: true, verified: true, ok: true, documentCount: 1 });
+    expect(JSON.parse(stdout.join(''))).toMatchObject({ success: true, verified: true, ok: true, documentCount: 1 });
   });
 
   test('fails when a listed file no longer matches manifest checksums', async () => {
@@ -87,9 +72,18 @@ describe('export bundle verifier', () => {
     expect(result.errors.join('\n')).toContain('sha256 mismatch');
 
     const stdout: string[] = [];
-    const code = await runExportApp(['--verify', outputDir], (message) => stdout.push(message), () => {});
-    expect(code).toBe(1);
+    expect(await runExportApp(['--verify', outputDir], (message) => stdout.push(message), () => {})).toBe(1);
     expect(JSON.parse(stdout.join(''))).toMatchObject({ success: false, verified: false });
+  });
+
+  test('fails when a required artifact disappears', async () => {
+    const outputDir = join(root, 'missing-bundle');
+    await writeBundle(outputDir);
+    unlinkSync(join(outputDir, 'relationships.json'));
+
+    const result = await verifyExportBundle(outputDir);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((line) => line.includes('relationships.json'))).toBe(true);
   });
 
   test('parses verify mode without requiring output', () => {

--- a/tests/tools/export-app/verify.test.ts
+++ b/tests/tools/export-app/verify.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -14,14 +14,33 @@ const exporterModule = await import('../../../tools/export-app/exporter.ts');
 const appModule = await import('../../../tools/export-app/index.ts');
 const verifyModule = await import('../../../tools/export-app/verify.ts');
 
-const { createDatabase, resetDefaultDatabaseForTests } = dbModule;
+const { createDatabase, oracleDocuments, resetDefaultDatabaseForTests } = dbModule;
 const { exportOracleData } = exporterModule;
 const { runExportApp } = appModule;
 const { verifyExportBundle } = verifyModule;
 
-function restoreDbPath(): string {
-  return savedDbPath
-    ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
+
+function seed(connection: ReturnType<typeof createDatabase>): void {
+  const now = 1_766_000_000_000;
+  connection.db.insert(oracleDocuments).values({
+    id: 'verify-doc', type: 'learning', sourceFile: 'psi/export/verify.md',
+    concepts: '["verify","backup"]', createdAt: now, updatedAt: now, indexedAt: now, createdBy: 'test',
+  }).run();
+  connection.sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)').run(
+    'verify-doc', 'Verifier export body.', 'verify backup',
+  );
+}
+
+async function writeBundle(name: string): Promise<string> {
+  const connection = createDatabase(join(root, `${name}.db`));
+  const outputDir = join(root, name);
+  try {
+    seed(connection);
+    await exportOracleData({ connection, outputDir, progress: () => {} });
+  } finally {
+    connection.storage.close();
+  }
+  return outputDir;
 }
 
 afterAll(() => {
@@ -29,43 +48,34 @@ afterAll(() => {
   else process.env.ORACLE_DATA_DIR = savedDataDir;
   if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
   else process.env.ORACLE_DB_PATH = savedDbPath;
-  resetDefaultDatabaseForTests(restoreDbPath());
+  resetDefaultDatabaseForTests(':memory:');
   rmSync(root, { recursive: true, force: true });
 });
 
-test('export bundle verifier checks manifest file inventory checksums', async () => {
-  const connection = createDatabase(join(root, 'verify.db'));
-  const outputDir = join(root, 'verify-export');
-  try {
-    await exportOracleData({ connection, outputDir, progress: () => {} });
-  } finally {
-    connection.storage.close();
-  }
+test('export bundle verifier checks inventory checksums and artifacts', async () => {
+  const outputDir = await writeBundle('verify-export');
+  const verified = await verifyExportBundle(outputDir);
+  expect(verified).toMatchObject({ ok: true, errors: [], documentCount: 1, relationshipFileCount: 3 });
+  expect(verified.collectionCount).toBeGreaterThan(5);
+  expect(verified.checkedFiles).toBeGreaterThan(verified.collectionCount);
+  expect(verified.bytes).toBeGreaterThan(0);
+  const markdown = join(outputDir, 'documents', 'markdown', 'psi_export_verify.md');
+  expect(existsSync(markdown)).toBe(true);
 
-  await expect(verifyExportBundle(outputDir)).resolves.toMatchObject({
-    ok: true,
-    fileCount: expect.any(Number),
-    errors: [],
-  });
-
-  writeFileSync(join(outputDir, 'README.md'), 'corrupted export bundle');
+  writeFileSync(markdown, 'tampered');
   const broken = await verifyExportBundle(outputDir);
   expect(broken.ok).toBe(false);
-  expect(broken.errors.some((line) => line.includes('README.md: sha256'))).toBe(true);
+  expect(broken.errors.some((line) => line.includes('checksum mismatch'))).toBe(true);
+  unlinkSync(join(outputDir, 'relationships.json'));
+  const missing = await verifyExportBundle(outputDir);
+  expect(missing.errors.some((line) => line.includes('relationships.json'))).toBe(true);
 });
 
 test('CLI --verify reports structured success and failure', async () => {
-  const connection = createDatabase(join(root, 'verify-cli.db'));
-  const outputDir = join(root, 'verify-cli-export');
+  const outputDir = await writeBundle('verify-cli-export');
   const stdout: string[] = [];
-  try {
-    await exportOracleData({ connection, outputDir, progress: () => {} });
-  } finally {
-    connection.storage.close();
-  }
-
   expect(await runExportApp(['--verify', outputDir], (msg) => stdout.push(msg), () => {})).toBe(0);
-  expect(JSON.parse(stdout.join(''))).toMatchObject({ success: true, verified: true });
+  expect(JSON.parse(stdout.join(''))).toMatchObject({ success: true, verified: true, documentCount: 1 });
 
   stdout.length = 0;
   writeFileSync(join(outputDir, 'README.md'), 'broken');

--- a/tests/tools/maw-plugin-arra/vector-config.test.ts
+++ b/tests/tools/maw-plugin-arra/vector-config.test.ts
@@ -120,4 +120,21 @@ describe('tools maw arra vector-config command', () => {
     expect(calls[0].url).toBe('http://arra.test/api/v1/vector/config/nomic');
     expect(calls[0].body).toEqual({ enabled: false });
   });
+
+  test('switches all collection adapters through the config patch API', async () => {
+    const { result, calls } = await run(['vector-config', 'switch', 'sqlite-vec', '--enabled', 'true']);
+
+    expect(result.ok).toBe(true);
+    expect(calls.map((call) => call.url)).toEqual([
+      'http://arra.test/api/v1/vector/config',
+      'http://arra.test/api/v1/vector/config',
+    ]);
+    expect(calls[1].init?.method).toBe('PATCH');
+    expect(calls[1].body).toMatchObject({
+      collections: {
+        'bge-m3': { adapter: 'sqlite-vec', enabled: true },
+        nomic: { adapter: 'sqlite-vec', enabled: true },
+      },
+    });
+  });
 });

--- a/tests/vector/fallback-embeddings.test.ts
+++ b/tests/vector/fallback-embeddings.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'bun:test';
+import { expect, mock, test } from 'bun:test';
 import { FallbackEmbeddings } from '../../src/vector/embeddings.ts';
 import type { EmbeddingProvider } from '../../src/vector/types.ts';
 
@@ -22,4 +22,15 @@ test('fallback embedder tries the next provider and logs the fallback event', as
 
   expect(await embedder.embed(['hello'], 'passage')).toEqual([[1, 2]]);
   expect(events).toEqual([{ from: 'ollama', to: 'openai', error: 'ollama down' }]);
+});
+
+test('fallback embedder resumes from the healthy provider after failover', async () => {
+  const ollama = { name: 'ollama', dimensions: 2, embed: mock(async () => { throw new Error('ollama down'); }) };
+  const gemini = { name: 'gemini', dimensions: 2, embed: mock(async () => [[3, 4]]) };
+  const embedder = new FallbackEmbeddings([ollama, gemini], () => undefined);
+
+  expect(await embedder.embed(['first'], 'passage')).toEqual([[3, 4]]);
+  expect(await embedder.embed(['second'], 'passage')).toEqual([[3, 4]]);
+  expect(ollama.embed).toHaveBeenCalledTimes(1);
+  expect(gemini.embed).toHaveBeenCalledTimes(2);
 });

--- a/tests/vector/provider-detection.test.ts
+++ b/tests/vector/provider-detection.test.ts
@@ -1,5 +1,9 @@
 import { expect, mock, test } from 'bun:test';
-import { clearProviderDetectionCache, getDetectedEmbeddingProviders } from '../../src/vector/provider-detection.ts';
+import {
+  clearProviderDetectionCache,
+  getDetectedEmbeddingProviders,
+  warmEmbeddingProviderDetection,
+} from '../../src/vector/provider-detection.ts';
 
 test('provider detection caches probes until force refresh', async () => {
   clearProviderDetectionCache();
@@ -15,5 +19,20 @@ test('provider detection caches probes until force refresh', async () => {
   expect(cached.providers[0].models).toEqual(['model-1']);
   expect(forced.providers[0].models).toEqual(['model-2']);
   expect(fetcher).toHaveBeenCalledTimes(2);
+  clearProviderDetectionCache();
+});
+
+test('provider detection warmup seeds startup cache', async () => {
+  clearProviderDetectionCache();
+  let n = 0;
+  const fetcher = mock(async () => Response.json({ models: [{ name: `startup-${++n}` }] })) as unknown as typeof fetch;
+  const options = { env: {}, fetcher };
+
+  const warmed = await warmEmbeddingProviderDetection(options);
+  const cached = await getDetectedEmbeddingProviders(false, options);
+
+  expect(warmed.providers[0].models).toEqual(['startup-1']);
+  expect(cached.providers[0].models).toEqual(['startup-1']);
+  expect(fetcher).toHaveBeenCalledTimes(1);
   clearProviderDetectionCache();
 });

--- a/tools/export-app/README.md
+++ b/tools/export-app/README.md
@@ -99,8 +99,9 @@ It also includes `collections.<table>.rowCount` so restore/preflight tooling can
 compare source and destination collection sizes without loading every artifact.
 The generated bundle `README.md` summarizes counts and verification steps for
 offline review before migration.
-Run `--verify <dir>` after copying an export bundle to recompute every
-manifest-listed file size and SHA-256 checksum.
+Run `--verify <bundle-dir>` after export or after copying a bundle to re-read
+`manifest.json`, recompute each listed file's byte count and SHA-256 checksum,
+and fail if a required artifact is missing.
 Progress writes to stderr by default as collection counts, percentages, and row
 counts. Use `--progress json` or `--progress-json` for machine-readable events,
 `--progress silent` or `--quiet` when another wrapper owns progress display.

--- a/tools/export-app/bundle-readme.ts
+++ b/tools/export-app/bundle-readme.ts
@@ -39,5 +39,7 @@ export function exportBundleReadme(input: ExportBundleReadmeInput): string {
     '3. Recompute SHA-256 for files listed in `manifest.json.files`.',
     '4. Inspect Markdown documents before migration or restore work.',
     '',
+    'CLI shortcut: `bun run tools/export-app/index.ts --verify <bundle-dir>`.',
+    '',
   ].join('\n');
 }

--- a/tools/export-app/index.ts
+++ b/tools/export-app/index.ts
@@ -69,6 +69,7 @@ export function parseArgs(args: string[]): CliOptions {
     throw new Error(arg.startsWith('-') ? `unknown flag: ${arg}` : `unexpected argument: ${arg}`);
   }
 
+  if (verifyDir && outputDir) throw new Error('--verify cannot be combined with --output');
   if (!outputDir && !verifyDir) throw new Error('missing required --output <dir>');
   return { outputDir: outputDir ?? verifyDir!, dbPath, quiet, progressMode, dryRun, verifyDir, collections };
 }

--- a/tools/export-app/verify.ts
+++ b/tools/export-app/verify.ts
@@ -1,73 +1,105 @@
-import { createHash } from 'node:crypto';
-import { readFile, stat } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import path from 'node:path';
-
-type ManifestFile = {
-  path: string;
-  bytes: number;
-  sha256: string;
-};
+import { exportFileInventory, type ExportFileInventoryEntry } from './inventory.ts';
 
 export interface ExportBundleVerification {
   ok: boolean;
   bundleDir: string;
+  checkedFiles: number;
   fileCount: number;
   errors: string[];
+  exportedAt?: string;
+  collectionCount?: number;
+  rowCount?: number;
+  relationshipCount?: number;
+  documentCount?: number;
 }
 
-function containedPath(baseDir: string, relativePath: string): string | null {
-  const resolvedBase = path.resolve(baseDir);
-  const resolved = path.resolve(resolvedBase, relativePath);
-  return resolved === resolvedBase || resolved.startsWith(`${resolvedBase}${path.sep}`) ? resolved : null;
-}
-
-async function sha256(filePath: string): Promise<string> {
-  return createHash('sha256').update(await readFile(filePath)).digest('hex');
-}
-
-function manifestFiles(value: unknown): ManifestFile[] {
-  if (!value || typeof value !== 'object' || !Array.isArray((value as { files?: unknown }).files)) {
-    throw new Error('manifest.json missing files inventory');
-  }
-  return (value as { files: ManifestFile[] }).files;
-}
+type Manifest = {
+  exportedAt?: string;
+  files?: ExportFileInventoryEntry[];
+  collectionCount?: number;
+  rowCount?: number;
+  relationshipCount?: number;
+  documentCount?: number;
+};
 
 export async function verifyExportBundle(bundleDir: string): Promise<ExportBundleVerification> {
   const root = path.resolve(bundleDir);
   const errors: string[] = [];
-  let files: ManifestFile[] = [];
+  const manifest = await readManifest(path.join(root, 'manifest.json'), errors);
+  if (!manifest) return result(root, errors, 0);
 
+  const expected = Array.isArray(manifest.files) ? manifest.files : [];
+  if (!Array.isArray(manifest.files)) errors.push('manifest.files must be an array');
+  const actual = await inventory(root, errors);
+  const actualByPath = new Map(actual.map((entry) => [entry.path, entry]));
+  const expectedPaths = new Set(expected.map((entry) => entry.path));
+
+  for (const entry of expected) verifyEntry(entry, actualByPath.get(entry.path), errors);
+  for (const entry of actual) {
+    if (!expectedPaths.has(entry.path)) errors.push(`unexpected file not listed in manifest: ${entry.path}`);
+  }
+  for (const file of requiredFiles(manifest)) {
+    if (!expectedPaths.has(file)) errors.push(`required file missing from manifest: ${file}`);
+  }
+
+  return {
+    ...result(root, errors, expected.length),
+    exportedAt: manifest.exportedAt,
+    collectionCount: manifest.collectionCount,
+    rowCount: manifest.rowCount,
+    relationshipCount: manifest.relationshipCount,
+    documentCount: manifest.documentCount,
+  };
+}
+
+async function readManifest(file: string, errors: string[]): Promise<Manifest | null> {
   try {
-    files = manifestFiles(JSON.parse(await readFile(path.join(root, 'manifest.json'), 'utf8')));
-  } catch (error) {
-    return {
-      ok: false,
-      bundleDir: root,
-      fileCount: 0,
-      errors: [error instanceof Error ? error.message : String(error)],
-    };
+    const manifest = JSON.parse(await readFile(file, 'utf8')) as Manifest;
+    if (!manifest || typeof manifest !== 'object') {
+      errors.push('manifest.json must contain an object');
+      return null;
+    }
+    return manifest;
+  } catch (cause) {
+    errors.push(`cannot read manifest.json: ${cause instanceof Error ? cause.message : String(cause)}`);
+    return null;
   }
+}
 
-  for (let index = 0; index < files.length; index += 1) {
-    const file = files[index]!;
-    if (!file || typeof file.path !== 'string' || typeof file.bytes !== 'number' || typeof file.sha256 !== 'string') {
-      errors.push(`files[${index}]: invalid inventory entry`);
-      continue;
-    }
-    const target = containedPath(root, file.path);
-    if (!target) {
-      errors.push(`${file.path}: escapes export bundle`);
-      continue;
-    }
-    try {
-      const [info, digest] = await Promise.all([stat(target), sha256(target)]);
-      if (!info.isFile()) errors.push(`${file.path}: not a file`);
-      if (info.size !== file.bytes) errors.push(`${file.path}: bytes ${info.size} !== ${file.bytes}`);
-      if (digest !== file.sha256) errors.push(`${file.path}: sha256 ${digest} !== ${file.sha256}`);
-    } catch (error) {
-      errors.push(`${file.path}: ${error instanceof Error ? error.message : String(error)}`);
-    }
+async function inventory(root: string, errors: string[]): Promise<ExportFileInventoryEntry[]> {
+  try {
+    return await exportFileInventory(root, { exclude: ['manifest.json'] });
+  } catch (cause) {
+    errors.push(`cannot inventory bundle: ${cause instanceof Error ? cause.message : String(cause)}`);
+    return [];
   }
+}
 
-  return { ok: errors.length === 0, bundleDir: root, fileCount: files.length, errors };
+function verifyEntry(expected: ExportFileInventoryEntry, actual: ExportFileInventoryEntry | undefined, errors: string[]): void {
+  if (!actual) {
+    errors.push(`missing file: ${expected.path}`);
+    return;
+  }
+  if (actual.bytes !== expected.bytes) {
+    errors.push(`byte mismatch for ${expected.path}: expected ${expected.bytes}, got ${actual.bytes}`);
+  }
+  if (actual.sha256 !== expected.sha256) errors.push(`sha256 mismatch for ${expected.path}`);
+}
+
+function requiredFiles(manifest: Manifest): string[] {
+  const formats = ['json', 'csv', 'md'];
+  return [
+    'README.md',
+    'all-collections.json',
+    'manifest.schema.json',
+    'documents/index.json',
+    'documents/documents.csv',
+    ...formats.map((format) => `relationships.${format}`),
+  ].filter((file) => manifest.documentCount !== 0 || !file.startsWith('documents/'));
+}
+
+function result(root: string, errors: string[], checkedFiles: number): ExportBundleVerification {
+  return { ok: errors.length === 0, bundleDir: root, checkedFiles, fileCount: checkedFiles, errors };
 }

--- a/tools/export-app/verify.ts
+++ b/tools/export-app/verify.ts
@@ -2,6 +2,8 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { exportFileInventory, type ExportFileInventoryEntry } from './inventory.ts';
 
+type JsonRecord = Record<string, unknown>;
+
 export interface ExportBundleVerification {
   ok: boolean;
   bundleDir: string;
@@ -13,11 +15,14 @@ export interface ExportBundleVerification {
   rowCount?: number;
   relationshipCount?: number;
   documentCount?: number;
+  bytes?: number;
+  relationshipFileCount?: number;
 }
 
 type Manifest = {
   exportedAt?: string;
   files?: ExportFileInventoryEntry[];
+  formats?: unknown;
   collectionCount?: number;
   rowCount?: number;
   relationshipCount?: number;
@@ -30,27 +35,27 @@ export async function verifyExportBundle(bundleDir: string): Promise<ExportBundl
   const manifest = await readManifest(path.join(root, 'manifest.json'), errors);
   if (!manifest) return result(root, errors, 0);
 
-  const expected = Array.isArray(manifest.files) ? manifest.files : [];
-  if (!Array.isArray(manifest.files)) errors.push('manifest.files must be an array');
+  const expected = manifestFiles(manifest, errors);
+  const expectedPaths = new Set(expected.map((entry) => entry.path));
   const actual = await inventory(root, errors);
   const actualByPath = new Map(actual.map((entry) => [entry.path, entry]));
-  const expectedPaths = new Set(expected.map((entry) => entry.path));
-
   for (const entry of expected) verifyEntry(entry, actualByPath.get(entry.path), errors);
-  for (const entry of actual) {
-    if (!expectedPaths.has(entry.path)) errors.push(`unexpected file not listed in manifest: ${entry.path}`);
-  }
-  for (const file of requiredFiles(manifest)) {
-    if (!expectedPaths.has(file)) errors.push(`required file missing from manifest: ${file}`);
-  }
+  for (const entry of actual) if (!expectedPaths.has(entry.path)) errors.push(`unexpected file not listed in manifest: ${entry.path}`);
+
+  const formats = readFormats(manifest, errors);
+  const collectionCount = await verifyCollections(root, manifest, formats, expectedPaths, errors);
+  const documentCount = await verifyDocuments(root, manifest, expectedPaths, errors);
+  const relationshipFileCount = verifyRelationships(formats, expectedPaths, errors);
 
   return {
     ...result(root, errors, expected.length),
     exportedAt: manifest.exportedAt,
-    collectionCount: manifest.collectionCount,
+    collectionCount,
     rowCount: manifest.rowCount,
     relationshipCount: manifest.relationshipCount,
-    documentCount: manifest.documentCount,
+    documentCount,
+    relationshipFileCount,
+    bytes: expected.reduce((total, entry) => total + entry.bytes, 0),
   };
 }
 
@@ -68,6 +73,15 @@ async function readManifest(file: string, errors: string[]): Promise<Manifest | 
   }
 }
 
+function manifestFiles(manifest: Manifest, errors: string[]): ExportFileInventoryEntry[] {
+  if (!Array.isArray(manifest.files)) { errors.push('manifest.files must be an array'); return []; }
+  return manifest.files.filter((entry, index) => {
+    const ok = entry && typeof entry.path === 'string' && typeof entry.bytes === 'number' && typeof entry.sha256 === 'string';
+    if (!ok) errors.push(`manifest.files[${index}] must include path, bytes, and sha256`);
+    return ok;
+  });
+}
+
 async function inventory(root: string, errors: string[]): Promise<ExportFileInventoryEntry[]> {
   try {
     return await exportFileInventory(root, { exclude: ['manifest.json'] });
@@ -78,26 +92,95 @@ async function inventory(root: string, errors: string[]): Promise<ExportFileInve
 }
 
 function verifyEntry(expected: ExportFileInventoryEntry, actual: ExportFileInventoryEntry | undefined, errors: string[]): void {
-  if (!actual) {
-    errors.push(`missing file: ${expected.path}`);
-    return;
-  }
-  if (actual.bytes !== expected.bytes) {
-    errors.push(`byte mismatch for ${expected.path}: expected ${expected.bytes}, got ${actual.bytes}`);
-  }
+  if (!actual) { errors.push(`missing file: ${expected.path}`); return; }
+  if (actual.bytes !== expected.bytes) errors.push(`byte mismatch for ${expected.path}: expected ${expected.bytes}, got ${actual.bytes}`);
   if (actual.sha256 !== expected.sha256) errors.push(`sha256 mismatch for ${expected.path}`);
 }
 
-function requiredFiles(manifest: Manifest): string[] {
-  const formats = ['json', 'csv', 'md'];
-  return [
-    'README.md',
-    'all-collections.json',
-    'manifest.schema.json',
-    'documents/index.json',
-    'documents/documents.csv',
-    ...formats.map((format) => `relationships.${format}`),
-  ].filter((file) => manifest.documentCount !== 0 || !file.startsWith('documents/'));
+function readFormats(manifest: Manifest, errors: string[]): string[] {
+  if (!Array.isArray(manifest.formats) || manifest.formats.some((format) => typeof format !== 'string')) {
+    errors.push('manifest.formats must be a string array');
+    return ['json', 'csv', 'markdown'];
+  }
+  return manifest.formats;
+}
+
+async function verifyCollections(
+  root: string,
+  manifest: Manifest,
+  formats: string[],
+  expectedPaths: Set<string>,
+  errors: string[],
+): Promise<number | undefined> {
+  const all = await readObject(path.join(root, 'all-collections.json'), 'all-collections.json', errors);
+  const collections = record(all?.collections, 'all-collections.collections', errors);
+  if (!collections) return manifest.collectionCount;
+  const names = Object.keys(collections);
+  if (manifest.collectionCount !== undefined && manifest.collectionCount !== names.length) {
+    errors.push(`manifest collectionCount ${manifest.collectionCount} does not match ${names.length}`);
+  }
+  for (const name of names) {
+    for (const format of formats) expectManifestPath(expectedPaths, `collections/${safeName(name)}.${extension(format)}`, errors);
+  }
+  return names.length;
+}
+
+async function verifyDocuments(
+  root: string,
+  manifest: Manifest,
+  expectedPaths: Set<string>,
+  errors: string[],
+): Promise<number | undefined> {
+  if ((manifest.documentCount ?? 0) === 0 && !expectedPaths.has('documents/index.json')) return manifest.documentCount;
+  const index = await readObject(path.join(root, 'documents/index.json'), 'documents/index.json', errors);
+  const docs = Array.isArray(index?.documents) ? index.documents : [];
+  expectManifestPath(expectedPaths, 'documents/documents.csv', errors);
+  for (const item of docs) {
+    const doc = record(item, 'document index entry', errors);
+    if (!doc) continue;
+    for (const key of ['markdown', 'json']) {
+      if (typeof doc[key] !== 'string') errors.push(`document index entry missing ${key}`);
+      else expectManifestPath(expectedPaths, doc[key], errors);
+    }
+  }
+  if (manifest.documentCount !== undefined && manifest.documentCount !== docs.length) {
+    errors.push(`manifest documentCount ${manifest.documentCount} does not match ${docs.length}`);
+  }
+  return docs.length;
+}
+
+function verifyRelationships(formats: string[], expectedPaths: Set<string>, errors: string[]): number {
+  for (const format of formats) expectManifestPath(expectedPaths, `relationships.${extension(format)}`, errors);
+  return formats.length;
+}
+
+async function readObject(file: string, label: string, errors: string[]): Promise<JsonRecord | null> {
+  try {
+    return record(JSON.parse(await readFile(file, 'utf8')), label, errors);
+  } catch (cause) {
+    errors.push(`cannot read ${label}: ${cause instanceof Error ? cause.message : String(cause)}`);
+    return null;
+  }
+}
+
+function record(value: unknown, label: string, errors: string[]): JsonRecord | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    errors.push(`${label} must be an object`);
+    return null;
+  }
+  return value as JsonRecord;
+}
+
+function expectManifestPath(expectedPaths: Set<string>, file: string, errors: string[]): void {
+  if (!expectedPaths.has(file)) errors.push(`required file missing from manifest: ${file}`);
+}
+
+function extension(format: string): string {
+  return format === 'markdown' ? 'md' : format;
+}
+
+function safeName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, '_').replace(/^_+|_+$/g, '') || 'row';
 }
 
 function result(root: string, errors: string[], checkedFiles: number): ExportBundleVerification {

--- a/tools/export-app/verify.ts
+++ b/tools/export-app/verify.ts
@@ -2,17 +2,28 @@ import { createHash } from 'node:crypto';
 import { readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
 
-type ManifestFile = {
-  path: string;
-  bytes: number;
-  sha256: string;
-};
+import { exportFileInventory, type ExportFileInventoryEntry } from './inventory.ts';
+
+type JsonRecord = Record<string, unknown>;
 
 export interface ExportBundleVerification {
   ok: boolean;
   bundleDir: string;
   fileCount: number;
+  checkedFiles: number;
+  bytes: number;
+  collectionCount: number;
+  documentCount: number;
+  relationshipFileCount: number;
   errors: string[];
+}
+
+interface VerifyState { checkedFiles: number }
+interface ExportManifest {
+  collectionCount?: number;
+  documentCount?: number;
+  formats?: unknown;
+  files?: ExportFileInventoryEntry[];
 }
 
 function containedPath(baseDir: string, relativePath: string): string | null {
@@ -25,49 +36,149 @@ async function sha256(filePath: string): Promise<string> {
   return createHash('sha256').update(await readFile(filePath)).digest('hex');
 }
 
-function manifestFiles(value: unknown): ManifestFile[] {
-  if (!value || typeof value !== 'object' || !Array.isArray((value as { files?: unknown }).files)) {
-    throw new Error('manifest.json missing files inventory');
+async function readJson(root: string, relativePath: string, errors: string[], state: VerifyState): Promise<unknown> {
+  const target = containedPath(root, relativePath);
+  if (!target) { errors.push(`${relativePath}: escapes export bundle`); return null; }
+  try {
+    state.checkedFiles += 1;
+    return JSON.parse(await readFile(target, 'utf8'));
+  } catch (error) {
+    errors.push(`${relativePath}: ${error instanceof Error ? error.message : String(error)}`);
+    return null;
   }
-  return (value as { files: ManifestFile[] }).files;
+}
+
+async function requireFile(root: string, relativePath: string, errors: string[], state: VerifyState): Promise<void> {
+  const target = containedPath(root, relativePath);
+  if (!target) { errors.push(`${relativePath}: escapes export bundle`); return; }
+  try {
+    const info = await stat(target);
+    state.checkedFiles += 1;
+    if (!info.isFile()) errors.push(`${relativePath}: not a file`);
+  } catch (error) {
+    errors.push(`${relativePath}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function record(value: unknown, label: string, errors: string[]): JsonRecord | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    errors.push(`${label} must be an object`);
+    return null;
+  }
+  return value as JsonRecord;
+}
+
+function stringArray(value: unknown, label: string, errors: string[]): string[] {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    errors.push(`${label} must be a string array`);
+    return [];
+  }
+  return value;
+}
+
+function ext(format: string): string {
+  return format === 'markdown' ? 'md' : format;
+}
+
+function safeName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, '_').replace(/^_+|_+$/g, '') || 'row';
+}
+
+function manifestFiles(manifest: ExportManifest, errors: string[]): ExportFileInventoryEntry[] {
+  if (!Array.isArray(manifest.files)) { errors.push('manifest.json missing files inventory'); return []; }
+  return manifest.files.filter((file, index) => {
+    const valid = file && typeof file.path === 'string' && typeof file.bytes === 'number' && typeof file.sha256 === 'string';
+    if (!valid) errors.push(`files[${index}]: invalid inventory entry`);
+    return valid;
+  });
+}
+
+async function verifyInventory(root: string, files: ExportFileInventoryEntry[], errors: string[], state: VerifyState): Promise<number> {
+  const expected = new Map(files.map((file) => [file.path, file]));
+  for (const file of files) {
+    const target = containedPath(root, file.path);
+    if (!target) { errors.push(`${file.path}: escapes export bundle`); continue; }
+    try {
+      const [info, digest] = await Promise.all([stat(target), sha256(target)]);
+      state.checkedFiles += 1;
+      if (!info.isFile()) errors.push(`${file.path}: not a file`);
+      if (info.size !== file.bytes) errors.push(`${file.path}: size mismatch ${info.size} !== ${file.bytes}`);
+      if (digest !== file.sha256) errors.push(`${file.path}: checksum mismatch ${digest} !== ${file.sha256}`);
+    } catch (error) {
+      errors.push(`${file.path}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  for (const file of await exportFileInventory(root, { exclude: ['manifest.json'] })) {
+    if (!expected.has(file.path)) errors.push(`${file.path}: unexpected file`);
+  }
+  return files.reduce((total, file) => total + file.bytes, 0);
+}
+
+async function verifyCollections(root: string, collections: JsonRecord, formats: string[], errors: string[], state: VerifyState): Promise<void> {
+  for (const name of Object.keys(collections)) {
+    for (const format of formats) await requireFile(root, `collections/${safeName(name)}.${ext(format)}`, errors, state);
+  }
+}
+
+async function verifyRelationships(root: string, formats: string[], errors: string[], state: VerifyState): Promise<number> {
+  for (const format of formats) await requireFile(root, `relationships.${ext(format)}`, errors, state);
+  return formats.length;
+}
+
+async function verifyDocuments(root: string, errors: string[], state: VerifyState): Promise<number> {
+  const rawIndex = await readJson(root, 'documents/index.json', errors, state);
+  const index = record(rawIndex, 'documents/index.json', errors);
+  if (!index) return 0;
+  const docs = Array.isArray(index.documents) ? index.documents : [];
+  await requireFile(root, 'documents/documents.csv', errors, state);
+  for (const item of docs) {
+    const doc = record(item, 'document index entry', errors);
+    if (!doc) continue;
+    for (const key of ['markdown', 'json']) {
+      if (typeof doc[key] !== 'string') errors.push(`document index entry missing ${key}`);
+      else await requireFile(root, doc[key], errors, state);
+    }
+  }
+  return docs.length;
 }
 
 export async function verifyExportBundle(bundleDir: string): Promise<ExportBundleVerification> {
   const root = path.resolve(bundleDir);
   const errors: string[] = [];
-  let files: ManifestFile[] = [];
+  const state = { checkedFiles: 0 };
+  const manifest = record(await readJson(root, 'manifest.json', errors, state), 'manifest', errors) as ExportManifest | null;
+  if (!manifest) return emptyResult(root, errors, state);
 
-  try {
-    files = manifestFiles(JSON.parse(await readFile(path.join(root, 'manifest.json'), 'utf8')));
-  } catch (error) {
-    return {
-      ok: false,
-      bundleDir: root,
-      fileCount: 0,
-      errors: [error instanceof Error ? error.message : String(error)],
-    };
+  const files = manifestFiles(manifest, errors);
+  const formats = stringArray(manifest.formats, 'manifest.formats', errors);
+  const all = record(await readJson(root, 'all-collections.json', errors, state), 'all-collections', errors);
+  const collections = all ? record(all.collections, 'all-collections.collections', errors) : null;
+  const collectionNames = collections ? Object.keys(collections) : [];
+
+  if (manifest.collectionCount !== undefined && manifest.collectionCount !== collectionNames.length) {
+    errors.push(`manifest collectionCount ${manifest.collectionCount} does not match ${collectionNames.length}`);
   }
 
-  for (let index = 0; index < files.length; index += 1) {
-    const file = files[index]!;
-    if (!file || typeof file.path !== 'string' || typeof file.bytes !== 'number' || typeof file.sha256 !== 'string') {
-      errors.push(`files[${index}]: invalid inventory entry`);
-      continue;
-    }
-    const target = containedPath(root, file.path);
-    if (!target) {
-      errors.push(`${file.path}: escapes export bundle`);
-      continue;
-    }
-    try {
-      const [info, digest] = await Promise.all([stat(target), sha256(target)]);
-      if (!info.isFile()) errors.push(`${file.path}: not a file`);
-      if (info.size !== file.bytes) errors.push(`${file.path}: bytes ${info.size} !== ${file.bytes}`);
-      if (digest !== file.sha256) errors.push(`${file.path}: sha256 ${digest} !== ${file.sha256}`);
-    } catch (error) {
-      errors.push(`${file.path}: ${error instanceof Error ? error.message : String(error)}`);
-    }
+  if (collections) await verifyCollections(root, collections, formats, errors, state);
+  const relationshipFileCount = await verifyRelationships(root, formats, errors, state);
+  const documentCount = await verifyDocuments(root, errors, state);
+  if (manifest.documentCount !== undefined && manifest.documentCount !== documentCount) {
+    errors.push(`manifest documentCount ${manifest.documentCount} does not match ${documentCount}`);
   }
+  const bytes = await verifyInventory(root, files, errors, state);
+  return {
+    ok: errors.length === 0,
+    bundleDir: root,
+    fileCount: files.length,
+    checkedFiles: state.checkedFiles,
+    bytes,
+    collectionCount: collectionNames.length,
+    documentCount,
+    relationshipFileCount,
+    errors,
+  };
+}
 
-  return { ok: errors.length === 0, bundleDir: root, fileCount: files.length, errors };
+function emptyResult(root: string, errors: string[], state: VerifyState): ExportBundleVerification {
+  return { ok: false, bundleDir: root, fileCount: 0, checkedFiles: state.checkedFiles, bytes: 0, collectionCount: 0, documentCount: 0, relationshipFileCount: 0, errors };
 }

--- a/tools/maw-plugin-arra/commands/vector-config.ts
+++ b/tools/maw-plugin-arra/commands/vector-config.ts
@@ -4,10 +4,12 @@ const usage = [
   'usage: maw arra vector-config list|get [collection]',
   '       maw arra vector-config set <collection> <field> <value>',
   '       maw arra vector-config add <collection> --model <model> [--adapter <adapter>]',
+  '       maw arra vector-config switch <lancedb|qdrant|chroma|sqlite-vec> [--enabled true|false]',
   '       maw arra vector-config remove|set-primary|test <collection>',
   '       maw arra vector-config reload',
 ].join('\n');
 const adapters = new Set(['chroma', 'sqlite-vec', 'lancedb', 'qdrant', 'cloudflare-vectorize', 'proxy', 'turbovec']);
+const switchableAdapters = new Set(['chroma', 'sqlite-vec', 'lancedb', 'qdrant']);
 const updateFields = new Set(['adapter', 'model', 'provider', 'service', 'endpoint', 'enabled', 'primary', 'embedder']);
 const createFields = new Set([...updateFields, 'collection']);
 
@@ -93,6 +95,15 @@ async function writeCollection(collection: string, body: JsonObject): Promise<Js
   return text ? JSON.parse(text) as JsonObject : {};
 }
 
+async function patchConfig(body: JsonObject): Promise<JsonObject> {
+  const text = await requestText('/api/v1/vector/config', {
+    method: 'PATCH',
+    headers: { accept: 'application/json', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return text ? JSON.parse(text) as JsonObject : {};
+}
+
 async function createCollection(collection: string, body: JsonObject): Promise<JsonObject> {
   const text = await requestText(`/api/v1/vector/config/${encodeURIComponent(collection)}`, {
     method: 'POST',
@@ -121,6 +132,22 @@ function requiredCollection(parsed: ParsedArgs): string {
   return collection;
 }
 
+async function switchBackend(parsed: ParsedArgs): Promise<JsonObject> {
+  const adapter = parseValue('adapter', requiredCollection(parsed));
+  if (typeof adapter !== 'string' || !switchableAdapters.has(adapter)) {
+    throw new Error('switch adapter must be lancedb, qdrant, chroma, or sqlite-vec');
+  }
+  const enabledRaw = flag(parsed, 'enabled');
+  const enabled = enabledRaw === undefined ? undefined : bool(enabledRaw);
+  const payload = await readConfig();
+  const collections = Object.fromEntries(Object.entries(configCollections(payload)).map(([key, value]) => [
+    key,
+    { ...object(value), adapter, ...(enabled !== undefined && { enabled }) },
+  ]));
+  if (Object.keys(collections).length === 0) throw new Error('no vector collections configured');
+  return patchConfig({ collections });
+}
+
 export async function runVectorConfigCommand(args: string[]): Promise<string> {
   const parsed = parseArgs(args);
   const action = (parsed.positionals[0] ?? 'list').toLowerCase().replace(/-/g, '_');
@@ -133,6 +160,7 @@ export async function runVectorConfigCommand(args: string[]): Promise<string> {
   if (action === 'set') {
     return json(await writeCollection(requiredCollection(parsed), updateBody(parsed)));
   }
+  if (action === 'switch' || action === 'backend') return json(await switchBackend(parsed));
   if (action === 'add') {
     const collection = requiredCollection(parsed);
     const body = flagUpdates(parsed, createFields);
@@ -152,4 +180,4 @@ export async function runVectorConfigCommand(args: string[]): Promise<string> {
   throw new Error(usage);
 }
 
-export const VECTOR_CONFIG_HELP = 'vector-config list|get|set|add|remove|set-primary|reload|test';
+export const VECTOR_CONFIG_HELP = 'vector-config list|get|set|switch|add|remove|set-primary|reload|test';

--- a/ψ/memory/hermes-agent-desktop-design-c5.md
+++ b/ψ/memory/hermes-agent-desktop-design-c5.md
@@ -1,0 +1,232 @@
+# Hermes Agent Desktop Design Reference for ARRA Oracle
+
+Issue: #1598
+Date: 2026-06-17
+Scope: architecture review and design guidance only; no implementation.
+
+## Decision Summary
+
+Use Hermes as a reference for **desktop host responsibilities**, not as a stack
+template. ARRA should keep its current Tauri + Bun/Elysia direction and avoid an
+Electron rewrite unless a later product requirement needs bundled Chromium or
+heavy PTY/xterm integration.
+
+Target architecture:
+
+```text
+[Tauri desktop host]
+  owns: native window/tray/menu, backend process lifecycle, secure storage,
+        file dialogs, logs, diagnostics, updates, narrow IPC
+
+[Bun/Elysia backend]
+  owns: HTTP API, MCP server/client state, vector config, search/indexing,
+        plugins, auth, database, ORACLE_DATA_DIR
+
+[React Studio renderer]
+  owns: UI state only; calls Elysia APIs and narrow Tauri commands
+```
+
+## Evidence Reviewed
+
+### Official / upstream Hermes sources
+
+- Desktop docs: https://hermes-agent.nousresearch.com/docs/user-guide/desktop
+  - Desktop shares config, API keys, sessions, skills, and memory with CLI/TUI.
+  - Packaged app ships an Electron shell; first launch installs the runtime into
+    `HERMES_HOME`; renderer talks to `hermes dashboard` backend APIs.
+  - Desktop can either manage a local backend or attach to a remote dashboard.
+- Architecture docs:
+  https://hermes-agent.nousresearch.com/docs/developer-guide/architecture
+  - Hermes is a multi-surface runtime: CLI, gateway, cron, tools, MCP, plugins,
+    sessions, and desktop all reuse the same agent core.
+- MCP guide: https://hermes-agent.nousresearch.com/docs/guides/use-mcp-with-hermes
+  - Hermes recommends allowlisting tools for sensitive systems and supports
+    per-server include/exclude plus resources/prompts toggles.
+- Upstream source checked via GitHub API on 2026-06-17:
+  - `apps/desktop/package.json`: Electron + React/Vite + electron-builder.
+  - `apps/desktop/electron/main.cjs`: backend supervision, safe storage, IPC,
+    update/bootstrap plumbing.
+  - `apps/desktop/electron/hardening.cjs`: sensitive-file blocking, path checks,
+    fetch/read limits, secure token storage.
+  - `apps/bootstrap-installer/src-tauri/tauri.conf.json`: Tauri is a bootstrap
+    installer, not the daily-driver Hermes desktop shell.
+
+### Official Tauri sources
+
+- Tauri security overview: https://v2.tauri.app/security/
+  - Tauri explicitly frames Rust core and WebView frontend as separate trust
+    zones bridged by IPC, so command payload validation matters.
+- Tauri CSP docs: https://v2.tauri.app/security/csp/
+  - CSP should be as restrictive as possible and avoid remote script loading.
+- Tauri permissions docs: https://v2.tauri.app/security/permissions/
+  - Frontend command access should be granted by explicit permissions and scopes.
+
+### Local ARRA facts checked
+
+- `frontend/src-tauri/src/lib.rs` already starts `bun run server`, exposes
+  `start_backend`, `stop_backend`, `health_check`, `get_backend_url`, tray/menu
+  status, and a fixed `http://localhost:47778` backend URL. It is 244 lines and
+  should be split before adding behavior.
+- `frontend/src-tauri/tauri.conf.json` builds the Vite frontend and permits
+  localhost HTTP/WebSocket connections in CSP.
+- `frontend/src/components/BackendGate.tsx` already gates React UI on browser vs
+  Tauri backend health checks.
+- `src/server.ts` is the existing Elysia composition root; keep product logic
+  there, not in desktop IPC.
+- `src/mcp/client.ts` is currently a one-shot MCP client. Desktop should not own
+  MCP state; it should surface backend-owned MCP registry/status APIs.
+- `src/plugins/unified-manifest.ts` is near the file-size limit but provides the
+  right declarative plugin source of truth.
+
+## Recommended ARRA Desktop Architecture
+
+### 1. Keep Tauri as the host shell
+
+Hermes uses Electron because it wraps a Python runtime and benefits from a
+Chromium/Node desktop ecosystem. ARRA already has Bun/TypeScript, a React/Vite
+frontend, and a Tauri scaffold. Tauri keeps the install surface smaller and maps
+well to a launcher/supervisor role.
+
+Use Electron only if ARRA later needs:
+
+- guaranteed bundled Chromium behavior across all platforms;
+- deep PTY/xterm panes similar to Hermes dashboard chat;
+- Electron-only integrations that materially exceed Tauri plugins.
+
+### 2. Split the Rust supervisor before adding features
+
+Proposed module shape:
+
+```text
+frontend/src-tauri/src/
+  lib.rs        // builder wiring only
+  backend.rs    // spawn, stop, readiness, PID/state
+  health.rs     // Rust HTTP/TCP probes; no external curl
+  tray.rs       // status icon and menu events
+  commands.rs   // command registration and typed responses
+  paths.rs      // ORACLE_DATA_DIR/profile resolution
+  logs.rs       // bounded desktop/backend log capture
+  security.rs   // path containment and sensitive-file checks
+```
+
+This follows repo conventions, keeps files under 250 lines, and avoids copying
+Hermes' large Electron `main.cjs` shape.
+
+### 3. Replace fixed port with readiness handshake
+
+Current Tauri code assumes `localhost:47778`. Desktop should support dynamic
+ports to avoid collisions with a separately running Oracle backend.
+
+Recommended contract:
+
+```text
+Tauri starts: bun run server -- --host 127.0.0.1 --port 0 --desktop
+Backend emits: ORACLE_READY {"port":12345,"token":"...","dataDir":"..."}
+Tauri stores: backendUrl=http://127.0.0.1:12345, desktopToken=...
+Renderer calls: get_backend_url(), then uses backend APIs with token header
+```
+
+If port `0` is not supported by the current server path, add it first behind a
+small startup contract rather than hardcoding another desktop-only path.
+
+### 4. Add a per-launch desktop token
+
+Localhost is not a sufficient authorization boundary for a desktop-owned backend.
+The desktop host should mint or receive a short-lived token and inject it into
+renderer requests:
+
+```http
+Authorization: Bearer <desktop-session-token>
+X-Oracle-Desktop: 1
+```
+
+Keep this separate from user API keys and remote auth. It is a local
+process-bound capability for the renderer to call the supervised backend.
+
+### 5. Keep MCP, vector, and plugin config backend-owned
+
+Hermes' strongest MCP lesson is policy-controlled registration: allowlists,
+excludes, resource/prompt toggles, reloads, and capability-aware tool exposure.
+For ARRA:
+
+- persist MCP server registry under `ORACLE_DATA_DIR`;
+- support stdio and remote HTTP/SSE transports in backend code;
+- expose per-server status, logs, include/exclude policy, and reload endpoints;
+- attach MCP-provided tools to `UnifiedPluginManifest` provenance where possible;
+- never store MCP/plugin/vector settings in renderer localStorage.
+
+### 6. Harden desktop IPC like a privilege boundary
+
+Copy Hermes' security posture, not its Electron code:
+
+- one Tauri command per capability;
+- no broad shell passthrough;
+- path normalization and containment checks;
+- deny reads/previews for `.env`, SSH/GPG/AWS credentials, key/cert stores;
+- file-size and timeout limits;
+- structured error codes for UI display;
+- explicit Tauri permissions/scopes and narrow CSP.
+
+### 7. Add diagnostics as a product feature
+
+Desktop should make local-first operations debuggable:
+
+```text
+ORACLE_DATA_DIR/logs/desktop.log
+ORACLE_DATA_DIR/logs/backend.log
+health snapshot
+vector config summary
+plugin manifest summary
+MCP registry status
+recent startup/update errors
+redacted env/config summary
+```
+
+Expose this as a “Copy diagnostics” / “Export support bundle” action in Studio
+and the Tauri menu.
+
+## P0 Build Sequence
+
+1. Split `frontend/src-tauri/src/lib.rs` into supervisor modules.
+2. Replace `curl` health checks with Rust HTTP/TCP checks and typed JSON return.
+3. Add `--host`, `--port`, and `--json-ready` server startup support if missing.
+4. Add per-launch desktop token middleware for desktop mode.
+5. Extend `BackendGate.tsx` to render structured states: starting, port occupied,
+   token rejected, DB migration failed, vector degraded, plugin degraded.
+
+## P1 Product Sequence
+
+1. Backend-owned MCP registry with include/exclude policy and server logs.
+2. Plugin provenance and per-surface enable/disable in the unified manifest UI.
+3. Native dialogs for import/export paths while backend owns the actual export.
+4. Desktop diagnostics bundle and log viewer.
+5. OS notifications for indexing completion, plugin failures, and backup/export.
+
+## Non-goals
+
+- Do not implement desktop features in this research task.
+- Do not switch ARRA to Electron based only on Hermes' choice.
+- Do not fork product logic into Tauri commands.
+- Do not make desktop packaging block server, MCP, export, or vector work.
+- Do not weaken CSP or expose filesystem APIs broadly for convenience.
+
+## Open Decisions
+
+1. Should the bundled desktop include Bun, or require system Bun for developer
+   builds only and bundled sidecar for releases?
+2. Should Studio load from bundled Tauri assets, from Elysia static output, or a
+   hybrid depending on dev vs release mode?
+3. How should `ORACLE_DATA_DIR`, tenant, and profile context map to desktop
+   windows and remote backends?
+4. Should desktop token auth be middleware-only or integrated into existing API
+   key scopes?
+5. Which release channel maps to project policy: alpha prerelease, stable, or a
+   separate desktop canary channel?
+
+## Final Recommendation
+
+Ship ARRA Desktop as a **thin Tauri supervisor over the existing Bun/Elysia
+Oracle runtime**. Use Hermes to validate the host boundary: startup, health,
+secure storage, MCP/tool policy, logs, diagnostics, and updates. Keep ARRA's
+backend as the only product brain and keep React Studio usable in browser/PWA
+mode so desktop remains an enhanced local shell, not a separate application.


### PR DESCRIPTION
## Summary
- Fix CI-scoped test isolation by repointing cached DB state for temp DB tests
- Keep vector proxy tests hermetic with fresh-process env setup
- Extend export bundle verification to validate manifest inventory, checksums, collections, relationships, and document artifacts

## Failing #1904 CI
- First failing test from latest failed run: `append reindex mode > upserts from a new repo root without deleting older indexed docs`
- Error: expected source files `ψ/memory/learnings/a.md` and `ψ/memory/learnings/b.md`, received `[]`
- Cascading failures came from stale/closed module-level DB/env state in the scoped Bun test process.

## Verification
- `bunx tsc --noEmit`
- `bun test --isolate tests/tools/export-app/verify.test.ts tests/tools/export-app/export-app.test.ts tests/tools/export-app/manifest-schema.test.ts tests/tools/export-app.test.ts` (19 pass)
- `bun test --isolate src/tools/__tests__/ src/server/__tests__/ tests/storage/ tests/http/swagger/ tests/http/health/ tests/lifecycle/ tests/plugins/ src/vault/__tests__/ src/indexer/__tests__/ src/drizzle-migration.test.ts src/indexer-preservation.test.ts` (409 pass)
- File-size gate: all changed files ≤250 lines
