### PR TITLE
chore(release): bump v26.7.5-alpha.1608

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-v3",
-  "version": "26.7.5-alpha.1354",
+  "version": "26.7.5-alpha.1608",
   "description": "Arra Oracle - MCP Memory Layer with semantic search, philosophy, and knowledge management",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
## Summary
- bump alpha package version to `26.7.5-alpha.1608`
- generated with `bun scripts/calver.ts --check` followed by alpha default write mode (`bun scripts/calver.ts`; no `--stable`)

## Verification
- `bunx tsc --noEmit`
- `git diff --check`
- `package.json` only, 146 lines

Refs #2708
