### PR TITLE
feat(frontend): persist vector service endpoints

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -79,7 +79,7 @@ export async function fetchVectorConfig(): Promise<VectorConfigResponse> {
 
 export async function updateVectorCollection(
   collection: string,
-  patch: { adapter?: string; enabled?: boolean; provider?: string; model?: string; primary?: boolean },
+  patch: { adapter?: string; enabled?: boolean; provider?: string; model?: string; primary?: boolean; service?: string; endpoint?: string },
 ): Promise<VectorConfigUpdateResponse> {
   return getJson<VectorConfigUpdateResponse>(`/api/v1/vector/config/${encodeURIComponent(collection)}`, {
     method: 'PUT',

--- a/frontend/src/components/VectorConfigPanel.tsx
+++ b/frontend/src/components/VectorConfigPanel.tsx
@@ -6,7 +6,7 @@ import type { SettingsEmbedderCollection, VectorConfigResponse } from '../types'
 const ADAPTERS = ['lancedb', 'qdrant', 'chroma', 'sqlite-vec', 'cloudflare-vectorize', 'proxy', 'turbovec'] as const;
 export const VECTOR_PROVIDERS = ['none', 'ollama', 'gemini', 'openai', 'local', 'remote'] as const;
 type SaveState = Record<string, 'idle' | 'saving' | 'testing' | 'primary'>;
-type Drafts = Record<string, { adapter: string; enabled: boolean; provider: string; model: string }>;
+type Drafts = Record<string, { adapter: string; enabled: boolean; provider: string; model: string; service: string; endpoint: string }>;
 type RuntimeState = { enabled?: boolean; ready?: boolean; primary?: string; reason?: string; recommendedAction?: string | null };
 type PanelResponse = VectorConfigResponse & { enabled?: boolean; engine?: string; state?: RuntimeState };
 
@@ -18,6 +18,17 @@ function statusClass(status: string) {
 
 function collectionEnabled(item: SettingsEmbedderCollection): boolean {
   return item.enabled !== false;
+}
+
+function draftFrom(key: string, item?: SettingsEmbedderCollection): Drafts[string] {
+  return {
+    adapter: item?.adapter ?? 'lancedb',
+    enabled: item ? collectionEnabled(item) : true,
+    provider: item?.provider ?? 'none',
+    model: item?.model ?? key,
+    service: item?.service ?? '',
+    endpoint: item?.endpoint ?? '',
+  };
 }
 
 async function testVectorCollection(key: string): Promise<{ success?: boolean; count?: number; error?: string; status?: string }> {
@@ -43,7 +54,7 @@ export function VectorConfigPanel() {
       setState(next);
       setDrafts(Object.fromEntries(Object.entries(next.config.collections).map(([key, item]) => [
         key,
-        { adapter: item.adapter ?? 'lancedb', enabled: collectionEnabled(item), provider: item.provider, model: item.model },
+        draftFrom(key, item),
       ])));
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause));
@@ -63,7 +74,7 @@ export function VectorConfigPanel() {
   const runtime = state?.state;
 
   function updateDraft(key: string, patch: Partial<Drafts[string]>) {
-    setDrafts((current) => ({ ...current, [key]: { ...(current[key] ?? { adapter: 'lancedb', enabled: true, provider: 'none', model: key }), ...patch } }));
+    setDrafts((current) => ({ ...current, [key]: { ...(current[key] ?? draftFrom(key)), ...patch } }));
   }
 
   async function saveAdapter(key: string) {
@@ -73,7 +84,10 @@ export function VectorConfigPanel() {
     setError('');
     setMessage('');
     try {
-      await updateVectorCollection(key, { adapter: draft.adapter, enabled: draft.enabled, provider: draft.provider, model: draft.model });
+      await updateVectorCollection(key, {
+        adapter: draft.adapter, enabled: draft.enabled, provider: draft.provider, model: draft.model,
+        service: draft.service, endpoint: draft.endpoint,
+      });
       await reloadVectorConfig();
       await load();
       setMessage(`Saved ${key}: ${draft.enabled ? `${draft.adapter} · ${draft.provider} · ${draft.model}` : 'disabled'}.`);
@@ -134,7 +148,7 @@ export function VectorConfigPanel() {
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-teal-300">Vector config</p>
           <h3 className="mt-2 text-lg font-semibold text-white">Active vector adapters</h3>
-          <p className="mt-2 text-sm text-slate-400">Get current config, edit model/provider, switch adapters, enable rows, set primary, and test health.</p>
+          <p className="mt-2 text-sm text-slate-400">Get current config, edit model/provider plus service endpoint, switch adapters, enable rows, set primary, and test health.</p>
           <p className="mt-2 text-xs text-slate-500">{summary}</p>
           <p className="mt-2 text-xs text-slate-500">
             Source {state?.source ?? 'loading'} · engine {state?.engine ?? 'loading'} · primary {runtime?.primary ?? 'none'} · {runtime?.ready ? 'ready' : 'not ready'}
@@ -151,10 +165,12 @@ export function VectorConfigPanel() {
 
       <div className="mt-5 grid gap-3">
         {rows.map(([key, item]) => {
-          const draft = drafts[key] ?? { adapter: item.adapter ?? 'lancedb', enabled: collectionEnabled(item), provider: item.provider, model: item.model };
+          const draft = drafts[key] ?? draftFrom(key, item);
           const health = state?.health[key];
           const status = health?.status ?? (draft.enabled ? 'unknown' : 'disabled');
-          const dirty = draft.adapter !== (item.adapter ?? 'lancedb') || draft.enabled !== collectionEnabled(item) || draft.provider !== item.provider || draft.model !== item.model;
+          const dirty = draft.adapter !== (item.adapter ?? 'lancedb') || draft.enabled !== collectionEnabled(item)
+            || draft.provider !== item.provider || draft.model !== item.model
+            || draft.service !== (item.service ?? '') || draft.endpoint !== (item.endpoint ?? '');
           return (
             <article key={key} className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
               <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
@@ -166,6 +182,7 @@ export function VectorConfigPanel() {
                   </div>
                   <p className="mt-2 text-sm text-slate-100">{item.collection}</p>
                   <p className="mt-1 text-xs text-slate-500">{item.provider} · {item.model} · {state?.doc_counts[key] ?? 0} docs</p>
+                  {item.service || item.endpoint ? <p className="mt-1 text-xs text-slate-500">Service {item.service || 'default'} · {item.endpoint || 'no endpoint'}</p> : null}
                   {health?.error ? <p className="mt-2 text-xs text-rose-300">{health.error}</p> : null}
                 </div>
                 <div className="flex flex-wrap items-center gap-3">
@@ -184,6 +201,14 @@ export function VectorConfigPanel() {
                     <select className="mt-1 block rounded-xl border border-white/10 bg-slate-900 px-3 py-2 text-sm text-slate-100" value={draft.provider} onChange={(event) => updateDraft(key, { provider: event.target.value })}>
                       {VECTOR_PROVIDERS.map((provider) => <option key={provider} value={provider}>{provider}</option>)}
                     </select>
+                  </label>
+                  <label className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                    Service
+                    <input className="mt-1 block rounded-xl border border-white/10 bg-slate-900 px-3 py-2 text-sm text-slate-100" placeholder="registry key" value={draft.service} onChange={(event) => updateDraft(key, { service: event.target.value })} />
+                  </label>
+                  <label className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                    Endpoint
+                    <input className="mt-1 block rounded-xl border border-white/10 bg-slate-900 px-3 py-2 text-sm text-slate-100" placeholder="http://localhost:6333" value={draft.endpoint} onChange={(event) => updateDraft(key, { endpoint: event.target.value })} />
                   </label>
                   <label className="flex items-center gap-2 text-sm text-slate-200">
                     <input type="checkbox" checked={draft.enabled} onChange={(event) => updateDraft(key, { enabled: event.target.checked })} />

--- a/frontend/src/pages/ExportApp.tsx
+++ b/frontend/src/pages/ExportApp.tsx
@@ -87,7 +87,7 @@ export function ExportApp({ initialBackendUrl = DEFAULT_BACKEND_URL, fetcher = g
     try {
       if (!fetcher) throw new Error('fetch is unavailable in this runtime.');
       const proxyPath = oracleV2CollectionsPath(normalized);
-      const proxy = await fetcher(backendApiUrl(DEFAULT_BACKEND_URL, proxyPath), { headers: { accept: 'application/json' } }).catch(() => null);
+      const proxy = await Promise.resolve(fetcher(backendApiUrl(DEFAULT_BACKEND_URL, proxyPath), { headers: { accept: 'application/json' } })).catch(() => null);
       if (proxy?.ok) {
         const next = normalizeExportAppCollections(await readExportPayload(proxy, proxyPath));
         setCollections(next);

--- a/frontend/src/pages/vectorSettingsHelpers.ts
+++ b/frontend/src/pages/vectorSettingsHelpers.ts
@@ -10,6 +10,8 @@ export type VectorServerCollection = {
   model: string;
   provider: string;
   adapter?: VectorConfigAdapter;
+  service?: string;
+  endpoint?: string;
   primary?: boolean;
   enabled?: boolean;
 };
@@ -32,6 +34,8 @@ export type VectorConfigHealth = {
   collection: string;
   adapter: VectorConfigAdapter;
   model: string;
+  service?: string;
+  endpoint?: string;
   error?: string;
 };
 
@@ -50,6 +54,8 @@ export interface VectorConfigDraft {
   model: string;
   provider: string;
   adapter: VectorConfigAdapter;
+  service: string;
+  endpoint: string;
   enabled: boolean;
 }
 
@@ -59,6 +65,8 @@ export type VectorConfigRow = {
   model: string;
   provider: string;
   adapter: VectorConfigAdapter;
+  service?: string;
+  endpoint?: string;
   primary?: boolean;
   enabled: boolean;
   count?: number;
@@ -121,6 +129,8 @@ export function parseVectorConfigResponse(value: unknown): VectorConfigResponse 
       model: typeof item.model === 'string' ? item.model : key,
       provider: typeof item.provider === 'string' ? item.provider : 'none',
       adapter: safeAdapter(item.adapter),
+      service: typeof item.service === 'string' ? item.service : undefined,
+      endpoint: typeof item.endpoint === 'string' ? item.endpoint : undefined,
       primary: item.primary === true,
       enabled: item.enabled !== false,
     };
@@ -156,6 +166,8 @@ export function toRows(response: VectorConfigResponse): VectorConfigRow[] {
       model: item.model,
       provider: item.provider,
       adapter: item.adapter ?? 'lancedb',
+      service: item.service,
+      endpoint: item.endpoint,
       primary: item.primary,
       enabled: item.enabled !== false,
       count: response.doc_counts?.[key],

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -184,6 +184,8 @@ export interface SettingsEmbedderCollection {
   model: string;
   provider: string;
   adapter?: string;
+  service?: string;
+  endpoint?: string;
   enabled?: boolean;
   primary?: boolean;
 }
@@ -220,6 +222,8 @@ export interface VectorConfigHealth {
   collection: string;
   adapter?: string;
   model?: string;
+  service?: string;
+  endpoint?: string;
   enabled?: boolean;
   error?: string;
 }

--- a/tests/frontend/api/update-vector-collection-provider.test.ts
+++ b/tests/frontend/api/update-vector-collection-provider.test.ts
@@ -7,12 +7,26 @@ describe('updateVectorCollection provider switching', () => {
   test('sends adapter, enabled, and provider fields to vector config API', async () => {
     const fetchMock = installFetch(() => jsonResponse({ success: true, source: 'file', config: { collections: {} } }));
 
-    await updateVectorCollection('bge-m3', { adapter: 'qdrant', enabled: false, provider: 'remote', model: 'bge-m3:latest' });
+    await updateVectorCollection('bge-m3', {
+      adapter: 'qdrant',
+      enabled: false,
+      provider: 'remote',
+      model: 'bge-m3:latest',
+      service: 'qdrant',
+      endpoint: 'http://localhost:6333',
+    });
 
     expect(VECTOR_PROVIDERS).toContain('remote');
     expect(fetchMock.calls[0]?.input).toBe('/api/v1/vector/config/bge-m3');
     expect(fetchMock.calls[0]?.init?.method).toBe('PUT');
-    expect(JSON.parse(String(fetchMock.calls[0]?.init?.body))).toEqual({ adapter: 'qdrant', enabled: false, provider: 'remote', model: 'bge-m3:latest' });
+    expect(JSON.parse(String(fetchMock.calls[0]?.init?.body))).toEqual({
+      adapter: 'qdrant',
+      enabled: false,
+      provider: 'remote',
+      model: 'bge-m3:latest',
+      service: 'qdrant',
+      endpoint: 'http://localhost:6333',
+    });
   });
 
   test('sends primary switch payload to vector config API', async () => {

--- a/tests/frontend/pages/settings-page-summary.test.tsx
+++ b/tests/frontend/pages/settings-page-summary.test.tsx
@@ -11,6 +11,6 @@ describe('SettingsPage summary', () => {
     expect(html).toContain('/menu /plugins /vector /mcp /settings');
     expect(html).toContain('Enable vector search');
     expect(html).toContain('Active vector adapters');
-    expect(html).toContain('Get current config, edit model/provider, switch adapters');
+    expect(html).toContain('Get current config, edit model/provider plus service endpoint, switch adapters');
   });
 });

--- a/tests/frontend/pages/vector-settings-helpers.test.ts
+++ b/tests/frontend/pages/vector-settings-helpers.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test';
+import { parseVectorConfigResponse, toRows } from '../../../frontend/src/pages/vectorSettingsHelpers';
+
+describe('vector settings helpers', () => {
+  test('preserves service registry endpoint metadata for proxy adapters', () => {
+    const rows = toRows(parseVectorConfigResponse({
+      source: 'file',
+      engine: 'proxy',
+      enabled: true,
+      config: {
+        version: '2',
+        host: '127.0.0.1',
+        port: 47778,
+        dataPath: '/tmp/vector',
+        embeddingEndpoint: '',
+        collections: {
+          turbo: {
+            collection: 'oracle_turbo',
+            model: 'bge-m3',
+            provider: 'ollama',
+            adapter: 'proxy',
+            service: 'turbovec',
+            endpoint: 'http://127.0.0.1:8082',
+          },
+        },
+      },
+      doc_counts: { turbo: 12 },
+      health: {},
+    }));
+
+    expect(rows).toMatchObject([{
+      key: 'turbo',
+      adapter: 'proxy',
+      service: 'turbovec',
+      endpoint: 'http://127.0.0.1:8082',
+      count: 12,
+    }]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add service and endpoint fields to the Vector config UI so proxy/Qdrant/TurboVec adapters can persist registry target metadata.
- Preserve service endpoint metadata through vector config frontend types/helpers and API update payloads.
- Fix standalone frontend tsc for ExportApp sync/async fetchers.

## Validation
- bunx tsc --noEmit
- cd frontend && bunx tsc --noEmit
- bun test tests/frontend
- bun test tests/http/vector/config-api.test.ts
- git diff --check origin/alpha...HEAD
- changed files <=250 lines

Refs #1595