### PR TITLE
fix(vector): alias legacy export collection

### DIFF
--- a/src/routes/vector/export.ts
+++ b/src/routes/vector/export.ts
@@ -3,9 +3,10 @@
  */
 
 import { Elysia, t } from 'elysia';
+import { COLLECTION_NAME } from '../../const.ts';
 import { getVectorStoreByModel } from '../../vector/factory.ts';
 import { availableExportFormats, exportFormatInfo, getExportFormat } from '../../vector/export-formats.ts';
-import type { VectorServerConfig } from '../../vector/config.ts';
+import type { VectorCollectionConfig, VectorServerConfig } from '../../vector/config.ts';
 import type { VectorStoreAdapter } from '../../vector/types.ts';
 import { activeConfig, resolveCollection as resolveConfigCollection } from './config-api-utils.ts';
 
@@ -69,6 +70,23 @@ function modelCollectionName(model: unknown): string | null {
     : null;
 }
 
+function isPrimaryCollection(collection: VectorCollectionConfig): boolean {
+  return collection.primary === true;
+}
+
+function isLegacyCollectionAliasTarget(collection: string | null | undefined): boolean {
+  return typeof collection === 'string' && collection.startsWith(`${COLLECTION_NAME}_`);
+}
+
+function preferredConfigCollection(config: VectorServerConfig): [string, VectorCollectionConfig] | null {
+  const entries = Object.entries(config.collections);
+  return entries.find(([, collection]) => isPrimaryCollection(collection)) ?? entries[0] ?? null;
+}
+
+function preferredModelKey(models: Record<string, unknown>): string | null {
+  return DEFAULT_COLLECTION in models ? DEFAULT_COLLECTION : Object.keys(models)[0] ?? null;
+}
+
 function configForResolution(getConfig?: () => VectorServerConfig, getModels?: () => Record<string, unknown>) {
   if (getConfig) return getConfig();
   return getModels ? null : activeConfig().config;
@@ -79,6 +97,12 @@ function resolveCollection(collection: string | undefined, deps: VectorExportDep
   const config = configForResolution(deps.getConfig, deps.getModels);
   if (config) {
     const match = resolveConfigCollection(config, resolved);
+    if (resolved === COLLECTION_NAME) {
+      const preferred = preferredConfigCollection(config);
+      if (preferred && isLegacyCollectionAliasTarget(preferred[1].collection) && preferred[0] !== match?.[0]) {
+        return { storeKey: preferred[0], filename: resolved };
+      }
+    }
     return match ? { storeKey: match[0], filename: resolved } : null;
   }
 
@@ -86,7 +110,10 @@ function resolveCollection(collection: string | undefined, deps: VectorExportDep
   if (!models) return { storeKey: resolved, filename: resolved };
   if (resolved in models) return { storeKey: resolved, filename: resolved };
   const byCollection = Object.entries(models).find(([, model]) => modelCollectionName(model) === resolved);
-  return byCollection ? { storeKey: byCollection[0], filename: resolved } : null;
+  if (byCollection) return { storeKey: byCollection[0], filename: resolved };
+  const preferred = resolved === COLLECTION_NAME ? preferredModelKey(models) : null;
+  const preferredCollection = preferred ? modelCollectionName(models[preferred]) : null;
+  return preferred && isLegacyCollectionAliasTarget(preferredCollection) ? { storeKey: preferred, filename: resolved } : null;
 }
 
 export function createVectorExportEndpoint(deps: VectorExportDeps = {}) {

--- a/tests/http/vector/export-collection-name.test.ts
+++ b/tests/http/vector/export-collection-name.test.ts
@@ -2,6 +2,7 @@ import { expect, mock, test } from 'bun:test';
 import { Elysia } from 'elysia';
 import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
 import { createVectorExportEndpoint } from '../../../src/routes/vector/export.ts';
+import { generateDefaultConfig } from '../../../src/vector/config.ts';
 import type { VectorStoreAdapter } from '../../../src/vector/types.ts';
 
 function createStore(): VectorStoreAdapter {
@@ -54,4 +55,48 @@ test('GET /api/v1/vector/export accepts collection names from model registry dep
     source_file: '',
     concepts: [],
   }]);
+});
+
+test('GET /api/v1/vector/export aliases legacy bare collection to primary config collection', async () => {
+  const store = createStore();
+  const selected: string[] = [];
+  const app = new Elysia({ prefix: '/api' }).use(createVectorExportEndpoint({
+    getConfig: generateDefaultConfig,
+    getStore: (collection) => {
+      selected.push(collection ?? '');
+      return store;
+    },
+  }));
+  const fetcher = createApiVersionedFetch((request) => app.handle(request));
+
+  const res = await fetcher(new Request(
+    'http://local/api/v1/vector/export?collection=oracle_knowledge&format=json',
+  ));
+
+  expect(res.status).toBe(200);
+  expect(selected).toEqual(['bge-m3']);
+  expect(res.headers.get('content-disposition')).toContain('oracle_knowledge.json');
+});
+
+test('GET /api/v1/vector/export aliases bare collection when registry only has suffixed collections', async () => {
+  const store = createStore();
+  const selected: string[] = [];
+  const app = new Elysia({ prefix: '/api' }).use(createVectorExportEndpoint({
+    getModels: () => ({
+      'bge-m3': { collection: 'oracle_knowledge_bge_m3' },
+      qwen3: { collection: 'oracle_knowledge_qwen3' },
+    }),
+    getStore: (collection) => {
+      selected.push(collection ?? '');
+      return store;
+    },
+  }));
+  const fetcher = createApiVersionedFetch((request) => app.handle(request));
+
+  const res = await fetcher(new Request(
+    'http://local/api/v1/vector/export?collection=oracle_knowledge&format=json',
+  ));
+
+  expect(res.status).toBe(200);
+  expect(selected).toEqual(['bge-m3']);
 });


### PR DESCRIPTION
## Summary
- resolve legacy bare `oracle_knowledge` export requests to the primary suffixed vector collection when config/model registry points at per-model collections
- preserve exact model-key and collection-name export behavior for non-legacy selections
- add regression coverage for default config and suffixed-only registries

Fixes #2457

## Validation
- `bunx tsc --noEmit`
- `bun test tests/http/vector/`
- `git diff --check`
- `wc -l src/routes/vector/export.ts tests/http/vector/export-collection-name.test.ts`