### PR TITLE
test: harden workers and indexer daemon edges

### DIFF
--- a/src/routes/indexer-daemon/model.ts
+++ b/src/routes/indexer-daemon/model.ts
@@ -58,8 +58,10 @@ function parseOptionalModelFilter(value: unknown, models: ModelRegistry): ParseR
 
 function parseLimit(value: unknown): ParseResult<number> {
   if (value === undefined || value === null || value === '') return { ok: true, value: 100 };
-  if (typeof value !== 'string' || !/^\d+$/.test(value)) return { ok: false, error: 'limit must be an integer between 1 and 1000' };
-  const limit = Number(value);
+  if (typeof value !== 'string') return { ok: false, error: 'limit must be an integer between 1 and 1000' };
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) return { ok: false, error: 'limit must be an integer between 1 and 1000' };
+  const limit = Number(trimmed);
   if (!Number.isSafeInteger(limit) || limit < 1) return { ok: false, error: 'limit must be an integer between 1 and 1000' };
   return { ok: true, value: Math.min(limit, 1000) };
 }

--- a/src/workers/canvas/index.ts
+++ b/src/workers/canvas/index.ts
@@ -48,6 +48,10 @@ function apiBase(env: CanvasWorkerEnv): string {
   try {
     const url = new URL(raw);
     if (url.protocol !== 'https:' && url.protocol !== 'http:') return DEFAULT_API_BASE;
+    url.username = '';
+    url.password = '';
+    url.search = '';
+    url.hash = '';
     return url.toString().replace(/\/$/, '');
   } catch {
     return DEFAULT_API_BASE;

--- a/tests/http/indexer-daemon/hardening.test.ts
+++ b/tests/http/indexer-daemon/hardening.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import Database from 'bun:sqlite';
 import { Elysia } from 'elysia';
-import { daemonApiPlugin } from '../../../src/routes/indexer-daemon/index.ts';
+import { daemonApiPlugin, makeEventBus } from '../../../src/routes/indexer-daemon/index.ts';
 import type { DaemonApiDeps } from '../../../src/routes/indexer-daemon/index.ts';
 import type { WorkerEvent } from '../../../src/indexer/worker.ts';
 
@@ -82,12 +82,49 @@ describe('indexer daemon input hardening', () => {
   test('trims valid job filters', async () => {
     const wired = deps();
     await app(wired).handle(new Request('http://local/index', jsonPost({ doc_id: 'doc-a', model_key: 'bge-m3' })));
-    const res = await app(wired).handle(new Request('http://local/jobs?status=%20pending%20&model=%20bge-m3%20&limit=1'));
+    const res = await app(wired).handle(new Request('http://local/jobs?status=%20pending%20&model=%20bge-m3%20&limit=%201%20'));
     const body = await res.json() as { count: number; jobs: Array<{ doc_id: string }> };
 
     expect(res.status).toBe(200);
     expect(body.count).toBe(1);
     expect(body.jobs[0].doc_id).toBe('doc-a');
+  });
+
+  test('reports queue depth for pending and claimed jobs only', async () => {
+    const wired = deps();
+    const insert = wired.db.prepare(
+      `INSERT INTO indexing_jobs (id, doc_id, model_key, collection, status, attempts, created_at)
+       VALUES (?, ?, ?, ?, ?, 0, ?)`,
+    );
+    insert.run('p1', 'doc-1', 'bge-m3', MODELS['bge-m3'].collection, 'pending', 1);
+    insert.run('c1', 'doc-2', 'bge-m3', MODELS['bge-m3'].collection, 'claimed', 2);
+    insert.run('d1', 'doc-3', 'bge-m3', MODELS['bge-m3'].collection, 'done', 3);
+    insert.run('p2', 'doc-4', 'qwen3', MODELS.qwen3.collection, 'pending', 4);
+
+    const res = await app(wired).handle(new Request('http://local/health'));
+    const body = await res.json() as { queue_depth: Record<string, number>; models: string[] };
+
+    expect(body.queue_depth).toEqual({ 'bge-m3': 2, qwen3: 1 });
+    expect(body.models).toEqual(['bge-m3', 'qwen3']);
+  });
+
+  test('drain marks the daemon unavailable for new index jobs', async () => {
+    let shuttingDown = false;
+    let drainCalls = 0;
+    const wired = deps({
+      isShuttingDown: () => shuttingDown,
+      requestShutdown: () => { drainCalls += 1; shuttingDown = true; },
+    });
+    const route = app(wired);
+
+    const drain = await route.handle(new Request('http://local/drain', { method: 'POST' }));
+    const health = await route.handle(new Request('http://local/health'));
+    const index = await route.handle(new Request('http://local/index', jsonPost({ doc_id: 'doc-a' })));
+
+    expect(await drain.json()).toEqual({ status: 'draining' });
+    expect((await health.json() as { shutting_down: boolean }).shutting_down).toBe(true);
+    expect(index.status).toBe(503);
+    expect(drainCalls).toBe(1);
   });
 });
 
@@ -99,4 +136,19 @@ test('indexer daemon event stream unsubscribes when the client cancels', async (
   await res.body?.cancel();
   expect(res.status).toBe(200);
   expect(unsubscribed).toBe(1);
+});
+
+test('indexer daemon event bus isolates throwing subscribers and supports idempotent unsubscribe', () => {
+  const events: string[] = [];
+  const bus = makeEventBus<{ type: string }>();
+  const unsubscribeThrower = bus.subscribe(() => { throw new Error('subscriber failed'); });
+  const unsubscribeRecorder = bus.subscribe((event) => events.push(event.type));
+
+  bus.publish({ type: 'claimed' });
+  unsubscribeThrower();
+  unsubscribeThrower();
+  unsubscribeRecorder();
+  bus.publish({ type: 'done' });
+
+  expect(events).toEqual(['claimed']);
 });

--- a/tests/workers/canvas-edge-cases.test.ts
+++ b/tests/workers/canvas-edge-cases.test.ts
@@ -38,6 +38,46 @@ describe('canvas worker edge cases', () => {
     expect(seen).toEqual(['https://studio.buildwithoracle.com/api/health?probe=1']);
   });
 
+  test('sanitizes configured API base before exposing it to health and HTML', async () => {
+    const env = { ORACLE_API_BASE: ' https://user:pass@oracle.example.test/root/?token=secret#frag ' };
+    const health = await handleCanvasRequest(
+      new Request('https://canvas.buildwithoracle.com/__health'),
+      env,
+    );
+    const body = await health.json() as { apiBase: string };
+    const page = await handleCanvasRequest(new Request('https://canvas.buildwithoracle.com/wave'), env);
+    const html = await page.text();
+
+    expect(body.apiBase).toBe('https://oracle.example.test/root');
+    expect(html).toContain('data-api-base="https://oracle.example.test/root"');
+    expect(html).not.toContain('user:pass');
+    expect(html).not.toContain('token=secret');
+  });
+
+  test('strips client host headers and omits bodies for HEAD API proxy requests', async () => {
+    const seen: Array<{ url: string; method: string; host: string | null; body: BodyInit | null | undefined }> = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      seen.push({
+        url: String(input),
+        method: init?.method ?? 'GET',
+        host: new Headers(init?.headers).get('host'),
+        body: init?.body,
+      });
+      return new Response(null, { status: 204 });
+    }) as typeof fetch;
+
+    const response = await handleCanvasRequest(
+      new Request('https://canvas.buildwithoracle.com/api/health', {
+        method: 'HEAD',
+        headers: { host: 'spoofed.example', 'x-api-key': 'token' },
+      }),
+      { ORACLE_API_BASE: 'https://oracle.example.test' },
+    );
+
+    expect(response.status).toBe(204);
+    expect(seen).toEqual([{ url: 'https://oracle.example.test/api/health', method: 'HEAD', host: null, body: undefined }]);
+  });
+
   test('rejects malformed percent-encoded local registry plugin ids', async () => {
     const response = await handleCanvasRequest(
       new Request('https://canvas.buildwithoracle.com/api/canvas/plugins/%E0%A4%A'),


### PR DESCRIPTION
## Summary
- sanitize canvas worker API base URLs before exposing them in health/HTML and before proxying
- add canvas worker coverage for sanitized API bases, stripped Host headers, and HEAD proxy body handling
- trim indexer-daemon job limits before validation
- add indexer-daemon coverage for queue depth, drain behavior, and event bus subscriber isolation

## Verification
```bash
bun test tests/workers/ tests/http/indexer-daemon/
bunx tsc --noEmit
git diff --check HEAD~1..HEAD
wc -l src/workers/canvas/index.ts src/routes/indexer-daemon/model.ts tests/workers/canvas-edge-cases.test.ts tests/http/indexer-daemon/hardening.test.ts
```

## Notes
- No UI changes; no screenshot needed.
- Docs not touched.