### PR TITLE
fix(frontend): exclude tests from build tsconfig

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -32,5 +32,10 @@
   "include": [
     "src",
     "vite.config.ts"
+  ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**"
   ]
 }


### PR DESCRIPTION
## Summary
- Excluded frontend test files from `frontend/tsconfig.json` so `tsc --noEmit && vite build` ignores Bun-only tests.
- Keeps `healthState.test.ts` runnable via `bun test` while restoring Studio deploy builds.

## Tests
```bash
cd frontend && bun run build
bun test --isolate frontend/src/components/simple/__tests__/healthState.test.ts
wc -l frontend/tsconfig.json
```

Refs #2440
