### PR TITLE
feat: scope indexer routes by tenant

### DIFF
--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -14,10 +14,11 @@ import fs from 'fs';
 import path from 'path';
 import { Database } from 'bun:sqlite';
 import { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
-import { eq, or, isNull, inArray } from 'drizzle-orm';
+import { and, eq, or, isNull, inArray, type SQL } from 'drizzle-orm';
 import * as schema from '../db/schema.ts';
 import { oracleDocuments } from '../db/schema.ts';
 import { createDatabase } from '../db/index.ts';
+import { currentTenantId } from '../middleware/tenant.ts';
 import { detectProject } from '../server/project-detect.ts';
 import type { OracleDocument, IndexerConfig } from '../types.ts';
 
@@ -52,6 +53,11 @@ export class OracleIndexer {
    */
   async index(options: IndexOptions = {}): Promise<void> {
     const append = options.append === true;
+    const tenantId = currentTenantId();
+    const indexerOwnedWhere = tenantScopedWhere(
+      or(eq(oracleDocuments.createdBy, 'indexer'), isNull(oracleDocuments.createdBy))!,
+      tenantId,
+    );
     console.log(append ? 'Starting Oracle indexing in append mode...' : 'Starting Oracle indexing...');
     this.seenContentHashes.clear();
 
@@ -64,7 +70,7 @@ export class OracleIndexer {
     const psiMemoryDir = path.join(this.config.repoRoot, '\u03c8', 'memory');
     const existingIndexerDocCount = this.db.select({ id: oracleDocuments.id })
       .from(oracleDocuments)
-      .where(or(eq(oracleDocuments.createdBy, 'indexer'), isNull(oracleDocuments.createdBy)))
+      .where(indexerOwnedWhere)
       .all().length;
 
     if (!append && !fs.existsSync(psiMemoryDir) && existingIndexerDocCount > 0) {
@@ -100,7 +106,7 @@ export class OracleIndexer {
       // Smart deletion: remove indexer-created docs whose source file no longer exists
       const allIndexerDocs = this.db.select({ id: oracleDocuments.id, sourceFile: oracleDocuments.sourceFile })
         .from(oracleDocuments)
-        .where(or(eq(oracleDocuments.createdBy, 'indexer'), isNull(oracleDocuments.createdBy)))
+        .where(indexerOwnedWhere)
         .all();
 
       const idsToDelete = allIndexerDocs
@@ -139,7 +145,7 @@ export class OracleIndexer {
 
     // Store in SQLite + FTS5 only. Vector indexing is a separate step
     // (src/scripts/index-model.ts) that uses the canonical LanceDB path.
-    await storeDocuments(this.sqlite, this.db, null, this.project, documents);
+    await storeDocuments(this.sqlite, this.db, null, this.project, documents, { tenantId });
 
     setIndexingStatus(this.sqlite, this.config, false, documents.length, documents.length);
     console.log(`Indexed ${documents.length} documents (SQLite + FTS5)`);
@@ -151,4 +157,8 @@ export class OracleIndexer {
   async close(): Promise<void> {
     this.sqlite.close();
   }
+}
+
+function tenantScopedWhere(base: SQL, tenantId: string | undefined): SQL {
+  return tenantId ? and(base, eq(oracleDocuments.tenantId, tenantId))! : base;
 }

--- a/src/indexer/storage.ts
+++ b/src/indexer/storage.ts
@@ -6,6 +6,7 @@ import { Database } from 'bun:sqlite';
 import { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 import * as schema from '../db/schema.ts';
 import { oracleDocuments } from '../db/schema.ts';
+import { tenantIdForWrite } from '../middleware/tenant.ts';
 import type { VectorStoreAdapter } from '../vector/types.ts';
 import type { OracleDocument } from '../types.ts';
 
@@ -19,9 +20,10 @@ export async function storeDocuments(
   vectorClient: VectorStoreAdapter | null,
   project: string | null,
   documents: OracleDocument[],
-  opts: { createdBy?: string } = {}
+  opts: { createdBy?: string; tenantId?: string } = {}
 ): Promise<void> {
   const now = Date.now();
+  const tenantId = opts.tenantId ?? tenantIdForWrite();
 
   // Prepare FTS statements. FTS5 virtual tables have no UNIQUE constraint on
   // the id column (it's UNINDEXED), so INSERT OR REPLACE doesn't dedupe —
@@ -50,6 +52,7 @@ export async function storeDocuments(
       db.insert(oracleDocuments)
         .values({
           id: doc.id,
+          tenantId,
           type: doc.type,
           sourceFile: doc.source_file,
           concepts: JSON.stringify(doc.concepts),
@@ -62,6 +65,7 @@ export async function storeDocuments(
         .onConflictDoUpdate({
           target: oracleDocuments.id,
           set: {
+            tenantId,
             type: doc.type,
             sourceFile: doc.source_file,
             concepts: JSON.stringify(doc.concepts),
@@ -86,6 +90,7 @@ export async function storeDocuments(
       contents.push(doc.content);
       metadatas.push({
         type: doc.type,
+        tenant_id: tenantId,
         source_file: doc.source_file,
         concepts: doc.concepts.join(',')
       });

--- a/src/routes/indexer/reindex.ts
+++ b/src/routes/indexer/reindex.ts
@@ -1,6 +1,7 @@
 import { Elysia, t } from 'elysia';
 import { runOracleReindex, resolveIndexerRepoRoot } from '../../indexer/runner.ts';
 import { indexRetrospectives, indexRetroFile } from '../../indexer/retro-index.ts';
+import { currentTenantId, runWithTenant } from '../../middleware/tenant.ts';
 
 type ReindexResult =
   | Awaited<ReturnType<typeof runOracleReindex>>
@@ -22,7 +23,7 @@ const defaultDeps: ReindexDeps = {
 };
 
 export function createReindexRoute(deps: ReindexDeps = defaultDeps) {
-  let activeJob: { id: string; startedAt: string } | null = null;
+  const activeJobs = new Map<string, { id: string; startedAt: string }>();
 
   return new Elysia().post('/indexer/reindex', async ({ body, set }) => {
     const requested = body ?? {};
@@ -31,6 +32,9 @@ export function createReindexRoute(deps: ReindexDeps = defaultDeps) {
     const append = requested.append === true;
     const repoRoot = deps.resolveRepoRoot(requested.repoRoot);
     const jobId = `reindex-${Date.now()}`;
+    const tenantId = currentTenantId();
+    const jobKey = tenantId ?? '*';
+    const activeJob = activeJobs.get(jobKey) ?? null;
 
     if (activeJob) {
       set.status = 409;
@@ -46,15 +50,15 @@ export function createReindexRoute(deps: ReindexDeps = defaultDeps) {
       return deps.runFull({ repoRoot, append });
     };
 
-    activeJob = { id: jobId, startedAt: new Date().toISOString() };
-    const task = run()
+    activeJobs.set(jobKey, { id: jobId, startedAt: new Date().toISOString() });
+    const task = runWithTenant(tenantId, run)
       .then((result) => ({ jobId, status: 'complete' as const, ...result }))
       .catch((err) => {
         const message = err instanceof Error ? err.message : String(err);
         return { ok: false as const, jobId, status: 'error' as const, repoRoot, error: message };
       })
       .finally(() => {
-        activeJob = null;
+        activeJobs.delete(jobKey);
       });
 
     if (wait) return await task;

--- a/src/routes/indexer/start.ts
+++ b/src/routes/indexer/start.ts
@@ -3,102 +3,128 @@ import { createVectorStoreForModel, getEmbeddingModels } from '../../vector/fact
 import { createDatabase } from '../../db/index.ts';
 import { setIndexingStatus } from '../../indexer/status.ts';
 import { DB_PATH, REPO_ROOT } from '../../config.ts';
+import { currentTenantId, runWithTenant } from '../../middleware/tenant.ts';
 import type { IndexerConfig } from '../../types.ts';
 
 let abortFlag = false;
 export function getAbortFlag() { return abortFlag; }
 export function setAbortFlag(v: boolean) { abortFlag = v; }
 
-export const startEndpoint = new Elysia().post('/indexer/start', async ({ body }) => {
-  const { model, sourcePath, batchSize } = body;
+type Models = ReturnType<typeof getEmbeddingModels>;
+type DatabaseConnection = ReturnType<typeof createDatabase>;
+type VectorStoreFactory = typeof createVectorStoreForModel;
 
-  const models = getEmbeddingModels();
-  const key = model && models[model] ? model : 'nomic';
-  const preset = models[key];
-  const batch = batchSize || (key === 'nomic' ? 100 : 50);
+export interface StartRouteDeps {
+  createDb?: (dbPath: string) => DatabaseConnection;
+  createStore?: VectorStoreFactory;
+  dbPath?: string;
+  getModels?: () => Models;
+  repoRoot?: string;
+  runInBackground?: (task: Promise<void>) => void;
+}
 
-  const { db, sqlite } = createDatabase(DB_PATH);
-  const config: IndexerConfig = {
-    repoRoot: sourcePath || REPO_ROOT,
-    dbPath: DB_PATH,
-    chromaPath: '',
-    sourcePaths: {
-      resonance: 'ψ/memory/resonance',
-      learnings: 'ψ/memory/learnings',
-      retrospectives: 'ψ/memory/retrospectives',
-      distillations: 'ψ/memory/distillations',
-      learn: 'ψ/learn',
-    },
-  };
+export function createStartRoute(deps: StartRouteDeps = {}) {
+  return new Elysia().post('/indexer/start', async ({ body }) => {
+    const { model, sourcePath, batchSize } = body;
 
-  const store = createVectorStoreForModel(preset);
+    const models = (deps.getModels ?? getEmbeddingModels)();
+    const key = model && models[model] ? model : 'nomic';
+    const preset = models[key];
+    const batch = batchSize || (key === 'nomic' ? 100 : 50);
 
-  abortFlag = false;
+    const dbPath = deps.dbPath ?? DB_PATH;
+    const repoRoot = sourcePath || deps.repoRoot || REPO_ROOT;
+    const tenantId = currentTenantId();
+    const { sqlite } = (deps.createDb ?? createDatabase)(dbPath);
+    const config: IndexerConfig = {
+      repoRoot,
+      dbPath,
+      chromaPath: '',
+      sourcePaths: {
+        resonance: 'ψ/memory/resonance',
+        learnings: 'ψ/memory/learnings',
+        retrospectives: 'ψ/memory/retrospectives',
+        distillations: 'ψ/memory/distillations',
+        learn: 'ψ/learn',
+      },
+    };
 
-  const jobId = `idx-${Date.now()}`;
+    const store = (deps.createStore ?? createVectorStoreForModel)(preset);
 
-  // Run indexing in background
-  (async () => {
-    try {
-      await store.connect();
-      try { await store.deleteCollection(); } catch {}
-      await store.ensureCollection();
+    abortFlag = false;
 
-      const rows = sqlite.prepare(`
-        SELECT d.id, d.type, GROUP_CONCAT(f.content, '\n') as content, d.source_file, d.concepts, d.project, d.created_at
+    const jobId = `idx-${Date.now()}`;
+
+    // Run indexing in background
+    const task = runWithTenant(tenantId, async () => {
+      try {
+        await store.connect();
+        try { await store.deleteCollection(); } catch {}
+        await store.ensureCollection();
+
+        const tenantWhere = tenantId ? 'WHERE d.tenant_id = ?' : '';
+        const rows = sqlite.prepare(`
+        SELECT d.id, d.tenant_id, d.type, GROUP_CONCAT(f.content, '\n') as content,
+          d.source_file, d.concepts, d.project, d.created_at
         FROM oracle_documents d
         JOIN oracle_fts f ON d.id = f.id
+        ${tenantWhere}
         GROUP BY d.id
         ORDER BY d.created_at DESC
-      `).all() as Array<{
-        id: string; type: string; content: string;
-        source_file: string; concepts: string; project: string | null; created_at: string;
-      }>;
+      `).all(...(tenantId ? [tenantId] : [])) as Array<{
+          id: string; tenant_id: string; type: string; content: string;
+          source_file: string; concepts: string; project: string | null; created_at: string;
+        }>;
 
-      const total = rows.length;
-      setIndexingStatus(sqlite, config, true, 0, total);
+        const total = rows.length;
+        setIndexingStatus(sqlite, config, true, 0, total);
 
-      for (let i = 0; i < rows.length; i += batch) {
-        if (abortFlag) {
-          setIndexingStatus(sqlite, config, false, i, total, 'Cancelled by user');
-          break;
+        for (let i = 0; i < rows.length; i += batch) {
+          if (abortFlag) {
+            setIndexingStatus(sqlite, config, false, i, total, 'Cancelled by user');
+            break;
+          }
+
+          const batchRows = rows.slice(i, i + batch);
+          const docs = batchRows.map(row => ({
+            id: row.id,
+            document: row.content,
+            metadata: {
+              type: row.type,
+              source_file: row.source_file,
+              concepts: row.concepts,
+              tenant_id: row.tenant_id,
+              ...(row.project && { project: row.project }),
+            },
+          }));
+
+          await store.addDocuments(docs);
+          setIndexingStatus(sqlite, config, true, i + batchRows.length, total);
         }
 
-        const batchRows = rows.slice(i, i + batch);
-        const docs = batchRows.map(row => ({
-          id: row.id,
-          document: row.content,
-          metadata: {
-            type: row.type,
-            source_file: row.source_file,
-            concepts: row.concepts,
-            ...(row.project && { project: row.project }),
-          },
-        }));
-
-        await store.addDocuments(docs);
-        setIndexingStatus(sqlite, config, true, i + batchRows.length, total);
+        if (!abortFlag) {
+          setIndexingStatus(sqlite, config, false, rows.length, rows.length);
+        }
+        await store.close();
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        setIndexingStatus(sqlite, config, false, 0, 0, msg);
       }
+    });
+    (deps.runInBackground ?? ((backgroundTask) => { void backgroundTask; }))(task);
 
-      if (!abortFlag) {
-        setIndexingStatus(sqlite, config, false, rows.length, rows.length);
-      }
-      await store.close();
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      setIndexingStatus(sqlite, config, false, 0, 0, msg);
-    }
-  })();
+    return { jobId, status: 'started', model: key, batchSize: batch, tenantId };
+  }, {
+    body: t.Object({
+      model: t.Optional(t.String()),
+      sourcePath: t.Optional(t.String()),
+      batchSize: t.Optional(t.Number()),
+    }),
+    detail: {
+      tags: ['indexer'],
+      summary: 'Start vector indexing job',
+    },
+  });
+}
 
-  return { jobId, status: 'started', model: key, batchSize: batch };
-}, {
-  body: t.Object({
-    model: t.Optional(t.String()),
-    sourcePath: t.Optional(t.String()),
-    batchSize: t.Optional(t.Number()),
-  }),
-  detail: {
-    tags: ['indexer'],
-    summary: 'Start vector indexing job',
-  },
-});
+export const startEndpoint = createStartRoute();

--- a/tests/http/indexer/basic.test.ts
+++ b/tests/http/indexer/basic.test.ts
@@ -1,8 +1,24 @@
-import { describe, expect, test } from 'bun:test';
-import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { afterAll, describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { Database } from 'bun:sqlite';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { indexerRoutes } from '../../../src/routes/indexer/index.ts';
+import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
+import type { VectorStoreAdapter, VectorDocument } from '../../../src/vector/types.ts';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const isolatedDataDir = mkdtempSync(join(tmpdir(), 'indexer-http-'));
+process.env.ORACLE_DATA_DIR = isolatedDataDir;
+
+const { createStartRoute } = await import('../../../src/routes/indexer/start.ts');
+const { indexerRoutes } = await import('../../../src/routes/indexer/index.ts');
+
+afterAll(() => {
+  rmSync(isolatedDataDir, { recursive: true, force: true });
+  if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = savedDataDir;
+});
 
 function request(path: string, init: RequestInit = {}) {
   return indexerRoutes.handle(new Request(`http://local${path}`, init));
@@ -64,4 +80,84 @@ describe('indexer HTTP routes', () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ stopped: true });
   });
+
+  test('POST /api/indexer/start scopes vector indexing by tenant', async () => {
+    const sqlite = tenantIndexerDb();
+    const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const tenantA = `tenant-a-${stamp}`;
+    const tenantB = `tenant-b-${stamp}`;
+    seedDoc(sqlite, `idx-a-${stamp}`, tenantA, `alpha ${stamp}`, 2);
+    seedDoc(sqlite, `idx-b-${stamp}`, tenantB, `beta ${stamp}`, 1);
+    const added: VectorDocument[] = [];
+    const tasks: Promise<void>[] = [];
+    const app = new Elysia({ prefix: '/api' }).use(createStartRoute({
+      createDb: () => ({ sqlite } as any),
+      createStore: () => fakeStore(added),
+      getModels: () => ({ nomic: { collection: 'test', model: 'nomic-embed-text' } }),
+      runInBackground: (task) => tasks.push(task),
+    }));
+
+    try {
+      const res = await createTenantFetch((request) => app.handle(request))(new Request('http://local/api/indexer/start', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', [TENANT_HEADER]: tenantA },
+        body: JSON.stringify({ model: 'nomic', batchSize: 10 }),
+      }));
+      const body = await res.json() as Record<string, unknown>;
+      await Promise.all(tasks);
+      const status = sqlite.prepare('SELECT progress_total FROM indexing_status WHERE id = 1').get() as any;
+
+      expect(res.status).toBe(200);
+      expect(body.tenantId).toBe(tenantA);
+      expect(added.map((doc) => doc.id)).toEqual([`idx-a-${stamp}`]);
+      expect(added[0].document).toContain('alpha');
+      expect(added[0].metadata.tenant_id).toBe(tenantA);
+      expect(status.progress_total).toBe(1);
+    } finally {
+      sqlite.close();
+    }
+  });
 });
+
+function tenantIndexerDb() {
+  const sqlite = new Database(':memory:');
+  sqlite.exec(`
+    CREATE TABLE oracle_documents (
+      id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, type TEXT NOT NULL,
+      source_file TEXT NOT NULL, concepts TEXT NOT NULL, project TEXT,
+      created_at INTEGER NOT NULL
+    );
+    CREATE TABLE oracle_fts (id TEXT, content TEXT, concepts TEXT);
+    CREATE TABLE indexing_status (
+      id INTEGER PRIMARY KEY, is_indexing INTEGER DEFAULT 0 NOT NULL,
+      progress_current INTEGER DEFAULT 0, progress_total INTEGER DEFAULT 0,
+      started_at INTEGER, completed_at INTEGER, error TEXT, repo_root TEXT
+    );
+    INSERT INTO indexing_status (id, is_indexing) VALUES (1, 0);
+  `);
+  return sqlite;
+}
+
+function seedDoc(sqlite: Database, id: string, tenantId: string, content: string, createdAt: number) {
+  sqlite.prepare(`
+    INSERT INTO oracle_documents
+      (id, tenant_id, type, source_file, concepts, project, created_at)
+    VALUES (?, ?, 'learning', ?, '[]', ?, ?)
+  `).run(id, tenantId, `ψ/${id}.md`, tenantId, createdAt);
+  sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)').run(id, content, 'tenant');
+}
+
+function fakeStore(added: VectorDocument[]): VectorStoreAdapter {
+  return {
+    name: 'fake-indexer-store',
+    connect: async () => {},
+    close: async () => {},
+    ensureCollection: async () => {},
+    deleteCollection: async () => {},
+    addDocuments: async (docs) => { added.push(...docs); },
+    query: async () => ({ ids: [], documents: [], distances: [], metadatas: [] }),
+    queryById: async () => ({ ids: [], documents: [], distances: [], metadatas: [] }),
+    getStats: async () => ({ count: added.length }),
+    getCollectionInfo: async () => ({ count: added.length, name: 'fake-indexer-store' }),
+  };
+}


### PR DESCRIPTION
## Summary
- scope indexer storage writes and indexer-owned cleanup queries to the active tenant
- scope vector indexing start jobs to the request tenant and include tenant metadata
- isolate concurrent reindex jobs per tenant and add HTTP coverage for tenant-scoped vector indexing

## Validation
- bun test tests/http/indexer/
- bunx tsc --noEmit
- git diff --check
- wc -l changed files <= 250

Closes slice of #1650