### PR TITLE
feat(maw-plugin): expose menu registry surface

### DIFF
--- a/maw-plugin/__tests__/dual-surface.test.ts
+++ b/maw-plugin/__tests__/dual-surface.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test';
+import handler, { listSubcommands } from '../index.ts';
+
+type Registry = {
+  plugin: string;
+  surface: string;
+  cli: string;
+  menu: string;
+  api: string;
+  commands: Array<{ name: string; help: string }>;
+};
+
+describe('maw arra dual-surface registry', () => {
+  test('menu/API invoke returns the shared CLI command registry', async () => {
+    const result = await handler({ source: 'api', args: {} });
+    const body = JSON.parse(result.output ?? '{}') as Registry;
+
+    expect(result.ok).toBe(true);
+    expect(body).toMatchObject({ plugin: 'arra', surface: 'api', cli: 'arra', menu: '/plugins/arra', api: '/api/arra' });
+    expect(body.commands.map(command => command.name)).toEqual(listSubcommands());
+    expect(body.commands).toContainEqual(expect.objectContaining({ name: 'search', help: expect.stringContaining('search <q>') }));
+    expect(body.commands).toContainEqual(expect.objectContaining({ name: 'serve', help: expect.stringContaining('serve') }));
+  });
+
+  test('empty CLI invoke still renders CLI usage for maw arra --help parity', async () => {
+    const result = await handler({ source: 'cli', args: [] });
+
+    expect(result).toMatchObject({ ok: false, error: 'usage' });
+    expect(result.output).toContain('usage: maw arra <subcommand>');
+  });
+});

--- a/maw-plugin/index.ts
+++ b/maw-plugin/index.ts
@@ -183,6 +183,14 @@ function usage(): InvokeResult {
 }
 export function listSubcommands(): string[] { return [...Object.keys(COMMANDS), ...Object.keys(LOCAL_COMMANDS)].sort(); }
 
+function registryPayload(source?: string): InvokeResult {
+  const commands = listSubcommands().map(name => {
+    const localHelp = LOCAL_COMMANDS[name as keyof typeof LOCAL_COMMANDS];
+    return { name, help: COMMANDS[name]?.help ?? localHelp };
+  });
+  return { ok: true, output: JSON.stringify({ plugin: 'arra', surface: source ?? 'api', cli: 'arra', menu: '/plugins/arra', api: '/api/arra', commands }, null, 2) };
+}
+
 function runFrontend(parsed: Parsed, opener: Opener, env: Record<string, string | undefined>): InvokeResult {
   const url = buildFrontendUrl(env);
   const shouldOpen = b(parsed, 'no_open') !== true;
@@ -225,7 +233,9 @@ export async function runArra(args: string[], request: Requester = requestJson, 
 }
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
-  const result = await runArra(apiArgsToCliArgs(ctx.args));
+  const args = apiArgsToCliArgs(ctx.args);
+  if (ctx.source !== 'cli' && args.length === 0) return registryPayload(ctx.source);
+  const result = await runArra(args);
   if (ctx.source === 'cli' && ctx.writer && result.ok && result.output) {
     ctx.writer(result.output);
     return { ok: true };


### PR DESCRIPTION
## Summary
- add a no-arg menu/API registry response to the installable `maw-plugin` handler
- keep empty CLI invokes on the existing help/usage path
- cover that the menu/API registry and CLI use the same command list

## Validation
- bun test maw-plugin/__tests__/
- bunx tsc --noEmit
- git diff --check HEAD~1..HEAD
- wc -l maw-plugin/index.ts maw-plugin/__tests__/dual-surface.test.ts