### PR TITLE
feat(search): boost oracle search with entity links

### DIFF
--- a/src/server/logging.ts
+++ b/src/server/logging.ts
@@ -64,7 +64,8 @@ export function logSearch(
     if (results.length > 0) {
       const expectedFields = [
         'id', 'type', 'content', 'source_file', 'concepts', 'source', 'score',
-        'distance', 'model', 'ftsScore', 'vectorScore', 'confidence', 'provenance',
+        'distance', 'model', 'ftsScore', 'vectorScore', 'entity_score',
+        'entity_matches', 'entityLinkScore', 'entityLinkMatches', 'confidence', 'provenance',
         'superseded_by', 'superseded_at', 'superseded_reason',
       ];
       const firstResult = results[0] as unknown as Record<string, unknown>;

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -12,6 +12,10 @@ export interface SearchResult {
   score?: number;
   distance?: number;
   model?: string;
+  entity_score?: number;
+  entity_matches?: string[];
+  entityLinkScore?: number;
+  entityLinkMatches?: string[];
   superseded_by?: string;
   superseded_at?: string | null;
   superseded_reason?: string | null;

--- a/src/tools/__tests__/search-entity-link.test.ts
+++ b/src/tools/__tests__/search-entity-link.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createDatabase } from '../../db/index.ts';
+import type { DatabaseConnection } from '../../db/create.ts';
+import { handleSearch } from '../search.ts';
+import type { EntityLinkSearchHook } from '../search.ts';
+import type { ToolContext } from '../types.ts';
+
+const roots: string[] = [];
+const connections: DatabaseConnection[] = [];
+const originalVectorEnabled = process.env.ORACLE_VECTOR_ENABLED;
+const originalRerankerUrl = process.env.ORACLE_RERANKER_URL;
+
+function tempRoot(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  roots.push(dir);
+  return dir;
+}
+
+function parse(response: { content: Array<{ text: string }> }) {
+  return JSON.parse(response.content[0].text);
+}
+
+function makeCtx(entityLinkSearch: EntityLinkSearchHook): ToolContext & { entityLinkSearch: EntityLinkSearchHook } {
+  const connection = createDatabase(path.join(tempRoot('arra-search-entity-link-'), 'oracle.db'));
+  connections.push(connection);
+  const vectorStore = {
+    name: 'mock-vector',
+    query: async () => ({
+      ids: ['keyword-doc', 'entity-doc'],
+      documents: ['keyword baseline', 'entity linked memory'],
+      distances: [0.55, 0.7],
+      metadatas: [
+        { type: 'learning', source_file: 'docs/keyword.md', concepts: '[]' },
+        { type: 'learning', source_file: 'docs/entity.md', concepts: '[]' },
+      ],
+    }),
+  };
+  return {
+    db: connection.db,
+    sqlite: connection.sqlite,
+    repoRoot: tempRoot('arra-search-entity-repo-'),
+    vectorStore: vectorStore as any,
+    vectorStatus: 'connected',
+    version: 'test-version',
+    entityLinkSearch,
+  };
+}
+
+afterEach(() => {
+  process.env.ORACLE_VECTOR_ENABLED = originalVectorEnabled;
+  process.env.ORACLE_RERANKER_URL = originalRerankerUrl;
+  for (const connection of connections.splice(0)) connection.storage.close();
+  for (const dir of roots.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('oracle_search uses entity links as a non-graph rank boost', async () => {
+  process.env.ORACLE_VECTOR_ENABLED = '1';
+  delete process.env.ORACLE_RERANKER_URL;
+  const ctx = makeCtx(async () => [
+    { sourceDocId: 'entity-doc', entity: 'Cloudflare Workers', score: 1 },
+  ]);
+
+  const body = parse(await handleSearch(ctx, {
+    query: 'workers deploy',
+    mode: 'vector',
+    limit: 2,
+  }));
+
+  expect(body.results.map((result: { id: string }) => result.id)).toEqual(['entity-doc', 'keyword-doc']);
+  expect(body.results[0].provenance).toMatchObject({
+    source: 'vector',
+    entity_link_score: 1,
+    entity_link_matches: ['Cloudflare Workers'],
+  });
+  expect(body.results[0].confidence.signals).toContain('matched by entity-link ranking signal');
+  expect(body.metadata.entityLinks).toMatchObject({
+    enabled: true,
+    graph: false,
+    hits: 1,
+    boosted: 1,
+  });
+});

--- a/src/tools/__tests__/search.test.ts
+++ b/src/tools/__tests__/search.test.ts
@@ -9,6 +9,7 @@ import {
   normalizeFtsScore,
   parseConceptsFromMetadata,
   combineResults,
+  applyEntityLinkBoost,
 } from '../search.ts';
 
 // ============================================================================
@@ -157,5 +158,38 @@ describe('combineResults', () => {
     expect(combineResults([], [])).toEqual([]);
     expect(combineResults(ftsResults, [])).toHaveLength(2);
     expect(combineResults([], vectorResults)).toHaveLength(2);
+  });
+});
+
+
+// ============================================================================
+// applyEntityLinkBoost
+// ============================================================================
+
+describe('applyEntityLinkBoost', () => {
+  const results = [
+    { id: 'plain', type: 'learning', content: 'Plain', source_file: 'plain.md', concepts: [], score: 0.6, source: 'fts' as const },
+    { id: 'linked', type: 'learning', content: 'Linked', source_file: 'linked.md', concepts: [], score: 0.45, source: 'fts' as const },
+  ];
+
+  it('should boost linked documents enough to affect rank', () => {
+    const boosted = applyEntityLinkBoost(results, [
+      { sourceDocId: 'linked', entity: 'Cloudflare Workers', score: 0.9 },
+    ]);
+
+    expect(boosted.boosted).toBe(1);
+    expect(boosted.results[0].id).toBe('linked');
+    expect(boosted.results[0].entityLinkScore).toBe(0.9);
+    expect(boosted.results[0].entityLinkMatches).toEqual(['Cloudflare Workers']);
+  });
+
+  it('should leave scores and order unchanged when no entity hits match', () => {
+    const boosted = applyEntityLinkBoost(results, [
+      { sourceDocId: 'other', entity: 'Other', score: 1 },
+    ]);
+
+    expect(boosted.boosted).toBe(0);
+    expect(boosted.results.map((result) => result.id)).toEqual(['plain', 'linked']);
+    expect(boosted.results.map((result) => result.score)).toEqual([0.6, 0.45]);
   });
 });

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -11,5 +11,12 @@ export {
   sanitizeFtsQuery,
 } from './search/helpers.ts';
 export { vectorSearch } from './search/vector.ts';
+export {
+  applyEntityLinkBoost,
+  hasEntityLinkSearchHook,
+  queryEntityLinks,
+  type EntityLinkHit,
+  type EntityLinkSearchHook,
+} from './search/entities.ts';
 export { handleSearch } from './search/handler.ts';
 export type { CombinedSearchResult, FtsResult, SearchConfidence, SearchProvenance, VectorResult } from './search/types.ts';

--- a/src/tools/search/entities.ts
+++ b/src/tools/search/entities.ts
@@ -1,0 +1,149 @@
+import { currentTenantId } from '../../middleware/tenant.ts';
+import { entityCollectionName } from '../../vector/entities.ts';
+import {
+  createVectorStoreForModel,
+  getEmbeddingModels,
+  type EmbeddingModelConfig,
+} from '../../vector/factory.ts';
+import type { VectorQueryResult, VectorStoreAdapter } from '../../vector/types.ts';
+import type { ToolContext } from '../types.ts';
+import type { CombinedSearchResult } from './types.ts';
+
+export type EntityLinkHit = {
+  sourceDocId: string;
+  entity: string;
+  score: number;
+  distance?: number;
+};
+
+export type EntityLinkSearchHook = (
+  query: string,
+  limit: number,
+  model?: string,
+) => EntityLinkHit[] | Promise<EntityLinkHit[]>;
+
+type EntityLinkContext = ToolContext & { entityLinkSearch?: EntityLinkSearchHook };
+type EntityStore = Pick<VectorStoreAdapter, 'connect' | 'ensureCollection' | 'query'>
+  & Partial<Pick<VectorStoreAdapter, 'close'>>;
+
+const DEFAULT_WEIGHT = 0.25;
+const MAX_LIMIT = 50;
+const MAX_MATCHES = 5;
+
+export function hasEntityLinkSearchHook(ctx: ToolContext): boolean {
+  return typeof (ctx as EntityLinkContext).entityLinkSearch === 'function';
+}
+
+export function applyEntityLinkBoost(
+  results: CombinedSearchResult[],
+  hits: EntityLinkHit[],
+  weight = DEFAULT_WEIGHT,
+): { results: CombinedSearchResult[]; boosted: number } {
+  if (results.length === 0 || hits.length === 0 || weight <= 0) return { results, boosted: 0 };
+  const links = aggregateHits(hits);
+  let boosted = 0;
+  const ranked = results.map((result, index) => {
+    const link = links.get(result.id);
+    if (!link) return { result, index };
+    const boostedScore = clamp(result.score + link.score * weight);
+    if (boostedScore > result.score) boosted += 1;
+    return {
+      result: {
+        ...result,
+        score: boostedScore,
+        entityLinkScore: round(link.score),
+        entityLinkMatches: link.matches,
+      },
+      index,
+    };
+  });
+  ranked.sort((a, b) => b.result.score - a.result.score || a.index - b.index);
+  return { results: ranked.map((item) => item.result), boosted };
+}
+
+export async function queryEntityLinks(
+  ctx: ToolContext,
+  query: string,
+  limit: number,
+  model?: string,
+): Promise<EntityLinkHit[]> {
+  const hook = (ctx as EntityLinkContext).entityLinkSearch;
+  if (hook) return cleanHits(await hook(query, boundedLimit(limit), model));
+
+  const models = getEmbeddingModels();
+  const preset = resolvePreset(model, models);
+  if (!preset) return [];
+
+  const store: EntityStore = createVectorStoreForModel({
+    ...preset,
+    collection: entityCollectionName(preset.collection),
+  });
+  try {
+    await store.connect();
+    await store.ensureCollection();
+    const tenantId = currentTenantId();
+    const filters = tenantId ? { tenant_id: tenantId } : undefined;
+    const result = await store.query(query, boundedLimit(limit), filters);
+    return cleanHits(hitsFromQuery(result));
+  } finally {
+    await store.close?.().catch(() => undefined);
+  }
+}
+
+function resolvePreset(
+  model: string | undefined,
+  models: Record<string, EmbeddingModelConfig>,
+): EmbeddingModelConfig | undefined {
+  if (model && models[model]) return models[model];
+  if (model) return Object.values(models).find((preset) => preset.collection === model);
+  return models['bge-m3'] ?? Object.values(models)[0];
+}
+
+function hitsFromQuery(result: VectorQueryResult): EntityLinkHit[] {
+  return result.ids.map((_, index) => {
+    const metadata = metadataAt(result, index);
+    const distance = Number(result.distances?.[index] ?? 0);
+    return {
+      sourceDocId: String(metadata.source_doc_id ?? ''),
+      entity: String(metadata.entity ?? result.documents?.[index] ?? ''),
+      score: 1 / (1 + Math.max(0, distance) / 100),
+      distance,
+    };
+  });
+}
+
+function aggregateHits(hits: EntityLinkHit[]): Map<string, { score: number; matches: string[] }> {
+  const grouped = new Map<string, { score: number; matches: string[] }>();
+  for (const hit of cleanHits(hits)) {
+    const existing = grouped.get(hit.sourceDocId) ?? { score: 0, matches: [] };
+    existing.score = Math.max(existing.score, hit.score);
+    if (hit.entity && !existing.matches.includes(hit.entity) && existing.matches.length < MAX_MATCHES) {
+      existing.matches.push(hit.entity);
+    }
+    grouped.set(hit.sourceDocId, existing);
+  }
+  return grouped;
+}
+
+function cleanHits(hits: EntityLinkHit[]): EntityLinkHit[] {
+  return hits
+    .filter((hit) => hit.sourceDocId.trim().length > 0)
+    .map((hit) => ({ ...hit, score: clamp(hit.score), entity: hit.entity.trim() }));
+}
+
+function metadataAt(result: VectorQueryResult, index: number): Record<string, unknown> {
+  const value = result.metadatas?.[index];
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function boundedLimit(limit: number): number {
+  return Math.min(MAX_LIMIT, Math.max(1, Math.trunc(limit) || 10));
+}
+
+function clamp(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.min(1, value)) : 0;
+}
+
+function round(value: number): number {
+  return Number(value.toFixed(3));
+}

--- a/src/tools/search/handler.ts
+++ b/src/tools/search/handler.ts
@@ -6,6 +6,7 @@ import type { SearchResult } from '../../server/types.ts';
 import { compactSearchResults, parseSearchRetrievalMode } from '../../search/compact-summary.ts';
 import { isVectorSectionEnabled } from '../../vector/config.ts';
 import type { ToolContext, ToolResponse, OracleSearchInput } from '../types.ts';
+import { applyEntityLinkBoost, hasEntityLinkSearchHook, queryEntityLinks } from './entities.ts';
 import { searchFts, mapFtsResults, enrichSupersedeFlags } from './fts.ts';
 import { attachSearchEvidence, combineResults, sanitizeFtsQuery } from './helpers.ts';
 import { vectorSearch } from './vector.ts';
@@ -72,8 +73,21 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
   const finalResults = reranked.reranked
     ? [...reranked.results, ...entityRankedResults.slice(50)]
     : entityRankedResults;
-  const totalMatches = finalResults.length;
-  let results: Array<Record<string, unknown>> = attachSearchEvidence(finalResults.slice(offset, offset + limit));
+  const hasEntityHook = hasEntityLinkSearchHook(ctx);
+  const entityLinksEnabled = requestedMode !== 'fts' && (effectiveMode !== 'fts' || hasEntityHook);
+  let entityLinkHits: Awaited<ReturnType<typeof queryEntityLinks>> = [];
+  let entityLinkWarning: string | undefined;
+  if (entityLinksEnabled && finalResults.length > 0) {
+    try {
+      entityLinkHits = await queryEntityLinks(ctx, query, Math.max(limit * 3, 10), model);
+    } catch (error) {
+      entityLinkWarning = error instanceof Error ? error.message : String(error);
+      console.error('[EntityLinkSearch]', entityLinkWarning);
+    }
+  }
+  const entityBoost = applyEntityLinkBoost(finalResults, entityLinkHits);
+  const totalMatches = entityBoost.results.length;
+  let results: Array<Record<string, unknown>> = attachSearchEvidence(entityBoost.results.slice(offset, offset + limit));
   enrichSupersedeFlags(ctx, results);
   const compact = retrieval.mode === 'compact-summary' ? compactSearchResults(results, query) : null;
   if (compact) results = compact.results;
@@ -94,6 +108,16 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
     ...(requestedMode !== 'fts' ? { vectorAvailable: vectorAvailable === true } : {}),
     reranked: reranked.reranked,
     ...(reranked.fallbackReason ? { rerankFallbackReason: reranked.fallbackReason } : {}),
+    ...(entityLinksEnabled ? {
+      entityLinks: {
+        enabled: true,
+        strategy: 'entity-link-sidecar-rank-boost',
+        graph: false,
+        hits: entityLinkHits.length,
+        boosted: entityBoost.boosted,
+        ...(entityLinkWarning ? { warning: entityLinkWarning } : {}),
+      },
+    } : {}),
     ...(compact ? { retrieval: compact.metadata } : {}),
     ...(warning ? { warning } : {}),
   };

--- a/src/tools/search/helpers.ts
+++ b/src/tools/search/helpers.ts
@@ -105,6 +105,8 @@ export function confidenceForResult(result: CombinedSearchResult): SearchConfide
   else signals.push('matched by vector search');
   if ((result.ftsScore ?? 0) >= 0.7) signals.push('strong keyword score');
   if ((result.vectorScore ?? 0) >= 0.7) signals.push('strong vector score');
+  if ((result.entity_score ?? 0) > 0) signals.push('matched by indexed entity-link ranking signal');
+  if ((result.entityLinkScore ?? 0) > 0) signals.push('matched by entity-link ranking signal');
 
   const thresholdBonus = source === 'hybrid' ? 0.05 : 0;
   const adjusted = boundedScore(score + thresholdBonus);
@@ -120,6 +122,10 @@ export function provenanceForResult(result: CombinedSearchResult): SearchProvena
     ...(result.vectorScore !== undefined ? { vector_score: Number(result.vectorScore.toFixed(3)) } : {}),
     ...(result.distance !== undefined ? { vector_distance: Number(result.distance.toFixed(3)) } : {}),
     ...(result.model ? { vector_model: result.model } : {}),
+    ...(result.entity_score !== undefined ? { entity_score: Number(result.entity_score.toFixed(3)) } : {}),
+    ...(result.entity_matches?.length ? { entity_matches: result.entity_matches } : {}),
+    ...(result.entityLinkScore !== undefined ? { entity_link_score: Number(result.entityLinkScore.toFixed(3)) } : {}),
+    ...(result.entityLinkMatches?.length ? { entity_link_matches: result.entityLinkMatches } : {}),
   };
 }
 

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -41,6 +41,10 @@ export type CombinedSearchResult = {
   vectorScore?: number;
   distance?: number;
   model?: string;
+  entity_score?: number;
+  entity_matches?: string[];
+  entityLinkScore?: number;
+  entityLinkMatches?: string[];
   superseded_by?: string;
   superseded_at?: string | null;
   superseded_reason?: string | null;
@@ -63,4 +67,8 @@ export type SearchProvenance = {
   vector_score?: number;
   vector_distance?: number;
   vector_model?: string;
+  entity_score?: number;
+  entity_matches?: string[];
+  entity_link_score?: number;
+  entity_link_matches?: string[];
 };


### PR DESCRIPTION
## Summary
- Wire entity sidecar hits into `oracle_search` ranking as a non-graph boost signal.
- Surface entity-link score/matches in search provenance and confidence signals.
- Add unit + MCP search integration coverage for rank changes from entity links.

Refs #2251

## Validation
```bash
bun test --isolate src/tools/__tests__/search.test.ts src/tools/__tests__/search-entity-link.test.ts src/tools/__tests__/search-supersede.test.ts tests/vector/entities.test.ts tests/http/vector/entity-search.test.ts
bunx tsc --noEmit
wc -l src/tools/search/entities.ts src/tools/search/handler.ts src/tools/search/helpers.ts src/tools/search/types.ts src/tools/search.ts src/tools/__tests__/search.test.ts src/tools/__tests__/search-entity-link.test.ts src/server/logging.ts src/server/types.ts
```
