### PR TITLE
fix: harden lifecycle and gateway error paths

### DIFF
--- a/src/gateway/__tests__/error-paths.test.ts
+++ b/src/gateway/__tests__/error-paths.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { gatewayPlugin } from '../index.ts';
+import { registerHook } from '../hooks.ts';
+
+const REQUEST_HOOK = 'test-hardening-request-throws';
+const ERROR_HOOK = 'test-hardening-error-throws';
+
+registerHook({
+  name: REQUEST_HOOK,
+  phase: 'onRequest',
+  handler: () => { throw new Error('request hook failed'); },
+});
+
+registerHook({
+  name: ERROR_HOOK,
+  phase: 'onError',
+  handler: () => { throw new Error('error hook failed'); },
+});
+
+describe('gateway plugin error paths', () => {
+  test('returns structured JSON when the configured error hook also throws', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-gateway-error-'));
+    const savedHotReload = process.env.ORACLE_GATEWAY_HOT_RELOAD;
+    process.env.ORACLE_GATEWAY_HOT_RELOAD = '0';
+    try {
+      fs.writeFileSync(path.join(dir, 'oracle-gateway.json'), JSON.stringify({
+        services: { upstream: { url: 'http://127.0.0.1:9', timeout: 10 } },
+        routes: [{ match: '/api/boom', service: 'upstream', fallback: 'error' }],
+        hooks: { onRequest: [REQUEST_HOOK], onError: [ERROR_HOOK] },
+      }));
+
+      const app = new Elysia().use(gatewayPlugin(dir));
+      const res = await app.handle(new Request('http://localhost/api/boom'));
+
+      expect(res.status).toBe(502);
+      expect(res.headers.get('content-type')).toContain('application/json');
+      expect(await res.json()).toEqual({
+        error: 'Gateway error handler failed',
+        gateway: true,
+      });
+    } finally {
+      restoreHotReload(savedHotReload);
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+function restoreHotReload(value: string | undefined) {
+  if (value === undefined) delete process.env.ORACLE_GATEWAY_HOT_RELOAD;
+  else process.env.ORACLE_GATEWAY_HOT_RELOAD = value;
+}

--- a/src/gateway/__tests__/health.test.ts
+++ b/src/gateway/__tests__/health.test.ts
@@ -93,4 +93,18 @@ describe('HealthRegistry', () => {
     expect(Object.keys(registry.getAllStatus())).toHaveLength(0);
     registry.stop();
   });
+
+  test('restart clears stale health state and accepts invalid intervals safely', async () => {
+    registry = new HealthRegistry();
+    registry.start(
+      { old: { url: 'http://localhost:1', healthCheck: 'http://localhost:1/h' } },
+      0,
+    );
+    expect(Object.keys(registry.getAllStatus())).toContain('old');
+
+    registry.start({ local: { url: 'http://localhost:3000' } }, -1);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(registry.getAllStatus()).toEqual({});
+    expect(registry.isUp('old')).toBe(true);
+  });
 });

--- a/src/gateway/health.ts
+++ b/src/gateway/health.ts
@@ -18,15 +18,26 @@ export interface ServiceHealth {
 const DEFAULT_INTERVAL_MS = 30_000;
 const CHECK_TIMEOUT_MS = 5_000;
 
+function safeIntervalMs(value: number): number {
+  return Number.isFinite(value) && value > 0 ? value : DEFAULT_INTERVAL_MS;
+}
+
 export class HealthRegistry {
   private health = new Map<string, ServiceHealth>();
   private interval: Timer | null = null;
+  private generation = 0;
 
   /**
    * Start polling services that have a healthCheck URL.
    * Services without healthCheck are always assumed "up".
    */
   start(services: Record<string, ServiceConfig>, intervalMs = DEFAULT_INTERVAL_MS): void {
+    this.stop();
+    this.health.clear();
+    this.generation += 1;
+    const generation = this.generation;
+    intervalMs = safeIntervalMs(intervalMs);
+
     // Seed initial state
     for (const [name, svc] of Object.entries(services)) {
       if (svc.healthCheck) {
@@ -37,8 +48,8 @@ export class HealthRegistry {
     if (this.health.size === 0) return; // nothing to poll
 
     // Fire first check immediately, then repeat on interval
-    this.checkAll(services);
-    this.interval = setInterval(() => this.checkAll(services), intervalMs);
+    this.checkAll(services, generation);
+    this.interval = setInterval(() => this.checkAll(services, generation), intervalMs);
     // Don't prevent process exit
     if (typeof this.interval === 'object' && 'unref' in this.interval) {
       this.interval.unref();
@@ -50,6 +61,7 @@ export class HealthRegistry {
   }
 
   stop(): void {
+    this.generation += 1;
     if (this.interval) {
       clearInterval(this.interval);
       this.interval = null;
@@ -71,15 +83,15 @@ export class HealthRegistry {
     return h.status !== 'down';
   }
 
-  private async checkAll(services: Record<string, ServiceConfig>): Promise<void> {
+  private async checkAll(services: Record<string, ServiceConfig>, generation: number): Promise<void> {
     const checks = Object.entries(services)
       .filter(([, svc]) => svc.healthCheck)
-      .map(([name, svc]) => this.checkOne(name, svc.healthCheck!));
+      .map(([name, svc]) => this.checkOne(name, svc.healthCheck!, generation));
 
     await Promise.allSettled(checks);
   }
 
-  private async checkOne(name: string, url: string): Promise<void> {
+  private async checkOne(name: string, url: string, generation: number): Promise<void> {
     const start = Date.now();
     try {
       const res = await fetch(url, {
@@ -89,8 +101,10 @@ export class HealthRegistry {
       const responseTime = Date.now() - start;
 
       if (res.ok) {
+        if (generation !== this.generation) return;
         this.health.set(name, { status: 'up', lastCheck: start, responseTime });
       } else {
+        if (generation !== this.generation) return;
         this.health.set(name, {
           status: 'down',
           lastCheck: start,
@@ -99,6 +113,7 @@ export class HealthRegistry {
         });
       }
     } catch (e) {
+      if (generation !== this.generation) return;
       this.health.set(name, {
         status: 'down',
         lastCheck: start,

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -82,6 +82,23 @@ function serviceUnavailableResponse(service: string): Response {
   });
 }
 
+function gatewayErrorHandlerFailure(error: unknown): Response {
+  const message = error instanceof Error ? error.message : String(error);
+  console.warn(`[Gateway] error hook failed: ${message}`);
+  return new Response(JSON.stringify({ error: 'Gateway error handler failed', gateway: true }), {
+    status: 502,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+async function runErrorHooks(state: GatewayState, ctx: GatewayContext): Promise<Response | void> {
+  try {
+    return await runHooks(state.hooks.onError, ctx);
+  } catch (error) {
+    return gatewayErrorHandlerFailure(error);
+  }
+}
+
 export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
   const initial = loadGatewayConfig(dataDir, vectorUrl);
 
@@ -179,7 +196,7 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
         if (early) return early;
       } catch (err) {
         ctx.error = err instanceof Error ? err : new Error(String(err));
-        const errResp = await runHooks(state.hooks.onError, ctx);
+        const errResp = await runErrorHooks(state, ctx);
         if (errResp) return errResp;
         if (ctx.meta.fallback_to_local) return; // fall through to local Elysia
         throw err;
@@ -191,7 +208,7 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
         response = await proxyToService(request, service);
       } catch (err) {
         ctx.error = err instanceof Error ? err : new Error(String(err));
-        const errResp = await runHooks(state.hooks.onError, ctx);
+        const errResp = await runErrorHooks(state, ctx);
         if (errResp) return errResp;
         if (ctx.meta.fallback_to_local) return; // fall through to local Elysia
         throw err;
@@ -213,7 +230,7 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
         if (override) return override;
       } catch (err) {
         ctx.error = err instanceof Error ? err : new Error(String(err));
-        const errResp = await runHooks(state.hooks.onError, ctx);
+        const errResp = await runErrorHooks(state, ctx);
         if (errResp) return errResp;
         if (ctx.meta.fallback_to_local) return;
         throw err;

--- a/src/lifecycle/self-test.ts
+++ b/src/lifecycle/self-test.ts
@@ -74,6 +74,7 @@ async function assertDbPing(dbPing: StartupSelfTestDependencies['dbPing']): Prom
 
 async function assertHealthEndpoint(healthFetch: StartupSelfTestDependencies['healthFetch']): Promise<void> {
   const response = await healthFetch();
+  if (!(response instanceof Response)) throw new Error('health endpoint returned an invalid response');
   if (!response.ok) throw new Error(`/api/health responded ${response.status}`);
 }
 

--- a/src/lifecycle/shutdown.ts
+++ b/src/lifecycle/shutdown.ts
@@ -27,6 +27,10 @@ function envMs(name: string, fallback: number): number {
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
 }
 
+function safeMs(value: number): number {
+  return Number.isFinite(value) && value >= 0 ? value : 0;
+}
+
 export function isDraining(): boolean {
   return draining;
 }
@@ -45,6 +49,8 @@ export async function trackRequest<T>(handler: () => T | Promise<T>): Promise<T>
 }
 
 export async function waitForActiveRequests(timeoutMs = 10_000, minDrainMs = 250): Promise<boolean> {
+  timeoutMs = safeMs(timeoutMs);
+  minDrainMs = safeMs(minDrainMs);
   const deadline = Date.now() + timeoutMs;
   if (minDrainMs > 0) await sleep(minDrainMs);
   while (activeRequests > 0) {

--- a/tests/lifecycle/shutdown-controller.test.ts
+++ b/tests/lifecycle/shutdown-controller.test.ts
@@ -22,6 +22,16 @@ describe('shutdown controller', () => {
     expect(activeRequestCount()).toBe(0);
   });
 
+  test('treats invalid wait durations as immediate timeout instead of hanging', async () => {
+    let release!: () => void;
+    const pending = trackRequest(() => new Promise<void>((resolve) => { release = resolve; }));
+
+    expect(await waitForActiveRequests(Number.NaN, -1)).toBe(false);
+    release();
+    await pending;
+    expect(activeRequestCount()).toBe(0);
+  });
+
   test('returns 503 for new non-health requests while draining', async () => {
     const blocked = drainingResponseFor(new Request('http://local/api/search?q=x'), { draining: true });
     const health = drainingResponseFor(new Request('http://local/api/health'), { draining: true });

--- a/tests/lifecycle/startup-edge.test.ts
+++ b/tests/lifecycle/startup-edge.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test';
+import { readStartupDbStatus } from '../../src/lifecycle/startup-context.ts';
+import { createStartupSelfTest, runStartupSelfTest } from '../../src/lifecycle/self-test.ts';
+
+describe('startup lifecycle edge cases', () => {
+  test('reports thrown db startup checks as degraded strings', () => {
+    const status = readStartupDbStatus(() => {
+      throw 'disk unavailable';
+    });
+
+    expect(status).toBe('degraded (disk unavailable)');
+  });
+
+  test('fails the health self-test clearly when the fetcher returns no response', async () => {
+    const results = await runStartupSelfTest({
+      checks: createStartupSelfTest({
+        dbPing: () => 'ok',
+        healthFetch: async () => undefined as unknown as Response,
+        vectorConfig: () => validVectorConfig(),
+      }),
+      log: () => undefined,
+    });
+
+    expect(results.find((result) => result.name === 'health-endpoint')).toMatchObject({
+      status: 'fail',
+      message: 'health endpoint returned an invalid response',
+    });
+  });
+});
+
+function validVectorConfig() {
+  return {
+    version: '1.0',
+    host: '0.0.0.0',
+    port: 8081,
+    collections: {
+      main: { collection: 'oracle_knowledge', model: 'nomic-embed-text', provider: 'none' },
+    },
+    dataPath: '/tmp/lancedb',
+  };
+}


### PR DESCRIPTION
## Summary
- clamp invalid shutdown drain durations so tests and shutdown paths cannot hang on bad inputs
- make startup health self-test fail clearly when no Response is returned
- restart gateway health polling safely by clearing stale state, clamping bad intervals, and ignoring stale async checks
- return structured JSON if a configured gateway error hook also throws

## Verification
- bunx tsc --noEmit
- bun test tests/lifecycle/ src/gateway/__tests__/
- git diff --check HEAD~1..HEAD
- wc -l changed files <=250