### PR TITLE
docs: harden Vercel Studio deploy guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/Soul-Brews-Studio/arra-oracle-v3/actions/workflows/ci.yml/badge.svg)](https://github.com/Soul-Brews-Studio/arra-oracle-v3/actions/workflows/ci.yml) [![License](https://img.shields.io/badge/license-BUSL--1.1-blue)](./LICENSE) [![Bun](https://img.shields.io/badge/runtime-Bun%201.2%2B-f9f1e1)](https://bun.sh)
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/Soul-Brews-Studio/arra-oracle-v3)
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/Soul-Brews-Studio/arra-oracle-v3&env=ORACLE_URL&envDescription=Oracle%20HTTP%20backend%20URL&project-name=arra-oracle-studio&repository-name=arra-oracle-studio) — [Vercel quickstart](docs/deploy-vercel.md)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FSoul-Brews-Studio%2Farra-oracle-v3&env=ORACLE_URL&envDescription=Oracle%20HTTP%20API%20base%20URL%20for%20the%20Studio%20API%20proxy&envLink=https%3A%2F%2Fgithub.com%2FSoul-Brews-Studio%2Farra-oracle-v3%2Fblob%2Falpha%2Fdocs%2Fdeploy-vercel.md%23environment-variables&project-name=arra-oracle-studio&repository-name=arra-oracle-studio) — [Vercel quickstart](docs/deploy-vercel.md)
 
 > "The Oracle Keeps the Human Human" — queryable through MCP, HTTP, CLI, and
 > maw-js plugin surfaces.

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ is linked here; keep new docs in the right section when adding files.
 | [BINS.md](./BINS.md) | Published command binaries and aliases. |
 | [DEPLOY-DIGITALOCEAN.md](./DEPLOY-DIGITALOCEAN.md) | Small public Arra HTTP node on DigitalOcean. |
 | [deploy-cloudflare-mcp.md](./deploy-cloudflare-mcp.md) | One-click Cloudflare Workers remote MCP deploy and Claude `/mcp` setup. |
+| [deploy-vercel.md](./deploy-vercel.md) | One-click Vercel deploy for the Oracle Studio frontend and `/api/*` proxy. |
 | [DOCKER-MCP-TOOLKIT.md](./DOCKER-MCP-TOOLKIT.md) | Docker MCP Toolkit package and profile setup. |
 | [LOCAL-DEV.md](./LOCAL-DEV.md) | Local development setup and repo workflow. |
 | [ONBOARDING.md](./ONBOARDING.md) | Progressive onboarding UI and first-use flow. |

--- a/docs/deploy-vercel.md
+++ b/docs/deploy-vercel.md
@@ -1,14 +1,19 @@
 # Deploy Oracle Studio on Vercel
 
 Use this path when you want Vercel to serve the React/Vite Studio while a
-running Oracle HTTP backend handles `/api/*` requests.
+running Oracle HTTP backend handles `/api/*` requests. The repository keeps the
+make-it-work-first Vercel config in `vercel.json` and the proxy function in
+`api/proxy.ts`.
 
 ## One-click deploy
 
-1. Click **Deploy with Vercel** in the root README.
-2. Set the `ORACLE_URL` environment variable to your Oracle backend, for
-   example `https://oracle.example.com`.
-3. Deploy. Vercel builds `frontend/` and serves `frontend/dist`.
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FSoul-Brews-Studio%2Farra-oracle-v3&env=ORACLE_URL&envDescription=Oracle%20HTTP%20API%20base%20URL%20for%20the%20Studio%20API%20proxy&envLink=https%3A%2F%2Fgithub.com%2FSoul-Brews-Studio%2Farra-oracle-v3%2Fblob%2Falpha%2Fdocs%2Fdeploy-vercel.md%23environment-variables&project-name=arra-oracle-studio&repository-name=arra-oracle-studio)
+
+1. Click **Deploy with Vercel** in the root README or this guide.
+2. Set `ORACLE_URL` to the Oracle backend, for example
+   `https://oracle.example.com`.
+3. Deploy. Vercel runs `cd frontend && bun run build` and serves
+   `frontend/dist`.
 4. Open the deployment URL and confirm Studio loads.
 5. Test the proxy:
 
@@ -31,16 +36,21 @@ Use the Vercel dashboard or CLI to set the production env var:
 vercel env add ORACLE_URL production
 ```
 
-## Runtime shape
+## Project settings
 
-```text
-Vercel static files     frontend/dist
-/api/*                 api/proxy.ts -> ORACLE_URL/api/*
-SPA fallback            /index.html
+`vercel.json` owns the Vite build, static output directory, SPA fallback, and
+`/api/:path*` rewrite:
+
+```json
+{
+  "framework": "vite",
+  "buildCommand": "cd frontend && bun run build",
+  "outputDirectory": "frontend/dist"
+}
 ```
 
-`vercel.json` keeps the Vite build command, static output directory, immutable
-asset caching, and the `/api/:path*` rewrite to the proxy function.
+Vercel's deploy button flow reads this repo config after cloning. If you test a
+branch without `vercel.json`, set equivalent values in Project Settings.
 
 ## Environment variables
 
@@ -53,9 +63,53 @@ asset caching, and the `/api/:path*` rewrite to the proxy function.
 Do not commit tokens or tenant secrets to `vercel.json`; configure them in
 Vercel project environment variables.
 
+## Runtime shape
+
+```text
+Vercel static files     frontend/dist
+/api/*                 api/proxy.ts -> ORACLE_URL/api/*
+SPA fallback            /index.html
+```
+
+## Local smoke check
+
+Before deploying a branch preview, run:
+
+```bash
+bun install
+bunx tsc --noEmit
+cd frontend
+bun install
+bun run build
+```
+
+Then confirm the backend is reachable from the public internet:
+
+```bash
+curl -sf "$ORACLE_URL/api/health"
+```
+
+## Troubleshooting
+
+- **Build cannot find `dist`:** verify the build command runs from the repo root
+  and the output directory is `frontend/dist`.
+- **Studio loads but API calls fail:** set `ORACLE_URL` to the backend origin,
+  not to a path under `/api`.
+- **CORS errors:** allow the Vercel preview/production origin in the backend or
+  route calls through the Vercel proxy.
+- **404 on deep links:** confirm the SPA fallback rewrite to `/index.html` is
+  present.
+
 ## Notes
 
 - The proxy strips hop-by-hop headers and overwrites the Host header.
 - `OPTIONS /api/*` stays local for browser preflight.
 - The proxy adds `x-oracle-studio-vercel` and `cache-control: no-store`.
 - Phase 2 can add an MCP-specific function if `/mcp` needs separate handling.
+
+## References
+
+- Vercel Deploy Button: https://vercel.com/docs/deploy-button
+- Deploy Button source parameters: https://vercel.com/docs/deploy-button/source
+- Deploy Button environment variables: https://vercel.com/docs/deploy-button/environment-variables
+- Vite on Vercel: https://vercel.com/docs/frameworks/frontend/vite

--- a/tests/docs/vercel-deploy-docs.test.ts
+++ b/tests/docs/vercel-deploy-docs.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const repo = 'https://github.com/Soul-Brews-Studio/arra-oracle-v3';
+const buttonImage = 'https://vercel.com/button';
+const buttonBase = 'https://vercel.com/new/clone';
+
+function read(path: string): string {
+  return readFileSync(path, 'utf8');
+}
+
+function extractVercelButton(markdown: string): URL {
+  const match = markdown.match(/\[!\[Deploy with Vercel\]\(https:\/\/vercel\.com\/button\)\]\(([^)]+)\)/);
+  expect(match).not.toBeNull();
+  return new URL(match![1]);
+}
+
+describe('Vercel deploy docs', () => {
+  test('README exposes one Deploy with Vercel button', () => {
+    const readme = read('README.md');
+    const matches = readme.match(/\[!\[Deploy with Vercel\]\([^)]+\)\]\([^)]+\)/g) ?? [];
+    expect(matches).toHaveLength(1);
+
+    const url = extractVercelButton(readme);
+    expect(url.origin + url.pathname).toBe(buttonBase);
+    expect(url.searchParams.get('repository-url')).toBe(repo);
+    expect(url.searchParams.get('project-name')).toBe('arra-oracle-studio');
+    expect(url.searchParams.get('repository-name')).toBe('arra-oracle-studio');
+    expect(url.searchParams.get('env')).toBe('ORACLE_URL');
+    expect(readme).toContain(`[![Deploy with Vercel](${buttonImage})]`);
+    expect(readme).toContain('docs/deploy-vercel.md');
+  });
+
+  test('deploy guide documents Vercel config and env handoff', () => {
+    const guide = read('docs/deploy-vercel.md');
+
+    expect(guide).toContain('# Deploy Oracle Studio on Vercel');
+    expect(guide).toContain('`ORACLE_URL`');
+    expect(guide).toContain('cd frontend && bun run build');
+    expect(guide).toContain('frontend/dist');
+    expect(guide).toContain('`/api/:path*` rewrite');
+    expect(guide).toContain('https://vercel.com/docs/deploy-button');
+  });
+
+  test('docs index links the Vercel deploy guide', () => {
+    const index = read('docs/README.md');
+
+    expect(index).toContain('[deploy-vercel.md](./deploy-vercel.md)');
+  });
+});


### PR DESCRIPTION
## Summary
- Updates the README Vercel deploy button with a docs-backed `envLink` and clearer `ORACLE_URL` description.
- Expands `docs/deploy-vercel.md` with one-click deploy, project settings, local smoke checks, troubleshooting, and Vercel references.
- Adds the Vercel deploy guide to `docs/README.md` navigation.
- Adds focused docs tests for the README button, Vercel guide, and docs index.

## Coordination
- Rebased after #2229 landed on `alpha`.
- Did not touch `vercel.json` or `api/proxy.ts`; this is the docs/button hardening slice only.

## Validation
```bash
bun test tests/docs/vercel-deploy-docs.test.ts tests/workers/vercel-deploy-config.test.ts
bunx tsc --noEmit
git diff --check origin/alpha...HEAD
wc -l README.md docs/README.md docs/deploy-vercel.md tests/docs/vercel-deploy-docs.test.ts tests/workers/vercel-deploy-config.test.ts api/proxy.ts vercel.json
```

Refs #2214
