### PR TITLE
feat(search): surface oracle_search confidence provenance

### DIFF
--- a/src/server/logging.ts
+++ b/src/server/logging.ts
@@ -64,7 +64,7 @@ export function logSearch(
     if (results.length > 0) {
       const expectedFields = [
         'id', 'type', 'content', 'source_file', 'concepts', 'source', 'score',
-        'distance', 'model', 'ftsScore', 'vectorScore',
+        'distance', 'model', 'ftsScore', 'vectorScore', 'confidence', 'provenance',
         'superseded_by', 'superseded_at', 'superseded_reason',
       ];
       const firstResult = results[0] as unknown as Record<string, unknown>;

--- a/src/tools/__tests__/search-evidence.test.ts
+++ b/src/tools/__tests__/search-evidence.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from 'bun:test';
+import { attachSearchEvidence, confidenceForResult, provenanceForResult } from '../search.ts';
+import type { CombinedSearchResult } from '../search/types.ts';
+
+const baseResult = {
+  id: 'memory-doc',
+  type: 'learning',
+  content: 'Memory systems need evidence and confidence.',
+  source_file: 'ψ/memory/morning-tape.md',
+  concepts: ['memory'],
+} satisfies Partial<CombinedSearchResult>;
+
+test('confidence ranks hybrid results above weak single-source matches', () => {
+  const hybrid = confidenceForResult({
+    ...baseResult,
+    score: 0.72,
+    source: 'hybrid',
+    ftsScore: 0.8,
+    vectorScore: 0.74,
+  } as CombinedSearchResult);
+  const fts = confidenceForResult({
+    ...baseResult,
+    score: 0.38,
+    source: 'fts',
+  } as CombinedSearchResult);
+
+  expect(hybrid.level).toBe('high');
+  expect(hybrid.signals).toContain('matched by FTS and vector search');
+  expect(fts.level).toBe('low');
+  expect(fts.signals).toEqual(['matched by keyword search']);
+});
+
+test('provenance surfaces source file and vector lineage', () => {
+  const provenance = provenanceForResult({
+    ...baseResult,
+    score: 0.91,
+    source: 'vector',
+    vectorScore: 0.91234,
+    distance: 0.08765,
+    model: 'bge-m3',
+  } as CombinedSearchResult);
+
+  expect(provenance).toEqual({
+    source: 'vector',
+    source_file: 'ψ/memory/morning-tape.md',
+    vector_score: 0.912,
+    vector_distance: 0.088,
+    vector_model: 'bge-m3',
+  });
+});
+
+test('attachSearchEvidence decorates oracle_search results inline', () => {
+  const [result] = attachSearchEvidence([{
+    ...baseResult,
+    score: 0.51,
+    source: 'fts',
+    ftsScore: 0.51,
+  } as CombinedSearchResult]);
+
+  expect(result.confidence).toMatchObject({ level: 'medium', score: 0.51 });
+  expect(result.provenance).toMatchObject({ source: 'fts', fts_score: 0.51 });
+});

--- a/src/tools/__tests__/search-supersede.test.ts
+++ b/src/tools/__tests__/search-supersede.test.ts
@@ -76,6 +76,9 @@ test('oracle_search includes inline supersede successor fields', async () => {
     id: 'old-supersede-doc',
     superseded_by: 'new-supersede-doc',
     superseded_reason: 'newer MCP memory',
+    confidence: { level: 'medium' },
+    provenance: { source: 'fts', source_file: 'ψ/memory/old.md' },
   });
+  expect(body.results[0].confidence.signals).toContain('matched by keyword search');
   expect(body.results[0].superseded_at).toMatch(/T.*Z$/);
 });

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -2,11 +2,14 @@
 
 export { searchToolDef } from './search/definition.ts';
 export {
+  attachSearchEvidence,
   combineResults,
+  confidenceForResult,
   normalizeFtsScore,
   parseConceptsFromMetadata,
+  provenanceForResult,
   sanitizeFtsQuery,
 } from './search/helpers.ts';
 export { vectorSearch } from './search/vector.ts';
 export { handleSearch } from './search/handler.ts';
-export type { CombinedSearchResult, FtsResult, VectorResult } from './search/types.ts';
+export type { CombinedSearchResult, FtsResult, SearchConfidence, SearchProvenance, VectorResult } from './search/types.ts';

--- a/src/tools/search/handler.ts
+++ b/src/tools/search/handler.ts
@@ -4,7 +4,7 @@ import type { SearchResult } from '../../server/types.ts';
 import { isVectorSectionEnabled } from '../../vector/config.ts';
 import type { ToolContext, ToolResponse, OracleSearchInput } from '../types.ts';
 import { searchFts, mapFtsResults, enrichSupersedeFlags } from './fts.ts';
-import { combineResults, sanitizeFtsQuery } from './helpers.ts';
+import { attachSearchEvidence, combineResults, sanitizeFtsQuery } from './helpers.ts';
 import { vectorSearch } from './vector.ts';
 
 let logSearchFn: typeof import('../../server/logging.ts').logSearch | null = null;
@@ -67,7 +67,7 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
     ? [...reranked.results, ...combinedResults.slice(50)]
     : combinedResults;
   const totalMatches = finalResults.length;
-  const results: Array<Record<string, unknown>> = finalResults.slice(offset, offset + limit);
+  const results: Array<Record<string, unknown>> = attachSearchEvidence(finalResults.slice(offset, offset + limit));
   enrichSupersedeFlags(ctx, results);
 
   const ftsCount = results.filter((result) => result.source === 'fts').length;

--- a/src/tools/search/helpers.ts
+++ b/src/tools/search/helpers.ts
@@ -1,4 +1,4 @@
-import type { CombinedSearchResult, FtsResult, VectorResult } from './types.ts';
+import type { CombinedSearchResult, FtsResult, SearchConfidence, SearchProvenance, VectorResult } from './types.ts';
 
 /** Sanitize FTS5 query to prevent parse errors. */
 export function sanitizeFtsQuery(query: string): string {
@@ -89,4 +89,44 @@ export function combineResults(
 
   combined.sort((a, b) => b.score - a.score);
   return combined;
+}
+
+function boundedScore(value: number | undefined): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, Number(value)));
+}
+
+export function confidenceForResult(result: CombinedSearchResult): SearchConfidence {
+  const score = boundedScore(result.score);
+  const source = result.source;
+  const signals: string[] = [];
+  if (source === 'hybrid') signals.push('matched by FTS and vector search');
+  else if (source === 'fts') signals.push('matched by keyword search');
+  else signals.push('matched by vector search');
+  if ((result.ftsScore ?? 0) >= 0.7) signals.push('strong keyword score');
+  if ((result.vectorScore ?? 0) >= 0.7) signals.push('strong vector score');
+
+  const thresholdBonus = source === 'hybrid' ? 0.05 : 0;
+  const adjusted = boundedScore(score + thresholdBonus);
+  const level = adjusted >= 0.75 ? 'high' : adjusted >= 0.45 ? 'medium' : 'low';
+  return { level, score: Number(score.toFixed(3)), signals };
+}
+
+export function provenanceForResult(result: CombinedSearchResult): SearchProvenance {
+  return {
+    source: result.source,
+    source_file: result.source_file,
+    ...(result.ftsScore !== undefined ? { fts_score: Number(result.ftsScore.toFixed(3)) } : {}),
+    ...(result.vectorScore !== undefined ? { vector_score: Number(result.vectorScore.toFixed(3)) } : {}),
+    ...(result.distance !== undefined ? { vector_distance: Number(result.distance.toFixed(3)) } : {}),
+    ...(result.model ? { vector_model: result.model } : {}),
+  };
+}
+
+export function attachSearchEvidence(results: CombinedSearchResult[]): CombinedSearchResult[] {
+  return results.map((result) => ({
+    ...result,
+    confidence: confidenceForResult(result),
+    provenance: provenanceForResult(result),
+  }));
 }

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -46,4 +46,21 @@ export type CombinedSearchResult = {
   superseded_reason?: string | null;
   valid_time?: string | null;
   valid_until?: string | null;
+  confidence?: SearchConfidence;
+  provenance?: SearchProvenance;
+};
+
+export type SearchConfidence = {
+  level: 'high' | 'medium' | 'low';
+  score: number;
+  signals: string[];
+};
+
+export type SearchProvenance = {
+  source: 'fts' | 'vector' | 'hybrid';
+  source_file: string;
+  fts_score?: number;
+  vector_score?: number;
+  vector_distance?: number;
+  vector_model?: string;
 };


### PR DESCRIPTION
## Summary
- Adds inline `confidence` to every `oracle_search` result (`high`/`medium`/`low`, rounded score, evidence signals).
- Adds inline `provenance` for result source lineage: source kind, source file, FTS/vector scores, vector distance, and model when present.
- Updates logging allow-list and MCP search tests so the evidence fields are treated as intentional output.

## Challenge 2 slice
- Issue: #1457
- Slice: confidence-ranking + provenance surfacing in `oracle_search`.

## Validation
```bash
rtk bunx tsc --noEmit
rtk bun test src/tools/__tests__/search.test.ts src/tools/__tests__/search-evidence.test.ts src/tools/__tests__/search-supersede.test.ts src/tools/__tests__/mcp-vector-guard.test.ts
rtk bash -lc 'wc -l src/tools/search.ts src/tools/search/helpers.ts src/tools/search/types.ts src/tools/search/handler.ts src/tools/__tests__/search-evidence.test.ts src/tools/__tests__/search-supersede.test.ts src/server/logging.ts && git diff --check'
```

## Notes
- No UI changes; screenshot not applicable.
- PR base: `alpha`.
