### PR TITLE
feat(maw-plugin): record package artifact integrity

### DIFF
--- a/maw-plugin/__tests__/build.test.ts
+++ b/maw-plugin/__tests__/build.test.ts
@@ -16,14 +16,17 @@ test('maw plugin build emits dist manifest, tgz, sha, and plugins.lock', async (
     artifact: { path: string; sha256: string };
   };
   const lock = JSON.parse(readFileSync(result.lockPath, 'utf8')) as {
-    plugins: { arra: { version: string; package: string; artifact: { sha256: string }; pinned: boolean } };
+    plugins: { arra: { version: string; package: string; packageSha256: string; artifact: { sha256: string }; pinned: boolean } };
   };
   const sha256 = createHash('sha256').update(readFileSync(entry)).digest('hex');
+  const packageSha256 = createHash('sha256').update(readFileSync(result.tgzPath)).digest('hex');
 
   expect(manifest.entry).toBe('./index.js');
   expect(manifest.artifact).toEqual({ path: './index.js', sha256 });
   expect(result.sha256).toBe(sha256);
+  expect(result.packageSha256).toBe(packageSha256);
   expect(existsSync(result.tgzPath)).toBe(true);
   expect(lock.plugins.arra).toMatchObject({ version: '1.0.0', package: 'arra-1.0.0.tgz', pinned: true });
   expect(lock.plugins.arra.artifact.sha256).toBe(sha256);
+  expect(lock.plugins.arra.packageSha256).toBe(packageSha256);
 });

--- a/maw-plugin/scripts/build.ts
+++ b/maw-plugin/scripts/build.ts
@@ -6,7 +6,14 @@ import { join, resolve } from 'node:path';
 type Artifact = { path: string; sha256: string };
 type Manifest = { name: string; version: string; entry: string; artifact?: Artifact; [key: string]: unknown };
 type BuildOptions = { root?: string; outDir?: string };
-type BuildResult = { outDir: string; manifestPath: string; lockPath: string; tgzPath: string; sha256: string };
+type BuildResult = {
+  outDir: string;
+  manifestPath: string;
+  lockPath: string;
+  tgzPath: string;
+  sha256: string;
+  packageSha256: string;
+};
 
 function arg(name: string): string | undefined {
   const index = process.argv.indexOf(name);
@@ -26,13 +33,14 @@ function sha256(path: string): string {
   return createHash('sha256').update(readFileSync(path)).digest('hex');
 }
 
-function writeLock(outDir: string, manifest: Manifest, tgzName: string, artifact: Artifact): string {
+function writeLock(outDir: string, manifest: Manifest, tgzName: string, artifact: Artifact, packageSha256: string): string {
   const lock = {
     version: 1,
     plugins: {
       [manifest.name]: {
         version: manifest.version,
         package: tgzName,
+        packageSha256,
         artifact,
         pinned: true,
       },
@@ -77,8 +85,9 @@ export async function buildPlugin(options: BuildOptions = {}): Promise<BuildResu
   const manifestPath = join(outDir, 'plugin.json');
   writeFileSync(manifestPath, `${JSON.stringify(distManifest, null, 2)}\n`);
   const tgzPath = pack(outDir, manifest);
-  const lockPath = writeLock(outDir, manifest, tgzPath.split('/').at(-1)!, artifact);
-  return { outDir, manifestPath, lockPath, tgzPath, sha256: artifact.sha256 };
+  const packageSha256 = sha256(tgzPath);
+  const lockPath = writeLock(outDir, manifest, tgzPath.split('/').at(-1)!, artifact, packageSha256);
+  return { outDir, manifestPath, lockPath, tgzPath, sha256: artifact.sha256, packageSha256 };
 }
 
 if (import.meta.main) {

--- a/tests/tools/maw-plugin-arra/build.test.ts
+++ b/tests/tools/maw-plugin-arra/build.test.ts
@@ -18,9 +18,10 @@ test('build emits an installable tgz, pinned lock, and runnable bundled handler'
     artifact: { path: string; sha256: string };
   };
   const lock = JSON.parse(readFileSync(result.lockPath, 'utf8')) as {
-    plugins: { arra: { version: string; package: string; pinned: boolean; artifact: { sha256: string } } };
+    plugins: { arra: { version: string; package: string; packageSha256: string; pinned: boolean; artifact: { sha256: string } } };
   };
   const sha256 = createHash('sha256').update(readFileSync(entryPath)).digest('hex');
+  const packageSha256 = createHash('sha256').update(readFileSync(result.tgzPath)).digest('hex');
   const tar = spawnSync('tar', ['-tzf', result.tgzPath], { encoding: 'utf8' });
   const built = await import(`${pathToFileURL(entryPath).href}?${Date.now()}`) as {
     default: (ctx: { source?: string; args?: string[] }) => Promise<{ ok: boolean; output?: string }>;
@@ -30,11 +31,13 @@ test('build emits an installable tgz, pinned lock, and runnable bundled handler'
   expect(manifest.entry).toBe('./index.js');
   expect(manifest.artifact).toEqual({ path: './index.js', sha256 });
   expect(result.sha256).toBe(sha256);
+  expect(result.packageSha256).toBe(packageSha256);
   expect(existsSync(result.tgzPath)).toBe(true);
   expect(tar.status).toBe(0);
   expect(tar.stdout.trim().split('\n').sort()).toEqual(['index.js', 'plugin.json']);
   expect(lock.plugins.arra).toMatchObject({ version: '0.1.0', package: 'arra-0.1.0.tgz', pinned: true });
   expect(lock.plugins.arra.artifact.sha256).toBe(sha256);
+  expect(lock.plugins.arra.packageSha256).toBe(packageSha256);
   expect(help.ok).toBe(true);
   expect(help.output).toContain('maw arra');
 });

--- a/tools/maw-plugin-arra/scripts/build.ts
+++ b/tools/maw-plugin-arra/scripts/build.ts
@@ -6,7 +6,14 @@ import { join, resolve } from 'node:path';
 type Artifact = { path: string; sha256: string };
 type Manifest = { name: string; version: string; entry: string; [key: string]: unknown };
 type BuildOptions = { root?: string; outDir?: string };
-type BuildResult = { outDir: string; manifestPath: string; lockPath: string; tgzPath: string; sha256: string };
+type BuildResult = {
+  outDir: string;
+  manifestPath: string;
+  lockPath: string;
+  tgzPath: string;
+  sha256: string;
+  packageSha256: string;
+};
 
 function option(name: string): string | undefined {
   const index = process.argv.indexOf(name);
@@ -26,12 +33,12 @@ function sha256(path: string): string {
   return createHash('sha256').update(readFileSync(path)).digest('hex');
 }
 
-function writeLock(outDir: string, manifest: Manifest, tgzName: string, artifact: Artifact): string {
+function writeLock(outDir: string, manifest: Manifest, tgzName: string, artifact: Artifact, packageSha256: string): string {
   const lockPath = join(outDir, 'plugins.lock');
   const lock = {
     version: 1,
     plugins: {
-      [manifest.name]: { version: manifest.version, package: tgzName, artifact, pinned: true },
+      [manifest.name]: { version: manifest.version, package: tgzName, packageSha256, artifact, pinned: true },
     },
   };
   writeFileSync(lockPath, `${JSON.stringify(lock, null, 2)}\n`);
@@ -68,8 +75,9 @@ export async function buildPlugin(options: BuildOptions = {}): Promise<BuildResu
   const manifestPath = join(outDir, 'plugin.json');
   writeFileSync(manifestPath, `${JSON.stringify({ ...manifest, entry: './index.js', artifact }, null, 2)}\n`);
   const tgzPath = pack(outDir, manifest);
-  const lockPath = writeLock(outDir, manifest, tgzPath.split('/').at(-1)!, artifact);
-  return { outDir, manifestPath, lockPath, tgzPath, sha256: artifact.sha256 };
+  const packageSha256 = sha256(tgzPath);
+  const lockPath = writeLock(outDir, manifest, tgzPath.split('/').at(-1)!, artifact, packageSha256);
+  return { outDir, manifestPath, lockPath, tgzPath, sha256: artifact.sha256, packageSha256 };
 }
 
 if (import.meta.main) {


### PR DESCRIPTION
## Summary
- record the generated plugin tgz SHA-256 alongside the bundled entry artifact hash
- return package integrity from both build helpers
- extend build smoke tests for the legacy and canonical maw plugin packages

## Validation
- bun test maw-plugin/__tests__/build.test.ts tests/tools/maw-plugin-arra/build.test.ts
- bun test tests/tools/maw-plugin-arra/ maw-plugin/__tests__/
- bunx tsc --noEmit -p tools/maw-plugin-arra/tsconfig.json
- bunx tsc --noEmit
- git diff --check origin/alpha...HEAD
- wc -l maw-plugin/scripts/build.ts maw-plugin/__tests__/build.test.ts tools/maw-plugin-arra/scripts/build.ts tests/tools/maw-plugin-arra/build.test.ts

Refs #1467