### PR TITLE
feat: expose standalone vector proxy server

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "dev": "bun src/index.ts",
     "server": "bun src/server.ts",
     "vector": "ORACLE_VECTOR_READONLY=1 bun src/vector-server.ts",
+    "vector:proxy": "ORACLE_VECTOR_DB=lancedb bun src/vector-server.ts",
     "vector:dev": "ORACLE_VECTOR_READONLY=1 bun --watch src/vector-server.ts",
     "server:ensure": "bun src/ensure-server.ts",
     "server:status": "bun src/ensure-server.ts --status",

--- a/src/vector-server.ts
+++ b/src/vector-server.ts
@@ -18,6 +18,7 @@ import { createCorsMiddleware } from './middleware/cors.ts';
 import { loadVectorConfig, generateDefaultConfig } from './vector/config.ts';
 import { warmEmbeddingProviderDetection } from './vector/provider-detection.ts';
 import { vectorRoutes } from './routes/vector/index.ts';
+import { createVectorProxyServer } from './vector/proxy-server.ts';
 import { searchEndpoint } from './routes/search/search.ts';
 
 import pkg from '../package.json' with { type: 'json' };
@@ -50,6 +51,7 @@ export function createVectorServerApp() {
       status: 'ok',
       docs: '/swagger',
     }))
+    .use(createVectorProxyServer({ version: pkg.version }))
     .use(new Elysia({ prefix: '/api' }).use(searchEndpoint))
     .use(vectorRoutes);
 }

--- a/src/vector/__tests__/proxy-server.test.ts
+++ b/src/vector/__tests__/proxy-server.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'bun:test';
+import pkg from '../../../package.json' with { type: 'json' };
+import { createVectorProxyServer } from '../proxy-server.ts';
+import type { VectorDocument, VectorQueryResult, VectorStoreAdapter } from '../adapter.ts';
+
+class FakeStore implements VectorStoreAdapter {
+  readonly name = 'fake-lancedb';
+  connected = 0;
+  ensured = 0;
+  docs: VectorDocument[] = [];
+
+  async connect() { this.connected++; }
+  async close() {}
+  async ensureCollection() { this.ensured++; }
+  async deleteCollection() { this.docs = []; }
+  async addDocuments(docs: VectorDocument[]) { this.docs.push(...docs); }
+  async query(text: string, limit = 10, where?: Record<string, unknown>): Promise<VectorQueryResult> {
+    const matches = this.docs.filter((doc) => !where || Object.entries(where).every(([key, value]) => doc.metadata[key] === value));
+    return {
+      ids: matches.slice(0, limit).map((doc) => doc.id),
+      documents: matches.slice(0, limit).map((doc) => `${text}:${doc.document}`),
+      distances: matches.slice(0, limit).map(() => 0.1),
+      metadatas: matches.slice(0, limit).map((doc) => doc.metadata),
+    };
+  }
+  async queryById(): Promise<VectorQueryResult> { return { ids: [], documents: [], distances: [], metadatas: [] }; }
+  async getStats() { return { count: this.docs.length }; }
+  async getCollectionInfo() { return { count: this.docs.length, name: 'oracle_test' }; }
+}
+
+function request(path: string, init?: RequestInit) {
+  return new Request(`http://vector.local${path}`, init);
+}
+
+describe('standalone vector proxy server', () => {
+  test('package exposes a Bun script for the LanceDB vector sidecar', () => {
+    expect(pkg.scripts['vector:proxy']).toBe('ORACLE_VECTOR_DB=lancedb bun src/vector-server.ts');
+  });
+
+  test('exposes health, add, query, stats, and delete endpoints used by ProxyVectorAdapter', async () => {
+    const store = new FakeStore();
+    const app = createVectorProxyServer({ store, collectionName: 'oracle_test', version: '1.2.3' });
+
+    const health = await app.handle(request('/health'));
+    expect(await health.json()).toMatchObject({ status: 'ok', name: 'fake-lancedb', protocol: 'vector-proxy-v1' });
+
+    const add = await app.handle(request('/vectors/add', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ documents: [{ id: 'a', document: 'alpha', metadata: { tenant: 'one' }, vector: [0.1] }] }),
+    }));
+    expect(await add.json()).toEqual({ ok: true, added: 1 });
+    expect(store.connected).toBe(1);
+    expect(store.ensured).toBe(1);
+
+    const query = await app.handle(request('/vectors/query', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text: 'find', limit: 5, where: { tenant: 'one' } }),
+    }));
+    expect(await query.json()).toMatchObject({ ids: ['a'], documents: ['find:alpha'] });
+
+    const stats = await app.handle(request('/vectors/stats'));
+    expect(await stats.json()).toEqual({ count: 1, name: 'oracle_test' });
+
+    const deleted = await app.handle(request('/vectors/collection', { method: 'DELETE' }));
+    expect(await deleted.json()).toEqual({ ok: true });
+  });
+
+  test('rejects invalid protocol requests before touching storage', async () => {
+    const store = new FakeStore();
+    const app = createVectorProxyServer({ store });
+    const response = await app.handle(request('/vectors/add', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ documents: 'nope' }),
+    }));
+
+    expect(response.status).toBe(400);
+    expect(store.connected).toBe(0);
+  });
+});

--- a/src/vector/proxy-server.ts
+++ b/src/vector/proxy-server.ts
@@ -1,0 +1,122 @@
+import { Elysia } from 'elysia';
+import { COLLECTION_NAME } from '../const.ts';
+import type { VectorStoreAdapter, VectorDocument } from './adapter.ts';
+import type { VectorDBType } from './types.ts';
+import { createVectorStore } from './factory.ts';
+import {
+  VECTOR_PROXY_PROTOCOL_VERSION,
+  VECTOR_PROXY_ROUTES,
+  type VectorProxyAddRequest,
+  type VectorProxyHealthResponse,
+  type VectorProxyQueryRequest,
+} from './proxy-protocol.ts';
+
+export interface VectorProxyServerOptions {
+  store?: VectorStoreAdapter;
+  collectionName?: string;
+  version?: string;
+}
+
+export function createVectorProxyServer(options: VectorProxyServerOptions = {}) {
+  const collectionName = options.collectionName || process.env.ORACLE_VECTOR_COLLECTION || COLLECTION_NAME;
+  const store = options.store ?? createVectorStore({
+    type: vectorDbType(process.env.ORACLE_VECTOR_DB),
+    collectionName,
+  });
+  const state = { ready: false, error: undefined as string | undefined };
+
+  async function readyStore() {
+    if (state.ready) return store;
+    await store.connect();
+    await store.ensureCollection();
+    state.ready = true;
+    state.error = undefined;
+    return store;
+  }
+
+  async function withStore<T>(operation: (connected: VectorStoreAdapter) => Promise<T>) {
+    try {
+      return await operation(await readyStore());
+    } catch (error) {
+      state.error = message(error);
+      throw error;
+    }
+  }
+
+  return new Elysia({ name: 'vector-proxy-server' })
+    .get(VECTOR_PROXY_ROUTES.health, () => healthPayload(store, state, collectionName, options.version))
+    .post(VECTOR_PROXY_ROUTES.add, async ({ body, set }) => {
+      const documents = validDocuments((body as VectorProxyAddRequest | undefined)?.documents);
+      if (!documents) return badRequest(set, 'documents must be an array');
+      await withStore((connected) => connected.addDocuments(documents));
+      return { ok: true, added: documents.length };
+    })
+    .post(VECTOR_PROXY_ROUTES.query, async ({ body, set }) => {
+      const request = body as VectorProxyQueryRequest | undefined;
+      if (!request || typeof request.text !== 'string') return badRequest(set, 'text is required');
+      const limit = normalizeLimit(request.limit);
+      return withStore((connected) => connected.query(request.text, limit, request.where));
+    })
+    .get(VECTOR_PROXY_ROUTES.stats, async () => withStore(async (connected) => {
+      const info = await connected.getCollectionInfo();
+      return { count: nonNegative(info.count), name: info.name || collectionName };
+    }))
+    .delete(VECTOR_PROXY_ROUTES.collection, async () => {
+      await withStore((connected) => connected.deleteCollection());
+      state.ready = false;
+      return { ok: true };
+    })
+    .onError(({ error, set }) => {
+      set.status = 500;
+      return { error: 'vector proxy server error', message: message(error) };
+    });
+}
+
+function vectorDbType(value: string | undefined): VectorDBType {
+  const type = value?.trim().toLowerCase();
+  if (type === 'qdrant' || type === 'sqlite-vec' || type === 'proxy' || type === 'turbovec') return type;
+  if (type === 'cloudflare-vectorize' || type === 'chroma') return type;
+  return 'lancedb';
+}
+
+function healthPayload(
+  store: VectorStoreAdapter,
+  state: { ready: boolean; error?: string },
+  collectionName: string,
+  version = 'dev',
+): VectorProxyHealthResponse & { collection: string; ready: boolean; error?: string } {
+  const status = state.error ? 'degraded' : 'ok';
+  return {
+    status,
+    name: store.name,
+    version,
+    protocol: VECTOR_PROXY_PROTOCOL_VERSION,
+    collection: collectionName,
+    ready: state.ready,
+    ...(state.error ? { error: state.error } : {}),
+  };
+}
+
+function validDocuments(value: unknown): VectorDocument[] | null {
+  if (!Array.isArray(value)) return null;
+  return value.every((doc) => doc && typeof doc === 'object' && typeof doc.id === 'string' && typeof doc.document === 'string')
+    ? value as VectorDocument[]
+    : null;
+}
+
+function badRequest(set: { status?: number | string }, messageText: string) {
+  set.status = 400;
+  return { error: messageText };
+}
+
+function normalizeLimit(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.floor(value) : 10;
+}
+
+function nonNegative(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? Math.floor(value) : 0;
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}


### PR DESCRIPTION
## Summary
- Add a standalone vector proxy server surface for the separate LanceDB vector process.
- Mount proxy-adapter protocol endpoints from `src/vector-server.ts`: `/health`, `/vectors/add`, `/vectors/query`, `/vectors/stats`, and `/vectors/collection`.
- Add `bun run vector:proxy` as the LanceDB sidecar start script.

## Tests
```bash
bun test src/vector/__tests__/proxy-server.test.ts src/server/__tests__/vector-server-route.test.ts
bunx tsc --noEmit
bun test src/vector/__tests__/proxy-contract.test.ts src/vector/__tests__/proxy-server.test.ts src/server/__tests__/vector-server-route.test.ts
git diff --check
```

Refs #2227
