### PR TITLE
fix: migrate search sidecars to Drizzle

### DIFF
--- a/src/search/bitemporal.ts
+++ b/src/search/bitemporal.ts
@@ -1,11 +1,17 @@
+import { and, eq, inArray, or, sql } from 'drizzle-orm';
 import type { Database } from 'bun:sqlite';
+import { drizzle, type BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
+import { alias } from 'drizzle-orm/sqlite-core';
+import * as schema from '../db/schema.ts';
 import { currentTenantId } from '../middleware/tenant.ts';
 import { isoTimestamp } from './timestamp.ts';
 
 export type AsOfParseResult = { ok: true; value?: number } | { ok: false; error: string };
 
 type SearchResultRecord = Record<string, unknown>;
-type TemporalRow = { id: string; valid_time: number | string | null; valid_until: number | string | null };
+type OracleDb = BunSQLiteDatabase<typeof schema>;
+type OracleDbInput = OracleDb | Database;
+type TemporalRow = { id: string; validTime: number | string | null; validUntil: number | string | null };
 
 const validStart = timestampSql('COALESCE(d.valid_time, d.updated_at, d.created_at, d.indexed_at)');
 const validUntil = timestampSql('COALESCE(s.valid_time, d.superseded_at)');
@@ -22,12 +28,26 @@ AND (
   OR ${validUntil} > ?
 )`;
 
+const supersedingDocuments = alias(schema.oracleDocuments, 's');
+
 function timestampSql(expr: string): string {
   return `CASE
     WHEN typeof(${expr}) = 'text' AND ${expr} GLOB '*[^0-9]*'
       THEN CAST(strftime('%s', ${expr}) AS INTEGER) * 1000
     ELSE CAST(${expr} AS INTEGER)
   END`;
+}
+
+function timestampExpr(expr: ReturnType<typeof sql>): ReturnType<typeof sql> {
+  return sql`CASE
+    WHEN typeof(${expr}) = 'text' AND ${expr} GLOB '*[^0-9]*'
+      THEN CAST(strftime('%s', ${expr}) AS INTEGER) * 1000
+    ELSE CAST(${expr} AS INTEGER)
+  END`;
+}
+
+function toDb(input: OracleDbInput): OracleDb {
+  return 'prepare' in input ? drizzle(input, { schema }) : input;
 }
 
 export function parseAsOf(raw: string | undefined): AsOfParseResult {
@@ -43,31 +63,52 @@ export function biTemporalParams(asOfMs: number): [number, number] {
 }
 
 export function filterResultsAsOf(
-  sqlite: Database,
+  dbInput: OracleDbInput,
   results: SearchResultRecord[],
   asOfMs: number | undefined,
   tenantId = currentTenantId(),
 ): SearchResultRecord[] {
+  const db = toDb(dbInput);
   if (!asOfMs || results.length === 0) return results;
   const ids = [...new Set(results.map((item) => item.id).filter((id): id is string => typeof id === 'string' && id.length > 0))];
   if (ids.length === 0) return [];
 
-  const placeholders = ids.map(() => '?').join(',');
-  const tenantFilter = tenantId ? 'AND d.tenant_id = ?' : '';
-  const rows = sqlite.prepare(`
-    SELECT d.id, d.valid_time, COALESCE(s.valid_time, d.superseded_at) as valid_until
-    FROM oracle_documents d
-    ${BI_TEMPORAL_JOIN}
-    WHERE d.id IN (${placeholders}) ${tenantFilter} AND ${BI_TEMPORAL_WHERE}
-  `).all(...ids, ...(tenantId ? [tenantId] : []), ...biTemporalParams(asOfMs)) as TemporalRow[];
+  const validStartExpr = timestampExpr(sql`COALESCE(
+    ${schema.oracleDocuments.validTime},
+    ${schema.oracleDocuments.updatedAt},
+    ${schema.oracleDocuments.createdAt},
+    ${schema.oracleDocuments.indexedAt}
+  )`);
+  const validUntilRaw = sql`COALESCE(${supersedingDocuments.validTime}, ${schema.oracleDocuments.supersededAt})`;
+  const validUntilExpr = timestampExpr(validUntilRaw);
+  const rows = db.select({
+    id: schema.oracleDocuments.id,
+    validTime: schema.oracleDocuments.validTime,
+    validUntil: validUntilRaw,
+  }).from(schema.oracleDocuments)
+    .leftJoin(supersedingDocuments, and(
+      eq(schema.oracleDocuments.supersededBy, supersedingDocuments.id),
+      eq(supersedingDocuments.tenantId, schema.oracleDocuments.tenantId),
+    ))
+    .where(and(
+      inArray(schema.oracleDocuments.id, ids),
+      ...(tenantId ? [eq(schema.oracleDocuments.tenantId, tenantId)] : []),
+      sql`${validStartExpr} <= ${asOfMs}`,
+      or(
+        sql`${schema.oracleDocuments.supersededBy} IS NULL`,
+        sql`${validUntilRaw} IS NULL`,
+        sql`${validUntilExpr} > ${asOfMs}`,
+      ),
+    ))
+    .all() as TemporalRow[];
 
   const temporal = new Map(rows.map((row) => [row.id, row]));
   return results.filter((item) => {
     if (typeof item.id !== 'string') return false;
     const row = temporal.get(item.id);
     if (!row) return false;
-    item.valid_time = isoTimestamp(row.valid_time);
-    item.valid_until = isoTimestamp(row.valid_until);
+    item.valid_time = isoTimestamp(row.validTime);
+    item.valid_until = isoTimestamp(row.validUntil);
     return true;
   });
 }

--- a/src/search/entity-ranking.ts
+++ b/src/search/entity-ranking.ts
@@ -1,4 +1,8 @@
+import { and, eq, inArray } from 'drizzle-orm';
 import type { Database } from 'bun:sqlite';
+import { drizzle } from 'drizzle-orm/bun-sqlite';
+import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
+import * as schema from '../db/schema.ts';
 import { extractEntities } from '../vector/entities.ts';
 
 const ENTITY_BOOST_PER_MATCH = 0.08;
@@ -7,7 +11,8 @@ const MAX_ENTITY_QUERY_KEYS = 16;
 const MAX_RANKING_CANDIDATES = 100;
 const QUERY_STOPWORDS = new Set(['a', 'an', 'and', 'are', 'but', 'for', 'from', 'how', 'the', 'this', 'that', 'what', 'when', 'where', 'with', 'why']);
 
-type SqliteLike = Pick<Database, 'prepare'>;
+type OracleDb = BunSQLiteDatabase<typeof schema>;
+type OracleDbInput = OracleDb | Database;
 export type EntityLinkRecord = {
   id: string;
   tenantId: string;
@@ -54,44 +59,57 @@ export function entityLinksForDocument(input: {
   }));
 }
 
-export function replaceEntityLinks(sqlite: SqliteLike, input: Parameters<typeof entityLinksForDocument>[0]): void {
+function toDb(input: OracleDbInput): OracleDb {
+  return 'prepare' in input ? drizzle(input, { schema }) : input;
+}
+
+export function replaceEntityLinks(dbInput: OracleDbInput, input: Parameters<typeof entityLinksForDocument>[0]): void {
+  const db = toDb(dbInput);
   const links = entityLinksForDocument(input);
   const tenantId = input.tenantId?.trim() || 'default';
   try {
-    sqlite.prepare('DELETE FROM oracle_entity_links WHERE tenant_id = ? AND document_id = ?')
-      .run(tenantId, input.documentId);
-    const insert = sqlite.prepare(`
-      INSERT INTO oracle_entity_links (id, tenant_id, document_id, entity, entity_key, weight, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-    `);
-    for (const link of links) {
-      insert.run(link.id, link.tenantId, link.documentId, link.entity, link.entityKey, link.weight, link.createdAt, link.updatedAt);
-    }
+    db.delete(schema.oracleEntityLinks)
+      .where(and(
+        eq(schema.oracleEntityLinks.tenantId, tenantId),
+        eq(schema.oracleEntityLinks.documentId, input.documentId),
+      ))
+      .run();
+    if (links.length > 0) db.insert(schema.oracleEntityLinks).values(links).run();
   } catch (error) {
     if (!isMissingEntityTable(error)) throw error;
   }
 }
 
 export function rerankByEntityLinks<T extends Rankable>(
-  sqlite: SqliteLike,
+  dbInput: OracleDbInput,
   results: T[],
   query: string,
   tenantId?: string,
 ): Array<T & EntityRankFields> {
+  const db = toDb(dbInput);
   const ids = results.map((result) => result.id).filter(Boolean).slice(0, MAX_RANKING_CANDIDATES);
   const keys = entityKeysForQuery(query);
   if (ids.length === 0 || keys.length === 0) return results;
 
   const linkMap = new Map<string, Map<string, LinkRow>>();
   try {
-    const keyPlaceholders = keys.map(() => '?').join(',');
-    const idPlaceholders = ids.map(() => '?').join(',');
-    const tenantClause = tenantId ? ' AND tenant_id = ?' : '';
-    const rows = sqlite.prepare(`
-      SELECT document_id AS documentId, entity, entity_key AS entityKey, weight
-      FROM oracle_entity_links
-      WHERE entity_key IN (${keyPlaceholders}) AND document_id IN (${idPlaceholders})${tenantClause}
-    `).all(...keys, ...ids, ...(tenantId ? [tenantId] : [])) as LinkRow[];
+    const rows = db.select({
+      documentId: schema.oracleEntityLinks.documentId,
+      entity: schema.oracleEntityLinks.entity,
+      entityKey: schema.oracleEntityLinks.entityKey,
+      weight: schema.oracleEntityLinks.weight,
+    }).from(schema.oracleEntityLinks)
+      .where(tenantId
+        ? and(
+          inArray(schema.oracleEntityLinks.entityKey, keys),
+          inArray(schema.oracleEntityLinks.documentId, ids),
+          eq(schema.oracleEntityLinks.tenantId, tenantId),
+        )
+        : and(
+          inArray(schema.oracleEntityLinks.entityKey, keys),
+          inArray(schema.oracleEntityLinks.documentId, ids),
+        ))
+      .all();
     for (const row of rows) {
       const docLinks = linkMap.get(row.documentId) ?? new Map<string, LinkRow>();
       docLinks.set(row.entityKey, row);

--- a/src/search/pointer-index.ts
+++ b/src/search/pointer-index.ts
@@ -1,12 +1,23 @@
+import { and, eq, inArray, isNull, or, type SQL } from 'drizzle-orm';
 import type { Database } from 'bun:sqlite';
+import { drizzle, type BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
+import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import * as schema from '../db/schema.ts';
 import { extractEntities } from '../vector/entities.ts';
 import { entityKey } from './entity-ranking.ts';
 
-type SqliteLike = Pick<Database, 'prepare'>;
+type OracleDb = BunSQLiteDatabase<typeof schema>;
+type OracleDbInput = OracleDb | Database;
 type PointerKind = 'topic' | 'entity' | 'date';
 type Pointer = { kind: PointerKind; key: string; label: string };
-type PointerRow = { id: string; kind: PointerKind; key: string; doc_ids: string };
-type DocRow = { id: string; type: string; source_file: string; concepts: string | null; content: string | null };
+type PointerRow = { id: string; kind: PointerKind; key: string; docIds: string };
+type DocRow = { id: string; type: string; sourceFile: string; concepts: string | null; content: string | null };
+
+const oracleFts = sqliteTable('oracle_fts', {
+  id: text('id'),
+  content: text('content'),
+  concepts: text('concepts'),
+});
 
 export type PointerInput = {
   documentId: string;
@@ -26,6 +37,10 @@ export type PointerSearchOptions = {
 const STOPWORDS = new Set(['and', 'are', 'for', 'from', 'into', 'the', 'this', 'that', 'with', 'what', 'when', 'where']);
 const KIND_WEIGHT: Record<PointerKind, number> = { entity: 0.55, topic: 0.35, date: 0.25 };
 
+function toDb(input: OracleDbInput): OracleDb {
+  return 'prepare' in input ? drizzle(input, { schema }) : input;
+}
+
 export function documentPointers(input: PointerInput): Pointer[] {
   return uniquePointers([
     ...conceptValues(input.concepts).map((topic) => pointer('topic', topic)),
@@ -34,56 +49,75 @@ export function documentPointers(input: PointerInput): Pointer[] {
   ]);
 }
 
-export function replaceDocumentPointers(sqlite: SqliteLike, input: PointerInput): void {
+export function replaceDocumentPointers(dbInput: OracleDbInput, input: PointerInput): void {
   try {
+    const db = toDb(dbInput);
     const tenantId = input.tenantId?.trim() || 'default';
-    removeDocumentPointers(sqlite, tenantId, [input.documentId]);
-    const select = sqlite.prepare('SELECT doc_ids FROM oracle_pointer_index WHERE id = ?');
-    const upsert = sqlite.prepare(`
-      INSERT INTO oracle_pointer_index (id, tenant_id, kind, key, doc_ids, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?)
-      ON CONFLICT(id) DO UPDATE SET doc_ids = excluded.doc_ids, updated_at = excluded.updated_at
-    `);
+    removeDocumentPointers(db, tenantId, [input.documentId]);
     const now = Date.now();
     for (const item of documentPointers(input)) {
       const id = pointerId(tenantId, item.kind, item.key);
-      const existing = parseIds((select.get(id) as { doc_ids?: string } | undefined)?.doc_ids);
+      const existingRow = db.select({ docIds: schema.oraclePointerIndex.docIds })
+        .from(schema.oraclePointerIndex)
+        .where(eq(schema.oraclePointerIndex.id, id))
+        .get();
+      const existing = parseIds(existingRow?.docIds);
       const docIds = [...new Set([...existing, input.documentId])].sort();
-      upsert.run(id, tenantId, item.kind, item.key, JSON.stringify(docIds), now);
+      db.insert(schema.oraclePointerIndex)
+        .values({ id, tenantId, kind: item.kind, key: item.key, docIds: JSON.stringify(docIds), updatedAt: now })
+        .onConflictDoUpdate({
+          target: schema.oraclePointerIndex.id,
+          set: { docIds: JSON.stringify(docIds), updatedAt: now },
+        })
+        .run();
     }
   } catch (error) {
     if (!missingPointerTable(error)) throw error;
   }
 }
 
-export function removeDocumentPointers(sqlite: SqliteLike, tenantId: string | undefined, documentIds: string[]): void {
+export function removeDocumentPointers(dbInput: OracleDbInput, tenantId: string | undefined, documentIds: string[]): void {
   if (documentIds.length === 0) return;
   try {
+    const db = toDb(dbInput);
     const tenant = tenantId?.trim() || 'default';
-    const rows = sqlite.prepare('SELECT id, kind, key, doc_ids FROM oracle_pointer_index WHERE tenant_id = ?').all(tenant) as PointerRow[];
-    const update = sqlite.prepare('UPDATE oracle_pointer_index SET doc_ids = ?, updated_at = ? WHERE id = ?');
-    const del = sqlite.prepare('DELETE FROM oracle_pointer_index WHERE id = ?');
+    const rows = db.select({
+      id: schema.oraclePointerIndex.id,
+      kind: schema.oraclePointerIndex.kind,
+      key: schema.oraclePointerIndex.key,
+      docIds: schema.oraclePointerIndex.docIds,
+    }).from(schema.oraclePointerIndex)
+      .where(eq(schema.oraclePointerIndex.tenantId, tenant))
+      .all() as PointerRow[];
     const remove = new Set(documentIds);
     const now = Date.now();
     for (const row of rows) {
-      const next = parseIds(row.doc_ids).filter((id) => !remove.has(id));
-      if (next.length === 0) del.run(row.id);
-      else if (next.length !== parseIds(row.doc_ids).length) update.run(JSON.stringify(next), now, row.id);
+      const existing = parseIds(row.docIds);
+      const next = existing.filter((id) => !remove.has(id));
+      if (next.length === 0) {
+        db.delete(schema.oraclePointerIndex).where(eq(schema.oraclePointerIndex.id, row.id)).run();
+      } else if (next.length !== existing.length) {
+        db.update(schema.oraclePointerIndex)
+          .set({ docIds: JSON.stringify(next), updatedAt: now })
+          .where(eq(schema.oraclePointerIndex.id, row.id))
+          .run();
+      }
     }
   } catch (error) {
     if (!missingPointerTable(error)) throw error;
   }
 }
 
-export function queryPointerIndex(sqlite: SqliteLike, options: PointerSearchOptions): PointerSearchResult[] {
+export function queryPointerIndex(dbInput: OracleDbInput, options: PointerSearchOptions): PointerSearchResult[] {
+  const db = toDb(dbInput);
   const limit = Math.max(1, Math.min(100, Math.trunc(options.limit ?? 10)));
   const tenantId = options.tenantId?.trim() || 'default';
   const keys = queryPointers(options.query);
   if (keys.length === 0) return [];
   try {
-    const rows = lookupPointerRows(sqlite, tenantId, keys);
+    const rows = lookupPointerRows(db, tenantId, keys);
     const ranked = rankDocs(rows, keys);
-    return hydratePointerDocs(sqlite, ranked, { ...options, tenantId, limit });
+    return hydratePointerDocs(db, ranked, { ...options, tenantId, limit });
   } catch (error) {
     if (missingPointerTable(error)) return [];
     throw error;
@@ -102,12 +136,21 @@ export function queryPointers(query: string): Pointer[] {
   ]).slice(0, 24);
 }
 
-function lookupPointerRows(sqlite: SqliteLike, tenantId: string, keys: Pointer[]): PointerRow[] {
-  const clauses = keys.map(() => '(kind = ? AND key = ?)').join(' OR ');
-  if (!clauses) return [];
-  const params = keys.flatMap((item) => [item.kind, item.key]);
-  return sqlite.prepare(`SELECT id, kind, key, doc_ids FROM oracle_pointer_index WHERE tenant_id = ? AND (${clauses})`)
-    .all(tenantId, ...params) as PointerRow[];
+function lookupPointerRows(db: OracleDb, tenantId: string, keys: Pointer[]): PointerRow[] {
+  const clauses = keys.map((item) => and(
+    eq(schema.oraclePointerIndex.kind, item.kind),
+    eq(schema.oraclePointerIndex.key, item.key),
+  )).filter((clause): clause is SQL => clause !== undefined);
+  const pointerMatch = or(...clauses);
+  if (!pointerMatch) return [];
+  return db.select({
+    id: schema.oraclePointerIndex.id,
+    kind: schema.oraclePointerIndex.kind,
+    key: schema.oraclePointerIndex.key,
+    docIds: schema.oraclePointerIndex.docIds,
+  }).from(schema.oraclePointerIndex)
+    .where(and(eq(schema.oraclePointerIndex.tenantId, tenantId), pointerMatch))
+    .all() as PointerRow[];
 }
 
 function rankDocs(rows: PointerRow[], wanted: Pointer[]): Map<string, { score: number; matches: string[] }> {
@@ -115,7 +158,7 @@ function rankDocs(rows: PointerRow[], wanted: Pointer[]): Map<string, { score: n
   const ranked = new Map<string, { score: number; matches: string[] }>();
   for (const row of rows) {
     const label = wantedLabels.get(`${row.kind}:${row.key}`) ?? row.key;
-    for (const docId of parseIds(row.doc_ids)) {
+    for (const docId of parseIds(row.docIds)) {
       const hit = ranked.get(docId) ?? { score: 0, matches: [] };
       hit.score += KIND_WEIGHT[row.kind];
       if (!hit.matches.includes(label)) hit.matches.push(label);
@@ -125,17 +168,25 @@ function rankDocs(rows: PointerRow[], wanted: Pointer[]): Map<string, { score: n
   return ranked;
 }
 
-function hydratePointerDocs(sqlite: SqliteLike, ranked: Map<string, { score: number; matches: string[] }>, options: Required<Pick<PointerSearchOptions, 'tenantId' | 'limit'>> & PointerSearchOptions): PointerSearchResult[] {
+function hydratePointerDocs(db: OracleDb, ranked: Map<string, { score: number; matches: string[] }>, options: Required<Pick<PointerSearchOptions, 'tenantId' | 'limit'>> & PointerSearchOptions): PointerSearchResult[] {
   const ids = [...ranked.keys()];
   if (ids.length === 0) return [];
-  const placeholders = ids.map(() => '?').join(',');
-  const typeFilter = options.type && options.type !== 'all' ? ' AND d.type = ?' : '';
-  const projectFilter = options.project ? ' AND (d.project = ? OR d.project IS NULL)' : '';
-  const rows = sqlite.prepare(`
-    SELECT d.id, d.type, d.source_file, d.concepts, f.content
-    FROM oracle_documents d LEFT JOIN oracle_fts f ON f.id = d.id
-    WHERE d.tenant_id = ? AND d.id IN (${placeholders})${typeFilter}${projectFilter}
-  `).all(options.tenantId, ...ids, ...(options.type && options.type !== 'all' ? [options.type] : []), ...(options.project ? [options.project] : [])) as DocRow[];
+  const filters = [
+    eq(schema.oracleDocuments.tenantId, options.tenantId),
+    inArray(schema.oracleDocuments.id, ids),
+    ...(options.type && options.type !== 'all' ? [eq(schema.oracleDocuments.type, options.type)] : []),
+    ...(options.project ? [or(eq(schema.oracleDocuments.project, options.project), isNull(schema.oracleDocuments.project))] : []),
+  ];
+  const rows = db.select({
+    id: schema.oracleDocuments.id,
+    type: schema.oracleDocuments.type,
+    sourceFile: schema.oracleDocuments.sourceFile,
+    concepts: schema.oracleDocuments.concepts,
+    content: oracleFts.content,
+  }).from(schema.oracleDocuments)
+    .leftJoin(oracleFts, eq(oracleFts.id, schema.oracleDocuments.id))
+    .where(and(...filters))
+    .all() as DocRow[];
   return rows.map((row) => {
     const hit = ranked.get(row.id)!;
     const pointerScore = clamp(hit.score / 1.4);
@@ -143,7 +194,7 @@ function hydratePointerDocs(sqlite: SqliteLike, ranked: Map<string, { score: num
       id: row.id,
       type: row.type,
       content: (row.content ?? '').slice(0, 500),
-      source_file: row.source_file,
+      source_file: row.sourceFile,
       concepts: conceptValues(row.concepts),
       score: pointerScore,
       source: 'pointer' as const,

--- a/src/search/supersede-status.ts
+++ b/src/search/supersede-status.ts
@@ -1,14 +1,19 @@
+import { and, eq, inArray, isNotNull } from 'drizzle-orm';
 import type { Database } from 'bun:sqlite';
+import { drizzle, type BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
+import * as schema from '../db/schema.ts';
 import { currentTenantId } from '../middleware/tenant.ts';
 import { isoTimestamp } from './timestamp.ts';
 
 type SearchResultRecord = Record<string, unknown>;
+type OracleDb = BunSQLiteDatabase<typeof schema>;
+type OracleDbInput = OracleDb | Database;
 
 type SupersedeRow = {
   id: string;
-  superseded_by: string;
-  superseded_at: number | string | null;
-  superseded_reason: string | null;
+  supersededBy: string;
+  supersededAt: number | string | null;
+  supersededReason: string | null;
 };
 
 function resultIds(results: SearchResultRecord[]): string[] {
@@ -17,23 +22,33 @@ function resultIds(results: SearchResultRecord[]): string[] {
     .filter((id): id is string => typeof id === 'string' && id.length > 0))];
 }
 
+function toDb(input: OracleDbInput): OracleDb {
+  return 'prepare' in input ? drizzle(input, { schema }) : input;
+}
+
 export function attachSupersedeStatus(
-  sqlite: Database,
+  dbInput: OracleDbInput,
   results: SearchResultRecord[],
   tenantId = currentTenantId(),
 ): void {
+  const db = toDb(dbInput);
   const ids = resultIds(results);
   if (ids.length === 0) return;
 
-  const placeholders = ids.map(() => '?').join(',');
-  const tenantFilter = tenantId ? 'AND tenant_id = ?' : '';
   let rows: SupersedeRow[];
   try {
-    rows = sqlite.prepare(`
-      SELECT id, superseded_by, superseded_at, superseded_reason
-      FROM oracle_documents
-      WHERE id IN (${placeholders}) AND superseded_by IS NOT NULL ${tenantFilter}
-    `).all(...ids, ...(tenantId ? [tenantId] : [])) as SupersedeRow[];
+    rows = db.select({
+      id: schema.oracleDocuments.id,
+      supersededBy: schema.oracleDocuments.supersededBy,
+      supersededAt: schema.oracleDocuments.supersededAt,
+      supersededReason: schema.oracleDocuments.supersededReason,
+    }).from(schema.oracleDocuments)
+      .where(and(
+        inArray(schema.oracleDocuments.id, ids),
+        isNotNull(schema.oracleDocuments.supersededBy),
+        ...(tenantId ? [eq(schema.oracleDocuments.tenantId, tenantId)] : []),
+      ))
+      .all() as SupersedeRow[];
   } catch (error) {
     console.warn('[SupersedeStatus] lookup failed:', error instanceof Error ? error.message : String(error));
     return;
@@ -44,8 +59,8 @@ export function attachSupersedeStatus(
     if (typeof result.id !== 'string') continue;
     const supersede = byId.get(result.id);
     if (!supersede) continue;
-    result.superseded_by = supersede.superseded_by;
-    result.superseded_at = isoTimestamp(supersede.superseded_at);
-    result.superseded_reason = supersede.superseded_reason;
+    result.superseded_by = supersede.supersededBy;
+    result.superseded_at = isoTimestamp(supersede.supersededAt);
+    result.superseded_reason = supersede.supersededReason;
   }
 }


### PR DESCRIPTION
## Summary\n- migrated entity ranking, pointer index, bitemporal filtering, and supersede status helpers from sqlite.prepare calls to Drizzle db queries\n- updated callers to pass Drizzle db handles and refreshed affected search tests\n\n## Validation\n- bunx tsc --noEmit\n- bun test tests/http/search/ src/search/__tests__/pointer-index.test.ts