### PR TITLE
feat(cors): wildcard *.buildwithoracle.com + PNA ghost popup guide

### DIFF
--- a/frontend/src/components/BackendGate.tsx
+++ b/frontend/src/components/BackendGate.tsx
@@ -76,12 +76,29 @@ function PnaGuide({ retryCount }: { retryCount: number }) {
     );
   }
   return (
-    <div className="pna-beacon pointer-events-none fixed left-[410px] top-[165px] z-50 grid -translate-x-1/2 justify-items-center gap-2" aria-hidden="true">
-      <svg className="text-accent-solid" width="28" height="40" viewBox="0 0 28 40">
-        <path d="M14 38 L14 8 M5 16 L14 8 L23 16" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" fill="none" />
-      </svg>
-      <div className="rounded-xl bg-accent-solid px-3 py-2 text-xs font-semibold text-on-accent shadow-lg">
-        Click <strong>Allow</strong> in the popup above
+    <div className="pna-beacon pointer-events-none fixed left-[90px] top-[10px] z-50 w-[330px] max-w-[calc(100vw-2rem)]" aria-hidden="true">
+      <div className="rounded-2xl border-2 border-dashed border-accent-solid/50 bg-[oklch(0.24_0.01_260/0.9)] p-4 shadow-2xl backdrop-blur-sm">
+        <div className="flex items-start justify-between gap-3">
+          <p className="text-sm font-semibold text-white">v4.buildwithoracle.com wants to</p>
+          <span className="text-sm text-white/50">✕</span>
+        </div>
+        <div className="mt-2 flex items-center gap-3 text-xs text-white/70">
+          <svg className="h-4 w-4 shrink-0" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5"><rect x="2.5" y="4" width="15" height="10" rx="1.5" /><path d="M7 17h6" strokeLinecap="round" /></svg>
+          Access other apps and services on this device
+        </div>
+        <div className="mt-3 flex items-center justify-end gap-2">
+          <span className="rounded-full bg-white/10 px-4 py-1.5 text-xs font-semibold text-white/80">Block</span>
+          <span className="animate-pulse rounded-full bg-accent-solid px-4 py-1.5 text-xs font-bold text-on-accent ring-2 ring-accent-solid/70">Allow</span>
+        </div>
+      </div>
+      <div className="mt-2 flex w-full items-center justify-between gap-3 rounded-xl bg-accent-solid/90 px-4 py-2.5 shadow-lg">
+        <p className="text-left text-xs font-semibold leading-snug text-on-accent">
+          The real Chrome prompt appears here.
+          <br />No prompt? Press <strong>Retry</strong> below.
+        </p>
+        <svg className="mr-2 shrink-0 text-on-accent" width="22" height="30" viewBox="0 0 22 30" aria-hidden="true">
+          <path d="M11 28 L11 6 M3 13 L11 5 L19 13" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+        </svg>
       </div>
     </div>
   );

--- a/frontend/src/components/BackendGate.tsx
+++ b/frontend/src/components/BackendGate.tsx
@@ -62,7 +62,7 @@ async function tauriHealthCheck(): Promise<void> {
     throw new Error(`health_check returned ${String(status)}`);
 }
 
-function PnaGuide({ retryCount }: { retryCount: number }) {
+function PnaGuide({ retryCount, onRetry }: { retryCount: number; onRetry: () => void }) {
   if (retryCount >= 3) {
     return (
       <div className="pna-beacon pointer-events-none fixed left-[165px] top-[52px] z-50 grid -translate-x-1/2 justify-items-center gap-2" aria-hidden="true">
@@ -76,8 +76,8 @@ function PnaGuide({ retryCount }: { retryCount: number }) {
     );
   }
   return (
-    <div className="pna-beacon pointer-events-none fixed left-[90px] top-[10px] z-50 w-[330px] max-w-[calc(100vw-2rem)]" aria-hidden="true">
-      <div className="rounded-2xl border-2 border-dashed border-accent-solid/50 bg-[oklch(0.24_0.01_260/0.9)] p-4 shadow-2xl backdrop-blur-sm">
+    <div className="pna-beacon fixed left-[147px] top-[10px] z-50 w-[330px] max-w-[calc(100vw-2rem)]">
+      <div className="pointer-events-none rounded-2xl border-2 border-dashed border-accent-solid/50 bg-[oklch(0.24_0.01_260/0.9)] p-4 shadow-2xl backdrop-blur-sm" aria-hidden="true">
         <div className="flex items-start justify-between gap-3">
           <p className="text-sm font-semibold text-white">v4.buildwithoracle.com wants to</p>
           <span className="text-sm text-white/50">✕</span>
@@ -94,7 +94,14 @@ function PnaGuide({ retryCount }: { retryCount: number }) {
       <div className="mt-2 flex w-full items-center justify-between gap-3 rounded-xl bg-accent-solid/90 px-4 py-2.5 shadow-lg">
         <p className="text-left text-xs font-semibold leading-snug text-on-accent">
           The real Chrome prompt appears here.
-          <br />No prompt? Press <strong>Retry</strong> below.
+          <br />No prompt?
+          <button
+            className="focus-ring ml-2 inline-block rounded-full bg-[oklch(0.20_0.02_260)] px-4 py-1.5 text-xs font-bold text-white transition hover:bg-[oklch(0.28_0.02_260)]"
+            type="button"
+            onClick={onRetry}
+          >
+            Retry
+          </button>
         </p>
         <svg className="mr-2 shrink-0 text-on-accent" width="22" height="30" viewBox="0 0 22 30" aria-hidden="true">
           <path d="M11 28 L11 6 M3 13 L11 5 L19 13" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" fill="none" />
@@ -133,7 +140,7 @@ export function ConnectOracleSetup({
 
   return (
     <main className="connect-shell flex min-h-screen items-center justify-center p-6 text-text">
-      {showGuide ? <PnaGuide retryCount={retryCount} /> : null}
+      {showGuide ? <PnaGuide retryCount={retryCount} onRetry={onRetry} /> : null}
       <section className="connect-glass w-full max-w-xl rounded-3xl p-8">
         <div className="mb-6 flex flex-col items-center gap-4 text-center sm:flex-row sm:text-left">
           <div className="flex h-20 w-20 items-center justify-center rounded-[1.35rem] bg-[oklch(0.12_0.02_265)] text-5xl drop-shadow-[0_0_20px_oklch(0.60_0.15_300/0.5)]" aria-hidden="true">

--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -16,6 +16,7 @@ const DEFAULT_ORIGINS = [
   'https://arra-oracle-studio.laris.workers.dev',
   'https://studio.buildwithoracle.com',
   'https://feed.buildwithoracle.com',
+  'https://v4.buildwithoracle.com',
 ] as const;
 const ALLOWED_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'] as const;
 const ALLOWED_HEADERS = [
@@ -86,9 +87,22 @@ export function parseCorsOrigins(value = configuredOrigins()): CorsPolicy {
   };
 }
 
+const TRUSTED_ORIGIN_SUFFIX = '.buildwithoracle.com';
+
+function isTrustedSubdomain(origin: string): boolean {
+  try {
+    const url = new URL(origin);
+    return url.protocol === 'https:' && (url.hostname.endsWith(TRUSTED_ORIGIN_SUFFIX) || url.hostname === TRUSTED_ORIGIN_SUFFIX.slice(1));
+  } catch {
+    return false;
+  }
+}
+
 export function allowedCorsOrigin(origin: string | null | undefined, policy = parseCorsOrigins()): string | null {
   const normalized = origin ? normalizeOrigin(origin) : null;
-  return normalized && policy.origins.includes(normalized) ? normalized : null;
+  if (!normalized) return null;
+  if (policy.origins.includes(normalized)) return normalized;
+  return isTrustedSubdomain(normalized) ? normalized : null;
 }
 
 type MutableHeaders = Record<string, string | number | string[]>;


### PR DESCRIPTION
## Summary
- **CORS wildcard**: any `https://*.buildwithoracle.com` origin is trusted automatically — no more manual DEFAULT_ORIGINS edits per subdomain (v4. was missing → CORS error on localhost connect, see screenshot in session)
- **PNA ghost popup mockup**: full mockup of Chrome's PNA dialog at the real prompt position (pixel-calibrated). Real prompt overlays it; if absent, user sees what's missing
- **Inline Retry button** in the guide — re-fires the health fetch (re-triggers the PNA prompt) without scrolling down
- Blocked-state fallback (≥3 retries) points at the URL-bar site icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)