### PR TITLE
fix(indexer): harden ψ reindex queue

### DIFF
--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -25,7 +25,14 @@ import type { OracleDocument, IndexerConfig } from '../types.ts';
 import { setIndexingStatus } from './status.ts';
 import { backupDatabase } from './backup.ts';
 import { parseResonanceFile, parseLearningFile, parseRetroFile, parseDistillationFile } from './parser.ts';
+import { getEmbeddingModels } from '../vector/factory.ts';
 import { collectDocuments, collectPsiLearn, collectSecurityCorpus } from './collectors.ts';
+import {
+  changedDocumentIds,
+  enqueueVectorReindexJobs,
+  snapshotActiveIndexerDocs,
+  supersedeReplacedSourceDocs,
+} from './reindex-state.ts';
 import { storeDocuments } from './storage.ts';
 
 export interface IndexOptions {
@@ -79,6 +86,8 @@ export class OracleIndexer {
         `Set ORACLE_REPO_ROOT or run from a directory containing ψ/memory/ to avoid data loss.`
       );
     }
+
+    const beforeDocs = snapshotActiveIndexerDocs(this.sqlite, tenantId);
 
     // Collect documents from all source types
     const shared = { config: this.config, seenContentHashes: this.seenContentHashes };
@@ -143,13 +152,19 @@ export class OracleIndexer {
       }
     }
 
-    // Store in SQLite + FTS5 only. Vector indexing is a separate step
-    // (src/scripts/index-model.ts) that uses the canonical LanceDB path.
+    const changedIds = changedDocumentIds(beforeDocs, documents);
+
+    // Store in SQLite + FTS5 first. Vector work is queued afterwards so
+    // embedding failures cannot roll back the source-of-truth text index.
     await storeDocuments(this.sqlite, this.db, null, this.project, documents, { tenantId });
+    const superseded = supersedeReplacedSourceDocs(this.sqlite, documents, tenantId);
+    const vectorJobs = safeEnqueueVectorJobs(this.sqlite, documents, changedIds);
 
     setIndexingStatus(this.sqlite, this.config, false, documents.length, documents.length);
     console.log(`Indexed ${documents.length} documents (SQLite + FTS5)`);
-    console.log('Run `bun src/scripts/index-model.ts bge-m3` to populate vector embeddings.');
+    if (superseded > 0) console.log(`Superseded ${superseded} stale document ids from reindexed sources`);
+    console.log(`Queued ${vectorJobs.queued} vector job(s); skipped ${vectorJobs.skipped}`);
+    if (vectorJobs.failed > 0) console.warn(`Failed to queue ${vectorJobs.failed} vector job(s); FTS5 index remains current`);
     console.log('Indexing complete!');
   }
 
@@ -161,4 +176,12 @@ export class OracleIndexer {
 
 function tenantScopedWhere(base: SQL, tenantId: string | undefined): SQL {
   return tenantId ? and(base, eq(oracleDocuments.tenantId, tenantId))! : base;
+}
+
+function safeEnqueueVectorJobs(sqlite: Database, documents: OracleDocument[], changedIds: Set<string>) {
+  try {
+    return enqueueVectorReindexJobs(sqlite, documents, getEmbeddingModels(), changedIds);
+  } catch {
+    return { queued: 0, skipped: 0, failed: documents.length };
+  }
 }

--- a/src/indexer/learn-doc-source.ts
+++ b/src/indexer/learn-doc-source.ts
@@ -77,7 +77,10 @@ export function storeSqliteDocuments(db: Database, documents: OracleDocument[]):
       concepts = excluded.concepts,
       updated_at = excluded.updated_at,
       indexed_at = excluded.indexed_at,
-      project = excluded.project
+      project = excluded.project,
+      superseded_by = NULL,
+      superseded_at = NULL,
+      superseded_reason = NULL
   `);
   const deleteFts = db.prepare('DELETE FROM oracle_fts WHERE id = ?');
   const insertFts = db.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)');

--- a/src/indexer/reindex-state.ts
+++ b/src/indexer/reindex-state.ts
@@ -1,0 +1,163 @@
+import type Database from 'bun:sqlite';
+import type { OracleDocument } from '../types.ts';
+import { enqueueIndexJob } from './jobs.ts';
+
+export type DocSnapshot = Map<string, { sourceFile: string; content: string | null }>;
+export type ModelRegistry = Record<string, { collection: string }>;
+
+export interface VectorQueueStats {
+  queued: number;
+  skipped: number;
+  failed: number;
+}
+
+const REINDEX_REASON = 'superseded by indexer reindex';
+
+export function snapshotActiveIndexerDocs(sqlite: Database, tenantId?: string): DocSnapshot {
+  const params: string[] = [];
+  const tenantClause = tenantId ? 'AND d.tenant_id = ?' : '';
+  if (tenantId) params.push(tenantId);
+  const rows = sqlite.prepare(`
+    SELECT d.id, d.source_file AS sourceFile,
+      (SELECT GROUP_CONCAT(f.content, '\n') FROM oracle_fts f WHERE f.id = d.id) AS content
+    FROM oracle_documents d
+    WHERE (d.created_by = 'indexer' OR d.created_by IS NULL)
+      AND d.superseded_by IS NULL
+      AND d.superseded_at IS NULL
+      ${tenantClause}
+  `).all(...params) as Array<{ id: string; sourceFile: string; content: string | null }>;
+
+  return new Map(rows.map((row) => [row.id, { sourceFile: row.sourceFile, content: row.content }]));
+}
+
+export function changedDocumentIds(before: DocSnapshot, documents: OracleDocument[]): Set<string> {
+  const changed = new Set<string>();
+  for (const doc of documents) {
+    const prior = before.get(doc.id);
+    if (!prior || prior.content !== doc.content) changed.add(doc.id);
+  }
+  return changed;
+}
+
+export function supersedeReplacedSourceDocs(
+  sqlite: Database,
+  documents: OracleDocument[],
+  tenantId?: string,
+): number {
+  const bySource = new Map<string, string[]>();
+  for (const doc of documents) {
+    const ids = bySource.get(doc.source_file) ?? [];
+    ids.push(doc.id);
+    bySource.set(doc.source_file, ids);
+  }
+
+  let superseded = 0;
+  const now = Date.now();
+  for (const [sourceFile, currentIds] of bySource) {
+    const stale = activeIndexerIdsForSource(sqlite, sourceFile, currentIds, tenantId);
+    if (stale.length === 0) continue;
+    const successorId = currentIds[0];
+    const update = sqlite.prepare(`
+      UPDATE oracle_documents
+      SET superseded_by = ?, superseded_at = ?, superseded_reason = ?
+      WHERE id = ? AND superseded_by IS NULL AND superseded_at IS NULL
+    `);
+    sqlite.exec('BEGIN');
+    try {
+      for (const id of stale) {
+        update.run(successorId, now, REINDEX_REASON, id);
+        superseded++;
+      }
+      sqlite.exec('COMMIT');
+    } catch (error) {
+      sqlite.exec('ROLLBACK');
+      throw error;
+    }
+  }
+  return superseded;
+}
+
+export function enqueueVectorReindexJobs(
+  sqlite: Database,
+  documents: OracleDocument[],
+  models: ModelRegistry,
+  changedIds: Set<string>,
+): VectorQueueStats {
+  const modelKeys = Object.keys(models);
+  const docIds = [...new Set(documents.map((doc) => doc.id))];
+  const stats: VectorQueueStats = { queued: 0, skipped: 0, failed: 0 };
+  if (docIds.length === 0 || modelKeys.length === 0) return stats;
+  if (!hasIndexingJobsTable(sqlite)) {
+    stats.failed = docIds.length * modelKeys.length;
+    return stats;
+  }
+
+  for (const docId of docIds) {
+    const changed = changedIds.has(docId);
+    for (const modelKey of modelKeys) {
+      try {
+        if (!needsVectorJob(sqlite, docId, modelKey, changed)) {
+          stats.skipped++;
+          continue;
+        }
+        const jobs = enqueueIndexJob(sqlite, { docId, modelKey, models });
+        stats.queued += jobs.length;
+        if (jobs.length === 0) stats.failed++;
+      } catch {
+        stats.failed++;
+      }
+    }
+  }
+  return stats;
+}
+
+function activeIndexerIdsForSource(
+  sqlite: Database,
+  sourceFile: string,
+  currentIds: string[],
+  tenantId?: string,
+): string[] {
+  if (currentIds.length === 0) return [];
+  const notIn = currentIds.map(() => '?').join(',');
+  const params: string[] = [sourceFile, ...currentIds];
+  const tenantClause = tenantId ? 'AND tenant_id = ?' : '';
+  if (tenantId) params.push(tenantId);
+  const rows = sqlite.prepare(`
+    SELECT id FROM oracle_documents
+    WHERE source_file = ?
+      AND id NOT IN (${notIn})
+      AND (created_by = 'indexer' OR created_by IS NULL)
+      AND superseded_by IS NULL
+      AND superseded_at IS NULL
+      ${tenantClause}
+  `).all(...params) as Array<{ id: string }>;
+  return rows.map((row) => row.id);
+}
+
+function hasIndexingJobsTable(sqlite: Database): boolean {
+  try {
+    const row = sqlite.prepare(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'indexing_jobs'",
+    ).get() as { name: string } | undefined;
+    return row?.name === 'indexing_jobs';
+  } catch {
+    return false;
+  }
+}
+
+function needsVectorJob(
+  sqlite: Database,
+  docId: string,
+  modelKey: string,
+  changed: boolean,
+): boolean {
+  const rows = sqlite.prepare(`
+    SELECT status FROM indexing_jobs
+    WHERE doc_id = ? AND model_key = ?
+    ORDER BY created_at DESC
+  `).all(docId, modelKey) as Array<{ status: string }>;
+  if (changed) return !rows.some((row) => row.status === 'pending');
+  return !rows.some((row) => row.status === 'pending'
+    || row.status === 'claimed'
+    || row.status === 'done');
+}

--- a/src/indexer/storage.ts
+++ b/src/indexer/storage.ts
@@ -72,6 +72,9 @@ export async function storeDocuments(
             updatedAt: doc.updated_at,
             indexedAt: now,
             project: docProject,
+            supersededBy: null,
+            supersededAt: null,
+            supersededReason: null,
           }
         })
         .run();

--- a/tests/indexer/reindex-hardening.test.ts
+++ b/tests/indexer/reindex-hardening.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import Database from 'bun:sqlite';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { IndexerConfig } from '../../src/types.ts';
+import { OracleIndexer } from '../../src/indexer/index.ts';
+
+const originalDataDir = process.env.ORACLE_DATA_DIR;
+const originalDbPath = process.env.ORACLE_DB_PATH;
+
+let cleanup: string[] = [];
+
+afterEach(() => {
+  restoreEnv();
+  for (const dir of cleanup.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('ψ reindex hardening', () => {
+  test('indexes ψ to FTS5 and queues vector jobs only when content changes', async () => {
+    const h = makeHarness('incremental');
+    writeLearning(h.repoRoot, 'stable.md', '# Stable\n\ninitial searchable content');
+
+    await runIndex(h);
+    const firstJobs = scalar(h.dbPath, 'SELECT COUNT(*) FROM indexing_jobs');
+    expect(firstJobs).toBeGreaterThan(0);
+    expect(ftsBySource(h.dbPath, 'ψ/memory/learnings/stable.md')).toContain('initial searchable');
+
+    exec(h.dbPath, "UPDATE indexing_jobs SET status = 'done'");
+    await runIndex(h);
+    expect(scalar(h.dbPath, 'SELECT COUNT(*) FROM indexing_jobs')).toBe(firstJobs);
+
+    writeLearning(h.repoRoot, 'stable.md', '# Stable\n\nchanged vector-worthy content');
+    await runIndex(h);
+    expect(scalar(h.dbPath, 'SELECT COUNT(*) FROM indexing_jobs')).toBe(firstJobs * 2);
+    expect(scalar(h.dbPath, "SELECT COUNT(*) FROM indexing_jobs WHERE status = 'pending'")).toBe(firstJobs);
+    expect(ftsBySource(h.dbPath, 'ψ/memory/learnings/stable.md')).toContain('changed vector-worthy');
+  });
+
+  test('supersedes stale document ids when a source reindexes to a new id', async () => {
+    const h = makeHarness('supersede');
+    writeLearning(h.repoRoot, 'rotate.md', '---\nid: old-rotate\n---\nold body');
+    await runIndex(h);
+
+    writeLearning(h.repoRoot, 'rotate.md', '---\nid: new-rotate\n---\nnew body');
+    await runIndex(h);
+
+    const db = new Database(h.dbPath, { readonly: true });
+    try {
+      const oldRow = db.query(`
+        SELECT superseded_by AS byId, superseded_reason AS reason
+        FROM oracle_documents WHERE id = 'old-rotate'
+      `).get() as { byId: string | null; reason: string | null };
+      const newRow = db.query(`
+        SELECT superseded_by AS byId FROM oracle_documents WHERE id = 'new-rotate'
+      `).get() as { byId: string | null };
+      expect(oldRow).toEqual({ byId: 'new-rotate', reason: 'superseded by indexer reindex' });
+      expect(newRow).toEqual({ byId: null });
+      expect(ftsContent(h.dbPath, 'old-rotate')).toContain('old body');
+      expect(ftsContent(h.dbPath, 'new-rotate')).toContain('new body');
+    } finally {
+      db.close();
+    }
+  });
+
+  test('keeps SQLite and FTS current when vector queueing is unavailable', async () => {
+    const h = makeHarness('partial');
+    writeLearning(h.repoRoot, 'queue-down.md', '# Queue Down\n\nfts survives missing queue');
+
+    const indexer = new OracleIndexer(configFor(h));
+    try {
+      (indexer as unknown as { sqlite: Database }).sqlite.exec('DROP TABLE indexing_jobs');
+      await indexer.index();
+    } finally {
+      await indexer.close();
+    }
+
+    expect(ftsBySource(h.dbPath, 'ψ/memory/learnings/queue-down.md')).toContain('fts survives missing queue');
+    expect(scalar(h.dbPath, 'SELECT COUNT(*) FROM oracle_documents')).toBe(1);
+  });
+});
+
+function makeHarness(name: string) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), `arra-indexer-${name}-`));
+  cleanup.push(tmp);
+  const dataDir = path.join(tmp, 'data');
+  const repoRoot = path.join(tmp, 'repo');
+  fs.mkdirSync(dataDir, { recursive: true });
+  process.env.ORACLE_DATA_DIR = dataDir;
+  process.env.ORACLE_DB_PATH = path.join(dataDir, 'oracle.db');
+  return { tmp, dataDir, repoRoot, dbPath: process.env.ORACLE_DB_PATH };
+}
+
+function writeLearning(repoRoot: string, filename: string, body: string): void {
+  const dir = path.join(repoRoot, 'ψ', 'memory', 'learnings');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, filename), body, 'utf8');
+}
+
+async function runIndex(h: ReturnType<typeof makeHarness>): Promise<void> {
+  const indexer = new OracleIndexer(configFor(h));
+  try { await indexer.index(); }
+  finally { await indexer.close(); }
+}
+
+function configFor(h: ReturnType<typeof makeHarness>): IndexerConfig {
+  return {
+    repoRoot: h.repoRoot,
+    dbPath: h.dbPath,
+    chromaPath: path.join(h.dataDir, 'chroma'),
+    sourcePaths: {
+      resonance: 'ψ/memory/resonance',
+      learnings: 'ψ/memory/learnings',
+      retrospectives: 'ψ/memory/retrospectives',
+      distillations: 'ψ/memory/distillations',
+      learn: 'ψ/learn',
+    },
+  };
+}
+
+function ftsContent(dbPath: string, id: string): string {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return (db.query('SELECT content FROM oracle_fts WHERE id = ?').get(id) as { content: string })?.content ?? '';
+  } finally {
+    db.close();
+  }
+}
+
+function ftsBySource(dbPath: string, sourceFile: string): string {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return (db.query(`
+      SELECT f.content FROM oracle_documents d
+      JOIN oracle_fts f ON f.id = d.id
+      WHERE d.source_file = ?
+      LIMIT 1
+    `).get(sourceFile) as { content: string })?.content ?? '';
+  } finally {
+    db.close();
+  }
+}
+
+function scalar(dbPath: string, sql: string): number {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const row = db.query(sql).get() as Record<string, number> | undefined;
+    return row ? Number(Object.values(row)[0]) : 0;
+  } finally {
+    db.close();
+  }
+}
+
+function exec(dbPath: string, sql: string): void {
+  const db = new Database(dbPath);
+  try { db.exec(sql); }
+  finally { db.close(); }
+}
+
+function restoreEnv(): void {
+  if (originalDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = originalDataDir;
+  if (originalDbPath === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = originalDbPath;
+}


### PR DESCRIPTION
## Summary
- queue vector reindex jobs after ψ documents are stored in SQLite/FTS5
- skip unchanged docs, requeue changed/error cases, and tolerate queue failures without rolling back FTS5
- supersede stale document IDs emitted from the same source on reindex

## Tests
- bun test tests/indexer/
- bun test src/indexer/__tests__
- bunx tsc --noEmit

Base: alpha (never main).