### PR TITLE
feat: add maw plugin MCP-in client

### DIFF
--- a/maw-plugin/README.md
+++ b/maw-plugin/README.md
@@ -16,6 +16,9 @@ The manifest exposes `oracle_arra_read` as an MCP-out tool. It reuses the same
 command core as CLI/menu/API and only advertises read-only commands; write verbs
 stay on the CLI/API surface where auth headers are explicit.
 
+For MCP-in, `maw arra mcp-call` posts a JSON-RPC `tools/call` request to `--url`
+or `ARRA_MCP_URL` without adding a hard dependency on a specific MCP server.
+
 ## Build artifact
 
 The repo-local manifest declares `target: "js"` and keeps `artifact.sha256` pinned to
@@ -102,6 +105,7 @@ maw arra schedule --status pending --limit 10
 maw arra schedule-add "daily standup" --date 2026-06-16
 maw arra vault-sync --dry-run --reindex
 maw arra mcp-tools
+maw arra mcp-call remote_search --url http://127.0.0.1:8080/mcp --arg q=oracle
 maw arra verify --check false --type learning
 ```
 

--- a/maw-plugin/__tests__/mcp-client.test.ts
+++ b/maw-plugin/__tests__/mcp-client.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+import { runArra } from '../index.ts';
+import { runMcpCall } from '../mcp-client.ts';
+
+describe('maw arra MCP-in client', () => {
+  test('requires an explicit or configured MCP endpoint', async () => {
+    const result = await runMcpCall(['remote_search'], {});
+
+    expect(result).toEqual({ ok: false, error: 'MCP endpoint required: pass --url or set ARRA_MCP_URL' });
+  });
+
+  test('accepts the tool after flags', async () => {
+    const fetcher = (async () => new Response(JSON.stringify({ result: { ok: true } }))) as typeof fetch;
+    const result = await runMcpCall(['--url', 'http://mcp.test/rpc', 'remote_stats'], {}, fetcher);
+
+    expect(result.ok).toBe(true);
+  });
+
+  test('posts JSON-RPC tools/call payloads and renders text results', async () => {
+    const calls: Array<{ url: string; body: unknown }> = [];
+    const fetcher = (async (url: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ url: String(url), body: JSON.parse(String(init?.body)) });
+      return new Response(JSON.stringify({ result: { content: [{ type: 'text', text: 'found oracle' }] } }));
+    }) as typeof fetch;
+
+    const result = await runMcpCall(['remote_search', '--url', 'http://mcp.test/rpc', '--arg', 'q=oracle', '--arg', 'limit=3'], {}, fetcher);
+
+    expect(result).toEqual({ ok: true, output: 'found oracle' });
+    expect(calls).toEqual([{ url: 'http://mcp.test/rpc', body: { jsonrpc: '2.0', id: 'arra-maw-plugin', method: 'tools/call', params: { name: 'remote_search', arguments: { q: 'oracle', limit: '3' } } } }]);
+  });
+
+  test('dispatches mcp-call through the shared CLI command core', async () => {
+    const oldFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response(JSON.stringify({ result: { answer: 42 } }))) as typeof fetch;
+    try {
+      const result = await runArra(['mcp-call', 'remote_stats'], async () => ({}), () => {}, { ARRA_MCP_URL: 'http://mcp.test/rpc' });
+
+      expect(result.ok).toBe(true);
+      expect(result.output).toContain('42');
+    } finally {
+      globalThis.fetch = oldFetch;
+    }
+  });
+});

--- a/maw-plugin/index.ts
+++ b/maw-plugin/index.ts
@@ -4,6 +4,7 @@ import { apiArgsToCliArgs } from './api.ts';
 import { resolveServePort, runServe, type ServeDeps } from './serve.ts';
 import { LOCAL_CLI_HELP, resolveLocalCliName, runLocalCli } from './local-cli.ts';
 import { runVectorConfig, VECTOR_CONFIG_HELP } from './vector-config.ts';
+import { MCP_CLIENT_HELP, runMcpCall } from './mcp-client.ts';
 type InvokeContext = { source?: string; args?: string[] | Record<string, unknown>; writer?: (...args: unknown[]) => void };
 type InvokeResult = { ok: boolean; output?: string; error?: string };
 type Requester = (path: string, init?: RequestInit) => Promise<unknown>;
@@ -176,7 +177,7 @@ export const COMMANDS: Record<string, Spec> = {
   verify: { tool: 'oracle_verify', method: 'POST', write: true, help: 'verify [--check true|false] [--type all|learning|pattern]', build: p => route('/api/verify', undefined, { check: b(p, 'check'), type: f(p, 'type') }), format: d => `arra verify: ${preview(d, 500)}` },
 };
 
-const LOCAL_COMMANDS = { commands: 'commands', frontend: 'frontend [--no-open]', ui: 'ui [--no-open]', open: 'open [--no-open]', serve: 'serve [--stop|--status] [--port N]', server: 'server [start|stop|status]', studio: 'studio [--port N]', ...LOCAL_CLI_HELP } as const;
+const LOCAL_COMMANDS = { commands: 'commands', mcp_call: MCP_CLIENT_HELP, frontend: 'frontend [--no-open]', ui: 'ui [--no-open]', open: 'open [--no-open]', serve: 'serve [--stop|--status] [--port N]', server: 'server [start|stop|status]', studio: 'studio [--port N]', ...LOCAL_CLI_HELP } as const;
 const MCP_COMMANDS = new Set(['commands', ...Object.entries(COMMANDS).filter(([name, spec]) => name !== 'vector_config' && !spec.write && spec.method === 'GET').map(([name]) => name)]);
 function usage(): InvokeResult {
   const commandNames = [...Object.keys(COMMANDS), ...Object.keys(LOCAL_COMMANDS)].sort();
@@ -219,6 +220,7 @@ export async function runArra(args: string[], request: Requester = requestJson, 
   if (sub === 'commands') return registryPayload('cli');
   if (sub === 'frontend' || sub === 'ui' || sub === 'open') return runFrontend(parsed, opener, env);
   if (sub === 'studio') return runStudio(parsed, runner, env);
+  if (sub === 'mcp_call') return runMcpCall(args.slice(1), env);
   if (sub === 'serve' || sub === 'server') return runServe(parsed, runner, env, serveDeps);
   if (resolveLocalCliName(sub)) return runLocalCli(sub, args.slice(1), runner, env);
   if (sub === 'vector_config') return runVectorConfig(parsed, request, authHeaders);

--- a/maw-plugin/mcp-client.ts
+++ b/maw-plugin/mcp-client.ts
@@ -1,0 +1,83 @@
+type Fetcher = typeof fetch;
+type InvokeResult = { ok: boolean; output?: string; error?: string };
+type ParsedMcp = { tool: string; url: string; input: Record<string, unknown> };
+
+type Env = Record<string, string | undefined>;
+
+export const MCP_CLIENT_HELP = 'mcp-call <tool> [--url URL] [--json JSON|--arg k=v]';
+
+function flagValue(args: string[], name: string): string | undefined {
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+
+function firstPositional(args: string[]): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    if (args[i].startsWith('--')) {
+      if (args[i + 1] && !args[i + 1].startsWith('--')) i++;
+      continue;
+    }
+    return args[i];
+  }
+}
+
+function envUrl(env: Env): string | undefined {
+  return env.ARRA_MCP_URL || env.ORACLE_MCP_URL || env.MCP_SERVER_URL;
+}
+
+function parseJson(value: string | undefined): Record<string, unknown> {
+  if (!value) return {};
+  const data = JSON.parse(value);
+  if (!data || typeof data !== 'object' || Array.isArray(data)) throw new Error('--json must be an object');
+  return data as Record<string, unknown>;
+}
+
+function parseArgs(values: string[]): Record<string, unknown> {
+  const input: Record<string, unknown> = {};
+  for (const value of values) {
+    const at = value.indexOf('=');
+    if (at <= 0) throw new Error('--arg must be key=value');
+    input[value.slice(0, at)] = value.slice(at + 1);
+  }
+  return input;
+}
+
+function parseMcp(args: string[], env: Env): ParsedMcp {
+  const tool = flagValue(args, '--tool') || firstPositional(args);
+  if (!tool) throw new Error('MCP tool name required');
+  const url = flagValue(args, '--url') || flagValue(args, '--endpoint') || envUrl(env);
+  if (!url) throw new Error('MCP endpoint required: pass --url or set ARRA_MCP_URL');
+  const json = parseJson(flagValue(args, '--json'));
+  const argValues = args.flatMap((arg, index) => arg === '--arg' && args[index + 1] ? [args[index + 1]] : []);
+  return { tool, url, input: { ...json, ...parseArgs(argValues) } };
+}
+
+function formatMcpResponse(data: unknown): string {
+  const payload = data && typeof data === 'object' && 'result' in data ? (data as { result: unknown }).result : data;
+  if (payload && typeof payload === 'object' && Array.isArray((payload as { content?: unknown }).content)) {
+    const text = (payload as { content: Array<{ text?: unknown }> }).content
+      .map((item) => typeof item.text === 'string' ? item.text : '')
+      .filter(Boolean);
+    if (text.length) return text.join('\n');
+  }
+  return JSON.stringify(payload, null, 2);
+}
+
+export async function runMcpCall(args: string[], env: Env = process.env, fetcher: Fetcher = fetch): Promise<InvokeResult> {
+  try {
+    const parsed = parseMcp(args, env);
+    const res = await fetcher(parsed.url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 'arra-maw-plugin', method: 'tools/call', params: { name: parsed.tool, arguments: parsed.input } }),
+    });
+    const text = await res.text();
+    const data = text ? JSON.parse(text) : null;
+    if (!res.ok) throw new Error(`HTTP ${res.status}: ${text}`);
+    if (data?.error) throw new Error(typeof data.error === 'string' ? data.error : JSON.stringify(data.error));
+    return { ok: true, output: formatMcpResponse(data) };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}

--- a/maw-plugin/package.json
+++ b/maw-plugin/package.json
@@ -12,6 +12,7 @@
     "index.ts",
     "api.ts",
     "local-cli.ts",
+    "mcp-client.ts",
     "serve.ts",
     "vector-config.ts"
   ]

--- a/maw-plugin/plugin.json
+++ b/maw-plugin/plugin.json
@@ -10,7 +10,7 @@
     "aliases": [
       "or"
     ],
-    "help": "maw arra <commands|backup|canvas-plugins|canvas-serve|changelog|completions|config|doctor|export|export-obsidian|huginn|import|import-obsidian|migrate|peers|plugin|release|seed|session|use|vault|frontend|ui|open|serve|server|studio|search|learn|stats|health|index|scan|plugins|settings|feed|menu|vector|vector-config|vector_index|vector_status|vector_stop|vector_models|trace|trace_list|trace_get|trace_link|trace_unlink|trace_chain|concepts|handoff|inbox|list|read|reflect|supersede|supersede_list|supersede_chain|thread|thread_read|thread_update|threads|schedule|schedule_add|vault_sync|mcp_tools|verify>"
+    "help": "maw arra <commands|backup|canvas-plugins|canvas-serve|changelog|completions|config|doctor|export|export-obsidian|huginn|import|import-obsidian|migrate|peers|plugin|release|seed|session|use|vault|frontend|ui|open|serve|server|studio|search|learn|stats|health|index|scan|plugins|settings|feed|menu|vector|vector-config|vector_index|vector_status|vector_stop|vector_models|trace|trace_list|trace_get|trace_link|trace_unlink|trace_chain|concepts|handoff|inbox|list|read|reflect|supersede|supersede_list|supersede_chain|thread|thread_read|thread_update|threads|schedule|schedule_add|vault_sync|mcp_tools|mcp-call|verify>"
   },
   "capabilities": [
     "net:http",
@@ -19,7 +19,7 @@
   ],
   "weight": 50,
   "schemaVersion": 1,
-  "help": "maw arra <commands|backup|canvas-plugins|canvas-serve|changelog|completions|config|doctor|export|export-obsidian|huginn|import|import-obsidian|migrate|peers|plugin|release|seed|session|use|vault|frontend|ui|open|serve|server|studio|search|learn|stats|health|index|scan|plugins|settings|feed|menu|vector|vector-config|vector_index|vector_status|vector_stop|vector_models|trace|trace_list|trace_get|trace_link|trace_unlink|trace_chain|concepts|handoff|inbox|list|read|reflect|supersede|supersede_list|supersede_chain|thread|thread_read|thread_update|threads|schedule|schedule_add|vault_sync|mcp_tools|verify>",
+  "help": "maw arra <commands|backup|canvas-plugins|canvas-serve|changelog|completions|config|doctor|export|export-obsidian|huginn|import|import-obsidian|migrate|peers|plugin|release|seed|session|use|vault|frontend|ui|open|serve|server|studio|search|learn|stats|health|index|scan|plugins|settings|feed|menu|vector|vector-config|vector_index|vector_status|vector_stop|vector_models|trace|trace_list|trace_get|trace_link|trace_unlink|trace_chain|concepts|handoff|inbox|list|read|reflect|supersede|supersede_list|supersede_chain|thread|thread_read|thread_update|threads|schedule|schedule_add|vault_sync|mcp_tools|mcp-call|verify>",
   "api": {
     "path": "/api/arra",
     "methods": [
@@ -30,7 +30,8 @@
   "config": {
     "dbBackend": "http",
     "embedderBackend": "none",
-    "apiBase": "http://localhost:47778"
+    "apiBase": "http://localhost:47778",
+    "mcpServerUrl": ""
   },
   "configSchema": {
     "type": "object",
@@ -51,6 +52,9 @@
         "type": "string"
       },
       "remoteEmbedderUrl": {
+        "type": "string"
+      },
+      "mcpServerUrl": {
         "type": "string"
       }
     },
@@ -74,7 +78,7 @@
   ],
   "artifact": {
     "path": "./index.ts",
-    "sha256": "ff8251c42ce5854f6d19deeb7d9fa2a54ca2caf5bc128182aba50c0dbdcbf9b5"
+    "sha256": "615c401bd7c31aabc710d3fab246b0dfc0260db72727dbff07e20187b94a0703"
   },
   "mcpTools": [
     {


### PR DESCRIPTION
## Summary
- add `maw arra mcp-call` for optional MCP-in JSON-RPC `tools/call` requests
- document `ARRA_MCP_URL`/`--url` usage and expose `mcpServerUrl` in plugin config
- include source files in plugin package metadata and cover parsing/dispatch behavior

## Validation
- bun test maw-plugin/__tests__ tests/tools/maw-plugin-arra/
- bunx tsc --noEmit
- targeted maw-plugin/tools plugin tsc
- git diff --check
- changed files <=250 lines

Refs #1467