### PR TITLE
test(http): harden thread and trace edges

### DIFF
--- a/src/mcp/http-proxy.ts
+++ b/src/mcp/http-proxy.ts
@@ -88,8 +88,11 @@ function bodyFromMap(entry: RemoteableMcpRestEntry, args: Record<string, unknown
   switch (entry.body) {
     case undefined: return undefined;
     case 'args': return args;
-    case 'thread-message':
-      return { message: args.message, thread_id: args.threadId, title: args.title, role: args.role ?? 'claude', model: args.model };
+    case 'thread-message': {
+      const body: Record<string, unknown> = { message: args.message, thread_id: args.threadId, title: args.title, role: args.role ?? 'claude', model: args.model };
+      if (args.reopen !== undefined) body.reopen = args.reopen;
+      return body;
+    }
     case 'thread-status': return { status: args.status };
     case 'trace-link': return { nextId: args.nextTraceId };
     case 'trace-distill': {

--- a/src/routes/forum/model.ts
+++ b/src/routes/forum/model.ts
@@ -17,6 +17,7 @@ export const threadCreateBody = t.Object({
   thread_id: t.Optional(t.Union([t.Number(), t.String()])),
   title: t.Optional(t.String()),
   role: t.Optional(t.String()),
+  reopen: t.Optional(t.Boolean()),
 });
 
 export const threadStatusBody = t.Object({

--- a/src/routes/forum/thread-create.ts
+++ b/src/routes/forum/thread-create.ts
@@ -1,5 +1,5 @@
 import { Elysia } from 'elysia';
-import { handleThreadMessage } from '../../forum/handler.ts';
+import { getThread, handleThreadMessage } from '../../forum/handler.ts';
 import { optionalThreadId, parseMessageRole, threadCreateBody, trimmedString } from './model.ts';
 
 export const threadCreateRoute = new Elysia().post('/api/thread', async ({ body, set }) => {
@@ -19,6 +19,14 @@ export const threadCreateRoute = new Elysia().post('/api/thread', async ({ body,
     if (role === null) {
       set.status = 400;
       return { error: 'Invalid role (human|oracle|claude)' };
+    }
+    const existing = threadId === undefined ? null : getThread(threadId);
+    if (existing?.status === 'closed' && data.reopen !== true) {
+      set.status = 409;
+      return {
+        error: `Thread ${threadId} is closed. Pass reopen=true to add a new message.`,
+        status: 'closed',
+      };
     }
     const result = await handleThreadMessage({
       message,

--- a/src/routes/traces/tenant-scope.ts
+++ b/src/routes/traces/tenant-scope.ts
@@ -153,7 +153,9 @@ export function getTenantTraceLinkedChain(traceId: string): { chain: TraceRecord
   const backwardVisited = new Set<string>();
   while (current?.prevTraceId && !backwardVisited.has(current.prevTraceId)) {
     backwardVisited.add(current.traceId);
-    current = getTenantTrace(current.prevTraceId);
+    const previous = getTenantTrace(current.prevTraceId);
+    if (!previous) break;
+    current = previous;
   }
   const forwardVisited = new Set<string>();
   while (current && !forwardVisited.has(current.traceId)) {

--- a/tests/http/threads/edge-cases.test.ts
+++ b/tests/http/threads/edge-cases.test.ts
@@ -1,0 +1,125 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const root = join(tmpdir(), `arra-thread-edge-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+const dbPath = join(root, 'oracle.db');
+mkdirSync(root, { recursive: true });
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = dbPath;
+
+const dbMod = await import('../../../src/db/index.ts');
+dbMod.resetDefaultDatabaseForTests(dbPath);
+const tenantMod = await import('../../../src/middleware/tenant.ts');
+const { forumApi } = await import('../../../src/routes/forum/index.ts');
+
+const tenantHandler = tenantMod.createTenantFetch((request) => forumApi.handle(request));
+
+type JsonBody = Record<string, any>;
+
+function request(pathname: string, init: RequestInit = {}) {
+  return forumApi.handle(new Request(`http://local${pathname}`, {
+    ...init,
+    headers: { 'content-type': 'application/json', ...((init.headers as Record<string, string>) ?? {}) },
+  }));
+}
+
+function tenantRequest(tenantId: string, pathname: string, init: RequestInit = {}) {
+  return tenantHandler(new Request(`http://local${pathname}`, {
+    ...init,
+    headers: {
+      'content-type': 'application/json',
+      [tenantMod.TENANT_HEADER]: tenantId,
+      ...((init.headers as Record<string, string>) ?? {}),
+    },
+  }));
+}
+
+async function json(response: Response): Promise<JsonBody> {
+  return await response.json() as JsonBody;
+}
+
+function restore(name: string, value: string | undefined) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+afterAll(() => {
+  dbMod.closeDb();
+  restore('ORACLE_DATA_DIR', savedDataDir);
+  restore('ORACLE_DB_PATH', savedDbPath);
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('thread HTTP edge cases', () => {
+  test('send/list/read/update stay scoped to the active tenant', async () => {
+    const tenantA = 'thread-edge-a';
+    const tenantB = 'thread-edge-b';
+    const created = await tenantRequest(tenantA, '/api/thread', {
+      method: 'POST',
+      body: JSON.stringify({ message: 'tenant-scoped message', title: 'tenant scoped' }),
+    });
+    expect(created.status).toBe(200);
+    const threadId = (await json(created)).thread_id as number;
+
+    expect((await tenantRequest(tenantB, `/api/thread/${threadId}`)).status).toBe(404);
+    const listB = await json(await tenantRequest(tenantB, '/api/threads?limit=5'));
+    expect(listB.threads.map((thread: JsonBody) => thread.id)).not.toContain(threadId);
+
+    const deniedUpdate = await tenantRequest(tenantB, `/api/thread/${threadId}/status`, {
+      method: 'PATCH',
+      body: JSON.stringify({ status: 'closed' }),
+    });
+    expect(deniedUpdate.status).toBe(404);
+
+    const updateA = await tenantRequest(tenantA, `/api/thread/${threadId}/status`, {
+      method: 'PATCH',
+      body: JSON.stringify({ status: 'closed' }),
+    });
+    expect(updateA.status).toBe(200);
+  });
+
+  test('continuing a closed thread requires explicit reopen intent', async () => {
+    const created = await request('/api/thread', {
+      method: 'POST',
+      body: JSON.stringify({ message: 'close me', title: 'closed gate' }),
+    });
+    const threadId = (await json(created)).thread_id as number;
+    expect((await request(`/api/thread/${threadId}/status`, {
+      method: 'PATCH',
+      body: JSON.stringify({ status: 'closed' }),
+    })).status).toBe(200);
+
+    const blocked = await request('/api/thread', {
+      method: 'POST',
+      body: JSON.stringify({ thread_id: threadId, message: 'should not reopen implicitly' }),
+    });
+    expect(blocked.status).toBe(409);
+    expect((await json(blocked)).error).toContain('reopen=true');
+
+    const reopened = await request('/api/thread', {
+      method: 'POST',
+      body: JSON.stringify({ thread_id: String(threadId), message: 'explicit reopen', reopen: true }),
+    });
+    expect(reopened.status).toBe(200);
+    expect((await json(reopened)).status).toBe('pending');
+
+    const read = await json(await request(`/api/thread/${threadId}`));
+    expect(read.messages.map((message: JsonBody) => message.content)).toEqual(['close me', 'explicit reopen']);
+  });
+
+  test('send/list/read/update reject malformed edge inputs', async () => {
+    expect((await request('/api/thread', { method: 'POST', body: JSON.stringify({ message: '   ' }) })).status).toBe(400);
+    expect((await request('/api/thread', { method: 'POST', body: JSON.stringify({ message: 'bad id', thread_id: 0 }) })).status).toBe(400);
+    expect((await request('/api/thread', { method: 'POST', body: JSON.stringify({ message: 'missing id', thread_id: 999999 }) })).status).toBe(404);
+    expect((await request('/api/threads?status=open')).status).toBe(400);
+    expect((await request('/api/threads?limit=0')).status).toBe(400);
+    expect((await request('/api/threads?offset=NaN')).status).toBe(400);
+    expect((await request('/api/thread/not-a-number')).status).toBe(400);
+    expect((await request('/api/thread/0/status', { method: 'PATCH', body: JSON.stringify({ status: 'closed' }) })).status).toBe(400);
+    expect((await request('/api/thread/999999/status', { method: 'PATCH', body: JSON.stringify({ status: 'closed' }) })).status).toBe(404);
+  });
+});

--- a/tests/http/traces/edge-cases.test.ts
+++ b/tests/http/traces/edge-cases.test.ts
@@ -20,7 +20,12 @@ const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 const traceA = `trace-edge-a-${stamp}`;
 const traceB = `trace-edge-b-${stamp}`;
 const cyclicTrace = `trace-edge-cycle-${stamp}`;
-const traceIds = [traceA, traceB, cyclicTrace];
+const brokenPrevTrace = `trace-edge-broken-prev-${stamp}`;
+const missingPrevTrace = `trace-edge-missing-prev-${stamp}`;
+const linkA = `trace-edge-link-a-${stamp}`;
+const linkB = `trace-edge-link-b-${stamp}`;
+const linkC = `trace-edge-link-c-${stamp}`;
+const traceIds = [traceA, traceB, cyclicTrace, brokenPrevTrace, linkA, linkB, linkC];
 const now = Date.now();
 
 dbMod.db.insert(dbMod.traceLog).values([
@@ -35,10 +40,17 @@ dbMod.db.insert(dbMod.traceLog).values([
     createdAt: now + 2,
     updatedAt: now + 2,
   },
+  { traceId: brokenPrevTrace, query: `trace edge ${stamp} broken prev`, prevTraceId: missingPrevTrace, childTraceIds: '[]', createdAt: now + 3, updatedAt: now + 3 },
+  { traceId: linkA, query: `trace edge ${stamp} link a`, childTraceIds: '[]', createdAt: now + 4, updatedAt: now + 4 },
+  { traceId: linkB, query: `trace edge ${stamp} link b`, childTraceIds: '[]', createdAt: now + 5, updatedAt: now + 5 },
+  { traceId: linkC, query: `trace edge ${stamp} link c`, childTraceIds: '[]', createdAt: now + 6, updatedAt: now + 6 },
 ]).run();
 
-function request(pathname: string) {
-  return tracesApi.handle(new Request(`http://local${pathname}`));
+function request(pathname: string, init: RequestInit = {}) {
+  return tracesApi.handle(new Request(`http://local${pathname}`, {
+    ...init,
+    headers: { 'content-type': 'application/json', ...((init.headers as Record<string, string>) ?? {}) },
+  }));
 }
 
 function restore(name: string, value: string | undefined) {
@@ -85,5 +97,61 @@ describe('trace route edge cases', () => {
 
     expect(res.status).toBe(200);
     expect(body.chain.map((trace) => trace.traceId)).toEqual([cyclicTrace]);
+  });
+
+  test('GET /api/traces/:id/linked-chain keeps the anchor when a prev link is stale', async () => {
+    const res = await request(`/api/traces/${brokenPrevTrace}/linked-chain`);
+    const body = await res.json() as { chain: Array<{ traceId: string }>; position: number };
+
+    expect(res.status).toBe(200);
+    expect(body.chain.map((trace) => trace.traceId)).toEqual([brokenPrevTrace]);
+    expect(body.position).toBe(0);
+  });
+
+  test('link/unlink routes reject duplicate, self, cycle, and missing-link edges', async () => {
+    const linked = await request(`/api/traces/${linkA}/link`, {
+      method: 'POST',
+      body: JSON.stringify({ nextId: linkB }),
+    });
+    expect(linked.status).toBe(200);
+
+    const duplicateNext = await request(`/api/traces/${linkA}/link`, {
+      method: 'POST',
+      body: JSON.stringify({ nextId: linkC }),
+    });
+    expect(duplicateNext.status).toBe(400);
+    expect((await duplicateNext.json() as { error: string }).error).toContain('already has a next link');
+
+    const duplicatePrev = await request(`/api/traces/${linkC}/link`, {
+      method: 'POST',
+      body: JSON.stringify({ nextId: linkB }),
+    });
+    expect(duplicatePrev.status).toBe(400);
+    expect((await duplicatePrev.json() as { error: string }).error).toContain('already has a prev link');
+
+    const selfLink = await request(`/api/traces/${linkC}/link`, {
+      method: 'POST',
+      body: JSON.stringify({ nextId: linkC }),
+    });
+    expect(selfLink.status).toBe(400);
+    expect((await selfLink.json() as { error: string }).error).toContain('itself');
+
+    const cycle = await request(`/api/traces/${linkB}/link`, {
+      method: 'POST',
+      body: JSON.stringify({ nextId: linkA }),
+    });
+    expect(cycle.status).toBe(400);
+    expect((await cycle.json() as { error: string }).error).toContain('create a cycle');
+
+    const missingLink = await request(`/api/traces/${linkC}/link?direction=next`, { method: 'DELETE' });
+    expect(missingLink.status).toBe(400);
+    expect((await missingLink.json() as { error: string }).error).toContain('No next link');
+
+    const unlinked = await request(`/api/traces/${linkB}/link?direction=prev`, { method: 'DELETE' });
+    expect(unlinked.status).toBe(200);
+
+    const chain = await request(`/api/traces/${linkA}/linked-chain`);
+    const body = await chain.json() as { chain: Array<{ traceId: string }> };
+    expect(body.chain.map((trace) => trace.traceId)).toEqual([linkA]);
   });
 });

--- a/tests/mcp/http-proxy-posts-thread-default-role.test.ts
+++ b/tests/mcp/http-proxy-posts-thread-default-role.test.ts
@@ -4,3 +4,7 @@ import { captureProxyRequest } from './support/http-proxy.ts';
 test('HTTP proxy maps oracle_thread with the default claude role', async () => {
   expect(await captureProxyRequest('oracle_thread', { message: 'hi', threadId: 't1' })).toMatchObject({ method: 'POST', path: '/api/thread', body: { message: 'hi', thread_id: 't1', role: 'claude' } });
 });
+
+test('HTTP proxy preserves oracle_thread reopen intent', async () => {
+  expect(await captureProxyRequest('oracle_thread', { message: 'hi', threadId: 't1', reopen: true })).toMatchObject({ body: { reopen: true } });
+});


### PR DESCRIPTION
## Summary
- Harden `/api/thread` continuation so closed threads require explicit `reopen=true`, matching oracle_thread safety semantics.
- Preserve `reopen` through the MCP HTTP proxy for remote oracle_thread calls.
- Harden trace linked-chain traversal when a stale `prevTraceId` points at a missing trace.
- Add HTTP edge coverage under `tests/http/threads/` and deeper trace link/unlink/chain coverage under `tests/http/traces/`.

## Validation
```bash
rtk bun test tests/http/threads tests/http/traces
rtk bun test tests/mcp/http-proxy-posts-thread-default-role.test.ts
rtk bunx tsc --noEmit
```

## File size check
```bash
wc -l src/mcp/http-proxy.ts src/routes/forum/model.ts src/routes/forum/thread-create.ts src/routes/traces/tenant-scope.ts tests/http/threads/edge-cases.test.ts tests/http/traces/edge-cases.test.ts tests/mcp/http-proxy-posts-thread-default-role.test.ts
```
All changed files are <= 250 lines.
