### PR TITLE
test: harden search and memory edge cases

### DIFF
--- a/src/routes/memory/index.ts
+++ b/src/routes/memory/index.ts
@@ -83,12 +83,15 @@ export function createMemoryRoutes(
 function mergeHits(hits: MemoryVectorHit[], records: MemoryRecord[]) {
   const byId = new Map(records.map((record) => [record.id, record]));
   const tenantId = currentTenantId();
+  const seen = new Set<string>();
   return hits.flatMap((hit) => {
+    if (seen.has(hit.memoryId)) return [];
     const record = byId.get(hit.memoryId);
     if (tenantId && !record) return [];
     const hitTenantId = hitTenant(hit);
     if (tenantId && hitTenantId && hitTenantId !== tenantId) return [];
     const memory = memoryForHit(hit, record);
+    seen.add(hit.memoryId);
     return [{
       ...memory,
       score: hit.score,
@@ -110,14 +113,30 @@ function withKeywordConfidence(memory: MemoryRecord) {
 
 function memoryForHit(hit: MemoryVectorHit, record?: MemoryRecord): MemoryRecord {
   if (record) return record;
-  const createdAt = typeof hit.metadata.createdAt === 'string' ? hit.metadata.createdAt : new Date().toISOString();
+  const createdAt = metadataText(hit.metadata.createdAt) ?? new Date().toISOString();
   return {
     id: hit.memoryId,
     content: hit.document,
-    tags: [],
+    title: metadataText(hit.metadata.title),
+    tags: metadataList(hit.metadata.tags ?? hit.metadata.concepts),
+    source: metadataText(hit.metadata.source ?? hit.metadata.source_file),
     createdAt,
-    updatedAt: createdAt,
+    updatedAt: metadataText(hit.metadata.updatedAt) ?? createdAt,
   };
+}
+
+function metadataText(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function metadataList(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map(String).map((item) => item.trim()).filter(Boolean);
+  if (typeof value !== 'string' || !value.trim()) return [];
+  try {
+    const parsed = JSON.parse(value);
+    if (Array.isArray(parsed)) return metadataList(parsed);
+  } catch {}
+  return value.split(',').map((item) => item.trim()).filter(Boolean);
 }
 
 export const memoryRoutes = createMemoryRoutes();

--- a/tests/http/memory/save-recall.test.ts
+++ b/tests/http/memory/save-recall.test.ts
@@ -149,3 +149,40 @@ test('memory save rejects blank content', async () => {
   expect(res.status).toBe(400);
   expect(await json(res)).toEqual({ success: false, error: 'memory content is required' });
 });
+
+test('memory search de-duplicates vector hits and preserves fallback metadata', async () => {
+  const hit = {
+    memoryId: 'ghost-memory',
+    vectorId: 'memory:ghost-memory:1',
+    document: 'Recovered only from vector metadata.',
+    metadata: {
+      title: 'Vector-only memory',
+      tags: '["vector", "fallback"]',
+      source_file: 'session://vector-only',
+      createdAt: '2026-06-17T00:00:00.000Z',
+      updatedAt: '2026-06-17T01:00:00.000Z',
+    },
+    distance: 0,
+    score: 0.91,
+  };
+  const store = { save: () => { throw new Error('unused'); }, recall: () => [], getByIds: () => [] } as any;
+  const vectorIndex: MemoryVectorIndex = {
+    async index() { return { indexed: true }; },
+    async search() { return [hit, { ...hit, vectorId: 'memory:ghost-memory:2', score: 0.6 }]; },
+  };
+  const app = createMemoryRoutes(store, vectorIndex);
+  const fetcher = createApiVersionedFetch((request) => app.handle(request));
+  const res = await fetcher(new Request('http://local/api/v1/memory/search?q=ghost'));
+  const body = await json(res);
+
+  expect(res.status).toBe(200);
+  expect(body.results).toHaveLength(1);
+  expect(body.results[0]).toMatchObject({
+    id: 'ghost-memory',
+    title: 'Vector-only memory',
+    tags: ['vector', 'fallback'],
+    source: 'session://vector-only',
+    score: 0.91,
+  });
+  expect(body.results[0].confidence.reasons).toContain('source_present');
+});

--- a/tests/http/search/query-hardening.test.ts
+++ b/tests/http/search/query-hardening.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from 'bun:test';
+import { buildTenantFtsQuery, parseConcepts, parseOffset, parsePositiveInt, parseSearchMode } from '../../../src/search/query.ts';
+
+test('search parsers reject partial and unsafe numeric values', () => {
+  expect(parsePositiveInt('2abc', 10, 100)).toBe(10);
+  expect(parsePositiveInt('9007199254740993', 10, 100)).toBe(10);
+  expect(parsePositiveInt(' 25 ', 10, 20)).toBe(20);
+  expect(parseOffset('-1')).toBe(0);
+  expect(parseOffset('003')).toBe(3);
+});
+
+test('search mode parser trims, lowercases, and rejects unknown modes', () => {
+  expect(parseSearchMode(undefined)).toBe('hybrid');
+  expect(parseSearchMode(' FTS ')).toBe('fts');
+  expect(parseSearchMode('nearest')).toBeNull();
+});
+
+test('FTS query builders strip punctuation, dedupe terms, and cap token fanout', () => {
+  const raw = '<b>alpha</b> beta alpha gamma delta epsilon zeta eta theta iota OR ( )';
+
+  expect(buildTenantFtsQuery(raw)).toBe('"alpha" OR "beta" OR "gamma" OR "delta" OR "epsilon" OR "zeta" OR "eta" OR "theta"');
+});
+
+test('parseConcepts trims, de-duplicates, and ignores non-string entries', () => {
+  expect(parseConcepts('[" oracle ", "oracle", 7, "memory"]')).toEqual(['oracle', 'memory']);
+  expect(parseConcepts('not-json')).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- Harden memory vector search merge behavior by de-duplicating repeated vector hits.
- Preserve fallback metadata (`title`, `tags`, `source`, timestamps) when a vector hit has no SQLite record.
- Add deeper parser/FTS hardening coverage for search query edge cases.

## Validation
```bash
rtk bunx tsc --noEmit
rtk bun test tests/http/search/query-hardening.test.ts tests/http/search/edge-cases.test.ts tests/http/search/tenant-routes.test.ts tests/http/memory/save-recall.test.ts tests/http/memory/limit-hardening.test.ts tests/http/memory/fanout.test.ts
```

## File Size Check
```bash
wc -l src/routes/memory/index.ts tests/http/search/query-hardening.test.ts tests/http/memory/save-recall.test.ts
```
All changed files are <=250 lines.

## Notes
- PR targets `alpha`.
- No UI changes; no screenshot needed.
