### PR TITLE
fix(frontend): restore memory dashboard glass surfaces

### DIFF
--- a/frontend/src/pages/MemoryDashboardPage.tsx
+++ b/frontend/src/pages/MemoryDashboardPage.tsx
@@ -72,7 +72,7 @@ export function MemoryDashboardContent({ items, total, asOf, state, error }: {
   const shown = items.length;
   return (
     <div className="grid w-full min-w-0 gap-5">
-      <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="memory-dashboard-title">
+      <section className="glass rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="memory-dashboard-title">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Memory</p>
         <h1 id="memory-dashboard-title" className="mt-2 text-3xl font-semibold text-text">Memory dashboard</h1>
         <p className="mt-2 max-w-3xl text-sm text-text-muted">
@@ -89,7 +89,7 @@ export function MemoryDashboardContent({ items, total, asOf, state, error }: {
         <StatCard label="Valid-time" value={summary.validWindowCount} detail="bounded windows" tone="neutral" />
       </section>
 
-      <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-label="Memory dashboard meters">
+      <section className="glass rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-label="Memory dashboard meters">
         <div className="grid min-w-0 gap-4 md:grid-cols-[repeat(4,minmax(0,1fr))]">
           <MeterBar label="Confidence" percent={summary.avgConfidence * 100} tone="success" valueText={percentText(summary.avgConfidence)} />
           <MeterBar label="Provenance" percent={summary.avgProvenance * 100} tone="accent" valueText={percentText(summary.avgProvenance)} />
@@ -143,7 +143,7 @@ export function MemoryDashboardPage({ client = fetchMemoryRecall }: { client?: M
 
   return (
     <div className="grid w-full min-w-0 gap-5">
-      <form aria-label="Memory dashboard filters" className="grid gap-3 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:grid-cols-[minmax(0,1fr)_16rem_auto] sm:p-6" onSubmit={submit}>
+      <form aria-label="Memory dashboard filters" className="glass grid gap-3 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:grid-cols-[minmax(0,1fr)_16rem_auto] sm:p-6" onSubmit={submit}>
         <input aria-label="Memory dashboard query" className="focus-ring rounded-xl border border-border bg-field px-4 py-3 text-text placeholder:text-text-muted" value={query} onChange={(event) => setQuery(event.currentTarget.value)} placeholder="Filter memories by source, title, tag…" type="search" />
         <input aria-label="Valid-time snapshot" className="focus-ring rounded-xl border border-border bg-field px-4 py-3 text-text" value={asOf} onChange={(event) => setAsOf(event.currentTarget.value)} type="datetime-local" />
         <button className="focus-ring rounded-xl bg-accent-solid px-5 py-3 font-semibold text-on-accent transition hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50" disabled={state === 'loading'} type="submit">

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -108,7 +108,7 @@ export function MemoryPage({ search = searchMemoryHealth, recall = fetchMemoryRe
     <div className="grid w-full min-w-0 gap-5">
       <MemoryDashboardContent items={dashboardItems} total={dashboardTotal} asOf={dashboardAsOf} state={dashboardState} error={dashboardError} />
 
-      <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-sm p-5 sm:p-6" aria-labelledby="memory-health-page-title">
+      <section className="glass rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-sm p-5 sm:p-6" aria-labelledby="memory-health-page-title">
         <div className="mb-5 flex min-w-0 flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
           <div className="min-w-0">
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent2">Memory</p>

--- a/tests/frontend/pages/memory-dashboard-page.test.tsx
+++ b/tests/frontend/pages/memory-dashboard-page.test.tsx
@@ -20,6 +20,7 @@ describe('MemoryDashboardContent', () => {
   test('renders one Studio view for memory confidence signals', () => {
     const html = htmlFor(<MemoryDashboardContent items={items} total={1} asOf="2026-06-17T00:00:00.000Z" state="ready" />);
     expect(html).toContain('Memory dashboard');
+    expect(html).toContain('class="glass rounded-3xl');
     expect(html).toContain('Source coverage');
     expect(html).toContain('confidence 86% · high');
     expect(html).toContain('heat 70%');

--- a/tests/frontend/pages/memory-page-render.test.tsx
+++ b/tests/frontend/pages/memory-page-render.test.tsx
@@ -12,6 +12,7 @@ describe('MemoryPage', () => {
     );
 
     expect(html).toContain('Memory health');
+    expect(html).toContain('class="glass rounded-3xl');
     expect(html).toContain('Heat and recency');
     expect(html).toContain('Heat heatmap');
     expect(html).toContain('Confidence bars');


### PR DESCRIPTION
## Summary
- add the theme-reactive `glass` class to the Memory dashboard banner, meters, filters, and memory health shell that still carried the dark glass fallback classes
- confirm `MemoryHealthPanel` and `MemoryDashboardInsights` do not use the hardcoded dark-glass bg/border/shadow combo
- add frontend render regression assertions for the memory dashboard glass class

Fixes #2627

## Validation
- `bunx tsc --noEmit`
- `cd frontend && bun run build`
- `bun test tests/frontend/pages/memory-dashboard-page.test.tsx tests/frontend/pages/memory-page-render.test.tsx tests/frontend/components/memory-health-panel.test.tsx tests/frontend/components/memory-dashboard-insights.test.tsx`
- Visual Playwright check at `/memory`: light computed dashboard glass bg `oklch(1 0 0 / 0.58)`; dark computed bg `oklch(0.16 0.02 265 / 0.35)`; screenshots captured locally at `/tmp/arra-2627/memory-light.png` and `/tmp/arra-2627/memory-dark.png`
- `git diff --check`; `wc -l` changed files

## Note
- Full `bun test tests/frontend/` was attempted and still has 5 unrelated existing failures from `origin/alpha` expectations in NavSidebar/theme tests; affected memory frontend tests pass.