### PR TITLE
fix: restore legacy API redirect contract

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -4,7 +4,9 @@ Verified against `src/server.ts`, `src/routes/*`, `src/tools/mcp-manifest.ts`,
 and `src/tools/mcp-rest-map.ts` on 2026-06-17. The internal Elysia routes are
 mounted under `/api/*`; the runnable server redirects most unversioned `/api/*`
 requests to `/api/v1/*` and rewrites them internally. `/api/health` stays
-unversioned for probes. Swagger UI is `/api/docs`; JSON is `/api/docs/json`.
+unversioned for probes. Hosted legacy Studio/Feed origins have a narrow
+unversioned browser-compatibility exception; CLI and local callers should expect
+the 308 redirect. Swagger UI is `/api/docs`; JSON is `/api/docs/json`.
 
 ## Auth, tenants, and errors
 

--- a/docs/MIDDLEWARE.md
+++ b/docs/MIDDLEWARE.md
@@ -32,7 +32,8 @@ Order:
 3. `createRequestDedupFetch` (`src/middleware/dedup.ts`)
    - Coalesces `GET`/`HEAD` by URL plus auth, cookie, range, accept, and tenant headers.
 4. `createApiVersionedFetch` (`src/middleware/api-version.ts`)
-   - Rewrites `/api/v1/*` internally to `/api/*`; redirects unversioned API callers to `/api/v1/*` except infrastructure paths such as `/api/health`.
+   - Rewrites `/api/v1/*` internally to `/api/*`; redirects unversioned API callers to `/api/v1/*` except the exact infrastructure path `/api/health`.
+   - Temporary compatibility: hosted legacy Studio/Feed origins are allowed to call old unversioned API paths directly; localhost and CLI callers still receive 308 redirects.
 5. `createTenantFetch` (`src/middleware/tenant.ts`)
    - Config: `ORACLE_TENANT_TOKENS`, `ORACLE_TENANT_API_KEYS`.
    - Headers: `X-Oracle-Tenant`, `X-Oracle-Tenant-Token`; aliases `X-Tenant-ID`, `X-Org-Id`, `X-API-Key`.

--- a/src/middleware/api-version.ts
+++ b/src/middleware/api-version.ts
@@ -5,7 +5,11 @@ export const API_VERSION = 'v1';
 export const API_VERSION_HEADER = 'X-API-Version';
 const API_PREFIX = '/api';
 const VERSIONED_PREFIX = `${API_PREFIX}/${API_VERSION}`;
-const INFRASTRUCTURE_PREFIXES = ['/api/health'];
+const INFRASTRUCTURE_PATHS = ['/api/health'];
+const LEGACY_HOSTED_ORIGINS = new Set([
+  'https://studio.buildwithoracle.com',
+  'https://feed.buildwithoracle.com',
+]);
 const publicPaths = new WeakMap<Request, string>();
 
 type FetchHandler = (request: Request) => Response | Promise<Response>;
@@ -25,15 +29,16 @@ function isVersionedApiPath(pathname: string): boolean {
 }
 
 function isInfrastructurePath(pathname: string): boolean {
-  return INFRASTRUCTURE_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
+  return INFRASTRUCTURE_PATHS.includes(pathname);
 }
 
 export function apiRequestPath(request: Request): string {
   return publicPaths.get(request) ?? new URL(request.url).pathname;
 }
 
-function shouldRewriteInPlace(request: Request): boolean {
-  return Boolean(allowedCorsOrigin(request.headers.get('origin'), parseCorsOrigins()));
+function shouldServeLegacyHostedRequest(request: Request): boolean {
+  const origin = allowedCorsOrigin(request.headers.get('origin'), parseCorsOrigins());
+  return Boolean(origin && LEGACY_HOSTED_ORIGINS.has(origin));
 }
 
 function versionedLocation(request: Request): string | null {
@@ -43,7 +48,7 @@ function versionedLocation(request: Request): string | null {
     || isVersionedApiPath(url.pathname)
     || isInfrastructurePath(url.pathname)
   ) return null;
-  if (shouldRewriteInPlace(request)) return null;
+  if (shouldServeLegacyHostedRequest(request)) return null;
   const suffix = url.pathname.slice(API_PREFIX.length);
   url.pathname = `${VERSIONED_PREFIX}${suffix}`;
   return url.toString();

--- a/tests/http/middleware/api-version-cors-edges.test.ts
+++ b/tests/http/middleware/api-version-cors-edges.test.ts
@@ -47,15 +47,35 @@ describe('api version middleware redirects and rewrites edge paths', () => {
     expect(body).toEqual({ routePath: '/api/search', publicPath: '/api/v1/search' });
   });
 
-  test('health subpaths stay unredirected for infrastructure probes', async () => {
-    const app = new Elysia().get('/api/health/deep', () => ({ status: 'ok' }));
-    const res = await createApiVersionedFetch((request) => app.handle(request))(
+  test('only exact health stays unredirected for infrastructure probes', async () => {
+    const app = new Elysia().get('/api/health', () => ({ status: 'ok' }));
+    const fetcher = createApiVersionedFetch((request) => app.handle(request));
+
+    const health = await fetcher(new Request('http://local/api/health'));
+    const deep = await fetcher(
       new Request('http://local/api/health/deep'),
     );
 
+    expect(health.status).toBe(200);
+    expect(health.headers.get('location')).toBeNull();
+    expect(await health.json()).toEqual({ status: 'ok' });
+    expect(deep.status).toBe(308);
+    expect(deep.headers.get('location')).toBe('http://local/api/v1/health/deep');
+  });
+
+  test('legacy hosted Studio origins keep old unversioned API calls direct', async () => {
+    const app = new Elysia().get('/api/list', () => ({ success: true, results: [] }));
+    const res = await createApiVersionedFetch((request) => app.handle(request))(
+      new Request('http://local/api/list?limit=50', {
+        headers: { origin: 'https://feed.buildwithoracle.com' },
+      }),
+    );
+    const body = await res.json() as { success: boolean; results: unknown[] };
+
     expect(res.status).toBe(200);
     expect(res.headers.get('location')).toBeNull();
-    expect(await res.json()).toEqual({ status: 'ok' });
+    expect(res.headers.get(API_VERSION_HEADER)).toBe('v1');
+    expect(body).toEqual({ success: true, results: [] });
   });
 });
 

--- a/tests/http/middleware/error-redirect-contract.test.ts
+++ b/tests/http/middleware/error-redirect-contract.test.ts
@@ -68,17 +68,20 @@ describe('api version 308 redirect contract depth', () => {
     expect(calls).toBe(0);
   });
 
-  test('health subtree bypasses legacy redirects while adjacent API paths still redirect', async () => {
+  test('only exact health bypasses legacy redirects while adjacent API paths still redirect', async () => {
     const app = new Elysia()
-      .get('/api/health/deep', () => ({ status: 'ok' }))
+      .get('/api/health', () => ({ status: 'ok' }))
       .get('/api/healthz', () => ({ status: 'healthz' }));
     const fetcher = createApiVersionedFetch((request) => app.handle(request));
 
+    const health = await fetcher(new Request('http://local/api/health'));
     const deep = await fetcher(new Request('http://local/api/health/deep'));
     const adjacent = await fetcher(new Request('http://local/api/healthz'));
 
-    expect(deep.status).toBe(200);
-    expect(await deep.json()).toEqual({ status: 'ok' });
+    expect(health.status).toBe(200);
+    expect(await health.json()).toEqual({ status: 'ok' });
+    expect(deep.status).toBe(308);
+    expect(deep.headers.get('location')).toBe('http://local/api/v1/health/deep');
     expect(adjacent.status).toBe(308);
     expect(adjacent.headers.get('location')).toBe('http://local/api/v1/healthz');
   });

--- a/tests/http/studio/old-studio-endpoints.test.ts
+++ b/tests/http/studio/old-studio-endpoints.test.ts
@@ -114,7 +114,7 @@ function auditApp() {
 }
 
 function request(app: Elysia, endpoint: Endpoint) {
-  const headers: Record<string, string> = { origin: 'http://localhost:3000' };
+  const headers: Record<string, string> = { origin: 'https://studio.buildwithoracle.com' };
   const init: RequestInit = { method: endpoint.method, headers };
   if (endpoint.body !== undefined) {
     headers['content-type'] = 'application/json';


### PR DESCRIPTION
## Summary
- Fixes #2688.
- Restores the documented legacy API contract for normal callers: unversioned `/api/*` returns `308` to `/api/v1/*` while `/api/v1/*` still rewrites internally.
- Narrows the #2527 old Studio compatibility bypass to hosted legacy Studio/Feed origins instead of every allowed CORS origin, so localhost/dev/skills-cli callers no longer bypass redirects.
- Restores exact-only `/api/health` infrastructure bypass; `/api/health/*` redirects like other unversioned API subpaths.
- Updates middleware/API docs and tests to document the narrow hosted legacy exception.

## Root cause
Posted to #2688: https://github.com/Soul-Brews-Studio/arra-oracle-v3/issues/2688#issuecomment-4885380111

Key commits:
- `561e20e29b6a00338032f825f0e4b6a2fe950130` made all allowed CORS origins serve unversioned `/api/*` directly.
- `335f364febd822aa082478bb537faedb03c74374` broadened `/api/health` bypass to `/api/health/*`.

Decision: middleware regression / overbroad compatibility exception, not a global contract change.

## Validation
- `bun test tests/http/middleware/ tests/http/versioning/`
- `bunx tsc --noEmit`
- Extra guard: `bun test tests/http/compat/old-studio.test.ts tests/http/studio/old-studio-endpoints.test.ts`
- changed files are all ≤250 lines
