### PR TITLE
[codex] add project maintenance vault

### DIFF
--- a/psi/.gitignore
+++ b/psi/.gitignore
@@ -1,0 +1,9 @@
+data/
+**/origin
+*.db
+*.db-*
+*.sqlite
+*.sqlite3
+*.sqlite3-*
+vector-index/
+cache/

--- a/psi/README.md
+++ b/psi/README.md
@@ -1,0 +1,29 @@
+# Project Maintenance Vault
+
+This `psi/` directory is for maintaining the `arra-oracle` / `arra-oracle-v3`
+repository.
+
+`arra-oracle` is the Oracle memory/API core. This vault records maintainer
+handoffs, decisions, readouts, and project-specific learnings. It is not the
+Oracle runtime database, not an indexed knowledge store, and not a task queue.
+
+## Rules
+
+- GitHub Issues and pull requests are the durable queue.
+- This vault is memory and handoff, not a task claim system.
+- Do not store secrets, tokens, API keys, `.env` files, generated databases,
+  vector indexes, cache directories, or service runtime state.
+- Keep API, CLI, MCP, and indexing changes in their source directories with
+  normal tests and review.
+- Use this vault only for project maintenance context.
+
+## Structure
+
+```text
+psi/
+  active/     current maintainer context and checkpoints
+  handoff/    session handoffs for future maintainers
+  decisions/  project decisions, reversals, and rationale
+  learn/      repo readouts, proofs, and investigations
+  memory/     durable project learnings and retrospectives
+```

--- a/psi/active/README.md
+++ b/psi/active/README.md
@@ -1,0 +1,6 @@
+# Active
+
+Current maintainer context and checkpoints for this repository.
+
+Use this for short-lived orientation notes. Durable tasks belong in GitHub
+Issues or pull requests.

--- a/psi/decisions/README.md
+++ b/psi/decisions/README.md
@@ -1,0 +1,6 @@
+# Decisions
+
+Project decisions, reversals, and rationale.
+
+Use this when a choice changes how the Oracle API, CLI, MCP server, indexing,
+or memory model is maintained.

--- a/psi/handoff/README.md
+++ b/psi/handoff/README.md
@@ -1,0 +1,6 @@
+# Handoff
+
+Session handoffs for future maintainers of this repository.
+
+Write what changed, what was verified, what remains open, and where the durable
+GitHub issue or pull request lives.

--- a/psi/learn/README.md
+++ b/psi/learn/README.md
@@ -1,0 +1,5 @@
+# Learn
+
+Readouts, proofs, and investigations about this repository.
+
+Use this for repo-specific research that should survive a single session.

--- a/psi/memory/README.md
+++ b/psi/memory/README.md
@@ -1,0 +1,6 @@
+# Memory
+
+Durable project learnings and retrospectives for maintainers.
+
+Do not store generated Oracle memory databases, vector indexes, or runtime
+service state here.


### PR DESCRIPTION
## Summary

Adds a minimal `psi/` project-maintenance vault for `arra-oracle` / `arra-oracle-v3`.

This vault is for maintainer handoffs, decisions, readouts, and project-specific learnings. It is explicitly not the Oracle runtime database, not an indexed knowledge store, and not a task queue.

## Why

This continues the SBS repo rollout from `oracle-mother` issue #9 using a small docs-only project-maintenance vault pattern.

## Validation

- `git diff --check`
- staged diff reviewed locally
- branch pushed from fork `natkingsize2/arra-oracle-v2`

## Notes

No API code, CLI code, MCP code, service config, generated DBs, vector indexes, secrets, `maw team`, or scheduler work was touched.
