### PR TITLE
fix(metrics): scope counters by tenant

### DIFF
--- a/src/routes/metrics/metrics.ts
+++ b/src/routes/metrics/metrics.ts
@@ -1,4 +1,5 @@
 import { Elysia, t } from 'elysia';
+import { currentTenantId } from '../../middleware/tenant.ts';
 
 export interface MemoryUsageSnapshot {
   rss: number;
@@ -15,6 +16,7 @@ export interface MetricsSnapshot {
   activeConnections: number;
   lastRestart: string;
   memoryUsage: MemoryUsageSnapshot;
+  tenant?: { id: string; scope: 'tenant_id' };
 }
 
 export interface MetricsTrackerOptions {
@@ -27,7 +29,7 @@ export interface MetricsTrackerOptions {
 export interface MetricsTracker {
   begin(request: Request): void;
   end(request: Request): void;
-  snapshot(): MetricsSnapshot;
+  snapshot(tenantId?: string): MetricsSnapshot;
 }
 
 const MemoryUsageSchema = t.Object({
@@ -45,6 +47,7 @@ const MetricsResponseSchema = t.Object({
   activeConnections: t.Number(),
   lastRestart: t.String(),
   memoryUsage: MemoryUsageSchema,
+  tenant: t.Optional(t.Object({ id: t.String(), scope: t.Literal('tenant_id') })),
 });
 
 function round(value: number): number {
@@ -62,38 +65,68 @@ function processMemoryUsage(): MemoryUsageSnapshot {
   };
 }
 
+type MetricsCounter = { requestCount: number; totalResponseMs: number; activeConnections: number };
+type RequestStart = { startedAt: number; tenantId?: string };
+
+function counter(): MetricsCounter {
+  return { requestCount: 0, totalResponseMs: 0, activeConnections: 0 };
+}
+
+function tenantCounter(counters: Map<string, MetricsCounter>, tenantId: string): MetricsCounter {
+  const existing = counters.get(tenantId);
+  if (existing) return existing;
+  const created = counter();
+  counters.set(tenantId, created);
+  return created;
+}
+
+function beginCounter(metrics: MetricsCounter): void {
+  metrics.activeConnections += 1;
+}
+
+function endCounter(metrics: MetricsCounter, elapsedMs: number): void {
+  metrics.activeConnections = Math.max(0, metrics.activeConnections - 1);
+  metrics.requestCount += 1;
+  metrics.totalResponseMs += Math.max(0, elapsedMs);
+}
+
 export function createMetricsTracker(options: MetricsTrackerOptions = {}): MetricsTracker {
   const nowMs = options.nowMs ?? (() => Date.now());
   const startedAtMs = options.startedAtMs ?? nowMs();
   const lastRestart = options.lastRestart ?? new Date(startedAtMs).toISOString();
   const memoryUsage = options.memoryUsage ?? processMemoryUsage;
-  const starts = new WeakMap<Request, number>();
-  let requestCount = 0;
-  let totalResponseMs = 0;
-  let activeConnections = 0;
+  const starts = new WeakMap<Request, RequestStart>();
+  const globalCounter = counter();
+  const tenantCounters = new Map<string, MetricsCounter>();
+
+  const buildSnapshot = (metrics: MetricsCounter, tenantId?: string): MetricsSnapshot => ({
+    uptime: round((nowMs() - startedAtMs) / 1000),
+    requestCount: metrics.requestCount,
+    avgResponseMs: metrics.requestCount === 0 ? 0 : round(metrics.totalResponseMs / metrics.requestCount),
+    activeConnections: metrics.activeConnections,
+    lastRestart,
+    memoryUsage: memoryUsage(),
+    tenant: tenantId ? { id: tenantId, scope: 'tenant_id' } : undefined,
+  });
 
   return {
     begin(request) {
-      activeConnections += 1;
-      starts.set(request, nowMs());
+      const tenantId = currentTenantId();
+      starts.set(request, { startedAt: nowMs(), tenantId });
+      beginCounter(globalCounter);
+      if (tenantId) beginCounter(tenantCounter(tenantCounters, tenantId));
     },
     end(request) {
       const started = starts.get(request);
       if (started === undefined) return;
       starts.delete(request);
-      activeConnections = Math.max(0, activeConnections - 1);
-      requestCount += 1;
-      totalResponseMs += Math.max(0, nowMs() - started);
+      const elapsed = nowMs() - started.startedAt;
+      endCounter(globalCounter, elapsed);
+      if (started.tenantId) endCounter(tenantCounter(tenantCounters, started.tenantId), elapsed);
     },
-    snapshot() {
-      return {
-        uptime: round((nowMs() - startedAtMs) / 1000),
-        requestCount,
-        avgResponseMs: requestCount === 0 ? 0 : round(totalResponseMs / requestCount),
-        activeConnections,
-        lastRestart,
-        memoryUsage: memoryUsage(),
-      };
+    snapshot(tenantId = currentTenantId()) {
+      if (!tenantId) return buildSnapshot(globalCounter);
+      return buildSnapshot(tenantCounter(tenantCounters, tenantId), tenantId);
     },
   };
 }

--- a/tests/http/metrics/tenant-isolation.test.ts
+++ b/tests/http/metrics/tenant-isolation.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
+import {
+  createMetricsLifecycle,
+  createMetricsRoutes,
+  createMetricsTracker,
+} from '../../../src/routes/metrics/index.ts';
+
+test('GET /api/metrics reports counters for only the active tenant', async () => {
+  let now = 1_000;
+  const tracker = createMetricsTracker({
+    startedAtMs: 0,
+    lastRestart: '2026-06-16T00:00:00.000Z',
+    nowMs: () => now,
+    memoryUsage: () => ({ rss: 1, heapTotal: 2, heapUsed: 3, external: 4, arrayBuffers: 5 }),
+  });
+  const app = new Elysia()
+    .use(createMetricsLifecycle(tracker))
+    .get('/api/ping', ({ request }) => {
+      now += request.headers.get(TENANT_HEADER) === 'tenant-a' ? 20 : 40;
+      return { ok: true };
+    })
+    .use(createMetricsRoutes(tracker));
+
+  await handle(app, 'tenant-a', '/api/ping');
+  await handle(app, 'tenant-b', '/api/ping');
+
+  const tenantA = await json(handle(app, 'tenant-a', '/api/metrics'));
+  const tenantB = await json(handle(app, 'tenant-b', '/api/metrics'));
+
+  expect(tenantA).toMatchObject({
+    requestCount: 1,
+    avgResponseMs: 20,
+    activeConnections: 1,
+    tenant: { id: 'tenant-a', scope: 'tenant_id' },
+  });
+  expect(tenantB).toMatchObject({
+    requestCount: 1,
+    avgResponseMs: 40,
+    activeConnections: 1,
+    tenant: { id: 'tenant-b', scope: 'tenant_id' },
+  });
+});
+
+function handle(app: Elysia, tenantId: string, pathname: string) {
+  return createTenantFetch((request) => app.handle(request))(new Request(`http://local${pathname}`, {
+    headers: { [TENANT_HEADER]: tenantId },
+  }));
+}
+
+async function json(response: Promise<Response>) {
+  const res = await response;
+  expect(res.status).toBe(200);
+  return await res.json() as Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary
- maintain per-tenant metrics counters alongside the existing global tracker
- return tenant-scoped request count, average response time, and active connections when a tenant is active
- add HTTP metrics tenant isolation coverage

## Tests
- bun test tests/http/metrics/
- bunx tsc --noEmit
- wc -l src/routes/metrics/metrics.ts tests/http/metrics/tenant-isolation.test.ts tests/http/metrics/basic-metrics.test.ts