### PR TITLE
test(oracles): harden reflect concept parsing

### DIFF
--- a/src/tools/reflect.ts
+++ b/src/tools/reflect.ts
@@ -7,6 +7,7 @@
 import { and, eq, sql, inArray } from 'drizzle-orm';
 import { oracleDocuments } from '../db/schema.ts';
 import { currentTenantId } from '../middleware/tenant.ts';
+import { parseConcepts } from '../search/query.ts';
 import type { ToolContext, ToolResponse, OracleReflectInput } from './types.ts';
 
 export const reflectToolDef = {
@@ -54,7 +55,7 @@ export async function handleReflect(ctx: ToolContext, _input: OracleReflectInput
           type: randomDoc.type,
           content: content.content,
           source_file: randomDoc.sourceFile,
-          concepts: JSON.parse(randomDoc.concepts || '[]')
+          concepts: parseConcepts(randomDoc.concepts)
         }
       }, null, 2)
     }]

--- a/tests/http/profile/reflect.test.ts
+++ b/tests/http/profile/reflect.test.ts
@@ -1,0 +1,56 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+
+const dbMod = await import('../../../src/db/index.ts');
+dbMod.resetDefaultDatabaseForTests();
+const { searchRoutes } = await import('../../../src/routes/search/index.ts');
+const { handleReflect } = await import('../../../src/tools/reflect.ts');
+
+const id = `profile-reflect-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const now = Date.now();
+
+dbMod.db.insert(dbMod.oracleDocuments).values({
+  id,
+  type: 'principle',
+  sourceFile: `ψ/memory/${id}.md`,
+  concepts: '{not-json',
+  createdAt: now,
+  updatedAt: now,
+  indexedAt: now,
+}).run();
+dbMod.sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
+  .run(id, 'reflect malformed concepts should not crash', '');
+
+afterAll(() => {
+  dbMod.db.delete(dbMod.oracleDocuments).where(eq(dbMod.oracleDocuments.id, id)).run();
+  dbMod.sqlite.prepare('DELETE FROM oracle_fts WHERE id = ?').run(id);
+  dbMod.resetDefaultDatabaseForTests(':memory:');
+});
+
+const ctx = {
+  db: dbMod.db,
+  sqlite: dbMod.sqlite,
+  repoRoot: process.cwd(),
+  vectorStore: {} as never,
+  vectorStatus: 'unknown' as const,
+  version: 'test',
+};
+
+describe('oracle reflect random-principle edge cases', () => {
+  test('returns reflection even when stored concepts payload is malformed', async () => {
+    const res = await searchRoutes.handle(new Request('http://local/api/reflect'));
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({ id, type: 'principle', concepts: [] });
+    expect(body.content).toBe('reflect malformed concepts should not crash');
+  });
+
+  test('MCP reflect tool also tolerates malformed stored concepts', async () => {
+    const response = await handleReflect(ctx, {});
+    const payload = JSON.parse(response.content[0].text) as { principle: { id: string; concepts: string[] } };
+
+    expect(payload.principle.id).toBe(id);
+    expect(payload.principle.concepts).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Reused defensive concept parsing in the `oracle_reflect` MCP tool so malformed stored concept JSON does not crash random-principle selection.
- Added `tests/http/profile/reflect.test.ts` coverage for malformed concepts through both `/api/reflect` and the MCP tool path.

## Tests
```bash
bun test --isolate tests/http/profile
bunx tsc --noEmit
wc -l src/tools/reflect.ts tests/http/profile/reflect.test.ts
```

Refs #2251
