### PR TITLE
feat: aggregate vector server health

### DIFF
--- a/src/routes/health/health.ts
+++ b/src/routes/health/health.ts
@@ -5,6 +5,7 @@ import { sqlite } from '../../db/index.ts';
 import { scanPlugins } from '../plugins/model.ts';
 import { readVectorBackendHealth } from '../../vector/health.ts';
 import { getVectorRuntimeStatus } from '../../vector/runtime-status.ts';
+import { readVectorServerHealth, type VectorServerHealth } from './vector-server.ts';
 import { mcpTools } from '../../tools/mcp-manifest.ts';
 import type { UnifiedPluginStatus } from '../../plugins/unified-loader.ts';
 import { sandboxLabel } from '../../runtime/sandbox-label.ts';
@@ -96,6 +97,7 @@ export interface HealthEndpointOptions {
   isDraining?: () => boolean;
   uptimeSeconds?: () => number;
   vectorHealth?: () => Promise<VectorHealth>;
+  vectorServerHealth?: () => Promise<VectorServerHealth>;
   pluginStatuses?: () => UnifiedPluginStatus[] | Promise<UnifiedPluginStatus[]>;
   dbPing?: DbPing;
   diskPath?: string;
@@ -149,8 +151,14 @@ async function readPluginStatuses(
   }
 }
 
-function aggregateStatus(db: DbStatus, pluginStatus: 'ok' | 'degraded') {
-  return db.status === 'connected' && pluginStatus === 'ok' ? 'ok' : 'degraded';
+function aggregateStatus(db: DbStatus, pluginStatus: 'ok' | 'degraded', vectorServer: VectorServerHealth) {
+  const vectorOk = vectorServer.status !== 'down';
+  return db.status === 'connected' && pluginStatus === 'ok' && vectorOk ? 'ok' : 'degraded';
+}
+
+async function readSafeVectorServerHealth(read = readVectorServerHealth): Promise<VectorServerHealth> {
+  try { return await read(); }
+  catch (error) { return { configured: true, status: 'down', error: errorMessage(error) }; }
 }
 
 function installedPluginCount(): number {
@@ -178,6 +186,7 @@ export function createHealthEndpoint(options: HealthEndpointOptions = {}) {
     const dbStatus = await readDbStatus(options.dbPing);
     const vector = await readVectorStatus(options.vectorHealth);
     const pluginItems = await readPluginStatuses(options.pluginStatuses);
+    const vectorServer = await readSafeVectorServerHealth(options.vectorServerHealth);
     const pluginCount = options.pluginCount ?? (pluginItems.length || installedPluginCount());
     const pluginStatus = pluginItems.some((plugin) => plugin.status === 'degraded') ? 'degraded' : 'ok';
     const toolCount = mcpTools.length + (options.pluginMcpToolCount ?? 0);
@@ -185,7 +194,7 @@ export function createHealthEndpoint(options: HealthEndpointOptions = {}) {
 
     const serviceUptime = Math.round(uptimeSeconds * 1000) / 1000;
     return {
-      status: aggregateStatus(dbStatus, pluginStatus),
+      status: aggregateStatus(dbStatus, pluginStatus, vectorServer),
       server: MCP_SERVER_NAME,
       version: pkg.version,
       port: Number(PORT),
@@ -203,6 +212,7 @@ export function createHealthEndpoint(options: HealthEndpointOptions = {}) {
       uptimeSecondsBreakdown: { seconds: serviceUptime },
       dbCheck: { ...dbStatus, path: DB_PATH },
       vector,
+      vectorServer,
       mcp: { toolCount },
       plugins: { count: pluginCount, status: pluginStatus, items: pluginItems },
     };

--- a/src/routes/health/vector-server.ts
+++ b/src/routes/health/vector-server.ts
@@ -1,0 +1,92 @@
+import { resolveVectorUrl } from '../../config.ts';
+import { resolveVectorProxyContract } from '../../vector/proxy-contract.ts';
+
+export type VectorServerHealth = {
+  configured: boolean;
+  status: 'ok' | 'down' | 'unconfigured';
+  url?: string;
+  httpStatus?: number;
+  protocol?: string;
+  name?: string;
+  version?: string;
+  error?: string;
+};
+
+type Fetcher = typeof fetch;
+
+export async function readVectorServerHealth(
+  fetcher: Fetcher = fetch,
+  env: Record<string, string | undefined> = process.env,
+  argv: string[] = process.argv,
+): Promise<VectorServerHealth> {
+  const baseUrl = normalizeBase(resolveVectorUrl(env, argv))
+    ?? resolveVectorProxyContract({ env })?.baseUrl;
+  if (!baseUrl) return { configured: false, status: 'unconfigured' };
+
+  const health = await fetchHealth(fetcher, baseUrl, '/health')
+    ?? await fetchHealth(fetcher, baseUrl, '/');
+  if (!health) return { configured: true, status: 'down', url: baseUrl, error: 'unreachable' };
+
+  const ok = health.httpStatus >= 200 && health.httpStatus < 300 && bodyOk(health.body);
+  return {
+    configured: true,
+    status: ok ? 'ok' : 'down',
+    url: baseUrl,
+    httpStatus: health.httpStatus,
+    ...bodySummary(health.body),
+    ...(ok ? {} : { error: health.error ?? statusText(health.body) }),
+  };
+}
+
+async function fetchHealth(fetcher: Fetcher, baseUrl: string, path: string) {
+  try {
+    const response = await fetcher(new URL(path, `${baseUrl}/`), {
+      signal: AbortSignal.timeout(Number(process.env.ORACLE_VECTOR_SERVER_HEALTH_TIMEOUT_MS ?? 1000)),
+    });
+    const body = await readBody(response);
+    return { httpStatus: response.status, body };
+  } catch (error) {
+    return { httpStatus: 0, body: undefined, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+async function readBody(response: Response): Promise<unknown> {
+  const text = await response.text().catch(() => '');
+  if (!text) return undefined;
+  try { return JSON.parse(text); } catch { return text; }
+}
+
+function normalizeBase(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return undefined;
+    url.search = '';
+    url.hash = '';
+    return url.toString().replace(/\/+$/, '');
+  } catch { return undefined; }
+}
+
+function bodyOk(body: unknown): boolean {
+  if (!body || typeof body !== 'object') return true;
+  const status = String((body as { status?: unknown }).status ?? '').toLowerCase();
+  return !status || status === 'ok' || status === 'up';
+}
+
+function bodySummary(body: unknown) {
+  if (!body || typeof body !== 'object') return {};
+  const record = body as Record<string, unknown>;
+  return {
+    ...(typeof record.protocol === 'string' && { protocol: record.protocol }),
+    ...(typeof record.name === 'string' && { name: record.name }),
+    ...(typeof record.server === 'string' && { name: record.server }),
+    ...(typeof record.version === 'string' && { version: record.version }),
+  };
+}
+
+function statusText(body: unknown): string | undefined {
+  if (!body || typeof body !== 'object') return undefined;
+  const status = (body as { status?: unknown }).status;
+  return status ? `vector server status: ${String(status)}` : undefined;
+}

--- a/tests/http/health/vector-server-aggregation.test.ts
+++ b/tests/http/health/vector-server-aggregation.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from 'bun:test';
+import { createHealthRoutes } from '../../../src/routes/health/index.ts';
+import { readVectorServerHealth } from '../../../src/routes/health/vector-server.ts';
+
+function baseOptions(vectorServerHealth: () => Promise<any>) {
+  return {
+    pluginCount: 0,
+    uptimeSeconds: () => 1,
+    dbPing: () => ({ status: 'connected' as const }),
+    vectorHealth: async () => ({ status: 'ok' as const, engines: [], checked_at: '2026-06-17T00:00:00.000Z' }),
+    vectorServerHealth,
+  };
+}
+
+test('GET /api/health includes separate vector-server health when configured', async () => {
+  const app = createHealthRoutes(baseOptions(async () => ({
+    configured: true,
+    status: 'ok',
+    url: 'http://127.0.0.1:8081',
+    httpStatus: 200,
+    protocol: 'vector-proxy-v1',
+  })));
+
+  const res = await app.handle(new Request('http://local/api/health'));
+  const body = await res.json() as Record<string, any>;
+
+  expect(res.status).toBe(200);
+  expect(body.status).toBe('ok');
+  expect(body.vectorServer).toMatchObject({
+    configured: true,
+    status: 'ok',
+    url: 'http://127.0.0.1:8081',
+    protocol: 'vector-proxy-v1',
+  });
+});
+
+test('GET /api/health degrades when configured vector-server is down', async () => {
+  const app = createHealthRoutes(baseOptions(async () => ({
+    configured: true,
+    status: 'down',
+    url: 'http://127.0.0.1:8081',
+    error: 'unreachable',
+  })));
+
+  const res = await app.handle(new Request('http://local/api/health'));
+  const body = await res.json() as Record<string, any>;
+
+  expect(body.status).toBe('degraded');
+  expect(body.vectorServer).toMatchObject({ status: 'down', error: 'unreachable' });
+});
+
+test('readVectorServerHealth probes VECTOR_URL health endpoint', async () => {
+  const seen: string[] = [];
+  const result = await readVectorServerHealth(async (input) => {
+    seen.push(String(input));
+    return Response.json({ status: 'ok', protocol: 'vector-proxy-v1', version: '1.0.0' });
+  }, { VECTOR_URL: 'http://vector.local:8081/root/' }, ['bun', 'src/server.ts']);
+
+  expect(seen).toEqual(['http://vector.local:8081/health']);
+  expect(result).toMatchObject({
+    configured: true,
+    status: 'ok',
+    url: 'http://vector.local:8081/root',
+    httpStatus: 200,
+    protocol: 'vector-proxy-v1',
+  });
+});


### PR DESCRIPTION
## Summary
- Added backend `/api/health` aggregation for the separate vector-server endpoint.
- Reports `vectorServer` as `ok`, `down`, or `unconfigured`, probing `VECTOR_URL` first and then vector proxy env aliases.
- Degrades aggregate health when a configured vector-server is down while preserving existing plugin aggregation.

## Validation
```bash
rtk bunx tsc --noEmit
rtk bun test tests/http/health/vector-server-aggregation.test.ts tests/http/health/plugin-status.test.ts tests/http/health/vector-details.test.ts src/routes/health/__tests__/health-vector-mode.test.ts src/vector/__tests__/proxy-server.test.ts
rtk git diff --check
rtk bash -lc 'git diff --name-only origin/alpha...HEAD | xargs wc -l'
```

## Issue
Refs #2227
