### PR TITLE
feat: deep link plugin search results

### DIFF
--- a/frontend/src/global-search.ts
+++ b/frontend/src/global-search.ts
@@ -1,6 +1,6 @@
 import { fetchMcpTools, fetchMenu, fetchPlugins } from './api';
 import { surfacesFor } from './plugin-surfaces';
-import { mcpToolPath } from './routePaths';
+import { mcpToolPath, pluginInventoryPath } from './routePaths';
 import type { McpTool, MenuItem, PluginEntry } from './types';
 
 export type GlobalSearchSurface = 'menu' | 'plugin' | 'mcp-tool';
@@ -65,7 +65,7 @@ function pluginResult(plugin: PluginEntry): GlobalSearchResult {
     surface: 'plugin',
     title: plugin.name,
     detail: surfaces.length ? `${detail} · ${surfaces.join(', ')}` : detail,
-    href: '/plugins',
+    href: pluginInventoryPath({ q: plugin.name }),
     keywords: [plugin.file, plugin.version, plugin.menu?.label, server, tools, surfaces.join(' ')].map(text).join(' '),
   };
 }

--- a/frontend/src/routePaths.ts
+++ b/frontend/src/routePaths.ts
@@ -8,6 +8,15 @@ export function menuSearchPath(query: string): string {
   return `/search?${new URLSearchParams({ q })}`;
 }
 
+export function pluginInventoryPath(filters: { q?: string; surface?: string; visibility?: string } = {}): string {
+  const params = new URLSearchParams();
+  if (filters.q?.trim()) params.set('q', filters.q.trim());
+  if (filters.surface && filters.surface !== 'all') params.set('surface', filters.surface);
+  if (filters.visibility && filters.visibility !== 'all') params.set('visibility', filters.visibility);
+  const query = params.toString();
+  return query ? `/plugins?${query}` : '/plugins';
+}
+
 export function vectorDashboardPath(): string {
   return '/vector';
 }

--- a/tests/frontend/routes/plugin-inventory-path.test.ts
+++ b/tests/frontend/routes/plugin-inventory-path.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from 'bun:test';
+import { pluginInventoryPath } from '../../../frontend/src/routePaths';
+
+describe('pluginInventoryPath', () => {
+  test('builds shareable plugin inventory filter URLs', () => {
+    expect(pluginInventoryPath()).toBe('/plugins');
+    expect(pluginInventoryPath({ q: 'echo tools', surface: 'mcp', visibility: 'enabled' })).toBe('/plugins?q=echo+tools&surface=mcp&visibility=enabled');
+    expect(pluginInventoryPath({ surface: 'all', visibility: 'all' })).toBe('/plugins');
+  });
+});

--- a/tests/frontend/search/build-global-search-plugin.test.ts
+++ b/tests/frontend/search/build-global-search-plugin.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { buildGlobalSearchResults } from '../../../frontend/src/global-search';
 
 describe('buildGlobalSearchResults plugin matches', () => {
-  test('matches plugin descriptions and points results at the plugin page', () => {
+  test('matches plugin descriptions and points results at filtered plugin inventory', () => {
     const results = buildGlobalSearchResults({
       menu: [],
       plugins: [{
@@ -15,7 +15,7 @@ describe('buildGlobalSearchResults plugin matches', () => {
       }],
       tools: [],
     }, 'workshop');
-    expect(results).toMatchObject([{ surface: 'plugin', title: 'echo', href: '/plugins' }]);
+    expect(results).toMatchObject([{ surface: 'plugin', title: 'echo', href: '/plugins?q=echo' }]);
     expect(results[0].detail).toContain('mcp');
   });
 });


### PR DESCRIPTION
Refs #1484

## Summary
- route global plugin search results to the filtered plugin inventory
- add pluginInventoryPath for shareable query/surface/visibility URLs
- cover plugin search hrefs and plugin inventory path encoding

## Verification
- git fetch origin && git rebase origin/alpha
- bunx tsc --noEmit
- bun test tests/frontend
- git diff --check
- wc -l frontend/src/global-search.ts frontend/src/routePaths.ts tests/frontend/search/build-global-search-plugin.test.ts tests/frontend/routes/plugin-inventory-path.test.ts