### PR TITLE
feat: add cloudflare mcp proxy tools

### DIFF
--- a/tests/workers/mcp-proxy-tools.test.ts
+++ b/tests/workers/mcp-proxy-tools.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { buildProxyUrl, oracleProxyTool, resolveOracleUrl } from '../../workers/mcp/src/proxy.ts';
+
+describe('Cloudflare MCP proxy tools', () => {
+  test('registers search, stats, and learn tools in the Worker entry', () => {
+    const entry = readFileSync('workers/mcp/src/index.ts', 'utf8');
+
+    expect(entry).toContain("'muninn_search'");
+    expect(entry).toContain("'muninn_stats'");
+    expect(entry).toContain("'oracle_learn'");
+    expect(entry).toContain("OracleMCP.serve('/mcp')");
+  });
+
+  test('normalizes backend URLs and appends only present query values', () => {
+    const base = resolveOracleUrl({ ORACLE_URL: 'https://oracle.example.test/oracle/?x=1#hash' });
+    const url = buildProxyUrl(base, '/api/search', {
+      q: 'vector safety',
+      limit: 5,
+      offset: 0,
+      empty: '',
+      missing: undefined,
+    });
+
+    expect(base).toBe('https://oracle.example.test/oracle');
+    expect(url).toBe('https://oracle.example.test/oracle/api/search?q=vector+safety&limit=5&offset=0');
+  });
+
+  test('proxies muninn_stats with auth and tenant headers', async () => {
+    const captured: Array<{ url: string; init?: RequestInit }> = [];
+    const fetcher = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      captured.push({ url: String(input), init });
+      return Response.json({ total_docs: 12, by_type: { learning: 12 } });
+    }) as typeof fetch;
+
+    const result = await oracleProxyTool({
+      ORACLE_URL: 'https://oracle.example.test',
+      ARRA_API_TOKEN: 'secret',
+    }, { path: '/api/stats', tenantId: 'tenant-a' }, fetcher);
+
+    const headers = captured[0].init?.headers as Headers;
+    expect(result.isError).toBeUndefined();
+    expect(captured[0].url).toBe('https://oracle.example.test/api/stats');
+    expect(headers.get('authorization')).toBe('Bearer secret');
+    expect(headers.get('x-oracle-tenant-id')).toBe('tenant-a');
+    expect(result.content[0].text).toContain('"total_docs": 12');
+  });
+
+  test('proxies oracle_learn as JSON and marks backend errors', async () => {
+    const captured: Array<{ url: string; init?: RequestInit }> = [];
+    const fetcher = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      captured.push({ url: String(input), init });
+      return Response.json({ error: 'Missing required field: pattern' }, { status: 400 });
+    }) as typeof fetch;
+
+    const result = await oracleProxyTool({ ORACLE_HTTP_URL: 'https://oracle.example.test/' }, {
+      method: 'POST',
+      path: '/api/learn',
+      body: { pattern: '' },
+    }, fetcher);
+
+    expect(result.isError).toBe(true);
+    expect(captured[0].url).toBe('https://oracle.example.test/api/learn');
+    expect(captured[0].init?.method).toBe('POST');
+    expect(await new Request('https://local', captured[0].init).json()).toEqual({ pattern: '' });
+    expect(result.content[0].text).toContain('Missing required field');
+  });
+});

--- a/workers/mcp/package.json
+++ b/workers/mcp/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@soul-brews/arra-oracle-cloudflare-mcp",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "agents": "^0.16.1",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260616.1",
+    "typescript": "^5.7.2",
+    "wrangler": "^4.101.0"
+  }
+}

--- a/workers/mcp/src/index.ts
+++ b/workers/mcp/src/index.ts
@@ -1,0 +1,71 @@
+import { McpAgent } from 'agents/mcp';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { oracleProxyTool, type OracleProxyEnv } from './proxy.ts';
+
+type Env = OracleProxyEnv;
+
+const typeArg = z.enum(['principle', 'pattern', 'learning', 'retro', 'all']).optional();
+const modeArg = z.enum(['hybrid', 'fts', 'vector']).optional();
+const modelArg = z.enum(['nomic', 'qwen3', 'bge-m3']).optional();
+const tenantArg = z.string().optional();
+const conceptsArg = z.union([z.array(z.string()), z.string()]).optional();
+
+export class OracleMCP extends McpAgent<Env> {
+  server = new McpServer({ name: 'arra-oracle', version: '1.0.0' });
+
+  async init() {
+    this.server.tool(
+      'muninn_search',
+      'Search the Arra Oracle knowledge backend through the Cloudflare MCP proxy.',
+      {
+        query: z.string(),
+        type: typeArg,
+        limit: z.number().optional(),
+        offset: z.number().optional(),
+        mode: modeArg,
+        project: z.string().optional(),
+        cwd: z.string().optional(),
+        model: modelArg,
+        tenantId: tenantArg,
+      },
+      async ({ query, tenantId, ...args }) => oracleProxyTool(this.env, {
+        path: '/api/search',
+        query: { q: query, ...args },
+        tenantId,
+      }),
+    );
+
+    this.server.tool(
+      'muninn_stats',
+      'Read Arra Oracle backend document, indexing, and vector status.',
+      { tenantId: tenantArg },
+      async ({ tenantId }) => oracleProxyTool(this.env, {
+        path: '/api/stats',
+        tenantId,
+      }),
+    );
+
+    this.server.tool(
+      'oracle_learn',
+      'Record a learning in the Arra Oracle backend through the Cloudflare MCP proxy.',
+      {
+        pattern: z.string(),
+        concepts: conceptsArg,
+        source: z.string().optional(),
+        origin: z.string().nullable().optional(),
+        project: z.string().nullable().optional(),
+        cwd: z.string().optional(),
+        tenantId: tenantArg,
+      },
+      async ({ tenantId, ...body }) => oracleProxyTool(this.env, {
+        method: 'POST',
+        path: '/api/learn',
+        body,
+        tenantId,
+      }),
+    );
+  }
+}
+
+export default OracleMCP.serve('/mcp');

--- a/workers/mcp/src/proxy.ts
+++ b/workers/mcp/src/proxy.ts
@@ -1,0 +1,99 @@
+export type OracleProxyEnv = {
+  ORACLE_URL?: string;
+  ORACLE_HTTP_URL?: string;
+  ORACLE_API?: string;
+  ARRA_API_TOKEN?: string;
+  ARRA_API_KEY?: string;
+};
+
+export type TextToolResult = {
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: boolean;
+};
+
+type ProxyRequest = {
+  method?: 'GET' | 'POST';
+  path: string;
+  query?: Record<string, unknown>;
+  body?: unknown;
+  tenantId?: unknown;
+};
+
+function trimValue(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  const text = String(value).trim();
+  return text || undefined;
+}
+
+export function resolveOracleUrl(env: OracleProxyEnv): string {
+  const raw = env.ORACLE_URL ?? env.ORACLE_HTTP_URL ?? env.ORACLE_API;
+  const trimmed = raw?.trim();
+  if (!trimmed) throw new Error('Set ORACLE_URL to the Arra Oracle HTTP backend.');
+  const url = new URL(trimmed);
+  url.hash = '';
+  url.search = '';
+  url.pathname = url.pathname.replace(/\/+$/, '');
+  return url.toString().replace(/\/+$/, '');
+}
+
+export function buildProxyUrl(baseUrl: string, path: string, query?: Record<string, unknown>): string {
+  const suffix = path.startsWith('/') ? path : `/${path}`;
+  const url = new URL(`${baseUrl}${suffix}`);
+  for (const [key, raw] of Object.entries(query ?? {})) {
+    const value = trimValue(raw);
+    if (value !== undefined) url.searchParams.set(key, value);
+  }
+  return url.toString();
+}
+
+function responseText(payload: unknown): string {
+  return typeof payload === 'string' ? payload : JSON.stringify(payload, null, 2);
+}
+
+function textResult(payload: unknown, isError = false): TextToolResult {
+  return {
+    content: [{ type: 'text', text: responseText(payload) }],
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+function proxyHeaders(env: OracleProxyEnv, hasBody: boolean, tenantId?: unknown): Headers {
+  const headers = new Headers({ accept: 'application/json' });
+  if (hasBody) headers.set('content-type', 'application/json');
+  const tenant = trimValue(tenantId);
+  if (tenant) headers.set('x-oracle-tenant-id', tenant);
+  const token = env.ARRA_API_TOKEN?.trim() || env.ARRA_API_KEY?.trim();
+  if (token) headers.set('authorization', `Bearer ${token}`);
+  return headers;
+}
+
+async function readPayload(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+export async function oracleProxyTool(
+  env: OracleProxyEnv,
+  request: ProxyRequest,
+  fetcher: typeof fetch = fetch,
+): Promise<TextToolResult> {
+  try {
+    const baseUrl = resolveOracleUrl(env);
+    const body = request.body === undefined ? undefined : JSON.stringify(request.body);
+    const response = await fetcher(buildProxyUrl(baseUrl, request.path, request.query), {
+      method: request.method ?? 'GET',
+      headers: proxyHeaders(env, body !== undefined, request.tenantId),
+      body,
+    });
+    return textResult(await readPayload(response), !response.ok);
+  } catch (error) {
+    return textResult({
+      error: error instanceof Error ? error.message : String(error),
+    }, true);
+  }
+}

--- a/workers/mcp/tsconfig.json
+++ b/workers/mcp/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "WebWorker"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/workers/mcp/wrangler.jsonc
+++ b/workers/mcp/wrangler.jsonc
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/cloudflare/workers-sdk/main/packages/wrangler/config-schema.json",
+  "name": "arra-oracle-mcp",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-06-16",
+  "compatibility_flags": ["nodejs_compat"],
+  "workers_dev": true,
+  "observability": { "enabled": true },
+  "durable_objects": {
+    "bindings": [
+      { "name": "MCP_OBJECT", "class_name": "OracleMCP" }
+    ]
+  },
+  "migrations": [
+    { "tag": "v1", "new_sqlite_classes": ["OracleMCP"] }
+  ],
+  "vars": {
+    "ORACLE_URL": "https://replace-with-your-oracle-backend.example.com"
+  }
+}


### PR DESCRIPTION
## Summary

- Add `workers/mcp` Phase 1 Cloudflare `McpAgent` worker package.
- Register `muninn_search`, `muninn_stats`, and `oracle_learn` in `workers/mcp/src/index.ts`.
- Proxy tool calls to an Arra Oracle HTTP backend via `ORACLE_URL` / `ORACLE_HTTP_URL` / `ORACLE_API`, with optional bearer token and tenant header forwarding.
- Add worker proxy coverage for entry registration, URL/query normalization, stats proxy headers, and learn error propagation.

## Coordination

- Read #2167 feasibility comment and c12 docs PR #2173 before implementation.
- Did not modify `src/workers/canvas/**` or `workers/canvas/wrangler.toml`.
- Did not modify vector adapter/backend files.

## Validation

```bash
bunx tsc --noEmit
bun test tests/workers/
wc -l workers/mcp/src/index.ts workers/mcp/src/proxy.ts workers/mcp/package.json \
  workers/mcp/tsconfig.json workers/mcp/wrangler.jsonc tests/workers/mcp-proxy-tools.test.ts
```

All changed files are under 250 lines.

Refs #2167
