### PR TITLE
feat(vector): show setup wizard cost preflight

### DIFF
--- a/frontend/src/components/SetupWizardContent.tsx
+++ b/frontend/src/components/SetupWizardContent.tsx
@@ -1,3 +1,4 @@
+import { SetupWizardCostEstimate } from "./SetupWizardCostEstimate";
 import type { Provider, Step, VectorConfig, VectorIndexSource } from "./setupWizardTypes";
 
 export const setupSteps = [
@@ -39,7 +40,7 @@ export function StepBody({
     );
   if (step === 1)
     return <ProviderList providers={providers} recommended={recommended} selectedProvider={selectedProvider} onProviderSelect={onProviderSelect} />;
-  if (step === 2) return <VaultPlan config={config} source={indexSource} repoRoot={repoRoot} onSource={onIndexSource} onRepoRoot={onRepoRoot} />;
+  if (step === 2) return <VaultPlan config={config} provider={selectedProvider || recommended?.type || "openai"} source={indexSource} repoRoot={repoRoot} onSource={onIndexSource} onRepoRoot={onRepoRoot} />;
   return (
     <p className="mt-2 text-sm text-slate-300">
       Done. Continue to the Vector dashboard or watch live progress in Vector Settings.
@@ -101,8 +102,9 @@ function ProviderList({
   );
 }
 
-function VaultPlan({ config, source, repoRoot, onSource, onRepoRoot }: {
+function VaultPlan({ config, provider, source, repoRoot, onSource, onRepoRoot }: {
   config: VectorConfig | null;
+  provider: string;
   source: VectorIndexSource;
   repoRoot: string;
   onSource?: (source: VectorIndexSource) => void;
@@ -125,6 +127,7 @@ function VaultPlan({ config, source, repoRoot, onSource, onRepoRoot }: {
         <input className="rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm normal-case text-slate-100" disabled={source === 'sqlite'} placeholder="Optional repo/vault path" value={repoRoot} onChange={(event) => onRepoRoot?.(event.target.value)} />
       </label>
       <p className="text-slate-400">Configured collections: {collections.length ? collections.map(([key]) => key).join(", ") : "none yet"}</p>
+      <SetupWizardCostEstimate provider={provider} />
     </div>
   );
 }

--- a/frontend/src/components/SetupWizardCostEstimate.tsx
+++ b/frontend/src/components/SetupWizardCostEstimate.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+import { apiUrl } from "../api";
+
+type CostEstimate = {
+  estimatedUsd: number;
+  fallbackSummary?: string;
+  formula: string;
+  provider: string;
+  recommendation?: string;
+};
+
+type Props = {
+  initialEstimate?: CostEstimate | null;
+  provider: string;
+};
+
+function formatCost(value: number): string {
+  return value === 0 ? "Free / local" : `$${value.toFixed(4)}`;
+}
+
+async function fetchEstimate(provider: string): Promise<CostEstimate> {
+  const qs = new URLSearchParams({ provider });
+  const response = await fetch(apiUrl(`/api/v1/vector/cost-estimate?${qs}`), {
+    headers: { accept: "application/json" },
+  });
+  if (!response.ok) throw new Error(`/api/v1/vector/cost-estimate returned ${response.status}`);
+  return response.json() as Promise<CostEstimate>;
+}
+
+export function SetupWizardCostEstimate({ initialEstimate, provider }: Props) {
+  const [estimate, setEstimate] = useState<CostEstimate | null>(initialEstimate ?? null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (initialEstimate !== undefined) return;
+    let active = true;
+    fetchEstimate(provider || "openai")
+      .then((next) => { if (active) setEstimate(next); })
+      .catch((cause) => { if (active) setError(cause instanceof Error ? cause.message : String(cause)); });
+    return () => { active = false; };
+  }, [initialEstimate, provider]);
+
+  if (error) return <p className="text-sm text-amber-100">Preflight cost unavailable: {error}</p>;
+  if (!estimate) return <p className="text-sm text-slate-400">Loading preflight cost estimate…</p>;
+  return (
+    <div className="rounded-2xl border border-teal-200/20 bg-teal-200/10 p-3 text-sm text-teal-50/90">
+      <p className="font-semibold text-teal-100">Preflight cost before Start indexing</p>
+      <p className="mt-1">{estimate.formula} · {estimate.provider}: {formatCost(estimate.estimatedUsd)}</p>
+      {estimate.recommendation ? <p className="mt-1 text-teal-100/75">{estimate.recommendation}</p> : null}
+      {estimate.fallbackSummary ? <p className="mt-1 text-teal-100/75">{estimate.fallbackSummary}</p> : null}
+    </div>
+  );
+}

--- a/tests/frontend/components/setup-wizard-first-run.test.tsx
+++ b/tests/frontend/components/setup-wizard-first-run.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { shouldShowSetupWizard } from "../../../frontend/src/components/SetupWizard";
+import { SetupWizardCostEstimate } from "../../../frontend/src/components/SetupWizardCostEstimate";
 import { StepBody, setupSteps } from "../../../frontend/src/components/SetupWizardContent";
 import { buildIndexStartBody, primaryCollectionKey } from "../../../frontend/src/components/setupWizardIndex";
 import { buildProviderConfigPatch, recommendedProvider } from "../../../frontend/src/components/setupWizardProvider";
@@ -81,6 +82,24 @@ describe("SetupWizard first-run detection", () => {
     expect(html).toContain("Vault path");
     expect(html).toContain("/repo/oracle");
     expect(html).toContain("Configured collections: bge");
+  });
+
+
+  test("renders first-run preflight cost estimate", () => {
+    const html = htmlFor(<SetupWizardCostEstimate
+      provider="gemini"
+      initialEstimate={{
+        estimatedUsd: 0,
+        formula: "42 docs × ~500 tokens/doc ≈ 21K tokens",
+        provider: "gemini",
+        recommendation: "Gemini free tier is recommended before paid remote embedding.",
+        fallbackSummary: "Fallback chain gemini stays free/local for this estimate.",
+      }}
+    />);
+    expect(html).toContain("Preflight cost before Start indexing");
+    expect(html).toContain("gemini: Free / local");
+    expect(html).toContain("21K tokens");
+    expect(html).toContain("Gemini free tier");
   });
 
   test("labels the final wizard step as done with dashboard guidance", () => {


### PR DESCRIPTION
## Summary
- Adds a first-run setup wizard preflight cost card before Start indexing
- Loads `/api/v1/vector/cost-estimate` for the selected provider and shows recommendation/fallback summary
- Covers the cost card with frontend wizard tests

## Validation
- `bunx tsc --noEmit`
- `bun test tests/frontend/components/setup-wizard-first-run.test.tsx tests/frontend/pages/vector-settings-page.test.tsx tests/frontend/components/vector-provider-service-panel.test.tsx`
- `bun test tests/http/vector/`
- changed files <= 250 lines
