### PR TITLE
docs: verify CLI guide and README surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ claude mcp list              # expect connected; tools/list exposes 27 tools
 Useful checks:
 ```bash
 curl -sf http://localhost:47778/api/health
-bun run src/cli/index.ts health
+bun cli/src/cli.ts health
 ```
 
 Run the React Studio UI:
@@ -69,7 +69,7 @@ docker run --rm -p 47778:47778 -v arra-data:/data \
 | Runtime plug-in/out | Unified manifests enable/disable CLI, menu/API, MCP, proxy, server, export-format, and lifecycle surfaces without forks. |
 | MCP memory tools | 27 tools: `____IMPORTANT` plus 26 `oracle_*`, including `oracle_research_note`, `oracle_profile`, and `oracle_trace_distill`. |
 | Memory confidence + supersede | Confidence receipts, reversible supersede chains, trace context, and async dry-run consolidation preserve history while deduping. |
-| HTTP API | Elysia route clusters under `/api/*`, with health, search, knowledge, vector, menu, plugins, canvas, federation, tenants, and settings surfaces. |
+| HTTP API | Elysia route clusters under `/api/*`, with health, search, knowledge, vector, menu, plugins, canvas, tenants, settings, and opt-in federation surfaces. |
 | Vector search | Configurable providers, LanceDB/local stores, proxy services, export formats, status/config APIs, and FTS fallback paths. |
 | maw-js `arra` plugin | `maw arra ...` gives CLI/API/menu access to ARRA verbs, maintenance commands, vector config/health, and server controls. |
 | Edge/cloud deploy | Cloudflare Workers remote MCP/canvas/studio/federation shapes, Vercel Studio proxy, Docker, and local Bun modes. |
@@ -110,23 +110,23 @@ Common endpoints:
 
 ```text
 GET  /api/health
-GET  /api/search?q=oracle&mode=fts
-POST /api/learn
-GET  /api/vector/config
+GET  /api/v1/search?q=oracle&mode=fts
+POST /api/v1/learn
+GET  /api/v1/vector/config
 GET  /api/v1/vector/status
-GET  /api/plugins
-GET  /api/menu
-GET  /api/canvas/plugins
+GET  /api/v1/plugins
+GET  /api/v1/menu
+GET  /api/v1/canvas/plugins
 ```
 
 Optional auth/tenant controls:
 
 ```bash
-export ARRA_API_TOKEN=secret                 # bearer token for protected writes
+export ARRA_API_TOKEN=secret                 # bearer token for protected API calls
 export ORACLE_TENANT_TOKENS='acme=secret,*=dev'
-curl -H 'X-Oracle-Tenant: acme' -H 'X-Oracle-Tenant-Token: secret' \
-  http://localhost:47778/api/search?q=team
-# Aliases accepted: X-Tenant-ID, X-Org-Id, X-API-Key.
+curl -H 'Authorization: Bearer secret' -H 'X-Oracle-Tenant: acme' \
+  -H 'X-Oracle-Tenant-Token: secret' http://localhost:47778/api/v1/search?q=team
+# Tenant ID aliases: X-Tenant-ID, X-Org-Id; X-API-Key can map tenant keys.
 ```
 
 ## Vector backends and export

--- a/docs/API-REFERENCE-INDEX.md
+++ b/docs/API-REFERENCE-INDEX.md
@@ -41,9 +41,9 @@ curl -H 'X-Oracle-Tenant: team-a' \
 | --- | --- | --- |
 | Health, stats, dashboard | `/api/health`, `/api/stats`, `/api/dashboard` | [http-api-reference.md](./http-api-reference.md#health-metrics-dashboard) |
 | Search and memory | `/api/search`, `/api/list`, `/api/memory/*` | [http-api-reference.md](./http-api-reference.md#search-knowledge-learn-memory) |
-| Vector and indexer | `/api/vector/*`, `/api/indexer/*`, `/api/map` | [API.md](./API.md#vector-api) |
-| Menu and plugins | `/api/menu`, `/api/plugins`, `/api/canvas/*` | [API.md](./API.md#menu-api) |
-| MCP catalogue | `/api/mcp/tools` | [API.md](./API.md#mcp-tool-listing-api) |
+| Vector and indexer | `/api/vector/*`, `/api/indexer/*`, `/api/map` | [API.md](./API.md#vector-config-and-indexing) |
+| Menu and plugins | `/api/menu`, `/api/plugins`, `/api/canvas/*` | [API.md](./API.md#menu-and-plugin-state) |
+| MCP catalogue | `/api/mcp/tools` | [API.md](./API.md#mcp-tool-catalogue) |
 | Export/import | `/api/export/*`, `/api/vector/export/*` | [http-api-reference.md](./http-api-reference.md#vector-and-indexer) |
 | Collaboration | `/api/traces`, `/api/supersede`, `/api/schedule` | [http-api-reference.md](./http-api-reference.md#collaboration-social-traces-schedule) |
 | Federation mesh | `/api/federation/status`, `/api/federation/capabilities`, `/api/federation/mesh/nodes` | [FEDERATION.md](./FEDERATION.md) |

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -142,17 +142,17 @@ show 27 core tools before plugin tools.
 
 ## 5. HTTP API quick calls
 
-Canonical API paths are `/api/v1/*`; legacy `/api/*` paths usually redirect.
-Infrastructure endpoints `/api/health` and `/api/docs` stay unversioned.
+Canonical API paths are `/api/v1/*`; legacy `/api/*` paths 308 redirect in the
+running server. `/api/health` is direct; `/api/docs` redirects to `/api/v1/docs`.
 
 ```bash
 curl -sf http://localhost:47778/api/health
 curl -s 'http://localhost:47778/api/v1/search?q=oracle&limit=5'
 curl -s 'http://localhost:47778/api/v1/vector/export?collection=bge-m3&format=jsonl'
-curl -s -X POST http://localhost:47778/api/ask \
+curl -s -X POST http://localhost:47778/api/v1/ask \
   -H 'content-type: application/json' \
   -d '{"q":"What changed in the memory pipeline?","limit":5}'
-open http://localhost:47778/api/docs
+open http://localhost:47778/api/v1/docs
 ```
 
 When `ARRA_API_TOKEN` is set, protected `/api/*` calls need
@@ -224,7 +224,7 @@ Set `TUNNEL_URL` and `FEDERATION_TOKEN` for federation. See
 - **CLI cannot reach server:** start `bun run server` or set `ORACLE_API` / `arra --at`.
 - **MCP proxy fails:** `ORACLE_HTTP_URL` must point at a healthy backend; match `ARRA_API_TOKEN`.
 - **Different data per surface:** set the same `ORACLE_DATA_DIR` for HTTP, MCP, CLI, and Docker.
-- **Versioned route surprise:** use `/api/v1/*` except `/api/health` and `/api/docs`.
+- **Versioned route surprise:** use `/api/v1/*`; `/api/health` is direct and `/api/docs` redirects.
 - **Workers cannot open SQLite/LanceDB:** Workers are edge proxies; keep DB/vector files on the origin.
 - **Vector unavailable:** FTS search still works; configure vector later with `arra vector-config`.
 - **Secrets in git:** never commit real tokens, origin URLs, or Cloudflare credentials.


### PR DESCRIPTION
## Summary
- Correct README quick-check CLI invocation and canonical API v1 endpoint examples.
- Clarify protected API bearer auth, tenant header aliases, and opt-in federation wording.
- Update CLI guide docs endpoint/versioning examples and repair API reference index anchors.

## Verification
- rtk bunx tsc --noEmit
- rtk bun test tests/docs tests/cli/bin/arra.test.ts tests/cli/config tests/cli/help tests/cli/vector-config tests/cli/export tests/http/docs tests/http/health/unversioned.test.ts tests/http/security/auth-and-cors.test.ts tests/http/tenant/auth.test.ts tests/http/canvas
- rtk git diff --check
- wc -l README.md docs/CLI-GUIDE.md docs/API-REFERENCE-INDEX.md