### PR TITLE
test(routes): harden metrics and indexer daemon edges

### DIFF
--- a/src/routes/indexer-daemon/index.ts
+++ b/src/routes/indexer-daemon/index.ts
@@ -22,6 +22,7 @@ import { Elysia, t } from 'elysia';
 import type Database from 'bun:sqlite';
 import { enqueueIndexJob, jobsByStatus } from '../../indexer/jobs.ts';
 import type { WorkerEvent } from '../../indexer/worker.ts';
+import { parseJobsQuery, parseOptionalModelKey, parseRequiredString } from './model.ts';
 
 export interface DaemonApiDeps {
   db: Database;
@@ -75,13 +76,19 @@ export function daemonApiPlugin(deps: DaemonApiDeps) {
           set.status = 503;
           return { error: 'shutting down' };
         }
-        if (!body.doc_id || typeof body.doc_id !== 'string') {
+        const docId = parseRequiredString(body.doc_id, 'doc_id');
+        if (!docId.ok) {
           set.status = 400;
-          return { error: 'doc_id required' };
+          return { error: docId.error };
+        }
+        const modelKey = parseOptionalModelKey(body.model_key, deps.models);
+        if (!modelKey.ok) {
+          set.status = 400;
+          return { error: modelKey.error };
         }
         const jobs = enqueueIndexJob(deps.db, {
-          docId: body.doc_id,
-          modelKey: body.model_key,
+          docId: docId.value,
+          modelKey: modelKey.value,
           models: deps.models,
         });
         return { jobs };
@@ -95,11 +102,13 @@ export function daemonApiPlugin(deps: DaemonApiDeps) {
     )
     .get(
       '/jobs',
-      ({ query }) => {
-        const status = query.status;
-        const modelKey = query.model;
-        const limit = Math.min(parseInt(query.limit || '100', 10) || 100, 1000);
-
+      ({ query, set }) => {
+        const parsed = parseJobsQuery(query, deps.models);
+        if (!parsed.ok) {
+          set.status = 400;
+          return { error: parsed.error };
+        }
+        const { status, modelKey, limit } = parsed.value;
         const where: string[] = [];
         const params: Array<string | number> = [];
         if (status) {
@@ -136,11 +145,13 @@ export function daemonApiPlugin(deps: DaemonApiDeps) {
       set.headers['Connection'] = 'keep-alive';
 
       const encoder = new TextEncoder();
+      let cleanup = () => {};
 
       const stream = new ReadableStream<Uint8Array>({
         start(controller) {
           let aborted = false;
           let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+          let unsubscribe = () => {};
 
           const writeSSE = (event: string, data: string) => {
             if (aborted) return;
@@ -151,11 +162,11 @@ export function daemonApiPlugin(deps: DaemonApiDeps) {
             }
           };
 
-          const unsubscribe = deps.subscribe((ev) => {
+          unsubscribe = deps.subscribe((ev) => {
             writeSSE(ev.type, JSON.stringify(ev));
           });
 
-          const cleanup = () => {
+          cleanup = () => {
             if (aborted) return;
             aborted = true;
             if (heartbeatTimer) clearInterval(heartbeatTimer);
@@ -173,7 +184,7 @@ export function daemonApiPlugin(deps: DaemonApiDeps) {
           }, 15_000);
         },
         cancel() {
-          // Client disconnected — controller already closing.
+          cleanup();
         },
       });
 

--- a/src/routes/indexer-daemon/model.ts
+++ b/src/routes/indexer-daemon/model.ts
@@ -1,0 +1,65 @@
+export const jobStatuses = ['pending', 'claimed', 'done', 'error'] as const;
+export type JobStatus = typeof jobStatuses[number];
+
+export type ModelRegistry = Record<string, { collection: string }>;
+
+export type ParsedJobsQuery = {
+  status?: JobStatus;
+  modelKey?: string;
+  limit: number;
+};
+
+export type ParseResult<T> = { ok: true; value: T } | { ok: false; error: string };
+
+export function trimmedString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function parseRequiredString(value: unknown, label: string): ParseResult<string> {
+  const trimmed = trimmedString(value);
+  return trimmed ? { ok: true, value: trimmed } : { ok: false, error: `${label} required` };
+}
+
+export function parseOptionalModelKey(value: unknown, models: ModelRegistry): ParseResult<string | undefined> {
+  if (value === undefined || value === null) return { ok: true, value: undefined };
+  const modelKey = trimmedString(value);
+  if (!modelKey) return { ok: false, error: 'model_key must not be blank' };
+  if (!models[modelKey]) return { ok: false, error: `Unknown model_key: ${modelKey}` };
+  return { ok: true, value: modelKey };
+}
+
+export function parseJobsQuery(query: { status?: string; model?: string; limit?: string }, models: ModelRegistry): ParseResult<ParsedJobsQuery> {
+  const status = parseOptionalStatus(query.status);
+  if (status.ok === false) return status;
+  const model = parseOptionalModelFilter(query.model, models);
+  if (model.ok === false) return model;
+  const limit = parseLimit(query.limit);
+  if (limit.ok === false) return limit;
+  return { ok: true, value: { status: status.value, modelKey: model.value, limit: limit.value } };
+}
+
+function parseOptionalStatus(value: unknown): ParseResult<JobStatus | undefined> {
+  if (value === undefined || value === null) return { ok: true, value: undefined };
+  const status = trimmedString(value);
+  if (!status) return { ok: false, error: 'status must not be blank' };
+  if (!jobStatuses.includes(status as JobStatus)) return { ok: false, error: 'Invalid status (pending|claimed|done|error)' };
+  return { ok: true, value: status as JobStatus };
+}
+
+function parseOptionalModelFilter(value: unknown, models: ModelRegistry): ParseResult<string | undefined> {
+  if (value === undefined || value === null) return { ok: true, value: undefined };
+  const modelKey = trimmedString(value);
+  if (!modelKey) return { ok: false, error: 'model must not be blank' };
+  if (!models[modelKey]) return { ok: false, error: `Unknown model: ${modelKey}` };
+  return { ok: true, value: modelKey };
+}
+
+function parseLimit(value: unknown): ParseResult<number> {
+  if (value === undefined || value === null || value === '') return { ok: true, value: 100 };
+  if (typeof value !== 'string' || !/^\d+$/.test(value)) return { ok: false, error: 'limit must be an integer between 1 and 1000' };
+  const limit = Number(value);
+  if (!Number.isSafeInteger(limit) || limit < 1) return { ok: false, error: 'limit must be an integer between 1 and 1000' };
+  return { ok: true, value: Math.min(limit, 1000) };
+}

--- a/src/routes/metrics/metrics.ts
+++ b/src/routes/metrics/metrics.ts
@@ -50,18 +50,32 @@ const MetricsResponseSchema = t.Object({
   tenant: t.Optional(t.Object({ id: t.String(), scope: t.Literal('tenant_id') })),
 });
 
+function safeNumber(value: number): number {
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
 function round(value: number): number {
-  return Math.round(value * 1000) / 1000;
+  return Math.round(safeNumber(value) * 1000) / 1000;
 }
 
 function processMemoryUsage(): MemoryUsageSnapshot {
   const usage = process.memoryUsage();
-  return {
+  return sanitizeMemoryUsage({
     rss: usage.rss,
     heapTotal: usage.heapTotal,
     heapUsed: usage.heapUsed,
     external: usage.external,
     arrayBuffers: usage.arrayBuffers ?? 0,
+  });
+}
+
+function sanitizeMemoryUsage(snapshot: MemoryUsageSnapshot): MemoryUsageSnapshot {
+  return {
+    rss: safeNumber(snapshot.rss),
+    heapTotal: safeNumber(snapshot.heapTotal),
+    heapUsed: safeNumber(snapshot.heapUsed),
+    external: safeNumber(snapshot.external),
+    arrayBuffers: safeNumber(snapshot.arrayBuffers),
   };
 }
 
@@ -70,6 +84,14 @@ type RequestStart = { startedAt: number; tenantId?: string };
 
 function counter(): MetricsCounter {
   return { requestCount: 0, totalResponseMs: 0, activeConnections: 0 };
+}
+
+function safeMemoryUsage(readMemoryUsage: () => MemoryUsageSnapshot): MemoryUsageSnapshot {
+  try {
+    return sanitizeMemoryUsage(readMemoryUsage());
+  } catch {
+    return { rss: 0, heapTotal: 0, heapUsed: 0, external: 0, arrayBuffers: 0 };
+  }
 }
 
 function tenantCounter(counters: Map<string, MetricsCounter>, tenantId: string): MetricsCounter {
@@ -105,12 +127,13 @@ export function createMetricsTracker(options: MetricsTrackerOptions = {}): Metri
     avgResponseMs: metrics.requestCount === 0 ? 0 : round(metrics.totalResponseMs / metrics.requestCount),
     activeConnections: metrics.activeConnections,
     lastRestart,
-    memoryUsage: memoryUsage(),
+    memoryUsage: safeMemoryUsage(memoryUsage),
     tenant: tenantId ? { id: tenantId, scope: 'tenant_id' } : undefined,
   });
 
   return {
     begin(request) {
+      if (starts.has(request)) return;
       const tenantId = currentTenantId();
       starts.set(request, { startedAt: nowMs(), tenantId });
       beginCounter(globalCounter);

--- a/tests/http/indexer-daemon/hardening.test.ts
+++ b/tests/http/indexer-daemon/hardening.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import Database from 'bun:sqlite';
+import { Elysia } from 'elysia';
+import { daemonApiPlugin } from '../../../src/routes/indexer-daemon/index.ts';
+import type { DaemonApiDeps } from '../../../src/routes/indexer-daemon/index.ts';
+import type { WorkerEvent } from '../../../src/indexer/worker.ts';
+
+const MODELS = {
+  'bge-m3': { collection: 'oracle_knowledge_bge_m3' },
+  qwen3: { collection: 'oracle_knowledge_qwen3' },
+};
+
+const MIGRATION_SQL = `
+CREATE TABLE indexing_jobs (
+  id TEXT PRIMARY KEY,
+  doc_id TEXT NOT NULL,
+  model_key TEXT NOT NULL,
+  collection TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  attempts INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')*1000),
+  claimed_at INTEGER,
+  finished_at INTEGER,
+  error TEXT
+);`;
+
+let openDbs: Database[] = [];
+
+afterEach(() => {
+  for (const db of openDbs.splice(0)) db.close();
+});
+
+function deps(overrides: Partial<DaemonApiDeps> = {}) {
+  const db = new Database(':memory:');
+  db.exec(MIGRATION_SQL);
+  openDbs.push(db);
+  return {
+    db,
+    models: MODELS,
+    isShuttingDown: () => false,
+    requestShutdown: () => undefined,
+    subscribe: () => () => undefined,
+    ...overrides,
+  } satisfies DaemonApiDeps;
+}
+
+function app(deps: DaemonApiDeps) {
+  return new Elysia().use(daemonApiPlugin(deps));
+}
+
+function jsonPost(body: unknown) {
+  return { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) };
+}
+
+describe('indexer daemon input hardening', () => {
+  test('trims doc_id/model_key before enqueuing', async () => {
+    const wired = deps();
+    const res = await app(wired).handle(new Request('http://local/index', jsonPost({ doc_id: ' doc-a ', model_key: ' bge-m3 ' })));
+    const body = await res.json() as { jobs: Array<{ docId: string; modelKey: string }> };
+    const row = wired.db.query<{ doc_id: string; model_key: string }, []>('SELECT doc_id, model_key FROM indexing_jobs').get();
+
+    expect(res.status).toBe(200);
+    expect(body.jobs).toEqual([{ id: expect.any(String), docId: 'doc-a', modelKey: 'bge-m3', collection: MODELS['bge-m3'].collection }]);
+    expect(row).toEqual({ doc_id: 'doc-a', model_key: 'bge-m3' });
+  });
+
+  test('rejects blank doc ids and invalid model keys', async () => {
+    const route = app(deps());
+    expect((await route.handle(new Request('http://local/index', jsonPost({ doc_id: '   ' })))).status).toBe(400);
+    expect((await route.handle(new Request('http://local/index', jsonPost({ doc_id: 'doc', model_key: '   ' })))).status).toBe(400);
+    expect((await route.handle(new Request('http://local/index', jsonPost({ doc_id: 'doc', model_key: 'missing' })))).status).toBe(400);
+  });
+
+  test('validates job filters and safe limits', async () => {
+    const route = app(deps());
+    expect((await route.handle(new Request('http://local/jobs?status=bogus'))).status).toBe(400);
+    expect((await route.handle(new Request('http://local/jobs?model=bogus'))).status).toBe(400);
+    expect((await route.handle(new Request('http://local/jobs?limit=-1'))).status).toBe(400);
+    expect((await route.handle(new Request('http://local/jobs?limit=abc'))).status).toBe(400);
+  });
+
+  test('trims valid job filters', async () => {
+    const wired = deps();
+    await app(wired).handle(new Request('http://local/index', jsonPost({ doc_id: 'doc-a', model_key: 'bge-m3' })));
+    const res = await app(wired).handle(new Request('http://local/jobs?status=%20pending%20&model=%20bge-m3%20&limit=1'));
+    const body = await res.json() as { count: number; jobs: Array<{ doc_id: string }> };
+
+    expect(res.status).toBe(200);
+    expect(body.count).toBe(1);
+    expect(body.jobs[0].doc_id).toBe('doc-a');
+  });
+});
+
+test('indexer daemon event stream unsubscribes when the client cancels', async () => {
+  let unsubscribed = 0;
+  const wired = deps({ subscribe: (_cb: (ev: WorkerEvent) => void) => () => { unsubscribed += 1; } });
+  const res = await app(wired).handle(new Request('http://local/events'));
+
+  await res.body?.cancel();
+  expect(res.status).toBe(200);
+  expect(unsubscribed).toBe(1);
+});

--- a/tests/http/metrics/hardening.test.ts
+++ b/tests/http/metrics/hardening.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from 'bun:test';
+import {
+  createMetricsRoutes,
+  createMetricsTracker,
+} from '../../../src/routes/metrics/index.ts';
+
+test('metrics tracker ignores duplicate begin calls and clamps backward clocks', () => {
+  let now = 1_000;
+  const tracker = createMetricsTracker({ startedAtMs: 2_000, nowMs: () => now });
+  const request = new Request('http://local/api/work');
+
+  tracker.begin(request);
+  tracker.begin(request);
+  now = 900;
+  tracker.end(request);
+  tracker.end(request);
+
+  expect(tracker.snapshot()).toMatchObject({
+    uptime: 0,
+    requestCount: 1,
+    avgResponseMs: 0,
+    activeConnections: 0,
+  });
+});
+
+test('metrics route returns sanitized memory values when collection fails', async () => {
+  const tracker = createMetricsTracker({
+    startedAtMs: 0,
+    nowMs: () => 1_000,
+    memoryUsage: () => { throw new Error('memory unavailable'); },
+  });
+  const res = await createMetricsRoutes(tracker).handle(new Request('http://local/api/metrics'));
+  const body = await res.json() as Record<string, unknown>;
+
+  expect(res.status).toBe(200);
+  expect(body.memoryUsage).toEqual({ rss: 0, heapTotal: 0, heapUsed: 0, external: 0, arrayBuffers: 0 });
+});


### PR DESCRIPTION
## Summary
- harden metrics snapshots against duplicate lifecycle starts, backward clocks, and memory collection failures
- validate and normalize indexer-daemon doc/model/job filter inputs, including safe job limits
- clean up indexer-daemon event stream subscriptions on client cancellation
- add focused metrics and indexer-daemon edge coverage

## Validation
- bunx tsc --noEmit
- bun test tests/http/metrics/ tests/http/indexer-daemon/ src/indexer/__tests__/api.test.ts
- ORACLE_DATA_DIR=$(mktemp -d) ORACLE_DB_PATH=$ORACLE_DATA_DIR/oracle.db bun test tests/http/errors/route-cluster-error-paths.test.ts
- git diff --check origin/alpha...HEAD
- changed files <=250 lines

Refs hardening sweep