### PR TITLE
fix: harden canvas lib edge cases

### DIFF
--- a/packages/canvas-plugins/src/index.ts
+++ b/packages/canvas-plugins/src/index.ts
@@ -80,16 +80,24 @@ export const CANVAS_PLUGINS: readonly CanvasPlugin[] = [...CANVAS_THREE_PLUGINS,
 
 const kinds = new Set<CanvasPluginKind>(['three', 'react']);
 
+function cloneCanvasPlugin(plugin: CanvasPlugin): CanvasPlugin {
+  return { ...plugin, query: { ...plugin.query } };
+}
+
 export function parseCanvasKind(value: unknown): CanvasPluginKind | undefined {
-  return typeof value === 'string' && kinds.has(value as CanvasPluginKind) ? value as CanvasPluginKind : undefined;
+  const kind = typeof value === 'string' ? value.trim().toLowerCase() : '';
+  return kinds.has(kind as CanvasPluginKind) ? kind as CanvasPluginKind : undefined;
 }
 
 export function listCanvasPlugins(kind?: CanvasPluginKind): CanvasPlugin[] {
-  return kind ? CANVAS_PLUGINS.filter((plugin) => plugin.kind === kind) : [...CANVAS_PLUGINS];
+  const plugins = kind ? CANVAS_PLUGINS.filter((plugin) => plugin.kind === kind) : CANVAS_PLUGINS;
+  return plugins.map(cloneCanvasPlugin);
 }
 
 export function findCanvasPlugin(id: string): CanvasPlugin | undefined {
-  return CANVAS_PLUGINS.find((plugin) => plugin.id === id);
+  const pluginId = id.trim();
+  const plugin = CANVAS_PLUGINS.find((candidate) => candidate.id === pluginId);
+  return plugin ? cloneCanvasPlugin(plugin) : undefined;
 }
 
 export function canvasPluginPath(id: string): string {

--- a/src/canvas/__tests__/plugin.test.ts
+++ b/src/canvas/__tests__/plugin.test.ts
@@ -30,4 +30,9 @@ describe('CanvasPlugin contract', () => {
     expect(isCanvasPlugin({ name: 'federation', tier: 'standard', routes: () => null })).toBe(false);
     expect(isCanvasPlugin({ name: 'menu-plugin', file: 'menu-plugin.wasm', size: 42 })).toBe(false);
   });
+
+  test('rejects whitespace-only plugin identifiers and labels', () => {
+    expect(isCanvasPlugin({ id: ' ', label: 'Wave', kind: 'three', mount: () => {} })).toBe(false);
+    expect(isCanvasPlugin({ id: 'wave', label: '\t', kind: 'three', mount: () => {} })).toBe(false);
+  });
 });

--- a/src/canvas/__tests__/registry.test.ts
+++ b/src/canvas/__tests__/registry.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test';
+
+import { canvasPluginDataPath } from '../index.ts';
+import { findCanvasPlugin, listCanvasPlugins } from '../plugins.ts';
+import { parseCanvasKind } from '../registry.ts';
+
+describe('canvas registry edge cases', () => {
+  test('normalizes kind filters while rejecting non-string values', () => {
+    expect(parseCanvasKind(' React ')).toBe('react');
+    expect(parseCanvasKind('THREE')).toBe('three');
+    expect(parseCanvasKind('video')).toBeUndefined();
+    expect(parseCanvasKind(['react'])).toBeUndefined();
+  });
+
+  test('trims plugin id lookup for CLI and URL inputs', () => {
+    expect(findCanvasPlugin(' map ')).toMatchObject({ id: 'map', kind: 'react' });
+    expect(canvasPluginDataPath(' planets ')).toBe('/api/map3d');
+  });
+
+  test('returns defensive copies instead of mutable registry singletons', () => {
+    const first = listCanvasPlugins()[0];
+    if (!first) throw new Error('expected canvas plugin fixture');
+    const original = { id: first.id, label: first.label, query: first.query.plugin };
+
+    first.label = 'Mutated Label';
+    first.query.plugin = 'mutated';
+
+    expect(findCanvasPlugin(original.id)).toMatchObject({
+      id: original.id,
+      label: original.label,
+      query: { plugin: original.query },
+    });
+    expect(listCanvasPlugins()[0]).toMatchObject({
+      id: original.id,
+      label: original.label,
+      query: { plugin: original.query },
+    });
+  });
+});

--- a/src/canvas/__tests__/standalone.test.ts
+++ b/src/canvas/__tests__/standalone.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test';
+
+import { DEFAULT_CANVAS_PORT, parseCanvasServeOptions } from '../standalone.ts';
+
+describe('canvas standalone option parsing', () => {
+  test('rejects flags that are missing values', () => {
+    expect(() => parseCanvasServeOptions(['--port'])).toThrow('--port requires a value');
+    expect(() => parseCanvasServeOptions(['--api-base='])).toThrow('--api-base requires a value');
+    expect(() => parseCanvasServeOptions(['--host'])).toThrow('--host requires a value');
+  });
+
+  test('trims flag values and ignores blank environment defaults', () => {
+    const parsed = parseCanvasServeOptions([
+      '--port',
+      ' 47780 ',
+      '--api-base',
+      ' https://api.example.test/ ',
+      '--host',
+      ' 127.0.0.1 ',
+    ]);
+    expect(parsed).toEqual({
+      port: 47780,
+      apiBase: 'https://api.example.test/',
+      hostname: '127.0.0.1',
+    });
+
+    expect(parseCanvasServeOptions([], {
+      CANVAS_PORT: ' ',
+      CANVAS_HOST: ' ',
+      ORACLE_API_BASE: ' ',
+    })).toEqual({
+      port: DEFAULT_CANVAS_PORT,
+      apiBase: undefined,
+      hostname: '0.0.0.0',
+    });
+  });
+});

--- a/src/canvas/plugin.ts
+++ b/src/canvas/plugin.ts
@@ -52,8 +52,8 @@ export type CanvasPlugin<Props extends Record<string, unknown> = Record<string, 
 export function isCanvasPlugin(value: unknown): value is CanvasPlugin {
   if (!value || typeof value !== 'object') return false;
   const plugin = value as Partial<CanvasPlugin>;
-  if (typeof plugin.id !== 'string' || plugin.id.length === 0) return false;
-  if (typeof plugin.label !== 'string' || plugin.label.length === 0) return false;
+  if (typeof plugin.id !== 'string' || plugin.id.trim().length === 0) return false;
+  if (typeof plugin.label !== 'string' || plugin.label.trim().length === 0) return false;
   if (plugin.kind === 'three') return typeof plugin.mount === 'function';
   if (plugin.kind === 'react') return typeof plugin.renderer === 'function';
   return false;

--- a/src/canvas/standalone.ts
+++ b/src/canvas/standalone.ts
@@ -19,19 +19,31 @@ export function createCanvasStandaloneApp(env: CanvasWorkerEnv = {}) {
 
 function readFlag(args: string[], name: string): string | undefined {
   const eq = args.find((arg) => arg.startsWith(`${name}=`));
-  if (eq) return eq.slice(name.length + 1);
+  if (eq) {
+    const value = eq.slice(name.length + 1).trim();
+    if (!value) throw new Error(`${name} requires a value`);
+    return value;
+  }
   const idx = args.indexOf(name);
-  return idx >= 0 ? args[idx + 1] : undefined;
+  if (idx < 0) return undefined;
+  const value = args[idx + 1]?.trim();
+  if (!value || value.startsWith('--')) throw new Error(`${name} requires a value`);
+  return value;
+}
+
+function readEnv(env: Record<string, string | undefined>, name: string): string | undefined {
+  const value = env[name]?.trim();
+  return value || undefined;
 }
 
 export function parseCanvasServeOptions(args: string[], env: Record<string, string | undefined> = process.env): CanvasServeOptions {
-  const rawPort = readFlag(args, '--port') ?? env.CANVAS_PORT ?? String(DEFAULT_CANVAS_PORT);
+  const rawPort = readFlag(args, '--port') ?? readEnv(env, 'CANVAS_PORT') ?? String(DEFAULT_CANVAS_PORT);
   const port = Number(rawPort);
   if (!Number.isInteger(port) || port < 1 || port > 65535) throw new Error('--port must be 1-65535');
   return {
     port,
-    apiBase: readFlag(args, '--api-base') ?? env.ORACLE_API_BASE,
-    hostname: readFlag(args, '--host') ?? env.CANVAS_HOST ?? '0.0.0.0',
+    apiBase: readFlag(args, '--api-base') ?? readEnv(env, 'ORACLE_API_BASE'),
+    hostname: readFlag(args, '--host') ?? readEnv(env, 'CANVAS_HOST') ?? '0.0.0.0',
   };
 }
 


### PR DESCRIPTION
## Summary
- Hardened canvas plugin contract validation to reject whitespace-only IDs/labels.
- Hardened the shared canvas registry to normalize kind filters, trim plugin ID lookups, and return defensive copies instead of mutable registry singletons.
- Hardened `canvas-serve` option parsing so missing flag values fail clearly and blank env defaults fall back safely.

## Tests
- `bun test src/canvas/__tests__`
- `bun test tests/canvas/phase2.test.ts tests/plugins/canvas-registry.test.ts`
- `bun test tests/http/canvas/full-flow.test.ts tests/workers/canvas-edge-cases.test.ts tests/workers/canvas-worker.test.ts tests/http/canvas-worker.test.ts`
- `bunx tsc --noEmit`

## File size check
- changed files: 161, 60, 57, 38, 39, 37 lines (all <=250)

## Notes
- No docs or UI changes.