### PR TITLE
fix(vector): unify cosine distance scoring

### DIFF
--- a/frontend/src/pages/VectorSearchPage.tsx
+++ b/frontend/src/pages/VectorSearchPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState, type FormEvent } from 'react';
 import { apiClient, type ApiClient, type VectorIndexModelsResponse } from '../api/client';
 import { MemoryHealthPanel, MemorySignalBadges } from '../components/MemoryHealthPanel';
 import { SearchResultSignals } from '../components/SearchResultSignals';
+import { cosineDistanceToSimilarity } from '../../../src/vector/scoring';
 import type { VectorSearchResponse } from '../../../src/server/types';
 
 type LoadState = 'idle' | 'loading' | 'ready' | 'error';
@@ -50,7 +51,7 @@ export function distanceLabel(result: Pick<VectorSearchResult, 'distance' | 'sco
 
 export function distancePercent(result: Pick<VectorSearchResult, 'distance' | 'score'>): number {
   if (typeof result.score === 'number' && Number.isFinite(result.score)) return Math.max(0, Math.min(100, result.score * 100));
-  if (typeof result.distance === 'number' && Number.isFinite(result.distance)) return Math.max(0, Math.min(100, (1 / (1 + Math.max(0, result.distance))) * 100));
+  if (typeof result.distance === 'number' && Number.isFinite(result.distance)) return cosineDistanceToSimilarity(result.distance) * 100;
   return 0;
 }
 

--- a/src/routes/memory/fanout-score.ts
+++ b/src/routes/memory/fanout-score.ts
@@ -1,9 +1,1 @@
-export function safeVectorDistance(value: unknown): number {
-  const distance = Number(value ?? 0);
-  return Number.isFinite(distance) && distance >= 0 ? distance : 0;
-}
-
-export function scoreFromVectorDistance(value: unknown): number {
-  const distance = safeVectorDistance(value);
-  return 1 / (1 + distance / 100);
-}
+export { safeVectorDistance, scoreFromVectorDistance } from '../../vector/scoring.ts';

--- a/src/routes/vector/entity-search.ts
+++ b/src/routes/vector/entity-search.ts
@@ -2,6 +2,7 @@ import { Elysia, t } from 'elysia';
 import { currentTenantId } from '../../middleware/tenant.ts';
 import { entityCollectionName } from '../../vector/entities.ts';
 import { createVectorStoreForModel, getEmbeddingModels, type EmbeddingModelConfig } from '../../vector/factory.ts';
+import { cosineDistanceToSimilarity } from '../../vector/scoring.ts';
 import type { VectorQueryResult, VectorStoreAdapter } from '../../vector/types.ts';
 
 type EntityStore = Pick<VectorStoreAdapter, 'connect' | 'ensureCollection' | 'query'> & Partial<Pick<VectorStoreAdapter, 'close'>>;
@@ -43,13 +44,14 @@ function metadataAt(result: VectorQueryResult, index: number): Record<string, un
 function toHits(result: VectorQueryResult) {
   return result.ids.map((id, index) => {
     const metadata = metadataAt(result, index);
+    const distance = Number(result.distances?.[index] ?? 0);
     return {
       id,
       entity: String(metadata.entity ?? result.documents?.[index] ?? ''),
       sourceDocId: String(metadata.source_doc_id ?? ''),
       tenantId: String(metadata.tenant_id ?? ''),
-      score: 1 / (1 + Number(result.distances?.[index] ?? 0) / 100),
-      distance: Number(result.distances?.[index] ?? 0),
+      score: cosineDistanceToSimilarity(distance),
+      distance,
       metadata,
     };
   });

--- a/src/routes/vector/search.ts
+++ b/src/routes/vector/search.ts
@@ -6,6 +6,7 @@ import type { SearchResult } from '../../server/types.ts';
 import { filterResultsAsOf, parseAsOf } from '../../search/bitemporal.ts';
 import { attachSupersedeStatus, supersedeWarnings } from '../../search/supersede-status.ts';
 import { getEmbeddingModels, getVectorStoreByModel } from '../../vector/factory.ts';
+import { cosineDistanceToSimilarity } from '../../vector/scoring.ts';
 import type { VectorQueryResult, VectorStoreAdapter } from '../../vector/types.ts';
 import { asOfResponse } from '../search/asof.ts';
 import { applyVectorEntityBoost } from './entity-boost.ts';
@@ -13,7 +14,13 @@ import { applyVectorEntityBoost } from './entity-boost.ts';
 type SortField = 'score' | 'distance' | 'date' | 'id' | 'type' | 'source_file';
 type SortOrder = 'asc' | 'desc';
 type SearchStore = Pick<VectorStoreAdapter, 'connect' | 'ensureCollection' | 'query'> & Partial<Pick<VectorStoreAdapter, 'close'>>;
-interface VectorSearchDeps { getStore?: (collection?: string) => SearchStore; getModels?: () => Record<string, unknown>; asOfDb?: Database }
+type BoostResults = (db: Database, hits: SearchHit[], query: string, tenantId?: string) => SearchHit[];
+interface VectorSearchDeps {
+  getStore?: (collection?: string) => SearchStore;
+  getModels?: () => Record<string, unknown>;
+  asOfDb?: Database;
+  boostResults?: BoostResults;
+}
 type SearchHit = SearchResult & { metadata: Record<string, unknown> };
 
 const DEFAULT_COLLECTION = 'bge-m3', MAX_LIMIT = 100, MAX_FETCH = 1_000;
@@ -76,7 +83,7 @@ function toHits(result: VectorQueryResult, collection: string): SearchHit[] {
     return {
       id, type: text(metadata.type, 'unknown'), content: text(result.documents?.[index]),
       source_file: text(metadata.source_file ?? metadata.sourceFile), concepts: concepts(metadata.concepts), source: 'vector',
-      score: 1 / (1 + distance / 100), distance, model: collection, metadata,
+      score: cosineDistanceToSimilarity(distance), distance, model: collection, metadata,
     };
   });
 }
@@ -144,6 +151,7 @@ function filterAsOf(hits: SearchHit[], db: Database, asOfMs?: number): SearchHit
 
 export function createVectorSearchEndpoint(deps: VectorSearchDeps = {}) {
   const getModels = deps.getModels ?? getEmbeddingModels, getStore = deps.getStore ?? getVectorStoreByModel, asOfDb = deps.asOfDb ?? sqlite;
+  const boostResults = deps.boostResults ?? ((db, hits, query, tenantId) => applyVectorEntityBoost(db, hits, query, { tenantId }));
   return new Elysia().get('/vector/search', async ({ query, request, set }) => {
     if (!query.q) { set.status = 400; return { error: 'Missing query parameter: q' }; }
     const q = sanitize(query.q);
@@ -175,7 +183,7 @@ export function createVectorSearchEndpoint(deps: VectorSearchDeps = {}) {
       const filtered = filterAsOf(toHits(raw, collection), asOfDb, asOf.value)
         .filter((hit) => matchesMetadata(hit, metadata))
         .filter((hit) => withinDateRange(hit, from, to));
-      const boosted = applyVectorEntityBoost(asOfDb, filtered, q, { tenantId: currentTenantId() });
+      const boosted = boostResults(asOfDb, filtered, q, currentTenantId());
       const sorted = sortHits(boosted, sort.field, sort.order);
       const results = sorted.slice(offset, offset + limit);
       attachSupersedeStatus(asOfDb, results as unknown as Array<Record<string, unknown>>);

--- a/src/server/__tests__/vector-score.test.ts
+++ b/src/server/__tests__/vector-score.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from 'bun:test';
-import { cosineDistanceToSimilarity } from '../handlers.ts';
+import { cosineDistanceToSimilarity } from '../../vector/scoring.ts';
 
 describe('cosineDistanceToSimilarity', () => {
   test('maps LanceDB cosine distance across the full 0..1 relevance range', () => {
-    const scores = [0, 0.5, 1, 1.5, 2].map(cosineDistanceToSimilarity);
+    expect([0, 1, 2].map(cosineDistanceToSimilarity)).toEqual([1, 0.5, 0]);
 
+    const scores = [0, 0.5, 1, 1.5, 2].map(cosineDistanceToSimilarity);
     expect(scores).toEqual([1, 0.75, 0.5, 0.25, 0]);
     expect(Math.max(...scores)).toBeLessThanOrEqual(1);
     expect(Math.min(...scores)).toBeGreaterThanOrEqual(0);

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -23,6 +23,7 @@ import { buildLearningMarkdown, dateSlug } from '../learn/markdown.ts';
 import { localNativeVectorDisabledReason, localVectorIndexMissingReason, logLocalVectorDisabled, noteLocalVectorEnabled } from '../vector/cpu-capabilities.ts';
 import { isVectorSectionEnabled } from '../vector/config.ts';
 import { candidatePoolSize } from '../search/retrieve-depth.ts';
+export { cosineDistanceToSimilarity } from '../vector/scoring.ts';
 
 // Module-level proxy instance — bound to VECTOR_URL at boot. If VECTOR_URL is
 // unset, this is null and the local vector adapter runs in-process (legacy
@@ -71,17 +72,6 @@ function runFtsAll<T>(stmt: { all: (...args: any[]) => T[] }, args: unknown[]): 
     console.warn('[FTS5] MATCH query failed; degrading to empty keyword leg:', error instanceof Error ? error.message : String(error));
     return [];
   }
-}
-
-/**
- * LanceDB is configured for cosine distance, where nearest-neighbor distances
- * are in the 0..2 range: 0 means identical, 2 means opposite. Convert that
- * directly to a bounded relevance score instead of using the old L2 scaling
- * formula, which saturated normal cosine distances around 0.99.
- */
-export function cosineDistanceToSimilarity(distance: number): number {
-  if (!Number.isFinite(distance)) return 0;
-  return Math.max(0, Math.min(1, 1 - distance / 2));
 }
 
 /**

--- a/src/server/vector-handlers/similar.ts
+++ b/src/server/vector-handlers/similar.ts
@@ -2,6 +2,7 @@ import { and, eq, inArray } from 'drizzle-orm';
 import { db, oracleDocuments } from '../../db/index.ts';
 import { currentTenantId } from '../../middleware/tenant.ts';
 import { EMBEDDING_MODELS, ensureVectorStoreConnected } from '../../vector/factory.ts';
+import { cosineDistanceToSimilarity } from '../../vector/scoring.ts';
 import type { VectorStoreAdapter } from '../../vector/types.ts';
 import type { SearchResult } from '../types.ts';
 
@@ -53,7 +54,7 @@ export async function handleSimilar(
         concepts: doc?.concepts ? JSON.parse(doc.concepts) : [],
         project: doc?.project,
         source: 'vector' as const,
-        score: Math.max(0, 1 - distance / 2),
+        score: cosineDistanceToSimilarity(distance),
       }];
     });
     return { results, docId };

--- a/src/server/vector-operations.ts
+++ b/src/server/vector-operations.ts
@@ -9,14 +9,10 @@ import {
 } from '../vector/factory.ts';
 import { localNativeVectorDisabledReason, localVectorIndexMissingReason } from '../vector/cpu-capabilities.ts';
 import { selectVectorSearchModelKeys } from '../vector/model-selection.ts';
+import { cosineDistanceToSimilarity } from '../vector/scoring.ts';
 import type { VectorStoreAdapter } from '../vector/types.ts';
 import type { SearchResult } from './types.ts';
 import type { VectorIndexModelInfo, VectorOperations, VectorSearchInput } from './vector-operation-types.ts';
-
-function cosineDistanceToSimilarity(distance: number): number {
-  if (!Number.isFinite(distance)) return 0;
-  return Math.max(0, Math.min(1, 1 - distance / 2));
-}
 
 function modelKeys(model?: string): Array<string | undefined> {
   return selectVectorSearchModelKeys(model, getEmbeddingModels());

--- a/src/tools/search/__tests__/chain.test.ts
+++ b/src/tools/search/__tests__/chain.test.ts
@@ -50,7 +50,7 @@ function makeCtx(queryByIdCalls: string[]): ToolContext {
       queryByIdCalls.push(id);
       expect(limit).toBe(3);
       if (id === 'seed') return vectorResult(['seed', 'side', 'next'], [0, 0.2, 0.25]);
-      if (id === 'next') return vectorResult(['seed', 'late'], [0.1, 0.9]);
+      if (id === 'next') return vectorResult(['seed', 'late'], [0.1, 1.5]);
       return vectorResult([], []);
     },
   };

--- a/src/tools/search/chain.ts
+++ b/src/tools/search/chain.ts
@@ -1,6 +1,7 @@
 import type { VectorQueryResult } from '../../vector/types.ts';
 import { linkTraces } from '../../trace/links.ts';
 import { createTrace } from '../../trace/store.ts';
+import { cosineDistanceToSimilarity } from '../../vector/scoring.ts';
 import type { FoundFile } from '../../trace/types.ts';
 import type { ToolContext } from '../types.ts';
 import { parseConceptsFromMetadata } from './helpers.ts';
@@ -46,10 +47,12 @@ function clampLimit(value: number | undefined, fallback: number): number {
 }
 
 function rankScore(result: Pick<VectorResult, 'distance' | 'score'>): number {
-  const raw = Number.isFinite(result.distance) ? result.distance : result.score;
-  if (!Number.isFinite(raw)) return 0;
-  if (raw >= 0 && raw <= 1) return 1 - raw;
-  return 1 / (1 + Math.max(0, raw));
+  if (typeof result.score === 'number' && Number.isFinite(result.score)) {
+    return Math.max(0, Math.min(1, result.score));
+  }
+  return typeof result.distance === 'number' && Number.isFinite(result.distance)
+    ? cosineDistanceToSimilarity(result.distance)
+    : 0;
 }
 
 function traceType(type: string): FoundFile['type'] {
@@ -77,7 +80,7 @@ function mapQueryById(result: VectorQueryResult, model: string | undefined): Vec
       content: (result.documents[i] || '').substring(0, 500),
       source_file: (metadata?.source_file as string) || '',
       concepts: parseConceptsFromMetadata(metadata?.concepts),
-      score: distance,
+      score: cosineDistanceToSimilarity(distance),
       distance,
       model: model || 'bge-m3',
       source: 'vector',

--- a/src/tools/search/entities.ts
+++ b/src/tools/search/entities.ts
@@ -5,6 +5,7 @@ import {
   getEmbeddingModels,
   type EmbeddingModelConfig,
 } from '../../vector/factory.ts';
+import { cosineDistanceToSimilarity } from '../../vector/scoring.ts';
 import type { VectorQueryResult, VectorStoreAdapter } from '../../vector/types.ts';
 import type { ToolContext } from '../types.ts';
 import type { CombinedSearchResult } from './types.ts';
@@ -106,7 +107,7 @@ function hitsFromQuery(result: VectorQueryResult): EntityLinkHit[] {
     return {
       sourceDocId: String(metadata.source_doc_id ?? ''),
       entity: String(metadata.entity ?? result.documents?.[index] ?? ''),
-      score: 1 / (1 + Math.max(0, distance) / 100),
+      score: cosineDistanceToSimilarity(distance),
       distance,
     };
   });

--- a/src/tools/search/vector.ts
+++ b/src/tools/search/vector.ts
@@ -1,5 +1,6 @@
 import { ensureVectorStoreConnected } from '../../vector/factory.ts';
 import { currentTenantId } from '../../middleware/tenant.ts';
+import { cosineDistanceToSimilarity } from '../../vector/scoring.ts';
 import type { ToolContext } from '../types.ts';
 import { parseConceptsFromMetadata } from './helpers.ts';
 import type { VectorResult } from './types.ts';
@@ -41,13 +42,14 @@ export async function vectorSearch(
       if (allowedIds && !allowedIds.has(id)) continue;
       const metadata = results.metadatas[i] as Record<string, unknown> | null;
       const rawDistance = results.distances[i] || 0;
+      const score = cosineDistanceToSimilarity(rawDistance);
       mappedResults.push({
         id,
         type: (metadata?.type as string) || 'unknown',
         content: (results.documents[i] || '').substring(0, 500),
         source_file: (metadata?.source_file as string) || '',
         concepts: parseConceptsFromMetadata(metadata?.concepts),
-        score: rawDistance,
+        score,
         distance: rawDistance,
         model: resolvedModelName,
         source: 'vector',

--- a/src/vector/fan-out.ts
+++ b/src/vector/fan-out.ts
@@ -1,3 +1,5 @@
+import { cosineDistanceToSimilarity } from './scoring.ts';
+
 export interface FanOutHit {
   id: string;
   score?: number;
@@ -60,7 +62,7 @@ function uniqueCollections(collections: string[]): string[] {
 function scoreFor(hit: FanOutHit): number {
   if (typeof hit.score === 'number' && Number.isFinite(hit.score)) return clampScore(hit.score);
   if (typeof hit.distance === 'number' && Number.isFinite(hit.distance)) {
-    return clampScore(1 / (1 + Math.max(0, hit.distance)));
+    return cosineDistanceToSimilarity(hit.distance);
   }
   return 0;
 }

--- a/src/vector/fanout-query.ts
+++ b/src/vector/fanout-query.ts
@@ -1,5 +1,6 @@
 import type { SearchResult } from '../server/types.ts';
 import type { VectorQueryResult, VectorStoreAdapter } from './adapter.ts';
+import { cosineDistanceToSimilarity } from './scoring.ts';
 
 export type FanoutStrategy = 'merge';
 
@@ -102,7 +103,7 @@ function toSearchResults(backend: string, result: VectorQueryResult): SearchResu
       source_file: result.metadatas?.[i]?.source_file ?? '',
       concepts: [],
       source: 'vector' as const,
-      score: scoreFromDistance(distance),
+      score: cosineDistanceToSimilarity(distance),
       distance,
       model: backend,
     };
@@ -122,8 +123,4 @@ function finiteScore(score: unknown): number {
   return typeof score === 'number' && Number.isFinite(score)
     ? Math.max(0, Math.min(1, score))
     : 0;
-}
-
-function scoreFromDistance(distance: number): number {
-  return Math.max(0, Math.min(1, 1 / (1 + distance / 100)));
 }

--- a/src/vector/scoring.ts
+++ b/src/vector/scoring.ts
@@ -1,0 +1,17 @@
+/**
+ * LanceDB cosine distance is bounded 0..2: 0 means identical, 2 means opposite.
+ * Convert directly to a bounded 0..1 similarity score.
+ */
+export function cosineDistanceToSimilarity(distance: number): number {
+  if (!Number.isFinite(distance)) return 0;
+  return Math.max(0, Math.min(1, 1 - distance / 2));
+}
+
+export function safeVectorDistance(value: unknown): number {
+  const distance = Number(value ?? 0);
+  return Number.isFinite(distance) && distance >= 0 ? distance : 0;
+}
+
+export function scoreFromVectorDistance(value: unknown): number {
+  return cosineDistanceToSimilarity(safeVectorDistance(value));
+}

--- a/src/workers/sleep-consolidation.ts
+++ b/src/workers/sleep-consolidation.ts
@@ -1,5 +1,6 @@
 import type { Database } from 'bun:sqlite';
 import { ensureVectorStoreConnected, getEmbeddingModels, type EmbeddingModelConfig } from '../vector/factory.ts';
+import { cosineDistanceToSimilarity } from '../vector/scoring.ts';
 import type { VectorQueryResult, VectorStoreAdapter } from '../vector/types.ts';
 import { memoryConfidence } from '../routes/memory/confidence.ts';
 import type { MemoryRecord } from '../routes/memory/store.ts';
@@ -207,9 +208,9 @@ function confidence(doc: RawDoc, now: number): number {
 }
 
 function similarityFromDistance(value: unknown): number {
-  const distance = Number(value ?? 1);
+  const distance = Number(value);
   if (!Number.isFinite(distance) || distance < 0) return 0;
-  return round(distance <= 1 ? 1 - distance : 1 / (1 + distance));
+  return round(cosineDistanceToSimilarity(distance));
 }
 
 function finish(enabled: boolean, started: number, plans: ConsolidationPlan[], scanned: number, emitted = 0, llm?: LlmConsolidationPassResult): SleepConsolidationResult {

--- a/tests/frontend/pages/vector-search-page-distance.test.ts
+++ b/tests/frontend/pages/vector-search-page-distance.test.ts
@@ -6,6 +6,6 @@ describe('VectorSearchPage distance helpers', () => {
     const result = { distance: 0.25 };
 
     expect(distanceLabel(result)).toBe('0.250');
-    expect(distancePercent(result)).toBe(80);
+    expect(distancePercent(result)).toBe(87.5);
   });
 });

--- a/tests/http/memory/fanout.test.ts
+++ b/tests/http/memory/fanout.test.ts
@@ -27,7 +27,7 @@ function confidenceFixture(): VectorQueryResult {
       'Oracle deploy confidence ranking note',
       'Oracle deploy confidence ranking note',
     ],
-    distances: [0, 10],
+    distances: [0, 0.8],
     metadatas: [
       { type: 'memory', createdAt: '2020-01-01T00:00:00.000Z' },
       {

--- a/tests/http/vector/entity-boost.test.ts
+++ b/tests/http/vector/entity-boost.test.ts
@@ -59,7 +59,7 @@ async function vectorResult(): Promise<VectorQueryResult> {
   return {
     ids: [plain, linked, otherTenant],
     documents: ['plain AP candidate', 'linked AP candidate', 'other tenant AP candidate'],
-    distances: [0, 10, 10],
+    distances: [0, 0.8, 0.8],
     metadatas: [
       { type: 'learning', tenant_id: tenantA, source_file: `ψ/entities/${plain}.md`, concepts: ['alpha'] },
       { type: 'learning', tenant_id: tenantA, source_file: `ψ/entities/${linked}.md`, concepts: ['alpha'] },

--- a/tests/http/vector/search.test.ts
+++ b/tests/http/vector/search.test.ts
@@ -23,6 +23,7 @@ function createFetch(
       requested.push(collection ?? '');
       return store;
     },
+    boostResults: (_db, hits) => hits,
   }));
   return { fetcher: createApiVersionedFetch((request) => app.handle(request)), requested, store };
 }
@@ -87,6 +88,24 @@ test('GET /api/v1/vector/search accepts JSON metadata filters and distance sort'
   expect(res.status).toBe(200);
   expect(body.sort).toEqual({ field: 'distance', order: 'asc' });
   expect(body.results.map((item) => item.id)).toEqual(['doc-b', 'doc-a']);
+});
+
+test('GET /api/v1/vector/search maps cosine distances to similarity scores', async () => {
+  const { fetcher } = createFetch({
+    ids: ['same', 'orthogonal', 'opposite'],
+    documents: ['same body', 'orthogonal body', 'opposite body'],
+    distances: [0, 1, 2],
+    metadatas: [{ type: 'note' }, { type: 'note' }, { type: 'note' }],
+  });
+  const res = await fetcher(new Request('http://local/api/v1/vector/search?q=oracle&limit=3'));
+  const body = await res.json() as { results: Array<{ id: string; score: number }> };
+
+  expect(res.status).toBe(200);
+  expect(body.results.map((item) => [item.id, item.score])).toEqual([
+    ['same', 1],
+    ['orthogonal', 0.5],
+    ['opposite', 0],
+  ]);
 });
 
 test('GET /api/v1/vector/search scopes results by resolved tenant', async () => {

--- a/tests/vector/fanout-query.test.ts
+++ b/tests/vector/fanout-query.test.ts
@@ -52,6 +52,22 @@ test('fanout query runs targets in parallel and preserves partial errors', async
   expect(response.errors).toEqual({ turbovec: 'backend down' });
 });
 
+test('fanout query maps cosine distances with the shared scoring helper', async () => {
+  const response = await queryFanout({
+    text: 'oracle',
+    limit: 3,
+    targets: [{
+      key: 'lancedb',
+      store: { query: async () => ({ ids: ['same', 'orthogonal', 'opposite'], documents: ['', '', ''], distances: [0, 1, 2], metadatas: [{}, {}, {}] }) },
+    }],
+  });
+
+  expect(response.results.map((item) => [item.id, item.score])).toEqual([
+    ['same', 1],
+    ['orthogonal', 0.5],
+    ['opposite', 0],
+  ]);
+});
 
 test('fanout query normalizes bad limits and non-finite distances', async () => {
   let seenLimit = 0;

--- a/tests/workers/sleep-consolidation.test.ts
+++ b/tests/workers/sleep-consolidation.test.ts
@@ -117,7 +117,7 @@ describe('sleep-time consolidation worker', () => {
       const queued = listQueuedConsolidationPlans('tenant-a');
 
       expect(result).toMatchObject({ enabled: true, scanned: 2, planned: 1, suggestionsEmitted: 1, deleted: 0 });
-      expect(queued[0]).toMatchObject({ oldId: 'old-doc', newId: 'new-doc', tenantId: 'tenant-a', cosine: 0.98 });
+      expect(queued[0]).toMatchObject({ oldId: 'old-doc', newId: 'new-doc', tenantId: 'tenant-a', cosine: 0.99 });
       expect(queued[0].reason).toContain('sleep-time vector duplicate');
       expect(supersededBy(conn, 'old-doc')).toBeNull();
       expect(sleepConsolidationStatus({ ORACLE_CONSOLIDATION_WORKER: '1' }).suggestionsEmitted).toBeGreaterThanOrEqual(1);
@@ -132,7 +132,7 @@ describe('sleep-time consolidation worker', () => {
 
     try {
       const result = await runSleepConsolidationSweep(conn.sqlite, {
-        env: { ORACLE_CONSOLIDATION_WORKER: '1', ORACLE_CONSOLIDATION_SIMILARITY_THRESHOLD: '0.99' },
+        env: { ORACLE_CONSOLIDATION_WORKER: '1', ORACLE_CONSOLIDATION_SIMILARITY_THRESHOLD: '0.995' },
         now, models, connect: connectWith(0.02),
       });
 


### PR DESCRIPTION
## Summary
- Added shared `src/vector/scoring.ts` for cosine distance → similarity: `max(0, min(1, 1 - distance / 2))`.
- Replaced old `/100` and inverse-distance scoring in vector search, fanout, entity sidecar, MCP/tool search, similar search, memory fanout, sleep consolidation, and Studio distance fallback.
- Added exact 0→1, 1→0.5, 2→0 coverage for the core helper and `/api/v1/vector/search`.

## Verification
- `bunx tsc --noEmit`
- `bun test tests/http/vector/` (103 pass)
- `bun test tests/http/search/` (31 pass)
- `cd frontend && bun run build`

## Notes
- Co-authored-by trailer credits mojisejr per #2712. Public GitHub profile email used because PR #2508 commits did not include a mojisejr-authored commit.
- `src/server/handlers.ts` is a pre-existing oversized legacy file; this PR only removes its duplicate scoring helper and re-exports the shared helper.

Fixes #2712
