### PR TITLE
test: add bge-m3 drift benchmark harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "test:huginn": "bun test src/huginn/__tests__/capture.test.ts src/huginn/__tests__/sweep.test.ts",
     "huginn:sweep": "bun scripts/huginn-sweep.ts",
     "bench": "bun run benchmarks/run-all.ts",
+    "bench:bge-m3-drift": "bun scripts/bge-m3-drift-benchmark.ts",
     "export": "bun src/cli/commands/export.ts",
     "cloudflare:mcp:dev": "wrangler dev --config workers/mcp/wrangler.jsonc",
     "cloudflare:mcp:deploy": "wrangler deploy --config workers/mcp/wrangler.jsonc",

--- a/scripts/bge-m3-drift-benchmark.ts
+++ b/scripts/bge-m3-drift-benchmark.ts
@@ -1,0 +1,40 @@
+import { CloudflareAIEmbeddings } from '../src/vector/adapters/cloudflare-vectorize.ts';
+import { OllamaEmbeddings } from '../src/vector/embeddings.ts';
+import { runBgeM3DriftBenchmark, type BenchmarkConfig } from '../src/vector/drift-benchmark.ts';
+
+const config: BenchmarkConfig = {
+  dbPath: process.env.BGE_DRIFT_DB_PATH || process.env.ORACLE_DB_PATH,
+  repoRoot: process.env.BGE_DRIFT_REPO_ROOT || process.env.ORACLE_REPO_ROOT || process.cwd(),
+  reportDir: process.env.BGE_DRIFT_REPORT_DIR,
+  sampleSize: intEnv('BGE_DRIFT_SAMPLE_SIZE', 100),
+  queryCount: intEnv('BGE_DRIFT_QUERY_COUNT', 8),
+  topK: intEnv('BGE_DRIFT_TOP_K', 10),
+  queries: process.env.BGE_DRIFT_QUERIES?.split(/\n|\|\|/),
+};
+
+const local = new OllamaEmbeddings({
+  model: process.env.BGE_DRIFT_LOCAL_MODEL || 'bge-m3',
+  baseUrl: process.env.OLLAMA_BASE_URL || process.env.OLLAMA_HOST,
+});
+const cloudflare = hasCloudflareSecrets() ? new CloudflareAIEmbeddings({
+  model: '@cf/baai/bge-m3',
+  accountId: process.env.CLOUDFLARE_ACCOUNT_ID || process.env.ACCOUNT_ID,
+  apiToken: process.env.CLOUDFLARE_API_TOKEN,
+}) : undefined;
+const result = await runBgeM3DriftBenchmark(config, { local, cloudflare });
+console.log(`status=${result.status}`);
+console.log(`docs=${result.docs.length} queries=${result.queries.length}`);
+if (result.metrics) {
+  console.log(`meanDrift=${result.metrics.meanDrift} p95Drift=${result.metrics.p95Drift} overlap=${result.metrics.avgTopKOverlap} verdict=${result.metrics.verdict}`);
+} else {
+  console.log('cloudflare=skipped (missing CLOUDFLARE_ACCOUNT_ID/CLOUDFLARE_API_TOKEN; blocked on #2680)');
+}
+console.log(`report=${result.reportPath}`);
+
+function hasCloudflareSecrets(): boolean {
+  return Boolean((process.env.CLOUDFLARE_ACCOUNT_ID?.trim() || process.env.ACCOUNT_ID?.trim()) && process.env.CLOUDFLARE_API_TOKEN?.trim());
+}
+function intEnv(name: string, fallback: number): number {
+  const parsed = Number.parseInt(process.env[name] ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}

--- a/src/vector/drift-benchmark.ts
+++ b/src/vector/drift-benchmark.ts
@@ -1,0 +1,204 @@
+import { Database } from 'bun:sqlite';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { EmbeddingProvider } from './types.ts';
+
+export type DriftDoc = { id: string; text: string; sourceFile: string; language: 'thai' | 'other' };
+export type DriftQuery = { id: string; text: string };
+export type BenchmarkConfig = {
+  dbPath?: string;
+  repoRoot?: string;
+  sampleSize?: number;
+  queryCount?: number;
+  topK?: number;
+  reportDir?: string;
+  now?: Date;
+  queries?: string[];
+};
+export type ProviderBundle = { local: EmbeddingProvider; cloudflare?: EmbeddingProvider };
+export type DriftMetrics = {
+  docCount: number;
+  queryCount: number;
+  topK: number;
+  meanCosine: number;
+  meanDrift: number;
+  p95Drift: number;
+  avgTopKOverlap: number;
+  verdict: 'warn-mode-ok' | 'separate-collection';
+  queryOverlaps: Array<{ query: string; overlap: number; localTop: string[]; cloudflareTop: string[] }>;
+};
+export type BenchmarkResult = {
+  docs: DriftDoc[];
+  queries: DriftQuery[];
+  local: { provider: string; dimensions: number; embedded: number };
+  cloudflare?: { provider: string; dimensions: number; embedded: number };
+  metrics?: DriftMetrics;
+  reportPath: string;
+  status: 'measured' | 'local-only';
+};
+
+const DEFAULT_SAMPLE = 100;
+const DEFAULT_QUERIES = 8;
+const DEFAULT_TOP_K = 10;
+const DRIFT_THRESHOLD = 0.05;
+const THAI_RE = /[\u0E00-\u0E7F]/;
+
+type Embeddings = { docs: number[][]; queries: number[][] };
+
+export async function runBgeM3DriftBenchmark(config: BenchmarkConfig, providers: ProviderBundle): Promise<BenchmarkResult> {
+  const sampleSize = positive(config.sampleSize, DEFAULT_SAMPLE);
+  const queryCount = positive(config.queryCount, DEFAULT_QUERIES);
+  const topK = positive(config.topK, DEFAULT_TOP_K);
+  const now = config.now ?? new Date();
+  const docs = loadBenchmarkDocs(config, sampleSize);
+  if (docs.length === 0) throw new Error('No benchmark documents found in SQLite corpus or repo markdown fallback');
+  const queries = buildQueries(docs, config.queries, queryCount);
+  const local = await embedAll(providers.local, docs, queries);
+  let cloudflare: Embeddings | undefined;
+  if (providers.cloudflare) cloudflare = await embedAll(providers.cloudflare, docs, queries);
+  const metrics = cloudflare ? computeDriftMetrics(docs, queries, local, cloudflare, topK) : undefined;
+  const result: BenchmarkResult = {
+    docs,
+    queries,
+    local: { provider: providers.local.name, dimensions: providers.local.dimensions, embedded: local.docs.length },
+    ...(cloudflare && providers.cloudflare ? {
+      cloudflare: { provider: providers.cloudflare.name, dimensions: providers.cloudflare.dimensions, embedded: cloudflare.docs.length },
+      metrics,
+      status: 'measured' as const,
+    } : { status: 'local-only' as const }),
+    reportPath: '',
+  };
+  result.reportPath = writeReport(config.reportDir ?? defaultReportDir(config.repoRoot), now, result);
+  return result;
+}
+
+export function loadBenchmarkDocs(config: BenchmarkConfig, sampleSize = DEFAULT_SAMPLE): DriftDoc[] {
+  const fromDb = readSqliteDocs(config.dbPath).slice(0, sampleSize * 4);
+  const candidates = fromDb.length ? fromDb : readMarkdownDocs(config.repoRoot ?? process.cwd(), sampleSize * 4);
+  return mixedSample(candidates, sampleSize);
+}
+
+export function computeDriftMetrics(docs: DriftDoc[], queries: DriftQuery[], local: Embeddings, cf: Embeddings, topK = DEFAULT_TOP_K): DriftMetrics {
+  assertAligned(local.docs, cf.docs, docs.length, 'document');
+  assertAligned(local.queries, cf.queries, queries.length, 'query');
+  const cosines = docs.map((_, i) => cosine(local.docs[i], cf.docs[i]));
+  const drifts = cosines.map((value) => 1 - value).sort((a, b) => a - b);
+  const queryOverlaps = queries.map((query, i) => {
+    const localTop = rankDocs(docs, local.docs, local.queries[i], topK);
+    const cloudflareTop = rankDocs(docs, cf.docs, cf.queries[i], topK);
+    return { query: query.text, overlap: overlap(localTop, cloudflareTop), localTop, cloudflareTop };
+  });
+  const p95Drift = percentile(drifts, 0.95);
+  return {
+    docCount: docs.length,
+    queryCount: queries.length,
+    topK,
+    meanCosine: round(mean(cosines)),
+    meanDrift: round(mean(drifts)),
+    p95Drift: round(p95Drift),
+    avgTopKOverlap: round(mean(queryOverlaps.map((item) => item.overlap))),
+    verdict: decideCompatibility(mean(drifts), p95Drift),
+    queryOverlaps,
+  };
+}
+
+export function decideCompatibility(meanDrift: number, p95Drift: number): DriftMetrics['verdict'] {
+  return meanDrift < DRIFT_THRESHOLD && p95Drift < DRIFT_THRESHOLD ? 'warn-mode-ok' : 'separate-collection';
+}
+
+export function buildQueries(docs: DriftDoc[], explicit: string[] | undefined, queryCount = DEFAULT_QUERIES): DriftQuery[] {
+  const texts = (explicit?.map((item) => item.trim()).filter(Boolean) ?? []).slice(0, queryCount);
+  if (texts.length) return texts.map((text, i) => ({ id: `query-${i + 1}`, text }));
+  return evenly(docs, Math.min(queryCount, docs.length)).map((doc, i) => ({ id: `query-${i + 1}`, text: queryFrom(doc.text) }));
+}
+
+function readSqliteDocs(dbPath?: string): DriftDoc[] {
+  const file = dbPath || process.env.ORACLE_DB_PATH;
+  if (!file || !fs.existsSync(file)) return [];
+  const db = new Database(file, { readonly: true });
+  try {
+    const rows = db.query(`
+      SELECT d.id, d.source_file AS sourceFile, f.content
+      FROM oracle_documents d JOIN oracle_fts f ON f.id = d.id
+      WHERE COALESCE(d.superseded_by, '') = '' AND LENGTH(f.content) >= 40
+      ORDER BY d.indexed_at DESC, d.id ASC LIMIT 1000
+    `).all() as Array<{ id: string; sourceFile: string; content: string }>;
+    return rows.map((row) => doc(row.id, row.content, row.sourceFile));
+  } catch { return []; }
+  finally { db.close(); }
+}
+
+function readMarkdownDocs(repoRoot: string, limit: number): DriftDoc[] {
+  const starts = ['ψ/memory', 'ψ/learn', 'docs', 'README.md'].map((item) => path.join(repoRoot, item));
+  const docs: DriftDoc[] = [];
+  const stack = starts.filter((item) => fs.existsSync(item));
+  while (stack.length && docs.length < limit) {
+    const current = stack.shift()!;
+    const stat = fs.statSync(current);
+    if (stat.isDirectory()) {
+      for (const name of fs.readdirSync(current).sort()) stack.push(path.join(current, name));
+      continue;
+    }
+    if (!current.endsWith('.md')) continue;
+    const text = fs.readFileSync(current, 'utf8').replace(/---[\s\S]*?---/, '').trim();
+    if (text.length >= 40) docs.push(doc(path.relative(repoRoot, current), text, path.relative(repoRoot, current)));
+  }
+  return docs;
+}
+
+function mixedSample(candidates: DriftDoc[], size: number): DriftDoc[] {
+  const thai = candidates.filter((item) => item.language === 'thai');
+  const other = candidates.filter((item) => item.language !== 'thai');
+  const targetThai = Math.min(thai.length, Math.ceil(size / 2));
+  const picked = [...evenly(thai, targetThai), ...evenly(other, size - targetThai)];
+  return picked.length >= size ? picked.slice(0, size) : [...picked, ...evenly(candidates.filter((item) => !picked.includes(item)), size - picked.length)];
+}
+
+async function embedAll(provider: EmbeddingProvider, docs: DriftDoc[], queries: DriftQuery[]): Promise<Embeddings> {
+  return { docs: await provider.embed(docs.map((item) => item.text), 'passage'), queries: await provider.embed(queries.map((item) => item.text), 'query') };
+}
+
+function writeReport(dir: string, now: Date, result: BenchmarkResult): string {
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `${now.toISOString().slice(0, 10)}_bge-m3-cf-local-drift.md`);
+  fs.writeFileSync(file, reportMarkdown(now, result));
+  return file;
+}
+
+function reportMarkdown(now: Date, result: BenchmarkResult): string {
+  const m = result.metrics;
+  const lines = [
+    '---', 'title: bge-m3 CF Workers AI vs local Ollama drift benchmark', 'tags: [benchmark, bge-m3, cloudflare-ai, ollama]', `created: ${now.toISOString()}`, '---', '',
+    '# bge-m3 drift benchmark — CF Workers AI vs local Ollama', '',
+    'Decision rule: if mean and p95 cosine drift are both `<0.05`, local/CF mismatch may run with `ORACLE_VECTOR_IDENTITY_MISMATCH=warn`; if either is `>=0.05`, keep a separate collection and do not mix vectors.', '',
+    `Status: **${result.status}**`,
+    `Corpus: ${result.docs.length} docs (${result.docs.filter((doc) => doc.language === 'thai').length} Thai / ${result.docs.filter((doc) => doc.language !== 'thai').length} other), ${result.queries.length} queries`,
+    `Local: ${result.local.provider}, ${result.local.dimensions} dims, embedded ${result.local.embedded} docs`,
+  ];
+  if (!m) lines.push('', 'Cloudflare side skipped: missing `CLOUDFLARE_ACCOUNT_ID`/`ACCOUNT_ID` and/or `CLOUDFLARE_API_TOKEN` (#2680). Do not create a token in this harness run. Verdict: **pending; keep collections separate until measured**.');
+  else lines.push(
+    `Cloudflare: ${result.cloudflare?.provider}, ${result.cloudflare?.dimensions} dims, embedded ${result.cloudflare?.embedded} docs`, '',
+    '| Metric | Value |', '| --- | ---: |',
+    `| mean cosine | ${m.meanCosine} |`, `| mean drift | ${m.meanDrift} |`, `| p95 drift | ${m.p95Drift} |`, `| avg top-${m.topK} overlap | ${m.avgTopKOverlap} |`,
+    `| verdict | ${m.verdict} |`, '',
+    '| Query | overlap | local top | CF top |', '| --- | ---: | --- | --- |',
+    ...m.queryOverlaps.map((q) => `| ${escapePipe(q.query)} | ${q.overlap} | ${q.localTop.slice(0, 3).join(', ')} | ${q.cloudflareTop.slice(0, 3).join(', ')} |`),
+  );
+  return `${lines.join('\n')}\n`;
+}
+
+function rankDocs(docs: DriftDoc[], vectors: number[][], query: number[], topK: number): string[] {
+  return docs.map((doc, i) => ({ id: doc.id, score: cosine(vectors[i], query) })).sort((a, b) => b.score - a.score || a.id.localeCompare(b.id)).slice(0, topK).map((item) => item.id);
+}
+function doc(id: string, text: string, sourceFile: string): DriftDoc { return { id, text: text.slice(0, 3000), sourceFile, language: THAI_RE.test(text) ? 'thai' : 'other' }; }
+function queryFrom(text: string): string { return text.replace(/[#*_`>\-[\]()]/g, ' ').replace(/\s+/g, ' ').trim().split(' ').slice(0, 10).join(' '); }
+function evenly<T>(items: T[], count: number): T[] { if (count <= 0 || items.length === 0) return []; return Array.from({ length: Math.min(count, items.length) }, (_, i) => items[Math.floor(i * items.length / Math.min(count, items.length))]); }
+function overlap(a: string[], b: string[]): number { const set = new Set(a); return round(b.filter((id) => set.has(id)).length / Math.max(1, Math.min(a.length, b.length))); }
+function cosine(a: number[], b: number[]): number { const n = Math.min(a.length, b.length); let dot = 0, aa = 0, bb = 0; for (let i = 0; i < n; i++) { dot += a[i] * b[i]; aa += a[i] ** 2; bb += b[i] ** 2; } return aa && bb ? dot / (Math.sqrt(aa) * Math.sqrt(bb)) : 0; }
+function assertAligned(a: unknown[], b: unknown[], expected: number, label: string): void { if (a.length !== expected || b.length !== expected) throw new Error(`Mismatched ${label} embeddings: local=${a.length}, cloudflare=${b.length}, expected=${expected}`); }
+function percentile(sorted: number[], p: number): number { return sorted[Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * p) - 1))] ?? 0; }
+function mean(values: number[]): number { return values.reduce((sum, value) => sum + value, 0) / Math.max(1, values.length); }
+function round(value: number): number { return Math.round(value * 10000) / 10000; }
+function positive(value: number | undefined, fallback: number): number { return Number.isFinite(value ?? NaN) && (value as number) > 0 ? Math.floor(value as number) : fallback; }
+function defaultReportDir(repoRoot = process.env.ORACLE_REPO_ROOT || process.cwd()): string { return path.join(repoRoot, 'ψ', 'memory', 'learnings'); }
+function escapePipe(value: string): string { return value.replace(/\|/g, '\\|').slice(0, 80); }

--- a/tests/vector/bge-m3-drift-benchmark.test.ts
+++ b/tests/vector/bge-m3-drift-benchmark.test.ts
@@ -1,0 +1,88 @@
+import { Database } from 'bun:sqlite';
+import { afterEach, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { decideCompatibility, loadBenchmarkDocs, runBgeM3DriftBenchmark, type DriftDoc } from '../../src/vector/drift-benchmark.ts';
+import type { EmbeddingProvider, EmbedType } from '../../src/vector/types.ts';
+
+const scratch: string[] = [];
+afterEach(() => { for (const dir of scratch.splice(0)) fs.rmSync(dir, { recursive: true, force: true }); });
+
+describe('bge-m3 drift benchmark harness', () => {
+  test('samples a mixed real corpus from SQLite before filesystem fallback', () => {
+    const dir = temp();
+    const dbPath = path.join(dir, 'oracle.db');
+    const db = new Database(dbPath);
+    db.exec('CREATE TABLE oracle_documents (id TEXT, source_file TEXT, superseded_by TEXT, indexed_at INTEGER); CREATE TABLE oracle_fts (id TEXT, content TEXT)');
+    for (let i = 0; i < 6; i++) insertDoc(db, `en-${i}`, `English deployment memory ${i} has enough text for benchmark sampling.`);
+    for (let i = 0; i < 4; i++) insertDoc(db, `th-${i}`, `บันทึกภาษาไทย ${i} สำหรับทดสอบ benchmark ของ bge m3 และ cosine drift`);
+    db.close();
+    const docs = loadBenchmarkDocs({ dbPath }, 6);
+    expect(docs).toHaveLength(6);
+    expect(docs.some((doc) => doc.language === 'thai')).toBe(true);
+    expect(docs.some((doc) => doc.language === 'other')).toBe(true);
+  });
+
+  test('runs local side and writes a pending report when Cloudflare secrets are absent', async () => {
+    const dir = temp();
+    fs.mkdirSync(path.join(dir, 'docs'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'docs', 'a.md'), '# A\n\nAlpha memory benchmark content for local embeddings.');
+    fs.writeFileSync(path.join(dir, 'docs', 'b.md'), '# B\n\nบันทึกภาษาไทยสำหรับ benchmark และ local embeddings');
+    const local = new FakeEmbedder('ollama', 4);
+    const result = await runBgeM3DriftBenchmark({ repoRoot: dir, sampleSize: 2, reportDir: path.join(dir, 'ψ/memory/learnings') }, { local });
+    expect(result.status).toBe('local-only');
+    expect(local.calls.map((call) => call.type)).toEqual(['passage', 'query']);
+    const report = fs.readFileSync(result.reportPath, 'utf8');
+    expect(report).toContain('Decision rule:');
+    expect(report).toContain('Cloudflare side skipped');
+  });
+
+  test('computes drift decision and ranking overlap for measured providers', async () => {
+    const dir = temp();
+    writeDocs(dir);
+    const local = new FakeEmbedder('ollama', 4);
+    const closeCf = new FakeEmbedder('cloudflare-ai', 4, 0.001);
+    const close = await runBgeM3DriftBenchmark({ repoRoot: dir, sampleSize: 3, queryCount: 2, topK: 2, reportDir: dir }, { local, cloudflare: closeCf });
+    expect(close.metrics?.verdict).toBe('warn-mode-ok');
+    expect(close.metrics?.avgTopKOverlap).toBeGreaterThan(0);
+    const farCf = new RotatedEmbedder();
+    const far = await runBgeM3DriftBenchmark({ repoRoot: dir, sampleSize: 3, queryCount: 2, topK: 2, reportDir: dir }, { local, cloudflare: farCf });
+    expect(far.metrics?.verdict).toBe('separate-collection');
+    expect(decideCompatibility(0.049, 0.05)).toBe('separate-collection');
+  });
+});
+
+class FakeEmbedder implements EmbeddingProvider {
+  calls: Array<{ count: number; type?: EmbedType }> = [];
+  constructor(readonly name: string, readonly dimensions: number, private skew = 0) {}
+  async embed(texts: string[], type?: EmbedType): Promise<number[][]> {
+    this.calls.push({ count: texts.length, type });
+    return texts.map((text) => vectorFor(text, this.dimensions, this.skew));
+  }
+}
+
+class RotatedEmbedder extends FakeEmbedder {
+  constructor() { super('cloudflare-ai', 4); }
+  async embed(texts: string[], type?: EmbedType): Promise<number[][]> {
+    this.calls.push({ count: texts.length, type });
+    return texts.map((text) => {
+      const v = vectorFor(text, 4, 0);
+      return [-v[1], v[0], -v[3], v[2]];
+    });
+  }
+}
+
+function vectorFor(text: string, dims: number, skew: number): number[] {
+  const out = Array.from({ length: dims }, (_, i) => ((text.charCodeAt(i % text.length) % 17) + 1) / 20 + skew);
+  return out;
+}
+function writeDocs(dir: string) {
+  fs.mkdirSync(path.join(dir, 'docs'), { recursive: true });
+  ['alpha deployment runbook', 'beta memory search notes', 'gamma cloudflare vector test'].forEach((text, i) => fs.writeFileSync(path.join(dir, 'docs', `${i}.md`), `# ${i}\n\n${text} with enough benchmark text.`));
+}
+function insertDoc(db: Database, id: string, content: string) {
+  db.prepare('INSERT INTO oracle_documents VALUES (?, ?, NULL, ?)').run(id, `ψ/memory/learnings/${id}.md`, Date.now());
+  db.prepare('INSERT INTO oracle_fts VALUES (?, ?)').run(id, content);
+}
+function temp(): string { const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bge-drift-')); scratch.push(dir); return dir; }


### PR DESCRIPTION
## Summary
- Adds a one-command bge-m3 drift benchmark harness: `bun run bench:bge-m3-drift`.
- Samples ~100 corpus docs from SQLite `oracle_documents`/`oracle_fts`, with repo Markdown fallback, and balances Thai/other docs when available.
- Embeds local Ollama `bge-m3` now; Cloudflare Workers AI `@cf/baai/bge-m3` runs only when `CLOUDFLARE_API_TOKEN` plus `CLOUDFLARE_ACCOUNT_ID`/`ACCOUNT_ID` are present, so no token is created in this PR.
- Writes a Markdown report to `ψ/memory/learnings/` and encodes the decision rule: mean+p95 cosine drift `<0.05` => warn-mode allowed; otherwise separate collection.

## Validation
- `bun test tests/vector/bge-m3-drift-benchmark.test.ts`
- `bun test tests/vector/`
- `bunx tsc --noEmit`
- file sizes: source 204, script 40, test 88, package 147 lines

Refs #2736
