### PR TITLE
fix(canvas): preserve proxied API request bodies

### DIFF
--- a/src/workers/canvas/index.ts
+++ b/src/workers/canvas/index.ts
@@ -45,7 +45,11 @@ async function proxyApi(request: Request, env: CanvasWorkerEnv): Promise<Respons
   const headers = new Headers(request.headers);
   headers.set('x-oracle-canvas-worker', 'canvas.buildwithoracle.com');
   headers.delete('host');
-  const upstream = await fetch(proxyTarget(request, env), { ...request, headers });
+  const upstream = await fetch(proxyTarget(request, env), {
+    method: request.method,
+    headers,
+    body: request.method === 'GET' || request.method === 'HEAD' ? undefined : request.body,
+  });
   const responseHeaders = new Headers(upstream.headers);
   for (const [key, value] of Object.entries(API_CACHE_HEADERS)) responseHeaders.set(key, value);
   return new Response(upstream.body, { status: upstream.status, statusText: upstream.statusText, headers: responseHeaders });

--- a/tests/workers/canvas-worker.test.ts
+++ b/tests/workers/canvas-worker.test.ts
@@ -124,4 +124,36 @@ describe('canvas Cloudflare Worker', () => {
     expect(response.headers.get('cache-control')).toBe('no-store');
     expect(await response.json()).toEqual({ ok: true });
   });
+
+  test('preserves proxied api method, body, and content headers', async () => {
+    const seen: Array<{ url: string; method: string; contentType: string | null; body: string }> = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const upstream = new Request(input, init);
+      seen.push({
+        url: String(input),
+        method: upstream.method,
+        contentType: upstream.headers.get('content-type'),
+        body: await upstream.text(),
+      });
+      return Response.json({ ok: true });
+    }) as typeof fetch;
+
+    const response = await handleCanvasRequest(
+      new Request('https://canvas.buildwithoracle.com/api/canvas-state?plugin=map', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ selected: 'map' }),
+      }),
+      { ORACLE_API_BASE: 'https://oracle.example.test' },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(seen).toEqual([{
+      url: 'https://oracle.example.test/api/canvas-state?plugin=map',
+      method: 'POST',
+      contentType: 'application/json',
+      body: '{"selected":"map"}',
+    }]);
+  });
 });


### PR DESCRIPTION
## Summary
- Preserve method, body, and content headers when the canvas subdomain worker proxies non-registry /api/* requests to the Oracle backend.
- Keep canvas worker registry and health routes local while maintaining no-store proxy cache headers.
- Add worker coverage for POST proxy forwarding.

## Validation
- ✅ bunx tsc --noEmit
- ✅ bun test tests/workers/canvas-worker.test.ts tests/http/canvas-worker.test.ts tests/http/canvas/ tests/canvas/ tests/plugins/canvas-registry.test.ts
- ✅ git diff --check
- ✅ wc -l src/workers/canvas/index.ts tests/workers/canvas-worker.test.ts (both <=250)

Refs #950.