### PR TITLE
fix: scope plugin routes by tenant

### DIFF
--- a/src/routes/files/plugin-by-name.ts
+++ b/src/routes/files/plugin-by-name.ts
@@ -4,9 +4,12 @@ import { Elysia } from 'elysia';
 import fs from 'fs';
 import path from 'path';
 import { PLUGINS_DIR } from '../../config.ts';
+import { tenantScopedPluginDir } from '../plugins/tenant.ts';
 import { pluginParams } from './model.ts';
 
-const currentPluginsDir = () => process.env.ORACLE_DATA_DIR ? path.join(process.env.ORACLE_DATA_DIR, 'plugins') : PLUGINS_DIR;
+const currentPluginsDir = () => tenantScopedPluginDir(
+  process.env.ORACLE_DATA_DIR ? path.join(process.env.ORACLE_DATA_DIR, 'plugins') : PLUGINS_DIR,
+);
 
 
 export const pluginByNameRoute = new Elysia().get(

--- a/src/routes/files/plugins.ts
+++ b/src/routes/files/plugins.ts
@@ -6,8 +6,11 @@ import { Elysia } from 'elysia';
 import fs from 'fs';
 import path from 'path';
 import { PLUGINS_DIR } from '../../config.ts';
+import { tenantScopedPluginDir } from '../plugins/tenant.ts';
 
-const currentPluginsDir = () => process.env.ORACLE_DATA_DIR ? path.join(process.env.ORACLE_DATA_DIR, 'plugins') : PLUGINS_DIR;
+const currentPluginsDir = () => tenantScopedPluginDir(
+  process.env.ORACLE_DATA_DIR ? path.join(process.env.ORACLE_DATA_DIR, 'plugins') : PLUGINS_DIR,
+);
 
 
 export const pluginsListRoute = new Elysia().get('/api/plugins', () => {

--- a/src/routes/plugins/model.ts
+++ b/src/routes/plugins/model.ts
@@ -15,6 +15,7 @@ import {
   type PublicUnifiedServerManifest,
 } from '../../plugins/unified-manifest.ts';
 import { resolveContainedPluginEntry } from '../../plugins/path-containment.ts';
+import { tenantScopedPluginDir } from './tenant.ts';
 
 export const PLUGIN_DIR = join(homedir(), '.oracle', 'plugins');
 
@@ -66,8 +67,12 @@ export function sanitizePluginName(name: string): string {
   return name.replace(/[^\w.-]/g, '').replace(/\.wasm$/, '');
 }
 
-export function currentPluginDir(): string {
+export function basePluginDir(): string {
   return process.env.ORACLE_PLUGIN_DIR || PLUGIN_DIR;
+}
+
+export function currentPluginDir(): string {
+  return tenantScopedPluginDir(basePluginDir());
 }
 
 export function readPluginManifest(dir: string): RawPluginManifest | null {

--- a/src/routes/plugins/registry.ts
+++ b/src/routes/plugins/registry.ts
@@ -1,7 +1,8 @@
 import { Elysia } from 'elysia';
 import type { LoadedPluginRegistryEntry } from '../../plugins/registry.ts';
-import { currentPluginDir, scanPlugins } from './model.ts';
+import { basePluginDir, scanPlugins } from './model.ts';
 import { readPluginEnabled } from './state.ts';
+import { hasTenantPluginScope, tenantScopedPluginDir } from './tenant.ts';
 
 export interface PluginsRegistryRouteOptions {
   dir?: string;
@@ -10,12 +11,13 @@ export interface PluginsRegistryRouteOptions {
 
 export function createPluginsRegistryRoute(options: PluginsRegistryRouteOptions = {}) {
   return new Elysia().get('/api/plugins', () => {
-    if (!options.registry) return scanPlugins(options.dir);
+    const dir = tenantScopedPluginDir(options.dir ?? basePluginDir());
+    if (!options.registry || hasTenantPluginScope()) return scanPlugins(dir);
     const plugins = options.registry().map((plugin) => ({
       ...plugin,
       enabled: readPluginEnabled(plugin.name) ?? plugin.enabled ?? true,
     }));
-    return { plugins, count: plugins.length, dir: options.dir ?? currentPluginDir() };
+    return { plugins, count: plugins.length, dir };
   }, {
     detail: {
       tags: ['plugins'],

--- a/src/routes/plugins/state.ts
+++ b/src/routes/plugins/state.ts
@@ -3,6 +3,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { Elysia, t } from 'elysia';
 import { sanitizePluginName } from './model.ts';
+import { tenantScopedPluginDirs } from './tenant.ts';
 
 const DEFAULT_PLUGIN_DIRS = [join(homedir(), '.arra', 'plugins'), join(homedir(), '.oracle', 'plugins')];
 
@@ -14,7 +15,7 @@ type PluginManifest = {
 
 function pluginDirs(): string[] {
   const configured = process.env.ARRA_PLUGIN_DIRS?.split(':').map((item) => item.trim()).filter(Boolean);
-  return configured?.length ? configured : DEFAULT_PLUGIN_DIRS;
+  return tenantScopedPluginDirs(configured?.length ? configured : DEFAULT_PLUGIN_DIRS);
 }
 
 function readJson(path: string): PluginManifest | null {

--- a/src/routes/plugins/tenant.ts
+++ b/src/routes/plugins/tenant.ts
@@ -1,0 +1,13 @@
+import { currentTenantId, tenantDataPath } from '../../middleware/tenant.ts';
+
+export function tenantScopedPluginDir(dir: string): string {
+  return tenantDataPath(dir);
+}
+
+export function tenantScopedPluginDirs(dirs: string[]): string[] {
+  return dirs.map(tenantScopedPluginDir);
+}
+
+export function hasTenantPluginScope(): boolean {
+  return Boolean(currentTenantId());
+}

--- a/tests/http/plugins/tenant-isolation.test.ts
+++ b/tests/http/plugins/tenant-isolation.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+import { Elysia } from 'elysia';
+import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
+import { createPluginsRouter } from '../../../src/routes/plugins/index.ts';
+import { pluginByNameRoute } from '../../../src/routes/files/plugin-by-name.ts';
+import { pluginsListRoute } from '../../../src/routes/files/plugins.ts';
+
+const WASM = new Uint8Array([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]);
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedPluginDirs = process.env.ARRA_PLUGIN_DIRS;
+const savedOraclePluginDir = process.env.ORACLE_PLUGIN_DIR;
+let tmp = '';
+
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantA = `tenant-a-${stamp}`;
+const tenantB = `tenant-b-${stamp}`;
+
+type Handler = { handle: (request: Request) => Response | Promise<Response> };
+type PluginList = { plugins: Array<{ name: string }>; dir?: string };
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'arra-plugin-tenant-'));
+});
+
+afterEach(() => {
+  if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = savedDataDir;
+  if (savedPluginDirs === undefined) delete process.env.ARRA_PLUGIN_DIRS;
+  else process.env.ARRA_PLUGIN_DIRS = savedPluginDirs;
+  if (savedOraclePluginDir === undefined) delete process.env.ORACLE_PLUGIN_DIR;
+  else process.env.ORACLE_PLUGIN_DIR = savedOraclePluginDir;
+  if (tmp) rmSync(tmp, { recursive: true, force: true });
+});
+
+function tenantPath(base: string, tenantId: string): string {
+  return join(dirname(base), 'tenants', tenantId, basename(base));
+}
+
+function writeNestedPlugin(base: string, name: string, enabled = true): string {
+  const dir = join(base, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'plugin.json'), JSON.stringify({
+    name,
+    version: '1.0.0',
+    wasm: `${name}.wasm`,
+    enabled,
+  }, null, 2));
+  writeFileSync(join(dir, `${name}.wasm`), WASM);
+  return join(dir, 'plugin.json');
+}
+
+function writeFlatPlugin(base: string, name: string) {
+  mkdirSync(base, { recursive: true });
+  writeFileSync(join(base, `${name}.wasm`), WASM);
+}
+
+function pluginNames(body: PluginList): string[] {
+  return body.plugins.map((plugin) => plugin.name).sort();
+}
+
+function tenantRequest(handler: Handler, tenantId: string, path: string, init: RequestInit = {}) {
+  return createTenantFetch((request) => handler.handle(request))(new Request(`http://local${path}`, {
+    ...init,
+    headers: { 'content-type': 'application/json', [TENANT_HEADER]: tenantId, ...(init.headers ?? {}) },
+  }));
+}
+
+describe('plugin routes tenant isolation', () => {
+  test('lists only the active tenant plugin directory instead of the global registry', async () => {
+    const base = join(tmp, 'plugins');
+    writeNestedPlugin(base, 'global-plugin');
+    writeNestedPlugin(tenantPath(base, tenantA), 'tenant-a-plugin');
+    writeNestedPlugin(tenantPath(base, tenantB), 'tenant-b-plugin');
+
+    const registryLeak = {
+      name: 'registry-leak', version: '1.0.0', status: 'ok', surfaces: [], mcpTools: [],
+      apiRoutes: [], proxy: [], cliSubcommands: [], exportFormats: [], file: '', size: 0,
+      modified: new Date().toISOString(),
+    };
+    const app = new Elysia().use(createPluginsRouter({
+      dir: base,
+      registry: () => [registryLeak] as never,
+    }));
+
+    const globalBody = await (await app.handle(new Request('http://local/api/plugins'))).json() as PluginList;
+    expect(pluginNames(globalBody)).toEqual(['registry-leak']);
+
+    const body = await (await tenantRequest(app, tenantA, '/api/plugins')).json() as PluginList;
+    expect(pluginNames(body)).toEqual(['tenant-a-plugin']);
+    expect(body.dir).toContain(`/tenants/${tenantA}/plugins`);
+  });
+
+  test('serves wasm and toggles state only from the active tenant plugin dir', async () => {
+    const base = join(tmp, 'plugins');
+    process.env.ARRA_PLUGIN_DIRS = base;
+    process.env.ORACLE_PLUGIN_DIR = base;
+    const globalManifest = writeNestedPlugin(base, 'shared-plugin', true);
+    const tenantManifest = writeNestedPlugin(tenantPath(base, tenantA), 'shared-plugin', true);
+    writeNestedPlugin(tenantPath(base, tenantB), 'other-plugin', true);
+    const app = new Elysia().use(createPluginsRouter({ dir: base }));
+
+    const wasm = await tenantRequest(app, tenantA, '/api/plugins/shared-plugin');
+    expect(wasm.status).toBe(200);
+    expect(new Uint8Array(await wasm.arrayBuffer()).slice(0, 4)).toEqual(WASM.slice(0, 4));
+    expect((await tenantRequest(app, tenantB, '/api/plugins/shared-plugin')).status).toBe(404);
+
+    const toggled = await tenantRequest(app, tenantA, '/api/plugins/shared-plugin/state', {
+      method: 'PATCH',
+      body: JSON.stringify({ enabled: false }),
+    });
+    expect(toggled.status).toBe(200);
+    expect(JSON.parse(readFileSync(tenantManifest, 'utf8')).enabled).toBe(false);
+    expect(JSON.parse(readFileSync(globalManifest, 'utf8')).enabled).toBe(true);
+  });
+
+  test('legacy flat plugin routes use the active tenant plugin directory', async () => {
+    process.env.ORACLE_DATA_DIR = tmp;
+    const base = join(tmp, 'plugins');
+    writeFlatPlugin(base, 'global-flat');
+    writeFlatPlugin(tenantPath(base, tenantA), 'tenant-flat');
+    writeFlatPlugin(tenantPath(base, tenantB), 'other-flat');
+    const app = new Elysia().use(pluginsListRoute).use(pluginByNameRoute);
+
+    const body = await (await tenantRequest(app, tenantA, '/api/plugins')).json() as PluginList;
+    expect(pluginNames(body)).toEqual(['tenant-flat']);
+    expect((await tenantRequest(app, tenantA, '/api/plugins/tenant-flat')).status).toBe(200);
+    expect((await tenantRequest(app, tenantB, '/api/plugins/tenant-flat')).status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary
- scope canonical plugin scanner/get/state routes to the active tenant plugin directory
- avoid leaking the global loaded plugin registry for tenant-scoped `/api/plugins` requests
- scope legacy flat `/api/plugins` routes used by files router and add tenant isolation coverage

## Validation
- `bunx tsc --noEmit`
- `bun test tests/http/plugins/` (28 pass)
- `bun test tests/http/files-plugins.test.ts` (20 pass)
- changed files ≤250 lines
