### PR TITLE
feat(cli): add arra mine folder ingest

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -101,6 +101,12 @@ async function main() {
     process.exit(await doctorCommand(args.slice(1)));
   }
 
+  if (cmd === "mine") {
+    if (hasHelpFlag(args.slice(1))) return printBuiltinHelp(cmd);
+    const { mineCommand } = await import("../../src/cli/commands/mine.ts");
+    process.exit(await mineCommand(args.slice(1)));
+  }
+
   if (cmd === "huginn") {
     if (hasHelpFlag(args.slice(1))) return printScopedBuiltinHelp(cmd, args.slice(1));
     process.exit(await huginnCommand(args.slice(1)));

--- a/src/cli/commands/mine.ts
+++ b/src/cli/commands/mine.ts
@@ -1,0 +1,50 @@
+import { mineFolder } from '../../indexer/mine.ts';
+
+export interface MineCliOptions { dir?: string; dbPath?: string; dryRun: boolean; help: boolean }
+
+export function parseMineArgs(args: string[]): MineCliOptions {
+  const options: MineCliOptions = { dryRun: false, help: false };
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--help' || arg === '-h') options.help = true;
+    else if (arg === '--dry-run') options.dryRun = true;
+    else if (arg === '--db-path') {
+      const value = args[++i]?.trim();
+      if (!value) throw new Error('--db-path requires a path');
+      options.dbPath = value;
+    } else if (arg?.startsWith('--db-path=')) {
+      const value = arg.slice('--db-path='.length).trim();
+      if (!value) throw new Error('--db-path requires a path');
+      options.dbPath = value;
+    } else if (arg?.startsWith('-')) {
+      throw new Error(`unknown mine option: ${arg}`);
+    } else if (!options.dir) options.dir = arg;
+    else throw new Error(`unexpected mine argument: ${arg}`);
+  }
+  return options;
+}
+
+export function mineHelp(): string {
+  return [
+    'Usage: arra mine <dir> [--db-path <file>] [--dry-run]',
+    'Ingest a folder into Oracle memory with deterministic IDs and safe re-runs.',
+    '',
+    'Defaults: indexes .md, .mdx, and .txt files; skips unchanged content.',
+  ].join('\n');
+}
+
+export async function mineCommand(args: string[]): Promise<number> {
+  let options: MineCliOptions;
+  try { options = parseMineArgs(args); }
+  catch (error) { console.error(error instanceof Error ? error.message : String(error)); console.error(mineHelp()); return 1; }
+  if (options.help) { console.log(mineHelp()); return 0; }
+  if (!options.dir) { console.error('mine requires a directory'); console.error(mineHelp()); return 1; }
+  try {
+    const result = await mineFolder(options as { dir: string; dbPath?: string; dryRun?: boolean });
+    console.log(`Mined ${result.stored} document${result.stored === 1 ? '' : 's'} from ${result.scanned} file${result.scanned === 1 ? '' : 's'} (${result.skipped} skipped) into project "${result.project}".`);
+    return 0;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -75,6 +75,13 @@ export const BUILTIN_HELP: CliHelpEntry[] = [
     examples: ["arra-cli completions zsh >> ~/.zshrc", "arra-cli completions fish"],
   },
   {
+    command: "mine",
+    help: "ingest a folder into Oracle memory",
+    usage: "arra-cli mine <dir> [--db-path <file>] [--dry-run]",
+    flags: ["--db-path <file>", "--dry-run", "--help", "-h"],
+    examples: ["arra-cli mine ~/notes", "arra-cli mine ./docs --dry-run"],
+  },
+  {
     command: "huginn",
     help: "run Huginn capture utilities",
     usage: "arra-cli huginn <subcommand>",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,14 +5,16 @@ import { serveCommand } from './commands/serve.ts';
 import { canvasPluginsCommand } from './commands/canvas-plugins.ts';
 import { canvasServeCommand } from './commands/canvas-serve.ts';
 import { vectorConfigCommand } from './commands/vector-config.ts';
+import { mineCommand } from './commands/mine.ts';
 
 function printUsage(): void {
-  console.error('usage: bun run src/cli/index.ts <export|serve|canvas-plugins|canvas-serve|vector-config> ...');
+  console.error('usage: bun run src/cli/index.ts <export|serve|canvas-plugins|canvas-serve|vector-config|mine> ...');
   console.error('  export: bun run src/cli/index.ts export --format json|markdown [--out <file>]');
-  console.error('  serve:  bun run src/cli/index.ts serve <start|stop|status> [--port N] [--foreground|--background] [--json]');
+  console.error('  serve:  bun run src/cli/index.ts serve <start|stop|status> [--foreground|--background] [--json]');
   console.error('  canvas-plugins: bun run src/cli/index.ts canvas-plugins [--kind three|react] [--id <id>] [--json]');
   console.error('  canvas-serve: bun run src/cli/index.ts canvas-serve [--port N] [--api-base URL]');
   console.error('  vector-config: bun run src/cli/index.ts vector-config list|get|set|add|remove|set-primary [--json]');
+  console.error('  mine: bun run src/cli/index.ts mine <dir> [--db-path <file>] [--dry-run]');
 }
 
 async function main() {
@@ -27,6 +29,7 @@ async function main() {
   if (args[0] === 'canvas-serve') process.exit(await canvasServeCommand(args));
   if (args[0] === 'export') process.exit(await exportCommand(args));
   if (args[0] === 'vector-config') process.exit(await vectorConfigCommand(args));
+  if (args[0] === 'mine') process.exit(await mineCommand(args.slice(1)));
 
   console.error(`unknown command: ${args[0]}`);
   printUsage();

--- a/src/indexer/mine.ts
+++ b/src/indexer/mine.ts
@@ -1,0 +1,87 @@
+import fs from 'fs';
+import path from 'path';
+import { createHash } from 'crypto';
+import { eq } from 'drizzle-orm';
+import { createDatabase } from '../db/index.ts';
+import { oracleDocuments } from '../db/schema.ts';
+import { detectProject } from '../server/project-detect.ts';
+import type { OracleDocument } from '../types.ts';
+import { extractConcepts, mergeConceptsWithTags } from './concepts.ts';
+import { storeDocuments } from './storage.ts';
+
+const DEFAULT_EXTENSIONS = new Set(['.md', '.mdx', '.txt']);
+const SKIP_DIRS = new Set(['.git', 'node_modules', 'dist', 'build', '.next', '.turbo']);
+
+export interface MineOptions { dir: string; dbPath?: string; dryRun?: boolean }
+export interface MineResult { scanned: number; stored: number; skipped: number; project: string; root: string }
+
+export function stableMineDocId(root: string, filePath: string): string {
+  const rel = relativeSource(root, filePath);
+  return `mine_${createHash('sha256').update(rel).digest('hex').slice(0, 24)}`;
+}
+
+export function contentVersion(content: string): number {
+  return parseInt(createHash('sha256').update(content).digest('hex').slice(0, 12), 16);
+}
+
+export function collectMineFiles(root: string): string[] {
+  const files: string[] = [];
+  function walk(dir: string): void {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name.startsWith('.') && entry.name !== '.notes') continue;
+      if (SKIP_DIRS.has(entry.name)) continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile() && DEFAULT_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) files.push(full);
+    }
+  }
+  walk(root);
+  return files.sort();
+}
+
+export async function mineFolder(options: MineOptions): Promise<MineResult> {
+  const root = path.resolve(options.dir);
+  if (!fs.existsSync(root) || !fs.statSync(root).isDirectory()) {
+    throw new Error(`mine target must be a directory: ${options.dir}`);
+  }
+  const files = collectMineFiles(root);
+  const project = detectProject(root) || path.basename(root).toLowerCase();
+  const { sqlite, db, storage } = createDatabase(options.dbPath);
+  try {
+    const docs: OracleDocument[] = [];
+    let skipped = 0;
+    for (const file of files) {
+      const content = fs.readFileSync(file, 'utf8').trim();
+      if (!content) { skipped++; continue; }
+      const id = stableMineDocId(root, file);
+      const updatedAt = contentVersion(content);
+      const existing = db.select({ updatedAt: oracleDocuments.updatedAt })
+        .from(oracleDocuments).where(eq(oracleDocuments.id, id)).get();
+      if (existing?.updatedAt === updatedAt) { skipped++; continue; }
+      docs.push(toMineDocument(root, file, content, id, updatedAt, project));
+    }
+    if (!options.dryRun && docs.length > 0) {
+      await storeDocuments(sqlite, db, null, project, docs, { createdBy: 'mine' });
+    }
+    return { scanned: files.length, stored: options.dryRun ? docs.length : docs.length, skipped, project, root };
+  } finally {
+    storage.close();
+  }
+}
+
+function toMineDocument(root: string, file: string, content: string, id: string, version: number, project: string): OracleDocument {
+  const source = relativeSource(root, file);
+  const title = path.basename(file, path.extname(file));
+  const folders = path.dirname(source).split('/').filter(part => part && part !== '.');
+  const concepts = mergeConceptsWithTags(extractConcepts(title, content), [project, ...folders]);
+  return {
+    id, type: 'learning', source_file: source, content,
+    concepts, created_at: fs.statSync(file).birthtimeMs || version,
+    updated_at: version, project,
+  };
+}
+
+function relativeSource(root: string, filePath: string): string {
+  return `mine/${path.basename(root)}/${path.relative(root, filePath).split(path.sep).join('/')}`;
+}

--- a/tests/cli/mine/mine.test.ts
+++ b/tests/cli/mine/mine.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { parseMineArgs } from '../../../src/cli/commands/mine.ts';
+import { createDatabase } from '../../../src/db/index.ts';
+import { oracleDocuments } from '../../../src/db/schema.ts';
+import { mineFolder, stableMineDocId } from '../../../src/indexer/mine.ts';
+
+let tempDir = '';
+
+afterEach(() => {
+  if (tempDir && fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true });
+  tempDir = '';
+});
+
+function tmp(): string {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-mine-'));
+  return tempDir;
+}
+
+describe('arra mine folder ingest', () => {
+  test('parses friendly command flags and rejects bad input', () => {
+    expect(parseMineArgs(['notes', '--db-path', '/tmp/oracle.db'])).toEqual({
+      dir: 'notes', dbPath: '/tmp/oracle.db', dryRun: false, help: false,
+    });
+    expect(parseMineArgs(['--dry-run', '--db-path=/tmp/oracle.db', 'notes']).dryRun).toBe(true);
+    expect(() => parseMineArgs(['notes', '--bad'])).toThrow('unknown mine option: --bad');
+    expect(() => parseMineArgs(['--db-path'])).toThrow('--db-path requires a path');
+  });
+
+  test('stores deterministic docs and skips unchanged reruns', async () => {
+    const root = tmp();
+    const dbPath = path.join(root, 'oracle.db');
+    const notes = path.join(root, 'notes');
+    fs.mkdirSync(path.join(notes, 'ops'), { recursive: true });
+    const notePath = path.join(notes, 'ops', 'deploy.md');
+    fs.writeFileSync(notePath, '# Deploy\n\nRollback checklist and deployment notes.');
+
+    const first = await mineFolder({ dir: notes, dbPath });
+    const second = await mineFolder({ dir: notes, dbPath });
+
+    expect(first).toMatchObject({ scanned: 1, stored: 1, skipped: 0, project: 'notes' });
+    expect(second).toMatchObject({ scanned: 1, stored: 0, skipped: 1, project: 'notes' });
+
+    const id = stableMineDocId(notes, notePath);
+    const { db, storage } = createDatabase(dbPath);
+    const row = db.select().from(oracleDocuments).where(eq(oracleDocuments.id, id)).get();
+    storage.close();
+
+    expect(row?.sourceFile).toBe('mine/notes/ops/deploy.md');
+    expect(row?.createdBy).toBe('mine');
+    expect(JSON.parse(row?.concepts ?? '[]')).toContain('ops');
+  });
+});


### PR DESCRIPTION
## Summary
- Added built-in `arra mine <dir>` dispatch and help text for the 10-minute onboarding path.
- Added a folder ingest wrapper that scans `.md`, `.mdx`, and `.txt`, derives project/folder concepts, and stores through the existing indexer storage path.
- Made re-runs idempotent with deterministic source-based doc IDs and content-version skip gating.

## Tests
```bash
bun test --isolate tests/cli/mine/mine.test.ts
bunx tsc --noEmit
bun run cli/src/cli.ts mine --help
wc -l cli/src/cli.ts src/cli/index.ts src/cli/help.ts src/cli/commands/mine.ts src/indexer/mine.ts tests/cli/mine/mine.test.ts
```

Refs #2420
