### PR TITLE
feat: make Docker the primary onboarding path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-# arra-oracle-v3 — multi-target image
-#   Default target: http-server  (port 47778)
+# arra-oracle-v3 — multi-stage, non-root, single-volume image
+#   Default target: http-server  (HTTP API + MCP tool catalog on port 47778)
 #   Alt target:     mcp-stdio    (stdio JSON-RPC MCP server)
 #   Test target:    test         (self-contained bun test + tsc)
+#   Runtime data:   /data        (HOME, SQLite, config, vectors)
 #
 # Build:
 #   docker build -t arra-oracle-v3 .
@@ -48,6 +49,8 @@ FROM oven/bun:1-slim AS production
 WORKDIR /app
 ENV HOME=/data \
     ORACLE_DATA_DIR=/data \
+    ORACLE_DB_PATH=/data/oracle.db \
+    ORACLE_LOG_TARGET=stderr \
     BUN_ENV=production
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist

--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@ federation gateway, and operator CLI. It stores local knowledge in SQLite,
 indexes it with vector backends, and exposes the same capabilities to humans,
 agents, maw-js, and web frontends.
 
-## Quick start: Docker + `arra mine` (recommended)
+## Primary install: Docker + `arra mine`
 
-Use this path first: one local data dir, Docker for HTTP, and `arra mine` to ingest notes before asking.
+Use Docker first: one `/data` volume, non-root HTTP server plus MCP catalog, and `arra mine` to ingest notes before asking.
 
 ```bash
-export ORACLE_DATA_DIR="$HOME/.arra-oracle-v2"
+export ORACLE_DATA_DIR="$HOME/.arra-oracle-v3"
 mkdir -p "$ORACLE_DATA_DIR"
 
 docker run --rm --name arra-oracle --user "$(id -u):$(id -g)" \
-  -p 47778:47778 -e ORACLE_EMBEDDER=none \
+  -p 47778:47778 -e ORACLE_EMBEDDER=none -e ORACLE_DB_PATH=/data/oracle.db \
   -v "$ORACLE_DATA_DIR:/data" \
   ghcr.io/soul-brews-studio/arra-oracle-v3:http
 ```
@@ -32,7 +32,7 @@ docker run --rm --name arra-oracle --user "$(id -u):$(id -g)" \
 In another shell, mine a folder into the same data dir and ask over HTTP:
 
 ```bash
-export ORACLE_DATA_DIR="$HOME/.arra-oracle-v2"
+export ORACLE_DATA_DIR="$HOME/.arra-oracle-v3"
 bunx --package arra-oracle-v3 arra mine ~/notes
 curl 'http://localhost:47778/api/v1/search?q=runbook&mode=fts'
 ```
@@ -42,7 +42,7 @@ For MCP clients, point the stdio Docker image at the same data dir:
 ```bash
 claude mcp add arra-oracle -- docker run --rm -i -e ORACLE_LOG_TARGET=stderr \
   -v "$ORACLE_DATA_DIR:/data" ghcr.io/soul-brews-studio/arra-oracle-v3:stdio
-claude mcp list              # expect connected; tools/list exposes 28 tools
+claude mcp list              # expect connected; tools/list exposes Oracle MCP tools
 ```
 
 ### Developer source path
@@ -65,7 +65,7 @@ Useful checks: `curl -sf http://localhost:47778/api/health` and `bun cli/src/cli
 | --- | --- |
 | Modular backend | Elysia/SQLite core can run all-local, behind a maw plugin backend, behind edge proxies, or split from vector/MCP adapters. |
 | Runtime plug-in/out | Unified manifests enable/disable CLI, menu/API, MCP, proxy, server, export-format, and lifecycle surfaces without forks. |
-| MCP memory tools | 28 tools: `____IMPORTANT` plus 27 `oracle_*`, including `oracle_recap`, `oracle_research_note`, `oracle_profile`, and `oracle_trace_distill`. |
+| MCP memory tools | 29 tools: `____IMPORTANT` plus 28 `oracle_*`, including `oracle_recap`, `oracle_research_note`, `oracle_profile`, and `oracle_trace_distill`. |
 | Memory confidence + supersede | Confidence receipts, reversible supersede chains, trace context, and async dry-run consolidation preserve history while deduping. |
 | HTTP API | Elysia route clusters under `/api/*`, with health, search, knowledge, vector, menu, plugins, canvas, tenants, settings, and opt-in federation surfaces. |
 | Vector search | Configurable providers, LanceDB/local stores, proxy services, export formats, status/config APIs, and FTS fallback paths. |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   arra:
     build:
       context: .
+      dockerfile: Dockerfile
       target: http-server
     image: arra-oracle-v3:http
     ports:
@@ -9,41 +10,20 @@ services:
     environment:
       HOME: /data
       ORACLE_DATA_DIR: /data
+      ORACLE_DB_PATH: /data/oracle.db
+      ORACLE_EMBEDDER: none
+      ORACLE_LOG_TARGET: stderr
       ORACLE_PORT: "47778"
       PORT: "47778"
     volumes:
       - arra-data:/data
+    healthcheck:
+      test: ["CMD", "bun", "-e", "const r=await fetch('http://127.0.0.1:47778/api/health');process.exit(r.ok?0:1)"]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
     restart: unless-stopped
-
-  test:
-    build:
-      context: .
-      target: http-server
-    environment:
-      HOME: /tmp/test-data
-      ORACLE_DATA_DIR: /tmp/test-data
-    volumes:
-      - ./src:/app/src:ro
-      - ./cli:/app/cli:ro
-      - ./tests:/app/tests:ro
-      - ./bunfig.toml:/app/bunfig.toml:ro
-      - ./tsconfig.json:/app/tsconfig.json:ro
-    entrypoint: ["bun"]
-    command: ["test", "--bail"]
-    profiles: ["test"]
-
-  typecheck:
-    build:
-      context: .
-      target: http-server
-    volumes:
-      - ./src:/app/src:ro
-      - ./cli:/app/cli:ro
-      - ./tests:/app/tests:ro
-      - ./tsconfig.json:/app/tsconfig.json:ro
-    entrypoint: ["bunx"]
-    command: ["tsc", "--noEmit"]
-    profiles: ["test"]
 
 volumes:
   arra-data:


### PR DESCRIPTION
## Summary
- document Docker as the primary install path with a single /data volume
- make the runtime image contract explicit: non-root bun user, HOME=/data, ORACLE_DB_PATH=/data/oracle.db, stderr logs
- simplify docker-compose.yml to the shippable HTTP server path with one named /data volume and healthcheck

## Validation
- docker build -t arra-oracle-v3:2420-docker .
- docker image inspect arra-oracle-v3:2420-docker (user bun, VOLUME /data, CMD bun dist/server.js)
- bunx tsc --noEmit
- TMPDIR=/Users/nat/.tmp bun test tests/docs/
- docker compose config --quiet
- wc -l Dockerfile docker-compose.yml README.md