### PR TITLE
test: guard workers MCP deploy readiness

### DIFF
--- a/tests/workers/cloudflare-deploy-config.test.ts
+++ b/tests/workers/cloudflare-deploy-config.test.ts
@@ -86,4 +86,26 @@ describe('Cloudflare deploy metadata', () => {
     expect(target.searchParams.get('url')).toBe(REPO_URL);
     expect(readme).toContain(`[![Deploy to Cloudflare](${BUTTON_IMAGE})]`);
   });
+
+  test('workers/mcp package stays deploy-ready for Wrangler', () => {
+    const cfg = parseJsonc<Record<string, any>>(read('workers/mcp/wrangler.jsonc'));
+    const pkg = JSON.parse(read('workers/mcp/package.json')) as Record<string, any>;
+
+    expect(pkg.scripts.deploy).toBe('wrangler deploy');
+    expect(pkg.dependencies).toMatchObject({
+      '@modelcontextprotocol/sdk': expect.any(String),
+      agents: expect.any(String),
+      zod: expect.any(String),
+    });
+    expect(pkg.devDependencies).toMatchObject({
+      '@cloudflare/workers-types': expect.any(String),
+      wrangler: expect.any(String),
+    });
+
+    expect(cfg.name).toBe('arra-oracle-mcp');
+    expect(cfg.main).toBe('src/index.ts');
+    expect(cfg.durable_objects.bindings).toContainEqual({ name: 'MCP_OBJECT', class_name: 'OracleMCP' });
+    expect(cfg.migrations).toContainEqual({ tag: 'v1', new_sqlite_classes: ['OracleMCP'] });
+    expect(cfg.vars.ORACLE_URL).toContain('replace-with-your-oracle-backend');
+  });
 });


### PR DESCRIPTION
## Summary
- Added a deploy-readiness regression guard for the isolated `workers/mcp` package.
- Verifies the Worker package keeps its Wrangler deploy script, required MCP/Agents deps, Workers types/Wrangler dev deps, Durable Object binding, migration, and placeholder backend URL.
- Kept this as polish/test-only; no new runtime features.

## Deploy Smoke
- `cd workers/mcp && bunx wrangler deploy --config wrangler.jsonc`
- Deployed URL: `https://arra-oracle-mcp.laris.workers.dev`
- Version ID: `7825fd62-17b5-4ad2-b825-25b4e4d1ee0d`
- `/mcp` JSON-RPC initialize smoke returned HTTP 200 `text/event-stream` with `serverInfo.name = arra-oracle`.

## Tests
- `bunx tsc --noEmit`
- `bunx tsc -p workers/mcp/tsconfig.json --noEmit`
- `bun test tests/workers/` (34 pass)
- `cd workers/mcp && bunx wrangler deploy --dry-run --outdir /tmp/arra-mcp-worker-dryrun-2 --config wrangler.jsonc`
- `git diff --check origin/alpha...HEAD`
- `wc -l $(git diff --name-only origin/alpha...HEAD)` (111 lines)
