### PR TITLE
test(knowledge): harden handoff and supersede edges

### DIFF
--- a/src/knowledge/handoff.ts
+++ b/src/knowledge/handoff.ts
@@ -28,10 +28,19 @@ export function handoffFilename(slug: string, now = new Date()): string {
 }
 
 export function writeHandoffFile(dirPath: string, content: string, slug: string, now = new Date()): string {
-  const filePath = containedHandoffFile(dirPath, handoffFilename(slug, now));
   fs.mkdirSync(dirPath, { recursive: true });
-  fs.writeFileSync(filePath, content, 'utf-8');
-  return filePath;
+  const base = handoffFilename(slug, now);
+  for (let i = 0; i < 100; i += 1) {
+    const suffix = i === 0 ? '' : `-${i}`;
+    const filePath = containedHandoffFile(dirPath, base.replace(/\.md$/, `${suffix}.md`));
+    try {
+      fs.writeFileSync(filePath, content, { encoding: 'utf-8', flag: 'wx' });
+      return filePath;
+    } catch (error) {
+      if ((error as { code?: string }).code !== 'EEXIST') throw error;
+    }
+  }
+  throw new Error('Unable to allocate unique handoff filename');
 }
 
 export function relativeKnowledgePath(repoRoot: string, filePath: string): string {

--- a/src/knowledge/inbox.ts
+++ b/src/knowledge/inbox.ts
@@ -17,11 +17,24 @@ function createdFromFilename(file: string): string {
   return dateMatch ? `${dateMatch[1]}T${dateMatch[2].replace('-', ':')}:00` : 'unknown';
 }
 
+function compareHandoffFiles(a: string, b: string): number {
+  const ap = parts(a);
+  const bp = parts(b);
+  if (ap.stamp !== bp.stamp) return bp.stamp.localeCompare(ap.stamp);
+  if (ap.suffix !== bp.suffix) return bp.suffix - ap.suffix;
+  return b.localeCompare(a);
+}
+
+function parts(file: string): { stamp: string; suffix: number } {
+  const match = file.match(/^(\d{4}-\d{2}-\d{2}_\d{2}-\d{2})_[\s\S]*?(?:-(\d+))?\.md$/);
+  return { stamp: match?.[1] ?? '', suffix: Number(match?.[2] ?? 0) };
+}
+
 export function listHandoffFiles(handoffDir: string, repoRoot: string): InboxFile[] {
   if (!fs.existsSync(handoffDir)) return [];
   let files: string[] = [];
   try {
-    files = fs.readdirSync(handoffDir).filter((file) => file.endsWith('.md')).sort().reverse();
+    files = fs.readdirSync(handoffDir).filter((file) => file.endsWith('.md')).sort(compareHandoffFiles);
   } catch {
     return [];
   }

--- a/tests/knowledge/handoff-inbox.test.ts
+++ b/tests/knowledge/handoff-inbox.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { containedHandoffFile, relativeKnowledgePath, safeHandoffSlug, writeHandoffFile } from '../../src/knowledge/handoff.ts';
+import { listHandoffFiles, parsePageInt } from '../../src/knowledge/inbox.ts';
+
+let tmp = '';
+function tempRoot() { tmp = mkdtempSync(path.join(tmpdir(), 'arra-knowledge-')); return tmp; }
+afterEach(() => { if (tmp) rmSync(tmp, { recursive: true, force: true }); tmp = ''; });
+
+describe('knowledge handoff append-only storage', () => {
+  test('sanitizes malformed slugs and contains generated files', () => {
+    const root = tempRoot();
+    const dir = path.join(root, 'ψ/inbox/handoff');
+    const file = writeHandoffFile(dir, 'hello', safeHandoffSlug('../../🔥', 'fallback text'), new Date('2026-06-16T08:09:00Z'));
+
+    expect(path.basename(file)).toContain('handoff');
+    expect(relativeKnowledgePath(root, file)).toBe('ψ/inbox/handoff/2026-06-16_08-09_handoff.md');
+    expect(() => containedHandoffFile(dir, '../escape.md')).toThrow('Invalid handoff path');
+  });
+
+  test('writes same-minute handoffs append-only instead of overwriting', () => {
+    const root = tempRoot();
+    const dir = path.join(root, 'ψ/inbox/handoff');
+    const now = new Date('2026-06-16T08:09:00Z');
+    const first = writeHandoffFile(dir, 'first', 'same', now);
+    const second = writeHandoffFile(dir, 'second', 'same', now);
+
+    expect(path.basename(first)).toBe('2026-06-16_08-09_same.md');
+    expect(path.basename(second)).toBe('2026-06-16_08-09_same-1.md');
+    expect(listHandoffFiles(dir, root).map((file) => file.preview)).toEqual(['second', 'first']);
+  });
+});
+
+describe('knowledge inbox retrieval', () => {
+  test('strictly parses pagination integers', () => {
+    expect(parsePageInt('25', 10, 1, 100)).toBe(25);
+    expect(parsePageInt('25abc', 10, 1, 100)).toBe(10);
+    expect(parsePageInt('-1', 10, 0, 100)).toBe(10);
+    expect(parsePageInt('500', 10, 1, 100)).toBe(100);
+  });
+
+  test('lists handoff markdown files while skipping malformed entries', () => {
+    const root = tempRoot();
+    const dir = path.join(root, 'ψ/inbox/handoff');
+    mkdirSync(path.join(dir, '2026-06-16_01-00_directory.md'), { recursive: true });
+    writeFileSync(path.join(dir, '2026-06-16_02-00_valid.md'), 'a'.repeat(600));
+    writeFileSync(path.join(dir, 'bad-name.md'), 'bad');
+    writeFileSync(path.join(dir, 'ignore.txt'), 'nope');
+
+    const files = listHandoffFiles(dir, root);
+
+    expect(files.map((file) => file.filename)).toEqual(['2026-06-16_02-00_valid.md', 'bad-name.md']);
+    expect(files[0].preview).toHaveLength(500);
+    expect(files[1].created).toBe('unknown');
+  });
+});

--- a/tests/knowledge/supersede-chain.test.ts
+++ b/tests/knowledge/supersede-chain.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createDatabase, oracleDocuments } from '../../src/db/index.ts';
+import type { DatabaseConnection } from '../../src/db/create.ts';
+import { runSupersede } from '../../src/tools/supersede.ts';
+
+const roots: string[] = [];
+const connections: DatabaseConnection[] = [];
+function tempDb(): DatabaseConnection {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-knowledge-super-'));
+  roots.push(root);
+  const connection = createDatabase(path.join(root, 'oracle.db'));
+  connections.push(connection);
+  return connection;
+}
+
+afterEach(() => {
+  for (const connection of connections.splice(0)) connection.storage.close();
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function insertDocs(connection: DatabaseConnection, ids: string[]) {
+  const now = Date.now();
+  connection.db.insert(oracleDocuments).values(ids.map((id) => ({
+    id,
+    type: 'learning',
+    sourceFile: `ψ/memory/${id}.md`,
+    concepts: '[]',
+    createdAt: now,
+    updatedAt: now,
+    indexedAt: now,
+  }))).run();
+}
+
+describe('knowledge supersede chain hardening', () => {
+  test('marks supersede once and preserves append-only old document rows', () => {
+    const connection = tempDb();
+    insertDocs(connection, ['old', 'new', 'newer']);
+
+    const first = runSupersede(connection.db, { oldId: 'old', newId: 'new', reason: 'updated' });
+    const second = runSupersede(connection.db, { oldId: 'old', newId: 'newer', reason: 'overwrite' });
+    const old = connection.db.select().from(oracleDocuments).where(eq(oracleDocuments.id, 'old')).get();
+
+    expect(first.payload).toMatchObject({ success: true, old_id: 'old', new_id: 'new' });
+    expect(second.isError).toBe(true);
+    expect(String(second.payload.error)).toContain('already superseded by');
+    expect(old?.supersededBy).toBe('new');
+    expect(old?.supersededReason).toBe('updated');
+  });
+
+  test('rejects malformed payloads and supersede cycles', () => {
+    const connection = tempDb();
+    insertDocs(connection, ['a', 'b', 'c']);
+    runSupersede(connection.db, { oldId: 'b', newId: 'c' });
+
+    const malformed = runSupersede(connection.db, { oldId: ' ', newId: 'b' } as never);
+    const cycle = runSupersede(connection.db, { oldId: 'c', newId: 'b' });
+
+    expect(malformed.isError).toBe(true);
+    expect(malformed.payload.error).toContain("field 'oldId'");
+    expect(cycle.isError).toBe(true);
+    expect(cycle.payload.error).toBe('arra_supersede would create a supersede cycle.');
+  });
+});


### PR DESCRIPTION
## Summary
- Made handoff inbox writes append-only by allocating unique same-minute filenames with exclusive file creation.
- Hardened inbox retrieval order so append-only suffix files sort newest-first while malformed markdown still returns safely.
- Added `tests/knowledge/` coverage for handoff storage/retrieval malformed entries and supersede chain guard behavior.

## Tests
```bash
bun test --isolate tests/knowledge
bunx tsc --noEmit
wc -l src/knowledge/handoff.ts src/knowledge/inbox.ts tests/knowledge/handoff-inbox.test.ts tests/knowledge/supersede-chain.test.ts
```
