### PR TITLE
test: isolate HTTP tenant fixture databases

### DIFF
--- a/tests/http/feed/tenant-isolation.test.ts
+++ b/tests/http/feed/tenant-isolation.test.ts
@@ -9,6 +9,8 @@ const savedDataDir = process.env.ORACLE_DATA_DIR;
 const savedDbPath = process.env.ORACLE_DB_PATH;
 const savedMawUrl = process.env.MAW_JS_URL;
 const root = mkdtempSync(join(tmpdir(), 'feed-tenant-'));
+const restoreDbPath = savedDbPath
+  ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
 process.env.ORACLE_DATA_DIR = root;
 process.env.ORACLE_DB_PATH = join(root, 'oracle.db');
 
@@ -87,6 +89,7 @@ afterAll(() => {
   else process.env.ORACLE_DB_PATH = savedDbPath;
   if (savedMawUrl === undefined) delete process.env.MAW_JS_URL;
   else process.env.MAW_JS_URL = savedMawUrl;
+  dbMod.resetDefaultDatabaseForTests(restoreDbPath);
 });
 
 test('/api/feed stores and lists only selected tenant feed events', async () => {

--- a/tests/http/schedule/tenant-isolation.test.ts
+++ b/tests/http/schedule/tenant-isolation.test.ts
@@ -14,6 +14,7 @@ process.env.ORACLE_REPO_ROOT = root;
 const dbMod = await import('../../../src/db/index.ts');
 const tenantMod = await import('../../../src/middleware/tenant.ts');
 const routeMod = await import('../../../src/routes/schedule/index.ts');
+dbMod.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
 
 const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 const tenantA = `tenant-a-${stamp}`;
@@ -53,6 +54,9 @@ afterAll(() => {
   if (previousRepoRoot === undefined) delete process.env.ORACLE_REPO_ROOT;
   else process.env.ORACLE_REPO_ROOT = previousRepoRoot;
   rmSync(root, { recursive: true, force: true });
+  const restoreDbPath = previousDbPath
+    ?? join(previousDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
+  dbMod.resetDefaultDatabaseForTests(restoreDbPath);
 });
 
 test('schedule HTTP routes isolate create/list/update/markdown by tenant', async () => {


### PR DESCRIPTION
## Summary
- Restore the default test database after the feed tenant isolation fixture tears down its temp root.
- Reset/restore the schedule tenant isolation fixture database so it is safe in the full non-isolated HTTP suite.

## Context
#1457 itself is already merged in PR #1978. This is the follow-up that makes the requested full `tests/http/` gate green after current alpha changes.

## Tests
- `bunx tsc --noEmit`
- `ORACLE_DATA_DIR=$(mktemp -d) ORACLE_DB_PATH=$ORACLE_DATA_DIR/oracle.db ORACLE_REPO_ROOT=$ORACLE_DATA_DIR bun test tests/http/` (625 pass, 0 fail)
- `git diff --check origin/alpha...HEAD`
- changed file line counts: 132, 89
