### PR TITLE
style(frontend): apply glassmorphism to pages

### DIFF
--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -31,7 +31,7 @@ export function activitySummary(state: PageState, total: number, shown: number):
 
 function TraceCard({ trace }: { trace: TraceSummary }) {
   return (
-    <article className="min-w-0 rounded-3xl border border-border bg-surface p-5" aria-label={`Trace ${trace.traceId}`}>
+    <article className="min-w-0 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5" aria-label={`Trace ${trace.traceId}`}>
       <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
           <p className="break-all font-mono text-xs font-semibold uppercase tracking-[0.18em] text-accent">{trace.traceId}</p>
@@ -89,7 +89,7 @@ export function ActivityPage({ load = fetchTraces }: { load?: TraceLoader }) {
 
   return (
     <section className="grid w-full min-w-0 gap-5" aria-labelledby="activity-page-title">
-      <header className="rounded-3xl border border-border bg-surface p-5 sm:p-6">
+      <header className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6">
         <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
           <div className="min-w-0">
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Activity / Traces</p>

--- a/frontend/src/pages/CanvasAliasPage.tsx
+++ b/frontend/src/pages/CanvasAliasPage.tsx
@@ -19,7 +19,7 @@ export function CanvasAliasPage() {
 
   return (
     <section className="grid w-full min-w-0 gap-5" aria-labelledby="canvas-alias-title">
-      <header className="rounded-3xl border border-border bg-surface p-5 sm:p-6">
+      <header className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Canvas app</p>
         <h1 id="canvas-alias-title" className="mt-2 text-3xl font-semibold text-text">Studio canvas alias</h1>
         <p className="mt-2 text-sm text-text-muted">/canvas remains available while the isolated canvas app runs on canvas.buildwithoracle.com.</p>
@@ -28,7 +28,7 @@ export function CanvasAliasPage() {
         </a>
       </header>
       <iframe
-        className="block min-h-[34rem] w-full min-w-0 rounded-3xl border border-border bg-field"
+        className="block min-h-[34rem] w-full min-w-0 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl"
         src={target}
         title="canvas.buildwithoracle.com preview"
       />

--- a/frontend/src/pages/CanvasPluginsPage.tsx
+++ b/frontend/src/pages/CanvasPluginsPage.tsx
@@ -40,7 +40,7 @@ function statusClass(plugin: CanvasPluginEntry): string {
 function PluginCard({ plugin, host }: { plugin: CanvasPluginEntry; host?: string }) {
   const target = pluginHref(plugin, host);
   return (
-    <article className="min-w-0 rounded-3xl border border-border bg-surface p-5" aria-label={`${plugin.label} canvas plugin`}>
+    <article className="min-w-0 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5" aria-label={`${plugin.label} canvas plugin`}>
       <div className="mb-4 flex min-w-0 items-start justify-between gap-3">
         <div className="min-w-0">
           <p className="break-all text-xs font-semibold uppercase tracking-[0.2em] text-text-muted">{plugin.id}</p>
@@ -96,7 +96,7 @@ export function CanvasPluginsPage({ plugins: initialPlugins = [], loading = true
 
   return (
     <section className="grid w-full min-w-0 gap-5" aria-labelledby="canvas-plugins-title">
-      <header className="rounded-3xl border border-border bg-surface p-5 sm:p-6">
+      <header className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Canvas plugins</p>
         <h1 id="canvas-plugins-title" className="mt-2 text-3xl font-semibold text-text">Canvas plugin registry</h1>
         <p className="mt-2 text-sm text-text-muted">Filter the standalone registry by runtime while keeping canvas.buildwithoracle.com targets visible.</p>
@@ -122,7 +122,7 @@ export function CanvasPluginsPage({ plugins: initialPlugins = [], loading = true
       {state === 'error' ? <ErrorMessage title="Could not load canvas plugins." message={error} /> : null}
       {state !== 'error' && error ? <ErrorMessage title="Canvas plugin warning" message={error} /> : null}
       {state !== 'error' && plugins.length ? <div className="grid min-w-0 gap-4 sm:grid-cols-[repeat(2,minmax(0,1fr))] xl:grid-cols-[repeat(3,minmax(0,1fr))]">{plugins.map((plugin) => <PluginCard key={plugin.id} plugin={plugin} host={host} />)}</div> : null}
-      {state === 'ready' && !plugins.length ? <p className="rounded-2xl border border-border bg-surface p-5 text-sm text-text-muted">No canvas plugins match this filter.</p> : null}
+      {state === 'ready' && !plugins.length ? <p className="rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-5 text-sm text-text-muted">No canvas plugins match this filter.</p> : null}
     </section>
   );
 }

--- a/frontend/src/pages/ExportApp.tsx
+++ b/frontend/src/pages/ExportApp.tsx
@@ -179,13 +179,13 @@ export function ExportApp({ initialBackendUrl = DEFAULT_BACKEND_URL, fetcher = g
 
   return (
     <div className="grid min-w-0 gap-5">
-      <section className="min-w-0 rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="export-app-title">
+      <section className="min-w-0 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="export-app-title">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Legacy Oracle v2</p>
         <h1 id="export-app-title" className="mt-2 text-3xl font-semibold text-text">Export app</h1>
         <p className="mt-2 text-sm text-text-muted">Connect to an old Oracle v2 backend, list collections, and prepare JSON or Markdown backups before migration.</p>
       </section>
 
-      <section className="min-w-0 rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="backend-title">
+      <section className="min-w-0 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="backend-title">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="min-w-0">
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Backend URL</p>
@@ -210,7 +210,7 @@ export function ExportApp({ initialBackendUrl = DEFAULT_BACKEND_URL, fetcher = g
       {exportState === 'error' ? <ErrorMessage title="Could not start export." message={error} /> : null}
 
       <section className="grid min-w-0 gap-4 lg:grid-cols-2">
-        <div className="min-w-0 rounded-3xl border border-border bg-surface-muted p-5 sm:p-6" aria-labelledby="collection-title">
+        <div className="min-w-0 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="collection-title">
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Collections</p>
           <h2 id="collection-title" className="mt-2 text-2xl font-semibold text-text">Choose data</h2>
           <label className="mt-5 grid min-w-0 gap-2 text-sm font-medium text-text-muted">
@@ -220,19 +220,19 @@ export function ExportApp({ initialBackendUrl = DEFAULT_BACKEND_URL, fetcher = g
             </select>
           </label>
           <ul className="mt-4 grid max-h-72 gap-2 overflow-auto" aria-label="Legacy export collections">
-            {collections.map((item) => <li key={item.id} className="break-words rounded-xl border border-border bg-surface px-4 py-3 text-sm text-text-muted">{collectionLabel(item)}</li>)}
+            {collections.map((item) => <li key={item.id} className="break-words rounded-xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md px-4 py-3 text-sm text-text-muted">{collectionLabel(item)}</li>)}
           </ul>
           {loadState === 'ready' && !collections.length ? (
             <p className="mt-4 rounded-xl border border-dashed border-border p-4 text-sm text-text-muted">No collections are available from this backend. Check the URL, then reload collections.</p>
           ) : null}
         </div>
 
-        <div className="min-w-0 rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="format-title">
+        <div className="min-w-0 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="format-title">
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Export</p>
           <h2 id="format-title" className="mt-2 text-2xl font-semibold text-text">Format and download</h2>
           <div className="mt-5 grid gap-3" role="radiogroup" aria-label="Export format">
             {exportAppFormats.map((item) => (
-              <label key={item.value} className="flex items-start gap-3 rounded-2xl border border-border bg-surface-muted px-4 py-3 text-sm text-text-muted">
+              <label key={item.value} className="flex items-start gap-3 rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md px-4 py-3 text-sm text-text-muted">
                 <input className="mt-1 h-4 w-4 accent-teal-300" checked={format === item.value} name="legacy-export-format" type="radio" value={item.value} onChange={() => { setFormat(item.value); setDownload(null); }} />
                 <span><span className="block font-semibold text-text">{item.label}</span><span>{item.detail}</span></span>
               </label>

--- a/frontend/src/pages/ExportPage.tsx
+++ b/frontend/src/pages/ExportPage.tsx
@@ -154,7 +154,7 @@ export function ExportPage() {
 
   return (
     <div className="grid gap-5">
-      <section className="rounded-3xl border border-border bg-surface p-5 shadow-sm dark:border-border dark:bg-surface sm:p-6" aria-labelledby="export-page-title">
+      <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="export-page-title">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent dark:text-accent">Export app</p>
         <h1 id="export-page-title" className="mt-2 text-3xl font-semibold text-on-accent dark:text-text">Export collections</h1>
         <p className="mt-2 text-sm text-text-muted dark:text-text-muted">Choose a database collection, export format, graph option, then download the generated snapshot.</p>
@@ -176,7 +176,7 @@ export function ExportPage() {
       {state === 'error' ? <ErrorMessage title="Could not load export collections." message={error} /> : null}
 
       <div className="grid gap-4 lg:grid-cols-4">
-        <section className="rounded-3xl border border-border bg-surface p-5 shadow-sm dark:border-border dark:bg-surface sm:p-6 lg:col-span-2" aria-labelledby="export-collection-title">
+        <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6 lg:col-span-2" aria-labelledby="export-collection-title">
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent dark:text-accent">Collection</p>
           <h2 id="export-collection-title" className="mt-2 text-2xl font-semibold text-on-accent dark:text-text">Collection picker</h2>
           <label className="mt-5 grid gap-2 text-sm font-medium text-text dark:text-text-muted">
@@ -195,12 +195,12 @@ export function ExportPage() {
           </label>
         </section>
 
-        <section className="rounded-3xl border border-border bg-field p-5 shadow-sm dark:border-border dark:bg-surface-muted sm:p-6 lg:col-span-2" aria-labelledby="export-format-title">
+        <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6 lg:col-span-2" aria-labelledby="export-format-title">
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent dark:text-accent">Format</p>
           <h2 id="export-format-title" className="mt-2 text-2xl font-semibold text-on-accent dark:text-text">Format picker</h2>
           <div className="mt-5 grid gap-2 sm:grid-cols-2" role="radiogroup" aria-label="Export format">
             {formats.map((item) => (
-              <label key={item} className="flex min-h-12 items-center gap-3 rounded-2xl border border-border bg-surface-muted px-4 py-3 text-sm text-text dark:border-border dark:bg-surface dark:text-text">
+              <label key={item} className="flex min-h-12 items-center gap-3 rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md px-4 py-3 text-sm text-text dark:text-text">
                 <input className="h-4 w-4 accent-teal-300" checked={format === item} name="export-format" type="radio" value={item} onChange={() => { setFormat(item); resetRun(); }} />
                 <span className="font-semibold">{formatLabels[item]}</span>
               </label>
@@ -208,16 +208,16 @@ export function ExportPage() {
           </div>
         </section>
 
-        <section className="rounded-3xl border border-border bg-field p-5 shadow-sm dark:border-border dark:bg-surface-muted sm:p-6 lg:col-span-2" aria-labelledby="export-options-title">
+        <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6 lg:col-span-2" aria-labelledby="export-options-title">
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent dark:text-accent">Options</p>
           <h2 id="export-options-title" className="mt-2 text-2xl font-semibold text-on-accent dark:text-text">Graph relationships</h2>
-          <label className="mt-5 flex items-center justify-between gap-4 rounded-2xl border border-border bg-surface-muted px-4 py-3 text-sm text-text dark:border-border dark:bg-surface dark:text-text">
+          <label className="mt-5 flex items-center justify-between gap-4 rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md px-4 py-3 text-sm text-text dark:text-text">
             <span className="font-semibold">Include graph relationships in the export file</span>
             <input className="h-5 w-5 accent-teal-300" checked={includeGraph} type="checkbox" onChange={(event) => { setIncludeGraph(event.target.checked); resetRun(); }} />
           </label>
         </section>
 
-        <section className="rounded-3xl border border-border bg-surface p-5 shadow-sm dark:border-border dark:bg-surface sm:p-6 lg:col-span-2" aria-labelledby="export-action-title">
+        <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6 lg:col-span-2" aria-labelledby="export-action-title">
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent dark:text-accent">Export</p>
           <h2 id="export-action-title" className="mt-2 text-2xl font-semibold text-on-accent dark:text-text">Run export</h2>
           <button

--- a/frontend/src/pages/FeedPage.tsx
+++ b/frontend/src/pages/FeedPage.tsx
@@ -34,7 +34,7 @@ function FeedRows({ items }: { items: SearchResult[] }) {
   return (
     <div className="grid gap-3" aria-label="DB-backed document feed">
       {items.map((item) => (
-        <article key={item.id} className="min-w-0 rounded-2xl border border-border bg-surface-muted p-4">
+        <article key={item.id} className="min-w-0 rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-4">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
             <div className="min-w-0">
               <h2 className="break-all text-base font-semibold text-text">{item.source_file || item.id}</h2>
@@ -77,7 +77,7 @@ export function FeedPage({ load = fetchDocumentFeed }: { load?: FeedLoader }) {
   const status = useMemo(() => feedStatus(state, total, items.length), [items.length, state, total]);
 
   return (
-    <section className="w-full min-w-0 rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="feed-title">
+    <section className="w-full min-w-0 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="feed-title">
       <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <div className="min-w-0">
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Feed</p>

--- a/frontend/src/pages/FirstRunWizard.tsx
+++ b/frontend/src/pages/FirstRunWizard.tsx
@@ -48,7 +48,7 @@ export function VectorFirstRunWizardPage() {
 
   return (
     <section className="grid gap-5" aria-labelledby="vector-first-run-title">
-      <header className="rounded-3xl border border-border bg-surface p-5 sm:p-6">
+      <header className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent2">Vector onboarding</p>
         <h1 id="vector-first-run-title" className="mt-2 text-3xl font-semibold text-text">First-run setup wizard</h1>
         <p className="mt-2 text-sm text-text-muted">Use the local vector backend default, review cost, choose the first vault collection, and start indexing.</p>
@@ -124,7 +124,7 @@ export function FirstRunWizard({ rows, onRefresh, initialStep = 0, initialCost =
   }
 
   return (
-    <section className={`rounded-3xl border p-5 sm:p-6 ${showAsFirstRun ? 'border-purple-300/20 bg-accent2-solid/10' : 'border-border bg-surface'}`} aria-labelledby="first-run-wizard-title">
+    <section className={`rounded-3xl border bg-[oklch(0.16_0.02_265/0.35)] p-5 shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl sm:p-6 ${showAsFirstRun ? 'border-purple-300/20' : 'border-[oklch(1_0_0/0.08)]'}`} aria-labelledby="first-run-wizard-title">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent2">First-run wizard</p>
@@ -137,7 +137,7 @@ export function FirstRunWizard({ rows, onRefresh, initialStep = 0, initialCost =
       {step === 1 ? <BackendPlan rows={rows} /> : null}
       {step === 2 ? <VaultPlan rows={rows} cost={cost} /> : null}
       {step === 3 ? <DoneActions /> : null}
-      {message ? <p className="mt-4 rounded-2xl border border-border bg-field/50 p-3 text-sm text-purple-100">{message}</p> : null}
+      {message ? <p className="mt-4 rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] p-3 text-sm text-purple-100 backdrop-blur-md">{message}</p> : null}
       {error ? <div className="mt-4"><ErrorMessage title="First-run step failed." message={error} /></div> : null}
 
       <div className="mt-5 flex flex-wrap gap-2">
@@ -187,7 +187,7 @@ function VaultPlan({ rows, cost }: { rows: VectorConfigRow[]; cost: CostEstimate
   const primary = rows.find((row) => row.primary) ?? rows[0];
   return (
     <div className="mt-4 grid gap-3 text-sm text-purple-100 lg:grid-cols-[1fr_1.3fr]">
-      <div className="rounded-2xl border border-border bg-field/50 p-4">
+      <div className="rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] p-4 backdrop-blur-md">
         <p>Primary collection: <span className="font-semibold">{primary?.collection ?? 'none'}</span></p>
         <p className="mt-1 text-purple-100/70">Vault selection is represented by indexed source documents; use Index now to backfill vectors for the primary model.</p>
       </div>

--- a/frontend/src/pages/ForumPage.tsx
+++ b/frontend/src/pages/ForumPage.tsx
@@ -32,7 +32,7 @@ function endpointFor(status: ForumStatusFilter): string {
 function statusClass(status: string): string {
   if (status === 'answered') return 'border-ok-border bg-ok-bg text-ok-text';
   if (status === 'pending' || status === 'active') return 'border-warn-border bg-warn-bg text-warn-text';
-  if (status === 'closed') return 'border-border bg-surface-muted text-text-muted';
+  if (status === 'closed') return 'border-border bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md text-text-muted';
   return 'border-err-border bg-err-bg text-err-text';
 }
 
@@ -44,7 +44,7 @@ function formatDate(value: string): string {
 
 function Stat({ label, value, detail }: { label: string; value: string | number; detail: string }) {
   return (
-    <article className="min-w-0 rounded-2xl border border-border bg-surface p-4">
+    <article className="min-w-0 rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-4">
       <p className="text-xs font-semibold uppercase tracking-[0.18em] text-text-muted">{label}</p>
       <p className="mt-2 break-words text-2xl font-semibold text-accent">{value}</p>
       <p className="mt-1 text-sm text-text-muted">{detail}</p>
@@ -54,7 +54,7 @@ function Stat({ label, value, detail }: { label: string; value: string | number;
 
 function ThreadCard({ thread }: { thread: ForumThreadSummary }) {
   return (
-    <article className="min-w-0 rounded-2xl border border-border bg-surface p-4 sm:p-5" aria-label={`Forum thread ${thread.id}`}>
+    <article className="min-w-0 rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-4 sm:p-5" aria-label={`Forum thread ${thread.id}`}>
       <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
           <p className="font-mono text-xs uppercase tracking-[0.18em] text-text-muted">Thread #{thread.id}</p>
@@ -123,7 +123,7 @@ export function ForumPage({ threads: initialThreads = EMPTY_THREADS, total: init
 
   return (
     <section className="grid min-w-0 gap-5" aria-labelledby="forum-page-title">
-      <header className="min-w-0 rounded-3xl border border-border bg-surface p-5 sm:p-6">
+      <header className="min-w-0 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Forum</p>
         <h1 id="forum-page-title" className="mt-2 text-3xl font-semibold text-text">Forum threads</h1>
         <p className="mt-2 text-sm text-text-muted">Operational conversations backed by GET {endpoint}.</p>
@@ -157,7 +157,7 @@ export function ForumPage({ threads: initialThreads = EMPTY_THREADS, total: init
       {threads.length ? (
         <div className="grid gap-3">{threads.map((thread) => <ThreadCard key={thread.id} thread={thread} />)}</div>
       ) : state === 'ready' ? (
-        <p className="rounded-2xl border border-border bg-surface p-5 text-sm text-text-muted">No forum threads match this filter.</p>
+        <p className="rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-5 text-sm text-text-muted">No forum threads match this filter.</p>
       ) : null}
     </section>
   );

--- a/frontend/src/pages/LearnPage.tsx
+++ b/frontend/src/pages/LearnPage.tsx
@@ -55,7 +55,7 @@ function LearnForm({ editing, form, saving, onChange, onCancel, onSubmit }: {
 }) {
   const disabled = saving || !patternFromForm(form);
   return (
-    <form className="grid gap-3 rounded-2xl border border-border bg-surface-muted p-4" aria-label="Learn entry form" onSubmit={onSubmit}>
+    <form className="grid gap-3 rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-4" aria-label="Learn entry form" onSubmit={onSubmit}>
       <div className="grid gap-2 sm:grid-cols-[1fr_auto] sm:items-end">
         <label className="grid gap-2 text-sm font-medium text-text-muted">
           Learning title
@@ -88,7 +88,7 @@ export function LearnEntryList({ entries, busy, onDelete, onEdit }: {
   return (
     <ul className="grid gap-3" aria-label="Learn entries">
       {entries.map((entry) => (
-        <li key={entry.id} className="rounded-2xl border border-border bg-surface-muted p-4">
+        <li key={entry.id} className="rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-4">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
             <div>
               <h2 className="text-xl font-semibold text-text">{entry.title}</h2>
@@ -159,7 +159,7 @@ export function LearnPage({ client = apiClient }: { client?: LearnClient }) {
 
   const busy = state === 'loading' || state === 'saving';
   return (
-    <section className="grid gap-5 rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="learn-page-title">
+    <section className="grid gap-5 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="learn-page-title">
       <div>
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Learn</p>
         <h1 id="learn-page-title" className="mt-2 text-3xl font-semibold text-text">Learn entries</h1>

--- a/frontend/src/pages/McpToolDetailPage.tsx
+++ b/frontend/src/pages/McpToolDetailPage.tsx
@@ -26,7 +26,7 @@ export function toolBrowserReturnPath(tool?: McpTool | null): string {
 
 function DetailCard({ label, value, href }: { label: string; value?: string; href?: string | null }) {
   return (
-    <div className="rounded-xl border border-border bg-surface-muted p-3">
+    <div className="rounded-xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-3">
       <dt className="text-xs uppercase tracking-[0.18em] text-text-muted">{label}</dt>
       <dd className="mt-1 break-all font-mono text-sm text-text">
         {href && value ? <a className="focus-ring text-accent hover:text-accent" href={href}>{value}</a> : value || '—'}
@@ -37,7 +37,7 @@ function DetailCard({ label, value, href }: { label: string; value?: string; hre
 
 function ToolSummaryCard({ tool }: { tool: McpTool }) {
   return (
-    <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="tool-summary-title">
+    <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="tool-summary-title">
       <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">MCP tool</p>
       <h2 id="tool-summary-title" className="mt-2 break-all text-2xl font-semibold text-text">{tool.name}</h2>
       <p className="mt-4 text-sm leading-6 text-text-muted">{tool.description || 'No description supplied.'}</p>
@@ -53,11 +53,11 @@ function ToolSummaryCard({ tool }: { tool: McpTool }) {
 
 function ToolSchemaCard({ tool }: { tool: McpTool }) {
   return (
-    <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="tool-schema-title">
+    <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="tool-schema-title">
       <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Schema</p>
       <h2 id="tool-schema-title" className="mt-2 text-2xl font-semibold text-text">Input schema</h2>
       <p className="mt-2 text-sm text-text-muted">JSON schema advertised by /api/mcp/tools.</p>
-      <pre className="mt-4 max-h-[36rem] overflow-auto rounded-xl bg-surface-muted p-4 text-xs text-text-muted">{schemaText(tool)}</pre>
+      <pre className="mt-4 max-h-[36rem] overflow-auto rounded-xl bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-4 text-xs text-text-muted">{schemaText(tool)}</pre>
     </section>
   );
 }
@@ -69,13 +69,13 @@ function StatusCard({ status, message, onRetry }: { status: 'ready' | 'loading' 
   }
 
   return (
-    <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-label="Tool not found">
+    <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-label="Tool not found">
       <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Tool lookup</p>
       <h2 className="mt-2 text-2xl font-semibold text-text">No tool found</h2>
       <p className="mt-2 text-sm text-text-muted">{message || 'No MCP tool matched this route parameter.'}</p>
       {onRetry ? (
         <button
-          className="mt-4 inline-flex rounded-xl border border-border px-3 py-2 text-sm text-text transition hover:border-accent-border"
+          className="mt-4 inline-flex rounded-xl border border-border px-3 py-2 text-sm text-text transition-all duration-200 hover:border-[oklch(1_0_0/0.12)]"
           type="button"
           onClick={onRetry}
         >
@@ -137,7 +137,7 @@ export function McpToolDetailPage({
 
   return (
     <div className="grid gap-5">
-      <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="tool-detail-title">
+      <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="tool-detail-title">
         <div className="mb-4 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Detail viewer</p>

--- a/frontend/src/pages/MemoryDashboardPage.tsx
+++ b/frontend/src/pages/MemoryDashboardPage.tsx
@@ -24,7 +24,7 @@ function MemoryCard({ memory }: { memory: RankedMemory }) {
   const rank = memory.ranking?.score ?? memory.confidence.score;
   const validScore = validTimeScore(memory);
   return (
-    <article className="min-w-0 rounded-2xl border border-border bg-surface p-4 shadow-lg shadow-black/10">
+    <article className="min-w-0 rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-4 shadow-lg shadow-black/10">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
           <h2 className="break-words font-mono text-sm font-semibold text-accent">{memory.title || memory.id}</h2>
@@ -37,7 +37,7 @@ function MemoryCard({ memory }: { memory: RankedMemory }) {
 
       <SearchResultSignals result={signal} />
 
-      <section aria-label="Memory valid-time" className="mt-3 rounded-xl border border-border bg-surface-muted p-3">
+      <section aria-label="Memory valid-time" className="mt-3 rounded-xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-3">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <div>
             <p className="text-xs font-semibold uppercase tracking-[0.14em] text-text-muted">valid-time</p>
@@ -72,7 +72,7 @@ export function MemoryDashboardContent({ items, total, asOf, state, error }: {
   const shown = items.length;
   return (
     <div className="grid w-full min-w-0 gap-5">
-      <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="memory-dashboard-title">
+      <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="memory-dashboard-title">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Memory</p>
         <h1 id="memory-dashboard-title" className="mt-2 text-3xl font-semibold text-text">Memory dashboard</h1>
         <p className="mt-2 max-w-3xl text-sm text-text-muted">
@@ -89,7 +89,7 @@ export function MemoryDashboardContent({ items, total, asOf, state, error }: {
         <StatCard label="Valid-time" value={summary.validWindowCount} detail="bounded windows" tone="neutral" />
       </section>
 
-      <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-label="Memory dashboard meters">
+      <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-label="Memory dashboard meters">
         <div className="grid min-w-0 gap-4 md:grid-cols-[repeat(4,minmax(0,1fr))]">
           <MeterBar label="Confidence" percent={summary.avgConfidence * 100} tone="success" valueText={percentText(summary.avgConfidence)} />
           <MeterBar label="Provenance" percent={summary.avgProvenance * 100} tone="accent" valueText={percentText(summary.avgProvenance)} />
@@ -100,7 +100,7 @@ export function MemoryDashboardContent({ items, total, asOf, state, error }: {
 
       {state === 'loading' ? <LoadingPanel title="Loading memory dashboard" detail="Fetching /api/memory/recall for confidence and valid-time signals." /> : null}
       {state === 'error' ? <ErrorMessage title="Memory dashboard failed." message={error || 'Unable to load memory recall.'} /> : null}
-      {state === 'ready' && !items.length ? <p className="rounded-2xl border border-border bg-surface p-4 text-sm text-text-muted">No memories matched this dashboard filter.</p> : null}
+      {state === 'ready' && !items.length ? <p className="rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-4 text-sm text-text-muted">No memories matched this dashboard filter.</p> : null}
       <div className="grid min-w-0 gap-3 xl:grid-cols-[repeat(2,minmax(0,1fr))]" aria-label="Memory dashboard results">
         {items.map((memory) => <MemoryCard key={memory.id} memory={memory} />)}
       </div>
@@ -143,7 +143,7 @@ export function MemoryDashboardPage({ client = fetchMemoryRecall }: { client?: M
 
   return (
     <div className="grid w-full min-w-0 gap-5">
-      <form aria-label="Memory dashboard filters" className="grid gap-3 rounded-3xl border border-border bg-surface p-5 sm:grid-cols-[minmax(0,1fr)_16rem_auto] sm:p-6" onSubmit={submit}>
+      <form aria-label="Memory dashboard filters" className="grid gap-3 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:grid-cols-[minmax(0,1fr)_16rem_auto] sm:p-6" onSubmit={submit}>
         <input aria-label="Memory dashboard query" className="focus-ring rounded-xl border border-border bg-field px-4 py-3 text-text placeholder:text-text-muted" value={query} onChange={(event) => setQuery(event.currentTarget.value)} placeholder="Filter memories by source, title, tag…" type="search" />
         <input aria-label="Valid-time snapshot" className="focus-ring rounded-xl border border-border bg-field px-4 py-3 text-text" value={asOf} onChange={(event) => setAsOf(event.currentTarget.value)} type="datetime-local" />
         <button className="focus-ring rounded-xl bg-accent-solid px-5 py-3 font-semibold text-on-accent transition hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50" disabled={state === 'loading'} type="submit">

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -108,7 +108,7 @@ export function MemoryPage({ search = searchMemoryHealth, recall = fetchMemoryRe
     <div className="grid w-full min-w-0 gap-5">
       <MemoryDashboardContent items={dashboardItems} total={dashboardTotal} asOf={dashboardAsOf} state={dashboardState} error={dashboardError} />
 
-      <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="memory-health-page-title">
+      <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-sm p-5 sm:p-6" aria-labelledby="memory-health-page-title">
         <div className="mb-5 flex min-w-0 flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
           <div className="min-w-0">
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent2">Memory</p>

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -63,10 +63,10 @@ function MenuRows({ items, emptyText = 'No menu items returned from /api/menu.' 
   if (!items.length) return <EmptyState text={emptyText} />;
 
   return (
-    <div className="overflow-hidden rounded-2xl border border-border bg-field/50">
+    <div className="overflow-hidden rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md">
       <div className="hidden overflow-x-auto md:block">
         <table className="min-w-full divide-y divide-white/10 text-left text-sm">
-          <thead className="bg-surface-muted text-xs font-semibold uppercase tracking-[0.16em] text-text-muted">
+          <thead className="bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md text-xs font-semibold uppercase tracking-[0.16em] text-text-muted">
             <tr>
               <th className="px-4 py-3" scope="col">Name</th>
               <th className="px-4 py-3" scope="col">Type</th>
@@ -75,7 +75,7 @@ function MenuRows({ items, emptyText = 'No menu items returned from /api/menu.' 
           </thead>
           <tbody className="divide-y divide-white/10">
             {items.map((item) => (
-              <tr key={menuKey(item)} className="transition hover:bg-surface-muted">
+              <tr key={menuKey(item)} className="transition-all duration-200 hover:bg-[oklch(0.20_0.02_265/0.25)] hover:border-[oklch(1_0_0/0.12)]">
                 <td className="px-4 py-4 align-top">
                   <a className="focus-ring font-semibold text-text hover:text-accent" href={item.path}>
                     {item.label}
@@ -96,7 +96,7 @@ function MenuRows({ items, emptyText = 'No menu items returned from /api/menu.' 
 
       <ul className="grid gap-2 p-3 md:hidden" aria-label="Menu items">
         {items.map((item) => (
-          <li key={menuKey(item)} className="rounded-xl border border-border bg-surface p-3">
+          <li key={menuKey(item)} className="rounded-xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-3">
             <div className="flex items-start justify-between gap-3">
               <div className="min-w-0">
                 <a className="focus-ring font-semibold text-text hover:text-accent" href={item.path}>
@@ -137,7 +137,7 @@ function MenuFiltersCard({
 }) {
   const hasFilters = filters.group !== 'all' || filters.source !== 'all';
   return (
-    <section className="mb-5 rounded-2xl border border-border bg-surface-muted p-4" aria-label="Menu filters">
+    <section className="mb-5 rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-4" aria-label="Menu filters">
       <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.18em] text-accent">Source filters</p>
@@ -158,7 +158,7 @@ function MenuFiltersCard({
               {sources.map((source) => <option key={source} value={source}>{source}</option>)}
             </select>
           </label>
-          <button className="focus-ring w-full rounded-xl border border-border px-3 py-2 text-sm font-semibold text-text hover:border-teal-300/40 disabled:opacity-40 sm:w-auto sm:self-end" disabled={!hasFilters} type="button" onClick={onClear}>
+          <button className="focus-ring w-full rounded-xl border border-border px-3 py-2 text-sm font-semibold text-text hover:border-[oklch(1_0_0/0.12)] disabled:opacity-40 sm:w-auto sm:self-end" disabled={!hasFilters} type="button" onClick={onClear}>
             Clear
           </button>
           <a className="focus-ring w-full rounded-xl border border-accent-border px-3 py-2 text-center text-sm font-semibold text-accent hover:border-accent-border sm:w-auto sm:self-end" href={sharePath}>
@@ -203,7 +203,7 @@ export function MenuPage({ items: initialItems = [], loading, client = apiClient
   const emptyText = sortedItems.length ? 'No menu items match the selected group/source filters.' : undefined;
 
   return (
-    <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="menu-page-title">
+    <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="menu-page-title">
       <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Menu</p>

--- a/frontend/src/pages/MetricsPage.tsx
+++ b/frontend/src/pages/MetricsPage.tsx
@@ -73,7 +73,7 @@ function MetricsChartsCard({ metrics }: { metrics: MetricsSnapshot }) {
   const tones: MeterTone[] = ['accent', 'accent2', 'success', 'warning', 'danger'];
 
   return (
-    <section className="rounded-3xl border border-border bg-surface-muted p-5 sm:p-6" aria-labelledby="metrics-charts-title">
+    <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="metrics-charts-title">
       <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Charts</p>
       <h2 id="metrics-charts-title" className="mt-2 text-2xl font-semibold text-text">Memory distribution</h2>
       <p className="mt-2 text-sm text-text-muted">Live memory profile and request throughput from /api/v1/metrics.</p>
@@ -94,7 +94,7 @@ function MetricsChartsCard({ metrics }: { metrics: MetricsSnapshot }) {
             ))}
           </ul>
         </div>
-        <div className="rounded-2xl border border-border bg-surface-muted p-4">
+        <div className="rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-4">
           <p className="text-sm text-text-muted">Request throughput</p>
           <p className="mt-2 text-4xl font-semibold text-text">{requestLoad.toFixed(1)} req/min</p>
           <div className="mt-4">
@@ -114,7 +114,7 @@ function MetricsChartsCard({ metrics }: { metrics: MetricsSnapshot }) {
 
 function MetricsActivityCard({ metrics }: { metrics: MetricsSnapshot }) {
   return (
-    <section className="min-w-0 rounded-3xl border border-border bg-surface-muted p-5 sm:p-6" aria-labelledby="metrics-activity-title">
+    <section className="min-w-0 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="metrics-activity-title">
       <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Recent activity</p>
       <h2 id="metrics-activity-title" className="mt-2 text-2xl font-semibold text-text">Runtime events</h2>
       <ul className="mt-4 grid gap-3 text-sm text-text-muted">
@@ -142,7 +142,7 @@ export function MetricsPage(props: MetricsPageProps) {
     const { metrics, loading } = props;
     return (
       <div className="grid w-full min-w-0 gap-5">
-        <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="metrics-page-title">
+        <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="metrics-page-title">
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Runtime metrics</p>
           <h2 id="metrics-page-title" className="mt-2 text-3xl font-semibold text-text">Metrics dashboard</h2>
           <p className="mt-2 text-sm text-text-muted">Runtime counters from GET /api/v1/metrics.</p>
@@ -153,7 +153,7 @@ export function MetricsPage(props: MetricsPageProps) {
 
         {metrics ? (
           <div className="grid min-w-0 gap-5 xl:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
-            <section className="min-w-0 rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="metrics-stats-title">
+            <section className="min-w-0 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="metrics-stats-title">
               <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Overview</p>
               <h2 id="metrics-stats-title" className="mt-2 text-2xl font-semibold text-text">Stats snapshot</h2>
               <div className="mt-4 grid min-w-0 gap-3 sm:grid-cols-[repeat(3,minmax(0,1fr))]">
@@ -169,7 +169,7 @@ export function MetricsPage(props: MetricsPageProps) {
         {metrics ? (
           <div className="grid min-w-0 gap-5 lg:grid-cols-[repeat(2,minmax(0,1fr))]">
             <MetricsChartsCard metrics={metrics} />
-            <section className="min-w-0 rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="memory-stats-title">
+            <section className="min-w-0 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="memory-stats-title">
               <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Memory</p>
               <h2 id="memory-stats-title" className="mt-2 text-2xl font-semibold text-text">Memory usage</h2>
               <dl className="mt-4 grid gap-3 text-sm text-text-muted">
@@ -185,7 +185,7 @@ export function MetricsPage(props: MetricsPageProps) {
   }
 
   return (
-    <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="metrics-page-title">
+    <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="metrics-page-title">
       <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Runtime metrics</p>
       <h2 id="metrics-page-title" className="text-2xl font-semibold text-text">Runtime metrics</h2>
       <p className="text-sm text-text-muted">Track dashboard and surface counts while debugging</p>

--- a/frontend/src/pages/PluginsPage.tsx
+++ b/frontend/src/pages/PluginsPage.tsx
@@ -147,7 +147,7 @@ export function PluginsPage({
       {showInventory ? <UnifiedPluginSurfaceOverview plugins={plugins} /> : null}
 
       {plugins.length ? (
-        <section className="min-w-0 rounded-2xl border border-border bg-surface p-4" aria-labelledby="plugin-filters-title">
+        <section className="min-w-0 rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-4" aria-labelledby="plugin-filters-title">
           <div className="flex min-w-0 flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
             <div className="min-w-0">
               <p className="text-xs font-semibold uppercase tracking-[0.18em] text-accent">Inventory filters</p>
@@ -191,7 +191,7 @@ export function PluginsPage({
                 </select>
               </label>
               <button
-                className="focus-ring self-end rounded-xl border border-border px-3 py-2 text-sm font-semibold text-text hover:border-teal-300/40 disabled:opacity-40"
+                className="focus-ring self-end rounded-xl border border-border px-3 py-2 text-sm font-semibold text-text hover:border-[oklch(1_0_0/0.12)] disabled:opacity-40"
                 disabled={!hasFilters}
                 type="button"
                 onClick={() => { setQuery(''); setVisibility('all'); setSurface('all'); }}
@@ -209,11 +209,11 @@ export function PluginsPage({
       {visiblePlugins.length ? (
         <PluginList plugins={visiblePlugins} enabledState={enabledState} onToggle={(name) => void togglePlugin(name)} />
       ) : plugins.length && showInventory ? (
-        <p className="rounded-lg border border-border bg-surface p-5 text-sm text-text-muted">
+        <p className="rounded-lg border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-5 text-sm text-text-muted">
           No plugins match the current filters. Clear filters or reload plugin manifests.
         </p>
       ) : showInventory ? (
-        <p className="rounded-lg border border-border bg-surface p-5 text-sm text-text-muted">
+        <p className="rounded-lg border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-5 text-sm text-text-muted">
           No installed plugins returned by {endpoint}.
         </p>
       ) : null}

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -67,7 +67,7 @@ function SearchInputCard({ query, loading, onQueryChange, onSubmit }: {
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
 }) {
   return (
-    <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-label="Search input card">
+    <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-label="Search input card">
       <div className="mb-5">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Menu search</p>
         <h1 id="menu-search-title" className="mt-2 text-3xl font-semibold text-text">Full-text menu search</h1>
@@ -100,7 +100,7 @@ export function MenuSearchResults({ query, results, state }: { query: string; re
     <ul className="grid gap-3" aria-label="Menu search results">
       {results.map((item) => (
         <li key={`${item.source ?? 'api'}:${item.path}:${item.label}`}>
-          <a className="focus-ring block min-w-0 rounded-2xl border border-border bg-surface-muted p-4 transition hover:border-teal-300/40" href={item.path}>
+          <a className="focus-ring block min-w-0 rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-4 transition-all duration-200 hover:border-[oklch(1_0_0/0.12)]" href={item.path}>
             <span className="text-lg font-semibold text-text"><HighlightedText text={item.label} query={query} /></span>
             <span className="mt-1 block break-all text-sm text-text-muted"><HighlightedText text={item.path} query={query} /></span>
             <span className="mt-3 inline-flex rounded-full border border-accent-border px-2 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-accent">
@@ -115,20 +115,20 @@ export function MenuSearchResults({ query, results, state }: { query: string; re
 
 function SearchScopeCard({ scope, resultGroups, total }: { scope: SearchScope; resultGroups: string[]; total: number }) {
   return (
-    <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-label="Search scope card">
+    <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-label="Search scope card">
       <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Scope</p>
       <h2 className="mt-2 text-2xl font-semibold text-text">Search boundaries</h2>
       <p className="mt-2 text-sm text-text-muted">Current query scope is constrained to menu records.</p>
       <ul className="mt-5 grid gap-2 text-sm text-text-muted">
-        <li className="rounded-xl border border-border bg-surface-muted p-3">
+        <li className="rounded-xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-3">
           <span className="text-xs uppercase tracking-[0.16em] text-text-muted">Mode</span>
           <p className="mt-1 font-semibold text-text capitalize">{scope}</p>
         </li>
-        <li className="rounded-xl border border-border bg-surface-muted p-3">
+        <li className="rounded-xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-3">
           <span className="text-xs uppercase tracking-[0.16em] text-text-muted">Result groups</span>
           <p className="mt-1 break-words font-semibold text-text">{resultGroups.length || '-'}{resultGroups.length ? ` (${resultGroups.join(', ')})` : ''}</p>
         </li>
-        <li className="rounded-xl border border-border bg-surface-muted p-3">
+        <li className="rounded-xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-3">
           <span className="text-xs uppercase tracking-[0.16em] text-text-muted">Matches</span>
           <p className="mt-1 font-semibold text-text">{total}</p>
         </li>
@@ -151,7 +151,7 @@ function SearchResultsCard({
   errorMessage: string;
 }) {
   return (
-    <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-label="Menu search results card">
+    <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-label="Menu search results card">
       <div className="mb-4">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Results</p>
         <h2 className="mt-2 text-2xl font-semibold text-text">Search results</h2>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -16,7 +16,7 @@ type SettingsPageProps = {
 
 function SectionCard({ title, children }: { title: string; children: ReactNode }) {
   return (
-    <section className="min-w-0 rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-label={title}>
+    <section className="min-w-0 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-label={title}>
       <h3 className="text-lg font-semibold text-text">{title}</h3>
       <div className="mt-4">{children}</div>
     </section>
@@ -25,7 +25,7 @@ function SectionCard({ title, children }: { title: string; children: ReactNode }
 
 function SettingPair({ label, value, detail }: { label: string; value: string | number; detail: string }) {
   return (
-    <div className="min-w-0 rounded-2xl border border-border bg-surface p-4">
+    <div className="min-w-0 rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-4">
       <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-text-muted">{label}</dt>
       <dd className="mt-2 break-words font-mono text-sm text-accent">{value}</dd>
       <dd className="mt-2 break-words text-sm leading-6 text-text-muted">{detail}</dd>
@@ -69,7 +69,7 @@ export function SettingsPage({ menuCount, pluginCount, surfaceCount, updatedAt, 
 
   return (
     <div className="grid gap-5">
-      <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="settings-page-title">
+      <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="settings-page-title">
         <div className="mb-5 flex min-w-0 flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
           <div className="min-w-0">
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent2">Settings</p>
@@ -198,7 +198,7 @@ export function SettingsPage({ menuCount, pluginCount, surfaceCount, updatedAt, 
           <SectionCard title="Vector collections">
             <div className="grid gap-3 sm:grid-cols-2">
               {settings.embedder.collections.map((collection) => (
-                <article key={collection.key} className="min-w-0 rounded-2xl border border-border bg-surface p-4">
+                <article key={collection.key} className="min-w-0 rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-4">
                   <p className="break-all font-mono text-sm text-accent">{collection.key}</p>
                   <p className="mt-2 break-words text-sm text-text">{collection.collection}</p>
                   <p className="mt-1 break-words text-sm text-text-muted">{collection.provider} · {collection.model} · {collection.adapter ?? 'adapter default'}</p>

--- a/frontend/src/pages/StatusPage.tsx
+++ b/frontend/src/pages/StatusPage.tsx
@@ -68,7 +68,7 @@ function databasePath(health: HealthResponse): string | undefined {
 
 function Field({ label, value }: { label: string; value: string | number | undefined }) {
   return (
-    <div className="min-w-0 rounded-2xl border border-border bg-surface-muted p-4">
+    <div className="min-w-0 rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-4">
       <dt className="text-xs font-semibold uppercase tracking-[0.18em] text-text-muted">{label}</dt>
       <dd className="mt-2 break-words font-mono text-sm text-text">{value ?? 'unknown'}</dd>
     </div>
@@ -113,7 +113,7 @@ function PluginRows({ health }: { health: HealthResponse }) {
   return (
     <ul className="grid gap-2">
       {items.map((plugin) => (
-        <li key={plugin.name} className="flex min-w-0 flex-col gap-2 rounded-xl border border-border bg-surface-muted p-3 sm:flex-row sm:items-center sm:justify-between">
+        <li key={plugin.name} className="flex min-w-0 flex-col gap-2 rounded-xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-3 sm:flex-row sm:items-center sm:justify-between">
           <a className="focus-ring break-all font-mono text-sm text-accent hover:text-accent" href={pluginHealthPath(plugin)}>{plugin.name}</a>
           <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs ${statusClass(plugin.status)}`} data-contrast-badge><span aria-hidden="true">●</span>{plugin.status}</span>
           {plugin.error ? <span className="break-words text-sm text-warn-text">{plugin.error}</span> : null}
@@ -129,7 +129,7 @@ function ProxyRows({ vector }: { vector: VectorHealthForStatus | null }) {
   return (
     <ul className="grid gap-2">
       {rows.map((row) => (
-        <li key={`${row.name}-${row.endpoint}`} className="min-w-0 rounded-xl border border-border bg-surface-muted p-3">
+        <li key={`${row.name}-${row.endpoint}`} className="min-w-0 rounded-xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-3">
           <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <span className="break-all font-mono text-sm text-accent">{row.name}</span>
             <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs ${statusClass(row.status === 'up' ? 'ok' : row.status)}`} data-contrast-badge><span aria-hidden="true">●</span>{row.status}</span>
@@ -177,7 +177,7 @@ export function StatusPage({ client = apiClient, initialHealth = null, initialVe
 
   return (
     <section className="grid min-w-0 gap-5" aria-labelledby="status-page-title">
-      <div className="min-w-0 rounded-3xl border border-border bg-surface p-5 sm:p-6">
+      <div className="min-w-0 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Server status</p>
         <h2 id="status-page-title" className="mt-2 text-2xl font-semibold text-text">Health overview</h2>
         <p className="mt-2 text-sm text-text-muted">Live health from GET /api/v1/health.</p>
@@ -204,11 +204,11 @@ export function StatusPage({ client = apiClient, initialHealth = null, initialVe
             <Field label="Oracle" value={health.oracle} />
             <Field label="DB path" value={databasePath(health)} />
           </dl>
-          <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-label="Plugin health rows">
+          <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-label="Plugin health rows">
             <h3 className="text-lg font-semibold text-text">Plugin health</h3>
             <div className="mt-4"><PluginRows health={health} /></div>
           </section>
-          <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-label="Proxy status rows">
+          <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-label="Proxy status rows">
             <h3 className="text-lg font-semibold text-text">Proxy status</h3>
             <p className="mt-2 text-sm text-text-muted">Vector proxy and registered proxy services from /api/v1/vector/health.</p>
             {vectorError ? <p className="mt-3 rounded-xl border border-warn-border bg-warn-bg p-3 text-sm text-warn-text">{vectorError}</p> : null}

--- a/frontend/src/pages/StoragePage.tsx
+++ b/frontend/src/pages/StoragePage.tsx
@@ -60,7 +60,7 @@ export function storageSummaryRows(settings: SettingsSystemResponse): DetailRow[
 
 function DetailCard({ row }: { row: DetailRow }) {
   return (
-    <article className="rounded-2xl border border-border bg-surface-muted p-4">
+    <article className="rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-4">
       <p className="text-xs font-semibold uppercase tracking-[0.18em] text-text-muted">{row.label}</p>
       <p className="mt-2 break-words font-mono text-sm text-accent">{row.value}</p>
       <p className="mt-2 text-sm leading-6 text-text-muted">{row.detail}</p>
@@ -94,7 +94,7 @@ export function StoragePage({ initialSettings, fetcher = fetchSettingsSystem }: 
 
   return (
     <div className="grid gap-5">
-      <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="storage-page-title">
+      <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="storage-page-title">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent2">Storage</p>

--- a/frontend/src/pages/UnifiedPluginSurfaceOverview.tsx
+++ b/frontend/src/pages/UnifiedPluginSurfaceOverview.tsx
@@ -141,7 +141,7 @@ export function UnifiedPluginSurfaceOverview({ plugins }: { plugins: PluginEntry
   const capabilities = useMemo(() => pluginCapabilityLinks(plugins), [plugins]);
 
   return (
-    <section className="min-w-0 rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="unified-surfaces-title">
+    <section className="min-w-0 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="unified-surfaces-title">
       <div className="mb-4 flex min-w-0 flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
         <div className="min-w-0">
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent2">Unified backend surfaces</p>
@@ -170,7 +170,7 @@ export function UnifiedPluginSurfaceOverview({ plugins }: { plugins: PluginEntry
 function SurfaceCard({ card }: { card: Card }) {
   const tone = card.tone === 'warn' ? 'text-warn-text' : 'text-accent';
   return (
-    <article className="min-w-0 rounded-2xl border border-border bg-surface-muted p-4">
+    <article className="min-w-0 rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-4">
       <p className="text-xs font-semibold uppercase tracking-[0.18em] text-text-muted">{card.label}</p>
       <p className={`mt-2 break-words text-2xl font-semibold ${tone}`}>{card.value}</p>
       <p className="mt-2 break-words text-sm leading-6 text-text-muted">{card.detail}</p>
@@ -184,7 +184,7 @@ function SurfaceCard({ card }: { card: Card }) {
 function SurfaceList({ title, items, empty }: { title: string; items: SurfaceListItem[]; empty: string }) {
   const visible = items.filter(Boolean);
   return (
-    <article className="min-w-0 rounded-2xl border border-border bg-surface-muted p-4">
+    <article className="min-w-0 rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-4">
       <p className="text-xs font-semibold uppercase tracking-[0.18em] text-text-muted">{title}</p>
       {visible.length ? (
         <ul className="mt-3 space-y-2 text-sm text-text-muted">

--- a/frontend/src/pages/VectorCollectionList.tsx
+++ b/frontend/src/pages/VectorCollectionList.tsx
@@ -41,7 +41,7 @@ export function VectorCollectionList({
   onPrimary,
 }: CollectionListProps) {
   return (
-    <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6">
+    <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Collections</p>
@@ -56,7 +56,7 @@ export function VectorCollectionList({
           const draft = drafts[row.key] ?? { model: row.model, provider: row.provider, adapter: row.adapter, enabled: row.enabled };
           const dirty = draft.model !== row.model || draft.provider !== row.provider || draft.adapter !== row.adapter || draft.enabled !== row.enabled;
           return (
-            <article key={row.key} className="rounded-2xl border border-border bg-surface p-4">
+            <article key={row.key} className="rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-4">
               <div className="mb-3 flex items-start justify-between gap-3">
                 <div>
                   <div className="flex flex-wrap items-center gap-2">

--- a/frontend/src/pages/VectorDocumentsPage.tsx
+++ b/frontend/src/pages/VectorDocumentsPage.tsx
@@ -166,7 +166,7 @@ export function VectorDocumentsPage() {
   }
 
   return (
-    <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="vector-documents-title">
+    <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="vector-documents-title">
       <div className="mb-5">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Vector</p>
         <h1 id="vector-documents-title" className="mt-2 text-3xl font-semibold text-text">Vector documents</h1>
@@ -190,14 +190,14 @@ export function VectorDocumentsPage() {
 
       <div className="mt-5 overflow-x-auto rounded-2xl border border-border">
         <table className="min-w-full divide-y divide-border text-left text-sm">
-          <thead className="bg-surface-muted text-xs uppercase tracking-[0.18em] text-text-muted">
+          <thead className="bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md text-xs uppercase tracking-[0.18em] text-text-muted">
             <tr><th className="px-4 py-3">ID</th><th className="px-4 py-3">Type</th><th className="px-4 py-3">Source file</th><th className="px-4 py-3">Preview</th></tr>
           </thead>
           <tbody className="divide-y divide-border text-text" aria-busy={state === 'loading'}>
             {documents.map((document) => {
               const expanded = expandedId === document.id;
               return (
-                <tr key={document.id} role="button" tabIndex={0} aria-expanded={expanded} className="cursor-pointer align-top hover:bg-surface-muted" onClick={() => setExpandedId(expanded ? null : document.id)} onKeyDown={(event) => { if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); setExpandedId(expanded ? null : document.id); } }}>
+                <tr key={document.id} role="button" tabIndex={0} aria-expanded={expanded} className="cursor-pointer align-top transition-all duration-200 hover:bg-[oklch(0.20_0.02_265/0.25)] hover:border-[oklch(1_0_0/0.12)]" onClick={() => setExpandedId(expanded ? null : document.id)} onKeyDown={(event) => { if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); setExpandedId(expanded ? null : document.id); } }}>
                   <td className="px-4 py-3 font-mono text-xs text-accent">{document.id}</td>
                   <td className="px-4 py-3 text-text-muted">{document.type || '—'}</td>
                   <td className="px-4 py-3 text-text-muted">{document.source_file || '—'}</td>

--- a/frontend/src/pages/VectorExportPage.tsx
+++ b/frontend/src/pages/VectorExportPage.tsx
@@ -110,7 +110,7 @@ export function VectorExportPage({
   }
 
   return (
-    <section className="min-w-0 overflow-hidden rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="vector-export-title">
+    <section className="min-w-0 overflow-hidden rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="vector-export-title">
       <div className="mb-5 min-w-0">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Vector</p>
         <h1 id="vector-export-title" className="mt-2 text-3xl font-semibold text-text">Vector export</h1>
@@ -120,7 +120,7 @@ export function VectorExportPage({
       {state === 'loading' ? <LoadingPanel title="Loading vector collections…" detail="Fetching /api/v1/vector/index/models." /> : null}
       {state === 'error' ? <ErrorMessage title="Could not load vector export options." message={error} /> : null}
 
-      <div className="mt-5 grid min-w-0 gap-4 overflow-hidden rounded-2xl border border-border bg-surface-muted p-4">
+      <div className="mt-5 grid min-w-0 gap-4 overflow-hidden rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-4">
         <label className="grid min-w-0 gap-2 text-sm font-medium text-text-muted">
           Collection
           <select

--- a/frontend/src/pages/VectorPage.tsx
+++ b/frontend/src/pages/VectorPage.tsx
@@ -85,7 +85,7 @@ export function vectorDashboardSummary(cards: VectorCollectionCard[], state: Pag
 
 function VectorDocumentsCard() {
   return (
-    <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="vector-documents-title">
+    <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="vector-documents-title">
       <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Documents</p>
       <h2 id="vector-documents-title" className="mt-2 text-2xl font-semibold text-text">Browse indexed documents</h2>
       <p className="mt-2 text-sm text-text-muted">Open the collection-level document browser for full content and metadata.</p>
@@ -154,7 +154,7 @@ export function VectorPage({
 
   return (
     <div className="grid min-w-0 gap-5">
-      <section className="min-w-0 overflow-hidden rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="vector-status-title">
+      <section className="min-w-0 overflow-hidden rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="vector-status-title">
         <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Vector status</p>
@@ -176,7 +176,7 @@ export function VectorPage({
           <QuickExportCard cards={cards} formats={formats} downloads={downloads} onExport={onExport} />
         </div>
 
-        <section className="min-w-0 overflow-hidden rounded-3xl border border-border bg-surface p-5 sm:p-6">
+        <section className="min-w-0 overflow-hidden rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6">
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Collection health</p>
           <h2 className="mt-2 text-2xl font-semibold text-text">Vector collections</h2>
           <p className="mt-2 text-sm text-text-muted">Status, model, and adapter details by collection.</p>

--- a/frontend/src/pages/VectorSearchPage.tsx
+++ b/frontend/src/pages/VectorSearchPage.tsx
@@ -71,7 +71,7 @@ function ResultCard({ result }: { result: VectorSearchResult }) {
   const percent = distancePercent(result);
   const concepts = conceptsFor(result);
   return (
-    <article className="rounded-2xl border border-border bg-surface p-4 shadow-lg shadow-black/10">
+    <article className="rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-4 shadow-lg shadow-black/10">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <h2 className="text-base font-semibold text-text">{titleFor(result)}</h2>
@@ -152,7 +152,7 @@ export function VectorSearchPage({ client = apiClient }: { client?: VectorSearch
   }
 
   return (
-    <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="vector-search-preview-title">
+    <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="vector-search-preview-title">
       <div className="mb-5">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Vector</p>
         <h1 id="vector-search-preview-title" className="mt-2 text-3xl font-semibold text-text">Vector search preview</h1>

--- a/frontend/src/pages/VectorSearchResultsPage.tsx
+++ b/frontend/src/pages/VectorSearchResultsPage.tsx
@@ -66,7 +66,7 @@ export function VectorSearchResultsPage() {
   }
 
   return (
-    <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="vector-results-title">
+    <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="vector-results-title">
       <div className="mb-5 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Vector</p>

--- a/frontend/src/pages/VectorSettingsPage.tsx
+++ b/frontend/src/pages/VectorSettingsPage.tsx
@@ -40,7 +40,7 @@ function VectorFirstRunWizardSection() {
 export function VectorSettingsPage() {
   return (
     <section className="grid min-w-0 gap-5" aria-labelledby="vector-settings-title">
-      <header className="min-w-0 rounded-3xl border border-border bg-surface p-5 sm:p-6">
+      <header className="min-w-0 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Vector settings</p>
         <h1 id="vector-settings-title" className="mt-2 text-3xl font-semibold text-text">Vector settings</h1>
         <p className="mt-2 break-words text-sm text-text-muted">

--- a/frontend/src/pages/vector-dashboard-cards.tsx
+++ b/frontend/src/pages/vector-dashboard-cards.tsx
@@ -65,7 +65,7 @@ export function VectorCollectionCards({
         const selected = selectedFormats[card.collection] ?? formats?.[0]?.format ?? 'json';
         const label = formatLabelFor(formats, selected);
         return (
-          <article key={card.key} className="min-w-0 overflow-hidden rounded-2xl border border-border bg-surface-muted p-4">
+          <article key={card.key} className="min-w-0 overflow-hidden rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] backdrop-blur-md p-4">
             <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
               <div className="min-w-0">
                 <p className="text-xs font-semibold uppercase tracking-[0.18em] text-text-muted">Collection</p>
@@ -109,7 +109,7 @@ export function VectorCollectionCards({
 
 export function VectorStatsCard({ cards }: { cards: VectorCollectionCard[] }) {
   return (
-    <section className="min-w-0 overflow-hidden rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="vector-stats-title">
+    <section className="min-w-0 overflow-hidden rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="vector-stats-title">
       <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Stats</p>
       <h2 id="vector-stats-title" className="mt-2 text-2xl font-semibold text-text">Collection stats</h2>
       <dl className="mt-4 grid gap-3 text-sm text-text-muted">
@@ -141,7 +141,7 @@ export function QuickExportCard({
 
   if (!cards.length) {
     return (
-      <section className="min-w-0 overflow-hidden rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="vector-quick-export-title">
+      <section className="min-w-0 overflow-hidden rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="vector-quick-export-title">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Quick export</p>
         <h2 id="vector-quick-export-title" className="mt-2 text-2xl font-semibold text-text">Export collection</h2>
         <p className="mt-2 text-sm text-text-muted">No collections are loaded yet.</p>
@@ -153,7 +153,7 @@ export function QuickExportCard({
   const isDownloading = Boolean(downloads[collection]);
   const disabled = isDownloading || formats.length === 0;
   return (
-    <section className="min-w-0 overflow-hidden rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="vector-quick-export-title">
+    <section className="min-w-0 overflow-hidden rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="vector-quick-export-title">
       <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Quick export</p>
       <h2 id="vector-quick-export-title" className="mt-2 text-2xl font-semibold text-text">Export collection</h2>
       <p className="mt-2 text-sm text-text-muted">Pick a collection and format to download from /api/v1/vector/export.</p>

--- a/frontend/src/pages/vector-health-dashboard-card.tsx
+++ b/frontend/src/pages/vector-health-dashboard-card.tsx
@@ -59,7 +59,7 @@ export function VectorHealthDashboardCard({
     ? `${storage.filter((item) => item.status === 'green').length}/${storage.length} storage backends healthy`
     : 'Storage status unavailable';
   return (
-    <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="vector-health-dashboard-title">
+    <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="vector-health-dashboard-title">
       <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Health</p>
       <h2 id="vector-health-dashboard-title" className="mt-2 text-2xl font-semibold text-text">Vector health dashboard</h2>
       <dl className="mt-4 grid gap-3 text-sm text-text-muted">


### PR DESCRIPTION
## Summary
- replace page surface panels with translucent oklch glass styling
- apply lighter glass treatment to nested page cards and muted subsections
- keep MemoryPage blur at backdrop-blur-sm for the 3D page constraint

## Validation
- bunx tsc --noEmit
- cd frontend && bun run build

## Notes
- changed files remain <= 250 lines
- did not touch styles.css, AppShell.tsx, NavSidebar.tsx, StatCard.tsx, or CommandPalette.tsx