### PR TITLE
feat: extract shared canvas plugins package

### DIFF
--- a/frontend/src/api/canvas-plugins.ts
+++ b/frontend/src/api/canvas-plugins.ts
@@ -1,40 +1,24 @@
+import type {
+  CanvasPluginKind,
+  CanvasPluginMetadataEntry,
+  CanvasPluginMetadataRegistry,
+  CanvasPluginRegistry,
+} from '@soul-brews/canvas-plugins';
 import { API_BASE } from './oracle';
 
-export type CanvasPluginKind = 'three' | 'react';
-
-interface BaseCanvasPluginEntry {
-  id: string;
-  label: string;
-  description: string;
-  kind: CanvasPluginKind;
+export type { CanvasPluginKind } from '@soul-brews/canvas-plugins';
+export type CanvasPluginEntry = Omit<CanvasPluginMetadataEntry, 'renderer'> & {
   path?: string;
   query?: { plugin: string };
-  standalonePath?: string;
   renderer?: string;
-  apiPath?: string;
-}
-
-export interface ThreeCanvasPluginEntry extends BaseCanvasPluginEntry {
-  kind: 'three';
   mount?: string;
-}
-
-export interface ReactCanvasPluginEntry extends BaseCanvasPluginEntry {
-  kind: 'react';
-  renderer: string;
-}
-
-export type CanvasPluginEntry = ThreeCanvasPluginEntry | ReactCanvasPluginEntry;
+};
 
 export interface CanvasPluginsResponse {
   plugins: CanvasPluginEntry[];
   count: number;
   kind: CanvasPluginKind | 'all' | 'canvas';
-  standalone?: {
-    host: string;
-    defaultPlugin: string;
-    serveCommand?: string;
-  };
+  standalone?: (CanvasPluginRegistry | CanvasPluginMetadataRegistry)['standalone'];
 }
 
 function urlFor(path: string): string {

--- a/frontend/src/routePaths.ts
+++ b/frontend/src/routePaths.ts
@@ -1,3 +1,5 @@
+import { CANVAS_ORIGIN, DEFAULT_CANVAS_PLUGIN, canvasPluginPath } from '@soul-brews/canvas-plugins';
+
 export function mcpToolPath(name: string): string {
   return `/mcp/tools/${encodeURIComponent(name)}`;
 }
@@ -73,21 +75,16 @@ export function vectorSettingsPath(): string {
   return '/vector/settings';
 }
 
-const CANVAS_STANDALONE_ORIGIN = 'https://canvas.buildwithoracle.com';
-const CLEAN_CANVAS_PLUGINS = new Set(['map', 'planets']);
-
 export function canvasAppPath(plugin = 'wave'): string {
   const id = plugin.trim();
   return id ? `/canvas?${new URLSearchParams({ plugin: id })}` : '/canvas';
 }
 
-export function canvasStandalonePath(plugin = 'wave'): string {
-  const id = plugin.trim() || 'wave';
-  if (CLEAN_CANVAS_PLUGINS.has(id)) return `/${id}`;
-  return `/?${new URLSearchParams({ plugin: id })}`;
+export function canvasStandalonePath(plugin = DEFAULT_CANVAS_PLUGIN): string {
+  return canvasPluginPath(plugin);
 }
 
-export function canvasStandaloneUrl(plugin = 'wave', origin = CANVAS_STANDALONE_ORIGIN): string {
+export function canvasStandaloneUrl(plugin = DEFAULT_CANVAS_PLUGIN, origin = CANVAS_ORIGIN): string {
   return new URL(canvasStandalonePath(plugin), origin).toString();
 }
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -2,7 +2,11 @@
   "compilerOptions": {
     "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ES2022"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -15,7 +19,18 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["vite/client"]
+    "types": [
+      "vite/client"
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@soul-brews/canvas-plugins": [
+        "../packages/canvas-plugins/src/index.ts"
+      ]
+    }
   },
-  "include": ["src", "vite.config.ts"]
+  "include": [
+    "src",
+    "vite.config.ts"
+  ]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,6 +7,11 @@ const proxyTarget = env?.FRONTEND_PROXY_TARGET ?? 'http://127.0.0.1:47778';
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@soul-brews/canvas-plugins': new URL('../packages/canvas-plugins/src/index.ts', import.meta.url).pathname,
+    },
+  },
   server: {
     port: Number(env?.VITE_PORT ?? 3000),
     strictPort: true,

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "bin",
     "src",
     "cli",
+    "packages",
     "README.md"
   ],
   "engines": {

--- a/packages/canvas-plugins/package.json
+++ b/packages/canvas-plugins/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@soul-brews/canvas-plugins",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "types": "./src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json --noEmit"
+  }
+}

--- a/packages/canvas-plugins/src/index.ts
+++ b/packages/canvas-plugins/src/index.ts
@@ -1,0 +1,153 @@
+export const CANVAS_HOST = 'canvas.buildwithoracle.com';
+export const CANVAS_ORIGIN = `https://${CANVAS_HOST}`;
+export const DEFAULT_CANVAS_PLUGIN = 'wave';
+
+export type CanvasPluginKind = 'three' | 'react';
+export type ThreeCanvasMount = 'cubeScene' | 'galaxyScene' | 'torusScene' | 'graph3dScene' | 'solarScene' | 'waveScene' | 'map3dScene';
+export type ReactCanvasRenderer = 'KnowledgeMapCanvas' | 'PlanetsCanvas';
+
+interface BaseCanvasPlugin {
+  id: string;
+  label: string;
+  description: string;
+  path: string;
+  query: { plugin: string };
+}
+
+export interface CanvasThreePlugin extends BaseCanvasPlugin {
+  kind: 'three';
+  mount: ThreeCanvasMount;
+}
+
+export interface CanvasReactPlugin extends BaseCanvasPlugin {
+  kind: 'react';
+  renderer: ReactCanvasRenderer;
+  apiPath: string;
+}
+
+export type CanvasPlugin = CanvasThreePlugin | CanvasReactPlugin;
+export type CanvasPluginDescriptor = CanvasPlugin;
+export type CanvasPluginRenderer = 'Three' | 'React';
+
+export type CanvasRegistryPlugin = CanvasPlugin & { standalonePath: string };
+
+export interface CanvasStandaloneRegistry {
+  host: string;
+  defaultPlugin: string;
+  serveCommand: string;
+}
+
+export interface CanvasPluginRegistry {
+  plugins: CanvasRegistryPlugin[];
+  count: number;
+  kind: CanvasPluginKind | 'all';
+  standalone: CanvasStandaloneRegistry;
+}
+
+export interface CanvasPluginMetadataEntry {
+  id: string;
+  label: string;
+  kind: CanvasPluginKind;
+  renderer: CanvasPluginRenderer;
+  description?: string;
+  standalonePath?: string;
+  apiPath?: string;
+}
+
+export interface CanvasPluginMetadataRegistry {
+  kind: 'canvas';
+  count: number;
+  plugins: CanvasPluginMetadataEntry[];
+  standalone: CanvasStandaloneRegistry;
+}
+
+export const CANVAS_THREE_PLUGINS: readonly CanvasThreePlugin[] = [
+  { id: 'cube', label: 'Cube', description: 'Rotating geometry scene.', kind: 'three', mount: 'cubeScene', path: '/canvas', query: { plugin: 'cube' } },
+  { id: 'galaxy', label: 'Galaxy', description: 'Particle galaxy scene.', kind: 'three', mount: 'galaxyScene', path: '/canvas', query: { plugin: 'galaxy' } },
+  { id: 'torus', label: 'Torus', description: 'Torus knot scene.', kind: 'three', mount: 'torusScene', path: '/canvas', query: { plugin: 'torus' } },
+  { id: 'graph3d', label: 'Graph 3D', description: 'Three-dimensional graph scene.', kind: 'three', mount: 'graph3dScene', path: '/canvas', query: { plugin: 'graph3d' } },
+  { id: 'solar', label: 'Solar', description: 'Solar orbit scene.', kind: 'three', mount: 'solarScene', path: '/canvas', query: { plugin: 'solar' } },
+  { id: 'wave', label: 'Wave', description: 'Wave field scene.', kind: 'three', mount: 'waveScene', path: '/canvas', query: { plugin: 'wave' } },
+  { id: 'map3d', label: 'Map 3D', description: 'Legacy 3D knowledge map scene.', kind: 'three', mount: 'map3dScene', path: '/canvas', query: { plugin: 'map3d' } },
+];
+
+export const CANVAS_REACT_PLUGINS: readonly CanvasReactPlugin[] = [
+  { id: 'map', label: 'Knowledge Map', description: 'React knowledge-map canvas backed by /api/map3d.', kind: 'react', renderer: 'KnowledgeMapCanvas', path: '/map', query: { plugin: 'map' }, apiPath: '/api/map3d' },
+  { id: 'planets', label: 'Planets', description: 'React orbital canvas view.', kind: 'react', renderer: 'PlanetsCanvas', path: '/planets', query: { plugin: 'planets' }, apiPath: '/api/map3d' },
+];
+
+export const CANVAS_PLUGINS: readonly CanvasPlugin[] = [...CANVAS_THREE_PLUGINS, ...CANVAS_REACT_PLUGINS];
+
+const kinds = new Set<CanvasPluginKind>(['three', 'react']);
+
+export function parseCanvasKind(value: unknown): CanvasPluginKind | undefined {
+  return typeof value === 'string' && kinds.has(value as CanvasPluginKind) ? value as CanvasPluginKind : undefined;
+}
+
+export function listCanvasPlugins(kind?: CanvasPluginKind): CanvasPlugin[] {
+  return kind ? CANVAS_PLUGINS.filter((plugin) => plugin.kind === kind) : [...CANVAS_PLUGINS];
+}
+
+export function findCanvasPlugin(id: string): CanvasPlugin | undefined {
+  return CANVAS_PLUGINS.find((plugin) => plugin.id === id);
+}
+
+export function canvasPluginPath(id: string): string {
+  const pluginId = id.trim() || DEFAULT_CANVAS_PLUGIN;
+  const plugin = findCanvasPlugin(pluginId);
+  if (plugin?.kind === 'react') return `/${plugin.id}`;
+  return `/?${new URLSearchParams({ plugin: pluginId })}`;
+}
+
+export function canvasPluginAbsoluteUrl(id: string, origin = CANVAS_ORIGIN): string {
+  return new URL(canvasPluginPath(id), origin).toString();
+}
+
+export function canvasPluginDataPath(id: string): string | undefined {
+  const plugin = findCanvasPlugin(id);
+  return plugin?.kind === 'react' ? plugin.apiPath : undefined;
+}
+
+function standalone(): CanvasStandaloneRegistry {
+  return {
+    host: CANVAS_HOST,
+    defaultPlugin: DEFAULT_CANVAS_PLUGIN,
+    serveCommand: 'bun run src/cli/index.ts canvas-serve --port 47779',
+  };
+}
+
+export function canvasRegistry(kind?: CanvasPluginKind): CanvasPluginRegistry {
+  const plugins = listCanvasPlugins(kind).map((plugin) => ({ ...plugin, standalonePath: canvasPluginPath(plugin.id) }));
+  return { plugins, count: plugins.length, kind: kind ?? 'all', standalone: standalone() };
+}
+
+export function canvasPluginEntry(id: string): { plugin: CanvasRegistryPlugin } | null {
+  const plugin = findCanvasPlugin(id);
+  return plugin ? { plugin: { ...plugin, standalonePath: canvasPluginPath(plugin.id) } } : null;
+}
+
+function rendererFor(kind: CanvasPluginKind): CanvasPluginRenderer {
+  return kind === 'three' ? 'Three' : 'React';
+}
+
+function metadataFromPlugin(plugin: CanvasPlugin): CanvasPluginMetadataEntry {
+  return { id: plugin.id, label: plugin.label, kind: plugin.kind, renderer: rendererFor(plugin.kind), description: plugin.description };
+}
+
+export const CANVAS_PLUGIN_METADATA: CanvasPluginMetadataEntry[] = listCanvasPlugins().map(metadataFromPlugin);
+
+export function listCanvasPluginMetadata(): { kind: 'canvas'; plugins: CanvasPluginMetadataEntry[] } {
+  return {
+    kind: 'canvas',
+    plugins: listCanvasPlugins().map((plugin) => ({
+      ...metadataFromPlugin(plugin),
+      standalonePath: canvasPluginPath(plugin.id),
+      apiPath: canvasPluginDataPath(plugin.id),
+    })),
+  };
+}
+
+export function canvasPluginMetadataRegistry(): CanvasPluginMetadataRegistry {
+  const metadata = listCanvasPluginMetadata();
+  return { ...metadata, count: metadata.plugins.length, standalone: standalone() };
+}

--- a/packages/canvas-plugins/tsconfig.json
+++ b/packages/canvas-plugins/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM"],
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/src/canvas/metadata.ts
+++ b/src/canvas/metadata.ts
@@ -1,54 +1,10 @@
-import { listCanvasPlugins, type CanvasPluginDescriptor, type CanvasPluginKind } from './plugins.ts';
-import { canvasRegistry } from './registry.ts';
-import { canvasPluginDataPath, canvasPluginPath } from './urls.ts';
-
-export type CanvasPluginRenderer = 'Three' | 'React';
-
-export interface CanvasPluginMetadataEntry {
-  id: string;
-  label: string;
-  kind: CanvasPluginKind;
-  renderer: CanvasPluginRenderer;
-  description?: string;
-  standalonePath?: string;
-  apiPath?: string;
-}
-
-export interface CanvasPluginMetadataRegistry {
-  kind: 'canvas';
-  count: number;
-  plugins: CanvasPluginMetadataEntry[];
-  standalone: ReturnType<typeof canvasRegistry>['standalone'];
-}
-
-function rendererFor(kind: CanvasPluginKind): CanvasPluginRenderer {
-  return kind === 'three' ? 'Three' : 'React';
-}
-
-function metadataFromPlugin(plugin: CanvasPluginDescriptor): CanvasPluginMetadataEntry {
-  return {
-    id: plugin.id,
-    label: plugin.label,
-    kind: plugin.kind,
-    renderer: rendererFor(plugin.kind),
-    description: plugin.description,
-  };
-}
-
-export const CANVAS_PLUGIN_METADATA: CanvasPluginMetadataEntry[] = listCanvasPlugins().map(metadataFromPlugin);
-
-export function listCanvasPluginMetadata(): { kind: 'canvas'; plugins: CanvasPluginMetadataEntry[] } {
-  return {
-    kind: 'canvas',
-    plugins: listCanvasPlugins().map((plugin) => ({
-      ...metadataFromPlugin(plugin),
-      standalonePath: canvasPluginPath(plugin.id),
-      apiPath: canvasPluginDataPath(plugin.id) ?? ('apiPath' in plugin ? plugin.apiPath : undefined),
-    })),
-  };
-}
-
-export function canvasPluginMetadataRegistry(): CanvasPluginMetadataRegistry {
-  const metadata = listCanvasPluginMetadata();
-  return { ...metadata, count: metadata.plugins.length, standalone: canvasRegistry().standalone };
-}
+export type {
+  CanvasPluginMetadataEntry,
+  CanvasPluginMetadataRegistry,
+  CanvasPluginRenderer,
+} from '@soul-brews/canvas-plugins';
+export {
+  CANVAS_PLUGIN_METADATA,
+  canvasPluginMetadataRegistry,
+  listCanvasPluginMetadata,
+} from '@soul-brews/canvas-plugins';

--- a/src/canvas/plugins.ts
+++ b/src/canvas/plugins.ts
@@ -1,47 +1,13 @@
-export type CanvasPluginKind = 'three' | 'react';
-
-interface BaseCanvasPlugin {
-  id: string;
-  label: string;
-  description: string;
-  path: string;
-  query: { plugin: string };
-}
-
-export interface ThreeCanvasPlugin extends BaseCanvasPlugin {
-  kind: 'three';
-  mount: string;
-}
-
-export interface ReactCanvasPlugin extends BaseCanvasPlugin {
-  kind: 'react';
-  renderer: string;
-  apiPath?: string;
-}
-
-export type CanvasPluginDescriptor = ThreeCanvasPlugin | ReactCanvasPlugin;
-
-const THREE_PLUGINS: readonly ThreeCanvasPlugin[] = [
-  { id: 'cube', label: 'Cube', description: 'Rotating geometry scene.', kind: 'three', mount: 'cubeScene', path: '/canvas', query: { plugin: 'cube' } },
-  { id: 'galaxy', label: 'Galaxy', description: 'Particle galaxy scene.', kind: 'three', mount: 'galaxyScene', path: '/canvas', query: { plugin: 'galaxy' } },
-  { id: 'torus', label: 'Torus', description: 'Torus knot scene.', kind: 'three', mount: 'torusScene', path: '/canvas', query: { plugin: 'torus' } },
-  { id: 'graph3d', label: 'Graph 3D', description: 'Three-dimensional graph scene.', kind: 'three', mount: 'graph3dScene', path: '/canvas', query: { plugin: 'graph3d' } },
-  { id: 'solar', label: 'Solar', description: 'Solar orbit scene.', kind: 'three', mount: 'solarScene', path: '/canvas', query: { plugin: 'solar' } },
-  { id: 'wave', label: 'Wave', description: 'Wave field scene.', kind: 'three', mount: 'waveScene', path: '/canvas', query: { plugin: 'wave' } },
-  { id: 'map3d', label: 'Map 3D', description: 'Legacy 3D knowledge map scene.', kind: 'three', mount: 'map3dScene', path: '/canvas', query: { plugin: 'map3d' } },
-];
-
-const REACT_PLUGINS: readonly ReactCanvasPlugin[] = [
-  { id: 'map', label: 'Knowledge Map', description: 'React knowledge-map canvas backed by /api/map3d.', kind: 'react', renderer: 'KnowledgeMapCanvas', path: '/map', query: { plugin: 'map' }, apiPath: '/api/map3d' },
-  { id: 'planets', label: 'Planets', description: 'React orbital canvas view.', kind: 'react', renderer: 'PlanetsCanvas', path: '/planets', query: { plugin: 'planets' }, apiPath: '/api/map3d' },
-];
-
-export const CANVAS_PLUGINS: readonly CanvasPluginDescriptor[] = [...THREE_PLUGINS, ...REACT_PLUGINS];
-
-export function listCanvasPlugins(kind?: CanvasPluginKind): CanvasPluginDescriptor[] {
-  return kind ? CANVAS_PLUGINS.filter((plugin) => plugin.kind === kind) : [...CANVAS_PLUGINS];
-}
-
-export function findCanvasPlugin(id: string): CanvasPluginDescriptor | undefined {
-  return CANVAS_PLUGINS.find((plugin) => plugin.id === id);
-}
+export type {
+  CanvasPlugin as CanvasPluginDescriptor,
+  CanvasPluginKind,
+  CanvasReactPlugin as ReactCanvasPlugin,
+  CanvasThreePlugin as ThreeCanvasPlugin,
+} from '@soul-brews/canvas-plugins';
+export {
+  CANVAS_PLUGINS,
+  CANVAS_REACT_PLUGINS,
+  CANVAS_THREE_PLUGINS,
+  findCanvasPlugin,
+  listCanvasPlugins,
+} from '@soul-brews/canvas-plugins';

--- a/src/canvas/registry.ts
+++ b/src/canvas/registry.ts
@@ -1,32 +1,7 @@
-import { findCanvasPlugin, listCanvasPlugins, type CanvasPluginKind } from './plugins.ts';
-import { CANVAS_HOST, DEFAULT_CANVAS_PLUGIN, canvasPluginPath } from './urls.ts';
-
-const kinds = new Set<CanvasPluginKind>(['three', 'react']);
-
-export function parseCanvasKind(value: unknown): CanvasPluginKind | undefined {
-  return typeof value === 'string' && kinds.has(value as CanvasPluginKind) ? value as CanvasPluginKind : undefined;
-}
-
-export const canvasPluginUrl = canvasPluginPath;
-
-export function canvasRegistry(kind?: CanvasPluginKind) {
-  const plugins = listCanvasPlugins(kind).map((plugin) => ({
-    ...plugin,
-    standalonePath: canvasPluginUrl(plugin.id),
-  }));
-  return {
-    plugins,
-    count: plugins.length,
-    kind: kind ?? 'all',
-    standalone: {
-      host: CANVAS_HOST,
-      defaultPlugin: DEFAULT_CANVAS_PLUGIN,
-      serveCommand: 'bun run src/cli/index.ts canvas-serve --port 47779',
-    },
-  };
-}
-
-export function canvasPluginEntry(id: string) {
-  const plugin = findCanvasPlugin(id);
-  return plugin ? { plugin: { ...plugin, standalonePath: canvasPluginUrl(plugin.id) } } : null;
-}
+export type { CanvasPluginKind, CanvasPluginRegistry, CanvasRegistryPlugin } from '@soul-brews/canvas-plugins';
+export {
+  canvasPluginEntry,
+  canvasPluginPath as canvasPluginUrl,
+  canvasRegistry,
+  parseCanvasKind,
+} from '@soul-brews/canvas-plugins';

--- a/src/canvas/urls.ts
+++ b/src/canvas/urls.ts
@@ -1,19 +1,8 @@
-export const CANVAS_HOST = 'canvas.buildwithoracle.com';
-export const CANVAS_ORIGIN = `https://${CANVAS_HOST}`;
-export const DEFAULT_CANVAS_PLUGIN = 'wave';
-
-const REACT_PLUGIN_PATHS = new Set(['map', 'planets']);
-
-export function canvasPluginPath(id: string): string {
-  const plugin = id.trim() || DEFAULT_CANVAS_PLUGIN;
-  if (REACT_PLUGIN_PATHS.has(plugin)) return `/${plugin}`;
-  return `/?${new URLSearchParams({ plugin })}`;
-}
-
-export function canvasPluginAbsoluteUrl(id: string, origin = CANVAS_ORIGIN): string {
-  return new URL(canvasPluginPath(id), origin).toString();
-}
-
-export function canvasPluginDataPath(id: string): string | undefined {
-  return REACT_PLUGIN_PATHS.has(id) ? '/api/map3d' : undefined;
-}
+export {
+  CANVAS_HOST,
+  CANVAS_ORIGIN,
+  DEFAULT_CANVAS_PLUGIN,
+  canvasPluginAbsoluteUrl,
+  canvasPluginDataPath,
+  canvasPluginPath,
+} from '@soul-brews/canvas-plugins';

--- a/src/workers/canvas/index.ts
+++ b/src/workers/canvas/index.ts
@@ -1,7 +1,12 @@
-import { canvasPluginMetadataRegistry } from '../../canvas/metadata.ts';
-import { canvasPluginEntry, canvasRegistry, parseCanvasKind } from '../../canvas/registry.ts';
-import { CANVAS_HOST, DEFAULT_CANVAS_PLUGIN } from '../../canvas/urls.ts';
-import { listCanvasPlugins } from '../../canvas/plugins.ts';
+import {
+  CANVAS_HOST,
+  DEFAULT_CANVAS_PLUGIN,
+  canvasPluginEntry,
+  canvasPluginMetadataRegistry,
+  canvasRegistry,
+  listCanvasPlugins,
+  parseCanvasKind,
+} from '@soul-brews/canvas-plugins';
 import { normalizePlugin, renderCanvasApp } from './render.ts';
 
 export interface CanvasWorkerEnv {

--- a/src/workers/canvas/render.ts
+++ b/src/workers/canvas/render.ts
@@ -1,7 +1,12 @@
-import { findCanvasPlugin, listCanvasPlugins, type CanvasPluginDescriptor } from '../../canvas/plugins.ts';
-import { CANVAS_HOST, CANVAS_ORIGIN, DEFAULT_CANVAS_PLUGIN, canvasPluginPath } from '../../canvas/urls.ts';
-
-export type CanvasPlugin = CanvasPluginDescriptor;
+import {
+  CANVAS_HOST,
+  CANVAS_ORIGIN,
+  DEFAULT_CANVAS_PLUGIN,
+  canvasPluginPath,
+  findCanvasPlugin,
+  listCanvasPlugins,
+  type CanvasPlugin,
+} from '@soul-brews/canvas-plugins';
 
 const STUDIO_HOME = 'https://studio.buildwithoracle.com/';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,13 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
-    "lib": ["ES2022"],
+    "lib": [
+      "ES2022"
+    ],
     "moduleResolution": "bundler",
-    "types": ["bun-types"],
+    "types": [
+      "bun-types"
+    ],
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "allowImportingTsExtensions": true,
@@ -13,8 +17,21 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "rootDir": "./src"
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {
+      "@soul-brews/canvas-plugins": [
+        "packages/canvas-plugins/src/index.ts"
+      ]
+    }
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/integration/**"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.test.ts",
+    "src/integration/**"
+  ]
 }


### PR DESCRIPTION
## Summary
- Extracted the canonical canvas plugin registry into `@soul-brews/canvas-plugins` under `packages/canvas-plugins`.
- Exported shared types, URL helpers, registry metadata, 7 Three mounts, and map/planets React plugin entries from one package.
- Updated Studio route/API helpers plus the canvas subdomain worker to import the shared package while keeping old `src/canvas/*` wrappers compatible.
- Included `packages` in the root package files so GitHub installs keep the shared package sources.

## Validation
- `bun install --frozen-lockfile --ignore-scripts`
- `bunx tsc --noEmit`
- `bunx tsc -p packages/canvas-plugins/tsconfig.json --noEmit`
- `bunx tsc -p frontend/tsconfig.json --noEmit`
- `bun test tests/canvas/ tests/workers/canvas-worker.test.ts tests/http/canvas-worker.test.ts tests/http/canvas/ tests/plugins/canvas-registry.test.ts tests/frontend/routes/canvas-app-path.test.ts tests/frontend/api/canvas-plugins-standalone.test.ts tests/frontend/pages/canvas-plugins-page.test.tsx src/canvas/__tests__/` (49 pass)
- `bun build src/workers/canvas/index.ts --target=browser --outdir /tmp/arra-canvas-build`
- Changed files are all <=250 lines.

Closes #2089