### PR TITLE
docs: publish live worker URLs

### DIFF
--- a/docs/deploy-cloudflare-mcp.md
+++ b/docs/deploy-cloudflare-mcp.md
@@ -22,11 +22,12 @@ planes instead of running in the Worker isolate.
 
 Use `workers/mcp/wrangler.jsonc` for the deploy target; it provisions the
 `MCP_OBJECT` Durable Object binding and deploys the Worker. The root
-`wrangler.jsonc` is a legacy teardown config for `arra-oracle-remote-mcp`. The deployed MCP URL
-will be:
+`wrangler.jsonc` is a legacy teardown config for `arra-oracle-remote-mcp`.
+
+Current live MCP Worker:
 
 ```text
-https://<worker-name>.<account>.workers.dev/mcp
+https://arra-oracle-mcp.laris.workers.dev/mcp
 ```
 
 ## Worker shape
@@ -98,7 +99,7 @@ npx @modelcontextprotocol/inspector@latest
 In the inspector UI, connect to:
 
 ```text
-https://<worker-name>.<account>.workers.dev/mcp
+https://arra-oracle-mcp.laris.workers.dev/mcp
 ```
 
 Then select **List Tools**. You should see remoteable REST tools from
@@ -117,15 +118,16 @@ Desktop settings, edit the Developer MCP config, and add:
       "command": "npx",
       "args": [
         "mcp-remote",
-        "https://<worker-name>.<account>.workers.dev/mcp"
+        "https://arra-oracle-mcp.laris.workers.dev/mcp"
       ]
     }
   }
 }
 ```
 
-If your Claude client supports remote MCP URLs directly, use the same `/mcp` URL
-as the server URL.
+If your Claude client supports remote MCP URLs directly, use the same live
+`/mcp` URL as the server URL. The paired live Studio Worker is
+`https://arra-oracle-studio.laris.workers.dev`.
 
 ## Multi-tenant setup for teams and schools
 

--- a/docs/deploy-production.md
+++ b/docs/deploy-production.md
@@ -5,6 +5,13 @@ one trusted backend host. Cloudflare Workers serve Studio, remote MCP, and the
 federation relay; `cloudflared` exposes the Bun backend through a stable HTTPS
 origin consumed by `ORACLE_ORIGIN_URL`.
 
+## Live Worker URLs
+
+```text
+Studio: https://arra-oracle-studio.laris.workers.dev
+MCP:    https://arra-oracle-mcp.laris.workers.dev/mcp
+```
+
 ## Production shape
 
 ```text
@@ -28,10 +35,9 @@ indexing on the backend/vector plane.
 - `bun`, `cloudflared`, and `wrangler` available locally.
 - `wrangler login` completed for the target Cloudflare account.
 - A backend host that can keep `maw arra serve` and `cloudflared` running.
-- DNS names chosen, for example:
-  - `oracle-origin.example.com` for the tunnel origin.
-  - `studio.example.com` for Studio, if not using `workers.dev`.
-  - `mcp.example.com` for remote MCP, if not using `workers.dev`.
+- DNS names chosen for the origin; current live Workers already use
+  `https://arra-oracle-studio.laris.workers.dev` and
+  `https://arra-oracle-mcp.laris.workers.dev/mcp`.
 
 ## 1. Start the Oracle backend
 
@@ -126,7 +132,7 @@ If Studio should connect directly to a separate MCP Worker, set this after the
 MCP deploy URL is known:
 
 ```bash
-export ORACLE_MCP_URL="https://arra-oracle-mcp.<account>.workers.dev/mcp"
+export ORACLE_MCP_URL="https://arra-oracle-mcp.laris.workers.dev/mcp"
 printf '%s' "$ORACLE_MCP_URL" |
   bunx wrangler secret put ORACLE_MCP_URL --config workers/studio/wrangler.jsonc
 ```
@@ -140,10 +146,10 @@ bunx tsc --noEmit
 bunx wrangler deploy --config wrangler.jsonc
 ```
 
-Record the deployed MCP URL:
+Record or verify the deployed MCP URL:
 
 ```text
-https://<mcp-worker-host>/mcp
+https://arra-oracle-mcp.laris.workers.dev/mcp
 ```
 
 Smoke test the deployed `/mcp` URL with MCP Inspector or a remote-capable MCP
@@ -171,8 +177,8 @@ bunx wrangler deploy --config wrangler.jsonc
 Smoke checks:
 
 ```bash
-curl -sf https://<studio-worker-host>/__health
-curl -sf https://<studio-worker-host>/api/health
+curl -sf https://arra-oracle-studio.laris.workers.dev/__health
+curl -sf https://arra-oracle-studio.laris.workers.dev/api/health
 ```
 
 Open the Studio URL and confirm dashboard/search calls succeed. If `/mcp` should
@@ -204,8 +210,10 @@ being forwarded to `TUNNEL_URL`.
 
 - `curl -sf "$ORACLE_ORIGIN_URL/api/health"` succeeds from outside the origin
   host.
-- Studio `GET /__health` and proxied `GET /api/health` both succeed.
-- MCP Inspector can list tools at the deployed `/mcp` URL; no Worker `/health` probe is expected.
+- Studio `GET /__health` and proxied `GET /api/health` both succeed at
+  `https://arra-oracle-studio.laris.workers.dev`.
+- MCP Inspector can list tools at
+  `https://arra-oracle-mcp.laris.workers.dev/mcp`; no Worker `/health` probe is expected.
 - MCP tenant forwarding is configured through auth props/claims, optional D1 tenants, or `ORACLE_TENANT_ID`.
 - Federation `GET /__health` reports `tunnelConfigured: true`.
 - Worker secrets are set with Wrangler or the Cloudflare dashboard; real URLs and


### PR DESCRIPTION
## Summary
- Update `docs/deploy-cloudflare-mcp.md` with the live MCP Worker URL: `https://arra-oracle-mcp.laris.workers.dev/mcp`.
- Update `docs/deploy-production.md` with the live Studio and MCP Worker URLs and smoke-check commands.
- Keep the deploy docs under the 250-line limit.

## Validation
```bash
bunx tsc --noEmit
bun test tests/docs/link-checker.test.ts
bun test tests/docs/
git diff --check
wc -l docs/deploy-cloudflare-mcp.md docs/deploy-production.md
```
