### PR TITLE
test: harden honest benchmark harness

### DIFF
--- a/benchmarks/honest-recall.ts
+++ b/benchmarks/honest-recall.ts
@@ -3,6 +3,7 @@ import { dirname } from 'node:path';
 
 export type MetricName = 'Recall@k' | 'Answer-Accuracy';
 export type BenchmarkMode = 'hybrid' | 'fts' | 'vector';
+type RecallMetricLabel = `Recall@${number}`;
 
 export type BenchmarkCase = {
   id: string;
@@ -18,8 +19,8 @@ export type Searcher = (request: SearchRequest) => Promise<SearchHit[]>;
 type CorpusRef = { label: string; size: number };
 
 type MetricRow =
-  | { metric: 'Recall@k'; label: string; value: number; hits: number; total_queries: number; top_k: number }
-  | { metric: 'Answer-Accuracy'; status: 'not-measured'; reason: string };
+  | { metric: RecallMetricLabel; metric_family: 'Recall@k'; label: RecallMetricLabel; value: number; hits: number; total_queries: number; top_k: number }
+  | { metric: 'Answer-Accuracy'; metric_family: 'Answer-Accuracy'; status: 'not-measured'; reason: string };
 
 export type HonestRecallReport = {
   schema: 'arra.honest-recall.v1';
@@ -29,7 +30,8 @@ export type HonestRecallReport = {
     model: string;
     top_k: number;
     corpus: CorpusRef;
-    metric: 'Recall@k';
+    metric: RecallMetricLabel;
+    metric_family: 'Recall@k';
     'git-sha': string;
     stack: string[];
   };
@@ -37,7 +39,8 @@ export type HonestRecallReport = {
   cases: Array<{
     id: string;
     query: string;
-    metric: 'Recall@k';
+    metric: RecallMetricLabel;
+    metric_family: 'Recall@k';
     expected_ids: string[];
     retrieved_ids: string[];
     hit: boolean;
@@ -87,8 +90,9 @@ export async function runHonestRecallBenchmark(options: {
   gitSha?: string;
   now?: string;
 }): Promise<HonestRecallReport> {
-  const mode = options.mode ?? 'hybrid';
+  const mode = normalizeMode(options.mode ?? 'hybrid');
   const model = options.model ?? 'multi';
+  const metric = recallMetric(options.topK);
   guardTopK(options.topK, options.corpus.size);
   if (!options.cases.length) throw new Error('benchmark dataset has no cases');
 
@@ -100,7 +104,8 @@ export async function runHonestRecallBenchmark(options: {
     cases.push({
       id: item.id,
       query: item.query,
-      metric: 'Recall@k',
+      metric,
+      metric_family: 'Recall@k',
       expected_ids: item.expectedIds,
       retrieved_ids: hits.map((hit) => hit.id),
       hit: matchedIndex >= 0,
@@ -118,13 +123,14 @@ export async function runHonestRecallBenchmark(options: {
       model,
       top_k: options.topK,
       corpus: options.corpus,
-      metric: 'Recall@k',
+      metric,
+      metric_family: 'Recall@k',
       'git-sha': options.gitSha ?? readGitSha(),
       stack: mode === 'hybrid' && model === 'multi' ? ['bge-m3', 'nomic', 'qwen3', 'FTS5'] : [model, mode],
     },
     metrics: [
-      { metric: 'Recall@k', label: `Recall@${options.topK}`, value: recall, hits, total_queries: cases.length, top_k: options.topK },
-      { metric: 'Answer-Accuracy', status: 'not-measured', reason: 'Retrieval-only harness: no answer generator or judge was run.' },
+      { metric, metric_family: 'Recall@k', label: metric, value: recall, hits, total_queries: cases.length, top_k: options.topK },
+      { metric: 'Answer-Accuracy', metric_family: 'Answer-Accuracy', status: 'not-measured', reason: 'Retrieval-only harness: no answer generator or judge was run.' },
     ],
     cases,
   };
@@ -134,6 +140,16 @@ export async function runHonestRecallBenchmark(options: {
     writeFileSync(options.outFile, `${JSON.stringify(report, null, 2)}\n`);
   }
   return report;
+}
+
+function normalizeMode(value: string): BenchmarkMode {
+  if (value === 'hybrid' || value === 'fts' || value === 'vector') return value;
+  throw new Error('mode must be one of: hybrid, fts, vector');
+}
+
+function recallMetric(topK: number): RecallMetricLabel {
+  guardTopK(topK, Number.MAX_SAFE_INTEGER);
+  return `Recall@${topK}`;
 }
 
 function parseCase(raw: unknown, index: number): BenchmarkCase {
@@ -192,7 +208,7 @@ function parseArgs(args: string[]) {
     corpus: opts.get('corpus') || 'oracle-hybrid-kb',
     corpusSize: Number(opts.get('corpus-size')),
     topK: Number(opts.get('top-k') ?? 10),
-    mode: (opts.get('mode') ?? 'hybrid') as BenchmarkMode,
+    mode: normalizeMode(opts.get('mode') ?? 'hybrid'),
     model: opts.get('model') ?? 'multi',
     baseUrl: opts.get('base-url') ?? 'http://127.0.0.1:47778',
     outFile: opts.get('out') ?? 'benchmarks/out/honest-recall.json',
@@ -206,7 +222,8 @@ function required(opts: Map<string, string>, key: string): string {
 }
 
 function printSummary(report: HonestRecallReport): void {
-  const recall = report.metrics[0] as Extract<MetricRow, { metric: 'Recall@k' }>;
+  const recall = report.metrics.find((row): row is Extract<MetricRow, { metric_family: 'Recall@k' }> => row.metric_family === 'Recall@k');
+  if (!recall) throw new Error('Recall@k metric row missing');
   console.log(`${recall.metric} ${recall.label}: ${recall.value} (${recall.hits}/${recall.total_queries})`);
   console.log('Answer-Accuracy: NOT MEASURED — retrieval-only harness');
   console.log(`provenance_json: ${report.provenance.mode}/${report.provenance.model} top_k=${report.provenance.top_k}`);

--- a/tests/benchmarks/honest-recall.test.ts
+++ b/tests/benchmarks/honest-recall.test.ts
@@ -26,6 +26,7 @@ describe('honest recall benchmark harness', () => {
   test('refuses to report Recall@k when top_k covers the corpus', async () => {
     const outFile = tempFile('refused.json');
     expect(() => guardTopK(4, 4)).toThrow('Refusing to report Recall@4');
+    expect(() => guardTopK(5, 4)).toThrow('top_k (5) must be smaller than corpus_size (4)');
     const searcher: Searcher = async () => { throw new Error('searcher should not run'); };
 
     await expect(runHonestRecallBenchmark({
@@ -58,12 +59,30 @@ describe('honest recall benchmark harness', () => {
       now: '2026-06-17T00:00:00.000Z',
     });
 
-    expect(report.provenance).toMatchObject({ mode: 'hybrid', model: 'multi', top_k: 3, metric: 'Recall@k', 'git-sha': 'abc123' });
+    expect(report.provenance).toMatchObject({ mode: 'hybrid', model: 'multi', top_k: 3, metric: 'Recall@3', metric_family: 'Recall@k', 'git-sha': 'abc123' });
     expect(report.provenance.stack).toEqual(['bge-m3', 'nomic', 'qwen3', 'FTS5']);
-    expect(report.metrics[0]).toMatchObject({ metric: 'Recall@k', label: 'Recall@3', value: 0.5, hits: 1, total_queries: 2 });
-    expect(report.metrics[1]).toMatchObject({ metric: 'Answer-Accuracy', status: 'not-measured' });
-    expect(report.cases.map((item) => item.metric)).toEqual(['Recall@k', 'Recall@k']);
+    expect(report.metrics[0]).toMatchObject({ metric: 'Recall@3', metric_family: 'Recall@k', label: 'Recall@3', value: 0.5, hits: 1, total_queries: 2 });
+    expect(report.metrics[1]).toMatchObject({ metric: 'Answer-Accuracy', metric_family: 'Answer-Accuracy', status: 'not-measured' });
+    expect('value' in report.metrics[1]).toBe(false);
+    expect(report.cases.map((item) => item.metric)).toEqual(['Recall@3', 'Recall@3']);
+    expect(report.cases.map((item) => item.metric_family)).toEqual(['Recall@k', 'Recall@k']);
     expect(JSON.parse(readFileSync(outFile, 'utf8')).provenance.corpus).toEqual({ label: 'oracle-test', size: 10 });
+  });
+
+  test('rejects invalid mode before search or provenance output', async () => {
+    const outFile = tempFile('bad-mode.json');
+    const searcher: Searcher = async () => { throw new Error('searcher should not run'); };
+
+    await expect(runHonestRecallBenchmark({
+      cases: [{ id: 'q1', query: 'alpha', expectedIds: ['doc-a'] }],
+      corpus: { label: 'oracle-test', size: 10 },
+      topK: 3,
+      mode: 'fake' as never,
+      searcher,
+      outFile,
+      gitSha: 'abc123',
+    })).rejects.toThrow('mode must be one of: hybrid, fts, vector');
+    expect(existsSync(outFile)).toBe(false);
   });
 
   test('HTTP searcher calls our hybrid multi-model search surface', async () => {


### PR DESCRIPTION
## Summary
- Harden the honest recall harness so every measured retrieval number is labeled with the exact `Recall@k` value plus `metric_family: Recall@k`.
- Keep Answer-Accuracy explicitly non-numeric/not-measured, preventing accidental mixing with retrieval Recall@k.
- Validate benchmark mode before search/provenance output and extend guard tests for `top_k >= corpus_size` refusal.

## Verification
- `bunx tsc --noEmit`
- `bun test tests/benchmarks/` (5 pass)
- Changed files line count: all <=250 lines
