### PR TITLE
test: isolate maw plugin menu DB fixtures

### DIFF
--- a/tests/http/menu/arra-maw-plugin-menu.test.ts
+++ b/tests/http/menu/arra-maw-plugin-menu.test.ts
@@ -1,6 +1,33 @@
-import { expect, test } from 'bun:test';
-import { loadUnifiedPlugins } from '../../../src/plugins/unified-loader.ts';
-import { createMenuRoutes, menuItemsFromUnifiedPlugins } from '../../../src/routes/menu/index.ts';
+import { afterAll, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const root = mkdtempSync(join(tmpdir(), 'arra-maw-plugin-menu-'));
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const savedRepoRoot = process.env.ORACLE_REPO_ROOT;
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = join(root, 'oracle.db');
+process.env.ORACLE_REPO_ROOT = root;
+
+const dbMod = await import('../../../src/db/index.ts');
+dbMod.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+const { loadUnifiedPlugins } = await import('../../../src/plugins/unified-loader.ts');
+const { createMenuRoutes, menuItemsFromUnifiedPlugins } = await import('../../../src/routes/menu/index.ts');
+
+afterAll(() => {
+  try { dbMod.closeDb(); } catch {}
+  restore('ORACLE_DATA_DIR', savedDataDir);
+  restore('ORACLE_DB_PATH', savedDbPath);
+  restore('ORACLE_REPO_ROOT', savedRepoRoot);
+  rmSync(root, { recursive: true, force: true });
+});
+
+function restore(name: string, value: string | undefined) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
 
 async function fetchMenu() {
   const runtime = await loadUnifiedPlugins({ dirs: [process.cwd()], warn: () => {} });

--- a/tests/http/menu/maw-plugin-discovery.test.ts
+++ b/tests/http/menu/maw-plugin-discovery.test.ts
@@ -2,17 +2,29 @@ import { afterEach, expect, test } from 'bun:test';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { defaultUnifiedPluginDirs, loadUnifiedPlugins } from '../../../src/plugins/unified-loader.ts';
-import { createMenuRoutes, menuItemsFromUnifiedPlugins } from '../../../src/routes/menu/index.ts';
 
 const originalCwd = process.cwd();
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const savedRepoRoot = process.env.ORACLE_REPO_ROOT;
 let tmp = '';
+let dbMod: typeof import('../../../src/db/index.ts') | undefined;
 
 afterEach(() => {
   process.chdir(originalCwd);
+  try { dbMod?.closeDb(); } catch {}
+  dbMod = undefined;
+  restore('ORACLE_DATA_DIR', savedDataDir);
+  restore('ORACLE_DB_PATH', savedDbPath);
+  restore('ORACLE_REPO_ROOT', savedRepoRoot);
   if (tmp) rmSync(tmp, { recursive: true, force: true });
   tmp = '';
 });
+
+function restore(name: string, value: string | undefined) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
 
 function writeLocalArraPlugin(root: string) {
   const dir = join(root, '.maw', 'plugins', 'arra');
@@ -28,10 +40,23 @@ function writeLocalArraPlugin(root: string) {
   }, null, 2));
 }
 
+async function loadMenuModules(root: string) {
+  process.env.ORACLE_DATA_DIR = root;
+  process.env.ORACLE_DB_PATH = join(root, 'oracle.db');
+  process.env.ORACLE_REPO_ROOT = root;
+  dbMod = await import('../../../src/db/index.ts');
+  dbMod.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+  const plugins = await import('../../../src/plugins/unified-loader.ts');
+  const menu = await import('../../../src/routes/menu/index.ts');
+  return { ...plugins, ...menu };
+}
+
 test('nearest .maw/plugins entries shadow bundled ARRA menu items', async () => {
   tmp = mkdtempSync(join(tmpdir(), 'arra-maw-menu-'));
   writeLocalArraPlugin(tmp);
   process.chdir(tmp);
+  const { defaultUnifiedPluginDirs, loadUnifiedPlugins, createMenuRoutes, menuItemsFromUnifiedPlugins } =
+    await loadMenuModules(tmp);
 
   const runtime = await loadUnifiedPlugins({
     dirs: defaultUnifiedPluginDirs([join(originalCwd, 'src', 'plugins')]),
@@ -49,4 +74,3 @@ test('nearest .maw/plugins entries shadow bundled ARRA menu items', async () => 
     source: 'plugin',
   });
 });
-


### PR DESCRIPTION
## Summary
- isolates maw plugin menu tests with temporary ORACLE_DATA_DIR/ORACLE_DB_PATH fixtures
- switches menu plugin discovery tests to dynamic imports after DB env setup
- fixes local scoped verification failures caused by stale/default SQLite migrations

## #1467 verification
- `maw plugin build` produced `maw-plugin/dist/index.js`, `maw-plugin/dist/plugin.json`, `maw-plugin/arra-1.0.0.tgz`, and matching artifact sha
- `maw plugin install ./arra --local` + `maw arra --help` passed in an isolated temp project
- `maw arra commands --json` and menu-source handler used the same command registry (67 commands)
- real no-embedder invoke passed with `ORACLE_EMBEDDER=none`: `maw arra learn` then `maw arra search --mode fts` returned 1 result

## Validation
- `bunx tsc --noEmit`
- `bun test maw-plugin/__tests__/ tests/http/menu/arra-maw-plugin-menu.test.ts tests/http/menu/maw-plugin-discovery.test.ts tests/http/plugins/maw-plugin-api.test.ts tests/tools/maw-plugin-arra/ tests/integration/maw-arra-plugin-lifecycle.test.ts` (56 pass)
- changed files ≤250 lines
