### PR TITLE
fix: guard vector collections by embedder identity

### DIFF
--- a/src/vector/embedder-identity.ts
+++ b/src/vector/embedder-identity.ts
@@ -1,0 +1,170 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { ORACLE_DATA_DIR } from '../config.ts';
+import type { EmbeddingProvider, VectorStoreAdapter } from './types.ts';
+
+export type EmbedderIdentity = { model_name: string; dimension: number };
+type RegistryEntry = EmbedderIdentity & { adapter: string; collection: string; updated_at: string };
+type Registry = { version: 1; collections: Record<string, RegistryEntry> };
+type Policy = 'error' | 'warn';
+
+type GuardOptions = {
+  adapterName: string;
+  collectionName: string;
+  embedder: Pick<EmbeddingProvider, 'name' | 'dimensions'>;
+  modelName?: string;
+  storagePath?: string;
+  registryPath?: string;
+  policy?: Policy;
+  logger?: Pick<Console, 'warn'>;
+};
+
+export function withEmbedderIdentityGuard<T extends VectorStoreAdapter>(adapter: T, options: GuardOptions): T {
+  const guard = new EmbedderIdentityGuard(options);
+  const connect = adapter.connect.bind(adapter);
+  const ensureCollection = adapter.ensureCollection.bind(adapter);
+  const deleteCollection = adapter.deleteCollection.bind(adapter);
+  let checked = false;
+
+  async function checkOnce() {
+    if (checked) return;
+    await guard.check();
+    checked = true;
+  }
+
+  adapter.connect = async () => { await connect(); await checkOnce(); };
+  adapter.ensureCollection = async () => { await ensureCollection(); await checkOnce(); };
+  adapter.deleteCollection = async () => {
+    await deleteCollection();
+    guard.clear();
+    checked = false;
+  };
+  return adapter;
+}
+
+export class EmbedderIdentityGuard {
+  private readonly entry: RegistryEntry;
+  private readonly key: string;
+  private readonly registryPath: string;
+  private readonly policy: Policy;
+  private readonly logger: Pick<Console, 'warn'>;
+
+  constructor(private readonly options: GuardOptions) {
+    const identity = embedderIdentity(options.embedder, options.modelName);
+    this.key = registryKey(options.adapterName, options.collectionName, options.storagePath);
+    this.registryPath = options.registryPath ?? registryPathFor(options.storagePath);
+    this.policy = options.policy ?? policyFromEnv();
+    this.logger = options.logger ?? console;
+    this.entry = {
+      ...identity,
+      adapter: options.adapterName,
+      collection: options.collectionName,
+      updated_at: new Date().toISOString(),
+    };
+  }
+
+  async check(): Promise<void> {
+    const registry = readRegistry(this.registryPath);
+    const existing = registry.collections[this.key];
+    if (!existing) {
+      registry.collections[this.key] = this.entry;
+      writeRegistry(this.registryPath, registry);
+      return;
+    }
+    if (sameIdentity(existing, this.entry)) return;
+    const message = mismatchMessage(existing, this.entry);
+    if (this.policy === 'warn') {
+      this.logger.warn(`[VectorIdentity] ${message}`);
+      return;
+    }
+    throw new Error(message);
+  }
+
+  clear(): void {
+    const registry = readRegistry(this.registryPath);
+    delete registry.collections[this.key];
+    writeRegistry(this.registryPath, registry);
+  }
+}
+
+export function embedderIdentity(embedder: Pick<EmbeddingProvider, 'name' | 'dimensions'>, modelName?: string): EmbedderIdentity {
+  const model = clean(modelName) ?? defaultModelName(embedder.name) ?? embedder.name;
+  return { model_name: model, dimension: Math.trunc(embedder.dimensions) };
+}
+
+export function registryPathFor(storagePath?: string): string {
+  const configured = clean(process.env.ORACLE_VECTOR_IDENTITY_PATH);
+  if (configured) return configured;
+  if (!storagePath) return path.join(ORACLE_DATA_DIR, 'vector-identity.json');
+  if (isHttpUrl(storagePath)) return path.join(ORACLE_DATA_DIR, 'vector-identity.json');
+  return looksLikeFile(storagePath)
+    ? `${storagePath}.embedder-identity.json`
+    : path.join(storagePath, '.embedder-identity.json');
+}
+
+function registryKey(adapter: string, collection: string, storagePath?: string): string {
+  const raw = `${adapter}\0${collection}\0${storagePath ?? ''}`;
+  return createHash('sha256').update(raw).digest('hex').slice(0, 16);
+}
+
+function readRegistry(file: string): Registry {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf8')) as Registry;
+    if (parsed.version === 1 && parsed.collections && typeof parsed.collections === 'object') return parsed;
+  } catch {}
+  return { version: 1, collections: {} };
+}
+
+function writeRegistry(file: string, registry: Registry): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const tmp = `${file}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, `${JSON.stringify(registry, null, 2)}\n`);
+  fs.renameSync(tmp, file);
+}
+
+function sameIdentity(a: EmbedderIdentity, b: EmbedderIdentity): boolean {
+  return a.model_name === b.model_name && a.dimension === b.dimension;
+}
+
+function mismatchMessage(existing: RegistryEntry, current: RegistryEntry): string {
+  return `Vector collection '${current.collection}' embedder mismatch: `
+    + `persisted ${existing.model_name} (${existing.dimension} dims), `
+    + `current ${current.model_name} (${current.dimension} dims). `
+    + 'Delete/reindex the collection or set ORACLE_VECTOR_IDENTITY_MISMATCH=warn to override.';
+}
+
+function policyFromEnv(): Policy {
+  return process.env.ORACLE_VECTOR_IDENTITY_MISMATCH?.trim().toLowerCase() === 'warn' ? 'warn' : 'error';
+}
+
+function defaultModelName(provider: string): string | undefined {
+  const first = provider.split('>')[0];
+  return ({
+    ollama: 'nomic-embed-text',
+    local: 'nomic-embed-text',
+    openai: 'text-embedding-3-small',
+    gemini: 'text-embedding-004',
+    'cloudflare-ai': '@cf/baai/bge-m3',
+    'chromadb-internal': 'chromadb-internal',
+    none: 'none',
+  } as Record<string, string | undefined>)[first];
+}
+
+function clean(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+function looksLikeFile(value: string): boolean {
+  return Boolean(path.extname(value));
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}

--- a/src/vector/factory.ts
+++ b/src/vector/factory.ts
@@ -1,7 +1,7 @@
 import { VECTORS_DB_PATH, LANCEDB_DIR, CHROMADB_DIR } from '../config.ts';
 import { COLLECTION_NAME } from '../const.ts';
 import type { VectorStoreAdapter } from './adapter.ts';
-import type { EmbedderConfig, VectorDBType, EmbeddingProviderType } from './types.ts';
+import type { EmbedderConfig, VectorDBType, EmbeddingProviderType, EmbeddingProvider } from './types.ts';
 import { ChromaMcpAdapter } from './adapters/chroma-mcp.ts';
 import { SqliteVecAdapter } from './adapters/sqlite-vec.ts';
 import { LanceDBAdapter } from './adapters/lancedb.ts';
@@ -15,6 +15,7 @@ import { GeminiEmbeddings } from './providers/gemini.ts';
 import { resolveEmbeddingFallbackChain, resolveEmbeddingModel, resolveEmbeddingProviderType } from './embedder-config.ts';
 import { configPath, loadVectorConfig, resolveServiceEndpoint, configToModels, fallbackCollectionsFor } from './config.ts';
 import { tenantDataPath } from '../middleware/tenant.ts';
+import { withEmbedderIdentityGuard } from './embedder-identity.ts';
 
 export type { VectorStoreAdapter } from './adapter.ts';
 export interface VectorStoreConfig {
@@ -65,17 +66,20 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
   switch (type) {
     case 'sqlite-vec': {
       const dbPath = tenantDataPath(clean(config.dataPath) || clean(process.env.ORACLE_VECTOR_DB_PATH) || VECTORS_DB_PATH);
-      return new SqliteVecAdapter(collectionName, dbPath, createConfiguredEmbedder(config));
+      const embedder = createConfiguredEmbedder(config);
+      return guardVectorStore(new SqliteVecAdapter(collectionName, dbPath, embedder), type, collectionName, embedder, dbPath, config.embeddingModel);
     }
     case 'lancedb': {
       const dbPath = tenantDataPath(clean(config.dataPath) || clean(process.env.ORACLE_VECTOR_DB_PATH) || LANCEDB_DIR);
-      return new LanceDBAdapter(collectionName, dbPath, createConfiguredEmbedder(config));
+      const embedder = createConfiguredEmbedder(config);
+      return guardVectorStore(new LanceDBAdapter(collectionName, dbPath, embedder), type, collectionName, embedder, dbPath, config.embeddingModel);
     }
     case 'qdrant': {
-      return new QdrantAdapter(collectionName, createConfiguredEmbedder(config), {
+      const embedder = createConfiguredEmbedder(config);
+      return guardVectorStore(new QdrantAdapter(collectionName, embedder, {
         url: clean(config.qdrantUrl) || clean(process.env.QDRANT_URL),
         apiKey: clean(config.qdrantApiKey) || clean(process.env.QDRANT_API_KEY),
-      });
+      }), type, collectionName, embedder, clean(config.qdrantUrl) || clean(process.env.QDRANT_URL), config.embeddingModel);
     }
     case 'cloudflare-vectorize': {
       return createCloudflareVectorStore(collectionName, config);
@@ -98,6 +102,18 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
       return new ChromaMcpAdapter(collectionName, dataPath, pythonVersion);
     }
   }
+}
+function guardVectorStore<T extends VectorStoreAdapter>(
+  store: T, adapterName: VectorDBType, collectionName: string, embedder: EmbeddingProvider,
+  storagePath?: string, modelName?: string,
+): T {
+  return withEmbedderIdentityGuard(store, {
+    adapterName,
+    collectionName,
+    embedder,
+    modelName: resolveEmbeddingModel(modelName),
+    storagePath,
+  });
 }
 function loadActiveVectorConfig(): ReturnType<typeof loadVectorConfig> {
   const dataDir = process.env.ORACLE_DATA_DIR;

--- a/tests/vector/embedder-identity.test.ts
+++ b/tests/vector/embedder-identity.test.ts
@@ -1,0 +1,90 @@
+import { expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { VectorDocument, VectorQueryResult, VectorStoreAdapter } from '../../src/vector/adapter.ts';
+import { withEmbedderIdentityGuard } from '../../src/vector/embedder-identity.ts';
+import { tempDir } from './helpers.ts';
+
+function memoryAdapter(): VectorStoreAdapter & { deleted: boolean } {
+  return {
+    name: 'memory',
+    deleted: false,
+    async connect() {},
+    async close() {},
+    async ensureCollection() {},
+    async deleteCollection() { this.deleted = true; },
+    async addDocuments(_docs: VectorDocument[]) {},
+    async query(): Promise<VectorQueryResult> { return emptyResult(); },
+    async queryById(): Promise<VectorQueryResult> { return emptyResult(); },
+    async getStats() { return { count: 0 }; },
+    async getCollectionInfo() { return { count: 0, name: 'memory' }; },
+  };
+}
+
+function guarded(registryPath: string, modelName: string, dimension: number, extras = {}) {
+  return withEmbedderIdentityGuard(memoryAdapter(), {
+    adapterName: 'lancedb',
+    collectionName: 'oracle_knowledge',
+    storagePath: '/vectors/lancedb',
+    registryPath,
+    embedder: { name: 'ollama', dimensions: dimension },
+    modelName,
+    ...extras,
+  });
+}
+
+function registryEntries(registryPath: string) {
+  const registry = JSON.parse(readFileSync(registryPath, 'utf8')) as { collections: Record<string, unknown> };
+  return Object.values(registry.collections);
+}
+
+function emptyResult(): VectorQueryResult {
+  return { ids: [], documents: [], distances: [], metadatas: [] };
+}
+
+test('embedder identity guard persists model and dimension on connect', async () => {
+  const registryPath = join(tempDir(), 'identity.json');
+
+  await guarded(registryPath, 'bge-m3', 1024).connect();
+
+  expect(registryEntries(registryPath)).toEqual([
+    expect.objectContaining({
+      adapter: 'lancedb',
+      collection: 'oracle_knowledge',
+      model_name: 'bge-m3',
+      dimension: 1024,
+    }),
+  ]);
+});
+
+test('embedder identity guard refuses a collection model or dimension mismatch', async () => {
+  const registryPath = join(tempDir(), 'identity.json');
+  await guarded(registryPath, 'bge-m3', 1024).connect();
+
+  await expect(guarded(registryPath, 'nomic-embed-text', 768).connect())
+    .rejects.toThrow("Vector collection 'oracle_knowledge' embedder mismatch");
+});
+
+test('embedder identity guard can warn without overwriting the persisted identity', async () => {
+  const registryPath = join(tempDir(), 'identity.json');
+  const warnings: string[] = [];
+  await guarded(registryPath, 'bge-m3', 1024).connect();
+
+  await guarded(registryPath, 'nomic-embed-text', 768, {
+    policy: 'warn',
+    logger: { warn: (message: string) => warnings.push(message) },
+  }).connect();
+
+  expect(warnings[0]).toContain('embedder mismatch');
+  expect(registryEntries(registryPath)[0]).toEqual(expect.objectContaining({ model_name: 'bge-m3', dimension: 1024 }));
+});
+
+test('embedder identity guard clears metadata when the collection is deleted', async () => {
+  const registryPath = join(tempDir(), 'identity.json');
+  const adapter = guarded(registryPath, 'bge-m3', 1024);
+  await adapter.connect();
+  await adapter.deleteCollection();
+
+  expect((adapter as ReturnType<typeof memoryAdapter>).deleted).toBe(true);
+  expect(registryEntries(registryPath)).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- Add an embedder identity guard that persists `model_name` + `dimension` per vector collection.
- Wire the guard into the vector factory connect/ensure path for embedded adapters (`lancedb`, `sqlite-vec`, `qdrant`) so mismatched embedders refuse by default.
- Support `ORACLE_VECTOR_IDENTITY_MISMATCH=warn` for explicit warn-only overrides and clear identity metadata when collections are deleted.

## Validation
- `rtk bunx tsc --noEmit`
- `rtk bun test tests/vector/`
- `rtk git diff --check`
- changed files <=250 lines (`src/vector/factory.ts` 250, `src/vector/embedder-identity.ts` 170, `tests/vector/embedder-identity.test.ts` 90)
