### PR TITLE
fix(indexer): migrate reindex SQL to Drizzle

### DIFF
--- a/src/db/drizzle-input.ts
+++ b/src/db/drizzle-input.ts
@@ -1,0 +1,10 @@
+import type { Database } from 'bun:sqlite';
+import { drizzle, type BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
+import * as schema from './schema.ts';
+
+export type OracleDb = BunSQLiteDatabase<typeof schema>;
+export type OracleDbInput = OracleDb | Database;
+
+export function asOracleDb(input: OracleDbInput): OracleDb {
+  return 'select' in input ? input as OracleDb : drizzle(input as Database, { schema });
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -16,7 +16,7 @@ export const oracleDocuments = sqliteTable('oracle_documents', {
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
   indexedAt: integer('indexed_at').notNull(),
-  validTime: integer('valid_time').default(sql`null`),
+  validTime: integer('valid_time'),
   supersededBy: text('superseded_by'),
   supersededAt: integer('superseded_at'),
   supersededReason: text('superseded_reason'),

--- a/src/indexer/__tests__/vector-index-manifest.test.ts
+++ b/src/indexer/__tests__/vector-index-manifest.test.ts
@@ -25,14 +25,14 @@ describe('vector index manifest', () => {
   test('first run marks every chunk for embedding and persists hashes', () => {
     const conn = freshDb();
     const docs = [doc('a', 'Alpha'), doc('b', 'Beta')];
-    const before = loadVectorIndexManifest(conn.sqlite, 'bge-m3');
+    const before = loadVectorIndexManifest(conn.db, 'bge-m3');
     const plan = planVectorIndex(docs, before, 'bge-m3', { now: 100 });
 
     expect(plan.changedDocs.map((item) => item.id)).toEqual(['a', 'b']);
     expect(plan.skipped).toBe(0);
 
-    writeVectorIndexManifest(conn.sqlite, plan);
-    const after = loadVectorIndexManifest(conn.sqlite, 'bge-m3');
+    writeVectorIndexManifest(conn.db, plan);
+    const after = loadVectorIndexManifest(conn.db, 'bge-m3');
     expect(after.get('a')?.contentHash).toBe(vectorContentHash(docs[0]));
     expect(after.get('a')?.indexedAt).toBe(100);
   });
@@ -40,14 +40,14 @@ describe('vector index manifest', () => {
   test('unchanged chunks are skipped and one edited chunk is re-indexed', () => {
     const conn = freshDb();
     const initial = [doc('a', 'Alpha'), doc('b', 'Beta')];
-    writeVectorIndexManifest(conn.sqlite, planVectorIndex(initial, new Map(), 'bge-m3', { now: 100 }));
+    writeVectorIndexManifest(conn.db, planVectorIndex(initial, new Map(), 'bge-m3', { now: 100 }));
 
-    const unchanged = planVectorIndex(initial, loadVectorIndexManifest(conn.sqlite, 'bge-m3'), 'bge-m3', { now: 200 });
+    const unchanged = planVectorIndex(initial, loadVectorIndexManifest(conn.db, 'bge-m3'), 'bge-m3', { now: 200 });
     expect(unchanged.changedDocs).toEqual([]);
     expect(unchanged.skipped).toBe(2);
 
     const edited = [doc('a', 'Alpha changed'), doc('b', 'Beta')];
-    const plan = planVectorIndex(edited, loadVectorIndexManifest(conn.sqlite, 'bge-m3'), 'bge-m3', { now: 300 });
+    const plan = planVectorIndex(edited, loadVectorIndexManifest(conn.db, 'bge-m3'), 'bge-m3', { now: 300 });
     expect(plan.changedDocs.map((item) => item.id)).toEqual(['a']);
     expect(plan.entries.find((entry) => entry.chunkId === 'a')?.indexedAt).toBe(300);
     expect(plan.entries.find((entry) => entry.chunkId === 'b')?.indexedAt).toBe(100);
@@ -56,14 +56,14 @@ describe('vector index manifest', () => {
   test('missing chunks are stale and force rebuild marks all chunks changed', () => {
     const conn = freshDb();
     const initial = [doc('a', 'Alpha'), doc('b', 'Beta')];
-    writeVectorIndexManifest(conn.sqlite, planVectorIndex(initial, new Map(), 'nomic', { now: 100 }));
+    writeVectorIndexManifest(conn.db, planVectorIndex(initial, new Map(), 'nomic', { now: 100 }));
 
     const current = [doc('a', 'Alpha')];
-    const plan = planVectorIndex(current, loadVectorIndexManifest(conn.sqlite, 'nomic'), 'nomic', { now: 200 });
+    const plan = planVectorIndex(current, loadVectorIndexManifest(conn.db, 'nomic'), 'nomic', { now: 200 });
     expect(plan.staleIds).toEqual(['b']);
     expect(plan.changedDocs).toEqual([]);
 
-    const forced = planVectorIndex(current, loadVectorIndexManifest(conn.sqlite, 'nomic'), 'nomic', { force: true, now: 300 });
+    const forced = planVectorIndex(current, loadVectorIndexManifest(conn.db, 'nomic'), 'nomic', { force: true, now: 300 });
     expect(forced.changedDocs.map((item) => item.id)).toEqual(['a']);
   });
 });

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -70,7 +70,7 @@ export class OracleIndexer {
     console.log(append ? 'Starting Oracle indexing in append mode...' : 'Starting Oracle indexing...');
     this.seenContentHashes.clear();
 
-    setIndexingStatus(this.sqlite, this.config, true, 0, 100);
+    setIndexingStatus(this.db, this.config, true, 0, 100);
     backupDatabase(this.sqlite, this.config);
 
     // Safety: verify the source directory layout exists. If ψ/memory/ is
@@ -89,7 +89,7 @@ export class OracleIndexer {
       );
     }
 
-    const beforeDocs = snapshotActiveIndexerDocs(this.sqlite, tenantId);
+    const beforeDocs = snapshotActiveIndexerDocs(this.db, tenantId);
 
     // Collect documents from all source types
     const shared = { config: this.config, seenContentHashes: this.seenContentHashes };
@@ -164,10 +164,10 @@ export class OracleIndexer {
     // Store in SQLite + FTS5 first. Vector work is queued afterwards so
     // embedding failures cannot roll back the source-of-truth text index.
     await storeDocuments(this.sqlite, this.db, null, this.project, indexDocuments, { tenantId });
-    const superseded = supersedeReplacedSourceDocs(this.sqlite, indexDocuments, tenantId);
-    const vectorJobs = safeEnqueueVectorJobs(this.sqlite, indexDocuments, changedIds);
+    const superseded = supersedeReplacedSourceDocs(this.db, indexDocuments, tenantId);
+    const vectorJobs = safeEnqueueVectorJobs(this.db, indexDocuments, changedIds);
 
-    setIndexingStatus(this.sqlite, this.config, false, indexDocuments.length, indexDocuments.length);
+    setIndexingStatus(this.db, this.config, false, indexDocuments.length, indexDocuments.length);
     console.log(`Indexed ${indexDocuments.length} chunks (SQLite + FTS5)`);
     if (superseded > 0) console.log(`Superseded ${superseded} stale document ids from reindexed sources`);
     console.log(`Queued ${vectorJobs.queued} vector job(s); skipped ${vectorJobs.skipped}`);
@@ -185,9 +185,9 @@ function tenantScopedWhere(base: SQL, tenantId: string | undefined): SQL {
   return tenantId ? and(base, eq(oracleDocuments.tenantId, tenantId))! : base;
 }
 
-function safeEnqueueVectorJobs(sqlite: Database, documents: OracleDocument[], changedIds: Set<string>) {
+function safeEnqueueVectorJobs(db: BunSQLiteDatabase<typeof schema>, documents: OracleDocument[], changedIds: Set<string>) {
   try {
-    return enqueueVectorReindexJobs(sqlite, documents, getEmbeddingModels(), changedIds);
+    return enqueueVectorReindexJobs(db, documents, getEmbeddingModels(), changedIds);
   } catch {
     return { queued: 0, skipped: 0, failed: documents.length };
   }

--- a/src/indexer/learn-doc-source.ts
+++ b/src/indexer/learn-doc-source.ts
@@ -4,14 +4,16 @@
 
 import fs from 'fs';
 import path from 'path';
-import type Database from 'bun:sqlite';
+import { eq, sql } from 'drizzle-orm';
+import { asOracleDb, type OracleDb, type OracleDbInput } from '../db/drizzle-input.ts';
+import { oracleDocuments, oracleFts, oraclePointerIndex } from '../db/schema.ts';
 import type { OracleDocument } from '../types.ts';
 import { deriveConceptsFromPath, mergeConceptsWithTags } from './concepts.ts';
 import { inferProjectFromPath } from './discovery.ts';
 import { parseLearningFile } from './parser.ts';
 import { enrichTextWithAcronyms } from '../search/acronyms.ts';
 import { chunkDocumentsForIndexing } from './chunk-text.ts';
-import { replaceDocumentPointers } from '../search/pointer-index.ts';
+import { documentPointers, type PointerInput } from '../search/pointer-index.ts';
 
 export const PSI_LEARN_REL = path.join('ψ', 'learn');
 export const MEMORY_LEARN_REL = path.join('ψ', 'memory', 'learnings');
@@ -82,55 +84,119 @@ export function readLearningDocuments(repoRoot: string, filePath: string): Oracl
 
 export const readPsiLearnDocuments = readLearningDocuments;
 
-export function storeSqliteDocuments(db: Database, documents: OracleDocument[]): string[] {
+export function storeSqliteDocuments(input: OracleDbInput, documents: OracleDocument[]): string[] {
   if (documents.length === 0) return [];
+  const db = asOracleDb(input);
   const storedDocuments = chunkDocumentsForIndexing(documents);
   const now = Date.now();
-  const upsertDoc = db.prepare(`
-    INSERT INTO oracle_documents
-      (id, type, source_file, concepts, created_at, updated_at, indexed_at, project, created_by)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'indexer')
-    ON CONFLICT(id) DO UPDATE SET
-      type = excluded.type,
-      source_file = excluded.source_file,
-      concepts = excluded.concepts,
-      updated_at = excluded.updated_at,
-      indexed_at = excluded.indexed_at,
-      project = excluded.project,
-      superseded_by = NULL,
-      superseded_at = NULL,
-      superseded_reason = NULL
-  `);
-  const deleteFts = db.prepare('DELETE FROM oracle_fts WHERE id = ?');
-  const insertFts = db.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)');
-
-  db.exec('BEGIN');
   try {
+    db.run(sql`ALTER TABLE oracle_documents ADD COLUMN valid_time INTEGER`);
+  } catch {
+    // Column already exists or the backend handles migrations elsewhere.
+  }
+
+  db.transaction((tx) => {
     for (const doc of storedDocuments) {
-      upsertDoc.run(
-        doc.id,
-        doc.type,
-        doc.source_file,
-        JSON.stringify(doc.concepts),
-        doc.created_at,
-        doc.updated_at,
-        now,
-        doc.project?.toLowerCase() ?? null,
-      );
+      const concepts = JSON.stringify(doc.concepts);
+      const project = doc.project?.toLowerCase() ?? null;
+      tx.insert(oracleDocuments)
+        .values({
+          id: doc.id,
+          type: doc.type,
+          sourceFile: doc.source_file,
+          concepts,
+          createdAt: doc.created_at,
+          updatedAt: doc.updated_at,
+          indexedAt: now,
+          project,
+          createdBy: 'indexer',
+        })
+        .onConflictDoUpdate({
+          target: oracleDocuments.id,
+          set: {
+            type: doc.type,
+            sourceFile: doc.source_file,
+            concepts,
+            updatedAt: doc.updated_at,
+            indexedAt: now,
+            project,
+            supersededBy: null,
+            supersededAt: null,
+            supersededReason: null,
+          },
+        })
+        .run();
       const indexedContent = enrichTextWithAcronyms(doc.content);
-      deleteFts.run(doc.id);
-      insertFts.run(doc.id, indexedContent, doc.concepts.join(' '));
-      replaceDocumentPointers(db, {
+      tx.delete(oracleFts).where(eq(oracleFts.id, doc.id)).run();
+      tx.insert(oracleFts)
+        .values({ id: doc.id, content: indexedContent, concepts: doc.concepts.join(' ') })
+        .run();
+      replaceDocumentPointersWithDb(tx as OracleDb, {
         documentId: doc.id,
         content: indexedContent,
         concepts: doc.concepts,
         timestamp: doc.updated_at || doc.created_at,
       });
     }
-    db.exec('COMMIT');
-  } catch (error) {
-    db.exec('ROLLBACK');
-    throw error;
-  }
+  });
   return storedDocuments.map((doc) => doc.id);
+}
+
+function replaceDocumentPointersWithDb(db: OracleDb, input: PointerInput): void {
+  try {
+    const tenantId = input.tenantId?.trim() || 'default';
+    removeDocumentPointersWithDb(db, tenantId, [input.documentId]);
+    const now = Date.now();
+    for (const item of documentPointers(input)) {
+      const id = pointerId(tenantId, item.kind, item.key);
+      const row = db.select({ docIds: oraclePointerIndex.docIds })
+        .from(oraclePointerIndex)
+        .where(eq(oraclePointerIndex.id, id))
+        .get();
+      const docIds = [...new Set([...parseIds(row?.docIds), input.documentId])].sort();
+      db.insert(oraclePointerIndex)
+        .values({ id, tenantId, kind: item.kind, key: item.key, docIds: JSON.stringify(docIds), updatedAt: now })
+        .onConflictDoUpdate({
+          target: oraclePointerIndex.id,
+          set: { docIds: JSON.stringify(docIds), updatedAt: now },
+        })
+        .run();
+    }
+  } catch (error) {
+    if (!missingPointerTable(error)) throw error;
+  }
+}
+
+function removeDocumentPointersWithDb(db: OracleDb, tenantId: string, documentIds: string[]): void {
+  if (documentIds.length === 0) return;
+  const rows = db.select({ id: oraclePointerIndex.id, docIds: oraclePointerIndex.docIds })
+    .from(oraclePointerIndex)
+    .where(eq(oraclePointerIndex.tenantId, tenantId))
+    .all();
+  const remove = new Set(documentIds);
+  const now = Date.now();
+  for (const row of rows) {
+    const existing = parseIds(row.docIds);
+    const next = existing.filter((id) => !remove.has(id));
+    if (next.length === 0) db.delete(oraclePointerIndex).where(eq(oraclePointerIndex.id, row.id)).run();
+    else if (next.length !== existing.length) {
+      db.update(oraclePointerIndex)
+        .set({ docIds: JSON.stringify(next), updatedAt: now })
+        .where(eq(oraclePointerIndex.id, row.id))
+        .run();
+    }
+  }
+}
+
+function pointerId(tenantId: string, kind: string, key: string): string { return `${tenantId}:${kind}:${key}`; }
+function parseIds(raw: string | undefined | null): string[] {
+  try {
+    const parsed = JSON.parse(raw || '[]');
+    return Array.isArray(parsed) ? parsed.map(String).filter(Boolean) : [];
+  } catch {
+    return [];
+  }
+}
+function missingPointerTable(error: unknown): boolean {
+  return String(error instanceof Error ? error.message : error).includes('oracle_pointer_index');
 }

--- a/src/indexer/reindex-state.ts
+++ b/src/indexer/reindex-state.ts
@@ -1,4 +1,6 @@
-import type Database from 'bun:sqlite';
+import { and, desc, eq, inArray, isNull, notInArray, or, sql } from 'drizzle-orm';
+import { indexingJobs, oracleDocuments, oracleFts } from '../db/schema.ts';
+import { asOracleDb, type OracleDb, type OracleDbInput } from '../db/drizzle-input.ts';
 import type { OracleDocument } from '../types.ts';
 import { enqueueIndexJob } from './jobs.ts';
 
@@ -13,19 +15,20 @@ export interface VectorQueueStats {
 
 const REINDEX_REASON = 'superseded by indexer reindex';
 
-export function snapshotActiveIndexerDocs(sqlite: Database, tenantId?: string): DocSnapshot {
-  const params: string[] = [];
-  const tenantClause = tenantId ? 'AND d.tenant_id = ?' : '';
-  if (tenantId) params.push(tenantId);
-  const rows = sqlite.prepare(`
-    SELECT d.id, d.source_file AS sourceFile,
-      (SELECT GROUP_CONCAT(f.content, '\n') FROM oracle_fts f WHERE f.id = d.id) AS content
-    FROM oracle_documents d
-    WHERE (d.created_by = 'indexer' OR d.created_by IS NULL)
-      AND d.superseded_by IS NULL
-      AND d.superseded_at IS NULL
-      ${tenantClause}
-  `).all(...params) as Array<{ id: string; sourceFile: string; content: string | null }>;
+export function snapshotActiveIndexerDocs(input: OracleDbInput, tenantId?: string): DocSnapshot {
+  const db = asOracleDb(input);
+  const rows = db.select({
+    id: oracleDocuments.id,
+    sourceFile: oracleDocuments.sourceFile,
+    content: sql<string | null>`(
+      SELECT GROUP_CONCAT(${oracleFts.content}, '\n')
+      FROM ${oracleFts}
+      WHERE ${oracleFts.id} = ${oracleDocuments.id}
+    )`,
+  })
+    .from(oracleDocuments)
+    .where(activeIndexerWhere(tenantId))
+    .all();
 
   return new Map(rows.map((row) => [row.id, { sourceFile: row.sourceFile, content: row.content }]));
 }
@@ -40,10 +43,11 @@ export function changedDocumentIds(before: DocSnapshot, documents: OracleDocumen
 }
 
 export function supersedeReplacedSourceDocs(
-  sqlite: Database,
+  input: OracleDbInput,
   documents: OracleDocument[],
   tenantId?: string,
 ): number {
+  const db = asOracleDb(input);
   const bySource = new Map<string, string[]>();
   for (const doc of documents) {
     const ids = bySource.get(doc.source_file) ?? [];
@@ -54,40 +58,34 @@ export function supersedeReplacedSourceDocs(
   let superseded = 0;
   const now = Date.now();
   for (const [sourceFile, currentIds] of bySource) {
-    const stale = activeIndexerIdsForSource(sqlite, sourceFile, currentIds, tenantId);
+    const stale = activeIndexerIdsForSource(db, sourceFile, currentIds, tenantId);
     if (stale.length === 0) continue;
     const successorId = currentIds[0];
-    const update = sqlite.prepare(`
-      UPDATE oracle_documents
-      SET superseded_by = ?, superseded_at = ?, superseded_reason = ?
-      WHERE id = ? AND superseded_by IS NULL AND superseded_at IS NULL
-    `);
-    sqlite.exec('BEGIN');
-    try {
-      for (const id of stale) {
-        update.run(successorId, now, REINDEX_REASON, id);
-        superseded++;
-      }
-      sqlite.exec('COMMIT');
-    } catch (error) {
-      sqlite.exec('ROLLBACK');
-      throw error;
-    }
+    db.update(oracleDocuments)
+      .set({ supersededBy: successorId, supersededAt: now, supersededReason: REINDEX_REASON })
+      .where(and(
+        inArray(oracleDocuments.id, stale),
+        isNull(oracleDocuments.supersededBy),
+        isNull(oracleDocuments.supersededAt),
+      ))
+      .run();
+    superseded += stale.length;
   }
   return superseded;
 }
 
 export function enqueueVectorReindexJobs(
-  sqlite: Database,
+  input: OracleDbInput,
   documents: OracleDocument[],
   models: ModelRegistry,
   changedIds: Set<string>,
 ): VectorQueueStats {
+  const db = asOracleDb(input);
   const modelKeys = Object.keys(models);
   const docIds = [...new Set(documents.map((doc) => doc.id))];
   const stats: VectorQueueStats = { queued: 0, skipped: 0, failed: 0 };
   if (docIds.length === 0 || modelKeys.length === 0) return stats;
-  if (!hasIndexingJobsTable(sqlite)) {
+  if (!hasIndexingJobsTable(db)) {
     stats.failed = docIds.length * modelKeys.length;
     return stats;
   }
@@ -96,11 +94,11 @@ export function enqueueVectorReindexJobs(
     const changed = changedIds.has(docId);
     for (const modelKey of modelKeys) {
       try {
-        if (!needsVectorJob(sqlite, docId, modelKey, changed)) {
+        if (!needsVectorJob(db, docId, modelKey, changed)) {
           stats.skipped++;
           continue;
         }
-        const jobs = enqueueIndexJob(sqlite, { docId, modelKey, models });
+        const jobs = enqueueIndexJob(db, { docId, modelKey, models });
         stats.queued += jobs.length;
         if (jobs.length === 0) stats.failed++;
       } catch {
@@ -112,33 +110,37 @@ export function enqueueVectorReindexJobs(
 }
 
 function activeIndexerIdsForSource(
-  sqlite: Database,
+  db: OracleDb,
   sourceFile: string,
   currentIds: string[],
   tenantId?: string,
 ): string[] {
   if (currentIds.length === 0) return [];
-  const notIn = currentIds.map(() => '?').join(',');
-  const params: string[] = [sourceFile, ...currentIds];
-  const tenantClause = tenantId ? 'AND tenant_id = ?' : '';
-  if (tenantId) params.push(tenantId);
-  const rows = sqlite.prepare(`
-    SELECT id FROM oracle_documents
-    WHERE source_file = ?
-      AND id NOT IN (${notIn})
-      AND (created_by = 'indexer' OR created_by IS NULL)
-      AND superseded_by IS NULL
-      AND superseded_at IS NULL
-      ${tenantClause}
-  `).all(...params) as Array<{ id: string }>;
+  const rows = db.select({ id: oracleDocuments.id })
+    .from(oracleDocuments)
+    .where(and(
+      eq(oracleDocuments.sourceFile, sourceFile),
+      notInArray(oracleDocuments.id, currentIds),
+      activeIndexerWhere(tenantId),
+    ))
+    .all();
   return rows.map((row) => row.id);
 }
 
-function hasIndexingJobsTable(sqlite: Database): boolean {
+function activeIndexerWhere(tenantId?: string) {
+  return and(
+    or(eq(oracleDocuments.createdBy, 'indexer'), isNull(oracleDocuments.createdBy))!,
+    isNull(oracleDocuments.supersededBy),
+    isNull(oracleDocuments.supersededAt),
+    tenantId ? eq(oracleDocuments.tenantId, tenantId) : undefined,
+  )!;
+}
+
+function hasIndexingJobsTable(db: OracleDb): boolean {
   try {
-    const row = sqlite.prepare(
-      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'indexing_jobs'",
-    ).get() as { name: string } | undefined;
+    const row = db.get<{ name: string }>(
+      sql`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'indexing_jobs'`,
+    );
     return row?.name === 'indexing_jobs';
   } catch {
     return false;
@@ -146,16 +148,16 @@ function hasIndexingJobsTable(sqlite: Database): boolean {
 }
 
 function needsVectorJob(
-  sqlite: Database,
+  db: OracleDb,
   docId: string,
   modelKey: string,
   changed: boolean,
 ): boolean {
-  const rows = sqlite.prepare(`
-    SELECT status FROM indexing_jobs
-    WHERE doc_id = ? AND model_key = ?
-    ORDER BY created_at DESC
-  `).all(docId, modelKey) as Array<{ status: string }>;
+  const rows = db.select({ status: indexingJobs.status })
+    .from(indexingJobs)
+    .where(and(eq(indexingJobs.docId, docId), eq(indexingJobs.modelKey, modelKey)))
+    .orderBy(desc(indexingJobs.createdAt))
+    .all();
   if (changed) return !rows.some((row) => row.status === 'pending');
   return !rows.some((row) => row.status === 'pending'
     || row.status === 'claimed'

--- a/src/indexer/status.ts
+++ b/src/indexer/status.ts
@@ -2,46 +2,41 @@
  * Indexing status updates for tray app
  */
 
-import { Database } from 'bun:sqlite';
+import { eq, sql } from 'drizzle-orm';
+import { asOracleDb, type OracleDbInput } from '../db/drizzle-input.ts';
+import { indexingStatus } from '../db/schema.ts';
 import type { IndexerConfig } from '../types.ts';
 
 /**
  * Update indexing status for tray app
  */
 export function setIndexingStatus(
-  sqlite: Database,
+  input: OracleDbInput,
   config: IndexerConfig,
   isIndexing: boolean,
   current: number = 0,
   total: number = 0,
   error?: string
 ): void {
+  const db = asOracleDb(input);
   // Ensure repo_root column exists (migration)
   try {
-    sqlite.exec('ALTER TABLE indexing_status ADD COLUMN repo_root TEXT');
+    db.run(sql`ALTER TABLE indexing_status ADD COLUMN repo_root TEXT`);
   } catch {
     // Column already exists
   }
 
-  sqlite.prepare(`
-    UPDATE indexing_status SET
-      is_indexing = ?,
-      progress_current = ?,
-      progress_total = ?,
-      started_at = CASE WHEN ? = 1 AND started_at IS NULL THEN ? ELSE started_at END,
-      completed_at = CASE WHEN ? = 0 THEN ? ELSE NULL END,
-      error = ?,
-      repo_root = ?
-    WHERE id = 1
-  `).run(
-    isIndexing ? 1 : 0,
-    current,
-    total,
-    isIndexing ? 1 : 0,
-    Date.now(),
-    isIndexing ? 1 : 0,
-    Date.now(),
-    error || null,
-    config.repoRoot
-  );
+  const now = Date.now();
+  db.update(indexingStatus)
+    .set({
+      isIndexing: isIndexing ? 1 : 0,
+      progressCurrent: current,
+      progressTotal: total,
+      startedAt: isIndexing ? sql`coalesce(${indexingStatus.startedAt}, ${now})` : sql`${indexingStatus.startedAt}`,
+      completedAt: isIndexing ? null : now,
+      error: error || null,
+      repoRoot: config.repoRoot,
+    })
+    .where(eq(indexingStatus.id, 1))
+    .run();
 }

--- a/src/indexer/vector-index-manifest.ts
+++ b/src/indexer/vector-index-manifest.ts
@@ -1,5 +1,7 @@
 import { createHash } from 'node:crypto';
-import type { Database } from 'bun:sqlite';
+import { eq, inArray } from 'drizzle-orm';
+import { asOracleDb, type OracleDbInput } from '../db/drizzle-input.ts';
+import { vectorIndexManifest } from '../db/schema.ts';
 import type { VectorDocument } from '../vector/types.ts';
 
 export interface VectorManifestRow {
@@ -35,13 +37,19 @@ export function vectorContentHash(doc: VectorDocument): string {
   return `sha256:${createHash('sha256').update(payload).digest('hex')}`;
 }
 
-export function loadVectorIndexManifest(sqlite: Database, modelKey: string): Map<string, VectorManifestRow> {
-  const rows = sqlite.prepare(`
-    SELECT chunk_id AS chunkId, source_file AS sourceFile, model_key AS modelKey,
-      content_hash AS contentHash, updated_at AS updatedAt, indexed_at AS indexedAt
-    FROM vector_index_manifest
-    WHERE model_key = ?
-  `).all(modelKey) as VectorManifestRow[];
+export function loadVectorIndexManifest(input: OracleDbInput, modelKey: string): Map<string, VectorManifestRow> {
+  const db = asOracleDb(input);
+  const rows = db.select({
+    chunkId: vectorIndexManifest.chunkId,
+    sourceFile: vectorIndexManifest.sourceFile,
+    modelKey: vectorIndexManifest.modelKey,
+    contentHash: vectorIndexManifest.contentHash,
+    updatedAt: vectorIndexManifest.updatedAt,
+    indexedAt: vectorIndexManifest.indexedAt,
+  })
+    .from(vectorIndexManifest)
+    .where(eq(vectorIndexManifest.modelKey, modelKey))
+    .all();
   return new Map(rows.map((row) => [row.chunkId, row]));
 }
 
@@ -76,32 +84,32 @@ export function planVectorIndex(
   return { modelKey, docs, changedDocs, staleIds, entries, skipped: docs.length - changedDocs.length, total: docs.length };
 }
 
-export function writeVectorIndexManifest(sqlite: Database, plan: VectorIndexPlan): void {
-  const deleteStmt = sqlite.prepare('DELETE FROM vector_index_manifest WHERE id = ?');
-  const upsertStmt = sqlite.prepare(`
-    INSERT INTO vector_index_manifest
-      (id, chunk_id, source_file, model_key, content_hash, updated_at, indexed_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?)
-    ON CONFLICT(id) DO UPDATE SET
-      chunk_id = excluded.chunk_id,
-      source_file = excluded.source_file,
-      model_key = excluded.model_key,
-      content_hash = excluded.content_hash,
-      updated_at = excluded.updated_at,
-      indexed_at = excluded.indexed_at
-  `);
-
-  sqlite.exec('BEGIN');
-  try {
-    for (const chunkId of plan.staleIds) deleteStmt.run(vectorManifestId(plan.modelKey, chunkId));
-    for (const entry of plan.entries) {
-      upsertStmt.run(entry.id, entry.chunkId, entry.sourceFile, entry.modelKey, entry.contentHash, entry.updatedAt, entry.indexedAt);
+export function writeVectorIndexManifest(input: OracleDbInput, plan: VectorIndexPlan): void {
+  const db = asOracleDb(input);
+  db.transaction((tx) => {
+    const staleIds = plan.staleIds.map((chunkId) => vectorManifestId(plan.modelKey, chunkId));
+    if (staleIds.length > 0) {
+      tx.delete(vectorIndexManifest)
+        .where(inArray(vectorIndexManifest.id, staleIds))
+        .run();
     }
-    sqlite.exec('COMMIT');
-  } catch (error) {
-    sqlite.exec('ROLLBACK');
-    throw error;
-  }
+    for (const entry of plan.entries) {
+      tx.insert(vectorIndexManifest)
+        .values(entry)
+        .onConflictDoUpdate({
+          target: vectorIndexManifest.id,
+          set: {
+            chunkId: entry.chunkId,
+            sourceFile: entry.sourceFile,
+            modelKey: entry.modelKey,
+            contentHash: entry.contentHash,
+            updatedAt: entry.updatedAt,
+            indexedAt: entry.indexedAt,
+          },
+        })
+        .run();
+    }
+  });
 }
 
 function normalizeVectorText(text: string): string {

--- a/src/routes/indexer/start.ts
+++ b/src/routes/indexer/start.ts
@@ -53,7 +53,9 @@ export function createStartRoute(deps: StartRouteDeps = {}) {
     const dbPath = deps.dbPath ?? DB_PATH;
     const repoRoot = sourcePath || deps.repoRoot || REPO_ROOT;
     const tenantId = currentTenantId();
-    const { sqlite } = (deps.createDb ?? createDatabase)(dbPath);
+    const conn = (deps.createDb ?? createDatabase)(dbPath);
+    const { sqlite } = conn;
+    const statusDb = conn.db ?? sqlite;
     const config: IndexerConfig = {
       repoRoot,
       dbPath,
@@ -100,11 +102,11 @@ export function createStartRoute(deps: StartRouteDeps = {}) {
         }>;
 
         const total = rows.length;
-        setIndexingStatus(sqlite, config, true, 0, total);
+        setIndexingStatus(statusDb, config, true, 0, total);
 
         for (let i = 0; i < rows.length; i += batch) {
           if (abortFlag) {
-            setIndexingStatus(sqlite, config, false, i, total, 'Cancelled by user');
+            setIndexingStatus(statusDb, config, false, i, total, 'Cancelled by user');
             break;
           }
 
@@ -132,15 +134,15 @@ export function createStartRoute(deps: StartRouteDeps = {}) {
             });
           }
           if (entityDocs.length > 0) await entityStore.addDocuments(entityDocs);
-          setIndexingStatus(sqlite, config, true, i + batchRows.length, total);
+          setIndexingStatus(statusDb, config, true, i + batchRows.length, total);
         }
 
         if (!abortFlag) {
-          setIndexingStatus(sqlite, config, false, rows.length, rows.length);
+          setIndexingStatus(statusDb, config, false, rows.length, rows.length);
         }
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
-        setIndexingStatus(sqlite, config, false, 0, 0, msg);
+        setIndexingStatus(statusDb, config, false, 0, 0, msg);
       } finally {
         await store.close().catch(() => undefined);
         await entityStore.close().catch(() => undefined);

--- a/src/scripts/index-model.ts
+++ b/src/scripts/index-model.ts
@@ -54,7 +54,7 @@ async function main() {
   const [{ total: docCount }] = db.select({ total: count() }).from(oracleDocuments).all();
   const rows = loadRows(sqlite);
   const docs = rows.map(vectorDoc);
-  const previous = loadVectorIndexManifest(sqlite, selectedModelKey);
+  const previous = loadVectorIndexManifest(db, selectedModelKey);
   const plan = planVectorIndex(docs, previous, selectedModelKey, { force });
   const startTime = Date.now();
 
@@ -72,7 +72,7 @@ async function main() {
 
   try {
     const embedded = await applyVectorPlan(store, plan, previous.size === 0 || force, startTime);
-    writeVectorIndexManifest(sqlite, plan);
+    writeVectorIndexManifest(db, plan);
     printSummary(rows, plan, { embedded, errors: 0, startTime, dryRun, force });
   } finally {
     await store.close();

--- a/src/services/file-watcher.ts
+++ b/src/services/file-watcher.ts
@@ -13,7 +13,6 @@ import {
   storeSqliteDocuments,
 } from '../indexer/learn-doc-source.ts';
 import { isWithinRoot, listDirs, listFiles, safeClearTimeout, safeClose, watchDir } from '../indexer/watch-utils.ts';
-
 type ModelRegistry = Record<string, { collection: string }>;
 type WatcherEventType = 'started' | 'stopped' | 'scheduled' | 'indexed' | 'skipped' | 'error';
 
@@ -121,6 +120,9 @@ export class FileWatcherService implements FileWatcherControl {
     if (!isWithinRoot(this.watchRoot, fullPath)) return;
     safeClearTimeout(this.pending.get(fullPath));
     const sourceFile = normalizeSourceFile(this.repoRoot, fullPath);
+    if (this.events[0]?.type === 'indexed' && this.events[0].path === sourceFile
+      && Date.now() - Date.parse(this.events[0].at) <= Math.max(25, this.debounceMs * 2)
+      && fs.existsSync(fullPath) && fs.statSync(fullPath).mtimeMs <= Date.parse(this.events[0].at)) return;
     this.record('scheduled', `scheduled re-index for ${sourceFile}`, sourceFile);
     this.pending.set(fullPath, setTimeout(() => {
       this.pending.delete(fullPath);
@@ -234,9 +236,7 @@ export class FileWatcherService implements FileWatcherControl {
   }
 }
 
-function errorText(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
+function errorText(error: unknown): string { return error instanceof Error ? error.message : String(error); }
 class LazyFileWatcherService implements FileWatcherControl {
   private service?: FileWatcherService;
   private get current(): FileWatcherService { return this.service ??= new FileWatcherService(); }

--- a/tests/http/memory/integration-closeout.test.ts
+++ b/tests/http/memory/integration-closeout.test.ts
@@ -65,7 +65,7 @@ test('memory CRUD, learn indexing, and morning tape share close-out context', as
   writeFileSync(learnFile, `## Integration proof\nLearn indexer stores ${unique} for morning recovery.`);
 
   const docs = readLearningDocuments(root, learnFile);
-  const indexedIds = storeSqliteDocuments(sqlite, docs);
+  const indexedIds = storeSqliteDocuments(db, docs);
   docIds.push(...indexedIds);
 
   expect(indexedIds.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- migrate reindex-state, status, vector manifest, and learn doc storage off sqlite.prepare onto Drizzle queries
- add Drizzle oracle_fts schema surface and a db-input adapter for raw SQLite/Drizzle callers
- keep watcher debounce stable after faster Drizzle writes

## Verification
- bunx tsc --noEmit
- bun test tests/http/indexer/
- bun test --isolate src/indexer/__tests__/ tests/http/watcher/ tests/services/file-watcher-lifecycle.test.ts tests/http/memory/integration-closeout.test.ts
- wc -l changed files <= 250

Issue: #2611