### PR TITLE
feat: add Vercel Studio deploy proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/Soul-Brews-Studio/arra-oracle-v3/actions/workflows/ci.yml/badge.svg)](https://github.com/Soul-Brews-Studio/arra-oracle-v3/actions/workflows/ci.yml) [![License](https://img.shields.io/badge/license-BUSL--1.1-blue)](./LICENSE) [![Bun](https://img.shields.io/badge/runtime-Bun%201.2%2B-f9f1e1)](https://bun.sh)
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/Soul-Brews-Studio/arra-oracle-v3)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/Soul-Brews-Studio/arra-oracle-v3&env=ORACLE_URL&envDescription=Oracle%20HTTP%20backend%20URL&project-name=arra-oracle-studio&repository-name=arra-oracle-studio) — [Vercel quickstart](docs/deploy-vercel.md)
 
 > "The Oracle Keeps the Human Human" — queryable through MCP, HTTP, CLI, and
 > maw-js plugin surfaces.

--- a/api/proxy.ts
+++ b/api/proxy.ts
@@ -1,0 +1,137 @@
+import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from 'node:http';
+
+export type OracleProxyEnv = Record<string, string | undefined> & {
+  ORACLE_URL?: string;
+  ORACLE_HTTP_URL?: string;
+  ORACLE_API?: string;
+}
+
+const PROXY_HEADER = 'oracle-studio-vercel';
+const API_METHODS = 'GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS';
+const HOP_BY_HOP_HEADERS = new Set([
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+  'host',
+]);
+
+export default async function handler(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  if ((req.method ?? 'GET').toUpperCase() === 'OPTIONS') {
+    writePreflight(res);
+    return;
+  }
+
+  try {
+    const target = buildProxyTarget(resolveOracleUrl(), req.url ?? '/');
+    const upstream = await fetch(target, {
+      method: req.method ?? 'GET',
+      headers: proxyRequestHeaders(req.headers),
+      body: hasRequestBody(req.method) ? await readBody(req) : undefined,
+      redirect: 'manual',
+    });
+
+    res.statusCode = upstream.status;
+    res.statusMessage = upstream.statusText;
+    copyResponseHeaders(upstream.headers, res);
+    res.setHeader('cache-control', 'no-store');
+    res.setHeader('x-oracle-studio-vercel', PROXY_HEADER);
+    res.end(Buffer.from(await upstream.arrayBuffer()));
+  } catch (error) {
+    writeJson(res, 502, { error: 'api proxy failed', message: message(error) });
+  }
+}
+
+export function resolveOracleUrl(env: OracleProxyEnv = process.env): string {
+  const raw = env.ORACLE_URL ?? env.ORACLE_HTTP_URL ?? env.ORACLE_API;
+  const value = raw?.trim();
+  if (!value) throw new Error('Set ORACLE_URL to the Oracle backend.');
+
+  const url = new URL(value);
+  if (!['http:', 'https:'].includes(url.protocol)) throw new Error('ORACLE_URL must be http(s).');
+  url.username = '';
+  url.password = '';
+  url.hash = '';
+  url.search = '';
+  url.pathname = url.pathname.replace(/\/+$/, '');
+  return url.toString().replace(/\/+$/, '');
+}
+
+export function buildProxyTarget(baseUrl: string, requestUrl: string): string {
+  const incoming = new URL(requestUrl, 'https://vercel.local');
+  const rewrittenPath = incoming.searchParams.get('path');
+  incoming.searchParams.delete('path');
+
+  const apiPath = rewrittenPath === null ? stripProxyPrefix(incoming.pathname) : cleanPath(rewrittenPath);
+  const target = new URL(`${baseUrl}/api${apiPath ? `/${apiPath}` : ''}`);
+  target.search = incoming.searchParams.toString();
+  return target.toString();
+}
+
+export function proxyRequestHeaders(source: IncomingHttpHeaders): Headers {
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(source)) {
+    const lower = key.toLowerCase();
+    if (HOP_BY_HOP_HEADERS.has(lower) || value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) headers.append(key, item);
+    } else {
+      headers.set(key, value);
+    }
+  }
+  headers.set('x-oracle-studio-vercel', PROXY_HEADER);
+  return headers;
+}
+
+async function readBody(req: IncomingMessage): Promise<Uint8Array | undefined> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  return chunks.length ? Buffer.concat(chunks) : undefined;
+}
+
+function stripProxyPrefix(pathname: string): string {
+  return cleanPath(pathname.replace(/^\/api(?:\/proxy)?\/?/, ''));
+}
+
+function cleanPath(path: string): string {
+  return path.split('/').filter(Boolean).join('/');
+}
+
+function hasRequestBody(method = 'GET'): boolean {
+  return !['GET', 'HEAD'].includes(method.toUpperCase());
+}
+
+function copyResponseHeaders(headers: Headers, res: ServerResponse): void {
+  headers.forEach((value, key) => {
+    if (!HOP_BY_HOP_HEADERS.has(key.toLowerCase())) res.setHeader(key, value);
+  });
+}
+
+function writePreflight(res: ServerResponse): void {
+  res.statusCode = 204;
+  res.setHeader('allow', API_METHODS);
+  res.setHeader('access-control-allow-origin', '*');
+  res.setHeader('access-control-allow-methods', API_METHODS);
+  res.setHeader('access-control-allow-headers', 'authorization, content-type, x-oracle-tenant, x-tenant-id');
+  res.setHeader('access-control-expose-headers', 'x-oracle-studio-vercel');
+  res.setHeader('cache-control', 'no-store');
+  res.setHeader('x-oracle-studio-vercel', PROXY_HEADER);
+  res.end();
+}
+
+function writeJson(res: ServerResponse, status: number, payload: unknown): void {
+  res.statusCode = status;
+  res.setHeader('content-type', 'application/json');
+  res.setHeader('cache-control', 'no-store');
+  res.setHeader('x-content-type-options', 'nosniff');
+  res.setHeader('x-oracle-studio-vercel', PROXY_HEADER);
+  res.end(JSON.stringify(payload));
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/docs/deploy-vercel.md
+++ b/docs/deploy-vercel.md
@@ -1,0 +1,61 @@
+# Deploy Oracle Studio on Vercel
+
+Use this path when you want Vercel to serve the React/Vite Studio while a
+running Oracle HTTP backend handles `/api/*` requests.
+
+## One-click deploy
+
+1. Click **Deploy with Vercel** in the root README.
+2. Set the `ORACLE_URL` environment variable to your Oracle backend, for
+   example `https://oracle.example.com`.
+3. Deploy. Vercel builds `frontend/` and serves `frontend/dist`.
+4. Open the deployment URL and confirm Studio loads.
+5. Test the proxy:
+
+```bash
+curl -sf https://<your-vercel-app>.vercel.app/api/health
+```
+
+## Manual deploy
+
+```bash
+bun install
+cd frontend && bun run build
+cd ..
+vercel deploy --prod
+```
+
+Use the Vercel dashboard or CLI to set the production env var:
+
+```bash
+vercel env add ORACLE_URL production
+```
+
+## Runtime shape
+
+```text
+Vercel static files     frontend/dist
+/api/*                 api/proxy.ts -> ORACLE_URL/api/*
+SPA fallback            /index.html
+```
+
+`vercel.json` keeps the Vite build command, static output directory, immutable
+asset caching, and the `/api/:path*` rewrite to the proxy function.
+
+## Environment variables
+
+| Name | Required | Description |
+| --- | --- | --- |
+| `ORACLE_URL` | yes | Public or private Oracle HTTP API base URL. |
+| `ORACLE_HTTP_URL` | fallback | Backward-compatible alias for `ORACLE_URL`. |
+| `ORACLE_API` | fallback | Legacy alias for `ORACLE_URL`. |
+
+Do not commit tokens or tenant secrets to `vercel.json`; configure them in
+Vercel project environment variables.
+
+## Notes
+
+- The proxy strips hop-by-hop headers and overwrites the Host header.
+- `OPTIONS /api/*` stays local for browser preflight.
+- The proxy adds `x-oracle-studio-vercel` and `cache-control: no-store`.
+- Phase 2 can add an MCP-specific function if `/mcp` needs separate handling.

--- a/tests/workers/vercel-deploy-config.test.ts
+++ b/tests/workers/vercel-deploy-config.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import handler, { buildProxyTarget, proxyRequestHeaders, resolveOracleUrl } from '../../api/proxy.ts';
+
+const REPO_URL = 'https://github.com/Soul-Brews-Studio/arra-oracle-v3';
+const BUTTON = '[![Deploy with Vercel](https://vercel.com/button)]';
+const originalFetch = globalThis.fetch;
+const originalOracleUrl = process.env.ORACLE_URL;
+
+type VercelConfig = {
+  buildCommand: string;
+  outputDirectory: string;
+  rewrites: Array<{ source: string; destination: string }>;
+  headers: Array<{ source: string; headers: Array<{ key: string; value: string }> }>;
+};
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalOracleUrl === undefined) delete process.env.ORACLE_URL;
+  else process.env.ORACLE_URL = originalOracleUrl;
+});
+
+function read(path: string): string {
+  return readFileSync(path, 'utf8');
+}
+
+function readJson<T>(path: string): T {
+  return JSON.parse(read(path)) as T;
+}
+
+async function withProxyServer<T>(run: (base: string) => Promise<T>): Promise<T> {
+  const server = createServer((req, res) => void handler(req, res));
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('server did not bind');
+  try {
+    return await run(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+  }
+}
+
+describe('Vercel Studio deploy config', () => {
+  test('builds the frontend and rewrites API traffic through api/proxy.ts', () => {
+    const cfg = readJson<VercelConfig>('vercel.json');
+
+    expect(cfg.buildCommand).toBe('cd frontend && bun run build');
+    expect(cfg.outputDirectory).toBe('frontend/dist');
+    expect(cfg.rewrites).toContainEqual({ source: '/api/:path*', destination: '/api/proxy?path=:path*' });
+    expect(cfg.rewrites.at(-1)).toEqual({ source: '/(.*)', destination: '/index.html' });
+    expect(cfg.headers).toContainEqual({
+      source: '/api/(.*)',
+      headers: [{ key: 'Cache-Control', value: 'no-store' }],
+    });
+  });
+
+  test('README exposes a Vercel deploy button wired to ORACLE_URL', () => {
+    const readme = read('README.md');
+    const match = readme.match(/\[!\[Deploy with Vercel\]\(https:\/\/vercel\.com\/button\)\]\(([^)]+)\)/);
+
+    expect(match?.[0]).toStartWith(BUTTON);
+    const target = new URL(match?.[1] ?? '');
+    expect(target.origin).toBe('https://vercel.com');
+    expect(target.pathname).toBe('/new/clone');
+    expect(target.searchParams.get('repository-url')).toBe(REPO_URL);
+    expect(target.searchParams.get('env')).toBe('ORACLE_URL');
+    expect(readme).toContain('docs/deploy-vercel.md');
+  });
+
+  test('proxy helpers normalize backend URLs, paths, queries, and headers', () => {
+    const base = resolveOracleUrl({ ORACLE_URL: 'https://user:pass@oracle.example/root/?debug=1#x' });
+    const target = buildProxyTarget(base, '/api/proxy?path=vector/config&limit=3');
+    const headers = proxyRequestHeaders({ host: 'spoofed.example', authorization: 'Bearer token', connection: 'keep-alive' });
+
+    expect(base).toBe('https://oracle.example/root');
+    expect(target).toBe('https://oracle.example/root/api/vector/config?limit=3');
+    expect(headers.get('authorization')).toBe('Bearer token');
+    expect(headers.get('host')).toBeNull();
+    expect(headers.get('connection')).toBeNull();
+    expect(headers.get('x-oracle-studio-vercel')).toBe('oracle-studio-vercel');
+  });
+
+  test('serverless handler proxies method, query, headers, and body', async () => {
+    process.env.ORACLE_URL = 'https://oracle.example/root';
+    const seen: Array<{ url: string; method: string; marker: string | null; body: string }> = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init);
+      seen.push({
+        url: String(input),
+        method: request.method,
+        marker: request.headers.get('x-oracle-studio-vercel'),
+        body: await request.text(),
+      });
+      return new Response('proxied', { status: 202, headers: { 'content-type': 'text/plain' } });
+    }) as typeof fetch;
+
+    await withProxyServer(async (base) => {
+      const response = await originalFetch(`${base}/api/proxy?path=search&q=vector`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{"limit":1}',
+      });
+
+      expect(response.status).toBe(202);
+      expect(response.headers.get('cache-control')).toBe('no-store');
+      expect(response.headers.get('x-oracle-studio-vercel')).toBe('oracle-studio-vercel');
+      expect(await response.text()).toBe('proxied');
+    });
+
+    expect(seen).toEqual([{ url: 'https://oracle.example/root/api/search?q=vector', method: 'POST', marker: 'oracle-studio-vercel', body: '{"limit":1}' }]);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,8 @@
     }
   },
   "include": [
-    "src/**/*"
+    "src/**/*",
+    "api/**/*"
   ],
   "exclude": [
     "node_modules",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "buildCommand": "cd frontend && bun run build",
+  "outputDirectory": "frontend/dist",
+  "rewrites": [
+    {
+      "source": "/api/:path*",
+      "destination": "/api/proxy?path=:path*"
+    },
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/api/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `vercel.json` for Vite Studio static builds from `frontend/` with SPA fallback.
- Add `api/proxy.ts` serverless function for `/api/* -> ORACLE_URL/api/*` with preflight handling, hop-by-hop header stripping, and no-store proxy responses.
- Add README one-click Vercel button plus `docs/deploy-vercel.md` quickstart.
- Add focused deploy/proxy coverage for Vercel config and the serverless handler.

## Validation

```bash
bunx tsc --noEmit
bun test tests/workers/vercel-deploy-config.test.ts tests/workers/studio-deploy-config.test.ts tests/workers/studio-worker.test.ts
cd frontend && bun run build
wc -l README.md tsconfig.json api/proxy.ts vercel.json docs/deploy-vercel.md tests/workers/vercel-deploy-config.test.ts
```

## Notes

- Real Vercel production deploy was not run from this worktree because it requires a Vercel project/token, but the local build and proxy handler path are covered.

Closes #2214
