### PR TITLE
docs: add Claude Code MCP quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ bunx tsc --noEmit
 bun run server                 # HTTP API on http://localhost:47778
 ```
 
+### Add Oracle MCP to Claude Code
+From a clone, use repo cwd instead of `${CLAUDE_PLUGIN_ROOT}`:
+```bash
+claude mcp add arra-oracle --cwd "$PWD" -- bun src/index.ts
+```
+Project `.mcp.json` equivalent:
+```json
+{"mcpServers":{"arra-oracle":{"type":"stdio","command":"bun","args":["src/index.ts"],"env":{"ORACLE_LOG_TARGET":"stderr"}}}}
+```
+
 Useful checks:
 
 ```bash


### PR DESCRIPTION
## Summary
- add a README Quick start section for adding Oracle MCP to Claude Code
- include the `claude mcp add` command for cloned-project use with repo cwd
- include a project `.mcp.json` equivalent using `bun src/index.ts` without touching the checked-in `.mcp.json` file

## Validation
```bash
bunx tsc --noEmit
bun test tests/docs/vercel-deploy-docs.test.ts tests/docs/modular-backend-architecture.test.ts
git diff --check origin/alpha..HEAD
wc -l README.md
```

Refs #2249