### PR TITLE
feat: add menu filter share links

### DIFF
--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { apiClient, type ApiClient } from '../api/client';
 import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
 import { EmptyState } from '../components/EmptyState';
+import { menuCatalogPath } from '../routePaths';
 import type { MenuItem } from '../types';
 import { menuFiltersFromSearch, type MenuFilters } from './menuFilters';
 
@@ -122,6 +123,7 @@ function MenuFiltersCard({
   onGroup,
   onSource,
   onClear,
+  sharePath,
 }: {
   groups: string[];
   sources: string[];
@@ -131,6 +133,7 @@ function MenuFiltersCard({
   onGroup: (value: string) => void;
   onSource: (value: string) => void;
   onClear: () => void;
+  sharePath: string;
 }) {
   const hasFilters = filters.group !== 'all' || filters.source !== 'all';
   return (
@@ -158,6 +161,9 @@ function MenuFiltersCard({
           <button className="focus-ring self-end rounded-xl border border-white/10 px-3 py-2 text-sm font-semibold text-slate-200 hover:border-teal-300/40 disabled:opacity-40" disabled={!hasFilters} type="button" onClick={onClear}>
             Clear
           </button>
+          <a className="focus-ring self-end rounded-xl border border-teal-300/20 px-3 py-2 text-sm font-semibold text-teal-100 hover:border-teal-300/50" href={sharePath}>
+            Share view
+          </a>
         </div>
       </div>
     </section>
@@ -219,6 +225,7 @@ export function MenuPage({ items: initialItems = [], loading, client = apiClient
           onGroup={(group) => setFilters((current) => ({ ...current, group }))}
           onSource={(source) => setFilters((current) => ({ ...current, source }))}
           onClear={clearFilters}
+          sharePath={menuCatalogPath(filters)}
         />
       ) : null}
       {state === 'loading' ? <LoadingPanel title="Loading menu items..." detail="Fetching /api/menu from the Elysia backend." /> : null}

--- a/frontend/src/routePaths.ts
+++ b/frontend/src/routePaths.ts
@@ -17,6 +17,14 @@ export function pluginInventoryPath(filters: { q?: string; surface?: string; vis
   return query ? `/plugins?${query}` : '/plugins';
 }
 
+export function menuCatalogPath(filters: { group?: string; source?: string } = {}): string {
+  const params = new URLSearchParams();
+  if (filters.group && filters.group !== 'all') params.set('group', filters.group);
+  if (filters.source && filters.source !== 'all') params.set('source', filters.source);
+  const query = params.toString();
+  return query ? `/menu?${query}` : '/menu';
+}
+
 export function vectorDashboardPath(): string {
   return '/vector';
 }

--- a/tests/frontend/pages/menu-page-filters.test.tsx
+++ b/tests/frontend/pages/menu-page-filters.test.tsx
@@ -38,6 +38,7 @@ describe('MenuPage filters', () => {
     expect(html).toContain('1/3 items');
     expect(html).toContain('value="tools" selected');
     expect(html).toContain('value="plugin:echo" selected');
+    expect(html).toContain('href="/menu?group=tools&amp;source=plugin%3Aecho"');
   });
 
   test('renders menu filter controls with plugin sources', () => {

--- a/tests/frontend/routes/menu-catalog-path.test.ts
+++ b/tests/frontend/routes/menu-catalog-path.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from 'bun:test';
+import { menuCatalogPath } from '../../../frontend/src/routePaths';
+
+describe('menuCatalogPath', () => {
+  test('builds shareable menu filter URLs', () => {
+    expect(menuCatalogPath()).toBe('/menu');
+    expect(menuCatalogPath({ group: 'tools', source: 'plugin:echo' })).toBe('/menu?group=tools&source=plugin%3Aecho');
+    expect(menuCatalogPath({ group: 'all', source: 'all' })).toBe('/menu');
+  });
+});


### PR DESCRIPTION
Refs #1484

## Summary
- add a menuCatalogPath route helper for shareable menu group/source filters
- render a Share view link from the menu catalog filter panel
- cover filtered menu href output and URL encoding

## Verification
- git fetch origin && git rebase origin/alpha
- bunx tsc --noEmit
- bun test tests/frontend
- git diff --check
- wc -l frontend/src/pages/MenuPage.tsx frontend/src/routePaths.ts tests/frontend/routes/menu-catalog-path.test.ts tests/frontend/pages/menu-page-filters.test.tsx