### PR TITLE
test(export): harden formatter registry seam

### DIFF
--- a/src/plugins/export-format-init.ts
+++ b/src/plugins/export-format-init.ts
@@ -1,6 +1,6 @@
 import { pathToFileURL } from 'node:url';
 
-import { registerExportFormat, type ExportFormatter } from '../vector/export-formats.ts';
+import { getExportFormat, registerExportFormat, type ExportFormatter } from '../vector/export-formats.ts';
 import { runPluginWithErrorContainment } from './error-containment.ts';
 import type { NormalizedUnifiedPluginManifest } from './unified-manifest.ts';
 
@@ -48,5 +48,6 @@ export async function registerPluginExportFormats(
     if (typeof result.value === 'function') {
       registerExportFormat(format.name, result.value as ExportFormatter);
     }
+    if (!getExportFormat(format.name)) return `export format not registered: ${format.name}`;
   }
 }

--- a/tests/export/formatter-registry.test.ts
+++ b/tests/export/formatter-registry.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { registerPluginExportFormats } from '../../src/plugins/export-format-init.ts';
+import {
+  exportFormatInfo,
+  getExportFormat,
+  registerExportFormat,
+  type EmbeddingDump,
+  type ExportFormatter,
+} from '../../src/vector/export-formats.ts';
+
+const tmp = mkdtempSync(join(tmpdir(), 'arra-export-registry-'));
+const emptyDump: EmbeddingDump = { ids: [], embeddings: [], metadatas: [], documents: [] };
+
+afterAll(() => rmSync(tmp, { recursive: true, force: true }));
+
+function streamText(format: string, dump = emptyDump): Promise<string> {
+  const formatter = getExportFormat(format);
+  if (!formatter) throw new Error(`missing formatter: ${format}`);
+  return new Response(formatter(dump)).text();
+}
+
+function formatter(): ExportFormatter {
+  return (() => new ReadableStream<Uint8Array>({ start: (controller) => controller.close() })) as ExportFormatter;
+}
+
+function plugin(name: string, entry: string, format: string, handler = 'register') {
+  const dir = join(tmp, name);
+  const entryPath = join(dir, 'index.ts');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(entryPath, entry, { flag: 'w' });
+  return {
+    entryPath,
+    manifest: {
+      name,
+      version: '1.0.0',
+      entry: './index.ts',
+      sdk: 'arra-oracle-v3',
+      depends: [],
+      apiRoutes: [],
+      mcpTools: [],
+      proxy: [],
+      menu: [],
+      cliSubcommands: [],
+      exportFormats: [{ name: format, handler }],
+    },
+  } as any;
+}
+
+describe('ExportFormatter registry hardening', () => {
+  test('built-in json/jsonl/csv/markdown format empty collections safely', async () => {
+    expect(await streamText('json')).toBe('[]');
+    expect(await streamText('jsonl')).toBe('');
+    expect(await streamText('csv')).toBe('id,document,type,source_file,concepts\n');
+    expect(await streamText('markdown')).toBe('');
+  });
+
+  test('rejects invalid format names before registry lookup or registration', () => {
+    expect(getExportFormat('../json')).toBeUndefined();
+    expect(exportFormatInfo('json/lines')).toBeUndefined();
+    expect(() => registerExportFormat('bad format', formatter())).toThrow('invalid export format');
+    expect(() => registerExportFormat('bad', 42 as unknown as ExportFormatter)).toThrow('must be a function');
+  });
+
+  test('plugin export format handlers can return a formatter for registration', async () => {
+    const format = `c10-plugin-${Date.now().toString(36)}`;
+    const result = await registerPluginExportFormats(plugin('returning-format', `
+      const encoder = new TextEncoder();
+      export function register() {
+        return Object.assign((dump) => new ReadableStream({
+          start(controller) {
+            controller.enqueue(encoder.encode(dump.ids.join('|')));
+            controller.close();
+          },
+        }), { contentType: 'text/plain; charset=utf-8', extension: 'txt', label: 'C10 Plugin' });
+      }
+    `, format), 500);
+
+    expect(result).toBeUndefined();
+    expect(exportFormatInfo(format)).toMatchObject({ format, extension: 'txt', label: 'C10 Plugin' });
+    expect(await streamText(format, { ids: ['a', 'b'], embeddings: [], metadatas: [], documents: [] })).toBe('a|b');
+  });
+
+  test('plugin export format init reports handlers that never register their declared format', async () => {
+    const format = `c10-missing-${Date.now().toString(36)}`;
+    const result = await registerPluginExportFormats(plugin('missing-format', 'export function register() { return undefined; }', format), 500);
+
+    expect(result).toBe(`export format not registered: ${format}`);
+    expect(getExportFormat(format)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Harden plugin export format initialization so a manifest-declared formatter must actually be registered or returned.
- Add `tests/export/` coverage for built-in `json`, `jsonl`, `csv`, and `markdown` empty dumps.
- Cover invalid format names and plugin formatter registration/no-op failure paths.

## Validation
```bash
rtk bun test tests/export src/plugins/__tests__/unified-export-formats.test.ts
rtk bunx tsc --noEmit
```

## File size check
```bash
wc -l src/plugins/export-format-init.ts tests/export/formatter-registry.test.ts
```
All changed files are <= 250 lines.
