### PR TITLE
fix: scope files routes by tenant

### DIFF
--- a/src/routes/files/context.ts
+++ b/src/routes/files/context.ts
@@ -1,10 +1,18 @@
 import { Elysia } from 'elysia';
 import { handleContext } from '../../server/context.ts';
 import { contextQuery } from './model.ts';
+import { projectAllowedForTenant } from './tenant.ts';
 
 export const contextRoute = new Elysia().get(
   '/api/context',
-  ({ query }) => handleContext(query.cwd),
+  ({ query, set }) => {
+    const result = handleContext(query.cwd);
+    if ('ghqPath' in result && !projectAllowedForTenant(result.ghqPath)) {
+      set.status = 404;
+      return { error: 'Project not found' };
+    }
+    return result;
+  },
   {
     query: contextQuery,
     detail: {

--- a/src/routes/files/file.ts
+++ b/src/routes/files/file.ts
@@ -12,6 +12,7 @@ import path from 'path';
 import { REPO_ROOT } from '../../config.ts';
 import { getVaultPsiRoot } from '../../vault/handler.ts';
 import { fileQuery } from './model.ts';
+import { projectAllowedForTenant } from './tenant.ts';
 
 const currentRepoRoot = () => process.env.ORACLE_REPO_ROOT || REPO_ROOT;
 
@@ -24,6 +25,10 @@ export const fileRoute = new Elysia().get(
     if (!filePath) {
       set.status = 400;
       return { error: 'Missing path parameter' };
+    }
+
+    if (project && !projectAllowedForTenant(project)) {
+      return new Response('File not found', { status: 404 });
     }
 
     // SECURITY: Block path traversal attempts (belt-and-suspenders with TypeBox pattern).

--- a/src/routes/files/graph.ts
+++ b/src/routes/files/graph.ts
@@ -1,12 +1,13 @@
 import { Elysia } from 'elysia';
 import { handleGraph } from '../../server/handlers.ts';
 import { graphQuery } from './model.ts';
+import { handleTenantGraph } from './tenant.ts';
 
 export const graphRoute = new Elysia().get(
   '/api/graph',
   ({ query }) => {
     const limit = query.limit ? parseInt(query.limit, 10) : undefined;
-    return handleGraph(limit);
+    return handleTenantGraph(limit) ?? handleGraph(limit);
   },
   {
     query: graphQuery,

--- a/src/routes/files/tenant.ts
+++ b/src/routes/files/tenant.ts
@@ -1,0 +1,64 @@
+import { sqlite } from '../../db/index.ts';
+import { currentTenantId } from '../../middleware/tenant.ts';
+
+const GRAPH_TYPES = ['principle', 'learning', 'retro'];
+
+type DocRow = {
+  id: string;
+  type: string;
+  source_file: string;
+  concepts: string | null;
+  project: string | null;
+};
+
+export function projectMatchesTenant(project: string, tenantId: string): boolean {
+  const normalizedProject = project.trim().toLowerCase();
+  const tenant = tenantId.trim().toLowerCase();
+  if (!tenant || normalizedProject === tenant) return true;
+  return normalizedProject.split(/[\\/]+/).filter(Boolean).includes(tenant);
+}
+
+export function projectAllowedForTenant(project?: string | null): boolean {
+  const tenantId = currentTenantId();
+  return !tenantId || !project || projectMatchesTenant(project, tenantId);
+}
+
+function parseConcepts(value: string | null): string[] {
+  try { return JSON.parse(value || '[]') as string[]; } catch { return []; }
+}
+
+function tenantRows(type: string, tenantId: string, limit: number): DocRow[] {
+  return sqlite.prepare(`
+    SELECT id, type, source_file, concepts, project
+    FROM oracle_documents
+    WHERE tenant_id = ? AND type = ?
+    ORDER BY RANDOM()
+    LIMIT ?
+  `).all(tenantId, type, limit) as DocRow[];
+}
+
+export function handleTenantGraph(limitPerType = 310): Record<string, unknown> | null {
+  const tenantId = currentTenantId();
+  if (!tenantId) return null;
+
+  const perType = Math.min(Math.max(limitPerType, 10), 500);
+  const docs = GRAPH_TYPES.flatMap((type) => tenantRows(type, tenantId, perType));
+  const nodes = docs.map((doc) => ({
+    id: doc.id,
+    type: doc.type,
+    source_file: doc.source_file,
+    project: doc.project,
+    concepts: parseConcepts(doc.concepts),
+  }));
+
+  const conceptSets = nodes.map((node) => new Set(node.concepts));
+  const links: Array<{ source: string; target: string; weight: number }> = [];
+  for (let i = 0; i < nodes.length && links.length < 5000; i++) {
+    for (let j = i + 1; j < nodes.length && links.length < 5000; j++) {
+      const weight = nodes[j].concepts.filter((concept) => conceptSets[i].has(concept)).length;
+      if (weight >= 1) links.push({ source: nodes[i].id, target: nodes[j].id, weight });
+    }
+  }
+
+  return { nodes, links };
+}

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -8,6 +8,7 @@
 import fs from 'fs';
 import path from 'path';
 import type { ToolContext, ToolResponse, OracleReadInput } from './types.ts';
+import { currentTenantId } from '../middleware/tenant.ts';
 
 let getVaultPsiRootFn: typeof import('../vault/handler.ts').getVaultPsiRoot | null = null;
 async function loadGetVaultPsiRoot(): Promise<typeof import('../vault/handler.ts').getVaultPsiRoot> {
@@ -51,6 +52,21 @@ function detectGhqRoot(repoRoot: string): string {
 }
 
 /** Extract ghq-style project prefix from a source_file path */
+
+function projectMatchesTenant(project: string, tenantId: string): boolean {
+  const normalizedProject = project.trim().toLowerCase();
+  const tenant = tenantId.trim().toLowerCase();
+  if (!tenant || normalizedProject === tenant) return true;
+  return normalizedProject.split(/[\/]+/).filter(Boolean).includes(tenant);
+}
+
+function notFound(idOrFile: string): ToolResponse {
+  return {
+    content: [{ type: 'text', text: JSON.stringify({ error: `Document not found: ${idOrFile}` }) }],
+    isError: true,
+  };
+}
+
 function extractProject(filePath: string): { project: string; remainder: string } | null {
   const match = filePath.match(/^(github\.com\/[^/]+\/[^/]+)\/(.*)/);
   if (match) return { project: match[1], remainder: match[2] };
@@ -115,21 +131,24 @@ export async function handleRead(ctx: ToolContext, input: OracleReadInput): Prom
 
   let sourceFile = file;
   let project: string | null = null;
+  const tenantId = currentTenantId();
 
   // ID lookup: resolve source_file from DB
   if (id) {
-    const row = ctx.sqlite.prepare(
-      'SELECT source_file, project FROM oracle_documents WHERE id = ?'
-    ).get(id) as { source_file: string; project: string | null } | null;
+    const row = tenantId
+      ? ctx.sqlite.prepare('SELECT source_file, project FROM oracle_documents WHERE id = ? AND tenant_id = ?')
+        .get(id, tenantId) as { source_file: string; project: string | null } | null
+      : ctx.sqlite.prepare('SELECT source_file, project FROM oracle_documents WHERE id = ?')
+        .get(id) as { source_file: string; project: string | null } | null;
 
-    if (!row) {
-      return {
-        content: [{ type: 'text', text: JSON.stringify({ error: `Document not found: ${id}` }) }],
-        isError: true,
-      };
-    }
+    if (!row) return notFound(id);
     sourceFile = sourceFile || row.source_file;
     project = row.project;
+  }
+
+  const sourceProject = project ?? (sourceFile ? extractProject(sourceFile)?.project ?? null : null);
+  if (tenantId && sourceProject && !projectMatchesTenant(sourceProject, tenantId)) {
+    return notFound(id || sourceFile || 'file');
   }
 
   const ghqRoot = detectGhqRoot(ctx.repoRoot);

--- a/tests/http/files/tenant-isolation.test.ts
+++ b/tests/http/files/tenant-isolation.test.ts
@@ -1,0 +1,107 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { beforeAll, describe, expect, test } from 'bun:test';
+import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-files-http-'));
+const ghqRoot = path.join(tempRoot, 'ghq');
+const repoA = path.join(ghqRoot, 'github.com/tenant-a/repo');
+const repoB = path.join(ghqRoot, 'github.com/tenant-b/repo');
+const stamp = `${Date.now()}${Math.random().toString(16).slice(2)}`;
+const tenantA = 'tenant-a';
+const tenantB = 'tenant-b';
+const ids = { a: `files-a-${stamp}`, b: `files-b-${stamp}` };
+
+let db: any;
+let sqlite: any;
+let oracleDocuments: any;
+let filesRouter: { handle: (request: Request) => Response | Promise<Response> };
+
+beforeAll(async () => {
+  fs.mkdirSync(repoA, { recursive: true });
+  fs.mkdirSync(repoB, { recursive: true });
+  fs.writeFileSync(path.join(repoB, 'secret.md'), 'tenant-b secret', 'utf-8');
+  Bun.spawnSync(['git', 'init'], { cwd: repoA, stdout: 'pipe', stderr: 'pipe' });
+  Bun.spawnSync(['git', 'init'], { cwd: repoB, stdout: 'pipe', stderr: 'pipe' });
+  process.env.GHQ_ROOT = ghqRoot;
+  process.env.ORACLE_REPO_ROOT = repoA;
+  process.env.ORACLE_DATA_DIR = tempRoot;
+  process.env.ORACLE_DB_PATH = path.join(tempRoot, 'oracle.db');
+
+  const dbModule = await import('../../../src/db/index.ts');
+  dbModule.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+  db = dbModule.db;
+  sqlite = dbModule.sqlite;
+  oracleDocuments = dbModule.oracleDocuments;
+  ({ filesRouter } = await import('../../../src/routes/files/index.ts'));
+  insertDoc(ids.a, tenantA, 'learning', 'alpha tenant file body');
+  insertDoc(ids.b, tenantB, 'principle', 'beta tenant file body');
+});
+
+function insertDoc(id: string, tenantId: string, type: string, content: string) {
+  const now = Date.now();
+  db.insert(oracleDocuments).values({
+    id,
+    tenantId,
+    type,
+    sourceFile: `github.com/${tenantId}/repo/ψ/docs/${id}.md`,
+    concepts: JSON.stringify(['shared-files', tenantId]),
+    createdAt: now,
+    updatedAt: now,
+    indexedAt: now,
+    project: `github.com/${tenantId}/repo`,
+    createdBy: 'files-tenant-test',
+  }).run();
+  sqlite.prepare('DELETE FROM oracle_fts WHERE id = ?').run(id);
+  sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
+    .run(id, content, tenantId);
+}
+
+function request(tenantId: string, route: string) {
+  return createTenantFetch((req) => filesRouter.handle(req))(new Request(`http://local${route}`, {
+    headers: { [TENANT_HEADER]: tenantId },
+  }));
+}
+
+describe('files routes tenant isolation', () => {
+  test('GET /api/read hides document ids from other tenants', async () => {
+    const denied = await request(tenantB, `/api/read?id=${ids.a}`);
+    const allowed = await request(tenantA, `/api/read?id=${ids.a}`);
+    const body = await allowed.json() as { content: string; source: string };
+
+    expect(denied.status).toBe(404);
+    expect(allowed.status).toBe(200);
+    expect(body.source).toBe('fts_cache');
+    expect(body.content).toContain('alpha tenant');
+  });
+
+  test('GET /api/graph includes only selected tenant document nodes', async () => {
+    const res = await request(tenantB, '/api/graph?limit=10');
+    const body = await res.json() as { nodes: Array<{ id: string }>; links: unknown[] };
+
+    expect(res.status).toBe(200);
+    expect(body.nodes.map((node) => node.id)).toContain(ids.b);
+    expect(body.nodes.map((node) => node.id)).not.toContain(ids.a);
+  });
+
+  test('GET /api/file blocks cross-tenant project reads', async () => {
+    const denied = await request(tenantA, '/api/file?project=github.com/tenant-b/repo&path=secret.md');
+    const allowed = await request(tenantB, '/api/file?project=github.com/tenant-b/repo&path=secret.md');
+
+    expect(denied.status).toBe(404);
+    expect(allowed.status).toBe(200);
+    expect(await allowed.text()).toBe('tenant-b secret');
+  });
+
+  test('GET /api/context blocks cross-tenant project context', async () => {
+    const cwd = encodeURIComponent(repoB);
+    const denied = await request(tenantA, `/api/context?cwd=${cwd}`);
+    const allowed = await request(tenantB, `/api/context?cwd=${cwd}`);
+    const body = await allowed.json() as { ghqPath: string };
+
+    expect(denied.status).toBe(404);
+    expect(allowed.status).toBe(200);
+    expect(body.ghqPath).toBe('github.com/tenant-b/repo');
+  });
+});


### PR DESCRIPTION
## Summary
- Scope `/api/graph` nodes/links to the resolved tenant
- Scope `/api/read?id=...` by tenant and block explicit cross-tenant project file reads
- Guard `/api/file?project=...` and `/api/context?cwd=...` against cross-tenant project access
- Add focused `tests/http/files/` coverage for read, graph, file, and context tenant boundaries

## Validation
- `bunx tsc --noEmit`
- `bun test tests/http/files/` (4 pass)
- `bun test tests/http/files-plugins.test.ts` (20 pass)
- `git diff --check`
- Changed files <= 250 lines

Refs #1650
