### PR TITLE
fix(fanout): isolate tenant and asOf candidates

### DIFF
--- a/src/routes/memory/fanout-filter.ts
+++ b/src/routes/memory/fanout-filter.ts
@@ -1,0 +1,48 @@
+import type { Database } from 'bun:sqlite';
+import { currentTenantId } from '../../middleware/tenant.ts';
+import { BI_TEMPORAL_JOIN, BI_TEMPORAL_WHERE, biTemporalParams } from '../../search/bitemporal.ts';
+import { isoTimestamp } from '../../search/timestamp.ts';
+import type { FanoutSearchResult } from './fanout-results.ts';
+
+type Row = {
+  id: string;
+  valid_time: number | string | null;
+  valid_until: number | string | null;
+};
+
+export function fanoutVectorWhere(): Record<string, string> | undefined {
+  const tenantId = currentTenantId();
+  return tenantId ? { tenant_id: tenantId } : undefined;
+}
+
+export function filterFanoutCandidates(
+  db: Database,
+  results: FanoutSearchResult[],
+  asOfMs: number | undefined,
+  tenantId = currentTenantId(),
+): FanoutSearchResult[] {
+  if ((!tenantId && !asOfMs) || results.length === 0) return results;
+  const ids = [...new Set(results.map((item) => item.id).filter(Boolean))];
+  if (ids.length === 0) return [];
+
+  const placeholders = ids.map(() => '?').join(',');
+  const temporalClause = asOfMs ? `AND ${BI_TEMPORAL_WHERE}` : '';
+  const tenantClause = tenantId ? 'AND d.tenant_id = ?' : '';
+  const rows = db.prepare(`
+    SELECT d.id, d.valid_time, COALESCE(s.valid_time, d.superseded_at) as valid_until
+    FROM oracle_documents d
+    ${BI_TEMPORAL_JOIN}
+    WHERE d.id IN (${placeholders}) ${tenantClause} ${temporalClause}
+  `).all(...ids, ...(tenantId ? [tenantId] : []), ...(asOfMs ? biTemporalParams(asOfMs) : [])) as Row[];
+
+  const allowed = new Map(rows.map((row) => [row.id, row]));
+  return results.filter((item) => {
+    const row = allowed.get(item.id);
+    if (!row) return false;
+    if (asOfMs) {
+      item.valid_time = isoTimestamp(row.valid_time);
+      item.valid_until = isoTimestamp(row.valid_until);
+    }
+    return true;
+  });
+}

--- a/src/routes/memory/fanout-results.ts
+++ b/src/routes/memory/fanout-results.ts
@@ -1,0 +1,66 @@
+import type { SearchResult } from '../../server/types.ts';
+import type { VectorQueryResult } from '../../vector/types.ts';
+import { safeVectorDistance, scoreFromVectorDistance } from './fanout-score.ts';
+
+export type FanoutSearchResult = SearchResult & {
+  title?: string;
+  tags?: string[];
+  memorySource?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  usageCount?: number;
+  lastAccessedAt?: string;
+};
+
+function text(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function dateText(value: unknown): string | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return new Date(value).toISOString();
+  return text(value);
+}
+
+function textList(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map(String).map((item) => item.trim()).filter(Boolean);
+  if (typeof value !== 'string' || !value.trim()) return [];
+  try {
+    const parsed = JSON.parse(value);
+    if (Array.isArray(parsed)) return textList(parsed);
+  } catch {}
+  return value.split(',').map((item) => item.trim()).filter(Boolean);
+}
+
+export function toFanoutSearchResults(collection: string, result: VectorQueryResult): FanoutSearchResult[] {
+  return result.ids.map((id, index) => {
+    const metadata = result.metadatas?.[index] ?? {};
+    const distance = safeVectorDistance(result.distances?.[index]);
+    const tags = textList(metadata.tags).length ? textList(metadata.tags) : textList(metadata.concepts);
+    return {
+      id,
+      type: metadata.type ?? 'unknown',
+      content: result.documents?.[index] ?? '',
+      source_file: metadata.source_file ?? metadata.path ?? '',
+      concepts: textList(metadata.concepts),
+      source: 'vector',
+      score: scoreFromVectorDistance(distance),
+      distance,
+      model: collection,
+      title: text(metadata.title),
+      tags,
+      memorySource: text(metadata.source ?? metadata.memory_source ?? metadata.source_file ?? metadata.path),
+      createdAt: dateText(metadata.createdAt ?? metadata.created_at),
+      updatedAt: dateText(metadata.updatedAt ?? metadata.updated_at),
+      usageCount: numberValue(metadata.usageCount ?? metadata.usage_count),
+      lastAccessedAt: dateText(metadata.lastAccessedAt ?? metadata.last_accessed_at),
+      superseded_by: text(metadata.superseded_by ?? metadata.supersededBy),
+      superseded_at: dateText(metadata.superseded_at ?? metadata.supersededAt),
+      superseded_reason: text(metadata.superseded_reason ?? metadata.supersededReason),
+    };
+  });
+}

--- a/src/routes/memory/fanout.ts
+++ b/src/routes/memory/fanout.ts
@@ -1,12 +1,15 @@
 import { Elysia } from 'elysia';
 import { sqlite } from '../../db/index.ts';
+import { parseAsOf } from '../../search/bitemporal.ts';
 import { attachSupersedeStatus, supersedeWarnings } from '../../search/supersede-status.ts';
 import type { SearchResult } from '../../server/types.ts';
 import { ensureVectorStoreConnected, getEmbeddingModels, type EmbeddingModelConfig } from '../../vector/factory.ts';
-import type { VectorQueryResult, VectorStoreAdapter } from '../../vector/types.ts';
+import type { VectorStoreAdapter } from '../../vector/types.ts';
+import { asOfResponse } from '../search/asof.ts';
 import { memoryConfidence, type MemoryConfidence } from './confidence.ts';
+import { fanoutVectorWhere, filterFanoutCandidates } from './fanout-filter.ts';
+import { toFanoutSearchResults, type FanoutSearchResult } from './fanout-results.ts';
 import { estimateFanoutCost } from './fanout-cost.ts';
-import { safeVectorDistance, scoreFromVectorDistance } from './fanout-score.ts';
 import { MemoryFanoutQuery, parseMemoryLimit } from './model.ts';
 import { scheduleMemoryReinforcement } from './reinforcement.ts';
 import { clampMemoryConfidenceWeight, memoryConfidenceRerankConfig, memoryFanoutConfidenceWeight } from './rerank-config.ts';
@@ -22,16 +25,6 @@ type MemoryFanoutDeps = {
   now?: () => Date;
 };
 
-type FanoutSearchResult = SearchResult & {
-  title?: string;
-  tags?: string[];
-  memorySource?: string;
-  createdAt?: string;
-  updatedAt?: string;
-  usageCount?: number;
-  lastAccessedAt?: string;
-};
-
 type RankedResult = SearchResult & {
   fusedScore: number;
   rankingScore: number;
@@ -44,59 +37,6 @@ const RRF_K = 60;
 
 function sanitize(q: string): string {
   return q.replace(/<[^>]*>/g, '').replace(/[\x00-\x1f]/g, '').trim();
-}
-
-function text(value: unknown): string | undefined {
-  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
-}
-
-function numberValue(value: unknown): number | undefined {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : undefined;
-}
-
-function dateText(value: unknown): string | undefined {
-  if (typeof value === 'number' && Number.isFinite(value)) return new Date(value).toISOString();
-  return text(value);
-}
-
-function textList(value: unknown): string[] {
-  if (Array.isArray(value)) return value.map(String).map((item) => item.trim()).filter(Boolean);
-  if (typeof value !== 'string' || !value.trim()) return [];
-  try {
-    const parsed = JSON.parse(value);
-    if (Array.isArray(parsed)) return textList(parsed);
-  } catch {}
-  return value.split(',').map((item) => item.trim()).filter(Boolean);
-}
-
-function toSearchResults(collection: string, result: VectorQueryResult): FanoutSearchResult[] {
-  return result.ids.map((id, index) => {
-    const metadata = result.metadatas?.[index] ?? {};
-    const distance = safeVectorDistance(result.distances?.[index]);
-    const tags = textList(metadata.tags).length ? textList(metadata.tags) : textList(metadata.concepts);
-    return {
-      id,
-      type: metadata.type ?? 'unknown',
-      content: result.documents?.[index] ?? '',
-      source_file: metadata.source_file ?? metadata.path ?? '',
-      concepts: textList(metadata.concepts),
-      source: 'vector',
-      score: scoreFromVectorDistance(distance),
-      distance,
-      model: collection,
-      title: text(metadata.title),
-      tags,
-      memorySource: text(metadata.source ?? metadata.memory_source ?? metadata.source_file ?? metadata.path),
-      createdAt: dateText(metadata.createdAt ?? metadata.created_at),
-      updatedAt: dateText(metadata.updatedAt ?? metadata.updated_at),
-      usageCount: numberValue(metadata.usageCount ?? metadata.usage_count),
-      lastAccessedAt: dateText(metadata.lastAccessedAt ?? metadata.last_accessed_at),
-      superseded_by: text(metadata.superseded_by ?? metadata.supersededBy),
-      superseded_at: dateText(metadata.superseded_at ?? metadata.supersededAt),
-      superseded_reason: text(metadata.superseded_reason ?? metadata.supersededReason),
-    };
-  });
 }
 
 function confidenceFor(result: FanoutSearchResult, now: Date, usageWeight?: number): MemoryConfidence {
@@ -188,8 +128,14 @@ export function createMemoryFanoutEndpoint(deps: MemoryFanoutDeps = {}) {
     const models = listModels();
     const collections = Object.keys(models);
     const limit = parseMemoryLimit(query.limit);
+    const asOf = parseAsOf(query.asOf);
+    if (!asOf.ok) {
+      set.status = 400;
+      return { error: asOf.error };
+    }
     const errors: Record<string, string> = {};
     const byCollection: Record<string, SearchResult[]> = {};
+    const where = fanoutVectorWhere();
     const rerankConfig = memoryConfidenceRerankConfig();
     const configuredConfidenceWeight = deps.confidenceWeight === undefined
       ? rerankConfig.confidenceWeight
@@ -197,7 +143,7 @@ export function createMemoryFanoutEndpoint(deps: MemoryFanoutDeps = {}) {
 
     const settled = await Promise.allSettled(collections.map(async (key) => {
       const store = await connect(key, models);
-      return { key, result: await store.query(q, limit) };
+      return { key, result: await store.query(q, limit, where) };
     }));
 
     settled.forEach((item, index) => {
@@ -206,7 +152,11 @@ export function createMemoryFanoutEndpoint(deps: MemoryFanoutDeps = {}) {
         errors[key] = item.reason instanceof Error ? item.reason.message : String(item.reason);
         return;
       }
-      byCollection[key] = toSearchResults(key, item.value.result);
+      byCollection[key] = filterFanoutCandidates(
+        sqlite,
+        toFanoutSearchResults(key, item.value.result),
+        asOf.value,
+      );
     });
 
     const results = fuseRankedResults(byCollection, limit, {
@@ -232,6 +182,7 @@ export function createMemoryFanoutEndpoint(deps: MemoryFanoutDeps = {}) {
       },
       results,
       ...(warnings.length ? { warnings } : {}),
+      ...asOfResponse(asOf.value),
       errors,
       cost: estimateFanoutCost(q, collections),
     };

--- a/src/routes/memory/model.ts
+++ b/src/routes/memory/model.ts
@@ -41,6 +41,7 @@ export const MorningTapeQuery = t.Object({
 export const MemoryFanoutQuery = t.Object({
   q: t.Optional(t.String()),
   limit: t.Optional(t.String()),
+  asOf: t.Optional(t.String()),
 });
 
 export const MemoryTiersQuery = t.Object({

--- a/src/routes/search/asof.ts
+++ b/src/routes/search/asof.ts
@@ -3,6 +3,7 @@ export const AS_OF_SUPPORTED_ENDPOINTS = [
   '/api/list',
   '/api/vector/search',
   '/api/ask',
+  '/api/memory/fanout',
   '/api/memory/recall',
   '/api/memory/search',
 ] as const;

--- a/tests/eval/phase1-entity-golden-baseline.test.ts
+++ b/tests/eval/phase1-entity-golden-baseline.test.ts
@@ -55,11 +55,11 @@ beforeAll(async () => {
   ({ entityKey } = await import('../../src/search/entity-ranking.ts'));
   const { createApiVersionedFetch } = await import('../../src/middleware/api-version.ts');
   const { createMemoryFanoutEndpoint } = await import('../../src/routes/memory/fanout.ts');
-  fanoutFetch = createApiVersionedFetch((req) => new Elysia({ prefix: '/api' }).use(createMemoryFanoutEndpoint({
+  fanoutFetch = createApiVersionedFetch(createTenantFetch((req) => new Elysia({ prefix: '/api' }).use(createMemoryFanoutEndpoint({
     models: () => ({ eval: { collection: 'eval', model: 'eval' } }),
     confidenceWeight: 0,
     connect: async () => ({ query: async (q) => fanoutResult(q) }),
-  })).handle(req));
+  })).handle(req)));
   seed();
 });
 
@@ -91,21 +91,19 @@ describe('Phase 1 entity golden eval baseline', () => {
     expect(ids(await fanout(q))).toEqual([item.plain, item.linked]);
   });
 
-  test('tenant isolation blocks cross-tenant entity matches in search and ask; fanout currently has no tenant guard', async () => {
+  test('tenant isolation blocks cross-tenant entity matches in search, ask, and fanout', async () => {
     const q = `${cases.tenant.entity} ${cases.tenant.anchor}`;
     expect(ids(await search(q))).toEqual([cases.tenant.plain]);
     expect((await askJson(q)).citations.map((item) => item.id)).toEqual([cases.tenant.plain]);
-    expect(ids(await fanout(q))).toEqual([cases.tenant.linked, cases.tenant.plain]);
+    expect(ids(await fanout(q))).toEqual([cases.tenant.plain]);
   });
 
-  test('asOf filters stale entity matches in search and ask; fanout currently returns stale vector hits', async () => {
+  test('asOf filters stale entity matches in search, ask, and fanout', async () => {
     const q = `${cases.stale.entity} ${cases.stale.anchor}`;
     const asOf = '2026-01-01T00:00:00.000Z';
     expect(ids(await search(q, `&asOf=${encodeURIComponent(asOf)}`))).toEqual([cases.stale.current]);
     expect((await askJson(q, { asOf })).citations.map((item) => item.id)).toEqual([cases.stale.current]);
-    const body = await fanout(q);
-    expect(ids(body)).toEqual([cases.stale.old, cases.stale.current]);
-    expect(body.warnings?.[0]).toContain(cases.stale.current);
+    expect(ids(await fanout(q, `&asOf=${encodeURIComponent(asOf)}`))).toEqual([cases.stale.current]);
   });
 
   test('entity-only sidecar hits do not appear unless the document is already a retrieval candidate', async () => {
@@ -169,8 +167,10 @@ async function askJson(q: string, extra: Record<string, unknown> = {}): Promise<
   return res.json();
 }
 
-async function fanout(q: string): Promise<FanoutBody> {
-  const res = await fanoutFetch(new Request(`http://local/api/v1/memory/fanout?q=${encodeURIComponent(q)}&limit=5`));
+async function fanout(q: string, suffix = ''): Promise<FanoutBody> {
+  const res = await fanoutFetch(new Request(`http://local/api/v1/memory/fanout?q=${encodeURIComponent(q)}&limit=5${suffix}`, {
+    headers: { [tenantHeader]: tenantA },
+  }));
   expect(res.status).toBe(200);
   return res.json();
 }

--- a/tests/http/memory/fanout-filters.test.ts
+++ b/tests/http/memory/fanout-filters.test.ts
@@ -1,0 +1,102 @@
+import { afterAll, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { inArray } from 'drizzle-orm';
+import { db, oracleDocuments } from '../../../src/db/index.ts';
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
+import { createMemoryFanoutEndpoint } from '../../../src/routes/memory/fanout.ts';
+import type { EmbeddingModelConfig } from '../../../src/vector/factory.ts';
+import type { VectorQueryResult } from '../../../src/vector/types.ts';
+
+const touchedIds: string[] = [];
+const models: Record<string, EmbeddingModelConfig> = {
+  eval: { collection: 'eval_docs', model: 'eval-embed' },
+};
+
+afterAll(() => {
+  if (touchedIds.length) db.delete(oracleDocuments).where(inArray(oracleDocuments.id, touchedIds)).run();
+});
+
+function insertDoc(input: {
+  id: string; tenantId?: string; validTime?: number; supersededBy?: string; supersededAt?: number;
+}) {
+  touchedIds.push(input.id);
+  const now = Date.parse('2026-07-05T00:00:00.000Z');
+  db.insert(oracleDocuments).values({
+    id: input.id,
+    tenantId: input.tenantId ?? 'tenant-a',
+    type: 'learning',
+    sourceFile: `fanout/${input.id}.md`,
+    concepts: '[]',
+    createdAt: now,
+    updatedAt: now,
+    indexedAt: now,
+    validTime: input.validTime,
+    supersededBy: input.supersededBy,
+    supersededAt: input.supersededAt,
+  }).run();
+}
+
+function vectorResult(ids: string[]): VectorQueryResult {
+  return {
+    ids,
+    documents: ids.map((id) => `${id} fanout fixture`),
+    distances: ids.map((_, index) => index * 0.1),
+    metadatas: ids.map((id) => ({ type: 'memory', source_file: `fanout/${id}.md` })),
+  };
+}
+
+function createFetch(result: VectorQueryResult) {
+  const wheres: Array<Record<string, unknown> | undefined> = [];
+  const app = new Elysia({ prefix: '/api' }).use(createMemoryFanoutEndpoint({
+    models: () => models,
+    confidenceWeight: 0,
+    connect: async () => ({
+      query: async (_q, _limit, where) => {
+        wheres.push(where);
+        return result;
+      },
+    }),
+  }));
+  return { fetcher: createApiVersionedFetch(createTenantFetch((request) => app.handle(request))), wheres };
+}
+
+async function bodyFor(fetcher: (request: Request) => Promise<Response>, url: string) {
+  const response = await fetcher(new Request(url, { headers: { [TENANT_HEADER]: 'tenant-a' } }));
+  expect(response.status).toBe(200);
+  return response.json() as Promise<Record<string, any>>;
+}
+
+test('fanout applies tenant isolation before fusion', async () => {
+  const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const keep = `tenant-keep-${stamp}`;
+  const leak = `tenant-leak-${stamp}`;
+  insertDoc({ id: keep, tenantId: 'tenant-a' });
+  insertDoc({ id: leak, tenantId: 'tenant-b' });
+
+  const { fetcher, wheres } = createFetch(vectorResult([leak, keep]));
+  const body = await bodyFor(fetcher, 'http://local/api/v1/memory/fanout?q=tenant&limit=5');
+
+  expect(body.results.map((item: { id: string }) => item.id)).toEqual([keep]);
+  expect(wheres).toEqual([{ tenant_id: 'tenant-a' }]);
+});
+
+test('fanout applies asOf stale filtering before fusion', async () => {
+  const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const old = `stale-old-${stamp}`;
+  const current = `stale-current-${stamp}`;
+  insertDoc({
+    id: old,
+    validTime: Date.parse('2024-01-01T00:00:00.000Z'),
+    supersededBy: current,
+    supersededAt: Date.parse('2025-01-01T00:00:00.000Z'),
+  });
+  insertDoc({ id: current, validTime: Date.parse('2025-01-01T00:00:00.000Z') });
+
+  const { fetcher } = createFetch(vectorResult([old, current]));
+  const asOf = encodeURIComponent('2026-01-01T00:00:00.000Z');
+  const body = await bodyFor(fetcher, `http://local/api/v1/memory/fanout?q=stale&limit=5&asOf=${asOf}`);
+
+  expect(body.results.map((item: { id: string }) => item.id)).toEqual([current]);
+  expect(body.asOfSupportedEndpoints).toContain('/api/memory/fanout');
+});


### PR DESCRIPTION
## Summary
- Added `asOf` support to `/api/memory/fanout` and advertised it in the shared asOf endpoint list.
- Applied tenant metadata filtering to vector queries and an authoritative `oracle_documents` tenant/asOf filter before RRF fusion.
- Updated Phase 1 eval fixtures so tenant + stale/asOf dimensions now flip for fanout without moving exact/alias/bigram/entity-only baselines.

## Root cause
- `/api/search` enters the tenant-aware path at `src/routes/search/search.ts:67` and falls back to `filterResultsAsOf` at `src/routes/search/search.ts:69-75`.
- That tenant path enforces `d.tenant_id = ?` plus the bitemporal clause in `src/routes/search/tenant-search.ts:34-57`.
- `/api/ask` uses the same `handleTenantSearch` + `filterResultsAsOf` discipline at `src/routes/ask/index.ts:65-77`.
- `/api/memory/fanout` previously called `store.query(q, limit)` and fused candidates directly; the fix is now at `src/routes/memory/fanout.ts:131-159` with the DB-backed filter in `src/routes/memory/fanout-filter.ts:18-48`.

## Verification
- `bunx tsc --noEmit`
- `bun test tests/eval/ tests/http/memory/` — 61 pass / 0 fail
- `git diff --check`
- Changed files are all ≤250 lines

Fixes #2724
