### PR TITLE
feat(vector): show service health in dashboard

### DIFF
--- a/frontend/src/pages/VectorPage.tsx
+++ b/frontend/src/pages/VectorPage.tsx
@@ -15,17 +15,25 @@ import {
   VectorCollectionCards,
   VectorStatsCard,
   QuickExportCard,
-  VectorHealthDashboardCard,
   type VectorCollectionCard,
+} from './vector-dashboard-cards';
+import {
+  VectorHealthDashboardCard,
   type VectorFreshnessCard,
   type VectorProviderHealthCard,
+  type VectorServiceHealthCard,
   type VectorStorageHealthCard,
-} from './vector-dashboard-cards';
+} from './vector-health-dashboard-card';
 
 type PageState = 'loading' | 'ready' | 'error';
 type VectorStatusClient = Pick<ApiClient, 'vectorIndexModels' | 'vectorHealth'>;
 type DownloadByCollection = Record<string, VectorExportFormat | undefined>;
-type VectorDashboardHealth = VectorHealthResponse & { providers?: VectorProviderHealthCard[]; freshness?: VectorFreshnessCard; storage?: VectorStorageHealthCard[] };
+type VectorDashboardHealth = VectorHealthResponse & {
+  providers?: VectorProviderHealthCard[];
+  services?: VectorServiceHealthCard[];
+  freshness?: VectorFreshnessCard;
+  storage?: VectorStorageHealthCard[];
+};
 
 export interface VectorPageProps {
   modelsResponse?: VectorIndexModelsResponse | null;
@@ -172,7 +180,7 @@ export function VectorPage({
 
         <div className="grid gap-4">
           <VectorStatsCard cards={cards} />
-          <VectorHealthDashboardCard providers={dashboardHealth?.providers} storage={dashboardHealth?.storage} freshness={dashboardHealth?.freshness} />
+          <VectorHealthDashboardCard providers={dashboardHealth?.providers} services={dashboardHealth?.services} storage={dashboardHealth?.storage} freshness={dashboardHealth?.freshness} />
           <QuickExportCard cards={cards} formats={formats} downloads={downloads} onExport={onExport} />
           <VectorIndexPanel />
         </div>

--- a/frontend/src/pages/vector-dashboard-cards.tsx
+++ b/frontend/src/pages/vector-dashboard-cards.tsx
@@ -13,16 +13,6 @@ export interface VectorCollectionCard {
   healthDetail?: string;
 }
 
-export type VectorProviderHealthCard = { type: string; status: 'green' | 'red'; available: boolean; detail?: string };
-export type VectorStorageHealthCard = { adapter: string; status: 'green' | 'red'; healthy: number; total: number; detail?: string };
-export type VectorFreshnessCard = {
-  status: 'fresh' | 'empty' | 'stale';
-  totalIndexed: number;
-  sourceDocs?: number;
-  docsPending?: number;
-  lastIndexed?: string;
-};
-
 type DownloadByCollection = Record<string, VectorExportFormat | undefined>;
 
 type VectorTotals = {
@@ -53,16 +43,6 @@ function docsLabel(cards: VectorCollectionCard[]): string {
   if (!collections) return 'No collection data yet';
   if (hasUnknownDocs) return `${knownDocs.toLocaleString()}+ docs across ${collections} collections`;
   return `${knownDocs.toLocaleString()} docs · ${collections} collections`;
-}
-
-function freshnessLine(freshness: VectorFreshnessCard): string {
-  return `${freshness.status} · ${freshness.totalIndexed.toLocaleString()} indexed`;
-}
-
-function pendingLine(freshness?: VectorFreshnessCard): string {
-  if (!freshness || typeof freshness.docsPending !== 'number') return 'Pending count unavailable';
-  const source = typeof freshness.sourceDocs === 'number' ? ` of ${freshness.sourceDocs.toLocaleString()} source docs` : '';
-  return `${freshness.docsPending.toLocaleString()} pending${source}`;
 }
 
 export function VectorCollectionCards({
@@ -140,36 +120,6 @@ export function VectorStatsCard({ cards }: { cards: VectorCollectionCard[] }) {
   );
 }
 
-
-export function VectorHealthDashboardCard({
-  providers = [],
-  storage = [],
-  freshness,
-}: {
-  providers?: VectorProviderHealthCard[];
-  storage?: VectorStorageHealthCard[];
-  freshness?: VectorFreshnessCard;
-}) {
-  const providerSummary = providers.length
-    ? `${providers.filter((item) => item.available).length}/${providers.length} providers available`
-    : 'Provider detection unavailable';
-  const storageSummary = storage.length ? `${storage.filter((item) => item.status === 'green').length}/${storage.length} storage backends healthy` : 'Storage status unavailable';
-  return (
-    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-health-dashboard-title">
-      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Health</p>
-      <h2 id="vector-health-dashboard-title" className="mt-2 text-2xl font-semibold text-white">Vector health dashboard</h2>
-      <dl className="mt-4 grid gap-3 text-sm text-slate-300">
-        <div><dt className="text-slate-500">Embedding providers</dt><dd className="text-lg font-semibold text-white">{providerSummary}</dd></div>
-        <div><dt className="text-slate-500">Storage backends</dt><dd className="text-lg font-semibold text-white">{storageSummary}</dd></div>
-        <div><dt className="text-slate-500">Index freshness</dt><dd className="text-lg font-semibold text-white">{freshness ? freshnessLine(freshness) : 'Unknown'}</dd></div>
-        <div><dt className="text-slate-500">Docs pending</dt><dd className="text-lg font-semibold text-white">{pendingLine(freshness)}</dd></div>
-        <div><dt className="text-slate-500">Last indexed</dt><dd className="text-lg font-semibold text-white">{freshness?.lastIndexed ?? 'Unknown'}</dd></div>
-      </dl>
-      {providers.length ? <div className="mt-4 flex flex-wrap gap-2">{providers.map((provider) => <span key={provider.type} className={`rounded-full border px-2 py-1 text-xs font-semibold ${statusClasses(provider.available)}`}>{provider.type}: {provider.status}</span>)}</div> : null}
-      {storage.length ? <div className="mt-2 flex flex-wrap gap-2">{storage.map((item) => <span key={item.adapter} className={`rounded-full border px-2 py-1 text-xs font-semibold ${statusClasses(item.status === 'green')}`}>{item.adapter}: {item.healthy}/{item.total}</span>)}</div> : null}
-    </section>
-  );
-}
 
 export function QuickExportCard({
   cards,

--- a/frontend/src/pages/vector-health-dashboard-card.tsx
+++ b/frontend/src/pages/vector-health-dashboard-card.tsx
@@ -1,0 +1,78 @@
+export type VectorProviderHealthCard = { type: string; status: 'green' | 'red'; available: boolean; detail?: string };
+export type VectorStorageHealthCard = { adapter: string; status: 'green' | 'red'; healthy: number; total: number; detail?: string };
+export type VectorServiceHealthCard = {
+  name: string;
+  type: string;
+  endpoint?: string;
+  status: 'green' | 'yellow' | 'red';
+  available: boolean;
+  health?: { status?: string; error?: string; checkedAt?: string };
+};
+export type VectorFreshnessCard = {
+  status: 'fresh' | 'empty' | 'stale';
+  totalIndexed: number;
+  sourceDocs?: number;
+  docsPending?: number;
+  lastIndexed?: string;
+};
+
+function statusClasses(healthy: boolean): string {
+  return healthy
+    ? 'border-emerald-300/30 bg-emerald-300/10 text-emerald-200'
+    : 'border-red-300/30 bg-red-300/10 text-red-100';
+}
+
+function freshnessLine(freshness: VectorFreshnessCard): string {
+  return `${freshness.status} · ${freshness.totalIndexed.toLocaleString()} indexed`;
+}
+
+function pendingLine(freshness?: VectorFreshnessCard): string {
+  if (!freshness || typeof freshness.docsPending !== 'number') return 'Pending count unavailable';
+  const source = typeof freshness.sourceDocs === 'number' ? ` of ${freshness.sourceDocs.toLocaleString()} source docs` : '';
+  return `${freshness.docsPending.toLocaleString()} pending${source}`;
+}
+
+function serviceDetail(service: VectorServiceHealthCard): string {
+  const health = service.health?.status ?? (service.available ? 'up' : 'unknown');
+  const error = service.health?.error ? ` · ${service.health.error}` : '';
+  return `${service.name}: ${health}${error}`;
+}
+
+export function VectorHealthDashboardCard({
+  providers = [],
+  services = [],
+  storage = [],
+  freshness,
+}: {
+  providers?: VectorProviderHealthCard[];
+  services?: VectorServiceHealthCard[];
+  storage?: VectorStorageHealthCard[];
+  freshness?: VectorFreshnessCard;
+}) {
+  const providerSummary = providers.length
+    ? `${providers.filter((item) => item.available).length}/${providers.length} providers available`
+    : 'Provider detection unavailable';
+  const serviceSummary = services.length
+    ? `${services.filter((item) => item.available).length}/${services.length} services up`
+    : 'Service registry unavailable';
+  const storageSummary = storage.length
+    ? `${storage.filter((item) => item.status === 'green').length}/${storage.length} storage backends healthy`
+    : 'Storage status unavailable';
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-health-dashboard-title">
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Health</p>
+      <h2 id="vector-health-dashboard-title" className="mt-2 text-2xl font-semibold text-white">Vector health dashboard</h2>
+      <dl className="mt-4 grid gap-3 text-sm text-slate-300">
+        <div><dt className="text-slate-500">Embedding providers</dt><dd className="text-lg font-semibold text-white">{providerSummary}</dd></div>
+        <div><dt className="text-slate-500">Registered services</dt><dd className="text-lg font-semibold text-white">{serviceSummary}</dd></div>
+        <div><dt className="text-slate-500">Storage backends</dt><dd className="text-lg font-semibold text-white">{storageSummary}</dd></div>
+        <div><dt className="text-slate-500">Index freshness</dt><dd className="text-lg font-semibold text-white">{freshness ? freshnessLine(freshness) : 'Unknown'}</dd></div>
+        <div><dt className="text-slate-500">Docs pending</dt><dd className="text-lg font-semibold text-white">{pendingLine(freshness)}</dd></div>
+        <div><dt className="text-slate-500">Last indexed</dt><dd className="text-lg font-semibold text-white">{freshness?.lastIndexed ?? 'Unknown'}</dd></div>
+      </dl>
+      {providers.length ? <div className="mt-4 flex flex-wrap gap-2">{providers.map((provider) => <span key={provider.type} className={`rounded-full border px-2 py-1 text-xs font-semibold ${statusClasses(provider.available)}`}>{provider.type}: {provider.status}</span>)}</div> : null}
+      {services.length ? <div className="mt-2 flex flex-wrap gap-2">{services.map((service) => <span key={service.name} className={`rounded-full border px-2 py-1 text-xs font-semibold ${statusClasses(service.status === 'green')}`}>{serviceDetail(service)}</span>)}</div> : null}
+      {storage.length ? <div className="mt-2 flex flex-wrap gap-2">{storage.map((item) => <span key={item.adapter} className={`rounded-full border px-2 py-1 text-xs font-semibold ${statusClasses(item.status === 'green')}`}>{item.adapter}: {item.healthy}/{item.total}</span>)}</div> : null}
+    </section>
+  );
+}

--- a/tests/frontend/pages/frontend-component-coverage.test.tsx
+++ b/tests/frontend/pages/frontend-component-coverage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { CanvasPluginsPage } from '../../../frontend/src/pages/CanvasPluginsPage';
 import { PluginsPage } from '../../../frontend/src/pages/PluginsPage';
-import { VectorHealthDashboardCard } from '../../../frontend/src/pages/vector-dashboard-cards';
+import { VectorHealthDashboardCard } from '../../../frontend/src/pages/vector-health-dashboard-card';
 import { htmlFor } from '../_render';
 
 describe('frontend component coverage', () => {
@@ -36,6 +36,10 @@ describe('frontend component coverage', () => {
         { type: 'ollama', status: 'green', available: true, detail: 'local' },
         { type: 'openai', status: 'red', available: false, detail: 'missing key' },
       ]}
+      services={[
+        { name: 'lancedb', type: 'builtin', status: 'green', available: true, health: { status: 'up' } },
+        { name: 'turbovec', type: 'proxy', endpoint: 'http://127.0.0.1:8787', status: 'red', available: false, health: { status: 'down', error: 'timeout' } },
+      ]}
       storage={[
         { adapter: 'lancedb', status: 'green', healthy: 2, total: 2 },
         { adapter: 'qdrant', status: 'red', healthy: 0, total: 1, detail: 'down' },
@@ -45,7 +49,10 @@ describe('frontend component coverage', () => {
 
     expect(html).toContain('Vector health dashboard');
     expect(html).toContain('1/2 providers available');
+    expect(html).toContain('1/2 services up');
     expect(html).toContain('1/2 storage backends healthy');
+    expect(html).toContain('lancedb: up');
+    expect(html).toContain('turbovec: down · timeout');
     expect(html).toContain('lancedb: 2/2');
     expect(html).toContain('qdrant: 0/1');
     expect(html).toContain('stale · 1,532 indexed');

--- a/tests/frontend/pages/vector-dashboard-cards.test.tsx
+++ b/tests/frontend/pages/vector-dashboard-cards.test.tsx
@@ -17,6 +17,10 @@ const healthResponse = {
     { key: 'bge', collection: 'oracle_bge', model: 'BAAI/bge-m3', ok: true },
     { key: 'qwen', collection: 'oracle_qwen', model: 'Qwen/qwen3', ok: false, error: 'timeout' },
   ],
+  services: [
+    { name: 'lancedb', type: 'builtin', status: 'green', available: true, health: { status: 'up' } },
+    { name: 'turbovec', type: 'proxy', status: 'red', available: false, health: { status: 'down', error: 'offline' } },
+  ],
 };
 
 describe('VectorPage dashboard cards', () => {
@@ -31,6 +35,9 @@ describe('VectorPage dashboard cards', () => {
     expect(html).toContain('qdrant');
     expect(html).toContain('Down');
     expect(html).toContain('timeout');
+    expect(html).toContain('Registered services');
+    expect(html).toContain('1/2 services up');
+    expect(html).toContain('turbovec: down · offline');
     expect(html).toContain('Vector search');
   });
 });


### PR DESCRIPTION
## Summary
- Wires registered vector service health into the Studio vector dashboard
- Extracts the health dashboard card to a focused component to keep files under 250 lines
- Adds coverage for service registry status alongside provider/storage/freshness health

## Validation
- `bunx tsc --noEmit`
- `bun test tests/frontend/pages/vector-dashboard-cards.test.tsx tests/frontend/pages/frontend-component-coverage.test.tsx`
- `bun test tests/http/vector/`
- changed files <= 250 lines
