### PR TITLE
feat(vector): show live index cost tracking

### DIFF
--- a/frontend/src/components/VectorIndexCostPanel.tsx
+++ b/frontend/src/components/VectorIndexCostPanel.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useMemo, useState } from 'react';
+import { fetchJson } from '../pages/vectorSettingsHelpers';
+
+export type VectorCostEstimate = {
+  formula: string;
+  estimatedUsd: number;
+  provider: string;
+  recommendation?: string;
+  fallbackSummary?: string;
+};
+
+type ProviderCost = {
+  apiCalls: number;
+  estimatedUsd: number;
+  inputTokens: number;
+  provider?: string;
+};
+
+type CostWindow = {
+  apiCalls: number;
+  estimatedUsd: number;
+  inputTokens: number;
+  providers?: Record<string, ProviderCost>;
+};
+
+export type VectorCostTracking = {
+  breakdown?: { daily?: CostWindow };
+  usage?: unknown[];
+};
+
+interface VectorIndexCostPanelProps {
+  indexing?: boolean;
+  initialCostEstimate?: VectorCostEstimate | null;
+  initialCostTracking?: VectorCostTracking | null;
+  loadCostEstimate?: () => Promise<VectorCostEstimate>;
+  loadCostTracking?: () => Promise<VectorCostTracking>;
+  pollMs?: number;
+}
+
+const loadDefaultCostEstimate = () => fetchJson<VectorCostEstimate>('/api/v1/vector/cost-estimate');
+const loadDefaultCostTracking = () => fetchJson<VectorCostTracking>('/api/v1/vector/costs');
+
+function formatCost(value: number): string {
+  return value === 0 ? 'Free / local' : `$${value.toFixed(4)}`;
+}
+
+function providerRows(window?: CostWindow): ProviderCost[] {
+  return Object.values(window?.providers ?? {})
+    .sort((a, b) => b.inputTokens - a.inputTokens)
+    .slice(0, 3);
+}
+
+export function VectorIndexCostPanel({
+  indexing = false,
+  initialCostEstimate,
+  initialCostTracking,
+  loadCostEstimate = loadDefaultCostEstimate,
+  loadCostTracking = loadDefaultCostTracking,
+  pollMs = 2000,
+}: VectorIndexCostPanelProps) {
+  const [costEstimate, setCostEstimate] = useState<VectorCostEstimate | null>(initialCostEstimate ?? null);
+  const [costTracking, setCostTracking] = useState<VectorCostTracking | null>(initialCostTracking ?? null);
+  const [costError, setCostError] = useState('');
+  const [trackingError, setTrackingError] = useState('');
+  const daily = costTracking?.breakdown?.daily;
+  const providers = useMemo(() => providerRows(daily), [daily]);
+
+  useEffect(() => {
+    if (initialCostEstimate !== undefined) return;
+    let active = true;
+    loadCostEstimate()
+      .then((next) => { if (active) setCostEstimate(next); })
+      .catch((err) => { if (active) setCostError(err instanceof Error ? err.message : String(err)); });
+    return () => { active = false; };
+  }, [initialCostEstimate, loadCostEstimate]);
+
+  useEffect(() => {
+    if (initialCostTracking !== undefined) return;
+    let active = true;
+    const load = () => loadCostTracking()
+      .then((next) => { if (active) setCostTracking(next); })
+      .catch((err) => { if (active) setTrackingError(err instanceof Error ? err.message : String(err)); });
+    void load();
+    if (!indexing || typeof window === 'undefined') return () => { active = false; };
+    const timer = window.setInterval(() => { void load(); }, pollMs);
+    return () => { active = false; window.clearInterval(timer); };
+  }, [indexing, initialCostTracking, loadCostTracking, pollMs]);
+
+  return (
+    <>
+      {costEstimate ? (
+        <div className="mb-4 rounded-2xl border border-teal-200/20 bg-teal-200/10 p-4 text-sm text-teal-50/90">
+          <p className="font-semibold text-teal-100">Preflight cost before Index Now</p>
+          <p className="mt-1">{costEstimate.formula} · {costEstimate.provider}: {formatCost(costEstimate.estimatedUsd)}</p>
+          {costEstimate.fallbackSummary ? <p className="mt-1 text-teal-100/75">{costEstimate.fallbackSummary}</p> : null}
+          {costEstimate.recommendation ? <p className="mt-1 text-teal-100/75">{costEstimate.recommendation}</p> : null}
+        </div>
+      ) : costError ? <p className="mb-4 text-sm text-amber-100">Cost estimate unavailable: {costError}</p> : null}
+
+      {costTracking ? (
+        <div className="mb-4 rounded-2xl border border-cyan-200/20 bg-cyan-200/10 p-4 text-sm text-cyan-50/90">
+          <p className="font-semibold text-cyan-100">Live cost tracking</p>
+          <p className="mt-1">
+            {(daily?.inputTokens ?? 0).toLocaleString()} tokens · {(daily?.apiCalls ?? 0).toLocaleString()} API calls · {formatCost(daily?.estimatedUsd ?? 0)} today
+          </p>
+          {providers.map((provider, index) => (
+            <p key={provider.provider ?? index} className="mt-1 text-cyan-100/75">
+              {provider.provider ?? 'provider'}: {provider.inputTokens.toLocaleString()} tokens · {formatCost(provider.estimatedUsd)}
+            </p>
+          ))}
+          {(daily?.inputTokens ?? 0) === 0 ? <p className="mt-1 text-cyan-100/70">No metered indexing usage recorded yet.</p> : null}
+        </div>
+      ) : trackingError ? <p className="mb-4 text-sm text-amber-100">Live cost tracking unavailable: {trackingError}</p> : null}
+    </>
+  );
+}

--- a/frontend/src/components/VectorIndexPanel.tsx
+++ b/frontend/src/components/VectorIndexPanel.tsx
@@ -6,27 +6,18 @@ import {
   type VectorIndexStatusResponse,
 } from '../api/client';
 import { ErrorMessage, LoadingPanel, Spinner } from './AsyncState';
-import { fetchJson } from '../pages/vectorSettingsHelpers';
+import { VectorIndexCostPanel, type VectorCostEstimate, type VectorCostTracking } from './VectorIndexCostPanel';
 
 type VectorIndexClient = Pick<ApiClient, 'startVectorIndex' | 'vectorIndexModels' | 'vectorIndexStatus'>;
-
-type VectorCostEstimate = {
-  formula: string;
-  estimatedUsd: number;
-  provider: string;
-  recommendation?: string;
-  fallbackSummary?: string;
-};
 
 interface VectorIndexPanelProps {
   client?: VectorIndexClient;
   initialModels?: Record<string, VectorIndexCollection>;
   initialStatus?: VectorIndexStatusResponse | null;
   initialCostEstimate?: VectorCostEstimate | null;
+  initialCostTracking?: VectorCostTracking | null;
   loadCostEstimate?: () => Promise<VectorCostEstimate>;
 }
-
-const loadDefaultCostEstimate = () => fetchJson<VectorCostEstimate>('/api/v1/vector/cost-estimate');
 
 export function formatIndexEta(seconds: number): string {
   if (!Number.isFinite(seconds) || seconds <= 0) return 'calculating';
@@ -43,10 +34,6 @@ function progressFor(status: VectorIndexStatusResponse): number {
 
 function totalVectors(models: Record<string, VectorIndexCollection>): number {
   return Object.values(models).reduce((sum, model) => sum + (model.count ?? 0), 0);
-}
-
-function formatCost(value: number): string {
-  return value === 0 ? 'Free / local' : `$${value.toFixed(4)}`;
 }
 
 function gapLabel(models: Record<string, VectorIndexCollection>, status: VectorIndexStatusResponse | null): string {
@@ -76,13 +63,12 @@ export function VectorIndexPanel({
   initialModels,
   initialStatus = null,
   initialCostEstimate,
-  loadCostEstimate = loadDefaultCostEstimate,
+  initialCostTracking,
+  loadCostEstimate,
 }: VectorIndexPanelProps) {
   const [models, setModels] = useState<Record<string, VectorIndexCollection>>(initialModels ?? {});
   const [loading, setLoading] = useState(!initialModels);
   const [status, setStatus] = useState<VectorIndexStatusResponse | null>(initialStatus);
-  const [costEstimate, setCostEstimate] = useState<VectorCostEstimate | null>(initialCostEstimate ?? null);
-  const [costError, setCostError] = useState('');
   const [error, setError] = useState('');
   const [startingKey, setStartingKey] = useState<string | null>(null);
 
@@ -114,15 +100,6 @@ export function VectorIndexPanel({
       .catch((err) => { if (active) setError(err instanceof Error ? err.message : String(err)); });
     return () => { active = false; };
   }, [client]);
-
-  useEffect(() => {
-    if (initialCostEstimate !== undefined) return;
-    let active = true;
-    loadCostEstimate()
-      .then((next) => { if (active) setCostEstimate(next); })
-      .catch((err) => { if (active) setCostError(err instanceof Error ? err.message : String(err)); });
-    return () => { active = false; };
-  }, [initialCostEstimate, loadCostEstimate]);
 
   useEffect(() => {
     if (!indexing || typeof window === 'undefined') return;
@@ -171,14 +148,7 @@ export function VectorIndexPanel({
         {status ? <IndexProgress status={status} /> : null}
       </div>
 
-      {costEstimate ? (
-        <div className="mb-4 rounded-2xl border border-teal-200/20 bg-teal-200/10 p-4 text-sm text-teal-50/90">
-          <p className="font-semibold text-teal-100">Preflight cost before Index Now</p>
-          <p className="mt-1">{costEstimate.formula} · {costEstimate.provider}: {formatCost(costEstimate.estimatedUsd)}</p>
-          {costEstimate.fallbackSummary ? <p className="mt-1 text-teal-100/75">{costEstimate.fallbackSummary}</p> : null}
-          {costEstimate.recommendation ? <p className="mt-1 text-teal-100/75">{costEstimate.recommendation}</p> : null}
-        </div>
-      ) : costError ? <p className="mb-4 text-sm text-amber-100">Cost estimate unavailable: {costError}</p> : null}
+      <VectorIndexCostPanel indexing={indexing} initialCostEstimate={initialCostEstimate} initialCostTracking={initialCostTracking} loadCostEstimate={loadCostEstimate} />
 
       {loading ? <LoadingPanel title="Loading vector collections…" detail="Fetching /api/v1/vector/index/models." /> : null}
       {error ? <ErrorMessage title="Vector indexing failed." message={error} /> : null}

--- a/tests/frontend/components/vector-index-panel-render.test.tsx
+++ b/tests/frontend/components/vector-index-panel-render.test.tsx
@@ -25,6 +25,18 @@ describe('VectorIndexPanel', () => {
           fallbackSummary: 'Fallback chain ollama → openai worst-case remote spend: $0.0010.',
           recommendation: 'Any configured embedding model should work.',
         }}
+        initialCostTracking={{
+          breakdown: {
+            daily: {
+              inputTokens: 250000,
+              apiCalls: 4,
+              estimatedUsd: 0.025,
+              providers: {
+                openai: { provider: 'openai', inputTokens: 250000, apiCalls: 4, estimatedUsd: 0.025 },
+              },
+            },
+          },
+        }}
         initialModels={{
           'bge-m3': { collection: 'oracle_bge_m3', model: 'BAAI/bge-m3', adapter: 'lancedb', count: 100 },
           qwen3: { collection: 'oracle_qwen3', model: 'Qwen3', adapter: 'lancedb', count: 80 },
@@ -41,6 +53,11 @@ describe('VectorIndexPanel', () => {
     expect(html).toContain('100 docs × ~500 tokens/doc ≈ 50K tokens');
     expect(html).toContain('$0.0010');
     expect(html).toContain('Fallback chain ollama');
+    expect(html).toContain('Live cost tracking');
+    expect(html).toContain('250,000 tokens');
+    expect(html).toContain('4 API calls');
+    expect(html).toContain('$0.0250');
+    expect(html).toContain('openai: 250,000 tokens');
     expect(html).toContain('Index Now');
     expect(html).toContain('Backfill Vectors');
     expect(html).toContain('Add Vault');


### PR DESCRIPTION
## Summary
- Add a VectorIndexCostPanel for Index Manager cost surfaces.
- Keep the preflight estimate while adding live /api/v1/vector/costs daily usage tracking during indexing.
- Cover live cost rendering in the VectorIndexPanel component test.

## Validation
- bunx tsc --noEmit
- bun test tests/frontend/components/vector-index-panel-render.test.tsx tests/frontend/pages/vector-settings-page.test.tsx tests/http/vector/
- git diff --check
- file sizes <=250 lines
