### PR TITLE
test(simple): cover Simple Mode full flow

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -72,6 +72,7 @@ import { watcherRoutes } from './routes/watcher/index.ts';
 import { indexerRoutes } from './routes/indexer/index.ts';
 import { fileWatcherService } from './services/file-watcher.ts';
 import { gatewayPlugin } from './gateway/index.ts';
+import { simpleModeResponse } from './simple-mode.ts';
 import pkg from '../package.json' with { type: 'json' };
 
 type UnifiedRuntime = Awaited<ReturnType<typeof loadUnifiedPlugins>>;
@@ -118,6 +119,7 @@ export function createApp({ unifiedPlugins, runtimeRef = createUnifiedRuntimeRef
     .get('/swagger', () => Response.redirect('/api/docs', 308), { detail: { hide: true } })
     .get('/swagger/json', () => Response.redirect('/api/docs/json', 308), { detail: { hide: true } })
     .get('/api/openapi.json', () => Response.redirect('/api/docs/json', 308), { detail: { hide: true } })
+    .get('/simple', ({ set }) => simpleModeResponse(set), { detail: { tags: ['frontend'], summary: 'Simple Mode entry page' } })
     .get('/', () => ({ server: MCP_SERVER_NAME, version: pkg.version, status: 'ok', docs: '/api/docs', api: '/api/v1' }));
 
   const routeModules = createServerRouteModules(unifiedPlugins, runtimeRef);

--- a/src/simple-mode.ts
+++ b/src/simple-mode.ts
@@ -1,0 +1,12 @@
+import { join } from 'node:path';
+
+const SIMPLE_HTML = join(import.meta.dir, 'simple.html');
+const HTML_CONTENT_TYPE = 'text/html; charset=utf-8';
+type HeaderSet = { headers: Record<string, string | number | string[]> };
+
+export function simpleModeResponse(set: HeaderSet): Response {
+  set.headers['Content-Type'] = HTML_CONTENT_TYPE;
+  return new Response(Bun.file(SIMPLE_HTML), {
+    headers: { 'Content-Type': HTML_CONTENT_TYPE },
+  });
+}

--- a/src/simple.html
+++ b/src/simple.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Arra Oracle Simple Mode</title>
+    <style>
+      :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
+      body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #080b12; color: #f6f0df; }
+      main { width: min(760px, calc(100vw - 32px)); padding: 32px; border: 1px solid #334155; border-radius: 28px; background: #101827; box-shadow: 0 24px 80px #0008; }
+      .eyebrow { color: #f6c85f; font-weight: 700; letter-spacing: .18em; text-transform: uppercase; font-size: .78rem; }
+      h1 { margin: 12px 0; font-size: clamp(2rem, 7vw, 4.5rem); line-height: .95; }
+      p { color: #cbd5e1; font-size: 1.08rem; line-height: 1.6; max-width: 56ch; }
+      .hero { margin-top: 24px; padding: 20px; border-radius: 20px; background: #162033; border: 1px solid #334155; }
+      .status { display: flex; gap: 10px; align-items: center; color: #86efac; font-weight: 700; }
+      .dot { width: 12px; height: 12px; border-radius: 50%; background: currentColor; box-shadow: 0 0 24px currentColor; }
+      code { color: #fde68a; background: #020617; padding: 2px 6px; border-radius: 6px; }
+      a { color: #93c5fd; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="eyebrow">Simple Mode</div>
+      <h1>Awake and remembering.</h1>
+      <p>
+        This lightweight page is served by the Oracle backend at <code>/simple</code>
+        so the Docker-first path has a no-surprises health and recall surface.
+      </p>
+      <section class="hero" aria-label="Health hero">
+        <div class="status"><span class="dot" aria-hidden="true"></span> Backend reachable</div>
+        <p>Health: <a href="/api/v1/health">GET /api/v1/health</a>. Search and learning APIs are available through <code>/api/v1</code>.</p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/tests/integration/simple-flow/full-flow.test.ts
+++ b/tests/integration/simple-flow/full-flow.test.ts
@@ -1,0 +1,195 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { createServer } from 'node:net';
+import { createSmokeEnv, removeSmokeEnv, REPO_ROOT, type SmokeEnv } from '../../smoke/_helpers.ts';
+
+type JsonRecord = Record<string, unknown>;
+type Spawned = ReturnType<typeof Bun.spawn>;
+type VectorStub = { url: string; setUp(up: boolean): void; stop(): Promise<void> };
+type FlowServer = SmokeEnv & {
+  baseUrl: string;
+  process: Spawned;
+  stdout: Promise<string>;
+  stderr: Promise<string>;
+  vector: VectorStub;
+  stop(): Promise<void>;
+};
+
+let server: FlowServer | null = null;
+const token = `simpleflow${Date.now()}`;
+
+beforeAll(async () => {
+  server = await startSimpleFlowServer();
+}, 30_000);
+
+afterAll(async () => {
+  await server?.stop();
+});
+
+function expectRecord(value: unknown): asserts value is JsonRecord {
+  expect(typeof value).toBe('object');
+  expect(value).not.toBeNull();
+  expect(Array.isArray(value)).toBe(false);
+}
+
+function expectJson(response: Response, status = 200): void {
+  expect(response.status).toBe(status);
+  expect(response.headers.get('content-type') ?? '').toContain('application/json');
+  expect(response.headers.get('x-api-version')).toBe('v1');
+}
+
+async function fetchJson(path: string, init: RequestInit = {}) {
+  expect(server).not.toBeNull();
+  const headers = new Headers(init.headers);
+  headers.set('accept', headers.get('accept') ?? 'application/json');
+  if (init.body && !headers.has('content-type')) headers.set('content-type', 'application/json');
+  const response = await fetch(`${server!.baseUrl}${path}`, { ...init, headers });
+  const body = await response.json() as unknown;
+  expectRecord(body);
+  return { response, body };
+}
+
+function postJson(path: string, body: unknown) {
+  return fetchJson(path, { method: 'POST', body: JSON.stringify(body) });
+}
+
+describe('Simple Mode full-flow integration', () => {
+  test('boots, serves /simple, searches, learns, and degrades on vector outage', async () => {
+    const simple = await fetch(`${server!.baseUrl}/simple`);
+    expect(simple.status).toBe(200);
+    const simpleType = simple.headers.get('content-type') ?? '';
+    const simpleText = await simple.text();
+    expect(simpleType).toContain('text/html');
+    expect(simpleText).toContain('Simple Mode');
+
+    const health = await fetchJson('/api/v1/health');
+    expectJson(health.response);
+    expect(health.body).toMatchObject({ status: 'ok', vectorMode: 'proxied' });
+
+    const search = await fetchJson(`/api/v1/search?q=${token}&limit=2`);
+    expectJson(search.response);
+    expect(Array.isArray(search.body.results)).toBe(true);
+    expect(search.body.results).toContainEqual(expect.objectContaining({ id: 'simple-flow-probe' }));
+
+    const learned = await postJson('/api/v1/learn', {
+      pattern: `${token} is saved through Simple Mode integration`,
+      concepts: ['simple-flow', token],
+      source: 'simple-flow integration test',
+    });
+    expectJson(learned.response);
+    expect(learned.body).toMatchObject({ success: true });
+    expect(typeof learned.body.id).toBe('string');
+
+    const readBack = await fetchJson(`/api/v1/learn/${encodeURIComponent(String(learned.body.id))}`);
+    expectJson(readBack.response);
+    expect(readBack.body).toMatchObject({ id: learned.body.id, type: 'learning' });
+
+    server!.vector.setUp(false);
+    const degraded = await waitForDegradedHealth();
+    expect(degraded.body).toMatchObject({ status: 'degraded' });
+    expect(degraded.body.vectorServer).toMatchObject({ status: 'down' });
+  }, 45_000);
+});
+
+async function waitForDegradedHealth() {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const health = await fetchJson('/api/v1/health');
+    expectJson(health.response);
+    if (health.body.status === 'degraded') return health;
+    await Bun.sleep(100);
+  }
+  throw new Error('health did not report degraded after vector outage');
+}
+
+function startVectorStub(): VectorStub {
+  let up = true;
+  const srv = Bun.serve({
+    hostname: '127.0.0.1',
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname === '/api/search') {
+        const query = url.searchParams.get('q') ?? '';
+        return Response.json({
+          results: [{ id: 'simple-flow-probe', type: 'learning', content: `${query} vector probe`, source: 'vector', score: 0.9 }],
+          total: 1,
+          query,
+        });
+      }
+      if (url.pathname === '/health' || url.pathname === '/' || url.pathname === '/api/vector/health') {
+        return Response.json({ status: up ? 'ok' : 'down', server: 'vector-stub' }, { status: up ? 200 : 503 });
+      }
+      return Response.json({ error: 'not found' }, { status: 404 });
+    },
+  });
+  return { url: `http://127.0.0.1:${srv.port}`, setUp: (next) => { up = next; }, stop: () => srv.stop(true) };
+}
+
+async function startSimpleFlowServer(): Promise<FlowServer> {
+  const smoke = createSmokeEnv('simple-flow');
+  const vector = startVectorStub();
+  Object.assign(smoke.env, {
+    VECTOR_URL: vector.url,
+    ARRA_PLUGIN_HOT_RELOAD: '0',
+    MAW_JS_URL: 'http://127.0.0.1:1',
+    ORACLE_FILE_WATCHER: '0',
+    ORACLE_GATEWAY_HOT_RELOAD: '0',
+    ORACLE_TOOL_GROUPS_HOT_RELOAD: '0',
+    ORACLE_VECTOR_HEALTH_TIMEOUT: '200',
+    ORACLE_VECTOR_SERVER_HEALTH_TIMEOUT_MS: '200',
+  });
+  const port = await freePort();
+  const env = { ...process.env, ...smoke.env, ORACLE_PORT: String(port) };
+  const proc = Bun.spawn(['bun', 'src/server.ts'], { cwd: REPO_ROOT, env, stdout: 'pipe', stderr: 'pipe' });
+  const stdout = new Response(proc.stdout).text();
+  const stderr = new Response(proc.stderr).text();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  try {
+    await waitForHealthy(baseUrl, proc);
+  } catch (error) {
+    proc.kill();
+    await proc.exited.catch(() => undefined);
+    await vector.stop().catch(() => undefined);
+    removeSmokeEnv(smoke.root);
+    throw new Error(`${error instanceof Error ? error.message : String(error)}\n${await stdout}\n${await stderr}`);
+  }
+  return { ...smoke, baseUrl, process: proc, stdout, stderr, vector, stop: () => stopServer(proc, smoke.root, vector, stdout, stderr) };
+}
+
+async function waitForHealthy(baseUrl: string, proc: Spawned): Promise<void> {
+  let exited = false;
+  proc.exited.then(() => { exited = true; }).catch(() => { exited = true; });
+  for (let attempt = 0; attempt < 80; attempt++) {
+    if (exited) throw new Error('server exited before /api/health became ready');
+    try {
+      const response = await fetch(`${baseUrl}/api/health`);
+      const body = await response.json().catch(() => ({})) as JsonRecord;
+      if (response.ok && body.status === 'ok') return;
+    } catch {}
+    await Bun.sleep(150);
+  }
+  throw new Error('server did not become healthy');
+}
+
+async function stopServer(proc: Spawned, root: string, vector: VectorStub, stdout: Promise<string>, stderr: Promise<string>): Promise<void> {
+  proc.kill('SIGTERM');
+  const done = await Promise.race([proc.exited.catch(() => null), Bun.sleep(1500).then(() => 'timeout' as const)]);
+  if (done === 'timeout') {
+    proc.kill('SIGKILL');
+    await proc.exited.catch(() => undefined);
+  }
+  await vector.stop().catch(() => undefined);
+  await Promise.all([stdout.catch(() => ''), stderr.catch(() => '')]);
+  removeSmokeEnv(root);
+}
+
+async function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const address = srv.address();
+      if (!address || typeof address === 'string') return reject(new Error('failed to allocate port'));
+      srv.close(() => resolve(address.port));
+    });
+  });
+}


### PR DESCRIPTION
Refs #2440

## Summary
- Serve a lightweight `/simple` Simple Mode HTML entry point from the backend.
- Add full-flow integration coverage for boot, `/simple`, `/api/v1/health`, `/api/v1/search`, `POST /api/v1/learn`, and vector-down health degradation.
- Use a controllable vector stub so the test proves proxied health flips from ok to degraded when the sidecar is down.

## Verification
- bunx tsc --noEmit
- bun test --isolate tests/integration/simple-flow/ tests/integration/smoke.test.ts
- git diff --check
- wc -l src/server.ts src/simple-mode.ts src/simple.html tests/integration/simple-flow/full-flow.test.ts

## Notes
- PR targets alpha.
- All changed files are <=250 lines.
