### PR TITLE
chore(workers): harden deploy dry-runs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ is linked here; keep new docs in the right section when adding files.
 | [BINS.md](./BINS.md) | Published command binaries and aliases. |
 | [DEPLOY-DIGITALOCEAN.md](./DEPLOY-DIGITALOCEAN.md) | Small public Arra HTTP node on DigitalOcean. |
 | [deploy-cloudflare-mcp.md](./deploy-cloudflare-mcp.md) | One-click Cloudflare Workers remote MCP deploy and Claude `/mcp` setup. |
+| [workers-deploy-configs.md](./workers-deploy-configs.md) | Validate Cloudflare MCP, Studio, and federation Worker configs and env vars. |
 | [deploy-vercel.md](./deploy-vercel.md) | One-click Vercel deploy for the Oracle Studio frontend and `/api/*` proxy. |
 | [DOCKER-MCP-TOOLKIT.md](./DOCKER-MCP-TOOLKIT.md) | Docker MCP Toolkit package and profile setup. |
 | [LOCAL-DEV.md](./LOCAL-DEV.md) | Local development setup and repo workflow. |

--- a/docs/workers-deploy-configs.md
+++ b/docs/workers-deploy-configs.md
@@ -1,0 +1,46 @@
+# Workers deploy config hardening
+
+This repo keeps three active Cloudflare Worker deploy surfaces plus one retired
+root teardown config. Use these commands before pushing deploy config changes:
+
+```bash
+bunx tsc --noEmit
+bun run cloudflare:mcp:dry-run
+bun run cloudflare:studio:dry-run
+bun run cloudflare:federation:dry-run
+```
+
+`cloudflare:studio:*` builds `frontend/dist` first because Workers Static Assets
+must exist before Wrangler can bundle the Studio worker.
+
+## Deploy targets
+
+| Surface | Wrangler config | Purpose | Dry-run proof |
+| --- | --- | --- | --- |
+| MCP | `workers/mcp/wrangler.jsonc` | Remote MCP endpoint at `/mcp`; proxies safe tools to an Oracle HTTP backend. | `bun run cloudflare:mcp:dry-run` must show `env.MCP_OBJECT` and `env.ORACLE_URL`. |
+| Studio | `workers/studio/wrangler.jsonc` | Vite app + `/api/*` and `/mcp/*` edge proxy. | `bun run cloudflare:studio:dry-run` must show `env.ASSETS`, `env.ORACLE_URL`, and `env.ORACLE_MCP_URL`. |
+| Federation | `workers/federation/wrangler.jsonc` | Narrow signed relay for `/api/send`, `/api/sessions`, and `/api/federation/status`. | `bun run cloudflare:federation:dry-run` must show `env.TUNNEL_URL`. |
+| Root teardown | `wrangler.jsonc` | Retires the old `OracleMcpAgent` Durable Object only. | Do not use for new MCP deploys. |
+
+## Environment variables and bindings
+
+| Name | Surface | Where | Required | Notes |
+| --- | --- | --- | --- | --- |
+| `MCP_OBJECT` | MCP | Durable Object binding | Yes | Session state for Cloudflare `McpAgent`; class is `OracleMCP`. |
+| `ORACLE_ORIGIN_URL` | MCP, Studio | secret | Production | Preferred HTTPS origin for the Bun API, usually a Cloudflare Tunnel or stable backend URL. |
+| `ORACLE_URL` | MCP, Studio | `vars` fallback or secret | Dev/fallback | Committed placeholder only; replace or override for real deploys. |
+| `ORACLE_HTTP_URL` | MCP, Studio | secret/env | Legacy fallback | Checked after `ORACLE_ORIGIN_URL` and `ORACLE_URL`. |
+| `ORACLE_API` | MCP, Studio | secret/env | Legacy fallback | Last backend-origin alias. |
+| `ORACLE_MCP_URL` | Studio | var/secret | Yes for split MCP | Points Studio `/mcp/*` traffic at the MCP Worker; if unset Studio falls back to backend `/mcp`. |
+| `ARRA_API_TOKEN` | MCP, Studio | secret | If backend auth is enabled | Forwarded as `Authorization: Bearer ...`. |
+| `ARRA_API_KEY` | MCP, Studio | secret | Legacy fallback | Used only when `ARRA_API_TOKEN` is absent. |
+| `ORACLE_TENANT_ID` | MCP | var/secret | Optional | Single-tenant smoke-test default; prefer OAuth/Access claims for shared deploys. |
+| `ORACLE_DB` | MCP | D1 binding | Optional | Enables tenant lookup for split/edge installs. |
+| `ORACLE_TENANTS_TABLE` | MCP | var | Optional | Overrides the D1 tenant table name; defaults to `tenants`. |
+| `ASSETS` | Studio | Workers Static Assets binding | Yes | Bound to `frontend/dist` with SPA fallback. |
+| `TUNNEL_URL` | Federation | var/secret | Yes | HTTPS base URL for the narrow maw/session tunnel; not the full backend origin. |
+| `FEDERATION_TOKEN` | Federation | secret | Yes | HMAC signing key. Never commit a real value. |
+| `federationToken` | Federation | secret | Legacy fallback | Kept for existing Worker secrets; prefer `FEDERATION_TOKEN`. |
+
+Keep real secrets in Wrangler or Cloudflare dashboard secrets. The committed
+Wrangler files should contain placeholders only.

--- a/package.json
+++ b/package.json
@@ -97,8 +97,15 @@
     "huginn:sweep": "bun scripts/huginn-sweep.ts",
     "bench": "bun run benchmarks/run-all.ts",
     "export": "bun src/cli/commands/export.ts",
-    "cloudflare:mcp:dev": "wrangler dev --config wrangler.jsonc",
-    "cloudflare:mcp:deploy": "wrangler deploy --config wrangler.jsonc"
+    "cloudflare:mcp:dev": "wrangler dev --config workers/mcp/wrangler.jsonc",
+    "cloudflare:mcp:deploy": "wrangler deploy --config workers/mcp/wrangler.jsonc",
+    "cloudflare:mcp:dry-run": "wrangler deploy --dry-run --config workers/mcp/wrangler.jsonc",
+    "cloudflare:studio:dev": "cd frontend && bun run build && cd .. && wrangler dev --config workers/studio/wrangler.jsonc",
+    "cloudflare:studio:dry-run": "cd frontend && bun run build && cd .. && wrangler deploy --dry-run --config workers/studio/wrangler.jsonc",
+    "cloudflare:studio:deploy": "cd frontend && bun run build && cd .. && wrangler deploy --config workers/studio/wrangler.jsonc",
+    "cloudflare:federation:dev": "wrangler dev --config workers/federation/wrangler.jsonc",
+    "cloudflare:federation:dry-run": "wrangler deploy --dry-run --config workers/federation/wrangler.jsonc",
+    "cloudflare:federation:deploy": "wrangler deploy --config workers/federation/wrangler.jsonc"
   },
   "dependencies": {
     "@elysiajs/cors": "^1.4.1",

--- a/tests/workers/cloudflare-deploy-config.test.ts
+++ b/tests/workers/cloudflare-deploy-config.test.ts
@@ -64,6 +64,55 @@ function stripTrailingCommas(source: string): string {
 }
 
 describe('Cloudflare deploy metadata', () => {
+  test('deploy docs list dry-run commands and required Worker environment', () => {
+    const docs = read('docs/workers-deploy-configs.md');
+
+    for (const command of [
+      'bun run cloudflare:mcp:dry-run',
+      'bun run cloudflare:studio:dry-run',
+      'bun run cloudflare:federation:dry-run',
+    ]) {
+      expect(docs).toContain(command);
+    }
+
+    for (const envName of [
+      'MCP_OBJECT',
+      'ORACLE_ORIGIN_URL',
+      'ORACLE_URL',
+      'ORACLE_HTTP_URL',
+      'ORACLE_API',
+      'ORACLE_MCP_URL',
+      'ARRA_API_TOKEN',
+      'ARRA_API_KEY',
+      'ORACLE_TENANT_ID',
+      'ORACLE_DB',
+      'ORACLE_TENANTS_TABLE',
+      'ASSETS',
+      'TUNNEL_URL',
+      'FEDERATION_TOKEN',
+      'federationToken',
+    ]) {
+      expect(docs).toContain(`\`${envName}\``);
+    }
+  });
+
+  test('root package scripts point at the active Worker configs', () => {
+    const pkg = readJson<Record<string, any>>('package.json');
+
+    expect(pkg.scripts).toMatchObject({
+      'cloudflare:mcp:dev': 'wrangler dev --config workers/mcp/wrangler.jsonc',
+      'cloudflare:mcp:deploy': 'wrangler deploy --config workers/mcp/wrangler.jsonc',
+      'cloudflare:mcp:dry-run': 'wrangler deploy --dry-run --config workers/mcp/wrangler.jsonc',
+      'cloudflare:studio:dev': 'cd frontend && bun run build && cd .. && wrangler dev --config workers/studio/wrangler.jsonc',
+      'cloudflare:studio:deploy': 'cd frontend && bun run build && cd .. && wrangler deploy --config workers/studio/wrangler.jsonc',
+      'cloudflare:studio:dry-run':
+        'cd frontend && bun run build && cd .. && wrangler deploy --dry-run --config workers/studio/wrangler.jsonc',
+      'cloudflare:federation:dev': 'wrangler dev --config workers/federation/wrangler.jsonc',
+      'cloudflare:federation:deploy': 'wrangler deploy --config workers/federation/wrangler.jsonc',
+      'cloudflare:federation:dry-run': 'wrangler deploy --dry-run --config workers/federation/wrangler.jsonc',
+    });
+  });
+
   test('root Wrangler config only tears down the retired remote MCP Durable Object', () => {
     const cfg = parseJsonc<Record<string, any>>(read('wrangler.jsonc'));
 
@@ -83,6 +132,7 @@ describe('Cloudflare deploy metadata', () => {
       build: 'tsc --noEmit',
       dev: 'wrangler dev --config wrangler.jsonc',
       deploy: 'tsc --noEmit && wrangler deploy --config wrangler.jsonc',
+      'dry-run': 'tsc --noEmit && wrangler deploy --dry-run --config wrangler.jsonc',
       typecheck: 'tsc --noEmit',
     });
   });
@@ -117,6 +167,7 @@ describe('Cloudflare deploy metadata', () => {
     const pkg = JSON.parse(read('workers/mcp/package.json')) as Record<string, any>;
 
     expect(pkg.scripts.deploy).toBe('tsc --noEmit && wrangler deploy --config wrangler.jsonc');
+    expect(pkg.scripts['dry-run']).toBe('tsc --noEmit && wrangler deploy --dry-run --config wrangler.jsonc');
     expect(pkg.dependencies).toMatchObject({
       '@modelcontextprotocol/sdk': expect.any(String),
       agents: expect.any(String),

--- a/tests/workers/mcp-deploy-config.test.ts
+++ b/tests/workers/mcp-deploy-config.test.ts
@@ -62,6 +62,8 @@ describe('workers/mcp deploy package', () => {
     expect(pkg.scripts.deploy).toContain('tsc --noEmit');
     expect(pkg.scripts.deploy).toContain('wrangler deploy');
     expect(pkg.scripts.deploy).toContain('--config wrangler.jsonc');
+    expect(pkg.scripts['dry-run']).toContain('wrangler deploy --dry-run');
+    expect(pkg.scripts['dry-run']).toContain('--config wrangler.jsonc');
     expect(pkg.dependencies).toMatchObject({
       '@modelcontextprotocol/sdk': expect.any(String),
       agents: expect.any(String),

--- a/tests/workers/studio-deploy.test.ts
+++ b/tests/workers/studio-deploy.test.ts
@@ -26,7 +26,8 @@ describe('Oracle Studio Worker deploy surface', () => {
     const pkg = readJson('workers/studio/package.json');
 
     expect(pkg.scripts.build).toBe('cd ../../frontend && bun run build');
-    expect(pkg.scripts.deploy).toBe('bun run build && wrangler deploy');
+    expect(pkg.scripts.deploy).toBe('bun run build && wrangler deploy --config wrangler.jsonc');
+    expect(pkg.scripts['dry-run']).toBe('bun run build && wrangler deploy --dry-run --config wrangler.jsonc');
     expect(pkg.type).toBe('module');
     expect(pkg.private).toBe(true);
   });

--- a/workers/mcp/package.json
+++ b/workers/mcp/package.json
@@ -6,7 +6,8 @@
     "build": "tsc --noEmit",
     "dev": "wrangler dev --config wrangler.jsonc",
     "deploy": "tsc --noEmit && wrangler deploy --config wrangler.jsonc",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "dry-run": "tsc --noEmit && wrangler deploy --dry-run --config wrangler.jsonc"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/workers/studio/package.json
+++ b/workers/studio/package.json
@@ -4,8 +4,9 @@
   "type": "module",
   "scripts": {
     "build": "cd ../../frontend && bun run build",
-    "deploy": "bun run build && wrangler deploy",
-    "typecheck": "tsc --noEmit"
+    "deploy": "bun run build && wrangler deploy --config wrangler.jsonc",
+    "typecheck": "tsc --noEmit",
+    "dry-run": "bun run build && wrangler deploy --dry-run --config wrangler.jsonc"
   },
   "devDependencies": {
     "typescript": "^5.7.2",


### PR DESCRIPTION
## Summary
- Point root Cloudflare scripts at active MCP, Studio, and Federation Worker configs.
- Add dry-run scripts for MCP and Studio worker packages.
- Document Worker deploy dry-run commands and env/binding requirements under `docs/`.
- Add tests for deploy docs, root scripts, and worker package dry-run coverage.

## Validation
```bash
bunx tsc --noEmit
bun test tests/workers
bun run cloudflare:mcp:dry-run
bun run cloudflare:studio:dry-run
bun run cloudflare:federation:dry-run
git diff --check
wc -l $(git diff --name-only --diff-filter=ACMRT origin/alpha...HEAD)
```
