### PR TITLE
feat: preflight vector sidecar on startup

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,7 @@ import { createUnifiedPluginRouteMount, createUnifiedRuntimeRef, type UnifiedRun
 import { startUnifiedPluginServers } from './plugins/unified-server.ts';
 import { closeCachedVectorStores } from './vector/factory.ts';
 import { warmEmbeddingProviderDetection } from './vector/provider-detection.ts';
+import { preflightVectorRuntime } from './vector/preflight.ts';
 import { drainingResponseFor, isDraining, registerGracefulShutdown, runShutdownSteps, trackRequest } from './lifecycle/shutdown.ts';
 import { createErrorMiddleware } from './middleware/errors.ts';
 import { validateStartupEnv } from './config/validate.ts';
@@ -129,7 +130,8 @@ export async function startServer(options: StartServerOptions = {}): Promise<Ret
 export async function createStartedApp(options: StartServerOptions = {}): Promise<ServerSpec> {
   const startupConfig = validateStartupEnv();
   resetIndexerStatus();
-  console.log('[Vector] mode:', VECTOR_URL ? 'proxy → ' + VECTOR_URL : 'local');
+  const vectorPreflight = await preflightVectorRuntime({ warn: (message) => console.warn(message) });
+  console.log('[Vector] mode:', vectorPreflight.vectorUrl ? 'proxy → ' + vectorPreflight.vectorUrl : vectorPreflight.vectorMode);
   void warmEmbeddingProviderDetection().catch((error) => console.warn('[Vector] embedding provider auto-detect failed:', error instanceof Error ? error.message : String(error)));
   logBusyTimeout();
   const ownsPidFile = options.writePidFile !== false;

--- a/src/vector/__tests__/preflight.test.ts
+++ b/src/vector/__tests__/preflight.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test';
+import { preflightVectorRuntime } from '../preflight.ts';
+
+const argv = ['bun', 'src/server.ts'];
+
+describe('preflightVectorRuntime', () => {
+  test('probes VECTOR_URL and marks proxied vector available', async () => {
+    const seen: string[] = [];
+    const result = await preflightVectorRuntime({
+      env: { VECTOR_URL: 'http://vector.local:8081' },
+      argv,
+      fetcher: async (input) => {
+        seen.push(String(input));
+        return Response.json({ status: 'ok', protocol: 'vector-proxy-v1' });
+      },
+    });
+
+    expect(seen).toEqual(['http://vector.local:8081/health']);
+    expect(result).toMatchObject({
+      vectorMode: 'proxied',
+      vectorUrl: 'http://vector.local:8081',
+      vectorAvailable: true,
+      vectorServer: { status: 'ok', protocol: 'vector-proxy-v1' },
+    });
+  });
+
+  test('keeps startup non-fatal and reports unavailable proxy', async () => {
+    const warnings: string[] = [];
+    const result = await preflightVectorRuntime({
+      env: { VECTOR_URL: 'http://vector.local:8081' },
+      argv,
+      fetcher: async () => new Response('down', { status: 503 }),
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(result.vectorMode).toBe('proxied');
+    expect(result.vectorAvailable).toBe(false);
+    expect(result.vectorServer).toMatchObject({ status: 'down', httpStatus: 503 });
+    expect(warnings[0]).toContain('VECTOR_URL preflight failed');
+  });
+});

--- a/src/vector/preflight.ts
+++ b/src/vector/preflight.ts
@@ -1,0 +1,32 @@
+import { getVectorRuntimeStatus, type VectorRuntimeStatus } from './runtime-status.ts';
+import { readVectorServerHealth, type VectorServerHealth } from '../routes/health/vector-server.ts';
+
+export interface VectorPreflightStatus extends VectorRuntimeStatus {
+  vectorAvailable: boolean;
+  vectorServer?: VectorServerHealth;
+}
+
+export interface VectorPreflightOptions {
+  env?: Record<string, string | undefined>;
+  argv?: string[];
+  fetcher?: typeof fetch;
+  warn?: (message: string) => void;
+}
+
+export async function preflightVectorRuntime(options: VectorPreflightOptions = {}): Promise<VectorPreflightStatus> {
+  const env = options.env ?? process.env;
+  const argv = options.argv ?? process.argv;
+  const runtime = getVectorRuntimeStatus({ env, argv });
+  if (runtime.vectorMode !== 'proxied') return { ...runtime, vectorAvailable: runtime.vectorMode === 'embedded' };
+
+  const vectorServer = await readVectorServerHealth(options.fetcher ?? fetch, env, argv);
+  const vectorAvailable = vectorServer.status === 'ok';
+  if (!vectorAvailable) options.warn?.(formatVectorPreflightWarning(vectorServer));
+  return { ...runtime, vectorAvailable, vectorServer };
+}
+
+function formatVectorPreflightWarning(vectorServer: VectorServerHealth): string {
+  const target = vectorServer.url ?? 'configured vector server';
+  const detail = vectorServer.error ? `: ${vectorServer.error}` : '';
+  return `[Vector] VECTOR_URL preflight failed for ${target}${detail}`;
+}


### PR DESCRIPTION
## Summary
- Adds serve-time `VECTOR_URL` preflight for proxied vector sidecars.
- Logs non-fatal startup warnings when the configured vector sidecar is unavailable.
- Adds focused coverage for healthy/down VECTOR_URL preflight behavior.

## Existing alpha coverage
- `alpha` already includes `/api/health` `vectorMode` + `vectorAvailable` coverage from the latest merged slices.

## Validation
Run against PR commit `f2e235c` rebased on latest `origin/alpha`:

```bash
bun install --frozen-lockfile
bun test src/vector/__tests__/preflight.test.ts src/routes/health/__tests__/health-vector-mode.test.ts tests/http/health src/server/__tests__/server-factory.test.ts
bunx tsc --noEmit
```

## Notes
- Preflight is non-fatal so FTS fallback remains available.
- PR targets `alpha`.
