### PR TITLE
feat(frontend): expose plugin proxy server links

### DIFF
--- a/frontend/src/pages/UnifiedPluginSurfaceOverview.tsx
+++ b/frontend/src/pages/UnifiedPluginSurfaceOverview.tsx
@@ -81,14 +81,20 @@ export function pluginCapabilityLinks(plugins: PluginEntry[]): Array<{ label: st
 }
 
 export function pluginServerRows(plugins: PluginEntry[]): Array<{ name: string; status: string; health: string; surface: 'server' | 'proxy' }> {
-  return plugins
-    .filter((plugin) => plugin.server || plugin.proxy?.length)
-    .map((plugin) => ({
+  return plugins.flatMap((plugin) => [
+    ...(plugin.server ? [{
       name: plugin.name,
       status: plugin.status ?? 'ok',
-      health: plugin.server?.healthPath ?? plugin.proxy?.[0]?.path ?? 'proxy route',
-      surface: plugin.server ? 'server' : 'proxy',
-    }));
+      health: plugin.server.healthPath ?? '/health',
+      surface: 'server' as const,
+    }] : []),
+    ...(plugin.proxy ?? []).map((proxy) => ({
+      name: plugin.name,
+      status: plugin.status ?? 'ok',
+      health: proxy.path,
+      surface: 'proxy' as const,
+    })),
+  ]);
 }
 
 export function pluginServerLinks(plugins: PluginEntry[]): Array<{ label: string; href: string }> {

--- a/tests/frontend/pages/unified-plugin-overview.test.tsx
+++ b/tests/frontend/pages/unified-plugin-overview.test.tsx
@@ -33,10 +33,12 @@ describe('UnifiedPluginSurfaceOverview', () => {
 
     expect(pluginServerRows(plugins)).toEqual([
       { name: 'echo', status: 'ok', health: '/health', surface: 'server' },
+      { name: 'echo', status: 'ok', health: '/api/plugins/echo/server', surface: 'proxy' },
       { name: 'proxy-only', status: 'ok', health: '/api/plugins/proxy-only/server', surface: 'proxy' },
     ]);
     expect(pluginServerLinks(plugins)).toEqual([
       { label: 'echo · ok · /health', href: '/plugins?q=echo&surface=server' },
+      { label: 'echo · ok · /api/plugins/echo/server', href: '/plugins?q=echo&surface=proxy' },
       { label: 'proxy-only · ok · /api/plugins/proxy-only/server', href: '/plugins?q=proxy-only&surface=proxy' },
     ]);
     expect(pluginCapabilityRows(plugins)).toContain('echo api GET /api/plugins/echo/ping');
@@ -62,6 +64,7 @@ describe('UnifiedPluginSurfaceOverview', () => {
     expect(html).toContain('href="/plugins?surface=mcp"');
     expect(html).toContain('href="/plugins?surface=server"');
     expect(html).toContain('href="/plugins?q=echo&amp;surface=server"');
+    expect(html).toContain('href="/plugins?q=echo&amp;surface=proxy"');
     expect(html).toContain('href="/plugins?q=proxy-only&amp;surface=proxy"');
     expect(html).toContain('href="/mcp/tools/echo_tool"');
     expect(html).toContain('href="/plugins?q=%2Fapi%2Fplugins%2Fecho%2Fping&amp;surface=apiRoutes"');


### PR DESCRIPTION
## Summary
- show plugin proxy routes alongside server health entries on the unified plugin overview
- link each server/proxy row back to the filtered plugin inventory
- extend frontend coverage for plugins exposing both server and proxy surfaces

## Tests
- bunx tsc --noEmit
- cd frontend && bunx tsc --noEmit
- bun test tests/frontend

## File sizes
- frontend/src/pages/UnifiedPluginSurfaceOverview.tsx: 192 lines
- tests/frontend/pages/unified-plugin-overview.test.tsx: 72 lines