### PR TITLE
docs: refresh API route count after Simple Mode search

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -26,7 +26,7 @@ curl -sf "${AUTH[@]}" "$BASE/api/v1/mcp/tools"
 
 ## Route inventory by family
 
-Base `createApp()` with no dynamic plugins/gateway config currently exposes 186 routes, 182 under `/api`; dynamic plugin and gateway routes may add more at runtime. These families match the mounted source modules.
+Base `createApp()` with no dynamic plugins/gateway config currently exposes 187 routes, 182 under `/api`; dynamic plugin and gateway routes may add more at runtime. These families match the mounted source modules.
 
 | Family | Methods and paths |
 | --- | --- |


### PR DESCRIPTION
## Summary
- Refreshes the docs/API.md base route-count claim after #2447/#2450 so the docs integrity gate matches the current Elysia app.

Refs #2447.

## Validation
- `bunx tsc --noEmit`
- `bun test --isolate tests/docs/readme-claims.test.ts`
- `bun test tests/frontend/components/simple-search-contract.test.tsx tests/frontend/components/simple-result-card-render.test.tsx tests/frontend/pages/simple-page.test.tsx frontend/src/components/simple/__tests__/healthState.test.ts tests/frontend/components/health-hero.test.tsx tests/frontend/components/simple-add-memory.test.tsx tests/docs/simple-mode-docs.test.ts tests/integration/simple-flow/full-flow.test.ts`
- Changed file line count <= 250.
