### PR TITLE
feat: add paragraph-aware indexer chunking

### DIFF
--- a/src/indexer/__tests__/chunk-text.test.ts
+++ b/src/indexer/__tests__/chunk-text.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test';
+import { chunkDocumentForIndexing, chunkText, chunk_text } from '../chunk-text.ts';
+import type { OracleDocument } from '../../types.ts';
+
+function doc(content: string): OracleDocument {
+  return {
+    id: 'learning-note',
+    type: 'learning',
+    source_file: 'ψ/memory/learnings/note.md',
+    content,
+    concepts: ['chunking'],
+    created_at: 1,
+    updated_at: 1,
+  };
+}
+
+describe('paragraph-aware chunk_text', () => {
+  test('packs whole paragraphs and records source line spans', () => {
+    const text = [
+      'first paragraph line 1',
+      'first paragraph line 2',
+      '',
+      'second paragraph',
+      '',
+      'third paragraph',
+    ].join('\n');
+
+    const chunks = chunkText(text, 65);
+
+    expect(chunk_text).toBe(chunkText);
+    expect(chunks).toHaveLength(2);
+    expect(chunks.every((chunk) => chunk.content.length <= 65)).toBe(true);
+    expect(chunks[0]).toMatchObject({ chunk_index: 0, line_start: 1, line_end: 4 });
+    expect(chunks[0].content).toContain('second paragraph');
+    expect(chunks[1]).toMatchObject({ chunk_index: 1, line_start: 6, line_end: 6 });
+    expect(chunks[1].content).toBe('third paragraph');
+  });
+
+  test('hard-splits an overlong line while keeping line metadata', () => {
+    const chunks = chunkText('abcdefghij', 4);
+
+    expect(chunks.map((chunk) => chunk.content)).toEqual(['abcd', 'efgh', 'ij']);
+    expect(chunks.map((chunk) => [chunk.line_start, chunk.line_end])).toEqual([[1, 1], [1, 1], [1, 1]]);
+  });
+
+  test('adds deterministic chunk ids only when a document needs multiple chunks', () => {
+    const first = `alpha ${'a'.repeat(30)}`;
+    const second = `beta ${'b'.repeat(30)}`;
+    const third = `gamma ${'c'.repeat(30)}`;
+    const chunks = chunkDocumentForIndexing(doc(`${first}\n\n${second}\n\n${third}`), 80);
+
+    expect(chunks.map((chunk) => chunk.id)).toEqual(['learning-note__chunk_0', 'learning-note__chunk_1']);
+    expect(chunks.map((chunk) => chunk.chunk_index)).toEqual([0, 1]);
+    expect(chunks[0].content).toContain(second);
+    expect(chunks[1]).toMatchObject({ line_start: 5, line_end: 5 });
+  });
+
+  test('preserves a short document id and exact content', () => {
+    const content = 'short\r\ncontent\n';
+    const [chunk] = chunkDocumentForIndexing(doc(content));
+
+    expect(chunk.id).toBe('learning-note');
+    expect(chunk.content).toBe(content);
+    expect(chunk).toMatchObject({ chunk_index: 0, line_start: 1, line_end: 2 });
+  });
+});

--- a/src/indexer/__tests__/storage-chunking.test.ts
+++ b/src/indexer/__tests__/storage-chunking.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createDatabase } from '../../db/index.ts';
+import { storeDocuments } from '../storage.ts';
+import type { OracleDocument } from '../../types.ts';
+import type { VectorDocument, VectorQueryResult, VectorStoreAdapter } from '../../vector/types.ts';
+
+class FakeVectorStore implements VectorStoreAdapter {
+  readonly name = 'fake-vector';
+  docs: VectorDocument[] = [];
+  async connect() {}
+  async close() {}
+  async ensureCollection() {}
+  async deleteCollection() { this.docs = []; }
+  async addDocuments(docs: VectorDocument[]) { this.docs.push(...docs); }
+  async replaceDocuments(docs: VectorDocument[]) { this.docs = docs; }
+  async query(): Promise<VectorQueryResult> { return { ids: [], documents: [], distances: [], metadatas: [] }; }
+  async queryById(): Promise<VectorQueryResult> { return { ids: [], documents: [], distances: [], metadatas: [] }; }
+  async getStats() { return { count: this.docs.length }; }
+  async getCollectionInfo() { return { count: this.docs.length, name: this.name }; }
+}
+
+function doc(content: string): OracleDocument {
+  return {
+    id: 'long-learning',
+    type: 'learning',
+    source_file: 'ψ/memory/learnings/long.md',
+    content,
+    concepts: ['chunking', 'line-map'],
+    created_at: 1,
+    updated_at: 1,
+  };
+}
+
+describe('storeDocuments chunking', () => {
+  test('stores paragraph chunks in SQLite/FTS and vector metadata', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-storage-chunking-'));
+    const dbPath = path.join(tmp, 'oracle.db');
+    const conn = createDatabase(dbPath);
+    const vector = new FakeVectorStore();
+    const para = (label: string, char: string) => `${label} ${char.repeat(330)}`;
+    const content = `${para('alpha', 'a')}\n\n${para('beta', 'b')}\n\n${para('gamma', 'c')}`;
+
+    try {
+      await storeDocuments(conn.sqlite, conn.db, vector, null, [doc(content)], { tenantId: 'default' });
+
+      const rows = conn.sqlite.prepare(`
+        SELECT d.id, f.content FROM oracle_documents d
+        JOIN oracle_fts f ON f.id = d.id
+        WHERE d.source_file = ?
+        ORDER BY d.id
+      `).all('ψ/memory/learnings/long.md') as Array<{ id: string; content: string }>;
+
+      expect(rows.map((row) => row.id)).toEqual(['long-learning__chunk_0', 'long-learning__chunk_1']);
+      expect(rows[0].content).toContain('alpha');
+      expect(rows[0].content).toContain('beta');
+      expect(rows[0].content).not.toContain('gamma');
+      expect(rows[1].content).toContain('gamma');
+      expect(vector.docs.map((item) => item.id)).toEqual(rows.map((row) => row.id));
+      expect(vector.docs.map((item) => item.metadata.chunk_index)).toEqual([0, 1]);
+      expect(vector.docs.map((item) => item.metadata.line_start)).toEqual([1, 5]);
+      expect(vector.docs.map((item) => item.metadata.line_end)).toEqual([3, 5]);
+    } finally {
+      conn.storage.close();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/indexer/chunk-text.ts
+++ b/src/indexer/chunk-text.ts
@@ -1,0 +1,148 @@
+import type { OracleDocument } from '../types.ts';
+
+export const DEFAULT_CHUNK_CHARS = 800;
+
+export interface TextChunk {
+  content: string;
+  chunk_index: number;
+  line_start: number;
+  line_end: number;
+}
+
+interface Segment {
+  content: string;
+  lineStart: number;
+  lineEnd: number;
+}
+
+export function chunkText(text: string, maxChars = DEFAULT_CHUNK_CHARS): TextChunk[] {
+  const normalized = text.replace(/\r\n?/g, '\n');
+  const max = Math.max(1, Math.floor(maxChars));
+  const segments = paragraphSegments(normalized, max);
+  if (segments.length === 0) {
+    return [{ content: normalized, chunk_index: 0, line_start: 1, line_end: lineCount(normalized) }];
+  }
+
+  const chunks: Segment[] = [];
+  let current: Segment | null = null;
+  for (const segment of segments) {
+    if (!current) {
+      current = { ...segment };
+      continue;
+    }
+    const joined: string = `${current.content}\n\n${segment.content}`;
+    if (joined.length <= max) {
+      current = { content: joined, lineStart: current.lineStart, lineEnd: segment.lineEnd };
+      continue;
+    }
+    chunks.push(current);
+    current = { ...segment };
+  }
+  if (current) chunks.push(current);
+
+  return chunks.map((chunk, index) => ({
+    content: chunk.content,
+    chunk_index: index,
+    line_start: chunk.lineStart,
+    line_end: chunk.lineEnd,
+  }));
+}
+
+export const chunk_text = chunkText;
+
+export function chunkDocumentForIndexing(doc: OracleDocument, maxChars = DEFAULT_CHUNK_CHARS): OracleDocument[] {
+  if (doc.chunk_index !== undefined) return [doc];
+  const chunks = chunkText(doc.content, maxChars);
+  if (chunks.length <= 1) {
+    const chunk = chunks[0] ?? { chunk_index: 0, line_start: 1, line_end: lineCount(doc.content) };
+    return [{ ...doc, chunk_index: 0, line_start: chunk.line_start, line_end: chunk.line_end }];
+  }
+  return chunks.map((chunk) => ({
+    ...doc,
+    id: `${doc.id}__chunk_${chunk.chunk_index}`,
+    content: chunk.content,
+    chunk_index: chunk.chunk_index,
+    line_start: chunk.line_start,
+    line_end: chunk.line_end,
+  }));
+}
+
+export function chunkDocumentsForIndexing(docs: OracleDocument[], maxChars = DEFAULT_CHUNK_CHARS): OracleDocument[] {
+  return docs.flatMap((doc) => chunkDocumentForIndexing(doc, maxChars));
+}
+
+function paragraphSegments(text: string, maxChars: number): Segment[] {
+  const lines = text.split('\n');
+  const paragraphs: Segment[] = [];
+  let start = 0;
+  let buffer: string[] = [];
+
+  const flush = (endExclusive: number) => {
+    if (buffer.length === 0) return;
+    paragraphs.push({
+      content: buffer.join('\n'),
+      lineStart: start + 1,
+      lineEnd: endExclusive,
+    });
+    buffer = [];
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() === '') {
+      flush(i);
+      continue;
+    }
+    if (buffer.length === 0) start = i;
+    buffer.push(lines[i]);
+  }
+  flush(lines.length);
+  return paragraphs.flatMap((segment) => splitLongSegment(segment, maxChars));
+}
+
+function splitLongSegment(segment: Segment, maxChars: number): Segment[] {
+  if (segment.content.length <= maxChars) return [segment];
+  const out: Segment[] = [];
+  let content = '';
+  let lineStart = segment.lineStart;
+
+  const flush = (lineEnd: number) => {
+    if (!content) return;
+    out.push({ content, lineStart, lineEnd });
+    content = '';
+  };
+
+  const lines = segment.content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const lineNo = segment.lineStart + i;
+    if (line.length > maxChars) {
+      flush(lineNo - 1);
+      out.push(...splitLongLine(line, lineNo, maxChars));
+      lineStart = lineNo + 1;
+      continue;
+    }
+    const next = content ? `${content}\n${line}` : line;
+    if (content && next.length > maxChars) {
+      flush(lineNo - 1);
+      lineStart = lineNo;
+      content = line;
+    } else {
+      if (!content) lineStart = lineNo;
+      content = next;
+    }
+  }
+  flush(segment.lineEnd);
+  return out;
+}
+
+function splitLongLine(line: string, lineNo: number, maxChars: number): Segment[] {
+  const out: Segment[] = [];
+  for (let i = 0; i < line.length; i += maxChars) {
+    out.push({ content: line.slice(i, i + maxChars), lineStart: lineNo, lineEnd: lineNo });
+  }
+  return out;
+}
+
+function lineCount(text: string): number {
+  return text === '' ? 1 : text.replace(/\r\n?/g, '\n').split('\n').length;
+}

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -34,6 +34,7 @@ import {
   supersedeReplacedSourceDocs,
 } from './reindex-state.ts';
 import { storeDocuments } from './storage.ts';
+import { chunkDocumentsForIndexing } from './chunk-text.ts';
 
 export interface IndexOptions {
   append?: boolean;
@@ -109,6 +110,11 @@ export class OracleIndexer {
       );
     }
 
+    const indexDocuments = chunkDocumentsForIndexing(documents);
+    if (indexDocuments.length !== documents.length) {
+      console.log(`Chunked ${documents.length} source documents into ${indexDocuments.length} index chunks`);
+    }
+
     if (append) {
       console.log('Append mode: skipping smart delete (preserving existing docs from other repo roots)');
     } else {
@@ -152,16 +158,16 @@ export class OracleIndexer {
       }
     }
 
-    const changedIds = changedDocumentIds(beforeDocs, documents);
+    const changedIds = changedDocumentIds(beforeDocs, indexDocuments);
 
     // Store in SQLite + FTS5 first. Vector work is queued afterwards so
     // embedding failures cannot roll back the source-of-truth text index.
-    await storeDocuments(this.sqlite, this.db, null, this.project, documents, { tenantId });
-    const superseded = supersedeReplacedSourceDocs(this.sqlite, documents, tenantId);
-    const vectorJobs = safeEnqueueVectorJobs(this.sqlite, documents, changedIds);
+    await storeDocuments(this.sqlite, this.db, null, this.project, indexDocuments, { tenantId });
+    const superseded = supersedeReplacedSourceDocs(this.sqlite, indexDocuments, tenantId);
+    const vectorJobs = safeEnqueueVectorJobs(this.sqlite, indexDocuments, changedIds);
 
-    setIndexingStatus(this.sqlite, this.config, false, documents.length, documents.length);
-    console.log(`Indexed ${documents.length} documents (SQLite + FTS5)`);
+    setIndexingStatus(this.sqlite, this.config, false, indexDocuments.length, indexDocuments.length);
+    console.log(`Indexed ${indexDocuments.length} chunks (SQLite + FTS5)`);
     if (superseded > 0) console.log(`Superseded ${superseded} stale document ids from reindexed sources`);
     console.log(`Queued ${vectorJobs.queued} vector job(s); skipped ${vectorJobs.skipped}`);
     if (vectorJobs.failed > 0) console.warn(`Failed to queue ${vectorJobs.failed} vector job(s); FTS5 index remains current`);

--- a/src/indexer/learn-doc-source.ts
+++ b/src/indexer/learn-doc-source.ts
@@ -7,6 +7,7 @@ import path from 'path';
 import type Database from 'bun:sqlite';
 import type { OracleDocument } from '../types.ts';
 import { parseLearningFile } from './parser.ts';
+import { chunkDocumentsForIndexing } from './chunk-text.ts';
 
 export const PSI_LEARN_REL = path.join('ψ', 'learn');
 export const MEMORY_LEARN_REL = path.join('ψ', 'memory', 'learnings');
@@ -66,6 +67,7 @@ export const readPsiLearnDocuments = readLearningDocuments;
 
 export function storeSqliteDocuments(db: Database, documents: OracleDocument[]): string[] {
   if (documents.length === 0) return [];
+  const storedDocuments = chunkDocumentsForIndexing(documents);
   const now = Date.now();
   const upsertDoc = db.prepare(`
     INSERT INTO oracle_documents
@@ -87,7 +89,7 @@ export function storeSqliteDocuments(db: Database, documents: OracleDocument[]):
 
   db.exec('BEGIN');
   try {
-    for (const doc of documents) {
+    for (const doc of storedDocuments) {
       upsertDoc.run(
         doc.id,
         doc.type,
@@ -106,5 +108,5 @@ export function storeSqliteDocuments(db: Database, documents: OracleDocument[]):
     db.exec('ROLLBACK');
     throw error;
   }
-  return documents.map((doc) => doc.id);
+  return storedDocuments.map((doc) => doc.id);
 }

--- a/src/indexer/mine.ts
+++ b/src/indexer/mine.ts
@@ -7,6 +7,7 @@ import { oracleDocuments } from '../db/schema.ts';
 import { detectProject } from '../server/project-detect.ts';
 import type { OracleDocument } from '../types.ts';
 import { extractConcepts, mergeConceptsWithTags } from './concepts.ts';
+import { chunkDocumentForIndexing } from './chunk-text.ts';
 import { storeDocuments } from './storage.ts';
 
 const DEFAULT_EXTENSIONS = new Set(['.md', '.mdx', '.txt']);
@@ -57,10 +58,14 @@ export async function mineFolder(options: MineOptions): Promise<MineResult> {
       if (!content) { skipped++; continue; }
       const id = stableMineDocId(root, file);
       const updatedAt = contentVersion(content);
-      const existing = db.select({ updatedAt: oracleDocuments.updatedAt })
-        .from(oracleDocuments).where(eq(oracleDocuments.id, id)).get();
-      if (existing?.updatedAt === updatedAt) { skipped++; continue; }
-      docs.push(toMineDocument(root, file, content, id, updatedAt, project));
+      const nextDocs = chunkDocumentForIndexing(toMineDocument(root, file, content, id, updatedAt, project));
+      const unchanged = nextDocs.every((doc) => {
+        const existing = db.select({ updatedAt: oracleDocuments.updatedAt })
+          .from(oracleDocuments).where(eq(oracleDocuments.id, doc.id)).get();
+        return existing?.updatedAt === updatedAt;
+      });
+      if (unchanged) { skipped++; continue; }
+      docs.push(...nextDocs);
     }
     if (!options.dryRun && docs.length > 0) {
       await storeDocuments(sqlite, db, null, project, docs, { createdBy: 'mine' });

--- a/src/indexer/storage.ts
+++ b/src/indexer/storage.ts
@@ -8,6 +8,7 @@ import * as schema from '../db/schema.ts';
 import { oracleDocuments } from '../db/schema.ts';
 import { tenantIdForWrite } from '../middleware/tenant.ts';
 import { replaceEntityLinks } from '../search/entity-ranking.ts';
+import { chunkDocumentsForIndexing } from './chunk-text.ts';
 import type { VectorStoreAdapter } from '../vector/types.ts';
 import type { OracleDocument } from '../types.ts';
 
@@ -25,6 +26,7 @@ export async function storeDocuments(
 ): Promise<void> {
   const now = Date.now();
   const tenantId = opts.tenantId ?? tenantIdForWrite();
+  const storedDocuments = chunkDocumentsForIndexing(documents);
 
   // Prepare FTS statements. FTS5 virtual tables have no UNIQUE constraint on
   // the id column (it's UNINDEXED), so INSERT OR REPLACE doesn't dedupe —
@@ -45,7 +47,7 @@ export async function storeDocuments(
   // Wrap SQLite inserts in a transaction for performance + atomicity
   sqlite.exec('BEGIN');
   try {
-    for (const doc of documents) {
+    for (const doc of storedDocuments) {
       // SQLite metadata - use doc.project if available, fall back to repo project
       const docProject = (doc.project || project)?.toLowerCase();
 
@@ -103,7 +105,10 @@ export async function storeDocuments(
         type: doc.type,
         tenant_id: tenantId,
         source_file: doc.source_file,
-        concepts: doc.concepts.join(',')
+        concepts: doc.concepts.join(','),
+        ...(doc.chunk_index !== undefined && { chunk_index: doc.chunk_index }),
+        ...(doc.line_start !== undefined && { line_start: doc.line_start }),
+        ...(doc.line_end !== undefined && { line_end: doc.line_end }),
       });
     }
     sqlite.exec('COMMIT');

--- a/src/routes/vector/indexer-source.ts
+++ b/src/routes/vector/indexer-source.ts
@@ -2,6 +2,7 @@ import { Database } from 'bun:sqlite';
 import { DB_PATH } from '../../config.ts';
 import { currentTenantId } from '../../middleware/tenant.ts';
 import { collectDocuments, collectSecurityCorpus } from '../../indexer/collectors.ts';
+import { chunkDocumentsForIndexing } from '../../indexer/chunk-text.ts';
 import { parseDistillationFile, parseLearningFile, parseResonanceFile, parseRetroFile } from '../../indexer/parser.ts';
 import { createIndexerConfig, resolveIndexerRepoRoot } from '../../indexer/runner.ts';
 import type { OracleDocument } from '../../types.ts';
@@ -29,6 +30,9 @@ function toVectorDocs(documents: OracleDocument[]): VectorDocument[] {
       source_file: doc.source_file,
       concepts: JSON.stringify(doc.concepts),
       ...(doc.project && { project: doc.project }),
+      ...(doc.chunk_index !== undefined && { chunk_index: doc.chunk_index }),
+      ...(doc.line_start !== undefined && { line_start: doc.line_start }),
+      ...(doc.line_end !== undefined && { line_end: doc.line_end }),
     },
   }));
 }
@@ -44,7 +48,7 @@ export function loadVaultVectorDocuments(repoRoot = resolveIndexerRepoRoot()): L
     ...collectSecurityCorpus(shared),
   ];
 
-  return { source: 'vault', repoRoot, docs: toVectorDocs(documents) };
+  return { source: 'vault', repoRoot, docs: toVectorDocs(chunkDocumentsForIndexing(documents)) };
 }
 
 export function loadSqliteVectorDocuments(dbPath = DB_PATH): LoadedVectorIndexDocuments {

--- a/src/server/__tests__/vector-indexer-source.test.ts
+++ b/src/server/__tests__/vector-indexer-source.test.ts
@@ -58,6 +58,28 @@ describe('loadVectorIndexDocuments', () => {
     expect(loaded.docs[0].metadata.project).toBe('github.com/Soul-Brews-Studio/arra-oracle-v3');
   });
 
+  test('loads long vault markdown as locatable paragraph chunks', () => {
+    const dir = path.join(vaultRoot, 'ψ', 'memory', 'learnings');
+    const para = (label: string, char: string) => `${label} ${char.repeat(330)}`;
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'long-vector-source.md'), [
+      para('alpha', 'a'),
+      '',
+      para('beta', 'b'),
+      '',
+      para('gamma', 'c'),
+    ].join('\n'));
+
+    const loaded = loadVectorIndexDocuments({ source: 'vault', repoRoot: vaultRoot, dbPath: sqlitePath });
+    const chunks = loaded.docs.filter((doc) => doc.id.includes('long-vector-source__chunk_'));
+
+    expect(chunks.map((doc) => doc.metadata.chunk_index)).toEqual([0, 1]);
+    expect(chunks.map((doc) => doc.metadata.line_start)).toEqual([1, 5]);
+    expect(chunks.map((doc) => doc.metadata.line_end)).toEqual([3, 5]);
+    expect(chunks[0].document).toContain('beta');
+    expect(chunks[1].document).toContain('gamma');
+  });
+
   test('auto mode falls back to SQLite when no vault markdown exists', () => {
     fs.mkdirSync(emptyRoot, { recursive: true });
     writeSqliteDb();

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,9 @@ export interface OracleDocument {
   source_file: string;  // Relative path from repo root
   content: string;      // The actual text to embed
   concepts: string[];   // Tags for filtering: ['trust', 'patterns', 'mirror']
+  chunk_index?: number; // Indexer chunk ordinal within source document
+  line_start?: number;  // 1-based inclusive source line for this chunk
+  line_end?: number;    // 1-based inclusive source line for this chunk
   created_at: number;   // Unix timestamp
   updated_at: number;   // Unix timestamp
   project?: string | null; // Source project (null = universal, undefined = inherit)

--- a/tests/cli/mine/mine.test.ts
+++ b/tests/cli/mine/mine.test.ts
@@ -55,6 +55,30 @@ describe('arra mine folder ingest', () => {
     expect(JSON.parse(row?.concepts ?? '[]')).toContain('ops');
   });
 
+  test('stores long notes as deterministic paragraph chunks', async () => {
+    const root = tmp();
+    const dbPath = path.join(root, 'oracle.db');
+    const notes = path.join(root, 'notes');
+    fs.mkdirSync(path.join(notes, 'ops'), { recursive: true });
+    const notePath = path.join(notes, 'ops', 'long.md');
+    const para = (label: string, char: string) => `${label} ${char.repeat(330)}`;
+    fs.writeFileSync(notePath, [para('alpha', 'a'), '', para('beta', 'b'), '', para('gamma', 'c')].join('\n'));
+
+    const first = await mineFolder({ dir: notes, dbPath });
+    const second = await mineFolder({ dir: notes, dbPath });
+
+    expect(first).toMatchObject({ scanned: 1, stored: 2, skipped: 0 });
+    expect(second).toMatchObject({ scanned: 1, stored: 0, skipped: 1 });
+
+    const id = stableMineDocId(notes, notePath);
+    const { db, storage } = createDatabase(dbPath);
+    const rows = db.select().from(oracleDocuments).orderBy(oracleDocuments.id).all();
+    storage.close();
+
+    expect(rows.map((row) => row.id)).toEqual([`${id}__chunk_0`, `${id}__chunk_1`]);
+    expect(rows.every((row) => row.createdBy === 'mine')).toBe(true);
+  });
+
   test('watch re-ingests changed files after the initial run', async () => {
     const root = tmp();
     const dbPath = path.join(root, 'oracle.db');

--- a/tests/indexer/reindex-hardening.test.ts
+++ b/tests/indexer/reindex-hardening.test.ts
@@ -37,6 +37,43 @@ describe('ψ reindex hardening', () => {
     expect(ftsBySource(h.dbPath, 'ψ/memory/learnings/stable.md')).toContain('changed vector-worthy');
   });
 
+  test('chunks long source docs before storing and queueing vectors', async () => {
+    const h = makeHarness('chunking');
+    const para = (label: string, char: string) => `${label} ${char.repeat(330)}`;
+    writeLearning(h.repoRoot, 'chunked.md', [
+      para('alpha', 'a'),
+      '',
+      para('beta', 'b'),
+      '',
+      para('gamma', 'c'),
+    ].join('\n'));
+
+    await runIndex(h);
+
+    const db = new Database(h.dbPath, { readonly: true });
+    try {
+      const rows = db.query<{ id: string; content: string }, []>(`
+        SELECT d.id, f.content FROM oracle_documents d
+        JOIN oracle_fts f ON f.id = d.id
+        WHERE d.source_file = 'ψ/memory/learnings/chunked.md'
+        ORDER BY d.id
+      `).all();
+      expect(rows.map((row) => row.id)).toEqual([
+        'learning_ψ/memory/learnings/chunked__chunk_0',
+        'learning_ψ/memory/learnings/chunked__chunk_1',
+      ]);
+      expect(rows[0].content).toContain('alpha');
+      expect(rows[0].content).toContain('beta');
+      expect(rows[0].content).not.toContain('gamma');
+      expect(rows[1].content).toContain('gamma');
+
+      const jobIds = db.query<{ doc_id: string }, []>('SELECT doc_id FROM indexing_jobs ORDER BY doc_id').all();
+      expect([...new Set(jobIds.map((row) => row.doc_id))]).toEqual(rows.map((row) => row.id));
+    } finally {
+      db.close();
+    }
+  });
+
   test('supersedes stale document ids when a source reindexes to a new id', async () => {
     const h = makeHarness('supersede');
     writeLearning(h.repoRoot, 'rotate.md', '---\nid: old-rotate\n---\nold body');


### PR DESCRIPTION
## Summary
- Add paragraph-aware ~800-char `chunk_text` helper with chunk_index/line_start/line_end metadata.
- Apply chunking across indexer storage, vector vault source, incremental learn storage, and mine ingest/skip checks.
- Cover chunk helper, SQLite/FTS/vector metadata storage, reindex queueing, vector source chunk metadata, and mine long-note behavior.

Refs #2420

## Validation
- `bunx tsc --noEmit`
- `bun test src/indexer/__tests__/chunk-text.test.ts src/indexer/__tests__/storage-chunking.test.ts src/indexer/__tests__/learn-source-service-hardening.test.ts src/indexer/__tests__/learn-watcher.test.ts src/indexer/__tests__/psi-fts-index.test.ts src/indexer/__tests__/structure-derivation.test.ts src/server/__tests__/vector-indexer-source.test.ts src/server/__tests__/vector-indexer-rebuild.test.ts src/search/__tests__/pointer-index.test.ts tests/indexer/reindex-hardening.test.ts tests/http/indexer/basic.test.ts tests/cli/mine/mine.test.ts`