### PR TITLE
fix(tenant): scope traces and supersede routes

### DIFF
--- a/src/routes/supersede/chain.ts
+++ b/src/routes/supersede/chain.ts
@@ -6,16 +6,14 @@ import { Elysia } from 'elysia';
 import { and, eq } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/sqlite-core';
 import { db, oracleDocuments } from '../../db/index.ts';
-import { currentTenantId } from '../../middleware/tenant.ts';
+import { activeTenantId } from '../../middleware/tenant.ts';
 
 export const supersedeChainEndpoint = new Elysia().get(
   '/supersede/chain/:path',
   ({ params }) => {
     const docPath = decodeURIComponent(params.path);
-    const tenantId = currentTenantId();
-    const targetWhere = tenantId
-      ? and(eq(oracleDocuments.sourceFile, docPath), eq(oracleDocuments.tenantId, tenantId))
-      : eq(oracleDocuments.sourceFile, docPath);
+    const tenantId = activeTenantId();
+    const targetWhere = and(eq(oracleDocuments.sourceFile, docPath), eq(oracleDocuments.tenantId, tenantId));
 
     const target = db.select({ id: oracleDocuments.id })
       .from(oracleDocuments)
@@ -28,15 +26,9 @@ export const supersedeChainEndpoint = new Elysia().get(
 
     const newDoc = alias(oracleDocuments, 'new_doc');
 
-    const newDocJoin = tenantId
-      ? and(eq(oracleDocuments.supersededBy, newDoc.id), eq(newDoc.tenantId, tenantId))
-      : eq(oracleDocuments.supersededBy, newDoc.id);
-    const oldWhere = tenantId
-      ? and(eq(oracleDocuments.id, target.id), eq(oracleDocuments.tenantId, tenantId))
-      : eq(oracleDocuments.id, target.id);
-    const newWhere = tenantId
-      ? and(eq(oracleDocuments.supersededBy, target.id), eq(oracleDocuments.tenantId, tenantId))
-      : eq(oracleDocuments.supersededBy, target.id);
+    const newDocJoin = and(eq(oracleDocuments.supersededBy, newDoc.id), eq(newDoc.tenantId, tenantId));
+    const oldWhere = and(eq(oracleDocuments.id, target.id), eq(oracleDocuments.tenantId, tenantId));
+    const newWhere = and(eq(oracleDocuments.supersededBy, target.id), eq(oracleDocuments.tenantId, tenantId));
 
     const asOld = db.select({
       newPath: newDoc.sourceFile,

--- a/src/routes/supersede/create.ts
+++ b/src/routes/supersede/create.ts
@@ -6,10 +6,24 @@
  */
 
 import { Elysia } from 'elysia';
-import { db, supersedeLog } from '../../db/index.ts';
+import { and, eq } from 'drizzle-orm';
+import { db, oracleDocuments, supersedeLog } from '../../db/index.ts';
+import { activeTenantId } from '../../middleware/tenant.ts';
 import { runSupersede } from '../../tools/supersede.ts';
 import type { OracleSupersededInput } from '../../tools/types.ts';
 import { SupersedeBody, SupersedeDocumentBody } from './model.ts';
+
+function documentInActiveTenant(id: string): boolean {
+  return Boolean(db.select({ id: oracleDocuments.id }).from(oracleDocuments)
+    .where(and(eq(oracleDocuments.id, id), eq(oracleDocuments.tenantId, activeTenantId()))).get());
+}
+
+function tenantDocumentError(input: OracleSupersededInput): string | null {
+  const { oldId, newId } = input as { oldId?: unknown; newId?: unknown };
+  if (typeof oldId === 'string' && oldId && !documentInActiveTenant(oldId)) return `Old document not found: ${oldId}`;
+  if (typeof newId === 'string' && newId && !documentInActiveTenant(newId)) return `New document not found: ${newId}`;
+  return null;
+}
 
 export const supersedeCreateEndpoint = new Elysia().post(
   '/supersede',
@@ -36,10 +50,7 @@ export const supersedeCreateEndpoint = new Elysia().post(
       }).returning({ id: supersedeLog.id }).get();
 
       set.status = 201;
-      return {
-        id: result.id,
-        message: 'Supersession logged',
-      };
+      return { id: result.id, message: 'Supersession logged' };
     } catch (error) {
       set.status = 500;
       return { error: error instanceof Error ? error.message : 'Unknown error' };
@@ -47,11 +58,7 @@ export const supersedeCreateEndpoint = new Elysia().post(
   },
   {
     body: SupersedeBody,
-    detail: {
-      tags: ['supersede'],
-      menu: { group: 'hidden' },
-      summary: 'Append to legacy supersede_log',
-    },
+    detail: { tags: ['supersede'], menu: { group: 'hidden' }, summary: 'Append to legacy supersede_log' },
   },
 );
 
@@ -59,6 +66,11 @@ export const supersedeDocumentEndpoint = new Elysia().post(
   '/supersede/document',
   ({ body, set }) => {
     try {
+      const tenantError = tenantDocumentError(body as OracleSupersededInput);
+      if (tenantError) {
+        set.status = 404;
+        return { success: false, error: tenantError };
+      }
       const result = runSupersede(db, body as OracleSupersededInput);
       if (result.isError) set.status = 400;
       return result.payload;
@@ -70,9 +82,6 @@ export const supersedeDocumentEndpoint = new Elysia().post(
   },
   {
     body: SupersedeDocumentBody,
-    detail: {
-      tags: ['supersede'],
-      summary: 'Mark an indexed document as superseded by another document',
-    },
+    detail: { tags: ['supersede'], summary: 'Mark an indexed document as superseded by another document' },
   },
 );

--- a/src/routes/supersede/list.ts
+++ b/src/routes/supersede/list.ts
@@ -7,7 +7,7 @@ import { eq, isNotNull, desc, sql, and } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/sqlite-core';
 import { db, oracleDocuments } from '../../db/index.ts';
 import { SupersedeQuery } from './model.ts';
-import { currentTenantId } from '../../middleware/tenant.ts';
+import { activeTenantId } from '../../middleware/tenant.ts';
 
 export const supersedeListEndpoint = new Elysia().get(
   '/supersede',
@@ -16,10 +16,9 @@ export const supersedeListEndpoint = new Elysia().get(
     const limit = parseInt(query.limit ?? '50');
     const offset = parseInt(query.offset ?? '0');
 
-    const tenantId = currentTenantId();
-    const filters = [isNotNull(oracleDocuments.supersededBy)];
+    const tenantId = activeTenantId();
+    const filters = [isNotNull(oracleDocuments.supersededBy), eq(oracleDocuments.tenantId, tenantId)];
     if (project) filters.push(eq(oracleDocuments.project, project));
-    if (tenantId) filters.push(eq(oracleDocuments.tenantId, tenantId));
     const whereClause = and(...filters);
 
     const countResult = db.select({ total: sql<number>`count(*)` })
@@ -29,9 +28,7 @@ export const supersedeListEndpoint = new Elysia().get(
     const total = countResult?.total || 0;
 
     const newDoc = alias(oracleDocuments, 'new_doc');
-    const newDocJoin = tenantId
-      ? and(eq(oracleDocuments.supersededBy, newDoc.id), eq(newDoc.tenantId, tenantId))
-      : eq(oracleDocuments.supersededBy, newDoc.id);
+    const newDocJoin = and(eq(oracleDocuments.supersededBy, newDoc.id), eq(newDoc.tenantId, tenantId));
     const rows = db.select({
       oldId: oracleDocuments.id,
       oldPath: oracleDocuments.sourceFile,

--- a/src/routes/traces/chain.ts
+++ b/src/routes/traces/chain.ts
@@ -1,10 +1,10 @@
 import { Elysia } from 'elysia';
-import { getTraceChain } from '../../trace/handler.ts';
+import { getTenantTraceChain } from './tenant-scope.ts';
 import { traceIdParam, chainQuery } from './model.ts';
 
 export const traceChainRoute = new Elysia().get('/api/traces/:id/chain', ({ params, query }) => {
   const direction = (query.direction as 'up' | 'down' | 'both') || 'both';
-  return getTraceChain(params.id, direction);
+  return getTenantTraceChain(params.id, direction);
 }, {
   params: traceIdParam,
   query: chainQuery,

--- a/src/routes/traces/create.ts
+++ b/src/routes/traces/create.ts
@@ -1,6 +1,6 @@
 import { Elysia } from 'elysia';
 
-import { createTrace } from '../../trace/handler.ts';
+import { createTenantTrace } from './tenant-scope.ts';
 import { traceCreateBody } from './model.ts';
 import type { CreateTraceInput } from '../../trace/types.ts';
 
@@ -15,7 +15,13 @@ export const traceCreateRoute = new Elysia().post('/api/traces', ({ body, set })
     };
   }
 
-  const result = createTrace(input as CreateTraceInput);
+  let result;
+  try {
+    result = createTenantTrace(input as CreateTraceInput);
+  } catch (error) {
+    set.status = 404;
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
+  }
   set.status = 201;
   return {
     success: result.success,

--- a/src/routes/traces/distill.ts
+++ b/src/routes/traces/distill.ts
@@ -1,6 +1,6 @@
 import { Elysia, t } from 'elysia';
 import { distillTraceAwakening } from '../../trace/distill.ts';
-import { getTrace } from '../../trace/handler.ts';
+import { getTenantTrace } from './tenant-scope.ts';
 import { traceIdParam } from './model.ts';
 
 const evidenceBody = t.Object({
@@ -41,7 +41,7 @@ export const traceDistillRoute = new Elysia().post('/api/traces/:id/distill', ({
     set.status = 400;
     return { error: 'awakening is required' };
   }
-  if (!getTrace(params.id)) {
+  if (!getTenantTrace(params.id)) {
     set.status = 404;
     return { error: 'Trace not found' };
   }

--- a/src/routes/traces/get.ts
+++ b/src/routes/traces/get.ts
@@ -1,9 +1,9 @@
 import { Elysia } from 'elysia';
-import { getTrace } from '../../trace/handler.ts';
+import { getTenantTrace } from './tenant-scope.ts';
 import { traceIdParam } from './model.ts';
 
 export const traceGetRoute = new Elysia().get('/api/traces/:id', ({ params, set }) => {
-  const trace = getTrace(params.id);
+  const trace = getTenantTrace(params.id);
   if (!trace) {
     set.status = 404;
     return { error: 'Trace not found' };

--- a/src/routes/traces/link.ts
+++ b/src/routes/traces/link.ts
@@ -1,5 +1,5 @@
 import { Elysia } from 'elysia';
-import { linkTraces } from '../../trace/handler.ts';
+import { linkTenantTraces } from './tenant-scope.ts';
 import { traceIdParam, linkBody } from './model.ts';
 
 export const traceLinkRoute = new Elysia().post('/api/traces/:id/link', async ({ params, body, set }) => {
@@ -9,7 +9,7 @@ export const traceLinkRoute = new Elysia().post('/api/traces/:id/link', async ({
       set.status = 400;
       return { error: 'Missing nextId in request body' };
     }
-    const result = linkTraces(params.id, nextId);
+    const result = linkTenantTraces(params.id, nextId);
     if (!result.success) {
       set.status = 400;
       return { error: result.message };

--- a/src/routes/traces/linked-chain.ts
+++ b/src/routes/traces/linked-chain.ts
@@ -1,10 +1,10 @@
 import { Elysia } from 'elysia';
-import { getTraceLinkedChain } from '../../trace/handler.ts';
+import { getTenantTraceLinkedChain } from './tenant-scope.ts';
 import { traceIdParam } from './model.ts';
 
 export const traceLinkedChainRoute = new Elysia().get('/api/traces/:id/linked-chain', async ({ params, set }) => {
   try {
-    return getTraceLinkedChain(params.id);
+    return getTenantTraceLinkedChain(params.id);
   } catch (err) {
     console.error('Get linked chain error:', err);
     set.status = 500;

--- a/src/routes/traces/list.ts
+++ b/src/routes/traces/list.ts
@@ -1,12 +1,12 @@
 import { Elysia } from 'elysia';
-import { listTraces } from '../../trace/handler.ts';
+import { listTenantTraces } from './tenant-scope.ts';
 import { listQuery } from './model.ts';
 
 export const tracesListRoute = new Elysia().get('/api/traces', ({ query }) => {
   const limit = parseInt(query.limit || '50');
   const offset = parseInt(query.offset || '0');
 
-  return listTraces({
+  return listTenantTraces({
     query: query.query || undefined,
     status: (query.status as 'raw' | 'reviewed' | 'distilled' | undefined) || undefined,
     project: query.project || undefined,

--- a/src/routes/traces/tenant-scope.ts
+++ b/src/routes/traces/tenant-scope.ts
@@ -1,0 +1,167 @@
+import { and, desc, eq, like, sql, type SQL } from 'drizzle-orm';
+import { db, traceLog } from '../../db/index.ts';
+import { activeTenantId, tenantIdForWrite } from '../../middleware/tenant.ts';
+import { createTrace, getTrace } from '../../trace/handler.ts';
+import type { CreateTraceInput, CreateTraceResult, ListTracesInput, ListTracesResult, TraceChainResult, TraceRecord, TraceSummary } from '../../trace/types.ts';
+
+function tenantTraceWhere(traceId: string): SQL {
+  return and(eq(traceLog.traceId, traceId), eq(traceLog.tenantId, activeTenantId())) as SQL;
+}
+
+export function getTenantTrace(traceId: string): TraceRecord | null {
+  const row = db.select({ traceId: traceLog.traceId }).from(traceLog).where(tenantTraceWhere(traceId)).get();
+  return row ? getTrace(traceId) : null;
+}
+
+export function createTenantTrace(input: CreateTraceInput): CreateTraceResult {
+  if (input.parentTraceId && !getTenantTrace(input.parentTraceId)) throw new Error(`Parent trace not found: ${input.parentTraceId}`);
+  const result = createTrace(input);
+  db.update(traceLog).set({ tenantId: tenantIdForWrite() }).where(eq(traceLog.traceId, result.traceId)).run();
+  return result;
+}
+
+export function listTenantTraces(input: ListTracesInput): ListTracesResult {
+  const limit = input.limit || 20;
+  const offset = input.offset || 0;
+  const conditions = [eq(traceLog.tenantId, activeTenantId())];
+  if (input.query) conditions.push(like(traceLog.query, `%${input.query}%`));
+  if (input.project) conditions.push(eq(traceLog.project, input.project));
+  if (input.status) conditions.push(eq(traceLog.status, input.status));
+  if (input.depth !== undefined) conditions.push(eq(traceLog.depth, input.depth));
+  const whereClause = and(...conditions);
+  const countResult = db.select({ count: sql<number>`count(*)` }).from(traceLog).where(whereClause).get();
+  const rows = db.select({
+    traceId: traceLog.traceId,
+    query: traceLog.query,
+    depth: traceLog.depth,
+    fileCount: traceLog.fileCount,
+    commitCount: traceLog.commitCount,
+    issueCount: traceLog.issueCount,
+    scope: traceLog.scope,
+    status: traceLog.status,
+    awakening: traceLog.awakening,
+    createdAt: traceLog.createdAt,
+  }).from(traceLog).where(whereClause).orderBy(desc(traceLog.createdAt)).limit(limit).offset(offset).all();
+  const total = countResult?.count || 0;
+  return {
+    traces: rows.map((row) => ({
+      traceId: row.traceId,
+      query: row.query,
+      scope: row.scope || 'project',
+      depth: row.depth || 0,
+      fileCount: row.fileCount || 0,
+      commitCount: row.commitCount || 0,
+      issueCount: row.issueCount || 0,
+      status: row.status || 'raw',
+      hasAwakening: !!row.awakening,
+      createdAt: row.createdAt,
+    })),
+    total,
+    hasMore: offset + rows.length < total,
+  };
+}
+
+export function getTenantTraceChain(traceId: string, direction: 'up' | 'down' | 'both' = 'both'): TraceChainResult {
+  const chain: TraceSummary[] = [];
+  let hasAwakening = false;
+  let awakeningTraceId: string | undefined;
+  if (direction === 'up' || direction === 'both') {
+    let current = getTenantTrace(traceId);
+    while (current?.parentTraceId) {
+      const parent = getTenantTrace(current.parentTraceId);
+      if (parent) {
+        chain.unshift(toSummary(parent));
+        if (parent.awakening) {
+          hasAwakening = true;
+          awakeningTraceId = parent.traceId;
+        }
+      }
+      current = parent;
+    }
+  }
+  const self = getTenantTrace(traceId);
+  if (self) {
+    chain.push(toSummary(self));
+    if (self.awakening) {
+      hasAwakening = true;
+      awakeningTraceId = self.traceId;
+    }
+  }
+  if (direction === 'down' || direction === 'both') {
+    const queue = self?.childTraceIds || [];
+    while (queue.length > 0) {
+      const child = getTenantTrace(queue.shift()!);
+      if (child) {
+        chain.push(toSummary(child));
+        if (child.awakening) {
+          hasAwakening = true;
+          awakeningTraceId = child.traceId;
+        }
+        queue.push(...child.childTraceIds);
+      }
+    }
+  }
+  return { chain, totalDepth: Math.max(...chain.map((trace) => trace.depth), 0), hasAwakening, awakeningTraceId };
+}
+
+export function linkTenantTraces(prevTraceId: string, nextTraceId: string) {
+  if (!prevTraceId) return { success: false, message: 'prevTraceId is required' };
+  if (!nextTraceId) return { success: false, message: 'nextTraceId is required' };
+  if (prevTraceId === nextTraceId) return { success: false, message: `Cannot link a trace to itself: ${prevTraceId}` };
+  const prevTrace = getTenantTrace(prevTraceId);
+  const nextTrace = getTenantTrace(nextTraceId);
+  if (!prevTrace) return { success: false, message: `Previous trace not found: ${prevTraceId}` };
+  if (!nextTrace) return { success: false, message: `Next trace not found: ${nextTraceId}` };
+  if (prevTrace.nextTraceId) return { success: false, message: `Trace ${prevTraceId} already has a next link` };
+  if (nextTrace.prevTraceId) return { success: false, message: `Trace ${nextTraceId} already has a prev link` };
+  const now = Date.now();
+  db.update(traceLog).set({ nextTraceId, updatedAt: now }).where(tenantTraceWhere(prevTraceId)).run();
+  db.update(traceLog).set({ prevTraceId, updatedAt: now }).where(tenantTraceWhere(nextTraceId)).run();
+  return { success: true, message: `Linked: ${prevTraceId} → ${nextTraceId}`, prevTrace: getTenantTrace(prevTraceId), nextTrace: getTenantTrace(nextTraceId) };
+}
+
+export function unlinkTenantTraces(traceId: string, direction: 'prev' | 'next') {
+  const trace = getTenantTrace(traceId);
+  if (!trace) return { success: false, message: `Trace not found: ${traceId}` };
+  const linkedId = direction === 'next' ? trace.nextTraceId : trace.prevTraceId;
+  if (!linkedId) return { success: false, message: `No ${direction} link to remove` };
+  const now = Date.now();
+  db.update(traceLog).set({ [direction === 'next' ? 'nextTraceId' : 'prevTraceId']: null, updatedAt: now }).where(tenantTraceWhere(traceId)).run();
+  const linkedPatch = direction === 'next' ? { prevTraceId: null, updatedAt: now } : { nextTraceId: null, updatedAt: now };
+  if (getTenantTrace(linkedId)) db.update(traceLog).set(linkedPatch).where(tenantTraceWhere(linkedId)).run();
+  return { success: true, message: `Unlinked ${direction}: ${traceId} -/-> ${linkedId}` };
+}
+
+export function getTenantTraceLinkedChain(traceId: string): { chain: TraceRecord[]; position: number } {
+  const chain: TraceRecord[] = [];
+  let position = 0;
+  let current = getTenantTrace(traceId);
+  const backwardVisited = new Set<string>();
+  while (current?.prevTraceId && !backwardVisited.has(current.prevTraceId)) {
+    backwardVisited.add(current.traceId);
+    current = getTenantTrace(current.prevTraceId);
+  }
+  const forwardVisited = new Set<string>();
+  while (current && !forwardVisited.has(current.traceId)) {
+    if (current.traceId === traceId) position = chain.length;
+    chain.push(current);
+    forwardVisited.add(current.traceId);
+    current = current.nextTraceId ? getTenantTrace(current.nextTraceId) : null;
+  }
+  return { chain, position };
+}
+
+function toSummary(trace: TraceRecord): TraceSummary {
+  return {
+    traceId: trace.traceId,
+    query: trace.query,
+    scope: trace.scope,
+    depth: trace.depth,
+    fileCount: trace.fileCount,
+    commitCount: trace.commitCount,
+    issueCount: trace.issueCount,
+    status: trace.status,
+    hasAwakening: !!trace.awakening,
+    createdAt: trace.createdAt,
+  };
+}

--- a/src/routes/traces/unlink.ts
+++ b/src/routes/traces/unlink.ts
@@ -1,5 +1,5 @@
 import { Elysia } from 'elysia';
-import { unlinkTraces } from '../../trace/handler.ts';
+import { unlinkTenantTraces } from './tenant-scope.ts';
 import { traceIdParam, unlinkQuery } from './model.ts';
 
 export const traceUnlinkRoute = new Elysia().delete('/api/traces/:id/link', async ({ params, query, set }) => {
@@ -9,7 +9,7 @@ export const traceUnlinkRoute = new Elysia().delete('/api/traces/:id/link', asyn
       set.status = 400;
       return { error: 'Missing or invalid direction (prev|next)' };
     }
-    const result = unlinkTraces(params.id, direction);
+    const result = unlinkTenantTraces(params.id, direction);
     if (!result.success) {
       set.status = 400;
       return { error: result.message };

--- a/tests/http/tenant/dashboard-supersede-isolation.test.ts
+++ b/tests/http/tenant/dashboard-supersede-isolation.test.ts
@@ -1,10 +1,22 @@
 import { afterAll, expect, test } from 'bun:test';
-import { Elysia } from 'elysia';
 import { inArray, like } from 'drizzle-orm';
-import { db, learnLog, oracleDocuments, searchLog } from '../../../src/db/index.ts';
-import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
-import { dashboardRoutes } from '../../../src/routes/dashboard/index.ts';
-import { supersedeRoutes } from '../../../src/routes/supersede/index.ts';
+import { mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const root = join(tmpdir(), `arra-dashboard-tenant-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+const dbPath = join(root, 'oracle.db');
+mkdirSync(root, { recursive: true });
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = dbPath;
+
+const dbMod = await import('../../../src/db/index.ts');
+dbMod.resetDefaultDatabaseForTests(dbPath);
+const tenantMod = await import('../../../src/middleware/tenant.ts');
+const { dashboardRoutes } = await import('../../../src/routes/dashboard/index.ts');
+const { supersedeRoutes } = await import('../../../src/routes/supersede/index.ts');
 
 const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 const tenantA = `tenant-a-${stamp}`;
@@ -17,15 +29,16 @@ const ids = {
 };
 const now = Date.now();
 const paths = Object.fromEntries(Object.entries(ids).map(([key, id]) => [key, `ψ/memory/${id}.md`])) as Record<keyof typeof ids, string>;
+type AppLike = { handle(request: Request): Response | Promise<Response> };
 
-function appRequest(app: Elysia, tenantId: string, path: string) {
-  return createTenantFetch((request) => app.handle(request))(new Request(`http://local${path}`, {
-    headers: { [TENANT_HEADER]: tenantId },
+function appRequest(app: AppLike, tenantId: string, path: string) {
+  return tenantMod.createTenantFetch((request) => app.handle(request))(new Request(`http://local${path}`, {
+    headers: { [tenantMod.TENANT_HEADER]: tenantId },
   }));
 }
 
 function insertDoc(id: string, tenantId: string, path: string, supersededBy?: string) {
-  db.insert(oracleDocuments).values({
+  dbMod.db.insert(dbMod.oracleDocuments).values({
     id,
     tenantId,
     type: 'learning',
@@ -47,19 +60,28 @@ insertDoc(ids.aNew, tenantA, paths.aNew);
 insertDoc(ids.bOld, tenantB, paths.bOld, ids.bNew);
 insertDoc(ids.bNew, tenantB, paths.bNew);
 
-db.insert(searchLog).values([
+dbMod.db.insert(dbMod.searchLog).values([
   { query: `tenant dashboard ${stamp} a`, tenantId: tenantA, mode: 'fts', resultsCount: 1, searchTimeMs: 1, createdAt: now },
   { query: `tenant dashboard ${stamp} b`, tenantId: tenantB, mode: 'fts', resultsCount: 1, searchTimeMs: 1, createdAt: now },
 ]).run();
-db.insert(learnLog).values([
+dbMod.db.insert(dbMod.learnLog).values([
   { documentId: ids.aOld, tenantId: tenantA, patternPreview: `learn a ${stamp}`, concepts: '[]', createdAt: now },
   { documentId: ids.bOld, tenantId: tenantB, patternPreview: `learn b ${stamp}`, concepts: '[]', createdAt: now },
 ]).run();
 
+function restore(name: string, value: string | undefined) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
 afterAll(() => {
-  db.delete(oracleDocuments).where(inArray(oracleDocuments.id, Object.values(ids))).run();
-  db.delete(searchLog).where(like(searchLog.query, `%${stamp}%`)).run();
-  db.delete(learnLog).where(inArray(learnLog.documentId, [ids.aOld, ids.bOld])).run();
+  dbMod.db.delete(dbMod.oracleDocuments).where(inArray(dbMod.oracleDocuments.id, Object.values(ids))).run();
+  dbMod.db.delete(dbMod.searchLog).where(like(dbMod.searchLog.query, `%${stamp}%`)).run();
+  dbMod.db.delete(dbMod.learnLog).where(inArray(dbMod.learnLog.documentId, [ids.aOld, ids.bOld])).run();
+  dbMod.closeDb();
+  restore('ORACLE_DATA_DIR', savedDataDir);
+  restore('ORACLE_DB_PATH', savedDbPath);
+  rmSync(root, { recursive: true, force: true });
 });
 
 test('dashboard summary and activity are scoped to selected tenant', async () => {
@@ -79,10 +101,9 @@ test('dashboard summary and activity are scoped to selected tenant', async () =>
 });
 
 test('supersede list and chain do not cross tenant boundaries', async () => {
-  const app = supersedeRoutes;
-  const list = await appRequest(app, tenantA, '/api/supersede?limit=10');
-  const deniedChain = await appRequest(app, tenantB, `/api/supersede/chain/${encodeURIComponent(paths.aOld)}`);
-  const allowedChain = await appRequest(app, tenantA, `/api/supersede/chain/${encodeURIComponent(paths.aOld)}`);
+  const list = await appRequest(supersedeRoutes, tenantA, '/api/supersede?limit=10');
+  const deniedChain = await appRequest(supersedeRoutes, tenantB, `/api/supersede/chain/${encodeURIComponent(paths.aOld)}`);
+  const allowedChain = await appRequest(supersedeRoutes, tenantA, `/api/supersede/chain/${encodeURIComponent(paths.aOld)}`);
   const listBody = await list.json() as { supersessions: Array<{ old_id: string; new_path: string | null }> };
   const deniedBody = await deniedChain.json() as { superseded_by: unknown[]; supersedes: unknown[] };
   const allowedBody = await allowedChain.json() as { superseded_by: Array<{ new_path: string }>; supersedes: unknown[] };

--- a/tests/http/tenant/supersede-document-isolation.test.ts
+++ b/tests/http/tenant/supersede-document-isolation.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, expect, test } from 'bun:test';
+import { eq, inArray } from 'drizzle-orm';
+import { mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const root = join(tmpdir(), `arra-supersede-tenant-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+const dbPath = join(root, 'oracle.db');
+mkdirSync(root, { recursive: true });
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = dbPath;
+
+const dbMod = await import('../../../src/db/index.ts');
+dbMod.resetDefaultDatabaseForTests(dbPath);
+const tenantMod = await import('../../../src/middleware/tenant.ts');
+const { supersedeRoutes } = await import('../../../src/routes/supersede/index.ts');
+
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantA = `sup-doc-a-${stamp}`;
+const tenantB = `sup-doc-b-${stamp}`;
+const ids = [`sup-old-a-${stamp}`, `sup-new-a-${stamp}`, `sup-new-b-${stamp}`];
+const now = Date.now();
+
+function insertDoc(id: string, tenantId: string) {
+  dbMod.db.insert(dbMod.oracleDocuments).values({
+    id,
+    tenantId,
+    type: 'learning',
+    sourceFile: `ψ/memory/${id}.md`,
+    concepts: '[]',
+    createdAt: now,
+    updatedAt: now,
+    indexedAt: now,
+    createdBy: 'tenant-test',
+  }).run();
+}
+
+ids.forEach((id, index) => insertDoc(id, index < 2 ? tenantA : tenantB));
+
+const handler = tenantMod.createTenantFetch((request) => supersedeRoutes.handle(request));
+
+async function postSupersede(tenantId: string, oldId: string, newId: string) {
+  const response = await handler(new Request('http://local/api/supersede/document', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', [tenantMod.TENANT_HEADER]: tenantId },
+    body: JSON.stringify({ oldId, newId, reason: 'tenant isolation' }),
+  }));
+  return { response, json: await response.json() as Record<string, any> };
+}
+
+function restore(name: string, value: string | undefined) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+afterAll(() => {
+  dbMod.db.delete(dbMod.oracleDocuments).where(inArray(dbMod.oracleDocuments.id, ids)).run();
+  dbMod.closeDb();
+  restore('ORACLE_DATA_DIR', savedDataDir);
+  restore('ORACLE_DB_PATH', savedDbPath);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('supersede document writes only update documents in the active tenant', async () => {
+  const denied = await postSupersede(tenantB, ids[0], ids[2]);
+  expect(denied.response.status).toBe(404);
+  expect(denied.json.error).toContain('Old document not found');
+  expect(dbMod.db.select({ supersededBy: dbMod.oracleDocuments.supersededBy }).from(dbMod.oracleDocuments).where(eq(dbMod.oracleDocuments.id, ids[0])).get()?.supersededBy).toBeNull();
+
+  const allowed = await postSupersede(tenantA, ids[0], ids[1]);
+  expect(allowed.response.status).toBe(200);
+  expect(allowed.json).toMatchObject({ success: true, old_id: ids[0], new_id: ids[1] });
+  expect(dbMod.db.select({ supersededBy: dbMod.oracleDocuments.supersededBy }).from(dbMod.oracleDocuments).where(eq(dbMod.oracleDocuments.id, ids[0])).get()?.supersededBy).toBe(ids[1]);
+});

--- a/tests/http/traces/tenant-isolation.test.ts
+++ b/tests/http/traces/tenant-isolation.test.ts
@@ -1,0 +1,95 @@
+import { afterAll, expect, test } from 'bun:test';
+import { eq, inArray } from 'drizzle-orm';
+import { mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const root = join(tmpdir(), `arra-trace-tenant-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+const dbPath = join(root, 'oracle.db');
+mkdirSync(root, { recursive: true });
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = dbPath;
+
+const dbMod = await import('../../../src/db/index.ts');
+dbMod.resetDefaultDatabaseForTests(dbPath);
+const tenantMod = await import('../../../src/middleware/tenant.ts');
+const { tracesApi } = await import('../../../src/routes/traces/index.ts');
+
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantA = `trace-tenant-a-${stamp}`;
+const tenantB = `trace-tenant-b-${stamp}`;
+const traceA = `trace-a-${stamp}`;
+const traceB = `trace-b-${stamp}`;
+const traceIds = [traceA, traceB];
+const now = Date.now();
+
+dbMod.db.insert(dbMod.traceLog).values([
+  { traceId: traceA, tenantId: tenantA, query: `shared trace ${stamp}`, childTraceIds: JSON.stringify([traceB]), nextTraceId: traceB, createdAt: now, updatedAt: now },
+  { traceId: traceB, tenantId: tenantB, query: `shared trace ${stamp}`, prevTraceId: traceA, createdAt: now + 1, updatedAt: now + 1 },
+]).run();
+
+const handler = tenantMod.createTenantFetch((request) => tracesApi.handle(request));
+
+function tenantRequest(tenantId: string, path: string, init: RequestInit = {}) {
+  return handler(new Request(`http://local${path}`, {
+    ...init,
+    headers: { 'content-type': 'application/json', [tenantMod.TENANT_HEADER]: tenantId, ...(init.headers ?? {}) },
+  }));
+}
+
+async function tenantJson(tenantId: string, path: string, init: RequestInit = {}) {
+  const response = await tenantRequest(tenantId, path, init);
+  return { response, json: await response.json() as Record<string, any> };
+}
+
+function restore(name: string, value: string | undefined) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+afterAll(() => {
+  const ids = traceIds.filter(Boolean);
+  if (ids.length > 0) dbMod.db.delete(dbMod.traceLog).where(inArray(dbMod.traceLog.traceId, ids)).run();
+  dbMod.closeDb();
+  restore('ORACLE_DATA_DIR', savedDataDir);
+  restore('ORACLE_DB_PATH', savedDbPath);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('trace HTTP routes stamp and filter records by active tenant', async () => {
+  const created = await tenantJson(tenantA, '/api/traces', {
+    method: 'POST',
+    body: JSON.stringify({ query: `created trace ${stamp}`, parentTraceId: traceA }),
+  });
+  expect(created.response.status).toBe(201);
+  traceIds.push(created.json.trace_id);
+  expect(dbMod.db.select({ tenantId: dbMod.traceLog.tenantId }).from(dbMod.traceLog).where(eq(dbMod.traceLog.traceId, created.json.trace_id)).get()?.tenantId).toBe(tenantA);
+
+  const listA = await tenantJson(tenantA, `/api/traces?query=${encodeURIComponent(stamp)}&limit=10`);
+  expect(listA.json.traces.map((trace: { traceId: string }) => trace.traceId).sort()).toEqual([created.json.trace_id, traceA].sort());
+  expect(listA.json.total).toBe(2);
+
+  const deniedGet = await tenantJson(tenantA, `/api/traces/${traceB}`);
+  expect(deniedGet.response.status).toBe(404);
+
+  const chainA = await tenantJson(tenantA, `/api/traces/${traceA}/chain`);
+  expect(chainA.json.chain.map((trace: { traceId: string }) => trace.traceId)).not.toContain(traceB);
+
+  const linkedA = await tenantJson(tenantA, `/api/traces/${traceA}/linked-chain`);
+  expect(linkedA.json.chain.map((trace: { traceId: string }) => trace.traceId)).toEqual([traceA]);
+
+  const deniedLink = await tenantJson(tenantA, `/api/traces/${traceA}/link`, {
+    method: 'POST',
+    body: JSON.stringify({ nextId: traceB }),
+  });
+  expect(deniedLink.response.status).toBe(400);
+  expect(deniedLink.json.error).toContain('Next trace not found');
+
+  const deniedDistill = await tenantJson(tenantA, `/api/traces/${traceB}/distill`, {
+    method: 'POST',
+    body: JSON.stringify({ awakening: 'cross tenant should not distill' }),
+  });
+  expect(deniedDistill.response.status).toBe(404);
+});

--- a/tests/http/traces/validation.test.ts
+++ b/tests/http/traces/validation.test.ts
@@ -1,6 +1,20 @@
-import { describe, expect, test } from 'bun:test';
-import { traceLinkRoute } from '../../../src/routes/traces/link.ts';
-import { traceUnlinkRoute } from '../../../src/routes/traces/unlink.ts';
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const root = join(tmpdir(), `arra-trace-validation-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+const dbPath = join(root, 'oracle.db');
+mkdirSync(root, { recursive: true });
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = dbPath;
+
+const dbMod = await import('../../../src/db/index.ts');
+dbMod.resetDefaultDatabaseForTests(dbPath);
+const { traceLinkRoute } = await import('../../../src/routes/traces/link.ts');
+const { traceUnlinkRoute } = await import('../../../src/routes/traces/unlink.ts');
 
 function postLink(body: unknown) {
   return traceLinkRoute.handle(new Request('http://local/api/traces/a/link', {
@@ -15,6 +29,18 @@ function deleteLink(query = '') {
     method: 'DELETE',
   }));
 }
+
+function restore(name: string, value: string | undefined) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+afterAll(() => {
+  dbMod.closeDb();
+  restore('ORACLE_DATA_DIR', savedDataDir);
+  restore('ORACLE_DB_PATH', savedDbPath);
+  rmSync(root, { recursive: true, force: true });
+});
 
 describe('trace link route input validation', () => {
   test('rejects missing or non-string nextId before link handling', async () => {


### PR DESCRIPTION
## Summary
- scope traces create/list/get/chain/link/unlink/linked-chain/distill by the active tenant
- scope supersede list/chain to the active tenant and require same-tenant docs for document supersede writes
- add tenant isolation coverage for traces and supersede document routes

## Validation
- bunx tsc --noEmit
- bun test tests/http/traces/
- bun test tests/http/tenant/dashboard-supersede-isolation.test.ts
- bun test tests/http/tenant/supersede-document-isolation.test.ts
- git diff --check
- changed files <= 250 lines