### PR TITLE
fix: complete Simple Mode core loop

### DIFF
--- a/frontend/src/components/simple/AddMemory.tsx
+++ b/frontend/src/components/simple/AddMemory.tsx
@@ -125,8 +125,15 @@ export function AddMemory({
 
   async function persistMemory(nextPattern = text) {
     const candidate = nextPattern.trim();
-    if (!candidate || status === 'saving') return;
+    if (status === 'saving') return;
     clearTimers();
+    if (!candidate) {
+      setLastFailed('');
+      setError('Write a memory first.');
+      setStatus('error');
+      setFading(false);
+      return;
+    }
     setStatus('saving');
     setError('');
     setFading(false);
@@ -149,7 +156,7 @@ export function AddMemory({
   }
 
   const saving = status === 'saving';
-  const disabled = saving || !text.trim();
+  const disabled = saving;
   return (
     <section className="grid gap-4 rounded-3xl border border-border bg-surface p-5 shadow-xl" aria-labelledby="simple-add-memory-title">
       <div>
@@ -165,6 +172,7 @@ export function AddMemory({
           id={textareaId}
           className="focus-ring min-h-32 rounded-2xl border border-border bg-field px-4 py-3 text-text placeholder:text-text-muted"
           disabled={saving}
+          aria-invalid={status === 'error' ? 'true' : undefined}
           placeholder="A detail, decision, or preference you want Oracle to recall."
           value={text}
           onChange={(event) => setText(event.currentTarget.value)}

--- a/frontend/src/components/simple/SimpleSearch.tsx
+++ b/frontend/src/components/simple/SimpleSearch.tsx
@@ -78,6 +78,11 @@ export function SimpleSearch({ client = apiClient }: { client?: SimpleSearchClie
     setQuery(example);
   }
 
+  function retrySearch() {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    void runSearch(activeQuery || query);
+  }
+
   const status = simpleSearchStatus(state, activeQuery || query.trim(), results.length);
 
   return (
@@ -120,7 +125,20 @@ export function SimpleSearch({ client = apiClient }: { client?: SimpleSearchClie
       </div>
 
       <p className="mt-4 text-sm text-text-muted" aria-live="polite">{status}</p>
-      {error ? <p role="alert" className="mt-2 text-sm text-err-text">{error}</p> : null}
+      {error ? (
+        <div role="alert" className="mt-3 rounded-2xl border border-err-border bg-err-bg p-3 text-sm text-err-text">
+          <p className="font-semibold">Couldn’t search memory.</p>
+          <p className="mt-1 break-words">{error}</p>
+          <button
+            className="focus-ring mt-3 rounded-full border border-err-border px-4 py-2 font-semibold hover:bg-surface"
+            disabled={state === 'loading'}
+            type="button"
+            onClick={retrySearch}
+          >
+            Retry search
+          </button>
+        </div>
+      ) : null}
 
       <div className="mt-5 grid gap-3" aria-busy={state === 'loading'}>
         {state !== 'loading' ? results.map((result) => <SimpleResultCard key={result.id} result={result} />) : null}

--- a/frontend/src/components/simple/__tests__/simpleModeLoop.test.tsx
+++ b/frontend/src/components/simple/__tests__/simpleModeLoop.test.tsx
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { HealthHero } from '../../HealthHero.tsx';
+import { SimplePage } from '../../../pages/SimplePage.tsx';
+import {
+  AddMemory,
+  AddMemoryFeedback,
+  saveSimpleMemory,
+  simpleMemoryPayload,
+  type SimpleMemoryPayload,
+} from '../AddMemory.tsx';
+import {
+  IndexFolderCard,
+  isLocalOracleHost,
+  mineCommandForPath,
+} from '../IndexFolderCard.tsx';
+import { SimpleSearch, SIMPLE_SEARCH_EMPTY, simpleSearchStatus, visibleSimpleResults } from '../SimpleSearch.tsx';
+import { HealthState, mapHealthState } from '../healthState.ts';
+
+function result(id: number) {
+  return { id: String(id), content: `memory ${id}`, source_file: `note-${id}.md` };
+}
+
+describe('Simple Mode core loop contracts', () => {
+  test('search contract exposes input, button, examples, cap, and empty copy', () => {
+    const html = renderToStaticMarkup(<SimpleSearch />);
+    expect(html).toContain('Simple search form');
+    expect(html).toContain('Search memory…');
+    expect(html).toContain('deployment notes');
+    expect(visibleSimpleResults([1, 2, 3, 4, 5, 6].map(result))).toHaveLength(5);
+    expect(simpleSearchStatus('ready', 'missing', 0)).toBe(SIMPLE_SEARCH_EMPTY);
+    expect(simpleSearchStatus('error', 'vector', 0)).toContain('retry');
+  });
+
+  test('add memory posts trimmed Simple Mode payload and rejects blanks', async () => {
+    let sent: SimpleMemoryPayload | null = null;
+    const payload = await saveSimpleMemory('  remember this  ', async (next) => {
+      sent = next;
+    });
+    expect(payload).toEqual({ pattern: 'remember this', source: 'Simple Mode' });
+    expect(sent).toEqual(payload);
+    expect(simpleMemoryPayload('  note  ')).toEqual({ pattern: 'note', source: 'Simple Mode' });
+    await expect(saveSimpleMemory('   ', async () => {
+      throw new Error('should not call backend');
+    })).rejects.toThrow('Memory text is required.');
+  });
+
+  test('add memory UI keeps retryable error and aria-live saved confirmation', () => {
+    const form = renderToStaticMarkup(<AddMemory />);
+    expect(form).toContain('Save something to memory');
+    const saved = renderToStaticMarkup(<AddMemoryFeedback status="saved" error="" fading={false} saving={false} onRetry={() => {}} />);
+    expect(saved).toContain('aria-live="polite"');
+    expect(saved).toContain('Saved.');
+    const error = renderToStaticMarkup(<AddMemoryFeedback status="error" error="offline" fading={false} saving={false} onRetry={() => {}} />);
+    expect(error).toContain('Couldn’t save memory.');
+    expect(error).toContain('Retry');
+  });
+
+  test('index folder browser fallback is explicit and copy-paste safe', () => {
+    expect(isLocalOracleHost('localhost:47778')).toBe(true);
+    expect(isLocalOracleHost('v4.buildwithoracle.com')).toBe(false);
+    expect(mineCommandForPath('/Users/alex/My Notes')).toBe("arra mine '/Users/alex/My Notes'");
+    expect(mineCommandForPath('')).toBe('arra mine <dir>');
+    const fallback = renderToStaticMarkup(
+      <IndexFolderCard defaultExpanded initialPath="/tmp/notes" runtime={{ tauri: false, localApi: true }} />,
+    );
+    expect(fallback).toContain('Browser tabs cannot launch local folder reads directly');
+    expect(fallback).toContain('arra mine /tmp/notes');
+    expect(fallback).toContain('Copy command');
+  });
+
+  test('simple path keeps actions visible while observing degraded search health', async () => {
+    const page = renderToStaticMarkup(<SimplePage />);
+    const state = mapHealthState({
+      msSinceLoad: 10_000,
+      health: { status: 'ok', dbStatus: 'connected', pluginStatus: 'ok', vectorAvailable: false },
+    });
+    expect(state).toBe(HealthState.DegradedFts);
+    const hero = renderToStaticMarkup(<HealthHero state={state} checkedAt={Date.now()} onAction={() => {}} />);
+    const search = visibleSimpleResults([1, 2].map(result));
+    let saved: SimpleMemoryPayload | null = null;
+    await saveSimpleMemory('degraded search still saves', async (payload) => {
+      saved = payload;
+    });
+    expect(page).toContain('Ask your Oracle');
+    expect(page).toContain('Add a memory');
+    expect(page).toContain('Add a whole folder of notes');
+    expect(hero).toContain('Running, but search is limited');
+    expect(search).toHaveLength(2);
+    expect(saved).toEqual({ pattern: 'degraded search still saves', source: 'Simple Mode' });
+  });
+});

--- a/frontend/src/pages/SimplePage.tsx
+++ b/frontend/src/pages/SimplePage.tsx
@@ -51,6 +51,11 @@ export function SimplePage() {
       <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-5xl flex-col py-6">
         <div className="grid flex-1 content-center gap-5">
           <HealthHero state={state} checkedAt={checkedAt} now={now} onAction={poll} />
+          {state === HealthState.Down ? (
+            <p className="rounded-2xl border border-err-border bg-err-bg p-4 text-sm text-err-text">
+              Recovery comes first: the cards below keep their text visible, but actions will report errors until the backend is reachable again.
+            </p>
+          ) : null}
           <SimpleSearch />
           <AddMemory />
           <IndexFolderCard />


### PR DESCRIPTION
## Summary
- Add retryable Simple Mode search errors while keeping explicit submit + debounce flow intact.
- Show blank Add Memory rejection before POST while preserving retryable backend failures.
- Add a Down-state recovery notice and Simple Mode loop contract tests for search/save/index/degraded health.

## Verification
- bunx tsc --noEmit
- (cd frontend && bunx tsc --noEmit)
- (cd frontend && bun run build)
- bun test frontend/src/components/simple/__tests__/
- bun test tests/frontend/components/simple-search-contract.test.tsx tests/frontend/components/simple-add-memory.test.tsx tests/frontend/components/simple-index-folder-card.test.tsx tests/frontend/components/simple-result-card-render.test.tsx tests/frontend/pages/simple-page.test.tsx frontend/src/components/simple/__tests__/
- bun test tests/integration/simple-flow/full-flow.test.ts

Screenshot: /tmp/arra-simple-mode-2638.png

Closes #2638