### PR TITLE
docs: document Simple Mode for non-devs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ bunx tsc --noEmit
 bun run server                 # HTTP API on http://localhost:47778
 ```
 
-Useful checks: `curl -sf http://localhost:47778/api/health` and `bun cli/src/cli.ts health`. React UI: `cd frontend && bun install && bun run dev`. Tauri: `cd frontend && cargo tauri dev`.
+Useful checks: `curl -sf http://localhost:47778/api/health` and `bun cli/src/cli.ts health`. Non-dev UI: open `http://localhost:47778/simple` for Simple Mode. React dev UI: `cd frontend && bun install && bun run dev`. Tauri: `cd frontend && cargo tauri dev`.
 
 ## Major features
 
@@ -74,6 +74,7 @@ Useful checks: `curl -sf http://localhost:47778/api/health` and `bun cli/src/cli
 | Multi-tenant HTTP isolation | Tenant headers and optional tenant tokens scope reads/writes by `tenant_id` for shared HTTP deployments. |
 | Federation | Opt-in `/api/federation/*` mesh capability provider for registered nodes, capability discovery, Workers relay smoke, and signed tunnel workflows. |
 | Studio + canvas UI | React/Tauri Studio plus `canvas.buildwithoracle.com` workers render search, vectors, plugins, MCP tools, and canvas plugins. |
+| Simple Mode | `/simple` is the non-dev first screen: health always visible, search/save obvious, advanced Studio optional. |
 
 ## Architecture overview
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ is linked here; keep new docs in the right section when adding files.
 | [CLI-GUIDE.md](./CLI-GUIDE.md) | Full CLI, MCP, HTTP, scripts, deploy, and env usage guide | `arra`, `arra-oracle-v3`, Claude MCP |
 | [QUICKSTART-10MIN.md](./QUICKSTART-10MIN.md) | Docker-first non-dev path: mine notes, then ask | Docker, `arra mine`, `/api/v1/ask` |
 | [QUICKSTART.md](./QUICKSTART.md) | Complete a five-minute first run | `arra-oracle-v3 serve`, `arra health`, MCP config |
+| [SIMPLE-MODE-SPEC.md](./SIMPLE-MODE-SPEC.md) | Explain the non-dev `/simple` screen and never-silent health states | Simple Mode, health hero, recovery copy |
 | [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) | Diagnose install, MCP, HTTP, vector, plugin, and Docker issues | health checks, auth, tenants, logs |
 | [FAQ.md](./FAQ.md) | Answer common operator and contributor questions | install path, binaries, data, vectors, tenants |
 | [architecture.md](./architecture.md) | Understand the installable runtime architecture | HTTP, MCP, CLI, plugins, storage |

--- a/docs/SIMPLE-MODE-SPEC.md
+++ b/docs/SIMPLE-MODE-SPEC.md
@@ -1,0 +1,62 @@
+# Simple Mode spec for non-developers
+
+Simple Mode is the friendly first screen at `/simple`. It is additive: Advanced
+Studio keeps its existing routes, but non-dev users can start here to see whether
+Arra is working, search memory, save a memory, and learn what to do next.
+
+Refs #2440.
+
+## Non-dev promise
+
+A person who does not know the codebase should be able to open:
+
+```text
+http://localhost:47778/simple
+```
+
+…and immediately answer three questions:
+
+1. Is my Oracle reachable?
+2. Can I search or save memories right now?
+3. If not, what exact Docker or Bun command should I try next?
+
+The page must never fail silently. Health is the gate and stays visible while the
+user searches, saves, or reads recovery copy.
+
+## Simple Mode layout
+
+- **Health hero** at the top, backed by `GET /api/health` and a 10s poll.
+- **Search card** with one visible query box, a button, debounce, and plain empty
+  result copy.
+- **Add-memory card** that posts to `/api/v1/learn` and announces success with
+  `aria-live`.
+- **Index-folder accordion** with local/Tauri gates and copy for `arra mine`.
+- **Advanced Studio link** for users who want vectors, plugins, MCP tools, or
+  route details.
+
+## Health states and copy
+
+| State | User-facing title | Meaning | Recovery guidance |
+| --- | --- | --- | --- |
+| Healthy | Awake and remembering | Backend, memory store, search, and plugins are ready enough to use. | Ask a question or add a memory. |
+| Starting | Starting up… | Health is not ready yet, or the app is inside startup grace. | Wait briefly; after ~30s show retry/start commands. |
+| Degraded FTS | Running, but search is limited | App is reachable, but vectors/search are not fully ready. | Save memories still works; rebuild or retry indexing for better search. |
+| Degraded DB | Running, but memory storage needs help | Backend answered, but SQLite/data dir is not healthy. | Check `ORACLE_DATA_DIR`, permissions, and disk path. |
+| Degraded plugin | Running, but a plugin needs attention | Core memory is up, but a plugin reports degraded/down. | Disable or fix the plugin; keep core search visible. |
+| Down | Can't reach your Oracle | Polling `/api/health` failed or timed out after retries. | Show Docker and Bun start commands plus a Retry button. |
+
+## Health state rules
+
+- Poll `GET /api/health` every 10 seconds.
+- Show `checked Xs ago` so a stale poll becomes obvious.
+- Treat startup as temporary for the first few seconds.
+- Escape startup after about 30 seconds into Down with recovery commands.
+- Flip to Down after repeated failed polls instead of leaving stale green copy.
+- Use degraded states when the backend answers but DB, plugins, or search/vector
+  capability is limited.
+
+## README and recap entry points
+
+- README should point non-dev users to `/simple` immediately after server start.
+- `oracle_recap` should mention `/simple` so session wake-up output gives humans
+  a visual health/search/save path, not only MCP tool names.

--- a/src/tools/__tests__/recap.test.ts
+++ b/src/tools/__tests__/recap.test.ts
@@ -73,6 +73,7 @@ test('oracle_recap emits identity and top memories grouped by project', async ()
   expect(text).toContain('## beta');
   expect(text.indexOf('alpha-hot')).toBeLessThan(text.indexOf('alpha-cold'));
   expect(text).toContain('heat');
+  expect(text).toContain('http://localhost:47778/simple');
   expect(tokens(text)).toBeLessThanOrEqual(300);
 });
 
@@ -82,5 +83,6 @@ test('oracle_recap handles an empty knowledge base cheaply', async () => {
 
   expect(text).toContain('No memories indexed yet');
   expect(text).toContain('oracle_learn');
+  expect(text).toContain('/simple');
   expect(tokens(text)).toBeLessThanOrEqual(220);
 });

--- a/src/tools/recap.ts
+++ b/src/tools/recap.ts
@@ -98,7 +98,7 @@ function renderRecap(
   const lines = [
     '# Oracle wake-up context',
     `Identity: ${MCP_SERVER_NAME} v${ctx.version}; vector=${ctx.vectorStatus}; tenant=${tenantId ?? 'default'}; docs=${total}.`,
-    'Role: MCP memory/search layer. Start with oracle_search for recall, oracle_read for exact source, oracle_learn for new durable facts.',
+    'Role: MCP memory/search layer. Non-devs open http://localhost:47778/simple; agents use oracle_search, oracle_read, oracle_learn.',
     `Budget: approx ${tokenPlaceholder} / ${maxTokens} tokens; ranked by heat + confidence.`,
   ];
   if (rows.length === 0) lines.push('', 'No memories indexed yet. Ingest with `arra mine <dir>` or add facts with `oracle_learn`.');

--- a/tests/docs/simple-mode-docs.test.ts
+++ b/tests/docs/simple-mode-docs.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const readme = readFileSync('README.md', 'utf8');
+const docsIndex = readFileSync('docs/README.md', 'utf8');
+const simpleSpec = readFileSync('docs/SIMPLE-MODE-SPEC.md', 'utf8');
+const recap = readFileSync('src/tools/recap.ts', 'utf8');
+
+describe('Simple Mode docs for non-dev users', () => {
+  test('README and wake-up recap point users to /simple', () => {
+    expect(readme).toContain('http://localhost:47778/simple');
+    expect(readme).toContain('Simple Mode');
+    expect(recap).toContain('http://localhost:47778/simple');
+  });
+
+  test('docs index links the Simple Mode spec', () => {
+    expect(docsIndex).toContain('[SIMPLE-MODE-SPEC.md](./SIMPLE-MODE-SPEC.md)');
+  });
+
+  test('Simple Mode spec names the six never-silent health states', () => {
+    for (const label of [
+      'Awake and remembering',
+      'Starting up…',
+      'Running, but search is limited',
+      'Running, but memory storage needs help',
+      'Running, but a plugin needs attention',
+      "Can't reach your Oracle",
+    ]) expect(simpleSpec).toContain(label);
+    expect(simpleSpec).toContain('Poll `GET /api/health` every 10 seconds');
+    expect(simpleSpec).toContain('Refs #2440');
+  });
+});


### PR DESCRIPTION
## Summary
- Point README non-dev startup guidance and feature table to `/simple` Simple Mode.
- Add `docs/SIMPLE-MODE-SPEC.md` with the non-dev promise, Simple Mode layout, and never-silent health states.
- Update `oracle_recap` wake-up context to point humans at `/simple`, with tests covering README/docs/recap references.

Refs #2440

## Verification
- `bunx tsc --noEmit`
- `bun test tests/docs/simple-mode-docs.test.ts src/tools/__tests__/recap.test.ts` (5 pass)
- Changed files line count: all <=250 lines
