### PR TITLE
test(benchmarks): expand recall dataset edge cases

### DIFF
--- a/benchmarks/fixtures/recall-dataset.jsonl
+++ b/benchmarks/fixtures/recall-dataset.jsonl
@@ -38,3 +38,11 @@
 {"id":"plugins/toggle","query":"enable and disable MCP tool plugins through the CLI manifest commands","expectedIds":["pub-plugin-toggle"]}
 {"id":"benchmarks/guard-topk","query":"honest recall benchmark refuses to report when top k covers the whole corpus","expectedIds":["pub-benchmark-guard-topk"]}
 {"id":"benchmarks/answer-accuracy","query":"recall harness reports Answer Accuracy as not measured separate from Recall at k","expectedIds":["pub-benchmark-metric-separation"]}
+{"id":"edge/multi-word-install-path","query":"global bun install path verification after alpha prerelease install","expectedIds":["pub-quickstart-install"]}
+{"id":"edge/multi-word-cross-origin","query":"hosted Studio browser fetch to localhost backend CORS allow origin credentials","expectedIds":["pub-cors-hosted-studio"]}
+{"id":"edge/multi-word-health-timeout","query":"never silent health hero startup grace escape timing retry counter","expectedIds":["pub-simple-health-timing"]}
+{"id":"edge/multi-word-memory-metrics","query":"heat distribution confidence histogram supersede chain valid time coverage metrics","expectedIds":["pub-memory-stats"]}
+{"id":"edge/no-match-weather","query":"tomorrow rainfall forecast for a city not present in Oracle memory","expectedIds":[]}
+{"id":"edge/no-match-recipes","query":"sourdough starter hydration schedule and baking temperature","expectedIds":[]}
+{"id":"edge/no-match-sports","query":"latest baseball playoff score and inning summary","expectedIds":[]}
+{"id":"edge/no-match-personal","query":"private diary entry location from a user home directory","expectedIds":[]}

--- a/benchmarks/honest-recall.ts
+++ b/benchmarks/honest-recall.ts
@@ -155,9 +155,9 @@ function recallMetric(topK: number): RecallMetricLabel {
 function parseCase(raw: unknown, index: number): BenchmarkCase {
   const row = raw && typeof raw === 'object' ? raw as Record<string, unknown> : {};
   const query = stringField(row.query) || stringField(row.question);
-  const expectedIds = stringArray(row.expectedIds ?? row.expected_ids ?? row.expected_doc_ids ?? row.relevant_ids ?? row.target_ids ?? row.evidence_ids);
+  const rawExpected = row.expectedIds ?? row.expected_ids ?? row.expected_doc_ids ?? row.relevant_ids ?? row.target_ids ?? row.evidence_ids, expectedIds = stringArray(rawExpected);
   if (!query) throw new Error(`case ${index + 1} missing query/question`);
-  if (!expectedIds.length) throw new Error(`case ${index + 1} missing expected/relevant ids`);
+  if (!Array.isArray(rawExpected)) throw new Error(`case ${index + 1} missing expected/relevant ids`);
   return {
     id: stringField(row.id) || `case-${index + 1}`,
     query,

--- a/tests/benchmarks/honest-recall.test.ts
+++ b/tests/benchmarks/honest-recall.test.ts
@@ -79,7 +79,12 @@ describe('honest recall benchmark harness', () => {
     expect(lines.length).toBeGreaterThanOrEqual(30);
     expect(lines.length).toBeLessThanOrEqual(50);
     expect(cases).toHaveLength(lines.length);
-    expect(cases.every((item) => item.id && item.query && item.expectedIds.length > 0)).toBe(true);
+    expect(cases.every((item) => item.id && item.query && Array.isArray(item.expectedIds))).toBe(true);
+    expect(cases.filter((item) => item.id.includes('multi-word'))).toHaveLength(4);
+    expect(cases.filter((item) => item.id.includes('no-match'))).toHaveLength(4);
+    expect(cases.filter((item) => item.expectedIds.length === 0).map((item) => item.id).sort())
+      .toEqual(['edge/no-match-personal', 'edge/no-match-recipes', 'edge/no-match-sports', 'edge/no-match-weather']);
+    expect(() => parseDatasetText('{"id":"bad","query":"missing expected ids"}')).toThrow('missing expected/relevant ids');
     expect(text).not.toContain('\u03c8/');
     expect(text).not.toContain('/Users/');
   });


### PR DESCRIPTION
## Summary
- Expanded the public recall JSONL fixture to 48 cases with multi-word query coverage and explicit no-match cases.
- Allowed empty `expectedIds` arrays for labeled no-match cases while still rejecting missing expected IDs.
- Strengthened parse validation to assert multi-word/no-match coverage and private-path guards.

## Tests
```bash
bun test --isolate tests/benchmarks/honest-recall.test.ts
bunx tsc --noEmit
wc -l benchmarks/honest-recall.ts benchmarks/fixtures/recall-dataset.jsonl tests/benchmarks/honest-recall.test.ts
```

Refs #2464
