### PR TITLE
feat(simple): link Simple Mode entry points

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -109,6 +109,12 @@ export function AppShell({
               <CommandPalette onRefresh={onRefresh} />
               <GlobalSearch />
               <div className="flex flex-wrap items-center justify-start gap-3 sm:justify-end">
+                <a
+                  className="focus-ring rounded-xl border border-accent-border px-4 py-3 font-semibold text-accent transition hover:bg-accent-soft"
+                  href="/simple"
+                >
+                  Simple Mode
+                </a>
                 <TauriBadge connected={!error} />
                 <ThemeToggle />
                 <button

--- a/frontend/src/pages/SimplePage.tsx
+++ b/frontend/src/pages/SimplePage.tsx
@@ -3,6 +3,7 @@ import { apiFetch } from '../api/oracle';
 import { HealthHero } from '../components/HealthHero';
 import { AddMemory } from '../components/simple/AddMemory';
 import { HealthState, mapHealthState, type SimpleHealthPayload } from '../components/simple/healthState';
+import { version } from '../../../package.json';
 
 async function fetchHealth(): Promise<SimpleHealthPayload> {
   const response = await apiFetch('/api/health', { headers: { accept: 'application/json' } });
@@ -37,9 +38,17 @@ export function SimplePage() {
 
   return (
     <main className="min-h-screen bg-field p-6 text-text">
-      <div className="mx-auto grid max-w-5xl gap-5 py-6">
-        <HealthHero state={state} checkedAt={checkedAt} onAction={poll} />
-        <AddMemory />
+      <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-5xl flex-col py-6">
+        <div className="grid flex-1 content-center gap-5">
+          <HealthHero state={state} checkedAt={checkedAt} onAction={poll} />
+          <AddMemory />
+        </div>
+        <footer className="flex flex-wrap items-center justify-between gap-3 border-t border-border py-4 text-sm text-text-muted">
+          <a className="focus-ring rounded-lg font-semibold text-accent hover:text-text" href="/">
+            Advanced Studio
+          </a>
+          <span>Arra Oracle v{version}</span>
+        </footer>
       </div>
     </main>
   );

--- a/tests/frontend/components/app-shell-summary.test.tsx
+++ b/tests/frontend/components/app-shell-summary.test.tsx
@@ -22,4 +22,21 @@ describe('AppShell summary', () => {
       restore();
     }
   });
+
+  test('exposes the Simple Mode header link', () => {
+    const restore = installBrowserLocation('/menu');
+    try {
+      const html = htmlFor(
+        <MemoryRouter initialEntries={['/menu']}>
+          <AppShell error="" loading={false} menuCount={2} pluginCount={1} surfaceCount={4} updatedAt="10:00" onRefresh={() => {}}>
+            <p>child content</p>
+          </AppShell>
+        </MemoryRouter>,
+      );
+      expect(html).toContain('href="/simple"');
+      expect(html).toContain('Simple Mode');
+    } finally {
+      restore();
+    }
+  });
 });

--- a/tests/frontend/pages/simple-page.test.tsx
+++ b/tests/frontend/pages/simple-page.test.tsx
@@ -10,6 +10,9 @@ describe('Simple page', () => {
       expect(html).toContain('Simple mode');
       expect(html).toContain('Starting up…');
       expect(html).toContain('Save something to memory');
+      expect(html).toContain('href="/"');
+      expect(html).toContain('Advanced Studio');
+      expect(html).toContain('Arra Oracle v');
       expect(html).not.toContain('Control Surface');
       expect(html).not.toContain('Backend unavailable');
     } finally {


### PR DESCRIPTION
## Summary

- Adds a single Advanced Studio header link to `/simple`.
- Adds Simple Mode footer with Advanced Studio link and package version.
- Covers both entry points with scoped frontend render tests.

Refs #2440.

## Validation

```bash
bunx tsc --noEmit
bunx tsc -p frontend/tsconfig.json --noEmit
bun test --isolate tests/frontend/components/app-shell-summary.test.tsx tests/frontend/pages/simple-page.test.tsx tests/frontend/components/health-hero.test.tsx frontend/src/components/simple/__tests__/healthState.test.ts
wc -l frontend/src/components/AppShell.tsx frontend/src/pages/SimplePage.tsx tests/frontend/components/app-shell-summary.test.tsx tests/frontend/pages/simple-page.test.tsx
```

- Scoped tests: 14 pass, 0 fail.
- File sizes: 148, 55, 42, 22 lines.