### PR TITLE
feat: add acronym query and index enrichment

### DIFF
--- a/src/indexer/__tests__/storage-chunking.test.ts
+++ b/src/indexer/__tests__/storage-chunking.test.ts
@@ -41,7 +41,7 @@ describe('storeDocuments chunking', () => {
     const conn = createDatabase(dbPath);
     const vector = new FakeVectorStore();
     const para = (label: string, char: string) => `${label} ${char.repeat(330)}`;
-    const content = `${para('alpha', 'a')}\n\n${para('beta', 'b')}\n\n${para('gamma', 'c')}`;
+    const content = `${para('alpha CORS', 'a')}\n\n${para('beta', 'b')}\n\n${para('gamma', 'c')}`;
 
     try {
       await storeDocuments(conn.sqlite, conn.db, vector, null, [doc(content)], { tenantId: 'default' });
@@ -57,6 +57,9 @@ describe('storeDocuments chunking', () => {
       expect(rows[0].content).toContain('alpha');
       expect(rows[0].content).toContain('beta');
       expect(rows[0].content).not.toContain('gamma');
+      expect(rows[0].content).toContain('Search expansions:');
+      expect(rows[0].content).toContain('Cross-Origin Resource Sharing');
+      expect(vector.docs[0].document).toContain('Cross-Origin Resource Sharing');
       expect(rows[1].content).toContain('gamma');
       expect(vector.docs.map((item) => item.id)).toEqual(rows.map((row) => row.id));
       expect(vector.docs.map((item) => item.metadata.chunk_index)).toEqual([0, 1]);

--- a/src/indexer/learn-doc-source.ts
+++ b/src/indexer/learn-doc-source.ts
@@ -9,6 +9,7 @@ import type { OracleDocument } from '../types.ts';
 import { deriveConceptsFromPath, mergeConceptsWithTags } from './concepts.ts';
 import { inferProjectFromPath } from './discovery.ts';
 import { parseLearningFile } from './parser.ts';
+import { enrichTextWithAcronyms } from '../search/acronyms.ts';
 import { chunkDocumentsForIndexing } from './chunk-text.ts';
 import { replaceDocumentPointers } from '../search/pointer-index.ts';
 
@@ -116,11 +117,12 @@ export function storeSqliteDocuments(db: Database, documents: OracleDocument[]):
         now,
         doc.project?.toLowerCase() ?? null,
       );
+      const indexedContent = enrichTextWithAcronyms(doc.content);
       deleteFts.run(doc.id);
-      insertFts.run(doc.id, doc.content, doc.concepts.join(' '));
+      insertFts.run(doc.id, indexedContent, doc.concepts.join(' '));
       replaceDocumentPointers(db, {
         documentId: doc.id,
-        content: doc.content,
+        content: indexedContent,
         concepts: doc.concepts,
         timestamp: doc.updated_at || doc.created_at,
       });

--- a/src/indexer/storage.ts
+++ b/src/indexer/storage.ts
@@ -6,6 +6,7 @@ import { Database } from 'bun:sqlite';
 import { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 import * as schema from '../db/schema.ts';
 import { oracleDocuments } from '../db/schema.ts';
+import { enrichTextWithAcronyms } from '../search/acronyms.ts';
 import { tenantIdForWrite } from '../middleware/tenant.ts';
 import { replaceEntityLinks } from '../search/entity-ranking.ts';
 import { chunkDocumentsForIndexing } from './chunk-text.ts';
@@ -83,32 +84,34 @@ export async function storeDocuments(
         })
         .run();
 
+      const indexedContent = enrichTextWithAcronyms(doc.content);
+
       // SQLite FTS (raw SQL required for FTS5): delete then insert to avoid
       // duplicates across re-index runs.
       deleteFts.run(doc.id);
       insertFts.run(
         doc.id,
-        doc.content,
+        indexedContent,
         doc.concepts.join(' ')
       );
       replaceEntityLinks(sqlite, {
         documentId: doc.id,
         tenantId,
-        content: doc.content,
+        content: indexedContent,
         concepts: doc.concepts,
         now,
       });
       replaceDocumentPointers(sqlite, {
         documentId: doc.id,
         tenantId,
-        content: doc.content,
+        content: indexedContent,
         concepts: doc.concepts,
         timestamp: doc.updated_at || doc.created_at,
       });
 
       // Vector store metadata (must be primitives, not arrays)
       ids.push(doc.id);
-      contents.push(doc.content);
+      contents.push(indexedContent);
       metadatas.push({
         type: doc.type,
         tenant_id: tenantId,

--- a/src/routes/search/search.ts
+++ b/src/routes/search/search.ts
@@ -5,6 +5,7 @@
 import { Elysia } from 'elysia';
 import { sqlite } from '../../db/index.ts';
 import { currentTenantId } from '../../middleware/tenant.ts';
+import { augmentQueryWithAcronyms } from '../../search/acronyms.ts';
 import { filterResultsAsOf, parseAsOf } from '../../search/bitemporal.ts';
 import { compactSearchResults, parseSearchRetrievalMode } from '../../search/compact-summary.ts';
 import { rerankByEntityLinks } from '../../search/entity-ranking.ts';
@@ -61,8 +62,9 @@ export const searchEndpoint = new Elysia().get(
     const model = parsedModel.value;
 
     try {
-      const tenantResult = handleTenantSearch(sanitizedQ, type, limit, offset, asOf.value);
-      const result = tenantResult ?? await handleSearch(sanitizedQ, type, limit, offset, mode, project, cwd, model);
+      const augmentedQ = augmentQueryWithAcronyms(sanitizedQ);
+      const tenantResult = handleTenantSearch(augmentedQ, type, limit, offset, asOf.value);
+      const result = tenantResult ?? await handleSearch(augmentedQ, type, limit, offset, mode, project, cwd, model);
       if (asOf.value && !tenantResult) {
         result.results = filterResultsAsOf(
           sqlite,
@@ -71,7 +73,7 @@ export const searchEndpoint = new Elysia().get(
         ) as unknown as typeof result.results;
         result.total = result.results.length;
       }
-      result.results = rerankByEntityLinks(sqlite, result.results, sanitizedQ, currentTenantId());
+      result.results = rerankByEntityLinks(sqlite, result.results, augmentedQ, currentTenantId());
       attachSupersedeStatus(sqlite, result.results as unknown as Array<Record<string, unknown>>);
       const compact = retrieval.mode === 'compact-summary'
         ? compactSearchResults(result.results as unknown as Array<Record<string, unknown>>, sanitizedQ)

--- a/src/search/__tests__/acronyms.test.ts
+++ b/src/search/__tests__/acronyms.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+import { augmentQueryWithAcronyms, enrichTextWithAcronyms, expansionsForText } from '../acronyms.ts';
+
+describe('acronym query augmentation and ingestion enrichment', () => {
+  test('appends CORS, PNA, and vector preflight expansions to queries', () => {
+    const query = augmentQueryWithAcronyms('CORS PNA vector URL preflight');
+
+    expect(query).toStartWith('CORS PNA vector URL preflight');
+    expect(query).toContain('Cross-Origin Resource Sharing');
+    expect(query).toContain('Private Network Access');
+    expect(query).toContain('Access-Control-Request-Private-Network');
+    expect(query).toContain('vectorAvailable');
+    expect(query).toContain('vectorMode');
+  });
+
+  test('detects full-form phrases and injects missing abbreviations for indexed text', () => {
+    const content = enrichTextWithAcronyms('Browser Private Network Access checks the Vector URL during preflight.');
+
+    expect(content).toContain('Search expansions:');
+    expect(content).toContain('PNA');
+    expect(content).toContain('VECTOR_URL');
+    expect(content).toContain('vectorAvailable');
+  });
+
+  test('does not duplicate full forms already present in the source text', () => {
+    const additions = expansionsForText('CORS means Cross-Origin Resource Sharing.');
+
+    expect(additions).toContain('Access-Control-Allow-Origin');
+    expect(additions).not.toContain('CORS');
+    expect(additions).not.toContain('Cross-Origin Resource Sharing');
+  });
+});

--- a/src/search/__tests__/query.test.ts
+++ b/src/search/__tests__/query.test.ts
@@ -18,6 +18,8 @@ describe('search query helpers', () => {
     expect(parseConcepts('[" one ","one",7,"two"]')).toEqual(['one', 'two']);
     expect(parseConcepts('"not-array"')).toEqual([]);
     expect(buildTenantFtsQuery('<b>alpha</b> OR ( beta alpha gamma delta epsilon zeta eta theta iota'))
-      .toBe('"alpha" OR "OR" OR "beta" OR "gamma" OR "delta" OR "epsilon" OR "zeta" OR "eta"');
+      .toBe('"alpha" OR "OR" OR "beta" OR "gamma" OR "delta" OR "epsilon" OR "zeta" OR "eta" OR "theta" OR "iota"');
+    expect(buildTenantFtsQuery('CORS PNA'))
+      .toContain('"Cross" OR "Origin" OR "Resource" OR "Sharing" OR "Access"');
   });
 });

--- a/src/search/acronyms.ts
+++ b/src/search/acronyms.ts
@@ -1,0 +1,98 @@
+export type AcronymExpansion = Readonly<{ short: string; fullForms: readonly string[]; triggers?: readonly string[] }>;
+
+const EXPANSIONS: readonly AcronymExpansion[] = [
+  { short: 'CORS', fullForms: ['Cross-Origin Resource Sharing', 'Access-Control-Allow-Origin'], triggers: ['cross origin', 'cross-origin'] },
+  { short: 'PNA', fullForms: ['Private Network Access', 'Access-Control-Request-Private-Network'], triggers: ['private network'] },
+  { short: 'API', fullForms: ['Application Programming Interface'] },
+  { short: 'MCP', fullForms: ['Model Context Protocol'] },
+  { short: 'FTS', fullForms: ['Full Text Search'] },
+  { short: 'FTS5', fullForms: ['SQLite FTS5', 'Full Text Search'] },
+  { short: 'DB', fullForms: ['Database'] },
+  { short: 'URL', fullForms: ['Uniform Resource Locator'], triggers: ['vector url', 'vector_url'] },
+  { short: 'VECTOR_URL', fullForms: ['Vector URL', 'vector preflight', 'vectorAvailable', 'vectorMode'], triggers: ['vector url', 'vector preflight', 'vector available', 'vector mode'] },
+  { short: 'QTA', fullForms: ['Query-Time Augmentation', 'query time augmentation'], triggers: ['query time augmentation', 'query-time augmentation'] },
+  { short: 'ITE', fullForms: ['Ingestion-Time Enrichment', 'ingestion time enrichment'], triggers: ['ingestion time enrichment', 'ingestion-time enrichment'] },
+] as const;
+
+export const ACRONYM_EXPANSIONS = EXPANSIONS;
+
+export function expansionsForText(text: string): string[] {
+  const normalized = normalize(text);
+  const additions: string[] = [];
+  for (const item of EXPANSIONS) {
+    if (!matchesExpansion(normalized, item)) continue;
+    additions.push(item.short, ...item.fullForms);
+  }
+  return uniqueMissing(text, additions);
+}
+
+export function augmentQueryWithAcronyms(query: string): string {
+  const additions = expansionsForText(query);
+  return additions.length ? `${query} ${additions.join(' ')}` : query;
+}
+
+export function enrichTextWithAcronyms(text: string): string {
+  const additions = expansionsForText(text);
+  return additions.length ? `${text}\n\nSearch expansions: ${additions.join('; ')}` : text;
+}
+
+function matchesExpansion(normalizedText: string, item: AcronymExpansion): boolean {
+  if (containsTerm(normalizedText, item.short)) return true;
+  return [item.short, ...item.fullForms, ...(item.triggers ?? [])]
+    .some((term) => containsPhrase(normalizedText, term));
+}
+
+function uniqueMissing(original: string, values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const normalizedOriginal = normalize(original);
+  const joinedOriginal = normalizeJoinedTokens(original);
+  const out: string[] = [];
+  for (const value of values) {
+    const key = normalize(value);
+    const present = isJoinedAlias(value)
+      ? containsJoinedTerm(joinedOriginal, value)
+      : containsPhrase(normalizedOriginal, value);
+    if (!key || seen.has(key) || present) continue;
+    seen.add(key);
+    out.push(value);
+  }
+  return out;
+}
+
+function containsTerm(normalizedText: string, term: string): boolean {
+  const escaped = normalize(term).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`(?:^|\\s)${escaped}(?:\\s|$)`, 'i').test(normalizedText);
+}
+
+function containsJoinedTerm(normalizedText: string, term: string): boolean {
+  const escaped = normalizeJoinedTokens(term).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`(?:^|\\s)${escaped}(?:\\s|$)`, 'i').test(normalizedText);
+}
+
+function containsPhrase(normalizedText: string, phrase: string): boolean {
+  return normalizedText.includes(normalize(phrase));
+}
+
+function normalize(value: string): string {
+  return value
+    .normalize('NFKC')
+    .replace(/[_-]+/g, ' ')
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function isJoinedAlias(value: string): boolean {
+  return /^[A-Z0-9_]+$/.test(value) && value.includes('_');
+}
+
+function normalizeJoinedTokens(value: string): string {
+  return value
+    .normalize('NFKC')
+    .replace(/-+/g, '_')
+    .replace(/[^\p{L}\p{N}_]+/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}

--- a/src/search/query.ts
+++ b/src/search/query.ts
@@ -1,7 +1,9 @@
+import { augmentQueryWithAcronyms } from './acronyms.ts';
+
 export type SearchMode = 'hybrid' | 'fts' | 'vector';
 
 const SEARCH_MODES = new Set<SearchMode>(['hybrid', 'fts', 'vector']);
-const FTS_TOKEN_LIMIT = 8;
+const FTS_TOKEN_LIMIT = 32;
 
 function parseWholeNumber(value: string | undefined): number | undefined {
   const normalized = value?.trim();
@@ -41,7 +43,7 @@ export function parseConcepts(value: unknown): string[] {
 }
 
 export function buildTenantFtsQuery(query: string): string {
-  const tokens = query
+  const tokens = augmentQueryWithAcronyms(query)
     .replace(/<[^>]*>/g, ' ')
     .normalize('NFKC')
     .match(/[\p{L}\p{N}_]+/gu)

--- a/src/tools/__tests__/search.test.ts
+++ b/src/tools/__tests__/search.test.ts
@@ -44,6 +44,13 @@ describe('sanitizeFtsQuery', () => {
     expect(sanitizeFtsQuery('git safety')).toBe('\"git\" OR \"safety\"');
   });
 
+  it('should append acronym expansions to MCP search tokens', () => {
+    const query = sanitizeFtsQuery('CORS PNA vector URL preflight');
+    expect(query).toContain('\"Cross\" OR \"Origin\" OR \"Resource\" OR \"Sharing\"');
+    expect(query).toContain('\"Access\" OR \"Control\" OR \"Allow\"');
+    expect(query).toContain('\"vectorAvailable\"');
+  });
+
   it('should handle colons which break FTS5', () => {
     expect(sanitizeFtsQuery('error: no such column')).toBe('\"error\" OR \"no\" OR \"such\" OR \"column\"');
     expect(sanitizeFtsQuery('time: 15:30')).toBe('\"time\" OR \"15\" OR \"30\"');

--- a/src/tools/search/handler.ts
+++ b/src/tools/search/handler.ts
@@ -1,4 +1,5 @@
 import { detectProject } from '../../server/project-detect.ts';
+import { augmentQueryWithAcronyms } from '../../search/acronyms.ts';
 import { currentTenantId } from '../../middleware/tenant.ts';
 import { rerankByEntityLinks } from '../../search/entity-ranking.ts';
 import { queryPointerIndex } from '../../search/pointer-index.ts';
@@ -25,7 +26,8 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
   const retrieval = parseSearchRetrievalMode(input.retrieval);
   if (!retrieval.ok) throw new Error(retrieval.error);
 
-  const safeQuery = sanitizeFtsQuery(query);
+  const augmentedQuery = augmentQueryWithAcronyms(query);
+  const safeQuery = sanitizeFtsQuery(augmentedQuery);
   const resolvedProject = (project ?? detectProject(cwd))?.toLowerCase() ?? null;
   let warning: string | undefined;
   let vectorSearchError = false;
@@ -47,7 +49,7 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
   }
 
   const pointerResults = queryPointerIndex(ctx.sqlite, {
-    query,
+    query: augmentedQuery,
     type,
     limit: limit * 3,
     project: resolvedProject,
@@ -57,7 +59,7 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
   let vecResults: Awaited<ReturnType<typeof vectorSearch>> = [];
   if (effectiveMode !== 'fts') {
     try {
-      vecResults = await vectorSearch(ctx, query, type, limit * 2, model);
+      vecResults = await vectorSearch(ctx, augmentedQuery, type, limit * 2, model);
     } catch (error) {
       vectorSearchError = true;
       vectorAvailable = false;
@@ -73,7 +75,7 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
   const ftsResults = mapFtsResults(ftsRawResults);
   const normalizedVectorResults = vecResults.map((result) => ({ ...result, score: 1 - (result.score || 0) }));
   const combinedResults = combineResults(ftsResults, normalizedVectorResults, 0.5, 0.5, pointerResults);
-  const entityRankedResults = rerankByEntityLinks(ctx.sqlite, combinedResults, query, currentTenantId());
+  const entityRankedResults = rerankByEntityLinks(ctx.sqlite, combinedResults, augmentedQuery, currentTenantId());
   const reranked = await rerankCandidates({
     query,
     candidates: entityRankedResults.slice(0, 50),
@@ -88,7 +90,7 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
   let entityLinkWarning: string | undefined;
   if (entityLinksEnabled && finalResults.length > 0) {
     try {
-      entityLinkHits = await queryEntityLinks(ctx, query, Math.max(limit * 3, 10), model);
+      entityLinkHits = await queryEntityLinks(ctx, augmentedQuery, Math.max(limit * 3, 10), model);
     } catch (error) {
       entityLinkWarning = error instanceof Error ? error.message : String(error);
       console.error('[EntityLinkSearch]', entityLinkWarning);

--- a/src/tools/search/helpers.ts
+++ b/src/tools/search/helpers.ts
@@ -1,17 +1,21 @@
+import { augmentQueryWithAcronyms } from '../../search/acronyms.ts';
 import type { CombinedSearchResult, FtsResult, PointerResult, SearchConfidence, SearchProvenance, VectorResult } from './types.ts';
+
+const FTS_TOKEN_LIMIT = 32;
 
 /** Sanitize FTS5 query to prevent parse errors. */
 export function sanitizeFtsQuery(query: string): string {
-  const tokens = query
+  const tokens = augmentQueryWithAcronyms(query)
     .replace(/<[^>]*>/g, ' ')
     .normalize('NFKC')
     .match(/[\p{L}\p{N}_]+/gu)
     ?.map((token) => token.trim())
-    .filter((token) => token.length > 0)
-    .slice(0, 8) ?? [];
+    .filter((token) => token.length > 0) ?? [];
 
-  const uniqueTokens = Array.from(new Set(tokens));
-  return uniqueTokens.map((token) => `"${token.replace(/"/g, '""')}"`).join(' OR ');
+  return [...new Set(tokens)]
+    .slice(0, FTS_TOKEN_LIMIT)
+    .map((token) => `"${token.replace(/"/g, '""')}"`)
+    .join(' OR ');
 }
 
 /** Normalize FTS5 rank score using exponential decay. */

--- a/tests/http/search/query-hardening.test.ts
+++ b/tests/http/search/query-hardening.test.ts
@@ -18,7 +18,8 @@ test('search mode parser trims, lowercases, and rejects unknown modes', () => {
 test('FTS query builders strip punctuation, dedupe terms, and cap token fanout', () => {
   const raw = '<b>alpha</b> beta alpha gamma delta epsilon zeta eta theta iota OR ( )';
 
-  expect(buildTenantFtsQuery(raw)).toBe('"alpha" OR "beta" OR "gamma" OR "delta" OR "epsilon" OR "zeta" OR "eta" OR "theta"');
+  expect(buildTenantFtsQuery(raw)).toBe('"alpha" OR "beta" OR "gamma" OR "delta" OR "epsilon" OR "zeta" OR "eta" OR "theta" OR "iota" OR "OR"');
+  expect(buildTenantFtsQuery(Array.from({ length: 40 }, (_, index) => `term${index}`).join(' ')).split(' OR ')).toHaveLength(32);
 });
 
 test('parseConcepts trims, de-duplicates, and ignores non-string entries', () => {


### PR DESCRIPTION
## Summary
- ref #2472
- add lightweight acronym expansion helper for QTA over HTTP/MCP search paths
- enrich indexed FTS/vector/pointer/entity text with missing acronym/full-form aliases
- cover CORS/PNA and vector preflight miss class without schema or architecture changes

## Validation
- bunx tsc --noEmit
- bun test src/tools/__tests__/search.test.ts src/search/__tests__/acronyms.test.ts src/search/__tests__/query.test.ts src/server/__tests__/search-fts-query.test.ts src/indexer/__tests__/storage-chunking.test.ts src/indexer/__tests__/learn-source-service-hardening.test.ts tests/http/search/ tests/http/tenant/search-isolation.test.ts tests/benchmarks/honest-recall.test.ts tests/benchmarks/honest-recall-rerank.test.ts

Frontend not touched; frontend build not run.