### PR TITLE
test(routes): harden verify and concepts

### DIFF
--- a/src/routes/concepts/index.ts
+++ b/src/routes/concepts/index.ts
@@ -9,9 +9,15 @@ const ConceptsQuery = t.Object({
   type: t.Optional(t.String()),
 });
 
+function parseLimit(value: string | undefined): number | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || !/^\d+$/.test(trimmed)) return undefined;
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
 function toConceptsInput(query: { limit?: string; type?: string }): OracleConceptsInput {
-  const parsedLimit = query.limit ? parseInt(query.limit, 10) : NaN;
-  const limit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : undefined;
+  const limit = parseLimit(query.limit);
   const type = ['principle', 'pattern', 'learning', 'retro', 'all'].includes(query.type ?? '')
     ? query.type as OracleConceptsInput['type']
     : 'all';

--- a/src/tools/concepts.ts
+++ b/src/tools/concepts.ts
@@ -9,6 +9,9 @@ import { oracleDocuments } from '../db/schema.ts';
 import { currentTenantId } from '../middleware/tenant.ts';
 import type { ToolContext, ToolResponse, OracleConceptsInput } from './types.ts';
 
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
 export const conceptsToolDef = {
   name: 'oracle_concepts',
   description: 'List all concept tags in the Oracle knowledge base with document counts. Useful for discovering what topics are covered and filtering searches.',
@@ -31,8 +34,32 @@ export const conceptsToolDef = {
   }
 };
 
+function normalizeLimit(limit: number | undefined): number {
+  if (!Number.isSafeInteger(limit) || limit === undefined || limit <= 0) return DEFAULT_LIMIT;
+  return Math.min(limit, MAX_LIMIT);
+}
+
+function conceptNames(raw: string): string[] {
+  let values: unknown[] = [];
+  try {
+    const parsed = JSON.parse(raw);
+    values = Array.isArray(parsed) ? parsed : typeof parsed === 'string' ? parsed.split(',') : [];
+  } catch {
+    values = raw.split(',');
+  }
+
+  const unique = new Set<string>();
+  for (const value of values) {
+    if (typeof value !== 'string') continue;
+    const concept = value.trim();
+    if (concept) unique.add(concept);
+  }
+  return [...unique];
+}
+
 export function listConcepts(db: ToolContext['db'], input: OracleConceptsInput) {
-  const { limit = 50, type = 'all' } = input;
+  const limit = normalizeLimit(input.limit);
+  const type = input.type ?? 'all';
 
   const filters = [isNotNull(oracleDocuments.concepts), ne(oracleDocuments.concepts, '[]')];
   const tenantId = currentTenantId();
@@ -44,28 +71,14 @@ export function listConcepts(db: ToolContext['db'], input: OracleConceptsInput) 
 
   const conceptCounts = new Map<string, number>();
   for (const row of rows as Array<{ concepts: string }>) {
-    try {
-      const concepts = JSON.parse(row.concepts);
-      if (Array.isArray(concepts)) {
-        for (const concept of concepts) {
-          if (typeof concept === 'string') {
-            conceptCounts.set(concept, (conceptCounts.get(concept) || 0) + 1);
-          }
-        }
-      }
-    } catch {
-      if (typeof row.concepts === 'string') {
-        const concepts = row.concepts.split(',').map(c => c.trim()).filter(Boolean);
-        for (const concept of concepts) {
-          conceptCounts.set(concept, (conceptCounts.get(concept) || 0) + 1);
-        }
-      }
+    for (const concept of conceptNames(row.concepts)) {
+      conceptCounts.set(concept, (conceptCounts.get(concept) || 0) + 1);
     }
   }
 
   const sortedConcepts = Array.from(conceptCounts.entries())
     .map(([name, count]) => ({ name, count }))
-    .sort((a, b) => b.count - a.count)
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
     .slice(0, limit);
 
   return {

--- a/src/verify/handler.ts
+++ b/src/verify/handler.ts
@@ -34,20 +34,29 @@ interface FileInfo {
   mtimeMs: number;
 }
 
-/**
- * Recursively collect all .md files with mtimes
- */
 function walkMarkdownFiles(dir: string, baseDir: string): FileInfo[] {
   const files: FileInfo[] = [];
   if (!fs.existsSync(dir)) return files;
 
-  const items = fs.readdirSync(dir);
+  let items: string[] = [];
+  try {
+    items = fs.readdirSync(dir);
+  } catch {
+    return files;
+  }
+
   for (const item of items) {
     const fullPath = path.join(dir, item);
-    const stat = fs.statSync(fullPath);
+    let stat: fs.Stats;
+    try {
+      stat = fs.lstatSync(fullPath);
+    } catch {
+      continue;
+    }
+    if (stat.isSymbolicLink()) continue;
     if (stat.isDirectory()) {
       files.push(...walkMarkdownFiles(fullPath, baseDir));
-    } else if (item.endsWith('.md')) {
+    } else if (stat.isFile() && item.endsWith('.md')) {
       files.push({
         relativePath: path.relative(baseDir, fullPath),
         mtimeMs: stat.mtimeMs,
@@ -57,9 +66,6 @@ function walkMarkdownFiles(dir: string, baseDir: string): FileInfo[] {
   return files;
 }
 
-/**
- * Verify knowledge base integrity: disk files vs DB index
- */
 export function verifyKnowledgeBase(opts: {
   check?: boolean;
   type?: string;

--- a/tests/http/concepts/tenant-isolation.test.ts
+++ b/tests/http/concepts/tenant-isolation.test.ts
@@ -22,22 +22,27 @@ const tenantB = `concepts-b-${stamp}`;
 const docs = {
   aLearning: `concept-a-learning-${stamp}`,
   aPrinciple: `concept-a-principle-${stamp}`,
+  aNoisy: `concept-a-noisy-${stamp}`,
+  aLegacy: `concept-a-legacy-${stamp}`,
   bLearning: `concept-b-learning-${stamp}`,
 };
 const concepts = {
   shared: `shared-${stamp}`,
   aOnly: `a-only-${stamp}`,
+  noisy: `noisy-${stamp}`,
+  legacyA: `legacy-a-${stamp}`,
+  legacyB: `legacy-b-${stamp}`,
   bOnly: `b-only-${stamp}`,
 };
 
-function insertDoc(id: string, tenantId: string, type: string, values: string[]) {
+function insertDoc(id: string, tenantId: string, type: string, values: unknown[] | string) {
   const now = Date.now();
   dbMod.db.insert(dbMod.oracleDocuments).values({
     id,
     tenantId,
     type,
     sourceFile: `ψ/memory/${id}.md`,
-    concepts: JSON.stringify(values),
+    concepts: typeof values === 'string' ? values : JSON.stringify(values),
     createdAt: now,
     updatedAt: now,
     indexedAt: now,
@@ -58,6 +63,8 @@ function countByName(body: { concepts: Array<{ name: string; count: number }> },
 
 insertDoc(docs.aLearning, tenantA, 'learning', [concepts.shared, concepts.aOnly]);
 insertDoc(docs.aPrinciple, tenantA, 'principle', [concepts.shared]);
+insertDoc(docs.aNoisy, tenantA, 'learning', [` ${concepts.noisy} `, concepts.noisy, '', 42]);
+insertDoc(docs.aLegacy, tenantA, 'learning', `${concepts.legacyA}, ${concepts.legacyA}, ${concepts.legacyB},`);
 insertDoc(docs.bLearning, tenantB, 'learning', [concepts.shared, concepts.bOnly]);
 
 afterAll(() => {
@@ -68,7 +75,7 @@ afterAll(() => {
   else process.env.ORACLE_DATA_DIR = savedDataDir;
   if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
   else process.env.ORACLE_DB_PATH = savedDbPath;
-  dbMod.resetDefaultDatabaseForTests();
+  dbMod.resetDefaultDatabaseForTests(':memory:');
   rmSync(root, { recursive: true, force: true });
 });
 
@@ -80,7 +87,7 @@ test('/api/concepts counts only documents from the active tenant', async () => {
   expect(countByName(body, concepts.shared)).toBe(2);
   expect(countByName(body, concepts.aOnly)).toBe(1);
   expect(countByName(body, concepts.bOnly)).toBe(0);
-  expect(body.total_unique).toBe(2);
+  expect(body.total_unique).toBe(5);
 });
 
 test('/api/concepts keeps type filters inside the selected tenant', async () => {
@@ -92,4 +99,16 @@ test('/api/concepts keeps type filters inside the selected tenant', async () => 
   expect(countByName(body, concepts.bOnly)).toBe(1);
   expect(countByName(body, concepts.aOnly)).toBe(0);
   expect(body.total_unique).toBe(2);
+});
+
+test('/api/concepts normalizes noisy concept payloads and rejects partial limits', async () => {
+  const res = await requestConcepts(tenantA, '/api/concepts?type=learning&limit=1abc');
+  const body = await res.json() as { concepts: Array<{ name: string; count: number }>; total_unique: number };
+
+  expect(res.status).toBe(200);
+  expect(body.concepts.length).toBeGreaterThan(1);
+  expect(countByName(body, concepts.noisy)).toBe(1);
+  expect(countByName(body, concepts.legacyA)).toBe(1);
+  expect(countByName(body, concepts.legacyB)).toBe(1);
+  expect(body.total_unique).toBe(5);
 });

--- a/tests/http/verify/tenant-isolation.test.ts
+++ b/tests/http/verify/tenant-isolation.test.ts
@@ -29,6 +29,7 @@ const paths = {
   bHealthy: `ψ/memory/learnings/verify-b-${stamp}.md`,
   bOrphan: `ψ/memory/learnings/verify-b-orphan-${stamp}.md`,
   unindexed: `ψ/memory/learnings/verify-unindexed-${stamp}.md`,
+  brokenLink: `ψ/memory/learnings/verify-broken-${stamp}.md`,
 };
 
 function writeRepoFile(relPath: string, content: string) {
@@ -62,6 +63,12 @@ function seedDoc(id: string, tenantId: string, sourceFile: string) {
 writeRepoFile(paths.aHealthy, '# Tenant A\n');
 writeRepoFile(paths.bHealthy, '# Tenant B\n');
 writeRepoFile(paths.unindexed, '# Unindexed disk-only file\n');
+try {
+  fs.symlinkSync(
+    path.join(repoRoot, 'missing-target.md'),
+    path.join(repoRoot, paths.brokenLink),
+  );
+} catch {}
 seedDoc(`verify-a-${stamp}`, tenantA, paths.aHealthy);
 seedDoc(`verify-b-${stamp}`, tenantB, paths.bHealthy);
 seedDoc(`verify-b-orphan-${stamp}`, tenantB, paths.bOrphan);
@@ -103,6 +110,16 @@ test('POST /api/verify check=false only flags orphaned docs in the active tenant
   expect(body.fixed_orphans).toBe(1);
   expect(orphan?.supersededBy).toBe('_verified_orphan');
   expect(tenantAHealthy?.supersededBy).toBeNull();
+});
+
+test('GET /api/verify skips broken symlinks and safely defaults invalid query filters', async () => {
+  const res = await tenantRequest(tenantA, '/api/verify?type=not-real&check=definitely');
+  const body = await res.json() as { missing: string[]; orphaned: string[]; drifted: string[] };
+
+  expect(res.status).toBe(200);
+  expect(body.missing).not.toContain(paths.brokenLink);
+  expect(body.orphaned).not.toContain(paths.brokenLink);
+  expect(body.drifted).not.toContain(paths.brokenLink);
 });
 
 afterAll(() => {


### PR DESCRIPTION
## Summary
- Harden `/api/concepts` limit parsing so partial numeric strings do not silently truncate results.
- Normalize concept payloads per document: trim names, ignore blanks/non-strings, dedupe duplicate tags in one document, support legacy comma strings, and stabilize tie sorting.
- Harden verify disk walking so unreadable/disappearing entries and symlinks do not crash `/api/verify`.
- Extend verify/concepts HTTP coverage for tenant scope plus noisy payloads, invalid filters, and broken symlink edge cases.

## Validation
- `bunx tsc --noEmit`
- `bun test tests/http/verify/ tests/http/concepts/`
- `ORACLE_DATA_DIR=<tmp> ORACLE_DB_PATH=<tmp>/oracle.db bun test src/tools/__tests__/backend-tools-unit.test.ts`
- `git diff --check`
- changed files <= 250 lines
