### PR TITLE
fix(plugins): clarify containment compatibility label

### DIFF
--- a/src/plugins/sandbox.ts
+++ b/src/plugins/sandbox.ts
@@ -1,6 +1,7 @@
 /**
- * @deprecated Use error-containment.ts. This module is NOT a sandbox or
- * security boundary; it only preserves the legacy import path.
+ * @deprecated Use error-containment.ts.
+ * Legacy compatibility module for plugin error containment only; it does not
+ * create process isolation, VM boundaries, or any security boundary.
  */
 export {
   runPluginWithErrorContainment as runPluginSandbox,

--- a/tests/plugins/error-containment.test.ts
+++ b/tests/plugins/error-containment.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { PluginEventBus, type PluginEventMap } from "../../src/plugins/event-bus.ts";
 import { runPluginWithErrorContainment } from "../../src/plugins/error-containment.ts";
-import { runPluginSandbox } from "../../src/plugins/sandbox.ts";
+import { runPluginSandbox as runLegacyPluginBoundary } from "../../src/plugins/sandbox.ts";
 
 describe("plugin error containment", () => {
   test("returns plugin failures and emits plugin:error without throwing", async () => {
@@ -32,8 +32,8 @@ describe("plugin error containment", () => {
     expect(events[0].error).toBeInstanceOf(Error);
   });
 
-  test("keeps the legacy sandbox export as a compatibility alias", async () => {
-    await expect(runPluginSandbox({ plugin: "legacy", phase: "runtime" }, () => "ok"))
+  test("keeps the legacy compatibility module as an error-containment alias", async () => {
+    await expect(runLegacyPluginBoundary({ plugin: "legacy", phase: "runtime" }, () => "ok"))
       .resolves.toEqual({ ok: true, value: "ok" });
   });
 });


### PR DESCRIPTION
## Summary\n- clarify the legacy src/plugins/sandbox.ts header as error containment compatibility, not process/VM isolation\n- rename the focused plugin test from sandbox to error-containment wording\n- keep the legacy runPluginSandbox export covered as a compatibility alias\n\n## Grep refs\n- remaining plugin sandbox references are the legacy compatibility export/import only\n- docs/comments now call the behavior error containment and explicitly reject process isolation, VM boundaries, or security boundaries\n\n## Validation\n- bun test tests/plugins/error-containment.test.ts\n- bunx tsc --noEmit\n- wc -l changed files (all <=250)