### PR TITLE
feat(memory): explain query-time confidence

### DIFF
--- a/docs/issues/memory-systems-ai-agents-1648.md
+++ b/docs/issues/memory-systems-ai-agents-1648.md
@@ -94,4 +94,5 @@ knowledge corpus.
 - `ψ/memory/ai-memory-systems-claims-ledger.md`
 - `ψ/memory/ai-memory-product-patterns-2026.md`
 - `ψ/memory/ai-agent-memory-recommendations-1648.md`
+- `ψ/memory/memory-confidence-contract-1648.md`
 - `docs/HUGINN-MUNINN.md`

--- a/src/routes/memory/confidence.ts
+++ b/src/routes/memory/confidence.ts
@@ -5,6 +5,12 @@ export type MemoryConfidence = {
   label: 'high' | 'medium' | 'low';
   ageDays: number;
   freshness: number;
+  components: {
+    match: number;
+    freshness: number;
+    provenance: number;
+  };
+  warnings: string[];
   reasons: string[];
 };
 
@@ -40,6 +46,12 @@ export function memoryConfidence(
     label: score >= 0.75 ? 'high' : score >= 0.45 ? 'medium' : 'low',
     ageDays: round(ageDays),
     freshness: round(freshness),
+    components: {
+      match: round(match),
+      freshness: round(freshness),
+      provenance: round(provenance),
+    },
+    warnings: warnings(ageDays, match, hasSource, hasTags),
     reasons: reasons(options.mode ?? 'keyword', hasSource, hasTags, halfLife),
   };
 }
@@ -64,6 +76,16 @@ function reasons(mode: ConfidenceMode, hasSource: boolean, hasTags: boolean, hal
     hasTags ? 'tags_present' : 'tags_missing',
     `freshness_half_life_${halfLifeDays}d`,
   ];
+}
+
+function warnings(ageDays: number, match: number, hasSource: boolean, hasTags: boolean): string[] {
+  const list: string[] = [];
+  if (!hasSource) list.push('missing_source');
+  if (!hasTags) list.push('missing_tags');
+  if (!hasSource && !hasTags) list.push('unanchored_memory');
+  if (!hasSource && !hasTags && ageDays >= UNVALIDATED_HALF_LIFE_DAYS) list.push('stale_unvalidated');
+  if (match < 0.45) list.push('low_match_score');
+  return list;
 }
 
 function clamp(value: number): number {

--- a/tests/http/memory/confidence.test.ts
+++ b/tests/http/memory/confidence.test.ts
@@ -26,6 +26,12 @@ test('memoryConfidence is computed at query time from match, freshness, and prov
     score: 0.96,
     ageDays: 0,
     freshness: 1,
+    components: {
+      match: 0.92,
+      freshness: 1,
+      provenance: 1,
+    },
+    warnings: [],
   });
   expect(confidence.reasons).toContain('computed_at_query_time');
   expect(confidence.reasons).toContain('freshness_half_life_139d');
@@ -41,4 +47,25 @@ test('unanchored old memory decays without storing a confidence column', () => {
   expect(stale.freshness).toBeLessThan(0.05);
   expect(stale.reasons).toContain('source_missing');
   expect(stale.reasons).toContain('freshness_half_life_30d');
+  expect(stale.warnings).toEqual(expect.arrayContaining([
+    'missing_source',
+    'missing_tags',
+    'unanchored_memory',
+    'stale_unvalidated',
+  ]));
+});
+
+test('weak semantic matches expose warnings without storing confidence', () => {
+  const confidence = memoryConfidence(memory({
+    source: 'ψ/memory/design-principles-arra-oracle.md',
+  }), { now, mode: 'semantic', semanticScore: 0.31 });
+
+  expect(confidence.label).toBe('medium');
+  expect(confidence.components).toMatchObject({
+    match: 0.31,
+    freshness: 1,
+    provenance: 0.45,
+  });
+  expect(confidence.warnings).toEqual(expect.arrayContaining(['missing_tags', 'low_match_score']));
+  expect(confidence.warnings).not.toContain('stale_unvalidated');
 });

--- a/ψ/memory/memory-confidence-contract-1648.md
+++ b/ψ/memory/memory-confidence-contract-1648.md
@@ -1,0 +1,94 @@
+# Memory Confidence Contract — #1648
+
+Status: 2026-06-17 implementation note for issue #1648. This file records the
+small runtime contract added after the deep-research pass so future memory work
+keeps confidence explainable instead of treating it as a stored truth column.
+
+## Decision
+
+Memory confidence is computed when a memory is read. It is not persisted on the
+memory row and it does not rewrite historical records. This matches the #1648
+research finding that confidence drifts as sources age, citations disappear,
+tenant context changes, and retrieval quality changes.
+
+## Current API shape
+
+`/api/memory/recall` and `/api/memory/search` include a top-level strategy block:
+
+```json
+{
+  "stored": false,
+  "strategy": "query-time-confidence",
+  "signals": ["match_score", "freshness_decay", "source", "tags", "title"]
+}
+```
+
+Each result includes a `confidence` object:
+
+```json
+{
+  "score": 0.87,
+  "label": "high",
+  "ageDays": 0,
+  "freshness": 1,
+  "components": {
+    "match": 1,
+    "freshness": 1,
+    "provenance": 0.35
+  },
+  "warnings": ["missing_source"],
+  "reasons": [
+    "computed_at_query_time",
+    "semantic_match",
+    "source_missing",
+    "tags_present",
+    "freshness_half_life_139d"
+  ]
+}
+```
+
+## Scoring inputs
+
+- `match`: keyword recall default or vector similarity score.
+- `freshness`: exponential decay from `updatedAt` or `createdAt`.
+- `provenance`: weighted source, tags, and title presence.
+- anchored memories use the longer research-backed half-life; unanchored
+  memories decay on the shorter unvalidated half-life.
+
+The current score is intentionally simple:
+
+```text
+score = match * 0.5 + freshness * 0.3 + provenance * 0.2
+```
+
+This keeps confidence visible before it changes ranking behavior.
+
+## Warning meanings
+
+| Warning | Meaning | Operator response |
+| --- | --- | --- |
+| `missing_source` | No source path, URL, route, or capture origin was saved | Add a source before promoting durable memory |
+| `missing_tags` | No tags were saved | Add lifecycle/topic tags so recall can explain scope |
+| `unanchored_memory` | No source and no tags | Treat as a personal note, not canonical knowledge |
+| `stale_unvalidated` | Unanchored memory passed the short half-life | Revalidate, promote with provenance, or archive |
+| `low_match_score` | Semantic match is weak | Use as supporting context only |
+
+## Guardrails
+
+- Do not persist the confidence score in `oracle_memories`.
+- Additive confidence fields are allowed; removing or renaming fields needs an
+  API compatibility note.
+- Warnings are guidance, not hard filters. Ranking changes should be measured
+  separately against false-positive and false-negative recall examples.
+- Keep tenant isolation before confidence: never raise confidence for a result
+  that does not belong to the active tenant context.
+
+## Next implementation slice
+
+1. Add explicit lifecycle metadata (`candidate`, `validated`, `promoted`,
+   `stale`, `contradicted`, `archived`) through Drizzle before changing ranking.
+2. Add source hash/path validation and include validation status in the
+   confidence components.
+3. Promote MCP writes into candidate memories only; CLI/UI should own validation
+   and durable promotion.
+4. Use search logs to decide whether confidence should influence ordering.


### PR DESCRIPTION
## Summary
- add ψ memory confidence contract for #1648 research findings
- expose confidence components and operator warnings at query time
- extend confidence tests for provenance, staleness, and low-match warnings

## Validation
- bunx tsc --noEmit
- ORACLE_DATA_DIR=$(mktemp -d) ORACLE_DB_PATH=$ORACLE_DATA_DIR/oracle.db bun test tests/http/memory/
- git diff --check origin/alpha...HEAD
- changed files <= 250 lines