### PR TITLE
fix(logger): capture LOG_FORMAT at startup

### DIFF
--- a/src/middleware/logger.ts
+++ b/src/middleware/logger.ts
@@ -31,16 +31,18 @@ export type RequestLogEntry = {
   sandbox: string;
 };
 
-export type RequestLogFormat = 'json' | 'nginx' | 'short';
+export const REQUEST_LOG_FORMATS = ['nginx', 'json', 'short'] as const;
+export type RequestLogFormat = (typeof REQUEST_LOG_FORMATS)[number];
 
 export type RequestLoggerOptions = {
   log?: (entry: RequestLogEntry) => void;
+  logFormat?: RequestLogFormat;
   now?: () => number;
 };
 
 const REDACTED = '[REDACTED]';
 const sensitiveHeaders = new Set(['authorization', 'proxy-authorization']);
-const logFormats = new Set<RequestLogFormat>(['json', 'nginx', 'short']);
+const logFormats = new Set<RequestLogFormat>(REQUEST_LOG_FORMATS);
 
 function nowMs(): number {
   return performance.now();
@@ -78,6 +80,10 @@ export function requestLogFormat(envValue = process.env.LOG_FORMAT): RequestLogF
   return requested && logFormats.has(requested) ? requested : 'nginx';
 }
 
+export function startupRequestLogFormat(env = process.env): RequestLogFormat {
+  return requestLogFormat(env.LOG_FORMAT);
+}
+
 function formatDurationMs(durationMs: number): string {
   return `${Math.max(0, durationMs).toFixed(2).replace(/\.?0+$/, '')}ms`;
 }
@@ -113,7 +119,7 @@ export function formatRequestLog(entry: RequestLogEntry, format: RequestLogForma
 export function createRequestLogger(options: RequestLoggerOptions = {}) {
   const metaByRequest = new WeakMap<Request, RequestMeta>();
   const now = options.now ?? nowMs;
-  const format = requestLogFormat();
+  const format = options.logFormat ?? startupRequestLogFormat();
   const log = options.log ?? ((entry: RequestLogEntry) => console.log(formatRequestLog(entry, format)));
 
   return {

--- a/src/middleware/request-logger.ts
+++ b/src/middleware/request-logger.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { Elysia } from 'elysia';
-import { formatRequestLog, requestLogFormat, type RequestLogFormat } from './logger.ts';
+import { formatRequestLog, startupRequestLogFormat, type RequestLogFormat } from './logger.ts';
 import { SANDBOX_LABEL_HEADER, sandboxLabel } from '../runtime/sandbox-label.ts';
 
 export type StructuredRequestLogEntry = {
@@ -76,7 +76,7 @@ export function createRequestLoggingMiddleware(options: RequestLoggingOptions = 
   const meta = new WeakMap<Request, RequestMeta>();
   const now = options.now ?? nowMs;
   const timestamp = options.timestamp ?? isoTimestamp;
-  const format = options.logFormat ?? requestLogFormat();
+  const format = options.logFormat ?? startupRequestLogFormat();
   const log = options.log ?? ((entry: StructuredRequestLogEntry) => console.log(formatRequestLog(entry, format)));
 
   return new Elysia({ name: 'structured-request-logger' })

--- a/tests/http/logger/format.test.ts
+++ b/tests/http/logger/format.test.ts
@@ -1,6 +1,12 @@
 import { expect, test } from 'bun:test';
 import { Elysia } from 'elysia';
-import { createRequestLogger, type RequestLogEntry } from '../../../src/middleware/logger.ts';
+import {
+  createRequestLogger,
+  requestLogFormat,
+  REQUEST_LOG_FORMATS,
+  startupRequestLogFormat,
+  type RequestLogEntry,
+} from '../../../src/middleware/logger.ts';
 
 const CORRELATION_ID = 'abcdef12-correlation-id';
 
@@ -56,6 +62,11 @@ async function captureLogLine(format: string | undefined, env?: string): Promise
 }
 
 test('LOG_FORMAT selects json, nginx, and short request log output', async () => {
+  expect(REQUEST_LOG_FORMATS).toEqual(['nginx', 'json', 'short']);
+  expect(requestLogFormat(' JSON ')).toBe('json');
+  expect(requestLogFormat('verbose')).toBe('nginx');
+  expect(startupRequestLogFormat({ LOG_FORMAT: 'short' })).toBe('short');
+
   const json = JSON.parse(await captureLogLine('json')) as RequestLogEntry;
   expect(json).toMatchObject({
     event: 'http_request',
@@ -73,4 +84,33 @@ test('LOG_FORMAT selects json, nginx, and short request log output', async () =>
 
 test('LOG_FORMAT defaults to nginx and labels production sandbox', async () => {
   expect(await captureLogLine(undefined, 'production')).toBe('GET /api/health 200 1.37ms [abcdef12] [prod]');
+});
+
+test('request logger captures LOG_FORMAT when created', async () => {
+  const lines: string[] = [];
+  const originalLog = console.log;
+  const originalFormat = process.env.LOG_FORMAT;
+  process.env.LOG_FORMAT = 'short';
+  console.log = (message?: unknown) => {
+    lines.push(String(message));
+  };
+
+  try {
+    const ticks = [200, 201.1];
+    const logger = createRequestLogger({ now: () => ticks.shift() ?? 201.1 });
+    process.env.LOG_FORMAT = 'json';
+    const app = new Elysia()
+      .onRequest(logger.onRequest)
+      .onAfterResponse(logger.onAfterResponse)
+      .get('/startup-log-format', () => ({ ok: true }));
+
+    const response = await app.fetch(new Request('http://local/startup-log-format', {
+      headers: { 'x-correlation-id': CORRELATION_ID },
+    }));
+    expect(response.status).toBe(200);
+    expect(await waitForLog(lines)).toBe('200 GET /startup-log-format 1ms');
+  } finally {
+    console.log = originalLog;
+    restoreLogFormat(originalFormat);
+  }
 });


### PR DESCRIPTION
## Summary
- make nginx/json/short LOG_FORMAT modes explicit from src/middleware/logger.ts
- add a startup LOG_FORMAT resolver and use it in both request logger surfaces
- add regression coverage for mode parsing and startup capture semantics

## Validation
- bunx tsc --noEmit
- bun test tests/http/logger/format.test.ts tests/http/logging/request-logger-middleware.test.ts tests/http/logging/request-log.test.ts tests/config/validate.test.ts
- ORACLE_DB_PATH=<tmp>/oracle.db bun test tests/http/health/core-hardening.test.ts
- git diff --check origin/alpha...HEAD
- changed files <=250 lines

Refs #1597