### PR TITLE
test: harden tenant middleware errors

### DIFF
--- a/src/middleware/tenant.ts
+++ b/src/middleware/tenant.ts
@@ -144,7 +144,11 @@ export function createTenantMiddleware() {
       if (tenantError) return { error: tenantError };
     })
     .onRequest(({ request }) => {
-      tenantIdFor(request);
+      try {
+        tenantIdFor(request);
+      } catch {
+        // derive returns the structured 400 tenant error response.
+      }
     });
 }
 

--- a/tests/http/tenant/middleware.test.ts
+++ b/tests/http/tenant/middleware.test.ts
@@ -4,21 +4,41 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { Elysia } from 'elysia';
 import { eq } from 'drizzle-orm';
-import { getTenantDb, closeTenantDbsForTests } from '../../../src/db/tenant.ts';
-import { settings } from '../../../src/db/index.ts';
 import {
   createTenantMiddleware,
+  createTenantFetch,
   LEGACY_TENANT_HEADER,
+  parseTenantTokens,
+  runWithTenant,
+  tenantDataPath,
   TENANT_API_KEY_HEADER,
+  TENANT_HEADER,
+  TENANT_TOKEN_HEADER,
 } from '../../../src/middleware/tenant.ts';
 
 const root = mkdtempSync(path.join(tmpdir(), 'arra-tenant-middleware-'));
+const previousDataDir = process.env.ORACLE_DATA_DIR;
+const previousDbPath = process.env.ORACLE_DB_PATH;
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = path.join(root, 'oracle.db');
+
+const dbTenant = await import('../../../src/db/tenant.ts');
+const dbIndex = await import('../../../src/db/index.ts');
+const { closeTenantDbsForTests, getTenantDb } = dbTenant;
+const { closeDb, resetDefaultDatabaseForTests, settings } = dbIndex;
+resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+
 const tenantA = `tenant-a-${Date.now()}`;
 const tenantB = `tenant-b-${Date.now()}`;
 
 afterAll(() => {
   closeTenantDbsForTests();
+  closeDb();
   rmSync(root, { recursive: true, force: true });
+  if (previousDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = previousDataDir;
+  if (previousDbPath === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = previousDbPath;
 });
 
 const app = new Elysia()
@@ -102,4 +122,52 @@ test('tenant middleware can derive tenant from configured API key', async () => 
     if (previous === undefined) delete process.env.ORACLE_TENANT_API_KEYS;
     else process.env.ORACLE_TENANT_API_KEYS = previous;
   }
+});
+
+test('tenant middleware returns a structured 400 for invalid tenant headers', async () => {
+  const res = await request('/notes', {
+    headers: { [TENANT_HEADER]: 'bad/tenant' },
+  });
+
+  expect(res.status).toBe(400);
+  expect(await res.json()).toEqual({ error: 'invalid tenant id' });
+});
+
+test('tenant fetch wrapper turns token failures into 400 responses', async () => {
+  const previous = process.env.ORACLE_TENANT_TOKENS;
+  process.env.ORACLE_TENANT_TOKENS = 'tenant-a=secret';
+  let called = false;
+  const fetch = createTenantFetch(() => {
+    called = true;
+    return Response.json({ ok: true });
+  });
+
+  try {
+    const res = await fetch(new Request('http://local/api/search', {
+      headers: {
+        [TENANT_HEADER]: 'tenant-a',
+        [TENANT_TOKEN_HEADER]: 'wrong',
+      },
+    }));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ success: false, error: 'invalid tenant token' });
+    expect(called).toBe(false);
+  } finally {
+    if (previous === undefined) delete process.env.ORACLE_TENANT_TOKENS;
+    else process.env.ORACLE_TENANT_TOKENS = previous;
+  }
+});
+
+test('tenant helpers parse token maps and sanitize tenant data paths', () => {
+  expect(parseTenantTokens('tenant-a=sec=ret, tenant-b = two')).toEqual({
+    'tenant-a': 'sec=ret',
+    'tenant-b': 'two',
+  });
+  expect(parseTenantTokens('{"tenant-a":"json-secret"}')).toEqual({
+    'tenant-a': 'json-secret',
+  });
+
+  const scoped = runWithTenant('tenant/a', () => tenantDataPath('/tmp/oracle.db'));
+  expect(scoped).toBe(path.join('/tmp', 'tenants', 'tenant_a', 'oracle.db'));
 });

--- a/tests/integration/middleware-order.test.ts
+++ b/tests/integration/middleware-order.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, expect, test } from 'bun:test';
 import { startSmokeServer, type SmokeServer } from '../smoke/_helpers.ts';
 
 const RESPONSE_TIME_RE = /^\d+\.\dms$/;
+const ALLOWED_ORIGIN = 'http://localhost:3000';
 
 let server: SmokeServer | null = null;
 
@@ -18,7 +19,7 @@ test('HTTP middleware emits ordered response and preflight headers', async () =>
   const baseUrl = server!.baseUrl;
 
   const health = await fetch(`${baseUrl}/api/v1/health`, {
-    headers: { origin: 'https://studio.example' },
+    headers: { origin: ALLOWED_ORIGIN },
   });
 
   expect(health.status).toBe(200);
@@ -31,14 +32,14 @@ test('HTTP middleware emits ordered response and preflight headers', async () =>
   const preflight = await fetch(`${baseUrl}/api/v1/health`, {
     method: 'OPTIONS',
     headers: {
-      origin: 'https://studio.example',
+      origin: ALLOWED_ORIGIN,
       'access-control-request-method': 'GET',
       'access-control-request-headers': 'content-type',
     },
   });
 
   expect(preflight.status).toBe(204);
-  expect(preflight.headers.get('Access-Control-Allow-Origin')).toBe('*');
+  expect(preflight.headers.get('Access-Control-Allow-Origin')).toBe(ALLOWED_ORIGIN);
   expect(preflight.headers.get('Access-Control-Allow-Methods')).toContain('GET');
   expect(preflight.headers.get('Access-Control-Allow-Headers')).toBe('content-type');
   expect(preflight.headers.get('Access-Control-Max-Age')).toBe('86400');

--- a/tests/integration/middleware-stack.test.ts
+++ b/tests/integration/middleware-stack.test.ts
@@ -5,7 +5,7 @@ import { createContentTypeMiddleware } from '../../src/middleware/content-type.t
 import { createCorrelationMiddleware } from '../../src/middleware/correlation.ts';
 import { createCorsMiddleware, parseCorsOrigins } from '../../src/middleware/cors.ts';
 import { BadRequestError, createErrorMiddleware } from '../../src/middleware/errors.ts';
-import { createRateLimitMiddleware } from '../../src/middleware/rate-limit.ts';
+import { createRateLimiterMiddleware } from '../../src/middleware/rate-limiter.ts';
 
 const previousApiKey = process.env.ARRA_API_KEY;
 
@@ -15,12 +15,14 @@ afterEach(() => {
 });
 
 function createStackedApp(now = (() => 1_000)) {
-  const hits = new Map<string, number[]>();
   process.env.ARRA_API_KEY = 'secret';
   return new Elysia()
     .use(createCorsMiddleware(parseCorsOrigins('https://studio.example')))
     .use(createApiKeyAuthMiddleware())
-    .use(createRateLimitMiddleware({ rpm: 2, windowMs: 60_000, now, store: hits }))
+    .use(createRateLimiterMiddleware({
+      now,
+      rules: [{ path: '/api/fail', limit: 2, windowMs: 60_000 }],
+    }))
     .use(createCorrelationMiddleware())
     .use(createContentTypeMiddleware())
     .use(createErrorMiddleware(() => undefined))
@@ -105,6 +107,6 @@ describe('middleware stack integration', () => {
     expect(secondLimited.status).toBe(400);
     expect(thirdLimited.status).toBe(429);
     expect(thirdLimited.headers.get('Retry-After')).toBe('60');
-    expect(await thirdLimited.json()).toMatchObject({ error: 'Too Many Requests' });
+    expect(await thirdLimited.json()).toMatchObject({ error: 'rate_limit_exceeded' });
   });
 });


### PR DESCRIPTION
## Summary
- catch tenant onRequest validation errors so derive can return structured 400 responses
- add tenant middleware edge coverage for invalid tenant headers, tenant token failures, token parsing, and tenant data path sanitization
- refresh middleware integration tests for current CORS/rate-limiter behavior

## Validation
- bunx tsc --noEmit
- bun test tests/http/tenant/
- bun test tests/http/auth/api-key.test.ts tests/http/compress/encoding.test.ts tests/http/content-type/negotiation.test.ts tests/http/cors/origins.test.ts tests/http/dedup/coalesce.test.ts tests/http/logging/request-logger-middleware.test.ts tests/http/rate-limiter/rate-limiter.test.ts tests/http/retry/attempt-header.test.ts tests/http/retry/upstream.test.ts tests/http/tenant/middleware.test.ts tests/http/timeout/request-timeout.test.ts tests/integration/middleware-order.test.ts tests/integration/middleware-stack.test.ts