### PR TITLE
fix(indexer): require psi learn scan path

### DIFF
--- a/src/indexer/retro-index.ts
+++ b/src/indexer/retro-index.ts
@@ -32,6 +32,7 @@ export async function indexRetrospectives(repoRoot: string) {
         learnings: 'ψ/memory/learnings',
         retrospectives: 'ψ/memory/retrospectives',
         distillations: 'ψ/memory/distillations',
+        learn: 'ψ/learn',
       },
     },
     seenContentHashes,

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,7 +126,7 @@ export interface IndexerConfig {
     learnings: string;
     retrospectives: string;
     distillations: string;
-    learn?: string;             // ψ/learn/ — auto-learned repo exploration docs
+    learn: string;              // ψ/learn/ — auto-learned repo exploration docs
     security_corpus?: string;  // Optional: ψ/learn/security-corpus/ — opt-in via ORACLE_INDEX_SECURITY_CORPUS=1
   };
 }

--- a/tests/http/learn/auto-index.test.ts
+++ b/tests/http/learn/auto-index.test.ts
@@ -4,7 +4,8 @@ import os from 'os';
 import path from 'path';
 import type { IndexerConfig } from '../../../src/types.ts';
 import { collectPsiLearn } from '../../../src/indexer/collectors.ts';
-import { createIndexerConfig } from '../../../src/indexer/cli.ts';
+import { createIndexerConfig as createCliIndexerConfig } from '../../../src/indexer/cli.ts';
+import { createIndexerConfig as createRunnerIndexerConfig } from '../../../src/indexer/runner.ts';
 
 let repoRoot = '';
 
@@ -19,6 +20,7 @@ function makeConfig(): IndexerConfig {
       learnings: 'ψ/memory/learnings',
       retrospectives: 'ψ/memory/retrospectives',
       distillations: 'ψ/memory/distillations',
+      learn: 'ψ/learn',
     },
   };
 }
@@ -30,7 +32,14 @@ afterEach(() => {
 
 describe('ψ/learn auto-index source discovery', () => {
   test('CLI indexer config includes ψ/learn in scan paths', () => {
-    const config = createIndexerConfig('/tmp/arra-psi-learn-config-test');
+    const config = createCliIndexerConfig('/tmp/arra-psi-learn-config-test');
+
+    expect(config.sourcePaths.learn).toBe('ψ/learn');
+    expect(Object.values(config.sourcePaths)).toContain('ψ/learn');
+  });
+
+  test('runtime indexer config includes ψ/learn in scan paths', () => {
+    const config = createRunnerIndexerConfig('/tmp/arra-psi-learn-runner-test');
 
     expect(config.sourcePaths.learn).toBe('ψ/learn');
     expect(Object.values(config.sourcePaths)).toContain('ψ/learn');


### PR DESCRIPTION
## Summary
- make `sourcePaths.learn` required on `IndexerConfig` so ψ/learn remains part of every indexer scan config
- add the ψ/learn scan path to the retro-index config fixture
- cover both CLI and runtime indexer configs in ψ/learn auto-index tests

## Validation
- bunx tsc --noEmit
- ORACLE_DB_PATH=<tmp>/oracle.db bun test tests/http/learn/auto-index.test.ts src/indexer/__tests__/collectors.test.ts src/routes/indexer/__tests__/scan.test.ts tests/http/indexer/basic.test.ts
- git diff --check origin/alpha...HEAD
- changed files <=250 lines

Refs #1423