### PR TITLE
test: harden huginn and trace edges

### DIFF
--- a/src/huginn/__tests__/capture.test.ts
+++ b/src/huginn/__tests__/capture.test.ts
@@ -109,6 +109,25 @@ describe('Huginn session capture', () => {
     expect(Object.keys(state.captures)).toHaveLength(1);
   });
 
+  it('falls back when an explicit session id sanitizes to empty', async () => {
+    const dir = tmpdir();
+    const transcript = path.join(dir, 'session fallback.jsonl');
+    writeJsonl(transcript, [
+      { message: { role: 'assistant', content: 'Learned: sanitized Huginn session ids need a deterministic fallback.' } },
+    ]);
+
+    const result = await captureSession({
+      transcriptPath: transcript,
+      sessionId: '💥💥',
+      statePath: path.join(dir, 'state.json'),
+      learn: () => ({ id: 'learn_safe_session' }),
+    });
+
+    expect(result.learned).toBe(true);
+    expect(result.sessionId).toBe('session-fallback');
+    expect(result.moments[0].text).toContain('deterministic fallback');
+  });
+
   it('does not learn empty/non-salient transcripts', async () => {
     const dir = tmpdir();
     const transcript = path.join(dir, 'quiet.jsonl');

--- a/src/huginn/capture.ts
+++ b/src/huginn/capture.ts
@@ -86,10 +86,17 @@ function writeState(statePath: string, state: CaptureState): void {
   fs.renameSync(tmp, statePath);
 }
 
+function safeSessionId(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 120);
+}
+
 function stableSessionId(transcriptPath: string, explicit?: string): string {
-  if (explicit) return explicit.replace(/[^a-zA-Z0-9._-]/g, '-').slice(0, 120);
-  const base = path.basename(transcriptPath).replace(/\.jsonl$/i, '');
-  return (base || sha256(transcriptPath).slice(0, 16)).replace(/[^a-zA-Z0-9._-]/g, '-').slice(0, 120);
+  const fallback = safeSessionId(path.basename(transcriptPath).replace(/\.jsonl$/i, ''))
+    || sha256(transcriptPath).slice(0, 16);
+  return explicit ? safeSessionId(explicit) || fallback : fallback;
 }
 
 function textFromContent(content: unknown): string {

--- a/src/routes/traces/model.ts
+++ b/src/routes/traces/model.ts
@@ -59,8 +59,9 @@ export function parsePagination(query: { limit?: string; offset?: string }) {
 
 function parseBoundedInt(value: string | undefined, fallback: number, min: number, max: number, label: string): number | string {
   if (value === undefined || value === '') return fallback;
-  if (!/^\d+$/.test(value)) return `${label} must be an integer between ${min} and ${max}`;
-  const parsed = Number(value);
+  const trimmed = value.trim();
+  if (!trimmed || !/^\d+$/.test(trimmed)) return `${label} must be an integer between ${min} and ${max}`;
+  const parsed = Number(trimmed);
   if (!Number.isSafeInteger(parsed) || parsed < min) return `${label} must be an integer between ${min} and ${max}`;
   return Math.min(parsed, max);
 }

--- a/src/routes/traces/tenant-scope.ts
+++ b/src/routes/traces/tenant-scope.ts
@@ -13,6 +13,17 @@ export function getTenantTrace(traceId: string): TraceRecord | null {
   return row ? getTrace(traceId) : null;
 }
 
+function hasTenantForwardPath(fromTraceId: string, toTraceId: string): boolean {
+  const seen = new Set<string>();
+  let current = getTenantTrace(fromTraceId);
+  while (current && !seen.has(current.traceId)) {
+    if (current.traceId === toTraceId) return true;
+    seen.add(current.traceId);
+    current = current.nextTraceId ? getTenantTrace(current.nextTraceId) : null;
+  }
+  return false;
+}
+
 export function createTenantTrace(input: CreateTraceInput): CreateTraceResult {
   if (input.parentTraceId && !getTenantTrace(input.parentTraceId)) throw new Error(`Parent trace not found: ${input.parentTraceId}`);
   const result = createTrace(input);
@@ -116,6 +127,7 @@ export function linkTenantTraces(prevTraceId: string, nextTraceId: string) {
   if (!nextTrace) return { success: false, message: `Next trace not found: ${nextTraceId}` };
   if (prevTrace.nextTraceId) return { success: false, message: `Trace ${prevTraceId} already has a next link` };
   if (nextTrace.prevTraceId) return { success: false, message: `Trace ${nextTraceId} already has a prev link` };
+  if (hasTenantForwardPath(nextTraceId, prevTraceId)) return { success: false, message: `Cannot link ${prevTraceId} → ${nextTraceId}: it would create a cycle` };
   const now = Date.now();
   db.update(traceLog).set({ nextTraceId, updatedAt: now }).where(tenantTraceWhere(prevTraceId)).run();
   db.update(traceLog).set({ prevTraceId, updatedAt: now }).where(tenantTraceWhere(nextTraceId)).run();

--- a/src/trace/__tests__/distill-edge.test.ts
+++ b/src/trace/__tests__/distill-edge.test.ts
@@ -1,0 +1,54 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const root = join(tmpdir(), `arra-trace-distill-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+const dbPath = join(root, 'oracle.db');
+mkdirSync(root, { recursive: true });
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = dbPath;
+
+const dbMod = await import('../../db/index.ts');
+dbMod.resetDefaultDatabaseForTests(dbPath);
+const { createTrace, getTrace } = await import('../handler.ts');
+const { distillTraceAwakening } = await import('../distill.ts');
+
+function restore(name: string, value: string | undefined) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+afterAll(() => {
+  dbMod.closeDb();
+  restore('ORACLE_DATA_DIR', savedDataDir);
+  restore('ORACLE_DB_PATH', savedDbPath);
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('trace awakening distill edge hardening', () => {
+  test('blank awakenings do not update trace status', () => {
+    const result = createTrace({ query: 'blank distill guard' });
+    const distilled = distillTraceAwakening({ traceId: result.traceId, awakening: '   ' });
+
+    expect(distilled).toEqual({ success: false, status: 'invalid', error: 'awakening is required' });
+    expect(getTrace(result.traceId)?.status).toBe('raw');
+  });
+
+  test('awakening content is trimmed before persistence', () => {
+    const result = createTrace({ query: 'trimmed distill content' });
+    const distilled = distillTraceAwakening({
+      traceId: result.traceId,
+      awakening: '  Learned: trace awakenings should store clean text.  ',
+      metadata: { source: 'edge-test' },
+    });
+    const trace = getTrace(result.traceId);
+
+    expect(distilled.success).toBe(true);
+    expect(trace?.status).toBe('distilled');
+    expect(trace?.awakening?.startsWith('Learned:')).toBe(true);
+    expect(trace?.awakening).toContain('"source": "edge-test"');
+  });
+});

--- a/src/trace/distill.ts
+++ b/src/trace/distill.ts
@@ -24,8 +24,15 @@ function conceptSlug(value: string): string {
     .replace(/-+/g, '-').replace(/^-|-$/g, '');
 }
 
-function uniqueConcepts(values: string[]): string[] {
-  return [...new Set(values.map(conceptSlug).filter(Boolean))];
+function uniqueConcepts(values: unknown[]): string[] {
+  return [...new Set(values
+    .filter((value): value is string => typeof value === 'string')
+    .map(conceptSlug)
+    .filter(Boolean))];
+}
+
+function normalizedAwakening(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
 }
 
 function oracleOrigin(input: DistillTraceInput): string {
@@ -84,7 +91,7 @@ function findingSections(finding: StormforgeFinding): string[] {
 }
 
 export function renderDistilledAwakening(input: DistillTraceInput): string {
-  const parts = [input.awakening.trim()];
+  const parts = [normalizedAwakening(input.awakening)];
   if (input.finding) parts.push(findingSections(input.finding).join('\n').trim());
   if (input.metadata && Object.keys(input.metadata).length) {
     parts.push(['## Metadata', '', '```json', JSON.stringify(input.metadata, null, 2), '```'].join('\n'));
@@ -96,15 +103,18 @@ export function distillTraceAwakening(input: DistillTraceInput): DistillTraceRes
   const trace = getTrace(input.traceId);
   if (!trace) return { success: false, status: 'not_found', error: 'Trace not found' };
 
+  const awakening = normalizedAwakening(input.awakening);
+  if (!awakening) return { success: false, status: 'invalid', error: 'awakening is required' };
+
   const origin = oracleOrigin(input);
   const concepts = learningConcepts(input);
-  const awakening = renderDistilledAwakening(input);
+  const renderedAwakening = renderDistilledAwakening({ ...input, awakening });
   const learning = input.promoteToLearning
-    ? handleLearn(awakening, input.source?.trim() || `Trace awakening ${input.traceId}`, concepts, origin, trace.project ?? undefined)
+    ? handleLearn(renderedAwakening, input.source?.trim() || `Trace awakening ${input.traceId}`, concepts, origin, trace.project ?? undefined)
     : undefined;
   const now = Date.now();
   const update: Partial<typeof traceLog.$inferInsert> = {
-    status: 'distilled', awakening, distilledAt: now, updatedAt: now,
+    status: 'distilled', awakening: renderedAwakening, distilledAt: now, updatedAt: now,
   };
   if (learning?.id) update.distilledToId = learning.id;
 

--- a/tests/http/traces/tenant-isolation.test.ts
+++ b/tests/http/traces/tenant-isolation.test.ts
@@ -93,3 +93,30 @@ test('trace HTTP routes stamp and filter records by active tenant', async () => 
   });
   expect(deniedDistill.response.status).toBe(404);
 });
+
+test('tenant trace linking refuses to close a forward cycle', async () => {
+  const first = await tenantJson(tenantA, '/api/traces', {
+    method: 'POST',
+    body: JSON.stringify({ query: `tenant cycle first ${stamp}` }),
+  });
+  const second = await tenantJson(tenantA, '/api/traces', {
+    method: 'POST',
+    body: JSON.stringify({ query: `tenant cycle second ${stamp}` }),
+  });
+  expect(first.response.status).toBe(201);
+  expect(second.response.status).toBe(201);
+  traceIds.push(first.json.trace_id, second.json.trace_id);
+
+  const linked = await tenantJson(tenantA, `/api/traces/${first.json.trace_id}/link`, {
+    method: 'POST',
+    body: JSON.stringify({ nextId: second.json.trace_id }),
+  });
+  expect(linked.response.status).toBe(200);
+
+  const cycle = await tenantJson(tenantA, `/api/traces/${second.json.trace_id}/link`, {
+    method: 'POST',
+    body: JSON.stringify({ nextId: first.json.trace_id }),
+  });
+  expect(cycle.response.status).toBe(400);
+  expect(cycle.json.error).toContain('create a cycle');
+});

--- a/tests/http/traces/validation.test.ts
+++ b/tests/http/traces/validation.test.ts
@@ -84,7 +84,7 @@ describe('trace list and chain route hardening', () => {
   });
 
   test('allows distilling status filtering', async () => {
-    const response = await apiRequest('/api/traces?status=distilling&limit=10');
+    const response = await apiRequest('/api/traces?status=distilling&limit=%2010%20&offset=%200%20');
     expect(response.status).toBe(200);
     const body = await response.json() as { traces: Array<{ traceId: string }> };
     expect(body.traces.map((trace) => trace.traceId)).toContain(traceB);


### PR DESCRIPTION
## Summary
- Harden Huginn session id normalization so unusable explicit ids fall back deterministically.
- Harden trace distillation against blank awakenings and trim persisted awakening content.
- Trim trace pagination params and prevent tenant-scoped linked-chain cycles.
- Add focused Huginn, trace distill, and trace HTTP regression coverage.

## Verification
```bash
bun test src/huginn/__tests__ src/trace/__tests__ tests/http/traces/
bunx tsc --noEmit
git diff --check HEAD~1..HEAD
wc -l src/huginn/capture.ts src/huginn/__tests__/capture.test.ts src/routes/traces/model.ts src/routes/traces/tenant-scope.ts src/trace/distill.ts src/trace/__tests__/distill-edge.test.ts tests/http/traces/validation.test.ts tests/http/traces/tenant-isolation.test.ts
```

## Notes
- All changed files are <=250 lines.
- No UI changes; no screenshot needed.
- Docs not touched.