### PR TITLE
fix: harden search and knowledge route edges

### DIFF
--- a/src/routes/knowledge/handoff.ts
+++ b/src/routes/knowledge/handoff.ts
@@ -12,13 +12,33 @@ import { HandoffBody } from './model.ts';
 const repoRoot = () => process.env.ORACLE_REPO_ROOT || REPO_ROOT;
 const relativePath = (filePath: string) => path.relative(repoRoot(), filePath).split(path.sep).join('/');
 const inboxDir = () => tenantDataPath(path.join(repoRoot(), 'ψ/inbox'));
+const fallbackSlug = (content: string) => content.substring(0, 50);
+
+function safeSlug(raw: unknown, content: string): string {
+  const source = typeof raw === 'string' && raw.trim() ? raw : fallbackSlug(content);
+  const slug = source
+    .substring(0, 80)
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  return slug || 'handoff';
+}
+
+function containedFile(dirPath: string, filename: string): string {
+  const root = path.resolve(dirPath);
+  const filePath = path.resolve(root, filename);
+  if (!filePath.startsWith(`${root}${path.sep}`)) throw new Error('Invalid handoff path');
+  return filePath;
+}
 
 export const handoffEndpoint = new Elysia().post(
   '/handoff',
   ({ body, set }) => {
     try {
       const data = (body ?? {}) as Record<string, any>;
-      if (!data.content) {
+      if (typeof data.content !== 'string' || !data.content.trim()) {
         set.status = 400;
         return { error: 'Missing required field: content' };
       }
@@ -27,17 +47,11 @@ export const handoffEndpoint = new Elysia().post(
       const dateStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
       const timeStr = `${String(now.getHours()).padStart(2, '0')}-${String(now.getMinutes()).padStart(2, '0')}`;
 
-      const slug = data.slug || data.content
-        .substring(0, 50)
-        .toLowerCase()
-        .replace(/[^a-z0-9\s-]/g, '')
-        .replace(/\s+/g, '-')
-        .replace(/-+/g, '-')
-        .replace(/^-|-$/g, '') || 'handoff';
+      const slug = safeSlug(data.slug, data.content);
 
       const filename = `${dateStr}_${timeStr}_${slug}.md`;
       const dirPath = path.join(inboxDir(), 'handoff');
-      const filePath = path.join(dirPath, filename);
+      const filePath = containedFile(dirPath, filename);
 
       fs.mkdirSync(dirPath, { recursive: true });
       fs.writeFileSync(filePath, data.content, 'utf-8');

--- a/src/routes/knowledge/inbox.ts
+++ b/src/routes/knowledge/inbox.ts
@@ -13,11 +13,17 @@ const repoRoot = () => process.env.ORACLE_REPO_ROOT || REPO_ROOT;
 const relativePath = (filePath: string) => path.relative(repoRoot(), filePath).split(path.sep).join('/');
 const inboxDir = () => tenantDataPath(path.join(repoRoot(), 'ψ/inbox'));
 
+function parsePageInt(value: string | undefined, fallback: number, min: number, max: number): number {
+  const parsed = Number.parseInt(value ?? '', 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(max, Math.max(min, parsed));
+}
+
 export const inboxEndpoint = new Elysia().get(
   '/inbox',
   ({ query }) => {
-    const limit = parseInt(query.limit ?? '10');
-    const offset = parseInt(query.offset ?? '0');
+    const limit = parsePageInt(query.limit, 10, 1, 100);
+    const offset = parsePageInt(query.offset, 0, 0, Number.MAX_SAFE_INTEGER);
     const type = query.type ?? 'all';
 
     const results: Array<{ filename: string; path: string; created: string; preview: string; type: string }> = [];
@@ -32,7 +38,9 @@ export const inboxEndpoint = new Elysia().get(
 
         for (const file of files) {
           const filePath = path.join(handoffDir, file);
-          const content = fs.readFileSync(filePath, 'utf-8');
+          if (!fs.statSync(filePath).isFile()) continue;
+          let content = '';
+          try { content = fs.readFileSync(filePath, 'utf-8'); } catch { continue; }
           const dateMatch = file.match(/^(\d{4}-\d{2}-\d{2})_(\d{2}-\d{2})/);
           const created = dateMatch
             ? `${dateMatch[1]}T${dateMatch[2].replace('-', ':')}:00`

--- a/src/routes/search/list.ts
+++ b/src/routes/search/list.ts
@@ -5,14 +5,15 @@
 import { Elysia } from 'elysia';
 import { handleList } from '../../server/handlers.ts';
 import { ListQuery } from './model.ts';
+import { parseOffset, parsePositiveInt } from './query.ts';
 import { handleTenantList } from './tenant-search.ts';
 
 export const listEndpoint = new Elysia().get(
   '/list',
   ({ query }) => {
     const type = query.type ?? 'all';
-    const limit = Math.min(1000, Math.max(1, parseInt(query.limit ?? '10')));
-    const offset = Math.max(0, parseInt(query.offset ?? '0'));
+    const limit = parsePositiveInt(query.limit, 10, 1000);
+    const offset = parseOffset(query.offset);
     const group = query.group !== 'false';
     return handleTenantList(type, limit, offset, group) ?? handleList(type, limit, offset, group);
   },

--- a/src/routes/search/query.ts
+++ b/src/routes/search/query.ts
@@ -1,0 +1,24 @@
+export type SearchMode = 'hybrid' | 'fts' | 'vector';
+
+const SEARCH_MODES = new Set<SearchMode>(['hybrid', 'fts', 'vector']);
+
+export function parsePositiveInt(
+  value: string | undefined,
+  fallback: number,
+  max: number,
+): number {
+  const parsed = Number.parseInt(value ?? '', 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(max, Math.max(1, parsed));
+}
+
+export function parseOffset(value: string | undefined): number {
+  const parsed = Number.parseInt(value ?? '', 10);
+  if (!Number.isFinite(parsed)) return 0;
+  return Math.max(0, parsed);
+}
+
+export function parseSearchMode(value: string | undefined): SearchMode | null {
+  if (value === undefined || value === '') return 'hybrid';
+  return SEARCH_MODES.has(value as SearchMode) ? value as SearchMode : null;
+}

--- a/src/routes/search/search.ts
+++ b/src/routes/search/search.ts
@@ -5,6 +5,7 @@
 import { Elysia } from 'elysia';
 import { handleSearch } from '../../server/handlers.ts';
 import { SearchQuery } from './model.ts';
+import { parseOffset, parsePositiveInt, parseSearchMode } from './query.ts';
 import { handleTenantSearch } from './tenant-search.ts';
 
 export const searchEndpoint = new Elysia().get(
@@ -26,9 +27,13 @@ export const searchEndpoint = new Elysia().get(
     }
 
     const type = query.type ?? 'all';
-    const limit = Math.min(100, Math.max(1, parseInt(query.limit ?? '10')));
-    const offset = Math.max(0, parseInt(query.offset ?? '0'));
-    const mode = (query.mode ?? 'hybrid') as 'hybrid' | 'fts' | 'vector';
+    const limit = parsePositiveInt(query.limit, 10, 100);
+    const offset = parseOffset(query.offset);
+    const mode = parseSearchMode(query.mode);
+    if (!mode) {
+      set.status = 400;
+      return { error: 'Invalid search mode. Expected one of: hybrid, fts, vector' };
+    }
     const project = query.project;
     const cwd = query.cwd;
     const model = query.model;

--- a/src/routes/search/tenant-search.ts
+++ b/src/routes/search/tenant-search.ts
@@ -4,6 +4,7 @@ import type { SearchResponse } from '../../server/types.ts';
 
 type SearchRouteResponse = SearchResponse & { mode: string; warning?: string; vectorAvailable: boolean };
 type ListRow = Record<string, any>;
+const FTS_TOKEN_LIMIT = 8;
 
 function normalizeRank(rank: number): number {
   return Math.min(1, Math.max(0, 1 / (1 + Math.abs(rank))));
@@ -13,37 +14,51 @@ function parseConcepts(value: string | null | undefined): string[] {
   try { return JSON.parse(value || '[]') as string[]; } catch { return []; }
 }
 
-function sanitizeFtsQuery(query: string): string {
-  return query
+function buildTenantFtsQuery(query: string): string {
+  const tokens = query
     .replace(/<[^>]*>/g, ' ')
-    .replace(/[?*+\-()^~"':;<>{}[\]\\/]/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
+    .normalize('NFKC')
+    .match(/[\p{L}\p{N}_]+/gu)
+    ?.map((token) => token.trim())
+    .filter(Boolean)
+    .slice(0, FTS_TOKEN_LIMIT) ?? [];
+
+  return Array.from(new Set(tokens))
+    .map((token) => `"${token.replace(/"/g, '""')}"`)
+    .join(' OR ');
+}
+
+function runFtsGet<T>(stmt: { get: (...args: any[]) => T }, args: unknown[]): T | null {
+  try { return stmt.get(...args); } catch { return null; }
+}
+
+function runFtsAll<T>(stmt: { all: (...args: any[]) => T[] }, args: unknown[]): T[] {
+  try { return stmt.all(...args); } catch { return []; }
 }
 
 export function handleTenantSearch(query: string, type = 'all', limit = 10, offset = 0): SearchRouteResponse | null {
   const tenantId = currentTenantId();
   if (!tenantId) return null;
 
-  const safeQuery = sanitizeFtsQuery(query);
+  const safeQuery = buildTenantFtsQuery(query);
   if (!safeQuery) return { results: [], total: 0, limit, offset, query, mode: 'fts', vectorAvailable: false };
 
   const typeClause = type === 'all' ? '' : 'AND d.type = ?';
   const params = type === 'all' ? [safeQuery, tenantId] : [safeQuery, type, tenantId];
-  const count = sqlite.prepare(`
+  const count = runFtsGet(sqlite.prepare(`
     SELECT COUNT(*) as total
     FROM oracle_fts f
     JOIN oracle_documents d ON f.id = d.id
     WHERE oracle_fts MATCH ? ${typeClause} AND d.tenant_id = ?
-  `).get(...params) as { total: number };
-  const rows = sqlite.prepare(`
+  `), params) as { total: number } | null;
+  const rows = runFtsAll(sqlite.prepare(`
     SELECT f.id, f.content, d.type, d.source_file, d.concepts, d.project, rank as score
     FROM oracle_fts f
     JOIN oracle_documents d ON f.id = d.id
     WHERE oracle_fts MATCH ? ${typeClause} AND d.tenant_id = ?
     ORDER BY rank
     LIMIT ? OFFSET ?
-  `).all(...params, limit, offset) as ListRow[];
+  `), [...params, limit, offset]) as ListRow[];
 
   return {
     results: rows.map((row) => ({
@@ -56,7 +71,7 @@ export function handleTenantSearch(query: string, type = 'all', limit = 10, offs
       source: 'fts' as const,
       score: normalizeRank(row.score),
     })),
-    total: count.total,
+    total: count?.total ?? 0,
     offset,
     limit,
     query,

--- a/tests/http/knowledge/edge-cases.test.ts
+++ b/tests/http/knowledge/edge-cases.test.ts
@@ -1,0 +1,89 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tempData = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-knowledge-edge-db-'));
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-knowledge-edge-root-'));
+const previousData = process.env.ORACLE_DATA_DIR;
+const previousDb = process.env.ORACLE_DB_PATH;
+const previousRoot = process.env.ORACLE_REPO_ROOT;
+const stamp = `${Date.now()}${Math.random().toString(16).slice(2)}`;
+const tenantId = `tenant-edge-${stamp}`;
+
+let knowledgeRoutes: { handle: (request: Request) => Response | Promise<Response> };
+let createTenantFetch: typeof import('../../../src/middleware/tenant.ts').createTenantFetch;
+let tenantHeader: string;
+let closeDb: () => void;
+
+beforeAll(async () => {
+  process.env.ORACLE_DATA_DIR = tempData;
+  process.env.ORACLE_DB_PATH = path.join(tempData, 'oracle.db');
+  process.env.ORACLE_REPO_ROOT = tempRoot;
+  const dbModule = await import('../../../src/db/index.ts');
+  dbModule.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+  closeDb = dbModule.closeDb;
+  const tenant = await import('../../../src/middleware/tenant.ts');
+  createTenantFetch = tenant.createTenantFetch;
+  tenantHeader = tenant.TENANT_HEADER;
+  ({ knowledgeRoutes } = await import('../../../src/routes/knowledge/index.ts'));
+});
+
+function requestKnowledge(pathname: string, init: RequestInit = {}) {
+  return createTenantFetch((request) => knowledgeRoutes.handle(request))(new Request(`http://local${pathname}`, {
+    ...init,
+    headers: { 'content-type': 'application/json', [tenantHeader]: tenantId, ...(init.headers ?? {}) },
+  }));
+}
+
+afterAll(() => {
+  closeDb?.();
+  if (previousData === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = previousData;
+  if (previousDb === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = previousDb;
+  if (previousRoot === undefined) delete process.env.ORACLE_REPO_ROOT;
+  else process.env.ORACLE_REPO_ROOT = previousRoot;
+  fs.rmSync(tempData, { recursive: true, force: true });
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+describe('knowledge route edge cases', () => {
+  test('POST /api/handoff sanitizes slugs into the tenant handoff directory', async () => {
+    const res = await requestKnowledge('/api/handoff', {
+      method: 'POST',
+      body: JSON.stringify({ content: `tenant handoff ${stamp}`, slug: '../../escape me' }),
+    });
+    const body = await res.json() as { file: string; success: boolean };
+
+    expect(res.status).toBe(201);
+    expect(body.success).toBe(true);
+    expect(body.file).toStartWith(`ψ/tenants/${tenantId}/inbox/handoff/`);
+    expect(body.file).not.toContain('..');
+    expect(path.basename(body.file)).toContain('escape-me');
+  });
+
+  test('POST /api/handoff rejects blank content', async () => {
+    const res = await requestKnowledge('/api/handoff', {
+      method: 'POST',
+      body: JSON.stringify({ content: '   ', slug: 'blank' }),
+    });
+    const body = await res.json() as { error: string };
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('content');
+  });
+
+  test('GET /api/inbox clamps pagination and skips non-file markdown entries', async () => {
+    const handoffDir = path.join(tempRoot, 'ψ', 'tenants', tenantId, 'inbox', 'handoff');
+    fs.mkdirSync(path.join(handoffDir, 'not-a-file.md'), { recursive: true });
+
+    const res = await requestKnowledge('/api/inbox?type=handoff&limit=NaN&offset=-50');
+    const body = await res.json() as { files: Array<{ filename: string }>; total: number; limit: number; offset: number };
+
+    expect(res.status).toBe(200);
+    expect(body.limit).toBe(10);
+    expect(body.offset).toBe(0);
+    expect(body.files.some((file) => file.filename === 'not-a-file.md')).toBe(false);
+  });
+});

--- a/tests/http/search/edge-cases.test.ts
+++ b/tests/http/search/edge-cases.test.ts
@@ -1,0 +1,85 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-search-edge-'));
+const stamp = `${Date.now()}${Math.random().toString(16).slice(2)}`;
+const tenantId = `tenant-edge-${stamp}`;
+const docId = `search-edge-${stamp}`;
+const term = `edgeterm${stamp}`;
+
+let dbModule: typeof import('../../../src/db/index.ts');
+let searchRoutes: { handle: (request: Request) => Response | Promise<Response> };
+let createTenantFetch: typeof import('../../../src/middleware/tenant.ts').createTenantFetch;
+let tenantHeader: string;
+
+beforeAll(async () => {
+  process.env.ORACLE_DATA_DIR = tempRoot;
+  process.env.ORACLE_DB_PATH = path.join(tempRoot, 'oracle.db');
+  dbModule = await import('../../../src/db/index.ts');
+  dbModule.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+  const tenant = await import('../../../src/middleware/tenant.ts');
+  createTenantFetch = tenant.createTenantFetch;
+  tenantHeader = tenant.TENANT_HEADER;
+  ({ searchRoutes } = await import('../../../src/routes/search/index.ts'));
+
+  const now = Date.now();
+  dbModule.db.insert(dbModule.oracleDocuments).values({
+    id: docId,
+    tenantId,
+    type: 'learning',
+    sourceFile: 'ψ/shared/search-edge.md',
+    concepts: JSON.stringify(['edge']),
+    createdAt: now,
+    updatedAt: now,
+    indexedAt: now,
+    project: 'edge',
+    createdBy: 'search-edge-test',
+  }).run();
+  dbModule.sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
+    .run(docId, `document with ${term}`, 'edge');
+});
+
+function request(route: string) {
+  return createTenantFetch((req) => searchRoutes.handle(req))(new Request(`http://local${route}`, {
+    headers: { [tenantHeader]: tenantId },
+  }));
+}
+
+afterAll(() => {
+  dbModule?.closeDb();
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+describe('search route edge cases', () => {
+  test('GET /api/search rejects unknown search modes before hitting handlers', async () => {
+    const res = await request(`/api/search?q=${term}&mode=nearest`);
+    const body = await res.json() as { error: string };
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Invalid search mode');
+  });
+
+  test('GET /api/search quotes tenant FTS tokens that look like operators', async () => {
+    const q = encodeURIComponent(`${term} OR (`);
+    const res = await request(`/api/search?q=${q}&mode=fts`);
+    const body = await res.json() as { results: Array<{ id: string }>; total: number; error?: string };
+
+    expect(res.status).toBe(200);
+    expect(body.error).toBeUndefined();
+    expect(body.total).toBe(1);
+    expect(body.results.map((item) => item.id)).toEqual([docId]);
+  });
+
+  test('GET /api/list falls back on safe pagination for bad numbers', async () => {
+    const res = await request('/api/list?limit=not-a-number&offset=-10');
+    const body = await res.json() as { results: Array<{ id: string }>; limit: number; offset: number; total: number };
+
+    expect(res.status).toBe(200);
+    expect(body.limit).toBe(10);
+    expect(body.offset).toBe(0);
+    expect(body.total).toBe(1);
+    expect(body.results.map((item) => item.id)).toEqual([docId]);
+  });
+});


### PR DESCRIPTION
## Summary

- Harden `src/routes/search` query parsing: safe limit/offset defaults, explicit search mode validation, and tenant FTS token quoting so operator-like input degrades safely instead of throwing.
- Harden `src/routes/knowledge` handoff/inbox paths: sanitize slugs, reject blank handoff content, clamp inbox pagination, and skip non-file/unreadable markdown entries.
- Add scoped edge-case coverage for search and knowledge routes while keeping existing tenant-isolation tests intact.

## Validation

- `bunx tsc --noEmit`
- `ORACLE_DATA_DIR=$(mktemp -d /tmp/arra-sk-test-XXXXXX) ORACLE_DB_PATH="$ORACLE_DATA_DIR/oracle.sqlite" bun test tests/http/search/ tests/http/knowledge/` — 11 pass
- `git diff --check origin/alpha...HEAD`
- File size gate: all files under `src/routes/search`, `src/routes/knowledge`, `tests/http/search`, and `tests/http/knowledge` are <=250 lines; largest changed file is 146 lines.

## Scope

Touched only:
- `src/routes/search/*`
- `src/routes/knowledge/*`
- `tests/http/search/*`
- `tests/http/knowledge/*`

No docs or `ψ/` changes.
