### PR TITLE
test(vector): harden factory proxy adapters

### DIFF
--- a/src/vector/__tests__/adapter-methods-unit.test.ts
+++ b/src/vector/__tests__/adapter-methods-unit.test.ts
@@ -58,6 +58,24 @@ describe('QdrantAdapter unit behavior without network', () => {
     expect(upsertPayload.payload.points[0].vector).toEqual([0.3, 0.2, 0.1]);
   });
 
+  test('addDocuments rejects mismatched embedder output before upsert', async () => {
+    const shortEmbedder: EmbeddingProvider = {
+      ...embedder,
+      async embed() { return [[0.1, 0.2, 0.3]]; },
+    };
+    const adapter = new QdrantAdapter('unit_collection', shortEmbedder) as any;
+    let upserted = false;
+    adapter.client = {
+      async upsert() { upserted = true; },
+    };
+
+    await expect(adapter.addDocuments([
+      { id: 'doc-a', document: 'alpha', metadata: {} },
+      { id: 'doc-b', document: 'beta', metadata: {} },
+    ])).rejects.toThrow('Qdrant embedder returned 1 vectors for 2 documents');
+    expect(upserted).toBe(false);
+  });
+
   test('query maps Qdrant similarity scores to distances and metadata', async () => {
     const adapter = new QdrantAdapter('unit_collection', embedder) as any;
     let searchRequest: any;

--- a/src/vector/adapters/proxy.ts
+++ b/src/vector/adapters/proxy.ts
@@ -61,6 +61,7 @@ export class ProxyVectorAdapter implements VectorStoreAdapter {
   }
 
   async addDocuments(docs: VectorDocument[]): Promise<void> {
+    if (docs.length === 0) return;
     const body: VectorProxyAddRequest = { documents: docs };
     await this.post(VECTOR_PROXY_ROUTES.add, body);
   }
@@ -71,7 +72,7 @@ export class ProxyVectorAdapter implements VectorStoreAdapter {
   }
 
   async query(text: string, limit: number = 10, where?: Record<string, any>): Promise<VectorQueryResult> {
-    const body: VectorProxyQueryRequest = { text, limit, ...(where ? { where } : {}) };
+    const body: VectorProxyQueryRequest = { text, limit: normalizeLimit(limit), ...(where ? { where } : {}) };
     return this.postJson<VectorProxyQueryResponse>(VECTOR_PROXY_ROUTES.query, body);
   }
 
@@ -107,7 +108,7 @@ export class ProxyVectorAdapter implements VectorStoreAdapter {
 
   private async proxyStats(): Promise<VectorProxyStatsResponse> {
     const stats = await this.fetchJson<VectorProxyStatsResponse>(VECTOR_PROXY_ROUTES.stats);
-    return { count: stats?.count ?? 0, name: stats?.name || this.collectionName };
+    return { count: nonNegativeCount(stats?.count), name: displayName(stats?.name, this.collectionName) };
   }
 
   private async health(): Promise<VectorProxyHealthResponse> {
@@ -163,4 +164,16 @@ export class ProxyVectorAdapter implements VectorStoreAdapter {
     const body = await res.text().catch(() => '');
     throw new Error(`Proxy vector request failed: ${res.status} ${res.statusText} ${body}`);
   }
+}
+
+function normalizeLimit(limit: number): number {
+  return Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 10;
+}
+
+function nonNegativeCount(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? Math.floor(value) : 0;
+}
+
+function displayName(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
 }

--- a/src/vector/adapters/qdrant.ts
+++ b/src/vector/adapters/qdrant.ts
@@ -34,8 +34,8 @@ export class QdrantAdapter implements VectorStoreAdapter {
   ) {
     this.collectionName = collectionName;
     this.embedder = embedder;
-    this.url = config.url || process.env.QDRANT_URL || 'http://localhost:6333';
-    this.apiKey = config.apiKey || process.env.QDRANT_API_KEY;
+    this.url = clean(config.url) || clean(process.env.QDRANT_URL) || 'http://localhost:6333';
+    this.apiKey = clean(config.apiKey) || clean(process.env.QDRANT_API_KEY);
   }
 
   async connect(): Promise<void> {
@@ -95,6 +95,7 @@ export class QdrantAdapter implements VectorStoreAdapter {
     let fresh: number[][] = [];
     if (needEmbed.length > 0) {
       fresh = await this.embedder.embed(needEmbed.map(i => docs[i].document), 'passage');
+      assertEmbeddingCount('Qdrant', fresh.length, needEmbed.length);
     }
     let freshIdx = 0;
 
@@ -207,4 +208,13 @@ export class QdrantAdapter implements VectorStoreAdapter {
   private pointId(id: string): string {
     return qdrantPointId(id);
   }
+}
+
+function assertEmbeddingCount(adapter: string, actual: number, expected: number): void {
+  if (actual !== expected) throw new Error(`${adapter} embedder returned ${actual} vectors for ${expected} documents`);
+}
+
+function clean(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
 }

--- a/src/vector/factory.ts
+++ b/src/vector/factory.ts
@@ -52,33 +52,27 @@ function createConfiguredEmbedder(config: VectorStoreConfig) {
   return createEmbeddingProvider(provider, model, options);
 }
 export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAdapter {
-  const type = config.type
-    || (process.env.ORACLE_VECTOR_DB as VectorDBType)
-    || 'lancedb';
-  const collectionName = config.collectionName || COLLECTION_NAME;
+  const type = (clean(config.type) || clean(process.env.ORACLE_VECTOR_DB) || 'lancedb').toLowerCase() as VectorDBType;
+  const collectionName = clean(config.collectionName) || COLLECTION_NAME;
   switch (type) {
     case 'sqlite-vec': {
-      const dbPath = tenantDataPath(config.dataPath
-        || process.env.ORACLE_VECTOR_DB_PATH
-        || VECTORS_DB_PATH);
+      const dbPath = tenantDataPath(clean(config.dataPath) || clean(process.env.ORACLE_VECTOR_DB_PATH) || VECTORS_DB_PATH);
       return new SqliteVecAdapter(collectionName, dbPath, createConfiguredEmbedder(config));
     }
     case 'lancedb': {
-      const dbPath = tenantDataPath(config.dataPath
-        || process.env.ORACLE_VECTOR_DB_PATH
-        || LANCEDB_DIR);
+      const dbPath = tenantDataPath(clean(config.dataPath) || clean(process.env.ORACLE_VECTOR_DB_PATH) || LANCEDB_DIR);
       return new LanceDBAdapter(collectionName, dbPath, createConfiguredEmbedder(config));
     }
     case 'qdrant': {
       return new QdrantAdapter(collectionName, createConfiguredEmbedder(config), {
-        url: config.qdrantUrl || process.env.QDRANT_URL,
-        apiKey: config.qdrantApiKey || process.env.QDRANT_API_KEY,
+        url: clean(config.qdrantUrl) || clean(process.env.QDRANT_URL),
+        apiKey: clean(config.qdrantApiKey) || clean(process.env.QDRANT_API_KEY),
       });
     }
     case 'cloudflare-vectorize': {
       const cfConfig = {
-        accountId: config.cfAccountId || process.env.CF_ACCOUNT_ID || process.env.CLOUDFLARE_ACCOUNT_ID,
-        apiToken: config.cfApiToken || process.env.CF_API_TOKEN || process.env.CLOUDFLARE_API_TOKEN,
+        accountId: clean(config.cfAccountId) || clean(process.env.CF_ACCOUNT_ID) || clean(process.env.CLOUDFLARE_ACCOUNT_ID),
+        apiToken: clean(config.cfApiToken) || clean(process.env.CF_API_TOKEN) || clean(process.env.CLOUDFLARE_API_TOKEN),
       };
       const embeddingModel = config.embeddingModel
         || process.env.ORACLE_EMBEDDING_MODEL;
@@ -89,19 +83,19 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
       return new CloudflareVectorizeAdapter(collectionName, embedder, cfConfig);
     }
     case 'proxy': {
-      const proxyUrl = config.proxyEndpoint || process.env.ORACLE_PROXY_VECTOR_URL;
+      const proxyUrl = clean(config.proxyEndpoint) || clean(process.env.ORACLE_PROXY_VECTOR_URL);
       if (!proxyUrl) {
         throw new Error('proxy vector adapter requires proxyEndpoint or ORACLE_PROXY_VECTOR_URL');
       }
       return new ProxyVectorAdapter(collectionName, proxyUrl);
     }
     case 'turbovec': {
-      return new TurboVecAdapter(collectionName, config.proxyEndpoint);
+      return new TurboVecAdapter(collectionName, clean(config.proxyEndpoint));
     }
     case 'chroma':
     default: {
-      const dataPath = tenantDataPath(config.dataPath || CHROMADB_DIR);
-      const pythonVersion = config.pythonVersion || '3.12';
+      const dataPath = tenantDataPath(clean(config.dataPath) || CHROMADB_DIR);
+      const pythonVersion = clean(config.pythonVersion) || '3.12';
       return new ChromaMcpAdapter(collectionName, dataPath, pythonVersion);
     }
   }
@@ -241,4 +235,9 @@ export async function reloadCachedVectorStores(
     return store;
   }));
   return { reloaded: reloadKeys.length };
+}
+
+function clean(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
 }

--- a/src/vector/proxy-protocol.ts
+++ b/src/vector/proxy-protocol.ts
@@ -39,7 +39,8 @@ export interface VectorProxyHealthResponse {
 }
 
 export function buildVectorProxyUrl(endpoint: string, route: VectorProxyRoute | string): string {
-  const safeBase = endpoint.replace(/\/+$/, '');
+  const safeBase = endpoint.trim().replace(/\/+$/, '');
+  if (!safeBase) throw new Error('Vector proxy endpoint is required');
   return `${safeBase}${route.startsWith('/') ? route : `/${route}`}`;
 }
 

--- a/tests/vector/factory-deep-hardening.test.ts
+++ b/tests/vector/factory-deep-hardening.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from 'bun:test';
+import { createVectorStore } from '../../src/vector/factory.ts';
+import { trackEnv } from './helpers.ts';
+
+test('vector factory trims adapter type, collection, and proxy endpoint config', () => {
+  const store = createVectorStore({
+    type: ' proxy ' as never,
+    collectionName: ' docs ',
+    proxyEndpoint: ' http://vector.local/ ',
+  }) as any;
+
+  expect(store.name).toBe('proxy');
+  expect(store.collectionName).toBe('docs');
+  expect(store.endpoint).toBe('http://vector.local/');
+});
+
+test('vector factory treats blank ORACLE_VECTOR_DB as unset', () => {
+  trackEnv('ORACLE_VECTOR_DB', '   ');
+  const store = createVectorStore({ dataPath: '/tmp/arra-vector-factory-hardening' });
+
+  expect(store.name).toBe('lancedb');
+});

--- a/tests/vector/proxy-deep-hardening.test.ts
+++ b/tests/vector/proxy-deep-hardening.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from 'bun:test';
+import { ProxyVectorAdapter } from '../../src/vector/adapters/proxy.ts';
+import { buildVectorProxyUrl } from '../../src/vector/proxy-protocol.ts';
+import { startServer } from './helpers.ts';
+
+test('proxy protocol trims endpoint and rejects blank endpoints', () => {
+  expect(buildVectorProxyUrl(' https://vector.example/base/ ', 'vectors/query'))
+    .toBe('https://vector.example/base/vectors/query');
+  expect(() => buildVectorProxyUrl('   ', '/health')).toThrow('Vector proxy endpoint is required');
+});
+
+test('proxy adapter skips empty add batches and normalizes stats/query edges', async () => {
+  let addHits = 0;
+  let queryPayload: unknown;
+  const target = startServer(async (req) => {
+    const path = new URL(req.url).pathname;
+    if (path === '/vectors/add') {
+      addHits += 1;
+      return Response.json({ ok: true });
+    }
+    if (path === '/vectors/stats') return Response.json({ count: -2, name: '   ' });
+    if (path === '/vectors/query') {
+      queryPayload = await req.json();
+      return Response.json({ ids: [], documents: [], distances: [], metadatas: [] });
+    }
+    return Response.json({ status: 'ok', name: 'proxy', version: 'test' });
+  });
+  const adapter = new ProxyVectorAdapter('docs', ` ${target}/ `);
+
+  await adapter.addDocuments([]);
+  const info = await adapter.getCollectionInfo();
+  await adapter.query('oracle', Number.NaN);
+
+  expect(addHits).toBe(0);
+  expect(info).toEqual({ name: 'docs', count: 0 });
+  expect(queryPayload).toMatchObject({ text: 'oracle', limit: 10 });
+});


### PR DESCRIPTION
## Summary
- Harden vector factory input normalization for padded/blank adapter, collection, endpoint, and credential config.
- Harden proxy protocol/adapter behavior for blank endpoints, empty add batches, bad limits, and malformed stats.
- Harden Qdrant adapter upserts so mismatched embedder output fails before sending incomplete vectors.

## Tests
```bash
bunx tsc --noEmit
bun test tests/vector/
bun test src/vector/__tests__/*.test.ts
git diff --check origin/alpha...HEAD
```

## Notes
- Vector library only; no route, docs, or UI changes.
- Changed files are all <= 250 lines.
