### PR TITLE
feat: add memory consolidation review queue

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -75,6 +75,7 @@ export function AppShell({
     { to: '/vector/export', label: 'Export', description: 'Download vector collections' },
     { to: '/learn', label: 'Learn', description: 'Create and edit learnings' },
     { to: '/memory', label: 'Memory Dashboard', description: 'Confidence, heat, provenance, valid-time, and recency' },
+    { to: '/memory/consolidation', label: 'Consolidation Queue', description: 'Review suggested supersede actions' },
     { to: '/metrics', label: 'Metrics', description: 'Runtime counters from /api/v1/metrics' },
     { to: '/mcp', label: 'MCP', description: 'Tool schemas and groups' },
     { to: '/storage', label: 'Storage', description: 'Backend config from /api/settings/system' },

--- a/frontend/src/components/NavSidebar.tsx
+++ b/frontend/src/components/NavSidebar.tsx
@@ -16,7 +16,7 @@ type NavGroup = {
 const navGroups: NavGroup[] = [
   { label: 'Core', paths: ['/', '/plugins', '/status'] },
   { label: 'Search', paths: ['/search', '/feed'] },
-  { label: 'Knowledge', paths: ['/memory', '/learn', '/forum', '/activity', '/traces'] },
+  { label: 'Knowledge', paths: ['/memory', '/memory/consolidation', '/learn', '/forum', '/activity', '/traces'] },
   { label: 'Vector', paths: ['/vector', '/vector/documents', '/vector/index', '/vector/first-run', '/vector/search', '/vector/settings', '/vector/export'] },
   { label: 'System', paths: ['/mcp', '/canvas', '/canvas/plugins', '/metrics', '/storage', '/settings', '/export'] },
 ];

--- a/frontend/src/pages/MemoryConsolidationPage.tsx
+++ b/frontend/src/pages/MemoryConsolidationPage.tsx
@@ -1,0 +1,244 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { apiFetch } from '../api';
+import { memoryPath } from '../routePaths';
+
+type LoadState = 'loading' | 'ready' | 'error';
+type ReviewAction = 'approve' | 'reject';
+type ReviewStatus = Record<string, string>;
+
+export type ConsolidationDoc = {
+  id: string;
+  title: string;
+  sourceFile?: string;
+  type?: string;
+  content?: string;
+};
+
+export type ConsolidationSuggestion = {
+  id: string;
+  original: ConsolidationDoc;
+  suggested: ConsolidationDoc;
+  confidence: number;
+  reason: string;
+};
+
+type QueueClient = {
+  list: () => Promise<ConsolidationSuggestion[]>;
+  approve: (item: ConsolidationSuggestion) => Promise<void>;
+  reject: (item: ConsolidationSuggestion) => Promise<void>;
+};
+type Props = { client?: QueueClient; initialSuggestions?: ConsolidationSuggestion[] };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function text(value: unknown, fallback = ''): string {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+function numeric(value: unknown, fallback = 0): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? Math.max(0, Math.min(1, n)) : fallback;
+}
+
+function docFrom(value: unknown, idFallback: string): ConsolidationDoc {
+  const row = isRecord(value) ? value : {};
+  const id = text(row.id ?? row.documentId ?? row.docId, idFallback);
+  const title = text(row.title ?? row.sourceFile ?? row.source_file, id);
+  return {
+    id,
+    title,
+    sourceFile: text(row.sourceFile ?? row.source_file, ''),
+    type: text(row.type, ''),
+    content: text(row.content ?? row.preview ?? row.excerpt, ''),
+  };
+}
+
+export function normalizeSuggestion(value: unknown): ConsolidationSuggestion | null {
+  if (!isRecord(value)) return null;
+  const oldId = text(value.oldId ?? value.old_id ?? value.originalId);
+  const newId = text(value.newId ?? value.new_id ?? value.suggestedId);
+  if (!oldId || !newId) return null;
+  const confidence = numeric(value.confidence ?? value.score ?? value.cosine, 0);
+  const id = text(value.id, `${oldId}->${newId}`);
+  return {
+    id,
+    original: docFrom(value.original ?? value.old ?? value.oldDoc, oldId),
+    suggested: docFrom(value.suggested ?? value.replacement ?? value.new ?? value.newDoc, newId),
+    confidence,
+    reason: text(value.reason, 'Memory consolidation suggested a supersede relationship.'),
+  };
+}
+
+function suggestionsFromPayload(payload: unknown): ConsolidationSuggestion[] {
+  const list = isRecord(payload)
+    ? payload.suggestions ?? payload.items ?? payload.plans ?? []
+    : payload;
+  return Array.isArray(list) ? list.map(normalizeSuggestion).filter((item): item is ConsolidationSuggestion => Boolean(item)) : [];
+}
+
+async function json<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const response = await apiFetch(path, {
+    ...init,
+    headers: { accept: 'application/json', 'content-type': 'application/json', ...(init.headers ?? {}) },
+  });
+  const body = await response.text();
+  const payload = body ? JSON.parse(body) as unknown : {};
+  if (!response.ok) throw new Error(isRecord(payload) && typeof payload.error === 'string' ? payload.error : `${path} returned ${response.status}`);
+  return payload as T;
+}
+
+async function postReview(path: string, body: unknown): Promise<Response> {
+  return apiFetch(path, {
+    method: 'POST',
+    headers: { accept: 'application/json', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+export const consolidationQueueClient: QueueClient = {
+  async list() {
+    return suggestionsFromPayload(await json('/api/memory/consolidation/suggestions?limit=50'));
+  },
+  async approve(item) {
+    const body = { oldId: item.original.id, newId: item.suggested.id, reason: item.reason };
+    const review = await postReview(`/api/memory/consolidation/suggestions/${encodeURIComponent(item.id)}/approve`, body);
+    if (review.ok) return;
+    if (review.status !== 404) throw new Error(`Approve failed (${review.status})`);
+    await json('/api/supersede/document', { method: 'POST', body: JSON.stringify(body) });
+  },
+  async reject(item) {
+    const review = await postReview(`/api/memory/consolidation/suggestions/${encodeURIComponent(item.id)}/reject`, { reason: 'rejected by reviewer' });
+    if (!review.ok && review.status !== 404) throw new Error(`Reject failed (${review.status})`);
+  },
+};
+
+function percent(value: number): string { return `${Math.round(value * 100)}%`; }
+function preview(doc: ConsolidationDoc): string { return doc.content || doc.sourceFile || doc.id; }
+
+function ConfidencePill({ score }: { score: number }) {
+  const tone = score >= 0.85 ? 'border-ok-border bg-ok-bg text-ok-text' : score >= 0.65 ? 'border-warn-border bg-warn-bg text-warn-text' : 'border-border bg-surface-muted text-text-muted';
+  return <span className={`rounded-full border px-3 py-1 text-sm font-semibold ${tone}`}>{percent(score)} confidence</span>;
+}
+
+function DocBlock({ label, doc }: { label: string; doc: ConsolidationDoc }) {
+  return (
+    <div className="min-w-0 rounded-2xl border border-border bg-surface p-4">
+      <p className="text-xs font-semibold text-text-muted">{label}</p>
+      <h3 className="mt-2 break-words text-base font-semibold text-text">{doc.title}</h3>
+      <p className="mt-2 line-clamp-3 text-sm text-text-muted">{preview(doc)}</p>
+      <p className="mt-3 font-mono text-xs text-text-muted">{doc.id}</p>
+    </div>
+  );
+}
+
+function EmptyState({ error }: { error?: string }) {
+  const title = error ? 'Consolidation queue unavailable' : 'No pending reviews';
+  const detail = error || 'Memory consolidation has no supersede suggestions awaiting human review.';
+  return (
+    <section className="rounded-3xl border border-border bg-surface p-6 text-sm text-text-muted">
+      <h2 className="text-lg font-semibold text-text">{title}</h2>
+      <p className="mt-2 max-w-2xl">{detail}</p>
+    </section>
+  );
+}
+
+export function MemoryConsolidationPage({ client = consolidationQueueClient, initialSuggestions }: Props) {
+  const [state, setState] = useState<LoadState>(initialSuggestions ? 'ready' : 'loading');
+  const [items, setItems] = useState<ConsolidationSuggestion[]>(initialSuggestions ?? []);
+  const [error, setError] = useState('');
+  const [message, setMessage] = useState('');
+  const [busy, setBusy] = useState<ReviewStatus>({});
+
+  useEffect(() => {
+    if (initialSuggestions) return;
+    let active = true;
+    setState('loading');
+    client.list().then((next) => {
+      if (!active) return;
+      setItems(next);
+      setState('ready');
+    }).catch((err) => {
+      if (!active) return;
+      setError(err instanceof Error ? err.message : String(err));
+      setState('error');
+    });
+    return () => { active = false; };
+  }, [client, initialSuggestions]);
+
+  const summary = useMemo(() => {
+    const high = items.filter((item) => item.confidence >= 0.85).length;
+    const avg = items.length ? items.reduce((sum, item) => sum + item.confidence, 0) / items.length : 0;
+    return { high, avg };
+  }, [items]);
+
+  async function review(item: ConsolidationSuggestion, action: ReviewAction) {
+    setBusy((current) => ({ ...current, [item.id]: action }));
+    setError('');
+    try {
+      if (action === 'approve') await client.approve(item);
+      else await client.reject(item);
+      setItems((current) => current.filter((candidate) => candidate.id !== item.id));
+      setMessage(`${action === 'approve' ? 'Approved' : 'Rejected'} ${item.original.id} → ${item.suggested.id}.`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(({ [item.id]: _done, ...rest }) => rest);
+    }
+  }
+
+  return (
+    <div className="grid w-full min-w-0 gap-5">
+      <section className="glass rounded-3xl border border-[oklch(1_0_0/0.08)] bg-[oklch(0.16_0.02_265/0.35)] p-5 sm:p-6" aria-labelledby="memory-consolidation-title">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <p className="text-sm font-semibold text-accent2">Memory governance</p>
+            <h1 id="memory-consolidation-title" className="mt-2 text-2xl font-semibold text-text">Consolidation review queue</h1>
+            <p className="mt-2 max-w-3xl text-sm text-text-muted">Review pending supersede suggestions before they change memory ranking. Approve only when the suggested document is the better current source.</p>
+          </div>
+          <Link className="focus-ring rounded-xl border border-border px-4 py-2 text-sm font-semibold text-text hover:border-accent-border" to={memoryPath()}>Memory dashboard</Link>
+        </div>
+      </section>
+
+      <section className="grid gap-3 sm:grid-cols-3" aria-label="Queue summary">
+        <Summary label="Pending" value={String(items.length)} />
+        <Summary label="High confidence" value={String(summary.high)} />
+        <Summary label="Average confidence" value={percent(summary.avg)} />
+      </section>
+
+      {message ? <p className="rounded-2xl border border-ok-border bg-ok-bg p-3 text-sm text-ok-text">{message}</p> : null}
+      {error && state !== 'error' ? <p role="alert" className="rounded-2xl border border-err-border bg-err-bg p-3 text-sm text-err-text">{error}</p> : null}
+      {state === 'loading' ? <EmptyState error="Loading pending memory consolidation suggestions…" /> : null}
+      {state === 'error' ? <EmptyState error={error} /> : null}
+      {state === 'ready' && !items.length ? <EmptyState /> : null}
+
+      <section className="grid gap-4" aria-label="Pending supersede suggestions">
+        {items.map((item) => (
+          <article key={item.id} className="rounded-3xl border border-border bg-surface-muted p-4 sm:p-5">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+              <div>
+                <ConfidencePill score={item.confidence} />
+                <p className="mt-3 max-w-3xl text-sm text-text-muted">{item.reason}</p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <button className="focus-ring rounded-xl border border-border px-4 py-2 text-sm font-semibold text-text disabled:opacity-50" disabled={Boolean(busy[item.id])} type="button" onClick={() => void review(item, 'reject')}>{busy[item.id] === 'reject' ? 'Rejecting…' : 'Reject'}</button>
+                <button className="focus-ring rounded-xl bg-accent-solid px-4 py-2 text-sm font-semibold text-on-accent disabled:opacity-50" disabled={Boolean(busy[item.id])} type="button" onClick={() => void review(item, 'approve')}>{busy[item.id] === 'approve' ? 'Approving…' : 'Approve'}</button>
+              </div>
+            </div>
+            <div className="mt-4 grid gap-3 lg:grid-cols-[1fr_auto_1fr] lg:items-stretch">
+              <DocBlock label="Original doc" doc={item.original} />
+              <div className="flex items-center justify-center text-sm font-semibold text-text-muted" aria-hidden="true">superseded by</div>
+              <DocBlock label="Suggested supersede" doc={item.suggested} />
+            </div>
+          </article>
+        ))}
+      </section>
+    </div>
+  );
+}
+
+function Summary({ label, value }: { label: string; value: string }) {
+  return <div className="rounded-2xl border border-border bg-surface p-4"><p className="text-sm text-text-muted">{label}</p><p className="mt-1 text-2xl font-semibold text-text">{value}</p></div>;
+}

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -6,7 +6,7 @@ import { MemoryDashboardInsights } from '../components/MemoryDashboardInsights';
 import { MemoryDashboardContent } from './MemoryDashboardPage';
 import { MemoryHealthPanel } from '../components/MemoryHealthPanel';
 import { SearchResultCard } from '../components/SearchResultCard';
-import { memoryPath, vectorResultsPath } from '../routePaths';
+import { memoryConsolidationPath, memoryPath, vectorResultsPath } from '../routePaths';
 import type { SearchResponse, SearchResult } from '../types';
 
 type PageState = 'idle' | 'loading' | 'ready' | 'error';
@@ -28,6 +28,9 @@ function MemoryRouteLinks() {
       </Link>
       <Link className="focus-ring rounded-xl border border-border px-4 py-2 text-sm text-text hover:border-accent-border" to={vectorResultsPath('')}>
         Search results
+      </Link>
+      <Link className="focus-ring rounded-xl border border-border px-4 py-2 text-sm text-text hover:border-accent-border" to={memoryConsolidationPath()}>
+        Consolidation queue
       </Link>
     </div>
   );

--- a/frontend/src/routeMeta.ts
+++ b/frontend/src/routeMeta.ts
@@ -90,6 +90,13 @@ export function routeMeta(pathname: string, search = ''): RouteMeta {
     return base('Memory dashboard', 'Memory', description, [{ label: 'Memory dashboard' }]);
   }
 
+  if (pathname === '/memory/consolidation') {
+    return base('Consolidation review', 'Memory', 'Review pending supersede suggestions before applying them.', [
+      { label: 'Memory dashboard', to: '/memory' },
+      { label: 'Consolidation review' },
+    ]);
+  }
+
   if (pathname === '/plugins') return base('Plugin list', 'Plugins', 'Registered plugins and exposed runtime surfaces.', [{ label: 'Plugins' }]);
   if (pathname === '/status') return base('Server status', 'Status', 'Server health from /api/v1/health.', [{ label: 'Status' }]);
   if (pathname === '/canvas') return base('Canvas app', 'Canvas', 'Studio alias for canvas.buildwithoracle.com.', [{ label: 'Canvas app' }]);

--- a/frontend/src/routePaths.ts
+++ b/frontend/src/routePaths.ts
@@ -77,6 +77,10 @@ export function memoryPath(query = ''): string {
   return `/memory?${new URLSearchParams({ q })}`;
 }
 
+export function memoryConsolidationPath(): string {
+  return '/memory/consolidation';
+}
+
 export function vectorDocumentsPath(): string {
   return '/vector/documents';
 }

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -9,6 +9,7 @@ import { FeedPage } from './pages/FeedPage';
 import { ForumPage } from './pages/ForumPage';
 import { LearnPage } from './pages/LearnPage';
 import { MemoryPage } from './pages/MemoryPage';
+import { MemoryConsolidationPage } from './pages/MemoryConsolidationPage';
 import { MenuPage } from './pages/MenuPage';
 import { PluginsPage } from './pages/PluginsPage';
 import { CanvasAliasPage } from './pages/CanvasAliasPage';
@@ -46,6 +47,7 @@ export const frontendRoutes = [
   '/traces',
   '/learn',
   '/memory',
+  '/memory/consolidation',
   '/vector',
   '/vector/search',
   '/vector/documents',
@@ -121,6 +123,7 @@ export function DashboardRoutes({
       <Route path="/traces" element={<ActivityPage />} />
       <Route path="/learn" element={<LearnPage />} />
       <Route path="/memory" element={<MemoryPage />} />
+      <Route path="/memory/consolidation" element={<MemoryConsolidationPage />} />
       <Route path="/menu" element={menuPage} />
       <Route path="/vector" element={<VectorPage />} />
       <Route path="/vector/search" element={<VectorSearchPage />} />

--- a/tests/frontend/pages/memory-consolidation-page.test.tsx
+++ b/tests/frontend/pages/memory-consolidation-page.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+import { MemoryRouter } from 'react-router-dom';
+import { MemoryConsolidationPage, normalizeSuggestion, type ConsolidationSuggestion } from '../../../frontend/src/pages/MemoryConsolidationPage';
+import { htmlFor } from '../_render';
+
+const suggestions: ConsolidationSuggestion[] = [{
+  id: 'old-a->new-a',
+  original: { id: 'old-a', title: 'Legacy runbook', sourceFile: 'ψ/memory/old.md', content: 'Outdated deployment steps.' },
+  suggested: { id: 'new-a', title: 'Current runbook', sourceFile: 'ψ/memory/new.md', content: 'Current deployment steps.' },
+  confidence: 0.91,
+  reason: 'async consolidation duplicate (cosine=0.96, fts_overlap=0.92)',
+}];
+
+function pageHtml(items = suggestions) {
+  return htmlFor(<MemoryRouter><MemoryConsolidationPage initialSuggestions={items} /></MemoryRouter>);
+}
+
+describe('MemoryConsolidationPage', () => {
+  test('renders pending supersede suggestions for human review', () => {
+    const html = pageHtml();
+    expect(html).toContain('Consolidation review queue');
+    expect(html).toContain('Original doc');
+    expect(html).toContain('Suggested supersede');
+    expect(html).toContain('Legacy runbook');
+    expect(html).toContain('Current runbook');
+    expect(html).toContain('91% confidence');
+    expect(html).toContain('Approve');
+    expect(html).toContain('Reject');
+  });
+
+  test('renders an empty reviewed state', () => {
+    const html = pageHtml([]);
+    expect(html).toContain('No pending reviews');
+    expect(html).toContain('0%');
+  });
+
+  test('normalizes memory-layer plan payloads', () => {
+    expect(normalizeSuggestion({
+      oldId: 'memory-old',
+      newId: 'memory-new',
+      cosine: 0.873,
+      oldDoc: { title: 'Old note', content: 'stale fact' },
+      newDoc: { title: 'New note', content: 'corrected fact' },
+    })).toMatchObject({
+      id: 'memory-old->memory-new',
+      confidence: 0.873,
+      original: { id: 'memory-old', title: 'Old note' },
+      suggested: { id: 'memory-new', title: 'New note' },
+    });
+  });
+});

--- a/tests/frontend/router.test.ts
+++ b/tests/frontend/router.test.ts
@@ -47,6 +47,7 @@ describe('frontend router', () => {
       '/traces',
       '/learn',
       '/memory',
+      '/memory/consolidation',
       '/vector',
       '/vector/search',
       '/vector/documents',
@@ -82,6 +83,7 @@ describe('frontend router', () => {
     expect(htmlAt('/learn')).toContain('Learn entries');
     expect(htmlAt('/memory')).toContain('Memory dashboard');
     expect(htmlAt('/memory')).toContain('Memory health');
+    expect(htmlAt('/memory/consolidation')).toContain('Consolidation review queue');
     expect(htmlAt('/vector')).toContain('Vector dashboard');
     expect(htmlAt('/vector/search')).toContain('Vector search preview');
     expect(htmlAt('/vector/documents')).toContain('Vector documents');

--- a/tests/frontend/routes/vector-meta.test.ts
+++ b/tests/frontend/routes/vector-meta.test.ts
@@ -16,5 +16,9 @@ describe('vector route metadata', () => {
       title: 'First-run setup',
       description: 'Use the local backend default, review cost, and start the first vector index.',
     });
+    expect(routeMeta('/memory/consolidation')).toMatchObject({
+      title: 'Consolidation review',
+      description: 'Review pending supersede suggestions before applying them.',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add a Memory Consolidation review queue page for pending supersede suggestions
- show original/suggested documents, confidence, reasons, and approve/reject actions
- wire the page into app routing/navigation and add focused frontend tests

## Validation
- bun test tests/frontend/pages/memory-consolidation-page.test.tsx tests/frontend/router.test.ts tests/frontend/routes/vector-meta.test.ts
- bunx tsc --noEmit
- bunx tsc --noEmit -p frontend/tsconfig.json
- cd frontend && bun run build
- git diff --check

Base: alpha