### PR TITLE
test: harden scripts and tools edge cases

### DIFF
--- a/src/scripts/__tests__/indexer-progress.test.ts
+++ b/src/scripts/__tests__/indexer-progress.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'bun:test';
+import { formatIndexProgress, normalizeBatchSize } from '../indexer-progress.ts';
+
+describe('indexer script helpers', () => {
+  it('normalizes invalid batch sizes to the fallback', () => {
+    expect(normalizeBatchSize(undefined, 50)).toBe(50);
+    expect(normalizeBatchSize('0', 50)).toBe(50);
+    expect(normalizeBatchSize('-3', 50)).toBe(50);
+    expect(normalizeBatchSize('not-a-number', 50)).toBe(50);
+    expect(normalizeBatchSize('25', 50)).toBe(25);
+  });
+
+  it('formats progress without Infinity or NaN when elapsed time is tiny', () => {
+    const progress = formatIndexProgress({ indexed: 5, total: 10, startTimeMs: 1_000, nowMs: 1_000 });
+    expect(progress.rate).not.toContain('Infinity');
+    expect(progress.rate).not.toContain('NaN');
+    expect(progress.eta).not.toContain('Infinity');
+    expect(progress.eta).not.toContain('NaN');
+  });
+});

--- a/src/scripts/index-model.ts
+++ b/src/scripts/index-model.ts
@@ -13,6 +13,7 @@ import { createVectorStoreForModel, EMBEDDING_MODELS } from '../vector/factory.t
 import { createDatabase, oracleDocuments } from '../db/index.ts';
 import { count } from 'drizzle-orm';
 import { DB_PATH } from '../config.ts';
+import { formatIndexProgress, normalizeBatchSize } from './indexer-progress.ts';
 
 const modelKey = process.argv[2];
 
@@ -25,8 +26,7 @@ if (!modelKey || !EMBEDDING_MODELS[modelKey]) {
 const preset = EMBEDDING_MODELS[modelKey];
 
 // Keep script batches aligned with OllamaEmbeddings' /api/embed batching default.
-const parsedBatchSize = Number.parseInt(process.env.ORACLE_EMBED_BATCH_SIZE || '50', 10);
-const BATCH_SIZE = Number.isFinite(parsedBatchSize) && parsedBatchSize > 0 ? parsedBatchSize : 50;
+const BATCH_SIZE = normalizeBatchSize(process.env.ORACLE_EMBED_BATCH_SIZE, 50);
 
 async function main() {
   console.log(`=== ${modelKey} Indexer ===`);
@@ -102,10 +102,8 @@ async function main() {
       }
       indexed += docs.length;
 
-      const elapsed = ((Date.now() - startTime) / 1000).toFixed(0);
-      const rate = (indexed / Number(elapsed)).toFixed(1);
-      const eta = ((rows.length - indexed) / Number(rate)).toFixed(0);
-      console.log(`  Batch ${batchNum}/${totalBatches} — ${indexed}/${rows.length} docs — ${rate}/s — ETA ${eta}s`);
+      const progress = formatIndexProgress({ indexed, total: rows.length, startTimeMs: startTime });
+      console.log(`  Batch ${batchNum}/${totalBatches} — ${indexed}/${rows.length} docs — ${progress.rate}/s — ETA ${progress.eta}s`);
     } catch (e) {
       errors++;
       console.error(`  Batch ${batchNum} FAILED:`, e instanceof Error ? e.message : String(e));

--- a/src/scripts/index-qwen3.ts
+++ b/src/scripts/index-qwen3.ts
@@ -11,8 +11,9 @@
 import { createVectorStoreForModel, getEmbeddingModels } from '../vector/factory.ts';
 import { Database } from 'bun:sqlite';
 import { DB_PATH } from '../config.ts';
+import { formatIndexProgress, normalizeBatchSize } from './indexer-progress.ts';
 
-const BATCH_SIZE = 50; // Smaller batches — qwen3 is slower per embedding
+const BATCH_SIZE = normalizeBatchSize(process.env.ORACLE_QWEN3_BATCH_SIZE ?? process.env.ORACLE_EMBED_BATCH_SIZE, 50);
 
 async function main() {
   const preset = getEmbeddingModels().qwen3;
@@ -76,10 +77,8 @@ async function main() {
       await store.addDocuments(docs);
       indexed += docs.length;
 
-      const elapsed = ((Date.now() - startTime) / 1000).toFixed(0);
-      const rate = (indexed / Number(elapsed)).toFixed(1);
-      const eta = ((rows.length - indexed) / Number(rate)).toFixed(0);
-      console.log(`  Batch ${batchNum}/${totalBatches} — ${indexed}/${rows.length} docs — ${rate}/s — ETA ${eta}s`);
+      const progress = formatIndexProgress({ indexed, total: rows.length, startTimeMs: startTime });
+      console.log(`  Batch ${batchNum}/${totalBatches} — ${indexed}/${rows.length} docs — ${progress.rate}/s — ETA ${progress.eta}s`);
     } catch (e) {
       errors++;
       console.error(`  Batch ${batchNum} FAILED:`, e instanceof Error ? e.message : String(e));

--- a/src/scripts/indexer-progress.ts
+++ b/src/scripts/indexer-progress.ts
@@ -1,0 +1,19 @@
+/** Shared helpers for one-off vector indexing scripts. */
+
+export function normalizeBatchSize(raw: string | number | undefined, fallback = 50): number {
+  const value = typeof raw === 'number' ? raw : Number(raw);
+  return Number.isSafeInteger(value) && value > 0 ? value : fallback;
+}
+
+export function formatIndexProgress(input: {
+  indexed: number;
+  total: number;
+  startTimeMs: number;
+  nowMs?: number;
+}): { rate: string; eta: string } {
+  const elapsedMs = Math.max((input.nowMs ?? Date.now()) - input.startTimeMs, 1);
+  const rate = input.indexed / (elapsedMs / 1000);
+  const remaining = Math.max(input.total - input.indexed, 0);
+  const eta = rate > 0 ? Math.ceil(remaining / rate) : 0;
+  return { rate: rate.toFixed(1), eta: String(eta) };
+}

--- a/src/tools/__tests__/backend-tools-unit.test.ts
+++ b/src/tools/__tests__/backend-tools-unit.test.ts
@@ -104,6 +104,26 @@ describe('backend MCP tools unit coverage', () => {
     await expect(handleList(ctx, { type: 'bad' as never, limit: 10, offset: 0 })).rejects.toThrow('Invalid type');
   });
 
+  test('handleList tolerates malformed concept metadata', async () => {
+    const ctx = makeCtx();
+    const now = Date.now();
+    ctx.db.insert(oracleDocuments).values({
+      id: 'doc-bad-concepts',
+      type: 'learning',
+      sourceFile: 'ψ/memory/learnings/bad-concepts.md',
+      concepts: 'not-json, fallback',
+      createdAt: now,
+      updatedAt: now,
+      indexedAt: now,
+    }).run();
+    ctx.sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
+      .run('doc-bad-concepts', 'Malformed concepts should not crash list.', 'not-json fallback');
+
+    const all = parse(await handleList(ctx, { type: 'all', limit: 10, offset: 0 }));
+    const doc = all.documents.find((item: any) => item.id === 'doc-bad-concepts');
+    expect(doc.concepts).toEqual(['not-json', 'fallback']);
+  });
+
   test('handleStats returns counts, FTS health, vector status, and version', async () => {
     const ctx = makeCtx();
 
@@ -183,6 +203,10 @@ describe('backend MCP tools unit coverage', () => {
 
     const second = parse(await handleInbox(ctx, { type: 'all', limit: 1, offset: 1 }));
     expect(second.files[0].filename).toContain('old');
+
+    await expect(handleInbox(ctx, null as never)).rejects.toThrow('inbox input must be an object');
+    await expect(handleInbox(ctx, { type: 'bad' as never, limit: 1, offset: 0 })).rejects.toThrow('Invalid inbox type');
+    await expect(handleInbox(ctx, { type: 'all', limit: 0, offset: 0 })).rejects.toThrow('limit must be between');
   });
 
   test('runSupersede validates inputs and handleSupersede marks the old document', async () => {

--- a/src/tools/inbox.ts
+++ b/src/tools/inbox.ts
@@ -35,7 +35,17 @@ export const inboxToolDef = {
 };
 
 export async function handleInbox(ctx: ToolContext, input: OracleInboxInput): Promise<ToolResponse> {
+  if (input == null || typeof input !== 'object') throw new Error('inbox input must be an object');
   const { limit = 10, offset = 0, type = 'all' } = input;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
+    throw new Error('limit must be between 1 and 100');
+  }
+  if (!Number.isSafeInteger(offset) || offset < 0) {
+    throw new Error('offset must be >= 0');
+  }
+  if (!['all', 'handoff'].includes(type)) {
+    throw new Error('Invalid inbox type: must be one of all, handoff');
+  }
   const inboxDir = path.join(ctx.repoRoot, 'ψ/inbox');
   const results: Array<{ filename: string; path: string; created: string; preview: string; type: string }> = [];
 

--- a/src/tools/list.ts
+++ b/src/tools/list.ts
@@ -36,6 +36,16 @@ export const listToolDef = {
   }
 };
 
+function parseConcepts(raw: unknown): string[] {
+  if (typeof raw !== 'string' || !raw.trim()) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : [];
+  } catch {
+    return raw.split(',').map((item) => item.trim()).filter(Boolean);
+  }
+}
+
 export async function handleList(ctx: ToolContext, input: OracleListInput): Promise<ToolResponse> {
   const { type = 'all', limit = 10, offset = 0 } = input;
 
@@ -88,7 +98,7 @@ export async function handleList(ctx: ToolContext, input: OracleListInput): Prom
     title: row.content.split('\n')[0].substring(0, 80),
     content: row.content.substring(0, 500),
     source_file: row.source_file,
-    concepts: JSON.parse(row.concepts || '[]'),
+    concepts: parseConcepts(row.concepts),
     indexed_at: row.indexed_at,
   }));
 


### PR DESCRIPTION
## Summary

- Added shared script helper coverage for batch-size normalization and finite index progress output.
- Hardened vector indexing scripts against invalid batch env values and same-tick progress math.
- Hardened `oracle_list` against malformed concept metadata and `oracle_inbox` against invalid/null pagination inputs.

## Tests

```bash
tmpdir=$(mktemp -d); ORACLE_DATA_DIR="$tmpdir" ORACLE_DB_PATH="$tmpdir/oracle.db" bun test src/scripts/__tests__ src/tools/__tests__
bunx tsc --noEmit
wc -l src/scripts/indexer-progress.ts src/scripts/__tests__/indexer-progress.test.ts src/scripts/index-model.ts src/scripts/index-qwen3.ts src/tools/__tests__/backend-tools-unit.test.ts src/tools/inbox.ts src/tools/list.ts
```

## Notes

- No UI changes; screenshot not applicable.
- All changed files are ≤250 lines.
