### PR TITLE
test(server): harden createApp composition

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -75,6 +75,8 @@ import pkg from '../package.json' with { type: 'json' };
 
 type UnifiedRuntime = Awaited<ReturnType<typeof loadUnifiedPlugins>>;
 type ServerSpec = { port: number; fetch(request: Request): Response | Promise<Response> };
+type ElysiaApp = Elysia<any, any, any, any, any, any, any>;
+type RouteModule = Parameters<ElysiaApp['use']>[0];
 export interface StartServerOptions { writePidFile?: boolean }
 
 export interface CreateAppOptions {
@@ -117,13 +119,30 @@ export function createApp({ unifiedPlugins, runtimeRef = createUnifiedRuntimeRef
     .get('/api/openapi.json', () => Response.redirect('/api/docs/json', 308), { detail: { hide: true } })
     .get('/', () => ({ server: MCP_SERVER_NAME, version: pkg.version, status: 'ok', docs: '/api/docs', api: '/api/v1' }));
 
-  const healthRoutes = createHealthRoutes({ pluginCount: unifiedPlugins.pluginCount, pluginMcpToolCount: unifiedPlugins.mcpTools.length, pluginStatuses: unifiedPlugins.pluginStatuses, isDraining });
-  const apiModules = [authRoutes, settingsRoutes, feedRoutes, healthRoutes, dashboardRoutes, searchRoutes, askRoutes, vectorRoutes, vectorConfigApiRoutes, conceptsRoutes, knowledgeRoutes, researchRoutes, verifyRoutes, supersedeRoutes, forumApi, tracesApi, scheduleApi, filesRouter, createPluginsRouter({ registry: () => runtimeRef.current.pluginRegistry(), runtimeRef }), sessionsRoutes, vaultRoutes, metricsRoutes, exportRoutes, memoryRoutes, canvasRoutes, tenantsRoutes, watcherRoutes, indexerRoutes];
-  const modules = [...apiModules, createMcpRoutes({ runtimeRef }), createMenuRoutes(menuItemsFromUnifiedPlugins(unifiedPlugins.menu))];
-  for (const mod of modules) app.use(mod as any);
+  const routeModules = createServerRouteModules(unifiedPlugins, runtimeRef);
+  mountRouteModules(app, routeModules);
   app.use(createUnifiedPluginRouteMount(runtimeRef, { localRoutes: () => app.routes }));
   app.use(createNotFoundMiddleware(() => app.routes));
   return app;
+}
+
+export function createServerRouteModules(unifiedPlugins: UnifiedRuntime, runtimeRef: UnifiedRuntimeRef<UnifiedRuntime>): RouteModule[] {
+  const healthRoutes = createHealthRoutes({ pluginCount: unifiedPlugins.pluginCount, pluginMcpToolCount: unifiedPlugins.mcpTools.length, pluginStatuses: unifiedPlugins.pluginStatuses, isDraining });
+  const apiModules = [authRoutes, settingsRoutes, feedRoutes, healthRoutes, dashboardRoutes, searchRoutes, askRoutes, vectorRoutes, vectorConfigApiRoutes, conceptsRoutes, knowledgeRoutes, researchRoutes, verifyRoutes, supersedeRoutes, forumApi, tracesApi, scheduleApi, filesRouter, createPluginsRouter({ registry: () => runtimeRef.current.pluginRegistry(), runtimeRef }), sessionsRoutes, vaultRoutes, metricsRoutes, exportRoutes, memoryRoutes, canvasRoutes, tenantsRoutes, watcherRoutes, indexerRoutes];
+  return [...apiModules, createMcpRoutes({ runtimeRef }), createMenuRoutes(menuItemsFromUnifiedPlugins(unifiedPlugins.menu))];
+}
+
+export function mountRouteModules(app: ElysiaApp, modules: RouteModule[]): void {
+  modules.forEach((mod, index) => {
+    assertRouteModule(mod, index);
+    app.use(mod as any);
+  });
+}
+
+function assertRouteModule(mod: unknown, index: number): asserts mod is RouteModule {
+  if (typeof mod !== 'function' && !(mod instanceof Elysia)) {
+    throw new Error(`Invalid server route module at index ${index}`);
+  }
 }
 
 export async function startServer(options: StartServerOptions = {}): Promise<ReturnType<typeof Bun.serve>> {

--- a/tests/integration/server-boot/composition.test.ts
+++ b/tests/integration/server-boot/composition.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApp, createServerRouteModules, mountRouteModules } from '../../../src/server.ts';
+import { createUnifiedRuntimeRef } from '../../../src/plugins/runtime-routes.ts';
+import type { UnifiedRuntime } from '../../../src/plugins/unified-loader.ts';
+
+function runtime(): UnifiedRuntime {
+  return {
+    pluginCount: 0,
+    routes: [],
+    mcpTools: [],
+    menu: [],
+    cliSubcommands: [],
+    servers: [],
+    callMcpTool: async () => ({}),
+    pluginStatuses: () => [],
+    pluginRegistry: () => [],
+    init: async () => {},
+    reload: async () => {},
+    stop: async () => {},
+  };
+}
+
+describe('server createApp composition', () => {
+  test('mounts core routes before plugin catch-all and not-found boundary', async () => {
+    const app = createApp({ unifiedPlugins: runtime() });
+    const paths = app.routes.map((route) => `${route.method} ${route.path}`);
+
+    expect(paths).toContain('GET /');
+    expect(paths).toContain('GET /api/health');
+    expect(paths.indexOf('GET /api/health')).toBeLessThan(paths.length - 1);
+
+    const root = await app.fetch(new Request('http://server.test/'));
+    expect(root.status).toBe(200);
+    expect(await root.json()).toMatchObject({ status: 'ok', docs: '/api/docs' });
+  });
+
+  test('keeps structured error boundary active for composed routes', async () => {
+    const app = createApp({ unifiedPlugins: runtime() })
+      .get('/api/__boot_throw', () => { throw new Error('boot exploded'); });
+
+    const res = await app.fetch(new Request('http://server.test/api/__boot_throw', {
+      headers: { 'x-request-id': 'boot-test' },
+    }));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body).toMatchObject({ success: false, error: 'Internal Server Error', code: 500 });
+    expect(body.details).toMatchObject({ message: 'boot exploded', correlationId: 'boot-test' });
+  });
+
+  test('rejects invalid route modules with a boot-time error', () => {
+    const app = new Elysia();
+
+    expect(() => mountRouteModules(app, [undefined as never])).toThrow('Invalid server route module at index 0');
+  });
+
+  test('builds route modules in API then MCP then menu order', () => {
+    const current = runtime();
+    const modules = createServerRouteModules(current, createUnifiedRuntimeRef(current));
+    const routePaths = modules.map((mod) => (mod as Elysia).routes.map((route) => route.path));
+
+    expect(routePaths[0]).toContain('/api/auth/login');
+    expect(routePaths.at(-2)?.some((path) => path.includes('/mcp'))).toBe(true);
+    expect(routePaths.at(-1)).toContain('/api/menu');
+  });
+});


### PR DESCRIPTION
## Summary
- Extracted server route-module construction into `createServerRouteModules()` so composition order is testable.
- Added guarded `mountRouteModules()` to fail fast on invalid sub-app modules before boot continues.
- Added integration boot coverage for core route order, plugin/not-found boundary position, structured errors, and invalid modules.

## Tests
```bash
bun test --isolate tests/integration/server-boot/composition.test.ts
bunx tsc --noEmit
wc -l src/server.ts tests/integration/server-boot/composition.test.ts
```
