### PR TITLE
fix(auth): scope sessions by tenant

### DIFF
--- a/src/routes/auth/index.ts
+++ b/src/routes/auth/index.ts
@@ -8,6 +8,7 @@
 import { Elysia } from 'elysia';
 import { createHmac, timingSafeEqual } from 'crypto';
 import { getSetting } from '../../db/index.ts';
+import { activeTenantId, DEFAULT_TENANT_ID } from '../../middleware/tenant.ts';
 import { statusRoute } from './status.ts';
 import { loginRoute } from './login.ts';
 import { logoutRoute } from './logout.ts';
@@ -15,6 +16,7 @@ import { logoutRoute } from './logout.ts';
 const SESSION_SECRET = process.env.ORACLE_SESSION_SECRET || crypto.randomUUID();
 export const SESSION_COOKIE_NAME = 'oracle_session';
 export const SESSION_DURATION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+type SessionPayload = { exp: number; tenant: string };
 
 export function isLocalIp(ip: string): boolean {
   return ip === '127.0.0.1'
@@ -52,32 +54,58 @@ export function isLocalNetwork(server: any, request: Request): boolean {
   return isLocalIp(remoteAddress(server, request));
 }
 
-export function generateSessionToken(): string {
-  const expires = Date.now() + SESSION_DURATION_MS;
-  const signature = createHmac('sha256', SESSION_SECRET)
-    .update(String(expires))
-    .digest('hex');
-  return `${expires}:${signature}`;
+function signatureFor(value: string): string {
+  return createHmac('sha256', SESSION_SECRET).update(value).digest('hex');
 }
 
-export function verifySessionToken(token: string): boolean {
-  if (!token) return false;
+function safeCompare(left: string, right: string): boolean {
+  const leftBuf = Buffer.from(left);
+  const rightBuf = Buffer.from(right);
+  return leftBuf.length === rightBuf.length && timingSafeEqual(leftBuf, rightBuf);
+}
+
+function encodePayload(payload: SessionPayload): string {
+  return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+}
+
+function decodePayload(value: string): SessionPayload | null {
+  try {
+    const payload = JSON.parse(Buffer.from(value, 'base64url').toString('utf8'));
+    if (typeof payload?.exp !== 'number' || typeof payload?.tenant !== 'string') return null;
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+function verifyLegacySessionToken(token: string, tenantId: string): boolean {
+  if (tenantId !== DEFAULT_TENANT_ID) return false;
   const colonIdx = token.indexOf(':');
   if (colonIdx === -1) return false;
-
   const expiresStr = token.substring(0, colonIdx);
   const signature = token.substring(colonIdx + 1);
   const expires = parseInt(expiresStr, 10);
   if (isNaN(expires) || expires < Date.now()) return false;
 
-  const expectedSignature = createHmac('sha256', SESSION_SECRET)
-    .update(expiresStr)
-    .digest('hex');
+  return safeCompare(signature, signatureFor(expiresStr));
+}
 
-  const sigBuf = Buffer.from(signature);
-  const expectedBuf = Buffer.from(expectedSignature);
-  if (sigBuf.length !== expectedBuf.length) return false;
-  return timingSafeEqual(sigBuf, expectedBuf);
+export function generateSessionToken(tenantId = activeTenantId()): string {
+  const payload = encodePayload({ exp: Date.now() + SESSION_DURATION_MS, tenant: tenantId });
+  return `v2.${payload}.${signatureFor(payload)}`;
+}
+
+export function verifySessionToken(token: string, tenantId = activeTenantId()): boolean {
+  if (!token) return false;
+  if (!token.startsWith('v2.')) return verifyLegacySessionToken(token, tenantId);
+
+  const parts = token.split('.');
+  if (parts.length !== 3) return false;
+  const [, payloadPart, signature] = parts;
+  if (!payloadPart || !signature || !safeCompare(signature, signatureFor(payloadPart))) return false;
+  const payload = decodePayload(payloadPart);
+  if (!payload || payload.exp < Date.now()) return false;
+  return payload.tenant === tenantId;
 }
 
 export function isAuthenticated(
@@ -91,7 +119,7 @@ export function isAuthenticated(
   const localBypass = getSetting('auth_local_bypass') !== 'false';
   if (localBypass && isLocalNetwork(server, request)) return true;
 
-  return verifySessionToken(sessionValue || '');
+  return verifySessionToken(sessionValue || '', activeTenantId());
 }
 
 export const authRoutes = new Elysia({ prefix: '/api/auth' })

--- a/src/routes/auth/status.ts
+++ b/src/routes/auth/status.ts
@@ -1,5 +1,6 @@
 import { Elysia } from 'elysia';
 import { getSetting, isDbLockError } from '../../db/index.ts';
+import { activeTenantId } from '../../middleware/tenant.ts';
 import {
   SESSION_COOKIE_NAME,
   isAuthenticated,
@@ -14,8 +15,9 @@ export const statusRoute = new Elysia().get('/status', ({ server, request, cooki
     const localBypass = getSetting('auth_local_bypass') !== 'false';
     const isLocal = isLocalNetwork(server, request);
     const authenticated = isAuthenticated(server, request, sessionValue);
+    const tenantId = activeTenantId();
 
-    return { authenticated, authEnabled, hasPassword, localBypass, isLocal };
+    return { authenticated, authEnabled, hasPassword, localBypass, isLocal, tenantId };
   } catch (err) {
     if (isDbLockError(err)) {
       return {
@@ -24,6 +26,7 @@ export const statusRoute = new Elysia().get('/status', ({ server, request, cooki
         hasPassword: false,
         localBypass: true,
         isLocal: true,
+        tenantId: activeTenantId(),
         indexing: true,
       };
     }

--- a/src/routes/sessions/store.ts
+++ b/src/routes/sessions/store.ts
@@ -1,0 +1,88 @@
+import fs from 'fs';
+import path from 'path';
+import { REPO_ROOT } from '../../config.ts';
+import { db, oracleDocuments, sqlite } from '../../db/index.ts';
+import { buildLearningMarkdown } from '../../learn/markdown.ts';
+import { activeTenantId, DEFAULT_TENANT_ID, tenantIdForWrite } from '../../middleware/tenant.ts';
+import { logLearning } from '../../server/logging.ts';
+
+const SUMMARY_ROOT = 'ψ/memory/session-summaries';
+
+function repoRoot(): string {
+  return process.env.ORACLE_REPO_ROOT || REPO_ROOT;
+}
+
+function safeSegment(value: string, limit: number): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, '-').slice(0, limit);
+}
+
+function summaryIdentity(sessionId: string): { id: string; filename: string; sourceFile: string } {
+  const safeSession = safeSegment(sessionId, 120);
+  if (!safeSession) throw new Error('Invalid session id');
+
+  const tenantId = activeTenantId();
+  if (tenantId === DEFAULT_TENANT_ID) {
+    return {
+      id: `session-summary_${safeSession}`,
+      filename: `${safeSession}.md`,
+      sourceFile: `${SUMMARY_ROOT}/${safeSession}.md`,
+    };
+  }
+
+  const tenantSegment = safeSegment(tenantId, 80) || DEFAULT_TENANT_ID;
+  return {
+    id: `session-summary_${tenantSegment}_${safeSession}`,
+    filename: `${safeSession}.md`,
+    sourceFile: `${SUMMARY_ROOT}/${tenantSegment}/${safeSession}.md`,
+  };
+}
+
+export function persistSessionSummary(
+  sessionId: string,
+  summary: string,
+  oracle?: string,
+): { ok: true; source_file: string; learning_id: string } {
+  const identity = summaryIdentity(sessionId);
+  const now = new Date();
+  const safeSession = safeSegment(sessionId, 120);
+  const concepts = ['session-summary', `session-${safeSession}`];
+  if (oracle) {
+    const safeOracle = safeSegment(oracle, 80);
+    if (safeOracle) concepts.push(`oracle-${safeOracle}`);
+  }
+
+  const title = summary.split('\n')[0].substring(0, 80);
+  const content = buildLearningMarkdown({
+    id: identity.id,
+    pattern: summary,
+    title,
+    concepts,
+    createdAt: now,
+    source: oracle ? `session-summary from ${oracle}` : 'session-summary',
+    footer: '*Added via session auto-summary*',
+  });
+
+  const filePath = path.join(repoRoot(), identity.sourceFile);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  if (fs.existsSync(filePath)) throw new Error(`File already exists: ${identity.filename}`);
+  fs.writeFileSync(filePath, content, 'utf-8');
+
+  db.insert(oracleDocuments).values({
+    id: identity.id,
+    tenantId: tenantIdForWrite(),
+    type: 'learning',
+    sourceFile: identity.sourceFile,
+    concepts: JSON.stringify(concepts),
+    createdAt: now.getTime(),
+    updatedAt: now.getTime(),
+    indexedAt: now.getTime(),
+    createdBy: 'session_summary',
+  }).run();
+
+  sqlite.prepare('DELETE FROM oracle_fts WHERE id = ?').run(identity.id);
+  sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
+    .run(identity.id, content, concepts.join(' '));
+  logLearning(identity.id, summary, oracle ? `session-summary from ${oracle}` : 'session-summary', concepts);
+
+  return { ok: true, source_file: identity.sourceFile, learning_id: identity.id };
+}

--- a/src/routes/sessions/summary.ts
+++ b/src/routes/sessions/summary.ts
@@ -1,6 +1,6 @@
 import { Elysia } from 'elysia';
-import { handleSessionSummary } from '../../server/handlers.ts';
 import { SummaryParams, SummaryBody, MAX_SUMMARY_CHARS } from './model.ts';
+import { persistSessionSummary } from './store.ts';
 
 export const summaryRoute = new Elysia().post(
   '/api/session/:id/summary',
@@ -15,7 +15,7 @@ export const summaryRoute = new Elysia().post(
       return { error: `summary exceeds max length (${MAX_SUMMARY_CHARS} chars)` };
     }
     set.status = 201;
-    return handleSessionSummary(params.id, summary, body.oracle);
+    return persistSessionSummary(params.id, summary, body.oracle);
   },
   {
     params: SummaryParams,

--- a/tests/http/auth/tenant-scope.test.ts
+++ b/tests/http/auth/tenant-scope.test.ts
@@ -1,0 +1,118 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { inArray } from 'drizzle-orm';
+import { mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const savedRepoRoot = process.env.ORACLE_REPO_ROOT;
+const root = join(tmpdir(), `auth-tenant-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+const dbPath = join(root, 'oracle.db');
+
+mkdirSync(root, { recursive: true });
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = dbPath;
+process.env.ORACLE_REPO_ROOT = root;
+
+const dbMod = await import('../../../src/db/index.ts');
+dbMod.resetDefaultDatabaseForTests(dbPath);
+const { authRoutes } = await import('../../../src/routes/auth/index.ts');
+const { sessionsRoutes } = await import('../../../src/routes/sessions/index.ts');
+const { createTenantFetch, TENANT_HEADER } = await import('../../../src/middleware/tenant.ts');
+
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantA = `auth-a-${stamp}`;
+const tenantB = `auth-b-${stamp}`;
+const password = `pw-${stamp}`;
+const sessionId = `session-${stamp}`;
+const createdIds: string[] = [];
+
+dbMod.setSetting('auth_enabled', 'true');
+dbMod.setSetting('auth_local_bypass', 'false');
+dbMod.setSetting('auth_password_hash', await Bun.password.hash(password));
+
+function restore(name: string, value: string | undefined) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+function requestFor(handler: { handle: (request: Request) => Response | Promise<Response> }, tenantId: string, path: string, init: RequestInit = {}) {
+  return createTenantFetch((request) => handler.handle(request))(new Request(`http://local${path}`, {
+    ...init,
+    headers: { 'content-type': 'application/json', [TENANT_HEADER]: tenantId, ...(init.headers ?? {}) },
+  }));
+}
+
+function sessionCookie(response: Response): string {
+  const raw = response.headers.get('set-cookie') ?? '';
+  const value = raw.match(/oracle_session=([^;]+)/)?.[1];
+  expect(value).toBeTruthy();
+  return `oracle_session=${value}`;
+}
+
+async function status(tenantId: string, cookie?: string) {
+  const headers = cookie ? { cookie } : {};
+  const res = await requestFor(authRoutes, tenantId, '/api/auth/status', { headers });
+  return { res, body: await res.json() as Record<string, unknown> };
+}
+
+async function postSummary(tenantId: string) {
+  const res = await requestFor(sessionsRoutes, tenantId, `/api/session/${sessionId}/summary`, {
+    method: 'POST',
+    body: JSON.stringify({ summary: `summary for ${tenantId}`, oracle: 'codex' }),
+  });
+  const body = await res.json() as { learning_id: string; source_file: string };
+  if (body.learning_id) createdIds.push(body.learning_id);
+  return { res, body };
+}
+
+afterAll(() => {
+  if (createdIds.length > 0) {
+    dbMod.db.delete(dbMod.oracleDocuments)
+      .where(inArray(dbMod.oracleDocuments.id, createdIds))
+      .run();
+    dbMod.db.delete(dbMod.learnLog)
+      .where(inArray(dbMod.learnLog.documentId, createdIds))
+      .run();
+    for (const id of createdIds) dbMod.sqlite.prepare('DELETE FROM oracle_fts WHERE id = ?').run(id);
+  }
+  restore('ORACLE_DATA_DIR', savedDataDir);
+  restore('ORACLE_DB_PATH', savedDbPath);
+  restore('ORACLE_REPO_ROOT', savedRepoRoot);
+  dbMod.resetDefaultDatabaseForTests();
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('tenant-scoped auth and sessions', () => {
+  test('does not authenticate another tenant with the first tenant session cookie', async () => {
+    const login = await requestFor(authRoutes, tenantA, '/api/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ password }),
+    });
+    expect(login.status).toBe(200);
+    const cookie = sessionCookie(login);
+
+    expect((await status(tenantA, cookie)).body).toMatchObject({ authenticated: true, tenantId: tenantA });
+    expect((await status(tenantB, cookie)).body).toMatchObject({ authenticated: false, tenantId: tenantB });
+  });
+
+  test('stamps session summaries with the active tenant and separates ids by tenant', async () => {
+    const a = await postSummary(tenantA);
+    const b = await postSummary(tenantB);
+    expect(a.res.status).toBe(201);
+    expect(b.res.status).toBe(201);
+    expect(a.body.learning_id).not.toBe(b.body.learning_id);
+
+    const rows = dbMod.db.select({
+      id: dbMod.oracleDocuments.id,
+      tenantId: dbMod.oracleDocuments.tenantId,
+      sourceFile: dbMod.oracleDocuments.sourceFile,
+    }).from(dbMod.oracleDocuments)
+      .where(inArray(dbMod.oracleDocuments.id, [a.body.learning_id, b.body.learning_id]))
+      .all();
+
+    expect(rows).toContainEqual({ id: a.body.learning_id, tenantId: tenantA, sourceFile: a.body.source_file });
+    expect(rows).toContainEqual({ id: b.body.learning_id, tenantId: tenantB, sourceFile: b.body.source_file });
+  });
+});


### PR DESCRIPTION
## Summary\n- bind auth session cookies to the active tenant so one tenant cookie cannot authenticate another tenant\n- expose tenantId in auth status responses\n- persist session summaries through a route-local tenant-aware store with tenant-separated IDs/source paths\n- add auth-folder regression coverage for tenant auth/session isolation\n\n## Validation\n- bun test tests/http/auth/\n- bun test tests/http/sessions/summary.test.ts\n- bun test tests/http/tenant/auth.test.ts\n- bunx tsc --noEmit\n- git diff --check\n- files <= 250 lines