### PR TITLE
feat: hydrate MCP tool filters from search params

### DIFF
--- a/frontend/src/components/McpToolBrowser.tsx
+++ b/frontend/src/components/McpToolBrowser.tsx
@@ -5,11 +5,31 @@ import { groupLabel, toolMode } from './toolView';
 import type { McpTool } from '../types';
 
 export type McpToolSourceFilter = 'all' | 'plugin' | 'core';
+export type McpToolFilterDefaults = { query: string; source: McpToolSourceFilter };
+
+const sourceFilters: McpToolSourceFilter[] = ['all', 'plugin', 'core'];
 
 type McpToolsResponse = {
   tools: McpTool[];
   total: number;
 };
+
+function browserSearch(): string {
+  return typeof window === 'undefined' ? '' : window.location.search;
+}
+
+function isSourceFilter(value: string | null): value is McpToolSourceFilter {
+  return sourceFilters.includes(value as McpToolSourceFilter);
+}
+
+export function mcpToolFiltersFromSearch(search = ''): McpToolFilterDefaults {
+  const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+  const source = params.get('source');
+  return {
+    query: params.get('q') ?? params.get('query') ?? '',
+    source: isSourceFilter(source) ? source : 'all',
+  };
+}
 
 function sourceKind(tool: McpTool): Exclude<McpToolSourceFilter, 'all'> {
   return tool.source === 'plugin' || Boolean(tool.plugin) ? 'plugin' : 'core';
@@ -69,15 +89,22 @@ function ToolCard({ tool, onOpen }: { tool: McpTool; onOpen?: (tool: McpTool) =>
 export function McpToolBrowser({
   onOpenTool,
   initialTools,
+  initialFilter,
+  initialSource,
+  initialSearch,
   fetcher = fetchMcpTools,
 }: {
   onOpenTool?: (tool: McpTool) => void;
   initialTools?: McpTool[];
+  initialFilter?: string;
+  initialSource?: McpToolSourceFilter;
+  initialSearch?: string;
   fetcher?: () => Promise<McpToolsResponse>;
 }) {
+  const filterDefaults = mcpToolFiltersFromSearch(initialSearch ?? browserSearch());
   const [tools, setTools] = useState<McpTool[]>(initialTools ?? []);
-  const [filter, setFilter] = useState('');
-  const [source, setSource] = useState<McpToolSourceFilter>('all');
+  const [filter, setFilter] = useState(initialFilter ?? filterDefaults.query);
+  const [source, setSource] = useState<McpToolSourceFilter>(initialSource ?? filterDefaults.source);
   const [state, setState] = useState<'loading' | 'ready' | 'error'>(initialTools ? 'ready' : 'loading');
   const [error, setError] = useState('');
 

--- a/tests/frontend/components/mcp-tool-browser-source-filter.test.tsx
+++ b/tests/frontend/components/mcp-tool-browser-source-filter.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import {
   filterMcpTools,
   McpToolBrowser,
+  mcpToolFiltersFromSearch,
   mcpToolSourceCounts,
   mcpToolSourceLabel,
 } from '../../../frontend/src/components/McpToolBrowser';
@@ -24,6 +25,18 @@ describe('McpToolBrowser source filters', () => {
     expect(filterMcpTools(tools, '', 'plugin').map((tool) => tool.name)).toEqual(['echo.say']);
     expect(filterMcpTools(tools, 'write', 'all').map((tool) => tool.name)).toEqual(['memory.write']);
     expect(filterMcpTools(tools, 'plugin:echo', 'all').map((tool) => tool.name)).toEqual(['echo.say']);
+  });
+
+  test('hydrates source and query filters from shareable route search', () => {
+    expect(mcpToolFiltersFromSearch('?q=echo&source=plugin')).toEqual({ query: 'echo', source: 'plugin' });
+    expect(mcpToolFiltersFromSearch('?query=memory&source=core')).toEqual({ query: 'memory', source: 'core' });
+    expect(mcpToolFiltersFromSearch('?source=bad')).toEqual({ query: '', source: 'all' });
+
+    const html = htmlFor(<McpToolBrowser initialTools={tools} initialSearch="?q=echo&source=plugin" />);
+    expect(html).toContain('value="echo"');
+    expect(html).toContain('value="plugin" selected');
+    expect(html).toContain('1/2 tools');
+    expect(html).toContain('echo.say');
   });
 
   test('renders the source selector and source badges from initial tools', () => {


### PR DESCRIPTION
Refs #1484

## Summary
- hydrate MCP tool browser query/source filters from route search params
- allow shareable /mcp?source=plugin&q=... views for unified-plugin MCP surfaces
- cover query/source parsing and rendered filtered browser state

## Verification
- git fetch origin && git rebase origin/alpha
- bunx tsc --noEmit
- bun test tests/frontend
- git diff --check
- wc -l frontend/src/components/McpToolBrowser.tsx tests/frontend/components/mcp-tool-browser-source-filter.test.tsx