### PR TITLE
test(frontend): harden page and e2e coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ vault-data.json
 
 services/**/__pycache__/
 services/**/*.pyc
+sidecar/**/__pycache__/
+sidecar/**/*.pyc
 
 # Codex agent worktrees (git worktree, registered in .git/worktrees — not tracked)
 agents/

--- a/bun.lock
+++ b/bun.lock
@@ -44,6 +44,7 @@
         "vite": "^7.3.0",
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.0",
         "@tauri-apps/api": "^2.11.0",
         "@tauri-apps/cli": "^2.11.2",
         "@types/react": "^19.2.7",

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260616.1",
+        "@playwright/test": "1.61.0",
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20.17.9",
         "better-sqlite3": "^12.9.0",
@@ -321,6 +322,8 @@
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.135.0", "", {}, "sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q=="],
+
+    "@playwright/test": ["@playwright/test@1.61.0", "", { "dependencies": { "playwright": "1.61.0" }, "bin": { "playwright": "cli.js" } }, "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA=="],
 
     "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
 
@@ -896,6 +899,10 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
+    "playwright": ["playwright@1.61.0", "", { "dependencies": { "playwright-core": "1.61.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ=="],
+
+    "playwright-core": ["playwright-core@1.61.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA=="],
+
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
@@ -1151,6 +1158,8 @@
     "miniflare/undici": ["undici@7.24.8", "", {}, "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ=="],
 
     "node-abi/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -1,0 +1,230 @@
+# Arra Oracle CLI and usage guide
+
+Use this guide when installing Arra Oracle from GitHub, wiring Claude MCP,
+running local surfaces, or choosing between CLI, MCP, HTTP, and Workers deploys.
+For architecture details, start from [architecture.md](./architecture.md).
+
+## 1. Install
+
+Use a pinned release tag for repeatable operator installs; use `#alpha` only for
+moving trunk testing.
+
+```bash
+bun add -g github:Soul-Brews-Studio/arra-oracle-v3#vX.Y.Z-alpha.N
+# development/head install:
+bun add -g github:Soul-Brews-Studio/arra-oracle-v3#alpha
+
+arra-oracle-v3 --help
+arra --version
+```
+
+The package bin is `arra-oracle-v3` for the HTTP/MCP server wrapper and `arra`
+for the operator CLI. Some older examples say `arra-oracle`; substitute
+`arra-oracle-v3` unless your shell has that alias.
+
+Source checkout for development:
+
+```bash
+git clone https://github.com/Soul-Brews-Studio/arra-oracle-v3.git
+cd arra-oracle-v3
+bun install
+bunx tsc --noEmit
+```
+
+## 2. Three local surfaces
+
+```bash
+# HTTP API + Swagger, default http://localhost:47778
+export ORACLE_DATA_DIR="$HOME/.oracle"
+bun run server
+# or, after global install: arra-oracle-v3 serve --port 47778
+
+# Stdio MCP server for Claude/agents
+arra-oracle-v3 mcp
+arra-oracle-v3 mcp --read-only
+# source equivalent: bun bin/arra.ts mcp [--read-only]
+
+# React Studio frontend; proxies /api/* to the Bun backend
+cd frontend
+bun install
+bun run dev
+```
+
+Common operator CLI calls:
+
+```bash
+arra config add local http://localhost:47778
+arra config use local
+arra health
+arra search "confidence ranking" --limit 5
+arra learn "New project fact" --source cli-guide
+arra vector-config list --json
+arra export --url http://localhost:47778 --collection oracle_documents \
+  --format markdown --output oracle.md
+```
+
+## 3. Claude MCP add
+
+From a source checkout, point Claude at the launcher that resolves `src/index.ts`
+from the repo root:
+
+```bash
+claude mcp add arra-oracle --cwd "$PWD" -- bun bin/mcp.ts
+claude mcp add arra-oracle-ro --cwd "$PWD" -- bun bin/mcp.ts --read-only
+claude mcp list
+```
+
+From a global install:
+
+```bash
+claude mcp add arra-oracle -- arra-oracle-v3 mcp
+claude mcp add arra-oracle-ro -- arra-oracle-v3 mcp --read-only
+```
+
+For stdio safety, set `ORACLE_LOG_TARGET=stderr` if your client supports MCP env
+configuration. For proxy mode, set `ORACLE_HTTP_URL=http://localhost:47778` so
+MCP calls reuse an already running HTTP backend.
+
+## 4. MCP tools: 27 advertised tools
+
+`bin/arra.ts mcp` loads `src/index.ts`, which registers the manifest in
+`src/tools/mcp-manifest.ts`. In Claude or MCP Inspector, `tools/list` should
+show 27 core tools before plugin tools.
+
+### Search and read
+
+| Tool | Mode | Use |
+| --- | --- | --- |
+| `____IMPORTANT` | read | Workflow guide shown in tool lists. |
+| `oracle_search` | read | Hybrid FTS/vector search over memories. |
+| `oracle_read` | read | Read one document by id/path. |
+| `oracle_list` | read | Browse documents with filters. |
+| `oracle_stats` | read | Knowledge-base and vector health stats. |
+| `oracle_concepts` | read | List concept tags with counts. |
+| `oracle_profile` | read | Read code-backed Oracle profiles. |
+| `oracle_reflect` | read | Return a random principle/learning. |
+| `oracle_inbox` | read | Preview handoff files. |
+
+### Write, verify, and bridge
+
+| Tool | Mode | Use |
+| --- | --- | --- |
+| `oracle_learn` | write | Add a learning and index it. |
+| `oracle_supersede` | write | Mark an older doc superseded, never deleted. |
+| `oracle_research_note` | write | Store a Thor/Stormforge research note. |
+| `oracle_handoff` | write | Write a session handoff to `ψ/inbox`. |
+| `oracle_verify` | write | Verify disk-vs-DB integrity; can mark orphans when not in check mode. |
+| `oracle_mcp_list_tools` | read | List tools from another stdio MCP server. |
+| `oracle_mcp_call` | write | Call one external MCP tool. |
+
+### Threads
+
+| Tool | Mode | Use |
+| --- | --- | --- |
+| `oracle_thread` | write | Create or continue an Oracle discussion thread. |
+| `oracle_threads` | read | List threads by status. |
+| `oracle_thread_read` | read | Read a thread history. |
+| `oracle_thread_update` | write | Close, reopen, or mark a thread. |
+
+### Traces and dig chains
+
+| Tool | Mode | Use |
+| --- | --- | --- |
+| `oracle_trace` | write | Log a trace session and findings. |
+| `oracle_trace_list` | read | List trace summaries. |
+| `oracle_trace_get` | read | Read full trace details. |
+| `oracle_trace_link` | write | Link traces into a chain. |
+| `oracle_trace_unlink` | write | Remove one trace-chain link. |
+| `oracle_trace_chain` | read | Read a linked trace chain. |
+| `oracle_trace_distill` | write | Distill a trace into memory. |
+
+`--read-only` or `ORACLE_READ_ONLY=true` hides write tools for safer browsing.
+
+## 5. HTTP API quick calls
+
+Canonical API paths are `/api/v1/*`; legacy `/api/*` paths usually redirect.
+Infrastructure endpoints `/api/health` and `/api/docs` stay unversioned.
+
+```bash
+curl -sf http://localhost:47778/api/health
+curl -s 'http://localhost:47778/api/v1/search?q=oracle&limit=5'
+curl -s 'http://localhost:47778/api/v1/vector/export?collection=bge-m3&format=jsonl'
+curl -s -X POST http://localhost:47778/api/ask \
+  -H 'content-type: application/json' \
+  -d '{"q":"What changed in the memory pipeline?","limit":5}'
+open http://localhost:47778/api/docs
+```
+
+When `ARRA_API_TOKEN` is set, protected `/api/*` calls need
+`Authorization: Bearer <token>`.
+
+## 6. Useful scripts
+
+| Script | Purpose |
+| --- | --- |
+| `bun run server` | Start the Elysia HTTP API. |
+| `bun run vector` | Start read-only vector server. |
+| `bun run vector:proxy` | Start vector proxy mode with `ORACLE_VECTOR_DB=lancedb`. |
+| `bun run index` | Run the indexer CLI. |
+| `bun run db:push` | Push Drizzle schema changes. |
+| `bunx tsc --noEmit` | Required build/type gate. |
+| `bun test tests/docs` | Scoped docs contract tests. |
+
+## 7. Deploy Workers: MCP, Studio, federation
+
+Production shape: keep the Bun backend and data on a trusted origin, then deploy
+thin Cloudflare Workers for remote MCP, Studio, and federation relay.
+
+```bash
+# prove configs before deploy
+bun run cloudflare:mcp:dry-run
+bun run cloudflare:studio:dry-run
+bun run cloudflare:federation:dry-run
+
+# deploy when secrets are set
+bun run cloudflare:mcp:deploy
+bun run cloudflare:studio:deploy
+bun run cloudflare:federation:deploy
+```
+
+Set `ORACLE_ORIGIN_URL` and `ARRA_API_TOKEN` as Worker secrets for MCP/Studio.
+Set `TUNNEL_URL` and `FEDERATION_TOKEN` for federation. See
+[deploy-production.md](./deploy-production.md),
+[deploy-cloudflare-mcp.md](./deploy-cloudflare-mcp.md), and
+[workers-deploy-configs.md](./workers-deploy-configs.md).
+
+## 8. Environment variables
+
+| Variable | Surface | Purpose |
+| --- | --- | --- |
+| `ORACLE_DATA_DIR` | all | Shared data root; set explicitly so CLI, HTTP, and MCP see the same DB. |
+| `ORACLE_DB_PATH` | local | Override SQLite DB path. |
+| `ORACLE_REPO_ROOT` | MCP/CLI | Force repo root discovery. |
+| `ORACLE_PORT` / `PORT` | HTTP | API port; default `47778`. |
+| `ORACLE_API` | CLI | Operator CLI target base URL. |
+| `ORACLE_HTTP_URL` | MCP | Proxy stdio MCP calls to an HTTP backend. |
+| `ORACLE_LOG_TARGET` | MCP | Use `stderr` to keep stdout valid JSON-RPC. |
+| `ORACLE_READ_ONLY` | MCP | Disable write tools when `true`. |
+| `ARRA_API_TOKEN` | HTTP/Workers | Bearer token for protected API calls. |
+| `ORACLE_TENANT_TOKENS` | HTTP | Tenant token map for shared deployments. |
+| `VECTOR_URL` | HTTP | Remote vector server/proxy base URL. |
+| `ORACLE_VECTOR_DB` | vector | Select vector adapter such as `lancedb`, `qdrant`, `proxy`. |
+| `QDRANT_URL` / `QDRANT_API_KEY` | vector | Qdrant backend config. |
+| `ORACLE_EMBEDDER` | embeddings | `none`, `ollama`, `openai`, `gemini`, `cloudflare-ai`, etc. |
+| `ORACLE_EMBEDDING_MODEL` | embeddings | Active embedding model, default commonly `bge-m3`. |
+| `OPENAI_API_KEY`, `GEMINI_API_KEY`, `OLLAMA_BASE_URL` | embeddings | Provider credentials/endpoints. |
+| `ORACLE_ORIGIN_URL` / `ORACLE_URL` | Workers | Backend origin for MCP and Studio Workers. |
+| `ORACLE_MCP_URL` | Studio Worker | Split remote MCP URL for Studio `/mcp/*`. |
+| `TUNNEL_URL`, `FEDERATION_TOKEN` | federation | Signed federation relay origin and HMAC secret. |
+| `ARRA_CORS_ORIGINS` | HTTP | Allowed browser origins. |
+
+## 9. Traps and fixes
+
+- **MCP JSON parse errors:** logs went to stdout. Use `ORACLE_LOG_TARGET=stderr`.
+- **CLI cannot reach server:** start `bun run server` or set `ORACLE_API` / `arra --at`.
+- **MCP proxy fails:** `ORACLE_HTTP_URL` must point at a healthy backend; match `ARRA_API_TOKEN`.
+- **Different data per surface:** set the same `ORACLE_DATA_DIR` for HTTP, MCP, CLI, and Docker.
+- **Versioned route surprise:** use `/api/v1/*` except `/api/health` and `/api/docs`.
+- **Workers cannot open SQLite/LanceDB:** Workers are edge proxies; keep DB/vector files on the origin.
+- **Vector unavailable:** FTS search still works; configure vector later with `arra vector-config`.
+- **Secrets in git:** never commit real tokens, origin URLs, or Cloudflare credentials.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ is linked here; keep new docs in the right section when adding files.
 ## Navigate by task
 
 - **Deploy**: start with [architecture/deploy-topologies.md](./architecture/deploy-topologies.md), then pick [deploy-production.md](./deploy-production.md), [deploy-cloudflare.md](./deploy-cloudflare.md), [deploy-cloudflare-mcp.md](./deploy-cloudflare-mcp.md), [deploy-vercel.md](./deploy-vercel.md), or [DEPLOY-DIGITALOCEAN.md](./DEPLOY-DIGITALOCEAN.md).
-- **Architecture**: read [architecture.md](./architecture.md), [architecture/modular-backend.md](./architecture/modular-backend.md), and [architecture/modular-backend-current-state.md](./architecture/modular-backend-current-state.md).
+- **Architecture**: read [architecture.md](./architecture.md), [architecture/modular-backend.md](./architecture/modular-backend.md), [architecture/https-localhost-vector-flow.md](./architecture/https-localhost-vector-flow.md), and [architecture/modular-backend-current-state.md](./architecture/modular-backend-current-state.md).
 - **Memory/search**: read [architecture/memory-layer.md](./architecture/memory-layer.md), [architecture/memory-pipeline.md](./architecture/memory-pipeline.md), [HUGINN-MUNINN.md](./HUGINN-MUNINN.md), and [vector-runtime.md](./vector-runtime.md).
 - **MCP**: read [mcp-tools.md](./mcp-tools.md), [architecture/mcp-remote-transport.md](./architecture/mcp-remote-transport.md), [MCP-FROM-OPENAPI.md](./MCP-FROM-OPENAPI.md), and [deploy-cloudflare-mcp.md](./deploy-cloudflare-mcp.md).
 
@@ -24,6 +24,7 @@ is linked here; keep new docs in the right section when adding files.
 | [architecture/modular-backend-current-state.md](./architecture/modular-backend-current-state.md) | Current modular-backend extraction status and boundaries | backend split, current state |
 | [architecture/mcp-remote-transport.md](./architecture/mcp-remote-transport.md) | Remote MCP Worker transport and `mcp-remote` client bridge contract | Workers, MCP bridge, OAuth |
 | [architecture/deploy-topologies.md](./architecture/deploy-topologies.md) | Choose all-local, Cloudflare edge, Vercel, or federation tunnel deployment. | deploy options, edge/backend/vector split |
+| [architecture/https-localhost-vector-flow.md](./architecture/https-localhost-vector-flow.md) | Sequence diagram for hosted HTTPS Studio calling a localhost Oracle backend and local vector flow. | #2312, localhost, PNA, vector |
 | [architecture/memory-layer.md](./architecture/memory-layer.md) | Memory confidence ranking, retrieval reinforcement, supersede, and consolidation contracts from #2251. | memory, confidence, supersede, consolidation |
 | [architecture/memory-pipeline.md](./architecture/memory-pipeline.md) | Diagram the write, FTS, async consolidation, confidence ranking, and bi-temporal read pipeline. | memory pipeline, FTS, asOf, ranking |
 | [architecture/cloudflared-origin-contract.md](./architecture/cloudflared-origin-contract.md) | `ORACLE_ORIGIN_URL` secret and Cloudflare Tunnel origin contract for Workers. | Cloudflare Tunnel, origin URL, Workers secrets |

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ is linked here; keep new docs in the right section when adding files.
 | [deploy-cloudflare.md](./deploy-cloudflare.md) | Cloudflare deployment guide for Oracle surfaces. |
 | [deploy-cloudflare-mcp.md](./deploy-cloudflare-mcp.md) | One-click Cloudflare Workers remote MCP deploy and Claude `/mcp` setup. |
 | [deploy-production.md](./deploy-production.md) | Production Cloudflare Workers deploy with cloudflared origin, secrets, Studio, MCP, and federation. |
+| [hosted-studio-local-backend.md](./hosted-studio-local-backend.md) | Hosted Studio direct-to-local backend connection and CORS/PNA checklist. |
 | [workers-deploy-configs.md](./workers-deploy-configs.md) | Validate Cloudflare MCP, Studio, and federation Worker configs and env vars. |
 | [deploy-vercel.md](./deploy-vercel.md) | One-click Vercel deploy for the Oracle Studio frontend and `/api/*` proxy. |
 | [DOCKER-MCP-TOOLKIT.md](./DOCKER-MCP-TOOLKIT.md) | Docker MCP Toolkit package and profile setup. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ is linked here; keep new docs in the right section when adding files.
 | Guide | Use when you need | Key surfaces |
 | --- | --- | --- |
 | [INSTALL.md](./INSTALL.md) | Install from Bun, plugins, Docker, or Docker MCP Toolkit | `bun add -g`, `arra plugin install`, GHCR |
+| [CLI-GUIDE.md](./CLI-GUIDE.md) | Full CLI, MCP, HTTP, scripts, deploy, and env usage guide | `arra`, `arra-oracle-v3`, Claude MCP |
 | [QUICKSTART.md](./QUICKSTART.md) | Complete a five-minute first run | `arra-oracle-v3 serve`, `arra health`, MCP config |
 | [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) | Diagnose install, MCP, HTTP, vector, plugin, and Docker issues | health checks, auth, tenants, logs |
 | [FAQ.md](./FAQ.md) | Answer common operator and contributor questions | install path, binaries, data, vectors, tenants |
@@ -37,6 +38,7 @@ is linked here; keep new docs in the right section when adding files.
 | Guide | Focus |
 | --- | --- |
 | [BINS.md](./BINS.md) | Published command binaries and aliases. |
+| [CLI-GUIDE.md](./CLI-GUIDE.md) | Full CLI and usage guide across local, MCP, HTTP, scripts, Workers, and env vars. |
 | [DEPLOY-DIGITALOCEAN.md](./DEPLOY-DIGITALOCEAN.md) | Small public Arra HTTP node on DigitalOcean. |
 | [deploy-cloudflare.md](./deploy-cloudflare.md) | Cloudflare deployment guide for Oracle surfaces. |
 | [deploy-cloudflare-mcp.md](./deploy-cloudflare-mcp.md) | One-click Cloudflare Workers remote MCP deploy and Claude `/mcp` setup. |

--- a/docs/architecture/https-localhost-vector-flow.md
+++ b/docs/architecture/https-localhost-vector-flow.md
@@ -1,0 +1,122 @@
+# HTTPS Studio to localhost backend to vector flow (#2312)
+
+Issue #2312 adds a personal-use path where hosted HTTPS Studio assets talk
+directly to the operator's local Oracle backend. The Cloudflare Worker serves the
+static Studio shell, but the browser sends API calls to `http://localhost:47778`
+instead of proxying through the Worker or a cloudflared tunnel.
+
+## When to use this pattern
+
+Use this for a single operator who wants a public HTTPS Studio URL while keeping
+all memory, plugins, and vectors local. Do not use it for shared/team access,
+mobile clients, or remote machines that cannot reach the operator's loopback
+interface.
+
+```text
+Hosted Studio URL: https://god.buildwithoracle.com/?host=localhost:47778
+Backend URL:       http://localhost:47778
+Vector sidecar:    http://localhost:<vector-port> or backend-selected adapter
+```
+
+## Sequence diagram
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor User
+  participant Browser as Browser running hosted Studio
+  participant Studio as HTTPS Studio Worker
+  participant Backend as localhost:47778 maw arra backend
+  participant Vector as local vector server / adapter
+  participant DB as local SQLite + FTS
+
+  User->>Browser: Open https://god.buildwithoracle.com/?host=localhost:47778
+  Browser->>Studio: GET /?host=localhost:47778
+  Studio-->>Browser: Static Studio assets
+  Browser->>Browser: Resolve host from ?host → localStorage → localhost:47778
+  Browser->>Backend: OPTIONS /api/search<br/>Origin: https://god.buildwithoracle.com<br/>Access-Control-Request-Private-Network: true
+  Backend-->>Browser: CORS + PNA allow headers
+  Browser->>Backend: POST /api/search<br/>targetAddressSpace: "local"
+  Backend->>Backend: Auth, tenant, route, plugin middleware
+  Backend->>DB: FTS/document metadata lookup
+  alt hybrid or vector mode
+    Backend->>Vector: POST /vectors/query with tenant context
+    Vector-->>Backend: vector matches + scores
+  end
+  Backend->>Backend: Merge, confidence/rerank, supersede filtering
+  Backend-->>Browser: JSON search response
+  Browser-->>User: Render results without sending data through edge proxy
+```
+
+## Browser-side contract
+
+The frontend API client owns host resolution and persistence:
+
+1. Read `?host=` on first load.
+2. Persist the host in `localStorage` under the Oracle Studio key.
+3. Redirect to a clean URL without the query parameter.
+4. Default to `localhost:47778` when no value exists.
+5. Build API URLs as `http://<host>/api/*` for local direct mode.
+6. Add Private Network Access metadata such as `targetAddressSpace: 'local'` on
+   fetches where the browser supports it.
+7. Show a "Connect to your Oracle" setup gate when health checks fail.
+
+Keep `/api/*` same-origin proxy mode available for production Cloudflare/Vercel
+setups that use `ORACLE_ORIGIN_URL` or `ORACLE_URL` instead.
+
+## Backend contract
+
+The local backend must accept the hosted Studio origin without weakening the rest
+of the API boundary:
+
+- `maw arra serve --port 47778` answers `GET /api/health` locally.
+- CORS allows the hosted Studio origin and requested auth/tenant headers.
+- Private Network Access preflight returns
+  `Access-Control-Allow-Private-Network: true` for approved origins.
+- API token auth still applies when `ARRA_API_TOKEN` is configured.
+- Tenant headers remain explicit; browser-provided tenant IDs are not trusted as
+  authorization by themselves.
+
+## Vector flow
+
+Vector search stays behind the backend. The browser never calls LanceDB, Qdrant,
+TurboVec, or embedding providers directly.
+
+```text
+Browser -> http://localhost:47778/api/search
+Backend -> local DB / FTS
+Backend -> vector server or selected vector adapter
+Backend -> confidence/rerank/supersede response
+```
+
+If a separate vector sidecar is running, the backend should use the existing
+vector proxy config, for example `ORACLE_PROXY_VECTOR_URL`. If no vector sidecar
+is available, the backend keeps FTS fallback behavior and the UI should surface
+that degraded mode rather than routing around the backend.
+
+## Security boundaries
+
+- The Worker serves assets only in this pattern; it cannot read local documents.
+- The browser talks to the operator's own loopback backend.
+- The local backend is still responsible for auth, tenant scoping, CORS, PNA,
+  plugin permissions, and vector fallback.
+- Use cloudflared + `ORACLE_ORIGIN_URL` instead when other people or devices need
+  to reach the same backend.
+
+## Failure states
+
+| Symptom | Expected UI / operator action |
+| --- | --- |
+| `GET /api/health` fails | Show BackendGate with start command and host picker. |
+| PNA preflight rejected | Explain that the backend must allow the hosted origin and PNA header. |
+| Browser lacks local-network support | Offer cloudflared production deploy as fallback. |
+| Vector sidecar down | Keep FTS search available and show vector degraded status. |
+| Token mismatch | Prompt for the backend token without changing the saved host. |
+
+## References
+
+- [#2312 direct HTTPS Studio to localhost pattern](https://github.com/Soul-Brews-Studio/arra-oracle-v3/issues/2312)
+- [Cloudflared origin contract](./cloudflared-origin-contract.md)
+- [Deploy topologies](./deploy-topologies.md)
+- [MDN secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Secure_Contexts)
+- [Chrome local network access](https://developer.chrome.com/blog/local-network-access)

--- a/docs/hosted-studio-local-backend.md
+++ b/docs/hosted-studio-local-backend.md
@@ -1,0 +1,60 @@
+# Hosted Studio local backend connection
+
+Hosted Oracle Studio can talk directly to a user's local backend, matching the
+Drizzle Studio pattern:
+
+```text
+https://god.buildwithoracle.com/?host=localhost:47778
+```
+
+The frontend host resolver owns `?host=` persistence. `BackendGate` is the
+support screen around that resolver: it hides the dashboard while `/api/health`
+is unreachable and shows a "Connect to your Oracle" form that reloads Studio
+with a `host` query parameter.
+
+## User flow
+
+1. Start the local backend:
+
+   ```bash
+   arra-oracle-v3 serve
+   ```
+
+2. Open hosted Studio with an optional host override:
+
+   ```text
+   https://god.buildwithoracle.com/?host=localhost:47778
+   ```
+
+3. If the backend is not reachable, use the setup form to enter a local host
+   such as `localhost:47778` or `127.0.0.1:47778`.
+
+## Backend CORS and PNA
+
+The Bun backend default CORS policy allows:
+
+- `http://localhost:3000`
+- `http://127.0.0.1:3000`
+- `http://localhost:4321`
+- `http://127.0.0.1:4321`
+- `https://god.buildwithoracle.com`
+
+Chrome Private Network Access preflights are handled by the existing
+private-network middleware. For hosted Studio to local backend requests, the
+preflight must include:
+
+```http
+Origin: https://god.buildwithoracle.com
+Access-Control-Request-Private-Network: true
+```
+
+The backend responds with:
+
+```http
+Access-Control-Allow-Origin: https://god.buildwithoracle.com
+Access-Control-Allow-Private-Network: true
+```
+
+Operators can still override defaults with `ARRA_CORS_ORIGINS`,
+`ORACLE_CORS_ORIGIN`, or `CORS_ORIGIN`; include the hosted Studio origin when
+using custom values.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "vite": "^7.3.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.0",
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/cli": "^2.11.2",
     "@types/react": "^19.2.7",

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,7 +1,7 @@
-import { apiUrl } from './api/oracle';
+import { apiFetch } from './api/oracle';
 import type { McpToolsResponse, MenuResponse, PluginsResponse, SearchResponse, SettingsSystemResponse, VectorConfigResponse, VectorConfigUpdateResponse } from './types';
 
-export { API_BASE, apiUrl, isTauri } from './api/oracle';
+export { API_BASE, apiFetch, apiUrl, isTauri, withLocalPna } from './api/oracle';
 
 export class ApiError extends Error {
   constructor(readonly status: number, message: string) {
@@ -15,7 +15,7 @@ async function getJson<T>(path: string, init?: RequestInit): Promise<T> {
   if (init?.body && !headers.has('content-type')) headers.set('content-type', 'application/json');
   let response: Response;
   try {
-    response = await fetch(apiUrl(path), { ...init, headers });
+    response = await apiFetch(path, { ...init, headers });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     throw new ApiError(0, `${path} is unreachable: ${message}`);

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -7,7 +7,7 @@ import type {
   VectorSearchResponse,
 } from '../../../src/server/types';
 import type { LearnCreateResponse, LearnDeleteResponse, LearnListResponse, LearnMutationPayload, LearnUpdateResponse } from '../types';
-import { API_BASE } from './oracle';
+import { API_BASE, apiFetch } from './oracle';
 
 export interface MenuSearchResponse {
   data: MenuItem[];
@@ -219,8 +219,7 @@ export class ApiClient {
   }
 
   private async fetchJson<T>(path: string, init: RequestInit = {}): Promise<T> {
-    const fetcher = this.options.fetch ?? globalThis.fetch?.bind(globalThis);
-    if (!fetcher) throw new ApiClientError(0, path, `${path} is unreachable: fetch is unavailable`);
+    const fetcher = this.options.fetch ?? apiFetch;
 
     const headers = withJsonHeaders(this.options.headers, init);
     let response: Response;

--- a/frontend/src/api/oracle.ts
+++ b/frontend/src/api/oracle.ts
@@ -1,11 +1,76 @@
 export const TAURI_API_BASE = 'http://localhost:47778';
-export const API_BASE = isTauri() ? TAURI_API_BASE : '';
+export const DEFAULT_API_HOST = 'localhost:47778';
+export const API_HOST_STORAGE_KEY = 'oracle.host';
 
 declare global {
   interface Window {
     __TAURI__?: unknown;
   }
 }
+
+type PrivateNetworkRequestInit = RequestInit & { targetAddressSpace?: 'local' };
+
+function browserWindow(): Window | undefined {
+  return typeof window === 'undefined' ? undefined : window;
+}
+
+function storage(): Storage | null {
+  try {
+    return browserWindow()?.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeApiHost(value: string | null | undefined): string {
+  const raw = value?.trim();
+  if (!raw) return DEFAULT_API_HOST;
+  const withProtocol = /^https?:\/\//i.test(raw) ? raw : `http://${raw}`;
+  try {
+    return new URL(withProtocol).host || DEFAULT_API_HOST;
+  } catch {
+    return raw.replace(/^https?:\/\//i, '').replace(/^\/+/, '').split('/')[0] || DEFAULT_API_HOST;
+  }
+}
+
+function cleanHostParam(url: URL): void {
+  if (!url.searchParams.has('host')) return;
+  url.searchParams.delete('host');
+  const clean = `${url.pathname}${url.search}${url.hash}`;
+  browserWindow()?.history.replaceState({}, '', clean || '/');
+}
+
+function resolveBrowserApiHost(): string {
+  const win = browserWindow();
+  if (!win) return DEFAULT_API_HOST;
+  const url = new URL(win.location.href);
+  const queryHost = url.searchParams.get('host');
+  const host = normalizeApiHost(queryHost || storage()?.getItem(API_HOST_STORAGE_KEY));
+  if (queryHost) {
+    storage()?.setItem(API_HOST_STORAGE_KEY, host);
+    cleanHostParam(url);
+  }
+  return host;
+}
+
+function isLocalAddress(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  return host === 'localhost' || host === '127.0.0.1' || host === '::1' || host.endsWith('.localhost');
+}
+
+export function isTauri(): boolean {
+  return typeof window !== 'undefined' && '__TAURI__' in window;
+}
+
+export const API_HOST = isTauri() ? 'localhost:47778' : resolveBrowserApiHost();
+export const API_BASE = isTauri() ? TAURI_API_BASE : `http://${API_HOST}`;
+export const USE_LOCAL_PNA = (() => {
+  try {
+    return !isTauri() && isLocalAddress(new URL(API_BASE).hostname);
+  } catch {
+    return false;
+  }
+})();
 
 export type VectorProvider = {
   type: string;
@@ -48,16 +113,39 @@ export type VectorHealthStatus = {
   error?: string;
 };
 
-export function isTauri(): boolean {
-  return typeof window !== 'undefined' && '__TAURI__' in window;
+export function hasStoredApiHost(): boolean {
+  return Boolean(storage()?.getItem(API_HOST_STORAGE_KEY));
+}
+
+export function persistApiHost(host: string): string {
+  const normalized = normalizeApiHost(host);
+  storage()?.setItem(API_HOST_STORAGE_KEY, normalized);
+  return normalized;
+}
+
+export function connectToApiHost(host: string): void {
+  const normalized = persistApiHost(host);
+  const url = new URL(browserWindow()?.location.href ?? 'http://localhost/');
+  url.searchParams.delete('host');
+  url.searchParams.set('host', normalized);
+  browserWindow()?.location.assign(`${url.pathname}${url.search}${url.hash}`);
 }
 
 export function apiUrl(path: string): string {
   return API_BASE ? new URL(path, API_BASE).toString() : path;
 }
 
+export function withLocalPna(init: RequestInit = {}): RequestInit {
+  if (!USE_LOCAL_PNA) return init;
+  return { ...init, targetAddressSpace: 'local' } as PrivateNetworkRequestInit;
+}
+
+export function apiFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  return fetch(apiUrl(path), withLocalPna(init));
+}
+
 async function fetchJson<T>(path: string, init: RequestInit = {}): Promise<T> {
-  const response = await fetch(apiUrl(path), {
+  const response = await apiFetch(path, {
     ...init,
     headers: { accept: 'application/json', 'content-type': 'application/json', ...(init.headers ?? {}) },
   });

--- a/frontend/src/api/plugin-admin.ts
+++ b/frontend/src/api/plugin-admin.ts
@@ -1,4 +1,4 @@
-import { apiUrl } from './oracle';
+import { apiFetch } from './oracle';
 
 export interface PluginStateResponse {
   ok: boolean;
@@ -18,7 +18,7 @@ function errorMessage(payload: unknown, fallback: string): string {
 
 export async function setPluginEnabled(name: string, enabled: boolean): Promise<PluginStateResponse> {
   const path = `/api/plugins/${encodeURIComponent(name)}/state`;
-  const response = await fetch(apiUrl(path), {
+  const response = await apiFetch(path, {
     method: 'PATCH',
     headers: { accept: 'application/json', 'content-type': 'application/json' },
     body: JSON.stringify({ enabled }),

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -77,7 +77,7 @@ export function AppShell({
   const retry = (
     <button
       aria-label="Retry loading backend dashboard data"
-      className="focus-ring rounded-lg border border-red-200/30 px-3 py-2 font-semibold text-red-50 hover:bg-red-200/10"
+      className="focus-ring rounded-lg border border-[color:var(--color-err-text,#991b1b)] px-3 py-2 font-semibold text-[color:var(--color-err-text,#991b1b)] hover:bg-[var(--color-err-bg,#fee2e2)]"
       type="button"
       onClick={onRefresh}
     >

--- a/frontend/src/components/BackendGate.tsx
+++ b/frontend/src/components/BackendGate.tsx
@@ -1,9 +1,19 @@
 import { invoke } from "@tauri-apps/api/core";
-import { API_BASE, API_HOST, apiFetch, connectToApiHost, hasStoredApiHost } from "../api/oracle";
+import {
+  API_BASE,
+  API_HOST,
+  API_HOST_STORAGE_KEY,
+  apiFetch,
+  apiUrl,
+  connectToApiHost,
+  hasStoredApiHost,
+} from "../api/oracle";
 import { SetupWizard } from "./SetupWizard";
-import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useState, type FormEvent, type ReactNode } from "react";
 
-type GateState = "checking" | "ready" | "unreachable";
+export type GateState = "checking" | "ready" | "unreachable";
+export const DEFAULT_ORACLE_HOST = "localhost:47778";
+export const ORACLE_HOST_STORAGE_KEY = API_HOST_STORAGE_KEY;
 
 declare global {
   interface Window {
@@ -21,11 +31,29 @@ function okStatus(value: unknown): boolean {
   return false;
 }
 
+export function normalizeOracleHost(value: string): string {
+  const trimmed = value.trim().replace(/\/+$/, "");
+  if (!trimmed) return DEFAULT_ORACLE_HOST;
+  try {
+    const url = trimmed.includes("://") ? new URL(trimmed) : new URL(`http://${trimmed}`);
+    return url.host || DEFAULT_ORACLE_HOST;
+  } catch {
+    return trimmed.replace(/^https?:\/\//, "").split("/")[0] || DEFAULT_ORACLE_HOST;
+  }
+}
+
+export function connectUrlForHost(input: string, href: string): string {
+  const url = new URL(href);
+  url.searchParams.set("host", normalizeOracleHost(input));
+  return url.toString();
+}
+
 async function browserHealthCheck(): Promise<void> {
+  const target = apiUrl("/api/health");
   const response = await apiFetch("/api/health", {
     headers: { accept: "application/json" },
   });
-  if (!response.ok) throw new Error(`/api/health returned ${response.status}`);
+  if (!response.ok) throw new Error(`${target} returned ${response.status}`);
 }
 
 async function tauriHealthCheck(): Promise<void> {
@@ -34,11 +62,91 @@ async function tauriHealthCheck(): Promise<void> {
     throw new Error(`health_check returned ${String(status)}`);
 }
 
+export function ConnectOracleSetup({
+  isTauri,
+  message,
+  onRetry,
+  onStartBackend,
+  starting,
+  state,
+}: {
+  isTauri: boolean;
+  message: string;
+  onRetry: () => void;
+  onStartBackend: () => void;
+  starting: boolean;
+  state: GateState;
+}) {
+  const [host, setHost] = useState(API_HOST);
+  const target = API_BASE;
+
+  function connect(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    connectToApiHost(host);
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-slate-950 p-6 text-slate-100">
+      <section className="w-full max-w-xl rounded-3xl border border-white/10 bg-white/[0.04] p-8 shadow-2xl">
+        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-teal-300">
+          ARRA Oracle
+        </p>
+        <h1 className="mt-3 text-3xl font-bold">Connect to your Oracle</h1>
+        <p className="mt-4 text-sm text-slate-300">
+          {state === "checking"
+            ? `Checking backend health at ${target}.`
+            : `Cannot reach ${target}: ${message}`}
+        </p>
+        <form className="mt-6 space-y-3" onSubmit={connect}>
+          <label className="block text-sm font-semibold text-slate-200" htmlFor="oracle-host">
+            Local Oracle host
+          </label>
+          <input
+            id="oracle-host"
+            className="w-full rounded-2xl border border-white/15 bg-slate-900 px-4 py-3 text-sm text-slate-100 outline-none focus:border-teal-300"
+            placeholder={DEFAULT_ORACLE_HOST}
+            value={host}
+            onChange={(event) => setHost(event.currentTarget.value)}
+          />
+          <p className="text-xs text-slate-400">
+            Start your backend with <code>arra-oracle-v3 serve</code>, then connect from hosted Studio.
+            {!hasStoredApiHost() ? " The default is localhost:47778." : null}
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <button
+              className="focus-ring rounded-full bg-teal-400 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-teal-300"
+              type="submit"
+            >
+              Use this backend
+            </button>
+            {state === "unreachable" && isTauri && (
+              <button
+                className="focus-ring rounded-full border border-teal-300/60 px-4 py-2 text-sm font-semibold text-teal-100 hover:bg-teal-300/10 disabled:opacity-60"
+                disabled={starting}
+                type="button"
+                onClick={onStartBackend}
+              >
+                {starting ? "Starting…" : "Start Backend"}
+              </button>
+            )}
+            <button
+              className="focus-ring rounded-full border border-white/15 px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-white/10"
+              type="button"
+              onClick={onRetry}
+            >
+              Retry
+            </button>
+          </div>
+        </form>
+      </section>
+    </main>
+  );
+}
+
 export function BackendGate({ children }: { children: ReactNode }) {
   const [state, setState] = useState<GateState>("checking");
   const [message, setMessage] = useState("Checking backend health…");
   const [starting, setStarting] = useState(false);
-  const [host, setHost] = useState(API_HOST);
   const isTauri = isTauriRuntime();
 
   const check = useCallback(async () => {
@@ -72,72 +180,16 @@ export function BackendGate({ children }: { children: ReactNode }) {
     }
   }
 
-  function connectBrowserBackend() {
-    connectToApiHost(host);
-  }
-
   if (state === "ready") return <SetupWizard>{children}</SetupWizard>;
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-slate-950 p-6 text-slate-100">
-      <section className="w-full max-w-lg rounded-3xl border border-white/10 bg-white/[0.04] p-8 shadow-2xl">
-        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-teal-300">
-          ARRA Oracle
-        </p>
-        <h1 className="mt-3 text-3xl font-bold">Backend unavailable</h1>
-        <p className="mt-4 text-sm text-slate-300">
-          {state === "checking"
-            ? "Checking whether the local Oracle API is ready."
-            : message}
-        </p>
-        {!isTauri && (
-          <div className="mt-6 rounded-2xl border border-teal-400/20 bg-teal-400/10 p-4">
-            <p className="text-sm font-semibold text-teal-200">Connect to your Oracle</p>
-            <p className="mt-2 text-xs text-slate-300">
-              Studio is trying {API_BASE}. Open with <code>?host=localhost:47778</code> or enter a host below.
-              {!hasStoredApiHost() ? " The default is localhost:47778." : null}
-            </p>
-            <label className="mt-3 block text-xs font-semibold uppercase tracking-[0.2em] text-slate-400" htmlFor="oracle-host">
-              Oracle host
-            </label>
-            <div className="mt-2 flex gap-2">
-              <input
-                className="min-w-0 flex-1 rounded-full border border-white/10 bg-slate-950 px-4 py-2 text-sm text-slate-100 outline-none focus:border-teal-300"
-                id="oracle-host"
-                value={host}
-                onChange={(event) => setHost(event.target.value)}
-                placeholder="localhost:47778"
-              />
-              <button
-                className="focus-ring rounded-full bg-teal-400 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-teal-300"
-                type="button"
-                onClick={connectBrowserBackend}
-              >
-                Connect
-              </button>
-            </div>
-          </div>
-        )}
-        <div className="mt-6 flex flex-wrap gap-3">
-          {state === "unreachable" && isTauri && (
-            <button
-              className="focus-ring rounded-full bg-teal-400 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-teal-300 disabled:opacity-60"
-              disabled={starting}
-              type="button"
-              onClick={() => void startBackend()}
-            >
-              {starting ? "Starting…" : "Start Backend"}
-            </button>
-          )}
-          <button
-            className="focus-ring rounded-full border border-white/15 px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-white/10"
-            type="button"
-            onClick={() => void check()}
-          >
-            Retry
-          </button>
-        </div>
-      </section>
-    </main>
+    <ConnectOracleSetup
+      isTauri={isTauri}
+      message={message}
+      onRetry={() => void check()}
+      onStartBackend={() => void startBackend()}
+      starting={starting}
+      state={state}
+    />
   );
 }

--- a/frontend/src/components/BackendGate.tsx
+++ b/frontend/src/components/BackendGate.tsx
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { API_BASE, API_HOST, apiFetch, connectToApiHost, hasStoredApiHost } from "../api/oracle";
 import { SetupWizard } from "./SetupWizard";
 import { useCallback, useEffect, useState, type ReactNode } from "react";
 
@@ -21,7 +22,7 @@ function okStatus(value: unknown): boolean {
 }
 
 async function browserHealthCheck(): Promise<void> {
-  const response = await fetch("/api/health", {
+  const response = await apiFetch("/api/health", {
     headers: { accept: "application/json" },
   });
   if (!response.ok) throw new Error(`/api/health returned ${response.status}`);
@@ -37,6 +38,7 @@ export function BackendGate({ children }: { children: ReactNode }) {
   const [state, setState] = useState<GateState>("checking");
   const [message, setMessage] = useState("Checking backend health…");
   const [starting, setStarting] = useState(false);
+  const [host, setHost] = useState(API_HOST);
   const isTauri = isTauriRuntime();
 
   const check = useCallback(async () => {
@@ -70,6 +72,10 @@ export function BackendGate({ children }: { children: ReactNode }) {
     }
   }
 
+  function connectBrowserBackend() {
+    connectToApiHost(host);
+  }
+
   if (state === "ready") return <SetupWizard>{children}</SetupWizard>;
 
   return (
@@ -84,6 +90,34 @@ export function BackendGate({ children }: { children: ReactNode }) {
             ? "Checking whether the local Oracle API is ready."
             : message}
         </p>
+        {!isTauri && (
+          <div className="mt-6 rounded-2xl border border-teal-400/20 bg-teal-400/10 p-4">
+            <p className="text-sm font-semibold text-teal-200">Connect to your Oracle</p>
+            <p className="mt-2 text-xs text-slate-300">
+              Studio is trying {API_BASE}. Open with <code>?host=localhost:47778</code> or enter a host below.
+              {!hasStoredApiHost() ? " The default is localhost:47778." : null}
+            </p>
+            <label className="mt-3 block text-xs font-semibold uppercase tracking-[0.2em] text-slate-400" htmlFor="oracle-host">
+              Oracle host
+            </label>
+            <div className="mt-2 flex gap-2">
+              <input
+                className="min-w-0 flex-1 rounded-full border border-white/10 bg-slate-950 px-4 py-2 text-sm text-slate-100 outline-none focus:border-teal-300"
+                id="oracle-host"
+                value={host}
+                onChange={(event) => setHost(event.target.value)}
+                placeholder="localhost:47778"
+              />
+              <button
+                className="focus-ring rounded-full bg-teal-400 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-teal-300"
+                type="button"
+                onClick={connectBrowserBackend}
+              >
+                Connect
+              </button>
+            </div>
+          </div>
+        )}
         <div className="mt-6 flex flex-wrap gap-3">
           {state === "unreachable" && isTauri && (
             <button

--- a/frontend/src/components/Badge.tsx
+++ b/frontend/src/components/Badge.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 
 export function Badge({ children }: { children: ReactNode }) {
   return (
-    <span className="rounded-full border border-teal-300/20 bg-teal-300/10 px-2.5 py-1 text-xs font-medium text-teal-200" data-contrast-badge>
+    <span className="rounded-full border border-[color:var(--color-accent,#0f766e)] px-2.5 py-1 text-xs font-medium text-[color:var(--color-accent,#0f766e)] dark:border-[color:var(--color-accent,#5eead4)] dark:text-[color:var(--color-accent,#5eead4)]" data-contrast-badge>
       {children}
     </span>
   );

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react';
-import { apiUrl } from '../api/oracle';
+import { apiUrl, withLocalPna } from '../api/oracle';
 
 export type ErrorReportStatus = 'idle' | 'reporting' | 'reported' | 'failed';
 export type ErrorReporter = (error: Error, info: ErrorInfo, retryCount: number) => Promise<boolean> | boolean;
@@ -65,7 +65,7 @@ export async function reportErrorToMetrics(
   };
 
   try {
-    const response = await fetcher(apiUrl('/api/metrics'), {
+    const response = await fetcher(apiUrl('/api/metrics'), withLocalPna({
       method: 'POST',
       keepalive: true,
       headers: {
@@ -74,7 +74,7 @@ export async function reportErrorToMetrics(
         'x-arra-report': 'frontend-error-boundary',
       },
       body: JSON.stringify(payload),
-    });
+    }));
     return response.ok;
   } catch {
     return false;

--- a/frontend/src/components/McpToolBrowser.tsx
+++ b/frontend/src/components/McpToolBrowser.tsx
@@ -70,7 +70,7 @@ export function filterMcpTools(tools: McpTool[], query: string, source: McpToolS
 function SourceBadge({ tool }: { tool: McpTool }) {
   const label = mcpToolSourceLabel(tool);
   const href = mcpToolPluginInventoryPath(tool);
-  const className = 'rounded-full bg-teal-300/10 px-2 py-1 text-xs text-teal-100';
+  const className = 'rounded-full border border-[color:var(--color-accent,#0f766e)] px-2 py-1 text-xs text-[color:var(--color-accent,#0f766e)]';
   return href ? <a className={`focus-ring ${className}`} href={href}>{label}</a> : <span className={className}>{label}</span>;
 }
 
@@ -78,9 +78,9 @@ function ToolCard({ tool, onOpen }: { tool: McpTool; onOpen?: (tool: McpTool) =>
   return (
     <article className="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
       <div className="flex flex-wrap items-center gap-2">
-        <h3 className="font-mono text-sm text-teal-200">{tool.name}</h3>
+        <h3 className="font-mono text-sm text-[color:var(--color-accent,#0f766e)]">{tool.name}</h3>
         <span className="rounded-full bg-white/5 px-2 py-1 text-xs text-slate-400">{groupLabel(tool)}</span>
-        <span className="rounded-full bg-purple-300/10 px-2 py-1 text-xs text-purple-200">{toolMode(tool)}</span>
+        <span className="rounded-full border border-[color:var(--color-accent2,#7e22ce)] px-2 py-1 text-xs text-[color:var(--color-accent2,#7e22ce)]">{toolMode(tool)}</span>
         <SourceBadge tool={tool} />
       </div>
       <p className="mt-3 text-sm leading-6 text-slate-400">{tool.description || 'No description supplied.'}</p>
@@ -148,7 +148,7 @@ export function McpToolBrowser({
     <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="mcp-tools-title">
       <div className="mb-5 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-300">MCP</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--color-accent2,#7e22ce)]">MCP</p>
           <h2 id="mcp-tools-title" className="mt-2 text-2xl font-semibold text-white">Tool browser</h2>
           <p className="mt-2 text-sm text-slate-400">Live tool schemas from /api/mcp/tools.</p>
         </div>
@@ -187,7 +187,7 @@ export function McpToolBrowser({
         </p>
       </div>
       <div className="mb-4 flex justify-end">
-        <a className="focus-ring rounded-xl border border-teal-300/20 px-3 py-2 text-sm font-semibold text-teal-100 hover:border-teal-300/50" href={mcpToolsPath({ q: filter, source })}>
+        <a className="focus-ring rounded-xl border border-[color:var(--color-accent,#0f766e)] px-3 py-2 text-sm font-semibold text-[color:var(--color-accent,#0f766e)] hover:border-[color:var(--color-accent,#0f766e)]" href={mcpToolsPath({ q: filter, source })}>
           Share tool view
         </a>
       </div>
@@ -197,7 +197,7 @@ export function McpToolBrowser({
         <ErrorMessage
           title="Could not load MCP tools."
           message={error}
-          action={<button aria-label="Retry loading MCP tools" className="focus-ring rounded-lg border border-red-200/30 px-3 py-2 font-semibold text-red-50 hover:bg-red-200/10" type="button" onClick={() => void load()}>Retry</button>}
+          action={<button aria-label="Retry loading MCP tools" className="focus-ring rounded-lg border border-[color:var(--color-err-text,#991b1b)] px-3 py-2 font-semibold text-[color:var(--color-err-text,#991b1b)] hover:bg-[var(--color-err-bg,#fee2e2)]" type="button" onClick={() => void load()}>Retry</button>}
         />
       ) : null}
       {state === 'ready' && !visible.length ? <p className="rounded-xl border border-dashed border-white/10 p-6 text-sm text-slate-400">No MCP tools matched.</p> : null}

--- a/frontend/src/components/PluginList.tsx
+++ b/frontend/src/components/PluginList.tsx
@@ -143,7 +143,7 @@ export function PluginList({
                   <button
                     aria-label={`${enabled ? 'Disable' : 'Enable'} ${plugin.name}`}
                     aria-pressed={enabled}
-                    className="focus-ring rounded-lg border border-teal-300/30 px-3 py-2 font-semibold text-teal-100 transition hover:bg-teal-300/10"
+                    className="focus-ring rounded-lg border border-[color:var(--color-accent,#0f766e)] px-3 py-2 font-semibold text-[color:var(--color-accent,#0f766e)] transition hover:bg-[var(--color-ok-bg,#dcfce7)]"
                     type="button"
                     onClick={() => onToggle?.(plugin.name)}
                   >
@@ -154,7 +154,7 @@ export function PluginList({
               {plugin.error ? (
                 <div className="sm:col-span-2">
                   <dt className="text-slate-500">Error</dt>
-                  <dd className="text-amber-200">{plugin.error}</dd>
+                  <dd className="text-[color:var(--color-warn-text,#92400e)]">{plugin.error}</dd>
                 </div>
               ) : null}
               {surfaceRows.length ? (

--- a/frontend/src/components/SearchResultCard.tsx
+++ b/frontend/src/components/SearchResultCard.tsx
@@ -6,8 +6,8 @@ export function SearchResultCard({ result }: { result: SearchResult }) {
   return (
     <article className="rounded-2xl border border-white/10 bg-slate-950/60 p-4 transition hover:border-teal-300/30">
       <div className="flex items-start justify-between gap-3">
-        <h3 className="break-all font-mono text-sm text-teal-200">{titleFor(result)}</h3>
-        {score ? <span className="rounded-full bg-teal-300/10 px-2 py-1 text-xs font-semibold text-teal-200">{score}</span> : null}
+        <h3 className="break-all font-mono text-sm text-[color:var(--color-accent,#0f766e)]">{titleFor(result)}</h3>
+        {score ? <span className="rounded-full border border-[color:var(--color-accent,#0f766e)] px-2 py-1 text-xs font-semibold text-[color:var(--color-accent,#0f766e)]">{score}</span> : null}
       </div>
       <p className="mt-3 text-sm leading-6 text-slate-400">{previewFor(result)}</p>
       <div className="mt-3 flex flex-wrap gap-2 text-xs text-slate-500">

--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
-import { apiUrl } from "../api";
+import { apiFetch } from "../api";
 import { Spinner } from "./AsyncState";
 import { StepBody, setupSteps } from "./SetupWizardContent";
 import { shouldShowSetupWizard } from "./setupWizardDetection";
@@ -13,7 +13,7 @@ type SetupState = "checking" | "hidden" | "visible";
 const DISMISS_KEY = "arra.vector.setup.dismissed";
 
 async function getJson<T>(path: string): Promise<T> {
-  const response = await fetch(apiUrl(path), {
+  const response = await apiFetch(path, {
     headers: { accept: "application/json" },
   });
   if (!response.ok) throw new Error(`${path} returned ${response.status}`);
@@ -92,13 +92,13 @@ export function SetupWizard({ children }: { children: ReactNode }) {
     if (!selectedProvider) return setMessage("Choose an embedding provider first.");
     setBusy(true);
     try {
-      const response = await fetch(apiUrl("/api/v1/vector/config"), {
+      const response = await apiFetch("/api/v1/vector/config", {
         method: "PATCH",
         headers: { accept: "application/json", "content-type": "application/json" },
         body: JSON.stringify(buildProviderConfigPatch(config, selectedProvider)),
       });
       if (!response.ok) throw new Error(`/api/v1/vector/config returned ${response.status}`);
-      await fetch(apiUrl("/api/v1/vector/config/reload"), { method: "POST", headers: { accept: "application/json" } });
+      await apiFetch("/api/v1/vector/config/reload", { method: "POST", headers: { accept: "application/json" } });
       setConfig(await getJson<VectorConfig>("/api/v1/vector/config"));
       setStep(2);
       setMessage(`Applied ${selectedProvider} as the first-run embedding provider.`);

--- a/frontend/src/components/SetupWizardCostEstimate.tsx
+++ b/frontend/src/components/SetupWizardCostEstimate.tsx
@@ -40,14 +40,14 @@ export function SetupWizardCostEstimate({ initialEstimate, provider }: Props) {
     return () => { active = false; };
   }, [initialEstimate, provider]);
 
-  if (error) return <p className="text-sm text-amber-100">Preflight cost unavailable: {error}</p>;
+  if (error) return <p className="text-sm text-[color:var(--color-warn-text,#92400e)]">Preflight cost unavailable: {error}</p>;
   if (!estimate) return <p className="text-sm text-slate-400">Loading preflight cost estimate…</p>;
   return (
-    <div className="rounded-2xl border border-teal-200/20 bg-teal-200/10 p-3 text-sm text-teal-50/90">
-      <p className="font-semibold text-teal-100">Preflight cost before Start indexing</p>
+    <div className="rounded-2xl border border-[color:var(--color-accent,#0f766e)] p-3 text-sm text-[color:var(--color-accent,#0f766e)]">
+      <p className="font-semibold text-[color:var(--color-accent,#0f766e)]">Preflight cost before Start indexing</p>
       <p className="mt-1">{estimate.formula} · {estimate.provider}: {formatCost(estimate.estimatedUsd)}</p>
-      {estimate.recommendation ? <p className="mt-1 text-teal-100/75">{estimate.recommendation}</p> : null}
-      {estimate.fallbackSummary ? <p className="mt-1 text-teal-100/75">{estimate.fallbackSummary}</p> : null}
+      {estimate.recommendation ? <p className="mt-1 text-[color:var(--color-accent,#0f766e)] opacity-75">{estimate.recommendation}</p> : null}
+      {estimate.fallbackSummary ? <p className="mt-1 text-[color:var(--color-accent,#0f766e)] opacity-75">{estimate.fallbackSummary}</p> : null}
     </div>
   );
 }

--- a/frontend/src/components/SetupWizardCostEstimate.tsx
+++ b/frontend/src/components/SetupWizardCostEstimate.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { apiUrl } from "../api";
+import { apiFetch } from "../api";
 
 type CostEstimate = {
   estimatedUsd: number;
@@ -20,7 +20,7 @@ function formatCost(value: number): string {
 
 async function fetchEstimate(provider: string): Promise<CostEstimate> {
   const qs = new URLSearchParams({ provider });
-  const response = await fetch(apiUrl(`/api/v1/vector/cost-estimate?${qs}`), {
+  const response = await apiFetch(`/api/v1/vector/cost-estimate?${qs}`, {
     headers: { accept: "application/json" },
   });
   if (!response.ok) throw new Error(`/api/v1/vector/cost-estimate returned ${response.status}`);

--- a/frontend/src/components/VectorConfigHealthSummary.tsx
+++ b/frontend/src/components/VectorConfigHealthSummary.tsx
@@ -57,7 +57,7 @@ export function VectorConfigHealthSummary({
           <h4 className="font-semibold text-white">Connection health</h4>
           <p className="mt-1 text-sm text-slate-400">{stats.summary}</p>
         </div>
-        <p className="rounded-full border border-teal-300/20 px-3 py-1 text-xs font-semibold text-teal-100">{stats.total} configured</p>
+        <p className="rounded-full border border-[color:var(--color-accent,#0f766e)] px-3 py-1 text-xs font-semibold text-[color:var(--color-accent,#0f766e)]">{stats.total} configured</p>
       </div>
 
       {downRows.length ? (
@@ -66,16 +66,16 @@ export function VectorConfigHealthSummary({
             const rowHealth = health[key];
             const adapter = rowAdapter(collection, rowHealth);
             return (
-              <article key={key} className="rounded-xl border border-rose-300/20 bg-rose-300/10 p-3 text-sm">
-                <p className="font-semibold text-rose-100">{key}: {adapter} connection down</p>
+              <article key={key} className="rounded-xl border border-[color:var(--color-err-text,#991b1b)] bg-[var(--color-err-bg,#fee2e2)] p-3 text-sm">
+                <p className="font-semibold text-[color:var(--color-err-text,#991b1b)]">{key}: {adapter} connection down</p>
                 <p className="mt-1 text-slate-300">{rowEndpoint(collection, rowHealth)}</p>
-                <p className="mt-1 text-xs text-rose-200">{rowHealth?.error || `Start ${adapter} or update the service endpoint, then Test/Reload.`}</p>
+                <p className="mt-1 text-xs text-[color:var(--color-err-text,#991b1b)]">{rowHealth?.error || `Start ${adapter} or update the service endpoint, then Test/Reload.`}</p>
               </article>
             );
           })}
         </div>
       ) : (
-        <p className="mt-3 text-sm text-emerald-200">All enabled vector connections are healthy.</p>
+        <p className="mt-3 text-sm text-[color:var(--color-ok-text,#166534)]">All enabled vector connections are healthy.</p>
       )}
     </section>
   );

--- a/frontend/src/components/VectorConfigPanel.tsx
+++ b/frontend/src/components/VectorConfigPanel.tsx
@@ -12,9 +12,9 @@ type RuntimeState = { enabled?: boolean; ready?: boolean; primary?: string; reas
 type PanelResponse = VectorConfigResponse & { enabled?: boolean; engine?: string; state?: RuntimeState };
 
 function statusClass(status: string) {
-  if (status === 'ok') return 'border-emerald-400/30 bg-emerald-400/10 text-emerald-200';
+  if (status === 'ok') return 'border-[color:var(--color-ok-text,#166534)] bg-[var(--color-ok-bg,#dcfce7)] text-[color:var(--color-ok-text,#166534)]';
   if (status === 'disabled') return 'border-slate-600 bg-slate-900/70 text-slate-400';
-  return 'border-rose-400/30 bg-rose-400/10 text-rose-200';
+  return 'border-[color:var(--color-err-text,#991b1b)] bg-[var(--color-err-bg,#fee2e2)] text-[color:var(--color-err-text,#991b1b)]';
 }
 
 function collectionEnabled(item: SettingsEmbedderCollection): boolean {
@@ -147,14 +147,14 @@ export function VectorConfigPanel() {
     <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-label="Vector backend config">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-teal-300">Vector config</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--color-accent,#0f766e)]">Vector config</p>
           <h3 className="mt-2 text-lg font-semibold text-white">Active vector adapters</h3>
           <p className="mt-2 text-sm text-slate-400">Get current config, edit model/provider plus service endpoint, switch adapters, enable rows, set primary, and test health.</p>
           <p className="mt-2 text-xs text-slate-500">{summary}</p>
           <p className="mt-2 text-xs text-slate-500">
             Source {state?.source ?? 'loading'} · engine {state?.engine ?? 'loading'} · primary {runtime?.primary ?? 'none'} · {runtime?.ready ? 'ready' : 'not ready'}
           </p>
-          {runtime?.reason ? <p className="mt-1 text-xs text-amber-200">State: {runtime.reason}{runtime.recommendedAction ? ` · ${runtime.recommendedAction}` : ''}</p> : null}
+          {runtime?.reason ? <p className="mt-1 text-xs text-[color:var(--color-warn-text,#92400e)]">State: {runtime.reason}{runtime.recommendedAction ? ` · ${runtime.recommendedAction}` : ''}</p> : null}
         </div>
         <button className="focus-ring rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-teal-300/40" type="button" onClick={reload}>
           {loading ? <Spinner label="Reloading" /> : 'Reload vector config'}
@@ -162,7 +162,7 @@ export function VectorConfigPanel() {
       </div>
 
       {error ? <div className="mt-4"><ErrorMessage title="Vector config update failed." message={error} /></div> : null}
-      {message ? <p className="mt-4 rounded-2xl border border-white/10 bg-slate-900/70 p-3 text-sm text-teal-100">{message}</p> : null}
+      {message ? <p className="mt-4 rounded-2xl border border-white/10 bg-slate-900/70 p-3 text-sm text-[color:var(--color-accent,#0f766e)]">{message}</p> : null}
       {state ? <VectorConfigHealthSummary collections={state.config.collections} health={state.health} /> : null}
 
       <div className="mt-5 grid gap-3">
@@ -178,14 +178,14 @@ export function VectorConfigPanel() {
               <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
                 <div>
                   <div className="flex flex-wrap items-center gap-2">
-                    <p className="font-mono text-sm text-teal-200">{key}</p>
-                    <span className={`rounded-full border px-2 py-0.5 text-xs ${statusClass(status)}`}>{status}</span>
-                    {item.primary ? <span className="rounded-full border border-purple-300/30 px-2 py-0.5 text-xs text-purple-200">primary</span> : null}
+                    <p className="font-mono text-sm text-[color:var(--color-accent,#0f766e)]">{key}</p>
+                    <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs ${statusClass(status)}`}><span aria-hidden="true">●</span>{status}</span>
+                    {item.primary ? <span className="rounded-full border border-[color:var(--color-accent2,#7e22ce)] px-2 py-0.5 text-xs text-[color:var(--color-accent2,#7e22ce)]">primary</span> : null}
                   </div>
                   <p className="mt-2 text-sm text-slate-100">{item.collection}</p>
                   <p className="mt-1 text-xs text-slate-500">{item.provider} · {item.model} · {state?.doc_counts[key] ?? 0} docs</p>
                   {item.service || item.endpoint ? <p className="mt-1 text-xs text-slate-500">Service {item.service || 'default'} · {item.endpoint || 'no endpoint'}</p> : null}
-                  {health?.error ? <p className="mt-2 text-xs text-rose-300">{health.error}</p> : null}
+                  {health?.error ? <p className="mt-2 text-xs text-[color:var(--color-err-text,#991b1b)]">{health.error}</p> : null}
                 </div>
                 <div className="flex flex-wrap items-center gap-3">
                   <label className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
@@ -216,8 +216,8 @@ export function VectorConfigPanel() {
                     <input type="checkbox" checked={draft.enabled} onChange={(event) => updateDraft(key, { enabled: event.target.checked })} />
                     Enabled
                   </label>
-                  <button className="focus-ring rounded-xl border border-teal-300/30 px-3 py-2 text-sm font-semibold text-teal-100 disabled:opacity-50" disabled={!dirty || saving[key] === 'saving'} type="button" onClick={() => void saveAdapter(key)}>{saving[key] === 'saving' ? <Spinner label="Saving" /> : 'Save switch'}</button>
-                  <button className="focus-ring rounded-xl border border-purple-300/30 px-3 py-2 text-sm font-semibold text-purple-100 disabled:opacity-50" disabled={saving[key] === 'testing'} type="button" onClick={() => void testAdapter(key)}>{saving[key] === 'testing' ? <Spinner label="Testing" /> : 'Test'}</button>
+                  <button className="focus-ring rounded-xl border border-[color:var(--color-accent,#0f766e)] px-3 py-2 text-sm font-semibold text-[color:var(--color-accent,#0f766e)] disabled:opacity-50" disabled={!dirty || saving[key] === 'saving'} type="button" onClick={() => void saveAdapter(key)}>{saving[key] === 'saving' ? <Spinner label="Saving" /> : 'Save switch'}</button>
+                  <button className="focus-ring rounded-xl border border-[color:var(--color-accent2,#7e22ce)] px-3 py-2 text-sm font-semibold text-[color:var(--color-accent2,#7e22ce)] disabled:opacity-50" disabled={saving[key] === 'testing'} type="button" onClick={() => void testAdapter(key)}>{saving[key] === 'testing' ? <Spinner label="Testing" /> : 'Test'}</button>
                   <button className="focus-ring rounded-xl border border-cyan-300/30 px-3 py-2 text-sm font-semibold text-cyan-100 disabled:opacity-50" disabled={item.primary || saving[key] === 'primary'} type="button" onClick={() => void setPrimary(key)}>{saving[key] === 'primary' ? <Spinner label="Setting primary" /> : 'Set primary'}</button>
                 </div>
               </div>

--- a/frontend/src/components/VectorConfigPanel.tsx
+++ b/frontend/src/components/VectorConfigPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { apiUrl, fetchVectorConfig, reloadVectorConfig, updateVectorCollection } from '../api';
+import { apiFetch, fetchVectorConfig, reloadVectorConfig, updateVectorCollection } from '../api';
 import { ErrorMessage, Spinner } from './AsyncState';
 import { VectorConfigHealthSummary } from './VectorConfigHealthSummary';
 import type { SettingsEmbedderCollection, VectorConfigResponse } from '../types';
@@ -33,7 +33,7 @@ function draftFrom(key: string, item?: SettingsEmbedderCollection): Drafts[strin
 }
 
 async function testVectorCollection(key: string): Promise<{ success?: boolean; count?: number; error?: string; status?: string }> {
-  const response = await fetch(apiUrl(`/api/v1/vector/config/${encodeURIComponent(key)}/test`), { method: 'POST', headers: { accept: 'application/json' } });
+  const response = await apiFetch(`/api/v1/vector/config/${encodeURIComponent(key)}/test`, { method: 'POST', headers: { accept: 'application/json' } });
   const payload = await response.json().catch(() => ({}));
   if (!response.ok) throw new Error(typeof payload.error === 'string' ? payload.error : response.statusText);
   return payload;

--- a/frontend/src/components/VectorIndexCostPanel.tsx
+++ b/frontend/src/components/VectorIndexCostPanel.tsx
@@ -89,13 +89,13 @@ export function VectorIndexCostPanel({
   return (
     <>
       {costEstimate ? (
-        <div className="mb-4 rounded-2xl border border-teal-200/20 bg-teal-200/10 p-4 text-sm text-teal-50/90">
-          <p className="font-semibold text-teal-100">Preflight cost before Index Now</p>
+        <div className="mb-4 rounded-2xl border border-[color:var(--color-accent,#0f766e)] p-4 text-sm text-[color:var(--color-accent,#0f766e)]">
+          <p className="font-semibold text-[color:var(--color-accent,#0f766e)]">Preflight cost before Index Now</p>
           <p className="mt-1">{costEstimate.formula} · {costEstimate.provider}: {formatCost(costEstimate.estimatedUsd)}</p>
-          {costEstimate.fallbackSummary ? <p className="mt-1 text-teal-100/75">{costEstimate.fallbackSummary}</p> : null}
-          {costEstimate.recommendation ? <p className="mt-1 text-teal-100/75">{costEstimate.recommendation}</p> : null}
+          {costEstimate.fallbackSummary ? <p className="mt-1 text-[color:var(--color-accent,#0f766e)] opacity-75">{costEstimate.fallbackSummary}</p> : null}
+          {costEstimate.recommendation ? <p className="mt-1 text-[color:var(--color-accent,#0f766e)] opacity-75">{costEstimate.recommendation}</p> : null}
         </div>
-      ) : costError ? <p className="mb-4 text-sm text-amber-100">Cost estimate unavailable: {costError}</p> : null}
+      ) : costError ? <p className="mb-4 text-sm text-[color:var(--color-warn-text,#92400e)]">Cost estimate unavailable: {costError}</p> : null}
 
       {costTracking ? (
         <div className="mb-4 rounded-2xl border border-cyan-200/20 bg-cyan-200/10 p-4 text-sm text-cyan-50/90">
@@ -110,7 +110,7 @@ export function VectorIndexCostPanel({
           ))}
           {(daily?.inputTokens ?? 0) === 0 ? <p className="mt-1 text-cyan-100/70">No metered indexing usage recorded yet.</p> : null}
         </div>
-      ) : trackingError ? <p className="mb-4 text-sm text-amber-100">Live cost tracking unavailable: {trackingError}</p> : null}
+      ) : trackingError ? <p className="mb-4 text-sm text-[color:var(--color-warn-text,#92400e)]">Live cost tracking unavailable: {trackingError}</p> : null}
     </>
   );
 }

--- a/frontend/src/components/VectorIndexPanel.tsx
+++ b/frontend/src/components/VectorIndexPanel.tsx
@@ -57,17 +57,17 @@ function jobNotice(status: VectorIndexStatusResponse | null): { title: string; d
   if (status.status === 'completed') return {
     title: 'Index job complete',
     detail: `${status.model} indexed ${status.current.toLocaleString()}/${status.total.toLocaleString()} docs. Dashboard vectors are ready.`,
-    tone: 'border-emerald-300/30 bg-emerald-300/10 text-emerald-50',
+    tone: 'border-[color:var(--color-ok-text,#166534)] bg-[var(--color-ok-bg,#dcfce7)] text-[color:var(--color-ok-text,#166534)]',
   };
   if (status.status === 'stopped') return {
     title: 'Index job stopped',
     detail: status.error ?? `${status.model} stopped at ${status.current.toLocaleString()}/${status.total.toLocaleString()} docs.`,
-    tone: 'border-amber-300/30 bg-amber-300/10 text-amber-50',
+    tone: 'border-[color:var(--color-warn-text,#92400e)] bg-[var(--color-warn-bg,#fef3c7)] text-[color:var(--color-warn-text,#92400e)]',
   };
   return {
     title: 'Index job failed',
     detail: status.error ?? `${status.model} failed before completing the vector backfill.`,
-    tone: 'border-rose-300/30 bg-rose-300/10 text-rose-50',
+    tone: 'border-[color:var(--color-err-text,#991b1b)] bg-[var(--color-err-bg,#fee2e2)] text-[color:var(--color-err-text,#991b1b)]',
   };
 }
 
@@ -152,13 +152,13 @@ export function VectorIndexPanel({
     <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-index-title">
       <div className="mb-5 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-purple-300">Index Manager</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--color-accent2,#7e22ce)]">Index Manager</p>
           <h2 id="vector-index-title" className="mt-2 text-2xl font-semibold text-white">Index jobs and collections</h2>
           <p className="mt-2 text-sm text-slate-400">Start, poll, and audit embedding rebuilds through /api/v1/vector/index/start.</p>
         </div>
         <div className="flex flex-wrap gap-2">
           <button className="focus-ring rounded-xl bg-purple-300 px-3 py-2 text-sm font-semibold text-slate-950 disabled:opacity-50" disabled={!firstModel || indexing || Boolean(startingKey)} type="button" onClick={startFirstModel}>Index Now</button>
-          <button className="focus-ring rounded-xl border border-purple-300/30 px-3 py-2 text-sm font-semibold text-purple-100 disabled:opacity-50" disabled={!firstModel || indexing || Boolean(startingKey)} type="button" onClick={startFirstModel}>Backfill Vectors</button>
+          <button className="focus-ring rounded-xl border border-[color:var(--color-accent2,#7e22ce)] px-3 py-2 text-sm font-semibold text-[color:var(--color-accent2,#7e22ce)] disabled:opacity-50" disabled={!firstModel || indexing || Boolean(startingKey)} type="button" onClick={startFirstModel}>Backfill Vectors</button>
           <a className="focus-ring rounded-xl border border-white/10 px-3 py-2 text-sm text-slate-200 hover:border-purple-300/40" href="/settings">Add Vault</a>
           <button className="focus-ring rounded-xl border border-white/10 px-3 py-2 text-sm text-slate-200 hover:border-purple-300/40" type="button" onClick={() => void refreshStatus()}>Refresh status</button>
         </div>
@@ -166,13 +166,13 @@ export function VectorIndexPanel({
 
       <div className="mb-4 rounded-2xl border border-white/10 bg-white/[0.03] p-4">
         <p className="text-sm font-semibold text-slate-200">Active jobs: {statusSummary(status)}</p>
-        <p className="mt-1 text-sm text-amber-100">Gap indicator: {gapLabel(models, status)}</p>
+        <p className="mt-1 text-sm text-[color:var(--color-warn-text,#92400e)]">Gap indicator: {gapLabel(models, status)}</p>
         {status ? <IndexProgress status={status} /> : null}
       </div>
 
       {notice ? (
         <div className={`mb-4 rounded-2xl border p-4 text-sm ${notice.tone}`} role="status" aria-live="polite">
-          <p className="font-semibold">{notice.title}</p>
+          <p className="font-semibold"><span aria-hidden="true">● </span>{notice.title}</p>
           <p className="mt-1 opacity-80">{notice.detail}</p>
         </div>
       ) : null}
@@ -184,18 +184,18 @@ export function VectorIndexPanel({
       {!loading && !modelEntries.length ? <p className="text-sm text-slate-500">No vector collections reported.</p> : null}
 
       <section className="mb-5 rounded-2xl border border-white/10 bg-white/[0.03] p-4" aria-label="Vault list">
-        <h3 className="font-semibold text-teal-100">Vault list</h3>
+        <h3 className="font-semibold text-[color:var(--color-accent,#0f766e)]">Vault list</h3>
         <div className="mt-3 grid gap-2 md:grid-cols-2">
           {modelEntries.map(([key, model]) => (
             <p key={key} className="rounded-xl border border-white/10 bg-slate-950/50 p-3 text-sm text-slate-300">
-              <span className="font-mono text-teal-200">{model.collection}</span><br />
+              <span className="font-mono text-[color:var(--color-accent,#0f766e)]">{model.collection}</span><br />
               {(model.count ?? 0).toLocaleString()} docs · {vaultState(model)}
             </p>
           ))}
         </div>
       </section>
 
-      <h3 className="mb-3 font-semibold text-purple-100">Vector Models</h3>
+      <h3 className="mb-3 font-semibold text-[color:var(--color-accent2,#7e22ce)]">Vector Models</h3>
       <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
         {modelEntries.map(([key, model]) => {
           const active = indexing && status?.model === key;
@@ -203,7 +203,7 @@ export function VectorIndexPanel({
             <article key={key} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
               <div className="flex items-start justify-between gap-3">
                 <div>
-                  <h3 className="font-mono text-base font-semibold text-teal-200">{key}</h3>
+                  <h3 className="font-mono text-base font-semibold text-[color:var(--color-accent,#0f766e)]">{key}</h3>
                   <p className="mt-1 text-sm text-slate-300">{model.collection}</p>
                 </div>
                 <button
@@ -239,7 +239,7 @@ function IndexProgress({ status }: { status: VectorIndexStatusResponse }) {
       <p className="mt-2 text-sm text-slate-400">
         {status.current}/{status.total} docs · {status.docsPerSec} docs/sec · ETA {formatIndexEta(status.eta)}
       </p>
-      {status.error ? <p className="mt-2 text-sm text-red-200">{status.error}</p> : null}
+      {status.error ? <p className="mt-2 text-sm text-[color:var(--color-err-text,#991b1b)]">{status.error}</p> : null}
     </div>
   );
 }

--- a/frontend/src/components/VectorProviderConfigFields.tsx
+++ b/frontend/src/components/VectorProviderConfigFields.tsx
@@ -41,7 +41,7 @@ export function VectorProviderConfigFields({ provider }: { provider?: VectorProv
   if (type === 'gemini') {
     return (
       <label className="mt-3 block text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
-        Google Gemini API key <span className="rounded-full bg-amber-300/15 px-2 py-0.5 text-[10px] text-amber-100">Free tier available!</span>
+        Google Gemini API key <span className="rounded-full border border-[color:var(--color-warn-text,#92400e)] bg-[var(--color-warn-bg,#fef3c7)] px-2 py-0.5 text-[10px] text-[color:var(--color-warn-text,#92400e)]">Free tier available!</span>
         <input className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-3 py-2 text-sm text-slate-100" placeholder="AIza…" type="password" value={geminiKey} onChange={(event) => setGeminiKey(event.target.value)} />
       </label>
     );

--- a/frontend/src/components/VectorSearchToggle.tsx
+++ b/frontend/src/components/VectorSearchToggle.tsx
@@ -107,7 +107,7 @@ export function VectorSearchToggle() {
     <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-search-toggle-title">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Vector Search panel</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--color-accent,#0f766e)]">Vector Search panel</p>
           <h2 id="vector-search-toggle-title" className="mt-2 text-2xl font-semibold text-white">Enable vector search</h2>
           <p className="mt-2 text-sm text-slate-400">Toggle collection indexing, switch all collection backends, and hot-reload adapters through PATCH /api/v1/vector/config.</p>
           <p className="mt-2 text-xs text-slate-500">{loading ? 'Loading vector search switch…' : enabledSummary(config)}</p>
@@ -135,7 +135,7 @@ export function VectorSearchToggle() {
           </label>
         </div>
       </div>
-      {message ? <p className="mt-4 rounded-2xl border border-teal-300/20 bg-teal-300/10 p-3 text-sm text-teal-100">{message}</p> : null}
+      {message ? <p className="mt-4 rounded-2xl border border-[color:var(--color-accent,#0f766e)] p-3 text-sm text-[color:var(--color-accent,#0f766e)]">{message}</p> : null}
       {error ? <div className="mt-4"><ErrorMessage title="Vector search toggle failed." message={error} /></div> : null}
     </section>
   );

--- a/frontend/src/components/VectorSearchWidget.tsx
+++ b/frontend/src/components/VectorSearchWidget.tsx
@@ -87,7 +87,7 @@ export function VectorSearchWidget({ onOpenResults }: { onOpenResults?: (query: 
           <ErrorMessage
             title="Vector search failed."
             message={error}
-            action={lastQuery ? <button aria-label={`Retry vector search for ${lastQuery}`} className="focus-ring rounded-lg border border-red-200/30 px-3 py-2 font-semibold text-red-50 hover:bg-red-200/10" type="button" onClick={() => void runSearch(lastQuery)}>Retry search</button> : null}
+            action={lastQuery ? <button aria-label={`Retry vector search for ${lastQuery}`} className="focus-ring rounded-lg border border-[color:var(--color-err-text,#991b1b)] px-3 py-2 font-semibold text-[color:var(--color-err-text,#991b1b)] hover:bg-[var(--color-err-bg,#fee2e2)]" type="button" onClick={() => void runSearch(lastQuery)}>Retry search</button> : null}
           />
         </div>
       ) : null}

--- a/frontend/src/components/export/ConnectionTest.tsx
+++ b/frontend/src/components/export/ConnectionTest.tsx
@@ -68,9 +68,9 @@ async function readJson(response: Response): Promise<unknown> {
 }
 
 function statusClass(state: TestState): string {
-  if (state === 'connected') return 'border-emerald-300/30 bg-emerald-300/10 text-emerald-100';
-  if (state === 'failed') return 'border-red-300/30 bg-red-300/10 text-red-100';
-  return 'border-amber-300/30 bg-amber-300/10 text-amber-100';
+  if (state === 'connected') return 'border-[color:var(--color-ok-text,#166534)] bg-[var(--color-ok-bg,#dcfce7)] text-[color:var(--color-ok-text,#166534)]';
+  if (state === 'failed') return 'border-[color:var(--color-err-text,#991b1b)] bg-[var(--color-err-bg,#fee2e2)] text-[color:var(--color-err-text,#991b1b)]';
+  return 'border-[color:var(--color-warn-text,#92400e)] bg-[var(--color-warn-bg,#fef3c7)] text-[color:var(--color-warn-text,#92400e)]';
 }
 
 function statusLabel(state: TestState): string {
@@ -151,12 +151,12 @@ export function ConnectionTest({ initialBackendUrl = DEFAULT_BACKEND_URL, fetche
     <section className="grid gap-4 rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="export-connection-title">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Export app</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--color-accent,#0f766e)]">Export app</p>
           <h2 id="export-connection-title" className="mt-2 text-2xl font-semibold text-white">Backend connection</h2>
           <p className="mt-2 text-sm text-slate-400">Test export app access and inspect available collections.</p>
         </div>
-        <span className={`inline-flex w-fit rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] ${statusClass(state)}`}>
-          {statusLabel(state)}
+        <span className={`inline-flex w-fit items-center gap-1 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] ${statusClass(state)}`}>
+          <span aria-hidden="true">●</span>{statusLabel(state)}
         </span>
       </div>
 

--- a/frontend/src/components/export/DownloadCard.tsx
+++ b/frontend/src/components/export/DownloadCard.tsx
@@ -3,8 +3,8 @@ import type { ExportDownloadLink } from '../../pages/exportAppHelpers';
 export function DownloadCard({ link }: { link: ExportDownloadLink | null }) {
   if (!link) return null;
   return (
-    <div className="rounded-2xl border border-emerald-300/20 bg-emerald-300/10 p-4" role="status">
-      <p className="text-sm font-semibold text-emerald-100">Export is ready.</p>
+    <div className="rounded-2xl border border-[color:var(--color-ok-text,#166534)] bg-[var(--color-ok-bg,#dcfce7)] p-4" role="status">
+      <p className="text-sm font-semibold text-[color:var(--color-ok-text,#166534)]"><span aria-hidden="true">✓ </span>Export is ready.</p>
       <a className="focus-ring mt-3 inline-flex rounded-xl bg-teal-300 px-5 py-3 text-sm font-semibold text-slate-950 hover:bg-teal-200" href={link.url} download={link.filename}>
         Download {link.filename}
       </a>

--- a/frontend/src/components/export/GraphPreview.tsx
+++ b/frontend/src/components/export/GraphPreview.tsx
@@ -193,7 +193,7 @@ export function GraphPreview({
           </p>
         </div>
         <button
-          className="focus-ring rounded-xl border border-teal-300/30 px-4 py-2 text-sm font-semibold text-teal-100 hover:bg-teal-300/10"
+          className="focus-ring rounded-xl border border-[color:var(--color-accent,#0f766e)] px-4 py-2 text-sm font-semibold text-[color:var(--color-accent,#0f766e)] hover:bg-[var(--color-ok-bg,#dcfce7)]"
           type="button"
           onClick={() => { if (svgRef.current) saveSvg(svgRef.current, fileName, onExportSvg); }}
         >

--- a/frontend/src/components/setupWizardIndex.ts
+++ b/frontend/src/components/setupWizardIndex.ts
@@ -1,4 +1,4 @@
-import { apiUrl } from '../api';
+import { apiFetch } from '../api';
 import type { VectorConfig, VectorIndexSource } from './setupWizardTypes';
 
 export type IndexStartBody = {
@@ -28,7 +28,7 @@ export function buildIndexStartBody(
 }
 
 export async function requestVectorIndexStart(body: IndexStartBody): Promise<void> {
-  await fetch(apiUrl('/api/v1/vector/index/start'), {
+  await apiFetch('/api/v1/vector/index/start', {
     method: 'POST',
     headers: { accept: 'application/json', 'content-type': 'application/json' },
     body: JSON.stringify(body),

--- a/frontend/src/components/wizard/FirstRunWizard.tsx
+++ b/frontend/src/components/wizard/FirstRunWizard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { ErrorMessage, LoadingPanel, Spinner } from '../AsyncState';
-import { apiUrl, type VectorProvider } from '../../api/oracle';
+import { apiFetch, type VectorProvider } from '../../api/oracle';
 import { useFirstRun } from '../../hooks/useFirstRun';
 
 type Step = 0 | 1 | 2 | 3;
@@ -23,7 +23,7 @@ const defaultPlans: CollectionPlan[] = [
 ];
 
 async function json<T>(path: string, init: RequestInit = {}): Promise<T> {
-  const response = await fetch(apiUrl(path), {
+  const response = await apiFetch(path, {
     ...init,
     headers: { accept: 'application/json', 'content-type': 'application/json', ...(init.headers ?? {}) },
   });

--- a/frontend/src/components/wizard/FirstRunWizard.tsx
+++ b/frontend/src/components/wizard/FirstRunWizard.tsx
@@ -146,7 +146,7 @@ export function FirstRunWizard() {
         <ConfirmCard active={step === 3} provider={selectedProvider} providerType={providerType} selected={selected} busy={busy} onStart={() => void startInitialIndexing()} />
       </div>
 
-      {message ? <p className="rounded-2xl border border-teal-300/20 bg-teal-300/10 p-4 text-sm text-teal-100">{message}</p> : null}
+      {message ? <p className="rounded-2xl border border-[color:var(--color-accent,#0f766e)] p-4 text-sm text-[color:var(--color-accent,#0f766e)]">{message}</p> : null}
       {error && state !== 'error' ? <ErrorMessage title="First-run setup failed." message={error} /> : null}
 
       <div className="flex flex-wrap gap-3">

--- a/frontend/src/hooks/useExport.ts
+++ b/frontend/src/hooks/useExport.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { apiUrl } from '../api/oracle';
+import { apiUrl, withLocalPna } from '../api/oracle';
 
 export type ExportStatus = 'idle' | 'starting' | 'running' | 'done' | 'error';
 export type ExportRunPayload = Record<string, unknown>;
@@ -158,7 +158,7 @@ export function useExport({ fetcher = globalThis.fetch?.bind(globalThis), pollMs
     if (!fetcher) throw new Error('fetch is unavailable');
     const path = `/api/v1/export/app/download/${encodeURIComponent(jobId)}`;
     while (!signal.aborted) {
-      const response = await fetcher(apiUrl(path), { headers: { accept: 'application/json, application/octet-stream' }, signal });
+      const response = await fetcher(apiUrl(path), withLocalPna({ headers: { accept: 'application/json, application/octet-stream' }, signal }));
       const payload = await jsonOrEmpty(response);
       const jobStatus = statusFrom(payload);
       const progress = Math.min(100, Math.max(0, progressFrom(payload) ?? 0));
@@ -194,12 +194,12 @@ export function useExport({ fetcher = globalThis.fetch?.bind(globalThis), pollMs
     lastPayloadRef.current = payload;
     setState({ status: 'starting', jobId: null, progress: 0 });
     try {
-      const response = await fetcher(apiUrl('/api/v1/export/app/run'), {
+      const response = await fetcher(apiUrl('/api/v1/export/app/run'), withLocalPna({
         method: 'POST',
         headers: { accept: 'application/json', 'content-type': 'application/json' },
         body: JSON.stringify(payload),
         signal: controller.signal,
-      });
+      }));
       const body = await jsonOrEmpty(response);
       if (!response.ok) throw new Error(textValue(body.error, body.message) ?? `/api/v1/export/app/run returned ${response.status}`);
       const jobId = textValue(body.jobId, body.id);

--- a/frontend/src/hooks/usePlugins.ts
+++ b/frontend/src/hooks/usePlugins.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { apiUrl } from '../api/oracle';
+import { apiUrl, withLocalPna } from '../api/oracle';
 import type { PluginEntry, PluginsResponse } from '../types';
 
 export const PLUGINS_ENDPOINT = '/api/plugins';
@@ -48,7 +48,7 @@ export async function fetchPluginsFromEndpoint({
 
   let response: Response;
   try {
-    response = await request(apiUrl(endpoint), { headers: { accept: 'application/json' } });
+    response = await request(apiUrl(endpoint), withLocalPna({ headers: { accept: 'application/json' } }));
   } catch (error) {
     throw new Error(`${endpoint} is unreachable: ${messageFor(error)}`);
   }

--- a/frontend/src/pages/CanvasAliasPage.tsx
+++ b/frontend/src/pages/CanvasAliasPage.tsx
@@ -20,10 +20,10 @@ export function CanvasAliasPage() {
   return (
     <section className="grid gap-5" aria-labelledby="canvas-alias-title">
       <header className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
-        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Canvas app</p>
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--color-accent,#0f766e)]">Canvas app</p>
         <h1 id="canvas-alias-title" className="mt-2 text-3xl font-semibold text-white">Studio canvas alias</h1>
         <p className="mt-2 text-sm text-slate-400">/canvas remains available while the isolated canvas app runs on canvas.buildwithoracle.com.</p>
-        <a className="focus-ring mt-4 inline-flex rounded-xl border border-teal-300/30 px-3 py-2 text-sm font-semibold text-teal-100 hover:bg-teal-300/10" href={target}>
+        <a className="focus-ring mt-4 inline-flex rounded-xl border border-[color:var(--color-accent,#0f766e)] px-3 py-2 text-sm font-semibold text-[color:var(--color-accent,#0f766e)] hover:bg-[var(--color-ok-bg,#dcfce7)]" href={target}>
           Open standalone canvas
         </a>
       </header>

--- a/frontend/src/pages/CanvasPluginsPage.tsx
+++ b/frontend/src/pages/CanvasPluginsPage.tsx
@@ -33,8 +33,8 @@ function pluginHref(plugin: CanvasPluginEntry, host?: string): string {
 }
 
 function statusClass(plugin: CanvasPluginEntry): string {
-  if (plugin.kind === 'react') return 'border-purple-300/30 bg-purple-300/10 text-purple-100';
-  return 'border-teal-300/30 bg-teal-300/10 text-teal-100';
+  if (plugin.kind === 'react') return 'border-[color:var(--color-accent2,#7e22ce)] text-[color:var(--color-accent2,#7e22ce)]';
+  return 'border-[color:var(--color-accent,#0f766e)] text-[color:var(--color-accent,#0f766e)]';
 }
 
 function PluginCard({ plugin, host }: { plugin: CanvasPluginEntry; host?: string }) {
@@ -50,12 +50,12 @@ function PluginCard({ plugin, host }: { plugin: CanvasPluginEntry; host?: string
       </div>
       <p className="text-sm text-slate-300">{plugin.description}</p>
       <dl className="mt-4 grid gap-3 text-sm">
-        <div><dt className="text-slate-500">Status</dt><dd className="font-semibold text-emerald-200">registered</dd></div>
+        <div><dt className="text-slate-500">Status</dt><dd className="font-semibold text-[color:var(--color-ok-text,#166534)]">registered</dd></div>
         <div><dt className="text-slate-500">Canvas target</dt><dd className="break-all font-mono text-slate-100">{target}</dd></div>
         <div><dt className="text-slate-500">Runtime hook</dt><dd className="font-mono text-slate-100">{'renderer' in plugin ? plugin.renderer : plugin.mount}</dd></div>
         {'apiPath' in plugin && plugin.apiPath ? <div><dt className="text-slate-500">Data API</dt><dd className="font-mono text-slate-100">{plugin.apiPath}</dd></div> : null}
       </dl>
-      <a className="focus-ring mt-4 inline-flex rounded-xl border border-teal-300/30 px-3 py-2 text-sm font-semibold text-teal-100 hover:bg-teal-300/10" href={target}>Open canvas</a>
+      <a className="focus-ring mt-4 inline-flex rounded-xl border border-[color:var(--color-accent,#0f766e)] px-3 py-2 text-sm font-semibold text-[color:var(--color-accent,#0f766e)] hover:bg-[var(--color-ok-bg,#dcfce7)]" href={target}>Open canvas</a>
     </article>
   );
 }
@@ -97,7 +97,7 @@ export function CanvasPluginsPage({ plugins: initialPlugins = [], loading = true
   return (
     <section className="grid gap-5" aria-labelledby="canvas-plugins-title">
       <header className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
-        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Canvas plugins</p>
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--color-accent,#0f766e)]">Canvas plugins</p>
         <h1 id="canvas-plugins-title" className="mt-2 text-3xl font-semibold text-white">Canvas plugin registry</h1>
         <p className="mt-2 text-sm text-slate-400">Filter the standalone registry by runtime while keeping canvas.buildwithoracle.com targets visible.</p>
         <p className="mt-2 font-mono text-xs text-slate-500">Registry endpoint: {endpointHint}</p>
@@ -107,7 +107,7 @@ export function CanvasPluginsPage({ plugins: initialPlugins = [], loading = true
             <button
               key={option.kind}
               aria-pressed={kindFilter === option.kind}
-              className={`focus-ring rounded-xl border px-3 py-2 text-left text-sm ${kindFilter === option.kind ? 'border-teal-300/40 bg-teal-300/10 text-teal-100' : 'border-white/10 text-slate-300 hover:border-teal-300/30'}`}
+              className={`focus-ring rounded-xl border px-3 py-2 text-left text-sm ${kindFilter === option.kind ? 'border-[color:var(--color-accent,#0f766e)] bg-[var(--color-ok-bg,#dcfce7)] text-[color:var(--color-accent,#0f766e)]' : 'border-white/10 text-slate-300 hover:border-[color:var(--color-accent,#0f766e)]'}`}
               type="button"
               onClick={() => setKindFilter(option.kind)}
             >

--- a/frontend/src/pages/ExportApp.tsx
+++ b/frontend/src/pages/ExportApp.tsx
@@ -204,7 +204,7 @@ export function ExportApp({ initialBackendUrl = DEFAULT_BACKEND_URL, fetcher = g
         <ErrorMessage
           title="Could not load legacy backend collections."
           message={error}
-          action={<button className="focus-ring rounded-lg border border-red-200/30 px-3 py-2 font-semibold text-red-50 hover:bg-red-200/10" type="button" onClick={() => void loadCollections()}>Retry loading collections</button>}
+          action={<button className="focus-ring rounded-lg border border-[color:var(--color-err-text,#991b1b)] px-3 py-2 font-semibold text-[color:var(--color-err-text,#991b1b)] hover:bg-[var(--color-err-bg,#fee2e2)]" type="button" onClick={() => void loadCollections()}>Retry loading collections</button>}
         />
       ) : null}
       {exportState === 'error' ? <ErrorMessage title="Could not start export." message={error} /> : null}

--- a/frontend/src/pages/FirstRunWizard.tsx
+++ b/frontend/src/pages/FirstRunWizard.tsx
@@ -167,12 +167,12 @@ function copyFor(step: WizardStep, firstRun: boolean, provider?: Provider): stri
 
 function DoneActions() {
   return (
-    <div className="mt-4 rounded-2xl border border-teal-200/20 bg-teal-200/10 p-4 text-sm text-teal-50/90">
-      <p className="font-semibold text-teal-100">Vector setup is underway</p>
+    <div className="mt-4 rounded-2xl border border-[color:var(--color-accent,#0f766e)] p-4 text-sm text-[color:var(--color-accent,#0f766e)]">
+      <p className="font-semibold text-[color:var(--color-accent,#0f766e)]">Vector setup is underway</p>
       <p className="mt-1">Continue to the Vector dashboard for collection health, or open the Index Manager for live progress.</p>
       <div className="mt-3 flex flex-wrap gap-2">
         <a className="focus-ring rounded-xl bg-teal-200 px-3 py-2 text-sm font-semibold text-slate-950" href="/vector">Open Vector dashboard</a>
-        <a className="focus-ring rounded-xl border border-teal-200/40 px-3 py-2 text-sm font-semibold text-teal-100" href="/vector/index">Open Index Manager</a>
+        <a className="focus-ring rounded-xl border border-[color:var(--color-accent,#0f766e)] px-3 py-2 text-sm font-semibold text-[color:var(--color-accent,#0f766e)]" href="/vector/index">Open Index Manager</a>
       </div>
     </div>
   );
@@ -191,9 +191,9 @@ function VaultPlan({ rows, cost }: { rows: VectorConfigRow[]; cost: CostEstimate
         <p>Primary collection: <span className="font-semibold">{primary?.collection ?? 'none'}</span></p>
         <p className="mt-1 text-purple-100/70">Vault selection is represented by indexed source documents; use Index now to backfill vectors for the primary model.</p>
       </div>
-      <div className="rounded-2xl border border-teal-200/20 bg-teal-200/10 p-4">
-        <p className="font-semibold text-teal-100">Estimated embedding cost</p>
-        {cost ? <CostSummary cost={cost} /> : <p className="mt-2 text-teal-100/70">Cost estimate will appear after provider detection completes.</p>}
+      <div className="rounded-2xl border border-[color:var(--color-accent,#0f766e)] p-4">
+        <p className="font-semibold text-[color:var(--color-accent,#0f766e)]">Estimated embedding cost</p>
+        {cost ? <CostSummary cost={cost} /> : <p className="mt-2 text-[color:var(--color-accent,#0f766e)] opacity-70">Cost estimate will appear after provider detection completes.</p>}
       </div>
     </div>
   );
@@ -201,13 +201,13 @@ function VaultPlan({ rows, cost }: { rows: VectorConfigRow[]; cost: CostEstimate
 
 function CostSummary({ cost }: { cost: CostEstimate }) {
   return (
-    <div className="mt-2 space-y-2 text-teal-50/85">
+    <div className="mt-2 space-y-2 text-[color:var(--color-accent,#0f766e)] opacity-85">
       <p>{cost.docs.toLocaleString()} docs · {cost.tokensPerDoc.toLocaleString()} tokens/doc · {cost.totalTokens.toLocaleString()} tokens total</p>
-      <p>{cost.provider} / {cost.model}: <span className="font-semibold text-teal-100">${cost.estimatedUsd.toFixed(4)}</span></p>
-      <p className="text-teal-100/70">{cost.formula}</p>
-      {cost.fallbackSummary ? <p className="text-teal-100/70">{cost.fallbackSummary}</p> : null}
-      <p><span className="font-semibold text-teal-100">Recommendation:</span> {cost.recommendation}</p>
-      <p className="text-teal-100/70">{cost.note}</p>
+      <p>{cost.provider} / {cost.model}: <span className="font-semibold text-[color:var(--color-accent,#0f766e)]">${cost.estimatedUsd.toFixed(4)}</span></p>
+      <p className="text-[color:var(--color-accent,#0f766e)] opacity-70">{cost.formula}</p>
+      {cost.fallbackSummary ? <p className="text-[color:var(--color-accent,#0f766e)] opacity-70">{cost.fallbackSummary}</p> : null}
+      <p><span className="font-semibold text-[color:var(--color-accent,#0f766e)]">Recommendation:</span> {cost.recommendation}</p>
+      <p className="text-[color:var(--color-accent,#0f766e)] opacity-70">{cost.note}</p>
     </div>
   );
 }

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -53,7 +53,7 @@ export function filterMenuItems(items: MenuItem[], filters: MenuFilters): MenuIt
 
 function MenuTypeBadge({ type }: { type: string }) {
   return (
-    <span className="inline-flex rounded-full border border-teal-300/20 bg-teal-300/10 px-2 py-1 text-xs font-semibold uppercase tracking-[0.14em] text-teal-100">
+    <span className="inline-flex rounded-full border border-[color:var(--color-accent,#0f766e)] px-2 py-1 text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--color-accent,#0f766e)]">
       {type}
     </span>
   );
@@ -77,7 +77,7 @@ function MenuRows({ items, emptyText = 'No menu items returned from /api/menu.' 
             {items.map((item) => (
               <tr key={menuKey(item)} className="transition hover:bg-white/[0.03]">
                 <td className="px-4 py-4 align-top">
-                  <a className="focus-ring font-semibold text-white hover:text-teal-200" href={item.path}>
+                  <a className="focus-ring font-semibold text-white hover:text-[color:var(--color-accent,#0f766e)]" href={item.path}>
                     {item.label}
                   </a>
                   <p className="mt-1 font-mono text-xs text-slate-500">{item.path}</p>
@@ -99,7 +99,7 @@ function MenuRows({ items, emptyText = 'No menu items returned from /api/menu.' 
           <li key={menuKey(item)} className="rounded-xl border border-white/10 bg-slate-950/70 p-3">
             <div className="flex items-start justify-between gap-3">
               <div className="min-w-0">
-                <a className="focus-ring font-semibold text-white hover:text-teal-200" href={item.path}>
+                <a className="focus-ring font-semibold text-white hover:text-[color:var(--color-accent,#0f766e)]" href={item.path}>
                   {item.label}
                 </a>
                 <p className="mt-1 truncate font-mono text-xs text-slate-500">{item.path}</p>
@@ -140,7 +140,7 @@ function MenuFiltersCard({
     <section className="mb-5 rounded-2xl border border-white/10 bg-white/[0.03] p-4" aria-label="Menu filters">
       <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-teal-300">Source filters</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--color-accent,#0f766e)]">Source filters</p>
           <p className="mt-1 text-sm text-slate-400">Showing {visible} of {total} items across {sources.length} menu sources.</p>
         </div>
         <div className="grid gap-2 sm:grid-cols-[10rem_minmax(12rem,1fr)_auto]">
@@ -161,7 +161,7 @@ function MenuFiltersCard({
           <button className="focus-ring self-end rounded-xl border border-white/10 px-3 py-2 text-sm font-semibold text-slate-200 hover:border-teal-300/40 disabled:opacity-40" disabled={!hasFilters} type="button" onClick={onClear}>
             Clear
           </button>
-          <a className="focus-ring self-end rounded-xl border border-teal-300/20 px-3 py-2 text-sm font-semibold text-teal-100 hover:border-teal-300/50" href={sharePath}>
+          <a className="focus-ring self-end rounded-xl border border-[color:var(--color-accent,#0f766e)] px-3 py-2 text-sm font-semibold text-[color:var(--color-accent,#0f766e)] hover:border-[color:var(--color-accent,#0f766e)]" href={sharePath}>
             Share view
           </a>
         </div>
@@ -206,7 +206,7 @@ export function MenuPage({ items: initialItems = [], loading, client = apiClient
     <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="menu-page-title">
       <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Menu</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--color-accent,#0f766e)]">Menu</p>
           <h2 id="menu-page-title" className="mt-2 text-2xl font-semibold text-white">Menu catalog</h2>
           <p className="mt-2 text-sm text-slate-400">All frontend menu rows from GET /api/menu.</p>
         </div>
@@ -234,7 +234,7 @@ export function MenuPage({ items: initialItems = [], loading, client = apiClient
           title="Could not load menu items."
           message={error || 'The /api/menu request failed.'}
           action={
-            <button className="focus-ring rounded-lg border border-red-200/30 px-3 py-2 font-semibold text-red-50 hover:bg-red-200/10" type="button" onClick={() => void loadMenu()}>
+            <button className="focus-ring rounded-lg border border-[color:var(--color-err-text,#991b1b)] px-3 py-2 font-semibold text-[color:var(--color-err-text,#991b1b)] hover:bg-[var(--color-err-bg,#fee2e2)]" type="button" onClick={() => void loadMenu()}>
               Retry
             </button>
           }

--- a/frontend/src/pages/PluginsPage.tsx
+++ b/frontend/src/pages/PluginsPage.tsx
@@ -47,9 +47,9 @@ function browserSearch(): string {
 
 function toneClass(tone: Tone): string {
   const tones: Record<Tone, string> = {
-    ok: 'border-emerald-300/30 bg-emerald-400/10 text-emerald-100',
-    warn: 'border-amber-300/30 bg-amber-400/10 text-amber-100',
-    bad: 'border-red-300/30 bg-red-400/10 text-red-100',
+    ok: 'border-[color:var(--color-ok-text,#166534)] bg-[var(--color-ok-bg,#dcfce7)] text-[color:var(--color-ok-text,#166534)]',
+    warn: 'border-[color:var(--color-warn-text,#92400e)] bg-[var(--color-warn-bg,#fef3c7)] text-[color:var(--color-warn-text,#92400e)]',
+    bad: 'border-[color:var(--color-err-text,#991b1b)] bg-[var(--color-err-bg,#fee2e2)] text-[color:var(--color-err-text,#991b1b)]',
     idle: 'border-slate-500/40 bg-slate-800 text-slate-200',
   };
   return tones[tone];
@@ -59,7 +59,7 @@ function MetricCard({ label, value, detail, tone = 'idle' }: { label: string; va
   return (
     <article className={`rounded-lg border p-4 ${toneClass(tone)}`}>
       <p className="text-xs font-semibold uppercase tracking-[0.18em] opacity-80">{label}</p>
-      <p className="mt-2 text-2xl font-semibold">{value}</p>
+      <p className="mt-2 flex items-center gap-2 text-2xl font-semibold">{tone !== 'idle' ? <span aria-hidden="true">●</span> : null}{value}</p>
       <p className="mt-1 text-sm opacity-75">{detail}</p>
     </article>
   );
@@ -123,7 +123,7 @@ export function PluginsPage({
   return (
     <section className="grid gap-5" aria-labelledby="plugins-page-title">
       <header>
-        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Plugin management</p>
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--color-accent,#0f766e)]">Plugin management</p>
         <h1 id="plugins-page-title" className="mt-2 text-3xl font-semibold text-white">Unified plugin surfaces</h1>
         <p className="mt-2 text-sm text-slate-400">Registered plugins, backend surfaces, and enable/disable controls from GET {endpoint}.</p>
       </header>
@@ -141,7 +141,7 @@ export function PluginsPage({
         </div>
       ) : null}
 
-      {adminMessage ? <p className="rounded-lg border border-teal-300/20 bg-teal-300/10 p-3 text-sm text-teal-100">{adminMessage}</p> : null}
+      {adminMessage ? <p className="rounded-lg border border-[color:var(--color-accent,#0f766e)] p-3 text-sm text-[color:var(--color-accent,#0f766e)]">{adminMessage}</p> : null}
       {adminError ? <ErrorMessage title="Could not update plugin state." message={adminError} /> : null}
 
       {showInventory ? <UnifiedPluginSurfaceOverview plugins={plugins} /> : null}
@@ -150,7 +150,7 @@ export function PluginsPage({
         <section className="rounded-2xl border border-white/10 bg-slate-950/70 p-4" aria-labelledby="plugin-filters-title">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
             <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-teal-300">Inventory filters</p>
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--color-accent,#0f766e)]">Inventory filters</p>
               <h2 id="plugin-filters-title" className="mt-1 text-lg font-semibold text-white">Find plugin surfaces</h2>
               <p className="mt-1 text-sm text-slate-400">Showing {visiblePlugins.length} of {plugins.length} plugins · {summary}</p>
             </div>
@@ -198,7 +198,7 @@ export function PluginsPage({
               >
                 Clear filters
               </button>
-              <a className="focus-ring self-end rounded-xl border border-teal-300/20 px-3 py-2 text-sm font-semibold text-teal-100 hover:border-teal-300/50" href={pluginInventoryPath({ q: query, visibility, surface })}>
+              <a className="focus-ring self-end rounded-xl border border-[color:var(--color-accent,#0f766e)] px-3 py-2 text-sm font-semibold text-[color:var(--color-accent,#0f766e)] hover:border-[color:var(--color-accent,#0f766e)]" href={pluginInventoryPath({ q: query, visibility, surface })}>
                 Share view
               </a>
             </div>

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -52,7 +52,7 @@ function HighlightedText({ text, query }: { text: string; query: string }) {
   return (
     <>
       {highlightParts(text, query).map((part, index) => part.match ? (
-        <mark key={`${part.text}-${index}`} className="rounded bg-amber-300/25 px-0.5 text-amber-100">
+        <mark key={`${part.text}-${index}`} className="rounded bg-amber-300/25 px-0.5 text-[color:var(--color-warn-text,#92400e)]">
           {part.text}
         </mark>
       ) : <span key={`${part.text}-${index}`}>{part.text}</span>)}
@@ -69,7 +69,7 @@ function SearchInputCard({ query, loading, onQueryChange, onSubmit }: {
   return (
     <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-label="Search input card">
       <div className="mb-5">
-        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Menu search</p>
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--color-accent,#0f766e)]">Menu search</p>
         <h1 id="menu-search-title" className="mt-2 text-3xl font-semibold text-white">Full-text menu search</h1>
         <p className="mt-2 text-sm text-slate-400">Search dashboard labels and paths through /api/menu/search?q=.</p>
       </div>
@@ -103,7 +103,7 @@ export function MenuSearchResults({ query, results, state }: { query: string; re
           <a className="focus-ring block rounded-2xl border border-white/10 bg-white/[0.03] p-4 transition hover:border-teal-300/40" href={item.path}>
             <span className="text-lg font-semibold text-white"><HighlightedText text={item.label} query={query} /></span>
             <span className="mt-1 block text-sm text-slate-400"><HighlightedText text={item.path} query={query} /></span>
-            <span className="mt-3 inline-flex rounded-full bg-teal-300/10 px-2 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-teal-200">
+            <span className="mt-3 inline-flex rounded-full border border-[color:var(--color-accent,#0f766e)] px-2 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--color-accent,#0f766e)]">
               {item.group}
             </span>
           </a>
@@ -116,7 +116,7 @@ export function MenuSearchResults({ query, results, state }: { query: string; re
 function SearchScopeCard({ scope, resultGroups, total }: { scope: SearchScope; resultGroups: string[]; total: number }) {
   return (
     <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-label="Search scope card">
-      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Scope</p>
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--color-accent,#0f766e)]">Scope</p>
       <h2 className="mt-2 text-2xl font-semibold text-white">Search boundaries</h2>
       <p className="mt-2 text-sm text-slate-400">Current query scope is constrained to menu records.</p>
       <ul className="mt-5 grid gap-2 text-sm text-slate-300">
@@ -153,7 +153,7 @@ function SearchResultsCard({
   return (
     <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-label="Menu search results card">
       <div className="mb-4">
-        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Results</p>
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--color-accent,#0f766e)]">Results</p>
         <h2 className="mt-2 text-2xl font-semibold text-white">Search results</h2>
         <p className="mt-2 text-sm text-slate-500">{summary}</p>
       </div>

--- a/frontend/src/pages/StatusPage.tsx
+++ b/frontend/src/pages/StatusPage.tsx
@@ -23,9 +23,9 @@ export interface StatusPageProps {
 }
 
 function statusClass(status?: string): string {
-  if (status === 'ok' || status === 'connected') return 'border-emerald-300/30 bg-emerald-300/10 text-emerald-100';
-  if (status === 'degraded' || status === 'draining') return 'border-amber-300/30 bg-amber-300/10 text-amber-100';
-  return 'border-red-300/30 bg-red-300/10 text-red-100';
+  if (status === 'ok' || status === 'connected') return 'border-[color:var(--color-ok-text,#166534)] bg-[var(--color-ok-bg,#dcfce7)] text-[color:var(--color-ok-text,#166534)]';
+  if (status === 'degraded' || status === 'draining') return 'border-[color:var(--color-warn-text,#92400e)] bg-[var(--color-warn-bg,#fef3c7)] text-[color:var(--color-warn-text,#92400e)]';
+  return 'border-[color:var(--color-err-text,#991b1b)] bg-[var(--color-err-bg,#fee2e2)] text-[color:var(--color-err-text,#991b1b)]';
 }
 
 function formatSeconds(seconds?: number): string {
@@ -49,7 +49,7 @@ function StatusBadge({ label, status }: { label: string; status?: string }) {
   return (
     <div className={`rounded-2xl border p-4 ${statusClass(status)}`} data-contrast-badge>
       <p className="text-xs font-semibold uppercase tracking-[0.18em] opacity-80">{label}</p>
-      <p className="mt-2 text-2xl font-semibold">{status ?? 'unknown'}</p>
+      <p className="mt-2 flex items-center gap-2 text-2xl font-semibold"><span aria-hidden="true">●</span>{status ?? 'unknown'}</p>
     </div>
   );
 }
@@ -84,9 +84,9 @@ function PluginRows({ health }: { health: HealthResponse }) {
     <ul className="grid gap-2">
       {items.map((plugin) => (
         <li key={plugin.name} className="flex flex-col gap-2 rounded-xl border border-white/10 bg-white/[0.03] p-3 sm:flex-row sm:items-center sm:justify-between">
-          <a className="focus-ring font-mono text-sm text-teal-100 hover:text-teal-200" href={pluginHealthPath(plugin)}>{plugin.name}</a>
-          <span className={`rounded-full border px-2 py-1 text-xs ${statusClass(plugin.status)}`} data-contrast-badge>{plugin.status}</span>
-          {plugin.error ? <span className="text-sm text-amber-200">{plugin.error}</span> : null}
+          <a className="focus-ring font-mono text-sm text-[color:var(--color-accent,#0f766e)] hover:text-[color:var(--color-accent,#0f766e)]" href={pluginHealthPath(plugin)}>{plugin.name}</a>
+          <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs ${statusClass(plugin.status)}`} data-contrast-badge><span aria-hidden="true">●</span>{plugin.status}</span>
+          {plugin.error ? <span className="text-sm text-[color:var(--color-warn-text,#92400e)]">{plugin.error}</span> : null}
         </li>
       ))}
     </ul>
@@ -101,8 +101,8 @@ function ProxyRows({ vector }: { vector: VectorHealthForStatus | null }) {
       {rows.map((row) => (
         <li key={`${row.name}-${row.endpoint}`} className="rounded-xl border border-white/10 bg-white/[0.03] p-3">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <span className="font-mono text-sm text-teal-100">{row.name}</span>
-            <span className={`rounded-full border px-2 py-1 text-xs ${statusClass(row.status === 'up' ? 'ok' : row.status)}`} data-contrast-badge>{row.status}</span>
+            <span className="font-mono text-sm text-[color:var(--color-accent,#0f766e)]">{row.name}</span>
+            <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs ${statusClass(row.status === 'up' ? 'ok' : row.status)}`} data-contrast-badge><span aria-hidden="true">●</span>{row.status}</span>
           </div>
           <p className="mt-2 break-words font-mono text-xs text-slate-300">{row.endpoint}</p>
           <p className="mt-1 text-sm text-slate-400">{row.detail}</p>
@@ -148,7 +148,7 @@ export function StatusPage({ client = apiClient, initialHealth = null, initialVe
   return (
     <section className="grid gap-5" aria-labelledby="status-page-title">
       <div className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
-        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Server status</p>
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--color-accent,#0f766e)]">Server status</p>
         <h2 id="status-page-title" className="mt-2 text-2xl font-semibold text-white">Health overview</h2>
         <p className="mt-2 text-sm text-slate-400">Live health from GET /api/v1/health.</p>
       </div>
@@ -181,7 +181,7 @@ export function StatusPage({ client = apiClient, initialHealth = null, initialVe
           <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-label="Proxy status rows">
             <h3 className="text-lg font-semibold text-white">Proxy status</h3>
             <p className="mt-2 text-sm text-slate-400">Vector proxy and registered proxy services from /api/v1/vector/health.</p>
-            {vectorError ? <p className="mt-3 rounded-xl border border-amber-300/20 bg-amber-300/10 p-3 text-sm text-amber-100">{vectorError}</p> : null}
+            {vectorError ? <p className="mt-3 rounded-xl border border-[color:var(--color-warn-text,#92400e)] bg-[var(--color-warn-bg,#fef3c7)] p-3 text-sm text-[color:var(--color-warn-text,#92400e)]">{vectorError}</p> : null}
             <div className="mt-4"><ProxyRows vector={vectorHealth} /></div>
           </section>
         </>

--- a/frontend/src/pages/VectorCollectionList.tsx
+++ b/frontend/src/pages/VectorCollectionList.tsx
@@ -18,14 +18,14 @@ function CollectionStatus({ row }: { row: VectorConfigRow }) {
   const ok = row.health?.ok;
   const label = row.health?.status ?? 'unknown';
   const classes = ok
-    ? 'border-emerald-300/40 bg-emerald-300/10 text-emerald-200'
-    : 'border-red-300/40 bg-red-300/10 text-red-200';
-  return <span className={`inline-flex rounded-full border px-2 py-1 text-xs ${classes}`}>{label}</span>;
+    ? 'border-[color:var(--color-ok-text,#166534)] bg-[var(--color-ok-bg,#dcfce7)] text-[color:var(--color-ok-text,#166534)]'
+    : 'border-[color:var(--color-err-text,#991b1b)] bg-[var(--color-err-bg,#fee2e2)] text-[color:var(--color-err-text,#991b1b)]';
+  return <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs ${classes}`}><span aria-hidden="true">●</span>{label}</span>;
 }
 
 function PrimaryBadge({ primary }: { primary?: boolean }) {
   if (!primary) return null;
-  return <span className="rounded-full border border-teal-300/40 bg-teal-300/10 px-2 py-1 text-xs text-teal-100">Primary</span>;
+  return <span className="inline-flex items-center gap-1 rounded-full border border-[color:var(--color-ok-text,#166534)] bg-[var(--color-ok-bg,#dcfce7)] px-2 py-1 text-xs text-[color:var(--color-ok-text,#166534)]"><span aria-hidden="true">★</span>Primary</span>;
 }
 
 export function VectorCollectionList({
@@ -44,7 +44,7 @@ export function VectorCollectionList({
     <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Collections</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--color-accent,#0f766e)]">Collections</p>
           <h2 className="mt-2 text-2xl font-semibold text-white">Collection settings</h2>
           <p className="mt-2 text-sm text-slate-400">Edit provider/model/adapter and choose the primary collection.</p>
         </div>
@@ -60,7 +60,7 @@ export function VectorCollectionList({
               <div className="mb-3 flex items-start justify-between gap-3">
                 <div>
                   <div className="flex flex-wrap items-center gap-2">
-                    <h3 className="text-base font-semibold text-teal-200">{row.collection}</h3>
+                    <h3 className="text-base font-semibold text-[color:var(--color-accent,#0f766e)]">{row.collection}</h3>
                     <PrimaryBadge primary={row.primary} />
                   </div>
                   <p className="mt-1 text-sm text-slate-400">{row.key} · {row.count ?? 0} docs · {row.adapter} · {row.enabled ? 'enabled' : 'disabled'}</p>
@@ -88,8 +88,8 @@ export function VectorCollectionList({
               </div>
 
               <div className="mt-3 flex flex-wrap gap-2">
-                <button className="focus-ring rounded-xl border border-teal-300/30 px-3 py-2 text-sm font-semibold text-teal-100 disabled:opacity-50" disabled={!dirty || saving[row.key]} type="button" onClick={() => onSave(row.key)}>{saving[row.key] ? <Spinner label="Saving" /> : 'Save'}</button>
-                <button className="focus-ring rounded-xl border border-purple-300/30 px-3 py-2 text-sm font-semibold text-purple-100 disabled:opacity-50" disabled={testing[row.key]} type="button" onClick={() => onTest(row.key)}>{testing[row.key] ? <Spinner label="Testing" /> : 'Test'}</button>
+                <button className="focus-ring rounded-xl border border-[color:var(--color-accent,#0f766e)] px-3 py-2 text-sm font-semibold text-[color:var(--color-accent,#0f766e)] disabled:opacity-50" disabled={!dirty || saving[row.key]} type="button" onClick={() => onSave(row.key)}>{saving[row.key] ? <Spinner label="Saving" /> : 'Save'}</button>
+                <button className="focus-ring rounded-xl border border-[color:var(--color-accent2,#7e22ce)] px-3 py-2 text-sm font-semibold text-[color:var(--color-accent2,#7e22ce)] disabled:opacity-50" disabled={testing[row.key]} type="button" onClick={() => onTest(row.key)}>{testing[row.key] ? <Spinner label="Testing" /> : 'Test'}</button>
                 <button className="focus-ring rounded-xl border border-cyan-300/30 px-3 py-2 text-sm font-semibold text-cyan-100 disabled:opacity-50" disabled={row.primary || primarySaving === row.key} type="button" onClick={() => onPrimary(row.key)}>{primarySaving === row.key ? <Spinner label="Setting" /> : 'Set primary'}</button>
               </div>
               {actionMessage[row.key] ? <p className="mt-2 text-sm text-slate-500">{actionMessage[row.key]}</p> : null}

--- a/frontend/src/pages/VectorDocumentsPage.tsx
+++ b/frontend/src/pages/VectorDocumentsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { apiUrl } from '../api/oracle';
+import { apiFetch } from '../api/oracle';
 
 type LoadState = 'idle' | 'loading' | 'ready' | 'error';
 
@@ -50,7 +50,7 @@ function isAbort(error: unknown): boolean {
 }
 
 async function fetchJson<T>(path: string, signal?: AbortSignal): Promise<T> {
-  const response = await fetch(apiUrl(path), { headers: { accept: 'application/json' }, signal });
+  const response = await apiFetch(path, { headers: { accept: 'application/json' }, signal });
   const text = await response.text();
   const data = text ? JSON.parse(text) : {};
   if (!response.ok) throw new Error(`${path} returned ${response.status}`);

--- a/frontend/src/pages/VectorExportPage.tsx
+++ b/frontend/src/pages/VectorExportPage.tsx
@@ -148,7 +148,7 @@ export function VectorExportPage({
         <p className="text-sm text-slate-500">{status}</p>
         {downloadError ? <ErrorMessage title="Vector export failed." message={downloadError} /> : null}
         <div className="flex flex-wrap gap-2">
-          <button className="focus-ring rounded-xl border border-teal-300/30 px-4 py-2 text-sm font-semibold text-teal-100 hover:bg-teal-300/10 disabled:cursor-not-allowed disabled:opacity-50" data-contrast-badge disabled={!collection || Boolean(downloading) || formatOptions.length === 0} type="button" onClick={() => void exportSelected()}>
+          <button className="focus-ring rounded-xl border border-[color:var(--color-accent,#0f766e)] px-4 py-2 text-sm font-semibold text-[color:var(--color-accent,#0f766e)] hover:bg-[var(--color-ok-bg,#dcfce7)] disabled:cursor-not-allowed disabled:opacity-50 dark:border-[color:var(--color-accent,#5eead4)] dark:text-[color:var(--color-accent,#5eead4)] dark:hover:bg-[var(--color-ok-bg,#064e3b)]" data-contrast-badge disabled={!collection || Boolean(downloading) || formatOptions.length === 0} type="button" onClick={() => void exportSelected()}>
             {downloading ? <Spinner label={`Downloading ${formatLabelFor(formatOptions, downloading)}`} /> : 'Export'}
           </button>
         </div>

--- a/frontend/src/pages/VectorSearchPage.tsx
+++ b/frontend/src/pages/VectorSearchPage.tsx
@@ -75,7 +75,7 @@ function ResultCard({ result }: { result: VectorSearchResult }) {
           <h2 className="text-base font-semibold text-white">{titleFor(result)}</h2>
           <p className="mt-1 text-sm leading-6 text-slate-300">{contentPreview(result.content)}</p>
         </div>
-        <span className="rounded-full border border-teal-300/20 bg-teal-300/10 px-2 py-1 text-xs font-semibold text-teal-100">
+        <span className="rounded-full border border-[color:var(--color-accent,#0f766e)] px-2 py-1 text-xs font-semibold text-[color:var(--color-accent,#0f766e)]">
           distance {distanceLabel(result)}
         </span>
       </div>
@@ -88,7 +88,7 @@ function ResultCard({ result }: { result: VectorSearchResult }) {
         <div><dt className="font-semibold text-slate-300">type</dt><dd>{result.type || '—'}</dd></div>
         <div><dt className="font-semibold text-slate-300">source_file</dt><dd className="break-all">{result.source_file || '—'}</dd></div>
         <div><dt className="font-semibold text-slate-300">model</dt><dd>{result.model || 'selected collection'}</dd></div>
-        {concepts.length ? <div className="sm:col-span-3"><dt className="font-semibold text-slate-300">concepts</dt><dd className="mt-1 flex flex-wrap gap-1">{concepts.map((concept) => <span key={concept} className="rounded-full bg-teal-400/10 px-2 py-0.5 text-teal-100">{concept}</span>)}</dd></div> : null}
+        {concepts.length ? <div className="sm:col-span-3"><dt className="font-semibold text-slate-300">concepts</dt><dd className="mt-1 flex flex-wrap gap-1">{concepts.map((concept) => <span key={concept} className="rounded-full border border-[color:var(--color-accent,#0f766e)] px-2 py-0.5 text-[color:var(--color-accent,#0f766e)]">{concept}</span>)}</dd></div> : null}
       </dl>
     </article>
   );
@@ -148,7 +148,7 @@ export function VectorSearchPage({ client = apiClient }: { client?: VectorSearch
   return (
     <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-search-preview-title">
       <div className="mb-5">
-        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Vector</p>
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--color-accent,#0f766e)]">Vector</p>
         <h1 id="vector-search-preview-title" className="mt-2 text-3xl font-semibold text-white">Vector search preview</h1>
         <p className="mt-2 text-sm text-slate-400">Preview semantic matches from /api/v1/vector/search by collection.</p>
       </div>
@@ -164,7 +164,7 @@ export function VectorSearchPage({ client = apiClient }: { client?: VectorSearch
       </form>
 
       <p className="mt-4 text-sm text-slate-500">{status}</p>
-      {error ? <p role="alert" className="mt-3 rounded-xl border border-red-400/30 bg-red-950/40 p-3 text-sm text-red-100">{error}</p> : null}
+      {error ? <p role="alert" className="mt-3 rounded-xl border border-[color:var(--color-err-text,#991b1b)] bg-[var(--color-err-bg,#fee2e2)] p-3 text-sm text-[color:var(--color-err-text,#991b1b)]">{error}</p> : null}
       <div className="mt-5 grid gap-3 lg:grid-cols-2" aria-busy={state === 'loading'}>
         {state !== 'loading' ? results.map((result) => <ResultCard key={result.id} result={result} />) : null}
       </div>

--- a/frontend/src/pages/vector-dashboard-cards.tsx
+++ b/frontend/src/pages/vector-dashboard-cards.tsx
@@ -23,8 +23,8 @@ type VectorTotals = {
 
 function statusClasses(healthy: boolean): string {
   return healthy
-    ? 'border-emerald-300/30 bg-emerald-300/10 text-emerald-200'
-    : 'border-red-300/30 bg-red-300/10 text-red-100';
+    ? 'border-[color:var(--color-ok-text,#166534)] bg-[var(--color-ok-bg,#dcfce7)] text-[color:var(--color-ok-text,#166534)]'
+    : 'border-[color:var(--color-err-text,#991b1b)] bg-[var(--color-err-bg,#fee2e2)] text-[color:var(--color-err-text,#991b1b)]';
 }
 
 export function docCountLabel(count?: number): string {
@@ -80,7 +80,7 @@ export function VectorCollectionCards({
               <div><dt className="text-slate-500">Model</dt><dd className="font-medium text-slate-100">{card.model}</dd></div>
               <div><dt className="text-slate-500">Documents</dt><dd className="font-medium text-slate-100">{docCountLabel(card.count)}</dd></div>
             </dl>
-            {card.healthDetail ? <p className="mt-3 text-xs text-red-200">{card.healthDetail}</p> : null}
+            {card.healthDetail ? <p className="mt-3 text-xs text-[color:var(--color-err-text,#991b1b)]">{card.healthDetail}</p> : null}
             <div className="mt-4 flex flex-wrap gap-2">
               <select
                 aria-label={`Export format for ${card.collection}`}
@@ -92,7 +92,7 @@ export function VectorCollectionCards({
                 {formats?.map((format) => <option key={format.format} value={format.format}>{format.label}</option>)}
               </select>
               <button
-                className="focus-ring rounded-xl border border-teal-300/30 px-3 py-2 text-sm font-semibold text-teal-100 hover:bg-teal-300/10 disabled:cursor-not-allowed disabled:opacity-50"
+                className="focus-ring rounded-xl border border-[color:var(--color-accent,#0f766e)] px-3 py-2 text-sm font-semibold text-[color:var(--color-accent,#0f766e)] hover:bg-[var(--color-ok-bg,#dcfce7)] disabled:cursor-not-allowed disabled:opacity-50"
                 disabled={disabled || !formats || formats.length === 0}
                 type="button"
                 onClick={() => onExport?.(card.collection, selected)}
@@ -110,7 +110,7 @@ export function VectorCollectionCards({
 export function VectorStatsCard({ cards }: { cards: VectorCollectionCard[] }) {
   return (
     <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-stats-title">
-      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Stats</p>
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--color-accent,#0f766e)]">Stats</p>
       <h2 id="vector-stats-title" className="mt-2 text-2xl font-semibold text-white">Collection stats</h2>
       <dl className="mt-4 grid gap-3 text-sm text-slate-300">
         <div><dt className="text-slate-500">Total docs</dt><dd className="text-lg font-semibold text-white">{docsLabel(cards)}</dd></div>
@@ -142,7 +142,7 @@ export function QuickExportCard({
   if (!cards.length) {
     return (
       <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-quick-export-title">
-        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Quick export</p>
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--color-accent,#0f766e)]">Quick export</p>
         <h2 id="vector-quick-export-title" className="mt-2 text-2xl font-semibold text-white">Export collection</h2>
         <p className="mt-2 text-sm text-slate-400">No collections are loaded yet.</p>
       </section>
@@ -154,7 +154,7 @@ export function QuickExportCard({
   const disabled = isDownloading || formats.length === 0;
   return (
     <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-quick-export-title">
-      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Quick export</p>
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--color-accent,#0f766e)]">Quick export</p>
       <h2 id="vector-quick-export-title" className="mt-2 text-2xl font-semibold text-white">Export collection</h2>
       <p className="mt-2 text-sm text-slate-400">Pick a collection and format to download from /api/v1/vector/export.</p>
       <div className="mt-4 grid gap-3 sm:grid-cols-2">
@@ -182,7 +182,7 @@ export function QuickExportCard({
         </label>
       </div>
       <button
-        className="focus-ring mt-4 rounded-xl border border-teal-300/30 px-4 py-2 text-sm font-semibold text-teal-100 hover:bg-teal-300/10 disabled:cursor-not-allowed disabled:opacity-50"
+        className="focus-ring mt-4 rounded-xl border border-[color:var(--color-accent,#0f766e)] px-4 py-2 text-sm font-semibold text-[color:var(--color-accent,#0f766e)] hover:bg-[var(--color-ok-bg,#dcfce7)] disabled:cursor-not-allowed disabled:opacity-50"
         disabled={disabled || !collection}
         type="button"
         onClick={() => onExport(collection, format)}

--- a/frontend/src/pages/vector-health-dashboard-card.tsx
+++ b/frontend/src/pages/vector-health-dashboard-card.tsx
@@ -18,8 +18,8 @@ export type VectorFreshnessCard = {
 
 function statusClasses(healthy: boolean): string {
   return healthy
-    ? 'border-emerald-300/30 bg-emerald-300/10 text-emerald-200'
-    : 'border-red-300/30 bg-red-300/10 text-red-100';
+    ? 'border-[color:var(--color-ok-text,#166534)] bg-[var(--color-ok-bg,#dcfce7)] text-[color:var(--color-ok-text,#166534)]'
+    : 'border-[color:var(--color-err-text,#991b1b)] bg-[var(--color-err-bg,#fee2e2)] text-[color:var(--color-err-text,#991b1b)]';
 }
 
 function freshnessLine(freshness: VectorFreshnessCard): string {
@@ -60,7 +60,7 @@ export function VectorHealthDashboardCard({
     : 'Storage status unavailable';
   return (
     <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 sm:p-6" aria-labelledby="vector-health-dashboard-title">
-      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-teal-300">Health</p>
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--color-accent,#0f766e)]">Health</p>
       <h2 id="vector-health-dashboard-title" className="mt-2 text-2xl font-semibold text-white">Vector health dashboard</h2>
       <dl className="mt-4 grid gap-3 text-sm text-slate-300">
         <div><dt className="text-slate-500">Embedding providers</dt><dd className="text-lg font-semibold text-white">{providerSummary}</dd></div>
@@ -70,9 +70,9 @@ export function VectorHealthDashboardCard({
         <div><dt className="text-slate-500">Docs pending</dt><dd className="text-lg font-semibold text-white">{pendingLine(freshness)}</dd></div>
         <div><dt className="text-slate-500">Last indexed</dt><dd className="text-lg font-semibold text-white">{freshness?.lastIndexed ?? 'Unknown'}</dd></div>
       </dl>
-      {providers.length ? <div className="mt-4 flex flex-wrap gap-2">{providers.map((provider) => <span key={provider.type} className={`rounded-full border px-2 py-1 text-xs font-semibold ${statusClasses(provider.available)}`}>{provider.type}: {provider.status}</span>)}</div> : null}
-      {services.length ? <div className="mt-2 flex flex-wrap gap-2">{services.map((service) => <span key={service.name} className={`rounded-full border px-2 py-1 text-xs font-semibold ${statusClasses(service.status === 'green')}`}>{serviceDetail(service)}</span>)}</div> : null}
-      {storage.length ? <div className="mt-2 flex flex-wrap gap-2">{storage.map((item) => <span key={item.adapter} className={`rounded-full border px-2 py-1 text-xs font-semibold ${statusClasses(item.status === 'green')}`}>{item.adapter}: {item.healthy}/{item.total}</span>)}</div> : null}
+      {providers.length ? <div className="mt-4 flex flex-wrap gap-2">{providers.map((provider) => <span key={provider.type} className={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs font-semibold ${statusClasses(provider.available)}`}><span aria-hidden="true">●</span>{provider.type}: {provider.status}</span>)}</div> : null}
+      {services.length ? <div className="mt-2 flex flex-wrap gap-2">{services.map((service) => <span key={service.name} className={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs font-semibold ${statusClasses(service.status === 'green')}`}><span aria-hidden="true">●</span>{serviceDetail(service)}</span>)}</div> : null}
+      {storage.length ? <div className="mt-2 flex flex-wrap gap-2">{storage.map((item) => <span key={item.adapter} className={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs font-semibold ${statusClasses(item.status === 'green')}`}><span aria-hidden="true">●</span>{item.adapter}: {item.healthy}/{item.total}</span>)}</div> : null}
     </section>
   );
 }

--- a/frontend/src/pages/vectorSettingsHelpers.ts
+++ b/frontend/src/pages/vectorSettingsHelpers.ts
@@ -1,4 +1,4 @@
-import { apiUrl } from '../api/oracle';
+import { apiFetch } from '../api/oracle';
 
 export const ADAPTER_OPTIONS = ['chroma', 'sqlite-vec', 'lancedb', 'qdrant', 'cloudflare-vectorize', 'proxy', 'turbovec'] as const;
 export type VectorConfigAdapter = (typeof ADAPTER_OPTIONS)[number];
@@ -177,7 +177,7 @@ export function toRows(response: VectorConfigResponse): VectorConfigRow[] {
 }
 
 export async function fetchJson<T>(path: string, init: RequestInit = {}): Promise<T> {
-  const response = await fetch(apiUrl(path), {
+  const response = await apiFetch(path, {
     headers: { accept: 'application/json', 'content-type': 'application/json', ...(init.headers ?? {}) },
     ...init,
   });

--- a/frontend/src/vectorExport.ts
+++ b/frontend/src/vectorExport.ts
@@ -1,4 +1,4 @@
-import { apiUrl } from './api/oracle';
+import { apiUrl, withLocalPna } from './api/oracle';
 
 export type VectorExportFormat = string;
 
@@ -67,7 +67,7 @@ export async function fetchVectorExportFormats(deps: { fetch?: ExportFetch } = {
   const fetcher = deps.fetch ?? globalThis.fetch?.bind(globalThis);
   if (!fetcher) throw new Error('fetch is unavailable');
   const path = vectorExportFormatsPath();
-  const response = await fetcher(apiUrl(path), { headers: { accept: 'application/json' } });
+  const response = await fetcher(apiUrl(path), withLocalPna({ headers: { accept: 'application/json' } }));
   if (!response.ok) throw new Error(`${path} returned ${response.status}`);
   return normalizeVectorExportFormats(await response.json());
 }
@@ -83,9 +83,9 @@ export async function downloadVectorCollection(
 ): Promise<void> {
   const fetcher = deps.fetch ?? globalThis.fetch?.bind(globalThis);
   if (!fetcher) throw new Error('fetch is unavailable');
-  const response = await fetcher(apiUrl(vectorExportPath(collection, format)), {
+  const response = await fetcher(apiUrl(vectorExportPath(collection, format)), withLocalPna({
     headers: { accept: acceptHeader(format) },
-  });
+  }));
   if (!response.ok) throw new Error('/api/v1/vector/export returned ' + response.status);
   await (deps.saveBlob ?? saveBlobAsDownload)(await response.blob(), vectorExportFilename(collection, format));
 }

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260616.1",
+    "@playwright/test": "1.61.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.17.9",
     "better-sqlite3": "^12.9.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,18 +2,21 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests/e2e',
-  // Use .e2e.ts (not .spec.ts) so `bun test` doesn't try to load these —
-  // bun's runner auto-discovers **/*.{test,spec}.ts and would fail to
-  // import @playwright/test (a separate dep/runner).
-  testMatch: /.*\.e2e\.ts$/,
+  testMatch: [/.*\.e2e\.ts$/, /contrast\.spec\.ts$/],
   timeout: 30000,
-  use: {
-    baseURL: 'http://localhost:47778',
-  },
-  webServer: {
-    command: 'bun run src/server.ts',
-    url: 'http://localhost:47778/api/health',
-    reuseExistingServer: !process.env.CI,
-    timeout: 30000,
-  },
+  use: { baseURL: 'http://127.0.0.1:3000' },
+  webServer: [
+    {
+      command: 'bun run src/server.ts',
+      url: 'http://127.0.0.1:47778/api/health',
+      reuseExistingServer: !process.env.CI,
+      timeout: 30000,
+    },
+    {
+      command: 'cd frontend && bun run dev',
+      url: 'http://127.0.0.1:3000',
+      reuseExistingServer: !process.env.CI,
+      timeout: 30000,
+    },
+  ],
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,22 +1,58 @@
 import { defineConfig } from '@playwright/test';
 
+const backendPort = process.env.PLAYWRIGHT_BACKEND_PORT ?? '47789';
+const frontendPort = process.env.PLAYWRIGHT_FRONTEND_PORT ?? '3310';
+const vectorPort = process.env.PLAYWRIGHT_VECTOR_PORT ?? '47790';
+const backendURL = process.env.PLAYWRIGHT_BACKEND_URL ?? `http://127.0.0.1:${backendPort}`;
+const frontendURL = process.env.PLAYWRIGHT_FRONTEND_URL ?? `http://127.0.0.1:${frontendPort}`;
+const vectorURL = process.env.PLAYWRIGHT_VECTOR_URL ?? `http://127.0.0.1:${vectorPort}`;
+const reuseExistingServer = !process.env.CI;
+const e2eDataDir = '.tmp/playwright-oracle-e2e';
+
 export default defineConfig({
   testDir: './tests/e2e',
   testMatch: [/.*\.e2e\.ts$/, /contrast\.spec\.ts$/],
   timeout: 30000,
-  use: { baseURL: 'http://127.0.0.1:3000' },
+  use: {
+    baseURL: frontendURL,
+  },
   webServer: [
     {
-      command: 'bun run src/server.ts',
-      url: 'http://127.0.0.1:47778/api/health',
-      reuseExistingServer: !process.env.CI,
+      command: 'bun run tests/e2e/vector-sidecar-fixture.ts',
+      url: `${vectorURL}/api/vector/health`,
+      reuseExistingServer,
       timeout: 30000,
+      env: {
+        ...process.env,
+        PLAYWRIGHT_VECTOR_PORT: vectorPort,
+      },
     },
     {
-      command: 'cd frontend && bun run dev',
-      url: 'http://127.0.0.1:3000',
-      reuseExistingServer: !process.env.CI,
+      command: 'bun run src/server.ts',
+      url: `${backendURL}/api/health`,
+      reuseExistingServer,
       timeout: 30000,
+      env: {
+        ...process.env,
+        ORACLE_PORT: backendPort,
+        ORACLE_DATA_DIR: e2eDataDir,
+        ORACLE_DB_PATH: `${e2eDataDir}/oracle.db`,
+        ORACLE_EMBEDDER: 'none',
+        VECTOR_URL: vectorURL,
+        ORACLE_FILE_WATCHER: '0',
+        ORACLE_GATEWAY_HOT_RELOAD: '0',
+      },
+    },
+    {
+      command: 'cd frontend && bun run dev --host 127.0.0.1',
+      url: frontendURL,
+      reuseExistingServer,
+      timeout: 30000,
+      env: {
+        ...process.env,
+        FRONTEND_PROXY_TARGET: backendURL,
+        VITE_PORT: frontendPort,
+      },
     },
   ],
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,14 @@
 import { defineConfig } from '@playwright/test';
 
+const backendPort = process.env.PLAYWRIGHT_BACKEND_PORT ?? '47789';
+const frontendPort = process.env.PLAYWRIGHT_FRONTEND_PORT ?? '3310';
+const vectorPort = process.env.PLAYWRIGHT_VECTOR_PORT ?? '47790';
+const backendURL = process.env.PLAYWRIGHT_BACKEND_URL ?? `http://127.0.0.1:${backendPort}`;
+const frontendURL = process.env.PLAYWRIGHT_FRONTEND_URL ?? `http://127.0.0.1:${frontendPort}`;
+const vectorURL = process.env.PLAYWRIGHT_VECTOR_URL ?? `http://127.0.0.1:${vectorPort}`;
+const reuseExistingServer = !process.env.CI;
+const e2eDataDir = '.tmp/playwright-oracle-e2e';
+
 export default defineConfig({
   testDir: './tests/e2e',
   // Use .e2e.ts (not .spec.ts) so `bun test` doesn't try to load these —
@@ -8,12 +17,45 @@ export default defineConfig({
   testMatch: /.*\.e2e\.ts$/,
   timeout: 30000,
   use: {
-    baseURL: 'http://localhost:47778',
+    baseURL: frontendURL,
   },
-  webServer: {
-    command: 'bun run src/server.ts',
-    url: 'http://localhost:47778/api/health',
-    reuseExistingServer: !process.env.CI,
-    timeout: 30000,
-  },
+  webServer: [
+    {
+      command: 'bun run tests/e2e/vector-sidecar-fixture.ts',
+      url: `${vectorURL}/api/vector/health`,
+      reuseExistingServer,
+      timeout: 30000,
+      env: {
+        ...process.env,
+        PLAYWRIGHT_VECTOR_PORT: vectorPort,
+      },
+    },
+    {
+      command: 'bun run src/server.ts',
+      url: `${backendURL}/api/health`,
+      reuseExistingServer,
+      timeout: 30000,
+      env: {
+        ...process.env,
+        ORACLE_PORT: backendPort,
+        ORACLE_DATA_DIR: e2eDataDir,
+        ORACLE_DB_PATH: `${e2eDataDir}/oracle.db`,
+        ORACLE_EMBEDDER: 'none',
+        VECTOR_URL: vectorURL,
+        ORACLE_FILE_WATCHER: '0',
+        ORACLE_GATEWAY_HOT_RELOAD: '0',
+      },
+    },
+    {
+      command: 'cd frontend && bun run dev --host 127.0.0.1',
+      url: frontendURL,
+      reuseExistingServer,
+      timeout: 30000,
+      env: {
+        ...process.env,
+        FRONTEND_PROXY_TARGET: backendURL,
+        VITE_PORT: frontendPort,
+      },
+    },
+  ],
 });

--- a/src/gateway/__tests__/config-watch.test.ts
+++ b/src/gateway/__tests__/config-watch.test.ts
@@ -6,6 +6,14 @@ import { watchGatewayConfig, type GatewayConfig } from '../config.ts';
 
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
+async function waitFor(predicate: () => boolean, timeoutMs = 1500): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await wait(50);
+  }
+}
+
 describe('watchGatewayConfig', () => {
   it('fires onChange when the config file is created', async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-gateway-watch-'));
@@ -90,6 +98,30 @@ describe('watchGatewayConfig', () => {
       await wait(450);
       expect(calls.length).toBe(count);
       expect(calls[calls.length - 1]?.services.v.url).toBe('http://localhost:1');
+    } finally {
+      stop();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('retries a hot-reload change when the reload callback throws', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-gateway-watch-'));
+    const file = path.join(dir, 'oracle-gateway.json');
+    let calls = 0;
+    const applied: Array<GatewayConfig | null> = [];
+    const stop = watchGatewayConfig(dir, (next) => {
+      calls += 1;
+      if (calls === 1) throw new Error('reload failed');
+      applied.push(next);
+    });
+    try {
+      fs.writeFileSync(file, JSON.stringify({
+        services: { v: { url: 'http://localhost:1', timeout: 1000 } },
+        routes: [{ match: '/api/search', service: 'v', fallback: 'fts5' }],
+      }));
+      await waitFor(() => calls >= 2);
+      expect(calls).toBeGreaterThanOrEqual(2);
+      expect(applied[0]?.services.v.url).toBe('http://localhost:1');
     } finally {
       stop();
       fs.rmSync(dir, { recursive: true, force: true });

--- a/src/gateway/__tests__/state-snapshot.test.ts
+++ b/src/gateway/__tests__/state-snapshot.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { gatewayPlugin } from '../index.ts';
+import { registerHook, type GatewayContext } from '../hooks.ts';
+
+const PAUSE_HOOK = 'test-gateway-snapshot-pause';
+const OLD_RESPONSE_HOOK = 'test-gateway-snapshot-old';
+const NEW_RESPONSE_HOOK = 'test-gateway-snapshot-new';
+
+let pause: { entered: () => void; wait: Promise<void> } | undefined;
+
+registerHook({
+  name: PAUSE_HOOK,
+  phase: 'onRequest',
+  handler: async () => {
+    pause?.entered();
+    await pause?.wait;
+  },
+});
+
+function tagResponse(tag: string) {
+  return (ctx: GatewayContext): Response => {
+    const response = ctx.response ?? new Response();
+    const headers = new Headers(response.headers);
+    headers.set('x-gateway-snapshot', tag);
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  };
+}
+
+registerHook({ name: OLD_RESPONSE_HOOK, phase: 'onResponse', handler: tagResponse('old') });
+registerHook({ name: NEW_RESPONSE_HOOK, phase: 'onResponse', handler: tagResponse('new') });
+
+function writeConfig(dir: string, url: string, hooks: Record<string, string[]>) {
+  fs.writeFileSync(path.join(dir, 'oracle-gateway.json'), JSON.stringify({
+    services: { upstream: { url, timeout: 1000 } },
+    routes: [{ match: '/api/snapshot', service: 'upstream', fallback: 'error' }],
+    hooks,
+  }));
+}
+
+async function waitUntil(predicate: () => Promise<boolean>) {
+  const deadline = Date.now() + 1000;
+  while (!(await predicate())) {
+    if (Date.now() > deadline) throw new Error('timed out waiting for gateway reload');
+    await Bun.sleep(10);
+  }
+}
+
+function restoreHotReload(value: string | undefined) {
+  if (value === undefined) delete process.env.ORACLE_GATEWAY_HOT_RELOAD;
+  else process.env.ORACLE_GATEWAY_HOT_RELOAD = value;
+}
+
+describe('gateway runtime state snapshots', () => {
+  test('keeps one request on its original hook pipeline during hot reload', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-gateway-snapshot-'));
+    const savedHotReload = process.env.ORACLE_GATEWAY_HOT_RELOAD;
+    const oldServer = Bun.serve({ hostname: '127.0.0.1', port: 0, fetch: () => new Response('old-upstream') });
+    const newServer = Bun.serve({ hostname: '127.0.0.1', port: 0, fetch: () => new Response('new-upstream') });
+
+    try {
+      process.env.ORACLE_GATEWAY_HOT_RELOAD = '1';
+      writeConfig(dir, `http://127.0.0.1:${oldServer.port}`, {
+        onRequest: [PAUSE_HOOK],
+        onResponse: [OLD_RESPONSE_HOOK],
+      });
+      const app = new Elysia().use(gatewayPlugin(dir));
+      let entered!: () => void;
+      let release!: () => void;
+      const started = new Promise<void>((resolve) => { entered = resolve; });
+      const wait = new Promise<void>((resolve) => { release = resolve; });
+      pause = { entered, wait };
+
+      const inFlight = app.handle(new Request('http://localhost/api/snapshot'));
+      await started;
+      const newUrl = `http://127.0.0.1:${newServer.port}`;
+      writeConfig(dir, newUrl, { onResponse: [NEW_RESPONSE_HOOK] });
+      await waitUntil(async () => {
+        const res = await app.handle(new Request('http://localhost/api/gateway/status'));
+        const body = await res.json() as { services?: { upstream?: { url: string } } };
+        return body.services?.upstream?.url === newUrl;
+      });
+
+      release();
+      const response = await inFlight;
+
+      expect(await response.text()).toBe('old-upstream');
+      expect(response.headers.get('x-gateway-snapshot')).toBe('old');
+    } finally {
+      pause = undefined;
+      restoreHotReload(savedHotReload);
+      await oldServer.stop(true);
+      await newServer.stop(true);
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/gateway/config.ts
+++ b/src/gateway/config.ts
@@ -43,6 +43,10 @@ function discoveredVectorServices(): RegisteredVectorService[] {
 }
 export { discoveredVectorServices as discoverGatewayVectorServices };
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 export function loadGatewayConfig(
   dataDir: string,
   vectorUrl?: string,
@@ -123,9 +127,13 @@ export function watchGatewayConfig(
     }
     const serialized = JSON.stringify(next);
     if (serialized === last) return;
-    last = serialized;
     console.log('[Gateway] Config changed — reloading');
-    onChange(next);
+    try {
+      onChange(next);
+      last = serialized;
+    } catch (error) {
+      console.warn(`[Gateway] Config reload callback failed: ${errorMessage(error)}`);
+    }
   };
 
   const tick = (): void => {

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -15,7 +15,8 @@ import { discoverGatewayVectorServices, loadGatewayConfig, watchGatewayConfig, t
 import { compileRoutes, matchRoute, type CompiledRoute } from './matcher.ts';
 import { proxyToService } from './proxy.ts';
 import { HealthRegistry, type ServiceHealth } from './health.ts';
-import { loadHooks, runHooks, type GatewayContext } from './hooks.ts';
+import { runHooks, type GatewayContext } from './hooks.ts';
+import { createGatewayState, describeGatewayState, type GatewayState } from './state.ts';
 
 // Register built-in hooks (side-effect imports)
 import './hooks/request-logger.ts';
@@ -26,27 +27,6 @@ import './hooks/rate-limit.ts';
 
 export { loadGatewayConfig, compileRoutes, matchRoute, proxyToService, HealthRegistry };
 export type { GatewayConfig, CompiledRoute, ServiceHealth };
-
-/**
- * Mutable state holder so the watcher can swap routes/services/hooks in
- * place without restarting the Elysia plugin. The request handler reads
- * from `state.*` at request time, so the swap takes effect immediately.
- */
-interface GatewayState {
-  config: GatewayConfig;
-  compiled: CompiledRoute[];
-  hooks: ReturnType<typeof loadHooks>;
-  registry: HealthRegistry;
-}
-
-function describeState(state: GatewayState): string {
-  const hookCount =
-    state.hooks.onRequest.length + state.hooks.onResponse.length + state.hooks.onError.length;
-  return (
-    `${state.config.routes.length} route(s), ${Object.keys(state.config.services).length} service(s)` +
-    (hookCount > 0 ? `, ${hookCount} hook(s)` : '')
-  );
-}
 
 function emptyFallbackResponse(pathname: string): Response {
   let payload: Record<string, unknown>;
@@ -110,30 +90,27 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
   // Even when no config exists at startup, install the watcher so the
   // gateway can pick up a file that's created later (unless explicitly
   // disabled via ORACLE_GATEWAY_HOT_RELOAD=0).
-  const buildState = (cfg: GatewayConfig): GatewayState => {
-    const registry = new HealthRegistry();
-    registry.start(cfg.services);
-    return {
-      config: cfg,
-      compiled: compileRoutes(cfg.routes),
-      hooks: loadHooks(cfg.hooks),
-      registry,
-    };
-  };
-
-  let state: GatewayState | null = initial ? buildState(initial) : null;
-  if (state) console.log(`[Gateway] Loaded ${describeState(state)}`);
+  let state: GatewayState | null = initial ? createGatewayState(initial) : null;
+  if (state) console.log(`[Gateway] Loaded ${describeGatewayState(state)}`);
 
   if (process.env.ORACLE_GATEWAY_HOT_RELOAD !== '0') {
     watchGatewayConfig(
       dataDir,
       (next) => {
-        // Stop the old health poller before swapping — it holds a timer.
-        if (state) state.registry.stop();
         if (next) {
-          state = buildState(next);
-          console.log(`[Gateway] Reloaded — ${describeState(state)}`);
+          const previous = state;
+          let replacement: GatewayState;
+          try {
+            replacement = createGatewayState(next);
+          } catch (error) {
+            console.warn('[Gateway] reload failed:', error);
+            return;
+          }
+          state = replacement;
+          previous?.registry.stop();
+          console.log(`[Gateway] Reloaded — ${describeGatewayState(state)}`);
         } else {
+          state?.registry.stop();
           state = null;
           console.log('[Gateway] Reloaded — disabled (no config)');
         }
@@ -165,17 +142,18 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
       services: state ? state.registry.getAllStatus() : {},
     }))
     .onRequest(async ({ request }) => {
-      if (!state) return; // no config loaded — fall through
+      const current = state;
+      if (!current) return; // no config loaded — fall through
 
       const url = new URL(request.url);
-      const match = matchRoute(url.pathname, state.compiled);
+      const match = matchRoute(url.pathname, current.compiled);
       if (!match) return; // no match — fall through to local Elysia routes
 
-      const service = state.config.services[match.service];
+      const service = current.config.services[match.service];
       if (!service || match.service === 'local') return; // "local" = handle locally
 
       // If health registry says service is down, return fallback immediately
-      if (!state.registry.isUp(match.service)) {
+      if (!current.registry.isUp(match.service)) {
         const fallback = match.fallback ?? 'error';
         if (fallback === 'empty') return emptyFallbackResponse(url.pathname);
         if (fallback === 'fts5') return;
@@ -188,16 +166,16 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
         service,
         // Surface per-hook options so hooks can be config-driven without
         // module-level globals. Hooks read ctx.meta.hook_options['<name>'].
-        meta: { hook_options: state.config.hook_options ?? {} },
+        meta: { hook_options: current.config.hook_options ?? {} },
       };
 
       // ── onRequest hooks ──
       try {
-        const early = await runHooks(state.hooks.onRequest, ctx);
+        const early = await runHooks(current.hooks.onRequest, ctx);
         if (early) return early;
       } catch (err) {
         ctx.error = err instanceof Error ? err : new Error(String(err));
-        const errResp = await runErrorHooks(state, ctx);
+        const errResp = await runErrorHooks(current, ctx);
         if (errResp) return errResp;
         if (ctx.meta.fallback_to_local) return; // fall through to local Elysia
         throw err;
@@ -209,7 +187,7 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
         response = await proxyToService(request, service);
       } catch (err) {
         ctx.error = err instanceof Error ? err : new Error(String(err));
-        const errResp = await runErrorHooks(state, ctx);
+        const errResp = await runErrorHooks(current, ctx);
         if (errResp) return errResp;
         if (ctx.meta.fallback_to_local) return; // fall through to local Elysia
         throw err;
@@ -227,11 +205,11 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
       // ── onResponse hooks ──
       ctx.response = response;
       try {
-        const override = await runHooks(state.hooks.onResponse, ctx);
+        const override = await runHooks(current.hooks.onResponse, ctx);
         if (override) return override;
       } catch (err) {
         ctx.error = err instanceof Error ? err : new Error(String(err));
-        const errResp = await runErrorHooks(state, ctx);
+        const errResp = await runErrorHooks(current, ctx);
         if (errResp) return errResp;
         if (ctx.meta.fallback_to_local) return;
         throw err;

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -99,16 +99,10 @@ export function gatewayPlugin(dataDir: string, vectorUrl?: string) {
       (next) => {
         if (next) {
           const previous = state;
-          let replacement: GatewayState;
-          try {
-            replacement = createGatewayState(next);
-          } catch (error) {
-            console.warn('[Gateway] reload failed:', error);
-            return;
-          }
+          const replacement = createGatewayState(next);
           state = replacement;
           previous?.registry.stop();
-          console.log(`[Gateway] Reloaded — ${describeGatewayState(state)}`);
+          console.log(`[Gateway] Reloaded — ${describeGatewayState(replacement)}`);
         } else {
           state?.registry.stop();
           state = null;

--- a/src/gateway/state.ts
+++ b/src/gateway/state.ts
@@ -1,0 +1,28 @@
+import type { GatewayConfig } from './config.ts';
+import { HealthRegistry } from './health.ts';
+import { loadHooks } from './hooks.ts';
+import { compileRoutes, type CompiledRoute } from './matcher.ts';
+
+export interface GatewayState {
+  config: GatewayConfig;
+  compiled: CompiledRoute[];
+  hooks: ReturnType<typeof loadHooks>;
+  registry: HealthRegistry;
+}
+
+export function createGatewayState(config: GatewayConfig): GatewayState {
+  const compiled = compileRoutes(config.routes);
+  const hooks = loadHooks(config.hooks);
+  const registry = new HealthRegistry();
+  registry.start(config.services);
+  return { config, compiled, hooks, registry };
+}
+
+export function describeGatewayState(state: GatewayState): string {
+  const hookCount =
+    state.hooks.onRequest.length + state.hooks.onResponse.length + state.hooks.onError.length;
+  return (
+    `${state.config.routes.length} route(s), ${Object.keys(state.config.services).length} service(s)` +
+    (hookCount > 0 ? `, ${hookCount} hook(s)` : '')
+  );
+}

--- a/src/gateway/state.ts
+++ b/src/gateway/state.ts
@@ -14,8 +14,13 @@ export function createGatewayState(config: GatewayConfig): GatewayState {
   const compiled = compileRoutes(config.routes);
   const hooks = loadHooks(config.hooks);
   const registry = new HealthRegistry();
-  registry.start(config.services);
-  return { config, compiled, hooks, registry };
+  try {
+    registry.start(config.services);
+    return { config, compiled, hooks, registry };
+  } catch (error) {
+    registry.stop();
+    throw error;
+  }
 }
 
 export function describeGatewayState(state: GatewayState): string {

--- a/src/lifecycle/self-test.ts
+++ b/src/lifecycle/self-test.ts
@@ -18,6 +18,7 @@ export interface StartupSelfTestResult {
 export interface StartupSelfTestOptions {
   checks: readonly StartupSelfTestCheck[];
   log?: (message: string) => void;
+  timeoutMs?: number;
 }
 
 export interface StartupSelfTestDependencies {
@@ -36,10 +37,11 @@ export function createStartupSelfTest(deps: StartupSelfTestDependencies): Startu
 
 export async function runStartupSelfTest(options: StartupSelfTestOptions): Promise<StartupSelfTestResult[]> {
   const log = options.log ?? console.log;
+  const timeoutMs = normalizedTimeout(options.timeoutMs);
   const results: StartupSelfTestResult[] = [];
   for (const check of options.checks) {
     try {
-      await check.run();
+      await runCheck(check, timeoutMs);
       results.push({ name: check.name, status: 'pass', message: 'ok' });
       log(`[SelfTest] PASS ${check.name}`);
     } catch (error) {
@@ -51,6 +53,21 @@ export async function runStartupSelfTest(options: StartupSelfTestOptions): Promi
   const passed = results.filter((result) => result.status === 'pass').length;
   log(`[SelfTest] summary: ${passed} passed, ${results.length - passed} failed`);
   return results;
+}
+
+async function runCheck(check: StartupSelfTestCheck, timeoutMs?: number): Promise<void> {
+  if (timeoutMs === undefined) return await check.run();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      Promise.resolve().then(() => check.run()),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`timed out after ${timeoutMs}ms`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 export function validateVectorConfig(config: unknown): asserts config is VectorServerConfig {
@@ -104,4 +121,10 @@ function filled(value: unknown): value is string {
 
 function validPort(value: unknown): value is number {
   return typeof value === 'number' && Number.isInteger(value) && value > 0 && value <= 65_535;
+}
+
+function normalizedTimeout(value: number | undefined): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? Math.ceil(value)
+    : undefined;
 }

--- a/src/mcp/aliases.ts
+++ b/src/mcp/aliases.ts
@@ -4,7 +4,10 @@ const ALIAS_PREFIXES = ['arra_', 'muninn_'] as const;
 export function resolveToolName(name: string): string {
   const clean = name.trim();
   for (const prefix of ALIAS_PREFIXES) {
-    if (clean.startsWith(prefix)) return 'oracle_' + clean.slice(prefix.length);
+    if (!clean.startsWith(prefix)) continue;
+    const suffix = clean.slice(prefix.length).trim();
+    if (!suffix) return clean;
+    return suffix.startsWith('oracle_') ? suffix : `oracle_${suffix}`;
   }
   return clean;
 }

--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -12,6 +12,7 @@ const DEFAULT_ORIGINS = [
   'http://127.0.0.1:3000',
   'http://localhost:4321',
   'http://127.0.0.1:4321',
+  'https://god.buildwithoracle.com',
 ] as const;
 const ALLOWED_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'] as const;
 const ALLOWED_HEADERS = [

--- a/src/plugins/runtime-reload.ts
+++ b/src/plugins/runtime-reload.ts
@@ -19,10 +19,11 @@ async function restorePreviousRuntime(
   previous: UnifiedRuntime,
   state: UnifiedRuntimeLifecycleState,
   options: Required<Pick<SwapUnifiedRuntimeOptions, 'startServers'>> & SwapUnifiedRuntimeOptions,
+  restartServers = true,
 ): Promise<void> {
   try {
     await previous.init();
-    state.servers = await options.startServers(previous.servers, options.warn);
+    if (restartServers) state.servers = await options.startServers(previous.servers, options.warn);
   } catch (error) {
     warn(options, `failed to restore previous runtime: ${error instanceof Error ? error.message : String(error)}`);
   }
@@ -38,8 +39,13 @@ export async function swapUnifiedRuntimeWithLifecycle(
   const previous = runtimeRef.current;
   let nextServers: UnifiedServerRuntime | undefined;
 
-  await previous.stop();
-  await state.servers.stop();
+  try {
+    await previous.stop();
+    await state.servers.stop();
+  } catch (error) {
+    await restorePreviousRuntime(previous, state, { ...options, startServers }, false);
+    throw error;
+  }
 
   try {
     await next.init();

--- a/src/plugins/watcher.ts
+++ b/src/plugins/watcher.ts
@@ -46,11 +46,18 @@ export function watchPluginManifests(options: PluginManifestWatcherOptions): Plu
   const watchImpl = options.watch ?? (fsWatch as unknown as PluginWatchFn);
   const watchers: Array<{ close: () => void }> = [];
   let timer: ReturnType<typeof setTimeout> | undefined;
+  let reloadChain: Promise<void> = Promise.resolve();
 
-  const reload = async (): Promise<UnifiedRuntime> => {
+  const runReload = async (): Promise<UnifiedRuntime> => {
     const runtime = await loader({ dirs, timeoutMs: options.timeoutMs, warn: options.warn });
     await options.onReload(runtime);
     return runtime;
+  };
+
+  const reload = (): Promise<UnifiedRuntime> => {
+    const run = reloadChain.then(runReload, runReload);
+    reloadChain = run.then(() => undefined, () => undefined);
+    return run;
   };
 
   const scheduleReload = () => {

--- a/src/routes/memory/confidence.ts
+++ b/src/routes/memory/confidence.ts
@@ -42,8 +42,8 @@ export function memoryConfidence(
   const freshness = clamp(0.5 ** (ageDays / halfLife));
   const match = clamp(options.semanticScore ?? (options.mode === 'semantic' ? 0.6 : 0.65));
   const provenance = Math.min(1, (hasSource ? 0.45 : 0) + (hasTags ? 0.35 : 0) + (hasTitle ? 0.2 : 0));
-  const usageCount = Math.max(0, Math.floor(Number(memory.usageCount ?? 0)));
-  const lastAccessedAgeDays = memory.lastAccessedAt ? daysSince(memory.lastAccessedAt, now) : undefined;
+  const usageCount = safeUsageCount(memory.usageCount);
+  const lastAccessedAgeDays = memory.lastAccessedAt ? optionalDaysSince(memory.lastAccessedAt, now) : undefined;
   const usage = usageSignal(usageCount, lastAccessedAgeDays);
   const score = round(clamp((match * 0.5) + (freshness * 0.3) + (provenance * 0.2) + (usage * 0.1)));
 
@@ -75,6 +75,17 @@ function daysSince(value: string, now: Date): number {
   const timestamp = Date.parse(value);
   if (!Number.isFinite(timestamp)) return 0;
   return Math.max(0, (now.getTime() - timestamp) / DAY_MS);
+}
+
+function optionalDaysSince(value: string, now: Date): number | undefined {
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? Math.max(0, (now.getTime() - timestamp) / DAY_MS) : undefined;
+}
+
+function safeUsageCount(value: unknown): number {
+  const parsed = Number(value ?? 0);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 0;
+  return Math.floor(parsed);
 }
 
 function reasons(

--- a/src/routes/memory/fanout-score.ts
+++ b/src/routes/memory/fanout-score.ts
@@ -1,0 +1,9 @@
+export function safeVectorDistance(value: unknown): number {
+  const distance = Number(value ?? 0);
+  return Number.isFinite(distance) && distance >= 0 ? distance : 0;
+}
+
+export function scoreFromVectorDistance(value: unknown): number {
+  const distance = safeVectorDistance(value);
+  return 1 / (1 + distance / 100);
+}

--- a/src/routes/memory/fanout.ts
+++ b/src/routes/memory/fanout.ts
@@ -3,6 +3,7 @@ import type { SearchResult } from '../../server/types.ts';
 import { ensureVectorStoreConnected, getEmbeddingModels, type EmbeddingModelConfig } from '../../vector/factory.ts';
 import type { VectorQueryResult, VectorStoreAdapter } from '../../vector/types.ts';
 import { memoryConfidence, type MemoryConfidence } from './confidence.ts';
+import { safeVectorDistance, scoreFromVectorDistance } from './fanout-score.ts';
 import { MemoryFanoutQuery, parseMemoryLimit } from './model.ts';
 import { clampMemoryConfidenceWeight, memoryConfidenceRerankConfig, memoryFanoutConfidenceWeight } from './rerank-config.ts';
 import type { MemoryRecord } from './store.ts';
@@ -84,7 +85,7 @@ function textList(value: unknown): string[] {
 function toSearchResults(collection: string, result: VectorQueryResult): FanoutSearchResult[] {
   return result.ids.map((id, index) => {
     const metadata = result.metadatas?.[index] ?? {};
-    const distance = result.distances?.[index] ?? 0;
+    const distance = safeVectorDistance(result.distances?.[index]);
     const tags = textList(metadata.tags).length ? textList(metadata.tags) : textList(metadata.concepts);
     return {
       id,
@@ -93,7 +94,7 @@ function toSearchResults(collection: string, result: VectorQueryResult): FanoutS
       source_file: metadata.source_file ?? metadata.path ?? '',
       concepts: textList(metadata.concepts),
       source: 'vector',
-      score: 1 / (1 + distance / 100),
+      score: scoreFromVectorDistance(distance),
       distance,
       model: collection,
       title: text(metadata.title),

--- a/src/routes/memory/model.ts
+++ b/src/routes/memory/model.ts
@@ -38,7 +38,9 @@ export const MemoryFanoutQuery = t.Object({
 
 
 export function parseMemoryLimit(raw: unknown, fallback = 10, max = 50): number {
-  const parsed = typeof raw === 'number' ? raw : Number.parseInt(String(raw ?? fallback), 10);
+  const value = typeof raw === 'number' ? String(raw) : String(raw ?? fallback).trim();
+  if (!/^\d+$/.test(value)) return fallback;
+  const parsed = Number(value);
   if (!Number.isFinite(parsed)) return fallback;
   return Math.min(max, Math.max(1, Math.trunc(parsed)));
 }

--- a/src/routes/search/tenant-search.ts
+++ b/src/routes/search/tenant-search.ts
@@ -1,6 +1,7 @@
 import { sqlite } from '../../db/index.ts';
 import { currentTenantId } from '../../middleware/tenant.ts';
 import { BI_TEMPORAL_JOIN, BI_TEMPORAL_WHERE, biTemporalParams } from '../../search/bitemporal.ts';
+import { isoTimestamp } from '../../search/timestamp.ts';
 import { logDocumentAccess } from '../../server/logging.ts';
 import type { SearchResponse } from '../../server/types.ts';
 import { buildTenantFtsQuery, parseConcepts } from '../../search/query.ts';
@@ -73,13 +74,6 @@ export function handleTenantSearch(query: string, type = 'all', limit = 10, offs
     vectorAvailable: false,
     warning: 'Tenant-scoped HTTP search uses SQLite/FTS isolation for this request',
   };
-}
-
-function isoTimestamp(value: number | string | null): string | null {
-  const ms = typeof value === 'number' ? value : Number(value);
-  if (!Number.isFinite(ms) || ms <= 0) return null;
-  const date = new Date(ms);
-  return Number.isNaN(date.getTime()) ? null : date.toISOString();
 }
 
 export function handleTenantList(type = 'all', limit = 10, offset = 0, groupByFile = true): SearchResponse | null {

--- a/src/routes/vector/documents.ts
+++ b/src/routes/vector/documents.ts
@@ -109,14 +109,18 @@ export function createVectorDocumentsEndpoint(deps: VectorDocumentsDeps = {}) {
         let listed: { items: DocumentItem[]; totalFallback: number };
 
         if (store.getAllEmbeddings) {
-          const all = await store.getAllEmbeddings(currentTenantId() ? MAX_LIMIT : offset + limit);
-          const docs = (all as { documents?: unknown[] }).documents;
-          listed = Array.isArray(docs)
-            ? (() => {
-                const scoped = filterTenantItems(pageItems(all.ids, docs, all.metadatas));
-                return { items: scoped.slice(offset, offset + limit), totalFallback: scoped.length };
-              })()
-            : await listWithQuery(store, offset, limit);
+          try {
+            const all = await store.getAllEmbeddings(currentTenantId() ? MAX_LIMIT : offset + limit);
+            const docs = (all as { documents?: unknown[] }).documents;
+            listed = Array.isArray(docs)
+              ? (() => {
+                  const scoped = filterTenantItems(pageItems(all.ids, docs, all.metadatas));
+                  return { items: scoped.slice(offset, offset + limit), totalFallback: scoped.length };
+                })()
+              : await listWithQuery(store, offset, limit);
+          } catch {
+            listed = await listWithQuery(store, offset, limit);
+          }
         } else {
           listed = await listWithQuery(store, offset, limit);
         }

--- a/src/search/bitemporal.ts
+++ b/src/search/bitemporal.ts
@@ -1,22 +1,34 @@
 import type { Database } from 'bun:sqlite';
 import { currentTenantId } from '../middleware/tenant.ts';
+import { isoTimestamp } from './timestamp.ts';
 
 export type AsOfParseResult = { ok: true; value?: number } | { ok: false; error: string };
 
 type SearchResultRecord = Record<string, unknown>;
 type TemporalRow = { id: string; valid_time: number | string | null; valid_until: number | string | null };
 
+const validStart = timestampSql('COALESCE(d.valid_time, d.updated_at, d.created_at, d.indexed_at)');
+const validUntil = timestampSql('COALESCE(s.valid_time, d.superseded_at)');
+
 export const BI_TEMPORAL_JOIN = `
 LEFT JOIN oracle_documents s
   ON d.superseded_by = s.id AND s.tenant_id = d.tenant_id`;
 
 export const BI_TEMPORAL_WHERE = `
-COALESCE(d.valid_time, d.updated_at, d.created_at, d.indexed_at) <= ?
+${validStart} <= ?
 AND (
   d.superseded_by IS NULL
   OR COALESCE(s.valid_time, d.superseded_at) IS NULL
-  OR COALESCE(s.valid_time, d.superseded_at) > ?
+  OR ${validUntil} > ?
 )`;
+
+function timestampSql(expr: string): string {
+  return `CASE
+    WHEN typeof(${expr}) = 'text' AND ${expr} GLOB '*[^0-9]*'
+      THEN CAST(strftime('%s', ${expr}) AS INTEGER) * 1000
+    ELSE CAST(${expr} AS INTEGER)
+  END`;
+}
 
 export function parseAsOf(raw: string | undefined): AsOfParseResult {
   const value = raw?.trim();
@@ -58,11 +70,4 @@ export function filterResultsAsOf(
     item.valid_until = isoTimestamp(row.valid_until);
     return true;
   });
-}
-
-function isoTimestamp(value: number | string | null): string | null {
-  const ms = typeof value === 'number' ? value : Number(value);
-  if (!Number.isFinite(ms) || ms <= 0) return null;
-  const date = new Date(ms);
-  return Number.isNaN(date.getTime()) ? null : date.toISOString();
 }

--- a/src/search/supersede-status.ts
+++ b/src/search/supersede-status.ts
@@ -1,5 +1,6 @@
 import type { Database } from 'bun:sqlite';
 import { currentTenantId } from '../middleware/tenant.ts';
+import { isoTimestamp } from './timestamp.ts';
 
 type SearchResultRecord = Record<string, unknown>;
 
@@ -14,13 +15,6 @@ function resultIds(results: SearchResultRecord[]): string[] {
   return [...new Set(results
     .map((result) => result.id)
     .filter((id): id is string => typeof id === 'string' && id.length > 0))];
-}
-
-function isoTimestamp(value: number | string | null): string | null {
-  const ms = typeof value === 'number' ? value : Number(value);
-  if (!Number.isFinite(ms) || ms <= 0) return null;
-  const date = new Date(ms);
-  return Number.isNaN(date.getTime()) ? null : date.toISOString();
 }
 
 export function attachSupersedeStatus(

--- a/src/search/timestamp.ts
+++ b/src/search/timestamp.ts
@@ -1,0 +1,15 @@
+export function isoTimestamp(value: number | string | null | undefined): string | null {
+  if (value === null || value === undefined) return null;
+  const ms = timestampMs(value);
+  if (ms === null || ms <= 0) return null;
+  const date = new Date(ms);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function timestampMs(value: number | string): number | null {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  const text = value.trim();
+  if (!text) return null;
+  const ms = /^\d+$/.test(text) ? Number(text) : Date.parse(text);
+  return Number.isFinite(ms) ? ms : null;
+}

--- a/src/vector/adapters/proxy.ts
+++ b/src/vector/adapters/proxy.ts
@@ -26,6 +26,8 @@ import {
   type VectorProxyStatsResponse,
 } from '../proxy-protocol.ts';
 
+const MAX_PROXY_LIMIT = 1000;
+
 function tenantHeaders(json = false): Record<string, string> {
   const headers: Record<string, string> = json ? { 'Content-Type': 'application/json' } : {};
   const tenantId = currentTenantId();
@@ -163,7 +165,7 @@ export class ProxyVectorAdapter implements VectorStoreAdapter {
 }
 
 function normalizeLimit(limit: number): number {
-  return Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 10;
+  return Number.isFinite(limit) && limit > 0 ? Math.min(MAX_PROXY_LIMIT, Math.floor(limit)) : 10;
 }
 
 function nonNegativeCount(value: unknown): number {
@@ -175,6 +177,8 @@ function displayName(value: unknown, fallback: string): string {
 }
 
 function exportPath(limit: number | undefined): string {
-  const normalized = Number.isFinite(limit) && Number(limit) > 0 ? Math.floor(Number(limit)) : undefined;
+  const normalized = Number.isFinite(limit) && Number(limit) > 0
+    ? Math.min(MAX_PROXY_LIMIT, Math.floor(Number(limit)))
+    : undefined;
   return normalized ? `${VECTOR_PROXY_ROUTES.export}?limit=${normalized}` : VECTOR_PROXY_ROUTES.export;
 }

--- a/src/vector/factory.ts
+++ b/src/vector/factory.ts
@@ -147,30 +147,14 @@ function resolveModelKey(model: string | undefined, models: Record<string, Embed
   return key;
 }
 export function createVectorStoreForModel(preset: EmbeddingModelConfig): VectorStoreAdapter {
-  return createVectorStore({
-    type: preset.adapter || 'lancedb',
-    collectionName: preset.collection,
-    embeddingProvider: preset.embedder?.backend ?? resolveEmbeddingProviderType(),
-    embeddingModel: preset.embedder?.model || preset.model,
-    embeddingUrl: preset.embedder?.url,
-    embeddingDimensions: preset.embedder?.dimensions,
-    embeddingFallbackChain: preset.embedder?.fallbackChain
-      ?? (preset.embedder?.fallback ? [preset.embedder.fallback] : undefined),
-    proxyEndpoint: preset.endpoint,
-    ...(preset.dataPath && { dataPath: preset.dataPath }),
-  });
+  return createVectorStore(vectorStoreConfigFromPreset(preset));
 }
-export function getVectorStoreConfigByModel(
-  model?: string,
-  models = getEmbeddingModels(),
-): VectorStoreConfig {
-  const key = resolveModelKey(model, models);
-  const preset = models[key];
+function vectorStoreConfigFromPreset(preset: EmbeddingModelConfig): VectorStoreConfig {
   return {
     type: preset.adapter || 'lancedb',
     collectionName: preset.collection,
     embeddingProvider: resolveEmbeddingProviderType(
-      preset.provider as EmbeddingProviderType | undefined ?? preset.embedder?.backend,
+      (preset.provider as EmbeddingProviderType | undefined) ?? preset.embedder?.backend,
     ),
     embeddingModel: preset.embedder?.model || preset.model,
     embeddingUrl: preset.embedder?.url,
@@ -186,6 +170,13 @@ export function getVectorStoreConfigByModel(
     ...(preset.cfApiToken && { cfApiToken: preset.cfApiToken }),
   };
 }
+export function getVectorStoreConfigByModel(
+  model?: string,
+  models = getEmbeddingModels(),
+): VectorStoreConfig {
+  const key = resolveModelKey(model, models);
+  return vectorStoreConfigFromPreset(models[key]);
+}
 export function getVectorStoreByModel(
   model?: string,
   models = getEmbeddingModels(),
@@ -197,7 +188,8 @@ export function getVectorStoreByModel(
     const preset = models[key];
     store = createVectorStoreForModel(preset);
     modelStoreCache.set(key, store);
-    connectPromises.set(key, connectStore(store).catch(e =>
+    const newStore = store;
+    connectPromises.set(key, Promise.resolve().then(() => connectStore(newStore)).catch(e =>
       console.warn(`[VectorRegistry] Failed to connect ${key}:`, e instanceof Error ? e.message : String(e))
     ));
   }

--- a/src/vector/fan-out.ts
+++ b/src/vector/fan-out.ts
@@ -58,16 +58,18 @@ function uniqueCollections(collections: string[]): string[] {
 }
 
 function scoreFor(hit: FanOutHit): number {
-  if (typeof hit.score === 'number' && Number.isFinite(hit.score)) return hit.score;
+  if (typeof hit.score === 'number' && Number.isFinite(hit.score)) return clampScore(hit.score);
   if (typeof hit.distance === 'number' && Number.isFinite(hit.distance)) {
-    return 1 / (1 + Math.max(0, hit.distance));
+    return clampScore(1 / (1 + Math.max(0, hit.distance)));
   }
   return 0;
 }
 
 function mergeHit(acc: Accumulator, collection: string, hit: FanOutHit, score: number): void {
-  acc.combinedScore += score;
-  acc.collectionScores[collection] = (acc.collectionScores[collection] ?? 0) + score;
+  const previous = acc.collectionScores[collection] ?? 0;
+  const next = Math.max(previous, score);
+  acc.combinedScore += next - previous;
+  acc.collectionScores[collection] = next;
   if (!acc.sourceCollections.includes(collection)) acc.sourceCollections.push(collection);
   if (score > acc.bestScore) {
     acc.bestHit = hit;
@@ -117,7 +119,7 @@ export class FanOutQuery {
     const byId = new Map<string, Accumulator>();
     for (const { collection, hits } of batches) {
       for (const hit of hits) {
-        const id = hit.id.trim();
+        const id = hitId(hit.id);
         if (!id) continue;
         const score = scoreFor(hit);
         const existing = byId.get(id);
@@ -141,4 +143,12 @@ export class FanOutQuery {
       .map(toResult)
       .sort((left, right) => right.score - left.score || left.id.localeCompare(right.id));
   }
+}
+
+function hitId(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function clampScore(value: number): number {
+  return Math.max(0, Math.min(1, value));
 }

--- a/src/vector/fanout-query.ts
+++ b/src/vector/fanout-query.ts
@@ -76,14 +76,16 @@ export async function queryFanout(options: FanoutQueryOptions): Promise<FanoutQu
 export function mergeFanoutResults(results: SearchResult[]): SearchResult[] {
   const best = new Map<string, SearchResult & { _hits?: number }>();
   for (const result of results) {
+    const resultScore = finiteScore(result.score);
     const existing = best.get(result.id);
     if (!existing) {
-      best.set(result.id, { ...result, _hits: 1 });
+      best.set(result.id, { ...result, score: resultScore, _hits: 1 });
       continue;
     }
     const hits = (existing._hits ?? 1) + 1;
-    const score = Math.min(1, Math.max(existing.score ?? 0, result.score ?? 0) + 0.05 * (hits - 1));
-    best.set(result.id, { ...(score >= (result.score ?? 0) ? existing : result), score, source: 'hybrid', _hits: hits });
+    const existingScore = finiteScore(existing.score);
+    const score = Math.min(1, Math.max(existingScore, resultScore) + 0.05 * (hits - 1));
+    best.set(result.id, { ...(resultScore > existingScore ? result : existing), score, source: 'hybrid', _hits: hits });
   }
   return [...best.values()]
     .map(({ _hits, ...result }) => result)
@@ -114,6 +116,12 @@ function normalizeFanoutLimit(limit: number): number {
 
 function finiteDistance(distance: unknown): number {
   return typeof distance === 'number' && Number.isFinite(distance) && distance >= 0 ? distance : 0;
+}
+
+function finiteScore(score: unknown): number {
+  return typeof score === 'number' && Number.isFinite(score)
+    ? Math.max(0, Math.min(1, score))
+    : 0;
 }
 
 function scoreFromDistance(distance: number): number {

--- a/src/vector/service-registry.ts
+++ b/src/vector/service-registry.ts
@@ -125,6 +125,7 @@ function syncConfig(
 
 function validateService(service: RegisteredVectorService): RegisteredVectorService {
   const name = service.name?.trim();
+  const capabilities = record(service.capabilities);
   if (!name) throw new Error('service name is required');
   if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(name)) throw new Error(`invalid service name: ${name}`);
   if (service.kind && service.kind !== VECTOR_CAPABILITY_KIND) throw new Error(`unsupported service kind: ${String(service.kind)}`);
@@ -140,7 +141,7 @@ function validateService(service: RegisteredVectorService): RegisteredVectorServ
       throw new Error(`proxy service ${name} requires http(s) endpoint`);
     }
   }
-  return { kind: VECTOR_CAPABILITY_KIND, name, type: service.type, endpoint, capabilities: service.capabilities };
+  return { kind: VECTOR_CAPABILITY_KIND, name, type: service.type, endpoint, ...(Object.keys(capabilities).length && { capabilities }) };
 }
 
 export class VectorServiceRegistry implements VectorServiceRegistryClient {

--- a/tests/e2e/api.e2e.ts
+++ b/tests/e2e/api.e2e.ts
@@ -34,10 +34,11 @@ test.describe('Oracle API E2E', () => {
     expect(res.ok()).toBe(true);
   });
 
-  test('consult endpoint', async ({ request }) => {
-    const res = await request.get('/api/consult?q=Should%20I%20use%20TypeScript');
+  test('concepts endpoint', async ({ request }) => {
+    const res = await request.get('/api/concepts?limit=5');
     expect(res.ok()).toBe(true);
     const data = await res.json();
-    expect(data).toHaveProperty('guidance');
+    expect(Array.isArray(data.concepts)).toBe(true);
+    expect(typeof data.total_unique).toBe('number');
   });
 });

--- a/tests/e2e/contrast.spec.ts
+++ b/tests/e2e/contrast.spec.ts
@@ -1,0 +1,92 @@
+import { mkdirSync } from 'node:fs';
+import { expect, test, type Page } from '@playwright/test';
+
+type Failure = { path: string; theme: string; text: string; ratio: number; color: string; background: string };
+const PAGES = ['/menu', '/plugins', '/status', '/vector', '/export', '/search', '/mcp', '/settings'];
+mkdirSync('test-results/contrast', { recursive: true });
+
+test.describe('frontend WCAG AA contrast', () => {
+  for (const theme of ['light', 'dark'] as const) {
+    for (const path of PAGES) {
+      test(`${theme} ${path} text contrast is at least 4.5:1`, async ({ page }) => {
+        await setTheme(page, theme);
+        await page.goto(path, { waitUntil: 'domcontentloaded' });
+        await page.locator('body').waitFor({ state: 'visible' });
+        await page.waitForTimeout(250);
+        await page.screenshot({ path: `test-results/contrast/${theme}-${slug(path)}.png`, fullPage: true });
+        const failures = await page.evaluate(({ path, theme }) => {
+          type Rgba = { r: number; g: number; b: number; a: number };
+          const text = (el: HTMLElement) => (el.innerText || el.textContent || '').replace(/\s+/g, ' ').trim();
+          const direct = (el: HTMLElement) => Array.from(el.childNodes).some((n) => n.nodeType === Node.TEXT_NODE && (n.textContent || '').trim());
+          const parse = (value: string): Rgba | null => {
+            const ctx = document.createElement('canvas').getContext('2d');
+            if (!ctx) return null;
+            ctx.fillStyle = '#000';
+            ctx.fillStyle = value;
+            const normalized = ctx.fillStyle;
+            const hex = normalized.match(/^#([\da-f]{6}|[\da-f]{8})$/i)?.[1];
+            if (hex) {
+              const v = Number.parseInt(hex, 16);
+              return hex.length === 8 ? { r: v >> 24 & 255, g: v >> 16 & 255, b: v >> 8 & 255, a: (v & 255) / 255 } : { r: v >> 16 & 255, g: v >> 8 & 255, b: v & 255, a: 1 };
+            }
+            const rgba = normalized.match(/^rgba?\(([^)]+)\)$/i)?.[1];
+            if (!rgba) return null;
+            const p = rgba.split(',').map((part) => Number.parseFloat(part.trim()));
+            return { r: p[0], g: p[1], b: p[2], a: p[3] ?? 1 };
+          };
+          const over = (top: Rgba, bottom: Rgba): Rgba => {
+            const a = top.a + bottom.a * (1 - top.a);
+            return a ? { r: (top.r * top.a + bottom.r * bottom.a * (1 - top.a)) / a, g: (top.g * top.a + bottom.g * bottom.a * (1 - top.a)) / a, b: (top.b * top.a + bottom.b * bottom.a * (1 - top.a)) / a, a } : { r: 0, g: 0, b: 0, a: 0 };
+          };
+          const bgFor = (el: HTMLElement): Rgba => {
+            let bg: Rgba = { r: 0, g: 0, b: 0, a: 0 };
+            for (let n: HTMLElement | null = el; n; n = n.parentElement) {
+              const c = parse(getComputedStyle(n).backgroundColor);
+              if (!c || c.a === 0) continue;
+              bg = over(bg, c);
+              if (bg.a >= 1) break;
+            }
+            return bg.a ? bg : { r: 255, g: 255, b: 255, a: 1 };
+          };
+          const lum = (c: Rgba) => {
+            const ch = (v: number) => { const s = v / 255; return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4; };
+            return 0.2126 * ch(c.r) + 0.7152 * ch(c.g) + 0.0722 * ch(c.b);
+          };
+          const ratio = (a: Rgba, b: Rgba) => { const [hi, lo] = [lum(a), lum(b)].sort((x, y) => y - x); return (hi + 0.05) / (lo + 0.05); };
+          const rgbaText = (c: Rgba) => `rgba(${Math.round(c.r)}, ${Math.round(c.g)}, ${Math.round(c.b)}, ${Math.round(c.a * 100) / 100})`;
+          const failures: Failure[] = [];
+          const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT);
+          for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+            const el = node as HTMLElement;
+            const style = getComputedStyle(el);
+            if (style.visibility === 'hidden' || style.display === 'none' || Number(style.opacity) === 0 || el.getClientRects().length === 0) continue;
+            if (!text(el) || !direct(el)) continue;
+            const fg = parse(style.color);
+            const bg = bgFor(el);
+            if (!fg) continue;
+            const value = ratio(over(fg, bg), bg);
+            if (value < 4.5) failures.push({ path, theme, text: text(el).slice(0, 80), ratio: Math.round(value * 100) / 100, color: style.color, background: rgbaText(bg) });
+          }
+          return failures;
+        }, { path, theme });
+        expect(formatFailures(failures)).toEqual('');
+      });
+    }
+  }
+});
+
+async function setTheme(page: Page, theme: 'light' | 'dark') {
+  await page.addInitScript((mode) => {
+    localStorage.setItem('ARRA_FRONTEND_THEME', mode);
+    document.documentElement.classList.toggle('dark', mode === 'dark');
+    document.documentElement.classList.toggle('light', mode === 'light');
+  }, theme);
+}
+
+function formatFailures(failures: Failure[]): string {
+  return failures.map((f) => `${f.theme} ${f.path} ${f.ratio}:1 ${JSON.stringify(f.text)} ${f.color} on ${f.background}`).join('\n');
+}
+
+function slug(path: string): string {
+  return path.replace(/^\//, '').replace(/[^a-z0-9]+/gi, '-') || 'home';
+}

--- a/tests/e2e/frontend-pages.e2e.ts
+++ b/tests/e2e/frontend-pages.e2e.ts
@@ -1,0 +1,54 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const frontendURL = process.env.PLAYWRIGHT_FRONTEND_URL ?? 'http://127.0.0.1:3310';
+const frontendHost = new URL(frontendURL).host;
+
+async function openFrontendPage(page: Page, path: string, heading: string | RegExp) {
+  await page.goto(path);
+  await expect(page.getByRole('heading', { name: heading }).first()).toBeVisible();
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript((host) => {
+    window.localStorage.setItem('arra.vector.setup.dismissed', '1');
+    window.localStorage.setItem('arra-oracle-setup-complete', '1');
+    window.localStorage.setItem('oracle.host', host);
+  }, frontendHost);
+});
+
+test.describe('Frontend pages render and interact through the Vite proxy', () => {
+  test('renders the primary dashboard pages', async ({ page }) => {
+    await openFrontendPage(page, '/menu', 'Menu catalog');
+    await openFrontendPage(page, '/plugins', 'Unified plugin surfaces');
+    await openFrontendPage(page, '/vector', 'Vector dashboard');
+    await openFrontendPage(page, '/mcp', 'Tool browser');
+  });
+
+  test('toggles the shell theme from a rendered menu page', async ({ page }) => {
+    await openFrontendPage(page, '/menu', 'Menu catalog');
+
+    const toggle = page.getByRole('button', { name: 'Dark mode' });
+    const previous = await toggle.getAttribute('aria-pressed');
+    await toggle.click();
+
+    await expect(toggle).toHaveAttribute('aria-pressed', previous === 'true' ? 'false' : 'true');
+    await expect(page.getByRole('heading', { name: 'Menu catalog' }).first()).toBeVisible();
+  });
+
+  test('submits menu search and navigates with the command palette', async ({ page }) => {
+    await openFrontendPage(page, '/search', 'Full-text menu search');
+    await page.getByLabel('Menu search query').fill('vector');
+    await page.getByLabel('Menu search form').getByRole('button', { name: 'Search' }).click();
+
+    await expect(page).toHaveURL(/\/search\?q=vector$/);
+    await expect(page.getByRole('region', { name: 'Menu search results card' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Search results' })).toBeVisible();
+
+    await page.getByLabel('Open command palette').click();
+    await page.getByLabel('Search command palette').fill('mcp');
+    await page.keyboard.press('Enter');
+
+    await expect(page).toHaveURL(/\/mcp$/);
+    await expect(page.getByRole('heading', { name: 'Tool browser' })).toBeVisible();
+  });
+});

--- a/tests/e2e/frontend-pages.e2e.ts
+++ b/tests/e2e/frontend-pages.e2e.ts
@@ -1,0 +1,50 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function openFrontendPage(page: Page, path: string, heading: string | RegExp) {
+  await page.goto(path);
+  await expect(page.getByRole('heading', { name: heading }).first()).toBeVisible();
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('arra.vector.setup.dismissed', '1');
+    window.localStorage.setItem('arra-oracle-setup-complete', '1');
+  });
+});
+
+test.describe('Frontend pages render and interact through the Vite proxy', () => {
+  test('renders the primary dashboard pages', async ({ page }) => {
+    await openFrontendPage(page, '/menu', 'Menu catalog');
+    await openFrontendPage(page, '/plugins', 'Unified plugin surfaces');
+    await openFrontendPage(page, '/vector', 'Vector dashboard');
+    await openFrontendPage(page, '/mcp', 'Tool browser');
+  });
+
+  test('toggles the shell theme from a rendered menu page', async ({ page }) => {
+    await openFrontendPage(page, '/menu', 'Menu catalog');
+
+    const toggle = page.getByRole('button', { name: 'Dark mode' });
+    const previous = await toggle.getAttribute('aria-pressed');
+    await toggle.click();
+
+    await expect(toggle).toHaveAttribute('aria-pressed', previous === 'true' ? 'false' : 'true');
+    await expect(page.getByRole('heading', { name: 'Menu catalog' }).first()).toBeVisible();
+  });
+
+  test('submits menu search and navigates with the command palette', async ({ page }) => {
+    await openFrontendPage(page, '/search', 'Full-text menu search');
+    await page.getByLabel('Menu search query').fill('vector');
+    await page.getByLabel('Menu search form').getByRole('button', { name: 'Search' }).click();
+
+    await expect(page).toHaveURL(/\/search\?q=vector$/);
+    await expect(page.getByRole('region', { name: 'Menu search results card' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Search results' })).toBeVisible();
+
+    await page.getByLabel('Open command palette').click();
+    await page.getByLabel('Search command palette').fill('mcp');
+    await page.keyboard.press('Enter');
+
+    await expect(page).toHaveURL(/\/mcp$/);
+    await expect(page.getByRole('heading', { name: 'Tool browser' })).toBeVisible();
+  });
+});

--- a/tests/e2e/vector-sidecar-fixture.ts
+++ b/tests/e2e/vector-sidecar-fixture.ts
@@ -1,0 +1,52 @@
+const port = Number(process.env.PLAYWRIGHT_VECTOR_PORT ?? 47790);
+const collection = 'playwright_e2e';
+
+function json(body: unknown, init?: ResponseInit) {
+  return Response.json(body, {
+    headers: { 'access-control-allow-origin': '*' },
+    ...init,
+  });
+}
+
+function health() {
+  return {
+    status: 'ok',
+    engines: [],
+    checked_at: new Date().toISOString(),
+  };
+}
+
+Bun.serve({
+  hostname: '127.0.0.1',
+  port,
+  fetch(request) {
+    const url = new URL(request.url);
+    if (request.method === 'OPTIONS') return new Response(null, { status: 204 });
+    if (url.pathname === '/health' || url.pathname === '/api/vector/health') return json(health());
+    if (url.pathname === '/api/vector/stats') {
+      return json({
+        vector: { enabled: true, count: 0, collection },
+        vectors: [],
+      });
+    }
+
+    if (url.pathname === '/api/vector/index/models' || url.pathname === '/api/vector/models') {
+      return json({ models: {} });
+    }
+    if (url.pathname === '/api/vector/index/status') {
+      return json({ status: 'idle', job: null });
+    }
+    if (url.pathname === '/api/search') {
+      return json({
+        results: [],
+        total: 0,
+        offset: Number(url.searchParams.get('offset') ?? 0),
+        limit: Number(url.searchParams.get('limit') ?? 10),
+        query: url.searchParams.get('q') ?? '',
+      });
+    }
+    return json({ error: 'not found' }, { status: 404 });
+  },
+});
+
+console.log(`Playwright vector sidecar fixture listening on http://127.0.0.1:${port}`);

--- a/tests/frontend/app/dashboard-load-error-matrix.test.ts
+++ b/tests/frontend/app/dashboard-load-error-matrix.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+import { loadDashboardData } from '../../../frontend/src/App';
+
+describe('dashboard load error matrix', () => {
+  test('reports every failed dashboard endpoint without discarding error context', async () => {
+    const result = await loadDashboardData({
+      menu: async () => { throw 'menu offline'; },
+      plugins: async () => { throw new Error('plugins unavailable'); },
+      metrics: async () => { throw 503; },
+    });
+
+    expect(result.menu).toBeNull();
+    expect(result.plugins).toBeNull();
+    expect(result.metrics).toBeNull();
+    expect(result.errors).toEqual({
+      menu: 'Menu: menu offline',
+      plugins: 'Plugins: plugins unavailable',
+      metrics: 'Metrics: 503',
+    });
+  });
+
+  test('keeps successful metrics when menu and plugin endpoints fail', async () => {
+    const result = await loadDashboardData({
+      menu: async () => { throw new Error('menu failed'); },
+      plugins: async () => { throw new Error('plugins failed'); },
+      metrics: async () => ({
+        uptime: 10,
+        requestCount: 2,
+        avgResponseMs: 1,
+        activeConnections: 0,
+        lastRestart: '2026-06-17T00:00:00.000Z',
+        memoryUsage: { rss: 1, heapTotal: 1, heapUsed: 1, external: 0, arrayBuffers: 0 },
+      }),
+    });
+
+    expect(result.metrics?.requestCount).toBe(2);
+    expect(result.menu).toBeNull();
+    expect(result.plugins).toBeNull();
+    expect(result.errors).toMatchObject({
+      menu: 'Menu: menu failed',
+      plugins: 'Plugins: plugins failed',
+    });
+  });
+});

--- a/tests/frontend/components/backend-gate-shell.test.tsx
+++ b/tests/frontend/components/backend-gate-shell.test.tsx
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'bun:test';
-import { BackendGate } from '../../../frontend/src/components/BackendGate';
-import { htmlFor } from '../_render';
+import {
+  BackendGate,
+  ConnectOracleSetup,
+  connectUrlForHost,
+  normalizeOracleHost,
+} from '../../../frontend/src/components/BackendGate';
+import { htmlFor, installBrowserLocation } from '../_render';
 
 describe('BackendGate shell', () => {
   test('keeps app content hidden while the backend health check is pending', () => {
@@ -10,10 +15,42 @@ describe('BackendGate shell', () => {
       </BackendGate>,
     );
 
-    expect(html).toContain('Backend unavailable');
-    expect(html).toContain('Checking whether the local Oracle API is ready.');
+    expect(html).toContain('Connect to your Oracle');
+    expect(html).toContain('Checking backend health at http://localhost:47778.');
+    expect(html).toContain('Local Oracle host');
+    expect(html).toContain('Use this backend');
     expect(html).toContain('Retry');
     expect(html).not.toContain('Loaded dashboard');
     expect(html).not.toContain('Start Backend');
+  });
+
+  test('renders unreachable setup guidance with default local host', () => {
+    const restore = installBrowserLocation('/?host=oracle.local:47778');
+    try {
+      const html = htmlFor(
+        <ConnectOracleSetup
+          isTauri
+          message="fetch failed"
+          onRetry={() => {}}
+          onStartBackend={() => {}}
+          starting={false}
+          state="unreachable"
+        />,
+      );
+
+      expect(html).toContain('Cannot reach http://localhost:47778: fetch failed');
+      expect(html).toContain('value="localhost:47778"');
+      expect(html).toContain('arra-oracle-v3 serve');
+      expect(html).toContain('Start Backend');
+    } finally {
+      restore();
+    }
+  });
+
+  test('normalizes connect host URLs for the api/oracle host resolver', () => {
+    expect(normalizeOracleHost(' https://localhost:47778/api/ ')).toBe('localhost:47778');
+    expect(normalizeOracleHost('oracle.local:47778///')).toBe('oracle.local:47778');
+    expect(connectUrlForHost('http://localhost:47778/api', 'https://god.buildwithoracle.com/vector?q=1'))
+      .toBe('https://god.buildwithoracle.com/vector?q=1&host=localhost%3A47778');
   });
 });

--- a/tests/frontend/components/basic-empty-badge.test.tsx
+++ b/tests/frontend/components/basic-empty-badge.test.tsx
@@ -9,7 +9,7 @@ describe('basic component shells', () => {
 
     expect(html).toContain('Plugin surface');
     expect(html).toContain('rounded-full');
-    expect(html).toContain('text-teal-200');
+    expect(html).toContain('text-[color:var(--color-accent,#0f766e)]');
   });
 
   test('renders empty-state text with dashed fallback styling', () => {

--- a/tests/frontend/pages/vector-export-empty-state.test.tsx
+++ b/tests/frontend/pages/vector-export-empty-state.test.tsx
@@ -11,7 +11,7 @@ describe('VectorExportPage empty interaction state', () => {
     expect(html).toContain('No vector collections are available to export.');
     expect(html).toContain('aria-label="Export collection"');
     expect(html).toContain('aria-label="Export format"');
-    expect(html).toContain('<button class="focus-ring rounded-xl border border-teal-300/30');
+    expect(html).toContain('<button class="focus-ring rounded-xl border border-[color:var(--color-accent,#0f766e)]');
     expect(html).toContain('disabled=""');
   });
 });

--- a/tests/http/memory/confidence.test.ts
+++ b/tests/http/memory/confidence.test.ts
@@ -91,6 +91,19 @@ test('retrieval reinforcement boosts stale docs without removing decay warnings'
   expect(reinforced.warnings).toContain('stale_unvalidated');
 });
 
+test('malformed usage signals do not create NaN confidence or fake recency boosts', () => {
+  const confidence = memoryConfidence(memory({
+    usageCount: Number.NaN,
+    lastAccessedAt: 'not-a-date',
+  }), { now, mode: 'semantic', semanticScore: Number.POSITIVE_INFINITY });
+
+  expect(confidence.usageCount).toBe(0);
+  expect(confidence.lastAccessedAgeDays).toBeUndefined();
+  expect(confidence.components.match).toBe(0);
+  expect(confidence.components.usage).toBe(0);
+  expect(Number.isFinite(confidence.score)).toBe(true);
+});
+
 test('confidence clamps malformed signals and future access without exploding score', () => {
   const confidence = memoryConfidence(memory({
     createdAt: 'not-a-date',

--- a/tests/http/memory/fanout.test.ts
+++ b/tests/http/memory/fanout.test.ts
@@ -94,6 +94,33 @@ test('GET /api/v1/memory/fanout preserves partial collection errors', async () =
   expect(body.errors).toEqual({ beta: 'beta unavailable' });
 });
 
+test('GET /api/v1/memory/fanout clamps malformed vector distances before scoring', async () => {
+  const app = new Elysia({ prefix: '/api' }).use(createMemoryFanoutEndpoint({
+    models: () => ({ alpha: models.alpha }),
+    connect: async () => ({
+      query: async () => ({
+        ids: ['nan-distance', 'negative-distance'],
+        documents: ['NaN distance memory', 'negative distance memory'],
+        distances: [Number.NaN, -100],
+        metadatas: [{ type: 'memory' }, { type: 'memory' }],
+      }),
+    }),
+  }));
+  const fetcher = createApiVersionedFetch((request) => app.handle(request));
+  const response = await fetcher(new Request('http://local/api/v1/memory/fanout?q=oracle&limit=2'));
+  const body = await json(response);
+
+  expect(response.status).toBe(200);
+  expect(body.results).toHaveLength(2);
+  for (const item of body.results as Array<{ score: unknown; confidence: { components: { match: unknown } } }>) {
+    expect(typeof item.score).toBe('number');
+    expect(Number.isFinite(item.score)).toBe(true);
+    expect(item.score).toBeGreaterThanOrEqual(0);
+    expect(item.score).toBeLessThanOrEqual(1);
+    expect(typeof item.confidence.components.match).toBe('number');
+  }
+});
+
 test('GET /api/v1/memory/fanout uses confidence to reorder fresh high-provenance matches', async () => {
   const app = new Elysia({ prefix: '/api' }).use(createMemoryFanoutEndpoint({
     models: () => ({ alpha: models.alpha }),

--- a/tests/http/memory/limit-hardening.test.ts
+++ b/tests/http/memory/limit-hardening.test.ts
@@ -50,8 +50,9 @@ test('memory routes fall back from malformed limit query values', async () => {
   await fetcher(new Request('http://local/api/v1/memory/morning-tape?limit=nope'));
   await fetcher(new Request('http://local/api/v1/memory/recall?limit=nope'));
   await fetcher(new Request('http://local/api/v1/memory/search?q=oracle&limit=nope'));
+  await fetcher(new Request('http://local/api/v1/memory/recall?limit=2abc'));
 
-  expect(recallLimits).toEqual([8, 10]);
+  expect(recallLimits).toEqual([8, 10, 10]);
   expect(searchLimits).toEqual([10]);
 });
 
@@ -68,7 +69,8 @@ test('memory routes clamp out-of-range limit query values', async () => {
 test('memory fanout normalizes malformed and large limits', async () => {
   const { fetcher, limits } = fanoutHarness();
   await fetcher(new Request('http://local/api/v1/memory/fanout?q=oracle&limit=nope'));
+  await fetcher(new Request('http://local/api/v1/memory/fanout?q=oracle&limit=2abc'));
   await fetcher(new Request('http://local/api/v1/memory/fanout?q=oracle&limit=999'));
 
-  expect(limits).toEqual([10, 50]);
+  expect(limits).toEqual([10, 10, 50]);
 });

--- a/tests/http/search/temporal-status-hardening.test.ts
+++ b/tests/http/search/temporal-status-hardening.test.ts
@@ -1,0 +1,69 @@
+import { Database } from 'bun:sqlite';
+import { describe, expect, test } from 'bun:test';
+import { filterResultsAsOf } from '../../../src/search/bitemporal.ts';
+import { attachSupersedeStatus } from '../../../src/search/supersede-status.ts';
+
+function memoryDb() {
+  const sqlite = new Database(':memory:');
+  sqlite.run(`
+    CREATE TABLE oracle_documents (
+      id TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL,
+      valid_time,
+      updated_at,
+      created_at,
+      indexed_at,
+      superseded_by TEXT,
+      superseded_at,
+      superseded_reason TEXT
+    )
+  `);
+  return sqlite;
+}
+
+describe('search temporal/supersede status hardening', () => {
+  test('attachSupersedeStatus formats legacy ISO text superseded_at values', () => {
+    const sqlite = memoryDb();
+    try {
+      sqlite.prepare(`
+        INSERT INTO oracle_documents
+          (id, tenant_id, superseded_by, superseded_at, superseded_reason)
+        VALUES (?, ?, ?, ?, ?)
+      `).run('old', 'tenant-a', 'new', '2026-06-17T00:00:00.000Z', 'replacement');
+      const results: Array<Record<string, unknown>> = [{ id: 'old' }];
+
+      attachSupersedeStatus(sqlite, results, 'tenant-a');
+
+      expect(results[0]).toMatchObject({
+        superseded_by: 'new',
+        superseded_at: '2026-06-17T00:00:00.000Z',
+        superseded_reason: 'replacement',
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test('filterResultsAsOf compares and emits ISO text temporal columns', () => {
+    const sqlite = memoryDb();
+    const valid = '2025-01-01T00:00:00.000Z';
+    const asOf = Date.parse('2025-06-01T00:00:00.000Z');
+    try {
+      sqlite.prepare(`
+        INSERT INTO oracle_documents
+          (id, tenant_id, valid_time, updated_at, created_at, indexed_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `).run('fact', 'tenant-a', valid, Date.parse(valid), Date.parse(valid), Date.parse(valid));
+
+      const filtered = filterResultsAsOf(sqlite, [{ id: 'fact' }], asOf, 'tenant-a');
+
+      expect(filtered).toEqual([{
+        id: 'fact',
+        valid_time: '2025-01-01T00:00:00.000Z',
+        valid_until: null,
+      }]);
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/tests/http/vector/documents.test.ts
+++ b/tests/http/vector/documents.test.ts
@@ -82,3 +82,28 @@ test('GET /api/v1/vector/documents returns offset-paged vector documents', async
   });
   expect(store.getAllEmbeddings).toHaveBeenCalledWith(4);
 });
+
+test('GET /api/v1/vector/documents falls back to query when export is unsupported', async () => {
+  const store = createStore();
+  store.getAllEmbeddings = mock(async () => {
+    const error = new Error('Proxy vector request failed: 501 Not Implemented');
+    Object.assign(error, { status: 501 });
+    throw error;
+  });
+  const collections: string[] = [];
+  const fetcher = createFetch(store, collections);
+
+  const res = await fetcher(new Request(
+    'http://local/api/v1/vector/documents?collection=proxy&limit=2',
+  ));
+  const body = await res.json() as {
+    items: Array<{ id: string; document: string; metadata: Record<string, unknown> }>;
+    total: number;
+  };
+
+  expect(res.status).toBe(200);
+  expect(collections).toEqual(['proxy']);
+  expect(body.items.map((item) => item.id)).toEqual(['doc-1', 'doc-2']);
+  expect(body.total).toBe(5);
+  expect(store.query).toHaveBeenCalledWith('', 2);
+});

--- a/tests/http/vector/fan-out.test.ts
+++ b/tests/http/vector/fan-out.test.ts
@@ -76,4 +76,27 @@ describe('FanOutQuery', () => {
     await expect(engine.search('oracle', [])).resolves.toEqual([]);
     await expect(engine.search('   ', ['alpha'])).rejects.toThrow('non-empty query');
   });
+
+  test('clamps scores, skips malformed ids, and does not double count same-collection duplicates', async () => {
+    const engine = new FanOutQuery(async () => [
+      { id: 'dup', score: 0.4, content: 'low' },
+      { id: 'dup', score: 0.9, content: 'high' },
+      { id: 'too-high', score: 4 },
+      { id: 'negative', score: -1 },
+      { id: 7 as any, score: 1 },
+      { id: 'near', distance: -5 },
+    ]);
+
+    const results = await engine.search('query', ['alpha'], { topK: 10 });
+
+    expect(results.find((item) => item.id === 'dup')).toMatchObject({
+      score: 0.9,
+      content: 'high',
+      collectionScores: { alpha: 0.9 },
+    });
+    expect(results.find((item) => item.id === 'too-high')?.score).toBe(1);
+    expect(results.find((item) => item.id === 'near')?.score).toBe(1);
+    expect(results.find((item) => item.id === 'negative')?.score).toBe(0);
+    expect(results.some((item) => item.id === '7')).toBe(false);
+  });
 });

--- a/tests/http/vector/oracle-api-client.test.ts
+++ b/tests/http/vector/oracle-api-client.test.ts
@@ -30,8 +30,8 @@ test('Studio vector API helpers call provider endpoints', async () => {
   await expect(getVectorProviders()).resolves.toEqual([{ type: 'gemini', available: true }]);
   await expect(testVectorProvider({ provider: 'gemini', text: 'hello' })).resolves.toMatchObject({ success: true });
   expect(calls.map((call) => `${call.method} ${call.url}`)).toEqual([
-    'GET /api/v1/vector/providers',
-    'POST /api/v1/vector/providers/test',
+    'GET http://localhost:47778/api/v1/vector/providers',
+    'POST http://localhost:47778/api/v1/vector/providers/test',
   ]);
 });
 
@@ -49,9 +49,9 @@ test('Studio vector API helpers call service registry endpoints', async () => {
   await expect(testVectorService('qdrant')).resolves.toMatchObject({ status: 'up' });
   await expect(unregisterVectorService('qdrant')).resolves.toBeUndefined();
   expect(calls.map((call) => `${call.method} ${call.url}`)).toEqual([
-    'GET /api/v1/vector/services',
-    'POST /api/v1/vector/services/register',
-    'POST /api/v1/vector/services/qdrant/test',
-    'DELETE /api/v1/vector/services/qdrant',
+    'GET http://localhost:47778/api/v1/vector/services',
+    'POST http://localhost:47778/api/v1/vector/services/register',
+    'POST http://localhost:47778/api/v1/vector/services/qdrant/test',
+    'DELETE http://localhost:47778/api/v1/vector/services/qdrant',
   ]);
 });

--- a/tests/integration/cors-pna.test.ts
+++ b/tests/integration/cors-pna.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createCorsMiddleware, createPrivateNetworkPreflightMiddleware, parseCorsOrigins } from '../../src/middleware/cors.ts';
+
+const HOSTED_STUDIO = 'https://god.buildwithoracle.com';
+
+function pnaPreflight(origin: string): Request {
+  return new Request('http://localhost:47778/api/health', {
+    method: 'OPTIONS',
+    headers: {
+      origin,
+      'access-control-request-method': 'GET',
+      'access-control-request-private-network': 'true',
+    },
+  });
+}
+
+function corsApp() {
+  return new Elysia()
+    .use(createPrivateNetworkPreflightMiddleware())
+    .use(createCorsMiddleware())
+    .get('/api/health', () => ({ status: 'ok' }));
+}
+
+describe('hosted Studio CORS and PNA preflight', () => {
+  test('default CORS origins include the hosted Studio domain', () => {
+    expect(parseCorsOrigins().origins).toContain(HOSTED_STUDIO);
+  });
+
+  test('allows hosted Studio private-network preflight to local Oracle', async () => {
+    const response = await corsApp().handle(pnaPreflight(HOSTED_STUDIO));
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe(HOSTED_STUDIO);
+    expect(response.headers.get('Access-Control-Allow-Private-Network')).toBe('true');
+    expect(response.headers.get('Access-Control-Allow-Methods')).toContain('GET');
+    expect(response.headers.get('Vary')).toContain('Origin');
+  });
+
+  test('does not grant private-network access to unknown origins', async () => {
+    const response = await corsApp().handle(pnaPreflight('https://evil.example'));
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull();
+    expect(response.headers.get('Access-Control-Allow-Private-Network')).toBeNull();
+  });
+});

--- a/tests/integration/vector-sidecar-proxy.test.ts
+++ b/tests/integration/vector-sidecar-proxy.test.ts
@@ -15,7 +15,7 @@ const originalEnv = snapshotEnv([
   'ORACLE_PROXY_VECTOR_URL', 'ORACLE_VECTOR_ENABLED', 'ORACLE_EMBEDDER',
   'ORACLE_EMBEDDER_URL', 'ORACLE_EMBEDDING_DIMENSIONS', 'ARRA_FORCE_AVX',
   'VECTOR_URL', 'ORACLE_VECTOR_DB_PATH', 'ARRA_API_TOKEN', 'ARRA_API_KEY',
-  'ORACLE_TENANT_TOKENS', 'ORACLE_TENANT_API_KEYS',
+  'ORACLE_TENANT_TOKENS', 'ORACLE_TENANT_API_KEYS', 'ORACLE_GATEWAY_HOT_RELOAD',
 ]);
 
 process.env.ORACLE_DATA_DIR = backendData;
@@ -31,53 +31,20 @@ delete process.env.ARRA_API_TOKEN;
 delete process.env.ARRA_API_KEY;
 delete process.env.ORACLE_TENANT_TOKENS;
 delete process.env.ORACLE_TENANT_API_KEYS;
+process.env.ORACLE_GATEWAY_HOT_RELOAD = '0';
 
 const { db, sqlite, oracleDocuments, closeDb, resetDefaultDatabaseForTests } = await import('../../src/db/index.ts');
 resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
 const { createApp } = await import('../../src/server.ts');
+const { proxyToolCall } = await import('../../src/mcp/http-proxy.ts');
 const { loadUnifiedPlugins } = await import('../../src/plugins/unified-loader.ts');
+const { closeCachedVectorStores } = await import('../../src/vector/factory.ts');
 
 describe('backend to vector sidecar wiring', () => {
   test('createApp search reaches bun run vector:proxy through proxy adapter', async () => {
-    const embedder = fixedEmbedder();
-    const port = await freePort();
-    const sidecar = Bun.spawn(['bun', 'run', 'vector:proxy'], {
-      cwd: process.cwd(),
-      env: {
-        ...process.env,
-        ORACLE_DATA_DIR: sidecarData,
-        ORACLE_DB_PATH: path.join(sidecarData, 'oracle.db'),
-        VECTOR_PORT: String(port),
-        ORACLE_VECTOR_DB: 'lancedb',
-        ORACLE_EMBEDDER: 'remote',
-        ORACLE_EMBEDDER_URL: `${embedder.url}embed`,
-        ORACLE_EMBEDDING_DIMENSIONS: '3',
-        ARRA_FORCE_AVX: '0',
-      },
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
-    const sidecarUrl = `http://127.0.0.1:${port}`;
-
+    const sidecar = await startSidecar();
     try {
-      await waitForOk(`${sidecarUrl}/health`);
-      process.env.ORACLE_PROXY_VECTOR_URL = sidecarUrl;
-      writeBackendVectorConfig(sidecarUrl);
-      seedBackendDoc();
-
-      const add = await fetch(`${sidecarUrl}/vectors/add`, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          documents: [{
-            id: 'wire-doc',
-            document: 'Sidecar vector proxy wiring proof',
-            metadata: { type: 'learning', source_file: 'docs/wire.md' },
-            vector: [0.9, 0.1, 0.1],
-          }],
-        }),
-      });
-      expect(add.status).toBe(200);
+      await seedWirePath(sidecar.url);
 
       const app = await createBackendApp();
       const response = await app.handle(new Request(
@@ -90,9 +57,33 @@ describe('backend to vector sidecar wiring', () => {
       expect(result.results?.map((item) => item.id)).toContain('wire-doc');
       expect(result.results?.[0]).toMatchObject({ source: 'vector', source_file: 'docs/wire.md' });
     } finally {
-      sidecar.kill();
-      embedder.stop(true);
-      await sidecar.exited.catch(() => undefined);
+      await sidecar.stop();
+    }
+  });
+
+  test('MCP oracle_search proxies through createApp and returns sidecar vector results', async () => {
+    const sidecar = await startSidecar();
+    let server: ReturnType<typeof Bun.serve> | undefined;
+    try {
+      await seedWirePath(sidecar.url);
+      const app = await createBackendApp();
+      server = Bun.serve({ hostname: '127.0.0.1', port: 0, fetch: (request) => app.fetch(request) });
+
+      const tool = await proxyToolCall(String(server.url).replace(/\/$/, ''), 'oracle_search', {
+        query: 'sidecar wiring',
+        type: 'learning',
+        limit: 5,
+        mode: 'vector',
+      });
+      const result = parseToolJson(tool);
+
+      expect(result.vectorAvailable).toBe(true);
+      expect(result.results?.map((item) => item.id)).toContain('wire-doc');
+      expect(result.results?.[0]?.source_file).toBe('docs/wire.md');
+      expect(['vector', 'hybrid']).toContain(result.results?.[0]?.source);
+    } finally {
+      await server?.stop(true);
+      await sidecar.stop();
     }
   });
 });
@@ -139,6 +130,71 @@ function seedBackendDoc() {
     indexedAt: now,
     project: null,
   }).run();
+}
+
+async function seedWirePath(sidecarUrl: string) {
+  await closeCachedVectorStores();
+  process.env.ORACLE_PROXY_VECTOR_URL = sidecarUrl;
+  writeBackendVectorConfig(sidecarUrl);
+  seedBackendDoc();
+  await fetch(`${sidecarUrl}/vectors/collection`, { method: 'DELETE' });
+  const add = await fetch(`${sidecarUrl}/vectors/add`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      documents: [{
+        id: 'wire-doc',
+        document: 'Sidecar vector proxy wiring proof',
+        metadata: { type: 'learning', source_file: 'docs/wire.md' },
+        vector: [0.9, 0.1, 0.1],
+      }],
+    }),
+  });
+  expect(add.status).toBe(200);
+}
+
+async function startSidecar() {
+  const embedder = fixedEmbedder();
+  const port = await freePort();
+  const proc = Bun.spawn(['bun', 'run', 'vector:proxy'], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      ORACLE_DATA_DIR: sidecarData,
+      ORACLE_DB_PATH: path.join(sidecarData, 'oracle.db'),
+      VECTOR_PORT: String(port),
+      ORACLE_VECTOR_DB: 'lancedb',
+      ORACLE_EMBEDDER: 'remote',
+      ORACLE_EMBEDDER_URL: `${embedder.url}embed`,
+      ORACLE_EMBEDDING_DIMENSIONS: '3',
+      ARRA_FORCE_AVX: '0',
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const url = `http://127.0.0.1:${port}`;
+  try {
+    await waitForOk(`${url}/health`);
+  } catch (error) {
+    proc.kill();
+    embedder.stop(true);
+    await proc.exited.catch(() => undefined);
+    throw error;
+  }
+  return {
+    url,
+    stop: async () => {
+      proc.kill();
+      embedder.stop(true);
+      await proc.exited.catch(() => undefined);
+    },
+  };
+}
+
+function parseToolJson(tool: Awaited<ReturnType<typeof proxyToolCall>>) {
+  expect(tool).not.toBeNull();
+  expect(tool?.isError).toBeUndefined();
+  return JSON.parse(tool!.content[0].text) as { vectorAvailable?: boolean; results?: Array<Record<string, unknown>> };
 }
 
 function fixedEmbedder() {

--- a/tests/lifecycle/self-test-timeout.test.ts
+++ b/tests/lifecycle/self-test-timeout.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test';
+import { runStartupSelfTest } from '../../src/lifecycle/self-test.ts';
+
+describe('startup self-test timeout hardening', () => {
+  test('marks a stuck check failed and still runs later checks', async () => {
+    const logs: string[] = [];
+    const calls: string[] = [];
+
+    const results = await runStartupSelfTest({
+      timeoutMs: 10,
+      checks: [
+        { name: 'stuck', run: () => new Promise<void>(() => undefined) },
+        { name: 'next', run: () => { calls.push('next'); } },
+      ],
+      log: (message) => logs.push(message),
+    });
+
+    expect(results).toEqual([
+      { name: 'stuck', status: 'fail', message: 'timed out after 10ms' },
+      { name: 'next', status: 'pass', message: 'ok' },
+    ]);
+    expect(calls).toEqual(['next']);
+    expect(logs).toContain('[SelfTest] FAIL stuck — timed out after 10ms');
+    expect(logs.at(-1)).toBe('[SelfTest] summary: 1 passed, 1 failed');
+  });
+
+  test('ignores invalid timeout values to preserve existing no-timeout behavior', async () => {
+    const results = await runStartupSelfTest({
+      timeoutMs: Number.NaN,
+      checks: [{ name: 'quick', run: async () => undefined }],
+      log: () => undefined,
+    });
+
+    expect(results).toEqual([{ name: 'quick', status: 'pass', message: 'ok' }]);
+  });
+});

--- a/tests/lifecycle/shutdown-controller.test.ts
+++ b/tests/lifecycle/shutdown-controller.test.ts
@@ -32,6 +32,14 @@ describe('shutdown controller', () => {
     expect(activeRequestCount()).toBe(0);
   });
 
+  test('releases tracked requests when handlers reject', async () => {
+    await expect(trackRequest(async () => {
+      throw new Error('handler failed');
+    })).rejects.toThrow('handler failed');
+
+    expect(activeRequestCount()).toBe(0);
+  });
+
   test('returns 503 for new non-health requests while draining', async () => {
     const blocked = drainingResponseFor(new Request('http://local/api/search?q=x'), { draining: true });
     const health = drainingResponseFor(new Request('http://local/api/health'), { draining: true });
@@ -40,6 +48,20 @@ describe('shutdown controller', () => {
     expect(blocked?.headers.get('Retry-After')).toBe('5');
     expect(await blocked?.json()).toMatchObject({ status: 'draining', draining: true });
     expect(health).toBeNull();
+  });
+
+  test('honors caller-provided health paths while draining', () => {
+    const health = drainingResponseFor(new Request('http://local/internal/live'), {
+      draining: true,
+      healthPaths: ['/internal/live'],
+    });
+    const blocked = drainingResponseFor(new Request('http://local/api/health'), {
+      draining: true,
+      healthPaths: ['/internal/live'],
+    });
+
+    expect(health).toBeNull();
+    expect(blocked?.status).toBe(503);
   });
 
   test('normalizes malformed Retry-After values while draining', () => {

--- a/tests/mcp/aliases-edge.test.ts
+++ b/tests/mcp/aliases-edge.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from 'bun:test';
+import { resolveToolName } from '../../src/mcp/aliases.ts';
+
+test('MCP aliases trim names and normalize already-canonical alias suffixes', () => {
+  expect(resolveToolName('  muninn_oracle_search  ')).toBe('oracle_search');
+  expect(resolveToolName('arra_oracle_learn')).toBe('oracle_learn');
+});
+
+test('MCP aliases leave empty legacy prefixes unchanged', () => {
+  expect(resolveToolName('arra_')).toBe('arra_');
+  expect(resolveToolName('muninn_')).toBe('muninn_');
+});

--- a/tests/mcp/tenant-proxy-edge.test.ts
+++ b/tests/mcp/tenant-proxy-edge.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, expect, test } from 'bun:test';
+import { proxyToolCall } from '../../src/mcp/http-proxy.ts';
+import { tenantIdFromMcpArgs } from '../../src/mcp/tenant.ts';
+import { TENANT_HEADER } from '../../src/middleware/tenant.ts';
+import { captureProxyRequest } from './support/http-proxy.ts';
+
+afterEach(() => {
+  delete process.env.ORACLE_TENANT_ID;
+  delete process.env.ORACLE_TENANT;
+});
+
+test('MCP tenant parser falls back to env only when explicit tenant hints are blank', () => {
+  process.env.ORACLE_TENANT_ID = 'env-tenant';
+  expect(tenantIdFromMcpArgs({ tenantId: '   ', tenant: '' })).toBe('env-tenant');
+  expect(() => tenantIdFromMcpArgs({ tenantId: 'bad tenant' })).toThrow('invalid tenant id');
+});
+
+test('HTTP proxy accepts tenant alias args and strips them from query params', async () => {
+  const captured = await captureProxyRequest('oracle_search', {
+    query: 'proxy tenant edge',
+    org_id: 'tenant-from-org',
+    tenant: 'ignored-lower-priority',
+  });
+
+  expect(captured).toMatchObject({
+    method: 'GET',
+    path: '/api/search',
+    query: { q: 'proxy tenant edge' },
+    headers: { [TENANT_HEADER.toLowerCase()]: 'ignored-lower-priority' },
+  });
+});
+
+test('HTTP proxy validates explicit tenant hints even when base URL is embedded', async () => {
+  await expect(proxyToolCall(null, 'oracle_search', { query: 'x', tenantId: 'bad tenant' })).rejects.toThrow('invalid tenant id');
+});

--- a/tests/plugins/watcher-runtime-ref-lifecycle.test.ts
+++ b/tests/plugins/watcher-runtime-ref-lifecycle.test.ts
@@ -32,11 +32,12 @@ function runtime(label: string, events: string[], initError?: Error): RuntimeStu
   };
 }
 
-function servers(label: string, events: string[]): UnifiedServerRuntime {
+function servers(label: string, events: string[], stopError?: Error): UnifiedServerRuntime {
   return {
     started: 0,
     stop: async () => {
       events.push(`${label}:servers-stop`);
+      if (stopError) throw stopError;
     },
   };
 }
@@ -45,6 +46,20 @@ async function startServers(nextServers: UnifiedRuntime["servers"], events: stri
   const label = nextServers[0]?.plugin ?? "none";
   events.push(`${label}:servers-start`);
   return servers(label, events);
+}
+
+async function waitUntil(predicate: () => boolean) {
+  const deadline = Date.now() + 500;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error("timed out waiting for condition");
+    await Bun.sleep(1);
+  }
+}
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => { resolve = done; });
+  return { promise, resolve };
 }
 
 describe("watchPluginManifests runtimeRef lifecycle", () => {
@@ -97,6 +112,59 @@ describe("watchPluginManifests runtimeRef lifecycle", () => {
       "next:stop",
       "old:init",
       "old:servers-start",
+    ]);
+    watcher.close();
+  });
+
+  test("restores the previous runtime when previous servers fail to stop", async () => {
+    const events: string[] = [];
+    const previous = runtime("old", events);
+    const ref = createUnifiedRuntimeRef(previous);
+    const next = runtime("next", events);
+    const state = { servers: servers("old", events, new Error("server stop failed")) };
+
+    const watcher = watchPluginManifests({
+      dirs: [],
+      loader: async () => next,
+      onReload: (runtime) => swapUnifiedRuntimeWithLifecycle(ref, state, runtime),
+    });
+
+    await expect(watcher.reload()).rejects.toThrow("server stop failed");
+
+    expect(ref.current).toBe(previous);
+    expect(events).toEqual(["old:stop", "old:servers-stop", "old:init"]);
+    watcher.close();
+  });
+
+  test("serializes overlapping reloads so lifecycle swaps cannot interleave", async () => {
+    const events: string[] = [];
+    const gate = deferred();
+    let id = 0;
+    const watcher = watchPluginManifests({
+      dirs: [],
+      loader: async () => runtime(`next-${++id}`, events),
+      onReload: async (loaded) => {
+        const label = (loaded as RuntimeStub).label;
+        events.push(`${label}:onReload-start`);
+        if (label === "next-1") await gate.promise;
+        events.push(`${label}:onReload-end`);
+      },
+    });
+
+    const first = watcher.reload();
+    await waitUntil(() => events.includes("next-1:onReload-start"));
+    const second = watcher.reload();
+    await Bun.sleep(10);
+    expect(events).toEqual(["next-1:onReload-start"]);
+
+    gate.resolve();
+    await Promise.all([first, second]);
+
+    expect(events).toEqual([
+      "next-1:onReload-start",
+      "next-1:onReload-end",
+      "next-2:onReload-start",
+      "next-2:onReload-end",
     ]);
     watcher.close();
   });

--- a/tests/vector/factory-connect-failure.test.ts
+++ b/tests/vector/factory-connect-failure.test.ts
@@ -24,3 +24,26 @@ test('vector store registry logs background connection failures without throwing
     console.warn = originalWarn;
   }
 });
+
+test('vector store registry logs synchronous connection failures without throwing', async () => {
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(' ')); };
+  try {
+    const store = getVectorStoreByModel('sync_failure_model', {
+      sync_failure_model: {
+        collection: 'sync_failure_collection',
+        model: 'sync-failure-model',
+        adapter: 'lancedb',
+        dataPath: tempDir('arra-vector-sync-failure-'),
+        embedder: { backend: 'none' },
+      },
+    }, () => { throw new Error('sync boom'); });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(store.name).toBe('lancedb');
+    expect(warnings.some((line) => line.includes('Failed to connect sync_failure_model'))).toBe(true);
+  } finally {
+    console.warn = originalWarn;
+  }
+});

--- a/tests/vector/factory-deep-hardening.test.ts
+++ b/tests/vector/factory-deep-hardening.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test';
-import { createVectorStore } from '../../src/vector/factory.ts';
+import { createVectorStore, createVectorStoreForModel } from '../../src/vector/factory.ts';
 import { trackEnv } from './helpers.ts';
 
 test('vector factory trims adapter type, collection, and proxy endpoint config', () => {
@@ -11,7 +11,7 @@ test('vector factory trims adapter type, collection, and proxy endpoint config',
 
   expect(store.name).toBe('proxy');
   expect(store.collectionName).toBe('docs');
-  expect(store.endpoint).toBe('http://vector.local/');
+  expect(store.endpoint).toBe('http://vector.local');
 });
 
 test('vector factory treats blank ORACLE_VECTOR_DB as unset', () => {
@@ -19,4 +19,19 @@ test('vector factory treats blank ORACLE_VECTOR_DB as unset', () => {
   const store = createVectorStore({ dataPath: '/tmp/arra-vector-factory-hardening' });
 
   expect(store.name).toBe('lancedb');
+});
+
+test('vector factory passes model-level qdrant config when creating stores', () => {
+  const store = createVectorStoreForModel({
+    collection: 'qdrant_docs',
+    model: 'qdrant-model',
+    adapter: 'qdrant',
+    qdrantUrl: ' http://qdrant.local ',
+    qdrantApiKey: ' secret ',
+    embedder: { backend: 'none' },
+  }) as any;
+
+  expect(store.name).toBe('qdrant');
+  expect(store.url).toBe('http://qdrant.local');
+  expect(store.apiKey).toBe('secret');
 });

--- a/tests/vector/fanout-query.test.ts
+++ b/tests/vector/fanout-query.test.ts
@@ -24,6 +24,20 @@ test('fanout merge deduplicates by id, boosts shared docs, and reranks', () => {
   expect(merged[0]).toMatchObject({ id: 'a', source: 'hybrid', score: 0.75 });
 });
 
+test('fanout merge clamps malformed result scores', () => {
+  const merged = mergeFanoutResults([
+    result('nan', Number.NaN, 'lancedb'),
+    result('negative', -5, 'lancedb'),
+    result('huge', 5, 'lancedb'),
+    result('nan', 0.2, 'turbovec'),
+  ]);
+
+  expect(merged.find((item) => item.id === 'huge')?.score).toBe(1);
+  expect(merged.find((item) => item.id === 'negative')?.score).toBe(0);
+  expect(merged.find((item) => item.id === 'nan')?.score).toBe(0.25);
+  expect(merged.every((item) => Number.isFinite(item.score))).toBe(true);
+});
+
 test('fanout query runs targets in parallel and preserves partial errors', async () => {
   const response = await queryFanout({
     text: 'oracle',

--- a/tests/vector/proxy-deep-hardening.test.ts
+++ b/tests/vector/proxy-deep-hardening.test.ts
@@ -35,3 +35,27 @@ test('proxy adapter skips empty add batches and normalizes stats/query edges', a
   expect(info).toEqual({ name: 'docs', count: 0 });
   expect(queryPayload).toMatchObject({ text: 'oracle', limit: 10 });
 });
+
+test('proxy adapter caps oversized query and export limits', async () => {
+  const paths: string[] = [];
+  let queryPayload: any;
+  const target = startServer(async (req) => {
+    const url = new URL(req.url);
+    paths.push(`${req.method} ${url.pathname}${url.search}`);
+    if (url.pathname === '/vectors/query') {
+      queryPayload = await req.json();
+      return Response.json({ ids: [], documents: [], distances: [], metadatas: [] });
+    }
+    if (url.pathname === '/vectors/export') {
+      return Response.json({ ids: [], embeddings: [], metadatas: [], documents: [] });
+    }
+    return Response.json({ status: 'ok', name: 'proxy', version: 'test' });
+  });
+  const adapter = new ProxyVectorAdapter('docs', target);
+
+  await adapter.query('oracle', 999999);
+  await adapter.getAllEmbeddings(999999);
+
+  expect(queryPayload.limit).toBe(1000);
+  expect(paths).toContain('GET /vectors/export?limit=1000');
+});

--- a/tests/vector/service-registry.test.ts
+++ b/tests/vector/service-registry.test.ts
@@ -112,3 +112,17 @@ test('VectorServiceRegistry verifies declared proxy protocol capability', async 
     server.stop(true);
   }
 });
+
+test('VectorServiceRegistry drops non-record capabilities before persisting', async () => {
+  useTempDataDir();
+  const registry = new VectorServiceRegistry();
+
+  const service = await registry.register({
+    name: 'arraycaps',
+    type: 'builtin',
+    capabilities: ['not', 'record'] as any,
+  });
+
+  expect(service).toEqual({ kind: 'vector', name: 'arraycaps', type: 'builtin', endpoint: undefined });
+  expect((await registry.discover()).find((item) => item.name === 'arraycaps')?.capabilities).toBeUndefined();
+});


### PR DESCRIPTION
## Summary
- Run Playwright e2e against isolated backend, frontend, and vector fixture servers.
- Add frontend page render/interaction coverage for menu, plugins, vector, MCP, theme toggle, search, and command palette navigation.
- Add dashboard loader edge tests for multiple endpoint failures and partial successes.
- Replace stale API e2e consult check with current concepts endpoint coverage.

## Validation
- `bunx tsc --noEmit`
- `bun test tests/frontend/`
- `bunx playwright test --reporter=line`
- `bun test tests/e2e/`
- `git diff --check`
- changed source/test/config files <= 250 lines
