### PR TITLE
test(routes): harden dashboard and feed edge cases

### DIFF
--- a/src/routes/dashboard/activity.ts
+++ b/src/routes/dashboard/activity.ts
@@ -1,11 +1,9 @@
 import { Elysia } from 'elysia';
 import { handleDashboardActivity } from '../../server/dashboard.ts';
-import { ActivityQuery } from './model.ts';
+import { ActivityQuery, normalizeActivityDays } from './model.ts';
 
 export const activityEndpoint = new Elysia().get('/dashboard/activity', ({ query }) => {
-  const parsed = parseInt(query.days ?? '7');
-  const days = Number.isFinite(parsed) ? parsed : 7;
-  return handleDashboardActivity(days);
+  return handleDashboardActivity(normalizeActivityDays(query.days));
 }, {
   query: ActivityQuery,
   detail: {

--- a/src/routes/dashboard/growth.ts
+++ b/src/routes/dashboard/growth.ts
@@ -1,10 +1,9 @@
 import { Elysia } from 'elysia';
 import { handleDashboardGrowth } from '../../server/dashboard.ts';
-import { GrowthQuery } from './model.ts';
+import { GrowthQuery, normalizeGrowthPeriod } from './model.ts';
 
 export const growthEndpoint = new Elysia().get('/dashboard/growth', ({ query }) => {
-  const period = query.period ?? 'week';
-  return handleDashboardGrowth(period);
+  return handleDashboardGrowth(normalizeGrowthPeriod(query.period));
 }, {
   query: GrowthQuery,
   detail: {

--- a/src/routes/dashboard/model.ts
+++ b/src/routes/dashboard/model.ts
@@ -11,3 +11,24 @@ export const GrowthQuery = t.Object({
 export const SessionStatsQuery = t.Object({
   since: t.Optional(t.String()),
 });
+
+export const DEFAULT_ACTIVITY_DAYS = 7;
+export const MAX_ACTIVITY_DAYS = 365;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export type GrowthPeriod = 'week' | 'month' | 'quarter';
+
+export function normalizeActivityDays(value: string | undefined): number {
+  const parsed = Number.parseInt(value ?? '', 10);
+  if (!Number.isFinite(parsed) || parsed < 1) return DEFAULT_ACTIVITY_DAYS;
+  return Math.min(parsed, MAX_ACTIVITY_DAYS);
+}
+
+export function normalizeGrowthPeriod(value: string | undefined): GrowthPeriod {
+  return value === 'month' || value === 'quarter' || value === 'week' ? value : 'week';
+}
+
+export function normalizeSessionSince(value: string | undefined, now = Date.now()): number {
+  const parsed = Number.parseInt(value ?? '', 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : now - DAY_MS;
+}

--- a/src/routes/dashboard/session-stats.ts
+++ b/src/routes/dashboard/session-stats.ts
@@ -1,7 +1,7 @@
 import { Elysia } from 'elysia';
 import { and, eq, gt, sql, type SQL } from 'drizzle-orm';
 import { db, searchLog, learnLog, isDbLockError } from '../../db/index.ts';
-import { SessionStatsQuery } from './model.ts';
+import { normalizeSessionSince, SessionStatsQuery } from './model.ts';
 import { activeTenantId } from '../../middleware/tenant.ts';
 
 type TenantLogTable = { tenantId: unknown };
@@ -11,8 +11,7 @@ function scoped<T extends TenantLogTable>(table: T, condition: SQL): SQL {
 }
 
 export const sessionStatsEndpoint = new Elysia().get('/session/stats', ({ query }) => {
-  const since = query.since;
-  const sinceTime = since !== undefined ? parseInt(since) : Date.now() - 24 * 60 * 60 * 1000;
+  const sinceTime = normalizeSessionSince(query.since);
 
   try {
     const searches = db.select({ count: sql<number>`count(*)` })

--- a/src/routes/feed/list.ts
+++ b/src/routes/feed/list.ts
@@ -5,23 +5,67 @@ import { currentTenantId, tenantDataPath, TENANT_HEADER } from '../../middleware
 import { FeedQuery, type FeedEvent } from './model.ts';
 
 const MAW_JS_URL = process.env.MAW_JS_URL || 'http://localhost:3456';
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
 
-function parseLocalEvent(line: string, fallbackTenantId?: string): FeedEvent {
+export function normalizeFeedLimit(value: string | undefined): number {
+  const parsed = Number.parseInt(value ?? '', 10);
+  if (!Number.isFinite(parsed) || parsed < 1) return DEFAULT_LIMIT;
+  return Math.min(parsed, MAX_LIMIT);
+}
+
+function valueString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function parseLocalEvent(line: string, fallbackTenantId?: string): FeedEvent | undefined {
   const parts = line.split(' | ').map(s => s.trim());
+  if (parts.length < 6) return undefined;
   const hasTenant = parts.length >= 7;
-  const [ts, tenantOrOracle, oracleOrHost, hostOrEvent, eventOrProject, projectOrRest, restValue] = parts;
-  const rest = hasTenant ? restValue : projectOrRest;
+  const [ts, tenantOrOracle, oracleOrHost, hostOrEvent, eventOrProject, projectOrRest, ...restParts] = parts;
+  const rest = (hasTenant ? restParts : [projectOrRest, ...restParts]).join(' | ');
   const [sessionId, ...msgParts] = (rest || '').split(' » ');
+  const oracle = hasTenant ? oracleOrHost : tenantOrOracle;
+  const event = hasTenant ? eventOrProject : hostOrEvent;
+  if (!ts || !oracle || !event) return undefined;
   return {
     timestamp: ts,
     tenant_id: hasTenant ? tenantOrOracle : fallbackTenantId,
-    oracle: hasTenant ? oracleOrHost : tenantOrOracle,
+    oracle,
     host: hasTenant ? hostOrEvent : oracleOrHost,
-    event: hasTenant ? eventOrProject : hostOrEvent,
+    event,
     project: hasTenant ? projectOrRest : eventOrProject,
-    session_id: sessionId?.trim(),
+    session_id: sessionId?.trim() ?? '',
     message: msgParts.join(' » ').trim(),
     source: 'local',
+  };
+}
+
+function remoteTimestamp(event: Record<string, unknown>): string {
+  const timestamp = valueString(event.timestamp).trim();
+  if (timestamp) return timestamp;
+  const date = new Date(valueString(event.ts));
+  return Number.isNaN(date.getTime())
+    ? new Date().toISOString().replace('T', ' ').slice(0, 19)
+    : date.toISOString().replace('T', ' ').slice(0, 19);
+}
+
+function parseMawEvent(event: unknown): FeedEvent | undefined {
+  if (!event || typeof event !== 'object') return undefined;
+  const raw = event as Record<string, unknown>;
+  const oracle = valueString(raw.oracle);
+  const type = valueString(raw.event);
+  if (!oracle || !type) return undefined;
+  return {
+    timestamp: remoteTimestamp(raw),
+    tenant_id: tenantForEvent(raw),
+    oracle,
+    host: valueString(raw.host),
+    event: type,
+    project: valueString(raw.project),
+    session_id: valueString(raw.sessionId ?? raw.session_id),
+    message: valueString(raw.message),
+    source: 'maw-js',
   };
 }
 
@@ -35,7 +79,7 @@ function tenantForEvent(event: unknown): string | undefined {
 
 export const listFeedRoute = new Elysia().get('/', async ({ query, set }) => {
   try {
-    const limit = Math.min(200, parseInt(query.limit || '50'));
+    const limit = normalizeFeedLimit(query.limit);
     const oracle = query.oracle || undefined;
     const event = query.event || undefined;
     const since = query.since || undefined;
@@ -46,7 +90,7 @@ export const listFeedRoute = new Elysia().get('/', async ({ query, set }) => {
 
     if (fs.existsSync(feedLog)) {
       const raw = fs.readFileSync(feedLog, 'utf-8').trim().split('\n').filter(Boolean);
-      allEvents.push(...raw.map(line => parseLocalEvent(line, tenantId)));
+      allEvents.push(...raw.map(line => parseLocalEvent(line, tenantId)).filter((event): event is FeedEvent => Boolean(event)));
     }
 
     try {
@@ -57,19 +101,11 @@ export const listFeedRoute = new Elysia().get('/', async ({ query, set }) => {
       if (mawRes.ok) {
         const mawData = await mawRes.json() as any;
         if (mawData.events && Array.isArray(mawData.events)) {
-          const mawEvents: FeedEvent[] = mawData.events
-            .filter((e: any) => !tenantId || tenantForEvent(e) === tenantId)
-            .map((e: any) => ({
-              timestamp: e.timestamp || new Date(e.ts).toISOString().replace('T', ' ').slice(0, 19),
-              tenant_id: tenantForEvent(e),
-              oracle: e.oracle,
-              host: e.host,
-              event: e.event,
-              project: e.project,
-              session_id: e.sessionId,
-              message: e.message,
-              source: 'maw-js',
-            }));
+          const rawEvents = mawData.events as unknown[];
+          const mawEvents: FeedEvent[] = rawEvents
+            .map(parseMawEvent)
+            .filter((event): event is FeedEvent => Boolean(event))
+            .filter((event) => !tenantId || event.tenant_id === tenantId);
           allEvents.push(...mawEvents);
         }
       }

--- a/tests/http/dashboard/query-hardening.test.ts
+++ b/tests/http/dashboard/query-hardening.test.ts
@@ -1,0 +1,53 @@
+import { afterAll, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const root = mkdtempSync(join(tmpdir(), 'dashboard-hardening-'));
+const dbPath = join(root, 'oracle.db');
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = dbPath;
+
+const dbMod = await import('../../../src/db/index.ts');
+dbMod.resetDefaultDatabaseForTests(dbPath);
+const { createTenantFetch } = await import('../../../src/middleware/tenant.ts');
+const { dashboardRoutes } = await import('../../../src/routes/dashboard/index.ts');
+
+function restore(name: string, value: string | undefined) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+function dashboardRequest(path: string) {
+  return createTenantFetch((request) => dashboardRoutes.handle(request))(new Request(`http://local${path}`));
+}
+
+async function dashboardJson(path: string) {
+  const response = await dashboardRequest(path);
+  return { response, json: await response.json() as Record<string, any> };
+}
+
+afterAll(() => {
+  dbMod.closeDb();
+  restore('ORACLE_DATA_DIR', savedDataDir);
+  restore('ORACLE_DB_PATH', savedDbPath);
+  rmSync(root, { recursive: true });
+});
+
+test('dashboard query parameters fall back to bounded defaults', async () => {
+  const invalidDays = await dashboardJson('/api/dashboard/activity?days=-9');
+  const cappedDays = await dashboardJson('/api/dashboard/activity?days=9999');
+  const growth = await dashboardJson('/api/dashboard/growth?period=forever');
+  const beforeDefaultSince = Date.now() - 24 * 60 * 60 * 1000 - 1_000;
+  const stats = await dashboardJson('/api/session/stats?since=not-a-number');
+
+  expect(invalidDays.response.status).toBe(200);
+  expect(invalidDays.json.days).toBe(7);
+  expect(cappedDays.json.days).toBe(365);
+  expect(growth.json.period).toBe('week');
+  expect(growth.json.days).toBe(7);
+  expect(stats.json.since).toBeGreaterThanOrEqual(beforeDefaultSince);
+  expect(stats.json.since).toBeLessThanOrEqual(Date.now());
+});

--- a/tests/http/feed/query-hardening.test.ts
+++ b/tests/http/feed/query-hardening.test.ts
@@ -1,0 +1,74 @@
+import { afterAll, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedMawUrl = process.env.MAW_JS_URL;
+const root = mkdtempSync(join(tmpdir(), 'feed-hardening-'));
+process.env.ORACLE_DATA_DIR = root;
+
+const maw = Bun.serve({
+  port: 0,
+  fetch() {
+    return Response.json({ events: [] });
+  },
+});
+process.env.MAW_JS_URL = String(maw.url).replace(/\/$/, '');
+
+const { createTenantFetch, TENANT_HEADER } = await import('../../../src/middleware/tenant.ts');
+const { createFeedRoute } = await import('../../../src/routes/feed/create.ts');
+const { listFeedRoute } = await import('../../../src/routes/feed/list.ts');
+
+const feedApp = new Elysia({ prefix: '/api/feed' }).use(createFeedRoute).use(listFeedRoute);
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantId = `feed-hardening-${stamp}`;
+
+function restore(name: string, value: string | undefined) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+function feedRequest(path: string, init: RequestInit = {}) {
+  return createTenantFetch((request) => feedApp.handle(request))(new Request(`http://local${path}`, {
+    ...init,
+    headers: { 'content-type': 'application/json', [TENANT_HEADER]: tenantId, ...(init.headers ?? {}) },
+  }));
+}
+
+function postFeed(oracle: string, message = oracle) {
+  return feedRequest('/api/feed', {
+    method: 'POST',
+    body: JSON.stringify({ oracle, event: 'notice', project: tenantId, session_id: oracle, message }),
+  });
+}
+
+afterAll(() => {
+  maw.stop();
+  restore('ORACLE_DATA_DIR', savedDataDir);
+  restore('MAW_JS_URL', savedMawUrl);
+  rmSync(root, { recursive: true });
+});
+
+test('/api/feed bounds unsafe limits and preserves delimiter-heavy messages', async () => {
+  const sharedOracle = `limit-${stamp}`;
+  const delimiterOracle = `delimiter-${stamp}`;
+  await postFeed(sharedOracle, 'one');
+  await postFeed(sharedOracle, 'two');
+  await postFeed(sharedOracle, 'three');
+  await postFeed(delimiterOracle, 'message with | pipe and » marker');
+
+  const invalidLimit = await feedRequest(`/api/feed?limit=-5&oracle=${encodeURIComponent(sharedOracle)}`);
+  const singleLimit = await feedRequest(`/api/feed?limit=1&oracle=${encodeURIComponent(sharedOracle)}`);
+  const delimiter = await feedRequest(`/api/feed?oracle=${encodeURIComponent(delimiterOracle)}`);
+  const invalidBody = await invalidLimit.json() as { events: Array<{ oracle: string }> };
+  const singleBody = await singleLimit.json() as { events: Array<{ oracle: string }> };
+  const delimiterBody = await delimiter.json() as { events: Array<{ message: string }> };
+
+  expect(invalidLimit.status).toBe(200);
+  expect(invalidBody.events).toHaveLength(3);
+  expect(singleBody.events).toHaveLength(1);
+  expect(delimiterBody.events).toHaveLength(1);
+  expect(delimiterBody.events[0]?.message).toBe('message with | pipe and » marker');
+});

--- a/tests/http/feed/tenant-isolation.test.ts
+++ b/tests/http/feed/tenant-isolation.test.ts
@@ -9,8 +9,6 @@ const savedDataDir = process.env.ORACLE_DATA_DIR;
 const savedDbPath = process.env.ORACLE_DB_PATH;
 const savedMawUrl = process.env.MAW_JS_URL;
 const root = mkdtempSync(join(tmpdir(), 'feed-tenant-'));
-const restoreDbPath = savedDbPath
-  ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
 process.env.ORACLE_DATA_DIR = root;
 process.env.ORACLE_DB_PATH = join(root, 'oracle.db');
 
@@ -82,14 +80,14 @@ afterAll(() => {
   dbMod.db.delete(oracleDocuments).where(like(oracleDocuments.id, `%${stamp}%`)).run();
   dbMod.db.delete(searchLog).where(like(searchLog.query, `%${stamp}%`)).run();
   dbMod.db.delete(learnLog).where(inArray(learnLog.documentId, [`feed-dashboard-a-${stamp}`, `feed-dashboard-b-${stamp}`])).run();
-  rmSync(root, { recursive: true, force: true });
+  dbMod.closeDb();
+  rmSync(root, { recursive: true });
   if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
   else process.env.ORACLE_DATA_DIR = savedDataDir;
   if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
   else process.env.ORACLE_DB_PATH = savedDbPath;
   if (savedMawUrl === undefined) delete process.env.MAW_JS_URL;
   else process.env.MAW_JS_URL = savedMawUrl;
-  dbMod.resetDefaultDatabaseForTests(restoreDbPath);
 });
 
 test('/api/feed stores and lists only selected tenant feed events', async () => {


### PR DESCRIPTION
## Summary
- normalize dashboard query edges for activity days, growth period, and session stats since values
- harden feed listing for unsafe limits, malformed local rows, and remote event shape quirks
- add focused HTTP coverage for dashboard/feed edge cases and fix feed tenant test teardown so it does not migrate the restored real DB

## Tests
- bun test tests/http/dashboard/ tests/http/feed/
- bunx tsc --noEmit
- git diff --check

## File sizes
All touched source/test files are <=250 lines.