### PR TITLE
feat: forward MCP tenant context to backend

### DIFF
--- a/docs/deploy-cloudflare-mcp.md
+++ b/docs/deploy-cloudflare-mcp.md
@@ -76,6 +76,25 @@ Use the #2167 Wrangler config as source of truth. The likely minimum is:
 If auth is enabled, wrap `/mcp` with Cloudflare's OAuth provider or Access and
 keep tool authorization tenant-aware.
 
+## Team and school tenants
+
+The Worker can serve one MCP endpoint for many users when the OAuth provider
+stores a tenant claim in `McpAgent` props. Supported claim names are
+`tenantId`, `tenant_id`, `tenant`, `orgId`, `org_id`, `organizationId`, and
+`organization_id` either at the top level or under `claims`.
+
+When a tenant is resolved, the Worker forwards both backend-compatible tenant
+headers to `ORACLE_URL`:
+
+```text
+X-Tenant-ID: <tenant>
+X-Oracle-Tenant: <tenant>
+```
+
+Use tool-level `tenantId` only for local smoke tests without OAuth props. In
+production, bind tenant selection to the OAuth/access token claim so users cannot
+choose another tenant in a tool call.
+
 ## Manual Wrangler deploy fallback
 
 Use this when the button is not ready or you need to test a branch preview:

--- a/tests/workers/mcp-proxy-tools.test.ts
+++ b/tests/workers/mcp-proxy-tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
-import { buildProxyUrl, oracleProxyTool, resolveOracleUrl } from '../../workers/mcp/src/proxy.ts';
+import { buildProxyUrl, oracleProxyTool, resolveMcpTenantId, resolveOracleUrl } from '../../workers/mcp/src/proxy.ts';
 
 describe('Cloudflare MCP proxy tools', () => {
   test('registers search, stats, and learn tools in the Worker entry', () => {
@@ -42,8 +42,15 @@ describe('Cloudflare MCP proxy tools', () => {
     expect(result.isError).toBeUndefined();
     expect(captured[0].url).toBe('https://oracle.example.test/api/stats');
     expect(headers.get('authorization')).toBe('Bearer secret');
-    expect(headers.get('x-oracle-tenant-id')).toBe('tenant-a');
+    expect(headers.get('X-Tenant-ID')).toBe('tenant-a');
+    expect(headers.get('X-Oracle-Tenant')).toBe('tenant-a');
     expect(result.content[0].text).toContain('"total_docs": 12');
+  });
+
+  test('resolves tenant ids from OAuth props before tool args', () => {
+    expect(resolveMcpTenantId({ claims: { tenant_id: 'school-a' } }, 'spoofed')).toBe('school-a');
+    expect(resolveMcpTenantId(undefined, 'tenant-b')).toBe('tenant-b');
+    expect(() => resolveMcpTenantId(undefined, 'bad tenant')).toThrow('invalid tenant id');
   });
 
   test('proxies oracle_learn as JSON and marks backend errors', async () => {

--- a/tests/workers/mcp-proxy.test.ts
+++ b/tests/workers/mcp-proxy.test.ts
@@ -5,6 +5,8 @@ type ToolHandler = (input: Record<string, unknown>) => Promise<{
   isError?: boolean;
 }>;
 type RegisteredTool = { description: string; handler: ToolHandler };
+type SdkTool = { description?: string; handler: ToolHandler };
+type SdkToolServer = { _registeredTools?: Record<string, SdkTool> };
 
 const tools = new Map<string, RegisteredTool>();
 let servedPath: string | undefined;
@@ -21,8 +23,10 @@ function zShape() {
 mock.module('agents/mcp', () => ({
   McpAgent: class {
     env: Record<string, unknown>;
+    props: Record<string, unknown>;
     constructor(env: Record<string, unknown> = {}) {
       this.env = env;
+      this.props = (env.__props as Record<string, unknown> | undefined) ?? {};
     }
     static serve(path: string) {
       servedPath = path;
@@ -54,14 +58,20 @@ mock.module('zod', () => ({
   },
 }));
 
-async function loadTools() {
+async function loadTools(props: Record<string, unknown> = {}) {
   tools.clear();
   const mod = await import('../../workers/mcp/src/index.ts');
   const agent = new mod.OracleMCP({
     ORACLE_URL: 'https://oracle.example.test/root/',
     ARRA_API_TOKEN: 'proxy-secret',
+    __props: props,
   } as never);
   await agent.init();
+  if (tools.size === 0) {
+    for (const [name, tool] of Object.entries((agent.server as SdkToolServer)._registeredTools ?? {})) {
+      tools.set(name, { description: tool.description ?? '', handler: tool.handler });
+    }
+  }
 }
 
 function paramsFrom(url: string) {
@@ -89,7 +99,7 @@ describe('Cloudflare McpAgent proxy flow', () => {
       return Response.json({ ok: true, path: new URL(String(input)).pathname });
     }) as typeof fetch;
 
-    await loadTools();
+    await loadTools({ claims: { tenantId: 'tenant-from-oauth' } });
     expect(servedPath).toBe('/mcp');
     expect([...tools.keys()].sort()).toEqual(['muninn_search', 'muninn_stats', 'oracle_learn']);
 
@@ -102,15 +112,15 @@ describe('Cloudflare McpAgent proxy flow', () => {
       project: 'github.com/soul/arra',
       cwd: '/tmp/arra',
       model: 'bge-m3',
-      tenantId: 'tenant-a',
+      tenantId: 'spoofed-tenant',
     });
-    await tools.get('muninn_stats')!.handler({ tenantId: 'tenant-a' });
+    await tools.get('muninn_stats')!.handler({ tenantId: 'spoofed-tenant' });
     await tools.get('oracle_learn')!.handler({
       pattern: 'Workers proxy tests should cover MCP tool forwarding.',
       concepts: ['cloudflare', 'mcp'],
       source: 'proxy-test',
       project: 'github.com/soul/arra',
-      tenantId: 'tenant-a',
+      tenantId: 'spoofed-tenant',
     });
 
     expect(requests.map((request) => [request.method, new URL(request.url).pathname])).toEqual([
@@ -130,7 +140,8 @@ describe('Cloudflare McpAgent proxy flow', () => {
     });
     for (const request of requests) {
       expect(request.headers.get('authorization')).toBe('Bearer proxy-secret');
-      expect(request.headers.get('x-oracle-tenant-id')).toBe('tenant-a');
+      expect(request.headers.get('X-Tenant-ID')).toBe('tenant-from-oauth');
+      expect(request.headers.get('X-Oracle-Tenant')).toBe('tenant-from-oauth');
     }
     expect(requests[0].body).toBeNull();
     expect(requests[1].body).toBeNull();

--- a/workers/mcp/src/index.ts
+++ b/workers/mcp/src/index.ts
@@ -1,7 +1,7 @@
 import { McpAgent } from 'agents/mcp';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { oracleProxyTool, type OracleProxyEnv } from './proxy.ts';
+import { oracleProxyTool, type OracleMcpAuthContext, type OracleProxyEnv } from './proxy.ts';
 
 type Env = OracleProxyEnv;
 
@@ -11,7 +11,7 @@ const modelArg = z.enum(['nomic', 'qwen3', 'bge-m3']).optional();
 const tenantArg = z.string().optional();
 const conceptsArg = z.union([z.array(z.string()), z.string()]).optional();
 
-export class OracleMCP extends McpAgent<Env> {
+export class OracleMCP extends McpAgent<Env, unknown, OracleMcpAuthContext> {
   server = new McpServer({ name: 'arra-oracle', version: '1.0.0' });
 
   async init() {
@@ -33,6 +33,7 @@ export class OracleMCP extends McpAgent<Env> {
         path: '/api/search',
         query: { q: query, ...args },
         tenantId,
+        authContext: this.props,
       }),
     );
 
@@ -43,6 +44,7 @@ export class OracleMCP extends McpAgent<Env> {
       async ({ tenantId }) => oracleProxyTool(this.env, {
         path: '/api/stats',
         tenantId,
+        authContext: this.props,
       }),
     );
 
@@ -63,6 +65,7 @@ export class OracleMCP extends McpAgent<Env> {
         path: '/api/learn',
         body,
         tenantId,
+        authContext: this.props,
       }),
     );
   }

--- a/workers/mcp/src/proxy.ts
+++ b/workers/mcp/src/proxy.ts
@@ -2,6 +2,7 @@ export type OracleProxyEnv = {
   ORACLE_URL?: string;
   ORACLE_HTTP_URL?: string;
   ORACLE_API?: string;
+  ORACLE_TENANT_ID?: string;
   ARRA_API_TOKEN?: string;
   ARRA_API_KEY?: string;
 };
@@ -17,12 +18,55 @@ type ProxyRequest = {
   query?: Record<string, unknown>;
   body?: unknown;
   tenantId?: unknown;
+  authContext?: OracleMcpAuthContext;
 };
+
+export type OracleMcpAuthContext = {
+  tenantId?: unknown;
+  tenant_id?: unknown;
+  tenant?: unknown;
+  orgId?: unknown;
+  org_id?: unknown;
+  organizationId?: unknown;
+  organization_id?: unknown;
+  claims?: Record<string, unknown>;
+};
+
+const TENANT_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/;
+const TENANT_KEYS = ['tenantId', 'tenant_id', 'tenant', 'orgId', 'org_id', 'organizationId', 'organization_id'] as const;
 
 function trimValue(value: unknown): string | undefined {
   if (value === undefined || value === null) return undefined;
   const text = String(value).trim();
   return text || undefined;
+}
+
+function tenantValueFrom(source: Record<string, unknown> | undefined): string | undefined {
+  for (const key of TENANT_KEYS) {
+    const value = trimValue(source?.[key]);
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function normalizeTenantId(value: unknown): string | undefined {
+  const tenant = trimValue(value);
+  if (!tenant) return undefined;
+  if (!TENANT_PATTERN.test(tenant)) throw new Error('invalid tenant id');
+  return tenant;
+}
+
+export function resolveMcpTenantId(
+  authContext: OracleMcpAuthContext | undefined,
+  explicitTenantId?: unknown,
+  env?: OracleProxyEnv,
+): string | undefined {
+  return normalizeTenantId(
+    tenantValueFrom(authContext) ??
+    tenantValueFrom(authContext?.claims) ??
+    trimValue(env?.ORACLE_TENANT_ID) ??
+    explicitTenantId
+  );
 }
 
 export function resolveOracleUrl(env: OracleProxyEnv): string {
@@ -57,11 +101,14 @@ function textResult(payload: unknown, isError = false): TextToolResult {
   };
 }
 
-function proxyHeaders(env: OracleProxyEnv, hasBody: boolean, tenantId?: unknown): Headers {
+function proxyHeaders(env: OracleProxyEnv, hasBody: boolean, tenantId?: string): Headers {
   const headers = new Headers({ accept: 'application/json' });
   if (hasBody) headers.set('content-type', 'application/json');
-  const tenant = trimValue(tenantId);
-  if (tenant) headers.set('x-oracle-tenant-id', tenant);
+  if (tenantId) {
+    headers.set('X-Tenant-ID', tenantId);
+    headers.set('X-Oracle-Tenant', tenantId);
+    headers.set('X-Oracle-Tenant-ID', tenantId);
+  }
   const token = env.ARRA_API_TOKEN?.trim() || env.ARRA_API_KEY?.trim();
   if (token) headers.set('authorization', `Bearer ${token}`);
   return headers;
@@ -85,9 +132,10 @@ export async function oracleProxyTool(
   try {
     const baseUrl = resolveOracleUrl(env);
     const body = request.body === undefined ? undefined : JSON.stringify(request.body);
+    const tenantId = resolveMcpTenantId(request.authContext, request.tenantId, env);
     const response = await fetcher(buildProxyUrl(baseUrl, request.path, request.query), {
       method: request.method ?? 'GET',
-      headers: proxyHeaders(env, body !== undefined, request.tenantId),
+      headers: proxyHeaders(env, body !== undefined, tenantId),
       body,
     });
     return textResult(await readPayload(response), !response.ok);


### PR DESCRIPTION
## Summary
- Resolve MCP tenant IDs from `McpAgent` OAuth props/claims before tool-level fallback args.
- Forward resolved tenants to `ORACLE_URL` using backend-compatible `X-Tenant-ID` / `X-Oracle-Tenant` headers, with the prior worker preview header preserved for compatibility.
- Cover shared-endpoint tenant isolation and auth-prop precedence in worker tests.
- Document team/school tenant setup expectations in `docs/deploy-cloudflare-mcp.md`.

## Validation
```bash
bunx tsc --noEmit
bun test tests/workers/
bunx tsc -p workers/mcp/tsconfig.json --noEmit
```

Refs #2193
