### PR TITLE
feat: add federation capability provider

### DIFF
--- a/src/federation/__tests__/capability-provider.test.ts
+++ b/src/federation/__tests__/capability-provider.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  FederationCapabilityProvider,
+  createDefaultFederationProvider,
+} from '../capability-provider.ts';
+
+const fixedClock = () => new Date('2026-06-17T00:00:00.000Z');
+
+describe('FederationCapabilityProvider', () => {
+  test('registers normalized mesh nodes and aggregates active capabilities', () => {
+    const provider = new FederationCapabilityProvider({ clock: fixedClock });
+    const node = provider.registerNode({
+      id: ' EDGE-1 ',
+      name: 'Edge relay',
+      url: 'https://relay.example.test/root/?secret=1#frag',
+      capabilities: ['Maw:Hey', 'maw:peek', 'maw:hey'],
+      metadata: { role: 'relay', '': 'drop' },
+    });
+
+    expect(node).toMatchObject({
+      id: 'edge-1',
+      name: 'Edge relay',
+      url: 'https://relay.example.test/root',
+      capabilities: ['maw:hey', 'maw:peek'],
+      metadata: { role: 'relay' },
+      status: 'active',
+      registeredAt: '2026-06-17T00:00:00.000Z',
+      updatedAt: '2026-06-17T00:00:00.000Z',
+    });
+    expect(provider.status()).toMatchObject({
+      nodes: 1,
+      activeNodes: 1,
+      capabilities: ['maw:hey', 'maw:peek'],
+    });
+  });
+
+  test('updates an existing node while preserving registration time', () => {
+    let now = new Date('2026-06-17T00:00:00.000Z');
+    const provider = new FederationCapabilityProvider({ clock: () => now });
+    provider.registerNode({ id: 'node-a', url: 'http://127.0.0.1:3456', capabilities: ['maw:hey'] });
+    now = new Date('2026-06-17T01:00:00.000Z');
+
+    const updated = provider.registerNode({
+      id: 'node-a',
+      url: 'http://127.0.0.1:3457/',
+      capabilities: ['federation:status'],
+      status: 'disabled',
+    });
+
+    expect(updated.registeredAt).toBe('2026-06-17T00:00:00.000Z');
+    expect(updated.updatedAt).toBe('2026-06-17T01:00:00.000Z');
+    expect(provider.status()).toMatchObject({ nodes: 1, activeNodes: 0, capabilities: [] });
+  });
+
+  test('rejects unsafe identifiers, endpoints, and capability names', () => {
+    const provider = new FederationCapabilityProvider();
+    expect(() => provider.registerNode({ id: '../bad', url: 'https://node.example' })).toThrow('mesh node id');
+    expect(() => provider.registerNode({ id: 'good', url: 'file:///tmp/node' })).toThrow('http(s)');
+    expect(() => provider.registerNode({
+      id: 'good',
+      url: 'https://node.example',
+      capabilities: ['bad space'],
+    })).toThrow('invalid federation capability');
+  });
+
+  test('creates a local backend node from runtime env defaults', () => {
+    const provider = createDefaultFederationProvider({
+      ORACLE_HTTP_URL: ' https://oracle.example/api?drop=1 ',
+    });
+
+    expect(provider.listNodes()[0]).toMatchObject({
+      id: 'local-oracle',
+      url: 'https://oracle.example/api',
+      metadata: { role: 'backend', source: 'maw-arra-plugin' },
+    });
+    expect(provider.capabilities()).toContain('federation:mesh-register');
+    expect(provider.capabilities()).toContain('vector:proxy');
+  });
+});

--- a/src/federation/capability-provider.ts
+++ b/src/federation/capability-provider.ts
@@ -1,0 +1,147 @@
+export type MeshNodeStatus = 'active' | 'disabled';
+
+export interface MeshNodeInput {
+  id?: string;
+  name?: string;
+  url: string;
+  capabilities?: string[];
+  metadata?: Record<string, unknown>;
+  status?: MeshNodeStatus;
+}
+
+export interface MeshNode {
+  id: string;
+  name: string;
+  url: string;
+  capabilities: string[];
+  metadata: Record<string, unknown>;
+  status: MeshNodeStatus;
+  registeredAt: string;
+  updatedAt: string;
+}
+
+export interface FederationStatus {
+  ok: true;
+  provider: 'arra-oracle-federation';
+  nodes: number;
+  activeNodes: number;
+  capabilities: string[];
+}
+
+const NODE_ID = /^[a-z0-9][a-z0-9._:-]{0,127}$/i;
+const CAPABILITY = /^[a-z][a-z0-9._-]*(?::[a-z0-9._-]+)*$/i;
+
+export const DEFAULT_FEDERATION_CAPABILITIES = [
+  'maw:hey',
+  'maw:peek',
+  'federation:status',
+  'federation:mesh-register',
+] as const;
+
+function normalizeId(value: string): string {
+  const id = value.trim().toLowerCase();
+  if (!NODE_ID.test(id)) throw new Error('mesh node id must be 1-128 letters, numbers, dot, underscore, colon, or dash');
+  return id;
+}
+
+function idFromUrl(url: string): string {
+  const parsed = new URL(url);
+  return normalizeId(parsed.hostname.replace(/[^a-z0-9._:-]+/gi, '-').replace(/^-+|-+$/g, '') || 'mesh-node');
+}
+
+function normalizeUrl(value: string): string {
+  const url = new URL(value.trim());
+  if (!['http:', 'https:'].includes(url.protocol)) throw new Error('mesh node url must be http(s)');
+  url.username = '';
+  url.password = '';
+  url.hash = '';
+  url.search = '';
+  url.pathname = url.pathname.replace(/\/+$/, '');
+  return url.toString().replace(/\/+$/, '');
+}
+
+function normalizeCapabilities(values: readonly string[] | undefined): string[] {
+  const input = values?.length ? values : DEFAULT_FEDERATION_CAPABILITIES;
+  const out = new Set<string>();
+  for (const value of input) {
+    const capability = value.trim().toLowerCase();
+    if (!CAPABILITY.test(capability)) throw new Error(`invalid federation capability: ${JSON.stringify(value)}`);
+    out.add(capability);
+  }
+  return [...out].sort();
+}
+
+function cleanMetadata(value: Record<string, unknown> | undefined): Record<string, unknown> {
+  if (!value) return {};
+  return Object.fromEntries(
+    Object.entries(value).filter(([key]) => key.trim().length > 0),
+  );
+}
+
+export class FederationCapabilityProvider {
+  private readonly nodes = new Map<string, MeshNode>();
+  private readonly clock: () => Date;
+
+  constructor(options: { self?: MeshNodeInput; clock?: () => Date } = {}) {
+    this.clock = options.clock ?? (() => new Date());
+    if (options.self) this.registerNode(options.self);
+  }
+
+  registerNode(input: MeshNodeInput): MeshNode {
+    const url = normalizeUrl(input.url);
+    const id = normalizeId(input.id ?? idFromUrl(url));
+    const existing = this.nodes.get(id);
+    const now = this.clock().toISOString();
+    const node: MeshNode = {
+      id,
+      name: input.name?.trim() || existing?.name || id,
+      url,
+      capabilities: normalizeCapabilities(input.capabilities),
+      metadata: cleanMetadata(input.metadata),
+      status: input.status ?? existing?.status ?? 'active',
+      registeredAt: existing?.registeredAt ?? now,
+      updatedAt: now,
+    };
+    this.nodes.set(id, node);
+    return { ...node, capabilities: [...node.capabilities], metadata: { ...node.metadata } };
+  }
+
+  listNodes(): MeshNode[] {
+    return [...this.nodes.values()]
+      .sort((a, b) => a.id.localeCompare(b.id))
+      .map((node) => ({ ...node, capabilities: [...node.capabilities], metadata: { ...node.metadata } }));
+  }
+
+  capabilities(): string[] {
+    const capabilities = new Set<string>();
+    for (const node of this.nodes.values()) {
+      if (node.status === 'active') for (const capability of node.capabilities) capabilities.add(capability);
+    }
+    return [...capabilities].sort();
+  }
+
+  status(): FederationStatus {
+    const nodes = this.listNodes();
+    return {
+      ok: true,
+      provider: 'arra-oracle-federation',
+      nodes: nodes.length,
+      activeNodes: nodes.filter((node) => node.status === 'active').length,
+      capabilities: this.capabilities(),
+    };
+  }
+}
+
+export function createDefaultFederationProvider(env: Record<string, string | undefined> = process.env) {
+  const port = env.ORACLE_PORT || env.PORT || '47778';
+  const url = env.ORACLE_HTTP_URL || env.ORACLE_API || `http://127.0.0.1:${port}`;
+  return new FederationCapabilityProvider({
+    self: {
+      id: 'local-oracle',
+      name: 'Local Arra Oracle',
+      url,
+      capabilities: [...DEFAULT_FEDERATION_CAPABILITIES, 'mcp:tools', 'vector:proxy'],
+      metadata: { role: 'backend', source: 'maw-arra-plugin' },
+    },
+  });
+}

--- a/src/routes/federation/index.ts
+++ b/src/routes/federation/index.ts
@@ -1,0 +1,59 @@
+import { Elysia, t } from 'elysia';
+import {
+  createDefaultFederationProvider,
+  FederationCapabilityProvider,
+  type MeshNodeInput,
+} from '../../federation/capability-provider.ts';
+
+const MeshNodeBody = t.Object({
+  id: t.Optional(t.String()),
+  name: t.Optional(t.String()),
+  url: t.String({ minLength: 1 }),
+  capabilities: t.Optional(t.Array(t.String())),
+  metadata: t.Optional(t.Record(t.String(), t.Unknown())),
+  status: t.Optional(t.Union([t.Literal('active'), t.Literal('disabled')])),
+});
+
+function failure(error: unknown, set: { status?: unknown }) {
+  set.status = 400;
+  return {
+    success: false,
+    error: error instanceof Error ? error.message : String(error),
+  };
+}
+
+export function createFederationRoutes(
+  provider: FederationCapabilityProvider = createDefaultFederationProvider(),
+) {
+  return new Elysia({ prefix: '/api/federation' })
+    .get('/status', () => provider.status(), {
+      detail: { tags: ['federation'], summary: 'Federation capability provider status' },
+    })
+    .get('/capabilities', () => ({
+      capabilities: provider.capabilities(),
+      nodes: provider.listNodes().length,
+    }), {
+      detail: { tags: ['federation'], summary: 'List active federation capabilities' },
+    })
+    .get('/mesh/nodes', () => {
+      const nodes = provider.listNodes();
+      return { count: nodes.length, nodes };
+    }, {
+      detail: { tags: ['federation'], summary: 'List registered mesh nodes' },
+    })
+    .post('/mesh/nodes/register', ({ body, set }) => {
+      try {
+        return {
+          success: true,
+          node: provider.registerNode(body as MeshNodeInput),
+        };
+      } catch (error) {
+        return failure(error, set);
+      }
+    }, {
+      body: MeshNodeBody,
+      detail: { tags: ['federation'], summary: 'Register or update one federation mesh node' },
+    });
+}
+
+export const federationRoutes = createFederationRoutes();

--- a/src/server/__tests__/server-plugin-loader.test.ts
+++ b/src/server/__tests__/server-plugin-loader.test.ts
@@ -105,13 +105,32 @@ describe('server plugin loader', () => {
     })).toThrow('Cannot disable core server plugin "search"');
   });
 
-  test('federation routes are not part of the builtin app surface', async () => {
+  test('federation capability provider is opt-in and registers mesh nodes', async () => {
+    const disabled = await appWithConfig([]);
+    expect(disabled.enabled.some((plugin) => plugin.name === 'federation')).toBe(false);
+    expect((await disabled.app.handle(new Request('http://local/api/federation/status'))).status).toBe(404);
+
     const { app, enabled } = await appWithConfig([], ['federation']);
-    expect(enabled.some((plugin) => plugin.name === 'federation')).toBe(false);
-    expect((await app.handle(new Request('http://local/info'))).status).toBe(404);
-    expect((await app.handle(new Request('http://local/api/identity'))).status).toBe(404);
-    expect((await app.handle(new Request('http://local/api/peers'))).status).toBe(404);
-    expect((await app.handle(new Request('http://local/api/health'))).status).toBe(200);
+    expect(enabled.some((plugin) => plugin.name === 'federation')).toBe(true);
+    const status = await app.handle(new Request('http://local/api/federation/status'));
+    expect(status.status).toBe(200);
+    expect(await status.json()).toMatchObject({
+      ok: true,
+      provider: 'arra-oracle-federation',
+      activeNodes: 1,
+    });
+
+    const registered = await app.handle(new Request('http://local/api/federation/mesh/nodes/register', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        id: 'mesh-relay',
+        url: 'https://relay.example.test',
+        capabilities: ['maw:hey', 'maw:peek'],
+      }),
+    }));
+    expect(registered.status).toBe(200);
+    expect(await registered.json()).toMatchObject({ success: true, node: { id: 'mesh-relay' } });
   });
 
   test('api manifest mounts a built-in example plugin under its declared path', async () => {

--- a/src/server/plugin/builtin.ts
+++ b/src/server/plugin/builtin.ts
@@ -22,6 +22,7 @@ import { pluginsRouter } from '../../routes/plugins/index.ts';
 import { sessionsRoutes } from '../../routes/sessions/index.ts';
 import { vaultRoutes } from '../../routes/vault/index.ts';
 import { createMenuRoutes } from '../../routes/menu/index.ts';
+import { createFederationRoutes } from '../../routes/federation/index.ts';
 import { gatewayPlugin } from '../../gateway/index.ts';
 
 interface BuiltinOptions {
@@ -34,8 +35,9 @@ function routePlugin(
   tier: ServerPlugin['tier'],
   routes: ServerPlugin['routes'],
   seedMenu = true,
+  enabled?: boolean,
 ): ServerPlugin {
-  return { name, tier, routes, seedMenu };
+  return { name, tier, routes, seedMenu, enabled };
 }
 
 async function optionalIndexerPlugin(): Promise<ServerPlugin | null> {
@@ -70,6 +72,7 @@ export async function createBuiltinServerPlugins(options: BuiltinOptions): Promi
   const unifiedManifestPlugins = await createUnifiedManifestServerPlugins();
   const plugins: Array<ServerPlugin | null> = [
     routePlugin('gateway', 'standard', () => gatewayRoutes, false),
+    routePlugin('federation', 'extra', () => createFederationRoutes(), false, false),
     createApiManifestExamplePlugin(),
     routePlugin('health', 'core', () => createHealthRoutes()),
     routePlugin('search', 'core', () => searchRoutes),

--- a/tests/http/federation/capability-provider.test.ts
+++ b/tests/http/federation/capability-provider.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { FederationCapabilityProvider } from '../../../src/federation/capability-provider.ts';
+import { createFederationRoutes } from '../../../src/routes/federation/index.ts';
+
+function createFetch() {
+  const provider = new FederationCapabilityProvider({
+    self: {
+      id: 'local-oracle',
+      url: 'http://127.0.0.1:47778',
+      capabilities: ['maw:hey', 'federation:status'],
+    },
+  });
+  const app = new Elysia().use(createFederationRoutes(provider));
+  return (request: Request) => app.handle(request);
+}
+
+async function json(res: Response) {
+  return JSON.parse(await res.text());
+}
+
+describe('federation capability HTTP routes', () => {
+  test('reports provider status and active capabilities', async () => {
+    const fetcher = createFetch();
+
+    const status = await fetcher(new Request('http://local/api/federation/status'));
+    const capabilities = await fetcher(new Request('http://local/api/federation/capabilities'));
+
+    expect(status.status).toBe(200);
+    expect(await json(status)).toMatchObject({
+      ok: true,
+      provider: 'arra-oracle-federation',
+      nodes: 1,
+      activeNodes: 1,
+      capabilities: ['federation:status', 'maw:hey'],
+    });
+    expect(await json(capabilities)).toEqual({
+      nodes: 1,
+      capabilities: ['federation:status', 'maw:hey'],
+    });
+  });
+
+  test('registers and updates mesh nodes', async () => {
+    const fetcher = createFetch();
+    const body = {
+      id: 'edge-relay',
+      name: 'Edge Relay',
+      url: 'https://relay.example.test/root/?drop=1',
+      capabilities: ['maw:peek', 'mcp:tools'],
+      metadata: { tunnel: 'cloudflared' },
+    };
+
+    const registered = await fetcher(new Request('http://local/api/federation/mesh/nodes/register', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }));
+    const listed = await fetcher(new Request('http://local/api/federation/mesh/nodes'));
+
+    expect(registered.status).toBe(200);
+    expect(await json(registered)).toMatchObject({
+      success: true,
+      node: {
+        id: 'edge-relay',
+        name: 'Edge Relay',
+        url: 'https://relay.example.test/root',
+        capabilities: ['maw:peek', 'mcp:tools'],
+      },
+    });
+    expect(await json(listed)).toMatchObject({
+      count: 2,
+      nodes: [
+        { id: 'edge-relay', metadata: { tunnel: 'cloudflared' } },
+        { id: 'local-oracle' },
+      ],
+    });
+  });
+
+  test('rejects invalid mesh node registration', async () => {
+    const response = await createFetch()(new Request('http://local/api/federation/mesh/nodes/register', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id: '../bad', url: 'https://relay.example.test' }),
+    }));
+
+    expect(response.status).toBe(400);
+    expect(await json(response)).toMatchObject({ success: false, error: expect.stringContaining('mesh node id') });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a federation capability provider for mesh node registration and capability aggregation.
- Adds opt-in `federation` server plugin (`enabled: false`) so the backend stays unchanged by default but can expose `/api/federation/*` when explicitly enabled.
- Adds HTTP routes for:
  - `GET /api/federation/status`
  - `GET /api/federation/capabilities`
  - `GET /api/federation/mesh/nodes`
  - `POST /api/federation/mesh/nodes/register`
- Updates the server plugin loader test from “federation absent” to “federation is opt-in and can register mesh nodes.”
- Merged current `origin/alpha` normally before PR; no force push.

## Validation
```bash
bunx tsc --noEmit
bun test src/federation/__tests__/capability-provider.test.ts tests/http/federation/capability-provider.test.ts src/server/__tests__/server-plugin-loader.test.ts
git diff --check origin/alpha...HEAD
git diff --name-only origin/alpha...HEAD | xargs wc -l
```

- Scoped tests: 15 pass / 0 fail / 36 expects
- File sizes:
  - `src/federation/capability-provider.ts` 147 lines
  - `src/routes/federation/index.ts` 59 lines
  - `tests/http/federation/capability-provider.test.ts` 89 lines
  - `src/federation/__tests__/capability-provider.test.ts` 79 lines
  - `src/server/__tests__/server-plugin-loader.test.ts` 174 lines
  - `src/server/plugin/builtin.ts` 103 lines
- GitHub checks: Typecheck and scoped tests ✅, GitGuardian ✅
- PR is mergeable against `alpha`

Refs #2227
