### PR TITLE
feat(search): add pointer index fast path

### DIFF
--- a/src/db/__tests__/fresh-install.test.ts
+++ b/src/db/__tests__/fresh-install.test.ts
@@ -83,6 +83,8 @@ describe("fresh install (#1111)", () => {
 		expect(names).toContain("idx_menu_path_studio");
 		expect(names).toContain("idx_entity_links_tenant_key");
 		expect(names).toContain("idx_entity_links_tenant_doc");
+		expect(names).toContain("idx_pointer_tenant_kind_key");
+		expect(names).toContain("idx_pointer_tenant_updated");
 
 		sqlite.close();
 		rmSync(dir, { recursive: true });

--- a/src/db/migrations/0038_pointer_index.sql
+++ b/src/db/migrations/0038_pointer_index.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS oracle_pointer_index (
+  id TEXT PRIMARY KEY NOT NULL,
+  tenant_id TEXT NOT NULL DEFAULT 'default' REFERENCES tenants(id),
+  kind TEXT NOT NULL,
+  key TEXT NOT NULL,
+  doc_ids TEXT NOT NULL DEFAULT '[]',
+  updated_at INTEGER NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_pointer_tenant_kind_key ON oracle_pointer_index (tenant_id, kind, key);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_pointer_tenant_updated ON oracle_pointer_index (tenant_id, updated_at);

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -237,6 +237,7 @@
     { "idx": 34, "version": "6", "when": 1781700000000, "tag": "0034_memory_ttl", "breakpoints": true },
     { "idx": 35, "version": "6", "when": 1781669700000, "tag": "0035_entity_links_ranking_sidecar", "breakpoints": true },
     { "idx": 36, "version": "6", "when": 1781703600000, "tag": "0036_memory_consolidation", "breakpoints": true },
-    { "idx": 37, "version": "6", "when": 1781703700000, "tag": "0037_memory_tiered_salience", "breakpoints": true }
+    { "idx": 37, "version": "6", "when": 1781703700000, "tag": "0037_memory_tiered_salience", "breakpoints": true },
+    { "idx": 38, "version": "6", "when": 1781703800000, "tag": "0038_pointer_index", "breakpoints": true }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -48,7 +48,16 @@ export const oracleEntityLinks = sqliteTable('oracle_entity_links', {
   index('idx_entity_links_tenant_key').on(table.tenantId, table.entityKey),
   index('idx_entity_links_tenant_doc').on(table.tenantId, table.documentId),
 ]);
-// Challenge 2 memory system persistence (#1457)
+export const oraclePointerIndex = sqliteTable('oracle_pointer_index', {
+  id: text('id').primaryKey(),
+  tenantId: text('tenant_id').default('default').notNull().references(() => tenants.id),
+  kind: text('kind').notNull(), key: text('key').notNull(),
+  docIds: text('doc_ids').default('[]').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+}, (table) => [
+  index('idx_pointer_tenant_kind_key').on(table.tenantId, table.kind, table.key),
+  index('idx_pointer_tenant_updated').on(table.tenantId, table.updatedAt),
+]);
 export const oracleMemories = sqliteTable('oracle_memories', {
   id: text('id').primaryKey(),
   tenantId: text('tenant_id').default('default').notNull(),
@@ -71,7 +80,7 @@ export const oracleMemories = sqliteTable('oracle_memories', {
   index('idx_memory_tenant_valid_time').on(table.tenantId, table.validFrom, table.validTo),
   index('idx_memory_tenant_tier_heat').on(table.tenantId, table.tier, table.heatScore),
 ]);
-// Indexing status tracking
+
 export const indexingStatus = sqliteTable('indexing_status', {
   id: integer('id').primaryKey(),
   isIndexing: integer('is_indexing').default(0).notNull(),
@@ -80,7 +89,7 @@ export const indexingStatus = sqliteTable('indexing_status', {
   startedAt: integer('started_at'),
   completedAt: integer('completed_at'),
   error: text('error'),
-  repoRoot: text('repo_root'),  // Root directory being indexed
+  repoRoot: text('repo_root'),
 });
 export const indexingJobs = sqliteTable('indexing_jobs', {
   id: text('id').primaryKey(),
@@ -96,7 +105,7 @@ export const indexingJobs = sqliteTable('indexing_jobs', {
   finishedAt: integer('finished_at'),
   error: text('error'),
 });
-// Search query logging
+
 export const searchLog = sqliteTable('search_log', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   query: text('query').notNull(),
@@ -107,15 +116,14 @@ export const searchLog = sqliteTable('search_log', {
   searchTimeMs: integer('search_time_ms'),
   createdAt: integer('created_at').notNull(),
   project: text('project'),
-  results: text('results'), // JSON array of top 5 results (id, type, score, snippet)
+  results: text('results'),
 }, (table) => [
   index('idx_search_project').on(table.project),
   index('idx_search_tenant').on(table.tenantId),
   index('idx_search_created').on(table.createdAt),
   index('idx_search_tenant_created').on(table.tenantId, table.createdAt),
 ]);
-// Consult log — legacy table kept for backward compat (pre-0007 snapshot had it).
-// Not actively used; retained to avoid destructive migration drop.
+
 export const consultLog = sqliteTable('consult_log', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   decision: text('decision').notNull(),
@@ -129,7 +137,7 @@ export const consultLog = sqliteTable('consult_log', {
   index('idx_consult_project').on(table.project),
   index('idx_consult_created').on(table.createdAt),
 ]);
-// Learning/pattern logging
+
 export const learnLog = sqliteTable('learn_log', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   documentId: text('document_id').notNull(),
@@ -145,7 +153,6 @@ export const learnLog = sqliteTable('learn_log', {
   index('idx_learn_created').on(table.createdAt),
 ]);
 
-// Document access logging
 export const documentAccess = sqliteTable('document_access', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   documentId: text('document_id').notNull(),
@@ -164,8 +171,8 @@ export const forumThreads = sqliteTable('forum_threads', {
   title: text('title').notNull(),
   tenantId: text('tenant_id').default('default').notNull(),
   createdBy: text('created_by').default('human'),
-  status: text('status').default('active'), // active, answered, pending, closed
-  issueUrl: text('issue_url'),              // GitHub mirror URL
+  status: text('status').default('active'),
+  issueUrl: text('issue_url'),
   issueNumber: integer('issue_number'),
   project: text('project'),
   createdAt: integer('created_at').notNull(),
@@ -181,56 +188,47 @@ export const forumThreads = sqliteTable('forum_threads', {
 export const forumMessages = sqliteTable('forum_messages', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   threadId: integer('thread_id').notNull().references(() => forumThreads.id),
-  role: text('role').notNull(),             // human, oracle, claude
+  role: text('role').notNull(),
   content: text('content').notNull(),
-  author: text('author'),                   // GitHub username or "oracle"
+  author: text('author'),
   principlesFound: integer('principles_found'),
   patternsFound: integer('patterns_found'),
   searchQuery: text('search_query'),
-  commentId: integer('comment_id'),         // GitHub comment ID if synced
+  commentId: integer('comment_id'),
   createdAt: integer('created_at').notNull(),
 }, (table) => [
   index('idx_message_thread').on(table.threadId),
   index('idx_message_role').on(table.role),
   index('idx_message_created').on(table.createdAt),
 ]);
-// Note: FTS5 virtual table (oracle_fts) is managed via raw SQL
-// since Drizzle doesn't natively support FTS5
-// Trace Log Tables (discovery tracing with dig points)
 export const traceLog = sqliteTable('trace_log', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   traceId: text('trace_id').unique().notNull(),
   tenantId: text('tenant_id').default('default').notNull(),
   query: text('query').notNull(),
-  queryType: text('query_type').default('general'),  // general, project, pattern, evolution
-
-  foundFiles: text('found_files'),            // [{path, type, matchReason, confidence}]
-  foundCommits: text('found_commits'),        // [{hash, shortHash, date, message}]
-  foundIssues: text('found_issues'),          // [{number, title, state, url}]
-  foundRetrospectives: text('found_retrospectives'),  // [paths]
-  foundLearnings: text('found_learnings'),    // [paths]
-  foundResonance: text('found_resonance'),    // [paths]
-
+  queryType: text('query_type').default('general'),
+  foundFiles: text('found_files'),
+  foundCommits: text('found_commits'),
+  foundIssues: text('found_issues'),
+  foundRetrospectives: text('found_retrospectives'),
+  foundLearnings: text('found_learnings'),
+  foundResonance: text('found_resonance'),
   fileCount: integer('file_count').default(0),
   commitCount: integer('commit_count').default(0),
   issueCount: integer('issue_count').default(0),
-
-  depth: integer('depth').default(0),         // 0 = initial, 1+ = dig from parent
-  parentTraceId: text('parent_trace_id'),     // Links to parent trace
-  childTraceIds: text('child_trace_ids').default('[]'),  // Links to child traces
-
-  prevTraceId: text('prev_trace_id'),         // ← Previous trace in chain
-  nextTraceId: text('next_trace_id'),         // → Next trace in chain
-
-  project: text('project'),                   // ghq format project path
-  scope: text('scope').default('project'),    // 'project' | 'cross-project' | 'human'
-  sessionId: text('session_id'),              // Claude session if available
+  depth: integer('depth').default(0),
+  parentTraceId: text('parent_trace_id'),
+  childTraceIds: text('child_trace_ids').default('[]'),
+  prevTraceId: text('prev_trace_id'),
+  nextTraceId: text('next_trace_id'),
+  project: text('project'),
+  scope: text('scope').default('project'),
+  sessionId: text('session_id'),
   agentCount: integer('agent_count').default(1),
   durationMs: integer('duration_ms'),
-
-  status: text('status').default('raw'),      // raw, reviewed, distilling, distilled
-  awakening: text('awakening'),               // Extracted insight (markdown)
-  distilledToId: text('distilled_to_id'),     // Learning ID if promoted
+  status: text('status').default('raw'),
+  awakening: text('awakening'),
+  distilledToId: text('distilled_to_id'),
   distilledAt: integer('distilled_at'),
 
   createdAt: integer('created_at').notNull(),

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -34,6 +34,7 @@ import {
   supersedeReplacedSourceDocs,
 } from './reindex-state.ts';
 import { storeDocuments } from './storage.ts';
+import { removeDocumentPointers } from '../search/pointer-index.ts';
 
 export interface IndexOptions {
   append?: boolean;
@@ -148,6 +149,7 @@ export class OracleIndexer {
           const batch = idsToDelete.slice(i, i + BATCH_SIZE);
           const placeholders = batch.map(() => '?').join(',');
           this.sqlite.prepare(`DELETE FROM oracle_fts WHERE id IN (${placeholders})`).run(...batch);
+          removeDocumentPointers(this.sqlite, tenantId, batch);
         }
       }
     }

--- a/src/indexer/learn-doc-source.ts
+++ b/src/indexer/learn-doc-source.ts
@@ -7,6 +7,7 @@ import path from 'path';
 import type Database from 'bun:sqlite';
 import type { OracleDocument } from '../types.ts';
 import { parseLearningFile } from './parser.ts';
+import { replaceDocumentPointers } from '../search/pointer-index.ts';
 
 export const PSI_LEARN_REL = path.join('ψ', 'learn');
 export const MEMORY_LEARN_REL = path.join('ψ', 'memory', 'learnings');
@@ -100,6 +101,12 @@ export function storeSqliteDocuments(db: Database, documents: OracleDocument[]):
       );
       deleteFts.run(doc.id);
       insertFts.run(doc.id, doc.content, doc.concepts.join(' '));
+      replaceDocumentPointers(db, {
+        documentId: doc.id,
+        content: doc.content,
+        concepts: doc.concepts,
+        timestamp: doc.updated_at || doc.created_at,
+      });
     }
     db.exec('COMMIT');
   } catch (error) {

--- a/src/indexer/storage.ts
+++ b/src/indexer/storage.ts
@@ -8,6 +8,7 @@ import * as schema from '../db/schema.ts';
 import { oracleDocuments } from '../db/schema.ts';
 import { tenantIdForWrite } from '../middleware/tenant.ts';
 import { replaceEntityLinks } from '../search/entity-ranking.ts';
+import { replaceDocumentPointers } from '../search/pointer-index.ts';
 import type { VectorStoreAdapter } from '../vector/types.ts';
 import type { OracleDocument } from '../types.ts';
 
@@ -94,6 +95,13 @@ export async function storeDocuments(
         content: doc.content,
         concepts: doc.concepts,
         now,
+      });
+      replaceDocumentPointers(sqlite, {
+        documentId: doc.id,
+        tenantId,
+        content: doc.content,
+        concepts: doc.concepts,
+        timestamp: doc.updated_at || doc.created_at,
       });
 
       // Vector store metadata (must be primitives, not arrays)

--- a/src/search/__tests__/pointer-index.test.ts
+++ b/src/search/__tests__/pointer-index.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createDatabase } from '../../db/index.ts';
+import type { DatabaseConnection } from '../../db/create.ts';
+import { storeDocuments } from '../../indexer/storage.ts';
+import { handleSearch } from '../../tools/search.ts';
+import type { ToolContext } from '../../tools/types.ts';
+import { documentPointers, queryPointerIndex, replaceDocumentPointers } from '../pointer-index.ts';
+
+const roots: string[] = [];
+const connections: DatabaseConnection[] = [];
+const stamp = Date.parse('2026-06-05T12:00:00.000Z');
+
+function tempRoot(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'arra-pointer-index-'));
+  roots.push(dir);
+  return dir;
+}
+
+function connection(): DatabaseConnection {
+  const conn = createDatabase(join(tempRoot(), 'oracle.db'));
+  connections.push(conn);
+  return conn;
+}
+
+function ctx(conn: DatabaseConnection): ToolContext {
+  return {
+    db: conn.db,
+    sqlite: conn.sqlite,
+    repoRoot: tempRoot(),
+    vectorStore: { name: 'mock-vector' } as any,
+    vectorStatus: 'connected',
+    version: 'test',
+  };
+}
+
+afterEach(() => {
+  for (const conn of connections.splice(0)) conn.storage.close();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+test('documentPointers emits compact topic, entity, and date keys', () => {
+  const pointers = documentPointers({
+    documentId: 'doc-1',
+    content: 'Cloudflare Workers deploy Arra Oracle in 2026.',
+    concepts: ['Edge Runtime'],
+    timestamp: stamp,
+  });
+
+  expect(pointers).toContainEqual({ kind: 'topic', key: 'edge-runtime', label: 'Edge Runtime' });
+  expect(pointers).toContainEqual({ kind: 'entity', key: 'cloudflare-workers', label: 'Cloudflare Workers' });
+  expect(pointers).toContainEqual({ kind: 'date', key: '2026-06', label: '2026-06' });
+});
+
+test('storeDocuments maintains the pointer index for cheap entity and date lookup', async () => {
+  const conn = connection();
+  await storeDocuments(conn.sqlite, conn.db, null, null, [{
+    id: 'pointer-doc',
+    type: 'learning',
+    source_file: 'ψ/memory/learnings/pointer.md',
+    concepts: ['Cloudflare Workers'],
+    content: 'Closet pointer index routes entity and date recalls before embeddings.',
+    created_at: stamp,
+    updated_at: stamp,
+  }]);
+
+  const results = queryPointerIndex(conn.sqlite, { query: 'Cloudflare Workers 2026-06', limit: 5 });
+  expect(results.map((result) => result.id)).toEqual(['pointer-doc']);
+  expect(results[0].pointerMatches).toEqual(expect.arrayContaining(['Cloudflare Workers', '2026-06']));
+});
+
+test('oracle_search surfaces pointer-only hits when FTS misses', async () => {
+  const conn = connection();
+  conn.db.insert((await import('../../db/schema.ts')).oracleDocuments).values({
+    id: 'pointer-only',
+    type: 'learning',
+    sourceFile: 'ψ/memory/learnings/pointer-only.md',
+    concepts: JSON.stringify(['Cloudflare Workers']),
+    createdAt: stamp,
+    updatedAt: stamp,
+    indexedAt: stamp,
+  }).run();
+  conn.sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
+    .run('pointer-only', 'opaque runbook without query terms', 'unrelated');
+  replaceDocumentPointers(conn.sqlite, {
+    documentId: 'pointer-only',
+    content: 'Cloudflare Workers deploy note',
+    concepts: ['Cloudflare Workers'],
+    timestamp: stamp,
+  });
+
+  const response = await handleSearch(ctx(conn), { query: 'Cloudflare Workers 2026-06', mode: 'fts', limit: 3 });
+  const body = JSON.parse(response.content[0].text);
+
+  expect(body.results.map((result: { id: string }) => result.id)).toEqual(['pointer-only']);
+  expect(body.results[0]).toMatchObject({
+    source: 'pointer',
+    provenance: { pointer_matches: expect.arrayContaining(['Cloudflare Workers', '2026-06']) },
+  });
+  expect(body.metadata.pointerIndex).toMatchObject({
+    enabled: true,
+    strategy: 'topic_entity_date_pointer_fast_path',
+    hits: 1,
+  });
+});

--- a/src/search/pointer-index.ts
+++ b/src/search/pointer-index.ts
@@ -1,0 +1,188 @@
+import type { Database } from 'bun:sqlite';
+import { extractEntities } from '../vector/entities.ts';
+import { entityKey } from './entity-ranking.ts';
+
+type SqliteLike = Pick<Database, 'prepare'>;
+type PointerKind = 'topic' | 'entity' | 'date';
+type Pointer = { kind: PointerKind; key: string; label: string };
+type PointerRow = { id: string; kind: PointerKind; key: string; doc_ids: string };
+type DocRow = { id: string; type: string; source_file: string; concepts: string | null; content: string | null };
+
+export type PointerInput = {
+  documentId: string;
+  tenantId?: string;
+  content: string;
+  concepts?: unknown;
+  timestamp?: number;
+};
+export type PointerSearchResult = {
+  id: string; type: string; content: string; source_file: string; concepts: string[];
+  score: number; source: 'pointer'; pointerScore: number; pointerMatches: string[];
+};
+export type PointerSearchOptions = {
+  query: string; type?: string; project?: string | null; tenantId?: string; limit?: number;
+};
+
+const STOPWORDS = new Set(['and', 'are', 'for', 'from', 'into', 'the', 'this', 'that', 'with', 'what', 'when', 'where']);
+const KIND_WEIGHT: Record<PointerKind, number> = { entity: 0.55, topic: 0.35, date: 0.25 };
+
+export function documentPointers(input: PointerInput): Pointer[] {
+  return uniquePointers([
+    ...conceptValues(input.concepts).map((topic) => pointer('topic', topic)),
+    ...extractEntities(input.content, input.concepts).map((entity) => pointer('entity', entity)),
+    ...dateKeys(input.timestamp).map((key) => ({ kind: 'date' as const, key, label: key })),
+  ]);
+}
+
+export function replaceDocumentPointers(sqlite: SqliteLike, input: PointerInput): void {
+  try {
+    const tenantId = input.tenantId?.trim() || 'default';
+    removeDocumentPointers(sqlite, tenantId, [input.documentId]);
+    const select = sqlite.prepare('SELECT doc_ids FROM oracle_pointer_index WHERE id = ?');
+    const upsert = sqlite.prepare(`
+      INSERT INTO oracle_pointer_index (id, tenant_id, kind, key, doc_ids, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET doc_ids = excluded.doc_ids, updated_at = excluded.updated_at
+    `);
+    const now = Date.now();
+    for (const item of documentPointers(input)) {
+      const id = pointerId(tenantId, item.kind, item.key);
+      const existing = parseIds((select.get(id) as { doc_ids?: string } | undefined)?.doc_ids);
+      const docIds = [...new Set([...existing, input.documentId])].sort();
+      upsert.run(id, tenantId, item.kind, item.key, JSON.stringify(docIds), now);
+    }
+  } catch (error) {
+    if (!missingPointerTable(error)) throw error;
+  }
+}
+
+export function removeDocumentPointers(sqlite: SqliteLike, tenantId: string | undefined, documentIds: string[]): void {
+  if (documentIds.length === 0) return;
+  try {
+    const tenant = tenantId?.trim() || 'default';
+    const rows = sqlite.prepare('SELECT id, kind, key, doc_ids FROM oracle_pointer_index WHERE tenant_id = ?').all(tenant) as PointerRow[];
+    const update = sqlite.prepare('UPDATE oracle_pointer_index SET doc_ids = ?, updated_at = ? WHERE id = ?');
+    const del = sqlite.prepare('DELETE FROM oracle_pointer_index WHERE id = ?');
+    const remove = new Set(documentIds);
+    const now = Date.now();
+    for (const row of rows) {
+      const next = parseIds(row.doc_ids).filter((id) => !remove.has(id));
+      if (next.length === 0) del.run(row.id);
+      else if (next.length !== parseIds(row.doc_ids).length) update.run(JSON.stringify(next), now, row.id);
+    }
+  } catch (error) {
+    if (!missingPointerTable(error)) throw error;
+  }
+}
+
+export function queryPointerIndex(sqlite: SqliteLike, options: PointerSearchOptions): PointerSearchResult[] {
+  const limit = Math.max(1, Math.min(100, Math.trunc(options.limit ?? 10)));
+  const tenantId = options.tenantId?.trim() || 'default';
+  const keys = queryPointers(options.query);
+  if (keys.length === 0) return [];
+  try {
+    const rows = lookupPointerRows(sqlite, tenantId, keys);
+    const ranked = rankDocs(rows, keys);
+    return hydratePointerDocs(sqlite, ranked, { ...options, tenantId, limit });
+  } catch (error) {
+    if (missingPointerTable(error)) return [];
+    throw error;
+  }
+}
+
+export function queryPointers(query: string): Pointer[] {
+  const words = query.normalize('NFKC').match(/[\p{L}\p{N}][\p{L}\p{N}._-]{2,}/gu)
+    ?.map((word) => word.toLowerCase()).filter((word) => !STOPWORDS.has(word)) ?? [];
+  return uniquePointers([
+    ...words.map((word) => pointer('topic', word)),
+    ...adjacent(words).map((phrase) => pointer('topic', phrase)),
+    ...extractEntities(query).map((entity) => pointer('entity', entity)),
+    ...words.map((word) => pointer('entity', word)),
+    ...dateKeysFromText(query).map((key) => ({ kind: 'date' as const, key, label: key })),
+  ]).slice(0, 24);
+}
+
+function lookupPointerRows(sqlite: SqliteLike, tenantId: string, keys: Pointer[]): PointerRow[] {
+  const clauses = keys.map(() => '(kind = ? AND key = ?)').join(' OR ');
+  if (!clauses) return [];
+  const params = keys.flatMap((item) => [item.kind, item.key]);
+  return sqlite.prepare(`SELECT id, kind, key, doc_ids FROM oracle_pointer_index WHERE tenant_id = ? AND (${clauses})`)
+    .all(tenantId, ...params) as PointerRow[];
+}
+
+function rankDocs(rows: PointerRow[], wanted: Pointer[]): Map<string, { score: number; matches: string[] }> {
+  const wantedLabels = new Map(wanted.map((item) => [`${item.kind}:${item.key}`, item.label]));
+  const ranked = new Map<string, { score: number; matches: string[] }>();
+  for (const row of rows) {
+    const label = wantedLabels.get(`${row.kind}:${row.key}`) ?? row.key;
+    for (const docId of parseIds(row.doc_ids)) {
+      const hit = ranked.get(docId) ?? { score: 0, matches: [] };
+      hit.score += KIND_WEIGHT[row.kind];
+      if (!hit.matches.includes(label)) hit.matches.push(label);
+      ranked.set(docId, hit);
+    }
+  }
+  return ranked;
+}
+
+function hydratePointerDocs(sqlite: SqliteLike, ranked: Map<string, { score: number; matches: string[] }>, options: Required<Pick<PointerSearchOptions, 'tenantId' | 'limit'>> & PointerSearchOptions): PointerSearchResult[] {
+  const ids = [...ranked.keys()];
+  if (ids.length === 0) return [];
+  const placeholders = ids.map(() => '?').join(',');
+  const typeFilter = options.type && options.type !== 'all' ? ' AND d.type = ?' : '';
+  const projectFilter = options.project ? ' AND (d.project = ? OR d.project IS NULL)' : '';
+  const rows = sqlite.prepare(`
+    SELECT d.id, d.type, d.source_file, d.concepts, f.content
+    FROM oracle_documents d LEFT JOIN oracle_fts f ON f.id = d.id
+    WHERE d.tenant_id = ? AND d.id IN (${placeholders})${typeFilter}${projectFilter}
+  `).all(options.tenantId, ...ids, ...(options.type && options.type !== 'all' ? [options.type] : []), ...(options.project ? [options.project] : [])) as DocRow[];
+  return rows.map((row) => {
+    const hit = ranked.get(row.id)!;
+    const pointerScore = clamp(hit.score / 1.4);
+    return {
+      id: row.id,
+      type: row.type,
+      content: (row.content ?? '').slice(0, 500),
+      source_file: row.source_file,
+      concepts: conceptValues(row.concepts),
+      score: pointerScore,
+      source: 'pointer' as const,
+      pointerScore,
+      pointerMatches: hit.matches.slice(0, 8),
+    };
+  }).sort((a, b) => b.pointerScore - a.pointerScore).slice(0, options.limit);
+}
+
+function pointer(kind: PointerKind, value: string): Pointer { return { kind, key: entityKey(value), label: value.trim() }; }
+function pointerId(tenantId: string, kind: PointerKind, key: string): string { return `${tenantId}:${kind}:${key}`; }
+function uniquePointers(items: Pointer[]): Pointer[] {
+  const out = new Map<string, Pointer>();
+  for (const item of items) if (item.key) out.set(`${item.kind}:${item.key}`, item);
+  return [...out.values()];
+}
+function adjacent(words: string[]): string[] { return words.slice(0, -1).map((word, i) => `${word} ${words[i + 1]}`); }
+function parseIds(raw: string | undefined): string[] {
+  try { const parsed = JSON.parse(raw || '[]'); return Array.isArray(parsed) ? parsed.map(String).filter(Boolean) : []; } catch { return []; }
+}
+function conceptValues(raw: unknown): string[] {
+  if (Array.isArray(raw)) return raw.map(String).filter(Boolean);
+  if (typeof raw !== 'string' || !raw.trim()) return [];
+  try { const parsed = JSON.parse(raw); return Array.isArray(parsed) ? parsed.map(String).filter(Boolean) : []; } catch { return raw.split(',').map((item) => item.trim()).filter(Boolean); }
+}
+function dateKeys(timestamp: number | undefined): string[] {
+  if (!timestamp || !Number.isFinite(timestamp)) return [];
+  const iso = new Date(timestamp).toISOString();
+  return [iso.slice(0, 4), iso.slice(0, 7), iso.slice(0, 10)];
+}
+function dateKeysFromText(text: string): string[] {
+  const keys = new Set<string>();
+  for (const match of text.matchAll(/\b(19\d{2}|20\d{2})(?:[-/](0?[1-9]|1[0-2])(?:[-/](0?[1-9]|[12]\d|3[01]))?)?\b/g)) {
+    const [, year, month, day] = match;
+    keys.add(year);
+    if (month) keys.add(`${year}-${month.padStart(2, '0')}`);
+    if (month && day) keys.add(`${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`);
+  }
+  return [...keys];
+}
+function clamp(value: number): number { return Number.isFinite(value) ? Math.max(0, Math.min(1, Number(value.toFixed(6)))) : 0; }
+function missingPointerTable(error: unknown): boolean { return String(error instanceof Error ? error.message : error).includes('oracle_pointer_index'); }

--- a/src/server/logging.ts
+++ b/src/server/logging.ts
@@ -64,7 +64,7 @@ export function logSearch(
     if (results.length > 0) {
       const expectedFields = [
         'id', 'type', 'content', 'source_file', 'concepts', 'source', 'score',
-        'distance', 'model', 'ftsScore', 'vectorScore', 'entity_score',
+        'distance', 'model', 'ftsScore', 'vectorScore', 'pointerScore', 'pointerMatches', 'entity_score',
         'entity_matches', 'entityLinkScore', 'entityLinkMatches', 'confidence', 'provenance',
         'superseded_by', 'superseded_at', 'superseded_reason',
       ];

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -8,10 +8,12 @@ export interface SearchResult {
   content: string;
   source_file: string;
   concepts: string[];
-  source?: 'fts' | 'vector' | 'hybrid';
+  source?: 'fts' | 'vector' | 'pointer' | 'hybrid';
   score?: number;
   distance?: number;
   model?: string;
+  pointerScore?: number;
+  pointerMatches?: string[];
   entity_score?: number;
   entity_matches?: string[];
   entityLinkScore?: number;

--- a/src/tools/search/handler.ts
+++ b/src/tools/search/handler.ts
@@ -1,6 +1,7 @@
 import { detectProject } from '../../server/project-detect.ts';
 import { currentTenantId } from '../../middleware/tenant.ts';
 import { rerankByEntityLinks } from '../../search/entity-ranking.ts';
+import { queryPointerIndex } from '../../search/pointer-index.ts';
 import { rerankCandidates } from '../../server/reranker.ts';
 import type { SearchResult } from '../../server/types.ts';
 import { compactSearchResults, parseSearchRetrievalMode } from '../../search/compact-summary.ts';
@@ -45,6 +46,14 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
     }
   }
 
+  const pointerResults = queryPointerIndex(ctx.sqlite, {
+    query,
+    type,
+    limit: limit * 3,
+    project: resolvedProject,
+    tenantId: currentTenantId(),
+  });
+
   let vecResults: Awaited<ReturnType<typeof vectorSearch>> = [];
   if (effectiveMode !== 'fts') {
     try {
@@ -63,7 +72,7 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
 
   const ftsResults = mapFtsResults(ftsRawResults);
   const normalizedVectorResults = vecResults.map((result) => ({ ...result, score: 1 - (result.score || 0) }));
-  const combinedResults = combineResults(ftsResults, normalizedVectorResults);
+  const combinedResults = combineResults(ftsResults, normalizedVectorResults, 0.5, 0.5, pointerResults);
   const entityRankedResults = rerankByEntityLinks(ctx.sqlite, combinedResults, query, currentTenantId());
   const reranked = await rerankCandidates({
     query,
@@ -105,6 +114,11 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
     vectorMatches: vecResults.length,
     sources: { fts: ftsCount, vector: vectorCount, hybrid: hybridCount },
     searchTime,
+    pointerIndex: {
+      enabled: true,
+      strategy: 'topic_entity_date_pointer_fast_path',
+      hits: pointerResults.length,
+    },
     ...(requestedMode !== 'fts' ? { vectorAvailable: vectorAvailable === true } : {}),
     reranked: reranked.reranked,
     ...(reranked.fallbackReason ? { rerankFallbackReason: reranked.fallbackReason } : {}),

--- a/src/tools/search/helpers.ts
+++ b/src/tools/search/helpers.ts
@@ -1,4 +1,4 @@
-import type { CombinedSearchResult, FtsResult, SearchConfidence, SearchProvenance, VectorResult } from './types.ts';
+import type { CombinedSearchResult, FtsResult, PointerResult, SearchConfidence, SearchProvenance, VectorResult } from './types.ts';
 
 /** Sanitize FTS5 query to prevent parse errors. */
 export function sanitizeFtsQuery(query: string): string {
@@ -38,10 +38,13 @@ export function combineResults(
   vectorResults: VectorResult[],
   ftsWeight = 0.5,
   vectorWeight = 0.5,
+  pointerResults: PointerResult[] = [],
+  pointerWeight = 0.35,
 ): CombinedSearchResult[] {
   const resultMap = new Map<string, Omit<CombinedSearchResult, 'score'> & {
     ftsScore?: number;
     vectorScore?: number;
+    pointerScore?: number;
   }>();
 
   for (const result of ftsResults) {
@@ -53,6 +56,26 @@ export function combineResults(
       concepts: result.concepts,
       ftsScore: result.score,
       source: 'fts',
+    });
+  }
+
+  for (const result of pointerResults) {
+    const existing = resultMap.get(result.id);
+    if (existing) {
+      existing.pointerScore = result.pointerScore;
+      existing.pointerMatches = result.pointerMatches;
+      existing.source = existing.source === 'pointer' ? 'pointer' : 'hybrid';
+      continue;
+    }
+    resultMap.set(result.id, {
+      id: result.id,
+      type: result.type,
+      content: result.content,
+      source_file: result.source_file,
+      concepts: result.concepts,
+      pointerScore: result.pointerScore,
+      pointerMatches: result.pointerMatches,
+      source: 'pointer',
     });
   }
 
@@ -79,11 +102,14 @@ export function combineResults(
   }
 
   const combined = Array.from(resultMap.values()).map((result) => {
-    const score = result.source === 'hybrid'
+    const base = result.source === 'hybrid'
       ? ((ftsWeight * (result.ftsScore ?? 0)) + (vectorWeight * (result.vectorScore ?? 0))) * 1.1
       : result.source === 'fts'
         ? (result.ftsScore ?? 0) * ftsWeight
-        : (result.vectorScore ?? 0) * vectorWeight;
+        : result.source === 'vector'
+          ? (result.vectorScore ?? 0) * vectorWeight
+          : (result.pointerScore ?? 0) * 0.7;
+    const score = Math.min(1, base + ((result.source === 'pointer' ? 0 : pointerWeight) * (result.pointerScore ?? 0)));
     return { ...result, score };
   });
 
@@ -100,11 +126,17 @@ export function confidenceForResult(result: CombinedSearchResult): SearchConfide
   const score = boundedScore(result.score);
   const source = result.source;
   const signals: string[] = [];
-  if (source === 'hybrid') signals.push('matched by FTS and vector search');
+  if (source === 'hybrid') {
+    signals.push(result.ftsScore !== undefined && result.vectorScore !== undefined
+      ? 'matched by FTS and vector search'
+      : 'matched by multiple retrieval indexes');
+  }
   else if (source === 'fts') signals.push('matched by keyword search');
-  else signals.push('matched by vector search');
+  else if (source === 'vector') signals.push('matched by vector search');
+  else signals.push('matched by pointer index');
   if ((result.ftsScore ?? 0) >= 0.7) signals.push('strong keyword score');
   if ((result.vectorScore ?? 0) >= 0.7) signals.push('strong vector score');
+  if ((result.pointerScore ?? 0) > 0) signals.push('matched by topic/entity/date pointer index');
   if ((result.entity_score ?? 0) > 0) signals.push('matched by indexed entity-link ranking signal');
   if ((result.entityLinkScore ?? 0) > 0) signals.push('matched by entity-link ranking signal');
 
@@ -120,6 +152,8 @@ export function provenanceForResult(result: CombinedSearchResult): SearchProvena
     source_file: result.source_file,
     ...(result.ftsScore !== undefined ? { fts_score: Number(result.ftsScore.toFixed(3)) } : {}),
     ...(result.vectorScore !== undefined ? { vector_score: Number(result.vectorScore.toFixed(3)) } : {}),
+    ...(result.pointerScore !== undefined ? { pointer_score: Number(result.pointerScore.toFixed(3)) } : {}),
+    ...(result.pointerMatches?.length ? { pointer_matches: result.pointerMatches } : {}),
     ...(result.distance !== undefined ? { vector_distance: Number(result.distance.toFixed(3)) } : {}),
     ...(result.model ? { vector_model: result.model } : {}),
     ...(result.entity_score !== undefined ? { entity_score: Number(result.entity_score.toFixed(3)) } : {}),

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -29,6 +29,18 @@ export type VectorResult = {
   source: 'vector';
 };
 
+export type PointerResult = {
+  id: string;
+  type: string;
+  content: string;
+  source_file: string;
+  concepts: string[];
+  score: number;
+  source: 'pointer';
+  pointerScore: number;
+  pointerMatches: string[];
+};
+
 export type CombinedSearchResult = {
   id: string;
   type: string;
@@ -36,9 +48,11 @@ export type CombinedSearchResult = {
   source_file: string;
   concepts: string[];
   score: number;
-  source: 'fts' | 'vector' | 'hybrid';
+  source: 'fts' | 'vector' | 'pointer' | 'hybrid';
   ftsScore?: number;
   vectorScore?: number;
+  pointerScore?: number;
+  pointerMatches?: string[];
   distance?: number;
   model?: string;
   entity_score?: number;
@@ -61,10 +75,12 @@ export type SearchConfidence = {
 };
 
 export type SearchProvenance = {
-  source: 'fts' | 'vector' | 'hybrid';
+  source: 'fts' | 'vector' | 'pointer' | 'hybrid';
   source_file: string;
   fts_score?: number;
   vector_score?: number;
+  pointer_score?: number;
+  pointer_matches?: string[];
   vector_distance?: number;
   vector_model?: string;
   entity_score?: number;


### PR DESCRIPTION
Refs #2420

## Summary
- Add compact oracle_pointer_index rows mapping topic/entity/date keys to doc_ids.
- Maintain pointer rows from indexer storage/learn-doc-source and stale-doc deletion.
- Wire oracle_search to query pointer index before vector stores and expose pointer provenance/metadata.

## Verification
- bunx tsc --noEmit
- bun test --isolate src/search/__tests__/pointer-index.test.ts src/tools/__tests__/search.test.ts src/tools/__tests__/search-evidence.test.ts src/db/__tests__/fresh-install.test.ts src/db/__tests__/schema-integrity.test.ts tests/storage/partial-migration-repair.test.ts tests/indexer/reindex-hardening.test.ts src/indexer/__tests__/learn-watcher.test.ts

## Notes
- PR targets alpha.
- All changed files are <=250 lines.
