### PR TITLE
feat: make plugin search links surface-aware

### DIFF
--- a/frontend/src/global-search.ts
+++ b/frontend/src/global-search.ts
@@ -55,17 +55,32 @@ function menuResult(item: MenuItem): GlobalSearchResult {
   };
 }
 
-function pluginResult(plugin: PluginEntry): GlobalSearchResult {
+function pluginSearchSurface(plugin: PluginEntry, query: string, surfaces: string[]): string | undefined {
+  const q = query.toLowerCase();
+  if (plugin.mcpTools?.some((tool) => tool.name.toLowerCase().includes(q))) return 'mcp';
+  if (plugin.apiRoutes?.some((route) => route.path.toLowerCase().includes(q))) return 'apiRoutes';
+  if (plugin.proxy?.some((proxy) => proxy.path.toLowerCase().includes(q))) return 'proxy';
+  const aliases: Record<string, string[]> = {
+    mcp: ['mcp', 'tool', 'tools'],
+    apiRoutes: ['api', 'route', 'routes'],
+    cliSubcommands: ['cli', 'command', 'commands'],
+    exportFormats: ['export', 'format', 'formats'],
+  };
+  return surfaces.find((surface) => surface.toLowerCase() === q || aliases[surface]?.includes(q));
+}
+
+function pluginResult(plugin: PluginEntry, query: string): GlobalSearchResult {
   const surfaces = surfacesFor(plugin);
   const server = plugin.server ? `${plugin.server.command} ${(plugin.server.args ?? []).join(' ')}` : '';
   const tools = plugin.mcpTools?.map((tool) => tool.name).join(' ') ?? '';
   const detail = plugin.description || `Plugin manifest${plugin.version ? ` · ${plugin.version}` : ''}`;
+  const surface = pluginSearchSurface(plugin, query, surfaces);
   return {
     id: `plugin:${plugin.name}`,
     surface: 'plugin',
     title: plugin.name,
     detail: surfaces.length ? `${detail} · ${surfaces.join(', ')}` : detail,
-    href: pluginInventoryPath({ q: plugin.name }),
+    href: pluginInventoryPath({ q: plugin.name, surface }),
     keywords: [plugin.file, plugin.version, plugin.menu?.label, server, tools, surfaces.join(' ')].map(text).join(' '),
   };
 }
@@ -91,7 +106,7 @@ export function buildGlobalSearchResults(sources: GlobalSearchSources, query: st
   if (!q) return [];
   return [
     ...sources.menu.map(menuResult),
-    ...sources.plugins.map(pluginResult),
+    ...sources.plugins.map((plugin) => pluginResult(plugin, q)),
     ...sources.tools.map(toolResult),
   ].filter((result) => haystack(result).includes(q)).slice(0, 12);
 }

--- a/tests/frontend/search/build-global-search-plugin.test.ts
+++ b/tests/frontend/search/build-global-search-plugin.test.ts
@@ -3,7 +3,7 @@ import { buildGlobalSearchResults } from '../../../frontend/src/global-search';
 
 describe('buildGlobalSearchResults plugin matches', () => {
   test('matches plugin descriptions and points results at filtered plugin inventory', () => {
-    const results = buildGlobalSearchResults({
+    const sources = {
       menu: [],
       plugins: [{
         name: 'echo',
@@ -14,8 +14,15 @@ describe('buildGlobalSearchResults plugin matches', () => {
         mcpTools: [{ name: 'echo.say', description: 'Say echo' }],
       }],
       tools: [],
-    }, 'workshop');
+    };
+    const results = buildGlobalSearchResults(sources, 'workshop');
     expect(results).toMatchObject([{ surface: 'plugin', title: 'echo', href: '/plugins?q=echo' }]);
     expect(results[0].detail).toContain('mcp');
+    expect(buildGlobalSearchResults(sources, 'echo.say')).toMatchObject([{ href: '/plugins?q=echo&surface=mcp' }]);
+    expect(buildGlobalSearchResults({
+      menu: [],
+      plugins: [{ name: 'proxybot', file: '', size: 0, modified: 'now', proxy: [{ path: '/proxy/echo', targetEnv: 'ECHO_URL' }] }],
+      tools: [],
+    }, 'proxy')).toMatchObject([{ href: '/plugins?q=proxybot&surface=proxy' }]);
   });
 });


### PR DESCRIPTION
Refs #1484

## Summary
- route plugin global-search matches to surface-filtered plugin inventory views when the query matches MCP/API/proxy surfaces
- preserve the default plugin inventory link for generic plugin name/description matches
- add coverage for MCP tool and proxy surface-aware plugin search links

## Verification
- git fetch origin && git rebase origin/alpha
- bunx tsc --noEmit
- bun test tests/frontend
- git diff --check
- wc -l frontend/src/global-search.ts tests/frontend/search/build-global-search-plugin.test.ts