### PR TITLE
feat(frontend): summarize vector config health

### DIFF
--- a/frontend/src/components/VectorConfigHealthSummary.tsx
+++ b/frontend/src/components/VectorConfigHealthSummary.tsx
@@ -1,0 +1,82 @@
+import type { SettingsEmbedderCollection, VectorConfigHealth } from '../types';
+
+type Collections = Record<string, SettingsEmbedderCollection>;
+type HealthMap = Record<string, VectorConfigHealth>;
+
+export type VectorConfigHealthStats = {
+  total: number;
+  enabled: number;
+  healthy: number;
+  down: number;
+  disabled: number;
+  summary: string;
+};
+
+function isEnabled(collection: SettingsEmbedderCollection): boolean {
+  return collection.enabled !== false;
+}
+
+function rowEndpoint(collection: SettingsEmbedderCollection, health?: VectorConfigHealth): string {
+  return collection.endpoint || health?.endpoint || 'no endpoint configured';
+}
+
+function rowAdapter(collection: SettingsEmbedderCollection, health?: VectorConfigHealth): string {
+  return collection.adapter || health?.adapter || 'lancedb';
+}
+
+export function vectorConfigHealthStats(collections: Collections, health: HealthMap = {}): VectorConfigHealthStats {
+  const rows = Object.entries(collections);
+  const enabledRows = rows.filter(([, collection]) => isEnabled(collection));
+  const healthy = enabledRows.filter(([key]) => health[key]?.ok).length;
+  const disabled = rows.length - enabledRows.length;
+  const down = enabledRows.length - healthy;
+  return {
+    total: rows.length,
+    enabled: enabledRows.length,
+    healthy,
+    down,
+    disabled,
+    summary: `${healthy}/${enabledRows.length} enabled connections healthy · ${down} down · ${disabled} disabled`,
+  };
+}
+
+export function VectorConfigHealthSummary({
+  collections,
+  health = {},
+}: {
+  collections: Collections;
+  health?: HealthMap;
+}) {
+  const stats = vectorConfigHealthStats(collections, health);
+  const downRows = Object.entries(collections).filter(([key, collection]) => isEnabled(collection) && !health[key]?.ok);
+
+  return (
+    <section className="mt-5 rounded-2xl border border-white/10 bg-white/[0.03] p-4" aria-label="Vector connection health">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h4 className="font-semibold text-white">Connection health</h4>
+          <p className="mt-1 text-sm text-slate-400">{stats.summary}</p>
+        </div>
+        <p className="rounded-full border border-teal-300/20 px-3 py-1 text-xs font-semibold text-teal-100">{stats.total} configured</p>
+      </div>
+
+      {downRows.length ? (
+        <div className="mt-3 grid gap-2">
+          {downRows.map(([key, collection]) => {
+            const rowHealth = health[key];
+            const adapter = rowAdapter(collection, rowHealth);
+            return (
+              <article key={key} className="rounded-xl border border-rose-300/20 bg-rose-300/10 p-3 text-sm">
+                <p className="font-semibold text-rose-100">{key}: {adapter} connection down</p>
+                <p className="mt-1 text-slate-300">{rowEndpoint(collection, rowHealth)}</p>
+                <p className="mt-1 text-xs text-rose-200">{rowHealth?.error || `Start ${adapter} or update the service endpoint, then Test/Reload.`}</p>
+              </article>
+            );
+          })}
+        </div>
+      ) : (
+        <p className="mt-3 text-sm text-emerald-200">All enabled vector connections are healthy.</p>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/VectorConfigPanel.tsx
+++ b/frontend/src/components/VectorConfigPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { apiUrl, fetchVectorConfig, reloadVectorConfig, updateVectorCollection } from '../api';
 import { ErrorMessage, Spinner } from './AsyncState';
+import { VectorConfigHealthSummary } from './VectorConfigHealthSummary';
 import type { SettingsEmbedderCollection, VectorConfigResponse } from '../types';
 
 const ADAPTERS = ['lancedb', 'qdrant', 'chroma', 'sqlite-vec', 'cloudflare-vectorize', 'proxy', 'turbovec'] as const;
@@ -162,6 +163,7 @@ export function VectorConfigPanel() {
 
       {error ? <div className="mt-4"><ErrorMessage title="Vector config update failed." message={error} /></div> : null}
       {message ? <p className="mt-4 rounded-2xl border border-white/10 bg-slate-900/70 p-3 text-sm text-teal-100">{message}</p> : null}
+      {state ? <VectorConfigHealthSummary collections={state.config.collections} health={state.health} /> : null}
 
       <div className="mt-5 grid gap-3">
         {rows.map(([key, item]) => {

--- a/tests/frontend/components/vector-config-health-summary.test.tsx
+++ b/tests/frontend/components/vector-config-health-summary.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import { VectorConfigHealthSummary, vectorConfigHealthStats } from '../../../frontend/src/components/VectorConfigHealthSummary';
+import { htmlFor } from '../_render';
+
+const collections = {
+  bge: { key: 'bge', collection: 'oracle_bge', model: 'bge-m3', provider: 'ollama', adapter: 'lancedb' },
+  qdrant: {
+    key: 'qdrant',
+    collection: 'oracle_qdrant',
+    model: 'qwen3',
+    provider: 'remote',
+    adapter: 'qdrant',
+    endpoint: 'http://localhost:6333',
+  },
+  off: { key: 'off', collection: 'oracle_off', model: 'nomic', provider: 'none', adapter: 'lancedb', enabled: false },
+};
+
+const health = {
+  bge: { ok: true, status: 'ok', collection: 'oracle_bge', adapter: 'lancedb', model: 'bge-m3' },
+  qdrant: {
+    ok: false,
+    status: 'down',
+    collection: 'oracle_qdrant',
+    adapter: 'qdrant',
+    model: 'qwen3',
+    error: 'connection refused',
+  },
+};
+
+describe('VectorConfigHealthSummary', () => {
+  test('summarizes healthy, down, and disabled vector connections', () => {
+    expect(vectorConfigHealthStats(collections, health).summary).toBe('1/2 enabled connections healthy · 1 down · 1 disabled');
+
+    const html = htmlFor(<VectorConfigHealthSummary collections={collections} health={health} />);
+
+    expect(html).toContain('Connection health');
+    expect(html).toContain('1/2 enabled connections healthy · 1 down · 1 disabled');
+    expect(html).toContain('qdrant: qdrant connection down');
+    expect(html).toContain('http://localhost:6333');
+    expect(html).toContain('connection refused');
+  });
+});


### PR DESCRIPTION
## Summary
- Add a Vector config connection-health summary to surface healthy/down/disabled adapter state before editing rows.
- Show down external adapters with endpoint and error guidance so Qdrant/proxy/TurboVec failures are visible from Settings.
- Add component coverage for healthy, down, and disabled vector config states.

## Validation
- bunx tsc --noEmit
- cd frontend && bunx tsc --noEmit
- bun test tests/frontend
- bun test tests/http/vector/config-api.test.ts
- git diff --check origin/alpha...HEAD
- changed files <=250 lines

Refs #1595