### PR TITLE
feat: add asOf filtering to vector search

### DIFF
--- a/src/routes/search/asof.ts
+++ b/src/routes/search/asof.ts
@@ -1,0 +1,8 @@
+export const AS_OF_SUPPORTED_ENDPOINTS = ['/api/search', '/api/list', '/api/vector/search'] as const;
+
+export function asOfResponse(asOfMs: number | undefined): Record<string, unknown> {
+  return asOfMs ? {
+    asOf: new Date(asOfMs).toISOString(),
+    asOfSupportedEndpoints: [...AS_OF_SUPPORTED_ENDPOINTS],
+  } : {};
+}

--- a/src/routes/search/list.ts
+++ b/src/routes/search/list.ts
@@ -1,28 +1,46 @@
 /**
- * GET /api/list — paginated document listing with optional type filter.
+ * GET /api/list — paginated document listing with optional type/asOf filters.
  */
 
 import { Elysia } from 'elysia';
+import { sqlite } from '../../db/index.ts';
+import { filterResultsAsOf, parseAsOf } from '../../search/bitemporal.ts';
 import { handleList } from '../../server/handlers.ts';
+import { asOfResponse } from './asof.ts';
 import { ListQuery } from './model.ts';
 import { parseOffset, parsePositiveInt } from './query.ts';
 import { handleTenantList } from './tenant-search.ts';
 
 export const listEndpoint = new Elysia().get(
   '/list',
-  ({ query }) => {
+  ({ query, set }) => {
+    const asOf = parseAsOf(query.asOf);
+    if (!asOf.ok) {
+      set.status = 400;
+      return { error: asOf.error };
+    }
     const type = query.type ?? 'all';
     const limit = parsePositiveInt(query.limit, 10, 1000);
     const offset = parseOffset(query.offset);
     const group = query.group !== 'false';
-    return handleTenantList(type, limit, offset, group) ?? handleList(type, limit, offset, group);
+    const tenantResult = handleTenantList(type, limit, offset, group, asOf.value);
+    const result = tenantResult ?? handleList(type, limit, offset, group);
+    if (asOf.value && !tenantResult) {
+      result.results = filterResultsAsOf(
+        sqlite,
+        result.results as unknown as Array<Record<string, unknown>>,
+        asOf.value,
+      ) as unknown as typeof result.results;
+      result.total = result.results.length;
+    }
+    return { ...result, ...asOfResponse(asOf.value) };
   },
   {
     query: ListQuery,
     detail: {
       tags: ['search'],
       menu: { group: 'main', path: '/feed', order: 20 },
-      summary: 'List oracle documents',
+      summary: 'List oracle documents with optional asOf valid-time filtering',
     },
   },
 );

--- a/src/routes/search/model.ts
+++ b/src/routes/search/model.ts
@@ -25,4 +25,5 @@ export const ListQuery = t.Object({
   limit: t.Optional(t.String()),
   offset: t.Optional(t.String()),
   group: t.Optional(t.String()),
+  asOf: t.Optional(t.String()),
 });

--- a/src/routes/search/search.ts
+++ b/src/routes/search/search.ts
@@ -11,6 +11,7 @@ import { compactSearchResults, parseSearchRetrievalMode } from '../../search/com
 import { rerankByEntityLinks } from '../../search/entity-ranking.ts';
 import { attachSupersedeStatus } from '../../search/supersede-status.ts';
 import { handleSearch } from '../../server/handlers.ts';
+import { asOfResponse } from './asof.ts';
 import { SearchQuery } from './model.ts';
 import { parseOptionalSearchModel } from './model-key.ts';
 import { parseOffset, parsePositiveInt, parseSearchMode } from './query.ts';
@@ -80,7 +81,7 @@ export const searchEndpoint = new Elysia().get(
         : null;
       if (compact) result.results = compact.results as unknown as typeof result.results;
       const metadata = compact ? { metadata: { ...('metadata' in result ? result.metadata as object : {}), retrieval: compact.metadata } } : {};
-      return { ...result, ...metadata, query: sanitizedQ, ...(asOf.value ? { asOf: new Date(asOf.value).toISOString() } : {}) };
+      return { ...result, ...metadata, query: sanitizedQ, ...asOfResponse(asOf.value) };
     } catch {
       set.status = 400;
       return { results: [], total: 0, query: sanitizedQ, error: 'Search failed' };
@@ -91,7 +92,7 @@ export const searchEndpoint = new Elysia().get(
     detail: {
       tags: ['search'],
       menu: { group: 'main', path: '/search', order: 10 },
-      summary: 'Hybrid search over oracle docs',
+      summary: 'Hybrid search over oracle docs with optional asOf valid-time filtering',
     },
   },
 );

--- a/src/routes/search/tenant-search.ts
+++ b/src/routes/search/tenant-search.ts
@@ -80,26 +80,32 @@ export function handleTenantSearch(query: string, type = 'all', limit = 10, offs
   };
 }
 
-export function handleTenantList(type = 'all', limit = 10, offset = 0, groupByFile = true): SearchResponse | null {
+export function handleTenantList(type = 'all', limit = 10, offset = 0, groupByFile = true, asOfMs?: number): SearchResponse | null {
   const tenantId = currentTenantId();
   if (!tenantId) return null;
 
   const typeClause = type === 'all' ? '' : 'AND d.type = ?';
-  const params = type === 'all' ? [tenantId] : [type, tenantId];
+  const temporalJoin = asOfMs ? BI_TEMPORAL_JOIN : '';
+  const temporalClause = asOfMs ? `AND ${BI_TEMPORAL_WHERE}` : '';
+  const temporalSelect = asOfMs ? ', d.valid_time, COALESCE(s.valid_time, d.superseded_at) as valid_until' : '';
+  const temporalParams = asOfMs ? biTemporalParams(asOfMs) : [];
+  const params = type === 'all' ? [tenantId, ...temporalParams] : [type, tenantId, ...temporalParams];
   const countExpr = groupByFile ? 'count(distinct d.source_file)' : 'count(*)';
   const count = sqlite.prepare(`
     SELECT ${countExpr} as total
     FROM oracle_documents d
-    WHERE 1=1 ${typeClause} AND d.tenant_id = ?
+    ${temporalJoin}
+    WHERE 1=1 ${typeClause} AND d.tenant_id = ? ${temporalClause}
   `).get(...params) as { total: number };
 
   const indexedAt = groupByFile ? 'MAX(d.indexed_at)' : 'd.indexed_at';
   const groupSql = groupByFile ? 'GROUP BY d.source_file' : '';
   const rows = sqlite.prepare(`
-    SELECT d.id, d.type, d.source_file, d.concepts, d.project, ${indexedAt} as indexed_at, f.content
+    SELECT d.id, d.type, d.source_file, d.concepts, d.project, ${indexedAt} as indexed_at, f.content${temporalSelect}
     FROM oracle_documents d
     JOIN oracle_fts f ON d.id = f.id
-    WHERE 1=1 ${typeClause} AND d.tenant_id = ?
+    ${temporalJoin}
+    WHERE 1=1 ${typeClause} AND d.tenant_id = ? ${temporalClause}
     ${groupSql}
     ORDER BY indexed_at DESC
     LIMIT ? OFFSET ?
@@ -114,6 +120,7 @@ export function handleTenantList(type = 'all', limit = 10, offset = 0, groupByFi
       concepts: parseConcepts(row.concepts),
       project: row.project,
       indexed_at: row.indexed_at,
+      ...(asOfMs ? { valid_time: isoTimestamp(row.valid_time), valid_until: isoTimestamp(row.valid_until) } : {}),
     })),
     total: count.total,
     offset,

--- a/src/routes/vector/search.ts
+++ b/src/routes/vector/search.ts
@@ -1,18 +1,17 @@
+import type { Database } from 'bun:sqlite';
 import { Elysia, t } from 'elysia';
+import { sqlite } from '../../db/index.ts';
 import { currentTenantId } from '../../middleware/tenant.ts';
+import type { SearchResult } from '../../server/types.ts';
+import { filterResultsAsOf, parseAsOf } from '../../search/bitemporal.ts';
 import { getEmbeddingModels, getVectorStoreByModel } from '../../vector/factory.ts';
 import type { VectorQueryResult, VectorStoreAdapter } from '../../vector/types.ts';
-import type { SearchResult } from '../../server/types.ts';
+import { asOfResponse } from '../search/asof.ts';
 
 type SortField = 'score' | 'distance' | 'date' | 'id' | 'type' | 'source_file';
 type SortOrder = 'asc' | 'desc';
 type SearchStore = Pick<VectorStoreAdapter, 'connect' | 'ensureCollection' | 'query'> & Partial<Pick<VectorStoreAdapter, 'close'>>;
-
-interface VectorSearchDeps {
-  getStore?: (collection?: string) => SearchStore;
-  getModels?: () => Record<string, unknown>;
-}
-
+interface VectorSearchDeps { getStore?: (collection?: string) => SearchStore; getModels?: () => Record<string, unknown>; asOfDb?: Database }
 type SearchHit = SearchResult & { metadata: Record<string, unknown> };
 
 const DEFAULT_COLLECTION = 'bge-m3', MAX_LIMIT = 100, MAX_FETCH = 1_000;
@@ -21,23 +20,19 @@ const sortFields = new Set<SortField>(['score', 'distance', 'date', 'id', 'type'
 const stringQuery = t.Optional(t.String());
 const VectorSearchQuery = t.Object({
   q: stringQuery, type: stringQuery, collection: stringQuery, model: stringQuery, limit: stringQuery, offset: stringQuery,
-  from: stringQuery, to: stringQuery, dateFrom: stringQuery, dateTo: stringQuery, metadata: stringQuery, sort: stringQuery, order: stringQuery,
+  from: stringQuery, to: stringQuery, dateFrom: stringQuery, dateTo: stringQuery, metadata: stringQuery, sort: stringQuery,
+  order: stringQuery, asOf: stringQuery,
 });
 
-function sanitize(query: string): string {
-  return query.replace(/<[^>]*>/g, '').replace(/[\x00-\x1f]/g, '').trim();
-}
-
+function sanitize(query: string): string { return query.replace(/<[^>]*>/g, '').replace(/[\x00-\x1f]/g, '').trim(); }
 function positiveInt(value: string | undefined, fallback: number, max: number): number {
   const parsed = Number.parseInt(value ?? '', 10);
   return Math.min(max, Number.isFinite(parsed) && parsed > 0 ? parsed : fallback);
 }
-
 function offsetOf(value: string | undefined): number {
   const parsed = Number.parseInt(value ?? '', 10);
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
 }
-
 function scalar(value: string): unknown {
   const trimmed = value.trim();
   if (trimmed === 'true') return true;
@@ -45,10 +40,8 @@ function scalar(value: string): unknown {
   if (/^-?\d+(\.\d+)?$/.test(trimmed)) return Number(trimmed);
   return trimmed;
 }
-
 function metadataFilters(request: Request, type?: string): Record<string, unknown> {
-  const params = new URL(request.url).searchParams;
-  const filters: Record<string, unknown> = {};
+  const params = new URL(request.url).searchParams, filters: Record<string, unknown> = {};
   const raw = params.get('metadata') ?? params.get('meta');
   if (raw) {
     const parsed = JSON.parse(raw);
@@ -62,62 +55,37 @@ function metadataFilters(request: Request, type?: string): Record<string, unknow
   if (type && type !== 'all') filters.type = type;
   return filters;
 }
-
 function normalizeMetadata(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
 }
-
-function text(value: unknown, fallback = ''): string {
-  if (typeof value === 'string') return value;
-  if (value == null) return fallback;
-  return String(value);
-}
-
+function text(value: unknown, fallback = ''): string { return typeof value === 'string' ? value : value == null ? fallback : String(value); }
 function concepts(value: unknown): string[] {
   if (Array.isArray(value)) return value.map((item) => text(item)).filter(Boolean);
   if (typeof value !== 'string') return [];
   try {
     const parsed = JSON.parse(value);
     if (Array.isArray(parsed)) return parsed.map((item) => text(item)).filter(Boolean);
-  } catch {
-    return value.split(',').map((item) => item.trim()).filter(Boolean);
-  }
+  } catch { return value.split(',').map((item) => item.trim()).filter(Boolean); }
   return [];
 }
-
 function toHits(result: VectorQueryResult, collection: string): SearchHit[] {
   return result.ids.map((id, index) => {
-    const metadata = normalizeMetadata(result.metadatas?.[index]);
-    const distance = Number(result.distances?.[index] ?? 0);
+    const metadata = normalizeMetadata(result.metadatas?.[index]), distance = Number(result.distances?.[index] ?? 0);
     return {
-      id,
-      type: text(metadata.type, 'unknown'),
-      content: text(result.documents?.[index]),
-      source_file: text(metadata.source_file ?? metadata.sourceFile),
-      concepts: concepts(metadata.concepts),
-      source: 'vector',
-      score: 1 / (1 + distance / 100),
-      distance,
-      model: collection,
-      metadata,
+      id, type: text(metadata.type, 'unknown'), content: text(result.documents?.[index]),
+      source_file: text(metadata.source_file ?? metadata.sourceFile), concepts: concepts(metadata.concepts), source: 'vector',
+      score: 1 / (1 + distance / 100), distance, model: collection, metadata,
     };
   });
 }
-
 function sameValue(actual: unknown, expected: unknown): boolean {
   if (actual == null) return false;
-  if (typeof actual === 'object' || typeof expected === 'object') {
-    return JSON.stringify(actual) === JSON.stringify(expected);
-  }
+  if (typeof actual === 'object' || typeof expected === 'object') return JSON.stringify(actual) === JSON.stringify(expected);
   return String(actual) === String(expected);
 }
-
 function matchesMetadata(hit: SearchHit, filters: Record<string, unknown>): boolean {
-  return Object.entries(filters).every(([key, value]) => (
-    key === 'type' ? sameValue(hit.type, value) : sameValue(hit.metadata[key], value)
-  ));
+  return Object.entries(filters).every(([key, value]) => key === 'type' ? sameValue(hit.type, value) : sameValue(hit.metadata[key], value));
 }
-
 function timestamp(value: unknown): number | undefined {
   if (typeof value === 'number' && Number.isFinite(value)) return value;
   if (typeof value !== 'string' || value.trim() === '') return undefined;
@@ -126,7 +94,6 @@ function timestamp(value: unknown): number | undefined {
   const parsed = Date.parse(value);
   return Number.isFinite(parsed) ? parsed : undefined;
 }
-
 function hitDate(hit: SearchHit): number | undefined {
   for (const key of dateKeys) {
     const value = timestamp(hit.metadata[key]);
@@ -134,14 +101,11 @@ function hitDate(hit: SearchHit): number | undefined {
   }
   return undefined;
 }
-
 function withinDateRange(hit: SearchHit, from?: number, to?: number): boolean {
   if (from === undefined && to === undefined) return true;
   const value = hitDate(hit);
-  if (value === undefined) return false;
-  return (from === undefined || value >= from) && (to === undefined || value <= to);
+  return value !== undefined && (from === undefined || value >= from) && (to === undefined || value <= to);
 }
-
 function sortConfig(raw: string | undefined, rawOrder: string | undefined): { field: SortField; order: SortOrder } {
   const fieldName = raw?.startsWith('-') ? raw.slice(1) : raw;
   const field = sortFields.has(fieldName as SortField) ? fieldName as SortField : 'score';
@@ -150,7 +114,6 @@ function sortConfig(raw: string | undefined, rawOrder: string | undefined): { fi
     : field === 'distance' || field === 'id' || field === 'type' || field === 'source_file' ? 'asc' : 'desc';
   return { field, order };
 }
-
 function sortValue(hit: SearchHit, field: SortField): string | number {
   if (field === 'distance') return hit.distance ?? Number.POSITIVE_INFINITY;
   if (field === 'date') return hitDate(hit) ?? 0;
@@ -159,47 +122,34 @@ function sortValue(hit: SearchHit, field: SortField): string | number {
   if (field === 'source_file') return hit.source_file;
   return hit.score ?? 0;
 }
-
 function sortHits(hits: SearchHit[], field: SortField, order: SortOrder): SearchHit[] {
   const direction = order === 'asc' ? 1 : -1;
   return [...hits].sort((left, right) => {
-    const a = sortValue(left, field);
-    const b = sortValue(right, field);
+    const a = sortValue(left, field), b = sortValue(right, field);
     const compared = typeof a === 'number' && typeof b === 'number' ? a - b : String(a).localeCompare(String(b));
     return compared === 0 ? left.id.localeCompare(right.id) : compared * direction;
   });
 }
-
 function resolveCollection(collection: string | undefined, getModels: () => Record<string, unknown>): string | null {
-  const name = (collection || DEFAULT_COLLECTION).trim();
-  const models = getModels();
+  const name = (collection || DEFAULT_COLLECTION).trim(), models = getModels();
   if (name in models) return name;
-  const byCollectionName = Object.values(models).find(
-    (m) => typeof m === 'object' && m && 'collection' in m && (m as { collection: string }).collection === name,
-  );
-  return byCollectionName ? name : null;
+  const found = Object.values(models).find((m) => typeof m === 'object' && m && 'collection' in m && (m as { collection: string }).collection === name);
+  return found ? name : null;
+}
+function filterAsOf(hits: SearchHit[], db: Database, asOfMs?: number): SearchHit[] {
+  return filterResultsAsOf(db, hits as unknown as Array<Record<string, unknown>>, asOfMs) as unknown as SearchHit[];
 }
 
 export function createVectorSearchEndpoint(deps: VectorSearchDeps = {}) {
-  const getModels = deps.getModels ?? getEmbeddingModels;
-  const getStore = deps.getStore ?? getVectorStoreByModel;
-
+  const getModels = deps.getModels ?? getEmbeddingModels, getStore = deps.getStore ?? getVectorStoreByModel, asOfDb = deps.asOfDb ?? sqlite;
   return new Elysia().get('/vector/search', async ({ query, request, set }) => {
-    if (!query.q) {
-      set.status = 400;
-      return { error: 'Missing query parameter: q' };
-    }
+    if (!query.q) { set.status = 400; return { error: 'Missing query parameter: q' }; }
     const q = sanitize(query.q);
-    if (!q) {
-      set.status = 400;
-      return { error: 'Invalid query: empty after sanitization' };
-    }
-
+    if (!q) { set.status = 400; return { error: 'Invalid query: empty after sanitization' }; }
+    const asOf = parseAsOf(query.asOf);
+    if (!asOf.ok) { set.status = 400; return { error: asOf.error }; }
     const collection = resolveCollection(query.collection ?? query.model, getModels);
-    if (!collection) {
-      set.status = 404;
-      return { error: `Unknown vector collection: ${query.collection ?? query.model}` };
-    }
+    if (!collection) { set.status = 404; return { error: `Unknown vector collection: ${query.collection ?? query.model}` }; }
 
     let metadata: Record<string, unknown>;
     try {
@@ -213,41 +163,30 @@ export function createVectorSearchEndpoint(deps: VectorSearchDeps = {}) {
 
     const limit = positiveInt(query.limit, 10, MAX_LIMIT), offset = offsetOf(query.offset);
     const from = timestamp(query.from ?? query.dateFrom), to = timestamp(query.to ?? query.dateTo);
-    const sort = sortConfig(query.sort, query.order);
-    const fetchLimit = Math.min(MAX_FETCH, Math.max(offset + limit, limit * 5));
-
+    const sort = sortConfig(query.sort, query.order), fetchLimit = Math.min(MAX_FETCH, Math.max(offset + limit, limit * 5));
     let store: SearchStore | undefined;
     try {
       store = getStore(collection);
       await store.connect();
       await store.ensureCollection();
       const raw = await store.query(q, fetchLimit, Object.keys(metadata).length > 0 ? metadata : undefined);
-      const filtered = toHits(raw, collection)
+      const filtered = filterAsOf(toHits(raw, collection), asOfDb, asOf.value)
         .filter((hit) => matchesMetadata(hit, metadata))
         .filter((hit) => withinDateRange(hit, from, to));
       const sorted = sortHits(filtered, sort.field, sort.order);
       return {
-        results: sorted.slice(offset, offset + limit),
-        total: sorted.length,
-        offset,
-        limit,
-        query: q,
-        mode: 'vector',
-        collection,
-        filters: { metadata, dateRange: { from: query.from ?? query.dateFrom, to: query.to ?? query.dateTo } },
-        sort,
-        vectorAvailable: true,
+        results: sorted.slice(offset, offset + limit), total: sorted.length, offset, limit, query: q, mode: 'vector', collection,
+        filters: { metadata, dateRange: { from: query.from ?? query.dateFrom, to: query.to ?? query.dateTo }, asOf: query.asOf },
+        sort, vectorAvailable: true, ...asOfResponse(asOf.value),
       };
     } catch (error) {
       set.status = 400;
       const message = error instanceof Error ? error.message : String(error);
       return { results: [], total: 0, query: q, error: 'Vector search failed', message };
-    } finally {
-      await store?.close?.().catch(() => undefined);
-    }
+    } finally { await store?.close?.().catch(() => undefined); }
   }, {
     query: VectorSearchQuery,
-    detail: { tags: ['vector'], menu: { group: 'hidden' }, summary: 'Vector search with filters, pagination, and sort' },
+    detail: { tags: ['vector'], menu: { group: 'hidden' }, summary: 'Vector search with filters, pagination, sort, and asOf valid-time filtering' },
   });
 }
 

--- a/tests/http/search/bitemporal-read.test.ts
+++ b/tests/http/search/bitemporal-read.test.ts
@@ -95,6 +95,21 @@ describe('bi-temporal search read', () => {
     });
   });
 
+
+  test('GET /api/list?asOf applies the same valid-time support contract', async () => {
+    const res = await request(`/api/list?group=false&asOf=2024-06-01T00:00:00.000Z`);
+    const body = await res.json() as { results: Array<Record<string, unknown>>; total: number; asOfSupportedEndpoints: string[] };
+
+    expect(res.status).toBe(200);
+    expect(body.total).toBe(1);
+    expect(body.results[0]).toMatchObject({
+      id: oldDocId,
+      valid_time: new Date(oldValid).toISOString(),
+      valid_until: new Date(newValid).toISOString(),
+    });
+    expect(body.asOfSupportedEndpoints).toEqual(['/api/search', '/api/list', '/api/vector/search']);
+  });
+
   test('GET /api/search rejects invalid asOf timestamps', async () => {
     const res = await request(`/api/search?q=${term}&mode=fts&asOf=not-a-date`);
     expect(res.status).toBe(400);

--- a/tests/http/vector/search-asof.test.ts
+++ b/tests/http/vector/search-asof.test.ts
@@ -1,0 +1,91 @@
+import { Database } from 'bun:sqlite';
+import { expect, mock, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createVectorSearchEndpoint } from '../../../src/routes/vector/search.ts';
+import type { VectorQueryResult } from '../../../src/vector/types.ts';
+
+function temporalDb(): Database {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE oracle_documents (
+      id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, valid_time,
+      updated_at, created_at, indexed_at, superseded_by TEXT, superseded_at
+    );
+  `);
+  return db;
+}
+
+function seed(db: Database, id: string, validTime: string) {
+  const ms = Date.parse(validTime);
+  db.prepare(`
+    INSERT INTO oracle_documents
+      (id, tenant_id, valid_time, updated_at, created_at, indexed_at)
+    VALUES (?, 'default', ?, ?, ?, ?)
+  `).run(id, ms, ms, ms, ms);
+}
+
+function createFetch(db: Database, queryImpl?: () => Promise<VectorQueryResult>) {
+  const result: VectorQueryResult = {
+    ids: ['past', 'future'],
+    documents: ['past fact', 'future fact'],
+    distances: [0.1, 0.2],
+    metadatas: [
+      { type: 'learning', source_file: 'notes/past.md', concepts: 'history' },
+      { type: 'learning', source_file: 'notes/future.md', concepts: 'roadmap' },
+    ],
+  };
+  const store = {
+    connect: mock(async () => {}),
+    ensureCollection: mock(async () => {}),
+    query: mock(queryImpl ?? (async () => result)),
+    close: mock(async () => {}),
+  };
+  const app = new Elysia({ prefix: '/api' }).use(createVectorSearchEndpoint({
+    asOfDb: db,
+    getModels: () => ({ 'bge-m3': {} }),
+    getStore: () => store,
+  }));
+  return { fetcher: createApiVersionedFetch((request) => app.handle(request)), store };
+}
+
+test('GET /api/v1/vector/search filters vector hits by asOf valid_time', async () => {
+  const db = temporalDb();
+  try {
+    seed(db, 'past', '2024-01-01T00:00:00.000Z');
+    seed(db, 'future', '2025-01-01T00:00:00.000Z');
+    const { fetcher, store } = createFetch(db);
+
+    const res = await fetcher(new Request(
+      'http://local/api/v1/vector/search?q=oracle&asOf=2024-06-01T00:00:00.000Z&sort=id',
+    ));
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(store.query).toHaveBeenCalledWith('oracle', 50, undefined);
+    expect(body.asOf).toBe('2024-06-01T00:00:00.000Z');
+    expect(body.asOfSupportedEndpoints).toEqual(['/api/search', '/api/list', '/api/vector/search']);
+    expect(body.total).toBe(1);
+    expect(body.results).toEqual([expect.objectContaining({
+      id: 'past',
+      valid_time: '2024-01-01T00:00:00.000Z',
+      valid_until: null,
+    })]);
+  } finally {
+    db.close();
+  }
+});
+
+test('GET /api/v1/vector/search rejects invalid asOf before querying the vector store', async () => {
+  const db = temporalDb();
+  try {
+    const { fetcher, store } = createFetch(db);
+    const res = await fetcher(new Request('http://local/api/v1/vector/search?q=oracle&asOf=not-a-date'));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'Invalid asOf timestamp' });
+    expect(store.query).not.toHaveBeenCalled();
+  } finally {
+    db.close();
+  }
+});


### PR DESCRIPTION
## Summary
- adds shared `asOf` support enumeration for `/api/search`, `/api/list`, and `/api/vector/search`
- extends `/api/list` tenant/global routing with optional `asOf` parsing and valid-time filtering
- extends `/api/vector/search` with `asOf` parsing, DB-backed valid-time filtering, and response metadata
- adds vector and list/search temporal contract tests

References #2645.

## Validation
- `bunx tsc --noEmit`
- `bun test tests/http/vector/`
- `bun test tests/http/search/`
- `wc -l` changed files (all <= 250)
