### PR TITLE
feat(vector): control provider detection cache

### DIFF
--- a/src/routes/vector/providers.ts
+++ b/src/routes/vector/providers.ts
@@ -22,7 +22,11 @@ export function createVectorProvidersEndpoint(options: VectorProvidersEndpointOp
   const api = createEmbeddingProviderApi(options);
 
   return new Elysia()
-    .get('/vector/providers', async () => api.detect({ force: true }), {
+    .get('/vector/providers', async ({ query }) => api.detect({ force: shouldForceRefresh(query) }), {
+      query: t.Object({
+        cached: t.Optional(t.String()),
+        force: t.Optional(t.String()),
+      }),
       detail: { tags: ['vector'], summary: 'Detected embedding providers and capabilities' },
     })
     .post('/vector/providers/test', async ({ body, set }) => {
@@ -42,3 +46,17 @@ export function createVectorProvidersEndpoint(options: VectorProvidersEndpointOp
 }
 
 export const vectorProvidersEndpoint = createVectorProvidersEndpoint();
+
+
+function shouldForceRefresh(query: { cached?: string; force?: string }): boolean {
+  if (query.force !== undefined) return parseBool(query.force, true);
+  if (query.cached !== undefined) return !parseBool(query.cached, false);
+  return true;
+}
+
+function parseBool(value: string, fallback: boolean): boolean {
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'y'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'n'].includes(normalized)) return false;
+  return fallback;
+}

--- a/tests/http/vector/providers.test.ts
+++ b/tests/http/vector/providers.test.ts
@@ -2,6 +2,7 @@ import { expect, mock, test } from 'bun:test';
 import { Elysia } from 'elysia';
 import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
 import { createVectorProvidersEndpoint } from '../../../src/routes/vector/providers.ts';
+import { clearProviderDetectionCache } from '../../../src/vector/provider-detection.ts';
 import type { EmbeddingProvider } from '../../../src/vector/types.ts';
 
 function fetcher() {
@@ -66,6 +67,26 @@ test('GET /api/v1/vector/providers reports missing env and failed Ollama probe',
   expect(body.providers).toContainEqual(expect.objectContaining({ type: 'openai', available: false }));
   expect(body.providers).toContainEqual(expect.objectContaining({ type: 'gemini', available: false }));
   expect(body.providers).toContainEqual(expect.objectContaining({ type: 'cloudflare-ai', available: false }));
+});
+
+
+
+test('GET /api/v1/vector/providers can use warmed cache without re-probing', async () => {
+  clearProviderDetectionCache();
+  let n = 0;
+  const tags = mock(async () => Response.json({ models: [{ name: `cached-${++n}` }] })) as unknown as typeof fetch;
+  const app = new Elysia({ prefix: '/api' }).use(createVectorProvidersEndpoint({ env: {}, fetcher: tags }));
+  const fetch = createApiVersionedFetch((request) => app.handle(request));
+
+  const cachedOne = await (await fetch(new Request('http://local/api/v1/vector/providers?cached=true'))).json() as { providers: Array<{ models?: string[] }> };
+  const cachedTwo = await (await fetch(new Request('http://local/api/v1/vector/providers?force=false'))).json() as { providers: Array<{ models?: string[] }> };
+  const refreshed = await (await fetch(new Request('http://local/api/v1/vector/providers'))).json() as { providers: Array<{ models?: string[] }> };
+
+  expect(cachedOne.providers[0].models).toEqual(['cached-1']);
+  expect(cachedTwo.providers[0].models).toEqual(['cached-1']);
+  expect(refreshed.providers[0].models).toEqual(['cached-2']);
+  expect(tags).toHaveBeenCalledTimes(2);
+  clearProviderDetectionCache();
 });
 
 test('POST /api/v1/vector/providers/test probes one provider config', async () => {


### PR DESCRIPTION
## Summary
- Add provider detection cache controls to /api/v1/vector/providers.
- Preserve default force re-probe behavior while supporting ?cached=true and ?force=false for warmed startup cache reads.
- Cover cached vs forced provider auto-detect behavior in HTTP tests.

## Validation
- bunx tsc --noEmit
- bun test tests/http/vector/providers.test.ts tests/vector/provider-detection.test.ts tests/http/vector/
- git diff --check
- file sizes <=250 lines
