### PR TITLE
feat(export-app): guard non-empty backup output

### DIFF
--- a/tests/tools/export-app/output-safety.test.ts
+++ b/tests/tools/export-app/output-safety.test.ts
@@ -1,0 +1,42 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseArgs, runExportApp, validateCliOptions } from '../../../tools/export-app/index.ts';
+
+const root = mkdtempSync(join(tmpdir(), 'arra-export-output-safety-'));
+const dbPath = join(root, 'oracle.db');
+const outputDir = join(root, 'backup');
+writeFileSync(dbPath, '');
+mkdirSync(outputDir);
+writeFileSync(join(outputDir, 'stale.json'), '{"old":true}\n');
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('export app output directory safety', () => {
+  test('rejects non-empty backup directories by default', async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const code = await runExportApp(
+      ['--output', outputDir, '--db', dbPath],
+      (message) => stdout.push(message),
+      (message) => stderr.push(message),
+    );
+
+    expect(code).toBe(1);
+    expect(stdout.join('')).toBe('');
+    expect(stderr.join('')).toContain('output directory is not empty');
+    expect(stderr.join('')).toContain('--allow-nonempty-output');
+  });
+
+  test('allows explicit non-empty output override and dry-run validation', () => {
+    expect(parseArgs(['--output', outputDir, '--allow-nonempty-output']))
+      .toMatchObject({ allowNonemptyOutput: true });
+    expect(() => validateCliOptions(parseArgs(['--output', outputDir, '--db', dbPath, '--allow-nonempty-output'])))
+      .not.toThrow();
+    expect(() => validateCliOptions(parseArgs(['--output', outputDir, '--db', dbPath, '--dry-run']), { willWrite: false }))
+      .not.toThrow();
+  });
+});

--- a/tools/export-app/README.md
+++ b/tools/export-app/README.md
@@ -73,12 +73,17 @@ bun run tools/export-app/index.ts --output ./backup/docs --collection oracle_doc
 bun run tools/export-app/index.ts --output ./backup/export-app --dry-run
 bun run tools/export-app/index.ts --output ./backup/export-app --progress json
 bun run tools/export-app/index.ts --verify ./backup/export-app
+bun run tools/export-app/index.ts --output ./backup/export-app --allow-nonempty-output
 ```
 
 Use `--dry-run` to print collection, row, relationship, and document counts
 without creating files. It is a safe preflight before long-running exports.
 Use `--collection <name>` repeatedly or `--collections a,b` to write only
 selected Drizzle collections when testing a narrow migration path.
+By default, batch export refuses to write into a non-empty output directory so
+old artifacts cannot be mistaken for a fresh backup. Use
+`--allow-nonempty-output` only when a wrapper has already cleaned or isolated
+the bundle path.
 
 The batch output includes:
 

--- a/tools/export-app/index.ts
+++ b/tools/export-app/index.ts
@@ -1,4 +1,4 @@
-import { existsSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, statSync } from 'node:fs';
 import { DB_PATH } from '../../src/config.ts';
 import { exportOracleData, type ExportProgressEvent } from './exporter.ts';
 import { previewOracleExport } from './summary.ts';
@@ -16,6 +16,7 @@ interface CliOptions {
   dryRun: boolean;
   verifyDir?: string;
   collections: string[];
+  allowNonemptyOutput: boolean;
 }
 
 function flagValue(args: string[], index: number, flag: string): string {
@@ -40,6 +41,7 @@ export function parseArgs(args: string[]): CliOptions {
   let dryRun = false;
   let verifyDir: string | undefined;
   let collections: string[] = [];
+  let allowNonemptyOutput = false;
 
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i]!;
@@ -65,13 +67,14 @@ export function parseArgs(args: string[]): CliOptions {
     if (arg === '--quiet' || arg === '--no-progress') { quiet = true; continue; }
     if (arg === '--progress-json') { progressMode = 'json'; continue; }
     if (arg === '--dry-run') { dryRun = true; continue; }
+    if (arg === '--allow-nonempty-output') { allowNonemptyOutput = true; continue; }
     if (arg === '--help' || arg === '-h') continue;
     throw new Error(arg.startsWith('-') ? `unknown flag: ${arg}` : `unexpected argument: ${arg}`);
   }
 
   if (verifyDir && outputDir) throw new Error('--verify cannot be combined with --output');
   if (!outputDir && !verifyDir) throw new Error('missing required --output <dir>');
-  return { outputDir: outputDir ?? verifyDir!, dbPath, quiet, progressMode, dryRun, verifyDir, collections };
+  return { outputDir: outputDir ?? verifyDir!, dbPath, quiet, progressMode, dryRun, verifyDir, collections, allowNonemptyOutput };
 }
 
 function readProgressMode(value: string): ProgressMode {
@@ -86,15 +89,19 @@ function requireFile(path: string): void {
   if (!statSync(path).isFile()) throw new Error(`database path is not a file: ${path}`);
 }
 
-function requireOutputTarget(path: string): void {
+function requireOutputTarget(path: string, requireEmpty: boolean): void {
   if (existsSync(path) && !statSync(path).isDirectory()) {
     throw new Error(`output path exists but is not a directory: ${path}`);
   }
+  if (requireEmpty && existsSync(path) && readdirSync(path).length > 0) {
+    throw new Error(`output directory is not empty: ${path}. Choose a new backup directory or pass --allow-nonempty-output.`);
+  }
 }
 
-export function validateCliOptions(options: CliOptions): void {
+export function validateCliOptions(options: CliOptions, validation: { willWrite?: boolean } = {}): void {
   requireFile(options.dbPath ?? DB_PATH);
-  requireOutputTarget(options.outputDir);
+  const willWrite = validation.willWrite ?? true;
+  requireOutputTarget(options.outputDir, willWrite && !options.allowNonemptyOutput);
 }
 
 function printHelp(write: Writer): void {
@@ -110,6 +117,8 @@ function printHelp(write: Writer): void {
     '  --progress <mode>    progress output: text, json, or silent',
     '  --dry-run            print collection counts without writing files',
     '  --verify <dir>       verify manifest file sizes and SHA-256 checksums',
+    '  --allow-nonempty-output',
+    '                       permit writing into a non-empty backup directory',
     '  --quiet              suppress progress output',
     '  --no-progress        alias for --quiet',
     '  --progress-json      emit progress as JSON lines on stderr',
@@ -143,7 +152,7 @@ export async function runExportApp(args: string[], stdout: Writer = process.stdo
       stdout(`${JSON.stringify({ success: result.ok, verified: result.ok, ...result }, null, 2)}\n`);
       return result.ok ? 0 : 1;
     }
-    validateCliOptions(options);
+    validateCliOptions(options, { willWrite: !options.dryRun });
     if (options.dryRun) {
       stdout(`${JSON.stringify({ success: true, dryRun: true, ...previewOracleExport({ dbPath: options.dbPath, collections: options.collections }) }, null, 2)}\n`);
       return 0;


### PR DESCRIPTION
Refs #1783

## Summary
- refuse non-empty standalone export-app output directories by default so stale artifacts cannot be mistaken for a fresh migration backup
- add explicit `--allow-nonempty-output` override for wrappers that already isolate/clean bundle paths
- document the output-safety behavior and add regression coverage

## Verification
- git fetch origin && git rebase origin/alpha
- bunx tsc --noEmit
- bun test tests/tools/export-app/output-safety.test.ts tests/tools/export-app.test.ts tests/tools/export-app/ tests/frontend/pages/export-app.test.tsx
- git diff --check
- wc -l tools/export-app/index.ts tools/export-app/README.md tests/tools/export-app/output-safety.test.ts

## Note
- `bun test tests/http/export/` still surfaces pre-existing shared DB migration reset errors unrelated to this standalone CLI output-safety slice.