### PR TITLE
fix(ask): reuse acronym query augmentation

### DIFF
--- a/src/routes/ask/index.ts
+++ b/src/routes/ask/index.ts
@@ -1,6 +1,7 @@
 import { Elysia } from 'elysia';
 import { sqlite } from '../../db/index.ts';
 import { currentTenantId } from '../../middleware/tenant.ts';
+import { augmentQueryWithAcronyms } from '../../search/acronyms.ts';
 import { filterResultsAsOf, parseAsOf } from '../../search/bitemporal.ts';
 import { rerankByEntityLinks } from '../../search/entity-ranking.ts';
 import { attachSupersedeStatus } from '../../search/supersede-status.ts';
@@ -64,9 +65,10 @@ export async function answerOracleAsk(body: AskInput, deps: AskDeps = {}): Promi
   if (!parsedModel.ok) return { status: 400, body: { error: parsedModel.error } };
   const asOf = parseAsOf(body.asOf);
   if (!asOf.ok) return { status: 400, body: { error: asOf.error } };
-  const tenantResult = handleTenantSearch(q, body.type ?? 'all', limit, 0, asOf.value);
+  const augmentedQ = augmentQueryWithAcronyms(q);
+  const tenantResult = handleTenantSearch(augmentedQ, body.type ?? 'all', limit, 0, asOf.value);
   const result = tenantResult
-    ?? await handleSearch(q, body.type ?? 'all', limit, 0, 'hybrid', body.project, body.cwd, parsedModel.value);
+    ?? await handleSearch(augmentedQ, body.type ?? 'all', limit, 0, 'hybrid', body.project, body.cwd, parsedModel.value);
   if (asOf.value && !tenantResult) {
     result.results = filterResultsAsOf(
       sqlite,
@@ -75,7 +77,7 @@ export async function answerOracleAsk(body: AskInput, deps: AskDeps = {}): Promi
     ) as unknown as typeof result.results;
     result.total = result.results.length;
   }
-  result.results = rerankByEntityLinks(sqlite, result.results, q, currentTenantId()) as typeof result.results;
+  result.results = rerankByEntityLinks(sqlite, result.results, augmentedQ, currentTenantId()) as typeof result.results;
   attachSupersedeStatus(sqlite, result.results as unknown as Array<Record<string, unknown>>);
   const sources = sourcesFrom(rankAskResults(result.results), limit);
   const client = body.llm === false ? undefined : deps.client ?? envAskClient();

--- a/tests/eval/phase1-entity-golden-baseline.test.ts
+++ b/tests/eval/phase1-entity-golden-baseline.test.ts
@@ -83,11 +83,11 @@ describe('Phase 1 entity golden eval baseline', () => {
     }
   });
 
-  test('acronym alias is boosted in /api/search but not yet in /api/ask or fanout', async () => {
+  test('acronym alias is boosted in /api/search and /api/ask but not fanout', async () => {
     const item = cases.alias;
     const q = `${item.queryEntity} ${item.anchor}`;
     expect(ids(await search(q))).toEqual([item.linked, item.plain]);
-    expect((await askJson(q)).citations.map((hit) => hit.id)).toEqual([item.plain, item.linked]);
+    expect((await askJson(q)).citations.map((hit) => hit.id)).toEqual([item.linked, item.plain]);
     expect(ids(await fanout(q))).toEqual([item.plain, item.linked]);
   });
 

--- a/tests/http/ask/contract.test.ts
+++ b/tests/http/ask/contract.test.ts
@@ -10,7 +10,10 @@ const staleId = `stale-${stamp}`;
 const currentId = `current-${stamp}`;
 const boostedId = `boosted-${stamp}`;
 const plainId = `plain-${stamp}`;
+const aliasPlainId = `alias-plain-${stamp}`;
+const aliasLinkedId = `alias-linked-${stamp}`;
 const term = `askcontract${stamp}`;
+const aliasTerm = `askalias${stamp}`;
 
 let dbModule: typeof import('../../../src/db/index.ts');
 let route: { handle: (request: Request) => Response | Promise<Response> };
@@ -41,7 +44,10 @@ beforeAll(async () => {
   });
   insertDoc(plainId, `${term} plain evidence for Orbit.`);
   insertDoc(boostedId, `${term} boosted evidence for Orbit.`);
+  insertDoc(aliasPlainId, `${aliasTerm} plain acronym evidence.`);
+  insertDoc(aliasLinkedId, `${aliasTerm} full-name acronym evidence.`);
   insertEntity(boostedId, 'Orbit');
+  insertEntity(aliasLinkedId, 'Application Programming Interface');
 });
 
 function insertDoc(id: string, content: string, options: { supersededBy?: string | null; validTime?: number } = {}) {
@@ -67,7 +73,7 @@ function insertDoc(id: string, content: string, options: { supersededBy?: string
 }
 
 function insertEntity(documentId: string, entity: string) {
-  const key = entity.toLowerCase();
+  const key = entityKey(entity);
   dbModule.db.insert(dbModule.oracleEntityLinks).values({
     id: `${tenantId}:${documentId}:${key}`,
     tenantId,
@@ -78,6 +84,10 @@ function insertEntity(documentId: string, entity: string) {
     createdAt: Date.now(),
     updatedAt: Date.now(),
   }).run();
+}
+
+function entityKey(value: string): string {
+  return value.normalize('NFKC').toLowerCase().replace(/[^\p{L}\p{N}]+/gu, '-').replace(/^-+|-+$/g, '');
 }
 
 function post(body: Record<string, unknown>) {
@@ -150,5 +160,16 @@ describe('POST /api/ask RAG contract', () => {
     expect(res.status).toBe(200);
     expect(body.sources[0]).toMatchObject({ id: boostedId, entityMatches: ['Orbit'] });
     expect(body.citations[0]).toMatchObject({ id: boostedId });
+  });
+
+  test('reuses search acronym augmentation before ask retrieval and ranking', async () => {
+    const res = await post({ question: `API ${aliasTerm}`, llm: false, limit: 2 });
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    expect(body.query).toBe(`API ${aliasTerm}`);
+    expect(body.sources.map((source: { id: string }) => source.id)).toEqual([aliasLinkedId, aliasPlainId]);
+    expect(body.citations[0]).toMatchObject({ id: aliasLinkedId, index: 1 });
+    expect(body.sources[0].entityMatches).toContain('Application Programming Interface');
   });
 });


### PR DESCRIPTION
## Summary
- Reuses the existing acronym query augmentation path in `/api/ask` before tenant/hybrid retrieval and entity-link reranking.
- Keeps the public ask query/synthesis question as the user's original sanitized question.
- Adds eval + HTTP ask regression coverage for the `API` → `Application Programming Interface` alias path so the full-name doc becomes citation/source `[1]`.

## Verification
- `bunx tsc --noEmit`
- `bun test tests/eval/` (10 pass)
- `bun test tests/http/ask/` (9 pass)

Fixes #2726
