### PR TITLE
feat: proxy Studio MCP endpoint

### DIFF
--- a/tests/workers/studio-worker.test.ts
+++ b/tests/workers/studio-worker.test.ts
@@ -65,6 +65,59 @@ describe('Oracle Studio Worker static assets proxy', () => {
     }]);
   });
 
+  test('proxies /mcp requests to ORACLE_MCP_URL and preserves protocol headers', async () => {
+    const seen: Array<{ url: string; method: string; session: string | null; body: string }> = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const upstream = new Request(input, init);
+      seen.push({
+        url: String(input),
+        method: upstream.method,
+        session: upstream.headers.get('mcp-session-id'),
+        body: await upstream.text(),
+      });
+      return new Response('event: message\n\ndata: ok\n', {
+        headers: { 'content-type': 'text/event-stream', 'mcp-session-id': 'upstream-session' },
+      });
+    }) as typeof fetch;
+
+    const response = await handleStudioRequest(new Request('https://studio.example/mcp?trace=1', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'mcp-session-id': 'client-session' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    }), env({ ORACLE_MCP_URL: 'https://mcp.example.test/mcp/' }));
+
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(response.headers.get('mcp-session-id')).toBe('upstream-session');
+    expect(response.headers.get('access-control-expose-headers')).toContain('mcp-session-id');
+    expect(await response.text()).toContain('data: ok');
+    expect(seen).toEqual([{
+      url: 'https://mcp.example.test/mcp?trace=1',
+      method: 'POST',
+      session: 'client-session',
+      body: '{"jsonrpc":"2.0","id":1,"method":"tools/list"}',
+    }]);
+  });
+
+  test('falls back to ORACLE_URL /mcp and handles MCP preflight locally', async () => {
+    const seen: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      seen.push(String(input));
+      return Response.json({ ok: true });
+    }) as typeof fetch;
+
+    const proxied = await handleStudioRequest(new Request('https://studio.example/mcp/sessions/a?probe=1'), env({
+      ORACLE_MCP_URL: undefined,
+      ORACLE_URL: 'https://oracle.example.test/root/',
+    }));
+    const preflight = await handleStudioRequest(new Request('https://studio.example/mcp', { method: 'OPTIONS' }), env());
+
+    expect(seen).toEqual(['https://oracle.example.test/root/mcp/sessions/a?probe=1']);
+    expect(proxied.headers.get('cache-control')).toBe('no-store');
+    expect(preflight.status).toBe(204);
+    expect(preflight.headers.get('access-control-allow-headers')).toContain('mcp-session-id');
+    expect(preflight.headers.get('access-control-allow-methods')).toContain('DELETE');
+  });
+
   test('serves non-api requests through the ASSETS binding with SPA cache headers', async () => {
     const requested: string[] = [];
     const response = await handleStudioRequest(new Request('https://studio.example/dashboard'), env({

--- a/workers/studio/worker.ts
+++ b/workers/studio/worker.ts
@@ -5,10 +5,12 @@ export interface StudioEnv {
   ORACLE_URL?: string;
   ORACLE_HTTP_URL?: string;
   ORACLE_API?: string;
+  ORACLE_MCP_URL?: string;
 }
 
 const WORKER_HEADER = 'oracle-studio-worker';
 const API_METHODS = 'GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS';
+const MCP_METHODS = 'GET, HEAD, POST, DELETE, OPTIONS';
 
 export default {
   fetch: handleStudioRequest,
@@ -21,7 +23,31 @@ export async function handleStudioRequest(request: Request, env: StudioEnv): Pro
     if (request.method === 'OPTIONS') return apiPreflight();
     return proxyApiRequest(request, env);
   }
+  if (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/')) {
+    if (request.method === 'OPTIONS') return mcpPreflight();
+    return proxyMcpRequest(request, env);
+  }
   return serveAsset(request, env);
+}
+
+async function proxyMcpRequest(request: Request, env: StudioEnv): Promise<Response> {
+  try {
+    const target = prefixedTarget(resolveMcpUrl(env), new URL(request.url), '/mcp');
+    const upstream = await fetch(target, {
+      method: request.method,
+      headers: proxyHeaders(request.headers),
+      body: hasRequestBody(request.method) ? request.body : undefined,
+      redirect: 'manual',
+    });
+    return withHeaders(upstream, {
+      'cache-control': 'no-store',
+      'x-oracle-studio-worker': WORKER_HEADER,
+      'access-control-allow-origin': '*',
+      'access-control-expose-headers': 'mcp-session-id, x-oracle-studio-worker',
+    });
+  } catch (error) {
+    return json({ error: 'mcp proxy failed', message: message(error) }, 502);
+  }
 }
 
 async function proxyApiRequest(request: Request, env: StudioEnv): Promise<Response> {
@@ -44,12 +70,15 @@ async function proxyApiRequest(request: Request, env: StudioEnv): Promise<Respon
   }
 }
 
-function resolveOracleUrl(env: StudioEnv): string {
-  const raw = env.ORACLE_URL ?? env.ORACLE_HTTP_URL ?? env.ORACLE_API;
-  const value = raw?.trim();
-  if (!value) throw new Error('Set ORACLE_URL to the Oracle backend.');
+function resolveMcpUrl(env: StudioEnv): string {
+  const direct = env.ORACLE_MCP_URL?.trim();
+  if (direct) return sanitizedHttpUrl(direct, 'ORACLE_MCP_URL');
+  return `${resolveOracleUrl(env)}/mcp`;
+}
+
+function sanitizedHttpUrl(value: string, label: string): string {
   const url = new URL(value);
-  if (!['http:', 'https:'].includes(url.protocol)) throw new Error('ORACLE_URL must be http(s).');
+  if (!['http:', 'https:'].includes(url.protocol)) throw new Error(`${label} must be http(s).`);
   url.username = '';
   url.password = '';
   url.hash = '';
@@ -58,8 +87,23 @@ function resolveOracleUrl(env: StudioEnv): string {
   return url.toString().replace(/\/+$/, '');
 }
 
+function resolveOracleUrl(env: StudioEnv): string {
+  const raw = env.ORACLE_URL ?? env.ORACLE_HTTP_URL ?? env.ORACLE_API;
+  const value = raw?.trim();
+  if (!value) throw new Error('Set ORACLE_URL to the Oracle backend.');
+  return sanitizedHttpUrl(value, 'ORACLE_URL');
+}
+
 function apiTarget(baseUrl: string, requestUrl: URL): string {
-  const target = new URL(`${baseUrl}${requestUrl.pathname}`);
+  return prefixedTarget(baseUrl, requestUrl, '');
+}
+
+function prefixedTarget(baseUrl: string, requestUrl: URL, prefix: string): string {
+  const suffix = prefix ? requestUrl.pathname.slice(prefix.length) : requestUrl.pathname;
+  const target = new URL(baseUrl);
+  const basePath = target.pathname.replace(/\/+$/, '');
+  const cleanSuffix = suffix.replace(/^\/+/, '');
+  target.pathname = cleanSuffix ? `${basePath}/${cleanSuffix}`.replace(/\/+/g, '/') : basePath || '/';
   target.search = requestUrl.search;
   return target.toString();
 }
@@ -93,6 +137,21 @@ function withHeaders(response: Response, values: Record<string, string>): Respon
   const headers = new Headers(response.headers);
   for (const [key, value] of Object.entries(values)) headers.set(key, value);
   return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
+}
+
+function mcpPreflight(): Response {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      allow: MCP_METHODS,
+      'access-control-allow-origin': '*',
+      'access-control-allow-methods': MCP_METHODS,
+      'access-control-allow-headers': 'authorization, content-type, accept, mcp-session-id, mcp-protocol-version',
+      'access-control-expose-headers': 'mcp-session-id, x-oracle-studio-worker',
+      'cache-control': 'no-store',
+      'x-oracle-studio-worker': WORKER_HEADER,
+    },
+  });
 }
 
 function apiPreflight(): Response {


### PR DESCRIPTION
## Summary
- Adds a Studio Worker `/mcp` proxy so the frontend can reach the remote MCP endpoint from the same Workers origin.
- Uses `ORACLE_MCP_URL` when configured, with fallback to `${ORACLE_URL}/mcp`.
- Handles MCP CORS preflight locally and preserves protocol/session headers for Streamable HTTP/SSE clients.
- Merged current `origin/alpha` to resolve the PR conflict without force-pushing.

## Validation
```bash
git diff --check
bunx tsc --noEmit
bunx tsc -p workers/studio/tsconfig.json --noEmit
bun test tests/workers/studio-worker.test.ts tests/workers/studio-deploy-config.test.ts tests/workers/studio-deploy-smoke.test.ts tests/workers/studio-deploy-workflow.test.ts tests/workers/studio-deploy.test.ts tests/workers/studio-frontend-build.test.ts tests/workers/studio-worker-proxy.test.ts
cd frontend && bun run build
cd ../workers/studio && bunx wrangler deploy --dry-run --config wrangler.jsonc
cd ../.. && wc -l workers/studio/worker.ts tests/workers/studio-worker.test.ts tests/workers/studio-worker-proxy.test.ts tests/workers/studio-deploy.test.ts
```

- `bun test`: 27 pass / 0 fail / 105 expects
- `frontend` Vite build: passed
- Wrangler dry-run: passed with `ASSETS`, `ORACLE_URL`, and `ORACLE_MCP_URL`
- File sizes: `workers/studio/worker.ts` 209 lines, `tests/workers/studio-worker.test.ts` 150 lines, `tests/workers/studio-worker-proxy.test.ts` 78 lines, `tests/workers/studio-deploy.test.ts` 100 lines
- GitHub checks: Typecheck and scoped tests ✅, GitGuardian ✅
- PR is mergeable against `alpha`

Refs #2206
