### PR TITLE
feat(tools): add oracle wake-up recap

### DIFF
--- a/src/tools/__tests__/index.test.ts
+++ b/src/tools/__tests__/index.test.ts
@@ -7,6 +7,7 @@ import * as tools from '../index.ts';
 
 describe('tools barrel export', () => {
   it('exports core tool definitions', () => {
+    expect(tools.recapToolDef).toBeDefined();
     expect(tools.searchToolDef).toBeDefined();
     expect(tools.learnToolDef).toBeDefined();
     expect(tools.listToolDef).toBeDefined();
@@ -18,6 +19,7 @@ describe('tools barrel export', () => {
   });
 
   it('exports core handlers', () => {
+    expect(typeof tools.handleRecap).toBe('function');
     expect(typeof tools.handleSearch).toBe('function');
     expect(typeof tools.handleLearn).toBe('function');
     expect(typeof tools.handleList).toBe('function');

--- a/src/tools/__tests__/mcp-manifest.test.ts
+++ b/src/tools/__tests__/mcp-manifest.test.ts
@@ -5,6 +5,7 @@ describe('runtime MCP manifest', () => {
   it('has unique manifest-driven tool names', () => {
     const names = mcpTools.map((tool) => tool.name);
     expect(new Set(names).size).toBe(names.length);
+    expect(names).toContain('oracle_recap');
     expect(names).toContain('oracle_search');
     expect(names).toContain('oracle_mcp_call');
   });
@@ -21,6 +22,7 @@ describe('runtime MCP manifest', () => {
   });
 
   it('models read-only behavior from manifest metadata', () => {
+    expect(mcpToolByName.get('oracle_recap')?.readOnly).toBe(true);
     expect(mcpToolByName.get('oracle_search')?.readOnly).toBe(true);
     expect(mcpToolByName.get('oracle_learn')?.readOnly).toBe(false);
     expect(mcpToolByName.get('oracle_mcp_call')?.readOnly).toBe(false);

--- a/src/tools/__tests__/recap.test.ts
+++ b/src/tools/__tests__/recap.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createDatabase } from '../../db/index.ts';
+import { oracleDocuments } from '../../db/schema.ts';
+import type { DatabaseConnection } from '../../db/create.ts';
+import { handleRecap } from '../recap.ts';
+import type { ToolContext } from '../types.ts';
+
+const roots: string[] = [];
+const connections: DatabaseConnection[] = [];
+
+function tempRoot(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  roots.push(dir);
+  return dir;
+}
+
+function makeCtx(): ToolContext {
+  const connection = createDatabase(path.join(tempRoot('arra-recap-'), 'oracle.db'));
+  connections.push(connection);
+  return {
+    db: connection.db,
+    sqlite: connection.sqlite,
+    repoRoot: tempRoot('arra-recap-repo-'),
+    vectorStore: { name: 'mock-vector' } as any,
+    vectorStatus: 'connected',
+    version: 'test-version',
+  };
+}
+
+function insertDoc(ctx: ToolContext, input: {
+  id: string; project?: string; content: string; usage?: number; concepts?: string[]; updatedOffset?: number;
+}) {
+  const now = Date.now();
+  ctx.db.insert(oracleDocuments).values({
+    id: input.id,
+    type: 'learning',
+    sourceFile: `docs/${input.project ?? 'misc'}/${input.id}.md`,
+    concepts: JSON.stringify(input.concepts ?? []),
+    createdAt: now - (input.updatedOffset ?? 0),
+    updatedAt: now - (input.updatedOffset ?? 0),
+    indexedAt: now - (input.updatedOffset ?? 0),
+    project: input.project,
+    usageCount: input.usage ?? 0,
+    lastAccessedAt: input.usage ? now - 60_000 : null,
+  }).run();
+  ctx.sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
+    .run(input.id, input.content, (input.concepts ?? []).join(','));
+}
+
+function tokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+afterEach(() => {
+  for (const connection of connections.splice(0)) connection.storage.close();
+  for (const dir of roots.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('oracle_recap emits identity and top memories grouped by project', async () => {
+  const ctx = makeCtx();
+  insertDoc(ctx, { id: 'alpha-hot', project: 'alpha', usage: 12, concepts: ['deploy'], content: 'Alpha deploy runbook. Use docker run then arra mine.' });
+  insertDoc(ctx, { id: 'alpha-cold', project: 'alpha', usage: 0, concepts: ['old'], content: 'Old alpha note.', updatedOffset: 90 * 86_400_000 });
+  insertDoc(ctx, { id: 'beta-hot', project: 'beta', usage: 5, concepts: ['search'], content: 'Beta search memory. Query with oracle_search first.' });
+
+  const text = (await handleRecap(ctx, { limit: 3, maxTokens: 300 })).content[0].text;
+
+  expect(text).toContain('Oracle wake-up context');
+  expect(text).toContain('arra-oracle-v3 vtest-version');
+  expect(text).toContain('## alpha');
+  expect(text).toContain('## beta');
+  expect(text.indexOf('alpha-hot')).toBeLessThan(text.indexOf('alpha-cold'));
+  expect(text).toContain('heat');
+  expect(tokens(text)).toBeLessThanOrEqual(300);
+});
+
+test('oracle_recap handles an empty knowledge base cheaply', async () => {
+  const ctx = makeCtx();
+  const text = (await handleRecap(ctx, { maxTokens: 220 })).content[0].text;
+
+  expect(text).toContain('No memories indexed yet');
+  expect(text).toContain('oracle_learn');
+  expect(tokens(text)).toBeLessThanOrEqual(220);
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -16,7 +16,11 @@ export type {
   OracleHandoffInput,
   OracleInboxInput,
   OracleReadInput,
+  OracleRecapInput,
 } from './types.ts';
+
+// Recap
+export { recapToolDef, handleRecap } from './recap.ts';
 
 // Search (+ pure helpers)
 export {

--- a/src/tools/mcp-manifest.ts
+++ b/src/tools/mcp-manifest.ts
@@ -1,6 +1,7 @@
 import type { UnifiedMcpToolManifest } from '../plugins/unified-manifest.ts';
 import { GUIDE_TOOL_NAME, guideToolDefinition, guideToolResponse } from '../mcp/guide.ts';
 import type { ToolContext, ToolResponse } from './types.ts';
+import { recapToolDef, handleRecap } from './recap.ts';
 import { searchToolDef, handleSearch } from './search.ts';
 import { readToolDef, handleRead } from './read.ts';
 import { learnToolDef, handleLearn } from './learn.ts';
@@ -48,6 +49,7 @@ const traceReadOnly = [false, true, true, false, false, true];
 
 export const mcpTools: RuntimeMcpToolManifest[] = [
   { ...guideToolDefinition(), group: 'guide', readOnly: true, enabledByDefault: true, handlerId: 'guide', handler: (_input, runtime) => guideToolResponse(runtime.version) },
+  ctxTool(recapToolDef, 'oracle', true, 'handleRecap', handleRecap),
   ctxTool(searchToolDef, 'search', true, 'handleSearch', handleSearch),
   ctxTool(readToolDef, 'search', true, 'handleRead', handleRead),
   ctxTool(learnToolDef, 'knowledge', false, 'handleLearn', handleLearn),

--- a/src/tools/recap.ts
+++ b/src/tools/recap.ts
@@ -1,0 +1,196 @@
+import { currentTenantId } from '../middleware/tenant.ts';
+import { MCP_SERVER_NAME } from '../const.ts';
+import type { ToolContext, ToolResponse, OracleRecapInput } from './types.ts';
+
+type RecapRow = {
+  id: string;
+  type: string;
+  source_file: string;
+  concepts: string | null;
+  updated_at: number;
+  indexed_at: number;
+  project: string | null;
+  usage_count: number;
+  last_accessed_at: number | null;
+  content: string | null;
+};
+
+type RankedRow = RecapRow & {
+  conceptsList: string[];
+  projectLabel: string;
+  heat: number;
+  confidence: number;
+  rank: number;
+};
+
+const DEFAULT_TOP_N = 8;
+const DEFAULT_MAX_TOKENS = 900;
+const MAX_TOP_N = 20;
+const MAX_TOKENS = 1200;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export const recapToolDef = {
+  name: 'oracle_recap',
+  description: 'Emit a compact session-start Oracle wake-up context: identity plus top memories by heat/confidence grouped by project.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      limit: { type: 'number', description: 'Top memories to include (1-20)', default: DEFAULT_TOP_N },
+      maxTokens: { type: 'number', description: 'Approximate output token budget (200-1200)', default: DEFAULT_MAX_TOKENS },
+    },
+    required: [],
+  },
+};
+
+export async function handleRecap(ctx: ToolContext, input: OracleRecapInput = {}): Promise<ToolResponse> {
+  const limit = boundedNumber(input.limit, DEFAULT_TOP_N, 1, MAX_TOP_N);
+  const maxTokens = boundedNumber(input.maxTokens, DEFAULT_MAX_TOKENS, 200, MAX_TOKENS);
+  const tenantId = currentTenantId();
+  const rows = fetchRows(ctx, Math.max(limit * 6, 30), tenantId);
+  const ranked = rows.map((row) => rankRow(row)).sort((a, b) => b.rank - a.rank).slice(0, limit);
+  const text = fitBudget(renderRecap(ctx, ranked, rows.length, maxTokens, tenantId), ranked, ctx, rows.length, maxTokens, tenantId);
+  return { content: [{ type: 'text', text }] };
+}
+
+function fetchRows(ctx: ToolContext, limit: number, tenantId: string | undefined): RecapRow[] {
+  const tenantClause = tenantId ? 'AND d.tenant_id = ?' : '';
+  return ctx.sqlite.prepare(`
+    SELECT d.id, d.type, d.source_file, d.concepts, d.updated_at, d.indexed_at,
+      d.project, d.usage_count, d.last_accessed_at, f.content
+    FROM oracle_documents d
+    LEFT JOIN oracle_fts f ON d.id = f.id
+    WHERE d.superseded_by IS NULL ${tenantClause}
+    ORDER BY d.usage_count DESC, COALESCE(d.last_accessed_at, d.updated_at) DESC
+    LIMIT ?
+  `).all(...(tenantId ? [tenantId] : []), limit) as RecapRow[];
+}
+
+function rankRow(row: RecapRow, now = Date.now()): RankedRow {
+  const usageCount = safeNumber(row.usage_count);
+  const ageDays = daysSince(row.updated_at || row.indexed_at, now);
+  const accessDays = row.last_accessed_at ? daysSince(row.last_accessed_at, now) : undefined;
+  const freshness = halfLife(ageDays, 120);
+  const access = accessDays === undefined ? 0 : halfLife(accessDays, 30);
+  const usage = Math.min(1, Math.log1p(usageCount) / Math.log1p(20));
+  const conceptsList = parseConcepts(row.concepts);
+  const provenance = Math.min(1, (row.source_file ? 0.45 : 0) + (conceptsList.length ? 0.35 : 0) + (row.project ? 0.2 : 0));
+  const heat = round((usage * 0.55) + (access * 0.3) + (freshness * 0.15));
+  const confidence = round((freshness * 0.45) + (provenance * 0.35) + (usage * 0.2));
+  return {
+    ...row,
+    conceptsList,
+    projectLabel: projectLabel(row),
+    heat,
+    confidence,
+    rank: round((heat * 0.6) + (confidence * 0.4)),
+  };
+}
+
+function renderRecap(
+  ctx: ToolContext,
+  rows: RankedRow[],
+  total: number,
+  maxTokens: number,
+  tenantId: string | undefined,
+): string {
+  const groups = groupByProject(rows);
+  const tokenPlaceholder = '__TOKENS__';
+  const lines = [
+    '# Oracle wake-up context',
+    `Identity: ${MCP_SERVER_NAME} v${ctx.version}; vector=${ctx.vectorStatus}; tenant=${tenantId ?? 'default'}; docs=${total}.`,
+    'Role: MCP memory/search layer. Start with oracle_search for recall, oracle_read for exact source, oracle_learn for new durable facts.',
+    `Budget: approx ${tokenPlaceholder} / ${maxTokens} tokens; ranked by heat + confidence.`,
+  ];
+  if (rows.length === 0) lines.push('', 'No memories indexed yet. Ingest with `arra mine <dir>` or add facts with `oracle_learn`.');
+  for (const [project, projectRows] of groups) {
+    lines.push('', `## ${project}`);
+    for (const row of projectRows) lines.push(itemLine(row));
+  }
+  const text = lines.join('\n');
+  return text.replace(tokenPlaceholder, String(estimateTokens(text)));
+}
+
+function itemLine(row: RankedRow): string {
+  const title = firstLine(row.content) || row.source_file || row.id;
+  const concepts = row.conceptsList.slice(0, 3).join(', ') || 'untagged';
+  const snippet = compact(row.content ?? '', 150);
+  return `- ${compact(title, 88)} [${row.type}; heat ${row.heat}; conf ${row.confidence}; concepts: ${concepts}; id: ${row.id}] ${snippet}`;
+}
+
+function fitBudget(
+  text: string,
+  rows: RankedRow[],
+  ctx: ToolContext,
+  total: number,
+  maxTokens: number,
+  tenantId: string | undefined,
+): string {
+  let kept = rows;
+  let next = text;
+  while (estimateTokens(next) > maxTokens && kept.length > 1) {
+    kept = kept.slice(0, -1);
+    next = renderRecap(ctx, kept, total, maxTokens, tenantId);
+  }
+  if (estimateTokens(next) <= maxTokens) return next;
+  const maxChars = Math.max(100, maxTokens * 4 - 32);
+  return `${next.slice(0, maxChars).trimEnd()}\n… truncated to wake-up budget`;
+}
+
+function groupByProject(rows: RankedRow[]): Map<string, RankedRow[]> {
+  const grouped = new Map<string, RankedRow[]>();
+  for (const row of rows) grouped.set(row.projectLabel, [...(grouped.get(row.projectLabel) ?? []), row]);
+  return new Map([...grouped.entries()].sort((a, b) => b[1][0].rank - a[1][0].rank));
+}
+
+function projectLabel(row: RecapRow): string {
+  const explicit = row.project?.trim();
+  if (explicit) return explicit;
+  const parts = row.source_file.split('/').filter(Boolean);
+  return parts.length > 1 ? parts[0] : 'unscoped';
+}
+
+function parseConcepts(raw: string | null): string[] {
+  if (!raw?.trim()) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : [];
+  } catch {
+    return raw.split(',').map((item) => item.trim()).filter(Boolean);
+  }
+}
+
+function firstLine(value: string | null): string {
+  return value?.split('\n').find((line) => line.trim())?.trim() ?? '';
+}
+
+function compact(value: string, max: number): string {
+  const cleaned = value.replace(/\s+/g, ' ').trim();
+  return cleaned.length <= max ? cleaned : `${cleaned.slice(0, max - 1).trimEnd()}…`;
+}
+
+function boundedNumber(value: unknown, fallback: number, min: number, max: number): number {
+  if (value === undefined) return fallback;
+  if (typeof value !== 'number' || !Number.isFinite(value)) throw new Error('oracle_recap numeric inputs must be finite numbers');
+  return Math.min(max, Math.max(min, Math.trunc(value)));
+}
+
+function daysSince(timestamp: number, now: number): number {
+  return Math.max(0, (now - safeNumber(timestamp)) / DAY_MS);
+}
+
+function halfLife(days: number, halfLifeDays: number): number {
+  return Math.max(0, Math.min(1, 0.5 ** (days / halfLifeDays)));
+}
+
+function safeNumber(value: unknown): number {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+function round(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -29,6 +29,11 @@ export interface ToolResponse {
 // Input interfaces (moved from index.ts)
 // ============================================================================
 
+export interface OracleRecapInput {
+  limit?: number;
+  maxTokens?: number;
+}
+
 export interface OracleSearchInput {
   query: string;
   type?: 'principle' | 'pattern' | 'learning' | 'retro' | 'all';


### PR DESCRIPTION
## Summary
- Add `oracle_recap`, a read-only first-call MCP tool for compact session-start wake-up context.
- Recap includes Oracle identity plus top memories ranked by heat/confidence and grouped by project.
- Enforces an approximate token budget and handles empty knowledge bases with onboarding guidance.

Refs #2420

## Validation
```bash
bun test --isolate src/tools/__tests__/recap.test.ts src/tools/__tests__/mcp-manifest.test.ts src/tools/__tests__/index.test.ts
bunx tsc --noEmit
wc -l src/tools/recap.ts src/tools/__tests__/recap.test.ts src/tools/types.ts src/tools/index.ts src/tools/mcp-manifest.ts src/tools/__tests__/index.test.ts src/tools/__tests__/mcp-manifest.test.ts
```
