### PR TITLE
feat(entity): add sidecar backfill worker

### DIFF
--- a/src/routes/health/health.ts
+++ b/src/routes/health/health.ts
@@ -13,6 +13,8 @@ import { sandboxLabel } from '../../runtime/sandbox-label.ts';
 import { healthRollupStatus } from './rollup.ts';
 import { buildHealthSubsystems, drainingSubsystems, rollupHealthStatus, type EmbeddingProviderProbe, type EmbeddingProviderSelection } from './subsystems.ts';
 import { sleepConsolidationStatus } from '../../workers/sleep-consolidation.ts';
+import { entityBackfillStatus } from '../../workers/entity-backfill.ts';
+import { readEntityCoverageStats, type EntityCoverageStats } from '../../search/entity-coverage.ts';
 import pkg from '../../../package.json' with { type: 'json' };
 
 type VectorHealth = Awaited<ReturnType<typeof readVectorBackendHealth>>;
@@ -44,6 +46,7 @@ export interface HealthEndpointOptions {
   diskPath?: string;
   diskUsage?: () => DiskHealth;
   memoryUsage?: () => NodeJS.MemoryUsage;
+  entityCoverage?: () => EntityCoverageStats;
 }
 
 function errorMessage(error: unknown): string {
@@ -122,10 +125,11 @@ export function createHealthEndpoint(options: HealthEndpointOptions = {}) {
       : getVectorRuntimeStatus());
     const serviceUptime = Math.round(uptimeSeconds * 1000) / 1000;
     const vectorIsAvailable = vectorAvailable(vectorRuntime, vector, vectorServer);
+    const entityCoverage = options.entityCoverage?.() ?? readEntityCoverageStats();
     const subsystems = await buildHealthSubsystems({
       dbStatus, vector, vectorServer, vectorRuntime, pluginStatus, pluginCount,
       toolCount, uptimeSeconds: serviceUptime, embeddingProviders: options.embeddingProviders,
-      embeddingProviderSelection: options.embeddingProviderSelection,
+      embeddingProviderSelection: options.embeddingProviderSelection, entityCoverage,
     });
     const healthStatus = rollupHealthStatus(subsystems);
 
@@ -152,6 +156,7 @@ export function createHealthEndpoint(options: HealthEndpointOptions = {}) {
       vector,
       vectorServer,
       memory: { fanoutReranking: memoryConfidenceRerankConfig(), consolidationWorker: sleepConsolidationStatus() },
+      entities: { coverage: entityCoverage, backfillWorker: entityBackfillStatus() },
       mcp: { toolCount },
       plugins: { count: pluginCount, status: pluginStatus, items: pluginItems },
       subsystems,

--- a/src/routes/health/subsystems.ts
+++ b/src/routes/health/subsystems.ts
@@ -2,12 +2,13 @@ import { DB_PATH } from '../../config.ts';
 import { sqlite } from '../../db/index.ts';
 import { resolveEmbeddingProviderSelection, type EmbeddingProviderSelection } from '../../vector/embedder-config.ts';
 import { getDetectedEmbeddingProviders, type DetectedEmbeddingProvider } from '../../vector/provider-detection.ts';
+import { readEntityCoverageStats, type EntityCoverageStats } from '../../search/entity-coverage.ts';
 import type { VectorBackendHealth } from '../../vector/health.ts';
 import type { VectorRuntimeStatus } from '../../vector/runtime-status.ts';
 import type { VectorServerHealth } from './vector-server.ts';
 
 type DbStatus = { status: 'connected' } | { status: 'error'; error: string };
-type CanonicalSubsystemName = 'backend' | 'database' | 'fts' | 'vector' | 'embedder' | 'mcp' | 'plugins';
+type CanonicalSubsystemName = 'backend' | 'database' | 'fts' | 'vector' | 'embedder' | 'entities' | 'mcp' | 'plugins';
 export type HealthStatusEnum = 'healthy' | 'starting' | 'degraded' | 'down';
 export type EmbeddingProviderDetection = { checkedAt?: string; providers: DetectedEmbeddingProvider[] };
 export type EmbeddingProviderProbe = () => Promise<EmbeddingProviderDetection>;
@@ -41,6 +42,7 @@ export async function buildHealthSubsystems(input: {
   uptimeSeconds: number;
   embeddingProviders?: EmbeddingProviderProbe;
   embeddingProviderSelection?: EmbeddingProviderSelection;
+  entityCoverage?: EntityCoverageStats;
 }): Promise<HealthSubsystems> {
   return withAliases({
     backend: backendSubsystem(input.uptimeSeconds),
@@ -48,6 +50,7 @@ export async function buildHealthSubsystems(input: {
     fts: ftsSubsystem(input.dbStatus),
     vector: vectorSubsystem(input.vector, input.vectorServer, input.vectorRuntime),
     embedder: await embedderSubsystem(input.embeddingProviders, input.vector, input.embeddingProviderSelection),
+    entities: entityCoverageSubsystem(input.entityCoverage ?? readEntityCoverageStats()),
     mcp: mcpSubsystem(input.toolCount),
     plugins: pluginSubsystem(input.pluginStatus, input.pluginCount),
   });
@@ -58,7 +61,7 @@ export function drainingSubsystems(): HealthSubsystems {
   return withAliases({
     backend: item('backend reachable'), database: item('database writable'),
     fts: item('FTS healthy'), vector: item('vector backend'),
-    embedder: item('embedder reachable'), mcp: item('MCP launchable'),
+    embedder: item('embedder reachable'), entities: item('entity sidecar coverage'), mcp: item('MCP launchable'),
     plugins: item('plugins loaded'),
   });
 }
@@ -166,6 +169,15 @@ function mcpSubsystem(toolCount: number): HealthSubsystem {
   return toolCount > 0
     ? healthy('MCP launchable', `${toolCount} MCP tool(s) registered`, { toolCount })
     : down('MCP launchable', 'no MCP tools registered', { toolCount });
+}
+
+function entityCoverageSubsystem(stats: EntityCoverageStats): HealthSubsystem {
+  if (stats.error) return degraded('entity sidecar coverage', `entity coverage unavailable: ${stats.error}`, { ...stats });
+  const percent = Number((stats.ratio * 100).toFixed(1));
+  const detail = stats.docsIndexed === 0
+    ? 'entity sidecar coverage ready; no indexed docs yet'
+    : `entity links cover ${stats.docsWithEntities}/${stats.docsIndexed} indexed docs (${percent}%)`;
+  return healthy('entity sidecar coverage', detail, { ...stats, percent });
 }
 
 function pluginSubsystem(status: 'ok' | 'degraded', count: number): HealthSubsystem {

--- a/src/search/entity-coverage.ts
+++ b/src/search/entity-coverage.ts
@@ -1,0 +1,79 @@
+import type { Database } from 'bun:sqlite';
+import { sqlite as defaultSqlite } from '../db/index.ts';
+import { currentTenantId } from '../middleware/tenant.ts';
+
+export type EntityCoverageStats = {
+  docsIndexed: number;
+  docsWithEntities: number;
+  docsMissingEntities: number;
+  ratio: number;
+  checkedAt: string;
+  tenantId?: string;
+  error?: string;
+};
+
+type CountRow = { count: number };
+
+export function readEntityCoverageStats(
+  sqlite: Database = defaultSqlite,
+  tenantId = currentTenantId(),
+): EntityCoverageStats {
+  const checkedAt = new Date().toISOString();
+  try {
+    if (!tableExists(sqlite, 'oracle_documents') || !tableExists(sqlite, 'oracle_fts')) {
+      return stats(0, 0, checkedAt, tenantId);
+    }
+    if (!tableExists(sqlite, 'oracle_entity_links')) {
+      const indexed = indexedCount(sqlite, tenantId);
+      return { ...stats(indexed, 0, checkedAt, tenantId), error: 'oracle_entity_links missing' };
+    }
+    return stats(indexedCount(sqlite, tenantId), linkedCount(sqlite, tenantId), checkedAt, tenantId);
+  } catch (error) {
+    return { ...stats(0, 0, checkedAt, tenantId), error: message(error) };
+  }
+}
+
+function indexedCount(sqlite: Database, tenantId?: string): number {
+  const where = tenantId ? 'WHERE d.tenant_id = ?' : '';
+  return count(sqlite, `
+    SELECT COUNT(DISTINCT d.id) AS count
+    FROM oracle_documents d JOIN oracle_fts f ON f.id = d.id
+    ${where}`, tenantId ? [tenantId] : []);
+}
+
+function linkedCount(sqlite: Database, tenantId?: string): number {
+  const where = tenantId ? 'WHERE d.tenant_id = ?' : '';
+  return count(sqlite, `
+    SELECT COUNT(DISTINCT d.id) AS count
+    FROM oracle_documents d
+    JOIN oracle_fts f ON f.id = d.id
+    JOIN oracle_entity_links l ON l.document_id = d.id AND l.tenant_id = d.tenant_id
+    ${where}`, tenantId ? [tenantId] : []);
+}
+
+function stats(indexed: number, linked: number, checkedAt: string, tenantId?: string): EntityCoverageStats {
+  const docsIndexed = Math.max(0, indexed);
+  const docsWithEntities = Math.min(docsIndexed, Math.max(0, linked));
+  const docsMissingEntities = Math.max(0, docsIndexed - docsWithEntities);
+  return {
+    docsIndexed,
+    docsWithEntities,
+    docsMissingEntities,
+    ratio: docsIndexed === 0 ? 1 : round(docsWithEntities / docsIndexed),
+    checkedAt,
+    ...(tenantId ? { tenantId } : {}),
+  };
+}
+
+function count(sqlite: Database, sql: string, params: string[]): number {
+  return (sqlite.query<CountRow, string[]>(sql).get(...params)?.count ?? 0);
+}
+
+function tableExists(sqlite: Database, name: string): boolean {
+  return Boolean(sqlite.query<CountRow, [string]>(
+    "SELECT COUNT(*) AS count FROM sqlite_master WHERE name = ? LIMIT 1",
+  ).get(name)?.count);
+}
+
+function round(value: number): number { return Number(value.toFixed(4)); }
+function message(error: unknown): string { return error instanceof Error ? error.message : String(error); }

--- a/src/server.ts
+++ b/src/server.ts
@@ -73,6 +73,7 @@ import { watcherRoutes } from './routes/watcher/index.ts';
 import { indexerRoutes } from './routes/indexer/index.ts';
 import { fileWatcherService } from './services/file-watcher.ts';
 import { createSleepConsolidationWorker } from './workers/sleep-consolidation.ts';
+import { createEntityBackfillWorker } from './workers/entity-backfill.ts';
 import { gatewayPlugin } from './gateway/index.ts';
 import { simpleModeResponse } from './simple-mode.ts';
 import pkg from '../package.json' with { type: 'json' };
@@ -170,8 +171,10 @@ export async function createStartedApp(options: StartServerOptions = {}): Promis
   }
   if (process.env.ORACLE_FILE_WATCHER !== '0') fileWatcherService.start();
   const consolidationWorker = createSleepConsolidationWorker(sqlite);
+  const entityBackfillWorker = createEntityBackfillWorker(sqlite);
   consolidationWorker.start();
-  registerGracefulShutdown({ close: async () => consolidationWorker.stop() });
+  entityBackfillWorker.start();
+  registerGracefulShutdown({ close: async () => { consolidationWorker.stop(); entityBackfillWorker.stop(); } });
 
   const pluginDirs = defaultUnifiedPluginDirs([join(import.meta.dir, 'plugins')]);
   const pluginWarn = (message: string) => console.warn(message);

--- a/src/workers/entity-backfill.ts
+++ b/src/workers/entity-backfill.ts
@@ -1,0 +1,179 @@
+import type { Database } from 'bun:sqlite';
+import { currentTenantId } from '../middleware/tenant.ts';
+import { entityLinksForDocument, replaceEntityLinks } from '../search/entity-ranking.ts';
+import { readEntityCoverageStats, type EntityCoverageStats } from '../search/entity-coverage.ts';
+import { entityCollectionName, entityDocumentsFor } from '../vector/entities.ts';
+import { createVectorStoreForModel, getEmbeddingModels, type EmbeddingModelConfig } from '../vector/factory.ts';
+import type { VectorDocument, VectorStoreAdapter } from '../vector/types.ts';
+
+type Env = Record<string, string | undefined>;
+type Logger = Pick<Console, 'warn' | 'error'>;
+type Store = Pick<VectorStoreAdapter, 'connect' | 'ensureCollection' | 'addDocuments'> &
+  Partial<Pick<VectorStoreAdapter, 'close' | 'deleteDocuments' | 'getAllEmbeddings'>>;
+type IndexedDoc = {
+  id: string; tenantId: string; type: string; sourceFile: string;
+  concepts: string; content: string; project: string | null;
+};
+type SidecarPlan = { key: string; preset: EmbeddingModelConfig; deleteIds: string[]; docs: VectorDocument[] };
+type Plan = { docs: IndexedDoc[]; linkDocs: IndexedDoc[]; sidecars: SidecarPlan[]; coverage: EntityCoverageStats };
+
+export type EntityBackfillOptions = {
+  env?: Env; force?: boolean; dryRunOnly?: boolean; limit?: number; entityScanLimit?: number;
+  tenantId?: string; models?: () => Record<string, EmbeddingModelConfig>;
+  createStore?: (preset: EmbeddingModelConfig) => Store; logger?: Logger;
+};
+export type EntityBackfillReport = EntityCoverageStats & {
+  scanned: number; linkDocsMissing: number; sidecarDocsMissing: number; entityDocsPlanned: number; models: string[];
+};
+export type EntityBackfillApplied = { docsRepaired: number; linksWritten: number; entityDocsWritten: number; errors: string[] };
+export type EntityBackfillResult = {
+  enabled: boolean; dryRun: EntityBackfillReport; applied: EntityBackfillApplied; after: EntityBackfillReport;
+};
+
+const DEFAULT_INTERVAL_MS = 15 * 60 * 1000;
+const DEFAULT_LIMIT = 250;
+const DEFAULT_ENTITY_SCAN_LIMIT = 100_000;
+const status = { running: false, lastRun: undefined as string | undefined, lastDurationMs: undefined as number | undefined, lastError: undefined as string | undefined, lastDryRun: undefined as EntityBackfillReport | undefined, lastApplied: undefined as EntityBackfillApplied | undefined };
+
+export function entityBackfillConfig(env: Env = process.env) {
+  return {
+    enabled: env.ORACLE_ENTITY_BACKFILL === '1',
+    intervalMs: intEnv(env.ORACLE_ENTITY_BACKFILL_INTERVAL_MS, DEFAULT_INTERVAL_MS, 60_000, 86_400_000),
+    limit: intEnv(env.ORACLE_ENTITY_BACKFILL_LIMIT, DEFAULT_LIMIT, 1, 5_000),
+    entityScanLimit: intEnv(env.ORACLE_ENTITY_BACKFILL_ENTITY_SCAN_LIMIT, DEFAULT_ENTITY_SCAN_LIMIT, 1, 1_000_000),
+  };
+}
+
+export function entityBackfillStatus(env: Env = process.env) {
+  const config = entityBackfillConfig(env);
+  return { ...status, ...config, ...(config.enabled ? {} : { disabledReason: 'set ORACLE_ENTITY_BACKFILL=1 to enable' }) };
+}
+
+export async function runEntityBackfillSweep(sqlite: Database, input: EntityBackfillOptions = {}): Promise<EntityBackfillResult> {
+  const started = Date.now(), config = entityBackfillConfig(input.env), enabled = config.enabled || input.force === true;
+  if (!enabled) return finish(false, started, emptyReport(sqlite, input), emptyApplied(), emptyReport(sqlite, input));
+  try {
+    const dryPlan = await plan(sqlite, input, config.limit, config.entityScanLimit);
+    const dryRun = report(dryPlan);
+    const applied = input.dryRunOnly ? emptyApplied() : await applyPlan(sqlite, dryPlan, input);
+    const after = report(await plan(sqlite, input, config.limit, config.entityScanLimit));
+    return finish(true, started, dryRun, applied, after);
+  } catch (error) {
+    status.lastError = message(error); input.logger?.error?.(status.lastError);
+    const dry = emptyReport(sqlite, input);
+    return finish(true, started, dry, { ...emptyApplied(), errors: [status.lastError] }, dry);
+  }
+}
+
+export function createEntityBackfillWorker(sqlite: Database, input: EntityBackfillOptions = {}) {
+  let timer: ReturnType<typeof setInterval> | null = null;
+  const runOnce = () => runEntityBackfillSweep(sqlite, input);
+  return {
+    runOnce,
+    start() {
+      const config = entityBackfillConfig(input.env);
+      if (!config.enabled || timer) return;
+      status.running = true;
+      timer = setInterval(() => { void runOnce().catch((error) => (input.logger ?? console).error(error)); }, config.intervalMs);
+    },
+    stop() { if (timer) clearInterval(timer); timer = null; status.running = false; },
+    isRunning: () => timer !== null,
+  };
+}
+
+async function plan(sqlite: Database, input: EntityBackfillOptions, limit: number, entityScanLimit: number): Promise<Plan> {
+  const tenantId = input.tenantId ?? currentTenantId();
+  const docs = loadDocs(sqlite, input.limit ?? limit, tenantId);
+  const links = existingLinkKeys(sqlite, docs.map((doc) => doc.id), tenantId);
+  const linkDocs = docs.filter((doc) => !sameSet(entityKeys(doc), links.get(doc.id) ?? new Set()));
+  const sidecars = await sidecarPlans(docs, input, entityScanLimit, tenantId);
+  return { docs, linkDocs, sidecars, coverage: readEntityCoverageStats(sqlite, tenantId) };
+}
+
+async function sidecarPlans(docs: IndexedDoc[], input: EntityBackfillOptions, scanLimit: number, tenantId?: string): Promise<SidecarPlan[]> {
+  const models = input.models?.() ?? getEmbeddingModels();
+  const createStore = input.createStore ?? createVectorStoreForModel;
+  const plans: SidecarPlan[] = [];
+  for (const [key, preset] of Object.entries(models)) {
+    const entityPreset = { ...preset, collection: entityCollectionName(preset.collection) };
+    const store = createStore(entityPreset);
+    try {
+      await store.connect(); await store.ensureCollection();
+      const existing = await existingEntityDocs(store, scanLimit, tenantId);
+      const docsToWrite: VectorDocument[] = [], deleteIds = new Set<string>();
+      for (const doc of docs) {
+        const expected = entityDocumentsFor(vectorDoc(doc));
+        if (expected.length === 0) continue;
+        const seen = existing.get(doc.id) ?? new Set<string>();
+        if (sameSet(new Set(expected.map((item) => item.id)), seen)) continue;
+        expected.forEach((item) => docsToWrite.push(item));
+        [...seen, ...expected.map((item) => item.id)].forEach((id) => deleteIds.add(id));
+      }
+      if (docsToWrite.length > 0) plans.push({ key, preset: entityPreset, docs: docsToWrite, deleteIds: [...deleteIds] });
+    } finally { await store.close?.().catch(() => undefined); }
+  }
+  return plans;
+}
+
+async function applyPlan(sqlite: Database, planned: Plan, input: EntityBackfillOptions): Promise<EntityBackfillApplied> {
+  let linksWritten = 0, entityDocsWritten = 0; const errors: string[] = [];
+  for (const doc of planned.linkDocs) {
+    try { replaceEntityLinks(sqlite, { documentId: doc.id, tenantId: doc.tenantId, content: doc.content, concepts: doc.concepts }); linksWritten += entityKeys(doc).size; }
+    catch (error) { errors.push(message(error)); }
+  }
+  const createStore = input.createStore ?? createVectorStoreForModel;
+  for (const item of planned.sidecars) {
+    const store = createStore(item.preset);
+    try {
+      await store.connect(); await store.ensureCollection();
+      await store.deleteDocuments?.(item.deleteIds);
+      await store.addDocuments(item.docs); entityDocsWritten += item.docs.length;
+    } catch (error) { errors.push(`${item.key}: ${message(error)}`); }
+    finally { await store.close?.().catch(() => undefined); }
+  }
+  return { docsRepaired: new Set([...planned.linkDocs.map((doc) => doc.id), ...planned.sidecars.flatMap((item) => item.docs.map((doc) => String(doc.metadata.source_doc_id)))]).size, linksWritten, entityDocsWritten, errors };
+}
+
+function loadDocs(sqlite: Database, limit: number, tenantId?: string): IndexedDoc[] {
+  const where = tenantId ? 'WHERE d.tenant_id = ?' : '';
+  return sqlite.query<IndexedDoc, any[]>(`
+    SELECT d.id, d.tenant_id AS tenantId, d.type, d.source_file AS sourceFile,
+      d.concepts, d.project, GROUP_CONCAT(f.content, '\n') AS content
+    FROM oracle_documents d JOIN oracle_fts f ON f.id = d.id
+    ${where} GROUP BY d.id ORDER BY d.indexed_at DESC LIMIT ?`).all(...(tenantId ? [tenantId, limit] : [limit]));
+}
+
+function existingLinkKeys(sqlite: Database, ids: string[], tenantId?: string): Map<string, Set<string>> {
+  if (ids.length === 0) return new Map();
+  const params = tenantId ? [tenantId, ...ids] : ids, tenant = tenantId ? 'tenant_id = ? AND' : '';
+  const rows = sqlite.query<{ documentId: string; entityKey: string }, any[]>(`
+    SELECT document_id AS documentId, entity_key AS entityKey FROM oracle_entity_links
+    WHERE ${tenant} document_id IN (${ids.map(() => '?').join(',')})`).all(...params);
+  const out = new Map<string, Set<string>>();
+  for (const row of rows) (out.get(row.documentId) ?? out.set(row.documentId, new Set()).get(row.documentId)!).add(row.entityKey);
+  return out;
+}
+
+async function existingEntityDocs(store: Store, limit: number, tenantId?: string): Promise<Map<string, Set<string>>> {
+  const snapshot = await store.getAllEmbeddings?.(limit);
+  const out = new Map<string, Set<string>>();
+  snapshot?.ids?.forEach((id, index) => {
+    const meta = (snapshot.metadatas?.[index] ?? {}) as Record<string, unknown>;
+    const docId = String(meta.source_doc_id ?? '');
+    if (!docId || (tenantId && meta.tenant_id !== tenantId)) return;
+    (out.get(docId) ?? out.set(docId, new Set()).get(docId)!).add(id);
+  });
+  return out;
+}
+
+function vectorDoc(doc: IndexedDoc): VectorDocument {
+  return { id: doc.id, document: doc.content, metadata: { type: doc.type, source_file: doc.sourceFile, concepts: doc.concepts, tenant_id: doc.tenantId, ...(doc.project ? { project: doc.project } : {}) } };
+}
+function entityKeys(doc: IndexedDoc): Set<string> { return new Set(entityLinksForDocument({ documentId: doc.id, tenantId: doc.tenantId, content: doc.content, concepts: doc.concepts }).map((link) => link.entityKey)); }
+function report(planned: Plan): EntityBackfillReport { return { ...planned.coverage, scanned: planned.docs.length, linkDocsMissing: planned.linkDocs.length, sidecarDocsMissing: new Set(planned.sidecars.flatMap((item) => item.docs.map((doc) => String(doc.metadata.source_doc_id)))).size, entityDocsPlanned: planned.sidecars.reduce((sum, item) => sum + item.docs.length, 0), models: planned.sidecars.map((item) => item.key) }; }
+function emptyReport(sqlite: Database, input: EntityBackfillOptions): EntityBackfillReport { return { ...readEntityCoverageStats(sqlite, input.tenantId ?? currentTenantId()), scanned: 0, linkDocsMissing: 0, sidecarDocsMissing: 0, entityDocsPlanned: 0, models: [] }; }
+function emptyApplied(): EntityBackfillApplied { return { docsRepaired: 0, linksWritten: 0, entityDocsWritten: 0, errors: [] }; }
+function finish(enabled: boolean, started: number, dryRun: EntityBackfillReport, applied: EntityBackfillApplied, after: EntityBackfillReport): EntityBackfillResult { status.lastRun = new Date(started).toISOString(); status.lastDurationMs = Date.now() - started; status.lastDryRun = dryRun; status.lastApplied = applied; return { enabled, dryRun, applied, after }; }
+function sameSet(left: Set<string>, right: Set<string>): boolean { return left.size === right.size && [...left].every((item) => right.has(item)); }
+function intEnv(raw: string | undefined, fallback: number, min: number, max: number): number { const parsed = Number.parseInt(raw ?? '', 10); return Number.isFinite(parsed) ? Math.min(max, Math.max(min, parsed)) : fallback; }
+function message(error: unknown): string { return error instanceof Error ? error.message : String(error); }

--- a/tests/http/health/entity-coverage.test.ts
+++ b/tests/http/health/entity-coverage.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from 'bun:test';
+import { createHealthRoutes } from '../../../src/routes/health/index.ts';
+
+test('GET /api/health exposes entity sidecar coverage ratio and worker gate', async () => {
+  const previous = process.env.ORACLE_ENTITY_BACKFILL;
+  delete process.env.ORACLE_ENTITY_BACKFILL;
+  try {
+    const app = createHealthRoutes({
+      pluginCount: 1,
+      uptimeSeconds: () => 4,
+      vectorHealth: async () => ({ status: 'ok', engines: [], checked_at: 'now' }),
+      vectorServerHealth: async () => ({ configured: false, status: 'unconfigured' }),
+      embeddingProviderSelection: { provider: 'none', source: 'env', explicit: true },
+      entityCoverage: () => ({
+        docsIndexed: 4,
+        docsWithEntities: 3,
+        docsMissingEntities: 1,
+        ratio: 0.75,
+        tenantId: 'tenant-a',
+        checkedAt: '2026-07-05T00:00:00.000Z',
+      }),
+    });
+
+    const res = await app.handle(new Request('http://local/api/health'));
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(body.subsystems.entities).toMatchObject({
+      status: 'healthy',
+      label: 'entity sidecar coverage',
+      data: { docsIndexed: 4, docsWithEntities: 3, docsMissingEntities: 1, ratio: 0.75, percent: 75 },
+    });
+    expect(body.entities.coverage).toMatchObject({ docsIndexed: 4, docsWithEntities: 3, tenantId: 'tenant-a' });
+    expect(body.entities.backfillWorker).toMatchObject({ enabled: false, running: false, disabledReason: 'set ORACLE_ENTITY_BACKFILL=1 to enable' });
+  } finally {
+    if (previous === undefined) delete process.env.ORACLE_ENTITY_BACKFILL;
+    else process.env.ORACLE_ENTITY_BACKFILL = previous;
+  }
+});

--- a/tests/workers/entity-backfill.test.ts
+++ b/tests/workers/entity-backfill.test.ts
@@ -1,0 +1,122 @@
+import { Database } from 'bun:sqlite';
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { entityDocumentsFor } from '../../src/vector/entities.ts';
+import { runEntityBackfillSweep } from '../../src/workers/entity-backfill.ts';
+import type { VectorDocument } from '../../src/vector/types.ts';
+
+const models = () => ({ nomic: { collection: 'test_docs', model: 'nomic-embed-text' } });
+const dbs: Database[] = [];
+
+afterEach(() => { while (dbs.length) dbs.pop()?.close(); });
+
+describe('entity sidecar backfill worker', () => {
+  test('is disabled by default and does not touch SQL or vector stores', async () => {
+    const sqlite = memoryDb();
+    seedDoc(sqlite, 'doc-disabled', 'default', 'Alpha Project learns Cloudflare Workers', ['Alpha Project']);
+    const stores = storesFor();
+
+    const result = await runEntityBackfillSweep(sqlite, { env: {}, models, createStore: stores.create });
+
+    expect(result.enabled).toBe(false);
+    expect(linkCount(sqlite)).toBe(0);
+    expect(stores.created()).toBe(0);
+  });
+
+  test('repairs missing SQL links and entity vector docs within tenant scope', async () => {
+    const sqlite = memoryDb();
+    seedDoc(sqlite, 'doc-a', 'tenant-a', 'Alpha Project uses Cloudflare Workers', ['Alpha Project']);
+    seedDoc(sqlite, 'doc-b', 'tenant-b', 'Beta Project uses Cloudflare Workers', ['Beta Project']);
+    const stores = storesFor();
+
+    const result = await runEntityBackfillSweep(sqlite, {
+      env: { ORACLE_ENTITY_BACKFILL: '1' }, tenantId: 'tenant-a', models, createStore: stores.create,
+    });
+
+    expect(result.dryRun).toMatchObject({ docsIndexed: 1, docsWithEntities: 0, linkDocsMissing: 1, sidecarDocsMissing: 1 });
+    expect(result.applied.docsRepaired).toBe(1);
+    expect(result.after).toMatchObject({ docsIndexed: 1, docsWithEntities: 1, docsMissingEntities: 0, ratio: 1 });
+    expect([...new Set(links(sqlite).map((row) => row.document_id))]).toEqual(['doc-a']);
+    expect(stores.docs('test_docs_entities').map((doc) => doc.metadata.source_doc_id)).toContain('doc-a');
+    expect(stores.docs('test_docs_entities').every((doc) => doc.metadata.tenant_id === 'tenant-a')).toBe(true);
+  });
+
+  test('is idempotent when links and sidecar docs already match expected entities', async () => {
+    const sqlite = memoryDb();
+    seedDoc(sqlite, 'doc-covered', 'default', 'Gamma Project keeps Arra Oracle searchable', ['Gamma Project']);
+    const stores = storesFor();
+    await runEntityBackfillSweep(sqlite, { env: { ORACLE_ENTITY_BACKFILL: '1' }, models, createStore: stores.create });
+    const addCalls = stores.addCalls('test_docs_entities');
+
+    const second = await runEntityBackfillSweep(sqlite, { env: { ORACLE_ENTITY_BACKFILL: '1' }, models, createStore: stores.create });
+
+    expect(second.dryRun).toMatchObject({ linkDocsMissing: 0, sidecarDocsMissing: 0, entityDocsPlanned: 0 });
+    expect(second.applied).toMatchObject({ docsRepaired: 0, linksWritten: 0, entityDocsWritten: 0, errors: [] });
+    expect(stores.addCalls('test_docs_entities')).toBe(addCalls);
+  });
+});
+
+function memoryDb(): Database {
+  const sqlite = new Database(':memory:');
+  sqlite.exec(`
+    CREATE TABLE oracle_documents (
+      id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, type TEXT NOT NULL,
+      source_file TEXT NOT NULL, concepts TEXT NOT NULL, created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL, indexed_at INTEGER NOT NULL, project TEXT
+    );
+    CREATE VIRTUAL TABLE oracle_fts USING fts5(id UNINDEXED, content, concepts);
+    CREATE TABLE oracle_entity_links (
+      id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, document_id TEXT NOT NULL,
+      entity TEXT NOT NULL, entity_key TEXT NOT NULL, weight INTEGER NOT NULL,
+      created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+    );
+  `);
+  dbs.push(sqlite);
+  return sqlite;
+}
+
+function seedDoc(sqlite: Database, id: string, tenantId: string, content: string, concepts: string[]) {
+  const now = Date.now();
+  sqlite.prepare(`INSERT INTO oracle_documents
+    (id, tenant_id, type, source_file, concepts, created_at, updated_at, indexed_at, project)
+    VALUES (?, ?, 'learning', ?, ?, ?, ?, ?, ?)`)
+    .run(id, tenantId, `ψ/memory/${id}.md`, JSON.stringify(concepts), now, now, now, tenantId);
+  sqlite.prepare('INSERT INTO oracle_fts(id, content, concepts) VALUES (?, ?, ?)')
+    .run(id, content, concepts.join(' '));
+}
+
+function storesFor() {
+  const stores = new Map<string, ReturnType<typeof fakeStore>>();
+  return {
+    create(preset: { collection: string }) {
+      const existing = stores.get(preset.collection) ?? fakeStore();
+      stores.set(preset.collection, existing);
+      return existing;
+    },
+    docs(collection: string) { return stores.get(collection)?.docs() ?? []; },
+    addCalls(collection: string) { return stores.get(collection)?.add.mock.calls.length ?? 0; },
+    created() { return stores.size; },
+  };
+}
+
+function fakeStore(seed: VectorDocument[] = []) {
+  let docs = [...seed];
+  const store = {
+    connect: mock(async () => {}),
+    ensureCollection: mock(async () => {}),
+    close: mock(async () => {}),
+    deleteDocuments: mock(async (ids: string[]) => { docs = docs.filter((doc) => !ids.includes(doc.id)); }),
+    add: mock(async (added: VectorDocument[]) => { docs.push(...added); }),
+    addDocuments(added: VectorDocument[]) { return store.add(added); },
+    getAllEmbeddings: mock(async () => ({ ids: docs.map((doc) => doc.id), documents: docs.map((doc) => doc.document), embeddings: [], metadatas: docs.map((doc) => doc.metadata) })),
+    docs: () => docs,
+  };
+  return store;
+}
+
+function links(sqlite: Database) {
+  return sqlite.query<{ document_id: string; entity: string }, []>('SELECT document_id, entity FROM oracle_entity_links ORDER BY document_id, entity').all();
+}
+function linkCount(sqlite: Database): number { return links(sqlite).length; }
+
+// Keeps the import covered by test-time typechecking for the exact sidecar shape.
+void entityDocumentsFor;


### PR DESCRIPTION
## Summary
- adds an off-by-default `ORACLE_ENTITY_BACKFILL=1` worker seam for entity sidecar hygiene
- dry-runs first, then repairs missing/stale `oracle_entity_links` and `_entities` vector docs idempotently
- keeps repair tenant-scoped and uses only the existing cheap sync entity extractor (no LLM, no graph DB)
- adds `/api/health` entity coverage ratio plus visible backfill worker gate/status

## Coverage before/after evidence
Worker regression fixture:
- before backfill: `docsIndexed=1`, `docsWithEntities=0`, `linkDocsMissing=1`, `sidecarDocsMissing=1`
- after backfill: `docsIndexed=1`, `docsWithEntities=1`, `docsMissingEntities=0`, `ratio=1`
- disabled default fixture: no SQL links written and no vector stores created
- idempotent fixture: second sweep reports `linkDocsMissing=0`, `sidecarDocsMissing=0`, `entityDocsPlanned=0`, `entityDocsWritten=0`

## Verification
- `bunx tsc --noEmit`
- `bun test tests/workers/ tests/http/health/` — 154 pass
- changed files ≤250 lines

Closes #2720
