### PR TITLE
feat(canvas): expose plugin metadata by kind

### DIFF
--- a/docs/http-api-reference.md
+++ b/docs/http-api-reference.md
@@ -123,7 +123,7 @@ Protected routes may require API token/session auth; tenant-aware routes honor `
 | GET | `/api/menu/source/official` | None. | Official menu source. |
 | POST | `/api/menu/reset-all` | None. | Reset all menu rows. |
 | POST | `/api/menu/reload` | None. | Reload/seed menu. |
-| GET | `/api/plugins` | None. | Plugin registry entries. |
+| GET | `/api/plugins` | `kind=canvas?` | Plugin registry entries or CanvasPlugin metadata. |
 | GET | `/api/plugins/:name` | `name` path. | Plugin details or file plugin details. |
 | PATCH | `/api/plugins/:name/state` | `{ enabled }` | Enable/disable state. |
 | GET | `/api/plugins/canvas` | `kind?` | Canvas plugin entries. |

--- a/src/routes/plugins/__tests__/canvas-metadata.test.ts
+++ b/src/routes/plugins/__tests__/canvas-metadata.test.ts
@@ -1,19 +1,23 @@
 import { describe, expect, test } from 'bun:test';
 import { Elysia } from 'elysia';
 
-import { pluginsRouter } from '../index.ts';
+import { createPluginsRouter } from '../index.ts';
 
 describe('/api/plugins?kind=canvas', () => {
   test('returns CanvasPlugin metadata without scanning installed wasm plugins', async () => {
-    const app = new Elysia().use(pluginsRouter);
+    const app = new Elysia().use(createPluginsRouter({
+      registry: () => { throw new Error('installed plugin registry should not load for canvas metadata'); },
+    }));
     const response = await app.handle(new Request('http://localhost/api/plugins?kind=canvas'));
     const body = await response.json() as {
       kind: string;
+      count: number;
       plugins: Array<{ id: string; kind: string; renderer: string }>;
     };
 
     expect(response.status).toBe(200);
     expect(body.kind).toBe('canvas');
+    expect(body.count).toBe(body.plugins.length);
     expect(body.plugins).toContainEqual(expect.objectContaining({ id: 'wave', kind: 'three', renderer: 'Three' }));
     expect(body.plugins).toContainEqual(expect.objectContaining({ id: 'map', kind: 'react', renderer: 'React' }));
     expect(body.plugins).toContainEqual(expect.objectContaining({ id: 'planets', kind: 'react', renderer: 'React' }));

--- a/src/routes/plugins/registry.ts
+++ b/src/routes/plugins/registry.ts
@@ -1,4 +1,5 @@
-import { Elysia } from 'elysia';
+import { Elysia, t } from 'elysia';
+import { listCanvasPluginMetadata } from '../../canvas/metadata.ts';
 import type { LoadedPluginRegistryEntry } from '../../plugins/registry.ts';
 import { basePluginDir, scanPlugins } from './model.ts';
 import { readPluginEnabled } from './state.ts';
@@ -9,8 +10,14 @@ export interface PluginsRegistryRouteOptions {
   registry?: () => LoadedPluginRegistryEntry[];
 }
 
+function canvasMetadataRegistry() {
+  const metadata = listCanvasPluginMetadata();
+  return { ...metadata, count: metadata.plugins.length };
+}
+
 export function createPluginsRegistryRoute(options: PluginsRegistryRouteOptions = {}) {
-  return new Elysia().get('/api/plugins', () => {
+  return new Elysia().get('/api/plugins', ({ query }) => {
+    if (query.kind === 'canvas') return canvasMetadataRegistry();
     const dir = tenantScopedPluginDir(options.dir ?? basePluginDir());
     if (!options.registry || hasTenantPluginScope()) return scanPlugins(dir);
     const plugins = options.registry().map((plugin) => ({
@@ -24,6 +31,7 @@ export function createPluginsRegistryRoute(options: PluginsRegistryRouteOptions 
       menu: { group: 'main', order: 70 },
       summary: 'List loaded plugins',
     },
+    query: t.Object({ kind: t.Optional(t.String()) }),
   });
 }
 


### PR DESCRIPTION
## Summary\n- implement the #950 Phase 3 metadata entrypoint: GET /api/plugins?kind=canvas\n- return bundled CanvasPlugin metadata without scanning installed wasm/plugin directories\n- document the canvas kind query and lock behavior with a registry test\n\nRefs #950\n\n## Tests\n- bunx tsc --noEmit\n- bun test src/routes/plugins/__tests__/canvas-metadata.test.ts tests/plugins/canvas-registry.test.ts tests/http/plugins/ tests/smoke/plugins-api.test.ts tests/frontend/api-client.test.ts tests/frontend/pages/canvas-plugins-page.test.tsx tests/frontend/api/canvas-plugins-standalone.test.ts\n\n## File sizes\n- src/routes/plugins/registry.ts: 38 lines\n- src/routes/plugins/__tests__/canvas-metadata.test.ts: 25 lines\n- docs/http-api-reference.md: 191 lines