### PR TITLE
feat(cli): add vector config collection ops

### DIFF
--- a/src/cli/commands/vector-config.ts
+++ b/src/cli/commands/vector-config.ts
@@ -4,8 +4,10 @@ import {
   activeConfig,
   atomicWriteVectorConfig,
   inspectCollection,
+  normalizedCreate,
   resolveCollection,
   withPrimary,
+  withoutCollection,
 } from '../../routes/vector/config-api-utils.ts';
 
 const ADAPTERS = new Set(['lancedb', 'qdrant', 'chroma', 'sqlite-vec', 'cloudflare-vectorize', 'proxy', 'turbovec']);
@@ -21,6 +23,9 @@ function usage(out: Writer): void {
     '       bun run src/cli/index.ts vector-config set <collection> <field> <value> [--json]',
     '       bun run src/cli/index.ts vector-config set <collection> --adapter <name> [--url <url>]',
     '       bun run src/cli/index.ts vector-config switch <adapter> [--enabled true|false]',
+    '       bun run src/cli/index.ts vector-config add <name> --model <name> [--primary]',
+    '       bun run src/cli/index.ts vector-config remove <collection> --yes',
+    '       bun run src/cli/index.ts vector-config set-primary <collection>',
     '       bun run src/cli/index.ts vector-config test <collection>',
     '       bun run src/cli/index.ts vector-config reload',
   ].join('\n') + '\n');
@@ -65,13 +70,19 @@ function parseUpdates(args: string[]): Update {
     updates[fieldName(field)] = parseValue(fieldName(field), value);
     args = args.slice(2);
   }
-  for (let i = 0; i < args.length; i += 2) {
+  for (let i = 0; i < args.length;) {
     const rawField = args[i];
     const rawValue = args[i + 1];
     if (!rawField?.startsWith('--')) throw new Error('set requires <field> <value> pairs or --field <value>');
-    if (rawValue === undefined || rawValue.startsWith('--')) throw new Error(`${rawField} value required`);
     const parsedField = fieldName(rawField);
+    if (parsedField === 'primary' && (rawValue === undefined || rawValue.startsWith('--'))) {
+      updates.primary = true;
+      i += 1;
+      continue;
+    }
+    if (rawValue === undefined || rawValue.startsWith('--')) throw new Error(`${rawField} value required`);
     updates[parsedField] = parseValue(parsedField, rawValue);
+    i += 2;
   }
   if (!Object.keys(updates).length) throw new Error('set requires at least one field');
   return updates;
@@ -150,6 +161,54 @@ async function setField(args: string[], jsonOut: boolean, out: Writer): Promise<
   return 0;
 }
 
+async function addCollection(args: string[], jsonOut: boolean, out: Writer): Promise<number> {
+  const [, collection, ...rawUpdates] = args;
+  if (!collection) throw new Error('add requires <collection>');
+  const updates = parseUpdates(rawUpdates);
+  const created = normalizedCreate(collection, updates as Parameters<typeof normalizedCreate>[1]);
+  if ('error' in created) throw new Error(created.error);
+  const { source, config } = activeConfig();
+  if (config.collections[collection]) throw new Error(`vector collection already exists: ${collection}`);
+  const base: typeof config = { ...config, collections: { ...config.collections, [collection]: created } };
+  const next = created.primary ? withPrimary(base, collection) : base;
+  const path = atomicWriteVectorConfig(next);
+  await closeCachedVectorStores();
+  if (jsonOut) out(JSON.stringify({ success: true, source, path, collection, config: next }, null, 2) + '\n');
+  else out(`added ${collection}: model=${JSON.stringify(created.model)}, adapter=${JSON.stringify(created.adapter ?? 'lancedb')}\npath: ${path}\n`);
+  return 0;
+}
+
+async function removeCollection(args: string[], jsonOut: boolean, out: Writer): Promise<number> {
+  const collection = args[1];
+  if (!collection) throw new Error('remove requires <collection>');
+  if (!flag(args, '--yes') && !flag(args, '-y')) throw new Error('remove requires --yes');
+  const { source, config } = activeConfig();
+  const resolved = resolveCollection(config, collection);
+  if (!resolved) throw new Error(`unknown vector collection: ${collection}`);
+  const [key] = resolved;
+  const next = withoutCollection(config, key);
+  const path = atomicWriteVectorConfig(next);
+  await closeCachedVectorStores();
+  if (jsonOut) out(JSON.stringify({ success: true, source, path, removed: key, config: next }, null, 2) + '\n');
+  else out(`removed ${key}\npath: ${path}\n`);
+  return 0;
+}
+
+async function setPrimary(args: string[], jsonOut: boolean, out: Writer): Promise<number> {
+  const collection = args[1];
+  if (!collection) throw new Error('set-primary requires <collection>');
+  const { source, config } = activeConfig();
+  const resolved = resolveCollection(config, collection);
+  if (!resolved) throw new Error(`unknown vector collection: ${collection}`);
+  const [key] = resolved;
+  const next = withPrimary(config, key);
+  const path = atomicWriteVectorConfig(next);
+  await closeCachedVectorStores();
+  if (jsonOut) out(JSON.stringify({ success: true, source, path, collection: key, config: next }, null, 2) + '\n');
+  else out(`set ${key} as primary vector collection\npath: ${path}\n`);
+  return 0;
+}
+
 async function testCollection(args: string[], out: Writer): Promise<number> {
   const collection = args[1];
   if (!collection) throw new Error('test requires <collection>');
@@ -167,12 +226,15 @@ export async function vectorConfigCommand(args: string[], stdout: Writer = proce
     const rest = args.slice(1);
     if (flag(rest, '--help') || flag(rest, '-h')) { usage(stdout); return 0; }
     const command = rest.find((item) => !item.startsWith('--'));
-    if (!command) return readState(flag(rest, '--json'), stdout);
-    if (command === 'list') return readState(flag(rest, '--json'), stdout);
-    if (command === 'get') return getCollection(cleanArgs(rest), flag(rest, '--json'), stdout);
-    if (command === 'set') return setField(cleanArgs(rest), flag(rest, '--json'), stdout);
-    if (command === 'switch' || command === 'backend') return switchBackend(cleanArgs(rest), flag(rest, '--json'), stdout);
-    if (command === 'test') return testCollection(cleanArgs(rest), stdout);
+    if (!command) return await readState(flag(rest, '--json'), stdout);
+    if (command === 'list') return await readState(flag(rest, '--json'), stdout);
+    if (command === 'get') return await getCollection(cleanArgs(rest), flag(rest, '--json'), stdout);
+    if (command === 'set') return await setField(cleanArgs(rest), flag(rest, '--json'), stdout);
+    if (command === 'switch' || command === 'backend') return await switchBackend(cleanArgs(rest), flag(rest, '--json'), stdout);
+    if (command === 'add') return await addCollection(cleanArgs(rest), flag(rest, '--json'), stdout);
+    if (command === 'remove' || command === 'rm') return await removeCollection(cleanArgs(rest), flag(rest, '--json'), stdout);
+    if (command === 'set-primary' || command === 'primary') return await setPrimary(cleanArgs(rest), flag(rest, '--json'), stdout);
+    if (command === 'test') return await testCollection(cleanArgs(rest), stdout);
     if (command === 'reload') { await closeCachedVectorStores(); stdout('vector config runtime cache reloaded\n'); return 0; }
     throw new Error(`unknown vector-config command: ${command}`);
   } catch (error) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,7 +12,7 @@ function printUsage(): void {
   console.error('  serve:  bun run src/cli/index.ts serve <start|stop|status> [--foreground|--background] [--json]');
   console.error('  canvas-plugins: bun run src/cli/index.ts canvas-plugins [--kind three|react] [--id <id>] [--json]');
   console.error('  canvas-serve: bun run src/cli/index.ts canvas-serve [--port N] [--api-base URL]');
-  console.error('  vector-config: bun run src/cli/index.ts vector-config list|get|set [--json]');
+  console.error('  vector-config: bun run src/cli/index.ts vector-config list|get|set|add|remove|set-primary [--json]');
 }
 
 async function main() {

--- a/tests/cli/vector-config/source-command.test.ts
+++ b/tests/cli/vector-config/source-command.test.ts
@@ -112,4 +112,28 @@ describe('src vector-config command get/set', () => {
     expect(afterSwitch.collections.phase2).toMatchObject({ adapter: 'sqlite-vec', enabled: true });
     expect(afterSwitch.collections['bge-m3']).toMatchObject({ adapter: 'sqlite-vec', enabled: true });
   });
+
+  test('adds, promotes, and removes collections on disk', async () => {
+    const add = await run(['add', 'phase3', '--model', 'embed-v3', '--adapter', 'lancedb', '--primary', '--json']);
+    expect(add.code).toBe(0);
+    expect(JSON.parse(add.stdout)).toMatchObject({ success: true, collection: 'phase3' });
+    expect(diskConfig().collections.phase3).toMatchObject({ model: 'embed-v3', primary: true });
+    expect(diskConfig().collections['bge-m3'].primary).toBe(false);
+
+    const primary = await run(['set-primary', 'bge-m3', '--json']);
+    expect(primary.code).toBe(0);
+    expect(JSON.parse(primary.stdout)).toMatchObject({ success: true, collection: 'bge-m3' });
+    expect(diskConfig().collections['bge-m3'].primary).toBe(true);
+    expect(diskConfig().collections.phase3.primary).toBe(false);
+
+    const blocked = await run(['remove', 'phase3']);
+    expect(blocked.code).toBe(1);
+    expect(blocked.stderr).toContain('remove requires --yes');
+    expect(diskConfig().collections.phase3).toBeDefined();
+
+    const removed = await run(['remove', 'phase3', '--yes', '--json']);
+    expect(removed.code).toBe(0);
+    expect(JSON.parse(removed.stdout)).toMatchObject({ success: true, removed: 'phase3' });
+    expect(diskConfig().collections.phase3).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- add repo-local vector-config add/remove/set-primary commands
- allow bare --primary when creating/promoting collections
- cover disk-backed add/promote/remove behavior and require --yes for removal

Refs #1596

## Validation
- bun test tests/cli/vector-config/source-command.test.ts tests/cli/vector-config/cli.test.ts tests/tools/maw-plugin-arra/vector-config.test.ts tests/tools/maw-plugin-arra/vector-config-ops.test.ts
- bunx tsc --noEmit
- wc -l src/cli/commands/vector-config.ts src/cli/index.ts tests/cli/vector-config/source-command.test.ts