### PR TITLE
feat(workers): add Studio static assets worker

### DIFF
--- a/tests/workers/cloudflare-deploy-config.test.ts
+++ b/tests/workers/cloudflare-deploy-config.test.ts
@@ -131,7 +131,8 @@ describe('Cloudflare deploy metadata', () => {
     const cfg = parseJsonc<Record<string, any>>(read('workers/mcp/wrangler.jsonc'));
     const pkg = JSON.parse(read('workers/mcp/package.json')) as Record<string, any>;
 
-    expect(pkg.scripts.deploy).toBe('wrangler deploy');
+    expect(pkg.scripts.deploy).toContain('wrangler deploy');
+    expect(pkg.scripts.deploy).toContain('--config wrangler.jsonc');
     expect(pkg.dependencies).toMatchObject({
       '@modelcontextprotocol/sdk': expect.any(String),
       agents: expect.any(String),

--- a/tests/workers/mcp-deploy-config.test.ts
+++ b/tests/workers/mcp-deploy-config.test.ts
@@ -54,7 +54,9 @@ describe('workers/mcp deploy package', () => {
   test('declares the runtime dependencies needed by wrangler deploy', () => {
     const pkg = readJson('workers/mcp/package.json');
 
-    expect(pkg.scripts).toMatchObject({ deploy: 'wrangler deploy', typecheck: 'tsc --noEmit' });
+    expect(pkg.scripts.typecheck).toBe('tsc --noEmit');
+    expect(pkg.scripts.deploy).toContain('wrangler deploy');
+    expect(pkg.scripts.deploy).toContain('--config wrangler.jsonc');
     expect(pkg.dependencies).toMatchObject({
       '@modelcontextprotocol/sdk': expect.any(String),
       agents: expect.any(String),

--- a/tests/workers/mcp-deploy-ready.test.ts
+++ b/tests/workers/mcp-deploy-ready.test.ts
@@ -40,7 +40,8 @@ describe('workers/mcp deploy readiness', () => {
   test('worker package keeps the dependencies needed by wrangler deploy', () => {
     const pkg = JSON.parse(read('workers/mcp/package.json')) as Record<string, any>;
 
-    expect(pkg.scripts.deploy).toBe('wrangler deploy');
+    expect(pkg.scripts.deploy).toContain('wrangler deploy');
+    expect(pkg.scripts.deploy).toContain('--config wrangler.jsonc');
     expect(pkg.dependencies).toMatchObject({
       '@modelcontextprotocol/sdk': expect.any(String),
       agents: expect.any(String),

--- a/tests/workers/studio-deploy-config.test.ts
+++ b/tests/workers/studio-deploy-config.test.ts
@@ -17,6 +17,7 @@ describe('Studio Worker deploy config', () => {
 
     expect(config.name).toBe('arra-oracle-studio');
     expect(config.main).toBe('worker.ts');
+    expect(config.account_id).toBe('a5eabdc2b11aae9bd5af46bd6a88179e');
     expect(config.assets).toEqual({
       directory: '../../frontend/dist',
       binding: 'ASSETS',

--- a/tests/workers/studio-worker.test.ts
+++ b/tests/workers/studio-worker.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { handleStudioRequest, type StudioWorkerEnv } from '../../workers/studio/worker.ts';
+
+const originalFetch = globalThis.fetch;
+
+function env(overrides: Partial<StudioWorkerEnv> = {}): StudioWorkerEnv {
+  return {
+    ASSETS: {
+      fetch: async (request) => new Response(new URL(request.url).pathname, {
+        headers: { 'content-type': 'text/html' },
+      }),
+    },
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('Studio Cloudflare Worker', () => {
+  test('serves Vite assets through the ASSETS binding with ui-oracle cache headers', async () => {
+    const response = await handleStudioRequest(
+      new Request('https://studio.example.test/assets/app-abcdef123.js'),
+      env({
+        ASSETS: {
+          fetch: async () => new Response('console.log("ok")', { headers: { 'content-type': 'text/javascript' } }),
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-oracle-studio-worker')).toBe('arra-oracle-studio');
+    expect(response.headers.get('cache-control')).toBe('public, max-age=31536000, immutable');
+    expect(await response.text()).toContain('console.log');
+  });
+
+  test('proxies /api requests to ORACLE_URL while preserving method, body, and auth', async () => {
+    const seen: Array<{ url: string; method: string; auth: string | null; body: string }> = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const upstream = new Request(input, init);
+      seen.push({
+        url: String(input),
+        method: upstream.method,
+        auth: upstream.headers.get('authorization'),
+        body: await upstream.text(),
+      });
+      return Response.json({ ok: true }, { status: 201 });
+    }) as typeof fetch;
+
+    const response = await handleStudioRequest(
+      new Request('https://studio.example.test/api/learn?source=studio', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ pattern: 'Workers frontend deploy' }),
+      }),
+      env({ ORACLE_URL: 'https://oracle.example.test/root/', ARRA_API_TOKEN: 'secret' }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(seen).toEqual([{
+      url: 'https://oracle.example.test/root/api/learn?source=studio',
+      method: 'POST',
+      auth: 'Bearer secret',
+      body: '{"pattern":"Workers frontend deploy"}',
+    }]);
+  });
+
+  test('proxies /mcp to the configured remote MCP endpoint', async () => {
+    const seen: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      seen.push(String(input));
+      return new Response('event: message\ndata: {}\n', { headers: { 'content-type': 'text/event-stream' } });
+    }) as typeof fetch;
+
+    const response = await handleStudioRequest(
+      new Request('https://studio.example.test/mcp?session=1', { headers: { accept: 'text/event-stream' } }),
+      env({ ORACLE_MCP_URL: 'https://arra-oracle-mcp.laris.workers.dev/mcp' }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/event-stream');
+    expect(response.headers.get('x-oracle-studio-worker')).toBe('arra-oracle-studio');
+    expect(seen).toEqual(['https://arra-oracle-mcp.laris.workers.dev/mcp?session=1']);
+  });
+
+  test('returns health and config errors without calling upstream services', async () => {
+    globalThis.fetch = (async () => { throw new Error('should not proxy'); }) as typeof fetch;
+
+    const health = await handleStudioRequest(new Request('https://studio.example.test/__health'), env());
+    const missing = await handleStudioRequest(new Request('https://studio.example.test/api/search'), env());
+
+    expect(health.status).toBe(200);
+    expect(await health.json()).toMatchObject({ ok: true, app: 'arra-oracle-studio' });
+    expect(missing.status).toBe(503);
+    expect(await missing.json()).toEqual({ error: 'Set ORACLE_URL to the Arra Oracle backend.' });
+  });
+});

--- a/workers/studio/package.json
+++ b/workers/studio/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@soul-brews/arra-oracle-studio-worker",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "cd ../../frontend && bun run build",
+    "dev": "bunx wrangler dev",
+    "deploy": "bun run build && bunx wrangler deploy",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260616.1",
+    "typescript": "^5.7.2",
+    "wrangler": "^4.101.0"
+  }
+}

--- a/workers/studio/tsconfig.json
+++ b/workers/studio/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "WebWorker"],
+    "strict": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["worker.ts"]
+}

--- a/workers/studio/worker.ts
+++ b/workers/studio/worker.ts
@@ -1,0 +1,132 @@
+export interface StudioAssets {
+  fetch(request: Request): Promise<Response>;
+}
+
+export interface StudioWorkerEnv {
+  ASSETS: StudioAssets;
+  ORACLE_URL?: string;
+  ORACLE_HTTP_URL?: string;
+  ORACLE_API?: string;
+  ORACLE_MCP_URL?: string;
+  ARRA_API_TOKEN?: string;
+  ARRA_API_KEY?: string;
+}
+
+const DEFAULT_MCP_URL = 'https://arra-oracle-mcp.laris.workers.dev/mcp';
+const HASHED_ASSET = /\/(?:assets\/|[^/]+-)[A-Za-z0-9_-]{8,}\.[a-z0-9]+$/i;
+const MARKER = { 'X-Oracle-Studio-Worker': 'arra-oracle-studio' };
+const API_HEADERS = {
+  'Access-Control-Allow-Headers': 'authorization, content-type, x-api-key, x-correlation-id',
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Expose-Headers': 'x-oracle-studio-worker',
+  'Cache-Control': 'no-store',
+  ...MARKER,
+};
+
+function trim(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  const text = String(value).trim();
+  return text || undefined;
+}
+
+function cleanBase(raw: unknown): string | undefined {
+  const value = trim(raw);
+  if (!value) return undefined;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return undefined;
+    url.username = '';
+    url.password = '';
+    url.hash = '';
+    url.search = '';
+    url.pathname = url.pathname.replace(/\/+$/, '');
+    return url.toString().replace(/\/+$/, '');
+  } catch {
+    return undefined;
+  }
+}
+
+function apiBase(env: StudioWorkerEnv): string | undefined {
+  return cleanBase(env.ORACLE_URL ?? env.ORACLE_HTTP_URL ?? env.ORACLE_API);
+}
+
+function mcpBase(env: StudioWorkerEnv): string {
+  return cleanBase(env.ORACLE_MCP_URL) ?? DEFAULT_MCP_URL;
+}
+
+function appendPath(base: string, requestUrl: URL, prefix = ''): string {
+  const path = prefix ? requestUrl.pathname.slice(prefix.length) || '' : requestUrl.pathname;
+  const suffix = path ? (path.startsWith('/') ? path : `/${path}`) : '';
+  return `${base}${suffix}${requestUrl.search}`;
+}
+
+function proxyHeaders(request: Request, env: StudioWorkerEnv): Headers {
+  const headers = new Headers(request.headers);
+  headers.delete('host');
+  headers.set('x-oracle-studio-worker', 'arra-oracle-studio');
+  const token = trim(env.ARRA_API_TOKEN) ?? trim(env.ARRA_API_KEY);
+  if (token && !headers.has('authorization')) headers.set('authorization', `Bearer ${token}`);
+  return headers;
+}
+
+async function proxy(request: Request, env: StudioWorkerEnv, target: string): Promise<Response> {
+  let upstream: Response;
+  try {
+    upstream = await fetch(target, {
+      method: request.method,
+      headers: proxyHeaders(request, env),
+      body: request.method === 'GET' || request.method === 'HEAD' ? undefined : request.body,
+    });
+  } catch {
+    return Response.json({ error: 'upstream proxy failed' }, { status: 502, headers: API_HEADERS });
+  }
+  const headers = new Headers(upstream.headers);
+  for (const [key, value] of Object.entries(API_HEADERS)) headers.set(key, value);
+  return new Response(upstream.body, { status: upstream.status, statusText: upstream.statusText, headers });
+}
+
+function health(env: StudioWorkerEnv): Response {
+  return Response.json({
+    ok: true,
+    app: 'arra-oracle-studio',
+    apiBase: apiBase(env) ?? null,
+    mcpUrl: mcpBase(env),
+  }, { headers: API_HEADERS });
+}
+
+async function assets(request: Request, env: StudioWorkerEnv): Promise<Response> {
+  const response = await env.ASSETS.fetch(request);
+  if (!response.ok) return response;
+  const headers = new Headers(response.headers);
+  const url = new URL(request.url);
+  headers.set('x-oracle-studio-worker', 'arra-oracle-studio');
+  headers.set(
+    'cache-control',
+    HASHED_ASSET.test(url.pathname)
+      ? 'public, max-age=31536000, immutable'
+      : 'public, max-age=3600, stale-while-revalidate=86400',
+  );
+  return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
+}
+
+export async function handleStudioRequest(request: Request, env: StudioWorkerEnv): Promise<Response> {
+  const url = new URL(request.url);
+  if (url.pathname === '/__health' || url.pathname === '/health') return health(env);
+  if (url.pathname === '/api' || url.pathname.startsWith('/api/')) {
+    if (request.method === 'OPTIONS') return new Response(null, { status: 204, headers: API_HEADERS });
+    const base = apiBase(env);
+    if (!base) return Response.json({ error: 'Set ORACLE_URL to the Arra Oracle backend.' }, { status: 503, headers: API_HEADERS });
+    return proxy(request, env, appendPath(base, url));
+  }
+  if (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/')) {
+    if (request.method === 'OPTIONS') return new Response(null, { status: 204, headers: API_HEADERS });
+    return proxy(request, env, appendPath(mcpBase(env), url, '/mcp'));
+  }
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    return new Response('Method not allowed', { status: 405, headers: { Allow: 'GET, HEAD', ...MARKER } });
+  }
+  return assets(request, env);
+}
+
+export default { fetch: handleStudioRequest };

--- a/workers/studio/wrangler.jsonc
+++ b/workers/studio/wrangler.jsonc
@@ -3,6 +3,7 @@
   "name": "arra-oracle-studio",
   "main": "worker.ts",
   "compatibility_date": "2026-06-16",
+  "account_id": "a5eabdc2b11aae9bd5af46bd6a88179e",
   "workers_dev": true,
   "observability": { "enabled": true },
   "assets": {


### PR DESCRIPTION
## Summary
- add `workers/studio/worker.ts` using the ui-oracle Workers Static Assets pattern: `/api/*` proxy, `/mcp` proxy, ASSETS fallback, cache headers, and worker health
- add `workers/studio/package.json` + `tsconfig.json` for local typecheck/build/deploy commands
- set the Studio Worker account id so non-interactive `wrangler deploy` works
- update MCP deploy-readiness assertions to match the latest `--config wrangler.jsonc` scripts on alpha

## Live deploy smoke
```bash
cd frontend && bun run build
cd workers/studio && bunx wrangler deploy
# deployed: https://arra-oracle-studio.laris.workers.dev
```

Smoke checks:
- `GET /` returned `200` and served the React/Vite app shell.
- `GET /__health` returned `{ "ok": true, "app": "arra-oracle-studio" }`.
- Screenshot captured locally with Playwright at `/tmp/arra-oracle-studio-worker.png`; UI code itself was not changed.

## Verification
```bash
bun test tests/workers/                         # 47 pass, 0 fail
bunx tsc --noEmit                               # pass
bunx tsc -p workers/studio/tsconfig.json --noEmit
cd frontend && bun run build
cd workers/studio && bunx wrangler deploy --dry-run
cd workers/studio && bunx wrangler deploy
git diff --check origin/alpha..HEAD
wc -l workers/studio/worker.ts tests/workers/studio-worker.test.ts
```

Refs #2206