### PR TITLE
feat: expose read-only maw MCP surface

### DIFF
--- a/maw-plugin/README.md
+++ b/maw-plugin/README.md
@@ -10,6 +10,12 @@ maw plugin enable arra
 ```
 
 
+## MCP surface
+
+The manifest exposes `oracle_arra_read` as an MCP-out tool. It reuses the same
+command core as CLI/menu/API and only advertises read-only commands; write verbs
+stay on the CLI/API surface where auth headers are explicit.
+
 ## Build artifact
 
 The repo-local manifest declares `target: "js"` and keeps `artifact.sha256` pinned to

--- a/maw-plugin/__tests__/api.test.ts
+++ b/maw-plugin/__tests__/api.test.ts
@@ -55,4 +55,24 @@ describe('maw arra API surface', () => {
       globalThis.fetch = oldFetch;
     }
   });
+
+  test('MCP source dispatches read-only commands and blocks writes', async () => {
+    const oldFetch = globalThis.fetch;
+    const calls: string[] = [];
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      calls.push(String(url));
+      return new Response(JSON.stringify({ status: 'ok' }), { status: 200 });
+    }) as typeof fetch;
+    try {
+      const health = await handler({ source: 'mcp', args: { command: 'health' } });
+      const denied = await handler({ source: 'mcp', args: { command: 'learn', args: ['secret'] } });
+
+      expect(health.ok).toBe(true);
+      expect(health.output).toContain('arra health: ok');
+      expect(denied).toEqual({ ok: false, error: 'MCP surface exposes read-only commands only' });
+      expect(calls).toEqual(['http://localhost:47778/api/health']);
+    } finally {
+      globalThis.fetch = oldFetch;
+    }
+  });
 });

--- a/maw-plugin/__tests__/manifest.test.ts
+++ b/maw-plugin/__tests__/manifest.test.ts
@@ -3,6 +3,7 @@ import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import manifest from '../plugin.json' with { type: 'json' };
+import { manifestSurfaces, normalizeUnifiedPluginManifest } from '../../src/plugins/unified-manifest.ts';
 
 test('arra maw plugin declares modern dual surfaces and swappable backend config', () => {
   expect(manifest).toMatchObject({
@@ -14,7 +15,16 @@ test('arra maw plugin declares modern dual surfaces and swappable backend config
     config: { dbBackend: 'http', embedderBackend: 'none' },
   });
   expect(manifest.menu.map((item) => item.path)).toContain('/plugins/arra');
+  expect(manifest.mcpTools[0]).toMatchObject({ name: 'oracle_arra_read', handler: 'default', readOnly: true });
+  expect(manifest.mcpTools[0].inputSchema.properties.command.enum).toContain('search');
   expect(manifest.configSchema.properties.dbBackend.enum).toEqual(['http', 'sqlite', 'memory', 'custom']);
+});
+
+test('arra maw plugin normalizes with MCP tool metadata', () => {
+  const normalized = normalizeUnifiedPluginManifest(manifest);
+
+  expect(manifestSurfaces(normalized)).toEqual(expect.arrayContaining(['mcpTools', 'apiRoutes', 'menu', 'cliSubcommands']));
+  expect(normalized.mcpTools.map((tool) => tool.name)).toEqual(['oracle_arra_read']);
 });
 
 test('arra maw plugin records a verifiable entry artifact hash', () => {

--- a/maw-plugin/index.ts
+++ b/maw-plugin/index.ts
@@ -177,6 +177,7 @@ export const COMMANDS: Record<string, Spec> = {
 };
 
 const LOCAL_COMMANDS = { commands: 'commands', frontend: 'frontend [--no-open]', ui: 'ui [--no-open]', open: 'open [--no-open]', serve: 'serve [--stop|--status] [--port N]', server: 'server [start|stop|status]', studio: 'studio [--port N]', ...LOCAL_CLI_HELP } as const;
+const MCP_COMMANDS = new Set(['commands', ...Object.entries(COMMANDS).filter(([name, spec]) => name !== 'vector_config' && !spec.write && spec.method === 'GET').map(([name]) => name)]);
 function usage(): InvokeResult {
   const commandNames = [...Object.keys(COMMANDS), ...Object.keys(LOCAL_COMMANDS)].sort();
   return { ok: false, error: 'usage', output: ['usage: maw arra <subcommand> [args]', `subcommands: ${commandNames.join('|')}`, '', ...Object.entries(LOCAL_COMMANDS).sort().map(([name, help]) => `  ${name}  ${help}`), ...Object.entries(COMMANDS).sort().map(([name, spec]) => `  ${name}  ${spec.help}`)].join('\n') };
@@ -235,6 +236,7 @@ export async function runArra(args: string[], request: Requester = requestJson, 
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
   const args = apiArgsToCliArgs(ctx.args);
+  if (ctx.source === 'mcp' && args.length && !MCP_COMMANDS.has(key(args[0]))) return { ok: false, error: 'MCP surface exposes read-only commands only' };
   if (ctx.source !== 'cli' && args.length === 0) return registryPayload(ctx.source);
   const result = await runArra(args);
   if (ctx.source === 'cli' && ctx.writer && result.ok && result.output) {

--- a/maw-plugin/plugin.json
+++ b/maw-plugin/plugin.json
@@ -74,6 +74,67 @@
   ],
   "artifact": {
     "path": "./index.ts",
-    "sha256": "917531bf76cc16ef6949f96158db491fc9e053d5715b2169777ec92ba127063f"
-  }
+    "sha256": "ff8251c42ce5854f6d19deeb7d9fa2a54ca2caf5bc128182aba50c0dbdcbf9b5"
+  },
+  "mcpTools": [
+    {
+      "name": "oracle_arra_read",
+      "description": "Run read-only ARRA Oracle commands through the shared maw plugin command core.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "command": {
+            "type": "string",
+            "enum": [
+              "commands",
+              "search",
+              "stats",
+              "plugins",
+              "settings",
+              "feed",
+              "menu",
+              "vector",
+              "vector_status",
+              "vector_models",
+              "health",
+              "trace_list",
+              "trace_get",
+              "trace_chain",
+              "concepts",
+              "inbox",
+              "list",
+              "read",
+              "reflect",
+              "supersede_list",
+              "supersede_chain",
+              "threads",
+              "thread_read",
+              "schedule",
+              "mcp_tools"
+            ]
+          },
+          "args": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "query": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "command"
+        ],
+        "additionalProperties": true
+      },
+      "handler": "default",
+      "group": "oracle",
+      "readOnly": true,
+      "enabledByDefault": true
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- add `oracle_arra_read` MCP tool metadata to the ARRA maw plugin manifest
- route `source: "mcp"` through the shared command core with a read-only command allowlist
- cover manifest normalization and MCP read/write guard behavior

## Validation
- bun test maw-plugin/__tests__
- bunx tsc --noEmit
- targeted maw-plugin tsc over plugin entry/modules
- git diff --check
- changed files <=250 lines

Refs #1467