### PR TITLE
feat(canvas): use unified plugin metadata

### DIFF
--- a/frontend/src/api/canvas-plugins.ts
+++ b/frontend/src/api/canvas-plugins.ts
@@ -7,20 +7,21 @@ interface BaseCanvasPluginEntry {
   label: string;
   description: string;
   kind: CanvasPluginKind;
-  path: string;
-  query: { plugin: string };
+  path?: string;
+  query?: { plugin: string };
   standalonePath?: string;
+  renderer?: string;
+  apiPath?: string;
 }
 
 export interface ThreeCanvasPluginEntry extends BaseCanvasPluginEntry {
   kind: 'three';
-  mount: string;
+  mount?: string;
 }
 
 export interface ReactCanvasPluginEntry extends BaseCanvasPluginEntry {
   kind: 'react';
   renderer: string;
-  apiPath?: string;
 }
 
 export type CanvasPluginEntry = ThreeCanvasPluginEntry | ReactCanvasPluginEntry;
@@ -28,7 +29,7 @@ export type CanvasPluginEntry = ThreeCanvasPluginEntry | ReactCanvasPluginEntry;
 export interface CanvasPluginsResponse {
   plugins: CanvasPluginEntry[];
   count: number;
-  kind: CanvasPluginKind | 'all';
+  kind: CanvasPluginKind | 'all' | 'canvas';
   standalone?: {
     host: string;
     defaultPlugin: string;
@@ -42,8 +43,8 @@ function urlFor(path: string): string {
 }
 
 export async function fetchCanvasPlugins(kind?: CanvasPluginKind): Promise<CanvasPluginsResponse> {
-  const query = kind ? `?${new URLSearchParams({ kind }).toString()}` : '';
-  const path = `/api/canvas/plugins${query}`;
+  const query = kind ? `?${new URLSearchParams({ kind }).toString()}` : '?kind=canvas';
+  const path = kind ? `/api/canvas/plugins${query}` : `/api/plugins${query}`;
   const response = await fetch(urlFor(path), { headers: { accept: 'application/json' } });
   if (!response.ok) throw new Error(`${path} returned ${response.status}`);
   return await response.json() as CanvasPluginsResponse;

--- a/src/canvas/metadata.ts
+++ b/src/canvas/metadata.ts
@@ -8,6 +8,8 @@ export interface CanvasPluginMetadataEntry {
   kind: CanvasPluginKind;
   renderer: CanvasPluginRenderer;
   description?: string;
+  standalonePath?: string;
+  apiPath?: string;
 }
 
 export const CANVAS_PLUGIN_METADATA: CanvasPluginMetadataEntry[] = [
@@ -76,6 +78,21 @@ export const CANVAS_PLUGIN_METADATA: CanvasPluginMetadataEntry[] = [
   },
 ];
 
+function standalonePath(id: string): string {
+  return id === 'map' || id === 'planets' ? `/${id}` : `/?plugin=${id}`;
+}
+
+function apiPath(id: string): string | undefined {
+  return id === 'map' || id === 'planets' ? '/api/map3d' : undefined;
+}
+
 export function listCanvasPluginMetadata(): { kind: 'canvas'; plugins: CanvasPluginMetadataEntry[] } {
-  return { kind: 'canvas', plugins: CANVAS_PLUGIN_METADATA };
+  return {
+    kind: 'canvas',
+    plugins: CANVAS_PLUGIN_METADATA.map((plugin) => ({
+      ...plugin,
+      standalonePath: standalonePath(plugin.id),
+      apiPath: apiPath(plugin.id),
+    })),
+  };
 }

--- a/src/routes/plugins/__tests__/canvas-metadata.test.ts
+++ b/src/routes/plugins/__tests__/canvas-metadata.test.ts
@@ -12,14 +12,16 @@ describe('/api/plugins?kind=canvas', () => {
     const body = await response.json() as {
       kind: string;
       count: number;
-      plugins: Array<{ id: string; kind: string; renderer: string }>;
+      standalone: { host: string };
+      plugins: Array<{ id: string; kind: string; renderer: string; standalonePath?: string; apiPath?: string }>;
     };
 
     expect(response.status).toBe(200);
     expect(body.kind).toBe('canvas');
     expect(body.count).toBe(body.plugins.length);
+    expect(body.standalone.host).toBe('canvas.buildwithoracle.com');
     expect(body.plugins).toContainEqual(expect.objectContaining({ id: 'wave', kind: 'three', renderer: 'Three' }));
-    expect(body.plugins).toContainEqual(expect.objectContaining({ id: 'map', kind: 'react', renderer: 'React' }));
-    expect(body.plugins).toContainEqual(expect.objectContaining({ id: 'planets', kind: 'react', renderer: 'React' }));
+    expect(body.plugins).toContainEqual(expect.objectContaining({ id: 'map', kind: 'react', renderer: 'React', standalonePath: '/map', apiPath: '/api/map3d' }));
+    expect(body.plugins).toContainEqual(expect.objectContaining({ id: 'planets', kind: 'react', renderer: 'React', standalonePath: '/planets', apiPath: '/api/map3d' }));
   });
 });

--- a/src/routes/plugins/registry.ts
+++ b/src/routes/plugins/registry.ts
@@ -1,5 +1,6 @@
 import { Elysia, t } from 'elysia';
 import { listCanvasPluginMetadata } from '../../canvas/metadata.ts';
+import { canvasRegistry } from '../../canvas/registry.ts';
 import type { LoadedPluginRegistryEntry } from '../../plugins/registry.ts';
 import { basePluginDir, scanPlugins } from './model.ts';
 import { readPluginEnabled } from './state.ts';
@@ -12,7 +13,7 @@ export interface PluginsRegistryRouteOptions {
 
 function canvasMetadataRegistry() {
   const metadata = listCanvasPluginMetadata();
-  return { ...metadata, count: metadata.plugins.length };
+  return { ...metadata, count: metadata.plugins.length, standalone: canvasRegistry().standalone };
 }
 
 export function createPluginsRegistryRoute(options: PluginsRegistryRouteOptions = {}) {

--- a/tests/frontend/api/canvas-plugins-standalone.test.ts
+++ b/tests/frontend/api/canvas-plugins-standalone.test.ts
@@ -10,13 +10,12 @@ describe('fetchCanvasPlugins standalone metadata', () => {
         label: 'Knowledge Map',
         description: 'React map.',
         kind: 'react',
-        renderer: 'KnowledgeMapCanvas',
-        path: '/map',
-        query: { plugin: 'map' },
+        renderer: 'React',
         standalonePath: '/map',
+        apiPath: '/api/map3d',
       }],
       count: 1,
-      kind: 'all',
+      kind: 'canvas',
       standalone: { host: 'canvas.buildwithoracle.com', defaultPlugin: 'wave' },
     }));
     try {
@@ -24,7 +23,7 @@ describe('fetchCanvasPlugins standalone metadata', () => {
         plugins: [{ id: 'map', standalonePath: '/map' }],
         standalone: { host: 'canvas.buildwithoracle.com' },
       });
-      expect(fetchMock.calls[0]?.input).toBe('/api/canvas/plugins');
+      expect(fetchMock.calls[0]?.input).toBe('/api/plugins?kind=canvas');
     } finally {
       fetchMock.restore();
     }


### PR DESCRIPTION
## Summary\n- enrich CanvasPlugin metadata with standalone canvas URLs and Oracle data API paths\n- include standalone host metadata on GET /api/plugins?kind=canvas without scanning installed plugin directories\n- point the Canvas plugin UI client at the unified plugin metadata endpoint by default\n\nRefs #950\n\n## Tests\n- bunx tsc --noEmit\n- bun test src/routes/plugins/__tests__/canvas-metadata.test.ts tests/plugins/canvas-registry.test.ts tests/frontend/api/canvas-plugins-standalone.test.ts tests/frontend/pages/canvas-plugins-page.test.tsx tests/frontend/pages/frontend-component-coverage.test.tsx tests/frontend/api-client.test.ts tests/http/canvas/full-flow.test.ts tests/workers/canvas-worker.test.ts\n- bun test tests/http/plugins/ src/routes/plugins/__tests__/canvas-metadata.test.ts tests/plugins/canvas-registry.test.ts tests/frontend/api/canvas-plugins-standalone.test.ts tests/frontend/pages/canvas-plugins-page.test.tsx\n\n## File sizes\n- src/canvas/metadata.ts: 98 lines\n- src/routes/plugins/registry.ts: 39 lines\n- frontend/src/api/canvas-plugins.ts: 51 lines\n- src/routes/plugins/__tests__/canvas-metadata.test.ts: 27 lines\n- tests/frontend/api/canvas-plugins-standalone.test.ts: 31 lines