### PR TITLE
feat: add studio worker proxy

### DIFF
--- a/tests/workers/studio-worker.test.ts
+++ b/tests/workers/studio-worker.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { handleStudioRequest, type StudioEnv } from '../../workers/studio/worker.ts';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function env(overrides: Partial<StudioEnv> = {}): StudioEnv {
+  return {
+    ORACLE_URL: 'https://oracle.example.test/root/',
+    ASSETS: {
+      fetch: async (request) => new Response(`<html>${new URL(request.url).pathname}</html>`, {
+        headers: { 'content-type': 'text/html' },
+      }),
+    },
+    ...overrides,
+  };
+}
+
+describe('Oracle Studio Worker', () => {
+  test('proxies /api requests to ORACLE_URL and preserves method, query, and body', async () => {
+    const seen: Array<{ url: string; method: string; host: string | null; marker: string | null; body: string }> = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const upstream = new Request(input, init);
+      seen.push({
+        url: String(input),
+        method: upstream.method,
+        host: upstream.headers.get('host'),
+        marker: upstream.headers.get('x-oracle-studio-worker'),
+        body: await upstream.text(),
+      });
+      return Response.json({ ok: true });
+    }) as typeof fetch;
+
+    const response = await handleStudioRequest(new Request('https://studio.example/api/search?q=vector', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', host: 'spoofed.example' },
+      body: JSON.stringify({ limit: 3 }),
+    }), env());
+
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(response.headers.get('x-oracle-studio-worker')).toBe('oracle-studio-worker');
+    expect(await response.json()).toEqual({ ok: true });
+    expect(seen).toEqual([{
+      url: 'https://oracle.example.test/root/api/search?q=vector',
+      method: 'POST',
+      host: null,
+      marker: 'oracle-studio-worker',
+      body: '{"limit":3}',
+    }]);
+  });
+
+  test('serves non-api requests through ASSETS with SPA cache headers', async () => {
+    const requested: string[] = [];
+    const response = await handleStudioRequest(new Request('https://studio.example/dashboard'), env({
+      ASSETS: {
+        fetch: async (request) => {
+          requested.push(request.url);
+          return new Response('<html>studio</html>', { headers: { 'content-type': 'text/html' } });
+        },
+      },
+    }));
+
+    expect(requested).toEqual(['https://studio.example/dashboard']);
+    expect(response.headers.get('cache-control')).toBe('public, max-age=3600, stale-while-revalidate=86400');
+    expect(response.headers.get('x-oracle-studio-worker')).toBe('oracle-studio-worker');
+    expect(await response.text()).toBe('<html>studio</html>');
+  });
+
+  test('sets immutable cache headers for Vite asset URLs', async () => {
+    const response = await handleStudioRequest(new Request('https://studio.example/assets/app.js'), env({
+      ASSETS: {
+        fetch: async () => new Response('console.log(1)', { headers: { 'content-type': 'text/javascript' } }),
+      },
+    }));
+
+    expect(response.headers.get('cache-control')).toBe('public, max-age=31536000, immutable');
+    expect(await response.text()).toBe('console.log(1)');
+  });
+
+  test('handles API preflight without upstream fetch', async () => {
+    globalThis.fetch = (async () => {
+      throw new Error('preflight should not proxy');
+    }) as typeof fetch;
+
+    const response = await handleStudioRequest(
+      new Request('https://studio.example/api/search', { method: 'OPTIONS' }),
+      env(),
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('access-control-allow-methods')).toContain('POST');
+    expect(response.headers.get('x-oracle-studio-worker')).toBe('oracle-studio-worker');
+  });
+
+  test('returns worker-local health', async () => {
+    const response = await handleStudioRequest(new Request('https://studio.example/__health'), env());
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true, app: 'arra-oracle-studio-worker' });
+  });
+});

--- a/workers/studio/worker.ts
+++ b/workers/studio/worker.ts
@@ -1,0 +1,140 @@
+type AssetFetcher = { fetch(request: Request): Promise<Response> };
+
+export interface StudioEnv {
+  ASSETS: AssetFetcher;
+  ORACLE_URL?: string;
+  ORACLE_HTTP_URL?: string;
+  ORACLE_API?: string;
+}
+
+const WORKER_HEADER = 'oracle-studio-worker';
+const API_METHODS = 'GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS';
+
+export default {
+  fetch: handleStudioRequest,
+};
+
+export async function handleStudioRequest(request: Request, env: StudioEnv): Promise<Response> {
+  const url = new URL(request.url);
+  if (url.pathname === '/__health') return healthResponse();
+  if (url.pathname === '/api' || url.pathname.startsWith('/api/')) {
+    if (request.method === 'OPTIONS') return apiPreflight();
+    return proxyApiRequest(request, env);
+  }
+  return serveAsset(request, env);
+}
+
+async function proxyApiRequest(request: Request, env: StudioEnv): Promise<Response> {
+  try {
+    const upstream = await fetch(proxyTarget(request, env), {
+      method: request.method,
+      headers: proxyHeaders(request.headers),
+      body: hasBody(request.method) ? request.body : undefined,
+      redirect: 'manual',
+    });
+    return withHeaders(upstream, {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Expose-Headers': 'x-oracle-studio-worker',
+      'Cache-Control': 'no-store',
+      'X-Oracle-Studio-Worker': WORKER_HEADER,
+    });
+  } catch (error) {
+    return json({ error: 'api proxy failed', message: message(error) }, 502);
+  }
+}
+
+function proxyTarget(request: Request, env: StudioEnv): string {
+  const source = new URL(request.url);
+  const target = new URL(`${apiBase(env)}${source.pathname}`);
+  target.search = source.search;
+  return target.toString();
+}
+
+function apiBase(env: StudioEnv): string {
+  const raw = env.ORACLE_URL ?? env.ORACLE_HTTP_URL ?? env.ORACLE_API;
+  const value = raw?.trim();
+  if (!value) throw new Error('Set ORACLE_URL to the Oracle backend.');
+  const url = new URL(value);
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('ORACLE_URL must be http(s).');
+  }
+  url.username = '';
+  url.password = '';
+  url.search = '';
+  url.hash = '';
+  url.pathname = url.pathname.replace(/\/+$/, '');
+  return url.toString().replace(/\/+$/, '');
+}
+
+function proxyHeaders(source: Headers): Headers {
+  const headers = new Headers(source);
+  headers.delete('host');
+  headers.set('X-Oracle-Studio-Worker', WORKER_HEADER);
+  return headers;
+}
+
+async function serveAsset(request: Request, env: StudioEnv): Promise<Response> {
+  const response = await env.ASSETS.fetch(request);
+  const cache = cacheControl(new URL(request.url).pathname, response.headers.get('content-type'));
+  return withHeaders(response, {
+    ...(cache ? { 'Cache-Control': cache } : {}),
+    'X-Oracle-Studio-Worker': WORKER_HEADER,
+  });
+}
+
+function cacheControl(pathname: string, contentType: string | null): string | undefined {
+  if (pathname.startsWith('/assets/')) return 'public, max-age=31536000, immutable';
+  if (contentType?.includes('text/html') || !pathname.split('/').pop()?.includes('.')) {
+    return 'public, max-age=3600, stale-while-revalidate=86400';
+  }
+  return undefined;
+}
+
+function withHeaders(response: Response, values: Record<string, string>): Response {
+  const headers = new Headers(response.headers);
+  for (const [key, value] of Object.entries(values)) headers.set(key, value);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function apiPreflight(): Response {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Headers': 'authorization, content-type, x-oracle-tenant, x-tenant-id',
+      'Access-Control-Allow-Methods': API_METHODS,
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Expose-Headers': 'x-oracle-studio-worker',
+      'Allow': API_METHODS,
+      'Cache-Control': 'no-store',
+      'X-Oracle-Studio-Worker': WORKER_HEADER,
+    },
+  });
+}
+
+function healthResponse(): Response {
+  return json({ ok: true, app: 'arra-oracle-studio-worker' }, 200);
+}
+
+function json(payload: unknown, status: number): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      'Cache-Control': 'no-store',
+      'Content-Type': 'application/json',
+      'X-Content-Type-Options': 'nosniff',
+      'X-Oracle-Studio-Worker': WORKER_HEADER,
+    },
+  });
+}
+
+function hasBody(method: string): boolean {
+  return !['GET', 'HEAD'].includes(method.toUpperCase());
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}


### PR DESCRIPTION
## Summary

- Add `workers/studio/worker.ts` using the ui-oracle Workers Static Assets pattern.
- Proxy `/api` and `/api/*` requests to `ORACLE_URL` / `ORACLE_HTTP_URL` / `ORACLE_API`.
- Fall back to `env.ASSETS.fetch(request)` for Studio SPA/static routes.
- Add worker-local API preflight, health, SPA cache headers, and immutable Vite asset cache headers.
- Add `tests/workers/studio-worker.test.ts` for proxy/static/cache/preflight behavior.

## Coordination

- Read #2206 and the learn-results comment first.
- #2212 already attempted this slice but is open/conflicting; this PR keeps the clean requested surface to `worker.ts` + scoped test only.
- Does not edit the merged `workers/studio/wrangler.jsonc` config.

## Validation

```bash
bunx tsc --noEmit
bun test tests/workers/studio-worker.test.ts tests/workers/studio-deploy-config.test.ts
wc -l workers/studio/worker.ts tests/workers/studio-worker.test.ts
```

Files are 140 and 104 lines.

Refs #2206
