### PR TITLE
feat(frontend): show proxy status on status page

### DIFF
--- a/frontend/src/pages/StatusPage.tsx
+++ b/frontend/src/pages/StatusPage.tsx
@@ -5,11 +5,21 @@ import { pluginInventoryPath } from '../routePaths';
 import type { HealthResponse } from '../../../src/server/types';
 
 type PageState = 'loading' | 'ready' | 'error';
-type StatusClient = Pick<ApiClient, 'health'>;
+type StatusClient = Pick<ApiClient, 'health'> & Partial<Pick<ApiClient, 'vectorHealth'>>;
+type VectorHealthForStatus = Awaited<ReturnType<ApiClient['vectorHealth']>> & { services?: VectorProxyService[] };
+type VectorProxyService = {
+  name: string;
+  type?: string;
+  endpoint?: string;
+  status?: string;
+  available?: boolean;
+  health?: { status?: string; error?: string; checkedAt?: string };
+};
 
 export interface StatusPageProps {
   client?: StatusClient;
   initialHealth?: HealthResponse | null;
+  initialVectorHealth?: VectorHealthForStatus | null;
 }
 
 function statusClass(status?: string): string {
@@ -44,6 +54,24 @@ function StatusBadge({ label, status }: { label: string; status?: string }) {
   );
 }
 
+export function vectorProxyRows(vector: VectorHealthForStatus | null): Array<{ name: string; status: string; endpoint: string; detail: string }> {
+  const services = (vector?.services ?? []).filter((service) => service.type === 'proxy');
+  if (services.length) {
+    return services.map((service) => ({
+      name: service.name,
+      status: service.health?.status ?? service.status ?? (service.available ? 'up' : 'unknown'),
+      endpoint: service.endpoint ?? 'not configured',
+      detail: service.health?.error ?? service.health?.checkedAt ?? 'proxy service registered',
+    }));
+  }
+  return vector?.proxy ? [{
+    name: 'VECTOR_URL',
+    status: vector.status,
+    endpoint: vector.proxy,
+    detail: vector.error ?? `${vector.engines.length} local engines bypassed by proxy health check`,
+  }] : [];
+}
+
 export function pluginHealthPath(plugin: { name: string; status?: string; error?: string }): string {
   const unhealthy = Boolean((plugin.status && plugin.status !== 'ok') || plugin.error);
   return pluginInventoryPath({ q: plugin.name, visibility: unhealthy ? 'unhealthy' : 'all' });
@@ -65,16 +93,38 @@ function PluginRows({ health }: { health: HealthResponse }) {
   );
 }
 
-export function StatusPage({ client = apiClient, initialHealth = null }: StatusPageProps) {
+function ProxyRows({ vector }: { vector: VectorHealthForStatus | null }) {
+  const rows = vectorProxyRows(vector);
+  if (!rows.length) return <p className="text-sm text-slate-400">No proxy service rows returned by /api/v1/vector/health.</p>;
+  return (
+    <ul className="grid gap-2">
+      {rows.map((row) => (
+        <li key={`${row.name}-${row.endpoint}`} className="rounded-xl border border-white/10 bg-white/[0.03] p-3">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <span className="font-mono text-sm text-teal-100">{row.name}</span>
+            <span className={`rounded-full border px-2 py-1 text-xs ${statusClass(row.status === 'up' ? 'ok' : row.status)}`}>{row.status}</span>
+          </div>
+          <p className="mt-2 break-words font-mono text-xs text-slate-300">{row.endpoint}</p>
+          <p className="mt-1 text-sm text-slate-400">{row.detail}</p>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function StatusPage({ client = apiClient, initialHealth = null, initialVectorHealth = null }: StatusPageProps) {
   const [state, setState] = useState<PageState>(initialHealth ? 'ready' : 'loading');
   const [health, setHealth] = useState<HealthResponse | null>(initialHealth);
+  const [vectorHealth, setVectorHealth] = useState<VectorHealthForStatus | null>(initialVectorHealth);
   const [error, setError] = useState('');
+  const [vectorError, setVectorError] = useState('');
 
   useEffect(() => {
     if (initialHealth) return;
     let cancelled = false;
     setState('loading');
     setError('');
+    setVectorError('');
     client.health()
       .then((response) => {
         if (cancelled) return;
@@ -86,6 +136,9 @@ export function StatusPage({ client = apiClient, initialHealth = null }: StatusP
         setError(cause instanceof Error ? cause.message : String(cause));
         setState('error');
       });
+    client.vectorHealth?.()
+      .then((response) => { if (!cancelled) setVectorHealth(response as VectorHealthForStatus); })
+      .catch((cause) => { if (!cancelled) setVectorError(cause instanceof Error ? cause.message : String(cause)); });
     return () => { cancelled = true; };
   }, [client, initialHealth]);
 
@@ -124,6 +177,12 @@ export function StatusPage({ client = apiClient, initialHealth = null }: StatusP
           <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-label="Plugin health rows">
             <h3 className="text-lg font-semibold text-white">Plugin health</h3>
             <div className="mt-4"><PluginRows health={health} /></div>
+          </section>
+          <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-label="Proxy status rows">
+            <h3 className="text-lg font-semibold text-white">Proxy status</h3>
+            <p className="mt-2 text-sm text-slate-400">Vector proxy and registered proxy services from /api/v1/vector/health.</p>
+            {vectorError ? <p className="mt-3 rounded-xl border border-amber-300/20 bg-amber-300/10 p-3 text-sm text-amber-100">{vectorError}</p> : null}
+            <div className="mt-4"><ProxyRows vector={vectorHealth} /></div>
           </section>
         </>
       ) : null}

--- a/tests/frontend/pages/status-page-plugin-links.test.tsx
+++ b/tests/frontend/pages/status-page-plugin-links.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { StatusPage, pluginHealthPath } from '../../../frontend/src/pages/StatusPage';
+import { StatusPage, pluginHealthPath, vectorProxyRows } from '../../../frontend/src/pages/StatusPage';
 import type { HealthResponse } from '../../../src/server/types';
 import { htmlFor } from '../_render';
 
@@ -29,5 +29,30 @@ describe('StatusPage plugin health links', () => {
     expect(html).toContain('Plugin health');
     expect(html).toContain('href="/plugins?q=echo"');
     expect(html).toContain('href="/plugins?q=broken&amp;visibility=unhealthy"');
+  });
+
+  test('renders vector proxy service status rows', () => {
+    const vector = {
+      status: 'degraded' as const,
+      checked_at: '2026-06-17T00:00:00.000Z',
+      engines: [],
+      services: [
+        { name: 'turbovec', type: 'proxy', endpoint: 'http://127.0.0.1:8787', health: { status: 'down', error: 'timeout' } },
+      ],
+    };
+
+    expect(vectorProxyRows(vector)).toEqual([{
+      name: 'turbovec',
+      status: 'down',
+      endpoint: 'http://127.0.0.1:8787',
+      detail: 'timeout',
+    }]);
+
+    const html = htmlFor(<StatusPage initialHealth={health} initialVectorHealth={vector} />);
+    expect(html).toContain('Proxy status');
+    expect(html).toContain('Vector proxy and registered proxy services');
+    expect(html).toContain('turbovec');
+    expect(html).toContain('http://127.0.0.1:8787');
+    expect(html).toContain('timeout');
   });
 });


### PR DESCRIPTION
## Summary
- fetch vector health alongside server health on the Status page
- render vector proxy / registered proxy service status rows
- add frontend coverage for proxy row normalization and rendering

Refs #1484

## Validation
- bun test tests/frontend/pages/status-page-plugin-links.test.tsx
- bun test tests/frontend
- cd frontend && bunx tsc --noEmit
- bunx tsc --noEmit
- wc -l frontend/src/pages/StatusPage.tsx tests/frontend/pages/status-page-plugin-links.test.tsx