### PR TITLE
feat(plugins): toggle runtime MCP tools

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -90,6 +90,8 @@ subcommands, and plugin-owned sidecar servers.
 | --- | --- | --- | --- |
 | `GET` | `/api/plugins` | none | `{ plugins: PluginEntry[], dir?: string }` |
 | `GET` | `/api/plugins/:name` | plugin name | `application/wasm` bytes or `404` |
+| `PATCH` | `/api/plugins/:name/state` | `{ enabled: boolean }` | persists manifest state; runtime reload still required |
+| `POST` | `/api/plugins/:name/toggle` | `{ enabled?: boolean }` or empty body | persists state and reloads unified runtime MCP tools |
 
 ```ts
 type PluginEntry = {
@@ -105,6 +107,9 @@ Example:
 ```bash
 curl http://localhost:47778/api/plugins
 curl -o plugin.wasm http://localhost:47778/api/plugins/canvas-inspector
+curl -X POST http://localhost:47778/api/plugins/community-search/toggle \
+  -H 'content-type: application/json' \
+  -d '{"enabled":false}'
 ```
 
 ### Plugin-owned server endpoints

--- a/src/routes/plugins/index.ts
+++ b/src/routes/plugins/index.ts
@@ -4,11 +4,15 @@ import { createPluginsRegistryRoute, type PluginsRegistryRouteOptions } from './
 import { pluginGetByNameRoute } from './get-by-name.ts';
 import { pluginStateRoute } from './state.ts';
 import { canvasPluginRegistryRoute } from './canvas.ts';
+import { createPluginToggleRoute, type PluginToggleRouteOptions } from './toggle.ts';
 
-export function createPluginsRouter(options: PluginsRegistryRouteOptions = {}) {
+export type PluginsRouterOptions = PluginsRegistryRouteOptions & PluginToggleRouteOptions;
+
+export function createPluginsRouter(options: PluginsRouterOptions = {}) {
   return new Elysia()
     .use(createPluginsRegistryRoute(options))
     .use(pluginStateRoute)
+    .use(createPluginToggleRoute({ runtime: options.runtime }))
     .use(canvasPluginRegistryRoute)
     .use(pluginGetByNameRoute);
 }

--- a/src/routes/plugins/state.ts
+++ b/src/routes/plugins/state.ts
@@ -59,7 +59,7 @@ export function readPluginEnabled(name: string): boolean | undefined {
   return manifest.enabled !== false;
 }
 
-function writePluginEnabled(name: string, enabled: boolean) {
+export function writePluginEnabled(name: string, enabled: boolean) {
   const path = manifestPathFor(name);
   if (!path) return null;
   const manifest = readJson(path);

--- a/src/routes/plugins/toggle.ts
+++ b/src/routes/plugins/toggle.ts
@@ -1,0 +1,56 @@
+import { Elysia, t } from 'elysia';
+import type { UnifiedRuntime } from '../../plugins/unified-loader.ts';
+import { sanitizePluginName } from './model.ts';
+import { readPluginEnabled, writePluginEnabled } from './state.ts';
+
+export interface PluginToggleRouteOptions {
+  runtime?: Pick<UnifiedRuntime, 'mcpTools' | 'reload'>;
+}
+
+type ToggleBody = { enabled?: boolean } | undefined;
+
+function mcpToolNames(runtime: Pick<UnifiedRuntime, 'mcpTools'>, plugin: string): string[] {
+  return runtime.mcpTools
+    .filter((tool) => tool.plugin === plugin)
+    .map((tool) => tool.name)
+    .sort();
+}
+
+export function createPluginToggleRoute(options: PluginToggleRouteOptions = {}) {
+  return new Elysia().post(
+    '/api/plugins/:name/toggle',
+    async ({ params, body, set }) => {
+      if (!options.runtime) {
+        set.status = 503;
+        return { ok: false, error: 'plugin runtime unavailable' };
+      }
+      const requested = (body as ToggleBody)?.enabled;
+      const current = readPluginEnabled(params.name);
+      const nextEnabled = requested ?? !(current ?? true);
+      const result = writePluginEnabled(params.name, nextEnabled);
+      if (!result) {
+        set.status = 404;
+        return { ok: false, error: 'plugin manifest not found', name: sanitizePluginName(params.name) };
+      }
+      try {
+        await options.runtime.reload();
+      } catch (error) {
+        set.status = 500;
+        return {
+          ok: false,
+          plugin: result.name,
+          enabled: result.enabled,
+          error: 'plugin runtime reload failed',
+          message: error instanceof Error ? error.message : String(error),
+        };
+      }
+      const mcpTools = mcpToolNames(options.runtime, result.name);
+      return { ok: true, plugin: result.name, enabled: result.enabled, reloaded: true, mcpTools, mcpToolCount: mcpTools.length };
+    },
+    {
+      params: t.Object({ name: t.String({ minLength: 1 }) }),
+      body: t.Optional(t.Object({ enabled: t.Optional(t.Boolean()) })),
+      detail: { tags: ['plugins'], summary: 'Enable or disable a plugin and reload runtime MCP tools' },
+    },
+  );
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -188,7 +188,7 @@ const apiModules = [
   tracesApi,
   scheduleApi,
   filesRouter,
-  createPluginsRouter({ registry: unifiedPlugins.pluginRegistry }),
+  createPluginsRouter({ registry: unifiedPlugins.pluginRegistry, runtime: unifiedPlugins }),
   sessionsRoutes,
   vaultRoutes,
   metricsRoutes,

--- a/tests/http/plugins/toggle-mcp-runtime.test.ts
+++ b/tests/http/plugins/toggle-mcp-runtime.test.ts
@@ -1,0 +1,95 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Elysia } from 'elysia';
+import { loadUnifiedPlugins } from '../../../src/plugins/unified-loader.ts';
+import { createMcpRoutes } from '../../../src/routes/mcp/index.ts';
+import { createPluginsRouter } from '../../../src/routes/plugins/index.ts';
+import { pluginDir } from '../../plugins/_fixtures.ts';
+
+const tmp = mkdtempSync(join(tmpdir(), 'arra-plugin-toggle-runtime-'));
+const previousDirs = process.env.ARRA_PLUGIN_DIRS;
+process.env.ARRA_PLUGIN_DIRS = tmp;
+
+afterAll(() => {
+  if (previousDirs === undefined) delete process.env.ARRA_PLUGIN_DIRS;
+  else process.env.ARRA_PLUGIN_DIRS = previousDirs;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function postToggle(app: Elysia, name: string, body?: Record<string, unknown>) {
+  return app.handle(new Request(`http://local/api/plugins/${name}/toggle`, {
+    method: 'POST',
+    headers: body ? { 'content-type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  }));
+}
+
+function toolNames(runtime: Awaited<ReturnType<typeof loadUnifiedPlugins>>): string[] {
+  return runtime.mcpTools.map((tool) => tool.name).sort();
+}
+
+async function listedPluginTools(app: Elysia): Promise<string[]> {
+  const response = await app.handle(new Request('http://local/api/mcp/tools'));
+  const body = await response.json() as { tools: Array<{ name: string; source: string }> };
+  return body.tools.filter((tool) => tool.source === 'plugin').map((tool) => tool.name).sort();
+}
+
+describe('POST /api/plugins/:name/toggle', () => {
+  test('plugs MCP tools out and back in through the existing runtime', async () => {
+    const dir = pluginDir(tmp, 'toggle-runtime', {
+      mcpTools: [{ name: 'oracle_toggle_runtime', description: 'Toggle runtime tool', inputSchema: {}, handler: 'tool' }],
+    }, "export function tool(ctx) { return { ok: true, body: { plugin: ctx.plugin, args: ctx.body } }; }\n");
+    const runtime = await loadUnifiedPlugins({ dirs: [tmp] });
+    const app = new Elysia()
+      .use(createPluginsRouter({ dir: tmp, registry: runtime.pluginRegistry, runtime }))
+      .use(createMcpRoutes(runtime.mcpTools));
+
+    expect(toolNames(runtime)).toEqual(['oracle_toggle_runtime']);
+    expect(await listedPluginTools(app)).toEqual(['oracle_toggle_runtime']);
+
+    const offResponse = await postToggle(app, 'toggle-runtime', { enabled: false });
+    expect(offResponse.status).toBe(200);
+    expect(await offResponse.json()).toMatchObject({
+      ok: true,
+      plugin: 'toggle-runtime',
+      enabled: false,
+      reloaded: true,
+      mcpTools: [],
+      mcpToolCount: 0,
+    });
+    expect(JSON.parse(readFileSync(join(dir, 'plugin.json'), 'utf8')).enabled).toBe(false);
+    expect(toolNames(runtime)).toEqual([]);
+    expect(await listedPluginTools(app)).toEqual([]);
+    expect(await runtime.callMcpTool('oracle_toggle_runtime', {})).toEqual({
+      ok: false,
+      error: 'MCP tool not found: oracle_toggle_runtime',
+    });
+
+    const onResponse = await postToggle(app, 'toggle-runtime', { enabled: true });
+    expect(onResponse.status).toBe(200);
+    expect(await onResponse.json()).toMatchObject({
+      ok: true,
+      plugin: 'toggle-runtime',
+      enabled: true,
+      mcpTools: ['oracle_toggle_runtime'],
+      mcpToolCount: 1,
+    });
+    expect(toolNames(runtime)).toEqual(['oracle_toggle_runtime']);
+    expect(await listedPluginTools(app)).toEqual(['oracle_toggle_runtime']);
+    expect(await runtime.callMcpTool('oracle_toggle_runtime', { q: 'again' })).toEqual({
+      ok: true,
+      body: { plugin: 'toggle-runtime', args: { q: 'again' } },
+    });
+  });
+
+  test('returns 404 for missing plugin manifests', async () => {
+    const runtime = await loadUnifiedPlugins({ dirs: [tmp] });
+    const app = new Elysia().use(createPluginsRouter({ dir: tmp, registry: runtime.pluginRegistry, runtime }));
+    const response = await postToggle(app, 'missing-plugin', { enabled: false });
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toMatchObject({ ok: false, error: 'plugin manifest not found', name: 'missing-plugin' });
+  });
+});


### PR DESCRIPTION
## Summary

- Added `POST /api/plugins/:name/toggle` for runtime plugin enable/disable.
- Persists the plugin manifest state and calls `UnifiedRuntime.reload()` so MCP tools plug in/out without recreating the server runtime.
- Wires the server plugins router to the shared unified runtime and documents the new API.

## Validation

```bash
bunx tsc --noEmit
bun test tests/http/plugins/ tests/plugins/unified-loader-reloads-mcp-tools.test.ts tests/plugins/unified-loader-call-mcp-tool.test.ts tests/http/mcp/tools.test.ts
git diff --check origin/alpha...HEAD
git diff --name-only origin/alpha...HEAD | xargs wc -l
```

## Notes

- The endpoint targets runtime MCP tool availability through the existing unified-loader reload path.
- Plugin API routes are still Elysia-mounted at server boot; this slice does not remount plugin HTTP routes.
