### PR TITLE
feat: add maw arra command registry

### DIFF
--- a/maw-plugin/__tests__/dual-surface.test.ts
+++ b/maw-plugin/__tests__/dual-surface.test.ts
@@ -20,6 +20,17 @@ describe('maw arra dual-surface registry', () => {
     expect(body.commands.map(command => command.name)).toEqual(listSubcommands());
     expect(body.commands).toContainEqual(expect.objectContaining({ name: 'search', help: expect.stringContaining('search <q>') }));
     expect(body.commands).toContainEqual(expect.objectContaining({ name: 'serve', help: expect.stringContaining('serve') }));
+    expect(body.commands).toContainEqual(expect.objectContaining({ name: 'commands' }));
+  });
+
+  test('commands subcommand returns the registry for CLI callers', async () => {
+    const result = await handler({ source: 'cli', args: ['commands'] });
+    const body = JSON.parse(result.output ?? '{}') as Registry;
+
+    expect(result.ok).toBe(true);
+    expect(body.surface).toBe('cli');
+    expect(body.commands.map(command => command.name)).toEqual(listSubcommands());
+    expect(body.commands).toContainEqual(expect.objectContaining({ name: 'commands' }));
   });
 
   test('empty CLI invoke still renders CLI usage for maw arra --help parity', async () => {

--- a/maw-plugin/index.ts
+++ b/maw-plugin/index.ts
@@ -176,7 +176,7 @@ export const COMMANDS: Record<string, Spec> = {
   verify: { tool: 'oracle_verify', method: 'POST', write: true, help: 'verify [--check true|false] [--type all|learning|pattern]', build: p => route('/api/verify', undefined, { check: b(p, 'check'), type: f(p, 'type') }), format: d => `arra verify: ${preview(d, 500)}` },
 };
 
-const LOCAL_COMMANDS = { frontend: 'frontend [--no-open]', ui: 'ui [--no-open]', open: 'open [--no-open]', serve: 'serve [--stop|--status] [--port N]', server: 'server [start|stop|status]', studio: 'studio [--port N]', ...LOCAL_CLI_HELP } as const;
+const LOCAL_COMMANDS = { commands: 'commands', frontend: 'frontend [--no-open]', ui: 'ui [--no-open]', open: 'open [--no-open]', serve: 'serve [--stop|--status] [--port N]', server: 'server [start|stop|status]', studio: 'studio [--port N]', ...LOCAL_CLI_HELP } as const;
 function usage(): InvokeResult {
   const commandNames = [...Object.keys(COMMANDS), ...Object.keys(LOCAL_COMMANDS)].sort();
   return { ok: false, error: 'usage', output: ['usage: maw arra <subcommand> [args]', `subcommands: ${commandNames.join('|')}`, '', ...Object.entries(LOCAL_COMMANDS).sort().map(([name, help]) => `  ${name}  ${help}`), ...Object.entries(COMMANDS).sort().map(([name, spec]) => `  ${name}  ${spec.help}`)].join('\n') };
@@ -215,6 +215,7 @@ export async function runArra(args: string[], request: Requester = requestJson, 
   const sub = key(args[0] || '');
   if (!sub || sub === 'help' || sub === '--help' || sub === '-h') return usage();
   const parsed = parse(args.slice(1));
+  if (sub === 'commands') return registryPayload('cli');
   if (sub === 'frontend' || sub === 'ui' || sub === 'open') return runFrontend(parsed, opener, env);
   if (sub === 'studio') return runStudio(parsed, runner, env);
   if (sub === 'serve' || sub === 'server') return runServe(parsed, runner, env, serveDeps);

--- a/maw-plugin/plugin.json
+++ b/maw-plugin/plugin.json
@@ -9,7 +9,7 @@
     "aliases": [
       "or"
     ],
-    "help": "maw arra <backup|canvas-plugins|canvas-serve|changelog|completions|config|doctor|export|export-obsidian|huginn|import|import-obsidian|migrate|peers|plugin|release|seed|session|use|vault|frontend|ui|open|serve|server|studio|search|learn|stats|health|index|scan|plugins|settings|feed|menu|vector|vector-config|vector_index|vector_status|vector_stop|vector_models|trace|trace_list|trace_get|trace_link|trace_unlink|trace_chain|concepts|handoff|inbox|list|read|reflect|supersede|supersede_list|supersede_chain|thread|thread_read|thread_update|threads|schedule|schedule_add|vault_sync|mcp_tools|verify>"
+    "help": "maw arra <commands|backup|canvas-plugins|canvas-serve|changelog|completions|config|doctor|export|export-obsidian|huginn|import|import-obsidian|migrate|peers|plugin|release|seed|session|use|vault|frontend|ui|open|serve|server|studio|search|learn|stats|health|index|scan|plugins|settings|feed|menu|vector|vector-config|vector_index|vector_status|vector_stop|vector_models|trace|trace_list|trace_get|trace_link|trace_unlink|trace_chain|concepts|handoff|inbox|list|read|reflect|supersede|supersede_list|supersede_chain|thread|thread_read|thread_update|threads|schedule|schedule_add|vault_sync|mcp_tools|verify>"
   },
   "capabilities": [
     "net:http",
@@ -18,7 +18,7 @@
   ],
   "weight": 50,
   "schemaVersion": 1,
-  "help": "maw arra <backup|canvas-plugins|canvas-serve|changelog|completions|config|doctor|export|export-obsidian|huginn|import|import-obsidian|migrate|peers|plugin|release|seed|session|use|vault|frontend|ui|open|serve|server|studio|search|learn|stats|health|index|scan|plugins|settings|feed|menu|vector|vector-config|vector_index|vector_status|vector_stop|vector_models|trace|trace_list|trace_get|trace_link|trace_unlink|trace_chain|concepts|handoff|inbox|list|read|reflect|supersede|supersede_list|supersede_chain|thread|thread_read|thread_update|threads|schedule|schedule_add|vault_sync|mcp_tools|verify>",
+  "help": "maw arra <commands|backup|canvas-plugins|canvas-serve|changelog|completions|config|doctor|export|export-obsidian|huginn|import|import-obsidian|migrate|peers|plugin|release|seed|session|use|vault|frontend|ui|open|serve|server|studio|search|learn|stats|health|index|scan|plugins|settings|feed|menu|vector|vector-config|vector_index|vector_status|vector_stop|vector_models|trace|trace_list|trace_get|trace_link|trace_unlink|trace_chain|concepts|handoff|inbox|list|read|reflect|supersede|supersede_list|supersede_chain|thread|thread_read|thread_update|threads|schedule|schedule_add|vault_sync|mcp_tools|verify>",
   "api": {
     "path": "/api/arra",
     "methods": [
@@ -73,6 +73,6 @@
   ],
   "artifact": {
     "path": "./index.ts",
-    "sha256": "980cf804f039423f3bf24ccc345b6f3273c6d4e4497ca64dfb8dcb042b5100f0"
+    "sha256": "917531bf76cc16ef6949f96158db491fc9e053d5715b2169777ec92ba127063f"
   }
 }

--- a/tests/tools/maw-plugin-arra/dual-surface.test.ts
+++ b/tests/tools/maw-plugin-arra/dual-surface.test.ts
@@ -6,7 +6,9 @@ describe('maw-plugin-arra dual surface contract', () => {
   test('declares modern CLI, API, and menu surfaces in one manifest', () => {
     expect(manifest).toMatchObject({
       name: 'arra',
+      target: 'js',
       entry: './index.ts',
+      artifact: { path: 'dist/index.js', sha256: null },
       cli: { command: 'arra' },
       api: { path: '/api/plugins/arra', methods: ['GET', 'POST'] },
     });
@@ -22,6 +24,7 @@ describe('maw-plugin-arra dual surface contract', () => {
     expect(body.api.path).toBe('/api/plugins/arra');
     expect(body.commands.map((item: { name: string }) => item.name))
       .toEqual(commandRegistry.map((item) => item.name));
+    expect(body.commands.map((item: { name: string }) => item.name)).toContain('commands');
     expect(body.commands.every((item: { surfaces: string[] }) => item.surfaces.includes('cli') && item.surfaces.includes('menu'))).toBe(true);
   });
 
@@ -33,5 +36,20 @@ describe('maw-plugin-arra dual surface contract', () => {
     expect(body.command).toBe('help');
     expect(body.output).toContain('maw arra');
     expect(body.output).toContain('vector-config');
+  });
+  test('runs the explicit command registry from CLI text and JSON', async () => {
+    const text = await handler({ args: ['commands'] });
+
+    expect(text.ok).toBe(true);
+    expect(text.output).toContain('shared by CLI/API/menu');
+    expect(text.output).toContain('vector-config');
+
+    const raw = await handler({ args: ['commands', '--json'] });
+    const body = JSON.parse(raw.output ?? '{}');
+
+    expect(raw.ok).toBe(true);
+    expect(body.source).toBe('cli');
+    expect(body.commands.map((item: { name: string }) => item.name))
+      .toEqual(commandRegistry.map((item) => item.name));
   });
 });

--- a/tools/maw-plugin-arra/index.ts
+++ b/tools/maw-plugin-arra/index.ts
@@ -20,6 +20,7 @@ type RegistryCommand = {
 const surfaces = ['cli', 'api', 'menu'] as const;
 
 const commandHandlers: Record<string, CommandHandler> = {
+  commands: runCommandsCommand,
   export: runExportCommand,
   status: () => runStatusCommand(),
   'vector-config': runVectorConfigCommand,
@@ -27,6 +28,7 @@ const commandHandlers: Record<string, CommandHandler> = {
 };
 
 export const commandRegistry: RegistryCommand[] = [
+  { name: 'commands', help: 'list the shared CLI/API/menu command registry', surfaces: [...surfaces] },
   { name: 'status', help: 'show vector collections, doc counts, and health', surfaces: [...surfaces] },
   { name: 'export', help: 'export app collections as json, csv, md, or jsonl', surfaces: [...surfaces] },
   { name: 'vector-config', help: VECTOR_CONFIG_HELP, surfaces: [...surfaces] },
@@ -73,6 +75,17 @@ function help(): string {
   ].join('\n');
 }
 
+function wantsJson(args: string[]): boolean {
+  return args.includes('--json');
+}
+
+function registryText(): string {
+  return [
+    'arra command registry (shared by CLI/API/menu):',
+    ...commandRegistry.map((item) => `  ${item.name.padEnd(14)} ${item.help}`),
+  ].join('\n');
+}
+
 function registryPayload(source: string) {
   return {
     plugin: 'arra',
@@ -90,6 +103,12 @@ function isApiLike(source?: string): boolean {
 
 function apiOutput(command: string, output: string): string {
   return JSON.stringify({ ok: true, command, output }, null, 2);
+}
+
+async function runCommandsCommand(args: string[]): Promise<string> {
+  return wantsJson(args)
+    ? JSON.stringify(registryPayload('cli'), null, 2)
+    : registryText();
 }
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {

--- a/tools/maw-plugin-arra/plugin.json
+++ b/tools/maw-plugin-arra/plugin.json
@@ -1,7 +1,12 @@
 {
   "name": "arra",
   "version": "0.1.0",
+  "target": "js",
   "entry": "./index.ts",
+  "artifact": {
+    "path": "dist/index.js",
+    "sha256": null
+  },
   "sdk": "^1.0.0",
   "description": "ARRA Oracle CLI bridge for vector export, status, and vector config commands.",
   "author": "Soul-Brews-Studio",
@@ -19,7 +24,7 @@
   ],
   "cli": {
     "command": "arra",
-    "help": "maw arra <status|export --collection X --format json|csv|md|vector-config list|get|set|add|remove|set-primary|reload|test>"
+    "help": "maw arra <commands|status|export --collection X --format json|csv|md|vector-config list|get|set|add|remove|set-primary|reload|test>"
   },
   "weight": 10,
   "license": "BUSL-1.1",


### PR DESCRIPTION
## Summary
- add explicit `maw arra commands` registry subcommand for shared CLI/API/menu command discovery
- declare modern JS plugin target/artifact metadata in the ARRA maw plugin manifest
- extend dual-surface tests for registry metadata and CLI JSON output

## Validation
- bun test tests/tools/maw-plugin-arra/
- bunx tsc --noEmit -p tools/maw-plugin-arra/tsconfig.json
- bunx tsc --noEmit
- git diff --check
- changed files <=250 lines

Refs #1467