### PR TITLE
fix(routes): harden schedule and session edge cases

### DIFF
--- a/src/routes/schedule/list.ts
+++ b/src/routes/schedule/list.ts
@@ -5,8 +5,22 @@ import { currentTenantId } from '../../middleware/tenant.ts';
 import { parseDate } from '../../tools/schedule.ts';
 import { listQuery } from './model.ts';
 
-export const scheduleListRoute = new Elysia().get('/api/schedule', async ({ query }) => {
-  const limit = query.limit ? parseInt(query.limit) : 50;
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+function readLimit(value?: string): number | string {
+  if (value === undefined) return DEFAULT_LIMIT;
+  const limit = Number(value);
+  if (!Number.isInteger(limit) || limit < 1) return `limit must be an integer between 1 and ${MAX_LIMIT}`;
+  return Math.min(limit, MAX_LIMIT);
+}
+
+export const scheduleListRoute = new Elysia().get('/api/schedule', async ({ query, set }) => {
+  const limit = readLimit(query.limit);
+  if (typeof limit === 'string') {
+    set.status = 400;
+    return { total: 0, events: [], byDate: {}, error: limit };
+  }
   const conditions: SQL[] = [];
   const tenantId = currentTenantId();
   if (tenantId) conditions.push(eq(schedule.tenantId, tenantId));

--- a/src/routes/schedule/update.ts
+++ b/src/routes/schedule/update.ts
@@ -2,15 +2,35 @@ import { Elysia } from 'elysia';
 import { and, eq } from 'drizzle-orm';
 import { db, schedule } from '../../db/index.ts';
 import { currentTenantId } from '../../middleware/tenant.ts';
+import { parseDate } from '../../tools/schedule.ts';
 import { scheduleIdParam, updateBody } from './model.ts';
 
+function readScheduleId(value: string): number | null {
+  const id = Number(value);
+  return Number.isSafeInteger(id) && id > 0 ? id : null;
+}
+
+function updateValues(body: unknown, updatedAt: number): Record<string, unknown> {
+  const data = body as Record<string, unknown>;
+  const values: Record<string, unknown> = { ...data, updatedAt };
+  if (typeof data.date === 'string') {
+    values.date = parseDate(data.date);
+    values.dateRaw = data.date;
+  }
+  return values;
+}
+
 export const scheduleUpdateRoute = new Elysia().patch('/api/schedule/:id', async ({ params, body, set }) => {
-  const id = parseInt(params.id);
+  const id = readScheduleId(params.id);
+  if (!id) {
+    set.status = 400;
+    return { success: false, error: 'Invalid schedule id' };
+  }
   const now = Date.now();
   const tenantId = currentTenantId();
   const where = tenantId ? and(eq(schedule.id, id), eq(schedule.tenantId, tenantId)) : eq(schedule.id, id);
   const row = db.update(schedule)
-    .set({ ...(body as any), updatedAt: now })
+    .set(updateValues(body, now))
     .where(where)
     .returning({ id: schedule.id })
     .get();

--- a/src/routes/sessions/summary.ts
+++ b/src/routes/sessions/summary.ts
@@ -2,6 +2,15 @@ import { Elysia } from 'elysia';
 import { SummaryParams, SummaryBody, MAX_SUMMARY_CHARS } from './model.ts';
 import { persistSessionSummary } from './store.ts';
 
+function persistenceError(error: unknown): { status: 400 | 409 | 500; body: { error: string } } {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message === 'Invalid session id') return { status: 400, body: { error: 'Invalid session id' } };
+  if (message.startsWith('File already exists:')) {
+    return { status: 409, body: { error: 'Session summary already exists' } };
+  }
+  return { status: 500, body: { error: 'Could not persist session summary' } };
+}
+
 export const summaryRoute = new Elysia().post(
   '/api/session/:id/summary',
   ({ params, body, set }) => {
@@ -14,8 +23,14 @@ export const summaryRoute = new Elysia().post(
       set.status = 400;
       return { error: `summary exceeds max length (${MAX_SUMMARY_CHARS} chars)` };
     }
-    set.status = 201;
-    return persistSessionSummary(params.id, summary, body.oracle);
+    try {
+      set.status = 201;
+      return persistSessionSummary(params.id, summary, body.oracle);
+    } catch (error) {
+      const response = persistenceError(error);
+      set.status = response.status;
+      return response.body;
+    }
   },
   {
     params: SummaryParams,

--- a/tests/http/schedule/tenant-isolation.test.ts
+++ b/tests/http/schedule/tenant-isolation.test.ts
@@ -36,10 +36,10 @@ async function json(res: Response): Promise<Json> {
   return await res.json() as Json;
 }
 
-async function createEvent(tenantId: string, event: string): Promise<number> {
+async function createEvent(tenantId: string, event: string, eventDate = date): Promise<number> {
   const res = await scheduleRequest(tenantId, '/api/schedule', {
     method: 'POST',
-    body: JSON.stringify({ date, event, time: '10:00', notes: tenantId }),
+    body: JSON.stringify({ date: eventDate, event, time: '10:00', notes: tenantId }),
   });
   expect(res.status).toBe(200);
   return (await json(res)).id as number;
@@ -47,6 +47,7 @@ async function createEvent(tenantId: string, event: string): Promise<number> {
 
 afterAll(() => {
   try { dbMod.closeDb(); } catch {}
+  dbMod.resetDefaultDatabaseForTests(':memory:');
   if (previousDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
   else process.env.ORACLE_DATA_DIR = previousDataDir;
   if (previousDbPath === undefined) delete process.env.ORACLE_DB_PATH;
@@ -54,9 +55,6 @@ afterAll(() => {
   if (previousRepoRoot === undefined) delete process.env.ORACLE_REPO_ROOT;
   else process.env.ORACLE_REPO_ROOT = previousRepoRoot;
   rmSync(root, { recursive: true, force: true });
-  const restoreDbPath = previousDbPath
-    ?? join(previousDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
-  dbMod.resetDefaultDatabaseForTests(restoreDbPath);
 });
 
 test('schedule HTTP routes isolate create/list/update/markdown by tenant', async () => {
@@ -86,4 +84,41 @@ test('schedule HTTP routes isolate create/list/update/markdown by tenant', async
   const mdA = await (await scheduleRequest(tenantA, '/api/schedule/md')).text();
   expect(mdA).toContain(eventA);
   expect(mdA).not.toContain(eventB);
+});
+
+test('schedule list rejects invalid limits and clamps large limits', async () => {
+  const tenant = `tenant-limit-${stamp}`;
+  await createEvent(tenant, `limit one ${stamp}`, '2036-04-06');
+  await createEvent(tenant, `limit two ${stamp}`, '2036-04-07');
+
+  const invalid = await scheduleRequest(tenant, '/api/schedule?status=all&limit=zero');
+  expect(invalid.status).toBe(400);
+  expect(await json(invalid)).toMatchObject({ error: 'limit must be an integer between 1 and 200' });
+
+  const range = 'from=2036-04-01&to=2036-04-30';
+  const limited = await json(await scheduleRequest(tenant, `/api/schedule?status=all&${range}&limit=1`));
+  expect(limited.total).toBe(1);
+
+  const clamped = await json(await scheduleRequest(tenant, `/api/schedule?status=all&${range}&limit=999`));
+  expect(clamped.events.length).toBeGreaterThanOrEqual(2);
+});
+
+test('schedule update rejects bad ids and normalizes patched dates', async () => {
+  const tenant = `tenant-update-${stamp}`;
+  const id = await createEvent(tenant, `normalize date ${stamp}`, '2036-04-08');
+
+  const invalid = await scheduleRequest(tenant, '/api/schedule/not-a-number', {
+    method: 'PATCH',
+    body: JSON.stringify({ status: 'done' }),
+  });
+  expect(invalid.status).toBe(400);
+  expect(await json(invalid)).toEqual({ success: false, error: 'Invalid schedule id' });
+
+  const patch = await scheduleRequest(tenant, `/api/schedule/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ date: '5 Mar 2036' }),
+  });
+  expect(patch.status).toBe(200);
+  const row = dbMod.sqlite.prepare('SELECT date, date_raw FROM schedule WHERE id = ?').get(id) as { date: string; date_raw: string };
+  expect(row).toEqual({ date: '2036-03-05', date_raw: '5 Mar 2036' });
 });

--- a/tests/http/sessions/summary.test.ts
+++ b/tests/http/sessions/summary.test.ts
@@ -18,6 +18,7 @@ process.env.ORACLE_REPO_ROOT = root;
 const dbMod = await import('../../../src/db/index.ts');
 dbMod.resetDefaultDatabaseForTests(dbPath);
 const { sessionsRoutes } = await import('../../../src/routes/sessions/index.ts');
+const { MAX_SUMMARY_CHARS } = await import('../../../src/routes/sessions/model.ts');
 const { createTenantFetch, DEFAULT_TENANT_ID, TENANT_HEADER } = await import('../../../src/middleware/tenant.ts');
 
 function restore(name: string, value: string | undefined) {
@@ -50,6 +51,29 @@ describe('session summary HTTP route', () => {
     const res = await post('empty-session', { summary: '   ' });
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ error: 'Missing required field: summary' });
+  });
+
+  test('rejects summaries over the configured maximum before writing a document', async () => {
+    const sessionId = `too-long-${Date.now()}`;
+    const res = await post(sessionId, { summary: 'x'.repeat(MAX_SUMMARY_CHARS + 1) });
+    const body = await res.json() as Record<string, string>;
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe(`summary exceeds max length (${MAX_SUMMARY_CHARS} chars)`);
+    const row = dbMod.db.select().from(dbMod.oracleDocuments)
+      .where(eq(dbMod.oracleDocuments.id, `session-summary_${sessionId}`))
+      .get();
+    expect(row).toBeUndefined();
+  });
+
+  test('returns a conflict instead of throwing when a summary file already exists', async () => {
+    const sessionId = `duplicate-${Date.now()}`;
+    const first = await post(sessionId, { summary: 'First duplicate summary.' });
+    const second = await post(sessionId, { summary: 'Second duplicate summary.' });
+
+    expect(first.status).toBe(201);
+    expect(second.status).toBe(409);
+    expect(await second.json()).toEqual({ error: 'Session summary already exists' });
   });
 
   test('separates identical session summary ids by active tenant', async () => {


### PR DESCRIPTION
## Summary
- harden schedule listing against invalid/oversized limits and return structured 400s
- harden schedule PATCH ids and normalize patched dates/dateRaw consistently with create
- harden session summary duplicate-file persistence into a 409 response and cover oversize summary no-write behavior

## Verification
- git fetch origin && git rebase origin/alpha
- bunx tsc --noEmit
- bun test tests/http/schedule/ tests/http/sessions/
- bun test --isolate tests/http/schedule/ tests/http/sessions/
- git diff --check
- wc -l src/routes/schedule/list.ts src/routes/schedule/update.ts src/routes/sessions/summary.ts tests/http/schedule/tenant-isolation.test.ts tests/http/sessions/summary.test.ts