### PR TITLE
test(services): harden file watcher lifecycle

### DIFF
--- a/src/services/file-watcher.ts
+++ b/src/services/file-watcher.ts
@@ -22,7 +22,7 @@ export interface WatcherEvent { type: WatcherEventType; at: string; path?: strin
 export interface FileWatcherStatus { running: boolean; watchRoot: string; debounceMs: number; watchedDirs: number; pending: number; events: WatcherEvent[]; }
 
 export interface FileWatcherControl {
-  start(): FileWatcherStatus; stop(): FileWatcherStatus; status(): FileWatcherStatus;
+  start(): FileWatcherStatus; stop(): FileWatcherStatus; restart(): FileWatcherStatus; status(): FileWatcherStatus;
   schedule(filePath: string): void;
 }
 
@@ -72,7 +72,7 @@ export class FileWatcherService implements FileWatcherControl {
   }
 
   start(): FileWatcherStatus {
-    if (this.running) return this.status();
+    if (this.running) return this.watchers.length ? this.status() : this.restart();
     try {
       fs.mkdirSync(this.watchRoot, { recursive: true });
       this.addWatchers(this.watchRoot);
@@ -102,6 +102,7 @@ export class FileWatcherService implements FileWatcherControl {
     return this.status();
   }
 
+  restart(): FileWatcherStatus { this.stop(); return this.start(); }
   status(): FileWatcherStatus {
     return {
       running: this.running,
@@ -236,12 +237,12 @@ export class FileWatcherService implements FileWatcherControl {
 function errorText(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
-
 class LazyFileWatcherService implements FileWatcherControl {
   private service?: FileWatcherService;
   private get current(): FileWatcherService { return this.service ??= new FileWatcherService(); }
   start(): FileWatcherStatus { return this.current.start(); }
   stop(): FileWatcherStatus { return this.current.stop(); }
+  restart(): FileWatcherStatus { return this.current.restart(); }
   status(): FileWatcherStatus { return this.current.status(); }
   schedule(filePath: string): void { this.current.schedule(filePath); }
 }

--- a/tests/services/file-watcher-lifecycle.test.ts
+++ b/tests/services/file-watcher-lifecycle.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { createDatabase, oracleDocuments } from '../../src/db/index.ts';
+import type { DatabaseConnection } from '../../src/db/create.ts';
+import { FileWatcherService } from '../../src/services/file-watcher.ts';
+
+let repoRoot = '';
+let connection: DatabaseConnection | undefined;
+let service: FileWatcherService | undefined;
+
+function setup(debounceMs = 10): FileWatcherService {
+  repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-watcher-life-'));
+  connection = createDatabase(path.join(repoRoot, 'oracle.db'));
+  service = new FileWatcherService({
+    db: connection.sqlite,
+    repoRoot,
+    debounceMs,
+    models: { test: { collection: 'test_collection' } },
+    logger: { log: () => {}, warn: () => {} },
+  });
+  return service;
+}
+
+function learnFile(name: string, content = 'watcher lifecycle durable learning') {
+  const file = path.join(repoRoot, 'ψ', 'learn', name);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, content);
+  return file;
+}
+
+afterEach(() => {
+  service?.stop();
+  connection?.storage.close();
+  if (repoRoot) fs.rmSync(repoRoot, { recursive: true, force: true });
+  service = undefined;
+  connection = undefined;
+  repoRoot = '';
+});
+
+describe('FileWatcherService lifecycle and debounce hardening', () => {
+  test('restart clears pending debounce timers and resumes watching', () => {
+    const watcher = setup(1000);
+    const file = learnFile('restart.md');
+    watcher.start();
+    watcher.schedule(file);
+
+    expect(watcher.status().pending).toBe(1);
+    const restarted = watcher.restart();
+
+    expect(restarted.running).toBe(true);
+    expect(restarted.pending).toBe(0);
+    expect(restarted.events[0].type).toBe('started');
+    expect(restarted.events.some((event) => event.type === 'stopped')).toBe(true);
+  });
+
+  test('debounces repeated schedules into one indexed document and job', async () => {
+    const watcher = setup(5);
+    const file = learnFile('debounce.md');
+    watcher.start();
+
+    watcher.schedule(file);
+    watcher.schedule(file);
+    await Bun.sleep(30);
+
+    const status = watcher.status();
+    const docs = connection!.db.select().from(oracleDocuments).all()
+      .filter((doc) => doc.sourceFile === 'ψ/learn/debounce.md');
+    const jobs = connection!.sqlite.query<{ count: number }, []>('select count(*) as count from indexing_jobs').get();
+
+    expect(status.pending).toBe(0);
+    expect(status.events.filter((event) => event.type === 'indexed')).toHaveLength(1);
+    expect(docs).toHaveLength(1);
+    expect(jobs?.count).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Added file watcher `restart()` lifecycle support and stale-running recovery when `start()` sees no active watchers.
- Added service tests for restart clearing pending debounce timers and resuming watches.
- Added debounce coverage proving repeated schedules produce one indexed document and one queue job.

## Tests
```bash
bun test --isolate tests/services
bunx tsc --noEmit
wc -l src/services/file-watcher.ts tests/services/file-watcher-lifecycle.test.ts tests/services/file-watcher-edge.test.ts
```
