### PR TITLE
test(vector): harden lib edge cases

### DIFF
--- a/src/vector/embedding-backends.ts
+++ b/src/vector/embedding-backends.ts
@@ -28,6 +28,9 @@ export interface RemoteHttpEmbeddingOptions {
   timeoutMs?: number;
 }
 
+const DEFAULT_REMOTE_DIMENSIONS = 768;
+const DEFAULT_REMOTE_TIMEOUT_MS = 15_000;
+
 export class RemoteHttpEmbeddings implements EmbeddingProvider {
   readonly name = 'remote';
   dimensions: number;
@@ -41,13 +44,18 @@ export class RemoteHttpEmbeddings implements EmbeddingProvider {
       || process.env.ORACLE_REMOTE_EMBEDDING_URL
       || '';
     this.model = options.model || process.env.ORACLE_EMBEDDING_MODEL;
-    this.dimensions = options.dimensions
-      || Number(process.env.ORACLE_EMBEDDING_DIMENSIONS || 768);
-    this.timeoutMs = options.timeoutMs
-      || Number(process.env.ORACLE_EMBEDDER_TIMEOUT_MS || 15_000);
+    this.dimensions = positiveInteger(
+      options.dimensions ?? Number(process.env.ORACLE_EMBEDDING_DIMENSIONS),
+      DEFAULT_REMOTE_DIMENSIONS,
+    );
+    this.timeoutMs = positiveInteger(
+      options.timeoutMs ?? Number(process.env.ORACLE_EMBEDDER_TIMEOUT_MS),
+      DEFAULT_REMOTE_TIMEOUT_MS,
+    );
   }
 
   async embed(texts: string[], type?: EmbedType): Promise<number[][]> {
+    if (texts.length === 0) return [];
     if (!this.url) {
       throw new EmbeddingUnavailableError('Remote embedder selected but ORACLE_EMBEDDER_URL is unset.');
     }
@@ -72,7 +80,7 @@ export class RemoteHttpEmbeddings implements EmbeddingProvider {
 }
 
 export function parseRemoteEmbeddingResponse(payload: unknown, expected: number): number[][] {
-  const value = payload as {
+  const value = record(payload) as {
     embeddings?: unknown;
     embedding?: unknown;
     data?: Array<{ embedding?: unknown; index?: number }>;
@@ -82,14 +90,15 @@ export function parseRemoteEmbeddingResponse(payload: unknown, expected: number)
   if (Array.isArray(value.embeddings)) vectors = value.embeddings;
   else if (Array.isArray(value.data)) {
     vectors = [...value.data]
-      .sort((a, b) => (a.index ?? 0) - (b.index ?? 0))
-      .map((item) => item.embedding);
+      .sort((a, b) => dataIndex(a) - dataIndex(b))
+      .map((item) => record(item).embedding);
   } else if (Array.isArray(value.embedding)) vectors = [value.embedding];
 
   if (!Array.isArray(vectors)) throw new Error('missing embeddings array');
   const normalized = vectors.map((vector) => {
-    if (!Array.isArray(vector) || !vector.every((n) => typeof n === 'number')) {
-      throw new Error('embedding must be number[]');
+    if (!Array.isArray(vector) || vector.length === 0) throw new Error('embedding must be non-empty number[]');
+    if (!vector.every((n) => typeof n === 'number' && Number.isFinite(n))) {
+      throw new Error('embedding must contain finite numbers');
     }
     return vector as number[];
   });
@@ -98,4 +107,17 @@ export function parseRemoteEmbeddingResponse(payload: unknown, expected: number)
     throw new Error(`embedding count ${normalized.length} does not match input count ${expected}`);
   }
   return normalized;
+}
+
+function positiveInteger(value: number, fallback: number): number {
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
+}
+
+function dataIndex(value: unknown): number {
+  const index = record(value).index;
+  return typeof index === 'number' && Number.isFinite(index) ? index : 0;
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
 }

--- a/src/vector/fanout-query.ts
+++ b/src/vector/fanout-query.ts
@@ -24,11 +24,15 @@ export interface FanoutQueryResponse {
   errors: Record<string, string>;
 }
 
+const DEFAULT_FANOUT_LIMIT = 10;
+const MAX_FANOUT_LIMIT = 100;
+
 export async function queryFanout(options: FanoutQueryOptions): Promise<FanoutQueryResponse> {
+  const limit = normalizeFanoutLimit(options.limit);
   const settled = await Promise.allSettled(options.targets.map(async (target) => {
     const startedAt = Date.now();
     try {
-      const result = await target.store.query(options.text, options.limit, options.where);
+      const result = await target.store.query(options.text, limit, options.where);
       return {
         key: target.key,
         elapsedMs: Math.max(0, Date.now() - startedAt),
@@ -64,7 +68,7 @@ export async function queryFanout(options: FanoutQueryOptions): Promise<FanoutQu
     strategy: options.strategy ?? 'merge',
     backends: options.targets.map((target) => target.key),
     backendStats,
-    results: mergeFanoutResults(results).slice(0, options.limit),
+    results: mergeFanoutResults(results).slice(0, limit),
     errors,
   };
 }
@@ -88,7 +92,7 @@ export function mergeFanoutResults(results: SearchResult[]): SearchResult[] {
 
 function toSearchResults(backend: string, result: VectorQueryResult): SearchResult[] {
   return result.ids.map((id, i) => {
-    const distance = result.distances?.[i] ?? 0;
+    const distance = finiteDistance(result.distances?.[i]);
     return {
       id,
       type: result.metadatas?.[i]?.type ?? 'unknown',
@@ -96,9 +100,22 @@ function toSearchResults(backend: string, result: VectorQueryResult): SearchResu
       source_file: result.metadatas?.[i]?.source_file ?? '',
       concepts: [],
       source: 'vector' as const,
-      score: 1 / (1 + distance / 100),
+      score: scoreFromDistance(distance),
       distance,
       model: backend,
     };
   });
+}
+
+function normalizeFanoutLimit(limit: number): number {
+  if (!Number.isFinite(limit)) return DEFAULT_FANOUT_LIMIT;
+  return Math.min(MAX_FANOUT_LIMIT, Math.max(1, Math.floor(limit)));
+}
+
+function finiteDistance(distance: unknown): number {
+  return typeof distance === 'number' && Number.isFinite(distance) && distance >= 0 ? distance : 0;
+}
+
+function scoreFromDistance(distance: number): number {
+  return Math.max(0, Math.min(1, 1 / (1 + distance / 100)));
 }

--- a/src/vector/query-cache.ts
+++ b/src/vector/query-cache.ts
@@ -19,9 +19,9 @@ export class QueryCache<T> {
   private readonly entries = new Map<string, CacheEntry<T>>();
 
   constructor(options: QueryCacheOptions = {}) {
-    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+    this.ttlMs = positiveNumber(options.ttlMs, DEFAULT_TTL_MS);
     this.now = options.now ?? Date.now;
-    this.maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+    this.maxEntries = nonNegativeInteger(options.maxEntries, DEFAULT_MAX_ENTRIES);
   }
 
   get(key: string): T | undefined {
@@ -40,7 +40,7 @@ export class QueryCache<T> {
     this.entries.set(key, { value, expiresAt: this.now() + this.ttlMs });
     while (this.entries.size > this.maxEntries) {
       const oldest = this.entries.keys().next().value;
-      if (!oldest) break;
+      if (oldest === undefined) break;
       this.entries.delete(oldest);
     }
   }
@@ -55,5 +55,24 @@ export class QueryCache<T> {
 }
 
 export function stableCacheKey(parts: Record<string, unknown>): string {
-  return JSON.stringify(Object.keys(parts).sort().map((key) => [key, parts[key]]));
+  return JSON.stringify(stableValue(parts));
+}
+
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (!isPlainRecord(value)) return value;
+  return Object.keys(value).sort().map((key) => [key, stableValue(value[key])]);
+}
+
+function positiveNumber(value: number | undefined, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function nonNegativeInteger(value: number | undefined, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return fallback;
+  return Math.floor(value);
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype;
 }

--- a/tests/vector/embedding-backends-hardening.test.ts
+++ b/tests/vector/embedding-backends-hardening.test.ts
@@ -1,0 +1,26 @@
+import { expect, mock, test } from 'bun:test';
+import { RemoteHttpEmbeddings, parseRemoteEmbeddingResponse } from '../../src/vector/embedding-backends.ts';
+import { trackEnv } from './helpers.ts';
+
+test('remote embedder parser rejects malformed and non-finite vectors', () => {
+  expect(() => parseRemoteEmbeddingResponse(null, 1)).toThrow('missing embeddings array');
+  expect(() => parseRemoteEmbeddingResponse({ embeddings: [[]] }, 1)).toThrow('non-empty number[]');
+  expect(() => parseRemoteEmbeddingResponse({ embeddings: [[Number.NaN]] }, 1)).toThrow('finite numbers');
+  expect(() => parseRemoteEmbeddingResponse({ embeddings: [[Infinity]] }, 1)).toThrow('finite numbers');
+});
+
+test('remote embedder ignores invalid dimension env and short-circuits empty input', async () => {
+  trackEnv('ORACLE_EMBEDDING_DIMENSIONS', 'not-a-number');
+  trackEnv('ORACLE_EMBEDDER_URL', 'http://127.0.0.1:9/embed');
+  const provider = new RemoteHttpEmbeddings();
+  const originalFetch = globalThis.fetch;
+  const fetchMock = mock(async () => Response.json({ embeddings: [] }));
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  try {
+    expect(provider.dimensions).toBe(768);
+    expect(await provider.embed([])).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tests/vector/fanout-query.test.ts
+++ b/tests/vector/fanout-query.test.ts
@@ -37,3 +37,31 @@ test('fanout query runs targets in parallel and preserves partial errors', async
   expect(response.results).toHaveLength(1);
   expect(response.errors).toEqual({ turbovec: 'backend down' });
 });
+
+
+test('fanout query normalizes bad limits and non-finite distances', async () => {
+  let seenLimit = 0;
+  const response = await queryFanout({
+    text: 'oracle',
+    limit: Number.NaN,
+    targets: [{
+      key: 'lancedb',
+      store: {
+        query: async (_text, limit) => {
+          seenLimit = limit ?? 0;
+          return {
+            ids: ['negative', 'nan'],
+            documents: ['negative body', 'nan body'],
+            distances: [-10, Number.NaN],
+            metadatas: [{}, {}],
+          };
+        },
+      },
+    }],
+  });
+
+  expect(seenLimit).toBe(10);
+  expect(response.results).toHaveLength(2);
+  expect(response.results.every((item) => item.score >= 0 && item.score <= 1)).toBe(true);
+  expect(response.results.map((item) => item.distance)).toEqual([0, 0]);
+});

--- a/tests/vector/query-cache.test.ts
+++ b/tests/vector/query-cache.test.ts
@@ -14,3 +14,19 @@ test('query cache returns entries before ttl and evicts after expiry', () => {
 test('stable cache key is independent of object key order', () => {
   expect(stableCacheKey({ b: 2, a: 1 })).toBe(stableCacheKey({ a: 1, b: 2 }));
 });
+
+
+test('query cache sanitizes invalid sizing options without retaining disabled entries', () => {
+  const cache = new QueryCache<number>({ ttlMs: Number.NaN, maxEntries: 0 });
+  cache.set('a', 1);
+
+  expect(cache.get('a')).toBeUndefined();
+  expect(cache.stats()).toMatchObject({ size: 0, maxEntries: 0, ttlMs: 30_000 });
+});
+
+test('stable cache key recursively sorts nested object keys', () => {
+  const left = stableCacheKey({ where: { b: 2, a: { y: 2, x: 1 } }, q: 'oracle' });
+  const right = stableCacheKey({ q: 'oracle', where: { a: { x: 1, y: 2 }, b: 2 } });
+
+  expect(left).toBe(right);
+});


### PR DESCRIPTION
## Summary
- Harden remote embedding parsing for null payloads, empty vectors, and non-finite values before vectors enter storage/query paths.
- Sanitize remote embedder dimension/timeout configuration and skip HTTP calls for empty embedding batches.
- Normalize fan-out query limits/distances and make query cache sizing + nested cache keys deterministic.

## Tests
```bash
bunx tsc --noEmit
bun test tests/vector/
bun test src/vector/__tests__/*.test.ts
git diff --check origin/alpha...HEAD
```

## Notes
- Vector library only; no route, docs, or UI changes.
- Changed files are all <= 250 lines.
