### PR TITLE
feat: connect hosted Studio to local Oracle

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,7 +1,7 @@
-import { apiUrl } from './api/oracle';
+import { apiFetch } from './api/oracle';
 import type { McpToolsResponse, MenuResponse, PluginsResponse, SearchResponse, SettingsSystemResponse, VectorConfigResponse, VectorConfigUpdateResponse } from './types';
 
-export { API_BASE, apiUrl, isTauri } from './api/oracle';
+export { API_BASE, apiFetch, apiUrl, isTauri, withLocalPna } from './api/oracle';
 
 export class ApiError extends Error {
   constructor(readonly status: number, message: string) {
@@ -15,7 +15,7 @@ async function getJson<T>(path: string, init?: RequestInit): Promise<T> {
   if (init?.body && !headers.has('content-type')) headers.set('content-type', 'application/json');
   let response: Response;
   try {
-    response = await fetch(apiUrl(path), { ...init, headers });
+    response = await apiFetch(path, { ...init, headers });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     throw new ApiError(0, `${path} is unreachable: ${message}`);

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -7,7 +7,7 @@ import type {
   VectorSearchResponse,
 } from '../../../src/server/types';
 import type { LearnCreateResponse, LearnDeleteResponse, LearnListResponse, LearnMutationPayload, LearnUpdateResponse } from '../types';
-import { API_BASE } from './oracle';
+import { API_BASE, apiFetch } from './oracle';
 
 export interface MenuSearchResponse {
   data: MenuItem[];
@@ -219,8 +219,7 @@ export class ApiClient {
   }
 
   private async fetchJson<T>(path: string, init: RequestInit = {}): Promise<T> {
-    const fetcher = this.options.fetch ?? globalThis.fetch?.bind(globalThis);
-    if (!fetcher) throw new ApiClientError(0, path, `${path} is unreachable: fetch is unavailable`);
+    const fetcher = this.options.fetch ?? apiFetch;
 
     const headers = withJsonHeaders(this.options.headers, init);
     let response: Response;

--- a/frontend/src/api/oracle.ts
+++ b/frontend/src/api/oracle.ts
@@ -1,11 +1,76 @@
 export const TAURI_API_BASE = 'http://localhost:47778';
-export const API_BASE = isTauri() ? TAURI_API_BASE : '';
+export const DEFAULT_API_HOST = 'localhost:47778';
+export const API_HOST_STORAGE_KEY = 'oracle.host';
 
 declare global {
   interface Window {
     __TAURI__?: unknown;
   }
 }
+
+type PrivateNetworkRequestInit = RequestInit & { targetAddressSpace?: 'local' };
+
+function browserWindow(): Window | undefined {
+  return typeof window === 'undefined' ? undefined : window;
+}
+
+function storage(): Storage | null {
+  try {
+    return browserWindow()?.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeApiHost(value: string | null | undefined): string {
+  const raw = value?.trim();
+  if (!raw) return DEFAULT_API_HOST;
+  const withProtocol = /^https?:\/\//i.test(raw) ? raw : `http://${raw}`;
+  try {
+    return new URL(withProtocol).host || DEFAULT_API_HOST;
+  } catch {
+    return raw.replace(/^https?:\/\//i, '').replace(/^\/+/, '').split('/')[0] || DEFAULT_API_HOST;
+  }
+}
+
+function cleanHostParam(url: URL): void {
+  if (!url.searchParams.has('host')) return;
+  url.searchParams.delete('host');
+  const clean = `${url.pathname}${url.search}${url.hash}`;
+  browserWindow()?.history.replaceState({}, '', clean || '/');
+}
+
+function resolveBrowserApiHost(): string {
+  const win = browserWindow();
+  if (!win) return DEFAULT_API_HOST;
+  const url = new URL(win.location.href);
+  const queryHost = url.searchParams.get('host');
+  const host = normalizeApiHost(queryHost || storage()?.getItem(API_HOST_STORAGE_KEY));
+  if (queryHost) {
+    storage()?.setItem(API_HOST_STORAGE_KEY, host);
+    cleanHostParam(url);
+  }
+  return host;
+}
+
+function isLocalAddress(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  return host === 'localhost' || host === '127.0.0.1' || host === '::1' || host.endsWith('.localhost');
+}
+
+export function isTauri(): boolean {
+  return typeof window !== 'undefined' && '__TAURI__' in window;
+}
+
+export const API_HOST = isTauri() ? 'localhost:47778' : resolveBrowserApiHost();
+export const API_BASE = isTauri() ? TAURI_API_BASE : `http://${API_HOST}`;
+export const USE_LOCAL_PNA = (() => {
+  try {
+    return !isTauri() && isLocalAddress(new URL(API_BASE).hostname);
+  } catch {
+    return false;
+  }
+})();
 
 export type VectorProvider = {
   type: string;
@@ -48,16 +113,39 @@ export type VectorHealthStatus = {
   error?: string;
 };
 
-export function isTauri(): boolean {
-  return typeof window !== 'undefined' && '__TAURI__' in window;
+export function hasStoredApiHost(): boolean {
+  return Boolean(storage()?.getItem(API_HOST_STORAGE_KEY));
+}
+
+export function persistApiHost(host: string): string {
+  const normalized = normalizeApiHost(host);
+  storage()?.setItem(API_HOST_STORAGE_KEY, normalized);
+  return normalized;
+}
+
+export function connectToApiHost(host: string): void {
+  const normalized = persistApiHost(host);
+  const url = new URL(browserWindow()?.location.href ?? 'http://localhost/');
+  url.searchParams.delete('host');
+  url.searchParams.set('host', normalized);
+  browserWindow()?.location.assign(`${url.pathname}${url.search}${url.hash}`);
 }
 
 export function apiUrl(path: string): string {
   return API_BASE ? new URL(path, API_BASE).toString() : path;
 }
 
+export function withLocalPna(init: RequestInit = {}): RequestInit {
+  if (!USE_LOCAL_PNA) return init;
+  return { ...init, targetAddressSpace: 'local' } as PrivateNetworkRequestInit;
+}
+
+export function apiFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  return fetch(apiUrl(path), withLocalPna(init));
+}
+
 async function fetchJson<T>(path: string, init: RequestInit = {}): Promise<T> {
-  const response = await fetch(apiUrl(path), {
+  const response = await apiFetch(path, {
     ...init,
     headers: { accept: 'application/json', 'content-type': 'application/json', ...(init.headers ?? {}) },
   });

--- a/frontend/src/api/plugin-admin.ts
+++ b/frontend/src/api/plugin-admin.ts
@@ -1,4 +1,4 @@
-import { apiUrl } from './oracle';
+import { apiFetch } from './oracle';
 
 export interface PluginStateResponse {
   ok: boolean;
@@ -18,7 +18,7 @@ function errorMessage(payload: unknown, fallback: string): string {
 
 export async function setPluginEnabled(name: string, enabled: boolean): Promise<PluginStateResponse> {
   const path = `/api/plugins/${encodeURIComponent(name)}/state`;
-  const response = await fetch(apiUrl(path), {
+  const response = await apiFetch(path, {
     method: 'PATCH',
     headers: { accept: 'application/json', 'content-type': 'application/json' },
     body: JSON.stringify({ enabled }),

--- a/frontend/src/components/BackendGate.tsx
+++ b/frontend/src/components/BackendGate.tsx
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { API_BASE, API_HOST, apiFetch, connectToApiHost, hasStoredApiHost } from "../api/oracle";
 import { SetupWizard } from "./SetupWizard";
 import { useCallback, useEffect, useState, type ReactNode } from "react";
 
@@ -21,7 +22,7 @@ function okStatus(value: unknown): boolean {
 }
 
 async function browserHealthCheck(): Promise<void> {
-  const response = await fetch("/api/health", {
+  const response = await apiFetch("/api/health", {
     headers: { accept: "application/json" },
   });
   if (!response.ok) throw new Error(`/api/health returned ${response.status}`);
@@ -37,6 +38,7 @@ export function BackendGate({ children }: { children: ReactNode }) {
   const [state, setState] = useState<GateState>("checking");
   const [message, setMessage] = useState("Checking backend health…");
   const [starting, setStarting] = useState(false);
+  const [host, setHost] = useState(API_HOST);
   const isTauri = isTauriRuntime();
 
   const check = useCallback(async () => {
@@ -70,6 +72,10 @@ export function BackendGate({ children }: { children: ReactNode }) {
     }
   }
 
+  function connectBrowserBackend() {
+    connectToApiHost(host);
+  }
+
   if (state === "ready") return <SetupWizard>{children}</SetupWizard>;
 
   return (
@@ -84,6 +90,34 @@ export function BackendGate({ children }: { children: ReactNode }) {
             ? "Checking whether the local Oracle API is ready."
             : message}
         </p>
+        {!isTauri && (
+          <div className="mt-6 rounded-2xl border border-teal-400/20 bg-teal-400/10 p-4">
+            <p className="text-sm font-semibold text-teal-200">Connect to your Oracle</p>
+            <p className="mt-2 text-xs text-slate-300">
+              Studio is trying {API_BASE}. Open with <code>?host=localhost:47778</code> or enter a host below.
+              {!hasStoredApiHost() ? " The default is localhost:47778." : null}
+            </p>
+            <label className="mt-3 block text-xs font-semibold uppercase tracking-[0.2em] text-slate-400" htmlFor="oracle-host">
+              Oracle host
+            </label>
+            <div className="mt-2 flex gap-2">
+              <input
+                className="min-w-0 flex-1 rounded-full border border-white/10 bg-slate-950 px-4 py-2 text-sm text-slate-100 outline-none focus:border-teal-300"
+                id="oracle-host"
+                value={host}
+                onChange={(event) => setHost(event.target.value)}
+                placeholder="localhost:47778"
+              />
+              <button
+                className="focus-ring rounded-full bg-teal-400 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-teal-300"
+                type="button"
+                onClick={connectBrowserBackend}
+              >
+                Connect
+              </button>
+            </div>
+          </div>
+        )}
         <div className="mt-6 flex flex-wrap gap-3">
           {state === "unreachable" && isTauri && (
             <button

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react';
-import { apiUrl } from '../api/oracle';
+import { apiUrl, withLocalPna } from '../api/oracle';
 
 export type ErrorReportStatus = 'idle' | 'reporting' | 'reported' | 'failed';
 export type ErrorReporter = (error: Error, info: ErrorInfo, retryCount: number) => Promise<boolean> | boolean;
@@ -65,7 +65,7 @@ export async function reportErrorToMetrics(
   };
 
   try {
-    const response = await fetcher(apiUrl('/api/metrics'), {
+    const response = await fetcher(apiUrl('/api/metrics'), withLocalPna({
       method: 'POST',
       keepalive: true,
       headers: {
@@ -74,7 +74,7 @@ export async function reportErrorToMetrics(
         'x-arra-report': 'frontend-error-boundary',
       },
       body: JSON.stringify(payload),
-    });
+    }));
     return response.ok;
   } catch {
     return false;

--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
-import { apiUrl } from "../api";
+import { apiFetch } from "../api";
 import { Spinner } from "./AsyncState";
 import { StepBody, setupSteps } from "./SetupWizardContent";
 import { shouldShowSetupWizard } from "./setupWizardDetection";
@@ -13,7 +13,7 @@ type SetupState = "checking" | "hidden" | "visible";
 const DISMISS_KEY = "arra.vector.setup.dismissed";
 
 async function getJson<T>(path: string): Promise<T> {
-  const response = await fetch(apiUrl(path), {
+  const response = await apiFetch(path, {
     headers: { accept: "application/json" },
   });
   if (!response.ok) throw new Error(`${path} returned ${response.status}`);
@@ -92,13 +92,13 @@ export function SetupWizard({ children }: { children: ReactNode }) {
     if (!selectedProvider) return setMessage("Choose an embedding provider first.");
     setBusy(true);
     try {
-      const response = await fetch(apiUrl("/api/v1/vector/config"), {
+      const response = await apiFetch("/api/v1/vector/config", {
         method: "PATCH",
         headers: { accept: "application/json", "content-type": "application/json" },
         body: JSON.stringify(buildProviderConfigPatch(config, selectedProvider)),
       });
       if (!response.ok) throw new Error(`/api/v1/vector/config returned ${response.status}`);
-      await fetch(apiUrl("/api/v1/vector/config/reload"), { method: "POST", headers: { accept: "application/json" } });
+      await apiFetch("/api/v1/vector/config/reload", { method: "POST", headers: { accept: "application/json" } });
       setConfig(await getJson<VectorConfig>("/api/v1/vector/config"));
       setStep(2);
       setMessage(`Applied ${selectedProvider} as the first-run embedding provider.`);

--- a/frontend/src/components/SetupWizardCostEstimate.tsx
+++ b/frontend/src/components/SetupWizardCostEstimate.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { apiUrl } from "../api";
+import { apiFetch } from "../api";
 
 type CostEstimate = {
   estimatedUsd: number;
@@ -20,7 +20,7 @@ function formatCost(value: number): string {
 
 async function fetchEstimate(provider: string): Promise<CostEstimate> {
   const qs = new URLSearchParams({ provider });
-  const response = await fetch(apiUrl(`/api/v1/vector/cost-estimate?${qs}`), {
+  const response = await apiFetch(`/api/v1/vector/cost-estimate?${qs}`, {
     headers: { accept: "application/json" },
   });
   if (!response.ok) throw new Error(`/api/v1/vector/cost-estimate returned ${response.status}`);

--- a/frontend/src/components/VectorConfigPanel.tsx
+++ b/frontend/src/components/VectorConfigPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { apiUrl, fetchVectorConfig, reloadVectorConfig, updateVectorCollection } from '../api';
+import { apiFetch, fetchVectorConfig, reloadVectorConfig, updateVectorCollection } from '../api';
 import { ErrorMessage, Spinner } from './AsyncState';
 import { VectorConfigHealthSummary } from './VectorConfigHealthSummary';
 import type { SettingsEmbedderCollection, VectorConfigResponse } from '../types';
@@ -33,7 +33,7 @@ function draftFrom(key: string, item?: SettingsEmbedderCollection): Drafts[strin
 }
 
 async function testVectorCollection(key: string): Promise<{ success?: boolean; count?: number; error?: string; status?: string }> {
-  const response = await fetch(apiUrl(`/api/v1/vector/config/${encodeURIComponent(key)}/test`), { method: 'POST', headers: { accept: 'application/json' } });
+  const response = await apiFetch(`/api/v1/vector/config/${encodeURIComponent(key)}/test`, { method: 'POST', headers: { accept: 'application/json' } });
   const payload = await response.json().catch(() => ({}));
   if (!response.ok) throw new Error(typeof payload.error === 'string' ? payload.error : response.statusText);
   return payload;

--- a/frontend/src/components/setupWizardIndex.ts
+++ b/frontend/src/components/setupWizardIndex.ts
@@ -1,4 +1,4 @@
-import { apiUrl } from '../api';
+import { apiFetch } from '../api';
 import type { VectorConfig, VectorIndexSource } from './setupWizardTypes';
 
 export type IndexStartBody = {
@@ -28,7 +28,7 @@ export function buildIndexStartBody(
 }
 
 export async function requestVectorIndexStart(body: IndexStartBody): Promise<void> {
-  await fetch(apiUrl('/api/v1/vector/index/start'), {
+  await apiFetch('/api/v1/vector/index/start', {
     method: 'POST',
     headers: { accept: 'application/json', 'content-type': 'application/json' },
     body: JSON.stringify(body),

--- a/frontend/src/components/wizard/FirstRunWizard.tsx
+++ b/frontend/src/components/wizard/FirstRunWizard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { ErrorMessage, LoadingPanel, Spinner } from '../AsyncState';
-import { apiUrl, type VectorProvider } from '../../api/oracle';
+import { apiFetch, type VectorProvider } from '../../api/oracle';
 import { useFirstRun } from '../../hooks/useFirstRun';
 
 type Step = 0 | 1 | 2 | 3;
@@ -23,7 +23,7 @@ const defaultPlans: CollectionPlan[] = [
 ];
 
 async function json<T>(path: string, init: RequestInit = {}): Promise<T> {
-  const response = await fetch(apiUrl(path), {
+  const response = await apiFetch(path, {
     ...init,
     headers: { accept: 'application/json', 'content-type': 'application/json', ...(init.headers ?? {}) },
   });

--- a/frontend/src/hooks/useExport.ts
+++ b/frontend/src/hooks/useExport.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { apiUrl } from '../api/oracle';
+import { apiUrl, withLocalPna } from '../api/oracle';
 
 export type ExportStatus = 'idle' | 'starting' | 'running' | 'done' | 'error';
 export type ExportRunPayload = Record<string, unknown>;
@@ -158,7 +158,7 @@ export function useExport({ fetcher = globalThis.fetch?.bind(globalThis), pollMs
     if (!fetcher) throw new Error('fetch is unavailable');
     const path = `/api/v1/export/app/download/${encodeURIComponent(jobId)}`;
     while (!signal.aborted) {
-      const response = await fetcher(apiUrl(path), { headers: { accept: 'application/json, application/octet-stream' }, signal });
+      const response = await fetcher(apiUrl(path), withLocalPna({ headers: { accept: 'application/json, application/octet-stream' }, signal }));
       const payload = await jsonOrEmpty(response);
       const jobStatus = statusFrom(payload);
       const progress = Math.min(100, Math.max(0, progressFrom(payload) ?? 0));
@@ -194,12 +194,12 @@ export function useExport({ fetcher = globalThis.fetch?.bind(globalThis), pollMs
     lastPayloadRef.current = payload;
     setState({ status: 'starting', jobId: null, progress: 0 });
     try {
-      const response = await fetcher(apiUrl('/api/v1/export/app/run'), {
+      const response = await fetcher(apiUrl('/api/v1/export/app/run'), withLocalPna({
         method: 'POST',
         headers: { accept: 'application/json', 'content-type': 'application/json' },
         body: JSON.stringify(payload),
         signal: controller.signal,
-      });
+      }));
       const body = await jsonOrEmpty(response);
       if (!response.ok) throw new Error(textValue(body.error, body.message) ?? `/api/v1/export/app/run returned ${response.status}`);
       const jobId = textValue(body.jobId, body.id);

--- a/frontend/src/hooks/usePlugins.ts
+++ b/frontend/src/hooks/usePlugins.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { apiUrl } from '../api/oracle';
+import { apiUrl, withLocalPna } from '../api/oracle';
 import type { PluginEntry, PluginsResponse } from '../types';
 
 export const PLUGINS_ENDPOINT = '/api/plugins';
@@ -48,7 +48,7 @@ export async function fetchPluginsFromEndpoint({
 
   let response: Response;
   try {
-    response = await request(apiUrl(endpoint), { headers: { accept: 'application/json' } });
+    response = await request(apiUrl(endpoint), withLocalPna({ headers: { accept: 'application/json' } }));
   } catch (error) {
     throw new Error(`${endpoint} is unreachable: ${messageFor(error)}`);
   }

--- a/frontend/src/pages/VectorDocumentsPage.tsx
+++ b/frontend/src/pages/VectorDocumentsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { apiUrl } from '../api/oracle';
+import { apiFetch } from '../api/oracle';
 
 type LoadState = 'idle' | 'loading' | 'ready' | 'error';
 
@@ -50,7 +50,7 @@ function isAbort(error: unknown): boolean {
 }
 
 async function fetchJson<T>(path: string, signal?: AbortSignal): Promise<T> {
-  const response = await fetch(apiUrl(path), { headers: { accept: 'application/json' }, signal });
+  const response = await apiFetch(path, { headers: { accept: 'application/json' }, signal });
   const text = await response.text();
   const data = text ? JSON.parse(text) : {};
   if (!response.ok) throw new Error(`${path} returned ${response.status}`);

--- a/frontend/src/pages/vectorSettingsHelpers.ts
+++ b/frontend/src/pages/vectorSettingsHelpers.ts
@@ -1,4 +1,4 @@
-import { apiUrl } from '../api/oracle';
+import { apiFetch } from '../api/oracle';
 
 export const ADAPTER_OPTIONS = ['chroma', 'sqlite-vec', 'lancedb', 'qdrant', 'cloudflare-vectorize', 'proxy', 'turbovec'] as const;
 export type VectorConfigAdapter = (typeof ADAPTER_OPTIONS)[number];
@@ -177,7 +177,7 @@ export function toRows(response: VectorConfigResponse): VectorConfigRow[] {
 }
 
 export async function fetchJson<T>(path: string, init: RequestInit = {}): Promise<T> {
-  const response = await fetch(apiUrl(path), {
+  const response = await apiFetch(path, {
     headers: { accept: 'application/json', 'content-type': 'application/json', ...(init.headers ?? {}) },
     ...init,
   });

--- a/frontend/src/vectorExport.ts
+++ b/frontend/src/vectorExport.ts
@@ -1,4 +1,4 @@
-import { apiUrl } from './api/oracle';
+import { apiUrl, withLocalPna } from './api/oracle';
 
 export type VectorExportFormat = string;
 
@@ -67,7 +67,7 @@ export async function fetchVectorExportFormats(deps: { fetch?: ExportFetch } = {
   const fetcher = deps.fetch ?? globalThis.fetch?.bind(globalThis);
   if (!fetcher) throw new Error('fetch is unavailable');
   const path = vectorExportFormatsPath();
-  const response = await fetcher(apiUrl(path), { headers: { accept: 'application/json' } });
+  const response = await fetcher(apiUrl(path), withLocalPna({ headers: { accept: 'application/json' } }));
   if (!response.ok) throw new Error(`${path} returned ${response.status}`);
   return normalizeVectorExportFormats(await response.json());
 }
@@ -83,9 +83,9 @@ export async function downloadVectorCollection(
 ): Promise<void> {
   const fetcher = deps.fetch ?? globalThis.fetch?.bind(globalThis);
   if (!fetcher) throw new Error('fetch is unavailable');
-  const response = await fetcher(apiUrl(vectorExportPath(collection, format)), {
+  const response = await fetcher(apiUrl(vectorExportPath(collection, format)), withLocalPna({
     headers: { accept: acceptHeader(format) },
-  });
+  }));
   if (!response.ok) throw new Error('/api/v1/vector/export returned ' + response.status);
   await (deps.saveBlob ?? saveBlobAsDownload)(await response.blob(), vectorExportFilename(collection, format));
 }


### PR DESCRIPTION
## Summary

- Resolve Studio API base from `?host=` → `localStorage['oracle.host']` → `localhost:47778`, matching the Drizzle Studio direct-local pattern.
- Persist `?host=` and clean the browser URL on first load; BackendGate includes a hosted-browser "Connect to your Oracle" host entry flow.
- Add `targetAddressSpace: 'local'` through the shared API fetch helper and existing `apiUrl` fetch call sites so hosted HTTPS Studio requests can target local Oracle.

## Validation

```bash
bunx tsc --noEmit
cd frontend && bun run build
cd .. && git diff --check
wc -l $(git diff --name-only origin/alpha...HEAD | tr '\n' ' ')
```
