### PR TITLE
feat: add MCP tool filter share links

### DIFF
--- a/frontend/src/components/McpToolBrowser.tsx
+++ b/frontend/src/components/McpToolBrowser.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { fetchMcpTools } from '../api';
+import { mcpToolsPath } from '../routePaths';
 import { ErrorMessage, LoadingPanel, Spinner } from './AsyncState';
 import { groupLabel, toolMode } from './toolView';
 import type { McpTool } from '../types';
@@ -173,6 +174,11 @@ export function McpToolBrowser({
         <p className="text-sm text-slate-500">
           {loading ? <Spinner label="Loading tools" /> : `${visible.length}/${tools.length} tools · ${groups} groups · ${sourceCounts.plugin} plugin · ${sourceCounts.core} core`}
         </p>
+      </div>
+      <div className="mb-4 flex justify-end">
+        <a className="focus-ring rounded-xl border border-teal-300/20 px-3 py-2 text-sm font-semibold text-teal-100 hover:border-teal-300/50" href={mcpToolsPath({ q: filter, source })}>
+          Share tool view
+        </a>
       </div>
 
       {loading ? <LoadingPanel title="Loading MCP tools…" detail="Fetching /api/mcp/tools." /> : null}

--- a/frontend/src/routePaths.ts
+++ b/frontend/src/routePaths.ts
@@ -2,6 +2,14 @@ export function mcpToolPath(name: string): string {
   return `/mcp/tools/${encodeURIComponent(name)}`;
 }
 
+export function mcpToolsPath(filters: { q?: string; source?: string } = {}): string {
+  const params = new URLSearchParams();
+  if (filters.q?.trim()) params.set('q', filters.q.trim());
+  if (filters.source && filters.source !== 'all') params.set('source', filters.source);
+  const query = params.toString();
+  return query ? `/mcp?${query}` : '/mcp';
+}
+
 export function menuSearchPath(query: string): string {
   const q = query.trim();
   if (!q) return '/search';

--- a/tests/frontend/components/mcp-tool-browser-source-filter.test.tsx
+++ b/tests/frontend/components/mcp-tool-browser-source-filter.test.tsx
@@ -37,6 +37,7 @@ describe('McpToolBrowser source filters', () => {
     expect(html).toContain('value="plugin" selected');
     expect(html).toContain('1/2 tools');
     expect(html).toContain('echo.say');
+    expect(html).toContain('href="/mcp?q=echo&amp;source=plugin"');
   });
 
   test('renders the source selector and source badges from initial tools', () => {

--- a/tests/frontend/routes/mcp-tools-path.test.ts
+++ b/tests/frontend/routes/mcp-tools-path.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from 'bun:test';
+import { mcpToolsPath } from '../../../frontend/src/routePaths';
+
+describe('mcpToolsPath', () => {
+  test('builds shareable MCP tool filter URLs', () => {
+    expect(mcpToolsPath()).toBe('/mcp');
+    expect(mcpToolsPath({ q: ' echo ', source: 'plugin' })).toBe('/mcp?q=echo&source=plugin');
+    expect(mcpToolsPath({ q: '   ', source: 'all' })).toBe('/mcp');
+  });
+});


### PR DESCRIPTION
Refs #1484

## Summary
- add an mcpToolsPath route helper for shareable MCP browser filters
- render a Share tool view link from the MCP tool browser filter state
- cover query/source URL encoding and rendered href output

## Verification
- git fetch origin && git rebase origin/alpha
- bunx tsc --noEmit
- bun test tests/frontend
- git diff --check
- wc -l frontend/src/components/McpToolBrowser.tsx frontend/src/routePaths.ts tests/frontend/components/mcp-tool-browser-source-filter.test.tsx tests/frontend/routes/mcp-tools-path.test.ts