### PR TITLE
docs: update architecture and plugin authoring

### DIFF
--- a/docs/PLUGIN-GUIDE.md
+++ b/docs/PLUGIN-GUIDE.md
@@ -1,202 +1,157 @@
-# Unified Plugin Guide
+# Plugin authoring guide
 
-The unified plugin system lets one `plugin.json` publish server, API, MCP, menu,
-and CLI surfaces. The loader lives in `src/plugins/unified-loader.ts`; the shared
-manifest contract lives in `src/plugins/unified-manifest.ts`.
+Arra plugins should feel installable like editor plugins: publish one folder (or
+artifact) with a `plugin.json`, let the installer place it in a plugin home, and
+let Arra discover it at boot.
 
-## Where plugins live
+## Target install UX
 
-By default the unified loader scans these directories, in order:
+Users should not clone Arra core to add a plugin. The target flow is one command
+that fetches a plugin repo or artifact, writes it to a plugin home, then lets Arra
+discover it on the next server/CLI start:
 
-1. `~/.arra/plugins/<plugin-name>/plugin.json`
-2. `~/.oracle/plugins/<plugin-name>/plugin.json`
+```bash
+arra plugin install github.com/owner/oracle-plugin --dry-run
+arra plugin install github.com/owner/oracle-plugin
+arra plugin list
+```
 
-Each plugin directory must contain a manifest and the entry module named by
-`entry`. The loader skips invalid manifests, disabled manifests, and duplicate
-plugin names already seen earlier in the scan.
+Today, use that installer for packaged artifact plugins that declare `wasm` and
+optional `build`. Use copy/symlink install for unified TypeScript plugin folders
+until source installs consume unified manifests directly.
 
-## Minimal shape
+During development, copy or symlink the plugin directory into a scan path:
+
+```bash
+mkdir -p ~/.oracle/plugins
+ln -s "$PWD" ~/.oracle/plugins/my-plugin
+arra-oracle-v3 serve --port 47778
+arra --help
+```
+
+The unified runtime scans `~/.arra/plugins/<name>/plugin.json` and
+`~/.oracle/plugins/<name>/plugin.json`.
+
+## Minimal unified plugin
 
 ```json
 {
-  "name": "smoke-loader",
+  "name": "hello-oracle",
   "version": "1.0.0",
   "entry": "./index.ts",
-  "description": "Example unified plugin",
+  "description": "Hello plugin for Arra Oracle",
   "apiRoutes": [
-    { "path": "/api/smoke-loader", "methods": ["GET"], "handler": "api" }
+    { "path": "/api/plugins/hello-oracle", "methods": ["GET"], "handler": "api" }
+  ],
+  "menu": [
+    { "label": "Hello Oracle", "path": "/plugins/hello-oracle", "group": "tools" }
+  ],
+  "cliSubcommands": [
+    { "command": "hello-oracle", "help": "Say hello", "handler": "cli" }
   ],
   "mcpTools": [
     {
-      "name": "smoke_loader_tool",
-      "description": "Smoke tool",
-      "inputSchema": {},
-      "handler": "tool"
+      "name": "oracle_hello",
+      "description": "Return a hello payload",
+      "inputSchema": { "type": "object", "properties": {} },
+      "handler": "tool",
+      "readOnly": true
     }
-  ],
-  "menu": [
-    { "label": "Smoke Loader", "path": "/smoke-loader", "group": "tools" }
-  ],
-  "cliSubcommands": [
-    { "command": "smoke-loader", "help": "Run smoke loader", "handler": "cli" }
   ]
 }
 ```
 
-Validation rules:
+## Entry module
 
-- `name` must match `/^[a-z0-9-]+$/`.
-- `version` must begin with semver (`1.2.3`, prerelease suffix allowed).
-- `entry` is a module path relative to the plugin directory.
-- `apiRoutes.path`, `proxy.path`, `menu.path`, and `server.healthPath` must be absolute.
-- `apiRoutes.methods` and `proxy.methods` accept `GET`, `POST`, `PUT`, `PATCH`,
-  `DELETE`, `OPTIONS`, `HEAD`, or `ALL`.
-- `mcpTools.name` must match `/^[a-z][a-z0-9_]*$/`.
-- `server.args` must be strings; `server.env` must be a string map.
-
-Legacy aliases still normalize into the unified shape:
-
-- `cli: { command, help }` becomes one `cliSubcommands` entry.
-- `api: { path, methods }` becomes one `apiRoutes` entry.
-
-## Entry module authoring
-
-Export one function per named handler, or use `default` when a surface omits
-`handler`.
+Export one function per handler named in the manifest. Return a plain response or
+an invoke-style result.
 
 ```ts
 export function api(ctx) {
-  return { body: { ok: true, query: ctx.query } };
+  return { ok: true, body: { plugin: ctx.plugin, query: ctx.query } };
+}
+
+export function cli(ctx) {
+  const name = ctx.args[0] ?? 'operator';
+  return { ok: true, output: `hello ${name}` };
 }
 
 export function tool(ctx) {
-  return { ok: true, body: ctx.body };
-}
-
-export function cli(ctx) {
-  const name = ctx.args[0] ?? 'world';
-  ctx.writer?.(`hello ${name}`);
-  return { ok: true, output: `done ${name}` };
+  return { ok: true, body: { message: 'hello from MCP', args: ctx.body } };
 }
 ```
 
-API and MCP handlers are invoked by `src/plugins/unified-loader.ts` with a context
-containing `source`, `plugin`, and surface-specific fields such as `request`,
-`params`, `query`, `body`, or `args`. API handlers may return a `Response`, a
-plain body, or an invoke result:
+Context includes `source`, `plugin`, and surface-specific fields such as
+`request`, `query`, `body`, `params`, `args`, and `writer`.
 
-```ts
-{ ok: true, body: { ... } }
-{ ok: true, output: "text" }
-{ ok: false, status: 400, error: "bad input" }
+## Manifest rules
+
+- `name` must match `/^[a-z0-9-]+$/`.
+- `version` must start with semver, e.g. `1.0.0` or `1.0.0-alpha.1`.
+- `entry` is relative to the plugin directory and must stay inside it.
+- Route, proxy, menu, and health paths must start with `/`.
+- HTTP methods may be `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`,
+  `HEAD`, or `ALL`.
+- MCP tool names must match `/^[a-z][a-z0-9_]*$/`.
+- `server.args`, `server.env`, and `depends` must be string arrays/maps as
+  documented by the schema.
+
+## Surfaces checklist
+
+| Surface | Add when | Smoke check |
+| --- | --- | --- |
+| `apiRoutes[]` | The plugin exposes HTTP behavior | `curl /api/plugins/<name>` |
+| `mcpTools[]` | Agents need a tool | `curl /api/mcp/tools` or MCP tools/list |
+| `menu[]` | Studio should show navigation | `curl /api/menu` |
+| `cliSubcommands[]` | Operators need terminal access | `arra <command> --help` |
+| `proxy[]` | Arra should front an external service | hit the proxy path |
+| `server` | The plugin owns a child process | hit `/api/plugins/<name>/server/*` |
+| `exportFormats[]` | Export app needs a new format | list export formats |
+
+## Packaging for easy install
+
+A plugin repo should keep the installable files at its root:
+
+```text
+plugin.json
+index.ts            # or dist/index.js
+README.md
+LICENSE
 ```
 
-CLI handlers are invoked by `cli/src/plugin/invoke.ts` with `ctx.args` and
-`ctx.writer`. Return `{ ok: true, output }` or `{ ok: false, error }`. If
-`handler` is absent on a CLI subcommand, the CLI calls the default export.
-
-## Surfaces
-
-### `apiRoutes`
-
-Creates Elysia routes directly in the main server. Each route declares a path,
-optional methods, and optional handler. The main server appends these to its API
-module list after core route clusters.
-
-### `mcpTools`
-
-Adds tool definitions to the MCP registry. The server-side runtime can dispatch
-with `runtime.callMcpTool(name, args)`, and `/api/mcp/tools` exposes core and
-plugin tool definitions to frontends.
-
-### `proxy`
-
-Creates proxy routes with `createUnifiedProxyRoute`. Use this when the plugin has
-an external service URL in an environment variable and the Oracle server should
-forward matching API calls.
-
-### `server`
-
-Declares a child process service:
+If you ship a prebuilt artifact for the current `arra plugin install` artifact
+path, include a manifest with artifact metadata:
 
 ```json
 {
-  "server": {
-    "command": "bun",
-    "args": ["index.ts"],
-    "healthPath": "/health",
-    "autostart": false,
-    "env": { "EXAMPLE_MODE": "smoke" }
-  }
+  "name": "hello-oracle",
+  "version": "1.0.0",
+  "wasm": "hello-oracle.wasm",
+  "build": "bun run build"
 }
 ```
 
-The unified server runtime allocates a port, injects `ARRA_PLUGIN_NAME`,
-`ARRA_PLUGIN_PORT`, and `PORT`, then proxies through
-`/api/plugins/<name>/server/*`. `autostart: false` delays startup until a server
-route is requested.
+Use `--artifact <url> --manifest <url>` for direct artifact installs. Use
+`--force` only when replacing an existing local install.
 
-### `menu`
-
-Adds navigation items to `/api/menu` as `source: "plugin"`. The boot seeder also
-persists plugin menu rows into `menu_items` with `source='plugin'` unless a
-non-plugin row already owns the same path.
-
-Groups default to `tools`; accepted groups are `main`, `tools`, and `hidden`.
-Menu items are navigation only: pair a menu item with an `apiRoutes`, `proxy`, or
-`server` path when clicking it should open a plugin feature.
-
-### `cliSubcommands`
-
-Adds commands to `arra-cli`. The CLI loader scans unified plugin directories
-before legacy CLI plugins, registers `cliSubcommands`, and resolves by command
-name. Dispatch uses `InvokeContext`:
-
-```ts
-export function cli(ctx) {
-  const [subcommand, ...rest] = ctx.args;
-  ctx.writer?.('optional progress');
-  return { ok: true, output: JSON.stringify({ subcommand, rest }) };
-}
-```
-
-`help` appears in `arra-cli --help` and `arra-cli -h <command>`. The command
-handler receives only arguments after the command name.
-
-## Registration flow
-
-Server boot:
-
-1. `src/server.ts` calls `loadUnifiedPlugins()`.
-2. The loader scans plugin dirs and normalizes each manifest.
-3. `runtime.routes` is mounted with the core Elysia modules.
-4. `runtime.servers` is passed to `startUnifiedPluginServers()`.
-5. `runtime.menu` is persisted via `seedUnifiedPluginMenuItems()` and merged into
-   `/api/menu` through `menuItemsFromUnifiedPlugins()`.
-6. `runtime.mcpTools` is passed to `createMcpRoutes()` for `/api/mcp/tools`.
-
-CLI boot:
-
-1. `cli/src/cli.ts` calls `discoverPlugins()`.
-2. `cli/src/plugin/loader.ts` imports unified manifests first, then legacy user
-   and bundled CLI plugins.
-3. `registerPlugins()` records commands from legacy `cli` and unified
-   `cliSubcommands`.
-4. `resolveCommand()` selects the command; `invokePluginCommand()` imports the
-   entry module and calls the requested handler.
-
-## Quick local check
+## Local validation
 
 ```bash
-mkdir -p ~/.oracle/plugins/smoke-loader
-cp plugin.json index.ts ~/.oracle/plugins/smoke-loader/
-bun src/server.ts
-arra-cli --help
-arra-cli smoke-loader test
-curl http://localhost:47778/api/menu
-curl http://localhost:47778/api/mcp/tools
+bun test tests/plugins/unified-manifest-surfaces.test.ts
+bun test tests/cli/plugin/loader-discovers-unified-plugin.test.ts
+bunx tsc --noEmit
 ```
 
-For tests, prefer isolated plugin directories and call
-`loadUnifiedPlugins({ dirs: [fixtureDir] })` so local user plugins do not affect
-the result.
+For fixture-driven tests, call `loadUnifiedPlugins({ dirs: [fixtureDir] })` so a
+user's local plugins do not affect the result.
+
+## Good plugin README
+
+Include:
+
+- Install command and required Arra version/tag.
+- Surfaces provided: CLI, API, MCP, menu, proxy, server, export.
+- Config/env variables and defaults.
+- Smoke checks in fenced code blocks.
+- Uninstall steps: remove `~/.oracle/plugins/<name>` or use plugin remove when
+  available.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,8 @@ Use this page as the one-hop map for the 2026-06-06/07 alpha docs wave.
 | --- | --- | --- |
 | [INSTALL.md](./INSTALL.md) | Easy install through global Bun, plugins, Docker, or Docker MCP Toolkit | `bun add -g github:...#vX.Y.Z`, `arra plugin install`, GHCR |
 | [QUICKSTART.md](./QUICKSTART.md) | Five-minute first run after install | `arra-oracle-v3 serve`, `arra health`, `arra learn`, MCP config |
+| [architecture.md](./architecture.md) | Understand the installable runtime architecture | HTTP, MCP, CLI, plugins, storage |
+| [PLUGIN-GUIDE.md](./PLUGIN-GUIDE.md) | Author installable Oracle plugins | `plugin.json`, unified surfaces, plugin install smoke checks |
 | [DEPLOY-DIGITALOCEAN.md](./DEPLOY-DIGITALOCEAN.md) | Deploy a small public Arra HTTP node on DigitalOcean | `doctl`, firewall allowlist, `ARRA_API_TOKEN`, seed, teardown |
 | [FEDERATION.md](./FEDERATION.md) | Pair and secure Arra peers | `/info`, `/api/identity`, `/api/peer/feed`, `/api/peer/search`, TOFU pins |
 | [HUGINN-MUNINN.md](./HUGINN-MUNINN.md) | Understand the capture/recall naming split | Muninn recall, Huginn capture, no `huginn_*` aliases |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,229 +1,110 @@
-# Arra Oracle v3 Architecture
+# Arra Oracle architecture overview
 
-> Knowledge system MCP server with hybrid search, consultation logging, and learning capabilities.
+Arra Oracle is the Oracle family's installable memory/search layer. One core
+runtime exposes the same capabilities through HTTP, MCP stdio, the `arra` CLI,
+Studio UI, unified plugins, and Docker/MCP Toolkit packaging.
 
-## Overview
+## Design goals
 
-Arra Oracle v3 indexes philosophy from markdown files and provides:
-- **Semantic + keyword search** (ChromaDB + FTS5)
-- **Decision guidance** via principles and patterns
-- **Learning capture** from sessions
-- **HTTP API** for web interfaces
+- **Easy install:** `bun add -g github:Soul-Brews-Studio/arra-oracle-v3#vX.Y.Z`
+  should be enough to run the server and CLI.
+- **One capability core:** HTTP routes, MCP tools, CLI commands, and plugins reuse
+  shared handlers instead of duplicating business logic.
+- **Local-first data:** SQLite + FTS5 remain available even when vector backends
+  or remote services are disabled.
+- **Plugin-shaped extension:** external features should install as plugin folders
+  or artifacts, not require editing core source.
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│                      ORACLE v2 SYSTEM                       │
-├─────────────────────────────────────────────────────────────┤
-│                                                             │
-│  ┌─────────────┐    ┌─────────────┐    ┌─────────────┐     │
-│  │   Claude    │    │  HTTP API   │    │  Dashboard  │     │
-│  │  (via MCP)  │    │  (REST)     │    │  (Web UI)   │     │
-│  └──────┬──────┘    └──────┬──────┘    └──────┬──────┘     │
-│         │                  │                  │             │
-│         └──────────────────┼──────────────────┘             │
-│                            │                                │
-│                    ┌───────▼───────┐                        │
-│                    │  Oracle Core  │                        │
-│                    │   (index.ts)  │                        │
-│                    └───────┬───────┘                        │
-│                            │                                │
-│         ┌──────────────────┼──────────────────┐             │
-│         │                  │                  │             │
-│  ┌──────▼──────┐   ┌───────▼───────┐  ┌───────▼───────┐    │
-│  │   SQLite    │   │   ChromaDB    │  │   Markdown    │    │
-│  │  (FTS5)     │   │   (vectors)   │  │   (source)    │    │
-│  └─────────────┘   └───────────────┘  └───────────────┘    │
-│                                                             │
-└─────────────────────────────────────────────────────────────┘
+## Runtime map
+
+```text
+Users, agents, Studio, maw-js, MCP clients
+        │
+        ├─ Server bin: bin/arra.ts (`arra-oracle-v3 serve|mcp`)
+        ├─ Operator CLI: cli/src/cli.ts (`arra ...`)
+        ├─ HTTP API: src/server.ts + src/routes/*
+        ├─ MCP stdio: src/index.ts + src/tools/*
+        └─ Plugin runtime: src/plugins/unified-loader.ts
+                  │
+        Core services and storage
+        ├─ src/tools/       MCP/CLI-ready tool handlers
+        ├─ src/vector/      vector adapters and config
+        ├─ src/indexer/     document parsing and backfill jobs
+        ├─ src/gateway/     federation/proxy guardrails
+        ├─ src/middleware/  auth, tenant, logging, negotiation
+        └─ SQLite + FTS5 + vector stores + vault markdown
 ```
 
-## Components
+## Request paths
 
-### MCP Server (`src/index.ts`)
+| Surface | Entrypoint | Primary contracts |
+| --- | --- | --- |
+| HTTP | `src/server.ts` | Elysia route clusters under `/api/*`, `/health` |
+| MCP embedded | `src/index.ts` | `oracle_search`, `oracle_learn`, `oracle_read`, plugin tools |
+| MCP proxy | `ORACLE_HTTP_URL` | Stdio MCP forwards covered writes/reads to HTTP |
+| CLI | `cli/src/cli.ts` | Built-ins plus plugin commands, target config, install helpers |
+| Studio | `frontend/` | React pages over HTTP routes and plugin/menu registries |
+| Docker | `Dockerfile`, `catalog/` | HTTP image, stdio image, Docker MCP Toolkit catalog |
 
-Exposes tools to Claude via Model Context Protocol:
+## Data flow
 
-| Tool | Purpose | Logs To |
-|------|---------|---------|
-| `oracle_search` | Hybrid keyword + semantic search | (none yet) |
-| `oracle_consult` | Get guidance on decisions | `consult_log` |
-| `oracle_reflect` | Random principle/learning | - |
-| `oracle_learn` | Add new pattern | writes file + indexes |
-| `oracle_list` | Browse documents | - |
-| `oracle_stats` | Database statistics | - |
-| `oracle_concepts` | List concept tags | - |
-
-### HTTP Server (`src/server.ts`)
-
-REST API on port 47778:
-
-| Endpoint | Method | Purpose |
-|----------|--------|---------|
-| `/health` | GET | Health check |
-| `/search` | GET | Keyword search |
-| `/list` | GET | Browse documents |
-| `/consult` | GET | Get guidance |
-| `/reflect` | GET | Random wisdom |
-| `/stats` | GET | Database stats |
-| `/graph` | GET | Knowledge graph |
-| `/learn` | POST | Add pattern |
-| `/file` | GET | Fetch file content |
-
-### Indexer (`src/indexer.ts`)
-
-Populates database from markdown files:
-
-```
-ψ/memory/resonance/*.md    → principles (split by ### + bullets)
-ψ/memory/learnings/*.md    → learnings (split by ## headers)
-ψ/memory/retrospectives/   → retrospectives (split by ## headers)
+```text
+markdown/import/API write
+        │
+        ▼
+parse/index document chunks
+        │
+        ├─ oracle_documents metadata table
+        ├─ oracle_fts keyword index
+        └─ vector collection when enabled
+        │
+        ▼
+search/list/read/export through HTTP, MCP, CLI, or plugin routes
 ```
 
-## Database Schema
+`oracle_documents` is the tenant-scoped source of truth for indexed metadata.
+FTS5 provides the always-on fallback search path. Vector adapters are optional
+and configured per model/collection.
 
-### `oracle_documents` - Metadata Index
+## Plugin architecture
 
-```sql
-CREATE TABLE oracle_documents (
-  id TEXT PRIMARY KEY,
-  type TEXT NOT NULL,           -- principle, learning, pattern, retro
-  source_file TEXT NOT NULL,
-  concepts TEXT DEFAULT '[]',   -- JSON array
-  created_at INTEGER,
-  updated_at INTEGER,
-  indexed_at INTEGER
-);
+Unified plugins are directories with `plugin.json` plus an entry module. The
+runtime scans `~/.arra/plugins` and `~/.oracle/plugins`, normalizes manifests,
+and registers declared surfaces:
+
+| Manifest key | Runtime effect |
+| --- | --- |
+| `apiRoutes[]` | Adds Elysia routes to the main HTTP server |
+| `mcpTools[]` | Adds tool definitions and dispatchable plugin MCP calls |
+| `menu[]` | Adds Studio/menu navigation rows |
+| `cliSubcommands[]` | Adds `arra <command>` operator commands |
+| `proxy[]` | Adds guarded proxy routes to external services |
+| `server` | Starts or lazily proxies a plugin-owned child service |
+| `exportFormats[]` | Adds app export formats |
+
+Easy plugin install should place the same folder shape under a plugin home, so
+installers only need to fetch, build/copy artifacts, and write `plugin.json`.
+See [PLUGIN-GUIDE.md](./PLUGIN-GUIDE.md) for authoring and packaging.
+
+## Security and isolation
+
+- Protected HTTP writes use bearer tokens when `ARRA_API_TOKEN` is set.
+- Shared HTTP deployments can require `ARRA_TENANT_TOKENS` and scope reads/writes
+  by `tenant_id`.
+- MCP stdio mode sends logs to stderr with `ORACLE_LOG_TARGET=stderr`.
+- File reads resolve real paths and stay inside allowed repo/ghq/vault roots.
+- Plugin paths and entry modules are containment-checked before import.
+
+## Operational checks
+
+```bash
+arra-oracle-v3 serve --port 47778
+curl -sf http://localhost:47778/api/health
+arra health
+bunx tsc --noEmit
+bun test tests/http/health/
+bun test tests/plugins/
 ```
 
-### `oracle_fts` - Full-Text Search
-
-```sql
-CREATE VIRTUAL TABLE oracle_fts USING fts5(
-  id UNINDEXED,
-  content,
-  concepts
-);
-```
-
-### `consult_log` - Consultation History
-
-```sql
-CREATE TABLE consult_log (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  decision TEXT NOT NULL,
-  context TEXT,
-  principles_found INTEGER NOT NULL,
-  patterns_found INTEGER NOT NULL,
-  guidance TEXT NOT NULL,
-  created_at INTEGER NOT NULL
-);
-```
-
-### `indexing_status` - Progress Tracking
-
-```sql
-CREATE TABLE indexing_status (
-  id INTEGER PRIMARY KEY CHECK (id = 1),
-  is_indexing INTEGER NOT NULL DEFAULT 0,
-  progress_current INTEGER DEFAULT 0,
-  progress_total INTEGER DEFAULT 0,
-  started_at INTEGER,
-  completed_at INTEGER,
-  error TEXT
-);
-```
-
-## Hybrid Search Algorithm
-
-1. **Sanitize query** - remove FTS5 special chars (`? * + - ( ) ^ ~ " ' : .`)
-2. **Run FTS5 search** - keyword matching on SQLite
-3. **Run vector search** - semantic similarity via ChromaDB
-4. **Normalize scores:**
-   - FTS5: `e^(-0.3 * |rank|)` (exponential decay)
-   - Vector: `1 - distance` (convert to similarity)
-5. **Merge results** - deduplicate by document ID
-6. **Hybrid scoring** - 50% FTS + 50% vector, 10% boost if in both
-7. **Return** with metadata (search time, source breakdown)
-
-### Graceful Degradation
-
-- If ChromaDB unavailable → FTS5-only with warning
-- If query sanitization empties query → return original (will error)
-
-## Logging
-
-### Current Logging
-
-| Event | Destination | Data |
-|-------|-------------|------|
-| Consultations | `consult_log` table | decision, context, counts, guidance |
-| ChromaDB status | stderr | connection state |
-| Indexing progress | `indexing_status` table | progress, errors |
-| FTS5 errors | stderr | query, error message |
-
-### Logging Gaps
-
-- No search query tracking (`oracle_search` calls)
-- No learning history (when/what was learned)
-- No document access tracking (which docs referenced)
-- No HTTP endpoint access logs
-
-## Configuration
-
-### Environment Variables
-
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `ORACLE_REPO_ROOT` | `process.cwd()` | Knowledge base location (your ψ/ repo) |
-| `PORT` | `47778` | HTTP server port |
-
-### MCP Configuration
-
-```json
-{
-  "mcpServers": {
-    "arra-oracle-v2": {
-      "command": "node",
-      "args": ["/path/to/arra-oracle-v2/dist/index.js"],
-      "env": {
-        "ORACLE_REPO_ROOT": "/path/to/knowledge-base"
-      }
-    }
-  }
-}
-```
-
-## Security
-
-### Path Traversal Protection
-
-`/file` endpoint uses `fs.realpathSync()` to resolve symlinks and verify paths stay within `REPO_ROOT`.
-
-### Query Sanitization
-
-FTS5 special characters are stripped to prevent SQL injection via FTS5 syntax errors.
-
-## Version History
-
-| Version | Changes |
-|---------|---------|
-| 0.1.0 | Initial MCP server with FTS5 |
-| 0.2.0 | ChromaDB hybrid search, oracle_stats, oracle_concepts, FTS5 bug fix |
-
-## Graph API Performance
-
-The `/api/graph` endpoint intentionally excludes retrospectives to prevent O(n²) explosion:
-
-| Scenario | Nodes | Link Comparisons |
-|----------|-------|-----------------|
-| Current (no retros) | 459 | ~210k |
-| With all retros | 4443 | ~20M |
-
-**Current design:**
-- All principles (~359)
-- Random 100 learnings
-- NO retros (3984 would kill performance)
-
-**If retros needed:** Sample top 50 by recency, never include all.
-
-See: `src/server/handlers.ts:handleGraph()`
+For install steps, start with [INSTALL.md](./INSTALL.md) and
+[QUICKSTART.md](./QUICKSTART.md).


### PR DESCRIPTION
## Summary

- Rewrote `docs/architecture.md` as a current installable-runtime overview covering HTTP, MCP, CLI, Studio, plugins, data flow, storage, security, and easy-install goals.
- Reworked `docs/PLUGIN-GUIDE.md` into a plugin authoring guide for installable Oracle plugins, including manifest rules, surfaces, packaging, and smoke checks.
- Added both guides to `docs/README.md` start-here links.

## Validation

```bash
bun test src/plugins/__tests__/unified-manifest.test.ts tests/plugins/unified-manifest-surfaces.test.ts tests/cli/plugin/loader-discovers-unified-plugin.test.ts tests/tools/maw-plugin-arra/install-smoke.test.ts
bunx tsc --noEmit
git diff --check HEAD~1..HEAD
wc -l docs/architecture.md docs/PLUGIN-GUIDE.md docs/README.md
```

## Notes

- Docs-only change under `docs/`; no `ψ/` changes.
- No UI changes; screenshot not applicable.
- All changed files are ≤250 lines.
