### PR TITLE
test(benchmarks): harden honest recall edge cases

### DIFF
--- a/benchmarks/honest-recall.ts
+++ b/benchmarks/honest-recall.ts
@@ -5,12 +5,7 @@ export type MetricName = 'Recall@k' | 'Answer-Accuracy';
 export type BenchmarkMode = 'hybrid' | 'fts' | 'vector';
 type RecallMetricLabel = `Recall@${number}`;
 
-export type BenchmarkCase = {
-  id: string;
-  query: string;
-  expectedIds: string[];
-  expectedAnswer?: string;
-};
+export type BenchmarkCase = { id: string; query: string; expectedIds: string[]; expectedAnswer?: string };
 
 export type SearchHit = { id: string; source_file?: string; sourceFile?: string };
 export type SearchRequest = { query: string; topK: number; mode: BenchmarkMode; model: string };
@@ -56,6 +51,12 @@ export function guardTopK(topK: number, corpusSize: number): void {
   }
 }
 
+function validateBenchmarkInputs(cases: BenchmarkCase[], corpus: CorpusRef, topK: number): void {
+  if (!cases.length) throw new Error('benchmark dataset has no cases');
+  if (!stringField(corpus.label)) throw new Error('benchmark corpus/collection label is required');
+  guardTopK(topK, corpus.size);
+}
+
 export function parseDatasetText(text: string): BenchmarkCase[] {
   const trimmed = text.trim();
   if (!trimmed) return [];
@@ -93,8 +94,7 @@ export async function runHonestRecallBenchmark(options: {
   const mode = normalizeMode(options.mode ?? 'hybrid');
   const model = options.model ?? 'multi';
   const recallLabel = recallMetric(options.topK);
-  guardTopK(options.topK, options.corpus.size);
-  if (!options.cases.length) throw new Error('benchmark dataset has no cases');
+  validateBenchmarkInputs(options.cases, options.corpus, options.topK);
 
   const cases: HonestRecallReport['cases'] = [];
   for (const item of options.cases) {

--- a/tests/benchmarks/honest-recall.test.ts
+++ b/tests/benchmarks/honest-recall.test.ts
@@ -34,11 +34,36 @@ describe('honest recall benchmark harness', () => {
     await expect(runHonestRecallBenchmark({
       cases: [{ id: 'q1', query: 'alpha', expectedIds: ['doc-a'] }],
       corpus: { label: 'tiny', size: 4 },
-      topK: 4,
+      topK: 5,
       searcher,
       outFile,
       gitSha: 'abc123',
-    })).rejects.toThrow('top_k (4) must be smaller than corpus_size (4)');
+    })).rejects.toThrow('top_k (5) must be smaller than corpus_size (4)');
+    expect(existsSync(outFile)).toBe(false);
+  });
+
+  test('refuses empty datasets and missing corpus labels before searching', async () => {
+    const outFile = tempFile('empty.json');
+    let searchCalls = 0;
+    const searcher: Searcher = async () => { searchCalls += 1; return []; };
+
+    await expect(runHonestRecallBenchmark({
+      cases: parseDatasetText(' \n '),
+      corpus: { label: 'oracle-test', size: 10 },
+      topK: 3,
+      searcher,
+      outFile,
+      gitSha: 'abc123',
+    })).rejects.toThrow('benchmark dataset has no cases');
+    await expect(runHonestRecallBenchmark({
+      cases: [{ id: 'q1', query: 'alpha', expectedIds: ['doc-a'] }],
+      corpus: { label: '', size: 10 },
+      topK: 3,
+      searcher,
+      outFile,
+      gitSha: 'abc123',
+    })).rejects.toThrow('benchmark corpus/collection label is required');
+    expect(searchCalls).toBe(0);
     expect(existsSync(outFile)).toBe(false);
   });
 


### PR DESCRIPTION
## Summary
- harden the honest-recall harness input gate before any search/output work
- keep `top_k > corpus_size` covered by the benchmark runner, not only the raw guard helper
- add regression coverage for empty datasets and missing corpus/collection labels

## Validation
- `bun test --isolate tests/benchmarks/` ✅
- `bunx tsc --noEmit` ✅
- `cd frontend && bun run build` ✅
- `wc -l benchmarks/honest-recall.ts tests/benchmarks/honest-recall.test.ts` ✅ (`250`, `135`)

Refs #2464