### PR TITLE
docs: verify architecture and API surfaces

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,221 +1,170 @@
 # Arra Oracle API Reference
 
-Base URL defaults to `http://localhost:47778`. Frontend dev servers proxy `/api/*` to
-that backend. When `ARRA_API_TOKEN` is set, protected `/api/*` calls need
-`Authorization: Bearer <token>` or `?token=<token>`; `/api/health` and
-`/api/docs` stay open. Federation mesh routes are opt-in via
-`ORACLE_ENABLED_PLUGINS=federation`.
+Verified against `src/server.ts`, `src/routes/*`, `src/tools/mcp-manifest.ts`,
+and `src/tools/mcp-rest-map.ts` on 2026-06-17. The internal Elysia routes are
+mounted under `/api/*`; the runnable server redirects most unversioned `/api/*`
+requests to `/api/v1/*` and rewrites them internally. `/api/health` stays
+unversioned for probes. Swagger UI is `/api/docs`; JSON is `/api/docs/json`.
 
-This page covers the active menu, plugin, vector, and MCP tool-listing surfaces.
-Swagger UI is mounted at `/api/docs`; legacy `/swagger` redirects there.
+## Auth, tenants, and errors
 
-## Common error shape
+- If `ARRA_API_TOKEN` is set, send `Authorization: Bearer <token>` for protected
+  `/api/*`; `/api/health` and `/api/docs*` remain open.
+- If `ARRA_API_KEY` is set, it is also a bearer guard; only `/api/health` is
+  bypassed. Do not set the two guards to different values for the same server.
+- Tenant scope: `X-Oracle-Tenant: <id>`. If `ORACLE_TENANT_TOKENS` is set, also
+  send `X-Oracle-Tenant-Token`; tenant API keys may be supplied with `X-API-Key`.
+- Common errors are `{ "error": "..." }` or structured `{ success: false,
+  error, code?, details? }` from middleware.
+
+```bash
+BASE=http://localhost:47778
+AUTH=(-H "Authorization: Bearer $ARRA_API_TOKEN")
+curl -sf "$BASE/api/health"
+curl -sf "${AUTH[@]}" "$BASE/api/v1/mcp/tools"
+```
+
+## Route inventory by family
+
+`createApp()` currently exposes 185 routes, 181 under `/api`; dynamic plugin
+routes may add more at runtime. These families match the mounted source modules.
+
+| Family | Methods and paths |
+| --- | --- |
+| Root/docs | `GET /`, `/swagger*` redirects, `GET /api/docs`, `/api/docs/json`, `/api/openapi.json` |
+| Auth/settings | `GET /api/auth/status`; `POST /api/auth/login`, `/api/auth/logout`; `GET/POST /api/settings/`; `GET /api/settings/system` |
+| Health/runtime | `GET /api/health`, `/api/health/deep`, `/api/stats`, `/api/metrics`, `/api/dashboard*`, `/api/session/stats`, `/api/oracles*`, `/api/gateway/*` |
+| Search/knowledge | `GET /api/search`, `/api/read`, `/api/list`, `/api/concepts`, `/api/reflect`; `GET/POST/PUT/DELETE /api/learn*`; `POST /api/handoff`, `/api/research/note`, `/api/verify`; `GET /api/inbox`, `/api/verify` |
+| Memory | `POST /api/memory/save`, `/api/memory/closeout`; `GET /api/memory/morning-tape`, `/api/memory/recall`, `/api/memory/search`, `/api/memory/fanout` |
+| Vector/indexer | `GET /api/vector/*`, `/api/similar`, `/api/compare`, `/api/map`, `/api/map3d`; `POST/PATCH/PUT/DELETE /api/vector/config*`, `/api/vector/collections*`, `/api/vector/services*`, `/api/vector/providers/test`, `/api/vector/costs/usage`, `/api/vector/index/*`; `ALL /api/vector-db*`; `GET/POST /api/indexer/*` |
+| Export/import | `GET /api/export*`; `POST /api/export`, `/api/export/run`, `/api/export/app/run`, `/api/export/batch`, `/api/export/import`, `/api/export/test-connection` |
+| Menu/plugins/canvas | `GET/POST/PUT/PATCH/DELETE /api/menu*`; `GET/PATCH/POST /api/plugins*`; `GET /api/canvas/plugins*`, `/api/canvas/registry` |
+| Files/vault | `GET /api/context`, `/api/file`, `/api/graph`, `/api/logs`, `/api/doc/:id`; `POST /api/doc`, `/api/vault/sync`; `PATCH /api/doc/:id` |
+| Collaboration | `GET/POST /api/feed/`; `GET /api/threads`, `/api/thread/:id`; `POST /api/thread`; `PATCH /api/thread/:id/status`; `GET/POST/DELETE /api/traces*`; `GET/POST/PATCH /api/schedule*`; `GET/POST /api/supersede*` |
+| Admin/ops | `GET/POST /api/tenants*`; `GET/POST /api/watcher/*`; `GET /api/mcp/tools` |
+
+## Request/response examples
+
+### Search
+
+```bash
+curl -s "${AUTH[@]}" \
+  "$BASE/api/v1/search?q=oracle&mode=fts&limit=2&asOf=2026-06-17T00:00:00Z"
+```
 
 ```json
-{ "error": "not found" }
+{ "query": "oracle", "results": [{ "id": "doc_1", "type": "learning", "sourceFile": "ψ/memory/learnings/x.md" }], "total": 1, "searchTimeMs": 8 }
 ```
 
-Validation errors use 4xx status codes. Proxy/upstream failures commonly return
-`502` or `503` with `{ "error": "..." }`.
-
-## Menu API
-
-`GET /api/menu` returns frontend navigation aggregated from route metadata,
-Drizzle-backed `menu_items`, file-backed custom items, gist menu config, and
-unified plugin menu entries.
-
-### Menu item shape
-
-```ts
-type MenuItem = {
-  id?: string; parentId?: string | null;
-  path: string; label: string;
-  group: 'main' | 'tools' | 'admin' | 'hidden';
-  order: number;
-  icon?: string; studio?: string | null;
-  access?: 'public' | 'auth';
-  source: 'api' | 'page' | 'plugin';
-  sourceName?: string; added?: boolean; hidden?: boolean;
-  scope?: 'main' | 'sub' | 'both';
-  query?: Record<string, string>;
-};
-```
-
-### Menu endpoints
-
-| Method | Path | Request | Response |
-| --- | --- | --- | --- |
-| `GET` | `/api/menu?host=&scope=` | optional `host`, `scope=main\|sub\|both` | `{ items: MenuItem[] }` |
-| `GET` | `/api/menu/source` | none | `{ url, hash, loaded_at, status }` |
-| `POST` | `/api/menu/reload` | none | refreshed source object |
-| `POST` | `/api/menu/source` | `{ url, mode?: 'merge'\|'override' }` | `{ mode, source }` |
-| `DELETE` | `/api/menu/source` | none | source object with cleared URL |
-| `GET` | `/api/menu/source/official` | none | `{ url }` |
-| `POST` | `/api/menu/reset-all` | none | reset counts plus `source` |
-| `GET` | `/api/menu/custom` | none | `{ items: MenuItem[] }` |
-| `POST` | `/api/menu/custom` | `{ path, label, group?, order?, icon? }` | `{ item, replaced }` |
-| `DELETE` | `/api/menu/custom/*` | path suffix is URL-encoded item path | `{ removed, path }` |
-| `GET` | `/api/menu/tree` | none | `{ items: MenuTreeNode[] }` |
-| `GET` | `/api/menu/items` | none | `{ items: MenuRow[] }` |
-| `POST` | `/api/menu/items` | `MenuRowCreate` | created `MenuRow` (`201`) |
-| `PATCH` | `/api/menu/items/:id` | partial `MenuRowCreate` except `path` | updated `MenuRow` |
-| `DELETE` | `/api/menu/items/:id` | none | `{ id, deleted: 'hard'\|'soft' }` |
-| `POST` | `/api/menu/reorder` | `{ items: [{ id, parentId?, position }] }` | `{ updated, ids }` |
-| `POST` | `/api/menu/reset/:id` | none | `{ id, path, touchedAt: null }` |
-
-`MenuRowCreate` fields: `path`, `label`, `groupKey?`, `parentId?`, `position?`,
-`enabled?`, `access?`, `icon?`, `host?`, `hidden?`, `scope?`, and `query?`.
-
-### Menu examples
+### Learn
 
 ```bash
-curl http://localhost:47778/api/menu?scope=main
-curl -X POST http://localhost:47778/api/menu/custom \
-  -H 'content-type: application/json' \
-  -d '{"path":"/canvas","label":"Canvas","group":"tools"}'
-curl -X POST http://localhost:47778/api/menu/reorder \
-  -H 'content-type: application/json' \
-  -d '{"items":[{"id":1,"parentId":null,"position":10}]}'
+curl -s "${AUTH[@]}" -H 'content-type: application/json' \
+  -d '{"pattern":"Document the verified API surface","concepts":["docs","api"],"project":"arra"}' \
+  "$BASE/api/v1/learn"
 ```
-
-## Plugins API
-
-Plugins live under plugin directories such as `~/.oracle/plugins/<name>/` with a
-`plugin.json` manifest, or as legacy flat `.wasm` files. The unified loader can
-also register plugin API routes, proxy routes, menu entries, MCP tools, CLI
-subcommands, and plugin-owned sidecar servers.
-
-### Plugin listing and wasm endpoints
-
-| Method | Path | Request | Response |
-| --- | --- | --- | --- |
-| `GET` | `/api/plugins` | none | `{ plugins: PluginEntry[], dir?: string }` |
-| `GET` | `/api/plugins/:name` | plugin name | `application/wasm` bytes or `404` |
-| `PATCH` | `/api/plugins/:name/state` | `{ enabled: boolean }` | persists manifest state; runtime reload still required |
-| `POST` | `/api/plugins/:name/toggle` | `{ enabled?: boolean }` or empty body | persists state and reloads unified runtime MCP tools |
-
-```ts
-type PluginEntry = {
-  name: string; file: string; size: number; modified: string;
-  version?: string; description?: string;
-  menu?: { label: string; group?: 'main'|'tools'|'hidden'; order?: number; icon?: string; path?: string };
-  server?: { command: string; args?: string[]; healthPath?: string; autostart?: boolean };
-};
-```
-
-Example:
-
-```bash
-curl http://localhost:47778/api/plugins
-curl -o plugin.wasm http://localhost:47778/api/plugins/canvas-inspector
-curl -X POST http://localhost:47778/api/plugins/community-search/toggle \
-  -H 'content-type: application/json' \
-  -d '{"enabled":false}'
-```
-
-### Plugin-owned server endpoints
-
-| Method | Path | Request | Response |
-| --- | --- | --- | --- |
-| `GET` | `/api/plugins/:name/server/health` | none | `{ ok, plugin, healthy, status?, healthPath, routePrefix, startedAt }` |
-| `ALL` | `/api/plugins/:name/server/*` | forwarded method, headers, query, body | upstream plugin server response |
-
-Missing server configs return:
 
 ```json
-{ "ok": false, "plugin": "missing", "error": "plugin server not found" }
+{ "success": true, "file": "ψ/memory/learnings/2026-06-17_document-the-verified-api-surface.md", "id": "learning_2026-06-17_document-the-verified-api-surface" }
 ```
 
-Unified plugin manifests may additionally expose `apiRoutes` at their declared
-absolute paths and `proxy` routes at their declared absolute paths.
-
-## Vector API
-
-The vector route cluster is mounted under `/api`. Some historical vector routes
-remain top-level (`/api/similar`, `/api/compare`, `/api/map`, `/api/map3d`) while
-newer control/status routes live under `/api/vector/*`.
-
-### Vector endpoints
-
-| Method | Path | Request | Response |
-| --- | --- | --- | --- |
-| `GET` | `/api/vector/health` | none | `{ status: 'ok'\|'degraded'\|'down', engines, checked_at, proxy? }` |
-| `GET` | `/api/vector/stats` | none | per-engine collection counts or `{ error }` |
-| `GET` | `/api/vector/config` | none | `{ source: 'file'\|'defaults', config }` |
-| `POST` | `/api/vector/index/start` | `{ model?: string, batchSize?: number }` | `{ jobId, status: 'started', model, batchSize }` |
-| `GET` | `/api/vector/index/status` | none | current job plus `docsPerSec` and `eta` |
-| `GET` | `/api/vector/index/models` | none | `{ models: { [key]: { collection, model, adapter, count? } } }` |
-| `ALL` | `/api/vector-db/*` | forwarded method, headers, query, body | sidecar vector DB response |
-| `GET` | `/api/similar?id=&limit=&model=` | doc id, optional limit/model | `{ docId, results }` or `{ error, results: [], docId }` |
-| `GET` | `/api/compare?q=&models=&limit=&type=&project=&cwd=` | query plus optional filters | `{ query, models, byModel, agreement }` |
-| `GET` | `/api/map` | none | `{ documents, total }` |
-| `GET` | `/api/map3d?model=` | optional model | `{ documents, total }` |
-
-The default sidecar proxy manifest is `path=/api/vector-db`,
-`targetEnv=VECTOR_DB_URL`, `stripPrefix=true`. When `VECTOR_URL` is configured,
-vector handlers proxy to that remote vector server where supported.
-
-### Vector examples
+### Health and vector health
 
 ```bash
-curl http://localhost:47778/api/vector/health
-curl http://localhost:47778/api/vector/config
-curl -X POST http://localhost:47778/api/vector/index/start \
-  -H 'content-type: application/json' \
-  -d '{"model":"bge-m3","batchSize":50}'
-curl 'http://localhost:47778/api/compare?q=oracle&models=bge-m3,nomic&limit=5'
-curl http://localhost:47778/api/vector-db/collections
+curl -s "$BASE/api/health"
+curl -s "${AUTH[@]}" "$BASE/api/v1/vector/health"
 ```
 
-## MCP tool listing API
-
-`GET /api/mcp/tools` exposes the MCP tool catalogue for UI browsers. It returns
-core tools plus unified-plugin MCP tools; handler names are intentionally omitted.
-
-| Method | Path | Request | Response |
-| --- | --- | --- | --- |
-| `GET` | `/api/mcp/tools` | none | `{ tools: PublicTool[], total: number }` |
-
-```ts
-type PublicTool = {
-  name: string;
-  description: string;
-  inputSchema: Record<string, unknown>;
-  group?: string;
-  readOnly?: boolean;
-  enabledByDefault?: boolean;
-  source: 'core' | 'plugin';
-  plugin?: string;
-};
+```json
+{ "status": "ok", "server": "arra-oracle-v3", "db": "connected", "vectorStatus": "ok", "mcp": { "toolCount": 27 } }
 ```
 
-Unified plugin tools with `"enabled": false` in `plugin.json` are not registered,
-listed, or callable. `enabledByDefault: false` keeps a tool registered but hides
-it unless config explicitly enables it.
+```json
+{ "status": "ok", "engines": [{ "key": "bge-m3", "ok": true }], "checked_at": "2026-06-17T00:00:00.000Z" }
+```
 
-Core tool names (27 total): `____IMPORTANT`, `oracle_search`, `oracle_read`,
-`oracle_learn`, `oracle_list`, `oracle_stats`, `oracle_concepts`,
-`oracle_supersede`, `oracle_research_note`, `oracle_handoff`, `oracle_inbox`,
-`oracle_thread`, `oracle_threads`, `oracle_thread_read`, `oracle_thread_update`,
-`oracle_profile`, `oracle_trace`, `oracle_trace_list`, `oracle_trace_get`,
-`oracle_trace_link`, `oracle_trace_unlink`, `oracle_trace_chain`,
-`oracle_trace_distill`, `oracle_reflect`, `oracle_verify`,
-`oracle_mcp_list_tools`, and `oracle_mcp_call`.
-
-Example:
+### Vector config and indexing
 
 ```bash
-curl http://localhost:47778/api/mcp/tools
+curl -s "${AUTH[@]}" -H 'content-type: application/json' \
+  -X PATCH -d '{"enabled":true,"engine":"lancedb"}' \
+  "$BASE/api/v1/vector/config"
+curl -s "${AUTH[@]}" -H 'content-type: application/json' \
+  -d '{"model":"bge-m3","batchSize":50}' \
+  "$BASE/api/v1/vector/index/start"
 ```
 
-Response excerpt:
+```json
+{ "success": true, "reloaded": true, "source": "file", "enabled": true, "collections": [{ "key": "bge-m3", "model": "bge-m3" }] }
+```
+
+```json
+{ "jobId": "vidx-1718582400000", "status": "started", "model": "bge-m3", "batchSize": 50, "source": "auto" }
+```
+
+### Menu and plugin state
+
+```bash
+curl -s "${AUTH[@]}" "$BASE/api/v1/menu?scope=main"
+curl -s "${AUTH[@]}" -H 'content-type: application/json' \
+  -d '{"path":"/canvas","label":"Canvas","group":"tools","order":40}' \
+  "$BASE/api/v1/menu/custom"
+curl -s "${AUTH[@]}" -H 'content-type: application/json' \
+  -d '{"enabled":false}' "$BASE/api/v1/plugins/community-search/toggle"
+```
+
+```json
+{ "items": [{ "path": "/search", "label": "Search", "group": "main", "source": "api" }] }
+```
+
+```json
+{ "added": true, "replaced": false, "item": { "path": "/canvas", "label": "Canvas", "group": "tools", "order": 40, "source": "page", "added": true } }
+```
+
+```json
+{ "ok": true, "plugin": "community-search", "enabled": false, "reloaded": true, "mcpTools": [] }
+```
+
+### Export job
+
+```bash
+curl -s "${AUTH[@]}" -H 'content-type: application/json' \
+  -d '{"collection":"oracle_documents","format":"json"}' \
+  "$BASE/api/v1/export"
+```
+
+```json
+{ "job": { "id": "export_01", "status": "queued", "format": "json", "source": "vault", "collection": "oracle_documents", "progress": 0 } }
+```
+
+## MCP tool catalogue
+
+`GET /api/v1/mcp/tools` returns core tools plus active plugin tools; handler names
+are omitted. The 27 core names are, in order:
+
+`____IMPORTANT`, `oracle_search`, `oracle_read`, `oracle_learn`, `oracle_list`,
+`oracle_stats`, `oracle_concepts`, `oracle_supersede`, `oracle_research_note`,
+`oracle_handoff`, `oracle_inbox`, `oracle_thread`, `oracle_threads`,
+`oracle_thread_read`, `oracle_thread_update`, `oracle_profile`, `oracle_trace`,
+`oracle_trace_list`, `oracle_trace_get`, `oracle_trace_link`,
+`oracle_trace_unlink`, `oracle_trace_chain`, `oracle_trace_distill`,
+`oracle_reflect`, `oracle_verify`, `oracle_mcp_list_tools`, `oracle_mcp_call`.
 
 ```json
 {
   "tools": [
-    { "name": "oracle_search", "group": "search", "readOnly": true, "source": "core" },
-    { "name": "oracle_canvas_inspect", "plugin": "canvas-inspector", "source": "plugin" }
+    {
+      "name": "oracle_search",
+      "group": "search",
+      "readOnly": true,
+      "remoteable": true,
+      "rest": { "method": "GET", "path": "/api/search" },
+      "source": "core"
+    }
   ],
-  "total": 2
+  "total": 27
 }
 ```
+
+Remoteable tools have a `rest` method/path; local-only tools have
+`localOnlyReason`. Plugin tools use `source: "plugin"` and include `plugin`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,19 +1,20 @@
 # Arra Oracle architecture overview
 
-Arra Oracle is the Oracle family's installable memory/search layer. One core
-runtime exposes the same capabilities through HTTP, MCP stdio, the `arra` CLI,
-Studio UI, unified plugins, and Docker/MCP Toolkit packaging.
+Verified against `src/server.ts`, `src/routes/*`, and `src/tools/*` on
+2026-06-17. Arra Oracle is the Oracle family's installable memory/search layer:
+SQLite + FTS5 stay local, vector backends are optional, and the same capability
+core is exposed through HTTP, MCP stdio, CLI, Studio, plugins, and packaging.
 
 ## Design goals
 
-- **Easy install:** `bun add -g github:Soul-Brews-Studio/arra-oracle-v3#vX.Y.Z`
-  should be enough to run the server and CLI.
 - **One capability core:** HTTP routes, MCP tools, CLI commands, and plugins reuse
   shared handlers instead of duplicating business logic.
-- **Local-first data:** SQLite + FTS5 remain available even when vector backends
-  or remote services are disabled.
-- **Plugin-shaped extension:** external features should install as plugin folders
-  or artifacts, not require editing core source.
+- **Local-first operation:** search, learn, read, and list work from SQLite/FTS5
+  even when vector services or remote proxies are disabled.
+- **Plugin-shaped extension:** additional API routes, MCP tools, menu items,
+  sidecars, export formats, and CLI commands come from `plugin.json` manifests.
+- **Safe multi-tenant deploys:** token auth and tenant headers scope data without
+  changing local-first defaults.
 
 ## Runtime map
 
@@ -27,84 +28,120 @@ Users, agents, Studio, maw-js, MCP clients
         └─ Plugin runtime: src/plugins/unified-loader.ts
                   │
         Core services and storage
-        ├─ src/tools/       MCP/CLI-ready tool handlers
-        ├─ src/vector/      vector adapters and config
-        ├─ src/indexer/     document parsing and backfill jobs
-        ├─ src/gateway/     federation/proxy guardrails
-        ├─ src/middleware/  auth, tenant, logging, negotiation
-        └─ SQLite + FTS5 + vector stores + vault markdown
+        ├─ src/tools/       MCP-ready handlers and REST mapping
+        ├─ src/vector/      vector adapters, config, provider detection
+        ├─ src/indexer/     document parsing, scan/reindex, daemon jobs
+        ├─ src/gateway/     vector/gateway status and proxy guardrails
+        ├─ src/middleware/  versioning, auth, tenant, limits, errors
+        └─ SQLite + FTS5 + optional vector stores + vault markdown
 ```
 
-## Request paths
+## Request lifecycle
 
-| Surface | Entrypoint | Primary contracts |
+1. `createStartedApp()` validates env, resets indexing status, preflights vector
+   runtime, starts file/plugin watchers, seeds menus, then wraps `app.fetch()`.
+2. `createApiVersionedFetch()` redirects public non-health `/api/*` requests to
+   `/api/v1/*` and rewrites `/api/v1/*` back to internal `/api/*` routes.
+3. Global middleware adds request logging, correlation IDs, tenant context, CORS,
+   private-network preflight, version/security/content headers, body limits,
+   optional API-key/token auth, rate limits, metrics, compression, ETags, DB
+   context, request de-duplication, timeouts, structured errors, and not-found
+   handling.
+4. `createServerRouteModules()` mounts the Elysia route modules, then plugin
+   routes, then the not-found boundary. A source inspection currently builds 185
+   routes, 181 of them under `/api`.
+
+## HTTP route families
+
+| Family | Source modules | Primary paths |
 | --- | --- | --- |
-| HTTP | `src/server.ts` | Elysia route clusters under `/api/*`, `/health` |
-| MCP embedded | `src/index.ts` | `oracle_search`, `oracle_learn`, `oracle_read`, plugin tools |
-| MCP proxy | `ORACLE_HTTP_URL` | Stdio MCP forwards covered writes/reads to HTTP |
-| CLI | `cli/src/cli.ts` | Built-ins plus plugin commands, target config, install helpers |
-| Studio | `frontend/` | React pages over HTTP routes and plugin/menu registries |
-| Docker | `Dockerfile`, `catalog/` | HTTP image, stdio image, Docker MCP Toolkit catalog |
+| Health/status | `routes/health`, `routes/metrics`, `gateway` | `/api/health`, `/api/health/deep`, `/api/stats`, `/api/metrics`, `/api/gateway/*` |
+| Search/knowledge | `routes/search`, `routes/learn`, `routes/knowledge` | `/api/search`, `/api/list`, `/api/read`, `/api/learn*`, `/api/handoff`, `/api/inbox` |
+| Vector/indexer | `routes/vector`, `routes/indexer` | `/api/vector/*`, `/api/vector-db*`, `/api/similar`, `/api/compare`, `/api/map*`, `/api/indexer/*` |
+| Studio/admin | `routes/menu`, `routes/plugins`, `routes/canvas`, `routes/settings` | `/api/menu*`, `/api/plugins*`, `/api/canvas/*`, `/api/settings/*` |
+| Collaboration | `routes/forum`, `routes/traces`, `routes/schedule`, `routes/supersede` | `/api/thread*`, `/api/threads`, `/api/traces*`, `/api/schedule*`, `/api/supersede*` |
+| Import/export | `routes/export`, `routes/vault`, `routes/files` | `/api/export*`, `/api/vault/sync`, `/api/doc*`, `/api/file`, `/api/context`, `/api/graph` |
+| MCP catalogue | `routes/mcp`, `src/tools/mcp-rest-map.ts` | `/api/mcp/tools` plus MCP stdio tools |
+
+## MCP and HTTP coupling
+
+`src/tools/mcp-manifest.ts` defines 27 core MCP tools. `src/tools/mcp-rest-map.ts`
+uses the same ordered names to mark 24 tools as HTTP-remoteable and three as
+local-only (`____IMPORTANT`, `oracle_mcp_list_tools`, `oracle_mcp_call`).
+`GET /api/mcp/tools` merges those core definitions with active plugin tools and
+returns public metadata only; plugin handlers are never exposed.
+
+Example catalogue item:
+
+```json
+{
+  "name": "oracle_search",
+  "group": "search",
+  "readOnly": true,
+  "remoteable": true,
+  "rest": { "method": "GET", "path": "/api/search" },
+  "source": "core"
+}
+```
 
 ## Data flow
 
 ```text
-markdown/import/API write
+HTTP/MCP/CLI/plugin write
         │
         ▼
-parse/index document chunks
+parse + normalize document metadata
         │
-        ├─ oracle_documents metadata table
-        ├─ oracle_fts keyword index
-        └─ vector collection when enabled
+        ├─ oracle_documents tenant-scoped source of truth
+        ├─ oracle_fts keyword index for always-on recall
+        └─ optional vector collection via configured adapter/provider
         │
         ▼
-search/list/read/export through HTTP, MCP, CLI, or plugin routes
+search/list/read/export via HTTP, MCP, CLI, Studio, or plugin routes
 ```
 
-`oracle_documents` is the tenant-scoped source of truth for indexed metadata.
-FTS5 provides the always-on fallback search path. Vector adapters are optional
-and configured per model/collection.
+`oracle_documents` owns metadata and tenant scope. FTS5 owns the fallback search
+path. Vector config lives in `vector-server.json`; default collections are
+`bge-m3`, `nomic`, and `qwen3`, with a default sidecar proxy manifest at
+`/api/vector-db*` using `VECTOR_DB_URL`.
 
 ## Plugin architecture
 
-Unified plugins are directories with `plugin.json` plus an entry module. The
-runtime scans parent `.maw/plugins`, `$MAW_PLUGINS_DIR`, `~/.maw/plugins`, `~/.arra/plugins`, and `~/.oracle/plugins`, normalizes manifests,
-and registers declared surfaces:
+Unified plugins are folders with `plugin.json` plus code/artifacts. The runtime
+scans parent `.maw/plugins`, `$MAW_PLUGINS_DIR`, `~/.maw/plugins`,
+`~/.arra/plugins`, and `~/.oracle/plugins`, normalizes manifests, and registers:
 
 | Manifest key | Runtime effect |
 | --- | --- |
-| `apiRoutes[]` | Adds Elysia routes to the main HTTP server |
-| `mcpTools[]` | Adds tool definitions and dispatchable plugin MCP calls |
-| `menu[]` | Adds Studio/menu navigation rows |
-| `cliSubcommands[]` | Adds `arra <command>` operator commands |
-| `proxy[]` | Adds guarded proxy routes to external services |
-| `server` | Starts or lazily proxies a plugin-owned child service |
-| `exportFormats[]` | Adds app export formats |
-
-Easy plugin install should place the same folder shape under a plugin home, so
-installers only need to fetch, build/copy artifacts, and write `plugin.json`.
-See [PLUGIN-GUIDE.md](./PLUGIN-GUIDE.md) for authoring and packaging.
+| `apiRoutes[]` / `proxy[]` | Mounted HTTP routes or guarded upstream proxies |
+| `mcpTools[]` | Extra MCP definitions and dispatchable plugin calls |
+| `menu[]` | Studio/menu rows seeded into `/api/menu` |
+| `cliSubcommands[]` | `arra <command>` operators |
+| `server` | Child sidecar service health/proxy lifecycle |
+| `exportFormats[]` | Additional export app formats |
 
 ## Security and isolation
 
-- Protected HTTP writes use bearer tokens when `ARRA_API_TOKEN` is set.
-- Shared HTTP deployments can require `ORACLE_TENANT_TOKENS` and scope reads/writes
-  by `tenant_id`.
-- MCP stdio mode sends logs to stderr with `ORACLE_LOG_TARGET=stderr`.
-- File reads resolve real paths and stay inside allowed repo/ghq/vault roots.
-- Plugin paths and entry modules are containment-checked before import.
+- `ARRA_API_TOKEN` protects `/api/*` except `/api/health` and `/api/docs*`.
+- `ARRA_API_KEY` is a legacy bearer guard that only bypasses `/api/health`.
+- Tenant scope comes from `X-Oracle-Tenant`; `ORACLE_TENANT_TOKENS` can require
+  `X-Oracle-Tenant-Token` per tenant or wildcard.
+- MCP stdio logs go to stderr when `ORACLE_LOG_TARGET=stderr`.
+- File reads resolve real paths inside allowed repo/ghq/vault roots, and plugin
+  paths/entry modules are containment-checked before import.
 
 ## Operational checks
 
 ```bash
 arra-oracle-v3 serve --port 47778
 curl -sf http://localhost:47778/api/health
-arra health
+curl -H "Authorization: Bearer $ARRA_API_TOKEN" \
+  'http://localhost:47778/api/v1/search?q=oracle&mode=fts&limit=3'
+curl -sf http://localhost:47778/api/v1/mcp/tools
 bunx tsc --noEmit
-bun test tests/http/health/
-bun test tests/plugins/
+bun test tests/http/health/ tests/http/mcp/tools.test.ts
 ```
 
 For install steps, start with [INSTALL.md](./INSTALL.md) and
-[QUICKSTART.md](./QUICKSTART.md).
+[QUICKSTART.md](./QUICKSTART.md). See [API.md](./API.md) for request/response
+examples and [PLUGIN-GUIDE.md](./PLUGIN-GUIDE.md) for plugin packaging.


### PR DESCRIPTION
## Summary
- Refresh docs/architecture.md with verified server lifecycle, route-family, MCP/HTTP, plugin, and security architecture details.
- Refresh docs/API.md with source-verified route family inventory, auth/tenant notes, and request/response examples.
- Correct MCP tool catalogue to the 27 core tools / 24 remoteable tools from src/tools.

## Verification
- route/tool source check: createApp routes=185, apiRoutes=181, mcpTools=27, restMap=27, remoteable=24
- docs path/tool cross-check: no missing documented exact routes; MCP tool list matches manifest order
- wc -l docs/architecture.md docs/API.md (147 / 170)
- bunx tsc --noEmit
- bun test tests/http/mcp/tools.test.ts tests/integration/server-boot/composition.test.ts tests/http/swagger/ tests/http/health/
