### PR TITLE
fix: rate limit versioned api paths

### DIFF
--- a/src/middleware/rate-limiter.ts
+++ b/src/middleware/rate-limiter.ts
@@ -1,5 +1,5 @@
 import { Elysia } from 'elysia';
-import { apiRequestPath } from './api-version.ts';
+import { API_VERSION, apiRequestPath } from './api-version.ts';
 import { apiErrorResponse } from './errors.ts';
 
 export type RateLimitRule = {
@@ -31,15 +31,21 @@ function pathMatches(rule: RateLimitRule, pathname: string): boolean {
   return typeof rule.path === 'string' ? pathname === rule.path : rule.path.test(pathname);
 }
 
+function canonicalApiPath(pathname: string): string {
+  const versionedRoot = `/api/${API_VERSION}`;
+  if (pathname === versionedRoot) return '/api';
+  return pathname.startsWith(`${versionedRoot}/`) ? `/api${pathname.slice(versionedRoot.length)}` : pathname;
+}
+
 export function matchingRateLimitRule(request: Request, rules = DEFAULT_RATE_LIMIT_RULES): RateLimitRule | undefined {
-  const pathname = apiRequestPath(request);
+  const pathname = canonicalApiPath(apiRequestPath(request));
   return rules.find((rule) => methodAllowed(rule, request.method) && pathMatches(rule, pathname));
 }
 
 export function clientRateLimitKey(request: Request): string {
   const forwarded = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim();
   const clientIp = request.headers.get('cf-connecting-ip')?.trim() || forwarded || 'local';
-  return `${request.method.toUpperCase()} ${apiRequestPath(request)} ${clientIp}`;
+  return `${request.method.toUpperCase()} ${canonicalApiPath(apiRequestPath(request))} ${clientIp}`;
 }
 
 function secondsUntil(resetAt: number, now: number): number {

--- a/tests/http/rate-limiter/rate-limiter.test.ts
+++ b/tests/http/rate-limiter/rate-limiter.test.ts
@@ -6,6 +6,7 @@ import {
   createRateLimiterMiddleware,
   matchingRateLimitRule,
 } from '../../../src/middleware/rate-limiter.ts';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
 
 function app(now: () => number, key?: (request: Request) => string) {
   return new Elysia()
@@ -65,10 +66,29 @@ describe('rate limiter middleware', () => {
   test('exposes default matching and client key helpers', () => {
     const search = new Request('http://local/api/search', { headers: { 'cf-connecting-ip': '198.51.100.3' } });
     const learn = new Request('http://local/api/learn', { method: 'POST' });
+    const versioned = new Request('http://local/api/v1/search', { headers: { 'x-forwarded-for': '198.51.100.4, 10.0.0.1' } });
 
     expect(DEFAULT_RATE_LIMIT_RULES.map((rule) => rule.limit)).toEqual([30, 10]);
     expect(matchingRateLimitRule(search)?.limit).toBe(30);
+    expect(matchingRateLimitRule(versioned)?.limit).toBe(30);
     expect(matchingRateLimitRule(learn)?.limit).toBe(10);
     expect(clientRateLimitKey(search)).toBe('GET /api/search 198.51.100.3');
+    expect(clientRateLimitKey(versioned)).toBe('GET /api/search 198.51.100.4');
+  });
+
+  test('limits versioned API requests against canonical route buckets', async () => {
+    const local = app(() => 1_000);
+    const fetchVersioned = createApiVersionedFetch((request) => local.handle(request));
+
+    expect((await fetchVersioned(new Request('http://local/api/v1/search'))).status).toBe(200);
+    expect((await fetchVersioned(new Request('http://local/api/search', { redirect: 'manual' }))).status).toBe(308);
+
+    const second = await fetchVersioned(new Request('http://local/api/v1/search'));
+    expect(second.status).toBe(200);
+    expect(second.headers.get('RateLimit-Remaining')).toBe('0');
+
+    const limited = await fetchVersioned(new Request('http://local/api/v1/search'));
+    expect(limited.status).toBe(429);
+    expect(await json(limited)).toMatchObject({ error: 'rate_limit_exceeded' });
   });
 });


### PR DESCRIPTION
## Summary
- Hardened rate limiting so `/api/v1/*` requests normalize to canonical `/api/*` route buckets.
- Kept client rate limit keys canonical across versioned and legacy API paths.
- Added HTTP coverage for versioned `/api/v1/search` exhausting the same configured rate-limit bucket.

## Validation
```bash
bun test tests/http/rate-limiter/ tests/http/versioning/
bunx tsc --noEmit
```

## Notes
- No UI changes; screenshot not applicable.
