### PR TITLE
test: harden vector and canvas worker edges

### DIFF
--- a/tests/vector/config-normalize-edge.test.ts
+++ b/tests/vector/config-normalize-edge.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from 'bun:test';
+import { generateDefaultConfig } from '../../src/vector/config.ts';
+import { normalizeVectorConfig } from '../../src/vector/config-normalize.ts';
+
+test('vector config normalizer treats malformed configs as legacy defaults', () => {
+  const defaults = generateDefaultConfig();
+  const config = normalizeVectorConfig(['bad'], defaults);
+
+  expect(config.version).toBe('legacy');
+  expect(config.collections).toEqual(defaults.collections);
+  expect(config.storage).toBeUndefined();
+});
+
+test('vector config normalizer backfills v2 storage and empty collections', () => {
+  const defaults = generateDefaultConfig();
+  const config = normalizeVectorConfig({ version: '2.0', enabled: true }, defaults);
+
+  expect(config.version).toBe('2.0');
+  expect(config.enabled).toBe(true);
+  expect(config.collections).toEqual({});
+  expect(config.storage).toEqual(defaults.storage);
+});

--- a/tests/vector/cost-estimation-edge.test.ts
+++ b/tests/vector/cost-estimation-edge.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from 'bun:test';
+import {
+  estimateEmbeddingCost,
+  estimateEmbeddingCosts,
+  estimateFallbackChainCost,
+  isCostProvider,
+} from '../../src/vector/cost-estimation.ts';
+
+test('embedding cost estimates clamp unsafe counts and preserve explicit model only for matching provider', () => {
+  const single = estimateEmbeddingCost({
+    docs: 1_234.9,
+    tokensPerDoc: 0,
+    provider: 'openai',
+    model: 'custom-openai',
+  });
+  const comparison = estimateEmbeddingCosts(single, ['openai', 'openai', 'gemini']);
+
+  expect(single).toMatchObject({
+    docs: 1234,
+    tokensPerDoc: 1,
+    totalTokens: 1234,
+    model: 'custom-openai',
+  });
+  expect(comparison.openai?.model).toBe('custom-openai');
+  expect(comparison.gemini?.model).toBe('text-embedding-004');
+  expect(Object.keys(comparison)).toEqual(['openai', 'gemini']);
+});
+
+test('fallback cost estimates dedupe providers and summarize free chains', () => {
+  const estimate = estimateFallbackChainCost(
+    { docs: 10, tokensPerDoc: 500 },
+    ['local', 'local', 'gemini'],
+  );
+
+  expect(estimate.providers).toEqual(['local', 'gemini']);
+  expect(estimate.worstCaseUsd).toBe(0);
+  expect(estimate.summary).toContain('stays free/local');
+  expect(isCostProvider('cloudflare-ai')).toBe(true);
+  expect(isCostProvider('bogus')).toBe(false);
+});

--- a/tests/workers/canvas-edge-cases.test.ts
+++ b/tests/workers/canvas-edge-cases.test.ts
@@ -38,6 +38,21 @@ describe('canvas worker edge cases', () => {
     expect(seen).toEqual(['https://studio.buildwithoracle.com/api/health?probe=1']);
   });
 
+  test('falls back to the default API base for non-http env protocols', async () => {
+    const seen: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      seen.push(String(input));
+      return Response.json({ ok: true });
+    }) as typeof fetch;
+
+    await handleCanvasRequest(
+      new Request('https://canvas.buildwithoracle.com/api/health'),
+      { ORACLE_API_BASE: 'file:///tmp/oracle.sock' },
+    );
+
+    expect(seen).toEqual(['https://studio.buildwithoracle.com/api/health']);
+  });
+
   test('rejects malformed percent-encoded local registry plugin ids', async () => {
     const response = await handleCanvasRequest(
       new Request('https://canvas.buildwithoracle.com/api/canvas/plugins/%E0%A4%A'),
@@ -46,6 +61,16 @@ describe('canvas worker edge cases', () => {
     expect(response.status).toBe(400);
     expect(response.headers.get('x-content-type-options')).toBe('nosniff');
     expect(await response.json()).toEqual({ error: 'invalid canvas plugin id' });
+  });
+
+  test('returns local registry 404s for unknown canvas plugin ids', async () => {
+    const response = await handleCanvasRequest(
+      new Request('https://canvas.buildwithoracle.com/api/plugins/canvas/missing-plugin'),
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get('content-type')).toContain('application/json');
+    expect(await response.json()).toEqual({ error: 'canvas plugin not found', id: 'missing-plugin' });
   });
 
   test('escapes unknown plugin text before rendering fallback notices', async () => {
@@ -59,6 +84,17 @@ describe('canvas worker edge cases', () => {
     expect(html).not.toContain(raw);
     expect(html).toContain('&lt;img src=x onerror=&quot;alert(1)&quot;&gt;');
     expect(html).toContain('loaded Wave instead');
+  });
+
+  test('HEAD page requests return HTML headers without a body', async () => {
+    const response = await handleCanvasRequest(
+      new Request('https://canvas.buildwithoracle.com/planets', { method: 'HEAD' }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/html');
+    expect(response.headers.get('x-oracle-canvas-worker')).toBe('canvas.buildwithoracle.com');
+    expect(await response.text()).toBe('');
   });
 
   test('non-page methods return a marked 405 with allowed methods', async () => {


### PR DESCRIPTION
## Summary
- Added vector config normalization edge coverage for malformed legacy input and v2 storage backfill.
- Added embedding cost-estimation edge coverage for clamped counts, provider dedupe, and free fallback summaries.
- Added canvas worker edge coverage for non-http API base fallback, registry 404s, and HEAD page responses.

## Validation
```bash
bun test tests/vector tests/workers
bunx tsc --noEmit
```

## Notes
- No UI changes; screenshot not applicable.
- Changed files are all <= 250 lines.
