### PR TITLE
fix: restore worker deploy gates

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#030712" media="(prefers-color-scheme: dark)" />
     <meta name="theme-color" content="#f8fafc" media="(prefers-color-scheme: light)" />
     <link rel="manifest" href="/manifest.json" />
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔮</text></svg>" type="image/svg+xml" />
+    <link rel="icon" href="/icons/arra-oracle.svg" type="image/svg+xml" />
     <script>
       try {
         const saved = localStorage.getItem('ARRA_FRONTEND_THEME');

--- a/tests/http/canvas-worker.test.ts
+++ b/tests/http/canvas-worker.test.ts
@@ -54,10 +54,10 @@ describe('canvas subdomain worker app', () => {
     expect(missing.status).toBe(404);
   });
 
-  test('wrangler custom domain runs worker first', () => {
+  test('wrangler custom domain uses a valid route shape', () => {
     const config = readFileSync('workers/canvas/wrangler.toml', 'utf8');
     expect(config).toContain('canvas.buildwithoracle.com');
     expect(config).toContain('custom_domain = true');
-    expect(config).toContain('run_worker_first = true');
+    expect(config).not.toContain('run_worker_first');
   });
 });

--- a/tests/http/canvas/full-flow.test.ts
+++ b/tests/http/canvas/full-flow.test.ts
@@ -101,10 +101,10 @@ describe('canvas.buildwithoracle.com full integration flow', () => {
     expect(registry.body.plugins.find((plugin: { id: string }) => plugin.id === 'wave').path).toBe('/canvas');
   });
 
-  test('worker config keeps canvas custom domain running first', () => {
+  test('worker config keeps canvas custom domain deployable', () => {
     const config = readFileSync('workers/canvas/wrangler.toml', 'utf8');
     expect(config).toContain('canvas.buildwithoracle.com');
     expect(config).toContain('custom_domain = true');
-    expect(config).toContain('run_worker_first = true');
+    expect(config).not.toContain('run_worker_first');
   });
 });

--- a/tests/workers/studio-frontend-build.test.ts
+++ b/tests/workers/studio-frontend-build.test.ts
@@ -34,6 +34,10 @@ function file(path: string): string {
   return readFileSync(path, 'utf8');
 }
 
+function stripAnsi(input: string): string {
+  return input.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '');
+}
+
 describe('Oracle Studio frontend Workers Static Assets build', () => {
   let buildOutput = '';
 
@@ -46,7 +50,7 @@ describe('Oracle Studio frontend Workers Static Assets build', () => {
     expect(pkg.scripts?.build).toBe('tsc --noEmit && vite build');
 
     expect(buildOutput).toContain('vite v');
-    expect(buildOutput).toContain('dist/index.html');
+    expect(stripAnsi(buildOutput)).toContain('dist/index.html');
     expect(existsSync(DIST_DIR)).toBe(true);
   });
 

--- a/workers/canvas/wrangler.toml
+++ b/workers/canvas/wrangler.toml
@@ -4,7 +4,7 @@ compatibility_date = "2026-06-16"
 workers_dev = false
 
 routes = [
-  { pattern = "canvas.buildwithoracle.com", custom_domain = true, run_worker_first = true }
+  { pattern = "canvas.buildwithoracle.com", custom_domain = true }
 ]
 
 [vars]


### PR DESCRIPTION
## Summary
- Fixes #2680
- Restores Deploy Canvas Worker by removing the Wrangler v4-invalid `routes[].run_worker_first` field from the custom-domain route.
- Restores Deploy Studio Worker by making the frontend build test robust to Vite ANSI output and aligning the app shell favicon with the existing public `/icons/arra-oracle.svg` asset.

## Root cause evidence
- Canvas run `28732580177` failed at `bunx wrangler deploy --config workers/canvas/wrangler.toml`: Wrangler v4.101 rejected `routes` because the route object included `run_worker_first`.
- Studio run `28732580180` failed before deploy in `tests/workers/studio-frontend-build.test.ts`: build succeeded, but assertions expected raw `dist/index.html` despite ANSI-styled Vite output and expected `/icons/arra-oracle.svg` while `frontend/index.html` emitted a data URI favicon.

## Validation
- `bunx tsc --noEmit`
- `bun test tests/workers/canvas-worker.test.ts tests/http/canvas-worker.test.ts tests/http/canvas/ tests/canvas/`
- `bun test tests/workers/studio-*.test.ts`
- `bunx wrangler@4.101.0 deploy --config workers/canvas/wrangler.toml --dry-run`
- changed files are all ≤250 lines
