### PR TITLE
test(mcp): harden tenant proxy alias edges

### DIFF
--- a/src/mcp/aliases.ts
+++ b/src/mcp/aliases.ts
@@ -4,7 +4,10 @@ const ALIAS_PREFIXES = ['arra_', 'muninn_'] as const;
 export function resolveToolName(name: string): string {
   const clean = name.trim();
   for (const prefix of ALIAS_PREFIXES) {
-    if (clean.startsWith(prefix)) return 'oracle_' + clean.slice(prefix.length);
+    if (!clean.startsWith(prefix)) continue;
+    const suffix = clean.slice(prefix.length).trim();
+    if (!suffix) return clean;
+    return suffix.startsWith('oracle_') ? suffix : `oracle_${suffix}`;
   }
   return clean;
 }

--- a/tests/mcp/aliases-edge.test.ts
+++ b/tests/mcp/aliases-edge.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from 'bun:test';
+import { resolveToolName } from '../../src/mcp/aliases.ts';
+
+test('MCP aliases trim names and normalize already-canonical alias suffixes', () => {
+  expect(resolveToolName('  muninn_oracle_search  ')).toBe('oracle_search');
+  expect(resolveToolName('arra_oracle_learn')).toBe('oracle_learn');
+});
+
+test('MCP aliases leave empty legacy prefixes unchanged', () => {
+  expect(resolveToolName('arra_')).toBe('arra_');
+  expect(resolveToolName('muninn_')).toBe('muninn_');
+});

--- a/tests/mcp/tenant-proxy-edge.test.ts
+++ b/tests/mcp/tenant-proxy-edge.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, expect, test } from 'bun:test';
+import { proxyToolCall } from '../../src/mcp/http-proxy.ts';
+import { tenantIdFromMcpArgs } from '../../src/mcp/tenant.ts';
+import { TENANT_HEADER } from '../../src/middleware/tenant.ts';
+import { captureProxyRequest } from './support/http-proxy.ts';
+
+afterEach(() => {
+  delete process.env.ORACLE_TENANT_ID;
+  delete process.env.ORACLE_TENANT;
+});
+
+test('MCP tenant parser falls back to env only when explicit tenant hints are blank', () => {
+  process.env.ORACLE_TENANT_ID = 'env-tenant';
+  expect(tenantIdFromMcpArgs({ tenantId: '   ', tenant: '' })).toBe('env-tenant');
+  expect(() => tenantIdFromMcpArgs({ tenantId: 'bad tenant' })).toThrow('invalid tenant id');
+});
+
+test('HTTP proxy accepts tenant alias args and strips them from query params', async () => {
+  const captured = await captureProxyRequest('oracle_search', {
+    query: 'proxy tenant edge',
+    org_id: 'tenant-from-org',
+    tenant: 'ignored-lower-priority',
+  });
+
+  expect(captured).toMatchObject({
+    method: 'GET',
+    path: '/api/search',
+    query: { q: 'proxy tenant edge' },
+    headers: { [TENANT_HEADER.toLowerCase()]: 'ignored-lower-priority' },
+  });
+});
+
+test('HTTP proxy validates explicit tenant hints even when base URL is embedded', async () => {
+  await expect(proxyToolCall(null, 'oracle_search', { query: 'x', tenantId: 'bad tenant' })).rejects.toThrow('invalid tenant id');
+});


### PR DESCRIPTION
## Summary
- harden MCP legacy alias resolution for already-canonical suffixes like `muninn_oracle_search`
- preserve empty legacy prefixes as invalid tool names instead of producing `oracle_`
- add tenant/proxy edge coverage for env fallback, explicit invalid tenants, alias tenant stripping, and proxy validation

## Validation
```bash
bun test --isolate tests/mcp/aliases-edge.test.ts tests/mcp/aliases-resolve-arra-prefix.test.ts tests/mcp/aliases-resolve-muninn-prefix.test.ts tests/mcp/aliases-preserve-canonical-name.test.ts tests/mcp/tenant-proxy-edge.test.ts tests/mcp/tenant-env-fallback.test.ts tests/mcp/tenant-invalid-id.test.ts tests/mcp/tenant-strip-aliases.test.ts tests/mcp/http-proxy-forwards-tenant.test.ts tests/mcp/server-call-handler-resolves-aliases.test.ts
bunx tsc --noEmit
git diff --check
wc -l src/mcp/aliases.ts tests/mcp/aliases-edge.test.ts tests/mcp/tenant-proxy-edge.test.ts
```
