### PR TITLE
feat(cli): add doctor stack verifier

### DIFF
--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -1,7 +1,10 @@
 import { existsSync } from "fs";
+import { resolve } from "path";
 import { globalConfigPath, findProjectConfigPath, loadConfigSources, resolveOracleApiBase, type ResolvedApiBase } from "../lib/config.ts";
+import type { HealthStatusEnum, HealthSubsystem } from "../../../src/routes/health/subsystems.ts";
 
 export type DoctorStatus = "pass" | "fail" | "warn";
+export type McpProbe = (input: { env: NodeJS.ProcessEnv; cwd: string; resolved: ResolvedApiBase }) => Promise<{ toolCount: number; detail?: string }>;
 
 export interface DoctorCheck {
   id: string;
@@ -18,6 +21,9 @@ export interface DoctorReport {
   checks: DoctorCheck[];
 }
 
+type DoctorOptions = { env?: NodeJS.ProcessEnv; cwd?: string; fetcher?: typeof fetch; mcpProbe?: McpProbe; timeoutMs?: number };
+type HealthPayload = { healthStatus?: HealthStatusEnum; status?: string; subsystems?: Record<string, HealthSubsystem> };
+
 function ok(id: string, label: string, detail?: string, data?: unknown): DoctorCheck {
   return { id, label, status: "pass", critical: true, detail, data };
 }
@@ -30,37 +36,42 @@ function warn(id: string, label: string, detail?: string, data?: unknown): Docto
   return { id, label, status: "warn", critical: false, detail, data };
 }
 
-async function fetchJson(baseUrl: string, path: string): Promise<{ status: number; data: any }> {
-  const res = await fetch(`${baseUrl}${path}`);
+async function fetchJson(baseUrl: string, path: string, fetcher: typeof fetch, timeoutMs: number): Promise<{ status: number; data: any }> {
+  const res = await fetcher(`${baseUrl}${path}`, { signal: AbortSignal.timeout(timeoutMs) });
   let data: any = null;
   try { data = await res.json(); } catch { /* non-json */ }
   return { status: res.status, data };
 }
 
-function adapterFromStats(stats: any): string | undefined {
-  const vector = stats?.vector ?? stats?.vectors;
-  if (!vector) return undefined;
-  if (typeof vector.adapter === "string") return vector.adapter;
-  if (typeof vector.type === "string") return vector.type;
-  if (typeof vector.engine === "string") return vector.engine;
-  if (typeof vector.collection === "string") return vector.collection;
+function subsystemCheck(id: string, label: string, subsystem: HealthSubsystem | undefined, mode: "strict" | "soft"): DoctorCheck {
+  if (!subsystem) return fail(id, label, "missing from /api/health subsystem detail");
+  if (subsystem.status === "healthy") return ok(id, label, subsystem.detail, subsystem.data);
+  if (mode === "soft" && subsystem.status === "degraded") return warn(id, label, subsystem.detail, subsystem.data);
+  return fail(id, label, subsystem.detail, subsystem.data);
+}
+
+function healthOverallCheck(health: HealthPayload): DoctorCheck {
+  const status = health.healthStatus ?? normalizeLegacyStatus(health.status);
+  if (status === "healthy") return ok("backend.status", "overall health", "healthy", health);
+  if (status === "degraded") return warn("backend.status", "overall health", "degraded; see subsystem detail", health);
+  return fail("backend.status", "overall health", status ?? "unknown", health);
+}
+
+function normalizeLegacyStatus(status: unknown): HealthStatusEnum | undefined {
+  if (status === "ok") return "healthy";
+  if (status === "degraded") return "degraded";
+  if (status === "draining") return "down";
   return undefined;
 }
 
-function countFromStats(stats: any): number | undefined {
-  const vector = stats?.vector ?? stats?.vectors;
-  if (typeof vector?.count === "number") return vector.count;
-  if (typeof vector?.total === "number") return vector.total;
-  if (typeof stats?.total === "number") return stats.total;
-  if (typeof stats?.total_docs === "number") return stats.total_docs;
-  return undefined;
-}
-
-export async function runDoctor(options: { env?: NodeJS.ProcessEnv; cwd?: string } = {}): Promise<DoctorReport> {
+export async function runDoctor(options: DoctorOptions = {}): Promise<DoctorReport> {
   const env = options.env ?? process.env;
   const cwd = options.cwd ?? process.cwd();
+  const fetcher = options.fetcher ?? fetch;
+  const timeoutMs = options.timeoutMs ?? 3000;
   const checks: DoctorCheck[] = [];
   let resolved: ResolvedApiBase;
+  let healthPayload: HealthPayload | null = null;
 
   try {
     resolved = resolveOracleApiBase({ env, cwd });
@@ -76,61 +87,67 @@ export async function runDoctor(options: { env?: NodeJS.ProcessEnv; cwd?: string
   }
   const projectPath = findProjectConfigPath(cwd);
   const globalPath = globalConfigPath(env);
-  checks.push((projectPath && existsSync(projectPath))
-    ? ok("config.project", "project config file", projectPath)
-    : warn("config.project", "project config file", "not found"));
-  checks.push(existsSync(globalPath)
-    ? ok("config.global", "global config file", globalPath)
-    : warn("config.global", "global config file", `not found (${globalPath})`));
-
-  checks.push(ok(
-    "mcp.mode",
-    "MCP mode",
-    env.ORACLE_HTTP_URL?.trim()
-      ? `HTTP proxy mode (${env.ORACLE_HTTP_URL})`
-      : "embedded mode (ORACLE_HTTP_URL not set)",
-    { ORACLE_HTTP_URL: env.ORACLE_HTTP_URL ?? null }
-  ));
+  checks.push((projectPath && existsSync(projectPath)) ? ok("config.project", "project config file", projectPath) : warn("config.project", "project config file", "not found"));
+  checks.push(existsSync(globalPath) ? ok("config.global", "global config file", globalPath) : warn("config.global", "global config file", `not found (${globalPath})`));
 
   if (resolved.url) {
     try {
-      const health = await fetchJson(resolved.url, "/api/health");
-      if (health.status >= 200 && health.status < 300) {
-        checks.push(ok("server.health", "server reachable", `${resolved.url}/api/health HTTP ${health.status}`, health.data));
-      } else {
-        checks.push(fail("server.health", "server reachable", `${resolved.url}/api/health HTTP ${health.status}`, health.data));
-      }
+      const health = await fetchJson(resolved.url, "/api/health", fetcher, timeoutMs);
+      healthPayload = health.data;
+      checks.push(health.status >= 200 && health.status < 300
+        ? ok("backend.reachable", "backend reachable", `${resolved.url}/api/health HTTP ${health.status}`, health.data)
+        : fail("backend.reachable", "backend reachable", `${resolved.url}/api/health HTTP ${health.status}`, health.data));
+      if (health.status >= 200 && health.status < 300) checks.push(healthOverallCheck(health.data));
     } catch (err) {
-      checks.push(fail("server.health", "server reachable", err instanceof Error ? err.message : String(err)));
+      checks.push(fail("backend.reachable", "backend reachable", err instanceof Error ? err.message : String(err)));
     }
+  }
 
-    try {
-      const stats = await fetchJson(resolved.url, "/api/stats");
-      if (stats.status >= 200 && stats.status < 300) {
-        const total = typeof stats.data?.total === "number" ? stats.data.total : stats.data?.total_docs;
-        const vector = stats.data?.vector ?? stats.data?.vectors;
-        checks.push(ok("db.stats", "DB stats", `documents=${total ?? "unknown"}`, stats.data));
-        checks.push(ok(
-          "vector.stats",
-          "vector adapter stats",
-          `adapter=${adapterFromStats(stats.data) ?? "unknown"} count=${countFromStats({ vector }) ?? "unknown"}`,
-          vector
-        ));
-      } else {
-        checks.push(fail("db.stats", "DB + vector stats", `${resolved.url}/api/stats HTTP ${stats.status}`, stats.data));
-      }
-    } catch (err) {
-      checks.push(fail("db.stats", "DB + vector stats", err instanceof Error ? err.message : String(err)));
-    }
+  const subsystems = healthPayload?.subsystems;
+  checks.push(subsystemCheck("db.writable", "DB writable", subsystems?.database, "strict"));
+  checks.push(subsystemCheck("fts.healthy", "FTS healthy", subsystems?.fts, "strict"));
+  checks.push(subsystemCheck("vector.backend", "vector backend", subsystems?.vector, "soft"));
+  checks.push(subsystemCheck("embedder.reachable", "embedder reachable", subsystems?.embedder, "soft"));
+
+  try {
+    const mcp = await (options.mcpProbe ?? defaultMcpProbe)({ env, cwd, resolved });
+    checks.push(ok("mcp.launchable", "MCP launchable", mcp.detail ?? `${mcp.toolCount} tool(s) listed`, mcp));
+  } catch (err) {
+    checks.push(fail("mcp.launchable", "MCP launchable", err instanceof Error ? err.message : String(err)));
   }
 
   return { ok: checks.every(check => check.status !== "fail" || !check.critical), resolved, checks };
 }
 
-function symbol(status: DoctorStatus): string {
-  if (status === "pass") return "✓";
-  if (status === "warn") return "!";
-  return "✗";
+async function defaultMcpProbe(input: { env: NodeJS.ProcessEnv; cwd: string; resolved: ResolvedApiBase }) {
+  const { listExternalMcpTools } = await import("../../../src/mcp/client.ts");
+  const repoRoot = resolve(import.meta.dir, "../../..");
+  const api = input.resolved.url || input.env.ORACLE_API || input.env.NEO_ARRA_API || "";
+  const tools = await listExternalMcpTools({
+    command: "bun",
+    args: ["bin/mcp.ts"],
+    cwd: repoRoot,
+    timeoutMs: 5000,
+    env: cleanEnv({
+      ...input.env,
+      ORACLE_API: api,
+      ORACLE_HTTP_URL: input.env.ORACLE_HTTP_URL || api,
+      ORACLE_FILE_WATCHER: "0",
+      ORACLE_GATEWAY_HOT_RELOAD: "0",
+      ORACLE_EMBEDDER: input.env.ORACLE_EMBEDDER || "none",
+    }),
+  });
+  return { toolCount: tools.length, detail: `${tools.length} MCP tool(s) listed` };
+}
+
+function cleanEnv(env: NodeJS.ProcessEnv): Record<string, string> {
+  return Object.fromEntries(Object.entries(env).filter((entry): entry is [string, string] => typeof entry[1] === "string"));
+}
+
+function label(status: DoctorStatus): string {
+  if (status === "pass") return "PASS";
+  if (status === "warn") return "WARN";
+  return "FAIL";
 }
 
 export async function doctorCommand(args: string[]): Promise<number> {
@@ -142,7 +159,7 @@ export async function doctorCommand(args: string[]): Promise<number> {
     console.log("ARRA Doctor\n");
     for (const check of report.checks) {
       const suffix = check.detail ? ` — ${check.detail}` : "";
-      console.log(`${symbol(check.status)} ${check.label}${suffix}`);
+      console.log(`${label(check.status)} ${check.label}${suffix}`);
     }
   }
   return report.ok ? 0 : 1;

--- a/frontend/src/components/simple/__tests__/healthState.test.ts
+++ b/frontend/src/components/simple/__tests__/healthState.test.ts
@@ -55,4 +55,12 @@ describe('simple health state mapper', () => {
   test('maps explicit down payloads to down', () => {
     expect(mapHealthState({ msSinceLoad: 10_000, health: { status: 'down' } })).toBe(HealthState.Down);
   });
+
+
+  test('prefers enriched healthStatus over legacy ok status', () => {
+    expect(mapHealthState({ msSinceLoad: 10_000, health: { status: 'ok', healthStatus: 'degraded', dbStatus: 'connected' } }))
+      .toBe(HealthState.DegradedFts);
+    expect(mapHealthState({ msSinceLoad: 10_000, health: { status: 'ok', healthStatus: 'down' } }))
+      .toBe(HealthState.Down);
+  });
 });

--- a/frontend/src/components/simple/healthState.ts
+++ b/frontend/src/components/simple/healthState.ts
@@ -13,6 +13,7 @@ export const HEALTH_DOWN_RETRY_COUNT = 3;
 
 export interface SimpleHealthPayload {
   status?: string;
+  healthStatus?: string;
   db?: string | { status?: string };
   dbStatus?: string;
   oracle?: string;
@@ -87,7 +88,7 @@ export function mapHealthState(input: HealthStateInput): HealthState {
     return HealthState.Starting;
   }
 
-  const status = health.status?.toLowerCase();
+  const status = (health.healthStatus ?? health.status)?.toLowerCase();
   if (health.draining || status === 'starting' || status === 'draining') return HealthState.Starting;
   if (status === 'down' || status === 'error') return HealthState.Down;
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -55,7 +55,7 @@ export const BUILTIN_HELP: CliHelpEntry[] = [
   },
   {
     command: "doctor",
-    help: "run operator diagnostics against the resolved target",
+    help: "verify backend, DB, FTS, vector, embedder, and MCP launch",
     usage: "arra-cli doctor [--json]",
     flags: ["--json", "--help", "-h"],
     examples: ["arra-cli doctor", "arra-cli doctor --json", "arra-cli --at cafe doctor"],

--- a/src/routes/health/health.ts
+++ b/src/routes/health/health.ts
@@ -1,4 +1,4 @@
-import { Elysia, t } from 'elysia';
+import { Elysia } from 'elysia';
 import { DB_PATH, PORT } from '../../config.ts';
 import { MCP_SERVER_NAME } from '../../const.ts';
 import { sqlite } from '../../db/index.ts';
@@ -11,6 +11,7 @@ import { mcpTools } from '../../tools/mcp-manifest.ts';
 import type { UnifiedPluginStatus } from '../../plugins/unified-loader.ts';
 import { sandboxLabel } from '../../runtime/sandbox-label.ts';
 import { healthRollupStatus } from './rollup.ts';
+import { buildHealthSubsystems, rollupHealthStatus, type EmbeddingProviderProbe } from './subsystems.ts';
 import pkg from '../../../package.json' with { type: 'json' };
 
 type VectorHealth = Awaited<ReturnType<typeof readVectorBackendHealth>>;
@@ -27,74 +28,6 @@ type DiskHealth = {
   error?: string;
 };
 
-const HealthVectorEngineSchema = t.Object({
-  key: t.String(),
-  model: t.String(),
-  collection: t.String(),
-  adapter: t.Optional(t.String()),
-  embeddingProvider: t.Optional(t.String()),
-  connectionStatus: t.Optional(t.Union([t.Literal('connected'), t.Literal('error')])),
-  count: t.Optional(t.Number()),
-  ok: t.Boolean(),
-  error: t.Optional(t.String()),
-});
-
-const HealthVectorSchema = t.Object({
-  status: t.Union([t.Literal('ok'), t.Literal('degraded'), t.Literal('down')]),
-  checked_at: t.String(),
-  engines: t.Array(HealthVectorEngineSchema),
-  collections: t.Optional(t.Array(HealthVectorEngineSchema)),
-  error: t.Optional(t.String()),
-});
-
-const HealthResponseSchema = t.Object({
-  status: t.Union([t.Literal('ok'), t.Literal('degraded'), t.Literal('draining')]),
-  server: t.String(),
-  version: t.String(),
-  port: t.Optional(t.Number()),
-  sandbox: t.Optional(t.String()),
-  oracle: t.Optional(t.Union([t.Literal('connected'), t.Literal('degraded')])),
-  uptimeSeconds: t.Optional(t.Number()),
-  dbStatus: t.Optional(t.Union([t.Literal('connected'), t.Literal('error')])),
-  vectorStatus: t.Optional(t.Union([t.Literal('ok'), t.Literal('degraded'), t.Literal('down')])),
-  vectorMode: t.Optional(t.Union([t.Literal('embedded'), t.Literal('proxied'), t.Literal('disabled')])),
-  vectorAvailable: t.Optional(t.Boolean()),
-  vectorUrl: t.Optional(t.String()),
-  vectorDisabledReason: t.Optional(t.String()),
-  pluginStatus: t.Optional(t.Union([t.Literal('ok'), t.Literal('degraded')])),
-  mcpToolCount: t.Optional(t.Number()),
-  pluginCount: t.Optional(t.Number()),
-  uptime: t.Optional(t.Object({
-    seconds: t.Number(),
-  })),
-  uptimeSecondsBreakdown: t.Optional(t.Object({
-    seconds: t.Number(),
-  })),
-  db: t.Optional(t.Object({
-    status: t.Union([t.Literal('connected'), t.Literal('error')]),
-    path: t.String(),
-    error: t.Optional(t.String()),
-  })),
-  dbCheck: t.Optional(t.Object({
-    status: t.Union([t.Literal('connected'), t.Literal('error')]),
-    path: t.Optional(t.String()),
-    error: t.Optional(t.String()),
-  })),
-  vector: t.Optional(HealthVectorSchema),
-  memory: t.Optional(t.Object({ fanoutReranking: t.Object({ enabled: t.Boolean(), confidenceWeight: t.Number(), source: t.String(), envKey: t.Optional(t.String()), strategy: t.String() }) })),
-  mcp: t.Optional(t.Object({ toolCount: t.Number() })),
-  plugins: t.Optional(t.Object({
-    count: t.Number(),
-    status: t.Union([t.Literal('ok'), t.Literal('degraded')]),
-    items: t.Array(t.Object({
-      name: t.String(),
-      status: t.Union([t.Literal('ok'), t.Literal('degraded')]),
-      error: t.Optional(t.String()),
-    })),
-  })),
-  draining: t.Optional(t.Boolean()),
-});
-
 export interface HealthEndpointOptions {
   pluginCount?: number;
   pluginMcpToolCount?: number;
@@ -103,6 +36,7 @@ export interface HealthEndpointOptions {
   vectorHealth?: () => Promise<VectorHealth>;
   vectorServerHealth?: () => Promise<VectorServerHealth>;
   pluginStatuses?: () => UnifiedPluginStatus[] | Promise<UnifiedPluginStatus[]>;
+  embeddingProviders?: EmbeddingProviderProbe;
   dbPing?: DbPing;
   diskPath?: string;
   diskUsage?: () => DiskHealth;
@@ -114,11 +48,8 @@ function errorMessage(error: unknown): string {
 }
 
 async function readDbStatus(ping: DbPing = defaultDbPing): Promise<DbStatus> {
-  try {
-    return await ping();
-  } catch (error) {
-    return { status: 'error', error: errorMessage(error) };
-  }
+  try { return await ping(); }
+  catch (error) { return { status: 'error', error: errorMessage(error) }; }
 }
 
 async function defaultDbPing(): Promise<DbStatus> {
@@ -136,30 +67,18 @@ async function readVectorStatus(check = readVectorBackendHealth): Promise<Vector
     return { ...vector, collections: vector.collections ?? vector.engines };
   } catch (error) {
     return {
-      status: 'down',
-      engines: [],
-      collections: [],
-      checked_at: new Date().toISOString(),
-      error: errorMessage(error),
+      status: 'down', engines: [], collections: [],
+      checked_at: new Date().toISOString(), error: errorMessage(error),
     } as VectorHealth & { error: string };
   }
 }
 
-async function readPluginStatuses(
-  read?: () => UnifiedPluginStatus[] | Promise<UnifiedPluginStatus[]>,
-): Promise<UnifiedPluginStatus[]> {
-  try {
-    return await read?.() ?? [];
-  } catch (error) {
-    return [{ name: 'plugin-status', status: 'degraded', error: errorMessage(error) }];
-  }
+async function readPluginStatuses(read?: () => UnifiedPluginStatus[] | Promise<UnifiedPluginStatus[]>): Promise<UnifiedPluginStatus[]> {
+  try { return await read?.() ?? []; }
+  catch (error) { return [{ name: 'plugin-status', status: 'degraded', error: errorMessage(error) }]; }
 }
 
-function vectorAvailable(
-  runtime: ReturnType<typeof getVectorRuntimeStatus>,
-  vector: VectorHealth,
-  vectorServer: VectorServerHealth,
-): boolean {
+function vectorAvailable(runtime: ReturnType<typeof getVectorRuntimeStatus>, vector: VectorHealth, vectorServer: VectorServerHealth): boolean {
   if (vectorServer.configured || runtime.vectorMode === 'proxied') return vectorServer.status === 'ok';
   if (runtime.vectorMode === 'disabled') return false;
   return vector.status !== 'down';
@@ -171,11 +90,8 @@ async function readSafeVectorServerHealth(read = readVectorServerHealth): Promis
 }
 
 function installedPluginCount(): number {
-  try {
-    return scanPlugins().plugins.length;
-  } catch {
-    return 0;
-  }
+  try { return scanPlugins().plugins.length; }
+  catch { return 0; }
 }
 
 export function createHealthEndpoint(options: HealthEndpointOptions = {}) {
@@ -183,11 +99,8 @@ export function createHealthEndpoint(options: HealthEndpointOptions = {}) {
     if (options.isDraining?.()) {
       set.status = 503;
       return {
-        status: 'draining',
-        server: MCP_SERVER_NAME,
-        version: pkg.version,
-        sandbox: sandboxLabel(),
-        draining: true,
+        status: 'draining', healthStatus: 'down', server: MCP_SERVER_NAME,
+        version: pkg.version, sandbox: sandboxLabel(), draining: true,
       };
     }
 
@@ -200,10 +113,15 @@ export function createHealthEndpoint(options: HealthEndpointOptions = {}) {
     const pluginStatus = pluginItems.some((plugin) => plugin.status === 'degraded') ? 'degraded' : 'ok';
     const toolCount = mcpTools.length + (options.pluginMcpToolCount ?? 0);
     const vectorRuntime = getVectorRuntimeStatus();
-
     const serviceUptime = Math.round(uptimeSeconds * 1000) / 1000;
+    const subsystems = await buildHealthSubsystems({
+      dbStatus, vector, vectorServer, vectorRuntime, pluginStatus, pluginCount,
+      toolCount, uptimeSeconds: serviceUptime, embeddingProviders: options.embeddingProviders,
+    });
+
     return {
       status: healthRollupStatus(dbStatus, pluginStatus, vector, vectorServer, vectorRuntime),
+      healthStatus: rollupHealthStatus(subsystems),
       server: MCP_SERVER_NAME,
       version: pkg.version,
       port: Number(PORT),
@@ -226,6 +144,7 @@ export function createHealthEndpoint(options: HealthEndpointOptions = {}) {
       memory: { fanoutReranking: memoryConfidenceRerankConfig() },
       mcp: { toolCount },
       plugins: { count: pluginCount, status: pluginStatus, items: pluginItems },
+      subsystems,
     };
   }, {
     detail: {

--- a/src/routes/health/subsystems.ts
+++ b/src/routes/health/subsystems.ts
@@ -1,0 +1,148 @@
+import { DB_PATH } from '../../config.ts';
+import { sqlite } from '../../db/index.ts';
+import { resolveEmbeddingProviderType } from '../../vector/embedder-config.ts';
+import { getDetectedEmbeddingProviders, type DetectedEmbeddingProvider } from '../../vector/provider-detection.ts';
+import type { VectorBackendHealth } from '../../vector/health.ts';
+import type { VectorRuntimeStatus } from '../../vector/runtime-status.ts';
+import type { VectorServerHealth } from './vector-server.ts';
+
+type DbStatus = { status: 'connected' } | { status: 'error'; error: string };
+export type HealthStatusEnum = 'healthy' | 'starting' | 'degraded' | 'down';
+export type EmbeddingProviderDetection = { checkedAt?: string; providers: DetectedEmbeddingProvider[] };
+export type EmbeddingProviderProbe = () => Promise<EmbeddingProviderDetection>;
+
+export type HealthSubsystem = {
+  status: HealthStatusEnum;
+  label: string;
+  detail: string;
+  critical: boolean;
+  checkedAt?: string;
+  data?: Record<string, unknown>;
+};
+
+export type HealthSubsystems = Record<'backend' | 'database' | 'fts' | 'vector' | 'embedder' | 'mcp' | 'plugins', HealthSubsystem>;
+
+function err(error: unknown): string { return error instanceof Error ? error.message : String(error); }
+
+export async function buildHealthSubsystems(input: {
+  dbStatus: DbStatus;
+  vector: VectorBackendHealth;
+  vectorServer: VectorServerHealth;
+  vectorRuntime: VectorRuntimeStatus;
+  pluginStatus: 'ok' | 'degraded';
+  pluginCount: number;
+  toolCount: number;
+  uptimeSeconds: number;
+  embeddingProviders?: EmbeddingProviderProbe;
+}): Promise<HealthSubsystems> {
+  return {
+    backend: backendSubsystem(input.uptimeSeconds),
+    database: databaseSubsystem(input.dbStatus),
+    fts: ftsSubsystem(input.dbStatus),
+    vector: vectorSubsystem(input.vector, input.vectorServer, input.vectorRuntime),
+    embedder: await embedderSubsystem(input.embeddingProviders),
+    mcp: mcpSubsystem(input.toolCount),
+    plugins: pluginSubsystem(input.pluginStatus, input.pluginCount),
+  };
+}
+
+export function rollupHealthStatus(subsystems: HealthSubsystems): HealthStatusEnum {
+  const values = Object.values(subsystems);
+  if (values.some((item) => item.critical && item.status === 'down')) return 'down';
+  if (values.some((item) => item.critical && item.status === 'starting')) return 'starting';
+  if (values.some((item) => item.status !== 'healthy')) return 'degraded';
+  return 'healthy';
+}
+
+function backendSubsystem(uptimeSeconds: number): HealthSubsystem {
+  return {
+    status: 'healthy', label: 'backend reachable', critical: true,
+    detail: `HTTP API responding; uptime ${Math.round(uptimeSeconds)}s`,
+    data: { uptimeSeconds },
+  };
+}
+
+function databaseSubsystem(dbStatus: DbStatus): HealthSubsystem {
+  if (dbStatus.status !== 'connected') return down('database writable', dbStatus.error, { path: DB_PATH });
+  try {
+    sqlite.exec('SAVEPOINT oracle_health_write');
+    sqlite.prepare("UPDATE settings SET updated_at = updated_at WHERE key = '__oracle_health_probe__'").run();
+    sqlite.exec('ROLLBACK TO oracle_health_write');
+    sqlite.exec('RELEASE oracle_health_write');
+    return healthy('database writable', `SQLite connected and writable at ${DB_PATH}`, { path: DB_PATH, writable: true });
+  } catch (error) {
+    try { sqlite.exec('ROLLBACK TO oracle_health_write'); sqlite.exec('RELEASE oracle_health_write'); } catch {}
+    return down('database writable', `SQLite write probe failed: ${err(error)}`, { path: DB_PATH, writable: false });
+  }
+}
+
+function ftsSubsystem(dbStatus: DbStatus): HealthSubsystem {
+  if (dbStatus.status !== 'connected') return down('FTS healthy', 'database is unavailable');
+  try {
+    const docs = count('oracle_documents');
+    const indexed = count('oracle_fts');
+    const status = docs > 0 && indexed === 0 ? 'degraded' : 'healthy';
+    return {
+      status, label: 'FTS healthy', critical: status === 'healthy',
+      detail: docs === 0 ? 'FTS5 table ready; no documents yet' : `FTS5 indexed ${indexed}/${docs} documents`,
+      data: { indexed, documents: docs, missing: Math.max(0, docs - indexed) },
+    };
+  } catch (error) {
+    return down('FTS healthy', `FTS5 check failed: ${err(error)}`);
+  }
+}
+
+function vectorSubsystem(vector: VectorBackendHealth, server: VectorServerHealth, runtime: VectorRuntimeStatus): HealthSubsystem {
+  const configuredProxy = server.configured || runtime.vectorMode === 'proxied';
+  if (configuredProxy) {
+    if (server.status === 'ok') return healthy('vector backend', `vector proxy reachable at ${server.url ?? runtime.vectorUrl ?? 'configured proxy'}`, { ...server });
+    return down('vector backend', `configured vector proxy unreachable: ${server.error ?? server.status}`, { ...server });
+  }
+  if (runtime.vectorMode === 'disabled') return degraded('vector backend', `degraded: FTS-only (${runtime.vectorDisabledReason ?? 'vector disabled'})`);
+  if (vector.status === 'ok') return healthy('vector backend', `${vector.engines.length} vector collection(s) available`, { engines: vector.engines.length });
+  if (vector.status === 'degraded') return { status: 'degraded', label: 'vector backend', critical: false, detail: 'some vector collections are unavailable; FTS fallback remains active', data: { engines: vector.engines.length } };
+  return degraded('vector backend', `degraded: FTS-only (${vector.engines[0]?.error ?? 'no vector collections available'})`);
+}
+
+async function embedderSubsystem(read?: EmbeddingProviderProbe): Promise<HealthSubsystem> {
+  const probe = read ?? (() => getDetectedEmbeddingProviders(false, { timeoutMs: 750 }));
+  const selected = resolveEmbeddingProviderType();
+  if (selected === 'none') return degraded('embedder reachable', 'degraded: FTS-only (embedder disabled; ORACLE_EMBEDDER=none)');
+  const lookup = selected === 'local' ? 'ollama' : selected;
+  try {
+    const detection = await probe();
+    const provider = detection.providers.find((item) => item.type === lookup);
+    if (provider?.available) return healthy('embedder reachable', `${selected} available`, { provider: selected, models: provider.models });
+    return down('embedder reachable', `${selected} unavailable: ${provider?.error ?? 'not configured'}`, { provider: selected, checkedAt: detection.checkedAt });
+  } catch (error) {
+    return down('embedder reachable', `embedder probe failed: ${err(error)}`, { provider: selected });
+  }
+}
+
+function mcpSubsystem(toolCount: number): HealthSubsystem {
+  return toolCount > 0
+    ? healthy('MCP launchable', `${toolCount} MCP tool(s) registered`, { toolCount })
+    : down('MCP launchable', 'no MCP tools registered', { toolCount });
+}
+
+function pluginSubsystem(status: 'ok' | 'degraded', count: number): HealthSubsystem {
+  return status === 'ok'
+    ? healthy('plugins loaded', `${count} plugin(s) loaded`, { count })
+    : { status: 'degraded', label: 'plugins loaded', critical: false, detail: `${count} plugin(s); at least one degraded`, data: { count } };
+}
+
+function count(table: string): number {
+  return (sqlite.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get() as { count: number }).count;
+}
+
+function healthy(label: string, detail: string, data?: Record<string, unknown>): HealthSubsystem {
+  return { status: 'healthy', label, critical: true, detail, data };
+}
+
+function down(label: string, detail: string, data?: Record<string, unknown>): HealthSubsystem {
+  return { status: 'down', label, critical: true, detail, data };
+}
+
+function degraded(label: string, detail: string): HealthSubsystem {
+  return { status: 'degraded', label, critical: false, detail };
+}

--- a/tests/cli/doctor/doctor.test.ts
+++ b/tests/cli/doctor/doctor.test.ts
@@ -16,7 +16,20 @@ function startDoctorServer(options: { healthStatus?: number; statsStatus?: numbe
     fetch(req) {
       const url = new URL(req.url);
       if (url.pathname === "/api/health") {
-        return Response.json({ status: "ok", server: "doctor-test", version: "test", port: Number(url.port), oracle: "connected" }, { status: options.healthStatus ?? 200 });
+        return Response.json({
+          status: "ok",
+          healthStatus: "healthy",
+          server: "doctor-test",
+          version: "test",
+          port: Number(url.port),
+          oracle: "connected",
+          subsystems: {
+            database: { status: "healthy", label: "DB writable", critical: true, detail: "SQLite writable" },
+            fts: { status: "healthy", label: "FTS healthy", critical: true, detail: "FTS ready" },
+            vector: { status: "healthy", label: "vector backend", critical: true, detail: "vector ready" },
+            embedder: { status: "healthy", label: "embedder reachable", critical: true, detail: "embedder ready" },
+          },
+        }, { status: options.healthStatus ?? 200 });
       }
       if (url.pathname === "/api/stats") {
         return Response.json({ total: 42, vector: { enabled: true, adapter: "lancedb", count: 7, collection: "oracle_knowledge" } }, { status: options.statsStatus ?? 200 });
@@ -54,10 +67,10 @@ describe("arra doctor", () => {
 
     expect(report.ok).toBe(true);
     expect(report.resolved.source).toBe("global");
-    expect(report.checks.find(c => c.id === "server.health")?.status).toBe("pass");
-    expect(report.checks.find(c => c.id === "db.stats")?.detail).toContain("documents=42");
-    expect(report.checks.find(c => c.id === "vector.stats")?.detail).toContain("adapter=lancedb");
-    expect(report.checks.find(c => c.id === "mcp.mode")?.detail).toContain("HTTP proxy mode");
+    expect(report.checks.find(c => c.id === "backend.reachable")?.status).toBe("pass");
+    expect(report.checks.find(c => c.id === "db.writable")?.status).toBe("pass");
+    expect(report.checks.find(c => c.id === "fts.healthy")?.status).toBe("pass");
+    expect(report.checks.find(c => c.id === "vector.backend")?.detail).toContain("vector ready");
   });
 
   test("runDoctor fails when a critical server check fails", async () => {
@@ -69,7 +82,7 @@ describe("arra doctor", () => {
     });
 
     expect(report.ok).toBe(false);
-    expect(report.checks.find(c => c.id === "server.health")?.status).toBe("fail");
+    expect(report.checks.find(c => c.id === "backend.reachable")?.status).toBe("fail");
   });
 
   test("CLI --json emits structured report and exits 0 when healthy", async () => {
@@ -84,7 +97,7 @@ describe("arra doctor", () => {
     expect(result.code).toBe(0);
     const data = tryParseJson(result.stdout) as { ok: boolean; checks: Array<{ id: string; status: string }> } | null;
     expect(data?.ok).toBe(true);
-    expect(data?.checks.some(c => c.id === "vector.stats" && c.status === "pass")).toBe(true);
+    expect(data?.checks.some(c => c.id === "vector.backend" && c.status === "pass")).toBe(true);
   }, 15_000);
 
   test("CLI exits non-zero when a critical probe fails", async () => {
@@ -112,8 +125,8 @@ describe("arra doctor", () => {
 
     expect(result.code).toBe(0);
     expect(result.stdout).toContain("ARRA Doctor");
-    expect(result.stdout).toContain("✓ resolved API target");
-    expect(result.stdout).toContain("✓ server reachable");
-    expect(result.stdout).toContain("✓ vector adapter stats");
+    expect(result.stdout).toContain("PASS resolved API target");
+    expect(result.stdout).toContain("PASS backend reachable");
+    expect(result.stdout).toContain("PASS vector backend");
   }, 15_000);
 });

--- a/tests/http/health/status.test.ts
+++ b/tests/http/health/status.test.ts
@@ -20,14 +20,19 @@ test('GET /api/health reports uptime, DB, vector, MCP, and plugin status', async
   const body = await res.json() as Record<string, any>;
 
   expect(body.status).toBe('ok');
+  expect(body.healthStatus).toBe('degraded');
   expect(body.sandbox).toBe('dev');
   expect(body.uptime).toBe(42.125);
   expect(body.uptimeSeconds).toBe(42.125);
   expect(body.db).toBe('connected');
   expect(body.dbStatus).toBe('connected');
   expect(body.dbCheck).toMatchObject({ status: 'connected', path: DB_PATH });
+  expect(body.subsystems.database).toMatchObject({ status: 'healthy', label: 'database writable' });
+  expect(body.subsystems.fts).toMatchObject({ status: 'healthy', label: 'FTS healthy' });
   expect(body.vectorStatus).toBe('ok');
   expect(body.vector).toMatchObject({ status: 'ok', engines: [{ key: 'bge-m3', ok: true }] });
+  expect(body.subsystems.vector).toMatchObject({ status: 'healthy', label: 'vector backend' });
+  expect(body.subsystems.embedder.detail).toContain('FTS-only');
   expect(body.memory.fanoutReranking).toMatchObject({ strategy: 'confidence_weighted_rrf', confidenceSource: 'query-time-confidence' });
   expect(body.memory.fanoutReranking.enabled).toBe(body.memory.fanoutReranking.confidenceWeight > 0);
   expect(body.memory.fanoutReranking.confidenceWeight).toBeGreaterThanOrEqual(0);
@@ -52,10 +57,12 @@ test('GET /api/health reflects database ping result in status and db field', asy
 
   expect(res.status).toBe(200);
   expect(body.status).toBe('degraded');
+  expect(body.healthStatus).toBe('down');
   expect(body.db).toBe('error');
   expect(body.oracle).toBe('degraded');
   expect(body.dbStatus).toBe('error');
   expect(body.dbCheck).toMatchObject({ status: 'error', error: 'db offline' });
+  expect(body.subsystems.database).toMatchObject({ status: 'down', detail: 'db offline' });
 });
 
 test('GET /api/health catches dbPing exceptions and keeps response shaped', async () => {
@@ -70,9 +77,33 @@ test('GET /api/health catches dbPing exceptions and keeps response shaped', asyn
 
   expect(res.status).toBe(200);
   expect(body.status).toBe('degraded');
+  expect(body.healthStatus).toBe('down');
   expect(body.uptimeSeconds).toBe(0.333);
   expect(body.db).toBe('error');
   expect(body.oracle).toBe('degraded');
   expect(body.dbCheck).toMatchObject({ status: 'error', error: 'db locked' });
   expect(body.vectorStatus).toBe('ok');
+});
+
+
+test('GET /api/health reports healthy enum when every subsystem is available', async () => {
+  const previous = process.env.ORACLE_EMBEDDER;
+  process.env.ORACLE_EMBEDDER = 'ollama';
+  try {
+    const app = createHealthRoutes({
+      pluginCount: 1,
+      uptimeSeconds: () => 2,
+      vectorHealth: async () => ({ status: 'ok', engines: [{ key: 'bge', model: 'bge', collection: 'docs', ok: true, count: 1 }], checked_at: 'now' }),
+      vectorServerHealth: async () => ({ configured: false, status: 'unconfigured' }),
+      embeddingProviders: async () => ({ checkedAt: 'now', providers: [{ type: 'ollama', available: true, configured: true, source: 'probe', models: ['bge'], capabilities: ['embed'] }] }),
+    });
+    const res = await app.handle(new Request('http://local/api/health'));
+    const body = await res.json() as Record<string, any>;
+    expect(body.healthStatus).toBe('healthy');
+    expect(body.subsystems.embedder).toMatchObject({ status: 'healthy', label: 'embedder reachable' });
+    expect(body.subsystems.mcp.status).toBe('healthy');
+  } finally {
+    if (previous === undefined) delete process.env.ORACLE_EMBEDDER;
+    else process.env.ORACLE_EMBEDDER = previous;
+  }
 });


### PR DESCRIPTION
## Summary
- Extend `arra doctor` into the “is it working?” verifier with PASS/WARN/FAIL checks for backend reachability, DB writability, FTS, vector fallback, embedder reachability, and MCP launchability.
- Enrich `/api/health` with backward-compatible `status` plus new `healthStatus` (`healthy|starting|degraded|down`) and per-subsystem detail for UI heartbeat rendering.
- Wire Simple Mode health mapping to prefer `healthStatus`, while preserving legacy `status: ok` behavior.

## Validation
```bash
bunx tsc --noEmit
bun test tests/http/health tests/cli/doctor tests/cli/help frontend/src/components/simple/__tests__/healthState.test.ts
bun test --isolate tests/docs/readme-claims.test.ts
```
