### PR TITLE
feat: configure search retrieve depth

### DIFF
--- a/benchmarks/honest-recall-cli.ts
+++ b/benchmarks/honest-recall-cli.ts
@@ -12,6 +12,7 @@ export async function runCli(args: string[]): Promise<void> {
     model: cli.model,
     searcher: createHttpSearcher(cli.baseUrl),
     outFile: cli.outFile,
+    retrieveDepth: Number.isSafeInteger(cli.retrieveDepth) ? cli.retrieveDepth : undefined,
     rerank: cli.rerank ? { enabled: true, url: cli.rerankerUrl } : undefined,
   });
   printSummary(report);
@@ -36,6 +37,7 @@ function parseArgs(args: string[]) {
     outFile: opts.get('out') ?? 'benchmarks/out/honest-recall.json',
     rerank: opts.has('rerank'),
     rerankerUrl: opts.get('reranker-url'),
+    retrieveDepth: Number(opts.get('retrieve-depth') ?? opts.get('candidate-pool') ?? NaN),
   };
 }
 

--- a/benchmarks/honest-recall-rerank.ts
+++ b/benchmarks/honest-recall-rerank.ts
@@ -1,30 +1,30 @@
 import { rerankCandidates } from '../src/server/reranker.ts';
 import type { BenchmarkMode, Searcher, SearchHit } from './honest-recall.ts';
 
-const RERANK_RETRIEVE_K = 100;
 const RERANK_MODEL = 'bge-reranker-v2-m3';
 
 export type RerankOptions = { enabled?: boolean; url?: string; timeoutMs?: number };
 export type RerankStage = { enabled: boolean; model?: string; retrieve_k?: number; applied: boolean; fallback_reason?: string };
 
-export function rerankStage(enabled: boolean): RerankStage {
-  return enabled ? { enabled: true, model: RERANK_MODEL, retrieve_k: RERANK_RETRIEVE_K, applied: false } : { enabled: false, applied: false };
+export function rerankStage(enabled: boolean, retrieveDepth: number): RerankStage {
+  return enabled ? { enabled: true, model: RERANK_MODEL, retrieve_k: retrieveDepth, applied: false } : { enabled: false, applied: false };
 }
 
 export async function searchWithOptionalRerank(input: {
   searcher: Searcher;
   query: string;
   topK: number;
+  retrieveDepth: number;
   mode: BenchmarkMode;
   model: string;
   rerank?: RerankOptions;
   stage: RerankStage;
 }): Promise<SearchHit[]> {
   if (!input.rerank?.enabled) {
-    return (await input.searcher(input)).slice(0, input.topK);
+    return (await input.searcher({ query: input.query, topK: input.retrieveDepth, mode: input.mode, model: input.model })).slice(0, input.topK);
   }
 
-  const candidates = await input.searcher({ ...input, topK: Math.max(RERANK_RETRIEVE_K, input.topK) });
+  const candidates = await input.searcher({ query: input.query, topK: input.retrieveDepth, mode: input.mode, model: input.model });
   const reranked = await rerankCandidates({
     query: input.query,
     candidates,

--- a/benchmarks/honest-recall.ts
+++ b/benchmarks/honest-recall.ts
@@ -1,5 +1,6 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
+import { candidatePoolSize } from '../src/search/retrieve-depth.ts';
 import { buildRetrievalMetrics, type MetricSamples, type RetrievalMetricRow } from './honest-recall-methodology.ts';
 import { rerankStage, searchWithOptionalRerank, type RerankOptions, type RerankStage } from './honest-recall-rerank.ts';
 
@@ -59,17 +60,19 @@ export function createHttpSearcher(baseUrl: string): Searcher {
 
 export async function runHonestRecallBenchmark(options: {
   cases: BenchmarkCase[]; corpus: CorpusRef; topK: number; mode?: BenchmarkMode; model?: string;
-  searcher: Searcher; outFile?: string; gitSha?: string; now?: string; rerank?: RerankOptions; metricSamples?: MetricSamples;
+  searcher: Searcher; outFile?: string; gitSha?: string; now?: string;
+  retrieveDepth?: number; rerank?: RerankOptions; metricSamples?: MetricSamples;
 }): Promise<HonestRecallReport> {
   const mode = normalizeMode(options.mode ?? 'hybrid');
   const model = options.model ?? 'multi';
   const recallLabel = recallMetric(options.topK);
+  const retrieveDepth = candidatePoolSize(options.topK, options.retrieveDepth === undefined ? process.env : { ORACLE_RETRIEVE_DEPTH: String(options.retrieveDepth) });
   validateBenchmarkInputs(options.cases, options.corpus, options.topK);
-  const stage = rerankStage(options.rerank?.enabled === true);
+  const stage = rerankStage(options.rerank?.enabled === true, retrieveDepth);
   const cases: HonestRecallReport['cases'] = [];
   for (const item of options.cases) {
     const hits = await searchWithOptionalRerank({
-      searcher: options.searcher, query: item.query, topK: options.topK, mode, model, rerank: options.rerank, stage,
+      searcher: options.searcher, query: item.query, topK: options.topK, retrieveDepth, mode, model, rerank: options.rerank, stage,
     });
     const expected = new Set(item.expectedIds);
     const retrievedIds = hits.map((hit) => hit.id);
@@ -137,3 +140,4 @@ if (import.meta.main) {
   try { const { runCli } = await import('./honest-recall-cli.ts'); await runCli(Bun.argv.slice(2)); }
   catch (error) { console.error(`HONEST BENCHMARK REFUSED: ${error instanceof Error ? error.message : String(error)}`); process.exit(1); }
 }
+

--- a/src/search/__tests__/retrieve-depth.test.ts
+++ b/src/search/__tests__/retrieve-depth.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test';
+import { candidatePoolSize, configuredRetrieveDepth, DEFAULT_RETRIEVE_DEPTH, MAX_RETRIEVE_DEPTH } from '../retrieve-depth.ts';
+
+describe('retrieve depth config', () => {
+  test('defaults per-retriever candidate pools to around 100', () => {
+    expect(DEFAULT_RETRIEVE_DEPTH).toBe(100);
+    expect(candidatePoolSize(3, {})).toBe(100);
+    expect(candidatePoolSize(150, {})).toBe(150);
+  });
+
+  test('allows bounded env override without shrinking below requested top k', () => {
+    expect(configuredRetrieveDepth({ ORACLE_RETRIEVE_DEPTH: '80' })).toBe(80);
+    expect(candidatePoolSize(10, { ORACLE_RETRIEVE_DEPTH: '80' })).toBe(80);
+    expect(candidatePoolSize(120, { ORACLE_RETRIEVE_DEPTH: '80' })).toBe(120);
+    expect(configuredRetrieveDepth({ ORACLE_RETRIEVE_DEPTH: String(MAX_RETRIEVE_DEPTH + 1) })).toBe(MAX_RETRIEVE_DEPTH);
+  });
+});

--- a/src/search/retrieve-depth.ts
+++ b/src/search/retrieve-depth.ts
@@ -1,0 +1,16 @@
+export const DEFAULT_RETRIEVE_DEPTH = 100;
+export const MAX_RETRIEVE_DEPTH = 500;
+
+export function configuredRetrieveDepth(env: Record<string, string | undefined> = process.env): number {
+  return boundedDepth(Number(env.ORACLE_RETRIEVE_DEPTH ?? env.ORACLE_SEARCH_RETRIEVE_DEPTH));
+}
+
+export function candidatePoolSize(limit: number, env: Record<string, string | undefined> = process.env): number {
+  const requested = Number.isSafeInteger(limit) && limit > 0 ? limit : 1;
+  return Math.max(requested, configuredRetrieveDepth(env));
+}
+
+function boundedDepth(raw: number): number {
+  if (!Number.isSafeInteger(raw) || raw < 1) return DEFAULT_RETRIEVE_DEPTH;
+  return Math.min(raw, MAX_RETRIEVE_DEPTH);
+}

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -22,6 +22,7 @@ import { createVectorProxy } from './vector-proxy.ts';
 import { buildLearningMarkdown, dateSlug } from '../learn/markdown.ts';
 import { localNativeVectorDisabledReason, localVectorIndexMissingReason, logLocalVectorDisabled } from '../vector/cpu-capabilities.ts';
 import { isVectorSectionEnabled } from '../vector/config.ts';
+import { candidatePoolSize } from '../search/retrieve-depth.ts';
 
 // Module-level proxy instance — bound to VECTOR_URL at boot. If VECTOR_URL is
 // unset, this is null and the local vector adapter runs in-process (legacy
@@ -101,6 +102,7 @@ export async function handleSearch(
   const resolvedProject = (project ?? detectProject(cwd))?.toLowerCase() ?? null;
   const startTime = Date.now();
   const ftsQuery = buildFtsQuery(query);
+  const retrieveDepth = candidatePoolSize(limit);
   if (!ftsQuery) {
     return { results: [], total: 0, limit, offset, query };
   }
@@ -162,7 +164,7 @@ export async function handleSearch(
         ORDER BY rank
         LIMIT ?
       `);
-      ftsResults = runFtsAll<any>(stmt, [ftsQuery, ...projectParams, limit * 3]).map((row: any) => ({
+      ftsResults = runFtsAll<any>(stmt, [ftsQuery, ...projectParams, retrieveDepth]).map((row: any) => ({
         id: row.id,
         type: row.type,
         content: row.content,
@@ -189,7 +191,7 @@ export async function handleSearch(
         ORDER BY rank
         LIMIT ?
       `);
-      ftsResults = runFtsAll<any>(stmt, [ftsQuery, type, ...projectParams, limit * 3]).map((row: any) => ({
+      ftsResults = runFtsAll<any>(stmt, [ftsQuery, type, ...projectParams, retrieveDepth]).map((row: any) => ({
         id: row.id,
         type: row.type,
         content: row.content,
@@ -218,8 +220,8 @@ export async function handleSearch(
     const remote = await vectorProxy.search({
       q: query,
       type,
-      limit,
-      offset,
+      limit: retrieveDepth,
+      offset: 0,
       mode: 'vector',
       project: resolvedProject ?? undefined,
       cwd,
@@ -237,7 +239,7 @@ export async function handleSearch(
       const vector = await localVectorOperations.search({
         query,
         type,
-        limit,
+        limit: retrieveDepth,
         project: resolvedProject,
         model,
       });

--- a/src/server/vector-operations.ts
+++ b/src/server/vector-operations.ts
@@ -28,7 +28,7 @@ async function searchOneModel(input: VectorSearchInput, model: string | undefine
   const limit = input.limit ?? 10;
   const isMulti = input.model === 'multi';
   const whereFilter = input.type && input.type !== 'all' ? { type: input.type } : undefined;
-  const vectorRows = await client.query(input.query, isMulti ? limit : limit * 2, whereFilter);
+  const vectorRows = await client.query(input.query, limit, whereFilter);
 
   if (!vectorRows.ids || vectorRows.ids.length === 0) return [];
 

--- a/src/tools/search/handler.ts
+++ b/src/tools/search/handler.ts
@@ -6,6 +6,7 @@ import { queryPointerIndex } from '../../search/pointer-index.ts';
 import { rerankCandidates } from '../../server/reranker.ts';
 import type { SearchResult } from '../../server/types.ts';
 import { compactSearchResults, parseSearchRetrievalMode } from '../../search/compact-summary.ts';
+import { candidatePoolSize } from '../../search/retrieve-depth.ts';
 import { isVectorSectionEnabled } from '../../vector/config.ts';
 import type { ToolContext, ToolResponse, OracleSearchInput } from '../types.ts';
 import { applyEntityLinkBoost, hasEntityLinkSearchHook, queryEntityLinks } from './entities.ts';
@@ -28,6 +29,7 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
 
   const augmentedQuery = augmentQueryWithAcronyms(query);
   const safeQuery = sanitizeFtsQuery(augmentedQuery);
+  const retrieveDepth = candidatePoolSize(limit);
   const resolvedProject = (project ?? detectProject(cwd))?.toLowerCase() ?? null;
   let warning: string | undefined;
   let vectorSearchError = false;
@@ -40,7 +42,7 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
   let ftsRawResults: ReturnType<typeof searchFts> = [];
   if (effectiveMode !== 'vector' && safeQuery) {
     try {
-      ftsRawResults = searchFts(ctx, safeQuery, type, limit * 3, resolvedProject);
+      ftsRawResults = searchFts(ctx, safeQuery, type, retrieveDepth, resolvedProject);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       warning = `FTS5 keyword search unavailable: ${errorMessage}`;
@@ -51,7 +53,7 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
   const pointerResults = queryPointerIndex(ctx.sqlite, {
     query: augmentedQuery,
     type,
-    limit: limit * 3,
+    limit: retrieveDepth,
     project: resolvedProject,
     tenantId: currentTenantId(),
   });
@@ -59,7 +61,7 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
   let vecResults: Awaited<ReturnType<typeof vectorSearch>> = [];
   if (effectiveMode !== 'fts') {
     try {
-      vecResults = await vectorSearch(ctx, augmentedQuery, type, limit * 2, model);
+      vecResults = await vectorSearch(ctx, augmentedQuery, type, retrieveDepth, model);
     } catch (error) {
       vectorSearchError = true;
       vectorAvailable = false;
@@ -78,11 +80,11 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
   const entityRankedResults = rerankByEntityLinks(ctx.sqlite, combinedResults, augmentedQuery, currentTenantId());
   const reranked = await rerankCandidates({
     query,
-    candidates: entityRankedResults.slice(0, 50),
+    candidates: entityRankedResults.slice(0, retrieveDepth),
     getText: (result) => result.content,
   });
   const finalResults = reranked.reranked
-    ? [...reranked.results, ...entityRankedResults.slice(50)]
+    ? [...reranked.results, ...entityRankedResults.slice(retrieveDepth)]
     : entityRankedResults;
   const hasEntityHook = hasEntityLinkSearchHook(ctx);
   const entityLinksEnabled = requestedMode !== 'fts' && (effectiveMode !== 'fts' || hasEntityHook);
@@ -90,7 +92,7 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
   let entityLinkWarning: string | undefined;
   if (entityLinksEnabled && finalResults.length > 0) {
     try {
-      entityLinkHits = await queryEntityLinks(ctx, augmentedQuery, Math.max(limit * 3, 10), model);
+      entityLinkHits = await queryEntityLinks(ctx, augmentedQuery, retrieveDepth, model);
     } catch (error) {
       entityLinkWarning = error instanceof Error ? error.message : String(error);
       console.error('[EntityLinkSearch]', entityLinkWarning);
@@ -110,6 +112,7 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
   const metadata = {
     mode,
     limit,
+    retrieveDepth,
     offset,
     total: totalMatches,
     ftsMatches: ftsRawResults.length,

--- a/tests/benchmarks/honest-recall-rerank.test.ts
+++ b/tests/benchmarks/honest-recall-rerank.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { runHonestRecallBenchmark, type Searcher } from '../../benchmarks/honest-recall.ts';
 
 describe('honest recall benchmark rerank stage', () => {
-  test('is off by default and keeps the requested retrieval depth', async () => {
+  test('is off by default and still retrieves the configured candidate pool', async () => {
     const seen: number[] = [];
     const searcher: Searcher = async ({ topK }) => {
       seen.push(topK);
@@ -18,7 +18,7 @@ describe('honest recall benchmark rerank stage', () => {
       now: '2026-06-17T00:00:00.000Z',
     });
 
-    expect(seen).toEqual([3]);
+    expect(seen).toEqual([100]);
     expect(report.provenance.rerank).toBeUndefined();
     expect(report.cases[0].retrieved_ids).toEqual(['doc-a', 'doc-b']);
   });

--- a/tests/benchmarks/honest-recall-retrieve-depth.test.ts
+++ b/tests/benchmarks/honest-recall-retrieve-depth.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+import { runHonestRecallBenchmark, type Searcher } from '../../benchmarks/honest-recall.ts';
+
+describe('honest recall retrieve depth', () => {
+  test('requests a deeper configured candidate pool before truncating to Recall@k', async () => {
+    const requested: number[] = [];
+    const searcher: Searcher = async ({ topK }) => {
+      requested.push(topK);
+      return Array.from({ length: topK }, (_, index) => ({ id: index === 9 ? 'doc-a' : `noise-${index}` }));
+    };
+
+    const report = await runHonestRecallBenchmark({
+      cases: [{ id: 'q1', query: 'alpha', expectedIds: ['doc-a'] }],
+      corpus: { label: 'oracle-test', size: 30 },
+      topK: 3,
+      retrieveDepth: 10,
+      searcher,
+      gitSha: 'abc123',
+    });
+
+    expect(requested).toEqual([10]);
+    expect(report.cases[0].retrieved_ids).toHaveLength(3);
+    expect(report.metrics[0]).toMatchObject({ value: 0, top_k: 3 });
+  });
+});


### PR DESCRIPTION
Refs #2472

## Summary
- add shared retrieve-depth config (default 100, bounded env override) for per-retriever candidate pools
- use retrieveDepth for MCP/server FTS, pointer, vector, entity-link, rerank candidate retrieval before final top-k truncation
- update honest recall harness/CLI so candidate-pool retrieval is configurable before Recall@k slicing

## Validation
- bunx tsc --noEmit
- bun test tests/benchmarks/honest-recall.test.ts tests/benchmarks/honest-recall-retrieve-depth.test.ts tests/benchmarks/honest-recall-rerank.test.ts src/search/__tests__/retrieve-depth.test.ts tests/benchmarks/compact-summary-mode.test.ts src/tools/__tests__/search-compact-summary.test.ts src/tools/__tests__/search-entity-link.test.ts src/tools/__tests__/mcp-vector-guard.test.ts src/server/__tests__/search-vector-proxy-total.test.ts src/server/__tests__/vector-proxy-edge.test.ts

Note: no frontend files touched; frontend build not required.