### PR TITLE
fix(frontend): restore glass surfaces (batch B, part of #2632)

### DIFF
--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -31,7 +31,7 @@ export function activitySummary(state: PageState, total: number, shown: number):
 
 function TraceCard({ trace }: { trace: TraceSummary }) {
   return (
-    <article className="min-w-0 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5" aria-label={`Trace ${trace.traceId}`}>
+    <article className="glass min-w-0 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5" aria-label={`Trace ${trace.traceId}`}>
       <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
           <p className="break-all font-mono text-xs font-semibold uppercase tracking-[0.18em] text-accent">{trace.traceId}</p>
@@ -89,7 +89,7 @@ export function ActivityPage({ load = fetchTraces }: { load?: TraceLoader }) {
 
   return (
     <section className="grid w-full min-w-0 gap-5" aria-labelledby="activity-page-title">
-      <header className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6">
+      <header className="glass rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6">
         <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
           <div className="min-w-0">
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Activity / Traces</p>

--- a/frontend/src/pages/ForumPage.tsx
+++ b/frontend/src/pages/ForumPage.tsx
@@ -123,7 +123,7 @@ export function ForumPage({ threads: initialThreads = EMPTY_THREADS, total: init
 
   return (
     <section className="grid min-w-0 gap-5" aria-labelledby="forum-page-title">
-      <header className="min-w-0 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6">
+      <header className="glass min-w-0 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Forum</p>
         <h1 id="forum-page-title" className="mt-2 text-3xl font-semibold text-text">Forum threads</h1>
         <p className="mt-2 text-sm text-text-muted">Operational conversations backed by GET {endpoint}.</p>

--- a/frontend/src/pages/LearnPage.tsx
+++ b/frontend/src/pages/LearnPage.tsx
@@ -159,7 +159,7 @@ export function LearnPage({ client = apiClient }: { client?: LearnClient }) {
 
   const busy = state === 'loading' || state === 'saving';
   return (
-    <section className="grid gap-5 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="learn-page-title">
+    <section className="glass grid gap-5 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="learn-page-title">
       <div>
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Learn</p>
         <h1 id="learn-page-title" className="mt-2 text-3xl font-semibold text-text">Learn entries</h1>

--- a/frontend/src/pages/VectorExportPage.tsx
+++ b/frontend/src/pages/VectorExportPage.tsx
@@ -110,7 +110,7 @@ export function VectorExportPage({
   }
 
   return (
-    <section className="min-w-0 overflow-hidden rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="vector-export-title">
+    <section className="glass min-w-0 overflow-hidden rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="vector-export-title">
       <div className="mb-5 min-w-0">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Vector</p>
         <h1 id="vector-export-title" className="mt-2 text-3xl font-semibold text-text">Vector export</h1>

--- a/frontend/src/pages/VectorPage.tsx
+++ b/frontend/src/pages/VectorPage.tsx
@@ -85,7 +85,7 @@ export function vectorDashboardSummary(cards: VectorCollectionCard[], state: Pag
 
 function VectorDocumentsCard() {
   return (
-    <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="vector-documents-title">
+    <section className="glass rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="vector-documents-title">
       <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Documents</p>
       <h2 id="vector-documents-title" className="mt-2 text-2xl font-semibold text-text">Browse indexed documents</h2>
       <p className="mt-2 text-sm text-text-muted">Open the collection-level document browser for full content and metadata.</p>
@@ -154,7 +154,7 @@ export function VectorPage({
 
   return (
     <div className="grid min-w-0 gap-5">
-      <section className="min-w-0 overflow-hidden rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="vector-status-title">
+      <section className="glass min-w-0 overflow-hidden rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="vector-status-title">
         <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Vector status</p>
@@ -176,7 +176,7 @@ export function VectorPage({
           <QuickExportCard cards={cards} formats={formats} downloads={downloads} onExport={onExport} />
         </div>
 
-        <section className="min-w-0 overflow-hidden rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6">
+        <section className="glass min-w-0 overflow-hidden rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6">
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Collection health</p>
           <h2 className="mt-2 text-2xl font-semibold text-text">Vector collections</h2>
           <p className="mt-2 text-sm text-text-muted">Status, model, and adapter details by collection.</p>

--- a/frontend/src/pages/VectorSearchPage.tsx
+++ b/frontend/src/pages/VectorSearchPage.tsx
@@ -152,7 +152,7 @@ export function VectorSearchPage({ client = apiClient }: { client?: VectorSearch
   }
 
   return (
-    <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="vector-search-preview-title">
+    <section className="glass rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="vector-search-preview-title">
       <div className="mb-5">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Vector</p>
         <h1 id="vector-search-preview-title" className="mt-2 text-3xl font-semibold text-text">Vector search preview</h1>

--- a/frontend/src/pages/VectorSettingsPage.tsx
+++ b/frontend/src/pages/VectorSettingsPage.tsx
@@ -40,7 +40,7 @@ function VectorFirstRunWizardSection() {
 export function VectorSettingsPage() {
   return (
     <section className="grid min-w-0 gap-5" aria-labelledby="vector-settings-title">
-      <header className="min-w-0 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6">
+      <header className="glass min-w-0 rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Vector settings</p>
         <h1 id="vector-settings-title" className="mt-2 text-3xl font-semibold text-text">Vector settings</h1>
         <p className="mt-2 break-words text-sm text-text-muted">

--- a/frontend/src/pages/vector-health-dashboard-card.tsx
+++ b/frontend/src/pages/vector-health-dashboard-card.tsx
@@ -59,7 +59,7 @@ export function VectorHealthDashboardCard({
     ? `${storage.filter((item) => item.status === 'green').length}/${storage.length} storage backends healthy`
     : 'Storage status unavailable';
   return (
-    <section className="rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="vector-health-dashboard-title">
+    <section className="glass rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6" aria-labelledby="vector-health-dashboard-title">
       <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Health</p>
       <h2 id="vector-health-dashboard-title" className="mt-2 text-2xl font-semibold text-text">Vector health dashboard</h2>
       <dl className="mt-4 grid gap-3 text-sm text-text-muted">


### PR DESCRIPTION
Part of #2632.

## Summary
- add the theme-reactive `glass` class to batch B dark-glass surfaces
- scoped to ActivityPage, VectorExportPage, VectorSettingsPage, vector-health-dashboard-card, ForumPage, VectorSearchPage, LearnPage, and VectorPage
- skipped MemoryPage.tsx per lead update because #2633 owns that file

## Tests
- `bunx tsc --noEmit`
- `cd frontend && bunx tsc --noEmit`
- `bun test frontend/src/components/simple/__tests__/healthState.test.ts`

## Notes
- all batch B files remain ≤250 lines