### PR TITLE
feat(vector): add entity sidecar search endpoint

### DIFF
--- a/src/routes/vector/entity-search.ts
+++ b/src/routes/vector/entity-search.ts
@@ -1,0 +1,104 @@
+import { Elysia, t } from 'elysia';
+import { currentTenantId } from '../../middleware/tenant.ts';
+import { entityCollectionName } from '../../vector/entities.ts';
+import { createVectorStoreForModel, getEmbeddingModels, type EmbeddingModelConfig } from '../../vector/factory.ts';
+import type { VectorQueryResult, VectorStoreAdapter } from '../../vector/types.ts';
+
+type EntityStore = Pick<VectorStoreAdapter, 'connect' | 'ensureCollection' | 'query'> & Partial<Pick<VectorStoreAdapter, 'close'>>;
+
+type EntitySearchDeps = {
+  getModels?: () => Record<string, EmbeddingModelConfig>;
+  createStore?: (preset: EmbeddingModelConfig) => EntityStore;
+};
+
+const MAX_LIMIT = 50;
+const EntitySearchQuery = t.Object({
+  q: t.Optional(t.String()),
+  model: t.Optional(t.String()),
+  collection: t.Optional(t.String()),
+  limit: t.Optional(t.String()),
+});
+
+function clean(value: string | undefined): string | undefined {
+  const trimmed = value?.replace(/<[^>]*>/g, '').replace(/[\x00-\x1f]/g, '').trim();
+  return trimmed || undefined;
+}
+
+function limitOf(value: string | undefined): number {
+  const parsed = Number.parseInt(value ?? '', 10);
+  return Math.min(MAX_LIMIT, Number.isFinite(parsed) && parsed > 0 ? parsed : 10);
+}
+
+function resolvePreset(name: string | undefined, models: Record<string, EmbeddingModelConfig>): EmbeddingModelConfig | undefined {
+  if (name && models[name]) return models[name];
+  if (name) return Object.values(models).find((preset) => preset.collection === name);
+  return models['bge-m3'] ?? Object.values(models)[0];
+}
+
+function metadataAt(result: VectorQueryResult, index: number): Record<string, unknown> {
+  const value = result.metadatas?.[index];
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function toHits(result: VectorQueryResult) {
+  return result.ids.map((id, index) => {
+    const metadata = metadataAt(result, index);
+    return {
+      id,
+      entity: String(metadata.entity ?? result.documents?.[index] ?? ''),
+      sourceDocId: String(metadata.source_doc_id ?? ''),
+      tenantId: String(metadata.tenant_id ?? ''),
+      score: 1 / (1 + Number(result.distances?.[index] ?? 0) / 100),
+      distance: Number(result.distances?.[index] ?? 0),
+      metadata,
+    };
+  });
+}
+
+export function createEntitySearchEndpoint(deps: EntitySearchDeps = {}) {
+  const getModels = deps.getModels ?? getEmbeddingModels;
+  const createStore = deps.createStore ?? createVectorStoreForModel;
+
+  return new Elysia().get('/vector/entities/search', async ({ query, set }) => {
+    const q = clean(query.q);
+    if (!q) {
+      set.status = 400;
+      return { error: 'Missing query parameter: q' };
+    }
+
+    const preset = resolvePreset(query.model ?? query.collection, getModels());
+    if (!preset) {
+      set.status = 404;
+      return { error: 'No embedding models configured' };
+    }
+
+    const entityCollection = entityCollectionName(preset.collection);
+    const tenantId = currentTenantId();
+    const filters = tenantId ? { tenant_id: tenantId } : undefined;
+    const store = createStore({ ...preset, collection: entityCollection });
+
+    try {
+      await store.connect();
+      await store.ensureCollection();
+      const result = await store.query(q, limitOf(query.limit), filters);
+      return {
+        query: q,
+        mode: 'entity-vector',
+        collection: entityCollection,
+        model: query.model ?? query.collection ?? null,
+        filters: { metadata: filters ?? {} },
+        results: toHits(result),
+      };
+    } catch (error) {
+      set.status = 400;
+      return { results: [], error: 'Entity search failed', message: error instanceof Error ? error.message : String(error) };
+    } finally {
+      await store.close?.().catch(() => undefined);
+    }
+  }, {
+    query: EntitySearchQuery,
+    detail: { tags: ['vector'], summary: 'Search entity-linking sidecar collection' },
+  });
+}
+
+export const entitySearchEndpoint = createEntitySearchEndpoint();

--- a/src/routes/vector/index.ts
+++ b/src/routes/vector/index.ts
@@ -24,6 +24,7 @@
 
 import { Elysia } from 'elysia';
 import { vectorSearchEndpoint } from './search.ts';
+import { entitySearchEndpoint } from './entity-search.ts';
 import { fanoutEndpoint } from './fanout.ts';
 import { similarEndpoint } from './similar.ts';
 import { compareEndpoint } from './compare.ts';
@@ -45,6 +46,7 @@ import { vectorCollectionsEndpoint } from './collections.ts';
 export const vectorRoutes = new Elysia({ prefix: '/api' })
   .use(vectorProxyEndpoint)
   .use(vectorSearchEndpoint)
+  .use(entitySearchEndpoint)
   .use(fanoutEndpoint)
   .use(similarEndpoint)
   .use(compareEndpoint)

--- a/tests/http/vector/entity-search.test.ts
+++ b/tests/http/vector/entity-search.test.ts
@@ -1,0 +1,67 @@
+import { expect, mock, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
+import { createEntitySearchEndpoint } from '../../../src/routes/vector/entity-search.ts';
+import type { VectorQueryResult } from '../../../src/vector/types.ts';
+
+const result: VectorQueryResult = {
+  ids: ['doc-a:entity:alpha-project'],
+  documents: ['Alpha Project'],
+  distances: [0.25],
+  metadatas: [{ entity: 'Alpha Project', source_doc_id: 'doc-a', tenant_id: 'tenant-a', type: 'entity' }],
+};
+
+function createFetch(queryImpl: () => Promise<VectorQueryResult> = async () => result) {
+  const presets: any[] = [];
+  const store = {
+    connect: mock(async () => {}),
+    ensureCollection: mock(async () => {}),
+    query: mock(queryImpl),
+    close: mock(async () => {}),
+  };
+  const app = new Elysia({ prefix: '/api' }).use(createEntitySearchEndpoint({
+    getModels: () => ({ 'bge-m3': { collection: 'oracle_knowledge_bge_m3', model: 'bge-m3' } }),
+    createStore: (preset) => {
+      presets.push(preset);
+      return store;
+    },
+  }));
+  return { fetcher: createApiVersionedFetch((request) => app.handle(request)), presets, store };
+}
+
+test('GET /api/v1/vector/entities/search queries entity sidecar collection', async () => {
+  const { fetcher, presets, store } = createFetch();
+  const res = await fetcher(new Request('http://local/api/v1/vector/entities/search?q=Alpha&limit=3'));
+  const body = await res.json() as Record<string, any>;
+
+  expect(res.status).toBe(200);
+  expect(presets[0].collection).toBe('oracle_knowledge_bge_m3_entities');
+  expect(store.query).toHaveBeenCalledWith('Alpha', 3, undefined);
+  expect(store.close).toHaveBeenCalledTimes(1);
+  expect(body).toMatchObject({ mode: 'entity-vector', collection: 'oracle_knowledge_bge_m3_entities' });
+  expect(body.results[0]).toMatchObject({ entity: 'Alpha Project', sourceDocId: 'doc-a', tenantId: 'tenant-a' });
+});
+
+test('GET /api/v1/vector/entities/search applies tenant metadata filter', async () => {
+  const { fetcher, store } = createFetch();
+  const tenantFetch = createTenantFetch(fetcher);
+  const res = await tenantFetch(new Request('http://local/api/v1/vector/entities/search?q=Alpha', {
+    headers: { [TENANT_HEADER]: 'tenant-a' },
+  }));
+
+  expect(res.status).toBe(200);
+  expect(store.query).toHaveBeenCalledWith('Alpha', 10, { tenant_id: 'tenant-a' });
+});
+
+test('GET /api/v1/vector/entities/search validates query and closes on failure', async () => {
+  const missing = await createFetch().fetcher(new Request('http://local/api/v1/vector/entities/search?q=%20'));
+  expect(missing.status).toBe(400);
+  expect(await missing.json()).toEqual({ error: 'Missing query parameter: q' });
+
+  const { fetcher, store } = createFetch(async () => { throw new Error('adapter down'); });
+  const failed = await fetcher(new Request('http://local/api/v1/vector/entities/search?q=Alpha'));
+  expect(failed.status).toBe(400);
+  expect(await failed.json()).toMatchObject({ results: [], error: 'Entity search failed', message: 'adapter down' });
+  expect(store.close).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
## Summary
- add `/api/vector/entities/search` for querying the `{collection}_entities` sidecar created in WAVE3 entity indexing
- resolve the selected model/collection to its sidecar collection and query it directly
- return entity/source document metadata and preserve tenant metadata filtering

## Validation
```bash
bun test --isolate tests/http/vector/entity-search.test.ts tests/vector/entities.test.ts tests/http/vector/search.test.ts
bunx tsc --noEmit
git diff --check
wc -l src/routes/vector/entity-search.ts src/routes/vector/index.ts tests/http/vector/entity-search.test.ts
```
