### PR TITLE
test(cli): harden command edge cases

### DIFF
--- a/src/cli/commands/backup.ts
+++ b/src/cli/commands/backup.ts
@@ -121,9 +121,15 @@ function parseBackupArgs(args: string[]): Pick<BackupOptions, 'outDir'> {
 
 function readValue(args: string[], flag: string): string | undefined {
   const index = args.indexOf(flag);
-  if (index >= 0) return args[index + 1];
+  if (index >= 0) {
+    const value = args[index + 1];
+    if (!value || value.startsWith('-')) throw new Error(`missing value for ${flag}`);
+    return value;
+  }
   const prefix = `${flag}=`;
-  return args.find(arg => arg.startsWith(prefix))?.slice(prefix.length);
+  const value = args.find(arg => arg.startsWith(prefix))?.slice(prefix.length);
+  if (value === '') throw new Error(`missing value for ${flag}`);
+  return value;
 }
 
 function columnEntries(table: DumpTable): Array<[string, DumpColumn]> {

--- a/src/cli/commands/changelog.ts
+++ b/src/cli/commands/changelog.ts
@@ -39,14 +39,36 @@ function printHelp(): void {
 
 function readValue(args: string[], flag: string): string | undefined {
   const index = args.indexOf(flag);
-  if (index >= 0) return args[index + 1];
+  if (index >= 0) {
+    const value = args[index + 1];
+    if (!value || value.startsWith("--")) throw new Error(`missing value for ${flag}`);
+    return value;
+  }
   const prefix = `${flag}=`;
-  return args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+  const value = args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+  if (value === "") throw new Error(`missing value for ${flag}`);
+  return value;
+}
+
+function consumeFlag(args: string[], flag: string, consumed: Set<number>): void {
+  const index = args.indexOf(flag);
+  if (index >= 0) {
+    consumed.add(index);
+    consumed.add(index + 1);
+  }
+  const inline = args.findIndex((arg) => arg.startsWith(`${flag}=`));
+  if (inline >= 0) consumed.add(inline);
 }
 
 export function parseChangelogOptions(args: string[]): ChangelogOptions {
+  const consumed = new Set<number>();
   const since = readValue(args, "--since");
+  consumeFlag(args, "--since", consumed);
   const outFile = readValue(args, "--out");
+  consumeFlag(args, "--out", consumed);
+  if (args.includes("--stdout")) consumed.add(args.indexOf("--stdout"));
+  const unknown = args.find((_, index) => !consumed.has(index));
+  if (unknown) throw new Error(`unknown changelog option: ${unknown}`);
   return {
     ...(since ? { since } : {}),
     ...(outFile ? { outFile } : {}),

--- a/src/cli/commands/export.ts
+++ b/src/cli/commands/export.ts
@@ -80,8 +80,7 @@ function readNonNegativeInt(args: string[], flag: string, fallback: number): num
 
 function hasNewExportFlag(args: string[]): boolean {
   return args.some((arg) => arg === "--url" || arg.startsWith("--url=")
-    || arg === "--output" || arg.startsWith("--output=")
-    || arg === "--out" || arg.startsWith("--out=") || arg === "-o" || arg.startsWith("-o="));
+    || arg === "--output" || arg.startsWith("--output="));
 }
 
 export function parseRemoteExportOptions(args: string[]): RemoteExportOptions {

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -20,15 +20,37 @@ function printHelp(): void {
 
 function readValue(args: string[], flag: string): string | undefined {
   const index = args.indexOf(flag);
-  if (index >= 0) return args[index + 1];
+  if (index >= 0) {
+    const value = args[index + 1];
+    if (!value || value.startsWith("--")) throw new Error(`missing value for ${flag}`);
+    return value;
+  }
   const prefix = `${flag}=`;
-  return args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+  const value = args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+  if (value === "") throw new Error(`missing value for ${flag}`);
+  return value;
+}
+
+function consumeFlag(args: string[], flag: string, consumed: Set<number>): void {
+  const index = args.indexOf(flag);
+  if (index >= 0) {
+    consumed.add(index);
+    consumed.add(index + 1);
+  }
+  const prefix = `${flag}=`;
+  const inline = args.findIndex((arg) => arg.startsWith(prefix));
+  if (inline >= 0) consumed.add(inline);
 }
 
 export function parseImportOptions(args: string[]): DataImportOptions {
+  const consumed = new Set<number>();
   const format = readValue(args, "--format") ?? "json";
+  consumeFlag(args, "--format", consumed);
   if (format !== "json") throw new Error(`unsupported format: ${format}`);
   const inFile = readValue(args, "--in");
+  consumeFlag(args, "--in", consumed);
+  const unknown = args.find((_, index) => !consumed.has(index));
+  if (unknown) throw new Error(`unknown import option: ${unknown}`);
   return inFile ? { format, inFile } : { format };
 }
 

--- a/tests/cli/backup/dump.test.ts
+++ b/tests/cli/backup/dump.test.ts
@@ -5,12 +5,6 @@ import { basename, join } from 'node:path';
 
 const savedDataDir = process.env.ORACLE_DATA_DIR;
 const savedRepoRoot = process.env.ORACLE_REPO_ROOT;
-const savedDbPath = process.env.ORACLE_DB_PATH;
-
-function restoreDbPath() {
-  return savedDbPath
-    ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
-}
 
 const importRoot = mkdtempSync(join(tmpdir(), 'arra-backup-import-'));
 process.env.ORACLE_DATA_DIR = join(importRoot, 'data');
@@ -34,7 +28,7 @@ afterAll(() => {
   else process.env.ORACLE_DATA_DIR = savedDataDir;
   if (savedRepoRoot === undefined) delete process.env.ORACLE_REPO_ROOT;
   else process.env.ORACLE_REPO_ROOT = savedRepoRoot;
-  resetDefaultDatabaseForTests(restoreDbPath());
+  resetDefaultDatabaseForTests(':memory:');
   rmSync(importRoot, { recursive: true, force: true });
 });
 
@@ -105,6 +99,22 @@ describe('SQLite backup dump command', () => {
       expect(sql).toContain('COMMIT;');
     } finally {
       connection.storage.close();
+    }
+  });
+
+  test('rejects missing and unknown backup options before opening the DB', async () => {
+    const cases = [
+      { args: ['--out-dir'], error: 'missing value for --out-dir' },
+      { args: ['--out-dir='], error: 'missing value for --out-dir' },
+      { args: ['--out-dir', '--json'], error: 'missing value for --out-dir' },
+      { args: ['--unknown'], error: 'unknown backup option: --unknown' },
+    ];
+
+    for (const item of cases) {
+      const stderr: string[] = [];
+      const code = await backupCommand(item.args, { stderr: msg => stderr.push(msg) });
+      expect(code).toBe(1);
+      expect(stderr.join('')).toContain(item.error);
     }
   });
 });

--- a/tests/cli/changelog/generate.test.ts
+++ b/tests/cli/changelog/generate.test.ts
@@ -127,6 +127,13 @@ describe("changelog generator", () => {
     });
   });
 
+  test("rejects malformed changelog flags before running git", () => {
+    expect(() => parseChangelogOptions(["--since"])).toThrow("missing value for --since");
+    expect(() => parseChangelogOptions(["--out="])).toThrow("missing value for --out");
+    expect(() => parseChangelogOptions(["--stdout=true"])).toThrow("unknown changelog option: --stdout=true");
+    expect(() => parseChangelogOptions(["--unknown"])).toThrow("unknown changelog option: --unknown");
+  });
+
   test("writes CHANGELOG.md through the command", async () => {
     await initRepo(root);
     await emptyCommit(root, "chore: baseline");

--- a/tests/cli/data/export-import.test.ts
+++ b/tests/cli/data/export-import.test.ts
@@ -8,11 +8,6 @@ import { runCli, tryParseJson } from "../_run.ts";
 const savedDataDir = process.env.ORACLE_DATA_DIR;
 const savedDbPath = process.env.ORACLE_DB_PATH;
 
-function restoreDbPath() {
-  return savedDbPath
-    ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
-}
-
 async function openDataDb(dbPath: string) {
   const mod = await import("../../../src/db/index.ts");
   const connection = mod.createDatabase(dbPath);
@@ -73,7 +68,7 @@ describe("data export/import CLI", () => {
     else process.env.ORACLE_DATA_DIR = savedDataDir;
     if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
     else process.env.ORACLE_DB_PATH = savedDbPath;
-    mod.resetDefaultDatabaseForTests(restoreDbPath());
+    mod.resetDefaultDatabaseForTests(":memory:");
     rmSync(root, { recursive: true, force: true });
   });
 

--- a/tests/cli/import/validation.test.ts
+++ b/tests/cli/import/validation.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runCli } from '../_run.ts';
+
+const roots: string[] = [];
+
+function isolatedEnv(): Record<string, string> {
+  const root = mkdtempSync(join(tmpdir(), 'arra-import-cli-'));
+  roots.push(root);
+  return {
+    HOME: join(root, 'home'),
+    ORACLE_DATA_DIR: join(root, 'data'),
+    ORACLE_REPO_ROOT: root,
+    ORACLE_DB_PATH: join(root, 'data', 'oracle.db'),
+  };
+}
+
+afterEach(() => {
+  for (const root of roots) rmSync(root, { recursive: true, force: true });
+  roots.length = 0;
+});
+
+describe('import CLI validation', () => {
+  test('rejects missing values and unknown options before reading stdin', async () => {
+    const cases = [
+      { args: ['import', '--format'], error: 'missing value for --format' },
+      { args: ['import', '--format='], error: 'missing value for --format' },
+      { args: ['import', '--in'], error: 'missing value for --in' },
+      { args: ['import', '--unknown'], error: 'unknown import option: --unknown' },
+      { args: ['import', '--format', 'yaml'], error: 'unsupported format: yaml' },
+    ];
+
+    for (const item of cases) {
+      const result = await runCli(item.args, isolatedEnv());
+      expect(result.code).toBe(1);
+      expect(result.stderr).toContain(item.error);
+    }
+  }, 15_000);
+});

--- a/tests/cli/seed/populate.test.ts
+++ b/tests/cli/seed/populate.test.ts
@@ -6,12 +6,6 @@ import { inArray } from 'drizzle-orm';
 
 const savedDataDir = process.env.ORACLE_DATA_DIR;
 const savedRepoRoot = process.env.ORACLE_REPO_ROOT;
-const savedDbPath = process.env.ORACLE_DB_PATH;
-
-function restoreDbPath() {
-  return savedDbPath
-    ?? join(savedDataDir ?? join(process.env.HOME!, '.arra-oracle-v2'), 'oracle.db');
-}
 
 const importRoot = mkdtempSync(join(tmpdir(), 'arra-seed-import-'));
 process.env.ORACLE_DATA_DIR = join(importRoot, 'data');
@@ -46,7 +40,7 @@ afterAll(() => {
   else process.env.ORACLE_DATA_DIR = savedDataDir;
   if (savedRepoRoot === undefined) delete process.env.ORACLE_REPO_ROOT;
   else process.env.ORACLE_REPO_ROOT = savedRepoRoot;
-  resetDefaultDatabaseForTests(restoreDbPath());
+  resetDefaultDatabaseForTests(':memory:');
   rmSync(importRoot, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
## Summary
- Harden CLI option parsing for backup, import, and changelog so missing values, empty equals-form values, and unknown args fail before side effects.
- Preserve legacy `arra-cli export --format json --out <file>` routing while keeping remote export aliases when `--url`/`--output` are present.
- Stabilize CLI DB-backed tests so cleanup resets to an in-memory DB instead of a developer-local SQLite path.

## Validation
- `bunx tsc --noEmit`
- `bun test tests/cli/`
- `git diff --check origin/alpha...HEAD`
- changed files <= 250 lines
