### PR TITLE
feat(maw-plugin): add canonical build package

### DIFF
--- a/tests/tools/maw-plugin-arra/build.test.ts
+++ b/tests/tools/maw-plugin-arra/build.test.ts
@@ -1,0 +1,40 @@
+import { afterAll, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { buildPlugin } from '../../../tools/maw-plugin-arra/scripts/build.ts';
+
+const tmp = mkdtempSync(join(tmpdir(), 'maw-plugin-arra-build-'));
+afterAll(() => rmSync(tmp, { recursive: true, force: true }));
+
+test('build emits an installable tgz, pinned lock, and runnable bundled handler', async () => {
+  const result = await buildPlugin({ root: join(import.meta.dir, '../../../tools/maw-plugin-arra'), outDir: tmp });
+  const entryPath = join(tmp, 'index.js');
+  const manifest = JSON.parse(readFileSync(result.manifestPath, 'utf8')) as {
+    entry: string;
+    artifact: { path: string; sha256: string };
+  };
+  const lock = JSON.parse(readFileSync(result.lockPath, 'utf8')) as {
+    plugins: { arra: { version: string; package: string; pinned: boolean; artifact: { sha256: string } } };
+  };
+  const sha256 = createHash('sha256').update(readFileSync(entryPath)).digest('hex');
+  const tar = spawnSync('tar', ['-tzf', result.tgzPath], { encoding: 'utf8' });
+  const built = await import(`${pathToFileURL(entryPath).href}?${Date.now()}`) as {
+    default: (ctx: { source?: string; args?: string[] }) => Promise<{ ok: boolean; output?: string }>;
+  };
+  const help = await built.default({ source: 'cli', args: ['help'] });
+
+  expect(manifest.entry).toBe('./index.js');
+  expect(manifest.artifact).toEqual({ path: './index.js', sha256 });
+  expect(result.sha256).toBe(sha256);
+  expect(existsSync(result.tgzPath)).toBe(true);
+  expect(tar.status).toBe(0);
+  expect(tar.stdout.trim().split('\n').sort()).toEqual(['index.js', 'plugin.json']);
+  expect(lock.plugins.arra).toMatchObject({ version: '0.1.0', package: 'arra-0.1.0.tgz', pinned: true });
+  expect(lock.plugins.arra.artifact.sha256).toBe(sha256);
+  expect(help.ok).toBe(true);
+  expect(help.output).toContain('maw arra');
+});

--- a/tools/maw-plugin-arra/package.json
+++ b/tools/maw-plugin-arra/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "arra-maw-plugin",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "build": "bun scripts/build.ts",
+    "typecheck": "bunx tsc --noEmit -p tsconfig.json",
+    "test": "bun test ../../tests/tools/maw-plugin-arra/"
+  },
+  "files": [
+    "commands",
+    "index.ts",
+    "plugin.json",
+    "scripts/build.ts",
+    "tsconfig.json"
+  ]
+}

--- a/tools/maw-plugin-arra/scripts/build.ts
+++ b/tools/maw-plugin-arra/scripts/build.ts
@@ -1,0 +1,82 @@
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+type Artifact = { path: string; sha256: string };
+type Manifest = { name: string; version: string; entry: string; [key: string]: unknown };
+type BuildOptions = { root?: string; outDir?: string };
+type BuildResult = { outDir: string; manifestPath: string; lockPath: string; tgzPath: string; sha256: string };
+
+function option(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+function readManifest(root: string): Manifest {
+  const manifestPath = join(root, 'plugin.json');
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as Partial<Manifest>;
+  if (!manifest.name || !manifest.version || !manifest.entry) {
+    throw new Error('plugin.json must include name, version, and entry');
+  }
+  return manifest as Manifest;
+}
+
+function sha256(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+function writeLock(outDir: string, manifest: Manifest, tgzName: string, artifact: Artifact): string {
+  const lockPath = join(outDir, 'plugins.lock');
+  const lock = {
+    version: 1,
+    plugins: {
+      [manifest.name]: { version: manifest.version, package: tgzName, artifact, pinned: true },
+    },
+  };
+  writeFileSync(lockPath, `${JSON.stringify(lock, null, 2)}\n`);
+  return lockPath;
+}
+
+function pack(outDir: string, manifest: Manifest): string {
+  const tgzPath = join(outDir, `${manifest.name}-${manifest.version}.tgz`);
+  const result = spawnSync('tar', ['-czf', tgzPath, '-C', outDir, 'index.js', 'plugin.json'], { encoding: 'utf8' });
+  if (result.status !== 0) throw new Error(result.stderr || 'tar failed');
+  return tgzPath;
+}
+
+export async function buildPlugin(options: BuildOptions = {}): Promise<BuildResult> {
+  const root = resolve(options.root ?? process.cwd());
+  const outDir = resolve(options.outDir ?? join(root, 'dist'));
+  const manifest = readManifest(root);
+  const entry = resolve(root, manifest.entry);
+  if (!existsSync(entry)) throw new Error(`entry file not found: ${entry}`);
+
+  rmSync(outDir, { recursive: true, force: true });
+  mkdirSync(outDir, { recursive: true });
+  const build = await Bun.build({
+    entrypoints: [entry],
+    outdir: outDir,
+    target: 'bun',
+    format: 'esm',
+    minify: true,
+    naming: 'index.js',
+  });
+  if (!build.success) throw new Error(build.logs.map((log) => log.message).join('\n') || 'Bun.build failed');
+
+  const artifact = { path: './index.js', sha256: sha256(join(outDir, 'index.js')) };
+  const manifestPath = join(outDir, 'plugin.json');
+  writeFileSync(manifestPath, `${JSON.stringify({ ...manifest, entry: './index.js', artifact }, null, 2)}\n`);
+  const tgzPath = pack(outDir, manifest);
+  const lockPath = writeLock(outDir, manifest, tgzPath.split('/').at(-1)!, artifact);
+  return { outDir, manifestPath, lockPath, tgzPath, sha256: artifact.sha256 };
+}
+
+if (import.meta.main) {
+  buildPlugin({ root: option('--root'), outDir: option('--out') })
+    .then((result) => console.log(JSON.stringify(result, null, 2)))
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    });
+}

--- a/tools/maw-plugin-arra/tsconfig.json
+++ b/tools/maw-plugin-arra/tsconfig.json
@@ -10,5 +10,5 @@
     "strict": true,
     "skipLibCheck": true
   },
-  "include": ["index.ts", "commands/**/*.ts"]
+  "include": ["index.ts", "commands/**/*.ts", "scripts/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- add a self-contained build script for the canonical `tools/maw-plugin-arra` package
- emit dist/index.js, dist/plugin.json artifact metadata, an installable tgz, and pinned plugins.lock
- add a build smoke test that validates tgz contents and invokes the bundled handler

## Validation
- bun test tests/tools/maw-plugin-arra/
- bunx tsc --noEmit -p tools/maw-plugin-arra/tsconfig.json
- bunx tsc --noEmit
- git diff --check origin/alpha...HEAD
- wc -l tools/maw-plugin-arra/scripts/build.ts tools/maw-plugin-arra/package.json tools/maw-plugin-arra/tsconfig.json tests/tools/maw-plugin-arra/build.test.ts

Refs #1467