### PR TITLE
fix(tenant): isolate gateway tenant context

### DIFF
--- a/src/gateway/__tests__/rate-limit.test.ts
+++ b/src/gateway/__tests__/rate-limit.test.ts
@@ -1,14 +1,18 @@
 import { describe, it, expect, beforeEach } from 'bun:test';
 import { loadHooks, runHooks, type GatewayContext } from '../hooks.ts';
 import { _resetRateLimitState } from '../hooks/rate-limit.ts';
+import { TENANT_HEADER } from '../../middleware/tenant.ts';
 
 const pipeline = loadHooks({ onRequest: ['rate-limit'] });
 const run = (ctx: GatewayContext) => runHooks(pipeline.onRequest, ctx);
 
-function ctxFor(ip: string, opts: Record<string, unknown> = {}): GatewayContext {
+function ctxFor(ip: string, opts: Record<string, unknown> = {}, tenantId?: string): GatewayContext {
+  const headers: Record<string, string> = { 'x-forwarded-for': ip };
+  if (tenantId) headers[TENANT_HEADER] = tenantId;
+
   return {
     request: new Request('http://localhost/api/search', {
-      headers: { 'x-forwarded-for': ip },
+      headers,
     }),
     meta: { hook_options: { 'rate-limit': opts } },
   };
@@ -47,6 +51,15 @@ describe('rate-limit hook', () => {
     expect(await run(ctxFor('4.4.4.4', opts))).toBeUndefined();
     // 3.3.3.3 again — blocked
     const blocked = await run(ctxFor('3.3.3.3', opts));
+    expect((blocked as Response).status).toBe(429);
+  });
+
+  it('isolates buckets per tenant when clients share a gateway key', async () => {
+    const opts = { tokens_per_window: 60, window_ms: 60_000, burst: 1 };
+    expect(await run(ctxFor('10.0.0.1', opts, 'tenant-a'))).toBeUndefined();
+    expect(await run(ctxFor('10.0.0.1', opts, 'tenant-b'))).toBeUndefined();
+
+    const blocked = await run(ctxFor('10.0.0.1', opts, 'tenant-a'));
     expect((blocked as Response).status).toBe(429);
   });
 

--- a/src/gateway/__tests__/tenant-proxy.test.ts
+++ b/src/gateway/__tests__/tenant-proxy.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'bun:test';
+
+import { proxyToService } from '../proxy.ts';
+import { LEGACY_TENANT_HEADER, runWithTenant, TENANT_HEADER } from '../../middleware/tenant.ts';
+
+const servers: ReturnType<typeof Bun.serve>[] = [];
+
+type CapturedRequest = {
+  path: string;
+  tenant: string | null;
+};
+
+function startCaptureServer(captured: CapturedRequest[]): string {
+  const server = Bun.serve({
+    hostname: '127.0.0.1',
+    port: 0,
+    fetch: (request) => {
+      const url = new URL(request.url);
+      captured.push({
+        path: `${url.pathname}${url.search}`,
+        tenant: request.headers.get(TENANT_HEADER),
+      });
+      return Response.json({ ok: true });
+    },
+  });
+  servers.push(server);
+  return `http://127.0.0.1:${server.port}`;
+}
+
+function stopServers(): void {
+  while (servers.length) servers.pop()!.stop();
+}
+
+describe('gateway tenant proxying', () => {
+  it('forwards active tenant context to upstream services', async () => {
+    const captured: CapturedRequest[] = [];
+    const target = startCaptureServer(captured);
+
+    try {
+      const response = await runWithTenant('tenant-gateway-a', () => (
+        proxyToService(new Request('http://local/api/search?q=tenant'), { url: target, timeout: 500 })
+      ));
+
+      expect(response.status).toBe(200);
+      expect(captured).toEqual([{ path: '/api/search?q=tenant', tenant: 'tenant-gateway-a' }]);
+    } finally {
+      stopServers();
+    }
+  });
+
+  it('normalizes header-derived tenant ids to the canonical upstream header', async () => {
+    const captured: CapturedRequest[] = [];
+    const target = startCaptureServer(captured);
+
+    try {
+      const response = await proxyToService(
+        new Request('http://local/api/map', { headers: { [LEGACY_TENANT_HEADER]: 'tenant-legacy' } }),
+        { url: target, timeout: 500 },
+      );
+
+      expect(response.status).toBe(200);
+      expect(captured).toEqual([{ path: '/api/map', tenant: 'tenant-legacy' }]);
+    } finally {
+      stopServers();
+    }
+  });
+});

--- a/src/gateway/hooks/rate-limit.ts
+++ b/src/gateway/hooks/rate-limit.ts
@@ -1,9 +1,9 @@
 /**
  * Built-in hook: rate-limit
  *
- * Per-key token bucket. The key is read from a request header (default
- * x-forwarded-for) — fall back to "anonymous" when the header is missing
- * so the bucket still meters traffic, just bucketed globally.
+ * Per-tenant, per-key token bucket. The key is read from a request header
+ * (default x-forwarded-for) — fall back to "anonymous" when the header is
+ * missing so the bucket still meters traffic, just bucketed by tenant.
  *
  * Options (via ctx.meta.hook_options['rate-limit']):
  *   header?: string             // header to read for the key (default x-forwarded-for)
@@ -18,6 +18,7 @@
  * variant can come later.
  */
 import { registerHook, type GatewayContext } from '../hooks.ts';
+import { currentTenantId, tenantIdFor } from '../../middleware/tenant.ts';
 
 interface RateLimitOptions {
   header?: string;
@@ -53,6 +54,11 @@ function extractKey(request: Request, header: string): string {
   return raw.split(',')[0].trim() || 'anonymous';
 }
 
+function tenantBucketKey(request: Request, clientKey: string): string {
+  const tenantId = currentTenantId() ?? tenantIdFor(request) ?? 'default';
+  return `tenant:${tenantId}|client:${clientKey}`;
+}
+
 function refill(bucket: Bucket, ratePerMs: number, max: number, now: number): void {
   const elapsed = now - bucket.lastRefill;
   if (elapsed <= 0) return;
@@ -77,7 +83,7 @@ registerHook({
 
     const ratePerMs = tokensPerWindow / windowMs;
     const now = Date.now();
-    const key = extractKey(ctx.request, headerName);
+    const key = tenantBucketKey(ctx.request, extractKey(ctx.request, headerName));
 
     let bucket = buckets.get(key);
     if (!bucket) {

--- a/src/gateway/proxy.ts
+++ b/src/gateway/proxy.ts
@@ -5,6 +5,7 @@
  * Returns 502 on connection refused, 504 on timeout.
  */
 import type { ServiceConfig } from './config.ts';
+import { currentTenantId, TENANT_HEADER, tenantIdFor } from '../middleware/tenant.ts';
 import { cloneRetryableBody, retryableRequestBody, retryUpstreamRequest } from '../middleware/retry.ts';
 
 const DEFAULT_TIMEOUT_MS = 15_000;
@@ -21,6 +22,9 @@ export async function proxyToService(
   try {
     const headers = new Headers(request.headers);
     headers.delete('host');
+    const tenantId = currentTenantId() ?? tenantIdFor(request);
+    if (tenantId) headers.set(TENANT_HEADER, tenantId);
+
     const body = await retryableRequestBody(request);
 
     const res = await retryUpstreamRequest(() => fetch(targetUrl, {


### PR DESCRIPTION
## Summary
- forward the active/current tenant to upstream gateway services via the canonical X-Oracle-Tenant header
- key gateway rate-limit buckets by tenant + client so tenants sharing gateway keys do not throttle each other
- add gateway tests for tenant header propagation and tenant-isolated rate-limit buckets

## Validation
- bunx tsc --noEmit
- bun test src/gateway/__tests__/
- git diff --check
- changed files <= 250 lines