### PR TITLE
test: harden health db ping edges

### DIFF
--- a/src/routes/health/health.ts
+++ b/src/routes/health/health.ts
@@ -215,7 +215,7 @@ export function createHealthEndpoint(options: HealthEndpointOptions = {}) {
       uptime: serviceUptime,
       uptimeSeconds: serviceUptime,
       db: dbStatus.status,
-      oracle: dbStatus.status === 'connected' ? 'connected' : 'error',
+      oracle: dbStatus.status === 'connected' ? 'connected' : 'degraded',
       dbStatus: dbStatus.status,
       vectorStatus: vector.status,
       ...vectorRuntime,

--- a/tests/http/health/deep.test.ts
+++ b/tests/http/health/deep.test.ts
@@ -59,4 +59,30 @@ describe('GET /api/health/deep', () => {
     expect(body.vector).toMatchObject({ status: 'down', error: 'vector offline' });
     expect(body.disk).toMatchObject({ status: 'warning', usedPercent: 95 });
   });
+
+  test('captures thrown dbPing errors with latency while preserving resource details', async () => {
+    const app = createHealthRoutes({
+      dbPing: async () => { throw new Error('sqlite busy'); },
+      vectorHealth: async () => ({ status: 'ok', checked_at: 'now', engines: [] }),
+      diskUsage: () => ({
+        status: 'ok',
+        path: '/tmp/oracle',
+        totalBytes: 200,
+        freeBytes: 150,
+        usedBytes: 50,
+        usedPercent: 25,
+      }),
+      memoryUsage: () => ({ rss: 2, heapTotal: 2, heapUsed: 1, external: 0, arrayBuffers: 0 }),
+    });
+
+    const res = await app.handle(new Request('http://local/api/health/deep'));
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe('down');
+    expect(body.db).toMatchObject({ status: 'error', error: 'sqlite busy' });
+    expect(body.db.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(body.vector.status).toBe('ok');
+    expect(body.disk).toMatchObject({ status: 'ok', usedPercent: 25 });
+  });
 });

--- a/tests/http/health/draining.test.ts
+++ b/tests/http/health/draining.test.ts
@@ -2,10 +2,19 @@ import { expect, test } from 'bun:test';
 import { createHealthRoutes } from '../../../src/routes/health/index.ts';
 
 test('GET /api/health reports draining state before dependency checks', async () => {
-  const app = createHealthRoutes({ isDraining: () => true });
+  let dbPingCalled = false;
+  let vectorCalled = false;
+  const app = createHealthRoutes({
+    isDraining: () => true,
+    dbPing: () => { dbPingCalled = true; return { status: 'connected' }; },
+    vectorHealth: async () => { vectorCalled = true; return { status: 'ok', engines: [], checked_at: 'now' }; },
+  });
+
   const res = await app.handle(new Request('http://local/api/health'));
   const body = await res.json() as Record<string, unknown>;
 
   expect(res.status).toBe(503);
   expect(body).toMatchObject({ status: 'draining', sandbox: 'dev', draining: true });
+  expect(dbPingCalled).toBe(false);
+  expect(vectorCalled).toBe(false);
 });

--- a/tests/http/health/status.test.ts
+++ b/tests/http/health/status.test.ts
@@ -53,5 +53,26 @@ test('GET /api/health reflects database ping result in status and db field', asy
   expect(res.status).toBe(200);
   expect(body.status).toBe('degraded');
   expect(body.db).toBe('error');
+  expect(body.oracle).toBe('degraded');
+  expect(body.dbStatus).toBe('error');
   expect(body.dbCheck).toMatchObject({ status: 'error', error: 'db offline' });
+});
+
+test('GET /api/health catches dbPing exceptions and keeps response shaped', async () => {
+  const app = createHealthRoutes({
+    uptimeSeconds: () => 0.3333,
+    dbPing: async () => { throw 'db locked'; },
+    vectorHealth: async () => ({ status: 'ok', engines: [], checked_at: '2026-06-16T00:00:00.000Z' }),
+    vectorServerHealth: async () => ({ configured: false, status: 'unconfigured' }),
+  });
+  const res = await app.handle(new Request('http://local/api/health'));
+  const body = await res.json() as Record<string, any>;
+
+  expect(res.status).toBe(200);
+  expect(body.status).toBe('degraded');
+  expect(body.uptimeSeconds).toBe(0.333);
+  expect(body.db).toBe('error');
+  expect(body.oracle).toBe('degraded');
+  expect(body.dbCheck).toMatchObject({ status: 'error', error: 'db locked' });
+  expect(body.vectorStatus).toBe('ok');
 });


### PR DESCRIPTION
## Summary

- Harden `/api/health` DB-ping failure reporting so the legacy `oracle` field degrades instead of emitting an out-of-contract `error` value.
- Add health-route coverage for dbPing errors/rejections, including shaped `/api/health` responses and `/api/health/deep` latency/error details.
- Verify draining health exits before DB/vector dependency checks.

## Validation

```bash
bunx tsc --noEmit
bun test tests/http/health/
git diff --check
git diff --name-only origin/alpha...HEAD | xargs wc -l
```
