### PR TITLE
fix(cors): allow hosted Studio origins

### DIFF
--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -13,6 +13,8 @@ const DEFAULT_ORIGINS = [
   'http://localhost:4321',
   'http://127.0.0.1:4321',
   'https://god.buildwithoracle.com',
+  'https://arra-oracle-studio.laris.workers.dev',
+  'https://studio.buildwithoracle.com',
 ] as const;
 const ALLOWED_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'] as const;
 const ALLOWED_HEADERS = [

--- a/tests/http/cors/origins.test.ts
+++ b/tests/http/cors/origins.test.ts
@@ -34,6 +34,23 @@ describe('CORS middleware origins', () => {
     expect(denied.headers.get('Access-Control-Allow-Origin')).toBeNull();
   });
 
+
+
+  test('allows hosted Studio origins by default for localhost backends', async () => {
+    delete process.env.ARRA_CORS_ORIGINS;
+
+    for (const origin of [
+      'https://arra-oracle-studio.laris.workers.dev',
+      'https://studio.buildwithoracle.com',
+    ]) {
+      const res = await request('/api/ping', { headers: { origin } });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe(origin);
+      expect(res.headers.get('Access-Control-Allow-Credentials')).toBe('true');
+    }
+  });
+
   test('reflects configured origins and rejects unlisted origins', async () => {
     process.env.ARRA_CORS_ORIGINS = 'https://studio.example, https://admin.example';
 


### PR DESCRIPTION
## Summary
- Added hosted Studio origins to the default CORS allowlist alongside `god.buildwithoracle.com`.
- Covered `https://arra-oracle-studio.laris.workers.dev` and `https://studio.buildwithoracle.com` default-origin echo behavior.

## Tests
```bash
bun test --isolate tests/http/cors/
bunx tsc --noEmit
wc -l src/middleware/cors.ts tests/http/cors/origins.test.ts
```
