### PR TITLE
feat(memory): unify memory ranking signals

### DIFF
--- a/src/routes/memory/index.ts
+++ b/src/routes/memory/index.ts
@@ -4,9 +4,10 @@ import { createMemoryFanoutEndpoint } from './fanout.ts';
 import { memoryStore, parseValidTime, type MemoryInput, type MemoryRecord, type MemoryStore } from './store.ts';
 import { memoryVectorIndex, type MemoryVectorHit, type MemoryVectorIndex } from './vector.ts';
 import { buildMorningTape } from './morning-tape.ts';
-import { MEMORY_CONFIDENCE_STRATEGY, memoryConfidence } from './confidence.ts';
+import { MEMORY_CONFIDENCE_STRATEGY } from './confidence.ts';
 import { formatCloseoutMemory, type MemoryCloseoutInput } from './closeout.ts';
 import { currentTenantId } from '../../middleware/tenant.ts';
+import { rankMemories } from './rank.ts';
 
 export function createMemoryRoutes(
   store: MemoryStore = memoryStore,
@@ -54,8 +55,9 @@ export function createMemoryRoutes(
     .get('/memory/recall', ({ query, set }) => {
       const limit = parseMemoryLimit(query.limit);
       try {
-        const items = store.recall(query.q ?? '', limit, query.asOf);
-        return { query: query.q ?? '', asOf: isoAsOf(query.asOf), total: items.length, confidence: MEMORY_CONFIDENCE_STRATEGY, items: items.map(withKeywordConfidence) };
+        const candidates = store.recall(query.q ?? '', limit, query.asOf);
+        const items = rankMemories(candidates, { mode: 'keyword', asOf: query.asOf });
+        return { query: query.q ?? '', asOf: isoAsOf(query.asOf), total: items.length, confidence: MEMORY_CONFIDENCE_STRATEGY, items };
       } catch (error) {
         return invalidAsOf(set, error);
       }
@@ -73,7 +75,9 @@ export function createMemoryRoutes(
         isoAsOf(query.asOf);
         const hits = await vectorIndex.search(query.q, limit);
         const records = store.getByIds(hits.map((hit) => hit.memoryId), query.asOf);
-        const results = mergeHits(hits, records);
+        const merged = mergeHits(hits, records);
+        const scores = new Map(hits.map((hit) => [hit.memoryId, hit.score]));
+        const results = rankMemories(merged, { mode: 'semantic', asOf: query.asOf, score: (memory) => scores.get(memory.id) }).slice(0, limit);
         return { success: true, query: query.q, asOf: isoAsOf(query.asOf), total: results.length, confidence: MEMORY_CONFIDENCE_STRATEGY, results };
       } catch (error) {
         const message = error instanceof Error ? error.message : 'memory vector search failed';
@@ -112,7 +116,6 @@ function mergeHits(hits: MemoryVectorHit[], records: MemoryRecord[]) {
       score: hit.score,
       distance: hit.distance,
       vectorId: hit.vectorId,
-      confidence: memoryConfidence(memory, { mode: 'semantic', semanticScore: hit.score }),
     }];
   });
 }
@@ -120,10 +123,6 @@ function mergeHits(hits: MemoryVectorHit[], records: MemoryRecord[]) {
 function hitTenant(hit: MemoryVectorHit): string | undefined {
   const value = hit.metadata.tenant_id ?? hit.metadata.tenantId ?? hit.metadata.tenant;
   return typeof value === 'string' ? value : undefined;
-}
-
-function withKeywordConfidence(memory: MemoryRecord) {
-  return { ...memory, confidence: memoryConfidence(memory, { mode: 'keyword' }) };
 }
 
 function memoryForHit(hit: MemoryVectorHit, record?: MemoryRecord): MemoryRecord {

--- a/src/routes/memory/rank.ts
+++ b/src/routes/memory/rank.ts
@@ -1,0 +1,86 @@
+import { memoryConfidence, type MemoryConfidence } from './confidence.ts';
+import type { MemoryRecord } from './store.ts';
+
+export type RankedMemory<T extends MemoryRecord = MemoryRecord> = T & {
+  confidence: MemoryConfidence;
+  ranking: {
+    score: number;
+    components: { match: number; confidence: number; heat: number; validTime: number };
+    strategy: 'valid_time_confidence_heat_match';
+  };
+};
+
+export type RankMemoryOptions = {
+  mode?: 'keyword' | 'semantic';
+  asOf?: string | number;
+  now?: Date;
+  score?: (memory: MemoryRecord) => number | undefined;
+};
+
+export function rankMemories<T extends MemoryRecord>(
+  memories: T[],
+  options: RankMemoryOptions = {},
+): Array<RankedMemory<T>> {
+  const now = options.now ?? new Date();
+  const asOf = parseTime(options.asOf) ?? now.getTime();
+  return memories.map((memory, index) => {
+    const match = clamp(options.score?.(memory) ?? keywordScore(memory));
+    const confidence = memoryConfidence(memory, { mode: options.mode ?? 'keyword', semanticScore: match, now });
+    const heat = heatScore(memory, now);
+    const validTime = validTimeScore(memory, asOf);
+    const score = round((match * 0.45) + (confidence.score * 0.25) + (heat * 0.2) + (validTime * 0.1));
+    return {
+      ...memory,
+      confidence,
+      ranking: {
+        score,
+        components: { match: round(match), confidence: confidence.score, heat: round(heat), validTime: round(validTime) },
+        strategy: 'valid_time_confidence_heat_match',
+      },
+      __rankIndex: index,
+    } as RankedMemory<T> & { __rankIndex: number };
+  }).sort((a, b) => b.ranking.score - a.ranking.score || a.__rankIndex - b.__rankIndex)
+    .map(({ __rankIndex: _rankIndex, ...memory }) => memory as RankedMemory<T>);
+}
+
+function keywordScore(memory: MemoryRecord): number {
+  const signals = [memory.title, memory.source, ...(memory.tags ?? [])].filter(Boolean).length;
+  return clamp(0.55 + Math.min(0.25, signals * 0.05));
+}
+
+function heatScore(memory: MemoryRecord, now: Date): number {
+  const usage = safeNumber(memory.usageCount);
+  const usageSignal = usage > 0 ? clamp(Math.log1p(usage) / Math.log1p(20)) : 0;
+  const accessed = parseTime(memory.lastAccessedAt);
+  const recency = accessed ? clamp(0.5 ** (Math.max(0, now.getTime() - accessed) / 2_592_000_000)) : 0;
+  return (usageSignal * 0.7) + (recency * 0.3);
+}
+
+function validTimeScore(memory: MemoryRecord, asOf: number): number {
+  const from = parseTime(memory.validFrom) ?? parseTime(memory.createdAt) ?? asOf;
+  const to = parseTime(memory.validTo);
+  if (from > asOf || (to !== undefined && to <= asOf)) return 0;
+  const ageDays = Math.max(0, (asOf - from) / 86_400_000);
+  const recency = 0.5 ** (ageDays / 365);
+  const bounded = to === undefined ? 0 : 0.1;
+  return clamp(0.75 + bounded + (recency * 0.15));
+}
+
+function parseTime(value: string | number | undefined): number | undefined {
+  if (value === undefined || value === '') return undefined;
+  const parsed = typeof value === 'number' ? value : Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function safeNumber(value: unknown): number {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+function clamp(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.min(1, value)) : 0;
+}
+
+function round(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}

--- a/tests/http/memory/rank.test.ts
+++ b/tests/http/memory/rank.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from 'bun:test';
+import { rankMemories } from '../../../src/routes/memory/rank.ts';
+import type { MemoryRecord } from '../../../src/routes/memory/store.ts';
+
+const now = new Date('2026-06-17T00:00:00.000Z');
+
+function memory(overrides: Partial<MemoryRecord>): MemoryRecord {
+  return {
+    id: overrides.id ?? crypto.randomUUID(),
+    content: overrides.content ?? 'shared ranking context',
+    tags: overrides.tags ?? ['rank'],
+    createdAt: overrides.createdAt ?? '2026-01-01T00:00:00.000Z',
+    updatedAt: overrides.updatedAt ?? '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+test('rankMemories combines vector score, confidence, heat, and valid-time recency', () => {
+  const staleHot = memory({
+    id: 'stale-hot',
+    validFrom: '2024-01-01T00:00:00.000Z',
+    usageCount: 20,
+    lastAccessedAt: '2026-06-16T00:00:00.000Z',
+  });
+  const currentRelevant = memory({
+    id: 'current-relevant',
+    validFrom: '2026-06-01T00:00:00.000Z',
+    source: 'issue-2251',
+  });
+
+  const ranked = rankMemories([staleHot, currentRelevant], {
+    mode: 'semantic',
+    now,
+    asOf: now.toISOString(),
+    score: (item) => item.id === 'current-relevant' ? 0.92 : 0.52,
+  });
+
+  expect(ranked.map((item) => item.id)).toEqual(['current-relevant', 'stale-hot']);
+  expect(ranked[0].ranking.strategy).toBe('valid_time_confidence_heat_match');
+  expect(ranked[0].ranking.components).toMatchObject({ match: 0.92 });
+  expect(ranked[1].ranking.components.heat).toBeGreaterThan(0.8);
+});
+
+test('rankMemories keeps inactive valid-time rows below active rows', () => {
+  const expired = memory({
+    id: 'expired',
+    validFrom: '2024-01-01T00:00:00.000Z',
+    validTo: '2025-01-01T00:00:00.000Z',
+    source: 'old-policy',
+  });
+  const active = memory({ id: 'active', validFrom: '2025-01-01T00:00:00.000Z' });
+
+  const ranked = rankMemories([expired, active], {
+    now,
+    asOf: '2026-01-01T00:00:00.000Z',
+    score: () => 0.7,
+  });
+
+  expect(ranked.map((item) => item.id)).toEqual(['active', 'expired']);
+  expect(ranked[1].ranking.components.validTime).toBe(0);
+});


### PR DESCRIPTION
## Summary
- add one rankMemories() function combining match score, confidence, heat, and valid-time signals
- use rankMemories() for memory keyword recall and vector-enriched search results
- return ranking metadata alongside query-time confidence
- add focused ranking tests for #2251 integration

References #2251.

## Validation
- bunx tsc --noEmit
- bun test --isolate tests/http/memory/ tests/db/memory-valid-time.test.ts

## Notes
- PR targets alpha; main untouched.