### PR TITLE
feat: scope MCP routes by tenant

### DIFF
--- a/src/mcp/http-proxy.ts
+++ b/src/mcp/http-proxy.ts
@@ -1,4 +1,5 @@
 import type { ToolResponse } from '../tools/types.ts';
+import { mcpTenantHeaders, stripMcpTenantArgs, tenantIdFromMcpArgs } from './tenant.ts';
 
 const EMBEDDED_API_VALUES = new Set(['embedded', 'embed', 'off', 'none', 'false', '0']);
 
@@ -136,22 +137,23 @@ function toToolResponse(payload: unknown, isError = false): ToolResponse {
   };
 }
 
-function proxyHeaders(hasBody: boolean): Record<string, string> | undefined {
-  const headers: Record<string, string> = {};
+function proxyHeaders(hasBody: boolean, tenantId?: string): Record<string, string> | undefined {
+  const headers: Record<string, string> = { ...mcpTenantHeaders(tenantId) };
   if (hasBody) headers['content-type'] = 'application/json';
   const token = process.env.ARRA_API_TOKEN?.trim() || process.env.ARRA_API_KEY?.trim();
   if (token) headers.authorization = `Bearer ${token}`;
   return Object.keys(headers).length ? headers : undefined;
 }
 
-export async function proxyToolCall(baseUrl: string | null, toolName: string, args: Record<string, unknown>): Promise<ToolResponse | null> {
+export async function proxyToolCall(baseUrl: string | null, toolName: string, args: Record<string, unknown>, tenantId = tenantIdFromMcpArgs(args)): Promise<ToolResponse | null> {
   if (!baseUrl) return null;
-  const proxyRequest = proxyRequestForTool(toolName, args);
+  const cleanArgs = stripMcpTenantArgs(args);
+  const proxyRequest = proxyRequestForTool(toolName, cleanArgs);
   if (!proxyRequest) return null;
   try {
     const response = await oracleApiFetch(baseUrl, appendQuery(proxyRequest.path, proxyRequest.query), {
       method: proxyRequest.method,
-      headers: proxyHeaders(proxyRequest.body !== undefined),
+      headers: proxyHeaders(proxyRequest.body !== undefined, tenantId),
       body: proxyRequest.body === undefined ? undefined : JSON.stringify(proxyRequest.body),
     });
     return toToolResponse(await readHttpPayload(response), !response.ok);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -16,6 +16,8 @@ import { loadUnifiedPlugins, type UnifiedRuntime } from '../plugins/unified-load
 import { resolveToolName } from './aliases.ts';
 import { proxyToolCall, resolveOracleApiBase } from './http-proxy.ts';
 import { pluginMcpToolsFrom } from './plugin-tools.ts';
+import { runWithTenant } from '../middleware/tenant.ts';
+import { stripMcpTenantArgs, tenantIdFromMcpArgs } from './tenant.ts';
 
 function errorResponse(text: string): ToolResponse {
   return { content: [{ type: 'text', text }], isError: true };
@@ -202,12 +204,14 @@ export class OracleMCPServer {
         return errorResponse(`Error: Tool "${toolName}" is disabled in read-only mode. This Oracle instance is configured for read-only access.`);
       }
       try {
-        const args = request.params.arguments && typeof request.params.arguments === 'object'
+        const rawArgs = request.params.arguments && typeof request.params.arguments === 'object'
           ? request.params.arguments as Record<string, unknown>
           : {};
-        const proxied = await proxyToolCall(this.oracleApiBase, toolName, args);
+        const tenantId = tenantIdFromMcpArgs(rawArgs);
+        const args = stripMcpTenantArgs(rawArgs);
+        const proxied = await proxyToolCall(this.oracleApiBase, toolName, args, tenantId);
         if (proxied) return proxied;
-        return await tool.handler(args, { version: this.version, getToolCtx: () => this.getToolCtx() });
+        return await runWithTenant(tenantId, () => tool.handler(args, { version: this.version, getToolCtx: () => this.getToolCtx() }));
       } catch (error) {
         return errorResponse(`Error: ${error instanceof Error ? error.message : String(error)}`);
       }

--- a/src/mcp/tenant.ts
+++ b/src/mcp/tenant.ts
@@ -1,0 +1,22 @@
+import { TENANT_HEADER, tenantIdFromHeaders } from '../middleware/tenant.ts';
+
+const MCP_TENANT_ARG_KEYS = ['tenantId', 'tenant_id', 'tenant', 'orgId', 'org_id'] as const;
+
+export function tenantIdFromMcpArgs(args: Record<string, unknown>): string | undefined {
+  const explicit = MCP_TENANT_ARG_KEYS
+    .map((key) => args[key])
+    .find((value): value is string => typeof value === 'string' && value.trim().length > 0);
+  const fallback = process.env.ORACLE_TENANT_ID?.trim() || process.env.ORACLE_TENANT?.trim();
+  const tenant = explicit?.trim() || fallback || undefined;
+  return tenant ? tenantIdFromHeaders(new Headers({ [TENANT_HEADER]: tenant })) : undefined;
+}
+
+export function stripMcpTenantArgs(args: Record<string, unknown>): Record<string, unknown> {
+  const stripped = { ...args };
+  for (const key of MCP_TENANT_ARG_KEYS) delete stripped[key];
+  return stripped;
+}
+
+export function mcpTenantHeaders(tenantId: string | undefined): Record<string, string> {
+  return tenantId ? { [TENANT_HEADER]: tenantId } : {};
+}

--- a/src/routes/mcp/tools.ts
+++ b/src/routes/mcp/tools.ts
@@ -1,5 +1,6 @@
 import { Elysia } from 'elysia';
 import type { UnifiedRuntime } from '../../plugins/unified-loader.ts';
+import { currentTenantId } from '../../middleware/tenant.ts';
 import { mcpTools, toMcpToolDefinition, type RuntimeMcpToolManifest } from '../../tools/mcp-manifest.ts';
 
 type PluginTool = UnifiedRuntime['mcpTools'][number];
@@ -38,7 +39,8 @@ function pluginTool(tool: PluginTool): PublicTool {
 export function createMcpRoutes(pluginTools: PluginTool[] = []) {
   return new Elysia({ prefix: '/api' }).get('/mcp/tools', () => {
     const tools = [...mcpTools.map(coreTool), ...pluginTools.map(pluginTool)];
-    return { tools, total: tools.length };
+    const tenantId = currentTenantId();
+    return { tools, total: tools.length, ...(tenantId ? { tenant: { id: tenantId, scope: 'tenant_id' } } : {}) };
   }, {
     detail: {
       tags: ['mcp'],

--- a/tests/http/mcp/tools.test.ts
+++ b/tests/http/mcp/tools.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'bun:test';
 import { createMcpRoutes } from '../../../src/routes/mcp/index.ts';
+import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
 
 test('GET /api/mcp/tools returns core and plugin tool metadata', async () => {
   const app = createMcpRoutes([{
@@ -23,4 +24,12 @@ test('GET /api/mcp/tools returns core and plugin tool metadata', async () => {
     readOnly: true,
   }));
   expect(body.tools.some((tool) => 'handler' in tool)).toBe(false);
+});
+
+test('GET /api/mcp/tools reports active tenant scope', async () => {
+  const handler = createTenantFetch((request) => createMcpRoutes().handle(request));
+  const res = await handler(new Request('http://local/api/mcp/tools', { headers: { [TENANT_HEADER]: 'tenant-a' } }));
+  expect(res.status).toBe(200);
+  const body = await res.json() as { tenant?: Record<string, unknown> };
+  expect(body.tenant).toEqual({ id: 'tenant-a', scope: 'tenant_id' });
 });

--- a/tests/mcp/http-proxy-forwards-tenant.test.ts
+++ b/tests/mcp/http-proxy-forwards-tenant.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from 'bun:test';
+import { proxyToolCall } from '../../src/mcp/http-proxy.ts';
+import { TENANT_HEADER } from '../../src/middleware/tenant.ts';
+
+test('HTTP proxy forwards MCP tenant hints as Oracle tenant header', async () => {
+  let captured: Record<string, unknown> = {};
+  const server = Bun.serve({
+    port: 0,
+    fetch: async (request) => {
+      captured = {
+        tenant: request.headers.get(TENANT_HEADER),
+        body: await request.json(),
+      };
+      return Response.json(captured);
+    },
+  });
+  try {
+    await proxyToolCall(`http://127.0.0.1:${server.port}`, 'oracle_learn', {
+      tenantId: 'tenant-a',
+      pattern: 'tenant scoped learning',
+    });
+    expect(captured.tenant).toBe('tenant-a');
+    expect(captured.body).toEqual({ pattern: 'tenant scoped learning' });
+  } finally {
+    await server.stop();
+  }
+});

--- a/tests/mcp/server-call-handler-tenant-context.test.ts
+++ b/tests/mcp/server-call-handler-tenant-context.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'bun:test';
+import { currentTenantId } from '../../src/middleware/tenant.ts';
+import { callToolHandler, withProxyServer } from './support/server.ts';
+
+test('MCP server runs plugin tool calls inside requested tenant context', async () => {
+  const server = withProxyServer();
+  try {
+    (server as any).unifiedRuntimeReady = Promise.resolve({
+      routes: [], menu: [], cliSubcommands: [], servers: [],
+      pluginStatuses: () => [], init: async () => {}, stop: async () => {},
+      mcpTools: [{ plugin: 'demo', name: 'tenant_probe', handler: 'run', description: 'probe', inputSchema: {} }],
+      callMcpTool: async (_name: string, args: unknown) => ({ tenantId: currentTenantId(), args }),
+    });
+    const response = await callToolHandler(server)({ params: { name: 'tenant_probe', arguments: { tenant_id: 'tenant-b', keep: true } } });
+    const body = JSON.parse(response.content[0].text);
+    expect(body).toEqual({ tenantId: 'tenant-b', args: { keep: true } });
+  } finally {
+    await server.cleanup();
+  }
+});


### PR DESCRIPTION
## Summary
- add MCP tenant hint extraction for tenantId/tenant_id/tenant/orgId arguments
- forward MCP proxy calls with X-Oracle-Tenant and strip control-plane tenant args from proxied payloads
- run embedded/plugin MCP calls inside tenant AsyncLocalStorage context
- report active tenant scope from /api/mcp/tools

## Validation
- bun test tests/http/mcp/ tests/mcp/http-proxy-forwards-tenant.test.ts tests/mcp/server-call-handler-tenant-context.test.ts
- bunx tsc --noEmit
- git diff --check
- ORACLE_DATA_DIR="$(mktemp -d)" bun test tests/mcp/ tests/http/mcp/
- wc -l changed files <= 250

Closes slice of #1650