### PR TITLE
fix(verify): scope route by tenant

### DIFF
--- a/src/verify/handler.ts
+++ b/src/verify/handler.ts
@@ -9,8 +9,9 @@
 
 import fs from 'fs';
 import path from 'path';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { db, oracleDocuments } from '../db/index.ts';
+import { currentTenantId } from '../middleware/tenant.ts';
 
 export interface VerifyResult {
   counts: {
@@ -65,6 +66,7 @@ export function verifyKnowledgeBase(opts: {
   repoRoot: string;
 }): VerifyResult {
   const { check = true, type, repoRoot } = opts;
+  const tenantId = currentTenantId();
 
   // 1. Walk indexed directories on disk
   const indexedDirs = [
@@ -85,22 +87,30 @@ export function verifyKnowledgeBase(opts: {
 
   // 2. Query DB for all indexed documents
   const typeFilter = type && type !== 'all' ? type : undefined;
-  const dbRows = typeFilter
+  const fields = {
+    id: oracleDocuments.id,
+    sourceFile: oracleDocuments.sourceFile,
+    indexedAt: oracleDocuments.indexedAt,
+    type: oracleDocuments.type,
+  };
+  const dbRows = typeFilter && tenantId
+    ? db.select(fields)
+        .from(oracleDocuments)
+        .where(and(eq(oracleDocuments.type, typeFilter), eq(oracleDocuments.tenantId, tenantId)))
+        .all()
+    : typeFilter
     ? db.select({
-        id: oracleDocuments.id,
-        sourceFile: oracleDocuments.sourceFile,
-        indexedAt: oracleDocuments.indexedAt,
-        type: oracleDocuments.type,
+        ...fields,
       })
         .from(oracleDocuments)
         .where(eq(oracleDocuments.type, typeFilter))
         .all()
-    : db.select({
-        id: oracleDocuments.id,
-        sourceFile: oracleDocuments.sourceFile,
-        indexedAt: oracleDocuments.indexedAt,
-        type: oracleDocuments.type,
-      })
+    : tenantId
+      ? db.select(fields)
+        .from(oracleDocuments)
+        .where(eq(oracleDocuments.tenantId, tenantId))
+        .all()
+      : db.select(fields)
         .from(oracleDocuments)
         .all();
 
@@ -126,12 +136,17 @@ export function verifyKnowledgeBase(opts: {
   const drifted: string[] = [];
   const orphaned: string[] = [];
 
-  // Check each file on disk
-  for (const [relPath, mtimeMs] of diskFiles) {
+  // Tenant-scoped requests can only prove ownership for DB-backed files.
+  // Keep global disk-only "missing"/"untracked" reporting for unscoped runs.
+  const pathsToCheck = tenantId ? dbFileMap.keys() : diskFiles.keys();
+  for (const relPath of pathsToCheck) {
+    const mtimeMs = diskFiles.get(relPath);
     const dbEntry = dbFileMap.get(relPath);
     if (!dbEntry) {
       // File on disk, not in DB
       missing.push(relPath);
+    } else if (mtimeMs === undefined) {
+      continue;
     } else {
       // File exists in both — check drift
       if (mtimeMs > dbEntry.indexedAt) {
@@ -156,11 +171,13 @@ export function verifyKnowledgeBase(opts: {
   // 4. Count untracked files outside indexed dirs.
   const untrackedDirs = ['ψ/inbox'];
   const untracked: string[] = [];
-  for (const dir of untrackedDirs) {
-    const fullDir = path.join(repoRoot, dir);
-    const files = walkMarkdownFiles(fullDir, repoRoot);
-    for (const f of files) {
-      untracked.push(f.relativePath);
+  if (!tenantId) {
+    for (const dir of untrackedDirs) {
+      const fullDir = path.join(repoRoot, dir);
+      const files = walkMarkdownFiles(fullDir, repoRoot);
+      for (const f of files) {
+        untracked.push(f.relativePath);
+      }
     }
   }
 
@@ -172,13 +189,16 @@ export function verifyKnowledgeBase(opts: {
       const entry = dbFileMap.get(sourceFile);
       if (entry) {
         for (const id of entry.ids) {
+          const where = tenantId
+            ? and(eq(oracleDocuments.id, id), eq(oracleDocuments.tenantId, tenantId))
+            : eq(oracleDocuments.id, id);
           db.update(oracleDocuments)
             .set({
               supersededBy: '_verified_orphan',
               supersededAt: now,
               supersededReason: 'File missing from disk (oracle_verify)',
             })
-            .where(eq(oracleDocuments.id, id))
+            .where(where)
             .run();
           fixedOrphans++;
         }

--- a/tests/http/verify/tenant-isolation.test.ts
+++ b/tests/http/verify/tenant-isolation.test.ts
@@ -1,0 +1,118 @@
+import { afterAll, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-verify-tenant-data-'));
+const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-verify-tenant-repo-'));
+const originalDataDir = process.env.ORACLE_DATA_DIR;
+const originalDbPath = process.env.ORACLE_DB_PATH;
+const originalRepoRoot = process.env.ORACLE_REPO_ROOT;
+
+process.env.ORACLE_DATA_DIR = dataDir;
+process.env.ORACLE_DB_PATH = path.join(dataDir, 'oracle.db');
+process.env.ORACLE_REPO_ROOT = repoRoot;
+
+const dbModule = await import('../../../src/db/index.ts');
+dbModule.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+const { db, oracleDocuments } = dbModule;
+const { createTenantFetch, TENANT_HEADER } = await import('../../../src/middleware/tenant.ts');
+const { verifyRoutes } = await import('../../../src/routes/verify/index.ts');
+
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantA = `verify-a-${stamp}`;
+const tenantB = `verify-b-${stamp}`;
+const now = Date.now();
+const paths = {
+  aHealthy: `ψ/memory/learnings/verify-a-${stamp}.md`,
+  bHealthy: `ψ/memory/learnings/verify-b-${stamp}.md`,
+  bOrphan: `ψ/memory/learnings/verify-b-orphan-${stamp}.md`,
+  unindexed: `ψ/memory/learnings/verify-unindexed-${stamp}.md`,
+};
+
+function writeRepoFile(relPath: string, content: string) {
+  const fullPath = path.join(repoRoot, relPath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, content);
+}
+
+function tenantRequest(tenantId: string, url: string, init: RequestInit = {}) {
+  return createTenantFetch((request) => verifyRoutes.handle(request))(new Request(`http://local${url}`, {
+    ...init,
+    headers: { 'content-type': 'application/json', [TENANT_HEADER]: tenantId, ...(init.headers ?? {}) },
+  }));
+}
+
+function seedDoc(id: string, tenantId: string, sourceFile: string) {
+  db.insert(oracleDocuments).values({
+    id,
+    tenantId,
+    type: 'learning',
+    concepts: '[]',
+    sourceFile,
+    createdAt: now,
+    updatedAt: now,
+    indexedAt: now + 60_000,
+    project: tenantId,
+    createdBy: 'test',
+  }).run();
+}
+
+writeRepoFile(paths.aHealthy, '# Tenant A\n');
+writeRepoFile(paths.bHealthy, '# Tenant B\n');
+writeRepoFile(paths.unindexed, '# Unindexed disk-only file\n');
+seedDoc(`verify-a-${stamp}`, tenantA, paths.aHealthy);
+seedDoc(`verify-b-${stamp}`, tenantB, paths.bHealthy);
+seedDoc(`verify-b-orphan-${stamp}`, tenantB, paths.bOrphan);
+
+test('GET /api/verify only reports DB-backed files for the active tenant', async () => {
+  const res = await tenantRequest(tenantA, '/api/verify?type=learning');
+  const body = await res.json() as {
+    counts: { healthy: number; missing: number; orphaned: number; untracked: number };
+    missing: string[];
+    orphaned: string[];
+    untracked: string[];
+  };
+
+  expect(res.status).toBe(200);
+  expect(body.counts.healthy).toBe(1);
+  expect(body.counts.missing).toBe(0);
+  expect(body.orphaned).not.toContain(paths.bOrphan);
+  expect(body.missing).not.toContain(paths.unindexed);
+  expect(body.untracked).toEqual([]);
+});
+
+test('POST /api/verify check=false only flags orphaned docs in the active tenant', async () => {
+  const res = await tenantRequest(tenantB, '/api/verify', {
+    method: 'POST',
+    body: JSON.stringify({ check: false, type: 'learning' }),
+  });
+  const body = await res.json() as { orphaned: string[]; fixed_orphans?: number };
+  const orphan = db.select({ supersededBy: oracleDocuments.supersededBy })
+    .from(oracleDocuments)
+    .where(eq(oracleDocuments.id, `verify-b-orphan-${stamp}`))
+    .get();
+  const tenantAHealthy = db.select({ supersededBy: oracleDocuments.supersededBy })
+    .from(oracleDocuments)
+    .where(eq(oracleDocuments.id, `verify-a-${stamp}`))
+    .get();
+
+  expect(res.status).toBe(200);
+  expect(body.orphaned).toContain(paths.bOrphan);
+  expect(body.fixed_orphans).toBe(1);
+  expect(orphan?.supersededBy).toBe('_verified_orphan');
+  expect(tenantAHealthy?.supersededBy).toBeNull();
+});
+
+afterAll(() => {
+  if (originalDataDir) process.env.ORACLE_DATA_DIR = originalDataDir;
+  else delete process.env.ORACLE_DATA_DIR;
+  if (originalDbPath) process.env.ORACLE_DB_PATH = originalDbPath;
+  else delete process.env.ORACLE_DB_PATH;
+  if (originalRepoRoot) process.env.ORACLE_REPO_ROOT = originalRepoRoot;
+  else delete process.env.ORACLE_REPO_ROOT;
+  dbModule.resetDefaultDatabaseForTests(':memory:');
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  fs.rmSync(repoRoot, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- scope oracle verify DB queries and orphan flagging to the active tenant
- suppress global disk-only missing/untracked reports when a tenant header is present
- add HTTP tenant isolation coverage for /api/verify

## Validation
- bun test tests/http/verify/ src/server/__tests__/verify-route.test.ts
- bunx tsc --noEmit
- git diff --check HEAD~2..HEAD
- wc -l src/verify/handler.ts tests/http/verify/tenant-isolation.test.ts