### PR TITLE
fix(export): skip absent optional tables

### DIFF
--- a/src/cli/commands/backup.ts
+++ b/src/cli/commands/backup.ts
@@ -5,6 +5,7 @@ import { ORACLE_DATA_DIR, DB_PATH } from '../../config.ts';
 import type { DatabaseConnection } from '../../db/index.ts';
 import * as schema from '../../db/schema.ts';
 import { auditLog } from '../../storage/audit-log.ts';
+import { isMissingTableError } from '../../db/errors.ts';
 import { createStorageBackend } from '../../storage/registry.ts';
 
 interface DumpColumn {
@@ -150,7 +151,8 @@ function columnDefinition(column: DumpColumn): string {
 }
 
 function selectRows(connection: DatabaseConnection, table: DumpTable): DumpRow[] {
-  return (connection.db as any).select().from(table).all() as DumpRow[];
+  try { return (connection.db as any).select().from(table).all() as DumpRow[]; }
+  catch (error) { if (isMissingTableError(error)) return []; throw error; }
 }
 
 function insertSql(tableName: string, columns: Array<[string, DumpColumn]>, row: DumpRow): string {

--- a/src/db/errors.ts
+++ b/src/db/errors.ts
@@ -1,0 +1,3 @@
+export function isMissingTableError(error: unknown): boolean {
+  return String(error instanceof Error ? error.message : error).toLowerCase().includes('no such table:');
+}

--- a/src/routes/export/app.ts
+++ b/src/routes/export/app.ts
@@ -11,20 +11,18 @@ import { createExportTestConnectionRoutes } from './test-connection.ts';
 import { rememberExportProgress } from './progress.ts';
 import { canReadTenantResource, currentExportTenantId, tenantScopedOutputDir, tenantWhereFor } from './tenant.ts';
 import { recordExportHistory } from './history-store.ts';
-
+import { isMissingTableError } from '../../db/errors.ts';
 type ExportRecord = Record<string, unknown>;
 type BaseExportFormat = 'json' | 'csv' | 'markdown';
 type ExportFormat = BaseExportFormat | 'jsonl';
 type DumpTable = ReturnType<typeof introspectDrizzleTables>[number];
 type QueryConnection = Pick<DatabaseConnection, 'db'>;
-
 interface ExportTools {
   extensionFor(format: BaseExportFormat): string;
   formatCollection(name: string, rows: ExportRecord[], format: BaseExportFormat): string;
   normalizeRecords(rows: ExportRecord[]): ExportRecord[];
   graphRelationships(collections: Record<string, ExportRecord[]>): ExportRecord[];
 }
-
 interface ExportJob {
   jobId: string;
   tenantId?: string;
@@ -39,7 +37,6 @@ interface ExportJob {
   sizeBytes: number;
   createdAt: string;
 }
-
 export interface ExportAppDeps {
   connection?: QueryConnection;
   outputDir?: string;
@@ -65,9 +62,14 @@ function tableMap(): Map<string, DumpTable> {
 }
 
 function selectRows(connection: QueryConnection, table: DumpTable): ExportRecord[] {
-  const query = (connection.db as any).select().from(table);
-  const where = tenantWhereFor(table);
-  return (where ? query.where(where) : query).all() as ExportRecord[];
+  try {
+    const query = (connection.db as any).select().from(table);
+    const where = tenantWhereFor(table);
+    return (where ? query.where(where) : query).all() as ExportRecord[];
+  } catch (error) {
+    if (isMissingTableError(error)) return [];
+    throw error;
+  }
 }
 
 function safeName(value: string): string {

--- a/src/routes/export/batch.ts
+++ b/src/routes/export/batch.ts
@@ -4,6 +4,7 @@ import { getTableName, isTable } from 'drizzle-orm';
 import { DB_PATH } from '../../config.ts';
 import * as schema from '../../db/schema.ts';
 import { createStorageBackend } from '../../storage/registry.ts';
+import { isMissingTableError } from '../../db/errors.ts';
 import {
   EXPORT_FORMATS,
   extensionFor,
@@ -59,12 +60,17 @@ function readCollections(names: string[]): CollectionMap {
     for (const name of names) {
       const table = tables.get(name);
       if (!table) throw new Error(`Unknown export collection: ${name}`);
-      out[name] = normalizeRecords(storage.db.select().from(table).all() as ExportRecord[]);
+      out[name] = normalizeRecords(selectRows(storage.db, table));
     }
     return out;
   } finally {
     storage.close();
   }
+}
+
+function selectRows(db: unknown, table: ExportTable): ExportRecord[] {
+  try { return (db as any).select().from(table).all() as ExportRecord[]; }
+  catch (error) { if (isMissingTableError(error)) return []; throw error; }
 }
 
 function normalizeCollectionNames(input: string[]): string[] {

--- a/src/routes/export/stats.ts
+++ b/src/routes/export/stats.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { ORACLE_DATA_DIR } from '../../config.ts';
 import { db as defaultDb, type DatabaseConnection } from '../../db/index.ts';
 import { introspectDrizzleTables } from '../../cli/commands/backup.ts';
+import { isMissingTableError } from '../../db/errors.ts';
 
 type ExportRecord = Record<string, unknown>;
 type DumpTable = ReturnType<typeof introspectDrizzleTables>[number];
@@ -27,7 +28,12 @@ function connectionFrom(deps: ExportStatsDeps): QueryConnection {
 }
 
 function selectRows(connection: QueryConnection, table: DumpTable): ExportRecord[] {
-  return (connection.db as any).select().from(table).all() as ExportRecord[];
+  try {
+    return (connection.db as any).select().from(table).all() as ExportRecord[];
+  } catch (error) {
+    if (isMissingTableError(error)) return [];
+    throw error;
+  }
 }
 
 export function formatExportSize(bytes: number): string {

--- a/tests/http/export/integration.test.ts
+++ b/tests/http/export/integration.test.ts
@@ -74,6 +74,8 @@ function exportCollection(format: string, extra: Record<string, unknown> = {}) {
 }
 
 beforeEach(() => {
+  const psiDir = join(root, 'psi');
+  if (existsSync(psiDir)) rmSync(psiDir, { recursive: true });
   dbMod.db.delete(dbMod.exportJobs).run();
   dbMod.db.delete(dbMod.learnLog).run();
   dbMod.db.delete(dbMod.oracleDocuments).run();

--- a/tools/export-app/exporter.ts
+++ b/tools/export-app/exporter.ts
@@ -21,6 +21,7 @@ import { exportFileInventory } from './inventory.ts';
 import { exportBundleReadme } from './bundle-readme.ts';
 import { selectExportTables, shouldExportDocuments } from './collections.ts';
 import { writeStandaloneBackupDump } from './backup.ts';
+import { isMissingTableError } from '../../src/db/errors.ts';
 
 type ExportTable = Parameters<typeof getTableName>[0];
 type Progress = (message: string, event?: ExportProgressEvent) => void;
@@ -160,7 +161,8 @@ function openReadonlyConnection(dbPath = DB_PATH): { connection: DatabaseConnect
 }
 
 function selectRows(connection: DatabaseConnection, table: ExportTable): ExportRecord[] {
-  return (connection.db as any).select().from(table).all() as ExportRecord[];
+  try { return (connection.db as any).select().from(table).all() as ExportRecord[]; }
+  catch (error) { if (isMissingTableError(error)) return []; throw error; }
 }
 
 function reportProgress(progress: Progress, event: Omit<ExportProgressEvent, 'percent'>): void {

--- a/tools/export-app/summary.ts
+++ b/tools/export-app/summary.ts
@@ -7,6 +7,7 @@ import { graphRelationships } from './graph.ts';
 import { normalizeRecords, type ExportRecord } from './formats.ts';
 import { readOracleV2Documents } from './documents.ts';
 import { selectExportTables, shouldExportDocuments } from './collections.ts';
+import { isMissingTableError } from '../../src/db/errors.ts';
 
 type ExportTable = ReturnType<typeof introspectDrizzleTables>[number];
 
@@ -65,5 +66,6 @@ function openReadonlyConnection(dbPath = DB_PATH): { connection: DatabaseConnect
 }
 
 function selectRows(connection: DatabaseConnection, table: ExportTable): ExportRecord[] {
-  return (connection.db as any).select().from(table).all() as ExportRecord[];
+  try { return (connection.db as any).select().from(table).all() as ExportRecord[]; }
+  catch (error) { if (isMissingTableError(error)) return []; throw error; }
 }


### PR DESCRIPTION
## Summary
- Skip absent optional Drizzle tables during export/stats/backup scans instead of letting SQLite throw raw 500 text.
- Apply the same guard to export app, stats, batch, standalone backup, export preview, and export engine paths.
- Reset test learning files between export integration cases to avoid cross-test sourceFile conflicts.

## Root cause before fix
`bun test tests/http/export/` reproduced 7 failures. Response dumps showed the non-JSON endpoints all failed with raw text:

```text
app collections: status 500, content-type null, body: no such table: oracle_vector_documents
app run json graph: status 500, content-type null, body: no such table: oracle_vector_documents
app direct markdown graph: status 500, content-type null, body: no such table: oracle_vector_documents
stats direct: status 500, content-type null, body: no such table: oracle_vector_documents
stats mounted: status 500, content-type null, body: no such table: oracle_vector_documents
core run: status 500, application/json, {"error":"Export run failed","message":"no such table: oracle_vector_documents"}
```

File:line:
- `src/routes/export/app.ts:67-70` and `:107-108` queried every introspected table for collections/graph exports.
- `src/routes/export/stats.ts:29-30` and `:83-87` did the same for stats.
- `src/routes/export/core.ts:129-135` called `tools/export-app/exporter.ts:82-86`, then `tools/export-app/backup.ts:20` -> `src/cli/commands/backup.ts:89-94`; the backup dump also queried every table.
- `tests/http/export/integration.test.ts` had one independent 409 due learning files persisting between tests while DB rows were cleared.

`git log --oneline -- src/routes/export/` head entries checked before fix:
- `f260c00b test: add onboarding e2e integration coverage (#2671)`
- `f79f7277 test(export): harden export formats and backup bundle (#2382)`
- `1b0a0f43 test(routes): harden canvas and export edges (#2118)`
- `5fe796e5 fix(export): add output aliases to CLI exporters (#2095)`
- `577193a6 feat(export): record app exports in history (#2072)`

## Validation
- `bun test tests/http/export/` — 46 pass / 0 fail
- `bunx tsc --noEmit` — green
- `bun test tests/cli/backup/ tests/export/standalone-backup.test.ts src/indexer/__tests__/backup-lock.test.ts` — 11 pass / 0 fail
- `git diff --check` — green
- changed files <=250 lines

Closes #2692.
