### PR TITLE
feat(canvas): point registry UI at plugin metadata

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -53,7 +53,7 @@ export function AppShell({
     { to: '/plugins', label: 'Plugins', description: 'Registered plugins and surfaces', badge: loading ? '…' : pluginCount },
     { to: '/status', label: 'Status', description: 'Server health from /api/v1/health' },
     { to: '/canvas?plugin=wave', label: 'Canvas App', description: 'Studio alias for canvas.buildwithoracle.com' },
-    { to: '/canvas/plugins', label: 'Canvas Plugins', description: 'Canvas registry from /api/canvas/plugins' },
+    { to: '/canvas/plugins', label: 'Canvas Plugins', description: 'Canvas metadata from /api/plugins?kind=canvas' },
     { to: '/search', label: 'Search', description: 'Full-text menu search' },
     { to: '/export', label: 'Export App', description: 'Legacy v2 JSON/Markdown backups' },
     { to: '/vector', label: 'Vector Dashboard', description: 'Collection health and indexing', end: true },

--- a/frontend/src/pages/CanvasPluginsPage.tsx
+++ b/frontend/src/pages/CanvasPluginsPage.tsx
@@ -89,11 +89,11 @@ export function CanvasPluginsPage({ plugins: initialPlugins = [], loading = true
       <header className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Canvas plugins</p>
         <h1 id="canvas-plugins-title" className="mt-2 text-3xl font-semibold text-white">Canvas plugin registry</h1>
-        <p className="mt-2 text-sm text-slate-400">Fetched from /api/canvas/plugins for canvas.buildwithoracle.com standalone rendering.</p>
+        <p className="mt-2 text-sm text-slate-400">Fetched from /api/plugins?kind=canvas for canvas.buildwithoracle.com standalone rendering.</p>
         <p className="mt-3 inline-flex rounded-full border border-white/10 px-3 py-2 text-sm text-slate-300">{summary}</p>
       </header>
 
-      {state === 'loading' ? <LoadingPanel title="Loading canvas plugins" detail="Reading /api/canvas/plugins." /> : null}
+      {state === 'loading' ? <LoadingPanel title="Loading canvas plugins" detail="Reading /api/plugins?kind=canvas." /> : null}
       {state === 'error' ? <ErrorMessage title="Could not load canvas plugins." message={error} /> : null}
       {state !== 'error' && error ? <ErrorMessage title="Canvas plugin warning" message={error} /> : null}
       {state !== 'error' ? <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">{plugins.map((plugin) => <PluginCard key={plugin.id} plugin={plugin} host={host} />)}</div> : null}

--- a/tests/frontend/components/app-shell-canvas-nav.test.tsx
+++ b/tests/frontend/components/app-shell-canvas-nav.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+import { MemoryRouter } from 'react-router-dom';
+import { AppShell } from '../../../frontend/src/components/AppShell';
+import { htmlFor, installBrowserLocation } from '../_render';
+
+describe('AppShell Canvas navigation', () => {
+  test('links to the canvas registry with unified plugin metadata copy', () => {
+    const restore = installBrowserLocation('/canvas/plugins');
+    try {
+      const html = htmlFor(
+        <MemoryRouter initialEntries={['/canvas/plugins']}>
+          <AppShell error="" loading={false} menuCount={0} pluginCount={0} surfaceCount={0} updatedAt="never" onRefresh={() => {}}>
+            <p>child</p>
+          </AppShell>
+        </MemoryRouter>,
+      );
+      expect(html).toContain('aria-label="Canvas Plugins: Canvas metadata from /api/plugins?kind=canvas"');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/tests/frontend/pages/canvas-plugins-page.test.tsx
+++ b/tests/frontend/pages/canvas-plugins-page.test.tsx
@@ -12,6 +12,7 @@ describe('CanvasPluginsPage', () => {
     const html = htmlFor(<CanvasPluginsPage plugins={plugins} loading={false} standaloneHost="canvas.buildwithoracle.com" />);
 
     expect(html).toContain('Canvas plugin registry');
+    expect(html).toContain('/api/plugins?kind=canvas');
     expect(html).toContain('2 registered · 1 three · 1 react');
     expect(html).toContain('Wave');
     expect(html).toContain('Knowledge Map');


### PR DESCRIPTION
## Summary
- update Canvas Plugins page copy to use the unified `/api/plugins?kind=canvas` metadata endpoint
- align sidebar navigation description with unified canvas plugin metadata
- add frontend coverage for the canvas registry copy and nav aria label

## Tests
- bunx tsc --noEmit
- bun test tests/frontend/pages/canvas-plugins-page.test.tsx tests/frontend/components/app-shell-canvas-nav.test.tsx tests/frontend/api/canvas-plugins-standalone.test.ts tests/frontend/router.test.ts