### PR TITLE
test: harden e2e and smoke coverage

### DIFF
--- a/tests/e2e/api-error-boundary.test.ts
+++ b/tests/e2e/api-error-boundary.test.ts
@@ -1,0 +1,30 @@
+import { afterAll, beforeAll, expect, test } from 'bun:test';
+import { startSmokeServer, type SmokeServer } from '../smoke/_helpers.ts';
+
+let server: SmokeServer;
+
+beforeAll(async () => {
+  server = await startSmokeServer({ name: 'e2e-api-error-boundary' });
+});
+
+afterAll(async () => {
+  await server.stop();
+});
+
+test('live API returns structured 404s and remains healthy afterward', async () => {
+  const missing = await fetch(`${server.baseUrl}/api/e2e-missing-route`);
+  expect(missing.status).toBe(404);
+  expect(missing.headers.get('content-type')).toContain('application/json');
+  expect(await missing.json()).toMatchObject({
+    error: 'Not Found',
+    code: 404,
+    details: {
+      path: '/api/v1/e2e-missing-route',
+      method: 'GET',
+    },
+  });
+
+  const health = await fetch(`${server.baseUrl}/api/health`);
+  expect(health.status).toBe(200);
+  expect(await health.json()).toMatchObject({ status: 'ok' });
+}, 20_000);

--- a/tests/e2e/unified-plugin-schema.test.ts
+++ b/tests/e2e/unified-plugin-schema.test.ts
@@ -88,7 +88,7 @@ test('live backend responses match the unified plugin menu, registry, and vector
   expect(Number.isNaN(Date.parse(plugin?.modified ?? ''))).toBe(false);
   expect(plugin?.server && 'env' in plugin.server).toBe(false);
 
-  const vector = await getJson<SearchBody>('/api/vector/search?q=smoke-orbit&limit=1');
+  const vector = await getJson<SearchBody>('/api/search?q=smoke-orbit&mode=hybrid&limit=1');
   expect(vector).toMatchObject({ query: 'smoke-orbit', total: 1, limit: 1, offset: 0 });
   expect(vector.results).toHaveLength(1);
   expect(vector.results[0]).toMatchObject({

--- a/tests/e2e/vector-search-flow.test.ts
+++ b/tests/e2e/vector-search-flow.test.ts
@@ -29,8 +29,12 @@ afterAll(async () => {
   await server.stop();
 });
 
-test('vector search flow sends a query and returns result records', async () => {
-  const response = await fetch(`${server.baseUrl}/api/vector/search?q=vector-flow&limit=1`, {
+test('vector proxy search flow sends a query and returns result records', async () => {
+  const url = new URL('/api/search', server.baseUrl);
+  url.searchParams.set('q', 'vector-flow');
+  url.searchParams.set('mode', 'hybrid');
+  url.searchParams.set('limit', '1');
+  const response = await fetch(url, {
     headers: { accept: 'application/json' },
   });
   expect(response.status).toBe(200);

--- a/tests/smoke/_helpers.ts
+++ b/tests/smoke/_helpers.ts
@@ -63,6 +63,14 @@ export function createSmokeEnv(name: string): SmokeEnv {
   };
 }
 
+export function removeSmokeEnv(root: string): void {
+  try {
+    rmSync(root, { recursive: true, force: true });
+  } catch {
+    // Temp cleanup must never mask the smoke assertion that failed first.
+  }
+}
+
 export function writeOraclePlugin(home: string): void {
   const dir = join(home, '.oracle', 'plugins', 'smoke-orbit');
   mkdirSync(dir, { recursive: true });
@@ -73,7 +81,7 @@ export function writeOraclePlugin(home: string): void {
       version: '0.1.0',
       entry: './index.ts',
       description: 'Smoke fixture plugin',
-      menu: { label: 'Smoke Orbit', path: '/smoke-orbit', group: 'tools', order: 123 },
+      menu: [{ label: 'Smoke Orbit', path: '/smoke-orbit', group: 'tools', order: 123 }],
       server: { command: 'bun', args: ['index.ts'], healthPath: '/health', autostart: false },
     }, null, 2),
   );
@@ -116,8 +124,11 @@ export async function startSmokeServer(options: {
     proc.kill();
     await proc.exited.catch(() => undefined);
     const logs = `${await stdout.catch(() => '')}\n${await stderr.catch(() => '')}`;
-    await vector?.stop();
-    rmSync(smoke.root, { recursive: true });
+    try {
+      await vector?.stop();
+    } finally {
+      removeSmokeEnv(smoke.root);
+    }
     throw new Error(`${error instanceof Error ? error.message : String(error)}\n${logs}`);
   }
 
@@ -129,13 +140,20 @@ export async function startSmokeServer(options: {
     stderr,
     stop: async () => {
       proc.kill('SIGTERM');
-      const done = await Promise.race([proc.exited.catch(() => null), sleep(1500).then(() => null)]);
-      if (done === null) {
+      const done = await Promise.race([
+        proc.exited.catch(() => null),
+        sleep(1500).then(() => 'timeout' as const),
+      ]);
+      if (done === 'timeout') {
         proc.kill('SIGKILL');
         await proc.exited.catch(() => undefined);
       }
-      await vector?.stop();
-      rmSync(smoke.root, { recursive: true });
+      try {
+        await vector?.stop();
+      } finally {
+        await Promise.all([stdout.catch(() => ''), stderr.catch(() => '')]);
+        removeSmokeEnv(smoke.root);
+      }
     },
   };
 }

--- a/tests/smoke/helpers-hardening.test.ts
+++ b/tests/smoke/helpers-hardening.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from 'bun:test';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { createSmokeEnv, removeSmokeEnv, startVectorStub } from './_helpers.ts';
+
+test('smoke env cleanup is idempotent and leaves no temp tree behind', () => {
+  const smoke = createSmokeEnv('helper-cleanup');
+  expect(existsSync(join(smoke.repoRoot, 'ψ'))).toBe(true);
+  expect(smoke.env.ORACLE_API_TOKEN).toBe('');
+  expect(smoke.env.ORACLE_EMBEDDER).toBe('none');
+
+  removeSmokeEnv(smoke.root);
+  expect(existsSync(smoke.root)).toBe(false);
+  expect(() => removeSmokeEnv(smoke.root)).not.toThrow();
+});
+
+test('vector stub records requests and returns JSON 404s for unknown routes', async () => {
+  const stub = startVectorStub((url) => ({ query: url.searchParams.get('q'), results: [] }));
+  try {
+    const missing = await fetch(`${stub.url}/api/unknown`);
+    expect(missing.status).toBe(404);
+    expect(await missing.json()).toEqual({ error: 'not found' });
+
+    const search = await fetch(`${stub.url}/api/search?q=smoke`);
+    expect(search.status).toBe(200);
+    expect(await search.json()).toEqual({ query: 'smoke', results: [] });
+    expect(stub.requests.map((url) => url.pathname)).toEqual(['/api/unknown', '/api/search']);
+  } finally {
+    await stub.stop();
+  }
+});

--- a/tests/smoke/plugins-api.test.ts
+++ b/tests/smoke/plugins-api.test.ts
@@ -11,7 +11,7 @@ afterAll(async () => {
   await server.stop();
 });
 
-test('live /api/plugins lists a local server-only plugin manifest', async () => {
+test('live /api/plugins lists a local plugin manifest', async () => {
   const res = await fetch(`${server.baseUrl}/api/plugins`);
   expect(res.status).toBe(200);
   const body = await res.json() as { plugins: Array<{ name: string; file: string; server?: unknown }> };


### PR DESCRIPTION
## Summary
- harden smoke helper cleanup/stop paths so failed startup and repeated cleanup do not leak temp state
- add smoke coverage for hermetic env cleanup plus vector stub 404/request tracking
- add live e2e error-boundary coverage and align vector proxy e2e flows with `/api/search`

## Verification
```bash
bun test --isolate tests/smoke/
bun test --isolate tests/e2e/api-error-boundary.test.ts tests/e2e/mcp-tool-call-flow.test.ts tests/e2e/unified-plugin-schema.test.ts tests/e2e/vector-search-flow.test.ts
bunx tsc --noEmit
git diff --check HEAD~1..HEAD
wc -l tests/smoke/_helpers.ts tests/smoke/helpers-hardening.test.ts tests/smoke/plugins-api.test.ts tests/e2e/api-error-boundary.test.ts tests/e2e/unified-plugin-schema.test.ts tests/e2e/vector-search-flow.test.ts
```

## Notes
- No UI changes; no screenshot needed.
- Playwright-only e2e files were not included in Bun scoped run because this repo does not install `@playwright/test`.