### PR TITLE
fix(export): add CLI output aliases

### DIFF
--- a/src/cli/commands/export.ts
+++ b/src/cli/commands/export.ts
@@ -1,14 +1,6 @@
 import { mkdir, writeFile as nodeWriteFile } from "node:fs/promises";
 import { dirname } from "node:path";
-import {
-  buildMarkdownExportPayload,
-  buildVaultJsonExport,
-  buildVectorExportPayload,
-  exportCommand as legacyExportCommand,
-} from "./export-legacy.ts";
 import { CLI_VERSION } from "../help.ts";
-
-export { buildMarkdownExportPayload, buildVaultJsonExport, buildVectorExportPayload };
 
 const RUN_PATH = "/api/v1/export/app/run";
 const FORMATS = new Set(["markdown", "json", "jsonl", "csv"]);
@@ -46,7 +38,8 @@ export function renderRemoteExportHelp(): string {
     "  --url <url>          Oracle v2 base URL, e.g. http://localhost:47778",
     "  --collection <name>  export collection name, e.g. oracle_documents",
     "  --format <format>    markdown, json, jsonl, or csv",
-    "  --output <path>      destination file path",
+    "  --output, --out, -o <path>",
+    "                        destination file path",
     "  --include-graph      include relationship graph rows when supported",
     "  --graph              alias for --include-graph",
     "  --retries <count>    retry transient HTTP/network failures",
@@ -87,7 +80,8 @@ function readNonNegativeInt(args: string[], flag: string, fallback: number): num
 
 function hasNewExportFlag(args: string[]): boolean {
   return args.some((arg) => arg === "--url" || arg.startsWith("--url=")
-    || arg === "--output" || arg.startsWith("--output="));
+    || arg === "--output" || arg.startsWith("--output=")
+    || arg === "--out" || arg.startsWith("--out=") || arg === "-o" || arg.startsWith("-o="));
 }
 
 export function parseRemoteExportOptions(args: string[]): RemoteExportOptions {
@@ -95,7 +89,7 @@ export function parseRemoteExportOptions(args: string[]): RemoteExportOptions {
     url: readValue(args, "--url"),
     collection: readValue(args, "--collection"),
     format: readValue(args, "--format"),
-    output: readValue(args, "--output"),
+    output: readValue(args, "--output") ?? readValue(args, "--out") ?? readValue(args, "-o"),
     includeGraph: args.includes("--include-graph") || args.includes("--graph"),
     retries: readNonNegativeInt(args, "--retries", 0),
     retryDelayMs: readNonNegativeInt(args, "--retry-delay-ms", DEFAULT_RETRY_DELAY_MS),
@@ -222,7 +216,7 @@ export async function exportCommand(args: string[]): Promise<number> {
     printHelp();
     return 0;
   }
-  if (!hasNewExportFlag(args)) return legacyExportCommand(args);
+  if (!hasNewExportFlag(args)) return (await import("./export-legacy.ts")).exportCommand(args);
 
   try {
     process.stdout.write(`${await runRemoteExportCommand(args)}\n`);

--- a/src/routes/export/build.ts
+++ b/src/routes/export/build.ts
@@ -3,7 +3,7 @@ import {
   buildMarkdownExportPayload,
   buildVaultJsonExport,
   buildVectorExportPayload,
-} from '../../cli/commands/export.ts';
+} from '../../cli/commands/export-legacy.ts';
 import { exportFormatInfo } from '../../vector/export-formats.ts';
 import type { ExportPayload, ExportRequest } from './model.ts';
 import { resolveExportFormat, resolveExportSource } from './model.ts';

--- a/tests/cli/export/remote-validation.test.ts
+++ b/tests/cli/export/remote-validation.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { runRemoteExportCommand } from "../../../src/cli/commands/export.ts";
+import { parseRemoteExportOptions, renderRemoteExportHelp, runRemoteExportCommand } from "../../../src/cli/commands/export.ts";
 
 test("export CLI rejects formats outside the requested remote export set", async () => {
   await expect(runRemoteExportCommand([
@@ -20,4 +20,12 @@ test("export CLI rejects invalid retry counts", async () => {
     "--output", join(tmpdir(), "bad.json"),
     "--retries", "-1",
   ])).rejects.toThrow("--retries must be a non-negative integer");
+});
+
+test("export CLI accepts output path aliases", () => {
+  expect(parseRemoteExportOptions(["--output", "a.json"]).output).toBe("a.json");
+  expect(parseRemoteExportOptions(["--out", "b.json"]).output).toBe("b.json");
+  expect(parseRemoteExportOptions(["-o", "c.json"]).output).toBe("c.json");
+  expect(parseRemoteExportOptions(["-o=d.json"]).output).toBe("d.json");
+  expect(renderRemoteExportHelp()).toContain("--output, --out, -o");
 });

--- a/tests/tools/maw-plugin-arra/export.test.ts
+++ b/tests/tools/maw-plugin-arra/export.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { runExportCommand } from '../../../tools/maw-plugin-arra/commands/export.ts';
+import { parseExportArgs, runExportCommand } from '../../../tools/maw-plugin-arra/commands/export.ts';
 
 type Call = { url: string; init?: RequestInit };
 
@@ -10,6 +10,12 @@ function json(data: unknown): Response {
 }
 
 describe('maw-plugin-arra export command', () => {
+  test('parses output aliases for operator CLI usage', () => {
+    expect(parseExportArgs(['export', '--out', '/tmp/docs.json']).output).toBe('/tmp/docs.json');
+    expect(parseExportArgs(['export', '-o', '/tmp/docs.csv']).output).toBe('/tmp/docs.csv');
+    expect(parseExportArgs(['export', '-o=/tmp/docs.jsonl']).output).toBe('/tmp/docs.jsonl');
+  });
+
   test('lists available app export collections', async () => {
     const calls: Call[] = [];
 

--- a/tools/export-app/README.md
+++ b/tools/export-app/README.md
@@ -150,6 +150,8 @@ bun run export -- --url http://localhost:47778 --collection oracle_documents --f
 
 Useful flags:
 
+- `--output <path>` also accepts `--out <path>` or `-o <path>` for
+  script-friendly exports.
 - `--include-graph` / `--graph` includes relationship graph rows when the
   backend supports them.
 - `--retries <count>` and `--retry-delay-ms <ms>` retry transient network,

--- a/tools/maw-plugin-arra/commands/export.ts
+++ b/tools/maw-plugin-arra/commands/export.ts
@@ -34,6 +34,8 @@ function normalizeArgs(args: string[]): string[] {
 }
 
 function readShortOutput(args: string[]): string | undefined {
+  const equals = args.find((arg) => arg.startsWith('-o='));
+  if (equals) return equals.slice(3);
   const index = args.indexOf('-o');
   return index >= 0 ? args[index + 1] : undefined;
 }
@@ -44,7 +46,7 @@ export function parseExportArgs(args: string[]): ExportOptions {
   return {
     collection: flag(parsed, 'collection') || parsed.positionals[0],
     format: flag(parsed, 'format') || parsed.positionals[1],
-    output: flag(parsed, 'output') || readShortOutput(clean),
+    output: flag(parsed, 'output') || flag(parsed, 'out') || readShortOutput(clean),
     help: clean.includes('--help') || clean.includes('-h'),
   };
 }
@@ -53,6 +55,7 @@ function usage(): string {
   return [
     'maw arra export',
     'maw arra export --collection NAME --format json|csv|md|jsonl --output PATH',
+    'Aliases: --out PATH or -o PATH',
     '',
     'Without export flags, lists available export collections.',
   ].join('\n');


### PR DESCRIPTION
## Summary
- Add `--out`/`-o` output aliases to the standalone export CLI and maw export bridge.
- Lazy-load the legacy DB-backed exporter so remote CLI help/version/parser tests do not initialize the default SQLite DB.
- Document the script-friendly output aliases and add parser coverage.

## Validation
- `bun test tests/cli/export/ tests/tools/maw-plugin-arra/export.test.ts tests/http/export/` (53 pass)
- `bunx tsc --noEmit`
- `wc -l` touched files all <= 250 lines