### PR TITLE
test: harden integration and mcp-in coverage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN bun install --production --frozen-lockfile \
  && rm -rf node_modules/@lancedb/lancedb-*-musl
 
 FROM deps AS builder
+COPY tsconfig.json ./
+COPY packages ./packages
 COPY src ./src
 RUN bun build src/server.ts src/index.ts --target bun --outdir dist
 

--- a/tests/integration/docker-compose.test.ts
+++ b/tests/integration/docker-compose.test.ts
@@ -84,7 +84,7 @@ test('docker compose prod stack serves versioned health and menu as non-root', a
     const health = await jsonGet(`${baseUrl}/api/v1/health`);
     expect(health.response.status).toBe(200);
     expect(health.response.headers.get('X-API-Version')).toBe('v1');
-    expect(health.body).toMatchObject({ status: 'ok', server: 'arra-oracle-v3', dbStatus: 'ok' });
+    expect(health.body).toMatchObject({ status: 'ok', server: 'arra-oracle-v3', dbStatus: 'connected' });
 
     const menu = await jsonGet(`${baseUrl}/api/v1/menu`);
     expect(menu.response.status).toBe(200);

--- a/tests/integration/middleware-stack.test.ts
+++ b/tests/integration/middleware-stack.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { Elysia, t } from 'elysia';
+import { createApiVersionedFetch } from '../../src/middleware/api-version.ts';
 import { createApiKeyAuthMiddleware } from '../../src/middleware/auth.ts';
 import { createContentTypeMiddleware } from '../../src/middleware/content-type.ts';
 import { createCorrelationMiddleware } from '../../src/middleware/correlation.ts';
@@ -108,5 +109,26 @@ describe('middleware stack integration', () => {
     expect(thirdLimited.status).toBe(429);
     expect(thirdLimited.headers.get('Retry-After')).toBe('60');
     expect(await thirdLimited.json()).toMatchObject({ error: 'rate_limit_exceeded' });
+  });
+
+  test('keeps auth and rate-limit behavior intact after /api/v1 rewrite', async () => {
+    const app = createStackedApp();
+    const fetchVersioned = createApiVersionedFetch((request) => app.handle(request));
+
+    const unauthenticated = await fetchVersioned(jsonRequest('/api/v1/fail', {
+      headers: { authorization: '' },
+    }));
+    expect(unauthenticated.status).toBe(401);
+    expect(unauthenticated.headers.get('Access-Control-Allow-Origin')).toBe('https://studio.example');
+
+    const headers = { 'x-forwarded-for': 'versioned-limited-client' };
+    const first = await fetchVersioned(jsonRequest('/api/v1/fail', { headers }));
+    const second = await fetchVersioned(jsonRequest('/api/v1/fail', { headers }));
+    const third = await fetchVersioned(jsonRequest('/api/v1/fail', { headers }));
+
+    expect(first.status).toBe(400);
+    expect(second.status).toBe(400);
+    expect(third.status).toBe(429);
+    expect(await third.json()).toMatchObject({ error: 'rate_limit_exceeded' });
   });
 });

--- a/tests/tools/mcp-in-call-success.test.ts
+++ b/tests/tools/mcp-in-call-success.test.ts
@@ -11,3 +11,22 @@ test('MCP-IN call handler returns external tool results as JSON text', async () 
     fixture.cleanup();
   }
 });
+
+test('MCP-IN call handler forwards environment overrides to the external server', async () => {
+  const fixture = writeExternalMcpServer();
+  try {
+    const response = await handleMcpCall({
+      command: 'bun',
+      args: [fixture.script],
+      env: { MCP_TEST_SUFFIX: '-from-env' },
+      toolName: 'echo',
+      toolArgs: { message: 'bridge' },
+    });
+    const payload = JSON.parse(response.content[0].text) as { content: Array<{ text: string }> };
+
+    expect(response.isError).toBeUndefined();
+    expect(payload.content[0].text).toBe('bridge-from-env');
+  } finally {
+    fixture.cleanup();
+  }
+});


### PR DESCRIPTION
## Summary
- Added middleware-stack integration coverage for `/api/v1` rewrite preserving auth, CORS, and canonical rate-limit behavior.
- Added MCP-IN coverage proving environment overrides are forwarded to external stdio MCP servers.
- Hardened docker-compose integration coverage by making the production Docker build include TS path-mapped package sources and aligning the health assertion with the current `dbStatus: "connected"` contract.

## Validation
```bash
bun test tests/integration tests/tools
bunx tsc --noEmit
```

## Notes
- No UI changes; screenshot not applicable.
- Changed files are all <= 250 lines.
