### PR TITLE
feat(simple): add health state mapper

### DIFF
--- a/frontend/src/components/simple/__tests__/healthState.test.ts
+++ b/frontend/src/components/simple/__tests__/healthState.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  HEALTH_DOWN_RETRY_COUNT,
+  HEALTH_STARTING_ESCAPE_MS,
+  HEALTH_STARTING_GRACE_MS,
+  HEALTH_STATE_COPY,
+  HealthState,
+  mapHealthState,
+} from '../healthState.ts';
+
+describe('simple health state mapper', () => {
+  test('exposes copy for all six states', () => {
+    expect(Object.keys(HEALTH_STATE_COPY).sort()).toEqual([
+      'degraded-db', 'degraded-fts', 'degraded-plugin', 'down', 'healthy', 'starting',
+    ].sort());
+    expect(HEALTH_STATE_COPY[HealthState.Healthy].title).toBe('Awake and remembering');
+    expect(HEALTH_STATE_COPY[HealthState.Down].action).toContain('Docker');
+  });
+
+  test('maps healthy payloads to healthy', () => {
+    expect(mapHealthState({ msSinceLoad: 10_000, health: { status: 'ok', dbStatus: 'connected', pluginStatus: 'ok', vectorStatus: 'ok' } }))
+      .toBe(HealthState.Healthy);
+  });
+
+  test('uses 8s startup grace for missing health and errors', () => {
+    expect(mapHealthState({ msSinceLoad: HEALTH_STARTING_GRACE_MS - 1, error: new Error('boot') }))
+      .toBe(HealthState.Starting);
+  });
+
+  test('escapes startup to down after 30s', () => {
+    expect(mapHealthState({ msSinceLoad: HEALTH_STARTING_ESCAPE_MS, error: new Error('timeout') }))
+      .toBe(HealthState.Down);
+  });
+
+  test('flips down after three failed polls', () => {
+    expect(mapHealthState({ msSinceLoad: 9_000, error: 'offline', failedPolls: HEALTH_DOWN_RETRY_COUNT }))
+      .toBe(HealthState.Down);
+  });
+
+  test('prioritizes database degradation over search and plugin warnings', () => {
+    expect(mapHealthState({ msSinceLoad: 10_000, health: { status: 'degraded', dbStatus: 'down', pluginStatus: 'degraded', vectorStatus: 'down' } }))
+      .toBe(HealthState.DegradedDb);
+  });
+
+  test('maps plugin degradation when storage is healthy', () => {
+    expect(mapHealthState({ msSinceLoad: 10_000, health: { status: 'ok', dbStatus: 'connected', pluginStatus: 'degraded' } }))
+      .toBe(HealthState.DegradedPlugin);
+  });
+
+  test('maps limited search/vector health to degraded fts', () => {
+    expect(mapHealthState({ msSinceLoad: 10_000, health: { status: 'ok', dbStatus: 'connected', pluginStatus: 'ok', vectorAvailable: false } }))
+      .toBe(HealthState.DegradedFts);
+  });
+
+  test('maps explicit down payloads to down', () => {
+    expect(mapHealthState({ msSinceLoad: 10_000, health: { status: 'down' } })).toBe(HealthState.Down);
+  });
+});

--- a/frontend/src/components/simple/healthState.ts
+++ b/frontend/src/components/simple/healthState.ts
@@ -1,0 +1,115 @@
+export enum HealthState {
+  Healthy = 'healthy',
+  Starting = 'starting',
+  DegradedFts = 'degraded-fts',
+  DegradedDb = 'degraded-db',
+  DegradedPlugin = 'degraded-plugin',
+  Down = 'down',
+}
+
+export const HEALTH_STARTING_GRACE_MS = 8_000;
+export const HEALTH_STARTING_ESCAPE_MS = 30_000;
+export const HEALTH_DOWN_RETRY_COUNT = 3;
+
+export interface SimpleHealthPayload {
+  status?: string;
+  db?: string | { status?: string };
+  dbStatus?: string;
+  oracle?: string;
+  vectorStatus?: string;
+  vectorAvailable?: boolean;
+  pluginStatus?: string;
+  plugins?: { status?: string };
+  draining?: boolean;
+}
+
+export interface HealthStateInput {
+  health?: SimpleHealthPayload | null;
+  error?: unknown;
+  msSinceLoad: number;
+  failedPolls?: number;
+}
+
+export interface HealthStateCopy {
+  title: string;
+  detail: string;
+  action: string;
+  tone: 'good' | 'wait' | 'warn' | 'bad';
+}
+
+export const HEALTH_STATE_COPY: Record<HealthState, HealthStateCopy> = {
+  [HealthState.Healthy]: {
+    title: 'Awake and remembering',
+    detail: 'Your Oracle is reachable and ready to search or save memories.',
+    action: 'Ask or add a memory.',
+    tone: 'good',
+  },
+  [HealthState.Starting]: {
+    title: 'Starting up…',
+    detail: 'The server is waking up. This usually clears in a few seconds.',
+    action: 'Wait briefly, then retry if it keeps spinning.',
+    tone: 'wait',
+  },
+  [HealthState.DegradedFts]: {
+    title: 'Running, but search is limited',
+    detail: 'The app is reachable, but the search/vector index is not fully ready.',
+    action: 'You can still save memories; rebuild or retry indexing for better search.',
+    tone: 'warn',
+  },
+  [HealthState.DegradedDb]: {
+    title: 'Running, but memory storage needs help',
+    detail: 'The server responded, but the database is not healthy.',
+    action: 'Check ORACLE_DATA_DIR and database permissions, then retry.',
+    tone: 'bad',
+  },
+  [HealthState.DegradedPlugin]: {
+    title: 'Running, but a plugin needs attention',
+    detail: 'Core memory is available, but one or more plugins reported degraded.',
+    action: 'Open plugin settings or disable the failing plugin.',
+    tone: 'warn',
+  },
+  [HealthState.Down]: {
+    title: "Can't reach your Oracle",
+    detail: 'The browser could not reach the backend health endpoint.',
+    action: 'If using Docker, restart the container. If using Bun, run the server again.',
+    tone: 'bad',
+  },
+};
+
+export function mapHealthState(input: HealthStateInput): HealthState {
+  const ms = Math.max(0, input.msSinceLoad);
+  const failedPolls = Math.max(0, input.failedPolls ?? 0);
+  const health = input.health ?? null;
+
+  if (!health || input.error) {
+    if (ms < HEALTH_STARTING_GRACE_MS) return HealthState.Starting;
+    if (failedPolls >= HEALTH_DOWN_RETRY_COUNT || ms >= HEALTH_STARTING_ESCAPE_MS) return HealthState.Down;
+    return HealthState.Starting;
+  }
+
+  const status = health.status?.toLowerCase();
+  if (health.draining || status === 'starting' || status === 'draining') return HealthState.Starting;
+  if (status === 'down' || status === 'error') return HealthState.Down;
+
+  if (dbIsBad(health)) return HealthState.DegradedDb;
+  if (pluginIsBad(health)) return HealthState.DegradedPlugin;
+  if (searchIsLimited(health)) return HealthState.DegradedFts;
+  if (status === 'degraded') return HealthState.DegradedFts;
+  return HealthState.Healthy;
+}
+
+function dbIsBad(health: SimpleHealthPayload): boolean {
+  const dbStatus = typeof health.db === 'string' ? health.db : health.db?.status;
+  return [health.dbStatus, dbStatus, health.oracle]
+    .some((value) => ['down', 'error', 'disconnected'].includes(String(value ?? '').toLowerCase()));
+}
+
+function pluginIsBad(health: SimpleHealthPayload): boolean {
+  const value = health.pluginStatus ?? health.plugins?.status;
+  return ['degraded', 'down', 'error'].includes(String(value ?? '').toLowerCase());
+}
+
+function searchIsLimited(health: SimpleHealthPayload): boolean {
+  const vector = String(health.vectorStatus ?? '').toLowerCase();
+  return health.vectorAvailable === false || ['down', 'error', 'degraded'].includes(vector);
+}


### PR DESCRIPTION
## Summary
- Added pure Simple Mode `mapHealthState()` mapper with six explicit states.
- Added `HEALTH_STATE_COPY` table for the health hero text/actions.
- Encoded the 8s startup grace, 30s startup escape, and 3-failed-poll down timing gates.

## Tests
```bash
bun test --isolate frontend/src/components/simple/__tests__/healthState.test.ts
bunx tsc --noEmit
wc -l frontend/src/components/simple/healthState.ts frontend/src/components/simple/__tests__/healthState.test.ts
```

Refs #2440
