### PR TITLE
feat(maw-plugin): add package build artifacts

### DIFF
--- a/maw-plugin/__tests__/build.test.ts
+++ b/maw-plugin/__tests__/build.test.ts
@@ -1,0 +1,29 @@
+import { afterAll, expect, test } from 'bun:test';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildPlugin } from '../scripts/build.ts';
+
+const tmp = mkdtempSync(join(tmpdir(), 'arra-maw-plugin-build-'));
+afterAll(() => rmSync(tmp, { recursive: true, force: true }));
+
+test('maw plugin build emits dist manifest, tgz, sha, and plugins.lock', async () => {
+  const result = await buildPlugin({ root: join(import.meta.dir, '..'), outDir: tmp });
+  const entry = join(tmp, 'index.js');
+  const manifest = JSON.parse(readFileSync(result.manifestPath, 'utf8')) as {
+    entry: string;
+    artifact: { path: string; sha256: string };
+  };
+  const lock = JSON.parse(readFileSync(result.lockPath, 'utf8')) as {
+    plugins: { arra: { version: string; package: string; artifact: { sha256: string }; pinned: boolean } };
+  };
+  const sha256 = createHash('sha256').update(readFileSync(entry)).digest('hex');
+
+  expect(manifest.entry).toBe('./index.js');
+  expect(manifest.artifact).toEqual({ path: './index.js', sha256 });
+  expect(result.sha256).toBe(sha256);
+  expect(existsSync(result.tgzPath)).toBe(true);
+  expect(lock.plugins.arra).toMatchObject({ version: '1.0.0', package: 'arra-1.0.0.tgz', pinned: true });
+  expect(lock.plugins.arra.artifact.sha256).toBe(sha256);
+});

--- a/maw-plugin/package.json
+++ b/maw-plugin/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "arra-maw-plugin",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "build": "bun scripts/build.ts"
+  },
+  "files": [
+    "README.md",
+    "plugin.json",
+    "index.ts",
+    "api.ts",
+    "local-cli.ts",
+    "serve.ts",
+    "vector-config.ts"
+  ]
+}

--- a/maw-plugin/scripts/build.ts
+++ b/maw-plugin/scripts/build.ts
@@ -1,0 +1,91 @@
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+type Artifact = { path: string; sha256: string };
+type Manifest = { name: string; version: string; entry: string; artifact?: Artifact; [key: string]: unknown };
+type BuildOptions = { root?: string; outDir?: string };
+type BuildResult = { outDir: string; manifestPath: string; lockPath: string; tgzPath: string; sha256: string };
+
+function arg(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+function readManifest(root: string): Manifest {
+  const path = join(root, 'plugin.json');
+  const manifest = JSON.parse(readFileSync(path, 'utf8')) as Partial<Manifest>;
+  if (!manifest.name || !manifest.version || !manifest.entry) {
+    throw new Error('plugin.json must include name, version, and entry');
+  }
+  return manifest as Manifest;
+}
+
+function sha256(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+function writeLock(outDir: string, manifest: Manifest, tgzName: string, artifact: Artifact): string {
+  const lock = {
+    version: 1,
+    plugins: {
+      [manifest.name]: {
+        version: manifest.version,
+        package: tgzName,
+        artifact,
+        pinned: true,
+      },
+    },
+  };
+  const lockPath = join(outDir, 'plugins.lock');
+  writeFileSync(lockPath, `${JSON.stringify(lock, null, 2)}\n`);
+  return lockPath;
+}
+
+function pack(outDir: string, manifest: Manifest): string {
+  const tgzName = `${manifest.name}-${manifest.version}.tgz`;
+  const tgzPath = join(outDir, tgzName);
+  const result = spawnSync('tar', ['-czf', tgzPath, '-C', outDir, 'index.js', 'plugin.json'], {
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) throw new Error(result.stderr || 'tar failed');
+  return tgzPath;
+}
+
+export async function buildPlugin(options: BuildOptions = {}): Promise<BuildResult> {
+  const root = resolve(options.root ?? process.cwd());
+  const outDir = resolve(options.outDir ?? join(root, 'dist'));
+  const manifest = readManifest(root);
+  const entry = resolve(root, manifest.entry);
+  if (!existsSync(entry)) throw new Error(`entry file not found: ${entry}`);
+
+  rmSync(outDir, { recursive: true, force: true });
+  mkdirSync(outDir, { recursive: true });
+  const build = await Bun.build({
+    entrypoints: [entry],
+    outdir: outDir,
+    target: 'bun',
+    format: 'esm',
+    minify: true,
+    naming: 'index.js',
+  });
+  if (!build.success) throw new Error(build.logs.map(log => log.message).join('\n') || 'Bun.build failed');
+
+  const artifact = { path: './index.js', sha256: sha256(join(outDir, 'index.js')) };
+  const distManifest = { ...manifest, entry: './index.js', artifact };
+  const manifestPath = join(outDir, 'plugin.json');
+  writeFileSync(manifestPath, `${JSON.stringify(distManifest, null, 2)}\n`);
+  const tgzPath = pack(outDir, manifest);
+  const lockPath = writeLock(outDir, manifest, tgzPath.split('/').at(-1)!, artifact);
+  return { outDir, manifestPath, lockPath, tgzPath, sha256: artifact.sha256 };
+}
+
+if (import.meta.main) {
+  buildPlugin({ root: arg('--root'), outDir: arg('--out') })
+    .then(result => console.log(JSON.stringify(result, null, 2)))
+    .catch(error => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary
- add a package-local build script for the installable maw arra plugin
- emit dist/index.js, dist/plugin.json with SHA-256 artifact metadata, a tgz, and plugins.lock
- cover the build output with a scoped regression test

## Validation
- bun test maw-plugin/__tests__/
- bunx tsc --noEmit
- git diff --check origin/alpha...HEAD
- wc -l maw-plugin/scripts/build.ts maw-plugin/package.json maw-plugin/__tests__/build.test.ts