### PR TITLE
feat(frontend): add memory confidence dashboard

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -70,7 +70,7 @@ export function AppShell({
     { to: '/vector/settings', label: 'Vector settings', description: 'Collection config and index controls' },
     { to: '/vector/export', label: 'Export', description: 'Download vector collections' },
     { to: '/learn', label: 'Learn', description: 'Create and edit learnings' },
-    { to: '/memory', label: 'Memory Health', description: 'Heat-score and recency visualization' },
+    { to: '/memory', label: 'Memory Dashboard', description: 'Confidence, heat, provenance, valid-time, and recency' },
     { to: '/metrics', label: 'Metrics', description: 'Runtime counters from /api/v1/metrics' },
     { to: '/mcp', label: 'MCP', description: 'Tool schemas and groups' },
     { to: '/storage', label: 'Storage', description: 'Backend config from /api/settings/system' },

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -19,7 +19,7 @@ export function commandPaletteActions(onRefresh: () => void): CommandPaletteActi
     { id: 'status', label: 'Status', description: 'Review server health from /api/v1/health.', href: '/status' },
     { id: 'storage', label: 'Storage backend', description: 'Inspect backend config from /api/settings/system.', href: '/storage' },
     { id: 'vector', label: 'Vector', description: 'Open vector search and indexing surfaces.', href: '/vector' },
-    { id: 'memory', label: 'Memory health', description: 'Review heat-score and recency signals.', href: '/memory' },
+    { id: 'memory', label: 'Memory Dashboard', description: 'Review memory health heat-score, confidence, provenance, valid-time, and recency signals.', href: '/memory' },
     { id: 'metrics', label: 'Metrics', description: 'Review dashboard metrics and counts.', href: '/metrics' },
     { id: 'settings', label: 'Settings', description: 'Inspect runtime settings and migration status.', href: '/settings' },
     { id: 'refresh', label: 'Refresh dashboard data', description: 'Reload menu and plugin data.', onAction: onRefresh },

--- a/frontend/src/memoryDashboard.ts
+++ b/frontend/src/memoryDashboard.ts
@@ -1,0 +1,139 @@
+import { apiFetch } from './api';
+import type { ProvenanceSearchResult } from './components/searchResultView';
+
+export type MemoryConfidence = {
+  score: number;
+  label?: string;
+  freshness?: number;
+  usageCount?: number;
+  lastAccessedAgeDays?: number;
+  components?: { match?: number; freshness?: number; provenance?: number; usage?: number };
+  warnings?: string[];
+  reasons?: string[];
+};
+
+export type RankedMemory = {
+  id: string;
+  content: string;
+  title?: string;
+  tags?: string[];
+  source?: string;
+  createdAt: string;
+  updatedAt: string;
+  validFrom?: string;
+  validTo?: string;
+  validUntil?: string;
+  supersededAt?: string;
+  supersededReason?: string;
+  confidence: MemoryConfidence;
+  ranking?: {
+    score: number;
+    components?: { match?: number; confidence?: number; heat?: number; validTime?: number };
+    strategy?: string;
+  };
+};
+
+export type MemoryRecallResponse = {
+  query?: string;
+  asOf?: string;
+  total: number;
+  items: RankedMemory[];
+  error?: string;
+};
+
+export type MemoryDashboardSummary = {
+  total: number;
+  sourceCoverage: number;
+  avgConfidence: number;
+  avgHeat: number;
+  avgProvenance: number;
+  validWindowCount: number;
+  highConfidenceCount: number;
+};
+
+function bounded(value: unknown): number {
+  const numeric = Number(value ?? 0);
+  return Number.isFinite(numeric) ? Math.max(0, Math.min(1, numeric)) : 0;
+}
+
+function average(items: RankedMemory[], signal: (memory: RankedMemory) => number): number {
+  return items.length ? items.reduce((sum, item) => sum + signal(item), 0) / items.length : 0;
+}
+
+export function percentText(value: number): string {
+  return `${Math.round(bounded(value) * 100)}%`;
+}
+
+export function memoryHeat(memory: RankedMemory): number {
+  return bounded(memory.ranking?.components?.heat ?? memory.confidence.components?.usage);
+}
+
+export function validTimeScore(memory: RankedMemory): number {
+  return bounded(memory.ranking?.components?.validTime ?? (memory.validFrom || memory.validTo || memory.validUntil ? 1 : 0.75));
+}
+
+export function memoryDashboardSummary(items: RankedMemory[]): MemoryDashboardSummary {
+  return {
+    total: items.length,
+    sourceCoverage: average(items, (item) => item.source ? 1 : 0),
+    avgConfidence: average(items, (item) => bounded(item.confidence.score)),
+    avgHeat: average(items, memoryHeat),
+    avgProvenance: average(items, (item) => bounded(item.confidence.components?.provenance)),
+    validWindowCount: items.filter((item) => Boolean(item.validFrom || item.validTo || item.validUntil)).length,
+    highConfidenceCount: items.filter((item) => item.confidence.label === 'high' || item.confidence.score >= 0.75).length,
+  };
+}
+
+export function memoryPreview(content: string, maxLength = 220): string {
+  const compact = content.replace(/\s+/g, ' ').trim() || 'No memory preview returned.';
+  return compact.length > maxLength ? `${compact.slice(0, maxLength - 1).trimEnd()}…` : compact;
+}
+
+export function shortDate(value?: string): string {
+  if (!value) return 'open';
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? new Date(timestamp).toISOString().slice(0, 10) : value;
+}
+
+export function validTimeWindow(memory: RankedMemory): string {
+  const start = memory.validFrom || memory.createdAt;
+  const end = memory.validTo || memory.validUntil;
+  return end ? `valid ${shortDate(start)} → ${shortDate(end)}` : `valid since ${shortDate(start)}`;
+}
+
+export function memoryToSignalResult(memory: RankedMemory): ProvenanceSearchResult {
+  return {
+    id: memory.id,
+    content: memory.content,
+    title: memory.title,
+    type: 'memory',
+    source: 'memory',
+    source_file: memory.source || `memory:${memory.id}`,
+    concepts: memory.tags ?? [],
+    score: memory.ranking?.score ?? memory.confidence.score,
+    memorySource: memory.source,
+    usageCount: memory.confidence.usageCount,
+    confidence: {
+      ...memory.confidence,
+      components: { ...memory.confidence.components, usage: memoryHeat(memory) },
+    },
+    rankingScore: memory.ranking?.score,
+    superseded_at: memory.supersededAt,
+    superseded_reason: memory.supersededReason,
+    valid_time: memory.validFrom || memory.createdAt,
+    valid_until: memory.validTo || memory.validUntil,
+    tags: memory.tags,
+    createdAt: memory.createdAt,
+    updatedAt: memory.updatedAt,
+  };
+}
+
+export async function fetchMemoryRecall(params: { q?: string; asOf?: string; limit?: number } = {}): Promise<MemoryRecallResponse> {
+  const qs = new URLSearchParams({ limit: String(params.limit ?? 50) });
+  if (params.q?.trim()) qs.set('q', params.q.trim());
+  if (params.asOf?.trim()) qs.set('asOf', params.asOf.trim());
+  const response = await apiFetch(`/api/memory/recall?${qs}`);
+  const data = await response.json() as MemoryRecallResponse;
+  if (!response.ok) throw new Error(data.error || `/api/memory/recall returned ${response.status}`);
+  return { ...data, items: Array.isArray(data.items) ? data.items : [], total: Number.isFinite(data.total) ? data.total : 0 };
+}

--- a/frontend/src/pages/MemoryDashboardPage.tsx
+++ b/frontend/src/pages/MemoryDashboardPage.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import { Badge } from '../components/Badge';
+import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
+import { MeterBar } from '../components/MeterBar';
+import { SearchResultSignals } from '../components/SearchResultSignals';
+import { StatCard } from '../components/StatCard';
+import {
+  fetchMemoryRecall,
+  memoryDashboardSummary,
+  memoryPreview,
+  memoryToSignalResult,
+  percentText,
+  validTimeScore,
+  validTimeWindow,
+  type MemoryRecallResponse,
+  type RankedMemory,
+} from '../memoryDashboard';
+
+type PageState = 'idle' | 'loading' | 'ready' | 'error';
+type MemoryClient = (params?: { q?: string; asOf?: string; limit?: number }) => Promise<MemoryRecallResponse>;
+
+function MemoryCard({ memory }: { memory: RankedMemory }) {
+  const signal = memoryToSignalResult(memory);
+  const rank = memory.ranking?.score ?? memory.confidence.score;
+  const validScore = validTimeScore(memory);
+  return (
+    <article className="rounded-2xl border border-border bg-surface p-4 shadow-lg shadow-black/10">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="font-mono text-sm font-semibold text-accent">{memory.title || memory.id}</h2>
+          <p className="mt-2 text-sm leading-6 text-text-muted">{memoryPreview(memory.content)}</p>
+        </div>
+        <Badge tone={rank >= 0.75 ? 'success' : rank >= 0.45 ? 'warning' : 'danger'} ariaLabel={`Memory rank ${percentText(rank)}`}>
+          rank {percentText(rank)}
+        </Badge>
+      </div>
+
+      <SearchResultSignals result={signal} />
+
+      <section aria-label="Memory valid-time" className="mt-3 rounded-xl border border-border bg-surface-muted p-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-text-muted">valid-time</p>
+            <p className="mt-1 text-sm font-medium text-text">{validTimeWindow(memory)}</p>
+          </div>
+          <Badge tone={memory.validTo || memory.validUntil ? 'warning' : 'accent'}>
+            {memory.validTo || memory.validUntil ? 'bounded' : 'open-ended'}
+          </Badge>
+        </div>
+        <div className="mt-3">
+          <MeterBar label="Valid-time fit" percent={validScore * 100} tone="accent2" valueText={percentText(validScore)} description="Derived from the active as-of snapshot and memory validity window." />
+        </div>
+      </section>
+
+      {memory.tags?.length ? (
+        <div className="mt-3 flex flex-wrap gap-1" aria-label="Memory tags">
+          {memory.tags.map((tag) => <Badge key={tag} tone="neutral">{tag}</Badge>)}
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+export function MemoryDashboardContent({ items, total, asOf, state, error }: {
+  items: RankedMemory[];
+  total: number;
+  asOf?: string;
+  state: PageState;
+  error?: string;
+}) {
+  const summary = useMemo(() => memoryDashboardSummary(items), [items]);
+  const shown = items.length;
+  return (
+    <div className="grid gap-5">
+      <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="memory-dashboard-title">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Memory</p>
+        <h1 id="memory-dashboard-title" className="mt-2 text-3xl font-semibold text-text">Memory dashboard</h1>
+        <p className="mt-2 max-w-3xl text-sm text-text-muted">
+          One Studio view for KB provenance, confidence, retrieval heat, and valid-time windows from /api/memory/recall.
+        </p>
+        {asOf ? <p className="mt-3 text-xs text-text-muted">Snapshot as of {asOf}</p> : null}
+      </section>
+
+      <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5" aria-label="Memory signal summary">
+        <StatCard label="Memories" value={shown} detail={total > shown ? `${total} total available` : 'active KB memories'} tone="accent" />
+        <StatCard label="High confidence" value={summary.highConfidenceCount} detail={`${percentText(summary.avgConfidence)} average`} tone="success" />
+        <StatCard label="Source coverage" value={percentText(summary.sourceCoverage)} detail={`${percentText(summary.avgProvenance)} provenance avg`} tone="accent" />
+        <StatCard label="Heat" value={percentText(summary.avgHeat)} detail="retrieval reinforcement" tone="warning" />
+        <StatCard label="Valid-time" value={summary.validWindowCount} detail="bounded windows" tone="neutral" />
+      </section>
+
+      <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-label="Memory dashboard meters">
+        <div className="grid gap-4 md:grid-cols-4">
+          <MeterBar label="Confidence" percent={summary.avgConfidence * 100} tone="success" valueText={percentText(summary.avgConfidence)} />
+          <MeterBar label="Provenance" percent={summary.avgProvenance * 100} tone="accent" valueText={percentText(summary.avgProvenance)} />
+          <MeterBar label="Heat" percent={summary.avgHeat * 100} tone="warning" valueText={percentText(summary.avgHeat)} />
+          <MeterBar label="Source coverage" percent={summary.sourceCoverage * 100} tone="accent2" valueText={percentText(summary.sourceCoverage)} />
+        </div>
+      </section>
+
+      {state === 'loading' ? <LoadingPanel title="Loading memory dashboard" detail="Fetching /api/memory/recall for confidence and valid-time signals." /> : null}
+      {state === 'error' ? <ErrorMessage title="Memory dashboard failed." message={error || 'Unable to load memory recall.'} /> : null}
+      {state === 'ready' && !items.length ? <p className="rounded-2xl border border-border bg-surface p-4 text-sm text-text-muted">No memories matched this dashboard filter.</p> : null}
+      <div className="grid gap-3 xl:grid-cols-2" aria-label="Memory dashboard results">
+        {items.map((memory) => <MemoryCard key={memory.id} memory={memory} />)}
+      </div>
+    </div>
+  );
+}
+
+export function MemoryDashboardPage({ client = fetchMemoryRecall }: { client?: MemoryClient }) {
+  const [query, setQuery] = useState('');
+  const [asOf, setAsOf] = useState('');
+  const [items, setItems] = useState<RankedMemory[]>([]);
+  const [total, setTotal] = useState(0);
+  const [responseAsOf, setResponseAsOf] = useState<string | undefined>();
+  const [state, setState] = useState<PageState>('idle');
+  const [error, setError] = useState('');
+
+  async function load(nextQuery = query, nextAsOf = asOf) {
+    setState('loading');
+    setError('');
+    try {
+      const response = await client({ q: nextQuery, asOf: nextAsOf, limit: 50 });
+      setItems(response.items);
+      setTotal(response.total);
+      setResponseAsOf(response.asOf || nextAsOf || undefined);
+      setState('ready');
+    } catch (cause) {
+      setItems([]);
+      setTotal(0);
+      setError(cause instanceof Error ? cause.message : String(cause));
+      setState('error');
+    }
+  }
+
+  useEffect(() => { void load('', ''); }, []);
+
+  function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    void load(query, asOf);
+  }
+
+  return (
+    <div className="grid gap-5">
+      <form aria-label="Memory dashboard filters" className="grid gap-3 rounded-3xl border border-border bg-surface p-5 sm:grid-cols-[minmax(0,1fr)_16rem_auto] sm:p-6" onSubmit={submit}>
+        <input aria-label="Memory dashboard query" className="focus-ring rounded-xl border border-border bg-field px-4 py-3 text-text placeholder:text-text-muted" value={query} onChange={(event) => setQuery(event.currentTarget.value)} placeholder="Filter memories by source, title, tag…" type="search" />
+        <input aria-label="Valid-time snapshot" className="focus-ring rounded-xl border border-border bg-field px-4 py-3 text-text" value={asOf} onChange={(event) => setAsOf(event.currentTarget.value)} type="datetime-local" />
+        <button className="focus-ring rounded-xl bg-accent-solid px-5 py-3 font-semibold text-on-accent transition hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50" disabled={state === 'loading'} type="submit">
+          {state === 'loading' ? 'Loading…' : 'Refresh' }
+        </button>
+      </form>
+      <MemoryDashboardContent items={items} total={total} asOf={responseAsOf} state={state} error={error} />
+    </div>
+  );
+}

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useMemo, useState, type FormEvent } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { searchMemoryHealth } from '../api';
+import { fetchMemoryRecall, type MemoryRecallResponse, type RankedMemory } from '../memoryDashboard';
 import { MemoryDashboardInsights } from '../components/MemoryDashboardInsights';
+import { MemoryDashboardContent } from './MemoryDashboardPage';
 import { MemoryHealthPanel } from '../components/MemoryHealthPanel';
 import { SearchResultCard } from '../components/SearchResultCard';
 import { memoryPath, vectorResultsPath } from '../routePaths';
@@ -9,6 +11,7 @@ import type { SearchResponse, SearchResult } from '../types';
 
 type PageState = 'idle' | 'loading' | 'ready' | 'error';
 type MemorySearch = (query: string, limit?: number) => Promise<SearchResponse>;
+type MemoryRecall = (params?: { q?: string; asOf?: string; limit?: number }) => Promise<MemoryRecallResponse>;
 
 export function memoryHealthStatus(state: PageState, query: string, total: number): string {
   if (state === 'idle') return 'Search memory to inspect heat-score, recency, and recall signals.';
@@ -30,7 +33,7 @@ function MemoryRouteLinks() {
   );
 }
 
-export function MemoryPage({ search = searchMemoryHealth }: { search?: MemorySearch }) {
+export function MemoryPage({ search = searchMemoryHealth, recall = fetchMemoryRecall }: { search?: MemorySearch; recall?: MemoryRecall }) {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const routeQuery = searchParams.get('q') ?? '';
@@ -39,6 +42,11 @@ export function MemoryPage({ search = searchMemoryHealth }: { search?: MemorySea
   const [results, setResults] = useState<SearchResult[]>([]);
   const [state, setState] = useState<PageState>('idle');
   const [error, setError] = useState('');
+  const [dashboardItems, setDashboardItems] = useState<RankedMemory[]>([]);
+  const [dashboardTotal, setDashboardTotal] = useState(0);
+  const [dashboardAsOf, setDashboardAsOf] = useState<string | undefined>();
+  const [dashboardState, setDashboardState] = useState<PageState>('idle');
+  const [dashboardError, setDashboardError] = useState('');
 
   async function runSearch(nextQuery: string) {
     const q = nextQuery.trim();
@@ -63,10 +71,29 @@ export function MemoryPage({ search = searchMemoryHealth }: { search?: MemorySea
     }
   }
 
+  async function loadDashboard() {
+    setDashboardState('loading');
+    setDashboardError('');
+    try {
+      const response = await recall({ limit: 50 });
+      setDashboardItems(response.items);
+      setDashboardTotal(response.total);
+      setDashboardAsOf(response.asOf);
+      setDashboardState('ready');
+    } catch (err) {
+      setDashboardItems([]);
+      setDashboardTotal(0);
+      setDashboardError(err instanceof Error ? err.message : String(err));
+      setDashboardState('error');
+    }
+  }
+
   useEffect(() => {
     setQuery(routeQuery);
     void runSearch(routeQuery);
   }, [routeQuery]);
+
+  useEffect(() => { void loadDashboard(); }, []);
 
   function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -79,11 +106,13 @@ export function MemoryPage({ search = searchMemoryHealth }: { search?: MemorySea
 
   return (
     <div className="grid gap-5">
+      <MemoryDashboardContent items={dashboardItems} total={dashboardTotal} asOf={dashboardAsOf} state={dashboardState} error={dashboardError} />
+
       <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="memory-health-page-title">
         <div className="mb-5 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
           <div>
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent2">Memory</p>
-            <h1 id="memory-health-page-title" className="mt-2 text-3xl font-semibold text-text">Memory health</h1>
+            <h2 id="memory-health-page-title" className="mt-2 text-2xl font-semibold text-text">Memory health</h2>
             <p className="mt-2 text-sm text-text-muted">Inspect heat-score, last-recalled, and recall counts from Studio memory search results.</p>
           </div>
           <MemoryRouteLinks />

--- a/frontend/src/routeMeta.ts
+++ b/frontend/src/routeMeta.ts
@@ -84,7 +84,10 @@ export function routeMeta(pathname: string, search = ''): RouteMeta {
 
   if (pathname === '/memory') {
     const query = new URLSearchParams(search).get('q')?.trim();
-    return base('Memory health', 'Memory', query ? `Heat-score and recency signals for “${query}”.` : 'Heat-score and recency visualization for Studio memory.', [{ label: 'Memory health' }]);
+    const description = query
+      ? `Provenance, confidence, heat, valid-time, and recency signals for “${query}”.`
+      : 'Provenance, confidence, heat, valid-time, and recency across Studio memory.';
+    return base('Memory dashboard', 'Memory', description, [{ label: 'Memory dashboard' }]);
   }
 
   if (pathname === '/plugins') return base('Plugin list', 'Plugins', 'Registered plugins and exposed runtime surfaces.', [{ label: 'Plugins' }]);

--- a/tests/frontend/components/app-shell-memory-nav.test.tsx
+++ b/tests/frontend/components/app-shell-memory-nav.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+import { MemoryRouter } from 'react-router-dom';
+import { AppShell } from '../../../frontend/src/components/AppShell';
+import { htmlFor, installBrowserLocation } from '../_render';
+
+describe('AppShell memory navigation', () => {
+  test('links to the memory dashboard from the sidebar', () => {
+    const restore = installBrowserLocation('/memory');
+    try {
+      const html = htmlFor(
+        <MemoryRouter initialEntries={['/memory']}>
+          <AppShell error="" loading={false} menuCount={0} pluginCount={0} surfaceCount={0} updatedAt="never" onRefresh={() => {}}>
+            <p>child</p>
+          </AppShell>
+        </MemoryRouter>,
+      );
+      expect(html).toContain('aria-label="Memory Dashboard: Confidence, heat, provenance, valid-time, and recency"');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/tests/frontend/components/app-shell-vector-nav.test.tsx
+++ b/tests/frontend/components/app-shell-vector-nav.test.tsx
@@ -20,7 +20,7 @@ describe('AppShell Vector navigation', () => {
       expect(html).toContain('aria-label="Index Manager: Backfill vectors and watch jobs"');
       expect(html).toContain('aria-label="Vector Search: Semantic preview by collection"');
       expect(html).toContain('aria-label="Export App: Legacy v2 JSON/Markdown backups"');
-      expect(html).toContain('aria-label="Memory Health: Heat-score and recency visualization"');
+      expect(html).toContain('aria-label="Memory Dashboard: Confidence, heat, provenance, valid-time, and recency"');
       expect(html).toContain('aria-label="Export: Download vector collections"');
     } finally {
       restore();

--- a/tests/frontend/pages/memory-dashboard-page.test.tsx
+++ b/tests/frontend/pages/memory-dashboard-page.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test';
+import { MemoryDashboardContent } from '../../../frontend/src/pages/MemoryDashboardPage';
+import { htmlFor } from '../_render';
+
+const items = [{
+  id: 'mem-1',
+  title: 'Source-backed memory',
+  content: 'A sourced memory with strong provenance, heat, and a bounded valid-time window.',
+  tags: ['provenance'],
+  source: 'vault/source.md',
+  createdAt: '2026-06-01T00:00:00.000Z',
+  updatedAt: '2026-06-02T00:00:00.000Z',
+  validFrom: '2026-06-01T00:00:00.000Z',
+  validTo: '2026-06-30T00:00:00.000Z',
+  confidence: { score: 0.86, label: 'high', usageCount: 8, freshness: 0.9, components: { match: 0.88, freshness: 0.9, provenance: 1, usage: 0.7 } },
+  ranking: { score: 0.82, components: { match: 0.88, confidence: 0.86, heat: 0.7, validTime: 0.92 } },
+}];
+
+describe('MemoryDashboardContent', () => {
+  test('renders one Studio view for memory confidence signals', () => {
+    const html = htmlFor(<MemoryDashboardContent items={items} total={1} asOf="2026-06-17T00:00:00.000Z" state="ready" />);
+    expect(html).toContain('Memory dashboard');
+    expect(html).toContain('Source coverage');
+    expect(html).toContain('confidence 86% · high');
+    expect(html).toContain('heat 70%');
+    expect(html).toContain('valid 2026-06-01 → 2026-06-30');
+    expect(html).toContain('Valid-time fit');
+  });
+});

--- a/tests/frontend/pages/memory-dashboard-summary.test.ts
+++ b/tests/frontend/pages/memory-dashboard-summary.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+import { memoryDashboardSummary, memoryToSignalResult, percentText, validTimeWindow } from '../../../frontend/src/memoryDashboard';
+
+const memories = [{
+  id: 'm1',
+  content: 'Memory one',
+  title: 'One',
+  source: 'vault/one.md',
+  tags: ['kb'],
+  createdAt: '2026-06-01T00:00:00.000Z',
+  updatedAt: '2026-06-02T00:00:00.000Z',
+  validFrom: '2026-06-01T00:00:00.000Z',
+  validTo: '2026-07-01T00:00:00.000Z',
+  confidence: { score: 0.8, label: 'high', usageCount: 4, components: { provenance: 1, usage: 0.5 } },
+  ranking: { score: 0.77, components: { heat: 0.6, validTime: 0.9 } },
+}, {
+  id: 'm2',
+  content: 'Memory two',
+  createdAt: '2026-06-03T00:00:00.000Z',
+  updatedAt: '2026-06-04T00:00:00.000Z',
+  confidence: { score: 0.4, label: 'low', components: { provenance: 0.2, usage: 0 } },
+}] as const;
+
+describe('memory dashboard helpers', () => {
+  test('summarizes provenance, heat, confidence, and valid-time signals', () => {
+    const summary = memoryDashboardSummary([...memories]);
+    expect(summary.total).toBe(2);
+    expect(percentText(summary.sourceCoverage)).toBe('50%');
+    expect(percentText(summary.avgConfidence)).toBe('60%');
+    expect(percentText(summary.avgHeat)).toBe('30%');
+    expect(summary.validWindowCount).toBe(1);
+    expect(validTimeWindow(memories[0])).toBe('valid 2026-06-01 → 2026-07-01');
+    expect(memoryToSignalResult(memories[0]).memorySource).toBe('vault/one.md');
+  });
+});

--- a/tests/frontend/router.test.ts
+++ b/tests/frontend/router.test.ts
@@ -71,6 +71,7 @@ describe('frontend router', () => {
     expect(htmlAt('/search')).toContain('Full-text menu search');
     expect(htmlAt('/export')).toContain('Export app');
     expect(htmlAt('/learn')).toContain('Learn entries');
+    expect(htmlAt('/memory')).toContain('Memory dashboard');
     expect(htmlAt('/memory')).toContain('Memory health');
     expect(htmlAt('/vector')).toContain('Vector dashboard');
     expect(htmlAt('/vector/search')).toContain('Vector search preview');

--- a/tests/frontend/routes/memory-meta.test.ts
+++ b/tests/frontend/routes/memory-meta.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'bun:test';
+import { routeMeta } from '../../../frontend/src/routeMeta';
+
+describe('memory route metadata', () => {
+  test('describes the Memory dashboard route chrome', () => {
+    expect(routeMeta('/memory')).toMatchObject({
+      title: 'Memory dashboard',
+      eyebrow: 'Memory',
+      description: 'Provenance, confidence, heat, valid-time, and recency across Studio memory.',
+    });
+  });
+});

--- a/tests/frontend/routes/memory-route.test.ts
+++ b/tests/frontend/routes/memory-route.test.ts
@@ -9,7 +9,7 @@ describe('memory route helpers', () => {
   });
 
   test('returns memory route chrome metadata', () => {
-    expect(routeMeta('/memory')).toMatchObject({ title: 'Memory health', eyebrow: 'Memory' });
-    expect(routeMeta('/memory', '?q=oracle').description).toBe('Heat-score and recency signals for “oracle”.');
+    expect(routeMeta('/memory')).toMatchObject({ title: 'Memory dashboard', eyebrow: 'Memory' });
+    expect(routeMeta('/memory', '?q=oracle').description).toBe('Provenance, confidence, heat, valid-time, and recency signals for “oracle”.');
   });
 });


### PR DESCRIPTION
## Summary
- Add a Studio Memory Dashboard surface at `/memory` for one-view KB provenance, confidence, retrieval heat, and valid-time windows.
- Keep the sibling Memory Health search/heat/recency surface on the same Studio view, preserving both #2251 signal sets after the alpha rebase.
- Fetch `/api/memory/recall` and summarize source coverage, average confidence/provenance/heat, bounded valid-time windows, and per-memory shared signal cards.

Refs #2251

## Verification
- `bunx tsc --noEmit`
- `cd frontend && bunx tsc --noEmit`
- `bun test tests/frontend/` (341 pass)
- Screenshot: `test-results/2251-memory-dashboard.png`
- Changed files line count: all <=250 lines
