### PR TITLE
test(routes): harden canvas and export edges

### DIFF
--- a/src/routes/canvas/index.ts
+++ b/src/routes/canvas/index.ts
@@ -1,8 +1,22 @@
 import { Elysia, t } from 'elysia';
 import { canvasPluginEntry, canvasRegistry, parseCanvasKind } from '../../canvas/registry.ts';
 
+function resolveKind(value: unknown): ReturnType<typeof parseCanvasKind> | 'invalid' {
+  if (typeof value !== 'string' || !value.trim()) return undefined;
+  return parseCanvasKind(value) ?? 'invalid';
+}
+
+function registryForKind(value: unknown, set: { status?: unknown }) {
+  const kind = resolveKind(value);
+  if (kind === 'invalid') {
+    set.status = 400;
+    return { error: 'Invalid canvas plugin kind', kind: value, allowed: ['three', 'react'] };
+  }
+  return canvasRegistry(kind);
+}
+
 export const canvasRoutes = new Elysia({ name: 'canvas-routes' })
-  .get('/api/canvas/plugins', ({ query }) => canvasRegistry(parseCanvasKind(query.kind)), {
+  .get('/api/canvas/plugins', ({ query, set }) => registryForKind(query.kind, set), {
     query: t.Object({ kind: t.Optional(t.String()) }),
     detail: { tags: ['canvas'], summary: 'List canvas plugin registry entries' },
   })
@@ -17,7 +31,7 @@ export const canvasRoutes = new Elysia({ name: 'canvas-routes' })
     params: t.Object({ id: t.String({ minLength: 1 }) }),
     detail: { tags: ['canvas'], summary: 'Get one canvas plugin registry entry' },
   })
-  .get('/api/canvas/registry', ({ query }) => canvasRegistry(parseCanvasKind(query.kind)), {
+  .get('/api/canvas/registry', ({ query, set }) => registryForKind(query.kind, set), {
     query: t.Object({ kind: t.Optional(t.String()) }),
     detail: { tags: ['canvas'], summary: 'Canvas standalone registry manifest' },
   });

--- a/src/routes/export/import.ts
+++ b/src/routes/export/import.ts
@@ -21,6 +21,11 @@ interface ExportImportDeps {
 
 const DEFAULT_COLLECTION = 'bge-m3';
 
+function normalizeChunkSize(value: number | undefined): number {
+  if (!Number.isFinite(value) || !value || value < 1) return 500;
+  return Math.max(1, Math.trunc(value));
+}
+
 async function readPayload(request: Request): Promise<ImportPayload> {
   const url = new URL(request.url);
   const type = request.headers.get('content-type') ?? '';
@@ -59,7 +64,7 @@ async function addInChunks(store: ImportStore, docs: VectorDocument[], chunkSize
 export function createExportImportRoutes(deps: ExportImportDeps = {}) {
   const getModels = deps.getModels ?? getEmbeddingModels;
   const getStore = deps.getStore ?? getVectorStoreByModel;
-  const chunkSize = deps.chunkSize ?? 500;
+  const chunkSize = normalizeChunkSize(deps.chunkSize);
 
   return new Elysia().post('/export/import', async ({ request, set }) => {
     let payload: ImportPayload;

--- a/tests/canvas/phase2.test.ts
+++ b/tests/canvas/phase2.test.ts
@@ -55,3 +55,13 @@ describe('canvas phase 2 HTTP and standalone surfaces', () => {
     expect(JSON.parse(lines[0])).toMatchObject({ port: 47780, host: 'canvas.buildwithoracle.com' });
   });
 });
+
+test('rejects invalid canvas plugin kind filters', async () => {
+  const app = new Elysia().use(canvasRoutes);
+  const plugins = await app.handle(new Request('http://local/api/canvas/plugins?kind=video'));
+  const registry = await app.handle(new Request('http://local/api/canvas/registry?kind=video'));
+
+  expect(plugins.status).toBe(400);
+  expect(registry.status).toBe(400);
+  expect(await plugins.json()).toEqual({ error: 'Invalid canvas plugin kind', kind: 'video', allowed: ['three', 'react'] });
+});

--- a/tests/http/export/import.test.ts
+++ b/tests/http/export/import.test.ts
@@ -160,3 +160,26 @@ test('POST /api/v1/export/import rejects unknown vector collections', async () =
   expect(batches).toEqual([]);
   expect(store.addDocuments).not.toHaveBeenCalled();
 });
+
+test('POST /api/v1/export/import normalizes invalid chunk sizes', async () => {
+  const { store, batches } = createStore();
+  const app = new Elysia({ prefix: '/api' }).use(createExportImportRoutes({
+    getModels: () => ({ 'bge-m3': {} }),
+    getStore: () => store,
+    chunkSize: 0,
+  }));
+  const fetcher = createApiVersionedFetch((request) => app.handle(request));
+  const rows = [
+    { id: 'chunk-1', document: 'alpha' },
+    { id: 'chunk-2', document: 'bravo' },
+  ];
+
+  const res = await fetcher(new Request('http://local/api/v1/export/import', {
+    method: 'POST',
+    body: multipart(new Blob([JSON.stringify(rows)], { type: 'application/json' }), 'export.json'),
+  }));
+
+  expect(res.status).toBe(200);
+  expect(await res.json()).toMatchObject({ success: true, imported: 2 });
+  expect(batches.map((batch) => batch.map((doc) => doc.id))).toEqual([['chunk-1', 'chunk-2']]);
+});


### PR DESCRIPTION
## Summary
- reject invalid canvas plugin kind filters with 400 instead of widening to all plugins
- normalize export import chunk sizes to avoid invalid dependency values causing a non-terminating import loop
- add scoped regressions for canvas kind validation and export import chunk-size hardening

## Tests
- ORACLE_DATA_DIR=$tmpdir ORACLE_DB_PATH=$tmpdir/oracle.db bun test tests/canvas tests/http/canvas tests/http/export
- bunx tsc --noEmit

Changed files are all <=250 lines.

Commit: a86a684f