### PR TITLE
fix(vector): reject incompatible proxy protocols

### DIFF
--- a/src/vector/adapters/proxy.ts
+++ b/src/vector/adapters/proxy.ts
@@ -15,6 +15,7 @@ import type {
 } from '../types.ts';
 import { currentTenantId, TENANT_HEADER } from '../../middleware/tenant.ts';
 import {
+  VECTOR_PROXY_PROTOCOL_VERSION,
   VECTOR_PROXY_ROUTES,
   buildVectorProxyUrl,
   isHealthyVectorProxy,
@@ -45,6 +46,9 @@ export class ProxyVectorAdapter implements VectorStoreAdapter {
     const health = await this.health();
     if (!isHealthyVectorProxy(health)) {
       throw new Error('Proxy vector service unavailable');
+    }
+    if (health.protocol && health.protocol !== VECTOR_PROXY_PROTOCOL_VERSION) {
+      throw new Error(`Unsupported proxy protocol ${health.protocol}`);
     }
   }
 

--- a/tests/http/vector/proxy-adapter.test.ts
+++ b/tests/http/vector/proxy-adapter.test.ts
@@ -14,6 +14,9 @@ const server = Bun.serve({
     const body = request.method === 'GET' || request.method === 'DELETE' ? undefined : await request.json();
     requests.push({ method: request.method, path: url.pathname, body });
     if (url.pathname === '/proxy/health') return Response.json({ status: 'ok', name: 'proxy-test', version: '1' });
+    if (url.pathname === '/legacy/health') {
+      return Response.json({ status: 'ok', name: 'legacy-proxy', version: '0.1', protocol: 'legacy-proxy' });
+    }
     if (url.pathname === '/proxy/vectors/stats') return Response.json({ count: 2, name: 'remote_proxy_docs' });
     if (url.pathname === '/proxy/vectors/add') return Response.json({ success: true });
     if (url.pathname === '/proxy/vectors/query') return Response.json({
@@ -55,6 +58,12 @@ test('ProxyVectorAdapter speaks vector proxy protocol under endpoint path prefix
 
 test('vectorServiceUrl preserves path prefixes', () => {
   expect(vectorServiceUrl('http://example.test/base/', '/health')).toBe('http://example.test/base/health');
+});
+
+test('ProxyVectorAdapter rejects incompatible proxy protocol versions', async () => {
+  const adapter = new ProxyVectorAdapter('proxy_docs', `${server.url}legacy`);
+
+  await expect(adapter.connect()).rejects.toThrow('Unsupported proxy protocol legacy-proxy');
 });
 
 test('factory registers proxy vector stores', async () => {


### PR DESCRIPTION
## Summary\n- validate the advertised vector proxy protocol during ProxyVectorAdapter.connect()\n- keep legacy/no-protocol health responses accepted, but reject explicit incompatible protocol versions\n- add HTTP adapter coverage for incompatible proxy health responses\n\n## Validation\n- bunx tsc --noEmit\n- bun test tests/http/vector/\n- files <=250 lines