### PR TITLE
release: v26.6.17-alpha.1832

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-v3",
-  "version": "26.6.17-alpha.1653",
+  "version": "26.6.17-alpha.1832",
   "description": "Arra Oracle - MCP Memory Layer with semantic search, philosophy, and knowledge management",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Re-cut after #2418 fixed the flaky vector-proxy test timeouts. Cuts v26.6.17-alpha.1832 via calver-release.yml on merge. #2251 memory epic complete + full hardening sweep (~80 PRs).