### PR TITLE
test: restore README claim env after docs smoke

### DIFF
--- a/tests/docs/readme-claims.test.ts
+++ b/tests/docs/readme-claims.test.ts
@@ -9,6 +9,13 @@ const repoRoot = process.cwd();
 const readme = readFileSync('README.md', 'utf8');
 const apiDoc = readFileSync('docs/API.md', 'utf8');
 const architectureDoc = readFileSync('docs/architecture.md', 'utf8');
+const envKeys = [
+  'ARRA_PLUGIN_HOT_RELOAD', 'NODE_ENV', 'ORACLE_DATA_DIR', 'ORACLE_DB_PATH',
+  'ORACLE_EMBEDDER', 'ORACLE_FILE_WATCHER', 'ORACLE_GATEWAY_HOT_RELOAD',
+  'ORACLE_REPO_ROOT', 'ORACLE_TOOL_GROUPS_HOT_RELOAD',
+  'ORACLE_VECTOR_HEALTH_TIMEOUT', 'VECTOR_URL',
+] as const;
+const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
 let scratch = '';
 let closeDb: (() => void) | undefined;
 let fetchClaim: ((request: Request) => Promise<Response> | Response) | undefined;
@@ -81,6 +88,7 @@ beforeAll(async () => {
 afterAll(() => {
   closeDb?.();
   if (scratch) rmSync(scratch, { recursive: true, force: true });
+  for (const key of envKeys) restoreEnv(key, originalEnv[key]);
 });
 
 describe('README/docs advertised claims', () => {
@@ -226,4 +234,9 @@ function emptyRuntime() {
     servers: [],
     pluginRegistry: () => [],
   } as any;
+}
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
 }


### PR DESCRIPTION
## Summary
- Restores every env var mutated by `tests/docs/readme-claims.test.ts` after its smoke app finishes.
- Fixes the cross-suite leak where `ORACLE_GATEWAY_HOT_RELOAD=0` disabled gateway route mounting for later OpenAPI completeness checks.
- Also prevents removed scratch `ORACLE_DATA_DIR`/`ORACLE_DB_PATH`/`ORACLE_REPO_ROOT` values from leaking into later HTTP server-spawn tests.

## Root cause
`readme-claims.test.ts` set process-wide env for its isolated docs smoke app but only removed the scratch dir. In combined runs, `openapi-completeness.test.ts` inherited `ORACLE_GATEWAY_HOT_RELOAD=0`, so `gatewayPlugin()` returned a no-op app and `/api/gateway/status` was absent from the generated spec.

## Validation
- `bun test tests/docs/readme-claims.test.ts tests/http/swagger/openapi-completeness.test.ts`
- `bun test tests/docs/ tests/http/swagger/openapi-completeness.test.ts`
- `bun test tests/http/ tests/workers/ tests/eval/ tests/frontend/ tests/docs/` → 1502/0
- `bun test tests/http/swagger/openapi-completeness.test.ts`
- `bunx tsc --noEmit`
- `wc -l tests/docs/readme-claims.test.ts` → 242

Fixes #2731
