### PR TITLE
fix: contain unified plugin entry paths

### DIFF
--- a/src/plugins/path-containment.ts
+++ b/src/plugins/path-containment.ts
@@ -1,10 +1,20 @@
 import { existsSync, realpathSync } from 'node:fs';
 import { resolve, sep } from 'node:path';
 
+function isContained(parent: string, child: string): boolean {
+  const parentRoot = parent.endsWith(sep) ? parent : `${parent}${sep}`;
+  return child === parent || child.startsWith(parentRoot);
+}
+
 function assertContained(pluginDir: string, entryPath: string): void {
-  const pluginRoot = pluginDir.endsWith(sep) ? pluginDir : `${pluginDir}${sep}`;
-  if (entryPath !== pluginDir && !entryPath.startsWith(pluginRoot)) {
-    throw new Error('plugin entry escapes plugin directory');
+  if (!isContained(pluginDir, entryPath)) throw new Error('plugin entry escapes plugin directory');
+}
+
+export function isContainedPluginPath(rootDir: string, candidatePath: string): boolean {
+  try {
+    return isContained(realpathSync(rootDir), realpathSync(candidatePath));
+  } catch {
+    return false;
   }
 }
 

--- a/src/plugins/unified-loader.ts
+++ b/src/plugins/unified-loader.ts
@@ -8,15 +8,13 @@ import { pluginRegistryFromLoadedPlugins, type LoadedPluginRegistryEntry } from 
 import { runPluginWithErrorContainment } from './error-containment.ts';
 import { createUnifiedProxyRoute } from './proxy-surface.ts';
 import { unifiedPluginServerRoutes, type UnifiedPluginServer } from './unified-server.ts';
-import { resolveContainedPluginEntry } from './path-containment.ts';
+import { isContainedPluginPath, resolveContainedPluginEntry } from './path-containment.ts';
 import { registerPluginExportFormats } from './export-format-init.ts';
 import { defaultUnifiedPluginDirs } from './plugin-dirs.ts';
 
 const DEFAULT_TIMEOUT_MS = Number(process.env.ARRA_PLUGIN_TIMEOUT_MS ?? 5000);
 
-type ElysiaApp = Elysia<any, any, any, any, any, any, any>;
-type JsonRecord = Record<string, unknown>;
-type LifecycleSource = 'init' | 'destroy';
+type ElysiaApp = Elysia<any, any, any, any, any, any, any>; type JsonRecord = Record<string, unknown>; type LifecycleSource = 'init' | 'destroy';
 
 export interface LoadedUnifiedPlugin {
   manifest: NormalizedUnifiedPluginManifest;
@@ -92,7 +90,9 @@ export async function discoverUnifiedPluginManifests(
     if (!existsSync(baseDir)) continue;
     for (const entry of readdirSync(baseDir, { withFileTypes: true })) {
       if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
-      const loaded = await readPluginDir(join(baseDir, entry.name), options);
+      const pluginDir = join(baseDir, entry.name);
+      if (!isContainedPluginPath(baseDir, pluginDir)) { warn(options, `skipped ${pluginDir}: plugin directory symlink escapes plugin root`); continue; }
+      const loaded = await readPluginDir(pluginDir, options);
       if (!loaded || seen.has(loaded.manifest.name)) continue;
       seen.add(loaded.manifest.name);
       found.push(loaded);

--- a/tests/plugins/path-containment.test.ts
+++ b/tests/plugins/path-containment.test.ts
@@ -41,6 +41,18 @@ describe("plugin entry path containment", () => {
     expect(warnings[0]).toContain("plugin entry escapes plugin directory");
   });
 
+  test("rejects symlinked plugin directories that point outside the plugin root", async () => {
+    const root = tempRoot();
+    const externalRoot = tempRoot();
+    const externalPlugin = pluginDir(externalRoot, "external", {});
+    symlinkSync(externalPlugin, join(root, "linked-plugin"), "dir");
+    const warnings: string[] = [];
+
+    expect(await discoverUnifiedPluginManifests({ dirs: [root], warn: (msg) => warnings.push(msg) }))
+      .toEqual([]);
+    expect(warnings[0]).toContain("plugin directory symlink escapes plugin root");
+  });
+
   test("rejects entry symlinks that point outside the plugin directory", () => {
     const tmp = tempRoot();
     const externalDir = join(tmp, "external");


### PR DESCRIPTION
## Summary
- reject plugin directory symlinks that escape the configured plugin root during unified plugin discovery
- reuse canonical path containment checks for entry paths and broken symlink handling
- add regression coverage for symlinked plugin-directory traversal plus existing entry traversal checks

## Validation
- bun test tests/plugins/ src/plugins/__tests__/unified-loader.test.ts
- bunx tsc --noEmit
- git diff --check
- wc -l changed files <= 250

Closes task #4 of #1597