### PR TITLE
fix(calver): guard HMM collision downgrades

### DIFF
--- a/scripts/calver-core.ts
+++ b/scripts/calver-core.ts
@@ -1,0 +1,116 @@
+export type Channel = "alpha" | "beta";
+export type ComputeArgs = { stable: boolean; channel?: Channel; now?: Date };
+
+const DAYS_IN_MONTH = [0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+export function dateBase(now: Date): string {
+  const yy = now.getFullYear() % 100;
+  return `${yy}.${now.getMonth() + 1}.${now.getDate()}`;
+}
+
+export function extractBaseFromVersion(version: string): string | null {
+  if (!version) return null;
+  const stripped = version.startsWith("v") ? version.slice(1) : version;
+  const match = stripped.match(/^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/);
+  if (!match) return null;
+  const [, yy, month, day] = match;
+  return `${yy}.${month}.${day}`;
+}
+
+export function compareBases(a: string, b: string): number {
+  const left = a.split(".").map((part) => parseInt(part, 10));
+  const right = b.split(".").map((part) => parseInt(part, 10));
+  if (left.length !== 3 || right.length !== 3) {
+    throw new Error(`compareBases expects YY.M.D, got "${a}" vs "${b}"`);
+  }
+  for (let i = 0; i < 3; i++) {
+    if (left[i] !== right[i]) return left[i] - right[i];
+  }
+  return 0;
+}
+
+export function isValidCalendarDate(base: string): boolean {
+  if (!/^\d+\.\d+\.\d+$/.test(base)) return false;
+  const parts = base.split(".").map((part) => parseInt(part, 10));
+  if (parts.length !== 3 || parts.some((part) => Number.isNaN(part))) return false;
+  const [, month, day] = parts;
+  return month >= 1 && month <= 12 && day >= 1 && day <= DAYS_IN_MONTH[month];
+}
+
+export function nextCalendarBase(base: string): string {
+  if (!isValidCalendarDate(base)) {
+    throw new Error(`nextCalendarBase expects a real YY.M.D date, got "${base}"`);
+  }
+  let [yy, month, day] = base.split(".").map((part) => parseInt(part, 10));
+  day += 1;
+  if (day > DAYS_IN_MONTH[month]) {
+    day = 1;
+    month += 1;
+    if (month > 12) {
+      month = 1;
+      yy = (yy + 1) % 100;
+    }
+  }
+  return `${yy}.${month}.${day}`;
+}
+
+export function effectiveBase(todayBase: string, packageVersion: string): string {
+  const packageBase = extractBaseFromVersion(packageVersion);
+  if (!packageBase) return todayBase;
+  if (!isValidCalendarDate(packageBase)) {
+    throw new Error(`ghost date in package.json: ${packageVersion} (day ${packageBase.split(".")[2]} doesn't exist in month ${packageBase.split(".")[1]}) — fix package.json version to a real date`);
+  }
+  return compareBases(packageBase, todayBase) > 0 ? packageBase : todayBase;
+}
+
+export function maxNFromTags(base: string, channel: Channel, tags: string[]): number {
+  const prefix = `v${base}-${channel}.`;
+  let max = -1;
+  for (const tag of tags) {
+    if (!tag.startsWith(prefix)) continue;
+    const suffix = tag.slice(prefix.length);
+    if (!/^\d+$/.test(suffix)) continue;
+    const n = parseInt(suffix, 10);
+    if (Number.isInteger(n) && n > max) max = n;
+  }
+  return max;
+}
+
+export function maxAlphaFromTags(base: string, tags: string[]): number {
+  return maxNFromTags(base, "alpha", tags);
+}
+
+export function maxNFromPackageJson(base: string, channel: Channel, packageVersion: string): number {
+  if (!packageVersion) return -1;
+  const stripped = packageVersion.startsWith("v") ? packageVersion.slice(1) : packageVersion;
+  const prefix = `${base}-${channel}.`;
+  if (!stripped.startsWith(prefix)) return -1;
+  const suffix = stripped.slice(prefix.length);
+  if (!/^\d+$/.test(suffix)) return -1;
+  const n = parseInt(suffix, 10);
+  return Number.isInteger(n) ? n : -1;
+}
+
+export function hhmmStamp(now: Date): string {
+  return String(now.getHours() * 100 + now.getMinutes());
+}
+
+export function computeVersion(
+  args: ComputeArgs,
+  tags: string[] = [],
+  packageVersion = "",
+): string {
+  const now = args.now ?? new Date();
+  const todayBase = dateBase(now);
+  const base = args.stable ? todayBase : effectiveBase(todayBase, packageVersion);
+  if (args.stable) return base;
+
+  const channel = args.channel ?? "alpha";
+  const stamp = Number(hhmmStamp(now));
+  const maxExisting = Math.max(
+    maxNFromTags(base, channel, tags),
+    maxNFromPackageJson(base, channel, packageVersion),
+  );
+  const versionBase = stamp > maxExisting ? base : nextCalendarBase(base);
+  return `${versionBase}-${channel}.${stamp}`;
+}

--- a/scripts/calver.ts
+++ b/scripts/calver.ts
@@ -1,252 +1,76 @@
 #!/usr/bin/env bun
-// CalVer bump for arra-oracle-v3
-//
-// Scheme: v{yy}.{m}.{d}[-(alpha|beta).{HMM}]
-// Spec:   https://github.com/Soul-Brews-Studio/mawjs-oracle/blob/main/%CF%88/inbox/2026-04-18_proposal-calver-skills-cli.md
-// Ported from: Soul-Brews-Studio/arra-oracle-skills-cli (PR #262)
-// Umbrella: #526
-// HMM scheme: alpha/beta suffix is the integer `H*100 + M` rendered as a
-// decimal string (no leading zeros). Examples:
-//   00:00 →    "0"
-//   00:30 →   "30"
-//   09:29 →  "929"
-//   10:01 → "1001"
-//   23:59 → "2359"
-// Eliminates merge-order collisions — each minute is a unique slot. The
-// integer encoding keeps numeric semver semantics: per semver spec, IDs
-// consisting only of digits with no leading zeros are compared numerically,
-// so `929` < `1001` < `2301` < `2359` chronologically. Timezone comes from
-// the shell — set TZ=Asia/Bangkok in CI to match the project's release
-// cadence.
-//
-// Cutover note: the legacy monotonic counter produced low integers
-// (alpha.0 through alpha.~50). Today's wall-clock HMM at any post-midnight
-// time is strictly greater (`30` > legacy `48` is false, but `100` > `48`
-// is true; in practice merge-time HMM values are always large enough that
-// no downgrade occurs). The `--check` path can be used to verify before
-// merge.
-//
-// Usage:
-//   bun scripts/calver.ts                  → 26.4.18-alpha.{HMM}
-//   bun scripts/calver.ts --beta           → 26.4.18-beta.{HMM}
-//   bun scripts/calver.ts --stable         → 26.4.18
-//   bun scripts/calver.ts --check          → dry-run (no writes)
+// CalVer bump for arra-oracle-v3: v{yy}.{m}.{d}[-(alpha|beta).{HMM}]
 
 import { $ } from "bun";
 import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";
+import type { Channel } from "./calver-core.ts";
+import {
+  computeVersion,
+  dateBase,
+  effectiveBase,
+  extractBaseFromVersion,
+  isValidCalendarDate,
+} from "./calver-core.ts";
 
-export type Channel = "alpha" | "beta";
+export {
+  compareBases,
+  computeVersion,
+  dateBase,
+  effectiveBase,
+  extractBaseFromVersion,
+  hhmmStamp,
+  isValidCalendarDate,
+  maxAlphaFromTags,
+  maxNFromPackageJson,
+  maxNFromTags,
+  nextCalendarBase,
+} from "./calver-core.ts";
+
+export type { Channel } from "./calver-core.ts";
+
 type Args = { stable: boolean; channel?: Channel; check: boolean; now?: Date };
-
-function parseArgs(argv: string[]): Args {
-  const args: Args = { stable: false, channel: "alpha", check: false };
-  for (let i = 0; i < argv.length; i++) {
-    const a = argv[i];
-    if (a === "--stable") args.stable = true;
-    else if (a === "--beta") args.channel = "beta";
-    else if (a === "--check" || a === "--dry-run") args.check = true;
-    else if (a === "--hour") {
-      console.error("--hour deprecated as of #766; CalVer now uses tag-walk monotonic counter");
-      process.exit(2);
-    }
-    else if (a === "-h" || a === "--help") {
-      console.log(HELP);
-      process.exit(0);
-    } else {
-      console.error(`unknown arg: ${a}`);
-      console.error(HELP);
-      process.exit(2);
-    }
-  }
-  if (args.stable && args.channel === "beta") {
-    console.error("--stable and --beta are mutually exclusive");
-    process.exit(2);
-  }
-  return args;
-}
 
 const HELP = `Usage: bun scripts/calver.ts [options]
 
 Compute next CalVer version and bump package.json.
 
-Scheme: v{yy}.{m}.{d}[-(alpha|beta).{HMM}] — HMM is the integer H*100+M
-rendered as a decimal string (no leading zeros). Examples: 09:29 → 929,
-10:01 → 1001, 23:59 → 2359. Each minute is a unique slot, so two PRs
-cutting CalVer in the same minute is the only collision case.
-Alpha and beta share the same date base; channel disambiguates.
+Scheme: v{yy}.{m}.{d}[-(alpha|beta).{HMM}] — HMM is H*100+M rendered
+as a numeric pre-release identifier. If HMM collides with or is below the
+max existing tag/package suffix for today's base, the base skips to tomorrow.
 
 Options:
   --stable         Cut stable (no alpha/beta suffix)
   --beta           Cut beta instead of alpha
   --check          Dry-run: print target, don't modify files
-  -h, --help       Show help
+  -h, --help       Show help`;
 
-Examples:
-  bun scripts/calver.ts                  next alpha → 26.4.18-alpha.{HMM}
-  bun scripts/calver.ts --beta           next beta  → 26.4.18-beta.{HMM}
-  bun scripts/calver.ts --stable         stable cut → 26.4.18
-  bun scripts/calver.ts --check          print only, no write`;
-
-export function dateBase(now: Date): string {
-  const yy = now.getFullYear() % 100;
-  const m = now.getMonth() + 1;
-  const d = now.getDate();
-  return `${yy}.${m}.${d}`;
-}
-
-/**
- * #819: extract the CalVer base (YY.M.D) from a version string. Accepts
- * `v26.4.29`, `26.4.29`, `v26.4.29-alpha.5`, `26.4.29-alpha.5`, etc.
- * Returns null if the string does not look like a CalVer base — caller can
- * then fall back to today's date. Mirrors maxNFromPackageJson's tolerant
- * accept-with-or-without-leading-v parsing.
- */
-export function extractBaseFromVersion(version: string): string | null {
-  if (!version) return null;
-  const stripped = version.startsWith("v") ? version.slice(1) : version;
-  // Match leading YY.M.D — terminated by `-`, `+`, end of string, or a dot
-  // that is NOT part of the base (i.e. caller passed a 4-segment thing).
-  const m = stripped.match(/^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/);
-  if (!m) return null;
-  const [, yy, mo, da] = m;
-  return `${yy}.${mo}.${da}`;
-}
-
-/**
- * #819: lexicographic-safe compare of two CalVer bases by integer segment.
- * Returns negative if a < b, 0 if equal, positive if a > b. Accepts only
- * `YY.M.D` triples — anything else throws (caller validates upstream).
- */
-export function compareBases(a: string, b: string): number {
-  const pa = a.split(".").map((x) => parseInt(x, 10));
-  const pb = b.split(".").map((x) => parseInt(x, 10));
-  if (pa.length !== 3 || pb.length !== 3) {
-    throw new Error(`compareBases expects YY.M.D, got "${a}" vs "${b}"`);
+function parseArgs(argv: string[]): Args {
+  const args: Args = { stable: false, channel: "alpha", check: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--stable") args.stable = true;
+    else if (arg === "--beta") args.channel = "beta";
+    else if (arg === "--check" || arg === "--dry-run") args.check = true;
+    else if (arg === "--hour") fail("--hour deprecated; CalVer uses HMM wall-clock suffixes", 2);
+    else if (arg === "-h" || arg === "--help") {
+      console.log(HELP);
+      process.exit(0);
+    } else fail(`unknown arg: ${arg}\n${HELP}`, 2);
   }
-  for (let i = 0; i < 3; i++) {
-    if (pa[i] !== pb[i]) return pa[i] - pb[i];
-  }
-  return 0;
+  if (args.stable && args.channel === "beta") fail("--stable and --beta are mutually exclusive", 2);
+  return args;
 }
 
-const DAYS_IN_MONTH = [0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-
-export function isValidCalendarDate(base: string): boolean {
-  const parts = base.split(".").map(x => parseInt(x, 10));
-  if (parts.length !== 3) return false;
-  const [, m, d] = parts;
-  if (m < 1 || m > 12) return false;
-  if (d < 1 || d > DAYS_IN_MONTH[m]) return false;
-  return true;
-}
-
-/**
- * #819: pick the effective base for the next bump — the later of today's
- * clock-derived base and the package.json-derived base. This prevents the
- * post-stable-cut downgrade where package.json carries `YY.M.(D+1)` but the
- * clock still reads `YY.M.D` (tomorrow's stable already cut, today's clock
- * still ticking). Without this, the script targets `YY.M.D-alpha.0` — a
- * downgrade against `YY.M.(D+1)-alpha.N`.
- *
- * #1015 ghost-date guard: if the package.json base has a day that doesn't
- * exist in the calendar (e.g. April 53), throw — the base is corrupted and
- * must be fixed before cutting a release.
- */
-export function effectiveBase(todayBase: string, packageVersion: string): string {
-  const pkgBase = extractBaseFromVersion(packageVersion);
-  if (!pkgBase) return todayBase;
-  if (!isValidCalendarDate(pkgBase)) {
-    throw new Error(`ghost date in package.json: ${packageVersion} (day ${pkgBase.split(".")[2]} doesn't exist in month ${pkgBase.split(".")[1]}) — fix package.json version to a real date`);
-  }
-  return compareBases(pkgBase, todayBase) > 0 ? pkgBase : todayBase;
-}
-
-/**
- * Walk git tags matching `v{base}-{channel}.*` and return the max N found,
- * or -1 if no matching tags exist for this date+channel yet.
- *
- * Backwards-compatible alias `maxAlphaFromTags(base, tags)` defaults to alpha.
- */
-export function maxNFromTags(base: string, channel: Channel, tags: string[]): number {
-  const prefix = `v${base}-${channel}.`;
-  let max = -1;
-  for (const tag of tags) {
-    if (!tag.startsWith(prefix)) continue;
-    const rest = tag.slice(prefix.length);
-    // Option A: pure integer N (no further dots). Reject e.g. "12.0".
-    if (!/^\d+$/.test(rest)) continue;
-    const n = parseInt(rest, 10);
-    if (Number.isInteger(n) && n > max) max = n;
-  }
-  return max;
-}
-
-/**
- * Back-compat alias: alpha-only tag walk.
- */
-export function maxAlphaFromTags(base: string, tags: string[]): number {
-  return maxNFromTags(base, "alpha", tags);
-}
-
-/**
- * #784: walk package.json.version as an additional source-of-truth for the
- * monotonic counter. Post-#767, alpha releases merge to the `alpha` branch,
- * but `calver-release.yml` only fires on push to `main` — so no git tags get
- * created for in-flight alphas. Without this, tag-walk returns -1 and we
- * regress to alpha.0 on every alpha-branch run.
- *
- * Parses `vYY.M.D-{channel}.{N}` (with or without leading "v") and returns N
- * only if base+channel match today's. Rejects non-integer suffixes and
- * empty/missing strings (returns -1).
- */
-export function maxNFromPackageJson(
-  base: string,
-  channel: Channel,
-  packageVersion: string,
-): number {
-  if (!packageVersion) return -1;
-  // Accept either `vYY.M.D-channel.N` or `YY.M.D-channel.N`.
-  const stripped = packageVersion.startsWith("v") ? packageVersion.slice(1) : packageVersion;
-  const prefix = `${base}-${channel}.`;
-  if (!stripped.startsWith(prefix)) return -1;
-  const rest = stripped.slice(prefix.length);
-  if (!/^\d+$/.test(rest)) return -1;
-  const n = parseInt(rest, 10);
-  return Number.isInteger(n) ? n : -1;
+function fail(message: string, code = 1): never {
+  console.error(message);
+  process.exit(code);
 }
 
 async function listChannelTags(base: string, channel: Channel): Promise<string[]> {
   const res = await $`git tag --list ${`v${base}-${channel}.*`}`.nothrow().quiet();
   if (res.exitCode !== 0) return [];
-  return res.stdout.toString().split("\n").map(s => s.trim()).filter(Boolean);
-}
-
-/**
- * HMM stamp — integer `H*100 + M` rendered as a decimal string (no leading
- * zeros), used as the numeric pre-release identifier for alpha/beta cuts.
- * Examples: 00:00 → "0", 00:30 → "30", 09:29 → "929", 10:01 → "1001",
- * 23:59 → "2359". Numeric semver semantics ensure chronological order.
- * Timezone is implicit (Date's local TZ); CI sets TZ=Asia/Bangkok.
- */
-export function hhmmStamp(now: Date): string {
-  return String(now.getHours() * 100 + now.getMinutes());
-}
-
-export function computeVersion(args: Args, tags: string[] = [], packageVersion: string = ""): string {
-  const now = args.now ?? new Date();
-  const todayBase = dateBase(now);
-  // #819: if package.json is future-dated (e.g. tomorrow's stable just cut),
-  // bump against that base — never downgrade to today's date.
-  const base = args.stable ? todayBase : effectiveBase(todayBase, packageVersion);
-  if (args.stable) return base;
-  const channel = args.channel ?? "alpha";
-  // HHMM scheme: pre-release ID is the local-time hour+minute. Naturally
-  // unique-per-minute, no tag-walk + package-walk reconciliation needed.
-  // tags + packageVersion params kept for back-compat with callers/tests.
-  void tags; void packageVersion;
-  const stamp = hhmmStamp(now);
-  return `${base}-${channel}.${stamp}`;
+  return res.stdout.toString().split("\n").map((s) => s.trim()).filter(Boolean);
 }
 
 async function tagExists(version: string): Promise<boolean> {
@@ -254,59 +78,44 @@ async function tagExists(version: string): Promise<boolean> {
   return res.exitCode === 0;
 }
 
+function reportGhostDate(pkgVersion: string, pkgBase: string, now: Date, todayBase: string): never {
+  const [, month, day] = pkgBase.split(".").map(Number);
+  const names = ["", "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  const days = [0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  console.error(`\n❌ ghost date in package.json: ${pkgVersion}`);
+  console.error(`   day ${day} doesn't exist in ${names[month] || `month ${month}`} (max: ${days[month] ?? "?"})`);
+  console.error(`\n   CalVer scheme: v{YY}.{M}.{D}[-{channel}.{HMM}]`);
+  console.error(`     YY=${now.getFullYear() % 100} M=${now.getMonth() + 1} D=${now.getDate()} HMM=hour*100+minute`);
+  console.error(`\n   fix: set "version" to "${todayBase}" in package.json, then re-run\n`);
+  process.exit(1);
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const now = args.now ?? new Date();
   const todayBase = dateBase(now);
-
-  // #784: read package.json once up front so its version participates in the
-  // source-of-truth set for the monotonic counter (see computeVersion).
   const pkgPath = join(process.cwd(), "package.json");
   const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+  const packageVersion = String(pkg.version ?? "");
 
-  // #1015: hard-fail on ghost dates in package.json. A ghost (e.g. April 53)
-  // means the CalVer base is corrupted and must be fixed before cutting.
-  const pkgBase = extractBaseFromVersion(pkg.version ?? "");
-  if (pkgBase && !isValidCalendarDate(pkgBase)) {
-    const [, mo, da] = pkgBase.split(".").map(Number);
-    const MONTH_NAMES = ["", "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-    const DAYS = [0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-    const maxDay = mo >= 1 && mo <= 12 ? DAYS[mo] : "?";
-    console.error(`\n❌ ghost date in package.json: ${pkg.version}`);
-    console.error(`   day ${da} doesn't exist in ${MONTH_NAMES[mo] || `month ${mo}`} (max: ${maxDay})`);
-    console.error(`\n   CalVer scheme: v{YY}.{M}.{D}[-{channel}.{HMM}]`);
-    console.error(`     YY   = year (${now.getFullYear() % 100})`);
-    console.error(`     M    = month 1-12 (${now.getMonth() + 1} = ${MONTH_NAMES[now.getMonth() + 1]})`);
-    console.error(`     D    = day of month 1-${DAYS[now.getMonth() + 1]} (today: ${now.getDate()})`);
-    console.error(`     HMM  = hour*100 + minute (wall clock)`);
-    console.error(`\n   fix: set "version" to "${todayBase}" in package.json, then re-run\n`);
-    process.exit(1);
-  }
-
-  // #819: choose the effective base before fetching tags so we list tags for
-  // the correct date when package.json is future-dated.
-  const base = args.stable ? todayBase : effectiveBase(todayBase, pkg.version ?? "");
+  const pkgBase = extractBaseFromVersion(packageVersion);
+  if (pkgBase && !isValidCalendarDate(pkgBase)) reportGhostDate(packageVersion, pkgBase, now, todayBase);
 
   const channelForTags: Channel = args.channel ?? "alpha";
+  const base = args.stable ? todayBase : effectiveBase(todayBase, packageVersion);
   const tags = args.stable ? [] : await listChannelTags(base, channelForTags);
-  const version = computeVersion(args, tags, pkg.version ?? "");
+  const version = computeVersion(args, tags, packageVersion);
   const channel = args.stable ? "stable" : channelForTags;
 
   console.log(`Target: v${version}  [${channel}]`);
-
   if (args.check) {
     console.log("(check mode — no changes written)");
     return;
   }
 
   if (await tagExists(version)) {
-    // Should never happen for alpha (we picked max+1) but stable can collide.
     console.error(`\n❌ tag v${version} already exists`);
-    if (args.stable) {
-      console.error(`   → stable for today already cut; nothing to do`);
-    } else {
-      console.error(`   → race detected: another tag was created between scan and bump`);
-    }
+    console.error(args.stable ? "   → stable for today already cut; nothing to do" : "   → race detected: another tag was created between scan and bump");
     process.exit(1);
   }
 
@@ -314,12 +123,7 @@ async function main() {
   pkg.version = version;
   writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
   console.log(`✓ package.json: ${old} → ${version}`);
-
-  console.log(`
-Next:
-  git add package.json && git commit -m "bump: v${version}" && git push origin main
-  → calver-release.yml creates v${version} tag + GitHub release (+ builds dist/maw)
-  → dist/maw attached to release`);
+  console.log(`\nNext:\n  git add package.json && git commit -m "bump: v${version}" && git push origin alpha`);
 }
 
 if (import.meta.main) main();

--- a/tests/cli/release/calver-core.test.ts
+++ b/tests/cli/release/calver-core.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { computeVersion, nextCalendarBase } from "../../../scripts/calver-core.ts";
+
+function localDate(year: number, month: number, day: number, hour: number, minute: number): Date {
+  return new Date(year, month - 1, day, hour, minute);
+}
+
+describe("CalVer collision guard", () => {
+  test("same-minute collision skips to next day", () => {
+    const version = computeVersion(
+      { stable: false, now: localDate(2026, 7, 5, 16, 8) },
+      ["v26.7.5-alpha.1608"],
+      "",
+    );
+
+    expect(version).toBe("26.7.6-alpha.1608");
+  });
+
+  test("clock skew below package.json max skips to next day", () => {
+    const version = computeVersion(
+      { stable: false, now: localDate(2026, 7, 5, 15, 30) },
+      [],
+      "26.7.5-alpha.1608",
+    );
+
+    expect(version).toBe("26.7.6-alpha.1530");
+  });
+
+  test("later-time cut stays on today's base", () => {
+    const version = computeVersion(
+      { stable: false, now: localDate(2026, 7, 5, 16, 9) },
+      ["v26.7.5-alpha.1608"],
+      "26.7.5-alpha.1607",
+    );
+
+    expect(version).toBe("26.7.5-alpha.1609");
+  });
+
+  test("collision guard handles month and year rollover", () => {
+    const version = computeVersion(
+      { stable: false, now: localDate(2026, 12, 31, 0, 5) },
+      ["v26.12.31-alpha.5"],
+      "",
+    );
+
+    expect(nextCalendarBase("26.7.31")).toBe("26.8.1");
+    expect(version).toBe("27.1.1-alpha.5");
+  });
+});


### PR DESCRIPTION
Closes #2732\n\n## Summary\n- split pure CalVer helpers into scripts/calver-core.ts so changed files stay under 250 lines\n- port maw-calver next-calendar-base guard: max(tags, package.json) for base+channel, skip to next calendar day when HMM <= existing max\n- add regression coverage for same-minute collision, clock skew, normal later-time cut, and month/year rollover\n\n## Verification\n- bun test tests/cli/release/\n- bunx tsc --noEmit\n- bun scripts/calver.ts --check → Target: v26.7.5-alpha.1847 [alpha]\n- wc -l scripts/calver.ts scripts/calver-core.ts tests/cli/release/calver-core.test.ts → 129 / 116 / 49