### PR TITLE
test: add Studio Worker dry-run coverage

### DIFF
--- a/tests/workers/cloudflare-deploy-config.test.ts
+++ b/tests/workers/cloudflare-deploy-config.test.ts
@@ -131,7 +131,7 @@ describe('Cloudflare deploy metadata', () => {
     const cfg = parseJsonc<Record<string, any>>(read('workers/mcp/wrangler.jsonc'));
     const pkg = JSON.parse(read('workers/mcp/package.json')) as Record<string, any>;
 
-    expect(pkg.scripts.deploy).toBe('wrangler deploy');
+    expect(pkg.scripts.deploy).toBe('tsc --noEmit && wrangler deploy --config wrangler.jsonc');
     expect(pkg.dependencies).toMatchObject({
       '@modelcontextprotocol/sdk': expect.any(String),
       agents: expect.any(String),

--- a/tests/workers/mcp-deploy-config.test.ts
+++ b/tests/workers/mcp-deploy-config.test.ts
@@ -54,7 +54,10 @@ describe('workers/mcp deploy package', () => {
   test('declares the runtime dependencies needed by wrangler deploy', () => {
     const pkg = readJson('workers/mcp/package.json');
 
-    expect(pkg.scripts).toMatchObject({ deploy: 'wrangler deploy', typecheck: 'tsc --noEmit' });
+    expect(pkg.scripts).toMatchObject({
+      deploy: 'tsc --noEmit && wrangler deploy --config wrangler.jsonc',
+      typecheck: 'tsc --noEmit',
+    });
     expect(pkg.dependencies).toMatchObject({
       '@modelcontextprotocol/sdk': expect.any(String),
       agents: expect.any(String),

--- a/tests/workers/mcp-deploy-ready.test.ts
+++ b/tests/workers/mcp-deploy-ready.test.ts
@@ -40,7 +40,7 @@ describe('workers/mcp deploy readiness', () => {
   test('worker package keeps the dependencies needed by wrangler deploy', () => {
     const pkg = JSON.parse(read('workers/mcp/package.json')) as Record<string, any>;
 
-    expect(pkg.scripts.deploy).toBe('wrangler deploy');
+    expect(pkg.scripts.deploy).toBe('tsc --noEmit && wrangler deploy --config wrangler.jsonc');
     expect(pkg.dependencies).toMatchObject({
       '@modelcontextprotocol/sdk': expect.any(String),
       agents: expect.any(String),

--- a/tests/workers/studio-deploy-config.test.ts
+++ b/tests/workers/studio-deploy-config.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+function read(path: string): string {
+  return readFileSync(path, 'utf8');
+}
+
+function parseJsonc<T>(source: string): T {
+  return JSON.parse(source.replace(/,\s*([}\]])/g, '$1')) as T;
+}
+
+describe('Studio Worker deploy config', () => {
+  test('copies the ui-oracle Workers Static Assets pattern', () => {
+    const cfg = parseJsonc<Record<string, any>>(read('workers/studio/wrangler.jsonc'));
+
+    expect(cfg.name).toBe('oracle-studio-worker');
+    expect(cfg.main).toBe('worker.ts');
+    expect(cfg.workers_dev).toBe(true);
+    expect(cfg.assets).toEqual({
+      directory: '../../frontend/dist',
+      binding: 'ASSETS',
+      not_found_handling: 'single-page-application',
+      run_worker_first: true,
+    });
+    expect(cfg.vars.ORACLE_URL).toContain('replace-with-your-oracle-backend');
+    expect(cfg.vars.ORACLE_MCP_URL).toContain('arra-oracle-mcp.laris.workers.dev');
+  });
+
+  test('package scripts build the frontend before deploy and dry-run', () => {
+    const pkg = JSON.parse(read('workers/studio/package.json')) as Record<string, any>;
+
+    expect(pkg.scripts.build).toBe('cd ../../frontend && bun run build');
+    expect(pkg.scripts.deploy).toBe('bun run build && wrangler deploy');
+    expect(pkg.scripts['deploy:dry-run']).toBe('bun run build && wrangler deploy --dry-run');
+    expect(pkg.devDependencies.wrangler).toEqual(expect.any(String));
+  });
+});

--- a/tests/workers/studio-worker.test.ts
+++ b/tests/workers/studio-worker.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { handleStudioRequest, type StudioWorkerEnv } from '../../workers/studio/worker.ts';
+
+const originalFetch = globalThis.fetch;
+const assetFetch = async (request: Request) => new Response('<!doctype html><div id="root"></div>', {
+  headers: { 'content-type': 'text/html' },
+});
+
+function env(overrides: Partial<StudioWorkerEnv> = {}): StudioWorkerEnv {
+  return {
+    ASSETS: { fetch: assetFetch },
+    ORACLE_URL: 'https://oracle.example.test/root/',
+    ORACLE_MCP_URL: 'https://mcp.example.test',
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('Studio Worker', () => {
+  test('serves frontend assets through the ASSETS binding with ui-oracle cache headers', async () => {
+    const response = await handleStudioRequest(new Request('https://studio.example.test/app'), env());
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-oracle-studio-worker')).toBe('oracle-studio-worker');
+    expect(response.headers.get('cache-control')).toBe('public, max-age=3600, stale-while-revalidate=86400');
+    expect(await response.text()).toContain('root');
+  });
+
+  test('caches Vite hashed assets as immutable', async () => {
+    const response = await handleStudioRequest(new Request('https://studio.example.test/assets/app-abc12345.js'), env({
+      ASSETS: { fetch: async () => new Response('console.log(1)', { headers: { 'content-type': 'text/javascript' } }) },
+    }));
+
+    expect(response.headers.get('cache-control')).toBe('public, max-age=31536000, immutable');
+  });
+
+  test('proxies /api requests to the configured Oracle backend', async () => {
+    const seen: Array<{ url: string; method: string; marker: string | null; body: string }> = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const upstream = new Request(input, init);
+      seen.push({
+        url: String(input),
+        method: upstream.method,
+        marker: upstream.headers.get('x-oracle-studio-worker'),
+        body: await upstream.text(),
+      });
+      return Response.json({ ok: true });
+    }) as typeof fetch;
+
+    const response = await handleStudioRequest(new Request('https://studio.example.test/api/search?q=oracle', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', host: 'spoofed.example' },
+      body: JSON.stringify({ limit: 3 }),
+    }), env());
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(seen).toEqual([{ url: 'https://oracle.example.test/api/search?q=oracle', method: 'POST', marker: 'oracle-studio-worker', body: '{"limit":3}' }]);
+  });
+
+  test('proxies /mcp requests to the MCP worker URL', async () => {
+    const seen: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      seen.push(String(input));
+      return new Response('event: message\n\n', { headers: { 'content-type': 'text/event-stream' } });
+    }) as typeof fetch;
+
+    const response = await handleStudioRequest(new Request('https://studio.example.test/mcp?session=1'), env());
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/event-stream');
+    expect(seen).toEqual(['https://mcp.example.test/mcp?session=1']);
+  });
+
+  test('returns a marked 502 when API upstream is not configured', async () => {
+    const response = await handleStudioRequest(new Request('https://studio.example.test/api/health'), env({ ORACLE_URL: 'file:///tmp/oracle.sock' }));
+
+    expect(response.status).toBe(502);
+    expect(response.headers.get('x-oracle-studio-worker')).toBe('oracle-studio-worker');
+    expect(await response.json()).toEqual({ error: 'api upstream not configured' });
+  });
+});

--- a/workers/studio/package.json
+++ b/workers/studio/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@soul-brews/arra-oracle-studio-worker",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "cd ../../frontend && bun run build",
+    "deploy": "bun run build && wrangler deploy",
+    "deploy:dry-run": "bun run build && wrangler deploy --dry-run"
+  },
+  "devDependencies": {
+    "wrangler": "^4.101.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/workers/studio/tsconfig.json
+++ b/workers/studio/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "WebWorker"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["worker.ts"]
+}

--- a/workers/studio/worker.ts
+++ b/workers/studio/worker.ts
@@ -1,0 +1,95 @@
+export interface StudioWorkerEnv {
+  ASSETS: { fetch: (request: Request) => Promise<Response> };
+  ORACLE_URL?: string;
+  ORACLE_MCP_URL?: string;
+}
+
+const WORKER = 'oracle-studio-worker';
+const HASHED_ASSET = /\/(?:assets\/|[^/]+-)[A-Za-z0-9_-]{8,}\.[a-z0-9]+$/i;
+const API_HEADERS = {
+  'Access-Control-Allow-Headers': 'authorization, content-type, x-api-key, x-correlation-id, x-oracle-tenant, x-tenant-id',
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Expose-Headers': 'x-oracle-studio-worker',
+  'Cache-Control': 'no-store',
+  'X-Oracle-Studio-Worker': WORKER,
+};
+const SECURITY_HEADERS = {
+  'Referrer-Policy': 'strict-origin-when-cross-origin',
+  'X-Content-Type-Options': 'nosniff',
+  'X-Oracle-Studio-Worker': WORKER,
+};
+
+function normalizedBase(raw: string | undefined): string | null {
+  const trimmed = raw?.trim();
+  if (!trimmed) return null;
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+    url.username = '';
+    url.password = '';
+    url.search = '';
+    url.hash = '';
+    return url.toString().replace(/\/+$/, '');
+  } catch {
+    return null;
+  }
+}
+
+function proxyTarget(request: Request, base: string): URL {
+  const source = new URL(request.url);
+  return new URL(source.pathname + source.search, base);
+}
+
+async function proxy(request: Request, base: string): Promise<Response> {
+  const headers = new Headers(request.headers);
+  headers.set('x-oracle-studio-worker', WORKER);
+  headers.delete('host');
+  try {
+    const upstream = await fetch(proxyTarget(request, base), {
+      method: request.method,
+      headers,
+      body: request.method === 'GET' || request.method === 'HEAD' ? undefined : request.body,
+    });
+    const responseHeaders = new Headers(upstream.headers);
+    for (const [key, value] of Object.entries(API_HEADERS)) responseHeaders.set(key, value);
+    return new Response(upstream.body, { status: upstream.status, statusText: upstream.statusText, headers: responseHeaders });
+  } catch {
+    return Response.json({ error: 'studio proxy failed' }, { status: 502, headers: API_HEADERS });
+  }
+}
+
+function configError(kind: 'api' | 'mcp'): Response {
+  return Response.json({ error: `${kind} upstream not configured` }, { status: 502, headers: API_HEADERS });
+}
+
+async function asset(request: Request, env: StudioWorkerEnv): Promise<Response> {
+  const response = await env.ASSETS.fetch(request);
+  if (!response.ok) return response;
+  const url = new URL(request.url);
+  const headers = new Headers(response.headers);
+  for (const [key, value] of Object.entries(SECURITY_HEADERS)) headers.set(key, value);
+  const cache = HASHED_ASSET.test(url.pathname)
+    ? 'public, max-age=31536000, immutable'
+    : 'public, max-age=3600, stale-while-revalidate=86400';
+  headers.set('Cache-Control', cache);
+  return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
+}
+
+export async function handleStudioRequest(request: Request, env: StudioWorkerEnv): Promise<Response> {
+  const url = new URL(request.url);
+  if ((url.pathname === '/api' || url.pathname.startsWith('/api/')) && request.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: API_HEADERS });
+  }
+  if (url.pathname === '/api' || url.pathname.startsWith('/api/')) {
+    const base = normalizedBase(env.ORACLE_URL);
+    return base ? proxy(request, base) : configError('api');
+  }
+  if (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/')) {
+    const base = normalizedBase(env.ORACLE_MCP_URL);
+    return base ? proxy(request, base) : configError('mcp');
+  }
+  return asset(request, env);
+}
+
+export default { fetch: handleStudioRequest };

--- a/workers/studio/wrangler.jsonc
+++ b/workers/studio/wrangler.jsonc
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://raw.githubusercontent.com/cloudflare/workers-sdk/main/packages/wrangler/config-schema.json",
+  "name": "oracle-studio-worker",
+  "main": "worker.ts",
+  "compatibility_date": "2026-05-07",
+  "workers_dev": true,
+  "observability": { "enabled": true },
+  "assets": {
+    "directory": "../../frontend/dist",
+    "binding": "ASSETS",
+    "not_found_handling": "single-page-application",
+    "run_worker_first": true
+  },
+  "vars": {
+    "ORACLE_URL": "https://replace-with-your-oracle-backend.example.com",
+    "ORACLE_MCP_URL": "https://arra-oracle-mcp.laris.workers.dev"
+  }
+}


### PR DESCRIPTION
## Summary
- Added the `workers/studio` make-it-work Worker implementation using the ui-oracle Static Assets pattern.
- Added package/tsconfig support so the Studio Worker can build the frontend before deploy or dry-run.
- Added Worker tests for static asset caching, `/api/*` proxying, `/mcp` proxying, and missing upstream errors.
- Added/updated deploy config guards, including stale MCP deploy script expectations after latest `alpha` changed those scripts.

## Validation
- `bunx tsc --noEmit`
- `bunx tsc -p workers/studio/tsconfig.json --noEmit`
- `bun test tests/workers/` — 49 pass, 0 fail
- `cd frontend && bun run build`
- `cd workers/studio && bunx wrangler deploy --dry-run --outdir /tmp/arra-studio-worker-dryrun-final --config wrangler.jsonc`
- `git diff --check origin/alpha...HEAD`
- `wc -l $(git diff --name-only origin/alpha...HEAD)` — all files <=250 lines

## Notes
- Resolved the `workers/studio` add/add conflict after #2211 landed by keeping upstream `arra-oracle-studio` naming and MCP URL, while adding the Worker/test/package dry-run coverage.
- No real deploy performed for this slice; requested dry-run passes and reads frontend `dist` assets.
