### PR TITLE
fix: harden MCP aliases and plugin edge cases

### DIFF
--- a/src/mcp/aliases.ts
+++ b/src/mcp/aliases.ts
@@ -2,8 +2,9 @@
 const ALIAS_PREFIXES = ['arra_', 'muninn_'] as const;
 
 export function resolveToolName(name: string): string {
+  const clean = name.trim();
   for (const prefix of ALIAS_PREFIXES) {
-    if (name.startsWith(prefix)) return 'oracle_' + name.slice(prefix.length);
+    if (clean.startsWith(prefix)) return 'oracle_' + clean.slice(prefix.length);
   }
-  return name;
+  return clean;
 }

--- a/src/plugins/proxy-surface.ts
+++ b/src/plugins/proxy-surface.ts
@@ -26,7 +26,7 @@ export async function proxyRequestForManifest(
     return json({ ok: false, error: 'method not allowed' }, 405, { allow: allowed.join(', ') });
   }
 
-  const targetBase = env[manifest.targetEnv]?.replace(/\/+$/, '');
+  const targetBase = targetBaseFrom(env[manifest.targetEnv]);
   if (!targetBase) {
     return json({ ok: false, error: `${manifest.targetEnv} is unset`, targetEnv: manifest.targetEnv }, 502);
   }
@@ -35,6 +35,21 @@ export async function proxyRequestForManifest(
     ? (url.pathname.slice(normalize(manifest.path).length) || '/')
     : url.pathname;
   return forward(request, `${targetBase}${targetPath.startsWith('/') ? targetPath : `/${targetPath}`}${url.search}`);
+}
+
+function targetBaseFrom(raw: string | undefined): string | null {
+  const trimmed = raw?.trim();
+  if (!trimmed) return null;
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+    url.search = '';
+    url.hash = '';
+    url.pathname = url.pathname.replace(/\/+$/, '');
+    return url.toString().replace(/\/+$/, '');
+  } catch {
+    return null;
+  }
 }
 
 function pathMatches(pathname: string, manifestPath: string): boolean {

--- a/src/plugins/unified-manifest.ts
+++ b/src/plugins/unified-manifest.ts
@@ -2,14 +2,7 @@ import type { ServerPluginTier } from '../server/plugin/types.ts';
 import { validatePluginConfig, type JsonSchema } from './config-schema.ts';
 import { validateExportFormatManifests, type UnifiedExportFormatManifest } from './export-format-manifest.ts';
 
-export type UnifiedPluginSurface =
-  | 'mcpTools'
-  | 'apiRoutes'
-  | 'proxy'
-  | 'server'
-  | 'menu'
-  | 'cliSubcommands'
-  | 'exportFormats';
+export type UnifiedPluginSurface = 'mcpTools' | 'apiRoutes' | 'proxy' | 'server' | 'menu' | 'cliSubcommands' | 'exportFormats';
 
 export type UnifiedHttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'ALL';
 
@@ -108,13 +101,9 @@ const SEMVER_RE = /^\d+\.\d+\.\d+/;
 const TOOL_RE = /^[a-z][a-z0-9_]*$/;
 const HTTP_METHODS = new Set<UnifiedHttpMethod>(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'HEAD', 'ALL']);
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
+function isRecord(value: unknown): value is Record<string, unknown> { return typeof value === 'object' && value !== null && !Array.isArray(value); }
 
-function asArray<T>(value: T[] | undefined): T[] {
-  return Array.isArray(value) ? value : [];
-}
+function asArray<T>(value: T[] | undefined): T[] { return Array.isArray(value) ? value : []; }
 
 function assertAbsolutePath(path: string, field: string): void {
   if (typeof path !== 'string' || !path.startsWith('/')) throw new Error(`${field} must be an absolute path`);
@@ -142,6 +131,14 @@ function assertStringRecord(value: unknown, field: string): void {
   if (!isRecord(value) || Object.values(value).some((item) => typeof item !== 'string')) {
     throw new Error(`${field} must be a string map`);
   }
+}
+
+function isNonBlankString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function assertOptionalHandler(value: unknown, field: string): void {
+  if (value !== undefined && !isNonBlankString(value)) throw new Error(`${field} must be a string`);
 }
 
 export function normalizeUnifiedPluginManifest(raw: unknown): NormalizedUnifiedPluginManifest {
@@ -177,14 +174,15 @@ export function normalizeUnifiedPluginManifest(raw: unknown): NormalizedUnifiedP
   for (const route of apiRoutes) {
     assertAbsolutePath(route.path, 'apiRoutes.path');
     assertMethods(route.methods, 'apiRoutes.methods');
+    assertOptionalHandler(route.handler, 'apiRoutes.handler');
   }
   for (const item of proxy) {
     assertAbsolutePath(item.path, 'proxy.path');
-    if (!item.targetEnv || typeof item.targetEnv !== 'string') throw new Error('proxy.targetEnv must be a string');
+    if (!isNonBlankString(item.targetEnv)) throw new Error('proxy.targetEnv must be a string');
     assertMethods(item.methods, 'proxy.methods');
   }
   if (manifest.server) {
-    if (!manifest.server.command || typeof manifest.server.command !== 'string') {
+    if (!isNonBlankString(manifest.server.command)) {
       throw new Error('server.command must be a string');
     }
     assertStringArray(manifest.server.args, 'server.args');
@@ -196,19 +194,21 @@ export function normalizeUnifiedPluginManifest(raw: unknown): NormalizedUnifiedP
   }
   for (const item of menu) {
     assertAbsolutePath(item.path, 'menu.path');
-    if (!item.label || typeof item.label !== 'string') throw new Error('menu.label must be a string');
+    if (!isNonBlankString(item.label)) throw new Error('menu.label must be a string');
   }
   for (const command of cliSubcommands) {
-    if (!command.command || typeof command.command !== 'string') throw new Error('cliSubcommands.command must be a string');
-    if (!command.help || typeof command.help !== 'string') throw new Error('cliSubcommands.help must be a string');
+    if (!isNonBlankString(command.command)) throw new Error('cliSubcommands.command must be a string');
+    if (!isNonBlankString(command.help)) throw new Error('cliSubcommands.help must be a string');
+    assertOptionalHandler(command.handler, 'cliSubcommands.handler');
   }
+  if (manifest.cli) assertOptionalHandler(manifest.cli.handler, 'cli.handler');
   validateExportFormatManifests(exportFormats);
   if (manifest.configSchema !== undefined) validatePluginConfig(manifest.config ?? {}, manifest.configSchema, manifest.name);
 
   if (manifest.lifecycle) {
     const { init, destroy, start, stop } = manifest.lifecycle;
-    if (init !== undefined && typeof init !== 'string') throw new Error('lifecycle.init must be a string');
-    if (destroy !== undefined && typeof destroy !== 'string') throw new Error('lifecycle.destroy must be a string');
+    assertOptionalHandler(init, 'lifecycle.init');
+    assertOptionalHandler(destroy, 'lifecycle.destroy');
     if (start !== undefined && typeof start !== 'boolean') throw new Error('lifecycle.start must be a boolean');
     if (stop !== undefined && typeof stop !== 'boolean') throw new Error('lifecycle.stop must be a boolean');
   }

--- a/tests/mcp/aliases-preserve-canonical-name.test.ts
+++ b/tests/mcp/aliases-preserve-canonical-name.test.ts
@@ -3,4 +3,5 @@ import { resolveToolName } from '../../src/mcp/aliases.ts';
 
 test('MCP aliases leave canonical tool names unchanged', () => {
   expect(resolveToolName('oracle_search')).toBe('oracle_search');
+  expect(resolveToolName(' oracle_search ')).toBe('oracle_search');
 });

--- a/tests/plugins/proxy-surface-edge.test.ts
+++ b/tests/plugins/proxy-surface-edge.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from 'bun:test';
+import { proxyRequestForManifest } from '../../src/plugins/proxy-surface.ts';
+
+test('plugin proxy normalizes target base URLs before forwarding', async () => {
+  let captured: { path?: string; search?: string } = {};
+  const upstream = Bun.serve({
+    port: 0,
+    fetch: (request) => {
+      const url = new URL(request.url);
+      captured = { path: url.pathname, search: url.search };
+      return Response.json(captured);
+    },
+  });
+
+  try {
+    const response = await proxyRequestForManifest(
+      new Request('http://oracle.test/proxy/nested?q=1'),
+      [{ path: '/proxy', targetEnv: 'PLUGIN_URL', stripPrefix: true }],
+      { PLUGIN_URL: ` http://127.0.0.1:${upstream.port}/base/?debug=1#frag ` },
+    );
+
+    expect(response?.status).toBe(200);
+    expect(captured).toEqual({ path: '/base/nested', search: '?q=1' });
+  } finally {
+    await upstream.stop();
+  }
+});
+
+test('plugin proxy rejects non-http target base URLs', async () => {
+  const response = await proxyRequestForManifest(
+    new Request('http://oracle.test/proxy'),
+    [{ path: '/proxy', targetEnv: 'PLUGIN_URL' }],
+    { PLUGIN_URL: 'file:///tmp/plugin.sock' },
+  );
+
+  expect(response?.status).toBe(502);
+  expect(await response?.json()).toMatchObject({ ok: false, targetEnv: 'PLUGIN_URL' });
+});

--- a/tests/plugins/unified-manifest-invalid-fields.test.ts
+++ b/tests/plugins/unified-manifest-invalid-fields.test.ts
@@ -13,14 +13,22 @@ describe('unified manifest field validation', () => {
       [{ ...base, depends: ['ok', 42] }, /depends/],
       [{ ...base, mcpTools: [{ name: 'Bad', description: 'x', inputSchema: {}, handler: 'h' }] }, /mcpTools.name/],
       [{ ...base, mcpTools: [{ name: 'ok_tool', inputSchema: {}, handler: 'h' }] }, /description/],
+      [{ ...base, mcpTools: [{ name: 'ok_tool', description: 'x', inputSchema: [], handler: 'h' }] }, /inputSchema/],
       [{ ...base, mcpTools: [{ name: 'ok_tool', description: 'x', inputSchema: {}, handler: 1 }] }, /handler/],
       [{ ...base, apiRoutes: [{ path: 'relative' }] }, /apiRoutes.path/],
       [{ ...base, apiRoutes: [{ path: '/ok', methods: 'GET' }] }, /apiRoutes.methods/],
       [{ ...base, apiRoutes: [{ path: '/ok', methods: ['BREW'] }] }, /invalid method/],
+      [{ ...base, apiRoutes: [{ path: '/ok', handler: '   ' }] }, /apiRoutes.handler/],
       [{ ...base, proxy: [{ path: '/proxy' }] }, /proxy.targetEnv/],
+      [{ ...base, proxy: [{ path: '/proxy', targetEnv: '   ' }] }, /proxy.targetEnv/],
+      [{ ...base, server: { command: '   ' } }, /server.command/],
+      [{ ...base, server: { command: 'bun', env: [] } }, /server.env/],
       [{ ...base, menu: [{ path: '/menu' }] }, /menu.label/],
+      [{ ...base, menu: [{ path: '/menu', label: '   ' }] }, /menu.label/],
       [{ ...base, cliSubcommands: [{ help: 'Missing command' }] }, /cliSubcommands.command/],
       [{ ...base, cliSubcommands: [{ command: 'go' }] }, /cliSubcommands.help/],
+      [{ ...base, cliSubcommands: [{ command: 'go', help: 'Go', handler: '' }] }, /cliSubcommands.handler/],
+      [{ ...base, lifecycle: { init: '' } }, /lifecycle.init/],
     ];
 
     for (const [manifest, message] of cases) {


### PR DESCRIPTION
## Summary
- Trim MCP tool names before alias resolution so canonical and prefixed names tolerate surrounding whitespace.
- Tighten unified plugin manifest validation for array-shaped schemas, blank handlers, blank commands/labels, and malformed env maps.
- Normalize plugin proxy target URLs before forwarding and reject non-http(s) targets.

## Tests
- `bunx tsc --noEmit`
- `bun test tests/mcp/ tests/plugins/ src/mcp/__tests__/ src/plugins/__tests__/`
- `git diff --check origin/alpha...HEAD`
- `wc -l` changed files (all <=250)
