### PR TITLE
feat(benchmarks): add optional honest recall rerank stage

### DIFF
--- a/benchmarks/honest-recall-cli.ts
+++ b/benchmarks/honest-recall-cli.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from 'node:fs';
+import { createHttpSearcher, parseDatasetText, runHonestRecallBenchmark } from './honest-recall.ts';
+import type { HonestRecallReport, MetricRow } from './honest-recall.ts';
+
+export async function runCli(args: string[]): Promise<void> {
+  const cli = parseArgs(args);
+  const report = await runHonestRecallBenchmark({
+    cases: parseDatasetText(readFileSync(cli.dataset, 'utf8')),
+    topK: cli.topK,
+    corpus: { label: cli.corpus, size: cli.corpusSize },
+    mode: cli.mode,
+    model: cli.model,
+    searcher: createHttpSearcher(cli.baseUrl),
+    outFile: cli.outFile,
+    rerank: cli.rerank ? { enabled: true, url: cli.rerankerUrl } : undefined,
+  });
+  printSummary(report);
+}
+
+function parseArgs(args: string[]) {
+  const opts = new Map<string, string>();
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (!arg.startsWith('--')) continue;
+    if (arg === '--rerank') opts.set('rerank', 'true');
+    else { opts.set(arg.slice(2), args[i + 1] ?? ''); i += 1; }
+  }
+  return {
+    dataset: required(opts, 'dataset'),
+    corpus: opts.get('corpus') || 'oracle-hybrid-kb',
+    corpusSize: Number(opts.get('corpus-size')),
+    topK: Number(opts.get('top-k') ?? (opts.has('rerank') ? 3 : 10)),
+    mode: cliMode(opts.get('mode') ?? 'hybrid'),
+    model: opts.get('model') ?? 'multi',
+    baseUrl: opts.get('base-url') ?? 'http://127.0.0.1:47778',
+    outFile: opts.get('out') ?? 'benchmarks/out/honest-recall.json',
+    rerank: opts.has('rerank'),
+    rerankerUrl: opts.get('reranker-url'),
+  };
+}
+
+function cliMode(value: string) {
+  if (value === 'hybrid' || value === 'fts' || value === 'vector') return value;
+  throw new Error('mode must be one of: hybrid, fts, vector');
+}
+
+function required(opts: Map<string, string>, key: string): string {
+  const value = opts.get(key);
+  if (!value) throw new Error(`missing --${key}`);
+  return value;
+}
+
+function printSummary(report: HonestRecallReport): void {
+  const recall = report.metrics.find((row): row is Extract<MetricRow, { metric_family: 'Recall@k' }> => row.metric_family === 'Recall@k');
+  if (!recall) throw new Error('Recall@k metric row missing');
+  console.log(`${recall.label}: ${recall.value} (${recall.hits}/${recall.total_queries})`);
+  console.log('Answer-Accuracy: NOT MEASURED — retrieval-only harness');
+  console.log(`provenance_json: ${report.provenance.mode}/${report.provenance.model} top_k=${report.provenance.top_k}`);
+}

--- a/benchmarks/honest-recall-rerank.ts
+++ b/benchmarks/honest-recall-rerank.ts
@@ -1,0 +1,43 @@
+import { rerankCandidates } from '../src/server/reranker.ts';
+import type { BenchmarkMode, Searcher, SearchHit } from './honest-recall.ts';
+
+const RERANK_RETRIEVE_K = 100;
+const RERANK_MODEL = 'bge-reranker-v2-m3';
+
+export type RerankOptions = { enabled?: boolean; url?: string; timeoutMs?: number };
+export type RerankStage = { enabled: boolean; model?: string; retrieve_k?: number; applied: boolean; fallback_reason?: string };
+
+export function rerankStage(enabled: boolean): RerankStage {
+  return enabled ? { enabled: true, model: RERANK_MODEL, retrieve_k: RERANK_RETRIEVE_K, applied: false } : { enabled: false, applied: false };
+}
+
+export async function searchWithOptionalRerank(input: {
+  searcher: Searcher;
+  query: string;
+  topK: number;
+  mode: BenchmarkMode;
+  model: string;
+  rerank?: RerankOptions;
+  stage: RerankStage;
+}): Promise<SearchHit[]> {
+  if (!input.rerank?.enabled) {
+    return (await input.searcher(input)).slice(0, input.topK);
+  }
+
+  const candidates = await input.searcher({ ...input, topK: Math.max(RERANK_RETRIEVE_K, input.topK) });
+  const reranked = await rerankCandidates({
+    query: input.query,
+    candidates,
+    getText: hitText,
+    topK: input.topK,
+    url: input.rerank.url,
+    timeoutMs: input.rerank.timeoutMs,
+  });
+  input.stage.applied ||= reranked.reranked;
+  if (reranked.fallbackReason) input.stage.fallback_reason = reranked.fallbackReason;
+  return reranked.results.slice(0, input.topK);
+}
+
+function hitText(hit: SearchHit): string {
+  return hit.content || hit.text || hit.title || hit.source_file || hit.sourceFile || hit.id;
+}

--- a/benchmarks/honest-recall.ts
+++ b/benchmarks/honest-recall.ts
@@ -1,5 +1,6 @@
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
+import { rerankStage, searchWithOptionalRerank, type RerankOptions, type RerankStage } from './honest-recall-rerank.ts';
 
 export type MetricName = 'Recall@k' | 'Answer-Accuracy';
 export type BenchmarkMode = 'hybrid' | 'fts' | 'vector';
@@ -7,13 +8,13 @@ type RecallMetricLabel = `Recall@${number}`;
 
 export type BenchmarkCase = { id: string; query: string; expectedIds: string[]; expectedAnswer?: string };
 
-export type SearchHit = { id: string; source_file?: string; sourceFile?: string };
+export type SearchHit = { id: string; source_file?: string; sourceFile?: string; content?: string; text?: string; title?: string };
 export type SearchRequest = { query: string; topK: number; mode: BenchmarkMode; model: string };
 export type Searcher = (request: SearchRequest) => Promise<SearchHit[]>;
 
 type CorpusRef = { label: string; size: number };
 
-type MetricRow =
+export type MetricRow =
   | { metric: 'Recall@k'; metric_family: 'Recall@k'; label: RecallMetricLabel; value: number; hits: number; total_queries: number; top_k: number }
   | { metric: 'Answer-Accuracy'; metric_family: 'Answer-Accuracy'; status: 'not-measured'; reason: string };
 
@@ -29,6 +30,7 @@ export type HonestRecallReport = {
     metric_family: 'Recall@k';
     'git-sha': string;
     stack: string[];
+    rerank?: RerankStage;
   };
   metrics: MetricRow[];
   cases: Array<{
@@ -90,15 +92,19 @@ export async function runHonestRecallBenchmark(options: {
   outFile?: string;
   gitSha?: string;
   now?: string;
+  rerank?: RerankOptions;
 }): Promise<HonestRecallReport> {
   const mode = normalizeMode(options.mode ?? 'hybrid');
   const model = options.model ?? 'multi';
   const recallLabel = recallMetric(options.topK);
   validateBenchmarkInputs(options.cases, options.corpus, options.topK);
+  const stage = rerankStage(options.rerank?.enabled === true);
 
   const cases: HonestRecallReport['cases'] = [];
   for (const item of options.cases) {
-    const hits = (await options.searcher({ query: item.query, topK: options.topK, mode, model })).slice(0, options.topK);
+    const hits = await searchWithOptionalRerank({
+      searcher: options.searcher, query: item.query, topK: options.topK, mode, model, rerank: options.rerank, stage,
+    });
     const expected = new Set(item.expectedIds);
     const matchedIndex = hits.findIndex((hit) => keysForHit(hit).some((key) => expected.has(key)));
     cases.push({
@@ -126,7 +132,8 @@ export async function runHonestRecallBenchmark(options: {
       metric: 'Recall@k',
       metric_family: 'Recall@k',
       'git-sha': options.gitSha ?? readGitSha(),
-      stack: mode === 'hybrid' && model === 'multi' ? ['bge-m3', 'nomic', 'qwen3', 'FTS5'] : [model, mode],
+      stack: stackFor(mode, model, stage),
+      ...(stage.enabled ? { rerank: stage } : {}),
     },
     metrics: [
       { metric: 'Recall@k', metric_family: 'Recall@k', label: recallLabel, value: recall, hits, total_queries: cases.length, top_k: options.topK },
@@ -179,7 +186,13 @@ function toHit(value: unknown): SearchHit | null {
   if (!value || typeof value !== 'object') return null;
   const row = value as Record<string, unknown>;
   const id = stringField(row.id);
-  return id ? { id, source_file: stringField(row.source_file), sourceFile: stringField(row.sourceFile) } : null;
+  if (!id) return null;
+  const hit: SearchHit = { id, sourceFile: stringField(row.sourceFile) };
+  for (const key of ['source_file', 'content', 'text', 'title'] as const) {
+    const value = stringField(row[key]);
+    if (value) hit[key] = value;
+  }
+  return hit;
 }
 
 function keysForHit(hit: SearchHit): string[] {
@@ -190,59 +203,21 @@ function roundMetric(value: number): number {
   return Number(value.toFixed(6));
 }
 
+function stackFor(mode: BenchmarkMode, model: string, stage: RerankStage): string[] {
+  const base = mode === 'hybrid' && model === 'multi' ? ['bge-m3', 'nomic', 'qwen3', 'FTS5'] : [model, mode];
+  return stage.enabled ? [...base, 'bge-reranker-v2-m3'] : base;
+}
+
 function readGitSha(): string {
   const proc = Bun.spawnSync(['git', 'rev-parse', 'HEAD']);
   return proc.success ? new TextDecoder().decode(proc.stdout).trim() : 'unknown';
 }
 
-function parseArgs(args: string[]) {
-  const opts = new Map<string, string>();
-  for (let i = 0; i < args.length; i += 1) {
-    const arg = args[i];
-    if (!arg.startsWith('--')) continue;
-    opts.set(arg.slice(2), args[i + 1] ?? '');
-    i += 1;
-  }
-  return {
-    dataset: required(opts, 'dataset'),
-    corpus: opts.get('corpus') || 'oracle-hybrid-kb',
-    corpusSize: Number(opts.get('corpus-size')),
-    topK: Number(opts.get('top-k') ?? 10),
-    mode: normalizeMode(opts.get('mode') ?? 'hybrid'),
-    model: opts.get('model') ?? 'multi',
-    baseUrl: opts.get('base-url') ?? 'http://127.0.0.1:47778',
-    outFile: opts.get('out') ?? 'benchmarks/out/honest-recall.json',
-  };
-}
-
-function required(opts: Map<string, string>, key: string): string {
-  const value = opts.get(key);
-  if (!value) throw new Error(`missing --${key}`);
-  return value;
-}
-
-function printSummary(report: HonestRecallReport): void {
-  const recall = report.metrics.find((row): row is Extract<MetricRow, { metric_family: 'Recall@k' }> => row.metric_family === 'Recall@k');
-  if (!recall) throw new Error('Recall@k metric row missing');
-  console.log(`${recall.label}: ${recall.value} (${recall.hits}/${recall.total_queries})`);
-  console.log('Answer-Accuracy: NOT MEASURED — retrieval-only harness');
-  console.log(`provenance_json: ${report.provenance.mode}/${report.provenance.model} top_k=${report.provenance.top_k}`);
-}
 
 if (import.meta.main) {
   try {
-    const cli = parseArgs(Bun.argv.slice(2));
-    const cases = parseDatasetText(readFileSync(cli.dataset, 'utf8'));
-    const report = await runHonestRecallBenchmark({
-      cases,
-      topK: cli.topK,
-      corpus: { label: cli.corpus, size: cli.corpusSize },
-      mode: cli.mode,
-      model: cli.model,
-      searcher: createHttpSearcher(cli.baseUrl),
-      outFile: cli.outFile,
-    });
-    printSummary(report);
+    const { runCli } = await import('./honest-recall-cli.ts');
+    await runCli(Bun.argv.slice(2));
   } catch (error) {
     console.error(`HONEST BENCHMARK REFUSED: ${error instanceof Error ? error.message : String(error)}`);
     process.exit(1);

--- a/tests/benchmarks/honest-recall-rerank.test.ts
+++ b/tests/benchmarks/honest-recall-rerank.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'bun:test';
+import { runHonestRecallBenchmark, type Searcher } from '../../benchmarks/honest-recall.ts';
+
+describe('honest recall benchmark rerank stage', () => {
+  test('is off by default and keeps the requested retrieval depth', async () => {
+    const seen: number[] = [];
+    const searcher: Searcher = async ({ topK }) => {
+      seen.push(topK);
+      return [{ id: 'doc-a' }, { id: 'doc-b' }];
+    };
+
+    const report = await runHonestRecallBenchmark({
+      cases: [{ id: 'q1', query: 'alpha', expectedIds: ['doc-a'] }],
+      corpus: { label: 'tiny', size: 10 },
+      topK: 3,
+      searcher,
+      gitSha: 'abc123',
+      now: '2026-06-17T00:00:00.000Z',
+    });
+
+    expect(seen).toEqual([3]);
+    expect(report.provenance.rerank).toBeUndefined();
+    expect(report.cases[0].retrieved_ids).toEqual(['doc-a', 'doc-b']);
+  });
+
+  test('fetches 100 hybrid/RRF candidates and reranks them to the final topK', async () => {
+    const sidecar = Bun.serve({
+      hostname: '127.0.0.1',
+      port: 0,
+      async fetch(request) {
+        const body = await request.json() as { candidates: string[]; top_k: number };
+        expect(new URL(request.url).pathname).toBe('/rerank');
+        expect(body.candidates).toHaveLength(4);
+        expect(body.top_k).toBe(3);
+        return Response.json({
+          model: 'BAAI/bge-reranker-v2-m3',
+          results: [2, 0, 1].map((index) => ({ index, score: 1 - index / 10, document: body.candidates[index] })),
+        });
+      },
+    });
+    const seen: number[] = [];
+    const searcher: Searcher = async ({ topK }) => {
+      seen.push(topK);
+      return [
+        { id: 'doc-a', content: 'alpha first' },
+        { id: 'doc-b', content: 'beta second' },
+        { id: 'doc-c', content: 'best answer' },
+        { id: 'doc-d', content: 'extra candidate' },
+      ];
+    };
+
+    try {
+      const report = await runHonestRecallBenchmark({
+        cases: [{ id: 'q1', query: 'alpha', expectedIds: ['doc-c'] }],
+        corpus: { label: 'tiny', size: 10 },
+        topK: 3,
+        searcher,
+        rerank: { enabled: true, url: `http://127.0.0.1:${sidecar.port}` },
+        gitSha: 'abc123',
+        now: '2026-06-17T00:00:00.000Z',
+      });
+
+      expect(seen).toEqual([100]);
+      expect(report.provenance.rerank).toMatchObject({ enabled: true, model: 'bge-reranker-v2-m3', retrieve_k: 100, applied: true });
+      expect(report.provenance.stack).toContain('bge-reranker-v2-m3');
+      expect(report.cases[0]).toMatchObject({ retrieved_ids: ['doc-c', 'doc-a', 'doc-b'], hit: true, matched_rank: 1 });
+    } finally {
+      await sidecar.stop(true);
+    }
+  });
+});


### PR DESCRIPTION
Ref #2472

## Summary
- add optional honest recall `--rerank` path using retrieve-100 candidates then bge-reranker-v2-m3 topK reranking
- keep rerank off by default and default rerank CLI output to top-3
- split CLI/rerank helpers so changed files remain <=250 lines

## Validation
- bun test tests/benchmarks/
- bunx tsc --noEmit
- wc -l changed files <=250

Frontend untouched; frontend build not run.