### PR TITLE
fix: harden tenant and trace route edges

### DIFF
--- a/src/routes/tenants/index.ts
+++ b/src/routes/tenants/index.ts
@@ -8,8 +8,14 @@ const TenantBody = t.Object({
   name: t.Optional(t.String()),
   status: t.Optional(t.Union([t.Literal('active'), t.Literal('disabled')])),
 });
+const TENANT_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/;
 
 function now() { return Date.now(); }
+
+function normalizeTenantId(value: string): string | null {
+  const id = value.trim();
+  return TENANT_ID_PATTERN.test(id) ? id : null;
+}
 
 function ensureDefaultTenant() {
   db.insert(tenants).values({
@@ -27,11 +33,16 @@ export const tenantsRoutes = new Elysia({ prefix: '/api' })
     const data = db.select().from(tenants).all();
     return { tenants: data, count: data.length };
   }, { detail: { tags: ['tenants'], summary: 'List tenants' } })
-  .post('/tenants', ({ body }) => {
+  .post('/tenants', ({ body, set }) => {
     const input = body as { id: string; name?: string; status?: 'active' | 'disabled' };
+    const id = normalizeTenantId(input.id);
+    if (!id) {
+      set.status = 400;
+      return { error: 'Invalid tenant id. Use 1-128 letters, numbers, dot, underscore, colon, or dash.' };
+    }
     const row = {
-      id: input.id.trim(),
-      name: input.name?.trim() || input.id.trim(),
+      id,
+      name: input.name?.trim() || id,
       status: input.status ?? 'active',
       createdAt: now(),
       updatedAt: now(),
@@ -42,10 +53,15 @@ export const tenantsRoutes = new Elysia({ prefix: '/api' })
     return { success: true, tenant: db.select().from(tenants).where(eq(tenants.id, row.id)).get() };
   }, { body: TenantBody, detail: { tags: ['tenants'], summary: 'Create or update a tenant' } })
   .get('/tenants/:id', ({ params, set }) => {
-    const tenant = db.select().from(tenants).where(eq(tenants.id, params.id)).get();
+    const id = normalizeTenantId(params.id);
+    if (!id) {
+      set.status = 400;
+      return { error: 'Invalid tenant id' };
+    }
+    const tenant = db.select().from(tenants).where(eq(tenants.id, id)).get();
     if (!tenant) {
       set.status = 404;
-      return { error: `Tenant not found: ${params.id}` };
+      return { error: `Tenant not found: ${id}` };
     }
     return { tenant };
   }, { params: t.Object({ id: t.String({ minLength: 1 }) }) });

--- a/src/routes/traces/tenant-scope.ts
+++ b/src/routes/traces/tenant-scope.ts
@@ -21,8 +21,8 @@ export function createTenantTrace(input: CreateTraceInput): CreateTraceResult {
 }
 
 export function listTenantTraces(input: ListTracesInput): ListTracesResult {
-  const limit = input.limit || 20;
-  const offset = input.offset || 0;
+  const limit = Math.min(100, Math.max(1, Number.isFinite(input.limit) ? input.limit! : 20));
+  const offset = Math.max(0, Number.isFinite(input.offset) ? input.offset! : 0);
   const conditions = [eq(traceLog.tenantId, activeTenantId())];
   if (input.query) conditions.push(like(traceLog.query, `%${input.query}%`));
   if (input.project) conditions.push(eq(traceLog.project, input.project));
@@ -63,40 +63,42 @@ export function listTenantTraces(input: ListTracesInput): ListTracesResult {
 
 export function getTenantTraceChain(traceId: string, direction: 'up' | 'down' | 'both' = 'both'): TraceChainResult {
   const chain: TraceSummary[] = [];
+  const added = new Set<string>();
   let hasAwakening = false;
   let awakeningTraceId: string | undefined;
+  const addTrace = (trace: TraceRecord, prepend = false) => {
+    if (added.has(trace.traceId)) return;
+    added.add(trace.traceId);
+    if (prepend) chain.unshift(toSummary(trace));
+    else chain.push(toSummary(trace));
+    if (trace.awakening) {
+      hasAwakening = true;
+      awakeningTraceId = trace.traceId;
+    }
+  };
   if (direction === 'up' || direction === 'both') {
     let current = getTenantTrace(traceId);
+    const visited = new Set<string>();
     while (current?.parentTraceId) {
+      if (visited.has(current.parentTraceId)) break;
+      visited.add(current.parentTraceId);
       const parent = getTenantTrace(current.parentTraceId);
-      if (parent) {
-        chain.unshift(toSummary(parent));
-        if (parent.awakening) {
-          hasAwakening = true;
-          awakeningTraceId = parent.traceId;
-        }
-      }
+      if (parent) addTrace(parent, true);
       current = parent;
     }
   }
   const self = getTenantTrace(traceId);
-  if (self) {
-    chain.push(toSummary(self));
-    if (self.awakening) {
-      hasAwakening = true;
-      awakeningTraceId = self.traceId;
-    }
-  }
+  if (self) addTrace(self);
   if (direction === 'down' || direction === 'both') {
     const queue = self?.childTraceIds || [];
+    const visited = new Set<string>(self ? [self.traceId] : []);
     while (queue.length > 0) {
-      const child = getTenantTrace(queue.shift()!);
+      const childId = queue.shift()!;
+      if (visited.has(childId)) continue;
+      visited.add(childId);
+      const child = getTenantTrace(childId);
       if (child) {
-        chain.push(toSummary(child));
-        if (child.awakening) {
-          hasAwakening = true;
-          awakeningTraceId = child.traceId;
-        }
+        addTrace(child);
         queue.push(...child.childTraceIds);
       }
     }

--- a/tests/http/tenant/admin.test.ts
+++ b/tests/http/tenant/admin.test.ts
@@ -24,3 +24,19 @@ test('tenant admin API creates and lists tenants', async () => {
   const body = await listed.json() as { tenants: Array<{ id: string }> };
   expect(body.tenants.map((tenant) => tenant.id)).toContain(tenantId);
 });
+
+test('tenant admin API rejects blank or unsafe tenant ids', async () => {
+  for (const id of ['   ', '../escape', 'bad tenant']) {
+    const res = await tenantsRoutes.handle(new Request('http://local/api/tenants', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id }),
+    }));
+    const body = await res.json() as { error: string };
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('tenant id');
+  }
+
+  expect(db.select().from(tenants).where(eq(tenants.id, '')).get()).toBeUndefined();
+});

--- a/tests/http/traces/edge-cases.test.ts
+++ b/tests/http/traces/edge-cases.test.ts
@@ -1,0 +1,89 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { inArray } from 'drizzle-orm';
+import { mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const root = join(tmpdir(), `arra-trace-edge-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+const dbPath = join(root, 'oracle.db');
+mkdirSync(root, { recursive: true });
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = dbPath;
+
+const dbMod = await import('../../../src/db/index.ts');
+dbMod.resetDefaultDatabaseForTests(dbPath);
+const { tracesApi } = await import('../../../src/routes/traces/index.ts');
+
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const traceA = `trace-edge-a-${stamp}`;
+const traceB = `trace-edge-b-${stamp}`;
+const cyclicTrace = `trace-edge-cycle-${stamp}`;
+const traceIds = [traceA, traceB, cyclicTrace];
+const now = Date.now();
+
+dbMod.db.insert(dbMod.traceLog).values([
+  { traceId: traceA, query: `trace edge ${stamp} a`, status: 'raw', childTraceIds: '[]', createdAt: now, updatedAt: now },
+  { traceId: traceB, query: `trace edge ${stamp} b`, status: 'distilled', childTraceIds: '[]', createdAt: now + 1, updatedAt: now + 1 },
+  {
+    traceId: cyclicTrace,
+    query: `trace edge ${stamp} cyclic`,
+    status: 'raw',
+    parentTraceId: cyclicTrace,
+    childTraceIds: JSON.stringify([cyclicTrace]),
+    createdAt: now + 2,
+    updatedAt: now + 2,
+  },
+]).run();
+
+function request(pathname: string) {
+  return tracesApi.handle(new Request(`http://local${pathname}`));
+}
+
+function restore(name: string, value: string | undefined) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+afterAll(() => {
+  dbMod.db.delete(dbMod.traceLog).where(inArray(dbMod.traceLog.traceId, traceIds)).run();
+  dbMod.closeDb();
+  restore('ORACLE_DATA_DIR', savedDataDir);
+  restore('ORACLE_DB_PATH', savedDbPath);
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('trace route edge cases', () => {
+  test('GET /api/traces rejects unsafe pagination values', async () => {
+    const res = await request(`/api/traces?query=${encodeURIComponent(stamp)}&limit=-1&offset=NaN`);
+    const body = await res.json() as { error: string };
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('limit');
+  });
+
+  test('GET /api/traces rejects unsupported status filters', async () => {
+    const res = await request('/api/traces?status=sideways');
+    const body = await res.json() as { error: string };
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('status');
+  });
+
+  test('GET /api/traces/:id/chain rejects bad direction and missing ids', async () => {
+    const badDirection = await request(`/api/traces/${traceA}/chain?direction=sideways`);
+    const missing = await request('/api/traces/not-found/chain');
+
+    expect(badDirection.status).toBe(400);
+    expect(missing.status).toBe(404);
+  });
+
+  test('GET /api/traces/:id/chain terminates on cyclic parent and child links', async () => {
+    const res = await request(`/api/traces/${cyclicTrace}/chain`);
+    const body = await res.json() as { chain: Array<{ traceId: string }>; totalDepth: number };
+
+    expect(res.status).toBe(200);
+    expect(body.chain.map((trace) => trace.traceId)).toEqual([cyclicTrace]);
+  });
+});


### PR DESCRIPTION
## Summary

- Harden `src/routes/tenants` admin writes by trimming and validating tenant IDs against the same safe segment shape used by tenant middleware before insert/upsert/get.
- Harden trace chain traversal in `src/routes/traces` so cyclic parent/child links terminate without duplicate/infinite traversal.
- Add scoped regression coverage for unsafe tenant IDs, trace list/status/direction edge cases, missing trace chain targets, and cyclic trace graph traversal.

## Validation

- `bunx tsc --noEmit`
- `ORACLE_DATA_DIR=$(mktemp -d /tmp/arra-tt-test-XXXXXX) ORACLE_DB_PATH="$ORACLE_DATA_DIR/oracle.sqlite" bun test tests/http/tenant/ tests/http/traces/` — 52 pass
- `git diff --check origin/alpha...HEAD`
- File size gate: all files under `src/routes/tenants`, `src/routes/traces`, `tests/http/tenant`, and `tests/http/traces` are <=250 lines.

## Scope

Touched only:
- `src/routes/tenants/*`
- `src/routes/traces/*`
- `tests/http/tenant/*`
- `tests/http/traces/*`

No docs or `ψ/` changes.
