### PR TITLE
fix: source feed and map3d from DB/FTS

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -75,6 +75,19 @@ export async function searchMemoryHealth(query: string, limit = 20): Promise<Sea
   };
 }
 
+export async function fetchDocumentFeed(limit = 50, offset = 0): Promise<SearchResponse> {
+  const qs = new URLSearchParams({ limit: String(limit), offset: String(offset), group: 'false' });
+  const data = await getJson<SearchResponse>(`/api/list?${qs}`);
+  return {
+    results: Array.isArray(data.results) ? data.results : [],
+    total: Number.isFinite(data.total) ? data.total : 0,
+    query: typeof data.query === 'string' ? data.query : '',
+    limit: data.limit,
+    offset: data.offset,
+    error: data.error,
+  };
+}
+
 export async function fetchMcpTools(): Promise<McpToolsResponse> {
   const data = await getJson<McpToolsResponse>('/api/mcp/tools');
   return {

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -62,6 +62,7 @@ export function AppShell({
     { to: '/canvas/plugins', label: 'Canvas Plugins', description: 'Canvas metadata from /api/plugins?kind=canvas' },
     { to: '/search', label: 'Search', description: 'Full-text menu search' },
     { to: '/export', label: 'Export App', description: 'Legacy v2 JSON/Markdown backups' },
+    { to: '/feed', label: 'Feed', description: 'DB-backed document feed from /api/list' },
     { to: '/vector', label: 'Vector Dashboard', description: 'Collection health and indexing', end: true },
     { to: '/vector/documents', label: 'Document Browser', description: 'Browse indexed vector documents' },
     { to: '/vector/first-run', label: 'First-run setup', description: 'Local backend and first index' },

--- a/frontend/src/pages/FeedPage.tsx
+++ b/frontend/src/pages/FeedPage.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useMemo, useState } from 'react';
+import { fetchDocumentFeed } from '../api';
+import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
+import { EmptyState } from '../components/EmptyState';
+import type { SearchResponse, SearchResult } from '../types';
+
+type PageState = 'loading' | 'ready' | 'error';
+type FeedLoader = (limit?: number, offset?: number) => Promise<SearchResponse>;
+
+const LIMIT = 50;
+
+export function feedStatus(state: PageState, total: number, count: number): string {
+  if (state === 'loading') return 'Loading DB-backed document feed…';
+  if (state === 'error') return 'Document feed failed.';
+  return total ? `Showing ${count} of ${total} DB/FTS documents.` : 'No DB/FTS documents found.';
+}
+
+function preview(content: string): string {
+  const compact = content.replace(/\s+/g, ' ').trim();
+  return compact.length > 180 ? `${compact.slice(0, 179).trimEnd()}…` : compact;
+}
+
+function typeCounts(items: SearchResult[]): string {
+  const counts = items.reduce<Record<string, number>>((acc, item) => {
+    const key = item.type || 'unknown';
+    acc[key] = (acc[key] ?? 0) + 1;
+    return acc;
+  }, {});
+  return Object.entries(counts).map(([type, count]) => `${type}: ${count}`).join(' · ') || 'No loaded rows';
+}
+
+function FeedRows({ items }: { items: SearchResult[] }) {
+  if (!items.length) return <EmptyState text="No documents returned from /api/list." />;
+  return (
+    <div className="grid gap-3" aria-label="DB-backed document feed">
+      {items.map((item) => (
+        <article key={item.id} className="rounded-2xl border border-border bg-surface-muted p-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <h2 className="text-base font-semibold text-text">{item.source_file || item.id}</h2>
+              <p className="mt-1 text-sm leading-6 text-text-muted">{preview(item.content)}</p>
+            </div>
+            <span className="rounded-full border border-accent-border px-2 py-1 text-xs font-semibold text-accent">
+              {item.type || 'unknown'}
+            </span>
+          </div>
+          <p className="mt-3 font-mono text-xs text-text-muted">{item.project || 'unscoped'} · {item.source || 'fts/db'}</p>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+export function FeedPage({ load = fetchDocumentFeed }: { load?: FeedLoader }) {
+  const [items, setItems] = useState<SearchResult[]>([]);
+  const [total, setTotal] = useState(0);
+  const [state, setState] = useState<PageState>('loading');
+  const [error, setError] = useState('');
+
+  async function refresh() {
+    setState('loading');
+    setError('');
+    try {
+      const data = await load(LIMIT, 0);
+      setItems(data.results);
+      setTotal(data.total);
+      setState('ready');
+    } catch (err) {
+      setItems([]);
+      setTotal(0);
+      setError(err instanceof Error ? err.message : String(err));
+      setState('error');
+    }
+  }
+
+  useEffect(() => { void refresh(); }, [load]);
+  const status = useMemo(() => feedStatus(state, total, items.length), [items.length, state, total]);
+
+  return (
+    <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="feed-title">
+      <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Feed</p>
+          <h1 id="feed-title" className="mt-2 text-3xl font-semibold text-text">Document feed</h1>
+          <p className="mt-2 text-sm text-text-muted">Reads /api/list from SQLite/FTS, not vector document collections.</p>
+        </div>
+        <button className="focus-ring rounded-xl border border-border px-4 py-2 text-sm text-text hover:border-accent-border" type="button" onClick={() => void refresh()}>
+          Refresh
+        </button>
+      </div>
+      <p className="mb-2 text-sm text-text-muted">{status}</p>
+      <p className="mb-5 text-xs text-text-muted">{typeCounts(items)}</p>
+      {state === 'loading' ? <LoadingPanel title="Loading feed…" detail="Fetching /api/list?group=false from the DB-backed API." /> : null}
+      {state === 'error' ? <ErrorMessage title="Could not load document feed." message={error} /> : null}
+      {state === 'ready' ? <FeedRows items={items} /> : null}
+    </section>
+  );
+}

--- a/frontend/src/routeMeta.ts
+++ b/frontend/src/routeMeta.ts
@@ -97,6 +97,7 @@ export function routeMeta(pathname: string, search = ''): RouteMeta {
   if (pathname === '/metrics') return base('Runtime metrics', 'Metrics', 'Runtime counters from /api/v1/metrics.', [{ label: 'Metrics' }]);
   if (pathname === '/search') return base('Search', 'Search', 'Search menu, plugin, and MCP tool surfaces.', [{ label: 'Search' }]);
   if (pathname === '/export') return base('Export app', 'Export', 'Connect to an old Oracle v2 backend and download JSON, CSV, or Markdown backups.', [{ label: 'Export app' }]);
+  if (pathname === '/feed') return base('Document feed', 'Feed', 'DB-backed document feed from /api/list, independent of vector collections.', [{ label: 'Feed' }]);
   if (pathname === '/learn') return base('Learn entries', 'Learn', 'Capture and edit Oracle learnings.', [{ label: 'Learn' }]);
   if (pathname === '/vector') return base('Vector dashboard', 'Vector', 'Collection health, search, and export status.', [{ label: 'Vector dashboard' }]);
   if (pathname === '/mcp') return base('MCP tools', 'MCP', 'Browse available MCP tool schemas and groups.', [{ label: 'MCP tools' }]);

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -5,6 +5,7 @@ import { McpPage } from './pages/McpPage';
 import { MetricsPage } from './pages/MetricsPage';
 import { McpToolDetailPage } from './pages/McpToolDetailPage';
 import { ExportApp } from './pages/ExportApp';
+import { FeedPage } from './pages/FeedPage';
 import { LearnPage } from './pages/LearnPage';
 import { MemoryPage } from './pages/MemoryPage';
 import { MenuPage } from './pages/MenuPage';
@@ -37,6 +38,7 @@ export const frontendRoutes = [
   '/metrics',
   '/search',
   '/export',
+  '/feed',
   '/learn',
   '/memory',
   '/vector',
@@ -108,6 +110,7 @@ export function DashboardRoutes({
       <Route path="/metrics" element={<MetricsPage metrics={metrics} loading={isRouteLoading(states.metrics)} />} />
       <Route path="/search" element={<SearchPage />} />
       <Route path="/export" element={<ExportApp />} />
+      <Route path="/feed" element={<FeedPage />} />
       <Route path="/learn" element={<LearnPage />} />
       <Route path="/memory" element={<MemoryPage />} />
       <Route path="/menu" element={menuPage} />

--- a/src/gateway/__tests__/vector-url.test.ts
+++ b/src/gateway/__tests__/vector-url.test.ts
@@ -9,7 +9,7 @@ import { compileRoutes, matchRoute } from '../matcher.ts';
 import { gatewayPlugin } from '../index.ts';
 
 describe('VECTOR_URL synthesized gateway config', () => {
-  it('covers the full vector route surface without local-vector fallback', () => {
+  it('covers vector routes while leaving DB-backed map3d local', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-gateway-vector-url-'));
     try {
       const cfg = loadGatewayConfig(dir, 'http://vector.local:47779/')!;
@@ -37,11 +37,7 @@ describe('VECTOR_URL synthesized gateway config', () => {
         fallback: 'empty',
         pattern: '/api/map',
       });
-      expect(matchRoute('/api/map3d', routes)).toEqual({
-        service: 'vector',
-        fallback: 'empty',
-        pattern: '/api/map3d',
-      });
+      expect(matchRoute('/api/map3d', routes)).toBeNull();
       expect(matchRoute('/api/vector/stats', routes)).toEqual({
         service: 'vector',
         fallback: 'error',
@@ -58,7 +54,8 @@ describe('VECTOR_URL synthesized gateway config', () => {
       const app = new Elysia()
         .use(gatewayPlugin(dir, 'http://127.0.0.1:9'))
         .get('/api/search', () => ({ source: 'local-fts5', results: [] }))
-        .get('/api/map', () => ({ source: 'local-vector-map' }));
+        .get('/api/map', () => ({ source: 'local-vector-map' }))
+        .get('/api/map3d', () => ({ source: 'local-db-fts-map3d', documents: [{ id: 'db-doc' }], total: 35164 }));
 
       const search = await app.handle(new Request('http://localhost/api/search?q=oracle'));
       expect(search.status).toBe(200);
@@ -74,16 +71,11 @@ describe('VECTOR_URL synthesized gateway config', () => {
 
       const map3d = await app.handle(new Request('http://localhost/api/map3d'));
       expect(map3d.status).toBe(200);
-      const map3dBody = await map3d.json();
-      expect(map3dBody.documents).toEqual([]);
-      expect(map3dBody.total).toBe(0);
-      expect(map3dBody.source).toBe('gateway-fallback');
-      expect(map3dBody.pca_info).toMatchObject({
-        variance_explained: [],
-        n_vectors: 0,
-        n_dimensions: 0,
+      expect(await map3d.json()).toEqual({
+        source: 'local-db-fts-map3d',
+        documents: [{ id: 'db-doc' }],
+        total: 35164,
       });
-      expect(typeof map3dBody.pca_info.computed_at).toBe('string');
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/src/gateway/config.ts
+++ b/src/gateway/config.ts
@@ -65,8 +65,9 @@ export function loadGatewayConfig(
   }
 
   // Backward compat: synthesize config from VECTOR_URL. Search can
-  // fall through to local FTS5 when the vector service is unreachable; pure
-  // vector routes must not fall back to local LanceDB inside the core process.
+  // fall through to local FTS5 when the vector service is unreachable. Map3D
+  // stays local because the memory globe must reflect the full DB/FTS corpus,
+  // not a partial vector collection.
   if (vectorUrl) {
     const vectorBase = vectorUrl.replace(/\/+$/, '');
     return mergeVectorServicesIntoGatewayConfig({
@@ -82,7 +83,6 @@ export function loadGatewayConfig(
         { match: '/api/similar', service: 'vector', fallback: 'error' },
         { match: '/api/compare', service: 'vector', fallback: 'error' },
         { match: '/api/map', service: 'vector', fallback: 'empty' },
-        { match: '/api/map3d', service: 'vector', fallback: 'empty' },
         { match: '/api/vector/**', service: 'vector', fallback: 'error' },
       ],
     }, vectorServices);

--- a/src/routes/search/index.ts
+++ b/src/routes/search/index.ts
@@ -1,8 +1,8 @@
 /**
  * Search Routes (Elysia) — composes /api/{search,reflect,list}.
  *
- * Vector-only endpoints (similar, map, map3d, compare) live in
- * src/routes/vector/ since #1071 phase 1.1.
+ * Vector-only endpoints (similar, map, compare) live in src/routes/vector/.
+ * Map3D is mounted there too but reads from DB/FTS for the memory globe.
  */
 
 import { Elysia } from 'elysia';

--- a/src/routes/vector/index.ts
+++ b/src/routes/vector/index.ts
@@ -7,7 +7,7 @@
  *   GET /api/similar         — nearest-neighbor by doc id
  *   GET /api/compare         — fan-out search across embedding models
  *   GET /api/map             — 2D layout of all docs
- *   GET /api/map3d           — 3D PCA projection from real embeddings
+ *   GET /api/map3d           — DB/FTS-backed 3D document globe
  *   GET /api/vector/stats    — per-engine collection counts
  *   GET /api/vector/health   — adapter liveness probe
  *   GET /api/vector/cost-estimate — estimate remote embedding cost

--- a/src/routes/vector/map3d.ts
+++ b/src/routes/vector/map3d.ts
@@ -1,31 +1,18 @@
 /**
- * GET /api/map3d — real PCA from LanceDB bge-m3 embeddings.
+ * GET /api/map3d — DB/FTS-backed 3D document globe.
  *
- * When VECTOR_URL is set, proxies to the remote vector server.
- * Falls back to local handleMap3d() when proxy is unavailable or unset.
+ * This endpoint intentionally stays local even when VECTOR_URL is set so the
+ * memory map reflects the full SQLite/FTS corpus, not a partial vector index.
  */
 
 import { Elysia } from 'elysia';
 import { handleMap3d } from '../../server/vector-handlers.ts';
-import { createVectorProxy } from '../../server/vector-proxy.ts';
-import { resolveVectorUrl } from '../../config.ts';
 import { Map3dQuery } from './model.ts';
-
-const currentProxy = () => createVectorProxy(resolveVectorUrl());
 
 export const map3dEndpoint = new Elysia().get(
   '/map3d',
   async ({ query, set }) => {
     const model = query.model || undefined;
-
-    // VECTOR_URL set -> proxy first, fall back to local on failure.
-    const proxy = currentProxy();
-    if (proxy) {
-      const remote = await proxy.map3d(model);
-      if (remote) return remote;
-      set.status = 503;
-      return { error: 'Vector proxy unavailable', documents: [], total: 0 };
-    }
 
     try {
       return await handleMap3d(model);
@@ -39,7 +26,7 @@ export const map3dEndpoint = new Elysia().get(
     detail: {
       tags: ['vector'],
       menu: { group: 'tools', order: 30 },
-      summary: '3D PCA projection of embeddings',
+      summary: '3D DB/FTS-backed document globe',
     },
   },
 );

--- a/src/server/__tests__/vector-routes-proxy-boundary.test.ts
+++ b/src/server/__tests__/vector-routes-proxy-boundary.test.ts
@@ -57,13 +57,13 @@ describe('VECTOR_URL route boundary', () => {
     expect(calls).toContain('GET /api/map');
   });
 
-  test('/api/map3d proxies to the remote vector sidecar', async () => {
+  test('/api/map3d stays on the local DB/FTS globe source', async () => {
     const res = await app.handle(new Request('http://localhost/api/map3d?model=bge-m3'));
     const body = await res.json() as { total: number };
 
     expect(res.status).toBe(200);
-    expect(body.total).toBe(3);
-    expect(calls).toContain('GET /api/map3d?model=bge-m3');
+    expect(body.total).toBe(0);
+    expect(calls).not.toContain('GET /api/map3d?model=bge-m3');
   });
 
   test('/api/vector/index/* proxies to the remote vector sidecar', async () => {

--- a/src/server/vector-handlers/map3d.ts
+++ b/src/server/vector-handlers/map3d.ts
@@ -1,134 +1,106 @@
-import { and, eq, inArray } from 'drizzle-orm';
-import { db, oracleDocuments } from '../../db/index.ts';
+import { sqlite } from '../../db/index.ts';
 import { currentTenantId } from '../../middleware/tenant.ts';
-import { ensureVectorStoreConnected, getVectorStoreByModel } from '../../vector/factory.ts';
-import { projectPca } from './map3d-pca.ts';
 
 type Map3dDoc = {
   id: string; type: string; title: string; source_file: string; concepts: string[];
   project: string | null; x: number; y: number; z: number; created_at: string | null;
 };
-type FileGroup = {
-  ids: string[]; vectors: number[][]; type: string; sourceFile: string;
-  concepts: string[]; project: string | null; createdAt: number | null;
-};
-
 type Map3dResult = {
   documents: Map3dDoc[];
   total: number;
   pca_info: { variance_explained: number[]; n_vectors: number; n_dimensions: number; computed_at: string };
 };
+type DocRow = {
+  id: string; type: string; source_file: string; concepts: string | null;
+  project: string | null; created_at: number | null;
+};
 
 const map3dCaches = new Map<string, { data: Map3dResult; timestamp: number }>();
 const MAP3D_CACHE_TTL = 30 * 60 * 1000;
-const emptyResult = (): Map3dResult => ({
-  documents: [],
-  total: 0,
-  pca_info: { variance_explained: [], n_vectors: 0, n_dimensions: 0, computed_at: new Date().toISOString() },
-});
+const MAP3D_DOC_LIMIT = 50_000;
+
+function emptyResult(): Map3dResult {
+  return {
+    documents: [],
+    total: 0,
+    pca_info: { variance_explained: [], n_vectors: 0, n_dimensions: 3, computed_at: new Date().toISOString() },
+  };
+}
 
 function concepts(value: string | null): string[] {
   try { return value ? JSON.parse(value) : []; } catch { return []; }
-}
-
-function averageVectors(files: FileGroup[], d: number): number[][] {
-  return files.map((file) => {
-    if (file.vectors.length === 1) return file.vectors[0];
-    const avg = new Array(d).fill(0);
-    for (const vector of file.vectors) for (let j = 0; j < d; j++) avg[j] += vector[j];
-    for (let j = 0; j < d; j++) avg[j] /= file.vectors.length;
-    return avg;
-  });
 }
 
 function title(sourceFile: string): string {
   return (sourceFile.split('/').pop() || sourceFile).replace(/\.[^.]+$/, '').replace(/[-_]/g, ' ');
 }
 
-export async function handleMap3d(model?: string): Promise<Map3dResult> {
-  const modelKey = model || 'bge-m3';
+function hash(str: string): number {
+  let value = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    value ^= str.charCodeAt(i);
+    value = Math.imul(value, 0x01000193);
+  }
+  return ((value >>> 0) % 10000) / 10000;
+}
+
+function point(index: number, total: number, row: DocRow) {
+  if (total <= 1) return { x: 0, y: 0, z: 0 };
+  const goldenAngle = Math.PI * (3 - Math.sqrt(5));
+  const y = 1 - (index / (total - 1)) * 2;
+  const radius = Math.sqrt(Math.max(0, 1 - y * y));
+  const angle = index * goldenAngle + hash(`${row.project ?? ''}:${row.source_file}`) * Math.PI * 2;
+  return { x: radius * Math.cos(angle), y, z: radius * Math.sin(angle) };
+}
+
+function dbRows(tenantId?: string | null) {
+  const where = tenantId ? 'WHERE d.tenant_id = ?' : '';
+  const params = tenantId ? [tenantId] : [];
+  const total = (sqlite.prepare(`
+    SELECT COUNT(*) as total
+    FROM oracle_documents d
+    JOIN oracle_fts f ON f.id = d.id
+    ${where}
+  `).get(...params) as { total: number } | undefined)?.total ?? 0;
+  const rows = sqlite.prepare(`
+    SELECT d.id, d.type, d.source_file, d.concepts, d.project, d.created_at
+    FROM oracle_documents d
+    JOIN oracle_fts f ON f.id = d.id
+    ${where}
+    ORDER BY d.indexed_at DESC, d.id ASC
+    LIMIT ?
+  `).all(...params, MAP3D_DOC_LIMIT) as DocRow[];
+  return { rows, total };
+}
+
+export async function handleMap3d(_model?: string): Promise<Map3dResult> {
   const tenantId = currentTenantId();
-  const cacheKey = `${tenantId ?? '*'}:${modelKey}`;
+  const cacheKey = `${tenantId ?? '*'}:fts-db`;
   const cached = map3dCaches.get(cacheKey);
   if (cached && (Date.now() - cached.timestamp) < MAP3D_CACHE_TTL) return cached.data;
 
   try {
-    const store = getVectorStoreByModel(modelKey);
-    await ensureVectorStoreConnected(modelKey);
-    if (!store.getAllEmbeddings) throw new Error('LanceDB adapter does not support getAllEmbeddings');
-    const { ids, embeddings, metadatas } = await store.getAllEmbeddings(25000);
-    if (embeddings.length === 0) return emptyResult();
-
-    const docLookup = new Map<string, { type: string; sourceFile: string; concepts: string[]; project: string | null; createdAt: number | null }>();
-    for (let i = 0; i < ids.length; i += 500) {
-      const batch = ids.slice(i, i + 500);
-      const idFilter = inArray(oracleDocuments.id, batch);
-      const rows = db.select({
-        id: oracleDocuments.id,
-        type: oracleDocuments.type,
-        sourceFile: oracleDocuments.sourceFile,
-        concepts: oracleDocuments.concepts,
-        project: oracleDocuments.project,
-        createdAt: oracleDocuments.createdAt,
-      })
-        .from(oracleDocuments)
-        .where(tenantId ? and(idFilter, eq(oracleDocuments.tenantId, tenantId)) : idFilter)
-        .all();
-      for (const row of rows) {
-        docLookup.set(row.id, {
-          type: row.type,
-          sourceFile: row.sourceFile,
-          concepts: concepts(row.concepts),
-          project: row.project || null,
-          createdAt: row.createdAt,
-        });
-      }
-    }
-
-    const fileGroups = new Map<string, FileGroup>();
-    for (let i = 0; i < embeddings.length; i++) {
-      const meta = docLookup.get(ids[i]);
-      if (tenantId && !meta) continue;
-      const vecMeta = metadatas[i];
-      const sourceFile = meta?.sourceFile || vecMeta?.source_file || ids[i];
-      const existing = fileGroups.get(sourceFile);
-      if (!existing) {
-        fileGroups.set(sourceFile, {
-          ids: [ids[i]],
-          vectors: [embeddings[i]],
-          type: meta?.type || vecMeta?.type || 'unknown',
-          sourceFile,
-          concepts: meta?.concepts || [],
-          project: meta?.project || null,
-          createdAt: meta?.createdAt || null,
-        });
-        continue;
-      }
-      existing.ids.push(ids[i]);
-      existing.vectors.push(embeddings[i]);
-      for (const concept of meta?.concepts || []) if (!existing.concepts.includes(concept)) existing.concepts.push(concept);
-    }
-
-    const files = Array.from(fileGroups.values());
-    if (files.length === 0) return emptyResult();
-    const avgVectors = averageVectors(files, embeddings[0].length);
-    const { projected, varianceExplained } = projectPca(avgVectors);
-    const documents = files.map((file, i) => ({
-      id: file.ids[0],
-      type: file.type,
-      title: title(file.sourceFile),
-      source_file: file.sourceFile,
-      concepts: file.concepts.slice(0, 10),
-      project: file.project,
-      x: +projected[i].x.toFixed(6),
-      y: +projected[i].y.toFixed(6),
-      z: +projected[i].z.toFixed(6),
-      created_at: file.createdAt ? new Date(file.createdAt).toISOString() : null,
-    }));
+    const { rows, total } = dbRows(tenantId);
+    if (!rows.length) return emptyResult();
+    const documents = rows.map((row, i) => {
+      const p = point(i, rows.length, row);
+      return {
+        id: row.id,
+        type: row.type,
+        title: title(row.source_file),
+        source_file: row.source_file,
+        concepts: concepts(row.concepts).slice(0, 10),
+        project: row.project,
+        x: +p.x.toFixed(6),
+        y: +p.y.toFixed(6),
+        z: +p.z.toFixed(6),
+        created_at: row.created_at ? new Date(row.created_at).toISOString() : null,
+      };
+    });
     const result = {
       documents,
-      total: documents.length,
-      pca_info: { variance_explained: varianceExplained, n_vectors: embeddings.length, n_dimensions: embeddings[0].length, computed_at: new Date().toISOString() },
+      total,
+      pca_info: { variance_explained: [], n_vectors: total, n_dimensions: 3, computed_at: new Date().toISOString() },
     };
     map3dCaches.set(cacheKey, { data: result, timestamp: Date.now() });
     return result;

--- a/tests/frontend/api/feed-documents-query-string.test.ts
+++ b/tests/frontend/api/feed-documents-query-string.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'bun:test';
+import { fetchDocumentFeed } from '../../../frontend/src/api';
+import { installFetch, jsonResponse } from './_fetch';
+
+describe('fetchDocumentFeed request URL', () => {
+  test('uses the DB-backed list endpoint instead of vector documents', async () => {
+    const fetchMock = installFetch(() => jsonResponse({ results: [{ id: 'd1', content: 'doc' }], total: 35164 }));
+    try {
+      await expect(fetchDocumentFeed(25, 50)).resolves.toMatchObject({ total: 35164 });
+      expect(fetchMock.calls[0]?.input).toBe('/api/list?limit=25&offset=50&group=false');
+    } finally {
+      fetchMock.restore();
+    }
+  });
+});

--- a/tests/frontend/components/app-shell-vector-nav.test.tsx
+++ b/tests/frontend/components/app-shell-vector-nav.test.tsx
@@ -15,6 +15,7 @@ describe('AppShell Vector navigation', () => {
         </MemoryRouter>,
       );
       expect(html).toContain('aria-label="Vector Dashboard: Collection health and indexing"');
+      expect(html).toContain('aria-label="Feed: DB-backed document feed from /api/list"');
       expect(html).toContain('aria-label="Document Browser: Browse indexed vector documents"');
       expect(html).toContain('aria-label="First-run setup: Local backend and first index"');
       expect(html).toContain('aria-label="Index Manager: Backfill vectors and watch jobs"');

--- a/tests/frontend/pages/feed-page.test.tsx
+++ b/tests/frontend/pages/feed-page.test.tsx
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test';
+import { FeedPage, feedStatus } from '../../../frontend/src/pages/FeedPage';
+import { htmlFor } from '../_render';
+
+describe('FeedPage', () => {
+  test('renders DB-backed feed copy and controls', () => {
+    const html = htmlFor(<FeedPage load={async () => ({ results: [], total: 0, query: '' })} />);
+    expect(html).toContain('Document feed');
+    expect(html).toContain('Reads /api/list');
+    expect(html).toContain('Refresh');
+  });
+
+  test('status reflects DB/FTS totals', () => {
+    expect(feedStatus('ready', 35164, 50)).toBe('Showing 50 of 35164 DB/FTS documents.');
+  });
+});

--- a/tests/frontend/router.test.ts
+++ b/tests/frontend/router.test.ts
@@ -41,6 +41,7 @@ describe('frontend router', () => {
       '/metrics',
       '/search',
       '/export',
+      '/feed',
       '/learn',
       '/memory',
       '/vector',
@@ -54,6 +55,7 @@ describe('frontend router', () => {
       '/mcp',
       '/storage',
       '/settings',
+      '/simple',
     ]);
   });
 
@@ -70,6 +72,7 @@ describe('frontend router', () => {
     expect(htmlAt('/metrics')).toContain('Memory usage');
     expect(htmlAt('/search')).toContain('Full-text menu search');
     expect(htmlAt('/export')).toContain('Export app');
+    expect(htmlAt('/feed')).toContain('Document feed');
     expect(htmlAt('/learn')).toContain('Learn entries');
     expect(htmlAt('/memory')).toContain('Memory dashboard');
     expect(htmlAt('/memory')).toContain('Memory health');

--- a/tests/http/vector/map3d-db-source.test.ts
+++ b/tests/http/vector/map3d-db-source.test.ts
@@ -1,0 +1,77 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { Elysia } from 'elysia';
+
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const root = mkdtempSync(path.join(tmpdir(), 'map3d-db-source-'));
+const dbPath = path.join(root, 'oracle.db');
+const tenantA = `map3d-a-${Date.now()}`;
+const tenantB = `map3d-b-${Date.now()}`;
+
+let dbMod: typeof import('../../../src/db/index.ts');
+let app: Elysia;
+let tenantFetch: typeof import('../../../src/middleware/tenant.ts').createTenantFetch;
+let tenantHeader: string;
+
+beforeAll(async () => {
+  process.env.ORACLE_DATA_DIR = root;
+  process.env.ORACLE_DB_PATH = dbPath;
+  dbMod = await import('../../../src/db/index.ts');
+  dbMod.resetDefaultDatabaseForTests(dbPath);
+  const tenant = await import('../../../src/middleware/tenant.ts');
+  tenantFetch = tenant.createTenantFetch;
+  tenantHeader = tenant.TENANT_HEADER;
+  const { map3dEndpoint } = await import('../../../src/routes/vector/map3d.ts');
+  app = new Elysia({ prefix: '/api' }).use(map3dEndpoint);
+  seedDoc('a-1', tenantA, 30);
+  seedDoc('a-2', tenantA, 20);
+  seedDoc('b-1', tenantB, 10);
+});
+
+afterAll(() => {
+  dbMod.closeDb();
+  if (savedDataDir === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = savedDataDir;
+  if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = savedDbPath;
+  rmSync(root, { recursive: true, force: true });
+});
+
+function seedDoc(id: string, tenantId: string, indexedAt: number) {
+  dbMod.db.insert(dbMod.oracleDocuments).values({
+    id,
+    tenantId,
+    type: 'learning',
+    sourceFile: `ψ/${tenantId}/${id}.md`,
+    concepts: JSON.stringify(['map3d-db']),
+    createdAt: indexedAt,
+    updatedAt: indexedAt,
+    indexedAt,
+    project: tenantId,
+  }).run();
+  dbMod.sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
+    .run(id, `content ${id}`, 'map3d-db');
+}
+
+function request(tenantId: string) {
+  return tenantFetch((req) => app.handle(req))(new Request('http://local/api/map3d?model=bge-m3', {
+    headers: { [tenantHeader]: tenantId },
+  }));
+}
+
+describe('/api/map3d DB-backed source', () => {
+  test('uses tenant-scoped DB/FTS documents instead of vector collection docs', async () => {
+    const res = await request(tenantA);
+    const body = await res.json() as { documents: Array<{ id: string; x: number; concepts: string[] }>; total: number; pca_info: { n_vectors: number } };
+
+    expect(res.status).toBe(200);
+    expect(body.total).toBe(2);
+    expect(body.pca_info.n_vectors).toBe(2);
+    expect(body.documents.map((item) => item.id)).toEqual(['a-1', 'a-2']);
+    expect(body.documents.every((item) => Number.isFinite(item.x))).toBe(true);
+    expect(body.documents[0].concepts).toEqual(['map3d-db']);
+  });
+});


### PR DESCRIPTION
## Summary
- route /feed to a DB/FTS-backed document feed using /api/list?group=false instead of vector documents
- keep /api/map3d local and source its globe data from oracle_documents + oracle_fts, even when VECTOR_URL is set
- update gateway/proxy-boundary coverage so map3d is not synthesized as a vector sidecar route

## Validation
- bunx tsc --noEmit
- bun run test
- bun test --isolate tests/frontend/api/feed-documents-query-string.test.ts tests/frontend/pages/feed-page.test.tsx tests/frontend/router.test.ts tests/frontend/components/app-shell-vector-nav.test.tsx src/gateway/__tests__/vector-url.test.ts src/server/__tests__/vector-routes-proxy-boundary.test.ts tests/http/vector/map3d-db-source.test.ts
- wc -l on changed files (all <=250)

Note: bare bun test was also attempted and fails pre-existing/unisolated all-suite cases outside this change; package test gate (bun run test) is green.