### PR TITLE
fix(health,indexer): harden status and start edge cases

### DIFF
--- a/src/routes/health/health.ts
+++ b/src/routes/health/health.ts
@@ -4,6 +4,7 @@ import { MCP_SERVER_NAME } from '../../const.ts';
 import { sqlite } from '../../db/index.ts';
 import { scanPlugins } from '../plugins/model.ts';
 import { readVectorBackendHealth } from '../../vector/health.ts';
+import { getVectorRuntimeStatus } from '../../vector/runtime-status.ts';
 import { mcpTools } from '../../tools/mcp-manifest.ts';
 import type { UnifiedPluginStatus } from '../../plugins/unified-loader.ts';
 import { sandboxLabel } from '../../runtime/sandbox-label.ts';
@@ -53,6 +54,9 @@ const HealthResponseSchema = t.Object({
   uptimeSeconds: t.Optional(t.Number()),
   dbStatus: t.Optional(t.Union([t.Literal('connected'), t.Literal('error')])),
   vectorStatus: t.Optional(t.Union([t.Literal('ok'), t.Literal('degraded'), t.Literal('down')])),
+  vectorMode: t.Optional(t.Union([t.Literal('embedded'), t.Literal('proxied'), t.Literal('disabled')])),
+  vectorUrl: t.Optional(t.String()),
+  vectorDisabledReason: t.Optional(t.String()),
   pluginStatus: t.Optional(t.Union([t.Literal('ok'), t.Literal('degraded')])),
   mcpToolCount: t.Optional(t.Number()),
   pluginCount: t.Optional(t.Number()),
@@ -135,6 +139,20 @@ async function readVectorStatus(check = readVectorBackendHealth): Promise<Vector
   }
 }
 
+async function readPluginStatuses(
+  read?: () => UnifiedPluginStatus[] | Promise<UnifiedPluginStatus[]>,
+): Promise<UnifiedPluginStatus[]> {
+  try {
+    return await read?.() ?? [];
+  } catch (error) {
+    return [{ name: 'plugin-status', status: 'degraded', error: errorMessage(error) }];
+  }
+}
+
+function aggregateStatus(db: DbStatus, vector: VectorHealth, pluginStatus: 'ok' | 'degraded') {
+  return db.status === 'connected' && vector.status === 'ok' && pluginStatus === 'ok' ? 'ok' : 'degraded';
+}
+
 function installedPluginCount(): number {
   try {
     return scanPlugins().plugins.length;
@@ -159,14 +177,15 @@ export function createHealthEndpoint(options: HealthEndpointOptions = {}) {
     const uptimeSeconds = Number(options.uptimeSeconds?.() ?? process.uptime());
     const dbStatus = await readDbStatus(options.dbPing);
     const vector = await readVectorStatus(options.vectorHealth);
-    const pluginItems = await options.pluginStatuses?.() ?? [];
+    const pluginItems = await readPluginStatuses(options.pluginStatuses);
     const pluginCount = options.pluginCount ?? (pluginItems.length || installedPluginCount());
     const pluginStatus = pluginItems.some((plugin) => plugin.status === 'degraded') ? 'degraded' : 'ok';
     const toolCount = mcpTools.length + (options.pluginMcpToolCount ?? 0);
+    const vectorRuntime = getVectorRuntimeStatus();
 
     const serviceUptime = Math.round(uptimeSeconds * 1000) / 1000;
     return {
-      status: dbStatus.status === 'connected' ? 'ok' : 'degraded',
+      status: aggregateStatus(dbStatus, vector, pluginStatus),
       server: MCP_SERVER_NAME,
       version: pkg.version,
       port: Number(PORT),
@@ -177,6 +196,7 @@ export function createHealthEndpoint(options: HealthEndpointOptions = {}) {
       oracle: dbStatus.status === 'connected' ? 'connected' : 'error',
       dbStatus: dbStatus.status,
       vectorStatus: vector.status,
+      ...vectorRuntime,
       pluginStatus,
       mcpToolCount: toolCount,
       pluginCount,

--- a/src/routes/health/health.ts
+++ b/src/routes/health/health.ts
@@ -149,8 +149,8 @@ async function readPluginStatuses(
   }
 }
 
-function aggregateStatus(db: DbStatus, vector: VectorHealth, pluginStatus: 'ok' | 'degraded') {
-  return db.status === 'connected' && vector.status === 'ok' && pluginStatus === 'ok' ? 'ok' : 'degraded';
+function aggregateStatus(db: DbStatus, pluginStatus: 'ok' | 'degraded') {
+  return db.status === 'connected' && pluginStatus === 'ok' ? 'ok' : 'degraded';
 }
 
 function installedPluginCount(): number {
@@ -185,7 +185,7 @@ export function createHealthEndpoint(options: HealthEndpointOptions = {}) {
 
     const serviceUptime = Math.round(uptimeSeconds * 1000) / 1000;
     return {
-      status: aggregateStatus(dbStatus, vector, pluginStatus),
+      status: aggregateStatus(dbStatus, pluginStatus),
       server: MCP_SERVER_NAME,
       version: pkg.version,
       port: Number(PORT),

--- a/src/routes/indexer/start.ts
+++ b/src/routes/indexer/start.ts
@@ -23,14 +23,30 @@ export interface StartRouteDeps {
   runInBackground?: (task: Promise<void>) => void;
 }
 
+function chooseModel(models: Models, requested?: string): string | undefined {
+  if (requested && models[requested]) return requested;
+  if (models.nomic) return 'nomic';
+  return Object.keys(models)[0];
+}
+
+function normalizeBatchSize(value: number | undefined, key: string): number {
+  const fallback = key === 'nomic' ? 100 : 50;
+  if (value === undefined || !Number.isFinite(value) || value <= 0) return fallback;
+  return Math.min(1000, Math.floor(value));
+}
+
 export function createStartRoute(deps: StartRouteDeps = {}) {
-  return new Elysia().post('/indexer/start', async ({ body }) => {
+  return new Elysia().post('/indexer/start', async ({ body, set }) => {
     const { model, sourcePath, batchSize } = body;
 
     const models = (deps.getModels ?? getEmbeddingModels)();
-    const key = model && models[model] ? model : 'nomic';
+    const key = chooseModel(models, model);
+    if (!key) {
+      set.status = 503;
+      return { status: 'error', error: 'No embedding models configured' };
+    }
     const preset = models[key];
-    const batch = batchSize || (key === 'nomic' ? 100 : 50);
+    const batch = normalizeBatchSize(batchSize, key);
 
     const dbPath = deps.dbPath ?? DB_PATH;
     const repoRoot = sourcePath || deps.repoRoot || REPO_ROOT;
@@ -105,10 +121,11 @@ export function createStartRoute(deps: StartRouteDeps = {}) {
         if (!abortFlag) {
           setIndexingStatus(sqlite, config, false, rows.length, rows.length);
         }
-        await store.close();
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
         setIndexingStatus(sqlite, config, false, 0, 0, msg);
+      } finally {
+        await store.close().catch(() => undefined);
       }
     });
     (deps.runInBackground ?? ((backgroundTask) => { void backgroundTask; }))(task);

--- a/tests/http/health/plugin-status.test.ts
+++ b/tests/http/health/plugin-status.test.ts
@@ -37,3 +37,22 @@ test('GET /api/health reports loaded plugin lifecycle status', async () => {
   ]);
   await runtime.stop();
 });
+
+test('GET /api/health degrades instead of failing when plugin status read throws', async () => {
+  const app = createHealthRoutes({
+    uptimeSeconds: () => 1,
+    vectorHealth: async () => ({ status: 'ok', engines: [], checked_at: '2026-06-16T00:00:00.000Z' }),
+    pluginStatuses: () => { throw new Error('plugin registry unavailable'); },
+  });
+  const res = await app.handle(new Request('http://local/api/health'));
+  const body = await res.json() as Record<string, any>;
+
+  expect(res.status).toBe(200);
+  expect(body.status).toBe('degraded');
+  expect(body.pluginStatus).toBe('degraded');
+  expect(body.plugins).toMatchObject({
+    count: 1,
+    status: 'degraded',
+    items: [{ name: 'plugin-status', status: 'degraded', error: 'plugin registry unavailable' }],
+  });
+});

--- a/tests/http/indexer/basic.test.ts
+++ b/tests/http/indexer/basic.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, test } from 'bun:test';
+import { afterAll, describe, expect, mock, test } from 'bun:test';
 import { Elysia } from 'elysia';
 import { Database } from 'bun:sqlite';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
@@ -24,8 +24,8 @@ function request(path: string, init: RequestInit = {}) {
   return indexerRoutes.handle(new Request(`http://local${path}`, init));
 }
 
-function post(path: string, body: unknown) {
-  return request(path, {
+function post(path: string, body: unknown, fetcher = request) {
+  return fetcher(path, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body),
@@ -79,6 +79,43 @@ describe('indexer HTTP routes', () => {
     const res = await post('/api/indexer/stop', {});
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ stopped: true });
+  });
+
+  test('POST /api/indexer/start returns 503 when no embedding models are configured', async () => {
+    const app = new Elysia({ prefix: '/api' }).use(createStartRoute({ getModels: () => ({} as any) }));
+    const res = await post('/api/indexer/start', {}, (path, init) => app.handle(new Request(`http://local${path}`, init)));
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(503);
+    expect(body).toEqual({ status: 'error', error: 'No embedding models configured' });
+  });
+
+  test('POST /api/indexer/start normalizes bad batch size and closes failed stores', async () => {
+    const sqlite = tenantIndexerDb();
+    const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    seedDoc(sqlite, `idx-fail-${stamp}`, 'default', `alpha ${stamp}`, 1);
+    const close = mock(async () => {});
+    const tasks: Promise<void>[] = [];
+    const app = new Elysia({ prefix: '/api' }).use(createStartRoute({
+      createDb: () => ({ sqlite } as any),
+      createStore: () => ({ ...fakeStore([]), close, addDocuments: mock(async () => { throw new Error('embed failed'); }) }),
+      getModels: () => ({ nomic: { collection: 'test', model: 'nomic-embed-text' } } as any),
+      runInBackground: (task) => tasks.push(task),
+    }));
+
+    try {
+      const res = await post('/api/indexer/start', { model: 'nomic', batchSize: -3 }, (path, init) => app.handle(new Request(`http://local${path}`, init)));
+      const body = await res.json() as Record<string, unknown>;
+      await Promise.all(tasks);
+      const status = sqlite.prepare('SELECT error FROM indexing_status WHERE id = 1').get() as any;
+
+      expect(res.status).toBe(200);
+      expect(body.batchSize).toBe(100);
+      expect(status.error).toBe('embed failed');
+      expect(close).toHaveBeenCalledTimes(1);
+    } finally {
+      sqlite.close();
+    }
   });
 
   test('POST /api/indexer/start scopes vector indexing by tenant', async () => {


### PR DESCRIPTION
## Summary
- Add vector runtime mode to `/api/health` and keep health responses degraded instead of failing when plugin status collection throws.
- Harden `/api/indexer/start` for empty model config, invalid batch sizes, and vector-store failures while ensuring stores close on error paths.
- Add focused health/indexer regression coverage.

## Scope
- Code changes limited to `src/routes/health` and `src/routes/indexer`.
- Tests limited to health/indexer scoped tests.

## Validation
- `ORACLE_DATA_DIR=$(mktemp -d) bun test tests/http/health/ tests/http/indexer/ src/routes/health/__tests__ src/routes/indexer/__tests__` (34 pass)
- `bunx tsc --noEmit`
- `wc -l src/routes/health/health.ts src/routes/indexer/start.ts tests/http/health/plugin-status.test.ts tests/http/indexer/basic.test.ts` (all <=250)