### PR TITLE
feat: hydrate plugin filters from search params

### DIFF
--- a/frontend/src/pages/PluginsPage.tsx
+++ b/frontend/src/pages/PluginsPage.tsx
@@ -9,6 +9,7 @@ import {
   filteredPluginsFor,
   healthForPlugin,
   pluginAdminSummary,
+  pluginFiltersFromSearch,
   pluginSurfaceFilterOptions,
   type PluginSurfaceFilter,
   type PluginVisibilityFilter,
@@ -23,6 +24,7 @@ export {
   enabledStateForPlugins,
   filteredPluginsFor,
   pluginAdminSummary,
+  pluginFiltersFromSearch,
   pluginSurfaceFilterOptions,
 } from './pluginInventory';
 export type { PluginSurfaceFilter, PluginVisibilityFilter } from './pluginInventory';
@@ -35,6 +37,11 @@ export interface PluginsPageProps {
   initialQuery?: string;
   initialVisibility?: PluginVisibilityFilter;
   initialSurface?: PluginSurfaceFilter;
+  initialSearch?: string;
+}
+
+function browserSearch(): string {
+  return typeof window === 'undefined' ? '' : window.location.search;
 }
 
 function toneClass(tone: Tone): string {
@@ -62,22 +69,25 @@ export function PluginsPage({
   loading = false,
   endpoint = PLUGINS_ENDPOINT,
   fetcher,
-  initialQuery = '',
-  initialVisibility = 'all',
-  initialSurface = 'all',
+  initialQuery,
+  initialVisibility,
+  initialSurface,
+  initialSearch,
 }: PluginsPageProps) {
+  const filterDefaults = pluginFiltersFromSearch(initialSearch ?? browserSearch());
   const initialLoading = loading || initialPlugins.length === 0;
   const { plugins, loading: fetching, error, reload } = usePlugins({ initialPlugins, initialLoading, endpoint, fetcher });
   const [overrides, setOverrides] = useState<PluginEnabledState>({});
-  const [query, setQuery] = useState(initialQuery);
-  const [visibility, setVisibility] = useState<PluginVisibilityFilter>(initialVisibility);
-  const [surface, setSurface] = useState<PluginSurfaceFilter>(initialSurface);
+  const [query, setQuery] = useState(initialQuery ?? filterDefaults.query);
+  const [visibility, setVisibility] = useState<PluginVisibilityFilter>(initialVisibility ?? filterDefaults.visibility);
+  const [surface, setSurface] = useState<PluginSurfaceFilter>(initialSurface ?? filterDefaults.surface);
   const [adminError, setAdminError] = useState('');
   const [adminMessage, setAdminMessage] = useState('');
   const enabledState = useMemo(() => ({ ...enabledStateForPlugins(plugins), ...overrides }), [plugins, overrides]);
   const summary = useMemo(() => pluginAdminSummary(plugins, enabledState), [plugins, enabledState]);
   const surfaceOptions = useMemo(() => pluginSurfaceFilterOptions(plugins), [plugins]);
   const visiblePlugins = useMemo(() => filteredPluginsFor(plugins, enabledState, query, visibility, surface), [plugins, enabledState, query, visibility, surface]);
+  const selectedSurfaceMissing = surface !== 'all' && !surfaceOptions.includes(surface);
   const hasFilters = query.trim().length > 0 || visibility !== 'all' || surface !== 'all';
   const metrics = useMemo(() => {
     const active = plugins.filter((plugin) => isPluginEnabled(plugin, enabledState)).length;
@@ -175,6 +185,7 @@ export function PluginsPage({
                   onChange={(event) => setSurface(event.currentTarget.value as PluginSurfaceFilter)}
                 >
                   <option value="all">All surfaces</option>
+                  {selectedSurfaceMissing ? <option value={surface}>{surface}</option> : null}
                   {surfaceOptions.map((option) => <option key={option} value={option}>{option}</option>)}
                 </select>
               </label>

--- a/frontend/src/pages/pluginInventory.ts
+++ b/frontend/src/pages/pluginInventory.ts
@@ -5,6 +5,33 @@ import type { PluginEntry } from '../types';
 export type Tone = 'ok' | 'warn' | 'bad' | 'idle';
 export type PluginVisibilityFilter = 'all' | 'enabled' | 'disabled' | 'unhealthy';
 export type PluginSurfaceFilter = 'all' | Surface | 'metadata';
+export type PluginFilterDefaults = {
+  query: string;
+  visibility: PluginVisibilityFilter;
+  surface: PluginSurfaceFilter;
+};
+
+const visibilityValues: PluginVisibilityFilter[] = ['all', 'enabled', 'disabled', 'unhealthy'];
+const surfaceValues: PluginSurfaceFilter[] = ['all', 'wasm', 'menu', 'server', 'mcp', 'apiRoutes', 'proxy', 'cliSubcommands', 'exportFormats', 'metadata'];
+
+function isVisibility(value: string | null): value is PluginVisibilityFilter {
+  return visibilityValues.includes(value as PluginVisibilityFilter);
+}
+
+function isSurface(value: string | null): value is PluginSurfaceFilter {
+  return surfaceValues.includes(value as PluginSurfaceFilter);
+}
+
+export function pluginFiltersFromSearch(search = ''): PluginFilterDefaults {
+  const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+  const visibility = params.get('visibility');
+  const surface = params.get('surface');
+  return {
+    query: params.get('q') ?? params.get('query') ?? '',
+    visibility: isVisibility(visibility) ? visibility : 'all',
+    surface: isSurface(surface) ? surface : 'all',
+  };
+}
 
 export function enabledStateForPlugins(plugins: PluginEntry[]): PluginEnabledState {
   return Object.fromEntries(plugins.map((plugin) => [

--- a/tests/frontend/pages/plugins-page-admin.test.tsx
+++ b/tests/frontend/pages/plugins-page-admin.test.tsx
@@ -4,6 +4,7 @@ import {
   enabledStateForPlugins,
   filteredPluginsFor,
   pluginAdminSummary,
+  pluginFiltersFromSearch,
   pluginSurfaceFilterOptions,
 } from '../../../frontend/src/pages/PluginsPage';
 import type { PluginEntry } from '../../../frontend/src/types';
@@ -43,6 +44,24 @@ describe('PluginsPage admin view', () => {
     expect(html).toContain('echo');
     expect(html).toContain('Clear filters');
     expect(html).toContain('All surfaces');
+  });
+
+  test('hydrates plugin filters from shareable route search params', () => {
+    expect(pluginFiltersFromSearch('?q=echo&visibility=enabled&surface=mcp')).toEqual({
+      query: 'echo',
+      visibility: 'enabled',
+      surface: 'mcp',
+    });
+    expect(pluginFiltersFromSearch('?visibility=bad&surface=unknown')).toEqual({
+      query: '',
+      visibility: 'all',
+      surface: 'all',
+    });
+
+    const html = htmlFor(<PluginsPage plugins={plugins} loading={false} initialSearch="?surface=mcp" />);
+    expect(html).toContain('Showing 1 of 4 plugins');
+    expect(html).toContain('echo');
+    expect(html).toContain('value="mcp" selected');
   });
 
   test('renders a no-match state for filtered plugin inventory', () => {


### PR DESCRIPTION
Refs #1484

## Summary
- hydrate plugin inventory query, visibility, and surface filters from route search params
- preserve selected surface params before plugin manifests finish loading
- cover shareable filter parsing and rendered filtered inventory state

## Verification
- git fetch origin && git rebase origin/alpha
- bunx tsc --noEmit
- bun test tests/frontend
- git diff --check
- wc -l frontend/src/pages/PluginsPage.tsx frontend/src/pages/pluginInventory.ts tests/frontend/pages/plugins-page-admin.test.tsx