### PR TITLE
test(routes): harden mcp and memory edges

### DIFF
--- a/src/routes/mcp/tools.ts
+++ b/src/routes/mcp/tools.ts
@@ -23,6 +23,17 @@ function coreTool(tool: RuntimeMcpToolManifest): PublicTool {
   };
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isValidPluginTool(tool: PluginTool): boolean {
+  return typeof tool.name === 'string' && tool.name.length > 0
+    && typeof tool.description === 'string' && tool.description.length > 0
+    && isRecord(tool.inputSchema)
+    && typeof tool.plugin === 'string' && tool.plugin.length > 0;
+}
+
 function pluginTool(tool: PluginTool): PublicTool {
   return {
     name: tool.name,
@@ -38,7 +49,7 @@ function pluginTool(tool: PluginTool): PublicTool {
 
 export function createMcpRoutes(pluginTools: PluginTool[] = []) {
   return new Elysia({ prefix: '/api' }).get('/mcp/tools', () => {
-    const tools = [...mcpTools.map(coreTool), ...pluginTools.map(pluginTool)];
+    const tools = [...mcpTools.map(coreTool), ...pluginTools.filter(isValidPluginTool).map(pluginTool)];
     const tenantId = currentTenantId();
     return { tools, total: tools.length, ...(tenantId ? { tenant: { id: tenantId, scope: 'tenant_id' } } : {}) };
   }, {

--- a/src/routes/memory/fanout.ts
+++ b/src/routes/memory/fanout.ts
@@ -2,7 +2,7 @@ import { Elysia } from 'elysia';
 import type { SearchResult } from '../../server/types.ts';
 import { ensureVectorStoreConnected, getEmbeddingModels, type EmbeddingModelConfig } from '../../vector/factory.ts';
 import type { VectorQueryResult, VectorStoreAdapter } from '../../vector/types.ts';
-import { MemoryFanoutQuery } from './model.ts';
+import { MemoryFanoutQuery, parseMemoryLimit } from './model.ts';
 
 type QueryStore = Pick<VectorStoreAdapter, 'query'>;
 
@@ -20,10 +20,6 @@ const RRF_K = 60;
 
 function sanitize(q: string): string {
   return q.replace(/<[^>]*>/g, '').replace(/[\x00-\x1f]/g, '').trim();
-}
-
-function parseLimit(raw: string | undefined): number {
-  return Math.min(50, Math.max(1, parseInt(raw ?? '10')));
 }
 
 function estimateTokens(text: string): number {
@@ -106,7 +102,7 @@ export function createMemoryFanoutEndpoint(deps: MemoryFanoutDeps = {}) {
 
     const models = listModels();
     const collections = Object.keys(models);
-    const limit = parseLimit(query.limit);
+    const limit = parseMemoryLimit(query.limit);
     const errors: Record<string, string> = {};
     const byCollection: Record<string, SearchResult[]> = {};
 

--- a/src/routes/memory/index.ts
+++ b/src/routes/memory/index.ts
@@ -1,5 +1,5 @@
 import { Elysia } from 'elysia';
-import { MemoryCloseoutBody, MorningTapeQuery, RecallMemoryQuery, SaveMemoryBody, SemanticMemoryQuery } from './model.ts';
+import { MemoryCloseoutBody, MorningTapeQuery, RecallMemoryQuery, SaveMemoryBody, SemanticMemoryQuery, parseMemoryLimit } from './model.ts';
 import { createMemoryFanoutEndpoint } from './fanout.ts';
 import { memoryStore, type MemoryInput, type MemoryRecord, type MemoryStore } from './store.ts';
 import { memoryVectorIndex, type MemoryVectorHit, type MemoryVectorIndex } from './vector.ts';
@@ -41,7 +41,7 @@ export function createMemoryRoutes(
     })
     .use(createMemoryFanoutEndpoint())
     .get('/memory/morning-tape', ({ query }) => {
-      const limit = Math.min(25, Math.max(1, parseInt(query.limit ?? '8')));
+      const limit = parseMemoryLimit(query.limit, 8, 25);
       const tape = buildMorningTape(store.recall('', limit));
       if (query.format === 'markdown' || query.format === 'md') {
         return new Response(tape.markdown, { headers: { 'content-type': 'text/markdown; charset=utf-8' } });
@@ -52,7 +52,7 @@ export function createMemoryRoutes(
       detail: { tags: ['memory'], menu: { group: 'hidden' }, summary: 'Render a two-minute morning recovery tape from persisted memories' },
     })
     .get('/memory/recall', ({ query }) => {
-      const limit = Math.min(50, Math.max(1, parseInt(query.limit ?? '10')));
+      const limit = parseMemoryLimit(query.limit);
       const items = store.recall(query.q ?? '', limit);
       return { query: query.q ?? '', total: items.length, confidence: MEMORY_CONFIDENCE_STRATEGY, items: items.map(withKeywordConfidence) };
     }, {
@@ -64,7 +64,7 @@ export function createMemoryRoutes(
         set.status = 400;
         return { success: false, error: 'Missing query parameter: q', results: [] };
       }
-      const limit = Math.min(50, Math.max(1, parseInt(query.limit ?? '10')));
+      const limit = parseMemoryLimit(query.limit);
       try {
         const hits = await vectorIndex.search(query.q, limit);
         const records = store.getByIds(hits.map((hit) => hit.memoryId));

--- a/src/routes/memory/model.ts
+++ b/src/routes/memory/model.ts
@@ -35,3 +35,10 @@ export const MemoryFanoutQuery = t.Object({
   q: t.Optional(t.String()),
   limit: t.Optional(t.String()),
 });
+
+
+export function parseMemoryLimit(raw: unknown, fallback = 10, max = 50): number {
+  const parsed = typeof raw === 'number' ? raw : Number.parseInt(String(raw ?? fallback), 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(max, Math.max(1, Math.trunc(parsed)));
+}

--- a/src/routes/memory/store.ts
+++ b/src/routes/memory/store.ts
@@ -3,6 +3,7 @@ import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 import { db as defaultDb, oracleMemories } from '../../db/index.ts';
 import { currentTenantId, tenantIdForWrite } from '../../middleware/tenant.ts';
 import type * as schema from '../../db/schema.ts';
+import { parseMemoryLimit } from './model.ts';
 
 export type MemoryInput = {
   content: string;
@@ -47,7 +48,7 @@ export class MemoryStore {
 
   recall(query = '', limit = 10): MemoryRecord[] {
     const normalized = query.trim();
-    const safeLimit = Math.min(50, Math.max(1, limit));
+    const safeLimit = parseMemoryLimit(limit);
     const where = combineWhere(tenantWhere(), searchWhere(normalized));
     const selected = this.db.select().from(oracleMemories);
     const rows = where

--- a/tests/http/mcp/tools.test.ts
+++ b/tests/http/mcp/tools.test.ts
@@ -33,3 +33,39 @@ test('GET /api/mcp/tools reports active tenant scope', async () => {
   const body = await res.json() as { tenant?: Record<string, unknown> };
   expect(body.tenant).toEqual({ id: 'tenant-a', scope: 'tenant_id' });
 });
+
+test('GET /api/mcp/tools filters malformed plugin tool metadata', async () => {
+  const app = createMcpRoutes([{
+    name: 'oracle_valid_plugin',
+    description: 'Valid plugin tool.',
+    inputSchema: { type: 'object' },
+    handler: 'valid',
+    plugin: 'valid-plugin',
+  }, {
+    name: '',
+    description: 'missing name',
+    inputSchema: { type: 'object' },
+    handler: 'bad',
+    plugin: 'bad-plugin',
+  }, {
+    name: 'oracle_bad_schema',
+    description: 'bad schema',
+    inputSchema: [],
+    handler: 'bad',
+    plugin: 'bad-plugin',
+  }, {
+    name: 'oracle_missing_plugin',
+    description: 'missing plugin',
+    inputSchema: { type: 'object' },
+    handler: 'bad',
+    plugin: '',
+  }] as never);
+
+  const res = await app.handle(new Request('http://local/api/mcp/tools'));
+  const body = await res.json() as { tools: Array<Record<string, unknown>> };
+  const pluginNames = body.tools.filter((tool) => tool.source === 'plugin').map((tool) => tool.name);
+
+  expect(res.status).toBe(200);
+  expect(pluginNames).toEqual(['oracle_valid_plugin']);
+  expect(body.tools.some((tool) => tool.name === '')).toBe(false);
+});

--- a/tests/http/memory/limit-hardening.test.ts
+++ b/tests/http/memory/limit-hardening.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createMemoryFanoutEndpoint } from '../../../src/routes/memory/fanout.ts';
+import { createMemoryRoutes } from '../../../src/routes/memory/index.ts';
+import type { MemoryRecord, MemoryStore } from '../../../src/routes/memory/store.ts';
+import type { MemoryVectorIndex } from '../../../src/routes/memory/vector.ts';
+import type { EmbeddingModelConfig } from '../../../src/vector/factory.ts';
+import type { VectorQueryResult } from '../../../src/vector/types.ts';
+
+const memory: MemoryRecord = {
+  id: 'mem_limit',
+  content: 'Limit hardening memory.',
+  createdAt: '2026-06-17T00:00:00.000Z',
+  updatedAt: '2026-06-17T00:00:00.000Z',
+};
+
+function memoryHarness() {
+  const recallLimits: number[] = [];
+  const searchLimits: number[] = [];
+  const store = {
+    save: () => memory,
+    recall: (_query = '', limit = 10) => {
+      recallLimits.push(limit);
+      return [memory];
+    },
+    getByIds: () => [],
+  } as unknown as MemoryStore;
+  const vectorIndex: MemoryVectorIndex = {
+    async index() { return { indexed: true }; },
+    async search(_query, limit) { searchLimits.push(limit); return []; },
+  };
+  const app = createMemoryRoutes(store, vectorIndex);
+  return { fetcher: createApiVersionedFetch((request) => app.handle(request)), recallLimits, searchLimits };
+}
+
+function fanoutHarness() {
+  const limits: number[] = [];
+  const models: Record<string, EmbeddingModelConfig> = { alpha: { collection: 'alpha', model: 'alpha' } };
+  const empty: VectorQueryResult = { ids: [], documents: [], metadatas: [], distances: [] };
+  const app = new Elysia({ prefix: '/api' }).use(createMemoryFanoutEndpoint({
+    models: () => models,
+    connect: async () => ({ query: async (_query, limit) => { limits.push(limit); return empty; } }),
+  }));
+  return { fetcher: createApiVersionedFetch((request) => app.handle(request)), limits };
+}
+
+test('memory routes fall back from malformed limit query values', async () => {
+  const { fetcher, recallLimits, searchLimits } = memoryHarness();
+  await fetcher(new Request('http://local/api/v1/memory/morning-tape?limit=nope'));
+  await fetcher(new Request('http://local/api/v1/memory/recall?limit=nope'));
+  await fetcher(new Request('http://local/api/v1/memory/search?q=oracle&limit=nope'));
+
+  expect(recallLimits).toEqual([8, 10]);
+  expect(searchLimits).toEqual([10]);
+});
+
+test('memory routes clamp out-of-range limit query values', async () => {
+  const { fetcher, recallLimits, searchLimits } = memoryHarness();
+  await fetcher(new Request('http://local/api/v1/memory/morning-tape?limit=999'));
+  await fetcher(new Request('http://local/api/v1/memory/recall?limit=0'));
+  await fetcher(new Request('http://local/api/v1/memory/search?q=oracle&limit=999'));
+
+  expect(recallLimits).toEqual([25, 1]);
+  expect(searchLimits).toEqual([50]);
+});
+
+test('memory fanout normalizes malformed and large limits', async () => {
+  const { fetcher, limits } = fanoutHarness();
+  await fetcher(new Request('http://local/api/v1/memory/fanout?q=oracle&limit=nope'));
+  await fetcher(new Request('http://local/api/v1/memory/fanout?q=oracle&limit=999'));
+
+  expect(limits).toEqual([10, 50]);
+});


### PR DESCRIPTION
## Summary
- filter malformed plugin MCP tool metadata before exposing /api/mcp/tools
- centralize memory limit parsing so malformed limits fall back and out-of-range limits clamp consistently
- add scoped HTTP coverage for mcp plugin metadata filtering and memory route/fanout limit hardening

## Tests
- ORACLE_DATA_DIR=$tmpdir ORACLE_DB_PATH=$tmpdir/oracle.db bun test tests/http/mcp tests/http/memory
- bunx tsc --noEmit

Changed files are all <=250 lines.

Commit: 40de1d74