### PR TITLE
fix(workers): repoint root MCP Wrangler config

### DIFF
--- a/tests/workers/cloudflare-deploy-config.test.ts
+++ b/tests/workers/cloudflare-deploy-config.test.ts
@@ -113,16 +113,19 @@ describe('Cloudflare deploy metadata', () => {
     });
   });
 
-  test('root Wrangler config only tears down the retired remote MCP Durable Object', () => {
+  test('root Wrangler config points at the active MCP Worker', () => {
     const cfg = parseJsonc<Record<string, any>>(read('wrangler.jsonc'));
 
-    expect(cfg.name).toBe('arra-oracle-remote-mcp');
-    expect(cfg.main).toBe('src/workers/remote-mcp-teardown.ts');
+    expect(cfg.name).toBe('arra-oracle-mcp');
+    expect(cfg.main).toBe('workers/mcp/src/index.ts');
     expect(cfg.compatibility_date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-    expect(cfg.durable_objects).toBeUndefined();
-    expect(cfg.vars).toBeUndefined();
-    expect(cfg.migrations).toContainEqual({ tag: 'v1', new_sqlite_classes: ['OracleMcpAgent'] });
-    expect(cfg.migrations).toContainEqual({ tag: 'v2', deleted_classes: ['OracleMcpAgent'] });
+    expect(cfg.compatibility_flags).toContain('nodejs_compat');
+    expect(cfg.durable_objects.bindings).toContainEqual({
+      name: 'MCP_OBJECT',
+      class_name: 'OracleMCP',
+    });
+    expect(cfg.migrations).toContainEqual({ tag: 'v1', new_sqlite_classes: ['OracleMCP'] });
+    expect(cfg.vars.ORACLE_URL).toContain('replace-with-your-oracle-backend');
   });
 
   test('workers/mcp package has explicit build and deploy scripts', () => {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,17 +1,25 @@
 /**
- * Legacy Cloudflare remote MCP teardown for #2227 Slice 0.
- * Canonical deploy target: workers/mcp/wrangler.jsonc (name: arra-oracle-mcp).
+ * Root Cloudflare MCP config mirrors the canonical Workers MCP deploy target.
+ * Package scripts use workers/mcp/wrangler.jsonc directly; this root config
+ * stays active so plain `wrangler dev/deploy` does not hit the retired teardown worker.
  */
 {
   "$schema": "https://raw.githubusercontent.com/cloudflare/workers-sdk/main/packages/wrangler/config-schema.json",
-  "name": "arra-oracle-remote-mcp",
-  "main": "src/workers/remote-mcp-teardown.ts",
+  "name": "arra-oracle-mcp",
+  "main": "workers/mcp/src/index.ts",
   "compatibility_date": "2026-06-16",
   "compatibility_flags": ["nodejs_compat"],
   "workers_dev": true,
   "observability": { "enabled": true },
+  "durable_objects": {
+    "bindings": [
+      { "name": "MCP_OBJECT", "class_name": "OracleMCP" }
+    ]
+  },
   "migrations": [
-    { "tag": "v1", "new_sqlite_classes": ["OracleMcpAgent"] },
-    { "tag": "v2", "deleted_classes": ["OracleMcpAgent"] }
-  ]
+    { "tag": "v1", "new_sqlite_classes": ["OracleMCP"] }
+  ],
+  "vars": {
+    "ORACLE_URL": "https://replace-with-your-oracle-backend.example.com"
+  }
 }


### PR DESCRIPTION
## Summary
- repoint root `wrangler.jsonc` from retired `arra-oracle-remote-mcp` teardown Worker to active `arra-oracle-mcp`
- point root config at `workers/mcp/src/index.ts` with the active `OracleMCP` Durable Object binding/migration
- update deploy metadata test coverage; root `package.json` scripts were verified to already target `workers/mcp/wrangler.jsonc`

## Validation
```bash
bun test --isolate tests/workers/cloudflare-deploy-config.test.ts tests/workers/mcp-deploy-config.test.ts tests/workers/mcp-deploy-ready.test.ts
bunx tsc --noEmit
git diff --check
wc -l wrangler.jsonc package.json workers/mcp/package.json tests/workers/cloudflare-deploy-config.test.ts docs/workers-deploy-configs.md
```
