### PR TITLE
test: add HTTP route-cluster coverage for research and tenants

### DIFF
--- a/tests/http/research/note.test.ts
+++ b/tests/http/research/note.test.ts
@@ -1,0 +1,78 @@
+import { afterAll, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { eq } from 'drizzle-orm';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const savedRepoRoot = process.env.ORACLE_REPO_ROOT;
+const repoRoot = mkdtempSync(join(tmpdir(), 'arra-research-route-'));
+process.env.ORACLE_REPO_ROOT = repoRoot;
+
+const dbMod = await import('../../../src/db/index.ts');
+dbMod.resetDefaultDatabaseForTests();
+const { createTenantFetch, TENANT_HEADER } = await import('../../../src/middleware/tenant.ts');
+const { researchRoutes } = await import('../../../src/routes/research/index.ts');
+
+const app = new Elysia().use(researchRoutes);
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantId = `research-tenant-${stamp}`;
+const createdIds: string[] = [];
+
+function request(body: unknown) {
+  return createTenantFetch((incoming) => app.handle(incoming))(new Request('http://local/api/research/note', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', [TENANT_HEADER]: tenantId },
+    body: JSON.stringify(body),
+  }));
+}
+
+function restore(name: string, value: string | undefined) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+afterAll(() => {
+  for (const id of createdIds) {
+    dbMod.db.delete(dbMod.oracleDocuments).where(eq(dbMod.oracleDocuments.id, id)).run();
+    dbMod.sqlite.prepare('DELETE FROM oracle_fts WHERE id = ?').run(id);
+    dbMod.db.delete(dbMod.learnLog).where(eq(dbMod.learnLog.documentId, id)).run();
+  }
+  restore('ORACLE_REPO_ROOT', savedRepoRoot);
+  rmSync(repoRoot, { recursive: true, force: true });
+});
+
+test('POST /api/research/note rejects missing titles', async () => {
+  const res = await request({ title: '   ', repoEvidence: [{ path: 'src/routes/research/index.ts', summary: 'route' }] });
+  const body = await res.json() as { success: boolean; error: string };
+
+  expect(res.status).toBe(400);
+  expect(body).toEqual({ success: false, error: 'oracle_research_note requires title' });
+});
+
+test('POST /api/research/note stores a tenant-scoped research learning', async () => {
+  const res = await request({
+    title: `Research route note ${stamp}`,
+    question: 'Does the dedicated research HTTP route persist notes?',
+    recommendation: 'Keep direct route-cluster coverage.',
+    repo: 'github.com/Soul-Brews-Studio/arra-oracle-v3',
+    repoEvidence: [{ path: 'src/routes/research/index.ts', summary: 'POST route builds a learning.' }],
+    concepts: ['coverage-gap'],
+    project: 'Arra Oracle',
+  });
+  const body = await res.json() as { success: boolean; id: string; file: string };
+  createdIds.push(body.id);
+
+  expect(res.status).toBe(200);
+  expect(body.success).toBe(true);
+  expect(body.id).toStartWith('learning_');
+  expect(body.file).toStartWith('ψ/memory/learnings/');
+
+  const row = dbMod.db.select().from(dbMod.oracleDocuments).where(eq(dbMod.oracleDocuments.id, body.id)).get();
+  expect(row).toMatchObject({ tenantId, type: 'learning', origin: 'thor-oracle', project: 'arra oracle' });
+  expect(JSON.parse(row?.concepts ?? '[]')).toEqual(expect.arrayContaining(['thor-oracle', 'stormforge', 'dev-research', 'coverage-gap']));
+
+  const file = readFileSync(join(repoRoot, body.file), 'utf-8');
+  expect(file).toContain(`Research route note ${stamp}`);
+  expect(file).toContain('Keep direct route-cluster coverage.');
+});

--- a/tests/http/tenants/admin.test.ts
+++ b/tests/http/tenants/admin.test.ts
@@ -1,0 +1,68 @@
+import { afterAll, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { eq, inArray } from 'drizzle-orm';
+
+const dbMod = await import('../../../src/db/index.ts');
+dbMod.resetDefaultDatabaseForTests();
+const { tenantsRoutes } = await import('../../../src/routes/tenants/index.ts');
+
+const app = new Elysia().use(tenantsRoutes);
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantId = `admin-tenant-${stamp}`;
+const createdIds = [tenantId];
+
+function request(pathname: string, init: RequestInit = {}) {
+  return app.handle(new Request(`http://local${pathname}`, init));
+}
+
+async function postTenant(body: unknown) {
+  return request('/api/tenants', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+afterAll(() => {
+  dbMod.db.delete(dbMod.tenants).where(inArray(dbMod.tenants.id, createdIds)).run();
+});
+
+test('GET and POST /api/tenants create, list, fetch, and update tenants', async () => {
+  const created = await postTenant({ id: tenantId, name: 'Admin Tenant' });
+  expect(created.status).toBe(200);
+  expect(await created.json()).toMatchObject({ success: true, tenant: { id: tenantId, name: 'Admin Tenant', status: 'active' } });
+
+  const listed = await request('/api/tenants');
+  const listBody = await listed.json() as { tenants: Array<{ id: string }>; count: number };
+  expect(listed.status).toBe(200);
+  expect(listBody.tenants.map((tenant) => tenant.id)).toContain(tenantId);
+  expect(listBody.count).toBe(listBody.tenants.length);
+
+  const fetched = await request(`/api/tenants/${tenantId}`);
+  expect(fetched.status).toBe(200);
+  expect(await fetched.json()).toMatchObject({ tenant: { id: tenantId, name: 'Admin Tenant', status: 'active' } });
+
+  const updated = await postTenant({ id: tenantId, name: 'Paused Tenant', status: 'disabled' });
+  expect(updated.status).toBe(200);
+  expect(await updated.json()).toMatchObject({ success: true, tenant: { id: tenantId, name: 'Paused Tenant', status: 'disabled' } });
+});
+
+test('tenant admin API rejects unsafe ids and returns shaped lookup errors', async () => {
+  for (const id of ['   ', '../escape', 'bad tenant']) {
+    const res = await postTenant({ id });
+    const body = await res.json() as { error: string };
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('tenant id');
+  }
+
+  expect(dbMod.db.select().from(dbMod.tenants).where(eq(dbMod.tenants.id, '')).get()).toBeUndefined();
+
+  const invalidLookup = await request('/api/tenants/bad%2Ftenant');
+  expect(invalidLookup.status).toBe(400);
+  expect(await invalidLookup.json()).toEqual({ error: 'Invalid tenant id' });
+
+  const missing = await request(`/api/tenants/missing-${stamp}`);
+  expect(missing.status).toBe(404);
+  expect(await missing.json()).toEqual({ error: `Tenant not found: missing-${stamp}` });
+});


### PR DESCRIPTION
## Summary

- Adds dedicated `tests/http/research/note.test.ts` coverage for `POST /api/research/note` validation and successful research-note learning persistence.
- Adds dedicated `tests/http/tenants/admin.test.ts` coverage for tenant admin list/create/get/update plus invalid-id and not-found contracts.
- Closes #2640.

## Validation

```bash
bun test tests/http/research/ tests/http/tenants/
bunx tsc --noEmit
git diff --cached --check
wc -l tests/http/research/note.test.ts tests/http/tenants/admin.test.ts
```

Results:
- Targeted tests: 4 pass / 0 fail
- Typecheck: green
- Changed files: 78 and 68 lines
