### PR TITLE
fix(vector): unify Gemini embedding provider

### DIFF
--- a/src/vector/embeddings.ts
+++ b/src/vector/embeddings.ts
@@ -1,6 +1,8 @@
 import type { EmbeddingProvider, EmbeddingProviderType, EmbedType } from './types.ts';
 import { NoneEmbeddings, RemoteHttpEmbeddings } from './embedding-backends.ts';
 import { EmbeddingFallbackChain } from './fallback-chain.ts';
+import { GeminiEmbeddings } from './providers/gemini.ts';
+export { GeminiEmbeddings } from './providers/gemini.ts';
 export type FallbackEvent = { from: string; to?: string; error: string };
 export type EmbeddingProviderOptions = { url?: string; dimensions?: number; fallbackChain?: EmbeddingProviderType[]; fallback?: EmbeddingProviderType };
 export class ChromaDBInternalEmbeddings implements EmbeddingProvider {
@@ -147,31 +149,6 @@ export class OpenAIEmbeddings implements EmbeddingProvider {
     return data.data
       .sort((a, b) => a.index - b.index)
       .map(d => d.embedding);
-  }
-}
-export class GeminiEmbeddings implements EmbeddingProvider {
-  readonly name = 'gemini';
-  readonly dimensions = 768;
-  private apiKey: string;
-  private model: string;
-  constructor(config: { apiKey?: string; model?: string } = {}) {
-    this.apiKey = config.apiKey || process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY || '';
-    this.model = config.model || 'text-embedding-004';
-    if (!this.apiKey) throw new Error('Gemini API key required. Set GEMINI_API_KEY.');
-  }
-  async embed(texts: string[], _type?: EmbedType): Promise<number[][]> {
-    return Promise.all(texts.map(async (text) => {
-      const url = `https://generativelanguage.googleapis.com/v1beta/models/${this.model}:embedContent?key=${this.apiKey}`;
-      const response = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content: { parts: [{ text }] } }),
-      });
-      if (!response.ok) throw new Error(`Gemini API error: ${await response.text()}`);
-      const data = await response.json() as { embedding?: { values?: number[] } };
-      if (!Array.isArray(data.embedding?.values)) throw new Error('Gemini API error: invalid embedding payload');
-      return data.embedding.values;
-    }));
   }
 }
 export class FallbackEmbeddings implements EmbeddingProvider {

--- a/tests/vector/embeddings-gemini.test.ts
+++ b/tests/vector/embeddings-gemini.test.ts
@@ -12,16 +12,17 @@ afterEach(() => {
 
 test('GeminiEmbeddings calls embedContent and returns vectors in input order', async () => {
   process.env.GEMINI_API_KEY = 'gemini-key';
-  const calls: Array<{ url: string; body: any }> = [];
+  const calls: Array<{ url: string; init?: RequestInit; body: any }> = [];
   globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
-    calls.push({ url: String(input), body: JSON.parse(String(init?.body)) });
+    calls.push({ url: String(input), init, body: JSON.parse(String(init?.body)) });
     return Response.json({ embedding: { values: [calls.length, 0.5] } });
   }) as unknown as typeof fetch;
 
   const vectors = await new GeminiEmbeddings().embed(['first', 'second'], 'query');
 
   expect(vectors).toEqual([[1, 0.5], [2, 0.5]]);
-  expect(calls.every((call) => call.url.includes(':embedContent?key=gemini-key'))).toBe(true);
+  expect(calls.every((call) => call.url.endsWith('/models/text-embedding-004:embedContent'))).toBe(true);
+  expect(calls.every((call) => new Headers(call.init?.headers).get('x-goog-api-key') === 'gemini-key')).toBe(true);
   expect(calls.map((call) => call.body.content.parts[0].text)).toEqual(['first', 'second']);
 });
 


### PR DESCRIPTION
## Summary
- make `src/vector/embeddings.ts` re-export the canonical Gemini provider from `src/vector/providers/gemini.ts`
- remove the duplicate Gemini implementation that used a separate request/auth path
- update Gemini embedding coverage to assert the canonical `x-goog-api-key` request behavior

## Validation
- ✅ `bunx tsc --noEmit`
- ✅ `bun test tests/http/vector/`
- ✅ `bun test tests/vector/embeddings-gemini.test.ts tests/vector/provider-api.test.ts tests/vector/provider-detection.test.ts`

## File sizes
- `src/vector/embeddings.ts` 219 lines
- `tests/vector/embeddings-gemini.test.ts` 33 lines
