### PR TITLE
docs: remove stale route count claim

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,8 +48,9 @@ Users, agents, Studio, maw-js, MCP clients
    context, request de-duplication, timeouts, structured errors, and not-found
    handling.
 4. `createServerRouteModules()` mounts the Elysia route modules, then plugin
-   routes, then the not-found boundary. A source inspection currently builds 185
-   routes, 181 of them under `/api`.
+   routes, then the not-found boundary. Derive exact route totals from
+   `app.routes` in tests or tooling instead of hard-coding them in docs; dynamic
+   plugin and gateway routes may add more at runtime.
 
 ## HTTP route families
 

--- a/tests/docs/readme-claims.test.ts
+++ b/tests/docs/readme-claims.test.ts
@@ -8,6 +8,7 @@ import { smokeArraMine, smokeDockerHeroPath } from './readme-claim-smoke.ts';
 const repoRoot = process.cwd();
 const readme = readFileSync('README.md', 'utf8');
 const apiDoc = readFileSync('docs/API.md', 'utf8');
+const architectureDoc = readFileSync('docs/architecture.md', 'utf8');
 let scratch = '';
 let closeDb: (() => void) | undefined;
 let fetchClaim: ((request: Request) => Promise<Response> | Response) | undefined;
@@ -111,6 +112,7 @@ describe('README/docs advertised claims', () => {
   test('API route inventory derives counts from the base Elysia app', () => {
     expect(apiDoc).toMatch(/Base `createApp\(\)` with no dynamic plugins\/gateway config exposes the route inventory below/i);
     expect(apiDoc).not.toMatch(/exposes \d+ routes, \d+ under `\/api`/i);
+    expect(architectureDoc).not.toMatch(/builds \d+\s+routes, \d+ of them under `\/api`/i);
     expect(routeCount).toBeGreaterThan(0);
     expect(apiRouteCount).toBeGreaterThan(0);
     expect(apiRouteCount).toBeLessThanOrEqual(routeCount);


### PR DESCRIPTION
## Summary\n- remove the stale hard-coded route-count claim from docs/architecture.md\n- extend readme-claims docs regression to reject architecture hard-coded route totals\n\n## Validation\n- bun test tests/docs/readme-claims.test.ts\n- bun test tests/docs/\n- bunx tsc --noEmit\n- wc -l docs/architecture.md tests/docs/readme-claims.test.ts