### PR TITLE
test(maw-plugin): add install smoke helper

### DIFF
--- a/tests/tools/maw-plugin-arra/install-smoke.test.ts
+++ b/tests/tools/maw-plugin-arra/install-smoke.test.ts
@@ -1,0 +1,19 @@
+import { afterAll, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { smokeInstall } from '../../../tools/maw-plugin-arra/scripts/install-smoke.ts';
+
+const tmp = mkdtempSync(join(tmpdir(), 'maw-plugin-arra-install-smoke-'));
+afterAll(() => rmSync(tmp, { recursive: true, force: true }));
+
+test('install smoke extracts tgz and invokes the installed handler', async () => {
+  const result = await smokeInstall({ root: join(import.meta.dir, '../../../tools/maw-plugin-arra'), workDir: tmp, keep: true });
+
+  expect(result.manifestName).toBe('arra');
+  expect(result.entry).toBe('./index.js');
+  expect(result.sha256).toMatch(/^[a-f0-9]{64}$/);
+  expect(result.installDir).toEndWith('/installed/arra');
+  expect(result.output).toContain('maw arra');
+  expect(result.output).toContain('vector-config');
+});

--- a/tools/maw-plugin-arra/package.json
+++ b/tools/maw-plugin-arra/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "build": "bun scripts/build.ts",
+    "smoke:install": "bun scripts/install-smoke.ts",
     "typecheck": "bunx tsc --noEmit -p tsconfig.json",
     "test": "bun test ../../tests/tools/maw-plugin-arra/"
   },
@@ -13,6 +14,7 @@
     "index.ts",
     "plugin.json",
     "scripts/build.ts",
+    "scripts/install-smoke.ts",
     "tsconfig.json"
   ]
 }

--- a/tools/maw-plugin-arra/scripts/install-smoke.ts
+++ b/tools/maw-plugin-arra/scripts/install-smoke.ts
@@ -1,0 +1,70 @@
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { buildPlugin } from './build.ts';
+
+type SmokeOptions = { root?: string; workDir?: string; keep?: boolean };
+type SmokeResult = {
+  installDir: string;
+  manifestName: string;
+  entry: string;
+  sha256: string;
+  output: string;
+};
+
+type Handler = (ctx: { source?: string; args?: string[] }) => Promise<{ ok: boolean; output?: string; error?: string }>;
+
+function option(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+function hash(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+function extract(tgzPath: string, installDir: string): void {
+  mkdirSync(installDir, { recursive: true });
+  const tar = spawnSync('tar', ['-xzf', tgzPath, '-C', installDir], { encoding: 'utf8' });
+  if (tar.status !== 0) throw new Error(tar.stderr || 'tar extract failed');
+}
+
+export async function smokeInstall(options: SmokeOptions = {}): Promise<SmokeResult> {
+  const root = resolve(options.root ?? process.cwd());
+  const workDir = resolve(options.workDir ?? mkdtempSync(join(tmpdir(), 'maw-plugin-arra-smoke-')));
+  const outDir = join(workDir, 'dist');
+  const installDir = join(workDir, 'installed', 'arra');
+
+  try {
+    const built = await buildPlugin({ root, outDir });
+    extract(built.tgzPath, installDir);
+    const manifest = JSON.parse(readFileSync(join(installDir, 'plugin.json'), 'utf8')) as {
+      name: string;
+      entry: string;
+      artifact: { path: string; sha256: string };
+    };
+    const entryPath = join(installDir, manifest.artifact.path);
+    const actualSha = hash(entryPath);
+    if (actualSha !== manifest.artifact.sha256) throw new Error('installed entry sha256 mismatch');
+
+    const mod = await import(`${pathToFileURL(entryPath).href}?${Date.now()}`) as { default: Handler };
+    const result = await mod.default({ source: 'cli', args: ['help'] });
+    if (!result.ok || !result.output?.includes('maw arra')) throw new Error(result.error || 'installed handler smoke failed');
+
+    return { installDir, manifestName: manifest.name, entry: manifest.entry, sha256: actualSha, output: result.output };
+  } finally {
+    if (!options.keep) rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+if (import.meta.main) {
+  smokeInstall({ root: option('--root'), workDir: option('--work-dir'), keep: process.argv.includes('--keep') })
+    .then((result) => console.log(JSON.stringify(result, null, 2)))
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary
- add a canonical maw-plugin install-smoke helper that builds the tgz, extracts it like an install, verifies the entry hash, and invokes the installed handler
- expose `bun run smoke:install` from `tools/maw-plugin-arra/package.json`
- add a scoped regression test for the install smoke path

## Validation
- bun test tests/tools/maw-plugin-arra/
- bunx tsc --noEmit -p tools/maw-plugin-arra/tsconfig.json
- bunx tsc --noEmit
- git diff --check origin/alpha...HEAD
- wc -l tools/maw-plugin-arra/scripts/install-smoke.ts tools/maw-plugin-arra/package.json tests/tools/maw-plugin-arra/install-smoke.test.ts

Refs #1467