### PR TITLE
feat(db): add memory valid-time windows

### DIFF
--- a/src/db/migrations/0033_memory_valid_time.sql
+++ b/src/db/migrations/0033_memory_valid_time.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `oracle_memories` ADD `valid_from` integer;--> statement-breakpoint
+ALTER TABLE `oracle_memories` ADD `valid_to` integer;--> statement-breakpoint
+CREATE INDEX `idx_memory_tenant_valid_time`
+ON `oracle_memories` (`tenant_id`,`valid_from`,`valid_to`);

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1781669499599,
       "tag": "0032_schema_integrity_guards",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "6",
+      "when": 1781686800000,
+      "tag": "0033_memory_valid_time",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -45,6 +45,8 @@ export const oracleMemories = sqliteTable('oracle_memories', {
   title: text('title'),
   tags: text('tags').default('[]').notNull(),
   source: text('source'),
+  validFrom: integer('valid_from'),
+  validTo: integer('valid_to'),
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
 }, (table) => [
@@ -52,6 +54,7 @@ export const oracleMemories = sqliteTable('oracle_memories', {
   index('idx_memory_title').on(table.title),
   index('idx_memory_source').on(table.source),
   index('idx_memory_tenant_created').on(table.tenantId, table.createdAt),
+  index('idx_memory_tenant_valid_time').on(table.tenantId, table.validFrom, table.validTo),
 ]);
 // Indexing status tracking
 export const indexingStatus = sqliteTable('indexing_status', {

--- a/src/routes/memory/index.ts
+++ b/src/routes/memory/index.ts
@@ -1,7 +1,7 @@
 import { Elysia } from 'elysia';
 import { MemoryCloseoutBody, MorningTapeQuery, RecallMemoryQuery, SaveMemoryBody, SemanticMemoryQuery, parseMemoryLimit } from './model.ts';
 import { createMemoryFanoutEndpoint } from './fanout.ts';
-import { memoryStore, type MemoryInput, type MemoryRecord, type MemoryStore } from './store.ts';
+import { memoryStore, parseValidTime, type MemoryInput, type MemoryRecord, type MemoryStore } from './store.ts';
 import { memoryVectorIndex, type MemoryVectorHit, type MemoryVectorIndex } from './vector.ts';
 import { buildMorningTape } from './morning-tape.ts';
 import { MEMORY_CONFIDENCE_STRATEGY, memoryConfidence } from './confidence.ts';
@@ -51,10 +51,14 @@ export function createMemoryRoutes(
       query: MorningTapeQuery,
       detail: { tags: ['memory'], menu: { group: 'hidden' }, summary: 'Render a two-minute morning recovery tape from persisted memories' },
     })
-    .get('/memory/recall', ({ query }) => {
+    .get('/memory/recall', ({ query, set }) => {
       const limit = parseMemoryLimit(query.limit);
-      const items = store.recall(query.q ?? '', limit);
-      return { query: query.q ?? '', total: items.length, confidence: MEMORY_CONFIDENCE_STRATEGY, items: items.map(withKeywordConfidence) };
+      try {
+        const items = store.recall(query.q ?? '', limit, query.asOf);
+        return { query: query.q ?? '', asOf: isoAsOf(query.asOf), total: items.length, confidence: MEMORY_CONFIDENCE_STRATEGY, items: items.map(withKeywordConfidence) };
+      } catch (error) {
+        return invalidAsOf(set, error);
+      }
     }, {
       query: RecallMemoryQuery,
       detail: { tags: ['memory'], menu: { group: 'hidden' }, summary: 'Recall persisted memories by keyword' },
@@ -66,18 +70,29 @@ export function createMemoryRoutes(
       }
       const limit = parseMemoryLimit(query.limit);
       try {
+        isoAsOf(query.asOf);
         const hits = await vectorIndex.search(query.q, limit);
-        const records = store.getByIds(hits.map((hit) => hit.memoryId));
+        const records = store.getByIds(hits.map((hit) => hit.memoryId), query.asOf);
         const results = mergeHits(hits, records);
-        return { success: true, query: query.q, total: results.length, confidence: MEMORY_CONFIDENCE_STRATEGY, results };
+        return { success: true, query: query.q, asOf: isoAsOf(query.asOf), total: results.length, confidence: MEMORY_CONFIDENCE_STRATEGY, results };
       } catch (error) {
-        set.status = 503;
-        return { success: false, error: error instanceof Error ? error.message : 'memory vector search failed', results: [] };
+        const message = error instanceof Error ? error.message : 'memory vector search failed';
+        set.status = message.includes('valid-time') ? 400 : 503;
+        return { success: false, error: message, results: [] };
       }
     }, {
       query: SemanticMemoryQuery,
       detail: { tags: ['memory'], menu: { group: 'hidden' }, summary: 'Search memories by vector similarity' },
     });
+}
+
+function isoAsOf(value: string | undefined): string | undefined {
+  return value ? new Date(parseValidTime(value)!).toISOString() : undefined;
+}
+
+function invalidAsOf(set: { status?: number | string }, error: unknown) {
+  set.status = 400;
+  return { success: false, error: error instanceof Error ? error.message : 'invalid valid-time timestamp' };
 }
 
 function mergeHits(hits: MemoryVectorHit[], records: MemoryRecord[]) {
@@ -122,6 +137,8 @@ function memoryForHit(hit: MemoryVectorHit, record?: MemoryRecord): MemoryRecord
     source: metadataText(hit.metadata.source ?? hit.metadata.source_file),
     createdAt,
     updatedAt: metadataText(hit.metadata.updatedAt) ?? createdAt,
+    validFrom: metadataText(hit.metadata.validFrom ?? hit.metadata.valid_from),
+    validTo: metadataText(hit.metadata.validTo ?? hit.metadata.valid_to),
   };
 }
 

--- a/src/routes/memory/model.ts
+++ b/src/routes/memory/model.ts
@@ -5,6 +5,8 @@ export const SaveMemoryBody = t.Object({
   title: t.Optional(t.String()),
   tags: t.Optional(t.Array(t.String())),
   source: t.Optional(t.String()),
+  validFrom: t.Optional(t.Union([t.String(), t.Number()])),
+  validTo: t.Optional(t.Union([t.String(), t.Number(), t.Null()])),
 });
 
 export const MemoryCloseoutBody = t.Object({
@@ -19,11 +21,13 @@ export const MemoryCloseoutBody = t.Object({
 export const RecallMemoryQuery = t.Object({
   q: t.Optional(t.String()),
   limit: t.Optional(t.String()),
+  asOf: t.Optional(t.String()),
 });
 
 export const SemanticMemoryQuery = t.Object({
   q: t.Optional(t.String()),
   limit: t.Optional(t.String()),
+  asOf: t.Optional(t.String()),
 });
 
 export const MorningTapeQuery = t.Object({

--- a/src/routes/memory/store.ts
+++ b/src/routes/memory/store.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, like, or, type SQL } from 'drizzle-orm';
+import { and, desc, eq, inArray, like, or, sql, type SQL } from 'drizzle-orm';
 import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 import { db as defaultDb, oracleMemories } from '../../db/index.ts';
 import { currentTenantId, tenantIdForWrite } from '../../middleware/tenant.ts';
@@ -10,6 +10,8 @@ export type MemoryInput = {
   title?: string;
   tags?: string[];
   source?: string;
+  validFrom?: string | number;
+  validTo?: string | number | null;
 };
 
 export type MemoryRecord = MemoryInput & {
@@ -19,6 +21,8 @@ export type MemoryRecord = MemoryInput & {
   updatedAt: string;
   usageCount?: number;
   lastAccessedAt?: string;
+  validFrom?: string;
+  validTo?: string;
 };
 
 type OracleDb = BunSQLiteDatabase<typeof schema>;
@@ -35,6 +39,9 @@ export class MemoryStore {
     const content = input.content.trim();
     if (!content) throw new Error('memory content is required');
     const now = Date.now();
+    const validFrom = parseValidTime(input.validFrom);
+    const validTo = parseValidTime(input.validTo);
+    if (validFrom && validTo && validTo <= validFrom) throw new Error('valid_to must be after valid_from');
     const row = this.db.insert(oracleMemories).values({
       id: `mem_${now.toString(36)}_${crypto.randomUUID().slice(0, 8)}`,
       tenantId: tenantIdForWrite(),
@@ -42,16 +49,18 @@ export class MemoryStore {
       title: input.title?.trim() || null,
       tags: JSON.stringify(cleanTags(input.tags)),
       source: input.source?.trim() || null,
+      validFrom: validFrom ?? null,
+      validTo: validTo ?? null,
       createdAt: now,
       updatedAt: now,
     }).returning().get();
     return memoryFromRow(row);
   }
 
-  recall(query = '', limit = 10): MemoryRecord[] {
+  recall(query = '', limit = 10, asOf?: string | number): MemoryRecord[] {
     const normalized = query.trim();
     const safeLimit = parseMemoryLimit(limit);
-    const where = combineWhere(tenantWhere(), searchWhere(normalized));
+    const where = combineWhere(tenantWhere(), searchWhere(normalized), asOfWhere(parseValidTime(asOf)));
     const selected = this.db.select().from(oracleMemories);
     const rows = where
       ? selected.where(where).orderBy(desc(oracleMemories.createdAt)).limit(safeLimit).all()
@@ -59,9 +68,9 @@ export class MemoryStore {
     return rows.map(memoryFromRow);
   }
 
-  getByIds(ids: string[]): MemoryRecord[] {
+  getByIds(ids: string[], asOf?: string | number): MemoryRecord[] {
     if (!ids.length) return [];
-    const where = combineWhere(inArray(oracleMemories.id, ids), tenantWhere());
+    const where = combineWhere(inArray(oracleMemories.id, ids), tenantWhere(), asOfWhere(parseValidTime(asOf)));
     const rows = this.db.select().from(oracleMemories).where(where).all();
     const byId = new Map(rows.map((row) => [row.id, memoryFromRow(row)]));
     return ids.map((id) => byId.get(id)).filter((row): row is MemoryRecord => Boolean(row));
@@ -72,6 +81,12 @@ export class MemoryStore {
 function tenantWhere(): SQL | undefined {
   const tenantId = currentTenantId();
   return tenantId ? eq(oracleMemories.tenantId, tenantId) : undefined;
+}
+
+function asOfWhere(asOf: number | undefined): SQL | undefined {
+  if (!asOf) return undefined;
+  return sql`coalesce(${oracleMemories.validFrom}, ${oracleMemories.createdAt}) <= ${asOf}
+    and (${oracleMemories.validTo} is null or ${oracleMemories.validTo} > ${asOf})`;
 }
 
 function searchWhere(query: string): SQL | undefined {
@@ -93,6 +108,13 @@ function cleanTags(tags: string[] = []): string[] {
   return tags.map((tag) => tag.trim()).filter(Boolean);
 }
 
+export function parseValidTime(value: string | number | null | undefined): number | undefined {
+  if (value === null || value === undefined || value === '') return undefined;
+  const ms = typeof value === 'number' ? value : Date.parse(value);
+  if (!Number.isSafeInteger(ms) || ms <= 0) throw new Error('invalid valid-time timestamp');
+  return ms;
+}
+
 function tagsFrom(value: string): string[] {
   try {
     const parsed = JSON.parse(value);
@@ -109,6 +131,8 @@ function memoryFromRow(row: MemoryRow): MemoryRecord {
     title: row.title ?? undefined,
     tags: tagsFrom(row.tags),
     source: row.source ?? undefined,
+    validFrom: row.validFrom ? new Date(row.validFrom).toISOString() : undefined,
+    validTo: row.validTo ? new Date(row.validTo).toISOString() : undefined,
     createdAt: new Date(row.createdAt).toISOString(),
     updatedAt: new Date(row.updatedAt).toISOString(),
   };

--- a/src/routes/memory/vector.ts
+++ b/src/routes/memory/vector.ts
@@ -57,6 +57,9 @@ function memoryDocument(memory: MemoryRecord): VectorDocument {
       source: memory.source ?? '',
       tags: (memory.tags ?? []).join(','),
       createdAt: memory.createdAt,
+      updatedAt: memory.updatedAt,
+      validFrom: memory.validFrom ?? '',
+      validTo: memory.validTo ?? '',
     },
   };
 }

--- a/tests/db/memory-valid-time.test.ts
+++ b/tests/db/memory-valid-time.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createDatabase, type DatabaseConnection } from '../../src/db/index.ts';
+import { MemoryStore } from '../../src/routes/memory/store.ts';
+
+let tempDir = '';
+let connection: DatabaseConnection | undefined;
+
+afterEach(() => {
+  connection?.storage.close();
+  connection = undefined;
+  if (tempDir && fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true });
+  tempDir = '';
+});
+
+function freshStore() {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-memory-valid-time-'));
+  connection = createDatabase(path.join(tempDir, 'oracle.db'));
+  return { store: new MemoryStore(connection.db), sqlite: connection.sqlite };
+}
+
+test('oracle_memories migration installs valid_from/valid_to and tenant valid-time index', () => {
+  const { sqlite } = freshStore();
+  const columns = sqlite.query<{ name: string }, []>('pragma table_info("oracle_memories")')
+    .all()
+    .map((row) => row.name);
+  const index = sqlite.query<{ name: string }, []>(
+    "select name from sqlite_master where type = 'index' and name = 'idx_memory_tenant_valid_time'",
+  ).get();
+
+  expect(columns).toContain('valid_from');
+  expect(columns).toContain('valid_to');
+  expect(index?.name).toBe('idx_memory_tenant_valid_time');
+});
+
+test('memory recall filters valid-time as-of separately from transaction time', () => {
+  const { store } = freshStore();
+  const oldMemory = store.save({
+    content: 'pricing policy memory',
+    validFrom: '2024-01-01T00:00:00.000Z',
+    validTo: '2025-01-01T00:00:00.000Z',
+  });
+  const newMemory = store.save({
+    content: 'pricing policy memory',
+    validFrom: '2025-01-01T00:00:00.000Z',
+  });
+
+  const mid2024 = store.recall('pricing policy', 10, '2024-06-01T00:00:00.000Z').map((row) => row.id);
+  const mid2025 = store.recall('pricing policy', 10, '2025-06-01T00:00:00.000Z').map((row) => row.id);
+
+  expect(mid2024).toContain(oldMemory.id);
+  expect(mid2024).not.toContain(newMemory.id);
+  expect(mid2025).toContain(newMemory.id);
+  expect(mid2025).not.toContain(oldMemory.id);
+});
+
+test('memory save rejects invalid valid-time intervals', () => {
+  const { store } = freshStore();
+  expect(() => store.save({
+    content: 'bad interval',
+    validFrom: '2025-01-01T00:00:00.000Z',
+    validTo: '2024-01-01T00:00:00.000Z',
+  })).toThrow('valid_to must be after valid_from');
+});


### PR DESCRIPTION
## Summary
- add valid_from/valid_to columns and tenant valid-time index for oracle_memories
- support closed-open memory as-of filtering for keyword recall and vector-enriched search records
- preserve valid-time metadata when indexing memories
- add focused tests under tests/db/ for #2251 memory valid-time behavior

References #2251.

## Validation
- bunx tsc --noEmit
- bun test --isolate tests/db/ tests/http/memory/ src/db/__tests__/

## Notes
- PR targets alpha; main untouched.