### PR TITLE
test(frontend): harden playwright page coverage

### DIFF
--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -65,7 +65,7 @@ export async function reportErrorToMetrics(
   };
 
   try {
-    const response = await fetcher(apiUrl('/api/metrics'), withLocalPna({
+    const response = await fetcher(apiUrl('/api/v1/metrics'), withLocalPna({
       method: 'POST',
       keepalive: true,
       headers: {

--- a/tests/e2e/frontend-pages.e2e.ts
+++ b/tests/e2e/frontend-pages.e2e.ts
@@ -24,6 +24,24 @@ test.describe('Frontend pages render and interact through the Vite proxy', () =>
     await openFrontendPage(page, '/mcp', 'Tool browser');
   });
 
+  test('renders operational and vector utility pages', async ({ page }) => {
+    const pages: Array<[string, string | RegExp]> = [
+      ['/status', 'Health overview'],
+      ['/metrics', 'Metrics dashboard'],
+      ['/storage', 'Storage backend'],
+      ['/learn', 'Learn entries'],
+      ['/canvas/plugins', 'Canvas plugin registry'],
+      ['/vector/search', 'Vector search preview'],
+      ['/vector/documents', 'Vector documents'],
+      ['/vector/index', 'Index jobs and collections'],
+      ['/vector/export', 'Vector export'],
+      ['/vector/settings', 'Vector settings'],
+      ['/export', 'Export app'],
+    ];
+
+    for (const [path, heading] of pages) await openFrontendPage(page, path, heading);
+  });
+
   test('toggles the shell theme from a rendered menu page', async ({ page }) => {
     await openFrontendPage(page, '/menu', 'Menu catalog');
 

--- a/tests/frontend/api/_fetch.ts
+++ b/tests/frontend/api/_fetch.ts
@@ -1,11 +1,18 @@
 type FetchHandler = (input: RequestInfo | URL, init?: RequestInit) => Response | Promise<Response>;
 
+export function requestPath(input: RequestInfo | URL): string {
+  const raw = input instanceof Request ? input.url : String(input);
+  const url = new URL(raw, 'http://localhost');
+  return `${url.pathname}${url.search}`;
+}
+
 export function installFetch(handler: FetchHandler) {
   const previousFetch = globalThis.fetch;
-  const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+  const calls: Array<{ input: string; init?: RequestInit }> = [];
   globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
-    calls.push({ input, init });
-    return Promise.resolve(handler(input, init));
+    const path = requestPath(input);
+    calls.push({ input: path, init });
+    return Promise.resolve(handler(path, init));
   }) as typeof fetch;
   return {
     calls,

--- a/tests/frontend/api/api-client-edges.test.ts
+++ b/tests/frontend/api/api-client-edges.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { ApiClientError, createApiClient } from '../../../frontend/src/api/client';
+import { requestPath } from './_fetch';
 
 function jsonResponse(data: unknown, init: ResponseInit = {}): Response {
   return new Response(JSON.stringify(data), {
@@ -12,7 +13,7 @@ function jsonResponse(data: unknown, init: ResponseInit = {}): Response {
 describe('ApiClient edge cases', () => {
   test('preserves zero vector offsets and omits empty optional filters', async () => {
     const calls: string[] = [];
-    const client = createApiClient({ fetch: (input) => { calls.push(String(input)); return jsonResponse({ results: [], total: 0 }); } });
+    const client = createApiClient({ fetch: (input) => { calls.push(requestPath(input)); return jsonResponse({ results: [], total: 0 }); } });
 
     await client.vectorSearch({ q: 'oracle', limit: 0, offset: 0, type: '', project: 'repo', cwd: '/tmp/oracle' });
 

--- a/tests/frontend/api/learn-create-path.test.ts
+++ b/tests/frontend/api/learn-create-path.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { createApiClient } from '../../../frontend/src/api/client';
+import { requestPath } from './_fetch';
 
 function jsonResponse(data: unknown): Response {
   return new Response(JSON.stringify(data), { headers: { 'content-type': 'application/json' } });
@@ -10,7 +11,7 @@ describe('ApiClient createLearn', () => {
     const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
     const client = createApiClient({ fetch: (input, init) => { calls.push({ input, init }); return jsonResponse({ success: true, id: 'one', file: 'one.md' }); } });
     await expect(client.createLearn({ pattern: 'One', concepts: ['learn'] })).resolves.toMatchObject({ id: 'one' });
-    expect(calls[0]?.input).toBe('/api/v1/learn');
+    expect(requestPath(calls[0]?.input ?? '')).toBe('/api/v1/learn');
     expect(calls[0]?.init?.method).toBe('POST');
     expect(calls[0]?.init?.body).toBe(JSON.stringify({ pattern: 'One', concepts: ['learn'] }));
     expect(new Headers(calls[0]?.init?.headers).get('content-type')).toBe('application/json');

--- a/tests/frontend/api/learn-delete-path.test.ts
+++ b/tests/frontend/api/learn-delete-path.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { createApiClient } from '../../../frontend/src/api/client';
+import { requestPath } from './_fetch';
 
 function jsonResponse(data: unknown): Response {
   return new Response(JSON.stringify(data), { headers: { 'content-type': 'application/json' } });
@@ -10,7 +11,7 @@ describe('ApiClient deleteLearn', () => {
     const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
     const client = createApiClient({ fetch: (input, init) => { calls.push({ input, init }); return jsonResponse({ id: 'learn/id', deleted: 'soft', supersededAt: 7 }); } });
     await expect(client.deleteLearn('learn/id')).resolves.toMatchObject({ deleted: 'soft', supersededAt: 7 });
-    expect(calls[0]?.input).toBe('/api/v1/learn/learn%2Fid');
+    expect(requestPath(calls[0]?.input ?? '')).toBe('/api/v1/learn/learn%2Fid');
     expect(calls[0]?.init?.method).toBe('DELETE');
   });
 });

--- a/tests/frontend/api/learn-list-path.test.ts
+++ b/tests/frontend/api/learn-list-path.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { createApiClient } from '../../../frontend/src/api/client';
+import { requestPath } from './_fetch';
 
 function jsonResponse(data: unknown): Response {
   return new Response(JSON.stringify(data), { headers: { 'content-type': 'application/json' } });
@@ -10,7 +11,7 @@ describe('ApiClient learn list', () => {
     const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
     const client = createApiClient({ fetch: (input, init) => { calls.push({ input, init }); return jsonResponse({ items: [], total: 0 }); } });
     await expect(client.learn()).resolves.toEqual({ items: [], total: 0 });
-    expect(calls[0]?.input).toBe('/api/v1/learn');
+    expect(requestPath(calls[0]?.input ?? '')).toBe('/api/v1/learn');
     expect(new Headers(calls[0]?.init?.headers).get('accept')).toBe('application/json');
   });
 });

--- a/tests/frontend/api/learn-update-path.test.ts
+++ b/tests/frontend/api/learn-update-path.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { createApiClient } from '../../../frontend/src/api/client';
+import { requestPath } from './_fetch';
 
 function jsonResponse(data: unknown): Response {
   return new Response(JSON.stringify(data), { headers: { 'content-type': 'application/json' } });
@@ -10,7 +11,7 @@ describe('ApiClient updateLearn', () => {
     const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
     const client = createApiClient({ fetch: (input, init) => { calls.push({ input, init }); return jsonResponse({ id: 'learn id', title: 'Updated' }); } });
     await expect(client.updateLearn('learn id', { pattern: 'Updated' })).resolves.toMatchObject({ title: 'Updated' });
-    expect(calls[0]?.input).toBe('/api/v1/learn/learn%20id');
+    expect(requestPath(calls[0]?.input ?? '')).toBe('/api/v1/learn/learn%20id');
     expect(calls[0]?.init?.method).toBe('PUT');
     expect(calls[0]?.init?.body).toBe(JSON.stringify({ pattern: 'Updated' }));
   });

--- a/tests/frontend/api/vector-health-client.test.ts
+++ b/tests/frontend/api/vector-health-client.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { createApiClient } from '../../../frontend/src/api/client';
+import { requestPath } from './_fetch';
 
 function jsonResponse(data: unknown): Response {
   return new Response(JSON.stringify(data), { headers: { 'content-type': 'application/json' } });
@@ -16,6 +17,6 @@ describe('ApiClient vectorHealth', () => {
     });
 
     await expect(client.vectorHealth()).resolves.toMatchObject({ status: 'ok', engines: [{ key: 'bge', ok: true }] });
-    expect(String(calls[0]?.input)).toBe('/api/v1/vector/health');
+    expect(requestPath(calls[0]?.input ?? '')).toBe('/api/v1/vector/health');
   });
 });

--- a/tests/frontend/api/vector-index-models-client.test.ts
+++ b/tests/frontend/api/vector-index-models-client.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { createApiClient } from '../../../frontend/src/api/client';
+import { requestPath } from './_fetch';
 
 function jsonResponse(data: unknown): Response {
   return new Response(JSON.stringify(data), { headers: { 'content-type': 'application/json' } });
@@ -16,7 +17,7 @@ describe('ApiClient vectorIndexModels', () => {
     });
 
     await expect(client.vectorIndexModels()).resolves.toMatchObject({ models: { bge: { count: 4 } } });
-    expect(String(calls[0]?.input)).toBe('/api/v1/vector/index/models');
+    expect(requestPath(calls[0]?.input ?? '')).toBe('/api/v1/vector/index/models');
     expect(new Headers(calls[0]?.init?.headers).get('accept')).toBe('application/json');
   });
 });

--- a/tests/frontend/error-boundary.test.ts
+++ b/tests/frontend/error-boundary.test.ts
@@ -6,6 +6,7 @@ import {
   reportErrorToMetrics,
 } from '../../frontend/src/components/ErrorBoundary';
 import { htmlFor } from './_render';
+import { requestPath } from './api/_fetch';
 
 describe('ErrorBoundary fallback', () => {
   test('renders fallback UI with auto-retry and reporting status', () => {
@@ -35,7 +36,7 @@ describe('ErrorBoundary fallback', () => {
 });
 
 describe('reportErrorToMetrics', () => {
-  test('posts frontend error reports to /api/metrics', async () => {
+  test('posts frontend error reports to /api/v1/metrics', async () => {
     let request: { input: RequestInfo | URL; init?: RequestInit } | null = null;
     const ok = await reportErrorToMetrics(
       new Error('render failed'),
@@ -48,7 +49,7 @@ describe('reportErrorToMetrics', () => {
     );
 
     expect(ok).toBe(true);
-    expect(String(request?.input)).toBe('/api/metrics');
+    expect(requestPath(request?.input ?? '')).toBe('/api/v1/metrics');
     expect(request?.init?.method).toBe('POST');
     const headers = new Headers(request?.init?.headers);
     expect(headers.get('accept')).toBe('application/json');

--- a/tests/frontend/hooks/use-plugins.test.tsx
+++ b/tests/frontend/hooks/use-plugins.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { fetchPluginsFromEndpoint, usePlugins } from '../../../frontend/src/hooks/usePlugins';
 import type { PluginEntry } from '../../../frontend/src/types';
 import { htmlFor } from '../_render';
+import { requestPath } from '../api/_fetch';
 
 const plugin: PluginEntry = { name: 'echo', file: 'echo.ts', size: 42, modified: '2026-06-16T00:00:00Z' };
 
@@ -27,7 +28,7 @@ describe('usePlugins hook and endpoint store', () => {
     });
 
     expect(response).toEqual({ plugins: [plugin], dir: '', count: 1 });
-    expect(calls[0]?.input).toBe('/api/plugins?surface=ui');
+    expect(requestPath(calls[0]?.input ?? '')).toBe('/api/plugins?surface=ui');
     expect((calls[0]?.init?.headers as Record<string, string>).accept).toBe('application/json');
   });
 

--- a/tests/frontend/pages/vector-page-export.test.tsx
+++ b/tests/frontend/pages/vector-page-export.test.tsx
@@ -13,6 +13,7 @@ import {
   type VectorCollectionCard,
 } from '../../../frontend/src/pages/VectorPage';
 import { htmlFor } from '../_render';
+import { requestPath } from '../api/_fetch';
 
 const card: VectorCollectionCard = {
   key: 'bge-m3',
@@ -72,7 +73,7 @@ describe('VectorPage export buttons', () => {
     const saved: Array<{ blob: Blob; filename: string }> = [];
     await downloadVectorCollection('oracle_knowledge_bge_m3', 'csv', {
       fetch: (input) => {
-        calls.push(String(input));
+        calls.push(requestPath(input));
         return new Response('id,content\n1,oracle\n', { status: 200, headers: { 'content-type': 'text/csv' } });
       },
       saveBlob: (blob, filename) => saved.push({ blob, filename }),


### PR DESCRIPTION
## Summary
- Deepen Playwright coverage across operational, canvas, export, and vector utility pages.
- Normalize frontend fetch assertions with requestPath so tests validate API path/query while source may use absolute backend URLs.
- Move frontend error-boundary metrics reporting to the canonical /api/v1/metrics path.

## Validation
- bunx tsc --noEmit
- bun test tests/frontend/ (316 pass)
- bunx playwright test tests/e2e/frontend-pages.e2e.ts (4 passed)
- git diff --check
- changed files <=250 lines
