### PR TITLE
feat(studio): route vector first-run wizard

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -58,6 +58,7 @@ export function AppShell({
     { to: '/export', label: 'Export App', description: 'Legacy v2 JSON/Markdown backups' },
     { to: '/vector', label: 'Vector Dashboard', description: 'Collection health and indexing', end: true },
     { to: '/vector/documents', label: 'Document Browser', description: 'Browse indexed vector documents' },
+    { to: '/vector/first-run', label: 'First-run setup', description: 'Provider detection and first index' },
     { to: '/vector/index', label: 'Index Manager', description: 'Backfill vectors and watch jobs' },
     { to: '/vector/search', label: 'Vector Search', description: 'Semantic preview by collection' },
     { to: '/vector/settings', label: 'Vector settings', description: 'Collection config and index controls' },

--- a/frontend/src/pages/FirstRunWizard.tsx
+++ b/frontend/src/pages/FirstRunWizard.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState } from 'react';
-import { ErrorMessage, Spinner } from '../components/AsyncState';
-import { fetchJson, type VectorConfigRow } from './vectorSettingsHelpers';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ErrorMessage, LoadingPanel, Spinner } from '../components/AsyncState';
+import { fetchJson, parseVectorConfigResponse, toRows, type VectorConfigRow } from './vectorSettingsHelpers';
 
 type WizardStep = 0 | 1 | 2 | 3;
 type Provider = { type: string; available?: boolean; configured?: boolean; models?: string[]; error?: string; status?: string };
@@ -27,6 +27,41 @@ export type FirstRunWizardProps = {
 };
 
 const steps = ['Welcome', 'Provider', 'Vault + index', 'Done'] as const;
+
+export function VectorFirstRunWizardPage() {
+  const [rows, setRows] = useState<VectorConfigRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const refresh = useCallback(async () => {
+    setError('');
+    setLoading(true);
+    try {
+      const body = await fetchJson<unknown>('/api/v1/vector/config');
+      setRows(toRows(parseVectorConfigResponse(body)));
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void refresh(); }, [refresh]);
+
+  return (
+    <section className="grid gap-5" aria-labelledby="vector-first-run-title">
+      <header className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-300">Vector onboarding</p>
+        <h1 id="vector-first-run-title" className="mt-2 text-3xl font-semibold text-white">First-run setup wizard</h1>
+        <p className="mt-2 text-sm text-slate-400">Auto-detect providers, review cost, choose the first vault collection, and start indexing.</p>
+      </header>
+
+      <FirstRunWizard rows={rows} onRefresh={refresh} />
+      {loading ? <LoadingPanel title="Loading first-run vector config…" detail="Fetching /api/v1/vector/config." /> : null}
+      {error ? <ErrorMessage title="Could not load first-run vector config." message={error} /> : null}
+    </section>
+  );
+}
 
 function primaryKey(rows: VectorConfigRow[]): string | null {
   return (rows.find((row) => row.primary) ?? rows[0])?.key ?? null;

--- a/frontend/src/routeMeta.ts
+++ b/frontend/src/routeMeta.ts
@@ -46,6 +46,13 @@ export function routeMeta(pathname: string, search = ''): RouteMeta {
     ]);
   }
 
+  if (pathname === '/vector/first-run') {
+    return base('First-run setup', 'Vector', 'Auto-detect providers, review cost, and start the first vector index.', [
+      { label: 'Vector dashboard', to: '/vector' },
+      { label: 'First-run setup' },
+    ]);
+  }
+
   if (pathname === '/vector/index') {
     return base('Index Manager', 'Vector', 'Track vector backfill jobs and reindex collections.', [
       { label: 'Vector dashboard', to: '/vector' },

--- a/frontend/src/routePaths.ts
+++ b/frontend/src/routePaths.ts
@@ -57,6 +57,10 @@ export function vectorDocumentsPath(): string {
   return '/vector/documents';
 }
 
+export function vectorFirstRunPath(): string {
+  return '/vector/first-run';
+}
+
 export function vectorIndexPath(): string {
   return '/vector/index';
 }

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -20,6 +20,7 @@ import { VectorDocumentsPage } from './pages/VectorDocumentsPage';
 import { VectorSearchResultsPage } from './pages/VectorSearchResultsPage';
 import { VectorExportPage } from './pages/VectorExportPage';
 import { VectorSettingsPage } from './pages/VectorSettingsPage';
+import { VectorFirstRunWizardPage } from './pages/FirstRunWizard';
 import { IndexManagerPanel } from './pages/IndexManagerPanel';
 import type { LoadState, MenuItem, PluginEntry } from './types';
 import type { MetricsSnapshot } from '../../src/server/types';
@@ -38,6 +39,7 @@ export const frontendRoutes = [
   '/vector',
   '/vector/search',
   '/vector/documents',
+  '/vector/first-run',
   '/vector/index',
   '/vector/results',
   '/vector/export',
@@ -98,6 +100,7 @@ export function DashboardRoutes({
       <Route path="/vector" element={<VectorPage />} />
       <Route path="/vector/search" element={<VectorSearchPage />} />
       <Route path="/vector/documents" element={<VectorDocumentsPage />} />
+      <Route path="/vector/first-run" element={<VectorFirstRunWizardPage />} />
       <Route path="/vector/index" element={<IndexManagerPanel />} />
       <Route path="/vector/results" element={<VectorSearchResultsPage />} />
       <Route path="/vector/export" element={<VectorExportPage />} />

--- a/tests/frontend/components/app-shell-vector-nav.test.tsx
+++ b/tests/frontend/components/app-shell-vector-nav.test.tsx
@@ -16,6 +16,7 @@ describe('AppShell Vector navigation', () => {
       );
       expect(html).toContain('aria-label="Vector Dashboard: Collection health and indexing"');
       expect(html).toContain('aria-label="Document Browser: Browse indexed vector documents"');
+      expect(html).toContain('aria-label="First-run setup: Provider detection and first index"');
       expect(html).toContain('aria-label="Index Manager: Backfill vectors and watch jobs"');
       expect(html).toContain('aria-label="Vector Search: Semantic preview by collection"');
       expect(html).toContain('aria-label="Export App: Legacy v2 JSON/Markdown backups"');

--- a/tests/frontend/router.test.ts
+++ b/tests/frontend/router.test.ts
@@ -45,6 +45,7 @@ describe('frontend router', () => {
       '/vector',
       '/vector/search',
       '/vector/documents',
+      '/vector/first-run',
       '/vector/index',
       '/vector/results',
       '/vector/export',
@@ -72,6 +73,7 @@ describe('frontend router', () => {
     expect(htmlAt('/vector')).toContain('Vector dashboard');
     expect(htmlAt('/vector/search')).toContain('Vector search preview');
     expect(htmlAt('/vector/documents')).toContain('Vector documents');
+    expect(htmlAt('/vector/first-run')).toContain('First-run setup wizard');
     expect(htmlAt('/vector/index')).toContain('Index Manager');
     expect(htmlAt('/vector/results')).toContain('Vector search results');
     expect(htmlAt('/vector/export')).toContain('Vector export');

--- a/tests/frontend/routes/vector-first-run-path.test.ts
+++ b/tests/frontend/routes/vector-first-run-path.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test } from 'bun:test';
+import { vectorFirstRunPath } from '../../../frontend/src/routePaths';
+
+describe('vectorFirstRunPath', () => {
+  test('points to the first-run onboarding route', () => {
+    expect(vectorFirstRunPath()).toBe('/vector/first-run');
+  });
+});

--- a/tests/frontend/routes/vector-meta.test.ts
+++ b/tests/frontend/routes/vector-meta.test.ts
@@ -12,5 +12,9 @@ describe('vector route metadata', () => {
       title: 'Index Manager',
       description: 'Track vector backfill jobs and reindex collections.',
     });
+    expect(routeMeta('/vector/first-run')).toMatchObject({
+      title: 'First-run setup',
+      description: 'Auto-detect providers, review cost, and start the first vector index.',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- adds a dedicated /vector/first-run Studio route for the first-run vector onboarding wizard
- loads vector config into the wizard page so provider detection, cost review, vault/index, and done flow are reachable outside Settings
- adds sidebar, route metadata, route helper, and router coverage for the new surface

## Tests
- bunx tsc --noEmit
- bun test tests/frontend/