### PR TITLE
feat: add cited /api/ask RAG contract

### DIFF
--- a/src/routes/ask/index.ts
+++ b/src/routes/ask/index.ts
@@ -1,11 +1,22 @@
 import { Elysia } from 'elysia';
 import { sqlite } from '../../db/index.ts';
+import { currentTenantId } from '../../middleware/tenant.ts';
+import { filterResultsAsOf, parseAsOf } from '../../search/bitemporal.ts';
+import { rerankByEntityLinks } from '../../search/entity-ranking.ts';
 import { attachSupersedeStatus } from '../../search/supersede-status.ts';
 import { handleSearch } from '../../server/handlers.ts';
 import { parseOptionalSearchModel } from '../search/model-key.ts';
 import { handleTenantSearch } from '../search/tenant-search.ts';
 import { AskBody } from './model.ts';
-import { envAskClient, sourcesFrom, synthesize, type AskClient } from './synthesis.ts';
+import {
+  citationsFrom,
+  envAskClient,
+  rankAskResults,
+  sourcesFrom,
+  synthesize,
+  warningsFrom,
+  type AskClient,
+} from './synthesis.ts';
 
 type AskDeps = { client?: AskClient; now?: () => Date };
 
@@ -20,7 +31,7 @@ function limitOf(value: number | undefined): number {
 
 export function createAskRoutes(deps: AskDeps = {}) {
   return new Elysia({ prefix: '/api' }).post('/ask', async ({ body, set }) => {
-    const q = sanitize(body.q ?? '');
+    const q = sanitize(body.question ?? body.q ?? '');
     if (!q) {
       set.status = 400;
       return { error: 'Invalid query: empty after sanitization' };
@@ -32,25 +43,43 @@ export function createAskRoutes(deps: AskDeps = {}) {
       set.status = 400;
       return { error: parsedModel.error };
     }
-    const result = handleTenantSearch(q, body.type ?? 'all', limit, 0)
+    const asOf = parseAsOf(body.asOf);
+    if (!asOf.ok) {
+      set.status = 400;
+      return { error: asOf.error };
+    }
+    const tenantResult = handleTenantSearch(q, body.type ?? 'all', limit, 0, asOf.value);
+    const result = tenantResult
       ?? await handleSearch(q, body.type ?? 'all', limit, 0, 'hybrid', body.project, body.cwd, parsedModel.value);
+    if (asOf.value && !tenantResult) {
+      result.results = filterResultsAsOf(
+        sqlite,
+        result.results as unknown as Array<Record<string, unknown>>,
+        asOf.value,
+      ) as unknown as typeof result.results;
+      result.total = result.results.length;
+    }
+    result.results = rerankByEntityLinks(sqlite, result.results, q, currentTenantId()) as typeof result.results;
     attachSupersedeStatus(sqlite, result.results as unknown as Array<Record<string, unknown>>);
-    const sources = sourcesFrom(result.results, limit);
+    const sources = sourcesFrom(rankAskResults(result.results), limit);
     const client = body.llm === false ? undefined : deps.client ?? envAskClient();
     const synthesis = await synthesize(q, sources, client);
     return {
       query: q,
       answer: synthesis.answer,
-      citations: synthesis.citations,
+      citations: citationsFrom(synthesis.citations, sources),
+      citationIndexes: synthesis.citations,
+      warnings: warningsFrom(sources, result.warning, synthesis.noEvidence),
       noEvidence: synthesis.noEvidence,
       mode: synthesis.mode,
       generatedAt: deps.now?.().toISOString() ?? new Date().toISOString(),
+      ...(asOf.value ? { asOf: new Date(asOf.value).toISOString() } : {}),
       search: { total: result.total, limit, vectorAvailable: result.vectorAvailable, warning: result.warning },
       sources,
     };
   }, {
     body: AskBody,
-    detail: { tags: ['ask'], menu: { group: 'main', path: '/ask', order: 12 }, summary: 'Ask the oracle with cited synthesis over hybrid search' },
+    detail: { tags: ['ask'], menu: { group: 'main', path: '/ask', order: 12 }, summary: 'Ask the oracle with cited synthesis over hybrid/vector search' },
   });
 }
 

--- a/src/routes/ask/model.ts
+++ b/src/routes/ask/model.ts
@@ -1,11 +1,13 @@
 import { t } from 'elysia';
 
 export const AskBody = t.Object({
-  q: t.String(),
+  q: t.Optional(t.String()),
+  question: t.Optional(t.String()),
   type: t.Optional(t.String()),
   limit: t.Optional(t.Number()),
   project: t.Optional(t.String()),
   cwd: t.Optional(t.String()),
   model: t.Optional(t.String()),
+  asOf: t.Optional(t.String()),
   llm: t.Optional(t.Boolean()),
 });

--- a/src/routes/ask/synthesis.ts
+++ b/src/routes/ask/synthesis.ts
@@ -1,25 +1,63 @@
 import type { SearchResult } from '../../server/types.ts';
 
 export type AskSource = {
-  index: number; id: string; type: string; sourceFile: string; score: number;
-  excerpt: string; supersededBy?: string; supersededAt?: string | null; supersededReason?: string | null;
+  index: number; id: string; type: string; title: string; sourceFile: string; score: number; confidence: number;
+  excerpt: string; stale: boolean; supersededBy?: string; supersededAt?: string | null; supersededReason?: string | null;
+  entityMatches?: string[]; chunk?: { index?: number; lineStart?: number; lineEnd?: number };
 };
+export type AskCitation = Pick<AskSource, 'index' | 'id' | 'title' | 'sourceFile' | 'excerpt' | 'score' | 'confidence' | 'stale' | 'chunk'>;
 export type AskPrompt = { instruction: string; question: string; sources: AskSource[] };
 export type AskClient = (prompt: AskPrompt) => Promise<unknown>;
 export type AskSynthesis = { answer: string; citations: number[]; noEvidence: boolean; mode: 'llm' | 'extractive' };
 
+type RankedResult = SearchResult & Record<string, unknown>;
+
+export function rankAskResults(results: SearchResult[]): SearchResult[] {
+  return results.map((result, index) => ({ ...result, askRank: askRank(result as RankedResult), __askIndex: index }))
+    .sort((a, b) => b.askRank - a.askRank || a.__askIndex - b.__askIndex)
+    .map(({ askRank: _rank, __askIndex: _index, ...result }) => result as SearchResult);
+}
+
 export function sourcesFrom(results: SearchResult[], limit: number): AskSource[] {
-  return results.slice(0, limit).map((result, index) => ({
-    index: index + 1,
-    id: result.id,
-    type: result.type,
-    sourceFile: result.source_file,
-    score: round(result.score ?? 0),
-    excerpt: excerpt(result.content),
-    supersededBy: result.superseded_by,
-    supersededAt: result.superseded_at,
-    supersededReason: result.superseded_reason,
-  }));
+  return results.slice(0, limit).map((result, index) => {
+    const record = result as RankedResult;
+    const sourceFile = result.source_file;
+    return {
+      index: index + 1,
+      id: result.id,
+      type: result.type,
+      title: titleFrom(sourceFile),
+      sourceFile,
+      score: round(result.score ?? 0),
+      confidence: confidenceFor(record),
+      excerpt: excerpt(result.content),
+      stale: Boolean(result.superseded_by),
+      supersededBy: result.superseded_by,
+      supersededAt: result.superseded_at,
+      supersededReason: result.superseded_reason,
+      entityMatches: arrayOfText(record.entity_matches ?? record.entityLinkMatches),
+      chunk: chunkFrom(record),
+    };
+  });
+}
+
+export function citationsFrom(indexes: number[], sources: AskSource[]): AskCitation[] {
+  const byIndex = new Map(sources.map((source) => [source.index, source]));
+  return indexes.map((index) => byIndex.get(index)).filter((source): source is AskSource => Boolean(source))
+    .map(({ index, id, title, sourceFile, excerpt, score, confidence, stale, chunk }) => ({
+      index, id, title, sourceFile, excerpt, score, confidence, stale, ...(chunk ? { chunk } : {}),
+    }));
+}
+
+export function warningsFrom(sources: AskSource[], searchWarning: unknown, noEvidence: boolean): string[] {
+  const warnings: string[] = [];
+  if (typeof searchWarning === 'string' && searchWarning.trim()) warnings.push(searchWarning.trim());
+  if (noEvidence) warnings.push('no_evidence_found');
+  for (const source of sources) {
+    if (source.stale) warnings.push(`source[${source.index}] superseded by ${source.supersededBy ?? 'another document'}${source.supersededReason ? `: ${source.supersededReason}` : ''}`);
+    if (source.confidence < 0.45) warnings.push(`source[${source.index}] low confidence`);
+  }
+  return [...new Set(warnings)];
 }
 
 export async function synthesize(question: string, sources: AskSource[], client?: AskClient): Promise<AskSynthesis> {
@@ -44,8 +82,25 @@ export function envAskClient(env: Record<string, string | undefined> = process.e
   };
 }
 
+function askRank(result: RankedResult): number {
+  const score = safeScore(result.score);
+  const entity = safeScore(result.entity_score ?? result.entityLinkScore);
+  const confidence = confidenceFor(result);
+  const stalePenalty = result.superseded_by ? 0.08 : 0;
+  return round(Math.max(0, Math.min(1, score * 0.62 + confidence * 0.26 + entity * 0.12 - stalePenalty)));
+}
+
+function confidenceFor(result: RankedResult): number {
+  const score = safeScore(result.score);
+  const hasSource = Boolean(result.source_file);
+  const concepts = Array.isArray(result.concepts) ? result.concepts.length : 0;
+  const provenance = Math.min(1, (hasSource ? 0.7 : 0) + Math.min(0.3, concepts * 0.06));
+  const stalePenalty = result.superseded_by ? 0.18 : 0;
+  return round(Math.max(0, Math.min(1, score * 0.72 + provenance * 0.28 - stalePenalty)));
+}
+
 function lacksEvidence(sources: AskSource[]): boolean {
-  return sources.length === 0 || Math.max(...sources.map((source) => source.score)) < 0.12;
+  return sources.length === 0 || Math.max(...sources.map((source) => source.confidence)) < 0.12;
 }
 
 function promptFor(question: string, sources: AskSource[]): AskPrompt {
@@ -53,6 +108,7 @@ function promptFor(question: string, sources: AskSource[]): AskPrompt {
     instruction: [
       'Answer the question using only the provided sources.',
       'Cite factual claims with bracket citations like [1].',
+      'Warn when evidence is stale or superseded.',
       'If sources do not support an answer, set noEvidence=true.',
       'Return JSON only: {"answer":"...","citations":[1],"noEvidence":false}.',
     ].join(' '),
@@ -63,12 +119,7 @@ function promptFor(question: string, sources: AskSource[]): AskPrompt {
 
 function extractiveAnswer(sources: AskSource[], noEvidence: boolean): AskSynthesis {
   const cited = sources.slice(0, 3);
-  return {
-    answer: cited.map((source) => `[${source.index}] ${source.excerpt}`).join('\n'),
-    citations: cited.map((source) => source.index),
-    noEvidence,
-    mode: 'extractive',
-  };
+  return { answer: cited.map((source) => `[${source.index}] ${source.excerpt}`).join('\n'), citations: cited.map((source) => source.index), noEvidence, mode: 'extractive' };
 }
 
 function parseLlm(raw: unknown): { answer: string; citations: number[]; noEvidence?: boolean } | null {
@@ -93,10 +144,27 @@ function validCitations(citations: number[], sources: AskSource[]): number[] {
   return Array.from(new Set(citations.filter((citation) => allowed.has(citation))));
 }
 
-function excerpt(content: string): string {
-  return content.replace(/\s+/g, ' ').trim().slice(0, 420);
+function titleFrom(sourceFile: string): string {
+  const file = sourceFile.split(/[\\/]/).pop() || sourceFile || 'source';
+  return file.replace(/\.[^.]+$/, '') || file;
 }
 
-function round(value: number): number {
-  return Math.round(value * 1000) / 1000;
+function chunkFrom(record: RankedResult): AskSource['chunk'] | undefined {
+  const index = numberField(record.chunk_index ?? record.chunkIndex);
+  const lineStart = numberField(record.line_start ?? record.lineStart);
+  const lineEnd = numberField(record.line_end ?? record.lineEnd);
+  return index !== undefined || lineStart !== undefined || lineEnd !== undefined ? { index, lineStart, lineEnd } : undefined;
 }
+
+function numberField(value: unknown): number | undefined {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function arrayOfText(value: unknown): string[] | undefined {
+  return Array.isArray(value) ? value.map(String).filter(Boolean) : undefined;
+}
+
+function excerpt(content: string): string { return content.replace(/\s+/g, ' ').trim().slice(0, 420); }
+function safeScore(value: unknown): number { const parsed = Number(value ?? 0); return Number.isFinite(parsed) ? Math.max(0, Math.min(1, parsed)) : 0; }
+function round(value: number): number { return Math.round(value * 1000) / 1000; }

--- a/tests/http/ask/contract.test.ts
+++ b/tests/http/ask/contract.test.ts
@@ -1,0 +1,136 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-ask-contract-'));
+const stamp = `${Date.now()}${Math.random().toString(16).slice(2)}`;
+const tenantId = `tenant-ask-contract-${stamp}`;
+const staleId = `stale-${stamp}`;
+const currentId = `current-${stamp}`;
+const boostedId = `boosted-${stamp}`;
+const plainId = `plain-${stamp}`;
+const term = `askcontract${stamp}`;
+
+let dbModule: typeof import('../../../src/db/index.ts');
+let route: { handle: (request: Request) => Response | Promise<Response> };
+let createTenantFetch: typeof import('../../../src/middleware/tenant.ts').createTenantFetch;
+let tenantHeader: string;
+
+beforeAll(async () => {
+  process.env.ORACLE_DATA_DIR = tempRoot;
+  process.env.ORACLE_DB_PATH = path.join(tempRoot, 'oracle.db');
+  dbModule = await import('../../../src/db/index.ts');
+  dbModule.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+  const tenant = await import('../../../src/middleware/tenant.ts');
+  createTenantFetch = tenant.createTenantFetch;
+  tenantHeader = tenant.TENANT_HEADER;
+  const ask = await import('../../../src/routes/ask/index.ts');
+  route = ask.createAskRoutes({ now: () => new Date('2026-06-17T00:00:00.000Z') });
+
+  insertDoc(staleId, `Superseded ${term} evidence mentions Phoenix.`, {
+    supersededBy: currentId,
+    validTime: Date.parse('2024-01-01T00:00:00.000Z'),
+  });
+  insertDoc(currentId, `Current ${term} evidence mentions Phoenix.`, {
+    validTime: Date.parse('2025-01-01T00:00:00.000Z'),
+  });
+  insertDoc(plainId, `${term} plain evidence for Orbit.`);
+  insertDoc(boostedId, `${term} boosted evidence for Orbit.`);
+  insertEntity(boostedId, 'Orbit');
+});
+
+function insertDoc(id: string, content: string, options: { supersededBy?: string | null; validTime?: number } = {}) {
+  const now = Date.now();
+  dbModule.db.insert(dbModule.oracleDocuments).values({
+    id,
+    tenantId,
+    type: 'learning',
+    sourceFile: `notes/${id}.md`,
+    concepts: JSON.stringify(['ask', 'contract']),
+    createdAt: now,
+    updatedAt: now,
+    indexedAt: now,
+    validTime: options.validTime,
+    supersededBy: options.supersededBy,
+    supersededAt: options.supersededBy ? now + 1 : null,
+    supersededReason: options.supersededBy ? 'replaced by current evidence' : null,
+    project: 'ask-contract',
+    createdBy: 'ask-contract-test',
+  }).run();
+  dbModule.sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
+    .run(id, content, 'ask contract');
+}
+
+function insertEntity(documentId: string, entity: string) {
+  const key = entity.toLowerCase();
+  dbModule.db.insert(dbModule.oracleEntityLinks).values({
+    id: `${tenantId}:${documentId}:${key}`,
+    tenantId,
+    documentId,
+    entity,
+    entityKey: key,
+    weight: 1,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  }).run();
+}
+
+function post(body: Record<string, unknown>) {
+  return createTenantFetch((req) => route.handle(req))(new Request('http://local/api/ask', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', [tenantHeader]: tenantId },
+    body: JSON.stringify(body),
+  }));
+}
+
+afterAll(() => {
+  dbModule?.closeDb();
+  if (fs.existsSync(tempRoot)) fs.rmSync(tempRoot, { recursive: true });
+});
+
+describe('POST /api/ask RAG contract', () => {
+  test('accepts question and returns detailed citations plus warnings', async () => {
+    const res = await post({ question: `${term} Phoenix`, llm: false, limit: 2 });
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({ query: `${term} Phoenix`, noEvidence: false, mode: 'extractive' });
+    expect(body.citations[0]).toMatchObject({ index: 1, id: expect.any(String), title: expect.any(String), excerpt: expect.stringContaining(term) });
+    expect(body.citations[0].sourceFile).toContain('notes/');
+    expect(body.citationIndexes).toContain(1);
+    expect(body.warnings.some((warning: string) => warning.includes('superseded by'))).toBe(true);
+    expect(body.sources.some((source: { stale: boolean; supersededBy?: string }) => source.stale && source.supersededBy === currentId)).toBe(true);
+  });
+
+  test('filters ask evidence by asOf before synthesis', async () => {
+    const res = await post({ question: `${term} Phoenix`, asOf: '2024-06-01T00:00:00.000Z', llm: false, limit: 3 });
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(body.asOf).toBe('2024-06-01T00:00:00.000Z');
+    expect(body.sources.map((source: { id: string }) => source.id)).toEqual([staleId]);
+    expect(body.citations[0]).toMatchObject({ id: staleId, stale: true });
+    expect(body.warnings.some((warning: string) => warning.includes('superseded by'))).toBe(true);
+  });
+
+  test('returns structured no-evidence response without failing', async () => {
+    const res = await post({ question: `missing-${stamp}`, llm: false });
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(body.noEvidence).toBe(true);
+    expect(body.answer).toContain('No evidence found');
+    expect(body.citations).toEqual([]);
+    expect(body.warnings).toContain('no_evidence_found');
+  });
+
+  test('entity boost participates in ask source ordering', async () => {
+    const res = await post({ question: `${term} Orbit`, llm: false, limit: 2 });
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(body.sources[0]).toMatchObject({ id: boostedId, entityMatches: ['Orbit'] });
+    expect(body.citations[0]).toMatchObject({ id: boostedId });
+  });
+});

--- a/tests/http/ask/edge-cases.test.ts
+++ b/tests/http/ask/edge-cases.test.ts
@@ -86,11 +86,12 @@ describe('POST /api/ask Dialectic hardening', () => {
   test('uses tenant-scoped retrieval sources for synthesis', async () => {
     promptSources = [];
     const res = await post({ q: term, llm: true }, tenantB);
-    const body = await res.json() as { sources: Array<{ id: string }>; citations: number[]; mode: string };
+    const body = await res.json() as { sources: Array<{ id: string }>; citations: Array<{ index: number; id: string }>; citationIndexes: number[]; mode: string };
 
     expect(res.status).toBe(200);
     expect(body.mode).toBe('llm');
-    expect(body.citations).toEqual([1]);
+    expect(body.citationIndexes).toEqual([1]);
+    expect(body.citations).toEqual([expect.objectContaining({ index: 1, id: docB })]);
     expect(body.sources.map((source) => source.id)).toEqual([docB]);
     expect(promptSources).toEqual([docB]);
   });

--- a/tests/http/search/ask-real-data.test.ts
+++ b/tests/http/search/ask-real-data.test.ts
@@ -76,7 +76,8 @@ describe('POST /api/ask real-data verification', () => {
     expect(res.status).toBe(200);
     expect(body.mode).toBe('llm');
     expect(body.answer).toContain('[1]');
-    expect(body.citations).toEqual([1]);
+    expect(body.citationIndexes).toEqual([1]);
+    expect(body.citations[0]).toMatchObject({ index: 1, id: oldDocId, sourceFile: `docs/real/${oldDocId}.md` });
     expect(body.noEvidence).toBe(false);
     expect(body.generatedAt).toBe('2026-06-17T01:00:00.000Z');
     expect(body.sources[0]).toMatchObject({

--- a/tests/http/search/ask.test.ts
+++ b/tests/http/search/ask.test.ts
@@ -61,33 +61,36 @@ afterAll(() => {
 describe('POST /api/ask', () => {
   test('runs hybrid search and returns LLM synthesis with citations', async () => {
     const res = await post({ q: term, llm: true });
-    const body = await res.json() as { answer: string; citations: number[]; noEvidence: boolean; mode: string; sources: Array<{ id: string }> };
+    const body = await res.json() as { answer: string; citations: Array<{ index: number; id: string }>; citationIndexes: number[]; noEvidence: boolean; mode: string; sources: Array<{ id: string }> };
 
     expect(res.status).toBe(200);
     expect(body.mode).toBe('llm');
     expect(body.answer).toContain('[1]');
-    expect(body.citations).toEqual([1]);
+    expect(body.citationIndexes).toEqual([1]);
+    expect(body.citations).toEqual([expect.objectContaining({ index: 1, id: docId })]);
     expect(body.noEvidence).toBe(false);
     expect(body.sources[0].id).toBe(docId);
   });
 
   test('falls back to extractive citations when LLM is disabled', async () => {
     const res = await post({ q: term, llm: false });
-    const body = await res.json() as { mode: string; citations: number[]; answer: string };
+    const body = await res.json() as { mode: string; citations: Array<{ index: number; id: string }>; citationIndexes: number[]; answer: string };
 
     expect(res.status).toBe(200);
     expect(body.mode).toBe('extractive');
-    expect(body.citations).toEqual([1]);
+    expect(body.citationIndexes).toEqual([1]);
+    expect(body.citations[0]).toMatchObject({ index: 1, id: docId });
     expect(body.answer).toContain('[1]');
   });
 
   test('flags no evidence when retrieval returns nothing', async () => {
     const res = await post({ q: `missing-${stamp}`, llm: true });
-    const body = await res.json() as { noEvidence: boolean; citations: number[]; sources: unknown[] };
+    const body = await res.json() as { noEvidence: boolean; citations: unknown[]; citationIndexes: number[]; sources: unknown[] };
 
     expect(res.status).toBe(200);
     expect(body.noEvidence).toBe(true);
     expect(body.citations).toEqual([]);
+    expect(body.citationIndexes).toEqual([]);
     expect(body.sources).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary\n- add /api/ask support for question input, detailed citation objects, warnings, and structured no-evidence responses\n- rank ask evidence with confidence and entity-boost signals while flagging stale/superseded sources\n- support ask asOf filtering before synthesis and cover the RAG contract in tests\n\n## Tests\n- bunx tsc --noEmit\n- bun test tests/http/ask/\n- bun test tests/http/search/ask.test.ts tests/http/search/ask-real-data.test.ts\n\nCloses #2662