### PR TITLE
fix(reflect): split LEFT JOIN to prevent Bun crash on 35k docs

### DIFF
--- a/src/routes/search/reflect.ts
+++ b/src/routes/search/reflect.ts
@@ -23,13 +23,15 @@ function handleGlobalReflect(): Record<string, unknown> {
     const total = Number(count?.total ?? 0);
     if (total < 1) return { error: 'No documents found', fts_status: 'empty' };
 
-    const row = sqlite.prepare(`
-      SELECT d.id, d.type, d.source_file, d.concepts, f.content
-      FROM oracle_documents d
-      LEFT JOIN oracle_fts f ON d.id = f.id
-      WHERE d.type IN ('principle', 'learning')
+    const doc = sqlite.prepare(`
+      SELECT id, type, source_file, concepts
+      FROM oracle_documents
+      WHERE type IN ('principle', 'learning')
       LIMIT 1 OFFSET ?
-    `).get(randomOffset(total)) as ReflectRow | undefined;
+    `).get(randomOffset(total)) as { id: string; type: string; source_file: string; concepts: string | null } | undefined;
+    if (!doc) return { error: 'No documents found', fts_status: 'empty' };
+    const fts = sqlite.prepare(`SELECT content FROM oracle_fts WHERE id = ?`).get(doc.id) as { content: string } | undefined;
+    const row: ReflectRow = { ...doc, content: fts?.content ?? null };
 
     if (!row) return { error: 'No documents found', fts_status: 'empty' };
     const base = {


### PR DESCRIPTION
LEFT JOIN oracle_fts with OFFSET on 35k docs crashes Bun 1.3.13. Split into two queries: doc lookup (fast) then FTS content by id (single row). Same result, no crash.