### PR TITLE
test: harden spawned HTTP cluster contracts

### DIFF
--- a/tests/integration/http-contract/clusters.test.ts
+++ b/tests/integration/http-contract/clusters.test.ts
@@ -1,0 +1,113 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import {
+  fetchJson,
+  isRecord,
+  jsonInit,
+  setContractSetting,
+  startHttpContractServer,
+  writeFakeGhq,
+  type ContractServer,
+} from './rtk.ts';
+
+const runId = `${process.pid}-${Date.now()}`;
+const api = (path: string) => `/api/v1${path}`;
+let server: ContractServer | null = null;
+
+type Spec = { path: string; init?: RequestInit; status?: number | number[]; keys?: string[] };
+type ClusterCase = { cluster: string; happy: Spec; error: Spec; errorMessage?: RegExp };
+
+beforeAll(async () => {
+  server = await startHttpContractServer({ name: 'http-contract-clusters', withPlugin: true, prepareEnv: writeFakeGhq });
+  setContractSetting(server, 'vault_repo', 'contract/vault');
+}, 25_000);
+
+afterAll(async () => {
+  await server?.stop();
+});
+
+const cases: ClusterCase[] = [
+  { cluster: 'gateway', happy: { path: '/api/gateway/status', keys: ['enabled'] }, error: { path: '/api/gateway/missing', status: 404 } },
+  { cluster: 'auth', happy: { path: api('/auth/status'), keys: ['authenticated', 'authEnabled'] }, error: { path: api('/auth/login'), init: jsonInit('POST', {}), status: 400 }, errorMessage: /Password required/ },
+  { cluster: 'settings', happy: { path: api('/settings'), keys: ['authEnabled', 'hasPassword'] }, error: { path: api('/settings'), init: jsonInit('POST', { authEnabled: true }), status: 400 }, errorMessage: /password/i },
+  { cluster: 'feed', happy: { path: api('/feed'), keys: ['events', 'total'] }, error: { path: api('/feed'), init: jsonInit('POST', {}), status: 400 }, errorMessage: /oracle, event/ },
+  { cluster: 'health', happy: { path: api('/health'), keys: ['status', 'server'] }, error: { path: api('/health/missing'), status: 404 } },
+  { cluster: 'dashboard', happy: { path: api('/dashboard'), keys: ['documents', 'concepts'] }, error: { path: api('/dashboard/bogus'), status: 404 } },
+  { cluster: 'search', happy: { path: api('/search?q=oracle'), keys: ['results', 'total'] }, error: { path: api('/search'), status: 400 }, errorMessage: /Missing query/ },
+  { cluster: 'ask', happy: { path: api('/ask'), init: jsonInit('POST', { q: 'oracle', llm: false }), keys: ['query', 'answer', 'sources'] }, error: { path: api('/ask'), init: jsonInit('POST', { q: '' }), status: 400 }, errorMessage: /empty/ },
+  { cluster: 'vector', happy: { path: api('/vector/config'), keys: ['enabled', 'state'] }, error: { path: api('/vector/export?format=bogus'), status: 400 }, errorMessage: /Invalid format/ },
+  { cluster: 'concepts', happy: { path: api('/concepts'), keys: ['concepts', 'total_unique'] }, error: { path: api('/concepts/missing'), status: 404 } },
+  { cluster: 'knowledge', happy: { path: api('/learn'), keys: ['items', 'total'] }, error: { path: api('/learn'), init: jsonInit('POST', {}), status: 400 }, errorMessage: /pattern/ },
+  { cluster: 'research', happy: { path: api('/research/note'), init: jsonInit('POST', { title: 'Contract note', question: 'Q', recommendation: 'R' }), keys: ['success', 'id'] }, error: { path: api('/research/note'), init: jsonInit('POST', {}), status: 400 }, errorMessage: /title/ },
+  { cluster: 'verify', happy: { path: api('/verify?check=true&type=all'), keys: ['counts', 'missing'] }, error: { path: api('/verify'), init: jsonInit('POST', { check: 'yes' }), status: 422 }, errorMessage: /Unprocessable/ },
+  { cluster: 'supersede', happy: { path: api('/supersede'), keys: ['supersessions', 'total'] }, error: { path: api('/supersede'), init: jsonInit('POST', {}), status: 400 }, errorMessage: /old_path/ },
+  { cluster: 'forum', happy: { path: api('/threads'), keys: ['threads', 'total'] }, error: { path: api('/thread/not-a-number'), status: 400 }, errorMessage: /Invalid thread/ },
+  { cluster: 'traces', happy: { path: api('/traces'), keys: ['traces', 'total'] }, error: { path: api('/traces/missing'), status: 404 }, errorMessage: /Trace not found/ },
+  { cluster: 'schedule', happy: { path: api('/schedule'), keys: ['events', 'total'] }, error: { path: api('/schedule/bad'), init: jsonInit('PATCH', { event: 'bad id' }), status: 400 }, errorMessage: /Invalid schedule id/ },
+  { cluster: 'files', happy: { path: api('/graph'), keys: ['nodes', 'links'] }, error: { path: api('/file'), status: 400 }, errorMessage: /Missing path/ },
+  { cluster: 'plugins', happy: { path: api('/plugins'), keys: ['plugins', 'count'] }, error: { path: api('/plugins/missing-nope'), status: 404 }, errorMessage: /Plugin not found/ },
+  { cluster: 'sessions', happy: { path: api(`/session/session-${runId}/summary`), init: jsonInit('POST', { summary: 'contract summary', oracle: 'test' }), status: 201, keys: ['learning_id', 'source_file'] }, error: { path: api(`/session/bad-${runId}/summary`), init: jsonInit('POST', { summary: '' }), status: 400 }, errorMessage: /summary/ },
+  { cluster: 'vault', happy: { path: api('/vault/sync'), init: jsonInit('POST', { dryRun: true }), keys: ['ok', 'migrate'] }, error: { path: api('/vault/sync'), init: jsonInit('POST', { dryRun: 'yes' }), status: 422 }, errorMessage: /Unprocessable/ },
+  { cluster: 'metrics', happy: { path: api('/metrics'), keys: ['uptime', 'requestCount'] }, error: { path: api('/metrics/missing'), status: 404 } },
+  { cluster: 'export', happy: { path: api('/export/collections'), keys: ['collections', 'formats'] }, error: { path: api('/export/progress'), status: 400 }, errorMessage: /jobId/ },
+  { cluster: 'memory', happy: { path: api('/memory/recall'), keys: ['query', 'items'] }, error: { path: api('/memory/search'), status: 400 }, errorMessage: /Missing query/ },
+  { cluster: 'canvas', happy: { path: api('/canvas/plugins'), keys: ['plugins', 'count'] }, error: { path: api('/canvas/plugins/missing'), status: 404 }, errorMessage: /canvas plugin not found/ },
+  { cluster: 'tenants', happy: { path: api('/tenants'), keys: ['tenants', 'count'] }, error: { path: api('/tenants'), init: jsonInit('POST', { id: 'bad space' }), status: 400 }, errorMessage: /Invalid tenant id/ },
+  { cluster: 'watcher', happy: { path: api('/watcher/status'), keys: ['running', 'watchedDirs'] }, error: { path: api('/watcher/nope'), status: 404 } },
+  { cluster: 'indexer', happy: { path: api('/indexer/config'), keys: ['adapters', 'models'] }, error: { path: api('/indexer/missing'), status: 404 } },
+  { cluster: 'mcp', happy: { path: api('/mcp/tools'), keys: ['tools', 'total'] }, error: { path: api('/mcp/missing'), status: 404 } },
+  { cluster: 'menu', happy: { path: api('/menu'), keys: ['items'] }, error: { path: api('/menu/items/not-number'), init: jsonInit('PATCH', {}), status: 400 }, errorMessage: /invalid id/ },
+];
+
+function expectStatus(response: Response, expected: number | number[] | undefined, fallback: number): void {
+  const statuses = Array.isArray(expected) ? expected : [expected ?? fallback];
+  expect(statuses).toContain(response.status);
+}
+
+function expectRecordBody(body: unknown): asserts body is Record<string, unknown> {
+  expect(isRecord(body)).toBe(true);
+}
+
+function expectKeys(body: Record<string, unknown>, keys: string[] = []): void {
+  for (const key of keys) expect(body).toHaveProperty(key);
+}
+
+async function exercise(spec: Spec) {
+  expect(server).not.toBeNull();
+  const result = await fetchJson(server!, spec.path, spec.init);
+  expect(result.response.headers.get('content-type') ?? '').toContain('application/json');
+  expect(result.response.headers.get('x-api-version')).toBe('v1');
+  expectRecordBody(result.body);
+  return result;
+}
+
+describe('spawned Elysia HTTP cluster contract', () => {
+  test('publishes OpenAPI JSON and root metadata outside the versioned API', async () => {
+    expect(server).not.toBeNull();
+    const docs = await fetchJson(server!, '/api/docs/json');
+    expect(docs.response.status).toBe(200);
+    expectRecordBody(docs.body);
+    expect(docs.body.paths).toHaveProperty('/api/health');
+
+    const root = await fetchJson(server!, '/');
+    expect(root.response.status).toBe(200);
+    expectRecordBody(root.body);
+    expect(root.body).toMatchObject({ status: 'ok', api: '/api/v1' });
+  });
+
+  for (const contract of cases) {
+    test(`${contract.cluster} happy path returns versioned JSON contract`, async () => {
+      const { response, body } = await exercise(contract.happy);
+      expectStatus(response, contract.happy.status, 200);
+      expect(response.ok).toBe(true);
+      expectKeys(body, contract.happy.keys);
+    });
+
+    test(`${contract.cluster} error path returns JSON error contract`, async () => {
+      const { response, body } = await exercise(contract.error);
+      expectStatus(response, contract.error.status, 400);
+      expect(response.ok).toBe(false);
+      expect(typeof body.error).toBe('string');
+      if (contract.errorMessage) expect(String(body.error)).toMatch(contract.errorMessage);
+    });
+  }
+});

--- a/tests/integration/http-contract/rtk.ts
+++ b/tests/integration/http-contract/rtk.ts
@@ -1,0 +1,152 @@
+import { chmodSync, mkdirSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:net';
+import { join } from 'node:path';
+import { Database } from 'bun:sqlite';
+import {
+  createSmokeEnv,
+  removeSmokeEnv,
+  REPO_ROOT,
+  writeOraclePlugin,
+  type SmokeEnv,
+} from '../../smoke/_helpers.ts';
+
+export type JsonRecord = Record<string, unknown>;
+type Spawned = ReturnType<typeof Bun.spawn>;
+
+export interface ContractServer extends SmokeEnv {
+  baseUrl: string;
+  process: Spawned;
+  stdout: Promise<string>;
+  stderr: Promise<string>;
+  stop: () => Promise<void>;
+}
+
+export interface ContractServerOptions {
+  name: string;
+  withPlugin?: boolean;
+  prepareEnv?: (env: SmokeEnv) => void;
+}
+
+export function jsonInit(method: string, body?: unknown): RequestInit {
+  return {
+    method,
+    headers: { 'content-type': 'application/json' },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  };
+}
+
+export async function fetchJson(server: ContractServer, path: string, init: RequestInit = {}) {
+  const headers = new Headers(init.headers);
+  headers.set('accept', headers.get('accept') ?? 'application/json');
+  const response = await fetch(`${server.baseUrl}${path}`, { ...init, headers });
+  const text = await response.text();
+  const body = text ? JSON.parse(text) as unknown : {};
+  return { response, body };
+}
+
+export function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function writeFakeGhq(env: SmokeEnv, repo = 'contract/vault'): void {
+  const ghqRoot = join(env.root, 'ghq');
+  const binDir = join(env.root, 'bin');
+  const vaultRepo = join(ghqRoot, 'github.com', 'contract', 'vault');
+  const sourceRepo = join(ghqRoot, 'github.com', 'contract', 'source');
+  mkdirSync(join(sourceRepo, 'ψ', 'memory', 'learnings'), { recursive: true });
+  mkdirSync(vaultRepo, { recursive: true });
+  writeFileSync(join(sourceRepo, 'ψ', 'memory', 'learnings', 'contract.md'), '# Contract vault fixture\n');
+  mkdirSync(binDir, { recursive: true });
+  const script = `#!/bin/sh
+if [ "$1" = "root" ]; then echo "${ghqRoot}"; exit 0; fi
+if [ "$1" = "list" ] && [ "$2" = "-p" ] && [ "$3" = "${repo}" ]; then echo "${vaultRepo}"; exit 0; fi
+if [ "$1" = "list" ] && [ "$2" = "-p" ]; then printf '%s\n%s\n' "${sourceRepo}" "${vaultRepo}"; exit 0; fi
+exit 1
+`;
+  const ghqPath = join(binDir, 'ghq');
+  writeFileSync(ghqPath, script);
+  chmodSync(ghqPath, 0o755);
+  env.env.PATH = `${binDir}:${process.env.PATH ?? ''}`;
+}
+
+export function setContractSetting(server: ContractServer, key: string, value: string | null): void {
+  const db = new Database(server.dbPath);
+  try {
+    db.query('INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value, updated_at=excluded.updated_at')
+      .run(key, value, Date.now());
+  } finally {
+    db.close();
+  }
+}
+
+export async function startHttpContractServer(options: ContractServerOptions): Promise<ContractServer> {
+  const smoke = createSmokeEnv(options.name);
+  if (options.withPlugin) writeOraclePlugin(smoke.home);
+  Object.assign(smoke.env, {
+    ARRA_PLUGIN_HOT_RELOAD: '0',
+    MAW_JS_URL: 'http://127.0.0.1:1',
+    ORACLE_CHROMA_TIMEOUT: '1000',
+    ORACLE_FILE_WATCHER: '0',
+    ORACLE_TOOL_GROUPS_HOT_RELOAD: '0',
+    ORACLE_VECTOR_HEALTH_TIMEOUT: '1000',
+    VECTOR_URL: '',
+  });
+  options.prepareEnv?.(smoke);
+
+  const port = await freePort();
+  const env = { ...process.env, ...smoke.env, ORACLE_PORT: String(port) };
+  const proc = Bun.spawn(['bun', 'src/server.ts'], { cwd: REPO_ROOT, env, stdout: 'pipe', stderr: 'pipe' });
+  const stdout = new Response(proc.stdout).text();
+  const stderr = new Response(proc.stderr).text();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  try {
+    await waitForHealth(baseUrl, proc);
+  } catch (error) {
+    proc.kill();
+    await proc.exited.catch(() => undefined);
+    removeSmokeEnv(smoke.root);
+    throw new Error(`${error instanceof Error ? error.message : String(error)}\n${await stdout}\n${await stderr}`);
+  }
+
+  return { ...smoke, baseUrl, process: proc, stdout, stderr, stop: () => stopServer(proc, smoke.root, stdout, stderr) };
+}
+
+async function stopServer(proc: Spawned, root: string, stdout: Promise<string>, stderr: Promise<string>): Promise<void> {
+  proc.kill('SIGTERM');
+  const done = await Promise.race([proc.exited.catch(() => null), sleep(1500).then(() => 'timeout' as const)]);
+  if (done === 'timeout') {
+    proc.kill('SIGKILL');
+    await proc.exited.catch(() => undefined);
+  }
+  await Promise.all([stdout.catch(() => ''), stderr.catch(() => '')]);
+  removeSmokeEnv(root);
+}
+
+async function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') return reject(new Error('failed to allocate port'));
+      server.close(() => resolve(address.port));
+    });
+  });
+}
+
+async function waitForHealth(baseUrl: string, proc: Spawned): Promise<void> {
+  let exited = false;
+  proc.exited.then(() => { exited = true; }).catch(() => { exited = true; });
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    if (exited) throw new Error('server exited before health check passed');
+    try { if ((await fetch(`${baseUrl}/api/health`)).ok) return; } catch {}
+    await sleep(150);
+  }
+  throw new Error('server did not become healthy');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary\n- add a tests/integration HTTP contract RTK for spawning the full Elysia server with isolated temp state\n- cover mounted HTTP clusters with happy and error JSON contract paths through /api/v1\n- include fixtures for plugin and vault/ghq-dependent integration paths\n\n## Validation\n- bunx tsc --noEmit\n- bun test tests/integration/http-contract\n\n## Notes\n- pre-existing local dirty files were left untouched: .maw-engine and .claude/skills/arra-lead/SKILL.md