### PR TITLE
feat(workers): add active fact curation

### DIFF
--- a/src/workers/consolidation.ts
+++ b/src/workers/consolidation.ts
@@ -2,6 +2,7 @@ import type { Database } from 'bun:sqlite';
 import { runWithTenant } from '../middleware/tenant.ts';
 import { runSupersede } from '../tools/supersede.ts';
 import type { ToolContext } from '../tools/types.ts';
+import { runFactCuration, type FactCurationOptions, type FactCurationResult } from './fact-curation.ts';
 
 type Db = ToolContext['db'];
 type Logger = Pick<Console, 'log' | 'warn' | 'error'>;
@@ -19,6 +20,7 @@ type ResolvedOptions = {
 export type ConsolidationOptions = {
   dryRun?: boolean; limit?: number; minCosine?: number; minFtsOverlap?: number;
   staleDays?: number; tenantId?: string; now?: number; logger?: Logger; llm?: unknown;
+  factCuration?: boolean | FactCurationOptions;
 };
 export type ConfidenceReceipt = {
   id: string; tenantId: string; score: number; stale: boolean;
@@ -31,6 +33,7 @@ export type ConsolidationPlan = {
 export type ConsolidationResult = {
   dryRun: boolean; scanned: number; planned: number; applied: number; skipped: number;
   deleted: 0; plans: ConsolidationPlan[]; confidence: ConfidenceReceipt[];
+  factCuration?: FactCurationResult;
 };
 
 const DAY_MS = 86_400_000;
@@ -43,9 +46,7 @@ function clamp(value: number, min = 0, max = 1): number { return Math.min(max, M
 
 function round(value: number): number { return Number(value.toFixed(4)); }
 
-function finiteNumber(value: unknown, fallback: number): number {
-  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
-}
+function finiteNumber(value: unknown, fallback: number): number { return typeof value === 'number' && Number.isFinite(value) ? value : fallback; }
 
 function resolveOptions(input: ConsolidationOptions): ResolvedOptions {
   const tenantId = typeof input.tenantId === 'string' ? input.tenantId.trim() : undefined;
@@ -58,6 +59,11 @@ function resolveOptions(input: ConsolidationOptions): ResolvedOptions {
     now: finiteNumber(input.now, Date.now()),
     ...(tenantId ? { tenantId } : {}),
   };
+}
+
+function resolveFactCuration(input: ConsolidationOptions): FactCurationOptions | null {
+  if (!input.factCuration) return null;
+  return { dryRun: input.dryRun, tenantId: input.tenantId, logger: input.logger, ...(typeof input.factCuration === 'object' ? input.factCuration : {}) };
 }
 
 function tokenize(text: string): string[] {
@@ -98,18 +104,8 @@ function confidenceFor(doc: RawDoc, tokens: string[], now: number, staleDays: nu
   const completeness = clamp(tokens.length / 80);
   const score = round((freshness * 0.45) + (provenance * 0.35) + (completeness * 0.2));
   const stale = ageDays >= staleDays || !doc.indexedAt;
-  return {
-    id: doc.id,
-    tenantId: doc.tenantId,
-    score,
-    stale,
-    label: score >= 0.75 ? 'high' : score >= 0.45 ? 'medium' : 'low',
-    reasons: [
-      stale ? 'stale_document' : 'fresh_document',
-      doc.project ? 'project_provenance' : 'missing_project',
-      tokens.length >= 40 ? 'content_complete' : 'content_sparse',
-    ],
-  };
+  return { id: doc.id, tenantId: doc.tenantId, score, stale, label: score >= 0.75 ? 'high' : score >= 0.45 ? 'medium' : 'low',
+    reasons: [stale ? 'stale_document' : 'fresh_document', doc.project ? 'project_provenance' : 'missing_project', tokens.length >= 40 ? 'content_complete' : 'content_sparse'] };
 }
 
 function docsSql(hasFts: boolean, tenantId?: string): string {
@@ -140,13 +136,7 @@ function loadDocs(sqlite: Database, options: ResolvedOptions): CandidateDoc[] {
     .all(...params);
   return rows.map((row) => {
     const tokens = tokenize(`${row.content}\n${row.concepts}\n${row.sourceFile}`);
-    return {
-      ...row,
-      content: row.content ?? '',
-      tokens,
-      tokenSet: new Set(tokens),
-      confidence: confidenceFor(row, tokens, options.now, options.staleDays),
-    };
+    return { ...row, content: row.content ?? '', tokens, tokenSet: new Set(tokens), confidence: confidenceFor(row, tokens, options.now, options.staleDays) };
   });
 }
 
@@ -220,10 +210,13 @@ export async function runConsolidationWorker(
       logger.warn(`[consolidation] skipped ${plan.oldId}: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
+  const factCuration = resolveFactCuration(input);
+  const curated = factCuration ? await runFactCuration(db, sqlite, factCuration) : undefined;
   return {
-    dryRun: options.dryRun, scanned: docs.length, planned: plans.length, applied,
-    skipped: plans.length - applied, deleted: 0, plans,
-    confidence: docs.map((doc) => doc.confidence).filter((receipt) => receipt.stale),
+    dryRun: options.dryRun, scanned: docs.length, planned: plans.length + (curated?.planned ?? 0),
+    applied: applied + (curated?.applied ?? 0), skipped: (plans.length - applied) + (curated?.skipped ?? 0),
+    deleted: 0, plans, confidence: docs.map((doc) => doc.confidence).filter((receipt) => receipt.stale),
+    ...(curated ? { factCuration: curated } : {}),
   };
 }
 

--- a/src/workers/fact-curation.ts
+++ b/src/workers/fact-curation.ts
@@ -1,0 +1,188 @@
+import type { Database } from 'bun:sqlite';
+import { runWithTenant } from '../middleware/tenant.ts';
+import { runSupersede } from '../tools/supersede.ts';
+import type { ToolContext } from '../tools/types.ts';
+
+type Db = ToolContext['db'];
+type Logger = Pick<Console, 'log' | 'warn'>;
+type Action = 'ADD' | 'UPDATE' | 'NOOP';
+type FactDoc = {
+  id: string; tenantId: string; type: string; sourceFile: string; updatedAt: number;
+  content: string; tokens: string[]; tokenSet: Set<string>; contentSet: Set<string>;
+};
+type Similar = { doc: FactDoc; similarity: number; overlap: number };
+type Resolved = {
+  dryRun: boolean; limit: number; topK: number; minSimilarity: number; minOverlap: number;
+  minNoveltyTokens: number; tenantId?: string; logger: Logger;
+};
+
+export type FactCurationOptions = {
+  dryRun?: boolean; limit?: number; topK?: number; minSimilarity?: number; minOverlap?: number;
+  minNoveltyTokens?: number; tenantId?: string; logger?: Logger;
+};
+export type FactCurationDecision = {
+  action: Action; targetId: string; tenantId: string; similarIds: string[];
+  similarity: number; overlap: number; reason: string;
+  supersede?: { oldId: string; newId: string };
+};
+export type FactCurationResult = {
+  enabled: true; scanned: number; decisions: FactCurationDecision[];
+  planned: number; applied: number; skipped: number; deleted: 0;
+};
+
+const DEFAULTS = { dryRun: true, limit: 120, topK: 5, minSimilarity: 0.55, minOverlap: 0.35, minNoveltyTokens: 4 };
+const MAX_LIMIT = 500;
+const STOP = new Set(['the', 'and', 'for', 'with', 'that', 'this', 'from', 'into', 'are', 'was', 'use', 'uses']);
+
+function clamp(value: number, min = 0, max = 1): number { return Math.min(max, Math.max(min, value)); }
+function finite(value: unknown, fallback: number): number { return typeof value === 'number' && Number.isFinite(value) ? value : fallback; }
+function round(value: number): number { return Number(value.toFixed(4)); }
+
+function resolve(input: FactCurationOptions): Resolved {
+  const tenantId = typeof input.tenantId === 'string' ? input.tenantId.trim() : undefined;
+  return {
+    dryRun: input.dryRun ?? DEFAULTS.dryRun,
+    limit: Math.max(0, Math.min(MAX_LIMIT, Math.floor(finite(input.limit, DEFAULTS.limit)))),
+    topK: Math.max(1, Math.min(20, Math.floor(finite(input.topK, DEFAULTS.topK)))),
+    minSimilarity: clamp(finite(input.minSimilarity, DEFAULTS.minSimilarity)),
+    minOverlap: clamp(finite(input.minOverlap, DEFAULTS.minOverlap)),
+    minNoveltyTokens: Math.max(0, Math.floor(finite(input.minNoveltyTokens, DEFAULTS.minNoveltyTokens))),
+    logger: input.logger ?? console,
+    ...(tenantId ? { tenantId } : {}),
+  };
+}
+
+function tokenize(text: string): string[] {
+  return (text.toLowerCase().normalize('NFKC').match(/[a-z0-9_:-]+/g) ?? [])
+    .filter((token) => token.length > 2 && !STOP.has(token));
+}
+
+function cosine(left: string[], right: string[]): number {
+  if (!left.length || !right.length) return 0;
+  const counts = new Map<string, number>();
+  for (const token of left) counts.set(token, (counts.get(token) ?? 0) + 1);
+  let dot = 0;
+  let leftNorm = 0;
+  let rightNorm = 0;
+  for (const value of counts.values()) leftNorm += value * value;
+  const rightCounts = new Map<string, number>();
+  for (const token of right) rightCounts.set(token, (rightCounts.get(token) ?? 0) + 1);
+  for (const [token, value] of rightCounts) {
+    rightNorm += value * value;
+    dot += (counts.get(token) ?? 0) * value;
+  }
+  return round(dot / (Math.sqrt(leftNorm) * Math.sqrt(rightNorm)));
+}
+
+function overlap(left: Set<string>, right: Set<string>): number {
+  const smallest = left.size <= right.size ? left : right;
+  const largest = left.size <= right.size ? right : left;
+  if (!smallest.size) return 0;
+  let hits = 0;
+  for (const token of smallest) if (largest.has(token)) hits += 1;
+  return round(hits / smallest.size);
+}
+
+function loadDocs(sqlite: Database, options: Resolved): FactDoc[] {
+  const tenant = options.tenantId ? 'AND d.tenant_id = ?' : '';
+  const params = options.tenantId ? [options.tenantId, options.limit] : [options.limit];
+  const rows = sqlite.prepare(`
+    SELECT d.id, d.tenant_id AS tenantId, d.type, d.source_file AS sourceFile,
+      d.updated_at AS updatedAt, coalesce(f.content, '') AS content, d.concepts
+    FROM oracle_documents d
+    LEFT JOIN oracle_fts f ON f.id = d.id
+    WHERE d.superseded_by IS NULL ${tenant}
+    ORDER BY d.updated_at DESC
+    LIMIT ?
+  `).all(...params) as Array<Omit<FactDoc, 'tokens' | 'tokenSet' | 'contentSet'> & { concepts: string }>;
+  return rows.map((row) => {
+    const contentTokens = tokenize(row.content ?? '');
+    const tokens = tokenize(`${row.content}\n${row.concepts}\n${row.sourceFile}`);
+    return { ...row, content: row.content ?? '', tokens, tokenSet: new Set(tokens), contentSet: new Set(contentTokens) };
+  });
+}
+
+function topSimilar(target: FactDoc, docs: FactDoc[], blocked: Set<string>, options: Resolved): Similar[] {
+  return docs
+    .filter((doc) => doc.id !== target.id && !blocked.has(doc.id) && doc.tenantId === target.tenantId && doc.type === target.type)
+    .map((doc) => ({ doc, similarity: cosine(target.tokens, doc.tokens), overlap: overlap(target.tokenSet, doc.tokenSet) }))
+    .filter((item) => item.similarity >= options.minSimilarity && item.overlap >= options.minOverlap)
+    .sort((a, b) => (b.similarity - a.similarity) || (b.overlap - a.overlap) || (b.doc.updatedAt - a.doc.updatedAt))
+    .slice(0, options.topK);
+}
+
+function novelty(target: FactDoc, existing: FactDoc): number {
+  let count = 0;
+  for (const token of target.contentSet) if (!existing.contentSet.has(token)) count += 1;
+  return count;
+}
+
+function classify(target: FactDoc, similar: Similar[], options: Resolved): FactCurationDecision {
+  if (!similar.length) {
+    return { action: 'ADD', targetId: target.id, tenantId: target.tenantId, similarIds: [], similarity: 0, overlap: 0, reason: 'no similar active facts above threshold' };
+  }
+  const best = similar[0];
+  const newTokens = novelty(target, best.doc);
+  const targetIsNewer = target.updatedAt >= best.doc.updatedAt;
+  if (targetIsNewer && newTokens >= options.minNoveltyTokens) {
+    return {
+      action: 'UPDATE', targetId: target.id, tenantId: target.tenantId,
+      similarIds: similar.map((item) => item.doc.id), similarity: best.similarity, overlap: best.overlap,
+      supersede: { oldId: best.doc.id, newId: target.id },
+      reason: `active fact-curation UPDATE against top-${options.topK} similar (novel_tokens=${newTokens})`,
+    };
+  }
+  return {
+    action: 'NOOP', targetId: target.id, tenantId: target.tenantId,
+    similarIds: similar.map((item) => item.doc.id), similarity: best.similarity, overlap: best.overlap,
+    supersede: { oldId: target.id, newId: best.doc.id },
+    reason: `active fact-curation NOOP against top-${options.topK} similar (novel_tokens=${newTokens})`,
+  };
+}
+
+function planDecisions(docs: FactDoc[], options: Resolved): FactCurationDecision[] {
+  const blocked = new Set<string>();
+  const decisions: FactCurationDecision[] = [];
+  for (const target of docs) {
+    if (blocked.has(target.id)) continue;
+    const decision = classify(target, topSimilar(target, docs, blocked, options), options);
+    decisions.push(decision);
+    if (decision.supersede) {
+      blocked.add(decision.supersede.oldId);
+      blocked.add(decision.supersede.newId);
+    }
+  }
+  return decisions;
+}
+
+export async function runFactCuration(
+  db: Db,
+  sqlite: Database,
+  input: FactCurationOptions = {},
+): Promise<FactCurationResult> {
+  const options = resolve(input);
+  const docs = loadDocs(sqlite, options);
+  const decisions = planDecisions(docs, options);
+  const planned = decisions.filter((decision) => decision.supersede);
+  let applied = 0;
+  for (const decision of planned) {
+    const edge = decision.supersede;
+    if (!edge) continue;
+    if (options.dryRun) {
+      options.logger.log(`[fact-curation:dry-run] ${decision.action} ${edge.oldId} -> ${edge.newId}`);
+      continue;
+    }
+    try {
+      const result = runWithTenant(decision.tenantId, () => runSupersede(db, {
+        oldId: edge.oldId,
+        newId: edge.newId,
+        reason: decision.reason,
+      }));
+      if (result.isError) options.logger.warn(`[fact-curation] skipped ${edge.oldId}: ${JSON.stringify(result.payload)}`);
+      else applied += 1;
+    } catch (error) {
+      options.logger.warn(`[fact-curation] skipped ${edge.oldId}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  return { enabled: true, scanned: docs.length, decisions, planned: planned.length, applied, skipped: planned.length - applied, deleted: 0 };
+}

--- a/tests/workers/fact-curation.test.ts
+++ b/tests/workers/fact-curation.test.ts
@@ -1,0 +1,131 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FactCurationResult } from '../../src/workers/fact-curation.ts';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const root = mkdtempSync(join(tmpdir(), 'arra-fact-curation-'));
+process.env.ORACLE_DATA_DIR = root;
+
+const dbModule = await import('../../src/db/index.ts');
+const { createDatabase, oracleDocuments, resetDefaultDatabaseForTests } = dbModule;
+const { runConsolidationWorker } = await import('../../src/workers/consolidation.ts');
+
+type Connection = ReturnType<typeof createDatabase>;
+type CurationRun = Awaited<ReturnType<typeof runConsolidationWorker>> & { factCuration: FactCurationResult };
+
+const now = 1_766_000_000_000;
+const quiet = { log: () => {}, warn: () => {}, error: () => {} };
+const curation = { limit: 10, topK: 2, minSimilarity: 0.2, minOverlap: 0.2, minNoveltyTokens: 2, logger: quiet };
+
+function connection(name: string): Connection {
+  return createDatabase(join(root, `${name}.db`));
+}
+
+function addDoc(conn: Connection, id: string, tenantId: string, updatedAt: number, content: string) {
+  conn.db.insert(oracleDocuments).values({
+    id,
+    tenantId,
+    type: 'learning',
+    sourceFile: `docs/${id}.md`,
+    concepts: '["fact","curation","memory"]',
+    createdAt: updatedAt - 10,
+    updatedAt,
+    indexedAt: updatedAt,
+    project: 'github.com/soul-brews-studio/arra-oracle-v3',
+    createdBy: 'test',
+  }).run();
+  conn.sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
+    .run(id, content, 'fact curation memory');
+}
+
+function seed(conn: Connection, tenantId = 'tenant-a', suffix = '') {
+  addDoc(conn, `old-router${suffix}`, tenantId, now - 100, 'Search routes use Hono middleware for router auth and request guards.');
+  addDoc(conn, `new-router${suffix}`, tenantId, now, 'Search routes use Elysia middleware for router auth and request guards. Elysia TypeBox schemas are current.');
+  const plugin = 'Plugin install uses bun add from GitHub package and code plugin install flow.';
+  addDoc(conn, `plugin-canonical${suffix}`, tenantId, now - 300, plugin);
+  addDoc(conn, `plugin-duplicate${suffix}`, tenantId, now - 200, plugin);
+  addDoc(conn, `unique-fact${suffix}`, tenantId, now - 400, 'Vector health dashboard shows providers services storage freshness.');
+}
+
+function supersededBy(conn: Connection, id: string) {
+  return conn.db.select({ supersededBy: oracleDocuments.supersededBy })
+    .from(oracleDocuments)
+    .where(eq(oracleDocuments.id, id))
+    .get()?.supersededBy;
+}
+
+async function run(conn: Connection, dryRun: boolean, tenantId?: string): Promise<CurationRun> {
+  return await runConsolidationWorker(conn.db, conn.sqlite, {
+    dryRun,
+    limit: 0,
+    tenantId,
+    logger: quiet,
+    factCuration: curation,
+  }) as CurationRun;
+}
+
+afterAll(() => {
+  if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = savedDataDir;
+  resetDefaultDatabaseForTests(':memory:');
+  if (existsSync(root)) rmSync(root, { recursive: true });
+});
+
+describe('active fact-curation consolidation pass', () => {
+  test('dry-run emits ADD, UPDATE, and NOOP decisions without mutating rows', async () => {
+    const conn = connection('dry-run');
+    seed(conn);
+
+    try {
+      const result = await run(conn, true);
+      const byTarget = Object.fromEntries(result.factCuration.decisions.map((decision) => [decision.targetId, decision]));
+
+      expect(result).toMatchObject({ dryRun: true, scanned: 0, planned: 2, applied: 0, deleted: 0 });
+      expect(result.factCuration).toMatchObject({ enabled: true, scanned: 5, planned: 2, applied: 0, deleted: 0 });
+      expect(byTarget['new-router']).toMatchObject({ action: 'UPDATE', supersede: { oldId: 'old-router', newId: 'new-router' } });
+      expect(byTarget['plugin-duplicate']).toMatchObject({ action: 'NOOP', supersede: { oldId: 'plugin-duplicate', newId: 'plugin-canonical' } });
+      expect(byTarget['unique-fact']).toMatchObject({ action: 'ADD', similarIds: [] });
+      expect(supersededBy(conn, 'old-router')).toBeNull();
+      expect(supersededBy(conn, 'plugin-duplicate')).toBeNull();
+    } finally {
+      conn.storage.close();
+    }
+  });
+
+  test('apply mode maps UPDATE and NOOP to reversible supersede edges', async () => {
+    const conn = connection('apply');
+    seed(conn);
+
+    try {
+      const result = await run(conn, false);
+      const count = conn.db.select({ id: oracleDocuments.id }).from(oracleDocuments).all().length;
+
+      expect(result.factCuration).toMatchObject({ planned: 2, applied: 2, skipped: 0, deleted: 0 });
+      expect(supersededBy(conn, 'old-router')).toBe('new-router');
+      expect(supersededBy(conn, 'plugin-duplicate')).toBe('plugin-canonical');
+      expect(count).toBe(5);
+    } finally {
+      conn.storage.close();
+    }
+  });
+
+  test('tenant filter keeps top-k decisions inside the requested tenant', async () => {
+    const conn = connection('tenant-filter');
+    seed(conn, 'tenant-a', '-a');
+    seed(conn, 'tenant-b', '-b');
+
+    try {
+      const result = await run(conn, false, ' tenant-b ');
+
+      expect(result.factCuration).toMatchObject({ scanned: 5, planned: 2, applied: 2 });
+      expect(supersededBy(conn, 'old-router-a')).toBeNull();
+      expect(supersededBy(conn, 'old-router-b')).toBe('new-router-b');
+      expect(supersededBy(conn, 'plugin-duplicate-b')).toBe('plugin-canonical-b');
+    } finally {
+      conn.storage.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- References #2251.
- Adds an off-write-path active fact-curation layer for the consolidation worker.
- Classifies active memories as `ADD`, `UPDATE`, or `NOOP` against top-k similar facts.
- Maps `UPDATE` and `NOOP` to reversible `runSupersede` edges; never deletes rows.

## Verification
```bash
bunx tsc --noEmit
bun test --isolate tests/workers/consolidation-worker.test.ts tests/workers/consolidation-llm.test.ts tests/workers/fact-curation.test.ts
wc -l src/workers/consolidation.ts src/workers/fact-curation.ts tests/workers/fact-curation.test.ts tests/workers/consolidation-worker.test.ts tests/workers/consolidation-llm.test.ts
git diff --check
```
