### PR TITLE
fix(auth): harden auth and settings edge cases

### DIFF
--- a/src/routes/auth/index.ts
+++ b/src/routes/auth/index.ts
@@ -19,27 +19,29 @@ export const SESSION_DURATION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 type SessionPayload = { exp: number; tenant: string };
 
 export function isLocalIp(ip: string): boolean {
-  return ip === '127.0.0.1'
-      || ip === '::1'
-      || ip === 'localhost'
-      || ip.startsWith('192.168.')
-      || ip.startsWith('10.')
-      || ip.startsWith('172.16.')
-      || ip.startsWith('172.17.')
-      || ip.startsWith('172.18.')
-      || ip.startsWith('172.19.')
-      || ip.startsWith('172.20.')
-      || ip.startsWith('172.21.')
-      || ip.startsWith('172.22.')
-      || ip.startsWith('172.23.')
-      || ip.startsWith('172.24.')
-      || ip.startsWith('172.25.')
-      || ip.startsWith('172.26.')
-      || ip.startsWith('172.27.')
-      || ip.startsWith('172.28.')
-      || ip.startsWith('172.29.')
-      || ip.startsWith('172.30.')
-      || ip.startsWith('172.31.');
+  const value = ip.trim().toLowerCase();
+  const normalized = value.startsWith('::ffff:') ? value.slice('::ffff:'.length) : value;
+  return normalized === '127.0.0.1'
+      || normalized === '::1'
+      || normalized === 'localhost'
+      || normalized.startsWith('192.168.')
+      || normalized.startsWith('10.')
+      || normalized.startsWith('172.16.')
+      || normalized.startsWith('172.17.')
+      || normalized.startsWith('172.18.')
+      || normalized.startsWith('172.19.')
+      || normalized.startsWith('172.20.')
+      || normalized.startsWith('172.21.')
+      || normalized.startsWith('172.22.')
+      || normalized.startsWith('172.23.')
+      || normalized.startsWith('172.24.')
+      || normalized.startsWith('172.25.')
+      || normalized.startsWith('172.26.')
+      || normalized.startsWith('172.27.')
+      || normalized.startsWith('172.28.')
+      || normalized.startsWith('172.29.')
+      || normalized.startsWith('172.30.')
+      || normalized.startsWith('172.31.');
 }
 
 export function remoteAddress(server: any, request: Request): string {
@@ -88,6 +90,19 @@ function verifyLegacySessionToken(token: string, tenantId: string): boolean {
   if (isNaN(expires) || expires < Date.now()) return false;
 
   return safeCompare(signature, signatureFor(expiresStr));
+}
+
+export function usablePassword(value: string | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  return value.trim().length > 0 ? value : null;
+}
+
+export async function passwordMatches(password: string, hash: string): Promise<boolean> {
+  try {
+    return await Bun.password.verify(password, hash);
+  } catch {
+    return false;
+  }
 }
 
 export function generateSessionToken(tenantId = activeTenantId()): string {

--- a/src/routes/auth/login.ts
+++ b/src/routes/auth/login.ts
@@ -5,11 +5,13 @@ import {
   SESSION_DURATION_MS,
   generateSessionToken,
   isLocalNetwork,
+  passwordMatches,
+  usablePassword,
 } from './index.ts';
 import { LoginBody } from './model.ts';
 
 export const loginRoute = new Elysia().post('/login', async ({ body, server, request, cookie, set }) => {
-  const { password } = body;
+  const password = usablePassword(body.password);
   if (!password) {
     set.status = 400;
     return { success: false, error: 'Password required' };
@@ -21,7 +23,7 @@ export const loginRoute = new Elysia().post('/login', async ({ body, server, req
     return { success: false, error: 'No password configured' };
   }
 
-  const valid = await Bun.password.verify(password, storedHash);
+  const valid = await passwordMatches(password, storedHash);
   if (!valid) {
     set.status = 401;
     return { success: false, error: 'Invalid password' };

--- a/src/routes/settings/update.ts
+++ b/src/routes/settings/update.ts
@@ -1,30 +1,48 @@
 import { Elysia } from 'elysia';
 import { getScopedSetting, setScopedSetting } from '../../db/scoped-settings.ts';
 import { activeTenantId } from '../../middleware/tenant.ts';
+import { passwordMatches, usablePassword } from '../auth/index.ts';
 import { UpdateSettingsBody } from './model.ts';
 
 export const updateSettingsRoute = new Elysia().post('/', async ({ body, set }) => {
-  if (body.newPassword) {
+  const nextPassword = usablePassword(body.newPassword);
+  const currentPassword = usablePassword(body.currentPassword);
+
+  if (body.newPassword !== undefined && !nextPassword) {
+    set.status = 400;
+    return { error: 'Password required' };
+  }
+
+  if (nextPassword && body.removePassword === true) {
+    set.status = 400;
+    return { error: 'Cannot set and remove password in the same request' };
+  }
+
+  if (nextPassword) {
     const existingHash = getScopedSetting('auth_password_hash');
     if (existingHash) {
-      if (!body.currentPassword) {
+      if (!currentPassword) {
         set.status = 400;
         return { error: 'Current password required' };
       }
-      const valid = await Bun.password.verify(body.currentPassword, existingHash);
+      const valid = await passwordMatches(currentPassword, existingHash);
       if (!valid) {
         set.status = 401;
         return { error: 'Current password is incorrect' };
       }
     }
-    const hash = await Bun.password.hash(body.newPassword);
+    const hash = await Bun.password.hash(nextPassword);
     setScopedSetting('auth_password_hash', hash);
   }
 
   if (body.removePassword === true) {
     const existingHash = getScopedSetting('auth_password_hash');
-    if (existingHash && body.currentPassword) {
-      const valid = await Bun.password.verify(body.currentPassword, existingHash);
+    if (existingHash) {
+      if (!currentPassword) {
+        set.status = 400;
+        return { error: 'Current password required' };
+      }
+      const valid = await passwordMatches(currentPassword, existingHash);
       if (!valid) {
         set.status = 401;
         return { error: 'Current password is incorrect' };

--- a/tests/http/auth/login-hardening.test.ts
+++ b/tests/http/auth/login-hardening.test.ts
@@ -1,0 +1,63 @@
+import { afterAll, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const root = mkdtempSync(join(tmpdir(), 'auth-login-hardening-'));
+const dbPath = join(root, 'oracle.db');
+const restoreDbPath = savedDbPath
+  ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = dbPath;
+
+const dbMod = await import('../../../src/db/index.ts');
+dbMod.resetDefaultDatabaseForTests(dbPath);
+const { setScopedSetting } = await import('../../../src/db/scoped-settings.ts');
+const { authRoutes, isLocalIp } = await import('../../../src/routes/auth/index.ts');
+
+function restore(name: string, value: string | undefined) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+async function login(body: Record<string, unknown>): Promise<Response> {
+  return authRoutes.handle(new Request('http://local/api/auth/login', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+}
+
+afterAll(() => {
+  dbMod.closeDb();
+  restore('ORACLE_DATA_DIR', savedDataDir);
+  restore('ORACLE_DB_PATH', savedDbPath);
+  dbMod.resetDefaultDatabaseForTests(restoreDbPath);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('POST /api/auth/login rejects whitespace-only passwords before verification', async () => {
+  setScopedSetting('auth_password_hash', await Bun.password.hash('secret'));
+
+  const res = await login({ password: '   \t' });
+  expect(res.status).toBe(400);
+  expect(await res.json()).toMatchObject({ success: false, error: 'Password required' });
+});
+
+test('POST /api/auth/login treats corrupt stored hashes as auth failure', async () => {
+  setScopedSetting('auth_password_hash', 'not-a-valid-password-hash');
+
+  const res = await login({ password: 'secret' });
+  expect(res.status).toBe(401);
+  expect(await res.json()).toMatchObject({ success: false, error: 'Invalid password' });
+});
+
+test('isLocalIp recognizes IPv4-mapped local addresses narrowly', () => {
+  expect(isLocalIp(' ::ffff:127.0.0.1 ')).toBe(true);
+  expect(isLocalIp('::ffff:10.2.3.4')).toBe(true);
+  expect(isLocalIp('172.31.255.255')).toBe(true);
+  expect(isLocalIp('172.32.0.1')).toBe(false);
+  expect(isLocalIp('::ffff:8.8.8.8')).toBe(false);
+});

--- a/tests/http/settings/update-hardening.test.ts
+++ b/tests/http/settings/update-hardening.test.ts
@@ -1,0 +1,87 @@
+import { afterAll, beforeEach, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const root = mkdtempSync(join(tmpdir(), 'settings-update-hardening-'));
+const dbPath = join(root, 'oracle.db');
+const restoreDbPath = savedDbPath
+  ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = dbPath;
+
+const dbMod = await import('../../../src/db/index.ts');
+dbMod.resetDefaultDatabaseForTests(dbPath);
+const { getScopedSetting, setScopedSetting } = await import('../../../src/db/scoped-settings.ts');
+const { updateSettingsRoute } = await import('../../../src/routes/settings/update.ts');
+
+function restore(name: string, value: string | undefined) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+async function postSettings(body: Record<string, unknown>): Promise<Response> {
+  return updateSettingsRoute.handle(new Request('http://local/', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+}
+
+beforeEach(() => {
+  setScopedSetting('auth_password_hash', null);
+  setScopedSetting('auth_enabled', null);
+  setScopedSetting('auth_local_bypass', null);
+});
+
+afterAll(() => {
+  dbMod.closeDb();
+  restore('ORACLE_DATA_DIR', savedDataDir);
+  restore('ORACLE_DB_PATH', savedDbPath);
+  dbMod.resetDefaultDatabaseForTests(restoreDbPath);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('POST /api/settings rejects blank new passwords without side effects', async () => {
+  const res = await postSettings({ newPassword: '  ', authEnabled: true });
+  expect(res.status).toBe(400);
+  expect(await res.json()).toMatchObject({ error: 'Password required' });
+  expect(getScopedSetting('auth_password_hash')).toBeNull();
+  expect(getScopedSetting('auth_enabled')).toBeNull();
+});
+
+test('POST /api/settings requires current password before removal', async () => {
+  const hash = await Bun.password.hash('old-secret');
+  setScopedSetting('auth_password_hash', hash);
+
+  const res = await postSettings({ removePassword: true });
+  expect(res.status).toBe(400);
+  expect(await res.json()).toMatchObject({ error: 'Current password required' });
+  expect(await Bun.password.verify('old-secret', getScopedSetting('auth_password_hash')!)).toBe(true);
+});
+
+test('POST /api/settings rejects set-and-remove conflicts before mutation', async () => {
+  setScopedSetting('auth_password_hash', await Bun.password.hash('old-secret'));
+  setScopedSetting('auth_enabled', 'true');
+
+  const res = await postSettings({
+    newPassword: 'new-secret',
+    removePassword: true,
+    currentPassword: 'old-secret',
+  });
+  expect(res.status).toBe(400);
+  expect(await res.json()).toMatchObject({ error: 'Cannot set and remove password in the same request' });
+  expect(await Bun.password.verify('old-secret', getScopedSetting('auth_password_hash')!)).toBe(true);
+  expect(getScopedSetting('auth_enabled')).toBe('true');
+});
+
+test('POST /api/settings treats corrupt stored hashes as failed verification', async () => {
+  setScopedSetting('auth_password_hash', 'not-a-valid-password-hash');
+
+  const res = await postSettings({ newPassword: 'new-secret', currentPassword: 'old-secret' });
+  expect(res.status).toBe(401);
+  expect(await res.json()).toMatchObject({ error: 'Current password is incorrect' });
+  expect(getScopedSetting('auth_password_hash')).toBe('not-a-valid-password-hash');
+});


### PR DESCRIPTION
## Summary
- Harden auth password handling: reject whitespace-only passwords and treat corrupt stored hashes as authentication failures instead of throwing.
- Harden settings password updates: reject blank new passwords, reject set+remove conflicts before mutation, and require current password before removing an existing password.
- Recognize IPv4-mapped local addresses in local-bypass detection without broadening private-range checks.
- Add focused auth/settings edge-case tests.

## Scope
Only touched:
- `src/routes/auth/*`
- `src/routes/settings/*`
- matching `tests/http/auth/*` and `tests/http/settings/*`

No `ψ/` changes.

## Tests
- `bunx tsc --noEmit`
- `ORACLE_DATA_DIR=$(mktemp -d) ORACLE_DB_PATH=$ORACLE_DATA_DIR/oracle.db bun test tests/http/auth/ tests/http/settings/ tests/http/auth-settings.test.ts` — 31 pass, 0 fail
- `git diff --check origin/alpha...HEAD`
- changed file line counts: 145, 51, 81, 63, 87
