### PR TITLE
feat(vector): PgVectorAdapter — muninn pg-migration Part B

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,14 @@ CORS_ORIGIN=                     # Allowed CORS origin for production (e.g., htt
 
 # Database
 ORACLE_DATA_DIR=                 # Path to Oracle data directory (default: ~/.oracle)
+# Managed Postgres (fleet-pg / oracle_kb) — used by pgvector adapter (Part B) and
+# the relational layer (Part A). For DO Managed PG keep sslmode in the URL AND
+# provide the CA below: the URL's sslmode is stripped and ssl:{ca} is used instead.
+ORACLE_DATABASE_URL=             # e.g. postgres://user:pass@host:25060/oracle_kb?sslmode=require
+DATABASE_CA_CERT=                # PEM CA cert for managed PG TLS (multiline)
 
-# Vector Store (choose one)
+# Vector Store (choose one): chroma | sqlite-vec | lancedb | qdrant | cloudflare-vectorize | pgvector
+ORACLE_VECTOR_DB=lancedb
 CHROMA_URL=http://localhost:8000
 QDRANT_URL=http://localhost:6333
 QDRANT_API_KEY=

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "oracle-v2-mcp",
@@ -14,11 +13,13 @@
         "drizzle-orm": "^0.45.2",
         "elysia": "^1.4.28",
         "hook-menu": "github:Soul-Brews-Studio/hook-menu",
+        "pg": "^8.13.0",
         "sqlite-vec": "^0.1.9",
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20.17.9",
+        "@types/pg": "^8.11.10",
         "better-sqlite3": "^12.9.0",
         "bun-types": "^1.3.12",
         "drizzle-kit": "^0.31.10",
@@ -136,6 +137,8 @@
     "@types/command-line-usage": ["@types/command-line-usage@5.0.4", "", {}, "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg=="],
 
     "@types/node": ["@types/node@20.19.27", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug=="],
+
+    "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
 
     "@unhead/schema": ["@unhead/schema@1.11.20", "", { "dependencies": { "hookable": "^5.5.3", "zhead": "^2.2.4" } }, "sha512-0zWykKAaJdm+/Y7yi/Yds20PrUK7XabLe9c3IRcjnwYmSWY6z0Cr19VIs3ozCj8P+GhR+/TI2mwtGlueCEYouA=="],
 
@@ -293,7 +296,7 @@
 
     "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
 
-    "hook-menu": ["hook-menu@github:Soul-Brews-Studio/hook-menu#cc5b563", { "peerDependencies": { "@sinclair/typebox": "^0.32.0", "elysia": "^1.0.0" } }, "Soul-Brews-Studio-hook-menu-cc5b563", "sha512-Ta7T8wEP3BDflB4sJpbLw5FptCpv5VnR4jpavuINRSONWyV3sI2XzU3d5Rk2VRHS/dJbOCnzFGSRXrgzmqtXCg=="],
+    "hook-menu": ["hook-menu@github:Soul-Brews-Studio/hook-menu#cc5b563", { "peerDependencies": { "@sinclair/typebox": "^0.32.0", "elysia": "^1.0.0" } }, "Soul-Brews-Studio-hook-menu-cc5b563"],
 
     "hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
 
@@ -371,7 +374,31 @@
 
     "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
 
+    "pg": ["pg@8.22.0", "", { "dependencies": { "pg-connection-string": "^2.14.0", "pg-pool": "^3.14.0", "pg-protocol": "^1.15.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.4.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA=="],
+
+    "pg-cloudflare": ["pg-cloudflare@1.4.0", "", {}, "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A=="],
+
+    "pg-connection-string": ["pg-connection-string@2.14.0", "", {}, "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg=="],
+
+    "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
+
+    "pg-pool": ["pg-pool@3.14.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw=="],
+
+    "pg-protocol": ["pg-protocol@1.15.0", "", {}, "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ=="],
+
+    "pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
+
+    "pgpass": ["pgpass@1.0.5", "", { "dependencies": { "split2": "^4.1.0" } }, "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug=="],
+
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
+
+    "postgres-bytea": ["postgres-bytea@1.0.1", "", {}, "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="],
+
+    "postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
+
+    "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
 
@@ -428,6 +455,8 @@
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "sqlite-vec": ["sqlite-vec@0.1.9", "", { "optionalDependencies": { "sqlite-vec-darwin-arm64": "0.1.9", "sqlite-vec-darwin-x64": "0.1.9", "sqlite-vec-linux-arm64": "0.1.9", "sqlite-vec-linux-x64": "0.1.9", "sqlite-vec-windows-x64": "0.1.9" } }, "sha512-L7XJWRIBNvR9O5+vh1FQ+IGkh/3D2AzVksW5gdtk28m78Hy8skFD0pqReKH1Yp0/BUKRGcffgKvyO/EON5JXpA=="],
 
@@ -492,6 +521,8 @@
     "wordwrapjs": ["wordwrapjs@5.1.1", "", {}, "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
     "zhead": ["zhead@2.2.4", "", {}, "sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag=="],
 

--- a/package.json
+++ b/package.json
@@ -68,11 +68,13 @@
     "drizzle-orm": "^0.45.2",
     "elysia": "^1.4.28",
     "hook-menu": "github:Soul-Brews-Studio/hook-menu",
+    "pg": "^8.13.0",
     "sqlite-vec": "^0.1.9"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.17.9",
+    "@types/pg": "^8.11.10",
     "better-sqlite3": "^12.9.0",
     "bun-types": "^1.3.12",
     "drizzle-kit": "^0.31.10",

--- a/src/db/pg.ts
+++ b/src/db/pg.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared Postgres connection (fleet-pg / oracle_kb).
+ *
+ * One long-lived pool for the whole process — the MCP + HTTP server and every
+ * vector-store adapter share it (do NOT open/close a connection per request).
+ * Both the relational layer (Part A) and PgVectorAdapter (Part B) use this.
+ *
+ * DO Managed Postgres TLS: the connection string's `sslmode=require` makes
+ * pg-connection-string verify against the SYSTEM root store, which rejects a
+ * managed CA ("self signed certificate in chain"). So when we have a CA (or SSL
+ * is otherwise wanted) we STRIP sslmode from the URL and pass `ssl: { ca }`
+ * ourselves — same lesson as te-kb. We never disable certificate verification.
+ */
+import pg from 'pg';
+
+let pool: pg.Pool | null = null;
+
+/** Remove the sslmode query param so our explicit `ssl` option governs TLS. */
+function stripSslMode(url: string): string {
+  try {
+    const u = new URL(url);
+    u.searchParams.delete('sslmode');
+    return u.toString();
+  } catch {
+    return url
+      .replace(/([?&])sslmode=[^&]*/i, (_m, p1: string) => (p1 === '?' ? '?' : ''))
+      .replace(/[?&]$/, '');
+  }
+}
+
+export interface PgPoolOptions {
+  connectionString?: string;
+  caCert?: string;
+  max?: number;
+}
+
+/**
+ * Get the shared process-wide pool, creating it on first use. Resolves the
+ * connection string from ORACLE_DATABASE_URL (or DATABASE_URL) and the CA from
+ * DATABASE_CA_CERT unless overridden via opts.
+ */
+export function getPgPool(opts: PgPoolOptions = {}): pg.Pool {
+  if (pool) return pool;
+  const url = opts.connectionString || process.env.ORACLE_DATABASE_URL || process.env.DATABASE_URL;
+  if (!url) {
+    throw new Error('[pg] ORACLE_DATABASE_URL (or DATABASE_URL) is not set');
+  }
+  const caCert = opts.caCert ?? process.env.DATABASE_CA_CERT ?? '';
+  const wantsSsl =
+    /sslmode=(require|prefer|verify-ca|verify-full)/.test(url) ||
+    /\.db\.ondigitalocean\.com/.test(url);
+  const ssl = caCert ? { ca: caCert } : wantsSsl ? true : undefined;
+  const connectionString = ssl ? stripSslMode(url) : url;
+  pool = new pg.Pool({ connectionString, max: opts.max ?? 10, ssl });
+  return pool;
+}
+
+/** True once the shared pool has been created. */
+export function hasPgPool(): boolean {
+  return pool !== null;
+}
+
+/** Close the shared pool (shutdown / tests). */
+export async function closePgPool(): Promise<void> {
+  if (pool) {
+    await pool.end();
+    pool = null;
+  }
+}

--- a/src/vector/__tests__/pgvector.test.ts
+++ b/src/vector/__tests__/pgvector.test.ts
@@ -1,0 +1,120 @@
+/**
+ * PgVectorAdapter unit test.
+ *
+ * Runs against a live pgvector Postgres when TEST_PG_URL is set, e.g.:
+ *   docker run -d --name pgv -e POSTGRES_USER=tekb -e POSTGRES_PASSWORD=tekb \
+ *     -e POSTGRES_DB=tekb -p 5439:5432 pgvector/pgvector:pg16
+ *   TEST_PG_URL=postgres://tekb:tekb@localhost:5439/tekb bun test src/vector/__tests__/pgvector.test.ts
+ *
+ * Skipped automatically when TEST_PG_URL is absent (no Postgres in plain CI).
+ * Uses a deterministic fake embedder so no Ollama is required.
+ */
+import { test, expect, beforeAll, afterAll } from 'bun:test';
+import { PgVectorAdapter } from '../adapters/pgvector.ts';
+import { closePgPool } from '../../db/pg.ts';
+import type { EmbeddingProvider, EmbedType } from '../types.ts';
+
+const TEST_PG_URL = process.env.TEST_PG_URL;
+const d = TEST_PG_URL ? test : test.skip;
+
+/** Deterministic hashing bag-of-words embedder (1024d, L2-normalized) — no GPU. */
+class FakeEmbedder implements EmbeddingProvider {
+  readonly name = 'fake';
+  readonly dimensions = 1024;
+  async embed(texts: string[], _type?: EmbedType): Promise<number[][]> {
+    return texts.map((t) => {
+      const vec = new Array(this.dimensions).fill(0);
+      const tokens = t.toLowerCase().split(/\s+/).filter(Boolean);
+      for (const tok of tokens) {
+        let h = 0x811c9dc5;
+        for (let i = 0; i < tok.length; i++) {
+          h ^= tok.charCodeAt(i);
+          h = Math.imul(h, 0x01000193);
+        }
+        vec[(h >>> 0) % this.dimensions] += 1;
+      }
+      let norm = 0;
+      for (const v of vec) norm += v * v;
+      norm = Math.sqrt(norm) || 1;
+      return vec.map((v) => v / norm);
+    });
+  }
+}
+
+const COLLECTION = 'test_pgvector_unit';
+let adapter: PgVectorAdapter;
+
+beforeAll(async () => {
+  if (!TEST_PG_URL) return;
+  adapter = new PgVectorAdapter(COLLECTION, new FakeEmbedder(), { connectionString: TEST_PG_URL });
+  await adapter.connect();
+  await adapter.deleteCollection(); // clean slate
+  await adapter.ensureCollection();
+});
+
+afterAll(async () => {
+  if (!TEST_PG_URL) return;
+  await adapter.deleteCollection().catch(() => {});
+  await closePgPool();
+});
+
+d('rejects an unsafe collection name', () => {
+  expect(() => new PgVectorAdapter('bad name; DROP', new FakeEmbedder())).toThrow();
+});
+
+d('addDocuments + getStats: count reflects inserts', async () => {
+  await adapter.addDocuments([
+    { id: 'a1', document: 'payment refund failed on withdraw', metadata: { type: 'error', project: 'p1' } },
+    { id: 'a2', document: 'พรุ่งนี้ประชุมทีมกี่โมง', metadata: { type: 'chat', project: 'p1' } },
+    { id: 'a3', document: 'sunny weather tomorrow', metadata: { type: 'news', project: 'p2' } },
+  ]);
+  expect((await adapter.getStats()).count).toBe(3);
+});
+
+d('addDocuments upserts on id conflict (no duplicate)', async () => {
+  await adapter.addDocuments([{ id: 'a1', document: 'updated text', metadata: { type: 'error', project: 'p1' } }]);
+  expect((await adapter.getStats()).count).toBe(3);
+});
+
+d('respects precomputed vectors (no re-embed)', async () => {
+  const vec = new Array(1024).fill(0);
+  vec[7] = 1;
+  await adapter.addDocuments([{ id: 'pre', document: 'ignored', metadata: { type: 'x' }, vector: vec }]);
+  const all = await adapter.getAllEmbeddings();
+  const got = all.embeddings[all.ids.indexOf('pre')];
+  expect(got[7]).toBeCloseTo(1, 5);
+});
+
+d('query ranks the semantically closest doc first', async () => {
+  const r = await adapter.query('refund withdraw payment', 3);
+  expect(r.ids.length).toBeGreaterThan(0);
+  expect(r.ids[0]).toBe('a1');
+  // distances ascending (cosine distance)
+  for (let i = 1; i < r.distances.length; i++) expect(r.distances[i - 1]).toBeLessThanOrEqual(r.distances[i]);
+});
+
+d('query honours a metadata where-filter', async () => {
+  const r = await adapter.query('weather', 5, { project: 'p2' });
+  expect(r.ids.length).toBeGreaterThan(0);
+  expect(r.metadatas.every((m: any) => m.project === 'p2')).toBe(true);
+});
+
+d('Thai content is retrievable (UTF-8 round-trip)', async () => {
+  const r = await adapter.query('ประชุมทีม', 3);
+  expect(r.ids).toContain('a2');
+});
+
+d('queryById excludes the seed id', async () => {
+  const r = await adapter.queryById('a1', 3);
+  expect(r.ids).not.toContain('a1');
+});
+
+d('replaceDocuments swaps the whole collection', async () => {
+  await adapter.replaceDocuments([
+    { id: 'z1', document: 'only doc now', metadata: { type: 'solo' } },
+  ]);
+  const stats = await adapter.getStats();
+  expect(stats.count).toBe(1);
+  const all = await adapter.getAllEmbeddings();
+  expect(all.ids).toEqual(['z1']);
+});

--- a/src/vector/adapters/index.ts
+++ b/src/vector/adapters/index.ts
@@ -3,3 +3,4 @@ export { SqliteVecAdapter } from './sqlite-vec.ts';
 export { LanceDBAdapter } from './lancedb.ts';
 export { QdrantAdapter } from './qdrant.ts';
 export { CloudflareVectorizeAdapter, CloudflareAIEmbeddings } from './cloudflare-vectorize.ts';
+export { PgVectorAdapter } from './pgvector.ts';

--- a/src/vector/adapters/pgvector.ts
+++ b/src/vector/adapters/pgvector.ts
@@ -1,0 +1,285 @@
+/**
+ * pgvector Adapter
+ *
+ * Stores embeddings in DO Managed Postgres (fleet-pg / oracle_kb) via the
+ * pgvector extension. Mirrors LanceDBAdapter's contract exactly so it is a
+ * drop-in replacement (ORACLE_VECTOR_DB=pgvector) — cosine distance, bge-m3
+ * 1024d, link key = id, metadata stored as JSONB.
+ *
+ * Shares the process-wide pool from db/pg.ts with the relational layer (one
+ * connection pool for everything — no per-request connect).
+ */
+
+import type pg from 'pg';
+import type { VectorStoreAdapter, VectorDocument, VectorQueryResult, EmbeddingProvider } from '../types.ts';
+import { getPgPool } from '../../db/pg.ts';
+
+/** Format a number[] as a pgvector literal: [0.1,0.2,...] */
+function toVectorLiteral(vec: number[]): string {
+  return `[${vec.join(',')}]`;
+}
+
+export class PgVectorAdapter implements VectorStoreAdapter {
+  readonly name = 'pgvector';
+  private pool: pg.Pool | null = null;
+  private collectionName: string;
+  private embedder: EmbeddingProvider;
+  private connectionString?: string;
+  private caCert?: string;
+  private ensured = false;
+
+  constructor(
+    collectionName: string,
+    embedder: EmbeddingProvider,
+    opts: { connectionString?: string; caCert?: string } = {},
+  ) {
+    // Collection name becomes a SQL identifier — whitelist to prevent injection.
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(collectionName)) {
+      throw new Error(`[pgvector] invalid collection name: ${collectionName}`);
+    }
+    this.collectionName = collectionName;
+    this.embedder = embedder;
+    this.connectionString = opts.connectionString;
+    this.caCert = opts.caCert;
+  }
+
+  /** Double-quoted, validated identifier for the collection table. */
+  private get table(): string {
+    return `"${this.collectionName}"`;
+  }
+
+  async connect(): Promise<void> {
+    if (this.pool) return;
+    this.pool = getPgPool({ connectionString: this.connectionString, caCert: this.caCert });
+    // Fail fast if the DB is unreachable / misconfigured.
+    await this.pool.query('SELECT 1');
+    console.error(`[pgvector] Connected (collection '${this.collectionName}')`);
+  }
+
+  async close(): Promise<void> {
+    // The pool is shared process-wide (relational + every model store). Drop our
+    // reference but never end it here — see db/pg.ts closePgPool() for shutdown.
+    this.pool = null;
+    this.ensured = false;
+    console.error('[pgvector] Closed (shared pool left open)');
+  }
+
+  private getPool(): pg.Pool {
+    if (!this.pool) this.pool = getPgPool({ connectionString: this.connectionString, caCert: this.caCert });
+    return this.pool;
+  }
+
+  async ensureCollection(): Promise<void> {
+    if (this.ensured) return;
+    const pool = this.getPool();
+    const dims = this.embedder.dimensions;
+    await pool.query('CREATE EXTENSION IF NOT EXISTS vector');
+    await pool.query(
+      `CREATE TABLE IF NOT EXISTS ${this.table} (
+         id        TEXT PRIMARY KEY,
+         document  TEXT,
+         metadata  JSONB,
+         vector    vector(${dims})
+       )`,
+    );
+    // HNSW + cosine — matches LanceDB's distanceType('cosine').
+    await pool.query(
+      `CREATE INDEX IF NOT EXISTS "${this.collectionName}_hnsw"
+       ON ${this.table} USING hnsw (vector vector_cosine_ops)`,
+    );
+    this.ensured = true;
+    console.error(`[pgvector] Collection '${this.collectionName}' ready (dim ${dims})`);
+  }
+
+  async deleteCollection(): Promise<void> {
+    const pool = this.getPool();
+    await pool.query(`DROP TABLE IF EXISTS ${this.table}`);
+    this.ensured = false;
+    console.error(`[pgvector] Collection '${this.collectionName}' deleted`);
+  }
+
+  /** Embed only docs lacking a precomputed vector (skip the Ollama round-trip otherwise). */
+  private async rowsForDocuments(
+    docs: VectorDocument[],
+  ): Promise<Array<{ id: string; document: string; metadata: string; vector: string }>> {
+    const needEmbed: number[] = [];
+    for (let i = 0; i < docs.length; i++) {
+      if (!docs[i].vector) needEmbed.push(i);
+    }
+    let fresh: number[][] = [];
+    if (needEmbed.length > 0) {
+      const texts = needEmbed.map((i) => docs[i].document);
+      fresh = await this.embedder.embed(texts, 'passage');
+    }
+    let freshIdx = 0;
+    return docs.map((doc) => ({
+      id: doc.id,
+      document: doc.document,
+      metadata: JSON.stringify(doc.metadata ?? {}),
+      vector: toVectorLiteral(doc.vector ?? fresh[freshIdx++]),
+    }));
+  }
+
+  async addDocuments(docs: VectorDocument[]): Promise<void> {
+    if (docs.length === 0) return;
+    await this.ensureCollection();
+    const pool = this.getPool();
+    const rows = await this.rowsForDocuments(docs);
+
+    // Multi-row upsert in one statement (chunked to stay under param limits).
+    const CHUNK = 500;
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      for (let off = 0; off < rows.length; off += CHUNK) {
+        const slice = rows.slice(off, off + CHUNK);
+        const values: any[] = [];
+        const tuples = slice.map((r, i) => {
+          const b = i * 4;
+          values.push(r.id, r.document, r.metadata, r.vector);
+          return `($${b + 1}, $${b + 2}, $${b + 3}::jsonb, $${b + 4}::vector)`;
+        });
+        await client.query(
+          `INSERT INTO ${this.table} (id, document, metadata, vector)
+           VALUES ${tuples.join(',')}
+           ON CONFLICT (id) DO UPDATE
+             SET document = EXCLUDED.document,
+                 metadata = EXCLUDED.metadata,
+                 vector   = EXCLUDED.vector`,
+          values,
+        );
+      }
+      await client.query('COMMIT');
+    } catch (e) {
+      await client.query('ROLLBACK');
+      throw e;
+    } finally {
+      client.release();
+    }
+
+    const reused = docs.filter((d) => d.vector).length;
+    console.error(
+      `[pgvector] Added ${docs.length} documents${reused ? ` (${reused} with precomputed vectors)` : ''}`,
+    );
+  }
+
+  /** Replace the whole collection (TRUNCATE + insert) inside one transaction. */
+  async replaceDocuments(docs: VectorDocument[]): Promise<void> {
+    await this.ensureCollection();
+    const pool = this.getPool();
+    const rows = docs.length ? await this.rowsForDocuments(docs) : [];
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query(`TRUNCATE ${this.table}`);
+      const CHUNK = 500;
+      for (let off = 0; off < rows.length; off += CHUNK) {
+        const slice = rows.slice(off, off + CHUNK);
+        const values: any[] = [];
+        const tuples = slice.map((r, i) => {
+          const b = i * 4;
+          values.push(r.id, r.document, r.metadata, r.vector);
+          return `($${b + 1}, $${b + 2}, $${b + 3}::jsonb, $${b + 4}::vector)`;
+        });
+        await client.query(
+          `INSERT INTO ${this.table} (id, document, metadata, vector)
+           VALUES ${tuples.join(',')}`,
+          values,
+        );
+      }
+      await client.query('COMMIT');
+    } catch (e) {
+      await client.query('ROLLBACK');
+      throw e;
+    } finally {
+      client.release();
+    }
+    console.error(`[pgvector] Replaced collection with ${docs.length} documents`);
+  }
+
+  /** Build a `metadata @> $n::jsonb` containment filter (typed, matches lancedb's ===). */
+  private whereClause(where: Record<string, any> | undefined, params: any[]): string {
+    if (!where || Object.keys(where).length === 0) return '';
+    params.push(JSON.stringify(where));
+    return `WHERE metadata @> $${params.length}::jsonb`;
+  }
+
+  async query(text: string, limit = 10, where?: Record<string, any>): Promise<VectorQueryResult> {
+    await this.ensureCollection();
+    const pool = this.getPool();
+    const [queryEmbedding] = await this.embedder.embed([text], 'query');
+    const params: any[] = [toVectorLiteral(queryEmbedding)];
+    const filter = this.whereClause(where, params);
+    params.push(limit);
+    const { rows } = await pool.query(
+      `SELECT id, document, metadata, vector <=> $1::vector AS distance
+       FROM ${this.table}
+       ${filter}
+       ORDER BY vector <=> $1::vector ASC
+       LIMIT $${params.length}`,
+      params,
+    );
+    return {
+      ids: rows.map((r) => r.id),
+      documents: rows.map((r) => r.document ?? ''),
+      distances: rows.map((r) => Number(r.distance)),
+      metadatas: rows.map((r) => r.metadata ?? {}),
+    };
+  }
+
+  async queryById(id: string, nResults = 5): Promise<VectorQueryResult> {
+    await this.ensureCollection();
+    const pool = this.getPool();
+    const found = await pool.query(`SELECT vector::text AS vector FROM ${this.table} WHERE id = $1`, [id]);
+    if (found.rows.length === 0) {
+      throw new Error(`No embedding found for document: ${id}`);
+    }
+    const vector = found.rows[0].vector as string; // already a pgvector literal
+    const { rows } = await pool.query(
+      `SELECT id, document, metadata, vector <=> $1::vector AS distance
+       FROM ${this.table}
+       WHERE id <> $2
+       ORDER BY vector <=> $1::vector ASC
+       LIMIT $3`,
+      [vector, id, nResults],
+    );
+    return {
+      ids: rows.map((r) => r.id),
+      documents: rows.map((r) => r.document ?? ''),
+      distances: rows.map((r) => Number(r.distance)),
+      metadatas: rows.map((r) => r.metadata ?? {}),
+    };
+  }
+
+  async getStats(): Promise<{ count: number }> {
+    try {
+      await this.ensureCollection();
+      const pool = this.getPool();
+      const { rows } = await pool.query(`SELECT COUNT(*)::int AS n FROM ${this.table}`);
+      return { count: rows[0].n };
+    } catch {
+      return { count: 0 };
+    }
+  }
+
+  async getCollectionInfo(): Promise<{ count: number; name: string }> {
+    const stats = await this.getStats();
+    return { count: stats.count, name: this.collectionName };
+  }
+
+  async getAllEmbeddings(
+    limit = 5000,
+  ): Promise<{ ids: string[]; embeddings: number[][]; metadatas: any[] }> {
+    await this.ensureCollection();
+    const pool = this.getPool();
+    const { rows } = await pool.query(
+      `SELECT id, vector::text AS vector, metadata FROM ${this.table} ORDER BY id LIMIT $1`,
+      [limit],
+    );
+    return {
+      ids: rows.map((r) => r.id),
+      embeddings: rows.map((r) => JSON.parse(r.vector) as number[]),
+      metadatas: rows.map((r) => r.metadata ?? {}),
+    };
+  }
+}

--- a/src/vector/factory.ts
+++ b/src/vector/factory.ts
@@ -14,6 +14,7 @@ import { SqliteVecAdapter } from './adapters/sqlite-vec.ts';
 import { LanceDBAdapter } from './adapters/lancedb.ts';
 import { QdrantAdapter } from './adapters/qdrant.ts';
 import { CloudflareVectorizeAdapter, CloudflareAIEmbeddings } from './adapters/cloudflare-vectorize.ts';
+import { PgVectorAdapter } from './adapters/pgvector.ts';
 import { createEmbeddingProvider } from './embeddings.ts';
 import { loadVectorConfig, configToModels, type VectorModelRegistryEntry } from './config.ts';
 import { localNativeVectorDisabledReason, logLocalVectorDisabled } from './cpu-capabilities.ts';
@@ -105,6 +106,20 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
         url: config.qdrantUrl || process.env.QDRANT_URL,
         apiKey: config.qdrantApiKey || process.env.QDRANT_API_KEY,
       });
+    }
+
+    case 'pgvector': {
+      // Managed Postgres (fleet-pg / oracle_kb) + pgvector. Reuses the shared
+      // pool resolved from ORACLE_DATABASE_URL + DATABASE_CA_CERT (db/pg.ts).
+      const embeddingType = config.embeddingProvider
+        || (process.env.ORACLE_EMBEDDING_PROVIDER as EmbeddingProviderType)
+        || 'ollama';
+
+      const embeddingModel = config.embeddingModel
+        || process.env.ORACLE_EMBEDDING_MODEL;
+
+      const embedder = createEmbeddingProvider(embeddingType, embeddingModel);
+      return new PgVectorAdapter(collectionName, embedder);
     }
 
     case 'cloudflare-vectorize': {

--- a/src/vector/types.ts
+++ b/src/vector/types.ts
@@ -69,5 +69,5 @@ export interface EmbeddingProvider {
   embed(texts: string[], type?: EmbedType): Promise<number[][]>;
 }
 
-export type VectorDBType = 'chroma' | 'sqlite-vec' | 'lancedb' | 'qdrant' | 'cloudflare-vectorize';
+export type VectorDBType = 'chroma' | 'sqlite-vec' | 'lancedb' | 'qdrant' | 'cloudflare-vectorize' | 'pgvector';
 export type EmbeddingProviderType = 'chromadb-internal' | 'ollama' | 'openai' | 'cloudflare-ai';


### PR DESCRIPTION
## muninn → fleet-pg migration — Part B (PgVectorAdapter)

First increment of `ψ/plans/2026-06-21_muninn-pg-migration-spec.md`. **Additive & non-breaking** — no existing adapter or sync DB code touched. Default stays `lancedb`; opt in with `ORACLE_VECTOR_DB=pgvector`.

### What's in
- **`src/vector/adapters/pgvector.ts`** — `VectorStoreAdapter` for DO Managed Postgres (fleet-pg / `oracle_kb`) via pgvector. Mirrors `LanceDBAdapter` exactly:
  - cosine (`<=>`), bge-m3 **1024d**, HNSW index, `id` PK, metadata `JSONB`
  - honours `doc.vector` precompute (no re-embed) · upsert `ON CONFLICT (id)`
  - `replaceDocuments` (TRUNCATE+insert in txn) · `query`/`queryById`/`getStats`/`getCollectionInfo`/`getAllEmbeddings`
  - metadata `where` filter via jsonb `@>` containment (typed parity with lancedb's `===`)
- **`src/db/pg.ts`** — shared process-wide pool. DO Managed PG TLS via **strip-`sslmode` + `ssl:{ca}`** (te-kb lesson, commit ac3b73a). Reused by Part A.
- Registered in `types.ts` / `factory.ts` / `adapters/index.ts`; `.env.example` documents `ORACLE_DATABASE_URL` / `DATABASE_CA_CERT` / `ORACLE_VECTOR_DB`. Added `pg` + `@types/pg`.

### Tests
- `src/vector/__tests__/pgvector.test.ts` (gated on `TEST_PG_URL`, deterministic fake embedder — no Ollama): **9/9 pass** against `pgvector/pgvector:pg16` incl. **Thai UTF-8 retrieval**, metadata filter, precomputed-vector reuse, upsert, queryById, replaceDocuments.
- `tsc --noEmit` clean; existing vector factory/config tests still pass.

### Next (separate PRs)
- **Part A** relational SQLite→Postgres — ⚠️ large: forces a **sync→async cascade** (127 sync `.get/.all/.run` + 44 raw `sqlite.prepare` across 52 files) + FTS5→tsvector/`pg_trgm` (Thai recall). Approach/staging to confirm with utils-pm.
- **Part C** `scripts/migrate-to-pg.ts` (copy all tables + vectors, no re-embed)
- **Part D** deploy on fleet-kb + Ollama bge-m3 (utils-pm helps with Coolify)

⚠️ Opened from fork (`meganechan` lacks write to the org repo). **Awaiting Tony approval** — do not merge automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)