### PR TITLE
feat(vector): add binding-only Vectorize adapter

### DIFF
--- a/src/vector/adapters/cloudflare.ts
+++ b/src/vector/adapters/cloudflare.ts
@@ -1,5 +1,6 @@
 import type { VectorStoreAdapter } from '../types.ts';
 import { CloudflareAIEmbeddings, CloudflareVectorizeAdapter } from './cloudflare-vectorize.ts';
+import { VectorizeAdapter } from './vectorize.ts';
 import {
   CloudflareVectorizeD1Adapter,
   CloudflareWorkerAIEmbeddings,
@@ -32,6 +33,12 @@ export function createCloudflareVectorStore(
       d1: config.cfD1,
     }, { tableName: config.cfD1Table });
   }
+  if (config.cfVectorize) {
+    const embedder = config.cfAi
+      ? new CloudflareWorkerAIEmbeddings(config.cfAi, { model })
+      : new CloudflareAIEmbeddings({ ...restConfig(config), model });
+    return new VectorizeAdapter(collectionName, embedder, config.cfVectorize);
+  }
   const cfConfig = restConfig(config);
   return new CloudflareVectorizeAdapter(
     collectionName,
@@ -52,6 +59,7 @@ function clean(value: string | undefined): string | undefined {
   return trimmed || undefined;
 }
 
+export { VectorizeAdapter } from './vectorize.ts';
 export { CloudflareAIEmbeddings, CloudflareVectorizeAdapter } from './cloudflare-vectorize.ts';
 export {
   CloudflareVectorizeD1Adapter,

--- a/src/vector/adapters/index.ts
+++ b/src/vector/adapters/index.ts
@@ -2,6 +2,7 @@ export { ChromaMcpAdapter } from './chroma-mcp.ts';
 export { SqliteVecAdapter } from './sqlite-vec.ts';
 export { LanceDBAdapter } from './lancedb.ts';
 export { QdrantAdapter } from './qdrant.ts';
+export { VectorizeAdapter } from './vectorize.ts';
 export { CloudflareVectorizeAdapter, CloudflareAIEmbeddings } from './cloudflare-vectorize.ts';
 export { CloudflareVectorizeD1Adapter, CloudflareWorkerAIEmbeddings } from './cloudflare-worker.ts';
 export { ProxyVectorAdapter } from './proxy.ts';

--- a/src/vector/adapters/vectorize.ts
+++ b/src/vector/adapters/vectorize.ts
@@ -1,0 +1,178 @@
+import type { VectorDocument, VectorQueryResult, VectorStoreAdapter } from '../adapter.ts';
+import type { EmbeddingProvider } from '../types.ts';
+import type { CloudflareVectorizeBinding } from './cloudflare-worker.ts';
+
+type VectorizeMatch = { id: string; score?: number; metadata?: Record<string, unknown> };
+type StoredVector = { id?: string; values?: number[]; metadata?: Record<string, unknown> };
+type VectorizeIndex = CloudflareVectorizeBinding & {
+  describe?: () => Promise<{ vectorsCount?: number; count?: number }>;
+  listVectors?: (options?: { count?: number; cursor?: string; namespace?: string }) => Promise<{
+    ids?: string[];
+    vectors?: Array<{ id: string }>;
+    cursor?: string;
+  }>;
+};
+
+export interface VectorizeAdapterOptions {
+  namespace?: string;
+}
+
+export class VectorizeAdapter implements VectorStoreAdapter {
+  readonly name = 'cloudflare-vectorize';
+  private namespace: string;
+
+  constructor(
+    private collectionName: string,
+    private embedder: EmbeddingProvider,
+    private vectorize: VectorizeIndex,
+    options: VectorizeAdapterOptions = {},
+  ) {
+    this.namespace = options.namespace ?? collectionName;
+  }
+
+  async connect(): Promise<void> { await this.ensureCollection(); }
+  async close(): Promise<void> {}
+
+  async ensureCollection(): Promise<void> {
+    if (this.vectorize.describe) await this.vectorize.describe();
+  }
+
+  async addDocuments(docs: VectorDocument[]): Promise<void> {
+    if (!docs.length) return;
+    await this.vectorize.upsert(await this.vectorsFor(docs));
+  }
+
+  async replaceDocuments(docs: VectorDocument[]): Promise<void> {
+    await this.deleteCollection();
+    await this.addDocuments(docs);
+  }
+
+  async deleteCollection(): Promise<void> {
+    if (!this.vectorize.deleteByIds || !this.vectorize.listVectors) {
+      throw new Error('VectorizeAdapter.deleteCollection requires listVectors and deleteByIds bindings');
+    }
+    const ids = await this.listIds();
+    for (let i = 0; i < ids.length; i += 100) await this.vectorize.deleteByIds(ids.slice(i, i + 100));
+  }
+
+  async query(text: string, limit = 10, where?: Record<string, unknown>): Promise<VectorQueryResult> {
+    const [vector] = await this.embedder.embed([text], 'query');
+    const response = await this.vectorize.query(vector, this.queryOptions(limit, where));
+    return fromMatches(matches(response));
+  }
+
+  async queryById(id: string, nResults = 5): Promise<VectorQueryResult> {
+    const options = this.queryOptions(nResults + 1);
+    const response = this.vectorize.queryById
+      ? await this.vectorize.queryById(id, options)
+      : await this.queryByStoredVector(id, options);
+    return fromMatches(matches(response).filter((match) => match.id !== id).slice(0, topK(nResults)));
+  }
+
+  async getStats(): Promise<{ count: number }> {
+    if (!this.vectorize.describe) return { count: 0 };
+    try {
+      const info = await this.vectorize.describe();
+      return { count: nonNegative(info.vectorsCount ?? info.count) };
+    } catch {
+      return { count: 0 };
+    }
+  }
+
+  async getCollectionInfo(): Promise<{ count: number; name: string }> {
+    return { ...(await this.getStats()), name: this.collectionName };
+  }
+
+  private async vectorsFor(docs: VectorDocument[]) {
+    const missing = docs.filter((doc) => !doc.vector);
+    const embedded = missing.length ? await this.embedder.embed(missing.map((doc) => doc.document), 'passage') : [];
+    if (embedded.length !== missing.length) throw new Error(`Vectorize embedder returned ${embedded.length} vectors for ${missing.length} documents`);
+    let offset = 0;
+    return docs.map((doc) => {
+      const values = doc.vector ?? embedded[offset++];
+      assertVector(values);
+      return {
+        id: doc.id,
+        values,
+        namespace: this.namespace,
+        metadata: { ...doc.metadata, collection: this.collectionName, document: doc.document },
+      };
+    });
+  }
+
+  private queryOptions(limit: number, where?: Record<string, unknown>): Record<string, unknown> {
+    return {
+      topK: topK(limit),
+      returnValues: false,
+      returnMetadata: 'all',
+      namespace: this.namespace,
+      ...(where && Object.keys(where).length ? { filter: eqFilter(where) } : {}),
+    };
+  }
+
+  private async queryByStoredVector(id: string, options: Record<string, unknown>): Promise<unknown> {
+    const record = storedVectors(await this.vectorize.getByIds?.([id]))[0];
+    if (!record?.values) throw new Error(`No embedding found for document: ${id}`);
+    return this.vectorize.query(record.values, options);
+  }
+
+  private async listIds(): Promise<string[]> {
+    const ids: string[] = [];
+    let cursor: string | undefined;
+    do {
+      const page = await this.vectorize.listVectors?.({ count: 1000, cursor, namespace: this.namespace });
+      ids.push(...(page?.ids ?? page?.vectors?.map((vector) => vector.id) ?? []));
+      cursor = page?.cursor;
+    } while (cursor);
+    return ids;
+  }
+}
+
+function topK(value: number): number {
+  return Math.max(1, Math.min(50, Number.isFinite(value) ? Math.trunc(value) : 10));
+}
+
+function nonNegative(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function eqFilter(where: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(where)
+    .filter(([, value]) => value !== undefined)
+    .map(([key, value]) => [key, isFilterOperator(value) ? value : { $eq: value }]));
+}
+
+function isFilterOperator(value: unknown): boolean {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function matches(value: unknown): VectorizeMatch[] {
+  const record = value as { matches?: VectorizeMatch[]; result?: { matches?: VectorizeMatch[] } };
+  return Array.isArray(record?.matches) ? record.matches : Array.isArray(record?.result?.matches) ? record.result.matches : [];
+}
+
+function storedVectors(value: unknown): StoredVector[] {
+  const record = value as { vectors?: StoredVector[]; result?: StoredVector[] };
+  if (Array.isArray(value)) return value as StoredVector[];
+  return Array.isArray(record?.vectors) ? record.vectors : Array.isArray(record?.result) ? record.result : [];
+}
+
+function fromMatches(found: VectorizeMatch[]): VectorQueryResult {
+  return {
+    ids: found.map((match) => match.id),
+    documents: found.map((match) => String(match.metadata?.document ?? '')),
+    distances: found.map((match) => 1 - nonNegative(match.score)),
+    metadatas: found.map((match) => stripDocument(match.metadata ?? {})),
+  };
+}
+
+function stripDocument(value: Record<string, unknown>): Record<string, unknown> {
+  const { document, ...rest } = value;
+  return rest;
+}
+
+function assertVector(value: unknown): asserts value is number[] {
+  if (!Array.isArray(value) || value.length === 0 || value.some((item) => typeof item !== 'number' || !Number.isFinite(item))) {
+    throw new Error('Vectorize vector must be a non-empty finite number array');
+  }
+}

--- a/tests/vector/vectorize-adapter.test.ts
+++ b/tests/vector/vectorize-adapter.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from 'bun:test';
+import { createVectorStore } from '../../src/vector/factory.ts';
+import { VectorizeAdapter } from '../../src/vector/adapters/cloudflare.ts';
+import type { EmbeddingProvider, EmbedType } from '../../src/vector/types.ts';
+import type { CloudflareVectorizeBinding } from '../../src/vector/adapters/cloudflare.ts';
+
+type Vector = { id: string; values: number[]; namespace?: string; metadata?: Record<string, unknown> };
+
+class StubEmbedder implements EmbeddingProvider {
+  readonly name = 'stub';
+  readonly dimensions = 3;
+  calls: Array<{ texts: string[]; type?: EmbedType }> = [];
+  async embed(texts: string[], type?: EmbedType): Promise<number[][]> {
+    this.calls.push({ texts, type });
+    return texts.map((_, index) => [1, index + 1, 0]);
+  }
+}
+
+function mockVectorize(): CloudflareVectorizeBinding & {
+  records: Map<string, Vector>;
+  queries: Record<string, unknown>[];
+  describe: () => Promise<{ vectorsCount: number }>;
+  listVectors: (options?: { namespace?: string }) => Promise<{ ids: string[] }>;
+} {
+  const records = new Map<string, Vector>();
+  const queries: Record<string, unknown>[] = [];
+  return {
+    records,
+    queries,
+    upsert: async (vectors) => { for (const vector of vectors as Vector[]) records.set(vector.id, vector); },
+    query: async (_vector, options = {}) => {
+      queries.push(options);
+      return { matches: [...records.values()].map((vector) => ({ id: vector.id, score: 0.75, metadata: vector.metadata })) };
+    },
+    queryById: async (_id, options = {}) => {
+      queries.push(options);
+      return { matches: [...records.values()].map((vector) => ({ id: vector.id, score: 0.75, metadata: vector.metadata })) };
+    },
+    getByIds: async (ids) => ids.map((id) => records.get(id)).filter(Boolean),
+    deleteByIds: async (ids) => { for (const id of ids) records.delete(id); },
+    describe: async () => ({ vectorsCount: records.size }),
+    listVectors: async (options = {}) => ({
+      ids: [...records.values()].filter((vector) => !options.namespace || vector.namespace === options.namespace).map((vector) => vector.id),
+    }),
+  };
+}
+
+describe('VectorizeAdapter', () => {
+  test('upserts precomputed vectors and queries with namespace plus metadata filters', async () => {
+    const embedder = new StubEmbedder();
+    const vectorize = mockVectorize();
+    const adapter = new VectorizeAdapter('edge_docs', embedder, vectorize);
+
+    await adapter.addDocuments([{ id: 'doc-1', document: 'hello edge', metadata: { kind: 'note' }, vector: [1, 2, 3] }]);
+    const result = await adapter.query('hello', Number.NaN, { kind: 'note' });
+
+    expect(embedder.calls).toEqual([{ texts: ['hello'], type: 'query' }]);
+    expect(vectorize.records.get('doc-1')).toMatchObject({
+      namespace: 'edge_docs',
+      metadata: { kind: 'note', collection: 'edge_docs', document: 'hello edge' },
+    });
+    expect(vectorize.queries[0]).toMatchObject({
+      topK: 10,
+      namespace: 'edge_docs',
+      returnMetadata: 'all',
+      filter: { kind: { $eq: 'note' } },
+    });
+    expect(result).toEqual({
+      ids: ['doc-1'],
+      documents: ['hello edge'],
+      distances: [0.25],
+      metadatas: [{ kind: 'note', collection: 'edge_docs' }],
+    });
+  });
+
+  test('queryById falls back through Vectorize and excludes the source id', async () => {
+    const vectorize = mockVectorize();
+    delete (vectorize as Partial<typeof vectorize>).queryById;
+    const adapter = new VectorizeAdapter('edge_docs', new StubEmbedder(), vectorize);
+    await adapter.addDocuments([
+      { id: 'doc-1', document: 'source', metadata: {}, vector: [1, 0, 0] },
+      { id: 'doc-2', document: 'neighbor', metadata: {}, vector: [0, 1, 0] },
+    ]);
+
+    const result = await adapter.queryById('doc-1', 5);
+
+    expect(result.ids).toEqual(['doc-2']);
+    expect(result.documents).toEqual(['neighbor']);
+  });
+
+  test('deletes all vectors in the adapter namespace', async () => {
+    const vectorize = mockVectorize();
+    const adapter = new VectorizeAdapter('edge_docs', new StubEmbedder(), vectorize);
+    await adapter.addDocuments([{ id: 'doc-1', document: 'delete me', metadata: {}, vector: [1, 0, 0] }]);
+
+    await adapter.deleteCollection();
+
+    expect(await adapter.getStats()).toEqual({ count: 0 });
+  });
+
+  test('factory selects binding-only Vectorize without REST credentials', () => {
+    const store = createVectorStore({
+      type: 'cloudflare-vectorize',
+      collectionName: 'edge_docs',
+      cfAi: { run: async (_model, input) => ({ data: input.text.map(() => [1, 0, 0]) }) },
+      cfVectorize: mockVectorize(),
+    });
+
+    expect(store).toBeInstanceOf(VectorizeAdapter);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a Workers binding-only `VectorizeAdapter` implementing the extracted `VectorStoreAdapter` contract from #2167.
- Use Vectorize namespaces per collection, store document text in vector metadata for hydration, and support precomputed vectors to avoid duplicate embedding work.
- Route `cloudflare-vectorize` factory creation to the binding-only adapter when `cfVectorize` is present without D1; existing D1-backed and REST adapters remain intact.
- Add regression coverage for upsert/query filters, queryById fallback, namespace deletes, and factory selection without REST credentials.

## Coordination
- Rebasing picked up c4 PR #2190; this slice imports the extracted `src/vector/adapter.ts` contract and does not edit the c4 extraction files.
- No docs/UI changes; no screenshot needed.

## Verification
```bash
bun test tests/vector/
bunx tsc --noEmit
git diff --check HEAD~1..HEAD
wc -l src/vector/adapters/vectorize.ts src/vector/adapters/cloudflare.ts src/vector/adapters/index.ts tests/vector/vectorize-adapter.test.ts
```

Refs #2167