### PR TITLE
feat(indexer): derive ingest structure metadata

### DIFF
--- a/src/indexer/__tests__/structure-derivation.test.ts
+++ b/src/indexer/__tests__/structure-derivation.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { collectPsiLearn } from '../collectors.ts';
+import { readLearningDocuments } from '../learn-doc-source.ts';
+
+function config(repoRoot: string) {
+  return {
+    repoRoot,
+    dbPath: ':memory:',
+    chromaPath: '',
+    sourcePaths: {
+      resonance: 'ψ/memory/resonance',
+      learnings: 'ψ/memory/learnings',
+      retrospectives: 'ψ/memory/retrospectives',
+      distillations: 'ψ/memory/distillations',
+      learn: 'ψ/learn',
+    },
+  };
+}
+
+test('bulk ψ/learn ingest derives project from local org/repo directories', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-derive-project-'));
+  try {
+    const file = path.join(root, 'ψ', 'learn', 'Soul-Brews-Studio', 'demo', 'ops', 'runbook.md');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, '# Runbook\n\n## Finding\n\nRetry retry deploy failures with traced context.', 'utf8');
+
+    const docs = collectPsiLearn({ config: config(root), seenContentHashes: new Set() });
+
+    expect(docs).toHaveLength(1);
+    expect(docs[0].project).toBe('github.com/soul-brews-studio/demo');
+    expect(docs[0].concepts).toEqual(expect.arrayContaining(['ops', 'runbook', 'retry', 'deploy']));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('readLearningDocuments derives folder concepts without frontmatter taxonomy', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-derive-concepts-'));
+  try {
+    const file = path.join(root, 'github.com', 'Soul-Brews-Studio', 'demo', 'ψ', 'learn', 'codex', 'vector-search.md');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, '# Vector Search\n\n## Finding\n\nLatency latency ranking improves retrieval.', 'utf8');
+
+    const docs = readLearningDocuments(root, file);
+
+    expect(docs).toHaveLength(1);
+    expect(docs[0].project).toBe('github.com/soul-brews-studio/demo');
+    expect(docs[0].concepts).toEqual(expect.arrayContaining(['codex', 'vector', 'search', 'latency', 'ranking']));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/src/indexer/concepts.ts
+++ b/src/indexer/concepts.ts
@@ -27,7 +27,17 @@ export function extractConcepts(...texts: string[]): string[] {
     }
   }
 
+  for (const keyword of scoredKeywords(combined)) concepts.add(keyword);
+
   return Array.from(concepts);
+}
+
+export function deriveConceptsFromPath(sourceFile: string): string[] {
+  const local = localStructurePath(sourceFile);
+  const tokens = local.split(/[\/._-]+/g)
+    .map(normalizeToken)
+    .filter((token) => token.length >= 3 && !STRUCTURE_STOPWORDS.has(token));
+  return [...new Set(tokens)].slice(0, 12);
 }
 
 /**
@@ -35,4 +45,36 @@ export function extractConcepts(...texts: string[]): string[] {
  */
 export function mergeConceptsWithTags(extracted: string[], fileTags: string[]): string[] {
   return [...new Set([...extracted, ...fileTags])];
+}
+
+const STRUCTURE_STOPWORDS = new Set([
+  'github', 'gitlab', 'bitbucket', 'com', 'org', 'repo', 'learn', 'memory',
+  'learnings', 'retrospectives', 'distillations', 'inbox', 'handoff', 'the',
+  'and', 'for', 'with', 'from', 'into', 'this', 'that', 'should', 'would',
+]);
+
+function scoredKeywords(text: string): string[] {
+  const counts = new Map<string, number>();
+  for (const raw of text.split(/[^a-z0-9]+/g)) {
+    const token = normalizeToken(raw);
+    if (token.length < 4 || STRUCTURE_STOPWORDS.has(token)) continue;
+    counts.set(token, (counts.get(token) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 8)
+    .map(([token]) => token);
+}
+
+function localStructurePath(sourceFile: string): string {
+  const normalized = sourceFile.replace(/\\/g, '/');
+  const projectFirst = normalized.match(/^(?:github\.com|gitlab\.com|bitbucket\.org)\/[^/]+\/[^/]+\/(ψ\/.*)$/);
+  if (projectFirst) return projectFirst[1];
+  const localProject = normalized.match(/^ψ\/learn\/[^/]+\/[^/]+\/(.*)$/);
+  if (localProject) return localProject[1];
+  return normalized;
+}
+
+function normalizeToken(token: string): string {
+  return token.toLowerCase().replace(/^[0-9]+|[0-9]+$/g, '').trim();
 }

--- a/src/indexer/discovery.ts
+++ b/src/indexer/discovery.ts
@@ -51,6 +51,12 @@ export function inferProjectFromPath(relativePath: string): string | null {
     return `${projectFirst[1]}/${projectFirst[2]}`.toLowerCase();
   }
 
+  // Local bulk ingest: psi/learn/{org}/{repo}/... -> github.com/org/repo
+  const localLearn = relativePath.match(/^ψ\/learn\/([^/]+)\/([^/]+)\//);
+  if (localLearn) {
+    return `github.com/${localLearn[1]}/${localLearn[2]}`.toLowerCase();
+  }
+
   // Legacy layout: psi/memory/{category}/github.com/org/repo/...
   const legacy = relativePath.match(
     /^\u03c8\/(?:memory\/(?:learnings|retrospectives)|inbox\/handoff)\/(github\.com|gitlab\.com|bitbucket\.org)\/([^/]+\/[^/]+)\//

--- a/src/indexer/learn-doc-source.ts
+++ b/src/indexer/learn-doc-source.ts
@@ -6,6 +6,8 @@ import fs from 'fs';
 import path from 'path';
 import type Database from 'bun:sqlite';
 import type { OracleDocument } from '../types.ts';
+import { deriveConceptsFromPath, mergeConceptsWithTags } from './concepts.ts';
+import { inferProjectFromPath } from './discovery.ts';
 import { parseLearningFile } from './parser.ts';
 
 export const PSI_LEARN_REL = path.join('ψ', 'learn');
@@ -40,10 +42,20 @@ export function parsePsiLearnFile(relativePath: string, content: string): Oracle
   const basename = path.basename(sourceFile);
   const pathHash = Bun.hash(sourceFile).toString(36);
 
-  return parseLearningFile(basename, content, sourceFile).map((doc) => ({
+  return withDerivedStructure(parseLearningFile(basename, content, sourceFile).map((doc) => ({
     ...doc,
     id: psiLearnDocId(pathHash, doc.id),
     source_file: sourceFile,
+  })), sourceFile);
+}
+
+function withDerivedStructure(documents: OracleDocument[], sourceFile: string): OracleDocument[] {
+  const project = inferProjectFromPath(sourceFile);
+  const pathConcepts = deriveConceptsFromPath(sourceFile);
+  return documents.map((doc) => ({
+    ...doc,
+    project: doc.project ?? project ?? undefined,
+    concepts: mergeConceptsWithTags(doc.concepts, pathConcepts),
   }));
 }
 
@@ -58,7 +70,10 @@ export function readLearningDocuments(repoRoot: string, filePath: string): Oracl
   const content = fs.readFileSync(filePath, 'utf8');
   if (!content.trim()) return [];
   if (isPsiLearnSource(sourceFile)) return parsePsiLearnFile(sourceFile, content);
-  if (isMemoryLearningSource(sourceFile)) return parseLearningFile(path.basename(sourceFile), content, sourceFile);
+  if (isMemoryLearningSource(sourceFile)) return withDerivedStructure(
+    parseLearningFile(path.basename(sourceFile), content, sourceFile),
+    sourceFile,
+  );
   return [];
 }
 


### PR DESCRIPTION
## Summary
- auto-derive project from local ψ/learn/<org>/<repo>/ bulk-ingest directories
- add folder-structure concepts and scored keyword concepts without requiring frontmatter taxonomy
- apply derived project/concepts through shared ψ/learn ingest path used by collectors and watcher
- add focused indexer tests for #2420

References #2420.

## Validation
- bunx tsc --noEmit
- bun test --isolate src/indexer/__tests__/ src/indexer/api.test.ts src/indexer/arra-indexer.test.ts src/indexer/jobs.test.ts

## Notes
- PR targets alpha; main untouched.