### PR TITLE
fix(health): HealthResponse type fields for StatusPage (frontend tsc green)

### DIFF
--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -99,6 +99,11 @@ export interface HealthResponse {
   mcpToolCount?: number;
   pluginCount?: number;
   draining?: boolean;
+  healthStatus?: RuntimeStatus | 'degraded' | 'starting' | 'down' | string;
+  state?: string;
+  uptimeSecondsBreakdown?: { seconds: number };
+  dbCheck?: { status?: string; path?: string };
+  subsystems?: Record<string, { status?: string; data?: Record<string, unknown> }>;
   uptime?: { seconds: number };
   db?: { status: 'ok'; path: string } | { status: 'down'; error: string; path: string };
   vector?: VectorHealthResponse;


### PR DESCRIPTION
Adds optional healthStatus/state/uptimeSecondsBreakdown/dbCheck/subsystems to HealthResponse so StatusPage.tsx compiles. Unblocks the 'Deploy Oracle Studio Worker' CI (frontend tsc). Verified: root tsc green + cd frontend && bun run build green.

🤖 Generated with Claude Code