### PR TITLE
feat: default-safe vector backend

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -64,7 +64,7 @@ export function AppShell({
     { to: '/export', label: 'Export App', description: 'Legacy v2 JSON/Markdown backups' },
     { to: '/vector', label: 'Vector Dashboard', description: 'Collection health and indexing', end: true },
     { to: '/vector/documents', label: 'Document Browser', description: 'Browse indexed vector documents' },
-    { to: '/vector/first-run', label: 'First-run setup', description: 'Provider detection and first index' },
+    { to: '/vector/first-run', label: 'First-run setup', description: 'Local backend and first index' },
     { to: '/vector/index', label: 'Index Manager', description: 'Backfill vectors and watch jobs' },
     { to: '/vector/search', label: 'Vector Search', description: 'Semantic preview by collection' },
     { to: '/vector/settings', label: 'Vector settings', description: 'Collection config and index controls' },

--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -1,12 +1,11 @@
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { apiFetch } from "../api";
 import { ErrorMessage, Spinner } from "./AsyncState";
 import { StateNotice } from "./StateNotice";
 import { StepBody, setupSteps } from "./SetupWizardContent";
 import { shouldShowSetupWizard } from "./setupWizardDetection";
 import { buildIndexStartBody, requestVectorIndexStart } from "./setupWizardIndex";
-import { buildProviderConfigPatch, recommendedProvider } from "./setupWizardProvider";
-import type { Provider, Stats, Step, VectorConfig, VectorIndexSource } from "./setupWizardTypes";
+import type { Stats, Step, VectorConfig, VectorIndexSource } from "./setupWizardTypes";
 
 export { shouldShowSetupWizard } from "./setupWizardDetection";
 
@@ -26,8 +25,6 @@ async function getJson<T>(path: string): Promise<T> {
 export function SetupWizard({ children }: { children: ReactNode }) {
   const [state, setState] = useState<SetupState>("checking");
   const [step, setStep] = useState<Step>(0);
-  const [providers, setProviders] = useState<Provider[]>([]);
-  const [selectedProvider, setSelectedProvider] = useState("");
   const [indexSource, setIndexSource] = useState<VectorIndexSource>("auto");
   const [repoRoot, setRepoRoot] = useState("");
   const [config, setConfig] = useState<VectorConfig | null>(null);
@@ -45,17 +42,12 @@ export function SetupWizard({ children }: { children: ReactNode }) {
     }
     let active = true;
     Promise.allSettled([
-      getJson<Stats>("/api/stats"), getJson<VectorConfig>("/api/v1/vector/config"), getJson<{ providers?: Provider[] }>("/api/v1/vector/providers"),
+      getJson<Stats>("/api/stats"), getJson<VectorConfig>("/api/v1/vector/config"),
     ])
-      .then(([statsResult, configResult, providersResult]) => {
+      .then(([statsResult, configResult]) => {
         if (!active) return;
         const stats = statsResult.status === "fulfilled" ? statsResult.value : null;
         const vectorConfig = configResult.status === "fulfilled" ? configResult.value : null;
-        if (providersResult.status === "fulfilled") {
-          const nextProviders = providersResult.value.providers ?? [];
-          setProviders(nextProviders);
-          setSelectedProvider((current) => current || recommendedProvider(nextProviders)?.type || "");
-        }
         if (vectorConfig) setConfig(vectorConfig);
         setState(shouldShowSetupWizard(stats, vectorConfig) ? "visible" : "hidden");
       })
@@ -67,44 +59,13 @@ export function SetupWizard({ children }: { children: ReactNode }) {
     };
   }, []);
 
-  const recommended = useMemo(() => recommendedProvider(providers), [providers]);
-
-  async function refreshDetection() {
+  async function refreshBackend() {
     setBusy(true);
     setError("");
     try {
-      const [providerBody, vectorConfig] = await Promise.all([
-        getJson<{ providers?: Provider[] }>("/api/v1/vector/providers"),
-        getJson<VectorConfig>("/api/v1/vector/config"),
-      ]);
-      const nextProviders = providerBody.providers ?? [];
-      setProviders(nextProviders);
-      setSelectedProvider((current) => current || recommendedProvider(nextProviders)?.type || "");
+      const vectorConfig = await getJson<VectorConfig>("/api/v1/vector/config");
       setConfig(vectorConfig);
-      setMessage("Auto-detect refreshed. Choose a provider and continue.");
-    } catch (cause) {
-      setMessage("");
-      setError(errorMessage(cause));
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  async function applyProvider() {
-    if (!selectedProvider) return setMessage("Choose an embedding provider first.");
-    setBusy(true);
-    setError("");
-    try {
-      const response = await apiFetch("/api/v1/vector/config", {
-        method: "PATCH",
-        headers: { accept: "application/json", "content-type": "application/json" },
-        body: JSON.stringify(buildProviderConfigPatch(config, selectedProvider)),
-      });
-      if (!response.ok) throw new Error(`/api/v1/vector/config returned ${response.status}`);
-      await apiFetch("/api/v1/vector/config/reload", { method: "POST", headers: { accept: "application/json" } });
-      setConfig(await getJson<VectorConfig>("/api/v1/vector/config"));
-      setStep(2);
-      setMessage(`Applied ${selectedProvider} as the first-run embedding provider.`);
+      setMessage("Local backend detected. Provider selection is optional; continue when ready.");
     } catch (cause) {
       setMessage("");
       setError(errorMessage(cause));
@@ -142,7 +103,7 @@ export function SetupWizard({ children }: { children: ReactNode }) {
       <section className="mx-auto max-w-4xl rounded-3xl border border-accent2-border bg-accent2-soft p-6 shadow-2xl">
         <p className="text-xs font-semibold uppercase tracking-[0.3em] text-accent2">First-run wizard</p>
         <h1 className="mt-3 text-3xl font-bold">Set up vector search</h1>
-        <p className="mt-3 text-sm text-accent2">No full-text documents and no active vector index were detected. Configure a provider, choose the initial vault source, then start indexing.</p>
+        <p className="mt-3 text-sm text-accent2">No full-text documents and no active vector index were detected. Arra picked a local vector backend. Choose an optional vault source, then start indexing.</p>
         <ol className="mt-5 flex gap-2" aria-label="Setup steps">
           {setupSteps.map((label, index) => (
             <li
@@ -155,11 +116,7 @@ export function SetupWizard({ children }: { children: ReactNode }) {
           <h2 className="text-xl font-semibold text-text">{setupSteps[step]}</h2>
           <StepBody
             step={step}
-            providers={providers}
-            recommended={recommended}
             config={config}
-            selectedProvider={selectedProvider}
-            onProviderSelect={setSelectedProvider}
             indexSource={indexSource}
             repoRoot={repoRoot}
             onIndexSource={setIndexSource}
@@ -181,18 +138,18 @@ export function SetupWizard({ children }: { children: ReactNode }) {
             <button
               className="focus-ring rounded-xl bg-accent2-solid px-4 py-2 text-sm font-semibold text-on-accent"
               type="button"
-              onClick={() => void refreshDetection()}
+              onClick={() => void refreshBackend()}
             >
-              {busy ? <Spinner label="Detecting" /> : "Auto-detect providers"}
+              {busy ? <Spinner label="Detecting" /> : "Detect local backend"}
             </button>
           ) : null}
           {step === 1 ? (
             <button
               className="focus-ring rounded-xl bg-accent-solid px-4 py-2 text-sm font-semibold text-on-accent"
               type="button"
-              onClick={() => void applyProvider()}
+              onClick={() => setStep(2)}
             >
-              {busy ? <Spinner label="Applying" /> : "Use selected provider"}
+              Use local default
             </button>
           ) : null}
           {step === 2 ? (

--- a/frontend/src/components/SetupWizardContent.tsx
+++ b/frontend/src/components/SetupWizardContent.tsx
@@ -1,20 +1,16 @@
 import { SetupWizardCostEstimate } from "./SetupWizardCostEstimate";
 import { StateNotice } from "./StateNotice";
-import type { Provider, Step, VectorConfig, VectorIndexSource } from "./setupWizardTypes";
+import type { Step, VectorConfig, VectorIndexSource } from "./setupWizardTypes";
 
 export const setupSteps = [
   "Welcome",
-  "Provider",
+  "Local backend",
   "Vault path",
   "Done",
 ] as const;
 
 export function StepBody({
   step,
-  providers,
-  recommended,
-  selectedProvider = '',
-  onProviderSelect,
   config,
   indexSource = 'auto',
   repoRoot = '',
@@ -22,10 +18,6 @@ export function StepBody({
   onRepoRoot,
 }: {
   step: Step;
-  providers: Provider[];
-  recommended?: Provider;
-  selectedProvider?: string;
-  onProviderSelect?: (provider: string) => void;
   config: VectorConfig | null;
   indexSource?: VectorIndexSource;
   repoRoot?: string;
@@ -36,14 +28,13 @@ export function StepBody({
     return (
       <div className="mt-3">
         <StateNotice
-          title="Ready to detect providers"
-          detail="Run auto-detect to check Ollama, OpenAI, Gemini, Cloudflare, and registered vector services."
+          title="Ready to use the local default"
+          detail="Arra selects a bundled local vector backend automatically. The provider wizard is optional/advanced."
         />
       </div>
     );
-  if (step === 1)
-    return <ProviderList providers={providers} recommended={recommended} selectedProvider={selectedProvider} onProviderSelect={onProviderSelect} />;
-  if (step === 2) return <VaultPlan config={config} provider={selectedProvider || recommended?.type || "openai"} source={indexSource} repoRoot={repoRoot} onSource={onIndexSource} onRepoRoot={onRepoRoot} />;
+  if (step === 1) return <LocalBackendPlan config={config} />;
+  if (step === 2) return <VaultPlan config={config} provider={defaultProvider(config)} source={indexSource} repoRoot={repoRoot} onSource={onIndexSource} onRepoRoot={onRepoRoot} />;
   return (
     <div className="mt-3">
       <StateNotice
@@ -55,61 +46,21 @@ export function StepBody({
   );
 }
 
-function ProviderList({
-  providers,
-  recommended,
-  selectedProvider,
-  onProviderSelect,
-}: {
-  providers: Provider[];
-  recommended?: Provider;
-  selectedProvider: string;
-  onProviderSelect?: (provider: string) => void;
-}) {
-  if (!providers.length)
-    return (
-      <div className="mt-3">
-        <StateNotice
-          tone="warning"
-          title="No provider report yet"
-          detail="Configure API keys or start Ollama, then auto-detect again."
-        />
-      </div>
-    );
+function LocalBackendPlan({ config }: { config: VectorConfig | null }) {
+  const engine = config?.resolution?.engine ?? "lancedb";
+  const collections = Object.entries(config?.config?.collections ?? {});
   return (
-    <div className="mt-3 grid gap-3 sm:grid-cols-2">
-      {providers.map((provider) => (
-        <label
-          key={provider.type}
-          className="rounded-xl border border-border bg-surface-muted p-3"
-        >
-          <span className="flex items-center gap-2 font-semibold text-accent2">
-            <input
-              checked={selectedProvider === provider.type}
-              name="setup-provider"
-              type="radio"
-              value={provider.type}
-              onChange={() => onProviderSelect?.(provider.type)}
-            />
-            {provider.type}
-            {recommended?.type === provider.type ? " · recommended" : ""}
-          </span>
-          <p className="mt-2 text-sm text-text-muted">
-            {provider.available ? "available" : "unavailable"} ·{" "}
-            {(provider.models ?? []).slice(0, 3).join(", ") ||
-              provider.status ||
-              provider.error ||
-              "no models"}
-          </p>
-          {provider.type.toLowerCase().includes("gemini") ? (
-            <p className="mt-2 text-xs font-semibold text-accent">
-              Free tier available!
-            </p>
-          ) : null}
-        </label>
-      ))}
+    <div className="mt-3 rounded-xl border border-ok-border bg-ok-bg p-3 text-sm text-ok-text">
+      <p className="font-semibold">Local vector backend selected: {engine}</p>
+      <p className="mt-2">No embedding/provider choice is required for first run. Tune providers later from Vector Settings.</p>
+      <p className="mt-2 text-ok-text/80">Configured collections: {collections.length ? collections.map(([key]) => key).join(", ") : "defaults will be used"}</p>
     </div>
   );
+}
+
+function defaultProvider(config: VectorConfig | null): string {
+  const primary = Object.values(config?.config?.collections ?? {}).find((item) => item.provider);
+  return primary?.provider ?? "ollama";
 }
 
 function VaultPlan({ config, provider, source, repoRoot, onSource, onRepoRoot }: {

--- a/frontend/src/components/setupWizardDetection.ts
+++ b/frontend/src/components/setupWizardDetection.ts
@@ -25,6 +25,8 @@ export function shouldShowSetupWizard(
   stats: Stats | null,
   config: VectorConfig | null,
 ): boolean {
+  if (config?.resolution?.wizard === "optional" && config.resolution.providerPrompt === false)
+    return false;
   return (
     docsCount(stats) === 0 &&
     (stats?.vector?.enabled === false ||

--- a/frontend/src/components/setupWizardTypes.ts
+++ b/frontend/src/components/setupWizardTypes.ts
@@ -6,6 +6,12 @@ export type Stats = {
   vector?: { enabled?: boolean; count?: number };
 };
 export type VectorConfig = {
+  source?: "file" | "defaults";
+  resolution?: {
+    providerPrompt?: boolean;
+    wizard?: "optional" | "required" | "advanced";
+    engine?: string;
+  };
   config?: {
     collections?: Record<
       string,

--- a/frontend/src/components/wizard/FirstRunWizard.tsx
+++ b/frontend/src/components/wizard/FirstRunWizard.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ErrorMessage, LoadingPanel, Spinner } from '../AsyncState';
-import { apiFetch, type VectorProvider } from '../../api/oracle';
+import { apiFetch } from '../../api/oracle';
 import { useFirstRun } from '../../hooks/useFirstRun';
 
 type Step = 0 | 1 | 2 | 3;
@@ -15,7 +15,7 @@ type CollectionPlan = {
   primary?: boolean;
 };
 
-const steps = ['Welcome', 'Provider', 'Collections', 'Confirm'] as const;
+const steps = ['Welcome', 'Backend', 'Collections', 'Confirm'] as const;
 const defaultPlans: CollectionPlan[] = [
   { key: 'bge-m3', label: 'BGE M3', collection: 'oracle_knowledge_bge_m3', model: 'bge-m3', selected: true, primary: true },
   { key: 'nomic', label: 'Nomic Embed Text', collection: 'oracle_knowledge', model: 'nomic-embed-text', selected: true },
@@ -36,19 +36,9 @@ async function json<T>(path: string, init: RequestInit = {}): Promise<T> {
   return payload as T;
 }
 
-function providerLabel(provider?: VectorProvider): string {
-  if (!provider) return 'No provider selected';
-  const state = provider.available ? 'available' : provider.configured ? 'configured' : provider.status ?? 'unavailable';
-  return `${provider.type} · ${state}`;
-}
-
-function providerModels(provider?: VectorProvider): string {
-  return provider?.models?.slice(0, 3).join(', ') || provider?.error || provider?.status || 'No models reported';
-}
-
 function copyFor(step: Step): string {
   if (step === 0) return 'Oracle turns local notes, docs, traces, and handoffs into searchable memory for the operator dashboard and MCP tools.';
-  if (step === 1) return 'Choose the embedding provider that will generate vectors for semantic search.';
+  if (step === 1) return 'Use the local vector backend selected automatically for first run.';
   if (step === 2) return 'Pick the initial vector collections to create before the first index run.';
   return 'Review the setup choices, create selected collections, and start initial indexing.';
 }
@@ -56,8 +46,7 @@ function copyFor(step: Step): string {
 export function FirstRunWizard() {
   const { markSetupComplete, setupComplete } = useFirstRun();
   const [step, setStep] = useState<Step>(0);
-  const [providers, setProviders] = useState<VectorProvider[]>([]);
-  const [providerType, setProviderType] = useState('');
+  const [backend, setBackend] = useState('lancedb');
   const [plans, setPlans] = useState(defaultPlans);
   const [state, setState] = useState<LoadState>('loading');
   const [busy, setBusy] = useState(false);
@@ -66,12 +55,10 @@ export function FirstRunWizard() {
 
   useEffect(() => {
     let active = true;
-    json<{ providers?: VectorProvider[] }>('/api/v1/vector/providers')
+    json<{ engine?: string; resolution?: { engine?: string } }>('/api/v1/vector/config')
       .then((body) => {
         if (!active) return;
-        const next = body.providers ?? [];
-        setProviders(next);
-        setProviderType((current) => current || next.find((item) => item.available || item.configured)?.type || next[0]?.type || 'none');
+        setBackend(body.resolution?.engine ?? body.engine ?? 'lancedb');
         setState('ready');
       })
       .catch((cause) => {
@@ -82,8 +69,7 @@ export function FirstRunWizard() {
     return () => { active = false; };
   }, []);
 
-  const selected = useMemo(() => plans.filter((plan) => plan.selected), [plans]);
-  const selectedProvider = providers.find((provider) => provider.type === providerType);
+  const selected = plans.filter((plan) => plan.selected);
 
   function toggleCollection(key: string) {
     setPlans((current) => current.map((plan) => (
@@ -104,8 +90,8 @@ export function FirstRunWizard() {
           body: JSON.stringify({
             collection: plan.collection,
             model: plan.model,
-            provider: providerType,
-            adapter: 'lancedb',
+            provider: 'ollama',
+            adapter: backend === 'sqlite-vec' ? 'sqlite-vec' : 'lancedb',
             primary: plan.primary === true,
           }),
         }).catch((cause) => {
@@ -136,14 +122,14 @@ export function FirstRunWizard() {
         </ol>
       </div>
 
-      {state === 'loading' ? <LoadingPanel title="Loading providers" detail="Fetching /api/v1/vector/providers." /> : null}
-      {state === 'error' ? <ErrorMessage title="Could not load embedding providers." message={error} /> : null}
+      {state === 'loading' ? <LoadingPanel title="Loading local backend" detail="Fetching /api/v1/vector/config." /> : null}
+      {state === 'error' ? <ErrorMessage title="Could not load vector backend." message={error} /> : null}
 
       <div className="grid gap-4 lg:grid-cols-4">
         <WelcomeCard active={step === 0} complete={setupComplete} />
-        <ProviderCard active={step === 1} providers={providers} providerType={providerType} onChange={setProviderType} />
+        <BackendCard active={step === 1} backend={backend} />
         <CollectionsCard active={step === 2} plans={plans} onToggle={toggleCollection} />
-        <ConfirmCard active={step === 3} provider={selectedProvider} providerType={providerType} selected={selected} busy={busy} onStart={() => void startInitialIndexing()} />
+        <ConfirmCard active={step === 3} backend={backend} selected={selected} busy={busy} onStart={() => void startInitialIndexing()} />
       </div>
 
       {message ? <p className="rounded-2xl border border-accent-border p-4 text-sm text-accent">{message}</p> : null}
@@ -172,15 +158,13 @@ function WelcomeCard({ active, complete }: { active: boolean; complete: boolean 
   );
 }
 
-function ProviderCard({ active, providers, providerType, onChange }: { active: boolean; providers: VectorProvider[]; providerType: string; onChange: (value: string) => void }) {
+function BackendCard({ active, backend }: { active: boolean; backend: string }) {
   return (
     <article className={`${cardClass(active)} lg:col-span-2`}>
-      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Provider</p>
-      <h2 className="mt-2 text-2xl font-semibold text-text">Embedding provider</h2>
-      <select className="focus-ring mt-5 w-full rounded-xl border border-border bg-field px-4 py-3 text-text" value={providerType} onChange={(event) => onChange(event.target.value)}>
-        {providers.length ? providers.map((provider) => <option key={provider.type} value={provider.type}>{providerLabel(provider)}</option>) : <option value="none">No providers loaded</option>}
-      </select>
-      <p className="mt-3 text-sm text-text-muted">{providerModels(providers.find((provider) => provider.type === providerType))}</p>
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Backend</p>
+      <h2 className="mt-2 text-2xl font-semibold text-text">Local backend default</h2>
+      <p className="mt-5 rounded-2xl border border-accent-border p-4 text-sm text-accent">{backend} is selected automatically. No provider prompt is required for first-run setup.</p>
+      <p className="mt-3 text-sm text-text-muted">Advanced provider tuning remains available in Vector Settings.</p>
     </article>
   );
 }
@@ -202,13 +186,13 @@ function CollectionsCard({ active, plans, onToggle }: { active: boolean; plans: 
   );
 }
 
-function ConfirmCard({ active, provider, providerType, selected, busy, onStart }: { active: boolean; provider?: VectorProvider; providerType: string; selected: CollectionPlan[]; busy: boolean; onStart: () => void }) {
+function ConfirmCard({ active, backend, selected, busy, onStart }: { active: boolean; backend: string; selected: CollectionPlan[]; busy: boolean; onStart: () => void }) {
   return (
     <article className={`${cardClass(active)} lg:col-span-2`}>
       <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Confirm</p>
       <h2 className="mt-2 text-2xl font-semibold text-text">Start initial indexing</h2>
       <dl className="mt-4 grid gap-2 text-sm text-text-muted">
-        <div><dt className="text-text-muted">Provider</dt><dd className="font-medium text-text">{providerLabel(provider) || providerType}</dd></div>
+        <div><dt className="text-text-muted">Backend</dt><dd className="font-medium text-text">{backend}</dd></div>
         <div><dt className="text-text-muted">Collections</dt><dd className="font-medium text-text">{selected.map((plan) => plan.key).join(', ') || 'none selected'}</dd></div>
       </dl>
       <button className="focus-ring mt-5 rounded-xl bg-accent-solid px-4 py-3 text-sm font-semibold text-on-accent disabled:cursor-not-allowed disabled:opacity-50" disabled={busy || !selected.length} type="button" onClick={onStart}>

--- a/frontend/src/pages/FirstRunWizard.tsx
+++ b/frontend/src/pages/FirstRunWizard.tsx
@@ -1,10 +1,8 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { ErrorMessage, LoadingPanel, Spinner } from '../components/AsyncState';
 import { fetchJson, parseVectorConfigResponse, toRows, type VectorConfigRow } from './vectorSettingsHelpers';
 
 type WizardStep = 0 | 1 | 2 | 3;
-type Provider = { type: string; available?: boolean; configured?: boolean; models?: string[]; error?: string; status?: string };
-type ProvidersResponse = { checkedAt?: string; providers?: Provider[] };
 type StatsResponse = { total?: number; total_docs?: number; vector?: { enabled?: boolean; count?: number } };
 type CostEstimate = {
   docs: number;
@@ -26,7 +24,7 @@ export type FirstRunWizardProps = {
   initialCost?: CostEstimate | null;
 };
 
-const steps = ['Welcome', 'Provider', 'Vault + index', 'Done'] as const;
+const steps = ['Welcome', 'Backend', 'Vault + index', 'Done'] as const;
 
 export function VectorFirstRunWizardPage() {
   const [rows, setRows] = useState<VectorConfigRow[]>([]);
@@ -53,7 +51,7 @@ export function VectorFirstRunWizardPage() {
       <header className="rounded-3xl border border-border bg-surface p-5 sm:p-6">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent2">Vector onboarding</p>
         <h1 id="vector-first-run-title" className="mt-2 text-3xl font-semibold text-text">First-run setup wizard</h1>
-        <p className="mt-2 text-sm text-text-muted">Auto-detect providers, review cost, choose the first vault collection, and start indexing.</p>
+        <p className="mt-2 text-sm text-text-muted">Use the local vector backend default, review cost, choose the first vault collection, and start indexing.</p>
       </header>
 
       <FirstRunWizard rows={rows} onRefresh={refresh} />
@@ -75,24 +73,20 @@ function firstRun(stats: StatsResponse | null, rows: VectorConfigRow[]): boolean
 
 export function FirstRunWizard({ rows, onRefresh, initialStep = 0, initialCost = null }: FirstRunWizardProps) {
   const [step, setStep] = useState<WizardStep>(initialStep);
-  const [providers, setProviders] = useState<Provider[]>([]);
   const [stats, setStats] = useState<StatsResponse | null>(null);
   const [cost, setCost] = useState<CostEstimate | null>(initialCost);
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
-  const recommended = useMemo(() => providers.find((item) => item.available) ?? providers[0], [providers]);
   const showAsFirstRun = firstRun(stats, rows);
 
   useEffect(() => {
     let active = true;
     Promise.allSettled([
-      fetchJson<ProvidersResponse>('/api/v1/vector/providers'),
       fetchJson<StatsResponse>('/api/v1/stats'),
       fetchJson<CostEstimate>('/api/v1/vector/cost-estimate'),
-    ]).then(([providerResult, statsResult, costResult]) => {
+    ]).then(([statsResult, costResult]) => {
       if (!active) return;
-      if (providerResult.status === 'fulfilled') setProviders(providerResult.value.providers ?? []);
       if (statsResult.status === 'fulfilled') setStats(statsResult.value);
       if (costResult.status === 'fulfilled') setCost(costResult.value);
     });
@@ -105,7 +99,7 @@ export function FirstRunWizard({ rows, onRefresh, initialStep = 0, initialCost =
     try {
       await fetchJson('/api/v1/vector/config/reload', { method: 'POST' });
       await onRefresh();
-      setMessage('Auto-detect refreshed. Review collection health and continue.');
+      setMessage('Local backend refreshed. Review collection health and continue.');
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause));
     } finally {
@@ -135,12 +129,12 @@ export function FirstRunWizard({ rows, onRefresh, initialStep = 0, initialCost =
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent2">First-run wizard</p>
           <h2 id="first-run-wizard-title" className="mt-2 text-2xl font-semibold text-text">{steps[step]}</h2>
-          <p className="mt-2 max-w-3xl text-sm text-purple-100/80">{copyFor(step, showAsFirstRun, recommended)}</p>
+          <p className="mt-2 max-w-3xl text-sm text-purple-100/80">{copyFor(step, showAsFirstRun)}</p>
         </div>
         <ol className="flex gap-2" aria-label="First-run steps">{steps.map((item, index) => <li key={item} className={`h-2 w-10 rounded-full ${index <= step ? 'bg-purple-200' : 'bg-white/20'}`} />)}</ol>
       </div>
 
-      {step === 1 ? <ProviderList providers={providers} /> : null}
+      {step === 1 ? <BackendPlan rows={rows} /> : null}
       {step === 2 ? <VaultPlan rows={rows} cost={cost} /> : null}
       {step === 3 ? <DoneActions /> : null}
       {message ? <p className="mt-4 rounded-2xl border border-border bg-field/50 p-3 text-sm text-purple-100">{message}</p> : null}
@@ -148,7 +142,7 @@ export function FirstRunWizard({ rows, onRefresh, initialStep = 0, initialCost =
 
       <div className="mt-5 flex flex-wrap gap-2">
         <button className="focus-ring rounded-xl border border-border px-3 py-2 text-sm text-purple-100 disabled:opacity-50" disabled={step === 0} type="button" onClick={() => setStep((step - 1) as WizardStep)}>Back</button>
-        {step === 0 ? <button className="focus-ring rounded-xl bg-purple-200 px-3 py-2 text-sm font-semibold text-on-accent" type="button" onClick={() => void reloadHealth()}>{busy ? <Spinner label="Detecting" /> : 'Run auto-detect'}</button> : null}
+        {step === 0 ? <button className="focus-ring rounded-xl bg-purple-200 px-3 py-2 text-sm font-semibold text-on-accent" type="button" onClick={() => void reloadHealth()}>{busy ? <Spinner label="Detecting" /> : 'Refresh local backend'}</button> : null}
         {step === 2 ? <button className="focus-ring rounded-xl bg-teal-200 px-3 py-2 text-sm font-semibold text-on-accent disabled:opacity-50" disabled={busy || !rows.length} type="button" onClick={() => void startIndex()}>{busy ? <Spinner label="Starting" /> : 'Start indexing'}</button> : null}
         <button className="focus-ring rounded-xl border border-purple-200/40 px-3 py-2 text-sm font-semibold text-purple-100 disabled:opacity-50" disabled={step === 3} type="button" onClick={() => setStep((step + 1) as WizardStep)}>Next</button>
         {step === 3 ? <a className="focus-ring rounded-xl bg-teal-200 px-3 py-2 text-sm font-semibold text-on-accent" href="/vector">Continue to dashboard</a> : null}
@@ -157,9 +151,9 @@ export function FirstRunWizard({ rows, onRefresh, initialStep = 0, initialCost =
   );
 }
 
-function copyFor(step: WizardStep, firstRun: boolean, provider?: Provider): string {
-  if (step === 0) return firstRun ? 'No complete vector index was detected. Start here to choose a provider and build the first index.' : 'Vector search is configured; use this wizard to refresh provider detection or onboard a new vault.';
-  if (step === 1) return provider ? `Recommended provider: ${provider.type}. Choose a configured provider before indexing.` : 'No providers reported yet; run auto-detect or configure keys.';
+function copyFor(step: WizardStep, firstRun: boolean): string {
+  if (step === 0) return firstRun ? 'No complete vector index was detected. A bundled local backend is already selected; build the first index when ready.' : 'Vector search is configured; use this optional wizard to refresh the backend or onboard a new vault.';
+  if (step === 1) return 'Arra auto-resolves local storage defaults for first run and keeps saved backend choices for returning users.';
   if (step === 2) return 'Review the primary collection, estimated cost, and recommendation before indexing.';
   return 'Indexing has started. The Index Manager shows live progress and completion state.';
 }
@@ -178,9 +172,15 @@ function DoneActions() {
   );
 }
 
-function ProviderList({ providers }: { providers: Provider[] }) {
-  if (!providers.length) return <p className="mt-4 text-sm text-purple-100/70">Provider detection has not returned results yet.</p>;
-  return <div className="mt-4 grid gap-2 sm:grid-cols-2 xl:grid-cols-4">{providers.map((provider) => <div key={provider.type} className="rounded-2xl border border-border bg-field/50 p-3"><p className="font-semibold text-purple-100">{provider.type}</p><p className="text-sm text-text-muted">{provider.available ? 'available' : 'unavailable'} · {(provider.models ?? []).slice(0, 2).join(', ') || 'no models'}</p></div>)}</div>;
+function BackendPlan({ rows }: { rows: VectorConfigRow[] }) {
+  const primary = rows.find((row) => row.primary) ?? rows[0];
+  return (
+    <div className="mt-4 rounded-2xl border border-accent-border p-4 text-sm text-accent">
+      <p className="font-semibold">Local backend default is active</p>
+      <p className="mt-1">No provider choice is required before indexing. Returning users keep their saved adapter automatically.</p>
+      <p className="mt-2 text-accent opacity-80">Primary adapter: {primary?.adapter ?? 'lancedb'} · collection {primary?.collection ?? 'default collections'}</p>
+    </div>
+  );
 }
 
 function VaultPlan({ rows, cost }: { rows: VectorConfigRow[]; cost: CostEstimate | null }) {
@@ -193,7 +193,7 @@ function VaultPlan({ rows, cost }: { rows: VectorConfigRow[]; cost: CostEstimate
       </div>
       <div className="rounded-2xl border border-accent-border p-4">
         <p className="font-semibold text-accent">Estimated embedding cost</p>
-        {cost ? <CostSummary cost={cost} /> : <p className="mt-2 text-accent opacity-70">Cost estimate will appear after provider detection completes.</p>}
+        {cost ? <CostSummary cost={cost} /> : <p className="mt-2 text-accent opacity-70">Cost estimate will appear after backend detection completes.</p>}
       </div>
     </div>
   );

--- a/frontend/src/routeMeta.ts
+++ b/frontend/src/routeMeta.ts
@@ -47,7 +47,7 @@ export function routeMeta(pathname: string, search = ''): RouteMeta {
   }
 
   if (pathname === '/vector/first-run') {
-    return base('First-run setup', 'Vector', 'Auto-detect providers, review cost, and start the first vector index.', [
+    return base('First-run setup', 'Vector', 'Use the local backend default, review cost, and start the first vector index.', [
       { label: 'Vector dashboard', to: '/vector' },
       { label: 'First-run setup' },
     ]);

--- a/src/routes/vector/__tests__/config.test.ts
+++ b/src/routes/vector/__tests__/config.test.ts
@@ -23,6 +23,12 @@ describe('/api/vector/config', () => {
     expect(body.source).toBe('defaults');
     expect(body.engine).toBe('lancedb');
     expect(body.enabled).toBe(false);
+    expect(body.resolution).toMatchObject({
+      engine: 'lancedb',
+      source: 'first-run-default',
+      providerPrompt: false,
+      wizard: 'optional',
+    });
     expect(body.state).toMatchObject({ enabled: false, ready: false, reason: 'vector section disabled' });
     expect(body.config.collections['bge-m3']).toMatchObject({
       adapter: 'lancedb',

--- a/src/routes/vector/config.ts
+++ b/src/routes/vector/config.ts
@@ -1,6 +1,7 @@
 import { Elysia, t } from 'elysia';
 import { reloadCachedVectorStores } from '../../vector/factory.ts';
 import { LOCAL_VECTOR_ENGINES, activeVectorEngine, applyVectorConfigUpdate, configToModels, type VectorConfigUpdate, type VectorServerConfig } from '../../vector/config.ts';
+import { resolveVectorBackend } from '../../vector/backend-resolution.ts';
 import {
   activeConfig,
   atomicWriteVectorConfig,
@@ -89,6 +90,7 @@ function configResponse(
       localEngines: LOCAL_VECTOR_ENGINES,
       embeddingProviders: ['ollama', 'openai', 'gemini', 'cloudflare-ai', 'chromadb-internal'],
     },
+    resolution: resolveVectorBackend(config, source),
     config,
     collections,
     doc_counts: Object.fromEntries(collections.map((col) => [col.key, col.count])),

--- a/src/vector/backend-resolution.ts
+++ b/src/vector/backend-resolution.ts
@@ -1,0 +1,98 @@
+import {
+  activeVectorEngine,
+  defaultDataPathForEngine,
+  isLocalVectorEngine,
+  type VectorServerConfig,
+} from './config.ts';
+import type { DetectedEmbeddingProvider } from './provider-detection.ts';
+import type { EmbeddingProviderType, VectorDBType } from './types.ts';
+
+export type ConfigSource = 'file' | 'defaults';
+export type ResolutionSource = 'config' | 'env' | 'detect' | 'first-run-default';
+
+export const DEFAULT_SAFE_LOCAL_ENGINE = 'lancedb' as const;
+const SAFE_LOCAL_ENGINES = new Set(['sqlite-vec', 'lancedb']);
+
+export interface VectorBackendResolution {
+  engine: VectorDBType;
+  source: Exclude<ResolutionSource, 'detect'>;
+  dataPath: string;
+  localDefault: boolean;
+  returningUser: boolean;
+  providerPrompt: false;
+  wizard: 'optional';
+  reason: string;
+}
+
+export interface EmbeddingProviderResolution {
+  provider: EmbeddingProviderType;
+  source: ResolutionSource;
+  local: boolean;
+  returningUser: boolean;
+  providerPrompt: false;
+  wizard: 'optional';
+  reason: string;
+}
+
+export function resolveVectorBackend(
+  config: VectorServerConfig,
+  source: ConfigSource,
+  env: NodeJS.ProcessEnv = process.env,
+): VectorBackendResolution {
+  const envEngine = normalizeEngine(env.ORACLE_VECTOR_DB);
+  if (envEngine) return backend(envEngine, 'env', defaultDataPathForEngine(envEngine), source === 'file', 'ORACLE_VECTOR_DB selects the local vector backend.');
+
+  const configured = activeVectorEngine(config);
+  if (source === 'file') {
+    return backend(configured, 'config', config.dataPath, true, 'Existing vector-server.json selects the backend.');
+  }
+
+  const selected = safeLocal(configured) ? configured : DEFAULT_SAFE_LOCAL_ENGINE;
+  return backend(selected, 'first-run-default', defaultDataPathForEngine(selected), false, 'Fresh installs use the bundled local backend without a provider prompt.');
+}
+
+export function resolveEmbeddingProvider(
+  config: VectorServerConfig,
+  source: ConfigSource,
+  providers: DetectedEmbeddingProvider[] = [],
+): EmbeddingProviderResolution {
+  const configured = primaryProvider(config);
+  if (source === 'file' && configured) return provider(configured, 'config', true, 'Existing vector config selects the embedding provider.');
+  const detected = providers.find((item) => item.available && item.type === 'ollama')
+    ?? providers.find((item) => item.available && item.configured);
+  if (detected) return provider(detected.type, 'detect', false, 'Detected provider is resolved automatically.');
+  return provider(configured ?? 'ollama', 'first-run-default', false, 'Fresh installs default to local Ollama/FTS fallback without prompting.');
+}
+
+function backend(engine: VectorDBType, source: VectorBackendResolution['source'], dataPath: string, returningUser: boolean, reason: string): VectorBackendResolution {
+  return {
+    engine, source, dataPath, returningUser, reason,
+    localDefault: safeLocal(engine),
+    providerPrompt: false,
+    wizard: 'optional',
+  };
+}
+
+function provider(providerName: EmbeddingProviderType, source: ResolutionSource, returningUser: boolean, reason: string): EmbeddingProviderResolution {
+  return {
+    provider: providerName, source, returningUser, reason,
+    local: providerName === 'ollama' || providerName === 'local' || providerName === 'none',
+    providerPrompt: false,
+    wizard: 'optional',
+  };
+}
+
+function normalizeEngine(value: string | undefined): typeof DEFAULT_SAFE_LOCAL_ENGINE | 'sqlite-vec' | null {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === 'sqlite-vec' || normalized === 'lancedb' ? normalized : null;
+}
+
+function safeLocal(engine: VectorDBType): engine is typeof DEFAULT_SAFE_LOCAL_ENGINE | 'sqlite-vec' {
+  return isLocalVectorEngine(engine) && SAFE_LOCAL_ENGINES.has(engine);
+}
+
+function primaryProvider(config: VectorServerConfig): EmbeddingProviderType | undefined {
+  const primary = Object.values(config.collections).find((item) => item.primary)
+    ?? Object.values(config.collections)[0];
+  return (primary?.provider ?? primary?.embedder?.backend ?? config.embedder?.backend) as EmbeddingProviderType | undefined;
+}

--- a/src/vector/provider-api.ts
+++ b/src/vector/provider-api.ts
@@ -8,6 +8,8 @@ import {
   type DetectedEmbeddingProvider,
   type ProviderDetectionOptions,
 } from './provider-detection.ts';
+import { generateDefaultConfig, loadVectorConfig, type VectorServerConfig } from './config.ts';
+import { resolveEmbeddingProvider, type ConfigSource, type EmbeddingProviderResolution } from './backend-resolution.ts';
 import type { EmbeddingProvider, EmbeddingProviderType } from './types.ts';
 
 export type ProviderScope = 'local' | 'remote' | 'internal' | 'disabled';
@@ -28,6 +30,8 @@ export interface ProviderApiOptions extends ProviderDetectionOptions {
   createProvider?: CreateEmbeddingProvider;
   force?: boolean;
   probeText?: string;
+  vectorConfig?: VectorServerConfig | null;
+  configSource?: ConfigSource;
 }
 
 export type ProviderInfo = DetectedEmbeddingProvider & {
@@ -41,6 +45,7 @@ export type ProviderInfo = DetectedEmbeddingProvider & {
 export interface ProviderListResult {
   checkedAt: string;
   providers: ProviderInfo[];
+  resolution: EmbeddingProviderResolution;
 }
 
 export interface ProviderTestRequest extends ProviderCreateOptions {
@@ -65,11 +70,15 @@ export function createEmbeddingProviderApi(defaults: ProviderApiOptions = {}): E
   return {
     async detect(options = {}) {
       const merged = { ...defaults, ...options };
-      const { force, createProvider: _createProvider, probeText: _probeText, ...detectOptions } = merged;
+      const { force, createProvider: _createProvider, probeText: _probeText, vectorConfig, configSource, ...detectOptions } = merged;
       const result = await getDetectedEmbeddingProviders(Boolean(force), detectOptions);
+      const loaded = vectorConfig === undefined ? loadVectorConfig() : vectorConfig;
+      const source = configSource ?? (loaded ? 'file' : 'defaults');
+      const config = loaded ?? generateDefaultConfig();
       return {
         checkedAt: result.checkedAt,
         providers: result.providers.map(toProviderInfo),
+        resolution: resolveEmbeddingProvider(config, source, result.providers),
       };
     },
 

--- a/tests/frontend/components/app-shell-vector-nav.test.tsx
+++ b/tests/frontend/components/app-shell-vector-nav.test.tsx
@@ -16,7 +16,7 @@ describe('AppShell Vector navigation', () => {
       );
       expect(html).toContain('aria-label="Vector Dashboard: Collection health and indexing"');
       expect(html).toContain('aria-label="Document Browser: Browse indexed vector documents"');
-      expect(html).toContain('aria-label="First-run setup: Provider detection and first index"');
+      expect(html).toContain('aria-label="First-run setup: Local backend and first index"');
       expect(html).toContain('aria-label="Index Manager: Backfill vectors and watch jobs"');
       expect(html).toContain('aria-label="Vector Search: Semantic preview by collection"');
       expect(html).toContain('aria-label="Export App: Legacy v2 JSON/Markdown backups"');

--- a/tests/frontend/components/first-run-wizard.test.tsx
+++ b/tests/frontend/components/first-run-wizard.test.tsx
@@ -13,7 +13,8 @@ describe('FirstRunWizard', () => {
     const html = htmlFor(<FirstRunWizard />);
     expect(html).toContain('First-run setup');
     expect(html).toContain('Oracle memory layer');
-    expect(html).toContain('Embedding provider');
+    expect(html).toContain('Local backend default');
+    expect(html).toContain('No provider prompt is required');
     expect(html).toContain('Collections to create');
     expect(html).toContain('Start initial indexing');
   });

--- a/tests/frontend/components/setup-wizard-first-run.test.tsx
+++ b/tests/frontend/components/setup-wizard-first-run.test.tsx
@@ -26,6 +26,12 @@ describe("SetupWizard first-run detection", () => {
         { config: { collections: {} }, doc_counts: {} },
       ),
     ).toBe(false);
+    expect(
+      shouldShowSetupWizard(
+        { total_docs: 0, vector: { enabled: false, count: 0 } },
+        { resolution: { wizard: "optional", providerPrompt: false }, config: { collections: {} }, doc_counts: {} },
+      ),
+    ).toBe(false);
   });
 
 
@@ -42,26 +48,22 @@ describe("SetupWizard first-run detection", () => {
     });
   });
 
-  test("renders selectable first-run provider radios", () => {
+  test("renders local default backend instead of first-run provider radios", () => {
     const html = htmlFor(<StepBody
       step={1}
-      providers={[{ type: "ollama", available: false }, { type: "gemini", available: true }]}
-      recommended={{ type: "gemini", available: true }}
-      selectedProvider="gemini"
-      onProviderSelect={() => {}}
-      config={null}
+      config={{ resolution: { engine: "sqlite-vec", providerPrompt: false, wizard: "optional" } }}
     />);
-    expect(html).toContain('name="setup-provider"');
-    expect(html).toContain('gemini · recommended');
-    expect(html).toContain('Free tier available!');
+    expect(html).toContain("Local vector backend selected: sqlite-vec");
+    expect(html).not.toContain('name="setup-provider"');
+    expect(html).toContain("No embedding/provider choice is required");
   });
 
   test("renders semantic empty and done wizard states", () => {
-    const empty = htmlFor(<StepBody step={1} providers={[]} selectedProvider="" config={null} />);
-    const done = htmlFor(<StepBody step={3} providers={[]} config={null} />);
+    const empty = htmlFor(<StepBody step={1} config={null} />);
+    const done = htmlFor(<StepBody step={3} config={null} />);
 
-    expect(empty).toContain("No provider report yet");
-    expect(empty).toContain("border-warn-border bg-warn-bg text-warn-text");
+    expect(empty).toContain("Local vector backend selected: lancedb");
+    expect(empty).toContain("border-ok-border bg-ok-bg");
     expect(done).toContain("First-run setup complete");
     expect(done).toContain("border-ok-border bg-ok-bg text-ok-text");
   });
@@ -80,7 +82,6 @@ describe("SetupWizard first-run detection", () => {
   test("renders vault source controls for first-run indexing", () => {
     const html = htmlFor(<StepBody
       step={2}
-      providers={[]}
       config={{ config: { collections: { bge: { model: "bge-m3" } } } }}
       indexSource="vault"
       repoRoot="/repo/oracle"
@@ -113,7 +114,7 @@ describe("SetupWizard first-run detection", () => {
 
   test("labels the final wizard step as done with dashboard guidance", () => {
     expect(setupSteps[3]).toBe("Done");
-    const html = htmlFor(<StepBody step={3} providers={[]} config={null} />);
+    const html = htmlFor(<StepBody step={3} config={null} />);
     expect(html).toContain("Vector dashboard");
     expect(html).toContain("Vector Settings");
   });

--- a/tests/frontend/routes/vector-meta.test.ts
+++ b/tests/frontend/routes/vector-meta.test.ts
@@ -14,7 +14,7 @@ describe('vector route metadata', () => {
     });
     expect(routeMeta('/vector/first-run')).toMatchObject({
       title: 'First-run setup',
-      description: 'Auto-detect providers, review cost, and start the first vector index.',
+      description: 'Use the local backend default, review cost, and start the first vector index.',
     });
   });
 });

--- a/tests/vector/backend-resolution.test.ts
+++ b/tests/vector/backend-resolution.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from 'bun:test';
+import {
+  resolveEmbeddingProvider,
+  resolveVectorBackend,
+} from '../../src/vector/backend-resolution.ts';
+import { generateDefaultConfig } from '../../src/vector/config.ts';
+
+test('fresh installs resolve a local vector backend without provider prompt', () => {
+  const cfg = generateDefaultConfig();
+  const resolution = resolveVectorBackend(cfg, 'defaults', {});
+
+  expect(resolution).toMatchObject({
+    engine: 'lancedb',
+    source: 'first-run-default',
+    localDefault: true,
+    returningUser: false,
+    providerPrompt: false,
+    wizard: 'optional',
+  });
+});
+
+test('returning users keep configured backend and embedding provider', () => {
+  const cfg = generateDefaultConfig();
+  cfg.dataPath = '/data/vectors.db';
+  cfg.collections['bge-m3'].adapter = 'sqlite-vec';
+  cfg.collections['bge-m3'].provider = 'gemini';
+
+  expect(resolveVectorBackend(cfg, 'file', {})).toMatchObject({
+    engine: 'sqlite-vec',
+    source: 'config',
+    returningUser: true,
+    providerPrompt: false,
+  });
+  expect(resolveEmbeddingProvider(cfg, 'file')).toMatchObject({
+    provider: 'gemini',
+    source: 'config',
+    returningUser: true,
+    providerPrompt: false,
+  });
+});
+
+test('ORACLE_VECTOR_DB can select sqlite-vec as the safe local default', () => {
+  const cfg = generateDefaultConfig();
+  const resolution = resolveVectorBackend(cfg, 'defaults', { ORACLE_VECTOR_DB: 'sqlite-vec' });
+
+  expect(resolution).toMatchObject({
+    engine: 'sqlite-vec',
+    source: 'env',
+    localDefault: true,
+    providerPrompt: false,
+  });
+  expect(resolution.dataPath.endsWith('vectors.db')).toBe(true);
+});

--- a/tests/vector/provider-api.test.ts
+++ b/tests/vector/provider-api.test.ts
@@ -22,6 +22,8 @@ test('provider API auto-detects local Ollama and remote credentials', async () =
       CF_ACCOUNT_ID: 'cf-account',
       CF_API_TOKEN: 'cf-token',
     },
+    vectorConfig: null,
+    configSource: 'defaults',
   });
 
   expect(result.providers).toContainEqual(expect.objectContaining({
@@ -48,12 +50,18 @@ test('provider API auto-detects local Ollama and remote credentials', async () =
     scope: 'remote',
     available: true,
   }));
+  expect(result.resolution).toMatchObject({
+    provider: 'ollama',
+    source: 'detect',
+    providerPrompt: false,
+    wizard: 'optional',
+  });
 });
 
 test('provider API caches detection until force refresh', async () => {
   let calls = 0;
   const fetcher = mock(async () => Response.json({ models: [{ name: `model-${++calls}` }] })) as unknown as typeof fetch;
-  const api = createEmbeddingProviderApi({ env: {}, fetcher });
+  const api = createEmbeddingProviderApi({ env: {}, fetcher, vectorConfig: null, configSource: 'defaults' });
 
   const first = await api.detect({ force: true });
   const cached = await api.detect();
@@ -62,7 +70,36 @@ test('provider API caches detection until force refresh', async () => {
   expect(first.providers[0].models).toEqual(['model-1']);
   expect(cached.providers[0].models).toEqual(['model-1']);
   expect(refreshed.providers[0].models).toEqual(['model-2']);
+  expect(cached.resolution.source).toBe('detect');
   expect(fetcher).toHaveBeenCalledTimes(2);
+});
+
+test('provider API resolves returning users from saved vector config', async () => {
+  const api = createEmbeddingProviderApi({
+    env: {},
+    fetcher: mock(async () => { throw new Error('no local server'); }) as unknown as typeof fetch,
+    vectorConfig: {
+      version: '1.0',
+      enabled: true,
+      host: '0.0.0.0',
+      port: 8081,
+      collections: {
+        docs: { collection: 'docs', model: 'bge-m3', provider: 'gemini', adapter: 'sqlite-vec', primary: true },
+      },
+      dataPath: '/tmp/vectors.db',
+      embeddingEndpoint: '',
+    },
+    configSource: 'file',
+  });
+
+  const result = await api.detect({ force: true });
+
+  expect(result.resolution).toMatchObject({
+    provider: 'gemini',
+    source: 'config',
+    returningUser: true,
+    providerPrompt: false,
+  });
 });
 
 test('provider API probes an embedding provider config', async () => {


### PR DESCRIPTION
## Summary
- add default-safe vector backend/provider resolution for fresh installs and returning users
- expose no-provider-prompt resolution metadata from vector config/provider detect APIs
- make first-run setup use the local backend default and keep provider tuning optional/advanced

Refs #2420

## Verification
- rtk bunx tsc --noEmit
- rtk bun test tests/vector/backend-resolution.test.ts tests/vector/provider-api.test.ts src/routes/vector/__tests__/config.test.ts src/vector/__tests__/config.test.ts tests/http/vector/default-config.test.ts tests/frontend/components/setup-wizard-first-run.test.tsx tests/frontend/components/first-run-wizard.test.tsx tests/frontend/pages/first-run-wizard-cost.test.tsx tests/frontend/routes/vector-meta.test.ts tests/frontend/components/app-shell-vector-nav.test.tsx tests/frontend/router.test.ts tests/frontend/api/vector-registry-oracle-api.test.ts
- rtk git diff --check HEAD~1..HEAD
- changed files <=250 lines