### PR TITLE
feat(canvas): derive plugin metadata from registry

### DIFF
--- a/src/canvas/__tests__/metadata.test.ts
+++ b/src/canvas/__tests__/metadata.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+
+import { listCanvasPlugins } from '../plugins.ts';
+import { CANVAS_PLUGIN_METADATA, listCanvasPluginMetadata } from '../metadata.ts';
+
+describe('canvas plugin metadata', () => {
+  test('derives plugin metadata from the canonical canvas registry', () => {
+    const pluginIds = listCanvasPlugins().map((plugin) => plugin.id);
+    const metadataIds = CANVAS_PLUGIN_METADATA.map((plugin) => plugin.id);
+    const apiIds = listCanvasPluginMetadata().plugins.map((plugin) => plugin.id);
+
+    expect(metadataIds).toEqual(pluginIds);
+    expect(apiIds).toEqual(pluginIds);
+  });
+
+  test('keeps standalone URLs and data APIs on generated metadata', () => {
+    const metadata = listCanvasPluginMetadata().plugins;
+
+    expect(metadata.find((plugin) => plugin.id === 'wave')).toMatchObject({ renderer: 'Three', standalonePath: '/?plugin=wave' });
+    expect(metadata.find((plugin) => plugin.id === 'map')).toMatchObject({ renderer: 'React', standalonePath: '/map', apiPath: '/api/map3d' });
+  });
+});

--- a/src/canvas/metadata.ts
+++ b/src/canvas/metadata.ts
@@ -1,4 +1,4 @@
-import type { CanvasPluginKind } from './plugin.ts';
+import { listCanvasPlugins, type CanvasPluginDescriptor, type CanvasPluginKind } from './plugins.ts';
 import { canvasPluginDataPath, canvasPluginPath } from './urls.ts';
 
 export type CanvasPluginRenderer = 'Three' | 'React';
@@ -13,79 +13,29 @@ export interface CanvasPluginMetadataEntry {
   apiPath?: string;
 }
 
-export const CANVAS_PLUGIN_METADATA: CanvasPluginMetadataEntry[] = [
-  {
-    id: 'cube',
-    label: 'Cube',
-    kind: 'three',
-    renderer: 'Three',
-    description: 'Bundled Three.js cube scene.',
-  },
-  {
-    id: 'galaxy',
-    label: 'Galaxy',
-    kind: 'three',
-    renderer: 'Three',
-    description: 'Bundled Three.js galaxy scene.',
-  },
-  {
-    id: 'torus',
-    label: 'Torus',
-    kind: 'three',
-    renderer: 'Three',
-    description: 'Bundled Three.js torus scene.',
-  },
-  {
-    id: 'graph3d',
-    label: 'Graph 3D',
-    kind: 'three',
-    renderer: 'Three',
-    description: 'Bundled Three.js graph scene.',
-  },
-  {
-    id: 'solar',
-    label: 'Solar',
-    kind: 'three',
-    renderer: 'Three',
-    description: 'Bundled Three.js solar scene.',
-  },
-  {
-    id: 'wave',
-    label: 'Wave',
-    kind: 'three',
-    renderer: 'Three',
-    description: 'Bundled Three.js wave scene.',
-  },
-  {
-    id: 'map3d',
-    label: 'Map 3D',
-    kind: 'three',
-    renderer: 'Three',
-    description: 'Bundled Three.js map scene.',
-  },
-  {
-    id: 'map',
-    label: 'Knowledge Map',
-    kind: 'react',
-    renderer: 'React',
-    description: 'React canvas plugin target for the knowledge map.',
-  },
-  {
-    id: 'planets',
-    label: 'Planets',
-    kind: 'react',
-    renderer: 'React',
-    description: 'React canvas plugin target for the planet/orbit view.',
-  },
-];
+function rendererFor(kind: CanvasPluginKind): CanvasPluginRenderer {
+  return kind === 'three' ? 'Three' : 'React';
+}
+
+function metadataFromPlugin(plugin: CanvasPluginDescriptor): CanvasPluginMetadataEntry {
+  return {
+    id: plugin.id,
+    label: plugin.label,
+    kind: plugin.kind,
+    renderer: rendererFor(plugin.kind),
+    description: plugin.description,
+  };
+}
+
+export const CANVAS_PLUGIN_METADATA: CanvasPluginMetadataEntry[] = listCanvasPlugins().map(metadataFromPlugin);
 
 export function listCanvasPluginMetadata(): { kind: 'canvas'; plugins: CanvasPluginMetadataEntry[] } {
   return {
     kind: 'canvas',
-    plugins: CANVAS_PLUGIN_METADATA.map((plugin) => ({
-      ...plugin,
+    plugins: listCanvasPlugins().map((plugin) => ({
+      ...metadataFromPlugin(plugin),
       standalonePath: canvasPluginPath(plugin.id),
-      apiPath: canvasPluginDataPath(plugin.id),
+      apiPath: canvasPluginDataPath(plugin.id) ?? ('apiPath' in plugin ? plugin.apiPath : undefined),
     })),
   };
 }

--- a/src/routes/plugins/__tests__/canvas-metadata.test.ts
+++ b/src/routes/plugins/__tests__/canvas-metadata.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { Elysia } from 'elysia';
 
+import { listCanvasPlugins } from '../../../canvas/plugins.ts';
 import { createPluginsRouter } from '../index.ts';
 
 describe('/api/plugins?kind=canvas', () => {
@@ -19,6 +20,7 @@ describe('/api/plugins?kind=canvas', () => {
     expect(response.status).toBe(200);
     expect(body.kind).toBe('canvas');
     expect(body.count).toBe(body.plugins.length);
+    expect(body.plugins.map((plugin) => plugin.id)).toEqual(listCanvasPlugins().map((plugin) => plugin.id));
     expect(body.standalone.host).toBe('canvas.buildwithoracle.com');
     expect(body.plugins).toContainEqual(expect.objectContaining({ id: 'wave', kind: 'three', renderer: 'Three' }));
     expect(body.plugins).toContainEqual(expect.objectContaining({ id: 'map', kind: 'react', renderer: 'React', standalonePath: '/map', apiPath: '/api/map3d' }));


### PR DESCRIPTION
## Summary
- derive `/api/plugins?kind=canvas` metadata from the canonical canvas plugin registry
- keep standalone paths and data API fields generated from shared URL helpers
- add coverage to prevent canvas metadata from drifting from bundled plugins

## Tests
- bunx tsc --noEmit
- bun test src/canvas/__tests__/metadata.test.ts src/routes/plugins/__tests__/canvas-metadata.test.ts tests/plugins/canvas-registry.test.ts tests/canvas/phase2.test.ts tests/http/canvas/full-flow.test.ts tests/workers/canvas-worker.test.ts