### PR TITLE
feat(workers): add D1 tenant registry

### DIFF
--- a/tests/workers/mcp-deploy-config.test.ts
+++ b/tests/workers/mcp-deploy-config.test.ts
@@ -54,7 +54,14 @@ describe('workers/mcp deploy package', () => {
   test('declares the runtime dependencies needed by wrangler deploy', () => {
     const pkg = readJson('workers/mcp/package.json');
 
-    expect(pkg.scripts).toMatchObject({ deploy: 'wrangler deploy', typecheck: 'tsc --noEmit' });
+    expect(pkg.scripts).toMatchObject({
+      build: 'tsc --noEmit',
+      dev: 'wrangler dev --config wrangler.jsonc',
+      typecheck: 'tsc --noEmit',
+    });
+    expect(pkg.scripts.deploy).toContain('tsc --noEmit');
+    expect(pkg.scripts.deploy).toContain('wrangler deploy');
+    expect(pkg.scripts.deploy).toContain('--config wrangler.jsonc');
     expect(pkg.dependencies).toMatchObject({
       '@modelcontextprotocol/sdk': expect.any(String),
       agents: expect.any(String),

--- a/tests/workers/mcp-deploy-ready.test.ts
+++ b/tests/workers/mcp-deploy-ready.test.ts
@@ -40,7 +40,9 @@ describe('workers/mcp deploy readiness', () => {
   test('worker package keeps the dependencies needed by wrangler deploy', () => {
     const pkg = JSON.parse(read('workers/mcp/package.json')) as Record<string, any>;
 
-    expect(pkg.scripts.deploy).toBe('wrangler deploy');
+    expect(pkg.scripts.deploy).toContain('tsc --noEmit');
+    expect(pkg.scripts.deploy).toContain('wrangler deploy');
+    expect(pkg.scripts.deploy).toContain('--config wrangler.jsonc');
     expect(pkg.dependencies).toMatchObject({
       '@modelcontextprotocol/sdk': expect.any(String),
       agents: expect.any(String),

--- a/tests/workers/mcp-proxy-tools.test.ts
+++ b/tests/workers/mcp-proxy-tools.test.ts
@@ -5,11 +5,13 @@ import { buildProxyUrl, oracleProxyTool, resolveMcpTenantId, resolveOracleUrl } 
 describe('Cloudflare MCP proxy tools', () => {
   test('registers search, stats, and learn tools in the Worker entry', () => {
     const entry = readFileSync('workers/mcp/src/index.ts', 'utf8');
+    const tools = readFileSync('workers/mcp/src/tools.ts', 'utf8');
 
-    expect(entry).toContain("'muninn_search'");
-    expect(entry).toContain("'muninn_stats'");
-    expect(entry).toContain("'oracle_learn'");
+    expect(entry).toContain('registerOracleMcpTools');
     expect(entry).toContain("OracleMCP.serve('/mcp')");
+    expect(tools).toContain("'muninn_search'");
+    expect(tools).toContain("'muninn_stats'");
+    expect(tools).toContain("'oracle_learn'");
   });
 
   test('normalizes backend URLs and appends only present query values', () => {

--- a/tests/workers/mcp-proxy.test.ts
+++ b/tests/workers/mcp-proxy.test.ts
@@ -1,15 +1,13 @@
-import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
+import { registerOracleMcpTools } from '../../workers/mcp/src/tools.ts';
 
 type ToolHandler = (input: Record<string, unknown>) => Promise<{
   content: Array<{ type: 'text'; text: string }>;
   isError?: boolean;
 }>;
 type RegisteredTool = { description: string; handler: ToolHandler };
-type SdkTool = { description?: string; handler: ToolHandler };
-type SdkToolServer = { _registeredTools?: Record<string, SdkTool> };
 
 const tools = new Map<string, RegisteredTool>();
-let servedPath: string | undefined;
 const originalFetch = globalThis.fetch;
 
 function zShape() {
@@ -20,58 +18,24 @@ function zShape() {
   return schema;
 }
 
-mock.module('agents/mcp', () => ({
-  McpAgent: class {
-    env: Record<string, unknown>;
-    props: Record<string, unknown>;
-    constructor(env: Record<string, unknown> = {}) {
-      this.env = env;
-      this.props = (env.__props as Record<string, unknown> | undefined) ?? {};
-    }
-    static serve(path: string) {
-      servedPath = path;
-      return { fetch: () => new Response('mock mcp') };
-    }
-  },
-}));
-
-mock.module('@modelcontextprotocol/sdk/server/mcp.js', () => ({
-  McpServer: class {
-    tool(name: string, ...args: unknown[]) {
-      const handler = args.at(-1);
-      if (typeof handler !== 'function') throw new Error(`missing handler for ${name}`);
-      tools.set(name, {
-        description: String(args[0] ?? ''),
-        handler: handler as ToolHandler,
-      });
-    }
-  },
-}));
-
-mock.module('zod', () => ({
-  z: {
-    array: () => zShape(),
-    enum: () => zShape(),
-    number: () => zShape(),
-    string: () => zShape(),
-    union: () => zShape(),
-  },
-}));
+const zLike = {
+  array: () => zShape(),
+  enum: () => zShape(),
+  number: () => zShape(),
+  string: () => zShape(),
+  union: () => zShape(),
+};
 
 async function loadTools(props: Record<string, unknown> = {}) {
   tools.clear();
-  const mod = await import('../../workers/mcp/src/index.ts');
-  const agent = new mod.OracleMCP({
+  registerOracleMcpTools({
+    tool(name: string, description: string, _schema: Record<string, unknown>, handler: ToolHandler) {
+      tools.set(name, { description, handler });
+    },
+  }, zLike, {
     ORACLE_URL: 'https://oracle.example.test/root/',
     ARRA_API_TOKEN: 'proxy-secret',
-    __props: props,
-  } as never);
-  await agent.init();
-  if (tools.size === 0) {
-    for (const [name, tool] of Object.entries((agent.server as SdkToolServer)._registeredTools ?? {})) {
-      tools.set(name, { description: tool.description ?? '', handler: tool.handler });
-    }
-  }
+  }, props);
 }
 
 function paramsFrom(url: string) {
@@ -87,7 +51,7 @@ afterEach(() => {
 });
 
 describe('Cloudflare McpAgent proxy flow', () => {
-  test('registers the Worker endpoint and forwards search, stats, and learn tools', async () => {
+  test('registers and forwards search, stats, and learn tools', async () => {
     const requests: Array<{ url: string; method: string; headers: Headers; body: unknown }> = [];
     globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
       requests.push({
@@ -100,7 +64,6 @@ describe('Cloudflare McpAgent proxy flow', () => {
     }) as typeof fetch;
 
     await loadTools({ claims: { tenantId: 'tenant-from-oauth' } });
-    expect(servedPath).toBe('/mcp');
     expect([...tools.keys()].sort()).toEqual(['muninn_search', 'muninn_stats', 'oracle_learn']);
 
     await tools.get('muninn_search')!.handler({
@@ -168,16 +131,8 @@ describe('Cloudflare McpAgent proxy flow', () => {
 
     await loadTools();
     const search = tools.get('muninn_search')!.handler;
-    const tenantA = payloadFrom(await search({
-      query: 'shared endpoint',
-      limit: 1,
-      tenantId: 'tenant-a',
-    }));
-    const tenantB = payloadFrom(await search({
-      query: 'shared endpoint',
-      limit: 1,
-      tenantId: 'tenant-b',
-    }));
+    const tenantA = payloadFrom(await search({ query: 'shared endpoint', limit: 1, tenantId: 'tenant-a' }));
+    const tenantB = payloadFrom(await search({ query: 'shared endpoint', limit: 1, tenantId: 'tenant-b' }));
 
     expect(seen).toEqual([
       { path: '/root/api/search', tenant: 'tenant-a', query: { q: 'shared endpoint', limit: '1' } },

--- a/tests/workers/mcp-tenant-registry.test.ts
+++ b/tests/workers/mcp-tenant-registry.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from 'bun:test';
+import { oracleProxyTool } from '../../workers/mcp/src/proxy.ts';
+import {
+  createTenant,
+  ensureTenantRegistry,
+  listTenants,
+  requireActiveTenant,
+  tenantScopedAll,
+  type D1TenantDatabase,
+  type D1TenantStatement,
+} from '../../workers/mcp/src/tenant-registry.ts';
+
+type D1Value = string | number | null;
+type TenantRow = {
+  id: string;
+  name: string | null;
+  status: 'active' | 'disabled';
+  createdAt: number;
+  updatedAt: number;
+};
+type State = { tenants: Map<string, TenantRow>; docs: Array<Record<string, D1Value>> };
+
+class MockD1 implements D1TenantDatabase {
+  state: State = { tenants: new Map(), docs: [] };
+
+  prepare(sql: string): D1TenantStatement {
+    return new MockStatement(sql, this.state);
+  }
+}
+
+class MockStatement implements D1TenantStatement {
+  private values: D1Value[] = [];
+
+  constructor(private readonly sql: string, private readonly state: State) {}
+
+  bind(...values: D1Value[]): D1TenantStatement {
+    this.values = values;
+    return this;
+  }
+
+  async run(): Promise<{ results: unknown[] }> {
+    if (this.normalized.includes('INSERT INTO "tenants"')) this.upsertTenant();
+    return { results: [] };
+  }
+
+  async all<T = unknown>(): Promise<{ results: T[] }> {
+    if (this.normalized.includes('FROM "tenants"')) return { results: this.selectTenants() as T[] };
+    if (this.normalized.includes('FROM "oracle_documents"')) return { results: this.selectDocs() as T[] };
+    return { results: [] };
+  }
+
+  async first<T = unknown>(): Promise<T | null> {
+    const { results } = await this.all<T>();
+    return results[0] ?? null;
+  }
+
+  private get normalized(): string {
+    return this.sql.replace(/\s+/g, ' ');
+  }
+
+  private upsertTenant(): void {
+    const [rawId, rawName, rawStatusOrCreated, rawCreated, rawUpdated] = this.values;
+    const id = String(rawId);
+    const existing = this.state.tenants.get(id);
+    const defaultInsert = this.values.length === 4;
+    if (defaultInsert && existing) return;
+    const status = defaultInsert || rawStatusOrCreated !== 'disabled' ? 'active' : 'disabled';
+    const createdAt = Number(defaultInsert ? rawStatusOrCreated : rawCreated);
+    const updatedAt = Number(defaultInsert ? rawCreated : rawUpdated);
+    this.state.tenants.set(id, {
+      id,
+      name: typeof rawName === 'string' ? rawName : null,
+      status,
+      createdAt: existing?.createdAt ?? createdAt,
+      updatedAt,
+    });
+  }
+
+  private selectTenants(): TenantRow[] {
+    let rows = [...this.state.tenants.values()];
+    if (this.normalized.includes('WHERE status = ?')) rows = rows.filter((row) => row.status === this.values[0]);
+    if (this.normalized.includes('WHERE id = ?')) rows = rows.filter((row) => row.id === this.values[0]);
+    return rows.sort((a, b) => a.id.localeCompare(b.id));
+  }
+
+  private selectDocs(): Array<Record<string, D1Value>> {
+    let valueIndex = 0;
+    const tenantId = this.values[valueIndex++];
+    let rows = this.state.docs.filter((row) => row.tenant_id === tenantId);
+    if (this.normalized.includes('"type" = ?')) {
+      const type = this.values[valueIndex++];
+      rows = rows.filter((row) => row.type === type);
+    }
+    const limit = Number(this.values.at(-2) ?? rows.length);
+    const offset = Number(this.values.at(-1) ?? 0);
+    return rows.slice(offset, offset + limit);
+  }
+}
+
+function d1(): MockD1 {
+  return new MockD1();
+}
+
+describe('D1 tenant registry', () => {
+  test('creates and lists active and disabled tenants', async () => {
+    const db = d1();
+
+    await ensureTenantRegistry(db);
+    await createTenant(db, { id: 'school-a', name: 'School A' });
+    await createTenant(db, { id: 'school-b', name: 'School B', status: 'disabled' });
+
+    expect((await listTenants(db)).map((tenant) => tenant.id)).toEqual(['default', 'school-a', 'school-b']);
+    expect((await listTenants(db, { status: 'active' })).map((tenant) => tenant.id)).toEqual(['default', 'school-a']);
+  });
+
+  test('requires active D1 tenants while preserving optional local tenants', async () => {
+    const db = d1();
+    await createTenant(db, { id: 'school-a' });
+    await createTenant(db, { id: 'school-b', status: 'disabled' });
+
+    await expect(requireActiveTenant({ ORACLE_DB: db }, 'school-a')).resolves.toBe('school-a');
+    await expect(requireActiveTenant({ ORACLE_DB: db }, undefined)).resolves.toBe('default');
+    await expect(requireActiveTenant({ ORACLE_DB: db }, 'school-b')).rejects.toThrow('Tenant is disabled: school-b');
+    await expect(requireActiveTenant({ ORACLE_DB: db }, 'school-c')).rejects.toThrow('Tenant not found: school-c');
+    await expect(requireActiveTenant({}, undefined)).resolves.toBeUndefined();
+  });
+
+  test('scopes D1 rows by tenant id and optional filters', async () => {
+    const db = d1();
+    db.state.docs.push(
+      { id: 'a-learn', tenant_id: 'school-a', type: 'learning' },
+      { id: 'a-note', tenant_id: 'school-a', type: 'note' },
+      { id: 'b-learn', tenant_id: 'school-b', type: 'learning' },
+    );
+
+    const tenantA = await tenantScopedAll(db, {
+      table: 'oracle_documents',
+      tenantId: 'school-a',
+      columns: ['id', 'tenant_id', 'type'],
+      filters: { type: 'learning' },
+      limit: 10,
+    });
+    const tenantB = await tenantScopedAll(db, { table: 'oracle_documents', tenantId: 'school-b' });
+
+    expect(tenantA.map((row) => row.id)).toEqual(['a-learn']);
+    expect(tenantB.map((row) => row.id)).toEqual(['b-learn']);
+    await expect(tenantScopedAll(db, { table: 'bad-table', tenantId: 'school-a' })).rejects.toThrow(
+      'Invalid D1 identifier',
+    );
+  });
+
+  test('validates registry tenants before forwarding MCP proxy requests', async () => {
+    const db = d1();
+    await createTenant(db, { id: 'school-a' });
+    await createTenant(db, { id: 'school-b', status: 'disabled' });
+    const captured: Array<{ url: string; headers: Headers }> = [];
+    const fetcher = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      captured.push({ url: String(input), headers: new Headers(init?.headers) });
+      return Response.json({ ok: true });
+    }) as typeof fetch;
+
+    const active = await oracleProxyTool({ ORACLE_DB: db, ORACLE_URL: 'https://oracle.example.test' }, {
+      path: '/api/stats',
+      tenantId: 'school-a',
+    }, fetcher);
+    const disabled = await oracleProxyTool({ ORACLE_DB: db, ORACLE_URL: 'https://oracle.example.test' }, {
+      path: '/api/stats',
+      tenantId: 'school-b',
+    }, fetcher);
+
+    expect(active.isError).toBeUndefined();
+    expect(disabled.isError).toBe(true);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].url).toBe('https://oracle.example.test/api/stats');
+    expect(captured[0].headers.get('x-tenant-id')).toBe('school-a');
+    expect(disabled.content[0].text).toContain('Tenant is disabled: school-b');
+  });
+});

--- a/workers/mcp/src/index.ts
+++ b/workers/mcp/src/index.ts
@@ -1,73 +1,16 @@
 import { McpAgent } from 'agents/mcp';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { oracleProxyTool, type OracleMcpAuthContext, type OracleProxyEnv } from './proxy.ts';
+import { type OracleMcpAuthContext, type OracleProxyEnv } from './proxy.ts';
+import { registerOracleMcpTools } from './tools.ts';
 
 type Env = OracleProxyEnv;
-
-const typeArg = z.enum(['principle', 'pattern', 'learning', 'retro', 'all']).optional();
-const modeArg = z.enum(['hybrid', 'fts', 'vector']).optional();
-const modelArg = z.enum(['nomic', 'qwen3', 'bge-m3']).optional();
-const tenantArg = z.string().optional();
-const conceptsArg = z.union([z.array(z.string()), z.string()]).optional();
 
 export class OracleMCP extends McpAgent<Env, unknown, OracleMcpAuthContext> {
   server = new McpServer({ name: 'arra-oracle', version: '1.0.0' });
 
   async init() {
-    this.server.tool(
-      'muninn_search',
-      'Search the Arra Oracle knowledge backend through the Cloudflare MCP proxy.',
-      {
-        query: z.string(),
-        type: typeArg,
-        limit: z.number().optional(),
-        offset: z.number().optional(),
-        mode: modeArg,
-        project: z.string().optional(),
-        cwd: z.string().optional(),
-        model: modelArg,
-        tenantId: tenantArg,
-      },
-      async ({ query, tenantId, ...args }) => oracleProxyTool(this.env, {
-        path: '/api/search',
-        query: { q: query, ...args },
-        tenantId,
-        authContext: this.props,
-      }),
-    );
-
-    this.server.tool(
-      'muninn_stats',
-      'Read Arra Oracle backend document, indexing, and vector status.',
-      { tenantId: tenantArg },
-      async ({ tenantId }) => oracleProxyTool(this.env, {
-        path: '/api/stats',
-        tenantId,
-        authContext: this.props,
-      }),
-    );
-
-    this.server.tool(
-      'oracle_learn',
-      'Record a learning in the Arra Oracle backend through the Cloudflare MCP proxy.',
-      {
-        pattern: z.string(),
-        concepts: conceptsArg,
-        source: z.string().optional(),
-        origin: z.string().nullable().optional(),
-        project: z.string().nullable().optional(),
-        cwd: z.string().optional(),
-        tenantId: tenantArg,
-      },
-      async ({ tenantId, ...body }) => oracleProxyTool(this.env, {
-        method: 'POST',
-        path: '/api/learn',
-        body,
-        tenantId,
-        authContext: this.props,
-      }),
-    );
+    registerOracleMcpTools(this.server, z, this.env, this.props);
   }
 }
 

--- a/workers/mcp/src/proxy.ts
+++ b/workers/mcp/src/proxy.ts
@@ -1,3 +1,5 @@
+import { requireActiveTenant, type TenantRegistryEnv } from './tenant-registry.ts';
+
 export type OracleProxyEnv = {
   ORACLE_URL?: string;
   ORACLE_HTTP_URL?: string;
@@ -5,7 +7,7 @@ export type OracleProxyEnv = {
   ORACLE_TENANT_ID?: string;
   ARRA_API_TOKEN?: string;
   ARRA_API_KEY?: string;
-};
+} & TenantRegistryEnv;
 
 export type TextToolResult = {
   content: Array<{ type: 'text'; text: string }>;
@@ -132,7 +134,8 @@ export async function oracleProxyTool(
   try {
     const baseUrl = resolveOracleUrl(env);
     const body = request.body === undefined ? undefined : JSON.stringify(request.body);
-    const tenantId = resolveMcpTenantId(request.authContext, request.tenantId, env);
+    const requestedTenantId = resolveMcpTenantId(request.authContext, request.tenantId, env);
+    const tenantId = await requireActiveTenant(env, requestedTenantId);
     const response = await fetcher(buildProxyUrl(baseUrl, request.path, request.query), {
       method: request.method ?? 'GET',
       headers: proxyHeaders(env, body !== undefined, tenantId),

--- a/workers/mcp/src/tenant-registry.ts
+++ b/workers/mcp/src/tenant-registry.ts
@@ -1,0 +1,171 @@
+type D1Value = string | number | null;
+type D1Result<T> = { results?: T[] };
+
+export interface D1TenantStatement {
+  bind(...values: D1Value[]): D1TenantStatement;
+  run<T = unknown>(): Promise<D1Result<T>>;
+  all<T = unknown>(): Promise<D1Result<T>>;
+  first<T = unknown>(): Promise<T | null>;
+}
+
+export interface D1TenantDatabase {
+  prepare(sql: string): D1TenantStatement;
+  batch?(statements: D1TenantStatement[]): Promise<unknown[]>;
+}
+
+export interface TenantRecord {
+  id: string;
+  name: string | null;
+  status: 'active' | 'disabled';
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface TenantRegistryEnv {
+  ORACLE_DB?: D1TenantDatabase;
+  ORACLE_TENANTS_TABLE?: string;
+}
+
+export interface TenantScopedSelect {
+  table: string;
+  tenantId: unknown;
+  columns?: string[];
+  filters?: Record<string, D1Value>;
+  limit?: number;
+  offset?: number;
+}
+
+const DEFAULT_TENANT_ID = 'default';
+const TENANT_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/;
+const IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export function normalizeTenantId(value: unknown, fallback = DEFAULT_TENANT_ID): string {
+  const requested = typeof value === 'string' ? value.trim() : '';
+  const tenantId = requested || fallback;
+  if (!TENANT_PATTERN.test(tenantId)) throw new Error('invalid tenant id');
+  return tenantId;
+}
+
+export function tenantRegistryTable(env?: TenantRegistryEnv): string {
+  return quoteIdentifier(env?.ORACLE_TENANTS_TABLE?.trim() || 'tenants');
+}
+
+export async function ensureTenantRegistry(db: D1TenantDatabase, table = tenantRegistryTable()): Promise<void> {
+  await db.prepare(
+    `CREATE TABLE IF NOT EXISTS ${table} (
+      id TEXT PRIMARY KEY NOT NULL,
+      name TEXT,
+      status TEXT DEFAULT 'active' NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )`,
+  ).run();
+  await db.prepare(`CREATE INDEX IF NOT EXISTS ${indexName(table)} ON ${table} (status)`).run();
+  const now = Date.now();
+  await db.prepare(
+    `INSERT INTO ${table} (id, name, status, created_at, updated_at)
+     VALUES (?, ?, 'active', ?, ?)
+     ON CONFLICT(id) DO NOTHING`,
+  ).bind(DEFAULT_TENANT_ID, 'Default tenant', now, now).run();
+}
+
+export async function createTenant(
+  db: D1TenantDatabase,
+  input: { id: unknown; name?: unknown; status?: unknown },
+  env?: TenantRegistryEnv,
+): Promise<TenantRecord> {
+  const table = tenantRegistryTable(env);
+  await ensureTenantRegistry(db, table);
+  const id = normalizeTenantId(input.id);
+  const name = typeof input.name === 'string' && input.name.trim() ? input.name.trim() : id;
+  const status = input.status === 'disabled' ? 'disabled' : 'active';
+  const now = Date.now();
+  await db.prepare(
+    `INSERT INTO ${table} (id, name, status, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET name = excluded.name, status = excluded.status, updated_at = excluded.updated_at`,
+  ).bind(id, name, status, now, now).run();
+  const tenant = await getTenant(db, id, env);
+  if (!tenant) throw new Error(`Failed to read tenant after create: ${id}`);
+  return tenant;
+}
+
+export async function listTenants(
+  db: D1TenantDatabase,
+  options: { status?: 'active' | 'disabled' } = {},
+  env?: TenantRegistryEnv,
+): Promise<TenantRecord[]> {
+  const table = tenantRegistryTable(env);
+  await ensureTenantRegistry(db, table);
+  const where = options.status ? ' WHERE status = ?' : '';
+  const statement = db.prepare(
+    `SELECT id, name, status, created_at AS createdAt, updated_at AS updatedAt
+     FROM ${table}${where} ORDER BY id`,
+  );
+  const result = await (options.status ? statement.bind(options.status) : statement).all<TenantRecord>();
+  return (result.results ?? []).map(normalizeTenantRecord);
+}
+
+export async function getTenant(db: D1TenantDatabase, id: unknown, env?: TenantRegistryEnv): Promise<TenantRecord | null> {
+  const table = tenantRegistryTable(env);
+  await ensureTenantRegistry(db, table);
+  const row = await db.prepare(
+    `SELECT id, name, status, created_at AS createdAt, updated_at AS updatedAt FROM ${table} WHERE id = ? LIMIT 1`,
+  ).bind(normalizeTenantId(id)).first<TenantRecord>();
+  return row ? normalizeTenantRecord(row) : null;
+}
+
+export async function requireActiveTenant(env: TenantRegistryEnv, requested?: unknown): Promise<string | undefined> {
+  if (!env.ORACLE_DB) return typeof requested === 'string' && requested.trim() ? normalizeTenantId(requested) : undefined;
+  const tenantId = normalizeTenantId(requested);
+  const tenant = await getTenant(env.ORACLE_DB, tenantId, env);
+  if (!tenant) throw new Error(`Tenant not found: ${tenantId}`);
+  if (tenant.status !== 'active') throw new Error(`Tenant is disabled: ${tenantId}`);
+  return tenant.id;
+}
+
+export async function tenantScopedAll<T>(db: D1TenantDatabase, query: TenantScopedSelect): Promise<T[]> {
+  const table = quoteIdentifier(query.table);
+  const columns = (query.columns?.length ? query.columns : ['*']).map(quoteColumn).join(', ');
+  const tenantId = normalizeTenantId(query.tenantId);
+  const filters = Object.entries(query.filters ?? {});
+  const filterSql = filters.map(([key]) => ` AND ${quoteIdentifier(key)} = ?`).join('');
+  const limit = boundedInteger(query.limit, 50, 1, 100);
+  const offset = boundedInteger(query.offset, 0, 0, 10_000);
+  const result = await db.prepare(
+    `SELECT ${columns} FROM ${table} WHERE tenant_id = ?${filterSql} LIMIT ? OFFSET ?`,
+  ).bind(tenantId, ...filters.map(([, value]) => value), limit, offset).all<T>();
+  return result.results ?? [];
+}
+
+function quoteColumn(value: string): string {
+  return value === '*' ? '*' : quoteIdentifier(value);
+}
+
+function quoteIdentifier(value: string): string {
+  if (!IDENTIFIER_PATTERN.test(value)) throw new Error(`Invalid D1 identifier: ${value}`);
+  return `"${value}"`;
+}
+
+function indexName(table: string): string {
+  return quoteIdentifier(`${stripQuotes(table)}_status_idx`);
+}
+
+function stripQuotes(value: string): string {
+  return value.replace(/^"|"$/g, '');
+}
+
+function boundedInteger(value: number | undefined, fallback: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(max, Math.max(min, Math.trunc(value!)));
+}
+
+function normalizeTenantRecord(row: TenantRecord): TenantRecord {
+  return {
+    id: row.id,
+    name: row.name ?? null,
+    status: row.status === 'disabled' ? 'disabled' : 'active',
+    createdAt: Number(row.createdAt),
+    updatedAt: Number(row.updatedAt),
+  };
+}

--- a/workers/mcp/src/tools.ts
+++ b/workers/mcp/src/tools.ts
@@ -1,0 +1,91 @@
+import { oracleProxyTool, type OracleMcpAuthContext, type OracleProxyEnv, type TextToolResult } from './proxy.ts';
+
+type ToolInput = Record<string, unknown>;
+type ToolHandler = (input: ToolInput) => Promise<TextToolResult>;
+type ToolServer = {
+  tool(name: string, description: string, schema: Record<string, unknown>, handler: ToolHandler): void;
+};
+type OptionalSchema = { optional(): unknown };
+type StringSchema = OptionalSchema & { nullable(): OptionalSchema };
+type ZodLike = {
+  array(schema: unknown): unknown;
+  enum(values: readonly [string, ...string[]]): OptionalSchema;
+  number(): OptionalSchema;
+  string(): StringSchema;
+  union(values: readonly [unknown, unknown, ...unknown[]]): OptionalSchema;
+};
+
+export function registerOracleMcpTools(
+  server: ToolServer,
+  z: ZodLike,
+  env: OracleProxyEnv,
+  authContext?: OracleMcpAuthContext,
+): void {
+  const typeArg = optional(z.enum(['principle', 'pattern', 'learning', 'retro', 'all']));
+  const modeArg = optional(z.enum(['hybrid', 'fts', 'vector']));
+  const modelArg = optional(z.enum(['nomic', 'qwen3', 'bge-m3']));
+  const tenantArg = z.string().optional();
+  const conceptsArg = z.union([z.array(z.string()), z.string()]).optional();
+
+  server.tool(
+    'muninn_search',
+    'Search the Arra Oracle knowledge backend through the Cloudflare MCP proxy.',
+    {
+      query: z.string(),
+      type: typeArg,
+      limit: z.number().optional(),
+      offset: z.number().optional(),
+      mode: modeArg,
+      project: z.string().optional(),
+      cwd: z.string().optional(),
+      model: modelArg,
+      tenantId: tenantArg,
+    },
+    async ({ query, tenantId, ...args }) => oracleProxyTool(env, {
+      path: '/api/search',
+      query: { q: query, ...args },
+      tenantId,
+      authContext,
+    }),
+  );
+
+  server.tool(
+    'muninn_stats',
+    'Read Arra Oracle backend document, indexing, and vector status.',
+    { tenantId: tenantArg },
+    async ({ tenantId }) => oracleProxyTool(env, {
+      path: '/api/stats',
+      tenantId,
+      authContext,
+    }),
+  );
+
+  server.tool(
+    'oracle_learn',
+    'Record a learning in the Arra Oracle backend through the Cloudflare MCP proxy.',
+    {
+      pattern: z.string(),
+      concepts: conceptsArg,
+      source: z.string().optional(),
+      origin: z.string().nullable().optional(),
+      project: z.string().nullable().optional(),
+      cwd: z.string().optional(),
+      tenantId: tenantArg,
+    },
+    async ({ tenantId, ...body }) => oracleProxyTool(env, {
+      method: 'POST',
+      path: '/api/learn',
+      body,
+      tenantId,
+      authContext,
+    }),
+  );
+}
+
+function optional(schema: unknown): unknown {
+  return hasOptional(schema) ? schema.optional() : schema;
+}
+
+function hasOptional(schema: unknown): schema is OptionalSchema {
+  return typeof schema === 'object' && schema !== null && 'optional' in schema && typeof schema.optional === 'function';
+}


### PR DESCRIPTION
## Summary
- add D1 tenant registry helpers for create/list/read and active-tenant enforcement in the MCP Worker proxy
- require active D1 tenants before forwarding MCP tool calls when `ORACLE_DB` is bound; preserve local/dev tenant behavior without D1
- add tenant-scoped D1 query helper plus two-tenant registry/proxy coverage
- extract MCP tool registration into a testable helper so proxy tests avoid loading Cloudflare runtime packages

## Validation
```bash
bunx tsc --noEmit
bunx tsc -p workers/mcp/tsconfig.json --noEmit
bun test tests/workers/mcp-*.test.ts
git diff --check origin/alpha..HEAD
wc -l workers/mcp/src/tenant-registry.ts workers/mcp/src/proxy.ts workers/mcp/src/index.ts workers/mcp/src/tools.ts tests/workers/mcp-tenant-registry.test.ts tests/workers/mcp-proxy.test.ts tests/workers/mcp-proxy-tools.test.ts tests/workers/mcp-deploy-ready.test.ts tests/workers/mcp-deploy-config.test.ts
```

Refs #2193