### PR TITLE
fix(vector): close search store on errors

### DIFF
--- a/src/routes/vector/search.ts
+++ b/src/routes/vector/search.ts
@@ -6,7 +6,7 @@ import type { SearchResult } from '../../server/types.ts';
 
 type SortField = 'score' | 'distance' | 'date' | 'id' | 'type' | 'source_file';
 type SortOrder = 'asc' | 'desc';
-type SearchStore = Pick<VectorStoreAdapter, 'connect' | 'ensureCollection' | 'query'>;
+type SearchStore = Pick<VectorStoreAdapter, 'connect' | 'ensureCollection' | 'query'> & Partial<Pick<VectorStoreAdapter, 'close'>>;
 
 interface VectorSearchDeps {
   getStore?: (collection?: string) => SearchStore;
@@ -206,15 +206,14 @@ export function createVectorSearchEndpoint(deps: VectorSearchDeps = {}) {
       return { error: 'Invalid metadata filter', message: error instanceof Error ? error.message : String(error) };
     }
 
-    const limit = positiveInt(query.limit, 10, MAX_LIMIT);
-    const offset = offsetOf(query.offset);
-    const from = timestamp(query.from ?? query.dateFrom);
-    const to = timestamp(query.to ?? query.dateTo);
+    const limit = positiveInt(query.limit, 10, MAX_LIMIT), offset = offsetOf(query.offset);
+    const from = timestamp(query.from ?? query.dateFrom), to = timestamp(query.to ?? query.dateTo);
     const sort = sortConfig(query.sort, query.order);
     const fetchLimit = Math.min(MAX_FETCH, Math.max(offset + limit, limit * 5));
 
+    let store: SearchStore | undefined;
     try {
-      const store = getStore(collection);
+      store = getStore(collection);
       await store.connect();
       await store.ensureCollection();
       const raw = await store.query(q, fetchLimit, Object.keys(metadata).length > 0 ? metadata : undefined);
@@ -238,6 +237,8 @@ export function createVectorSearchEndpoint(deps: VectorSearchDeps = {}) {
       set.status = 400;
       const message = error instanceof Error ? error.message : String(error);
       return { results: [], total: 0, query: q, error: 'Vector search failed', message };
+    } finally {
+      await store?.close?.().catch(() => undefined);
     }
   }, {
     query: VectorSearchQuery,

--- a/tests/http/vector/search.test.ts
+++ b/tests/http/vector/search.test.ts
@@ -5,13 +5,17 @@ import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant
 import { createVectorSearchEndpoint } from '../../../src/routes/vector/search.ts';
 import type { VectorQueryResult } from '../../../src/vector/types.ts';
 
-function createFetch(result: VectorQueryResult, collections = ['bge-m3', 'qwen3']) {
+function createFetch(
+  result: VectorQueryResult,
+  collections = ['bge-m3', 'qwen3'],
+  queryImpl: () => Promise<VectorQueryResult> = async () => result,
+) {
   const requested: string[] = [];
   const store = {
     connect: mock(async () => {}),
     ensureCollection: mock(async () => {}),
-    query: mock(async () => result),
-    getStats: mock(async () => ({ count: result.ids.length })),
+    query: mock(queryImpl),
+    close: mock(async () => {}),
   };
   const app = new Elysia({ prefix: '/api' }).use(createVectorSearchEndpoint({
     getModels: () => Object.fromEntries(collections.map((name) => [name, {}])),
@@ -57,6 +61,7 @@ test('GET /api/v1/vector/search filters selected collection before paginating so
   expect(res.status).toBe(200);
   expect(requested).toEqual(['qwen3']);
   expect(store.query).toHaveBeenCalledWith('oracle', 5, { origin: 'human', type: 'note' });
+  expect(store.close).toHaveBeenCalledTimes(1);
   expect(body.total).toBe(3);
   expect(body.offset).toBe(1);
   expect(body.limit).toBe(1);
@@ -106,6 +111,16 @@ test('GET /api/v1/vector/search scopes results by resolved tenant', async () => 
   expect(store.query).toHaveBeenCalledWith('oracle', 50, { tenant_id: 'tenant-a' });
   expect(body.filters.metadata).toEqual({ tenant_id: 'tenant-a' });
   expect(body.results.map((item) => item.id)).toEqual(['doc-a']);
+});
+
+test('GET /api/v1/vector/search closes stores when vector query fails', async () => {
+  const { fetcher, store } = createFetch(result, ['bge-m3'], async () => { throw new Error('adapter down'); });
+  const res = await fetcher(new Request('http://local/api/v1/vector/search?q=oracle'));
+  const body = await res.json() as Record<string, unknown>;
+
+  expect(res.status).toBe(400);
+  expect(body).toMatchObject({ results: [], total: 0, error: 'Vector search failed', message: 'adapter down' });
+  expect(store.close).toHaveBeenCalledTimes(1);
 });
 
 test('GET /api/v1/vector/search rejects bad filters and unknown collections', async () => {


### PR DESCRIPTION
## Summary
- Harden `src/routes/vector/search.ts` so vector stores are closed after successful searches and failure paths.
- Add HTTP coverage for vector query failures to lock the 400 response shape and close behavior.

## Scope
- Code changes limited to `src/routes/vector`.
- Tests limited to `tests/http/vector`.

## Validation
- `bun test tests/http/vector/` (76 pass)
- `bunx tsc --noEmit`
- `wc -l src/routes/vector/search.ts tests/http/vector/search.test.ts` (249 / 138)