### PR TITLE
feat: add in-process maw serve mode

### DIFF
--- a/maw-plugin/__tests__/index.test.ts
+++ b/maw-plugin/__tests__/index.test.ts
@@ -60,7 +60,7 @@ describe('maw arra plugin', () => {
     expect(help.output).toContain('enabled <true|false>');
     expect(help.output).toContain('trace_chain');
     expect(help.output).toContain('thread_update');
-    expect(help.output).toContain('serve [--backend] [--stop|--status] [--port N]');
+    expect(help.output).toContain('serve [--backend] [--in-process] [--stop|--status] [--port N]');
     expect(help.output).toContain('schedule-add');
     expect(help.output).toContain('vault-sync');
     expect(help.output).toContain('verify');

--- a/maw-plugin/__tests__/serve.test.ts
+++ b/maw-plugin/__tests__/serve.test.ts
@@ -48,6 +48,25 @@ describe('maw arra serve command', () => {
     })]);
   });
 
+
+  test('starts optional in-process backend without spawning manifest command', async () => {
+    const started: unknown[] = [];
+    const result = await runServe({ pos: [], flags: { in_process: true, port: '47780' } }, runner, env(), {
+      isAlive: () => false,
+      start: () => { throw new Error('spawn should not be used for --in-process'); },
+      inProcessStart: async (root, startEnv) => {
+        started.push({ root, port: startEnv.ORACLE_PORT, source: startEnv.ARRA_BACKEND_SOURCE });
+        return { pid: 24601, port: '47780', healthPath: '/api/health' };
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain('started pid=24601 port=47780');
+    expect(result.output).toContain('mode: in-process');
+    expect(result.output).not.toContain('command:');
+    expect(started).toEqual([{ root: '/repo/arra-oracle-v3', port: '47780', source: 'maw-plugin' }]);
+  });
+
   test('supports positional start stop status actions', async () => {
     const home = env();
     let alive = true;

--- a/maw-plugin/index.ts
+++ b/maw-plugin/index.ts
@@ -177,7 +177,7 @@ export const COMMANDS: Record<string, Spec> = {
   verify: { tool: 'oracle_verify', method: 'POST', write: true, help: 'verify [--check true|false] [--type all|learning|pattern]', build: p => route('/api/verify', undefined, { check: b(p, 'check'), type: f(p, 'type') }), format: d => `arra verify: ${preview(d, 500)}` },
 };
 
-const LOCAL_COMMANDS = { commands: 'commands', mcp_call: MCP_CLIENT_HELP, frontend: 'frontend [--no-open]', ui: 'ui [--no-open]', open: 'open [--no-open]', serve: 'serve [--backend] [--stop|--status] [--port N]', server: 'server [start|stop|status]', studio: 'studio [--port N]', ...LOCAL_CLI_HELP } as const;
+const LOCAL_COMMANDS = { commands: 'commands', mcp_call: MCP_CLIENT_HELP, frontend: 'frontend [--no-open]', ui: 'ui [--no-open]', open: 'open [--no-open]', serve: 'serve [--backend] [--in-process] [--stop|--status] [--port N]', server: 'server [start|stop|status]', studio: 'studio [--port N]', ...LOCAL_CLI_HELP } as const;
 const MCP_COMMANDS = new Set(['commands', ...Object.entries(COMMANDS).filter(([name, spec]) => name !== 'vector_config' && !spec.write && spec.method === 'GET').map(([name]) => name)]);
 function usage(): InvokeResult {
   const commandNames = [...Object.keys(COMMANDS), ...Object.keys(LOCAL_COMMANDS)].sort();

--- a/maw-plugin/serve.ts
+++ b/maw-plugin/serve.ts
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 export type Parsed = { pos: string[]; flags: Record<string, string | boolean> };
 export type InvokeResult = { ok: boolean; output?: string; error?: string };
@@ -15,6 +15,7 @@ export type ServeDeps = {
   kill?: (pid: number, signal?: NodeJS.Signals) => void;
   sleep?: (ms: number) => Promise<void>;
   start?: (cwd: string, env: Record<string, string | undefined>, command: ServerCommand) => number | undefined;
+  inProcessStart?: (root: string, env: Record<string, string | undefined>) => Promise<{ pid?: number; port: string; healthPath?: string }>;
 };
 
 const DEFAULT_PORT = '47778';
@@ -35,6 +36,11 @@ function serveAction(parsed: Parsed): 'start' | 'stop' | 'status' {
   if (flag(parsed, 'stop') || action === 'stop') return 'stop';
   if (!action || action === 'start') return 'start';
   throw new Error('serve action must be start, stop, or status');
+}
+
+function inProcessRequested(parsed: Parsed): boolean {
+  const value = flag(parsed, 'in-process');
+  return value !== undefined && value !== 'false';
 }
 
 function backendRequested(parsed: Parsed): boolean {
@@ -129,6 +135,14 @@ function startServer(cwd: string, env: Record<string, string | undefined>, comma
   return child.pid;
 }
 
+async function startInProcess(root: string, env: Record<string, string | undefined>): Promise<{ pid: number; port: string; healthPath: string }> {
+  Object.assign(process.env, env, { ORACLE_ROOT: root });
+  const moduleUrl = pathToFileURL(join(root, 'src/server.ts')).href;
+  const { startServer } = await import(moduleUrl) as { startServer: (options?: { writePidFile?: boolean }) => Promise<{ port: number }> };
+  const server = await startServer({ writePidFile: false });
+  return { pid: process.pid, port: String(server.port), healthPath: '/api/health' };
+}
+
 async function health(port: string, healthPath: string, fetcher: typeof fetch): Promise<string> {
   const url = `http://127.0.0.1:${port}${healthPath}`;
   try {
@@ -164,6 +178,7 @@ export async function runServe(parsed: Parsed, runner: Runner, env: Record<strin
 
     const action = serveAction(parsed);
     const explicitBackend = backendRequested(parsed);
+    const inProcess = inProcessRequested(parsed);
 
     if (action === 'status') {
       const healthPort = flag(parsed, 'port') ? port : state?.port ?? port;
@@ -192,6 +207,18 @@ export async function runServe(parsed: Parsed, runner: Runner, env: Record<strin
     mkdirSync(dirname(path), { recursive: true });
     const command = resolveServerCommand(cwd, { ...env, ORACLE_PORT: port, PORT: port });
     const startEnv = { ...env, ...command.env, ORACLE_ROOT: cwd, ORACLE_PORT: port, PORT: port };
+    if (inProcess) {
+      const server = await (deps.inProcessStart ?? startInProcess)(cwd, startEnv);
+      const pid = server.pid ?? process.pid;
+      writeState(path, { pid, port: server.port, root: cwd, healthPath: server.healthPath ?? command.healthPath, startedAt: new Date().toISOString() });
+      return { ok: true, output: [
+        `arra serve: started pid=${pid} port=${server.port}`,
+        explicitBackend && 'backend: full Oracle',
+        'mode: in-process',
+        `root: ${cwd}`,
+        `pid: ${path}`,
+      ].filter(Boolean).join('\n') };
+    }
     const pid = (deps.start ?? startServer)(command.cwd, startEnv, command);
     if (!pid) throw new Error(`${command.command} ${command.args.join(' ')} did not return a PID`);
     writeState(path, { pid, port, root: cwd, healthPath: command.healthPath, startedAt: new Date().toISOString() });

--- a/src/server.ts
+++ b/src/server.ts
@@ -69,6 +69,7 @@ import pkg from '../package.json' with { type: 'json' };
 
 type UnifiedRuntime = Awaited<ReturnType<typeof loadUnifiedPlugins>>;
 type ServerSpec = { port: number; fetch(request: Request): Response | Promise<Response> };
+export interface StartServerOptions { writePidFile?: boolean }
 
 export interface CreateAppOptions {
   unifiedPlugins: UnifiedRuntime;
@@ -117,25 +118,28 @@ export function createApp({ unifiedPlugins, dataDir = ORACLE_DATA_DIR, vectorUrl
   return app;
 }
 
-export async function startServer(): Promise<ReturnType<typeof Bun.serve>> {
-  const app = await createStartedApp();
+export async function startServer(options: StartServerOptions = {}): Promise<ReturnType<typeof Bun.serve>> {
+  const app = await createStartedApp(options);
   return Bun.serve(app);
 }
 
-export async function createStartedApp(): Promise<ServerSpec> {
+export async function createStartedApp(options: StartServerOptions = {}): Promise<ServerSpec> {
   const startupConfig = validateStartupEnv();
   resetIndexerStatus();
   console.log('[Vector] mode:', VECTOR_URL ? 'proxy → ' + VECTOR_URL : 'local');
   void warmEmbeddingProviderDetection().catch((error) => console.warn('[Vector] embedding provider auto-detect failed:', error instanceof Error ? error.message : String(error)));
   logBusyTimeout();
-  configure({ dataDir: ORACLE_DATA_DIR, pidFileName: 'oracle-http.pid' });
-  writePidFile({ pid: process.pid, port: Number(PORT), startedAt: new Date().toISOString(), name: 'oracle-http' });
+  const ownsPidFile = options.writePidFile !== false;
+  if (ownsPidFile) {
+    configure({ dataDir: ORACLE_DATA_DIR, pidFileName: 'oracle-http.pid' });
+    writePidFile({ pid: process.pid, port: Number(PORT), startedAt: new Date().toISOString(), name: 'oracle-http' });
+  }
   if (process.env.ORACLE_FILE_WATCHER !== '0') fileWatcherService.start();
 
   const unifiedPlugins = await loadUnifiedPlugins({ dirs: defaultUnifiedPluginDirs([join(import.meta.dir, 'plugins')]), warn: (message) => console.warn(message) });
   await unifiedPlugins.init();
   const unifiedServers = await startUnifiedPluginServers(unifiedPlugins.servers);
-  registerGracefulShutdown({ close: async () => shutdown(unifiedPlugins, unifiedServers) });
+  registerGracefulShutdown({ close: async () => shutdown(unifiedPlugins, unifiedServers, ownsPidFile) });
 
   const app = createApp({ unifiedPlugins });
   await seedMenus(app, unifiedPlugins);
@@ -170,7 +174,7 @@ async function announceStartup(app: any, startupConfig: ReturnType<typeof valida
   await runStartupSelfTest({ checks: createStartupSelfTest({ dbPing: dbStatus, healthFetch: () => app.fetch(new Request(`http://127.0.0.1:${PORT}/api/health`)) }) });
 }
 
-async function shutdown(unifiedPlugins: UnifiedRuntime, unifiedServers: Awaited<ReturnType<typeof startUnifiedPluginServers>>): Promise<void> {
+async function shutdown(unifiedPlugins: UnifiedRuntime, unifiedServers: Awaited<ReturnType<typeof startUnifiedPluginServers>>, ownsPidFile: boolean): Promise<void> {
   console.log('\n🔮 Shutting down gracefully...');
   await runShutdownSteps([
     { name: 'file-watcher', run: () => { fileWatcherService.stop(); } },
@@ -178,7 +182,7 @@ async function shutdown(unifiedPlugins: UnifiedRuntime, unifiedServers: Awaited<
     { name: 'unified-plugin-servers', run: () => unifiedServers.stop() },
     { name: 'vector-stores', run: () => closeCachedVectorStores() },
     { name: 'database', run: () => closeDb() },
-    { name: 'pid-file', run: () => removePidFile() },
+    ...(ownsPidFile ? [{ name: 'pid-file', run: () => removePidFile() }] : []),
   ], console.warn);
   console.log('👋 Arra Oracle HTTP Server stopped.');
 }


### PR DESCRIPTION
## Summary
- Add optional `maw arra serve --in-process` mode for the Slice 1b in-host backend path.
- Keep spawned process mode as the default.
- In-process mode imports `ORACLE_ROOT/src/server.ts` and calls `startServer({ writePidFile: false })`, leaving the maw serve pidfile as the single owner.
- Update compact help and tests for the new flag.

## Tests
```bash
bun test maw-plugin/__tests__/serve.test.ts maw-plugin/__tests__/index.test.ts src/server/__tests__/server-factory.test.ts src/server/__tests__/server-plugin-loader.test.ts tests/lifecycle/shutdown.test.ts
bunx tsc --noEmit
git diff --check
wc -l maw-plugin/serve.ts maw-plugin/__tests__/serve.test.ts maw-plugin/index.ts maw-plugin/__tests__/index.test.ts src/server.ts
```

Refs #2227
