### PR TITLE
fix(metrics): harden observability counters

### DIFF
--- a/src/routes/health/health.ts
+++ b/src/routes/health/health.ts
@@ -10,6 +10,7 @@ import { memoryConfidenceRerankConfig } from '../memory/rerank-config.ts';
 import { mcpTools } from '../../tools/mcp-manifest.ts';
 import type { UnifiedPluginStatus } from '../../plugins/unified-loader.ts';
 import { sandboxLabel } from '../../runtime/sandbox-label.ts';
+import { healthRollupStatus } from './rollup.ts';
 import pkg from '../../../package.json' with { type: 'json' };
 
 type VectorHealth = Awaited<ReturnType<typeof readVectorBackendHealth>>;
@@ -154,11 +155,6 @@ async function readPluginStatuses(
   }
 }
 
-function aggregateStatus(db: DbStatus, pluginStatus: 'ok' | 'degraded', vectorServer: VectorServerHealth) {
-  const vectorOk = vectorServer.status !== 'down';
-  return db.status === 'connected' && pluginStatus === 'ok' && vectorOk ? 'ok' : 'degraded';
-}
-
 function vectorAvailable(
   runtime: ReturnType<typeof getVectorRuntimeStatus>,
   vector: VectorHealth,
@@ -207,7 +203,7 @@ export function createHealthEndpoint(options: HealthEndpointOptions = {}) {
 
     const serviceUptime = Math.round(uptimeSeconds * 1000) / 1000;
     return {
-      status: aggregateStatus(dbStatus, pluginStatus, vectorServer),
+      status: healthRollupStatus(dbStatus, pluginStatus, vector, vectorServer, vectorRuntime),
       server: MCP_SERVER_NAME,
       version: pkg.version,
       port: Number(PORT),

--- a/src/routes/health/rollup.ts
+++ b/src/routes/health/rollup.ts
@@ -1,0 +1,30 @@
+type DbStatus = { status: 'connected' | 'error' };
+type PluginStatus = 'ok' | 'degraded';
+type VectorStatus = { status: 'ok' | 'degraded' | 'down' };
+type VectorServerStatus = { configured: boolean; status: 'ok' | 'down' | 'unconfigured' };
+type VectorRuntimeStatus = { vectorMode: 'embedded' | 'proxied' | 'disabled' };
+
+export type HealthRollupStatus = 'ok' | 'degraded';
+
+export function healthRollupStatus(
+  db: DbStatus,
+  pluginStatus: PluginStatus,
+  vector: VectorStatus,
+  vectorServer: VectorServerStatus,
+  runtime: VectorRuntimeStatus,
+): HealthRollupStatus {
+  if (db.status !== 'connected' || pluginStatus !== 'ok') return 'degraded';
+  return vectorRollupOk(vector, vectorServer, runtime) ? 'ok' : 'degraded';
+}
+
+function vectorRollupOk(
+  vector: VectorStatus,
+  vectorServer: VectorServerStatus,
+  runtime: VectorRuntimeStatus,
+): boolean {
+  if (runtime.vectorMode === 'disabled') return true;
+  if (runtime.vectorMode === 'proxied' || vectorServer.configured) {
+    return vectorServer.status === 'ok';
+  }
+  return vector.status === 'ok';
+}

--- a/src/routes/metrics/metrics.ts
+++ b/src/routes/metrics/metrics.ts
@@ -13,7 +13,12 @@ export interface MetricsSnapshot {
   uptime: number;
   requestCount: number;
   avgResponseMs: number;
+  lastResponseMs: number;
+  maxResponseMs: number;
   activeConnections: number;
+  errorCount: number;
+  statusCounts: Record<string, number>;
+  methodCounts: Record<string, number>;
   lastRestart: string;
   memoryUsage: MemoryUsageSnapshot;
   tenant?: { id: string; scope: 'tenant_id' };
@@ -28,7 +33,7 @@ export interface MetricsTrackerOptions {
 
 export interface MetricsTracker {
   begin(request: Request): void;
-  end(request: Request): void;
+  end(request: Request, statusCode?: number): void;
   snapshot(tenantId?: string): MetricsSnapshot;
 }
 
@@ -44,14 +49,19 @@ const MetricsResponseSchema = t.Object({
   uptime: t.Number(),
   requestCount: t.Number(),
   avgResponseMs: t.Number(),
+  lastResponseMs: t.Number(),
+  maxResponseMs: t.Number(),
   activeConnections: t.Number(),
+  errorCount: t.Number(),
+  statusCounts: t.Record(t.String(), t.Number()),
+  methodCounts: t.Record(t.String(), t.Number()),
   lastRestart: t.String(),
   memoryUsage: MemoryUsageSchema,
   tenant: t.Optional(t.Object({ id: t.String(), scope: t.Literal('tenant_id') })),
 });
 
-function safeNumber(value: number): number {
-  return Number.isFinite(value) && value > 0 ? value : 0;
+function safeNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 0;
 }
 
 function round(value: number): number {
@@ -79,11 +89,29 @@ function sanitizeMemoryUsage(snapshot: MemoryUsageSnapshot): MemoryUsageSnapshot
   };
 }
 
-type MetricsCounter = { requestCount: number; totalResponseMs: number; activeConnections: number };
-type RequestStart = { startedAt: number; tenantId?: string };
+type RequestStart = { startedAt: number; tenantId?: string; method: string };
+type MetricsCounter = {
+  requestCount: number;
+  totalResponseMs: number;
+  activeConnections: number;
+  errorCount: number;
+  lastResponseMs: number;
+  maxResponseMs: number;
+  statusCounts: Record<string, number>;
+  methodCounts: Record<string, number>;
+};
 
 function counter(): MetricsCounter {
-  return { requestCount: 0, totalResponseMs: 0, activeConnections: 0 };
+  return {
+    requestCount: 0,
+    totalResponseMs: 0,
+    activeConnections: 0,
+    errorCount: 0,
+    lastResponseMs: 0,
+    maxResponseMs: 0,
+    statusCounts: { '1xx': 0, '2xx': 0, '3xx': 0, '4xx': 0, '5xx': 0, unknown: 0 },
+    methodCounts: {},
+  };
 }
 
 function safeMemoryUsage(readMemoryUsage: () => MemoryUsageSnapshot): MemoryUsageSnapshot {
@@ -106,26 +134,59 @@ function beginCounter(metrics: MetricsCounter): void {
   metrics.activeConnections += 1;
 }
 
-function endCounter(metrics: MetricsCounter, elapsedMs: number): void {
+function endCounter(metrics: MetricsCounter, elapsedMs: number, statusCode: number | undefined, method: string): void {
+  const elapsed = safeNumber(elapsedMs);
+  const bucket = statusBucket(statusCode);
   metrics.activeConnections = Math.max(0, metrics.activeConnections - 1);
   metrics.requestCount += 1;
-  metrics.totalResponseMs += Math.max(0, elapsedMs);
+  metrics.totalResponseMs += elapsed;
+  metrics.lastResponseMs = round(elapsed);
+  metrics.maxResponseMs = Math.max(metrics.maxResponseMs, metrics.lastResponseMs);
+  metrics.statusCounts[bucket] = (metrics.statusCounts[bucket] ?? 0) + 1;
+  metrics.methodCounts[method] = (metrics.methodCounts[method] ?? 0) + 1;
+  if (bucket === '5xx') metrics.errorCount += 1;
+}
+
+function readNow(nowMs: () => number): number {
+  try { return safeNumber(nowMs()); } catch { return 0; }
+}
+
+function isoFromMs(ms: number): string {
+  try { return new Date(safeNumber(ms)).toISOString(); }
+  catch { return new Date(0).toISOString(); }
+}
+
+function statusBucket(statusCode: number | undefined): string {
+  if (!Number.isFinite(statusCode)) return 'unknown';
+  const bucket = Math.trunc(Number(statusCode) / 100);
+  return bucket >= 1 && bucket <= 5 ? `${bucket}xx` : 'unknown';
+}
+
+function statusFrom(response: unknown, setStatus: unknown, fallback: number): number {
+  if (response instanceof Response) return response.status;
+  if (typeof setStatus === 'number') return setStatus;
+  return fallback;
 }
 
 export function createMetricsTracker(options: MetricsTrackerOptions = {}): MetricsTracker {
   const nowMs = options.nowMs ?? (() => Date.now());
-  const startedAtMs = options.startedAtMs ?? nowMs();
-  const lastRestart = options.lastRestart ?? new Date(startedAtMs).toISOString();
+  const startedAtMs = safeNumber(options.startedAtMs ?? readNow(nowMs));
+  const lastRestart = options.lastRestart ?? isoFromMs(startedAtMs);
   const memoryUsage = options.memoryUsage ?? processMemoryUsage;
   const starts = new WeakMap<Request, RequestStart>();
   const globalCounter = counter();
   const tenantCounters = new Map<string, MetricsCounter>();
 
   const buildSnapshot = (metrics: MetricsCounter, tenantId?: string): MetricsSnapshot => ({
-    uptime: round((nowMs() - startedAtMs) / 1000),
+    uptime: round((readNow(nowMs) - startedAtMs) / 1000),
     requestCount: metrics.requestCount,
     avgResponseMs: metrics.requestCount === 0 ? 0 : round(metrics.totalResponseMs / metrics.requestCount),
+    lastResponseMs: metrics.lastResponseMs,
+    maxResponseMs: metrics.maxResponseMs,
     activeConnections: metrics.activeConnections,
+    errorCount: metrics.errorCount,
+    statusCounts: { ...metrics.statusCounts },
+    methodCounts: { ...metrics.methodCounts },
     lastRestart,
     memoryUsage: safeMemoryUsage(memoryUsage),
     tenant: tenantId ? { id: tenantId, scope: 'tenant_id' } : undefined,
@@ -135,17 +196,19 @@ export function createMetricsTracker(options: MetricsTrackerOptions = {}): Metri
     begin(request) {
       if (starts.has(request)) return;
       const tenantId = currentTenantId();
-      starts.set(request, { startedAt: nowMs(), tenantId });
+      starts.set(request, { startedAt: readNow(nowMs), tenantId, method: request.method.toUpperCase() });
       beginCounter(globalCounter);
       if (tenantId) beginCounter(tenantCounter(tenantCounters, tenantId));
     },
-    end(request) {
+    end(request, statusCode) {
       const started = starts.get(request);
       if (started === undefined) return;
       starts.delete(request);
-      const elapsed = nowMs() - started.startedAt;
-      endCounter(globalCounter, elapsed);
-      if (started.tenantId) endCounter(tenantCounter(tenantCounters, started.tenantId), elapsed);
+      const elapsed = readNow(nowMs) - started.startedAt;
+      endCounter(globalCounter, elapsed, statusCode, started.method);
+      if (started.tenantId) {
+        endCounter(tenantCounter(tenantCounters, started.tenantId), elapsed, statusCode, started.method);
+      }
     },
     snapshot(tenantId = currentTenantId()) {
       if (!tenantId) return buildSnapshot(globalCounter);
@@ -161,11 +224,11 @@ export function createMetricsLifecycle(tracker: MetricsTracker = serverMetrics) 
     .onRequest(({ request }) => {
       tracker.begin(request);
     })
-    .onAfterHandle({ as: 'global' }, ({ request }) => {
-      tracker.end(request);
+    .onAfterHandle({ as: 'global' }, (ctx) => {
+      tracker.end(ctx.request, statusFrom((ctx as any).response, (ctx as any).set?.status, 200));
     })
-    .onError({ as: 'global' }, ({ request }) => {
-      tracker.end(request);
+    .onError({ as: 'global' }, (ctx) => {
+      tracker.end(ctx.request, statusFrom(undefined, (ctx as any).set?.status, 500));
     });
 }
 

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -118,7 +118,12 @@ export interface MetricsSnapshot {
   uptime: number;
   requestCount: number;
   avgResponseMs: number;
+  lastResponseMs?: number;
+  maxResponseMs?: number;
   activeConnections: number;
+  errorCount?: number;
+  statusCounts?: Record<string, number>;
+  methodCounts?: Record<string, number>;
   lastRestart: string;
   memoryUsage: MemoryUsageSnapshot;
 }

--- a/tests/http/metrics/basic-metrics.test.ts
+++ b/tests/http/metrics/basic-metrics.test.ts
@@ -29,11 +29,16 @@ test('GET /api/metrics reports lifecycle-tracked runtime counters', async () => 
   expect(res.status).toBe(200);
   const body = await res.json() as Record<string, unknown>;
 
-  expect(body).toEqual({
+  expect(body).toMatchObject({
     uptime: 1.025,
     requestCount: 1,
     avgResponseMs: 25,
+    lastResponseMs: 25,
+    maxResponseMs: 25,
     activeConnections: 1,
+    errorCount: 0,
+    statusCounts: { '2xx': 1 },
+    methodCounts: { GET: 1 },
     lastRestart: '2026-06-16T00:00:00.000Z',
     memoryUsage: { rss: 67108864, heapTotal: 33554432, heapUsed: 16777216, external: 1024, arrayBuffers: 0 },
   });

--- a/tests/http/metrics/observability-counters.test.ts
+++ b/tests/http/metrics/observability-counters.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createHealthRoutes } from '../../../src/routes/health/index.ts';
+import {
+  createMetricsLifecycle,
+  createMetricsTracker,
+} from '../../../src/routes/metrics/index.ts';
+
+describe('metrics observability counters', () => {
+  test('counts methods, status classes, errors, and response timings', async () => {
+    let now = 1_000;
+    const tracker = createMetricsTracker({ startedAtMs: 1_000, nowMs: () => now });
+    const app = new Elysia()
+      .use(createMetricsLifecycle(tracker))
+      .get('/ok', () => { now += 10; return { ok: true }; })
+      .post('/invalid', ({ set }) => { now += 20; set.status = 422; return { ok: false }; })
+      .get('/fail', () => { now += 30; throw new Error('boom'); });
+
+    expect((await app.handle(new Request('http://local/ok'))).status).toBe(200);
+    expect((await app.handle(new Request('http://local/invalid', { method: 'POST' }))).status).toBe(422);
+    expect((await app.handle(new Request('http://local/fail'))).status).toBe(500);
+
+    expect(tracker.snapshot()).toMatchObject({
+      requestCount: 3,
+      avgResponseMs: 20,
+      lastResponseMs: 30,
+      maxResponseMs: 30,
+      errorCount: 1,
+      activeConnections: 0,
+      statusCounts: { '2xx': 1, '4xx': 1, '5xx': 1 },
+      methodCounts: { GET: 2, POST: 1 },
+    });
+  });
+
+  test('uses Response.status for redirect-style handlers', async () => {
+    let now = 0;
+    const tracker = createMetricsTracker({ startedAtMs: 0, nowMs: () => now });
+    const app = new Elysia()
+      .use(createMetricsLifecycle(tracker))
+      .get('/redirect', () => { now += 5; return new Response(null, { status: 302 }); });
+
+    const res = await app.handle(new Request('http://local/redirect'));
+
+    expect(res.status).toBe(302);
+    expect(tracker.snapshot()).toMatchObject({
+      requestCount: 1,
+      avgResponseMs: 5,
+      statusCounts: { '3xx': 1 },
+      methodCounts: { GET: 1 },
+    });
+  });
+
+  test('non-finite clocks do not poison snapshots or counters', () => {
+    let now = Number.NaN;
+    const tracker = createMetricsTracker({ startedAtMs: Number.POSITIVE_INFINITY, nowMs: () => now });
+    const req = new Request('http://local/work', { method: 'PATCH' });
+
+    tracker.begin(req);
+    now = Number.NEGATIVE_INFINITY;
+    tracker.end(req, 204);
+
+    expect(tracker.snapshot()).toMatchObject({
+      uptime: 0,
+      requestCount: 1,
+      avgResponseMs: 0,
+      lastResponseMs: 0,
+      maxResponseMs: 0,
+      statusCounts: { '2xx': 1 },
+      methodCounts: { PATCH: 1 },
+    });
+  });
+});
+
+describe('health rollup observability edges', () => {
+  test('degrades aggregate health when embedded vector health is down', async () => {
+    const app = createHealthRoutes({
+      dbPing: () => ({ status: 'connected' }),
+      pluginCount: 0,
+      vectorHealth: async () => ({ status: 'down', checked_at: 'now', engines: [], error: 'offline' }),
+      vectorServerHealth: async () => ({ configured: false, status: 'unconfigured' }),
+    });
+
+    const res = await app.handle(new Request('http://local/api/health'));
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(body.vectorStatus).toBe('down');
+    expect(body.vectorServer.status).toBe('unconfigured');
+    expect(body.status).toBe(body.vectorMode === 'disabled' ? 'ok' : 'degraded');
+  });
+});


### PR DESCRIPTION
## Summary
- harden metrics tracker status/method/error counters and response timing snapshots
- add health rollup handling for vector-down edge cases
- extend metrics HTTP tests for counters, timings, non-finite clocks, and rollup behavior

## Tests
- bunx tsc --noEmit
- bun test tests/http/metrics/
- bun test tests/http/health/

## Notes
- files checked <= 250 lines
- PR targets alpha, not main