### PR TITLE
feat(frontend): theme plugin system

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -8,6 +8,7 @@ import { StatCard } from './StatCard';
 import { CommandPalette } from './CommandPalette';
 import { TauriBadge } from './TauriBadge';
 import { ThemeToggle } from './ThemeToggle';
+import { ThemeSelector } from './ThemeSelector';
 import { GlobalSearch } from './GlobalSearch';
 import type { MetricsSnapshot } from '../../../src/server/types';
 
@@ -119,6 +120,7 @@ export function AppShell({
                   Simple Mode
                 </a>
                 <TauriBadge connected={!error} />
+                <ThemeSelector />
                 <ThemeToggle />
                 <button
                   className="focus-ring rounded-xl bg-accent-solid px-5 py-3 font-semibold text-on-accent transition hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"

--- a/frontend/src/components/ThemeSelector.tsx
+++ b/frontend/src/components/ThemeSelector.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useRef, useState } from 'react';
+import { getThemes } from '../themes/registry';
+import { applyColorTheme, clearColorThemeOverrides, readStoredColorTheme, saveColorTheme } from '../theme';
+
+export function ThemeSelector() {
+  const [open, setOpen] = useState(false);
+  const [activeId, setActiveId] = useState(() => readStoredColorTheme());
+  const panelRef = useRef<HTMLDivElement>(null);
+  const themes = getThemes();
+
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    function onClick(e: MouseEvent) {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('mousedown', onClick);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('mousedown', onClick);
+    };
+  }, [open]);
+
+  function handlePreview(id: string) {
+    clearColorThemeOverrides();
+    applyColorTheme(id);
+  }
+
+  function handleSelect(id: string) {
+    saveColorTheme(id);
+    setActiveId(id);
+    setOpen(false);
+  }
+
+  function handleLeave() {
+    clearColorThemeOverrides();
+    applyColorTheme(activeId);
+  }
+
+  const active = themes.find((t) => t.id === activeId);
+
+  return (
+    <div className="relative" ref={panelRef}>
+      <button
+        type="button"
+        className="focus-ring inline-flex items-center gap-2 rounded-xl border border-border bg-field px-3 py-2 text-sm font-semibold text-text shadow-sm transition hover:border-accent-border hover:bg-accent-soft"
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-label="Select color theme"
+      >
+        <ThemeSwatch theme={active} />
+        <span className="hidden sm:inline">{active?.name ?? 'Theme'}</span>
+      </button>
+
+      {open ? (
+        <div
+          role="listbox"
+          aria-label="Color themes"
+          className="glass absolute right-0 top-full z-50 mt-2 grid max-h-[24rem] w-64 gap-1 overflow-y-auto rounded-2xl p-2"
+          onMouseLeave={handleLeave}
+        >
+          {themes.map((t) => (
+            <button
+              key={t.id}
+              role="option"
+              type="button"
+              aria-selected={t.id === activeId}
+              className={`flex items-center gap-3 rounded-xl px-3 py-2 text-left transition ${
+                t.id === activeId ? 'bg-accent-soft text-accent' : 'text-text hover:bg-surface-muted'
+              }`}
+              onMouseEnter={() => handlePreview(t.id)}
+              onClick={() => handleSelect(t.id)}
+            >
+              <ThemeSwatch theme={t} />
+              <div className="min-w-0">
+                <p className="truncate text-sm font-semibold">{t.name}</p>
+                <p className="truncate text-xs text-text-muted">{t.description}</p>
+              </div>
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ThemeSwatch({ theme }: { theme?: { light: Record<string, string>; dark: Record<string, string> } }) {
+  const accent = theme?.dark['--color-accent'] ?? theme?.light['--color-accent'] ?? 'oklch(0.82 0.13 178)';
+  const accent2 = theme?.dark['--color-accent2'] ?? theme?.light['--color-accent2'] ?? 'oklch(0.78 0.16 300)';
+  return (
+    <span className="inline-flex shrink-0 gap-0.5" aria-hidden="true">
+      <span className="h-4 w-4 rounded-full" style={{ background: accent }} />
+      <span className="h-4 w-4 rounded-full" style={{ background: accent2 }} />
+    </span>
+  );
+}

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,6 +1,9 @@
+import { DEFAULT_THEME_ID, getTheme } from './themes/registry';
+
 export type ThemeMode = 'light' | 'dark';
 
 export const THEME_KEY = 'ARRA_FRONTEND_THEME';
+export const COLOR_THEME_KEY = 'ARRA_FRONTEND_COLOR_THEME';
 
 function browserWindow(): Window | undefined {
   return typeof window === 'undefined' ? undefined : window;
@@ -19,6 +22,14 @@ export function readStoredTheme(): ThemeMode {
   }
 }
 
+export function readStoredColorTheme(): string {
+  try {
+    return browserWindow()?.localStorage.getItem(COLOR_THEME_KEY) || DEFAULT_THEME_ID;
+  } catch {
+    return DEFAULT_THEME_ID;
+  }
+}
+
 export function applyTheme(theme: ThemeMode) {
   const root = typeof document === 'undefined' ? undefined : document.documentElement;
   if (!root) return;
@@ -28,17 +39,49 @@ export function applyTheme(theme: ThemeMode) {
   root.style.colorScheme = theme;
 }
 
+export function applyColorTheme(themeId: string) {
+  const root = typeof document === 'undefined' ? undefined : document.documentElement;
+  if (!root) return;
+  const theme = getTheme(themeId);
+  if (!theme) return;
+
+  root.dataset.colorTheme = themeId;
+  const mode = root.classList.contains('dark') ? 'dark' : 'light';
+  const tokens = mode === 'dark' ? theme.dark : theme.light;
+
+  for (const [key, value] of Object.entries(tokens)) {
+    root.style.setProperty(key, value);
+  }
+}
+
+export function clearColorThemeOverrides() {
+  const root = typeof document === 'undefined' ? undefined : document.documentElement;
+  if (!root) return;
+  const vars = root.style.cssText.match(/--[\w-]+/g) || [];
+  for (const v of vars) root.style.removeProperty(v);
+}
+
+export function saveColorTheme(themeId: string) {
+  try {
+    browserWindow()?.localStorage.setItem(COLOR_THEME_KEY, themeId);
+  } catch {}
+  clearColorThemeOverrides();
+  applyColorTheme(themeId);
+}
+
 export function loadTheme(): ThemeMode {
   const theme = readStoredTheme();
   applyTheme(theme);
+  const colorTheme = readStoredColorTheme();
+  applyColorTheme(colorTheme);
   return theme;
 }
 
 export function saveTheme(theme: ThemeMode) {
   try {
     browserWindow()?.localStorage.setItem(THEME_KEY, theme);
-  } catch {
-    // localStorage can be unavailable in privacy-restricted contexts.
-  }
+  } catch {}
   applyTheme(theme);
+  const colorTheme = readStoredColorTheme();
+  applyColorTheme(colorTheme);
 }

--- a/frontend/src/themes/midnight-teal.ts
+++ b/frontend/src/themes/midnight-teal.ts
@@ -1,0 +1,30 @@
+import type { ThemeDefinition } from './types';
+
+export const midnightTeal: ThemeDefinition = {
+  id: 'midnight-teal',
+  name: 'Midnight Teal',
+  description: 'Deep navy background with teal accents — darker Oracle vibe',
+  light: {
+    '--color-bg': 'oklch(0.96 0.006 220)',
+    '--color-accent': 'oklch(0.45 0.12 178)',
+    '--color-accent2': 'oklch(0.50 0.18 300)',
+    '--color-accent-solid': 'oklch(0.72 0.14 178)',
+    '--color-accent-hover': 'oklch(0.80 0.10 178)',
+    '--color-accent-soft': 'oklch(0.92 0.06 178 / 0.72)',
+    '--color-accent-border': 'oklch(0.45 0.12 178 / 0.36)',
+    '--glass-bg': 'oklch(1 0 0 / 0.52)',
+    '--glass-border': 'oklch(0.45 0.12 178 / 0.20)',
+  },
+  dark: {
+    '--color-bg': 'oklch(0.08 0.02 265)',
+    '--color-surface': 'oklch(0.15 0.02 260 / 0.7)',
+    '--color-surface-muted': 'oklch(0.19 0.02 260 / 0.58)',
+    '--color-accent': 'oklch(0.82 0.13 178)',
+    '--color-accent2': 'oklch(0.78 0.16 300)',
+    '--color-accent-solid': 'oklch(0.82 0.13 178)',
+    '--color-accent-hover': 'oklch(0.88 0.10 178)',
+    '--glass-bg': 'oklch(0.12 0.02 265 / 0.40)',
+    '--glass-border': 'oklch(1 0 0 / 0.06)',
+    '--glass-shadow': '0 8px 36px oklch(0 0 0 / 0.5)',
+  },
+};

--- a/frontend/src/themes/oracle-default.ts
+++ b/frontend/src/themes/oracle-default.ts
@@ -1,0 +1,9 @@
+import type { ThemeDefinition } from './types';
+
+export const oracleDefault: ThemeDefinition = {
+  id: 'oracle-default',
+  name: 'Oracle Default',
+  description: 'The original teal and purple glassmorphism theme',
+  light: {},
+  dark: {},
+};

--- a/frontend/src/themes/registry.ts
+++ b/frontend/src/themes/registry.ts
@@ -1,0 +1,23 @@
+import type { ThemeDefinition } from './types';
+import { oracleDefault } from './oracle-default';
+import { midnightTeal } from './midnight-teal';
+
+const all: ThemeDefinition[] = [oracleDefault, midnightTeal];
+
+const byId = new Map(all.map((t) => [t.id, t]));
+
+export function getThemes(): ThemeDefinition[] {
+  return all;
+}
+
+export function getTheme(id: string): ThemeDefinition | undefined {
+  return byId.get(id);
+}
+
+export function registerTheme(theme: ThemeDefinition): void {
+  if (byId.has(theme.id)) return;
+  all.push(theme);
+  byId.set(theme.id, theme);
+}
+
+export const DEFAULT_THEME_ID = 'oracle-default';

--- a/frontend/src/themes/types.ts
+++ b/frontend/src/themes/types.ts
@@ -1,0 +1,42 @@
+export type ThemeTokens = {
+  '--color-bg': string;
+  '--color-surface': string;
+  '--color-surface-muted': string;
+  '--color-field': string;
+  '--color-border': string;
+  '--color-text': string;
+  '--color-text-muted': string;
+  '--color-accent': string;
+  '--color-accent2': string;
+  '--color-accent2-soft': string;
+  '--color-accent2-border': string;
+  '--color-accent2-solid': string;
+  '--color-accent2-hover': string;
+  '--color-accent-soft': string;
+  '--color-accent-border': string;
+  '--color-accent-solid': string;
+  '--color-accent-hover': string;
+  '--color-on-accent': string;
+  '--color-ok-bg': string;
+  '--color-ok-text': string;
+  '--color-ok-border': string;
+  '--color-warn-bg': string;
+  '--color-warn-text': string;
+  '--color-warn-border': string;
+  '--color-err-bg': string;
+  '--color-err-text': string;
+  '--color-err-border': string;
+  '--glass-bg': string;
+  '--glass-border': string;
+  '--glass-shadow': string;
+  '--glass-blur': string;
+};
+
+export type ThemeDefinition = {
+  id: string;
+  name: string;
+  description: string;
+  author?: string;
+  light: Partial<ThemeTokens>;
+  dark: Partial<ThemeTokens>;
+};


### PR DESCRIPTION
## Summary
- Theme plugin system: swappable color themes with CSS custom property overrides
- `ThemeDefinition` type with light/dark token variants
- Registry with `getThemes()`, `getTheme()`, `registerTheme()`
- `ThemeSelector` component with live preview on hover, glass dropdown
- Extended `theme.ts` with color theme persistence (`ARRA_FRONTEND_COLOR_THEME`)
- Ships with `oracle-default` (no overrides) and `midnight-teal` as first example theme
- 20 more theme issues created (#2546–#2565) for coders to implement

## Test plan
- [ ] Theme selector appears in header between TauriBadge and ThemeToggle
- [ ] Hovering a theme in the dropdown previews it live
- [ ] Clicking a theme applies it and persists to localStorage
- [ ] Light/dark toggle still works independently of color theme
- [ ] Page reload restores the last selected theme

Closes #2545

🤖 Generated with [Claude Code](https://claude.com/claude-code)