### PR TITLE
feat(studio): add memory stats data hook

### DIFF
--- a/frontend/src/hooks/useMemoryStats.ts
+++ b/frontend/src/hooks/useMemoryStats.ts
@@ -1,0 +1,160 @@
+import { useCallback, useEffect, useState } from 'react';
+import { apiUrl } from '../api/oracle';
+export const MEMORY_STATS_ENDPOINT = '/api/v1/memory/stats';
+
+export interface MemoryStatsBuckets {
+  cold: number;
+  warm: number;
+  hot: number;
+}
+
+export interface MemoryConfidenceHistogram {
+  low: number;
+  medium: number;
+  high: number;
+}
+
+export interface MemoryStatsResponse {
+  total: number;
+  active: number;
+  superseded: number;
+  heat_distribution: MemoryStatsBuckets;
+  confidence_histogram: MemoryConfidenceHistogram;
+  supersede_chain: { linked: number; max_depth: number };
+  valid_time_coverage: { count: number; percent: number };
+}
+
+type MemoryStatsFetch = (input: RequestInfo | URL, init?: RequestInit) => Response | Promise<Response>;
+
+type UseMemoryStatsOptions = {
+  endpoint?: string;
+  fetcher?: MemoryStatsFetch;
+  initialStats?: MemoryStatsResponse | null;
+  initialLoading?: boolean;
+};
+
+export type UseMemoryStatsResult = {
+  stats: MemoryStatsResponse | null;
+  loading: boolean;
+  error: string | null;
+  reload: () => void;
+};
+
+const emptyBuckets = { cold: 0, warm: 0, hot: 0 };
+const emptyHistogram = { low: 0, medium: 0, high: 0 };
+
+function messageFor(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function numberValue(value: unknown): number {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function bucket(source: unknown, key: 'cold' | 'warm' | 'hot'): number {
+  return Math.max(0, numberValue(record(source)[key]));
+}
+
+function histogram(source: unknown, key: 'low' | 'medium' | 'high'): number {
+  return Math.max(0, numberValue(record(source)[key]));
+}
+
+export function normalizeMemoryStats(payload: unknown): MemoryStatsResponse {
+  const data = record(payload);
+  const chain = record(data.supersede_chain);
+  const coverage = record(data.valid_time_coverage);
+  return {
+    total: Math.max(0, numberValue(data.total)),
+    active: Math.max(0, numberValue(data.active)),
+    superseded: Math.max(0, numberValue(data.superseded)),
+    heat_distribution: {
+      cold: bucket(data.heat_distribution, 'cold'),
+      warm: bucket(data.heat_distribution, 'warm'),
+      hot: bucket(data.heat_distribution, 'hot'),
+    },
+    confidence_histogram: {
+      low: histogram(data.confidence_histogram, 'low'),
+      medium: histogram(data.confidence_histogram, 'medium'),
+      high: histogram(data.confidence_histogram, 'high'),
+    },
+    supersede_chain: {
+      linked: Math.max(0, numberValue(chain.linked)),
+      max_depth: Math.max(0, numberValue(chain.max_depth)),
+    },
+    valid_time_coverage: {
+      count: Math.max(0, numberValue(coverage.count)),
+      percent: Math.max(0, Math.min(1, numberValue(coverage.percent))),
+    },
+  };
+}
+
+export async function fetchMemoryStats({
+  endpoint = MEMORY_STATS_ENDPOINT,
+  fetcher,
+}: Pick<UseMemoryStatsOptions, 'endpoint' | 'fetcher'> = {}): Promise<MemoryStatsResponse> {
+  const request = fetcher ?? globalThis.fetch?.bind(globalThis);
+  if (!request) throw new Error(`${endpoint} is unreachable: fetch is unavailable`);
+  let response: Response;
+  try {
+    response = await request(apiUrl(endpoint), { headers: { accept: 'application/json' } });
+  } catch (error) {
+    throw new Error(`${endpoint} is unreachable: ${messageFor(error)}`);
+  }
+  const text = await response.text();
+  let payload: unknown = {};
+  try {
+    payload = text ? JSON.parse(text) : {};
+  } catch {
+    throw new Error(`${endpoint} returned invalid JSON`);
+  }
+  if (!response.ok) {
+    const detail = typeof record(payload).error === 'string' ? record(payload).error : response.statusText;
+    throw new Error(`${endpoint} returned ${response.status}${detail ? `: ${detail}` : ''}`);
+  }
+  return normalizeMemoryStats(payload);
+}
+
+export function useMemoryStats({
+  endpoint = MEMORY_STATS_ENDPOINT,
+  fetcher,
+  initialStats = null,
+  initialLoading = true,
+}: UseMemoryStatsOptions = {}): UseMemoryStatsResult {
+  const [reloadKey, setReloadKey] = useState(0);
+  const [state, setState] = useState<Omit<UseMemoryStatsResult, 'reload'>>({
+    stats: initialStats,
+    loading: initialLoading,
+    error: null,
+  });
+  const reload = useCallback(() => setReloadKey((key) => key + 1), []);
+
+  useEffect(() => {
+    if (!initialLoading) setState({ stats: initialStats, loading: false, error: null });
+  }, [initialLoading, initialStats]);
+
+  useEffect(() => {
+    let active = true;
+    setState((current) => ({ ...current, loading: true, error: null }));
+    fetchMemoryStats({ endpoint, fetcher })
+      .then((stats) => active && setState({ stats, loading: false, error: null }))
+      .catch((error) => active && setState((current) => ({ ...current, loading: false, error: messageFor(error) })));
+    return () => { active = false; };
+  }, [endpoint, fetcher, reloadKey]);
+
+  return { ...state, reload };
+}
+
+export const EMPTY_MEMORY_STATS: MemoryStatsResponse = {
+  total: 0,
+  active: 0,
+  superseded: 0,
+  heat_distribution: emptyBuckets,
+  confidence_histogram: emptyHistogram,
+  supersede_chain: { linked: 0, max_depth: 0 },
+  valid_time_coverage: { count: 0, percent: 0 },
+};

--- a/tests/frontend/hooks/use-memory-stats.test.tsx
+++ b/tests/frontend/hooks/use-memory-stats.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test';
+import { fetchMemoryStats, normalizeMemoryStats, useMemoryStats } from '../../../frontend/src/hooks/useMemoryStats';
+import { htmlFor } from '../_render';
+
+const payload = {
+  total: 4,
+  active: 3,
+  superseded: 1,
+  heat_distribution: { cold: 1, warm: 1, hot: 2 },
+  confidence_histogram: { low: 1, medium: 2, high: 1 },
+  supersede_chain: { linked: 1, max_depth: 2 },
+  valid_time_coverage: { count: 2, percent: 0.5 },
+};
+
+function StatsProbe() {
+  const state = useMemoryStats({ initialStats: payload, initialLoading: false, fetcher: async () => new Response('{}') });
+  return <span>{state.loading ? 'loading' : 'ready'}:{state.stats?.total}:{state.stats?.heat_distribution.hot}</span>;
+}
+
+describe('useMemoryStats hook and endpoint contract', () => {
+  test('normalizes sparse memory stats payloads to dashboard-safe buckets', () => {
+    expect(normalizeMemoryStats({ total: '2', heat_distribution: { hot: '1' }, valid_time_coverage: { percent: 2 } })).toEqual({
+      total: 2,
+      active: 0,
+      superseded: 0,
+      heat_distribution: { cold: 0, warm: 0, hot: 1 },
+      confidence_histogram: { low: 0, medium: 0, high: 0 },
+      supersede_chain: { linked: 0, max_depth: 0 },
+      valid_time_coverage: { count: 0, percent: 1 },
+    });
+  });
+
+  test('fetches /api/v1/memory/stats with JSON accept header', async () => {
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    const stats = await fetchMemoryStats({
+      fetcher: (input, init) => {
+        calls.push({ input, init });
+        return new Response(JSON.stringify(payload), { status: 200 });
+      },
+    });
+
+    expect(stats).toEqual(payload);
+    expect(new URL(String(calls[0]?.input)).pathname).toBe('/api/v1/memory/stats');
+    expect((calls[0]?.init?.headers as Record<string, string>).accept).toBe('application/json');
+  });
+
+  test('renders initial hook state for the dashboard shell', () => {
+    expect(htmlFor(<StatsProbe />)).toContain('ready:4:2');
+  });
+
+  test('reports invalid JSON and non-ok stats responses', async () => {
+    await expect(fetchMemoryStats({ fetcher: () => new Response('{bad') })).rejects.toThrow('/api/v1/memory/stats returned invalid JSON');
+    await expect(fetchMemoryStats({ fetcher: () => new Response('{"error":"offline"}', { status: 503 }) })).rejects.toThrow('/api/v1/memory/stats returned 503: offline');
+  });
+});


### PR DESCRIPTION
## Summary
- Added a typed Studio data hook for `/api/v1/memory/stats`.
- Normalizes heat distribution, confidence histogram, supersede-chain depth, and valid-time coverage into dashboard-safe values.
- Added frontend hook tests for endpoint fetch, normalization, initial state, and error handling.

## Tests
```bash
bun test --isolate tests/frontend/hooks/use-memory-stats.test.tsx
bunx tsc --noEmit
wc -l frontend/src/hooks/useMemoryStats.ts tests/frontend/hooks/use-memory-stats.test.tsx
```

Refs #2251
