### PR TITLE
feat: boost vector results by entity links

### DIFF
--- a/src/routes/vector/entity-boost.ts
+++ b/src/routes/vector/entity-boost.ts
@@ -1,0 +1,218 @@
+import type { Database } from 'bun:sqlite';
+import { getScopedSetting } from '../../db/scoped-settings.ts';
+import { DEFAULT_TENANT_ID } from '../../middleware/tenant.ts';
+import { entityKey } from '../../search/entity-ranking.ts';
+import { extractEntities } from '../../vector/entities.ts';
+import { memoryConfidence } from '../memory/confidence.ts';
+import type { MemoryRecord } from '../memory/store.ts';
+
+export const ENTITY_BOOST_CAP_SETTING = 'vector.entity_boost_cap';
+export const ENTITY_ALIASES_SETTING = 'vector.entity_aliases';
+export const DEFAULT_ENTITY_BOOST_CAP = 1.5;
+export const MAX_ENTITY_BOOST_CAP = 3;
+
+const STOPWORDS = new Set(['a', 'an', 'and', 'are', 'but', 'for', 'from', 'how', 'the', 'this', 'that', 'what', 'when', 'where', 'with', 'why']);
+const STRATEGY = 'entity_link_confidence_heat_capped_multiplier';
+
+type BoostHit = {
+  id: string;
+  score?: number;
+  content?: string;
+  source_file?: string;
+  concepts?: string[];
+  metadata?: Record<string, unknown>;
+  type?: string;
+};
+type LinkRow = { documentId: string; entity: string; entityKey: string; weight: number };
+type DocRow = {
+  id: string; sourceFile?: string; concepts?: string; createdAt?: number; updatedAt?: number;
+  usageCount?: number; lastAccessedAt?: number;
+};
+type AliasRule = { alias: string; entity: string };
+export type EntityBoostSettings = { cap: number; aliases: AliasRule[] };
+
+export type EntityBoostFields = {
+  entity_score?: number;
+  entity_matches?: string[];
+  entity_boost?: {
+    factor: number; cap: number; baseScore: number; preBoostScore: number;
+    confidence: number; heat: number; strategy: typeof STRATEGY;
+  };
+};
+
+export function vectorEntityBoostSettings(read = getScopedSetting): EntityBoostSettings {
+  return {
+    cap: parseCap(read(ENTITY_BOOST_CAP_SETTING)),
+    aliases: parseAliases(read(ENTITY_ALIASES_SETTING)),
+  };
+}
+
+export function applyVectorEntityBoost<T extends BoostHit>(
+  db: Database,
+  hits: T[],
+  query: string,
+  options: { tenantId?: string; settings?: EntityBoostSettings; now?: Date } = {},
+): Array<T & EntityBoostFields> {
+  if (hits.length === 0) return hits;
+  const tenantId = options.tenantId?.trim() || DEFAULT_TENANT_ID;
+  const settings = options.settings ?? vectorEntityBoostSettings();
+  const keys = entityKeysForQuery(query, settings.aliases);
+  const ids = hits.map((hit) => hit.id).filter(Boolean).slice(0, 100);
+  const docs = readDocs(db, ids, tenantId);
+  const links = keys.length ? readLinks(db, ids, keys, tenantId) : new Map<string, LinkRow[]>();
+
+  return hits.map((hit) => {
+    const confidence = confidenceForHit(hit, docs.get(hit.id), options.now);
+    const baseScore = finiteScore(hit.score);
+    const heat = confidence.components.usage;
+    const preBoostScore = round6(clamp((baseScore * 0.72) + (confidence.score * 0.18) + (heat * 0.1)));
+    const matches = links.get(hit.id) ?? [];
+    const factor = matches.length ? settings.cap : 1;
+    const score = round6(preBoostScore * factor);
+    return {
+      ...hit,
+      score,
+      ...(matches.length ? {
+        entity_score: round3(factor - 1),
+        entity_matches: matches.map((match) => match.entity),
+        entity_boost: { factor, cap: settings.cap, baseScore, preBoostScore, confidence: confidence.score, heat, strategy: STRATEGY },
+      } : {}),
+    };
+  });
+}
+
+export function entityKeysForQuery(query: string, aliases: AliasRule[] = []): string[] {
+  const keys = new Set(extractEntities(query).map(entityKey).filter(Boolean));
+  const words = query.normalize('NFKC').match(/[\p{L}\p{N}][\p{L}\p{N}._-]{1,}/gu)
+    ?.map((word) => word.toLowerCase()).filter((word) => !STOPWORDS.has(word)) ?? [];
+  for (const word of words) keys.add(entityKey(word));
+  for (let i = 0; i < words.length - 1; i += 1) keys.add(entityKey(`${words[i]} ${words[i + 1]}`));
+  const lower = ` ${query.normalize('NFKC').toLowerCase()} `;
+  for (const rule of aliases) {
+    const aliasKey = entityKey(rule.alias);
+    if (keys.has(aliasKey) || lower.includes(` ${rule.alias.toLowerCase()} `)) keys.add(entityKey(rule.entity));
+  }
+  return [...keys].filter(Boolean).slice(0, 24);
+}
+
+function readLinks(db: Database, ids: string[], keys: string[], tenantId: string): Map<string, LinkRow[]> {
+  const out = new Map<string, LinkRow[]>();
+  if (!ids.length || !keys.length) return out;
+  try {
+    const rows = db.query<LinkRow, any[]>(`
+      SELECT document_id AS documentId, entity, entity_key AS entityKey, weight
+      FROM oracle_entity_links
+      WHERE tenant_id = ? AND document_id IN (${marks(ids)}) AND entity_key IN (${marks(keys)})
+    `).all(tenantId, ...ids, ...keys);
+    for (const row of rows) out.set(row.documentId, [...(out.get(row.documentId) ?? []), row]);
+  } catch (error) {
+    if (!missingSchema(error)) throw error;
+  }
+  return out;
+}
+
+function readDocs(db: Database, ids: string[], tenantId: string): Map<string, DocRow> {
+  const out = new Map<string, DocRow>();
+  if (!ids.length) return out;
+  try {
+    const rows = db.query<DocRow, any[]>(`
+      SELECT id, source_file AS sourceFile, concepts, created_at AS createdAt, updated_at AS updatedAt,
+        usage_count AS usageCount, last_accessed_at AS lastAccessedAt
+      FROM oracle_documents
+      WHERE tenant_id = ? AND id IN (${marks(ids)})
+    `).all(tenantId, ...ids);
+    for (const row of rows) out.set(row.id, row);
+  } catch (error) {
+    if (!missingSchema(error)) throw error;
+  }
+  return out;
+}
+
+function confidenceForHit(hit: BoostHit, doc?: DocRow, now?: Date) {
+  const metadata = hit.metadata ?? {};
+  const memory: MemoryRecord = {
+    id: hit.id,
+    content: hit.content ?? '',
+    source: text(hit.source_file ?? metadata.source_file ?? doc?.sourceFile),
+    tags: list(hit.concepts ?? metadata.concepts ?? doc?.concepts),
+    createdAt: time(metadata.created_at ?? metadata.createdAt ?? doc?.createdAt) ?? new Date(0).toISOString(),
+    updatedAt: time(metadata.updated_at ?? metadata.updatedAt ?? doc?.updatedAt) ?? new Date().toISOString(),
+    usageCount: number(metadata.usage_count ?? metadata.usageCount ?? doc?.usageCount) ?? 0,
+    lastAccessedAt: time(metadata.last_accessed_at ?? metadata.lastAccessedAt ?? doc?.lastAccessedAt),
+    tier: 'warm',
+    heatScore: 0,
+  };
+  return memoryConfidence(memory, { mode: 'semantic', semanticScore: finiteScore(hit.score), now });
+}
+
+function parseCap(value: string | null): number {
+  const parsed = Number(value ?? process.env.ORACLE_VECTOR_ENTITY_BOOST_CAP ?? DEFAULT_ENTITY_BOOST_CAP);
+  if (!Number.isFinite(parsed)) return DEFAULT_ENTITY_BOOST_CAP;
+  return Math.max(1, Math.min(MAX_ENTITY_BOOST_CAP, parsed));
+}
+
+function parseAliases(raw: string | null): AliasRule[] {
+  if (!raw?.trim()) return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return [];
+    return Object.entries(parsed).flatMap(([alias, value]) => {
+      const values = Array.isArray(value) ? value : [value];
+      return values.filter((item): item is string => typeof item === 'string').map((entity) => ({ alias, entity }));
+    })
+      .filter((rule) => rule.alias.trim() && rule.entity.trim());
+  } catch {
+    return [];
+  }
+}
+
+function marks(values: unknown[]): string {
+  return values.map(() => '?').join(',');
+}
+
+function missingSchema(error: unknown): boolean {
+  const message = String(error instanceof Error ? error.message : error);
+  return message.includes('no such table') || message.includes('no such column');
+}
+
+function text(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function list(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map(String).filter(Boolean);
+  if (typeof value !== 'string' || !value.trim()) return [];
+  try {
+    const parsed = JSON.parse(value);
+    if (Array.isArray(parsed)) return list(parsed);
+  } catch {}
+  return value.split(',').map((item) => item.trim()).filter(Boolean);
+}
+
+function time(value: unknown): string | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return new Date(value).toISOString();
+  if (typeof value === 'string' && value.trim()) return value;
+  return undefined;
+}
+
+function number(value: unknown): number | undefined {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function finiteScore(value: unknown): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.max(0, parsed) : 0;
+}
+
+function clamp(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.min(1, value)) : 0;
+}
+
+function round3(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+function round6(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
+}

--- a/src/routes/vector/search.ts
+++ b/src/routes/vector/search.ts
@@ -7,6 +7,7 @@ import { filterResultsAsOf, parseAsOf } from '../../search/bitemporal.ts';
 import { getEmbeddingModels, getVectorStoreByModel } from '../../vector/factory.ts';
 import type { VectorQueryResult, VectorStoreAdapter } from '../../vector/types.ts';
 import { asOfResponse } from '../search/asof.ts';
+import { applyVectorEntityBoost } from './entity-boost.ts';
 
 type SortField = 'score' | 'distance' | 'date' | 'id' | 'type' | 'source_file';
 type SortOrder = 'asc' | 'desc';
@@ -153,8 +154,8 @@ export function createVectorSearchEndpoint(deps: VectorSearchDeps = {}) {
 
     let metadata: Record<string, unknown>;
     try {
-      metadata = metadataFilters(request, query.type);
       const tenantId = currentTenantId();
+      metadata = metadataFilters(request, query.type);
       if (tenantId) metadata.tenant_id = tenantId;
     } catch (error) {
       set.status = 400;
@@ -173,7 +174,8 @@ export function createVectorSearchEndpoint(deps: VectorSearchDeps = {}) {
       const filtered = filterAsOf(toHits(raw, collection), asOfDb, asOf.value)
         .filter((hit) => matchesMetadata(hit, metadata))
         .filter((hit) => withinDateRange(hit, from, to));
-      const sorted = sortHits(filtered, sort.field, sort.order);
+      const boosted = applyVectorEntityBoost(asOfDb, filtered, q, { tenantId: currentTenantId() });
+      const sorted = sortHits(boosted, sort.field, sort.order);
       return {
         results: sorted.slice(offset, offset + limit), total: sorted.length, offset, limit, query: q, mode: 'vector', collection,
         filters: { metadata, dateRange: { from: query.from ?? query.dateFrom, to: query.to ?? query.dateTo }, asOf: query.asOf },

--- a/tests/http/vector/entity-boost.test.ts
+++ b/tests/http/vector/entity-boost.test.ts
@@ -1,0 +1,107 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, mock, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createTenantFetch, runWithTenant, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
+import { createVectorSearchEndpoint } from '../../../src/routes/vector/search.ts';
+import type { VectorQueryResult } from '../../../src/vector/types.ts';
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-vector-entity-boost-'));
+const stamp = `${Date.now()}${Math.random().toString(16).slice(2)}`;
+const tenantA = `tenant-a-${stamp}`;
+const tenantB = `tenant-b-${stamp}`;
+const linked = `boost-linked-${stamp}`;
+const plain = `boost-plain-${stamp}`;
+const otherTenant = `boost-other-${stamp}`;
+
+let dbModule: typeof import('../../../src/db/index.ts');
+let replaceEntityLinks: typeof import('../../../src/search/entity-ranking.ts').replaceEntityLinks;
+let setScopedSetting: typeof import('../../../src/db/scoped-settings.ts').setScopedSetting;
+let fetcher: (request: Request) => Response | Promise<Response>;
+
+beforeAll(async () => {
+  process.env.ORACLE_DATA_DIR = tempRoot;
+  process.env.ORACLE_DB_PATH = path.join(tempRoot, 'oracle.db');
+  dbModule = await import('../../../src/db/index.ts');
+  dbModule.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+  ({ replaceEntityLinks } = await import('../../../src/search/entity-ranking.ts'));
+  ({ setScopedSetting } = await import('../../../src/db/scoped-settings.ts'));
+  insertDoc(linked, tenantA, 6, Date.now());
+  insertDoc(plain, tenantA, 0, undefined);
+  insertDoc(otherTenant, tenantB, 20, Date.now());
+  replaceEntityLinks(dbModule.sqlite, { documentId: linked, tenantId: tenantA, content: 'Alpha Project launch', concepts: [] });
+  replaceEntityLinks(dbModule.sqlite, { documentId: otherTenant, tenantId: tenantB, content: 'Alpha Project leak', concepts: [] });
+  runWithTenant(tenantA, () => setScopedSetting('vector.entity_aliases', JSON.stringify({ AP: 'Alpha Project' })));
+  runWithTenant(tenantB, () => {
+    setScopedSetting('vector.entity_boost_cap', '9');
+    setScopedSetting('vector.entity_aliases', JSON.stringify({ BETA: 'Alpha Project' }));
+  });
+
+  const app = new Elysia({ prefix: '/api' }).use(createVectorSearchEndpoint({
+    getModels: () => ({ 'bge-m3': {} }),
+    getStore: () => ({ connect: mock(async () => {}), ensureCollection: mock(async () => {}), close: mock(async () => {}), query: mock(vectorResult) }),
+  }));
+  fetcher = createTenantFetch(createApiVersionedFetch((request) => app.handle(request)));
+});
+
+function insertDoc(id: string, tenantId: string, usageCount: number, lastAccessedAt: number | undefined) {
+  const now = Date.now();
+  dbModule.db.insert(dbModule.oracleDocuments).values({
+    id, tenantId, type: 'learning', sourceFile: `ψ/entities/${id}.md`, concepts: JSON.stringify(['alpha']),
+    createdAt: now - 86_400_000, updatedAt: now, indexedAt: now, project: 'entity-boost', createdBy: 'entity-boost-test',
+    usageCount, lastAccessedAt,
+  }).run();
+}
+
+async function vectorResult(): Promise<VectorQueryResult> {
+  return {
+    ids: [plain, linked, otherTenant],
+    documents: ['plain AP candidate', 'linked AP candidate', 'other tenant AP candidate'],
+    distances: [0, 10, 10],
+    metadatas: [
+      { type: 'learning', tenant_id: tenantA, source_file: `ψ/entities/${plain}.md`, concepts: ['alpha'] },
+      { type: 'learning', tenant_id: tenantA, source_file: `ψ/entities/${linked}.md`, concepts: ['alpha'] },
+      { type: 'learning', tenant_id: tenantB, source_file: `ψ/entities/${otherTenant}.md`, concepts: ['alpha'] },
+    ],
+  };
+}
+
+function request(tenantId: string, q = 'AP rollout') {
+  return fetcher(new Request(`http://local/api/v1/vector/search?q=${encodeURIComponent(q)}&limit=10`, {
+    headers: { [TENANT_HEADER]: tenantId },
+  }));
+}
+
+afterAll(() => {
+  dbModule?.closeDb();
+  if (fs.existsSync(tempRoot)) fs.rmSync(tempRoot, { recursive: true });
+});
+
+describe('vector entity boost', () => {
+  test('boosts tenant-local entity aliases and interacts with heat/confidence ranking', async () => {
+    const res = await request(tenantA);
+    const body = await res.json() as { results: Array<Record<string, any>>; filters: { metadata: Record<string, string> } };
+
+    expect(res.status).toBe(200);
+    expect(body.filters.metadata).toEqual({ tenant_id: tenantA });
+    expect(body.results.map((item) => item.id)).toEqual([linked, plain]);
+    expect(body.results[0].entity_matches).toContain('Alpha Project');
+    expect(body.results[0].entity_boost).toMatchObject({ factor: 1.5, cap: 1.5 });
+    expect(body.results[0].entity_boost.heat).toBeGreaterThan(0);
+    expect(body.results[0].score).toBeGreaterThan(body.results[1].score);
+  });
+
+  test('keeps aliases tenant-isolated and clamps configured boost caps to 3x', async () => {
+    const noAlias = await request(tenantA, 'BETA rollout');
+    const noAliasBody = await noAlias.json() as { results: Array<Record<string, any>> };
+    expect(noAliasBody.results.every((item) => item.entity_boost === undefined)).toBe(true);
+
+    const capped = await request(tenantB, 'BETA rollout');
+    const cappedBody = await capped.json() as { results: Array<Record<string, any>> };
+    expect(cappedBody.results).toHaveLength(1);
+    expect(cappedBody.results[0].id).toBe(otherTenant);
+    expect(cappedBody.results[0].entity_boost).toMatchObject({ factor: 3, cap: 3 });
+  });
+});


### PR DESCRIPTION
## Summary
- add capped entity-link boost for `/api/vector/search` ranking
- read tenant-scoped boost cap and aliases from settings (`vector.entity_boost_cap`, `vector.entity_aliases`), defaulting to 1.5x and clamping at 3x
- blend vector score with confidence/usage heat before applying the capped entity multiplier

Closes #2664.

## Validation
- `bunx tsc --noEmit`
- `bun test tests/http/vector/`
- `wc -l src/routes/vector/entity-boost.ts src/routes/vector/search.ts tests/http/vector/entity-boost.test.ts`
