### PR TITLE
docs: make Simple Mode the install health check

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -51,13 +51,17 @@ arra-oracle-v3 serve --port "$ORACLE_PORT"
 From another shell:
 
 ```bash
+open "http://localhost:$ORACLE_PORT/simple"   # human-first health screen
 curl -sf "http://localhost:$ORACLE_PORT/api/health"
 arra config add local "http://localhost:$ORACLE_PORT"
 arra config use local
 arra health
 ```
 
-Expected health includes `status: ok` / `server: arra-oracle-v3`.
+Expected Simple Mode result: **Awake and remembering** when core health is
+ready, or an actionable recovery message if startup, DB, search/vector, or
+plugins are degraded. CLI fallback health includes `status: ok` /
+`server: arra-oracle-v3` and should use the same recovery targets.
 
 ## First memory
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -39,11 +39,17 @@ arra-oracle-v3 serve --port "$ORACLE_PORT"
 Keep this shell open. In a second shell:
 
 ```bash
+open "http://localhost:$ORACLE_PORT/simple"   # human-first health screen
 curl -sf "http://localhost:$ORACLE_PORT/api/health"
 arra config add local "http://localhost:$ORACLE_PORT"
 arra config use local
 arra health
 ```
+
+Expected Simple Mode result: **Awake and remembering** when core health is
+ready, or an actionable degraded/down recovery message if DB, search/vector, or
+plugins need attention. Use `curl /api/health` and `arra health --json` as CLI
+fallbacks for the same health vocabulary.
 
 ## 3. Mine the sample notes
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -6,12 +6,18 @@ fail. Start with the quickest health check, then narrow by symptom.
 ## Quick triage
 
 ```bash
+open http://localhost:47778/simple
 arra-oracle-v3 --help
 arra --help
 arra health
 curl -sf http://localhost:47778/api/health
 bunx tsc --noEmit
 ```
+
+Use Simple Mode first for human verification: it should show **Awake and
+remembering** or a specific recovery target for startup, DB, limited search,
+plugins, or a down backend. Use `arra health --json` and `curl /api/health`
+when you need machine-readable details.
 
 If the HTTP server runs on a non-default port, replace `47778` with that port or
 set the CLI target with `arra config add` and `arra config use`.
@@ -45,6 +51,7 @@ Symptoms: port binding errors, `EADDRINUSE`, or the CLI points at a dead server.
 
 ```bash
 ORACLE_PORT=47881 arra-oracle-v3 serve --port 47881
+open http://localhost:47881/simple
 arra config add local-47881 http://localhost:47881
 arra config use local-47881
 curl -sf http://localhost:47881/api/health

--- a/tests/docs/simple-mode-docs.test.ts
+++ b/tests/docs/simple-mode-docs.test.ts
@@ -3,7 +3,10 @@ import { readFileSync } from 'node:fs';
 
 const readme = readFileSync('README.md', 'utf8');
 const docsIndex = readFileSync('docs/README.md', 'utf8');
+const install = readFileSync('docs/INSTALL.md', 'utf8');
+const quickstart = readFileSync('docs/QUICKSTART.md', 'utf8');
 const simpleSpec = readFileSync('docs/SIMPLE-MODE-SPEC.md', 'utf8');
+const troubleshooting = readFileSync('docs/TROUBLESHOOTING.md', 'utf8');
 const recap = readFileSync('src/tools/recap.ts', 'utf8');
 
 describe('Simple Mode docs for non-dev users', () => {
@@ -15,6 +18,14 @@ describe('Simple Mode docs for non-dev users', () => {
 
   test('docs index links the Simple Mode spec', () => {
     expect(docsIndex).toContain('[SIMPLE-MODE-SPEC.md](./SIMPLE-MODE-SPEC.md)');
+  });
+
+  test('install and recovery docs use /simple as the human-first health check', () => {
+    for (const doc of [install, quickstart, troubleshooting]) {
+      expect(doc).toContain('/simple');
+      expect(doc).toMatch(/Awake and\s+remembering/);
+      expect(doc).toMatch(/curl .*api\/health|curl \/api\/health/);
+    }
   });
 
   test('Simple Mode spec names the six never-silent health states', () => {


### PR DESCRIPTION
## Summary\n- update install, quickstart, and troubleshooting docs to send humans to /simple first after starting the server\n- keep curl /api/health and arra health as CLI/machine-readable fallbacks\n- extend docs regression coverage so install/recovery docs keep /simple + Awake and remembering copy\n\n## Install verification\n- isolated BUN_INSTALL/HOME\n- bun add -g github:Soul-Brews-Studio/arra-oracle-v3#v26.7.5-alpha.404 succeeded\n- arra-oracle-v3 serve --port 47840 started and /api/health responded with version 26.7.5-alpha.404\n\n## Validation\n- bun test tests/docs/simple-mode-docs.test.ts\n- bun test tests/docs/\n- bunx tsc --noEmit\n- wc -l docs/QUICKSTART.md docs/INSTALL.md docs/TROUBLESHOOTING.md tests/docs/simple-mode-docs.test.ts