### PR TITLE
feat(export): record app exports in history

### DIFF
--- a/src/routes/export/app.ts
+++ b/src/routes/export/app.ts
@@ -10,6 +10,7 @@ import { createExportStatsRoutes } from './stats.ts';
 import { createExportTestConnectionRoutes } from './test-connection.ts';
 import { rememberExportProgress } from './progress.ts';
 import { canReadTenantResource, currentExportTenantId, tenantScopedOutputDir, tenantWhereFor } from './tenant.ts';
+import { recordExportHistory } from './history-store.ts';
 
 type ExportRecord = Record<string, unknown>;
 type BaseExportFormat = 'json' | 'csv' | 'markdown';
@@ -223,6 +224,7 @@ export function createExportAppRoutes(deps: ExportAppDeps = {}) {
         createdAt: (deps.now?.() ?? new Date()).toISOString(),
       };
       jobs.set(jobId, job);
+      recordExportHistory({ id: jobId, tenantId, collection: job.collection, format: job.format, timestamp: Date.parse(job.createdAt), status: 'completed' });
       rememberExportProgress({ id: jobId, jobId, tenantId, status: 'completed', progress: 100, updatedAt: job.createdAt, downloadUrl, filename, fileSizeEstimate: sizeBytes, sizeBytes });
       return { ...job, filePath: undefined, status: 'completed', progress: 100, downloadUrl };
     }, {

--- a/src/routes/export/history-store.ts
+++ b/src/routes/export/history-store.ts
@@ -1,0 +1,22 @@
+import { db, exportJobs } from '../../db/index.ts';
+import { DEFAULT_TENANT_ID } from '../../middleware/tenant.ts';
+
+export interface ExportHistoryRecord {
+  id: string;
+  tenantId?: string | null;
+  collection: string;
+  format: string;
+  timestamp: number;
+  status: string;
+}
+
+export function recordExportHistory(job: ExportHistoryRecord): void {
+  db.insert(exportJobs).values({
+    id: job.id,
+    tenantId: job.tenantId ?? DEFAULT_TENANT_ID,
+    collection: job.collection,
+    format: job.format,
+    timestamp: job.timestamp,
+    status: job.status,
+  }).run();
+}

--- a/src/routes/export/history.ts
+++ b/src/routes/export/history.ts
@@ -12,6 +12,7 @@ import { formatOracleV2DocumentsCsv } from './oracle-v2-csv.ts';
 import { formatOracleV2DocumentsMarkdown } from './oracle-v2-markdown.ts';
 import { rememberExportProgress } from './progress.ts';
 import { canReadTenantResource } from './tenant.ts';
+import { recordExportHistory } from './history-store.ts';
 
 function clean(value: string): string {
   return value.trim();
@@ -23,10 +24,6 @@ function safeName(value: string): string {
 
 function oracleV2Url(body: { oracleV2Url?: string; baseUrl?: string }): string | undefined {
   return (body.oracleV2Url ?? body.baseUrl)?.trim() || undefined;
-}
-
-function insertJob(job: ExportHistoryJob): void {
-  db.insert(exportJobs).values(job).run();
 }
 
 function oracleV2Extension(format: string): string {
@@ -149,7 +146,7 @@ export function createExportHistoryRoutes() {
         timestamp: Date.now(),
         status,
       };
-      insertJob(job);
+      recordExportHistory(job);
 
       if (baseUrl) {
         try {

--- a/tests/http/export/app.test.ts
+++ b/tests/http/export/app.test.ts
@@ -20,10 +20,6 @@ const { createExportProgressResponse, readRememberedExportProgress } = await imp
 const { createDatabase, oracleDocuments, supersedeLog, traceLog, resetDefaultDatabaseForTests } = dbModule;
 const connection = createDatabase(dbPath);
 
-function restoreDbPath() {
-  return savedDbPath ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
-}
-
 function seed() {
   const now = 1_766_000_000_000;
   connection.db.insert(oracleDocuments).values([
@@ -80,7 +76,7 @@ afterAll(() => {
   else process.env.ORACLE_DATA_DIR = savedDataDir;
   if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
   else process.env.ORACLE_DB_PATH = savedDbPath;
-  resetDefaultDatabaseForTests(restoreDbPath());
+  resetDefaultDatabaseForTests(':memory:');
   rmSync(root, { recursive: true, force: true });
 });
 

--- a/tests/http/export/core.test.ts
+++ b/tests/http/export/core.test.ts
@@ -19,10 +19,6 @@ const { createExportCoreRoutes } = await import('../../../src/routes/export/core
 const { createDatabase, oracleDocuments, resetDefaultDatabaseForTests } = dbModule;
 const connection = createDatabase(dbPath);
 
-function restoreDbPath() {
-  return savedDbPath ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
-}
-
 function seed() {
   const now = 1_766_000_000_000;
   connection.db.insert(oracleDocuments).values([
@@ -70,7 +66,7 @@ afterAll(() => {
   else process.env.ORACLE_DATA_DIR = savedDataDir;
   if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
   else process.env.ORACLE_DB_PATH = savedDbPath;
-  resetDefaultDatabaseForTests(restoreDbPath());
+  resetDefaultDatabaseForTests(':memory:');
   rmSync(root, { recursive: true, force: true });
 });
 

--- a/tests/http/export/integration.test.ts
+++ b/tests/http/export/integration.test.ts
@@ -21,9 +21,6 @@ const { createLearnCrudRoutes } = await import('../../../src/routes/learn/index.
 const { createExportAppRoutes } = await import('../../../src/routes/export/app.ts');
 const { exportRoutes } = await import('../../../src/routes/export/index.ts');
 
-const restoreDbPath = savedDbPath
-  ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
-
 const app = new Elysia({ prefix: '/api' })
   .use(createLearnCrudRoutes())
   .use(createExportAppRoutes());
@@ -54,6 +51,7 @@ async function seedLearnings(): Promise<void> {
 }
 
 interface ExportJobResponse {
+  jobId: string;
   downloadUrl: string;
   filename: string;
   rowCount: number;
@@ -90,7 +88,7 @@ afterAll(() => {
   else process.env.ORACLE_DB_PATH = savedDbPath;
   if (savedRepoRoot === undefined) delete process.env.ORACLE_REPO_ROOT;
   else process.env.ORACLE_REPO_ROOT = savedRepoRoot;
-  dbMod.resetDefaultDatabaseForTests(restoreDbPath);
+  dbMod.resetDefaultDatabaseForTests(':memory:');
   rmSync(root, { recursive: true, force: true });
 });
 
@@ -109,6 +107,10 @@ describe('POST /api/v1/export/app/run', () => {
       'Alpha export integration body',
       'Bravo export integration body',
     ]));
+
+    const historyRes = await createApiVersionedFetch((next) => exportRoutes.handle(next))(new Request('http://local/api/v1/export/history'));
+    const history = await historyRes.json() as { jobs: Array<Record<string, unknown>> };
+    expect(history.jobs[0]).toMatchObject({ id: jsonExport.job.jobId, collection: 'learn_log', format: 'json', status: 'completed' });
 
     const csvExport = await exportCollection('csv');
     const csv = await csvExport.download.text();

--- a/tests/http/export/stats.test.ts
+++ b/tests/http/export/stats.test.ts
@@ -21,10 +21,6 @@ const { createDatabase, oracleDocuments, supersedeLog, traceLog, resetDefaultDat
 const connection = createDatabase(dbPath);
 const lastExport = new Date('2026-02-03T04:05:06.007Z');
 
-function restoreDbPath() {
-  return savedDbPath ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
-}
-
 function seed() {
   const now = 1_766_000_000_000;
   connection.db.insert(oracleDocuments).values([
@@ -62,7 +58,7 @@ afterAll(() => {
   else process.env.ORACLE_DATA_DIR = savedDataDir;
   if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
   else process.env.ORACLE_DB_PATH = savedDbPath;
-  resetDefaultDatabaseForTests(restoreDbPath());
+  resetDefaultDatabaseForTests(':memory:');
   rmSync(root, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
## Summary
- persist `/api/export/app/run` jobs into the export history table
- share a small history-store helper between export-app and legacy history routes
- assert app exports appear in `/api/export/history` and stabilize export test DB teardown

Refs #1783

## Validation
- bun test tests/http/export/
- bunx tsc --noEmit
- wc -l src/routes/export/app.ts src/routes/export/history.ts src/routes/export/history-store.ts tests/http/export/app.test.ts tests/http/export/core.test.ts tests/http/export/integration.test.ts tests/http/export/stats.test.ts