### PR TITLE
test: harden vault and huginn edge cases

### DIFF
--- a/src/huginn/__tests__/capture.test.ts
+++ b/src/huginn/__tests__/capture.test.ts
@@ -48,6 +48,18 @@ describe('Huginn session capture', () => {
     expect(mined.hash).toMatch(/^[a-f0-9]{64}$/);
   });
 
+  it('falls back to the default capture limit for invalid maxItems', () => {
+    const dir = tmpdir();
+    const transcript = path.join(dir, 'limits.jsonl');
+    writeJsonl(transcript, [
+      { message: { role: 'assistant', content: 'Decision: keep capture limits defensive when hook config is invalid.' } },
+      { message: { role: 'assistant', content: 'Learned: invalid maxItems should not suppress all Huginn session memories.' } },
+    ]);
+
+    const mined = mineSessionJsonl(transcript, 0);
+    expect(mined.moments).toHaveLength(2);
+  });
+
   it('learns once per session+content hash and skips duplicate reruns', async () => {
     const dir = tmpdir();
     const transcript = path.join(dir, 'session-abc.jsonl');
@@ -73,6 +85,28 @@ describe('Huginn session capture', () => {
     const second = await captureSession({ transcriptPath: transcript, sessionId: 'abc', statePath, learn });
     expect(second.skipped).toBe('duplicate');
     expect(learned).toHaveLength(1);
+  });
+
+  it('recovers when the capture state has malformed records', async () => {
+    const dir = tmpdir();
+    const transcript = path.join(dir, 'state-edge.jsonl');
+    const statePath = path.join(dir, 'state.json');
+    fs.writeFileSync(statePath, JSON.stringify({ captures: [] }));
+    writeJsonl(transcript, [
+      { message: { role: 'assistant', content: 'Learned: malformed Huginn state should be ignored instead of blocking capture.' } },
+    ]);
+
+    const result = await captureSession({
+      transcriptPath: transcript,
+      sessionId: 'state-edge',
+      statePath,
+      learn: () => ({ id: 'learn_state_edge' }),
+    });
+
+    expect(result.learned).toBe(true);
+    const state = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    expect(Array.isArray(state.captures)).toBe(false);
+    expect(Object.keys(state.captures)).toHaveLength(1);
   });
 
   it('does not learn empty/non-salient transcripts', async () => {

--- a/src/huginn/__tests__/sweep.test.ts
+++ b/src/huginn/__tests__/sweep.test.ts
@@ -53,6 +53,31 @@ describe('Huginn periodic sweep', () => {
     expect(Object.keys(state.captures)).toHaveLength(1);
   });
 
+  it('recovers when persisted sweep state has malformed records', async () => {
+    const dir = tmpdir();
+    const sessions = path.join(dir, 'sessions');
+    const transcript = path.join(sessions, 'malformed-state.jsonl');
+    const statePath = path.join(dir, 'state.json');
+    fs.writeFileSync(statePath, JSON.stringify({ captures: [], sweeps: [] }));
+    writeJsonl(transcript, [
+      { message: { role: 'assistant', content: 'Decision: Huginn sweep should tolerate malformed persisted state records.' } },
+    ], 2_000);
+
+    const result = await sweepHuginn({
+      sessionDirs: [sessions],
+      statePath,
+      now: 3_000,
+      learn: () => ({ id: 'learn_malformed_state' }),
+      indexMarkdown: () => {},
+    });
+
+    expect(result.learned).toBe(1);
+    const state = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    expect(Array.isArray(state.captures)).toBe(false);
+    expect(Array.isArray(state.sweeps)).toBe(false);
+    expect(state.sweeps.lastSweepAtMs).toBe(3_000);
+  });
+
   it('uses #49 dedup state when the fast-path hook already captured the transcript', async () => {
     const dir = tmpdir();
     const sessions = path.join(dir, 'sessions');

--- a/src/huginn/capture.ts
+++ b/src/huginn/capture.ts
@@ -60,11 +60,16 @@ function sha256(text: string): string {
   return crypto.createHash('sha256').update(text).digest('hex');
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
 function readState(statePath: string): CaptureState {
   try {
     const raw = fs.readFileSync(statePath, 'utf-8');
-    const parsed = JSON.parse(raw);
-    return { captures: parsed && typeof parsed.captures === 'object' ? parsed.captures : {} };
+    const parsed: unknown = JSON.parse(raw);
+    const captures = isRecord(parsed) && isRecord(parsed.captures) ? parsed.captures : {};
+    return { captures: captures as CaptureState['captures'] };
   } catch {
     return { captures: {} };
   }
@@ -122,11 +127,17 @@ function compact(text: string, max = 360): string {
   return text.replace(/\s+/g, ' ').trim().slice(0, max).trim();
 }
 
+function normalizeMaxItems(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 12;
+  return Math.floor(value);
+}
+
 export function mineSessionJsonl(transcriptPath: string, maxItems = 12): { moments: HuginnMoment[]; hash: string; sourceText: string } {
   if (!fs.existsSync(transcriptPath)) return { moments: [], hash: '', sourceText: '' };
   const raw = fs.readFileSync(transcriptPath, 'utf-8');
   const selected: HuginnMoment[] = [];
   const seen = new Set<string>();
+  const limit = normalizeMaxItems(maxItems);
 
   for (const line of raw.split(/\r?\n/)) {
     if (!line.trim()) continue;
@@ -140,7 +151,7 @@ export function mineSessionJsonl(transcriptPath: string, maxItems = 12): { momen
     if (seen.has(key)) continue;
     seen.add(key);
     selected.push({ kind: classify(clipped), text: clipped });
-    if (selected.length >= maxItems) break;
+    if (selected.length >= limit) break;
   }
 
   const sourceText = selected.map((m) => `${m.kind}: ${m.text}`).join('\n');

--- a/src/huginn/sweep.ts
+++ b/src/huginn/sweep.ts
@@ -38,12 +38,16 @@ export interface HuginnSweepSummary {
   files: Array<{ path: string; action: string; sessionId?: string; hash?: string; sourceFile?: string }>;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
 function readSweepState(statePath: string): HuginnSweepState {
   try {
-    const parsed = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    const parsed: unknown = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
     return {
-      captures: parsed && typeof parsed.captures === 'object' ? parsed.captures : {},
-      sweeps: parsed && typeof parsed.sweeps === 'object' ? parsed.sweeps : {},
+      captures: isRecord(parsed) && isRecord(parsed.captures) ? parsed.captures as HuginnSweepState['captures'] : {},
+      sweeps: isRecord(parsed) && isRecord(parsed.sweeps) ? parsed.sweeps as HuginnSweepState['sweeps'] : {},
     };
   } catch {
     return { captures: {}, sweeps: {} };

--- a/src/vault/__tests__/handler.test.ts
+++ b/src/vault/__tests__/handler.test.ts
@@ -48,6 +48,11 @@ describe('parseGitStatus', () => {
     expect(parseGitStatus(status)).toEqual({ added: 0, modified: 1, deleted: 0 });
   });
 
+  it('counts copies as added and type changes as modified', () => {
+    const status = 'C  ψ/source.md -> ψ/copy.md\nT  ψ/memory/link.md';
+    expect(parseGitStatus(status)).toEqual({ added: 1, modified: 1, deleted: 0 });
+  });
+
   it('handles mixed status output', () => {
     const status = [
       '?? ψ/memory/new.md',
@@ -163,6 +168,14 @@ describe('ensureFrontmatterProject', () => {
     expect(result).toContain(`project: ${project}`);
     expect(result).toContain('tags: [git, safety]');
     expect(result).toContain('source: Oracle Learn');
+  });
+
+  it('injects project into CRLF frontmatter without duplicating fences', () => {
+    const content = '---\r\ntags: [git, safety]\r\n---\r\n\r\n# Content';
+    const result = ensureFrontmatterProject(content, project);
+    expect(result).toContain(`project: ${project}`);
+    expect(result.startsWith('---\r\n')).toBe(true);
+    expect(result.match(/^---/gm)?.length).toBe(2);
   });
 
   it('does not modify if project already exists', () => {

--- a/src/vault/git.ts
+++ b/src/vault/git.ts
@@ -17,9 +17,9 @@ export function parseGitStatus(porcelainOutput: string): GitStatusCounts {
 
   for (const line of porcelainOutput.trim().split('\n')) {
     const code = line.substring(0, 2);
-    if (code.includes('A') || code === '??') added++;
+    if (code.includes('A') || code.includes('C') || code === '??') added++;
     else if (code.includes('D')) deleted++;
-    else if (code.includes('M') || code.includes('R')) modified++;
+    else if (code.includes('M') || code.includes('R') || code.includes('T')) modified++;
   }
 
   return { added, modified, deleted };

--- a/src/vault/path-mapping.ts
+++ b/src/vault/path-mapping.ts
@@ -69,7 +69,7 @@ export function mapFromVaultPath(vaultRelativePath: string, project: string): st
  * Returns modified content (or original if already has project).
  */
 export function ensureFrontmatterProject(content: string, project: string): string {
-  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
 
   if (frontmatterMatch) {
     const frontmatter = frontmatterMatch[1];
@@ -77,8 +77,9 @@ export function ensureFrontmatterProject(content: string, project: string): stri
     if (/^project:\s/m.test(frontmatter)) return content;
 
     // Inject project: after existing frontmatter fields
-    const newFrontmatter = `${frontmatter}\nproject: ${project}`;
-    return content.replace(frontmatterMatch[0], `---\n${newFrontmatter}\n---`);
+    const newline = frontmatterMatch[0].includes('\r\n') ? '\r\n' : '\n';
+    const newFrontmatter = `${frontmatter}${newline}project: ${project}`;
+    return content.replace(frontmatterMatch[0], `---${newline}${newFrontmatter}${newline}---`);
   }
 
   // No frontmatter — add one


### PR DESCRIPTION
## Summary

- Harden Huginn capture/sweep state loading so malformed persisted arrays are ignored and rewritten as records.
- Guard Huginn JSONL mining against invalid `maxItems` values so bad hook config does not suppress captures.
- Harden vault edge handling for Git porcelain copy/type-change statuses and CRLF markdown frontmatter.

## Tests

```bash
tmpdir=$(mktemp -d); ORACLE_DATA_DIR="$tmpdir" ORACLE_DB_PATH="$tmpdir/oracle.db" bun test src/huginn/__tests__ src/vault/__tests__ tests/http/vault
bunx tsc --noEmit
wc -l src/huginn/capture.ts src/huginn/sweep.ts src/huginn/__tests__/capture.test.ts src/huginn/__tests__/sweep.test.ts src/vault/git.ts src/vault/path-mapping.ts src/vault/__tests__/handler.test.ts
```

## Notes

- No UI changes; screenshot not applicable.
- All changed files are ≤250 lines.
