### PR TITLE
test(frontend): guard badge contrast

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260616.1",
+        "@playwright/test": "^1.61.0",
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20.17.9",
         "better-sqlite3": "^12.9.0",
@@ -321,6 +322,8 @@
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.135.0", "", {}, "sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q=="],
+
+    "@playwright/test": ["@playwright/test@1.61.0", "", { "dependencies": { "playwright": "1.61.0" }, "bin": { "playwright": "cli.js" } }, "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA=="],
 
     "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
 
@@ -896,6 +899,10 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
+    "playwright": ["playwright@1.61.0", "", { "dependencies": { "playwright-core": "1.61.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ=="],
+
+    "playwright-core": ["playwright-core@1.61.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA=="],
+
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
@@ -1151,6 +1158,8 @@
     "miniflare/undici": ["undici@7.24.8", "", {}, "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ=="],
 
     "node-abi/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 

--- a/frontend/src/components/Badge.tsx
+++ b/frontend/src/components/Badge.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 
 export function Badge({ children }: { children: ReactNode }) {
   return (
-    <span className="rounded-full border border-teal-300/20 bg-teal-300/10 px-2.5 py-1 text-xs font-medium text-teal-200">
+    <span className="rounded-full border border-teal-300/20 bg-teal-300/10 px-2.5 py-1 text-xs font-medium text-teal-200" data-contrast-badge>
       {children}
     </span>
   );

--- a/frontend/src/pages/StatusPage.tsx
+++ b/frontend/src/pages/StatusPage.tsx
@@ -47,7 +47,7 @@ function Field({ label, value }: { label: string; value: string | number | undef
 
 function StatusBadge({ label, status }: { label: string; status?: string }) {
   return (
-    <div className={`rounded-2xl border p-4 ${statusClass(status)}`}>
+    <div className={`rounded-2xl border p-4 ${statusClass(status)}`} data-contrast-badge>
       <p className="text-xs font-semibold uppercase tracking-[0.18em] opacity-80">{label}</p>
       <p className="mt-2 text-2xl font-semibold">{status ?? 'unknown'}</p>
     </div>
@@ -85,7 +85,7 @@ function PluginRows({ health }: { health: HealthResponse }) {
       {items.map((plugin) => (
         <li key={plugin.name} className="flex flex-col gap-2 rounded-xl border border-white/10 bg-white/[0.03] p-3 sm:flex-row sm:items-center sm:justify-between">
           <a className="focus-ring font-mono text-sm text-teal-100 hover:text-teal-200" href={pluginHealthPath(plugin)}>{plugin.name}</a>
-          <span className={`rounded-full border px-2 py-1 text-xs ${statusClass(plugin.status)}`}>{plugin.status}</span>
+          <span className={`rounded-full border px-2 py-1 text-xs ${statusClass(plugin.status)}`} data-contrast-badge>{plugin.status}</span>
           {plugin.error ? <span className="text-sm text-amber-200">{plugin.error}</span> : null}
         </li>
       ))}
@@ -102,7 +102,7 @@ function ProxyRows({ vector }: { vector: VectorHealthForStatus | null }) {
         <li key={`${row.name}-${row.endpoint}`} className="rounded-xl border border-white/10 bg-white/[0.03] p-3">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <span className="font-mono text-sm text-teal-100">{row.name}</span>
-            <span className={`rounded-full border px-2 py-1 text-xs ${statusClass(row.status === 'up' ? 'ok' : row.status)}`}>{row.status}</span>
+            <span className={`rounded-full border px-2 py-1 text-xs ${statusClass(row.status === 'up' ? 'ok' : row.status)}`} data-contrast-badge>{row.status}</span>
           </div>
           <p className="mt-2 break-words font-mono text-xs text-slate-300">{row.endpoint}</p>
           <p className="mt-1 text-sm text-slate-400">{row.detail}</p>

--- a/frontend/src/pages/VectorExportPage.tsx
+++ b/frontend/src/pages/VectorExportPage.tsx
@@ -148,7 +148,7 @@ export function VectorExportPage({
         <p className="text-sm text-slate-500">{status}</p>
         {downloadError ? <ErrorMessage title="Vector export failed." message={downloadError} /> : null}
         <div className="flex flex-wrap gap-2">
-          <button className="focus-ring rounded-xl border border-teal-300/30 px-4 py-2 text-sm font-semibold text-teal-100 hover:bg-teal-300/10 disabled:cursor-not-allowed disabled:opacity-50" disabled={!collection || Boolean(downloading) || formatOptions.length === 0} type="button" onClick={() => void exportSelected()}>
+          <button className="focus-ring rounded-xl border border-teal-300/30 px-4 py-2 text-sm font-semibold text-teal-100 hover:bg-teal-300/10 disabled:cursor-not-allowed disabled:opacity-50" data-contrast-badge disabled={!collection || Boolean(downloading) || formatOptions.length === 0} type="button" onClick={() => void exportSelected()}>
             {downloading ? <Spinner label={`Downloading ${formatLabelFor(formatOptions, downloading)}`} /> : 'Export'}
           </button>
         </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -56,8 +56,15 @@ body {
 .light .text-slate-300 { color: #334155; }
 .light .text-slate-400 { color: #475569; }
 .light .text-slate-500 { color: #64748b; }
+.light .text-teal-100,
 .light .text-teal-200,
 .light .text-teal-300 { color: #0f766e; }
+.light .text-emerald-100,
+.light .text-emerald-200 { color: #065f46; }
+.light .text-amber-100,
+.light .text-amber-200 { color: #92400e; }
+.light .text-red-100,
+.light .text-red-200 { color: #b91c1c; }
 .light .text-purple-200,
 .light .text-purple-300 { color: #7e22ce; }
 .light .hover\:bg-slate-900:hover { background-color: rgb(241 245 249 / 0.95); }

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260616.1",
+    "@playwright/test": "^1.61.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.17.9",
     "better-sqlite3": "^12.9.0",

--- a/tests/e2e/badge-contrast.e2e.ts
+++ b/tests/e2e/badge-contrast.e2e.ts
@@ -1,0 +1,205 @@
+import { expect, test, type Page } from '@playwright/test';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { join } from 'node:path';
+import { createServer } from 'node:net';
+
+let frontend: ChildProcessWithoutNullStreams | null = null;
+let frontendUrl = '';
+
+test.beforeAll(async () => {
+  const port = await freePort();
+  frontendUrl = `http://127.0.0.1:${port}`;
+  frontend = spawn('bun', ['run', 'dev'], {
+    cwd: join(process.cwd(), 'frontend'),
+    env: {
+      ...process.env,
+      FRONTEND_PROXY_TARGET: 'http://127.0.0.1:47778',
+      VITE_PORT: String(port),
+    },
+  });
+  await waitForFrontend(frontendUrl);
+});
+
+test.afterAll(() => {
+  frontend?.kill();
+});
+
+for (const theme of ['light', 'dark'] as const) {
+  test(`status badges meet 4.5:1 contrast in ${theme} theme`, async ({ page }) => {
+    await mockApi(page);
+    await page.goto(`${frontendUrl}/status`);
+    await setTheme(page, theme);
+    await expect(page.getByRole('heading', { name: 'Health overview' })).toBeVisible();
+    await expect(page.locator('[data-contrast-badge]')).toHaveCount(6);
+    await expectContrast(page, theme, 'status');
+  });
+
+  test(`vector export action meets 4.5:1 contrast in ${theme} theme`, async ({ page }) => {
+    await mockApi(page);
+    await page.goto(`${frontendUrl}/vector/export`);
+    await setTheme(page, theme);
+    await expect(page.locator('section[aria-labelledby="vector-export-title"]').getByRole('heading', { name: 'Vector export' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Export' })).toBeEnabled();
+    await expectContrast(page, theme, 'vector export');
+  });
+}
+
+async function freePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      server.close(() => {
+        typeof address === 'object' && address ? resolve(address.port) : reject(new Error('No port'));
+      });
+    });
+  });
+}
+
+async function waitForFrontend(url: string): Promise<void> {
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      if (response.status < 500) return;
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+  }
+  throw new Error(`Frontend did not start at ${url}`);
+}
+
+async function mockApi(page: Page): Promise<void> {
+  const now = new Date('2026-06-17T00:00:00.000Z').toISOString();
+  await fulfill(page, '**/api/menu*', { items: [] });
+  await fulfill(page, '**/api/plugins*', { plugins: [], dir: '/tmp/oracle/plugins', count: 0 });
+  await fulfill(page, '**/api/v1/metrics*', {
+    uptime: 12,
+    requestCount: 2,
+    avgResponseMs: 4,
+    activeConnections: 0,
+    lastRestart: now,
+    memoryUsage: { rss: 1, heapTotal: 1, heapUsed: 1, external: 0, arrayBuffers: 0 },
+  });
+  await fulfill(page, '**/api/v1/health*', {
+    status: 'ok',
+    server: 'oracle-test',
+    version: 'test',
+    port: 47778,
+    oracle: 'connected',
+    uptimeSeconds: 90,
+    dbStatus: 'ok',
+    vectorStatus: 'ok',
+    pluginStatus: 'ok',
+    mcpToolCount: 3,
+    pluginCount: 1,
+    db: { status: 'ok', path: '/tmp/oracle.sqlite' },
+    plugins: { count: 1, status: 'ok', items: [{ name: 'contrast-plugin', status: 'ok' }] },
+  });
+  await fulfill(page, '**/api/v1/vector/health*', {
+    status: 'ok',
+    checked_at: now,
+    engines: [],
+    services: [{ name: 'vector-proxy', type: 'proxy', endpoint: 'http://127.0.0.1:47779', status: 'up', available: true, health: { status: 'ok', checkedAt: now } }],
+  });
+  await fulfill(page, '**/api/v1/vector/index/models*', {
+    models: { qwen3: { collection: 'oracle_knowledge_qwen3', model: 'qwen3', adapter: 'proxy', count: 12 } },
+  });
+  await fulfill(page, '**/api/v1/vector/export/formats*', {
+    formats: [
+      { format: 'json', label: 'JSON', mimeType: 'application/json', extension: 'json' },
+      { format: 'markdown', label: 'Markdown', mimeType: 'text/markdown', extension: 'md' },
+    ],
+  });
+}
+
+async function fulfill(page: Page, url: string, payload: unknown): Promise<void> {
+  await page.route(url, (route) => route.fulfill({ contentType: 'application/json', body: JSON.stringify(payload) }));
+}
+
+async function setTheme(page: Page, theme: 'light' | 'dark'): Promise<void> {
+  await page.evaluate((next) => {
+    document.documentElement.classList.remove('light', 'dark');
+    document.documentElement.classList.add(next);
+    document.documentElement.dataset.theme = next;
+    document.documentElement.style.colorScheme = next;
+    localStorage.setItem('ARRA_FRONTEND_THEME', next);
+  }, theme);
+}
+
+async function expectContrast(page: Page, theme: string, surface: string): Promise<void> {
+  const failures = await page.locator('[data-contrast-badge]').evaluateAll((nodes) => {
+    type Rgba = { r: number; g: number; b: number; a: number };
+    const parse = (value: string): Rgba => {
+      const color = value.trim();
+      if (color === 'transparent') return { r: 0, g: 0, b: 0, a: 0 };
+      const rgb = color.match(/^rgba?\(([^)]+)\)$/);
+      if (rgb) {
+        const parts = rgb[1].split(/[,/ ]+/).filter(Boolean).map(Number);
+        return { r: parts[0], g: parts[1], b: parts[2], a: parts[3] ?? 1 };
+      }
+      const srgb = color.match(/^color\(srgb\s+([0-9.]+)\s+([0-9.]+)\s+([0-9.]+)(?:\s*\/\s*([0-9.]+))?\)$/);
+      if (srgb) return { r: Number(srgb[1]) * 255, g: Number(srgb[2]) * 255, b: Number(srgb[3]) * 255, a: Number(srgb[4] ?? 1) };
+      const oklab = color.match(/^oklab\(([-0-9.]+%?)\s+([-0-9.]+)\s+([-0-9.]+)(?:\s*\/\s*([0-9.]+%?))?\)$/);
+      if (oklab) {
+        const c = Math.hypot(Number(oklab[2]), Number(oklab[3]));
+        const h = Math.atan2(Number(oklab[3]), Number(oklab[2])) * 180 / Math.PI;
+        return parse(`oklch(${oklab[1]} ${c} ${h} / ${oklab[4] ?? 1})`);
+      }
+      const oklch = color.match(/^oklch\(([-0-9.]+%?)\s+([-0-9.]+)\s+([-0-9.]+)(?:deg)?(?:\s*\/\s*([0-9.]+%?))?\)$/);
+      if (!oklch) throw new Error(`Unsupported color ${color}`);
+      const l = oklch[1].endsWith('%') ? Number(oklch[1].slice(0, -1)) / 100 : Number(oklch[1]);
+      const c = Number(oklch[2]);
+      const h = Number(oklch[3]) * Math.PI / 180;
+      const a = oklch[4]?.endsWith('%') ? Number(oklch[4].slice(0, -1)) / 100 : Number(oklch[4] ?? 1);
+      const labA = c * Math.cos(h);
+      const labB = c * Math.sin(h);
+      const lp = l + 0.3963377774 * labA + 0.2158037573 * labB;
+      const mp = l - 0.1055613458 * labA - 0.0638541728 * labB;
+      const sp = l - 0.0894841775 * labA - 1.291485548 * labB;
+      const ll = lp ** 3;
+      const mm = mp ** 3;
+      const ss = sp ** 3;
+      const gamma = (n: number) => {
+        const v = Math.min(1, Math.max(0, n));
+        return 255 * (v <= 0.0031308 ? 12.92 * v : 1.055 * (v ** (1 / 2.4)) - 0.055);
+      };
+      return {
+        r: gamma(4.0767416621 * ll - 3.3077115913 * mm + 0.2309699292 * ss),
+        g: gamma(-1.2684380046 * ll + 2.6097574011 * mm - 0.3413193965 * ss),
+        b: gamma(-0.0041960863 * ll - 0.7034186147 * mm + 1.707614701 * ss),
+        a,
+      };
+    };
+    const blend = (top: Rgba, bottom: Rgba): Rgba => {
+      const a = top.a + bottom.a * (1 - top.a);
+      return a === 0 ? { r: 0, g: 0, b: 0, a: 0 } : {
+        r: (top.r * top.a + bottom.r * bottom.a * (1 - top.a)) / a,
+        g: (top.g * top.a + bottom.g * bottom.a * (1 - top.a)) / a,
+        b: (top.b * top.a + bottom.b * bottom.a * (1 - top.a)) / a,
+        a,
+      };
+    };
+    const channel = (value: number) => {
+      const v = value / 255;
+      return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
+    };
+    const luminance = (color: Rgba) => 0.2126 * channel(color.r) + 0.7152 * channel(color.g) + 0.0722 * channel(color.b);
+    const ratio = (left: Rgba, right: Rgba) => {
+      const [high, low] = [luminance(left), luminance(right)].sort((a, b) => b - a);
+      return (high + 0.05) / (low + 0.05);
+    };
+    return nodes.map((node) => {
+      const element = node as HTMLElement;
+      let bg: Rgba = { r: 255, g: 255, b: 255, a: 1 };
+      const chain: Element[] = [];
+      for (let current: Element | null = element; current; current = current.parentElement) chain.unshift(current);
+      for (const current of chain) bg = blend(parse(getComputedStyle(current).backgroundColor), bg);
+      const fg = blend(parse(getComputedStyle(element).color), bg);
+      const contrast = ratio(fg, bg);
+      return { text: element.innerText.replace(/\s+/g, ' ').trim(), contrast: Number(contrast.toFixed(2)) };
+    }).filter((item) => item.text && item.contrast < 4.5);
+  });
+  expect(failures, `${surface} ${theme} contrast failures`).toEqual([]);
+}


### PR DESCRIPTION
## Summary
- add Playwright coverage for status badges and vector export action contrast in light and dark themes
- mark badge/action elements with a stable contrast regression hook
- harden light theme status color overrides and add the missing Playwright runner dependency

## Validation
- bunx tsc --noEmit
- (cd frontend && bunx tsc --noEmit)
- bun test tests/frontend/
- bunx playwright test tests/e2e/badge-contrast.e2e.ts --output=/tmp/arra-playwright-contrast

## Notes
- PR targets alpha
- Source/test/package files are <=250 lines