### PR TITLE
test: enforce honest recall metric labels

### DIFF
--- a/benchmarks/honest-recall.ts
+++ b/benchmarks/honest-recall.ts
@@ -19,7 +19,7 @@ export type Searcher = (request: SearchRequest) => Promise<SearchHit[]>;
 type CorpusRef = { label: string; size: number };
 
 type MetricRow =
-  | { metric: RecallMetricLabel; metric_family: 'Recall@k'; label: RecallMetricLabel; value: number; hits: number; total_queries: number; top_k: number }
+  | { metric: 'Recall@k'; metric_family: 'Recall@k'; label: RecallMetricLabel; value: number; hits: number; total_queries: number; top_k: number }
   | { metric: 'Answer-Accuracy'; metric_family: 'Answer-Accuracy'; status: 'not-measured'; reason: string };
 
 export type HonestRecallReport = {
@@ -30,7 +30,7 @@ export type HonestRecallReport = {
     model: string;
     top_k: number;
     corpus: CorpusRef;
-    metric: RecallMetricLabel;
+    metric: 'Recall@k';
     metric_family: 'Recall@k';
     'git-sha': string;
     stack: string[];
@@ -39,7 +39,7 @@ export type HonestRecallReport = {
   cases: Array<{
     id: string;
     query: string;
-    metric: RecallMetricLabel;
+    metric: 'Recall@k';
     metric_family: 'Recall@k';
     expected_ids: string[];
     retrieved_ids: string[];
@@ -92,7 +92,7 @@ export async function runHonestRecallBenchmark(options: {
 }): Promise<HonestRecallReport> {
   const mode = normalizeMode(options.mode ?? 'hybrid');
   const model = options.model ?? 'multi';
-  const metric = recallMetric(options.topK);
+  const recallLabel = recallMetric(options.topK);
   guardTopK(options.topK, options.corpus.size);
   if (!options.cases.length) throw new Error('benchmark dataset has no cases');
 
@@ -104,7 +104,7 @@ export async function runHonestRecallBenchmark(options: {
     cases.push({
       id: item.id,
       query: item.query,
-      metric,
+      metric: 'Recall@k',
       metric_family: 'Recall@k',
       expected_ids: item.expectedIds,
       retrieved_ids: hits.map((hit) => hit.id),
@@ -123,13 +123,13 @@ export async function runHonestRecallBenchmark(options: {
       model,
       top_k: options.topK,
       corpus: options.corpus,
-      metric,
+      metric: 'Recall@k',
       metric_family: 'Recall@k',
       'git-sha': options.gitSha ?? readGitSha(),
       stack: mode === 'hybrid' && model === 'multi' ? ['bge-m3', 'nomic', 'qwen3', 'FTS5'] : [model, mode],
     },
     metrics: [
-      { metric, metric_family: 'Recall@k', label: metric, value: recall, hits, total_queries: cases.length, top_k: options.topK },
+      { metric: 'Recall@k', metric_family: 'Recall@k', label: recallLabel, value: recall, hits, total_queries: cases.length, top_k: options.topK },
       { metric: 'Answer-Accuracy', metric_family: 'Answer-Accuracy', status: 'not-measured', reason: 'Retrieval-only harness: no answer generator or judge was run.' },
     ],
     cases,
@@ -224,7 +224,7 @@ function required(opts: Map<string, string>, key: string): string {
 function printSummary(report: HonestRecallReport): void {
   const recall = report.metrics.find((row): row is Extract<MetricRow, { metric_family: 'Recall@k' }> => row.metric_family === 'Recall@k');
   if (!recall) throw new Error('Recall@k metric row missing');
-  console.log(`${recall.metric} ${recall.label}: ${recall.value} (${recall.hits}/${recall.total_queries})`);
+  console.log(`${recall.label}: ${recall.value} (${recall.hits}/${recall.total_queries})`);
   console.log('Answer-Accuracy: NOT MEASURED — retrieval-only harness');
   console.log(`provenance_json: ${report.provenance.mode}/${report.provenance.model} top_k=${report.provenance.top_k}`);
 }

--- a/tests/benchmarks/honest-recall.test.ts
+++ b/tests/benchmarks/honest-recall.test.ts
@@ -25,6 +25,7 @@ afterEach(() => {
 describe('honest recall benchmark harness', () => {
   test('refuses to report Recall@k when top_k covers the corpus', async () => {
     const outFile = tempFile('refused.json');
+    expect(() => guardTopK(12, 12)).toThrow('Refusing to report Recall@12');
     expect(() => guardTopK(4, 4)).toThrow('Refusing to report Recall@4');
     expect(() => guardTopK(5, 4)).toThrow('top_k (5) must be smaller than corpus_size (4)');
     const searcher: Searcher = async () => { throw new Error('searcher should not run'); };
@@ -59,12 +60,13 @@ describe('honest recall benchmark harness', () => {
       now: '2026-06-17T00:00:00.000Z',
     });
 
-    expect(report.provenance).toMatchObject({ mode: 'hybrid', model: 'multi', top_k: 3, metric: 'Recall@3', metric_family: 'Recall@k', 'git-sha': 'abc123' });
+    expect(report.provenance).toMatchObject({ mode: 'hybrid', model: 'multi', top_k: 3, metric: 'Recall@k', metric_family: 'Recall@k', 'git-sha': 'abc123' });
     expect(report.provenance.stack).toEqual(['bge-m3', 'nomic', 'qwen3', 'FTS5']);
-    expect(report.metrics[0]).toMatchObject({ metric: 'Recall@3', metric_family: 'Recall@k', label: 'Recall@3', value: 0.5, hits: 1, total_queries: 2 });
+    expect(report.metrics[0]).toMatchObject({ metric: 'Recall@k', metric_family: 'Recall@k', label: 'Recall@3', value: 0.5, hits: 1, total_queries: 2 });
     expect(report.metrics[1]).toMatchObject({ metric: 'Answer-Accuracy', metric_family: 'Answer-Accuracy', status: 'not-measured' });
+    expect(report.metrics.map((item) => item.metric)).toEqual(['Recall@k', 'Answer-Accuracy']);
     expect('value' in report.metrics[1]).toBe(false);
-    expect(report.cases.map((item) => item.metric)).toEqual(['Recall@3', 'Recall@3']);
+    expect(report.cases.map((item) => item.metric)).toEqual(['Recall@k', 'Recall@k']);
     expect(report.cases.map((item) => item.metric_family)).toEqual(['Recall@k', 'Recall@k']);
     expect(JSON.parse(readFileSync(outFile, 'utf8')).provenance.corpus).toEqual({ label: 'oracle-test', size: 10 });
   });


### PR DESCRIPTION
## Summary
- Enforces the exact `guardTopK(12, 12)` refusal case requested in #2464.
- Keeps honest recall reports from conflating `Recall@k` with a concrete display label: report `metric` stays `Recall@k`, while `label` carries `Recall@3`.
- Locks `Answer-Accuracy` as `status: not-measured` with no value field.

Refs #2464.

## Validation
- `bunx tsc --noEmit`
- `bun test tests/benchmarks/honest-recall.test.ts`
- `git diff --check origin/alpha...HEAD`
- Changed files <= 250 lines.
- Frontend not touched; `cd frontend && bun run build` not applicable.
