### PR TITLE
fix: rank memory search over confidence candidates

### DIFF
--- a/src/routes/memory/index.ts
+++ b/src/routes/memory/index.ts
@@ -9,6 +9,7 @@ import { formatCloseoutMemory, type MemoryCloseoutInput } from './closeout.ts';
 import { currentTenantId } from '../../middleware/tenant.ts';
 import { rankMemories } from './rank.ts';
 import { createMemoryStatsEndpoint } from './stats.ts';
+import { candidatePoolSize } from '../../search/retrieve-depth.ts';
 
 export function createMemoryRoutes(
   store: MemoryStore = memoryStore,
@@ -85,7 +86,8 @@ export function createMemoryRoutes(
       const limit = parseMemoryLimit(query.limit);
       try {
         isoAsOf(query.asOf);
-        const hits = await vectorIndex.search(query.q, limit);
+        const candidateLimit = candidatePoolSize(limit);
+        const hits = await vectorIndex.search(query.q, candidateLimit);
         const records = store.getByIds(hits.map((hit) => hit.memoryId), { asOf: query.asOf });
         const merged = mergeHits(hits, records);
         const scores = new Map(hits.map((hit) => [hit.memoryId, hit.score]));
@@ -96,7 +98,12 @@ export function createMemoryRoutes(
           score: (memory) => scores.get(memory.id),
           entityScore: (memory) => entityScores.get(memory.id),
         }).slice(0, limit);
-        return { success: true, query: query.q, asOf: isoAsOf(query.asOf), total: results.length, confidence: MEMORY_CONFIDENCE_STRATEGY, results };
+        return {
+          success: true, query: query.q, asOf: isoAsOf(query.asOf), total: results.length,
+          confidence: MEMORY_CONFIDENCE_STRATEGY,
+          ranking: { strategy: 'valid_time_confidence_heat_entity_match', candidatePool: candidateLimit },
+          results,
+        };
       } catch (error) {
         const message = error instanceof Error ? error.message : 'memory vector search failed';
         set.status = message.includes('valid-time') ? 400 : 503;

--- a/tests/http/memory/limit-hardening.test.ts
+++ b/tests/http/memory/limit-hardening.test.ts
@@ -53,7 +53,7 @@ test('memory routes fall back from malformed limit query values', async () => {
   await fetcher(new Request('http://local/api/v1/memory/recall?limit=2abc'));
 
   expect(recallLimits).toEqual([8, 10, 10]);
-  expect(searchLimits).toEqual([10]);
+  expect(searchLimits).toEqual([100]);
 });
 
 test('memory routes clamp out-of-range limit query values', async () => {
@@ -63,7 +63,7 @@ test('memory routes clamp out-of-range limit query values', async () => {
   await fetcher(new Request('http://local/api/v1/memory/search?q=oracle&limit=999'));
 
   expect(recallLimits).toEqual([25, 1]);
-  expect(searchLimits).toEqual([50]);
+  expect(searchLimits).toEqual([100]);
 });
 
 test('memory fanout normalizes malformed and large limits', async () => {

--- a/tests/http/memory/search-confidence-ranking.test.ts
+++ b/tests/http/memory/search-confidence-ranking.test.ts
@@ -1,0 +1,94 @@
+import { expect, test } from 'bun:test';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createMemoryRoutes } from '../../../src/routes/memory/index.ts';
+import type { MemoryRecord, MemoryStore } from '../../../src/routes/memory/store.ts';
+import type { MemoryVectorHit, MemoryVectorIndex } from '../../../src/routes/memory/vector.ts';
+
+const fresh = new Date().toISOString();
+
+function record(overrides: Partial<MemoryRecord>): MemoryRecord {
+  return {
+    id: overrides.id ?? crypto.randomUUID(),
+    content: 'oracle confidence ranking memory',
+    createdAt: overrides.createdAt ?? fresh,
+    updatedAt: overrides.updatedAt ?? fresh,
+    ...overrides,
+  };
+}
+
+class RankingStore implements Partial<MemoryStore> {
+  constructor(private readonly records: MemoryRecord[]) {}
+
+  save() { throw new Error('unused'); }
+  recall() { return []; }
+  tierSummary() { throw new Error('unused'); }
+
+  getByIds(ids: string[]) {
+    const byId = new Map(this.records.map((item) => [item.id, item]));
+    return ids.map((id) => byId.get(id)).filter((item): item is MemoryRecord => Boolean(item));
+  }
+}
+
+class RankingVectorIndex implements MemoryVectorIndex {
+  readonly requestedLimits: number[] = [];
+
+  constructor(private readonly hits: MemoryVectorHit[]) {}
+
+  async index() { return { indexed: true as const }; }
+
+  async search(_query: string, limit: number) {
+    this.requestedLimits.push(limit);
+    return this.hits.slice(0, limit);
+  }
+}
+
+async function json(response: Response) {
+  return JSON.parse(await response.text());
+}
+
+test('GET /api/v1/memory/search ranks a wider candidate pool by confidence before slicing', async () => {
+  const staleVectorWin = record({
+    id: 'stale-vector-win',
+    createdAt: '2020-01-01T00:00:00.000Z',
+    updatedAt: '2020-01-01T00:00:00.000Z',
+  });
+  const trustedFresh = record({
+    id: 'trusted-fresh',
+    title: 'Trusted fresh note',
+    tags: ['deploy', 'confidence'],
+    source: 'session://phase-1',
+    usageCount: 20,
+    lastAccessedAt: fresh,
+  });
+  const hits: MemoryVectorHit[] = [
+    hit(staleVectorWin, 1),
+    hit(trustedFresh, 0.93),
+  ];
+  const vector = new RankingVectorIndex(hits);
+  const app = createMemoryRoutes(new RankingStore([staleVectorWin, trustedFresh]) as MemoryStore, vector);
+  const fetcher = createApiVersionedFetch((request) => app.handle(request));
+
+  const response = await fetcher(new Request('http://local/api/v1/memory/search?q=oracle&limit=1'));
+  const body = await json(response);
+
+  expect(response.status).toBe(200);
+  expect(vector.requestedLimits[0]).toBeGreaterThan(1);
+  expect(body.ranking).toMatchObject({
+    strategy: 'valid_time_confidence_heat_entity_match',
+    candidatePool: vector.requestedLimits[0],
+  });
+  expect(body.results.map((item: MemoryRecord) => item.id)).toEqual(['trusted-fresh']);
+  expect(body.results[0].ranking.components.confidence).toBeGreaterThan(0.9);
+  expect(body.results[0].ranking.components.confidence).toBeLessThanOrEqual(1);
+});
+
+function hit(memory: MemoryRecord, score: number): MemoryVectorHit {
+  return {
+    memoryId: memory.id,
+    vectorId: `memory:${memory.id}`,
+    document: memory.content,
+    metadata: { type: 'memory', memoryId: memory.id },
+    distance: 1 - score,
+    score,
+  };
+}


### PR DESCRIPTION
## Summary
- make `/api/memory/search` retrieve a wider bounded candidate pool before final ranking/slicing, so query-time memory confidence can actually reorder returned search results
- expose the memory search ranking strategy and candidate-pool size in the response
- add regression coverage proving a fresh/high-provenance hit can beat a higher raw vector score before `limit=1` slicing

## Validation
- `bunx tsc --noEmit`
- `bun test tests/http/memory/`
- changed files all <=250 lines

Refs #2644
