### PR TITLE
feat: hydrate menu filters from search params

### DIFF
--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -3,15 +3,19 @@ import { apiClient, type ApiClient } from '../api/client';
 import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
 import { EmptyState } from '../components/EmptyState';
 import type { MenuItem } from '../types';
+import { menuFiltersFromSearch, type MenuFilters } from './menuFilters';
 
 type PageState = 'loading' | 'ready' | 'error';
 type MenuClient = Pick<ApiClient, 'menu'>;
-type MenuFilters = { group: string; source: string };
-
 export interface MenuPageProps {
   items?: MenuItem[];
   loading?: boolean;
   client?: MenuClient;
+  initialSearch?: string;
+}
+
+function browserSearch(): string {
+  return typeof window === 'undefined' ? '' : window.location.search;
 }
 
 function menuKey(item: MenuItem): string {
@@ -160,13 +164,14 @@ function MenuFiltersCard({
   );
 }
 
-export function MenuPage({ items: initialItems = [], loading, client = apiClient }: MenuPageProps) {
+export function MenuPage({ items: initialItems = [], loading, client = apiClient, initialSearch }: MenuPageProps) {
+  const filterDefaults = menuFiltersFromSearch(initialSearch ?? browserSearch());
   const [items, setItems] = useState<MenuItem[]>(initialItems);
   const [state, setState] = useState<PageState>(() =>
     loading || (loading === undefined && !initialItems.length) ? 'loading' : 'ready'
   );
   const [error, setError] = useState('');
-  const [filters, setFilters] = useState<MenuFilters>({ group: 'all', source: 'all' });
+  const [filters, setFilters] = useState<MenuFilters>(filterDefaults);
 
   async function loadMenu() {
     setState('loading');

--- a/frontend/src/pages/menuFilters.ts
+++ b/frontend/src/pages/menuFilters.ts
@@ -1,0 +1,9 @@
+export type MenuFilters = { group: string; source: string };
+
+export function menuFiltersFromSearch(search = ''): MenuFilters {
+  const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+  return {
+    group: params.get('group')?.trim() || 'all',
+    source: params.get('source')?.trim() || 'all',
+  };
+}

--- a/tests/frontend/pages/menu-page-filters.test.tsx
+++ b/tests/frontend/pages/menu-page-filters.test.tsx
@@ -5,6 +5,7 @@ import {
   MenuPage,
   menuSource,
 } from '../../../frontend/src/pages/MenuPage';
+import { menuFiltersFromSearch } from '../../../frontend/src/pages/menuFilters';
 import type { MenuItem } from '../../../frontend/src/types';
 import { htmlFor } from '../_render';
 
@@ -27,6 +28,16 @@ describe('MenuPage filters', () => {
     const visible = filterMenuItems(items, { group: 'tools', source: 'plugin:echo' });
     expect(visible.map((item) => item.label)).toEqual(['Echo']);
     expect(filterMenuItems(items, { group: 'admin', source: 'plugin:echo' })).toEqual([]);
+  });
+
+  test('hydrates menu filters from shareable route search params', () => {
+    expect(menuFiltersFromSearch('?group=tools&source=plugin%3Aecho')).toEqual({ group: 'tools', source: 'plugin:echo' });
+    expect(menuFiltersFromSearch('?group=&source=')).toEqual({ group: 'all', source: 'all' });
+
+    const html = htmlFor(<MenuPage items={items} loading={false} initialSearch="?group=tools&source=plugin%3Aecho" />);
+    expect(html).toContain('1/3 items');
+    expect(html).toContain('value="tools" selected');
+    expect(html).toContain('value="plugin:echo" selected');
   });
 
   test('renders menu filter controls with plugin sources', () => {


### PR DESCRIPTION
Refs #1484

## Summary
- hydrate menu catalog group/source filters from route search params
- allow shareable /menu?group=...&source=... views for plugin menu sources
- cover menu filter parsing and rendered filtered menu state

## Verification
- git fetch origin && git rebase origin/alpha
- bunx tsc --noEmit
- bun test tests/frontend
- git diff --check
- wc -l frontend/src/pages/MenuPage.tsx frontend/src/pages/menuFilters.ts tests/frontend/pages/menu-page-filters.test.tsx