### PR TITLE
fix: align vector export collection validation

### DIFF
--- a/src/routes/vector/export.ts
+++ b/src/routes/vector/export.ts
@@ -3,13 +3,16 @@
  */
 
 import { Elysia, t } from 'elysia';
-import { getEmbeddingModels, getVectorStoreByModel } from '../../vector/factory.ts';
+import { getVectorStoreByModel } from '../../vector/factory.ts';
 import { availableExportFormats, exportFormatInfo, getExportFormat } from '../../vector/export-formats.ts';
+import type { VectorServerConfig } from '../../vector/config.ts';
 import type { VectorStoreAdapter } from '../../vector/types.ts';
+import { activeConfig, resolveCollection as resolveConfigCollection } from './config-api-utils.ts';
 
 interface VectorExportDeps {
   getStore?: (collection?: string) => VectorStoreAdapter;
   getModels?: () => Record<string, unknown>;
+  getConfig?: () => VectorServerConfig;
 }
 
 const DEFAULT_COLLECTION = 'bge-m3';
@@ -17,6 +20,7 @@ const DEFAULT_EXPORT_LIMIT = 50_000;
 const encoder = new TextEncoder();
 
 type GetStore = NonNullable<VectorExportDeps['getStore']>;
+type CollectionSelection = { storeKey: string; filename: string };
 
 function progressEvent(event: string, payload: Record<string, unknown>): Uint8Array {
   return encoder.encode(`event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`);
@@ -56,14 +60,37 @@ function progressStream(getStore: GetStore, collection: string): ReadableStream<
   });
 }
 
-function resolveCollection(collection: string | undefined, getModels?: () => Record<string, unknown>): string | null {
+function modelCollectionName(model: unknown): string | null {
+  return typeof model === 'object'
+    && model !== null
+    && 'collection' in model
+    && typeof model.collection === 'string'
+    ? model.collection
+    : null;
+}
+
+function configForResolution(getConfig?: () => VectorServerConfig, getModels?: () => Record<string, unknown>) {
+  if (getConfig) return getConfig();
+  return getModels ? null : activeConfig().config;
+}
+
+function resolveCollection(collection: string | undefined, deps: VectorExportDeps): CollectionSelection | null {
   const resolved = (collection || DEFAULT_COLLECTION).trim() || DEFAULT_COLLECTION;
-  return !getModels || resolved in getModels() ? resolved : null;
+  const config = configForResolution(deps.getConfig, deps.getModels);
+  if (config) {
+    const match = resolveConfigCollection(config, resolved);
+    return match ? { storeKey: match[0], filename: resolved } : null;
+  }
+
+  const models = deps.getModels?.();
+  if (!models) return { storeKey: resolved, filename: resolved };
+  if (resolved in models) return { storeKey: resolved, filename: resolved };
+  const byCollection = Object.entries(models).find(([, model]) => modelCollectionName(model) === resolved);
+  return byCollection ? { storeKey: byCollection[0], filename: resolved } : null;
 }
 
 export function createVectorExportEndpoint(deps: VectorExportDeps = {}) {
   const getStore = deps.getStore ?? getVectorStoreByModel;
-  const getModels = deps.getModels ?? getEmbeddingModels;
 
   return new Elysia()
     .get('/vector/export/formats', () => ({ formats: availableExportFormats() }), {
@@ -75,13 +102,13 @@ export function createVectorExportEndpoint(deps: VectorExportDeps = {}) {
     .get(
       '/vector/export/progress',
       ({ query, set }) => {
-        const collection = resolveCollection(query.collection, getModels);
+        const collection = resolveCollection(query.collection, deps);
         if (!collection) {
           set.status = 404;
           return { error: `Unknown vector collection: ${query.collection}` };
         }
 
-        return new Response(progressStream(getStore, collection), {
+        return new Response(progressStream(getStore, collection.storeKey), {
           headers: {
             'Content-Type': 'text/event-stream; charset=utf-8',
             'Cache-Control': 'no-cache, no-transform',
@@ -106,13 +133,13 @@ export function createVectorExportEndpoint(deps: VectorExportDeps = {}) {
         return { error: 'Invalid format', formats: availableExportFormats() };
       }
 
-      const collection = resolveCollection(query.collection, getModels);
+      const collection = resolveCollection(query.collection, deps);
       if (!collection) {
         set.status = 404;
         return { error: `Unknown vector collection: ${query.collection}` };
       }
 
-      const store = getStore(collection);
+      const store = getStore(collection.storeKey);
       try {
         await store.connect();
         await store.ensureCollection();
@@ -129,7 +156,7 @@ export function createVectorExportEndpoint(deps: VectorExportDeps = {}) {
         return new Response(stream, {
           headers: {
             'Content-Type': info.mimeType,
-            'Content-Disposition': `attachment; filename="${collection}.${info.extension}"`,
+            'Content-Disposition': `attachment; filename="${collection.filename}.${info.extension}"`,
           },
         });
       } catch (error) {

--- a/tests/http/vector/export-config-collections.test.ts
+++ b/tests/http/vector/export-config-collections.test.ts
@@ -1,0 +1,90 @@
+import { afterAll, expect, mock, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import type { VectorStoreAdapter } from '../../../src/vector/types.ts';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const root = mkdtempSync(join(tmpdir(), 'vector-export-config-'));
+process.env.ORACLE_DATA_DIR = root;
+
+const vectorConfig = await import('../../../src/vector/config.ts');
+const { vectorConfigApiEndpoint } = await import('../../../src/routes/vector/config.ts');
+const { createVectorExportEndpoint } = await import('../../../src/routes/vector/export.ts');
+
+const formats = ['json', 'jsonl', 'csv', 'markdown'] as const;
+const expectedCollections = [
+  'oracle_knowledge',
+  'oracle_knowledge_bge_m3',
+  'oracle_knowledge_qwen3',
+  'oracle_per_collection',
+];
+const expectedKeys = ['nomic', 'bge-m3', 'qwen3', 'per'];
+
+function createStore(): VectorStoreAdapter {
+  return {
+    name: 'fake-vector-export',
+    connect: mock(async () => {}),
+    close: mock(async () => {}),
+    ensureCollection: mock(async () => {}),
+    deleteCollection: mock(async () => {}),
+    addDocuments: mock(async () => {}),
+    query: mock(async () => ({ ids: [], documents: [], distances: [], metadatas: [] })),
+    queryById: mock(async () => ({ ids: [], documents: [], distances: [], metadatas: [] })),
+    getStats: mock(async () => ({ count: 0 })),
+    getCollectionInfo: mock(async () => ({ count: 0, name: 'fake' })),
+    getAllEmbeddings: mock(async () => ({ ids: [], documents: [], embeddings: [], metadatas: [] })),
+  };
+}
+
+function seedConfig() {
+  const config = vectorConfig.generateDefaultConfig();
+  config.enabled = false;
+  config.dataPath = join(root, 'lance');
+  config.collections = {
+    nomic: { collection: 'oracle_knowledge', model: 'nomic-embed-text', provider: 'ollama', adapter: 'lancedb', primary: true },
+    'bge-m3': { collection: 'oracle_knowledge_bge_m3', model: 'bge-m3', provider: 'ollama', adapter: 'lancedb' },
+    qwen3: { collection: 'oracle_knowledge_qwen3', model: 'qwen3-embedding', provider: 'ollama', adapter: 'lancedb' },
+    per: { collection: 'oracle_per_collection', model: 'per-model', provider: 'none', adapter: 'lancedb' },
+  };
+  vectorConfig.writeVectorConfig(config, vectorConfig.configPath(root));
+}
+
+const seenKeys: string[] = [];
+const app = new Elysia({ prefix: '/api' })
+  .use(vectorConfigApiEndpoint)
+  .use(createVectorExportEndpoint({ getStore: (key) => { seenKeys.push(key ?? ''); return createStore(); } }));
+const fetcher = createApiVersionedFetch((request) => app.handle(request));
+
+async function request(path: string): Promise<Response> {
+  return fetcher(new Request(`http://local${path}`));
+}
+
+afterAll(() => {
+  if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = savedDataDir;
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('every collection listed by /vector/config exports in registered formats', async () => {
+  seedConfig();
+  const configRes = await request('/api/v1/vector/config');
+  const body = await configRes.json() as { collections: Array<{ key: string; collection: string }> };
+  const listed = body.collections.map((collection) => collection.collection);
+
+  expect(configRes.status).toBe(200);
+  expect(listed).toEqual(expectedCollections);
+
+  for (const collection of listed) {
+    for (const format of formats) {
+      const res = await request(`/api/v1/vector/export?collection=${encodeURIComponent(collection)}&format=${format}`);
+      expect(res.status, `${collection} ${format}`).toBe(200);
+      expect(res.headers.get('content-disposition')).toContain(`${collection}.`);
+      await res.text();
+    }
+  }
+
+  expect(seenKeys).toEqual(expectedKeys.flatMap((key) => formats.map(() => key)));
+});


### PR DESCRIPTION
## Summary\n- resolve /api/v1/vector/export collections through the same active vector config resolver used by /api/v1/vector/config\n- accept both registry keys and listed collection names, then open the matching store key instead of falling back/404ing\n- add HTTP coverage proving every /vector/config collection exports as json, jsonl, csv, and markdown\n\nRefs #2457\n\n## Validation\n- bunx tsc --noEmit\n- bun test tests/http/vector/\n- git diff --check HEAD~1..HEAD\n- wc -l src/routes/vector/export.ts tests/http/vector/export-config-collections.test.ts