### PR TITLE
test: harden memory fanout confidence edges

### DIFF
--- a/src/routes/memory/fanout.ts
+++ b/src/routes/memory/fanout.ts
@@ -103,6 +103,9 @@ function toSearchResults(collection: string, result: VectorQueryResult): FanoutS
       updatedAt: dateText(metadata.updatedAt ?? metadata.updated_at),
       usageCount: numberValue(metadata.usageCount ?? metadata.usage_count),
       lastAccessedAt: dateText(metadata.lastAccessedAt ?? metadata.last_accessed_at),
+      superseded_by: text(metadata.superseded_by ?? metadata.supersededBy),
+      superseded_at: dateText(metadata.superseded_at ?? metadata.supersededAt),
+      superseded_reason: text(metadata.superseded_reason ?? metadata.supersededReason),
     };
   });
 }

--- a/src/server/__tests__/vector-indexer-source.test.ts
+++ b/src/server/__tests__/vector-indexer-source.test.ts
@@ -29,7 +29,9 @@ function writeSqliteDb() {
   db.exec(`
     CREATE TABLE oracle_documents (
       id TEXT PRIMARY KEY, type TEXT, source_file TEXT,
-      concepts TEXT, project TEXT, created_at INTEGER
+      concepts TEXT, project TEXT, created_at INTEGER,
+      usage_count INTEGER NOT NULL DEFAULT 0,
+      last_accessed_at INTEGER
     );
     CREATE TABLE oracle_fts (id TEXT, content TEXT);
   `);

--- a/src/tools/__tests__/learn-enqueue.test.ts
+++ b/src/tools/__tests__/learn-enqueue.test.ts
@@ -59,6 +59,8 @@ CREATE TABLE indexing_jobs (
 
 const ORIGINAL_ENQUEUE = process.env.ORACLE_INDEXER_ENQUEUE;
 const ORIGINAL_REPO_ROOT = process.env.ORACLE_REPO_ROOT;
+const ORIGINAL_EMBEDDER = process.env.ORACLE_EMBEDDER;
+const ORIGINAL_EMBEDDING_PROVIDER = process.env.ORACLE_EMBEDDING_PROVIDER;
 
 interface Harness {
   ctx: ToolContext;
@@ -92,6 +94,8 @@ function cleanupHarness(h: Harness): void {
 // import below — main's REPO_ROOT is module-frozen at first import.
 const SHARED_REPO_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-learn-m5-root-'));
 process.env.ORACLE_REPO_ROOT = SHARED_REPO_ROOT;
+process.env.ORACLE_EMBEDDER = 'none';
+process.env.ORACLE_EMBEDDING_PROVIDER = 'none';
 const createdMarkdownFiles = new Set<string>();
 
 function markdownPathCandidates(relativePath: string): string[] {
@@ -134,6 +138,8 @@ describe('handleLearn — M5 enqueue branch', () => {
     createdMarkdownFiles.clear();
     if (ORIGINAL_ENQUEUE) process.env.ORACLE_INDEXER_ENQUEUE = ORIGINAL_ENQUEUE;
     else delete process.env.ORACLE_INDEXER_ENQUEUE;
+    process.env.ORACLE_EMBEDDER = 'none';
+    process.env.ORACLE_EMBEDDING_PROVIDER = 'none';
   });
 
   it('default (env unset) → does NOT enqueue any jobs (existing behavior preserved)', async () => {
@@ -222,4 +228,8 @@ describe('handleLearn — M5 enqueue branch', () => {
 process.on('exit', () => {
   try { fs.rmSync(SHARED_REPO_ROOT, { recursive: true, force: true }); } catch {}
   if (ORIGINAL_REPO_ROOT) process.env.ORACLE_REPO_ROOT = ORIGINAL_REPO_ROOT;
+  if (ORIGINAL_EMBEDDER) process.env.ORACLE_EMBEDDER = ORIGINAL_EMBEDDER;
+  else delete process.env.ORACLE_EMBEDDER;
+  if (ORIGINAL_EMBEDDING_PROVIDER) process.env.ORACLE_EMBEDDING_PROVIDER = ORIGINAL_EMBEDDING_PROVIDER;
+  else delete process.env.ORACLE_EMBEDDING_PROVIDER;
 });

--- a/src/tools/__tests__/learn-enqueue.test.ts
+++ b/src/tools/__tests__/learn-enqueue.test.ts
@@ -99,7 +99,8 @@ process.env.ORACLE_EMBEDDING_PROVIDER = 'none';
 const createdMarkdownFiles = new Set<string>();
 
 function markdownPathCandidates(relativePath: string): string[] {
-  return [SHARED_REPO_ROOT, process.cwd()]
+  const dataRoot = process.env.ORACLE_DATA_DIR || path.join(os.homedir(), '.arra-oracle-v2');
+  return [SHARED_REPO_ROOT, process.cwd(), dataRoot]
     .map((root) => path.join(root, relativePath));
 }
 

--- a/tests/http/indexer/basic.test.ts
+++ b/tests/http/indexer/basic.test.ts
@@ -166,7 +166,8 @@ function tenantIndexerDb() {
     CREATE TABLE oracle_documents (
       id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, type TEXT NOT NULL,
       source_file TEXT NOT NULL, concepts TEXT NOT NULL, project TEXT,
-      created_at INTEGER NOT NULL
+      created_at INTEGER NOT NULL, usage_count INTEGER NOT NULL DEFAULT 0,
+      last_accessed_at INTEGER
     );
     CREATE TABLE oracle_fts (id TEXT, content TEXT, concepts TEXT);
     CREATE TABLE indexing_status (

--- a/tests/http/memory/confidence.test.ts
+++ b/tests/http/memory/confidence.test.ts
@@ -90,3 +90,20 @@ test('retrieval reinforcement boosts stale docs without removing decay warnings'
   expect(reinforced.reasons).toContain('retrieval_reinforced');
   expect(reinforced.warnings).toContain('stale_unvalidated');
 });
+
+test('confidence clamps malformed signals and future access without exploding score', () => {
+  const confidence = memoryConfidence(memory({
+    createdAt: 'not-a-date',
+    updatedAt: 'not-a-date',
+    usageCount: -4.9,
+    lastAccessedAt: '2026-07-01T00:00:00.000Z',
+  }), { now, mode: 'semantic', semanticScore: Number.POSITIVE_INFINITY });
+
+  expect(confidence.score).toBeGreaterThanOrEqual(0);
+  expect(confidence.score).toBeLessThanOrEqual(1);
+  expect(confidence.components.match).toBe(0);
+  expect(confidence.usageCount).toBe(0);
+  expect(confidence.lastAccessedAgeDays).toBe(0);
+  expect(confidence.reasons).toContain('source_missing');
+  expect(confidence.warnings).toEqual(expect.arrayContaining(['missing_source', 'missing_tags']));
+});

--- a/tests/http/memory/fanout.test.ts
+++ b/tests/http/memory/fanout.test.ts
@@ -167,3 +167,32 @@ test('fuseRankedResults can disable confidence weighting for pure RRF ordering',
   expect(first.id).toBe('stale-duplicate');
   expect(first.confidenceWeight).toBe(0);
 });
+
+test('GET /api/v1/memory/fanout preserves supersede metadata from vector hits', async () => {
+  const supersededAt = Date.parse('2026-06-16T10:00:00.000Z');
+  const app = new Elysia({ prefix: '/api' }).use(createMemoryFanoutEndpoint({
+    models: () => ({ alpha: models.alpha }),
+    connect: async () => ({ query: async () => ({
+      ids: ['old-memory'],
+      documents: ['Legacy memory replaced by newer source.'],
+      distances: [0],
+      metadatas: [{
+        type: 'memory',
+        source_file: 'ψ/memory/old.md',
+        superseded_by: 'new-memory',
+        superseded_at: supersededAt,
+        superseded_reason: 'newer source of truth',
+      }],
+    }) }),
+  }));
+  const fetcher = createApiVersionedFetch((request) => app.handle(request));
+  const response = await fetcher(new Request('http://local/api/v1/memory/fanout?q=legacy'));
+  const body = await json(response);
+
+  expect(body.results[0]).toMatchObject({
+    id: 'old-memory',
+    superseded_by: 'new-memory',
+    superseded_at: '2026-06-16T10:00:00.000Z',
+    superseded_reason: 'newer source of truth',
+  });
+});

--- a/tests/http/watcher/file-watcher.test.ts
+++ b/tests/http/watcher/file-watcher.test.ts
@@ -23,7 +23,9 @@ CREATE TABLE oracle_documents (
   origin TEXT,
   project TEXT,
   tenant_id TEXT NOT NULL DEFAULT 'default',
-  created_by TEXT
+  created_by TEXT,
+  usage_count INTEGER NOT NULL DEFAULT 0,
+  last_accessed_at INTEGER
 );
 CREATE VIRTUAL TABLE oracle_fts USING fts5(id UNINDEXED, content, concepts, tokenize='porter unicode61');
 CREATE TABLE indexing_jobs (


### PR DESCRIPTION
## Summary

- Preserve supersede metadata (`superseded_by`, `superseded_at`, `superseded_reason`) when memory fanout results are built from vector metadata.
- Add fanout coverage for superseded vector hits so stale memory pointers survive the confidence/RRF path.
- Add confidence hardening coverage for malformed dates, negative usage counts, future access timestamps, and non-finite semantic scores.
- Sync evolved document fixture schemas used by learn/indexer/watcher tests so CI remains hermetic after the document usage reinforcement columns.

## Validation

```bash
bun test tests/http/memory/
bun test --isolate src/tools/__tests__/learn-enqueue.test.ts src/server/__tests__/vector-indexer-source.test.ts tests/http/watcher/file-watcher.test.ts tests/http/indexer/basic.test.ts
bun run test:unit
bunx tsc --noEmit
git diff --check
wc -l src/routes/memory/fanout.ts src/server/__tests__/vector-indexer-source.test.ts src/tools/__tests__/learn-enqueue.test.ts tests/http/indexer/basic.test.ts tests/http/memory/confidence.test.ts tests/http/memory/fanout.test.ts tests/http/watcher/file-watcher.test.ts
```

## CI

- PR #2291 is rebased on `origin/alpha` and mergeable.
- Typecheck and scoped tests: green.
