### PR TITLE
test: cover P0 onboarding mine path

### DIFF
--- a/tests/http/config/defaults.test.ts
+++ b/tests/http/config/defaults.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test';
+import { defaultDataPathForEngine, generateDefaultConfig } from '../../../src/vector/config.ts';
+import { resolveEmbeddingProvider, resolveVectorBackend } from '../../../src/vector/backend-resolution.ts';
+
+describe('P0 first-run config defaults', () => {
+  test('selects local vector and embedding defaults without prompting', () => {
+    const defaults = generateDefaultConfig();
+    const backend = resolveVectorBackend(defaults, 'defaults', {} as NodeJS.ProcessEnv);
+    const provider = resolveEmbeddingProvider(defaults, 'defaults', []);
+
+    expect(defaults.enabled).toBe(false);
+    expect(defaults.collections['bge-m3']).toMatchObject({ adapter: 'lancedb', provider: 'ollama', primary: true });
+    expect(backend).toMatchObject({
+      engine: 'lancedb',
+      source: 'first-run-default',
+      dataPath: defaultDataPathForEngine('lancedb'),
+      localDefault: true,
+      returningUser: false,
+      providerPrompt: false,
+      wizard: 'optional',
+    });
+    expect(provider).toMatchObject({
+      provider: 'ollama',
+      source: 'first-run-default',
+      local: true,
+      returningUser: false,
+      providerPrompt: false,
+      wizard: 'optional',
+    });
+  });
+});

--- a/tests/http/indexer/chunker.test.ts
+++ b/tests/http/indexer/chunker.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test';
+import { chunkDocumentForIndexing, chunkText } from '../../../src/indexer/chunk-text.ts';
+import type { OracleDocument } from '../../../src/types.ts';
+
+function doc(content: string): OracleDocument {
+  return {
+    id: 'onboarding-note',
+    type: 'learning',
+    source_file: 'mine/sample/onboarding.md',
+    content,
+    concepts: ['onboarding'],
+    created_at: 1,
+    updated_at: 2,
+  };
+}
+
+describe('P0 onboarding chunker', () => {
+  test('splits long notes on paragraph boundaries before crossing the max size', () => {
+    const first = `alpha ${'a'.repeat(28)}`;
+    const second = `beta ${'b'.repeat(28)}`;
+    const third = `gamma ${'c'.repeat(28)}`;
+    const text = `${first}\n\n${second}\n\n${third}`;
+
+    const chunks = chunkText(text, 80);
+
+    expect(chunks).toEqual([
+      { content: `${first}\n\n${second}`, chunk_index: 0, line_start: 1, line_end: 3 },
+      { content: third, chunk_index: 1, line_start: 5, line_end: 5 },
+    ]);
+    expect(chunks[0].content).not.toContain(third);
+  });
+
+  test('adds stable chunk ids and line ranges for indexed documents', () => {
+    const chunks = chunkDocumentForIndexing(doc('first paragraph\n\nsecond paragraph\n\nthird paragraph'), 34);
+
+    expect(chunks.map((chunk) => chunk.id)).toEqual(['onboarding-note__chunk_0', 'onboarding-note__chunk_1']);
+    expect(chunks.map((chunk) => chunk.chunk_index)).toEqual([0, 1]);
+    expect(chunks[0]).toMatchObject({ line_start: 1, line_end: 3 });
+    expect(chunks[1]).toMatchObject({ content: 'third paragraph', line_start: 5, line_end: 5 });
+  });
+});

--- a/tests/http/indexer/mine.test.ts
+++ b/tests/http/indexer/mine.test.ts
@@ -1,0 +1,84 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import { mineFolder } from '../../../src/indexer/mine.ts';
+
+const root = mkdtempSync(join(tmpdir(), 'arra-mine-onboarding-'));
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+type RunResult = { exitCode: number; stdout: string; stderr: string };
+
+async function run(command: string[], env: Record<string, string | undefined>): Promise<RunResult> {
+  const proc = Bun.spawn(command, { cwd: process.cwd(), env, stdout: 'pipe', stderr: 'pipe' });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { exitCode, stdout, stderr };
+}
+
+function rows(dbPath: string): Array<Record<string, any>> {
+  const sqlite = new Database(dbPath, { readonly: true });
+  try {
+    return sqlite.prepare(`
+      SELECT d.id, d.source_file, d.project, d.concepts, d.created_by, f.content
+      FROM oracle_documents d
+      JOIN oracle_fts f ON f.id = d.id
+      WHERE d.created_by = 'mine'
+      ORDER BY d.source_file
+    `).all() as Array<Record<string, any>>;
+  } finally {
+    sqlite.close();
+  }
+}
+
+describe('P0 onboarding mine CLI', () => {
+  test('ingests a markdown folder through the shipped CLI', async () => {
+    const notes = join(root, `notes-${Date.now()}`);
+    const dbPath = join(root, 'mine-cli.db');
+    mkdirSync(join(notes, 'ops'), { recursive: true });
+    writeFileSync(join(notes, 'ops', 'deploy.md'), '# Deploy Runbook\n\nRollback checklist and deploy memory notes.');
+    writeFileSync(join(notes, 'ops', 'ignore.json'), '{"skip":true}');
+
+    const result = await run([process.execPath, 'bin/arra.ts', 'mine', notes, '--db-path', dbPath], {
+      ...process.env,
+      ORACLE_DATA_DIR: join(root, 'data-cli'),
+      ORACLE_EMBEDDER: 'none',
+      ORACLE_VECTOR_DISABLED: '1',
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('Mined 1 document from 1 file');
+    const stored = rows(dbPath);
+    expect(stored).toHaveLength(1);
+    expect(stored[0]).toMatchObject({ created_by: 'mine', source_file: `mine/${basename(notes)}/ops/deploy.md` });
+    expect(stored[0].content).toContain('Rollback checklist');
+    expect(JSON.parse(stored[0].concepts)).toEqual(expect.arrayContaining(['deploy', 'memory', 'ops']));
+  }, 30_000);
+
+  test('auto-derives project and concepts from the mined directory structure', async () => {
+    const repo = join(root, 'github.com', 'Soul-Brews-Studio', 'onboarding-demo');
+    const docs = join(repo, 'knowledge');
+    const dbPath = join(root, 'mine-derive.db');
+    mkdirSync(join(docs, 'architecture'), { recursive: true });
+    writeFileSync(join(docs, 'architecture', 'vector-search.md'), '# Vector Search\n\nRetrieval ranking and onboarding config notes.');
+
+    const result = await mineFolder({ dir: docs, dbPath });
+    const [stored] = rows(dbPath);
+
+    expect(result).toMatchObject({ scanned: 1, stored: 1, skipped: 0, project: 'github.com/soul-brews-studio/onboarding-demo' });
+    expect(stored.project).toBe('github.com/soul-brews-studio/onboarding-demo');
+    expect(JSON.parse(stored.concepts)).toEqual(expect.arrayContaining([
+      'github.com/soul-brews-studio/onboarding-demo',
+      'architecture',
+      'vector',
+      'search',
+      'ranking',
+      'config',
+    ]));
+  });
+});


### PR DESCRIPTION
## Summary

- Adds P0 onboarding coverage for `arra mine` ingesting a sample folder through the shipped CLI.
- Adds regression tests for mine auto-derivation of project + concepts from a ghq-style directory.
- Adds chunker tests proving paragraph-boundary splits and stable chunk metadata.
- Adds first-run default config coverage proving local defaults are selected without provider prompts.

Closes #2420.

## Validation

```bash
bun test tests/http/indexer/mine.test.ts tests/http/indexer/chunker.test.ts tests/http/config/defaults.test.ts
bunx tsc --noEmit
git diff --check
wc -l tests/http/indexer/mine.test.ts tests/http/indexer/chunker.test.ts tests/http/config/defaults.test.ts
```

Results:
- Scoped tests: 5 pass / 0 fail
- Typecheck: green
- Files: 84 / 41 / 31 lines
