### PR TITLE
fix(vector): pass fallback config through provider test

### DIFF
--- a/src/routes/vector/providers.ts
+++ b/src/routes/vector/providers.ts
@@ -36,6 +36,8 @@ export function createVectorProvidersEndpoint(options: VectorProvidersEndpointOp
         url: t.Optional(t.String()),
         dimensions: t.Optional(t.Number()),
         text: t.Optional(t.String()),
+        fallback: t.Optional(providerSchema),
+        fallbackChain: t.Optional(t.Array(providerSchema)),
       }),
       detail: { tags: ['vector'], summary: 'Test one embedding provider configuration' },
     });

--- a/src/vector/provider-api.ts
+++ b/src/vector/provider-api.ts
@@ -1,4 +1,7 @@
-import { createEmbeddingProvider as defaultCreateProvider } from './embeddings.ts';
+import {
+  createEmbeddingProvider as defaultCreateProvider,
+  type EmbeddingProviderOptions,
+} from './embeddings.ts';
 import {
   clearProviderDetectionCache,
   getDetectedEmbeddingProviders,
@@ -13,8 +16,13 @@ export type ProviderStatus = 'available' | 'unavailable';
 export type CreateEmbeddingProvider = (
   type?: EmbeddingProviderType,
   model?: string,
-  options?: { url?: string; dimensions?: number },
+  options?: ProviderCreateOptions,
 ) => EmbeddingProvider;
+
+export type ProviderCreateOptions = Pick<
+  EmbeddingProviderOptions,
+  'url' | 'dimensions' | 'fallback' | 'fallbackChain'
+>;
 
 export interface ProviderApiOptions extends ProviderDetectionOptions {
   createProvider?: CreateEmbeddingProvider;
@@ -35,11 +43,9 @@ export interface ProviderListResult {
   providers: ProviderInfo[];
 }
 
-export interface ProviderTestRequest {
+export interface ProviderTestRequest extends ProviderCreateOptions {
   provider: EmbeddingProviderType;
   model?: string;
-  url?: string;
-  dimensions?: number;
   text?: string;
 }
 
@@ -71,6 +77,8 @@ export function createEmbeddingProviderApi(defaults: ProviderApiOptions = {}): E
       return createProvider(request.provider, request.model, {
         url: request.url,
         dimensions: request.dimensions,
+        fallback: request.fallback,
+        fallbackChain: request.fallbackChain,
       });
     },
 

--- a/tests/http/vector/providers.test.ts
+++ b/tests/http/vector/providers.test.ts
@@ -80,6 +80,48 @@ test('POST /api/v1/vector/providers/test probes one provider config', async () =
   expect(body).toMatchObject({ success: true, provider: 'gemini', dimensions: 3 });
 });
 
+test('POST /api/v1/vector/providers/test forwards fallback chain config', async () => {
+  const seen: unknown[] = [];
+  const app = new Elysia({ prefix: '/api' }).use(createVectorProvidersEndpoint({
+    createProvider: (provider, model, options): EmbeddingProvider => {
+      seen.push({ provider, model, options });
+      return {
+        name: provider,
+        dimensions: 5,
+        embed: mock(async () => [[1, 2, 3, 4, 5]]),
+      };
+    },
+  }));
+
+  const res = await createApiVersionedFetch((request) => app.handle(request))(
+    new Request('http://local/api/v1/vector/providers/test', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        provider: 'ollama',
+        model: 'bge-m3',
+        fallback: 'openai',
+        fallbackChain: ['gemini'],
+        text: 'hello',
+      }),
+    }),
+  );
+  const body = await res.json() as Record<string, unknown>;
+
+  expect(res.status).toBe(200);
+  expect(body).toMatchObject({ success: true, provider: 'ollama', dimensions: 5, model: 'bge-m3' });
+  expect(seen[0]).toEqual({
+    provider: 'ollama',
+    model: 'bge-m3',
+    options: {
+      url: undefined,
+      dimensions: undefined,
+      fallback: 'openai',
+      fallbackChain: ['gemini'],
+    },
+  });
+});
+
 test('POST /api/v1/vector/providers/test returns 503 when provider probe fails', async () => {
   const app = new Elysia({ prefix: '/api' }).use(createVectorProvidersEndpoint({
     createProvider: (provider): EmbeddingProvider => ({


### PR DESCRIPTION
## Summary\n- extend the vector provider test API request/schema to accept fallback and fallbackChain\n- pass fallback config through to createEmbeddingProvider so provider probes can exercise the configured chain\n- add HTTP coverage for forwarding fallback-chain config\n\n## Validation\n- bunx tsc --noEmit\n- bun test tests/http/vector/\n- bun test src/vector/__tests__/\n- files <=250 lines