### PR TITLE
fix: skip 308 redirect for cross-origin API requests (old Studio compat)

### DIFF
--- a/src/middleware/api-version.ts
+++ b/src/middleware/api-version.ts
@@ -32,6 +32,10 @@ export function apiRequestPath(request: Request): string {
   return publicPaths.get(request) ?? new URL(request.url).pathname;
 }
 
+function shouldRewriteInPlace(request: Request): boolean {
+  return Boolean(allowedCorsOrigin(request.headers.get('origin'), parseCorsOrigins()));
+}
+
 function versionedLocation(request: Request): string | null {
   const url = new URL(request.url);
   if (
@@ -39,6 +43,7 @@ function versionedLocation(request: Request): string | null {
     || isVersionedApiPath(url.pathname)
     || isInfrastructurePath(url.pathname)
   ) return null;
+  if (shouldRewriteInPlace(request)) return null;
   const suffix = url.pathname.slice(API_PREFIX.length);
   url.pathname = `${VERSIONED_PREFIX}${suffix}`;
   return url.toString();


### PR DESCRIPTION
## Summary
- Cross-origin requests from allowed CORS origins (like `studio.buildwithoracle.com`) skip the 308 redirect and route directly to the unversioned handler
- Non-browser requests (no Origin) still get the 308 redirect as before
- 5-line change in `src/middleware/api-version.ts`

## Test plan
- [x] `/api/stats` without origin → 308 (backward compat)
- [x] `/api/stats` with `Origin: https://studio.buildwithoracle.com` → 200 OK
- [x] `bunx tsc --noEmit` green

Closes #2526

🤖 Generated with [Claude Code](https://claude.com/claude-code)