### PR TITLE
test(cloudflare): smoke wrangler mcp deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ playwright-report/
 test-results/
 *.pid
 
+# Local Cloudflare Wrangler state
+.wrangler/
+
 # Oracle instance data (per-user vault; never commit)
 ψ/
 

--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -61,7 +61,7 @@ This repo uses a root skeleton:
 {
   "name": "arra-oracle-remote-mcp",
   "main": "./src/workers/oracle-mcp.ts",
-  "compatibility_date": "2026-06-16",
+  "compatibility_date": "2026-05-07",
   "compatibility_flags": ["nodejs_compat"],
   "workers_dev": true,
   "observability": { "enabled": true }

--- a/src/workers/oracle-mcp.ts
+++ b/src/workers/oracle-mcp.ts
@@ -1,0 +1,67 @@
+export interface OracleMcpWorkerEnv {
+  ORACLE_MCP_PATH?: string;
+  ORACLE_STORAGE_BACKEND?: string;
+  ORACLE_VECTOR_BACKEND?: string;
+}
+
+const JSON_HEADERS = {
+  'Content-Type': 'application/json; charset=utf-8',
+  'Cache-Control': 'no-store',
+  'X-Oracle-Worker': 'arra-oracle-remote-mcp',
+};
+
+function mcpPath(env: OracleMcpWorkerEnv): string {
+  const raw = env.ORACLE_MCP_PATH?.trim() || '/mcp';
+  return raw.startsWith('/') ? raw : `/${raw}`;
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: JSON_HEADERS });
+}
+
+function health(env: OracleMcpWorkerEnv): Response {
+  return json({
+    ok: true,
+    app: 'arra-oracle-remote-mcp',
+    mcpPath: mcpPath(env),
+    storage: env.ORACLE_STORAGE_BACKEND || 'd1',
+    vector: env.ORACLE_VECTOR_BACKEND || 'cloudflare-vectorize',
+  });
+}
+
+async function mcp(request: Request, env: OracleMcpWorkerEnv): Promise<Response> {
+  if (request.method === 'GET' || request.method === 'HEAD') {
+    return json({
+      ok: true,
+      transport: 'streamable-http',
+      path: mcpPath(env),
+      capabilities: { tools: {} },
+    });
+  }
+  if (request.method !== 'POST') return json({ error: 'method not allowed' }, 405);
+
+  const payload = await request.json().catch(() => null) as { id?: unknown; method?: string } | null;
+  if (payload?.method === 'initialize') {
+    return json({
+      jsonrpc: '2.0',
+      id: payload.id ?? null,
+      result: {
+        protocolVersion: '2025-03-26',
+        serverInfo: { name: 'arra-oracle-remote-mcp', version: '0.1.0' },
+        capabilities: { tools: {} },
+      },
+    });
+  }
+  return json({ jsonrpc: '2.0', id: payload?.id ?? null, error: { code: -32601, message: 'Method not found' } }, 404);
+}
+
+export async function handleOracleMcpRequest(request: Request, env: OracleMcpWorkerEnv = {}): Promise<Response> {
+  const url = new URL(request.url);
+  if (url.pathname === '/health' || url.pathname === '/__health') return health(env);
+  if (url.pathname === mcpPath(env)) return mcp(request, env);
+  return json({ error: 'not found' }, 404);
+}
+
+export default {
+  fetch: handleOracleMcpRequest,
+};

--- a/tests/workers/wrangler-dev-smoke.test.ts
+++ b/tests/workers/wrangler-dev-smoke.test.ts
@@ -1,0 +1,90 @@
+import { expect, setDefaultTimeout, test } from 'bun:test';
+
+setDefaultTimeout(90_000);
+
+function freePort(): number {
+  const server = Bun.serve({ port: 0, fetch: () => new Response('ok') });
+  const port = server.port;
+  server.stop(true);
+  return port;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function text(stream: ReadableStream<Uint8Array> | null): Promise<string> {
+  if (!stream) return '';
+  return new Response(stream).text();
+}
+
+async function waitForMcp(baseUrl: string): Promise<Record<string, unknown>> {
+  const deadline = Date.now() + 45_000;
+  let lastError = '';
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${baseUrl}/mcp`, { headers: { accept: 'application/json' } });
+      if (response.ok) return await response.json() as Record<string, unknown>;
+      lastError = `status ${response.status}: ${await response.text()}`;
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    await sleep(500);
+  }
+  throw new Error(`wrangler dev did not serve /mcp in time (${lastError})`);
+}
+
+test('wrangler dev --local starts the Cloudflare Worker and serves /mcp', async () => {
+  const port = freePort();
+  const proc = Bun.spawn([
+    'bunx',
+    'wrangler',
+    'dev',
+    '--local',
+    '--config',
+    'wrangler.jsonc',
+    '--ip',
+    '127.0.0.1',
+    '--port',
+    String(port),
+  ], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      NO_COLOR: '1',
+      WRANGLER_SEND_METRICS: 'false',
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const output = Promise.all([text(proc.stdout), text(proc.stderr)]).then((parts) => parts.join('\n'));
+
+  try {
+    const mcp = await waitForMcp(`http://127.0.0.1:${port}`);
+    expect(mcp).toMatchObject({
+      ok: true,
+      transport: 'streamable-http',
+      path: '/mcp',
+      capabilities: { tools: {} },
+    });
+
+    const init = await fetch(`http://127.0.0.1:${port}/mcp`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
+    });
+    expect(init.status).toBe(200);
+    expect(await init.json()).toMatchObject({
+      jsonrpc: '2.0',
+      id: 1,
+      result: { serverInfo: { name: 'arra-oracle-remote-mcp' } },
+    });
+  } catch (error) {
+    proc.kill();
+    await proc.exited.catch(() => {});
+    throw new Error(`${error instanceof Error ? error.message : String(error)}\n\nwrangler output:\n${await output}`);
+  } finally {
+    proc.kill();
+    await proc.exited.catch(() => {});
+  }
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,7 +4,7 @@
   // Placeholder owned by the #2167 Worker-entry lane. This docs/config PR
   // intentionally does not add or overwrite src/workers/* implementation.
   "main": "./src/workers/oracle-mcp.ts",
-  "compatibility_date": "2026-06-16",
+  "compatibility_date": "2026-05-07",
   "compatibility_flags": ["nodejs_compat"],
   "workers_dev": true,
   "observability": { "enabled": true },


### PR DESCRIPTION
## Summary
- Add a minimal root Cloudflare Worker entrypoint at `src/workers/oracle-mcp.ts` so the deploy button target can actually start locally.
- Add a `wrangler dev --local` smoke test that boots the root `wrangler.jsonc` config and verifies `/mcp` responds to GET and JSON-RPC `initialize`.
- Pin the root Worker `compatibility_date` to the newest date supported by the local Wrangler runtime used in the smoke test and ignore generated `.wrangler/` state.

## Tests
```bash
bun test tests/workers/wrangler-dev-smoke.test.ts
bun test tests/workers/
bunx tsc --noEmit
git diff --check origin/alpha...HEAD
```

## Notes
- Smoke test found the previous `2026-06-16` compatibility date would not start under local Wrangler 4.87 (`newest date supported ... 2026-05-07`), so this PR moves the root config to `2026-05-07`.
- Changed files are all <= 250 lines.
