### PR TITLE
feat: add simple mode health hero

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { apiClient, type ApiClient } from './api/client';
 import { AppShell } from './components/AppShell';
 import { countPluginSurfaces } from './plugin-surfaces';
-import { AppRouter, DashboardRoutes, isRouteLoading } from './router';
+import { AppRouter, DashboardRoutes, SimpleRoutes, isRouteLoading } from './router';
 import type { LoadState, MenuItem, PluginEntry } from './types';
 import type { MetricsSnapshot } from '../../src/server/types';
 
@@ -49,7 +49,7 @@ export async function loadDashboardData(client: DashboardClient = apiClient): Pr
   };
 }
 
-export default function App() {
+function DashboardApp() {
   const [states, setStates] = useState<LoadStates>(idleStates);
   const [menu, setMenu] = useState<MenuItem[]>([]);
   const [plugins, setPlugins] = useState<PluginEntry[]>([]);
@@ -98,28 +98,38 @@ export default function App() {
   const refresh = () => void load();
 
   return (
-    <AppRouter>
-      <AppShell
-        error={error}
-        loading={loading}
-        menuCount={menu.length}
-        pluginCount={plugins.length}
-        surfaceCount={surfaceCount}
+    <AppShell
+      error={error}
+      loading={loading}
+      menuCount={menu.length}
+      pluginCount={plugins.length}
+      surfaceCount={surfaceCount}
+      metrics={metrics}
+      metricsLoading={metricsLoading}
+      updatedAt={updatedAt}
+      onRefresh={refresh}
+    >
+      <DashboardRoutes
+        menu={menu}
+        plugins={plugins}
+        states={states}
         metrics={metrics}
-        metricsLoading={metricsLoading}
+        surfaceCount={surfaceCount}
         updatedAt={updatedAt}
         onRefresh={refresh}
-      >
-        <DashboardRoutes
-          menu={menu}
-          plugins={plugins}
-          states={states}
-          metrics={metrics}
-          surfaceCount={surfaceCount}
-          updatedAt={updatedAt}
-          onRefresh={refresh}
-        />
-      </AppShell>
+      />
+    </AppShell>
+  );
+}
+
+function isSimpleRoute(): boolean {
+  return typeof window !== 'undefined' && window.location.pathname === '/simple';
+}
+
+export default function App() {
+  return (
+    <AppRouter>
+      {isSimpleRoute() ? <SimpleRoutes /> : <DashboardApp />}
     </AppRouter>
   );
 }

--- a/frontend/src/components/HealthHero.tsx
+++ b/frontend/src/components/HealthHero.tsx
@@ -1,60 +1,11 @@
-export const healthStates = ['checking', 'ok', 'degraded', 'down', 'draining', 'unknown'] as const;
-export type HealthState = typeof healthStates[number];
+import { HEALTH_STATE_COPY, HealthState } from './simple/healthState';
 
-type HeroTone = {
-  dot: string;
-  headline: string;
-  detail: string;
-  cta: string;
+const toneDots: Record<(typeof HEALTH_STATE_COPY)[HealthState]['tone'], string> = {
+  good: 'bg-emerald-400',
+  wait: 'bg-blue-400',
+  warn: 'bg-amber-400',
+  bad: 'bg-red-500',
 };
-
-const tones: Record<HealthState, HeroTone> = {
-  checking: {
-    dot: 'bg-blue-400',
-    headline: 'Checking Oracle health',
-    detail: 'Simple mode is contacting the backend health endpoint.',
-    cta: 'Refresh now',
-  },
-  ok: {
-    dot: 'bg-emerald-400',
-    headline: 'Oracle is ready',
-    detail: 'Core services are responding and simple mode can continue.',
-    cta: 'Open dashboard',
-  },
-  degraded: {
-    dot: 'bg-amber-400',
-    headline: 'Oracle is degraded',
-    detail: 'The backend is reachable, but at least one dependency needs attention.',
-    cta: 'Review status',
-  },
-  down: {
-    dot: 'bg-red-500',
-    headline: 'Oracle is offline',
-    detail: 'Simple mode cannot reach the backend health endpoint yet.',
-    cta: 'Try again',
-  },
-  draining: {
-    dot: 'bg-purple-400',
-    headline: 'Oracle is draining',
-    detail: 'The backend is shutting down or refusing new work temporarily.',
-    cta: 'Check again',
-  },
-  unknown: {
-    dot: 'bg-slate-400',
-    headline: 'Oracle health is unknown',
-    detail: 'The latest response did not map cleanly to a known state.',
-    cta: 'Retry health check',
-  },
-};
-
-export function healthState(value: unknown): HealthState {
-  if (value === 'ok') return 'ok';
-  if (value === 'degraded') return 'degraded';
-  if (value === 'down') return 'down';
-  if (value === 'draining') return 'draining';
-  if (value === 'checking') return 'checking';
-  return 'unknown';
-}
 
 export function checkedAgo(checkedAt: number | null, now = Date.now()): string {
   if (!checkedAt) return 'not checked yet';
@@ -71,7 +22,7 @@ export function HealthHero({
   checkedAt: number | null;
   onAction: () => void;
 }) {
-  const tone = tones[state];
+  const copy = HEALTH_STATE_COPY[state];
   return (
     <section
       aria-live="polite"
@@ -79,18 +30,18 @@ export function HealthHero({
       role="status"
     >
       <div className="flex items-center gap-3 text-sm font-semibold uppercase tracking-[0.25em] text-text-muted">
-        <span aria-hidden="true" className={`h-3 w-3 rounded-full ${tone.dot}`} />
+        <span aria-hidden="true" className={`h-3 w-3 rounded-full ${toneDots[copy.tone]}`} />
         Simple mode
       </div>
-      <h1 className="mt-4 text-4xl font-bold text-text">{tone.headline}</h1>
-      <p className="mt-3 max-w-2xl text-base text-text-muted">{tone.detail}</p>
+      <h1 className="mt-4 text-4xl font-bold text-text">{copy.title}</h1>
+      <p className="mt-3 max-w-2xl text-base text-text-muted">{copy.detail}</p>
       <div className="mt-6 flex flex-wrap items-center gap-4">
         <button
           className="focus-ring rounded-full bg-accent-solid px-5 py-3 text-sm font-semibold text-on-accent hover:bg-accent-solid"
           type="button"
           onClick={onAction}
         >
-          {tone.cta}
+          {copy.action}
         </button>
         <span className="text-sm text-text-muted">{checkedAgo(checkedAt)}</span>
       </div>

--- a/frontend/src/components/HealthHero.tsx
+++ b/frontend/src/components/HealthHero.tsx
@@ -1,0 +1,99 @@
+export const healthStates = ['checking', 'ok', 'degraded', 'down', 'draining', 'unknown'] as const;
+export type HealthState = typeof healthStates[number];
+
+type HeroTone = {
+  dot: string;
+  headline: string;
+  detail: string;
+  cta: string;
+};
+
+const tones: Record<HealthState, HeroTone> = {
+  checking: {
+    dot: 'bg-blue-400',
+    headline: 'Checking Oracle health',
+    detail: 'Simple mode is contacting the backend health endpoint.',
+    cta: 'Refresh now',
+  },
+  ok: {
+    dot: 'bg-emerald-400',
+    headline: 'Oracle is ready',
+    detail: 'Core services are responding and simple mode can continue.',
+    cta: 'Open dashboard',
+  },
+  degraded: {
+    dot: 'bg-amber-400',
+    headline: 'Oracle is degraded',
+    detail: 'The backend is reachable, but at least one dependency needs attention.',
+    cta: 'Review status',
+  },
+  down: {
+    dot: 'bg-red-500',
+    headline: 'Oracle is offline',
+    detail: 'Simple mode cannot reach the backend health endpoint yet.',
+    cta: 'Try again',
+  },
+  draining: {
+    dot: 'bg-purple-400',
+    headline: 'Oracle is draining',
+    detail: 'The backend is shutting down or refusing new work temporarily.',
+    cta: 'Check again',
+  },
+  unknown: {
+    dot: 'bg-slate-400',
+    headline: 'Oracle health is unknown',
+    detail: 'The latest response did not map cleanly to a known state.',
+    cta: 'Retry health check',
+  },
+};
+
+export function healthState(value: unknown): HealthState {
+  if (value === 'ok') return 'ok';
+  if (value === 'degraded') return 'degraded';
+  if (value === 'down') return 'down';
+  if (value === 'draining') return 'draining';
+  if (value === 'checking') return 'checking';
+  return 'unknown';
+}
+
+export function checkedAgo(checkedAt: number | null, now = Date.now()): string {
+  if (!checkedAt) return 'not checked yet';
+  const seconds = Math.max(0, Math.floor((now - checkedAt) / 1000));
+  return `checked ${seconds}s ago`;
+}
+
+export function HealthHero({
+  state,
+  checkedAt,
+  onAction,
+}: {
+  state: HealthState;
+  checkedAt: number | null;
+  onAction: () => void;
+}) {
+  const tone = tones[state];
+  return (
+    <section
+      aria-live="polite"
+      className="rounded-3xl border border-border bg-surface p-8 shadow-2xl"
+      role="status"
+    >
+      <div className="flex items-center gap-3 text-sm font-semibold uppercase tracking-[0.25em] text-text-muted">
+        <span aria-hidden="true" className={`h-3 w-3 rounded-full ${tone.dot}`} />
+        Simple mode
+      </div>
+      <h1 className="mt-4 text-4xl font-bold text-text">{tone.headline}</h1>
+      <p className="mt-3 max-w-2xl text-base text-text-muted">{tone.detail}</p>
+      <div className="mt-6 flex flex-wrap items-center gap-4">
+        <button
+          className="focus-ring rounded-full bg-accent-solid px-5 py-3 text-sm font-semibold text-on-accent hover:bg-accent-solid"
+          type="button"
+          onClick={onAction}
+        >
+          {tone.cta}
+        </button>
+        <span className="text-sm text-text-muted">{checkedAgo(checkedAt)}</span>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -9,10 +9,12 @@ import { loadTheme } from './theme';
 loadTheme();
 registerServiceWorker();
 
+function isSimpleRoute(): boolean {
+  return window.location.pathname === '/simple';
+}
+
+const app = isSimpleRoute() ? <App /> : <BackendGate><App /></BackendGate>;
+
 createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <BackendGate>
-      <App />
-    </BackendGate>
-  </StrictMode>,
+  <StrictMode>{app}</StrictMode>,
 );

--- a/frontend/src/pages/SimplePage.tsx
+++ b/frontend/src/pages/SimplePage.tsx
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useState } from 'react';
+import { apiFetch } from '../api/oracle';
+import { HealthHero, healthState, type HealthState } from '../components/HealthHero';
+import type { HealthResponse } from '../../../src/server/types';
+
+async function fetchHealth(): Promise<HealthState> {
+  const response = await apiFetch('/api/health', { headers: { accept: 'application/json' } });
+  if (!response.ok) return 'down';
+  const body = await response.json() as Partial<HealthResponse>;
+  return body.draining ? 'draining' : healthState(body.status);
+}
+
+export function SimplePage() {
+  const [state, setState] = useState<HealthState>('checking');
+  const [checkedAt, setCheckedAt] = useState<number | null>(null);
+
+  const poll = useCallback(async () => {
+    setState((current) => current === 'ok' ? current : 'checking');
+    try {
+      setState(await fetchHealth());
+    } catch {
+      setState('down');
+    } finally {
+      setCheckedAt(Date.now());
+    }
+  }, []);
+
+  useEffect(() => {
+    void poll();
+    const timer = window.setInterval(() => void poll(), 10_000);
+    return () => window.clearInterval(timer);
+  }, [poll]);
+
+  return (
+    <main className="min-h-screen bg-field p-6 text-text">
+      <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-5xl items-center">
+        <HealthHero state={state} checkedAt={checkedAt} onAction={poll} />
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/pages/SimplePage.tsx
+++ b/frontend/src/pages/SimplePage.tsx
@@ -1,25 +1,28 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { apiFetch } from '../api/oracle';
-import { HealthHero, healthState, type HealthState } from '../components/HealthHero';
-import type { HealthResponse } from '../../../src/server/types';
+import { HealthHero } from '../components/HealthHero';
+import { HealthState, mapHealthState, type SimpleHealthPayload } from '../components/simple/healthState';
 
-async function fetchHealth(): Promise<HealthState> {
+async function fetchHealth(): Promise<SimpleHealthPayload> {
   const response = await apiFetch('/api/health', { headers: { accept: 'application/json' } });
-  if (!response.ok) return 'down';
-  const body = await response.json() as Partial<HealthResponse>;
-  return body.draining ? 'draining' : healthState(body.status);
+  if (!response.ok) throw new Error(`/api/health returned ${response.status}`);
+  return await response.json() as SimpleHealthPayload;
 }
 
 export function SimplePage() {
-  const [state, setState] = useState<HealthState>('checking');
+  const loadedAt = useRef(Date.now());
+  const failedPolls = useRef(0);
+  const [state, setState] = useState<HealthState>(HealthState.Starting);
   const [checkedAt, setCheckedAt] = useState<number | null>(null);
 
   const poll = useCallback(async () => {
-    setState((current) => current === 'ok' ? current : 'checking');
     try {
-      setState(await fetchHealth());
-    } catch {
-      setState('down');
+      const health = await fetchHealth();
+      failedPolls.current = 0;
+      setState(mapHealthState({ health, msSinceLoad: Date.now() - loadedAt.current }));
+    } catch (error) {
+      failedPolls.current += 1;
+      setState(mapHealthState({ error, failedPolls: failedPolls.current, msSinceLoad: Date.now() - loadedAt.current }));
     } finally {
       setCheckedAt(Date.now());
     }

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -14,6 +14,7 @@ import { CanvasPluginsPage } from './pages/CanvasPluginsPage';
 import { SearchPage } from './pages/SearchPage';
 import { SettingsPage } from './pages/SettingsPage';
 import { StatusPage } from './pages/StatusPage';
+import { SimplePage } from './pages/SimplePage';
 import { StoragePage } from './pages/StoragePage';
 import { VectorPage } from './pages/VectorPage';
 import { VectorSearchPage } from './pages/VectorSearchPage';
@@ -49,6 +50,7 @@ export const frontendRoutes = [
   '/mcp',
   '/storage',
   '/settings',
+  '/simple',
 ] as const;
 export type FrontendRoute = typeof frontendRoutes[number];
 
@@ -73,6 +75,15 @@ export function AppRouter({ children }: { children: ReactNode }) {
     <ErrorBoundary>
       <BrowserRouter>{children}</BrowserRouter>
     </ErrorBoundary>
+  );
+}
+
+export function SimpleRoutes() {
+  return (
+    <Routes>
+      <Route path="/simple" element={<SimplePage />} />
+      <Route path="*" element={<Navigate to="/simple" replace />} />
+    </Routes>
   );
 }
 

--- a/tests/frontend/components/health-hero.test.tsx
+++ b/tests/frontend/components/health-hero.test.tsx
@@ -1,27 +1,25 @@
 import { describe, expect, test } from 'bun:test';
-import { HealthHero, checkedAgo, healthState, healthStates } from '../../../frontend/src/components/HealthHero';
+import { HealthHero, checkedAgo } from '../../../frontend/src/components/HealthHero';
+import { HEALTH_STATE_COPY, HealthState } from '../../../frontend/src/components/simple/healthState';
 import { htmlFor } from '../_render';
 
 describe('HealthHero', () => {
   test('renders all health states with status semantics', () => {
-    const html = healthStates.map((state) => htmlFor(
+    const html = Object.values(HealthState).map((state) => htmlFor(
       <HealthHero state={state} checkedAt={1_000} onAction={() => {}} />,
     )).join('\n');
 
     expect(html).toContain('role="status"');
     expect(html).toContain('aria-live="polite"');
-    expect(html).toContain('Oracle is ready');
-    expect(html).toContain('Oracle is degraded');
-    expect(html).toContain('Oracle is offline');
-    expect(html).toContain('Oracle is draining');
-    expect(html).toContain('Oracle health is unknown');
-    expect(html).toContain('Checking Oracle health');
+    for (const state of Object.values(HealthState)) {
+      const copy = HEALTH_STATE_COPY[state];
+      expect(html).toContain(copy.title.replace("Can't", 'Can&#x27;t'));
+      expect(html).toContain(copy.action);
+    }
   });
 
-  test('maps raw health status and renders checked age', () => {
-    expect(healthState('ok')).toBe('ok');
-    expect(healthState('degraded')).toBe('degraded');
-    expect(healthState('surprising')).toBe('unknown');
+  test('renders checked age', () => {
     expect(checkedAgo(1_000, 12_400)).toBe('checked 11s ago');
+    expect(checkedAgo(null)).toBe('not checked yet');
   });
 });

--- a/tests/frontend/components/health-hero.test.tsx
+++ b/tests/frontend/components/health-hero.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test';
+import { HealthHero, checkedAgo, healthState, healthStates } from '../../../frontend/src/components/HealthHero';
+import { htmlFor } from '../_render';
+
+describe('HealthHero', () => {
+  test('renders all health states with status semantics', () => {
+    const html = healthStates.map((state) => htmlFor(
+      <HealthHero state={state} checkedAt={1_000} onAction={() => {}} />,
+    )).join('\n');
+
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-live="polite"');
+    expect(html).toContain('Oracle is ready');
+    expect(html).toContain('Oracle is degraded');
+    expect(html).toContain('Oracle is offline');
+    expect(html).toContain('Oracle is draining');
+    expect(html).toContain('Oracle health is unknown');
+    expect(html).toContain('Checking Oracle health');
+  });
+
+  test('maps raw health status and renders checked age', () => {
+    expect(healthState('ok')).toBe('ok');
+    expect(healthState('degraded')).toBe('degraded');
+    expect(healthState('surprising')).toBe('unknown');
+    expect(checkedAgo(1_000, 12_400)).toBe('checked 11s ago');
+  });
+});

--- a/tests/frontend/pages/simple-page.test.tsx
+++ b/tests/frontend/pages/simple-page.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test';
+import App from '../../../frontend/src/App';
+import { htmlFor, installBrowserLocation } from '../_render';
+
+describe('Simple page', () => {
+  test('renders simple mode without the dashboard shell', () => {
+    const restore = installBrowserLocation('/simple');
+    try {
+      const html = htmlFor(<App />);
+      expect(html).toContain('Simple mode');
+      expect(html).toContain('Checking Oracle health');
+      expect(html).not.toContain('Control Surface');
+      expect(html).not.toContain('Backend unavailable');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/tests/frontend/pages/simple-page.test.tsx
+++ b/tests/frontend/pages/simple-page.test.tsx
@@ -8,7 +8,7 @@ describe('Simple page', () => {
     try {
       const html = htmlFor(<App />);
       expect(html).toContain('Simple mode');
-      expect(html).toContain('Checking Oracle health');
+      expect(html).toContain('Starting up…');
       expect(html).not.toContain('Control Surface');
       expect(html).not.toContain('Backend unavailable');
     } finally {


### PR DESCRIPTION
## Summary
- Add HealthHero for the six simple health states from the health mapper enum, with role=status, aria-live, state dot, headline, CTA, and checked-age copy
- Add SimplePage with 10s /api/health polling and route /simple
- Split app entry so direct /simple bypasses AppShell and BackendGate while normal app routes keep the existing gate

Refs #2440

## Validation
- bunx tsc --noEmit
- bun test tests/frontend/components/health-hero.test.tsx tests/frontend/pages/simple-page.test.tsx tests/frontend/app/app-renders-shell.test.tsx frontend/src/components/simple/__tests__/healthState.test.ts