### PR TITLE
fix: harden vault sync and menu edge cases

### DIFF
--- a/src/routes/menu/admin-order.ts
+++ b/src/routes/menu/admin-order.ts
@@ -8,6 +8,7 @@ import { Elysia, t } from 'elysia';
 import { eq } from 'drizzle-orm';
 import { db, menuItems } from '../../db/index.ts';
 import { menuOwnedWhere } from '../../menu/tenant.ts';
+import { isMenuId, parseMenuIdParam } from './ids.ts';
 
 export function createMenuOrderRoutes() {
   return new Elysia()
@@ -19,6 +20,10 @@ export function createMenuOrderRoutes() {
           const ids = db.transaction((tx) => {
             const touched: number[] = [];
             for (const item of body.items) {
+              if (!isMenuId(item.id)) throw new Error('invalid id');
+              if (item.parentId != null && !isMenuId(item.parentId)) {
+                throw new Error('invalid parentId');
+              }
               const row = tx
                 .update(menuItems)
                 .set({
@@ -63,8 +68,8 @@ export function createMenuOrderRoutes() {
     .post(
       '/menu/reset/:id',
       ({ params, set }) => {
-        const id = Number(params.id);
-        if (!Number.isFinite(id)) {
+        const id = parseMenuIdParam(params.id);
+        if (id == null) {
           set.status = 400;
           return { error: 'invalid id' };
         }

--- a/src/routes/menu/admin.ts
+++ b/src/routes/menu/admin.ts
@@ -11,6 +11,7 @@ import { ScopeSchema } from './model.ts';
 import { softDeleteWhere } from '../../storage/soft-delete.ts';
 import { AccessSchema, GroupSchema, buildTree, toResponse, type MenuRow } from './admin-model.ts';
 import { menuOwnedWhere, menuTenantIdForWrite, menuVisibleWhere } from '../../menu/tenant.ts';
+import { parseMenuIdParam } from './ids.ts';
 
 export function createMenuAdminRoutes() {
   return new Elysia()
@@ -112,8 +113,8 @@ export function createMenuAdminRoutes() {
     .patch(
       '/menu/items/:id',
       ({ params, body, set }) => {
-        const id = Number(params.id);
-        if (!Number.isFinite(id)) {
+        const id = parseMenuIdParam(params.id);
+        if (id == null) {
           set.status = 400;
           return { error: 'invalid id' };
         }
@@ -168,8 +169,8 @@ export function createMenuAdminRoutes() {
     .delete(
       '/menu/items/:id',
       ({ params, set }) => {
-        const id = Number(params.id);
-        if (!Number.isFinite(id)) {
+        const id = parseMenuIdParam(params.id);
+        if (id == null) {
           set.status = 400;
           return { error: 'invalid id' };
         }

--- a/src/routes/menu/crud.ts
+++ b/src/routes/menu/crud.ts
@@ -5,11 +5,7 @@ import { softDeleteWhere } from '../../storage/soft-delete.ts';
 import { ScopeSchema } from './model.ts';
 import { AccessSchema, GroupSchema, toResponse, type MenuRow } from './admin-model.ts';
 import { menuOwnedWhere, menuTenantIdForWrite } from '../../menu/tenant.ts';
-
-function idParam(value: string): number | null {
-  const id = Number(value);
-  return Number.isFinite(id) ? id : null;
-}
+import { parseMenuIdParam } from './ids.ts';
 
 function insertMenuItem(body: MenuCreateBody) {
   const now = new Date();
@@ -85,7 +81,7 @@ export function createMenuCrudRoutes() {
       }
     }, { body: CreateBody, detail: { tags: ['menu'], summary: 'Create a menu item' } })
     .put('/menu/:id', ({ params, body, set }) => {
-      const id = idParam(params.id);
+      const id = parseMenuIdParam(params.id);
       if (id == null) {
         set.status = 400;
         return { error: 'invalid id' };
@@ -98,7 +94,7 @@ export function createMenuCrudRoutes() {
       return toResponse(updated);
     }, { params: t.Object({ id: t.String() }), body: UpdateBody, detail: { tags: ['menu'], summary: 'Update a menu item' } })
     .delete('/menu/:id', ({ params, set }) => {
-      const id = idParam(params.id);
+      const id = parseMenuIdParam(params.id);
       if (id == null) {
         set.status = 400;
         return { error: 'invalid id' };

--- a/src/routes/menu/ids.ts
+++ b/src/routes/menu/ids.ts
@@ -1,0 +1,10 @@
+export function parseMenuIdParam(value: string): number | null {
+  const trimmed = value.trim();
+  if (!/^[1-9]\d*$/.test(trimmed)) return null;
+  const id = Number(trimmed);
+  return Number.isSafeInteger(id) ? id : null;
+}
+
+export function isMenuId(value: number): boolean {
+  return Number.isSafeInteger(value) && value > 0;
+}

--- a/src/routes/menu/search.ts
+++ b/src/routes/menu/search.ts
@@ -1,5 +1,5 @@
 import { Elysia, t } from 'elysia';
-import { and, asc, eq, isNull, like, or } from 'drizzle-orm';
+import { and, asc, eq, isNull, or, sql } from 'drizzle-orm';
 import { db, menuItems } from '../../db/index.ts';
 import { menuRowToItem } from './list-paginated.ts';
 import { menuVisibleWhere } from '../../menu/tenant.ts';
@@ -8,9 +8,13 @@ function searchTerm(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
 }
 
+function escapeLikeTerm(value: string): string {
+  return value.replace(/[\\%_]/g, (char) => `\\${char}`);
+}
+
 function searchMenuRows(q: string) {
   if (!q) return [];
-  const pattern = `%${q}%`;
+  const pattern = `%${escapeLikeTerm(q)}%`;
   return db
     .select()
     .from(menuItems)
@@ -18,7 +22,10 @@ function searchMenuRows(q: string) {
       menuVisibleWhere(and(
         eq(menuItems.enabled, true),
         isNull(menuItems.deletedAt),
-        or(like(menuItems.label, pattern), like(menuItems.path, pattern)),
+        or(
+          sql`${menuItems.label} LIKE ${pattern} ESCAPE '\\'`,
+          sql`${menuItems.path} LIKE ${pattern} ESCAPE '\\'`,
+        ),
       )),
     )
     .orderBy(asc(menuItems.position), asc(menuItems.id))

--- a/src/routes/vault/sync.ts
+++ b/src/routes/vault/sync.ts
@@ -41,15 +41,21 @@ export function createVaultSyncRoute(deps: SyncDeps = defaultDeps) {
         const result = deps.migrate(migrateOpts);
 
         let reindexSpawned = false;
+        let reindexError: string | undefined;
         if (reindex && !dryRun && result.filesCopied > 0) {
-          deps.spawnIndexer();
-          reindexSpawned = true;
+          try {
+            deps.spawnIndexer();
+            reindexSpawned = true;
+          } catch (err) {
+            reindexError = err instanceof Error ? err.message : String(err);
+          }
         }
 
         return {
           ok: true,
           dryRun,
           reindex: reindexSpawned,
+          reindexError,
           tenant: tenantId ? { id: tenantId, scope: 'vault_project' } : undefined,
           migrate: result,
         };

--- a/tests/http/menu/id-hardening.test.ts
+++ b/tests/http/menu/id-hardening.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+import { createMenuApp, requestJson } from './_helpers.ts';
+
+describe('menu id hardening', () => {
+  test('rejects non-positive and fractional route ids before DB writes', async () => {
+    const app = createMenuApp();
+    const cases: Array<[string, string, unknown?]> = [
+      ['PUT', '/api/menu/1.5', { label: 'Bad' }],
+      ['DELETE', '/api/menu/0'],
+      ['PATCH', '/api/menu/items/-1', { label: 'Bad' }],
+      ['DELETE', '/api/menu/items/1e3'],
+      ['POST', '/api/menu/reset/1.5'],
+    ];
+
+    for (const [method, path, body] of cases) {
+      const { status, json } = await requestJson<Record<string, string>>(
+        app,
+        method,
+        path,
+        body,
+      );
+      expect({ method, path, status, error: json.error }).toEqual({
+        method,
+        path,
+        status: 400,
+        error: 'invalid id',
+      });
+    }
+  });
+
+  test('rejects invalid reorder ids and parent ids transactionally', async () => {
+    const app = createMenuApp();
+
+    const badId = await requestJson<Record<string, string>>(app, 'POST', '/api/menu/reorder', {
+      items: [{ id: 1.5, position: 1 }],
+    });
+    const badParent = await requestJson<Record<string, string>>(app, 'POST', '/api/menu/reorder', {
+      items: [{ id: 1, parentId: 0, position: 1 }],
+    });
+
+    expect(badId).toMatchObject({ status: 400, json: { error: 'invalid id' } });
+    expect(badParent).toMatchObject({ status: 400, json: { error: 'invalid parentId' } });
+  });
+});

--- a/tests/http/menu/search.test.ts
+++ b/tests/http/menu/search.test.ts
@@ -25,4 +25,18 @@ describe('GET /api/menu/search', () => {
     expect(json).toMatchObject({ q: 'search', total: 2 });
     expect(json.data.map((item) => item.path)).toEqual(['/beta-search', '/alpha']);
   });
+
+  test('treats LIKE wildcard characters as literal search text', async () => {
+    insertMenuRow({ path: '/percent-literal', label: 'Usage 100% Ready', position: 10 });
+    insertMenuRow({ path: '/underscore_literal', label: 'Under_score', position: 20 });
+    insertMenuRow({ path: '/plain', label: 'Plain Menu Row', position: 30 });
+
+    const percent = await requestJson<MenuSearch>(createMenuApp(), 'GET', '/api/menu/search?q=%');
+    const underscore = await requestJson<MenuSearch>(createMenuApp(), 'GET', '/api/menu/search?q=_');
+
+    expect(percent.status).toBe(200);
+    expect(percent.json.data.map((item) => item.path)).toEqual(['/percent-literal']);
+    expect(underscore.status).toBe(200);
+    expect(underscore.json.data.map((item) => item.path)).toEqual(['/underscore_literal']);
+  });
 });

--- a/tests/http/vault/sync.test.ts
+++ b/tests/http/vault/sync.test.ts
@@ -76,6 +76,21 @@ describe('vault sync HTTP route', () => {
     expect(spawnIndexer).toHaveBeenCalledTimes(1);
   });
 
+  test('reindex spawn failures keep completed sync result visible', async () => {
+    const migrate = mock(() => ({ ...emptyMigrate, filesCopied: 1 }));
+    const spawnIndexer = mock(() => {
+      throw new Error('spawn unavailable');
+    });
+    const res = await post(appWith(migrate, spawnIndexer), { reindex: true });
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.reindex).toBe(false);
+    expect(body.reindexError).toBe('spawn unavailable');
+    expect(body.migrate.filesCopied).toBe(1);
+  });
+
   test('matches vault projects to tenant ids before migration filtering', () => {
     expect(projectMatchesTenant('github.com/soul-brews-studio/arra-oracle-v3', 'soul-brews-studio')).toBe(true);
     expect(projectMatchesTenant('tenant-a', 'tenant-a')).toBe(true);


### PR DESCRIPTION
## Summary
- Kept vault sync results successful when optional background reindex spawning fails, returning `reindexError` instead of hiding the completed migrate result.
- Hardened menu write/reset route IDs to require positive safe integers and added transactional reorder validation for invalid item/parent IDs.
- Escaped `%`, `_`, and `\` in `/api/menu/search` so user search text cannot act as a broad LIKE wildcard.

## Validation
- `bunx tsc --noEmit`
- Fresh-DB scoped route tests per file:
  - `tests/http/vault/sync.test.ts`
  - `src/routes/vault/__tests__/sync.test.ts`
  - `tests/http/menu/search.test.ts`
  - `tests/http/menu/id-hardening.test.ts`
  - `tests/http/menu/crud-errors.test.ts`
  - `tests/http/menu/crud.test.ts`
  - `tests/http/menu/menu-admin-delete-invalid-id.test.ts`
  - `tests/http/menu/menu-admin-patch-invalid-id.test.ts`
  - `tests/http/menu/menu-reset-invalid-id.test.ts`
  - `tests/http/menu/reset.test.ts`
  - `tests/http/menu/reorder.test.ts`
- `git diff --check origin/alpha..HEAD`
- Changed files all <=250 lines.