### PR TITLE
test: harden vector export and document pagination edges

### DIFF
--- a/src/routes/vector/documents.ts
+++ b/src/routes/vector/documents.ts
@@ -4,7 +4,7 @@
 
 import { Elysia, t } from 'elysia';
 import { currentTenantId } from '../../middleware/tenant.ts';
-import { getVectorStoreByModel } from '../../vector/factory.ts';
+import { getEmbeddingModels, getVectorStoreByModel } from '../../vector/factory.ts';
 import type { VectorQueryResult, VectorStoreAdapter } from '../../vector/types.ts';
 
 interface DocumentItem {
@@ -15,6 +15,7 @@ interface DocumentItem {
 
 interface VectorDocumentsDeps {
   getStore?: (collection?: string) => VectorStoreAdapter;
+  getModels?: () => Record<string, unknown>;
 }
 
 const DEFAULT_COLLECTION = 'bge-m3';
@@ -31,6 +32,11 @@ function parsePositiveInt(value: string | undefined, fallback: number, max?: num
 function parseOffset(value: string | undefined, fallback: number): number {
   const parsed = Number.parseInt(value ?? '', 10);
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function resolveCollection(collection: string | undefined, getModels?: () => Record<string, unknown>): string | null {
+  const name = (collection || DEFAULT_COLLECTION).trim() || DEFAULT_COLLECTION;
+  return !getModels || name in getModels() ? name : null;
 }
 
 function normalizeMetadata(metadata: unknown): Record<string, unknown> {
@@ -90,15 +96,20 @@ async function listWithQuery(
 
 export function createVectorDocumentsEndpoint(deps: VectorDocumentsDeps = {}) {
   const getStore = deps.getStore ?? getVectorStoreByModel;
+  const getModels = deps.getModels ?? (deps.getStore ? undefined : getEmbeddingModels);
 
   return new Elysia().get(
     '/vector/documents',
     async ({ query, set }) => {
-      const collection = query.collection || DEFAULT_COLLECTION;
       const limit = parsePositiveInt(query.limit, DEFAULT_LIMIT, MAX_LIMIT);
       const pageFallback = parsePositiveInt(query.page, DEFAULT_PAGE);
       const offset = parseOffset(query.offset, (pageFallback - 1) * limit);
       const page = query.page ? pageFallback : Math.floor(offset / limit) + 1;
+      const collection = resolveCollection(query.collection, getModels);
+      if (!collection) {
+        set.status = 404;
+        return { error: `Unknown vector collection: ${query.collection}`, items: [], total: 0, page, limit, offset };
+      }
 
       try {
         const store = getStore(collection);

--- a/src/routes/vector/export.ts
+++ b/src/routes/vector/export.ts
@@ -9,6 +9,7 @@ import type { VectorStoreAdapter } from '../../vector/types.ts';
 
 interface VectorExportDeps {
   getStore?: (collection?: string) => VectorStoreAdapter;
+  getModels?: () => Record<string, unknown>;
 }
 
 const DEFAULT_COLLECTION = 'bge-m3';
@@ -53,14 +54,14 @@ function progressStream(getStore: GetStore, collection: string): ReadableStream<
   });
 }
 
-function resolveCollection(collection: string | undefined): string | null {
-  const resolved = collection || DEFAULT_COLLECTION;
-  const models = getEmbeddingModels();
-  return models[resolved] ? resolved : null;
+function resolveCollection(collection: string | undefined, getModels?: () => Record<string, unknown>): string | null {
+  const resolved = (collection || DEFAULT_COLLECTION).trim() || DEFAULT_COLLECTION;
+  return !getModels || resolved in getModels() ? resolved : null;
 }
 
 export function createVectorExportEndpoint(deps: VectorExportDeps = {}) {
   const getStore = deps.getStore ?? getVectorStoreByModel;
+  const getModels = deps.getModels ?? (deps.getStore ? undefined : getEmbeddingModels);
 
   return new Elysia()
     .get('/vector/export/formats', () => ({ formats: availableExportFormats() }), {
@@ -72,7 +73,7 @@ export function createVectorExportEndpoint(deps: VectorExportDeps = {}) {
     .get(
       '/vector/export/progress',
       ({ query, set }) => {
-        const collection = resolveCollection(query.collection);
+        const collection = resolveCollection(query.collection, getModels);
         if (!collection) {
           set.status = 404;
           return { error: `Unknown vector collection: ${query.collection}` };
@@ -103,7 +104,7 @@ export function createVectorExportEndpoint(deps: VectorExportDeps = {}) {
         return { error: 'Invalid format', formats: availableExportFormats() };
       }
 
-      const collection = resolveCollection(query.collection);
+      const collection = resolveCollection(query.collection, getModels);
       if (!collection) {
         set.status = 404;
         return { error: `Unknown vector collection: ${query.collection}` };

--- a/tests/http/vector/documents-pagination-edge.test.ts
+++ b/tests/http/vector/documents-pagination-edge.test.ts
@@ -1,0 +1,78 @@
+import { expect, mock, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createVectorDocumentsEndpoint } from '../../../src/routes/vector/documents.ts';
+import type { VectorStoreAdapter } from '../../../src/vector/types.ts';
+
+type Doc = { id: string; document: string; metadata: Record<string, unknown> };
+
+function createStore(rows: Doc[]): VectorStoreAdapter {
+  return {
+    name: 'fake-vector',
+    connect: mock(async () => {}),
+    close: mock(async () => {}),
+    ensureCollection: mock(async () => {}),
+    deleteCollection: mock(async () => {}),
+    addDocuments: mock(async () => {}),
+    query: mock(async (_q, limit = 10) => ({
+      ids: rows.slice(0, limit).map((doc) => doc.id),
+      documents: rows.slice(0, limit).map((doc) => doc.document),
+      distances: rows.slice(0, limit).map(() => 0),
+      metadatas: rows.slice(0, limit).map((doc) => doc.metadata),
+    })),
+    queryById: mock(async () => ({ ids: [], documents: [], distances: [], metadatas: [] })),
+    getStats: mock(async () => ({ count: rows.length })),
+    getCollectionInfo: mock(async () => ({ count: rows.length, name: 'fake' })),
+    getAllEmbeddings: mock(async (limit = 5000) => ({
+      ids: rows.slice(0, limit).map((doc) => doc.id),
+      documents: rows.slice(0, limit).map((doc) => doc.document),
+      embeddings: rows.slice(0, limit).map(() => [0, 0, 0]),
+      metadatas: rows.slice(0, limit).map((doc) => doc.metadata),
+    })),
+  };
+}
+
+function createFetch(store: VectorStoreAdapter, collections: string[] = ['bge-m3']) {
+  const seen: string[] = [];
+  const app = new Elysia({ prefix: '/api' }).use(createVectorDocumentsEndpoint({
+    getModels: () => Object.fromEntries(collections.map((key) => [key, {}])),
+    getStore: (collection) => { seen.push(collection ?? ''); return store; },
+  }));
+  return { seen, fetcher: createApiVersionedFetch((request) => app.handle(request)) };
+}
+
+test('GET /api/v1/vector/documents rejects unknown collections before store fallback', async () => {
+  const { seen, fetcher } = createFetch(createStore([]));
+  const res = await fetcher(new Request('http://local/api/v1/vector/documents?collection=missing'));
+  const body = await res.json() as Record<string, unknown>;
+
+  expect(res.status).toBe(404);
+  expect(body).toMatchObject({ error: 'Unknown vector collection: missing', items: [], total: 0 });
+  expect(seen).toEqual([]);
+});
+
+test('GET /api/v1/vector/documents caps huge limits and normalizes bad pagination', async () => {
+  const store = createStore([
+    { id: 'doc-1', document: 'alpha', metadata: {} },
+    { id: 'doc-2', document: 'bravo', metadata: {} },
+  ]);
+  const { fetcher } = createFetch(store);
+  const res = await fetcher(new Request(
+    'http://local/api/v1/vector/documents?limit=999999&page=-2&offset=-10',
+  ));
+  const body = await res.json() as Record<string, unknown>;
+
+  expect(res.status).toBe(200);
+  expect(body).toMatchObject({ total: 2, page: 1, limit: 500, offset: 0 });
+  expect((body.items as Array<{ id: string }>).map((item) => item.id)).toEqual(['doc-1', 'doc-2']);
+  expect(store.getAllEmbeddings).toHaveBeenCalledWith(500);
+});
+
+test('GET /api/v1/vector/documents returns stable empty pagination shape', async () => {
+  const { fetcher } = createFetch(createStore([]));
+  const res = await fetcher(new Request('http://local/api/v1/vector/documents?page=3&limit=10'));
+  const body = await res.json() as Record<string, unknown>;
+
+  expect(res.status).toBe(200);
+  expect(body).toEqual({ items: [], total: 0, page: 3, limit: 10, offset: 20 });
+});

--- a/tests/http/vector/export-edge-cases.test.ts
+++ b/tests/http/vector/export-edge-cases.test.ts
@@ -1,0 +1,81 @@
+import { expect, mock, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createVectorExportEndpoint } from '../../../src/routes/vector/export.ts';
+import type { VectorStoreAdapter } from '../../../src/vector/types.ts';
+
+type Doc = { id: string; document: string; metadata: Record<string, unknown> };
+
+function createStore(rows: Doc[] = []): VectorStoreAdapter {
+  return {
+    name: 'fake-vector',
+    connect: mock(async () => {}),
+    close: mock(async () => {}),
+    ensureCollection: mock(async () => {}),
+    deleteCollection: mock(async () => {}),
+    addDocuments: mock(async () => {}),
+    query: mock(async () => ({ ids: [], documents: [], distances: [], metadatas: [] })),
+    queryById: mock(async () => ({ ids: [], documents: [], distances: [], metadatas: [] })),
+    getStats: mock(async () => ({ count: rows.length })),
+    getCollectionInfo: mock(async () => ({ count: rows.length, name: 'fake' })),
+    getAllEmbeddings: mock(async () => ({
+      ids: rows.map((doc) => doc.id),
+      documents: rows.map((doc) => doc.document),
+      embeddings: rows.map(() => [0, 0, 0]),
+      metadatas: rows.map((doc) => doc.metadata),
+    })),
+  };
+}
+
+function createFetch(store: VectorStoreAdapter, collections: string[] = []) {
+  const seen: string[] = [];
+  const app = new Elysia({ prefix: '/api' }).use(createVectorExportEndpoint({
+    getModels: () => Object.fromEntries(collections.map((key) => [key, {}])),
+    getStore: (collection) => { seen.push(collection ?? ''); return store; },
+  }));
+  return { seen, fetcher: createApiVersionedFetch((request) => app.handle(request)) };
+}
+
+test('GET /api/v1/vector/export rejects bad formats before opening a store', async () => {
+  const { seen, fetcher } = createFetch(createStore(), ['bge-m3']);
+  const res = await fetcher(new Request('http://local/api/v1/vector/export?format=zip'));
+  const body = await res.json() as { error: string; formats: Array<{ format: string }> };
+
+  expect(res.status).toBe(400);
+  expect(body.error).toBe('Invalid format');
+  expect(body.formats.map((item) => item.format)).toEqual(['csv', 'json', 'jsonl', 'markdown', 'v2']);
+  expect(seen).toEqual([]);
+});
+
+test('GET /api/v1/vector/export reports unknown collections without default fallback', async () => {
+  const { seen, fetcher } = createFetch(createStore(), ['bge-m3']);
+  const res = await fetcher(new Request(
+    'http://local/api/v1/vector/export?collection=missing&format=json',
+  ));
+  const body = await res.json() as Record<string, unknown>;
+
+  expect(res.status).toBe(404);
+  expect(body).toEqual({ error: 'Unknown vector collection: missing' });
+  expect(seen).toEqual([]);
+});
+
+test('GET /api/v1/vector/export streams empty json/jsonl/csv/markdown consistently', async () => {
+  const store = createStore();
+  const { fetcher } = createFetch(store, ['bge-m3']);
+
+  const json = await fetcher(new Request('http://local/api/v1/vector/export?format=json'));
+  expect(json.status).toBe(200);
+  expect(await json.json()).toEqual([]);
+
+  const jsonl = await fetcher(new Request('http://local/api/v1/vector/export?format=jsonl'));
+  expect(jsonl.status).toBe(200);
+  expect(await jsonl.text()).toBe('');
+
+  const csv = await fetcher(new Request('http://local/api/v1/vector/export?format=csv'));
+  expect(csv.status).toBe(200);
+  expect(await csv.text()).toBe('id,document,type,source_file,concepts\n');
+
+  const markdown = await fetcher(new Request('http://local/api/v1/vector/export?format=markdown'));
+  expect(markdown.status).toBe(200);
+  expect(await markdown.text()).toBe('');
+});


### PR DESCRIPTION
## Summary

- Harden vector export/document collection resolution so production endpoints return `404` for unknown collections instead of falling back to the default model.
- Add export edge tests for bad formats, unknown collections, and empty `json` / `jsonl` / `csv` / `markdown` streams.
- Add documents pagination edge tests for unknown collections, huge limit capping, bad page/offset normalization, and empty pages.

## Validation

```bash
bunx tsc --noEmit
bun test tests/http/vector/
git diff --check
git diff --name-only origin/alpha...HEAD | xargs wc -l
```
