### PR TITLE
test(middleware): harden cors and tenant edges

### DIFF
--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -28,6 +28,7 @@ const ALLOWED_HEADERS = [
   LEGACY_TENANT_HEADER.toLowerCase(),
 ] as const;
 const MAX_AGE_SECONDS = '86400';
+const PNA_REQUEST_HEADER = 'access-control-request-private-network';
 
 export interface CorsPolicy {
   wildcard: false;
@@ -66,7 +67,11 @@ function allowedRequestHeaders(request: Request): string[] | null {
 function allowsRequestMethod(request: Request): boolean {
   const requested = request.headers.get('access-control-request-method');
   if (!requested) return true;
-  return ALLOWED_METHODS.includes(requested.toUpperCase() as typeof ALLOWED_METHODS[number]);
+  return ALLOWED_METHODS.includes(requested.trim().toUpperCase() as typeof ALLOWED_METHODS[number]);
+}
+
+function wantsPrivateNetwork(request: Request): boolean {
+  return request.headers.get(PNA_REQUEST_HEADER)?.trim().toLowerCase() === 'true';
 }
 
 export function parseCorsOrigins(value = configuredOrigins()): CorsPolicy {
@@ -118,7 +123,10 @@ function preflightResponse(request: Request, policy: CorsPolicy): Response {
     'Access-Control-Max-Age': MAX_AGE_SECONDS,
   };
   const allowed = applyCorsHeaders(headers, request, policy);
-  if (allowed && request.headers.get('access-control-request-private-network') === 'true') {
+  appendVary(headers, 'Access-Control-Request-Method');
+  appendVary(headers, 'Access-Control-Request-Headers');
+  appendVary(headers, 'Access-Control-Request-Private-Network');
+  if (allowed && wantsPrivateNetwork(request)) {
     headers['Access-Control-Allow-Private-Network'] = 'true';
   }
   return new Response(null, { status: 204, headers });
@@ -139,10 +147,7 @@ export function createCorsMiddleware(policy = parseCorsOrigins()) {
 
 export function createPrivateNetworkPreflightMiddleware(policy = parseCorsOrigins()) {
   return new Elysia({ name: 'private-network-preflight' }).onRequest(({ request }) => {
-    if (
-      request.method === 'OPTIONS' &&
-      request.headers.get('access-control-request-private-network') === 'true'
-    ) {
+    if (request.method === 'OPTIONS' && wantsPrivateNetwork(request)) {
       return preflightResponse(request, policy);
     }
   });

--- a/src/middleware/tenant.ts
+++ b/src/middleware/tenant.ts
@@ -10,6 +10,7 @@ export const LEGACY_TENANT_HEADER = 'X-Tenant-ID';
 export const ORG_HEADER = 'X-Org-Id';
 export const TENANT_API_KEY_HEADER = 'X-API-Key';
 const TENANT_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/;
+const RESERVED_TENANT_KEYS = new Set(['constructor', 'prototype']);
 
 export const DEFAULT_TENANT_ID = 'default';
 type TenantContext = { tenantId?: string };
@@ -60,7 +61,7 @@ function tokenMapFromEntries(entries: TokenEntry[]): TenantTokenMap {
     const tenant = rawTenant.trim();
     const token = typeof rawToken === 'string' ? rawToken.trim() : '';
     if (!tenant && !token) continue;
-    if (!tenant || !token || (tenant !== '*' && !TENANT_PATTERN.test(tenant))) {
+    if (!tenant || !token || (tenant !== '*' && !isValidTenantId(tenant))) {
       throw new Error('invalid tenant token config');
     }
     map[tenant] = token;
@@ -68,12 +69,17 @@ function tokenMapFromEntries(entries: TokenEntry[]): TenantTokenMap {
   return map;
 }
 
+function isValidTenantId(tenantId: string): boolean {
+  return TENANT_PATTERN.test(tenantId) && !RESERVED_TENANT_KEYS.has(tenantId.toLowerCase());
+}
+
 function tenantIdFromApiKey(headers: Headers, apiKeys = parseTenantApiKeys()): string | undefined {
   const actual = headers.get(TENANT_API_KEY_HEADER)?.trim() || bearerToken(headers);
   if (!actual) return undefined;
   for (const [tenantId, expected] of Object.entries(apiKeys)) {
+    if (tenantId === '*') continue;
     if (expected && safeEqual(actual, expected)) {
-      if (!TENANT_PATTERN.test(tenantId)) throw new Error('invalid tenant id');
+      if (!isValidTenantId(tenantId)) throw new Error('invalid tenant id');
       return tenantId;
     }
   }
@@ -84,7 +90,7 @@ export function tenantIdFromHeaders(headers: Headers): string | undefined {
   const raw = headers.get(TENANT_HEADER) ?? headers.get(LEGACY_TENANT_HEADER) ?? headers.get(ORG_HEADER);
   const tenant = raw?.trim();
   if (!tenant) return tenantIdFromApiKey(headers);
-  if (!TENANT_PATTERN.test(tenant)) throw new Error('invalid tenant id');
+  if (!isValidTenantId(tenant)) throw new Error('invalid tenant id');
   return tenant;
 }
 

--- a/tests/http/tenant/middleware.test.ts
+++ b/tests/http/tenant/middleware.test.ts
@@ -124,6 +124,22 @@ test('tenant middleware can derive tenant from configured API key', async () => 
   }
 });
 
+test('tenant middleware ignores wildcard API keys when deriving a tenant', async () => {
+  const previous = process.env.ORACLE_TENANT_API_KEYS;
+  process.env.ORACLE_TENANT_API_KEYS = '*=shared-key';
+  try {
+    const res = await request('/notes', {
+      headers: { [TENANT_API_KEY_HEADER]: 'shared-key' },
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'tenant required' });
+  } finally {
+    if (previous === undefined) delete process.env.ORACLE_TENANT_API_KEYS;
+    else process.env.ORACLE_TENANT_API_KEYS = previous;
+  }
+});
+
 test('tenant middleware returns a structured 400 for invalid tenant headers', async () => {
   const res = await request('/notes', {
     headers: { [TENANT_HEADER]: 'bad/tenant' },
@@ -167,6 +183,8 @@ test('tenant helpers parse token maps and sanitize tenant data paths', () => {
   expect(parseTenantTokens('{"tenant-a":"json-secret"}')).toEqual({
     'tenant-a': 'json-secret',
   });
+  expect(() => parseTenantTokens('constructor=secret')).toThrow('invalid tenant token config');
+  expect(() => parseTenantTokens('{"prototype":"secret"}')).toThrow('invalid tenant token config');
 
   const scoped = runWithTenant('tenant/a', () => tenantDataPath('/tmp/oracle.db'));
   expect(scoped).toBe(path.join('/tmp', 'tenants', 'tenant_a', 'oracle.db'));

--- a/tests/integration/cors-pna.test.ts
+++ b/tests/integration/cors-pna.test.ts
@@ -37,8 +37,45 @@ describe('hosted Studio CORS and PNA preflight', () => {
     expect(response.headers.get('Vary')).toContain('Origin');
   });
 
+  test('normalizes preflight method and private-network casing', async () => {
+    const response = await corsApp().handle(new Request('http://localhost:47778/api/health', {
+      method: 'OPTIONS',
+      headers: {
+        origin: HOSTED_STUDIO,
+        'access-control-request-method': ' get ',
+        'access-control-request-headers': 'Content-Type, X-Oracle-Tenant',
+        'access-control-request-private-network': ' TRUE ',
+      },
+    }));
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe(HOSTED_STUDIO);
+    expect(response.headers.get('Access-Control-Allow-Private-Network')).toBe('true');
+    expect(response.headers.get('Access-Control-Allow-Headers')).toBe('content-type,x-oracle-tenant');
+    expect(response.headers.get('Vary')).toContain('Origin');
+    expect(response.headers.get('Vary')).toContain('Access-Control-Request-Method');
+    expect(response.headers.get('Vary')).toContain('Access-Control-Request-Headers');
+    expect(response.headers.get('Vary')).toContain('Access-Control-Request-Private-Network');
+  });
+
   test('does not grant private-network access to unknown origins', async () => {
     const response = await corsApp().handle(pnaPreflight('https://evil.example'));
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull();
+    expect(response.headers.get('Access-Control-Allow-Private-Network')).toBeNull();
+  });
+
+  test('does not grant private-network access for unsupported request headers', async () => {
+    const response = await corsApp().handle(new Request('http://localhost:47778/api/health', {
+      method: 'OPTIONS',
+      headers: {
+        origin: HOSTED_STUDIO,
+        'access-control-request-method': 'GET',
+        'access-control-request-headers': 'x-not-allowed',
+        'access-control-request-private-network': 'true',
+      },
+    }));
 
     expect(response.status).toBe(204);
     expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull();


### PR DESCRIPTION
## Summary
- Normalize CORS preflight method and private-network header casing/whitespace for hosted Studio local-backend access.
- Add preflight Vary coverage for request method, request headers, and private-network requests.
- Harden tenant edge cases by rejecting reserved tenant keys and ignoring wildcard API-key entries for tenant derivation.

## Tests
```bash
bunx tsc --noEmit
bun test tests/http/cors tests/http/security/auth-and-cors.test.ts tests/integration/cors-pna.test.ts tests/integration/middleware-stack.test.ts tests/integration/middleware-order.test.ts tests/http/tenant/
```

## File sizes
```bash
wc -l src/middleware/cors.ts src/middleware/tenant.ts tests/integration/cors-pna.test.ts tests/http/tenant/middleware.test.ts
```
All changed files are <=250 lines.
