### PR TITLE
feat(canvas): share standalone alias URL helpers

### DIFF
--- a/frontend/src/pages/CanvasAliasPage.tsx
+++ b/frontend/src/pages/CanvasAliasPage.tsx
@@ -1,22 +1,15 @@
 import { useEffect, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
+import { canvasStandaloneUrl } from '../routePaths';
 
-const CANVAS_HOST = 'https://canvas.buildwithoracle.com';
-const DEFAULT_PLUGIN = 'wave';
-
-function canvasPath(plugin: string): string {
-  const id = plugin.trim() || DEFAULT_PLUGIN;
-  return id === 'map' || id === 'planets' ? `/${id}` : `/?${new URLSearchParams({ plugin: id })}`;
-}
-
-export function canvasStandaloneUrl(search: string): string {
+function standaloneTarget(search: string): string {
   const params = new URLSearchParams(search);
-  return new URL(canvasPath(params.get('plugin') ?? DEFAULT_PLUGIN), CANVAS_HOST).toString();
+  return canvasStandaloneUrl(params.get('plugin') ?? undefined);
 }
 
 export function CanvasAliasPage() {
   const location = useLocation();
-  const target = useMemo(() => canvasStandaloneUrl(location.search), [location.search]);
+  const target = useMemo(() => standaloneTarget(location.search), [location.search]);
 
   useEffect(() => {
     if (import.meta.env.DEV) {

--- a/frontend/src/routePaths.ts
+++ b/frontend/src/routePaths.ts
@@ -69,9 +69,22 @@ export function vectorSettingsPath(): string {
   return '/vector/settings';
 }
 
+const CANVAS_STANDALONE_ORIGIN = 'https://canvas.buildwithoracle.com';
+const CLEAN_CANVAS_PLUGINS = new Set(['map', 'planets']);
+
 export function canvasAppPath(plugin = 'wave'): string {
   const id = plugin.trim();
   return id ? `/canvas?${new URLSearchParams({ plugin: id })}` : '/canvas';
+}
+
+export function canvasStandalonePath(plugin = 'wave'): string {
+  const id = plugin.trim() || 'wave';
+  if (CLEAN_CANVAS_PLUGINS.has(id)) return `/${id}`;
+  return `/?${new URLSearchParams({ plugin: id })}`;
+}
+
+export function canvasStandaloneUrl(plugin = 'wave', origin = CANVAS_STANDALONE_ORIGIN): string {
+  return new URL(canvasStandalonePath(plugin), origin).toString();
 }
 
 export function canvasPluginsPath(): string {

--- a/tests/frontend/router.test.ts
+++ b/tests/frontend/router.test.ts
@@ -61,6 +61,7 @@ describe('frontend router', () => {
     expect(htmlAt('/status')).toContain('GET /api/v1/health');
     expect(htmlAt('/canvas?plugin=map')).toContain('https://canvas.buildwithoracle.com/map');
     expect(htmlAt('/canvas?plugin=wave')).toContain('Studio canvas alias');
+    expect(htmlAt('/canvas?plugin=torus')).toContain('https://canvas.buildwithoracle.com/?plugin=torus');
     expect(htmlAt('/canvas/plugins')).toContain('Canvas plugin registry');
     expect(htmlAt('/metrics')).toContain('Metrics dashboard');
     expect(htmlAt('/metrics')).toContain('42');

--- a/tests/frontend/routes/canvas-app-path.test.ts
+++ b/tests/frontend/routes/canvas-app-path.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, test } from 'bun:test';
-import { canvasAppPath } from '../../../frontend/src/routePaths';
+import { canvasAppPath, canvasStandalonePath, canvasStandaloneUrl } from '../../../frontend/src/routePaths';
 
-describe('canvasAppPath', () => {
+describe('canvas route helpers', () => {
   test('preserves the Studio /canvas plugin query alias', () => {
     expect(canvasAppPath('wave')).toBe('/canvas?plugin=wave');
     expect(canvasAppPath('')).toBe('/canvas');
+  });
+
+  test('maps standalone canvas plugins to clean and query URLs', () => {
+    expect(canvasStandalonePath('map')).toBe('/map');
+    expect(canvasStandalonePath('planets')).toBe('/planets');
+    expect(canvasStandalonePath('wave')).toBe('/?plugin=wave');
+    expect(canvasStandaloneUrl('torus')).toBe('https://canvas.buildwithoracle.com/?plugin=torus');
   });
 });


### PR DESCRIPTION
## Summary
- move standalone canvas URL mapping into frontend route helpers
- keep Studio `/canvas?plugin=X` as the alias while mapping `map`/`planets` to clean canvas subdomain paths
- add route-helper and router coverage for clean React paths and Three query URLs

## Tests
- bunx tsc --noEmit
- bun test tests/frontend/routes/canvas-app-path.test.ts tests/frontend/router.test.ts tests/frontend/pages/canvas-plugins-page.test.tsx tests/frontend/api/canvas-plugins-standalone.test.ts

## Note
- Extra `bunx tsc -p frontend/tsconfig.json --noEmit` currently fails outside this slice in `frontend/src/pages/ExportApp.tsx:90` (`fetcher(...).catch` on `Response | Promise<Response)`).