### PR TITLE
feat(canvas): preserve studio canvas alias

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -52,6 +52,7 @@ export function AppShell({
     { to: '/', label: 'Menu', description: 'Navigation rows from /api/menu', badge: loading ? '…' : menuCount },
     { to: '/plugins', label: 'Plugins', description: 'Registered plugins and surfaces', badge: loading ? '…' : pluginCount },
     { to: '/status', label: 'Status', description: 'Server health from /api/v1/health' },
+    { to: '/canvas?plugin=wave', label: 'Canvas App', description: 'Studio alias for canvas.buildwithoracle.com' },
     { to: '/canvas/plugins', label: 'Canvas Plugins', description: 'Canvas registry from /api/canvas/plugins' },
     { to: '/search', label: 'Search', description: 'Full-text menu search' },
     { to: '/export', label: 'Export App', description: 'Legacy v2 JSON/Markdown backups' },

--- a/frontend/src/pages/CanvasAliasPage.tsx
+++ b/frontend/src/pages/CanvasAliasPage.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const CANVAS_HOST = 'https://canvas.buildwithoracle.com';
+const DEFAULT_PLUGIN = 'wave';
+
+function canvasPath(plugin: string): string {
+  const id = plugin.trim() || DEFAULT_PLUGIN;
+  return id === 'map' || id === 'planets' ? `/${id}` : `/?${new URLSearchParams({ plugin: id })}`;
+}
+
+export function canvasStandaloneUrl(search: string): string {
+  const params = new URLSearchParams(search);
+  return new URL(canvasPath(params.get('plugin') ?? DEFAULT_PLUGIN), CANVAS_HOST).toString();
+}
+
+export function CanvasAliasPage() {
+  const location = useLocation();
+  const target = useMemo(() => canvasStandaloneUrl(location.search), [location.search]);
+
+  useEffect(() => {
+    if (import.meta.env.DEV) {
+      console.warn('[canvas] /canvas is a deprecated Studio alias; prefer canvas.buildwithoracle.com');
+    }
+  }, []);
+
+  return (
+    <section className="grid gap-5" aria-labelledby="canvas-alias-title">
+      <header className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Canvas app</p>
+        <h1 id="canvas-alias-title" className="mt-2 text-3xl font-semibold text-white">Studio canvas alias</h1>
+        <p className="mt-2 text-sm text-slate-400">/canvas remains available while the isolated canvas app runs on canvas.buildwithoracle.com.</p>
+        <a className="focus-ring mt-4 inline-flex rounded-xl border border-teal-300/30 px-3 py-2 text-sm font-semibold text-teal-100 hover:bg-teal-300/10" href={target}>
+          Open standalone canvas
+        </a>
+      </header>
+      <iframe
+        className="min-h-[34rem] w-full rounded-3xl border border-white/10 bg-slate-950"
+        src={target}
+        title="canvas.buildwithoracle.com preview"
+      />
+    </section>
+  );
+}

--- a/frontend/src/routeMeta.ts
+++ b/frontend/src/routeMeta.ts
@@ -77,6 +77,7 @@ export function routeMeta(pathname: string, search = ''): RouteMeta {
 
   if (pathname === '/plugins') return base('Plugin list', 'Plugins', 'Registered plugins and exposed runtime surfaces.', [{ label: 'Plugins' }]);
   if (pathname === '/status') return base('Server status', 'Status', 'Server health from /api/v1/health.', [{ label: 'Status' }]);
+  if (pathname === '/canvas') return base('Canvas app', 'Canvas', 'Studio alias for canvas.buildwithoracle.com.', [{ label: 'Canvas app' }]);
   if (pathname === '/canvas/plugins') return base('Canvas plugins', 'Canvas', 'Canvas plugin registry and standalone status.', [{ label: 'Canvas plugins' }]);
   if (pathname === '/metrics') return base('Runtime metrics', 'Metrics', 'Runtime counters from /api/v1/metrics.', [{ label: 'Metrics' }]);
   if (pathname === '/search') return base('Search', 'Search', 'Search menu, plugin, and MCP tool surfaces.', [{ label: 'Search' }]);

--- a/frontend/src/routePaths.ts
+++ b/frontend/src/routePaths.ts
@@ -69,6 +69,11 @@ export function vectorSettingsPath(): string {
   return '/vector/settings';
 }
 
+export function canvasAppPath(plugin = 'wave'): string {
+  const id = plugin.trim();
+  return id ? `/canvas?${new URLSearchParams({ plugin: id })}` : '/canvas';
+}
+
 export function canvasPluginsPath(): string {
   return '/canvas/plugins';
 }

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -8,6 +8,7 @@ import { ExportApp } from './pages/ExportApp';
 import { LearnPage } from './pages/LearnPage';
 import { MenuPage } from './pages/MenuPage';
 import { PluginsPage } from './pages/PluginsPage';
+import { CanvasAliasPage } from './pages/CanvasAliasPage';
 import { CanvasPluginsPage } from './pages/CanvasPluginsPage';
 import { SearchPage } from './pages/SearchPage';
 import { SettingsPage } from './pages/SettingsPage';
@@ -28,6 +29,7 @@ export const frontendRoutes = [
   '/menu',
   '/plugins',
   '/status',
+  '/canvas',
   '/canvas/plugins',
   '/metrics',
   '/search',
@@ -86,6 +88,7 @@ export function DashboardRoutes({
       <Route index element={menuPage} />
       <Route path="/plugins" element={pluginPage} />
       <Route path="/status" element={<StatusPage />} />
+      <Route path="/canvas" element={<CanvasAliasPage />} />
       <Route path="/canvas/plugins" element={<CanvasPluginsPage />} />
       <Route path="/metrics" element={<MetricsPage metrics={metrics} loading={isRouteLoading(states.metrics)} />} />
       <Route path="/search" element={<SearchPage />} />

--- a/tests/frontend/router.test.ts
+++ b/tests/frontend/router.test.ts
@@ -36,6 +36,7 @@ describe('frontend router', () => {
       '/menu',
       '/plugins',
       '/status',
+      '/canvas',
       '/canvas/plugins',
       '/metrics',
       '/search',
@@ -58,6 +59,8 @@ describe('frontend router', () => {
     expect(htmlAt('/')).toContain('Menu catalog');
     expect(htmlAt('/plugins')).toContain('Registered plugins');
     expect(htmlAt('/status')).toContain('GET /api/v1/health');
+    expect(htmlAt('/canvas?plugin=map')).toContain('https://canvas.buildwithoracle.com/map');
+    expect(htmlAt('/canvas?plugin=wave')).toContain('Studio canvas alias');
     expect(htmlAt('/canvas/plugins')).toContain('Canvas plugin registry');
     expect(htmlAt('/metrics')).toContain('Metrics dashboard');
     expect(htmlAt('/metrics')).toContain('42');

--- a/tests/frontend/routes/canvas-app-path.test.ts
+++ b/tests/frontend/routes/canvas-app-path.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'bun:test';
+import { canvasAppPath } from '../../../frontend/src/routePaths';
+
+describe('canvasAppPath', () => {
+  test('preserves the Studio /canvas plugin query alias', () => {
+    expect(canvasAppPath('wave')).toBe('/canvas?plugin=wave');
+    expect(canvasAppPath('')).toBe('/canvas');
+  });
+});


### PR DESCRIPTION
## Summary\n- add a Studio /canvas alias route that preserves /canvas?plugin=X and embeds the isolated canvas.buildwithoracle.com app\n- add Canvas App navigation/route metadata and a route path helper for the legacy Studio alias\n- cover /canvas?plugin=map and /canvas?plugin=wave routing plus the helper output\n\nRefs #950\n\n## Tests\n- bunx tsc --noEmit\n- bun test tests/frontend/router.test.ts tests/frontend/routes/canvas-app-path.test.ts tests/frontend/components/app-shell-summary.test.tsx tests/frontend/components/app-shell-storage-nav.test.tsx tests/frontend/pages/canvas-plugins-page.test.tsx tests/frontend/api/canvas-plugins-standalone.test.ts tests/http/canvas/full-flow.test.ts tests/workers/canvas-worker.test.ts\n\n## File sizes\n- frontend/src/pages/CanvasAliasPage.tsx: 44 lines\n- frontend/src/router.tsx: 115 lines\n- frontend/src/routeMeta.ts: 91 lines\n- frontend/src/components/AppShell.tsx: 134 lines\n- frontend/src/routePaths.ts: 83 lines\n- tests/frontend/router.test.ts: 92 lines\n- tests/frontend/routes/canvas-app-path.test.ts: 9 lines