### PR TITLE
fix: harden trace and huginn edge cases

### DIFF
--- a/src/huginn/__tests__/capture.test.ts
+++ b/src/huginn/__tests__/capture.test.ts
@@ -116,4 +116,16 @@ describe('Huginn session capture', () => {
     const result = await captureSession({ transcriptPath: transcript, learn: () => { throw new Error('should not learn'); } });
     expect(result.skipped).toBe('empty');
   });
+
+  it('treats directory transcript paths as missing instead of throwing', async () => {
+    const dir = tmpdir();
+    const mined = mineSessionJsonl(dir);
+    const result = await captureSession({
+      transcriptPath: dir,
+      learn: () => { throw new Error('should not learn'); },
+    });
+
+    expect(mined).toEqual({ moments: [], hash: '', sourceText: '' });
+    expect(result.skipped).toBe('missing-transcript');
+  });
 });

--- a/src/huginn/__tests__/sweep.test.ts
+++ b/src/huginn/__tests__/sweep.test.ts
@@ -123,4 +123,32 @@ describe('Huginn periodic sweep', () => {
     expect(second.markdownIndexed).toBe(0);
     expect(indexed).toHaveLength(1);
   });
+
+  it('normalizes invalid limits and ignores future sweep watermarks', async () => {
+    const dir = tmpdir();
+    const sessions = path.join(dir, 'sessions');
+    const statePath = path.join(dir, 'state.json');
+    fs.writeFileSync(statePath, JSON.stringify({ captures: {}, sweeps: { lastSweepAtMs: 999_999 } }));
+    writeJsonl(path.join(sessions, 'one.jsonl'), [
+      { message: { role: 'assistant', content: 'Decision: invalid Huginn sweep limits should fall back safely.' } },
+    ], 2_000);
+    writeJsonl(path.join(sessions, 'two.jsonl'), [
+      { message: { role: 'assistant', content: 'Learned: future sweep watermarks should not suppress backfill.' } },
+    ], 2_100);
+
+    const result = await sweepHuginn({
+      sessionDirs: [sessions],
+      statePath,
+      now: 3_000,
+      lookbackHours: Number.NaN,
+      maxFiles: 0,
+      learn: () => ({ id: 'learn_normalized' }),
+      indexMarkdown: () => {},
+    });
+
+    expect(result.watermarkBeforeMs).toBeUndefined();
+    expect(result.scanned).toBe(2);
+    expect(result.learned).toBe(2);
+    expect(result.capped).toBe(false);
+  });
 });

--- a/src/huginn/capture.ts
+++ b/src/huginn/capture.ts
@@ -75,6 +75,10 @@ function readState(statePath: string): CaptureState {
   }
 }
 
+function isReadableFile(filePath: string): boolean {
+  try { return fs.statSync(filePath).isFile(); } catch { return false; }
+}
+
 function writeState(statePath: string, state: CaptureState): void {
   fs.mkdirSync(path.dirname(statePath), { recursive: true });
   const tmp = `${statePath}.${process.pid}.${Date.now()}.tmp`;
@@ -133,8 +137,9 @@ function normalizeMaxItems(value: number): number {
 }
 
 export function mineSessionJsonl(transcriptPath: string, maxItems = 12): { moments: HuginnMoment[]; hash: string; sourceText: string } {
-  if (!fs.existsSync(transcriptPath)) return { moments: [], hash: '', sourceText: '' };
-  const raw = fs.readFileSync(transcriptPath, 'utf-8');
+  if (!isReadableFile(transcriptPath)) return { moments: [], hash: '', sourceText: '' };
+  let raw = '';
+  try { raw = fs.readFileSync(transcriptPath, 'utf-8'); } catch { return { moments: [], hash: '', sourceText: '' }; }
   const selected: HuginnMoment[] = [];
   const seen = new Set<string>();
   const limit = normalizeMaxItems(maxItems);
@@ -176,7 +181,7 @@ export function formatLearning(sessionId: string, moments: HuginnMoment[], trans
 
 export async function captureSession(options: HuginnCaptureOptions): Promise<HuginnCaptureResult> {
   const sessionId = stableSessionId(options.transcriptPath, options.sessionId);
-  if (!fs.existsSync(options.transcriptPath)) return { ok: true, skipped: 'missing-transcript', sessionId, moments: [] };
+  if (!isReadableFile(options.transcriptPath)) return { ok: true, skipped: 'missing-transcript', sessionId, moments: [] };
 
   const mined = mineSessionJsonl(options.transcriptPath, options.maxItems ?? 12);
   if (mined.moments.length === 0) return { ok: true, skipped: 'empty', sessionId, hash: mined.hash, moments: [] };

--- a/src/huginn/sweep.ts
+++ b/src/huginn/sweep.ts
@@ -97,6 +97,20 @@ function sourceFileForMarkdown(repoRoot: string, filePath: string): string {
   return path.relative(repoRoot, filePath).split(path.sep).join('/');
 }
 
+function positiveNumber(value: unknown, fallback: number): number {
+  const number = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(number) && number > 0 ? number : fallback;
+}
+
+function positiveInteger(value: unknown, fallback: number): number {
+  return Math.max(1, Math.floor(positiveNumber(value, fallback)));
+}
+
+function validWatermark(value: unknown, now: number): number | undefined {
+  const number = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(number) && number >= 0 && number <= now ? number : undefined;
+}
+
 function safeSessionIdFromFile(filePath: string): string {
   return path.basename(filePath).replace(/\.jsonl$/i, '');
 }
@@ -142,13 +156,14 @@ async function markdownIndexed(sourceFile: string): Promise<boolean> {
 }
 
 export async function sweepHuginn(options: HuginnSweepOptions = {}): Promise<HuginnSweepSummary> {
-  const now = options.now ?? Date.now();
+  const now = Number.isFinite(options.now) ? options.now! : Date.now();
   const statePath = options.statePath ?? defaultStatePath();
   const state = readSweepState(statePath);
-  const lookbackMs = (options.lookbackHours ?? Number(process.env.ARRA_HUGINN_SWEEP_LOOKBACK_HOURS || 24)) * 60 * 60 * 1000;
-  const watermarkBeforeMs = state.sweeps?.lastSweepAtMs;
+  const lookbackHours = positiveNumber(options.lookbackHours ?? process.env.ARRA_HUGINN_SWEEP_LOOKBACK_HOURS ?? 24, 24);
+  const lookbackMs = lookbackHours * 60 * 60 * 1000;
+  const watermarkBeforeMs = validWatermark(state.sweeps?.lastSweepAtMs, now);
   const sinceMs = watermarkBeforeMs ?? now - lookbackMs;
-  const maxFiles = options.maxFiles ?? Number(process.env.ARRA_HUGINN_SWEEP_MAX_FILES || 200);
+  const maxFiles = positiveInteger(options.maxFiles ?? process.env.ARRA_HUGINN_SWEEP_MAX_FILES ?? 200, 200);
   const files: HuginnSweepSummary['files'] = [];
   const summary: HuginnSweepSummary = {
     ok: true,
@@ -191,7 +206,6 @@ export async function sweepHuginn(options: HuginnSweepOptions = {}): Promise<Hug
   const repoRoot = options.repoRoot ?? REPO_ROOT;
   const learningsDir = path.join(repoRoot, 'ψ', 'memory', 'learnings');
   const markdowns: string[] = [];
-  walkRecentFiles(learningsDir, sinceMs, [], 0); // no-op guard for missing dir parity
   if (fs.existsSync(learningsDir)) {
     const collectMd = (dir: string) => {
       for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {

--- a/src/trace/__tests__/chain-cycle.test.ts
+++ b/src/trace/__tests__/chain-cycle.test.ts
@@ -13,12 +13,15 @@ process.env.ORACLE_DB_PATH = dbPath;
 
 const dbMod = await import('../../db/index.ts');
 dbMod.resetDefaultDatabaseForTests(dbPath);
-const { getTraceChain, getTraceLinkedChain } = await import('../handler.ts');
+const { getTrace, getTraceChain, getTraceLinkedChain, linkTraces } = await import('../handler.ts');
 
 const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 const cycle = `trace-cycle-${stamp}`;
 const linkedA = `trace-linked-a-${stamp}`;
 const linkedB = `trace-linked-b-${stamp}`;
+const linearA = `trace-linear-a-${stamp}`;
+const linearB = `trace-linear-b-${stamp}`;
+const brokenPrev = `trace-broken-prev-${stamp}`;
 const now = Date.now();
 
 dbMod.db.insert(dbMod.traceLog).values([
@@ -45,6 +48,27 @@ dbMod.db.insert(dbMod.traceLog).values([
     nextTraceId: linkedA,
     createdAt: now + 2,
     updatedAt: now + 2,
+  },
+  {
+    traceId: linearA,
+    query: 'linear linked chain a',
+    nextTraceId: linearB,
+    createdAt: now + 3,
+    updatedAt: now + 3,
+  },
+  {
+    traceId: linearB,
+    query: 'linear linked chain b',
+    prevTraceId: linearA,
+    createdAt: now + 4,
+    updatedAt: now + 4,
+  },
+  {
+    traceId: brokenPrev,
+    query: 'linked chain with missing previous pointer',
+    prevTraceId: `missing-${stamp}`,
+    createdAt: now + 5,
+    updatedAt: now + 5,
   },
 ]).run();
 
@@ -74,5 +98,21 @@ describe('trace chain cycle hardening', () => {
 
     expect(result.chain.map((trace) => trace.traceId).sort()).toEqual([linkedA, linkedB].sort());
     expect(new Set(result.chain.map((trace) => trace.traceId)).size).toBe(2);
+  });
+
+  test('linked-chain traversal keeps the requested trace when prev link is missing', () => {
+    const result = getTraceLinkedChain(brokenPrev);
+
+    expect(result.chain.map((trace) => trace.traceId)).toEqual([brokenPrev]);
+    expect(result.position).toBe(0);
+  });
+
+  test('linking traces refuses to close a forward cycle', () => {
+    const result = linkTraces(linearB, linearA);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('create a cycle');
+    expect(getTrace(linearA)?.prevTraceId).toBeNull();
+    expect(getTrace(linearB)?.nextTraceId).toBeNull();
   });
 });

--- a/src/trace/__tests__/storage-edge.test.ts
+++ b/src/trace/__tests__/storage-edge.test.ts
@@ -58,10 +58,27 @@ describe('trace storage edge hardening', () => {
     expect(trace?.parentTraceId).toBeNull();
   });
 
-  test('list pagination clamps unsafe values for direct handler callers', () => {
-    const result = listTraces({ query: stamp, limit: -10, offset: Number.NaN });
+  test('runtime non-array dig point fields do not inflate persisted counts', () => {
+    const result = createTrace({
+      query: `non array dig points ${stamp}`,
+      foundFiles: 'src/trace/store.ts' as any,
+      foundCommits: { length: 2 } as any,
+      foundIssues: 'issue-1' as any,
+      foundRetrospectives: 'retro.md' as any,
+      foundResonance: 'resonance.md' as any,
+    });
+    const trace = getTrace(result.traceId);
 
-    expect(result.traces.length).toBeLessThanOrEqual(100);
+    expect(result.summary).toEqual({ fileCount: 0, commitCount: 0, issueCount: 0, totalDigPoints: 0 });
+    expect(trace?.foundFiles).toEqual([]);
+    expect(trace?.foundCommits).toEqual([]);
+    expect(trace?.foundIssues).toEqual([]);
+  });
+
+  test('list pagination clamps unsafe values for direct handler callers', () => {
+    const result = listTraces({ query: `orphan parent ${stamp}`, limit: -10, offset: Number.NaN });
+
+    expect(result.traces).toHaveLength(1);
     expect(result.hasMore).toBe(false);
   });
 });

--- a/src/trace/chain.ts
+++ b/src/trace/chain.ts
@@ -69,7 +69,9 @@ export function getTraceLinkedChain(traceId: string): { chain: TraceRecord[]; po
 
   while (current?.prevTraceId && !backwardVisited.has(current.prevTraceId)) {
     backwardVisited.add(current.traceId);
-    current = getTrace(current.prevTraceId);
+    const previous = getTrace(current.prevTraceId);
+    if (!previous) break;
+    current = previous;
   }
 
   const forwardVisited = new Set<string>();

--- a/src/trace/links.ts
+++ b/src/trace/links.ts
@@ -10,6 +10,17 @@ type LinkResult = {
   nextTrace?: TraceRecord;
 };
 
+function hasForwardPath(fromTraceId: string, toTraceId: string): boolean {
+  const seen = new Set<string>();
+  let current: TraceRecord | null = getTrace(fromTraceId);
+  while (current && !seen.has(current.traceId)) {
+    if (current.traceId === toTraceId) return true;
+    seen.add(current.traceId);
+    current = current.nextTraceId ? getTrace(current.nextTraceId) : null;
+  }
+  return false;
+}
+
 export function linkTraces(prevTraceId: string, nextTraceId: string): LinkResult {
   if (!prevTraceId || typeof prevTraceId !== 'string') {
     return { success: false, message: `prevTraceId is required (got: ${prevTraceId === undefined ? 'undefined' : typeof prevTraceId})` };
@@ -25,6 +36,7 @@ export function linkTraces(prevTraceId: string, nextTraceId: string): LinkResult
   if (!nextTrace) return { success: false, message: `Next trace not found: ${nextTraceId}` };
   if (prevTrace.nextTraceId) return { success: false, message: `Trace ${prevTraceId} already has a next link` };
   if (nextTrace.prevTraceId) return { success: false, message: `Trace ${nextTraceId} already has a prev link` };
+  if (hasForwardPath(nextTraceId, prevTraceId)) return { success: false, message: `Cannot link ${prevTraceId} → ${nextTraceId}: it would create a cycle` };
 
   const now = Date.now();
   db.update(traceLog).set({ nextTraceId, updatedAt: now }).where(eq(traceLog.traceId, prevTraceId)).run();

--- a/src/trace/store.ts
+++ b/src/trace/store.ts
@@ -11,18 +11,22 @@ function normalizedQuery(input: CreateTraceInput): string {
   return query;
 }
 
+function arrayCount(value: unknown): number {
+  return Array.isArray(value) ? value.length : 0;
+}
+
 export function createTrace(input: CreateTraceInput): CreateTraceResult {
   const traceId = randomUUID();
   const now = Date.now();
   const query = normalizedQuery(input);
   const processedLearnings = processLearnings(input.foundLearnings, input.project || null, query);
   const fileCount =
-    (input.foundFiles?.length || 0) +
-    (input.foundRetrospectives?.length || 0) +
+    arrayCount(input.foundFiles) +
+    arrayCount(input.foundRetrospectives) +
     processedLearnings.length +
-    (input.foundResonance?.length || 0);
-  const commitCount = input.foundCommits?.length || 0;
-  const issueCount = input.foundIssues?.length || 0;
+    arrayCount(input.foundResonance);
+  const commitCount = arrayCount(input.foundCommits);
+  const issueCount = arrayCount(input.foundIssues);
 
   const parent = input.parentTraceId ? db
     .select({ depth: traceLog.depth })


### PR DESCRIPTION
## Summary
- Harden trace lib edge cases: runtime non-array dig-point inputs no longer inflate counts, broken linked-chain prev pointers keep the requested trace visible, and trace linking rejects forward cycles.
- Harden Huginn edge cases: directory/unreadable transcript paths skip safely, invalid sweep numeric limits fall back defensively, and future persisted watermarks no longer suppress backfill.

## Validation
```bash
bun test src/trace/__tests__/ src/huginn/__tests__/
bunx tsc --noEmit
wc -l src/trace/store.ts src/trace/chain.ts src/trace/links.ts src/trace/__tests__/chain-cycle.test.ts src/trace/__tests__/storage-edge.test.ts src/huginn/capture.ts src/huginn/sweep.ts src/huginn/__tests__/capture.test.ts src/huginn/__tests__/sweep.test.ts
```

## Notes
- PR branch is based on `alpha` with a clean single commit (`ded8d648`).
- No docs, ψ, or UI changes; no screenshot needed.
