### PR TITLE
fix(frontend): type new health response shape

### DIFF
--- a/frontend/src/pages/StatusPage.tsx
+++ b/frontend/src/pages/StatusPage.tsx
@@ -29,6 +29,15 @@ function statusClass(status?: string): string {
   return 'border-err-border bg-err-bg text-err-text';
 }
 
+function rawSeconds(value: HealthResponse['uptime'] | undefined): number | undefined {
+  if (typeof value === 'number') return value;
+  return value?.seconds;
+}
+
+function healthUptimeSeconds(health: HealthResponse | null): number | undefined {
+  return health?.uptimeSeconds ?? rawSeconds(health?.uptimeSecondsBreakdown) ?? rawSeconds(health?.uptime);
+}
+
 function formatSeconds(seconds?: number): string {
   if (typeof seconds !== 'number' || !Number.isFinite(seconds)) return 'unknown';
   if (seconds < 60) return `${Math.round(seconds)}s`;
@@ -161,7 +170,7 @@ export function StatusPage({ client = apiClient, initialHealth = null, initialVe
     return () => { cancelled = true; };
   }, [client, initialHealth]);
 
-  const uptime = useMemo(() => formatSeconds(health?.uptimeSeconds ?? health?.uptime), [health]);
+  const uptime = useMemo(() => formatSeconds(healthUptimeSeconds(health)), [health]);
   const isLoading = state === 'loading';
 
   return (

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -82,6 +82,9 @@ export interface DashboardSummary {
 export type RuntimeStatus = 'ok' | 'down' | 'degraded' | 'draining' | string;
 export type PublicHealthStatus = 'healthy' | 'starting' | 'degraded' | 'down';
 export type HealthSubsystemName = 'backend' | 'database' | 'db' | 'fts' | 'vector' | 'embedder' | 'mcp' | 'plugins' | 'plugin';
+export type HealthUptimeSeconds = number | { seconds: number };
+export type VectorRuntimeMode = 'embedded' | 'proxied' | 'disabled';
+
 
 export interface VectorHealthResponse {
   status: RuntimeStatus;
@@ -107,18 +110,34 @@ export interface HealthResponse {
   server: string;
   version: string;
   port?: number;
+  sandbox?: string;
   oracle?: 'connected' | 'degraded';
   uptimeSeconds?: number;
+  uptimeSecondsBreakdown?: HealthUptimeSeconds;
   dbStatus?: 'connected' | 'error';
   vectorStatus?: RuntimeStatus;
+  vectorMode?: VectorRuntimeMode;
+  vectorAvailable?: boolean;
+  vectorUrl?: string;
+  vectorDisabledReason?: string;
   pluginStatus?: 'ok' | 'degraded';
   mcpToolCount?: number;
   pluginCount?: number;
   draining?: boolean;
-  uptime?: number;
+  uptime?: HealthUptimeSeconds;
   db?: 'connected' | 'error';
-  dbCheck?: { status: 'connected'; path: string } | { status: 'error'; error: string; path: string };
+  dbCheck?: { status: 'connected'; path?: string } | { status: 'error'; error?: string; path?: string };
   vector?: VectorHealthResponse;
+  vectorServer?: {
+    configured: boolean;
+    status: 'ok' | 'down' | 'unconfigured';
+    url?: string;
+    httpStatus?: number;
+    protocol?: string;
+    name?: string;
+    version?: string;
+    error?: string;
+  };
   mcp?: { toolCount: number };
   plugins?: {
     count: number;

--- a/tests/frontend/pages/status-page-plugin-links.test.tsx
+++ b/tests/frontend/pages/status-page-plugin-links.test.tsx
@@ -8,7 +8,7 @@ const health: HealthResponse = {
   healthStatus: 'degraded',
   server: 'oracle',
   version: '1.0.0',
-  uptime: 90,
+  uptimeSecondsBreakdown: { seconds: 90 },
   dbStatus: 'connected',
   dbCheck: { status: 'connected', path: '/tmp/oracle.db' },
   vectorStatus: 'ok',
@@ -35,6 +35,7 @@ describe('StatusPage plugin health links', () => {
 
     const html = htmlFor(<StatusPage initialHealth={health} />);
     expect(html).toContain('Plugin health');
+    expect(html).toContain('1m 30s');
     expect(html).toContain('href="/plugins?q=echo"');
     expect(html).toContain('href="/plugins?q=broken&amp;visibility=unhealthy"');
   });


### PR DESCRIPTION
## Summary
- expand `HealthResponse` for the new `/api/health` payload (`healthStatus`, `state`, subsystem map, vector runtime fields, `dbCheck`, `uptimeSecondsBreakdown`)
- normalize StatusPage uptime rendering across numeric and `{ seconds }` shapes
- cover the new uptime breakdown fixture in the StatusPage frontend test

## Validation
- `cd frontend && bun run build` ✅
- `bun test --isolate tests/frontend/pages/status-page-plugin-links.test.tsx tests/frontend/pages/status-page-loading-edge.test.tsx` ✅
- `bunx tsc --noEmit` ✅
- `wc -l src/server/types.ts frontend/src/pages/StatusPage.tsx tests/frontend/pages/status-page-plugin-links.test.tsx` ✅ (237, 219, 67)

Refs #2460