### PR TITLE
fix: harden canvas worker edge cases

### DIFF
--- a/src/workers/canvas/index.ts
+++ b/src/workers/canvas/index.ts
@@ -44,7 +44,14 @@ const REGISTRY_HEADERS = {
 };
 
 function apiBase(env: CanvasWorkerEnv): string {
-  return (env.ORACLE_API_BASE || DEFAULT_API_BASE).replace(/\/$/, '');
+  const raw = (env.ORACLE_API_BASE || DEFAULT_API_BASE).trim();
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return DEFAULT_API_BASE;
+    return url.toString().replace(/\/$/, '');
+  } catch {
+    return DEFAULT_API_BASE;
+  }
 }
 
 function proxyTarget(request: Request, env: CanvasWorkerEnv): URL {
@@ -57,11 +64,16 @@ async function proxyApi(request: Request, env: CanvasWorkerEnv): Promise<Respons
   const headers = new Headers(request.headers);
   headers.set('x-oracle-canvas-worker', CANVAS_HOST);
   headers.delete('host');
-  const upstream = await fetch(proxyTarget(request, env), {
-    method: request.method,
-    headers,
-    body: request.method === 'GET' || request.method === 'HEAD' ? undefined : request.body,
-  });
+  let upstream: Response;
+  try {
+    upstream = await fetch(proxyTarget(request, env), {
+      method: request.method,
+      headers,
+      body: request.method === 'GET' || request.method === 'HEAD' ? undefined : request.body,
+    });
+  } catch {
+    return Response.json({ error: 'api proxy failed' }, { status: 502, headers: API_CACHE_HEADERS });
+  }
   const responseHeaders = new Headers(upstream.headers);
   for (const [key, value] of Object.entries(API_CACHE_HEADERS)) responseHeaders.set(key, value);
   return new Response(upstream.body, { status: upstream.status, statusText: upstream.statusText, headers: responseHeaders });
@@ -89,8 +101,14 @@ function registryResponse(url: URL): Response | null {
   }
   const match = url.pathname.match(/^\/api\/(?:canvas\/plugins|plugins\/canvas)\/([^/]+)$/);
   if (!match) return null;
-  const entry = canvasPluginEntry(decodeURIComponent(match[1]));
-  if (!entry) return Response.json({ error: 'canvas plugin not found', id: match[1] }, { status: 404, headers: REGISTRY_HEADERS });
+  let id: string;
+  try {
+    id = decodeURIComponent(match[1]);
+  } catch {
+    return Response.json({ error: 'invalid canvas plugin id' }, { status: 400, headers: REGISTRY_HEADERS });
+  }
+  const entry = canvasPluginEntry(id);
+  if (!entry) return Response.json({ error: 'canvas plugin not found', id }, { status: 404, headers: REGISTRY_HEADERS });
   return Response.json(entry, { headers: REGISTRY_HEADERS });
 }
 
@@ -113,7 +131,12 @@ export async function handleCanvasRequest(request: Request, env: CanvasWorkerEnv
   }
   if (url.pathname.startsWith('/api/') && request.method === 'OPTIONS') return new Response(null, { status: 204, headers: API_CACHE_HEADERS });
   if (url.pathname.startsWith('/api/')) return proxyApi(request, env);
-  if (request.method !== 'GET' && request.method !== 'HEAD') return new Response('Method not allowed', { status: 405 });
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    return new Response('Method not allowed', {
+      status: 405,
+      headers: { ...SECURITY_HEADERS, Allow: 'GET, HEAD' },
+    });
+  }
   const selection = pluginFrom(url);
   const html = renderCanvasApp(selection.plugin, apiBase(env), selection.requested);
   return new Response(request.method === 'HEAD' ? null : html, { headers: HTML_HEADERS });

--- a/src/workers/canvas/render.ts
+++ b/src/workers/canvas/render.ts
@@ -11,7 +11,7 @@ import {
 const STUDIO_HOME = 'https://studio.buildwithoracle.com/';
 
 export function normalizePlugin(value: string | null): CanvasPlugin {
-  return findCanvasPlugin(value ?? '') ?? findCanvasPlugin(DEFAULT_CANVAS_PLUGIN)!;
+  return findCanvasPlugin(value?.trim() ?? '') ?? findCanvasPlugin(DEFAULT_CANVAS_PLUGIN)!;
 }
 
 function titleFor(plugin: CanvasPlugin): string {
@@ -27,7 +27,12 @@ function canonicalUrl(id: string): string {
 }
 
 function escapeHtml(value: string): string {
-  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
 }
 
 function pluginLinks(current: string): string {

--- a/tests/workers/canvas-edge-cases.test.ts
+++ b/tests/workers/canvas-edge-cases.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { handleCanvasRequest } from '../../src/workers/canvas/index.ts';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('canvas worker edge cases', () => {
+  test('returns a marked 502 JSON response when upstream API fetch fails', async () => {
+    globalThis.fetch = (async () => {
+      throw new Error('network unavailable');
+    }) as typeof fetch;
+
+    const response = await handleCanvasRequest(
+      new Request('https://canvas.buildwithoracle.com/api/health'),
+    );
+
+    expect(response.status).toBe(502);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(response.headers.get('x-oracle-canvas-worker')).toBe('canvas.buildwithoracle.com');
+    expect(await response.json()).toEqual({ error: 'api proxy failed' });
+  });
+
+  test('falls back to the default API base when env base URL is invalid', async () => {
+    const seen: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      seen.push(String(input));
+      return Response.json({ ok: true });
+    }) as typeof fetch;
+
+    await handleCanvasRequest(
+      new Request('https://canvas.buildwithoracle.com/api/health?probe=1'),
+      { ORACLE_API_BASE: 'not a url' },
+    );
+
+    expect(seen).toEqual(['https://studio.buildwithoracle.com/api/health?probe=1']);
+  });
+
+  test('rejects malformed percent-encoded local registry plugin ids', async () => {
+    const response = await handleCanvasRequest(
+      new Request('https://canvas.buildwithoracle.com/api/canvas/plugins/%E0%A4%A'),
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get('x-content-type-options')).toBe('nosniff');
+    expect(await response.json()).toEqual({ error: 'invalid canvas plugin id' });
+  });
+
+  test('escapes unknown plugin text before rendering fallback notices', async () => {
+    const raw = '<img src=x onerror="alert(1)">';
+    const response = await handleCanvasRequest(
+      new Request(`https://canvas.buildwithoracle.com/?plugin=${encodeURIComponent(raw)}`),
+    );
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).not.toContain(raw);
+    expect(html).toContain('&lt;img src=x onerror=&quot;alert(1)&quot;&gt;');
+    expect(html).toContain('loaded Wave instead');
+  });
+
+  test('non-page methods return a marked 405 with allowed methods', async () => {
+    const response = await handleCanvasRequest(
+      new Request('https://canvas.buildwithoracle.com/planets', { method: 'POST' }),
+    );
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get('allow')).toBe('GET, HEAD');
+    expect(response.headers.get('x-oracle-canvas-worker')).toBe('canvas.buildwithoracle.com');
+  });
+});


### PR DESCRIPTION
## Summary
- Hardened the canvas worker API proxy to return marked `502` JSON when upstream fetch fails.
- Sanitized invalid `ORACLE_API_BASE` values back to the default Studio API origin.
- Guarded local registry plugin detail decoding so malformed percent-encoded IDs return `400` instead of throwing.
- Escaped fallback notice text more completely before rendering unknown plugin names in HTML.
- Added an `Allow` header and worker marker to non-page `405` responses.

## Validation
- `bunx tsc --noEmit`
- `bun test tests/workers/canvas-edge-cases.test.ts tests/workers/canvas-worker.test.ts tests/workers/canvas-deploy-workflow.test.ts tests/http/canvas-worker.test.ts tests/http/canvas/` (30 pass)
- `bun build src/workers/canvas/index.ts --target=browser --outdir /tmp/arra-canvas-worker-hardening`
- `git diff --check origin/alpha..HEAD`
- Changed files all <=250 lines.

## Notes
- Read the project goal gist; this keeps the canvas worker install/runtime path resilient without changing UI.
- No UI changes, so no screenshot attached.
- No issue number was provided for this hardening slice, so no issue comment was posted.