### PR TITLE
fix(oracles): harden profile and reflect fallbacks

### DIFF
--- a/src/oracles/principles.ts
+++ b/src/oracles/principles.ts
@@ -1,0 +1,51 @@
+import { listOracleProfiles, type OracleProfileSource } from './registry.ts';
+import type { OracleProfile } from './model.ts';
+
+export interface OracleProfilePrinciple {
+  id: string;
+  type: 'principle';
+  content: string;
+  source_file: string;
+  concepts: string[];
+  profile: Pick<OracleProfile, 'id' | 'slug' | 'name'>;
+}
+
+interface RandomPrincipleOptions {
+  profiles?: OracleProfileSource;
+  random?: () => number;
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
+}
+
+function profileConcepts(profile: OracleProfile): string[] {
+  return uniqueStrings([profile.id, profile.slug, profile.theme, ...profile.defaultConcepts]);
+}
+
+function randomIndex(length: number, random: () => number): number {
+  const value = random();
+  const safeValue = Number.isFinite(value) ? value : 0;
+  return Math.min(length - 1, Math.max(0, Math.floor(Math.max(0, safeValue) * length)));
+}
+
+export function randomProfilePrinciple(options: RandomPrincipleOptions = {}): OracleProfilePrinciple | undefined {
+  const candidates = listOracleProfiles(options.profiles).flatMap((profile) => (
+    profile.principles.map((content, index) => ({ profile, content, index }))
+  ));
+  if (!candidates.length) return undefined;
+  const random = options.random ?? Math.random;
+  const candidate = candidates[randomIndex(candidates.length, random)];
+  return {
+    id: `${candidate.profile.slug}-profile-principle-${candidate.index + 1}`,
+    type: 'principle',
+    content: candidate.content,
+    source_file: `oracle-profile://${candidate.profile.slug}`,
+    concepts: profileConcepts(candidate.profile),
+    profile: {
+      id: candidate.profile.id,
+      slug: candidate.profile.slug,
+      name: candidate.profile.name,
+    },
+  };
+}

--- a/src/oracles/registry.ts
+++ b/src/oracles/registry.ts
@@ -1,7 +1,27 @@
 import { thorOracleProfile } from './thor.ts';
-import type { OracleProfile } from './model.ts';
+import type { OracleCapability, OracleProfile } from './model.ts';
 
-const profiles = [thorOracleProfile] as const satisfies readonly OracleProfile[];
+const codeBackedProfiles: readonly unknown[] = [thorOracleProfile];
+const REQUIRED_STRINGS = ['id', 'slug', 'name', 'role', 'theme', 'born', 'motto'] as const;
+const ARRAY_FIELDS = ['principles', 'workflows', 'defaultConcepts'] as const;
+
+export interface OracleProfileIssue {
+  index: number;
+  id?: string;
+  slug?: string;
+  reason: string;
+}
+
+export interface OracleProfileCatalog {
+  profiles: OracleProfile[];
+  invalidProfiles: OracleProfileIssue[];
+}
+
+export type OracleProfileSource = readonly unknown[];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
 
 function key(value: string): string {
   return value
@@ -10,6 +30,80 @@ function key(value: string): string {
     .replace(/[_-]+/g, ' ')
     .replace(/\s+/g, ' ')
     .toLowerCase();
+}
+
+function readString(record: Record<string, unknown>, field: string, errors: string[]): string {
+  const value = record[field];
+  if (typeof value === 'string' && value.trim()) return value.trim();
+  errors.push(`${field} must be a non-empty string`);
+  return '';
+}
+
+function readStringArray(record: Record<string, unknown>, field: string, errors: string[]): string[] {
+  const value = record[field];
+  if (!Array.isArray(value)) {
+    errors.push(`${field} must be an array`);
+    return [];
+  }
+  const items = value.filter((item): item is string => typeof item === 'string').map((item) => item.trim()).filter(Boolean);
+  if (items.length !== value.length) errors.push(`${field} must contain only non-empty strings`);
+  if (field === 'principles' && items.length === 0) errors.push('principles must contain at least one string');
+  return items;
+}
+
+function readCapabilities(value: unknown, errors: string[]): OracleCapability[] {
+  if (!Array.isArray(value)) {
+    errors.push('capabilities must be an array');
+    return [];
+  }
+  const capabilities: OracleCapability[] = [];
+  value.forEach((item, index) => {
+    if (!isRecord(item)) {
+      errors.push(`capabilities[${index}] must be an object`);
+      return;
+    }
+    const capErrors: string[] = [];
+    const id = readString(item, 'id', capErrors);
+    const label = readString(item, 'label', capErrors);
+    const description = readString(item, 'description', capErrors);
+    if (capErrors.length) errors.push(`capabilities[${index}]: ${capErrors.join(', ')}`);
+    else capabilities.push({ id, label, description });
+  });
+  return capabilities;
+}
+
+function profileIssue(index: number, value: unknown, reason: string): OracleProfileIssue {
+  const record = isRecord(value) ? value : {};
+  return {
+    index,
+    ...(typeof record.id === 'string' ? { id: record.id } : {}),
+    ...(typeof record.slug === 'string' ? { slug: record.slug } : {}),
+    reason,
+  };
+}
+
+function normalizeProfile(value: unknown, index: number): OracleProfile | OracleProfileIssue {
+  if (!isRecord(value)) return profileIssue(index, value, 'profile must be an object');
+  const errors: string[] = [];
+  const base = Object.fromEntries(REQUIRED_STRINGS.map((field) => [field, readString(value, field, errors)]));
+  const arrays = Object.fromEntries(ARRAY_FIELDS.map((field) => [field, readStringArray(value, field, errors)]));
+  const capabilities = readCapabilities(value.capabilities, errors);
+  if (value.human !== undefined && typeof value.human !== 'string') errors.push('human must be a string');
+  if (errors.length) return profileIssue(index, value, errors.join('; '));
+  return cloneProfile({
+    id: base.id,
+    slug: base.slug,
+    name: base.name,
+    role: base.role,
+    theme: base.theme,
+    born: base.born,
+    ...(typeof value.human === 'string' && value.human.trim() ? { human: value.human.trim() } : {}),
+    motto: base.motto,
+    principles: arrays.principles,
+    capabilities,
+    workflows: arrays.workflows,
+    defaultConcepts: arrays.defaultConcepts,
+  });
 }
 
 function cloneProfile(profile: OracleProfile): OracleProfile {
@@ -31,14 +125,24 @@ function aliases(profile: OracleProfile): string[] {
   ];
 }
 
-export function listOracleProfiles(): OracleProfile[] {
-  return profiles.map(cloneProfile);
+export function listOracleProfileCatalog(source: OracleProfileSource = codeBackedProfiles): OracleProfileCatalog {
+  const catalog: OracleProfileCatalog = { profiles: [], invalidProfiles: [] };
+  source.forEach((raw, index) => {
+    const profile = normalizeProfile(raw, index);
+    if ('reason' in profile) catalog.invalidProfiles.push(profile);
+    else catalog.profiles.push(profile);
+  });
+  catalog.profiles.sort((left, right) => left.slug.localeCompare(right.slug));
+  return catalog;
 }
 
-export function getOracleProfile(slugOrId: unknown): OracleProfile | undefined {
+export function listOracleProfiles(source?: OracleProfileSource): OracleProfile[] {
+  return listOracleProfileCatalog(source).profiles;
+}
+
+export function getOracleProfile(slugOrId: unknown, source?: OracleProfileSource): OracleProfile | undefined {
   if (typeof slugOrId !== 'string') return undefined;
   const requested = key(slugOrId);
   if (!requested) return undefined;
-  const profile = profiles.find((item) => aliases(item).map(key).includes(requested));
-  return profile ? cloneProfile(profile) : undefined;
+  return listOracleProfiles(source).find((item) => aliases(item).map(key).includes(requested));
 }

--- a/src/routes/profile/index.ts
+++ b/src/routes/profile/index.ts
@@ -1,6 +1,10 @@
 import { Elysia, t } from 'elysia';
-import { getOracleProfile, listOracleProfiles } from '../../oracles/registry.ts';
+import { getOracleProfile, listOracleProfileCatalog, type OracleProfileSource } from '../../oracles/registry.ts';
 import type { OracleProfile } from '../../oracles/model.ts';
+
+interface OracleProfilesEndpointOptions {
+  profiles?: OracleProfileSource;
+}
 
 function oracleCapabilitySchema() {
   return t.Object({
@@ -27,39 +31,58 @@ export function oracleProfileSchema() {
   });
 }
 
+function issueSchema() {
+  return t.Object({
+    index: t.Number(),
+    id: t.Optional(t.String()),
+    slug: t.Optional(t.String()),
+    reason: t.String(),
+  });
+}
+
 function profileChoice(profile: OracleProfile) {
   return { id: profile.id, slug: profile.slug, name: profile.name };
 }
 
-function sortedProfiles(): OracleProfile[] {
-  return listOracleProfiles().sort((left, right) => left.slug.localeCompare(right.slug));
+function catalog(options: OracleProfilesEndpointOptions) {
+  return listOracleProfileCatalog(options.profiles);
+}
+
+function withIssues<T extends Record<string, unknown>>(body: T, invalidProfiles: unknown[]) {
+  return invalidProfiles.length ? { ...body, invalidProfiles } : body;
 }
 
 function profilesResponseSchema() {
-  return t.Object({ profiles: t.Array(oracleProfileSchema()), total: t.Number() });
+  return t.Object({
+    profiles: t.Array(oracleProfileSchema()),
+    total: t.Number(),
+    invalidProfiles: t.Optional(t.Array(issueSchema())),
+  });
 }
 
 const notFoundSchema = t.Object({
   error: t.String(),
   requested: t.String(),
   profiles: t.Array(t.Object({ id: t.String(), slug: t.String(), name: t.String() })),
+  invalidProfiles: t.Optional(t.Array(issueSchema())),
 });
 
-export function createOracleProfilesEndpoint() {
+export function createOracleProfilesEndpoint(options: OracleProfilesEndpointOptions = {}) {
   return new Elysia()
     .get('/oracles/profiles', () => {
-      const profiles = sortedProfiles();
-      return { profiles, total: profiles.length };
+      const { profiles, invalidProfiles } = catalog(options);
+      return withIssues({ profiles, total: profiles.length }, invalidProfiles);
     }, {
       response: profilesResponseSchema(),
       detail: { tags: ['health'], menu: { group: 'hidden' }, summary: 'List code-backed Oracle profiles' },
     })
     .get('/oracles/profiles/:slug', ({ params, set }) => {
       const requested = params.slug.trim();
-      const profile = getOracleProfile(requested);
+      const profile = getOracleProfile(requested, options.profiles);
       if (!profile) {
+        const { profiles, invalidProfiles } = catalog(options);
         set.status = 404;
-        return { error: 'Oracle profile not found', requested: params.slug, profiles: sortedProfiles().map(profileChoice) };
+        return withIssues({ error: 'Oracle profile not found', requested: params.slug, profiles: profiles.map(profileChoice) }, invalidProfiles);
       }
       return profile;
     }, {

--- a/src/routes/search/reflect.ts
+++ b/src/routes/search/reflect.ts
@@ -6,8 +6,16 @@ import { Elysia } from 'elysia';
 import { isDbLockError, sqlite } from '../../db/index.ts';
 import { parseConcepts } from '../../search/query.ts';
 import { handleTenantReflect } from './tenant-search.ts';
+import { randomProfilePrinciple } from '../../oracles/principles.ts';
 
 type ReflectRow = { id: string; type: string; source_file: string; concepts: string | null; content: string | null };
+
+export function emptyKnowledgeReflectResponse(): Record<string, unknown> {
+  const fallback = randomProfilePrinciple();
+  return fallback
+    ? { ...fallback, error: 'No documents found', fts_status: 'empty', fallback: 'oracle_profile' }
+    : { error: 'No documents found', fts_status: 'empty' };
+}
 
 function handleGlobalReflect(): Record<string, unknown> {
   try {
@@ -20,7 +28,7 @@ function handleGlobalReflect(): Record<string, unknown> {
       LIMIT 1
     `).get() as ReflectRow | undefined;
 
-    if (!row) return { error: 'No documents found', fts_status: 'empty' };
+    if (!row) return emptyKnowledgeReflectResponse();
     const base = {
       id: row.id,
       type: row.type,

--- a/src/routes/search/tenant-search.ts
+++ b/src/routes/search/tenant-search.ts
@@ -5,6 +5,7 @@ import { isoTimestamp } from '../../search/timestamp.ts';
 import { logDocumentAccess } from '../../server/logging.ts';
 import type { SearchResponse } from '../../server/types.ts';
 import { buildTenantFtsQuery, parseConcepts } from '../../search/query.ts';
+import { randomProfilePrinciple } from '../../oracles/principles.ts';
 
 type SearchRouteResponse = SearchResponse & { mode: string; warning?: string; vectorAvailable: boolean };
 type ListRow = Record<string, any>;
@@ -130,7 +131,12 @@ export function handleTenantReflect(): Record<string, unknown> | null {
     LIMIT 1
   `).get(tenantId) as ListRow | undefined;
 
-  if (!row) return { error: 'No documents found', fts_status: 'empty' };
+  if (!row) {
+    const fallback = randomProfilePrinciple();
+    return fallback
+      ? { ...fallback, error: 'No documents found', fts_status: 'empty', fallback: 'oracle_profile' }
+      : { error: 'No documents found', fts_status: 'empty' };
+  }
   if (!row.content) {
     return {
       error: 'Document content not found in FTS index',

--- a/src/tools/oracle.ts
+++ b/src/tools/oracle.ts
@@ -1,4 +1,4 @@
-import { getOracleProfile, listOracleProfiles } from '../oracles/registry.ts';
+import { getOracleProfile, listOracleProfileCatalog } from '../oracles/registry.ts';
 import { handleLearn } from './learn.ts';
 import { buildResearchNoteLearning } from '../research/note.ts';
 import type { DistillTraceInput } from '../trace/types.ts';
@@ -63,7 +63,14 @@ export const oracleResearchNoteToolDef = {
 };
 
 export function handleOracleProfile(input: { id?: string }): ToolResponse {
-  if (!input?.id) return text({ profiles: listOracleProfiles(), total: listOracleProfiles().length });
+  const catalog = listOracleProfileCatalog();
+  if (!input?.id) {
+    return text({
+      profiles: catalog.profiles,
+      total: catalog.profiles.length,
+      ...(catalog.invalidProfiles.length ? { invalidProfiles: catalog.invalidProfiles } : {}),
+    });
+  }
   const profile = getOracleProfile(input.id);
   return profile ? text(profile) : text({ success: false, error: `Oracle profile not found: ${input.id}` }, true);
 }

--- a/src/tools/reflect.ts
+++ b/src/tools/reflect.ts
@@ -7,6 +7,8 @@
 import { and, eq, sql, inArray } from 'drizzle-orm';
 import { oracleDocuments } from '../db/schema.ts';
 import { currentTenantId } from '../middleware/tenant.ts';
+import { randomProfilePrinciple } from '../oracles/principles.ts';
+import { parseConcepts } from '../search/query.ts';
 import type { ToolContext, ToolResponse, OracleReflectInput } from './types.ts';
 
 export const reflectToolDef = {
@@ -17,6 +19,10 @@ export const reflectToolDef = {
     properties: {}
   }
 };
+
+function text(payload: unknown): ToolResponse {
+  return { content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }] };
+}
 
 export async function handleReflect(ctx: ToolContext, _input: OracleReflectInput): Promise<ToolResponse> {
   const tenantId = currentTenantId();
@@ -34,7 +40,9 @@ export async function handleReflect(ctx: ToolContext, _input: OracleReflectInput
     .get();
 
   if (!randomDoc) {
-    throw new Error('No documents found in Oracle knowledge base');
+    const fallback = randomProfilePrinciple();
+    if (!fallback) throw new Error('No documents found in Oracle knowledge base');
+    return text({ principle: fallback, knowledge_base_status: 'empty', fallback: 'oracle_profile' });
   }
 
   const content = ctx.sqlite.prepare(`
@@ -54,7 +62,7 @@ export async function handleReflect(ctx: ToolContext, _input: OracleReflectInput
           type: randomDoc.type,
           content: content.content,
           source_file: randomDoc.sourceFile,
-          concepts: JSON.parse(randomDoc.concepts || '[]')
+          concepts: parseConcepts(randomDoc.concepts)
         }
       }, null, 2)
     }]

--- a/tests/http/profile/oracle-profile.test.ts
+++ b/tests/http/profile/oracle-profile.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { Elysia } from 'elysia';
 import { createOracleProfilesEndpoint } from '../../../src/routes/profile/index.ts';
+import { thorOracleProfile } from '../../../src/oracles/thor.ts';
 
 function createApp() {
   return new Elysia({ prefix: '/api' }).use(createOracleProfilesEndpoint());
@@ -34,6 +35,31 @@ describe('oracle profile HTTP routes', () => {
     expect(profile.id).toBe('thor-oracle');
     expect(fresh.id).toBe('thor-oracle');
     expect(fresh.principles).not.toContain('mutated response copy');
+  });
+
+
+  test('GET /api/oracles/profiles skips malformed code-backed profiles with diagnostics', async () => {
+    const malformed = { id: 'broken-oracle', slug: 'broken', name: 'Broken Oracle', principles: 'nope' };
+    const app = new Elysia({ prefix: '/api' }).use(createOracleProfilesEndpoint({ profiles: [malformed, thorOracleProfile] }));
+    const res = await app.handle(new Request('http://local/api/oracles/profiles'));
+    const body = await res.json() as {
+      profiles: Array<{ slug: string }>;
+      total: number;
+      invalidProfiles: Array<{ id?: string; slug?: string; reason: string }>;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.total).toBe(1);
+    expect(body.profiles.map((profile) => profile.slug)).toEqual(['thor']);
+    expect(body.invalidProfiles).toHaveLength(1);
+    expect(body.invalidProfiles[0]).toMatchObject({ id: 'broken-oracle', slug: 'broken' });
+    expect(body.invalidProfiles[0].reason).toContain('principles must be an array');
+
+    const missing = await app.handle(new Request('http://local/api/oracles/profiles/broken'));
+    const missingBody = await missing.json() as { profiles: Array<{ slug: string }>; invalidProfiles: unknown[] };
+    expect(missing.status).toBe(404);
+    expect(missingBody.profiles.map((profile) => profile.slug)).toEqual(['thor']);
+    expect(missingBody.invalidProfiles).toHaveLength(1);
   });
 
   test('GET /api/oracles/profiles/:slug reports requested id and valid choices on 404', async () => {

--- a/tests/http/profile/reflect-empty-kb.test.ts
+++ b/tests/http/profile/reflect-empty-kb.test.ts
@@ -1,0 +1,43 @@
+import { afterAll, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const root = mkdtempSync(join(tmpdir(), 'profile-reflect-empty-'));
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = join(root, 'oracle.db');
+
+const dbMod = await import('../../../src/db/index.ts');
+dbMod.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+const { searchRoutes } = await import('../../../src/routes/search/index.ts');
+
+afterAll(() => {
+  if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = savedDataDir;
+  if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = savedDbPath;
+  dbMod.resetDefaultDatabaseForTests(':memory:');
+  if (existsSync(root)) rmSync(root, { recursive: true });
+});
+
+test('/api/reflect falls back to a code-backed profile principle when the KB is empty', async () => {
+  const res = await searchRoutes.handle(new Request('http://local/api/reflect'));
+  const body = await res.json() as {
+    error: string;
+    fallback: string;
+    fts_status: string;
+    content: string;
+    source_file: string;
+    profile: { slug: string };
+    concepts: string[];
+  };
+
+  expect(res.status).toBe(200);
+  expect(body).toMatchObject({ error: 'No documents found', fallback: 'oracle_profile', fts_status: 'empty' });
+  expect(body.content.length).toBeGreaterThan(10);
+  expect(body.source_file).toBe('oracle-profile://thor');
+  expect(body.profile.slug).toBe('thor');
+  expect(body.concepts).toContain('thor-oracle');
+});


### PR DESCRIPTION
## Summary\n- validate code-backed oracle profiles and surface invalid profile diagnostics without breaking listings\n- add code-backed profile principle fallback for empty-KB reflect/random-principle flows\n- harden profile MCP listing and reflect concept parsing\n\n## Tests\n- bunx tsc --noEmit\n- rtk test bun test tests/http/profile\n- rtk test bun test tests/http/stats/health-states.test.ts tests/http/search/tenant-routes.test.ts src/oracles/__tests__/registry.test.ts src/tools/__tests__/oracle-profile.test.ts\n\nBase: alpha