### PR TITLE
feat(vector): choose provider in setup wizard

### DIFF
--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -3,6 +3,7 @@ import { apiUrl } from "../api";
 import { Spinner } from "./AsyncState";
 import { StepBody, setupSteps } from "./SetupWizardContent";
 import { shouldShowSetupWizard } from "./setupWizardDetection";
+import { buildProviderConfigPatch, recommendedProvider } from "./setupWizardProvider";
 import type { Provider, Stats, Step, VectorConfig } from "./setupWizardTypes";
 
 export { shouldShowSetupWizard } from "./setupWizardDetection";
@@ -22,6 +23,7 @@ export function SetupWizard({ children }: { children: ReactNode }) {
   const [state, setState] = useState<SetupState>("checking");
   const [step, setStep] = useState<Step>(0);
   const [providers, setProviders] = useState<Provider[]>([]);
+  const [selectedProvider, setSelectedProvider] = useState("");
   const [config, setConfig] = useState<VectorConfig | null>(null);
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState("");
@@ -46,8 +48,11 @@ export function SetupWizard({ children }: { children: ReactNode }) {
           statsResult.status === "fulfilled" ? statsResult.value : null;
         const vectorConfig =
           configResult.status === "fulfilled" ? configResult.value : null;
-        if (providersResult.status === "fulfilled")
-          setProviders(providersResult.value.providers ?? []);
+        if (providersResult.status === "fulfilled") {
+          const nextProviders = providersResult.value.providers ?? [];
+          setProviders(nextProviders);
+          setSelectedProvider((current) => current || recommendedProvider(nextProviders)?.type || "");
+        }
         if (vectorConfig) setConfig(vectorConfig);
         setState(
           shouldShowSetupWizard(stats, vectorConfig) ? "visible" : "hidden",
@@ -61,12 +66,7 @@ export function SetupWizard({ children }: { children: ReactNode }) {
     };
   }, []);
 
-  const recommended = useMemo(
-    () =>
-      providers.find((provider) => provider.available || provider.configured) ??
-      providers[0],
-    [providers],
-  );
+  const recommended = useMemo(() => recommendedProvider(providers), [providers]);
 
   async function refreshDetection() {
     setBusy(true);
@@ -75,9 +75,30 @@ export function SetupWizard({ children }: { children: ReactNode }) {
         getJson<{ providers?: Provider[] }>("/api/v1/vector/providers"),
         getJson<VectorConfig>("/api/v1/vector/config"),
       ]);
-      setProviders(providerBody.providers ?? []);
+      const nextProviders = providerBody.providers ?? [];
+      setProviders(nextProviders);
+      setSelectedProvider((current) => current || recommendedProvider(nextProviders)?.type || "");
       setConfig(vectorConfig);
       setMessage("Auto-detect refreshed. Choose a provider and continue.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function applyProvider() {
+    if (!selectedProvider) return setMessage("Choose an embedding provider first.");
+    setBusy(true);
+    try {
+      const response = await fetch(apiUrl("/api/v1/vector/config"), {
+        method: "PATCH",
+        headers: { accept: "application/json", "content-type": "application/json" },
+        body: JSON.stringify(buildProviderConfigPatch(config, selectedProvider)),
+      });
+      if (!response.ok) throw new Error(`/api/v1/vector/config returned ${response.status}`);
+      await fetch(apiUrl("/api/v1/vector/config/reload"), { method: "POST", headers: { accept: "application/json" } });
+      setConfig(await getJson<VectorConfig>("/api/v1/vector/config"));
+      setStep(2);
+      setMessage(`Applied ${selectedProvider} as the first-run embedding provider.`);
     } finally {
       setBusy(false);
     }
@@ -147,6 +168,8 @@ export function SetupWizard({ children }: { children: ReactNode }) {
             providers={providers}
             recommended={recommended}
             config={config}
+            selectedProvider={selectedProvider}
+            onProviderSelect={setSelectedProvider}
           />
         </div>
         {message ? (
@@ -170,6 +193,15 @@ export function SetupWizard({ children }: { children: ReactNode }) {
               onClick={() => void refreshDetection()}
             >
               {busy ? <Spinner label="Detecting" /> : "Auto-detect providers"}
+            </button>
+          ) : null}
+          {step === 1 ? (
+            <button
+              className="focus-ring rounded-xl bg-teal-200 px-4 py-2 text-sm font-semibold text-slate-950"
+              type="button"
+              onClick={() => void applyProvider()}
+            >
+              {busy ? <Spinner label="Applying" /> : "Use selected provider"}
             </button>
           ) : null}
           {step === 2 ? (

--- a/frontend/src/components/SetupWizardContent.tsx
+++ b/frontend/src/components/SetupWizardContent.tsx
@@ -11,11 +11,15 @@ export function StepBody({
   step,
   providers,
   recommended,
+  selectedProvider = '',
+  onProviderSelect,
   config,
 }: {
   step: Step;
   providers: Provider[];
   recommended?: Provider;
+  selectedProvider?: string;
+  onProviderSelect?: (provider: string) => void;
   config: VectorConfig | null;
 }) {
   if (step === 0)
@@ -26,7 +30,7 @@ export function StepBody({
       </p>
     );
   if (step === 1)
-    return <ProviderList providers={providers} recommended={recommended} />;
+    return <ProviderList providers={providers} recommended={recommended} selectedProvider={selectedProvider} onProviderSelect={onProviderSelect} />;
   if (step === 2) return <VaultPlan config={config} />;
   return (
     <p className="mt-2 text-sm text-slate-300">
@@ -38,9 +42,13 @@ export function StepBody({
 function ProviderList({
   providers,
   recommended,
+  selectedProvider,
+  onProviderSelect,
 }: {
   providers: Provider[];
   recommended?: Provider;
+  selectedProvider: string;
+  onProviderSelect?: (provider: string) => void;
 }) {
   if (!providers.length)
     return (
@@ -52,15 +60,22 @@ function ProviderList({
   return (
     <div className="mt-3 grid gap-3 sm:grid-cols-2">
       {providers.map((provider) => (
-        <article
+        <label
           key={provider.type}
           className="rounded-xl border border-white/10 bg-white/[0.03] p-3"
         >
-          <p className="font-semibold text-purple-100">
+          <span className="flex items-center gap-2 font-semibold text-purple-100">
+            <input
+              checked={selectedProvider === provider.type}
+              name="setup-provider"
+              type="radio"
+              value={provider.type}
+              onChange={() => onProviderSelect?.(provider.type)}
+            />
             {provider.type}
             {recommended?.type === provider.type ? " · recommended" : ""}
-          </p>
-          <p className="text-sm text-slate-400">
+          </span>
+          <p className="mt-2 text-sm text-slate-400">
             {provider.available ? "available" : "unavailable"} ·{" "}
             {(provider.models ?? []).slice(0, 3).join(", ") ||
               provider.status ||
@@ -72,7 +87,7 @@ function ProviderList({
               Free tier available!
             </p>
           ) : null}
-        </article>
+        </label>
       ))}
     </div>
   );

--- a/frontend/src/components/setupWizardProvider.ts
+++ b/frontend/src/components/setupWizardProvider.ts
@@ -1,0 +1,21 @@
+import type { Provider, VectorConfig } from './setupWizardTypes';
+
+export function recommendedProvider(providers: Provider[]): Provider | undefined {
+  return providers.find((provider) => provider.available || provider.configured) ?? providers[0];
+}
+
+export function buildProviderConfigPatch(config: VectorConfig | null, provider: string): Record<string, unknown> {
+  const collections = Object.fromEntries(
+    Object.entries(config?.config?.collections ?? {}).map(([key, collection]) => [
+      key,
+      { ...collection, provider },
+    ]),
+  );
+  const embedder = config?.config?.embedder && typeof config.config.embedder === 'object' && !Array.isArray(config.config.embedder)
+    ? { ...config.config.embedder, default: provider }
+    : { default: provider };
+  return {
+    embedder,
+    ...(Object.keys(collections).length ? { collections } : {}),
+  };
+}

--- a/frontend/src/components/setupWizardTypes.ts
+++ b/frontend/src/components/setupWizardTypes.ts
@@ -15,6 +15,7 @@ export type VectorConfig = {
         provider?: string;
       }
     >;
+    embedder?: Record<string, unknown>;
   };
   doc_counts?: Record<string, number>;
 };

--- a/tests/frontend/components/setup-wizard-first-run.test.tsx
+++ b/tests/frontend/components/setup-wizard-first-run.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { shouldShowSetupWizard } from "../../../frontend/src/components/SetupWizard";
 import { StepBody, setupSteps } from "../../../frontend/src/components/SetupWizardContent";
+import { buildProviderConfigPatch, recommendedProvider } from "../../../frontend/src/components/setupWizardProvider";
 import { htmlFor } from "../_render";
 
 describe("SetupWizard first-run detection", () => {
@@ -23,6 +24,34 @@ describe("SetupWizard first-run detection", () => {
         { config: { collections: {} }, doc_counts: {} },
       ),
     ).toBe(false);
+  });
+
+
+  test("builds a vector config patch for the selected first-run provider", () => {
+    expect(recommendedProvider([{ type: "openai" }, { type: "gemini", available: true }])?.type).toBe("gemini");
+    expect(buildProviderConfigPatch({
+      config: {
+        embedder: { fallback: "openai" },
+        collections: { bge: { model: "bge-m3", provider: "ollama" } },
+      },
+    }, "gemini")).toEqual({
+      embedder: { default: "gemini", fallback: "openai" },
+      collections: { bge: { model: "bge-m3", provider: "gemini" } },
+    });
+  });
+
+  test("renders selectable first-run provider radios", () => {
+    const html = htmlFor(<StepBody
+      step={1}
+      providers={[{ type: "ollama", available: false }, { type: "gemini", available: true }]}
+      recommended={{ type: "gemini", available: true }}
+      selectedProvider="gemini"
+      onProviderSelect={() => {}}
+      config={null}
+    />);
+    expect(html).toContain('name="setup-provider"');
+    expect(html).toContain('gemini · recommended');
+    expect(html).toContain('Free tier available!');
   });
 
   test("labels the final wizard step as done with dashboard guidance", () => {


### PR DESCRIPTION
## Summary
- Adds selectable embedding provider radios to the first-run Setup Wizard provider step
- Applies the selected provider through PATCH `/api/v1/vector/config` and hot-reloads config before moving to the vault/index step
- Extracts provider recommendation/config-patch helpers with focused tests

## Validation
- `bunx tsc --noEmit`
- `bun test tests/frontend/components/setup-wizard-first-run.test.tsx tests/frontend/pages/vector-settings-page.test.tsx tests/frontend/components/vector-provider-service-panel.test.tsx`
- `bun test tests/http/vector/`
- changed files <= 250 lines
