### PR TITLE
test: add Playwright contrast regression harness

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -43,6 +43,7 @@
         "vite": "^7.3.0",
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.0",
         "@tauri-apps/api": "^2.11.0",
         "@tauri-apps/cli": "^2.11.2",
         "@types/react": "^19.2.7",
@@ -321,6 +322,8 @@
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.135.0", "", {}, "sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q=="],
+
+    "@playwright/test": ["@playwright/test@1.61.0", "", { "dependencies": { "playwright": "1.61.0" }, "bin": { "playwright": "cli.js" } }, "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA=="],
 
     "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
 
@@ -896,6 +899,10 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
+    "playwright": ["playwright@1.61.0", "", { "dependencies": { "playwright-core": "1.61.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ=="],
+
+    "playwright-core": ["playwright-core@1.61.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA=="],
+
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
@@ -1151,6 +1158,8 @@
     "miniflare/undici": ["undici@7.24.8", "", {}, "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ=="],
 
     "node-abi/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "vite": "^7.3.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.0",
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/cli": "^2.11.2",
     "@types/react": "^19.2.7",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,18 +2,21 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests/e2e',
-  // Use .e2e.ts (not .spec.ts) so `bun test` doesn't try to load these —
-  // bun's runner auto-discovers **/*.{test,spec}.ts and would fail to
-  // import @playwright/test (a separate dep/runner).
-  testMatch: /.*\.e2e\.ts$/,
+  testMatch: [/.*\.e2e\.ts$/, /contrast\.spec\.ts$/],
   timeout: 30000,
-  use: {
-    baseURL: 'http://localhost:47778',
-  },
-  webServer: {
-    command: 'bun run src/server.ts',
-    url: 'http://localhost:47778/api/health',
-    reuseExistingServer: !process.env.CI,
-    timeout: 30000,
-  },
+  use: { baseURL: 'http://127.0.0.1:3000' },
+  webServer: [
+    {
+      command: 'bun run src/server.ts',
+      url: 'http://127.0.0.1:47778/api/health',
+      reuseExistingServer: !process.env.CI,
+      timeout: 30000,
+    },
+    {
+      command: 'cd frontend && bun run dev',
+      url: 'http://127.0.0.1:3000',
+      reuseExistingServer: !process.env.CI,
+      timeout: 30000,
+    },
+  ],
 });

--- a/tests/e2e/contrast.spec.ts
+++ b/tests/e2e/contrast.spec.ts
@@ -1,0 +1,92 @@
+import { mkdirSync } from 'node:fs';
+import { expect, test, type Page } from '@playwright/test';
+
+type Failure = { path: string; theme: string; text: string; ratio: number; color: string; background: string };
+const PAGES = ['/menu', '/plugins', '/status', '/vector', '/export', '/search', '/mcp', '/settings'];
+mkdirSync('test-results/contrast', { recursive: true });
+
+test.describe('frontend WCAG AA contrast', () => {
+  for (const theme of ['light', 'dark'] as const) {
+    for (const path of PAGES) {
+      test(`${theme} ${path} text contrast is at least 4.5:1`, async ({ page }) => {
+        await setTheme(page, theme);
+        await page.goto(path, { waitUntil: 'domcontentloaded' });
+        await page.locator('body').waitFor({ state: 'visible' });
+        await page.waitForTimeout(250);
+        await page.screenshot({ path: `test-results/contrast/${theme}-${slug(path)}.png`, fullPage: true });
+        const failures = await page.evaluate(({ path, theme }) => {
+          type Rgba = { r: number; g: number; b: number; a: number };
+          const text = (el: HTMLElement) => (el.innerText || el.textContent || '').replace(/\s+/g, ' ').trim();
+          const direct = (el: HTMLElement) => Array.from(el.childNodes).some((n) => n.nodeType === Node.TEXT_NODE && (n.textContent || '').trim());
+          const parse = (value: string): Rgba | null => {
+            const ctx = document.createElement('canvas').getContext('2d');
+            if (!ctx) return null;
+            ctx.fillStyle = '#000';
+            ctx.fillStyle = value;
+            const normalized = ctx.fillStyle;
+            const hex = normalized.match(/^#([\da-f]{6}|[\da-f]{8})$/i)?.[1];
+            if (hex) {
+              const v = Number.parseInt(hex, 16);
+              return hex.length === 8 ? { r: v >> 24 & 255, g: v >> 16 & 255, b: v >> 8 & 255, a: (v & 255) / 255 } : { r: v >> 16 & 255, g: v >> 8 & 255, b: v & 255, a: 1 };
+            }
+            const rgba = normalized.match(/^rgba?\(([^)]+)\)$/i)?.[1];
+            if (!rgba) return null;
+            const p = rgba.split(',').map((part) => Number.parseFloat(part.trim()));
+            return { r: p[0], g: p[1], b: p[2], a: p[3] ?? 1 };
+          };
+          const over = (top: Rgba, bottom: Rgba): Rgba => {
+            const a = top.a + bottom.a * (1 - top.a);
+            return a ? { r: (top.r * top.a + bottom.r * bottom.a * (1 - top.a)) / a, g: (top.g * top.a + bottom.g * bottom.a * (1 - top.a)) / a, b: (top.b * top.a + bottom.b * bottom.a * (1 - top.a)) / a, a } : { r: 0, g: 0, b: 0, a: 0 };
+          };
+          const bgFor = (el: HTMLElement): Rgba => {
+            let bg: Rgba = { r: 0, g: 0, b: 0, a: 0 };
+            for (let n: HTMLElement | null = el; n; n = n.parentElement) {
+              const c = parse(getComputedStyle(n).backgroundColor);
+              if (!c || c.a === 0) continue;
+              bg = over(bg, c);
+              if (bg.a >= 1) break;
+            }
+            return bg.a ? bg : { r: 255, g: 255, b: 255, a: 1 };
+          };
+          const lum = (c: Rgba) => {
+            const ch = (v: number) => { const s = v / 255; return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4; };
+            return 0.2126 * ch(c.r) + 0.7152 * ch(c.g) + 0.0722 * ch(c.b);
+          };
+          const ratio = (a: Rgba, b: Rgba) => { const [hi, lo] = [lum(a), lum(b)].sort((x, y) => y - x); return (hi + 0.05) / (lo + 0.05); };
+          const rgbaText = (c: Rgba) => `rgba(${Math.round(c.r)}, ${Math.round(c.g)}, ${Math.round(c.b)}, ${Math.round(c.a * 100) / 100})`;
+          const failures: Failure[] = [];
+          const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT);
+          for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+            const el = node as HTMLElement;
+            const style = getComputedStyle(el);
+            if (style.visibility === 'hidden' || style.display === 'none' || Number(style.opacity) === 0 || el.getClientRects().length === 0) continue;
+            if (!text(el) || !direct(el)) continue;
+            const fg = parse(style.color);
+            const bg = bgFor(el);
+            if (!fg) continue;
+            const value = ratio(over(fg, bg), bg);
+            if (value < 4.5) failures.push({ path, theme, text: text(el).slice(0, 80), ratio: Math.round(value * 100) / 100, color: style.color, background: rgbaText(bg) });
+          }
+          return failures;
+        }, { path, theme });
+        expect(formatFailures(failures)).toEqual('');
+      });
+    }
+  }
+});
+
+async function setTheme(page: Page, theme: 'light' | 'dark') {
+  await page.addInitScript((mode) => {
+    localStorage.setItem('ARRA_FRONTEND_THEME', mode);
+    document.documentElement.classList.toggle('dark', mode === 'dark');
+    document.documentElement.classList.toggle('light', mode === 'light');
+  }, theme);
+}
+
+function formatFailures(failures: Failure[]): string {
+  return failures.map((f) => `${f.theme} ${f.path} ${f.ratio}:1 ${JSON.stringify(f.text)} ${f.color} on ${f.background}`).join('\n');
+}
+
+function slug(path: string): string {
+  return path.replace(/^\//, '').replace(/[^a-z0-9]+/gi, '-') || 'home';
+}


### PR DESCRIPTION
## Summary
- Add real Playwright dependency in `frontend` and update the root Playwright config to run both backend `127.0.0.1:47778` and frontend dev `127.0.0.1:3000`.
- Add `tests/e2e/contrast.spec.ts` to navigate Menu/Plugins/Status/Vector/Export/Search/MCP/Settings in both light and dark themes.
- The harness parses computed colors through canvas, composites effective backgrounds, asserts WCAG AA text contrast >= 4.5:1, and captures a full-page screenshot for each page/theme under `test-results/contrast/`.

## Validation
```bash
cd frontend && rtk bun add -d @playwright/test && rtk bunx playwright install chromium
rtk bunx tsc --noEmit
cd frontend && rtk bunx tsc --noEmit
rtk bunx playwright test tests/e2e/contrast.spec.ts --reporter=list --workers=1
```

Result: `16 passed (8.1s)`.

## Screenshots
- Generated locally: `test-results/contrast/*.png` (16 files: 8 pages × light/dark).

## File Size Check
```bash
wc -l tests/e2e/contrast.spec.ts playwright.config.ts frontend/package.json
```
All changed files are <=250 lines.

## Notes
- PR targets `alpha`.
- This PR only adds the harness; no `frontend/src/styles.css` changes, to avoid conflicting with c8.
