### PR TITLE
test(vector): cover export collection-name aliases

### DIFF
--- a/tests/http/vector/export-collection-name.test.ts
+++ b/tests/http/vector/export-collection-name.test.ts
@@ -1,0 +1,57 @@
+import { expect, mock, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createVectorExportEndpoint } from '../../../src/routes/vector/export.ts';
+import type { VectorStoreAdapter } from '../../../src/vector/types.ts';
+
+function createStore(): VectorStoreAdapter {
+  return {
+    name: 'fake-vector',
+    connect: mock(async () => {}),
+    close: mock(async () => {}),
+    ensureCollection: mock(async () => {}),
+    deleteCollection: mock(async () => {}),
+    addDocuments: mock(async () => {}),
+    query: mock(async () => ({ ids: [], documents: [], distances: [], metadatas: [] })),
+    queryById: mock(async () => ({ ids: [], documents: [], distances: [], metadatas: [] })),
+    getStats: mock(async () => ({ count: 1 })),
+    getCollectionInfo: mock(async () => ({ count: 1, name: 'oracle_knowledge' })),
+    getAllEmbeddings: mock(async () => ({
+      ids: ['doc-1'],
+      documents: ['alpha'],
+      embeddings: [[0]],
+      metadatas: [{ type: 'learning' }],
+    })),
+  };
+}
+
+test('GET /api/v1/vector/export accepts collection names from model registry deps', async () => {
+  const store = createStore();
+  const selected: string[] = [];
+  const app = new Elysia({ prefix: '/api' }).use(createVectorExportEndpoint({
+    getModels: () => ({
+      nomic: { collection: 'oracle_knowledge' },
+      'bge-m3': { collection: 'oracle_knowledge_bge_m3' },
+    }),
+    getStore: (collection) => {
+      selected.push(collection ?? '');
+      return store;
+    },
+  }));
+  const fetcher = createApiVersionedFetch((request) => app.handle(request));
+
+  const res = await fetcher(new Request(
+    'http://local/api/v1/vector/export?collection=oracle_knowledge&format=json',
+  ));
+  const body = await res.json() as Array<Record<string, unknown>>;
+
+  expect(res.status).toBe(200);
+  expect(selected).toEqual(['nomic']);
+  expect(body).toEqual([{
+    id: 'doc-1',
+    document: 'alpha',
+    type: 'learning',
+    source_file: '',
+    concepts: [],
+  }]);
+});


### PR DESCRIPTION
## Summary\n- Add regression coverage for /api/v1/vector/export accepting physical collection names like oracle_knowledge from the model registry.\n- Verifies the export handler resolves the collection name back to the model key before opening the vector store.\n\n## Validation\n- bunx tsc --noEmit\n- bun test tests/http/vector/\n- bun run test\n\nNote: this worktree was fast-forwarded to current origin/alpha before the commit; the handler fix is already present there, and this PR locks the registry-deps alias path.