### PR TITLE
test: harden lib config and mcp coverage

### DIFF
--- a/tests/config/profiles.test.ts
+++ b/tests/config/profiles.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import {
   applyProfileDefaults,
+  applyProfileDefaultsToProcessEnv,
   resolveArraEnv,
   resolveConfigProfile,
 } from '../../src/config/profiles.ts';
@@ -38,6 +39,21 @@ describe('environment config profiles', () => {
     expect(profile.verboseLogging).toBe(true);
     expect(profile.rateLimit.tokensPerWindow).toBe(250);
     expect(profile.rateLimit.burst).toBe(300);
+  });
+
+  test('process env defaults fill blanks without overwriting explicit values', () => {
+    const env = {
+      HOME: '/tmp/arra-home',
+      ARRA_ENV: 'staging',
+      DEBUG: '1',
+      ARRA_RATE_LIMIT_ENABLED: ' ',
+    } as NodeJS.ProcessEnv;
+    const merged = applyProfileDefaultsToProcessEnv(env);
+
+    expect(env.DEBUG).toBe('1');
+    expect(env.ARRA_RATE_LIMIT_ENABLED).toBe('1');
+    expect(env.ORACLE_GATEWAY_HOT_RELOAD).toBe('1');
+    expect(merged.ARRA_ENV).toBe('staging');
   });
 
   test('profile booleans accept padded truthy values', () => {

--- a/tests/config/validate.test.ts
+++ b/tests/config/validate.test.ts
@@ -76,6 +76,15 @@ describe('config env validation', () => {
       .toThrow(/Proxy vector DB requires ORACLE_PROXY_VECTOR_URL/);
   });
 
+  test('requires provider credentials for remote embedding backends', () => {
+    expect(() => validateEnv({ env: { HOME: '/tmp/arra-home', ORACLE_EMBEDDER: 'remote' }, emitOptionalWarnings: false }))
+      .toThrow(/Remote embedder requires ORACLE_EMBEDDER_URL or ORACLE_REMOTE_EMBEDDING_URL/);
+    expect(() => validateEnv({ env: { HOME: '/tmp/arra-home', ORACLE_EMBEDDER: 'openai' }, emitOptionalWarnings: false }))
+      .toThrow(/OpenAI embedder requires OPENAI_API_KEY/);
+    expect(() => validateEnv({ env: { HOME: '/tmp/arra-home', ORACLE_VECTOR_DB: 'cloudflare-vectorize' }, emitOptionalWarnings: false }))
+      .toThrow(/Cloudflare vector\/AI config requires CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN/);
+  });
+
   test('rejects non-http remote service URLs clearly', () => {
     expect(() => validateEnv({
       env: { HOME: '/tmp/arra-home', ORACLE_VECTOR_DB: 'proxy', ORACLE_PROXY_VECTOR_URL: 'ftp://vectors' },

--- a/tests/lib/oracle-v2-client.test.ts
+++ b/tests/lib/oracle-v2-client.test.ts
@@ -60,6 +60,34 @@ test('OracleV2Client avoids duplicating /api when base URL already includes it',
   expect(urls).toEqual(['https://old.example/api/collections']);
 });
 
+test('OracleV2Client normalizes alternate payload keys and string documents', async () => {
+  const urls: string[] = [];
+  const client = new OracleV2Client({
+    baseUrl: 'https://old.example',
+    fetch: async (input) => {
+      const url = String(input);
+      urls.push(url);
+      if (url.endsWith('/api/collections')) {
+        return json({ items: [{ key: ' trace_log ', rowCount: 2 }, { id: 'docs', documentCount: 1 }] });
+      }
+      return json({ rows: ['plain body', { id: 'doc-2', title: 'Second' }] });
+    },
+  });
+
+  await expect(client.listCollections()).resolves.toMatchObject([
+    { name: 'trace_log', rowCount: 2 },
+    { name: 'docs', documentCount: 1 },
+  ]);
+  await expect(client.listDocuments(' trace_log ')).resolves.toEqual([
+    { collection: 'trace_log', content: 'plain body' },
+    { collection: 'trace_log', id: 'doc-2', title: 'Second' },
+  ]);
+  expect(urls).toEqual([
+    'https://old.example/api/collections',
+    'https://old.example/api/documents?collection=trace_log',
+  ]);
+});
+
 test('OracleV2Client reports invalid inputs and backend errors', async () => {
   const client = new OracleV2Client({
     baseUrl: 'https://old.example',

--- a/tests/mcp/http-proxy-posts-trace-distill.test.ts
+++ b/tests/mcp/http-proxy-posts-trace-distill.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'bun:test';
+import { captureProxyRequest } from './support/http-proxy.ts';
+
+test('HTTP proxy maps oracle_trace_distill and omits path-only trace id from the body', async () => {
+  expect(await captureProxyRequest('oracle_trace_distill', {
+    traceId: 'tr/1',
+    summary: 'distilled',
+  })).toMatchObject({
+    method: 'POST',
+    path: '/api/traces/tr%2F1/distill',
+    body: { summary: 'distilled' },
+  });
+});

--- a/tests/mcp/http-proxy-skips-trace-distill-without-id.test.ts
+++ b/tests/mcp/http-proxy-skips-trace-distill-without-id.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from 'bun:test';
+import { proxyToolCall } from '../../src/mcp/http-proxy.ts';
+
+test('HTTP proxy skips oracle_trace_distill without a trace id', async () => {
+  expect(await proxyToolCall('http://127.0.0.1:1', 'oracle_trace_distill', { summary: 'missing id' }))
+    .toBeNull();
+});

--- a/tests/mcp/tenant-env-fallback.test.ts
+++ b/tests/mcp/tenant-env-fallback.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from 'bun:test';
+import { TENANT_HEADER } from '../../src/middleware/tenant.ts';
+import { mcpTenantHeaders, tenantIdFromMcpArgs } from '../../src/mcp/tenant.ts';
+
+test('MCP tenant parser falls back to environment tenant hints and emits headers', () => {
+  const previous = {
+    ORACLE_TENANT_ID: process.env.ORACLE_TENANT_ID,
+    ORACLE_TENANT: process.env.ORACLE_TENANT,
+  };
+  try {
+    process.env.ORACLE_TENANT_ID = 'tenant-env';
+    process.env.ORACLE_TENANT = 'tenant-secondary';
+
+    expect(tenantIdFromMcpArgs({ tenantId: ' ', query: 'x' })).toBe('tenant-env');
+    expect(mcpTenantHeaders('tenant-env')).toEqual({ [TENANT_HEADER]: 'tenant-env' });
+    expect(mcpTenantHeaders(undefined)).toEqual({});
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- Added Oracle v2 client coverage for alternate collection/document payload keys and string document rows.
- Added config coverage for process profile default mutation and missing provider credential failures.
- Added MCP coverage for trace distill proxy mapping/skipping and tenant env fallback/header emission.

## Validation
```bash
bun test tests/lib tests/config tests/mcp
bunx tsc --noEmit
```

## Notes
- No UI changes; screenshot not applicable.
- Changed files are all <= 250 lines.
