### PR TITLE
ci: add Studio Worker deploy workflow

### DIFF
--- a/.github/workflows/deploy-studio-worker.yml
+++ b/.github/workflows/deploy-studio-worker.yml
@@ -1,0 +1,79 @@
+name: Deploy Studio Worker
+
+on:
+  push:
+    branches: [alpha]
+    paths:
+      - .github/workflows/deploy-studio-worker.yml
+      - workers/studio/**
+      - frontend/**
+      - tests/workers/studio-*.test.ts
+      - package.json
+      - bun.lock
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: studio-worker-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy Oracle Studio Worker
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: studio-worker
+      url: https://arra-oracle-studio.workers.dev
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bunx tsc --noEmit
+
+      - name: Check Studio worker files
+        id: studio
+        run: |
+          if [ -f workers/studio/wrangler.jsonc ] && [ -f workers/studio/worker.ts ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "workers/studio is not complete on this ref; skipping deploy."
+          fi
+
+      - name: Build frontend
+        if: steps.studio.outputs.ready == 'true'
+        run: cd frontend && bun run build
+
+      - name: Studio worker tests
+        if: steps.studio.outputs.ready == 'true'
+        run: |
+          if ls tests/workers/studio-*.test.ts >/dev/null 2>&1; then
+            bun test tests/workers/studio-*.test.ts
+          else
+            echo "No Studio worker tests found yet."
+          fi
+
+      - name: Deploy Cloudflare Worker
+        if: steps.studio.outputs.ready == 'true'
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy --config workers/studio/wrangler.jsonc

--- a/tests/workers/studio-deploy-workflow.test.ts
+++ b/tests/workers/studio-deploy-workflow.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const workflow = () => readFileSync('.github/workflows/deploy-studio-worker.yml', 'utf8');
+
+describe('Studio Worker deployment workflow', () => {
+  test('deploys Oracle Studio from alpha with Wrangler', () => {
+    const yml = workflow();
+
+    expect(yml).toContain('branches: [alpha]');
+    expect(yml).toContain('cloudflare/wrangler-action@v3');
+    expect(yml).toContain('deploy --config workers/studio/wrangler.jsonc');
+    expect(yml).toContain('CLOUDFLARE_API_TOKEN');
+    expect(yml).toContain('CLOUDFLARE_ACCOUNT_ID');
+    expect(yml).toContain('https://arra-oracle-studio.workers.dev');
+  });
+
+  test('builds the Vite frontend before deploy', () => {
+    const yml = workflow();
+
+    expect(yml).toContain('frontend/**');
+    expect(yml).toContain('workers/studio/**');
+    expect(yml).toContain('cd frontend && bun run build');
+    expect(yml).toContain('tests/workers/studio-*.test.ts');
+  });
+
+  test('waits for the Studio worker implementation without failing alpha', () => {
+    const yml = workflow();
+
+    expect(yml).toContain('id: studio');
+    expect(yml).toContain('ready=true');
+    expect(yml).toContain("if: steps.studio.outputs.ready == 'true'");
+    expect(yml).toContain('workers/studio is not complete on this ref; skipping deploy.');
+  });
+
+  test('keeps Studio on Workers Static Assets, not Cloudflare Pages', () => {
+    const yml = workflow();
+
+    expect(yml).not.toContain('wrangler pages');
+    expect(yml).not.toContain('pages deploy');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions deploy workflow for the Oracle Studio Cloudflare Worker.
- Builds `frontend/` before Wrangler deploy and runs `tests/workers/studio-*.test.ts` when the Worker implementation is present.
- Keeps deploys on Cloudflare Workers (`workers/studio/wrangler.jsonc`), not Pages.
- Adds a regression test locking the workflow shape.

## Notes
- This is a non-overlapping #2206 slice: it does not touch `workers/studio/**`, so it complements the existing Studio Worker implementation PRs.
- The workflow has a readiness guard so it can merge before `workers/studio/worker.ts` lands without failing alpha; once the Worker files are present, the same workflow builds/tests/deploys.

## Validation
```bash
bun test tests/workers/studio-deploy-config.test.ts tests/workers/studio-deploy-workflow.test.ts
bunx tsc --noEmit
git diff --check origin/alpha...HEAD
actionlint .github/workflows/deploy-studio-worker.yml
wc -l .github/workflows/deploy-studio-worker.yml tests/workers/studio-deploy-workflow.test.ts
```

Refs #2206
