### PR TITLE
fix(export): exempt vector exports from json negotiation

### DIFF
--- a/src/middleware/content-type.ts
+++ b/src/middleware/content-type.ts
@@ -2,6 +2,10 @@ import { Elysia } from 'elysia';
 
 export const JSON_CONTENT_TYPE = 'application/json';
 const WILDCARD_MEDIA = '*/*';
+const STREAMING_EXPORT_PREFIXES = [
+  '/api/vector/export',
+  '/api/v1/vector/export',
+] as const;
 
 interface MediaRange {
   type: string;
@@ -50,6 +54,18 @@ function hasContentType(headers: MutableHeaders): boolean {
   return headers['Content-Type'] !== undefined || headers['content-type'] !== undefined;
 }
 
+function responseHasContentType(response: unknown): boolean {
+  return response instanceof Response && response.headers.has('content-type');
+}
+
+function isVectorExportPath(pathname: string): boolean {
+  return STREAMING_EXPORT_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
+}
+
+export function skipsJsonContentNegotiation(request: Request): boolean {
+  return isVectorExportPath(new URL(request.url).pathname);
+}
+
 export function setJsonContentType(headers: MutableHeaders): void {
   if (!hasContentType(headers)) headers['Content-Type'] = JSON_CONTENT_TYPE;
 }
@@ -66,7 +82,7 @@ export function notAcceptableBody(accept: string | null) {
 export function createContentTypeMiddleware() {
   return new Elysia({ name: 'content-type-negotiation' })
     .onBeforeHandle({ as: 'global' }, ({ request, set }) => {
-      if (request.method === 'OPTIONS') return;
+      if (request.method === 'OPTIONS' || skipsJsonContentNegotiation(request)) return;
       const accept = request.headers.get('accept');
       if (acceptsJson(accept)) return;
 
@@ -74,7 +90,8 @@ export function createContentTypeMiddleware() {
       setJsonContentType(set.headers);
       return notAcceptableBody(accept);
     })
-    .onAfterHandle({ as: 'global' }, ({ set }) => {
+    .onAfterHandle({ as: 'global' }, ({ request, response, set }) => {
+      if (skipsJsonContentNegotiation(request) || responseHasContentType(response)) return;
       setJsonContentType(set.headers);
     })
     .onError({ as: 'global' }, ({ set }) => {

--- a/tests/http/vector/export-content-type-middleware.test.ts
+++ b/tests/http/vector/export-content-type-middleware.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createContentTypeMiddleware } from '../../../src/middleware/content-type.ts';
+import { createVectorExportEndpoint } from '../../../src/routes/vector/export.ts';
+import type { VectorStoreAdapter } from '../../../src/vector/types.ts';
+
+type ExportCase = { format: string; accept: string; contentType: string; body: (text: string) => void };
+
+function createStore(): VectorStoreAdapter {
+  return {
+    name: 'fake-vector',
+    connect: mock(async () => {}),
+    close: mock(async () => {}),
+    ensureCollection: mock(async () => {}),
+    deleteCollection: mock(async () => {}),
+    addDocuments: mock(async () => {}),
+    query: mock(async () => ({ ids: [], documents: [], distances: [], metadatas: [] })),
+    queryById: mock(async () => ({ ids: [], documents: [], distances: [], metadatas: [] })),
+    getStats: mock(async () => ({ count: 1 })),
+    getCollectionInfo: mock(async () => ({ count: 1, name: 'fake' })),
+    getAllEmbeddings: mock(async () => ({
+      ids: ['doc-1'],
+      documents: ['alpha document'],
+      embeddings: [[0, 0, 0]],
+      metadatas: [{ type: 'learning', source_file: 'notes/alpha.md', concepts: ['alpha'] }],
+    })),
+  };
+}
+
+function createFetch() {
+  const app = new Elysia({ prefix: '/api' })
+    .use(createContentTypeMiddleware())
+    .use(createVectorExportEndpoint({
+      getModels: () => ({ 'bge-m3': {} }),
+      getStore: () => createStore(),
+    }));
+  return createApiVersionedFetch((request) => app.handle(request));
+}
+
+const cases: ExportCase[] = [
+  { format: 'json', accept: 'application/json', contentType: 'application/json', body: (text) => expect(JSON.parse(text)[0].id).toBe('doc-1') },
+  { format: 'jsonl', accept: 'application/x-ndjson', contentType: 'application/x-ndjson', body: (text) => expect(JSON.parse(text.trim()).id).toBe('doc-1') },
+  { format: 'csv', accept: 'text/csv', contentType: 'text/csv', body: (text) => expect(text).toStartWith('id,document,type,source_file,concepts') },
+  { format: 'markdown', accept: 'text/markdown', contentType: 'text/markdown', body: (text) => expect(text).toContain('<!-- source: notes/alpha.md -->') },
+];
+
+describe('vector export with global content-type middleware', () => {
+  for (const item of cases) {
+    test(`returns ${item.format} with ${item.contentType} instead of 406`, async () => {
+      const res = await createFetch()(new Request(
+        `http://local/api/v1/vector/export?collection=bge-m3&format=${item.format}`,
+        { headers: { accept: item.accept } },
+      ));
+      const text = await res.text();
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toContain(item.contentType);
+      item.body(text);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- Exempts `/api/v1/vector/export` / `/api/vector/export` paths from the global JSON-only Accept negotiation.
- Preserves explicit `Response` content-types instead of stamping JSON over streamed responses.
- Adds vector export coverage for json/jsonl/csv/markdown under the global content-type middleware.

Refs #2457.

## Coordination

- Based on current `origin/alpha`, including c5 collection-validation PR #2458.
- Does not touch `src/routes/vector/export.ts`; this PR only handles the global middleware 406/content-type blocker.

## Validation

```bash
bunx tsc --noEmit
bun test --isolate \
  tests/http/vector/export-content-type-middleware.test.ts \
  tests/http/vector/export-config-collections.test.ts \
  tests/http/vector/export.test.ts \
  tests/http/vector/export-formats.test.ts \
  tests/http/vector/export-csv.test.ts \
  tests/http/vector/export-jsonl.test.ts \
  tests/http/vector/export-markdown.test.ts \
  tests/http/content-type/negotiation.test.ts
wc -l src/middleware/content-type.ts tests/http/vector/export-content-type-middleware.test.ts
```

- Scoped tests: 17 pass, 0 fail.
- File sizes: 100 and 62 lines.