### PR TITLE
test(export): close out export app acceptance

### DIFF
--- a/src/cli/commands/export.ts
+++ b/src/cli/commands/export.ts
@@ -1,14 +1,6 @@
 import { mkdir, writeFile as nodeWriteFile } from "node:fs/promises";
 import { dirname } from "node:path";
-import {
-  buildMarkdownExportPayload,
-  buildVaultJsonExport,
-  buildVectorExportPayload,
-  exportCommand as legacyExportCommand,
-} from "./export-legacy.ts";
 import { CLI_VERSION } from "../help.ts";
-
-export { buildMarkdownExportPayload, buildVaultJsonExport, buildVectorExportPayload };
 
 const RUN_PATH = "/api/v1/export/app/run";
 const FORMATS = new Set(["markdown", "json", "jsonl", "csv"]);
@@ -222,7 +214,10 @@ export async function exportCommand(args: string[]): Promise<number> {
     printHelp();
     return 0;
   }
-  if (!hasNewExportFlag(args)) return legacyExportCommand(args);
+  if (!hasNewExportFlag(args)) {
+    const { exportCommand: legacyExportCommand } = await import("./export-legacy.ts");
+    return legacyExportCommand(args);
+  }
 
   try {
     process.stdout.write(`${await runRemoteExportCommand(args)}\n`);

--- a/src/routes/export/build.ts
+++ b/src/routes/export/build.ts
@@ -3,7 +3,7 @@ import {
   buildMarkdownExportPayload,
   buildVaultJsonExport,
   buildVectorExportPayload,
-} from '../../cli/commands/export.ts';
+} from '../../cli/commands/export-legacy.ts';
 import { exportFormatInfo } from '../../vector/export-formats.ts';
 import type { ExportPayload, ExportRequest } from './model.ts';
 import { resolveExportFormat, resolveExportSource } from './model.ts';

--- a/tests/cli/backup/dump.test.ts
+++ b/tests/cli/backup/dump.test.ts
@@ -5,13 +5,6 @@ import { basename, join } from 'node:path';
 
 const savedDataDir = process.env.ORACLE_DATA_DIR;
 const savedRepoRoot = process.env.ORACLE_REPO_ROOT;
-const savedDbPath = process.env.ORACLE_DB_PATH;
-
-function restoreDbPath() {
-  return savedDbPath
-    ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
-}
-
 const importRoot = mkdtempSync(join(tmpdir(), 'arra-backup-import-'));
 process.env.ORACLE_DATA_DIR = join(importRoot, 'data');
 process.env.ORACLE_REPO_ROOT = importRoot;
@@ -34,7 +27,7 @@ afterAll(() => {
   else process.env.ORACLE_DATA_DIR = savedDataDir;
   if (savedRepoRoot === undefined) delete process.env.ORACLE_REPO_ROOT;
   else process.env.ORACLE_REPO_ROOT = savedRepoRoot;
-  resetDefaultDatabaseForTests(restoreDbPath());
+  resetDefaultDatabaseForTests(':memory:');
   rmSync(importRoot, { recursive: true, force: true });
 });
 

--- a/tests/cli/data/export-import.test.ts
+++ b/tests/cli/data/export-import.test.ts
@@ -8,11 +8,6 @@ import { runCli, tryParseJson } from "../_run.ts";
 const savedDataDir = process.env.ORACLE_DATA_DIR;
 const savedDbPath = process.env.ORACLE_DB_PATH;
 
-function restoreDbPath() {
-  return savedDbPath
-    ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
-}
-
 async function openDataDb(dbPath: string) {
   const mod = await import("../../../src/db/index.ts");
   const connection = mod.createDatabase(dbPath);
@@ -73,7 +68,7 @@ describe("data export/import CLI", () => {
     else process.env.ORACLE_DATA_DIR = savedDataDir;
     if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
     else process.env.ORACLE_DB_PATH = savedDbPath;
-    mod.resetDefaultDatabaseForTests(restoreDbPath());
+    mod.resetDefaultDatabaseForTests(":memory:");
     rmSync(root, { recursive: true, force: true });
   });
 

--- a/tests/tools/export-app/closeout.test.ts
+++ b/tests/tools/export-app/closeout.test.ts
@@ -1,0 +1,97 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const root = mkdtempSync(join(tmpdir(), 'arra-export-closeout-'));
+const dbPath = join(root, 'oracle.db');
+
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = dbPath;
+
+const dbModule = await import('../../../src/db/index.ts');
+const { runExportApp } = await import('../../../tools/export-app/index.ts');
+const { writeSqliteBackup } = await import('../../../src/cli/commands/backup.ts');
+const { createDatabase, oracleDocuments, resetDefaultDatabaseForTests } = dbModule;
+
+function seed(connection: ReturnType<typeof createDatabase>) {
+  const now = 1_766_000_000_000;
+  connection.db.insert(oracleDocuments).values({
+    id: 'closeout-doc',
+    type: 'learning',
+    sourceFile: 'ψ/closeout/export.md',
+    concepts: JSON.stringify(['export', 'backup']),
+    createdAt: now,
+    updatedAt: now + 1,
+    indexedAt: now + 2,
+    createdBy: 'test',
+  }).run();
+  connection.sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)').run(
+    'closeout-doc',
+    'Closeout export body for Markdown and JSON backups.',
+    'export backup',
+  );
+}
+
+afterAll(() => {
+  if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = savedDataDir;
+  if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = savedDbPath;
+  resetDefaultDatabaseForTests(':memory:');
+  rmSync(root, { recursive: true });
+});
+
+describe('#1783 export app closeout', () => {
+  test('shows dry-run counts, writes Markdown/JSON dumps, and creates SQL backup', async () => {
+    const setup = createDatabase(dbPath);
+    seed(setup);
+    setup.storage.close();
+
+    const previewOut: string[] = [];
+    const previewDir = join(root, 'preview-only');
+    const previewCode = await runExportApp(
+      ['--output', previewDir, '--db', dbPath, '--dry-run'],
+      (message) => previewOut.push(message),
+      () => {},
+    );
+    const preview = JSON.parse(previewOut.join('')) as Record<string, number | boolean>;
+
+    expect(previewCode).toBe(0);
+    expect(preview).toMatchObject({ success: true, dryRun: true, documentCount: 1 });
+    expect(preview.rowCount).toBeGreaterThan(0);
+    expect(existsSync(previewDir)).toBe(false);
+
+    const dumpOut: string[] = [];
+    const outputDir = join(root, 'bundle');
+    const dumpCode = await runExportApp(
+      ['--output', outputDir, '--db', dbPath, '--progress', 'silent'],
+      (message) => dumpOut.push(message),
+      () => {},
+    );
+    const dump = JSON.parse(dumpOut.join('')) as { documentCount: number; rowCount: number };
+
+    expect(dumpCode).toBe(0);
+    expect(dump.documentCount).toBe(1);
+    expect(dump.rowCount).toBeGreaterThan(0);
+    expect(readFileSync(join(outputDir, 'documents', 'markdown', 'closeout_export.md'), 'utf8'))
+      .toContain('Closeout export body');
+    const docJson = JSON.parse(readFileSync(join(outputDir, 'documents', 'json', 'closeout_export.json'), 'utf8'));
+    expect(docJson).toMatchObject({ id: 'closeout-doc', concepts: ['export', 'backup'] });
+    const collectionJson = JSON.parse(readFileSync(join(outputDir, 'collections', 'oracle_documents.json'), 'utf8'));
+    expect(collectionJson).toMatchObject({ collection: 'oracle_documents', rowCount: 1 });
+
+    const backupConnection = createDatabase(dbPath);
+    try {
+      const backup = await writeSqliteBackup({ connection: backupConnection, outDir: join(root, 'sql-backups') });
+      const sql = readFileSync(backup.path, 'utf8');
+      expect(backup.rowCount).toBeGreaterThan(0);
+      expect(sql).toContain('CREATE TABLE IF NOT EXISTS "oracle_documents"');
+      expect(sql).toContain('closeout-doc');
+    } finally {
+      backupConnection.storage.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add #1783 closeout coverage proving dry-run/show, Markdown + JSON document dumps, collection JSON, and SQL backup output in one flow.
- Keep export CLI help/version and remote-export paths from initializing the legacy DB by lazy-loading the legacy exporter only when needed.
- Stabilize backup/data CLI tests so cleanup does not reset the default DB to a developer-local SQLite file.

## Acceptance audit
#1783 acceptance is covered:
- dump/export documents + metadata: `tools/export-app/documents.ts` + closeout/tool/http tests
- Markdown/JSON/CSV output: export app bundle + HTTP export route tests
- backup output: CLI SQL backup + Oracle v2 backup hardening tests
- show/preflight: export app `--dry-run` closeout coverage
- graph/progress/verify: existing export-app and HTTP export tests

## Validation
- `bunx tsc --noEmit`
- `bun test tests/tools/export-app/`
- `bun test tests/http/export/`
- `bun test tests/cli/backup/`
- `bun test tests/cli/data/export-import.test.ts`
- `bun test tests/cli/export/`
- `bun test tests/frontend/pages/export-app.test.tsx`
- `git diff --check`
- changed files <= 250 lines
