### PR TITLE
feat(maw-plugin): declare backend config contract

### DIFF
--- a/tests/tools/maw-plugin-arra/dual-surface.test.ts
+++ b/tests/tools/maw-plugin-arra/dual-surface.test.ts
@@ -9,10 +9,13 @@ describe('maw-plugin-arra dual surface contract', () => {
       target: 'js',
       entry: './index.ts',
       artifact: { path: 'dist/index.js', sha256: null },
+      config: { dbBackend: 'http', embedderBackend: 'none' },
       cli: { command: 'arra' },
       api: { path: '/api/plugins/arra', methods: ['GET', 'POST'] },
     });
     expect(manifest.menu[0]).toMatchObject({ label: 'ARRA Oracle', path: '/plugins/arra' });
+    expect(manifest.configSchema.properties.dbBackend.enum).toEqual(['http', 'sqlite', 'memory', 'custom']);
+    expect(manifest.configSchema.properties.embedderBackend.enum).toEqual(['none', 'local', 'remote']);
   });
 
   test('serves the shared command registry for menu/API callers', async () => {
@@ -22,6 +25,8 @@ describe('maw-plugin-arra dual surface contract', () => {
     expect(result.ok).toBe(true);
     expect(body.menu.path).toBe('/plugins/arra');
     expect(body.api.path).toBe('/api/plugins/arra');
+    expect(body.config).toMatchObject({ dbBackend: 'http', embedderBackend: 'none' });
+    expect(body.configSchema.properties.embedderBackend.enum).toEqual(['none', 'local', 'remote']);
     expect(body.commands.map((item: { name: string }) => item.name))
       .toEqual(commandRegistry.map((item) => item.name));
     expect(body.commands.map((item: { name: string }) => item.name)).toContain('commands');
@@ -37,6 +42,20 @@ describe('maw-plugin-arra dual surface contract', () => {
     expect(body.output).toContain('maw arra');
     expect(body.output).toContain('vector-config');
   });
+
+  test('exposes swappable backend config via CLI and API registry', async () => {
+    const text = await handler({ args: ['config'] });
+    const raw = await handler({ source: 'api', args: { command: 'config', args: ['--json'] } });
+    const body = JSON.parse(JSON.parse(raw.output ?? '{}').output);
+
+    expect(text.ok).toBe(true);
+    expect(text.output).toContain('dbBackend: http');
+    expect(text.output).toContain('embedderBackend: none');
+    expect(raw.ok).toBe(true);
+    expect(body.configSchema.properties.dbBackend.enum).toContain('custom');
+    expect(body.configSchema.properties.embedderBackend.enum).toContain('remote');
+  });
+
   test('runs the explicit command registry from CLI text and JSON', async () => {
     const text = await handler({ args: ['commands'] });
 

--- a/tools/maw-plugin-arra/index.ts
+++ b/tools/maw-plugin-arra/index.ts
@@ -19,8 +19,27 @@ type RegistryCommand = {
 
 const surfaces = ['cli', 'api', 'menu'] as const;
 
+export const pluginConfig = {
+  dbBackend: 'http',
+  embedderBackend: 'none',
+  apiBase: 'http://localhost:47778',
+  remoteEmbedderUrl: '',
+};
+
+export const pluginConfigSchema = {
+  type: 'object',
+  properties: {
+    dbBackend: { type: 'string', enum: ['http', 'sqlite', 'memory', 'custom'] },
+    embedderBackend: { type: 'string', enum: ['none', 'local', 'remote'] },
+    apiBase: { type: 'string' },
+    remoteEmbedderUrl: { type: 'string' },
+  },
+  additionalProperties: true,
+};
+
 const commandHandlers: Record<string, CommandHandler> = {
   commands: runCommandsCommand,
+  config: runConfigCommand,
   export: runExportCommand,
   status: () => runStatusCommand(),
   'vector-config': runVectorConfigCommand,
@@ -29,6 +48,7 @@ const commandHandlers: Record<string, CommandHandler> = {
 
 export const commandRegistry: RegistryCommand[] = [
   { name: 'commands', help: 'list the shared CLI/API/menu command registry', surfaces: [...surfaces] },
+  { name: 'config', help: 'show swappable DB and optional embedder defaults', surfaces: [...surfaces] },
   { name: 'status', help: 'show vector collections, doc counts, and health', surfaces: [...surfaces] },
   { name: 'export', help: 'export app collections as json, csv, md, or jsonl', surfaces: [...surfaces] },
   { name: 'vector-config', help: VECTOR_CONFIG_HELP, surfaces: [...surfaces] },
@@ -90,6 +110,8 @@ function registryPayload(source: string) {
   return {
     plugin: 'arra',
     source,
+    config: pluginConfig,
+    configSchema: pluginConfigSchema,
     menu: { label: 'ARRA Oracle', path: '/plugins/arra', group: 'tools' },
     api: { path: '/api/plugins/arra', methods: ['GET', 'POST'] },
     cli: { command: 'arra' },
@@ -109,6 +131,18 @@ async function runCommandsCommand(args: string[]): Promise<string> {
   return wantsJson(args)
     ? JSON.stringify(registryPayload('cli'), null, 2)
     : registryText();
+}
+
+async function runConfigCommand(args: string[]): Promise<string> {
+  const payload = { config: pluginConfig, configSchema: pluginConfigSchema };
+  if (wantsJson(args)) return JSON.stringify(payload, null, 2);
+  return [
+    'arra plugin config defaults:',
+    `  dbBackend: ${pluginConfig.dbBackend}`,
+    `  embedderBackend: ${pluginConfig.embedderBackend}`,
+    `  apiBase: ${pluginConfig.apiBase}`,
+    '  remoteEmbedderUrl: (unset)',
+  ].join('\n');
 }
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {

--- a/tools/maw-plugin-arra/plugin.json
+++ b/tools/maw-plugin-arra/plugin.json
@@ -9,6 +9,22 @@
   },
   "sdk": "^1.0.0",
   "description": "ARRA Oracle CLI bridge for vector export, status, and vector config commands.",
+  "config": {
+    "dbBackend": "http",
+    "embedderBackend": "none",
+    "apiBase": "http://localhost:47778",
+    "remoteEmbedderUrl": ""
+  },
+  "configSchema": {
+    "type": "object",
+    "properties": {
+      "dbBackend": { "type": "string", "enum": ["http", "sqlite", "memory", "custom"] },
+      "embedderBackend": { "type": "string", "enum": ["none", "local", "remote"] },
+      "apiBase": { "type": "string" },
+      "remoteEmbedderUrl": { "type": "string" }
+    },
+    "additionalProperties": true
+  },
   "author": "Soul-Brews-Studio",
   "api": {
     "path": "/api/plugins/arra",
@@ -24,7 +40,7 @@
   ],
   "cli": {
     "command": "arra",
-    "help": "maw arra <commands|status|export --collection X --format json|csv|md|vector-config list|get|set|add|remove|set-primary|reload|test>"
+    "help": "maw arra <commands|config|status|export --collection X --format json|csv|md|vector-config list|get|set|add|remove|set-primary|reload|test>"
   },
   "weight": 10,
   "license": "BUSL-1.1",


### PR DESCRIPTION
## Summary
- declare canonical maw plugin defaults for swappable DB backend and optional none/local/remote embedder
- expose the config contract through the shared CLI/API/menu registry and `maw arra config`
- cover manifest, registry, and CLI/API config output in scoped tests

## Validation
- bun test tests/tools/maw-plugin-arra/
- bunx tsc --noEmit -p tools/maw-plugin-arra/tsconfig.json
- bunx tsc --noEmit
- git diff --check origin/alpha...HEAD
- wc -l tools/maw-plugin-arra/plugin.json tools/maw-plugin-arra/index.ts tests/tools/maw-plugin-arra/dual-surface.test.ts

Refs #1467