### PR TITLE
fix(vector): unify provider auto-detection

### DIFF
--- a/src/vector/auto-detect.ts
+++ b/src/vector/auto-detect.ts
@@ -1,3 +1,8 @@
+import {
+  clearProviderDetectionCache,
+  getDetectedEmbeddingProviders,
+  type ProviderDetectionOptions,
+} from './provider-detection.ts';
 import type { EmbeddingProviderType } from './types.ts';
 
 export type AutoDetectProvider = Extract<
@@ -13,90 +18,31 @@ export interface AutoDetectedEmbeddingProvider {
   models?: string[];
 }
 
-export interface DetectEmbeddingProvidersOptions {
-  env?: Record<string, string | undefined>;
-  fetcher?: typeof fetch;
+export interface DetectEmbeddingProvidersOptions extends ProviderDetectionOptions {
   force?: boolean;
-  ollamaUrl?: string;
-  timeoutMs?: number;
 }
 
-let cachedProviders: AutoDetectedEmbeddingProvider[] | null = null;
+const AUTO_DETECT_PROVIDERS = new Set<EmbeddingProviderType>([
+  'ollama',
+  'openai',
+  'gemini',
+  'cloudflare-ai',
+]);
 
 export async function detectEmbeddingProviders(
   options: DetectEmbeddingProvidersOptions = {},
 ): Promise<AutoDetectedEmbeddingProvider[]> {
-  if (cachedProviders && !options.force) return cloneProviders(cachedProviders);
-
-  const env = options.env ?? process.env;
-  const providers: AutoDetectedEmbeddingProvider[] = [
-    await detectOllama(options),
-    envProvider('openai', hasAnyEnv(env, 'OPENAI_API_KEY'), [
-      'text-embedding-3-small',
-      'text-embedding-3-large',
-    ]),
-    envProvider('gemini', hasAnyEnv(env, 'GEMINI_API_KEY', 'GOOGLE_API_KEY'), ['text-embedding-004']),
-    envProvider('cloudflare-ai', hasCloudflareCredentials(env), ['@cf/baai/bge-m3']),
-  ];
-
-  cachedProviders = providers;
-  return cloneProviders(providers);
+  const { force, ...detectOptions } = options;
+  const result = await getDetectedEmbeddingProviders(Boolean(force), detectOptions);
+  return result.providers
+    .filter((provider) => AUTO_DETECT_PROVIDERS.has(provider.type))
+    .map((provider) => ({
+      provider: provider.type as AutoDetectProvider,
+      status: provider.available ? 'available' : 'unavailable',
+      ...(provider.available && { models: [...provider.models] }),
+    }));
 }
 
 export function clearEmbeddingProviderAutoDetectCache(): void {
-  cachedProviders = null;
-}
-
-async function detectOllama(
-  options: DetectEmbeddingProvidersOptions,
-): Promise<AutoDetectedEmbeddingProvider> {
-  const fetcher = options.fetcher ?? fetch;
-  const baseUrl = options.ollamaUrl ?? options.env?.OLLAMA_BASE_URL ?? 'http://localhost:11434';
-
-  try {
-    const response = await fetcher(`${baseUrl}/api/tags`, {
-      signal: AbortSignal.timeout(options.timeoutMs ?? 1500),
-    });
-    if (!response.ok) return unavailable('ollama');
-
-    const body = await response.json() as { models?: Array<{ name?: string }> };
-    const models = (body.models ?? [])
-      .map((model) => model.name)
-      .filter((name): name is string => Boolean(name?.trim()));
-
-    return { provider: 'ollama', status: 'available', models };
-  } catch {
-    return unavailable('ollama');
-  }
-}
-
-function envProvider(
-  provider: AutoDetectProvider,
-  available: boolean,
-  models: string[],
-): AutoDetectedEmbeddingProvider {
-  if (!available) return unavailable(provider);
-  return { provider, status: 'available', models };
-}
-
-function unavailable(provider: AutoDetectProvider): AutoDetectedEmbeddingProvider {
-  return { provider, status: 'unavailable' };
-}
-
-function hasCloudflareCredentials(env: Record<string, string | undefined>): boolean {
-  return (hasAnyEnv(env, 'CF_ACCOUNT_ID') && hasAnyEnv(env, 'CF_API_TOKEN'))
-    || (hasAnyEnv(env, 'CLOUDFLARE_ACCOUNT_ID') && hasAnyEnv(env, 'CLOUDFLARE_API_TOKEN'));
-}
-
-function hasAnyEnv(env: Record<string, string | undefined>, ...keys: string[]): boolean {
-  return keys.some((key) => Boolean(env[key]?.trim()));
-}
-
-function cloneProviders(
-  providers: AutoDetectedEmbeddingProvider[],
-): AutoDetectedEmbeddingProvider[] {
-  return providers.map((provider) => ({
-    ...provider,
-    models: provider.models ? [...provider.models] : undefined,
-  }));
+  clearProviderDetectionCache();
 }

--- a/src/vector/provider-detection.ts
+++ b/src/vector/provider-detection.ts
@@ -1,5 +1,11 @@
 import type { EmbeddingProviderType } from './types.ts';
 
+export const DETECTED_PROVIDER_MODELS = {
+  openai: ['text-embedding-3-small', 'text-embedding-3-large'],
+  gemini: ['text-embedding-004'],
+  'cloudflare-ai': ['@cf/baai/bge-m3'],
+} as const;
+
 export interface DetectedEmbeddingProvider {
   type: EmbeddingProviderType;
   available: boolean;
@@ -42,6 +48,7 @@ function provider(
 async function detectOllama(options: ProviderDetectionOptions): Promise<DetectedEmbeddingProvider> {
   const fetcher = options.fetcher ?? fetch;
   const base = options.ollamaUrl || options.env?.OLLAMA_BASE_URL || 'http://localhost:11434';
+  const configured = Boolean(options.ollamaUrl || options.env?.OLLAMA_BASE_URL);
   try {
     const res = await fetcher(`${base}/api/tags`, { signal: AbortSignal.timeout(options.timeoutMs ?? 1500) });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -54,7 +61,7 @@ async function detectOllama(options: ProviderDetectionOptions): Promise<Detected
       capabilities: ['embed', 'local', 'models:list'],
     });
   } catch (error) {
-    return provider('ollama', false, {
+    return provider('ollama', configured, {
       source: 'probe',
       available: false,
       capabilities: ['embed', 'local', 'models:list'],
@@ -73,15 +80,15 @@ export async function detectEmbeddingProviders(
   const providers = [
     await detectOllama({ ...options, env }),
     provider('openai', has(env, 'OPENAI_API_KEY'), {
-      models: has(env, 'OPENAI_API_KEY') ? ['text-embedding-3-small', 'text-embedding-3-large'] : [],
+      models: has(env, 'OPENAI_API_KEY') ? [...DETECTED_PROVIDER_MODELS.openai] : [],
       capabilities: ['embed', 'remote'],
     }),
     provider('gemini', geminiConfigured, {
-      models: geminiConfigured ? ['text-embedding-004'] : [],
+      models: geminiConfigured ? [...DETECTED_PROVIDER_MODELS.gemini] : [],
       capabilities: ['embed', 'remote', 'free-tier'],
     }),
     provider('cloudflare-ai', cfConfigured, {
-      models: cfConfigured ? ['@cf/baai/bge-base-en-v1.5'] : [],
+      models: cfConfigured ? [...DETECTED_PROVIDER_MODELS['cloudflare-ai']] : [],
       capabilities: ['embed', 'remote', 'edge'],
     }),
   ];

--- a/tests/http/vector/config-hot-reload.test.ts
+++ b/tests/http/vector/config-hot-reload.test.ts
@@ -23,8 +23,11 @@ process.env.ORACLE_VECTOR_HEALTH_TIMEOUT = '500';
 const oldProxy = startProxy('old-proxy', 11);
 const newProxy = startProxy('new-proxy', 22);
 const vectorConfig = await import('../../../src/vector/config.ts');
-const { vectorRoutes } = await import('../../../src/routes/vector/index.ts');
-const app = new Elysia().use(vectorRoutes);
+const { vectorConfigEndpoint } = await import('../../../src/routes/vector/config.ts');
+const { vectorDocumentsEndpoint } = await import('../../../src/routes/vector/documents.ts');
+const app = new Elysia({ prefix: '/api' })
+  .use(vectorDocumentsEndpoint)
+  .use(vectorConfigEndpoint);
 const versionedFetch = createApiVersionedFetch((request) => app.handle(request));
 
 function startProxy(name: string, count: number): ProxyHarness {

--- a/tests/vector/config-provider-local.test.ts
+++ b/tests/vector/config-provider-local.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'bun:test';
 import { configToModels, generateDefaultConfig } from '../../src/vector/config.ts';
 
-test('vector config maps legacy ollama collection provider to local embedder', () => {
+test('vector config maps legacy ollama collection provider to Ollama embedder', () => {
   const base = generateDefaultConfig();
   const models = configToModels({
     ...base,
@@ -9,5 +9,5 @@ test('vector config maps legacy ollama collection provider to local embedder', (
     collections: { local: { collection: 'local_c', model: 'local-model', provider: 'ollama' } },
   });
 
-  expect(models.local.embedder).toEqual({ backend: 'local', model: 'local-model' });
+  expect(models.local.embedder).toEqual({ backend: 'ollama', model: 'local-model' });
 });

--- a/tests/vector/embeddings-ollama-http-error.test.ts
+++ b/tests/vector/embeddings-ollama-http-error.test.ts
@@ -6,5 +6,5 @@ test('ollama embedder surfaces HTTP errors from the local embedding server', asy
   const target = startServer(() => new Response('ollama down', { status: 500 }));
   const provider = new OllamaEmbeddings({ baseUrl: target, model: 'nomic-embed-text' });
 
-  await expect(provider.embed(['hello'])).rejects.toThrow(/Ollama API error: ollama down/);
+  await expect(provider.embed(['hello'])).rejects.toThrow(/Ollama API error \(500\): ollama down/);
 });

--- a/tests/vector/embeddings-ollama-passage-prefix.test.ts
+++ b/tests/vector/embeddings-ollama-passage-prefix.test.ts
@@ -5,7 +5,7 @@ import { startServer } from './helpers.ts';
 test('ollama embedder prefixes BGE passage prompts', async () => {
   let prompt = '';
   const target = startServer(async (req) => {
-    prompt = ((await req.json()) as any).prompt;
+    prompt = ((await req.json()) as any).input[0];
     return Response.json({ embedding: [1, 2] });
   });
   const provider = new OllamaEmbeddings({ baseUrl: target, model: 'bge-m3' });

--- a/tests/vector/embeddings-ollama-query-prefix.test.ts
+++ b/tests/vector/embeddings-ollama-query-prefix.test.ts
@@ -5,7 +5,7 @@ import { startServer } from './helpers.ts';
 test('ollama embedder prefixes BGE query prompts', async () => {
   let prompt = '';
   const target = startServer(async (req) => {
-    prompt = ((await req.json()) as any).prompt;
+    prompt = ((await req.json()) as any).input[0];
     return Response.json({ embedding: [1, 2, 3] });
   });
   const provider = new OllamaEmbeddings({ baseUrl: target, model: 'bge-m3' });

--- a/tests/vector/embeddings-ollama-qwen-query-prefix.test.ts
+++ b/tests/vector/embeddings-ollama-qwen-query-prefix.test.ts
@@ -5,7 +5,7 @@ import { startServer } from './helpers.ts';
 test('ollama embedder uses qwen3 instruction prompts for queries', async () => {
   let prompt = '';
   const target = startServer(async (req) => {
-    prompt = ((await req.json()) as any).prompt;
+    prompt = ((await req.json()) as any).input[0];
     return Response.json({ embedding: [1] });
   });
   const provider = new OllamaEmbeddings({ baseUrl: target, model: 'qwen3-embedding' });

--- a/tests/vector/embeddings-ollama-truncation.test.ts
+++ b/tests/vector/embeddings-ollama-truncation.test.ts
@@ -5,7 +5,7 @@ import { startServer } from './helpers.ts';
 test('ollama embedder truncates very long prompts before embedding', async () => {
   let prompt = '';
   const target = startServer(async (req) => {
-    prompt = ((await req.json()) as any).prompt;
+    prompt = ((await req.json()) as any).input[0];
     return Response.json({ embedding: [1] });
   });
   const provider = new OllamaEmbeddings({ baseUrl: target, model: 'nomic-embed-text' });

--- a/tests/vector/provider-detection.test.ts
+++ b/tests/vector/provider-detection.test.ts
@@ -36,3 +36,21 @@ test('provider detection warmup seeds startup cache', async () => {
   expect(fetcher).toHaveBeenCalledTimes(1);
   clearProviderDetectionCache();
 });
+
+test('provider detection keeps configured Ollama URL visible when probe fails', async () => {
+  clearProviderDetectionCache();
+  const fetcher = mock(async () => new Response('down', { status: 503 })) as unknown as typeof fetch;
+
+  const result = await getDetectedEmbeddingProviders(true, {
+    env: { OLLAMA_BASE_URL: 'http://ollama.internal' },
+    fetcher,
+  });
+
+  expect(result.providers[0]).toMatchObject({
+    type: 'ollama',
+    configured: true,
+    available: false,
+    error: 'HTTP 503',
+  });
+  clearProviderDetectionCache();
+});


### PR DESCRIPTION
## Summary
- route the legacy vector auto-detect helper through the richer provider detection cache so Phase 1 has one source of truth
- keep configured Ollama endpoints visible when probes fail and align Cloudflare AI detection with the active `@cf/baai/bge-m3` embedder model
- isolate the config hot-reload HTTP test from unrelated vector route imports and refresh stale Ollama unit expectations for the current `/api/embed` payload

## Verification
- `git diff --check`
- `bunx tsc --noEmit`
- `bun test tests/http/vector/`
- `bun test tests/vector/`

Part of #1436 / #1437 Phase 1.