### PR TITLE
feat(cli): add bunx mine install entry

### DIFF
--- a/bin/arra.ts
+++ b/bin/arra.ts
@@ -8,10 +8,12 @@ function showHelp(): void {
 Usage:
   arra-oracle [serve] [options]
   arra-oracle mcp [--read-only]
+  arra-oracle mine <dir> [--watch]
 
 Commands:
   serve        Run the HTTP server (default)
   mcp          Run the stdio MCP server
+  mine         Ingest a folder into Oracle memory
 
 Serve options:
   --port <n>    Port to listen on (default: 47778, env: ORACLE_PORT)
@@ -19,6 +21,11 @@ Serve options:
 
 Legacy aliases kept working: arra-oracle-v3, arra-oracle-v2.
 Once running, open the UI with: bunx oracle-studio`);
+}
+
+if (command === "mine") {
+  const { mineCommand } = await import("../src/cli/commands/mine.ts");
+  process.exit(await mineCommand(args.slice(1)));
 }
 
 if (args.includes("--help") || args.includes("-h")) {

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -2,6 +2,12 @@
 
 A five-minute path from empty machine to searchable local Oracle memory.
 
+One-line ingest if Bun is already installed:
+
+```bash
+bunx -p arra-oracle-v3 arra-oracle mine docs/sample-notes
+```
+
 ## 1. Install
 
 ```bash
@@ -13,6 +19,13 @@ For latest alpha branch testing instead of a pinned tag:
 
 ```bash
 bun add -g github:Soul-Brews-Studio/arra-oracle-v3#alpha
+```
+
+Verify the global `arra` command is on your `PATH`:
+
+```bash
+command -v arra
+arra --version
 ```
 
 ## 2. Start the server
@@ -32,18 +45,18 @@ arra config use local
 arra health
 ```
 
-## 3. Add one memory
+## 3. Mine the sample notes
 
 ```bash
-arra learn "Arra Oracle quickstart is running from a global Bun install." \
-  --source "quickstart" \
-  --concepts "install,quickstart"
+arra mine docs/sample-notes
+# or keep it live while editing notes:
+# arra mine docs/sample-notes --watch
 ```
 
 ## 4. Search it
 
 ```bash
-arra search "global Bun install" --limit 5
+arra search "memory onboarding" --limit 5
 arra read --help
 arra list --limit 5
 ```

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   ],
   "main": "src/index.ts",
   "bin": {
+    "arra-oracle": "./bin/arra.ts",
     "arra-oracle-v3": "./bin/arra.ts",
     "arra-oracle-v2": "./src/index.ts",
     "arra-cli": "./cli/src/cli.ts",

--- a/tests/cli/bin/arra.test.ts
+++ b/tests/cli/bin/arra.test.ts
@@ -25,6 +25,14 @@ describe('arra bin argument hardening', () => {
 
     expect(result.code).toBe(0);
     expect(result.stdout).toContain('arra-oracle mcp [--read-only]');
+    expect(result.stdout).toContain('arra-oracle mine <dir> [--watch]');
+  });
+
+  test('delegates mine help without starting the server', async () => {
+    const result = await runBin(['mine', '--help']);
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('Usage: arra mine <dir>');
   });
 
   test('rejects unknown mcp options before importing server code', async () => {
@@ -44,5 +52,13 @@ describe('arra bin argument hardening', () => {
     expect(badFlag.stdout).toContain('Serve options:');
     expect(badPort.code).toBe(1);
     expect(badPort.stderr).toContain('--port requires a numeric value');
+  });
+});
+
+describe('published bin aliases', () => {
+  test('exposes arra and arra-oracle commands for global installs', async () => {
+    const pkg = await import('../../../package.json');
+    expect(pkg.default.bin.arra).toBe('./cli/src/cli.ts');
+    expect(pkg.default.bin['arra-oracle']).toBe('./bin/arra.ts');
   });
 });


### PR DESCRIPTION
## Summary
- Added `arra-oracle` as a published bin alias for bunx/global install convenience.
- Delegated `arra-oracle mine <dir>` to the existing friendly mine command without starting the server.
- Updated QUICKSTART with one-line `bunx -p arra-oracle-v3 arra-oracle mine docs/sample-notes` and `arra` PATH verification.

## Tests
```bash
bun test --isolate tests/cli/bin/arra.test.ts
bunx tsc --noEmit
wc -l package.json bin/arra.ts docs/QUICKSTART.md tests/cli/bin/arra.test.ts
```

Refs #2420
