### PR TITLE
feat: connect export app to Oracle v2 backend

### DIFF
--- a/frontend/src-tauri/src/app_menu.rs
+++ b/frontend/src-tauri/src/app_menu.rs
@@ -58,7 +58,7 @@ pub fn handle_menu_event<R: Runtime>(app: &AppHandle<R>, event: tauri::menu::Men
 
 fn open_export_page<R: Runtime>(app: &AppHandle<R>) {
     if let Some(window) = app.get_webview_window("main") {
-        let script = "window.history.pushState(null, '', '/vector/export'); window.dispatchEvent(new PopStateEvent('popstate'));";
+        let script = "window.history.pushState(null, '', '/export'); window.dispatchEvent(new PopStateEvent('popstate'));";
         if let Err(err) = window.eval(script) {
             eprintln!("[Tauri menu] navigation failed: {err}");
         }

--- a/frontend/src/components/export/DownloadCard.tsx
+++ b/frontend/src/components/export/DownloadCard.tsx
@@ -1,0 +1,13 @@
+import type { ExportDownloadLink } from '../../pages/exportAppHelpers';
+
+export function DownloadCard({ link }: { link: ExportDownloadLink | null }) {
+  if (!link) return null;
+  return (
+    <div className="rounded-2xl border border-emerald-300/20 bg-emerald-300/10 p-4" role="status">
+      <p className="text-sm font-semibold text-emerald-100">Export is ready.</p>
+      <a className="focus-ring mt-3 inline-flex rounded-xl bg-teal-300 px-5 py-3 text-sm font-semibold text-slate-950 hover:bg-teal-200" href={link.url} download={link.filename}>
+        Download {link.filename}
+      </a>
+    </div>
+  );
+}

--- a/frontend/src/pages/ExportApp.tsx
+++ b/frontend/src/pages/ExportApp.tsx
@@ -1,19 +1,27 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { ErrorMessage, LoadingPanel, Spinner } from '../components/AsyncState';
 import { BackendSelector, DEFAULT_BACKEND_URL, normalizeBackendUrl } from '../components/export/BackendSelector';
+import { DownloadCard } from '../components/export/DownloadCard';
 import { ExportProgress } from '../components/export/ExportProgress';
 import {
   backendApiUrl,
+  collectionLabel,
+  errorMessage,
   exportResponseError,
   exportAppFormats,
   exportProgressUrl,
+  isLegacyFallback,
+  isOracleV2ProxyFormat,
   legacyDirectExportLink,
   messageFromPayload,
   normalizeExportAppCollections,
+  oracleV2CollectionsPath,
+  oracleV2RunPayload,
   progressPatchFromExportPayload,
   readExportPayload,
   resolveDownloadLink,
   type ExportAppFormat,
+  type ExportAppMode,
   type ExportDownloadLink,
   type LegacyExportCollection,
 } from './exportAppHelpers';
@@ -29,33 +37,9 @@ type ExportAppProps = {
   autoLoad?: boolean;
 };
 
-function collectionLabel(collection: LegacyExportCollection): string {
-  const count = typeof collection.count === 'number' ? ` · ${collection.count.toLocaleString()} rows` : '';
-  return `${collection.label}${count}`;
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
-function isLegacyFallback(status: number): boolean {
-  return status === 404 || status === 405 || status === 501;
-}
-
-function DownloadCard({ link }: { link: ExportDownloadLink | null }) {
-  if (!link) return null;
-  return (
-    <div className="rounded-2xl border border-emerald-300/20 bg-emerald-300/10 p-4" role="status">
-      <p className="text-sm font-semibold text-emerald-100">Export is ready.</p>
-      <a className="focus-ring mt-3 inline-flex rounded-xl bg-teal-300 px-5 py-3 text-sm font-semibold text-slate-950 hover:bg-teal-200" href={link.url} download={link.filename}>
-        Download {link.filename}
-      </a>
-    </div>
-  );
-}
-
 export function ExportApp({ initialBackendUrl = DEFAULT_BACKEND_URL, fetcher = globalThis.fetch?.bind(globalThis), autoLoad = true }: ExportAppProps) {
   const [backendUrl, setBackendUrl] = useState(() => normalizeBackendUrl(initialBackendUrl));
+  const [mode, setMode] = useState<ExportAppMode>('export-app');
   const [loadState, setLoadState] = useState<LoadState>('idle');
   const [exportState, setExportState] = useState<ExportState>('idle');
   const [error, setError] = useState('');
@@ -102,6 +86,16 @@ export function ExportApp({ initialBackendUrl = DEFAULT_BACKEND_URL, fetcher = g
     setProgress({ status: 'idle', jobId: null, progress: 0 });
     try {
       if (!fetcher) throw new Error('fetch is unavailable in this runtime.');
+      const proxyPath = oracleV2CollectionsPath(normalized);
+      const proxy = await fetcher(backendApiUrl(DEFAULT_BACKEND_URL, proxyPath), { headers: { accept: 'application/json' } }).catch(() => null);
+      if (proxy?.ok) {
+        const next = normalizeExportAppCollections(await readExportPayload(proxy, proxyPath));
+        setCollections(next);
+        setCollection((current) => next.find((item) => item.id === current)?.id ?? next[0]?.id ?? '');
+        setMode('oracle-v2');
+        setLoadState('ready');
+        return;
+      }
       const path = '/api/v1/export/app/collections';
       const response = await fetcher(backendApiUrl(normalized, '/api/v1/export/app/collections'), {
         headers: { accept: 'application/json' },
@@ -110,6 +104,7 @@ export function ExportApp({ initialBackendUrl = DEFAULT_BACKEND_URL, fetcher = g
       const next = normalizeExportAppCollections(await readExportPayload(response, path));
       setCollections(next);
       setCollection((current) => next.find((item) => item.id === current)?.id ?? next[0]?.id ?? '');
+      setMode('export-app');
       setLoadState('ready');
     } catch (err) {
       setCollections([]);
@@ -131,15 +126,21 @@ export function ExportApp({ initialBackendUrl = DEFAULT_BACKEND_URL, fetcher = g
     closeProgress();
     setProgress({ status: 'starting', jobId: null, progress: 0 });
     const normalized = normalizeBackendUrl(backendUrl);
-    const payload = { collection: selected.id, format, includeGraph: true, includeMetadata: true };
+    const apiBase = mode === 'oracle-v2' ? DEFAULT_BACKEND_URL : normalized;
+    const path = mode === 'oracle-v2' ? '/api/v1/export/run' : '/api/v1/export/app/run';
+    const payload = mode === 'oracle-v2'
+      ? oracleV2RunPayload(selected.id, format, normalized)
+      : { collection: selected.id, format, includeGraph: true, includeMetadata: true };
     try {
-      const path = '/api/v1/export/app/run';
-      const response = await fetcher(backendApiUrl(normalized, '/api/v1/export/app/run'), {
+      if (mode === 'oracle-v2' && !isOracleV2ProxyFormat(format)) {
+        throw new Error('Oracle v2 direct export supports JSON, CSV, and Markdown. Choose JSON or Markdown for migration backups.');
+      }
+      const response = await fetcher(backendApiUrl(apiBase, path), {
         method: 'POST',
         headers: { accept: 'application/json', 'content-type': 'application/json' },
         body: JSON.stringify(payload),
       });
-      if (isLegacyFallback(response.status)) {
+      if (mode === 'export-app' && isLegacyFallback(response.status)) {
         const link = legacyDirectExportLink(normalized, selected.id, format);
         setDownload(link);
         setProgress({ status: 'done', jobId: null, progress: 100, downloadUrl: link.url, filename: link.filename });
@@ -151,7 +152,7 @@ export function ExportApp({ initialBackendUrl = DEFAULT_BACKEND_URL, fetcher = g
         const detail = progressPatchFromExportPayload(body).error ?? messageFromPayload(body);
         throw new Error(`${path} returned ${response.status}${detail ? `: ${detail}` : ''}`);
       }
-      const link = resolveDownloadLink(normalized, body, selected.id, format);
+      const link = resolveDownloadLink(apiBase, body, selected.id, format);
       if (!link) throw new Error('Export response did not include a download URL or job id.');
       const patch = progressPatchFromExportPayload(body);
       setDownload(link);
@@ -163,7 +164,7 @@ export function ExportApp({ initialBackendUrl = DEFAULT_BACKEND_URL, fetcher = g
         downloadUrl: link.url,
         filename: link.filename,
       }));
-      if (patch.jobId) connectProgress(normalized, patch.jobId);
+      if (patch.jobId) connectProgress(apiBase, patch.jobId);
       setExportState('ready');
     } catch (err) {
       const message = errorMessage(err);
@@ -181,7 +182,7 @@ export function ExportApp({ initialBackendUrl = DEFAULT_BACKEND_URL, fetcher = g
       <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="export-app-title">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Legacy Oracle v2</p>
         <h1 id="export-app-title" className="mt-2 text-3xl font-semibold text-white">Export app</h1>
-        <p className="mt-2 text-sm text-slate-400">Connect to an old Oracle v2 backend, list collections, and prepare JSON, JSONL, CSV, or Markdown backups before migration.</p>
+        <p className="mt-2 text-sm text-slate-400">Connect to an old Oracle v2 backend, list collections, and prepare JSON or Markdown backups before migration.</p>
       </section>
 
       <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="backend-title">
@@ -198,7 +199,7 @@ export function ExportApp({ initialBackendUrl = DEFAULT_BACKEND_URL, fetcher = g
         <div className="mt-4"><BackendSelector value={backendUrl} onChange={setBackendUrl} /></div>
       </section>
 
-      {loadState === 'loading' ? <LoadingPanel title="Loading export collections" detail="Calling /api/v1/export/app/collections on the selected backend." /> : null}
+      {loadState === 'loading' ? <LoadingPanel title="Loading export collections" detail="Checking the local Oracle v2 proxy, then export-app collections if needed." /> : null}
       {loadState === 'error' ? (
         <ErrorMessage
           title="Could not load legacy backend collections."

--- a/frontend/src/pages/exportAppHelpers.ts
+++ b/frontend/src/pages/exportAppHelpers.ts
@@ -2,6 +2,7 @@ import { normalizeBackendUrl } from '../components/export/BackendSelector';
 import type { ExportProgressState } from '../hooks/useExport';
 
 export type ExportAppFormat = 'json' | 'jsonl' | 'csv' | 'markdown';
+export type ExportAppMode = 'export-app' | 'oracle-v2';
 
 export type LegacyExportCollection = {
   id: string;
@@ -80,12 +81,43 @@ function nestedJob(payload: Record<string, unknown>): Record<string, unknown> {
   return isRecord(job) ? job : payload;
 }
 
+function nestedArtifact(payload: Record<string, unknown>): Record<string, unknown> {
+  const artifact = payload.artifact;
+  return isRecord(artifact) ? artifact : {};
+}
+
 function stringField(payload: Record<string, unknown>, fields: string[]): string {
   for (const field of fields) {
     const value = payload[field];
     if (typeof value === 'string' && value.trim()) return value.trim();
   }
   return '';
+}
+
+export function collectionLabel(collection: LegacyExportCollection): string {
+  const count = typeof collection.count === 'number' ? ` · ${collection.count.toLocaleString()} rows` : '';
+  return `${collection.label}${count}`;
+}
+
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function isLegacyFallback(status: number): boolean {
+  return status === 404 || status === 405 || status === 501;
+}
+
+export function isOracleV2ProxyFormat(format: ExportAppFormat): boolean {
+  return format === 'json' || format === 'markdown' || format === 'csv';
+}
+
+export function oracleV2CollectionsPath(oracleV2Url: string): string {
+  const query = new URLSearchParams({ baseUrl: normalizeBackendUrl(oracleV2Url) });
+  return `/api/v1/export/oracle-v2/collections?${query.toString()}`;
+}
+
+export function oracleV2RunPayload(collection: string, format: ExportAppFormat, oracleV2Url: string) {
+  return { collection, format, oracleV2Url: normalizeBackendUrl(oracleV2Url) };
 }
 
 export function resolveDownloadLink(
@@ -96,13 +128,17 @@ export function resolveDownloadLink(
 ): ExportDownloadLink | null {
   if (!isRecord(payload)) return null;
   const job = nestedJob(payload);
-  const rawUrl = stringField(job, ['downloadUrl', 'download_url', 'url', 'href']);
+  const artifact = nestedArtifact(payload);
+  const rawUrl = stringField(job, ['downloadUrl', 'download_url', 'url', 'href'])
+    || stringField(artifact, ['downloadUrl', 'download_url', 'url', 'href']);
   const jobId = stringField(job, ['jobId', 'id']);
   const path = rawUrl || (jobId ? `/api/v1/export/app/download/${encodeURIComponent(jobId)}` : '');
   if (!path) return null;
   return {
     url: new URL(path, `${normalizeBackendUrl(backendUrl)}/`).toString(),
-    filename: stringField(job, ['filename', 'fileName', 'name']) || filenameFrom(format, collection),
+    filename: stringField(job, ['filename', 'fileName', 'name'])
+      || stringField(artifact, ['filename', 'fileName', 'name'])
+      || filenameFrom(format, collection),
   };
 }
 
@@ -123,7 +159,9 @@ export function exportProgressUrl(backendUrl: string, jobId: string): string {
 }
 
 export function progressPatchFromExportPayload(payload: unknown): Partial<ExportProgressState> {
-  const job = nestedJob(isRecord(payload) ? payload : {});
+  const record = isRecord(payload) ? payload : {};
+  const job = nestedJob(record);
+  const artifact = nestedArtifact(record);
   const rawStatus = stringField(job, ['status', 'state']).toLowerCase();
   const progress = numberValue(job.progress, job.percent, job.progressPercent);
   const status = rawStatus === 'completed' || rawStatus === 'done' ? 'done'
@@ -133,9 +171,11 @@ export function progressPatchFromExportPayload(payload: unknown): Partial<Export
     ...(status ? { status } : {}),
     jobId: stringField(job, ['jobId', 'id']) || null,
     progress: progress === undefined ? undefined : Math.max(0, Math.min(100, progress <= 1 ? progress * 100 : progress)),
-    fileSizeEstimate: numberValue(job.fileSizeEstimate, job.sizeBytes, job.bytes),
-    downloadUrl: stringField(job, ['downloadUrl', 'download_url', 'url', 'href']) || undefined,
-    filename: stringField(job, ['filename', 'fileName', 'name']) || undefined,
+    fileSizeEstimate: numberValue(job.fileSizeEstimate, job.sizeBytes, job.bytes, artifact.sizeBytes, artifact.bytes),
+    downloadUrl: stringField(job, ['downloadUrl', 'download_url', 'url', 'href'])
+      || stringField(artifact, ['downloadUrl', 'download_url', 'url', 'href']) || undefined,
+    filename: stringField(job, ['filename', 'fileName', 'name'])
+      || stringField(artifact, ['filename', 'fileName', 'name']) || undefined,
     error: stringField(job, ['error', 'message']) || undefined,
   };
 }

--- a/src/routes/export/history.ts
+++ b/src/routes/export/history.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { Elysia } from 'elysia';
+import { Elysia, t } from 'elysia';
 import { desc, eq } from 'drizzle-orm';
 import { ORACLE_DATA_DIR } from '../../config.ts';
 import { db, exportJobs } from '../../db/index.ts';
@@ -10,6 +10,8 @@ import { currentTenantId, tenantDataPath, tenantIdForWrite } from '../../middlew
 import { exportHistoryRunBody, type ExportHistoryJob } from './model.ts';
 import { formatOracleV2DocumentsCsv } from './oracle-v2-csv.ts';
 import { formatOracleV2DocumentsMarkdown } from './oracle-v2-markdown.ts';
+import { rememberExportProgress } from './progress.ts';
+import { canReadTenantResource } from './tenant.ts';
 
 function clean(value: string): string {
   return value.trim();
@@ -39,10 +41,34 @@ function oracleV2ContentType(format: string): string {
   return 'application/json; charset=utf-8';
 }
 
+function downloadUrl(jobId: string): string {
+  return `/api/v1/export/history/${encodeURIComponent(jobId)}/download`;
+}
+
+function artifactPath(job: ExportHistoryJob): string {
+  const filename = `${safeName(job.collection)}-${job.id}.${oracleV2Extension(job.format)}`;
+  return path.join(tenantDataPath(path.join(ORACLE_DATA_DIR, 'exports', 'oracle-v2')), filename);
+}
+
+function rememberDone(job: ExportHistoryJob, artifact: { filename: string; sizeBytes: number }): void {
+  rememberExportProgress({
+    id: job.id,
+    jobId: job.id,
+    tenantId: job.tenantId,
+    status: 'completed',
+    progress: 100,
+    updatedAt: new Date(job.timestamp).toISOString(),
+    downloadUrl: downloadUrl(job.id),
+    filename: artifact.filename,
+    sizeBytes: artifact.sizeBytes,
+    fileSizeEstimate: artifact.sizeBytes,
+  });
+}
+
 async function writeOracleV2Export(
   job: ExportHistoryJob,
   baseUrl: string,
-): Promise<{ filePath: string; filename: string; documents: OracleV2Document[]; collections: string[] }> {
+): Promise<{ filePath: string; filename: string; sizeBytes: number; documents: OracleV2Document[]; collections: string[] }> {
   const client = createOracleV2Client({ baseUrl });
   const collections = await client.listCollections();
   const names = collections.map((item) => item.name);
@@ -71,11 +97,35 @@ async function writeOracleV2Export(
 
   await mkdir(path.dirname(filePath), { recursive: true });
   await writeFile(filePath, payload, 'utf8');
-  return { filePath, filename, documents, collections: names };
+  return { filePath, filename, sizeBytes: new TextEncoder().encode(payload).byteLength, documents, collections: names };
 }
 
 export function createExportHistoryRoutes() {
   return new Elysia()
+    .get('/export/oracle-v2/collections', async ({ query, set }) => {
+      const baseUrl = oracleV2Url(query);
+      if (!baseUrl) {
+        set.status = 400;
+        return { error: 'baseUrl query parameter is required' };
+      }
+      try {
+        const collections = await createOracleV2Client({ baseUrl }).listCollections();
+        return { baseUrl, collections, total: collections.length };
+      } catch (error) {
+        set.status = 502;
+        return { error: error instanceof Error ? error.message : String(error) };
+      }
+    }, {
+      query: t.Object({
+        baseUrl: t.Optional(t.String({ minLength: 1 })),
+        oracleV2Url: t.Optional(t.String({ minLength: 1 })),
+      }),
+      detail: {
+        tags: ['export'],
+        menu: { group: 'hidden' },
+        summary: 'List collections from a legacy Oracle v2 backend',
+      },
+    })
     .post('/export/run', async ({ body, set }) => {
       const collection = clean(body.collection);
       const format = clean(body.format);
@@ -104,6 +154,7 @@ export function createExportHistoryRoutes() {
       if (baseUrl) {
         try {
           const artifact = await writeOracleV2Export(job, baseUrl);
+          rememberDone(job, artifact);
           set.status = 201;
           return {
             job,
@@ -112,6 +163,8 @@ export function createExportHistoryRoutes() {
               filename: artifact.filename,
               contentType: oracleV2ContentType(format),
               documentCount: artifact.documents.length,
+              sizeBytes: artifact.sizeBytes,
+              downloadUrl: downloadUrl(job.id),
             },
             collections: artifact.collections,
           };
@@ -149,6 +202,32 @@ export function createExportHistoryRoutes() {
         tags: ['export'],
         menu: { group: 'hidden' },
         summary: 'List latest export job history entries',
+      },
+    })
+    .get('/export/history/:jobId/download', async ({ params, set }) => {
+      const job = db.select().from(exportJobs).where(eq(exportJobs.id, params.jobId)).get();
+      if (!job || !canReadTenantResource(job.tenantId)) {
+        set.status = 404;
+        return { error: 'Export artifact not found', id: params.jobId };
+      }
+      const filename = `${safeName(job.collection)}-${job.id}.${oracleV2Extension(job.format)}`;
+      try {
+        return new Response(await readFile(artifactPath(job)), {
+          headers: {
+            'Content-Type': oracleV2ContentType(job.format),
+            'Content-Disposition': `attachment; filename="${filename}"`,
+          },
+        });
+      } catch {
+        set.status = 404;
+        return { error: 'Export artifact file not found', id: params.jobId };
+      }
+    }, {
+      params: t.Object({ jobId: t.String() }),
+      detail: {
+        tags: ['export'],
+        menu: { group: 'hidden' },
+        summary: 'Download a legacy Oracle v2 export artifact',
       },
     });
 }

--- a/tests/frontend/pages/export-app.test.tsx
+++ b/tests/frontend/pages/export-app.test.tsx
@@ -6,6 +6,9 @@ import {
   legacyDirectExportLink,
   messageFromPayload,
   normalizeExportAppCollections,
+  oracleV2CollectionsPath,
+  oracleV2RunPayload,
+  progressPatchFromExportPayload,
   readExportPayload,
   resolveDownloadLink,
 } from '../../../frontend/src/pages/exportAppHelpers';
@@ -36,10 +39,33 @@ describe('ExportApp legacy v2 UI', () => {
       .toBe('oracle_documents.csv');
     expect(resolveDownloadLink('https://oracle.example/root', { jobId: 'job 3' }, 'oracle_documents', 'jsonl')?.filename)
       .toBe('oracle_documents.jsonl');
+    expect(resolveDownloadLink('localhost:47778', {
+      job: { id: 'job-v2', status: 'completed' },
+      artifact: { downloadUrl: '/api/v1/export/history/job-v2/download', filename: 'oracle_documents-job-v2.md' },
+    }, 'oracle_documents', 'markdown')).toEqual({
+      url: 'http://localhost:47778/api/v1/export/history/job-v2/download',
+      filename: 'oracle_documents-job-v2.md',
+    });
     expect(legacyDirectExportLink('localhost:47778', 'oracle_documents', 'markdown').url)
       .toContain('/api/v1/export/app?collection=oracle_documents&format=markdown');
     expect(legacyDirectExportLink('localhost:47778', 'oracle_documents', 'csv').filename)
       .toBe('oracle_documents.csv');
+    expect(oracleV2CollectionsPath('old.example/oracle'))
+      .toBe('/api/v1/export/oracle-v2/collections?baseUrl=http%3A%2F%2Fold.example%2Foracle');
+    expect(oracleV2RunPayload('oracle_documents', 'json', 'old.example')).toEqual({
+      collection: 'oracle_documents',
+      format: 'json',
+      oracleV2Url: 'http://old.example',
+    });
+    expect(progressPatchFromExportPayload({
+      job: { id: 'job-v2', status: 'completed' },
+      artifact: { downloadUrl: '/api/v1/export/history/job-v2/download', filename: 'docs.md', sizeBytes: 12 },
+    })).toMatchObject({
+      jobId: 'job-v2',
+      status: 'done',
+      filename: 'docs.md',
+      fileSizeEstimate: 12,
+    });
   });
 
   test('extracts backend error payloads and invalid JSON failures', async () => {

--- a/tests/http/export/oracle-v2-markdown.test.ts
+++ b/tests/http/export/oracle-v2-markdown.test.ts
@@ -51,6 +51,11 @@ async function postExport(body: Record<string, unknown>): Promise<Response> {
   }));
 }
 
+async function getExport(path: string): Promise<Response> {
+  const api = new Elysia().use(exportRoutes);
+  return api.handle(new Request(`http://local${path}`));
+}
+
 afterAll(() => {
   dbMod.closeDb();
   if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
@@ -62,6 +67,22 @@ afterAll(() => {
 });
 
 describe('Oracle v2 markdown export history route', () => {
+  test('lists collections from a legacy Oracle v2 backend', async () => {
+    const legacy = legacyOracle();
+    try {
+      const query = new URLSearchParams({ baseUrl: `http://127.0.0.1:${legacy.server.port}` });
+      const res = await getExport(`/api/export/oracle-v2/collections?${query.toString()}`);
+      const body = await res.json() as Record<string, any>;
+
+      expect(res.status).toBe(200);
+      expect(body.collections).toEqual([{ name: 'oracle_documents', count: 2 }]);
+      expect(body.total).toBe(1);
+      expect(legacy.seen).toEqual(['/api/collections']);
+    } finally {
+      legacy.server.stop(true);
+    }
+  });
+
   test('writes a Markdown artifact for Oracle v2 documents', async () => {
     const legacy = legacyOracle();
     try {
@@ -71,9 +92,10 @@ describe('Oracle v2 markdown export history route', () => {
         oracleV2Url: `http://127.0.0.1:${legacy.server.port}`,
       });
       const body = await res.json() as Record<string, any>;
-      const artifact = body.artifact as { filename: string; filePath: string };
+      const artifact = body.artifact as { filename: string; filePath: string; downloadUrl: string };
       const filename = artifact.filename;
       const filePath = artifact.filePath;
+      const downloadUrl = artifact.downloadUrl;
 
       expect(res.status).toBe(201);
       expect(body.job).toMatchObject({ collection: 'oracle_documents', format: 'markdown' });
@@ -81,6 +103,7 @@ describe('Oracle v2 markdown export history route', () => {
         filename: expect.stringContaining('oracle_documents'),
         contentType: 'text/markdown; charset=utf-8',
         documentCount: 2,
+        downloadUrl: expect.stringContaining('/api/v1/export/history/'),
       });
       expect(filename.endsWith('.md')).toBe(true);
       expect(existsSync(filePath)).toBe(true);
@@ -92,6 +115,11 @@ describe('Oracle v2 markdown export history route', () => {
       expect(markdown).toContain('Alpha legacy body');
       expect(markdown).toContain('Bravo legacy body');
       expect(legacy.seen).toEqual(['/api/collections', '/api/documents?collection=oracle_documents']);
+
+      const download = await getExport(downloadUrl.replace('/api/v1', '/api'));
+      expect(download.status).toBe(200);
+      expect(download.headers.get('content-type')).toBe('text/markdown; charset=utf-8');
+      expect(await download.text()).toBe(markdown);
     } finally {
       legacy.server.stop(true);
     }

--- a/tools/export-app/README.md
+++ b/tools/export-app/README.md
@@ -41,6 +41,8 @@ When `/api/export/run` is pointed at a legacy Oracle v2 backend with
 `oracleV2Url`, `format: "json"` writes the metadata dump and
 `format: "markdown"` writes a readable document vault file, and
 `format: "csv"` writes a spreadsheet review artifact.
+The Tauri/React export screen uses the local backend as a proxy so a raw Oracle
+v2 server only needs `/api/collections` and `/api/documents`.
 The direct fallback download path is
 `/api/v1/export/app?collection=oracle_documents&format=markdown`.
 
@@ -171,7 +173,9 @@ bun run export -- --url http://localhost:47778 --collection oracle_documents \
 The React export app is intentionally safe to use before a migration:
 
 - **Loading collections** calls `GET /api/v1/export/app/collections` on the
-  selected backend and disables the reload button while the request is active.
+  selected backend when the local Oracle v2 proxy is unavailable. Direct Oracle
+  v2 collection probes call `/api/v1/export/oracle-v2/collections?baseUrl=...`
+  through the local Tauri backend.
 - **Backend errors** display the backend `error`, `message`, or nested
   `data.message` value when one is returned; invalid JSON is reported as a
   response-shape problem so operators do not mistake it for an empty export.


### PR DESCRIPTION
## Summary
- add Oracle v2 collection proxy and export artifact download endpoints
- route the Tauri/React Export App through the local backend proxy for raw Oracle v2 backends
- point Tauri Export Data menu to the standalone export app and document the proxy flow

## Validation
- bunx tsc --noEmit
- changed files <=250 lines
