### PR TITLE
feat(indexer): skip unchanged vector chunks

### DIFF
--- a/src/indexer/__tests__/vector-index-manifest.test.ts
+++ b/src/indexer/__tests__/vector-index-manifest.test.ts
@@ -3,8 +3,9 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createDatabase, type DatabaseConnection } from '../../db/index.ts';
-import type { VectorDocument } from '../../vector/types.ts';
+import type { VectorDocument, VectorStoreAdapter } from '../../vector/types.ts';
 import {
+  applyVectorIndexPlan,
   loadVectorIndexManifest,
   planVectorIndex,
   vectorContentHash,
@@ -66,6 +67,24 @@ describe('vector index manifest', () => {
     const forced = planVectorIndex(current, loadVectorIndexManifest(conn.db, 'nomic'), 'nomic', { force: true, now: 300 });
     expect(forced.changedDocs.map((item) => item.id)).toEqual(['a']);
   });
+
+  test('apply plan embeds changed chunks and deletes stale ids', async () => {
+    const conn = freshDb();
+    const docs = [doc('a', 'Alpha'), doc('b', 'Beta')];
+    const store = fakeStore();
+    const first = planVectorIndex(docs, new Map(), 'nomic', { now: 100 });
+    const applied = await applyVectorIndexPlan(store, first, { replaceBaseline: true, batchSize: 1 });
+    expect(applied.embedded).toBe(2);
+    writeVectorIndexManifest(conn.db, first);
+
+    const next = [doc('a', 'Alpha changed')];
+    const plan = planVectorIndex(next, loadVectorIndexManifest(conn.db, 'nomic'), 'nomic', { now: 200 });
+    const changed = await applyVectorIndexPlan(store, plan);
+
+    expect(changed).toMatchObject({ embedded: 1, deleted: 1, replaced: false });
+    expect(store.docs.map((item) => item.id)).toEqual(['a']);
+    expect(store.docs[0].document).toBe('Alpha changed');
+  });
 });
 
 function freshDb(): DatabaseConnection {
@@ -80,5 +99,31 @@ function doc(id: string, text: string): VectorDocument {
     id,
     document: text,
     metadata: { type: 'learning', source_file: `ψ/${id}.md`, concepts: '[]' },
+  };
+}
+
+type FakeStore = VectorStoreAdapter & { docs: VectorDocument[] };
+
+function fakeStore(): FakeStore {
+  const docs: VectorDocument[] = [];
+  return {
+    name: 'fake-vector-manifest',
+    docs,
+    connect: async () => {},
+    close: async () => {},
+    ensureCollection: async () => {},
+    deleteCollection: async () => { docs.splice(0, docs.length); },
+    addDocuments: async (next) => { docs.push(...next); },
+    deleteDocuments: async (ids) => {
+      for (const id of ids) {
+        const index = docs.findIndex((item) => item.id === id);
+        if (index >= 0) docs.splice(index, 1);
+      }
+    },
+    query: async () => ({ ids: [], documents: [], distances: [], metadatas: [] }),
+    queryById: async () => ({ ids: [], documents: [], distances: [], metadatas: [] }),
+    getStats: async () => ({ count: docs.length }),
+    getCollectionInfo: async () => ({ count: docs.length, name: 'fake-vector-manifest' }),
+    getAllEmbeddings: async () => ({ ids: docs.map((item) => item.id), embeddings: [], metadatas: [] }),
   };
 }

--- a/src/indexer/vector-index-manifest.ts
+++ b/src/indexer/vector-index-manifest.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { eq, inArray } from 'drizzle-orm';
 import { asOracleDb, type OracleDbInput } from '../db/drizzle-input.ts';
 import { vectorIndexManifest } from '../db/schema.ts';
-import type { VectorDocument } from '../vector/types.ts';
+import type { VectorDocument, VectorStoreAdapter } from '../vector/types.ts';
 
 export interface VectorManifestRow {
   chunkId: string;
@@ -25,6 +25,20 @@ export interface VectorIndexPlan {
   total: number;
 }
 
+export interface VectorIndexApplyResult {
+  embedded: number;
+  deleted: number;
+  replaced: boolean;
+  aborted: boolean;
+}
+
+export interface VectorIndexApplyOptions {
+  batchSize?: number;
+  replaceBaseline?: boolean;
+  shouldAbort?: () => boolean;
+  onProgress?: (embedded: number, total: number, action: 'embedded' | 'replaced') => void;
+}
+
 export function vectorManifestId(modelKey: string, chunkId: string): string {
   return `${modelKey}:${chunkId}`;
 }
@@ -39,29 +53,34 @@ export function vectorContentHash(doc: VectorDocument): string {
 
 export function loadVectorIndexManifest(input: OracleDbInput, modelKey: string): Map<string, VectorManifestRow> {
   const db = asOracleDb(input);
-  const rows = db.select({
-    chunkId: vectorIndexManifest.chunkId,
-    sourceFile: vectorIndexManifest.sourceFile,
-    modelKey: vectorIndexManifest.modelKey,
-    contentHash: vectorIndexManifest.contentHash,
-    updatedAt: vectorIndexManifest.updatedAt,
-    indexedAt: vectorIndexManifest.indexedAt,
-  })
-    .from(vectorIndexManifest)
-    .where(eq(vectorIndexManifest.modelKey, modelKey))
-    .all();
-  return new Map(rows.map((row) => [row.chunkId, row]));
+  try {
+    const rows = db.select({
+      chunkId: vectorIndexManifest.chunkId,
+      sourceFile: vectorIndexManifest.sourceFile,
+      modelKey: vectorIndexManifest.modelKey,
+      contentHash: vectorIndexManifest.contentHash,
+      updatedAt: vectorIndexManifest.updatedAt,
+      indexedAt: vectorIndexManifest.indexedAt,
+    })
+      .from(vectorIndexManifest)
+      .where(eq(vectorIndexManifest.modelKey, modelKey))
+      .all();
+    return new Map(rows.map((row) => [row.chunkId, row]));
+  } catch (error) {
+    if (isMissingManifestTable(error)) return new Map();
+    throw error;
+  }
 }
 
 export function planVectorIndex(
   docs: VectorDocument[],
   previous: Map<string, VectorManifestRow>,
   modelKey: string,
-  opts: { force?: boolean; now?: number } = {},
+  opts: { force?: boolean; now?: number; pruneStale?: boolean } = {},
 ): VectorIndexPlan {
   const now = opts.now ?? Date.now();
   const currentIds = new Set(docs.map((doc) => doc.id));
-  const staleIds = [...previous.keys()].filter((chunkId) => !currentIds.has(chunkId));
+  const staleIds = opts.pruneStale === false ? [] : [...previous.keys()].filter((chunkId) => !currentIds.has(chunkId));
   const changedDocs: VectorDocument[] = [];
   const entries: VectorManifestEntry[] = [];
 
@@ -84,32 +103,86 @@ export function planVectorIndex(
   return { modelKey, docs, changedDocs, staleIds, entries, skipped: docs.length - changedDocs.length, total: docs.length };
 }
 
-export function writeVectorIndexManifest(input: OracleDbInput, plan: VectorIndexPlan): void {
+export function writeVectorIndexManifest(input: OracleDbInput, plan: VectorIndexPlan): boolean {
   const db = asOracleDb(input);
-  db.transaction((tx) => {
-    const staleIds = plan.staleIds.map((chunkId) => vectorManifestId(plan.modelKey, chunkId));
-    if (staleIds.length > 0) {
-      tx.delete(vectorIndexManifest)
-        .where(inArray(vectorIndexManifest.id, staleIds))
-        .run();
+  try {
+    db.transaction((tx) => {
+      const staleIds = plan.staleIds.map((chunkId) => vectorManifestId(plan.modelKey, chunkId));
+      if (staleIds.length > 0) {
+        tx.delete(vectorIndexManifest)
+          .where(inArray(vectorIndexManifest.id, staleIds))
+          .run();
+      }
+      for (const entry of plan.entries) {
+        tx.insert(vectorIndexManifest)
+          .values(entry)
+          .onConflictDoUpdate({
+            target: vectorIndexManifest.id,
+            set: {
+              chunkId: entry.chunkId,
+              sourceFile: entry.sourceFile,
+              modelKey: entry.modelKey,
+              contentHash: entry.contentHash,
+              updatedAt: entry.updatedAt,
+              indexedAt: entry.indexedAt,
+            },
+          })
+          .run();
+      }
+    });
+    return true;
+  } catch (error) {
+    if (isMissingManifestTable(error)) return false;
+    throw error;
+  }
+}
+
+export async function applyVectorIndexPlan(
+  store: VectorStoreAdapter,
+  plan: VectorIndexPlan,
+  opts: VectorIndexApplyOptions = {},
+): Promise<VectorIndexApplyResult> {
+  if (opts.replaceBaseline !== true && plan.changedDocs.length === 0 && plan.staleIds.length === 0) {
+    return { embedded: 0, deleted: 0, replaced: false, aborted: false };
+  }
+  const mustReplace = opts.replaceBaseline === true
+    || ((plan.changedDocs.length > 0 || plan.staleIds.length > 0) && !store.deleteDocuments);
+  if (mustReplace) {
+    if (store.replaceDocuments) {
+      return replaceBatches(store, plan, opts);
     }
-    for (const entry of plan.entries) {
-      tx.insert(vectorIndexManifest)
-        .values(entry)
-        .onConflictDoUpdate({
-          target: vectorIndexManifest.id,
-          set: {
-            chunkId: entry.chunkId,
-            sourceFile: entry.sourceFile,
-            modelKey: entry.modelKey,
-            contentHash: entry.contentHash,
-            updatedAt: entry.updatedAt,
-            indexedAt: entry.indexedAt,
-          },
-        })
-        .run();
-    }
-  });
+    await store.deleteCollection();
+    await store.ensureCollection();
+    return addBatches(store, plan.docs, plan, { ...opts, action: 'replaced', replaced: true });
+  }
+
+  const deleteIds = [...plan.staleIds, ...plan.changedDocs.map((doc) => doc.id)];
+  if (deleteIds.length > 0) await store.deleteDocuments?.(deleteIds);
+  return addBatches(store, plan.changedDocs, plan, { ...opts, action: 'embedded', replaced: false });
+}
+
+async function replaceBatches(
+  store: VectorStoreAdapter,
+  plan: VectorIndexPlan,
+  opts: VectorIndexApplyOptions,
+): Promise<VectorIndexApplyResult> {
+  if (opts.shouldAbort?.()) return result(0, plan, true, true);
+  if (plan.docs.length === 0) {
+    await store.replaceDocuments?.([]);
+    opts.onProgress?.(0, plan.total, 'replaced');
+    return result(0, plan, true, false);
+  }
+  const batchSize = Math.max(1, Math.trunc(opts.batchSize ?? 100));
+  let embedded = 0;
+  for (let i = 0; i < plan.docs.length; i += batchSize) {
+    if (opts.shouldAbort?.()) return result(embedded, plan, true, true);
+    const batch = plan.docs.slice(i, i + batchSize);
+    if (i === 0) await store.replaceDocuments?.(batch);
+    else await store.addDocuments(batch);
+    embedded += batch.length;
+    opts.onProgress?.(embedded, plan.total, 'replaced');
+  }
+  return result(embedded, plan, true, false);
 }
 
 function normalizeVectorText(text: string): string {
@@ -123,4 +196,30 @@ function stableMetadata(metadata: Record<string, string | number>): Record<strin
 function sourceFileOf(doc: VectorDocument): string {
   const source = doc.metadata.source_file;
   return typeof source === 'string' ? source : '';
+}
+
+async function addBatches(
+  store: VectorStoreAdapter,
+  docs: VectorDocument[],
+  plan: VectorIndexPlan,
+  opts: VectorIndexApplyOptions & { action: 'embedded' | 'replaced'; replaced: boolean },
+): Promise<VectorIndexApplyResult> {
+  const batchSize = Math.max(1, Math.trunc(opts.batchSize ?? 100));
+  let embedded = 0;
+  for (let i = 0; i < docs.length; i += batchSize) {
+    if (opts.shouldAbort?.()) return result(embedded, plan, opts.replaced, true);
+    const batch = docs.slice(i, i + batchSize);
+    await store.addDocuments(batch);
+    embedded += batch.length;
+    opts.onProgress?.(embedded, plan.total, opts.action);
+  }
+  return result(embedded, plan, opts.replaced, false);
+}
+
+function result(embedded: number, plan: VectorIndexPlan, replaced: boolean, aborted: boolean): VectorIndexApplyResult {
+  return { embedded, deleted: plan.staleIds.length, replaced, aborted };
+}
+
+function isMissingManifestTable(error: unknown): boolean {
+  return String(error instanceof Error ? error.message : error).includes('vector_index_manifest');
 }

--- a/src/routes/indexer/start.ts
+++ b/src/routes/indexer/start.ts
@@ -6,7 +6,14 @@ import { DB_PATH, REPO_ROOT } from '../../config.ts';
 import { currentTenantId, runWithTenant } from '../../middleware/tenant.ts';
 import { replaceEntityLinks } from '../../search/entity-ranking.ts';
 import { entityCollectionName, entityDocumentsFor } from '../../vector/entities.ts';
+import {
+  applyVectorIndexPlan,
+  loadVectorIndexManifest,
+  planVectorIndex,
+  writeVectorIndexManifest,
+} from '../../indexer/vector-index-manifest.ts';
 import type { IndexerConfig } from '../../types.ts';
+import type { VectorDocument } from '../../vector/types.ts';
 
 let abortFlag = false;
 export function getAbortFlag() { return abortFlag; }
@@ -37,6 +44,30 @@ function normalizeBatchSize(value: number | undefined, key: string): number {
   return Math.min(1000, Math.floor(value));
 }
 
+type IndexedRow = {
+  id: string;
+  tenant_id: string;
+  type: string;
+  content: string;
+  source_file: string;
+  concepts: string;
+  project: string | null;
+};
+
+function vectorDoc(row: IndexedRow): VectorDocument {
+  return {
+    id: row.id,
+    document: row.content,
+    metadata: {
+      type: row.type,
+      source_file: row.source_file,
+      concepts: row.concepts,
+      tenant_id: row.tenant_id,
+      ...(row.project && { project: row.project }),
+    },
+  };
+}
+
 export function createStartRoute(deps: StartRouteDeps = {}) {
   return new Elysia().post('/indexer/start', async ({ body, set }) => {
     const { model, sourcePath, batchSize } = body;
@@ -55,7 +86,7 @@ export function createStartRoute(deps: StartRouteDeps = {}) {
     const tenantId = currentTenantId();
     const conn = (deps.createDb ?? createDatabase)(dbPath);
     const { sqlite } = conn;
-    const statusDb = conn.db ?? sqlite;
+    const indexDb = conn.db ?? sqlite;
     const config: IndexerConfig = {
       repoRoot,
       dbPath,
@@ -82,8 +113,6 @@ export function createStartRoute(deps: StartRouteDeps = {}) {
       try {
         await store.connect();
         await entityStore.connect();
-        try { await store.deleteCollection(); } catch {}
-        try { await entityStore.deleteCollection(); } catch {}
         await store.ensureCollection();
         await entityStore.ensureCollection();
 
@@ -96,36 +125,41 @@ export function createStartRoute(deps: StartRouteDeps = {}) {
         ${tenantWhere}
         GROUP BY d.id
         ORDER BY d.created_at DESC
-      `).all(...(tenantId ? [tenantId] : [])) as Array<{
-          id: string; tenant_id: string; type: string; content: string;
-          source_file: string; concepts: string; project: string | null; created_at: string;
-        }>;
+      `).all(...(tenantId ? [tenantId] : [])) as IndexedRow[];
 
         const total = rows.length;
-        setIndexingStatus(statusDb, config, true, 0, total);
+        setIndexingStatus(indexDb, config, true, 0, total);
 
-        for (let i = 0; i < rows.length; i += batch) {
-          if (abortFlag) {
-            setIndexingStatus(statusDb, config, false, i, total, 'Cancelled by user');
-            break;
+        const docs = rows.map(vectorDoc);
+        const previous = loadVectorIndexManifest(indexDb, key);
+        const plan = planVectorIndex(docs, previous, key, { pruneStale: !tenantId });
+        const applied = await applyVectorIndexPlan(store, plan, {
+          batchSize: batch,
+          replaceBaseline: previous.size === 0 && docs.length > 0,
+          shouldAbort: () => abortFlag,
+          onProgress: (indexed) => setIndexingStatus(indexDb, config, true, indexed, total),
+        });
+
+        if (applied.aborted) {
+          setIndexingStatus(indexDb, config, false, applied.embedded, total, 'Cancelled by user');
+          return;
+        }
+
+        if (previous.size === 0 || plan.changedDocs.length > 0 || plan.staleIds.length > 0) {
+          const entityPlan = planVectorIndex(docs.flatMap(entityDocumentsFor), new Map(), `${key}:entities`, { force: true });
+          const entityApplied = await applyVectorIndexPlan(entityStore, entityPlan, {
+            batchSize: batch,
+            replaceBaseline: true,
+            shouldAbort: () => abortFlag,
+          });
+          if (entityApplied.aborted) {
+            setIndexingStatus(indexDb, config, false, applied.embedded, total, 'Cancelled by user');
+            return;
           }
+        }
 
-          const batchRows = rows.slice(i, i + batch);
-          const docs = batchRows.map(row => ({
-            id: row.id,
-            document: row.content,
-            metadata: {
-              type: row.type,
-              source_file: row.source_file,
-              concepts: row.concepts,
-              tenant_id: row.tenant_id,
-              ...(row.project && { project: row.project }),
-            },
-          }));
-
-          await store.addDocuments(docs);
-          const entityDocs = docs.flatMap(entityDocumentsFor);
-          for (const doc of docs) {
+        if (plan.changedDocs.length > 0) {
+          for (const doc of plan.changedDocs) {
             replaceEntityLinks(sqlite, {
               documentId: doc.id,
               tenantId: String(doc.metadata.tenant_id ?? ''),
@@ -133,16 +167,15 @@ export function createStartRoute(deps: StartRouteDeps = {}) {
               concepts: doc.metadata.concepts,
             });
           }
-          if (entityDocs.length > 0) await entityStore.addDocuments(entityDocs);
-          setIndexingStatus(statusDb, config, true, i + batchRows.length, total);
         }
+        writeVectorIndexManifest(indexDb, plan);
 
         if (!abortFlag) {
-          setIndexingStatus(statusDb, config, false, rows.length, rows.length);
+          setIndexingStatus(indexDb, config, false, rows.length, rows.length);
         }
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
-        setIndexingStatus(statusDb, config, false, 0, 0, msg);
+        setIndexingStatus(indexDb, config, false, 0, 0, msg);
       } finally {
         await store.close().catch(() => undefined);
         await entityStore.close().catch(() => undefined);

--- a/src/scripts/index-model.ts
+++ b/src/scripts/index-model.ts
@@ -7,12 +7,13 @@ import { count } from 'drizzle-orm';
 import { DB_PATH } from '../config.ts';
 import { formatIndexProgress, normalizeBatchSize } from './indexer-progress.ts';
 import {
+  applyVectorIndexPlan,
   loadVectorIndexManifest,
   planVectorIndex,
   writeVectorIndexManifest,
   type VectorIndexPlan,
 } from '../indexer/vector-index-manifest.ts';
-import type { VectorDocument, VectorStoreAdapter } from '../vector/types.ts';
+import type { VectorDocument } from '../vector/types.ts';
 
 const args = process.argv.slice(2);
 const modelKey = args.find((arg) => !arg.startsWith('--'));
@@ -71,9 +72,13 @@ async function main() {
   await store.connect();
 
   try {
-    const embedded = await applyVectorPlan(store, plan, previous.size === 0 || force, startTime);
+    const applied = await applyVectorIndexPlan(store, plan, {
+      batchSize: BATCH_SIZE,
+      replaceBaseline: previous.size === 0 || force,
+      onProgress: (indexed, total, action) => logProgress(action === 'replaced' ? 'Rebuilt' : 'Embedded', indexed, total, startTime),
+    });
     writeVectorIndexManifest(db, plan);
-    printSummary(rows, plan, { embedded, errors: 0, startTime, dryRun, force });
+    printSummary(rows, plan, { embedded: applied.embedded, errors: 0, startTime, dryRun, force });
   } finally {
     await store.close();
     sqlite.close();
@@ -103,46 +108,6 @@ function vectorDoc(row: DbVectorRow): VectorDocument {
       ...(row.project && { project: row.project }),
     },
   };
-}
-
-async function applyVectorPlan(
-  store: VectorStoreAdapter,
-  plan: VectorIndexPlan,
-  replaceBaseline: boolean,
-  startTime: number,
-): Promise<number> {
-  if (replaceBaseline || (plan.staleIds.length > 0 && !store.deleteDocuments)) {
-    if (!store.replaceDocuments) throw new Error(`Vector adapter '${store.name}' does not support replaceDocuments()`);
-    await replaceAll(store, plan.docs, startTime);
-    return plan.docs.length;
-  }
-
-  if (plan.staleIds.length > 0) await store.deleteDocuments?.(plan.staleIds);
-  const changedIds = plan.changedDocs.map((doc) => doc.id);
-  if (changedIds.length > 0) await store.deleteDocuments?.(changedIds);
-  await addChanged(store, plan.changedDocs, plan.total, startTime);
-  return plan.changedDocs.length;
-}
-
-async function replaceAll(store: VectorStoreAdapter, docs: VectorDocument[], startTime: number): Promise<void> {
-  if (docs.length === 0) {
-    await store.replaceDocuments?.([]);
-    return;
-  }
-  for (let i = 0; i < docs.length; i += BATCH_SIZE) {
-    const batch = docs.slice(i, i + BATCH_SIZE);
-    if (i === 0) await store.replaceDocuments?.(batch);
-    else await store.addDocuments(batch);
-    logProgress('Rebuilt', i + batch.length, docs.length, startTime);
-  }
-}
-
-async function addChanged(store: VectorStoreAdapter, docs: VectorDocument[], total: number, startTime: number): Promise<void> {
-  for (let i = 0; i < docs.length; i += BATCH_SIZE) {
-    const batch = docs.slice(i, i + BATCH_SIZE);
-    await store.addDocuments(batch);
-    logProgress('Embedded', i + batch.length, total, startTime);
-  }
 }
 
 function logProgress(label: string, indexed: number, total: number, startTime: number): void {

--- a/tests/http/indexer/basic.test.ts
+++ b/tests/http/indexer/basic.test.ts
@@ -158,6 +158,43 @@ describe('indexer HTTP routes', () => {
       sqlite.close();
     }
   });
+
+  test('POST /api/indexer/start skips unchanged chunks on re-run', async () => {
+    const sqlite = tenantIndexerDb();
+    const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    seedDoc(sqlite, `idx-inc-${stamp}`, 'default', `Stable Project ${stamp}`, 1);
+    const added: VectorDocument[] = [];
+    let embedded = 0;
+    const tasks: Promise<void>[] = [];
+    const app = new Elysia({ prefix: '/api' }).use(createStartRoute({
+      createDb: () => ({ sqlite } as any),
+      createStore: (preset: any) => {
+        const store = fakeStore(String(preset.collection).endsWith('_entities') ? [] : added);
+        if (!String(preset.collection).endsWith('_entities')) {
+          const add = store.addDocuments;
+          store.addDocuments = async (docs) => { embedded += docs.length; await add(docs); };
+        }
+        return store;
+      },
+      getModels: () => ({ nomic: { collection: 'test', model: 'nomic-embed-text' } }),
+      runInBackground: (task) => tasks.push(task),
+    }));
+
+    try {
+      const run = async () => {
+        const res = await post('/api/indexer/start', { model: 'nomic', batchSize: 10 }, (path, init) => app.handle(new Request(`http://local${path}`, init)));
+        await Promise.all(tasks.splice(0));
+        expect(res.status).toBe(200);
+      };
+      await run();
+      expect(embedded).toBe(1);
+      await run();
+      expect(embedded).toBe(1);
+      expect(added.map((doc) => doc.id)).toEqual([`idx-inc-${stamp}`]);
+    } finally {
+      sqlite.close();
+    }
+  });
 });
 
 function tenantIndexerDb() {
@@ -174,6 +211,10 @@ function tenantIndexerDb() {
       id INTEGER PRIMARY KEY, is_indexing INTEGER DEFAULT 0 NOT NULL,
       progress_current INTEGER DEFAULT 0, progress_total INTEGER DEFAULT 0,
       started_at INTEGER, completed_at INTEGER, error TEXT, repo_root TEXT
+    );
+    CREATE TABLE vector_index_manifest (
+      id TEXT PRIMARY KEY, chunk_id TEXT NOT NULL, source_file TEXT NOT NULL,
+      model_key TEXT NOT NULL, content_hash TEXT NOT NULL, updated_at INTEGER NOT NULL, indexed_at INTEGER NOT NULL
     );
     INSERT INTO indexing_status (id, is_indexing) VALUES (1, 0);
   `);
@@ -192,11 +233,15 @@ function seedDoc(sqlite: Database, id: string, tenantId: string, content: string
 function fakeStore(added: VectorDocument[]): VectorStoreAdapter {
   return {
     name: 'fake-indexer-store',
-    connect: async () => {},
-    close: async () => {},
-    ensureCollection: async () => {},
-    deleteCollection: async () => {},
+    connect: async () => {}, close: async () => {}, ensureCollection: async () => {},
+    deleteCollection: async () => { added.splice(0, added.length); },
     addDocuments: async (docs) => { added.push(...docs); },
+    deleteDocuments: async (ids) => {
+      for (const id of ids) {
+        const index = added.findIndex((doc) => doc.id === id);
+        if (index >= 0) added.splice(index, 1);
+      }
+    },
     query: async () => ({ ids: [], documents: [], distances: [], metadatas: [] }),
     queryById: async () => ({ ids: [], documents: [], distances: [], metadatas: [] }),
     getStats: async () => ({ count: added.length }),


### PR DESCRIPTION
Closes #2485.

## Summary
- add shared vector-index-manifest apply flow for changed/stale chunk plans
- wire `/api/indexer/start` and `src/scripts/index-model.ts` to skip unchanged chunk hashes and prune stale vectors
- add manifest + HTTP coverage for unchanged re-runs and changed/stale application

## Tests
- `bunx tsc --noEmit`
- `bun test tests/http/indexer/`
- `bun test src/indexer/__tests__`

## Notes
- all changed files are ≤250 lines