### PR TITLE
feat: add studio worker deploy config

### DIFF
--- a/tests/workers/studio-deploy-config.test.ts
+++ b/tests/workers/studio-deploy-config.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+function stripJsonc(input: string): string {
+  return input
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|\s)\/\/.*$/gm, '$1');
+}
+
+function studioConfig() {
+  return JSON.parse(stripJsonc(readFileSync('workers/studio/wrangler.jsonc', 'utf8')));
+}
+
+describe('Studio Worker deploy config', () => {
+  test('serves the Vite frontend with Workers Static Assets before fallback', () => {
+    const config = studioConfig();
+
+    expect(config.name).toBe('arra-oracle-studio');
+    expect(config.main).toBe('worker.ts');
+    expect(config.assets).toEqual({
+      directory: '../../frontend/dist',
+      binding: 'ASSETS',
+      not_found_handling: 'single-page-application',
+      run_worker_first: true,
+    });
+  });
+
+  test('keeps frontend API proxy URLs configurable', () => {
+    const config = studioConfig();
+
+    expect(config.vars.ORACLE_URL).toContain('replace-with-your-oracle-backend');
+    expect(config.vars.ORACLE_MCP_URL).toBe('https://arra-oracle-mcp.laris.workers.dev/mcp');
+  });
+});

--- a/workers/studio/wrangler.jsonc
+++ b/workers/studio/wrangler.jsonc
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://raw.githubusercontent.com/cloudflare/workers-sdk/main/packages/wrangler/config-schema.json",
+  "name": "arra-oracle-studio",
+  "main": "worker.ts",
+  "compatibility_date": "2026-06-16",
+  "workers_dev": true,
+  "observability": { "enabled": true },
+  "assets": {
+    "directory": "../../frontend/dist",
+    "binding": "ASSETS",
+    "not_found_handling": "single-page-application",
+    "run_worker_first": true
+  },
+  "vars": {
+    "ORACLE_URL": "https://replace-with-your-oracle-backend.example.com",
+    "ORACLE_MCP_URL": "https://arra-oracle-mcp.laris.workers.dev/mcp"
+  }
+}


### PR DESCRIPTION
## Summary

- Add `workers/studio/wrangler.jsonc` for Oracle Studio on Cloudflare Workers Static Assets.
- Configure the `ASSETS` binding to `../../frontend/dist`, SPA `not_found_handling`, and `run_worker_first: true` for the future `worker.ts` API proxy.
- Add `tests/workers/studio-deploy-config.test.ts` to lock the ui-oracle deploy shape and configurable backend URLs.

## Validation

```bash
bunx tsc --noEmit
bun test tests/workers/studio-deploy-config.test.ts tests/workers/cloudflare-deploy-config.test.ts
wc -l workers/studio/wrangler.jsonc tests/workers/studio-deploy-config.test.ts
```

Files are 18 and 34 lines.

Refs #2206
