### PR TITLE
fix: default-safe first-run vector backend

### DIFF
--- a/frontend/src/components/SetupWizardContent.tsx
+++ b/frontend/src/components/SetupWizardContent.tsx
@@ -1,6 +1,7 @@
 import { SetupWizardCostEstimate } from "./SetupWizardCostEstimate";
 import { StateNotice } from "./StateNotice";
 import type { Step, VectorConfig, VectorIndexSource } from "./setupWizardTypes";
+import { DEFAULT_SAFE_VECTOR_ENGINE } from "../../../src/config/defaults";
 
 export const setupSteps = [
   "Welcome",
@@ -47,7 +48,7 @@ export function StepBody({
 }
 
 function LocalBackendPlan({ config }: { config: VectorConfig | null }) {
-  const engine = config?.resolution?.engine ?? "lancedb";
+  const engine = config?.resolution?.engine ?? DEFAULT_SAFE_VECTOR_ENGINE;
   const collections = Object.entries(config?.config?.collections ?? {});
   return (
     <div className="mt-3 rounded-xl border border-ok-border bg-ok-bg p-3 text-sm text-ok-text">

--- a/frontend/src/components/wizard/FirstRunWizard.tsx
+++ b/frontend/src/components/wizard/FirstRunWizard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { ErrorMessage, LoadingPanel, Spinner } from '../AsyncState';
 import { apiFetch } from '../../api/oracle';
 import { useFirstRun } from '../../hooks/useFirstRun';
+import { DEFAULT_SAFE_VECTOR_ENGINE } from '../../../../src/config/defaults';
 
 type Step = 0 | 1 | 2 | 3;
 type LoadState = 'loading' | 'ready' | 'error';
@@ -46,7 +47,7 @@ function copyFor(step: Step): string {
 export function FirstRunWizard() {
   const { markSetupComplete, setupComplete } = useFirstRun();
   const [step, setStep] = useState<Step>(0);
-  const [backend, setBackend] = useState('lancedb');
+  const [backend, setBackend] = useState<string>(DEFAULT_SAFE_VECTOR_ENGINE);
   const [plans, setPlans] = useState(defaultPlans);
   const [state, setState] = useState<LoadState>('loading');
   const [busy, setBusy] = useState(false);
@@ -58,7 +59,7 @@ export function FirstRunWizard() {
     json<{ engine?: string; resolution?: { engine?: string } }>('/api/v1/vector/config')
       .then((body) => {
         if (!active) return;
-        setBackend(body.resolution?.engine ?? body.engine ?? 'lancedb');
+        setBackend(body.resolution?.engine ?? body.engine ?? DEFAULT_SAFE_VECTOR_ENGINE);
         setState('ready');
       })
       .catch((cause) => {

--- a/frontend/src/pages/FirstRunWizard.tsx
+++ b/frontend/src/pages/FirstRunWizard.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { ErrorMessage, LoadingPanel, Spinner } from '../components/AsyncState';
 import { fetchJson, parseVectorConfigResponse, toRows, type VectorConfigRow } from './vectorSettingsHelpers';
+import { DEFAULT_VECTOR_COLLECTION, detectDefaultVectorBackend } from '../../../src/config/defaults';
 
 type WizardStep = 0 | 1 | 2 | 3;
 type StatsResponse = { total?: number; total_docs?: number; vector?: { enabled?: boolean; count?: number } };
@@ -25,6 +26,7 @@ export type FirstRunWizardProps = {
 };
 
 const steps = ['Welcome', 'Backend', 'Vault + index', 'Done'] as const;
+type WizardResolution = ReturnType<typeof detectFirstRunWizardResolution>;
 
 export function VectorFirstRunWizardPage() {
   const [rows, setRows] = useState<VectorConfigRow[]>([]);
@@ -51,7 +53,7 @@ export function VectorFirstRunWizardPage() {
       <header className="glass rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl p-5 sm:p-6">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent2">Vector onboarding</p>
         <h1 id="vector-first-run-title" className="mt-2 text-3xl font-semibold text-text">First-run setup wizard</h1>
-        <p className="mt-2 text-sm text-text-muted">Use the local vector backend default, review cost, choose the first vault collection, and start indexing.</p>
+        <p className="mt-2 text-sm text-text-muted">Arra selects sqlite-vec automatically. This page is optional/advanced for review, cost, and first index controls.</p>
       </header>
 
       <FirstRunWizard rows={rows} onRefresh={refresh} />
@@ -61,14 +63,27 @@ export function VectorFirstRunWizardPage() {
   );
 }
 
-function primaryKey(rows: VectorConfigRow[]): string | null {
-  return (rows.find((row) => row.primary) ?? rows[0])?.key ?? null;
+function primaryRow(rows: VectorConfigRow[]): VectorConfigRow | null {
+  return rows.find((row) => row.primary) ?? rows[0] ?? null;
 }
 
-function firstRun(stats: StatsResponse | null, rows: VectorConfigRow[]): boolean {
-  const total = stats?.total_docs ?? stats?.total ?? 0;
-  const vectorCount = stats?.vector?.count ?? rows.reduce((sum, row) => sum + (row.count ?? 0), 0);
-  return total === 0 || vectorCount === 0;
+function indexedCount(stats: StatsResponse | null, rows: VectorConfigRow[]): number {
+  return stats?.vector?.count ?? rows.reduce((sum, row) => sum + (row.count ?? 0), 0);
+}
+
+export function detectFirstRunWizardResolution(rows: VectorConfigRow[], stats: StatsResponse | null) {
+  const primary = primaryRow(rows);
+  const count = indexedCount(stats, rows);
+  const choice = detectDefaultVectorBackend({
+    configuredEngine: primary?.adapter,
+    hasExistingIndex: count > 0 || stats?.vector?.enabled === true,
+  });
+  return {
+    ...choice,
+    count,
+    key: primary?.key ?? DEFAULT_VECTOR_COLLECTION.key,
+    collection: primary?.collection ?? DEFAULT_VECTOR_COLLECTION.collection,
+  };
 }
 
 export function FirstRunWizard({ rows, onRefresh, initialStep = 0, initialCost = null }: FirstRunWizardProps) {
@@ -78,7 +93,8 @@ export function FirstRunWizard({ rows, onRefresh, initialStep = 0, initialCost =
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
-  const showAsFirstRun = firstRun(stats, rows);
+  const resolution = detectFirstRunWizardResolution(rows, stats);
+  const showAsFirstRun = !resolution.returningUser && resolution.count === 0;
 
   useEffect(() => {
     let active = true;
@@ -108,8 +124,7 @@ export function FirstRunWizard({ rows, onRefresh, initialStep = 0, initialCost =
   }
 
   async function startIndex() {
-    const model = primaryKey(rows);
-    if (!model) return setError('No vector collection is available to index.');
+    const model = resolution.key;
     setBusy(true);
     setError('');
     try {
@@ -127,23 +142,23 @@ export function FirstRunWizard({ rows, onRefresh, initialStep = 0, initialCost =
     <section className={`glass rounded-3xl border bg-[oklch(0.16_0.02_265/0.35)] p-5 shadow-[0_8px_32px_oklch(0_0_0/0.4)] backdrop-blur-xl sm:p-6 ${showAsFirstRun ? 'border-purple-300/20' : 'border-[oklch(1_0_0/0.08)]'}`} aria-labelledby="first-run-wizard-title">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent2">First-run wizard</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent2">Optional first-run wizard</p>
           <h2 id="first-run-wizard-title" className="mt-2 text-2xl font-semibold text-text">{steps[step]}</h2>
-          <p className="mt-2 max-w-3xl text-sm text-purple-100/80">{copyFor(step, showAsFirstRun)}</p>
+          <p className="mt-2 max-w-3xl text-sm text-purple-100/80">{copyFor(step, resolution, showAsFirstRun)}</p>
         </div>
         <ol className="flex gap-2" aria-label="First-run steps">{steps.map((item, index) => <li key={item} className={`h-2 w-10 rounded-full ${index <= step ? 'bg-purple-200' : 'bg-white/20'}`} />)}</ol>
       </div>
 
-      {step === 1 ? <BackendPlan rows={rows} /> : null}
-      {step === 2 ? <VaultPlan rows={rows} cost={cost} /> : null}
+      {step === 1 ? <BackendPlan resolution={resolution} /> : null}
+      {step === 2 ? <VaultPlan resolution={resolution} cost={cost} /> : null}
       {step === 3 ? <DoneActions /> : null}
       {message ? <p className="mt-4 rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] p-3 text-sm text-purple-100 backdrop-blur-md">{message}</p> : null}
       {error ? <div className="mt-4"><ErrorMessage title="First-run step failed." message={error} /></div> : null}
 
       <div className="mt-5 flex flex-wrap gap-2">
         <button className="focus-ring rounded-xl border border-border px-3 py-2 text-sm text-purple-100 disabled:opacity-50" disabled={step === 0} type="button" onClick={() => setStep((step - 1) as WizardStep)}>Back</button>
-        {step === 0 ? <button className="focus-ring rounded-xl bg-purple-200 px-3 py-2 text-sm font-semibold text-on-accent" type="button" onClick={() => void reloadHealth()}>{busy ? <Spinner label="Detecting" /> : 'Refresh local backend'}</button> : null}
-        {step === 2 ? <button className="focus-ring rounded-xl bg-teal-200 px-3 py-2 text-sm font-semibold text-on-accent disabled:opacity-50" disabled={busy || !rows.length} type="button" onClick={() => void startIndex()}>{busy ? <Spinner label="Starting" /> : 'Start indexing'}</button> : null}
+        {step === 0 ? <button className="focus-ring rounded-xl bg-purple-200 px-3 py-2 text-sm font-semibold text-on-accent" type="button" onClick={() => void reloadHealth()}>{busy ? <Spinner label="Detecting" /> : 'Detect local defaults'}</button> : null}
+        {step === 2 ? <button className="focus-ring rounded-xl bg-teal-200 px-3 py-2 text-sm font-semibold text-on-accent disabled:opacity-50" disabled={busy} type="button" onClick={() => void startIndex()}>{busy ? <Spinner label="Starting" /> : 'Start indexing'}</button> : null}
         <button className="focus-ring rounded-xl border border-purple-200/40 px-3 py-2 text-sm font-semibold text-purple-100 disabled:opacity-50" disabled={step === 3} type="button" onClick={() => setStep((step + 1) as WizardStep)}>Next</button>
         {step === 3 ? <a className="focus-ring rounded-xl bg-teal-200 px-3 py-2 text-sm font-semibold text-on-accent" href="/vector">Continue to dashboard</a> : null}
       </div>
@@ -151,10 +166,10 @@ export function FirstRunWizard({ rows, onRefresh, initialStep = 0, initialCost =
   );
 }
 
-function copyFor(step: WizardStep, firstRun: boolean): string {
-  if (step === 0) return firstRun ? 'No complete vector index was detected. A bundled local backend is already selected; build the first index when ready.' : 'Vector search is configured; use this optional wizard to refresh the backend or onboard a new vault.';
-  if (step === 1) return 'Arra auto-resolves local storage defaults for first run and keeps saved backend choices for returning users.';
-  if (step === 2) return 'Review the primary collection, estimated cost, and recommendation before indexing.';
+function copyFor(step: WizardStep, resolution: WizardResolution, firstRun: boolean): string {
+  if (step === 0) return firstRun ? `No provider prompt: ${resolution.engine} is selected automatically; build the first index when ready.` : `Existing backend detected (${resolution.engine}); this wizard is optional/advanced.`;
+  if (step === 1) return `detect() resolved ${resolution.engine} from ${resolution.source}; returning users keep saved backend choices.`;
+  if (step === 2) return `Review ${resolution.collection}, estimated cost, and recommendation before indexing.`;
   return 'Indexing has started. The Index Manager shows live progress and completion state.';
 }
 
@@ -172,23 +187,21 @@ function DoneActions() {
   );
 }
 
-function BackendPlan({ rows }: { rows: VectorConfigRow[] }) {
-  const primary = rows.find((row) => row.primary) ?? rows[0];
+function BackendPlan({ resolution }: { resolution: WizardResolution }) {
   return (
     <div className="mt-4 rounded-2xl border border-accent-border p-4 text-sm text-accent">
       <p className="font-semibold">Local backend default is active</p>
-      <p className="mt-1">No provider choice is required before indexing. Returning users keep their saved adapter automatically.</p>
-      <p className="mt-2 text-accent opacity-80">Primary adapter: {primary?.adapter ?? 'lancedb'} · collection {primary?.collection ?? 'default collections'}</p>
+      <p className="mt-1">No provider prompt or provider choice is required before indexing. Returning users keep their saved adapter automatically.</p>
+      <p className="mt-2 text-accent opacity-80">Primary adapter: {resolution.engine} · collection {resolution.collection}</p>
     </div>
   );
 }
 
-function VaultPlan({ rows, cost }: { rows: VectorConfigRow[]; cost: CostEstimate | null }) {
-  const primary = rows.find((row) => row.primary) ?? rows[0];
+function VaultPlan({ resolution, cost }: { resolution: WizardResolution; cost: CostEstimate | null }) {
   return (
     <div className="mt-4 grid gap-3 text-sm text-purple-100 lg:grid-cols-[1fr_1.3fr]">
       <div className="rounded-2xl border border-[oklch(1_0_0/0.05)] bg-[oklch(0.20_0.02_265/0.25)] p-4 backdrop-blur-md">
-        <p>Primary collection: <span className="font-semibold">{primary?.collection ?? 'none'}</span></p>
+        <p>Primary collection: <span className="font-semibold">{resolution.collection}</span></p>
         <p className="mt-1 text-purple-100/70">Vault selection is represented by indexed source documents; use Index now to backfill vectors for the primary model.</p>
       </div>
       <div className="rounded-2xl border border-accent-border p-4">

--- a/frontend/src/pages/vectorSettingsHelpers.ts
+++ b/frontend/src/pages/vectorSettingsHelpers.ts
@@ -1,4 +1,5 @@
 import { apiFetch } from '../api/oracle';
+import { DEFAULT_SAFE_VECTOR_ENGINE, DEFAULT_VECTOR_LOCAL_ENGINES } from '../../../src/config/defaults';
 
 export const ADAPTER_OPTIONS = ['chroma', 'sqlite-vec', 'lancedb', 'qdrant', 'cloudflare-vectorize', 'proxy', 'turbovec'] as const;
 export type VectorConfigAdapter = (typeof ADAPTER_OPTIONS)[number];
@@ -89,7 +90,7 @@ function isAdapter(value: unknown): value is VectorConfigAdapter {
 }
 
 export function safeAdapter(value: unknown): VectorConfigAdapter {
-  return isAdapter(value) ? value : 'lancedb';
+  return isAdapter(value) ? value : DEFAULT_SAFE_VECTOR_ENGINE;
 }
 
 export function parseVectorConfigResponse(value: unknown): VectorConfigResponse {
@@ -104,9 +105,9 @@ export function parseVectorConfigResponse(value: unknown): VectorConfigResponse 
       embeddingEndpoint: '',
       embedder: { backend: 'unknown' },
     },
-    engine: 'lancedb' as VectorConfigAdapter,
+    engine: DEFAULT_SAFE_VECTOR_ENGINE as VectorConfigAdapter,
     enabled: false,
-    options: { localEngines: ['lancedb', 'qdrant', 'sqlite-vec'] as VectorConfigAdapter[] },
+    options: { localEngines: [...DEFAULT_VECTOR_LOCAL_ENGINES] as VectorConfigAdapter[] },
     doc_counts: {},
     health: {},
     checked_at: new Date().toISOString(),
@@ -165,7 +166,7 @@ export function toRows(response: VectorConfigResponse): VectorConfigRow[] {
       collection: item.collection,
       model: item.model,
       provider: item.provider,
-      adapter: item.adapter ?? 'lancedb',
+      adapter: item.adapter ?? DEFAULT_SAFE_VECTOR_ENGINE,
       service: item.service,
       endpoint: item.endpoint,
       primary: item.primary,

--- a/src/config/__tests__/defaults.test.ts
+++ b/src/config/__tests__/defaults.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  DEFAULT_SAFE_VECTOR_ENGINE,
+  DEFAULT_VECTOR_COLLECTION,
+  detectDefaultVectorBackend,
+} from '../defaults.ts';
+
+describe('default-safe vector backend resolution', () => {
+  test('first run resolves sqlite-vec without a provider prompt', () => {
+    expect(DEFAULT_SAFE_VECTOR_ENGINE).toBe('sqlite-vec');
+    expect(DEFAULT_VECTOR_COLLECTION).toMatchObject({ key: 'bge-m3', adapter: 'sqlite-vec' });
+    expect(detectDefaultVectorBackend()).toMatchObject({
+      engine: 'sqlite-vec',
+      source: 'first-run-default',
+      returningUser: false,
+      providerPrompt: false,
+      wizard: 'optional',
+    });
+  });
+
+  test('returning users keep detected backend choices', () => {
+    expect(detectDefaultVectorBackend({ configuredEngine: 'lancedb', hasExistingIndex: true })).toMatchObject({
+      engine: 'lancedb',
+      source: 'detect',
+      returningUser: true,
+    });
+  });
+});

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -1,0 +1,67 @@
+export const DEFAULT_SAFE_VECTOR_ENGINE = 'sqlite-vec' as const;
+export const DEFAULT_VECTOR_LOCAL_ENGINES = ['sqlite-vec', 'lancedb', 'qdrant'] as const;
+export const DEFAULT_VECTOR_COLLECTION = {
+  key: 'bge-m3',
+  collection: 'oracle_knowledge_bge_m3',
+  model: 'bge-m3',
+  provider: 'ollama',
+  adapter: DEFAULT_SAFE_VECTOR_ENGINE,
+  primary: true,
+  enabled: true,
+} as const;
+
+export type DefaultVectorConfigSource = 'file' | 'defaults';
+export type DefaultVectorResolutionSource = 'config' | 'env' | 'detect' | 'first-run-default';
+export type DefaultVectorBackendResolution = {
+  engine: string;
+  source: DefaultVectorResolutionSource;
+  localDefault: boolean;
+  returningUser: boolean;
+  providerPrompt: false;
+  wizard: 'optional';
+  reason: string;
+};
+
+const SAFE_DEFAULT_ENGINES = new Set<string>(['sqlite-vec', 'lancedb']);
+const LOCAL_ENGINE_SET = new Set<string>(DEFAULT_VECTOR_LOCAL_ENGINES);
+
+export function detectDefaultVectorBackend(input: {
+  envEngine?: string;
+  configuredEngine?: string;
+  configSource?: DefaultVectorConfigSource;
+  hasExistingIndex?: boolean;
+} = {}): DefaultVectorBackendResolution {
+  const envEngine = normalizeLocalEngine(input.envEngine);
+  if (envEngine) return resolution(envEngine, 'env', false, 'ORACLE_VECTOR_DB selects the local vector backend.');
+
+  const configuredEngine = normalizeEngine(input.configuredEngine);
+  if (input.configSource === 'file' && configuredEngine) {
+    return resolution(configuredEngine, 'config', true, 'Existing vector-server.json selects the backend.');
+  }
+  if (input.hasExistingIndex && configuredEngine) {
+    return resolution(configuredEngine, 'detect', true, 'Existing vector index was detected; keeping the current backend.');
+  }
+  return resolution(DEFAULT_SAFE_VECTOR_ENGINE, 'first-run-default', false, 'Fresh installs use sqlite-vec without a provider prompt.');
+}
+
+function normalizeLocalEngine(value: string | undefined): string | null {
+  const normalized = normalizeEngine(value);
+  return normalized && LOCAL_ENGINE_SET.has(normalized) ? normalized : null;
+}
+
+function normalizeEngine(value: string | undefined): string | null {
+  const normalized = value?.trim().toLowerCase();
+  return normalized || null;
+}
+
+function resolution(engine: string, source: DefaultVectorResolutionSource, returningUser: boolean, reason: string): DefaultVectorBackendResolution {
+  return {
+    engine,
+    source,
+    returningUser,
+    reason,
+    localDefault: SAFE_DEFAULT_ENGINES.has(engine),
+    providerPrompt: false,
+    wizard: 'optional',
+  };
+}

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -16,6 +16,7 @@ import {
   type RuntimeEnv,
 } from './schema.ts';
 import { applyProfileDefaults, resolveConfigProfile, type ConfigProfile } from './profiles.ts';
+import { DEFAULT_SAFE_VECTOR_ENGINE } from './defaults.ts';
 
 export class ConfigValidationError extends Error {
   constructor(readonly issues: string[]) {
@@ -168,7 +169,7 @@ function validateRuntimePaths(env: RuntimeEnv, issues: string[]): void {
   if (filled(env.ORACLE_REPO_ROOT)) validateWritablePath('ORACLE_REPO_ROOT', env.ORACLE_REPO_ROOT.trim(), issues, true);
 }
 function validateVectorConnectionConfig(env: RuntimeEnv, issues: string[]): void {
-  const type = (env.ORACLE_VECTOR_DB?.trim() || 'lancedb').toLowerCase();
+  const type = (env.ORACLE_VECTOR_DB?.trim() || DEFAULT_SAFE_VECTOR_ENGINE).toLowerCase();
   if (type === 'qdrant' && !filled(env.QDRANT_URL)) issues.push('Qdrant vector DB requires QDRANT_URL.');
   if (type === 'proxy' && !filled(env.ORACLE_PROXY_VECTOR_URL)) issues.push('Proxy vector DB requires ORACLE_PROXY_VECTOR_URL.');
   if (type === 'lancedb' || type === 'sqlite-vec') {

--- a/src/routes/vector/__tests__/config.test.ts
+++ b/src/routes/vector/__tests__/config.test.ts
@@ -15,23 +15,23 @@ const { getEmbeddingModels, getVectorStoreConfigByModel } = await import('../../
 const app = new Elysia({ prefix: '/api' }).use(vectorConfigEndpoint);
 
 describe('/api/vector/config', () => {
-  test('GET keeps backward-compatible defaults when no config file exists', async () => {
+  test('GET uses default-safe sqlite-vec defaults when no config file exists', async () => {
     const res = await app.handle(new Request('http://localhost/api/vector/config'));
     const body = await res.json() as any;
 
     expect(res.status).toBe(200);
     expect(body.source).toBe('defaults');
-    expect(body.engine).toBe('lancedb');
+    expect(body.engine).toBe('sqlite-vec');
     expect(body.enabled).toBe(false);
     expect(body.resolution).toMatchObject({
-      engine: 'lancedb',
+      engine: 'sqlite-vec',
       source: 'first-run-default',
       providerPrompt: false,
       wizard: 'optional',
     });
     expect(body.state).toMatchObject({ enabled: false, ready: false, reason: 'vector section disabled' });
     expect(body.config.collections['bge-m3']).toMatchObject({
-      adapter: 'lancedb',
+      adapter: 'sqlite-vec',
       model: 'bge-m3',
       primary: true,
     });

--- a/src/vector/__tests__/config.test.ts
+++ b/src/vector/__tests__/config.test.ts
@@ -26,10 +26,10 @@ describe('vector-server config', () => {
   test('default config advertises per-collection adapter/provider metadata', () => {
     const cfg = generateDefaultConfig();
     expect(cfg.enabled).toBe(false);
-    expect(cfg.collections['bge-m3'].adapter).toBe('lancedb');
+    expect(cfg.collections['bge-m3'].adapter).toBe('sqlite-vec');
     expect(cfg.collections['bge-m3'].provider).toBe('ollama');
-    expect(cfg.collections.nomic.adapter).toBe('lancedb');
-    expect(cfg.collections.qwen3.adapter).toBe('lancedb');
+    expect(cfg.collections.nomic.adapter).toBe('sqlite-vec');
+    expect(cfg.collections.qwen3.adapter).toBe('sqlite-vec');
   });
 
   test('writeVectorConfig creates ORACLE_DATA_DIR and loadVectorConfig reads it back', () => {
@@ -130,7 +130,7 @@ describe('local vector engine selection', () => {
       },
     });
 
-    expect(cfg.collections['bge-m3'].adapter).toBe('lancedb');
+    expect(cfg.collections['bge-m3'].adapter).toBe('sqlite-vec');
     expect(configToModels(cfg).fast).toMatchObject({
       adapter: 'qdrant',
       collection: 'oracle_fast_nomic',

--- a/src/vector/__tests__/factory-config-selection.test.ts
+++ b/src/vector/__tests__/factory-config-selection.test.ts
@@ -97,7 +97,7 @@ describe('vector engine/config selection coverage', () => {
         qdrantApiKey: 'secret-key',
       });
       expect(getVectorStoreConfigByModel('missing-model')).toMatchObject({
-        type: 'lancedb',
+        type: 'sqlite-vec',
         collectionName: 'oracle_knowledge_bge_m3',
         embeddingModel: 'bge-m3',
       });

--- a/src/vector/backend-resolution.ts
+++ b/src/vector/backend-resolution.ts
@@ -4,18 +4,18 @@ import {
   isLocalVectorEngine,
   type VectorServerConfig,
 } from './config.ts';
+import { detectDefaultVectorBackend } from '../config/defaults.ts';
 import type { DetectedEmbeddingProvider } from './provider-detection.ts';
 import type { EmbeddingProviderType, VectorDBType } from './types.ts';
 
 export type ConfigSource = 'file' | 'defaults';
 export type ResolutionSource = 'config' | 'env' | 'detect' | 'first-run-default';
 
-export const DEFAULT_SAFE_LOCAL_ENGINE = 'lancedb' as const;
 const SAFE_LOCAL_ENGINES = new Set(['sqlite-vec', 'lancedb']);
 
 export interface VectorBackendResolution {
   engine: VectorDBType;
-  source: Exclude<ResolutionSource, 'detect'>;
+  source: ResolutionSource;
   dataPath: string;
   localDefault: boolean;
   returningUser: boolean;
@@ -39,16 +39,16 @@ export function resolveVectorBackend(
   source: ConfigSource,
   env: NodeJS.ProcessEnv = process.env,
 ): VectorBackendResolution {
-  const envEngine = normalizeEngine(env.ORACLE_VECTOR_DB);
-  if (envEngine) return backend(envEngine, 'env', defaultDataPathForEngine(envEngine), source === 'file', 'ORACLE_VECTOR_DB selects the local vector backend.');
-
-  const configured = activeVectorEngine(config);
-  if (source === 'file') {
-    return backend(configured, 'config', config.dataPath, true, 'Existing vector-server.json selects the backend.');
-  }
-
-  const selected = safeLocal(configured) ? configured : DEFAULT_SAFE_LOCAL_ENGINE;
-  return backend(selected, 'first-run-default', defaultDataPathForEngine(selected), false, 'Fresh installs use the bundled local backend without a provider prompt.');
+  const choice = detectDefaultVectorBackend({
+    envEngine: env.ORACLE_VECTOR_DB,
+    configuredEngine: activeVectorEngine(config),
+    configSource: source,
+  });
+  const engine = choice.engine as VectorDBType;
+  const dataPath = choice.source === 'config'
+    ? config.dataPath
+    : isLocalVectorEngine(engine) ? defaultDataPathForEngine(engine) : config.dataPath;
+  return backend(engine, choice.source, dataPath, choice.returningUser, choice.reason);
 }
 
 export function resolveEmbeddingProvider(
@@ -64,7 +64,7 @@ export function resolveEmbeddingProvider(
   return provider(configured ?? 'ollama', 'first-run-default', false, 'Fresh installs default to local Ollama/FTS fallback without prompting.');
 }
 
-function backend(engine: VectorDBType, source: VectorBackendResolution['source'], dataPath: string, returningUser: boolean, reason: string): VectorBackendResolution {
+function backend(engine: VectorDBType, source: ResolutionSource, dataPath: string, returningUser: boolean, reason: string): VectorBackendResolution {
   return {
     engine, source, dataPath, returningUser, reason,
     localDefault: safeLocal(engine),
@@ -82,12 +82,7 @@ function provider(providerName: EmbeddingProviderType, source: ResolutionSource,
   };
 }
 
-function normalizeEngine(value: string | undefined): typeof DEFAULT_SAFE_LOCAL_ENGINE | 'sqlite-vec' | null {
-  const normalized = value?.trim().toLowerCase();
-  return normalized === 'sqlite-vec' || normalized === 'lancedb' ? normalized : null;
-}
-
-function safeLocal(engine: VectorDBType): engine is typeof DEFAULT_SAFE_LOCAL_ENGINE | 'sqlite-vec' {
+function safeLocal(engine: VectorDBType): boolean {
   return isLocalVectorEngine(engine) && SAFE_LOCAL_ENGINES.has(engine);
 }
 

--- a/src/vector/config.ts
+++ b/src/vector/config.ts
@@ -4,13 +4,14 @@
  * Phase 2 of #1071: the config file describes collections, models,
  * and deployment settings for the standalone vector server (Phase 3).
  *
- * The file is optional. When absent, getEmbeddingModels() returns
- * hardcoded defaults. When present, it's the source of truth.
+ * The file is optional. When absent, getEmbeddingModels() returns the
+ * default-safe sqlite-vec config. When present, it's the source of truth.
  */
 
 import fs from 'fs';
 import path from 'path';
 import { ORACLE_DATA_DIR } from '../config.ts';
+import { DEFAULT_SAFE_VECTOR_ENGINE, DEFAULT_VECTOR_LOCAL_ENGINES } from '../config/defaults.ts';
 import { COLLECTION_NAME, LANCEDB_DIR_NAME, VECTORS_DB_FILE } from '../const.ts';
 import type { VectorDBType } from './types.ts';
 import type { LocalVectorEngine, VectorCollectionConfig, VectorConfigUpdate, VectorProxyManifest, VectorServerConfig, VectorStorageConfig } from './config-types.ts';
@@ -18,7 +19,7 @@ import { zeroConfigEmbedder } from './default-embedder.ts';
 import { normalizeVectorConfig } from './config-normalize.ts';
 
 export const VECTOR_CONFIG_FILE = 'vector-server.json';
-export const LOCAL_VECTOR_ENGINES = ['lancedb', 'qdrant', 'sqlite-vec'] as const;
+export const LOCAL_VECTOR_ENGINES = DEFAULT_VECTOR_LOCAL_ENGINES;
 export type { LocalVectorEngine, VectorCollectionConfig, VectorConfigUpdate, VectorProxyManifest, VectorServerConfig, VectorServerV2Storage, VectorStorageConfig, VectorStorageService, VectorModelRegistryEntry } from './config-types.ts';
 export { configToModels, resolveServiceEndpoint } from './config-models.ts';
 
@@ -44,6 +45,8 @@ export function configPath(dataDir = process.env.ORACLE_DATA_DIR || ORACLE_DATA_
  * This is the "factory" version — users can tweak after writing to disk.
  */
 export function generateDefaultConfig(): VectorServerConfig {
+  const adapter = DEFAULT_SAFE_VECTOR_ENGINE;
+  const dataPath = defaultDataPathForEngine(adapter);
   return {
     version: '1.0',
     enabled: false,
@@ -54,7 +57,7 @@ export function generateDefaultConfig(): VectorServerConfig {
         collection: 'oracle_knowledge_bge_m3',
         model: 'bge-m3',
         provider: 'ollama',
-        adapter: 'lancedb',
+        adapter,
         primary: true,
         embedder: zeroConfigEmbedder('bge-m3'),
       },
@@ -62,23 +65,23 @@ export function generateDefaultConfig(): VectorServerConfig {
         collection: COLLECTION_NAME,
         model: 'nomic-embed-text',
         provider: 'ollama',
-        adapter: 'lancedb',
+        adapter,
         embedder: zeroConfigEmbedder('nomic-embed-text'),
       },
       qwen3: {
         collection: 'oracle_knowledge_qwen3',
         model: 'qwen3-embedding',
         provider: 'ollama',
-        adapter: 'lancedb',
+        adapter,
         embedder: zeroConfigEmbedder('qwen3-embedding'),
       },
     },
-    dataPath: defaultLanceDbDir(),
+    dataPath,
     embeddingEndpoint: '',
     storage: {
-      default: 'lancedb',
+      default: adapter,
       services: {
-        lancedb: { type: 'builtin' },
+        [adapter]: { type: 'builtin' },
       },
     },
     proxy: defaultVectorProxyManifest(),
@@ -218,7 +221,7 @@ export function fallbackCollectionsFor(config: VectorServerConfig): VectorCollec
       collection: `oracle_knowledge_${name.replace(/[^a-z0-9]+/g, '_')}`,
       model: 'bge-m3',
       provider: 'none',
-      adapter: 'lancedb',
+      adapter: isLocalVectorEngine(name) ? name : DEFAULT_SAFE_VECTOR_ENGINE,
       service: name,
       primary: name === storageService.default,
     }));

--- a/src/vector/factory.ts
+++ b/src/vector/factory.ts
@@ -13,7 +13,7 @@ import { TurboVecAdapter } from './adapters/turbovec.ts';
 import { createEmbeddingProvider, FallbackEmbeddings } from './embeddings.ts';
 import { GeminiEmbeddings } from './providers/gemini.ts';
 import { resolveEmbeddingFallbackChain, resolveEmbeddingModel, resolveEmbeddingProviderType } from './embedder-config.ts';
-import { configPath, loadVectorConfig, resolveServiceEndpoint, configToModels, fallbackCollectionsFor } from './config.ts';
+import { configPath, loadVectorConfig, resolveServiceEndpoint, configToModels, fallbackCollectionsFor, generateDefaultConfig } from './config.ts';
 import { tenantDataPath } from '../middleware/tenant.ts';
 import { withEmbedderIdentityGuard } from './embedder-identity.ts';
 
@@ -132,18 +132,14 @@ export function getEmbeddingModels(
       modelMap[col.collection] = {
         collection: col.collection,
         model: col.model,
-        adapter: storageService?.type === 'proxy' ? 'proxy' : 'lancedb',
+        adapter: storageService?.type === 'proxy' ? 'proxy' : col.adapter,
         endpoint: resolveServiceEndpoint(cfg, serviceName),
       };
     }
     return modelMap;
   }
   if (cfg) return configToModels(cfg);
-  return {
-    nomic: { collection: COLLECTION_NAME, model: 'nomic-embed-text', adapter: 'lancedb', dataPath: LANCEDB_DIR },
-    qwen3: { collection: 'oracle_knowledge_qwen3', model: 'qwen3-embedding', adapter: 'lancedb', dataPath: LANCEDB_DIR },
-    'bge-m3': { collection: 'oracle_knowledge_bge_m3', model: 'bge-m3', adapter: 'lancedb', dataPath: LANCEDB_DIR },
-  };
+  return configToModels(generateDefaultConfig());
 }
 export const EMBEDDING_MODELS = new Proxy({} as Record<string, EmbeddingModelConfig>, {
   get(_, prop: string) { return getEmbeddingModels()[prop]; },

--- a/tests/frontend/components/setup-wizard-first-run.test.tsx
+++ b/tests/frontend/components/setup-wizard-first-run.test.tsx
@@ -62,7 +62,7 @@ describe("SetupWizard first-run detection", () => {
     const empty = htmlFor(<StepBody step={1} config={null} />);
     const done = htmlFor(<StepBody step={3} config={null} />);
 
-    expect(empty).toContain("Local vector backend selected: lancedb");
+    expect(empty).toContain("Local vector backend selected: sqlite-vec");
     expect(empty).toContain("border-ok-border bg-ok-bg");
     expect(done).toContain("First-run setup complete");
     expect(done).toContain("border-ok-border bg-ok-bg text-ok-text");

--- a/tests/frontend/pages/first-run-wizard-cost.test.tsx
+++ b/tests/frontend/pages/first-run-wizard-cost.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { FirstRunWizard } from '../../../frontend/src/pages/FirstRunWizard';
+import { FirstRunWizard, detectFirstRunWizardResolution } from '../../../frontend/src/pages/FirstRunWizard';
 import { htmlFor } from '../_render';
 
 const rows = [
@@ -29,6 +29,25 @@ const cost = {
 };
 
 describe('FirstRunWizard cost review step', () => {
+  test('defaults to sqlite-vec with no provider prompt when no config exists', () => {
+    const html = htmlFor(<FirstRunWizard rows={[]} onRefresh={() => {}} initialStep={1} initialCost={cost} />);
+    expect(html).toContain('detect() resolved sqlite-vec from first-run-default');
+    expect(html).toContain('No provider prompt or provider choice is required');
+    expect(html).toContain('Primary adapter: sqlite-vec');
+  });
+
+  test('detects returning users from existing indexed collections', () => {
+    const resolution = detectFirstRunWizardResolution(rows, null);
+    expect(resolution).toMatchObject({
+      engine: 'lancedb',
+      source: 'detect',
+      returningUser: true,
+      providerPrompt: false,
+      wizard: 'optional',
+      collection: 'oracle_bge_m3',
+    });
+  });
+
   test('shows cost estimate and recommendation before indexing', () => {
     const html = htmlFor(<FirstRunWizard rows={rows} onRefresh={() => {}} initialStep={2} initialCost={cost} />);
     expect(html).toContain('Estimated embedding cost');

--- a/tests/vector/backend-resolution.test.ts
+++ b/tests/vector/backend-resolution.test.ts
@@ -10,7 +10,7 @@ test('fresh installs resolve a local vector backend without provider prompt', ()
   const resolution = resolveVectorBackend(cfg, 'defaults', {});
 
   expect(resolution).toMatchObject({
-    engine: 'lancedb',
+    engine: 'sqlite-vec',
     source: 'first-run-default',
     localDefault: true,
     returningUser: false,

--- a/tests/vector/factory-models-fallback.test.ts
+++ b/tests/vector/factory-models-fallback.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from 'bun:test';
 import { getEmbeddingModels } from '../../src/vector/factory.ts';
 
-test('vector store model registry returns hardcoded defaults when config is absent', () => {
+test('vector store model registry returns default-safe sqlite-vec defaults when config is absent', () => {
   const models = getEmbeddingModels(null);
 
   expect(Object.keys(models).sort()).toEqual(['bge-m3', 'nomic', 'qwen3']);
+  expect(Object.values(models).every((model) => model.adapter === 'sqlite-vec')).toBe(true);
 });


### PR DESCRIPTION
## Summary\n- centralize default-safe vector backend constants/resolution in src/config/defaults.ts\n- switch fresh installs and absent vector configs to sqlite-vec without provider prompts\n- refactor first-run wizard copy/actions to make the wizard optional/advanced and detect returning users\n\n## Validation\n- bunx tsc --noEmit\n- bunx tsc --noEmit -p frontend/tsconfig.json\n- bun run build (frontend)\n- bun test src/config/__tests__/defaults.test.ts tests/vector/backend-resolution.test.ts tests/vector/factory-models-fallback.test.ts src/vector/__tests__/config.test.ts src/vector/__tests__/factory-config-selection.test.ts src/routes/vector/__tests__/config.test.ts tests/frontend/pages/first-run-wizard-cost.test.tsx tests/frontend/components/setup-wizard-first-run.test.tsx