### PR TITLE
docs: complete docs navigation index

### DIFF
--- a/docs/API-REFERENCE-INDEX.md
+++ b/docs/API-REFERENCE-INDEX.md
@@ -1,0 +1,69 @@
+# API reference index
+
+Use this page to choose the right API reference for HTTP, MCP, plugin, vector,
+and route-family work.
+
+## Entry points
+
+| Need | Use |
+| --- | --- |
+| Interactive Swagger UI | `http://localhost:47778/api/docs` |
+| Machine-readable spec | [openapi.json](./openapi.json) |
+| Full Elysia route inventory | [http-api-reference.md](./http-api-reference.md) |
+| Menu, plugin, vector, MCP notes | [API.md](./API.md) |
+| Install and auth setup | [INSTALL.md](./INSTALL.md) |
+| First-run smoke tests | [QUICKSTART.md](./QUICKSTART.md) |
+
+## Base URL and auth
+
+The default HTTP backend is `http://localhost:47778`. Most `/api/*` routes are
+also reachable under `/api/v1/*`; infrastructure routes such as `/api/health`
+remain direct.
+
+When `ARRA_API_TOKEN` is set, protected routes need a bearer token:
+
+```bash
+curl -H "Authorization: Bearer $ARRA_API_TOKEN" \
+  http://localhost:47778/api/stats
+```
+
+Tenant-aware routes use `X-Oracle-Tenant` and optional
+`X-Oracle-Tenant-Token`:
+
+```bash
+curl -H 'X-Oracle-Tenant: team-a' \
+  'http://localhost:47778/api/search?q=oracle&limit=5'
+```
+
+## Route families
+
+| Family | Common paths | Primary reference |
+| --- | --- | --- |
+| Health, stats, dashboard | `/api/health`, `/api/stats`, `/api/dashboard` | [http-api-reference.md](./http-api-reference.md#health-metrics-dashboard) |
+| Search and memory | `/api/search`, `/api/list`, `/api/memory/*` | [http-api-reference.md](./http-api-reference.md#search-knowledge-learn-memory) |
+| Vector and indexer | `/api/vector/*`, `/api/indexer/*`, `/api/map` | [API.md](./API.md#vector-api) |
+| Menu and plugins | `/api/menu`, `/api/plugins`, `/api/canvas/*` | [API.md](./API.md#menu-api) |
+| MCP catalogue | `/api/mcp/tools` | [API.md](./API.md#mcp-tool-listing-api) |
+| Export/import | `/api/export/*`, `/api/vector/export/*` | [http-api-reference.md](./http-api-reference.md#vector-and-indexer) |
+| Collaboration | `/api/traces`, `/api/supersede`, `/api/schedule` | [http-api-reference.md](./http-api-reference.md#collaboration-social-traces-schedule) |
+| Federation/peer | `/identity`, `/peer/*`, `/search` | [FEDERATION.md](./FEDERATION.md) |
+
+## Curl smoke checks
+
+```bash
+curl -sf http://localhost:47778/api/health
+curl -sf http://localhost:47778/api/docs >/dev/null
+curl 'http://localhost:47778/api/search?q=oracle&mode=fts&limit=5'
+curl -sf http://localhost:47778/api/mcp/tools
+curl -sf http://localhost:47778/api/vector/health
+```
+
+## Adding or changing endpoints
+
+- Add the Elysia route under `src/routes/<cluster>/` and compose it in
+  `src/server.ts` when it is a new cluster.
+- Add or update fetch-based HTTP tests under `tests/http/<cluster>/`.
+- Update [http-api-reference.md](./http-api-reference.md) for route inventory
+  changes and [API.md](./API.md) when behavior needs deeper examples.
+- Export/update [openapi.json](./openapi.json) when route schemas change.
+- Keep changed docs and tests at or below 250 lines per file.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,69 @@
+# FAQ
+
+## What is Arra Oracle V3?
+
+Arra Oracle V3 is the Oracle-family memory, search, MCP, and HTTP layer. It
+stores and searches project knowledge, exposes MCP tools, and is being shaped so
+capabilities can be installed like plugins instead of editing the core engine.
+
+## Which install path should I use?
+
+Use the global Bun install path for local operators and agents. Use Docker or
+Docker MCP Toolkit when you need isolated runtime packaging. Use a source clone
+only when contributing code.
+
+## What command starts the server?
+
+For a local source checkout, run `bun run server`. For an installed package, use
+`arra-oracle-v3 serve` or the command shown by `arra-oracle-v3 --help`.
+
+## What is `arra` vs `arra-oracle-v3`?
+
+`arra` is the short operator CLI. `arra-oracle-v3` is the package binary and is
+useful when validating installation or starting the packaged server directly.
+
+## Does Arra require vector search?
+
+No. Vector adapters improve recall, comparison, and map views, but keyword/FTS
+paths and many HTTP/MCP surfaces still work while vector services are offline.
+Use `/api/vector/health` to check adapter status.
+
+## Where is data stored?
+
+Local installs use the configured Oracle data directory and SQLite-backed state.
+Docker installs should mount a persistent volume. Treat exported Markdown/JSON as
+portable recovery material and re-index when adapters change.
+
+## How do I connect an MCP client?
+
+For embedded mode, leave `ORACLE_HTTP_URL` unset. For HTTP-proxy mode, set
+`ORACLE_HTTP_URL=http://localhost:47778`. Always set `ORACLE_LOG_TARGET=stderr`
+so MCP stdout stays valid JSON-RPC.
+
+## How do I install plugins?
+
+Install or copy a plugin directory with a valid `plugin.json` manifest into the
+configured plugin path, then restart or reload the server. Confirm registration
+with `/api/plugins`, `/api/menu`, and `/api/mcp/tools`.
+
+## Why do docs and PRs target alpha?
+
+`alpha` is the working trunk. `main` is reserved for stable releases, so feature,
+fix, and docs PRs should target `alpha` unless the maintainer explicitly says
+otherwise.
+
+## Can I run multi-tenant?
+
+Yes. Tenant-aware HTTP routes honor `X-Oracle-Tenant` and optional
+`X-Oracle-Tenant-Token`. Use tenant headers consistently for reads, writes,
+imports, and indexing jobs so data remains isolated.
+
+## What API docs should I read first?
+
+Start with [API-REFERENCE-INDEX.md](./API-REFERENCE-INDEX.md). It points to the
+Swagger UI, OpenAPI JSON, route inventory, and deeper API notes.
+
+## Where do UI screenshots go?
+
+Post UI screenshots to the relevant GitHub issue or PR comment. Keep docs under
+`docs/` and do not store docs or screenshots in unrelated private folders.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,44 +1,91 @@
 # Arra Oracle docs index
 
-Use this page as the one-hop map for the 2026-06-06/07 alpha docs wave.
+Use this page as the one-hop navigation map for Arra Oracle install, plugin,
+HTTP/MCP, operations, and contributor docs. Every Markdown guide under `docs/`
+is linked here; keep new docs in the right section when adding files.
 
 ## Start here
 
 | Guide | Use when you need | Key surfaces |
 | --- | --- | --- |
-| [INSTALL.md](./INSTALL.md) | Easy install through global Bun, plugins, Docker, or Docker MCP Toolkit | `bun add -g github:...#vX.Y.Z`, `arra plugin install`, GHCR |
-| [QUICKSTART.md](./QUICKSTART.md) | Five-minute first run after install | `arra-oracle-v3 serve`, `arra health`, `arra learn`, MCP config |
+| [INSTALL.md](./INSTALL.md) | Install from Bun, plugins, Docker, or Docker MCP Toolkit | `bun add -g`, `arra plugin install`, GHCR |
+| [QUICKSTART.md](./QUICKSTART.md) | Complete a five-minute first run | `arra-oracle-v3 serve`, `arra health`, MCP config |
+| [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) | Diagnose install, MCP, HTTP, vector, plugin, and Docker issues | health checks, auth, tenants, logs |
+| [FAQ.md](./FAQ.md) | Answer common operator and contributor questions | install path, binaries, data, vectors, tenants |
 | [architecture.md](./architecture.md) | Understand the installable runtime architecture | HTTP, MCP, CLI, plugins, storage |
-| [PLUGIN-GUIDE.md](./PLUGIN-GUIDE.md) | Author installable Oracle plugins | `plugin.json`, unified surfaces, plugin install smoke checks |
-| [DEPLOY-DIGITALOCEAN.md](./DEPLOY-DIGITALOCEAN.md) | Deploy a small public Arra HTTP node on DigitalOcean | `doctl`, firewall allowlist, `ARRA_API_TOKEN`, seed, teardown |
-| [FEDERATION.md](./FEDERATION.md) | Pair and secure Arra peers | `/info`, `/api/identity`, `/api/peer/feed`, `/api/peer/search`, TOFU pins |
-| [HUGINN-MUNINN.md](./HUGINN-MUNINN.md) | Understand the capture/recall naming split | Muninn recall, Huginn capture, no `huginn_*` aliases |
-| [issues/memory-systems-ai-agents-1648.md](./issues/memory-systems-ai-agents-1648.md) | Apply the #1648 memory-systems research | provenance-first hybrid memory, confidence, validation, review-gated capture |
-| [MORNING-TAPE-TEMPLATE.md](./MORNING-TAPE-TEMPLATE.md) | Complete Challenge 2 memory bootstrapping | two-minute recovery tape, safety rails, blocked/done reporting |
-| [CONTRIBUTING.md](../CONTRIBUTING.md) | Pick the correct repo/branch for PRs | two-repo rule, source PRs to `arra-oracle-v3:alpha` |
-| [CONTRIBUTING.md](./CONTRIBUTING.md) | Contributor quickstart for source PRs | branch from `alpha`, scoped tests, PR checklist |
-| [GITHUB-ISSUE-UPDATES.md](./GITHUB-ISSUE-UPDATES.md) | Post polished issue updates | `##` headers, bullets, code blocks, status badges |
-| [CHANGELOG.md](../CHANGELOG.md) | Review what changed in the alpha wave | release notes, tracker issues, source PRs |
-| [TONIGHT-SHIPPED.md](./TONIGHT-SHIPPED.md) | Find feature knobs and first commands | MCP modes, plugins, CLI targets, vectors, Docker, federation |
+| [PLUGIN-GUIDE.md](./PLUGIN-GUIDE.md) | Author installable Oracle plugins | `plugin.json`, CLI/MCP/menu/API surfaces |
+| [API-REFERENCE-INDEX.md](./API-REFERENCE-INDEX.md) | Choose the right API reference | `/api/docs`, `openapi.json`, route family map |
 
-## Feature knobs quick map
+## Install, onboarding, and operations
 
-| Feature | Main doc | Common knobs / paths |
-| --- | --- | --- |
-| MCP embedded vs HTTP-proxy | [TONIGHT-SHIPPED.md](./TONIGHT-SHIPPED.md#mcp-modes-embedded-vs-http-proxy) | `ORACLE_HTTP_URL`, `ORACLE_API`, `NEO_ARRA_API` |
-| MCP tool/plugin toggles | [TONIGHT-SHIPPED.md](./TONIGHT-SHIPPED.md#mcp-tool-plugin-toggles) | `arra.config.json`, `plugins.json`, `$ORACLE_DATA_DIR/config.json` |
-| Operator CLI targets | [INSTALL.md](./INSTALL.md#first-server) | `arra config add`, `arra config use`, `ORACLE_API`, `--at` |
-| Vector adapters | [TONIGHT-SHIPPED.md](./TONIGHT-SHIPPED.md#vector-store-adapters-and-per-collection-config) | `ORACLE_VECTOR_DB`, `QDRANT_URL`, `VECTOR_URL`, `VECTOR_FALLBACK` |
-| Docker/GHCR | [INSTALL.md](./INSTALL.md#docker-install) | `:http`, `:stdio`, Docker volumes |
-| Docker MCP Toolkit | [INSTALL.md](./INSTALL.md#docker-install) | `catalog/arra-oracle.yaml`, `docker mcp profile create` |
-| DigitalOcean deploy | [DEPLOY-DIGITALOCEAN.md](./DEPLOY-DIGITALOCEAN.md) | `doctl`, `sgp1`, `s-1vcpu-2gb`, `ARRA_API_TOKEN`, `scripts/deploy-do.sh` |
-| Federation | [FEDERATION.md](./FEDERATION.md) | `ARRA_PEER_TOKEN`, `ARRA_NAMED_PEERS`, `ARRA_SCOUT_ANNOUNCE`, `peers-tofu.json` |
-| Capture/recall taxonomy | [HUGINN-MUNINN.md](./HUGINN-MUNINN.md) | `oracle_search`, `oracle_trace*`, `oracle_learn`, `oracle_handoff`, no `huginn_*` aliases |
-| Memory-systems research | [issues/memory-systems-ai-agents-1648.md](./issues/memory-systems-ai-agents-1648.md) | `oracle_documents`, `oracle_memories`, confidence, validation, provenance |
+| Guide | Focus |
+| --- | --- |
+| [BINS.md](./BINS.md) | Published command binaries and aliases. |
+| [DEPLOY-DIGITALOCEAN.md](./DEPLOY-DIGITALOCEAN.md) | Small public Arra HTTP node on DigitalOcean. |
+| [DOCKER-MCP-TOOLKIT.md](./DOCKER-MCP-TOOLKIT.md) | Docker MCP Toolkit package and profile setup. |
+| [LOCAL-DEV.md](./LOCAL-DEV.md) | Local development setup and repo workflow. |
+| [ONBOARDING.md](./ONBOARDING.md) | Progressive onboarding UI and first-use flow. |
+| [REBRAND-RUNBOOK.md](./REBRAND-RUNBOOK.md) | Arra Oracle naming and migration checklist. |
+| [RTK-SETUP.md](./RTK-SETUP.md) | RTK setup for Claude Code sessions. |
+| [SWAGGER-DEPLOY.md](./SWAGGER-DEPLOY.md) | Public Swagger/API docs deployment notes. |
+| [TONIGHT-SHIPPED.md](./TONIGHT-SHIPPED.md) | Shipped feature knobs and first commands. |
 
-## Source references
+## API, MCP, middleware, and data
 
-- [README.md](../README.md) — project overview and top-level install snippets.
-- [API.md](./API.md) — HTTP API notes.
-- [architecture.md](./architecture.md) — system architecture.
-- [LOCAL-DEV.md](./LOCAL-DEV.md) — local development setup.
+| Guide | Focus |
+| --- | --- |
+| [API.md](./API.md) | Menu, plugin, vector, and MCP HTTP API notes. |
+| [http-api-reference.md](./http-api-reference.md) | Full Elysia route inventory. |
+| [mcp-tools.md](./mcp-tools.md) | MCP tool names, contracts, and usage. |
+| [MCP-FROM-OPENAPI.md](./MCP-FROM-OPENAPI.md) | Generate MCP tools from OpenAPI route metadata. |
+| [MIDDLEWARE.md](./MIDDLEWARE.md) | HTTP middleware order and request lifecycle. |
+| [DB-MIGRATIONS.md](./DB-MIGRATIONS.md) | Drizzle migration workflow. |
+| [CLOUD-VECTOR-PROXY.md](./CLOUD-VECTOR-PROXY.md) | Cloud vector proxy runbook. |
+| [vector-runtime.md](./vector-runtime.md) | Vector runtime mode reference. |
+| [openapi.json](./openapi.json) | Machine-readable OpenAPI export. |
+
+## Plugins, menus, UI, and canvas
+
+| Guide | Focus |
+| --- | --- |
+| [UNIFIED-PLUGIN.md](./UNIFIED-PLUGIN.md) | Unified plugin manifest fields. |
+| [PLUGIN-TAXONOMY.md](./PLUGIN-TAXONOMY.md) | Plugin categories and naming. |
+| [PLUGIN-MENU.md](./PLUGIN-MENU.md) | Plugin-provided menu entries. |
+| [HOOK-MENU-PACKAGE.md](./HOOK-MENU-PACKAGE.md) | Shared hook-menu package integration. |
+| [examples/unified-plugin](./examples/unified-plugin/plugin.json) / [index.ts](./examples/unified-plugin/index.ts) | Example unified plugin manifest and entrypoint. |
+| [MENU-AUTOLOAD.md](./MENU-AUTOLOAD.md) | `ORACLE_MENU_DIR` menu autoloading. |
+| [MENU-CONFIG.md](./MENU-CONFIG.md) | Menu configuration sources and overrides. |
+| [MULTI-STUDIO.md](./MULTI-STUDIO.md) | Multi-studio menu tags and domains. |
+| [dashboard-proposal.md](./dashboard-proposal.md) | Dashboard proposal and UI shape. |
+
+## Federation, memory, and oracle workflows
+
+| Guide | Focus |
+| --- | --- |
+| [FEDERATION.md](./FEDERATION.md) | Pair and secure Arra peers. |
+| [HUGINN-MUNINN.md](./HUGINN-MUNINN.md) | Capture/recall taxonomy and naming split. |
+| [huginn-capture.md](./huginn-capture.md) | Huginn auto-capture hook behavior. |
+| [MORNING-TAPE-TEMPLATE.md](./MORNING-TAPE-TEMPLATE.md) | Challenge 2 memory bootstrapping template. |
+| [oracles/thor-stormforge.md](./oracles/thor-stormforge.md) | Thor Oracle Stormforge workflow profile. |
+
+## Contributor and issue docs
+
+| Guide | Focus |
+| --- | --- |
+| [CONTRIBUTING.md](../CONTRIBUTING.md) | Repo-level branch and PR rules. |
+| [CONTRIBUTING.md](./CONTRIBUTING.md) | Source contributor quickstart. |
+| [CONTRIBUTING-AWAKENING.md](./CONTRIBUTING-AWAKENING.md) | Oracle Awakening contribution announcements. |
+| [GITHUB-ISSUE-UPDATES.md](./GITHUB-ISSUE-UPDATES.md) | Polished issue update format. |
+| [CHANGELOG.md](../CHANGELOG.md) | Release notes and alpha wave changes. |
+| [issues/1598-hermes-agent-desktop-codex-3.md](./issues/1598-hermes-agent-desktop-codex-3.md) | #1598 desktop architecture review. |
+| [issues/hermes-agent-architecture-review-1598.md](./issues/hermes-agent-architecture-review-1598.md) | #1598 Hermes desktop review. |
+| [issues/memory-systems-ai-agents-1648.md](./issues/memory-systems-ai-agents-1648.md) | #1648 memory-systems research. |
+| [issues/multi-tenant-http-isolation-design.md](./issues/multi-tenant-http-isolation-design.md) | Multi-tenant HTTP isolation design. |
+| [issues/trace-log-feature-spec.md](./issues/trace-log-feature-spec.md) | Trace log feature specification. |
+
+## Specs and source references
+
+| Guide | Focus |
+| --- | --- |
+| [SPEC-original.md](./SPEC-original.md) | Original Arra Oracle V3 specification. |
+| [README.md](../README.md) | Project overview and top-level install snippets. |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,166 @@
+# Troubleshooting guide
+
+Use this guide when install, startup, MCP, HTTP, vector, plugin, or Docker flows
+fail. Start with the quickest health check, then narrow by symptom.
+
+## Quick triage
+
+```bash
+arra-oracle-v3 --help
+arra --help
+arra health
+curl -sf http://localhost:47778/api/health
+bunx tsc --noEmit
+```
+
+If the HTTP server runs on a non-default port, replace `47778` with that port or
+set the CLI target with `arra config add` and `arra config use`.
+
+## Install or PATH issues
+
+Symptoms: `command not found: arra`, `command not found: arra-oracle-v3`, or an
+old binary keeps running.
+
+- Reinstall from the pinned tag or branch shown in the release/issue.
+- Check Bun's global bin directory with `bun pm bin -g` and ensure it is on
+  `PATH`.
+- Prefer the short operator binary for day-to-day use: `arra`.
+- Use the long binary when debugging package installation: `arra-oracle-v3`.
+
+```bash
+bun pm bin -g
+bun add -g github:Soul-Brews-Studio/arra-oracle-v3#alpha
+arra-oracle-v3 --help
+arra --help
+```
+
+## Server will not start
+
+Symptoms: port binding errors, `EADDRINUSE`, or the CLI points at a dead server.
+
+- Pick a free port and tell both server and CLI about it.
+- Check whether another Arra instance, Docker container, or dev server owns the
+  default `47778` port.
+- Keep server logs visible during first setup.
+
+```bash
+ORACLE_PORT=47881 arra-oracle-v3 serve --port 47881
+arra config add local-47881 http://localhost:47881
+arra config use local-47881
+curl -sf http://localhost:47881/api/health
+```
+
+## HTTP auth returns 401 or 403
+
+Protected `/api/*` routes require a bearer token when `ARRA_API_TOKEN` is set.
+Open health/docs/identity routes may still work, which can make auth failures
+look like route-specific bugs.
+
+```bash
+export ARRA_API_TOKEN='copy-server-token'
+curl -H "Authorization: Bearer $ARRA_API_TOKEN" \
+  http://localhost:47778/api/stats
+```
+
+For tenant-scoped deployments, add the tenant header and optional tenant token:
+
+```bash
+curl -H "Authorization: Bearer $ARRA_API_TOKEN" \
+  -H 'X-Oracle-Tenant: team-a' \
+  -H 'X-Oracle-Tenant-Token: tenant-secret' \
+  http://localhost:47778/api/search?q=oracle
+```
+
+`X-Tenant-ID` is accepted by legacy middleware, but new docs and clients should
+prefer `X-Oracle-Tenant`.
+
+## Empty results in multi-tenant mode
+
+Symptoms: health is green but search, dashboard, traces, or lists show no rows.
+
+- Confirm the request uses the tenant that originally wrote or indexed the data.
+- Re-run the same query without tenant headers only against a local development
+  server, never against shared deployments.
+- Verify import/index jobs wrote to the intended tenant before assuming vector
+  search is broken.
+
+## MCP stdio JSON parse errors
+
+Symptoms: the MCP client reports invalid JSON, unexpected log text, or protocol
+parse failures.
+
+- Send logs to stderr so stdout remains JSON-RPC only.
+- Use embedded mode by leaving `ORACLE_HTTP_URL` unset.
+- Use HTTP-proxy mode by setting `ORACLE_HTTP_URL` to a healthy Arra backend.
+
+```json
+{
+  "env": {
+    "ORACLE_LOG_TARGET": "stderr",
+    "ORACLE_HTTP_URL": "http://localhost:47778"
+  }
+}
+```
+
+## MCP proxy cannot reach HTTP backend
+
+Symptoms: MCP tools return connection refused, 502, or upstream unavailable.
+
+```bash
+curl -sf http://localhost:47778/api/health
+ORACLE_HTTP_URL=http://localhost:47778 bun src/index.ts
+```
+
+If health fails, fix server startup first. If health passes, verify proxy env is
+visible to the MCP process and that `ARRA_API_TOKEN` matches the server when auth
+is enabled.
+
+## Vector search is unavailable or empty
+
+Symptoms: `/api/vector/health` is degraded/down, semantic results are empty, or a
+vector sidecar proxy returns 502/503.
+
+- Check `/api/vector/health` and `/api/vector/config`.
+- Use FTS/search routes while vector adapters are offline.
+- Re-run indexing after imports, adapter switches, or collection config changes.
+- Confirm vector sidecar env such as `VECTOR_URL`, `VECTOR_DB_URL`, `QDRANT_URL`,
+  or `ORACLE_VECTOR_DB` matches the selected adapter.
+
+```bash
+curl -sf http://localhost:47778/api/vector/health
+curl -sf http://localhost:47778/api/vector/config
+curl 'http://localhost:47778/api/search?q=oracle&mode=fts&limit=5'
+```
+
+## Plugin or menu entry is missing
+
+- Confirm the plugin has a valid `plugin.json` manifest.
+- Restart or reload after adding a plugin directory.
+- Check both plugin and menu surfaces.
+- If the plugin exposes a sidecar server, verify its health endpoint.
+
+```bash
+curl -sf http://localhost:47778/api/plugins
+curl -sf http://localhost:47778/api/menu
+curl -sf http://localhost:47778/api/mcp/tools
+```
+
+## Docker data or port issues
+
+- Mount a persistent data volume so indexes and config survive container
+  restarts.
+- Publish the HTTP port you actually configured.
+- Keep `ORACLE_LOG_TARGET=stderr` for stdio-style containers.
+- Pass `ARRA_API_TOKEN` and tenant env explicitly instead of relying on your
+  shell environment.
+
+## What to include in a bug report
+
+Include enough detail to reproduce without secrets:
+
+- OS, Bun version, install command, and package tag/commit.
+- Server command, selected port, Docker image tag if used.
+- Sanitized environment keys, especially auth, tenant, MCP, and vector knobs.
+- Exact request/CLI command plus status code and response body.
+- Relevant server logs with tokens redacted.
+- Whether the same operation works through `/api/docs`, CLI, MCP, or curl.


### PR DESCRIPTION
## Summary
- rewrite `docs/README.md` into a complete categorized navigation map
- link every Markdown guide under `docs/`, plus `openapi.json` and unified plugin examples
- include troubleshooting, FAQ, and API reference index docs so navigation is standalone against current `alpha`

## Validation
- `bun test --isolate tests/http/docs/ tests/http/swagger/ tests/http/health/` (22 pass)
- `bunx tsc --noEmit`
- `git diff --check`
- docs navigation script: no missing Markdown guide links
- `wc -l docs/README.md docs/TROUBLESHOOTING.md docs/FAQ.md docs/API-REFERENCE-INDEX.md` (all <=250 lines)