### PR TITLE
test: verify Studio local host routing

### DIFF
--- a/tests/frontend/oracle-api-host.test.ts
+++ b/tests/frontend/oracle-api-host.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+const originalFetch = globalThis.fetch;
+
+type FakeWindow = {
+  location: { href: string; assign: (url: string) => void };
+  localStorage: Storage;
+  history: { replaceState: (...args: unknown[]) => void };
+  assigned?: string;
+  replaced?: string;
+};
+
+function fakeStorage(seed: Record<string, string> = {}): Storage {
+  const values = new Map(Object.entries(seed));
+  return {
+    get length() { return values.size; },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key) => { values.delete(key); },
+    setItem: (key, value) => { values.set(key, value); },
+  } as Storage;
+}
+
+function installWindow(href: string, stored: Record<string, string> = {}): FakeWindow {
+  const fake = {
+    location: { href, assign: (url: string) => { fake.assigned = url; } },
+    localStorage: fakeStorage(stored),
+    history: { replaceState: (_state: unknown, _title: unknown, url?: unknown) => { fake.replaced = String(url); } },
+  } as FakeWindow;
+  Object.defineProperty(globalThis, 'window', { configurable: true, value: fake });
+  return fake;
+}
+
+async function loadOracleApi(label: string) {
+  return import(`../../frontend/src/api/oracle.ts?host-test=${label}-${Date.now()}-${Math.random()}`);
+}
+
+afterEach(() => {
+  if (originalWindow) Object.defineProperty(globalThis, 'window', originalWindow);
+  else delete (globalThis as { window?: unknown }).window;
+  globalThis.fetch = originalFetch;
+});
+
+describe('Studio local Oracle host resolution', () => {
+  test('?host persists, cleans the URL, and targets local API with PNA', async () => {
+    const fake = installWindow('https://god.buildwithoracle.com/status?host=localhost:47778&tab=health#top');
+    let captured: { input: RequestInfo | URL; init?: RequestInit } | null = null;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      captured = { input, init };
+      return new Response('{"ok":true}', { status: 200 });
+    }) as typeof fetch;
+
+    const api = await loadOracleApi('query-localhost');
+    expect(api.API_HOST).toBe('localhost:47778');
+    expect(api.API_BASE).toBe('http://localhost:47778');
+    expect(fake.localStorage.getItem(api.API_HOST_STORAGE_KEY)).toBe('localhost:47778');
+    expect(fake.replaced).toBe('/status?tab=health#top');
+    expect(api.apiUrl('/api/health')).toBe('http://localhost:47778/api/health');
+
+    await api.apiFetch('/api/health', { headers: { accept: 'application/json' } });
+    expect(String(captured?.input)).toBe('http://localhost:47778/api/health');
+    expect((captured?.init as RequestInit & { targetAddressSpace?: string })?.targetAddressSpace).toBe('local');
+  });
+
+  test('stored host is reused when query param is absent', async () => {
+    installWindow('https://god.buildwithoracle.com/', { 'oracle.host': '127.0.0.1:47778' });
+    const api = await loadOracleApi('stored-host');
+    expect(api.API_HOST).toBe('127.0.0.1:47778');
+    expect(api.apiUrl('/api/v1/vector/config')).toBe('http://127.0.0.1:47778/api/v1/vector/config');
+  });
+
+  test('remote hosts do not receive local PNA metadata', async () => {
+    installWindow('https://god.buildwithoracle.com/?host=https://oracle.example.test/api');
+    const api = await loadOracleApi('remote-host');
+    expect(api.API_HOST).toBe('oracle.example.test');
+    expect(api.withLocalPna({ method: 'GET' })).toEqual({ method: 'GET' });
+  });
+
+  test('connectToApiHost normalizes, persists, and redirects through ?host=', async () => {
+    const fake = installWindow('https://god.buildwithoracle.com/dashboard?tab=vector#config');
+    const api = await loadOracleApi('connect-host');
+    api.connectToApiHost('http://localhost:47778/path');
+    expect(fake.localStorage.getItem(api.API_HOST_STORAGE_KEY)).toBe('localhost:47778');
+    expect(fake.assigned).toBe('/dashboard?tab=vector&host=localhost%3A47778#config');
+  });
+});


### PR DESCRIPTION
## Summary

- Add a focused frontend host-routing regression test for the merged Studio direct-local connect flow.
- Verify `?host=localhost:47778` persists to `localStorage['oracle.host']`, cleans the URL, resolves `/api/*` against `http://localhost:47778`, and sends Chrome PNA `targetAddressSpace: 'local'`.
- Cover stored-host fallback, remote-host no-PNA behavior, and `connectToApiHost()` normalization/redirect.

## Validation

```bash
bunx tsc --noEmit
cd frontend && bun run build
cd .. && bun test tests/frontend/oracle-api-host.test.ts
git diff --check
git diff --name-only origin/alpha...HEAD | xargs wc -l
```
