### PR TITLE
test: cover BackendGate CORS and PNA detection

### DIFF
--- a/tests/frontend/components/backend-gate-shell.test.tsx
+++ b/tests/frontend/components/backend-gate-shell.test.tsx
@@ -152,4 +152,71 @@ describe('BackendGate shell', () => {
     expect(calls).toHaveLength(2);
     expect(calls[1]?.mode).toBe('no-cors');
   });
+
+  test('CORS-rejected health checks render origin-trust guidance, not the PNA prompt', async () => {
+    const restoreLocation = installBrowserLocation('https://studio.example/memory');
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = ((_url: string | URL | Request, init?: RequestInit) => init?.mode === 'no-cors'
+      ? Promise.resolve(new Response('', { status: 204 }))
+      : Promise.reject(new TypeError('Failed to fetch'))) as typeof fetch;
+
+    try {
+      await browserHealthCheck();
+      throw new Error('expected browserHealthCheck to reject');
+    } catch (error) {
+      expect(error).toBeInstanceOf(BrowserHealthError);
+      const html = htmlFor(
+        <ConnectOracleSetup
+          accessIssue={(error as BrowserHealthError).issue}
+          isTauri={false}
+          message={(error as Error).message}
+          onRetry={() => {}}
+          onStartBackend={() => {}}
+          starting={false}
+          state="unreachable"
+        />,
+      );
+
+      expect(html).toContain('https://studio.example is not in the backend CORS allowlist');
+      expect(html).toContain('The backend answered, but this Studio origin is not trusted.');
+      expect(html).toContain('ARRA_CORS_ORIGINS');
+      expect(html).not.toContain('v4.buildwithoracle.com wants to');
+      expect(html).not.toContain('The real Chrome prompt appears here.');
+    } finally {
+      globalThis.fetch = previousFetch;
+      restoreLocation();
+    }
+  });
+
+  test('genuine connectivity failures still render the PNA guide', async () => {
+    const previousFetch = globalThis.fetch;
+    const original = new TypeError('Failed to fetch');
+    globalThis.fetch = (() => Promise.reject(original)) as typeof fetch;
+
+    try {
+      await browserHealthCheck();
+      throw new Error('expected browserHealthCheck to reject');
+    } catch (error) {
+      expect(error).toBe(original);
+      const html = htmlFor(
+        <ConnectOracleSetup
+          accessIssue="pna"
+          isTauri={false}
+          message={(error as Error).message}
+          onRetry={() => {}}
+          onStartBackend={() => {}}
+          starting={false}
+          state="unreachable"
+        />,
+      );
+
+      expect(html).toContain('Cannot reach http://localhost:47778: Failed to fetch');
+      expect(html).toContain('v4.buildwithoracle.com wants to');
+      expect(html).toContain('The real Chrome prompt appears here.');
+      expect(html).not.toContain('ARRA_CORS_ORIGINS');
+      expect(html).not.toContain('this Studio origin is not trusted');
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- Adds BackendGate regression coverage for the PR #2631 browser CORS/PNA detection path.
- Verifies a failed CORS health check plus successful `no-cors` probe renders the origin-trust / `ARRA_CORS_ORIGINS` message and hides the PNA ghost prompt.
- Verifies genuine connectivity/PNA failure still renders the PNA guide.

## Validation

```bash
bun test tests/frontend/components/backend-gate-shell.test.tsx
bunx tsc --noEmit
git diff --check
wc -l tests/frontend/components/backend-gate-shell.test.tsx
```

Results:
- Scoped frontend tests: 10 pass / 0 fail
- Typecheck: green
- File length: 222 lines
