### PR TITLE
feat(vector): add Cloudflare Workers vector backend

### DIFF
--- a/docs/cloudflare-vector-backend.md
+++ b/docs/cloudflare-vector-backend.md
@@ -1,0 +1,43 @@
+# Cloudflare Workers vector backend
+
+Issue #2167 needs a Workers-compatible vector path because local SQLite and
+`sqlite-vec` are not an edge runtime storage strategy. The vector factory can
+now build the existing `cloudflare-vectorize` adapter from Workers bindings:
+
+```ts
+createVectorStore({
+  type: 'cloudflare-vectorize',
+  collectionName: 'oracle_knowledge_bge_m3',
+  cfAi: env.AI,
+  cfD1: env.DB,
+  cfVectorize: env.VECTORIZE,
+});
+```
+
+## Runtime shape
+
+- `env.VECTORIZE` stores vectors and handles nearest-neighbor queries.
+- `env.AI` embeds text with Workers AI, defaulting to `@cf/baai/bge-m3`.
+- `env.DB` stores document text and metadata for query hydration, stats, and
+  collection deletes.
+- No Cloudflare REST account token is required when all three bindings are
+  supplied. The REST adapter remains available for Bun/CLI usage.
+
+## D1 table contract
+
+The adapter does not create tables at runtime. Provision this table via the
+Worker deploy/migration path:
+
+```sql
+CREATE TABLE IF NOT EXISTS oracle_vector_documents (
+  collection TEXT NOT NULL,
+  id TEXT NOT NULL,
+  document TEXT NOT NULL,
+  metadata TEXT NOT NULL DEFAULT '{}',
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (collection, id)
+);
+```
+
+`ensureCollection()` fails fast with a migration-oriented error when the table is
+missing, so Worker health checks can surface the deployment gap clearly.

--- a/src/vector/adapters/cloudflare-worker.ts
+++ b/src/vector/adapters/cloudflare-worker.ts
@@ -1,0 +1,228 @@
+import type { EmbeddingProvider, VectorDocument, VectorQueryResult, VectorStoreAdapter } from '../types.ts';
+
+type D1Value = string | number | null;
+type D1Result<T> = { results?: T[] };
+type VectorMetadata = Record<string, string | number | boolean>;
+
+export interface CloudflareD1Statement {
+  bind(...values: D1Value[]): CloudflareD1Statement;
+  run<T = unknown>(): Promise<D1Result<T>>;
+  all<T = unknown>(): Promise<D1Result<T>>;
+  first<T = unknown>(): Promise<T | null>;
+}
+
+export interface CloudflareD1Database {
+  prepare(sql: string): CloudflareD1Statement;
+  batch(statements: CloudflareD1Statement[]): Promise<unknown[]>;
+}
+
+export interface CloudflareAIWorkerBinding {
+  run(model: string, input: { text: string[] }): Promise<{ data?: number[][]; result?: { data?: number[][] } }>;
+}
+
+export interface CloudflareVectorizeBinding {
+  upsert(vectors: Array<{ id: string; values: number[]; metadata?: VectorMetadata }>): Promise<unknown>;
+  query(vector: number[], options?: Record<string, unknown>): Promise<unknown>;
+  queryById?(id: string, options?: Record<string, unknown>): Promise<unknown>;
+  getByIds?(ids: string[]): Promise<unknown>;
+  deleteByIds?(ids: string[]): Promise<unknown>;
+}
+
+interface D1VectorRow { id: string; document: string; metadata: string }
+interface VectorizeMatch { id: string; score?: number; metadata?: Record<string, unknown> }
+
+const CF_MODEL = '@cf/baai/bge-m3';
+const CF_DIMENSIONS = 1024;
+const TABLE = 'oracle_vector_documents';
+
+export class CloudflareWorkerAIEmbeddings implements EmbeddingProvider {
+  readonly name = 'cloudflare-ai';
+  readonly dimensions = CF_DIMENSIONS;
+  private model: string;
+
+  constructor(private ai: CloudflareAIWorkerBinding, config: { model?: string } = {}) {
+    this.model = config.model || CF_MODEL;
+  }
+
+  async embed(texts: string[]): Promise<number[][]> {
+    if (!texts.length) return [];
+    const response = await this.ai.run(this.model, { text: texts.map((text) => text.slice(0, 3000)) });
+    const data = response.data ?? response.result?.data;
+    if (!Array.isArray(data) || data.length !== texts.length) throw new Error('Cloudflare Workers AI returned invalid embeddings');
+    for (const vector of data) assertVector(vector);
+    return data;
+  }
+}
+
+export class CloudflareVectorizeD1Adapter implements VectorStoreAdapter {
+  readonly name = 'cloudflare-vectorize';
+  private table: string;
+
+  constructor(
+    private collectionName: string,
+    private embedder: EmbeddingProvider,
+    private bindings: { vectorize: CloudflareVectorizeBinding; d1: CloudflareD1Database },
+    config: { tableName?: string } = {},
+  ) {
+    this.table = quoteIdentifier(config.tableName || TABLE);
+  }
+
+  async connect(): Promise<void> { await this.ensureCollection(); }
+  async close(): Promise<void> {}
+
+  async ensureCollection(): Promise<void> {
+    try {
+      await this.bindings.d1.prepare(`SELECT COUNT(*) AS count FROM ${this.table} WHERE collection = ?`)
+        .bind(this.collectionName).first();
+    } catch (error) {
+      throw new Error(`Cloudflare D1 vector table ${this.table} is unavailable; run the Workers D1 migration first: ${message(error)}`);
+    }
+  }
+
+  async addDocuments(docs: VectorDocument[]): Promise<void> {
+    if (!docs.length) return;
+    await this.bindings.vectorize.upsert(await this.vectorsFor(docs));
+    await this.writeRows(docs);
+  }
+
+  async replaceDocuments(docs: VectorDocument[]): Promise<void> {
+    await this.deleteCollection();
+    await this.addDocuments(docs);
+  }
+
+  async deleteCollection(): Promise<void> {
+    const ids = (await this.rowsForCollection()).map((row) => row.id);
+    for (let i = 0; i < ids.length; i += 100) await this.bindings.vectorize.deleteByIds?.(ids.slice(i, i + 100));
+    await this.bindings.d1.prepare(`DELETE FROM ${this.table} WHERE collection = ?`).bind(this.collectionName).run();
+  }
+
+  async query(text: string, limit = 10, where?: Record<string, unknown>): Promise<VectorQueryResult> {
+    const [vector] = await this.embedder.embed([text], 'query');
+    const response = await this.bindings.vectorize.query(vector, {
+      topK: topK(limit),
+      returnValues: false,
+      returnMetadata: 'all',
+      ...(where && { filter: eqFilter(where) }),
+    });
+    return this.hydrate(matches(response));
+  }
+
+  async queryById(id: string, nResults = 5): Promise<VectorQueryResult> {
+    const options = { topK: topK(nResults + 1), returnValues: false, returnMetadata: 'all' };
+    const response = this.bindings.vectorize.queryById
+      ? await this.bindings.vectorize.queryById(id, options)
+      : await this.queryByStoredVector(id, options);
+    return this.hydrate(matches(response).filter((match) => match.id !== id).slice(0, topK(nResults)));
+  }
+
+  async getStats(): Promise<{ count: number }> {
+    const row = await this.bindings.d1.prepare(`SELECT COUNT(*) AS count FROM ${this.table} WHERE collection = ?`)
+      .bind(this.collectionName).first<{ count: number }>();
+    return { count: nonNegative(row?.count) };
+  }
+
+  async getCollectionInfo(): Promise<{ count: number; name: string }> {
+    return { ...(await this.getStats()), name: this.collectionName };
+  }
+
+  private async queryByStoredVector(id: string, options: Record<string, unknown>): Promise<unknown> {
+    const found = await this.bindings.vectorize.getByIds?.([id]);
+    const record = vectors(found)[0];
+    if (!record?.values) throw new Error(`No embedding found for document: ${id}`);
+    return this.bindings.vectorize.query(record.values, options);
+  }
+
+  private async vectorsFor(docs: VectorDocument[]) {
+    const missing = docs.filter((doc) => !doc.vector);
+    const embedded = missing.length ? await this.embedder.embed(missing.map((doc) => doc.document), 'passage') : [];
+    if (embedded.length !== missing.length) throw new Error(`Cloudflare embedder returned ${embedded.length} vectors for ${missing.length} documents`);
+    let offset = 0;
+    return docs.map((doc) => {
+      const values = doc.vector ?? embedded[offset++];
+      assertVector(values);
+      return { id: doc.id, values, metadata: { ...doc.metadata, collection: this.collectionName } };
+    });
+  }
+
+  private async writeRows(docs: VectorDocument[]): Promise<void> {
+    const sql = `INSERT INTO ${this.table} (collection,id,document,metadata,updated_at) VALUES (?,?,?,?,?) `
+      + 'ON CONFLICT(collection,id) DO UPDATE SET document=excluded.document, metadata=excluded.metadata, updated_at=excluded.updated_at';
+    const now = new Date().toISOString();
+    const statements = docs.map((doc) => this.bindings.d1.prepare(sql)
+      .bind(this.collectionName, doc.id, doc.document, JSON.stringify(doc.metadata), now));
+    for (let i = 0; i < statements.length; i += 50) await this.bindings.d1.batch(statements.slice(i, i + 50));
+  }
+
+  private async rowsFor(ids: string[]): Promise<Map<string, D1VectorRow>> {
+    if (!ids.length) return new Map();
+    const placeholders = ids.map(() => '?').join(',');
+    const result = await this.bindings.d1.prepare(
+      `SELECT id, document, metadata FROM ${this.table} WHERE collection = ? AND id IN (${placeholders})`,
+    ).bind(this.collectionName, ...ids).all<D1VectorRow>();
+    return new Map((result.results ?? []).map((row) => [row.id, row]));
+  }
+
+  private async rowsForCollection(): Promise<D1VectorRow[]> {
+    const result = await this.bindings.d1.prepare(`SELECT id, document, metadata FROM ${this.table} WHERE collection = ?`)
+      .bind(this.collectionName).all<D1VectorRow>();
+    return result.results ?? [];
+  }
+
+  private async hydrate(found: VectorizeMatch[]): Promise<VectorQueryResult> {
+    const rows = await this.rowsFor(found.map((match) => match.id));
+    return {
+      ids: found.map((match) => match.id),
+      documents: found.map((match) => rows.get(match.id)?.document ?? String(match.metadata?.document ?? '')),
+      distances: found.map((match) => 1 - nonNegative(match.score)),
+      metadatas: found.map((match) => parseMetadata(rows.get(match.id)?.metadata, match.metadata)),
+    };
+  }
+}
+
+function quoteIdentifier(value: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(value)) throw new Error(`Invalid D1 vector table name: ${value}`);
+  return `"${value}"`;
+}
+
+function topK(value: number): number {
+  return Math.max(1, Math.min(50, Number.isFinite(value) ? Math.trunc(value) : 10));
+}
+
+function nonNegative(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function eqFilter(where: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(where).map(([key, value]) => [key, { $eq: value }]));
+}
+
+function matches(value: unknown): VectorizeMatch[] {
+  const record = value as { matches?: VectorizeMatch[]; result?: { matches?: VectorizeMatch[] } };
+  return Array.isArray(record?.matches) ? record.matches : Array.isArray(record?.result?.matches) ? record.result.matches : [];
+}
+
+function vectors(value: unknown): Array<{ values?: number[] }> {
+  const record = value as { vectors?: Array<{ values?: number[] }>; result?: Array<{ values?: number[] }> };
+  if (Array.isArray(value)) return value as Array<{ values?: number[] }>;
+  return Array.isArray(record?.vectors) ? record.vectors : Array.isArray(record?.result) ? record.result : [];
+}
+
+function parseMetadata(raw: string | undefined, fallback: Record<string, unknown> = {}): Record<string, unknown> {
+  try { return raw ? JSON.parse(raw) as Record<string, unknown> : stripDocument(fallback); }
+  catch { return stripDocument(fallback); }
+}
+
+function stripDocument(value: Record<string, unknown>): Record<string, unknown> {
+  const { document, ...rest } = value;
+  return rest;
+}
+
+function assertVector(value: unknown): asserts value is number[] {
+  if (!Array.isArray(value) || value.length === 0 || value.some((item) => typeof item !== 'number' || !Number.isFinite(item))) {
+    throw new Error('Cloudflare vector must be a non-empty finite number array');
+  }
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/vector/adapters/cloudflare.ts
+++ b/src/vector/adapters/cloudflare.ts
@@ -1,0 +1,63 @@
+import type { VectorStoreAdapter } from '../types.ts';
+import { CloudflareAIEmbeddings, CloudflareVectorizeAdapter } from './cloudflare-vectorize.ts';
+import {
+  CloudflareVectorizeD1Adapter,
+  CloudflareWorkerAIEmbeddings,
+  type CloudflareAIWorkerBinding,
+  type CloudflareD1Database,
+  type CloudflareVectorizeBinding,
+} from './cloudflare-worker.ts';
+
+export interface CloudflareVectorStoreOptions {
+  embeddingModel?: string;
+  cfAccountId?: string;
+  cfApiToken?: string;
+  cfVectorize?: CloudflareVectorizeBinding;
+  cfD1?: CloudflareD1Database;
+  cfAi?: CloudflareAIWorkerBinding;
+  cfD1Table?: string;
+}
+
+export function createCloudflareVectorStore(
+  collectionName: string,
+  config: CloudflareVectorStoreOptions = {},
+): VectorStoreAdapter {
+  const model = config.embeddingModel || process.env.ORACLE_EMBEDDING_MODEL;
+  if (config.cfVectorize && config.cfD1) {
+    const embedder = config.cfAi
+      ? new CloudflareWorkerAIEmbeddings(config.cfAi, { model })
+      : new CloudflareAIEmbeddings({ ...restConfig(config), model });
+    return new CloudflareVectorizeD1Adapter(collectionName, embedder, {
+      vectorize: config.cfVectorize,
+      d1: config.cfD1,
+    }, { tableName: config.cfD1Table });
+  }
+  const cfConfig = restConfig(config);
+  return new CloudflareVectorizeAdapter(
+    collectionName,
+    new CloudflareAIEmbeddings({ ...cfConfig, model }),
+    cfConfig,
+  );
+}
+
+function restConfig(config: CloudflareVectorStoreOptions) {
+  return {
+    accountId: clean(config.cfAccountId) || clean(process.env.CF_ACCOUNT_ID) || clean(process.env.CLOUDFLARE_ACCOUNT_ID),
+    apiToken: clean(config.cfApiToken) || clean(process.env.CF_API_TOKEN) || clean(process.env.CLOUDFLARE_API_TOKEN),
+  };
+}
+
+function clean(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+export { CloudflareAIEmbeddings, CloudflareVectorizeAdapter } from './cloudflare-vectorize.ts';
+export {
+  CloudflareVectorizeD1Adapter,
+  CloudflareWorkerAIEmbeddings,
+  type CloudflareAIWorkerBinding,
+  type CloudflareD1Database,
+  type CloudflareD1Statement,
+  type CloudflareVectorizeBinding,
+} from './cloudflare-worker.ts';

--- a/src/vector/adapters/index.ts
+++ b/src/vector/adapters/index.ts
@@ -3,5 +3,6 @@ export { SqliteVecAdapter } from './sqlite-vec.ts';
 export { LanceDBAdapter } from './lancedb.ts';
 export { QdrantAdapter } from './qdrant.ts';
 export { CloudflareVectorizeAdapter, CloudflareAIEmbeddings } from './cloudflare-vectorize.ts';
+export { CloudflareVectorizeD1Adapter, CloudflareWorkerAIEmbeddings } from './cloudflare-worker.ts';
 export { ProxyVectorAdapter } from './proxy.ts';
 export { TurboVecAdapter } from './turbovec.ts';

--- a/src/vector/factory.ts
+++ b/src/vector/factory.ts
@@ -5,7 +5,7 @@ import { ChromaMcpAdapter } from './adapters/chroma-mcp.ts';
 import { SqliteVecAdapter } from './adapters/sqlite-vec.ts';
 import { LanceDBAdapter } from './adapters/lancedb.ts';
 import { QdrantAdapter } from './adapters/qdrant.ts';
-import { CloudflareVectorizeAdapter, CloudflareAIEmbeddings } from './adapters/cloudflare-vectorize.ts';
+import { createCloudflareVectorStore, type CloudflareAIWorkerBinding, type CloudflareD1Database, type CloudflareVectorizeBinding } from './adapters/cloudflare.ts';
 import { ProxyVectorAdapter } from './adapters/proxy.ts';
 import { TurboVecAdapter } from './adapters/turbovec.ts';
 import { createEmbeddingProvider, FallbackEmbeddings } from './embeddings.ts';
@@ -27,6 +27,10 @@ export interface VectorStoreConfig {
   qdrantApiKey?: string;
   cfAccountId?: string;
   cfApiToken?: string;
+  cfAi?: CloudflareAIWorkerBinding;
+  cfVectorize?: CloudflareVectorizeBinding;
+  cfD1?: CloudflareD1Database;
+  cfD1Table?: string;
   proxyEndpoint?: string;
 }
 export interface EmbeddingModelConfig {
@@ -70,17 +74,7 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
       });
     }
     case 'cloudflare-vectorize': {
-      const cfConfig = {
-        accountId: clean(config.cfAccountId) || clean(process.env.CF_ACCOUNT_ID) || clean(process.env.CLOUDFLARE_ACCOUNT_ID),
-        apiToken: clean(config.cfApiToken) || clean(process.env.CF_API_TOKEN) || clean(process.env.CLOUDFLARE_API_TOKEN),
-      };
-      const embeddingModel = config.embeddingModel
-        || process.env.ORACLE_EMBEDDING_MODEL;
-      const embedder = new CloudflareAIEmbeddings({
-        ...cfConfig,
-        model: embeddingModel,
-      });
-      return new CloudflareVectorizeAdapter(collectionName, embedder, cfConfig);
+      return createCloudflareVectorStore(collectionName, config);
     }
     case 'proxy': {
       const proxyUrl = clean(config.proxyEndpoint) || clean(process.env.ORACLE_PROXY_VECTOR_URL);

--- a/tests/vector/cloudflare-worker-vector.test.ts
+++ b/tests/vector/cloudflare-worker-vector.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from 'bun:test';
+import { createVectorStore } from '../../src/vector/factory.ts';
+import {
+  CloudflareVectorizeD1Adapter,
+  CloudflareWorkerAIEmbeddings,
+  type CloudflareAIWorkerBinding,
+  type CloudflareD1Database,
+  type CloudflareD1Statement,
+  type CloudflareVectorizeBinding,
+} from '../../src/vector/adapters/cloudflare.ts';
+
+type Row = { id: string; document: string; metadata: string };
+type Vector = { id: string; values: number[]; metadata?: Record<string, unknown> };
+
+class MockStatement implements CloudflareD1Statement {
+  private values: Array<string | number | null> = [];
+  constructor(private sql: string, private rows: Map<string, Row>) {}
+  bind(...values: Array<string | number | null>) { this.values = values; return this; }
+  async run<T = unknown>() {
+    const [collection, id, document, metadata] = this.values;
+    if (this.sql.startsWith('INSERT')) this.rows.set(`${collection}:${id}`, { id: String(id), document: String(document), metadata: String(metadata) });
+    if (this.sql.startsWith('DELETE')) for (const key of [...this.rows.keys()]) if (key.startsWith(`${collection}:`)) this.rows.delete(key);
+    return { results: [] as T[] };
+  }
+  async all<T = unknown>() {
+    const [collection, ...ids] = this.values.map(String);
+    const rows = [...this.rows.entries()]
+      .filter(([key, row]) => key.startsWith(`${collection}:`) && (!ids.length || ids.includes(row.id)))
+      .map(([, row]) => row as T);
+    return { results: rows };
+  }
+  async first<T = unknown>() {
+    if (!this.sql.includes('COUNT')) return null;
+    const collection = String(this.values[0]);
+    const count = [...this.rows.keys()].filter((key) => key.startsWith(`${collection}:`)).length;
+    return { count } as T;
+  }
+}
+
+function mockD1(): CloudflareD1Database {
+  const rows = new Map<string, Row>();
+  return {
+    prepare: (sql) => new MockStatement(sql, rows),
+    batch: async (statements) => Promise.all(statements.map((statement) => statement.run())),
+  };
+}
+
+function mockAI(): CloudflareAIWorkerBinding & { calls: Array<{ model: string; text: string[] }> } {
+  const calls: Array<{ model: string; text: string[] }> = [];
+  return {
+    calls,
+    run: async (model, input) => {
+      calls.push({ model, text: input.text });
+      return { data: input.text.map((_, index) => [1, index + 1, 0]) };
+    },
+  };
+}
+
+function mockVectorize(): CloudflareVectorizeBinding & { records: Map<string, Vector>; queries: unknown[] } {
+  const records = new Map<string, Vector>();
+  const queries: unknown[] = [];
+  return {
+    records,
+    queries,
+    upsert: async (vectors) => { for (const vector of vectors) records.set(vector.id, vector); },
+    query: async (_vector, options) => {
+      queries.push(options);
+      return { matches: [...records.values()].map((vector) => ({ id: vector.id, score: 0.75, metadata: vector.metadata })) };
+    },
+    getByIds: async (ids) => ids.map((id) => records.get(id)).filter(Boolean),
+    deleteByIds: async (ids) => { for (const id of ids) records.delete(id); },
+  };
+}
+
+describe('Cloudflare Workers Vectorize + D1 vector backend', () => {
+  test('stores vectors in Vectorize and hydrates documents from D1', async () => {
+    const ai = mockAI();
+    const vectorize = mockVectorize();
+    const adapter = new CloudflareVectorizeD1Adapter('edge_docs', new CloudflareWorkerAIEmbeddings(ai), {
+      vectorize,
+      d1: mockD1(),
+    });
+
+    await adapter.ensureCollection();
+    await adapter.addDocuments([{ id: 'doc-1', document: 'hello edge', metadata: { kind: 'note' } }]);
+    const result = await adapter.query('hello', Number.NaN, { kind: 'note' });
+
+    expect(ai.calls[0]).toMatchObject({ model: '@cf/baai/bge-m3', text: ['hello edge'] });
+    expect(vectorize.records.get('doc-1')?.metadata).toMatchObject({ kind: 'note', collection: 'edge_docs' });
+    expect(vectorize.queries[0]).toMatchObject({ topK: 10, filter: { kind: { $eq: 'note' } } });
+    expect(result).toEqual({
+      ids: ['doc-1'],
+      documents: ['hello edge'],
+      distances: [0.25],
+      metadatas: [{ kind: 'note' }],
+    });
+    expect(await adapter.getStats()).toEqual({ count: 1 });
+  });
+
+  test('factory selects the Workers binding adapter without REST credentials', () => {
+    const store = createVectorStore({
+      type: 'cloudflare-vectorize',
+      collectionName: 'edge_docs',
+      cfAi: mockAI(),
+      cfD1: mockD1(),
+      cfVectorize: mockVectorize(),
+    });
+
+    expect(store).toBeInstanceOf(CloudflareVectorizeD1Adapter);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a Cloudflare Workers-native `cloudflare-vectorize` path that uses Workers bindings instead of local SQLite: `env.VECTORIZE` for vector search, `env.DB` (D1) for document/metadata hydration, and `env.AI` for embeddings.
- Keep the existing Cloudflare REST adapter for Bun/CLI, while factory config now selects the Workers Vectorize+D1 adapter when bindings are supplied.
- Document the D1 table contract and add mocked binding coverage for add/query/stats/factory behavior.

## Research notes
- Cloudflare recommends Workers bindings for platform resources; Vectorize bindings expose direct index operations such as upsert/query/getByIds, and upserts are asynchronous before vectors become queryable: https://developers.cloudflare.com/vectorize/reference/client-api/
- D1 is accessed in Workers through environment bindings with prepared statements and batch execution: https://developers.cloudflare.com/d1/worker-api/
- Workers AI is available from a Worker through an `AI` binding and `env.AI.run(...)`: https://developers.cloudflare.com/workers-ai/configuration/bindings/

## Tests
```bash
bunx tsc --noEmit
bun test tests/vector/
bun test src/vector/__tests__/*.test.ts
git diff --check origin/alpha...HEAD
```

## Notes
- Backend/docs only; no UI deploy-flow screenshot needed for this vector slice.
- Changed files are all <= 250 lines.
