### PR TITLE
bump: v26.7.3-alpha.2147

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-v3",
-  "version": "26.6.17-alpha.2232",
+  "version": "26.7.3-alpha.2147",
   "description": "Arra Oracle - MCP Memory Layer with semantic search, philosophy, and knowledge management",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
## Summary
- CalVer bump to v26.7.3-alpha.2147
- Includes: reflect crash fix, old Studio compat, vector collection resolve, 308 redirect skip, Feed fix, endpoint audit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)