### PR TITLE
feat: incremental vector indexing with chunk hashes

### DIFF
--- a/src/db/__tests__/fresh-install.test.ts
+++ b/src/db/__tests__/fresh-install.test.ts
@@ -85,6 +85,8 @@ describe("fresh install (#1111)", () => {
 		expect(names).toContain("idx_entity_links_tenant_doc");
 		expect(names).toContain("idx_pointer_tenant_kind_key");
 		expect(names).toContain("idx_pointer_tenant_updated");
+		expect(names).toContain("idx_vector_manifest_model_hash");
+		expect(names).toContain("idx_vector_manifest_source");
 
 		sqlite.close();
 		rmSync(dir, { recursive: true });

--- a/src/db/migrations/0039_vector_index_manifest.sql
+++ b/src/db/migrations/0039_vector_index_manifest.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS vector_index_manifest (
+  id TEXT PRIMARY KEY NOT NULL,
+  chunk_id TEXT NOT NULL,
+  source_file TEXT NOT NULL,
+  model_key TEXT NOT NULL,
+  content_hash TEXT NOT NULL,
+  updated_at INTEGER NOT NULL,
+  indexed_at INTEGER NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_vector_manifest_model_hash ON vector_index_manifest (model_key, content_hash);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_vector_manifest_source ON vector_index_manifest (source_file);

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -238,6 +238,7 @@
     { "idx": 35, "version": "6", "when": 1781669700000, "tag": "0035_entity_links_ranking_sidecar", "breakpoints": true },
     { "idx": 36, "version": "6", "when": 1781703600000, "tag": "0036_memory_consolidation", "breakpoints": true },
     { "idx": 37, "version": "6", "when": 1781703700000, "tag": "0037_memory_tiered_salience", "breakpoints": true },
-    { "idx": 38, "version": "6", "when": 1781703800000, "tag": "0038_pointer_index", "breakpoints": true }
+    { "idx": 38, "version": "6", "when": 1781703800000, "tag": "0038_pointer_index", "breakpoints": true },
+    { "idx": 39, "version": "6", "when": 1781703900000, "tag": "0039_vector_index_manifest", "breakpoints": true }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -80,7 +80,6 @@ export const oracleMemories = sqliteTable('oracle_memories', {
   index('idx_memory_tenant_valid_time').on(table.tenantId, table.validFrom, table.validTo),
   index('idx_memory_tenant_tier_heat').on(table.tenantId, table.tier, table.heatScore),
 ]);
-
 export const indexingStatus = sqliteTable('indexing_status', {
   id: integer('id').primaryKey(),
   isIndexing: integer('is_indexing').default(0).notNull(),
@@ -98,14 +97,20 @@ export const indexingJobs = sqliteTable('indexing_jobs', {
   collection: text('collection').notNull(),
   status: text('status').default('pending').notNull(),
   attempts: integer('attempts').default(0).notNull(),
-  createdAt: integer('created_at')
-    .default(sql`(strftime('%s','now')*1000)`)
-    .notNull(),
+  createdAt: integer('created_at').default(sql`(strftime('%s','now')*1000)`).notNull(),
   claimedAt: integer('claimed_at'),
   finishedAt: integer('finished_at'),
   error: text('error'),
 });
-
+export const vectorIndexManifest = sqliteTable('vector_index_manifest', {
+  id: text('id').primaryKey(), chunkId: text('chunk_id').notNull(),
+  sourceFile: text('source_file').notNull(), modelKey: text('model_key').notNull(),
+  contentHash: text('content_hash').notNull(),
+  updatedAt: integer('updated_at').notNull(), indexedAt: integer('indexed_at').notNull(),
+}, (table) => [
+  index('idx_vector_manifest_model_hash').on(table.modelKey, table.contentHash),
+  index('idx_vector_manifest_source').on(table.sourceFile),
+]);
 export const searchLog = sqliteTable('search_log', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   query: text('query').notNull(),
@@ -123,7 +128,6 @@ export const searchLog = sqliteTable('search_log', {
   index('idx_search_created').on(table.createdAt),
   index('idx_search_tenant_created').on(table.tenantId, table.createdAt),
 ]);
-
 export const consultLog = sqliteTable('consult_log', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   decision: text('decision').notNull(),
@@ -137,7 +141,6 @@ export const consultLog = sqliteTable('consult_log', {
   index('idx_consult_project').on(table.project),
   index('idx_consult_created').on(table.createdAt),
 ]);
-
 export const learnLog = sqliteTable('learn_log', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   documentId: text('document_id').notNull(),
@@ -152,7 +155,6 @@ export const learnLog = sqliteTable('learn_log', {
   index('idx_learn_tenant').on(table.tenantId),
   index('idx_learn_created').on(table.createdAt),
 ]);
-
 export const documentAccess = sqliteTable('document_access', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   documentId: text('document_id').notNull(),
@@ -230,7 +232,6 @@ export const traceLog = sqliteTable('trace_log', {
   awakening: text('awakening'),
   distilledToId: text('distilled_to_id'),
   distilledAt: integer('distilled_at'),
-
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
 }, (table) => [

--- a/src/indexer/__tests__/vector-index-manifest.test.ts
+++ b/src/indexer/__tests__/vector-index-manifest.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createDatabase, type DatabaseConnection } from '../../db/index.ts';
+import type { VectorDocument } from '../../vector/types.ts';
+import {
+  loadVectorIndexManifest,
+  planVectorIndex,
+  vectorContentHash,
+  writeVectorIndexManifest,
+} from '../vector-index-manifest.ts';
+
+let open: Array<{ conn: DatabaseConnection; dir: string }> = [];
+
+afterEach(() => {
+  for (const item of open) {
+    item.conn.storage.close();
+    rmSync(item.dir, { recursive: true, force: true });
+  }
+  open = [];
+});
+
+describe('vector index manifest', () => {
+  test('first run marks every chunk for embedding and persists hashes', () => {
+    const conn = freshDb();
+    const docs = [doc('a', 'Alpha'), doc('b', 'Beta')];
+    const before = loadVectorIndexManifest(conn.sqlite, 'bge-m3');
+    const plan = planVectorIndex(docs, before, 'bge-m3', { now: 100 });
+
+    expect(plan.changedDocs.map((item) => item.id)).toEqual(['a', 'b']);
+    expect(plan.skipped).toBe(0);
+
+    writeVectorIndexManifest(conn.sqlite, plan);
+    const after = loadVectorIndexManifest(conn.sqlite, 'bge-m3');
+    expect(after.get('a')?.contentHash).toBe(vectorContentHash(docs[0]));
+    expect(after.get('a')?.indexedAt).toBe(100);
+  });
+
+  test('unchanged chunks are skipped and one edited chunk is re-indexed', () => {
+    const conn = freshDb();
+    const initial = [doc('a', 'Alpha'), doc('b', 'Beta')];
+    writeVectorIndexManifest(conn.sqlite, planVectorIndex(initial, new Map(), 'bge-m3', { now: 100 }));
+
+    const unchanged = planVectorIndex(initial, loadVectorIndexManifest(conn.sqlite, 'bge-m3'), 'bge-m3', { now: 200 });
+    expect(unchanged.changedDocs).toEqual([]);
+    expect(unchanged.skipped).toBe(2);
+
+    const edited = [doc('a', 'Alpha changed'), doc('b', 'Beta')];
+    const plan = planVectorIndex(edited, loadVectorIndexManifest(conn.sqlite, 'bge-m3'), 'bge-m3', { now: 300 });
+    expect(plan.changedDocs.map((item) => item.id)).toEqual(['a']);
+    expect(plan.entries.find((entry) => entry.chunkId === 'a')?.indexedAt).toBe(300);
+    expect(plan.entries.find((entry) => entry.chunkId === 'b')?.indexedAt).toBe(100);
+  });
+
+  test('missing chunks are stale and force rebuild marks all chunks changed', () => {
+    const conn = freshDb();
+    const initial = [doc('a', 'Alpha'), doc('b', 'Beta')];
+    writeVectorIndexManifest(conn.sqlite, planVectorIndex(initial, new Map(), 'nomic', { now: 100 }));
+
+    const current = [doc('a', 'Alpha')];
+    const plan = planVectorIndex(current, loadVectorIndexManifest(conn.sqlite, 'nomic'), 'nomic', { now: 200 });
+    expect(plan.staleIds).toEqual(['b']);
+    expect(plan.changedDocs).toEqual([]);
+
+    const forced = planVectorIndex(current, loadVectorIndexManifest(conn.sqlite, 'nomic'), 'nomic', { force: true, now: 300 });
+    expect(forced.changedDocs.map((item) => item.id)).toEqual(['a']);
+  });
+});
+
+function freshDb(): DatabaseConnection {
+  const dir = mkdtempSync(join(tmpdir(), 'arra-vector-manifest-'));
+  const conn = createDatabase(join(dir, 'oracle.db'));
+  open.push({ conn, dir });
+  return conn;
+}
+
+function doc(id: string, text: string): VectorDocument {
+  return {
+    id,
+    document: text,
+    metadata: { type: 'learning', source_file: `ψ/${id}.md`, concepts: '[]' },
+  };
+}

--- a/src/indexer/vector-index-manifest.ts
+++ b/src/indexer/vector-index-manifest.ts
@@ -1,0 +1,118 @@
+import { createHash } from 'node:crypto';
+import type { Database } from 'bun:sqlite';
+import type { VectorDocument } from '../vector/types.ts';
+
+export interface VectorManifestRow {
+  chunkId: string;
+  sourceFile: string;
+  modelKey: string;
+  contentHash: string;
+  updatedAt: number;
+  indexedAt: number;
+}
+
+export interface VectorManifestEntry extends VectorManifestRow { id: string }
+
+export interface VectorIndexPlan {
+  modelKey: string;
+  docs: VectorDocument[];
+  changedDocs: VectorDocument[];
+  staleIds: string[];
+  entries: VectorManifestEntry[];
+  skipped: number;
+  total: number;
+}
+
+export function vectorManifestId(modelKey: string, chunkId: string): string {
+  return `${modelKey}:${chunkId}`;
+}
+
+export function vectorContentHash(doc: VectorDocument): string {
+  const payload = JSON.stringify({
+    document: normalizeVectorText(doc.document),
+    metadata: stableMetadata(doc.metadata),
+  });
+  return `sha256:${createHash('sha256').update(payload).digest('hex')}`;
+}
+
+export function loadVectorIndexManifest(sqlite: Database, modelKey: string): Map<string, VectorManifestRow> {
+  const rows = sqlite.prepare(`
+    SELECT chunk_id AS chunkId, source_file AS sourceFile, model_key AS modelKey,
+      content_hash AS contentHash, updated_at AS updatedAt, indexed_at AS indexedAt
+    FROM vector_index_manifest
+    WHERE model_key = ?
+  `).all(modelKey) as VectorManifestRow[];
+  return new Map(rows.map((row) => [row.chunkId, row]));
+}
+
+export function planVectorIndex(
+  docs: VectorDocument[],
+  previous: Map<string, VectorManifestRow>,
+  modelKey: string,
+  opts: { force?: boolean; now?: number } = {},
+): VectorIndexPlan {
+  const now = opts.now ?? Date.now();
+  const currentIds = new Set(docs.map((doc) => doc.id));
+  const staleIds = [...previous.keys()].filter((chunkId) => !currentIds.has(chunkId));
+  const changedDocs: VectorDocument[] = [];
+  const entries: VectorManifestEntry[] = [];
+
+  for (const doc of docs) {
+    const contentHash = vectorContentHash(doc);
+    const prior = previous.get(doc.id);
+    const changed = opts.force === true || !prior || prior.contentHash !== contentHash;
+    if (changed) changedDocs.push(doc);
+    entries.push({
+      id: vectorManifestId(modelKey, doc.id),
+      chunkId: doc.id,
+      sourceFile: sourceFileOf(doc),
+      modelKey,
+      contentHash,
+      updatedAt: now,
+      indexedAt: changed ? now : prior.indexedAt,
+    });
+  }
+
+  return { modelKey, docs, changedDocs, staleIds, entries, skipped: docs.length - changedDocs.length, total: docs.length };
+}
+
+export function writeVectorIndexManifest(sqlite: Database, plan: VectorIndexPlan): void {
+  const deleteStmt = sqlite.prepare('DELETE FROM vector_index_manifest WHERE id = ?');
+  const upsertStmt = sqlite.prepare(`
+    INSERT INTO vector_index_manifest
+      (id, chunk_id, source_file, model_key, content_hash, updated_at, indexed_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(id) DO UPDATE SET
+      chunk_id = excluded.chunk_id,
+      source_file = excluded.source_file,
+      model_key = excluded.model_key,
+      content_hash = excluded.content_hash,
+      updated_at = excluded.updated_at,
+      indexed_at = excluded.indexed_at
+  `);
+
+  sqlite.exec('BEGIN');
+  try {
+    for (const chunkId of plan.staleIds) deleteStmt.run(vectorManifestId(plan.modelKey, chunkId));
+    for (const entry of plan.entries) {
+      upsertStmt.run(entry.id, entry.chunkId, entry.sourceFile, entry.modelKey, entry.contentHash, entry.updatedAt, entry.indexedAt);
+    }
+    sqlite.exec('COMMIT');
+  } catch (error) {
+    sqlite.exec('ROLLBACK');
+    throw error;
+  }
+}
+
+function normalizeVectorText(text: string): string {
+  return text.replace(/\r\n?/g, '\n').trim();
+}
+
+function stableMetadata(metadata: Record<string, string | number>): Record<string, string | number> {
+  return Object.fromEntries(Object.entries(metadata).sort(([a], [b]) => a.localeCompare(b)));
+}
+
+function sourceFileOf(doc: VectorDocument): string {
+  const source = doc.metadata.source_file;
+  return typeof source === 'string' ? source : '';
+}

--- a/src/scripts/index-model.ts
+++ b/src/scripts/index-model.ts
@@ -1,130 +1,174 @@
 #!/usr/bin/env bun
-/**
- * Generic embedding model indexer.
- * Reads model config from EMBEDDING_MODELS registry in factory.ts.
- *
- * Usage:
- *   bun src/scripts/index-model.ts bge-m3
- *   bun src/scripts/index-model.ts qwen3
- *   bun src/scripts/index-model.ts nomic
- */
+/** Generic embedding model indexer with incremental chunk-hash support. */
 
 import { createVectorStoreForModel, EMBEDDING_MODELS } from '../vector/factory.ts';
 import { createDatabase, oracleDocuments } from '../db/index.ts';
 import { count } from 'drizzle-orm';
 import { DB_PATH } from '../config.ts';
 import { formatIndexProgress, normalizeBatchSize } from './indexer-progress.ts';
+import {
+  loadVectorIndexManifest,
+  planVectorIndex,
+  writeVectorIndexManifest,
+  type VectorIndexPlan,
+} from '../indexer/vector-index-manifest.ts';
+import type { VectorDocument, VectorStoreAdapter } from '../vector/types.ts';
 
-const modelKey = process.argv[2];
+const args = process.argv.slice(2);
+const modelKey = args.find((arg) => !arg.startsWith('--'));
+const flags = new Set(args.filter((arg) => arg.startsWith('--')));
 
-if (!modelKey || !EMBEDDING_MODELS[modelKey]) {
-  console.error(`Usage: bun src/scripts/index-model.ts <model>`);
+if (!modelKey || !EMBEDDING_MODELS[modelKey] || flags.has('--help')) {
+  console.error('Usage: bun src/scripts/index-model.ts <model> [--incremental] [--dry-run] [--force]');
   console.error(`Available models: ${Object.keys(EMBEDDING_MODELS).join(', ')}`);
-  process.exit(1);
+  process.exit(flags.has('--help') ? 0 : 1);
 }
 
-const preset = EMBEDDING_MODELS[modelKey];
-
-// Keep script batches aligned with OllamaEmbeddings' /api/embed batching default.
+const selectedModelKey = modelKey;
+const preset = EMBEDDING_MODELS[selectedModelKey];
 const BATCH_SIZE = normalizeBatchSize(process.env.ORACLE_EMBED_BATCH_SIZE, 50);
+const dryRun = flags.has('--dry-run');
+const force = flags.has('--force');
+
+interface DbVectorRow {
+  id: string;
+  tenant_id: string;
+  type: string;
+  content: string;
+  source_file: string;
+  concepts: string;
+  project: string | null;
+  created_at: number;
+}
 
 async function main() {
-  console.log(`=== ${modelKey} Indexer ===`);
+  console.log(`=== ${selectedModelKey} Indexer ===`);
   console.log(`DB: ${DB_PATH}`);
   console.log(`Collection: ${preset.collection}`);
   console.log(`Model: ${preset.model}`);
   console.log(`Adapter: ${preset.adapter || 'lancedb'}`);
   console.log(`Batch size: ${BATCH_SIZE}`);
+  console.log(`Mode: ${force ? 'force rebuild' : 'incremental'}${dryRun ? ' dry-run' : ''}`);
 
-  // Use Drizzle for structured queries, raw sqlite only for FTS5 joins
   const { db, sqlite } = createDatabase(DB_PATH);
   const [{ total: docCount }] = db.select({ total: count() }).from(oracleDocuments).all();
+  const rows = loadRows(sqlite);
+  const docs = rows.map(vectorDoc);
+  const previous = loadVectorIndexManifest(sqlite, selectedModelKey);
+  const plan = planVectorIndex(docs, previous, selectedModelKey, { force });
+  const startTime = Date.now();
+
   console.log(`Documents: ${docCount}`);
+  console.log(`Chunks: ${plan.total}; changed: ${plan.changedDocs.length}; stale: ${plan.staleIds.length}; skipped: ${plan.skipped}`);
 
-  const store = createVectorStoreForModel(preset);
-
-  await store.connect();
-
-  if (!store.replaceDocuments) {
-    throw new Error(`Vector adapter '${store.name}' does not support safe replaceDocuments(); refusing drop/recreate reindex (#987).`);
+  if (dryRun) {
+    printSummary(rows, plan, { embedded: plan.changedDocs.length, errors: 0, startTime, dryRun, force });
+    sqlite.close();
+    return;
   }
 
-  // FTS5 join requires raw SQL — Drizzle doesn't support virtual tables
-  const rows = sqlite.prepare(`
-    SELECT d.id, d.type, GROUP_CONCAT(f.content, '\n') as content, d.source_file, d.concepts, d.project, d.created_at
+  const store = createVectorStoreForModel(preset);
+  await store.connect();
+
+  try {
+    const embedded = await applyVectorPlan(store, plan, previous.size === 0 || force, startTime);
+    writeVectorIndexManifest(sqlite, plan);
+    printSummary(rows, plan, { embedded, errors: 0, startTime, dryRun, force });
+  } finally {
+    await store.close();
+    sqlite.close();
+  }
+}
+
+function loadRows(sqlite: ReturnType<typeof createDatabase>['sqlite']): DbVectorRow[] {
+  return sqlite.prepare(`
+    SELECT d.id, d.tenant_id, d.type, GROUP_CONCAT(f.content, '\n') as content,
+      d.source_file, d.concepts, d.project, d.created_at
     FROM oracle_documents d
     JOIN oracle_fts f ON d.id = f.id
     GROUP BY d.id
     ORDER BY d.created_at DESC
-  `).all() as Array<{
-    id: string;
-    type: string;
-    content: string;
-    source_file: string;
-    concepts: string;
-    project: string | null;
-    created_at: string;
-  }>;
+  `).all() as DbVectorRow[];
+}
 
-  const totalBatches = Math.ceil(rows.length / BATCH_SIZE);
-  let indexed = 0;
-  let errors = 0;
-  const startTime = Date.now();
+function vectorDoc(row: DbVectorRow): VectorDocument {
+  return {
+    id: row.id,
+    document: row.content,
+    metadata: {
+      type: row.type,
+      source_file: row.source_file,
+      concepts: row.concepts,
+      tenant_id: row.tenant_id,
+      ...(row.project && { project: row.project }),
+    },
+  };
+}
 
-  if (rows.length === 0) {
-    await store.replaceDocuments([]);
+async function applyVectorPlan(
+  store: VectorStoreAdapter,
+  plan: VectorIndexPlan,
+  replaceBaseline: boolean,
+  startTime: number,
+): Promise<number> {
+  if (replaceBaseline || (plan.staleIds.length > 0 && !store.deleteDocuments)) {
+    if (!store.replaceDocuments) throw new Error(`Vector adapter '${store.name}' does not support replaceDocuments()`);
+    await replaceAll(store, plan.docs, startTime);
+    return plan.docs.length;
   }
 
-  for (let i = 0; i < rows.length; i += BATCH_SIZE) {
-    const batch = rows.slice(i, i + BATCH_SIZE);
-    const batchNum = Math.floor(i / BATCH_SIZE) + 1;
+  if (plan.staleIds.length > 0) await store.deleteDocuments?.(plan.staleIds);
+  const changedIds = plan.changedDocs.map((doc) => doc.id);
+  if (changedIds.length > 0) await store.deleteDocuments?.(changedIds);
+  await addChanged(store, plan.changedDocs, plan.total, startTime);
+  return plan.changedDocs.length;
+}
 
-    const docs = batch.map(row => ({
-      id: row.id,
-      document: row.content,
-      metadata: {
-        type: row.type,
-        source_file: row.source_file,
-        concepts: row.concepts,
-        ...(row.project && { project: row.project }),
-      },
-    }));
-
-    try {
-      if (i === 0) {
-        // Replace the first batch in-place instead of drop/recreate. Dropping
-        // the LanceDB table invalidates long-lived server/MCP table handles and
-        // caused silent vector-store corruption after index-model backfills
-        // (#987). Subsequent batches append to the same table version chain.
-        await store.replaceDocuments(docs);
-      } else {
-        await store.addDocuments(docs);
-      }
-      indexed += docs.length;
-
-      const progress = formatIndexProgress({ indexed, total: rows.length, startTimeMs: startTime });
-      console.log(`  Batch ${batchNum}/${totalBatches} — ${indexed}/${rows.length} docs — ${progress.rate}/s — ETA ${progress.eta}s`);
-    } catch (e) {
-      errors++;
-      console.error(`  Batch ${batchNum} FAILED:`, e instanceof Error ? e.message : String(e));
-      if (i === 0) {
-        throw new Error('First reindex batch failed during safe replace; aborting to avoid appending into stale pre-reindex data.', {
-          cause: e,
-        });
-      }
-    }
+async function replaceAll(store: VectorStoreAdapter, docs: VectorDocument[], startTime: number): Promise<void> {
+  if (docs.length === 0) {
+    await store.replaceDocuments?.([]);
+    return;
   }
+  for (let i = 0; i < docs.length; i += BATCH_SIZE) {
+    const batch = docs.slice(i, i + BATCH_SIZE);
+    if (i === 0) await store.replaceDocuments?.(batch);
+    else await store.addDocuments(batch);
+    logProgress('Rebuilt', i + batch.length, docs.length, startTime);
+  }
+}
 
-  const totalTime = ((Date.now() - startTime) / 1000).toFixed(1);
-  const stats = await store.getStats();
+async function addChanged(store: VectorStoreAdapter, docs: VectorDocument[], total: number, startTime: number): Promise<void> {
+  for (let i = 0; i < docs.length; i += BATCH_SIZE) {
+    const batch = docs.slice(i, i + BATCH_SIZE);
+    await store.addDocuments(batch);
+    logProgress('Embedded', i + batch.length, total, startTime);
+  }
+}
 
+function logProgress(label: string, indexed: number, total: number, startTime: number): void {
+  const progress = formatIndexProgress({ indexed, total, startTimeMs: startTime });
+  console.log(`  ${label} ${indexed}/${total} chunks — ${progress.rate}/s — ETA ${progress.eta}s`);
+}
+
+function printSummary(
+  rows: DbVectorRow[],
+  plan: VectorIndexPlan,
+  result: { embedded: number; errors: number; startTime: number; dryRun: boolean; force: boolean },
+): void {
+  const durationMs = Date.now() - result.startTime;
+  const summary = {
+    scanned_files: new Set(rows.map((row) => row.source_file)).size,
+    total_chunks: plan.total,
+    skipped: result.force ? 0 : plan.skipped,
+    embedded: result.embedded,
+    deleted: plan.staleIds.length,
+    errors: result.errors,
+    dry_run: result.dryRun,
+    force: result.force,
+    duration_ms: durationMs,
+  };
   console.log('\n=== Done ===');
-  console.log(`Indexed: ${stats.count} docs`);
-  console.log(`Errors: ${errors} batches`);
-  console.log(`Time: ${totalTime}s`);
-
-  await store.close();
-  sqlite.close();
+  console.log(JSON.stringify(summary, null, 2));
 }
 
 main().catch(e => {

--- a/src/vector/__tests__/lancedb-stale-handle.test.ts
+++ b/src/vector/__tests__/lancedb-stale-handle.test.ts
@@ -91,4 +91,25 @@ describe('LanceDB stale-handle safety (#987)', () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it('deleteDocuments removes selected rows without dropping the collection', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oracle-lancedb-delete-docs-'));
+    const adapter = new LanceDBAdapter('delete_documents_regression', tmpDir, new DeterministicEmbedder());
+
+    try {
+      await adapter.connect();
+      await adapter.ensureCollection();
+      await adapter.addDocuments([doc('keep'), doc('drop')]);
+      await adapter.deleteDocuments(['drop']);
+
+      const stats = await adapter.getStats();
+      const result = await adapter.query('keep', 10);
+
+      expect(stats.count).toBe(1);
+      expect(result.ids).toEqual(['keep']);
+    } finally {
+      try { await adapter.close(); } catch {}
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/vector/adapter.ts
+++ b/src/vector/adapter.ts
@@ -40,6 +40,8 @@ export interface VectorStoreAdapter {
   ensureCollection(): Promise<void>;
   deleteCollection(): Promise<void>;
   addDocuments(docs: VectorDocument[]): Promise<void>;
+  /** Delete specific vector rows by document/chunk id without dropping the collection. */
+  deleteDocuments?(ids: string[]): Promise<void>;
   /**
    * Replace collection contents without dropping/recreating the table.
    *

--- a/src/vector/adapters/lancedb.ts
+++ b/src/vector/adapters/lancedb.ts
@@ -80,6 +80,14 @@ export class LanceDBAdapter implements VectorStoreAdapter {
     }
   }
 
+  async deleteDocuments(ids: string[]): Promise<void> {
+    if (ids.length === 0) return;
+    if (!this.table) await this.ensureCollection();
+    await this.checkoutLatest();
+    for (const id of ids) await this.table.delete(`id = '${id.replaceAll("'", "''")}'`);
+    console.error(`[LanceDB] Deleted ${ids.length} documents`);
+  }
+
   async addDocuments(docs: VectorDocument[]): Promise<void> {
     if (docs.length === 0) return;
     if (!this.table) await this.ensureCollection();


### PR DESCRIPTION
## Summary
- add vector_index_manifest migration/schema for per-model chunk content hashes
- make index-model incremental by default with --dry-run and --force summaries
- delete changed/stale LanceDB rows before incremental adds to prevent duplicates

## Verification
- bunx tsc --noEmit
- bun run test
- bun test src/indexer/__tests__/vector-index-manifest.test.ts src/db/__tests__/fresh-install.test.ts
- bun test src/vector/__tests__/lancedb-stale-handle.test.ts

Note: bare `bun test` was also run and hit unrelated repo/environment failures (for example Docker daemon unavailable and existing frontend/router baseline mismatch); the scripted repo test gate passes.