### PR TITLE
docs: add Epic Verification section to docs-site

### DIFF
--- a/web/src/data/epic-verification.ts
+++ b/web/src/data/epic-verification.ts
@@ -1,0 +1,32 @@
+// Epic Verification ledger — single source of truth.
+//
+// This file collects the per-epic verification data. The /verify dashboard and
+// the per-epic detail pages read from `epics` below. Only GENUINELY-COMPLETED
+// epics (verified DONE on `main`) are listed here.
+//
+// HOW TO STAMP AN EPIC "PASSED":
+//   1. Follow the E2E procedure on the epic's detail page (/verify/<slug>).
+//   2. Open the epic's data file under src/data/epics/ (e.g. epic-1278.ts).
+//   3. Set:  status: 'passed', verifiedBy: 'Your Name', verifiedDate: '2026-06-21'
+//      (optionally tick individual `passed: true` flags on each feature).
+//   4. Re-run `bun run build`; the dashboard badge updates automatically.
+
+import type { Epic } from "./epics/types";
+import { epic1278 } from "./epics/epic-1278";
+import { epic1072 } from "./epics/epic-1072";
+import { epic1369 } from "./epics/epic-1369";
+
+export type { Epic, Feature, VerifyStatus } from "./epics/types";
+
+/** The ordered list of epics under verification. */
+export const epics: Epic[] = [epic1278, epic1072, epic1369];
+
+/** Look up an epic by its URL slug (used by the dynamic detail route). */
+export function epicBySlug(slug: string): Epic | undefined {
+  return epics.find((e) => e.slug === slug);
+}
+
+/** Count of epics stamped PASSED. */
+export function passedCount(): number {
+  return epics.filter((e) => e.status === "passed").length;
+}

--- a/web/src/data/epics/epic-1072.ts
+++ b/web/src/data/epics/epic-1072.ts
@@ -1,0 +1,84 @@
+import type { Epic } from "./types";
+
+// Epic 1072 — API gateway router on :47778.
+// Verified against `main` HEAD. The gateway plugin is always mounted on the
+// main server. Its status endpoint returns `{ enabled: false }` when no
+// oracle-gateway.json exists and no VECTOR_URL is set (pure pass-through).
+// With VECTOR_URL set, a config is synthesized in memory (no file needed).
+
+export const epic1072: Epic = {
+  id: 1072,
+  slug: "1072-api-gateway",
+  title: "API gateway router on :47778",
+  summary:
+    "A built-in gateway exposes status/health endpoints, proxies vector traffic with an FTS5 fallback when the vector service is down, hot-reloads its config file, and ships named request/response/error hooks.",
+  status: "pending",
+  verifiedBy: "",
+  verifiedDate: "",
+  prerequisites: [
+    "Open a terminal at the repo root (the folder with package.json and src/).",
+    "Install deps once if needed: `bun install`.",
+    "Start the dev server with `bun run server` — it listens on http://localhost:47778. Stop it with Ctrl-C.",
+    "Use a SECOND terminal for the curl commands so the server keeps running.",
+    "Gateway routes/hooks are counts in the status JSON, not arrays. With no config and no VECTOR_URL the gateway is a no-op pass-through — that is expected.",
+  ],
+  features: [
+    {
+      id: "status",
+      name: "`GET /api/gateway/status` returns gateway state",
+      steps: [
+        "Start the server with `bun run server` (no extra env).",
+        "In the second terminal: `curl -s http://localhost:47778/api/gateway/status`.",
+      ],
+      expected:
+        'With no config file and no VECTOR_URL the response is exactly `{ "enabled": false }`. When a config or VECTOR_URL is active the response is `{ "enabled": true, "routes": <number>, "services": { ... }, "hooks": <number> }` (routes and hooks are counts).',
+    },
+    {
+      id: "health",
+      name: "`GET /api/gateway/health` reports service health",
+      steps: [
+        "With the server running, in the second terminal: `curl -s http://localhost:47778/api/gateway/health`.",
+      ],
+      expected:
+        'Returns `{ "services": { ... } }`. With no gateway config the services object is empty: `{ "services": {} }`. With a vector service configured each entry looks like `{ "status": "up"|"down"|"unknown", "lastCheck": <ms> }`.',
+    },
+    {
+      id: "vector-fallback",
+      name: "VECTOR_URL proxy with fts5 fallback when vector is down",
+      notes:
+        "Setting VECTOR_URL synthesizes a gateway config with a `vector` service and 6 routes. The /api/search route has `fallback: 'fts5'`, so if the vector backend is unreachable the request falls through to the local FTS5 search handler instead of erroring.",
+      steps: [
+        "Pick a vector URL that is NOT running, e.g. http://localhost:47781. Start the server pointed at it: `VECTOR_URL=http://localhost:47781 bun run server`.",
+        "In the second terminal confirm the gateway is enabled: `curl -s http://localhost:47778/api/gateway/status` → expect `\"enabled\": true` with `\"routes\": 6`.",
+        "Now run a search that would normally hit vector: `curl -s \"http://localhost:47778/api/search?q=test&mode=hybrid\"`.",
+      ],
+      expected:
+        "gateway/status shows enabled:true, routes:6, and a `vector` service. The search request does NOT fail with a 502/504 — it falls through to the local FTS5 search and returns a normal `{ results, total, ... }` JSON body because of the `fts5` fallback.",
+    },
+    {
+      id: "hot-reload",
+      name: "Hot-reload of oracle-gateway.json via fs.watch",
+      notes:
+        "The gateway watches `oracle-gateway.json` in the data dir with fs.watch (200ms debounce) and also watches the directory so a first-time create is picked up live — no restart needed. Disable with ORACLE_GATEWAY_HOT_RELOAD=0.",
+      steps: [
+        "Start the server with `bun run server` (no VECTOR_URL). Confirm `curl -s http://localhost:47778/api/gateway/status` → `{ \"enabled\": false }`.",
+        "Find the data dir the server uses (printed at boot, or the value of ORACLE_DATA_DIR / the default data dir). Create a minimal `oracle-gateway.json` there with one service and route, for example: `{ \"services\": { \"demo\": { \"url\": \"http://localhost:9\" } }, \"routes\": [ { \"path\": \"/api/demo\", \"service\": \"demo\" } ] }`.",
+        "WITHOUT restarting, re-run: `curl -s http://localhost:47778/api/gateway/status`.",
+      ],
+      expected:
+        "Within a fraction of a second of saving the file, gateway/status flips to `\"enabled\": true` and reports the new route count — proving the config was hot-reloaded without a server restart.",
+    },
+    {
+      id: "hooks",
+      name: "Built-in hooks are registered",
+      notes:
+        "Five built-in hooks ship: auth-guard, request-logger, rate-limit, fts5-fallback, error-json (plus an extra request-logger-response onResponse hook). Hooks are registered at startup but only RUN when named in the config's `hooks` arrays.",
+      steps: [
+        "Confirm the hook source files exist (each calls registerHook with its name): `ls src/gateway/hooks/`.",
+        "Verify the five names are present: `grep -rh \"name:\" src/gateway/hooks/ | sort`.",
+      ],
+      expected:
+        "src/gateway/hooks/ contains auth-guard.ts, request-logger.ts, rate-limit.ts, fts5-fallback.ts, and error-json.ts, and the grep lists the hook names auth-guard, request-logger, rate-limit, fts5-fallback, error-json (plus request-logger-response).",
+    },
+  ],
+};

--- a/web/src/data/epics/epic-1278.ts
+++ b/web/src/data/epics/epic-1278.ts
@@ -1,0 +1,106 @@
+import type { Epic } from "./types";
+
+// Epic 1278 — Server plugin engine.
+// Verified against `main` HEAD. CLI binary is `arra-cli`; from the repo root
+// run it with `bun cli/src/cli.ts <args>`. Plugin enable/disable changes are
+// read only at server boot, so a restart is required after each toggle.
+
+export const epic1278: Epic = {
+  id: 1278,
+  slug: "1278-plugin-engine",
+  title: "Server plugin engine",
+  summary:
+    "Bundled server plugins can be listed, enabled, and disabled from the CLI; toggling a plugin mounts or unmounts its routes after a restart, core plugins are protected, and the choice persists to config.",
+  status: "pending",
+  verifiedBy: "",
+  verifiedDate: "",
+  prerequisites: [
+    "Open a terminal at the repo root (the folder containing package.json and src/).",
+    "Install deps once if you have not already: `bun install`.",
+    "You will start and stop the dev server several times below. Start it with `bun run server` (it listens on http://localhost:47778). Stop it with Ctrl-C.",
+    "The CLI is the `arra-cli` binary. From the repo root, run it as `bun cli/src/cli.ts <args>`.",
+  ],
+  features: [
+    {
+      id: "list",
+      name: "`plugin list` lists installed plugins",
+      notes:
+        "`plugin list` reports WASM/dir plugins installed under ~/.oracle/plugins. On a fresh machine this list is empty — that is the correct, expected output, not an error.",
+      steps: [
+        "In a terminal at the repo root, run:",
+        "$ bun cli/src/cli.ts plugin list",
+        "Read the output. It prints the plugin install directory and any installed plugins.",
+      ],
+      expected:
+        "The command exits 0 and prints the plugin directory (~/.oracle/plugins) with an empty plugin list on a fresh checkout. No stack trace.",
+    },
+    {
+      id: "route-flip",
+      name: "Disable/enable the federation plugin flips the /info route",
+      notes:
+        "The federation plugin is disabled by default and mounts `GET /info`. Enable/disable is read at boot, so you must restart the server after each toggle.",
+      steps: [
+        "Start the server: `bun run server`. In a SECOND terminal run: `curl -s -o /dev/null -w \"%{http_code}\\n\" http://localhost:47778/info` — federation is off by default so expect 404. Stop the server (Ctrl-C).",
+        "Enable federation: `bun cli/src/cli.ts plugin enable federation`.",
+        "Restart the server: `bun run server`. In the second terminal run the same curl: `curl -s -o /dev/null -w \"%{http_code}\\n\" http://localhost:47778/info`. Now expect 200. Stop the server.",
+        "Disable it again to restore defaults: `bun cli/src/cli.ts plugin disable federation`. Restart and curl `/info` once more — back to 404. Stop the server.",
+      ],
+      expected:
+        "/info returns 404 while federation is disabled and 200 after `plugin enable federation` + restart. The flip is reversible.",
+    },
+    {
+      id: "core-refused",
+      name: "Disabling a core plugin is refused",
+      notes:
+        "Core plugins (health, search, knowledge, concepts, verify, vector, files, indexer) cannot be disabled.",
+      steps: [
+        "Run: `bun cli/src/cli.ts plugin disable search`.",
+        "Read the printed error and check the exit code with: `echo $?`.",
+      ],
+      expected:
+        'The command prints `Cannot disable core server plugin "search"` and exits with code 1. No config is changed.',
+    },
+    {
+      id: "api-manifest",
+      name: "API-manifest plugin mounts a route",
+      notes:
+        "The `plugin-api-example` plugin (disabled by default) declares an API manifest that mounts `GET /api/plugin-example`.",
+      steps: [
+        "Enable it: `bun cli/src/cli.ts plugin enable plugin-api-example`.",
+        "Start the server: `bun run server`.",
+        "In a second terminal: `curl -s http://localhost:47778/api/plugin-example`.",
+        "Stop the server and restore defaults: `bun cli/src/cli.ts plugin disable plugin-api-example`.",
+      ],
+      expected:
+        'The route returns JSON `{ "ok": true, "plugin": "plugin-api-example", "mountedBy": "server-plugin-api-manifest" }`. Before enabling, the same route returns 404.',
+    },
+    {
+      id: "unified-lifecycle",
+      name: "Unified one-handler plugin emits start/stop lifecycle",
+      notes:
+        "The `unified-example` plugin (disabled by default) mounts `GET`/`POST /api/unified-example` and logs lifecycle lines on plugin start and stop.",
+      steps: [
+        "Enable it: `bun cli/src/cli.ts plugin enable unified-example`.",
+        "Start the server: `bun run server`. Watch the server's stdout — on startup it prints `[unified-example] start`.",
+        "In a second terminal: `curl -s -X POST http://localhost:47778/api/unified-example -H 'content-type: application/json' -d '{\"hi\":1}'`.",
+        "Stop the server with Ctrl-C and watch stdout — it prints `[unified-example] stop`.",
+        "Restore defaults: `bun cli/src/cli.ts plugin disable unified-example`.",
+      ],
+      expected:
+        'Server stdout shows `[unified-example] start` on boot and `[unified-example] stop` on shutdown. The POST returns JSON `{ "ok": true, "plugin": "unified-example", "source": "api", "method": "POST", "body": { "hi": 1 } }`.',
+    },
+    {
+      id: "config-persist",
+      name: "Plugin toggles persist to config",
+      notes:
+        "`plugin disable`/`enable` write `disabledPlugins` / `enabledPlugins` arrays to the GLOBAL config file (~/.config/arra/config.json), which the server reads at boot. A project-scoped .arra/config.json is also read but is not the CLI write target.",
+      steps: [
+        "Disable a non-core plugin: `bun cli/src/cli.ts plugin disable federation`.",
+        "Inspect the global config: `cat ~/.config/arra/config.json`.",
+        "Re-enable to restore: `bun cli/src/cli.ts plugin enable federation`.",
+      ],
+      expected:
+        'After disabling, ~/.config/arra/config.json contains `"disabledPlugins": ["federation"]` (and the reverse `"enabledPlugins"` entry after enabling). The file persists across restarts.',
+    },
+  ],
+};

--- a/web/src/data/epics/epic-1369.ts
+++ b/web/src/data/epics/epic-1369.ts
@@ -1,0 +1,79 @@
+import type { Epic } from "./types";
+
+// Epic 1369 — Zero-config onboarding.
+// Verified against `main` HEAD. With VECTOR_URL empty (the default), search
+// falls to a local FTS5 floor and no vector store directory is created. The
+// web docs-site provides /search, /connect, and /install onboarding pages.
+// The tool-toggle and vector-config endpoints persist opt-in choices to config.
+
+export const epic1369: Epic = {
+  id: 1369,
+  slug: "1369-zero-config-onboarding",
+  title: "Zero-config onboarding",
+  summary:
+    "A fresh install works with no vector backend: keyword (FTS5) search runs locally with no lancedb/ dir, the web site guides Connect/Install, per-tool MCP toggles persist, and vector is strictly opt-in.",
+  status: "pending",
+  verifiedBy: "",
+  verifiedDate: "",
+  prerequisites: [
+    "Open a terminal at the repo root (the folder with package.json and src/). Install deps once if needed: `bun install`.",
+    "Start the backend with `bun run server` — it listens on http://localhost:47778. Use a SECOND terminal for curl. Stop the server with Ctrl-C.",
+    "For the web-page checks, run the docs-site separately: `cd web && bun run dev`, then open the printed local URL (Astro dev server) in a browser.",
+    "Keep VECTOR_URL unset/empty for the zero-config checks — that is the default and the whole point of this epic.",
+  ],
+  features: [
+    {
+      id: "fts-floor",
+      name: "FTS keyword search works with no vector backend and no lancedb/ dir",
+      notes:
+        "With VECTOR_URL empty, `mode=fts` runs the local FTS5 search path only — it never opens or creates a vector store, so no lancedb/ directory appears.",
+      steps: [
+        "Make sure VECTOR_URL is empty (do not set it). Start the server: `bun run server`.",
+        "From the repo root, list directories so you have a before-picture: `ls`. Note there is no `lancedb` folder.",
+        "In the second terminal: `curl -s \"http://localhost:47778/api/search?mode=fts&q=oracle\"`.",
+        "Back at the repo root, run `ls` again and confirm no `lancedb` folder was created.",
+      ],
+      expected:
+        'The search returns JSON `{ results, total, limit, offset, query, ... }` (results may be empty if nothing is indexed, which is fine). No `lancedb/` directory is created by the FTS request.',
+    },
+    {
+      id: "web-pages",
+      name: "Onboarding pages /search, /connect, /install render",
+      notes:
+        "These are static Astro pages served by the docs-site (cd web && bun run dev), not the backend.",
+      steps: [
+        "With the docs-site running, open `/search` — a keyword search box. Type a query and submit; it calls the backend `GET /api/search?...&mode=fts` and lists results.",
+        "Open `/connect` — it stores your backend URL and an optional token, generating a `claude mcp add ...` command you can copy.",
+        "Open `/install` — a 3-step copy-friendly setup guide (backend, UI, CLI one-liners).",
+      ],
+      expected:
+        "All three pages load. /connect produces a command of the form `claude mcp add arra-oracle-v3 --env ORACLE_API='<api>' -- bunx --bun arra-oracle-v3@github:Soul-Brews-Studio/arra-oracle-v3` (with an extra `--env ARRA_API_TOKEN=...` if you set a token). /install shows three copyable steps.",
+    },
+    {
+      id: "tool-toggle",
+      name: "Per-tool MCP toggle persists allowed_tools",
+      notes:
+        "The page is /tools/config. Saving calls `PUT /api/settings/tools` with body `{ enabled_tools: string[] }`, which writes `allowed_tools` into the project .arra/config.json. The endpoint is session-gated, so use the web page (which carries the session cookie) rather than a raw curl.",
+      steps: [
+        "With both the backend (`bun run server`) and docs-site (`cd web && bun run dev`) running, open `/tools/config` in the browser.",
+        "Untick a tool (or two), then click Save. The page should confirm success.",
+        "At the repo root, inspect the written config: `cat .arra/config.json`.",
+      ],
+      expected:
+        "The save succeeds and `.arra/config.json` now contains an `allowed_tools` array reflecting your selection (the tools you left enabled). Re-opening /tools/config shows the same selection.",
+    },
+    {
+      id: "vector-opt-in",
+      name: "Vector is opt-in via PATCH /api/vector/config",
+      notes:
+        "Vector stays off until you opt in. PATCH `/api/vector/config` with `{ enabled: true }` turns it on and the response carries a recommended next action (nested under `state.recommendedAction`).",
+      steps: [
+        "With the backend running, in the second terminal: `curl -s -X PATCH http://localhost:47778/api/vector/config -H 'content-type: application/json' -d '{\"enabled\":true}'`.",
+        "Read the JSON response, specifically the `state.recommendedAction` field.",
+        "Optional: turn it back off with `curl -s -X PATCH http://localhost:47778/api/vector/config -H 'content-type: application/json' -d '{\"enabled\":false}'`.",
+      ],
+      expected:
+        'The response JSON has `state.enabled: true` and `state.recommendedAction: "POST /api/vector/index/start"` (when no index is built yet). A `vector-server.json` config file is written only after this opt-in — not before.',
+    },
+  ],
+};

--- a/web/src/data/epics/types.ts
+++ b/web/src/data/epics/types.ts
@@ -1,0 +1,45 @@
+// Epic Verification — shared types.
+//
+// This file defines the shape of the verification ledger. The actual data
+// lives in one file per epic (epic-1278.ts, epic-1072.ts, epic-1369.ts) and
+// is collected by ../epic-verification.ts.
+//
+// A human "stamps" an epic PASSED by editing the epic's data file:
+//   status: 'passed', verifiedBy: 'Your Name', verifiedDate: '2026-06-21'
+// (optionally ticking individual feature `passed` flags as you go).
+
+export type VerifyStatus = "pending" | "passed";
+
+export interface Feature {
+  /** Stable id, unique within the epic (used for anchors + checkboxes). */
+  id: string;
+  /** Short human-readable feature name. */
+  name: string;
+  /** Prerequisites or notes shown before the numbered steps (optional). */
+  notes?: string;
+  /** Numbered, end-to-end, copy-friendly steps. Plain strings; commands in `backticks` or as `$ cmd`. */
+  steps: string[];
+  /** The exact expected result after running the steps. */
+  expected: string;
+  /** Per-feature stamp. Tick to true once you have personally verified it. */
+  passed?: boolean;
+}
+
+export interface Epic {
+  /** Epic number from the tracker (e.g. 1278). */
+  id: number;
+  /** URL slug for the detail page, e.g. "1278-plugin-engine". */
+  slug: string;
+  title: string;
+  /** One-line summary of what the epic delivers. */
+  summary: string;
+  /** Overall verification status. Set to 'passed' to stamp. */
+  status: VerifyStatus;
+  /** Who stamped it (fill in when status -> 'passed'). */
+  verifiedBy: string;
+  /** Date stamped, ISO yyyy-mm-dd (fill in when status -> 'passed'). */
+  verifiedDate: string;
+  /** How to start the server / prerequisites shared by all features. */
+  prerequisites: string[];
+  features: Feature[];
+}

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -8,6 +8,7 @@ const CARDS = [
   { href: "/connect", title: "Connect", body: "Save ARRA_API_TOKEN and copy Claude MCP install snippets." },
   { href: "/traces", title: "Audit Log", body: "Review AI search and trace history with clickable detail." },
   { href: "/canvas/", title: "Canvas", body: "Three.js host with pluggable ESM modules — cube, galaxy, torus." },
+  { href: "/verify", title: "Epic Verification", body: "E2E test procedures for completed epics — track and stamp each PASSED." },
 ];
 
 const INSTALL = [

--- a/web/src/pages/verify/[slug].astro
+++ b/web/src/pages/verify/[slug].astro
@@ -1,0 +1,109 @@
+---
+import Base from "../../layouts/Base.astro";
+import { epics } from "../../data/epic-verification";
+
+export function getStaticPaths() {
+  return epics.map((epic) => ({
+    params: { slug: epic.slug },
+    props: { epic },
+  }));
+}
+
+const { epic } = Astro.props;
+---
+
+<Base title={`#${epic.id} ${epic.title} | Epic Verification`}>
+  <main class="max-w-3xl mx-auto px-6 py-16">
+    <a href="/verify" class="text-gray-500 hover:text-teal-300 text-sm transition-colors">← all epics</a>
+
+    <div class="mt-4 mb-8 flex items-start justify-between gap-4">
+      <div>
+        <h1 class="text-4xl font-bold tracking-tight mb-2">
+          <span class="text-gray-500 font-mono text-2xl mr-2">#{epic.id}</span>
+          {epic.title}
+        </h1>
+        <p class="text-gray-400 text-lg">{epic.summary}</p>
+      </div>
+      {epic.status === "passed" ? (
+        <span class="shrink-0 inline-flex items-center rounded-full border border-green-700 bg-green-950/50 px-3 py-1 text-xs font-mono text-green-300">
+          ✅ PASSED
+        </span>
+      ) : (
+        <span class="shrink-0 inline-flex items-center rounded-full border border-amber-700 bg-amber-950/40 px-3 py-1 text-xs font-mono text-amber-300">
+          🟡 PENDING
+        </span>
+      )}
+    </div>
+
+    <section class="mb-10 rounded-xl border border-gray-800 bg-gray-900/50 p-6">
+      <h2 class="text-sm font-mono text-gray-500 uppercase tracking-widest mb-3">Prerequisites</h2>
+      <ol class="list-decimal list-inside space-y-2 text-sm text-gray-300">
+        {epic.prerequisites.map((p) => <li>{p}</li>)}
+      </ol>
+    </section>
+
+    <h2 class="text-sm font-mono text-gray-500 uppercase tracking-widest mb-4">Feature checklist & E2E procedures</h2>
+
+    <div class="space-y-8">
+      {epic.features.map((f, i) => (
+        <section id={f.id} class="rounded-xl border border-gray-800 bg-gray-900/40 p-6">
+          <div class="flex items-start gap-3 mb-3">
+            <input
+              type="checkbox"
+              checked={f.passed === true}
+              disabled
+              class="mt-1.5 h-4 w-4 shrink-0 rounded border-gray-600 bg-gray-800 accent-teal-500"
+              aria-label={`feature ${f.name} verified`}
+            />
+            <h3 class="font-semibold text-lg">
+              <span class="text-gray-500 font-mono text-sm mr-2">{i + 1}.</span>
+              {f.name}
+            </h3>
+          </div>
+
+          {f.notes && (
+            <p class="text-sm text-gray-400 mb-4 pl-7 border-l border-gray-800 ml-1.5">{f.notes}</p>
+          )}
+
+          <ol class="space-y-3 text-sm text-gray-300 list-decimal list-inside ml-1">
+            {f.steps.map((s) =>
+              s.startsWith("$") || s.startsWith("curl") || s.startsWith("bun") ? (
+                <li class="list-none">
+                  <pre class="bg-gray-950 border border-gray-800 rounded-lg px-4 py-3 overflow-x-auto text-teal-300 font-mono text-xs"><code>{s}</code></pre>
+                </li>
+              ) : (
+                <li>{s}</li>
+              ),
+            )}
+          </ol>
+
+          <div class="mt-4 rounded-lg border border-teal-900/60 bg-teal-950/20 px-4 py-3">
+            <span class="text-xs font-mono uppercase tracking-widest text-teal-400">Expected result</span>
+            <p class="text-sm text-gray-200 mt-1">{f.expected}</p>
+          </div>
+        </section>
+      ))}
+    </div>
+
+    <section class="mt-12 rounded-xl border-2 border-dashed border-gray-700 bg-gray-900/60 p-6">
+      <h2 class="text-lg font-semibold mb-3">Sign-off / Stamp</h2>
+      {epic.status === "passed" ? (
+        <p class="text-green-300 text-sm font-mono">
+          ✅ PASSED — verified by {epic.verifiedBy || "—"}
+          {epic.verifiedDate ? ` on ${epic.verifiedDate}` : ""}.
+        </p>
+      ) : (
+        <p class="text-amber-300 text-sm font-mono">🟡 PENDING — not yet verified.</p>
+      )}
+      <div class="mt-4 text-sm text-gray-400 space-y-2">
+        <p>To stamp this epic <span class="font-mono text-teal-300">PASSED</span>, edit:</p>
+        <pre class="bg-gray-950 border border-gray-800 rounded-lg px-4 py-3 overflow-x-auto text-teal-300 font-mono text-xs"><code>web/src/data/epics/epic-{epic.id}.ts</code></pre>
+        <p>and set:</p>
+        <pre class="bg-gray-950 border border-gray-800 rounded-lg px-4 py-3 overflow-x-auto text-teal-300 font-mono text-xs"><code>status: 'passed',
+verifiedBy: 'Your Name',
+verifiedDate: '2026-06-21',</code></pre>
+        <p>Optionally tick each feature by setting <code class="text-teal-300 font-mono">passed: true</code> on it. Rebuild to update the badges.</p>
+      </div>
+    </section>
+  </main>
+</Base>

--- a/web/src/pages/verify/index.astro
+++ b/web/src/pages/verify/index.astro
@@ -1,0 +1,75 @@
+---
+import Base from "../../layouts/Base.astro";
+import { epics, passedCount } from "../../data/epic-verification";
+
+const passed = passedCount();
+const total = epics.length;
+---
+
+<Base title="Epic Verification | Neo ARRA V3">
+  <main class="max-w-4xl mx-auto px-6 py-16">
+    <a href="/" class="text-gray-500 hover:text-teal-300 text-sm transition-colors">← home</a>
+    <h1 class="text-5xl font-bold tracking-tight mt-4 mb-2">Epic Verification</h1>
+    <p class="text-gray-400 mb-6 text-lg">
+      Beginner-friendly, end-to-end test procedures that prove each completed epic actually works —
+      and a place to stamp it <span class="text-teal-300 font-mono">PASSED</span> once you've checked it yourself.
+    </p>
+
+    <div class="mb-10 inline-flex items-center gap-3 bg-gray-900/80 border border-gray-800 rounded-lg px-5 py-3">
+      <span class="text-2xl font-bold text-teal-300 font-mono">{passed} / {total}</span>
+      <span class="text-gray-400 text-sm">epics stamped <span class="font-mono text-teal-300">PASSED</span></span>
+    </div>
+
+    <div class="space-y-4">
+      {epics.map((e) => (
+        <a
+          href={`/verify/${e.slug}`}
+          class="block bg-gray-900/80 border border-gray-800 rounded-xl p-6 hover:border-teal-700/70 hover:ring-1 hover:ring-teal-500/30 transition-all duration-200 group"
+        >
+          <div class="flex items-start justify-between gap-4">
+            <div>
+              <h2 class="font-semibold text-lg mb-1">
+                <span class="text-gray-500 font-mono text-sm mr-2">#{e.id}</span>
+                {e.title}
+              </h2>
+              <p class="text-gray-400 text-sm">{e.summary}</p>
+            </div>
+            {e.status === "passed" ? (
+              <span class="shrink-0 inline-flex items-center rounded-full border border-green-700 bg-green-950/50 px-3 py-1 text-xs font-mono text-green-300">
+                ✅ PASSED
+              </span>
+            ) : (
+              <span class="shrink-0 inline-flex items-center rounded-full border border-amber-700 bg-amber-950/40 px-3 py-1 text-xs font-mono text-amber-300">
+                🟡 PENDING
+              </span>
+            )}
+          </div>
+          <div class="mt-3 flex items-center justify-between">
+            <span class="text-xs text-gray-500">
+              {e.features.length} features ·{" "}
+              {e.status === "passed"
+                ? `verified by ${e.verifiedBy || "—"}${e.verifiedDate ? ` on ${e.verifiedDate}` : ""}`
+                : "not yet verified"}
+            </span>
+            <span class="text-teal-400 group-hover:translate-x-1 inline-block transition-transform">→</span>
+          </div>
+        </a>
+      ))}
+    </div>
+
+    <div class="mt-12 rounded-xl border border-gray-800 bg-gray-900/50 p-6 text-sm text-gray-400">
+      <h3 class="text-gray-200 font-semibold mb-2">How to stamp an epic PASSED</h3>
+      <ol class="list-decimal list-inside space-y-1">
+        <li>Open the epic's detail page and follow the end-to-end procedure for every feature.</li>
+        <li>
+          Edit the epic's data file under{" "}
+          <code class="text-teal-300 font-mono">web/src/data/epics/</code> and set{" "}
+          <code class="text-teal-300 font-mono">status: 'passed'</code>,{" "}
+          <code class="text-teal-300 font-mono">verifiedBy</code>, and{" "}
+          <code class="text-teal-300 font-mono">verifiedDate</code>.
+        </li>
+        <li>Rebuild — this dashboard badge and the progress count update automatically.</li>
+      </ol>
+    </div>
+  </main>
+</Base>


### PR DESCRIPTION
## What was added

A new **Epic Verification** section in the docs-site (`web/`, Astro + Tailwind):

- **Single-source-of-truth registry** — `web/src/data/epic-verification.ts` (barrel) + one typed data file per epic under `web/src/data/epics/`. Each epic has `{ id, slug, title, summary, status, verifiedBy, verifiedDate, prerequisites, features[] }`; each feature has numbered E2E `steps`, an `expected` result, and a `passed` flag. This file IS the tracking ledger.
- **Dashboard** — `/verify` (`web/src/pages/verify/index.astro`): cards for every epic with a 🟡 PENDING / ✅ PASSED badge and an overall "N / 3 epics stamped PASSED" progress count.
- **Per-epic detail pages** — `/verify/[slug]` (`getStaticPaths` dynamic route): prerequisites, a feature checklist, the full numbered copy-friendly E2E procedure with the exact command in `<pre>` blocks and the expected result after each, plus a Sign-off / Stamp block with edit instructions.
- **Home nav link** — added a `/verify` card to `web/src/pages/index.astro` (matches existing card style).

## Epics covered (only those verified DONE on `main`)

- **#1278 — Server plugin engine**: `plugin list`, federation route flip (`/info` 404↔200 across restart), core-plugin refusal (`Cannot disable core server plugin "search"`, exit 1), `plugin-api-example` route mount, `unified-example` start/stop lifecycle, config persistence.
- **#1072 — API gateway router on :47778**: `/api/gateway/status` + `/health`, VECTOR_URL proxy with `fts5` fallback, `oracle-gateway.json` hot-reload via fs.watch, built-in hooks (auth-guard, request-logger, rate-limit, fts5-fallback, error-json).
- **#1369 — Zero-config onboarding**: FTS floor with empty VECTOR_URL (no `lancedb/` dir), `/search` `/connect` `/install` pages, per-tool toggle (`PUT /api/settings/tools` → `allowed_tools` in `.arra/config.json`), vector opt-in (`PATCH /api/vector/config` → `state.recommendedAction`).

## How to stamp an epic PASSED

Follow the E2E steps on the epic's detail page, then edit its data file under `web/src/data/epics/` (e.g. `epic-1278.ts`): set `status: 'passed'`, `verifiedBy`, `verifiedDate` (optionally tick per-feature `passed: true`). Rebuild — badges and the progress count update automatically.

## Verification

Content was **verified against `main` HEAD** by reading `src/`, `cli/`, and `web/` source. Corrections applied vs. the original audit notes: CLI binary is `arra-cli` (run `bun cli/src/cli.ts`); API-manifest plugin is named `plugin-api-example`; `plugin list` lists installed WASM/dir plugins (empty on fresh checkout); CLI toggles persist to global `~/.config/arra/config.json`; gateway `status.routes`/`hooks` are counts not arrays and return `{enabled:false}` when no config/VECTOR_URL; vector `recommendedAction` is nested under `state`.

`cd web && bun run build` passes (13 pages, all 4 verify routes generated). `cd web && bun test` passes (4/4). All new source files are ≤ 250 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)