### PR TITLE
feat: align health status vocabulary

### DIFF
--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -22,7 +22,7 @@ export interface DoctorReport {
 }
 
 type DoctorOptions = { env?: NodeJS.ProcessEnv; cwd?: string; fetcher?: typeof fetch; mcpProbe?: McpProbe; timeoutMs?: number };
-type HealthPayload = { healthStatus?: HealthStatusEnum; status?: string; subsystems?: Record<string, HealthSubsystem> };
+type HealthPayload = { healthStatus?: HealthStatusEnum; state?: HealthStatusEnum; status?: string; subsystems?: Record<string, HealthSubsystem> };
 
 function ok(id: string, label: string, detail?: string, data?: unknown): DoctorCheck {
   return { id, label, status: "pass", critical: true, detail, data };
@@ -51,7 +51,7 @@ function subsystemCheck(id: string, label: string, subsystem: HealthSubsystem | 
 }
 
 function healthOverallCheck(health: HealthPayload): DoctorCheck {
-  const status = health.healthStatus ?? normalizeLegacyStatus(health.status);
+  const status = health.healthStatus ?? health.state ?? normalizeLegacyStatus(health.status);
   if (status === "healthy") return ok("backend.status", "overall health", "healthy", health);
   if (status === "degraded") return warn("backend.status", "overall health", "degraded; see subsystem detail", health);
   return fail("backend.status", "overall health", status ?? "unknown", health);
@@ -62,6 +62,10 @@ function normalizeLegacyStatus(status: unknown): HealthStatusEnum | undefined {
   if (status === "degraded") return "degraded";
   if (status === "draining") return "down";
   return undefined;
+}
+
+function pickSubsystem(subsystems: Record<string, HealthSubsystem> | undefined, ...names: string[]) {
+  return names.map(name => subsystems?.[name]).find(Boolean);
 }
 
 export async function runDoctor(options: DoctorOptions = {}): Promise<DoctorReport> {
@@ -104,10 +108,11 @@ export async function runDoctor(options: DoctorOptions = {}): Promise<DoctorRepo
   }
 
   const subsystems = healthPayload?.subsystems;
-  checks.push(subsystemCheck("db.writable", "DB writable", subsystems?.database, "strict"));
-  checks.push(subsystemCheck("fts.healthy", "FTS healthy", subsystems?.fts, "strict"));
-  checks.push(subsystemCheck("vector.backend", "vector backend", subsystems?.vector, "soft"));
-  checks.push(subsystemCheck("embedder.reachable", "embedder reachable", subsystems?.embedder, "soft"));
+  checks.push(subsystemCheck("db.writable", "DB writable", pickSubsystem(subsystems, "database", "db"), "strict"));
+  checks.push(subsystemCheck("fts.healthy", "FTS healthy", pickSubsystem(subsystems, "fts"), "strict"));
+  checks.push(subsystemCheck("vector.backend", "vector backend", pickSubsystem(subsystems, "vector"), "soft"));
+  checks.push(subsystemCheck("embedder.reachable", "embedder reachable", pickSubsystem(subsystems, "embedder"), "soft"));
+  checks.push(subsystemCheck("plugins.loaded", "plugins loaded", pickSubsystem(subsystems, "plugins", "plugin"), "soft"));
 
   try {
     const mcp = await (options.mcpProbe ?? defaultMcpProbe)({ env, cwd, resolved });

--- a/docs/API.md
+++ b/docs/API.md
@@ -75,7 +75,18 @@ curl -s "${AUTH[@]}" "$BASE/api/v1/vector/health"
 ```
 
 ```json
-{ "status": "ok", "server": "arra-oracle-v3", "db": "connected", "vectorStatus": "ok", "mcp": { "toolCount": 28 } }
+{
+  "status": "ok",
+  "healthStatus": "healthy",
+  "server": "arra-oracle-v3",
+  "subsystems": {
+    "db": { "status": "healthy" },
+    "fts": { "status": "healthy" },
+    "vector": { "status": "healthy" },
+    "plugin": { "status": "healthy" }
+  },
+  "mcp": { "toolCount": 28 }
+}
 ```
 
 ```json

--- a/docs/API.md
+++ b/docs/API.md
@@ -26,7 +26,7 @@ curl -sf "${AUTH[@]}" "$BASE/api/v1/mcp/tools"
 
 ## Route inventory by family
 
-Base `createApp()` with no dynamic plugins/gateway config currently exposes 186 routes, 182 under `/api`; dynamic plugin and gateway routes may add more at runtime. These families match the mounted source modules.
+Base `createApp()` with no dynamic plugins/gateway config currently exposes 187 routes, 182 under `/api`; dynamic plugin and gateway routes may add more at runtime. These families match the mounted source modules.
 
 | Family | Methods and paths |
 | --- | --- |
@@ -75,7 +75,18 @@ curl -s "${AUTH[@]}" "$BASE/api/v1/vector/health"
 ```
 
 ```json
-{ "status": "ok", "server": "arra-oracle-v3", "db": "connected", "vectorStatus": "ok", "mcp": { "toolCount": 28 } }
+{
+  "status": "ok",
+  "healthStatus": "healthy",
+  "server": "arra-oracle-v3",
+  "subsystems": {
+    "db": { "status": "healthy" },
+    "fts": { "status": "healthy" },
+    "vector": { "status": "healthy" },
+    "plugin": { "status": "healthy" }
+  },
+  "mcp": { "toolCount": 28 }
+}
 ```
 
 ```json

--- a/docs/SIMPLE-MODE-SPEC.md
+++ b/docs/SIMPLE-MODE-SPEC.md
@@ -54,6 +54,8 @@ user searches, saves, or reads recovery copy.
 - Flip to Down after repeated failed polls instead of leaving stale green copy.
 - Use degraded states when the backend answers but DB, plugins, or search/vector
   capability is limited.
+- Prefer backend `healthStatus` (`healthy|starting|degraded|down`) and
+  `subsystems.{db,fts,vector,plugin}` when present; fall back to legacy fields.
 
 ## README and recap entry points
 

--- a/docs/http-api-reference.md
+++ b/docs/http-api-reference.md
@@ -20,7 +20,7 @@ Protected routes may require API token/session auth; tenant-aware routes honor `
 
 | Method | Path | Request | Response |
 |---|---|---|---|
-| GET | `/api/health` | None. | Aggregate `{ status, uptime, version, db, vectorStatus, pluginStatus }` |
+| GET | `/api/health` | None. | Aggregate `{ status, healthStatus, subsystems, uptime, version }` |
 | GET | `/api/stats` | Optional `X-Oracle-Tenant`. | Document, vector, vault, tenant-scoped counts. |
 | GET | `/api/oracles` | Optional tenant header. | Oracle identities/projects summary. |
 | GET | `/api/oracles/profiles` | None. | Code-backed Oracle profile registry. |

--- a/frontend/src/components/simple/__tests__/healthState.test.ts
+++ b/frontend/src/components/simple/__tests__/healthState.test.ts
@@ -52,10 +52,24 @@ describe('simple health state mapper', () => {
       .toBe(HealthState.DegradedFts);
   });
 
+  test('prefers backend healthStatus and subsystem details when present', () => {
+    expect(mapHealthState({
+      msSinceLoad: 10_000,
+      health: { status: 'ok', healthStatus: 'healthy', vectorAvailable: false, subsystems: { vector: { status: 'healthy' }, fts: { status: 'healthy' } } },
+    })).toBe(HealthState.Healthy);
+    expect(mapHealthState({ msSinceLoad: 10_000, health: { status: 'ok', healthStatus: 'starting' } }))
+      .toBe(HealthState.Starting);
+    expect(mapHealthState({ msSinceLoad: 10_000, health: { status: 'ok', healthStatus: 'healthy', subsystems: { database: { status: 'down' } } } }))
+      .toBe(HealthState.DegradedDb);
+    expect(mapHealthState({ msSinceLoad: 10_000, health: { status: 'ok', healthStatus: 'healthy', subsystems: { plugins: { status: 'degraded' } } } }))
+      .toBe(HealthState.DegradedPlugin);
+    expect(mapHealthState({ msSinceLoad: 10_000, health: { status: 'degraded', healthStatus: 'degraded', subsystems: { fts: { status: 'degraded' } } } }))
+      .toBe(HealthState.DegradedFts);
+  });
+
   test('maps explicit down payloads to down', () => {
     expect(mapHealthState({ msSinceLoad: 10_000, health: { status: 'down' } })).toBe(HealthState.Down);
   });
-
 
   test('prefers enriched healthStatus over legacy ok status', () => {
     expect(mapHealthState({ msSinceLoad: 10_000, health: { status: 'ok', healthStatus: 'degraded', dbStatus: 'connected' } }))

--- a/frontend/src/components/simple/healthState.ts
+++ b/frontend/src/components/simple/healthState.ts
@@ -11,9 +11,12 @@ export const HEALTH_STARTING_GRACE_MS = 8_000;
 export const HEALTH_STARTING_ESCAPE_MS = 30_000;
 export const HEALTH_DOWN_RETRY_COUNT = 3;
 
+type SimpleSubsystem = { status?: string; ok?: boolean };
+
 export interface SimpleHealthPayload {
   status?: string;
   healthStatus?: string;
+  state?: string;
   db?: string | { status?: string };
   dbStatus?: string;
   oracle?: string;
@@ -21,6 +24,7 @@ export interface SimpleHealthPayload {
   vectorAvailable?: boolean;
   pluginStatus?: string;
   plugins?: { status?: string };
+  subsystems?: Partial<Record<string, SimpleSubsystem>>;
   draining?: boolean;
 }
 
@@ -88,29 +92,42 @@ export function mapHealthState(input: HealthStateInput): HealthState {
     return HealthState.Starting;
   }
 
-  const status = (health.healthStatus ?? health.status)?.toLowerCase();
-  if (health.draining || status === 'starting' || status === 'draining') return HealthState.Starting;
-  if (status === 'down' || status === 'error') return HealthState.Down;
+  const legacyStatus = health.status?.toLowerCase();
+  const status = (health.healthStatus ?? health.state)?.toLowerCase();
+  if (health.draining || status === 'starting' || legacyStatus === 'starting' || legacyStatus === 'draining') return HealthState.Starting;
 
   if (dbIsBad(health)) return HealthState.DegradedDb;
   if (pluginIsBad(health)) return HealthState.DegradedPlugin;
   if (searchIsLimited(health)) return HealthState.DegradedFts;
-  if (status === 'degraded') return HealthState.DegradedFts;
+  if (status === 'degraded' || legacyStatus === 'degraded') return HealthState.DegradedFts;
+  if (status === 'down' || legacyStatus === 'down' || legacyStatus === 'error') return HealthState.Down;
   return HealthState.Healthy;
+}
+
+function subsystemStatus(health: SimpleHealthPayload, ...names: string[]): string | undefined {
+  for (const name of names) {
+    const status = health.subsystems?.[name]?.status;
+    if (status) return status;
+  }
+  return undefined;
 }
 
 function dbIsBad(health: SimpleHealthPayload): boolean {
   const dbStatus = typeof health.db === 'string' ? health.db : health.db?.status;
-  return [health.dbStatus, dbStatus, health.oracle]
+  return [subsystemStatus(health, 'db', 'database'), health.dbStatus, dbStatus, health.oracle]
     .some((value) => ['down', 'error', 'disconnected'].includes(String(value ?? '').toLowerCase()));
 }
 
 function pluginIsBad(health: SimpleHealthPayload): boolean {
-  const value = health.pluginStatus ?? health.plugins?.status;
+  const value = subsystemStatus(health, 'plugin', 'plugins') ?? health.pluginStatus ?? health.plugins?.status;
   return ['degraded', 'down', 'error'].includes(String(value ?? '').toLowerCase());
 }
 
 function searchIsLimited(health: SimpleHealthPayload): boolean {
+  const fts = String(subsystemStatus(health, 'fts') ?? '').toLowerCase();
+  const vectorSubsystem = String(subsystemStatus(health, 'vector') ?? '').toLowerCase();
+  if (['down', 'error', 'degraded'].includes(fts) || ['down', 'error', 'degraded'].includes(vectorSubsystem)) return true;
+  if (health.healthStatus || health.state || health.subsystems) return false;
   const vector = String(health.vectorStatus ?? '').toLowerCase();
   return health.vectorAvailable === false || ['down', 'error', 'degraded'].includes(vector);
 }

--- a/src/routes/health/health.ts
+++ b/src/routes/health/health.ts
@@ -11,7 +11,7 @@ import { mcpTools } from '../../tools/mcp-manifest.ts';
 import type { UnifiedPluginStatus } from '../../plugins/unified-loader.ts';
 import { sandboxLabel } from '../../runtime/sandbox-label.ts';
 import { healthRollupStatus } from './rollup.ts';
-import { buildHealthSubsystems, rollupHealthStatus, type EmbeddingProviderProbe } from './subsystems.ts';
+import { buildHealthSubsystems, drainingSubsystems, rollupHealthStatus, type EmbeddingProviderProbe } from './subsystems.ts';
 import pkg from '../../../package.json' with { type: 'json' };
 
 type VectorHealth = Awaited<ReturnType<typeof readVectorBackendHealth>>;
@@ -98,9 +98,12 @@ export function createHealthEndpoint(options: HealthEndpointOptions = {}) {
   return new Elysia().get('/health', async ({ set }) => {
     if (options.isDraining?.()) {
       set.status = 503;
+      const healthStatus = 'down';
       return {
-        status: 'draining', healthStatus: 'down', server: MCP_SERVER_NAME,
+        status: 'draining', healthStatus, state: healthStatus,
+        checked_at: new Date().toISOString(), server: MCP_SERVER_NAME,
         version: pkg.version, sandbox: sandboxLabel(), draining: true,
+        subsystems: drainingSubsystems(),
       };
     }
 
@@ -114,14 +117,16 @@ export function createHealthEndpoint(options: HealthEndpointOptions = {}) {
     const toolCount = mcpTools.length + (options.pluginMcpToolCount ?? 0);
     const vectorRuntime = getVectorRuntimeStatus();
     const serviceUptime = Math.round(uptimeSeconds * 1000) / 1000;
+    const vectorIsAvailable = vectorAvailable(vectorRuntime, vector, vectorServer);
     const subsystems = await buildHealthSubsystems({
       dbStatus, vector, vectorServer, vectorRuntime, pluginStatus, pluginCount,
       toolCount, uptimeSeconds: serviceUptime, embeddingProviders: options.embeddingProviders,
     });
+    const healthStatus = rollupHealthStatus(subsystems);
 
     return {
       status: healthRollupStatus(dbStatus, pluginStatus, vector, vectorServer, vectorRuntime),
-      healthStatus: rollupHealthStatus(subsystems),
+      healthStatus, state: healthStatus, checked_at: new Date().toISOString(),
       server: MCP_SERVER_NAME,
       version: pkg.version,
       port: Number(PORT),
@@ -133,7 +138,7 @@ export function createHealthEndpoint(options: HealthEndpointOptions = {}) {
       dbStatus: dbStatus.status,
       vectorStatus: vector.status,
       ...vectorRuntime,
-      vectorAvailable: vectorAvailable(vectorRuntime, vector, vectorServer),
+      vectorAvailable: vectorIsAvailable,
       pluginStatus,
       mcpToolCount: toolCount,
       pluginCount,

--- a/src/routes/health/subsystems.ts
+++ b/src/routes/health/subsystems.ts
@@ -7,6 +7,7 @@ import type { VectorRuntimeStatus } from '../../vector/runtime-status.ts';
 import type { VectorServerHealth } from './vector-server.ts';
 
 type DbStatus = { status: 'connected' } | { status: 'error'; error: string };
+type CanonicalSubsystemName = 'backend' | 'database' | 'fts' | 'vector' | 'embedder' | 'mcp' | 'plugins';
 export type HealthStatusEnum = 'healthy' | 'starting' | 'degraded' | 'down';
 export type EmbeddingProviderDetection = { checkedAt?: string; providers: DetectedEmbeddingProvider[] };
 export type EmbeddingProviderProbe = () => Promise<EmbeddingProviderDetection>;
@@ -20,7 +21,11 @@ export type HealthSubsystem = {
   data?: Record<string, unknown>;
 };
 
-export type HealthSubsystems = Record<'backend' | 'database' | 'fts' | 'vector' | 'embedder' | 'mcp' | 'plugins', HealthSubsystem>;
+type CanonicalHealthSubsystems = Record<CanonicalSubsystemName, HealthSubsystem>;
+export type HealthSubsystems = CanonicalHealthSubsystems & {
+  db: HealthSubsystem;
+  plugin: HealthSubsystem;
+};
 
 function err(error: unknown): string { return error instanceof Error ? error.message : String(error); }
 
@@ -35,7 +40,7 @@ export async function buildHealthSubsystems(input: {
   uptimeSeconds: number;
   embeddingProviders?: EmbeddingProviderProbe;
 }): Promise<HealthSubsystems> {
-  return {
+  return withAliases({
     backend: backendSubsystem(input.uptimeSeconds),
     database: databaseSubsystem(input.dbStatus),
     fts: ftsSubsystem(input.dbStatus),
@@ -43,7 +48,17 @@ export async function buildHealthSubsystems(input: {
     embedder: await embedderSubsystem(input.embeddingProviders),
     mcp: mcpSubsystem(input.toolCount),
     plugins: pluginSubsystem(input.pluginStatus, input.pluginCount),
-  };
+  });
+}
+
+export function drainingSubsystems(): HealthSubsystems {
+  const item = (label: string) => down(label, 'server is draining requests');
+  return withAliases({
+    backend: item('backend reachable'), database: item('database writable'),
+    fts: item('FTS healthy'), vector: item('vector backend'),
+    embedder: item('embedder reachable'), mcp: item('MCP launchable'),
+    plugins: item('plugins loaded'),
+  });
 }
 
 export function rollupHealthStatus(subsystems: HealthSubsystems): HealthStatusEnum {
@@ -52,6 +67,10 @@ export function rollupHealthStatus(subsystems: HealthSubsystems): HealthStatusEn
   if (values.some((item) => item.critical && item.status === 'starting')) return 'starting';
   if (values.some((item) => item.status !== 'healthy')) return 'degraded';
   return 'healthy';
+}
+
+function withAliases(subsystems: CanonicalHealthSubsystems): HealthSubsystems {
+  return { ...subsystems, db: subsystems.database, plugin: subsystems.plugins };
 }
 
 function backendSubsystem(uptimeSeconds: number): HealthSubsystem {
@@ -81,11 +100,12 @@ function ftsSubsystem(dbStatus: DbStatus): HealthSubsystem {
   try {
     const docs = count('oracle_documents');
     const indexed = count('oracle_fts');
+    const missing = Math.max(0, docs - indexed);
     const status = docs > 0 && indexed === 0 ? 'degraded' : 'healthy';
     return {
       status, label: 'FTS healthy', critical: status === 'healthy',
       detail: docs === 0 ? 'FTS5 table ready; no documents yet' : `FTS5 indexed ${indexed}/${docs} documents`,
-      data: { indexed, documents: docs, missing: Math.max(0, docs - indexed) },
+      data: { indexed, documents: docs, missing },
     };
   } catch (error) {
     return down('FTS healthy', `FTS5 check failed: ${err(error)}`);

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -80,6 +80,8 @@ export interface DashboardSummary {
 }
 
 export type RuntimeStatus = 'ok' | 'down' | 'degraded' | 'draining' | string;
+export type PublicHealthStatus = 'healthy' | 'starting' | 'degraded' | 'down';
+export type HealthSubsystemName = 'backend' | 'database' | 'db' | 'fts' | 'vector' | 'embedder' | 'mcp' | 'plugins' | 'plugin';
 
 export interface VectorHealthResponse {
   status: RuntimeStatus;
@@ -88,21 +90,34 @@ export interface VectorHealthResponse {
   error?: string;
 }
 
+export interface HealthSubsystemDetail {
+  status: PublicHealthStatus;
+  label: string;
+  detail: string;
+  critical: boolean;
+  checkedAt?: string;
+  data?: Record<string, unknown>;
+}
+
 export interface HealthResponse {
   status: RuntimeStatus;
+  healthStatus?: PublicHealthStatus;
+  state?: PublicHealthStatus;
+  checked_at?: string;
   server: string;
   version: string;
   port?: number;
   oracle?: 'connected' | 'degraded';
   uptimeSeconds?: number;
-  dbStatus?: 'ok' | 'down';
+  dbStatus?: 'connected' | 'error';
   vectorStatus?: RuntimeStatus;
   pluginStatus?: 'ok' | 'degraded';
   mcpToolCount?: number;
   pluginCount?: number;
   draining?: boolean;
-  uptime?: { seconds: number };
-  db?: { status: 'ok'; path: string } | { status: 'down'; error: string; path: string };
+  uptime?: number;
+  db?: 'connected' | 'error';
+  dbCheck?: { status: 'connected'; path: string } | { status: 'error'; error: string; path: string };
   vector?: VectorHealthResponse;
   mcp?: { toolCount: number };
   plugins?: {
@@ -110,6 +125,7 @@ export interface HealthResponse {
     status: 'ok' | 'degraded';
     items: Array<{ name: string; status: 'ok' | 'degraded'; error?: string }>;
   };
+  subsystems?: Partial<Record<HealthSubsystemName, HealthSubsystemDetail>>;
 }
 
 export interface MemoryUsageSnapshot {

--- a/tests/cli/doctor/doctor.test.ts
+++ b/tests/cli/doctor/doctor.test.ts
@@ -10,26 +10,39 @@ function writeJson(path: string, value: unknown) {
   writeFileSync(path, JSON.stringify(value, null, 2));
 }
 
-function startDoctorServer(options: { healthStatus?: number; statsStatus?: number } = {}) {
+function defaultHealthBody(port: string) {
+  return {
+    status: "ok",
+    healthStatus: "healthy",
+    server: "doctor-test",
+    version: "test",
+    port: Number(port),
+    oracle: "connected",
+    subsystems: {
+      database: { status: "healthy", label: "DB writable", critical: true, detail: "SQLite writable" },
+      db: { status: "healthy", label: "DB writable", critical: true, detail: "SQLite writable" },
+      fts: { status: "healthy", label: "FTS healthy", critical: true, detail: "FTS ready" },
+      vector: { status: "healthy", label: "vector backend", critical: true, detail: "vector ready" },
+      embedder: { status: "healthy", label: "embedder reachable", critical: true, detail: "embedder ready" },
+      plugins: { status: "healthy", label: "plugins loaded", critical: true, detail: "plugins ready" },
+      plugin: { status: "healthy", label: "plugins loaded", critical: true, detail: "plugins ready" },
+    },
+  };
+}
+
+function startDoctorServer(options: { healthStatus?: number; statsStatus?: number; healthBody?: Record<string, any> } = {}) {
   return Bun.serve({
     port: 0,
     fetch(req) {
       const url = new URL(req.url);
       if (url.pathname === "/api/health") {
-        return Response.json({
-          status: "ok",
-          healthStatus: "healthy",
-          server: "doctor-test",
-          version: "test",
-          port: Number(url.port),
-          oracle: "connected",
-          subsystems: {
-            database: { status: "healthy", label: "DB writable", critical: true, detail: "SQLite writable" },
-            fts: { status: "healthy", label: "FTS healthy", critical: true, detail: "FTS ready" },
-            vector: { status: "healthy", label: "vector backend", critical: true, detail: "vector ready" },
-            embedder: { status: "healthy", label: "embedder reachable", critical: true, detail: "embedder ready" },
-          },
-        }, { status: options.healthStatus ?? 200 });
+        const base = defaultHealthBody(url.port);
+        const body = {
+          ...base,
+          ...options.healthBody,
+          subsystems: { ...base.subsystems, ...options.healthBody?.subsystems },
+        };
+        return Response.json(body, { status: options.healthStatus ?? 200 });
       }
       if (url.pathname === "/api/stats") {
         return Response.json({ total: 42, vector: { enabled: true, adapter: "lancedb", count: 7, collection: "oracle_knowledge" } }, { status: options.statsStatus ?? 200 });
@@ -71,6 +84,28 @@ describe("arra doctor", () => {
     expect(report.checks.find(c => c.id === "db.writable")?.status).toBe("pass");
     expect(report.checks.find(c => c.id === "fts.healthy")?.status).toBe("pass");
     expect(report.checks.find(c => c.id === "vector.backend")?.detail).toContain("vector ready");
+    expect(report.checks.find(c => c.id === "plugins.loaded")?.status).toBe("pass");
+  });
+
+  test("runDoctor renders backend health vocabulary and plugin subsystem", async () => {
+    server = startDoctorServer({
+      healthBody: {
+        healthStatus: "degraded",
+        subsystems: {
+          plugins: { status: "degraded", label: "plugins loaded", critical: false, detail: "plugin degraded" },
+        },
+      },
+    });
+
+    const report = await runDoctor({
+      cwd: root,
+      env: { HOME: join(root, "home"), XDG_CONFIG_HOME: join(root, "xdg"), ORACLE_API: server.url.href, NEO_ARRA_API: "" },
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.checks.find(c => c.id === "backend.status")?.status).toBe("warn");
+    expect(report.checks.find(c => c.id === "plugins.loaded")?.status).toBe("warn");
+    expect(report.checks.find(c => c.id === "plugins.loaded")?.detail).toContain("plugin degraded");
   });
 
   test("runDoctor fails when a critical server check fails", async () => {

--- a/tests/http/health/simple-status.test.ts
+++ b/tests/http/health/simple-status.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from 'bun:test';
+import { createHealthRoutes } from '../../../src/routes/health/index.ts';
+
+function withEmbedder<T>(fn: () => Promise<T>) {
+  const previous = {
+    embedder: process.env.ORACLE_EMBEDDER,
+    legacy: process.env.ORACLE_EMBEDDING_PROVIDER,
+    backend: process.env.ORACLE_EMBEDDER_BACKEND,
+    type: process.env.EMBEDDER_TYPE,
+  };
+  process.env.ORACLE_EMBEDDER = 'ollama';
+  delete process.env.ORACLE_EMBEDDING_PROVIDER;
+  delete process.env.ORACLE_EMBEDDER_BACKEND;
+  delete process.env.EMBEDDER_TYPE;
+  return fn().finally(() => {
+    restore('ORACLE_EMBEDDER', previous.embedder);
+    restore('ORACLE_EMBEDDING_PROVIDER', previous.legacy);
+    restore('ORACLE_EMBEDDER_BACKEND', previous.backend);
+    restore('EMBEDDER_TYPE', previous.type);
+  });
+}
+
+function restore(key: string, value: string | undefined) {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+test('GET /api/health exposes shared state and db/plugin subsystem aliases', async () => withEmbedder(async () => {
+  const app = createHealthRoutes({
+    pluginCount: 1,
+    uptimeSeconds: () => 2,
+    vectorHealth: async () => ({ status: 'ok', engines: [{ key: 'bge', model: 'bge', collection: 'docs', ok: true, count: 1 }], checked_at: 'now' }),
+    vectorServerHealth: async () => ({ configured: false, status: 'unconfigured' }),
+    embeddingProviders: async () => ({ checkedAt: 'now', providers: [{ type: 'ollama', available: true, configured: true, source: 'probe', models: ['bge'], capabilities: ['embed'] }] }),
+  });
+
+  const res = await app.handle(new Request('http://local/api/health'));
+  const body = await res.json() as Record<string, any>;
+
+  expect(res.status).toBe(200);
+  expect(body.healthStatus).toBe('healthy');
+  expect(body.state).toBe('healthy');
+  expect(body.checked_at).toBeTypeOf('string');
+  expect(body.subsystems.db).toEqual(body.subsystems.database);
+  expect(body.subsystems.plugin).toEqual(body.subsystems.plugins);
+  expect(body.subsystems.vector).toMatchObject({ status: 'healthy', label: 'vector backend' });
+  expect(body.subsystems.fts).toMatchObject({ status: 'healthy', label: 'FTS healthy' });
+}));
+
+test('GET /api/health maps draining to down with subsystem detail', async () => {
+  let checked = false;
+  const app = createHealthRoutes({
+    isDraining: () => true,
+    dbPing: () => { checked = true; return { status: 'connected' }; },
+  });
+
+  const res = await app.handle(new Request('http://local/api/health'));
+  const body = await res.json() as Record<string, any>;
+
+  expect(res.status).toBe(503);
+  expect(checked).toBe(false);
+  expect(body.status).toBe('draining');
+  expect(body.healthStatus).toBe('down');
+  expect(body.state).toBe('down');
+  expect(body.subsystems.db).toMatchObject({ status: 'down', label: 'database writable' });
+  expect(body.subsystems.plugin).toMatchObject({ status: 'down', label: 'plugins loaded' });
+});

--- a/tests/http/health/status.test.ts
+++ b/tests/http/health/status.test.ts
@@ -87,8 +87,16 @@ test('GET /api/health catches dbPing exceptions and keeps response shaped', asyn
 
 
 test('GET /api/health reports healthy enum when every subsystem is available', async () => {
-  const previous = process.env.ORACLE_EMBEDDER;
+  const previous = {
+    embedder: process.env.ORACLE_EMBEDDER,
+    legacy: process.env.ORACLE_EMBEDDING_PROVIDER,
+    backend: process.env.ORACLE_EMBEDDER_BACKEND,
+    type: process.env.EMBEDDER_TYPE,
+  };
   process.env.ORACLE_EMBEDDER = 'ollama';
+  delete process.env.ORACLE_EMBEDDING_PROVIDER;
+  delete process.env.ORACLE_EMBEDDER_BACKEND;
+  delete process.env.EMBEDDER_TYPE;
   try {
     const app = createHealthRoutes({
       pluginCount: 1,
@@ -103,7 +111,14 @@ test('GET /api/health reports healthy enum when every subsystem is available', a
     expect(body.subsystems.embedder).toMatchObject({ status: 'healthy', label: 'embedder reachable' });
     expect(body.subsystems.mcp.status).toBe('healthy');
   } finally {
-    if (previous === undefined) delete process.env.ORACLE_EMBEDDER;
-    else process.env.ORACLE_EMBEDDER = previous;
+    restoreEnv('ORACLE_EMBEDDER', previous.embedder);
+    restoreEnv('ORACLE_EMBEDDING_PROVIDER', previous.legacy);
+    restoreEnv('ORACLE_EMBEDDER_BACKEND', previous.backend);
+    restoreEnv('EMBEDDER_TYPE', previous.type);
   }
 });
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}


### PR DESCRIPTION
## Summary
- enrich `/api/health` with shared `state`/`checked_at` fields and `db`/`plugin` subsystem aliases alongside the doctor vocabulary
- update Simple Mode health mapping to prefer `healthStatus`/`state` plus subsystem detail while preserving legacy fallbacks
- teach `arra doctor` to accept aliases and surface plugin subsystem degradation

Refs #2440

## Validation
- `bunx tsc --noEmit`
- `bun test --isolate tests/http/health/ frontend/src/components/simple/__tests__/healthState.test.ts tests/cli/doctor/doctor.test.ts`
- `bun run test:unit`
- `bun run test:integration`