### PR TITLE
chore(maw-plugin): record entry artifact hash

### DIFF
--- a/maw-plugin/__tests__/manifest.test.ts
+++ b/maw-plugin/__tests__/manifest.test.ts
@@ -1,4 +1,7 @@
 import { expect, test } from 'bun:test';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import manifest from '../plugin.json' with { type: 'json' };
 
 test('arra maw plugin declares modern dual surfaces and swappable backend config', () => {
@@ -11,4 +14,11 @@ test('arra maw plugin declares modern dual surfaces and swappable backend config
   });
   expect(manifest.menu.map((item) => item.path)).toContain('/plugins/arra');
   expect(manifest.configSchema.properties.dbBackend.enum).toEqual(['http', 'sqlite', 'memory', 'custom']);
+});
+
+test('arra maw plugin records a verifiable entry artifact hash', () => {
+  const entry = join(import.meta.dir, '..', manifest.artifact.path);
+  const sha256 = createHash('sha256').update(readFileSync(entry)).digest('hex');
+
+  expect(manifest.artifact).toEqual({ path: './index.ts', sha256 });
 });

--- a/maw-plugin/plugin.json
+++ b/maw-plugin/plugin.json
@@ -70,5 +70,9 @@
       "order": 10,
       "icon": "search"
     }
-  ]
+  ],
+  "artifact": {
+    "path": "./index.ts",
+    "sha256": "980cf804f039423f3bf24ccc345b6f3273c6d4e4497ca64dfb8dcb042b5100f0"
+  }
 }


### PR DESCRIPTION
## Summary
- add artifact metadata to the installable maw `arra` plugin manifest
- record the SHA-256 for the current entry file for loader/build verification
- add a manifest regression test that verifies the artifact hash matches `index.ts`

## Validation
- bun test maw-plugin/__tests__/
- bunx tsc --noEmit
- git diff --check HEAD~1..HEAD
- wc -l maw-plugin/plugin.json maw-plugin/__tests__/manifest.test.ts