### PR TITLE
fix(frontend): link proxy-only plugin surfaces

### DIFF
--- a/frontend/src/pages/ExportApp.tsx
+++ b/frontend/src/pages/ExportApp.tsx
@@ -87,7 +87,7 @@ export function ExportApp({ initialBackendUrl = DEFAULT_BACKEND_URL, fetcher = g
     try {
       if (!fetcher) throw new Error('fetch is unavailable in this runtime.');
       const proxyPath = oracleV2CollectionsPath(normalized);
-      const proxy = await fetcher(backendApiUrl(DEFAULT_BACKEND_URL, proxyPath), { headers: { accept: 'application/json' } }).catch(() => null);
+      const proxy = await Promise.resolve(fetcher(backendApiUrl(DEFAULT_BACKEND_URL, proxyPath), { headers: { accept: 'application/json' } })).catch(() => null);
       if (proxy?.ok) {
         const next = normalizeExportAppCollections(await readExportPayload(proxy, proxyPath));
         setCollections(next);

--- a/frontend/src/pages/UnifiedPluginSurfaceOverview.tsx
+++ b/frontend/src/pages/UnifiedPluginSurfaceOverview.tsx
@@ -80,20 +80,21 @@ export function pluginCapabilityLinks(plugins: PluginEntry[]): Array<{ label: st
   ]);
 }
 
-export function pluginServerRows(plugins: PluginEntry[]): Array<{ name: string; status: string; health: string }> {
+export function pluginServerRows(plugins: PluginEntry[]): Array<{ name: string; status: string; health: string; surface: 'server' | 'proxy' }> {
   return plugins
     .filter((plugin) => plugin.server || plugin.proxy?.length)
     .map((plugin) => ({
       name: plugin.name,
       status: plugin.status ?? 'ok',
       health: plugin.server?.healthPath ?? plugin.proxy?.[0]?.path ?? 'proxy route',
+      surface: plugin.server ? 'server' : 'proxy',
     }));
 }
 
 export function pluginServerLinks(plugins: PluginEntry[]): Array<{ label: string; href: string }> {
   return pluginServerRows(plugins).map((server) => ({
     label: `${server.name} · ${server.status} · ${server.health}`,
-    href: pluginInventoryPath({ q: server.name, surface: 'server' }),
+    href: pluginInventoryPath({ q: server.name, surface: server.surface }),
   }));
 }
 

--- a/tests/frontend/pages/unified-plugin-overview.test.tsx
+++ b/tests/frontend/pages/unified-plugin-overview.test.tsx
@@ -22,10 +22,23 @@ describe('UnifiedPluginSurfaceOverview', () => {
       mcpTools: [{ name: 'echo_tool', description: 'Echo', inputSchema: {}, source: 'plugin', readOnly: true }],
       cliSubcommands: [{ command: 'echo', help: 'Echo input' }],
       exportFormats: [{ extension: 'echo' }],
+    }, {
+      name: 'proxy-only',
+      file: '',
+      size: 0,
+      modified: 'now',
+      status: 'ok',
+      proxy: [{ path: '/api/plugins/proxy-only/server', targetEnv: 'PROXY_ONLY_URL' }],
     }];
 
-    expect(pluginServerRows(plugins)).toEqual([{ name: 'echo', status: 'ok', health: '/health' }]);
-    expect(pluginServerLinks(plugins)).toEqual([{ label: 'echo · ok · /health', href: '/plugins?q=echo&surface=server' }]);
+    expect(pluginServerRows(plugins)).toEqual([
+      { name: 'echo', status: 'ok', health: '/health', surface: 'server' },
+      { name: 'proxy-only', status: 'ok', health: '/api/plugins/proxy-only/server', surface: 'proxy' },
+    ]);
+    expect(pluginServerLinks(plugins)).toEqual([
+      { label: 'echo · ok · /health', href: '/plugins?q=echo&surface=server' },
+      { label: 'proxy-only · ok · /api/plugins/proxy-only/server', href: '/plugins?q=proxy-only&surface=proxy' },
+    ]);
     expect(pluginCapabilityRows(plugins)).toContain('echo api GET /api/plugins/echo/ping');
     expect(pluginCapabilityRows(plugins)).toContain('echo mcp echo_tool read-only');
     expect(pluginCapabilityLinks(plugins)).toContainEqual({
@@ -49,6 +62,7 @@ describe('UnifiedPluginSurfaceOverview', () => {
     expect(html).toContain('href="/plugins?surface=mcp"');
     expect(html).toContain('href="/plugins?surface=server"');
     expect(html).toContain('href="/plugins?q=echo&amp;surface=server"');
+    expect(html).toContain('href="/plugins?q=proxy-only&amp;surface=proxy"');
     expect(html).toContain('href="/mcp/tools/echo_tool"');
     expect(html).toContain('href="/plugins?q=%2Fapi%2Fplugins%2Fecho%2Fping&amp;surface=apiRoutes"');
   });


### PR DESCRIPTION
## Summary\n- route proxy-only plugin server rows to the proxy surface filter instead of the server filter\n- cover proxy-only unified-plugin overview links in frontend tests\n- fix the frontend tsc fetcher union by wrapping the optional export proxy fetch in Promise.resolve\n\n## Validation\n- bunx tsc --noEmit\n- cd frontend && bunx tsc --noEmit\n- bun test tests/frontend\n- files <=250 lines