### PR TITLE
test: stub vector proxy network calls

### DIFF
--- a/src/server/__tests__/search-vector-proxy-fallback.test.ts
+++ b/src/server/__tests__/search-vector-proxy-fallback.test.ts
@@ -7,18 +7,14 @@ const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-search-vector-proxy-
 const dataDir = path.join(tmpRoot, 'data');
 const dbPath = path.join(dataDir, 'oracle.db');
 
-const remote = Bun.serve({
-  port: 0,
-  fetch(request) {
-    const url = new URL(request.url);
-    if (url.pathname === '/api/search') return Response.json({ error: 'remote vector down' }, { status: 503 });
-    if (url.pathname === '/api/vector/health') return Response.json({ status: 'down', engines: [], checked_at: new Date().toISOString() });
-    return Response.json({ error: 'not found' }, { status: 404 });
-  },
-});
-
 function runFallbackInFreshProcess() {
   const script = `
+    globalThis.fetch = async (input) => {
+      const url = new URL(typeof input === 'string' ? input : input.url);
+      if (url.pathname === '/api/search') return Response.json({ error: 'remote vector down' }, { status: 503 });
+      if (url.pathname === '/api/vector/health') return Response.json({ status: 'down', engines: [], checked_at: new Date().toISOString() });
+      return Response.json({ error: 'unexpected proxy call' }, { status: 404 });
+    };
     const { handleLearn, handleSearch } = await import('./src/server/handlers.ts');
     handleLearn('cloudproxy1378 local fts ground truth survives remote vector outage', 'test', ['cloudproxy1378']);
     const result = await handleSearch('cloudproxy1378', 'all', 5, 0, 'hybrid');
@@ -32,7 +28,7 @@ function runFallbackInFreshProcess() {
       ORACLE_DATA_DIR: dataDir,
       ORACLE_DB_PATH: dbPath,
       ORACLE_REPO_ROOT: tmpRoot,
-      VECTOR_URL: `http://127.0.0.1:${remote.port}`,
+      VECTOR_URL: 'http://127.0.0.1:9',
     },
     stdout: 'pipe',
     stderr: 'pipe',
@@ -61,6 +57,5 @@ describe('handleSearch cloud vector proxy fallback', () => {
 });
 
 afterAll(() => {
-  remote.stop(true);
   fs.rmSync(tmpRoot, { recursive: true, force: true });
 });

--- a/src/server/__tests__/search-vector-proxy-total.test.ts
+++ b/src/server/__tests__/search-vector-proxy-total.test.ts
@@ -7,34 +7,30 @@ const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-search-vector-proxy-
 const dataDir = path.join(tmpRoot, 'data');
 const dbPath = path.join(dataDir, 'oracle.db');
 
-const fakeVector = Bun.serve({
-  port: 0,
-  fetch(request) {
-    const url = new URL(request.url);
-    if (url.pathname !== '/api/search') return Response.json({ error: 'not found' }, { status: 404 });
-    return Response.json({
-      results: [{
-        id: 'remote-vector-1',
-        type: 'learning',
-        content: 'Remote vector result',
-        source_file: 'vault/remote.md',
-        concepts: [],
-        source: 'vector',
-        score: 0.91,
-      }],
-      total: 42,
-      offset: 0,
-      limit: 1,
-      mode: 'vector',
-      vectorAvailable: true,
-    });
-  },
-});
-
 function runSearchInFreshProcess() {
   const script = `
     const warnMessages = [];
     console.warn = (...args) => warnMessages.push(args.map(String).join(' '));
+    globalThis.fetch = async (input) => {
+      const url = new URL(typeof input === 'string' ? input : input.url);
+      if (url.pathname !== '/api/search') return Response.json({ error: 'unexpected proxy call' }, { status: 404 });
+      return Response.json({
+        results: [{
+          id: 'remote-vector-1',
+          type: 'learning',
+          content: 'Remote vector result',
+          source_file: 'vault/remote.md',
+          concepts: [],
+          source: 'vector',
+          score: 0.91,
+        }],
+        total: 42,
+        offset: 0,
+        limit: 1,
+        mode: 'vector',
+        vectorAvailable: true,
+      });
+    };
     const { handleSearch } = await import('./src/server/handlers.ts');
     const result = await handleSearch('oracle', 'all', 1, 0, 'vector');
     console.log('RESULT_JSON:' + JSON.stringify({ result, warnMessages }));
@@ -47,7 +43,7 @@ function runSearchInFreshProcess() {
       ORACLE_DATA_DIR: dataDir,
       ORACLE_DB_PATH: dbPath,
       ORACLE_REPO_ROOT: tmpRoot,
-      VECTOR_URL: `http://127.0.0.1:${fakeVector.port}`,
+      VECTOR_URL: 'http://127.0.0.1:9',
     },
     stdout: 'pipe',
     stderr: 'pipe',
@@ -76,6 +72,5 @@ describe('handleSearch VECTOR_URL proxy totals', () => {
 });
 
 afterAll(() => {
-  fakeVector.stop(true);
   fs.rmSync(tmpRoot, { recursive: true, force: true });
 });

--- a/src/tools/__tests__/learn-enqueue.test.ts
+++ b/src/tools/__tests__/learn-enqueue.test.ts
@@ -100,8 +100,12 @@ const createdMarkdownFiles = new Set<string>();
 
 function markdownPathCandidates(relativePath: string): string[] {
   const dataRoot = process.env.ORACLE_DATA_DIR || path.join(os.homedir(), '.arra-oracle-v2');
-  return [SHARED_REPO_ROOT, process.cwd(), dataRoot]
-    .map((root) => path.join(root, relativePath));
+  const tmpRoots = fs.readdirSync(os.tmpdir(), { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith('arra-'))
+    .map((entry) => path.join(os.tmpdir(), entry.name));
+  const roots = [SHARED_REPO_ROOT, ORIGINAL_REPO_ROOT, process.cwd(), dataRoot, ...tmpRoots]
+    .filter((root): root is string => Boolean(root));
+  return Array.from(new Set(roots)).map((root) => path.join(root, relativePath));
 }
 
 function rememberMarkdown(relativePath: string): void {


### PR DESCRIPTION
## Summary
- replace vector proxy test servers with child-process fetch mocks and closed-port VECTOR_URL
- keep proxy fallback/total assertions fast and hermetic
- harden learn enqueue markdown lookup against cached test REPO_ROOT during full unit runs

## Validation
- bunx tsc --noEmit
- bun run test:unit