### PR TITLE
fix: forward tenant context in mcp proxy

### DIFF
--- a/src/mcp/http-proxy.ts
+++ b/src/mcp/http-proxy.ts
@@ -1,4 +1,5 @@
 import type { ToolResponse } from '../tools/types.ts';
+import { currentTenantId } from '../middleware/tenant.ts';
 import { mcpTenantHeaders, stripMcpTenantArgs, tenantIdFromMcpArgs } from './tenant.ts';
 
 const EMBEDDED_API_VALUES = new Set(['embedded', 'embed', 'off', 'none', 'false', '0']);
@@ -138,7 +139,7 @@ function toToolResponse(payload: unknown, isError = false): ToolResponse {
 }
 
 function proxyHeaders(hasBody: boolean, tenantId?: string): Record<string, string> | undefined {
-  const headers: Record<string, string> = { ...mcpTenantHeaders(tenantId) };
+  const headers: Record<string, string> = { ...mcpTenantHeaders(tenantId ?? currentTenantId()) };
   if (hasBody) headers['content-type'] = 'application/json';
   const token = process.env.ARRA_API_TOKEN?.trim() || process.env.ARRA_API_KEY?.trim();
   if (token) headers.authorization = `Bearer ${token}`;

--- a/tests/mcp/http-proxy-forwards-tenant.test.ts
+++ b/tests/mcp/http-proxy-forwards-tenant.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'bun:test';
 import { proxyToolCall } from '../../src/mcp/http-proxy.ts';
-import { TENANT_HEADER } from '../../src/middleware/tenant.ts';
+import { runWithTenant, TENANT_HEADER } from '../../src/middleware/tenant.ts';
+import { captureProxyRequest } from './support/http-proxy.ts';
 
 test('HTTP proxy forwards MCP tenant hints as Oracle tenant header', async () => {
   let captured: Record<string, unknown> = {};
@@ -24,4 +25,17 @@ test('HTTP proxy forwards MCP tenant hints as Oracle tenant header', async () =>
   } finally {
     await server.stop();
   }
+});
+
+test('HTTP proxy forwards validated tenant context to Oracle API calls', async () => {
+  const captured = await runWithTenant('tenant-mcp-a', () => (
+    captureProxyRequest('oracle_search', { query: 'tenant scoped' })
+  ));
+
+  expect(captured).toMatchObject({
+    method: 'GET',
+    path: '/api/search',
+    query: { q: 'tenant scoped' },
+    headers: { [TENANT_HEADER.toLowerCase()]: 'tenant-mcp-a' },
+  });
 });

--- a/tests/mcp/support/http-proxy.ts
+++ b/tests/mcp/support/http-proxy.ts
@@ -10,6 +10,7 @@ export async function captureProxyRequest(toolName: string, args: Record<string,
         method: request.method,
         path: url.pathname,
         query: Object.fromEntries(url.searchParams.entries()),
+        headers: Object.fromEntries(request.headers.entries()),
         body: request.headers.get('content-type') ? await request.json() : null,
       };
       return Response.json(captured);


### PR DESCRIPTION
## Summary
- forward the validated tenant context through MCP HTTP proxy calls via `X-Oracle-Tenant`
- expose captured proxy headers in MCP proxy test support
- add regression coverage that a tenant-scoped MCP proxy call reaches the Oracle API with tenant context intact

Refs #1650

## Validation
- bunx tsc --noEmit
- bun test tests/mcp/http-proxy-*.test.ts
- wc -l changed files <=250
