### PR TITLE
feat: preserve mcp tool browser return links

### DIFF
--- a/frontend/src/pages/McpToolDetailPage.tsx
+++ b/frontend/src/pages/McpToolDetailPage.tsx
@@ -3,7 +3,7 @@ import { Link, useParams } from 'react-router-dom';
 import { fetchMcpTools } from '../api';
 import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
 import { groupLabel, schemaText, toolMode } from '../components/toolView';
-import { pluginInventoryPath } from '../routePaths';
+import { mcpToolsPath, pluginInventoryPath } from '../routePaths';
 import type { McpTool } from '../types';
 
 type PageState = 'loading' | 'ready' | 'error';
@@ -16,6 +16,12 @@ export function toolDetailSource(tool: McpTool): string {
 
 export function toolPluginInventoryPath(tool: McpTool): string | null {
   return tool.plugin ? pluginInventoryPath({ q: tool.plugin, surface: 'mcp' }) : null;
+}
+
+export function toolBrowserReturnPath(tool?: McpTool | null): string {
+  if (!tool) return '/mcp';
+  if (tool.source === 'plugin' || tool.plugin) return mcpToolsPath({ q: tool.plugin ?? tool.name, source: 'plugin' });
+  return mcpToolsPath({ q: tool.name, source: 'core' });
 }
 
 function DetailCard({ label, value, href }: { label: string; value?: string; href?: string | null }) {
@@ -138,7 +144,7 @@ export function McpToolDetailPage({
             <h1 id="tool-detail-title" className="mt-2 text-3xl font-semibold text-white">MCP tool detail</h1>
             <p className="mt-2 text-sm text-slate-400">Inspect MCP tool metadata and input schema.</p>
           </div>
-          <Link className="focus-ring rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-teal-300/40" to="/mcp">
+          <Link className="focus-ring rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-teal-300/40" to={toolBrowserReturnPath(tool)}>
             Back to MCP tools
           </Link>
         </div>

--- a/tests/frontend/pages/mcp-tool-detail-source.test.tsx
+++ b/tests/frontend/pages/mcp-tool-detail-source.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { McpToolDetailPage, toolDetailSource, toolPluginInventoryPath } from '../../../frontend/src/pages/McpToolDetailPage';
+import { McpToolDetailPage, toolBrowserReturnPath, toolDetailSource, toolPluginInventoryPath } from '../../../frontend/src/pages/McpToolDetailPage';
 import type { McpTool } from '../../../frontend/src/types';
 import { htmlFor } from '../_render';
 
@@ -20,6 +20,8 @@ describe('McpToolDetailPage source labels', () => {
     expect(toolDetailSource({ name: 'memory.write', description: '', source: 'core' })).toBe('core');
     expect(toolPluginInventoryPath(pluginTool)).toBe('/plugins?q=echo&surface=mcp');
     expect(toolPluginInventoryPath({ name: 'memory.write', description: '', source: 'core' })).toBeNull();
+    expect(toolBrowserReturnPath(pluginTool)).toBe('/mcp?q=echo&source=plugin');
+    expect(toolBrowserReturnPath({ name: 'memory.write', description: '', source: 'core' })).toBe('/mcp?q=memory.write&source=core');
   });
 
   test('renders ready-state plugin source details from initial tools', () => {
@@ -33,6 +35,7 @@ describe('McpToolDetailPage source labels', () => {
     expect(html).toContain('echo.say');
     expect(html).toContain('plugin:echo');
     expect(html).toContain('href="/plugins?q=echo&amp;surface=mcp"');
+    expect(html).toContain('href="/mcp?q=echo&amp;source=plugin"');
     expect(html).toContain('Input schema');
   });
 });


### PR DESCRIPTION
Refs #1484

## Summary
- make MCP tool detail Back links return to filtered MCP browser views
- preserve plugin/core source context when navigating back from a tool detail
- add coverage for generated return URLs and rendered detail links

## Verification
- git fetch origin && git rebase origin/alpha
- bunx tsc --noEmit
- bun test tests/frontend
- bun test tests/frontend/pages/mcp-tool-detail-source.test.tsx
- git diff --check
- wc -l frontend/src/pages/McpToolDetailPage.tsx tests/frontend/pages/mcp-tool-detail-source.test.tsx