### PR TITLE
feat: add studio workers static proxy

### DIFF
--- a/tests/workers/studio-worker.test.ts
+++ b/tests/workers/studio-worker.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { handleStudioRequest, type StudioEnv } from '../../workers/studio/worker.ts';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function env(overrides: Partial<StudioEnv> = {}): StudioEnv {
+  return {
+    ORACLE_URL: 'https://oracle.example.test/root/',
+    ASSETS: {
+      fetch: async (request) => new Response(`<html>${new URL(request.url).pathname}</html>`, {
+        headers: { 'content-type': 'text/html' },
+      }),
+    },
+    ...overrides,
+  };
+}
+
+describe('Oracle Studio Worker static assets proxy', () => {
+  test('wrangler config uses Workers Static Assets with worker-first routing', () => {
+    const config = JSON.parse(readFileSync('workers/studio/wrangler.jsonc', 'utf8'));
+
+    expect(config.main).toBe('worker.ts');
+    expect(config.assets).toMatchObject({
+      directory: '../../frontend/dist',
+      binding: 'ASSETS',
+      not_found_handling: 'single-page-application',
+      run_worker_first: true,
+    });
+  });
+
+  test('proxies /api requests to ORACLE_URL and preserves method/body/query', async () => {
+    const seen: Array<{ url: string; method: string; host: string | null; marker: string | null; body: string }> = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const upstream = new Request(input, init);
+      seen.push({
+        url: String(input),
+        method: upstream.method,
+        host: upstream.headers.get('host'),
+        marker: upstream.headers.get('x-oracle-studio-worker'),
+        body: await upstream.text(),
+      });
+      return Response.json({ ok: true });
+    }) as typeof fetch;
+
+    const response = await handleStudioRequest(new Request('https://studio.example/api/search?q=vector', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', host: 'spoofed.example' },
+      body: JSON.stringify({ limit: 3 }),
+    }), env());
+
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(response.headers.get('x-oracle-studio-worker')).toBe('oracle-studio-worker');
+    expect(await response.json()).toEqual({ ok: true });
+    expect(seen).toEqual([{
+      url: 'https://oracle.example.test/root/api/search?q=vector',
+      method: 'POST',
+      host: null,
+      marker: 'oracle-studio-worker',
+      body: '{"limit":3}',
+    }]);
+  });
+
+  test('serves non-api requests through the ASSETS binding with SPA cache headers', async () => {
+    const requested: string[] = [];
+    const response = await handleStudioRequest(new Request('https://studio.example/dashboard'), env({
+      ASSETS: { fetch: async (request) => { requested.push(request.url); return new Response('<html>studio</html>', { headers: { 'content-type': 'text/html' } }); } },
+    }));
+
+    expect(requested).toEqual(['https://studio.example/dashboard']);
+    expect(response.headers.get('cache-control')).toBe('public, max-age=3600, stale-while-revalidate=86400');
+    expect(await response.text()).toBe('<html>studio</html>');
+  });
+
+  test('sets immutable cache headers for Vite asset URLs', async () => {
+    const response = await handleStudioRequest(new Request('https://studio.example/assets/app.js'), env({
+      ASSETS: { fetch: async () => new Response('console.log(1)', { headers: { 'content-type': 'text/javascript' } }) },
+    }));
+
+    expect(response.headers.get('cache-control')).toBe('public, max-age=31536000, immutable');
+    expect(await response.text()).toBe('console.log(1)');
+  });
+
+  test('api preflight stays worker-local', async () => {
+    globalThis.fetch = (async () => { throw new Error('preflight should not proxy'); }) as typeof fetch;
+
+    const response = await handleStudioRequest(new Request('https://studio.example/api/search', { method: 'OPTIONS' }), env());
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('access-control-allow-methods')).toContain('POST');
+    expect(response.headers.get('x-oracle-studio-worker')).toBe('oracle-studio-worker');
+  });
+});

--- a/workers/studio/package.json
+++ b/workers/studio/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@soul-brews/arra-oracle-studio-worker",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "cd ../../frontend && bun run build",
+    "deploy": "bun run build && bunx wrangler deploy",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.2",
+    "wrangler": "^4.101.0"
+  }
+}

--- a/workers/studio/tsconfig.json
+++ b/workers/studio/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "WebWorker"],
+    "strict": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["worker.ts"]
+}

--- a/workers/studio/worker.ts
+++ b/workers/studio/worker.ts
@@ -1,0 +1,135 @@
+type AssetFetcher = { fetch(request: Request): Promise<Response> };
+
+export interface StudioEnv {
+  ASSETS: AssetFetcher;
+  ORACLE_URL?: string;
+  ORACLE_HTTP_URL?: string;
+  ORACLE_API?: string;
+}
+
+const WORKER_HEADER = 'oracle-studio-worker';
+const API_METHODS = 'GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS';
+
+export default {
+  fetch: handleStudioRequest,
+};
+
+export async function handleStudioRequest(request: Request, env: StudioEnv): Promise<Response> {
+  const url = new URL(request.url);
+  if (url.pathname === '/__health') return health();
+  if (url.pathname === '/api' || url.pathname.startsWith('/api/')) {
+    if (request.method === 'OPTIONS') return apiPreflight();
+    return proxyApiRequest(request, env);
+  }
+  return serveAsset(request, env);
+}
+
+async function proxyApiRequest(request: Request, env: StudioEnv): Promise<Response> {
+  try {
+    const target = apiTarget(resolveOracleUrl(env), new URL(request.url));
+    const upstream = await fetch(target, {
+      method: request.method,
+      headers: proxyHeaders(request.headers),
+      body: hasRequestBody(request.method) ? request.body : undefined,
+      redirect: 'manual',
+    });
+    return withHeaders(upstream, {
+      'cache-control': 'no-store',
+      'x-oracle-studio-worker': WORKER_HEADER,
+      'access-control-allow-origin': '*',
+      'access-control-expose-headers': 'x-oracle-studio-worker',
+    });
+  } catch (error) {
+    return json({ error: 'api proxy failed', message: message(error) }, 502);
+  }
+}
+
+function resolveOracleUrl(env: StudioEnv): string {
+  const raw = env.ORACLE_URL ?? env.ORACLE_HTTP_URL ?? env.ORACLE_API;
+  const value = raw?.trim();
+  if (!value) throw new Error('Set ORACLE_URL to the Oracle backend.');
+  const url = new URL(value);
+  if (!['http:', 'https:'].includes(url.protocol)) throw new Error('ORACLE_URL must be http(s).');
+  url.username = '';
+  url.password = '';
+  url.hash = '';
+  url.search = '';
+  url.pathname = url.pathname.replace(/\/+$/, '');
+  return url.toString().replace(/\/+$/, '');
+}
+
+function apiTarget(baseUrl: string, requestUrl: URL): string {
+  const target = new URL(`${baseUrl}${requestUrl.pathname}`);
+  target.search = requestUrl.search;
+  return target.toString();
+}
+
+function proxyHeaders(source: Headers): Headers {
+  const headers = new Headers(source);
+  headers.delete('host');
+  headers.set('x-oracle-studio-worker', WORKER_HEADER);
+  return headers;
+}
+
+async function serveAsset(request: Request, env: StudioEnv): Promise<Response> {
+  const response = await env.ASSETS.fetch(request);
+  const url = new URL(request.url);
+  const cache = cacheControlFor(url.pathname, response.headers.get('content-type'));
+  return withHeaders(response, {
+    ...(cache ? { 'cache-control': cache } : {}),
+    'x-oracle-studio-worker': WORKER_HEADER,
+  });
+}
+
+function cacheControlFor(pathname: string, contentType: string | null): string | undefined {
+  if (pathname.startsWith('/assets/')) return 'public, max-age=31536000, immutable';
+  if (contentType?.includes('text/html') || !pathname.split('/').pop()?.includes('.')) {
+    return 'public, max-age=3600, stale-while-revalidate=86400';
+  }
+  return undefined;
+}
+
+function withHeaders(response: Response, values: Record<string, string>): Response {
+  const headers = new Headers(response.headers);
+  for (const [key, value] of Object.entries(values)) headers.set(key, value);
+  return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
+}
+
+function apiPreflight(): Response {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      allow: API_METHODS,
+      'access-control-allow-origin': '*',
+      'access-control-allow-methods': API_METHODS,
+      'access-control-allow-headers': 'authorization, content-type, x-oracle-tenant, x-tenant-id',
+      'access-control-expose-headers': 'x-oracle-studio-worker',
+      'cache-control': 'no-store',
+      'x-oracle-studio-worker': WORKER_HEADER,
+    },
+  });
+}
+
+function health(): Response {
+  return json({ ok: true, app: 'arra-oracle-studio-worker' }, 200);
+}
+
+function json(payload: unknown, status: number): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'cache-control': 'no-store',
+      'x-content-type-options': 'nosniff',
+      'x-oracle-studio-worker': WORKER_HEADER,
+    },
+  });
+}
+
+function hasRequestBody(method: string): boolean {
+  return !['GET', 'HEAD'].includes(method.toUpperCase());
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/workers/studio/wrangler.jsonc
+++ b/workers/studio/wrangler.jsonc
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://raw.githubusercontent.com/cloudflare/workers-sdk/main/packages/wrangler/config-schema.json",
+  "name": "arra-oracle-studio",
+  "main": "worker.ts",
+  "compatibility_date": "2026-06-17",
+  "workers_dev": true,
+  "observability": { "enabled": true },
+  "assets": {
+    "directory": "../../frontend/dist",
+    "binding": "ASSETS",
+    "not_found_handling": "single-page-application",
+    "run_worker_first": true
+  },
+  "vars": {
+    "ORACLE_URL": "https://replace-with-your-oracle-backend.example.com"
+  }
+}


### PR DESCRIPTION
## Summary
- Added `workers/studio/worker.ts` using the ui-oracle-style Workers Static Assets pattern: worker-first `/api/*` proxy to `ORACLE_URL`, otherwise `env.ASSETS.fetch(request)`.
- Added `workers/studio/wrangler.jsonc` with native `ASSETS` binding, SPA fallback, and `run_worker_first`.
- Added studio worker package/tsconfig for build/deploy/typecheck.
- Covered API proxy behavior, ASSETS fallback, SPA/immutable cache headers, and local preflight handling.

## Validation
```bash
bunx tsc --noEmit
bunx tsc -p workers/studio/tsconfig.json --noEmit
bun test tests/workers/studio-worker.test.ts
cd frontend && bun run build
```

Refs #2206
