### PR TITLE
docs: diagram HTTPS Studio localhost vector flow

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ is linked here; keep new docs in the right section when adding files.
 ## Navigate by task
 
 - **Deploy**: start with [architecture/deploy-topologies.md](./architecture/deploy-topologies.md), then pick [deploy-production.md](./deploy-production.md), [deploy-cloudflare.md](./deploy-cloudflare.md), [deploy-cloudflare-mcp.md](./deploy-cloudflare-mcp.md), [deploy-vercel.md](./deploy-vercel.md), or [DEPLOY-DIGITALOCEAN.md](./DEPLOY-DIGITALOCEAN.md).
-- **Architecture**: read [architecture.md](./architecture.md), [architecture/modular-backend.md](./architecture/modular-backend.md), and [architecture/modular-backend-current-state.md](./architecture/modular-backend-current-state.md).
+- **Architecture**: read [architecture.md](./architecture.md), [architecture/modular-backend.md](./architecture/modular-backend.md), [architecture/https-localhost-vector-flow.md](./architecture/https-localhost-vector-flow.md), and [architecture/modular-backend-current-state.md](./architecture/modular-backend-current-state.md).
 - **Memory/search**: read [architecture/memory-layer.md](./architecture/memory-layer.md), [architecture/memory-pipeline.md](./architecture/memory-pipeline.md), [HUGINN-MUNINN.md](./HUGINN-MUNINN.md), and [vector-runtime.md](./vector-runtime.md).
 - **MCP**: read [mcp-tools.md](./mcp-tools.md), [architecture/mcp-remote-transport.md](./architecture/mcp-remote-transport.md), [MCP-FROM-OPENAPI.md](./MCP-FROM-OPENAPI.md), and [deploy-cloudflare-mcp.md](./deploy-cloudflare-mcp.md).
 
@@ -24,6 +24,7 @@ is linked here; keep new docs in the right section when adding files.
 | [architecture/modular-backend-current-state.md](./architecture/modular-backend-current-state.md) | Current modular-backend extraction status and boundaries | backend split, current state |
 | [architecture/mcp-remote-transport.md](./architecture/mcp-remote-transport.md) | Remote MCP Worker transport and `mcp-remote` client bridge contract | Workers, MCP bridge, OAuth |
 | [architecture/deploy-topologies.md](./architecture/deploy-topologies.md) | Choose all-local, Cloudflare edge, Vercel, or federation tunnel deployment. | deploy options, edge/backend/vector split |
+| [architecture/https-localhost-vector-flow.md](./architecture/https-localhost-vector-flow.md) | Sequence diagram for hosted HTTPS Studio calling a localhost Oracle backend and local vector flow. | #2312, localhost, PNA, vector |
 | [architecture/memory-layer.md](./architecture/memory-layer.md) | Memory confidence ranking, retrieval reinforcement, supersede, and consolidation contracts from #2251. | memory, confidence, supersede, consolidation |
 | [architecture/memory-pipeline.md](./architecture/memory-pipeline.md) | Diagram the write, FTS, async consolidation, confidence ranking, and bi-temporal read pipeline. | memory pipeline, FTS, asOf, ranking |
 | [architecture/cloudflared-origin-contract.md](./architecture/cloudflared-origin-contract.md) | `ORACLE_ORIGIN_URL` secret and Cloudflare Tunnel origin contract for Workers. | Cloudflare Tunnel, origin URL, Workers secrets |

--- a/docs/architecture/https-localhost-vector-flow.md
+++ b/docs/architecture/https-localhost-vector-flow.md
@@ -1,0 +1,122 @@
+# HTTPS Studio to localhost backend to vector flow (#2312)
+
+Issue #2312 adds a personal-use path where hosted HTTPS Studio assets talk
+directly to the operator's local Oracle backend. The Cloudflare Worker serves the
+static Studio shell, but the browser sends API calls to `http://localhost:47778`
+instead of proxying through the Worker or a cloudflared tunnel.
+
+## When to use this pattern
+
+Use this for a single operator who wants a public HTTPS Studio URL while keeping
+all memory, plugins, and vectors local. Do not use it for shared/team access,
+mobile clients, or remote machines that cannot reach the operator's loopback
+interface.
+
+```text
+Hosted Studio URL: https://god.buildwithoracle.com/?host=localhost:47778
+Backend URL:       http://localhost:47778
+Vector sidecar:    http://localhost:<vector-port> or backend-selected adapter
+```
+
+## Sequence diagram
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor User
+  participant Browser as Browser running hosted Studio
+  participant Studio as HTTPS Studio Worker
+  participant Backend as localhost:47778 maw arra backend
+  participant Vector as local vector server / adapter
+  participant DB as local SQLite + FTS
+
+  User->>Browser: Open https://god.buildwithoracle.com/?host=localhost:47778
+  Browser->>Studio: GET /?host=localhost:47778
+  Studio-->>Browser: Static Studio assets
+  Browser->>Browser: Resolve host from ?host → localStorage → localhost:47778
+  Browser->>Backend: OPTIONS /api/search<br/>Origin: https://god.buildwithoracle.com<br/>Access-Control-Request-Private-Network: true
+  Backend-->>Browser: CORS + PNA allow headers
+  Browser->>Backend: POST /api/search<br/>targetAddressSpace: "local"
+  Backend->>Backend: Auth, tenant, route, plugin middleware
+  Backend->>DB: FTS/document metadata lookup
+  alt hybrid or vector mode
+    Backend->>Vector: POST /vectors/query with tenant context
+    Vector-->>Backend: vector matches + scores
+  end
+  Backend->>Backend: Merge, confidence/rerank, supersede filtering
+  Backend-->>Browser: JSON search response
+  Browser-->>User: Render results without sending data through edge proxy
+```
+
+## Browser-side contract
+
+The frontend API client owns host resolution and persistence:
+
+1. Read `?host=` on first load.
+2. Persist the host in `localStorage` under the Oracle Studio key.
+3. Redirect to a clean URL without the query parameter.
+4. Default to `localhost:47778` when no value exists.
+5. Build API URLs as `http://<host>/api/*` for local direct mode.
+6. Add Private Network Access metadata such as `targetAddressSpace: 'local'` on
+   fetches where the browser supports it.
+7. Show a "Connect to your Oracle" setup gate when health checks fail.
+
+Keep `/api/*` same-origin proxy mode available for production Cloudflare/Vercel
+setups that use `ORACLE_ORIGIN_URL` or `ORACLE_URL` instead.
+
+## Backend contract
+
+The local backend must accept the hosted Studio origin without weakening the rest
+of the API boundary:
+
+- `maw arra serve --port 47778` answers `GET /api/health` locally.
+- CORS allows the hosted Studio origin and requested auth/tenant headers.
+- Private Network Access preflight returns
+  `Access-Control-Allow-Private-Network: true` for approved origins.
+- API token auth still applies when `ARRA_API_TOKEN` is configured.
+- Tenant headers remain explicit; browser-provided tenant IDs are not trusted as
+  authorization by themselves.
+
+## Vector flow
+
+Vector search stays behind the backend. The browser never calls LanceDB, Qdrant,
+TurboVec, or embedding providers directly.
+
+```text
+Browser -> http://localhost:47778/api/search
+Backend -> local DB / FTS
+Backend -> vector server or selected vector adapter
+Backend -> confidence/rerank/supersede response
+```
+
+If a separate vector sidecar is running, the backend should use the existing
+vector proxy config, for example `ORACLE_PROXY_VECTOR_URL`. If no vector sidecar
+is available, the backend keeps FTS fallback behavior and the UI should surface
+that degraded mode rather than routing around the backend.
+
+## Security boundaries
+
+- The Worker serves assets only in this pattern; it cannot read local documents.
+- The browser talks to the operator's own loopback backend.
+- The local backend is still responsible for auth, tenant scoping, CORS, PNA,
+  plugin permissions, and vector fallback.
+- Use cloudflared + `ORACLE_ORIGIN_URL` instead when other people or devices need
+  to reach the same backend.
+
+## Failure states
+
+| Symptom | Expected UI / operator action |
+| --- | --- |
+| `GET /api/health` fails | Show BackendGate with start command and host picker. |
+| PNA preflight rejected | Explain that the backend must allow the hosted origin and PNA header. |
+| Browser lacks local-network support | Offer cloudflared production deploy as fallback. |
+| Vector sidecar down | Keep FTS search available and show vector degraded status. |
+| Token mismatch | Prompt for the backend token without changing the saved host. |
+
+## References
+
+- [#2312 direct HTTPS Studio to localhost pattern](https://github.com/Soul-Brews-Studio/arra-oracle-v3/issues/2312)
+- [Cloudflared origin contract](./cloudflared-origin-contract.md)
+- [Deploy topologies](./deploy-topologies.md)
+- [MDN secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Secure_Contexts)
+- [Chrome local network access](https://developer.chrome.com/blog/local-network-access)


### PR DESCRIPTION
## Summary
- Add `docs/architecture/https-localhost-vector-flow.md` with a Mermaid sequence diagram for the #2312 hosted HTTPS Studio → localhost backend → vector flow.
- Document browser host resolution, PNA/CORS preflight, backend auth/tenant responsibilities, vector fallback, and failure states.
- Link the new architecture guide from `docs/README.md`.

## Validation
```bash
bunx tsc --noEmit
bun test tests/docs/
git diff --check
wc -l docs/architecture/https-localhost-vector-flow.md docs/README.md
```
