### PR TITLE
fix(studio): resolve hosted API host

### DIFF
--- a/frontend/src/api/oracle.ts
+++ b/frontend/src/api/oracle.ts
@@ -1,6 +1,7 @@
 export const TAURI_API_BASE = 'http://localhost:47778';
 export const DEFAULT_API_HOST = 'localhost:47778';
-export const API_HOST_STORAGE_KEY = 'oracle.host';
+export const API_HOST_STORAGE_KEY = 'oracle:host';
+const LEGACY_API_HOST_STORAGE_KEY = 'oracle.host';
 
 declare global {
   interface Window {
@@ -45,9 +46,11 @@ function resolveBrowserApiHost(): string {
   if (!win) return DEFAULT_API_HOST;
   const url = new URL(win.location.href);
   const queryHost = url.searchParams.get('host');
-  const host = normalizeApiHost(queryHost || storage()?.getItem(API_HOST_STORAGE_KEY));
-  if (queryHost) {
-    storage()?.setItem(API_HOST_STORAGE_KEY, host);
+  const store = storage();
+  const storedHost = store?.getItem(API_HOST_STORAGE_KEY) ?? store?.getItem(LEGACY_API_HOST_STORAGE_KEY);
+  const host = normalizeApiHost(queryHost || storedHost);
+  if (queryHost || storedHost) {
+    store?.setItem(API_HOST_STORAGE_KEY, host);
     cleanHostParam(url);
   }
   return host;
@@ -114,7 +117,8 @@ export type VectorHealthStatus = {
 };
 
 export function hasStoredApiHost(): boolean {
-  return Boolean(storage()?.getItem(API_HOST_STORAGE_KEY));
+  const store = storage();
+  return Boolean(store?.getItem(API_HOST_STORAGE_KEY) ?? store?.getItem(LEGACY_API_HOST_STORAGE_KEY));
 }
 
 export function persistApiHost(host: string): string {

--- a/frontend/src/components/BackendGate.tsx
+++ b/frontend/src/components/BackendGate.tsx
@@ -91,7 +91,7 @@ export function ConnectOracleSetup({
         <p className="text-sm font-semibold uppercase tracking-[0.3em] text-teal-300">
           ARRA Oracle
         </p>
-        <h1 className="mt-3 text-3xl font-bold">Connect to your Oracle</h1>
+        <h1 className="mt-3 text-3xl font-bold">{state === "unreachable" ? "Backend unavailable" : "Connect to your Oracle"}</h1>
         <p className="mt-4 text-sm text-slate-300">
           {state === "checking"
             ? `Checking backend health at ${target}.`

--- a/tests/frontend/components/backend-gate-shell.test.tsx
+++ b/tests/frontend/components/backend-gate-shell.test.tsx
@@ -38,6 +38,7 @@ describe('BackendGate shell', () => {
         />,
       );
 
+      expect(html).toContain('Backend unavailable');
       expect(html).toContain('Cannot reach http://localhost:47778: fetch failed');
       expect(html).toContain('value="localhost:47778"');
       expect(html).toContain('arra-oracle-v3 serve');
@@ -74,6 +75,7 @@ describe('BackendGate shell', () => {
       />,
     );
 
+    expect(html).toContain('Backend unavailable');
     expect(html).toContain('Cannot reach http://localhost:47778: offline');
     expect(html).toContain('Use this backend');
     expect(html).toContain('Retry');

--- a/tests/frontend/oracle-api-host.test.ts
+++ b/tests/frontend/oracle-api-host.test.ts
@@ -41,31 +41,6 @@ afterEach(() => {
   if (originalWindow) Object.defineProperty(globalThis, 'window', originalWindow);
   else delete (globalThis as { window?: unknown }).window;
   globalThis.fetch = originalFetch;
-
-  test('absolute ?host values keep non-host query params while changing ports', async () => {
-    const fake = installWindow('https://god.buildwithoracle.com/vector?pane=menu&host=https://127.0.0.1:47779/api#dash');
-    const api = await loadOracleApi('absolute-host');
-    expect(api.API_HOST).toBe('127.0.0.1:47779');
-    expect(api.API_BASE).toBe('http://127.0.0.1:47779');
-    expect(fake.localStorage.getItem(api.API_HOST_STORAGE_KEY)).toBe('127.0.0.1:47779');
-    expect(fake.replaced).toBe('/vector?pane=menu#dash');
-  });
-
-  test('apiFetch targets a stored local backend with PNA metadata', async () => {
-    installWindow('https://god.buildwithoracle.com/', { 'oracle.host': 'localhost:47780' });
-    let captured: { input: RequestInfo | URL; init?: RequestInit } | null = null;
-    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-      captured = { input, init };
-      return new Response('{}', { status: 200 });
-    }) as typeof fetch;
-    const api = await loadOracleApi('stored-local-fetch');
-
-    await api.apiFetch('/api/health', { headers: { accept: 'application/json' } });
-
-    expect(String(captured?.input)).toBe('http://localhost:47780/api/health');
-    expect((captured?.init as RequestInit & { targetAddressSpace?: string })?.targetAddressSpace).toBe('local');
-  });
-
 });
 
 describe('Studio local Oracle host resolution', () => {
@@ -90,10 +65,19 @@ describe('Studio local Oracle host resolution', () => {
   });
 
   test('stored host is reused when query param is absent', async () => {
-    installWindow('https://god.buildwithoracle.com/', { 'oracle.host': '127.0.0.1:47778' });
+    installWindow('https://god.buildwithoracle.com/', { 'oracle:host': '127.0.0.1:47778' });
     const api = await loadOracleApi('stored-host');
     expect(api.API_HOST).toBe('127.0.0.1:47778');
     expect(api.apiUrl('/api/v1/vector/config')).toBe('http://127.0.0.1:47778/api/v1/vector/config');
+  });
+
+
+  test('legacy stored host is migrated to oracle:host', async () => {
+    const fake = installWindow('https://god.buildwithoracle.com/', { 'oracle.host': '127.0.0.1:47781' });
+    const api = await loadOracleApi('legacy-stored-host');
+    expect(api.API_HOST_STORAGE_KEY).toBe('oracle:host');
+    expect(api.API_HOST).toBe('127.0.0.1:47781');
+    expect(fake.localStorage.getItem('oracle:host')).toBe('127.0.0.1:47781');
   });
 
   test('remote hosts do not receive local PNA metadata', async () => {
@@ -121,7 +105,7 @@ describe('Studio local Oracle host resolution', () => {
   });
 
   test('apiFetch targets a stored local backend with PNA metadata', async () => {
-    installWindow('https://god.buildwithoracle.com/', { 'oracle.host': 'localhost:47780' });
+    installWindow('https://god.buildwithoracle.com/', { 'oracle:host': 'localhost:47780' });
     let captured: { input: RequestInfo | URL; init?: RequestInit } | null = null;
     globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
       captured = { input, init };


### PR DESCRIPTION
## Summary
- Uses `oracle:host` as the hosted Studio API host storage key, with migration from the prior `oracle.host` key.
- Keeps browser API base on `?host=` → localStorage → `http://localhost:47778`, never same-origin static worker.
- Keeps local PNA fetch metadata and labels the unreachable setup card as `Backend unavailable` with the existing host picker.

## Verification
```bash
rtk bunx tsc --noEmit
rtk bun test tests/frontend/oracle-api-host.test.ts tests/frontend/components/backend-gate-shell.test.tsx
wc -l frontend/src/api/oracle.ts frontend/src/components/BackendGate.tsx tests/frontend/oracle-api-host.test.ts tests/frontend/components/backend-gate-shell.test.tsx
```

Closes #2342.