### PR TITLE
fix(tenant): scope session summaries

### DIFF
--- a/src/routes/sessions/store.ts
+++ b/src/routes/sessions/store.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { REPO_ROOT } from '../../config.ts';
 import { db, oracleDocuments, sqlite } from '../../db/index.ts';
 import { buildLearningMarkdown } from '../../learn/markdown.ts';
-import { activeTenantId, DEFAULT_TENANT_ID, tenantIdForWrite } from '../../middleware/tenant.ts';
+import { DEFAULT_TENANT_ID, tenantIdForWrite } from '../../middleware/tenant.ts';
 import { logLearning } from '../../server/logging.ts';
 
 const SUMMARY_ROOT = 'ψ/memory/session-summaries';
@@ -16,11 +16,9 @@ function safeSegment(value: string, limit: number): string {
   return value.replace(/[^a-zA-Z0-9._-]/g, '-').slice(0, limit);
 }
 
-function summaryIdentity(sessionId: string): { id: string; filename: string; sourceFile: string } {
+function summaryIdentity(sessionId: string, tenantId: string): { id: string; filename: string; sourceFile: string } {
   const safeSession = safeSegment(sessionId, 120);
   if (!safeSession) throw new Error('Invalid session id');
-
-  const tenantId = activeTenantId();
   if (tenantId === DEFAULT_TENANT_ID) {
     return {
       id: `session-summary_${safeSession}`,
@@ -41,8 +39,9 @@ export function persistSessionSummary(
   sessionId: string,
   summary: string,
   oracle?: string,
-): { ok: true; source_file: string; learning_id: string } {
-  const identity = summaryIdentity(sessionId);
+): { ok: true; source_file: string; learning_id: string; tenant_id: string } {
+  const tenantId = tenantIdForWrite();
+  const identity = summaryIdentity(sessionId, tenantId);
   const now = new Date();
   const safeSession = safeSegment(sessionId, 120);
   const concepts = ['session-summary', `session-${safeSession}`];
@@ -69,7 +68,7 @@ export function persistSessionSummary(
 
   db.insert(oracleDocuments).values({
     id: identity.id,
-    tenantId: tenantIdForWrite(),
+    tenantId,
     type: 'learning',
     sourceFile: identity.sourceFile,
     concepts: JSON.stringify(concepts),
@@ -84,5 +83,5 @@ export function persistSessionSummary(
     .run(identity.id, content, concepts.join(' '));
   logLearning(identity.id, summary, oracle ? `session-summary from ${oracle}` : 'session-summary', concepts);
 
-  return { ok: true, source_file: identity.sourceFile, learning_id: identity.id };
+  return { ok: true, source_file: identity.sourceFile, learning_id: identity.id, tenant_id: tenantId };
 }

--- a/tests/http/sessions/summary.test.ts
+++ b/tests/http/sessions/summary.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, test } from 'bun:test';
-import { eq } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm';
 import { mkdirSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -18,16 +18,21 @@ process.env.ORACLE_REPO_ROOT = root;
 const dbMod = await import('../../../src/db/index.ts');
 dbMod.resetDefaultDatabaseForTests(dbPath);
 const { sessionsRoutes } = await import('../../../src/routes/sessions/index.ts');
+const { createTenantFetch, DEFAULT_TENANT_ID, TENANT_HEADER } = await import('../../../src/middleware/tenant.ts');
 
 function restore(name: string, value: string | undefined) {
   if (value === undefined) delete process.env[name];
   else process.env[name] = value;
 }
 
-function post(id: string, body: unknown) {
-  return sessionsRoutes.handle(new Request(`http://local/api/session/${id}/summary`, {
+function post(id: string, body: unknown, tenantId?: string) {
+  const headers = {
+    'content-type': 'application/json',
+    ...(tenantId ? { [TENANT_HEADER]: tenantId } : {}),
+  };
+  return createTenantFetch((request) => sessionsRoutes.handle(request))(new Request(`http://local/api/session/${id}/summary`, {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers,
     body: JSON.stringify(body),
   }));
 }
@@ -45,6 +50,40 @@ describe('session summary HTTP route', () => {
     const res = await post('empty-session', { summary: '   ' });
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ error: 'Missing required field: summary' });
+  });
+
+  test('separates identical session summary ids by active tenant', async () => {
+    const sessionId = `shared-session-${Date.now()}`;
+    const tenantA = `session-a-${Date.now()}`;
+    const tenantB = `session-b-${Date.now()}`;
+    const defaultRes = await post(sessionId, { summary: 'Default tenant summary.' });
+    const tenantARes = await post(sessionId, { summary: 'Tenant A summary.', oracle: 'codex' }, tenantA);
+    const tenantBRes = await post(sessionId, { summary: 'Tenant B summary.', oracle: 'codex' }, tenantB);
+    const bodies = await Promise.all([defaultRes, tenantARes, tenantBRes].map(async (res) => await res.json() as Record<string, any>));
+
+    expect([defaultRes.status, tenantARes.status, tenantBRes.status]).toEqual([201, 201, 201]);
+    expect(bodies.map((body) => body.tenant_id)).toEqual([DEFAULT_TENANT_ID, tenantA, tenantB]);
+    expect(new Set(bodies.map((body) => body.learning_id)).size).toBe(3);
+    expect(bodies[0].source_file).toBe(`ψ/memory/session-summaries/${sessionId}.md`);
+    expect(bodies[1].source_file).toBe(`ψ/memory/session-summaries/${tenantA}/${sessionId}.md`);
+    expect(bodies[2].source_file).toBe(`ψ/memory/session-summaries/${tenantB}/${sessionId}.md`);
+
+    const ids = bodies.map((body) => String(body.learning_id));
+    const docs = dbMod.db.select({ id: dbMod.oracleDocuments.id, tenantId: dbMod.oracleDocuments.tenantId })
+      .from(dbMod.oracleDocuments)
+      .where(inArray(dbMod.oracleDocuments.id, ids))
+      .all();
+    const logs = dbMod.db.select({ documentId: dbMod.learnLog.documentId, tenantId: dbMod.learnLog.tenantId })
+      .from(dbMod.learnLog)
+      .where(inArray(dbMod.learnLog.documentId, ids))
+      .all();
+    const ftsRows = ids.map((id) => dbMod.sqlite.prepare('SELECT id FROM oracle_fts WHERE id = ?').get(id));
+
+    expect(docs).toHaveLength(3);
+    expect(logs).toHaveLength(3);
+    expect(docs.map((row) => row.tenantId).sort()).toEqual([DEFAULT_TENANT_ID, tenantA, tenantB].sort());
+    expect(logs.map((row) => row.tenantId).sort()).toEqual([DEFAULT_TENANT_ID, tenantA, tenantB].sort());
+    expect(ftsRows.every(Boolean)).toBe(true);
   });
 
   test('persists a valid session summary as a learning document', async () => {


### PR DESCRIPTION
## Summary
- keep session summary identity and document writes pinned to one resolved active tenant
- return the resolved tenant_id from session summary writes for contract visibility
- add sessions HTTP coverage for default/no-header and same-session-id multi-tenant separation across documents, learn logs, and FTS rows

## Validation
- bunx tsc --noEmit
- bun test tests/http/sessions/
- bun test tests/http/auth/tenant-scope.test.ts
- git diff --check
- changed files <= 250 lines