### PR TITLE
test: harden server and process manager edges

### DIFF
--- a/src/process-manager/HealthMonitor.ts
+++ b/src/process-manager/HealthMonitor.ts
@@ -151,8 +151,12 @@ export async function getWorkerStatus(
       return { running: true, healthy: false };
     }
 
-    const readinessResponse = await fetch(`${opts.baseUrl}:${port}${opts.readinessPath}`);
-    return { running: true, healthy: readinessResponse.ok };
+    try {
+      const readinessResponse = await fetch(`${opts.baseUrl}:${port}${opts.readinessPath}`);
+      return { running: true, healthy: readinessResponse.ok };
+    } catch {
+      return { running: true, healthy: false };
+    }
   } catch {
     return { running: false, healthy: false };
   }

--- a/src/process-manager/processes.ts
+++ b/src/process-manager/processes.ts
@@ -52,10 +52,16 @@ export async function forceKillProcess(pid: number): Promise<void> {
 }
 
 export async function waitForProcessesExit(pids: number[], timeoutMs: number): Promise<boolean> {
+  const validPids = pids.filter(isPositiveInteger);
+  if (validPids.length === 0) {
+    logger.info('SYSTEM', 'All processes exited');
+    return true;
+  }
+
   const start = Date.now();
 
   while (Date.now() - start < timeoutMs) {
-    const stillAlive = pids.filter(pid => isProcessAlive(pid));
+    const stillAlive = validPids.filter(pid => isProcessAlive(pid));
     if (stillAlive.length === 0) {
       logger.info('SYSTEM', 'All processes exited');
       return true;

--- a/src/server/__tests__/server-utils-edge.test.ts
+++ b/src/server/__tests__/server-utils-edge.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'bun:test';
+import { validateRequired } from '../utils.ts';
+
+function responseSink() {
+  const res = {
+    statusCode: 200,
+    headers: new Map<string, string>(),
+    body: '',
+    setHeader(name: string, value: string) {
+      this.headers.set(name, value);
+    },
+    end(value: string) {
+      this.body = value;
+    },
+  };
+  return res;
+}
+
+test('required query validation accepts falsy but present values', () => {
+  const res = responseSink();
+  expect(validateRequired(res as any, { limit: 0, enabled: false }, ['limit', 'enabled'])).toBeNull();
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toBe('');
+});
+
+test('required query validation rejects absent and blank strings', () => {
+  const res = responseSink();
+  expect(validateRequired(res as any, { q: '   ' }, ['q'])).toBe('q');
+  expect(res.statusCode).toBe(400);
+  expect(res.headers.get('Content-Type')).toBe('application/json');
+  expect(JSON.parse(res.body)).toEqual({ error: 'Missing required parameter: q' });
+});

--- a/src/server/__tests__/vector-proxy-edge.test.ts
+++ b/src/server/__tests__/vector-proxy-edge.test.ts
@@ -1,0 +1,26 @@
+import { afterAll, expect, test } from 'bun:test';
+import { createVectorProxy } from '../vector-proxy.ts';
+
+const requests: string[] = [];
+const remote = Bun.serve({
+  port: 0,
+  fetch(request) {
+    const url = new URL(request.url);
+    requests.push(`${url.pathname}${url.search}`);
+    return Response.json({ query: url.searchParams.get('q'), total: 0, results: [] });
+  },
+});
+
+afterAll(() => remote.stop(true));
+
+test('vector proxy ignores blank URLs', () => {
+  expect(createVectorProxy('   ')).toBeNull();
+});
+
+test('vector proxy trims base URL and preserves falsy numeric query params', async () => {
+  const proxy = createVectorProxy(`  http://127.0.0.1:${remote.port}/  `);
+  const result = await proxy?.search({ q: 'a b&c', limit: 0, offset: 0 });
+
+  expect(result).toMatchObject({ query: 'a b&c', total: 0, results: [] });
+  expect(requests).toContain('/api/search?q=a%20b%26c&limit=0&offset=0');
+});

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -38,7 +38,7 @@ export function validateRequired(
   required: string[]
 ): string | null {
   for (const param of required) {
-    if (!params[param]) {
+    if (isMissingRequiredValue(params[param])) {
       res.statusCode = 400;
       res.setHeader('Content-Type', 'application/json');
       res.end(JSON.stringify({ error: `Missing required parameter: ${param}` }));
@@ -65,4 +65,10 @@ export function asyncHandlerWithValidation<T>(
     return; // Response already sent
   }
   asyncHandler(res, handler);
+}
+
+function isMissingRequiredValue(value: unknown): boolean {
+  return value === undefined ||
+    value === null ||
+    (typeof value === 'string' && value.trim().length === 0);
 }

--- a/src/server/vector-proxy.ts
+++ b/src/server/vector-proxy.ts
@@ -126,8 +126,9 @@ export interface VectorProxy {
  * @param baseUrl — e.g. `https://vector.example.com` or empty/undefined for local mode
  */
 export function createVectorProxy(baseUrl: string | undefined | null): VectorProxy | null {
-  if (!baseUrl) return null;
-  const base = baseUrl.replace(/\/+$/, '');
+  const trimmedBaseUrl = baseUrl?.trim();
+  if (!trimmedBaseUrl) return null;
+  const base = trimmedBaseUrl.replace(/\/+$/, '');
 
   async function fetchJson<T>(pathAndQuery: string, timeoutMs = TIMEOUT_MS): Promise<T | null> {
     const url = `${base}${pathAndQuery}`;

--- a/tests/process-manager/health-status-readiness-failure.test.ts
+++ b/tests/process-manager/health-status-readiness-failure.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from 'bun:test';
+import { getWorkerStatus } from '../../src/process-manager/index.ts';
+
+const originalFetch = globalThis.fetch;
+
+test('worker status stays running when readiness fetch fails after health succeeds', async () => {
+  const calls: string[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = new URL(String(input));
+    calls.push(url.pathname);
+    if (url.pathname === '/health') return new Response('{}', { status: 200 });
+    throw new TypeError('socket closed');
+  }) as typeof fetch;
+
+  try {
+    expect(await getWorkerStatus(47778)).toEqual({ running: true, healthy: false });
+    expect(calls).toEqual(['/health', '/readiness']);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tests/process-manager/wait-processes-invalid-pids.test.ts
+++ b/tests/process-manager/wait-processes-invalid-pids.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'bun:test';
+import { waitForProcessesExit } from '../../src/process-manager/index.ts';
+
+test('waiting for process exit treats empty pid lists as already done', async () => {
+  expect(await waitForProcessesExit([], 0)).toBe(true);
+});
+
+test('waiting for process exit ignores invalid pids', async () => {
+  expect(await waitForProcessesExit([0, -1, Number.NaN], 0)).toBe(true);
+});


### PR DESCRIPTION
## Summary
- harden process-manager status and process-exit helpers for readiness failures, empty pid lists, and invalid pids
- harden server utilities so required parameter validation accepts falsy-but-present values
- harden vector proxy setup by trimming base URLs and rejecting blank configuration
- add targeted server/process-manager regression coverage

## Verification
```bash
bun test src/server/__tests__ tests/process-manager/
bunx tsc --noEmit
git diff --check HEAD~1..HEAD
wc -l src/process-manager/HealthMonitor.ts src/process-manager/processes.ts src/server/utils.ts src/server/vector-proxy.ts src/server/__tests__/server-utils-edge.test.ts src/server/__tests__/vector-proxy-edge.test.ts tests/process-manager/health-status-readiness-failure.test.ts tests/process-manager/wait-processes-invalid-pids.test.ts
```

## Notes
- No UI changes; no screenshot needed.
- Docs not touched.