### PR TITLE
test: validate unified memory ranking

### DIFF
--- a/src/routes/memory/index.ts
+++ b/src/routes/memory/index.ts
@@ -79,7 +79,13 @@ export function createMemoryRoutes(
         const records = store.getByIds(hits.map((hit) => hit.memoryId), query.asOf);
         const merged = mergeHits(hits, records);
         const scores = new Map(hits.map((hit) => [hit.memoryId, hit.score]));
-        const results = rankMemories(merged, { mode: 'semantic', asOf: query.asOf, score: (memory) => scores.get(memory.id) }).slice(0, limit);
+        const entityScores = new Map(hits.map((hit) => [hit.memoryId, entityScoreFromHit(hit)]));
+        const results = rankMemories(merged, {
+          mode: 'semantic',
+          asOf: query.asOf,
+          score: (memory) => scores.get(memory.id),
+          entityScore: (memory) => entityScores.get(memory.id),
+        }).slice(0, limit);
         return { success: true, query: query.q, asOf: isoAsOf(query.asOf), total: results.length, confidence: MEMORY_CONFIDENCE_STRATEGY, results };
       } catch (error) {
         const message = error instanceof Error ? error.message : 'memory vector search failed';
@@ -125,6 +131,15 @@ function mergeHits(hits: MemoryVectorHit[], records: MemoryRecord[]) {
 function hitTenant(hit: MemoryVectorHit): string | undefined {
   const value = hit.metadata.tenant_id ?? hit.metadata.tenantId ?? hit.metadata.tenant;
   return typeof value === 'string' ? value : undefined;
+}
+
+function entityScoreFromHit(hit: MemoryVectorHit): number | undefined {
+  const value = hit.metadata.entityScore
+    ?? hit.metadata.entity_score
+    ?? hit.metadata.entityMatchScore
+    ?? hit.metadata.entity_match_score;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.max(0, Math.min(1, parsed)) : undefined;
 }
 
 function memoryForHit(hit: MemoryVectorHit, record?: MemoryRecord): MemoryRecord {

--- a/src/routes/memory/rank.ts
+++ b/src/routes/memory/rank.ts
@@ -5,8 +5,8 @@ export type RankedMemory<T extends MemoryRecord = MemoryRecord> = T & {
   confidence: MemoryConfidence;
   ranking: {
     score: number;
-    components: { match: number; confidence: number; heat: number; validTime: number };
-    strategy: 'valid_time_confidence_heat_match';
+    components: { match: number; confidence: number; heat: number; validTime: number; entity: number };
+    strategy: 'valid_time_confidence_heat_entity_match';
   };
 };
 
@@ -15,6 +15,7 @@ export type RankMemoryOptions = {
   asOf?: string | number;
   now?: Date;
   score?: (memory: MemoryRecord) => number | undefined;
+  entityScore?: (memory: MemoryRecord) => number | undefined;
 };
 
 export function rankMemories<T extends MemoryRecord>(
@@ -28,14 +29,15 @@ export function rankMemories<T extends MemoryRecord>(
     const confidence = memoryConfidence(memory, { mode: options.mode ?? 'keyword', semanticScore: match, now });
     const heat = heatScore(memory, now);
     const validTime = validTimeScore(memory, asOf);
-    const score = round((match * 0.45) + (confidence.score * 0.25) + (heat * 0.2) + (validTime * 0.1));
+    const entity = clamp(options.entityScore?.(memory) ?? entitySignal(memory));
+    const score = round((match * 0.38) + (confidence.score * 0.22) + (heat * 0.18) + (validTime * 0.1) + (entity * 0.12));
     return {
       ...memory,
       confidence,
       ranking: {
         score,
-        components: { match: round(match), confidence: confidence.score, heat: round(heat), validTime: round(validTime) },
-        strategy: 'valid_time_confidence_heat_match',
+        components: { match: round(match), confidence: confidence.score, heat: round(heat), validTime: round(validTime), entity: round(entity) },
+        strategy: 'valid_time_confidence_heat_entity_match',
       },
       __rankIndex: index,
     } as RankedMemory<T> & { __rankIndex: number };
@@ -64,6 +66,13 @@ function validTimeScore(memory: MemoryRecord, asOf: number): number {
   const recency = 0.5 ** (ageDays / 365);
   const bounded = to === undefined ? 0 : 0.1;
   return clamp(0.75 + bounded + (recency * 0.15));
+}
+
+function entitySignal(memory: MemoryRecord): number {
+  const value = (memory as Record<string, unknown>).entityScore
+    ?? (memory as Record<string, unknown>).entityMatchScore
+    ?? (memory as Record<string, unknown>).entity_match_score;
+  return safeNumber(value);
 }
 
 function parseTime(value: string | number | undefined): number | undefined {

--- a/tests/http/memory/rank.test.ts
+++ b/tests/http/memory/rank.test.ts
@@ -36,8 +36,9 @@ test('rankMemories combines vector score, confidence, heat, and valid-time recen
   });
 
   expect(ranked.map((item) => item.id)).toEqual(['current-relevant', 'stale-hot']);
-  expect(ranked[0].ranking.strategy).toBe('valid_time_confidence_heat_match');
+  expect(ranked[0].ranking.strategy).toBe('valid_time_confidence_heat_entity_match');
   expect(ranked[0].ranking.components).toMatchObject({ match: 0.92 });
+  expect(ranked[0].ranking.components.entity).toBe(0);
   expect(ranked[1].ranking.components.heat).toBeGreaterThan(0.8);
 });
 

--- a/tests/integration/memory/unified-ranking.test.ts
+++ b/tests/integration/memory/unified-ranking.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from 'bun:test';
+import { createMemoryRoutes } from '../../../src/routes/memory/index.ts';
+import type { MemoryRecord, MemoryStore } from '../../../src/routes/memory/store.ts';
+import type { MemoryVectorHit, MemoryVectorIndex } from '../../../src/routes/memory/vector.ts';
+
+type RankedMemory = MemoryRecord & {
+  ranking: {
+    score: number;
+    strategy: string;
+    components: { match: number; confidence: number; heat: number; validTime: number; entity: number };
+  };
+};
+
+const now = Date.now();
+const asOf = new Date(now).toISOString();
+
+function iso(daysAgo: number): string {
+  return new Date(now - (daysAgo * 86_400_000)).toISOString();
+}
+
+function memory(id: string, overrides: Partial<MemoryRecord> = {}): MemoryRecord {
+  return {
+    id,
+    content: `${id} unified ranking memory`,
+    createdAt: iso(200),
+    updatedAt: iso(200),
+    ...overrides,
+  };
+}
+
+const records = new Map<string, MemoryRecord>([
+  ['high-match-only', memory('high-match-only', {
+    content: 'High semantic match without heat, confidence provenance, or entity sidecar support.',
+    validFrom: iso(2),
+    updatedAt: iso(2),
+  })],
+  ['entity-only', memory('entity-only', {
+    title: 'Entity sidecar hit',
+    source: 'entity-sidecar',
+    tags: ['oracle', 'entity'],
+    validFrom: iso(160),
+    updatedAt: iso(30),
+  })],
+  ['hot-expired', memory('hot-expired', {
+    title: 'Hot but expired',
+    source: 'old-policy',
+    tags: ['oracle', 'heat'],
+    validFrom: iso(400),
+    validTo: iso(1),
+    usageCount: 25,
+    lastAccessedAt: iso(0),
+    updatedAt: iso(5),
+  })],
+  ['unified-winner', memory('unified-winner', {
+    title: 'Unified memory ranking',
+    source: 'issue-2251',
+    tags: ['oracle', 'entity', 'confidence'],
+    validFrom: iso(1),
+    usageCount: 18,
+    lastAccessedAt: iso(0),
+    updatedAt: iso(1),
+  })],
+]);
+
+const hits: MemoryVectorHit[] = [
+  hit('high-match-only', 0.99, 0),
+  hit('hot-expired', 0.45, 0.4),
+  hit('entity-only', 0.65, 0.98),
+  hit('unified-winner', 0.78, 0.9),
+];
+
+function hit(memoryId: string, score: number, entityScore: number): MemoryVectorHit {
+  return {
+    memoryId,
+    vectorId: `memory:${memoryId}`,
+    document: records.get(memoryId)?.content ?? '',
+    metadata: { memoryId, type: 'memory', entityScore },
+    distance: 1 - score,
+    score,
+  };
+}
+
+const store = {
+  getByIds(ids: string[]) {
+    return ids.map((id) => records.get(id)).filter((record): record is MemoryRecord => Boolean(record));
+  },
+} as unknown as MemoryStore;
+
+const vectorIndex: MemoryVectorIndex = {
+  async index() { return { indexed: true }; },
+  async search() { return hits; },
+};
+
+describe('unified memory ranking integration (#2251)', () => {
+  test('combines heat, valid-time, confidence, and entity sidecar scores into ordering', async () => {
+    const app = createMemoryRoutes(store, vectorIndex);
+    const res = await app.handle(new Request(`http://local/api/memory/search?q=oracle&limit=4&asOf=${encodeURIComponent(asOf)}`));
+    const body = await res.json() as { success: boolean; results: RankedMemory[] };
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.results.map((result) => result.id)).toEqual([
+      'unified-winner',
+      'high-match-only',
+      'entity-only',
+      'hot-expired',
+    ]);
+
+    const [winner, highMatch, entityOnly, expired] = body.results;
+    expect(winner.ranking.strategy).toBe('valid_time_confidence_heat_entity_match');
+    expect(winner.ranking.components.match).toBeGreaterThan(0.7);
+    expect(winner.ranking.components.confidence).toBeGreaterThan(0.85);
+    expect(winner.ranking.components.heat).toBeGreaterThan(0.85);
+    expect(winner.ranking.components.validTime).toBeGreaterThan(0.85);
+    expect(winner.ranking.components.entity).toBeGreaterThan(0.85);
+    expect(highMatch.ranking.components.match).toBeGreaterThan(winner.ranking.components.match);
+    expect(entityOnly.ranking.components.entity).toBeGreaterThan(winner.ranking.components.entity);
+    expect(expired.ranking.components.validTime).toBe(0);
+    expect(winner.ranking.score).toBeGreaterThan(highMatch.ranking.score);
+  });
+});


### PR DESCRIPTION
## Summary
- Add entity sidecar score support to the memory ranking blend alongside match, confidence, heat, and valid-time.
- Pass entity scores from memory vector hit metadata into semantic memory search ranking.
- Add tests/integration/memory coverage asserting combined ordering for #2251.

Refs #2251

## Verification
- rtk bunx tsc --noEmit
- rtk bun test tests/integration/memory tests/http/memory/rank.test.ts tests/http/memory/save-recall.test.ts tests/http/memory/confidence.test.ts tests/http/vector/entity-search.test.ts tests/vector/entities.test.ts
- rtk git diff --check
- wc -l src/routes/memory/rank.ts src/routes/memory/index.ts tests/http/memory/rank.test.ts tests/integration/memory/unified-ranking.test.ts