### PR TITLE
fix(indexer): harden scan and worker edge cases

### DIFF
--- a/src/indexer/__tests__/hardening.test.ts
+++ b/src/indexer/__tests__/hardening.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test';
+import Database from 'bun:sqlite';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { getAllMarkdownFiles } from '../collectors.ts';
+import { enqueueIndexJob } from '../jobs.ts';
+import { listDirs, listFiles } from '../watch-utils.ts';
+import { runWorker } from '../worker.ts';
+
+const JOB_SCHEMA = `
+CREATE TABLE indexing_jobs (
+  id TEXT PRIMARY KEY,
+  doc_id TEXT NOT NULL,
+  model_key TEXT NOT NULL,
+  collection TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  attempts INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')*1000),
+  claimed_at INTEGER,
+  finished_at INTEGER,
+  error TEXT
+);`;
+
+describe('indexer filesystem hardening', () => {
+  test('treats missing scan roots as empty instead of throwing', () => {
+    const missing = path.join(os.tmpdir(), `arra-indexer-missing-${Date.now()}`);
+
+    expect(getAllMarkdownFiles(missing)).toEqual([]);
+    expect(listDirs(missing)).toEqual([]);
+    expect(listFiles(missing, () => true)).toEqual([]);
+  });
+
+  test('skips directories that vanish during recursive watch scans', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-indexer-vanish-'));
+    const gone = path.join(root, 'gone');
+    fs.mkdirSync(gone);
+    fs.rmSync(gone, { recursive: true, force: true });
+
+    try {
+      expect(listDirs(gone)).toEqual([]);
+      expect(listFiles(gone, () => true)).toEqual([]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('indexer worker hardening', () => {
+  test('ignores throwing event observers and still completes the job', async () => {
+    const db = new Database(':memory:');
+    db.exec(JOB_SCHEMA);
+    enqueueIndexJob(db, {
+      docId: 'doc-observer',
+      models: { 'bge-m3': { collection: 'oracle_knowledge_bge_m3' } },
+    });
+
+    let checks = 0;
+    const stats = await runWorker('bge-m3', {
+      db,
+      getDocText: () => 'observer failures must not poison indexing',
+      embed: async () => [1, 2, 3],
+      upsertVector: async () => undefined,
+      isShuttingDown: () => ++checks > 1,
+      onEvent: () => { throw new Error('observer failed'); },
+    });
+
+    const row = db.query<{ status: string }, []>('SELECT status FROM indexing_jobs').get();
+    expect(stats).toMatchObject({ processed: 1, errors: 0 });
+    expect(row?.status).toBe('done');
+    db.close();
+  });
+});

--- a/src/indexer/collectors.ts
+++ b/src/indexer/collectors.ts
@@ -13,20 +13,32 @@ const SECURITY_CORPUS_EXTENSIONS = ['.md', '.txt', '.yaml', '.yml', '.json', '.r
 const SECURITY_CORPUS_MAX_FILE_BYTES = 200 * 1024;  // 200KB cap per file
 const SECURITY_CORPUS_SKIP_DIRS = ['_meta', '.git', 'node_modules', '__pycache__'];
 
+function skippableFsError(err: unknown): boolean {
+  const code = err && typeof err === 'object' && 'code' in err
+    ? (err as NodeJS.ErrnoException).code
+    : undefined;
+  return code === 'ENOENT' || code === 'ENOTDIR' || code === 'EACCES' || code === 'EPERM';
+}
+
 /**
  * Recursively get all markdown files in a directory
  */
 export function getAllMarkdownFiles(dir: string): string[] {
   const files: string[] = [];
-  const items = fs.readdirSync(dir);
+  let items: string[];
+  try {
+    items = fs.readdirSync(dir);
+  } catch (err) {
+    if (skippableFsError(err)) return files;
+    throw err;
+  }
   for (const item of items) {
     const fullPath = path.join(dir, item);
     let stat: fs.Stats;
     try {
       stat = fs.statSync(fullPath);
     } catch (err) {
-      const code = err && typeof err === 'object' && 'code' in err ? (err as NodeJS.ErrnoException).code : undefined;
-      if (code === 'ENOENT') continue;
+      if (skippableFsError(err)) continue;
       throw err;
     }
     if (stat.isDirectory()) {
@@ -99,7 +111,13 @@ export function collectDocuments(opts: CollectOpts): OracleDocument[] {
  */
 function getSecurityCorpusFiles(dir: string): string[] {
   const files: string[] = [];
-  const items = fs.readdirSync(dir, { withFileTypes: true });
+  let items: fs.Dirent[];
+  try {
+    items = fs.readdirSync(dir, { withFileTypes: true });
+  } catch (err) {
+    if (skippableFsError(err)) return files;
+    throw err;
+  }
   for (const item of items) {
     if (SECURITY_CORPUS_SKIP_DIRS.includes(item.name)) continue;
     const fullPath = path.join(dir, item.name);

--- a/src/indexer/watch-utils.ts
+++ b/src/indexer/watch-utils.ts
@@ -16,9 +16,19 @@ export function isWithinRoot(root: string, candidate: string): boolean {
   return rel === '' || (rel !== '..' && !rel.startsWith(`..${path.sep}`) && !path.isAbsolute(rel));
 }
 
+function readDir(root: string): fs.Dirent[] | null {
+  try {
+    return fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+}
+
 export function listDirs(root: string): string[] {
+  const entries = readDir(root);
+  if (!entries) return [];
   const dirs = [root];
-  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+  for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     if (entry.name === '.git' || entry.name === 'node_modules') continue;
     dirs.push(...listDirs(path.join(root, entry.name)));
@@ -28,7 +38,9 @@ export function listDirs(root: string): string[] {
 
 export function listFiles(root: string, include: (filePath: string) => boolean): string[] {
   const files: string[] = [];
-  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+  const entries = readDir(root);
+  if (!entries) return files;
+  for (const entry of entries) {
     const fullPath = path.join(root, entry.name);
     if (entry.isDirectory()) files.push(...listFiles(fullPath, include));
     else if (entry.isFile() && include(fullPath)) files.push(fullPath);

--- a/src/indexer/worker.ts
+++ b/src/indexer/worker.ts
@@ -65,6 +65,14 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function emit(deps: WorkerDeps, ev: WorkerEvent): void {
+  try {
+    deps.onEvent?.(ev);
+  } catch {
+    // Observability hooks must not poison queue processing.
+  }
+}
+
 /**
  * Run a worker loop for a single model. Returns when `isShuttingDown()` is true.
  *
@@ -87,12 +95,12 @@ export async function runWorker(
     const job = claimNextJob(deps.db, modelKey);
     if (!job) {
       stats.emptyPolls++;
-      deps.onEvent?.({ type: 'idle', modelKey });
+      emit(deps, { type: 'idle', modelKey });
       await sleep(pollMs);
       continue;
     }
 
-    deps.onEvent?.({ type: 'claimed', job });
+    emit(deps, { type: 'claimed', job });
 
     try {
       const text = deps.getDocText(job.docId);
@@ -101,7 +109,7 @@ export async function runWorker(
         // Plug-play: removing a doc from oracle_documents leaves queue rows
         // safely consumable. The worker absorbs the no-op gracefully.
         markJobDone(deps.db, job.id);
-        deps.onEvent?.({ type: 'doc_missing', job });
+        emit(deps, { type: 'doc_missing', job });
         stats.processed++;
         continue;
       }
@@ -111,7 +119,7 @@ export async function runWorker(
       await deps.upsertVector(job.collection, job.docId, vector);
       markJobDone(deps.db, job.id);
       stats.processed++;
-      deps.onEvent?.({
+      emit(deps, {
         type: 'done',
         job,
         durationMs: Math.round(performance.now() - t0),
@@ -120,7 +128,7 @@ export async function runWorker(
       const msg = err instanceof Error ? err.message : String(err);
       markJobError(deps.db, job.id, msg);
       stats.errors++;
-      deps.onEvent?.({ type: 'error', job, error: msg });
+      emit(deps, { type: 'error', job, error: msg });
     }
   }
 


### PR DESCRIPTION
## Summary
- tolerate missing/unreadable indexer scan roots instead of failing recursive scans
- make watcher directory/file listing resilient when paths disappear mid-scan
- isolate worker event observer failures so telemetry hooks cannot poison jobs
- add focused hardening coverage for filesystem edges and worker observer failures

## Verification
```bash
bunx tsc --noEmit
while IFS= read -r test_file; do bun test --isolate "$test_file"; done < <(find src/indexer/__tests__ -name "*.test.ts" -print | sort)
git diff --check HEAD~1..HEAD
wc -l src/indexer/collectors.ts src/indexer/watch-utils.ts src/indexer/worker.ts src/indexer/__tests__/hardening.test.ts
```

## Notes
- No UI changes.
- Aligns with the project goal of plugin/install-friendly robustness by keeping indexer scans and background workers tolerant of local filesystem and observer edge cases.