### PR TITLE
feat(studio): add local backend gate

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ is linked here; keep new docs in the right section when adding files.
 | [deploy-cloudflare.md](./deploy-cloudflare.md) | Cloudflare deployment guide for Oracle surfaces. |
 | [deploy-cloudflare-mcp.md](./deploy-cloudflare-mcp.md) | One-click Cloudflare Workers remote MCP deploy and Claude `/mcp` setup. |
 | [deploy-production.md](./deploy-production.md) | Production Cloudflare Workers deploy with cloudflared origin, secrets, Studio, MCP, and federation. |
+| [hosted-studio-local-backend.md](./hosted-studio-local-backend.md) | Hosted Studio direct-to-local backend connection and CORS/PNA checklist. |
 | [workers-deploy-configs.md](./workers-deploy-configs.md) | Validate Cloudflare MCP, Studio, and federation Worker configs and env vars. |
 | [deploy-vercel.md](./deploy-vercel.md) | One-click Vercel deploy for the Oracle Studio frontend and `/api/*` proxy. |
 | [DOCKER-MCP-TOOLKIT.md](./DOCKER-MCP-TOOLKIT.md) | Docker MCP Toolkit package and profile setup. |

--- a/docs/hosted-studio-local-backend.md
+++ b/docs/hosted-studio-local-backend.md
@@ -1,0 +1,60 @@
+# Hosted Studio local backend connection
+
+Hosted Oracle Studio can talk directly to a user's local backend, matching the
+Drizzle Studio pattern:
+
+```text
+https://god.buildwithoracle.com/?host=localhost:47778
+```
+
+The frontend host resolver owns `?host=` persistence. `BackendGate` is the
+support screen around that resolver: it hides the dashboard while `/api/health`
+is unreachable and shows a "Connect to your Oracle" form that reloads Studio
+with a `host` query parameter.
+
+## User flow
+
+1. Start the local backend:
+
+   ```bash
+   arra-oracle-v3 serve
+   ```
+
+2. Open hosted Studio with an optional host override:
+
+   ```text
+   https://god.buildwithoracle.com/?host=localhost:47778
+   ```
+
+3. If the backend is not reachable, use the setup form to enter a local host
+   such as `localhost:47778` or `127.0.0.1:47778`.
+
+## Backend CORS and PNA
+
+The Bun backend default CORS policy allows:
+
+- `http://localhost:3000`
+- `http://127.0.0.1:3000`
+- `http://localhost:4321`
+- `http://127.0.0.1:4321`
+- `https://god.buildwithoracle.com`
+
+Chrome Private Network Access preflights are handled by the existing
+private-network middleware. For hosted Studio to local backend requests, the
+preflight must include:
+
+```http
+Origin: https://god.buildwithoracle.com
+Access-Control-Request-Private-Network: true
+```
+
+The backend responds with:
+
+```http
+Access-Control-Allow-Origin: https://god.buildwithoracle.com
+Access-Control-Allow-Private-Network: true
+```
+
+Operators can still override defaults with `ARRA_CORS_ORIGINS`,
+`ORACLE_CORS_ORIGIN`, or `CORS_ORIGIN`; include the hosted Studio origin when
+using custom values.

--- a/frontend/src/components/BackendGate.tsx
+++ b/frontend/src/components/BackendGate.tsx
@@ -1,8 +1,13 @@
 import { invoke } from "@tauri-apps/api/core";
 import { SetupWizard } from "./SetupWizard";
-import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useState, type FormEvent, type ReactNode } from "react";
+import { API_BASE, apiUrl } from "../api/oracle";
 
-type GateState = "checking" | "ready" | "unreachable";
+export type GateState = "checking" | "ready" | "unreachable";
+type PrivateNetworkRequestInit = RequestInit & { targetAddressSpace?: "local" };
+
+export const DEFAULT_ORACLE_HOST = "localhost:47778";
+export const ORACLE_HOST_STORAGE_KEY = "oracle.host";
 
 declare global {
   interface Window {
@@ -20,17 +25,135 @@ function okStatus(value: unknown): boolean {
   return false;
 }
 
+export function normalizeOracleHost(value: string): string {
+  const trimmed = value.trim().replace(/\/+$/, "");
+  if (!trimmed) return DEFAULT_ORACLE_HOST;
+  try {
+    const url = trimmed.includes("://") ? new URL(trimmed) : new URL(`http://${trimmed}`);
+    return url.host || DEFAULT_ORACLE_HOST;
+  } catch {
+    return trimmed.replace(/^https?:\/\//, "").split("/")[0] || DEFAULT_ORACLE_HOST;
+  }
+}
+
+export function connectUrlForHost(input: string, href: string): string {
+  const url = new URL(href);
+  url.searchParams.set("host", normalizeOracleHost(input));
+  return url.toString();
+}
+
+function savedHost(): string {
+  if (typeof window === "undefined") return DEFAULT_ORACLE_HOST;
+  try {
+    return normalizeOracleHost(window.localStorage?.getItem(ORACLE_HOST_STORAGE_KEY) ?? "");
+  } catch {
+    return DEFAULT_ORACLE_HOST;
+  }
+}
+
+function backendTargetLabel(): string {
+  return API_BASE || `http://${savedHost()}`;
+}
+
 async function browserHealthCheck(): Promise<void> {
-  const response = await fetch("/api/health", {
+  const target = apiUrl("/api/health");
+  const init: PrivateNetworkRequestInit = {
     headers: { accept: "application/json" },
-  });
-  if (!response.ok) throw new Error(`/api/health returned ${response.status}`);
+    targetAddressSpace: "local",
+  };
+  const response = await fetch(target, init);
+  if (!response.ok) throw new Error(`${target} returned ${response.status}`);
 }
 
 async function tauriHealthCheck(): Promise<void> {
   const status = await invoke<string>("health_check");
   if (!okStatus(status))
     throw new Error(`health_check returned ${String(status)}`);
+}
+
+export function ConnectOracleSetup({
+  isTauri,
+  message,
+  onRetry,
+  onStartBackend,
+  starting,
+  state,
+}: {
+  isTauri: boolean;
+  message: string;
+  onRetry: () => void;
+  onStartBackend: () => void;
+  starting: boolean;
+  state: GateState;
+}) {
+  const [host, setHost] = useState(savedHost);
+  const target = backendTargetLabel();
+
+  function connect(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (typeof window === "undefined") return;
+    const normalized = normalizeOracleHost(host);
+    try {
+      window.localStorage?.setItem(ORACLE_HOST_STORAGE_KEY, normalized);
+    } catch {}
+    window.location.assign(connectUrlForHost(normalized, window.location.href));
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-slate-950 p-6 text-slate-100">
+      <section className="w-full max-w-xl rounded-3xl border border-white/10 bg-white/[0.04] p-8 shadow-2xl">
+        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-teal-300">
+          ARRA Oracle
+        </p>
+        <h1 className="mt-3 text-3xl font-bold">Connect to your Oracle</h1>
+        <p className="mt-4 text-sm text-slate-300">
+          {state === "checking"
+            ? `Checking backend health at ${target}.`
+            : `Cannot reach ${target}: ${message}`}
+        </p>
+        <form className="mt-6 space-y-3" onSubmit={connect}>
+          <label className="block text-sm font-semibold text-slate-200" htmlFor="oracle-host">
+            Local Oracle host
+          </label>
+          <input
+            id="oracle-host"
+            className="w-full rounded-2xl border border-white/15 bg-slate-900 px-4 py-3 text-sm text-slate-100 outline-none focus:border-teal-300"
+            placeholder={DEFAULT_ORACLE_HOST}
+            value={host}
+            onChange={(event) => setHost(event.currentTarget.value)}
+          />
+          <p className="text-xs text-slate-400">
+            Start your backend with <code>arra-oracle-v3 serve</code>, then connect from hosted Studio.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <button
+              className="focus-ring rounded-full bg-teal-400 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-teal-300"
+              type="submit"
+            >
+              Use this backend
+            </button>
+            {state === "unreachable" && isTauri && (
+              <button
+                className="focus-ring rounded-full border border-teal-300/60 px-4 py-2 text-sm font-semibold text-teal-100 hover:bg-teal-300/10 disabled:opacity-60"
+                disabled={starting}
+                type="button"
+                onClick={onStartBackend}
+              >
+                {starting ? "Starting…" : "Start Backend"}
+              </button>
+            )}
+            <button
+              className="focus-ring rounded-full border border-white/15 px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-white/10"
+              type="button"
+              onClick={onRetry}
+            >
+              Retry
+            </button>
+          </div>
+        </form>
+      </section>
+    </main>
+  );
 }
 
 export function BackendGate({ children }: { children: ReactNode }) {
@@ -73,37 +196,13 @@ export function BackendGate({ children }: { children: ReactNode }) {
   if (state === "ready") return <SetupWizard>{children}</SetupWizard>;
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-slate-950 p-6 text-slate-100">
-      <section className="w-full max-w-lg rounded-3xl border border-white/10 bg-white/[0.04] p-8 shadow-2xl">
-        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-teal-300">
-          ARRA Oracle
-        </p>
-        <h1 className="mt-3 text-3xl font-bold">Backend unavailable</h1>
-        <p className="mt-4 text-sm text-slate-300">
-          {state === "checking"
-            ? "Checking whether the local Oracle API is ready."
-            : message}
-        </p>
-        <div className="mt-6 flex flex-wrap gap-3">
-          {state === "unreachable" && isTauri && (
-            <button
-              className="focus-ring rounded-full bg-teal-400 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-teal-300 disabled:opacity-60"
-              disabled={starting}
-              type="button"
-              onClick={() => void startBackend()}
-            >
-              {starting ? "Starting…" : "Start Backend"}
-            </button>
-          )}
-          <button
-            className="focus-ring rounded-full border border-white/15 px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-white/10"
-            type="button"
-            onClick={() => void check()}
-          >
-            Retry
-          </button>
-        </div>
-      </section>
-    </main>
+    <ConnectOracleSetup
+      isTauri={isTauri}
+      message={message}
+      onRetry={() => void check()}
+      onStartBackend={() => void startBackend()}
+      starting={starting}
+      state={state}
+    />
   );
 }

--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -12,6 +12,7 @@ const DEFAULT_ORIGINS = [
   'http://127.0.0.1:3000',
   'http://localhost:4321',
   'http://127.0.0.1:4321',
+  'https://god.buildwithoracle.com',
 ] as const;
 const ALLOWED_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'] as const;
 const ALLOWED_HEADERS = [

--- a/tests/frontend/components/backend-gate-shell.test.tsx
+++ b/tests/frontend/components/backend-gate-shell.test.tsx
@@ -1,6 +1,12 @@
 import { describe, expect, test } from 'bun:test';
-import { BackendGate } from '../../../frontend/src/components/BackendGate';
-import { htmlFor } from '../_render';
+import {
+  BackendGate,
+  ConnectOracleSetup,
+  connectUrlForHost,
+  normalizeOracleHost,
+  ORACLE_HOST_STORAGE_KEY,
+} from '../../../frontend/src/components/BackendGate';
+import { htmlFor, installBrowserLocation } from '../_render';
 
 describe('BackendGate shell', () => {
   test('keeps app content hidden while the backend health check is pending', () => {
@@ -10,10 +16,43 @@ describe('BackendGate shell', () => {
       </BackendGate>,
     );
 
-    expect(html).toContain('Backend unavailable');
-    expect(html).toContain('Checking whether the local Oracle API is ready.');
+    expect(html).toContain('Connect to your Oracle');
+    expect(html).toContain('Checking backend health at http://localhost:47778.');
+    expect(html).toContain('Local Oracle host');
+    expect(html).toContain('Use this backend');
     expect(html).toContain('Retry');
     expect(html).not.toContain('Loaded dashboard');
     expect(html).not.toContain('Start Backend');
+  });
+
+  test('renders unreachable setup guidance with saved local host', () => {
+    const restore = installBrowserLocation('/?host=oracle.local:47778');
+    try {
+      window.localStorage.setItem(ORACLE_HOST_STORAGE_KEY, 'oracle.local:47778');
+      const html = htmlFor(
+        <ConnectOracleSetup
+          isTauri
+          message="fetch failed"
+          onRetry={() => {}}
+          onStartBackend={() => {}}
+          starting={false}
+          state="unreachable"
+        />,
+      );
+
+      expect(html).toContain('Cannot reach http://oracle.local:47778: fetch failed');
+      expect(html).toContain('value="oracle.local:47778"');
+      expect(html).toContain('arra-oracle-v3 serve');
+      expect(html).toContain('Start Backend');
+    } finally {
+      restore();
+    }
+  });
+
+  test('normalizes connect host URLs for the api/oracle host resolver', () => {
+    expect(normalizeOracleHost(' https://localhost:47778/api/ ')).toBe('localhost:47778');
+    expect(normalizeOracleHost('oracle.local:47778///')).toBe('oracle.local:47778');
+    expect(connectUrlForHost('http://localhost:47778/api', 'https://god.buildwithoracle.com/vector?q=1'))
+      .toBe('https://god.buildwithoracle.com/vector?q=1&host=localhost%3A47778');
   });
 });

--- a/tests/integration/cors-pna.test.ts
+++ b/tests/integration/cors-pna.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createCorsMiddleware, createPrivateNetworkPreflightMiddleware, parseCorsOrigins } from '../../src/middleware/cors.ts';
+
+const HOSTED_STUDIO = 'https://god.buildwithoracle.com';
+
+function pnaPreflight(origin: string): Request {
+  return new Request('http://localhost:47778/api/health', {
+    method: 'OPTIONS',
+    headers: {
+      origin,
+      'access-control-request-method': 'GET',
+      'access-control-request-private-network': 'true',
+    },
+  });
+}
+
+function corsApp() {
+  return new Elysia()
+    .use(createPrivateNetworkPreflightMiddleware())
+    .use(createCorsMiddleware())
+    .get('/api/health', () => ({ status: 'ok' }));
+}
+
+describe('hosted Studio CORS and PNA preflight', () => {
+  test('default CORS origins include the hosted Studio domain', () => {
+    expect(parseCorsOrigins().origins).toContain(HOSTED_STUDIO);
+  });
+
+  test('allows hosted Studio private-network preflight to local Oracle', async () => {
+    const response = await corsApp().handle(pnaPreflight(HOSTED_STUDIO));
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe(HOSTED_STUDIO);
+    expect(response.headers.get('Access-Control-Allow-Private-Network')).toBe('true');
+    expect(response.headers.get('Access-Control-Allow-Methods')).toContain('GET');
+    expect(response.headers.get('Vary')).toContain('Origin');
+  });
+
+  test('does not grant private-network access to unknown origins', async () => {
+    const response = await corsApp().handle(pnaPreflight('https://evil.example'));
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull();
+    expect(response.headers.get('Access-Control-Allow-Private-Network')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Add a hosted Studio `BackendGate` setup screen titled "Connect to your Oracle" with local host input and `?host=` handoff through the merged `api/oracle.ts` host resolver.
- Allow `https://god.buildwithoracle.com` in the default backend CORS policy and verify PNA preflight headers.
- Document hosted Studio direct-to-local backend setup under `docs/`.
- Preserved c4's `frontend/src/api/oracle.ts` host/PNA resolver and integrated the gate with its `apiFetch`/`connectToApiHost` helpers.

## Validation
```bash
bunx tsc --noEmit
bun test tests/frontend/components/backend-gate-shell.test.tsx tests/integration/cors-pna.test.ts tests/integration/middleware-order.test.ts tests/integration/middleware-stack.test.ts
(cd frontend && bun run build)
git diff --check
wc -l $(git diff --name-only --diff-filter=ACMRT origin/alpha...HEAD)
```
