### PR TITLE
fix: harden health route initialization

### DIFF
--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -136,6 +136,7 @@ function validateEnums(env: RuntimeEnv, issues: string[]): void {
   checkEnum(env, issues, ['ORACLE_EMBEDDER', 'ORACLE_EMBEDDER_BACKEND', 'ORACLE_EMBEDDING_PROVIDER', 'EMBEDDER_TYPE'], EMBEDDER_VALUES);
   checkEnum(env, issues, ['ORACLE_VECTOR_DB'], VECTOR_DB_VALUES);
   checkEnum(env, issues, ['VECTOR_FALLBACK'], VECTOR_FALLBACK_VALUES);
+  checkEnum(env, issues, ['LOG_FORMAT'], ['nginx', 'json', 'short'] as const);
 }
 
 function validateDatabaseUrl(env: RuntimeEnv, issues: string[]): void {
@@ -221,7 +222,6 @@ function pathFromDatabaseUrl(value?: string): string {
 }
 
 const homeDir = (env: RuntimeEnv): string => env.HOME || env.USERPROFILE || '';
-
 function optionalWarnings(env: RuntimeEnv): string[] {
   return OPTIONAL_DEFAULTS
     .filter((item) => !item.keys.some((key) => filled(env[key])))

--- a/src/routes/health/deep.ts
+++ b/src/routes/health/deep.ts
@@ -24,38 +24,40 @@ type DiskHealth = {
   error?: string;
 };
 
-const DeepHealthResponseSchema = t.Object({
-  status: t.Union([t.Literal('ok'), t.Literal('degraded'), t.Literal('down')]),
-  checked_at: t.String(),
-  db: t.Object({
-    status: t.Union([t.Literal('connected'), t.Literal('error')]),
-    path: t.String(),
-    latencyMs: t.Number(),
-    error: t.Optional(t.String()),
-  }),
-  vector: t.Object({
+function deepHealthResponseSchema() {
+  return t.Object({
     status: t.Union([t.Literal('ok'), t.Literal('degraded'), t.Literal('down')]),
     checked_at: t.String(),
-    engines: t.Array(t.Any()),
-    error: t.Optional(t.String()),
-  }),
-  disk: t.Object({
-    status: t.Union([t.Literal('ok'), t.Literal('warning'), t.Literal('error')]),
-    path: t.String(),
-    totalBytes: t.Number(),
-    freeBytes: t.Number(),
-    usedBytes: t.Number(),
-    usedPercent: t.Number(),
-    error: t.Optional(t.String()),
-  }),
-  memory: t.Object({
-    rss: t.Number(),
-    heapTotal: t.Number(),
-    heapUsed: t.Number(),
-    external: t.Number(),
-    arrayBuffers: t.Number(),
-  }),
-});
+    db: t.Object({
+      status: t.Union([t.Literal('connected'), t.Literal('error')]),
+      path: t.String(),
+      latencyMs: t.Number(),
+      error: t.Optional(t.String()),
+    }),
+    vector: t.Object({
+      status: t.Union([t.Literal('ok'), t.Literal('degraded'), t.Literal('down')]),
+      checked_at: t.String(),
+      engines: t.Array(t.Any()),
+      error: t.Optional(t.String()),
+    }),
+    disk: t.Object({
+      status: t.Union([t.Literal('ok'), t.Literal('warning'), t.Literal('error')]),
+      path: t.String(),
+      totalBytes: t.Number(),
+      freeBytes: t.Number(),
+      usedBytes: t.Number(),
+      usedPercent: t.Number(),
+      error: t.Optional(t.String()),
+    }),
+    memory: t.Object({
+      rss: t.Number(),
+      heapTotal: t.Number(),
+      heapUsed: t.Number(),
+      external: t.Number(),
+      arrayBuffers: t.Number(),
+    }),
+  });
+}
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -121,7 +123,7 @@ export function createDeepHealthEndpoint(options: DeepHealthOptions = {}) {
     const memory = options.memoryUsage?.() ?? process.memoryUsage();
     return { status: overallStatus(db, vector, disk), checked_at: new Date().toISOString(), db, vector, disk, memory };
   }, {
-    response: DeepHealthResponseSchema,
+    response: deepHealthResponseSchema(),
     detail: {
       tags: ['health'],
       menu: { group: 'hidden' },

--- a/src/routes/health/index.ts
+++ b/src/routes/health/index.ts
@@ -4,19 +4,17 @@
 import { Elysia } from 'elysia';
 import { createHealthEndpoint, type HealthEndpointOptions } from './health.ts';
 import { createDeepHealthEndpoint } from './deep.ts';
-import { statsEndpoint } from './stats.ts';
-import { oraclesEndpoint } from './oracles.ts';
-import { oracleProfilesEndpoint } from './oracle-profiles.ts';
-import { thorOracleEndpoint } from './thor.ts';
+import { createStatsEndpoint } from './stats.ts';
+import { createOraclesEndpoint } from './oracles.ts';
+import { createOracleProfilesEndpoint } from './oracle-profiles.ts';
+import { createThorOracleEndpoint } from './thor.ts';
 
 export function createHealthRoutes(options: HealthEndpointOptions = {}) {
   return new Elysia({ prefix: '/api' })
     .use(createHealthEndpoint(options))
     .use(createDeepHealthEndpoint(options))
-    .use(statsEndpoint)
-    .use(oraclesEndpoint)
-    .use(oracleProfilesEndpoint)
-    .use(thorOracleEndpoint);
+    .use(createStatsEndpoint())
+    .use(createOraclesEndpoint())
+    .use(createOracleProfilesEndpoint())
+    .use(createThorOracleEndpoint());
 }
-
-export const healthRoutes = createHealthRoutes();

--- a/src/routes/health/oracle-profiles.ts
+++ b/src/routes/health/oracle-profiles.ts
@@ -1,57 +1,65 @@
 import { Elysia, t } from 'elysia';
 import { getOracleProfile, listOracleProfiles } from '../../oracles/registry.ts';
 
-export const OracleCapabilitySchema = t.Object({
-  id: t.String(),
-  label: t.String(),
-  description: t.String(),
-});
-
-export const OracleProfileSchema = t.Object({
-  id: t.String(),
-  slug: t.String(),
-  name: t.String(),
-  role: t.String(),
-  theme: t.String(),
-  born: t.String(),
-  human: t.Optional(t.String()),
-  motto: t.String(),
-  principles: t.Array(t.String()),
-  capabilities: t.Array(OracleCapabilitySchema),
-  workflows: t.Array(t.String()),
-  defaultConcepts: t.Array(t.String()),
-});
-
-const ProfilesResponseSchema = t.Object({
-  profiles: t.Array(OracleProfileSchema),
-  total: t.Number(),
-});
-
-export const oracleProfilesEndpoint = new Elysia()
-  .get('/oracles/profiles', () => {
-    const profiles = listOracleProfiles();
-    return { profiles, total: profiles.length };
-  }, {
-    response: ProfilesResponseSchema,
-    detail: {
-      tags: ['health'],
-      menu: { group: 'hidden' },
-      summary: 'List code-backed Oracle profiles',
-    },
-  })
-  .get('/oracles/profiles/:slug', ({ params, set }) => {
-    const profile = getOracleProfile(params.slug);
-    if (!profile) {
-      set.status = 404;
-      return { error: 'Oracle profile not found' };
-    }
-    return profile;
-  }, {
-    params: t.Object({ slug: t.String() }),
-    response: t.Union([OracleProfileSchema, t.Object({ error: t.String() })]),
-    detail: {
-      tags: ['health'],
-      menu: { group: 'hidden' },
-      summary: 'Read one code-backed Oracle profile',
-    },
+function oracleCapabilitySchema() {
+  return t.Object({
+    id: t.String(),
+    label: t.String(),
+    description: t.String(),
   });
+}
+
+export function oracleProfileSchema() {
+  return t.Object({
+    id: t.String(),
+    slug: t.String(),
+    name: t.String(),
+    role: t.String(),
+    theme: t.String(),
+    born: t.String(),
+    human: t.Optional(t.String()),
+    motto: t.String(),
+    principles: t.Array(t.String()),
+    capabilities: t.Array(oracleCapabilitySchema()),
+    workflows: t.Array(t.String()),
+    defaultConcepts: t.Array(t.String()),
+  });
+}
+
+function profilesResponseSchema() {
+  return t.Object({
+    profiles: t.Array(oracleProfileSchema()),
+    total: t.Number(),
+  });
+}
+
+export function createOracleProfilesEndpoint() {
+  return new Elysia()
+    .get('/oracles/profiles', () => {
+      const profiles = listOracleProfiles();
+      return { profiles, total: profiles.length };
+    }, {
+      response: profilesResponseSchema(),
+      detail: {
+        tags: ['health'],
+        menu: { group: 'hidden' },
+        summary: 'List code-backed Oracle profiles',
+      },
+    })
+    .get('/oracles/profiles/:slug', ({ params, set }) => {
+      const profile = getOracleProfile(params.slug);
+      if (!profile) {
+        set.status = 404;
+        return { error: 'Oracle profile not found' };
+      }
+      return profile;
+    }, {
+      params: t.Object({ slug: t.String() }),
+      response: t.Union([oracleProfileSchema(), t.Object({ error: t.String() })]),
+      detail: {
+        tags: ['health'],
+        menu: { group: 'hidden' },
+        summary: 'Read one code-backed Oracle profile',
+      },
+    });
+}

--- a/src/routes/health/oracles.ts
+++ b/src/routes/health/oracles.ts
@@ -1,34 +1,37 @@
 import { Elysia, t } from 'elysia';
 import { sqlite } from '../../db/index.ts';
 import { currentTenantId } from '../../middleware/tenant.ts';
-import { OraclesQuery } from './model.ts';
 
-const OracleIdentitiesSchema = t.Object({
-  oracle_name: t.String(),
-  source: t.String(),
-  last_seen: t.Nullable(t.Union([t.String(), t.Number()])),
-  actions: t.Number(),
-});
+function oraclesQuerySchema() {
+  return t.Object({ hours: t.Optional(t.String()) });
+}
 
-const OracleProjectsSchema = t.Object({
-  project: t.String(),
-  docs: t.Number(),
-  types: t.Number(),
-  last_indexed: t.Nullable(t.Union([t.String(), t.Number()])),
-});
-
-const OraclesResponseSchema = t.Object({
-  identities: t.Array(OracleIdentitiesSchema),
-  projects: t.Array(OracleProjectsSchema),
-  total_projects: t.Number(),
-  total_identities: t.Number(),
-  window_hours: t.Number(),
-  tenant: t.Optional(t.Object({
-    id: t.String(),
-    scope: t.String(),
-  })),
-  cached_at: t.String(),
-});
+function oraclesResponseSchema() {
+  const identity = t.Object({
+    oracle_name: t.String(),
+    source: t.String(),
+    last_seen: t.Nullable(t.Union([t.String(), t.Number()])),
+    actions: t.Number(),
+  });
+  const project = t.Object({
+    project: t.String(),
+    docs: t.Number(),
+    types: t.Number(),
+    last_indexed: t.Nullable(t.Union([t.String(), t.Number()])),
+  });
+  return t.Object({
+    identities: t.Array(identity),
+    projects: t.Array(project),
+    total_projects: t.Number(),
+    total_identities: t.Number(),
+    window_hours: t.Number(),
+    tenant: t.Optional(t.Object({
+      id: t.String(),
+      scope: t.String(),
+    })),
+    cached_at: t.String(),
+  });
+}
 
 interface OraclesResponse {
   identities: Array<{
@@ -52,21 +55,22 @@ interface OraclesResponse {
 
 let oracleCache: { data: OraclesResponse; ts: number; key: string } | null = null;
 
-export const oraclesEndpoint = new Elysia().get('/oracles', ({ query }) => {
-  const parsed = parseInt(query.hours ?? '168');
-  const hours = Number.isFinite(parsed) ? parsed : 168;
-  const now = Date.now();
-  const tenantId = currentTenantId();
-  const cacheKey = `${tenantId ?? '*'}:${hours}`;
-  if (oracleCache && oracleCache.key === cacheKey && (now - oracleCache.ts) < 60_000) return oracleCache.data;
+export function createOraclesEndpoint() {
+  return new Elysia().get('/oracles', ({ query }) => {
+    const parsed = parseInt(query.hours ?? '168');
+    const hours = Number.isFinite(parsed) ? parsed : 168;
+    const now = Date.now();
+    const tenantId = currentTenantId();
+    const cacheKey = `${tenantId ?? '*'}:${hours}`;
+    if (oracleCache && oracleCache.key === cacheKey && (now - oracleCache.ts) < 60_000) return oracleCache.data;
 
-  const cutoff = now - hours * 3600_000;
-  const docProjectWhere = tenantId ? 'AND tenant_id = ?' : '';
-  const learnProjectWhere = tenantId ? 'AND tenant_id = ?' : '';
-  const traceProjectWhere = tenantId ? 'AND tenant_id = ?' : '';
-  const forumProjectWhere = tenantId ? 'AND forum_threads.tenant_id = ?' : '';
-  const tenantArg = tenantId ? [tenantId] : [];
-  const identities = sqlite.prepare(`
+    const cutoff = now - hours * 3600_000;
+    const docProjectWhere = tenantId ? 'AND tenant_id = ?' : '';
+    const learnProjectWhere = tenantId ? 'AND tenant_id = ?' : '';
+    const traceProjectWhere = tenantId ? 'AND tenant_id = ?' : '';
+    const forumProjectWhere = tenantId ? 'AND forum_threads.tenant_id = ?' : '';
+    const tenantArg = tenantId ? [tenantId] : [];
+    const identities = sqlite.prepare(`
     SELECT oracle_name, source, max(last_seen) as last_seen, sum(actions) as actions
     FROM (
       SELECT author as oracle_name, 'forum' as source, max(forum_messages.created_at) as last_seen, count(*) as actions
@@ -88,7 +92,7 @@ export const oraclesEndpoint = new Elysia().get('/oracles', ({ query }) => {
     ORDER BY last_seen DESC
   `).all(cutoff, ...tenantArg, cutoff, ...tenantArg, cutoff, ...tenantArg) as OraclesResponse['identities'];
 
-  const projects = sqlite.prepare(`
+    const projects = sqlite.prepare(`
     SELECT project, count(*) as docs,
            count(DISTINCT type) as types,
            max(created_at) as last_indexed
@@ -98,24 +102,25 @@ export const oraclesEndpoint = new Elysia().get('/oracles', ({ query }) => {
     ORDER BY last_indexed DESC
   `).all(...tenantArg) as OraclesResponse['projects'];
 
-  const result: OraclesResponse = {
-    identities,
-    projects,
-    total_projects: projects.length,
-    total_identities: identities.length,
-    window_hours: hours,
-    tenant: tenantId ? { id: tenantId, scope: 'tenant_id' } : undefined,
-    cached_at: new Date().toISOString(),
-  };
-  oracleCache = { data: result, ts: now, key: cacheKey };
-  return result;
-}, {
-  query: OraclesQuery,
-  response: OraclesResponseSchema,
-  detail: {
-    tags: ['health'],
-    menu: { group: 'hidden' },
-    description: 'Returns active oracle identities and project activity aggregates scoped by query window.',
-    summary: 'Oracle identities + project activity',
-  },
-});
+    const result: OraclesResponse = {
+      identities,
+      projects,
+      total_projects: projects.length,
+      total_identities: identities.length,
+      window_hours: hours,
+      tenant: tenantId ? { id: tenantId, scope: 'tenant_id' } : undefined,
+      cached_at: new Date().toISOString(),
+    };
+    oracleCache = { data: result, ts: now, key: cacheKey };
+    return result;
+  }, {
+    query: oraclesQuerySchema(),
+    response: oraclesResponseSchema(),
+    detail: {
+      tags: ['health'],
+      menu: { group: 'hidden' },
+      description: 'Returns active oracle identities and project activity aggregates scoped by query window.',
+      summary: 'Oracle identities + project activity',
+    },
+  });
+}

--- a/src/routes/health/stats.ts
+++ b/src/routes/health/stats.ts
@@ -5,43 +5,46 @@ import { handleStats } from '../../server/handlers.ts';
 import { handleVectorStats } from '../../server/vector-handlers.ts';
 import { tenantStats } from './tenant-stats.ts';
 
-const StatsResponseSchema = t.Object({
-  total: t.Optional(t.Number()),
-  total_docs: t.Optional(t.Number()),
-  by_type: t.Record(t.String(), t.Number()),
-  is_indexing: t.Optional(t.Boolean()),
-  indexing: t.Optional(t.Boolean()),
-  vector: t.Optional(t.Object({
-    enabled: t.Boolean(),
-    count: t.Number(),
-    collection: t.String(),
-  })),
-  database: t.Optional(t.String()),
-  vault_repo: t.Optional(t.Nullable(t.String())),
-  tenant: t.Optional(t.Object({
-    id: t.String(),
-    scope: t.String(),
-  })),
-  error: t.Optional(t.String()),
-});
+function statsResponseSchema() {
+  return t.Object({
+    total: t.Optional(t.Number()),
+    total_docs: t.Optional(t.Number()),
+    by_type: t.Record(t.String(), t.Number()),
+    is_indexing: t.Optional(t.Boolean()),
+    indexing: t.Optional(t.Boolean()),
+    vector: t.Optional(t.Object({
+      enabled: t.Boolean(),
+      count: t.Number(),
+      collection: t.String(),
+    })),
+    database: t.Optional(t.String()),
+    vault_repo: t.Optional(t.Nullable(t.String())),
+    tenant: t.Optional(t.Object({
+      id: t.String(),
+      scope: t.String(),
+    })),
+    error: t.Optional(t.String()),
+  });
+}
 
-export const statsEndpoint = new Elysia().get('/stats', async () => {
-  try {
-    const stats = tenantStats() ?? handleStats(DB_PATH);
-    const vaultRepo = getSetting('vault_repo');
-    let vectorStats = { vector: { enabled: false, count: 0, collection: 'oracle_knowledge' } };
+export function createStatsEndpoint() {
+  return new Elysia().get('/stats', async () => {
     try {
-      vectorStats = await handleVectorStats();
-    } catch { /* vector unavailable */ }
-    return { ...stats, ...vectorStats, vault_repo: vaultRepo };
-  } catch (err) {
-    if (isDbLockError(err)) {
-      return { total_docs: 0, by_type: {}, indexing: true, error: 'db temporarily unavailable' };
+      const stats = tenantStats() ?? handleStats(DB_PATH);
+      const vaultRepo = getSetting('vault_repo');
+      let vectorStats = { vector: { enabled: false, count: 0, collection: 'oracle_knowledge' } };
+      try {
+        vectorStats = await handleVectorStats();
+      } catch { /* vector unavailable */ }
+      return { ...stats, ...vectorStats, vault_repo: vaultRepo };
+    } catch (err) {
+      if (isDbLockError(err)) {
+        return { total_docs: 0, by_type: {}, indexing: true, error: 'db temporarily unavailable' };
+      }
+      throw err;
     }
-    throw err;
-  }
-}, {
-    response: StatsResponseSchema,
+  }, {
+    response: statsResponseSchema(),
     detail: {
       tags: ['health'],
       menu: { group: 'tools', order: 50 },
@@ -49,3 +52,4 @@ export const statsEndpoint = new Elysia().get('/stats', async () => {
       summary: 'Database and vector stats',
     },
   });
+}

--- a/src/routes/health/thor.ts
+++ b/src/routes/health/thor.ts
@@ -1,13 +1,15 @@
 import { Elysia } from 'elysia';
 import { thorOracleProfile } from '../../oracles/thor.ts';
-import { OracleProfileSchema } from './oracle-profiles.ts';
+import { oracleProfileSchema } from './oracle-profiles.ts';
 
-export const thorOracleEndpoint = new Elysia().get('/oracles/thor', () => thorOracleProfile, {
-  response: OracleProfileSchema,
-  detail: {
-    tags: ['health'],
-    menu: { group: 'hidden' },
-    description: 'Returns the Thor Oracle dev/research awakening profile and Stormforge capabilities.',
-    summary: 'Thor Oracle dev/research profile',
-  },
-});
+export function createThorOracleEndpoint() {
+  return new Elysia().get('/oracles/thor', () => thorOracleProfile, {
+    response: oracleProfileSchema(),
+    detail: {
+      tags: ['health'],
+      menu: { group: 'hidden' },
+      description: 'Returns the Thor Oracle dev/research awakening profile and Stormforge capabilities.',
+      summary: 'Thor Oracle dev/research profile',
+    },
+  });
+}

--- a/src/server/plugin/builtin.ts
+++ b/src/server/plugin/builtin.ts
@@ -6,7 +6,7 @@ import type { ServerPlugin } from './types.ts';
 import { authRoutes } from '../../routes/auth/index.ts';
 import { settingsRoutes } from '../../routes/settings/index.ts';
 import { feedRoutes } from '../../routes/feed/index.ts';
-import { healthRoutes } from '../../routes/health/index.ts';
+import { createHealthRoutes } from '../../routes/health/index.ts';
 import { dashboardRoutes } from '../../routes/dashboard/index.ts';
 import { searchRoutes } from '../../routes/search/index.ts';
 import { conceptsRoutes } from '../../routes/concepts/index.ts';
@@ -71,7 +71,7 @@ export async function createBuiltinServerPlugins(options: BuiltinOptions): Promi
   const plugins: Array<ServerPlugin | null> = [
     routePlugin('gateway', 'standard', () => gatewayRoutes, false),
     createApiManifestExamplePlugin(),
-    routePlugin('health', 'core', () => healthRoutes),
+    routePlugin('health', 'core', () => createHealthRoutes()),
     routePlugin('search', 'core', () => searchRoutes),
     routePlugin('knowledge', 'core', () => knowledgeRoutes),
     routePlugin('concepts', 'core', () => conceptsRoutes),

--- a/tests/config/validate.test.ts
+++ b/tests/config/validate.test.ts
@@ -23,6 +23,13 @@ describe('config env validation', () => {
       .toThrow(/PORT must be <= 65535/);
   });
 
+  test('rejects unknown LOG_FORMAT values before logger startup', () => {
+    expect(() => validateEnv({ env: { HOME: '/tmp/arra-home', LOG_FORMAT: 'verbose' }, emitOptionalWarnings: false }))
+      .toThrow(/LOG_FORMAT must be one of nginx, json, short/);
+    expect(validateEnv({ env: { HOME: '/tmp/arra-home', LOG_FORMAT: 'JSON' }, emitOptionalWarnings: false }).env.LOG_FORMAT)
+      .toBe('JSON');
+  });
+
   test('rejects directory database paths with a clear message', () => {
     const dir = mkdtempSync(join(tmpdir(), 'arra-config-db-'));
     expect(() => validateEnv({ env: { HOME: '/tmp/arra-home', ORACLE_DB_PATH: dir }, emitOptionalWarnings: false }))


### PR DESCRIPTION
## Summary
- Lazily create health sub-routes from factory functions to avoid import-cycle/TDZ failures during /api/health route construction.
- Keep builtin health plugin using createHealthRoutes() instead of an eager module-level health app.
- Validate LOG_FORMAT against supported nginx/json/short modes before logger startup.

## Validation
- bunx tsc --noEmit
- ORACLE_DATA_DIR="$(mktemp -d)" ORACLE_DB_PATH="$ORACLE_DATA_DIR/oracle.db" bun test tests/http/health/unversioned.test.ts tests/http/health/deep.test.ts tests/http/health/status.test.ts tests/http/health/core-hardening.test.ts tests/http/logger/format.test.ts tests/plugins/path-containment.test.ts tests/config/validate.test.ts
- git diff --check origin/alpha...HEAD
- changed-file line counts <= 250

Closes #1597