### PR TITLE
fix: harden API token open path matching

### DIFF
--- a/src/integration/api-token-auth.test.ts
+++ b/src/integration/api-token-auth.test.ts
@@ -62,6 +62,9 @@ describe('ARRA_API_TOKEN HTTP auth', () => {
   test('set token gates /api/learn while health stays open and federation stays absent', async () => {
     const base = await startServer('secret');
     expect((await fetch(`${base}/api/health`)).status).toBe(200);
+    expect((await fetch(`${base}/api/health/deep`)).status).toBe(200);
+    expect((await fetch(`${base}/api/healthz`)).status).toBe(401);
+    expect((await fetch(`${base}/api/docs-malicious`)).status).toBe(401);
     expect((await fetch(`${base}/info`)).status).toBe(404);
     expect((await fetch(`${base}/api/identity`)).status).toBe(401);
     expect((await fetch(`${base}/api/peer/feed`)).status).toBe(401);

--- a/src/server/api-token-auth.ts
+++ b/src/server/api-token-auth.ts
@@ -1,7 +1,7 @@
 import { timingSafeEqual } from 'crypto';
 import { apiErrorResponse } from '../middleware/errors.ts';
 
-const OPEN_PREFIXES = ['/api/health', '/api/docs/'];
+const OPEN_API_ROOTS = ['/api/health', '/api/docs'];
 
 export function apiToken() { return process.env.ARRA_API_TOKEN?.trim() || ''; }
 export function isApiTokenEnabled() { return apiToken().length > 0; }
@@ -14,7 +14,7 @@ function safeEqual(a: string, b: string) {
 
 export function isApiPathProtected(pathname: string) {
   if (!pathname.startsWith('/api/')) return false;
-  if (OPEN_PREFIXES.some((prefix) => pathname === prefix.slice(0, -1) || pathname.startsWith(prefix))) return false;
+  if (OPEN_API_ROOTS.some((root) => pathname === root || pathname.startsWith(`${root}/`))) return false;
   return true;
 }
 

--- a/tests/http/security/auth-and-cors.test.ts
+++ b/tests/http/security/auth-and-cors.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { Elysia } from 'elysia';
 import { createCorsMiddleware, createPrivateNetworkPreflightMiddleware } from '../../../src/middleware/cors.ts';
-import { isApiAuthorized } from '../../../src/server/api-token-auth.ts';
+import { isApiAuthorized, isApiPathProtected } from '../../../src/server/api-token-auth.ts';
 
 const previousApiToken = process.env.ARRA_API_TOKEN;
 const previousCorsOrigins = process.env.ARRA_CORS_ORIGINS;
@@ -33,6 +33,15 @@ describe('HTTP auth and CORS security contracts', () => {
     } finally {
       restoreEnv();
     }
+  });
+
+  test('open API auth bypasses match exact paths or child paths only', () => {
+    expect(isApiPathProtected('/api/health')).toBe(false);
+    expect(isApiPathProtected('/api/health/deep')).toBe(false);
+    expect(isApiPathProtected('/api/healthz')).toBe(true);
+    expect(isApiPathProtected('/api/docs')).toBe(false);
+    expect(isApiPathProtected('/api/docs/json')).toBe(false);
+    expect(isApiPathProtected('/api/docs-malicious')).toBe(true);
   });
 
   test('private-network preflight does not grant disallowed origins', async () => {


### PR DESCRIPTION
## Summary
- Hardened `ARRA_API_TOKEN` open-path matching so `/api/health` and `/api/docs` bypass auth only on exact paths or child routes.
- Added security/unit coverage for prefix-overmatch cases like `/api/healthz` and `/api/docs-malicious`.
- Added integration coverage proving token-protected server rejects those prefix-overmatch paths while real health routes remain open.

## Validation
- `bun test tests/http/security/auth-and-cors.test.ts`
- `bun test src/integration/`
- `bun test src/server/__tests__/`
- `bunx tsc --noEmit`
- changed file line counts: 31, 65, 81 (all <=250)

## Notes
- No docs or UI changes.