### PR TITLE
fix(feed): scope feed events by tenant

### DIFF
--- a/src/routes/feed/create.ts
+++ b/src/routes/feed/create.ts
@@ -1,7 +1,9 @@
 import { Elysia } from 'elysia';
 import fs from 'fs';
 import os from 'os';
+import path from 'path';
 import { FEED_LOG } from '../../config.ts';
+import { tenantDataPath, tenantIdForWrite } from '../../middleware/tenant.ts';
 import { CreateFeedBody } from './model.ts';
 
 export const createFeedRoute = new Elysia().post('/', async ({ body, set }) => {
@@ -15,10 +17,13 @@ export const createFeedRoute = new Elysia().post('/', async ({ body, set }) => {
 
     const timestamp = new Date().toISOString().replace('T', ' ').slice(0, 19);
     const host = os.hostname();
-    const line = `${timestamp} | ${oracle} | ${host} | ${event} | ${project || ''} | ${session_id || ''} » ${message || ''}\n`;
+    const tenantId = tenantIdForWrite();
+    const feedLog = tenantDataPath(FEED_LOG);
+    const line = `${timestamp} | ${tenantId} | ${oracle} | ${host} | ${event} | ${project || ''} | ${session_id || ''} » ${message || ''}\n`;
 
-    fs.appendFileSync(FEED_LOG, line);
-    return { success: true, timestamp };
+    fs.mkdirSync(path.dirname(feedLog), { recursive: true });
+    fs.appendFileSync(feedLog, line);
+    return { success: true, timestamp, tenant_id: tenantId };
   } catch (e: any) {
     set.status = 500;
     return { error: e.message };

--- a/src/routes/feed/list.ts
+++ b/src/routes/feed/list.ts
@@ -1,9 +1,37 @@
 import { Elysia } from 'elysia';
 import fs from 'fs';
 import { FEED_LOG } from '../../config.ts';
+import { currentTenantId, tenantDataPath, TENANT_HEADER } from '../../middleware/tenant.ts';
 import { FeedQuery, type FeedEvent } from './model.ts';
 
 const MAW_JS_URL = process.env.MAW_JS_URL || 'http://localhost:3456';
+
+function parseLocalEvent(line: string, fallbackTenantId?: string): FeedEvent {
+  const parts = line.split(' | ').map(s => s.trim());
+  const hasTenant = parts.length >= 7;
+  const [ts, tenantOrOracle, oracleOrHost, hostOrEvent, eventOrProject, projectOrRest, restValue] = parts;
+  const rest = hasTenant ? restValue : projectOrRest;
+  const [sessionId, ...msgParts] = (rest || '').split(' » ');
+  return {
+    timestamp: ts,
+    tenant_id: hasTenant ? tenantOrOracle : fallbackTenantId,
+    oracle: hasTenant ? oracleOrHost : tenantOrOracle,
+    host: hasTenant ? hostOrEvent : oracleOrHost,
+    event: hasTenant ? eventOrProject : hostOrEvent,
+    project: hasTenant ? projectOrRest : eventOrProject,
+    session_id: sessionId?.trim(),
+    message: msgParts.join(' » ').trim(),
+    source: 'local',
+  };
+}
+
+function tenantForEvent(event: unknown): string | undefined {
+  if (!event || typeof event !== 'object') return undefined;
+  const value = (event as Record<string, unknown>).tenant_id
+    ?? (event as Record<string, unknown>).tenantId
+    ?? (event as Record<string, unknown>).tenant;
+  return typeof value === 'string' ? value : undefined;
+}
 
 export const listFeedRoute = new Elysia().get('/', async ({ query, set }) => {
   try {
@@ -12,42 +40,36 @@ export const listFeedRoute = new Elysia().get('/', async ({ query, set }) => {
     const event = query.event || undefined;
     const since = query.since || undefined;
 
+    const tenantId = currentTenantId();
+    const feedLog = tenantDataPath(FEED_LOG);
     let allEvents: FeedEvent[] = [];
 
-    if (fs.existsSync(FEED_LOG)) {
-      const raw = fs.readFileSync(FEED_LOG, 'utf-8').trim().split('\n').filter(Boolean);
-      const localEvents: FeedEvent[] = raw.map(line => {
-        const [ts, oracleName, host, eventType, project, rest] = line.split(' | ').map(s => s.trim());
-        const [sessionId, ...msgParts] = (rest || '').split(' » ');
-        return {
-          timestamp: ts,
-          oracle: oracleName,
-          host,
-          event: eventType,
-          project,
-          session_id: sessionId?.trim(),
-          message: msgParts.join(' » ').trim(),
-          source: 'local',
-        };
-      });
-      allEvents.push(...localEvents);
+    if (fs.existsSync(feedLog)) {
+      const raw = fs.readFileSync(feedLog, 'utf-8').trim().split('\n').filter(Boolean);
+      allEvents.push(...raw.map(line => parseLocalEvent(line, tenantId)));
     }
 
     try {
-      const mawRes = await fetch(`${MAW_JS_URL}/api/feed?limit=100`, { signal: AbortSignal.timeout(2000) });
+      const mawRes = await fetch(`${MAW_JS_URL}/api/feed?limit=100`, {
+        headers: tenantId ? { [TENANT_HEADER]: tenantId } : undefined,
+        signal: AbortSignal.timeout(2000),
+      });
       if (mawRes.ok) {
         const mawData = await mawRes.json() as any;
         if (mawData.events && Array.isArray(mawData.events)) {
-          const mawEvents: FeedEvent[] = mawData.events.map((e: any) => ({
-            timestamp: e.timestamp || new Date(e.ts).toISOString().replace('T', ' ').slice(0, 19),
-            oracle: e.oracle,
-            host: e.host,
-            event: e.event,
-            project: e.project,
-            session_id: e.sessionId,
-            message: e.message,
-            source: 'maw-js',
-          }));
+          const mawEvents: FeedEvent[] = mawData.events
+            .filter((e: any) => !tenantId || tenantForEvent(e) === tenantId)
+            .map((e: any) => ({
+              timestamp: e.timestamp || new Date(e.ts).toISOString().replace('T', ' ').slice(0, 19),
+              tenant_id: tenantForEvent(e),
+              oracle: e.oracle,
+              host: e.host,
+              event: e.event,
+              project: e.project,
+              session_id: e.sessionId,
+              message: e.message,
+              source: 'maw-js',
+            }));
           allEvents.push(...mawEvents);
         }
       }

--- a/src/routes/feed/model.ts
+++ b/src/routes/feed/model.ts
@@ -23,5 +23,6 @@ export interface FeedEvent {
   project: string;
   session_id: string;
   message: string;
+  tenant_id?: string;
   source: 'local' | 'maw-js';
 }

--- a/tests/http/feed/tenant-isolation.test.ts
+++ b/tests/http/feed/tenant-isolation.test.ts
@@ -1,0 +1,129 @@
+import { afterAll, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { inArray, like } from 'drizzle-orm';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const savedMawUrl = process.env.MAW_JS_URL;
+const root = mkdtempSync(join(tmpdir(), 'feed-tenant-'));
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = join(root, 'oracle.db');
+
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantA = `tenant-feed-a-${stamp}`;
+const tenantB = `tenant-feed-b-${stamp}`;
+const remoteSeen: string[] = [];
+const now = Date.now();
+
+const maw = Bun.serve({
+  port: 0,
+  fetch(request) {
+    remoteSeen.push(request.headers.get('X-Oracle-Tenant') ?? 'none');
+    return Response.json({ events: [
+      { timestamp: '2026-06-17 09:00:00', tenant_id: tenantA, oracle: `remote-a-${stamp}`, host: 'maw', event: 'ping', project: 'a', sessionId: 'ra', message: 'remote a' },
+      { timestamp: '2026-06-17 09:00:01', tenant_id: tenantB, oracle: `remote-b-${stamp}`, host: 'maw', event: 'ping', project: 'b', sessionId: 'rb', message: 'remote b' },
+      { timestamp: '2026-06-17 09:00:02', oracle: `remote-global-${stamp}`, host: 'maw', event: 'ping', project: 'global', sessionId: 'rg', message: 'remote global' },
+    ] });
+  },
+});
+process.env.MAW_JS_URL = String(maw.url).replace(/\/$/, '');
+
+const { createTenantFetch, TENANT_HEADER } = await import('../../../src/middleware/tenant.ts');
+const { createFeedRoute } = await import('../../../src/routes/feed/create.ts');
+const { listFeedRoute } = await import('../../../src/routes/feed/list.ts');
+const { dashboardRoutes } = await import('../../../src/routes/dashboard/index.ts');
+const dbMod = await import('../../../src/db/index.ts');
+dbMod.resetDefaultDatabaseForTests();
+const { learnLog, oracleDocuments, searchLog } = dbMod;
+
+const feedApp = new Elysia({ prefix: '/api/feed' }).use(createFeedRoute).use(listFeedRoute);
+
+function tenantRequest(handler: { handle: (request: Request) => Response | Promise<Response> }, tenantId: string, path: string, init: RequestInit = {}) {
+  return createTenantFetch((request) => handler.handle(request))(new Request(`http://local${path}`, {
+    ...init,
+    headers: { 'content-type': 'application/json', [TENANT_HEADER]: tenantId, ...(init.headers ?? {}) },
+  }));
+}
+
+async function postFeed(tenantId: string, oracle: string) {
+  return tenantRequest(feedApp, tenantId, '/api/feed', {
+    method: 'POST',
+    body: JSON.stringify({ oracle, event: 'notice', project: tenantId, session_id: oracle, message: `msg ${oracle}` }),
+  });
+}
+
+function insertDashboardRows(tenantId: string, id: string, query: string) {
+  dbMod.db.insert(oracleDocuments).values({
+    id,
+    tenantId,
+    type: 'learning',
+    sourceFile: `ψ/memory/${id}.md`,
+    concepts: JSON.stringify([tenantId]),
+    createdAt: now,
+    updatedAt: now,
+    indexedAt: now,
+    project: tenantId,
+    createdBy: 'tenant-test',
+  }).run();
+  dbMod.db.insert(searchLog).values({ query, tenantId, mode: 'fts', resultsCount: 1, searchTimeMs: 1, createdAt: now }).run();
+  dbMod.db.insert(learnLog).values({ documentId: id, tenantId, patternPreview: query, concepts: '[]', createdAt: now }).run();
+}
+
+insertDashboardRows(tenantA, `feed-dashboard-a-${stamp}`, `feed dashboard a ${stamp}`);
+insertDashboardRows(tenantB, `feed-dashboard-b-${stamp}`, `feed dashboard b ${stamp}`);
+
+afterAll(() => {
+  maw.stop();
+  dbMod.db.delete(oracleDocuments).where(like(oracleDocuments.id, `%${stamp}%`)).run();
+  dbMod.db.delete(searchLog).where(like(searchLog.query, `%${stamp}%`)).run();
+  dbMod.db.delete(learnLog).where(inArray(learnLog.documentId, [`feed-dashboard-a-${stamp}`, `feed-dashboard-b-${stamp}`])).run();
+  rmSync(root, { recursive: true, force: true });
+  if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = savedDataDir;
+  if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = savedDbPath;
+  if (savedMawUrl === undefined) delete process.env.MAW_JS_URL;
+  else process.env.MAW_JS_URL = savedMawUrl;
+});
+
+test('/api/feed stores and lists only selected tenant feed events', async () => {
+  const localA = `local-a-${stamp}`;
+  const localB = `local-b-${stamp}`;
+  expect((await postFeed(tenantA, localA)).status).toBe(200);
+  expect((await postFeed(tenantB, localB)).status).toBe(200);
+
+  const res = await tenantRequest(feedApp, tenantA, '/api/feed?limit=20');
+  const body = await res.json() as { events: Array<{ oracle: string; tenant_id?: string }>; active_oracles: string[] };
+  const oracles = body.events.map((event) => event.oracle);
+
+  expect(res.status).toBe(200);
+  expect(oracles).toContain(localA);
+  expect(oracles).toContain(`remote-a-${stamp}`);
+  expect(oracles).not.toContain(localB);
+  expect(oracles).not.toContain(`remote-b-${stamp}`);
+  expect(oracles).not.toContain(`remote-global-${stamp}`);
+  expect(body.events.every((event) => event.tenant_id === tenantA)).toBe(true);
+  expect(remoteSeen).toContain(tenantA);
+});
+
+test('/api/dashboard routes summarize only the selected tenant', async () => {
+  const [summaryRes, activityRes, growthRes] = await Promise.all([
+    tenantRequest(dashboardRoutes, tenantA, '/api/dashboard/summary'),
+    tenantRequest(dashboardRoutes, tenantA, '/api/dashboard/activity?days=1'),
+    tenantRequest(dashboardRoutes, tenantA, '/api/dashboard/growth?period=week'),
+  ]);
+  const summary = await summaryRes.json() as { documents: { total: number }; concepts: { top: Array<{ name: string }> } };
+  const activity = await activityRes.json() as { searches: Array<{ query: string }>; learnings: Array<{ document_id: string }> };
+  const growth = await growthRes.json() as { data: Array<{ documents: number; searches: number }> };
+
+  expect(summary.documents.total).toBe(1);
+  expect(summary.concepts.top.map((item) => item.name)).toEqual([tenantA]);
+  expect(activity.searches.map((item) => item.query)).toContain(`feed dashboard a ${stamp}`);
+  expect(activity.searches.map((item) => item.query)).not.toContain(`feed dashboard b ${stamp}`);
+  expect(activity.learnings.map((item) => item.document_id)).toEqual([`feed-dashboard-a-${stamp}`]);
+  expect(growth.data.reduce((sum, row) => sum + row.documents, 0)).toBe(1);
+  expect(growth.data.reduce((sum, row) => sum + row.searches, 0)).toBe(1);
+});


### PR DESCRIPTION
## Summary
- confirm #1650 memory tenant slice is already merged via PR #1943
- write/read feed logs through tenant-scoped paths and include tenant metadata in feed responses
- forward tenant headers to maw-js feed and merge only explicitly matching tenant events
- add feed-suite regression covering feed isolation plus dashboard summary/activity/growth tenant scoping

## Validation
- bun test tests/http/feed/
- bunx tsc --noEmit
- changed files <=250 lines

Refs #1650