### PR TITLE
fix(concepts): scope route by tenant

### DIFF
--- a/src/tools/concepts.ts
+++ b/src/tools/concepts.ts
@@ -6,6 +6,7 @@
 
 import { eq, and, ne, isNotNull } from 'drizzle-orm';
 import { oracleDocuments } from '../db/schema.ts';
+import { currentTenantId } from '../middleware/tenant.ts';
 import type { ToolContext, ToolResponse, OracleConceptsInput } from './types.ts';
 
 export const conceptsToolDef = {
@@ -33,7 +34,10 @@ export const conceptsToolDef = {
 export function listConcepts(db: ToolContext['db'], input: OracleConceptsInput) {
   const { limit = 50, type = 'all' } = input;
 
-  const baseCondition = and(isNotNull(oracleDocuments.concepts), ne(oracleDocuments.concepts, '[]'));
+  const filters = [isNotNull(oracleDocuments.concepts), ne(oracleDocuments.concepts, '[]')];
+  const tenantId = currentTenantId();
+  if (tenantId) filters.push(eq(oracleDocuments.tenantId, tenantId));
+  const baseCondition = and(...filters);
   const rows = type === 'all'
     ? db.select({ concepts: oracleDocuments.concepts }).from(oracleDocuments).where(baseCondition).all()
     : db.select({ concepts: oracleDocuments.concepts }).from(oracleDocuments).where(and(baseCondition, eq(oracleDocuments.type, type))).all();

--- a/tests/http/concepts/tenant-isolation.test.ts
+++ b/tests/http/concepts/tenant-isolation.test.ts
@@ -1,0 +1,95 @@
+import { afterAll, expect, test } from 'bun:test';
+import { inArray } from 'drizzle-orm';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const root = mkdtempSync(join(tmpdir(), 'concepts-tenant-'));
+const dbPath = join(root, 'oracle.db');
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = dbPath;
+
+const dbMod = await import('../../../src/db/index.ts');
+dbMod.resetDefaultDatabaseForTests(dbPath);
+const { createTenantFetch, TENANT_HEADER } = await import('../../../src/middleware/tenant.ts');
+const { conceptsRoutes } = await import('../../../src/routes/concepts/index.ts');
+
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantA = `concepts-a-${stamp}`;
+const tenantB = `concepts-b-${stamp}`;
+const docs = {
+  aLearning: `concept-a-learning-${stamp}`,
+  aPrinciple: `concept-a-principle-${stamp}`,
+  bLearning: `concept-b-learning-${stamp}`,
+};
+const concepts = {
+  shared: `shared-${stamp}`,
+  aOnly: `a-only-${stamp}`,
+  bOnly: `b-only-${stamp}`,
+};
+
+function insertDoc(id: string, tenantId: string, type: string, values: string[]) {
+  const now = Date.now();
+  dbMod.db.insert(dbMod.oracleDocuments).values({
+    id,
+    tenantId,
+    type,
+    sourceFile: `ψ/memory/${id}.md`,
+    concepts: JSON.stringify(values),
+    createdAt: now,
+    updatedAt: now,
+    indexedAt: now,
+    project: tenantId,
+    createdBy: 'tenant-test',
+  }).run();
+}
+
+function requestConcepts(tenantId: string, path: string) {
+  return createTenantFetch((request) => conceptsRoutes.handle(request))(new Request(`http://local${path}`, {
+    headers: { [TENANT_HEADER]: tenantId },
+  }));
+}
+
+function countByName(body: { concepts: Array<{ name: string; count: number }> }, name: string): number {
+  return body.concepts.find((concept) => concept.name === name)?.count ?? 0;
+}
+
+insertDoc(docs.aLearning, tenantA, 'learning', [concepts.shared, concepts.aOnly]);
+insertDoc(docs.aPrinciple, tenantA, 'principle', [concepts.shared]);
+insertDoc(docs.bLearning, tenantB, 'learning', [concepts.shared, concepts.bOnly]);
+
+afterAll(() => {
+  dbMod.db.delete(dbMod.oracleDocuments)
+    .where(inArray(dbMod.oracleDocuments.id, Object.values(docs)))
+    .run();
+  if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = savedDataDir;
+  if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = savedDbPath;
+  dbMod.resetDefaultDatabaseForTests();
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('/api/concepts counts only documents from the active tenant', async () => {
+  const res = await requestConcepts(tenantA, '/api/concepts?limit=10');
+  const body = await res.json() as { concepts: Array<{ name: string; count: number }>; total_unique: number };
+
+  expect(res.status).toBe(200);
+  expect(countByName(body, concepts.shared)).toBe(2);
+  expect(countByName(body, concepts.aOnly)).toBe(1);
+  expect(countByName(body, concepts.bOnly)).toBe(0);
+  expect(body.total_unique).toBe(2);
+});
+
+test('/api/concepts keeps type filters inside the selected tenant', async () => {
+  const res = await requestConcepts(tenantB, '/api/concepts?type=learning');
+  const body = await res.json() as { concepts: Array<{ name: string; count: number }>; total_unique: number };
+
+  expect(res.status).toBe(200);
+  expect(countByName(body, concepts.shared)).toBe(1);
+  expect(countByName(body, concepts.bOnly)).toBe(1);
+  expect(countByName(body, concepts.aOnly)).toBe(0);
+  expect(body.total_unique).toBe(2);
+});


### PR DESCRIPTION
## Summary\n- filter oracle concept counts by active tenant when tenant context is present\n- preserve legacy global concepts behavior for requests without a tenant header\n- add HTTP regression coverage for tenant-isolated concept counts and type filters\n\n## Validation\n- bun test tests/http/concepts/tenant-isolation.test.ts\n- bunx tsc --noEmit\n- git diff --check\n- files <= 250 lines