### PR TITLE
fix(frontend): theme dropdown opaque enough to read over live content

### DIFF
--- a/frontend/src/components/ThemeSelector.tsx
+++ b/frontend/src/components/ThemeSelector.tsx
@@ -60,7 +60,7 @@ export function ThemeSelector() {
         <div
           role="listbox"
           aria-label="Color themes"
-          className="glass absolute right-0 top-full z-50 mt-2 grid max-h-[24rem] w-64 gap-1 overflow-y-auto rounded-2xl p-2"
+          className="glass-popover absolute right-0 top-full z-50 mt-2 grid max-h-[min(24rem,60vh)] w-64 gap-1 overflow-y-auto rounded-2xl p-2"
           onMouseLeave={handleLeave}
         >
           {themes.map((t) => (

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -35,6 +35,7 @@
   --glass-border: oklch(0.50 0.11 178 / 0.18);
   --glass-shadow: 0 8px 28px oklch(0.13 0.02 265 / 0.12);
   --glass-blur: 18px;
+  --glass-popover-bg: oklch(1 0 0 / 0.94);
 }
 
 .dark {
@@ -68,6 +69,7 @@
   --glass-border: oklch(1 0 0 / 0.08);
   --glass-shadow: 0 8px 32px oklch(0 0 0 / 0.4);
   --glass-blur: 24px;
+  --glass-popover-bg: oklch(0.16 0.02 265 / 0.94);
 }
 
 body {
@@ -94,6 +96,17 @@ body {
 
 .glass {
   background: var(--glass-bg);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--glass-shadow);
+}
+
+/* Floating overlays (dropdowns/popovers) need a near-opaque backing —
+   .glass's ambient alpha is tuned for background panels and lets
+   whatever's underneath bleed through when it floats over live content. */
+.glass-popover {
+  background: var(--glass-popover-bg);
   backdrop-filter: blur(var(--glass-blur));
   -webkit-backdrop-filter: blur(var(--glass-blur));
   border: 1px solid var(--glass-border);


### PR DESCRIPTION
## Summary
- The previous z-index fix (#2622) correctly stacked the theme dropdown above the header/stat-cards, but it reused the ambient `.glass` token (58% light / 35% dark alpha) meant for background panels — with the dropdown running up to 384px tall it spills past the header into the stat-cards row below, and bold headline numbers stayed legible right through the blur, reading as overlapping garbled text instead of a clean floating menu.
- Added a dedicated `.glass-popover` CSS token (94% opacity, same blur/border/shadow) for floating overlays, applied it to `ThemeSelector`'s dropdown, and capped its height to `min(24rem, 60vh)` so it can't overrun small viewports.

## Test plan
- [x] `bunx tsc --noEmit` — clean
- [x] Verified visually with Playwright screenshots in both light and dark themes — dropdown is now solid/legible with only a faint ambient ghost of what's behind, no more overlapping readable text