### PR TITLE
feat(vector): harden TurboVec sidecar backend

### DIFF
--- a/sidecar/turbovec/README.md
+++ b/sidecar/turbovec/README.md
@@ -12,11 +12,21 @@ It exposes the standard HTTP contract used by `ProxyVectorAdapter`:
 `GET /health` includes `protocol: "vector-proxy-v1"` so Arra can verify the
 service speaks the #1438 proxy contract.
 
-Run locally:
+Run locally with the dependency-free fallback backend:
 
 ```bash
-python3 sidecar/turbovec/server.py --port 8082
+python3 sidecar/turbovec/server.py --port 8082 --backend fallback
 ```
+
+Run with TurboVec when the optional Python package is installed:
+
+```bash
+python3 sidecar/turbovec/server.py --port 8082 --backend turbovec
+```
+
+The default `--backend auto` uses TurboVec when importable, otherwise it falls
+back to the in-memory cosine index. `--dimensions` and `--bit-width` configure
+the wrapped `IdMapIndex`.
 
 Register it with Arra:
 
@@ -26,6 +36,6 @@ curl -X POST http://localhost:47778/api/vector/services/register \
   -d '{"name":"turbovec","type":"proxy","endpoint":"http://127.0.0.1:8082"}'
 ```
 
-The reference server has a dependency-free cosine index fallback so the protocol
-can be tested anywhere. It is intentionally small; production TurboVec wiring can
-swap the internal `VectorIndex` implementation while preserving the protocol.
+The sidecar uses a lock around index mutation/query to preserve the proxy
+contract under concurrent HTTP requests. Health and stats responses include a
+`backend` field (`turbovec` or `fallback`) for registry diagnostics.

--- a/sidecar/turbovec/server.py
+++ b/sidecar/turbovec/server.py
@@ -16,79 +16,11 @@ the in-memory cosine index is the safe fallback reference path.
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
-import math
-from dataclasses import dataclass, field
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 
-VERSION = "0.1.0"
-PROTOCOL = "vector-proxy-v1"
-DIMENSIONS = 64
-
-
-def embed_text(text: str) -> list[float]:
-    vector = [0.0] * DIMENSIONS
-    tokens = text.lower().split() or [text.lower()]
-    for token in tokens:
-        digest = hashlib.sha256(token.encode("utf-8")).digest()
-        index = int.from_bytes(digest[:2], "big") % DIMENSIONS
-        vector[index] += 1.0
-    norm = math.sqrt(sum(value * value for value in vector)) or 1.0
-    return [value / norm for value in vector]
-
-
-def cosine_distance(left: list[float], right: list[float]) -> float:
-    dot = sum(a * b for a, b in zip(left, right))
-    return max(0.0, 1.0 - dot) * 100.0
-
-
-def metadata_matches(metadata: dict[str, Any], where: dict[str, Any] | None) -> bool:
-    if not where:
-        return True
-    return all(metadata.get(key) == value for key, value in where.items())
-
-
-@dataclass
-class StoredDoc:
-    id: str
-    document: str
-    metadata: dict[str, Any]
-    vector: list[float]
-
-
-@dataclass
-class VectorIndex:
-    name: str
-    docs: dict[str, StoredDoc] = field(default_factory=dict)
-
-    def add(self, documents: list[dict[str, Any]]) -> None:
-        for item in documents:
-            doc_id = str(item["id"])
-            text = str(item.get("document", ""))
-            metadata = dict(item.get("metadata") or {})
-            metadata.setdefault("id", doc_id)
-            vector = item.get("vector")
-            if not isinstance(vector, list) or not all(isinstance(n, (int, float)) for n in vector):
-                vector = embed_text(text)
-            self.docs[doc_id] = StoredDoc(doc_id, text, metadata, [float(n) for n in vector])
-
-    def query(self, text: str, limit: int, where: dict[str, Any] | None = None) -> dict[str, Any]:
-        query_vector = embed_text(text)
-        rows = [
-            (cosine_distance(query_vector, doc.vector), doc)
-            for doc in self.docs.values()
-            if metadata_matches(doc.metadata, where)
-        ]
-        rows.sort(key=lambda item: item[0])
-        selected = rows[: max(1, min(limit, 100))]
-        return {
-            "ids": [doc.id for _, doc in selected],
-            "documents": [doc.document for _, doc in selected],
-            "distances": [distance for distance, _ in selected],
-            "metadatas": [doc.metadata for _, doc in selected],
-        }
+from vector_index import DIMENSIONS, PROTOCOL, VERSION, VectorIndex
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -113,9 +45,19 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_GET(self) -> None:
         if self.path == "/health":
-            return self.send_json({"status": "ok", "name": self.index.name, "version": VERSION, "protocol": PROTOCOL})
+            return self.send_json({
+                "status": "ok",
+                "name": self.index.name,
+                "version": VERSION,
+                "protocol": PROTOCOL,
+                "backend": self.index.backend,
+            })
         if self.path == "/vectors/stats":
-            return self.send_json({"count": len(self.index.docs), "name": self.index.name})
+            return self.send_json({
+                "count": self.index.count(),
+                "name": self.index.name,
+                "backend": self.index.backend,
+            })
         self.send_json({"error": "not found"}, 404)
 
     def do_POST(self) -> None:
@@ -138,7 +80,7 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_DELETE(self) -> None:
         if self.path == "/vectors/collection":
-            self.index.docs.clear()
+            self.index.clear()
             return self.send_json({"success": True})
         self.send_json({"error": "not found"}, 404)
 
@@ -148,11 +90,21 @@ def main() -> None:
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8082)
     parser.add_argument("--name", default="turbovec")
+    parser.add_argument("--dimensions", type=int, default=DIMENSIONS)
+    parser.add_argument("--bit-width", type=int, default=4)
+    parser.add_argument("--backend", choices=["auto", "turbovec", "fallback"], default="auto")
     args = parser.parse_args()
 
-    Handler.index = VectorIndex(args.name)
+    Handler.index = VectorIndex(
+        args.name,
+        dimensions=args.dimensions,
+        bit_width=args.bit_width,
+        prefer_turbovec=args.backend != "fallback",
+    )
+    if args.backend == "turbovec" and Handler.index.backend != "turbovec":
+        raise SystemExit("turbovec backend requested but package is not installed")
     server = ThreadingHTTPServer((args.host, args.port), Handler)
-    print(f"[turbovec-sidecar] listening on http://{args.host}:{args.port}")
+    print(f"[turbovec-sidecar] listening on http://{args.host}:{args.port} ({Handler.index.backend})")
     server.serve_forever()
 
 

--- a/sidecar/turbovec/vector_index.py
+++ b/sidecar/turbovec/vector_index.py
@@ -1,0 +1,184 @@
+"""Vector index implementation for the TurboVec sidecar."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import threading
+from dataclasses import dataclass, field
+from typing import Any
+
+VERSION = "0.1.0"
+PROTOCOL = "vector-proxy-v1"
+DIMENSIONS = 64
+UINT64_MAX = (1 << 64) - 1
+
+try:  # Optional production backend; fallback keeps CI dependency-free.
+    import numpy as np  # type: ignore[import-not-found]
+    from turbovec import IdMapIndex  # type: ignore[import-not-found]
+except Exception:  # noqa: BLE001 - optional dependency probe.
+    np = None
+    IdMapIndex = None
+
+
+def embed_text(text: str, dimensions: int = DIMENSIONS) -> list[float]:
+    vector = [0.0] * dimensions
+    tokens = text.lower().split() or [text.lower()]
+    for token in tokens:
+        digest = hashlib.sha256(token.encode("utf-8")).digest()
+        index = int.from_bytes(digest[:2], "big") % dimensions
+        vector[index] += 1.0
+    norm = math.sqrt(sum(value * value for value in vector)) or 1.0
+    return [value / norm for value in vector]
+
+
+def cosine_distance(left: list[float], right: list[float]) -> float:
+    dot = sum(a * b for a, b in zip(left, right))
+    return max(0.0, 1.0 - dot) * 100.0
+
+
+def metadata_matches(metadata: dict[str, Any], where: dict[str, Any] | None) -> bool:
+    if not where:
+        return True
+    return all(metadata.get(key) == value for key, value in where.items())
+
+
+@dataclass
+class StoredDoc:
+    id: str
+    document: str
+    metadata: dict[str, Any]
+    vector: list[float]
+
+
+@dataclass
+class VectorIndex:
+    name: str
+    dimensions: int = DIMENSIONS
+    bit_width: int = 4
+    prefer_turbovec: bool = True
+    docs: dict[str, StoredDoc] = field(default_factory=dict)
+    numeric_ids: dict[int, str] = field(default_factory=dict)
+    lock: threading.RLock = field(default_factory=threading.RLock)
+    turbovec: Any | None = None
+    backend: str = "fallback"
+
+    def __post_init__(self) -> None:
+        if self.prefer_turbovec and IdMapIndex is not None:
+            self.turbovec = IdMapIndex(dim=self.dimensions, bit_width=self.bit_width)
+            self.backend = "turbovec"
+
+    def numeric_id(self, doc_id: str) -> int:
+        digest = hashlib.sha256(doc_id.encode("utf-8")).digest()
+        candidate = int.from_bytes(digest[:8], "big") or 1
+        while candidate in self.numeric_ids and self.numeric_ids[candidate] != doc_id:
+            candidate = (candidate + 1) & UINT64_MAX or 1
+        self.numeric_ids[candidate] = doc_id
+        return candidate
+
+    def normalized_vector(self, item: dict[str, Any], text: str) -> list[float]:
+        vector = item.get("vector")
+        if isinstance(vector, list) and all(isinstance(n, (int, float)) for n in vector):
+            values = [float(n) for n in vector]
+            if len(values) == self.dimensions:
+                return values
+        return embed_text(text, self.dimensions)
+
+    def add(self, documents: list[dict[str, Any]]) -> None:
+        vectors: list[list[float]] = []
+        ids: list[int] = []
+        with self.lock:
+            for item in documents:
+                doc_id = str(item["id"])
+                text = str(item.get("document", ""))
+                metadata = dict(item.get("metadata") or {})
+                metadata.setdefault("id", doc_id)
+                vector = self.normalized_vector(item, text)
+                self.docs[doc_id] = StoredDoc(doc_id, text, metadata, vector)
+                vectors.append(vector)
+                ids.append(self.numeric_id(doc_id))
+            self.add_to_turbovec(vectors, ids)
+
+    def add_to_turbovec(self, vectors: list[list[float]], ids: list[int]) -> None:
+        if self.turbovec is None or np is None or not vectors:
+            return
+        try:
+            for numeric_id in ids:
+                try:
+                    self.turbovec.remove(numeric_id)
+                except Exception:
+                    pass
+            self.turbovec.add_with_ids(
+                np.asarray(vectors, dtype=np.float32),
+                np.asarray(ids, dtype=np.uint64),
+            )
+        except Exception as exc:  # noqa: BLE001 - fallback keeps sidecar alive.
+            print(f"[turbovec-sidecar] disabling TurboVec backend: {exc}")
+            self.turbovec = None
+            self.backend = "fallback"
+
+    def query(self, text: str, limit: int, where: dict[str, Any] | None = None) -> dict[str, Any]:
+        with self.lock:
+            if self.turbovec is not None and np is not None:
+                result = self.query_turbovec(text, limit, where)
+                if result is not None:
+                    return result
+            rows = self.query_fallback(text, where)
+        return self.response(rows[: max(1, min(limit, 100))])
+
+    def query_fallback(self, text: str, where: dict[str, Any] | None) -> list[tuple[float, StoredDoc]]:
+        query_vector = embed_text(text, self.dimensions)
+        rows = [
+            (cosine_distance(query_vector, doc.vector), doc)
+            for doc in self.docs.values()
+            if metadata_matches(doc.metadata, where)
+        ]
+        rows.sort(key=lambda item: item[0])
+        return rows
+
+    def query_turbovec(self, text: str, limit: int, where: dict[str, Any] | None) -> dict[str, Any] | None:
+        allowed = [
+            num for num, doc_id in self.numeric_ids.items()
+            if metadata_matches(self.docs[doc_id].metadata, where)
+        ]
+        if where and not allowed:
+            return self.response([])
+        try:
+            query = np.asarray(embed_text(text, self.dimensions), dtype=np.float32)
+            kwargs = {"k": max(1, min(limit, 100))}
+            if where:
+                kwargs["allowlist"] = np.asarray(allowed, dtype=np.uint64)
+            scores, numeric_ids = self.turbovec.search(query, **kwargs)
+            selected = self.turbovec_rows(scores, numeric_ids)
+            return self.response(selected)
+        except Exception as exc:  # noqa: BLE001 - fall back for compatibility.
+            print(f"[turbovec-sidecar] TurboVec search failed, falling back: {exc}")
+            return None
+
+    def turbovec_rows(self, scores: Any, numeric_ids: Any) -> list[tuple[float, StoredDoc]]:
+        selected: list[tuple[float, StoredDoc]] = []
+        for score, numeric_id in zip(scores, numeric_ids):
+            doc_id = self.numeric_ids.get(int(numeric_id))
+            if doc_id and doc_id in self.docs:
+                distance = max(0.0, 1.0 - float(score)) * 100.0
+                selected.append((distance, self.docs[doc_id]))
+        return selected
+
+    def count(self) -> int:
+        with self.lock:
+            return len(self.docs)
+
+    def response(self, selected: list[tuple[float, StoredDoc]]) -> dict[str, Any]:
+        return {
+            "ids": [doc.id for _, doc in selected],
+            "documents": [doc.document for _, doc in selected],
+            "distances": [distance for distance, _ in selected],
+            "metadatas": [doc.metadata for _, doc in selected],
+        }
+
+    def clear(self) -> None:
+        with self.lock:
+            self.docs.clear()
+            self.numeric_ids.clear()
+            if self.backend == "turbovec" and IdMapIndex is not None:
+                self.turbovec = IdMapIndex(dim=self.dimensions, bit_width=self.bit_width)

--- a/tests/http/vector/turbovec-sidecar.test.ts
+++ b/tests/http/vector/turbovec-sidecar.test.ts
@@ -44,7 +44,7 @@ afterAll(() => {
 test('TurboVec sidecar reference speaks the vector proxy protocol', async () => {
   const port = await freePort();
   const base = `http://127.0.0.1:${port}`;
-  sidecar = spawn('python3', ['sidecar/turbovec/server.py', '--port', String(port), '--name', 'turbovec-test'], {
+  sidecar = spawn('python3', ['sidecar/turbovec/server.py', '--port', String(port), '--name', 'turbovec-test', '--backend', 'fallback'], {
     cwd: process.cwd(),
     stdio: 'pipe',
   });
@@ -55,8 +55,13 @@ test('TurboVec sidecar reference speaks the vector proxy protocol', async () => 
     status: 'ok',
     name: 'turbovec-test',
     protocol: 'vector-proxy-v1',
+    backend: 'fallback',
   });
-  expect(await json(`${base}/vectors/stats`)).toMatchObject({ count: 0, name: 'turbovec-test' });
+  expect(await json(`${base}/vectors/stats`)).toMatchObject({
+    count: 0,
+    name: 'turbovec-test',
+    backend: 'fallback',
+  });
 
   const docs = [
     { id: 'doc-a', document: 'oracle memory search', metadata: { type: 'learning' } },


### PR DESCRIPTION
## Summary
- split the TurboVec sidecar index into a lock-protected `VectorIndex` module
- add optional `turbovec.IdMapIndex` backend wiring with dependency-free fallback
- expose `--backend`, `--dimensions`, and `--bit-width` sidecar flags plus backend diagnostics in health/stats
- update sidecar docs and protocol test coverage for deterministic fallback mode

## Validation
- ✅ `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile sidecar/turbovec/server.py sidecar/turbovec/vector_index.py`
- ✅ `bunx tsc --noEmit`
- ✅ `bun test tests/http/vector/turbovec-sidecar.test.ts tests/http/vector/proxy-protocol.test.ts tests/http/vector/proxy-adapter.test.ts tests/http/vector/services.test.ts tests/http/vector/turbovec.test.ts tests/vector/service-registry.test.ts`
- ⚠️ `bun test` full suite was attempted and is not green on current alpha; failures are outside this slice (for example missing `filterAdvertisedTools` export from `src/index.ts`, missing `src/middleware/rate-limit.ts`, docker health `dbStatus` expectation drift, menu/traces unrelated cases).

## File sizes
- `sidecar/turbovec/server.py` 112 lines
- `sidecar/turbovec/vector_index.py` 184 lines
- `sidecar/turbovec/README.md` 41 lines
- `tests/http/vector/turbovec-sidecar.test.ts` 93 lines
