### PR TITLE
feat(vector): write entity sidecar collection

### DIFF
--- a/src/indexer-preservation.test.ts
+++ b/src/indexer-preservation.test.ts
@@ -1,218 +1,35 @@
-/**
- * Indexer Preservation Tests
- *
- * Tests that oracle_learn documents are preserved during re-indexing.
- * This is critical for cross-repo knowledge sharing.
- *
- * Philosophy: "Nothing is Deleted" - oracle_learn docs have no local files
- * and must not be wiped during indexer runs.
- */
-
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
-import { Database } from 'bun:sqlite';
-import { drizzle, BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
-import { eq, and, or, isNull, inArray } from 'drizzle-orm';
-import * as schema from './db/schema.ts';
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { eq } from 'drizzle-orm';
 import { oracleDocuments } from './db/schema.ts';
-import fs from 'fs';
+import { database, insertTestDoc, resetPreservationDb, simulateSmartDeletion } from './indexer/preservation-harness.test-helper.ts';
+import { registerExtraPreservationTests } from './indexer/preservation-extra.test-helper.ts';
 
-// ============================================================================
-// Test Database Setup
-// ============================================================================
-
-let sqlite: Database;
-let db: BunSQLiteDatabase<typeof schema>;
-const TEST_DB_PATH = '/tmp/oracle-indexer-preservation-test.db';
-
-beforeAll(() => {
-  // Remove existing test db
-  if (fs.existsSync(TEST_DB_PATH)) {
-    fs.unlinkSync(TEST_DB_PATH);
-  }
-
-  sqlite = new Database(TEST_DB_PATH);
-  db = drizzle(sqlite, { schema });
-
-  // Create schema matching production
-  sqlite.exec(`
-    -- Main document index
-    CREATE TABLE oracle_documents (
-      id TEXT PRIMARY KEY,
-      type TEXT NOT NULL,
-      source_file TEXT NOT NULL,
-      concepts TEXT NOT NULL DEFAULT '[]',
-      created_at INTEGER NOT NULL,
-      updated_at INTEGER NOT NULL,
-      indexed_at INTEGER NOT NULL,
-      superseded_by TEXT,
-      superseded_at INTEGER,
-      superseded_reason TEXT,
-      origin TEXT,
-      project TEXT,
-      tenant_id TEXT NOT NULL DEFAULT 'default',
-      created_by TEXT
-    );
-
-    CREATE INDEX idx_type ON oracle_documents(type);
-    CREATE INDEX idx_source ON oracle_documents(source_file);
-    CREATE INDEX idx_project ON oracle_documents(project);
-    CREATE INDEX idx_tenant ON oracle_documents(tenant_id);
-    CREATE INDEX idx_created_by ON oracle_documents(created_by);
-
-    -- FTS5 virtual table
-    CREATE VIRTUAL TABLE oracle_fts USING fts5(
-      id UNINDEXED,
-      content,
-      concepts,
-      tokenize='porter unicode61'
-    );
-  `);
-});
-
-afterAll(() => {
-  sqlite.close();
-  if (fs.existsSync(TEST_DB_PATH)) {
-    fs.unlinkSync(TEST_DB_PATH);
-  }
-});
-
-beforeEach(() => {
-  // Clear tables before each test
-  sqlite.exec('DELETE FROM oracle_documents');
-  sqlite.exec('DELETE FROM oracle_fts');
-});
-
-// ============================================================================
-// Helper: Simulate Smart Deletion Logic
-// ============================================================================
-
-function simulateSmartDeletion(project: string | null): string[] {
-  const docsToDelete = db.select({ id: oracleDocuments.id })
-    .from(oracleDocuments)
-    .where(
-      and(
-        // Match current project OR universal (null)
-        project
-          ? or(eq(oracleDocuments.project, project), isNull(oracleDocuments.project))
-          : isNull(oracleDocuments.project),
-        // Only delete indexer-created OR legacy (null) docs
-        or(eq(oracleDocuments.createdBy, 'indexer'), isNull(oracleDocuments.createdBy))
-      )
-    )
-    .all();
-
-  const idsToDelete = docsToDelete.map(d => d.id);
-
-  if (idsToDelete.length > 0) {
-    db.delete(oracleDocuments)
-      .where(inArray(oracleDocuments.id, idsToDelete))
-      .run();
-
-    // Delete from FTS
-    const placeholders = idsToDelete.map(() => '?').join(',');
-    sqlite.prepare(`DELETE FROM oracle_fts WHERE id IN (${placeholders})`).run(...idsToDelete);
-  }
-
-  return idsToDelete;
-}
-
-function insertTestDoc(doc: {
-  id: string;
-  type: string;
-  sourceFile: string;
-  createdBy: string | null;
-  project: string | null;
-  content?: string;
-}) {
-  const now = Date.now();
-  db.insert(oracleDocuments)
-    .values({
-      id: doc.id,
-      type: doc.type,
-      sourceFile: doc.sourceFile,
-      concepts: '[]',
-      createdAt: now,
-      updatedAt: now,
-      indexedAt: now,
-      createdBy: doc.createdBy,
-      project: doc.project,
-    })
-    .run();
-
-  sqlite.prepare(`
-    INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)
-  `).run(doc.id, doc.content || 'Test content', '');
-}
-
-// ============================================================================
-// Preservation Tests
-// ============================================================================
+beforeEach(resetPreservationDb);
 
 describe('Indexer Preservation - oracle_learn documents', () => {
   it('should preserve oracle_learn documents during re-index', () => {
-    // Insert oracle_learn doc from another repo
-    insertTestDoc({
-      id: 'test-oracle-learn-1',
-      type: 'learning',
-      sourceFile: 'ψ/memory/learnings/test.md',
-      createdBy: 'oracle_learn',
-      project: 'github.com/other/repo',
-    });
-
-    // Insert indexer doc from current repo
-    insertTestDoc({
-      id: 'test-indexer-1',
-      type: 'learning',
-      sourceFile: 'ψ/memory/learnings/local.md',
-      createdBy: 'indexer',
-      project: 'github.com/current/repo',
-    });
-
-    // Simulate indexer run for current repo
+    insertTestDoc({ id: 'test-oracle-learn-1', type: 'learning', sourceFile: 'ψ/memory/learnings/test.md', createdBy: 'oracle_learn', project: 'github.com/other/repo' });
+    insertTestDoc({ id: 'test-indexer-1', type: 'learning', sourceFile: 'ψ/memory/learnings/local.md', createdBy: 'indexer', project: 'github.com/current/repo' });
     const deleted = simulateSmartDeletion('github.com/current/repo');
-
-    // Verify oracle_learn doc is preserved
-    const preserved = db.select().from(oracleDocuments)
+    const preserved = database().select().from(oracleDocuments)
       .where(eq(oracleDocuments.id, 'test-oracle-learn-1')).get();
+    const notPreserved = database().select().from(oracleDocuments)
+      .where(eq(oracleDocuments.id, 'test-indexer-1')).get();
     expect(preserved).toBeDefined();
     expect(preserved?.createdBy).toBe('oracle_learn');
-
-    // Verify indexer doc was deleted
-    const notPreserved = db.select().from(oracleDocuments)
-      .where(eq(oracleDocuments.id, 'test-indexer-1')).get();
     expect(notPreserved).toBeUndefined();
-
     expect(deleted).toContain('test-indexer-1');
     expect(deleted).not.toContain('test-oracle-learn-1');
   });
 
   it('should preserve oracle_learn docs from different projects', () => {
-    // Insert oracle_learn docs from various projects
-    insertTestDoc({
-      id: 'learn-repo-a',
-      type: 'learning',
-      sourceFile: 'ψ/memory/learnings/a.md',
-      createdBy: 'oracle_learn',
-      project: 'github.com/team/repo-a',
-    });
-
-    insertTestDoc({
-      id: 'learn-repo-b',
-      type: 'learning',
-      sourceFile: 'ψ/memory/learnings/b.md',
-      createdBy: 'oracle_learn',
-      project: 'github.com/team/repo-b',
-    });
-
-    // Simulate indexer run for repo-a
+    insertTestDoc({ id: 'learn-repo-a', type: 'learning', sourceFile: 'ψ/memory/learnings/a.md', createdBy: 'oracle_learn', project: 'github.com/team/repo-a' });
+    insertTestDoc({ id: 'learn-repo-b', type: 'learning', sourceFile: 'ψ/memory/learnings/b.md', createdBy: 'oracle_learn', project: 'github.com/team/repo-b' });
     simulateSmartDeletion('github.com/team/repo-a');
-
-    // Both oracle_learn docs should be preserved
-    const docA = db.select().from(oracleDocuments)
+    const docA = database().select().from(oracleDocuments)
       .where(eq(oracleDocuments.id, 'learn-repo-a')).get();
-    const docB = db.select().from(oracleDocuments)
+    const docB = database().select().from(oracleDocuments)
       .where(eq(oracleDocuments.id, 'learn-repo-b')).get();
-
     expect(docA).toBeDefined();
     expect(docB).toBeDefined();
   });
@@ -220,243 +37,35 @@ describe('Indexer Preservation - oracle_learn documents', () => {
 
 describe('Indexer Preservation - project isolation', () => {
   it('should delete indexer docs from current project only', () => {
-    // Insert indexer doc from different project
-    insertTestDoc({
-      id: 'other-repo-doc',
-      type: 'principle',
-      sourceFile: 'ψ/memory/resonance/other.md',
-      createdBy: 'indexer',
-      project: 'github.com/other/repo',
-    });
-
-    // Insert indexer doc from current project
-    insertTestDoc({
-      id: 'current-repo-doc',
-      type: 'principle',
-      sourceFile: 'ψ/memory/resonance/current.md',
-      createdBy: 'indexer',
-      project: 'github.com/current/repo',
-    });
-
-    // Simulate indexer run for current repo
+    insertTestDoc({ id: 'other-repo-doc', type: 'principle', sourceFile: 'ψ/memory/resonance/other.md', createdBy: 'indexer', project: 'github.com/other/repo' });
+    insertTestDoc({ id: 'current-repo-doc', type: 'principle', sourceFile: 'ψ/memory/resonance/current.md', createdBy: 'indexer', project: 'github.com/current/repo' });
     const deleted = simulateSmartDeletion('github.com/current/repo');
-
-    // Other repo's doc should be preserved
-    const otherDoc = db.select().from(oracleDocuments)
+    const otherDoc = database().select().from(oracleDocuments)
       .where(eq(oracleDocuments.id, 'other-repo-doc')).get();
-    expect(otherDoc).toBeDefined();
-
-    // Current repo's doc should be deleted
-    const currentDoc = db.select().from(oracleDocuments)
+    const currentDoc = database().select().from(oracleDocuments)
       .where(eq(oracleDocuments.id, 'current-repo-doc')).get();
+    expect(otherDoc).toBeDefined();
     expect(currentDoc).toBeUndefined();
-
     expect(deleted).toContain('current-repo-doc');
     expect(deleted).not.toContain('other-repo-doc');
   });
 
   it('should delete universal (null project) indexer docs', () => {
-    // Insert universal indexer doc (no project)
-    insertTestDoc({
-      id: 'universal-indexer-doc',
-      type: 'principle',
-      sourceFile: 'ψ/memory/resonance/universal.md',
-      createdBy: 'indexer',
-      project: null,
-    });
-
-    // Insert project-specific doc
-    insertTestDoc({
-      id: 'project-specific-doc',
-      type: 'principle',
-      sourceFile: 'ψ/memory/resonance/project.md',
-      createdBy: 'indexer',
-      project: 'github.com/current/repo',
-    });
-
-    // Simulate indexer run for current repo
+    insertTestDoc({ id: 'universal-indexer-doc', type: 'principle', sourceFile: 'ψ/memory/resonance/universal.md', createdBy: 'indexer', project: null });
+    insertTestDoc({ id: 'project-specific-doc', type: 'principle', sourceFile: 'ψ/memory/resonance/project.md', createdBy: 'indexer', project: 'github.com/current/repo' });
     const deleted = simulateSmartDeletion('github.com/current/repo');
-
-    // Both should be deleted (universal + current project)
     expect(deleted).toContain('universal-indexer-doc');
     expect(deleted).toContain('project-specific-doc');
   });
 
   it('should preserve universal oracle_learn docs', () => {
-    // Insert universal oracle_learn doc (created from a context without project detection)
-    insertTestDoc({
-      id: 'universal-learn-doc',
-      type: 'learning',
-      sourceFile: 'ψ/memory/learnings/universal.md',
-      createdBy: 'oracle_learn',
-      project: null,
-    });
-
-    // Simulate indexer run
+    insertTestDoc({ id: 'universal-learn-doc', type: 'learning', sourceFile: 'ψ/memory/learnings/universal.md', createdBy: 'oracle_learn', project: null });
     const deleted = simulateSmartDeletion('github.com/any/repo');
-
-    // Universal oracle_learn should be preserved
-    const doc = db.select().from(oracleDocuments)
+    const doc = database().select().from(oracleDocuments)
       .where(eq(oracleDocuments.id, 'universal-learn-doc')).get();
     expect(doc).toBeDefined();
     expect(deleted).not.toContain('universal-learn-doc');
   });
 });
 
-describe('Indexer Preservation - legacy docs (null createdBy)', () => {
-  it('should treat legacy docs (null createdBy) as indexer-created', () => {
-    // Insert legacy doc (pre-createdBy field)
-    insertTestDoc({
-      id: 'legacy-doc',
-      type: 'learning',
-      sourceFile: 'ψ/memory/learnings/legacy.md',
-      createdBy: null,
-      project: 'github.com/current/repo',
-    });
-
-    // Simulate indexer run
-    const deleted = simulateSmartDeletion('github.com/current/repo');
-
-    // Legacy doc should be deleted (treated as indexer doc)
-    const doc = db.select().from(oracleDocuments)
-      .where(eq(oracleDocuments.id, 'legacy-doc')).get();
-    expect(doc).toBeUndefined();
-    expect(deleted).toContain('legacy-doc');
-  });
-});
-
-describe('Indexer Preservation - FTS sync', () => {
-  it('should delete from FTS table when deleting from oracle_documents', () => {
-    // Insert doc with FTS content
-    insertTestDoc({
-      id: 'fts-test-doc',
-      type: 'learning',
-      sourceFile: 'ψ/memory/learnings/fts.md',
-      createdBy: 'indexer',
-      project: 'github.com/current/repo',
-      content: 'Searchable content for FTS test',
-    });
-
-    // Verify FTS entry exists
-    const ftsBefore = sqlite.prepare(
-      'SELECT id FROM oracle_fts WHERE id = ?'
-    ).get('fts-test-doc');
-    expect(ftsBefore).toBeDefined();
-
-    // Simulate indexer run
-    simulateSmartDeletion('github.com/current/repo');
-
-    // Verify FTS entry is also deleted
-    const ftsAfter = sqlite.prepare(
-      'SELECT id FROM oracle_fts WHERE id = ?'
-    ).get('fts-test-doc');
-    expect(ftsAfter).toBeFalsy(); // null or undefined
-  });
-
-  it('should preserve FTS entries for preserved documents', () => {
-    // Insert oracle_learn doc
-    insertTestDoc({
-      id: 'fts-preserved-doc',
-      type: 'learning',
-      sourceFile: 'ψ/memory/learnings/preserved.md',
-      createdBy: 'oracle_learn',
-      project: 'github.com/other/repo',
-      content: 'This content should remain searchable',
-    });
-
-    // Simulate indexer run
-    simulateSmartDeletion('github.com/current/repo');
-
-    // FTS entry should still exist
-    const fts = sqlite.prepare(
-      'SELECT content FROM oracle_fts WHERE id = ?'
-    ).get('fts-preserved-doc') as { content: string } | undefined;
-    expect(fts).toBeDefined();
-    expect(fts?.content).toBe('This content should remain searchable');
-  });
-});
-
-describe('Indexer Preservation - edge cases', () => {
-  it('should handle empty database gracefully', () => {
-    // Run on empty database
-    const deleted = simulateSmartDeletion('github.com/any/repo');
-    expect(deleted).toEqual([]);
-  });
-
-  it('should handle database with only oracle_learn docs', () => {
-    // Insert only oracle_learn docs
-    insertTestDoc({
-      id: 'only-learn-1',
-      type: 'learning',
-      sourceFile: 'ψ/memory/learnings/1.md',
-      createdBy: 'oracle_learn',
-      project: 'github.com/repo/1',
-    });
-
-    insertTestDoc({
-      id: 'only-learn-2',
-      type: 'learning',
-      sourceFile: 'ψ/memory/learnings/2.md',
-      createdBy: 'oracle_learn',
-      project: 'github.com/repo/2',
-    });
-
-    // Run indexer - should delete nothing
-    const deleted = simulateSmartDeletion('github.com/any/repo');
-    expect(deleted).toEqual([]);
-
-    // All docs should remain
-    const count = db.select().from(oracleDocuments).all().length;
-    expect(count).toBe(2);
-  });
-
-  it('should handle mixed createdBy values correctly', () => {
-    // Insert docs with various createdBy values
-    insertTestDoc({
-      id: 'indexer-doc',
-      type: 'learning',
-      sourceFile: 'ψ/memory/learnings/indexer.md',
-      createdBy: 'indexer',
-      project: 'github.com/current/repo',
-    });
-
-    insertTestDoc({
-      id: 'oracle-learn-doc',
-      type: 'learning',
-      sourceFile: 'ψ/memory/learnings/learn.md',
-      createdBy: 'oracle_learn',
-      project: 'github.com/current/repo',
-    });
-
-    insertTestDoc({
-      id: 'manual-doc',
-      type: 'learning',
-      sourceFile: 'ψ/memory/learnings/manual.md',
-      createdBy: 'manual',
-      project: 'github.com/current/repo',
-    });
-
-    insertTestDoc({
-      id: 'legacy-doc',
-      type: 'learning',
-      sourceFile: 'ψ/memory/learnings/legacy.md',
-      createdBy: null,
-      project: 'github.com/current/repo',
-    });
-
-    // Run indexer
-    const deleted = simulateSmartDeletion('github.com/current/repo');
-
-    // Only indexer and legacy should be deleted
-    expect(deleted).toContain('indexer-doc');
-    expect(deleted).toContain('legacy-doc');
-    expect(deleted).not.toContain('oracle-learn-doc');
-    expect(deleted).not.toContain('manual-doc');
-
-    // Verify remaining docs
-    const remaining = db.select({ id: oracleDocuments.id }).from(oracleDocuments).all();
-    const remainingIds = remaining.map(d => d.id);
-    expect(remainingIds).toContain('oracle-learn-doc');
-    expect(remainingIds).toContain('manual-doc');
-  });
-});
+registerExtraPreservationTests();

--- a/src/indexer/__tests__/learn-source-service-hardening.test.ts
+++ b/src/indexer/__tests__/learn-source-service-hardening.test.ts
@@ -21,7 +21,9 @@ CREATE TABLE oracle_documents (
   origin TEXT,
   project TEXT,
   tenant_id TEXT NOT NULL DEFAULT 'default',
-  created_by TEXT
+  created_by TEXT,
+  usage_count INTEGER NOT NULL DEFAULT 0,
+  last_accessed_at INTEGER
 );
 CREATE VIRTUAL TABLE oracle_fts USING fts5(id UNINDEXED, content, concepts, tokenize='porter unicode61');`;
 

--- a/src/indexer/__tests__/learn-watcher.test.ts
+++ b/src/indexer/__tests__/learn-watcher.test.ts
@@ -24,7 +24,9 @@ CREATE TABLE oracle_documents (
   origin TEXT,
   project TEXT,
   tenant_id TEXT NOT NULL DEFAULT 'default',
-  created_by TEXT
+  created_by TEXT,
+  usage_count INTEGER NOT NULL DEFAULT 0,
+  last_accessed_at INTEGER
 );
 CREATE VIRTUAL TABLE oracle_fts USING fts5(id UNINDEXED, content, concepts, tokenize='porter unicode61');
 CREATE TABLE indexing_jobs (

--- a/src/indexer/preservation-extra.test-helper.ts
+++ b/src/indexer/preservation-extra.test-helper.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { oracleDocuments } from '../db/schema.ts';
+import { database, insertTestDoc, simulateSmartDeletion, sqliteDb } from './preservation-harness.test-helper.ts';
+
+export function registerExtraPreservationTests() {
+  describe('Indexer Preservation - legacy docs (null createdBy)', () => {
+    it('should treat legacy docs (null createdBy) as indexer-created', () => {
+      insertTestDoc({
+        id: 'legacy-doc',
+        type: 'learning',
+        sourceFile: 'ψ/memory/learnings/legacy.md',
+        createdBy: null,
+        project: 'github.com/current/repo',
+      });
+      const deleted = simulateSmartDeletion('github.com/current/repo');
+      const doc = database().select().from(oracleDocuments)
+        .where(eq(oracleDocuments.id, 'legacy-doc')).get();
+      expect(doc).toBeUndefined();
+      expect(deleted).toContain('legacy-doc');
+    });
+  });
+
+  describe('Indexer Preservation - FTS sync', () => {
+    it('should delete from FTS table when deleting from oracle_documents', () => {
+      insertTestDoc({
+        id: 'fts-test-doc',
+        type: 'learning',
+        sourceFile: 'ψ/memory/learnings/fts.md',
+        createdBy: 'indexer',
+        project: 'github.com/current/repo',
+        content: 'Searchable content for FTS test',
+      });
+      const before = sqliteDb().prepare('SELECT id FROM oracle_fts WHERE id = ?').get('fts-test-doc');
+      expect(before).toBeDefined();
+      simulateSmartDeletion('github.com/current/repo');
+      const after = sqliteDb().prepare('SELECT id FROM oracle_fts WHERE id = ?').get('fts-test-doc');
+      expect(after).toBeFalsy();
+    });
+
+    it('should preserve FTS entries for preserved documents', () => {
+      insertTestDoc({
+        id: 'fts-preserved-doc',
+        type: 'learning',
+        sourceFile: 'ψ/memory/learnings/preserved.md',
+        createdBy: 'oracle_learn',
+        project: 'github.com/other/repo',
+        content: 'This content should remain searchable',
+      });
+      simulateSmartDeletion('github.com/current/repo');
+      const fts = sqliteDb().prepare('SELECT content FROM oracle_fts WHERE id = ?')
+        .get('fts-preserved-doc') as { content: string } | undefined;
+      expect(fts).toBeDefined();
+      expect(fts?.content).toBe('This content should remain searchable');
+    });
+  });
+
+  describe('Indexer Preservation - edge cases', () => {
+    it('should handle empty database gracefully', () => {
+      expect(simulateSmartDeletion('github.com/any/repo')).toEqual([]);
+    });
+
+    it('should handle database with only oracle_learn docs', () => {
+      insertTestDoc({ id: 'only-learn-1', type: 'learning', sourceFile: 'ψ/memory/learnings/1.md', createdBy: 'oracle_learn', project: 'github.com/repo/1' });
+      insertTestDoc({ id: 'only-learn-2', type: 'learning', sourceFile: 'ψ/memory/learnings/2.md', createdBy: 'oracle_learn', project: 'github.com/repo/2' });
+      expect(simulateSmartDeletion('github.com/any/repo')).toEqual([]);
+      expect(database().select().from(oracleDocuments).all().length).toBe(2);
+    });
+
+    it('should handle mixed createdBy values correctly', () => {
+      insertTestDoc({ id: 'indexer-doc', type: 'learning', sourceFile: 'ψ/memory/learnings/indexer.md', createdBy: 'indexer', project: 'github.com/current/repo' });
+      insertTestDoc({ id: 'oracle-learn-doc', type: 'learning', sourceFile: 'ψ/memory/learnings/learn.md', createdBy: 'oracle_learn', project: 'github.com/current/repo' });
+      insertTestDoc({ id: 'manual-doc', type: 'learning', sourceFile: 'ψ/memory/learnings/manual.md', createdBy: 'manual', project: 'github.com/current/repo' });
+      insertTestDoc({ id: 'legacy-doc', type: 'learning', sourceFile: 'ψ/memory/learnings/legacy.md', createdBy: null, project: 'github.com/current/repo' });
+      const deleted = simulateSmartDeletion('github.com/current/repo');
+      expect(deleted).toContain('indexer-doc');
+      expect(deleted).toContain('legacy-doc');
+      expect(deleted).not.toContain('oracle-learn-doc');
+      expect(deleted).not.toContain('manual-doc');
+      const remainingIds = database().select({ id: oracleDocuments.id })
+        .from(oracleDocuments).all().map((doc) => doc.id);
+      expect(remainingIds).toContain('oracle-learn-doc');
+      expect(remainingIds).toContain('manual-doc');
+    });
+  });
+}

--- a/src/indexer/preservation-harness.test-helper.ts
+++ b/src/indexer/preservation-harness.test-helper.ts
@@ -1,0 +1,112 @@
+import { beforeAll, afterAll, beforeEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { drizzle, type BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
+import { and, eq, inArray, isNull, or } from 'drizzle-orm';
+import fs from 'fs';
+import * as schema from '../db/schema.ts';
+import { oracleDocuments } from '../db/schema.ts';
+
+let sqlite: Database;
+let db: BunSQLiteDatabase<typeof schema>;
+const TEST_DB_PATH = '/tmp/oracle-indexer-preservation-test.db';
+
+beforeAll(() => {
+  if (fs.existsSync(TEST_DB_PATH)) fs.unlinkSync(TEST_DB_PATH);
+  sqlite = new Database(TEST_DB_PATH);
+  db = drizzle(sqlite, { schema });
+  sqlite.exec(`
+    CREATE TABLE oracle_documents (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      source_file TEXT NOT NULL,
+      concepts TEXT NOT NULL DEFAULT '[]',
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      indexed_at INTEGER NOT NULL,
+      superseded_by TEXT,
+      superseded_at INTEGER,
+      superseded_reason TEXT,
+      origin TEXT,
+      project TEXT,
+      tenant_id TEXT NOT NULL DEFAULT 'default',
+      created_by TEXT,
+      usage_count INTEGER NOT NULL DEFAULT 0,
+      last_accessed_at INTEGER
+    );
+    CREATE INDEX idx_type ON oracle_documents(type);
+    CREATE INDEX idx_source ON oracle_documents(source_file);
+    CREATE INDEX idx_project ON oracle_documents(project);
+    CREATE INDEX idx_tenant ON oracle_documents(tenant_id);
+    CREATE INDEX idx_created_by ON oracle_documents(created_by);
+    CREATE VIRTUAL TABLE oracle_fts USING fts5(
+      id UNINDEXED,
+      content,
+      concepts,
+      tokenize='porter unicode61'
+    );
+  `);
+});
+
+afterAll(() => {
+  sqlite.close();
+  if (fs.existsSync(TEST_DB_PATH)) fs.unlinkSync(TEST_DB_PATH);
+});
+
+export function resetPreservationDb() {
+  sqlite.exec('DELETE FROM oracle_documents');
+  sqlite.exec('DELETE FROM oracle_fts');
+}
+
+beforeEach(resetPreservationDb);
+
+export function database() {
+  return db;
+}
+
+export function sqliteDb() {
+  return sqlite;
+}
+
+export function simulateSmartDeletion(project: string | null): string[] {
+  const docsToDelete = db.select({ id: oracleDocuments.id })
+    .from(oracleDocuments)
+    .where(and(
+      project
+        ? or(eq(oracleDocuments.project, project), isNull(oracleDocuments.project))
+        : isNull(oracleDocuments.project),
+      or(eq(oracleDocuments.createdBy, 'indexer'), isNull(oracleDocuments.createdBy))
+    ))
+    .all();
+  const idsToDelete = docsToDelete.map((doc) => doc.id);
+  if (idsToDelete.length === 0) return idsToDelete;
+
+  db.delete(oracleDocuments).where(inArray(oracleDocuments.id, idsToDelete)).run();
+  const placeholders = idsToDelete.map(() => '?').join(',');
+  sqlite.prepare(`DELETE FROM oracle_fts WHERE id IN (${placeholders})`).run(...idsToDelete);
+  return idsToDelete;
+}
+
+export function insertTestDoc(doc: {
+  id: string;
+  type: string;
+  sourceFile: string;
+  createdBy: string | null;
+  project: string | null;
+  content?: string;
+}) {
+  const now = Date.now();
+  db.insert(oracleDocuments).values({
+    id: doc.id,
+    type: doc.type,
+    sourceFile: doc.sourceFile,
+    concepts: '[]',
+    createdAt: now,
+    updatedAt: now,
+    indexedAt: now,
+    createdBy: doc.createdBy,
+    project: doc.project,
+    usageCount: 0,
+  }).run();
+  sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
+    .run(doc.id, doc.content || 'Test content', '');
+}

--- a/src/routes/indexer/start.ts
+++ b/src/routes/indexer/start.ts
@@ -4,6 +4,7 @@ import { createDatabase } from '../../db/index.ts';
 import { setIndexingStatus } from '../../indexer/status.ts';
 import { DB_PATH, REPO_ROOT } from '../../config.ts';
 import { currentTenantId, runWithTenant } from '../../middleware/tenant.ts';
+import { entityCollectionName, entityDocumentsFor } from '../../vector/entities.ts';
 import type { IndexerConfig } from '../../types.ts';
 
 let abortFlag = false;
@@ -65,7 +66,9 @@ export function createStartRoute(deps: StartRouteDeps = {}) {
       },
     };
 
-    const store = (deps.createStore ?? createVectorStoreForModel)(preset);
+    const storeFactory = deps.createStore ?? createVectorStoreForModel;
+    const store = storeFactory(preset);
+    const entityStore = storeFactory({ ...preset, collection: entityCollectionName(preset.collection) });
 
     abortFlag = false;
 
@@ -75,8 +78,11 @@ export function createStartRoute(deps: StartRouteDeps = {}) {
     const task = runWithTenant(tenantId, async () => {
       try {
         await store.connect();
+        await entityStore.connect();
         try { await store.deleteCollection(); } catch {}
+        try { await entityStore.deleteCollection(); } catch {}
         await store.ensureCollection();
+        await entityStore.ensureCollection();
 
         const tenantWhere = tenantId ? 'WHERE d.tenant_id = ?' : '';
         const rows = sqlite.prepare(`
@@ -115,6 +121,8 @@ export function createStartRoute(deps: StartRouteDeps = {}) {
           }));
 
           await store.addDocuments(docs);
+          const entityDocs = docs.flatMap(entityDocumentsFor);
+          if (entityDocs.length > 0) await entityStore.addDocuments(entityDocs);
           setIndexingStatus(sqlite, config, true, i + batchRows.length, total);
         }
 
@@ -126,6 +134,7 @@ export function createStartRoute(deps: StartRouteDeps = {}) {
         setIndexingStatus(sqlite, config, false, 0, 0, msg);
       } finally {
         await store.close().catch(() => undefined);
+        await entityStore.close().catch(() => undefined);
       }
     });
     (deps.runInBackground ?? ((backgroundTask) => { void backgroundTask; }))(task);

--- a/src/tools/__tests__/learn-enqueue.test.ts
+++ b/src/tools/__tests__/learn-enqueue.test.ts
@@ -37,7 +37,9 @@ CREATE TABLE oracle_documents (
   origin TEXT,
   project TEXT,
   tenant_id TEXT NOT NULL DEFAULT 'default',
-  created_by TEXT
+  created_by TEXT,
+  usage_count INTEGER NOT NULL DEFAULT 0,
+  last_accessed_at INTEGER
 );
 CREATE VIRTUAL TABLE oracle_fts USING fts5(id UNINDEXED, content, concepts, tokenize='porter unicode61');
 CREATE TABLE indexing_jobs (

--- a/src/tools/__tests__/learn-vault-frontmatter.test.ts
+++ b/src/tools/__tests__/learn-vault-frontmatter.test.ts
@@ -25,7 +25,9 @@ CREATE TABLE oracle_documents (
   origin TEXT,
   project TEXT,
   tenant_id TEXT NOT NULL DEFAULT 'default',
-  created_by TEXT
+  created_by TEXT,
+  usage_count INTEGER NOT NULL DEFAULT 0,
+  last_accessed_at INTEGER
 );
 CREATE VIRTUAL TABLE oracle_fts USING fts5(id UNINDEXED, content, concepts, tokenize='porter unicode61');
 CREATE TABLE indexing_jobs (

--- a/src/vector/entities.ts
+++ b/src/vector/entities.ts
@@ -1,0 +1,54 @@
+import type { VectorDocument } from './types.ts';
+
+export interface EntitySourceDocument extends VectorDocument {
+  metadata: VectorDocument['metadata'] & { tenant_id?: string | number };
+}
+
+const MAX_ENTITIES_PER_DOC = 12;
+const ENTITY_PATTERN = /\b(?:[A-Z][\p{L}\p{N}._-]*(?:\s+[A-Z][\p{L}\p{N}._-]*){0,3}|[a-z][\p{L}\p{N}]+(?:[-_][a-z0-9][\p{L}\p{N}]*)+)\b/gu;
+const STOPWORDS = new Set(['The', 'This', 'That', 'These', 'Those', 'When', 'Where', 'What', 'Why', 'How', 'And', 'But', 'For', 'With', 'From']);
+
+export function entityCollectionName(collection: string): string {
+  return `${collection}_entities`;
+}
+
+export function extractEntities(text: string, concepts?: unknown): string[] {
+  const candidates = new Set<string>();
+  for (const concept of conceptValues(concepts)) addEntity(candidates, concept);
+  for (const match of text.matchAll(ENTITY_PATTERN)) addEntity(candidates, match[0]);
+  return [...candidates].slice(0, MAX_ENTITIES_PER_DOC);
+}
+
+export function entityDocumentsFor(doc: EntitySourceDocument): VectorDocument[] {
+  return extractEntities(doc.document, doc.metadata.concepts).map((entity) => ({
+    id: `${doc.id}:entity:${slug(entity)}`,
+    document: entity,
+    metadata: {
+      entity,
+      source_doc_id: doc.id,
+      tenant_id: doc.metadata.tenant_id ?? '',
+      type: 'entity',
+    },
+  }));
+}
+
+function addEntity(out: Set<string>, raw: string): void {
+  const entity = raw.replace(/\s+/g, ' ').trim();
+  if (entity.length < 3 || STOPWORDS.has(entity)) return;
+  out.add(entity);
+}
+
+function conceptValues(raw: unknown): string[] {
+  if (Array.isArray(raw)) return raw.filter((item): item is string => typeof item === 'string');
+  if (typeof raw !== 'string') return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : [];
+  } catch {
+    return raw.split(',').map((item) => item.trim()).filter(Boolean);
+  }
+}
+
+function slug(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 80) || 'entity';
+}

--- a/tests/http/indexer/basic.test.ts
+++ b/tests/http/indexer/basic.test.ts
@@ -112,7 +112,7 @@ describe('indexer HTTP routes', () => {
       expect(res.status).toBe(200);
       expect(body.batchSize).toBe(100);
       expect(status.error).toBe('embed failed');
-      expect(close).toHaveBeenCalledTimes(1);
+      expect(close).toHaveBeenCalledTimes(2);
     } finally {
       sqlite.close();
     }
@@ -123,13 +123,14 @@ describe('indexer HTTP routes', () => {
     const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
     const tenantA = `tenant-a-${stamp}`;
     const tenantB = `tenant-b-${stamp}`;
-    seedDoc(sqlite, `idx-a-${stamp}`, tenantA, `alpha ${stamp}`, 2);
+    seedDoc(sqlite, `idx-a-${stamp}`, tenantA, `Alpha Project ${stamp}`, 2);
     seedDoc(sqlite, `idx-b-${stamp}`, tenantB, `beta ${stamp}`, 1);
     const added: VectorDocument[] = [];
+    const entityDocs: VectorDocument[] = [];
     const tasks: Promise<void>[] = [];
     const app = new Elysia({ prefix: '/api' }).use(createStartRoute({
       createDb: () => ({ sqlite } as any),
-      createStore: () => fakeStore(added),
+      createStore: (preset: any) => fakeStore(String(preset.collection).endsWith('_entities') ? entityDocs : added),
       getModels: () => ({ nomic: { collection: 'test', model: 'nomic-embed-text' } }),
       runInBackground: (task) => tasks.push(task),
     }));
@@ -147,8 +148,11 @@ describe('indexer HTTP routes', () => {
       expect(res.status).toBe(200);
       expect(body.tenantId).toBe(tenantA);
       expect(added.map((doc) => doc.id)).toEqual([`idx-a-${stamp}`]);
-      expect(added[0].document).toContain('alpha');
+      expect(added[0].document).toContain('Alpha Project');
       expect(added[0].metadata.tenant_id).toBe(tenantA);
+      expect(entityDocs.map((doc) => doc.document)).toContain('Alpha Project');
+      expect(entityDocs[0].metadata.source_doc_id).toBe(`idx-a-${stamp}`);
+      expect(entityDocs[0].metadata.tenant_id).toBe(tenantA);
       expect(status.progress_total).toBe(1);
     } finally {
       sqlite.close();

--- a/tests/vector/entities.test.ts
+++ b/tests/vector/entities.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from 'bun:test';
+import { entityCollectionName, entityDocumentsFor, extractEntities } from '../../src/vector/entities.ts';
+
+test('extractEntities combines concept metadata with write-time text entities', () => {
+  const entities = extractEntities('Arra Oracle indexes Cloudflare Workers and mem0-style entity links.', '["LanceDB","Cloudflare Workers"]');
+  expect(entities).toContain('LanceDB');
+  expect(entities).toContain('Cloudflare Workers');
+  expect(entities).toContain('Arra Oracle');
+  expect(entities).toContain('mem0-style');
+});
+
+test('entityDocumentsFor writes a parallel vector payload without graph edges', () => {
+  const docs = entityDocumentsFor({
+    id: 'doc-1',
+    document: 'Arra Oracle recalls Nat projects.',
+    metadata: { concepts: 'Oracle,Nat', tenant_id: 'team-a' },
+  });
+
+  expect(entityCollectionName('oracle_knowledge')).toBe('oracle_knowledge_entities');
+  expect(docs[0]).toMatchObject({
+    id: 'doc-1:entity:oracle',
+    document: 'Oracle',
+    metadata: { source_doc_id: 'doc-1', tenant_id: 'team-a', type: 'entity' },
+  });
+});


### PR DESCRIPTION
## Summary
- add deterministic write-time entity extraction for vector documents and concept metadata
- mirror entity payloads into `{collection}_entities` sidecar vector collections during indexer writes
- cover sidecar routing and keep stale in-memory schema tests green without graph DB work

## Validation
```bash
bun test --isolate tests/vector/entities.test.ts
bun test --isolate tests/http/indexer/basic.test.ts
bun test --isolate src/indexer-preservation.test.ts
bun test --isolate src/tools/__tests__/learn-enqueue.test.ts
bun test --isolate src/tools/__tests__/learn-vault-frontmatter.test.ts
bun test --isolate src/indexer/__tests__/learn-watcher.test.ts
bun test --isolate src/indexer/__tests__/learn-source-service-hardening.test.ts
bun test --isolate src/server/__tests__/vector-indexer-source.test.ts
bun test --isolate src/drizzle-migration.test.ts
bunx tsc --noEmit
git diff --check
wc -l ...changed files
```
