### PR TITLE
fix: harden menu and process manager edges

### DIFF
--- a/src/menu/__tests__/index.test.ts
+++ b/src/menu/__tests__/index.test.ts
@@ -28,8 +28,8 @@ describe('menu directory loader edge handling', () => {
     writeFileSync(join(dir, '01.json'), JSON.stringify([
       {
         path: ' alpha ', label: ' Alpha ', group: 'bogus', order: 'late', source: 'weird',
-        access: 'auth', studio: 'menu.example.test', scope: 'sub',
-        query: { keep: 'yes', drop: 1 },
+        access: 'auth', parentId: ' root ', studio: ' menu.example.test ', sourceName: ' env ',
+        scope: 'sub', query: { ' keep ': ' yes ', blank: '   ', '': 'no', drop: 1 },
       },
       { path: '/dup', label: 'First', group: 'tools', order: 5, source: 'page' },
       { path: '', label: 'No path', group: 'tools', order: 1 },
@@ -43,7 +43,8 @@ describe('menu directory loader edge handling', () => {
     expect(await loadMenuItemsFromDir(dir)).toEqual([
       {
         path: '/alpha', label: 'Alpha', group: 'tools', order: 999, source: 'page',
-        access: 'auth', studio: 'menu.example.test', scope: 'sub', query: { keep: 'yes' },
+        access: 'auth', parentId: 'root', studio: 'menu.example.test', sourceName: 'env',
+        scope: 'sub', query: { keep: 'yes' },
       },
       { path: '/dup', label: 'Second', group: 'main', order: 2, source: 'api', icon: 'bolt' },
     ]);

--- a/src/menu/index.ts
+++ b/src/menu/index.ts
@@ -33,19 +33,30 @@ function normalizeQuery(value: unknown): Record<string, string> | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
   const query: Record<string, string> = {};
   for (const [key, raw] of Object.entries(value)) {
-    if (typeof raw === 'string') query[key] = raw;
+    const cleanKey = key.trim();
+    const cleanValue = typeof raw === 'string' ? raw.trim() : '';
+    if (cleanKey && cleanValue) query[cleanKey] = cleanValue;
   }
   return Object.keys(query).length ? query : undefined;
 }
 
+function normalizeOptionalText(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
 function setOptionalFields(item: MenuItem, raw: Record<string, unknown>): void {
-  if (typeof raw.icon === 'string' && raw.icon.trim()) item.icon = raw.icon.trim();
-  if (typeof raw.parentId === 'string') item.parentId = raw.parentId;
+  const icon = normalizeOptionalText(raw.icon);
+  const parentId = normalizeOptionalText(raw.parentId);
+  const studio = normalizeOptionalText(raw.studio);
+  const sourceName = normalizeOptionalText(raw.sourceName);
+
+  if (icon) item.icon = icon;
+  if (parentId) item.parentId = parentId;
   else if (raw.parentId === null) item.parentId = null;
-  if (typeof raw.studio === 'string') item.studio = raw.studio;
+  if (studio) item.studio = studio;
   else if (raw.studio === null) item.studio = null;
   if (raw.access === 'public' || raw.access === 'auth') item.access = raw.access;
-  if (typeof raw.sourceName === 'string' && raw.sourceName.trim()) item.sourceName = raw.sourceName.trim();
+  if (sourceName) item.sourceName = sourceName;
   if (typeof raw.hidden === 'boolean') item.hidden = raw.hidden;
   if (typeof raw.added === 'boolean') item.added = raw.added;
   if (typeof raw.scope === 'string' && MENU_SCOPES.includes(raw.scope as MenuScope)) {

--- a/src/process-manager/HealthMonitor.ts
+++ b/src/process-manager/HealthMonitor.ts
@@ -30,6 +30,22 @@ const defaultOptions: Required<HealthCheckOptions> = {
   shutdownPath: '/shutdown'
 };
 
+function normalizePath(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return '/';
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+}
+
+function normalizeOptions(options: HealthCheckOptions = {}): Required<HealthCheckOptions> {
+  const opts = { ...defaultOptions, ...options };
+  return {
+    baseUrl: opts.baseUrl.replace(/\/+$/, ''),
+    healthPath: normalizePath(opts.healthPath),
+    readinessPath: normalizePath(opts.readinessPath),
+    shutdownPath: normalizePath(opts.shutdownPath),
+  };
+}
+
 /**
  * Check if a port is in use by querying the health endpoint
  */
@@ -37,7 +53,7 @@ export async function isPortInUse(
   port: number,
   options: HealthCheckOptions = {}
 ): Promise<boolean> {
-  const opts = { ...defaultOptions, ...options };
+  const opts = normalizeOptions(options);
   try {
     const response = await fetch(`${opts.baseUrl}:${port}${opts.healthPath}`);
     return response.ok;
@@ -57,7 +73,7 @@ export async function waitForHealth(
   timeoutMs: number = 30000,
   options: HealthCheckOptions = {}
 ): Promise<boolean> {
-  const opts = { ...defaultOptions, ...options };
+  const opts = normalizeOptions(options);
   const start = Date.now();
 
   while (Date.now() - start < timeoutMs) {
@@ -99,7 +115,7 @@ export async function httpShutdown(
   port: number,
   options: HealthCheckOptions = {}
 ): Promise<boolean> {
-  const opts = { ...defaultOptions, ...options };
+  const opts = normalizeOptions(options);
 
   try {
     const response = await fetch(`${opts.baseUrl}:${port}${opts.shutdownPath}`, {
@@ -127,7 +143,7 @@ export async function getWorkerStatus(
   port: number,
   options: HealthCheckOptions = {}
 ): Promise<{ running: boolean; healthy: boolean }> {
-  const opts = { ...defaultOptions, ...options };
+  const opts = normalizeOptions(options);
 
   try {
     const healthResponse = await fetch(`${opts.baseUrl}:${port}${opts.healthPath}`);
@@ -150,13 +166,13 @@ export async function getWorkerVersion(
   versionPath: string = '/version',
   options: HealthCheckOptions = {}
 ): Promise<string | null> {
-  const opts = { ...defaultOptions, ...options };
+  const opts = normalizeOptions(options);
 
   try {
-    const response = await fetch(`${opts.baseUrl}:${port}${versionPath}`);
+    const response = await fetch(`${opts.baseUrl}:${port}${normalizePath(versionPath)}`);
     if (!response.ok) return null;
     const data = await response.json() as { version?: unknown };
-    return typeof data.version === 'string' ? data.version : null;
+    return typeof data.version === 'string' && data.version.trim() ? data.version.trim() : null;
   } catch {
     return null;
   }

--- a/src/process-manager/processes.ts
+++ b/src/process-manager/processes.ts
@@ -70,22 +70,26 @@ export async function waitForProcessesExit(pids: number[], timeoutMs: number): P
 }
 
 export async function findProcesses(pattern: string): Promise<number[]> {
-  if (typeof pattern !== 'string' || pattern.length === 0) return [];
+  const search = normalizeProcessPattern(pattern);
+  if (!search) return [];
 
   try {
-    if (process.platform === 'win32') return await findWindowsProcesses(pattern);
-    return await findUnixProcesses(pattern);
+    if (process.platform === 'win32') return await findWindowsProcesses(search);
+    return await findUnixProcesses(search);
   } catch (error) {
-    logger.warn('SYSTEM', 'Failed to find processes', { pattern }, error as Error);
+    logger.warn('SYSTEM', 'Failed to find processes', { pattern: search }, error as Error);
     return [];
   }
 }
 
 export async function killProcesses(pattern: string): Promise<number> {
-  const pids = await findProcesses(pattern);
+  const search = normalizeProcessPattern(pattern);
+  if (!search) return 0;
+
+  const pids = await findProcesses(search);
   if (pids.length === 0) return 0;
 
-  logger.info('SYSTEM', 'Killing processes', { pattern, count: pids.length, pids });
+  logger.info('SYSTEM', 'Killing processes', { pattern: search, count: pids.length, pids });
   let killed = 0;
   for (const pid of pids) {
     try {
@@ -127,6 +131,12 @@ function processIdsFromWmic(stdout: string): number[] {
     .split('\n')
     .map(line => Number.parseInt(line.match(/ProcessId=(\d+)/i)?.[1] ?? '', 10))
     .filter(isPositiveInteger);
+}
+
+function normalizeProcessPattern(pattern: string): string | null {
+  if (typeof pattern !== 'string') return null;
+  const trimmed = pattern.trim();
+  return trimmed.length > 0 ? trimmed : null;
 }
 
 function isPositiveInteger(value: number): boolean {

--- a/tests/process-manager/find-processes-literal-pattern.test.ts
+++ b/tests/process-manager/find-processes-literal-pattern.test.ts
@@ -15,3 +15,7 @@ test('process search treats shell metacharacters as literal text', async () => {
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test('process search ignores blank patterns', async () => {
+  expect(await findProcesses('   ')).toEqual([]);
+});

--- a/tests/process-manager/health-version-invalid.test.ts
+++ b/tests/process-manager/health-version-invalid.test.ts
@@ -9,3 +9,13 @@ test('worker version returns null for malformed version payloads', async () => {
     await server.stop();
   }
 });
+
+test('worker version tolerates normalized base URLs and paths', async () => {
+  const server = Bun.serve({ port: 0, fetch: () => Response.json({ version: ' 1.2.3 ' }) });
+  try {
+    expect(await getWorkerVersion(server.port, 'version', { baseUrl: 'http://127.0.0.1/' }))
+      .toBe('1.2.3');
+  } finally {
+    await server.stop();
+  }
+});


### PR DESCRIPTION
## Summary\n- Normalize menu loader optional text fields and query keys/values, dropping blank query entries.\n- Normalize process-manager health URLs/paths and trim version payloads.\n- Ignore blank process search/kill patterns before calling platform process listing.\n\n## Tests\n- bunx tsc --noEmit\n- bun test src/menu/__tests__ tests/process-manager/\n- git diff --check\n- wc -l changed files (all <=250)