### PR TITLE
fix: harden tenant header context isolation

### DIFF
--- a/src/middleware/tenant.ts
+++ b/src/middleware/tenant.ts
@@ -11,6 +11,7 @@ export const ORG_HEADER = 'X-Org-Id';
 export const TENANT_API_KEY_HEADER = 'X-API-Key';
 const TENANT_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/;
 const RESERVED_TENANT_KEYS = new Set(['constructor', 'prototype']);
+const TENANT_ID_HEADERS = [TENANT_HEADER, LEGACY_TENANT_HEADER, ORG_HEADER] as const;
 
 export const DEFAULT_TENANT_ID = 'default';
 type TenantContext = { tenantId?: string };
@@ -73,10 +74,10 @@ function isValidTenantId(tenantId: string): boolean {
   return TENANT_PATTERN.test(tenantId) && !RESERVED_TENANT_KEYS.has(tenantId.toLowerCase());
 }
 
-function tenantIdFromApiKey(headers: Headers, apiKeys = parseTenantApiKeys()): string | undefined {
+function tenantIdFromApiKey(headers: Headers, apiKeys?: TenantTokenMap): string | undefined {
   const actual = headers.get(TENANT_API_KEY_HEADER)?.trim() || bearerToken(headers);
   if (!actual) return undefined;
-  for (const [tenantId, expected] of Object.entries(apiKeys)) {
+  for (const [tenantId, expected] of Object.entries(apiKeys ?? parseTenantApiKeys())) {
     if (tenantId === '*') continue;
     if (expected && safeEqual(actual, expected)) {
       if (!isValidTenantId(tenantId)) throw new Error('invalid tenant id');
@@ -86,12 +87,25 @@ function tenantIdFromApiKey(headers: Headers, apiKeys = parseTenantApiKeys()): s
   return undefined;
 }
 
+function tenantIdFromTenantHeaders(headers: Headers): string | undefined {
+  let resolved: string | undefined;
+  for (const header of TENANT_ID_HEADERS) {
+    const tenant = headers.get(header)?.trim();
+    if (!tenant) continue;
+    if (!isValidTenantId(tenant)) throw new Error('invalid tenant id');
+    if (resolved && resolved !== tenant) throw new Error('conflicting tenant headers');
+    resolved = tenant;
+  }
+  return resolved;
+}
+
 export function tenantIdFromHeaders(headers: Headers): string | undefined {
-  const raw = headers.get(TENANT_HEADER) ?? headers.get(LEGACY_TENANT_HEADER) ?? headers.get(ORG_HEADER);
-  const tenant = raw?.trim();
-  if (!tenant) return tenantIdFromApiKey(headers);
-  if (!isValidTenantId(tenant)) throw new Error('invalid tenant id');
-  return tenant;
+  const explicitTenant = tenantIdFromTenantHeaders(headers);
+  const keyTenant = tenantIdFromApiKey(headers);
+  if (explicitTenant && keyTenant && explicitTenant !== keyTenant) {
+    throw new Error('conflicting tenant credentials');
+  }
+  return explicitTenant ?? keyTenant;
 }
 
 export function validateTenantToken(headers: Headers, tenantId: string | undefined, tokens = parseTenantTokens()): void {
@@ -108,10 +122,9 @@ export function rememberTenant(request: Request, tenantId: string | undefined): 
 }
 
 export function tenantIdFor(request: Request): string | undefined {
-  if (tenants.has(request)) return tenants.get(request);
   const tenantId = tenantIdFromHeaders(request.headers);
   validateTenantToken(request.headers, tenantId);
-  rememberTenant(request, tenantId);
+  if (!tenants.has(request) || tenants.get(request) !== tenantId) rememberTenant(request, tenantId);
   return tenantId;
 }
 

--- a/tests/http/tenant/header-als.test.ts
+++ b/tests/http/tenant/header-als.test.ts
@@ -1,0 +1,99 @@
+import { expect, test } from 'bun:test';
+import {
+  createTenantFetch,
+  currentTenantId,
+  LEGACY_TENANT_HEADER,
+  ORG_HEADER,
+  runWithTenant,
+  tenantIdFromHeaders,
+  TENANT_API_KEY_HEADER,
+  TENANT_HEADER,
+} from '../../../src/middleware/tenant.ts';
+
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantA = `tenant-a-${stamp}`;
+const tenantB = `tenant-b-${stamp}`;
+
+function withTenantKeys<T>(value: string | undefined, callback: () => T): T {
+  const previous = process.env.ORACLE_TENANT_API_KEYS;
+  if (value === undefined) delete process.env.ORACLE_TENANT_API_KEYS;
+  else process.env.ORACLE_TENANT_API_KEYS = value;
+  try {
+    return callback();
+  } finally {
+    if (previous === undefined) delete process.env.ORACLE_TENANT_API_KEYS;
+    else process.env.ORACLE_TENANT_API_KEYS = previous;
+  }
+}
+
+function jsonTenantFetch(delayMs = 0) {
+  return createTenantFetch(async () => {
+    const before = currentTenantId();
+    if (delayMs) await Bun.sleep(delayMs);
+    return Response.json({ before: before ?? null, after: currentTenantId() ?? null });
+  });
+}
+
+test('tenant header resolution skips blank aliases and rejects conflicts', () => {
+  expect(tenantIdFromHeaders(new Headers({
+    [TENANT_HEADER]: ' ',
+    [LEGACY_TENANT_HEADER]: tenantA,
+  }))).toBe(tenantA);
+
+  expect(tenantIdFromHeaders(new Headers({
+    [TENANT_HEADER]: ` ${tenantA} `,
+    [LEGACY_TENANT_HEADER]: tenantA,
+    [ORG_HEADER]: tenantA,
+  }))).toBe(tenantA);
+
+  expect(() => tenantIdFromHeaders(new Headers({
+    [TENANT_HEADER]: tenantA,
+    [LEGACY_TENANT_HEADER]: tenantB,
+  }))).toThrow('conflicting tenant headers');
+});
+
+test('tenant API key derivation cannot contradict explicit tenant headers', () => {
+  withTenantKeys(`${tenantA}=key-a,${tenantB}=key-b`, () => {
+    expect(tenantIdFromHeaders(new Headers({ [TENANT_API_KEY_HEADER]: 'key-a' }))).toBe(tenantA);
+    expect(tenantIdFromHeaders(new Headers({
+      [TENANT_HEADER]: tenantA,
+      [TENANT_API_KEY_HEADER]: 'key-a',
+    }))).toBe(tenantA);
+
+    expect(() => tenantIdFromHeaders(new Headers({
+      [TENANT_HEADER]: tenantB,
+      [TENANT_API_KEY_HEADER]: 'key-a',
+    }))).toThrow('conflicting tenant credentials');
+  });
+});
+
+test('tenant fetch recomputes tenant when a reused Request has new headers', async () => {
+  const fetch = jsonTenantFetch();
+  const request = new Request('http://local/api/test', { headers: { [TENANT_HEADER]: tenantA } });
+
+  expect(await (await fetch(request)).json()).toEqual({ before: tenantA, after: tenantA });
+  request.headers.set(TENANT_HEADER, tenantB);
+  expect(await (await fetch(request)).json()).toEqual({ before: tenantB, after: tenantB });
+});
+
+test('AsyncLocalStorage stays scoped across concurrent tenant fetches', async () => {
+  const fetch = jsonTenantFetch(5);
+  const [resA, resB] = await Promise.all([
+    fetch(new Request('http://local/api/test', { headers: { [TENANT_HEADER]: tenantA } })),
+    fetch(new Request('http://local/api/test', { headers: { [TENANT_HEADER]: tenantB } })),
+  ]);
+
+  expect(await resA.json()).toEqual({ before: tenantA, after: tenantA });
+  expect(await resB.json()).toEqual({ before: tenantB, after: tenantB });
+  expect(currentTenantId()).toBeUndefined();
+});
+
+test('tenant fetch clears ambient tenant context for unscoped requests', async () => {
+  const fetch = jsonTenantFetch();
+  const seen = await runWithTenant(tenantA, async () => {
+    const res = await fetch(new Request('http://local/api/test'));
+    return { body: await res.json(), after: currentTenantId() };
+  });
+
+  expect(seen).toEqual({ body: { before: null, after: null }, after: tenantA });
+});


### PR DESCRIPTION
## Summary\n- resolve tenant aliases by first non-empty matching value and reject conflicting tenant headers\n- reject tenant API key credentials that contradict explicit tenant headers\n- re-resolve tenant context per request to avoid stale AsyncLocalStorage context on reused Request objects\n- add tenant HTTP regressions for header resolution, credential conflicts, Request reuse, concurrent ALS isolation, and ambient context clearing\n\n## Verification\n- bunx tsc --noEmit\n- bun test tests/http/tenant/\n- wc -l src/middleware/tenant.ts tests/http/tenant/header-als.test.ts