### PR TITLE
fix: harden runtime sandbox labels

### DIFF
--- a/src/runtime/sandbox-label.ts
+++ b/src/runtime/sandbox-label.ts
@@ -1,8 +1,19 @@
 export const SANDBOX_LABEL_HEADER = 'X-Sandbox-Label';
 
-export function sandboxLabel(env = process.env.ARRA_ENV): string {
-  const value = env?.trim().toLowerCase();
-  if (value === 'production') return 'prod';
-  if (value === 'staging') return 'staging';
-  return 'dev';
+export type SandboxLabel = 'dev' | 'staging' | 'prod';
+
+const labels: Record<string, SandboxLabel> = {
+  development: 'dev',
+  dev: 'dev',
+  local: 'dev',
+  test: 'dev',
+  staging: 'staging',
+  stage: 'staging',
+  production: 'prod',
+  prod: 'prod',
+};
+
+export function sandboxLabel(env: unknown = process.env.ARRA_ENV): SandboxLabel {
+  if (typeof env !== 'string') return 'dev';
+  return labels[env.trim().toLowerCase()] ?? 'dev';
 }

--- a/tests/runtime/sandbox-label.test.ts
+++ b/tests/runtime/sandbox-label.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test';
+import { SANDBOX_LABEL_HEADER, sandboxLabel } from '../../src/runtime/sandbox-label.ts';
+
+describe('runtime sandbox label', () => {
+  test('keeps the shared response header stable', () => {
+    expect(SANDBOX_LABEL_HEADER).toBe('X-Sandbox-Label');
+  });
+
+  test('normalizes supported production and staging aliases', () => {
+    expect(sandboxLabel(' production ')).toBe('prod');
+    expect(sandboxLabel('PROD')).toBe('prod');
+    expect(sandboxLabel(' staging ')).toBe('staging');
+    expect(sandboxLabel('STAGE')).toBe('staging');
+  });
+
+  test('maps development-like environments to dev', () => {
+    for (const value of ['development', 'dev', 'local', 'test']) {
+      expect(sandboxLabel(value)).toBe('dev');
+    }
+  });
+
+  test('falls back to dev for empty, unknown, and non-string values', () => {
+    for (const value of ['', '   ', 'preview', undefined, null, 42, { env: 'production' }]) {
+      expect(sandboxLabel(value)).toBe('dev');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Hardened the shared runtime sandbox label helper to accept only known normalized labels.
- Added aliases for prod/stage/dev-style environments while defaulting empty, unknown, and non-string input to `dev`.
- Added focused runtime coverage for header stability, alias normalization, and fallback behavior.

## Validation
```bash
bunx tsc --noEmit
bun test tests/runtime tests/http/logger/format.test.ts tests/http/logging/request-log.test.ts tests/http/logging/request-logger-middleware.test.ts
```

## Notes
- Read the project goal gist and kept this slice aligned with install-safe, plugin/core stability hardening.
- No UI changes; screenshot not applicable.
