### PR TITLE
test: harden frontend routing layout edges

### DIFF
--- a/frontend/src/routePaths.ts
+++ b/frontend/src/routePaths.ts
@@ -4,10 +4,21 @@ export function mcpToolPath(name: string): string {
   return `/mcp/tools/${encodeURIComponent(name)}`;
 }
 
+function trimmed(value: string | undefined): string {
+  return value?.trim() ?? '';
+}
+
+function scopedFilter(value: string | undefined): string {
+  const normalized = trimmed(value);
+  return normalized && normalized !== 'all' ? normalized : '';
+}
+
 export function mcpToolsPath(filters: { q?: string; source?: string } = {}): string {
   const params = new URLSearchParams();
-  if (filters.q?.trim()) params.set('q', filters.q.trim());
-  if (filters.source && filters.source !== 'all') params.set('source', filters.source);
+  const q = trimmed(filters.q);
+  const source = scopedFilter(filters.source);
+  if (q) params.set('q', q);
+  if (source) params.set('source', source);
   const query = params.toString();
   return query ? `/mcp?${query}` : '/mcp';
 }
@@ -20,17 +31,22 @@ export function menuSearchPath(query: string): string {
 
 export function pluginInventoryPath(filters: { q?: string; surface?: string; visibility?: string } = {}): string {
   const params = new URLSearchParams();
-  if (filters.q?.trim()) params.set('q', filters.q.trim());
-  if (filters.surface && filters.surface !== 'all') params.set('surface', filters.surface);
-  if (filters.visibility && filters.visibility !== 'all') params.set('visibility', filters.visibility);
+  const q = trimmed(filters.q);
+  const surface = scopedFilter(filters.surface);
+  const visibility = scopedFilter(filters.visibility);
+  if (q) params.set('q', q);
+  if (surface) params.set('surface', surface);
+  if (visibility) params.set('visibility', visibility);
   const query = params.toString();
   return query ? `/plugins?${query}` : '/plugins';
 }
 
 export function menuCatalogPath(filters: { group?: string; source?: string } = {}): string {
   const params = new URLSearchParams();
-  if (filters.group && filters.group !== 'all') params.set('group', filters.group);
-  if (filters.source && filters.source !== 'all') params.set('source', filters.source);
+  const group = scopedFilter(filters.group);
+  const source = scopedFilter(filters.source);
+  if (group) params.set('group', group);
+  if (source) params.set('source', source);
   const query = params.toString();
   return query ? `/menu?${query}` : '/menu';
 }

--- a/tests/frontend/components/app-shell-route-chrome-edge.test.tsx
+++ b/tests/frontend/components/app-shell-route-chrome-edge.test.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test';
+import { MemoryRouter } from 'react-router-dom';
+import { AppShell } from '../../../frontend/src/components/AppShell';
+import { htmlFor, installBrowserLocation } from '../_render';
+
+describe('AppShell route chrome edge cases', () => {
+  test('renders query-aware vector result chrome in the layout shell', () => {
+    const restore = installBrowserLocation('/vector/results?q=oracle');
+    try {
+      const html = htmlFor(
+        <MemoryRouter initialEntries={['/vector/results?q=oracle']}>
+          <AppShell error="" loading={false} menuCount={1} pluginCount={2} surfaceCount={3} updatedAt="12:00" onRefresh={() => {}}>
+            <p>results body</p>
+          </AppShell>
+        </MemoryRouter>,
+      );
+
+      expect(html).toContain('Vector search results');
+      expect(html).toContain('Semantic matches for “oracle”.');
+      expect(html).toContain('Results: oracle');
+      expect(html).toContain('results body');
+    } finally {
+      restore();
+    }
+  });
+
+  test('keeps metric cards stable when metrics are still unavailable', () => {
+    const restore = installBrowserLocation('/menu');
+    try {
+      const html = htmlFor(
+        <MemoryRouter initialEntries={['/menu']}>
+          <AppShell error="" loading={false} menuCount={0} pluginCount={0} surfaceCount={0} metrics={null} updatedAt="never" onRefresh={() => {}}>
+            <p>child</p>
+          </AppShell>
+        </MemoryRouter>,
+      );
+
+      expect(html).toContain('Requests');
+      expect(html).toContain('Avg response');
+      expect(html).toContain('from /api/v1/metrics');
+      expect(html).toContain('—');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/tests/frontend/router.test.ts
+++ b/tests/frontend/router.test.ts
@@ -79,8 +79,13 @@ describe('frontend router', () => {
     expect(htmlAt('/vector/export')).toContain('Vector export');
     expect(htmlAt('/vector/settings')).toContain('Configure adapters, embedding models');
     expect(htmlAt('/mcp')).toContain('Tool browser');
+    expect(htmlAt('/mcp/tools/plugin%3Aecho')).toContain('MCP tool detail');
     expect(htmlAt('/storage')).toContain('Storage backend');
     expect(htmlAt('/settings')).toContain('Runtime configuration');
+  });
+
+  test('renders no stale route content before wildcard redirects in the browser', () => {
+    expect(htmlAt('/missing-route')).toBe('');
   });
 
   test('wraps routed children in the browser router and error boundary shell', () => {

--- a/tests/frontend/routes/filter-path-edge.test.ts
+++ b/tests/frontend/routes/filter-path-edge.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+import { mcpToolsPath, menuCatalogPath, pluginInventoryPath } from '../../../frontend/src/routePaths';
+
+describe('frontend filter route path edge cases', () => {
+  test('trims MCP filter values and omits all/blank selectors', () => {
+    expect(mcpToolsPath({ q: ' echo ', source: ' plugin ' })).toBe('/mcp?q=echo&source=plugin');
+    expect(mcpToolsPath({ q: '   ', source: ' all ' })).toBe('/mcp');
+  });
+
+  test('normalizes menu catalog filters before encoding', () => {
+    expect(menuCatalogPath({ group: ' tools ', source: ' plugin:echo ' })).toBe('/menu?group=tools&source=plugin%3Aecho');
+    expect(menuCatalogPath({ group: ' all ', source: '   ' })).toBe('/menu');
+  });
+
+  test('normalizes plugin inventory filters independently', () => {
+    expect(pluginInventoryPath({ q: ' echo tools ', surface: ' all ', visibility: ' enabled ' })).toBe('/plugins?q=echo+tools&visibility=enabled');
+    expect(pluginInventoryPath({ surface: ' cli ', visibility: ' all ' })).toBe('/plugins?surface=cli');
+  });
+});

--- a/tests/frontend/routes/route-meta-edge.test.ts
+++ b/tests/frontend/routes/route-meta-edge.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test';
+import { routeMeta } from '../../../frontend/src/routeMeta';
+
+describe('routeMeta routing edge cases', () => {
+  test('decodes encoded MCP tool names for breadcrumbs and descriptions', () => {
+    const meta = routeMeta('/mcp/tools/plugin%3Aecho%2Finspect');
+
+    expect(meta.description).toBe('Inspect schema and metadata for plugin:echo/inspect.');
+    expect(meta.breadcrumbs.at(-1)).toEqual({ label: 'plugin:echo/inspect' });
+  });
+
+  test('keeps malformed encoded MCP route labels without throwing', () => {
+    const meta = routeMeta('/mcp/tools/%E0%A4%A');
+
+    expect(meta.title).toBe('MCP tool detail');
+    expect(meta.breadcrumbs.at(-1)).toEqual({ label: '%E0%A4%A' });
+  });
+
+  test('trims query terms in vector route chrome copy', () => {
+    expect(routeMeta('/vector/search', '?q=%20oracle%20').description).toBe('Preview semantic matches for “oracle”.');
+    expect(routeMeta('/vector/results', '?q=%20oracle%20').breadcrumbs.at(-1)).toEqual({ label: 'Results: oracle' });
+  });
+});


### PR DESCRIPTION
## Summary
- Hardened frontend filter route helpers to trim selector values and omit blank/`all` filters consistently.
- Added routing edge coverage for MCP tool detail routes, wildcard redirects, malformed/encoded route metadata, and vector query chrome.
- Added AppShell layout coverage for query-aware route chrome and unavailable metrics card fallbacks.

## Validation
```bash
rtk bunx tsc --noEmit
rtk bun test tests/frontend
rtk bash -lc 'git diff --check origin/alpha...HEAD && echo diff-check-ok'
rtk bash -lc 'git diff --name-only origin/alpha...HEAD | xargs wc -l'
```

## Notes
- PR targets `alpha`.
- No docs changed.
- No visual UI changes; no screenshot required.
- Changed files are all <=250 lines.
