### PR TITLE
test(middleware): harden errors and redirects

### DIFF
--- a/src/middleware/api-version.ts
+++ b/src/middleware/api-version.ts
@@ -24,7 +24,7 @@ function isVersionedApiPath(pathname: string): boolean {
 }
 
 function isInfrastructurePath(pathname: string): boolean {
-  return INFRASTRUCTURE_PREFIXES.includes(pathname);
+  return INFRASTRUCTURE_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
 }
 
 export function apiRequestPath(request: Request): string {

--- a/src/middleware/errors.ts
+++ b/src/middleware/errors.ts
@@ -54,17 +54,32 @@ export class UnprocessableEntityError extends HttpError {
   }
 }
 
+const STATUS_LABELS: Record<number, string> = {
+  400: 'Bad Request',
+  401: 'Unauthorized',
+  403: 'Forbidden',
+  404: 'Not Found',
+  405: 'Method Not Allowed',
+  409: 'Conflict',
+  413: 'Payload Too Large',
+  415: 'Unsupported Media Type',
+  422: 'Unprocessable Entity',
+  429: 'Too Many Requests',
+  500: 'Internal Server Error',
+  502: 'Bad Gateway',
+  503: 'Service Unavailable',
+  504: 'Gateway Timeout',
+};
+
 function statusLabel(statusCode: number): string {
-  if (statusCode === 400) return 'Bad Request';
-  if (statusCode === 401) return 'Unauthorized';
-  if (statusCode === 404) return 'Not Found';
-  if (statusCode === 422) return 'Unprocessable Entity';
-  if (statusCode === 503) return 'Service Unavailable';
-  return 'Internal Server Error';
+  return STATUS_LABELS[statusCode] ?? (statusCode >= 500 ? 'Internal Server Error' : 'Request Error');
 }
 
 function numericStatus(value: unknown): number | null {
-  return typeof value === 'number' && value >= 400 && value <= 599 ? value : null;
+  const status = typeof value === 'string' && value.trim() ? Number(value) : value;
+  return typeof status === 'number' && Number.isInteger(status) && status >= 400 && status <= 599
+    ? status
+    : null;
 }
 
 function errorMessage(error: unknown): string {
@@ -108,6 +123,10 @@ function defaultErrorLogger(entry: { requestId: string; statusCode: number; code
   console.error(`[HTTP:${entry.requestId}] ${entry.statusCode} ${entry.code}: ${entry.message}`);
 }
 
+function logSafely(logger: ErrorLogger, entry: Parameters<ErrorLogger>[0]): void {
+  try { logger(entry); } catch {}
+}
+
 export function createErrorMiddleware(logger: ErrorLogger = defaultErrorLogger) {
   return new Elysia({ name: 'structured-errors' }).onError({ as: 'global' }, ({ code, error, request, set }) => {
     const statusCode = knownStatus(String(code), error, apiRequestPath(request));
@@ -117,7 +136,7 @@ export function createErrorMiddleware(logger: ErrorLogger = defaultErrorLogger) 
     set.headers[REQUEST_ID_HEADER] = id;
     set.headers[RESPONSE_TIME_HEADER] = responseTimeFor(request);
     set.headers['x-correlation-id'] = id;
-    logger({ requestId: id, statusCode, code: String(code), message });
+    logSafely(logger, { requestId: id, statusCode, code: String(code), message });
     return apiErrorResponse(error instanceof HttpError ? error.error : statusLabel(statusCode), statusCode, {
       message,
       correlationId: id,

--- a/tests/http/middleware/error-redirect-contract.test.ts
+++ b/tests/http/middleware/error-redirect-contract.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import {
+  API_VERSION_HEADER,
+  apiRequestPath,
+  createApiVersionedFetch,
+} from '../../../src/middleware/api-version.ts';
+import { BadRequestError, createErrorMiddleware } from '../../../src/middleware/errors.ts';
+
+describe('middleware error boundary hardening', () => {
+  test('logger failures do not replace the structured API error response', async () => {
+    const app = new Elysia()
+      .use(createErrorMiddleware(() => { throw new Error('logger unavailable'); }))
+      .get('/api/fail', () => { throw new BadRequestError('invalid probe'); });
+
+    const res = await app.handle(new Request('http://local/api/fail', {
+      headers: { 'x-request-id': 'error-contract' },
+    }));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(res.headers.get('x-request-id')).toBe('error-contract');
+    expect(body).toEqual({
+      success: false,
+      error: 'Bad Request',
+      code: 400,
+      details: { message: 'invalid probe', correlationId: 'error-contract' },
+    });
+  });
+
+  test('status-like string fields are normalized to standard HTTP labels', async () => {
+    const app = new Elysia()
+      .use(createErrorMiddleware(() => undefined))
+      .get('/api/conflict', () => {
+        throw Object.assign(new Error('duplicate plugin id'), { status: '409' });
+      });
+
+    const res = await app.handle(new Request('http://local/api/conflict'));
+    const body = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(body).toMatchObject({
+      success: false,
+      error: 'Conflict',
+      code: 409,
+      details: { message: 'duplicate plugin id' },
+    });
+  });
+});
+
+describe('api version 308 redirect contract depth', () => {
+  test('root API redirects are permanent, absolute, query-preserving, and skip handlers', async () => {
+    let calls = 0;
+    const fetcher = createApiVersionedFetch(() => {
+      calls += 1;
+      return new Response('unexpected');
+    });
+
+    const root = await fetcher(new Request('http://local/api?next=%2Fapi%2Fsearch'));
+    const slash = await fetcher(new Request('http://local/api/?next=%2Fapi%2Fsearch'));
+
+    expect(root.status).toBe(308);
+    expect(root.headers.get('location')).toBe('http://local/api/v1?next=%2Fapi%2Fsearch');
+    expect(root.headers.get(API_VERSION_HEADER)).toBe('v1');
+    expect(await root.text()).toBe('');
+    expect(slash.status).toBe(308);
+    expect(slash.headers.get('location')).toBe('http://local/api/v1/?next=%2Fapi%2Fsearch');
+    expect(calls).toBe(0);
+  });
+
+  test('health subtree bypasses legacy redirects while adjacent API paths still redirect', async () => {
+    const app = new Elysia()
+      .get('/api/health/deep', () => ({ status: 'ok' }))
+      .get('/api/healthz', () => ({ status: 'healthz' }));
+    const fetcher = createApiVersionedFetch((request) => app.handle(request));
+
+    const deep = await fetcher(new Request('http://local/api/health/deep'));
+    const adjacent = await fetcher(new Request('http://local/api/healthz'));
+
+    expect(deep.status).toBe(200);
+    expect(await deep.json()).toEqual({ status: 'ok' });
+    expect(adjacent.status).toBe(308);
+    expect(adjacent.headers.get('location')).toBe('http://local/api/v1/healthz');
+  });
+
+  test('versioned POST rewrites preserve method, body, headers, and public path', async () => {
+    const app = new Elysia().post('/api/echo', async ({ request }) => ({
+      method: request.method,
+      routePath: new URL(request.url).pathname,
+      publicPath: apiRequestPath(request),
+      tenant: request.headers.get('x-oracle-tenant'),
+      body: await request.json(),
+    }));
+    const fetcher = createApiVersionedFetch((request) => app.handle(request));
+
+    const res = await fetcher(new Request('http://local/api/v1/echo?trace=1', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-oracle-tenant': 'tenant-a' },
+      body: JSON.stringify({ ok: true }),
+    }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get(API_VERSION_HEADER)).toBe('v1');
+    expect(body).toEqual({
+      method: 'POST',
+      routePath: '/api/echo',
+      publicPath: '/api/v1/echo',
+      tenant: 'tenant-a',
+      body: { ok: true },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- harden API version redirect infra matching so /api/health/* probes bypass legacy 308 redirects while adjacent /api paths still redirect
- make structured error middleware resilient to logger failures and normalize string status fields to standard HTTP labels
- add tests/http/middleware coverage for error boundary stability, status normalization, root 308 redirects, health subtree bypass, and versioned POST rewrite preservation

## Verification
- bunx tsc --noEmit
- bun test tests/http/middleware/

## Notes
- PR targets alpha; main untouched.