### PR TITLE
feat(cli): add mine watch mode and samples

### DIFF
--- a/docs/sample-notes/ops/runbook.txt
+++ b/docs/sample-notes/ops/runbook.txt
@@ -1,0 +1,7 @@
+Oracle quickstart runbook:
+
+1. Start the server.
+2. Run `arra mine docs/sample-notes`.
+3. Ask a question about memory onboarding.
+
+Re-running mine is safe; unchanged files are skipped.

--- a/docs/sample-notes/projects/oracle-memory.md
+++ b/docs/sample-notes/projects/oracle-memory.md
@@ -1,0 +1,9 @@
+# Oracle Memory Notes
+
+Arra stores operational knowledge as searchable memories. Start by mining a small folder, then ask questions against the indexed notes.
+
+## Concepts
+
+- memory onboarding
+- folder ingest
+- cited answers

--- a/src/cli/commands/mine.ts
+++ b/src/cli/commands/mine.ts
@@ -1,13 +1,14 @@
-import { mineFolder } from '../../indexer/mine.ts';
+import { mineFolder, watchMineFolder } from '../../indexer/mine.ts';
 
-export interface MineCliOptions { dir?: string; dbPath?: string; dryRun: boolean; help: boolean }
+export interface MineCliOptions { dir?: string; dbPath?: string; dryRun: boolean; watch: boolean; help: boolean }
 
 export function parseMineArgs(args: string[]): MineCliOptions {
-  const options: MineCliOptions = { dryRun: false, help: false };
+  const options: MineCliOptions = { dryRun: false, watch: false, help: false };
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg === '--help' || arg === '-h') options.help = true;
     else if (arg === '--dry-run') options.dryRun = true;
+    else if (arg === '--watch' || arg === '-w') options.watch = true;
     else if (arg === '--db-path') {
       const value = args[++i]?.trim();
       if (!value) throw new Error('--db-path requires a path');
@@ -26,10 +27,11 @@ export function parseMineArgs(args: string[]): MineCliOptions {
 
 export function mineHelp(): string {
   return [
-    'Usage: arra mine <dir> [--db-path <file>] [--dry-run]',
+    'Usage: arra mine <dir> [--watch] [--db-path <file>] [--dry-run]',
     'Ingest a folder into Oracle memory with deterministic IDs and safe re-runs.',
     '',
     'Defaults: indexes .md, .mdx, and .txt files; skips unchanged content.',
+    'Use --watch to keep re-ingesting the folder when files change.',
   ].join('\n');
 }
 
@@ -39,9 +41,16 @@ export async function mineCommand(args: string[]): Promise<number> {
   catch (error) { console.error(error instanceof Error ? error.message : String(error)); console.error(mineHelp()); return 1; }
   if (options.help) { console.log(mineHelp()); return 0; }
   if (!options.dir) { console.error('mine requires a directory'); console.error(mineHelp()); return 1; }
+  const print = (r: { stored: number; scanned: number; skipped: number; project: string }) => {
+    console.log(`Mined ${r.stored} document${r.stored === 1 ? '' : 's'} from ${r.scanned} file${r.scanned === 1 ? '' : 's'} (${r.skipped} skipped) into project "${r.project}".`);
+  };
   try {
-    const result = await mineFolder(options as { dir: string; dbPath?: string; dryRun?: boolean });
-    console.log(`Mined ${result.stored} document${result.stored === 1 ? '' : 's'} from ${result.scanned} file${result.scanned === 1 ? '' : 's'} (${result.skipped} skipped) into project "${result.project}".`);
+    if (options.watch) {
+      const controller = new AbortController();
+      process.once('SIGINT', () => controller.abort());
+      console.log(`Watching ${options.dir} for changes...`);
+      await watchMineFolder({ ...options, dir: options.dir, signal: controller.signal }, print);
+    } else print(await mineFolder(options as { dir: string; dbPath?: string; dryRun?: boolean }));
     return 0;
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -77,9 +77,9 @@ export const BUILTIN_HELP: CliHelpEntry[] = [
   {
     command: "mine",
     help: "ingest a folder into Oracle memory",
-    usage: "arra-cli mine <dir> [--db-path <file>] [--dry-run]",
-    flags: ["--db-path <file>", "--dry-run", "--help", "-h"],
-    examples: ["arra-cli mine ~/notes", "arra-cli mine ./docs --dry-run"],
+    usage: "arra-cli mine <dir> [--watch] [--db-path <file>] [--dry-run]",
+    flags: ["--watch", "--db-path <file>", "--dry-run", "--help", "-h"],
+    examples: ["arra-cli mine docs/sample-notes", "arra-cli mine ~/notes --watch"],
   },
   {
     command: "huginn",

--- a/src/indexer/mine.ts
+++ b/src/indexer/mine.ts
@@ -14,6 +14,7 @@ const SKIP_DIRS = new Set(['.git', 'node_modules', 'dist', 'build', '.next', '.t
 
 export interface MineOptions { dir: string; dbPath?: string; dryRun?: boolean }
 export interface MineResult { scanned: number; stored: number; skipped: number; project: string; root: string }
+export interface MineWatchOptions extends MineOptions { signal?: AbortSignal; debounceMs?: number }
 
 export function stableMineDocId(root: string, filePath: string): string {
   const rel = relativeSource(root, filePath);
@@ -68,6 +69,48 @@ export async function mineFolder(options: MineOptions): Promise<MineResult> {
   } finally {
     storage.close();
   }
+}
+
+export async function watchMineFolder(
+  options: MineWatchOptions,
+  onResult: (result: MineResult) => void = () => {},
+): Promise<void> {
+  const root = path.resolve(options.dir);
+  const signal = options.signal;
+  const debounceMs = options.debounceMs ?? 300;
+  const watchers: fs.FSWatcher[] = [];
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let running = Promise.resolve();
+
+  const run = () => {
+    running = running.then(async () => onResult(await mineFolder(options)));
+    return running;
+  };
+  const schedule = () => {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => { void run(); }, debounceMs);
+  };
+  const close = () => {
+    if (timer) clearTimeout(timer);
+    for (const watcher of watchers) watcher.close();
+  };
+
+  for (const dir of collectMineDirs(root)) watchers.push(fs.watch(dir, schedule));
+  await run();
+  if (signal?.aborted) return close();
+  await new Promise<void>((resolve) => {
+    signal?.addEventListener('abort', () => { close(); resolve(); }, { once: true });
+  });
+  await running;
+}
+
+function collectMineDirs(root: string): string[] {
+  const dirs = [root];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory() || SKIP_DIRS.has(entry.name) || entry.name.startsWith('.')) continue;
+    dirs.push(...collectMineDirs(path.join(root, entry.name)));
+  }
+  return dirs;
 }
 
 function toMineDocument(root: string, file: string, content: string, id: string, version: number, project: string): OracleDocument {

--- a/tests/cli/mine/mine.test.ts
+++ b/tests/cli/mine/mine.test.ts
@@ -6,7 +6,7 @@ import path from 'path';
 import { parseMineArgs } from '../../../src/cli/commands/mine.ts';
 import { createDatabase } from '../../../src/db/index.ts';
 import { oracleDocuments } from '../../../src/db/schema.ts';
-import { mineFolder, stableMineDocId } from '../../../src/indexer/mine.ts';
+import { mineFolder, stableMineDocId, watchMineFolder } from '../../../src/indexer/mine.ts';
 
 let tempDir = '';
 
@@ -23,9 +23,10 @@ function tmp(): string {
 describe('arra mine folder ingest', () => {
   test('parses friendly command flags and rejects bad input', () => {
     expect(parseMineArgs(['notes', '--db-path', '/tmp/oracle.db'])).toEqual({
-      dir: 'notes', dbPath: '/tmp/oracle.db', dryRun: false, help: false,
+      dir: 'notes', dbPath: '/tmp/oracle.db', dryRun: false, watch: false, help: false,
     });
-    expect(parseMineArgs(['--dry-run', '--db-path=/tmp/oracle.db', 'notes']).dryRun).toBe(true);
+    expect(parseMineArgs(['--dry-run', '--watch', '--db-path=/tmp/oracle.db', 'notes']).dryRun).toBe(true);
+    expect(parseMineArgs(['-w', 'notes']).watch).toBe(true);
     expect(() => parseMineArgs(['notes', '--bad'])).toThrow('unknown mine option: --bad');
     expect(() => parseMineArgs(['--db-path'])).toThrow('--db-path requires a path');
   });
@@ -52,5 +53,29 @@ describe('arra mine folder ingest', () => {
     expect(row?.sourceFile).toBe('mine/notes/ops/deploy.md');
     expect(row?.createdBy).toBe('mine');
     expect(JSON.parse(row?.concepts ?? '[]')).toContain('ops');
+  });
+
+  test('watch re-ingests changed files after the initial run', async () => {
+    const root = tmp();
+    const dbPath = path.join(root, 'oracle.db');
+    const notes = path.join(root, 'notes');
+    fs.mkdirSync(notes, { recursive: true });
+    const notePath = path.join(notes, 'watch.md');
+    fs.writeFileSync(notePath, 'first version');
+
+    const controller = new AbortController();
+    const results: number[] = [];
+    const watchDone = watchMineFolder(
+      { dir: notes, dbPath, debounceMs: 20, signal: controller.signal },
+      (result) => {
+        results.push(result.stored);
+        if (results.length === 1) fs.writeFileSync(notePath, 'second version');
+        if (results.length >= 2) controller.abort();
+      },
+    );
+
+    await watchDone;
+
+    expect(results).toEqual([1, 1]);
   });
 });


### PR DESCRIPTION
## Summary
- Added `arra mine --watch` / `-w` for debounced folder re-ingest on file changes.
- Updated CLI help examples for the watch flow.
- Added a tiny `docs/sample-notes/` corpus for quickstart users to mine out of the box.

## Tests
```bash
bun test --isolate tests/cli/mine/mine.test.ts
bunx tsc --noEmit
bun run cli/src/cli.ts mine --help
wc -l src/indexer/mine.ts src/cli/commands/mine.ts src/cli/help.ts tests/cli/mine/mine.test.ts docs/sample-notes/projects/oracle-memory.md docs/sample-notes/ops/runbook.txt
```

Refs #2420
