### PR TITLE
test(workers): lock Cloudflare MCP deploy metadata

### DIFF
--- a/tests/workers/cloudflare-deploy-config.test.ts
+++ b/tests/workers/cloudflare-deploy-config.test.ts
@@ -10,6 +10,10 @@ function read(path: string): string {
   return readFileSync(path, 'utf8');
 }
 
+function readJson<T>(path: string): T {
+  return JSON.parse(read(path)) as T;
+}
+
 function parseJsonc<T>(source: string): T {
   return JSON.parse(stripTrailingCommas(stripComments(source))) as T;
 }
@@ -73,6 +77,42 @@ describe('Cloudflare deploy metadata', () => {
       ORACLE_MCP_PATH: '/mcp',
       ORACLE_STORAGE_BACKEND: 'd1',
       ORACLE_VECTOR_BACKEND: 'cloudflare-vectorize',
+    });
+  });
+
+  test('package metadata describes each root Wrangler deploy var', () => {
+    const cfg = parseJsonc<Record<string, any>>(read('wrangler.jsonc'));
+    const pkg = readJson<Record<string, any>>('package.json');
+    const bindings = pkg.cloudflare?.bindings ?? {};
+
+    for (const key of Object.keys(cfg.vars ?? {})) {
+      expect(typeof bindings[key]?.description).toBe('string');
+      expect(bindings[key].description.trim().length).toBeGreaterThan(20);
+    }
+  });
+
+  test('workers/mcp package has explicit build and deploy scripts', () => {
+    const pkg = readJson<Record<string, any>>('workers/mcp/package.json');
+
+    expect(pkg.scripts).toMatchObject({
+      build: 'tsc --noEmit',
+      dev: 'wrangler dev --config wrangler.jsonc',
+      deploy: 'tsc --noEmit && wrangler deploy --config wrangler.jsonc',
+      typecheck: 'tsc --noEmit',
+    });
+  });
+
+  test('workers/mcp Wrangler config keeps the backend proxy var', () => {
+    const cfg = parseJsonc<Record<string, any>>(read('workers/mcp/wrangler.jsonc'));
+
+    expect(cfg.main).toBe('src/index.ts');
+    expect(cfg.compatibility_flags).toContain('nodejs_compat');
+    expect(cfg.durable_objects.bindings).toContainEqual({
+      name: 'MCP_OBJECT',
+      class_name: 'OracleMCP',
+    });
+    expect(cfg.vars).toEqual({
+      ORACLE_URL: 'https://replace-with-your-oracle-backend.example.com',
     });
   });
 

--- a/workers/mcp/package.json
+++ b/workers/mcp/package.json
@@ -3,8 +3,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "wrangler dev",
-    "deploy": "wrangler deploy",
+    "build": "tsc --noEmit",
+    "dev": "wrangler dev --config wrangler.jsonc",
+    "deploy": "tsc --noEmit && wrangler deploy --config wrangler.jsonc",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Add an explicit `workers/mcp` build script and make `dev`/`deploy` call the local `wrangler.jsonc` config.
- Extend Workers deploy metadata tests to lock the MCP package scripts, backend proxy var, root Wrangler deploy vars, and README deploy button URL.
- Kept the root deploy button and Wrangler vars unchanged after the final audit.

## Validation
```bash
bun test tests/workers/
bunx tsc --noEmit
npm exec --yes --prefix workers/mcp --package=typescript@5.7.2 --package=@cloudflare/workers-types@4.20260616.1 --package=agents@0.16.1 --package=zod@3.25.76 --package=@modelcontextprotocol/sdk@1.29.0 -- tsc --noEmit
git diff --check origin/alpha...HEAD
wc -l tests/workers/cloudflare-deploy-config.test.ts workers/mcp/package.json workers/mcp/README.md wrangler.jsonc README.md docs/deploy-cloudflare-mcp.md
```

## File sizes
```text
129 tests/workers/cloudflare-deploy-config.test.ts
21  workers/mcp/package.json
157 workers/mcp/README.md
39  wrangler.jsonc
239 README.md
250 docs/deploy-cloudflare-mcp.md
```

No UI changes; no screenshot required.
