### PR TITLE
feat(maw-plugin): return invoke exit codes

### DIFF
--- a/tests/tools/maw-plugin-arra/dual-surface.test.ts
+++ b/tests/tools/maw-plugin-arra/dual-surface.test.ts
@@ -52,4 +52,14 @@ describe('maw-plugin-arra dual surface contract', () => {
     expect(body.commands.map((item: { name: string }) => item.name))
       .toEqual(commandRegistry.map((item) => item.name));
   });
+
+  test('returns modern InvokeResult exit codes for dispatch failures', async () => {
+    const missing = await handler({ args: ['missing'] });
+    const failed = await handler({ args: ['vector-config', 'add', 'missing-model'] });
+
+    expect(missing).toMatchObject({ ok: false, exitCode: 2 });
+    expect(missing.error).toContain('maw arra');
+    expect(failed).toEqual({ ok: false, error: 'add requires --model <model>', exitCode: 1 });
+  });
+
 });

--- a/tests/tools/maw-plugin-arra/vector-config-ops.test.ts
+++ b/tests/tools/maw-plugin-arra/vector-config-ops.test.ts
@@ -43,7 +43,7 @@ describe('maw arra vector-config ops commands', () => {
 
   test('removes a vector collection config', async () => {
     const blocked = await run(['vector-config', 'remove', 'nomic'], { success: true, removed: 'nomic' });
-    expect(blocked.result).toEqual({ ok: false, error: 'remove requires --yes' });
+    expect(blocked.result).toEqual({ ok: false, error: 'remove requires --yes', exitCode: 1 });
     expect(blocked.calls).toEqual([]);
 
     const { result, calls } = await run(['vector-config', 'remove', 'nomic', '--yes'], { success: true, removed: 'nomic' });
@@ -71,6 +71,7 @@ describe('maw arra vector-config ops commands', () => {
 
     expect(result.ok).toBe(false);
     expect(result.error).toBe('add requires --model <model>');
+    expect(result.exitCode).toBe(1);
     expect(calls).toEqual([]);
   });
 });

--- a/tools/maw-plugin-arra/index.ts
+++ b/tools/maw-plugin-arra/index.ts
@@ -9,7 +9,7 @@ type InvokeContext = {
   writer?: (line?: string) => void;
 };
 
-type InvokeResult = { ok: boolean; output?: string; error?: string };
+type InvokeResult = { ok: boolean; output?: string; error?: string; exitCode?: number };
 type CommandHandler = (args: string[]) => Promise<string>;
 type RegistryCommand = {
   name: string;
@@ -123,13 +123,13 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
   }
 
   const run = commandHandlers[subcommand];
-  if (!run) return { ok: false, error: help() };
+  if (!run) return { ok: false, error: help(), exitCode: 2 };
 
   try {
     const output = await run(args.slice(1));
     if (ctx.writer) ctx.writer(output);
     return { ok: true, output: isApiLike(ctx.source) ? apiOutput(subcommand, output) : output };
   } catch (error) {
-    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    return { ok: false, error: error instanceof Error ? error.message : String(error), exitCode: 1 };
   }
 }


### PR DESCRIPTION
## Summary
- add explicit `exitCode` support to the canonical maw arra InvokeResult shape
- return exit code 2 for unknown subcommands and 1 for command execution failures
- cover failure shapes in dual-surface and vector-config tests

## Validation
- bun test tests/tools/maw-plugin-arra/
- bunx tsc --noEmit -p tools/maw-plugin-arra/tsconfig.json
- bunx tsc --noEmit
- git diff --check origin/alpha...HEAD
- wc -l tools/maw-plugin-arra/index.ts tests/tools/maw-plugin-arra/dual-surface.test.ts tests/tools/maw-plugin-arra/vector-config-ops.test.ts

Refs #1467