### PR TITLE
fix: harden MCP proxy and storage edges

### DIFF
--- a/src/mcp/http-proxy.ts
+++ b/src/mcp/http-proxy.ts
@@ -28,7 +28,7 @@ class OracleApiUnavailableError extends Error {
 export function resolveOracleApiBase(): string | null {
   const trimmed = configuredApiBase();
   if (!trimmed || EMBEDDED_API_VALUES.has(trimmed.toLowerCase())) return null;
-  return trimmed.replace(/\/+$/, '');
+  return normalizeApiBase(trimmed);
 }
 
 function configuredApiBase(): string | null {
@@ -41,9 +41,25 @@ function configuredApiBase(): string | null {
 
 function cleanQueryValue(value: unknown): string | undefined {
   if (value === undefined || value === null) return undefined;
-  if (typeof value === 'string') return value;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
   if (typeof value === 'number' || typeof value === 'boolean') return String(value);
   return undefined;
+}
+
+function normalizeApiBase(raw: string): string | null {
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+    url.search = '';
+    url.hash = '';
+    url.pathname = url.pathname.replace(/\/+$/, '');
+    return url.toString().replace(/\/+$/, '');
+  } catch {
+    return raw.replace(/\/+$/, '') || null;
+  }
 }
 
 function queryFrom(input: Record<string, unknown>, fields: Record<string, string>): Record<string, string> {

--- a/src/mcp/tenant.ts
+++ b/src/mcp/tenant.ts
@@ -18,5 +18,8 @@ export function stripMcpTenantArgs(args: Record<string, unknown>): Record<string
 }
 
 export function mcpTenantHeaders(tenantId: string | undefined): Record<string, string> {
-  return tenantId ? { [TENANT_HEADER]: tenantId } : {};
+  const trimmed = tenantId?.trim();
+  if (!trimmed) return {};
+  const validated = tenantIdFromHeaders(new Headers({ [TENANT_HEADER]: trimmed }));
+  return validated ? { [TENANT_HEADER]: validated } : {};
 }

--- a/src/storage/drizzle-sqlite.ts
+++ b/src/storage/drizzle-sqlite.ts
@@ -67,6 +67,21 @@ function sqliteObjectExists(sqlite: Database, type: string, name: string): boole
   return Boolean(row);
 }
 
+function stripLeadingSqlComments(statement: string): string {
+  let remaining = statement.trimStart();
+  while (remaining.startsWith('--') || remaining.startsWith('/*')) {
+    if (remaining.startsWith('--')) {
+      const nextLine = remaining.indexOf('\n');
+      remaining = nextLine === -1 ? '' : remaining.slice(nextLine + 1).trimStart();
+      continue;
+    }
+    const commentEnd = remaining.indexOf('*/');
+    if (commentEnd === -1) return '';
+    remaining = remaining.slice(commentEnd + 2).trimStart();
+  }
+  return remaining;
+}
+
 function tableColumnExists(sqlite: Database, table: string, column: string): boolean {
   if (!sqliteObjectExists(sqlite, 'table', table)) return false;
   return sqlite.query<SqliteColumnRow, []>(
@@ -83,12 +98,14 @@ function addedColumn(statement: string): [string, string] | null {
 
 function createdIndex(statement: string): string | null {
   return statement.match(
-    /^create(?:\s+unique)?\s+index\s+[`"]?([a-z_][\w]*)[`"]?\s+on\b/i,
+    /^create(?:\s+unique)?\s+index\s+(?:if\s+not\s+exists\s+)?[`"]?([a-z_][\w]*)[`"]?\s+on\b/i,
   )?.[1] ?? null;
 }
 
 function createdTable(statement: string): { table: string; columns: string[] } | null {
-  const match = statement.match(/^create\s+table\s+[`"]?([a-z_][\w]*)[`"]?\s*\(([\s\S]*)\)/i);
+  const match = statement.match(
+    /^create\s+table\s+(?:if\s+not\s+exists\s+)?[`"]?([a-z_][\w]*)[`"]?\s*\(([\s\S]*)\)/i,
+  );
   if (!match) return null;
   const columns = [...match[2].matchAll(/^\s*[`"]?([a-z_][\w]*)[`"]?\s+/gim)]
     .map((column) => column[1])
@@ -97,17 +114,37 @@ function createdTable(statement: string): { table: string; columns: string[] } |
   return { table: match[1], columns };
 }
 
+function insertedLiteralRow(statement: string): { table: string; column: string; value: string } | null {
+  const match = statement.match(
+    /^insert\s+into\s+[`"]?([a-z_][\w]*)[`"]?\s*\(\s*[`"]?([a-z_][\w]*)[`"]?[\s\S]*?\)\s*values\s*\(\s*'((?:''|[^'])*)'/i,
+  );
+  return match ? { table: match[1], column: match[2], value: match[3].replace(/''/g, "'") } : null;
+}
+
 function statementAlreadyApplied(sqlite: Database, statement: string): boolean | null {
-  const column = addedColumn(statement);
+  const cleanStatement = stripLeadingSqlComments(statement);
+  if (!cleanStatement || /^select\b/i.test(cleanStatement)) return true;
+
+  const column = addedColumn(cleanStatement);
   if (column) return tableColumnExists(sqlite, column[0], column[1]);
 
-  const indexName = createdIndex(statement);
+  const indexName = createdIndex(cleanStatement);
   if (indexName) return sqliteObjectExists(sqlite, 'index', indexName);
 
-  const table = createdTable(statement);
+  const table = createdTable(cleanStatement);
   if (table) {
     return sqliteObjectExists(sqlite, 'table', table.table)
       && table.columns.every((column) => tableColumnExists(sqlite, table.table, column));
+  }
+
+  const inserted = insertedLiteralRow(cleanStatement);
+  if (inserted) {
+    if (!tableColumnExists(sqlite, inserted.table, inserted.column)) return false;
+    const row = sqlite.query(
+      `select 1 from ${quoteIdentifier(inserted.table)}
+       where ${quoteIdentifier(inserted.column)} = ? limit 1`,
+    ).get(inserted.value);
+    return Boolean(row);
   }
 
   return null;

--- a/src/storage/soft-delete.ts
+++ b/src/storage/soft-delete.ts
@@ -26,6 +26,10 @@ function restorePatch(restoredAt: Date, extra: Record<string, unknown>) {
   return { updatedAt: restoredAt, ...extra, deletedAt: null };
 }
 
+function validRowId(id: number): boolean {
+  return Number.isSafeInteger(id) && id > 0;
+}
+
 export function notDeleted(table: SoftDeleteTable, predicate?: SQL): SQL | undefined {
   const active = isNull(table.deletedAt);
   return predicate ? and(predicate, active) : active;
@@ -52,6 +56,10 @@ export function softDeleteById<Row = unknown>(
   id: number,
   options: SoftDeleteOptions = {},
 ): SoftDeleteResult<Row> {
+  if (!validRowId(id)) {
+    const deletedAt = options.deletedAt ?? new Date();
+    return { rows: [], count: 0, deletedAt };
+  }
   return softDeleteWhere(db, table, eq(table.id, id), options);
 }
 
@@ -62,6 +70,7 @@ export function restoreById<Row = unknown>(
   restoredAt = new Date(),
   extra: Record<string, unknown> = {},
 ): Row | undefined {
+  if (!validRowId(id)) return undefined;
   return (db.update(table as never)
     .set(restorePatch(restoredAt, extra) as never)
     .where(eq(table.id, id))

--- a/tests/mcp/http-proxy-forwards-tenant.test.ts
+++ b/tests/mcp/http-proxy-forwards-tenant.test.ts
@@ -39,3 +39,9 @@ test('HTTP proxy forwards validated tenant context to Oracle API calls', async (
     headers: { [TENANT_HEADER.toLowerCase()]: 'tenant-mcp-a' },
   });
 });
+
+test('HTTP proxy rejects invalid tenant context before proxying', async () => {
+  await expect(runWithTenant('bad tenant', () => (
+    proxyToolCall('http://127.0.0.1:1', 'oracle_search', { query: 'x' })
+  ))).rejects.toThrow('invalid tenant id');
+});

--- a/tests/mcp/http-proxy-resolves-base-url.test.ts
+++ b/tests/mcp/http-proxy-resolves-base-url.test.ts
@@ -2,6 +2,24 @@ import { expect, test } from 'bun:test';
 import { resolveOracleApiBase } from '../../src/mcp/http-proxy.ts';
 
 test('HTTP proxy base resolver trims usable API URLs', () => {
-  process.env.ORACLE_HTTP_URL = ' http://127.0.0.1:47778/// ';
-  expect(resolveOracleApiBase()).toBe('http://127.0.0.1:47778');
+  withApiEnv(' http://127.0.0.1:47778/// ', () => {
+    expect(resolveOracleApiBase()).toBe('http://127.0.0.1:47778');
+  });
 });
+
+test('HTTP proxy base resolver drops accidental query and hash fragments', () => {
+  withApiEnv(' https://oracle.test/base/?debug=1#frag ', () => {
+    expect(resolveOracleApiBase()).toBe('https://oracle.test/base');
+  });
+});
+
+function withApiEnv(value: string, callback: () => void): void {
+  const previous = process.env.ORACLE_HTTP_URL;
+  process.env.ORACLE_HTTP_URL = value;
+  try {
+    callback();
+  } finally {
+    if (previous === undefined) delete process.env.ORACLE_HTTP_URL;
+    else process.env.ORACLE_HTTP_URL = previous;
+  }
+}

--- a/tests/mcp/http-proxy-skips-thread-read-without-id.test.ts
+++ b/tests/mcp/http-proxy-skips-thread-read-without-id.test.ts
@@ -3,4 +3,6 @@ import { proxyToolCall } from '../../src/mcp/http-proxy.ts';
 
 test('HTTP proxy skips oracle_thread_read without a thread id', async () => {
   expect(await proxyToolCall('http://127.0.0.1:1', 'oracle_thread_read', {})).toBeNull();
+  expect(await proxyToolCall('http://127.0.0.1:1', 'oracle_thread_read', { threadId: '   ' }))
+    .toBeNull();
 });

--- a/tests/mcp/tenant-strip-aliases.test.ts
+++ b/tests/mcp/tenant-strip-aliases.test.ts
@@ -1,7 +1,14 @@
 import { expect, test } from 'bun:test';
-import { stripMcpTenantArgs, tenantIdFromMcpArgs } from '../../src/mcp/tenant.ts';
+import { mcpTenantHeaders, stripMcpTenantArgs, tenantIdFromMcpArgs } from '../../src/mcp/tenant.ts';
+import { TENANT_HEADER } from '../../src/middleware/tenant.ts';
 
 test('MCP tenant parser strips aliases and keeps normal args', () => {
   expect(tenantIdFromMcpArgs({ org_id: 'tenant-a', query: 'x' })).toBe('tenant-a');
   expect(stripMcpTenantArgs({ org_id: 'tenant-a', tenant: 'tenant-b', query: 'x' })).toEqual({ query: 'x' });
+});
+
+test('MCP tenant headers trim and validate tenant context values', () => {
+  expect(mcpTenantHeaders(' tenant-a ')).toEqual({ [TENANT_HEADER]: 'tenant-a' });
+  expect(mcpTenantHeaders('   ')).toEqual({});
+  expect(() => mcpTenantHeaders('bad tenant')).toThrow('invalid tenant id');
 });

--- a/tests/storage/partial-migration-repair.test.ts
+++ b/tests/storage/partial-migration-repair.test.ts
@@ -7,6 +7,7 @@ import { createStorageBackend } from '../../src/storage/registry.ts';
 import type { StorageBackend } from '../../src/storage/types.ts';
 
 const FIRST_TENANT_MEMORY_MIGRATION = 1781628166154;
+const INDEXING_JOBS_MIGRATION = 1780185600000;
 let tempDir = '';
 let backend: StorageBackend | undefined;
 
@@ -39,4 +40,28 @@ test('sqlite backend repairs additive migrations already present in schema', () 
 
   expect(repaired?.count).toBe(4);
   expect(memoryColumns).toContain('tenant_id');
+});
+
+test('sqlite backend repairs migrations with if-not-exists DDL', () => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-storage-migration-if-not-exists-'));
+  const dbPath = path.join(tempDir, 'oracle.db');
+  backend = createStorageBackend({ dbPath });
+  backend.close();
+  backend = undefined;
+
+  const raw = new Database(dbPath);
+  raw.query('delete from __drizzle_migrations where created_at >= ?')
+    .run(INDEXING_JOBS_MIGRATION);
+  raw.close();
+
+  backend = createStorageBackend({ dbPath });
+  const repaired = backend.sqlite.query<{ count: number }, [number]>(
+    'select count(*) as count from __drizzle_migrations where created_at = ?',
+  ).get(INDEXING_JOBS_MIGRATION);
+  const pendingIndex = backend.sqlite.query<{ name: string }, []>(
+    "select name from sqlite_master where type = 'index' and name = 'idx_indexing_jobs_pending'",
+  ).get();
+
+  expect(repaired?.count).toBe(1);
+  expect(pendingIndex?.name).toBe('idx_indexing_jobs_pending');
 });

--- a/tests/storage/soft-delete.test.ts
+++ b/tests/storage/soft-delete.test.ts
@@ -80,6 +80,16 @@ test('generic soft delete helpers filter and restore deleted rows', () => {
   expect(visibleAfterRestore).toHaveLength(1);
 });
 
+test('generic soft delete helpers ignore invalid row ids', () => {
+  const storage = createBackend();
+  const deletedAt = new Date(1700000020000);
+
+  const deleted = softDeleteById(storage.db, softDeleteMenuItems, Number.NaN, { deletedAt });
+  const restored = restoreById(storage.db, softDeleteMenuItems, -1, deletedAt);
+
+  expect(deleted).toEqual({ rows: [], count: 0, deletedAt });
+  expect(restored).toBeUndefined();
+});
 
 test('menu schema exposes deletedAt and parent metadata for Drizzle migrations', () => {
   const fkSymbol = Object.getOwnPropertySymbols(menuItems)


### PR DESCRIPTION
## Summary\n- Validate/trim MCP tenant headers and reject invalid tenant context before proxying.\n- Normalize HTTP proxy base URLs, trim scalar query/path values, and skip blank thread IDs.\n- Harden sqlite migration repair for comment/no-op, IF NOT EXISTS DDL, and literal insert drift; ignore invalid soft-delete row IDs.\n\n## Tests\n- bunx tsc --noEmit\n- bun test tests/mcp/ tests/storage/ src/mcp/__tests__/\n- git diff --check\n- wc -l changed files (all <=250)