### PR TITLE
fix: harden supersede and files routes

### DIFF
--- a/src/routes/files/file.ts
+++ b/src/routes/files/file.ts
@@ -4,7 +4,7 @@
  *   1. TypeBox pattern on `path` (see model.ts) rejects "..", null-byte
  *   2. Handler re-checks explicitly so we return the canonical 400 JSON
  *      shape on traversal attempts instead of Elysia's 422 validator body
- *   3. `realpathSync` + `.startsWith(realRoot)` confines resolution
+ *   3. `realpathSync` + relative-path containment confines resolution
  */
 import { Elysia } from 'elysia';
 import fs from 'fs';
@@ -12,6 +12,7 @@ import path from 'path';
 import { REPO_ROOT } from '../../config.ts';
 import { getVaultPsiRoot } from '../../vault/handler.ts';
 import { fileQuery } from './model.ts';
+import { pathWithinRoot } from './path-security.ts';
 import { projectAllowedForTenant } from './tenant.ts';
 
 const currentRepoRoot = () => process.env.ORACLE_REPO_ROOT || REPO_ROOT;
@@ -74,8 +75,8 @@ export const fileRoute = new Elysia().get(
       const realGhqRoot = fs.realpathSync(GHQ_ROOT);
       const realRepoRoot = fs.realpathSync(root);
       if (
-        !realPath.startsWith(realGhqRoot) &&
-        !realPath.startsWith(realRepoRoot)
+        !pathWithinRoot(realGhqRoot, realPath) &&
+        !pathWithinRoot(realRepoRoot, realPath)
       ) {
         set.status = 400;
         return { error: 'Invalid path: outside allowed bounds' };
@@ -92,7 +93,7 @@ export const fileRoute = new Elysia().get(
         const repoFullPath = path.join(root, filePath);
         const realRepoFullPath = path.resolve(repoFullPath);
         if (
-          realRepoFullPath.startsWith(realRepoRoot) &&
+          pathWithinRoot(realRepoRoot, realRepoFullPath) &&
           fs.existsSync(repoFullPath)
         ) {
           return new Response(fs.readFileSync(repoFullPath, 'utf-8'));
@@ -105,7 +106,7 @@ export const fileRoute = new Elysia().get(
         const realVaultPath = path.resolve(vaultFullPath);
         const realVaultRoot = fs.realpathSync(vault.path);
         if (
-          realVaultPath.startsWith(realVaultRoot) &&
+          pathWithinRoot(realVaultRoot, realVaultPath) &&
           fs.existsSync(vaultFullPath)
         ) {
           return new Response(fs.readFileSync(vaultFullPath, 'utf-8'));

--- a/src/routes/files/path-security.ts
+++ b/src/routes/files/path-security.ts
@@ -1,0 +1,13 @@
+import path from 'path';
+
+export function pathWithinRoot(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
+}
+
+export function safePluginWasmFileName(name: string): string | null {
+  const file = name.endsWith('.wasm') ? name : `${name}.wasm`;
+  if (!file || file === '.wasm' || file.includes('\0') || file.includes('/') || file.includes('\\')) return null;
+  if (file.includes('..') || path.basename(file) !== file) return null;
+  return file;
+}

--- a/src/routes/files/plugin-by-name.ts
+++ b/src/routes/files/plugin-by-name.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import { PLUGINS_DIR } from '../../config.ts';
 import { tenantScopedPluginDir } from '../plugins/tenant.ts';
 import { pluginParams } from './model.ts';
+import { pathWithinRoot, safePluginWasmFileName } from './path-security.ts';
 
 const currentPluginsDir = () => tenantScopedPluginDir(
   process.env.ORACLE_DATA_DIR ? path.join(process.env.ORACLE_DATA_DIR, 'plugins') : PLUGINS_DIR,
@@ -15,11 +16,25 @@ const currentPluginsDir = () => tenantScopedPluginDir(
 export const pluginByNameRoute = new Elysia().get(
   '/api/plugins/:name',
   ({ params, set }) => {
-    const file = params.name.endsWith('.wasm')
-      ? params.name
-      : `${params.name}.wasm`;
-    const filePath = path.join(currentPluginsDir(), file);
+    const file = safePluginWasmFileName(params.name);
+    if (!file) {
+      set.status = 400;
+      return { error: 'Invalid plugin name' };
+    }
+    const pluginsDir = currentPluginsDir();
+    const filePath = path.join(pluginsDir, file);
     if (!fs.existsSync(filePath)) {
+      set.status = 404;
+      return { error: 'Plugin not found' };
+    }
+    try {
+      const realPluginsDir = fs.realpathSync(pluginsDir);
+      const realFilePath = fs.realpathSync(filePath);
+      if (!pathWithinRoot(realPluginsDir, realFilePath)) {
+        set.status = 404;
+        return { error: 'Plugin not found' };
+      }
+    } catch {
       set.status = 404;
       return { error: 'Plugin not found' };
     }

--- a/src/routes/files/tenant.ts
+++ b/src/routes/files/tenant.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { sqlite } from '../../db/index.ts';
 import { currentTenantId } from '../../middleware/tenant.ts';
 
@@ -12,10 +13,15 @@ type DocRow = {
 };
 
 export function projectMatchesTenant(project: string, tenantId: string): boolean {
-  const normalizedProject = project.trim().toLowerCase();
+  const trimmed = project.trim();
+  const normalizedProject = trimmed.toLowerCase();
   const tenant = tenantId.trim().toLowerCase();
-  if (!tenant || normalizedProject === tenant) return true;
-  return normalizedProject.split(/[\\/]+/).filter(Boolean).includes(tenant);
+  if (!tenant) return true;
+  if (!trimmed || trimmed.includes('\0') || path.isAbsolute(trimmed)) return false;
+  const segments = normalizedProject.split(/[\\/]+/).filter(Boolean);
+  if (segments.includes('..')) return false;
+  if (normalizedProject === tenant) return true;
+  return segments.includes(tenant);
 }
 
 export function projectAllowedForTenant(project?: string | null): boolean {

--- a/src/routes/supersede/chain.ts
+++ b/src/routes/supersede/chain.ts
@@ -8,10 +8,23 @@ import { alias } from 'drizzle-orm/sqlite-core';
 import { db, oracleDocuments } from '../../db/index.ts';
 import { activeTenantId } from '../../middleware/tenant.ts';
 
+function decodePathParam(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+}
+
 export const supersedeChainEndpoint = new Elysia().get(
   '/supersede/chain/:path',
-  ({ params }) => {
-    const docPath = decodeURIComponent(params.path);
+  ({ params, set }) => {
+    const docPath = decodePathParam(params.path);
+    if (!docPath) {
+      set.status = 400;
+      return { error: 'Invalid path parameter' };
+    }
     const tenantId = activeTenantId();
     const targetWhere = and(eq(oracleDocuments.sourceFile, docPath), eq(oracleDocuments.tenantId, tenantId));
 

--- a/src/routes/supersede/list.ts
+++ b/src/routes/supersede/list.ts
@@ -9,12 +9,18 @@ import { db, oracleDocuments } from '../../db/index.ts';
 import { SupersedeQuery } from './model.ts';
 import { activeTenantId } from '../../middleware/tenant.ts';
 
+function boundedInteger(raw: string | undefined, fallback: number, min: number, max: number): number {
+  const value = Number.parseInt(raw ?? '', 10);
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(Math.max(value, min), max);
+}
+
 export const supersedeListEndpoint = new Elysia().get(
   '/supersede',
   ({ query }) => {
     const project = query.project;
-    const limit = parseInt(query.limit ?? '50');
-    const offset = parseInt(query.offset ?? '0');
+    const limit = boundedInteger(query.limit, 50, 1, 200);
+    const offset = boundedInteger(query.offset, 0, 0, 100_000);
 
     const tenantId = activeTenantId();
     const filters = [isNotNull(oracleDocuments.supersededBy), eq(oracleDocuments.tenantId, tenantId)];

--- a/tests/http/files/tenant-isolation.test.ts
+++ b/tests/http/files/tenant-isolation.test.ts
@@ -95,6 +95,31 @@ describe('files routes tenant isolation', () => {
     expect(await allowed.text()).toBe('tenant-b secret');
   });
 
+  test('GET /api/file rejects tenant-shaped project traversal outside ghq root', async () => {
+    const evilDir = path.join(tempRoot, 'ghq-evil', tenantB);
+    fs.mkdirSync(evilDir, { recursive: true });
+    fs.writeFileSync(path.join(evilDir, 'leak.md'), 'tenant-b leaked sibling', 'utf-8');
+
+    const project = encodeURIComponent(`../ghq-evil/${tenantB}`);
+    const res = await request(tenantB, `/api/file?project=${project}&path=leak.md`);
+
+    expect(res.status).toBe(404);
+    expect(await res.text()).not.toBe('tenant-b leaked sibling');
+  });
+
+  test('GET /api/plugins/:name blocks tenant plugin symlink escapes', async () => {
+    const pluginDir = path.join(tempRoot, 'tenants', tenantB, 'plugins');
+    fs.mkdirSync(pluginDir, { recursive: true });
+    const outside = path.join(tempRoot, 'outside.wasm');
+    fs.writeFileSync(outside, 'not really wasm', 'utf-8');
+    fs.symlinkSync(outside, path.join(pluginDir, 'escape.wasm'));
+
+    const denied = await request(tenantB, '/api/plugins/escape');
+
+    expect(denied.status).toBe(404);
+    expect(await denied.json()).toEqual({ error: 'Plugin not found' });
+  });
+
   test('GET /api/context blocks cross-tenant project context', async () => {
     const cwd = encodeURIComponent(repoB);
     const denied = await request(tenantA, `/api/context?cwd=${cwd}`);

--- a/tests/http/supersede/tenant-isolation.test.ts
+++ b/tests/http/supersede/tenant-isolation.test.ts
@@ -98,6 +98,23 @@ test('/api/supersede list and chain stay tenant scoped after document updates', 
   expect(await deniedChain.json()).toEqual({ superseded_by: [], supersedes: [] });
 });
 
+test('/api/supersede clamps malformed pagination instead of throwing', async () => {
+  const res = await requestSupersede(tenantA, '/api/supersede?limit=not-a-number&offset=-10');
+  const body = await res.json() as { limit: number; offset: number; supersessions: unknown[] };
+
+  expect(res.status).toBe(200);
+  expect(body.limit).toBe(50);
+  expect(body.offset).toBe(0);
+  expect(Array.isArray(body.supersessions)).toBe(true);
+});
+
+test('/api/supersede/chain rejects malformed encoded paths', async () => {
+  const res = await requestSupersede(tenantA, '/api/supersede/chain/%E0%A4%A');
+
+  expect(res.status).toBe(400);
+  expect(await res.json()).toEqual({ error: 'Invalid path parameter' });
+});
+
 function supersededBy(id: string): string | null {
   return dbModule.db.select({ supersededBy: oracleDocuments.supersededBy })
     .from(oracleDocuments)


### PR DESCRIPTION
## Summary
- replace raw prefix path checks in files route with relative containment helper
- reject tenant-shaped project traversal and plugin symlink escapes under legacy files plugin fetch
- clamp supersede pagination and reject malformed chain path params
- add scoped HTTP coverage for files and supersede edge cases

## Validation
- bunx tsc --noEmit
- bun test tests/http/files/ tests/http/supersede/
- git diff --check origin/alpha...HEAD
- wc -l src/routes/files/path-security.ts src/routes/files/file.ts src/routes/files/plugin-by-name.ts src/routes/files/tenant.ts src/routes/supersede/chain.ts src/routes/supersede/list.ts tests/http/files/tenant-isolation.test.ts tests/http/supersede/tenant-isolation.test.ts