### PR TITLE
feat(memory): expose memory stats endpoint

### DIFF
--- a/src/routes/memory/index.ts
+++ b/src/routes/memory/index.ts
@@ -8,6 +8,7 @@ import { MEMORY_CONFIDENCE_STRATEGY } from './confidence.ts';
 import { formatCloseoutMemory, type MemoryCloseoutInput } from './closeout.ts';
 import { currentTenantId } from '../../middleware/tenant.ts';
 import { rankMemories } from './rank.ts';
+import { createMemoryStatsEndpoint } from './stats.ts';
 
 export function createMemoryRoutes(
   store: MemoryStore = memoryStore,
@@ -41,6 +42,7 @@ export function createMemoryRoutes(
       detail: { tags: ['memory'], menu: { group: 'hidden' }, summary: 'Persist a Challenge 2 session close-out memory' },
     })
     .use(createMemoryFanoutEndpoint())
+    .use(createMemoryStatsEndpoint())
     .get('/memory/morning-tape', ({ query }) => {
       const limit = parseMemoryLimit(query.limit, 8, 25);
       const tape = buildMorningTape(store.recall('', limit));

--- a/src/routes/memory/stats.ts
+++ b/src/routes/memory/stats.ts
@@ -1,0 +1,110 @@
+import { Elysia } from 'elysia';
+import { eq } from 'drizzle-orm';
+import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
+import { db as defaultDb, oracleMemories } from '../../db/index.ts';
+import { currentTenantId } from '../../middleware/tenant.ts';
+import { memoryConfidence } from './confidence.ts';
+import type { MemoryRecord } from './store.ts';
+import type * as schema from '../../db/schema.ts';
+
+type Db = BunSQLiteDatabase<typeof schema>;
+type Row = typeof oracleMemories.$inferSelect;
+
+type Buckets = Record<'cold' | 'warm' | 'hot', number>;
+type Histogram = Record<'low' | 'medium' | 'high', number>;
+
+export function createMemoryStatsEndpoint(database: Db = defaultDb) {
+  return new Elysia().get('/memory/stats', () => memoryStats(database), {
+    detail: { tags: ['memory'], menu: { group: 'hidden' }, summary: 'Memory health and consolidation metrics' },
+  });
+}
+
+export function memoryStats(database: Db = defaultDb, now = new Date()) {
+  const rows = loadRows(database);
+  const records = rows.map(memoryFromRow);
+  const confidence: Histogram = { low: 0, medium: 0, high: 0 };
+  const heat: Buckets = { cold: 0, warm: 0, hot: 0 };
+  for (const memory of records) {
+    confidence[memoryConfidence(memory, { now }).label] += 1;
+    heat[heatBucket(memory, now)] += 1;
+  }
+  const superseded = rows.filter((row) => row.supersededAt !== null || row.supersededBy !== null).length;
+  const validTime = rows.filter((row) => row.validFrom !== null || row.validTo !== null).length;
+  return {
+    total: rows.length,
+    active: rows.length - superseded,
+    superseded,
+    heat_distribution: heat,
+    confidence_histogram: confidence,
+    supersede_chain: chainStats(rows),
+    valid_time_coverage: {
+      count: validTime,
+      percent: rows.length ? round(validTime / rows.length) : 0,
+    },
+  };
+}
+
+function loadRows(database: Db): Row[] {
+  const tenantId = currentTenantId();
+  const query = database.select().from(oracleMemories);
+  return tenantId ? query.where(eq(oracleMemories.tenantId, tenantId)).all() : query.all();
+}
+
+function chainStats(rows: Row[]) {
+  const byId = new Map(rows.map((row) => [row.id, row]));
+  let maxDepth = 0;
+  let linked = 0;
+  for (const row of rows) {
+    if (!row.supersededBy) continue;
+    linked += 1;
+    let depth = 1;
+    const seen = new Set([row.id]);
+    let next = byId.get(row.supersededBy);
+    while (next?.supersededBy && !seen.has(next.id)) {
+      seen.add(next.id);
+      depth += 1;
+      next = byId.get(next.supersededBy);
+    }
+    maxDepth = Math.max(maxDepth, depth);
+  }
+  return { linked, max_depth: maxDepth };
+}
+
+function heatBucket(memory: MemoryRecord, now: Date): keyof Buckets {
+  const usage = Math.max(0, Number(memory.usageCount ?? 0));
+  const touched = Date.parse(memory.lastAccessedAt ?? memory.updatedAt);
+  const ageDays = Number.isFinite(touched) ? Math.max(0, (now.getTime() - touched) / 86_400_000) : Number.POSITIVE_INFINITY;
+  if (usage >= 10 || ageDays <= 7) return 'hot';
+  if (usage >= 2 || ageDays <= 30) return 'warm';
+  return 'cold';
+}
+
+function memoryFromRow(row: Row): MemoryRecord {
+  return {
+    id: row.id,
+    tenantId: row.tenantId,
+    content: row.content,
+    title: row.title ?? undefined,
+    tags: tagsFrom(row.tags),
+    source: row.source ?? undefined,
+    validFrom: row.validFrom ? new Date(row.validFrom).toISOString() : undefined,
+    validTo: row.validTo ? new Date(row.validTo).toISOString() : undefined,
+    supersededBy: row.supersededBy ?? undefined,
+    supersededAt: row.supersededAt ? new Date(row.supersededAt).toISOString() : undefined,
+    supersededReason: row.supersededReason ?? undefined,
+    createdAt: new Date(row.createdAt).toISOString(),
+    updatedAt: new Date(row.updatedAt).toISOString(),
+  };
+}
+
+function tagsFrom(value: string): string[] {
+  try {
+    const parsed = JSON.parse(value);
+    if (Array.isArray(parsed)) return parsed.map(String).filter(Boolean);
+  } catch {}
+  return [];
+}
+
+function round(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}

--- a/tests/http/memory/stats.test.ts
+++ b/tests/http/memory/stats.test.ts
@@ -1,0 +1,61 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createDatabase } from '../../../src/db/create.ts';
+import { oracleMemories } from '../../../src/db/schema.ts';
+import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
+import { createMemoryStatsEndpoint, memoryStats } from '../../../src/routes/memory/stats.ts';
+
+const connection = createDatabase(':memory:');
+const now = Date.parse('2026-06-17T00:00:00.000Z');
+const app = new Elysia({ prefix: '/api' }).use(createMemoryStatsEndpoint(connection.db));
+const fetcher = createTenantFetch((request) => app.handle(request));
+
+afterAll(() => connection.storage.close());
+
+function addMemory(input: {
+  id: string; tenantId?: string; updatedAt: number; tags?: string[]; source?: string | null;
+  validFrom?: number | null; validTo?: number | null; supersededBy?: string | null; supersededAt?: number | null;
+}) {
+  connection.db.insert(oracleMemories).values({
+    id: input.id,
+    tenantId: input.tenantId ?? 'tenant-a',
+    content: `${input.id} memory stats fixture`,
+    title: input.id,
+    tags: JSON.stringify(input.tags ?? []),
+    source: input.source ?? null,
+    validFrom: input.validFrom ?? null,
+    validTo: input.validTo ?? null,
+    supersededBy: input.supersededBy ?? null,
+    supersededAt: input.supersededAt ?? null,
+    createdAt: input.updatedAt - 1000,
+    updatedAt: input.updatedAt,
+  }).run();
+}
+
+addMemory({ id: 'hot', updatedAt: now - 86_400_000, tags: ['deploy'], source: 'docs/a.md', validFrom: now - 10 });
+addMemory({ id: 'warm', updatedAt: now - 20 * 86_400_000, tags: ['deploy'] });
+addMemory({ id: 'cold-old', updatedAt: now - 90 * 86_400_000, supersededBy: 'warm', supersededAt: now - 1 });
+addMemory({ id: 'tenant-b', tenantId: 'tenant-b', updatedAt: now - 86_400_000, tags: ['other'], source: 'docs/b.md' });
+
+describe('GET /api/v1/memory/stats', () => {
+  test('summarizes heat, confidence, supersede depth, and valid-time coverage', () => {
+    const stats = memoryStats(connection.db, new Date(now));
+
+    expect(stats).toMatchObject({ total: 4, active: 3, superseded: 1 });
+    expect(stats.heat_distribution).toEqual({ hot: 2, warm: 1, cold: 1 });
+    expect(stats.confidence_histogram.high + stats.confidence_histogram.medium + stats.confidence_histogram.low).toBe(4);
+    expect(stats.supersede_chain).toEqual({ linked: 1, max_depth: 1 });
+    expect(stats.valid_time_coverage).toEqual({ count: 1, percent: 0.25 });
+  });
+
+  test('HTTP endpoint is tenant scoped', async () => {
+    const res = await fetcher(new Request('http://local/api/memory/stats', {
+      headers: { [TENANT_HEADER]: 'tenant-b' },
+    }));
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({ total: 1, active: 1, superseded: 0 });
+    expect(body.valid_time_coverage).toEqual({ count: 0, percent: 0 });
+  });
+});


### PR DESCRIPTION
## Summary
- Added `/api/v1/memory/stats` for memory heat distribution, confidence histogram, supersede-chain depth, and valid-time coverage.
- Kept stats tenant-scoped through existing tenant context.
- Added `tests/http/memory/stats.test.ts` aggregate and tenant-scope coverage.

## Tests
```bash
bun test --isolate tests/http/memory
bunx tsc --noEmit
wc -l src/routes/memory/stats.ts src/routes/memory/index.ts tests/http/memory/stats.test.ts
```

Refs #2251
