### PR TITLE
feat(canvas): share standalone URL helpers

### DIFF
--- a/src/canvas/__tests__/urls.test.ts
+++ b/src/canvas/__tests__/urls.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  CANVAS_ORIGIN,
+  canvasPluginAbsoluteUrl,
+  canvasPluginDataPath,
+  canvasPluginPath,
+} from '../index.ts';
+
+describe('canvas URL helpers', () => {
+  test('maps react plugins to clean standalone paths', () => {
+    expect(canvasPluginPath('map')).toBe('/map');
+    expect(canvasPluginPath('planets')).toBe('/planets');
+    expect(canvasPluginAbsoluteUrl('map')).toBe(`${CANVAS_ORIGIN}/map`);
+  });
+
+  test('maps three plugins to query-string standalone paths', () => {
+    expect(canvasPluginPath('wave')).toBe('/?plugin=wave');
+    expect(canvasPluginPath('')).toBe('/?plugin=wave');
+    expect(canvasPluginAbsoluteUrl('map3d')).toBe(`${CANVAS_ORIGIN}/?plugin=map3d`);
+  });
+
+  test('exposes data API only for react canvas plugins', () => {
+    expect(canvasPluginDataPath('map')).toBe('/api/map3d');
+    expect(canvasPluginDataPath('planets')).toBe('/api/map3d');
+    expect(canvasPluginDataPath('wave')).toBeUndefined();
+  });
+});

--- a/src/canvas/index.ts
+++ b/src/canvas/index.ts
@@ -14,3 +14,4 @@ export { renderCanvasPlugin } from './host.ts';
 export { isCanvasPlugin } from './plugin.ts';
 export type { CanvasPluginMetadataEntry, CanvasPluginRenderer } from './metadata.ts';
 export { CANVAS_PLUGIN_METADATA, listCanvasPluginMetadata } from './metadata.ts';
+export { CANVAS_HOST, CANVAS_ORIGIN, DEFAULT_CANVAS_PLUGIN, canvasPluginAbsoluteUrl, canvasPluginDataPath, canvasPluginPath } from './urls.ts';

--- a/src/canvas/metadata.ts
+++ b/src/canvas/metadata.ts
@@ -1,4 +1,5 @@
 import type { CanvasPluginKind } from './plugin.ts';
+import { canvasPluginDataPath, canvasPluginPath } from './urls.ts';
 
 export type CanvasPluginRenderer = 'Three' | 'React';
 
@@ -78,21 +79,13 @@ export const CANVAS_PLUGIN_METADATA: CanvasPluginMetadataEntry[] = [
   },
 ];
 
-function standalonePath(id: string): string {
-  return id === 'map' || id === 'planets' ? `/${id}` : `/?plugin=${id}`;
-}
-
-function apiPath(id: string): string | undefined {
-  return id === 'map' || id === 'planets' ? '/api/map3d' : undefined;
-}
-
 export function listCanvasPluginMetadata(): { kind: 'canvas'; plugins: CanvasPluginMetadataEntry[] } {
   return {
     kind: 'canvas',
     plugins: CANVAS_PLUGIN_METADATA.map((plugin) => ({
       ...plugin,
-      standalonePath: standalonePath(plugin.id),
-      apiPath: apiPath(plugin.id),
+      standalonePath: canvasPluginPath(plugin.id),
+      apiPath: canvasPluginDataPath(plugin.id),
     })),
   };
 }

--- a/src/canvas/registry.ts
+++ b/src/canvas/registry.ts
@@ -1,4 +1,5 @@
 import { findCanvasPlugin, listCanvasPlugins, type CanvasPluginKind } from './plugins.ts';
+import { canvasPluginPath } from './urls.ts';
 
 const kinds = new Set<CanvasPluginKind>(['three', 'react']);
 
@@ -6,9 +7,7 @@ export function parseCanvasKind(value: unknown): CanvasPluginKind | undefined {
   return typeof value === 'string' && kinds.has(value as CanvasPluginKind) ? value as CanvasPluginKind : undefined;
 }
 
-export function canvasPluginUrl(id: string): string {
-  return id === 'map' || id === 'planets' ? `/${id}` : `/?plugin=${id}`;
-}
+export const canvasPluginUrl = canvasPluginPath;
 
 export function canvasRegistry(kind?: CanvasPluginKind) {
   const plugins = listCanvasPlugins(kind).map((plugin) => ({

--- a/src/canvas/urls.ts
+++ b/src/canvas/urls.ts
@@ -1,0 +1,19 @@
+export const CANVAS_HOST = 'canvas.buildwithoracle.com';
+export const CANVAS_ORIGIN = `https://${CANVAS_HOST}`;
+export const DEFAULT_CANVAS_PLUGIN = 'wave';
+
+const REACT_PLUGIN_PATHS = new Set(['map', 'planets']);
+
+export function canvasPluginPath(id: string): string {
+  const plugin = id.trim() || DEFAULT_CANVAS_PLUGIN;
+  if (REACT_PLUGIN_PATHS.has(plugin)) return `/${plugin}`;
+  return `/?${new URLSearchParams({ plugin })}`;
+}
+
+export function canvasPluginAbsoluteUrl(id: string, origin = CANVAS_ORIGIN): string {
+  return new URL(canvasPluginPath(id), origin).toString();
+}
+
+export function canvasPluginDataPath(id: string): string | undefined {
+  return REACT_PLUGIN_PATHS.has(id) ? '/api/map3d' : undefined;
+}

--- a/src/workers/canvas/render.ts
+++ b/src/workers/canvas/render.ts
@@ -1,9 +1,9 @@
 import { findCanvasPlugin, listCanvasPlugins, type CanvasPluginDescriptor } from '../../canvas/plugins.ts';
+import { CANVAS_ORIGIN, canvasPluginPath } from '../../canvas/urls.ts';
 
 export type CanvasPlugin = CanvasPluginDescriptor;
 
 const DEFAULT_PLUGIN = 'wave';
-const CANVAS_ORIGIN = 'https://canvas.buildwithoracle.com';
 const STUDIO_HOME = 'https://studio.buildwithoracle.com/';
 
 export function normalizePlugin(value: string | null): CanvasPlugin {
@@ -15,7 +15,7 @@ function titleFor(plugin: CanvasPlugin): string {
 }
 
 function pluginUrl(id: string): string {
-  return id === 'map' || id === 'planets' ? `/${id}` : `/?plugin=${id}`;
+  return canvasPluginPath(id);
 }
 
 function canonicalUrl(id: string): string {


### PR DESCRIPTION
## Summary\n- add shared canvas URL/data-path helpers for standalone plugin paths and canvas host URLs\n- reuse the helper from registry metadata and the canvas worker shell to avoid divergent map/planets path rules\n- export the helper surface for the future shared canvas plugin package\n\nRefs #950\n\n## Tests\n- bunx tsc --noEmit\n- bun test src/canvas/__tests__/urls.test.ts src/canvas/__tests__/host.test.ts src/canvas/__tests__/plugin.test.ts tests/canvas/phase2.test.ts tests/workers/canvas-worker.test.ts tests/http/canvas/full-flow.test.ts tests/http/canvas-worker.test.ts src/routes/plugins/__tests__/canvas-metadata.test.ts tests/frontend/api/canvas-plugins-standalone.test.ts tests/frontend/router.test.ts tests/frontend/routes/canvas-app-path.test.ts\n\n## File sizes\n- src/canvas/urls.ts: 19 lines\n- src/canvas/index.ts: 17 lines\n- src/canvas/registry.ts: 32 lines\n- src/canvas/metadata.ts: 91 lines\n- src/workers/canvas/render.ts: 105 lines\n- src/canvas/__tests__/urls.test.ts: 28 lines