### PR TITLE
fix(mcp): expose tenant scope on tool routes

### DIFF
--- a/src/routes/mcp/tools.ts
+++ b/src/routes/mcp/tools.ts
@@ -1,6 +1,14 @@
 import { Elysia } from 'elysia';
 import type { UnifiedRuntime } from '../../plugins/unified-loader.ts';
 import { mcpTools, toMcpToolDefinition, type RuntimeMcpToolManifest } from '../../tools/mcp-manifest.ts';
+import {
+  currentTenantId,
+  LEGACY_TENANT_HEADER,
+  ORG_HEADER,
+  TENANT_API_KEY_HEADER,
+  TENANT_HEADER,
+  TENANT_TOKEN_HEADER,
+} from '../../middleware/tenant.ts';
 
 type PluginTool = UnifiedRuntime['mcpTools'][number];
 
@@ -11,6 +19,15 @@ type PublicTool = ReturnType<typeof toMcpToolDefinition> & {
   source: 'core' | 'plugin';
   plugin?: string;
 };
+
+const TENANT_VARY_HEADERS = [
+  TENANT_HEADER,
+  LEGACY_TENANT_HEADER,
+  ORG_HEADER,
+  TENANT_TOKEN_HEADER,
+  TENANT_API_KEY_HEADER,
+  'Authorization',
+].join(', ');
 
 function coreTool(tool: RuntimeMcpToolManifest): PublicTool {
   return {
@@ -36,9 +53,13 @@ function pluginTool(tool: PluginTool): PublicTool {
 }
 
 export function createMcpRoutes(pluginTools: PluginTool[] = []) {
-  return new Elysia({ prefix: '/api' }).get('/mcp/tools', () => {
+  return new Elysia({ prefix: '/api' }).get('/mcp/tools', ({ set }) => {
     const tools = [...mcpTools.map(coreTool), ...pluginTools.map(pluginTool)];
-    return { tools, total: tools.length };
+    const tenantId = currentTenantId();
+    if (!tenantId) return { tools, total: tools.length };
+    set.headers[TENANT_HEADER] = tenantId;
+    set.headers.Vary = TENANT_VARY_HEADERS;
+    return { tools, total: tools.length, tenant: { id: tenantId, scope: 'tenant_id' } };
   }, {
     detail: {
       tags: ['mcp'],

--- a/tests/http/mcp/tools.test.ts
+++ b/tests/http/mcp/tools.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'bun:test';
 import { createMcpRoutes } from '../../../src/routes/mcp/index.ts';
+import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
 
 test('GET /api/mcp/tools returns core and plugin tool metadata', async () => {
   const app = createMcpRoutes([{
@@ -23,4 +24,22 @@ test('GET /api/mcp/tools returns core and plugin tool metadata', async () => {
     readOnly: true,
   }));
   expect(body.tools.some((tool) => 'handler' in tool)).toBe(false);
+  expect(body).not.toHaveProperty('tenant');
+});
+
+test('GET /api/mcp/tools reports the active tenant scope when tenant context is set', async () => {
+  const tenantId = `mcp-tenant-${Date.now()}`;
+  const app = createMcpRoutes();
+  const fetcher = createTenantFetch((request) => app.handle(request));
+
+  const res = await fetcher(new Request('http://local/api/mcp/tools', {
+    headers: { [TENANT_HEADER]: tenantId },
+  }));
+  expect(res.status).toBe(200);
+  expect(res.headers.get(TENANT_HEADER)).toBe(tenantId);
+  expect(res.headers.get('vary')).toContain(TENANT_HEADER);
+
+  const body = await res.json() as { tenant?: { id: string; scope: string }; tools: unknown[]; total: number };
+  expect(body.tenant).toEqual({ id: tenantId, scope: 'tenant_id' });
+  expect(body.total).toBe(body.tools.length);
 });


### PR DESCRIPTION
## Summary
- Confirmed no codex-4 PR/branch covers the MCP routes slice for #1650.
- Adds tenant-aware response metadata for /api/mcp/tools when tenant context is active.
- Echoes the active tenant header and varies the route response on tenant/auth headers so MCP tool route responses do not cross tenant request variants.

## Validation
- bunx tsc --noEmit
- ORACLE_DATA_DIR="$(mktemp -d)" ORACLE_DB_PATH="$ORACLE_DATA_DIR/oracle.db" bun test tests/http/mcp/ tests/http/errors/route-cluster-error-paths.test.ts
- git diff --check origin/alpha...HEAD
- changed-file line counts <= 250

Refs #1650