### PR TITLE
fix(menu): scope routes by tenant

### DIFF
--- a/src/db/logistics-schema.ts
+++ b/src/db/logistics-schema.ts
@@ -84,6 +84,7 @@ export const settings = sqliteTable('settings', {
 
 export const menuItems = sqliteTable('menu_items', {
   id: integer('id').primaryKey({ autoIncrement: true }),
+  tenantId: text('tenant_id').default('default').notNull(),
   path: text('path').notNull(),
   label: text('label').notNull(),
   groupKey: text('group_key').notNull(),
@@ -103,6 +104,8 @@ export const menuItems = sqliteTable('menu_items', {
   updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),
   deletedAt: integer('deleted_at', { mode: 'timestamp' }),
 }, (table) => [
+  index('idx_menu_tenant').on(table.tenantId),
+  index('idx_menu_tenant_deleted_position').on(table.tenantId, table.deletedAt, table.position),
   index('idx_menu_parent').on(table.parentId, table.position),
   index('idx_menu_group').on(table.groupKey, table.position),
   index('idx_menu_deleted_at').on(table.deletedAt),

--- a/src/db/migrations/0028_menu_tenant.sql
+++ b/src/db/migrations/0028_menu_tenant.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `menu_items` ADD `tenant_id` text DEFAULT 'default' NOT NULL;--> statement-breakpoint
+CREATE INDEX `idx_menu_tenant` ON `menu_items` (`tenant_id`);--> statement-breakpoint
+CREATE INDEX `idx_menu_tenant_deleted_position` ON `menu_items` (`tenant_id`,`deleted_at`,`position`);

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1781631000000,
       "tag": "0027_schedule_tenant",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "6",
+      "when": 1781664000000,
+      "tag": "0028_menu_tenant",
+      "breakpoints": true
     }
   ]
 }

--- a/src/menu/config.ts
+++ b/src/menu/config.ts
@@ -1,6 +1,7 @@
 import type { MenuItem } from '../routes/menu/model.ts';
 import { getSetting } from '../db/index.ts';
 import { fetchGistMenu, invalidateGistCache } from './gist.ts';
+import { menuSettingKey, menuSourceStateKey } from './tenant.ts';
 
 export type MenuConfig = {
   items: MenuItem[];
@@ -14,19 +15,34 @@ export type MenuSource = {
   status: 'ok' | 'stale' | 'error' | 'none';
 };
 
-let sourceState: MenuSource = {
-  url: null,
-  hash: null,
-  loaded_at: null,
-  status: 'none',
-};
+function emptySource(): MenuSource {
+  return {
+    url: null,
+    hash: null,
+    loaded_at: null,
+    status: 'none',
+  };
+}
+
+const sourceStates = new Map<string, MenuSource>();
+
+function setMenuSource(source: MenuSource): void {
+  sourceStates.set(menuSourceStateKey(), source);
+}
+
+function currentSource(): MenuSource {
+  return sourceStates.get(menuSourceStateKey()) ?? emptySource();
+}
 
 export function getMenuSource(): MenuSource {
-  return { ...sourceState };
+  const source = currentSource();
+  if (source.url || source.status !== 'none') return { ...source };
+  const url = resolveGistUrl();
+  return url ? { url, hash: null, loaded_at: null, status: 'none' } : emptySource();
 }
 
 function resolveGistUrl(): string | null {
-  const fromDb = getSetting('menu_gist_url');
+  const fromDb = getSetting(menuSettingKey('menu_gist_url'));
   if (fromDb && fromDb.trim()) return fromDb.trim();
   const fromEnvNew = process.env.ORACLE_MENU_GIST_URL;
   if (fromEnvNew && fromEnvNew.trim()) return fromEnvNew.trim();
@@ -62,18 +78,19 @@ export async function getMenuConfig(): Promise<MenuConfig> {
 
   const gistUrl = resolveGistUrl();
   if (!gistUrl) {
-    sourceState = { url: null, hash: null, loaded_at: null, status: 'none' };
+    setMenuSource(emptySource());
     return { items, disable };
   }
 
   const result = await fetchGistMenu(gistUrl);
   if (!result) {
-    sourceState = {
+    const previous = getMenuSource();
+    setMenuSource({
       url: gistUrl,
       hash: null,
-      loaded_at: sourceState.url === gistUrl ? sourceState.loaded_at : null,
+      loaded_at: previous.url === gistUrl ? previous.loaded_at : null,
       status: 'error',
-    };
+    });
     return { items, disable };
   }
 
@@ -82,12 +99,12 @@ export async function getMenuConfig(): Promise<MenuConfig> {
     for (const p of result.data.disable) if (typeof p === 'string') disable.add(p);
   }
 
-  sourceState = {
+  setMenuSource({
     url: gistUrl,
     hash: result.hash,
     loaded_at: result.loadedAt,
     status: result.stale ? 'stale' : 'ok',
-  };
+  });
 
   return { items, disable };
 }
@@ -100,5 +117,5 @@ export async function reloadMenuConfig(): Promise<MenuConfig> {
 }
 
 export function _resetMenuSource(): void {
-  sourceState = { url: null, hash: null, loaded_at: null, status: 'none' };
+  sourceStates.clear();
 }

--- a/src/menu/custom-store.ts
+++ b/src/menu/custom-store.ts
@@ -9,8 +9,13 @@ import fs from 'fs';
 import path from 'path';
 import type { MenuItem } from '../routes/menu/model.ts';
 import { ORACLE_DATA_DIR } from '../config.ts';
+import { tenantDataPath } from '../middleware/tenant.ts';
 
 export const CUSTOM_MENU_FILE = path.join(ORACLE_DATA_DIR, 'custom-menu.json');
+
+export function customMenuFile(): string {
+  return tenantDataPath(CUSTOM_MENU_FILE);
+}
 
 export interface CustomMenuInput {
   path: string;
@@ -22,7 +27,7 @@ export interface CustomMenuInput {
 
 type RawFile = { items?: CustomMenuInput[] };
 
-function readRaw(file = CUSTOM_MENU_FILE): CustomMenuInput[] {
+function readRaw(file = customMenuFile()): CustomMenuInput[] {
   if (!fs.existsSync(file)) return [];
   try {
     const parsed = JSON.parse(fs.readFileSync(file, 'utf-8')) as RawFile | CustomMenuInput[];
@@ -36,7 +41,7 @@ function readRaw(file = CUSTOM_MENU_FILE): CustomMenuInput[] {
   }
 }
 
-function writeRaw(items: CustomMenuInput[], file = CUSTOM_MENU_FILE): void {
+function writeRaw(items: CustomMenuInput[], file = customMenuFile()): void {
   fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.writeFileSync(file, JSON.stringify({ items }, null, 2) + '\n');
 }
@@ -47,7 +52,7 @@ function normalizePath(p: string): string {
   return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
 }
 
-export function listCustomMenuItems(file = CUSTOM_MENU_FILE): MenuItem[] {
+export function listCustomMenuItems(file = customMenuFile()): MenuItem[] {
   return readRaw(file).map((i) => ({
     path: normalizePath(i.path),
     label: i.label,
@@ -60,7 +65,7 @@ export function listCustomMenuItems(file = CUSTOM_MENU_FILE): MenuItem[] {
 
 export function addCustomMenuItem(
   input: CustomMenuInput,
-  file = CUSTOM_MENU_FILE,
+  file = customMenuFile(),
 ): { added: boolean; replaced: boolean; item: MenuItem } {
   const cleaned: CustomMenuInput = {
     path: normalizePath(input.path),
@@ -92,7 +97,7 @@ export function addCustomMenuItem(
 
 export function removeCustomMenuItem(
   rawPath: string,
-  file = CUSTOM_MENU_FILE,
+  file = customMenuFile(),
 ): { removed: boolean; path: string } {
   const target = normalizePath(rawPath);
   const existing = readRaw(file);

--- a/src/menu/source-store.ts
+++ b/src/menu/source-store.ts
@@ -16,14 +16,15 @@ import { eq, inArray } from 'drizzle-orm';
 import { db, menuItems, setSetting } from '../db/index.ts';
 import { fetchGistMenu, invalidateGistCache, parseGistUrl } from './gist.ts';
 import { _resetMenuSource } from './config.ts';
-import { CUSTOM_MENU_FILE } from './custom-store.ts';
+import { customMenuFile } from './custom-store.ts';
+import { menuOwnedWhere, menuSettingKey } from './tenant.ts';
 
 export const MENU_GIST_SETTING_KEY = 'menu_gist_url';
 
 export type ApplyMode = 'merge' | 'override';
 
 export async function applyMenuGistUrl(url: string, mode: ApplyMode = 'merge'): Promise<void> {
-  setSetting(MENU_GIST_SETTING_KEY, url);
+  setSetting(menuSettingKey(MENU_GIST_SETTING_KEY), url);
   invalidateGistCache();
   _resetMenuSource();
   if (mode !== 'override') return;
@@ -37,12 +38,12 @@ export async function applyMenuGistUrl(url: string, mode: ApplyMode = 'merge'): 
   const now = new Date();
   db.update(menuItems)
     .set({ touchedAt: null, enabled: true, updatedAt: now })
-    .where(inArray(menuItems.path, paths))
+    .where(menuOwnedWhere(inArray(menuItems.path, paths)))
     .run();
 }
 
 export function clearMenuGistUrl(): void {
-  setSetting(MENU_GIST_SETTING_KEY, null);
+  setSetting(menuSettingKey(MENU_GIST_SETTING_KEY), null);
   invalidateGistCache();
   _resetMenuSource();
 }
@@ -57,16 +58,17 @@ export function resetAllMenu(): ResetAllResult {
   const touchedRows = db
     .update(menuItems)
     .set({ touchedAt: null, enabled: true, updatedAt: now })
-    .where(eq(menuItems.source, 'route'))
+    .where(menuOwnedWhere(eq(menuItems.source, 'route')))
     .returning()
     .all();
   const customDeleted = db
     .delete(menuItems)
-    .where(eq(menuItems.source, 'custom'))
+    .where(menuOwnedWhere(eq(menuItems.source, 'custom')))
     .returning()
     .all();
   try {
-    if (fs.existsSync(CUSTOM_MENU_FILE)) fs.rmSync(CUSTOM_MENU_FILE);
+    const file = customMenuFile();
+    if (fs.existsSync(file)) fs.rmSync(file);
   } catch {
     // best-effort cleanup — seed file may not exist on fresh installs
   }

--- a/src/menu/tenant.ts
+++ b/src/menu/tenant.ts
@@ -1,0 +1,46 @@
+import { and, eq, or, type SQL } from 'drizzle-orm';
+import { menuItems } from '../db/index.ts';
+import {
+  currentTenantId,
+  DEFAULT_TENANT_ID,
+  tenantIdForWrite,
+} from '../middleware/tenant.ts';
+
+function combineWhere(...conditions: Array<SQL | undefined>): SQL | undefined {
+  const active = conditions.filter((condition): condition is SQL => condition !== undefined);
+  if (active.length === 0) return undefined;
+  if (active.length === 1) return active[0];
+  return and(...active);
+}
+
+function sharedRouteWhere(): SQL | undefined {
+  return and(eq(menuItems.tenantId, DEFAULT_TENANT_ID), eq(menuItems.source, 'route'));
+}
+
+export function menuTenantIdForWrite(): string {
+  return tenantIdForWrite();
+}
+
+export function menuSettingKey(key: string): string {
+  const tenantId = currentTenantId();
+  return tenantId && tenantId !== DEFAULT_TENANT_ID ? `tenant:${tenantId}:${key}` : key;
+}
+
+export function menuSourceStateKey(): string {
+  const tenantId = currentTenantId();
+  return tenantId && tenantId !== DEFAULT_TENANT_ID ? tenantId : DEFAULT_TENANT_ID;
+}
+
+export function menuVisibleWhere(base?: SQL): SQL | undefined {
+  const tenantId = currentTenantId();
+  if (!tenantId) return base;
+  return combineWhere(
+    base,
+    or(eq(menuItems.tenantId, tenantId), sharedRouteWhere()),
+  );
+}
+
+export function menuOwnedWhere(base?: SQL): SQL | undefined {
+  const tenantId = currentTenantId();
+  return combineWhere(base, tenantId ? eq(menuItems.tenantId, tenantId) : undefined);
+}

--- a/src/routes/menu/admin-order.ts
+++ b/src/routes/menu/admin-order.ts
@@ -7,6 +7,7 @@
 import { Elysia, t } from 'elysia';
 import { eq } from 'drizzle-orm';
 import { db, menuItems } from '../../db/index.ts';
+import { menuOwnedWhere } from '../../menu/tenant.ts';
 
 export function createMenuOrderRoutes() {
   return new Elysia()
@@ -26,7 +27,7 @@ export function createMenuOrderRoutes() {
                   touchedAt: now,
                   updatedAt: now,
                 })
-                .where(eq(menuItems.id, item.id))
+                .where(menuOwnedWhere(eq(menuItems.id, item.id)))
                 .returning({ id: menuItems.id })
                 .get();
               if (!row) {
@@ -67,7 +68,7 @@ export function createMenuOrderRoutes() {
           set.status = 400;
           return { error: 'invalid id' };
         }
-        const row = db.select().from(menuItems).where(eq(menuItems.id, id)).get();
+        const row = db.select().from(menuItems).where(menuOwnedWhere(eq(menuItems.id, id))).get();
         if (!row) {
           set.status = 404;
           return { error: 'not found' };
@@ -80,7 +81,7 @@ export function createMenuOrderRoutes() {
         const updated = db
           .update(menuItems)
           .set({ touchedAt: null, updatedAt: now })
-          .where(eq(menuItems.id, id))
+          .where(menuOwnedWhere(eq(menuItems.id, id)))
           .returning()
           .get();
         return {

--- a/src/routes/menu/admin.ts
+++ b/src/routes/menu/admin.ts
@@ -8,15 +8,21 @@ import { Elysia, t } from 'elysia';
 import { eq, asc } from 'drizzle-orm';
 import { db, menuItems } from '../../db/index.ts';
 import { ScopeSchema } from './model.ts';
-import { softDeleteMenuItemById } from '../../storage/soft-delete.ts';
+import { softDeleteWhere } from '../../storage/soft-delete.ts';
 import { AccessSchema, GroupSchema, buildTree, toResponse, type MenuRow } from './admin-model.ts';
+import { menuOwnedWhere, menuTenantIdForWrite, menuVisibleWhere } from '../../menu/tenant.ts';
 
 export function createMenuAdminRoutes() {
   return new Elysia()
     .get(
       '/menu/tree',
       () => {
-        const rows = db.select().from(menuItems).orderBy(asc(menuItems.position)).all();
+        const rows = db
+          .select()
+          .from(menuItems)
+          .where(menuVisibleWhere())
+          .orderBy(asc(menuItems.position))
+          .all();
         return { items: buildTree(rows) };
       },
       {
@@ -33,6 +39,7 @@ export function createMenuAdminRoutes() {
         const rows = db
           .select()
           .from(menuItems)
+          .where(menuVisibleWhere())
           .orderBy(asc(menuItems.groupKey), asc(menuItems.position))
           .all();
         return { items: rows.map(toResponse) };
@@ -53,6 +60,7 @@ export function createMenuAdminRoutes() {
           const inserted = db
             .insert(menuItems)
             .values({
+              tenantId: menuTenantIdForWrite(),
               path: body.path,
               label: body.label,
               groupKey: body.groupKey ?? 'main',
@@ -126,7 +134,7 @@ export function createMenuAdminRoutes() {
         const updated = db
           .update(menuItems)
           .set(patch)
-          .where(eq(menuItems.id, id))
+          .where(menuOwnedWhere(eq(menuItems.id, id)))
           .returning()
           .get();
         if (!updated) {
@@ -165,16 +173,20 @@ export function createMenuAdminRoutes() {
           set.status = 400;
           return { error: 'invalid id' };
         }
-        const row = db.select().from(menuItems).where(eq(menuItems.id, id)).get();
+        const row = db.select().from(menuItems).where(menuOwnedWhere(eq(menuItems.id, id))).get();
         if (!row) {
           set.status = 404;
           return { error: 'not found' };
         }
         if (row.source === 'custom') {
-          db.delete(menuItems).where(eq(menuItems.id, id)).run();
+          db.delete(menuItems).where(menuOwnedWhere(eq(menuItems.id, id))).run();
           return { id, deleted: 'hard' as const };
         }
-        softDeleteMenuItemById(db, id, new Date());
+        const deletedAt = new Date();
+        softDeleteWhere(db, menuItems, menuOwnedWhere(eq(menuItems.id, id))!, {
+          deletedAt,
+          set: { enabled: false, touchedAt: deletedAt },
+        });
         return { id, deleted: 'soft' as const };
       },
       {

--- a/src/routes/menu/crud.ts
+++ b/src/routes/menu/crud.ts
@@ -1,9 +1,10 @@
 import { Elysia, t } from 'elysia';
 import { eq } from 'drizzle-orm';
 import { db, menuItems } from '../../db/index.ts';
-import { softDeleteMenuItemById } from '../../storage/soft-delete.ts';
+import { softDeleteWhere } from '../../storage/soft-delete.ts';
 import { ScopeSchema } from './model.ts';
 import { AccessSchema, GroupSchema, toResponse, type MenuRow } from './admin-model.ts';
+import { menuOwnedWhere, menuTenantIdForWrite } from '../../menu/tenant.ts';
 
 function idParam(value: string): number | null {
   const id = Number(value);
@@ -15,6 +16,7 @@ function insertMenuItem(body: MenuCreateBody) {
   return db
     .insert(menuItems)
     .values({
+      tenantId: menuTenantIdForWrite(),
       path: body.path,
       label: body.label,
       groupKey: body.groupKey ?? 'main',
@@ -88,7 +90,7 @@ export function createMenuCrudRoutes() {
         set.status = 400;
         return { error: 'invalid id' };
       }
-      const updated = db.update(menuItems).set(updatePatch(body)).where(eq(menuItems.id, id)).returning().get();
+      const updated = db.update(menuItems).set(updatePatch(body)).where(menuOwnedWhere(eq(menuItems.id, id))).returning().get();
       if (!updated) {
         set.status = 404;
         return { error: 'not found' };
@@ -101,7 +103,11 @@ export function createMenuCrudRoutes() {
         set.status = 400;
         return { error: 'invalid id' };
       }
-      const updated = softDeleteMenuItemById(db, id).rows[0];
+      const deletedAt = new Date();
+      const updated = softDeleteWhere(db, menuItems, menuOwnedWhere(eq(menuItems.id, id))!, {
+        deletedAt,
+        set: { enabled: false, touchedAt: deletedAt },
+      }).rows[0];
       if (!updated) {
         set.status = 404;
         return { error: 'not found' };

--- a/src/routes/menu/list-paginated.ts
+++ b/src/routes/menu/list-paginated.ts
@@ -5,6 +5,7 @@ import { getMenuConfig } from '../../menu/config.ts';
 import { listCustomMenuItems } from '../../menu/custom-store.ts';
 import { buildMenuItems, readApiMenuItemsFromDb } from './menu-items.ts';
 import { ScopeSchema, type MenuItem, type Scope } from './model.ts';
+import { menuVisibleWhere } from '../../menu/tenant.ts';
 
 type MenuRow = typeof menuItems.$inferSelect;
 
@@ -70,7 +71,7 @@ export function menuRowToItem(row: MenuRow): MenuItem {
 }
 
 function readPaginatedMenuItems(pageSize: number, offset: number) {
-  const where = and(eq(menuItems.enabled, true), isNull(menuItems.deletedAt));
+  const where = menuVisibleWhere(and(eq(menuItems.enabled, true), isNull(menuItems.deletedAt)));
   const total = Number(
     db.select({ total: count() }).from(menuItems).where(where).get()?.total ?? 0,
   );

--- a/src/routes/menu/menu-items.ts
+++ b/src/routes/menu/menu-items.ts
@@ -4,6 +4,7 @@ import { getFrontendMenuItems } from '../../menu/index.ts';
 import { getPluginMenuItems } from '../plugins/model.ts';
 import type { MenuExtras } from './menu.ts';
 import type { MenuItem, MenuMeta, Scope } from './model.ts';
+import { menuVisibleWhere } from '../../menu/tenant.ts';
 
 export const API_TO_STUDIO: ReadonlyArray<readonly [string, string]> = [
   ['/api/supersede', '/superseded'],
@@ -83,7 +84,7 @@ export function readApiMenuItemsFromDb(host?: string, scope?: Scope): MenuItem[]
   const rows = db
     .select()
     .from(menuItems)
-    .where(isNull(menuItems.deletedAt))
+    .where(menuVisibleWhere(isNull(menuItems.deletedAt)))
     .orderBy(asc(menuItems.position))
     .all();
 

--- a/src/routes/menu/search.ts
+++ b/src/routes/menu/search.ts
@@ -2,6 +2,7 @@ import { Elysia, t } from 'elysia';
 import { and, asc, eq, isNull, like, or } from 'drizzle-orm';
 import { db, menuItems } from '../../db/index.ts';
 import { menuRowToItem } from './list-paginated.ts';
+import { menuVisibleWhere } from '../../menu/tenant.ts';
 
 function searchTerm(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
@@ -14,11 +15,11 @@ function searchMenuRows(q: string) {
     .select()
     .from(menuItems)
     .where(
-      and(
+      menuVisibleWhere(and(
         eq(menuItems.enabled, true),
         isNull(menuItems.deletedAt),
         or(like(menuItems.label, pattern), like(menuItems.path, pattern)),
-      ),
+      )),
     )
     .orderBy(asc(menuItems.position), asc(menuItems.id))
     .all();

--- a/tests/http/menu/tenant-isolation.test.ts
+++ b/tests/http/menu/tenant-isolation.test.ts
@@ -1,0 +1,138 @@
+import { afterAll, expect, test } from 'bun:test';
+import { eq, like } from 'drizzle-orm';
+import fs from 'fs';
+import path from 'path';
+import { db, menuItems, setSetting } from '../../../src/db/index.ts';
+import { _resetMenuSource } from '../../../src/menu/config.ts';
+import { CUSTOM_MENU_FILE } from '../../../src/menu/custom-store.ts';
+import { _clearGistCache } from '../../../src/menu/gist.ts';
+import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
+import { createMenuRoutes } from '../../../src/routes/menu/index.ts';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const app = createMenuRoutes();
+const handleTenant = createTenantFetch((request) => app.handle(request));
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantA = `tenant-a-${stamp}`;
+const tenantB = `tenant-b-${stamp}`;
+
+function tenantRequest(tenantId: string, pathname: string, init: RequestInit = {}) {
+  return handleTenant(new Request(`http://local${pathname}`, {
+    ...init,
+    headers: { 'content-type': 'application/json', [TENANT_HEADER]: tenantId, ...(init.headers ?? {}) },
+  }));
+}
+
+async function json<T = any>(response: Response): Promise<T> {
+  const text = await response.text();
+  return text ? JSON.parse(text) as T : null as T;
+}
+
+async function postMenuItem(tenantId: string, slug: string) {
+  const response = await tenantRequest(tenantId, '/api/menu/items', {
+    method: 'POST',
+    body: JSON.stringify({ path: `/${slug}`, label: slug, groupKey: 'tools' }),
+  });
+  expect(response.status).toBe(201);
+  return json<{ id: number; path: string }>(response);
+}
+
+afterAll(() => {
+  db.delete(menuItems).where(like(menuItems.path, `%${stamp}%`)).run();
+  setSetting(`tenant:${tenantA}:menu_gist_url`, null);
+  setSetting(`tenant:${tenantB}:menu_gist_url`, null);
+  _clearGistCache();
+  _resetMenuSource();
+  globalThis.fetch = ORIGINAL_FETCH;
+  for (const tenantId of [tenantA, tenantB]) {
+    const tenantDir = path.join(path.dirname(CUSTOM_MENU_FILE), 'tenants', tenantId);
+    if (fs.existsSync(tenantDir)) fs.rmSync(tenantDir, { recursive: true });
+  }
+});
+
+function stubGistFetch() {
+  globalThis.fetch = (async () => {
+    const response = new Response(JSON.stringify({ items: [] }), { status: 200 });
+    Object.defineProperty(response, 'url', {
+      value: 'https://gist.githubusercontent.com/natw/abcdef01/raw/feedface/menu.json',
+    });
+    return response;
+  }) as typeof fetch;
+}
+
+test('menu DB routes list only rows visible to the active tenant', async () => {
+  const itemA = await postMenuItem(tenantA, `tenant-a-menu-${stamp}`);
+  const itemB = await postMenuItem(tenantB, `tenant-b-menu-${stamp}`);
+
+  const storedA = db.select().from(menuItems).where(eq(menuItems.id, itemA.id)).get();
+  expect(storedA?.tenantId).toBe(tenantA);
+
+  const list = await json<{ items: Array<{ path: string }> }>(
+    await tenantRequest(tenantA, '/api/menu/items'),
+  );
+  const paths = list.items.map((item) => item.path);
+  expect(paths).toContain(itemA.path);
+  expect(paths).not.toContain(itemB.path);
+
+  const search = await json<{ data: Array<{ path: string }> }>(
+    await tenantRequest(tenantA, `/api/menu/search?q=${encodeURIComponent(stamp)}`),
+  );
+  const searchPaths = search.data.map((item) => item.path);
+  expect(searchPaths).toContain(itemA.path);
+  expect(searchPaths).not.toContain(itemB.path);
+
+  const denied = await tenantRequest(tenantA, `/api/menu/items/${itemB.id}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ label: 'cross tenant edit' }),
+  });
+  expect(denied.status).toBe(404);
+});
+
+test('file-backed custom menu items use tenant-specific files', async () => {
+  const pathA = `/tenant-a-custom-${stamp}`;
+  const pathB = `/tenant-b-custom-${stamp}`;
+
+  expect((await tenantRequest(tenantA, '/api/menu/custom', {
+    method: 'POST',
+    body: JSON.stringify({ path: pathA, label: `A ${stamp}` }),
+  })).status).toBe(201);
+  expect((await tenantRequest(tenantB, '/api/menu/custom', {
+    method: 'POST',
+    body: JSON.stringify({ path: pathB, label: `B ${stamp}` }),
+  })).status).toBe(201);
+
+  const list = await json<{ items: Array<{ path: string }> }>(
+    await tenantRequest(tenantA, '/api/menu/custom'),
+  );
+  const customPaths = list.items.map((item) => item.path);
+  expect(customPaths).toContain(pathA);
+  expect(customPaths).not.toContain(pathB);
+
+  const tenantFile = path.join(path.dirname(CUSTOM_MENU_FILE), 'tenants', tenantA, 'custom-menu.json');
+  expect(fs.existsSync(tenantFile)).toBe(true);
+});
+
+test('menu source settings stay tenant-specific', async () => {
+  stubGistFetch();
+  const urlA = 'https://gist.github.com/natw/abcdef01';
+  const urlB = 'https://gist.github.com/natw/abcdef02';
+
+  expect((await tenantRequest(tenantA, '/api/menu/source', {
+    method: 'POST',
+    body: JSON.stringify({ url: urlA }),
+  })).status).toBe(200);
+  expect((await tenantRequest(tenantB, '/api/menu/source', {
+    method: 'POST',
+    body: JSON.stringify({ url: urlB }),
+  })).status).toBe(200);
+
+  const sourceA = await json<{ url: string | null }>(
+    await tenantRequest(tenantA, '/api/menu/source'),
+  );
+  const sourceB = await json<{ url: string | null }>(
+    await tenantRequest(tenantB, '/api/menu/source'),
+  );
+
+  expect(sourceA.url).toBe(urlA);
+  expect(sourceB.url).toBe(urlB);
+});


### PR DESCRIPTION
## Summary
- add tenant_id to menu_items and scope menu DB reads/writes by active tenant
- isolate file-backed custom menus and menu source settings per tenant
- add menu tenant isolation coverage for DB, custom file, and source settings

## Validation
- bunx tsc --noEmit
- ORACLE_DATA_DIR=$(mktemp -d /tmp/arra-menu-test-XXXXXX) ORACLE_DB_PATH=$ORACLE_DATA_DIR/oracle.db bun test tests/http/menu/

Base: alpha