### PR TITLE
test(plugins): harden unified loader failures

### DIFF
--- a/src/plugins/plugin-result.ts
+++ b/src/plugins/plugin-result.ts
@@ -1,0 +1,65 @@
+export interface PluginInvokeResult {
+  ok?: boolean;
+  body?: unknown;
+  output?: string;
+  status?: number;
+  headers?: unknown;
+  error?: unknown;
+}
+
+function failureStatus(status: unknown): number {
+  return Number.isInteger(status) && Number(status) >= 400 && Number(status) <= 599 ? Number(status) : 500;
+}
+
+export function pluginFailureMessage(error: unknown): string {
+  return typeof error === 'string' && error.length > 0 ? error : 'plugin failed';
+}
+
+function responseHeaders(headers: unknown): Headers | undefined {
+  if (headers instanceof Headers) return headers;
+  if (!headers || typeof headers !== 'object' || Array.isArray(headers)) return undefined;
+  const result = new Headers();
+  for (const [name, value] of Object.entries(headers)) {
+    if (typeof value !== 'string') continue;
+    try {
+      result.set(name, value);
+    } catch {
+      // Plugin-provided header names are untrusted; ignore invalid pairs.
+    }
+  }
+  return result;
+}
+
+export function responseFromPluginResult(result: unknown): unknown {
+  if (result instanceof Response) return result;
+  const record = (result && typeof result === 'object') ? result as PluginInvokeResult : null;
+  if (!record) return result ?? { ok: true };
+  if (record.ok === false) {
+    return Response.json(
+      { ok: false, error: pluginFailureMessage(record.error) },
+      { status: failureStatus(record.status), headers: responseHeaders(record.headers) },
+    );
+  }
+  if (record.body !== undefined) return record.body;
+  if (record.output !== undefined) return { ok: true, output: record.output };
+  return record;
+}
+
+export function isPluginInvokeFailure(result: unknown): result is PluginInvokeResult & { ok: false } {
+  return !!result && typeof result === 'object' && (result as PluginInvokeResult).ok === false;
+}
+
+export async function withPluginTimeout<T>(operation: () => T | Promise<T>, timeoutMs: number): Promise<T> {
+  const ms = Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 1;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      Promise.resolve().then(operation),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error('handler timed out')), ms);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/src/plugins/unified-loader.ts
+++ b/src/plugins/unified-loader.ts
@@ -11,6 +11,7 @@ import { unifiedPluginServerRoutes, type UnifiedPluginServer } from './unified-s
 import { isContainedPluginPath, resolveContainedPluginEntry } from './path-containment.ts';
 import { registerPluginExportFormats } from './export-format-init.ts';
 import { defaultUnifiedPluginDirs } from './plugin-dirs.ts';
+import { isPluginInvokeFailure, pluginFailureMessage, responseFromPluginResult, withPluginTimeout } from './plugin-result.ts';
 
 const DEFAULT_TIMEOUT_MS = Number(process.env.ARRA_PLUGIN_TIMEOUT_MS ?? 5000);
 
@@ -54,14 +55,6 @@ interface InvokeContext {
   body?: unknown;
 }
 
-interface InvokeResult {
-  ok?: boolean;
-  body?: unknown;
-  output?: string;
-  status?: number;
-  headers?: Record<string, string>;
-  error?: string;
-}
 
 function warn(options: UnifiedLoaderOptions, message: string): void {
   options.warn?.(`[unified-plugin] ${message}`);
@@ -88,7 +81,14 @@ export async function discoverUnifiedPluginManifests(
   const seen = new Set<string>();
   for (const baseDir of options.dirs ?? defaultUnifiedPluginDirs()) {
     if (!existsSync(baseDir)) continue;
-    for (const entry of readdirSync(baseDir, { withFileTypes: true })) {
+    let entries: Array<{ name: string; isDirectory(): boolean; isSymbolicLink(): boolean }>;
+    try {
+      entries = readdirSync(baseDir, { withFileTypes: true });
+    } catch (error) {
+      warn(options, `skipped ${baseDir}: ${error instanceof Error ? error.message : String(error)}`);
+      continue;
+    }
+    for (const entry of entries) {
       if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
       const pluginDir = join(baseDir, entry.name);
       if (!isContainedPluginPath(baseDir, pluginDir)) { warn(options, `skipped ${pluginDir}: plugin directory symlink escapes plugin root`); continue; }
@@ -110,31 +110,9 @@ async function invoke(plugin: LoadedUnifiedPlugin, handler: string | undefined, 
     const mod = await import(pathToFileURL(plugin.entryPath).href);
     const fn = handler === 'default' ? mod.default : (mod[handler] ?? mod.default);
     if (typeof fn !== 'function') throw new Error(`handler not found: ${handler}`);
-    return await Promise.race([
-      Promise.resolve(fn({ ...ctx, config: plugin.manifest.config ?? {} })),
-      new Promise((_, reject) => setTimeout(() => reject(new Error('handler timed out')), timeoutMs)),
-    ]);
+    return await withPluginTimeout(() => fn({ ...ctx, config: plugin.manifest.config ?? {} }), timeoutMs);
   });
   return result.ok ? result.value : { ok: false, error: result.error };
-}
-
-function responseFrom(result: unknown): unknown {
-  if (result instanceof Response) return result;
-  const record = (result && typeof result === 'object') ? result as InvokeResult : null;
-  if (!record) return result ?? { ok: true };
-  if (record.ok === false) {
-    return Response.json(
-      { ok: false, error: record.error ?? 'plugin failed' },
-      { status: record.status ?? 500, headers: record.headers },
-    );
-  }
-  if (record.body !== undefined) return record.body;
-  if (record.output !== undefined) return { ok: true, output: record.output };
-  return record;
-}
-
-function invokeFailed(result: unknown): result is InvokeResult & { ok: false } {
-  return !!result && typeof result === 'object' && (result as InvokeResult).ok === false;
 }
 
 function apiRoute(plugin: LoadedUnifiedPlugin, route: UnifiedApiRouteManifest, timeoutMs: number): ElysiaApp {
@@ -150,7 +128,7 @@ function apiRoute(plugin: LoadedUnifiedPlugin, route: UnifiedApiRouteManifest, t
         query,
         body,
       }, timeoutMs);
-      return responseFrom(result);
+      return responseFromPluginResult(result);
     });
   }
   return app;
@@ -200,8 +178,8 @@ function runtimeFrom(plugins: LoadedUnifiedPlugin[], options: UnifiedLoaderOptio
       source,
       plugin: plugin.manifest.name,
     }, timeoutMs);
-    if (invokeFailed(result)) {
-      const error = result.error ?? 'plugin failed';
+    if (isPluginInvokeFailure(result)) {
+      const error = pluginFailureMessage(result.error);
       pluginStatus.set(plugin.manifest.name, { name: plugin.manifest.name, status: 'degraded', error });
       warn(options, `${plugin.manifest.name}.${source} failed: ${error}`);
     } else {

--- a/tests/plugins/unified-loader-api-sanitized-failure.test.ts
+++ b/tests/plugins/unified-loader-api-sanitized-failure.test.ts
@@ -1,0 +1,30 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadUnifiedPlugins } from "../../src/plugins/unified-loader.ts";
+import { handleWith, pluginDir } from "./_fixtures.ts";
+
+const tmp = mkdtempSync(join(tmpdir(), "arra-unified-api-sanitized-"));
+afterAll(() => rmSync(tmp, { recursive: true, force: true }));
+
+describe("unified plugin API failure hardening", () => {
+  test("sanitizes malformed failure status and headers", async () => {
+    pluginDir(tmp, "api-sanitized", {
+      apiRoutes: [{ path: "/api/sanitized", handler: "default" }],
+    }, `export default () => ({
+      ok: false,
+      status: 204,
+      error: '',
+      headers: { 'x-plugin-error': 'kept', 'bad header': 'drop', 'x-number': 42 },
+    });\n`);
+
+    const runtime = await loadUnifiedPlugins({ dirs: [tmp] });
+    const response = await handleWith(runtime.routes, new Request("http://local/api/sanitized"));
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get("x-plugin-error")).toBe("kept");
+    expect(response.headers.get("x-number")).toBeNull();
+    expect(await response.json()).toEqual({ ok: false, error: "plugin failed" });
+  });
+});

--- a/tests/plugins/unified-loader-load-catches-discovery-errors.test.ts
+++ b/tests/plugins/unified-loader-load-catches-discovery-errors.test.ts
@@ -1,19 +1,26 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadUnifiedPlugins } from "../../src/plugins/unified-loader.ts";
+import { pluginDir } from "./_fixtures.ts";
 
 const tmp = mkdtempSync(join(tmpdir(), "arra-unified-load-catch-"));
 afterAll(() => rmSync(tmp, { recursive: true, force: true }));
 
 describe("loadUnifiedPlugins", () => {
-  test("returns an empty runtime when discovery throws", async () => {
+  test("skips unreadable plugin roots without disabling later roots", async () => {
     const filePath = join(tmp, "not-a-dir");
+    const validRoot = join(tmp, "valid-root");
     writeFileSync(filePath, "x");
+    mkdirSync(validRoot);
+    pluginDir(validRoot, "valid-plugin", { menu: [{ label: "Valid", path: "/valid" }] });
     const warnings: string[] = [];
-    const runtime = await loadUnifiedPlugins({ dirs: [filePath], warn: (msg) => warnings.push(msg) });
-    expect(runtime.routes).toEqual([]);
-    expect(warnings[0]).toContain("loader disabled");
+
+    const runtime = await loadUnifiedPlugins({ dirs: [filePath, validRoot], warn: (msg) => warnings.push(msg) });
+
+    expect(runtime.menu.map((item) => item.path)).toEqual(["/valid"]);
+    expect(warnings[0]).toContain("[unified-plugin] skipped");
+    expect(warnings[0]).toContain("not-a-dir");
   });
 });


### PR DESCRIPTION
## Summary
- keep unified plugin discovery resilient when one configured root is unreadable/non-directory
- centralize plugin handler result handling with sanitized failure status, error text, and headers
- add regression coverage for malformed plugin API failure results and discovery continuation

## Tests
- bun test src/plugins/__tests__ tests/plugins
- bunx tsc --noEmit

Changed files are all <=250 lines.