### PR TITLE
docs: add contributor issue update templates

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributor quickstart
+
+This repo ships the Arra Oracle source package. Keep contribution loops small,
+verifiable, and easy for the lead to review.
+
+## 1. Start from alpha
+
+```bash
+git fetch origin
+git switch -c feat/my-slice origin/alpha
+```
+
+Use your own branch/worktree. Do not push to `main`; all PRs target `alpha`.
+
+## 2. Keep the slice narrow
+
+- Change the smallest set of files needed for the issue.
+- Prefer existing helpers and patterns before adding new abstractions.
+- Keep every changed source, test, and doc file at or below 250 lines.
+- Docs belong under `docs/`; do not write project docs into `ψ/`.
+
+## 3. Add tests first when behavior changes
+
+Pick the scoped test path that matches the changed area:
+
+```bash
+bun test tests/http/<cluster>/
+bun test src/tools/__tests__/
+bun test tests/tools/maw-plugin-arra/
+```
+
+For docs-only work, run the nearest relevant smoke test plus typecheck.
+
+## 4. Run required gates
+
+```bash
+bunx tsc --noEmit
+bun test <scoped-test-path>
+wc -l <changed-files>
+git diff --check
+```
+
+If a gate cannot run, explain the exact reason in the PR and issue update.
+
+## 5. Write a reviewable PR
+
+```bash
+gh pr create \
+  --repo Soul-Brews-Studio/arra-oracle-v3 \
+  --base alpha \
+  --head feat/my-slice
+```
+
+PR body checklist:
+
+- `## Summary` with bullets.
+- `## Validation` with exact commands in code blocks.
+- `## Notes` for screenshots, docs-only status, or remaining risk.
+- Link the issue with a normal reference or fully qualified closer when needed.
+
+## 6. Update the GitHub issue
+
+Use [GITHUB-ISSUE-UPDATES.md](./GITHUB-ISSUE-UPDATES.md) for formatted issue
+comments. Every meaningful update should include:
+
+- One status badge.
+- `##` section headers.
+- Bullets for summary/risk/next step.
+- Code blocks for commands, logs, or screenshots links.
+- PR link and validation evidence when ready for review.
+
+## 7. UI screenshot rule
+
+If a user-visible UI changed, capture a screenshot and post it to the issue before
+reporting done. In the PR, link the issue comment that contains the screenshot.
+
+## Done definition
+
+A slice is done when the PR targets `alpha`, tests/typecheck are green, files are
+≤250 lines, issue update is readable, and any UI screenshot is posted.

--- a/docs/GITHUB-ISSUE-UPDATES.md
+++ b/docs/GITHUB-ISSUE-UPDATES.md
@@ -1,0 +1,135 @@
+# GitHub issue update format
+
+Use this format for tracker issues so leads can skim status, evidence, and next
+steps without reading raw logs. Keep comments short, structured, and copy/paste
+friendly.
+
+## Status badges
+
+Use one badge at the top of every substantial issue update:
+
+```md
+![status: starting](https://img.shields.io/badge/status-starting-blue)
+![status: working](https://img.shields.io/badge/status-working-yellow)
+![status: blocked](https://img.shields.io/badge/status-blocked-red)
+![status: ready for review](https://img.shields.io/badge/status-ready_for_review-purple)
+![status: done](https://img.shields.io/badge/status-done-brightgreen)
+```
+
+Pick one status per comment. If the task changes scope, post a new update rather
+than editing old evidence.
+
+## Starting template
+
+````md
+![status: starting](https://img.shields.io/badge/status-starting-blue)
+
+## Starting
+
+- **Task:** #ISSUE short task name
+- **Branch:** `feat/example-c12`
+- **Scope:** `src/routes/example`, `tests/http/example`
+- **Plan:**
+  - Sync `origin/alpha`
+  - Add focused tests before behavior changes
+  - Implement the smallest safe slice
+  - Run scoped tests + `bunx tsc --noEmit`
+
+## Acceptance checks
+
+```bash
+bun test tests/http/example/
+bunx tsc --noEmit
+wc -l <changed-files>
+```
+````
+
+## Progress template
+
+````md
+![status: working](https://img.shields.io/badge/status-working-yellow)
+
+## Progress
+
+- **Done:** concise bullets for completed work
+- **Now:** one current action
+- **Risk:** explicit risk or `None known`
+
+## Evidence so far
+
+```bash
+bun test tests/http/example/
+# current result or short failure summary
+```
+````
+
+## Blocked template
+
+````md
+![status: blocked](https://img.shields.io/badge/status-blocked-red)
+
+## Blocked
+
+- **Blocker:** exact missing permission, dependency, or conflict
+- **Tried:** alternatives already attempted
+- **Impact:** what cannot proceed until resolved
+- **Needed:** one concrete ask
+
+## Evidence
+
+```text
+paste the shortest useful error or command output
+```
+````
+
+## Done / PR template
+
+````md
+![status: ready for review](https://img.shields.io/badge/status-ready_for_review-purple)
+
+## Summary
+
+- Bullet 1: user-visible change
+- Bullet 2: tests/edge cases added
+- Bullet 3: files intentionally not touched
+
+## Validation
+
+```bash
+bun test tests/http/example/
+bunx tsc --noEmit
+wc -l <changed-files>
+```
+
+## PR
+
+- PR: https://github.com/Soul-Brews-Studio/arra-oracle-v3/pull/NNNN
+- Base: `alpha`
+- Commit: `abcdef12`
+- UI screenshot: not applicable / link to issue comment
+````
+
+## Posting with `gh`
+
+Prefer body files for multi-line comments:
+
+````bash
+cat > /tmp/issue-update.md <<'MD'
+![status: ready for review](https://img.shields.io/badge/status-ready_for_review-purple)
+
+## Summary
+
+- Added focused docs update.
+
+## Validation
+
+```bash
+bunx tsc --noEmit
+```
+MD
+
+gh issue comment 123 --repo Soul-Brews-Studio/arra-oracle-v3 --body-file /tmp/issue-update.md
+````
+
+For UI changes, attach a screenshot to the issue and link it from the `## PR` or
+`## Validation` section.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,8 @@ Use this page as the one-hop map for the 2026-06-06/07 alpha docs wave.
 | [issues/memory-systems-ai-agents-1648.md](./issues/memory-systems-ai-agents-1648.md) | Apply the #1648 memory-systems research | provenance-first hybrid memory, confidence, validation, review-gated capture |
 | [MORNING-TAPE-TEMPLATE.md](./MORNING-TAPE-TEMPLATE.md) | Complete Challenge 2 memory bootstrapping | two-minute recovery tape, safety rails, blocked/done reporting |
 | [CONTRIBUTING.md](../CONTRIBUTING.md) | Pick the correct repo/branch for PRs | two-repo rule, source PRs to `arra-oracle-v3:alpha` |
+| [CONTRIBUTING.md](./CONTRIBUTING.md) | Contributor quickstart for source PRs | branch from `alpha`, scoped tests, PR checklist |
+| [GITHUB-ISSUE-UPDATES.md](./GITHUB-ISSUE-UPDATES.md) | Post polished issue updates | `##` headers, bullets, code blocks, status badges |
 | [CHANGELOG.md](../CHANGELOG.md) | Review what changed in the alpha wave | release notes, tracker issues, source PRs |
 | [TONIGHT-SHIPPED.md](./TONIGHT-SHIPPED.md) | Find feature knobs and first commands | MCP modes, plugins, CLI targets, vectors, Docker, federation |
 


### PR DESCRIPTION
## Summary

- Added `docs/GITHUB-ISSUE-UPDATES.md` with copy/paste issue comment templates using `##` headers, bullets, fenced command output, and status badges.
- Added `docs/CONTRIBUTING.md` as a contributor quickstart for branch, scope, test, PR, and issue update expectations.
- Linked both new docs from `docs/README.md`.

## Validation

```bash
bun test tests/tools/maw-plugin-arra/install-smoke.test.ts tests/tools/maw-plugin-arra/dual-surface.test.ts
bunx tsc --noEmit
git diff --check HEAD~1..HEAD
wc -l docs/GITHUB-ISSUE-UPDATES.md docs/CONTRIBUTING.md docs/README.md
```

## Notes

- Docs-only change under `docs/`; no `ψ/` changes.
- No UI changes; screenshot not applicable.
- All changed files are ≤250 lines.
