### PR TITLE
fix: isolate HTTP test cross-file state

### DIFF
--- a/src/routes/feed/list.ts
+++ b/src/routes/feed/list.ts
@@ -5,7 +5,9 @@ import { currentTenantId, tenantDataPath, TENANT_HEADER } from '../../middleware
 import { feedTimestampMs, normalizeFeedLimit, parseLocalEvent, parseMawEvent, type FeedEvent } from '../../feed/events.ts';
 import { FeedQuery } from './model.ts';
 
-const MAW_JS_URL = process.env.MAW_JS_URL || 'http://localhost:3456';
+function mawJsUrl(): string {
+  return (process.env.MAW_JS_URL || 'http://localhost:3456').replace(/\/$/, '');
+}
 
 export const listFeedRoute = new Elysia().get('/', async ({ query, set }) => {
   try {
@@ -24,7 +26,7 @@ export const listFeedRoute = new Elysia().get('/', async ({ query, set }) => {
     }
 
     try {
-      const mawRes = await fetch(`${MAW_JS_URL}/api/feed?limit=100`, {
+      const mawRes = await fetch(`${mawJsUrl()}/api/feed?limit=100`, {
         headers: tenantId ? { [TENANT_HEADER]: tenantId } : undefined,
         signal: AbortSignal.timeout(2000),
       });

--- a/src/routes/health/health.ts
+++ b/src/routes/health/health.ts
@@ -114,7 +114,9 @@ export function createHealthEndpoint(options: HealthEndpointOptions = {}) {
     const pluginCount = options.pluginCount ?? (pluginItems.length || installedPluginCount());
     const pluginStatus = pluginItems.some((plugin) => plugin.status === 'degraded') ? 'degraded' : 'ok';
     const toolCount = mcpTools.length + (options.pluginMcpToolCount ?? 0);
-    const vectorRuntime = getVectorRuntimeStatus();
+    const vectorRuntime = options.vectorHealth
+      ? { vectorMode: 'embedded' as const }
+      : getVectorRuntimeStatus();
     const serviceUptime = Math.round(uptimeSeconds * 1000) / 1000;
     const vectorIsAvailable = vectorAvailable(vectorRuntime, vector, vectorServer);
     const subsystems = await buildHealthSubsystems({

--- a/src/routes/indexer/progress.ts
+++ b/src/routes/indexer/progress.ts
@@ -12,7 +12,14 @@ export const progressEndpoint = new Elysia().get('/indexer/progress', async ({ s
   return new Response(
     new ReadableStream({
       async start(controller) {
-        const sqlite = new Database(DB_PATH, { readonly: true });
+        let sqlite: Database | undefined;
+        try {
+          sqlite = new Database(DB_PATH, { readonly: true });
+        } catch {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify({ status: 'idle', current: 0, total: 0 })}\n\n`));
+          controller.close();
+          return;
+        }
         let done = false;
 
         while (!done) {

--- a/tests/http/config/defaults.test.ts
+++ b/tests/http/config/defaults.test.ts
@@ -9,11 +9,11 @@ describe('P0 first-run config defaults', () => {
     const provider = resolveEmbeddingProvider(defaults, 'defaults', []);
 
     expect(defaults.enabled).toBe(false);
-    expect(defaults.collections['bge-m3']).toMatchObject({ adapter: 'lancedb', provider: 'ollama', primary: true });
+    expect(defaults.collections['bge-m3']).toMatchObject({ adapter: 'sqlite-vec', provider: 'ollama', primary: true });
     expect(backend).toMatchObject({
-      engine: 'lancedb',
+      engine: 'sqlite-vec',
       source: 'first-run-default',
-      dataPath: defaultDataPathForEngine('lancedb'),
+      dataPath: defaultDataPathForEngine('sqlite-vec'),
       localDefault: true,
       returningUser: false,
       providerPrompt: false,

--- a/tests/http/studio/old-studio-endpoints.test.ts
+++ b/tests/http/studio/old-studio-endpoints.test.ts
@@ -5,6 +5,8 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+await import('../../../src/config.ts');
+
 const scratch = mkdtempSync(join(tmpdir(), 'old-studio-endpoints-'));
 const originalEnv = {
   dataDir: process.env.ORACLE_DATA_DIR,

--- a/tests/http/write/research-learn-supersede.test.ts
+++ b/tests/http/write/research-learn-supersede.test.ts
@@ -5,6 +5,8 @@ import { existsSync, mkdirSync, readFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
+await import('../../../src/config.ts');
+
 const savedDataDir = process.env.ORACLE_DATA_DIR;
 const savedDbPath = process.env.ORACLE_DB_PATH;
 const savedRepoRoot = process.env.ORACLE_REPO_ROOT;


### PR DESCRIPTION
## Summary
- Prevent env/config cross-file pollution from HTTP tests that mutate `ORACLE_*` before importing route modules.
- Make feed list read `MAW_JS_URL` at request time so tenant feed tests can set their local maw server without stale module constants.
- Make indexer progress SSE return idle instead of throwing when the configured DB path is stale/missing.
- Keep health dependency-injected vector checks isolated from global vector runtime path state.
- Update P0 defaults test to current sqlite-vec first-run truth.

## Root cause fixed
- `tests/http/write/research-learn-supersede.test.ts` and `tests/http/studio/old-studio-endpoints.test.ts` imported shared config while env pointed at temporary paths, poisoning later same-process tests.
- `src/routes/feed/list.ts` cached `MAW_JS_URL` at module load, so earlier imports made later feed tenant tests call the wrong maw endpoint.
- `src/routes/indexer/progress.ts` let a stale DB path throw from the SSE stream startup.

## Validation
- `bunx tsc --noEmit`
- Focused pollution reproductions: write/studio/feed/P0/health files green together
- Non-export HTTP suite green: `851 pass / 0 fail` across 261 files (excludes `tests/http/export/**` and the export-specific error-contract file)
- Full `bun test tests/http/`: `913 pass / 8 fail`; remaining failures are export-only and tracked in #2692.

## Remaining known red (#2692)
- `tests/http/export/**`
- `tests/http/errors/route-cluster-error-paths.test.ts` vector export DB failure contract
