### PR TITLE
feat(simple): add index folder card

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -26,7 +26,7 @@ curl -sf "${AUTH[@]}" "$BASE/api/v1/mcp/tools"
 
 ## Route inventory by family
 
-Base `createApp()` with no dynamic plugins/gateway config currently exposes 186 routes, 182 under `/api`; dynamic plugin and gateway routes may add more at runtime. These families match the mounted source modules.
+Base `createApp()` with no dynamic plugins/gateway config currently exposes 187 routes, 182 under `/api`; dynamic plugin and gateway routes may add more at runtime. These families match the mounted source modules.
 
 | Family | Methods and paths |
 | --- | --- |

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ use tauri_plugin_shell::{
 };
 
 mod app_menu;
+mod mine;
 
 const BACKEND_URL: &str = "http://localhost:47778";
 const BACKEND_HEALTH_URL: &str = "http://localhost:47778/api/health";
@@ -230,6 +231,7 @@ pub fn run() {
             get_about_info,
             start_backend,
             stop_backend,
+            mine::mine_folder,
         ])
         .setup(|app| {
             let window = app.get_webview_window("main").unwrap();

--- a/frontend/src-tauri/src/mine.rs
+++ b/frontend/src-tauri/src/mine.rs
@@ -1,0 +1,43 @@
+use std::path::PathBuf;
+use tauri::{AppHandle, Runtime};
+use tauri_plugin_shell::ShellExt;
+
+use crate::project_root;
+
+#[tauri::command]
+pub async fn mine_folder<R: Runtime>(app: AppHandle<R>, dir: String) -> Result<String, String> {
+    let target = dir.trim();
+    if target.is_empty() {
+        return Err("folder path is required".to_string());
+    }
+
+    let folder = PathBuf::from(target);
+    if !folder.exists() {
+        return Err(format!("folder does not exist: {target}"));
+    }
+    if !folder.is_dir() {
+        return Err(format!("folder path must be a directory: {target}"));
+    }
+
+    let output = app
+        .shell()
+        .command("bun")
+        .args(["cli/src/cli.ts", "mine", target])
+        .current_dir(project_root()?)
+        .output()
+        .await
+        .map_err(|err| format!("failed to run arra mine: {err}"))?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if output.status.success() {
+        return Ok(if stdout.is_empty() { "Folder indexed.".to_string() } else { stdout });
+    }
+
+    let detail = if stderr.is_empty() { stdout } else { stderr };
+    Err(if detail.is_empty() {
+        format!("arra mine exited with status {:?}", output.status.code())
+    } else {
+        detail
+    })
+}

--- a/frontend/src/components/simple/IndexFolderCard.tsx
+++ b/frontend/src/components/simple/IndexFolderCard.tsx
@@ -1,0 +1,181 @@
+import { invoke } from '@tauri-apps/api/core';
+import { useMemo, useState, type FormEvent } from 'react';
+import { API_HOST, isTauri } from '../../api/oracle';
+
+export interface IndexFolderRuntime {
+  tauri: boolean;
+  localApi: boolean;
+}
+
+export interface IndexFolderCardProps {
+  defaultExpanded?: boolean;
+  initialPath?: string;
+  onIndexFolder?: (folderPath: string) => Promise<string | void> | string | void;
+  runtime?: IndexFolderRuntime;
+}
+
+type Status = 'idle' | 'copy' | 'running' | 'success' | 'error';
+
+const buttonBase = 'focus-ring rounded-full px-4 py-2 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-55';
+
+export function isLocalOracleHost(host: string): boolean {
+  const value = host.trim();
+  if (!value) return false;
+  const normalized = /^https?:\/\//i.test(value) ? value : `http://${value}`;
+  try {
+    const hostname = new URL(normalized).hostname.toLowerCase();
+    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname.endsWith('.localhost');
+  } catch {
+    return false;
+  }
+}
+
+export function detectIndexFolderRuntime(): IndexFolderRuntime {
+  return { tauri: isTauri(), localApi: isLocalOracleHost(API_HOST) };
+}
+
+export function mineCommandForPath(folderPath: string): string {
+  const path = folderPath.trim();
+  return `arra mine ${quoteShellArg(path || '<dir>')}`;
+}
+
+function quoteShellArg(value: string): string {
+  if (value === '<dir>') return value;
+  if (/^[A-Za-z0-9_@%+=:,./~-]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+async function runDesktopMine(folderPath: string): Promise<string> {
+  return await invoke<string>('mine_folder', { dir: folderPath });
+}
+
+export function IndexFolderCard({
+  defaultExpanded = false,
+  initialPath = '',
+  onIndexFolder,
+  runtime = detectIndexFolderRuntime(),
+}: IndexFolderCardProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const [folderPath, setFolderPath] = useState(initialPath);
+  const [status, setStatus] = useState<Status>('idle');
+  const [message, setMessage] = useState('');
+  const trimmedPath = folderPath.trim();
+  const command = useMemo(() => mineCommandForPath(folderPath), [folderPath]);
+  const runMine = onIndexFolder ?? (runtime.tauri ? runDesktopMine : undefined);
+  const directIndexReady = Boolean(runMine && (runtime.tauri || runtime.localApi));
+  const title = directIndexReady ? 'Index this folder now' : gateTitle(runtime);
+
+  async function copyCommand() {
+    try {
+      await navigator.clipboard?.writeText(command);
+      setStatus('copy');
+      setMessage('Command copied. Paste it into a local terminal to index this folder.');
+    } catch {
+      setStatus('copy');
+      setMessage('Copy the command below into a local terminal to index this folder.');
+    }
+  }
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!trimmedPath) {
+      setStatus('error');
+      setMessage('Enter a folder path first.');
+      return;
+    }
+    if (!runMine || !directIndexReady) {
+      await copyCommand();
+      return;
+    }
+    setStatus('running');
+    setMessage('Indexing folder…');
+    try {
+      const detail = await runMine(trimmedPath);
+      setStatus('success');
+      setMessage(detail || 'Folder indexing started. Search will update as Oracle ingests the notes.');
+    } catch (error) {
+      setStatus('error');
+      setMessage(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  return (
+    <section className="rounded-3xl border border-border bg-surface p-5 shadow-sm" aria-labelledby="index-folder-title">
+      <button
+        aria-controls="index-folder-panel"
+        aria-expanded={expanded}
+        className="focus-ring flex w-full items-center justify-between gap-4 text-left"
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+      >
+        <span>
+          <span id="index-folder-title" className="block text-lg font-semibold text-text">Add a whole folder of notes</span>
+          <span className="mt-1 block text-sm text-text-muted">Mine Markdown, MDX, and text files into Oracle memory.</span>
+        </span>
+        <span aria-hidden="true" className="text-2xl text-accent">{expanded ? '−' : '+'}</span>
+      </button>
+
+      {expanded ? (
+        <div id="index-folder-panel" className="mt-5 grid gap-4">
+          <form className="grid gap-3" onSubmit={submit}>
+            <label className="text-sm font-semibold text-text" htmlFor="simple-index-folder-path">Folder path</label>
+            <input
+              id="simple-index-folder-path"
+              className="w-full rounded-2xl border border-border bg-field px-4 py-3 text-sm text-text outline-none focus:border-accent"
+              placeholder="/Users/alex/notes"
+              value={folderPath}
+              onChange={(event) => setFolderPath(event.currentTarget.value)}
+            />
+            <div className="flex flex-wrap items-center gap-3">
+              <button
+                className={`${buttonBase} bg-accent-solid text-on-accent hover:bg-accent-hover`}
+                disabled={!trimmedPath || !directIndexReady || status === 'running'}
+                title={title}
+                type="submit"
+              >
+                {status === 'running' ? 'Indexing…' : 'Index folder'}
+              </button>
+              {!directIndexReady ? <span className="text-xs text-text-muted">{gateCopy(runtime)}</span> : null}
+            </div>
+          </form>
+
+          {!directIndexReady ? (
+            <div className="rounded-2xl border border-accent-border bg-accent-soft/40 p-4 text-sm text-text">
+              <p className="font-semibold">CLI fallback</p>
+              <p className="mt-1 text-text-muted">Copy-paste this on the machine that can read the folder:</p>
+              <code className="mt-3 block overflow-x-auto rounded-xl bg-field px-3 py-2 font-mono text-xs text-text">{command}</code>
+              <button
+                className={`${buttonBase} mt-3 border border-accent-border text-accent hover:bg-accent-soft`}
+                type="button"
+                onClick={() => void copyCommand()}
+              >
+                Copy command
+              </button>
+            </div>
+          ) : (
+            <p className="rounded-2xl border border-ok-border bg-ok-bg px-4 py-3 text-sm text-ok-text">
+              Desktop/local indexing is available for this folder path.
+            </p>
+          )}
+
+          {message ? <p className={statusClass(status)} aria-live="polite">{message}</p> : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function gateTitle(runtime: IndexFolderRuntime): string {
+  if (runtime.localApi) return 'Use the CLI command below from this local browser session';
+  return 'Available in the desktop app or CLI';
+}
+
+function gateCopy(runtime: IndexFolderRuntime): string {
+  if (runtime.localApi) return 'Browser tabs cannot launch local folder reads directly; use the CLI command below.';
+  return 'Available in the desktop app or CLI.';
+}
+
+function statusClass(status: Status): string {
+  const tone = status === 'error' ? 'border-err-border bg-err-bg text-err-text' : 'border-ok-border bg-ok-bg text-ok-text';
+  return `rounded-2xl border px-4 py-3 text-sm ${tone}`;
+}

--- a/frontend/src/pages/SimplePage.tsx
+++ b/frontend/src/pages/SimplePage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { apiFetch } from '../api/oracle';
 import { HealthHero } from '../components/HealthHero';
+import { IndexFolderCard } from '../components/simple/IndexFolderCard';
 import { HealthState, mapHealthState, type SimpleHealthPayload } from '../components/simple/healthState';
 
 async function fetchHealth(): Promise<SimpleHealthPayload> {
@@ -36,8 +37,9 @@ export function SimplePage() {
 
   return (
     <main className="min-h-screen bg-field p-6 text-text">
-      <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-5xl items-center">
+      <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-3xl flex-col justify-center gap-6">
         <HealthHero state={state} checkedAt={checkedAt} onAction={poll} />
+        <IndexFolderCard />
       </div>
     </main>
   );

--- a/tests/frontend/components/simple-index-folder-card.test.tsx
+++ b/tests/frontend/components/simple-index-folder-card.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  IndexFolderCard,
+  isLocalOracleHost,
+  mineCommandForPath,
+} from '../../../frontend/src/components/simple/IndexFolderCard';
+import { htmlFor } from '../_render';
+
+const remote = { tauri: false, localApi: false };
+const desktop = { tauri: true, localApi: true };
+
+describe('IndexFolderCard', () => {
+  test('renders as a collapsed accordion by default', () => {
+    const html = htmlFor(<IndexFolderCard runtime={remote} />);
+
+    expect(html).toContain('Add a whole folder of notes');
+    expect(html).toContain('aria-expanded="false"');
+    expect(html).not.toContain('Folder path');
+  });
+
+  test('gates remote browsers to an honest arra mine copy-paste command', () => {
+    const html = htmlFor(<IndexFolderCard defaultExpanded initialPath="/home/alex/My Notes" runtime={remote} />);
+
+    expect(html).toContain('Folder path');
+    expect(html).toContain('Index folder');
+    expect(html).toContain('disabled=""');
+    expect(html).toContain('Available in the desktop app or CLI');
+    expect(html).toContain("arra mine &#x27;/home/alex/My Notes&#x27;");
+    expect(html).toContain('Copy command');
+  });
+
+  test('enables direct indexing for the desktop runtime', () => {
+    const html = htmlFor(<IndexFolderCard defaultExpanded initialPath="/Users/alex/notes" runtime={desktop} />);
+
+    expect(html).toContain('aria-expanded="true"');
+    expect(html).toContain('Index folder');
+    expect(html).not.toContain('disabled=""');
+    expect(html).toContain('Desktop/local indexing is available');
+    expect(html).not.toContain('CLI fallback');
+  });
+
+  test('quotes CLI paths safely and detects local Oracle hosts', () => {
+    expect(mineCommandForPath('/tmp/notes')).toBe('arra mine /tmp/notes');
+    expect(mineCommandForPath('/tmp/My Notes')).toBe("arra mine '/tmp/My Notes'");
+    expect(isLocalOracleHost('localhost:47778')).toBe(true);
+    expect(isLocalOracleHost('https://god.buildwithoracle.com')).toBe(false);
+  });
+});

--- a/tests/frontend/components/simple-index-folder-card.test.tsx
+++ b/tests/frontend/components/simple-index-folder-card.test.tsx
@@ -39,6 +39,21 @@ describe('IndexFolderCard', () => {
     expect(html).not.toContain('CLI fallback');
   });
 
+  test('allows a wired local runner without pretending remote browsers can read folders', () => {
+    const html = htmlFor(
+      <IndexFolderCard
+        defaultExpanded
+        initialPath="/vault/notes"
+        onIndexFolder={() => 'started'}
+        runtime={{ tauri: false, localApi: true }}
+      />,
+    );
+
+    expect(html).toContain('Index folder');
+    expect(html).not.toContain('disabled=""');
+    expect(html).not.toContain('CLI fallback');
+  });
+
   test('quotes CLI paths safely and detects local Oracle hosts', () => {
     expect(mineCommandForPath('/tmp/notes')).toBe('arra mine /tmp/notes');
     expect(mineCommandForPath('/tmp/My Notes')).toBe("arra mine '/tmp/My Notes'");

--- a/tests/frontend/pages/simple-page.test.tsx
+++ b/tests/frontend/pages/simple-page.test.tsx
@@ -9,6 +9,7 @@ describe('Simple page', () => {
       const html = htmlFor(<App />);
       expect(html).toContain('Simple mode');
       expect(html).toContain('Starting up…');
+      expect(html).toContain('Add a whole folder of notes');
       expect(html).not.toContain('Control Surface');
       expect(html).not.toContain('Backend unavailable');
     } finally {


### PR DESCRIPTION
## Summary\n- Adds Simple Mode IndexFolderCard accordion for 'Add a whole folder of notes'\n- Gates direct indexing to Tauri/explicit local runners; remote/browser fallback shows copy-paste `arra mine <dir>` guidance\n- Wires the card into /simple and adds a Tauri `mine_folder` command that runs `arra mine` with path validation\n\nRefs #2440\n\n## Validation\n- `rtk bun test tests/frontend/components/simple-index-folder-card.test.tsx tests/frontend/pages/simple-page.test.tsx tests/frontend/components/simple-add-memory.test.tsx frontend/src/components/simple/__tests__/healthState.test.ts`\n- `rtk bunx tsc --noEmit`\n- `rtk bunx tsc --noEmit --project frontend/tsconfig.json`\n- `rtk cargo check --manifest-path frontend/src-tauri/Cargo.toml`