### PR TITLE
feat(canvas): align plugin API registry metadata

### DIFF
--- a/docs/http-api-reference.md
+++ b/docs/http-api-reference.md
@@ -126,8 +126,8 @@ Protected routes may require API token/session auth; tenant-aware routes honor `
 | GET | `/api/plugins` | `kind=canvas?` | Plugin registry entries or CanvasPlugin metadata. |
 | GET | `/api/plugins/:name` | `name` path. | Plugin details or file plugin details. |
 | PATCH | `/api/plugins/:name/state` | `{ enabled }` | Enable/disable state. |
-| GET | `/api/plugins/canvas` | `kind?` | Canvas plugin entries. |
-| GET | `/api/plugins/canvas/:id` | `id` path. | Canvas plugin detail. |
+| GET | `/api/plugins/canvas` | `kind?` | Canvas registry entries with standalone metadata. |
+| GET | `/api/plugins/canvas/:id` | `id` path. | Canvas registry detail with standalone metadata. |
 | GET | `/api/canvas/plugins` | `kind?` | Canvas registry entries. |
 | GET | `/api/canvas/plugins/:id` | `id` path. | Canvas registry detail. |
 | GET | `/api/canvas/registry` | `kind?` | Standalone canvas registry manifest. |

--- a/src/routes/plugins/canvas.ts
+++ b/src/routes/plugins/canvas.ts
@@ -1,28 +1,18 @@
 import { Elysia, t } from 'elysia';
-import { findCanvasPlugin, listCanvasPlugins, type CanvasPluginKind } from '../../canvas/plugins.ts';
-
-const kinds = new Set<CanvasPluginKind>(['three', 'react']);
-
-function parseKind(value: unknown): CanvasPluginKind | undefined {
-  return typeof value === 'string' && kinds.has(value as CanvasPluginKind) ? value as CanvasPluginKind : undefined;
-}
+import { canvasPluginEntry, canvasRegistry, parseCanvasKind } from '../../canvas/registry.ts';
 
 export const canvasPluginRegistryRoute = new Elysia()
-  .get('/api/plugins/canvas', ({ query }) => {
-    const kind = parseKind(query.kind);
-    const plugins = listCanvasPlugins(kind);
-    return { plugins, count: plugins.length, kind: kind ?? 'all' };
-  }, {
+  .get('/api/plugins/canvas', ({ query }) => canvasRegistry(parseCanvasKind(query.kind)), {
     query: t.Object({ kind: t.Optional(t.String()) }),
     detail: { tags: ['plugins'], summary: 'List bundled canvas plugins' },
   })
   .get('/api/plugins/canvas/:id', ({ params, set }) => {
-    const plugin = findCanvasPlugin(params.id);
-    if (!plugin) {
+    const entry = canvasPluginEntry(params.id);
+    if (!entry) {
       set.status = 404;
       return { error: 'canvas plugin not found', id: params.id };
     }
-    return { plugin };
+    return entry;
   }, {
     params: t.Object({ id: t.String({ minLength: 1 }) }),
     detail: { tags: ['plugins'], summary: 'Get one bundled canvas plugin' },

--- a/tests/plugins/canvas-registry.test.ts
+++ b/tests/plugins/canvas-registry.test.ts
@@ -18,12 +18,23 @@ describe('canvas plugin registry', () => {
     const app = new Elysia().use(createPluginsRouter());
     const response = await app.handle(new Request('http://local/api/plugins/canvas?kind=react'));
     expect(response.status).toBe(200);
-    const body = await response.json() as { count: number; plugins: Array<{ id: string; kind: string }> };
+    const body = await response.json() as { count: number; standalone: { host: string }; plugins: Array<{ id: string; kind: string; standalonePath: string }> };
     expect(body.count).toBe(2);
+    expect(body.standalone.host).toBe('canvas.buildwithoracle.com');
     expect(body.plugins).toEqual([
-      expect.objectContaining({ id: 'map', kind: 'react' }),
-      expect.objectContaining({ id: 'planets', kind: 'react' }),
+      expect.objectContaining({ id: 'map', kind: 'react', standalonePath: '/map' }),
+      expect.objectContaining({ id: 'planets', kind: 'react', standalonePath: '/planets' }),
     ]);
+  });
+
+
+  test('exposes standalone metadata through plugin detail route', async () => {
+    const app = new Elysia().use(createPluginsRouter());
+    const response = await app.handle(new Request('http://local/api/plugins/canvas/wave'));
+    const body = await response.json() as { plugin: { id: string; standalonePath: string } };
+
+    expect(response.status).toBe(200);
+    expect(body.plugin).toMatchObject({ id: 'wave', standalonePath: '/?plugin=wave' });
   });
 
   test('lists canvas plugins through CLI command', async () => {


### PR DESCRIPTION
## Summary
- make `/api/plugins/canvas` reuse the canonical canvas registry response
- return standalone metadata from `/api/plugins/canvas/:id` details
- update docs and tests for the plugin-route canvas registry contract

## Tests
- bunx tsc --noEmit
- bun test tests/plugins/canvas-registry.test.ts tests/canvas/phase2.test.ts tests/http/canvas/full-flow.test.ts tests/workers/canvas-worker.test.ts src/routes/plugins/__tests__/canvas-metadata.test.ts
- ORACLE_DATA_DIR=$(mktemp -d /tmp/arra-route-errors.XXXXXX) ORACLE_DB_PATH=$ORACLE_DATA_DIR/oracle.db bun test tests/http/errors/route-cluster-error-paths.test.ts