### PR TITLE
fix: scope search routes by tenant

### DIFF
--- a/src/routes/search/list.ts
+++ b/src/routes/search/list.ts
@@ -5,6 +5,7 @@
 import { Elysia } from 'elysia';
 import { handleList } from '../../server/handlers.ts';
 import { ListQuery } from './model.ts';
+import { handleTenantList } from './tenant-search.ts';
 
 export const listEndpoint = new Elysia().get(
   '/list',
@@ -13,7 +14,7 @@ export const listEndpoint = new Elysia().get(
     const limit = Math.min(1000, Math.max(1, parseInt(query.limit ?? '10')));
     const offset = Math.max(0, parseInt(query.offset ?? '0'));
     const group = query.group !== 'false';
-    return handleList(type, limit, offset, group);
+    return handleTenantList(type, limit, offset, group) ?? handleList(type, limit, offset, group);
   },
   {
     query: ListQuery,

--- a/src/routes/search/reflect.ts
+++ b/src/routes/search/reflect.ts
@@ -4,8 +4,9 @@
 
 import { Elysia } from 'elysia';
 import { handleReflect } from '../../server/handlers.ts';
+import { handleTenantReflect } from './tenant-search.ts';
 
-export const reflectEndpoint = new Elysia().get('/reflect', () => handleReflect(), {
+export const reflectEndpoint = new Elysia().get('/reflect', () => handleTenantReflect() ?? handleReflect(), {
   detail: {
     tags: ['search'],
     menu: { group: 'main', path: '/playground', order: 30 },

--- a/src/routes/search/tenant-search.ts
+++ b/src/routes/search/tenant-search.ts
@@ -2,24 +2,30 @@ import { sqlite } from '../../db/index.ts';
 import { currentTenantId } from '../../middleware/tenant.ts';
 import type { SearchResponse } from '../../server/types.ts';
 
+type SearchRouteResponse = SearchResponse & { mode: string; warning?: string; vectorAvailable: boolean };
+type ListRow = Record<string, any>;
+
 function normalizeRank(rank: number): number {
   return Math.min(1, Math.max(0, 1 / (1 + Math.abs(rank))));
 }
 
-export function handleTenantSearch(
-  query: string,
-  type = 'all',
-  limit = 10,
-  offset = 0,
-): SearchResponse & { mode: string; warning?: string; vectorAvailable: boolean } | null {
-  const tenantId = currentTenantId();
-  if (!tenantId) return null;
+function parseConcepts(value: string | null | undefined): string[] {
+  try { return JSON.parse(value || '[]') as string[]; } catch { return []; }
+}
 
-  const safeQuery = query
+function sanitizeFtsQuery(query: string): string {
+  return query
     .replace(/<[^>]*>/g, ' ')
     .replace(/[?*+\-()^~"':;<>{}[\]\\/]/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
+}
+
+export function handleTenantSearch(query: string, type = 'all', limit = 10, offset = 0): SearchRouteResponse | null {
+  const tenantId = currentTenantId();
+  if (!tenantId) return null;
+
+  const safeQuery = sanitizeFtsQuery(query);
   if (!safeQuery) return { results: [], total: 0, limit, offset, query, mode: 'fts', vectorAvailable: false };
 
   const typeClause = type === 'all' ? '' : 'AND d.type = ?';
@@ -37,7 +43,7 @@ export function handleTenantSearch(
     WHERE oracle_fts MATCH ? ${typeClause} AND d.tenant_id = ?
     ORDER BY rank
     LIMIT ? OFFSET ?
-  `).all(...params, limit, offset) as Array<Record<string, any>>;
+  `).all(...params, limit, offset) as ListRow[];
 
   return {
     results: rows.map((row) => ({
@@ -45,7 +51,7 @@ export function handleTenantSearch(
       type: row.type,
       content: row.content,
       source_file: row.source_file,
-      concepts: JSON.parse(row.concepts || '[]'),
+      concepts: parseConcepts(row.concepts),
       project: row.project,
       source: 'fts' as const,
       score: normalizeRank(row.score),
@@ -57,5 +63,69 @@ export function handleTenantSearch(
     mode: 'fts',
     vectorAvailable: false,
     warning: 'Tenant-scoped HTTP search uses SQLite/FTS isolation for this request',
+  };
+}
+
+export function handleTenantList(type = 'all', limit = 10, offset = 0, groupByFile = true): SearchResponse | null {
+  const tenantId = currentTenantId();
+  if (!tenantId) return null;
+
+  const typeClause = type === 'all' ? '' : 'AND d.type = ?';
+  const params = type === 'all' ? [tenantId] : [type, tenantId];
+  const countExpr = groupByFile ? 'count(distinct d.source_file)' : 'count(*)';
+  const count = sqlite.prepare(`
+    SELECT ${countExpr} as total
+    FROM oracle_documents d
+    WHERE 1=1 ${typeClause} AND d.tenant_id = ?
+  `).get(...params) as { total: number };
+
+  const indexedAt = groupByFile ? 'MAX(d.indexed_at)' : 'd.indexed_at';
+  const groupSql = groupByFile ? 'GROUP BY d.source_file' : '';
+  const rows = sqlite.prepare(`
+    SELECT d.id, d.type, d.source_file, d.concepts, d.project, ${indexedAt} as indexed_at, f.content
+    FROM oracle_documents d
+    JOIN oracle_fts f ON d.id = f.id
+    WHERE 1=1 ${typeClause} AND d.tenant_id = ?
+    ${groupSql}
+    ORDER BY indexed_at DESC
+    LIMIT ? OFFSET ?
+  `).all(...params, limit, offset) as ListRow[];
+
+  return {
+    results: rows.map((row) => ({
+      id: row.id,
+      type: row.type,
+      content: row.content || '',
+      source_file: row.source_file,
+      concepts: parseConcepts(row.concepts),
+      project: row.project,
+      indexed_at: row.indexed_at,
+    })),
+    total: count.total,
+    offset,
+    limit,
+  };
+}
+
+export function handleTenantReflect(): Record<string, unknown> | null {
+  const tenantId = currentTenantId();
+  if (!tenantId) return null;
+
+  const row = sqlite.prepare(`
+    SELECT d.id, d.type, d.source_file, d.concepts, f.content
+    FROM oracle_documents d
+    JOIN oracle_fts f ON d.id = f.id
+    WHERE d.tenant_id = ? AND d.type IN ('principle', 'learning')
+    ORDER BY RANDOM()
+    LIMIT 1
+  `).get(tenantId) as ListRow | undefined;
+
+  if (!row) return { error: 'No documents found' };
+  return {
+    id: row.id,
+    type: row.type,
+    content: row.content,
+    source_file: row.source_file,
+    concepts: parseConcepts(row.concepts),
   };
 }

--- a/tests/http/search/tenant-routes.test.ts
+++ b/tests/http/search/tenant-routes.test.ts
@@ -1,0 +1,84 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { beforeAll, describe, expect, test } from 'bun:test';
+import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-search-http-'));
+const stamp = `${Date.now()}${Math.random().toString(16).slice(2)}`;
+const tenantA = `tenant-a-${stamp}`;
+const tenantB = `tenant-b-${stamp}`;
+const ids = { a: `search-a-${stamp}`, b: `search-b-${stamp}` };
+const sharedTerm = `sharedterm${stamp}`;
+
+let db: any;
+let sqlite: any;
+let oracleDocuments: any;
+let searchRoutes: { handle: (request: Request) => Response | Promise<Response> };
+
+beforeAll(async () => {
+  process.env.ORACLE_DATA_DIR = tempRoot;
+  process.env.ORACLE_DB_PATH = path.join(tempRoot, 'oracle.db');
+  const dbModule = await import('../../../src/db/index.ts');
+  dbModule.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+  db = dbModule.db;
+  sqlite = dbModule.sqlite;
+  oracleDocuments = dbModule.oracleDocuments;
+  ({ searchRoutes } = await import('../../../src/routes/search/index.ts'));
+  insertDoc(ids.a, tenantA, 'learning', `alpha-only ${sharedTerm}`);
+  insertDoc(ids.b, tenantB, 'principle', `beta-only ${sharedTerm}`);
+});
+
+function insertDoc(id: string, tenantId: string, type: string, content: string) {
+  const now = Date.now();
+  db.insert(oracleDocuments).values({
+    id,
+    tenantId,
+    type,
+    sourceFile: 'ψ/shared/tenant-search.md',
+    concepts: JSON.stringify([tenantId]),
+    createdAt: now,
+    updatedAt: now,
+    indexedAt: now,
+    project: tenantId,
+    createdBy: 'tenant-search-test',
+  }).run();
+  sqlite.prepare('DELETE FROM oracle_fts WHERE id = ?').run(id);
+  sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
+    .run(id, content, tenantId);
+}
+
+function request(tenantId: string, route: string) {
+  return createTenantFetch((req) => searchRoutes.handle(req))(new Request(`http://local${route}`, {
+    headers: { [TENANT_HEADER]: tenantId },
+  }));
+}
+
+describe('search routes tenant isolation', () => {
+  test('GET /api/search hides matching documents from other tenants', async () => {
+    const res = await request(tenantA, `/api/search?q=${sharedTerm}&mode=fts`);
+    const body = await res.json() as { results: Array<{ id: string }>; total: number };
+
+    expect(res.status).toBe(200);
+    expect(body.total).toBe(1);
+    expect(body.results.map((item) => item.id)).toEqual([ids.a]);
+  });
+
+  test('GET /api/list groups and counts only selected tenant documents', async () => {
+    const res = await request(tenantB, '/api/list?group=true&limit=10');
+    const body = await res.json() as { results: Array<{ id: string }>; total: number };
+
+    expect(res.status).toBe(200);
+    expect(body.total).toBe(1);
+    expect(body.results.map((item) => item.id)).toEqual([ids.b]);
+  });
+
+  test('GET /api/reflect samples only selected tenant documents', async () => {
+    const res = await request(tenantB, '/api/reflect');
+    const body = await res.json() as { id: string; content: string };
+
+    expect(res.status).toBe(200);
+    expect(body.id).toBe(ids.b);
+    expect(body.content).toContain('beta-only');
+  });
+});


### PR DESCRIPTION
## Summary
- Scope `/api/list` by the resolved tenant so grouped and ungrouped listings do not cross tenants
- Scope `/api/reflect` by the resolved tenant and avoid falling back to global documents when a tenant has no matches
- Keep legacy no-tenant behavior by falling back to existing shared handlers only when no tenant context is present
- Add scoped HTTP search tests for `/api/search`, `/api/list`, and `/api/reflect`

## Validation
- `bunx tsc --noEmit`
- `bun test tests/http/search/` (3 pass)
- `git diff --check`
- Changed files <= 250 lines

Refs #1650
