### PR TITLE
fix(vector): mark failed service probes unavailable

### DIFF
--- a/src/routes/vector/services.ts
+++ b/src/routes/vector/services.ts
@@ -58,11 +58,13 @@ export function createVectorServicesApiEndpoint(registry: VectorServiceRegistryC
       }
       const health = await registry.healthCheck();
       const result = health.get(params.name);
+      const status = result?.status ?? 'unknown';
+      if (status !== 'up') set.status = 503;
       return {
         name: params.name,
-        status: result?.status ?? 'unknown',
+        status,
         ...(result || {}),
-        success: result?.status === 'up',
+        success: status === 'up',
       };
     }, {
       params: t.Object({ name: t.String({ minLength: 1 }) }),

--- a/tests/http/vector/services.test.ts
+++ b/tests/http/vector/services.test.ts
@@ -91,6 +91,35 @@ test('vector service registry API rejects proxy registration without endpoint', 
   expect(await json(res)).toMatchObject({ success: false, error: 'proxy service requires endpoint' });
 });
 
+test('vector service registry API returns 503 when service test is down', async () => {
+  const registry = new FakeRegistry();
+  registry.services.set('down-proxy', {
+    name: 'down-proxy',
+    type: 'proxy',
+    endpoint: 'http://127.0.0.1:9',
+  });
+  registry.healthCheck = async () => new Map<string, HealthStatus>([
+    ['lancedb', { status: 'up', checkedAt: '2026-06-16T00:00:00.000Z' }],
+    ['down-proxy', {
+      status: 'down',
+      checkedAt: '2026-06-16T00:00:00.000Z',
+      error: 'connection refused',
+    }],
+  ]);
+
+  const res = await createFetch(registry)(
+    new Request('http://local/api/v1/vector/services/down-proxy/test', { method: 'POST' }),
+  );
+
+  expect(res.status).toBe(503);
+  expect(await json(res)).toMatchObject({
+    name: 'down-proxy',
+    status: 'down',
+    success: false,
+    error: 'connection refused',
+  });
+});
+
 test('VectorServiceRegistry persists services and probes proxy health', async () => {
   const savedDataDir = process.env.ORACLE_DATA_DIR;
   const root = mkdtempSync(join(tmpdir(), 'vector-services-registry-'));


### PR DESCRIPTION
## Summary\n- return 503 from POST /api/vector/services/:name/test when a registered service health probe is not up\n- keep the response body with status/error/success fields for registry diagnostics\n- add HTTP coverage for down proxy service probes\n\n## Validation\n- bunx tsc --noEmit\n- bun test tests/http/vector/\n- files <=250 lines