### PR TITLE
fix(settings): scope auth settings by tenant

### DIFF
--- a/src/db/scoped-settings.ts
+++ b/src/db/scoped-settings.ts
@@ -1,0 +1,31 @@
+import { eq } from 'drizzle-orm';
+import { db, settings } from './index.ts';
+import { currentTenantId, DEFAULT_TENANT_ID } from '../middleware/tenant.ts';
+
+function encodeTenantSegment(tenantId: string): string {
+  return Buffer.from(tenantId, 'utf8').toString('base64url');
+}
+
+export function scopedSettingKey(key: string, tenantId = currentTenantId()): string {
+  if (!tenantId || tenantId === DEFAULT_TENANT_ID) return key;
+  return `tenant:${encodeTenantSegment(tenantId)}:${key}`;
+}
+
+export function getScopedSetting(key: string): string | null {
+  const row = db.select()
+    .from(settings)
+    .where(eq(settings.key, scopedSettingKey(key)))
+    .get();
+  return row?.value ?? null;
+}
+
+export function setScopedSetting(key: string, value: string | null): void {
+  const settingKey = scopedSettingKey(key);
+  db.insert(settings)
+    .values({ key: settingKey, value, updatedAt: Date.now() })
+    .onConflictDoUpdate({
+      target: settings.key,
+      set: { value, updatedAt: Date.now() },
+    })
+    .run();
+}

--- a/src/routes/auth/index.ts
+++ b/src/routes/auth/index.ts
@@ -7,7 +7,7 @@
 
 import { Elysia } from 'elysia';
 import { createHmac, timingSafeEqual } from 'crypto';
-import { getSetting } from '../../db/index.ts';
+import { getScopedSetting } from '../../db/scoped-settings.ts';
 import { activeTenantId, DEFAULT_TENANT_ID } from '../../middleware/tenant.ts';
 import { statusRoute } from './status.ts';
 import { loginRoute } from './login.ts';
@@ -113,10 +113,10 @@ export function isAuthenticated(
   request: Request,
   sessionValue: string | undefined,
 ): boolean {
-  const authEnabled = getSetting('auth_enabled') === 'true';
+  const authEnabled = getScopedSetting('auth_enabled') === 'true';
   if (!authEnabled) return true;
 
-  const localBypass = getSetting('auth_local_bypass') !== 'false';
+  const localBypass = getScopedSetting('auth_local_bypass') !== 'false';
   if (localBypass && isLocalNetwork(server, request)) return true;
 
   return verifySessionToken(sessionValue || '', activeTenantId());

--- a/src/routes/auth/login.ts
+++ b/src/routes/auth/login.ts
@@ -1,5 +1,5 @@
 import { Elysia } from 'elysia';
-import { getSetting } from '../../db/index.ts';
+import { getScopedSetting } from '../../db/scoped-settings.ts';
 import {
   SESSION_COOKIE_NAME,
   SESSION_DURATION_MS,
@@ -15,7 +15,7 @@ export const loginRoute = new Elysia().post('/login', async ({ body, server, req
     return { success: false, error: 'Password required' };
   }
 
-  const storedHash = getSetting('auth_password_hash');
+  const storedHash = getScopedSetting('auth_password_hash');
   if (!storedHash) {
     set.status = 400;
     return { success: false, error: 'No password configured' };

--- a/src/routes/auth/status.ts
+++ b/src/routes/auth/status.ts
@@ -1,5 +1,6 @@
 import { Elysia } from 'elysia';
-import { getSetting, isDbLockError } from '../../db/index.ts';
+import { isDbLockError } from '../../db/index.ts';
+import { getScopedSetting } from '../../db/scoped-settings.ts';
 import { activeTenantId } from '../../middleware/tenant.ts';
 import {
   SESSION_COOKIE_NAME,
@@ -10,9 +11,9 @@ import {
 export const statusRoute = new Elysia().get('/status', ({ server, request, cookie }) => {
   const sessionValue = cookie[SESSION_COOKIE_NAME]?.value as string | undefined;
   try {
-    const authEnabled = getSetting('auth_enabled') === 'true';
-    const hasPassword = !!getSetting('auth_password_hash');
-    const localBypass = getSetting('auth_local_bypass') !== 'false';
+    const authEnabled = getScopedSetting('auth_enabled') === 'true';
+    const hasPassword = !!getScopedSetting('auth_password_hash');
+    const localBypass = getScopedSetting('auth_local_bypass') !== 'false';
     const isLocal = isLocalNetwork(server, request);
     const authenticated = isAuthenticated(server, request, sessionValue);
     const tenantId = activeTenantId();

--- a/src/routes/settings/get.ts
+++ b/src/routes/settings/get.ts
@@ -1,12 +1,13 @@
 import { Elysia } from 'elysia';
-import { getSetting } from '../../db/index.ts';
+import { getScopedSetting } from '../../db/scoped-settings.ts';
+import { activeTenantId } from '../../middleware/tenant.ts';
 
 export const getSettingsRoute = new Elysia().get('/', () => {
-  const authEnabled = getSetting('auth_enabled') === 'true';
-  const localBypass = getSetting('auth_local_bypass') !== 'false';
-  const hasPassword = !!getSetting('auth_password_hash');
-  const vaultRepo = getSetting('vault_repo');
-  return { authEnabled, localBypass, hasPassword, vaultRepo };
+  const authEnabled = getScopedSetting('auth_enabled') === 'true';
+  const localBypass = getScopedSetting('auth_local_bypass') !== 'false';
+  const hasPassword = !!getScopedSetting('auth_password_hash');
+  const vaultRepo = getScopedSetting('vault_repo');
+  return { authEnabled, localBypass, hasPassword, vaultRepo, tenantId: activeTenantId() };
 }, {
   detail: {
     tags: ['settings'],

--- a/src/routes/settings/update.ts
+++ b/src/routes/settings/update.ts
@@ -1,10 +1,11 @@
 import { Elysia } from 'elysia';
-import { getSetting, setSetting } from '../../db/index.ts';
+import { getScopedSetting, setScopedSetting } from '../../db/scoped-settings.ts';
+import { activeTenantId } from '../../middleware/tenant.ts';
 import { UpdateSettingsBody } from './model.ts';
 
 export const updateSettingsRoute = new Elysia().post('/', async ({ body, set }) => {
   if (body.newPassword) {
-    const existingHash = getSetting('auth_password_hash');
+    const existingHash = getScopedSetting('auth_password_hash');
     if (existingHash) {
       if (!body.currentPassword) {
         set.status = 400;
@@ -17,11 +18,11 @@ export const updateSettingsRoute = new Elysia().post('/', async ({ body, set }) 
       }
     }
     const hash = await Bun.password.hash(body.newPassword);
-    setSetting('auth_password_hash', hash);
+    setScopedSetting('auth_password_hash', hash);
   }
 
   if (body.removePassword === true) {
-    const existingHash = getSetting('auth_password_hash');
+    const existingHash = getScopedSetting('auth_password_hash');
     if (existingHash && body.currentPassword) {
       const valid = await Bun.password.verify(body.currentPassword, existingHash);
       if (!valid) {
@@ -29,27 +30,28 @@ export const updateSettingsRoute = new Elysia().post('/', async ({ body, set }) 
         return { error: 'Current password is incorrect' };
       }
     }
-    setSetting('auth_password_hash', null);
-    setSetting('auth_enabled', 'false');
+    setScopedSetting('auth_password_hash', null);
+    setScopedSetting('auth_enabled', 'false');
   }
 
   if (typeof body.authEnabled === 'boolean') {
-    if (body.authEnabled && !getSetting('auth_password_hash')) {
+    if (body.authEnabled && !getScopedSetting('auth_password_hash')) {
       set.status = 400;
       return { error: 'Cannot enable auth without password' };
     }
-    setSetting('auth_enabled', body.authEnabled ? 'true' : 'false');
+    setScopedSetting('auth_enabled', body.authEnabled ? 'true' : 'false');
   }
 
   if (typeof body.localBypass === 'boolean') {
-    setSetting('auth_local_bypass', body.localBypass ? 'true' : 'false');
+    setScopedSetting('auth_local_bypass', body.localBypass ? 'true' : 'false');
   }
 
   return {
     success: true,
-    authEnabled: getSetting('auth_enabled') === 'true',
-    localBypass: getSetting('auth_local_bypass') !== 'false',
-    hasPassword: !!getSetting('auth_password_hash'),
+    authEnabled: getScopedSetting('auth_enabled') === 'true',
+    localBypass: getScopedSetting('auth_local_bypass') !== 'false',
+    hasPassword: !!getScopedSetting('auth_password_hash'),
+    tenantId: activeTenantId(),
   };
 }, {
   body: UpdateSettingsBody,

--- a/tests/http/auth/tenant-scope.test.ts
+++ b/tests/http/auth/tenant-scope.test.ts
@@ -19,18 +19,24 @@ const dbMod = await import('../../../src/db/index.ts');
 dbMod.resetDefaultDatabaseForTests(dbPath);
 const { authRoutes } = await import('../../../src/routes/auth/index.ts');
 const { sessionsRoutes } = await import('../../../src/routes/sessions/index.ts');
-const { createTenantFetch, TENANT_HEADER } = await import('../../../src/middleware/tenant.ts');
+const { createTenantFetch, runWithTenant, TENANT_HEADER } = await import('../../../src/middleware/tenant.ts');
+const { setScopedSetting } = await import('../../../src/db/scoped-settings.ts');
 
 const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 const tenantA = `auth-a-${stamp}`;
 const tenantB = `auth-b-${stamp}`;
 const password = `pw-${stamp}`;
+const passwordHash = await Bun.password.hash(password);
 const sessionId = `session-${stamp}`;
 const createdIds: string[] = [];
 
-dbMod.setSetting('auth_enabled', 'true');
-dbMod.setSetting('auth_local_bypass', 'false');
-dbMod.setSetting('auth_password_hash', await Bun.password.hash(password));
+for (const tenantId of [tenantA, tenantB]) {
+  runWithTenant(tenantId, () => {
+    setScopedSetting('auth_enabled', 'true');
+    setScopedSetting('auth_local_bypass', 'false');
+    setScopedSetting('auth_password_hash', passwordHash);
+  });
+}
 
 function restore(name: string, value: string | undefined) {
   if (value === undefined) delete process.env[name];

--- a/tests/http/settings/tenant-isolation.test.ts
+++ b/tests/http/settings/tenant-isolation.test.ts
@@ -1,0 +1,102 @@
+import { afterAll, expect, test } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tempData = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-settings-db-'));
+const previousData = process.env.ORACLE_DATA_DIR;
+const previousDb = process.env.ORACLE_DB_PATH;
+process.env.ORACLE_DATA_DIR = tempData;
+process.env.ORACLE_DB_PATH = path.join(tempData, 'oracle.db');
+
+const dbModule = await import('../../../src/db/index.ts');
+dbModule.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+const { createTenantFetch, TENANT_HEADER } = await import('../../../src/middleware/tenant.ts');
+const { authRoutes } = await import('../../../src/routes/auth/index.ts');
+const { settingsRoutes } = await import('../../../src/routes/settings/index.ts');
+
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantA = `settings-a-${stamp}`;
+const tenantB = `settings-b-${stamp}`;
+const passwordA = `pw-a-${stamp}`;
+const passwordB = `pw-b-${stamp}`;
+
+type Handler = { handle: (request: Request) => Response | Promise<Response> };
+type SettingsBody = { authEnabled: boolean; hasPassword: boolean; tenantId: string };
+
+function tenantRequest(handler: Handler, tenantId: string, pathname: string, init: RequestInit = {}) {
+  return createTenantFetch((request) => handler.handle(request))(new Request(`http://local${pathname}`, {
+    ...init,
+    headers: { 'content-type': 'application/json', [TENANT_HEADER]: tenantId, ...(init.headers ?? {}) },
+  }));
+}
+
+function settingsRequest(tenantId: string, init: RequestInit = {}) {
+  return tenantRequest(settingsRoutes, tenantId, '/api/settings', init);
+}
+
+async function settingsJson(tenantId: string, init: RequestInit = {}) {
+  const res = await settingsRequest(tenantId, init);
+  return { res, body: await res.json() as SettingsBody };
+}
+
+function cookieFrom(response: Response): string {
+  const value = response.headers.get('set-cookie')?.match(/oracle_session=([^;]+)/)?.[1];
+  expect(value).toBeTruthy();
+  return `oracle_session=${value}`;
+}
+
+async function login(tenantId: string, password: string): Promise<Response> {
+  return tenantRequest(authRoutes, tenantId, '/api/auth/login', {
+    method: 'POST',
+    body: JSON.stringify({ password }),
+  });
+}
+
+afterAll(() => {
+  dbModule.closeDb();
+  if (previousData === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = previousData;
+  if (previousDb === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = previousDb;
+  fs.rmSync(tempData, { recursive: true, force: true });
+});
+
+test('/api/settings writes auth settings only for the active tenant', async () => {
+  const configuredA = await settingsJson(tenantA, {
+    method: 'POST',
+    body: JSON.stringify({ newPassword: passwordA, authEnabled: true, localBypass: false }),
+  });
+  expect(configuredA.res.status).toBe(200);
+  expect(configuredA.body).toMatchObject({ authEnabled: true, hasPassword: true, tenantId: tenantA });
+
+  expect((await settingsRequest(tenantA)).status).toBe(401);
+  const tenantBSettings = await settingsJson(tenantB);
+  expect(tenantBSettings.res.status).toBe(200);
+  expect(tenantBSettings.body).toMatchObject({ authEnabled: false, hasPassword: false, tenantId: tenantB });
+
+  const deniedBLogin = await login(tenantB, passwordA);
+  expect(deniedBLogin.status).toBe(400);
+});
+
+test('tenant auth cookies unlock only matching tenant settings', async () => {
+  const loginA = await login(tenantA, passwordA);
+  expect(loginA.status).toBe(200);
+  const cookieA = cookieFrom(loginA);
+
+  const unlockedA = await settingsJson(tenantA, { headers: { cookie: cookieA } });
+  expect(unlockedA.res.status).toBe(200);
+  expect(unlockedA.body).toMatchObject({ authEnabled: true, hasPassword: true, tenantId: tenantA });
+
+  const configuredB = await settingsJson(tenantB, {
+    method: 'POST',
+    body: JSON.stringify({ newPassword: passwordB, authEnabled: true, localBypass: false }),
+  });
+  expect(configuredB.res.status).toBe(200);
+  expect((await settingsRequest(tenantB, { headers: { cookie: cookieA } })).status).toBe(401);
+
+  const loginB = await login(tenantB, passwordB);
+  expect(loginB.status).toBe(200);
+  const cookieB = cookieFrom(loginB);
+  expect((await settingsRequest(tenantB, { headers: { cookie: cookieB } })).status).toBe(200);
+});


### PR DESCRIPTION
## Summary\n- add tenant-scoped setting keys for non-default tenants\n- make auth/status/login and settings get/update read/write tenant-scoped auth settings\n- add HTTP coverage for tenant settings isolation and update tenant auth test seeding\n\n## Validation\n- bunx tsc --noEmit\n- bun test tests/http/settings/ tests/http/auth/tenant-scope.test.ts tests/http/auth-settings.test.ts\n- wc -l changed files (all <=250)