### PR TITLE
docs: fix swagger middleware cloudflare deploy docs

### DIFF
--- a/docs/MIDDLEWARE.md
+++ b/docs/MIDDLEWARE.md
@@ -1,78 +1,84 @@
 # HTTP Middleware Order
 
-Source of truth: `src/server.ts`. The server has two layers: outer fetch wrappers, then the Elysia app pipeline.
-Keep this order stable unless a middleware explicitly needs to run earlier for short-circuit responses.
+Source of truth: `src/server.ts`. Requests pass through outer fetch wrappers,
+then the Elysia app pipeline. Keep docs in this file tied to concrete filenames
+and env vars; the unsupported per-minute alias and singular rate-limit filename
+are intentionally omitted because current source uses profile keys and
+`src/middleware/rate-limiter.ts`.
 
-## Outer fetch wrappers
+## Outer fetch path
 
-1. `trackRequest` (`src/lifecycle/shutdown.ts`)
-   - Tracks in-flight requests for graceful shutdown.
-   - Config: none.
+`createStartedApp()` returns a fetch handler equivalent to:
+
+```ts
+fetch(request) => drainingResponseFor(request)
+  ?? trackRequest(() => createRequestTimeoutFetch(
+    createRequestDedupFetch(
+      createApiVersionedFetch(
+        createTenantFetch(
+          createDbContextFetch((request) => app.fetch(request))
+        )
+      )
+    )
+  )(request))
+```
+
+Order:
+
+1. `drainingResponseFor` / `trackRequest` (`src/lifecycle/shutdown.ts`)
+   - Short-circuits during graceful shutdown and tracks in-flight requests.
 2. `createRequestTimeoutFetch` (`src/middleware/timeout.ts`)
-   - Aborts slow handlers and returns structured `408` JSON.
-   - Config: `ARRA_REQUEST_TIMEOUT_MS` (default `30000`).
-3. `createApiVersionedFetch` (`src/middleware/api-version.ts`)
-   - Serves `/api/v1/*` by rewriting internally to `/api/*` and redirects legacy `/api/*` callers.
-   - Config: none; current version is `v1`.
+   - Config: `ARRA_REQUEST_TIMEOUT_MS`, default `30000`.
+3. `createRequestDedupFetch` (`src/middleware/dedup.ts`)
+   - Coalesces `GET`/`HEAD` by URL plus auth, cookie, range, accept, and tenant headers.
+4. `createApiVersionedFetch` (`src/middleware/api-version.ts`)
+   - Rewrites `/api/v1/*` internally to `/api/*`; redirects unversioned API callers to `/api/v1/*` except infrastructure paths such as `/api/health`.
+5. `createTenantFetch` (`src/middleware/tenant.ts`)
+   - Config: `ORACLE_TENANT_TOKENS`, `ORACLE_TENANT_API_KEYS`.
+   - Headers: `X-Oracle-Tenant`, `X-Oracle-Tenant-Token`; aliases `X-Tenant-ID`, `X-Org-Id`, `X-API-Key`.
+6. `createDbContextFetch` (`src/middleware/db-context.ts`)
+   - Stores request id context for DB tracing.
+7. `app.fetch` (Elysia app below).
 
 ## Elysia app pipeline
 
-1. `requestLogger.onRequest` (`src/middleware/logger.ts`)
-   - Captures start metadata and redacted request headers for after-response logging.
-   - Config: none.
+Registered by `createApp()` in this order:
+
+1. `createRequestLoggingMiddleware` (`src/middleware/request-logger.ts`)
+   - Structured request log, redacts `authorization` and `proxy-authorization`.
 2. `createCorrelationMiddleware` (`src/middleware/correlation.ts`)
-   - Adds `X-Request-Id` and `X-Response-Time`; runs before short-circuiting middleware.
-   - Config: none. Accepts inbound `X-Request-Id` / `x-correlation-id` only when needed by helpers.
-3. `createPrivateNetworkPreflightMiddleware` (`src/middleware/cors.ts`)
-   - Handles Private Network Access preflight before route/auth work.
-   - Config: `ARRA_CORS_ORIGINS` (or legacy `ORACLE_CORS_ORIGIN` / `CORS_ORIGIN`);
-     defaults to explicit local development origins, not `*`.
-4. `createCorsMiddleware` (`src/middleware/cors.ts`)
-   - Handles normal CORS preflight and response CORS headers.
-   - Config: `ARRA_CORS_ORIGINS` (or legacy `ORACLE_CORS_ORIGIN` / `CORS_ORIGIN`);
-     defaults to explicit local development origins, not `*`.
+   - Adds `X-Request-Id`, `X-Response-Time`, and `x-correlation-id`.
+3. `createTenantMiddleware` (`src/middleware/tenant.ts`)
+   - Adds `X-Oracle-Tenant` response header or returns tenant config errors.
+4. `createPrivateNetworkPreflightMiddleware` then `createCorsMiddleware` (`src/middleware/cors.ts`)
+   - Config: `ARRA_CORS_ORIGINS`, legacy `ORACLE_CORS_ORIGIN`, `CORS_ORIGIN`.
 5. `createApiVersionHeaderMiddleware` (`src/middleware/api-version.ts`)
-   - Adds `X-API-Version: v1` to responses and errors.
-   - Config: none.
+   - Adds `X-API-Version: v1`.
 6. `createSecurityHeadersMiddleware` (`src/middleware/security-headers.ts`)
-   - Adds `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, optional HSTS.
-   - Config: `ARRA_HSTS=true` enables `Strict-Transport-Security`.
+   - Config: `ARRA_HSTS=true` adds HSTS.
 7. `createContentTypeMiddleware` (`src/middleware/content-type.ts`)
-   - Enforces JSON response negotiation and sets `Content-Type` when missing.
-   - Config: none.
+   - Enforces JSON response negotiation.
 8. `createBodyLimitMiddleware` (`src/middleware/body-limit.ts`)
-   - Rejects oversized request bodies before route parsing.
-   - Config: `ARRA_MAX_BODY_KB` (default `1024`).
-9. `createRateLimitMiddleware` (`src/middleware/rate-limit.ts`)
-   - In-memory per-IP request limiting; bypasses `/api/health`.
-   - Config: `ARRA_RATE_LIMIT_RPM` (default `60`). Profile envs `ARRA_RATE_LIMIT_*` feed startup config/banner defaults.
-10. `createApiKeyAuthMiddleware` (`src/middleware/auth.ts`)
-   - Optional bearer-token auth for API routes; bypasses `/api/health`.
-   - Config: `ARRA_API_KEY`.
-11. `createMetricsLifecycle` (`src/routes/metrics/index.ts`)
-    - Records request metrics and exposes metrics routes.
-    - Config: none.
-12. Inline legacy API-token guard (`src/server/api-token-auth.ts`)
-    - Protects legacy API paths when token auth is configured.
-    - Config: `ORACLE_API_TOKEN`, `ARRA_API_TOKEN`.
-13. Inline cache/referrer headers (`src/server.ts`)
-    - Adds `Cache-Control` and `Referrer-Policy` after handlers.
-    - Config: none.
-14. `requestLogger.onAfterResponse` (`src/middleware/logger.ts`)
-    - Emits the final structured request log.
-    - Config: `ARRA_VERBOSE_LOGGING` / `DEBUG` affect broader runtime verbosity, not this logger directly.
-15. `createErrorMiddleware` (`src/middleware/errors.ts`)
-    - Converts errors to structured JSON and preserves request/timing headers.
-    - Config: none.
-16. Swagger, gateway, peer, API, MCP, and menu route modules
-    - Registered after global middleware so routes inherit the headers/auth/timeout stack.
-    - Config examples: `VECTOR_URL`, `ORACLE_GATEWAY_HOT_RELOAD`, plugin and route-specific env vars.
+   - Config: `ARRA_MAX_BODY_KB`, default `1024`.
+9. `createApiKeyAuthMiddleware` (`src/middleware/auth.ts`)
+   - Config: `ARRA_API_KEY`; bypasses `/api/health` only.
+10. `createRateLimiterMiddleware` (`src/middleware/rate-limiter.ts`)
+    - Installed with `DEFAULT_RATE_LIMIT_RULES`: `/api/search` 30/min and `/api/learn` 10/min.
+    - Profile envs validated by `src/config/schema.ts` and `src/config/profiles.ts`: `ARRA_RATE_LIMIT_ENABLED`, `ARRA_RATE_LIMIT_TOKENS_PER_WINDOW`, `ARRA_RATE_LIMIT_WINDOW_MS`, `ARRA_RATE_LIMIT_BURST`.
+11. `createMetricsLifecycle` (`src/routes/metrics/index.ts`).
+12. `swagger({ provider: 'swagger-ui', path: '/api/docs', specPath: '/api/docs/json' })`.
+13. Response shaping: `createResponseFormatMiddleware`, `createCompressMiddleware`, `createEtagMiddleware`.
+14. Inline legacy API-token guard (`src/server/api-token-auth.ts`)
+    - Config: `ARRA_API_TOKEN`; exempts `/api/health` and `/api/docs` descendants.
+15. Inline no-cache/referrer headers, then `createErrorMiddleware` (`src/middleware/errors.ts`).
+16. `gatewayPlugin`, docs redirects, root route, API/MCP/menu modules, plugin route mount, then `createNotFoundMiddleware`.
 
 ## Verification
 
-`tests/integration/middleware-order.test.ts` starts the real server and asserts:
+Use current source and tests, not stale docs:
 
-- `X-Request-Id` is present on an API response.
-- `X-Response-Time` is present on an API response.
-- Security headers are present on an API response.
-- CORS preflight returns the expected CORS headers.
+```bash
+grep -n "createRequestTimeoutFetch\|createRequestLoggingMiddleware\|swagger" src/server.ts
+bun test --isolate tests/http/rate-limiter/rate-limiter.test.ts src/integration/api-token-auth.test.ts
+bunx tsc --noEmit
+```

--- a/docs/SWAGGER-DEPLOY.md
+++ b/docs/SWAGGER-DEPLOY.md
@@ -1,261 +1,111 @@
-# Deploying `/swagger` Publicly
+# Deploying `/api/docs` Publicly
 
-The Elysia server ships a Scalar UI at `http://localhost:47778/swagger` and
-the raw spec at `http://localhost:47778/swagger/json`. This doc describes
-how to expose that documentation to the public internet without leaking the
-oracle's private HTTP API.
+Verified against `src/server.ts`, `src/server/api-token-auth.ts`,
+`scripts/export-openapi.ts`, and `tests/http/swagger/export-openapi.test.ts`.
+The main Elysia app uses `@elysiajs/swagger` with `provider: 'swagger-ui'`.
 
-> Status: **not yet deployed.** This is a choose-your-path reference.
+## Live routes
 
-## TL;DR
+| Route | Behavior |
+| --- | --- |
+| `/api/docs` | Swagger UI. Public even when `ARRA_API_TOKEN` is set. |
+| `/api/docs/json` | Canonical OpenAPI JSON. |
+| `/swagger` | `308` redirect to `/api/docs`. |
+| `/swagger/json` | `308` redirect to `/api/docs/json`. |
+| `/api/openapi.json` | `308` redirect to `/api/docs/json`. |
 
-1. Run `bun scripts/export-openapi.ts` to produce `docs/openapi.json`.
-2. Pick one of the three options below. **Option B (static Scalar on CF
-   Workers) is the recommended path.**
-3. Update the CI / release flow to re-run the export on every API change.
-
----
+`/api/docs-malicious` is not public; the API-token guard only exempts
+`/api/docs` and descendants.
 
 ## Export the spec
 
-`scripts/export-openapi.ts`:
+`scripts/export-openapi.ts` starts `bun src/server.ts` on a scratch port,
+polls `/`, fetches a spec path, validates OpenAPI 3 metadata, writes JSON, then
+stops the child process.
 
-- boots `bun src/server.ts` on a scratch port (default `48900`),
-- polls `/` until the server is ready,
-- fetches `/swagger/json`,
-- validates `openapi` starts with `3.`, `info.title`, `info.version`, and
-  `paths` exist,
-- writes pretty-printed JSON to `docs/openapi.json`,
-- kills the subprocess on success, failure, or SIGINT/SIGTERM.
+Use the canonical path when exporting fresh docs:
 
 ```bash
-bun scripts/export-openapi.ts
-# → ✓ wrote /…/docs/openapi.json
-#     openapi: 3.1.0
-#     title:   Arra Oracle API
-#     paths:   NN
+bun scripts/export-openapi.ts --spec-path /api/docs/json --out docs/openapi.json
 ```
 
-Flags: `--port <n>` (default `48900`), `--out <path>` (default
-`docs/openapi.json`).
+The script default currently asks `/api/openapi.json`, which works only because
+that route redirects to `/api/docs/json`.
 
-The script does not require a build step — it runs the TypeScript server
-directly via Bun.
+## Option A — proxy live docs
 
----
-
-## Option A — Proxy `/swagger` through studio.buildwithoracle.com
-
-Forward `/swagger` and `/swagger/json` on the public studio host straight
-to the Oracle HTTP API.
-
-### Pros
-- Always live, always matches the running server.
-- No extra build/publish step; new routes show up immediately.
-
-### Cons
-- **Requires backend access on `studio.buildwithoracle.com`** — not always
-  available in the current dev fleet.
-- Exposes a live API surface to the internet even if only the docs are
-  linked. The proxy must be locked down to `GET /swagger*` only.
-- Couples studio uptime to oracle uptime.
-
-### Sketch (Caddyfile)
+Forward only `GET`/`HEAD` for `/api/docs` and `/api/docs/json` to the Oracle
+HTTP backend. Do not expose the whole `/api/*` surface just to publish docs.
 
 ```caddy
 studio.buildwithoracle.com {
-  @swagger path /swagger /swagger/* /swagger/json
-  reverse_proxy @swagger http://oracle-world.wg:47778 {
-    header_up Host oracle-world.wg
-  }
+  @docs path /api/docs /api/docs/json
+  reverse_proxy @docs http://oracle-world.wg:47778
 
-  # Everything else → studio app
   reverse_proxy http://127.0.0.1:3000
 }
 ```
 
-### Sketch (Cloudflare Workers, fetch-style)
+Cloudflare Worker sketch:
 
 ```ts
 export default {
   async fetch(req: Request): Promise<Response> {
     const url = new URL(req.url);
-    if (req.method === 'GET' && url.pathname.startsWith('/swagger')) {
-      const upstream = new URL(url.pathname + url.search, 'https://oracle.internal');
-      return fetch(upstream, { headers: req.headers });
-    }
-    return new Response('not found', { status: 404 });
+    const allowed = url.pathname === '/api/docs' || url.pathname === '/api/docs/json';
+    if (req.method !== 'GET' && req.method !== 'HEAD') return new Response('method not allowed', { status: 405 });
+    if (!allowed) return new Response('not found', { status: 404 });
+    return fetch(new URL(url.pathname + url.search, 'https://oracle-origin.example.com'));
   },
 };
 ```
 
-Use this when the oracle host is reachable from studio's network (WireGuard
-tunnel, internal Cloudflare Tunnel, etc.). Reject any method other than
-`GET` at the proxy.
+## Option B — static OpenAPI artifact on Workers
 
----
+Serve `docs/openapi.json` plus a viewer shell as static Worker assets. This does
+not expose the live backend, but the artifact must be regenerated whenever API
+routes or schemas change.
 
-## Option B — Static export + Scalar on Cloudflare Workers (recommended)
+Minimal layout:
 
-Serve `docs/openapi.json` and a Scalar HTML shell as a static site on a
-Worker. Nothing of the live server is exposed.
-
-### Pros
-- No backend access needed.
-- Cheap, fast, cached at the edge.
-- Docs site is a pure artifact of the repo; previewable per-PR.
-- Matches the house rule: **CF Workers, not Pages** (use `wrangler deploy`
-  with `assets.directory`, never `wrangler pages`).
-
-### Cons
-- Requires re-running the export on every API change.
-- Docs drift if the export is skipped; guard with CI.
-
-### Layout
-
-```
+```text
 docs/
-├── openapi.json          # generated
+├── openapi.json
 └── site/
-    ├── index.html        # Scalar UI shell
-    └── _headers          # optional CF headers
+    └── index.html
 ```
 
-`docs/site/index.html`:
+A viewer shell can point to `/openapi.json` with Swagger UI, Scalar, or Redoc.
+The live backend UI is Swagger UI; static docs are just an OpenAPI artifact.
 
-```html
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <title>Arra Oracle API</title>
-  </head>
-  <body>
-    <script
-      id="api-reference"
-      data-url="/openapi.json"
-      data-proxy-url=""
-    ></script>
-    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
-  </body>
-</html>
-```
-
-Prefer pinning a Scalar version (e.g. `@scalar/api-reference@1`) in
-production.
-
-### `wrangler.json`
+`wrangler.jsonc` shape:
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/cloudflare/workers-sdk/main/packages/wrangler/config-schema.json",
   "name": "arra-oracle-docs",
-  "compatibility_date": "2026-04-19",
   "main": "docs/worker.ts",
-  "assets": {
-    "directory": "docs/",
-    "binding": "ASSETS",
-    "not_found_handling": "single-page-application"
-  },
-  "routes": [
-    { "pattern": "docs.buildwithoracle.com", "custom_domain": true }
-  ],
+  "compatibility_date": "2026-06-17",
+  "assets": { "directory": "docs/", "binding": "ASSETS" },
   "observability": { "enabled": true }
 }
 ```
 
-Minimal `docs/worker.ts` (optional — Workers-only assets works without a
-worker, but this keeps a place to add redirects/headers later):
+`docs/worker.ts` can serve `/site/index.html` for `/` and otherwise delegate to
+`ASSETS`.
 
-```ts
-export interface Env { ASSETS: Fetcher }
-
-export default {
-  async fetch(req: Request, env: Env): Promise<Response> {
-    const url = new URL(req.url);
-    if (url.pathname === '/' || url.pathname === '/index.html') {
-      return env.ASSETS.fetch(new Request(new URL('/site/index.html', url), req));
-    }
-    return env.ASSETS.fetch(req);
-  },
-};
-```
-
-### Deploy (not executed)
+## Verification
 
 ```bash
-bun scripts/export-openapi.ts
-wrangler deploy
+bun scripts/export-openapi.ts --spec-path /api/docs/json --out docs/openapi.json
+bun test --isolate tests/http/swagger/export-openapi.test.ts src/integration/api-token-auth.test.ts
+bunx tsc --noEmit
 ```
 
-### Alternative UI: Redoc
+Manual route checks on a running server:
 
-Swap the Scalar shell for Redoc if you prefer its layout:
-
-```html
-<redoc spec-url="/openapi.json"></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js"></script>
+```bash
+curl -i http://127.0.0.1:47778/api/docs
+curl -i http://127.0.0.1:47778/api/docs/json
+curl -i http://127.0.0.1:47778/swagger
+curl -i http://127.0.0.1:47778/api/openapi.json
 ```
-
-Everything else (wrangler config, export script) is unchanged.
-
----
-
-## Option C — GitHub Pages
-
-Drop the same `docs/openapi.json` + Scalar HTML into a `gh-pages` branch
-(or the `docs/` folder on main with Pages configured to serve from it).
-
-### Pros
-- Zero infra: repo settings + an Action.
-- Free, versioned alongside source.
-
-### Cons
-- URL lives under `github.io` unless a custom domain is wired up.
-- Pages is a separate publish target from the CF Workers used elsewhere in
-  the fleet — adds a deploy surface.
-
-### Sketch (`.github/workflows/docs.yml`)
-
-```yaml
-name: docs
-on:
-  push:
-    branches: [main]
-    paths:
-      - 'src/routes/**'
-      - 'src/server.ts'
-      - 'scripts/export-openapi.ts'
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-      - run: bun install --frozen-lockfile
-      - run: bun scripts/export-openapi.ts
-      - run: cp docs/site/index.html docs/index.html
-      - uses: actions/upload-pages-artifact@v3
-        with: { path: docs }
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment: { name: github-pages, url: "${{ steps.d.outputs.page_url }}" }
-    steps:
-      - id: d
-        uses: actions/deploy-pages@v4
-```
-
----
-
-## Recommendation
-
-Go with **Option B**. It matches the CF Workers house rule, needs no
-studio backend access, and keeps the public surface to a pure static
-artifact. Run `bun scripts/export-openapi.ts` in CI on any change to
-`src/routes/**` or `src/server.ts` so the docs never drift.

--- a/docs/architecture/mcp-remote-transport.md
+++ b/docs/architecture/mcp-remote-transport.md
@@ -7,17 +7,18 @@ Bun-only tool handlers.
 ## Runtime boundary
 
 ```text
-MCP client -> workers/mcp /mcp -> ORACLE_URL /api/* -> maw arra backend
+MCP client -> workers/mcp /mcp -> ORACLE_ORIGIN_URL /api/* -> maw arra backend
 ```
 
 - The Worker hosts a Streamable HTTP MCP endpoint at `/mcp` through `McpAgent`.
 - Tool execution is REST proxying only. The Worker generates its tool list from
   the pure `src/tools/mcp-rest-map.ts` table and registers entries with
   `remoteable: true`.
-- Backend calls use `ORACLE_URL` first, then `ORACLE_HTTP_URL`, then
-  `ORACLE_API`.
-- Tenant context is resolved from authenticated `McpAgent` props before tool
-  arguments, then forwarded as backend-compatible tenant headers.
+- Backend calls use `ORACLE_ORIGIN_URL` first, then `ORACLE_URL`, then
+  `ORACLE_HTTP_URL`, then `ORACLE_API`.
+- Tenant forwarding is shipped: authenticated `McpAgent` props/claims win before
+  deploy fallback `ORACLE_TENANT_ID` and tool `tenantId`; the Worker forwards
+  `X-Tenant-ID`, `X-Oracle-Tenant`, and `X-Oracle-Tenant-ID`.
 - `ARRA_API_TOKEN` / `ARRA_API_KEY` are forwarded as Bearer auth when present.
 
 ## mcp-remote client bridge
@@ -45,8 +46,8 @@ Transport rules:
 1. The URL must end in `/mcp`.
 2. Browser navigation to `/mcp` is not a valid smoke test; use MCP Inspector,
    `mcp-remote`, or a remote-capable MCP client.
-3. `/health` can be plain HTTP readiness, but MCP tool listing/calls must use
-   MCP protocol messages.
+3. The Worker has no plain `/health` endpoint; probe `/mcp` with MCP Inspector,
+   `mcp-remote`, or a remote-capable MCP client.
 4. The Worker must not import `src/tools/mcp-manifest.ts`, `src/db/*`, or
    `src/vector/*`; only the pure REST map is edge-safe.
 

--- a/docs/deploy-cloudflare-mcp.md
+++ b/docs/deploy-cloudflare-mcp.md
@@ -36,10 +36,11 @@ The entry uses Cloudflare `McpAgent` and Durable Object session state. At init,
 registers only REST-proxyable tools. The Worker must not import the Bun-side
 `src/tools/mcp-manifest.ts`, DB modules, or vector adapters.
 
-`/health` is a normal HTTP readiness endpoint. `/mcp` expects MCP protocol
-messages, so use MCP Inspector, `mcp-remote`, or a remote-capable client instead
-of browser navigation. See `docs/architecture/mcp-remote-transport.md` for the
-transport contract.
+The deployed Worker exposes `/mcp` only via `OracleMCP.serve('/mcp')`; it does
+not ship a plain `/health` route. `/mcp` expects MCP protocol messages, so use
+MCP Inspector, `mcp-remote`, or a remote-capable client instead of browser
+navigation. See `docs/architecture/mcp-remote-transport.md` for the transport
+contract.
 
 ## Required configuration
 
@@ -48,12 +49,18 @@ transport contract.
 | `main` | `workers/mcp/src/index.ts` via `workers/mcp/wrangler.jsonc`. |
 | `compatibility_flags` | Includes `nodejs_compat` for Agents SDK/runtime compatibility. |
 | `MCP_OBJECT` | Durable Object binding required by `McpAgent` session state. |
-| `ORACLE_URL` | Backend URL for proxying remoteable tools to a full Arra Oracle server. |
-| `ORACLE_API_TOKEN` | Optional Bearer token for protected backend calls. |
-| D1/Vectorize/R2 | Future edge-native persistence/search replacements. |
+| `ORACLE_ORIGIN_URL` | Preferred backend URL for proxying remoteable tools to a full Arra Oracle server. |
+| `ORACLE_URL` | Legacy fallback backend URL from `workers/mcp/wrangler.jsonc`. |
+| `ORACLE_HTTP_URL` | Fallback after `ORACLE_ORIGIN_URL` and `ORACLE_URL`. |
+| `ORACLE_API` | Last legacy fallback backend URL. |
+| `ARRA_API_TOKEN` / `ARRA_API_KEY` | Optional Bearer token for protected backend calls. |
+| `ORACLE_TENANT_ID` | Optional single-tenant fallback when auth props do not provide a tenant. |
+| `ORACLE_DB` / `ORACLE_TENANTS_TABLE` | Optional D1 tenant registry used to require active tenants. |
 
-Without `ORACLE_ORIGIN_URL` or fallback `ORACLE_URL`, proxy tools return a clear
-MCP tool error that explains how to configure the backend.
+`resolveOracleUrl()` precedence is `ORACLE_ORIGIN_URL` > `ORACLE_URL` >
+`ORACLE_HTTP_URL` > `ORACLE_API`. It strips credentials, query strings, hashes,
+and trailing slashes. Without one of those URLs, proxy tools return a clear MCP
+tool error that explains how to configure the backend.
 
 ## Manual Wrangler deploy fallback
 
@@ -70,14 +77,16 @@ For local Workers testing:
 
 ```bash
 bun run cloudflare:mcp:dev
-curl -sf http://localhost:8787/health
+# Then connect MCP Inspector or mcp-remote to http://localhost:8787/mcp.
 ```
 
 Store secrets with Wrangler or the Cloudflare dashboard, not in git:
 
 ```bash
 cd workers/mcp
-bunx wrangler secret put ORACLE_API_TOKEN --config wrangler.jsonc
+bunx wrangler secret put ARRA_API_TOKEN --config wrangler.jsonc
+# Optional compatibility secret:
+# bunx wrangler secret put ARRA_API_KEY --config wrangler.jsonc
 ```
 
 ## Smoke test with MCP Inspector
@@ -130,31 +139,32 @@ Oracle. Example models:
 | Team | `platform`, `design`, `support` | GitHub org/team, WorkOS org, or Auth0 organization |
 | SaaS | `customer-acme`, `customer-river` | Billing/customer table or D1 tenant registry |
 
-Do not treat caller-supplied `tenantId` as authorization. Put OAuth or
-Cloudflare Access in front of `/mcp`, resolve the signed-in identity to a tenant,
-and forward only that trusted tenant to `ORACLE_HTTP_URL`. Backend routes already
-scope by tenant ID from #1650.
+Multi-tenant forwarding is shipped in `workers/mcp/src/proxy.ts`. The Worker
+resolves tenant IDs from `McpAgent` auth props/claims before tool arguments,
+falls back to `ORACLE_TENANT_ID`, validates tenant ID syntax, optionally checks
+a D1 tenant registry, then forwards backend-compatible tenant headers:
+`X-Tenant-ID`, `X-Oracle-Tenant`, and `X-Oracle-Tenant-ID`. Do not treat a raw
+tool argument as authorization in shared deployments; put OAuth or Cloudflare
+Access in front of `/mcp` and write the trusted tenant into auth props or D1.
 
 Recommended rollout:
 
 1. Keep the Phase 1 proxy private or token-protected until OAuth is wired.
 2. Choose a tenant registry: static `wrangler.jsonc` vars for small teams, or D1
    for self-serve tenants and roster changes.
-3. Store a tenant claim in `McpAgent` props.
-4. Reject users without a tenant mapping instead of falling back to a shared
-   default tenant.
-5. Forward backend-compatible tenant headers to `ORACLE_HTTP_URL` when the proxy
-   adds authenticated tenant support.
+3. Store a tenant claim in `McpAgent` props, or use D1 tenants for active/disabled status.
+4. Reject users without a tenant mapping instead of falling back to a shared default tenant.
+5. Verify backend logs show `X-Oracle-Tenant` and `X-Oracle-Tenant-ID`.
 
 ## Storage roadmap
 
 This Worker intentionally avoids importing local SQLite, Drizzle, LanceDB, or
 embedding runtimes. Follow-up slices should add Cloudflare-native storage:
 
-- D1 for metadata and FTS-style document lookup.
+- D1-backed edge reads beyond the shipped tenant registry.
 - Vectorize for embedding search.
 - Workers AI or a remote embedding service for indexing.
-- OAuth/Cloudflare Access before exposing write tools.
+- OAuth/Cloudflare Access policies for production tenant identity.
 
 ## Troubleshooting
 
@@ -166,8 +176,8 @@ embedding runtimes. Follow-up slices should add Cloudflare-native storage:
   browser navigation is not a valid MCP request.
 - **Claude shows no tools:** verify the deployed URL ends in `/mcp`, restart the
   client, and run MCP Inspector to separate client config from server issues.
-- **Search fails:** set `ORACLE_URL` or `ORACLE_HTTP_URL`; if protected, also
-  set `ORACLE_API_TOKEN`.
+- **Search fails:** set `ORACLE_ORIGIN_URL` or fallback `ORACLE_URL`,
+  `ORACLE_HTTP_URL`, or `ORACLE_API`; if protected, also set `ARRA_API_TOKEN`.
 
 ## References
 

--- a/docs/deploy-production.md
+++ b/docs/deploy-production.md
@@ -98,7 +98,9 @@ curl -sf "$ORACLE_ORIGIN_URL/api/health"
 ## 3. Store Worker secrets
 
 Set `ORACLE_ORIGIN_URL` and the backend token on the Studio and MCP Workers.
-Production values should be secrets, not committed `wrangler.jsonc` vars.
+Production values should be secrets, not committed `wrangler.jsonc` vars. Both
+Workers resolve backend origins in this order: `ORACLE_ORIGIN_URL` > `ORACLE_URL`
+> `ORACLE_HTTP_URL` > `ORACLE_API`.
 
 ```bash
 for config in workers/mcp/wrangler.jsonc workers/studio/wrangler.jsonc; do
@@ -144,10 +146,11 @@ Record the deployed MCP URL:
 https://<mcp-worker-host>/mcp
 ```
 
-Smoke test with MCP Inspector or a remote-capable MCP client. Select **List
-Tools** and confirm remoteable tools such as `oracle_search` and `oracle_stats`
-appear. If tools return backend errors, re-check `ORACLE_ORIGIN_URL` and
-`ARRA_API_TOKEN` secrets.
+Smoke test the deployed `/mcp` URL with MCP Inspector or a remote-capable MCP
+client. The Worker does not expose `/health`; do not use `/health` as the MCP
+probe. Select **List Tools** and confirm remoteable tools such as `oracle_search`
+and `oracle_stats` appear. If tools return backend errors, re-check
+`ORACLE_ORIGIN_URL` and `ARRA_API_TOKEN` secrets.
 
 ## 5. Deploy Worker 2: Studio frontend
 
@@ -202,7 +205,8 @@ being forwarded to `TUNNEL_URL`.
 - `curl -sf "$ORACLE_ORIGIN_URL/api/health"` succeeds from outside the origin
   host.
 - Studio `GET /__health` and proxied `GET /api/health` both succeed.
-- MCP Inspector can list tools at the deployed `/mcp` URL.
+- MCP Inspector can list tools at the deployed `/mcp` URL; no Worker `/health` probe is expected.
+- MCP tenant forwarding is configured through auth props/claims, optional D1 tenants, or `ORACLE_TENANT_ID`.
 - Federation `GET /__health` reports `tunnelConfigured: true`.
 - Worker secrets are set with Wrangler or the Cloudflare dashboard; real URLs and
   tokens are not committed to git.
@@ -216,7 +220,7 @@ being forwarded to `TUNNEL_URL`.
 | --- | --- |
 | Worker says `Set ORACLE_ORIGIN_URL` | Secret was set on the wrong Worker/config or not deployed into the active environment. |
 | Studio loads but API fails | Confirm `/api/health` works through `ORACLE_ORIGIN_URL` and that `ARRA_API_TOKEN` matches the backend. |
-| MCP lists no tools | Use the `/mcp` URL with MCP Inspector; browser GET is not a valid MCP session. |
+| MCP lists no tools | Use the `/mcp` URL with MCP Inspector; browser GET and `/health` are not valid MCP sessions. |
 | Federation returns `tunnel unavailable` | Set `TUNNEL_URL` on `workers/federation/wrangler.jsonc` and redeploy. |
 | Cloudflared 502/1033 | The backend is down, the tunnel config points at the wrong port, or DNS targets the wrong tunnel. |
 


### PR DESCRIPTION
## Summary
- Correct Swagger deploy docs to match `@elysiajs/swagger` at `/api/docs` with `/api/docs/json` and redirect compatibility from `/swagger` and `/api/openapi.json`.
- Correct middleware docs to match the real outer fetch wrappers, Elysia registration order, filenames, and rate-limit config names.
- Correct Cloudflare deploy docs for `resolveOracleUrl` precedence, MCP `/mcp` probing instead of Worker `/health`, and shipped tenant forwarding.

## Verification
```bash
bunx tsc --noEmit
bun test --isolate tests/http/swagger/export-openapi.test.ts tests/http/rate-limiter/rate-limiter.test.ts src/integration/api-token-auth.test.ts tests/workers/mcp-proxy.test.ts tests/workers/mcp-proxy-tools.test.ts tests/workers/mcp-deploy-config.test.ts tests/workers/mcp-deploy-ready.test.ts
git diff --check
wc -l docs/SWAGGER-DEPLOY.md docs/MIDDLEWARE.md docs/deploy-cloudflare-mcp.md docs/architecture/mcp-remote-transport.md docs/deploy-production.md
```

Refs #2324
