### PR TITLE
feat: add async consolidation worker

### DIFF
--- a/src/workers/consolidation.ts
+++ b/src/workers/consolidation.ts
@@ -1,0 +1,238 @@
+import type { Database } from 'bun:sqlite';
+import { runWithTenant } from '../middleware/tenant.ts';
+import { runSupersede } from '../tools/supersede.ts';
+import type { ToolContext } from '../tools/types.ts';
+
+type Db = ToolContext['db'];
+type Logger = Pick<Console, 'log' | 'warn' | 'error'>;
+type RawDoc = {
+  id: string; tenantId: string; type: string; sourceFile: string; concepts: string;
+  createdAt: number; updatedAt: number; indexedAt: number; project: string | null;
+  createdBy: string | null; content: string;
+};
+type CandidateDoc = RawDoc & { tokens: string[]; tokenSet: Set<string>; confidence: ConfidenceReceipt };
+type ResolvedOptions = {
+  dryRun: boolean; limit: number; minCosine: number; minFtsOverlap: number;
+  staleDays: number; tenantId?: string; now: number;
+};
+
+export type ConsolidationOptions = {
+  dryRun?: boolean; limit?: number; minCosine?: number; minFtsOverlap?: number;
+  staleDays?: number; tenantId?: string; now?: number; logger?: Logger;
+};
+export type ConfidenceReceipt = {
+  id: string; tenantId: string; score: number; stale: boolean;
+  label: 'high' | 'medium' | 'low'; reasons: string[];
+};
+export type ConsolidationPlan = {
+  oldId: string; newId: string; tenantId: string; cosine: number; ftsOverlap: number;
+  oldConfidence: number; newConfidence: number; reason: string;
+};
+export type ConsolidationResult = {
+  dryRun: boolean; scanned: number; planned: number; applied: number; skipped: number;
+  deleted: 0; plans: ConsolidationPlan[]; confidence: ConfidenceReceipt[];
+};
+
+const DAY_MS = 86_400_000;
+const DEFAULTS = {
+  dryRun: true,
+  limit: 250,
+  minCosine: 0.94,
+  minFtsOverlap: 0.86,
+  staleDays: 45,
+};
+const STOP_WORDS = new Set(['the', 'and', 'for', 'with', 'that', 'this', 'from', 'into', 'are', 'was']);
+
+function clamp(value: number, min = 0, max = 1): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function round(value: number): number {
+  return Number(value.toFixed(4));
+}
+
+function tokenize(text: string): string[] {
+  return (text.toLowerCase().normalize('NFKC').match(/[a-z0-9_:-]+/g) ?? [])
+    .filter((token) => token.length > 2 && !STOP_WORDS.has(token));
+}
+
+function cosine(left: string[], right: string[]): number {
+  if (!left.length || !right.length) return 0;
+  const counts = new Map<string, number>();
+  for (const token of left) counts.set(token, (counts.get(token) ?? 0) + 1);
+  const rightCounts = new Map<string, number>();
+  for (const token of right) rightCounts.set(token, (rightCounts.get(token) ?? 0) + 1);
+  let dot = 0;
+  let leftNorm = 0;
+  let rightNorm = 0;
+  for (const value of counts.values()) leftNorm += value * value;
+  for (const [token, value] of rightCounts) {
+    rightNorm += value * value;
+    dot += (counts.get(token) ?? 0) * value;
+  }
+  return round(dot / (Math.sqrt(leftNorm) * Math.sqrt(rightNorm)));
+}
+
+function ftsOverlap(left: Set<string>, right: Set<string>): number {
+  const smallest = left.size <= right.size ? left : right;
+  const largest = left.size <= right.size ? right : left;
+  if (!smallest.size) return 0;
+  let intersection = 0;
+  for (const token of smallest) if (largest.has(token)) intersection += 1;
+  return round(intersection / smallest.size);
+}
+
+function confidenceFor(doc: RawDoc, tokens: string[], now: number, staleDays: number): ConfidenceReceipt {
+  const ageDays = Math.max(0, Math.floor((now - (doc.updatedAt || doc.createdAt)) / DAY_MS));
+  const freshness = clamp(1 - (ageDays / Math.max(1, staleDays * 3)));
+  const provenance = (doc.project ? 0.45 : 0) + (doc.createdBy ? 0.35 : 0) + (doc.sourceFile ? 0.2 : 0);
+  const completeness = clamp(tokens.length / 80);
+  const score = round((freshness * 0.45) + (provenance * 0.35) + (completeness * 0.2));
+  const stale = ageDays >= staleDays || !doc.indexedAt;
+  return {
+    id: doc.id,
+    tenantId: doc.tenantId,
+    score,
+    stale,
+    label: score >= 0.75 ? 'high' : score >= 0.45 ? 'medium' : 'low',
+    reasons: [
+      stale ? 'stale_document' : 'fresh_document',
+      doc.project ? 'project_provenance' : 'missing_project',
+      tokens.length >= 40 ? 'content_complete' : 'content_sparse',
+    ],
+  };
+}
+
+function docsSql(hasFts: boolean, tenantId?: string): string {
+  const content = hasFts ? "coalesce(f.content, '')" : "''";
+  const join = hasFts ? 'LEFT JOIN oracle_fts f ON f.id = d.id' : '';
+  const tenant = tenantId ? 'AND d.tenant_id = ?' : '';
+  return `
+    SELECT d.id, d.tenant_id AS tenantId, d.type, d.source_file AS sourceFile,
+      d.concepts, d.created_at AS createdAt, d.updated_at AS updatedAt,
+      d.indexed_at AS indexedAt, d.project, d.created_by AS createdBy, ${content} AS content
+    FROM oracle_documents d
+    ${join}
+    WHERE d.superseded_by IS NULL ${tenant}
+    ORDER BY d.updated_at DESC
+    LIMIT ?`;
+}
+
+function objectExists(sqlite: Database, name: string): boolean {
+  const row = sqlite.query<{ name: string }, [string]>(
+    'SELECT name FROM sqlite_master WHERE name = ? LIMIT 1',
+  ).get(name);
+  return Boolean(row);
+}
+
+function loadDocs(sqlite: Database, options: ResolvedOptions): CandidateDoc[] {
+  const params = options.tenantId ? [options.tenantId, options.limit] : [options.limit];
+  const rows = sqlite.query<RawDoc, (string | number)[]>(docsSql(objectExists(sqlite, 'oracle_fts'), options.tenantId))
+    .all(...params);
+  return rows.map((row) => {
+    const tokens = tokenize(`${row.content}\n${row.concepts}\n${row.sourceFile}`);
+    return {
+      ...row,
+      content: row.content ?? '',
+      tokens,
+      tokenSet: new Set(tokens),
+      confidence: confidenceFor(row, tokens, options.now, options.staleDays),
+    };
+  });
+}
+
+function chooseOld(left: CandidateDoc, right: CandidateDoc): [CandidateDoc, CandidateDoc] {
+  if (left.confidence.score !== right.confidence.score) {
+    return left.confidence.score < right.confidence.score ? [left, right] : [right, left];
+  }
+  if (left.updatedAt !== right.updatedAt) return left.updatedAt < right.updatedAt ? [left, right] : [right, left];
+  return left.createdAt <= right.createdAt ? [left, right] : [right, left];
+}
+
+function planDocs(docs: CandidateDoc[], options: ResolvedOptions): ConsolidationPlan[] {
+  const plans: ConsolidationPlan[] = [];
+  const used = new Set<string>();
+  for (let i = 0; i < docs.length; i += 1) {
+    for (let j = i + 1; j < docs.length; j += 1) {
+      const left = docs[i];
+      const right = docs[j];
+      if (left.tenantId !== right.tenantId || left.type !== right.type) continue;
+      if (used.has(left.id) || used.has(right.id)) continue;
+      const sim = cosine(left.tokens, right.tokens);
+      const overlap = ftsOverlap(left.tokenSet, right.tokenSet);
+      if (sim < options.minCosine || overlap < options.minFtsOverlap) continue;
+      const [oldDoc, newDoc] = chooseOld(left, right);
+      used.add(oldDoc.id);
+      used.add(newDoc.id);
+      plans.push({
+        oldId: oldDoc.id,
+        newId: newDoc.id,
+        tenantId: oldDoc.tenantId,
+        cosine: sim,
+        ftsOverlap: overlap,
+        oldConfidence: oldDoc.confidence.score,
+        newConfidence: newDoc.confidence.score,
+        reason: `async consolidation duplicate (cosine=${sim}, fts_overlap=${overlap})`,
+      });
+    }
+  }
+  return plans;
+}
+
+export async function runConsolidationWorker(
+  db: Db,
+  sqlite: Database,
+  input: ConsolidationOptions = {},
+): Promise<ConsolidationResult> {
+  const options = { ...DEFAULTS, now: Date.now(), tenantId: undefined, ...input };
+  const logger = input.logger ?? console;
+  const docs = loadDocs(sqlite, options);
+  const plans = planDocs(docs, options);
+  let applied = 0;
+  for (const plan of plans) {
+    if (options.dryRun) {
+      logger.log(`[consolidation:dry-run] would supersede ${plan.oldId} -> ${plan.newId}`);
+      continue;
+    }
+    try {
+      const result = runWithTenant(plan.tenantId, () => runSupersede(db, {
+        oldId: plan.oldId,
+        newId: plan.newId,
+        reason: plan.reason,
+      }));
+      if (result.isError) logger.warn(`[consolidation] skipped ${plan.oldId}: ${JSON.stringify(result.payload)}`);
+      else applied += 1;
+    } catch (error) {
+      logger.warn(`[consolidation] skipped ${plan.oldId}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  return {
+    dryRun: options.dryRun,
+    scanned: docs.length,
+    planned: plans.length,
+    applied,
+    skipped: plans.length - applied,
+    deleted: 0,
+    plans,
+    confidence: docs.map((doc) => doc.confidence).filter((receipt) => receipt.stale),
+  };
+}
+
+export function createConsolidationWorker(db: Db, sqlite: Database, input: ConsolidationOptions & { intervalMs?: number } = {}) {
+  let timer: ReturnType<typeof setInterval> | null = null;
+  const intervalMs = input.intervalMs ?? 300_000;
+  const runOnce = () => runConsolidationWorker(db, sqlite, input);
+  return {
+    runOnce,
+    start() {
+      if (timer) return;
+      timer = setInterval(() => { void runOnce().catch((error) => (input.logger ?? console).error(error)); }, intervalMs);
+    },
+    stop() {
+      if (!timer) return;
+      clearInterval(timer);
+      timer = null;
+    },
+    isRunning: () => timer !== null,
+  };
+}

--- a/tests/workers/consolidation-worker.test.ts
+++ b/tests/workers/consolidation-worker.test.ts
@@ -1,0 +1,116 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const root = mkdtempSync(join(tmpdir(), 'arra-consolidation-'));
+process.env.ORACLE_DATA_DIR = root;
+
+const dbModule = await import('../../src/db/index.ts');
+const workerModule = await import('../../src/workers/consolidation.ts');
+const { createDatabase, oracleDocuments, resetDefaultDatabaseForTests } = dbModule;
+const { createConsolidationWorker, runConsolidationWorker } = workerModule;
+
+type Connection = ReturnType<typeof createDatabase>;
+
+const now = 1_766_000_000_000;
+const duplicateContent = `Oracle install plugin flow quickstart with deploy button and
+bun add github package setup. This document explains the same easy install
+steps, troubleshooting hints, and plugin activation details for new users.`;
+
+function connection(name: string): Connection {
+  return createDatabase(join(root, `${name}.db`));
+}
+
+function addDoc(conn: Connection, id: string, tenantId: string, updatedAt: number, content: string) {
+  conn.db.insert(oracleDocuments).values({
+    id,
+    tenantId,
+    type: 'learning',
+    sourceFile: `docs/${id}.md`,
+    concepts: '["install","plugin","quickstart"]',
+    createdAt: updatedAt - 10,
+    updatedAt,
+    indexedAt: updatedAt,
+    project: 'github.com/soul-brews-studio/arra-oracle-v3',
+    createdBy: 'test',
+  }).run();
+  conn.sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
+    .run(id, content, 'install plugin quickstart');
+}
+
+function addDuplicatePair(conn: Connection, tenantId = 'tenant-a') {
+  addDoc(conn, 'old-doc', tenantId, now - (70 * 86_400_000), duplicateContent);
+  addDoc(conn, 'new-doc', tenantId, now, `${duplicateContent} Updated current guidance.`);
+}
+
+function doc(conn: Connection, id: string) {
+  return conn.db.select({ id: oracleDocuments.id, supersededBy: oracleDocuments.supersededBy })
+    .from(oracleDocuments)
+    .where(eq(oracleDocuments.id, id))
+    .get();
+}
+
+afterAll(() => {
+  if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = savedDataDir;
+  if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = savedDbPath;
+  resetDefaultDatabaseForTests(':memory:');
+  if (existsSync(root)) rmSync(root, { recursive: true });
+});
+
+describe('async consolidation worker', () => {
+  test('dry-run plans near duplicates without mutating documents', async () => {
+    const conn = connection('dry-run');
+    addDuplicatePair(conn);
+
+    try {
+      const logs: string[] = [];
+      const result = await runConsolidationWorker(conn.db, conn.sqlite, {
+        dryRun: true,
+        now,
+        logger: { log: (line) => logs.push(String(line)), warn: () => {}, error: () => {} },
+      });
+
+      expect(result).toMatchObject({ dryRun: true, scanned: 2, planned: 1, applied: 0, deleted: 0 });
+      expect(result.plans[0]).toMatchObject({ oldId: 'old-doc', newId: 'new-doc', tenantId: 'tenant-a' });
+      expect(logs[0]).toContain('would supersede old-doc -> new-doc');
+      expect(doc(conn, 'old-doc')?.supersededBy).toBeNull();
+    } finally {
+      conn.storage.close();
+    }
+  });
+
+  test('apply mode uses reversible supersede and never deletes rows', async () => {
+    const conn = connection('apply');
+    addDuplicatePair(conn);
+
+    try {
+      const result = await createConsolidationWorker(conn.db, conn.sqlite, { dryRun: false, now }).runOnce();
+      const count = conn.db.select({ id: oracleDocuments.id }).from(oracleDocuments).all().length;
+
+      expect(result).toMatchObject({ dryRun: false, planned: 1, applied: 1, deleted: 0 });
+      expect(doc(conn, 'old-doc')?.supersededBy).toBe('new-doc');
+      expect(count).toBe(2);
+    } finally {
+      conn.storage.close();
+    }
+  });
+
+  test('does not plan supersessions across tenants', async () => {
+    const conn = connection('tenants');
+    addDoc(conn, 'tenant-a-doc', 'tenant-a', now - 1, duplicateContent);
+    addDoc(conn, 'tenant-b-doc', 'tenant-b', now, duplicateContent);
+
+    try {
+      const result = await runConsolidationWorker(conn.db, conn.sqlite, { dryRun: true, now });
+      expect(result.plans).toEqual([]);
+    } finally {
+      conn.storage.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary\n- add async consolidation worker under src/workers with interval runner + runOnce API\n- plan non-LLM duplicate supersessions with token cosine + FTS overlap, defaulting to dry-run logging\n- apply via reversible runSupersede only; result reports deleted: 0 and never hard-deletes\n- include stale-document confidence recompute receipts\n\n## Validation\n- bun test tests/workers/consolidation-worker.test.ts\n- bunx tsc --noEmit\n- wc -l src/workers/consolidation.ts tests/workers/consolidation-worker.test.ts\n\nCloses #2257