### PR TITLE
docs: diagram memory pipeline

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ is linked here; keep new docs in the right section when adding files.
 | [architecture/mcp-remote-transport.md](./architecture/mcp-remote-transport.md) | Remote MCP Worker transport and `mcp-remote` client bridge contract. |
 | [architecture/deploy-topologies.md](./architecture/deploy-topologies.md) | Choose all-local, Cloudflare edge, Vercel, or federation tunnel deployment. | deploy options, edge/backend/vector split |
 | [architecture/memory-layer.md](./architecture/memory-layer.md) | Memory confidence ranking, retrieval reinforcement, supersede, and consolidation contracts from #2251. | memory, confidence, supersede, consolidation |
+| [architecture/memory-pipeline.md](./architecture/memory-pipeline.md) | Diagram the write, FTS, async consolidation, confidence ranking, and bi-temporal read pipeline. | memory pipeline, FTS, asOf, ranking |
 | [architecture/cloudflared-origin-contract.md](./architecture/cloudflared-origin-contract.md) | `ORACLE_ORIGIN_URL` secret and Cloudflare Tunnel origin contract for Workers. | Cloudflare Tunnel, origin URL, Workers secrets |
 | [architecture/proxy-terminology.md](./architecture/proxy-terminology.md) | Disambiguate request-tier, storage-tier, and manifest passthrough proxy meanings. | proxy vocabulary, external-only adapters |
 | [PLUGIN-GUIDE.md](./PLUGIN-GUIDE.md) | Author installable Oracle plugins | `plugin.json`, CLI/MCP/menu/API surfaces |

--- a/docs/architecture/memory-layer.md
+++ b/docs/architecture/memory-layer.md
@@ -2,7 +2,8 @@
 
 This document records the memory-layer contracts added by the #2251 waves that
 are present on `alpha`: confidence-ranked retrieval, retrieval reinforcement,
-supersede-not-delete, and the async consolidation worker. The guiding rule is:
+supersede-not-delete, the async consolidation worker, and bi-temporal reads.
+The guiding rule is:
 **reads stay fast and LLM-free; curation is explicit, auditable, and never
 physically deletes memories.**
 
@@ -17,16 +18,19 @@ physically deletes memories.**
   `SUPERSEDE` actions.
 - Keep every path tenant-aware and compatible with SQLite/FTS5 plus vector
   adapters.
+- Answer historical searches with `valid_time` / `asOf` without deleting old
+  rows.
 
 ## End-to-end shape
 
 ```text
 write/index
   -> oracle_documents + oracle_fts + vector collections
-  -> usage_count / last_accessed_at start cold
+  -> valid_time + usage_count / last_accessed_at start cold
 
 read/search
   -> FTS/vector/fan-out retrieval
+  -> optional asOf filter uses valid_time / valid_until
   -> query-time confidence score
   -> rankingScore = normalized RRF blended with confidence
   -> logDocumentAccess() bumps usage_count + last_accessed_at
@@ -187,6 +191,16 @@ This adopts the useful part of LLM write-time curation while preserving the
 project invariant: wrong curation remains reversible/auditable because no row is
 hard-deleted.
 
+## Bi-temporal reads
+
+`oracle_documents.valid_time` records world-valid time. `/api/search?asOf=...`
+uses `src/search/bitemporal.ts` to include rows where the coalesced valid start
+is at or before `asOf`, and the successor's `valid_time` or `superseded_at` is
+after `asOf`. Returned rows can expose `valid_time` and `valid_until` alongside
+supersede metadata.
+
+See [`memory-pipeline.md`](./memory-pipeline.md) for the full write/read flow.
+
 ## Wave status and follow-ups
 
 Implemented on current `alpha`:
@@ -195,15 +209,15 @@ Implemented on current `alpha`:
 - search access reinforces confidence through usage heat;
 - supersede metadata is returned with search results;
 - async consolidation can plan/apply supersede-only cleanup;
-- optional LLM consolidation is isolated from read paths.
+- optional LLM consolidation is isolated from read paths;
+- bi-temporal `valid_time` / `asOf` reads return `valid_time` and `valid_until`.
 
 Tracked by #2251 but not a current `alpha` contract in this branch:
 
-- bi-temporal `valid_time` / `asOf` reads from PR #2282;
 - entity-linking sidecar collections from PR #2285.
 
-When those land, extend this document with the valid-time semantics and entity
-fusion/ranking contract, but keep the same non-goals below.
+When that lands, extend this document with the entity fusion/ranking contract,
+but keep the same non-goals below.
 
 ## Non-goals
 

--- a/docs/architecture/memory-pipeline.md
+++ b/docs/architecture/memory-pipeline.md
@@ -1,0 +1,112 @@
+# Memory pipeline diagram
+
+This is the operational flow for the Oracle memory layer on `alpha`: writes land
+in SQLite/FTS/vector stores, background consolidation creates supersede links,
+reads rank by confidence without LLM calls, and `asOf` reads use bi-temporal
+validity windows.
+
+## Pipeline diagram
+
+```mermaid
+flowchart LR
+  W[Write: learn, import, indexer] --> D[oracle_documents]
+  W --> F[oracle_fts]
+  W --> V[vector collections]
+
+  D --> C[async consolidation worker]
+  F --> C
+  C -->|runSupersede| S[superseded_by / superseded_at / reason]
+  S --> D
+
+  Q[Read query] --> R1[/api/search]
+  Q --> R2[/api/v1/memory/fanout]
+
+  R1 --> F
+  R1 --> B[bi-temporal asOf filter]
+  B --> T[valid_time / valid_until]
+  T --> A[attach supersede status]
+
+  R2 --> V
+  R2 --> K[RRF k=60]
+  K --> H[query-time confidence]
+  H --> O[confidence-ranked results]
+
+  A --> U[document_access + usage heat]
+  O --> U
+  U --> D
+```
+
+## Phase flow
+
+### 1. Write and index
+
+Writes come from MCP/HTTP learn flows, imports, and the indexer. The canonical row
+is `oracle_documents`; search text is mirrored to `oracle_fts`; vector adapters
+receive embeddings for semantic/fan-out recall.
+
+Important columns:
+
+- `tenant_id` scopes all memory surfaces;
+- `valid_time` records when the fact became true in the world;
+- `superseded_by`, `superseded_at`, `superseded_reason` preserve history;
+- `usage_count`, `last_accessed_at` store retrieval reinforcement heat.
+
+### 2. FTS and vector substrates
+
+`oracle_fts` is the low-latency keyword substrate for `/api/search` and tenant
+search. Vector collections power `/api/v1/memory/fanout`; current fan-out fuses
+collections with Reciprocal Rank Fusion before confidence reranking.
+
+### 3. Async consolidation
+
+`src/workers/consolidation.ts` scans active docs (`superseded_by IS NULL`) off the
+hot path. It compares same-tenant, same-type candidates with lexical cosine and
+FTS/token overlap, defaults to dry-run, and applies only through `runSupersede()`.
+The result contract includes `deleted: 0`.
+
+The optional LLM layer in `src/workers/consolidation-llm.ts` is still
+supersede-only: it accepts validated `SUPERSEDE` calls and ignores delete/update,
+unknown IDs, and self-supersede.
+
+### 4. Confidence-ranked reads
+
+`/api/v1/memory/fanout` computes confidence at query time. Ranking is:
+
+```text
+rankingScore = normalizedRrf * (1 - confidenceWeight)
+             + confidence.score * confidenceWeight
+```
+
+`src/routes/memory/rerank-config.ts` exposes the effective configuration; health
+reports it as `memory.fanoutReranking`. Confidence uses match score, freshness,
+provenance, and usage heat. The read path remains LLM-free.
+
+### 5. Bi-temporal reads
+
+`/api/search?asOf=<timestamp>` answers “what was true then?” by applying
+`src/search/bitemporal.ts`:
+
+```text
+valid_start = coalesce(valid_time, updated_at, created_at, indexed_at)
+valid_until = coalesce(successor.valid_time, superseded_at)
+include row when valid_start <= asOf and (valid_until is null or valid_until > asOf)
+```
+
+Returned rows may include:
+
+- `valid_time`: the row's world-valid start time;
+- `valid_until`: the replacement's `valid_time`, falling back to transaction-time
+  `superseded_at`;
+- supersede metadata from `attachSupersedeStatus()`.
+
+Tenant FTS search applies the bi-temporal predicate in SQL. Other search modes
+filter candidate results after retrieval, then report `asOf` as an ISO timestamp.
+
+## Safety contracts
+
+- No hard deletes for contradiction or consolidation.
+- No LLM calls on synchronous read paths.
+- Consolidation is off-path and dry-run-first.
+- Bi-temporal reads preserve transaction history while exposing world-valid time.
+- Retrieval reinforcement can lift useful old docs, but stale warnings remain
+  visible through confidence details.


### PR DESCRIPTION
## Summary
- Adds `docs/architecture/memory-pipeline.md` with a Mermaid pipeline diagram and phase flow for write → FTS/vector → async consolidation → confidence ranking → bi-temporal `asOf` reads.
- Updates `docs/architecture/memory-layer.md` now that `valid_time` / `asOf` reads are on `alpha`.
- Links the new pipeline guide from `docs/README.md`.

## Validation
- `bunx tsc --noEmit`
- `bun test tests/docs tests/http/memory tests/http/search/bitemporal-read.test.ts tests/http/health/status.test.ts tests/server/document-usage-reinforcement.test.ts tests/workers/consolidation-worker.test.ts tests/workers/consolidation-llm.test.ts` (52 tests)
- `git diff --check origin/alpha...HEAD`
- `wc -l docs/architecture/memory-pipeline.md docs/architecture/memory-layer.md docs/README.md` (112 / 228 / 100)
