### PR TITLE
fix: harden gateway and runtime edge cases

### DIFF
--- a/src/gateway/__tests__/builtin-hooks.test.ts
+++ b/src/gateway/__tests__/builtin-hooks.test.ts
@@ -82,6 +82,30 @@ describe('auth-guard hook', () => {
     expect(res).toBeUndefined();
   });
 
+  it('ignores blank allowlist entries instead of bypassing every path', async () => {
+    const ctx = makeCtx('http://localhost/api/search', {}, {
+      'auth-guard': { header: 'x-oracle-token', allowlist: ['', '   ', '/api/health/'] },
+    });
+    const res = await runRequest(ctx);
+    expect((res as Response).status).toBe(401);
+  });
+
+  it('trims configured header names and falls back from malformed names', async () => {
+    const trimmed = makeCtx(
+      'http://localhost/api/search',
+      { headers: { 'x-oracle-token': 'secret' } },
+      { 'auth-guard': { header: ' x-oracle-token ', expected: 'secret' } },
+    );
+    expect(await runRequest(trimmed)).toBeUndefined();
+
+    const malformed = makeCtx(
+      'http://localhost/api/search',
+      { headers: { 'x-oracle-token': 'secret' } },
+      { 'auth-guard': { header: 'bad header', expected: 'secret' } },
+    );
+    expect(await runRequest(malformed)).toBeUndefined();
+  });
+
   it('defaults to header x-oracle-token when none specified', async () => {
     const ctx = makeCtx('http://localhost/api/search', {}, { 'auth-guard': {} });
     const res = await runRequest(ctx);

--- a/src/gateway/__tests__/config-watch.test.ts
+++ b/src/gateway/__tests__/config-watch.test.ts
@@ -71,6 +71,31 @@ describe('watchGatewayConfig', () => {
     }
   });
 
+  it('keeps last good config on malformed JSON even when VECTOR_URL is set', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-gateway-watch-'));
+    const file = path.join(dir, 'oracle-gateway.json');
+    const cfg: GatewayConfig = {
+      services: { v: { url: 'http://localhost:1', timeout: 1000 } },
+      routes: [{ match: '/api/search', service: 'v', fallback: 'fts5' }],
+    };
+    const calls: Array<GatewayConfig | null> = [];
+    const stop = watchGatewayConfig(dir, (next) => calls.push(next), 'http://vector.local');
+    try {
+      fs.writeFileSync(file, JSON.stringify(cfg));
+      await wait(450);
+      const count = calls.length;
+      expect(count).toBeGreaterThanOrEqual(1);
+
+      fs.writeFileSync(file, '{ not valid json');
+      await wait(450);
+      expect(calls.length).toBe(count);
+      expect(calls[calls.length - 1]?.services.v.url).toBe('http://localhost:1');
+    } finally {
+      stop();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('fires onChange(null) when the config file is deleted', async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-gateway-watch-'));
     const file = path.join(dir, 'oracle-gateway.json');

--- a/src/gateway/__tests__/rate-limit.test.ts
+++ b/src/gateway/__tests__/rate-limit.test.ts
@@ -150,4 +150,15 @@ describe('rate-limit hook', () => {
     expect(await run(a)).toBeUndefined();
     expect((await run(b) as Response).status).toBe(429);
   });
+
+  it('falls back to x-forwarded-for when configured header is blank or malformed', async () => {
+    const opts = { header: 'bad header', tokens_per_window: 60, window_ms: 60_000, burst: 1 };
+    expect(await run(ctxFor('11.11.11.11', opts))).toBeUndefined();
+    expect((await run(ctxFor('11.11.11.11', opts)) as Response).status).toBe(429);
+
+    _resetRateLimitState();
+    const blank = { ...opts, header: ' ' };
+    expect(await run(ctxFor('12.12.12.12', blank))).toBeUndefined();
+    expect((await run(ctxFor('12.12.12.12', blank)) as Response).status).toBe(429);
+  });
 });

--- a/src/gateway/__tests__/tenant-proxy.test.ts
+++ b/src/gateway/__tests__/tenant-proxy.test.ts
@@ -64,4 +64,22 @@ describe('gateway tenant proxying', () => {
       stopServers();
     }
   });
+
+  it('trims service URLs and treats non-positive timeouts as the default', async () => {
+    const captured: CapturedRequest[] = [];
+    const target = startCaptureServer(captured);
+
+    try {
+      const response = await proxyToService(
+        new Request('http://local/api/search?q=trimmed'),
+        { url: ` ${target}/ `, timeout: 0 },
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('X-Gateway-Service')).toBe(target);
+      expect(captured).toEqual([{ path: '/api/search?q=trimmed', tenant: null }]);
+    } finally {
+      stopServers();
+    }
+  });
 });

--- a/src/gateway/config.ts
+++ b/src/gateway/config.ts
@@ -103,7 +103,7 @@ export function watchGatewayConfig(
     // state until the user saves a valid file.
     const fileMissing = !fs.existsSync(configPath);
     const next = loadGatewayConfig(dataDir, vectorUrl);
-    if (next === null && !fileMissing && !vectorUrl) {
+    if (next === null && !fileMissing) {
       // file exists but failed to parse — hold last good
       return;
     }

--- a/src/gateway/hooks/auth-guard.ts
+++ b/src/gateway/hooks/auth-guard.ts
@@ -20,6 +20,22 @@ interface AuthGuardOptions {
   allowlist?: string[];
 }
 
+const DEFAULT_HEADER = 'x-oracle-token';
+const HEADER_NAME = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+
+function configuredHeader(value: unknown): string {
+  const header = typeof value === 'string' ? value.trim() : '';
+  return header && HEADER_NAME.test(header) ? header : DEFAULT_HEADER;
+}
+
+function allowlistRoots(values: unknown): string[] {
+  if (!Array.isArray(values)) return [];
+  return values
+    .filter((value): value is string => typeof value === 'string')
+    .map((value) => value.trim().replace(/\/+$/, ''))
+    .filter(Boolean);
+}
+
 function unauthorized(reason: string): Response {
   return new Response(JSON.stringify({ error: 'unauthorized', reason }), {
     status: 401,
@@ -34,10 +50,10 @@ registerHook({
     const opts =
       (ctx.meta.hook_options as Record<string, AuthGuardOptions> | undefined)?.['auth-guard'] ??
       {};
-    const headerName = opts.header ?? 'x-oracle-token';
+    const headerName = configuredHeader(opts.header);
 
     const pathname = new URL(ctx.request.url).pathname;
-    for (const prefix of opts.allowlist ?? []) {
+    for (const prefix of allowlistRoots(opts.allowlist)) {
       if (pathname === prefix || pathname.startsWith(prefix + '/')) return;
     }
 

--- a/src/gateway/hooks/rate-limit.ts
+++ b/src/gateway/hooks/rate-limit.ts
@@ -37,6 +37,7 @@ const DEFAULTS = {
   tokens_per_window: 60,
   window_ms: 60_000,
 } as const;
+const HEADER_NAME = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
 
 // Module-level state — per-process bucket map keyed by client identifier.
 const buckets = new Map<string, Bucket>();
@@ -52,6 +53,11 @@ function extractKey(request: Request, header: string): string {
   const raw = request.headers.get(header);
   if (!raw) return 'anonymous';
   return raw.split(',')[0].trim() || 'anonymous';
+}
+
+function configuredHeader(value: unknown): string {
+  const header = typeof value === 'string' ? value.trim() : '';
+  return header && HEADER_NAME.test(header) ? header : DEFAULTS.header;
 }
 
 function tenantBucketKey(request: Request, clientKey: string): string {
@@ -74,7 +80,7 @@ registerHook({
     const opts =
       (ctx.meta.hook_options as Record<string, RateLimitOptions> | undefined)?.['rate-limit'] ??
       {};
-    const headerName = opts.header ?? DEFAULTS.header;
+    const headerName = configuredHeader(opts.header);
     const tokensPerWindow = opts.tokens_per_window ?? DEFAULTS.tokens_per_window;
     const windowMs = opts.window_ms ?? DEFAULTS.window_ms;
     const burst = opts.burst ?? tokensPerWindow;

--- a/src/gateway/proxy.ts
+++ b/src/gateway/proxy.ts
@@ -10,14 +10,18 @@ import { cloneRetryableBody, retryableRequestBody, retryUpstreamRequest } from '
 
 const DEFAULT_TIMEOUT_MS = 15_000;
 
+function safeTimeoutMs(value: number | undefined): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : DEFAULT_TIMEOUT_MS;
+}
+
 export async function proxyToService(
   request: Request,
   service: ServiceConfig,
 ): Promise<Response> {
   const incomingUrl = new URL(request.url);
-  const targetBase = service.url.replace(/\/+$/, '');
+  const targetBase = service.url.trim().replace(/\/+$/, '');
   const targetUrl = `${targetBase}${incomingUrl.pathname}${incomingUrl.search}`;
-  const timeoutMs = service.timeout ?? DEFAULT_TIMEOUT_MS;
+  const timeoutMs = safeTimeoutMs(service.timeout);
 
   try {
     const headers = new Headers(request.headers);
@@ -37,7 +41,7 @@ export async function proxyToService(
 
     // Stream the response back, preserving status and headers
     const responseHeaders = new Headers(res.headers);
-    responseHeaders.set('X-Gateway-Service', service.url);
+    responseHeaders.set('X-Gateway-Service', targetBase);
 
     return new Response(res.body, {
       status: res.status,

--- a/src/runtime/sandbox-label.ts
+++ b/src/runtime/sandbox-label.ts
@@ -13,7 +13,15 @@ const labels: Record<string, SandboxLabel> = {
   prod: 'prod',
 };
 
+function envValue(env: unknown): string | undefined {
+  if (typeof env === 'string') return env;
+  if (!env || typeof env !== 'object') return undefined;
+  const value = (env as Record<string, unknown>).ARRA_ENV;
+  return typeof value === 'string' ? value : undefined;
+}
+
 export function sandboxLabel(env: unknown = process.env.ARRA_ENV): SandboxLabel {
-  if (typeof env !== 'string') return 'dev';
-  return labels[env.trim().toLowerCase()] ?? 'dev';
+  const value = envValue(env);
+  if (!value) return 'dev';
+  return labels[value.trim().toLowerCase()] ?? 'dev';
 }

--- a/tests/runtime/sandbox-label.test.ts
+++ b/tests/runtime/sandbox-label.test.ts
@@ -24,4 +24,10 @@ describe('runtime sandbox label', () => {
       expect(sandboxLabel(value)).toBe('dev');
     }
   });
+
+  test('accepts process-env-shaped objects without trusting unrelated keys', () => {
+    expect(sandboxLabel({ ARRA_ENV: ' production ' })).toBe('prod');
+    expect(sandboxLabel({ ARRA_ENV: 'stage' })).toBe('staging');
+    expect(sandboxLabel({ NODE_ENV: 'production' })).toBe('dev');
+  });
 });


### PR DESCRIPTION
## Summary
- Hardened gateway config hot-reload so malformed JSON keeps the last good config even when `VECTOR_URL` synthesis is active.
- Hardened gateway hooks/proxy edge cases: blank allowlist entries no longer bypass auth, malformed hook header names fall back safely, service URLs are trimmed, and non-positive proxy timeouts use the default.
- Hardened runtime sandbox labels to accept process-env-shaped inputs while ignoring unrelated env keys.

## Tests
- `bun test src/gateway/__tests__`
- `bun test tests/runtime/sandbox-label.test.ts`
- `bunx tsc --noEmit`

## File size check
- changed files: 163, 69, 64, 120, 27, 136, 139, 164, 85, 33 lines (all <=250)

## Notes
- No docs or UI changes.