### PR TITLE
fix(feed): allow hosted feed origin

### DIFF
--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -15,6 +15,7 @@ const DEFAULT_ORIGINS = [
   'https://god.buildwithoracle.com',
   'https://arra-oracle-studio.laris.workers.dev',
   'https://studio.buildwithoracle.com',
+  'https://feed.buildwithoracle.com',
 ] as const;
 const ALLOWED_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'] as const;
 const ALLOWED_HEADERS = [

--- a/tests/http/compat/old-studio.test.ts
+++ b/tests/http/compat/old-studio.test.ts
@@ -16,6 +16,7 @@ delete process.env.ARRA_API_TOKEN;
 
 const { createApp } = await import('../../../src/server.ts');
 const { closeDb } = await import('../../../src/db/index.ts');
+const { createApiVersionedFetch } = await import('../../../src/middleware/api-version.ts');
 
 function runtime(): UnifiedRuntime {
   return {
@@ -26,6 +27,7 @@ function runtime(): UnifiedRuntime {
 }
 
 const app = createApp({ unifiedPlugins: runtime(), dataDir: scratch, vectorUrl: '' });
+const versionedFetch = createApiVersionedFetch((request) => app.handle(request));
 
 async function withTimeout<T>(work: Promise<T>, label: string): Promise<T> {
   let timer: Timer | undefined;
@@ -41,6 +43,14 @@ async function json(path: string, init: RequestInit = {}) {
   headers.set('accept', 'application/json');
   if (init.body && !headers.has('content-type')) headers.set('content-type', 'application/json');
   const res = await withTimeout(app.handle(new Request(`http://studio.test${path}`, { ...init, headers })), path);
+  const body = await withTimeout(res.json(), `${path} json`);
+  return { res, body };
+}
+
+async function hostedJson(path: string, origin: string) {
+  const res = await withTimeout(versionedFetch(new Request(`http://localhost:47778${path}`, {
+    headers: { accept: 'application/json', origin },
+  })), path);
   const body = await withTimeout(res.json(), `${path} json`);
   return { res, body };
 }
@@ -73,6 +83,22 @@ describe('old Studio backend compatibility endpoints', () => {
     const { body } = await json('/api/sessions') as { body: { sessions: unknown[]; total: number } };
     expect(Array.isArray(body.sessions)).toBe(true);
     expect(body.total).toBe(body.sessions.length);
+  });
+
+  test('hosted Feed page list request returns top-level document feed JSON', async () => {
+    for (const origin of ['https://studio.buildwithoracle.com', 'https://feed.buildwithoracle.com']) {
+      const { res, body } = await hostedJson('/api/list?limit=50&offset=0&group=false', origin) as {
+        res: Response;
+        body: { success?: boolean; results?: unknown[]; total?: number };
+      };
+      expect(res.status).toBe(200);
+      expect(res.headers.get('location')).toBeNull();
+      expect(res.headers.get('x-api-version')).toBe('v1');
+      expect(res.headers.get('access-control-allow-origin')).toBe(origin);
+      expect(body.success).toBe(true);
+      expect(Array.isArray(body.results)).toBe(true);
+      expect(typeof body.total).toBe('number');
+    }
   });
 });
 

--- a/tests/http/cors/origins.test.ts
+++ b/tests/http/cors/origins.test.ts
@@ -33,15 +33,13 @@ describe('CORS middleware origins', () => {
     expect(allowed.headers.get('Access-Control-Allow-Credentials')).toBe('true');
     expect(denied.headers.get('Access-Control-Allow-Origin')).toBeNull();
   });
-
-
-
-  test('allows hosted Studio origins by default for localhost backends', async () => {
+  test('allows hosted Studio and Feed origins by default for localhost backends', async () => {
     delete process.env.ARRA_CORS_ORIGINS;
 
     for (const origin of [
       'https://arra-oracle-studio.laris.workers.dev',
       'https://studio.buildwithoracle.com',
+      'https://feed.buildwithoracle.com',
     ]) {
       const res = await request('/api/ping', { headers: { origin } });
 


### PR DESCRIPTION
## Summary
- allow https://feed.buildwithoracle.com as a default CORS origin for local Oracle backends
- lock hosted Feed page /api/list?group=false requests to return top-level JSON without a legacy API redirect
- keep existing Studio origin compatibility covered

## Verification
- bun test tests/http/cors/origins.test.ts tests/http/compat/old-studio.test.ts tests/frontend/pages/feed-page.test.tsx tests/frontend/api/feed-documents-query-string.test.ts
- bun test tests/http/feed/ tests/http/search/tenant-routes.test.ts
- bunx tsc --noEmit
- wc -l src/middleware/cors.ts tests/http/cors/origins.test.ts tests/http/compat/old-studio.test.ts