### PR TITLE
fix(frontend): align status page with health shape

### DIFF
--- a/frontend/src/pages/StatusPage.tsx
+++ b/frontend/src/pages/StatusPage.tsx
@@ -23,8 +23,9 @@ export interface StatusPageProps {
 }
 
 function statusClass(status?: string): string {
-  if (status === 'ok' || status === 'connected') return 'border-ok-border bg-ok-bg text-ok-text';
-  if (status === 'degraded' || status === 'draining') return 'border-warn-border bg-warn-bg text-warn-text';
+  const normalized = status?.toLowerCase();
+  if (normalized === 'ok' || normalized === 'connected' || normalized === 'healthy' || normalized === 'up') return 'border-ok-border bg-ok-bg text-ok-text';
+  if (normalized === 'degraded' || normalized === 'draining' || normalized === 'starting') return 'border-warn-border bg-warn-bg text-warn-text';
   return 'border-err-border bg-err-bg text-err-text';
 }
 
@@ -34,6 +35,24 @@ function formatSeconds(seconds?: number): string {
   const minutes = Math.floor(seconds / 60);
   const remaining = Math.round(seconds % 60);
   return `${minutes}m ${remaining}s`;
+}
+
+
+function databaseStatus(health: HealthResponse): string | undefined {
+  return health.subsystems?.database?.status ?? health.subsystems?.db?.status ?? health.dbStatus ?? health.db;
+}
+
+function subsystemStatus(health: HealthResponse, name: 'vector' | 'plugins' | 'plugin', fallback?: string): string | undefined {
+  return health.subsystems?.[name]?.status ?? fallback;
+}
+
+function subsystemDataString(health: HealthResponse, name: 'database' | 'db', key: string): string | undefined {
+  const value = health.subsystems?.[name]?.data?.[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function databasePath(health: HealthResponse): string | undefined {
+  return health.dbCheck?.path ?? subsystemDataString(health, 'database', 'path') ?? subsystemDataString(health, 'db', 'path');
 }
 
 function Field({ label, value }: { label: string; value: string | number | undefined }) {
@@ -142,7 +161,7 @@ export function StatusPage({ client = apiClient, initialHealth = null, initialVe
     return () => { cancelled = true; };
   }, [client, initialHealth]);
 
-  const uptime = useMemo(() => formatSeconds(health?.uptimeSeconds ?? health?.uptime?.seconds), [health]);
+  const uptime = useMemo(() => formatSeconds(health?.uptimeSeconds ?? health?.uptime), [health]);
   const isLoading = state === 'loading';
 
   return (
@@ -159,10 +178,10 @@ export function StatusPage({ client = apiClient, initialHealth = null, initialVe
       {health && state === 'ready' ? (
         <>
           <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-            <StatusBadge label="Server" status={health.status} />
-            <StatusBadge label="Database" status={health.dbStatus ?? health.db?.status} />
-            <StatusBadge label="Vector" status={health.vectorStatus ?? health.vector?.status} />
-            <StatusBadge label="Plugins" status={health.pluginStatus ?? health.plugins?.status} />
+            <StatusBadge label="Server" status={health.healthStatus ?? health.state ?? health.status} />
+            <StatusBadge label="Database" status={databaseStatus(health)} />
+            <StatusBadge label="Vector" status={subsystemStatus(health, 'vector', health.vectorStatus ?? health.vector?.status)} />
+            <StatusBadge label="Plugins" status={subsystemStatus(health, 'plugins', health.pluginStatus ?? health.plugins?.status)} />
           </div>
           <dl className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
             <Field label="Name" value={health.server} />
@@ -172,7 +191,7 @@ export function StatusPage({ client = apiClient, initialHealth = null, initialVe
             <Field label="MCP tools" value={health.mcpToolCount ?? health.mcp?.toolCount} />
             <Field label="Plugins" value={health.pluginCount ?? health.plugins?.count} />
             <Field label="Oracle" value={health.oracle} />
-            <Field label="DB path" value={health.db?.path} />
+            <Field label="DB path" value={databasePath(health)} />
           </dl>
           <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-label="Plugin health rows">
             <h3 className="text-lg font-semibold text-text">Plugin health</h3>

--- a/tests/frontend/pages/status-page-plugin-links.test.tsx
+++ b/tests/frontend/pages/status-page-plugin-links.test.tsx
@@ -5,11 +5,19 @@ import { htmlFor } from '../_render';
 
 const health: HealthResponse = {
   status: 'degraded',
+  healthStatus: 'degraded',
   server: 'oracle',
   version: '1.0.0',
-  dbStatus: 'ok',
+  uptime: 90,
+  dbStatus: 'connected',
+  dbCheck: { status: 'connected', path: '/tmp/oracle.db' },
   vectorStatus: 'ok',
   pluginStatus: 'degraded',
+  subsystems: {
+    database: { status: 'healthy', label: 'database writable', detail: 'ok', critical: true, data: { path: '/tmp/oracle.db' } },
+    vector: { status: 'healthy', label: 'vector backend', detail: 'ok', critical: true },
+    plugins: { status: 'degraded', label: 'plugins loaded', detail: 'one degraded', critical: false },
+  },
   plugins: {
     count: 2,
     status: 'degraded',


### PR DESCRIPTION
## Summary

- Updates StatusPage to consume the new `/api/health` shape from #2454 (`healthStatus`, `state`, `subsystems`, `dbCheck`).
- Removes old reads like `uptime.seconds`, `db.status`, and `db.path` that broke frontend tsc.
- Keeps legacy fallbacks for older health payload fields and updates status render tests to the new shape.

Refs #2460.

## Validation

```bash
cd frontend && bun run build
bun test --isolate tests/frontend/pages/status-page-plugin-links.test.tsx tests/frontend/pages/status-page-loading-edge.test.tsx
bunx tsc --noEmit
wc -l frontend/src/pages/StatusPage.tsx tests/frontend/pages/status-page-plugin-links.test.tsx
```

- Frontend build (`tsc --noEmit && vite build`): pass.
- Scoped frontend tests: 3 pass, 0 fail.
- Root tsc: pass.
- File sizes: 210 and 66 lines.