### PR TITLE
feat(canvas): explain plugin fallback

### DIFF
--- a/src/workers/canvas/index.ts
+++ b/src/workers/canvas/index.ts
@@ -83,9 +83,14 @@ function registryResponse(url: URL): Response | null {
   return Response.json(entry, { headers: REGISTRY_HEADERS });
 }
 
-function pluginFrom(url: URL) {
+function requestedPluginFrom(url: URL): string | null {
   const pathPlugin = url.pathname.length > 1 ? url.pathname.slice(1).split('/')[0] : null;
-  return normalizePlugin(url.searchParams.get('plugin') ?? pathPlugin);
+  return url.searchParams.get('plugin') ?? pathPlugin;
+}
+
+function pluginFrom(url: URL) {
+  const requested = requestedPluginFrom(url);
+  return { plugin: normalizePlugin(requested), requested };
 }
 
 export async function handleCanvasRequest(request: Request, env: CanvasWorkerEnv = {}): Promise<Response> {
@@ -98,7 +103,8 @@ export async function handleCanvasRequest(request: Request, env: CanvasWorkerEnv
   if (url.pathname.startsWith('/api/') && request.method === 'OPTIONS') return new Response(null, { status: 204, headers: API_CACHE_HEADERS });
   if (url.pathname.startsWith('/api/')) return proxyApi(request, env);
   if (request.method !== 'GET' && request.method !== 'HEAD') return new Response('Method not allowed', { status: 405 });
-  const html = renderCanvasApp(pluginFrom(url), apiBase(env));
+  const selection = pluginFrom(url);
+  const html = renderCanvasApp(selection.plugin, apiBase(env), selection.requested);
   return new Response(request.method === 'HEAD' ? null : html, { headers: HTML_HEADERS });
 }
 

--- a/src/workers/canvas/render.ts
+++ b/src/workers/canvas/render.ts
@@ -39,11 +39,15 @@ function pluginOptions(current: string): string {
   }).join('');
 }
 
-export function renderCanvasApp(plugin: CanvasPlugin, apiBase: string): string {
+export function renderCanvasApp(plugin: CanvasPlugin, apiBase: string, requested?: string | null): string {
   const id = plugin.id;
   const title = titleFor(plugin);
   const canonical = canonicalUrl(id);
   const description = `${plugin.description} Runs as a dedicated Oracle canvas subdomain app.`;
+  const fallback = requested && requested !== id;
+  const fallbackNotice = fallback
+    ? `<p class="notice" role="status">Unknown canvas plugin “${escapeHtml(requested)}”; loaded ${escapeHtml(plugin.label)} instead.</p>`
+    : '';
   const plugins = listCanvasPlugins().map((item) => ({
     id: item.id,
     label: item.label,
@@ -68,11 +72,11 @@ body{margin:0;min-height:100vh;background:radial-gradient(circle at top,#164e63 
 header{position:fixed;inset:1rem 1rem auto;z-index:2;display:grid;gap:.8rem;padding:1rem 1.25rem;border:1px solid rgb(255 255 255/.12);border-radius:1.25rem;background:rgb(2 6 23/.72);backdrop-filter:blur(18px)}
 .top{display:flex;align-items:center;justify-content:space-between;gap:1rem}nav{display:flex;flex-wrap:wrap;gap:.4rem}a{color:#99f6e4;text-decoration:none;border:1px solid rgb(45 212 191/.25);border-radius:999px;padding:.3rem .55rem;font-size:.75rem}h1{margin:0;font-size:clamp(1.2rem,2.5vw,2rem)}
 p{margin:.25rem 0 0;color:#94a3b8}.pill{border:1px solid rgb(45 212 191/.4);border-radius:999px;padding:.45rem .75rem;color:#99f6e4;font-weight:700}
-.picker{display:flex;flex-wrap:wrap;gap:.5rem;align-items:center}.picker label{font-size:.75rem;color:#94a3b8}.picker select{border:1px solid rgb(45 212 191/.28);border-radius:.8rem;background:#020617;color:#e2e8f0;padding:.45rem .65rem}canvas{display:block;width:100vw;height:100vh}.error{position:fixed;left:1rem;right:1rem;bottom:1rem;color:#fecaca}
+.picker{display:flex;flex-wrap:wrap;gap:.5rem;align-items:center}.picker label{font-size:.75rem;color:#94a3b8}.picker select{border:1px solid rgb(45 212 191/.28);border-radius:.8rem;background:#020617;color:#e2e8f0;padding:.45rem .65rem}.notice{margin-top:.65rem;border:1px solid rgb(251 191 36/.35);border-radius:.85rem;background:rgb(251 191 36/.12);color:#fde68a;padding:.55rem .7rem;font-size:.8rem}canvas{display:block;width:100vw;height:100vh}.error{position:fixed;left:1rem;right:1rem;bottom:1rem;color:#fecaca}
 </style>
 </head>
-<body data-plugin="${escapeHtml(id)}" data-kind="${escapeHtml(plugin.kind)}" data-api-base="${escapeHtml(apiBase)}">
-<header><div class="top"><div><h1 id="canvas-title">${escapeHtml(title)}</h1><p id="canvas-subtitle">${escapeHtml(CANVAS_HOST)} · plugin=${escapeHtml(id)} · ${escapeHtml(plugin.kind)}</p></div><span class="pill" id="status">loading API</span></div><div class="picker"><label for="plugin-picker">Hot-swap plugin</label><select id="plugin-picker" aria-label="Hot-swap canvas plugin">${pluginOptions(id)}</select><a href="${STUDIO_HOME}" data-studio-home aria-label="Open Oracle Studio home">Studio home</a></div><nav aria-label="Canvas plugins">${pluginLinks(id)}</nav></header>
+<body data-plugin="${escapeHtml(id)}" data-kind="${escapeHtml(plugin.kind)}" data-api-base="${escapeHtml(apiBase)}" data-requested-plugin="${escapeHtml(requested ?? id)}">
+<header><div class="top"><div><h1 id="canvas-title">${escapeHtml(title)}</h1><p id="canvas-subtitle">${escapeHtml(CANVAS_HOST)} · plugin=${escapeHtml(id)} · ${escapeHtml(plugin.kind)}</p>${fallbackNotice}</div><span class="pill" id="status">loading API</span></div><div class="picker"><label for="plugin-picker">Hot-swap plugin</label><select id="plugin-picker" aria-label="Hot-swap canvas plugin">${pluginOptions(id)}</select><a href="${STUDIO_HOME}" data-studio-home aria-label="Open Oracle Studio home">Studio home</a></div><nav aria-label="Canvas plugins">${pluginLinks(id)}</nav></header>
 <canvas id="oracle-canvas" aria-label="${escapeHtml(id)} canvas visualization"></canvas><p class="error" id="error"></p>
 <script type="module">
 let plugins=${JSON.stringify(plugins)};let plugin=${JSON.stringify(id)};let pluginData={documents:[]};const apiBase=${JSON.stringify(apiBase)};const canvasHost=${JSON.stringify(CANVAS_HOST)};const canvas=document.querySelector('canvas');const ctx=canvas.getContext('2d');

--- a/tests/http/canvas-worker.test.ts
+++ b/tests/http/canvas-worker.test.ts
@@ -36,6 +36,16 @@ describe('canvas subdomain worker app', () => {
     expect(body.plugins[0].standalonePath).toBe('/map');
   });
 
+  test('explains unknown plugin deep-link fallback in rendered HTML', async () => {
+    const response = await handleCanvasRequest(new Request('https://canvas.buildwithoracle.com/not-a-plugin'));
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain('plugin=wave');
+    expect(html).toContain('data-requested-plugin="not-a-plugin"');
+    expect(html).toContain('Unknown canvas plugin');
+  });
+
   test('serves one local canvas plugin and leaves other api routes proxied', async () => {
     const plugin = await handleCanvasRequest(new Request('https://canvas.buildwithoracle.com/api/canvas/plugins/wave'));
     expect(await plugin.json()).toMatchObject({ plugin: { id: 'wave', standalonePath: '/?plugin=wave' } });

--- a/tests/workers/canvas-worker.test.ts
+++ b/tests/workers/canvas-worker.test.ts
@@ -61,9 +61,15 @@ describe('canvas Cloudflare Worker', () => {
     expect(html).toContain('loadRegistry()');
   });
 
-  test('falls back to wave for unknown plugins', async () => {
+  test('falls back to wave for unknown plugins with a visible notice', async () => {
     const response = await handleCanvasRequest(new Request('https://canvas.buildwithoracle.com/?plugin=unknown'));
-    expect(await response.text()).toContain('plugin=wave');
+    const html = await response.text();
+
+    expect(html).toContain('plugin=wave');
+    expect(html).toContain('data-requested-plugin="unknown"');
+    expect(html).toContain('role="status"');
+    expect(html).toContain('Unknown canvas plugin');
+    expect(html).toContain('loaded Wave instead');
   });
 
 


### PR DESCRIPTION
## Summary
- keeps the requested canvas plugin id on rendered standalone pages
- shows a visible status notice when unknown plugin deep links fall back to Wave
- covers query-string and clean-path fallback cases in canvas worker tests

## Tests
- bunx tsc --noEmit
- bun test tests/workers/canvas-worker.test.ts tests/http/canvas-worker.test.ts tests/canvas/ src/canvas/__tests__/ tests/plugins/canvas-registry.test.ts