### PR TITLE
docs(thor): expand stormforge workflow runbook

### DIFF
--- a/docs/oracles/thor-stormforge.md
+++ b/docs/oracles/thor-stormforge.md
@@ -4,14 +4,44 @@ Thor Oracle is the Dev + Research Oracle for turning unclear context into
 implementation-grade understanding. Thor stores evidence and decisions, not
 hidden chain-of-thought.
 
-## Profile
+Issue: [#1030](https://github.com/Soul-Brews-Studio/arra-oracle-v3/issues/1030)
+
+## Profile surfaces
 
 - API list: `GET /api/oracles/profiles`
 - API read: `GET /api/oracles/profiles/thor`
 - Compatibility alias: `GET /api/oracles/thor`
 - MCP read: `oracle_profile({ id: "thor" })`
+- Trace distill: `POST /api/traces/:id/distill`
+- MCP distill: `oracle_trace_distill(...)`
+- MCP standalone note: `oracle_research_note(...)`
 
-## Stormforge Artifact Template
+## Research grounding
+
+Thor's product shape is based on four agent patterns:
+
+| Pattern | Source | Stormforge implication |
+| --- | --- | --- |
+| Interleaved research/action | [ReAct](https://arxiv.org/abs/2210.03629) | Keep evidence and plan updates visible as tools/code/tests change the answer. |
+| Verbal reflection memory | [Reflexion](https://arxiv.org/abs/2303.11366) | Distill feedback into durable learnings instead of relying on ephemeral session recall. |
+| Agent-computer interface | [SWE-agent](https://arxiv.org/abs/2405.15793) | Optimize Thor around repo navigation, edit plans, and verification logs, not a persona string. |
+| Skill library + self-verification | [Voyager](https://arxiv.org/abs/2305.16291) | Reusable findings should carry verification steps and tags for later retrieval. |
+
+## Stormforge protocol
+
+Thor runs a four-stage loop:
+
+1. **Scout** — read the issue, current code, docs, tests, and primary sources.
+2. **Forge** — convert the evidence into a bounded implementation or research
+   artifact with explicit assumptions.
+3. **Prove** — run the smallest validation that proves the claim.
+4. **Distill** — store the reusable finding through trace distillation or a
+   research note, tagged with Thor concepts and issue context.
+
+Use this protocol when the task mixes architecture, external research, and code
+execution. For simple mechanical fixes, use the normal implementation workflow.
+
+## Stormforge artifact template
 
 ```md
 ## Question
@@ -41,27 +71,96 @@ hidden chain-of-thought.
 ## Distillable learning
 ```
 
-## Distillation
+## API example
 
-Use `POST /api/traces/:id/distill` or MCP `oracle_trace_distill` with a concise
-`awakening` plus optional `finding`. When `promoteToLearning` is true, the
-learning is tagged with `thor-oracle`, `stormforge`, `dev-research`, the trace
-id, and `issue-<number>` when provided.
+```http
+POST /api/traces/trace-1030/distill
+Content-Type: application/json
 
-```json
 {
   "awakening": "Thor links research hypotheses to implementation evidence.",
   "promoteToLearning": true,
+  "oracle": "Thor Oracle",
+  "theme": "Stormforge",
+  "concepts": ["dev-research", "verification"],
+  "source": "issue #1030",
   "finding": {
     "issue": 1030,
     "repo": "github.com/Soul-Brews-Studio/arra-oracle-v3",
-    "recommendation": "Promote Thor from profile alias to registry + MCP workflow."
+    "recommendation": "Use profile registry + trace distillation as Thor's durable workflow."
   }
 }
 ```
 
-## Research notes
+Expected result:
 
-Use MCP `oracle_research_note` for a standalone Stormforge note when no trace id
-exists yet. It writes a searchable learning with the same Thor concepts and a
-rendered evidence template.
+- trace status becomes `distilled`,
+- promoted learning carries `thor-oracle`, `stormforge`, `dev-research`,
+  `trace-<id>`, and `issue-1030` concepts,
+- `GET /api/learn/:id` can retrieve the distilled note,
+- search surfaces can find the note by issue, concepts, and content.
+
+## MCP examples
+
+Read Thor profile:
+
+```json
+{
+  "tool": "oracle_profile",
+  "arguments": { "id": "thor" }
+}
+```
+
+Distill an existing trace:
+
+```json
+{
+  "tool": "oracle_trace_distill",
+  "arguments": {
+    "traceId": "trace-1030",
+    "awakening": "Stormforge captured the implementation decision and test proof.",
+    "promoteToLearning": true,
+    "finding": {
+      "issue": 1030,
+      "implementationPlan": ["reuse registry", "reuse trace distill", "document workflow"],
+      "verificationPlan": ["HTTP profile tests", "trace distill tests", "tsc --noEmit"]
+    }
+  }
+}
+```
+
+Create a standalone research/dev note:
+
+```json
+{
+  "tool": "oracle_research_note",
+  "arguments": {
+    "title": "Thor Stormforge runbook",
+    "issue": 1030,
+    "recommendation": "Use the Scout/Forge/Prove/Distill loop for dev+research tasks.",
+    "concepts": ["runbook", "verification"]
+  }
+}
+```
+
+## Acceptance checklist for #1030 slices
+
+- `GET /api/oracles/thor` remains a compatibility alias.
+- `GET /api/oracles/profiles` lists Thor from the generic registry.
+- `oracle_profile` can list/read Thor without HTTP-specific knowledge.
+- `POST /api/traces/:id/distill` keeps simple-body compatibility.
+- Structured `finding` content renders into the distilled awakening.
+- Promoted findings include Thor default concepts and `issue-<number>` when
+  provided.
+- Any new doc, test, or source file remains <=250 lines.
+- Validation output is captured before the PR is opened.
+
+## Boundaries
+
+Thor is not an autonomous code runner inside ARRA Oracle. The repository should
+provide identity, memory, research artifact, MCP, and HTTP surfaces. Actual code
+execution stays with external agents such as Codex, Claude, maw, or human
+operators.
+
+Thor stores conclusions, evidence summaries, paths, source links, validation
+plans, and results. It must not store hidden chain-of-thought as durable memory.


### PR DESCRIPTION
## Summary
- expand the Thor Stormforge doc for #1030 with the implemented API/MCP surfaces
- add the Scout/Forge/Prove/Distill operating loop for dev+research work
- document API/MCP examples, acceptance checks, and boundaries without touching the Oracle vault

## Research sources
- ReAct: https://arxiv.org/abs/2210.03629
- Reflexion: https://arxiv.org/abs/2303.11366
- SWE-agent: https://arxiv.org/abs/2405.15793
- Voyager: https://arxiv.org/abs/2305.16291

## Validation
- bunx tsc --noEmit
- ORACLE_DB_PATH=<tmp>/oracle.db bun test tests/http/health/oracles.test.ts tests/http/traces/routes.test.ts src/tools/__tests__/oracle-profile.test.ts src/tools/__tests__/mcp-manifest.test.ts
- git diff --check origin/alpha...HEAD
- docs/oracles/thor-stormforge.md is 166 lines (<=250)

Refs #1030