### PR TITLE
feat(plugins): reload unified MCP tools at runtime

### DIFF
--- a/docs/PLUGIN-GUIDE.md
+++ b/docs/PLUGIN-GUIDE.md
@@ -145,6 +145,20 @@ bunx tsc --noEmit
 For fixture-driven tests, call `loadUnifiedPlugins({ dirs: [fixtureDir] })` so a
 user's local plugins do not affect the result.
 
+## MCP tool in/out during development
+
+Unified plugin MCP tools can be added or removed without editing core code. The
+runtime keeps a mutable MCP registry:
+
+```ts
+const runtime = await loadUnifiedPlugins({ dirs: ['~/.oracle/plugins'] });
+await runtime.reload(); // re-scan plugin.json files and update mcpTools in place
+```
+
+After reload, MCP `tools/list`, `/api/mcp/tools`, and `callMcpTool()` see the
+new tool set. API route surfaces still require remounting or restarting the HTTP
+app because Elysia routes are bound when the app is composed.
+
 ## Good plugin README
 
 Include:

--- a/docs/UNIFIED-PLUGIN.md
+++ b/docs/UNIFIED-PLUGIN.md
@@ -6,8 +6,8 @@ plugin contributes while preserving the current ServerPlugin, Installed/Wasm,
 CanvasPlugin, and CLI plugin surfaces.
 
 This started as a design-first slice: schema, migration map, reference manifest,
-and validation tests. Alpha now includes the first runtime loader bridge; MCP and
-CLI execution remain follow-up work.
+and validation tests. Alpha now includes the runtime loader bridge for plugin
+API, proxy, menu, server, MCP tool, export, and CLI metadata surfaces.
 
 ## Manifest shape
 
@@ -63,22 +63,17 @@ loads normalized manifests at boot, then registers whichever surfaces are presen
   `ARRA_PLUGIN_PORT`, must pass `healthPath` (default `/health`), and are proxied
   behind `/api/plugins/<name>/server/*`.
 - `menu[]` entries are seeded into `menu_items` as plugin-owned rows.
-- `mcpTools[]` and `cliSubcommands[]` are collected as registry metadata for the
-  MCP/CLI loaders to consume in follow-up slices.
+- `mcpTools[]` are advertised by `/api/mcp/tools`, appended to MCP stdio
+  `tools/list`, and dispatched through `UnifiedRuntime.callMcpTool()`.
+- `cliSubcommands[]` are collected as registry metadata for the CLI loader.
 
 Missing surfaces are skipped. Invalid or failing plugin manifests are warned and
 ignored so one plugin cannot prevent the server from booting.
 
-## MCP tool registration gap
+## MCP tool runtime
 
-This is the largest missing capability. Today MCP tools are static:
-
-1. definitions are imported from `src/tools/*`;
-2. `src/index.ts` lists them in `ListToolsRequestSchema`;
-3. calls are routed by a `switch (toolName)`;
-4. `src/config/tool-groups.ts` only knows static names in `TOOL_GROUPS`.
-
-A plugin MCP tool needs a dynamic registry before it can be advertised or called:
+Plugin MCP tools use the normalized manifest as their definition and the named
+entry export as their handler:
 
 ```ts
 type RegisteredMcpTool = {
@@ -93,18 +88,28 @@ type RegisteredMcpTool = {
 };
 ```
 
-Recommended runtime flow:
+Runtime flow:
 
-1. load and normalize all unified manifests;
-2. for each `mcpTools[]` item, import `entry` and bind `handler`;
-3. append registered tool definitions to `ListToolsRequestSchema` output;
-4. before the static `switch`, dispatch `toolName` to the dynamic registry;
-5. extend tool toggles so plugin tools are known names, not ignored typos.
+1. `loadUnifiedPlugins()` discovers and normalizes plugin manifests.
+2. For each `mcpTools[]` item, the runtime records public metadata and a
+   `(plugin, handler)` invoker.
+3. HTTP browsers see core + plugin tools at `GET /api/mcp/tools`.
+4. MCP stdio builds a fresh registry for each list/call, so plugin tools can be
+   advertised, called, disabled, or removed without editing core tool code.
+5. `runtime.reload()` re-scans plugin dirs in place; callers that hold the
+   runtime object see added/removed MCP tools on the next list/call.
+
+`runtime.reload()` mutates the existing `mcpTools` array, plugin registry, and
+invoker map. API route additions still need the HTTP app to remount routes; use
+reload for MCP tool in/out and restart/remount for newly added route surfaces.
 
 ### Toggle integration (#1372)
 
-`getDisabledTools()` currently rejects names not present in its static
-`ALL_TOOL_NAMES`. Plugin tools need an additional known-tool set:
+Static tool toggles remain backed by `TOOL_GROUPS`. Plugin tools are filtered at
+MCP registry time by their own `enabledByDefault` flag and by explicit
+`disabled_tools` / `enabled_tools` entries when the runtime tool name is present.
+Future strict allow-list work can pass plugin names as an additional known-tool
+set:
 
 ```ts
 getDisabledTools(config, { extraToolNames: registry.toolNames() })
@@ -136,7 +141,6 @@ because no static tool names change.
 
 ## Non-goals for this PR
 
-- No dynamic MCP execution yet.
 - No restart/backoff supervisor for plugin-owned servers yet.
 - No npm package extraction.
 - No subdomain deploy work.

--- a/src/plugins/unified-loader.ts
+++ b/src/plugins/unified-loader.ts
@@ -42,6 +42,7 @@ export interface UnifiedRuntime {
   pluginStatuses: () => UnifiedPluginStatus[];
   pluginRegistry: () => LoadedPluginRegistryEntry[];
   init: () => Promise<void>;
+  reload: () => Promise<void>;
   stop: () => Promise<void>;
 }
 
@@ -134,7 +135,9 @@ function apiRoute(plugin: LoadedUnifiedPlugin, route: UnifiedApiRouteManifest, t
   return app;
 }
 
-function runtimeFrom(plugins: LoadedUnifiedPlugin[], options: UnifiedLoaderOptions): UnifiedRuntime {
+function replaceAll<T>(target: T[], next: T[]): void { target.splice(0, target.length, ...next); }
+
+function runtimeFrom(initialPlugins: LoadedUnifiedPlugin[], options: UnifiedLoaderOptions): UnifiedRuntime {
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const routes: ElysiaApp[] = [];
   const mcpTools: UnifiedRuntime['mcpTools'] = [];
@@ -144,29 +147,8 @@ function runtimeFrom(plugins: LoadedUnifiedPlugin[], options: UnifiedLoaderOptio
   const mcpInvokers = new Map<string, { plugin: LoadedUnifiedPlugin; tool: UnifiedMcpToolManifest }>();
   const initialized = new Set<string>();
   const pluginStatus = new Map<string, UnifiedPluginStatus>();
-
-  for (const plugin of plugins) {
-    pluginStatus.set(plugin.manifest.name, { name: plugin.manifest.name, status: 'ok' });
-    for (const tool of plugin.manifest.mcpTools) {
-      mcpTools.push({ ...tool, plugin: plugin.manifest.name });
-      mcpInvokers.set(tool.name, { plugin, tool });
-    }
-    for (const route of plugin.manifest.apiRoutes) routes.push(apiRoute(plugin, route, timeoutMs));
-    for (const proxy of plugin.manifest.proxy) routes.push(createUnifiedProxyRoute(plugin.manifest.name, proxy));
-    if (plugin.manifest.server) {
-      servers.push({
-        ...plugin.manifest.server,
-        plugin: plugin.manifest.name,
-        dir: plugin.dir,
-        routePrefix: `/api/plugins/${plugin.manifest.name}/server`,
-      });
-    }
-    for (const item of plugin.manifest.menu) menu.push({ ...item, plugin: plugin.manifest.name });
-    for (const command of plugin.manifest.cliSubcommands) {
-      cliSubcommands.push({ ...command, plugin: plugin.manifest.name });
-    }
-  }
-  if (servers.length) routes.push(unifiedPluginServerRoutes(servers));
+  let plugins: LoadedUnifiedPlugin[] = [];
+  let initRan = false;
 
   const callMcpTool = async (name: string, args?: unknown): Promise<unknown> => {
     const hit = mcpInvokers.get(name);
@@ -196,6 +178,7 @@ function runtimeFrom(plugins: LoadedUnifiedPlugin[], options: UnifiedLoaderOptio
       if (!plugin.manifest.lifecycle?.init || initialized.has(plugin.manifest.name)) continue;
       await invokeLifecycle('init', plugin);
     }
+    initRan = true;
   };
   const stop = async () => {
     for (const plugin of [...plugins].reverse()) {
@@ -204,11 +187,35 @@ function runtimeFrom(plugins: LoadedUnifiedPlugin[], options: UnifiedLoaderOptio
       await invokeLifecycle('destroy', plugin);
     }
     initialized.clear();
+    initRan = false;
   };
   const pluginStatuses = () => plugins.map((plugin) => pluginStatus.get(plugin.manifest.name)
     ?? { name: plugin.manifest.name, status: 'ok' as const });
   const pluginRegistry = () => pluginRegistryFromLoadedPlugins(plugins, pluginStatuses());
-  return { pluginCount: plugins.length, routes, mcpTools, menu, cliSubcommands, servers, callMcpTool, pluginStatuses, pluginRegistry, init, stop };
+  const rebuild = (next: LoadedUnifiedPlugin[]) => {
+    plugins = next; mcpInvokers.clear(); pluginStatus.clear(); initialized.clear();
+    replaceAll(routes, []); replaceAll(mcpTools, []); replaceAll(menu, []); replaceAll(cliSubcommands, []); replaceAll(servers, []);
+    for (const plugin of plugins) {
+      pluginStatus.set(plugin.manifest.name, { name: plugin.manifest.name, status: 'ok' });
+      for (const tool of plugin.manifest.mcpTools) { mcpTools.push({ ...tool, plugin: plugin.manifest.name }); mcpInvokers.set(tool.name, { plugin, tool }); }
+      for (const route of plugin.manifest.apiRoutes) routes.push(apiRoute(plugin, route, timeoutMs));
+      for (const proxy of plugin.manifest.proxy) routes.push(createUnifiedProxyRoute(plugin.manifest.name, proxy));
+      if (plugin.manifest.server) servers.push({ ...plugin.manifest.server, plugin: plugin.manifest.name, dir: plugin.dir, routePrefix: `/api/plugins/${plugin.manifest.name}/server` });
+      for (const item of plugin.manifest.menu) menu.push({ ...item, plugin: plugin.manifest.name });
+      for (const command of plugin.manifest.cliSubcommands) cliSubcommands.push({ ...command, plugin: plugin.manifest.name });
+    }
+    if (servers.length) routes.push(unifiedPluginServerRoutes(servers));
+    runtime.pluginCount = plugins.length;
+  };
+  const reload = async () => {
+    const shouldInit = initRan;
+    if (shouldInit) await stop();
+    rebuild(sortPluginsByDependencies(await discoverUnifiedPluginManifests(options), { warn: options.warn }));
+    if (shouldInit) await init();
+  };
+  const runtime: UnifiedRuntime = { pluginCount: 0, routes, mcpTools, menu, cliSubcommands, servers, callMcpTool, pluginStatuses, pluginRegistry, init, reload, stop };
+  rebuild(initialPlugins);
+  return runtime;
 }
 
 export async function loadUnifiedPlugins(options: UnifiedLoaderOptions = {}): Promise<UnifiedRuntime> {

--- a/tests/plugins/unified-loader-reloads-mcp-tools.test.ts
+++ b/tests/plugins/unified-loader-reloads-mcp-tools.test.ts
@@ -1,0 +1,51 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadUnifiedPlugins } from '../../src/plugins/unified-loader.ts';
+import { pluginDir } from './_fixtures.ts';
+
+const tmp = mkdtempSync(join(tmpdir(), 'arra-unified-mcp-reload-'));
+afterAll(() => rmSync(tmp, { recursive: true, force: true }));
+
+function toolNames(runtime: Awaited<ReturnType<typeof loadUnifiedPlugins>>): string[] {
+  return runtime.mcpTools.map((tool) => tool.name).sort();
+}
+
+describe('UnifiedRuntime.reload MCP tools', () => {
+  test('adds and removes plugin MCP tools without recreating the runtime', async () => {
+    const alphaDir = pluginDir(tmp, 'alpha-pack', {
+      mcpTools: [{ name: 'oracle_alpha_runtime', description: 'Alpha runtime tool', inputSchema: {}, handler: 'tool' }],
+    }, "export function tool(ctx) { return { ok: true, body: { plugin: ctx.plugin, args: ctx.body } }; }\n");
+    const runtime = await loadUnifiedPlugins({ dirs: [tmp] });
+
+    expect(runtime.pluginCount).toBe(1);
+    expect(toolNames(runtime)).toEqual(['oracle_alpha_runtime']);
+    expect(await runtime.callMcpTool('oracle_alpha_runtime', { q: 'first' })).toEqual({
+      ok: true,
+      body: { plugin: 'alpha-pack', args: { q: 'first' } },
+    });
+
+    pluginDir(tmp, 'beta-pack', {
+      mcpTools: [{ name: 'oracle_beta_runtime', description: 'Beta runtime tool', inputSchema: {}, handler: 'tool' }],
+    }, "export function tool(ctx) { return { ok: true, body: { plugin: ctx.plugin, args: ctx.body } }; }\n");
+    await runtime.reload();
+
+    expect(runtime.pluginCount).toBe(2);
+    expect(toolNames(runtime)).toEqual(['oracle_alpha_runtime', 'oracle_beta_runtime']);
+    expect(await runtime.callMcpTool('oracle_beta_runtime', { q: 'added' })).toEqual({
+      ok: true,
+      body: { plugin: 'beta-pack', args: { q: 'added' } },
+    });
+
+    rmSync(alphaDir, { recursive: true, force: true });
+    await runtime.reload();
+
+    expect(runtime.pluginCount).toBe(1);
+    expect(toolNames(runtime)).toEqual(['oracle_beta_runtime']);
+    expect(await runtime.callMcpTool('oracle_alpha_runtime', {})).toEqual({
+      ok: false,
+      error: 'MCP tool not found: oracle_alpha_runtime',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `UnifiedRuntime.reload()` so a running unified-loader runtime re-scans plugin dirs and mutates the existing MCP tool registry/invoker map in place.
- Add regression coverage proving plugin MCP tools can be added and removed after `loadUnifiedPlugins()` without recreating the runtime object.
- Update unified plugin docs and plugin authoring docs to close the stale MCP tool registration gap.

## Validation
```bash
bun test tests/plugins/unified-loader-reloads-mcp-tools.test.ts tests/plugins/unified-loader-call-mcp-tool.test.ts src/mcp/__tests__/plugin-tools.test.ts tests/http/mcp/tools.test.ts
bunx tsc --noEmit
git diff --check origin/alpha...HEAD
wc -l src/plugins/unified-loader.ts tests/plugins/unified-loader-reloads-mcp-tools.test.ts docs/UNIFIED-PLUGIN.md docs/PLUGIN-GUIDE.md
```

Also ran broader plugin/MCP coverage before the final alpha merge:

```bash
bun test tests/plugins/ tests/mcp/ src/mcp/__tests__/ tests/http/mcp/
```

## File sizes
```text
235 src/plugins/unified-loader.ts
51  tests/plugins/unified-loader-reloads-mcp-tools.test.ts
146 docs/UNIFIED-PLUGIN.md
171 docs/PLUGIN-GUIDE.md
```

No UI changes; no screenshot required.
