### PR TITLE
feat(search): surface supersede status in results

### DIFF
--- a/frontend/src/components/SearchResultSignals.tsx
+++ b/frontend/src/components/SearchResultSignals.tsx
@@ -10,8 +10,11 @@ import {
   provenanceDescription,
   sourceDetails,
   sourceLabel,
+  supersedeDateLabel,
+  supersedeInfo,
   type ProvenanceSearchResult,
 } from './searchResultView';
+import { vectorResultsPath } from '../routePaths';
 
 const meterTone: Record<BadgeTone, MeterTone> = {
   neutral: 'accent',
@@ -29,7 +32,7 @@ export function SearchResultSignals({ result }: { result: ProvenanceSearchResult
   const heatText = percentLabel(heat) ?? '0%';
   const provenance = provenanceDescription(result);
   const details = sourceDetails(result);
-  const superseded = Boolean(result.superseded_by || result.superseded_at);
+  const superseded = supersedeInfo(result);
 
   return (
     <section aria-label="Memory provenance and confidence" className="mt-4 grid gap-3 rounded-xl border border-border bg-surface-muted p-3">
@@ -40,7 +43,15 @@ export function SearchResultSignals({ result }: { result: ProvenanceSearchResult
         <Badge tone={heat > 0.66 ? 'success' : heat > 0.33 ? 'warning' : 'accent'} ariaLabel={`Heat ${heatText}`}>
           heat {heatText}
         </Badge>
-        {superseded ? <Badge tone="warning">superseded</Badge> : null}
+        {superseded ? (
+          <a
+            className="focus-ring inline-flex max-w-full items-center rounded-full border border-warn-border bg-warn-bg/90 px-2.5 py-1 text-xs font-medium text-warn-text backdrop-blur-sm"
+            href={vectorResultsPath(superseded.by)}
+            title={superseded.reason ?? `Superseded by ${superseded.by}`}
+          >
+            <span className="truncate">superseded on {supersedeDateLabel(superseded.at)} → doc {superseded.by}</span>
+          </a>
+        ) : null}
       </div>
 
       <dl className="grid gap-2 text-xs text-text-muted sm:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
@@ -53,7 +64,7 @@ export function SearchResultSignals({ result }: { result: ProvenanceSearchResult
           <dd className="mt-1 text-text">{provenance || 'score-only result'}</dd>
         </div>
         {details.length ? <div className="sm:col-span-2"><dt className="sr-only">result details</dt><dd>{details.join(' · ')}</dd></div> : null}
-        {result.superseded_reason ? <div className="sm:col-span-2"><dt className="sr-only">supersede reason</dt><dd>{result.superseded_reason}</dd></div> : null}
+        {superseded?.reason ? <div className="sm:col-span-2"><dt className="sr-only">supersede reason</dt><dd>{superseded.reason}</dd></div> : null}
       </dl>
 
       <div className="grid gap-3 sm:grid-cols-2">

--- a/frontend/src/components/searchResultView.ts
+++ b/frontend/src/components/searchResultView.ts
@@ -33,12 +33,15 @@ export type ProvenanceSearchResult = SearchResult & {
   superseded_by?: string | null;
   superseded_at?: string | null;
   superseded_reason?: string | null;
+  superseded?: { by?: string | null; at?: string | null; reason?: string | null } | null;
   valid_time?: string | null;
   valid_until?: string | null;
   tags?: string[];
   createdAt?: string;
   updatedAt?: string;
 };
+
+export type SupersedeBadgeInfo = { by: string; at: string | null; reason: string | null };
 
 export function titleFor(result: SearchResult): string {
   return result.title || result.source_file || result.id;
@@ -119,4 +122,20 @@ export function provenanceDescription(result: ProvenanceSearchResult): string {
   const freshness = percentLabel(result.confidence?.freshness ?? components?.freshness);
   const match = percentLabel(components?.match);
   return [provenance ? `provenance ${provenance}` : '', freshness ? `freshness ${freshness}` : '', match ? `match ${match}` : ''].filter(Boolean).join(' · ');
+}
+
+export function supersedeInfo(result: ProvenanceSearchResult): SupersedeBadgeInfo | null {
+  const by = result.superseded?.by ?? result.superseded_by;
+  if (!by) return null;
+  return {
+    by,
+    at: result.superseded?.at ?? result.superseded_at ?? null,
+    reason: result.superseded?.reason ?? result.superseded_reason ?? null,
+  };
+}
+
+export function supersedeDateLabel(value: string | null): string {
+  if (!value) return 'unknown date';
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString().slice(0, 10) : value.slice(0, 10);
 }

--- a/src/routes/memory/fanout.ts
+++ b/src/routes/memory/fanout.ts
@@ -1,4 +1,6 @@
 import { Elysia } from 'elysia';
+import { sqlite } from '../../db/index.ts';
+import { attachSupersedeStatus, supersedeWarnings } from '../../search/supersede-status.ts';
 import type { SearchResult } from '../../server/types.ts';
 import { ensureVectorStoreConnected, getEmbeddingModels, type EmbeddingModelConfig } from '../../vector/factory.ts';
 import type { VectorQueryResult, VectorStoreAdapter } from '../../vector/types.ts';
@@ -211,6 +213,8 @@ export function createMemoryFanoutEndpoint(deps: MemoryFanoutDeps = {}) {
       confidenceWeight: configuredConfidenceWeight,
       now: deps.now?.(),
     });
+    attachSupersedeStatus(sqlite, results as unknown as Array<Record<string, unknown>>);
+    const warnings = supersedeWarnings(results as unknown as Array<Record<string, unknown>>);
     scheduleMemoryReinforcement(results, deps.reinforce);
 
     return {
@@ -227,6 +231,7 @@ export function createMemoryFanoutEndpoint(deps: MemoryFanoutDeps = {}) {
         confidenceSource: rerankConfig.confidenceSource,
       },
       results,
+      ...(warnings.length ? { warnings } : {}),
       errors,
       cost: estimateFanoutCost(q, collections),
     };

--- a/src/routes/search/search.ts
+++ b/src/routes/search/search.ts
@@ -9,7 +9,7 @@ import { augmentQueryWithAcronyms } from '../../search/acronyms.ts';
 import { filterResultsAsOf, parseAsOf } from '../../search/bitemporal.ts';
 import { compactSearchResults, parseSearchRetrievalMode } from '../../search/compact-summary.ts';
 import { rerankByEntityLinks } from '../../search/entity-ranking.ts';
-import { attachSupersedeStatus } from '../../search/supersede-status.ts';
+import { attachSupersedeStatus, supersedeWarnings } from '../../search/supersede-status.ts';
 import { handleSearch } from '../../server/handlers.ts';
 import { asOfResponse } from './asof.ts';
 import { SearchQuery } from './model.ts';
@@ -76,12 +76,16 @@ export const searchEndpoint = new Elysia().get(
       }
       result.results = rerankByEntityLinks(sqlite, result.results, augmentedQ, currentTenantId());
       attachSupersedeStatus(sqlite, result.results as unknown as Array<Record<string, unknown>>);
+      const warnings = [
+        ...(typeof result.warning === 'string' && result.warning.trim() ? [result.warning.trim()] : []),
+        ...supersedeWarnings(result.results as unknown as Array<Record<string, unknown>>),
+      ];
       const compact = retrieval.mode === 'compact-summary'
         ? compactSearchResults(result.results as unknown as Array<Record<string, unknown>>, sanitizedQ)
         : null;
       if (compact) result.results = compact.results as unknown as typeof result.results;
       const metadata = compact ? { metadata: { ...('metadata' in result ? result.metadata as object : {}), retrieval: compact.metadata } } : {};
-      return { ...result, ...metadata, query: sanitizedQ, ...asOfResponse(asOf.value) };
+      return { ...result, ...metadata, query: sanitizedQ, ...(warnings.length ? { warnings: [...new Set(warnings)] } : {}), ...asOfResponse(asOf.value) };
     } catch {
       set.status = 400;
       return { results: [], total: 0, query: sanitizedQ, error: 'Search failed' };

--- a/src/routes/vector/fanout.ts
+++ b/src/routes/vector/fanout.ts
@@ -1,6 +1,6 @@
 import { Elysia } from 'elysia';
 import { sqlite } from '../../db/index.ts';
-import { attachSupersedeStatus } from '../../search/supersede-status.ts';
+import { attachSupersedeStatus, supersedeWarnings } from '../../search/supersede-status.ts';
 import { ensureVectorStoreConnected, getEmbeddingModels, type EmbeddingModelConfig } from '../../vector/factory.ts';
 import { queryFanout, type FanoutStrategy } from '../../vector/fanout-query.ts';
 import { loadVectorConfig } from '../../vector/config.ts';
@@ -38,7 +38,8 @@ function withSupersedeStatus(result: Record<string, unknown>): Record<string, un
   if (!Array.isArray(result.results)) return result;
   const results = result.results.map((item) => ({ ...(item as Record<string, unknown>) }));
   attachSupersedeStatus(sqlite, results);
-  return { ...result, results };
+  const warnings = supersedeWarnings(results);
+  return { ...result, results, ...(warnings.length ? { warnings } : {}) };
 }
 
 function requestedBackends(

--- a/src/routes/vector/search.ts
+++ b/src/routes/vector/search.ts
@@ -4,6 +4,7 @@ import { sqlite } from '../../db/index.ts';
 import { currentTenantId } from '../../middleware/tenant.ts';
 import type { SearchResult } from '../../server/types.ts';
 import { filterResultsAsOf, parseAsOf } from '../../search/bitemporal.ts';
+import { attachSupersedeStatus, supersedeWarnings } from '../../search/supersede-status.ts';
 import { getEmbeddingModels, getVectorStoreByModel } from '../../vector/factory.ts';
 import type { VectorQueryResult, VectorStoreAdapter } from '../../vector/types.ts';
 import { asOfResponse } from '../search/asof.ts';
@@ -176,10 +177,13 @@ export function createVectorSearchEndpoint(deps: VectorSearchDeps = {}) {
         .filter((hit) => withinDateRange(hit, from, to));
       const boosted = applyVectorEntityBoost(asOfDb, filtered, q, { tenantId: currentTenantId() });
       const sorted = sortHits(boosted, sort.field, sort.order);
+      const results = sorted.slice(offset, offset + limit);
+      attachSupersedeStatus(asOfDb, results as unknown as Array<Record<string, unknown>>);
+      const warnings = supersedeWarnings(results as unknown as Array<Record<string, unknown>>);
       return {
-        results: sorted.slice(offset, offset + limit), total: sorted.length, offset, limit, query: q, mode: 'vector', collection,
+        results, total: sorted.length, offset, limit, query: q, mode: 'vector', collection,
         filters: { metadata, dateRange: { from: query.from ?? query.dateFrom, to: query.to ?? query.dateTo }, asOf: query.asOf },
-        sort, vectorAvailable: true, ...asOfResponse(asOf.value),
+        sort, vectorAvailable: true, ...(warnings.length ? { warnings } : {}), ...asOfResponse(asOf.value),
       };
     } catch (error) {
       set.status = 400;

--- a/src/search/supersede-status.ts
+++ b/src/search/supersede-status.ts
@@ -15,6 +15,7 @@ type SupersedeRow = {
   supersededAt: number | string | null;
   supersededReason: string | null;
 };
+export type SupersedeStatus = { by: string; at: string | null; reason: string | null };
 
 function resultIds(results: SearchResultRecord[]): string[] {
   return [...new Set(results
@@ -26,6 +27,41 @@ function toDb(input: OracleDbInput): OracleDb {
   return 'prepare' in input ? drizzle(input, { schema }) : input;
 }
 
+function text(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function statusFor(by: unknown, at: unknown, reason: unknown): SupersedeStatus | null {
+  const target = text(by);
+  if (!target) return null;
+  return { by: target, at: isoTimestamp(at as number | string | null | undefined), reason: text(reason) };
+}
+
+export function normalizeSupersedeStatus(result: SearchResultRecord): SupersedeStatus | null {
+  const existing = result.superseded;
+  if (existing && typeof existing === 'object' && !Array.isArray(existing)) {
+    const record = existing as Record<string, unknown>;
+    const status = statusFor(record.by, record.at, record.reason);
+    if (status) return status;
+  }
+  return statusFor(result.superseded_by ?? result.supersededBy, result.superseded_at ?? result.supersededAt, result.superseded_reason ?? result.supersededReason);
+}
+
+function setSupersedeStatus(result: SearchResultRecord, status: SupersedeStatus | null): void {
+  result.superseded = status;
+  if (!status) return;
+  result.superseded_by = status.by;
+  result.superseded_at = status.at;
+  result.superseded_reason = status.reason;
+}
+
+export function supersedeWarnings(results: SearchResultRecord[], label = 'result'): string[] {
+  return results.flatMap((result, index) => {
+    const status = normalizeSupersedeStatus(result);
+    return status ? [`${label}[${index + 1}] superseded by ${status.by}${status.reason ? `: ${status.reason}` : ''}`] : [];
+  });
+}
+
 export function attachSupersedeStatus(
   dbInput: OracleDbInput,
   results: SearchResultRecord[],
@@ -33,6 +69,7 @@ export function attachSupersedeStatus(
 ): void {
   const db = toDb(dbInput);
   const ids = resultIds(results);
+  for (const result of results) setSupersedeStatus(result, normalizeSupersedeStatus(result));
   if (ids.length === 0) return;
 
   let rows: SupersedeRow[];
@@ -59,8 +96,6 @@ export function attachSupersedeStatus(
     if (typeof result.id !== 'string') continue;
     const supersede = byId.get(result.id);
     if (!supersede) continue;
-    result.superseded_by = supersede.supersededBy;
-    result.superseded_at = isoTimestamp(supersede.supersededAt);
-    result.superseded_reason = supersede.supersededReason;
+    setSupersedeStatus(result, statusFor(supersede.supersededBy, supersede.supersededAt, supersede.supersededReason));
   }
 }

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -21,6 +21,11 @@ export interface SearchResult {
   superseded_by?: string;
   superseded_at?: string | null;
   superseded_reason?: string | null;
+  superseded?: {
+    by: string;
+    at: string | null;
+    reason: string | null;
+  } | null;
   valid_time?: string | null;
   valid_until?: string | null;
 }
@@ -31,6 +36,8 @@ export interface SearchResponse {
   offset: number;
   limit: number;
   query?: string;
+  warning?: string;
+  warnings?: string[];
 }
 
 export interface StatsResponse {

--- a/tests/frontend/components/search-result-card-provenance.test.tsx
+++ b/tests/frontend/components/search-result-card-provenance.test.tsx
@@ -35,4 +35,21 @@ describe('SearchResultCard provenance signals', () => {
     expect(html).toContain('aria-valuenow="82"');
     expect(html).toContain('aria-valuenow="69"');
   });
+
+  test('renders superseded badge with replacement link', () => {
+    const html = htmlFor(
+      <SearchResultCard
+        result={{
+          id: 'legacy',
+          content: 'Legacy memory.',
+          source_file: 'vault/legacy.md',
+          superseded: { by: 'current-doc', at: '2026-06-16T10:00:00.000Z', reason: 'newer source' },
+        }}
+      />,
+    );
+
+    expect(html).toContain('superseded on 2026-06-16 → doc current-doc');
+    expect(html).toContain('href="/vector/results?q=current-doc"');
+    expect(html).toContain('newer source');
+  });
 });

--- a/tests/http/memory/fanout.test.ts
+++ b/tests/http/memory/fanout.test.ts
@@ -215,12 +215,18 @@ test('GET /api/v1/memory/fanout preserves supersede metadata from vector hits', 
   }));
   const fetcher = createApiVersionedFetch((request) => app.handle(request));
   const response = await fetcher(new Request('http://local/api/v1/memory/fanout?q=legacy'));
-  const body = await json(response);
+  const body = await json(response) as { results: Array<Record<string, unknown>>; warnings?: string[] };
 
   expect(body.results[0]).toMatchObject({
     id: 'old-memory',
     superseded_by: 'new-memory',
     superseded_at: '2026-06-16T10:00:00.000Z',
     superseded_reason: 'newer source of truth',
+    superseded: {
+      by: 'new-memory',
+      at: '2026-06-16T10:00:00.000Z',
+      reason: 'newer source of truth',
+    },
   });
+  expect(body.warnings).toEqual(['result[1] superseded by new-memory: newer source of truth']);
 });

--- a/tests/http/search/edge-cases.test.ts
+++ b/tests/http/search/edge-cases.test.ts
@@ -172,7 +172,7 @@ describe('search route edge cases', () => {
 
   test('GET /api/search surfaces supersede status inline with results', async () => {
     const res = await request(`/api/search?q=${supersedeTerm}&mode=fts`);
-    const body = await res.json() as { results: Array<Record<string, unknown>>; total: number };
+    const body = await res.json() as { results: Array<Record<string, unknown>>; total: number; warnings?: string[] };
 
     expect(res.status).toBe(200);
     expect(body.total).toBe(1);
@@ -181,7 +181,22 @@ describe('search route edge cases', () => {
       superseded_by: successorDocId,
       superseded_at: new Date(supersededAt).toISOString(),
       superseded_reason: 'newer source of truth',
+      superseded: {
+        by: successorDocId,
+        at: new Date(supersededAt).toISOString(),
+        reason: 'newer source of truth',
+      },
     });
+    expect(body.warnings).toContain(`result[1] superseded by ${successorDocId}: newer source of truth`);
+  });
+
+  test('GET /api/search marks non-superseded results with null status', async () => {
+    const res = await request(`/api/search?q=${term}&mode=fts`);
+    const body = await res.json() as { results: Array<Record<string, unknown>>; warnings?: string[] };
+
+    expect(res.status).toBe(200);
+    expect(body.results[0]).toMatchObject({ id: docId, superseded: null });
+    expect(body.warnings?.some((warning) => warning.includes('superseded by'))).toBe(false);
   });
 
   test('GET /api/list falls back on safe pagination for bad numbers', async () => {

--- a/tests/http/search/temporal-status-hardening.test.ts
+++ b/tests/http/search/temporal-status-hardening.test.ts
@@ -38,7 +38,19 @@ describe('search temporal/supersede status hardening', () => {
         superseded_by: 'new',
         superseded_at: '2026-06-17T00:00:00.000Z',
         superseded_reason: 'replacement',
+        superseded: { by: 'new', at: '2026-06-17T00:00:00.000Z', reason: 'replacement' },
       });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test('attachSupersedeStatus sets null status for current results', () => {
+    const sqlite = memoryDb();
+    try {
+      const results: Array<Record<string, unknown>> = [{ id: 'current' }];
+      attachSupersedeStatus(sqlite, results, 'tenant-a');
+      expect(results[0]).toEqual({ id: 'current', superseded: null });
     } finally {
       sqlite.close();
     }

--- a/tests/http/vector/fanout-supersede.test.ts
+++ b/tests/http/vector/fanout-supersede.test.ts
@@ -60,7 +60,7 @@ afterAll(() => {
 
 test('GET /api/v1/vector/fanout includes supersede status on hits', async () => {
   const res = await fetcher(new Request('http://local/api/v1/vector/fanout?q=legacy&cache=false'));
-  const body = await res.json() as { results: Array<Record<string, unknown>> };
+  const body = await res.json() as { results: Array<Record<string, unknown>>; warnings?: string[] };
 
   expect(res.status).toBe(200);
   expect(body.results[0]).toMatchObject({
@@ -68,5 +68,11 @@ test('GET /api/v1/vector/fanout includes supersede status on hits', async () => 
     superseded_by: 'fanout-new-doc',
     superseded_at: new Date(supersededAt).toISOString(),
     superseded_reason: 'fanout replacement',
+    superseded: {
+      by: 'fanout-new-doc',
+      at: new Date(supersededAt).toISOString(),
+      reason: 'fanout replacement',
+    },
   });
+  expect(body.warnings).toEqual(['result[1] superseded by fanout-new-doc: fanout replacement']);
 });


### PR DESCRIPTION
Refs #2701

## Summary
- Add normalized `superseded: { by, at, reason } | null` status to search, vector search, memory fanout, and vector fanout result items while preserving legacy `superseded_*` fields.
- Emit top-result supersede warnings in the search/fanout response `warnings` arrays.
- Render a Studio superseded badge linking to a search for the replacement doc.

## Screenshot
Posted to #2701: https://github.com/Soul-Brews-Studio/arra-oracle-v3/issues/2701#issuecomment-4885478143

## Verification
- `bun test tests/http/search/` — 31/31 pass
- `bun test tests/frontend/` — 392/392 pass
- `bunx tsc --noEmit` — green
- `bun test tests/http/memory/fanout.test.ts tests/http/vector/fanout-supersede.test.ts tests/http/vector/search.test.ts tests/http/vector/search-asof.test.ts` — 15/15 pass
- `git diff --check` — clean
- Changed files all ≤250 lines
