### PR TITLE
fix(routes): harden learn and watcher edges

### DIFF
--- a/src/routes/learn/content.ts
+++ b/src/routes/learn/content.ts
@@ -1,0 +1,49 @@
+export type LearnConceptInput = string[] | string | undefined;
+
+function cleanConcepts(values: unknown[]): string[] {
+  return values.map(String).map((c) => c.trim()).filter(Boolean);
+}
+
+export function conceptsFrom(value: LearnConceptInput): string[] {
+  if (Array.isArray(value)) return cleanConcepts(value);
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      if (Array.isArray(parsed)) return cleanConcepts(parsed);
+    } catch {}
+    return value.split(',').map((c) => c.trim()).filter(Boolean);
+  }
+  return [];
+}
+
+export function slugFor(pattern: string): string {
+  const slug = pattern
+    .slice(0, 50)
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  return slug || 'learning';
+}
+
+export function learningContent(pattern: string, concepts: string[], source?: string): string {
+  const title = pattern.split('\n')[0].slice(0, 80);
+  const today = new Date().toISOString().slice(0, 10);
+  return [
+    '---',
+    `title: ${title}`,
+    concepts.length ? `tags: [${concepts.join(', ')}]` : 'tags: []',
+    `created: ${today}`,
+    `source: ${source || 'Oracle Learn'}`,
+    '---',
+    '',
+    `# ${title}`,
+    '',
+    pattern,
+    '',
+    '---',
+    '*Added via Oracle Learn*',
+    '',
+  ].join('\n');
+}

--- a/src/routes/learn/crud.ts
+++ b/src/routes/learn/crud.ts
@@ -3,16 +3,22 @@ import { and, eq } from 'drizzle-orm';
 import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
 import fs from 'fs';
 import path from 'path';
-import { REPO_ROOT } from '../../config.ts';
 import { db, learnLog, oracleDocuments } from '../../db/index.ts';
 import { currentTenantId, tenantIdForWrite } from '../../middleware/tenant.ts';
+import { conceptsFrom, learningContent, slugFor } from './content.ts';
+import {
+  INVALID_LEARNING_ID,
+  INVALID_LEARNING_SOURCE_FILE,
+  learningSourcePath,
+  safeLearningId,
+  safeLearningSourceFile,
+} from './safety.ts';
 type LearnDoc = typeof oracleDocuments.$inferSelect;
 const oracleFts = sqliteTable('oracle_fts', {
   id: text('id'),
   content: text('content'),
   concepts: text('concepts'),
 });
-const repoRoot = () => process.env.ORACLE_REPO_ROOT || REPO_ROOT;
 type LearnCreateBody = {
   pattern?: string;
   concepts?: string[] | string;
@@ -45,52 +51,9 @@ const UpdateBody = t.Object({
   supersededBy: t.Optional(t.Nullable(t.String())),
   supersededReason: t.Optional(t.Nullable(t.String())),
 });
-function cleanConcepts(values: unknown[]): string[] {
-  return values.map(String).map((c) => c.trim()).filter(Boolean);
-}
-function conceptsFrom(value: LearnCreateBody['concepts']): string[] {
-  if (Array.isArray(value)) return cleanConcepts(value);
-  if (typeof value === 'string') {
-    try {
-      const parsed = JSON.parse(value);
-      if (Array.isArray(parsed)) return cleanConcepts(parsed);
-    } catch {}
-    return value.split(',').map((c) => c.trim()).filter(Boolean);
-  }
-  return [];
-}
-function slugFor(pattern: string): string {
-  const slug = pattern
-    .slice(0, 50)
-    .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, '')
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '');
-  return slug || 'learning';
-}
-function learningContent(pattern: string, concepts: string[], source?: string): string {
-  const title = pattern.split('\n')[0].slice(0, 80);
-  const today = new Date().toISOString().slice(0, 10);
-  return [
-    '---',
-    `title: ${title}`,
-    concepts.length ? `tags: [${concepts.join(', ')}]` : 'tags: []',
-    `created: ${today}`,
-    `source: ${source || 'Oracle Learn'}`,
-    '---',
-    '',
-    `# ${title}`,
-    '',
-    pattern,
-    '',
-    '---',
-    '*Added via Oracle Learn*',
-    '',
-  ].join('\n');
-}
 function writeLearningFile(sourceFile: string, content: string): void {
-  const filePath = path.join(repoRoot(), sourceFile);
+  const filePath = learningSourcePath(sourceFile);
+  if (!filePath) throw new Error(INVALID_LEARNING_SOURCE_FILE);
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, content, 'utf-8');
 }
@@ -124,7 +87,8 @@ function nextIdentity(pattern: string, requestedId?: string, requestedSourceFile
       .from(oracleDocuments)
       .where(where)
       .get();
-    if (!existing && !fs.existsSync(path.join(repoRoot(), sourceFile))) {
+    const filePath = learningSourcePath(sourceFile);
+    if (!existing && filePath && !fs.existsSync(filePath)) {
       return {
         id,
         sourceFile,
@@ -146,9 +110,12 @@ function responseRow(row: LearnDoc) {
 function createLearning(body: LearnCreateBody) {
   const pattern = body.pattern?.trim();
   if (!pattern) return { status: 400, body: { error: 'Missing required field: pattern' } };
+  if (body.id !== undefined && !safeLearningId(body.id)) return { status: 400, body: { error: INVALID_LEARNING_ID } };
+  const requestedSourceFile = body.sourceFile === undefined ? undefined : safeLearningSourceFile(body.sourceFile);
+  if (requestedSourceFile === null) return { status: 400, body: { error: INVALID_LEARNING_SOURCE_FILE } };
   const now = Date.now();
   const concepts = conceptsFrom(body.concepts);
-  const identity = nextIdentity(pattern, body.id, body.sourceFile);
+  const identity = nextIdentity(pattern, body.id, requestedSourceFile);
   if (rowById(identity.id)) return { status: 409, body: { error: 'Learning already exists' } };
   const content = learningContent(pattern, concepts, body.source);
   writeLearningFile(identity.sourceFile, content);
@@ -183,7 +150,11 @@ function updateLearning(id: string, body: LearnUpdateBody) {
   if (!existing) return { status: 404, body: { error: 'Learning not found' } };
   const now = Date.now();
   const set: Partial<LearnDoc> = { updatedAt: now, indexedAt: now };
-  if (body.sourceFile !== undefined) set.sourceFile = body.sourceFile;
+  if (body.sourceFile !== undefined) {
+    const sourceFile = safeLearningSourceFile(body.sourceFile);
+    if (!sourceFile) return { status: 400, body: { error: INVALID_LEARNING_SOURCE_FILE } };
+    set.sourceFile = sourceFile;
+  }
   if (body.concepts !== undefined) set.concepts = JSON.stringify(conceptsFrom(body.concepts));
   if (body.origin !== undefined) set.origin = body.origin;
   if (body.project !== undefined) set.project = body.project?.toLowerCase() ?? null;

--- a/src/routes/learn/safety.ts
+++ b/src/routes/learn/safety.ts
@@ -1,0 +1,28 @@
+import path from 'path';
+import { REPO_ROOT } from '../../config.ts';
+
+const repoRoot = () => process.env.ORACLE_REPO_ROOT || REPO_ROOT;
+
+export const INVALID_LEARNING_ID = 'Invalid learning id';
+export const INVALID_LEARNING_SOURCE_FILE = 'Invalid learning sourceFile';
+
+export function safeLearningId(id: string): boolean {
+  return /^[A-Za-z0-9._:-]{1,160}$/.test(id);
+}
+
+export function safeLearningSourceFile(sourceFile: string): string | null {
+  const trimmed = sourceFile.trim();
+  if (!trimmed || trimmed.includes('\0')) return null;
+  const normalized = path.posix.normalize(trimmed.replaceAll('\\', '/'));
+  if (path.posix.isAbsolute(normalized) || normalized === '.' || normalized === '..') return null;
+  if (normalized.startsWith('../')) return null;
+  return normalized;
+}
+
+export function learningSourcePath(sourceFile: string): string | null {
+  const safeSourceFile = safeLearningSourceFile(sourceFile);
+  if (!safeSourceFile) return null;
+  const root = path.resolve(repoRoot());
+  const filePath = path.resolve(root, safeSourceFile);
+  return filePath.startsWith(root + path.sep) ? filePath : null;
+}

--- a/src/routes/watcher/index.ts
+++ b/src/routes/watcher/index.ts
@@ -1,15 +1,30 @@
 import { Elysia } from 'elysia';
 import { fileWatcherService, type FileWatcherService } from '../../services/file-watcher.ts';
 
+type StatusSetter = { status?: number | string };
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error || 'Watcher operation failed');
+}
+
+function safeWatcherCall<T>(set: StatusSetter, action: () => T): T | { error: string } {
+  try {
+    return action();
+  } catch (error) {
+    set.status = 500;
+    return { error: errorMessage(error) };
+  }
+}
+
 export function createWatcherRoutes(service: FileWatcherService = fileWatcherService) {
   return new Elysia({ prefix: '/api' })
-    .get('/watcher/status', () => service.status(), {
+    .get('/watcher/status', ({ set }) => safeWatcherCall(set, () => service.status()), {
       detail: { tags: ['watcher'], summary: 'File watcher daemon status' },
     })
-    .post('/watcher/start', () => service.start(), {
+    .post('/watcher/start', ({ set }) => safeWatcherCall(set, () => service.start()), {
       detail: { tags: ['watcher'], summary: 'Start the ψ/learn file watcher daemon' },
     })
-    .post('/watcher/stop', () => service.stop(), {
+    .post('/watcher/stop', ({ set }) => safeWatcherCall(set, () => service.stop()), {
       detail: { tags: ['watcher'], summary: 'Stop the ψ/learn file watcher daemon' },
     });
 }

--- a/tests/http/learn/crud-edge.test.ts
+++ b/tests/http/learn/crud-edge.test.ts
@@ -1,14 +1,12 @@
 import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
 import { Elysia } from 'elysia';
 import { eq } from 'drizzle-orm';
-import { mkdirSync, rmSync } from 'fs';
+import { existsSync, mkdirSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
 const savedDataDir = process.env.ORACLE_DATA_DIR;
 const savedDbPath = process.env.ORACLE_DB_PATH;
-const restoreDbPath = savedDbPath
-  ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
 const savedRepoRoot = process.env.ORACLE_REPO_ROOT;
 const root = join(tmpdir(), `arra-learn-edge-${Date.now()}-${Math.random().toString(16).slice(2)}`);
 const dbPath = join(root, 'oracle.db');
@@ -45,10 +43,10 @@ beforeEach(() => {
 });
 
 afterAll(() => {
+  dbMod.resetDefaultDatabaseForTests(':memory:');
   restoreEnv('ORACLE_DATA_DIR', savedDataDir);
   restoreEnv('ORACLE_DB_PATH', savedDbPath);
   restoreEnv('ORACLE_REPO_ROOT', savedRepoRoot);
-  dbMod.resetDefaultDatabaseForTests(restoreDbPath);
   rmSync(root, { recursive: true, force: true });
 });
 
@@ -87,6 +85,39 @@ describe('POST/DELETE /api/learn edge cases', () => {
     const missingDelete = await call('DELETE', '/api/learn/learning_missing_edge');
     expect(missingDelete.status).toBe(404);
     expect(missingDelete.json.error).toBe('Learning not found');
+  });
+
+  test('rejects unsafe ids and sourceFile traversal without writing outside repo', async () => {
+    const badId = await call('POST', '/api/learn', {
+      id: '../escape',
+      pattern: 'Unsafe id should not become a file path',
+    });
+    expect(badId.status).toBe(400);
+    expect(badId.json.error).toBe('Invalid learning id');
+
+    const traversal = await call('POST', '/api/learn', {
+      pattern: 'Unsafe source paths should be rejected',
+      sourceFile: '../outside.md',
+    });
+    expect(traversal.status).toBe(400);
+    expect(traversal.json.error).toBe('Invalid learning sourceFile');
+    expect(existsSync(join(root, 'outside.md'))).toBe(false);
+
+    const created = await call('POST', '/api/learn', {
+      id: 'learning_safe_source',
+      pattern: 'Safe learning source',
+      sourceFile: 'ψ/memory/learnings/safe-source.md',
+    });
+    expect(created.status).toBe(200);
+
+    const update = await call('PUT', '/api/learn/learning_safe_source', {
+      sourceFile: '../../outside.md',
+    });
+    expect(update.status).toBe(400);
+    expect(update.json.error).toBe('Invalid learning sourceFile');
+
+    const read = await call('GET', '/api/learn/learning_safe_source');
+    expect(read.json.sourceFile).toBe('ψ/memory/learnings/safe-source.md');
   });
 });
 

--- a/tests/http/watcher/error-paths.test.ts
+++ b/tests/http/watcher/error-paths.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createWatcherRoutes } from '../../../src/routes/watcher/index.ts';
+
+function throwingService(message: string) {
+  const fail = () => { throw new Error(message); };
+  return { status: fail, start: fail, stop: fail };
+}
+
+async function call(pathname: string, method = 'GET') {
+  const app = new Elysia().use(createWatcherRoutes(throwingService(`${method} boom`) as any));
+  const res = await app.handle(new Request(`http://local${pathname}`, { method }));
+  return { status: res.status, body: await res.json() as { error: string } };
+}
+
+describe('watcher HTTP error paths', () => {
+  test('returns structured 500s when watcher status throws', async () => {
+    const res = await call('/api/watcher/status');
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('GET boom');
+  });
+
+  test('returns structured 500s when watcher start throws', async () => {
+    const res = await call('/api/watcher/start', 'POST');
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('POST boom');
+  });
+
+  test('returns structured 500s when watcher stop throws', async () => {
+    const res = await call('/api/watcher/stop', 'POST');
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('POST boom');
+  });
+});


### PR DESCRIPTION
## Summary
- validate learn ids and sourceFile paths before file writes/updates
- keep learn CRUD under file-size limit by extracting content/path helpers
- return structured 500 responses for watcher service exceptions
- add learn traversal and watcher error-path coverage

## Verification
- bunx tsc --noEmit
- ORACLE_DATA_DIR=$(mktemp -d /tmp/arra-scoped.XXXXXX) ORACLE_DB_PATH=$ORACLE_DATA_DIR/oracle.db bun test tests/http/learn/ tests/http/watcher/
- git diff --check
- wc -l changed files <=250