### PR TITLE
docs(cloudflare): add deploy button metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Arra Oracle V3 — MCP Memory, Search, and Plugin Layer
 
 [![CI](https://github.com/Soul-Brews-Studio/arra-oracle-v3/actions/workflows/ci.yml/badge.svg)](https://github.com/Soul-Brews-Studio/arra-oracle-v3/actions/workflows/ci.yml) [![License](https://img.shields.io/badge/license-BUSL--1.1-blue)](./LICENSE) [![Bun](https://img.shields.io/badge/runtime-Bun%201.2%2B-f9f1e1)](https://bun.sh)
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/Soul-Brews-Studio/arra-oracle-v3)
 
 > "The Oracle Keeps the Human Human" — queryable through MCP, HTTP, CLI, and
 > maw-js plugin surfaces.

--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -22,8 +22,8 @@ memory/search surface once D1 and Vectorize bindings are wired.
 
 ## Deploy button target
 
-Add this to `README.md` once the Worker entrypoint is present and a smoke deploy
-has produced a healthy `/mcp` or `/health` response:
+The root `README.md` includes this button so users can start the Cloudflare
+fork-and-deploy flow from the project front page:
 
 ```md
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/Soul-Brews-Studio/arra-oracle-v3)

--- a/package.json
+++ b/package.json
@@ -30,6 +30,34 @@
   "publishConfig": {
     "access": "public"
   },
+  "cloudflare": {
+    "bindings": {
+      "AI": {
+        "description": "Workers AI binding for edge embeddings. The vector adapter defaults to `@cf/baai/bge-m3` unless `ORACLE_EMBEDDING_MODEL` is changed."
+      },
+      "ORACLE_DB": {
+        "description": "Cloudflare D1 database for Oracle documents, config, logs, jobs, and Vectorize document/metadata hydration."
+      },
+      "ORACLE_VECTORIZE": {
+        "description": "Cloudflare Vectorize index for semantic search. Use dimensions that match the active embedding model."
+      },
+      "ORACLE_STATE": {
+        "description": "Optional KV namespace for lightweight Worker state, deploy metadata, OAuth state, or caches."
+      },
+      "ARRA_API_TOKEN": {
+        "description": "Optional bearer token for protected Oracle HTTP/MCP writes. Generate a random value such as `openssl rand -hex 32`."
+      },
+      "ORACLE_MCP_PATH": {
+        "description": "Remote MCP mount path. Keep `/mcp` unless your Worker route needs a different Streamable HTTP endpoint."
+      },
+      "ORACLE_STORAGE_BACKEND": {
+        "description": "Storage backend selector for Workers deploys. Use `d1` on Cloudflare; local SQLite is not Workers-compatible."
+      },
+      "ORACLE_VECTOR_BACKEND": {
+        "description": "Vector backend selector for Workers deploys. Use `cloudflare-vectorize` to avoid local SQLite/vector files at the edge."
+      }
+    }
+  },
   "scripts": {
     "dev": "bun src/index.ts",
     "server": "bun src/server.ts",


### PR DESCRIPTION
## Summary
- Add the Deploy to Cloudflare button markdown to the root README.
- Add `package.json > cloudflare.bindings` descriptions for Workers AI, D1, Vectorize, KV, auth token, and deploy selector vars.
- Update `docs/deploy-cloudflare.md` so its deploy-button section matches the README state.

## Research notes
- Cloudflare's Deploy to Cloudflare docs provide the README markdown button format and note that deploy buttons can provision supported resources from Wrangler config: https://developers.cloudflare.com/workers/platform/deploy-buttons/
- The same docs document `package.json > cloudflare.bindings.<NAME>.description` for explaining binding values in the deploy flow.

## Tests
```bash
bun -e "JSON.parse(await Bun.file('package.json').text()); console.log('package.json ok')"
bunx tsc --noEmit
git diff --check origin/alpha...HEAD
wc -l README.md docs/deploy-cloudflare.md package.json
```

## Notes
- Docs/package metadata only; no UI screenshot required.
- Changed files are all <= 250 lines.
