### PR TITLE
refactor(frontend): theme registry — eliminate parallel merge conflicts

### DIFF
--- a/frontend/src/components/ThemeSelector.tsx
+++ b/frontend/src/components/ThemeSelector.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { getThemes } from '../themes/registry';
+import { getThemes } from '../themes/index';
 import { applyColorTheme, clearColorThemeOverrides, readStoredColorTheme, saveColorTheme } from '../theme';
 
 export function ThemeSelector() {

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_THEME_ID, getTheme } from './themes/registry';
+import { DEFAULT_THEME_ID, getTheme } from './themes/index';
 
 export type ThemeMode = 'light' | 'dark';
 

--- a/frontend/src/themes/index.ts
+++ b/frontend/src/themes/index.ts
@@ -1,0 +1,13 @@
+import { registerTheme } from './registry';
+import { oracleDefault } from './oracle-default';
+import { midnightTeal } from './midnight-teal';
+import { emeraldNoir } from './emerald-noir';
+import { sakura } from './sakura';
+
+registerTheme(oracleDefault);
+registerTheme(midnightTeal);
+registerTheme(emeraldNoir);
+registerTheme(sakura);
+
+export { getThemes, getTheme, DEFAULT_THEME_ID } from './registry';
+export type { ThemeDefinition, ThemeTokens } from './types';

--- a/frontend/src/themes/registry.ts
+++ b/frontend/src/themes/registry.ts
@@ -1,12 +1,13 @@
 import type { ThemeDefinition } from './types';
-import { oracleDefault } from './oracle-default';
-import { midnightTeal } from './midnight-teal';
-import { emeraldNoir } from './emerald-noir';
-import { sakura } from './sakura';
 
-const all: ThemeDefinition[] = [oracleDefault, midnightTeal, emeraldNoir, sakura];
+const all: ThemeDefinition[] = [];
+const byId = new Map<string, ThemeDefinition>();
 
-const byId = new Map(all.map((t) => [t.id, t]));
+export function registerTheme(theme: ThemeDefinition): void {
+  if (byId.has(theme.id)) return;
+  all.push(theme);
+  byId.set(theme.id, theme);
+}
 
 export function getThemes(): ThemeDefinition[] {
   return all;
@@ -14,12 +15,6 @@ export function getThemes(): ThemeDefinition[] {
 
 export function getTheme(id: string): ThemeDefinition | undefined {
   return byId.get(id);
-}
-
-export function registerTheme(theme: ThemeDefinition): void {
-  if (byId.has(theme.id)) return;
-  all.push(theme);
-  byId.set(theme.id, theme);
 }
 
 export const DEFAULT_THEME_ID = 'oracle-default';


### PR DESCRIPTION
Coders adding themes in parallel all edited registry.ts → conflicts. Now: registry.ts is import-free (just API), index.ts centralizes imports. Theme PRs only touch their own file + one line in index.ts.