### PR TITLE
feat: add Simple Mode memory card

### DIFF
--- a/frontend/src/components/simple/AddMemory.tsx
+++ b/frontend/src/components/simple/AddMemory.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useId, useRef, useState, type FormEvent } from 'react';
+import { apiFetch } from '../../api/oracle';
+import type { LearnCreateResponse } from '../../types';
+
+export const SIMPLE_MODE_SOURCE = 'Simple Mode';
+export const ADD_MEMORY_ENDPOINT = '/api/v1/learn';
+export const SAVE_CONFIRMATION_MS = 3_000;
+const FADE_MS = 300;
+
+export type SimpleMemoryPayload = {
+  pattern: string;
+  source: typeof SIMPLE_MODE_SOURCE;
+};
+
+export type SaveMemory = (payload: SimpleMemoryPayload) => Promise<unknown>;
+export type AddMemoryStatus = 'idle' | 'saving' | 'saved' | 'error';
+
+export function simpleMemoryPayload(pattern: string): SimpleMemoryPayload {
+  return { pattern: pattern.trim(), source: SIMPLE_MODE_SOURCE };
+}
+
+function responseMessage(payload: unknown, fallback: string): string {
+  if (typeof payload === 'object' && payload !== null && 'error' in payload) return String(payload.error);
+  if (typeof payload === 'object' && payload !== null && 'message' in payload) return String(payload.message);
+  return fallback;
+}
+
+export async function postSimpleMemory(payload: SimpleMemoryPayload): Promise<LearnCreateResponse> {
+  const response = await apiFetch(ADD_MEMORY_ENDPOINT, {
+    method: 'POST',
+    headers: { accept: 'application/json', 'content-type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  const text = await response.text();
+  const body = text ? JSON.parse(text) as unknown : {};
+  if (!response.ok) {
+    throw new Error(`${ADD_MEMORY_ENDPOINT} returned ${response.status}: ${responseMessage(body, response.statusText)}`);
+  }
+  return body as LearnCreateResponse;
+}
+
+export async function saveSimpleMemory(pattern: string, saveMemory: SaveMemory = postSimpleMemory): Promise<SimpleMemoryPayload> {
+  const payload = simpleMemoryPayload(pattern);
+  if (!payload.pattern) throw new Error('Memory text is required.');
+  await saveMemory(payload);
+  return payload;
+}
+
+export function AddMemoryFeedback({
+  status,
+  error,
+  fading,
+  saving,
+  onRetry,
+}: {
+  status: AddMemoryStatus;
+  error: string;
+  fading: boolean;
+  saving: boolean;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="grid gap-3">
+      <p
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className={`min-h-5 text-sm font-medium text-ok-text transition-opacity duration-300 ${status === 'saved' && !fading ? 'opacity-100' : 'opacity-0'}`}
+      >
+        {status === 'saved' ? 'Saved.' : ''}
+      </p>
+      {status === 'error' ? (
+        <div className="rounded-2xl border border-err-border/40 bg-err-bg p-3 text-sm text-err-text" role="alert">
+          <p className="font-semibold">Couldn’t save memory.</p>
+          <p className="mt-1 break-words">{error || 'Try again when the backend is reachable.'}</p>
+          <button
+            className="focus-ring mt-3 rounded-full border border-err-border px-4 py-2 font-semibold hover:bg-surface"
+            disabled={saving}
+            type="button"
+            onClick={onRetry}
+          >
+            Retry
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function AddMemory({
+  saveMemory = postSimpleMemory,
+  clearDelayMs = SAVE_CONFIRMATION_MS,
+}: {
+  saveMemory?: SaveMemory;
+  clearDelayMs?: number;
+}) {
+  const textareaId = useId();
+  const [text, setText] = useState('');
+  const [status, setStatus] = useState<AddMemoryStatus>('idle');
+  const [error, setError] = useState('');
+  const [lastFailed, setLastFailed] = useState('');
+  const [fading, setFading] = useState(false);
+  const clearTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const fadeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  function clearTimers() {
+    if (clearTimer.current) clearTimeout(clearTimer.current);
+    if (fadeTimer.current) clearTimeout(fadeTimer.current);
+    clearTimer.current = null;
+    fadeTimer.current = null;
+  }
+
+  useEffect(() => clearTimers, []);
+
+  function scheduleSavedClear() {
+    clearTimers();
+    clearTimer.current = setTimeout(() => {
+      setFading(true);
+      fadeTimer.current = setTimeout(() => {
+        setStatus('idle');
+        setFading(false);
+      }, FADE_MS);
+    }, clearDelayMs);
+  }
+
+  async function persistMemory(nextPattern = text) {
+    const candidate = nextPattern.trim();
+    if (!candidate || status === 'saving') return;
+    clearTimers();
+    setStatus('saving');
+    setError('');
+    setFading(false);
+    try {
+      await saveSimpleMemory(candidate, saveMemory);
+      setText('');
+      setLastFailed('');
+      setStatus('saved');
+      scheduleSavedClear();
+    } catch (err) {
+      setLastFailed(candidate);
+      setError(err instanceof Error ? err.message : String(err));
+      setStatus('error');
+    }
+  }
+
+  function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    void persistMemory();
+  }
+
+  const saving = status === 'saving';
+  const disabled = saving || !text.trim();
+  return (
+    <section className="grid gap-4 rounded-3xl border border-border bg-surface p-5 shadow-xl" aria-labelledby="simple-add-memory-title">
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Memory</p>
+        <h2 id="simple-add-memory-title" className="mt-2 text-2xl font-semibold text-text">Add a memory</h2>
+        <p className="mt-2 text-sm text-text-muted">Capture a note for Oracle to remember from Simple Mode.</p>
+      </div>
+      <form className="grid gap-3" onSubmit={submit}>
+        <label className="grid gap-2 text-sm font-medium text-text-muted" htmlFor={textareaId}>
+          Save something to memory
+        </label>
+        <textarea
+          id={textareaId}
+          className="focus-ring min-h-32 rounded-2xl border border-border bg-field px-4 py-3 text-text placeholder:text-text-muted"
+          disabled={saving}
+          placeholder="A detail, decision, or preference you want Oracle to recall."
+          value={text}
+          onChange={(event) => setText(event.currentTarget.value)}
+        />
+        <button
+          className="focus-ring w-full rounded-full bg-accent-solid px-5 py-3 font-semibold text-on-accent transition hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={disabled}
+          type="submit"
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+      </form>
+      <AddMemoryFeedback
+        status={status}
+        error={error}
+        fading={fading}
+        saving={saving}
+        onRetry={() => void persistMemory(lastFailed || text)}
+      />
+    </section>
+  );
+}

--- a/frontend/src/pages/SimplePage.tsx
+++ b/frontend/src/pages/SimplePage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { apiFetch } from '../api/oracle';
 import { HealthHero } from '../components/HealthHero';
+import { AddMemory } from '../components/simple/AddMemory';
 import { HealthState, mapHealthState, type SimpleHealthPayload } from '../components/simple/healthState';
 
 async function fetchHealth(): Promise<SimpleHealthPayload> {
@@ -36,8 +37,9 @@ export function SimplePage() {
 
   return (
     <main className="min-h-screen bg-field p-6 text-text">
-      <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-5xl items-center">
+      <div className="mx-auto grid max-w-5xl gap-5 py-6">
         <HealthHero state={state} checkedAt={checkedAt} onAction={poll} />
+        <AddMemory />
       </div>
     </main>
   );

--- a/tests/frontend/components/simple-add-memory.test.tsx
+++ b/tests/frontend/components/simple-add-memory.test.tsx
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { AddMemory, AddMemoryFeedback, ADD_MEMORY_ENDPOINT, SAVE_CONFIRMATION_MS, postSimpleMemory, saveSimpleMemory, simpleMemoryPayload } from '../../../frontend/src/components/simple/AddMemory';
+import { htmlFor } from '../_render';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function pathFor(input: RequestInfo | URL): string {
+  return new URL(String(input)).pathname;
+}
+
+describe('AddMemory simple mode card', () => {
+  test('renders the simple textarea, full-width save pill, and live saved region', () => {
+    const html = htmlFor(<AddMemory />);
+
+    expect(html).toContain('Save something to memory');
+    expect(html).toContain('textarea');
+    expect(html).toContain('w-full rounded-full');
+    expect(html).toContain('aria-live="polite"');
+    expect(html).toContain('role="status"');
+    expect(SAVE_CONFIRMATION_MS).toBe(3000);
+  });
+
+  test('builds the Simple Mode learn payload and rejects blank memories', async () => {
+    expect(simpleMemoryPayload('  Remember the blue mug.  ')).toEqual({
+      pattern: 'Remember the blue mug.',
+      source: 'Simple Mode',
+    });
+    await expect(saveSimpleMemory('   ', async () => {})).rejects.toThrow('Memory text is required.');
+  });
+
+  test('posts saved memories to the versioned learn endpoint', async () => {
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    globalThis.fetch = (async (input, init) => {
+      calls.push({ input, init });
+      return Response.json({ success: true, id: 'simple-memory', file: 'ψ/memory/learnings/simple-memory.md' });
+    }) as typeof fetch;
+
+    await expect(postSimpleMemory(simpleMemoryPayload('Keep the receipt.'))).resolves.toMatchObject({ success: true, id: 'simple-memory' });
+
+    expect(calls).toHaveLength(1);
+    expect(pathFor(calls[0].input)).toBe(ADD_MEMORY_ENDPOINT);
+    expect(calls[0].init?.method).toBe('POST');
+    expect(new Headers(calls[0].init?.headers).get('content-type')).toBe('application/json');
+    expect(JSON.parse(String(calls[0].init?.body))).toEqual({ pattern: 'Keep the receipt.', source: 'Simple Mode' });
+  });
+
+  test('renders save errors with a Retry action', () => {
+    const html = htmlFor(<AddMemoryFeedback status="error" error="offline" fading={false} saving={false} onRetry={() => {}} />);
+
+    expect(html).toContain('role="alert"');
+    expect(html).toContain('Couldn’t save memory.');
+    expect(html).toContain('offline');
+    expect(html).toContain('Retry');
+  });
+});

--- a/tests/frontend/pages/simple-page.test.tsx
+++ b/tests/frontend/pages/simple-page.test.tsx
@@ -9,6 +9,7 @@ describe('Simple page', () => {
       const html = htmlFor(<App />);
       expect(html).toContain('Simple mode');
       expect(html).toContain('Starting up…');
+      expect(html).toContain('Save something to memory');
       expect(html).not.toContain('Control Surface');
       expect(html).not.toContain('Backend unavailable');
     } finally {


### PR DESCRIPTION
## Summary\n- add Simple Mode AddMemory card with textarea, full-width Save pill, success live region, and retryable error state\n- POST saved notes to /api/v1/learn with { pattern, source: 'Simple Mode' }\n- render the memory card on /simple below the health hero\n\nRefs #2440\n\n## Validation\n- bunx tsc --noEmit\n- bun test tests/frontend/components/simple-add-memory.test.tsx tests/frontend/pages/simple-page.test.tsx tests/frontend/api/learn-create-path.test.ts tests/http/learn/crud.test.ts\n- git diff --check HEAD~1..HEAD\n- wc -l changed files <= 250