### PR TITLE
test(e2e): verify hosted Studio local Oracle chain

### DIFF
--- a/frontend/src/api/oracle.ts
+++ b/frontend/src/api/oracle.ts
@@ -8,7 +8,8 @@ declare global {
   }
 }
 
-type PrivateNetworkRequestInit = RequestInit & { targetAddressSpace?: 'local' };
+type LocalNetworkAddressSpace = 'local' | 'loopback';
+type PrivateNetworkRequestInit = RequestInit & { targetAddressSpace?: LocalNetworkAddressSpace };
 
 function browserWindow(): Window | undefined {
   return typeof window === 'undefined' ? undefined : window;
@@ -53,9 +54,32 @@ function resolveBrowserApiHost(): string {
   return host;
 }
 
-function isLocalAddress(hostname: string): boolean {
-  const host = hostname.toLowerCase();
-  return host === 'localhost' || host === '127.0.0.1' || host === '::1' || host.endsWith('.localhost');
+function normalizedHostname(hostname: string): string {
+  return hostname.toLowerCase().replace(/^\[|\]$/g, '');
+}
+
+function isLoopbackAddress(hostname: string): boolean {
+  const host = normalizedHostname(hostname);
+  return host === 'localhost' || host === '::1' || host.endsWith('.localhost') || /^127(?:\.|$)/.test(host);
+}
+
+function isPrivateNetworkAddress(hostname: string): boolean {
+  const host = normalizedHostname(hostname);
+  const firstTwo = host.split('.').slice(0, 2).map((part) => Number(part));
+  const [first, second] = firstTwo;
+  return host.endsWith('.local')
+    || first === 10
+    || first === 192 && second === 168
+    || first === 172 && second >= 16 && second <= 31
+    || first === 169 && second === 254
+    || /^f[cd][0-9a-f]{2}:/i.test(host)
+    || host.startsWith('fe80:');
+}
+
+function targetAddressSpace(hostname: string): LocalNetworkAddressSpace | null {
+  if (isLoopbackAddress(hostname)) return 'loopback';
+  if (isPrivateNetworkAddress(hostname)) return 'local';
+  return null;
 }
 
 export function isTauri(): boolean {
@@ -64,13 +88,14 @@ export function isTauri(): boolean {
 
 export const API_HOST = isTauri() ? 'localhost:47778' : resolveBrowserApiHost();
 export const API_BASE = isTauri() ? TAURI_API_BASE : `http://${API_HOST}`;
-export const USE_LOCAL_PNA = (() => {
+export const TARGET_ADDRESS_SPACE = (() => {
   try {
-    return !isTauri() && isLocalAddress(new URL(API_BASE).hostname);
+    return isTauri() ? null : targetAddressSpace(new URL(API_BASE).hostname);
   } catch {
-    return false;
+    return null;
   }
 })();
+export const USE_LOCAL_PNA = TARGET_ADDRESS_SPACE !== null;
 
 export type VectorProvider = {
   type: string;
@@ -137,7 +162,7 @@ export function apiUrl(path: string): string {
 
 export function withLocalPna(init: RequestInit = {}): RequestInit {
   if (!USE_LOCAL_PNA) return init;
-  return { ...init, targetAddressSpace: 'local' } as PrivateNetworkRequestInit;
+  return { ...init, targetAddressSpace: TARGET_ADDRESS_SPACE } as PrivateNetworkRequestInit;
 }
 
 export function apiFetch(path: string, init: RequestInit = {}): Promise<Response> {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,20 +1,26 @@
 import { defineConfig } from '@playwright/test';
 
+const backendPort = process.env.PLAYWRIGHT_BACKEND_PORT ?? '47778';
+const frontendPort = process.env.PLAYWRIGHT_FRONTEND_PORT ?? '3000';
+const backendUrl = `http://127.0.0.1:${backendPort}`;
+const frontendUrl = `http://127.0.0.1:${frontendPort}`;
+const corsOrigins = `${frontendUrl},http://localhost:${frontendPort}`;
+
 export default defineConfig({
   testDir: './tests/e2e',
   testMatch: [/.*\.e2e\.ts$/, /contrast\.spec\.ts$/],
   timeout: 30000,
-  use: { baseURL: 'http://127.0.0.1:3000' },
+  use: { baseURL: frontendUrl },
   webServer: [
     {
-      command: 'bun run src/server.ts',
-      url: 'http://127.0.0.1:47778/api/health',
+      command: `ARRA_CORS_ORIGINS=${corsOrigins} ORACLE_PORT=${backendPort} PORT=${backendPort} bun run src/server.ts`,
+      url: `${backendUrl}/api/health`,
       reuseExistingServer: !process.env.CI,
       timeout: 30000,
     },
     {
-      command: 'cd frontend && bun run dev',
-      url: 'http://127.0.0.1:3000',
+      command: `cd frontend && VITE_PORT=${frontendPort} FRONTEND_PROXY_TARGET=${backendUrl} bun run dev`,
+      url: frontendUrl,
       reuseExistingServer: !process.env.CI,
       timeout: 30000,
     },

--- a/tests/e2e/hosted-studio-local-oracle.e2e.ts
+++ b/tests/e2e/hosted-studio-local-oracle.e2e.ts
@@ -1,0 +1,33 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const apiHost = process.env.ORACLE_E2E_API_HOST ?? `127.0.0.1:${process.env.PLAYWRIGHT_BACKEND_PORT ?? '47778'}`;
+const healthUrl = `http://${apiHost}/api/health`;
+
+async function expectReady(page: Page) {
+  await expect(page.getByText('Backend unavailable')).toHaveCount(0);
+  await expect(page.getByRole('button', { name: /Refresh data|Refreshing/ })).toBeVisible();
+}
+
+test.describe('hosted Studio to local Oracle deploy chain', () => {
+  test('host query connects the browser app to the local Oracle API', async ({ page }) => {
+    const health = page.waitForResponse((response) => response.url() === healthUrl && response.ok());
+
+    await page.goto(`/?host=${encodeURIComponent(apiHost)}`);
+    await health;
+
+    await expect.poll(() => new URL(page.url()).searchParams.has('host')).toBe(false);
+    await expectReady(page);
+    await expect.poll(() => page.evaluate(() => localStorage.getItem('oracle.host'))).toBe(apiHost);
+  });
+
+  test('stored host connects a clean hosted Studio URL on reload', async ({ page }) => {
+    await page.addInitScript((host) => localStorage.setItem('oracle.host', host), apiHost);
+    const health = page.waitForResponse((response) => response.url() === healthUrl && response.ok());
+
+    await page.goto('/');
+    await health;
+
+    await expect.poll(() => new URL(page.url()).searchParams.has('host')).toBe(false);
+    await expectReady(page);
+  });
+});

--- a/tests/frontend/oracle-api-host.test.ts
+++ b/tests/frontend/oracle-api-host.test.ts
@@ -61,7 +61,7 @@ describe('Studio local Oracle host resolution', () => {
 
     await api.apiFetch('/api/health', { headers: { accept: 'application/json' } });
     expect(String(captured?.input)).toBe('http://localhost:47778/api/health');
-    expect((captured?.init as RequestInit & { targetAddressSpace?: string })?.targetAddressSpace).toBe('local');
+    expect((captured?.init as RequestInit & { targetAddressSpace?: string })?.targetAddressSpace).toBe('loopback');
   });
 
   test('stored host is reused when query param is absent', async () => {

--- a/tests/smoke/studio-host-pna-contract.test.ts
+++ b/tests/smoke/studio-host-pna-contract.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, expect, test } from 'bun:test';
+
+const previousWindow = globalThis.window;
+const previousFetch = globalThis.fetch;
+
+afterEach(() => {
+  if (previousWindow === undefined) delete (globalThis as { window?: Window }).window;
+  else globalThis.window = previousWindow;
+  globalThis.fetch = previousFetch;
+});
+
+function installBrowser(url: string, storedHost?: string) {
+  const storage = new Map<string, string>();
+  const assigned: string[] = [];
+  const replaced: string[] = [];
+  if (storedHost) storage.set('oracle.host', storedHost);
+  globalThis.window = {
+    location: { href: url, assign: (next: string) => assigned.push(next) },
+    history: { replaceState: (_state: unknown, _title: string, next: string) => replaced.push(next) },
+    localStorage: {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+    },
+  } as unknown as Window & typeof globalThis;
+  return { assigned, replaced, storage };
+}
+
+async function importOracleApi() {
+  return import(`../../frontend/src/api/oracle.ts?smoke=${Date.now()}-${Math.random()}`);
+}
+
+test('host query persists local Oracle host and uses Private Network Access fetches', async () => {
+  const browser = installBrowser('https://studio.example/?host=127.0.0.1:47778&view=menu#/status');
+  const calls: Array<{ input: RequestInfo | URL; init?: RequestInit & { targetAddressSpace?: string } }> = [];
+  globalThis.fetch = ((input, init) => {
+    calls.push({ input, init });
+    return Promise.resolve(Response.json({ status: 'ok' }));
+  }) as typeof fetch;
+
+  const oracle = await importOracleApi();
+  await oracle.apiFetch('/api/health', { headers: { accept: 'application/json' } });
+
+  expect(oracle.API_BASE).toBe('http://127.0.0.1:47778');
+  expect(oracle.TARGET_ADDRESS_SPACE).toBe('loopback');
+  expect(browser.storage.get('oracle.host')).toBe('127.0.0.1:47778');
+  expect(browser.replaced).toEqual(['/?view=menu#/status']);
+  expect(String(calls[0]?.input)).toBe('http://127.0.0.1:47778/api/health');
+  expect(calls[0]?.init?.targetAddressSpace).toBe('loopback');
+});
+
+test('connectToApiHost normalizes host input and reloads through the host query', async () => {
+  const browser = installBrowser('https://studio.example/vector?plugin=wave#docs', 'localhost:47778');
+  const oracle = await importOracleApi();
+
+  oracle.connectToApiHost('oracle.local:47778/path');
+
+  expect(browser.storage.get('oracle.host')).toBe('oracle.local:47778');
+  expect(browser.assigned).toEqual(['/vector?plugin=wave&host=oracle.local%3A47778#docs']);
+});


### PR DESCRIPTION
## Summary
- Add Playwright deploy-chain coverage for hosted Studio connecting to a local Oracle API via `?host=` and stored `oracle.host`.
- Add a Bun smoke contract for host persistence, URL cleanup, and Local Network Access fetch metadata.
- Fix loopback requests to use `targetAddressSpace: "loopback"`, while preserving `"local"` for RFC1918/`.local` hosts.
- Make Playwright backend/frontend ports, proxy target, and CORS origins env-overridable for isolated deploy-chain runs.

## Validation
- `bun test tests/frontend/oracle-api-host.test.ts`
- `bun test tests/smoke`
- `ORACLE_DATA_DIR=/tmp/arra-oracle-e2e-c10 PLAYWRIGHT_FRONTEND_PORT=3001 PLAYWRIGHT_BACKEND_PORT=47779 ORACLE_E2E_API_HOST=127.0.0.1:47779 CI=1 bunx playwright test tests/e2e/hosted-studio-local-oracle.e2e.ts --output=/tmp/arra-playwright-hosted-studio-ci --reporter=line`
- `bunx tsc --noEmit`
- `wc -l frontend/src/api/oracle.ts playwright.config.ts tests/e2e/hosted-studio-local-oracle.e2e.ts tests/frontend/oracle-api-host.test.ts tests/smoke/studio-host-pna-contract.test.ts`

## Reference
- Local Network Access `targetAddressSpace` values: https://developer.mozilla.org/en-US/docs/Web/API/Request/targetAddressSpace
