### PR TITLE
fix: harden Simple Mode health gate contract

### DIFF
--- a/frontend/src/components/HealthHero.tsx
+++ b/frontend/src/components/HealthHero.tsx
@@ -16,10 +16,12 @@ export function checkedAgo(checkedAt: number | null, now = Date.now()): string {
 export function HealthHero({
   state,
   checkedAt,
+  now,
   onAction,
 }: {
   state: HealthState;
   checkedAt: number | null;
+  now?: number;
   onAction: () => void;
 }) {
   const copy = HEALTH_STATE_COPY[state];
@@ -40,6 +42,13 @@ export function HealthHero({
       </div>
       <h1 className="mt-4 text-4xl font-bold text-text">{copy.title}</h1>
       <p className="mt-3 max-w-2xl text-base text-text-muted">{copy.detail}</p>
+      {copy.recovery ? (
+        <ul className="mt-4 grid gap-2 text-sm text-text-muted">
+          {copy.recovery.map((item) => (
+            <li key={item}><code className="rounded-lg bg-field px-2 py-1">{item}</code></li>
+          ))}
+        </ul>
+      ) : null}
       <div className="mt-6 flex flex-wrap items-center gap-4">
         <button
           className="focus-ring rounded-full bg-accent-solid px-5 py-3 text-sm font-semibold text-on-accent hover:bg-accent-solid"
@@ -48,7 +57,7 @@ export function HealthHero({
         >
           {copy.action}
         </button>
-        <span className="text-sm text-text-muted">{checkedAgo(checkedAt)}</span>
+        <span className="text-sm text-text-muted">{checkedAgo(checkedAt, now)}</span>
       </div>
     </section>
   );

--- a/frontend/src/components/simple/__tests__/healthState.test.ts
+++ b/frontend/src/components/simple/__tests__/healthState.test.ts
@@ -14,7 +14,8 @@ describe('simple health state mapper', () => {
       'degraded-db', 'degraded-fts', 'degraded-plugin', 'down', 'healthy', 'starting',
     ].sort());
     expect(HEALTH_STATE_COPY[HealthState.Healthy].title).toBe('Awake and remembering');
-    expect(HEALTH_STATE_COPY[HealthState.Down].action).toContain('Docker');
+    expect(HEALTH_STATE_COPY[HealthState.Down].action).toBe('Retry');
+    expect(HEALTH_STATE_COPY[HealthState.Down].recovery?.join('\n')).toContain('docker compose up -d');
   });
 
   test('maps healthy payloads to healthy', () => {
@@ -69,6 +70,8 @@ describe('simple health state mapper', () => {
 
   test('maps explicit down payloads to down', () => {
     expect(mapHealthState({ msSinceLoad: 10_000, health: { status: 'down' } })).toBe(HealthState.Down);
+    expect(mapHealthState({ msSinceLoad: 10_000, health: { status: 'draining', healthStatus: 'down', draining: true } }))
+      .toBe(HealthState.Down);
   });
 
   test('prefers enriched healthStatus over legacy ok status', () => {

--- a/frontend/src/components/simple/healthState.ts
+++ b/frontend/src/components/simple/healthState.ts
@@ -40,6 +40,7 @@ export interface HealthStateCopy {
   detail: string;
   action: string;
   tone: 'good' | 'wait' | 'warn' | 'bad';
+  recovery?: string[];
 }
 
 export const HEALTH_STATE_COPY: Record<HealthState, HealthStateCopy> = {
@@ -76,7 +77,8 @@ export const HEALTH_STATE_COPY: Record<HealthState, HealthStateCopy> = {
   [HealthState.Down]: {
     title: "Can't reach your Oracle",
     detail: 'The browser could not reach the backend health endpoint.',
-    action: 'If using Docker, restart the container. If using Bun, run the server again.',
+    action: 'Retry',
+    recovery: ['Docker: docker compose up -d', 'Bun: bun run server'],
     tone: 'bad',
   },
 };
@@ -94,7 +96,8 @@ export function mapHealthState(input: HealthStateInput): HealthState {
 
   const legacyStatus = health.status?.toLowerCase();
   const status = (health.healthStatus ?? health.state)?.toLowerCase();
-  if (health.draining || status === 'starting' || legacyStatus === 'starting' || legacyStatus === 'draining') return HealthState.Starting;
+  if (health.draining || legacyStatus === 'draining') return status === 'down' ? HealthState.Down : HealthState.Starting;
+  if (status === 'starting' || legacyStatus === 'starting') return HealthState.Starting;
 
   if (dbIsBad(health)) return HealthState.DegradedDb;
   if (pluginIsBad(health)) return HealthState.DegradedPlugin;

--- a/frontend/src/pages/SimplePage.tsx
+++ b/frontend/src/pages/SimplePage.tsx
@@ -18,6 +18,7 @@ export function SimplePage() {
   const failedPolls = useRef(0);
   const [state, setState] = useState<HealthState>(HealthState.Starting);
   const [checkedAt, setCheckedAt] = useState<number | null>(null);
+  const [now, setNow] = useState(Date.now());
 
   const poll = useCallback(async () => {
     try {
@@ -28,7 +29,9 @@ export function SimplePage() {
       failedPolls.current += 1;
       setState(mapHealthState({ error, failedPolls: failedPolls.current, msSinceLoad: Date.now() - loadedAt.current }));
     } finally {
-      setCheckedAt(Date.now());
+      const checked = Date.now();
+      setCheckedAt(checked);
+      setNow(checked);
     }
   }, []);
 
@@ -38,11 +41,16 @@ export function SimplePage() {
     return () => window.clearInterval(timer);
   }, [poll]);
 
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), 1_000);
+    return () => window.clearInterval(timer);
+  }, []);
+
   return (
     <main className="min-h-screen bg-field p-6 text-text">
       <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-5xl flex-col py-6">
         <div className="grid flex-1 content-center gap-5">
-          <HealthHero state={state} checkedAt={checkedAt} onAction={poll} />
+          <HealthHero state={state} checkedAt={checkedAt} now={now} onAction={poll} />
           <SimpleSearch />
           <AddMemory />
           <IndexFolderCard />

--- a/src/routes/health/health.ts
+++ b/src/routes/health/health.ts
@@ -95,9 +95,8 @@ function installedPluginCount(): number {
 }
 
 export function createHealthEndpoint(options: HealthEndpointOptions = {}) {
-  return new Elysia().get('/health', async ({ set }) => {
+  return new Elysia().get('/health', async () => {
     if (options.isDraining?.()) {
-      set.status = 503;
       const healthStatus = 'down';
       return {
         status: 'draining', healthStatus, state: healthStatus,

--- a/tests/e2e/simple-health.e2e.ts
+++ b/tests/e2e/simple-health.e2e.ts
@@ -62,7 +62,7 @@ const scenarios: Scenario[] = [
   {
     name: 'down',
     headline: "Can't reach your Oracle",
-    cta: 'If using Docker, restart the container. If using Bun, run the server again.',
+    cta: 'Retry',
     dotColor: 'oklch(0.637 0.237 25.331)',
     health: { ...baseHealth, status: 'down' },
   },
@@ -94,6 +94,10 @@ test.describe('Simple Mode health hero', () => {
       await expect(hero).toHaveAttribute('data-health-state', scenario.name);
       await expect(page.getByRole('heading', { name: scenario.headline })).toBeVisible();
       await expect(page.getByRole('button', { name: scenario.cta })).toBeVisible();
+      if (scenario.name === 'down') {
+        await expect(page.getByText('Docker: docker compose up -d')).toBeVisible();
+        await expect(page.getByText('Bun: bun run server')).toBeVisible();
+      }
       await expect(page.getByTestId('simple-health-dot')).toHaveCSS('background-color', scenario.dotColor);
       await expect(page.getByText(/checked \d+s ago/)).toBeVisible();
 

--- a/tests/http/health/draining.test.ts
+++ b/tests/http/health/draining.test.ts
@@ -13,7 +13,7 @@ test('GET /api/health reports draining state before dependency checks', async ()
   const res = await app.handle(new Request('http://local/api/health'));
   const body = await res.json() as Record<string, unknown>;
 
-  expect(res.status).toBe(503);
+  expect(res.status).toBe(200);
   expect(body).toMatchObject({ status: 'draining', sandbox: 'dev', draining: true });
   expect(dbPingCalled).toBe(false);
   expect(vectorCalled).toBe(false);

--- a/tests/http/health/phase1-contract.test.ts
+++ b/tests/http/health/phase1-contract.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from 'bun:test';
+import { createHealthRoutes } from '../../../src/routes/health/index.ts';
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+test('GET /api/health keeps HTTP 200 and shaped health contract when checks throw', async () => {
+  const previous = {
+    embedder: process.env.ORACLE_EMBEDDER,
+    legacy: process.env.ORACLE_EMBEDDING_PROVIDER,
+    backend: process.env.ORACLE_EMBEDDER_BACKEND,
+    type: process.env.EMBEDDER_TYPE,
+  };
+  process.env.ORACLE_EMBEDDER = 'ollama';
+  delete process.env.ORACLE_EMBEDDING_PROVIDER;
+  delete process.env.ORACLE_EMBEDDER_BACKEND;
+  delete process.env.EMBEDDER_TYPE;
+  try {
+    const app = createHealthRoutes({
+      uptimeSeconds: () => 31,
+      dbPing: () => { throw new Error('sqlite busy'); },
+      vectorHealth: async () => { throw new Error('vector offline'); },
+      vectorServerHealth: async () => { throw new Error('proxy offline'); },
+      pluginStatuses: () => { throw new Error('plugin scan failed'); },
+      embeddingProviders: async () => { throw new Error('ollama timeout'); },
+    });
+
+    const res = await app.handle(new Request('http://local/api/health'));
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(body.healthStatus).toBe('down');
+    expect(body.state).toBe('down');
+    expect(['healthy', 'starting', 'degraded', 'down']).toContain(body.healthStatus);
+    expect(body.dbCheck).toMatchObject({ status: 'error', error: 'sqlite busy' });
+    expect(body.vector).toMatchObject({ status: 'down', error: 'vector offline' });
+    expect(body.vectorServer).toMatchObject({ status: 'down', error: 'proxy offline' });
+    expect(body.plugins.items[0]).toMatchObject({ status: 'degraded', error: 'plugin scan failed' });
+    expect(body.subsystems.db).toEqual(body.subsystems.database);
+    expect(body.subsystems.plugin).toEqual(body.subsystems.plugins);
+    for (const name of ['database', 'db', 'fts', 'vector', 'embedder', 'plugins', 'plugin']) {
+      expect(['healthy', 'starting', 'degraded', 'down']).toContain(body.subsystems[name].status);
+    }
+  } finally {
+    restoreEnv('ORACLE_EMBEDDER', previous.embedder);
+    restoreEnv('ORACLE_EMBEDDING_PROVIDER', previous.legacy);
+    restoreEnv('ORACLE_EMBEDDER_BACKEND', previous.backend);
+    restoreEnv('EMBEDDER_TYPE', previous.type);
+  }
+});

--- a/tests/http/health/simple-status.test.ts
+++ b/tests/http/health/simple-status.test.ts
@@ -57,7 +57,7 @@ test('GET /api/health maps draining to down with subsystem detail', async () => 
   const res = await app.handle(new Request('http://local/api/health'));
   const body = await res.json() as Record<string, any>;
 
-  expect(res.status).toBe(503);
+  expect(res.status).toBe(200);
   expect(checked).toBe(false);
   expect(body.status).toBe('draining');
   expect(body.healthStatus).toBe('down');

--- a/tests/lifecycle/shutdown.test.ts
+++ b/tests/lifecycle/shutdown.test.ts
@@ -15,7 +15,7 @@ describe('graceful shutdown', () => {
 
       fixture.process.kill('SIGTERM');
       const draining = await waitForDrainingHealth(fixture);
-      expect(draining.status).toBe(503);
+      expect(draining.status).toBe(200);
       expect(draining.body.status).toBe('draining');
 
       const exitCode = await Promise.race([
@@ -99,7 +99,10 @@ async function waitForDrainingHealth(fixture: ServerFixture): Promise<{ status: 
   while (Date.now() < deadline) {
     try {
       const res = await fetch(`${fixture.baseUrl}/api/health`);
-      if (res.status === 503) return { status: res.status, body: await res.json() };
+      if (res.status === 200) {
+        const body = await res.json();
+        if (body.status === 'draining') return { status: res.status, body };
+      }
     } catch {}
     await sleep(50);
   }


### PR DESCRIPTION
## Summary
- keep `/api/health` as HTTP 200 while the process is alive, including draining, while preserving shaped `healthStatus/state/subsystems` body
- add Phase 1 contract coverage for thrown DB/vector/vector-server/plugin/embedder checks and canonical subsystem aliases
- harden Simple Mode gate behavior: draining/down payloads render Down, checked-age ticks live, Down shows concrete Docker/Bun commands with a Retry button

## Validation
- `bunx tsc --noEmit`
- `bun test tests/http/health/`
- `bunx tsc -p frontend/tsconfig.json --noEmit`
- `bun test frontend/src/components/simple/__tests__/healthState.test.ts tests/frontend/components/health-hero.test.tsx tests/frontend/pages/simple-page.test.tsx`
- `bunx playwright test tests/e2e/simple-health.e2e.ts`
- `wc -l` on changed files (all <=250)

Refs #2637
