### PR TITLE
feat(vector): select first-run index source

### DIFF
--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -3,8 +3,9 @@ import { apiUrl } from "../api";
 import { Spinner } from "./AsyncState";
 import { StepBody, setupSteps } from "./SetupWizardContent";
 import { shouldShowSetupWizard } from "./setupWizardDetection";
+import { buildIndexStartBody, requestVectorIndexStart } from "./setupWizardIndex";
 import { buildProviderConfigPatch, recommendedProvider } from "./setupWizardProvider";
-import type { Provider, Stats, Step, VectorConfig } from "./setupWizardTypes";
+import type { Provider, Stats, Step, VectorConfig, VectorIndexSource } from "./setupWizardTypes";
 
 export { shouldShowSetupWizard } from "./setupWizardDetection";
 
@@ -24,6 +25,8 @@ export function SetupWizard({ children }: { children: ReactNode }) {
   const [step, setStep] = useState<Step>(0);
   const [providers, setProviders] = useState<Provider[]>([]);
   const [selectedProvider, setSelectedProvider] = useState("");
+  const [indexSource, setIndexSource] = useState<VectorIndexSource>("auto");
+  const [repoRoot, setRepoRoot] = useState("");
   const [config, setConfig] = useState<VectorConfig | null>(null);
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState("");
@@ -105,28 +108,13 @@ export function SetupWizard({ children }: { children: ReactNode }) {
   }
 
   async function startIndex() {
-    const collections = Object.entries(config?.config?.collections ?? {});
-    const key =
-      collections.find(([, item]) => item.enabled !== false)?.[0] ??
-      collections[0]?.[0];
-    if (!key)
-      return setMessage(
-        "No vector collection is configured yet. Open Vector Settings to add one.",
-      );
+    const body = buildIndexStartBody(config, indexSource, repoRoot);
+    if ('error' in body) return setMessage(body.error);
     setBusy(true);
     try {
-      await fetch(apiUrl("/api/v1/vector/index/start"), {
-        method: "POST",
-        headers: {
-          accept: "application/json",
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({ model: key }),
-      });
+      await requestVectorIndexStart(body);
       setStep(3);
-      setMessage(
-        `Started indexing ${key}. Continue to the dashboard or watch /vector/settings.`,
-      );
+      setMessage(`Started indexing ${body.model} from ${body.source}. Continue to the dashboard or watch /vector/settings.`);
     } finally {
       setBusy(false);
     }
@@ -170,6 +158,10 @@ export function SetupWizard({ children }: { children: ReactNode }) {
             config={config}
             selectedProvider={selectedProvider}
             onProviderSelect={setSelectedProvider}
+            indexSource={indexSource}
+            repoRoot={repoRoot}
+            onIndexSource={setIndexSource}
+            onRepoRoot={setRepoRoot}
           />
         </div>
         {message ? (

--- a/frontend/src/components/SetupWizardContent.tsx
+++ b/frontend/src/components/SetupWizardContent.tsx
@@ -1,4 +1,4 @@
-import type { Provider, Step, VectorConfig } from "./setupWizardTypes";
+import type { Provider, Step, VectorConfig, VectorIndexSource } from "./setupWizardTypes";
 
 export const setupSteps = [
   "Welcome",
@@ -14,6 +14,10 @@ export function StepBody({
   selectedProvider = '',
   onProviderSelect,
   config,
+  indexSource = 'auto',
+  repoRoot = '',
+  onIndexSource,
+  onRepoRoot,
 }: {
   step: Step;
   providers: Provider[];
@@ -21,6 +25,10 @@ export function StepBody({
   selectedProvider?: string;
   onProviderSelect?: (provider: string) => void;
   config: VectorConfig | null;
+  indexSource?: VectorIndexSource;
+  repoRoot?: string;
+  onIndexSource?: (source: VectorIndexSource) => void;
+  onRepoRoot?: (path: string) => void;
 }) {
   if (step === 0)
     return (
@@ -31,7 +39,7 @@ export function StepBody({
     );
   if (step === 1)
     return <ProviderList providers={providers} recommended={recommended} selectedProvider={selectedProvider} onProviderSelect={onProviderSelect} />;
-  if (step === 2) return <VaultPlan config={config} />;
+  if (step === 2) return <VaultPlan config={config} source={indexSource} repoRoot={repoRoot} onSource={onIndexSource} onRepoRoot={onRepoRoot} />;
   return (
     <p className="mt-2 text-sm text-slate-300">
       Done. Continue to the Vector dashboard or watch live progress in Vector Settings.
@@ -93,20 +101,30 @@ function ProviderList({
   );
 }
 
-function VaultPlan({ config }: { config: VectorConfig | null }) {
+function VaultPlan({ config, source, repoRoot, onSource, onRepoRoot }: {
+  config: VectorConfig | null;
+  source: VectorIndexSource;
+  repoRoot: string;
+  onSource?: (source: VectorIndexSource) => void;
+  onRepoRoot?: (path: string) => void;
+}) {
   const collections = Object.entries(config?.config?.collections ?? {});
   return (
-    <div className="mt-2 text-sm text-slate-300">
-      <p>
-        Select the vault path you want to index, then seed the primary vector
-        collection.
-      </p>
-      <p className="mt-2 text-slate-400">
-        Configured collections:{" "}
-        {collections.length
-          ? collections.map(([key]) => key).join(", ")
-          : "none yet"}
-      </p>
+    <div className="mt-2 grid gap-3 text-sm text-slate-300">
+      <p>Select the vault path you want to index, then seed the primary vector collection.</p>
+      <label className="grid gap-1 text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+        Index source
+        <select className="rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm normal-case text-slate-100" value={source} onChange={(event) => onSource?.(event.target.value as VectorIndexSource)}>
+          <option value="auto">Auto (vault, then SQLite fallback)</option>
+          <option value="vault">Vault path</option>
+          <option value="sqlite">SQLite documents</option>
+        </select>
+      </label>
+      <label className="grid gap-1 text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+        Vault path
+        <input className="rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm normal-case text-slate-100" disabled={source === 'sqlite'} placeholder="Optional repo/vault path" value={repoRoot} onChange={(event) => onRepoRoot?.(event.target.value)} />
+      </label>
+      <p className="text-slate-400">Configured collections: {collections.length ? collections.map(([key]) => key).join(", ") : "none yet"}</p>
     </div>
   );
 }

--- a/frontend/src/components/setupWizardIndex.ts
+++ b/frontend/src/components/setupWizardIndex.ts
@@ -1,0 +1,36 @@
+import { apiUrl } from '../api';
+import type { VectorConfig, VectorIndexSource } from './setupWizardTypes';
+
+export type IndexStartBody = {
+  model: string;
+  source: VectorIndexSource;
+  repoRoot?: string;
+};
+
+export function primaryCollectionKey(config: VectorConfig | null): string | null {
+  const collections = Object.entries(config?.config?.collections ?? {});
+  return collections.find(([, item]) => item.enabled !== false)?.[0] ?? collections[0]?.[0] ?? null;
+}
+
+export function buildIndexStartBody(
+  config: VectorConfig | null,
+  source: VectorIndexSource,
+  repoRoot: string,
+): IndexStartBody | { error: string } {
+  const model = primaryCollectionKey(config);
+  if (!model) return { error: 'No vector collection is configured yet. Open Vector Settings to add one.' };
+  const path = repoRoot.trim();
+  return {
+    model,
+    source,
+    ...(path && source !== 'sqlite' ? { repoRoot: path } : {}),
+  };
+}
+
+export async function requestVectorIndexStart(body: IndexStartBody): Promise<void> {
+  await fetch(apiUrl('/api/v1/vector/index/start'), {
+    method: 'POST',
+    headers: { accept: 'application/json', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}

--- a/frontend/src/components/setupWizardTypes.ts
+++ b/frontend/src/components/setupWizardTypes.ts
@@ -1,4 +1,5 @@
 export type Step = 0 | 1 | 2 | 3;
+export type VectorIndexSource = 'auto' | 'vault' | 'sqlite';
 export type Stats = {
   total?: number;
   total_docs?: number;

--- a/tests/frontend/components/setup-wizard-first-run.test.tsx
+++ b/tests/frontend/components/setup-wizard-first-run.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { shouldShowSetupWizard } from "../../../frontend/src/components/SetupWizard";
 import { StepBody, setupSteps } from "../../../frontend/src/components/SetupWizardContent";
+import { buildIndexStartBody, primaryCollectionKey } from "../../../frontend/src/components/setupWizardIndex";
 import { buildProviderConfigPatch, recommendedProvider } from "../../../frontend/src/components/setupWizardProvider";
 import { htmlFor } from "../_render";
 
@@ -52,6 +53,34 @@ describe("SetupWizard first-run detection", () => {
     expect(html).toContain('name="setup-provider"');
     expect(html).toContain('gemini · recommended');
     expect(html).toContain('Free tier available!');
+  });
+
+
+  test("builds vector index start body from selected source and vault path", () => {
+    const config = { config: { collections: { bge: { enabled: false }, qwen: { enabled: true } } } };
+    expect(primaryCollectionKey(config)).toBe("qwen");
+    expect(buildIndexStartBody(config, "vault", "/repo/oracle")).toEqual({
+      model: "qwen",
+      source: "vault",
+      repoRoot: "/repo/oracle",
+    });
+    expect(buildIndexStartBody(config, "sqlite", "/ignored")).toEqual({ model: "qwen", source: "sqlite" });
+  });
+
+  test("renders vault source controls for first-run indexing", () => {
+    const html = htmlFor(<StepBody
+      step={2}
+      providers={[]}
+      config={{ config: { collections: { bge: { model: "bge-m3" } } } }}
+      indexSource="vault"
+      repoRoot="/repo/oracle"
+      onIndexSource={() => {}}
+      onRepoRoot={() => {}}
+    />);
+    expect(html).toContain("Index source");
+    expect(html).toContain("Vault path");
+    expect(html).toContain("/repo/oracle");
+    expect(html).toContain("Configured collections: bge");
   });
 
   test("labels the final wizard step as done with dashboard guidance", () => {


### PR DESCRIPTION
## Summary
- Adds source selection to the first-run vector setup wizard (`auto`, `vault`, or `sqlite`)
- Adds optional vault path input and sends `source`/`repoRoot` to `/api/v1/vector/index/start`
- Extracts first-run index request helpers and covers selection/body behavior in frontend tests

## Validation
- `bunx tsc --noEmit`
- `bun test tests/frontend/components/setup-wizard-first-run.test.tsx tests/frontend/pages/vector-settings-page.test.tsx tests/frontend/components/vector-provider-service-panel.test.tsx`
- `bun test tests/http/vector/`
- changed files <= 250 lines
