### PR TITLE
feat: link unified plugin overview rows

### DIFF
--- a/frontend/src/pages/UnifiedPluginSurfaceOverview.tsx
+++ b/frontend/src/pages/UnifiedPluginSurfaceOverview.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { fetchMcpTools, fetchMenu, fetchSettingsSystem, fetchVectorConfig } from '../api';
 import { apiClient } from '../api/client';
 import { surfacesFor } from '../plugin-surfaces';
-import { pluginInventoryPath } from '../routePaths';
+import { mcpToolPath, pluginInventoryPath } from '../routePaths';
 import type { McpTool, MenuItem, PluginEntry, SettingsSystemResponse, VectorConfigResponse } from '../types';
 import type { HealthResponse } from '../../../src/server/types';
 
@@ -15,6 +15,7 @@ type SurfaceState = {
 };
 
 type Card = { label: string; value: string | number; detail: string; href: string; tone?: 'ok' | 'warn' };
+type SurfaceListItem = string | { label: string; href: string };
 
 function countBySurface(plugins: PluginEntry[]): Record<string, number> {
   const counts: Record<string, number> = {};
@@ -51,12 +52,31 @@ function buildCards(plugins: PluginEntry[], state: SurfaceState): Card[] {
 
 
 export function pluginCapabilityRows(plugins: PluginEntry[]): string[] {
+  return pluginCapabilityLinks(plugins).map((item) => item.label);
+}
+
+export function pluginCapabilityLinks(plugins: PluginEntry[]): Array<{ label: string; href: string }> {
   return plugins.flatMap((plugin) => [
-    ...(plugin.apiRoutes ?? []).map((route) => `${plugin.name} api ${route.methods?.join('|') ?? 'ALL'} ${route.path}`),
-    ...(plugin.mcpTools ?? []).map((tool) => `${plugin.name} mcp ${tool.name}${tool.readOnly ? ' read-only' : ''}`),
-    ...(plugin.cliSubcommands ?? []).map((command) => `${plugin.name} cli ${command.command}`),
-    ...(plugin.exportFormats ?? []).map((format) => `${plugin.name} export ${format.extension}`),
-    ...(plugin.proxy ?? []).map((proxy) => `${plugin.name} proxy ${proxy.path}`),
+    ...(plugin.apiRoutes ?? []).map((route) => ({
+      label: `${plugin.name} api ${route.methods?.join('|') ?? 'ALL'} ${route.path}`,
+      href: pluginInventoryPath({ q: route.path, surface: 'apiRoutes' }),
+    })),
+    ...(plugin.mcpTools ?? []).map((tool) => ({
+      label: `${plugin.name} mcp ${tool.name}${tool.readOnly ? ' read-only' : ''}`,
+      href: mcpToolPath(tool.name),
+    })),
+    ...(plugin.cliSubcommands ?? []).map((command) => ({
+      label: `${plugin.name} cli ${command.command}`,
+      href: pluginInventoryPath({ q: command.command, surface: 'cliSubcommands' }),
+    })),
+    ...(plugin.exportFormats ?? []).map((format) => ({
+      label: `${plugin.name} export ${format.extension}`,
+      href: pluginInventoryPath({ q: format.extension, surface: 'exportFormats' }),
+    })),
+    ...(plugin.proxy ?? []).map((proxy) => ({
+      label: `${plugin.name} proxy ${proxy.path}`,
+      href: pluginInventoryPath({ q: proxy.path, surface: 'proxy' }),
+    })),
   ]);
 }
 
@@ -68,6 +88,13 @@ export function pluginServerRows(plugins: PluginEntry[]): Array<{ name: string; 
       status: plugin.status ?? 'ok',
       health: plugin.server?.healthPath ?? plugin.proxy?.[0]?.path ?? 'proxy route',
     }));
+}
+
+export function pluginServerLinks(plugins: PluginEntry[]): Array<{ label: string; href: string }> {
+  return pluginServerRows(plugins).map((server) => ({
+    label: `${server.name} · ${server.status} · ${server.health}`,
+    href: pluginInventoryPath({ q: server.name, surface: 'server' }),
+  }));
 }
 
 export function UnifiedPluginSurfaceOverview({ plugins }: { plugins: PluginEntry[] }) {
@@ -95,8 +122,8 @@ export function UnifiedPluginSurfaceOverview({ plugins }: { plugins: PluginEntry
   const cards = useMemo(() => buildCards(plugins, state), [plugins, state]);
   const counts = useMemo(() => countBySurface(plugins), [plugins]);
   const countLinks = useMemo(() => surfaceCountLinks(counts), [counts]);
-  const servers = useMemo(() => pluginServerRows(plugins), [plugins]);
-  const capabilities = useMemo(() => pluginCapabilityRows(plugins), [plugins]);
+  const servers = useMemo(() => pluginServerLinks(plugins), [plugins]);
+  const capabilities = useMemo(() => pluginCapabilityLinks(plugins), [plugins]);
 
   return (
     <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="unified-surfaces-title">
@@ -115,9 +142,9 @@ export function UnifiedPluginSurfaceOverview({ plugins }: { plugins: PluginEntry
       {error ? <p className="mb-3 text-sm text-amber-200">{error}</p> : null}
       <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">{cards.map((card) => <SurfaceCard key={card.label} card={card} />)}</div>
       <div className="mt-4 grid gap-3 xl:grid-cols-5">
-        <SurfaceList title="Menu items" items={state.menu.slice(0, 5).map((item) => `${item.label} → ${item.path}`)} empty="No /api/menu items loaded yet." />
-        <SurfaceList title="MCP tools" items={state.tools.slice(0, 5).map((tool) => `${tool.name}${tool.plugin ? ` · ${tool.plugin}` : ''}`)} empty="No /api/mcp/tools entries loaded yet." />
-        <SurfaceList title="Plugin servers" items={servers.map((server) => `${server.name} · ${server.status} · ${server.health}`)} empty="No plugin server or proxy surfaces." />
+        <SurfaceList title="Menu items" items={state.menu.slice(0, 5).map((item) => ({ label: `${item.label} → ${item.path}`, href: item.path }))} empty="No /api/menu items loaded yet." />
+        <SurfaceList title="MCP tools" items={state.tools.slice(0, 5).map((tool) => ({ label: `${tool.name}${tool.plugin ? ` · ${tool.plugin}` : ''}`, href: mcpToolPath(tool.name) }))} empty="No /api/mcp/tools entries loaded yet." />
+        <SurfaceList title="Plugin servers" items={servers} empty="No plugin server or proxy surfaces." />
         <SurfaceList title="Capabilities" items={capabilities.slice(0, 6)} empty="No API, CLI, proxy, export, or MCP capabilities." />
         <SurfaceList title="Storage" items={[state.settings ? `${state.settings.storage.activeBackend} · ${formatPath(state.settings.storage.dbPath)}` : 'Storage config not loaded yet.']} empty="Storage config not loaded yet." />
       </div>
@@ -139,12 +166,20 @@ function SurfaceCard({ card }: { card: Card }) {
   );
 }
 
-function SurfaceList({ title, items, empty }: { title: string; items: string[]; empty: string }) {
+function SurfaceList({ title, items, empty }: { title: string; items: SurfaceListItem[]; empty: string }) {
   const visible = items.filter(Boolean);
   return (
     <article className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
       <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{title}</p>
-      {visible.length ? <ul className="mt-3 space-y-2 text-sm text-slate-300">{visible.map((item) => <li key={item} className="truncate font-mono">{item}</li>)}</ul> : <p className="mt-3 text-sm text-slate-500">{empty}</p>}
+      {visible.length ? (
+        <ul className="mt-3 space-y-2 text-sm text-slate-300">
+          {visible.map((item) => (
+            <li key={typeof item === 'string' ? item : `${item.href}:${item.label}`} className="truncate font-mono">
+              {typeof item === 'string' ? item : <a className="focus-ring text-teal-100 hover:text-teal-200" href={item.href}>{item.label}</a>}
+            </li>
+          ))}
+        </ul>
+      ) : <p className="mt-3 text-sm text-slate-500">{empty}</p>}
     </article>
   );
 }

--- a/tests/frontend/pages/unified-plugin-overview.test.tsx
+++ b/tests/frontend/pages/unified-plugin-overview.test.tsx
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'bun:test';
-import { UnifiedPluginSurfaceOverview, pluginCapabilityRows, pluginServerRows } from '../../../frontend/src/pages/UnifiedPluginSurfaceOverview';
+import {
+  UnifiedPluginSurfaceOverview,
+  pluginCapabilityLinks,
+  pluginCapabilityRows,
+  pluginServerLinks,
+  pluginServerRows,
+} from '../../../frontend/src/pages/UnifiedPluginSurfaceOverview';
 import { htmlFor } from '../_render';
 
 describe('UnifiedPluginSurfaceOverview', () => {
@@ -19,8 +25,13 @@ describe('UnifiedPluginSurfaceOverview', () => {
     }];
 
     expect(pluginServerRows(plugins)).toEqual([{ name: 'echo', status: 'ok', health: '/health' }]);
+    expect(pluginServerLinks(plugins)).toEqual([{ label: 'echo · ok · /health', href: '/plugins?q=echo&surface=server' }]);
     expect(pluginCapabilityRows(plugins)).toContain('echo api GET /api/plugins/echo/ping');
     expect(pluginCapabilityRows(plugins)).toContain('echo mcp echo_tool read-only');
+    expect(pluginCapabilityLinks(plugins)).toContainEqual({
+      label: 'echo mcp echo_tool read-only',
+      href: '/mcp/tools/echo_tool',
+    });
     const html = htmlFor(<UnifiedPluginSurfaceOverview plugins={plugins} />);
     expect(html).toContain('Menu items');
     expect(html).toContain('MCP tools');
@@ -37,5 +48,8 @@ describe('UnifiedPluginSurfaceOverview', () => {
     expect(html).toContain('href="/storage"');
     expect(html).toContain('href="/plugins?surface=mcp"');
     expect(html).toContain('href="/plugins?surface=server"');
+    expect(html).toContain('href="/plugins?q=echo&amp;surface=server"');
+    expect(html).toContain('href="/mcp/tools/echo_tool"');
+    expect(html).toContain('href="/plugins?q=%2Fapi%2Fplugins%2Fecho%2Fping&amp;surface=apiRoutes"');
   });
 });


### PR DESCRIPTION
Refs #1484

## Summary
- make unified plugin overview menu, MCP, server, and capability rows navigable
- route MCP capability rows to schema detail and other plugin capabilities to filtered inventory views
- keep row/link helper coverage for the overview surface map

## Verification
- git fetch origin && git rebase origin/alpha
- bunx tsc --noEmit
- bun test tests/frontend
- git diff --check
- wc -l frontend/src/pages/UnifiedPluginSurfaceOverview.tsx tests/frontend/pages/unified-plugin-overview.test.tsx