### PR TITLE
feat(memory): add Challenge 2 closeout endpoint

### DIFF
--- a/MORNING-TAPE.md
+++ b/MORNING-TAPE.md
@@ -40,6 +40,7 @@ Check these before claiming certainty:
 
 - Human-readable durable memory: repo docs, `MORNING-TAPE.md`, `docs/MORNING-TAPE-TEMPLATE.md`, and `ψ/memory/` when present.
 - DB memory: `oracle_memories` through `/api/memory/save`, `/api/memory/recall`, and `/api/memory/search`.
+- Session close-out: `/api/memory/closeout` saves the summary, next action, blockers, and artifacts for future boot.
 - Morning recovery API: `/api/memory/morning-tape` renders recent persisted memories into a two-minute briefing.
 - Vector search helps recall but is not authority; verify against files before claiming done.
 

--- a/docs/http-api-reference.md
+++ b/docs/http-api-reference.md
@@ -48,6 +48,7 @@ Protected routes may require API token/session auth; tenant-aware routes honor `
 | POST | `/api/handoff` | Handoff JSON payload. | Persisted handoff result. |
 | GET | `/api/inbox` | None. | Inbox/knowledge messages. |
 | POST | `/api/memory/save` | `{ content, title?, tags?, source? }` | `{ success, memory, vector }` |
+| POST | `/api/memory/closeout` | `{ summary, title?, next?, blockers?, artifacts?, tags? }` | Challenge 2 close-out memory plus vector index result. |
 | GET | `/api/memory/recall` | `q?, limit?` | `{ query, total, items }` keyword memories. |
 | GET | `/api/memory/search` | `q` required; `limit?` | `{ success, query, total, results }` vector-enriched memories. |
 | GET | `/api/memory/morning-tape` | `limit?, format=json|markdown|md` | Morning tape JSON or `text/markdown`. |

--- a/src/routes/memory/closeout.ts
+++ b/src/routes/memory/closeout.ts
@@ -1,0 +1,41 @@
+import type { MemoryInput } from './store.ts';
+
+export type MemoryCloseoutInput = {
+  summary: string;
+  title?: string;
+  next?: string;
+  blockers?: string[];
+  artifacts?: string[];
+  tags?: string[];
+};
+
+export function formatCloseoutMemory(input: MemoryCloseoutInput, now = new Date()): MemoryInput {
+  const summary = input.summary.trim();
+  if (!summary) throw new Error('closeout summary is required');
+
+  const lines = ['## Summary', summary];
+  addOptionalSection(lines, 'Next boot action', input.next);
+  addListSection(lines, 'Blockers', input.blockers);
+  addListSection(lines, 'Artifacts', input.artifacts);
+
+  return {
+    title: input.title?.trim() || `Session close-out ${now.toISOString().slice(0, 10)}`,
+    content: lines.join('\n\n'),
+    tags: uniqueTags(['challenge-2', 'closeout', 'morning-tape', ...(input.tags ?? [])]),
+    source: 'challenge-2-closeout',
+  };
+}
+
+function addOptionalSection(lines: string[], title: string, value?: string): void {
+  const clean = value?.trim();
+  if (clean) lines.push(`## ${title}`, clean);
+}
+
+function addListSection(lines: string[], title: string, values: string[] = []): void {
+  const clean = values.map((value) => value.trim()).filter(Boolean);
+  if (clean.length) lines.push(`## ${title}`, clean.map((value) => `- ${value}`).join('\n'));
+}
+
+function uniqueTags(tags: string[]): string[] {
+  return [...new Set(tags.map((tag) => tag.trim()).filter(Boolean))];
+}

--- a/src/routes/memory/index.ts
+++ b/src/routes/memory/index.ts
@@ -1,10 +1,11 @@
 import { Elysia } from 'elysia';
-import { MorningTapeQuery, RecallMemoryQuery, SaveMemoryBody, SemanticMemoryQuery } from './model.ts';
+import { MemoryCloseoutBody, MorningTapeQuery, RecallMemoryQuery, SaveMemoryBody, SemanticMemoryQuery } from './model.ts';
 import { createMemoryFanoutEndpoint } from './fanout.ts';
 import { memoryStore, type MemoryInput, type MemoryRecord, type MemoryStore } from './store.ts';
 import { memoryVectorIndex, type MemoryVectorHit, type MemoryVectorIndex } from './vector.ts';
 import { buildMorningTape } from './morning-tape.ts';
 import { MEMORY_CONFIDENCE_STRATEGY, memoryConfidence } from './confidence.ts';
+import { formatCloseoutMemory, type MemoryCloseoutInput } from './closeout.ts';
 import { currentTenantId } from '../../middleware/tenant.ts';
 
 export function createMemoryRoutes(
@@ -24,6 +25,19 @@ export function createMemoryRoutes(
     }, {
       body: SaveMemoryBody,
       detail: { tags: ['memory'], menu: { group: 'hidden' }, summary: 'Save a persisted memory' },
+    })
+    .post('/memory/closeout', async ({ body, set }) => {
+      try {
+        const memory = store.save(formatCloseoutMemory(body as MemoryCloseoutInput));
+        const vector = await vectorIndex.index(memory);
+        return { success: true, memory, vector };
+      } catch (error) {
+        set.status = 400;
+        return { success: false, error: error instanceof Error ? error.message : 'failed to close out memory' };
+      }
+    }, {
+      body: MemoryCloseoutBody,
+      detail: { tags: ['memory'], menu: { group: 'hidden' }, summary: 'Persist a Challenge 2 session close-out memory' },
     })
     .use(createMemoryFanoutEndpoint())
     .get('/memory/morning-tape', ({ query }) => {

--- a/src/routes/memory/model.ts
+++ b/src/routes/memory/model.ts
@@ -7,6 +7,15 @@ export const SaveMemoryBody = t.Object({
   source: t.Optional(t.String()),
 });
 
+export const MemoryCloseoutBody = t.Object({
+  summary: t.String(),
+  title: t.Optional(t.String()),
+  next: t.Optional(t.String()),
+  blockers: t.Optional(t.Array(t.String())),
+  artifacts: t.Optional(t.Array(t.String())),
+  tags: t.Optional(t.Array(t.String())),
+});
+
 export const RecallMemoryQuery = t.Object({
   q: t.Optional(t.String()),
   limit: t.Optional(t.String()),

--- a/tests/http/memory/closeout.test.ts
+++ b/tests/http/memory/closeout.test.ts
@@ -1,0 +1,95 @@
+import { afterAll, expect, test } from 'bun:test';
+import { inArray } from 'drizzle-orm';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { db, oracleMemories } from '../../../src/db/index.ts';
+import { formatCloseoutMemory } from '../../../src/routes/memory/closeout.ts';
+import { createMemoryRoutes } from '../../../src/routes/memory/index.ts';
+import type { MemoryRecord } from '../../../src/routes/memory/store.ts';
+import type { MemoryVectorIndex } from '../../../src/routes/memory/vector.ts';
+
+const savedIds: string[] = [];
+
+afterAll(() => {
+  if (savedIds.length) db.delete(oracleMemories).where(inArray(oracleMemories.id, savedIds)).run();
+});
+
+class CapturingMemoryVectorIndex implements MemoryVectorIndex {
+  readonly memories: MemoryRecord[] = [];
+
+  async index(memory: MemoryRecord) {
+    this.memories.push(memory);
+    return { indexed: true as const };
+  }
+
+  async search() {
+    return [];
+  }
+}
+
+function harness() {
+  const vectorIndex = new CapturingMemoryVectorIndex();
+  const app = createMemoryRoutes(undefined, vectorIndex);
+  return { fetcher: createApiVersionedFetch((request) => app.handle(request)), vectorIndex };
+}
+
+async function json(response: Response) {
+  return JSON.parse(await response.text());
+}
+
+test('formatCloseoutMemory turns a session handoff into bootable memory', () => {
+  const memory = formatCloseoutMemory({
+    summary: 'Finished the morning-tape boot path.',
+    next: 'Open the PR and verify CI.',
+    blockers: ['none'],
+    artifacts: ['PR #1457'],
+    tags: ['codex'],
+  }, new Date('2026-06-17T00:00:00.000Z'));
+
+  expect(memory).toMatchObject({
+    title: 'Session close-out 2026-06-17',
+    source: 'challenge-2-closeout',
+    tags: ['challenge-2', 'closeout', 'morning-tape', 'codex'],
+  });
+  expect(memory.content).toContain('## Next boot action');
+  expect(memory.content).toContain('- PR #1457');
+});
+
+test('POST /api/v1/memory/closeout persists and indexes next-session context', async () => {
+  const { fetcher, vectorIndex } = harness();
+  const unique = `closeout-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const response = await fetcher(new Request('http://local/api/v1/memory/closeout', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      title: 'Challenge 2 closeout',
+      summary: `Saved ${unique} for future boot.`,
+      next: 'Read MORNING-TAPE.md, then run the scoped memory tests.',
+      blockers: ['none'],
+      artifacts: ['MORNING-TAPE.md'],
+      tags: ['academy'],
+    }),
+  }));
+  const body = await json(response);
+  savedIds.push(body.memory.id);
+
+  expect(response.status).toBe(200);
+  expect(body.memory).toMatchObject({ title: 'Challenge 2 closeout', source: 'challenge-2-closeout' });
+  expect(body.memory.tags).toEqual(['challenge-2', 'closeout', 'morning-tape', 'academy']);
+  expect(body.vector).toMatchObject({ indexed: true });
+  expect(vectorIndex.memories[0].content).toContain(unique);
+
+  const tape = await (await fetcher(new Request('http://local/api/v1/memory/morning-tape?format=markdown&limit=5'))).text();
+  expect(tape).toContain(unique);
+  expect(tape).toContain('Read MORNING-TAPE.md');
+});
+
+test('POST /api/v1/memory/closeout rejects blank summaries', async () => {
+  const response = await harness().fetcher(new Request('http://local/api/v1/memory/closeout', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ summary: '   ' }),
+  }));
+
+  expect(response.status).toBe(400);
+  expect(await json(response)).toEqual({ success: false, error: 'closeout summary is required' });
+});


### PR DESCRIPTION
## Summary
- add /api/memory/closeout to persist Challenge 2 session summaries into oracle_memories
- format close-outs with summary, next boot action, blockers, artifacts, and challenge tags
- document the close-out path in MORNING-TAPE.md and HTTP API reference

## Validation
- bunx tsc --noEmit
- ORACLE_DATA_DIR=$(mktemp -d) ORACLE_DB_PATH=$ORACLE_DATA_DIR/oracle.db bun test tests/http/memory/ tests/docs/morning-tape-contract.test.ts
- git diff --check origin/alpha...HEAD
- changed files <= 250 lines