### PR TITLE
feat(vector): write entity sidecar collection

### DIFF
--- a/src/routes/indexer/start.ts
+++ b/src/routes/indexer/start.ts
@@ -4,6 +4,7 @@ import { createDatabase } from '../../db/index.ts';
 import { setIndexingStatus } from '../../indexer/status.ts';
 import { DB_PATH, REPO_ROOT } from '../../config.ts';
 import { currentTenantId, runWithTenant } from '../../middleware/tenant.ts';
+import { entityCollectionName, entityDocumentsFor } from '../../vector/entities.ts';
 import type { IndexerConfig } from '../../types.ts';
 
 let abortFlag = false;
@@ -65,7 +66,9 @@ export function createStartRoute(deps: StartRouteDeps = {}) {
       },
     };
 
-    const store = (deps.createStore ?? createVectorStoreForModel)(preset);
+    const storeFactory = deps.createStore ?? createVectorStoreForModel;
+    const store = storeFactory(preset);
+    const entityStore = storeFactory({ ...preset, collection: entityCollectionName(preset.collection) });
 
     abortFlag = false;
 
@@ -75,8 +78,11 @@ export function createStartRoute(deps: StartRouteDeps = {}) {
     const task = runWithTenant(tenantId, async () => {
       try {
         await store.connect();
+        await entityStore.connect();
         try { await store.deleteCollection(); } catch {}
+        try { await entityStore.deleteCollection(); } catch {}
         await store.ensureCollection();
+        await entityStore.ensureCollection();
 
         const tenantWhere = tenantId ? 'WHERE d.tenant_id = ?' : '';
         const rows = sqlite.prepare(`
@@ -115,6 +121,8 @@ export function createStartRoute(deps: StartRouteDeps = {}) {
           }));
 
           await store.addDocuments(docs);
+          const entityDocs = docs.flatMap(entityDocumentsFor);
+          if (entityDocs.length > 0) await entityStore.addDocuments(entityDocs);
           setIndexingStatus(sqlite, config, true, i + batchRows.length, total);
         }
 
@@ -126,6 +134,7 @@ export function createStartRoute(deps: StartRouteDeps = {}) {
         setIndexingStatus(sqlite, config, false, 0, 0, msg);
       } finally {
         await store.close().catch(() => undefined);
+        await entityStore.close().catch(() => undefined);
       }
     });
     (deps.runInBackground ?? ((backgroundTask) => { void backgroundTask; }))(task);

--- a/src/vector/entities.ts
+++ b/src/vector/entities.ts
@@ -1,0 +1,54 @@
+import type { VectorDocument } from './types.ts';
+
+export interface EntitySourceDocument extends VectorDocument {
+  metadata: VectorDocument['metadata'] & { tenant_id?: string | number };
+}
+
+const MAX_ENTITIES_PER_DOC = 12;
+const ENTITY_PATTERN = /\b(?:[A-Z][\p{L}\p{N}._-]*(?:\s+[A-Z][\p{L}\p{N}._-]*){0,3}|[a-z][\p{L}\p{N}]+(?:[-_][a-z0-9][\p{L}\p{N}]*)+)\b/gu;
+const STOPWORDS = new Set(['The', 'This', 'That', 'These', 'Those', 'When', 'Where', 'What', 'Why', 'How', 'And', 'But', 'For', 'With', 'From']);
+
+export function entityCollectionName(collection: string): string {
+  return `${collection}_entities`;
+}
+
+export function extractEntities(text: string, concepts?: unknown): string[] {
+  const candidates = new Set<string>();
+  for (const concept of conceptValues(concepts)) addEntity(candidates, concept);
+  for (const match of text.matchAll(ENTITY_PATTERN)) addEntity(candidates, match[0]);
+  return [...candidates].slice(0, MAX_ENTITIES_PER_DOC);
+}
+
+export function entityDocumentsFor(doc: EntitySourceDocument): VectorDocument[] {
+  return extractEntities(doc.document, doc.metadata.concepts).map((entity) => ({
+    id: `${doc.id}:entity:${slug(entity)}`,
+    document: entity,
+    metadata: {
+      entity,
+      source_doc_id: doc.id,
+      tenant_id: doc.metadata.tenant_id ?? '',
+      type: 'entity',
+    },
+  }));
+}
+
+function addEntity(out: Set<string>, raw: string): void {
+  const entity = raw.replace(/\s+/g, ' ').trim();
+  if (entity.length < 3 || STOPWORDS.has(entity)) return;
+  out.add(entity);
+}
+
+function conceptValues(raw: unknown): string[] {
+  if (Array.isArray(raw)) return raw.filter((item): item is string => typeof item === 'string');
+  if (typeof raw !== 'string') return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : [];
+  } catch {
+    return raw.split(',').map((item) => item.trim()).filter(Boolean);
+  }
+}
+
+function slug(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 80) || 'entity';
+}

--- a/tests/http/indexer/basic.test.ts
+++ b/tests/http/indexer/basic.test.ts
@@ -112,7 +112,7 @@ describe('indexer HTTP routes', () => {
       expect(res.status).toBe(200);
       expect(body.batchSize).toBe(100);
       expect(status.error).toBe('embed failed');
-      expect(close).toHaveBeenCalledTimes(1);
+      expect(close).toHaveBeenCalledTimes(2);
     } finally {
       sqlite.close();
     }
@@ -123,13 +123,14 @@ describe('indexer HTTP routes', () => {
     const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
     const tenantA = `tenant-a-${stamp}`;
     const tenantB = `tenant-b-${stamp}`;
-    seedDoc(sqlite, `idx-a-${stamp}`, tenantA, `alpha ${stamp}`, 2);
+    seedDoc(sqlite, `idx-a-${stamp}`, tenantA, `Alpha Project ${stamp}`, 2);
     seedDoc(sqlite, `idx-b-${stamp}`, tenantB, `beta ${stamp}`, 1);
     const added: VectorDocument[] = [];
+    const entityDocs: VectorDocument[] = [];
     const tasks: Promise<void>[] = [];
     const app = new Elysia({ prefix: '/api' }).use(createStartRoute({
       createDb: () => ({ sqlite } as any),
-      createStore: () => fakeStore(added),
+      createStore: (preset: any) => fakeStore(String(preset.collection).endsWith('_entities') ? entityDocs : added),
       getModels: () => ({ nomic: { collection: 'test', model: 'nomic-embed-text' } }),
       runInBackground: (task) => tasks.push(task),
     }));
@@ -147,8 +148,11 @@ describe('indexer HTTP routes', () => {
       expect(res.status).toBe(200);
       expect(body.tenantId).toBe(tenantA);
       expect(added.map((doc) => doc.id)).toEqual([`idx-a-${stamp}`]);
-      expect(added[0].document).toContain('alpha');
+      expect(added[0].document).toContain('Alpha Project');
       expect(added[0].metadata.tenant_id).toBe(tenantA);
+      expect(entityDocs.map((doc) => doc.document)).toContain('Alpha Project');
+      expect(entityDocs[0].metadata.source_doc_id).toBe(`idx-a-${stamp}`);
+      expect(entityDocs[0].metadata.tenant_id).toBe(tenantA);
       expect(status.progress_total).toBe(1);
     } finally {
       sqlite.close();

--- a/tests/vector/entities.test.ts
+++ b/tests/vector/entities.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from 'bun:test';
+import { entityCollectionName, entityDocumentsFor, extractEntities } from '../../src/vector/entities.ts';
+
+test('extractEntities combines concept metadata with write-time text entities', () => {
+  const entities = extractEntities('Arra Oracle indexes Cloudflare Workers and mem0-style entity links.', '["LanceDB","Cloudflare Workers"]');
+  expect(entities).toContain('LanceDB');
+  expect(entities).toContain('Cloudflare Workers');
+  expect(entities).toContain('Arra Oracle');
+  expect(entities).toContain('mem0-style');
+});
+
+test('entityDocumentsFor writes a parallel vector payload without graph edges', () => {
+  const docs = entityDocumentsFor({
+    id: 'doc-1',
+    document: 'Arra Oracle recalls Nat projects.',
+    metadata: { concepts: 'Oracle,Nat', tenant_id: 'team-a' },
+  });
+
+  expect(entityCollectionName('oracle_knowledge')).toBe('oracle_knowledge_entities');
+  expect(docs[0]).toMatchObject({
+    id: 'doc-1:entity:oracle',
+    document: 'Oracle',
+    metadata: { source_doc_id: 'doc-1', tenant_id: 'team-a', type: 'entity' },
+  });
+});


### PR DESCRIPTION
## Summary
- Adds lightweight write-time entity extraction for vector indexing, following the mem0 2026 entity-linking path without introducing a graph DB.
- Writes extracted entities into a parallel `{collection}_entities` vector collection.
- Preserves source document and tenant metadata for later entity-match fusion work.

## Validation
```bash
bun test tests/vector/entities.test.ts tests/http/indexer/basic.test.ts
bunx tsc --noEmit
git diff --check
```

## Notes
- This slice only creates and populates the sidecar collection. Query-time entity-match as a third fusion signal can build on the sidecar in a follow-up.
- PR targets `alpha`.
