### PR TITLE
fix(supersede): scope document updates by tenant

### DIFF
--- a/src/tools/supersede.ts
+++ b/src/tools/supersede.ts
@@ -5,8 +5,9 @@
  * "Nothing is Deleted" — old doc preserved but marked outdated.
  */
 
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { oracleDocuments } from '../db/schema.ts';
+import { currentTenantId } from '../middleware/tenant.ts';
 import type { ToolContext, ToolResponse, OracleSupersededInput } from './types.ts';
 
 type SupersedeRunResult = {
@@ -88,13 +89,17 @@ export function runSupersede(db: ToolContext['db'], input: OracleSupersededInput
   }
 
   const now = Date.now();
+  const tenantId = currentTenantId();
+  const docWhere = (id: string) => tenantId
+    ? and(eq(oracleDocuments.id, id), eq(oracleDocuments.tenantId, tenantId))
+    : eq(oracleDocuments.id, id);
   const oldDoc = db.select({ id: oracleDocuments.id, type: oracleDocuments.type })
     .from(oracleDocuments)
-    .where(eq(oracleDocuments.id, oldId))
+    .where(docWhere(oldId))
     .get();
   const newDoc = db.select({ id: oracleDocuments.id, type: oracleDocuments.type })
     .from(oracleDocuments)
-    .where(eq(oracleDocuments.id, newId))
+    .where(docWhere(newId))
     .get();
 
   if (!oldDoc) throw new Error(`Old document not found: ${oldId}`);
@@ -106,7 +111,7 @@ export function runSupersede(db: ToolContext['db'], input: OracleSupersededInput
       supersededAt: now,
       supersededReason: typeof reason === 'string' ? reason : null,
     })
-    .where(eq(oracleDocuments.id, oldId))
+    .where(docWhere(oldId))
     .run();
 
   console.error(`[SUPERSEDE] ${oldId} → superseded by → ${newId}`);

--- a/tests/http/supersede/tenant-isolation.test.ts
+++ b/tests/http/supersede/tenant-isolation.test.ts
@@ -1,0 +1,106 @@
+import { afterAll, expect, test } from 'bun:test';
+import { inArray } from 'drizzle-orm';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tempData = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-supersede-db-'));
+const previousData = process.env.ORACLE_DATA_DIR;
+const previousDb = process.env.ORACLE_DB_PATH;
+process.env.ORACLE_DATA_DIR = tempData;
+process.env.ORACLE_DB_PATH = path.join(tempData, 'oracle.db');
+
+const dbModule = await import('../../../src/db/index.ts');
+dbModule.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+const { oracleDocuments } = dbModule;
+const { createTenantFetch, TENANT_HEADER } = await import('../../../src/middleware/tenant.ts');
+const { supersedeRoutes } = await import('../../../src/routes/supersede/index.ts');
+
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantA = `tenant-a-${stamp}`;
+const tenantB = `tenant-b-${stamp}`;
+const ids = {
+  aOld: `sup-a-old-${stamp}`,
+  aNew: `sup-a-new-${stamp}`,
+  bOld: `sup-b-old-${stamp}`,
+  bNew: `sup-b-new-${stamp}`,
+};
+const paths = Object.fromEntries(Object.entries(ids).map(([key, id]) => [key, `ψ/memory/${id}.md`])) as Record<keyof typeof ids, string>;
+
+function requestSupersede(tenantId: string, pathname: string, init: RequestInit = {}) {
+  return createTenantFetch((request) => supersedeRoutes.handle(request))(new Request(`http://local${pathname}`, {
+    ...init,
+    headers: { 'content-type': 'application/json', [TENANT_HEADER]: tenantId, ...(init.headers ?? {}) },
+  }));
+}
+
+function insertDoc(id: string, tenantId: string, sourceFile: string) {
+  const now = Date.now();
+  dbModule.db.insert(oracleDocuments).values({
+    id,
+    tenantId,
+    type: 'learning',
+    sourceFile,
+    concepts: JSON.stringify([tenantId]),
+    createdAt: now,
+    updatedAt: now,
+    indexedAt: now,
+    project: `project-${tenantId}`,
+    createdBy: 'tenant-test',
+  }).run();
+}
+
+insertDoc(ids.aOld, tenantA, paths.aOld);
+insertDoc(ids.aNew, tenantA, paths.aNew);
+insertDoc(ids.bOld, tenantB, paths.bOld);
+insertDoc(ids.bNew, tenantB, paths.bNew);
+
+afterAll(() => {
+  dbModule.db.delete(oracleDocuments).where(inArray(oracleDocuments.id, Object.values(ids))).run();
+  dbModule.closeDb();
+  if (previousData === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = previousData;
+  if (previousDb === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = previousDb;
+  fs.rmSync(tempData, { recursive: true, force: true });
+});
+
+test('/api/supersede/document updates only docs visible to the active tenant', async () => {
+  const allowed = await requestSupersede(tenantA, '/api/supersede/document', {
+    method: 'POST',
+    body: JSON.stringify({ oldId: ids.aOld, newId: ids.aNew, reason: 'tenant scoped' }),
+  });
+  expect(allowed.status).toBe(200);
+  expect(supersededBy(ids.aOld)).toBe(ids.aNew);
+
+  const denied = await requestSupersede(tenantA, '/api/supersede/document', {
+    method: 'POST',
+    body: JSON.stringify({ oldId: ids.bOld, newId: ids.bNew, reason: 'cross tenant' }),
+  });
+  const body = await denied.json() as { error: string };
+
+  expect(denied.status).toBe(404);
+  expect(body.error).toMatch(/Old document not found/);
+  expect(supersededBy(ids.bOld)).toBeNull();
+});
+
+test('/api/supersede list and chain stay tenant scoped after document updates', async () => {
+  const list = await requestSupersede(tenantA, '/api/supersede?limit=10');
+  const chain = await requestSupersede(tenantA, `/api/supersede/chain/${encodeURIComponent(paths.aOld)}`);
+  const deniedChain = await requestSupersede(tenantB, `/api/supersede/chain/${encodeURIComponent(paths.aOld)}`);
+  const listBody = await list.json() as { supersessions: Array<{ old_id: string }> };
+  const chainBody = await chain.json() as { superseded_by: Array<{ new_path: string }> };
+
+  expect(list.status).toBe(200);
+  expect(listBody.supersessions.map((item) => item.old_id)).toContain(ids.aOld);
+  expect(listBody.supersessions.map((item) => item.old_id)).not.toContain(ids.bOld);
+  expect(chainBody.superseded_by.map((item) => item.new_path)).toContain(paths.aNew);
+  expect(await deniedChain.json()).toEqual({ superseded_by: [], supersedes: [] });
+});
+
+function supersededBy(id: string): string | null {
+  return dbModule.db.select({ supersededBy: oracleDocuments.supersededBy })
+    .from(oracleDocuments)
+    .where(inArray(oracleDocuments.id, [id]))
+    .get()?.supersededBy ?? null;
+}


### PR DESCRIPTION
## Summary
- scope supersede document lookups and updates to the active tenant context
- keep non-tenant callers backward compatible by only filtering when a tenant is active
- add HTTP supersede tenant isolation coverage for document updates, list, and chain

## Tests
- bun test tests/http/supersede/
- bunx tsc --noEmit
- wc -l src/tools/supersede.ts tests/http/supersede/tenant-isolation.test.ts