### PR TITLE
fix: add project-safe MCP launcher

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,7 +3,10 @@
     "arra-oracle": {
       "type": "stdio",
       "command": "bun",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/src/index.ts"],
+      "args": [
+        "-e",
+        "const { join } = await import('node:path'); const { pathToFileURL } = await import('node:url'); const root = process.env.CLAUDE_PLUGIN_ROOT || process.cwd(); const mod = await import(pathToFileURL(join(root, 'bin/mcp.ts')).href); await mod.main();"
+      ],
       "env": {}
     }
   }

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ bun test tests/http/health/
 bun run src/cli/index.ts health
 ```
 
+Claude Code project scope: open this clone directly and the checked-in `.mcp.json`
+starts `bin/mcp.ts`, which resolves this repo without `CLAUDE_PLUGIN_ROOT`.
+
 Run the React Studio UI:
 
 ```bash

--- a/bin/mcp.ts
+++ b/bin/mcp.ts
@@ -1,0 +1,33 @@
+#!/usr/bin/env bun
+/** Claude MCP launcher that works from project and plugin scopes. */
+
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export function launcherRoot(metaUrl = import.meta.url): string {
+  return dirname(dirname(Bun.fileURLToPath(metaUrl)));
+}
+
+export function mcpEntrypoint(root = launcherRoot()): string {
+  return join(root, 'src', 'index.ts');
+}
+
+export async function main(args = process.argv.slice(2)): Promise<void> {
+  const root = launcherRoot();
+  const entry = mcpEntrypoint(root);
+  if (args.includes('--resolve-entry')) {
+    console.log(entry);
+    return;
+  }
+  if (!existsSync(entry)) throw new Error(`MCP entrypoint not found: ${entry}`);
+  process.env.ORACLE_REPO_ROOT ||= root;
+  const mod = await import(pathToFileURL(entry).href) as { main?: () => Promise<void> };
+  if (typeof mod.main !== 'function') throw new Error(`MCP entrypoint has no main(): ${entry}`);
+  await mod.main();
+}
+
+if (import.meta.main) main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exit(1);
+});

--- a/tests/mcp/project-scope-config.test.ts
+++ b/tests/mcp/project-scope-config.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+import { launcherRoot, mcpEntrypoint } from '../../bin/mcp.ts';
+
+const repoRoot = process.cwd();
+
+describe('project-scope MCP launcher config', () => {
+  test('.mcp.json does not require CLAUDE_PLUGIN_ROOT interpolation', async () => {
+    const config = await Bun.file('.mcp.json').json() as any;
+    const server = config.mcpServers['arra-oracle'];
+    expect(server.command).toBe('bun');
+    expect(JSON.stringify(server.args)).not.toContain('CLAUDE_PLUGIN_ROOT}');
+    expect(server.args.join(' ')).toContain('bin/mcp.ts');
+  });
+
+  test('launcher resolves the repo-local MCP entrypoint from its own directory', () => {
+    expect(launcherRoot()).toBe(repoRoot);
+    expect(mcpEntrypoint()).toBe(join(repoRoot, 'src', 'index.ts'));
+  });
+
+  test('fresh project clone can resolve entry without plugin env', async () => {
+    const proc = Bun.spawn(['bun', 'bin/mcp.ts', '--resolve-entry'], {
+      cwd: repoRoot,
+      env: { ...process.env, CLAUDE_PLUGIN_ROOT: undefined },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const [exitCode, stdout, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    expect(stderr).toBe('');
+    expect(exitCode).toBe(0);
+    expect(stdout.trim()).toBe(join(repoRoot, 'src', 'index.ts'));
+  });
+});


### PR DESCRIPTION
## Summary
- Added `bin/mcp.ts`, a small MCP launcher that resolves the repo root from its own file location.
- Updated `.mcp.json` to avoid `${CLAUDE_PLUGIN_ROOT}` interpolation and use the launcher from plugin or project scope.
- Documented project-scope Claude Code setup in README.
- Added tests for the project-scope config and no-env fresh clone launcher path.

## Validation
```bash
rtk bunx tsc --noEmit
rtk bun test tests/mcp/project-scope-config.test.ts src/integration/mcp.test.ts
rtk git diff --check
rtk bash -lc 'git diff --name-only origin/alpha...HEAD | xargs wc -l'
```

## Issue
Closes #2249
