### PR TITLE
feat(vector): surface backend config on settings

### DIFF
--- a/frontend/src/components/VectorConfigPanel.tsx
+++ b/frontend/src/components/VectorConfigPanel.tsx
@@ -7,6 +7,8 @@ const ADAPTERS = ['lancedb', 'qdrant', 'chroma', 'sqlite-vec', 'cloudflare-vecto
 export const VECTOR_PROVIDERS = ['none', 'ollama', 'gemini', 'openai', 'local', 'remote'] as const;
 type SaveState = Record<string, 'idle' | 'saving' | 'testing' | 'primary'>;
 type Drafts = Record<string, { adapter: string; enabled: boolean; provider: string; model: string }>;
+type RuntimeState = { enabled?: boolean; ready?: boolean; primary?: string; reason?: string; recommendedAction?: string | null };
+type PanelResponse = VectorConfigResponse & { enabled?: boolean; engine?: string; state?: RuntimeState };
 
 function statusClass(status: string) {
   if (status === 'ok') return 'border-emerald-400/30 bg-emerald-400/10 text-emerald-200';
@@ -26,7 +28,7 @@ async function testVectorCollection(key: string): Promise<{ success?: boolean; c
 }
 
 export function VectorConfigPanel() {
-  const [state, setState] = useState<VectorConfigResponse | null>(null);
+  const [state, setState] = useState<PanelResponse | null>(null);
   const [drafts, setDrafts] = useState<Drafts>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -37,7 +39,7 @@ export function VectorConfigPanel() {
     setError('');
     setLoading(true);
     try {
-      const next = await fetchVectorConfig();
+      const next = await fetchVectorConfig() as PanelResponse;
       setState(next);
       setDrafts(Object.fromEntries(Object.entries(next.config.collections).map(([key, item]) => [
         key,
@@ -58,6 +60,7 @@ export function VectorConfigPanel() {
     const enabled = rows.filter(([, item]) => collectionEnabled(item)).length;
     return `${enabled}/${rows.length} enabled · ${healthy}/${rows.length} healthy`;
   }, [rows, state]);
+  const runtime = state?.state;
 
   function updateDraft(key: string, patch: Partial<Drafts[string]>) {
     setDrafts((current) => ({ ...current, [key]: { ...(current[key] ?? { adapter: 'lancedb', enabled: true, provider: 'none', model: key }), ...patch } }));
@@ -133,6 +136,10 @@ export function VectorConfigPanel() {
           <h3 className="mt-2 text-lg font-semibold text-white">Active vector adapters</h3>
           <p className="mt-2 text-sm text-slate-400">Get current config, edit model/provider, switch adapters, enable rows, set primary, and test health.</p>
           <p className="mt-2 text-xs text-slate-500">{summary}</p>
+          <p className="mt-2 text-xs text-slate-500">
+            Source {state?.source ?? 'loading'} · engine {state?.engine ?? 'loading'} · primary {runtime?.primary ?? 'none'} · {runtime?.ready ? 'ready' : 'not ready'}
+          </p>
+          {runtime?.reason ? <p className="mt-1 text-xs text-amber-200">State: {runtime.reason}{runtime.recommendedAction ? ` · ${runtime.recommendedAction}` : ''}</p> : null}
         </div>
         <button className="focus-ring rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-teal-300/40" type="button" onClick={reload}>
           {loading ? <Spinner label="Reloading" /> : 'Reload vector config'}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -109,20 +109,22 @@ export function SettingsPage({ menuCount, pluginCount, surfaceCount, updatedAt, 
       {loading && !settings ? <LoadingPanel title="Loading settings…" detail="Fetching /api/settings/system." /> : null}
       {error ? <ErrorMessage title="Could not load runtime settings." message={error} /> : null}
 
+      <section className="grid gap-5 xl:grid-cols-2" aria-label="Vector backend configuration">
+        <div className="xl:col-span-2">
+          <VectorSearchToggle />
+        </div>
+
+        <div className="xl:col-span-2">
+          <VectorProviderServicePanel />
+        </div>
+
+        <div className="xl:col-span-2">
+          <VectorConfigPanel />
+        </div>
+      </section>
+
       {settings ? (
         <section className="grid gap-5 xl:grid-cols-2">
-          <div className="xl:col-span-2">
-            <VectorSearchToggle />
-          </div>
-
-          <div className="xl:col-span-2">
-            <VectorProviderServicePanel />
-          </div>
-
-          <div className="xl:col-span-2">
-            <VectorConfigPanel />
-          </div>
-
           <SectionCard title="Storage backend">
             <div className="grid gap-3 sm:grid-cols-2">
               <SettingPair

--- a/tests/frontend/pages/settings-page-summary.test.tsx
+++ b/tests/frontend/pages/settings-page-summary.test.tsx
@@ -9,5 +9,8 @@ describe('SettingsPage summary', () => {
     expect(html).toContain('3 menu · 2 plugins');
     expect(html).toContain('Plugin surfaces');
     expect(html).toContain('/menu /plugins /vector /mcp /settings');
+    expect(html).toContain('Enable vector search');
+    expect(html).toContain('Active vector adapters');
+    expect(html).toContain('Get current config, edit model/provider, switch adapters');
   });
 });


### PR DESCRIPTION
## Summary
- keep Vector backend get/set controls visible on Settings even while system settings are still loading or unavailable
- show vector config source, active engine, primary collection, readiness, and recommended state action in the config panel
- add Settings page coverage for the vector config controls

## Verification
- bunx tsc --noEmit
- bun test tests/frontend/pages/settings-page-summary.test.tsx tests/frontend/api/update-vector-collection-provider.test.ts tests/frontend/components/vector-adapter-switcher.test.tsx tests/frontend/pages/vector-settings-page.test.tsx
- bun test tests/http/vector/config-api.test.ts

## File sizes
- frontend/src/components/VectorConfigPanel.tsx: 204 lines
- frontend/src/pages/SettingsPage.tsx: 214 lines
- tests/frontend/pages/settings-page-summary.test.tsx: 16 lines