### PR TITLE
feat: expose vector preflight availability

### DIFF
--- a/src/routes/health/__tests__/health-vector-mode.test.ts
+++ b/src/routes/health/__tests__/health-vector-mode.test.ts
@@ -7,5 +7,6 @@ describe('/api/health vector mode', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(['embedded', 'proxied', 'disabled']).toContain(body.vectorMode);
+    expect(typeof body.vectorAvailable).toBe('boolean');
   });
 });

--- a/src/routes/health/health.ts
+++ b/src/routes/health/health.ts
@@ -4,7 +4,7 @@ import { MCP_SERVER_NAME } from '../../const.ts';
 import { sqlite } from '../../db/index.ts';
 import { scanPlugins } from '../plugins/model.ts';
 import { readVectorBackendHealth } from '../../vector/health.ts';
-import { getVectorRuntimeStatus } from '../../vector/runtime-status.ts';
+import { getVectorRuntimeStatus, type VectorRuntimeStatus } from '../../vector/runtime-status.ts';
 import { readVectorServerHealth, type VectorServerHealth } from './vector-server.ts';
 import { mcpTools } from '../../tools/mcp-manifest.ts';
 import type { UnifiedPluginStatus } from '../../plugins/unified-loader.ts';
@@ -56,6 +56,7 @@ const HealthResponseSchema = t.Object({
   dbStatus: t.Optional(t.Union([t.Literal('connected'), t.Literal('error')])),
   vectorStatus: t.Optional(t.Union([t.Literal('ok'), t.Literal('degraded'), t.Literal('down')])),
   vectorMode: t.Optional(t.Union([t.Literal('embedded'), t.Literal('proxied'), t.Literal('disabled')])),
+  vectorAvailable: t.Optional(t.Boolean()),
   vectorUrl: t.Optional(t.String()),
   vectorDisabledReason: t.Optional(t.String()),
   pluginStatus: t.Optional(t.Union([t.Literal('ok'), t.Literal('degraded')])),
@@ -98,6 +99,7 @@ export interface HealthEndpointOptions {
   uptimeSeconds?: () => number;
   vectorHealth?: () => Promise<VectorHealth>;
   vectorServerHealth?: () => Promise<VectorServerHealth>;
+  vectorPreflight?: VectorRuntimeStatus & { vectorAvailable?: boolean };
   pluginStatuses?: () => UnifiedPluginStatus[] | Promise<UnifiedPluginStatus[]>;
   dbPing?: DbPing;
   diskPath?: string;
@@ -151,6 +153,13 @@ async function readPluginStatuses(
   }
 }
 
+function vectorAvailability(runtime: VectorRuntimeStatus & { vectorAvailable?: boolean }, vectorServer: VectorServerHealth): boolean {
+  if (typeof runtime.vectorAvailable === 'boolean') return runtime.vectorAvailable;
+  if (runtime.vectorMode === 'proxied' || vectorServer.configured) return vectorServer.status === 'ok';
+  if (runtime.vectorMode === 'disabled') return false;
+  return true;
+}
+
 function aggregateStatus(db: DbStatus, pluginStatus: 'ok' | 'degraded', vectorServer: VectorServerHealth) {
   const vectorOk = vectorServer.status !== 'down';
   return db.status === 'connected' && pluginStatus === 'ok' && vectorOk ? 'ok' : 'degraded';
@@ -190,7 +199,8 @@ export function createHealthEndpoint(options: HealthEndpointOptions = {}) {
     const pluginCount = options.pluginCount ?? (pluginItems.length || installedPluginCount());
     const pluginStatus = pluginItems.some((plugin) => plugin.status === 'degraded') ? 'degraded' : 'ok';
     const toolCount = mcpTools.length + (options.pluginMcpToolCount ?? 0);
-    const vectorRuntime = getVectorRuntimeStatus();
+    const vectorRuntime = options.vectorPreflight ?? getVectorRuntimeStatus();
+    const vectorAvailable = vectorAvailability(vectorRuntime, vectorServer);
 
     const serviceUptime = Math.round(uptimeSeconds * 1000) / 1000;
     return {
@@ -206,6 +216,7 @@ export function createHealthEndpoint(options: HealthEndpointOptions = {}) {
       dbStatus: dbStatus.status,
       vectorStatus: vector.status,
       ...vectorRuntime,
+      vectorAvailable,
       pluginStatus,
       mcpToolCount: toolCount,
       pluginCount,

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,7 @@ import { createUnifiedPluginRouteMount, createUnifiedRuntimeRef, type UnifiedRun
 import { startUnifiedPluginServers } from './plugins/unified-server.ts';
 import { closeCachedVectorStores } from './vector/factory.ts';
 import { warmEmbeddingProviderDetection } from './vector/provider-detection.ts';
+import { preflightVectorRuntime, type VectorPreflightStatus } from './vector/preflight.ts';
 import { drainingResponseFor, isDraining, registerGracefulShutdown, runShutdownSteps, trackRequest } from './lifecycle/shutdown.ts';
 import { createErrorMiddleware } from './middleware/errors.ts';
 import { validateStartupEnv } from './config/validate.ts';
@@ -77,9 +78,10 @@ export interface CreateAppOptions {
   runtimeRef?: UnifiedRuntimeRef<UnifiedRuntime>;
   dataDir?: string;
   vectorUrl?: string;
+  vectorPreflight?: VectorPreflightStatus;
 }
 
-export function createApp({ unifiedPlugins, runtimeRef = createUnifiedRuntimeRef(unifiedPlugins), dataDir = ORACLE_DATA_DIR, vectorUrl = VECTOR_URL }: CreateAppOptions) {
+export function createApp({ unifiedPlugins, runtimeRef = createUnifiedRuntimeRef(unifiedPlugins), dataDir = ORACLE_DATA_DIR, vectorUrl = VECTOR_URL, vectorPreflight }: CreateAppOptions) {
   const app = new Elysia()
     .use(createRequestLoggingMiddleware())
     .use(createCorrelationMiddleware())
@@ -112,7 +114,7 @@ export function createApp({ unifiedPlugins, runtimeRef = createUnifiedRuntimeRef
     .get('/api/openapi.json', () => Response.redirect('/api/docs/json', 308), { detail: { hide: true } })
     .get('/', () => ({ server: MCP_SERVER_NAME, version: pkg.version, status: 'ok', docs: '/api/docs', api: '/api/v1' }));
 
-  const healthRoutes = createHealthRoutes({ pluginCount: unifiedPlugins.pluginCount, pluginMcpToolCount: unifiedPlugins.mcpTools.length, pluginStatuses: unifiedPlugins.pluginStatuses, isDraining });
+  const healthRoutes = createHealthRoutes({ pluginCount: unifiedPlugins.pluginCount, pluginMcpToolCount: unifiedPlugins.mcpTools.length, pluginStatuses: unifiedPlugins.pluginStatuses, isDraining, vectorPreflight });
   const apiModules = [authRoutes, settingsRoutes, feedRoutes, healthRoutes, dashboardRoutes, searchRoutes, vectorRoutes, vectorConfigApiRoutes, conceptsRoutes, knowledgeRoutes, verifyRoutes, supersedeRoutes, forumApi, tracesApi, scheduleApi, filesRouter, createPluginsRouter({ registry: () => runtimeRef.current.pluginRegistry(), runtimeRef }), sessionsRoutes, vaultRoutes, metricsRoutes, exportRoutes, memoryRoutes, canvasRoutes, tenantsRoutes, watcherRoutes, indexerRoutes];
   const modules = [...apiModules, createMcpRoutes(unifiedPlugins.mcpTools), createMenuRoutes(menuItemsFromUnifiedPlugins(unifiedPlugins.menu))];
   for (const mod of modules) app.use(mod as any);
@@ -129,7 +131,8 @@ export async function startServer(options: StartServerOptions = {}): Promise<Ret
 export async function createStartedApp(options: StartServerOptions = {}): Promise<ServerSpec> {
   const startupConfig = validateStartupEnv();
   resetIndexerStatus();
-  console.log('[Vector] mode:', VECTOR_URL ? 'proxy → ' + VECTOR_URL : 'local');
+  const vectorPreflight = await preflightVectorRuntime({ warn: (message) => console.warn(message) });
+  console.log('[Vector] mode:', vectorPreflight.vectorUrl ? 'proxy → ' + vectorPreflight.vectorUrl : vectorPreflight.vectorMode);
   void warmEmbeddingProviderDetection().catch((error) => console.warn('[Vector] embedding provider auto-detect failed:', error instanceof Error ? error.message : String(error)));
   logBusyTimeout();
   const ownsPidFile = options.writePidFile !== false;
@@ -144,7 +147,7 @@ export async function createStartedApp(options: StartServerOptions = {}): Promis
   const unifiedServers = await startUnifiedPluginServers(unifiedPlugins.servers);
   registerGracefulShutdown({ close: async () => shutdown(unifiedPlugins, unifiedServers, ownsPidFile) });
 
-  const app = createApp({ unifiedPlugins });
+  const app = createApp({ unifiedPlugins, vectorPreflight });
   await seedMenus(app, unifiedPlugins);
   await announceStartup(app, startupConfig);
   const serverFetch = createRequestTimeoutFetch(createRequestDedupFetch(createApiVersionedFetch(createTenantFetch(createDbContextFetch((request: Request) => app.fetch(request))))));

--- a/src/vector/__tests__/preflight.test.ts
+++ b/src/vector/__tests__/preflight.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test';
+import { preflightVectorRuntime } from '../preflight.ts';
+
+const argv = ['bun', 'src/server.ts'];
+
+describe('preflightVectorRuntime', () => {
+  test('probes VECTOR_URL and marks proxied vector available', async () => {
+    const seen: string[] = [];
+    const result = await preflightVectorRuntime({
+      env: { VECTOR_URL: 'http://vector.local:8081' },
+      argv,
+      fetcher: async (input) => {
+        seen.push(String(input));
+        return Response.json({ status: 'ok', protocol: 'vector-proxy-v1' });
+      },
+    });
+
+    expect(seen).toEqual(['http://vector.local:8081/health']);
+    expect(result).toMatchObject({
+      vectorMode: 'proxied',
+      vectorUrl: 'http://vector.local:8081',
+      vectorAvailable: true,
+      vectorServer: { status: 'ok', protocol: 'vector-proxy-v1' },
+    });
+  });
+
+  test('keeps startup non-fatal and reports unavailable proxy', async () => {
+    const warnings: string[] = [];
+    const result = await preflightVectorRuntime({
+      env: { VECTOR_URL: 'http://vector.local:8081' },
+      argv,
+      fetcher: async () => new Response('down', { status: 503 }),
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(result.vectorMode).toBe('proxied');
+    expect(result.vectorAvailable).toBe(false);
+    expect(result.vectorServer).toMatchObject({ status: 'down', httpStatus: 503 });
+    expect(warnings[0]).toContain('VECTOR_URL preflight failed');
+  });
+});

--- a/src/vector/preflight.ts
+++ b/src/vector/preflight.ts
@@ -1,0 +1,32 @@
+import { getVectorRuntimeStatus, type VectorRuntimeStatus } from './runtime-status.ts';
+import { readVectorServerHealth, type VectorServerHealth } from '../routes/health/vector-server.ts';
+
+export interface VectorPreflightStatus extends VectorRuntimeStatus {
+  vectorAvailable: boolean;
+  vectorServer?: VectorServerHealth;
+}
+
+export interface VectorPreflightOptions {
+  env?: Record<string, string | undefined>;
+  argv?: string[];
+  fetcher?: typeof fetch;
+  warn?: (message: string) => void;
+}
+
+export async function preflightVectorRuntime(options: VectorPreflightOptions = {}): Promise<VectorPreflightStatus> {
+  const env = options.env ?? process.env;
+  const argv = options.argv ?? process.argv;
+  const runtime = getVectorRuntimeStatus({ env, argv });
+  if (runtime.vectorMode !== 'proxied') return { ...runtime, vectorAvailable: runtime.vectorMode === 'embedded' };
+
+  const vectorServer = await readVectorServerHealth(options.fetcher ?? fetch, env, argv);
+  const vectorAvailable = vectorServer.status === 'ok';
+  if (!vectorAvailable) options.warn?.(formatVectorPreflightWarning(vectorServer));
+  return { ...runtime, vectorAvailable, vectorServer };
+}
+
+function formatVectorPreflightWarning(vectorServer: VectorServerHealth): string {
+  const target = vectorServer.url ?? 'configured vector server';
+  const detail = vectorServer.error ? `: ${vectorServer.error}` : '';
+  return `[Vector] VECTOR_URL preflight failed for ${target}${detail}`;
+}

--- a/tests/http/health/vector-server-aggregation.test.ts
+++ b/tests/http/health/vector-server-aggregation.test.ts
@@ -26,6 +26,7 @@ test('GET /api/health includes separate vector-server health when configured', a
 
   expect(res.status).toBe(200);
   expect(body.status).toBe('ok');
+  expect(body.vectorAvailable).toBe(true);
   expect(body.vectorServer).toMatchObject({
     configured: true,
     status: 'ok',
@@ -46,6 +47,7 @@ test('GET /api/health degrades when configured vector-server is down', async () 
   const body = await res.json() as Record<string, any>;
 
   expect(body.status).toBe('degraded');
+  expect(body.vectorAvailable).toBe(false);
   expect(body.vectorServer).toMatchObject({ status: 'down', error: 'unreachable' });
 });
 


### PR DESCRIPTION
## Summary
- Adds serve-time `VECTOR_URL` preflight for proxied vector sidecars.
- Surfaces `vectorAvailable` in `/api/health` beside existing `vectorMode` and `vectorServer` details.
- Covers healthy/down vector preflight plus health aggregation behavior.

## Validation
```bash
bun test src/vector/__tests__/preflight.test.ts src/routes/health/__tests__/health-vector-mode.test.ts tests/http/health src/server/__tests__/server-factory.test.ts
bunx tsc --noEmit
```

## Notes
- Preflight is non-fatal: startup continues but logs a warning when `VECTOR_URL` is configured and unreachable.
- Rebased on latest `origin/alpha` after unified runtime route changes.
- PR targets `alpha`.
