### PR TITLE
fix(vector): resolve collection by name, not just model key

### DIFF
--- a/src/routes/vector/documents.ts
+++ b/src/routes/vector/documents.ts
@@ -36,7 +36,13 @@ function parseOffset(value: string | undefined, fallback: number): number {
 
 function resolveCollection(collection: string | undefined, getModels?: () => Record<string, unknown>): string | null {
   const name = (collection || DEFAULT_COLLECTION).trim() || DEFAULT_COLLECTION;
-  return !getModels || name in getModels() ? name : null;
+  if (!getModels) return name;
+  const models = getModels();
+  if (name in models) return name;
+  const byCollectionName = Object.values(models).find(
+    (m) => typeof m === 'object' && m && 'collection' in m && (m as { collection: string }).collection === name,
+  );
+  return byCollectionName ? name : null;
 }
 
 function normalizeMetadata(metadata: unknown): Record<string, unknown> {

--- a/src/routes/vector/search.ts
+++ b/src/routes/vector/search.ts
@@ -172,7 +172,12 @@ function sortHits(hits: SearchHit[], field: SortField, order: SortOrder): Search
 
 function resolveCollection(collection: string | undefined, getModels: () => Record<string, unknown>): string | null {
   const name = (collection || DEFAULT_COLLECTION).trim();
-  return name in getModels() ? name : null;
+  const models = getModels();
+  if (name in models) return name;
+  const byCollectionName = Object.values(models).find(
+    (m) => typeof m === 'object' && m && 'collection' in m && (m as { collection: string }).collection === name,
+  );
+  return byCollectionName ? name : null;
 }
 
 export function createVectorSearchEndpoint(deps: VectorSearchDeps = {}) {


### PR DESCRIPTION
## Summary
- `/api/v1/vector/documents?collection=oracle_knowledge_bge_m3` was 404ing because `resolveCollection` only checked model keys (`bge-m3`) not collection names (`oracle_knowledge_bge_m3`)
- Same bug in `/api/v1/vector/search`
- Now falls back to matching the `collection` field in the model config

## Test plan
- [x] `curl /api/v1/vector/documents?collection=oracle_knowledge_bge_m3` → 200, 164 docs
- [x] `bunx tsc --noEmit` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)