### PR TITLE
test: harden integration auth edges

### DIFF
--- a/src/integration/api-token-auth.test.ts
+++ b/src/integration/api-token-auth.test.ts
@@ -1,22 +1,37 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { mkdtempSync, mkdirSync } from 'fs';
+import net from 'node:net';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
 const ROOT = process.cwd();
 let proc: Bun.Subprocess | undefined;
 
+async function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
 async function waitFor(base: string, timeoutMs = 15000) {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     try { const r = await fetch(`${base}/api/health`); if (r.ok) return; } catch {}
+    if (proc?.exitCode !== null) throw new Error(`Server exited while waiting for ${base}`);
     await new Promise((r) => setTimeout(r, 200));
   }
   throw new Error(`Timed out waiting for ${base}`);
 }
 
 async function startServer(token?: string) {
-  const port = 52000 + Math.floor(Math.random() * 1000);
+  const port = await getFreePort();
   const dataDir = mkdtempSync(join(tmpdir(), 'arra-api-token-data-'));
   const repoRoot = mkdtempSync(join(tmpdir(), 'arra-api-token-repo-'));
   mkdirSync(join(repoRoot, 'ψ'), { recursive: true });
@@ -49,11 +64,23 @@ async function postLearn(base: string, init: RequestInit = {}) {
   });
 }
 
-afterEach(() => { proc?.kill(); proc = undefined; });
+afterEach(async () => {
+  const running = proc;
+  proc = undefined;
+  running?.kill();
+  await running?.exited.catch(() => undefined);
+});
 
 describe('ARRA_API_TOKEN HTTP auth', () => {
   test('unset token keeps /api/learn open', async () => {
     const base = await startServer();
+    const res = await postLearn(base);
+    expect(res.status).not.toBe(401);
+    expect(res.ok).toBe(true);
+  });
+
+  test('whitespace-only token keeps API auth disabled', async () => {
+    const base = await startServer('   ');
     const res = await postLearn(base);
     expect(res.status).not.toBe(401);
     expect(res.ok).toBe(true);
@@ -73,6 +100,18 @@ describe('ARRA_API_TOKEN HTTP auth', () => {
     expect(await denied.json()).toMatchObject({ error: 'api_auth_required' });
 
     const allowed = await postLearn(base, { headers: { authorization: 'Bearer secret' } });
+    expect(allowed.status).toBe(200);
+  });
+
+  test('trims token values and rejects malformed authorization headers', async () => {
+    const base = await startServer('  trimmed-secret  ');
+
+    for (const authorization of ['Basic trimmed-secret', 'Bearer wrong', 'Bearer    ']) {
+      const denied = await postLearn(base, { headers: { authorization } });
+      expect(denied.status).toBe(401);
+    }
+
+    const allowed = await postLearn(base, { headers: { authorization: 'Bearer   trimmed-secret   ' } });
     expect(allowed.status).toBe(200);
   });
 });


### PR DESCRIPTION
## Summary
- Hardened `src/integration/api-token-auth.test.ts` server startup to use an OS-assigned free port instead of a random range.
- Made the test harness await spawned server shutdown between cases to avoid leaked process races.
- Added API token edge coverage for whitespace-only config, trimmed token values, malformed auth schemes, wrong bearer values, and blank bearer values.

## Validation
```bash
bunx tsc --noEmit
bun test --isolate src/integration/
```

## Notes
- Read the project goal gist: install-safe core with plugin-style extensibility.
- No UI changes; screenshot not applicable.
