### PR TITLE
test: verify maw plugin build lock artifacts

### DIFF
--- a/maw-plugin/__tests__/build.test.ts
+++ b/maw-plugin/__tests__/build.test.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { buildPlugin } from '../scripts/build.ts';
+import { verifyMawPluginBuild } from '../scripts/verify-build.ts';
 
 const tmp = mkdtempSync(join(tmpdir(), 'arra-maw-plugin-build-'));
 afterAll(() => rmSync(tmp, { recursive: true, force: true }));
@@ -29,4 +30,12 @@ test('maw plugin build emits dist manifest, tgz, sha, and plugins.lock', async (
   expect(lock.plugins.arra).toMatchObject({ version: '1.0.0', package: 'arra-1.0.0.tgz', pinned: true });
   expect(lock.plugins.arra.artifact.sha256).toBe(sha256);
   expect(lock.plugins.arra.packageSha256).toBe(packageSha256);
+});
+
+test('actual maw plugin build emits verifiable artifact and install records plugins.lock', () => {
+  const result = verifyMawPluginBuild({ root: join(import.meta.dir, '..') });
+
+  expect(result.artifactSha256).toStartWith('sha256:');
+  expect(result.packageSha256).toStartWith('sha256:');
+  expect(result.lockSha256).toBe(result.artifactSha256);
 });

--- a/maw-plugin/scripts/verify-build.ts
+++ b/maw-plugin/scripts/verify-build.ts
@@ -1,0 +1,82 @@
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { cpSync, existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join, resolve } from 'node:path';
+
+type VerifyOptions = { root?: string; keep?: boolean };
+type Lock = { plugins?: Record<string, { version?: string; sha256?: string; source?: string }> };
+
+export type VerifyBuildResult = {
+  workDir: string;
+  pluginDir: string;
+  entryPath: string;
+  manifestPath: string;
+  tgzPath: string;
+  lockPath: string;
+  artifactSha256: string;
+  packageSha256: string;
+  lockSha256: string;
+};
+
+function run(cmd: string, args: string[], cwd: string, home: string): string {
+  const result = spawnSync(cmd, args, { cwd, env: { ...process.env, HOME: home }, encoding: 'utf8' });
+  if (result.status !== 0) throw new Error(result.stderr || result.stdout || `${cmd} failed`);
+  return `${result.stdout}${result.stderr}`;
+}
+
+function sha256(path: string): string {
+  return `sha256:${createHash('sha256').update(readFileSync(path)).digest('hex')}`;
+}
+
+function option(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+function copyPlugin(root: string, pluginDir: string): void {
+  cpSync(root, pluginDir, {
+    recursive: true,
+    filter: (src) => !['dist', '.maw'].includes(basename(src)) && !src.endsWith('.tgz'),
+  });
+}
+
+export function verifyMawPluginBuild(options: VerifyOptions = {}): VerifyBuildResult {
+  const root = resolve(options.root ?? process.cwd());
+  const workDir = mkdtempSync(join(tmpdir(), 'arra-maw-build-'));
+  const home = join(workDir, 'home');
+  const pluginDir = join(workDir, 'arra');
+  try {
+    copyPlugin(root, pluginDir);
+    run('maw', ['plugin', 'build'], pluginDir, home);
+    const manifestPath = join(pluginDir, 'dist', 'plugin.json');
+    const entryPath = join(pluginDir, 'dist', 'index.js');
+    const tgzPath = join(pluginDir, 'arra-1.0.0.tgz');
+    if (!existsSync(entryPath) || !existsSync(manifestPath) || !existsSync(tgzPath)) {
+      throw new Error('maw plugin build did not emit dist/index.js, dist/plugin.json, and tgz');
+    }
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as { artifact?: { sha256?: string } };
+    const artifactSha256 = sha256(entryPath);
+    if (manifest.artifact?.sha256 !== artifactSha256) throw new Error('artifact sha256 mismatch');
+
+    run('maw', ['plugin', 'install', './arra-1.0.0.tgz', '--local', '--pin'], pluginDir, home);
+    const lockPath = join(home, '.maw', 'plugins.lock');
+    const lock = JSON.parse(readFileSync(lockPath, 'utf8')) as Lock;
+    const lockSha256 = lock.plugins?.arra?.sha256;
+    if (lock.plugins?.arra?.version !== '1.0.0' || lockSha256 !== artifactSha256) {
+      throw new Error('plugins.lock did not pin arra with the built artifact sha256');
+    }
+    return { workDir, pluginDir, entryPath, manifestPath, tgzPath, lockPath, artifactSha256, packageSha256: sha256(tgzPath), lockSha256 };
+  } finally {
+    if (!options.keep) rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+if (import.meta.main) {
+  try {
+    console.log(JSON.stringify(verifyMawPluginBuild({ root: option('--root'), keep: process.argv.includes('--keep') }), null, 2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- add `maw-plugin/scripts/verify-build.ts` to exercise the real `maw plugin build` lifecycle in a temp copy
- verify build output includes `dist/index.js`, `dist/plugin.json`, `arra-1.0.0.tgz`, and a manifest artifact sha that matches the bundle
- install the built tgz with `--pin` in isolated HOME and assert `plugins.lock` records `arra` with the built artifact sha
- wire the verifier into `maw-plugin/__tests__/build.test.ts`

## Validation
- `bunx tsc --noEmit`
- `bun test maw-plugin/__tests__/` (38 pass)
- `bun maw-plugin/scripts/verify-build.ts --root maw-plugin`
- changed files ≤250 lines
