### PR TITLE
feat(search): add cited ask endpoint

### DIFF
--- a/src/routes/ask/index.ts
+++ b/src/routes/ask/index.ts
@@ -1,0 +1,49 @@
+import { Elysia } from 'elysia';
+import { sqlite } from '../../db/index.ts';
+import { attachSupersedeStatus } from '../../search/supersede-status.ts';
+import { handleSearch } from '../../server/handlers.ts';
+import { AskBody } from './model.ts';
+import { envAskClient, sourcesFrom, synthesize, type AskClient } from './synthesis.ts';
+
+type AskDeps = { client?: AskClient; now?: () => Date };
+
+function sanitize(q: string): string {
+  return q.replace(/<[^>]*>/g, '').replace(/[\x00-\x1f]/g, '').trim();
+}
+
+function limitOf(value: number | undefined): number {
+  if (!Number.isFinite(value ?? NaN)) return 8;
+  return Math.max(1, Math.min(20, Math.floor(value as number)));
+}
+
+export function createAskRoutes(deps: AskDeps = {}) {
+  return new Elysia({ prefix: '/api' }).post('/ask', async ({ body, set }) => {
+    const q = sanitize(body.q ?? '');
+    if (!q) {
+      set.status = 400;
+      return { error: 'Invalid query: empty after sanitization' };
+    }
+
+    const limit = limitOf(body.limit);
+    const result = await handleSearch(q, body.type ?? 'all', limit, 0, 'hybrid', body.project, body.cwd, body.model);
+    attachSupersedeStatus(sqlite, result.results as unknown as Array<Record<string, unknown>>);
+    const sources = sourcesFrom(result.results, limit);
+    const client = body.llm === false ? undefined : deps.client ?? envAskClient();
+    const synthesis = await synthesize(q, sources, client);
+    return {
+      query: q,
+      answer: synthesis.answer,
+      citations: synthesis.citations,
+      noEvidence: synthesis.noEvidence,
+      mode: synthesis.mode,
+      generatedAt: deps.now?.().toISOString() ?? new Date().toISOString(),
+      search: { total: result.total, limit, vectorAvailable: result.vectorAvailable, warning: result.warning },
+      sources,
+    };
+  }, {
+    body: AskBody,
+    detail: { tags: ['ask'], menu: { group: 'main', path: '/ask', order: 12 }, summary: 'Ask the oracle with cited synthesis over hybrid search' },
+  });
+}
+
+export const askRoutes = createAskRoutes();

--- a/src/routes/ask/model.ts
+++ b/src/routes/ask/model.ts
@@ -1,0 +1,11 @@
+import { t } from 'elysia';
+
+export const AskBody = t.Object({
+  q: t.String(),
+  type: t.Optional(t.String()),
+  limit: t.Optional(t.Number()),
+  project: t.Optional(t.String()),
+  cwd: t.Optional(t.String()),
+  model: t.Optional(t.String()),
+  llm: t.Optional(t.Boolean()),
+});

--- a/src/routes/ask/synthesis.ts
+++ b/src/routes/ask/synthesis.ts
@@ -1,0 +1,102 @@
+import type { SearchResult } from '../../server/types.ts';
+
+export type AskSource = {
+  index: number; id: string; type: string; sourceFile: string; score: number;
+  excerpt: string; supersededBy?: string; supersededAt?: string | null; supersededReason?: string | null;
+};
+export type AskPrompt = { instruction: string; question: string; sources: AskSource[] };
+export type AskClient = (prompt: AskPrompt) => Promise<unknown>;
+export type AskSynthesis = { answer: string; citations: number[]; noEvidence: boolean; mode: 'llm' | 'extractive' };
+
+export function sourcesFrom(results: SearchResult[], limit: number): AskSource[] {
+  return results.slice(0, limit).map((result, index) => ({
+    index: index + 1,
+    id: result.id,
+    type: result.type,
+    sourceFile: result.source_file,
+    score: round(result.score ?? 0),
+    excerpt: excerpt(result.content),
+    supersededBy: result.superseded_by,
+    supersededAt: result.superseded_at,
+    supersededReason: result.superseded_reason,
+  }));
+}
+
+export async function synthesize(question: string, sources: AskSource[], client?: AskClient): Promise<AskSynthesis> {
+  const noEvidence = lacksEvidence(sources);
+  if (noEvidence) return { answer: 'No evidence found in indexed oracle documents.', citations: [], noEvidence: true, mode: 'extractive' };
+  if (!client) return extractiveAnswer(sources, false);
+  try {
+    const parsed = parseLlm(await client(promptFor(question, sources)));
+    if (parsed) return { answer: parsed.answer, citations: validCitations(parsed.citations, sources), noEvidence: Boolean(parsed.noEvidence), mode: 'llm' };
+  } catch {}
+  return extractiveAnswer(sources, false);
+}
+
+export function envAskClient(env: Record<string, string | undefined> = process.env): AskClient | undefined {
+  const enabled = ['1', 'true', 'yes'].includes(String(env.ORACLE_ASK_LLM ?? '').toLowerCase());
+  const url = env.ORACLE_ASK_LLM_URL?.trim();
+  if (!enabled || !url) return undefined;
+  return async (prompt) => {
+    const response = await fetch(url, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(prompt) });
+    if (!response.ok) throw new Error(`ask LLM endpoint failed (${response.status})`);
+    return response.text();
+  };
+}
+
+function lacksEvidence(sources: AskSource[]): boolean {
+  return sources.length === 0 || Math.max(...sources.map((source) => source.score)) < 0.12;
+}
+
+function promptFor(question: string, sources: AskSource[]): AskPrompt {
+  return {
+    instruction: [
+      'Answer the question using only the provided sources.',
+      'Cite factual claims with bracket citations like [1].',
+      'If sources do not support an answer, set noEvidence=true.',
+      'Return JSON only: {"answer":"...","citations":[1],"noEvidence":false}.',
+    ].join(' '),
+    question,
+    sources,
+  };
+}
+
+function extractiveAnswer(sources: AskSource[], noEvidence: boolean): AskSynthesis {
+  const cited = sources.slice(0, 3);
+  return {
+    answer: cited.map((source) => `[${source.index}] ${source.excerpt}`).join('\n'),
+    citations: cited.map((source) => source.index),
+    noEvidence,
+    mode: 'extractive',
+  };
+}
+
+function parseLlm(raw: unknown): { answer: string; citations: number[]; noEvidence?: boolean } | null {
+  const payload = typeof raw === 'string' ? jsonish(raw) : raw;
+  if (!payload || typeof payload !== 'object') return null;
+  const record = payload as Record<string, unknown>;
+  const answer = typeof record.answer === 'string' ? record.answer.trim() : '';
+  if (!answer) return null;
+  const citations = Array.isArray(record.citations) ? record.citations.map(Number).filter(Number.isFinite) : [];
+  return { answer, citations, noEvidence: Boolean(record.noEvidence ?? record.no_evidence) };
+}
+
+function jsonish(raw: string): unknown {
+  const fenced = raw.trim().match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i)?.[1] ?? raw.trim();
+  const start = fenced.indexOf('{');
+  if (start < 0) return null;
+  try { return JSON.parse(fenced.slice(start)); } catch { return null; }
+}
+
+function validCitations(citations: number[], sources: AskSource[]): number[] {
+  const allowed = new Set(sources.map((source) => source.index));
+  return Array.from(new Set(citations.filter((citation) => allowed.has(citation))));
+}
+
+function excerpt(content: string): string {
+  return content.replace(/\s+/g, ' ').trim().slice(0, 420);
+}
+
+function round(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -45,6 +45,7 @@ import { feedRoutes } from './routes/feed/index.ts';
 import { createHealthRoutes } from './routes/health/index.ts';
 import { dashboardRoutes } from './routes/dashboard/index.ts';
 import { searchRoutes } from './routes/search/index.ts';
+import { askRoutes } from './routes/ask/index.ts';
 import { vectorRoutes } from './routes/vector/index.ts';
 import { vectorConfigApiRoutes } from './routes/vector/config-api.ts';
 import { conceptsRoutes } from './routes/concepts/index.ts';
@@ -116,7 +117,7 @@ export function createApp({ unifiedPlugins, runtimeRef = createUnifiedRuntimeRef
     .get('/', () => ({ server: MCP_SERVER_NAME, version: pkg.version, status: 'ok', docs: '/api/docs', api: '/api/v1' }));
 
   const healthRoutes = createHealthRoutes({ pluginCount: unifiedPlugins.pluginCount, pluginMcpToolCount: unifiedPlugins.mcpTools.length, pluginStatuses: unifiedPlugins.pluginStatuses, isDraining });
-  const apiModules = [authRoutes, settingsRoutes, feedRoutes, healthRoutes, dashboardRoutes, searchRoutes, vectorRoutes, vectorConfigApiRoutes, conceptsRoutes, knowledgeRoutes, verifyRoutes, supersedeRoutes, forumApi, tracesApi, scheduleApi, filesRouter, createPluginsRouter({ registry: () => runtimeRef.current.pluginRegistry(), runtimeRef }), sessionsRoutes, vaultRoutes, metricsRoutes, exportRoutes, memoryRoutes, canvasRoutes, tenantsRoutes, watcherRoutes, indexerRoutes];
+  const apiModules = [authRoutes, settingsRoutes, feedRoutes, healthRoutes, dashboardRoutes, searchRoutes, askRoutes, vectorRoutes, vectorConfigApiRoutes, conceptsRoutes, knowledgeRoutes, verifyRoutes, supersedeRoutes, forumApi, tracesApi, scheduleApi, filesRouter, createPluginsRouter({ registry: () => runtimeRef.current.pluginRegistry(), runtimeRef }), sessionsRoutes, vaultRoutes, metricsRoutes, exportRoutes, memoryRoutes, canvasRoutes, tenantsRoutes, watcherRoutes, indexerRoutes];
   const modules = [...apiModules, createMcpRoutes({ runtimeRef }), createMenuRoutes(menuItemsFromUnifiedPlugins(unifiedPlugins.menu))];
   for (const mod of modules) app.use(mod as any);
   app.use(createUnifiedPluginRouteMount(runtimeRef, { localRoutes: () => app.routes }));

--- a/tests/http/search/ask.test.ts
+++ b/tests/http/search/ask.test.ts
@@ -1,0 +1,93 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-ask-'));
+const stamp = `${Date.now()}${Math.random().toString(16).slice(2)}`;
+const tenantId = `tenant-ask-${stamp}`;
+const docId = `ask-doc-${stamp}`;
+const term = `askterm${stamp}`;
+
+let dbModule: typeof import('../../../src/db/index.ts');
+let route: { handle: (request: Request) => Response | Promise<Response> };
+let createTenantFetch: typeof import('../../../src/middleware/tenant.ts').createTenantFetch;
+let tenantHeader: string;
+
+beforeAll(async () => {
+  process.env.ORACLE_DATA_DIR = tempRoot;
+  process.env.ORACLE_DB_PATH = path.join(tempRoot, 'oracle.db');
+  dbModule = await import('../../../src/db/index.ts');
+  dbModule.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+  const tenant = await import('../../../src/middleware/tenant.ts');
+  createTenantFetch = tenant.createTenantFetch;
+  tenantHeader = tenant.TENANT_HEADER;
+  const ask = await import('../../../src/routes/ask/index.ts');
+  route = ask.createAskRoutes({
+    client: async (prompt) => ({ answer: `Use the cited oracle source [${prompt.sources[0]?.index}].`, citations: [1], noEvidence: false }),
+    now: () => new Date('2026-06-17T00:00:00.000Z'),
+  });
+
+  const now = Date.now();
+  dbModule.db.insert(dbModule.oracleDocuments).values({
+    id: docId,
+    tenantId,
+    type: 'learning',
+    sourceFile: 'ψ/shared/ask.md',
+    concepts: JSON.stringify(['ask']),
+    createdAt: now,
+    updatedAt: now,
+    indexedAt: now,
+    project: 'ask',
+    createdBy: 'ask-test',
+  }).run();
+  dbModule.sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
+    .run(docId, `Oracle answer evidence with ${term}`, 'ask');
+});
+
+function post(body: Record<string, unknown>) {
+  return createTenantFetch((req) => route.handle(req))(new Request('http://local/api/ask', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', [tenantHeader]: tenantId },
+    body: JSON.stringify(body),
+  }));
+}
+
+afterAll(() => {
+  dbModule?.closeDb();
+  if (fs.existsSync(tempRoot)) fs.rmSync(tempRoot, { recursive: true });
+});
+
+describe('POST /api/ask', () => {
+  test('runs hybrid search and returns LLM synthesis with citations', async () => {
+    const res = await post({ q: term, llm: true });
+    const body = await res.json() as { answer: string; citations: number[]; noEvidence: boolean; mode: string; sources: Array<{ id: string }> };
+
+    expect(res.status).toBe(200);
+    expect(body.mode).toBe('llm');
+    expect(body.answer).toContain('[1]');
+    expect(body.citations).toEqual([1]);
+    expect(body.noEvidence).toBe(false);
+    expect(body.sources[0].id).toBe(docId);
+  });
+
+  test('falls back to extractive citations when LLM is disabled', async () => {
+    const res = await post({ q: term, llm: false });
+    const body = await res.json() as { mode: string; citations: number[]; answer: string };
+
+    expect(res.status).toBe(200);
+    expect(body.mode).toBe('extractive');
+    expect(body.citations).toEqual([1]);
+    expect(body.answer).toContain('[1]');
+  });
+
+  test('flags no evidence when retrieval returns nothing', async () => {
+    const res = await post({ q: `missing-${stamp}`, llm: true });
+    const body = await res.json() as { noEvidence: boolean; citations: number[]; sources: unknown[] };
+
+    expect(res.status).toBe(200);
+    expect(body.noEvidence).toBe(true);
+    expect(body.citations).toEqual([]);
+    expect(body.sources).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add `POST /api/ask` for a natural-language ask flow over existing hybrid search
- build cited source excerpts, preserve supersede metadata, and flag `noEvidence`
- support opt-in LLM synthesis via injected client or `ORACLE_ASK_LLM=1` + `ORACLE_ASK_LLM_URL`, with extractive fallback when disabled/unavailable

## Validation
```bash
bun test --isolate tests/http/search/ask.test.ts tests/http/search/edge-cases.test.ts tests/http/search/tenant-routes.test.ts
bunx tsc --noEmit
git diff --check
wc -l src/routes/ask/index.ts src/routes/ask/model.ts src/routes/ask/synthesis.ts src/server.ts tests/http/search/ask.test.ts
```
