### PR TITLE
feat: link plugin surface badges

### DIFF
--- a/frontend/src/components/PluginList.tsx
+++ b/frontend/src/components/PluginList.tsx
@@ -1,4 +1,5 @@
 import { surfacesFor } from '../plugin-surfaces';
+import { pluginInventoryPath } from '../routePaths';
 import type { PluginEntry } from '../types';
 import { Badge } from './Badge';
 import { EmptyState } from './EmptyState';
@@ -26,6 +27,10 @@ export function pluginHealthLabel(plugin: PluginEntry, enabled: boolean): string
 
 export function togglePluginEnabled(state: PluginEnabledState, name: string): PluginEnabledState {
   return { ...state, [name]: !(state[name] ?? true) };
+}
+
+export function pluginSurfaceBadgePath(pluginName: string, surface: string): string {
+  return pluginInventoryPath({ q: pluginName, surface });
 }
 
 type SurfaceRow = { label: string; value: string };
@@ -94,8 +99,16 @@ export function PluginList({
                 <Badge>{status}</Badge>
                 <Badge>{health}</Badge>
                 {surfaces.length
-                  ? surfaces.map((surface) => <Badge key={surface}>{surface}</Badge>)
-                  : <Badge>metadata</Badge>}
+                  ? surfaces.map((surface) => (
+                    <a key={surface} className="focus-ring rounded-full" href={pluginSurfaceBadgePath(plugin.name, surface)}>
+                      <Badge>{surface}</Badge>
+                    </a>
+                  ))
+                  : (
+                    <a className="focus-ring rounded-full" href={pluginSurfaceBadgePath(plugin.name, 'metadata')}>
+                      <Badge>metadata</Badge>
+                    </a>
+                  )}
               </div>
             </div>
             <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-2">

--- a/tests/frontend/components/plugin-list-surfaces.test.tsx
+++ b/tests/frontend/components/plugin-list-surfaces.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { PluginList } from '../../../frontend/src/components/PluginList';
+import { PluginList, pluginSurfaceBadgePath } from '../../../frontend/src/components/PluginList';
 import { surfacesFor } from '../../../frontend/src/plugin-surfaces';
 import { htmlFor } from '../_render';
 
@@ -31,6 +31,8 @@ describe('PluginList surfaces', () => {
     expect(html).toContain('mcp');
     expect(html).toContain('apiRoutes');
     expect(html).toContain('proxy');
+    expect(html).toContain('href="/plugins?q=echo&amp;surface=apiRoutes"');
+    expect(html).toContain('href="/plugins?q=echo&amp;surface=mcp"');
     expect(html).toContain('bun echo.ts · /ready');
     expect(html).toContain('Surface details');
     expect(html).toContain('echo.say');
@@ -42,5 +44,10 @@ describe('PluginList surfaces', () => {
 
   test('normalizes backend mcpTools surface names for badges', () => {
     expect(surfacesFor({ name: 'echo', file: '', size: 0, modified: 'now', surfaces: ['mcpTools'] })).toEqual(['mcp']);
+  });
+
+  test('builds shareable inventory links for plugin surface badges', () => {
+    expect(pluginSurfaceBadgePath('echo tools', 'mcp')).toBe('/plugins?q=echo+tools&surface=mcp');
+    expect(pluginSurfaceBadgePath('metadata-only', 'metadata')).toBe('/plugins?q=metadata-only&surface=metadata');
   });
 });


### PR DESCRIPTION
Refs #1484

## Summary
- make plugin inventory surface badges link to shareable filtered inventory views
- include metadata-only plugins in the same surface badge linking flow
- add coverage for generated badge URLs and rendered plugin surface links

## Verification
- git fetch origin && git rebase origin/alpha
- bunx tsc --noEmit
- bun test tests/frontend
- git diff --check
- wc -l frontend/src/components/PluginList.tsx tests/frontend/components/plugin-list-surfaces.test.tsx