### PR TITLE
feat(plugins): route unified runtime dynamically

### DIFF
--- a/src/middleware/not-found.ts
+++ b/src/middleware/not-found.ts
@@ -21,7 +21,7 @@ export type MethodNotAllowedResponse = {
   };
 };
 
-type RouteLike = { method?: string; path: string };
+export type RouteLike = { method?: string; path: string };
 type RouteMatcher = { path: string; allowedMethods: Set<string> };
 
 const METHOD_ORDER = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
@@ -91,10 +91,12 @@ function allowedMethodsFor(matchers: RouteMatcher[], request: Request): string[]
   return null;
 }
 
-export function createNotFoundMiddleware(routes: RouteLike[] = []) {
-  const matchers = routeMatchers([...routes]);
+type RouteSource = RouteLike[] | (() => RouteLike[]);
+
+export function createNotFoundMiddleware(routes: RouteSource = []) {
   return new Elysia({ name: 'not-found' }).all('*', ({ request, set }) => {
-    const allowedMethods = allowedMethodsFor(matchers, request);
+    const source = typeof routes === 'function' ? routes() : routes;
+    const allowedMethods = allowedMethodsFor(routeMatchers([...source]), request);
     if (allowedMethods) {
       set.status = 405;
       set.headers.Allow = allowedMethods.join(', ');

--- a/src/plugins/runtime-routes.ts
+++ b/src/plugins/runtime-routes.ts
@@ -1,0 +1,100 @@
+import { Elysia } from 'elysia';
+import type { UnifiedRuntime } from './unified-loader.ts';
+import { methodNotAllowedResponse, type RouteLike } from '../middleware/not-found.ts';
+
+type ElysiaApp = Elysia<any, any, any, any, any, any, any>;
+type RuntimeRouteSource = Pick<UnifiedRuntime, 'routes'>;
+type RouteDecision = { kind: 'allowed' } | { kind: 'method-not-allowed'; allowed: string[] } | { kind: 'none' };
+type RuntimeRouteDecision =
+  | { kind: 'route'; app: ElysiaApp }
+  | { kind: 'method-not-allowed'; allowed: string[] }
+  | { kind: 'none' };
+
+export interface UnifiedRuntimeRef<T = UnifiedRuntime> {
+  current: T;
+}
+
+export interface RuntimeRouteMountOptions {
+  localRoutes?: () => RouteLike[];
+}
+
+const METHOD_ORDER = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
+const ALL_METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
+
+export function createUnifiedRuntimeRef<T>(runtime: T): UnifiedRuntimeRef<T> {
+  return { current: runtime };
+}
+
+export function createUnifiedPluginRouteMount(
+  runtimeRef: UnifiedRuntimeRef<RuntimeRouteSource>,
+  options: RuntimeRouteMountOptions = {},
+) {
+  return new Elysia({ name: 'unified:runtime-routes' }).onRequest(async ({ request }) => {
+    if (routeDecision(options.localRoutes?.() ?? [], request, false).kind === 'allowed') return;
+    const match = runtimeRouteFor(runtimeRef.current.routes, request);
+    if (match.kind === 'none') return;
+    if (match.kind === 'method-not-allowed') {
+      return Response.json(methodNotAllowedResponse(request, match.allowed), {
+        status: 405,
+        headers: { Allow: match.allowed.join(', ') },
+      });
+    }
+    return match.app.handle(request);
+  });
+}
+
+function runtimeRouteFor(routes: ElysiaApp[], request: Request): RuntimeRouteDecision {
+  const allowed = new Set<string>();
+  for (const app of routes) {
+    const decision = routeDecision((app.routes ?? []) as RouteLike[], request, true);
+    if (decision.kind === 'allowed') return { kind: 'route', app };
+    if (decision.kind === 'method-not-allowed') decision.allowed.forEach((method) => allowed.add(method));
+  }
+  return allowed.size ? { kind: 'method-not-allowed', allowed: sortedMethods(allowed) } : { kind: 'none' };
+}
+
+function routeDecision(routes: RouteLike[], request: Request, includeAll: boolean): RouteDecision {
+  const pathname = new URL(request.url).pathname;
+  const requestMethod = request.method.toUpperCase();
+  const allowed = new Set<string>();
+  for (const route of routes) {
+    const method = route.method?.toUpperCase();
+    if (!method || (!includeAll && (method === 'ALL' || route.path === '*'))) continue;
+    if (!pathMatches(route.path, pathname)) continue;
+    const methods = method === 'ALL' ? ALL_METHODS : [method, ...(method === 'GET' ? ['HEAD'] : [])];
+    if (methods.includes(requestMethod)) return { kind: 'allowed' };
+    methods.forEach((value) => allowed.add(value));
+  }
+  return allowed.size ? { kind: 'method-not-allowed', allowed: sortedMethods(allowed) } : { kind: 'none' };
+}
+
+function pathMatches(pattern: string, pathname: string): boolean {
+  if (pattern === '*' || pattern === pathname) return true;
+  const patternParts = trim(pattern).split('/');
+  const pathParts = trim(pathname).split('/');
+  for (let i = 0; i < patternParts.length; i += 1) {
+    const part = patternParts[i];
+    const value = pathParts[i];
+    if (part === '*') return true;
+    if (value == null) return false;
+    if (part.startsWith(':')) continue;
+    if (part.endsWith('*')) return value.startsWith(part.slice(0, -1));
+    if (part !== value) return false;
+  }
+  return patternParts.length === pathParts.length;
+}
+
+function trim(pathname: string): string {
+  return pathname.replace(/^\/+|\/+$/g, '');
+}
+
+function sortedMethods(methods: Set<string>): string[] {
+  return [...methods].sort((a, b) => {
+    const ai = METHOD_ORDER.indexOf(a);
+    const bi = METHOD_ORDER.indexOf(b);
+    if (ai === -1 && bi === -1) return a.localeCompare(b);
+    if (ai === -1) return 1;
+    if (bi === -1) return -1;
+    return ai - bi;
+  });
+}

--- a/src/routes/plugins/index.ts
+++ b/src/routes/plugins/index.ts
@@ -12,7 +12,7 @@ export function createPluginsRouter(options: PluginsRouterOptions = {}) {
   return new Elysia()
     .use(createPluginsRegistryRoute(options))
     .use(pluginStateRoute)
-    .use(createPluginToggleRoute({ runtime: options.runtime }))
+    .use(createPluginToggleRoute({ runtime: options.runtime, runtimeRef: options.runtimeRef }))
     .use(canvasPluginRegistryRoute)
     .use(pluginGetByNameRoute);
 }

--- a/src/routes/plugins/toggle.ts
+++ b/src/routes/plugins/toggle.ts
@@ -1,10 +1,14 @@
 import { Elysia, t } from 'elysia';
 import type { UnifiedRuntime } from '../../plugins/unified-loader.ts';
+import type { UnifiedRuntimeRef } from '../../plugins/runtime-routes.ts';
 import { sanitizePluginName } from './model.ts';
 import { readPluginEnabled, writePluginEnabled } from './state.ts';
 
+type ToggleRuntime = Pick<UnifiedRuntime, 'mcpTools' | 'reload'>;
+
 export interface PluginToggleRouteOptions {
-  runtime?: Pick<UnifiedRuntime, 'mcpTools' | 'reload'>;
+  runtime?: ToggleRuntime;
+  runtimeRef?: UnifiedRuntimeRef<ToggleRuntime>;
 }
 
 type ToggleBody = { enabled?: boolean } | undefined;
@@ -20,7 +24,8 @@ export function createPluginToggleRoute(options: PluginToggleRouteOptions = {}) 
   return new Elysia().post(
     '/api/plugins/:name/toggle',
     async ({ params, body, set }) => {
-      if (!options.runtime) {
+      const runtime = options.runtimeRef?.current ?? options.runtime;
+      if (!runtime) {
         set.status = 503;
         return { ok: false, error: 'plugin runtime unavailable' };
       }
@@ -33,7 +38,7 @@ export function createPluginToggleRoute(options: PluginToggleRouteOptions = {}) 
         return { ok: false, error: 'plugin manifest not found', name: sanitizePluginName(params.name) };
       }
       try {
-        await options.runtime.reload();
+        await runtime.reload();
       } catch (error) {
         set.status = 500;
         return {
@@ -44,7 +49,7 @@ export function createPluginToggleRoute(options: PluginToggleRouteOptions = {}) 
           message: error instanceof Error ? error.message : String(error),
         };
       }
-      const mcpTools = mcpToolNames(options.runtime, result.name);
+      const mcpTools = mcpToolNames(runtime, result.name);
       return { ok: true, plugin: result.name, enabled: result.enabled, reloaded: true, mcpTools, mcpToolCount: mcpTools.length };
     },
     {

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import { createContentTypeMiddleware } from './middleware/content-type.ts';
 import { createApiKeyAuthMiddleware } from './middleware/auth.ts';
 import { createCorrelationMiddleware } from './middleware/correlation.ts';
 import { defaultUnifiedPluginDirs, loadUnifiedPlugins, seedUnifiedPluginMenuItems } from './plugins/unified-loader.ts';
+import { createUnifiedPluginRouteMount, createUnifiedRuntimeRef, type UnifiedRuntimeRef } from './plugins/runtime-routes.ts';
 import { startUnifiedPluginServers } from './plugins/unified-server.ts';
 import { closeCachedVectorStores } from './vector/factory.ts';
 import { warmEmbeddingProviderDetection } from './vector/provider-detection.ts';
@@ -73,11 +74,12 @@ export interface StartServerOptions { writePidFile?: boolean }
 
 export interface CreateAppOptions {
   unifiedPlugins: UnifiedRuntime;
+  runtimeRef?: UnifiedRuntimeRef<UnifiedRuntime>;
   dataDir?: string;
   vectorUrl?: string;
 }
 
-export function createApp({ unifiedPlugins, dataDir = ORACLE_DATA_DIR, vectorUrl = VECTOR_URL }: CreateAppOptions) {
+export function createApp({ unifiedPlugins, runtimeRef = createUnifiedRuntimeRef(unifiedPlugins), dataDir = ORACLE_DATA_DIR, vectorUrl = VECTOR_URL }: CreateAppOptions) {
   const app = new Elysia()
     .use(createRequestLoggingMiddleware())
     .use(createCorrelationMiddleware())
@@ -111,10 +113,11 @@ export function createApp({ unifiedPlugins, dataDir = ORACLE_DATA_DIR, vectorUrl
     .get('/', () => ({ server: MCP_SERVER_NAME, version: pkg.version, status: 'ok', docs: '/api/docs', api: '/api/v1' }));
 
   const healthRoutes = createHealthRoutes({ pluginCount: unifiedPlugins.pluginCount, pluginMcpToolCount: unifiedPlugins.mcpTools.length, pluginStatuses: unifiedPlugins.pluginStatuses, isDraining });
-  const apiModules = [authRoutes, settingsRoutes, feedRoutes, healthRoutes, dashboardRoutes, searchRoutes, vectorRoutes, vectorConfigApiRoutes, conceptsRoutes, knowledgeRoutes, verifyRoutes, supersedeRoutes, forumApi, tracesApi, scheduleApi, filesRouter, createPluginsRouter({ registry: unifiedPlugins.pluginRegistry, runtime: unifiedPlugins }), sessionsRoutes, vaultRoutes, metricsRoutes, exportRoutes, memoryRoutes, canvasRoutes, tenantsRoutes, watcherRoutes, indexerRoutes, ...unifiedPlugins.routes];
+  const apiModules = [authRoutes, settingsRoutes, feedRoutes, healthRoutes, dashboardRoutes, searchRoutes, vectorRoutes, vectorConfigApiRoutes, conceptsRoutes, knowledgeRoutes, verifyRoutes, supersedeRoutes, forumApi, tracesApi, scheduleApi, filesRouter, createPluginsRouter({ registry: () => runtimeRef.current.pluginRegistry(), runtimeRef }), sessionsRoutes, vaultRoutes, metricsRoutes, exportRoutes, memoryRoutes, canvasRoutes, tenantsRoutes, watcherRoutes, indexerRoutes];
   const modules = [...apiModules, createMcpRoutes(unifiedPlugins.mcpTools), createMenuRoutes(menuItemsFromUnifiedPlugins(unifiedPlugins.menu))];
   for (const mod of modules) app.use(mod as any);
-  app.use(createNotFoundMiddleware(app.routes));
+  app.use(createUnifiedPluginRouteMount(runtimeRef, { localRoutes: () => app.routes }));
+  app.use(createNotFoundMiddleware(() => app.routes));
   return app;
 }
 

--- a/tests/plugins/unified-runtime-routes.test.ts
+++ b/tests/plugins/unified-runtime-routes.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Elysia } from 'elysia';
+import { loadUnifiedPlugins } from '../../src/plugins/unified-loader.ts';
+import { createUnifiedPluginRouteMount, createUnifiedRuntimeRef } from '../../src/plugins/runtime-routes.ts';
+import { createNotFoundMiddleware } from '../../src/middleware/not-found.ts';
+import { pluginDir } from './_fixtures.ts';
+
+const temps: string[] = [];
+
+afterEach(() => {
+  for (const dir of temps.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function tmp() {
+  const dir = mkdtempSync(join(tmpdir(), 'arra-runtime-routes-'));
+  temps.push(dir);
+  return dir;
+}
+
+function writeApiPlugin(base: string, name: string, paths = [`/api/${name}/hello`]) {
+  return pluginDir(base, name, {
+    apiRoutes: paths.map((path) => ({ path, methods: ['GET'], handler: 'hello' })),
+  }, `export function hello(ctx) { return { ok: true, body: { plugin: ctx.plugin } }; }\n`);
+}
+
+function setPluginEnabled(dir: string, enabled: boolean) {
+  const path = join(dir, 'plugin.json');
+  const json = JSON.parse(readFileSync(path, 'utf8')) as Record<string, unknown>;
+  writeFileSync(path, JSON.stringify({ ...json, enabled }, null, 2));
+}
+
+function appFor(ref: ReturnType<typeof createUnifiedRuntimeRef>) {
+  const app = new Elysia().get('/api/core', () => ({ source: 'core' }));
+  app.use(createUnifiedPluginRouteMount(ref, { localRoutes: () => app.routes }));
+  app.use(createNotFoundMiddleware(() => app.routes));
+  return app;
+}
+
+async function getJson(app: Elysia, path: string, method = 'GET') {
+  const response = await app.handle(new Request(`http://local${path}`, { method }));
+  const text = await response.text();
+  return { response, body: text ? JSON.parse(text) : null };
+}
+
+describe('unified plugin runtime routes', () => {
+  test('reads a swapped runtimeRef through one stable Elysia mount', async () => {
+    const a = tmp();
+    const b = tmp();
+    writeApiPlugin(a, 'alpha');
+    writeApiPlugin(b, 'beta', ['/api/beta/hello', '/api/core']);
+    const runtimeA = await loadUnifiedPlugins({ dirs: [a] });
+    const runtimeB = await loadUnifiedPlugins({ dirs: [b] });
+    const ref = createUnifiedRuntimeRef(runtimeA);
+    const app = appFor(ref);
+
+    expect((await getJson(app, '/api/alpha/hello')).body).toEqual({ plugin: 'alpha' });
+    expect((await getJson(app, '/api/beta/hello')).response.status).toBe(404);
+
+    ref.current = runtimeB;
+    expect((await getJson(app, '/api/alpha/hello')).response.status).toBe(404);
+    expect((await getJson(app, '/api/beta/hello')).body).toEqual({ plugin: 'beta' });
+    expect((await getJson(app, '/api/core')).body).toEqual({ source: 'core' });
+
+    const wrongMethod = await getJson(app, '/api/beta/hello', 'POST');
+    expect(wrongMethod.response.status).toBe(405);
+    expect(wrongMethod.response.headers.get('allow')).toContain('GET');
+  });
+
+  test('uses runtime.reload route mutations without remounting the app', async () => {
+    const root = tmp();
+    const dir = writeApiPlugin(root, 'toggle-route');
+    const runtime = await loadUnifiedPlugins({ dirs: [root] });
+    const app = appFor(createUnifiedRuntimeRef(runtime));
+
+    expect((await getJson(app, '/api/toggle-route/hello')).body).toEqual({ plugin: 'toggle-route' });
+    setPluginEnabled(dir, false);
+    await runtime.reload();
+    expect((await getJson(app, '/api/toggle-route/hello')).response.status).toBe(404);
+
+    setPluginEnabled(dir, true);
+    await runtime.reload();
+    expect((await getJson(app, '/api/toggle-route/hello')).body).toEqual({ plugin: 'toggle-route' });
+  });
+});


### PR DESCRIPTION
## Summary
- add a mutable unified plugin `runtimeRef` and a single stable Elysia plugin-route mount
- route unified plugin HTTP/API/proxy/server surfaces through a per-request runtime lookup instead of boot-time `app.use(...runtime.routes)` snapshots
- keep core routes winning for matching methods while allowing runtime plugin route swaps/reloads without remounting the app
- make `createNotFoundMiddleware` accept a dynamic route source so 404/405 checks no longer freeze the boot route table

## Validation
```bash
bunx tsc --noEmit
bun test tests/plugins/ tests/http/plugins/ tests/http/mcp/ src/server/__tests__/server-factory.test.ts src/server/__tests__/server-plugin-loader.test.ts
git diff --check origin/alpha..HEAD
wc -l src/plugins/runtime-routes.ts src/middleware/not-found.ts src/routes/plugins/toggle.ts src/routes/plugins/index.ts src/server.ts tests/plugins/unified-runtime-routes.test.ts
```

Refs #2227