### PR TITLE
feat(memory): add optional TTL autosupersede

### DIFF
--- a/src/db/migrations/0034_memory_ttl.sql
+++ b/src/db/migrations/0034_memory_ttl.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `oracle_memories` ADD `superseded_at` integer;
+--> statement-breakpoint
+ALTER TABLE `oracle_memories` ADD `superseded_reason` text;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_memory_tenant_superseded` ON `oracle_memories` (`tenant_id`,`superseded_at`);

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -239,6 +239,7 @@
       "when": 1781686800000,
       "tag": "0033_memory_valid_time",
       "breakpoints": true
-    }
+    },
+    { "idx": 34, "version": "6", "when": 1781700000000, "tag": "0034_memory_ttl", "breakpoints": true }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -47,6 +47,7 @@ export const oracleMemories = sqliteTable('oracle_memories', {
   source: text('source'),
   validFrom: integer('valid_from'),
   validTo: integer('valid_to'),
+  supersededAt: integer('superseded_at'), supersededReason: text('superseded_reason'),
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
 }, (table) => [

--- a/src/routes/memory/model.ts
+++ b/src/routes/memory/model.ts
@@ -7,6 +7,7 @@ export const SaveMemoryBody = t.Object({
   source: t.Optional(t.String()),
   validFrom: t.Optional(t.Union([t.String(), t.Number()])),
   validTo: t.Optional(t.Union([t.String(), t.Number(), t.Null()])),
+  validUntil: t.Optional(t.Union([t.String(), t.Number()])),
 });
 
 export const MemoryCloseoutBody = t.Object({

--- a/src/routes/memory/store.ts
+++ b/src/routes/memory/store.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, like, or, sql, type SQL } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNull, like, lt, or, sql, type SQL } from 'drizzle-orm';
 import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 import { db as defaultDb, oracleMemories } from '../../db/index.ts';
 import { currentTenantId, tenantIdForWrite } from '../../middleware/tenant.ts';
@@ -12,6 +12,7 @@ export type MemoryInput = {
   source?: string;
   validFrom?: string | number;
   validTo?: string | number | null;
+  validUntil?: string | number;
 };
 
 export type MemoryRecord = MemoryInput & {
@@ -23,13 +24,18 @@ export type MemoryRecord = MemoryInput & {
   lastAccessedAt?: string;
   validFrom?: string;
   validTo?: string;
+  validUntil?: string;
+  supersededAt?: string;
+  supersededReason?: string;
 };
 
 type OracleDb = BunSQLiteDatabase<typeof schema>;
 type MemoryRow = typeof oracleMemories.$inferSelect;
 
+export type MemoryDecayOptions = { enabled?: boolean; now?: () => number };
+
 export class MemoryStore {
-  constructor(private readonly database?: OracleDb) {}
+  constructor(private readonly database?: OracleDb, private readonly decay: MemoryDecayOptions = {}) {}
 
   private get db(): OracleDb {
     return this.database ?? defaultDb;
@@ -40,7 +46,7 @@ export class MemoryStore {
     if (!content) throw new Error('memory content is required');
     const now = Date.now();
     const validFrom = parseValidTime(input.validFrom);
-    const validTo = parseValidTime(input.validTo);
+    const validTo = parseValidTime(input.validTo ?? input.validUntil);
     if (validFrom && validTo && validTo <= validFrom) throw new Error('valid_to must be after valid_from');
     const row = this.db.insert(oracleMemories).values({
       id: `mem_${now.toString(36)}_${crypto.randomUUID().slice(0, 8)}`,
@@ -58,9 +64,10 @@ export class MemoryStore {
   }
 
   recall(query = '', limit = 10, asOf?: string | number): MemoryRecord[] {
+    this.supersedeExpired();
     const normalized = query.trim();
     const safeLimit = parseMemoryLimit(limit);
-    const where = combineWhere(tenantWhere(), searchWhere(normalized), asOfWhere(parseValidTime(asOf)));
+    const where = combineWhere(tenantWhere(), isNull(oracleMemories.supersededAt), searchWhere(normalized), asOfWhere(parseValidTime(asOf)));
     const selected = this.db.select().from(oracleMemories);
     const rows = where
       ? selected.where(where).orderBy(desc(oracleMemories.createdAt)).limit(safeLimit).all()
@@ -70,10 +77,25 @@ export class MemoryStore {
 
   getByIds(ids: string[], asOf?: string | number): MemoryRecord[] {
     if (!ids.length) return [];
-    const where = combineWhere(inArray(oracleMemories.id, ids), tenantWhere(), asOfWhere(parseValidTime(asOf)));
+    this.supersedeExpired();
+    const where = combineWhere(inArray(oracleMemories.id, ids), tenantWhere(), isNull(oracleMemories.supersededAt), asOfWhere(parseValidTime(asOf)));
     const rows = this.db.select().from(oracleMemories).where(where).all();
     const byId = new Map(rows.map((row) => [row.id, memoryFromRow(row)]));
     return ids.map((id) => byId.get(id)).filter((row): row is MemoryRecord => Boolean(row));
+  }
+
+  supersedeExpired(reason = 'memory TTL expired'): number {
+    if (!this.decay.enabled) return 0;
+    const now = this.now();
+    const result = this.db.update(oracleMemories)
+      .set({ supersededAt: now, supersededReason: reason })
+      .where(combineWhere(tenantWhere(), isNull(oracleMemories.supersededAt), lt(oracleMemories.validTo, now)))
+      .run() as { changes?: number } | void;
+    return result?.changes ?? 0;
+  }
+
+  private now(): number {
+    return this.decay.now?.() ?? Date.now();
   }
 
 }
@@ -133,9 +155,15 @@ function memoryFromRow(row: MemoryRow): MemoryRecord {
     source: row.source ?? undefined,
     validFrom: row.validFrom ? new Date(row.validFrom).toISOString() : undefined,
     validTo: row.validTo ? new Date(row.validTo).toISOString() : undefined,
+    validUntil: row.validTo ? new Date(row.validTo).toISOString() : undefined,
+    supersededAt: row.supersededAt ? new Date(row.supersededAt).toISOString() : undefined,
+    supersededReason: row.supersededReason ?? undefined,
     createdAt: new Date(row.createdAt).toISOString(),
     updatedAt: new Date(row.updatedAt).toISOString(),
   };
 }
 
-export const memoryStore = new MemoryStore();
+export const memoryStore = new MemoryStore(undefined, {
+  enabled: process.env.MEMORY_TTL_AUTOSUPERSEDE === '1'
+    || process.env.MEMORY_TTL_AUTOSUPERSEDE === 'true',
+});

--- a/src/routes/memory/vector.ts
+++ b/src/routes/memory/vector.ts
@@ -59,7 +59,7 @@ function memoryDocument(memory: MemoryRecord): VectorDocument {
       createdAt: memory.createdAt,
       updatedAt: memory.updatedAt,
       validFrom: memory.validFrom ?? '',
-      validTo: memory.validTo ?? '',
+      validTo: memory.validTo ?? memory.validUntil ?? '',
     },
   };
 }

--- a/tests/http/memory/ttl.test.ts
+++ b/tests/http/memory/ttl.test.ts
@@ -1,0 +1,43 @@
+import { afterAll, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { createDatabase } from '../../../src/db/create.ts';
+import { oracleMemories } from '../../../src/db/schema.ts';
+import { MemoryStore } from '../../../src/routes/memory/store.ts';
+
+const connection = createDatabase(':memory:');
+const now = Date.parse('2026-06-17T00:00:00.000Z');
+
+afterAll(() => connection.storage.close());
+
+test('memory TTL auto-supersedes expired memories off the write path', () => {
+  const store = new MemoryStore(connection.db, { enabled: true, now: () => now });
+  const expired = store.save({
+    content: 'stale launch note',
+    validUntil: '2026-06-16T23:59:59.000Z',
+  });
+  const active = store.save({
+    content: 'fresh launch note',
+    validUntil: '2026-06-18T00:00:00.000Z',
+  });
+
+  expect(connection.db.select().from(oracleMemories).where(eq(oracleMemories.id, expired.id)).get()?.supersededAt).toBeNull();
+  expect(store.recall('launch', 10).map((memory) => memory.id)).toEqual([active.id]);
+
+  const stale = connection.db.select().from(oracleMemories).where(eq(oracleMemories.id, expired.id)).get();
+  expect(stale?.supersededAt).toBe(now);
+  expect(stale?.supersededReason).toBe('memory TTL expired');
+});
+
+test('memory TTL stays configurable and disabled stores keep expired memories visible', () => {
+  const store = new MemoryStore(connection.db, { enabled: false, now: () => now });
+  const memory = store.save({ content: 'configurable ttl note', validUntil: '2026-06-16T00:00:00.000Z' });
+
+  expect(store.recall('configurable', 10).map((item) => item.id)).toContain(memory.id);
+  expect(connection.db.select().from(oracleMemories).where(eq(oracleMemories.id, memory.id)).get()?.supersededAt).toBeNull();
+});
+
+test('memory save rejects malformed validUntil values', () => {
+  const store = new MemoryStore(connection.db, { enabled: true, now: () => now });
+
+  expect(() => store.save({ content: 'bad ttl', validUntil: 'not-a-date' })).toThrow('invalid valid-time timestamp');
+});


### PR DESCRIPTION
## Summary
- Added optional `validUntil` memory writes as an alias for the existing valid-time expiry (`validTo`).
- Added configurable off-write-path TTL supersede marking via `MEMORY_TTL_AUTOSUPERSEDE=1|true`.
- Added SQLite migration fields for memory supersede metadata and TTL regression coverage.

## Tests
```bash
bun test --isolate tests/http/memory
bunx tsc --noEmit
wc -l src/db/schema.ts src/routes/memory/model.ts src/routes/memory/store.ts src/routes/memory/vector.ts src/db/migrations/0034_memory_ttl.sql src/db/migrations/meta/_journal.json tests/http/memory/ttl.test.ts
```

Refs #2251
