### PR TITLE
feat: enrich unified plugin search details

### DIFF
--- a/frontend/src/global-search.ts
+++ b/frontend/src/global-search.ts
@@ -30,6 +30,16 @@ function text(value: unknown): string {
   return String(value ?? '').trim();
 }
 
+function menuSourceLabel(item: MenuItem): string {
+  if (item.sourceName) return `${item.source ?? 'source'}:${item.sourceName}`;
+  return item.source ?? 'api';
+}
+
+function toolSourceLabel(tool: McpTool): string {
+  if (tool.source === 'plugin' || tool.plugin) return tool.plugin ? `plugin:${tool.plugin}` : 'plugin';
+  return tool.source ?? 'core';
+}
+
 function haystack(result: GlobalSearchResult): string {
   return `${result.title} ${result.detail} ${result.keywords}`.toLowerCase();
 }
@@ -39,7 +49,7 @@ function menuResult(item: MenuItem): GlobalSearchResult {
     id: `menu:${item.path}:${item.label}`,
     surface: 'menu',
     title: item.label,
-    detail: `${item.path} · ${item.group ?? 'tools'}`,
+    detail: `${item.path} · ${item.group ?? 'tools'} · ${menuSourceLabel(item)}`,
     href: item.path,
     keywords: [item.icon, item.source, item.sourceName, item.order].map(text).join(' '),
   };
@@ -49,11 +59,12 @@ function pluginResult(plugin: PluginEntry): GlobalSearchResult {
   const surfaces = surfacesFor(plugin);
   const server = plugin.server ? `${plugin.server.command} ${(plugin.server.args ?? []).join(' ')}` : '';
   const tools = plugin.mcpTools?.map((tool) => tool.name).join(' ') ?? '';
+  const detail = plugin.description || `Plugin manifest${plugin.version ? ` · ${plugin.version}` : ''}`;
   return {
     id: `plugin:${plugin.name}`,
     surface: 'plugin',
     title: plugin.name,
-    detail: plugin.description || `Plugin manifest${plugin.version ? ` · ${plugin.version}` : ''}`,
+    detail: surfaces.length ? `${detail} · ${surfaces.join(', ')}` : detail,
     href: '/plugins',
     keywords: [plugin.file, plugin.version, plugin.menu?.label, server, tools, surfaces.join(' ')].map(text).join(' '),
   };
@@ -65,7 +76,7 @@ function toolResult(tool: McpTool): GlobalSearchResult {
     id: `mcp:${tool.source ?? 'core'}:${tool.name}`,
     surface: 'mcp-tool',
     title: tool.name,
-    detail: tool.description || 'No description supplied.',
+    detail: `${tool.description || 'No description supplied.'} · ${toolSourceLabel(tool)}`,
     href: mcpToolPath(tool.name),
     keywords: [tool.group, tool.plugin, tool.source, mode].map(text).join(' '),
   };

--- a/frontend/src/pages/McpToolDetailPage.tsx
+++ b/frontend/src/pages/McpToolDetailPage.tsx
@@ -6,6 +6,12 @@ import { groupLabel, schemaText, toolMode } from '../components/toolView';
 import type { McpTool } from '../types';
 
 type PageState = 'loading' | 'ready' | 'error';
+type ToolFetcher = () => Promise<{ tools: McpTool[] }>;
+
+export function toolDetailSource(tool: McpTool): string {
+  if (tool.source === 'plugin' || tool.plugin) return tool.plugin ? `plugin:${tool.plugin}` : 'plugin';
+  return tool.source ?? 'core';
+}
 
 function DetailCard({ label, value }: { label: string; value?: string }) {
   return (
@@ -25,7 +31,7 @@ function ToolSummaryCard({ tool }: { tool: McpTool }) {
       <dl className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
         <DetailCard label="Group" value={groupLabel(tool)} />
         <DetailCard label="Mode" value={toolMode(tool)} />
-        <DetailCard label="Source" value={tool.source ?? 'core'} />
+        <DetailCard label="Source" value={toolDetailSource(tool)} />
         <DetailCard label="Plugin" value={tool.plugin} />
       </dl>
     </section>
@@ -76,17 +82,24 @@ function routeName(value?: string): string {
   }
 }
 
-export function McpToolDetailPage() {
+export function McpToolDetailPage({
+  initialTools,
+  fetcher = fetchMcpTools,
+}: {
+  initialTools?: McpTool[];
+  fetcher?: ToolFetcher;
+} = {}) {
   const toolName = routeName(useParams().name);
-  const [tools, setTools] = useState<McpTool[]>([]);
-  const [state, setState] = useState<PageState>('loading');
+  const [tools, setTools] = useState<McpTool[]>(initialTools ?? []);
+  const [state, setState] = useState<PageState>(initialTools ? 'ready' : 'loading');
   const [error, setError] = useState('');
 
   useEffect(() => {
+    if (initialTools) return;
     let active = true;
     setState('loading');
     setError('');
-    fetchMcpTools()
+    fetcher()
       .then((response) => {
         if (!active) return;
         setTools(response.tools);
@@ -100,11 +113,11 @@ export function McpToolDetailPage() {
     return () => {
       active = false;
     };
-  }, [toolName]);
+  }, [fetcher, initialTools, toolName]);
 
   const tool = useMemo(() => tools.find((entry) => entry.name === toolName), [toolName, tools]);
   const refresh = () => {
-    fetchMcpTools()
+    fetcher()
       .then((response) => setTools(response.tools))
       .catch(() => undefined);
   };

--- a/tests/frontend/pages/mcp-tool-detail-source.test.tsx
+++ b/tests/frontend/pages/mcp-tool-detail-source.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { McpToolDetailPage, toolDetailSource } from '../../../frontend/src/pages/McpToolDetailPage';
+import type { McpTool } from '../../../frontend/src/types';
+import { htmlFor } from '../_render';
+
+const pluginTool: McpTool = {
+  name: 'echo.say',
+  description: 'Echo a message',
+  group: 'echo',
+  source: 'plugin',
+  plugin: 'echo',
+  readOnly: true,
+  inputSchema: { type: 'object' },
+};
+
+describe('McpToolDetailPage source labels', () => {
+  test('normalizes plugin and core source labels', () => {
+    expect(toolDetailSource(pluginTool)).toBe('plugin:echo');
+    expect(toolDetailSource({ name: 'memory.write', description: '', source: 'core' })).toBe('core');
+  });
+
+  test('renders ready-state plugin source details from initial tools', () => {
+    const html = htmlFor(
+      <MemoryRouter initialEntries={['/mcp/tools/echo.say']}>
+        <Routes>
+          <Route path="/mcp/tools/:name" element={<McpToolDetailPage initialTools={[pluginTool]} />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(html).toContain('echo.say');
+    expect(html).toContain('plugin:echo');
+    expect(html).toContain('Input schema');
+  });
+});

--- a/tests/frontend/search/build-global-search-mcp-tool.test.ts
+++ b/tests/frontend/search/build-global-search-mcp-tool.test.ts
@@ -6,8 +6,9 @@ describe('buildGlobalSearchResults MCP tool matches', () => {
     const results = buildGlobalSearchResults({
       menu: [],
       plugins: [],
-      tools: [{ name: 'plugin:echo', description: 'Echo an Oracle memory', group: 'plugin' }],
+      tools: [{ name: 'plugin:echo', description: 'Echo an Oracle memory', group: 'plugin', source: 'plugin', plugin: 'echo' }],
     }, 'memory');
     expect(results).toMatchObject([{ surface: 'mcp-tool', title: 'plugin:echo', href: '/mcp/tools/plugin%3Aecho' }]);
+    expect(results[0].detail).toContain('plugin:echo');
   });
 });

--- a/tests/frontend/search/build-global-search-menu.test.ts
+++ b/tests/frontend/search/build-global-search-menu.test.ts
@@ -4,10 +4,11 @@ import { buildGlobalSearchResults } from '../../../frontend/src/global-search';
 describe('buildGlobalSearchResults menu matches', () => {
   test('returns matching menu rows as navigable unified results', () => {
     const results = buildGlobalSearchResults({
-      menu: [{ label: 'Vector search', path: '/vector', group: 'tools', order: 3 }],
+      menu: [{ label: 'Vector search', path: '/vector', group: 'tools', order: 3, source: 'plugin', sourceName: 'vector' }],
       plugins: [],
       tools: [],
     }, 'vector');
     expect(results).toMatchObject([{ surface: 'menu', title: 'Vector search', href: '/vector' }]);
+    expect(results[0].detail).toBe('/vector · tools · plugin:vector');
   });
 });

--- a/tests/frontend/search/build-global-search-plugin.test.ts
+++ b/tests/frontend/search/build-global-search-plugin.test.ts
@@ -5,9 +5,17 @@ describe('buildGlobalSearchResults plugin matches', () => {
   test('matches plugin descriptions and points results at the plugin page', () => {
     const results = buildGlobalSearchResults({
       menu: [],
-      plugins: [{ name: 'echo', file: '', size: 0, modified: 'now', description: 'Workshop assistant' }],
+      plugins: [{
+        name: 'echo',
+        file: '',
+        size: 0,
+        modified: 'now',
+        description: 'Workshop assistant',
+        mcpTools: [{ name: 'echo.say', description: 'Say echo' }],
+      }],
       tools: [],
     }, 'workshop');
     expect(results).toMatchObject([{ surface: 'plugin', title: 'echo', href: '/plugins' }]);
+    expect(results[0].detail).toContain('mcp');
   });
 });


### PR DESCRIPTION
Refs #1484

## Summary
- show plugin-aware source labels on MCP tool detail pages (for example plugin:echo)
- allow MCP detail ready-state rendering with initial tools for focused UI coverage
- enrich global search result details with menu sources, plugin surface summaries, and MCP plugin/core source labels

## Verification
- git fetch origin && git rebase origin/alpha
- bunx tsc --noEmit
- bun test tests/frontend
- git diff --check
- wc -l frontend/src/global-search.ts tests/frontend/search/build-global-search-menu.test.ts tests/frontend/search/build-global-search-plugin.test.ts tests/frontend/search/build-global-search-mcp-tool.test.ts frontend/src/pages/McpToolDetailPage.tsx tests/frontend/pages/mcp-tool-detail-source.test.tsx