### PR TITLE
docs: clarify proxy terminology for modular backend

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ is linked here; keep new docs in the right section when adding files.
 | [FAQ.md](./FAQ.md) | Answer common operator and contributor questions | install path, binaries, data, vectors, tenants |
 | [architecture.md](./architecture.md) | Understand the installable runtime architecture | HTTP, MCP, CLI, plugins, storage |
 | [architecture/modular-backend.md](./architecture/modular-backend.md) | Modular backend target: CF Workers edge, maw plugin backend, vector server, MCP plugins. |
+| [architecture/proxy-terminology.md](./architecture/proxy-terminology.md) | Disambiguate request-tier, storage-tier, and manifest passthrough proxy meanings. |
 | [PLUGIN-GUIDE.md](./PLUGIN-GUIDE.md) | Author installable Oracle plugins | `plugin.json`, CLI/MCP/menu/API surfaces |
 | [API-REFERENCE-INDEX.md](./API-REFERENCE-INDEX.md) | Choose the right API reference | `/api/docs`, `openapi.json`, route family map |
 

--- a/docs/architecture/modular-backend-current-state.md
+++ b/docs/architecture/modular-backend-current-state.md
@@ -105,6 +105,9 @@ Capabilities present:
 - `ProxyVectorAdapter` implements the standard proxy protocol:
   `POST /vectors/add`, `POST /vectors/query`, `GET /vectors/stats`,
   `DELETE /vectors/collection`, and `GET /health`.
+- `ProxyVectorAdapter` and `TurboVecAdapter` are external-only client adapters:
+  they require an already running remote service and do not create local vector
+  storage or sidecar processes.
 - Tenant IDs flow to proxy vector requests through tenant headers.
 - `proxyVectorSidecarRequest()` can expose vector sidecar proxy routes from the
   same manifest shape used by unified proxy routes.
@@ -116,6 +119,9 @@ Gaps:
 - Separate vector server process orchestration is present as config/protocol
   contracts, but end-to-end backend -> vector-server deployment is not the
   default happy path yet.
+- The word `proxy` is overloaded. See
+  [`proxy-terminology.md`](./proxy-terminology.md) before changing gateway,
+  vector adapter, or plugin manifest passthrough behavior.
 
 ## MCP state
 

--- a/docs/architecture/modular-backend.md
+++ b/docs/architecture/modular-backend.md
@@ -90,6 +90,11 @@ aliases. The backend remains responsible for tenant headers, timeout policy, and
 fallback behavior; the vector server remains responsible for collection-specific
 storage/search.
 
+Terminology note: `proxy` can mean the request-tier `gatewayPlugin()` route
+proxy, the storage-tier vector proxy adapter, or plugin manifest passthrough
+routes. See [`proxy-terminology.md`](./proxy-terminology.md) for the required
+qualified names and external-only adapter labels.
+
 ## Layer 4: MCP plugin system
 
 MCP tools are a runtime projection of plugin packages, not a hardcoded edge list.

--- a/docs/architecture/proxy-terminology.md
+++ b/docs/architecture/proxy-terminology.md
@@ -1,0 +1,38 @@
+# Proxy terminology (#2227)
+
+`proxy` names three different seams in Arra Oracle. Use the qualified term
+below in issues, PRs, and docs so storage changes do not get confused with HTTP
+gateway or plugin passthrough work.
+
+## The three proxy meanings
+
+| Qualified term | Code surface | Config surface | Meaning | Not this |
+| --- | --- | --- | --- | --- |
+| **Request-tier gateway proxy** | `gatewayPlugin()` in `src/gateway/index.ts` | `VECTOR_URL` or `oracle-gateway.json` | Proxies selected incoming HTTP API routes to another service before local Elysia routes run. `VECTOR_URL` synthesizes routes such as `/api/search`, `/api/vector/**`, `/api/map`, and `/api/map3d`. | It does not select a `VectorStoreAdapter`, implement `/vectors/*`, or mean plugin `proxy[]`. |
+| **Storage-tier vector proxy adapter** | `ProxyVectorAdapter` and `TurboVecAdapter` | `ORACLE_VECTOR_DB=proxy`, `ORACLE_PROXY_VECTOR_URL`, `VECTOR_DB_URL`, `ORACLE_TURBOVEC_URL`, or collection `service` endpoint | Makes backend vector calls to an external vector service using the vector protocol: `GET /health`, `POST /vectors/add`, `POST /vectors/query`, `GET /vectors/stats`, `DELETE /vectors/collection`. | It does not route browser/API requests and does not create local storage. |
+| **Manifest passthrough proxy** | `plugin.json` `proxy[]`, `createUnifiedProxyRoute()`, `proxyRequestForManifest()` | `targetEnv`, `path`, `methods`, `stripPrefix` in a plugin manifest | Adds a plugin-owned HTTP passthrough route that forwards matching requests to a target URL from an env var. | It does not imply vector storage, `VECTOR_URL`, or automatic service discovery. |
+
+## External-only adapter labels
+
+The `proxy` and `turbovec` vector adapters are **external-only client
+adapters**:
+
+- they require an already running remote service;
+- they do not open LanceDB, SQLite, or local vector files;
+- they do not start TurboVec or any sidecar process;
+- they only speak the documented vector HTTP protocol;
+- collection export/map/map3d features need explicit remote protocol support
+  before treating these adapters as primary full-store replacements.
+
+Use `external-only` in docs or UI labels when an operator must provide the
+remote endpoint. Use `embedded` only for adapters that can own their storage in
+the Arra backend process.
+
+## Decision checklist
+
+- Are you forwarding **incoming `/api/*` requests** to another HTTP service?
+  Use **request-tier gateway proxy**.
+- Are you making **vector store calls** from backend code to a vector service?
+  Use **storage-tier vector proxy adapter**.
+- Are you exposing a **plugin-declared passthrough route**?
+  Use **manifest passthrough proxy**.


### PR DESCRIPTION
## Summary

- Added `docs/architecture/proxy-terminology.md` to name the three #2227 proxy meanings:
  - request-tier `gatewayPlugin()` / `VECTOR_URL`
  - storage-tier `ProxyVectorAdapter` / `TurboVecAdapter`
  - plugin manifest `proxy[]` passthrough
- Marked `proxy` and `turbovec` vector adapters as external-only client adapters.
- Linked the terminology guide from the modular backend docs and docs index.

## Validation

```bash
bunx tsc --noEmit
bun test tests/docs/modular-backend-architecture.test.ts
git diff --check origin/alpha...HEAD
git diff --name-only origin/alpha...HEAD | xargs wc -l
```

## Notes

- Docs-only Slice 0b; no runtime behavior changed.
