### PR TITLE
feat: link mcp tool plugins to inventory

### DIFF
--- a/frontend/src/pages/McpToolDetailPage.tsx
+++ b/frontend/src/pages/McpToolDetailPage.tsx
@@ -3,6 +3,7 @@ import { Link, useParams } from 'react-router-dom';
 import { fetchMcpTools } from '../api';
 import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
 import { groupLabel, schemaText, toolMode } from '../components/toolView';
+import { pluginInventoryPath } from '../routePaths';
 import type { McpTool } from '../types';
 
 type PageState = 'loading' | 'ready' | 'error';
@@ -13,11 +14,17 @@ export function toolDetailSource(tool: McpTool): string {
   return tool.source ?? 'core';
 }
 
-function DetailCard({ label, value }: { label: string; value?: string }) {
+export function toolPluginInventoryPath(tool: McpTool): string | null {
+  return tool.plugin ? pluginInventoryPath({ q: tool.plugin, surface: 'mcp' }) : null;
+}
+
+function DetailCard({ label, value, href }: { label: string; value?: string; href?: string | null }) {
   return (
     <div className="rounded-xl border border-white/10 bg-white/[0.03] p-3">
       <dt className="text-xs uppercase tracking-[0.18em] text-slate-500">{label}</dt>
-      <dd className="mt-1 break-all font-mono text-sm text-slate-200">{value || '—'}</dd>
+      <dd className="mt-1 break-all font-mono text-sm text-slate-200">
+        {href && value ? <a className="focus-ring text-teal-100 hover:text-teal-200" href={href}>{value}</a> : value || '—'}
+      </dd>
     </div>
   );
 }
@@ -32,7 +39,7 @@ function ToolSummaryCard({ tool }: { tool: McpTool }) {
         <DetailCard label="Group" value={groupLabel(tool)} />
         <DetailCard label="Mode" value={toolMode(tool)} />
         <DetailCard label="Source" value={toolDetailSource(tool)} />
-        <DetailCard label="Plugin" value={tool.plugin} />
+        <DetailCard label="Plugin" value={tool.plugin} href={toolPluginInventoryPath(tool)} />
       </dl>
     </section>
   );

--- a/tests/frontend/pages/mcp-tool-detail-source.test.tsx
+++ b/tests/frontend/pages/mcp-tool-detail-source.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { McpToolDetailPage, toolDetailSource } from '../../../frontend/src/pages/McpToolDetailPage';
+import { McpToolDetailPage, toolDetailSource, toolPluginInventoryPath } from '../../../frontend/src/pages/McpToolDetailPage';
 import type { McpTool } from '../../../frontend/src/types';
 import { htmlFor } from '../_render';
 
@@ -18,6 +18,8 @@ describe('McpToolDetailPage source labels', () => {
   test('normalizes plugin and core source labels', () => {
     expect(toolDetailSource(pluginTool)).toBe('plugin:echo');
     expect(toolDetailSource({ name: 'memory.write', description: '', source: 'core' })).toBe('core');
+    expect(toolPluginInventoryPath(pluginTool)).toBe('/plugins?q=echo&surface=mcp');
+    expect(toolPluginInventoryPath({ name: 'memory.write', description: '', source: 'core' })).toBeNull();
   });
 
   test('renders ready-state plugin source details from initial tools', () => {
@@ -30,6 +32,7 @@ describe('McpToolDetailPage source labels', () => {
     );
     expect(html).toContain('echo.say');
     expect(html).toContain('plugin:echo');
+    expect(html).toContain('href="/plugins?q=echo&amp;surface=mcp"');
     expect(html).toContain('Input schema');
   });
 });


### PR DESCRIPTION
Refs #1484

## Summary
- link plugin-owned MCP tool detail pages back to the filtered plugin inventory
- keep core tools unlinked while plugin tools point at the MCP surface filter
- add coverage for the generated plugin inventory URL and rendered detail link

## Verification
- git fetch origin && git rebase origin/alpha
- bunx tsc --noEmit
- bun test tests/frontend
- bun test tests/frontend/pages/mcp-tool-detail-source.test.tsx
- git diff --check
- wc -l frontend/src/pages/McpToolDetailPage.tsx tests/frontend/pages/mcp-tool-detail-source.test.tsx