### PR TITLE
feat: add memory consolidation governance API

### DIFF
--- a/src/routes/memory/consolidation.ts
+++ b/src/routes/memory/consolidation.ts
@@ -1,0 +1,211 @@
+import { Elysia } from 'elysia';
+import { db, sqlite } from '../../db/index.ts';
+import { activeTenantId, runWithTenant } from '../../middleware/tenant.ts';
+import { auditLog } from '../../storage/audit-log.ts';
+import { runSupersede } from '../../tools/supersede.ts';
+import { runConsolidationWorker, type ConsolidationPlan } from '../../workers/consolidation.ts';
+import { parseMemoryLimit } from './model.ts';
+
+type DocPreview = { id: string; title: string; sourceFile: string; type: string; content: string };
+type Suggestion = {
+  id: string; oldId: string; newId: string; tenantId: string; confidence: number; score: number;
+  reason: string; original: DocPreview; suggested: DocPreview;
+  metrics: { cosine: number; ftsOverlap: number; oldConfidence: number; newConfidence: number };
+};
+type DocRow = { id: string; type: string; sourceFile: string; content: string | null };
+type AuditPayload = {
+  type: `memory_consolidation.${'approve' | 'reject'}`; suggestionId: string; oldId: string;
+  newId: string; tenantId: string; who: string; when: number; reason?: string;
+};
+
+const ACTOR_HEADERS = ['x-oracle-actor', 'x-actor', 'x-user', 'x-user-id'];
+const silentLogger = { log() {}, warn() {}, error() {} };
+
+export function createMemoryConsolidationRoutes() {
+  const routes = new Elysia({ prefix: '/memory/consolidation' })
+    .get('/pending', ({ query }) => pendingResponse(parseMemoryLimit(query.limit, 50, 1000)))
+    .get('/suggestions', ({ query }) => pendingResponse(parseMemoryLimit(query.limit, 50, 1000)))
+    .post('/suggestions/:id/approve', ({ params, body, request, set }) => approve(params.id, body, request, set))
+    .post('/suggestions/:id/reject', ({ params, body, request, set }) => reject(params.id, body, request, set))
+    .post('/:id/approve', ({ params, body, request, set }) => approve(params.id, body, request, set))
+    .post('/:id/reject', ({ params, body, request, set }) => reject(params.id, body, request, set));
+  return routes;
+}
+
+async function pendingResponse(limit: number) {
+  const tenantId = activeTenantId();
+  const suggestions = await pendingSuggestions(limit, tenantId);
+  return { success: true, total: suggestions.length, tenant: { id: tenantId, scope: 'tenant_id' }, suggestions, items: suggestions };
+}
+
+async function approve(rawId: string, body: unknown, request: Request, set: { status?: number | string }) {
+  const tenantId = activeTenantId();
+  const suggestion = await suggestionFor(rawId, tenantId);
+  if (!suggestion) return notFound(set, rawId);
+
+  const result = runWithTenant(tenantId, () => runSupersede(db, {
+    oldId: suggestion.oldId,
+    newId: suggestion.newId,
+    reason: reasonFrom(body) ?? suggestion.reason,
+  }));
+  if (result.isError) {
+    set.status = 400;
+    return result.payload;
+  }
+  const audit = writeAudit('approve', suggestion, request, reasonFrom(body));
+  return { success: true, suggestion, result: result.payload, audit };
+}
+
+async function reject(rawId: string, body: unknown, request: Request, set: { status?: number | string }) {
+  const tenantId = activeTenantId();
+  const suggestion = await suggestionFor(rawId, tenantId);
+  if (!suggestion) return notFound(set, rawId);
+  const audit = writeAudit('reject', suggestion, request, reasonFrom(body));
+  return { success: true, suggestion, audit };
+}
+
+async function suggestionFor(rawId: string, tenantId: string): Promise<Suggestion | undefined> {
+  const id = safeDecode(rawId);
+  const bodyIds = idsFromSuggestionId(id);
+  const limit = bodyIds ? 1000 : 250;
+  const suggestions = await pendingSuggestions(limit, tenantId);
+  return suggestions.find((item) => item.id === id || item.id === rawId);
+}
+
+async function pendingSuggestions(limit: number, tenantId: string): Promise<Suggestion[]> {
+  const result = await runConsolidationWorker(db, sqlite, {
+    dryRun: true,
+    limit,
+    tenantId,
+    logger: silentLogger,
+  });
+  const rejected = rejectedSuggestionIds(tenantId);
+  const docs = docsFor(result.plans, tenantId);
+  return result.plans
+    .map((plan) => suggestionFromPlan(plan, docs))
+    .filter((item) => !rejected.has(item.id));
+}
+
+function suggestionFromPlan(plan: ConsolidationPlan, docs: Map<string, DocPreview>): Suggestion {
+  const original = docs.get(plan.oldId) ?? fallbackDoc(plan.oldId);
+  const suggested = docs.get(plan.newId) ?? fallbackDoc(plan.newId);
+  const confidence = round((plan.cosine * 0.6) + (plan.ftsOverlap * 0.4));
+  return {
+    id: suggestionId(plan.oldId, plan.newId), oldId: plan.oldId, newId: plan.newId,
+    tenantId: plan.tenantId, confidence, score: confidence, reason: plan.reason,
+    original, suggested,
+    metrics: {
+      cosine: plan.cosine, ftsOverlap: plan.ftsOverlap,
+      oldConfidence: plan.oldConfidence, newConfidence: plan.newConfidence,
+    },
+  };
+}
+
+function docsFor(plans: ConsolidationPlan[], tenantId: string): Map<string, DocPreview> {
+  const ids = [...new Set(plans.flatMap((plan) => [plan.oldId, plan.newId]))];
+  if (!ids.length) return new Map();
+  const fts = sqlite.query<{ name: string }, [string]>('SELECT name FROM sqlite_master WHERE name = ? LIMIT 1').get('oracle_fts');
+  const content = fts ? "coalesce(f.content, '')" : "''";
+  const join = fts ? 'LEFT JOIN oracle_fts f ON f.id = d.id' : '';
+  const placeholders = ids.map(() => '?').join(',');
+  const rows = sqlite.query<DocRow, (string | number)[]>(`
+    SELECT d.id, d.type, d.source_file AS sourceFile, ${content} AS content
+    FROM oracle_documents d ${join}
+    WHERE d.tenant_id = ? AND d.id IN (${placeholders})`,
+  ).all(tenantId, ...ids);
+  return new Map(rows.map((row) => [row.id, docPreview(row)]));
+}
+
+function docPreview(row: DocRow): DocPreview {
+  return {
+    id: row.id,
+    title: titleFrom(row.sourceFile, row.id),
+    sourceFile: row.sourceFile,
+    type: row.type,
+    content: preview(row.content ?? ''),
+  };
+}
+
+function fallbackDoc(id: string): DocPreview {
+  return { id, title: id, sourceFile: '', type: '', content: '' };
+}
+
+function writeAudit(action: 'approve' | 'reject', suggestion: Suggestion, request: Request, reason?: string) {
+  const when = Date.now();
+  const payload: AuditPayload = {
+    type: `memory_consolidation.${action}`,
+    suggestionId: suggestion.id,
+    oldId: suggestion.oldId,
+    newId: suggestion.newId,
+    tenantId: suggestion.tenantId,
+    who: actorFrom(request),
+    when,
+    ...(reason ? { reason } : {}),
+  };
+  db.insert(auditLog).values({
+    who: payload.who,
+    what: JSON.stringify(payload),
+    when,
+    requestId: request.headers.get('x-request-id'),
+  }).run();
+  return { ...payload, at: new Date(when).toISOString() };
+}
+
+function rejectedSuggestionIds(tenantId: string): Set<string> {
+  try {
+    const rows = sqlite.query<{ what: string }, [string]>('SELECT what FROM audit_log WHERE what LIKE ?')
+      .all('%"type":"memory_consolidation.reject"%');
+    return new Set(rows.flatMap((row) => {
+      const parsed = parseAudit(row.what);
+      return parsed?.tenantId === tenantId ? [parsed.suggestionId] : [];
+    }));
+  } catch { return new Set(); }
+}
+
+function parseAudit(value: string): AuditPayload | null {
+  try {
+    const parsed = JSON.parse(value) as Partial<AuditPayload>;
+    return parsed.type === 'memory_consolidation.reject' && typeof parsed.suggestionId === 'string'
+      ? parsed as AuditPayload
+      : null;
+  } catch { return null; }
+}
+
+function actorFrom(request: Request): string {
+  for (const header of ACTOR_HEADERS) {
+    const actor = request.headers.get(header)?.trim();
+    if (actor) return actor.slice(0, 120);
+  }
+  return request.headers.has('authorization') ? 'api' : 'anonymous';
+}
+
+function reasonFrom(body: unknown): string | undefined {
+  if (!body || typeof body !== 'object') return undefined;
+  const value = (body as Record<string, unknown>).reason;
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function notFound(set: { status?: number | string }, id: string) {
+  set.status = 404;
+  return { success: false, error: `Pending consolidation suggestion not found: ${safeDecode(id)}` };
+}
+
+function titleFrom(sourceFile: string, fallback: string): string {
+  const leaf = sourceFile.split('/').filter(Boolean).at(-1)?.replace(/\.md$/i, '');
+  return leaf || fallback;
+}
+
+function preview(value: string): string {
+  const clean = value.replace(/\s+/g, ' ').trim();
+  return clean.length > 280 ? `${clean.slice(0, 277)}…` : clean;
+}
+
+function suggestionId(oldId: string, newId: string): string { return `${oldId}->${newId}`; }
+function round(value: number): number { return Number(value.toFixed(4)); }
+function safeDecode(value: string): string { try { return decodeURIComponent(value); } catch { return value; } }
+function idsFromSuggestionId(id: string): [string, string] | null {
+  const index = id.indexOf('->');
+  return index > 0 ? [id.slice(0, index), id.slice(index + 2)] : null;
+}
+
+export const memoryConsolidationRoutes = createMemoryConsolidationRoutes();

--- a/src/routes/memory/index.ts
+++ b/src/routes/memory/index.ts
@@ -9,6 +9,7 @@ import { formatCloseoutMemory, type MemoryCloseoutInput } from './closeout.ts';
 import { currentTenantId } from '../../middleware/tenant.ts';
 import { rankMemories } from './rank.ts';
 import { createMemoryStatsEndpoint } from './stats.ts';
+import { createMemoryConsolidationRoutes } from './consolidation.ts';
 import { candidatePoolSize } from '../../search/retrieve-depth.ts';
 
 export function createMemoryRoutes(
@@ -44,6 +45,7 @@ export function createMemoryRoutes(
     })
     .use(createMemoryFanoutEndpoint())
     .use(createMemoryStatsEndpoint())
+    .use(createMemoryConsolidationRoutes())
     .get('/memory/morning-tape', ({ query }) => {
       const limit = parseMemoryLimit(query.limit, 8, 25);
       const tape = buildMorningTape(store.recall('', limit));

--- a/tests/http/memory/consolidation.test.ts
+++ b/tests/http/memory/consolidation.test.ts
@@ -1,0 +1,154 @@
+import { afterAll, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { eq, inArray } from 'drizzle-orm';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const tempData = mkdtempSync(join(tmpdir(), 'arra-memory-consolidation-api-'));
+const previousData = process.env.ORACLE_DATA_DIR;
+const previousDb = process.env.ORACLE_DB_PATH;
+process.env.ORACLE_DATA_DIR = tempData;
+process.env.ORACLE_DB_PATH = join(tempData, 'oracle.db');
+
+const dbMod = await import('../../../src/db/index.ts');
+dbMod.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+const { db, oracleDocuments, oracleFts, tenants } = dbMod;
+const { auditLog } = await import('../../../src/storage/audit-log.ts');
+const { createApiVersionedFetch } = await import('../../../src/middleware/api-version.ts');
+const { createTenantFetch, TENANT_HEADER } = await import('../../../src/middleware/tenant.ts');
+const { createMemoryConsolidationRoutes } = await import('../../../src/routes/memory/consolidation.ts');
+
+type PendingBody = { suggestions: Array<{ id: string; oldId: string; newId: string; tenantId: string; confidence: number }> };
+type AuditRow = { who: string; what: string; when: number };
+
+const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const tenantA = `consolidation-a-${stamp}`;
+const tenantB = `consolidation-b-${stamp}`;
+const ids = {
+  aOld: `approve-old-${stamp}`,
+  aNew: `approve-new-${stamp}`,
+  rOld: `reject-old-${stamp}`,
+  rNew: `reject-new-${stamp}`,
+  bOld: `tenant-b-old-${stamp}`,
+  bNew: `tenant-b-new-${stamp}`,
+};
+const app = new Elysia({ prefix: '/api' }).use(createMemoryConsolidationRoutes());
+const fetcher = createTenantFetch(createApiVersionedFetch((request) => app.handle(request)));
+const now = Date.parse('2026-06-17T00:00:00.000Z');
+
+function request(tenantId: string, path: string, init: RequestInit = {}) {
+  return fetcher(new Request(`http://local${path}`, {
+    ...init,
+    headers: { 'content-type': 'application/json', [TENANT_HEADER]: tenantId, ...(init.headers ?? {}) },
+  }));
+}
+
+function addTenant(id: string) {
+  db.insert(tenants).values({ id, name: id, status: 'active', createdAt: now, updatedAt: now })
+    .onConflictDoNothing().run();
+}
+
+function addPair(oldId: string, newId: string, tenantId: string, phrase: string) {
+  addDoc(oldId, tenantId, phrase, now - 90_000);
+  addDoc(newId, tenantId, phrase, now);
+}
+
+function addDoc(id: string, tenantId: string, phrase: string, updatedAt: number) {
+  db.insert(oracleDocuments).values({
+    id,
+    tenantId,
+    type: 'learning',
+    sourceFile: `ψ/memory/learnings/${id}.md`,
+    concepts: JSON.stringify([tenantId, 'consolidation', phrase]),
+    createdAt: updatedAt - 1000,
+    updatedAt,
+    indexedAt: updatedAt,
+    project: `project-${tenantId}`,
+    createdBy: 'consolidation-test',
+  }).run();
+  db.insert(oracleFts).values({ id, content: phrase, concepts: JSON.stringify(['consolidation', tenantId]) }).run();
+}
+
+function seedFixtures() {
+  addTenant(tenantA);
+  addTenant(tenantB);
+  addPair(ids.aOld, ids.aNew, tenantA, 'alpha approve governance queue duplicate canonical memory review supersede human control');
+  addPair(ids.rOld, ids.rNew, tenantA, 'beta reject governance queue duplicate canonical memory review supersede human control');
+  addPair(ids.bOld, ids.bNew, tenantB, 'gamma tenant isolation queue duplicate canonical memory review supersede human control');
+}
+
+async function json<T>(res: Response): Promise<T> {
+  return await res.json() as T;
+}
+
+function suggestion(body: PendingBody, oldId: string) {
+  return body.suggestions.find((item) => item.oldId === oldId);
+}
+
+function audits(type: 'approve' | 'reject'): AuditRow[] {
+  return db.select({ who: auditLog.who, what: auditLog.what, when: auditLog.when }).from(auditLog).all()
+    .filter((row) => row.what.includes(`memory_consolidation.${type}`));
+}
+
+seedFixtures();
+
+afterAll(() => {
+  db.delete(oracleDocuments).where(inArray(oracleDocuments.id, Object.values(ids))).run();
+  dbMod.closeDb();
+  if (previousData === undefined) delete process.env.ORACLE_DATA_DIR;
+  else process.env.ORACLE_DATA_DIR = previousData;
+  if (previousDb === undefined) delete process.env.ORACLE_DB_PATH;
+  else process.env.ORACLE_DB_PATH = previousDb;
+  if (existsSync(tempData)) rmSync(tempData, { recursive: true });
+});
+
+test('GET /api/v1/memory/consolidation/pending lists tenant-scoped supersede suggestions', async () => {
+  const response = await request(tenantA, '/api/v1/memory/consolidation/pending?limit=10');
+  const body = await json<PendingBody>(response);
+  const approve = suggestion(body, ids.aOld);
+
+  expect(response.status).toBe(200);
+  expect(approve).toMatchObject({ oldId: ids.aOld, newId: ids.aNew, tenantId: tenantA });
+  expect(approve!.confidence).toBeGreaterThan(0.9);
+  expect(suggestion(body, ids.bOld)).toBeUndefined();
+});
+
+test('POST /api/v1/memory/consolidation/:id/approve applies supersede and audits reviewer', async () => {
+  const pending = await json<PendingBody>(await request(tenantA, '/api/v1/memory/consolidation/pending'));
+  const item = suggestion(pending, ids.aOld)!;
+  const response = await request(tenantA, `/api/v1/memory/consolidation/${encodeURIComponent(item.id)}/approve`, {
+    method: 'POST',
+    headers: { 'x-oracle-actor': 'metis' },
+    body: JSON.stringify({ reason: 'approved by governance review' }),
+  });
+  const row = db.select({ supersededBy: oracleDocuments.supersededBy, reason: oracleDocuments.supersededReason })
+    .from(oracleDocuments).where(eq(oracleDocuments.id, ids.aOld)).get();
+  const audit = audits('approve').find((entry) => entry.who === 'metis');
+
+  expect(response.status).toBe(200);
+  expect(row).toEqual({ supersededBy: ids.aNew, reason: 'approved by governance review' });
+  expect(audit).toBeDefined();
+  expect(JSON.parse(audit!.what)).toMatchObject({ oldId: ids.aOld, newId: ids.aNew, tenantId: tenantA, who: 'metis' });
+});
+
+test('POST /api/v1/memory/consolidation/suggestions/:id/reject dismisses only the active tenant suggestion', async () => {
+  const pending = await json<PendingBody>(await request(tenantA, '/api/v1/memory/consolidation/suggestions'));
+  const item = suggestion(pending, ids.rOld)!;
+  const response = await request(tenantA, `/api/v1/memory/consolidation/suggestions/${encodeURIComponent(item.id)}/reject`, {
+    method: 'POST',
+    headers: { 'x-oracle-actor': 'oracle-reviewer' },
+    body: JSON.stringify({ reason: 'not a true duplicate' }),
+  });
+  const afterReject = await json<PendingBody>(await request(tenantA, '/api/v1/memory/consolidation/pending'));
+  const tenantBPending = await json<PendingBody>(await request(tenantB, '/api/v1/memory/consolidation/pending'));
+  const oldRow = db.select({ supersededBy: oracleDocuments.supersededBy })
+    .from(oracleDocuments).where(eq(oracleDocuments.id, ids.rOld)).get();
+  const audit = audits('reject').find((entry) => entry.who === 'oracle-reviewer');
+
+  expect(response.status).toBe(200);
+  expect(oldRow?.supersededBy).toBeNull();
+  expect(suggestion(afterReject, ids.rOld)).toBeUndefined();
+  expect(suggestion(tenantBPending, ids.bOld)).toMatchObject({ tenantId: tenantB });
+  expect(JSON.parse(audit!.what)).toMatchObject({ oldId: ids.rOld, newId: ids.rNew, tenantId: tenantA });
+});


### PR DESCRIPTION
## Summary
- add `/api/memory/consolidation/pending` plus approve/reject review endpoints
- support existing review-queue UI aliases under `/suggestions`
- generate tenant-scoped pending suggestions from the consolidation worker, approve through existing `runSupersede`, and audit approve/reject decisions

## Validation
- bun test tests/http/memory/
- bunx tsc --noEmit
- git diff --check

Base: alpha