### PR TITLE
feat: export psi vault as OKF bundle

### DIFF
--- a/bin/arra.ts
+++ b/bin/arra.ts
@@ -9,11 +9,13 @@ Usage:
   arra-oracle [serve] [options]
   arra-oracle mcp [--read-only]
   arra-oracle mine <dir> [--watch]
+  arra-oracle okf export [--out <dir>] [--source <vault-root>]
 
 Commands:
   serve        Run the HTTP server (default)
   mcp          Run the stdio MCP server
   mine         Ingest a folder into Oracle memory
+  okf          Export ψ vault as an OKF v0.1 bundle
 
 Serve options:
   --port <n>    Port to listen on (default: 47778, env: ORACLE_PORT)
@@ -26,6 +28,11 @@ Once running, open the UI with: bunx oracle-studio`);
 if (command === "mine") {
   const { mineCommand } = await import("../src/cli/mine.ts");
   process.exit(await mineCommand(args.slice(1)));
+}
+
+if (command === "okf") {
+  const { okfCommand } = await import("../src/cli/okf/index.ts");
+  process.exit(await okfCommand(args.slice(1)));
 }
 
 if (args.includes("--help") || args.includes("-h")) {

--- a/src/cli/okf/command.ts
+++ b/src/cli/okf/command.ts
@@ -1,0 +1,126 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { ORACLE_DATA_DIR, REPO_ROOT } from '../../config.ts';
+import { stringifyMarkdown } from './frontmatter.ts';
+import { generateIndexes } from './index-gen.ts';
+import { rewriteWikilinks } from './links.ts';
+import { mapToOkf, type OkfDocument, type SourceDocument } from './mapper.ts';
+
+export interface OkfExportOptions {
+  sourceDir?: string;
+  outDir?: string;
+}
+
+export interface OkfExportResult {
+  sourceDir: string;
+  outDir: string;
+  documents: number;
+}
+
+export function okfHelp(): string {
+  return [
+    'Usage: arra-oracle okf export [--out <dir>] [--source <vault-root>]',
+    'Export a ψ vault as an Open Knowledge Format v0.1 bundle.',
+    '',
+    `Defaults: --source ${path.join(REPO_ROOT, 'ψ')}`,
+    `          --out ${path.join(ORACLE_DATA_DIR, 'exports', 'okf')}`,
+  ].join('\n');
+}
+
+export function parseOkfArgs(args: string[]): { help: boolean; export?: OkfExportOptions } {
+  if (args.includes('--help') || args.includes('-h')) return { help: true };
+  if (args[0] !== 'export') throw new Error('okf requires subcommand: export');
+  const options: OkfExportOptions = {};
+  for (let i = 1; i < args.length; i += 1) {
+    const arg = args[i]!;
+    if (arg === '--out' || arg === '--source') {
+      const value = args[++i]?.trim();
+      if (!value) throw new Error(`${arg} requires a path`);
+      if (arg === '--out') options.outDir = value;
+      else options.sourceDir = value;
+    } else if (arg.startsWith('--out=')) options.outDir = requiredInline(arg, '--out=');
+    else if (arg.startsWith('--source=')) options.sourceDir = requiredInline(arg, '--source=');
+    else if (arg.startsWith('-')) throw new Error(`unknown okf option: ${arg}`);
+    else throw new Error(`unexpected okf argument: ${arg}`);
+  }
+  return { help: false, export: options };
+}
+
+export async function okfCommand(args: string[]): Promise<number> {
+  try {
+    const parsed = parseOkfArgs(args);
+    if (parsed.help) {
+      console.log(okfHelp());
+      return 0;
+    }
+    const result = exportOkfBundle(parsed.export ?? {});
+    console.log(`Exported ${result.documents} OKF document${result.documents === 1 ? '' : 's'} to ${result.outDir}`);
+    return 0;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    console.error(okfHelp());
+    return 1;
+  }
+}
+
+export function exportOkfBundle(options: OkfExportOptions = {}): OkfExportResult {
+  const sourceDir = path.resolve(options.sourceDir ?? path.join(REPO_ROOT, 'ψ'));
+  const outDir = path.resolve(options.outDir ?? path.join(ORACLE_DATA_DIR, 'exports', 'okf'));
+  assertDirectory(sourceDir, 'source');
+  assertOutIsOutsideSource(sourceDir, outDir);
+
+  const sourceDocs = collectMarkdown(sourceDir);
+  const docs = sourceDocs.map(mapToOkf);
+  for (const doc of docs) doc.body = rewriteWikilinks(doc.body, docs);
+
+  for (const doc of docs) writeDocument(outDir, doc);
+  generateIndexes(outDir, docs);
+  return { sourceDir, outDir, documents: docs.length };
+}
+
+function collectMarkdown(root: string): SourceDocument[] {
+  const docs: SourceDocument[] = [];
+  walk(root, (absPath) => {
+    const name = path.basename(absPath).toLowerCase();
+    if (!name.endsWith('.md') || name === 'index.md' || name === 'log.md') return;
+    const stat = fs.statSync(absPath);
+    docs.push({
+      relPath: path.relative(root, absPath).split(path.sep).join('/'),
+      content: fs.readFileSync(absPath, 'utf8'),
+      mtimeMs: stat.mtimeMs,
+    });
+  });
+  return docs.sort((a, b) => a.relPath.localeCompare(b.relPath));
+}
+
+function walk(dir: string, onFile: (absPath: string) => void): void {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    const absPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(absPath, onFile);
+    else if (entry.isFile()) onFile(absPath);
+  }
+}
+
+function writeDocument(outDir: string, doc: OkfDocument): void {
+  const target = path.join(outDir, doc.relPath);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, stringifyMarkdown(doc.frontmatter, doc.body), 'utf8');
+}
+
+function assertDirectory(dir: string, label: string): void {
+  if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) throw new Error(`OKF ${label} directory not found: ${dir}`);
+}
+
+function assertOutIsOutsideSource(sourceDir: string, outDir: string): void {
+  const relative = path.relative(sourceDir, outDir);
+  if (!relative || (!relative.startsWith('..') && !path.isAbsolute(relative))) {
+    throw new Error('OKF output directory must be outside the source vault');
+  }
+  fs.mkdirSync(outDir, { recursive: true });
+}
+
+function requiredInline(arg: string, prefix: string): string {
+  const value = arg.slice(prefix.length).trim();
+  if (!value) throw new Error(`${prefix.slice(0, -1)} requires a path`);
+  return value;
+}

--- a/src/cli/okf/frontmatter.ts
+++ b/src/cli/okf/frontmatter.ts
@@ -1,0 +1,119 @@
+export type FrontmatterValue = string | number | boolean | null | FrontmatterValue[];
+export type Frontmatter = Record<string, FrontmatterValue>;
+
+const KEY_RE = /^([A-Za-z0-9_-]+):\s*(.*)$/;
+const ORDER = ['type', 'title', 'description', 'resource', 'tags', 'timestamp'];
+
+export function splitMarkdown(content: string): { frontmatter: Frontmatter; body: string } {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
+  if (!match) return { frontmatter: {}, body: content };
+  return { frontmatter: parseFrontmatter(match[1] ?? ''), body: match[2] ?? '' };
+}
+
+export function stringifyMarkdown(frontmatter: Frontmatter, body: string): string {
+  return `---\n${stringifyFrontmatter(frontmatter)}\n---\n\n${body.replace(/^\n+/, '')}`;
+}
+
+export function parseFrontmatter(yaml: string): Frontmatter {
+  const lines = yaml.split(/\r?\n/);
+  const out: Frontmatter = {};
+  let current: string | null = null;
+
+  for (const line of lines) {
+    const match = line.match(KEY_RE);
+    if (match) {
+      const [, key, raw = ''] = match;
+      current = key;
+      out[key] = raw.trim() === '' ? [] : parseValue(raw.trim());
+      continue;
+    }
+
+    const item = line.match(/^\s*-\s*(.*)$/);
+    if (item && current) {
+      const list = Array.isArray(out[current]) ? out[current] as FrontmatterValue[] : [];
+      list.push(parseValue(item[1]?.trim() ?? ''));
+      out[current] = list;
+      continue;
+    }
+
+    if (current && /^\s+\S/.test(line) && typeof out[current] === 'string') {
+      out[current] = `${out[current]} ${line.trim()}`;
+    }
+  }
+
+  return out;
+}
+
+export function stringifyFrontmatter(frontmatter: Frontmatter): string {
+  const seen = new Set<string>();
+  const keys = [
+    ...ORDER.filter((key) => key in frontmatter),
+    ...Object.keys(frontmatter).filter((key) => !ORDER.includes(key)).sort(),
+  ];
+  const lines: string[] = [];
+  for (const key of keys) {
+    if (seen.has(key)) continue;
+    seen.add(key);
+    lines.push(`${key}: ${stringifyValue(frontmatter[key] ?? null)}`);
+  }
+  return lines.join('\n');
+}
+
+export function stringField(value: FrontmatterValue | undefined): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+export function listField(value: FrontmatterValue | undefined): string[] {
+  if (Array.isArray(value)) return value.map((item) => String(item).trim()).filter(Boolean);
+  if (typeof value !== 'string') return [];
+  const text = value.trim();
+  if (!text) return [];
+  return text.split(',').map((item) => item.trim()).filter(Boolean);
+}
+
+function parseValue(raw: string): FrontmatterValue {
+  if (raw === '' || raw === 'null') return raw === '' ? '' : null;
+  if (raw === 'true' || raw === 'false') return raw === 'true';
+  if (/^-?\d+(?:\.\d+)?$/.test(raw)) return Number(raw);
+  if (raw.startsWith('[') && raw.endsWith(']')) return parseInlineList(raw.slice(1, -1));
+  if ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))) {
+    try { return JSON.parse(raw); } catch { return raw.slice(1, -1); }
+  }
+  return raw;
+}
+
+function parseInlineList(inner: string): FrontmatterValue[] {
+  const values: FrontmatterValue[] = [];
+  let buf = '';
+  let quote: string | null = null;
+  for (let i = 0; i < inner.length; i += 1) {
+    const char = inner[i]!;
+    if ((char === '"' || char === "'") && inner[i - 1] !== '\\') quote = quote === char ? null : quote ?? char;
+    if (char === ',' && !quote) {
+      values.push(parseValue(buf.trim()));
+      buf = '';
+    } else buf += char;
+  }
+  if (buf.trim()) values.push(parseValue(buf.trim()));
+  return values;
+}
+
+function stringifyValue(value: FrontmatterValue): string {
+  if (Array.isArray(value)) return `[${value.map((item) => stringifyArrayItem(item)).join(', ')}]`;
+  if (value === null) return 'null';
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return yamlScalar(String(value));
+}
+
+function stringifyArrayItem(value: FrontmatterValue): string {
+  if (Array.isArray(value)) return JSON.stringify(value);
+  if (value === null) return 'null';
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return yamlScalar(String(value));
+}
+
+function yamlScalar(value: string): string {
+  return /^[A-Za-z0-9_./@+-]+(?: [A-Za-z0-9_./@+-]+)*$/.test(value)
+    ? value
+    : JSON.stringify(value);
+}

--- a/src/cli/okf/index-gen.ts
+++ b/src/cli/okf/index-gen.ts
@@ -1,0 +1,93 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { OkfDocument } from './mapper.ts';
+
+export function generateIndexes(outDir: string, docs: OkfDocument[]): void {
+  const dirs = collectDirs(docs);
+  for (const dir of [...dirs].sort()) writeIndex(outDir, dir, dirs, docs);
+  writeLog(outDir, docs);
+}
+
+function collectDirs(docs: OkfDocument[]): Set<string> {
+  const dirs = new Set<string>(['']);
+  for (const doc of docs) {
+    let dir = path.posix.dirname(doc.relPath);
+    if (dir === '.') dir = '';
+    while (true) {
+      dirs.add(dir);
+      if (!dir) break;
+      const parent = path.posix.dirname(dir);
+      dir = parent === '.' ? '' : parent;
+    }
+  }
+  return dirs;
+}
+
+function writeIndex(outDir: string, dir: string, dirs: Set<string>, docs: OkfDocument[]): void {
+  const childDirs = directChildDirs(dir, dirs);
+  const childDocs = docs.filter((doc) => dirname(doc.relPath) === dir).sort(byTitle);
+  const lines: string[] = [];
+  if (!dir) lines.push('---', 'okf_version: "0.1"', '---', '');
+  lines.push(`# ${dir ? titleize(path.posix.basename(dir)) : 'Contents'}`);
+
+  if (childDirs.length > 0) {
+    lines.push('', '## Subdirectories');
+    for (const child of childDirs) {
+      const summary = summarizeDir(child, docs);
+      lines.push(`* [${titleize(path.posix.basename(child))}](${relativeLink(dir, `${child}/index.md`)}) - ${summary}`);
+    }
+  }
+
+  if (childDocs.length > 0) {
+    lines.push('', '## Documents');
+    for (const doc of childDocs) {
+      lines.push(`* [${doc.title}](${relativeLink(dir, doc.relPath)}) - ${doc.description}`);
+    }
+  }
+
+  const target = path.join(outDir, dir, 'index.md');
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, `${lines.join('\n')}\n`, 'utf8');
+}
+
+function writeLog(outDir: string, docs: OkfDocument[]): void {
+  const groups = new Map<string, OkfDocument[]>();
+  for (const doc of docs) {
+    const day = doc.timestamp.slice(0, 10);
+    groups.set(day, [...(groups.get(day) ?? []), doc]);
+  }
+  const lines = ['# Bundle Update Log'];
+  for (const day of [...groups.keys()].sort().reverse()) {
+    lines.push('', `## ${day}`);
+    for (const doc of (groups.get(day) ?? []).sort(byTitle)) {
+      lines.push(`* **Export**: [${doc.title}](/${doc.relPath}) - ${doc.description}`);
+    }
+  }
+  fs.writeFileSync(path.join(outDir, 'log.md'), `${lines.join('\n')}\n`, 'utf8');
+}
+
+function directChildDirs(parent: string, dirs: Set<string>): string[] {
+  return [...dirs].filter((dir) => dir && dirname(dir) === parent).sort();
+}
+
+function summarizeDir(dir: string, docs: OkfDocument[]): string {
+  const children = docs.filter((doc) => doc.relPath.startsWith(`${dir}/`));
+  return children[0]?.description ?? `${children.length} document${children.length === 1 ? '' : 's'}`;
+}
+
+function relativeLink(fromDir: string, target: string): string {
+  return path.posix.relative(fromDir || '.', target) || path.posix.basename(target);
+}
+
+function dirname(relPath: string): string {
+  const dir = path.posix.dirname(relPath);
+  return dir === '.' ? '' : dir;
+}
+
+function titleize(value: string): string {
+  return value.replace(/[-_]+/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function byTitle(a: OkfDocument, b: OkfDocument): number {
+  return a.title.localeCompare(b.title) || a.relPath.localeCompare(b.relPath);
+}

--- a/src/cli/okf/index.ts
+++ b/src/cli/okf/index.ts
@@ -1,0 +1,1 @@
+export { exportOkfBundle, okfCommand, okfHelp, parseOkfArgs } from './command.ts';

--- a/src/cli/okf/links.ts
+++ b/src/cli/okf/links.ts
@@ -1,0 +1,57 @@
+import path from 'node:path';
+
+export interface LinkTarget {
+  relPath: string;
+}
+
+export function rewriteWikilinks(body: string, targets: LinkTarget[]): string {
+  const resolver = new WikilinkResolver(targets.map((target) => target.relPath));
+  return body.replace(/\[\[([^\]\n]+)\]\]/g, (full, inner: string) => {
+    const [rawTarget, rawLabel] = inner.split('|');
+    const target = rawTarget?.trim() ?? '';
+    const relPath = resolver.resolve(target);
+    if (!relPath) return full;
+    const label = (rawLabel?.trim() || target.split(/[\\/#]/).pop() || target).replace(/\]/g, '\\]');
+    return `[${label}](/${relPath})`;
+  });
+}
+
+class WikilinkResolver {
+  private readonly noExtPaths: string[];
+  private readonly exact = new Map<string, string | null>();
+
+  constructor(private readonly relPaths: string[]) {
+    this.noExtPaths = relPaths.map((rel) => stripMd(rel));
+    for (const rel of relPaths) {
+      this.add(stripMd(rel), rel);
+      this.add(path.posix.basename(rel, '.md'), rel);
+    }
+  }
+
+  resolve(rawTarget: string): string | null {
+    const normalized = normalizeTarget(rawTarget);
+    if (!normalized) return null;
+    const direct = this.exact.get(normalized);
+    if (direct !== undefined) return direct;
+
+    const matches = this.noExtPaths
+      .map((noExt, index) => ({ noExt, rel: this.relPaths[index]! }))
+      .filter(({ noExt }) => noExt === normalized || noExt.endsWith(`/${normalized}`));
+    return matches.length === 1 ? matches[0]!.rel : null;
+  }
+
+  private add(key: string, rel: string): void {
+    if (!key) return;
+    if (this.exact.has(key) && this.exact.get(key) !== rel) this.exact.set(key, null);
+    else this.exact.set(key, rel);
+  }
+}
+
+function normalizeTarget(target: string): string {
+  const withoutHeading = target.split('#')[0] ?? '';
+  return stripMd(withoutHeading.replace(/\\/g, '/').replace(/^\/+/, '').replace(/^\.\//, '').trim());
+}
+
+function stripMd(value: string): string {
+  return value.endsWith('.md') ? value.slice(0, -3) : value;
+}

--- a/src/cli/okf/mapper.ts
+++ b/src/cli/okf/mapper.ts
@@ -1,0 +1,88 @@
+import path from 'node:path';
+import { listField, splitMarkdown, stringField, type Frontmatter } from './frontmatter.ts';
+
+export interface SourceDocument {
+  relPath: string;
+  content: string;
+  mtimeMs: number;
+}
+
+export interface OkfDocument {
+  relPath: string;
+  frontmatter: Frontmatter;
+  body: string;
+  title: string;
+  description: string;
+  timestamp: string;
+}
+
+export function mapToOkf(doc: SourceDocument): OkfDocument {
+  const { frontmatter, body } = splitMarkdown(doc.content);
+  const title = deriveTitle(body, doc.relPath);
+  const description = oneSentence(stringField(frontmatter.pattern) ?? firstParagraph(body) ?? stringField(frontmatter.description) ?? title);
+  const timestamp = deriveTimestamp(frontmatter, doc.mtimeMs);
+  const tags = listField(frontmatter.concepts);
+  const source = stringField(frontmatter.source);
+  const existingResource = stringField(frontmatter.resource);
+
+  const mapped: Frontmatter = {
+    ...frontmatter,
+    type: typeFromPath(doc.relPath),
+    title,
+    description,
+    tags: tags.length > 0 ? tags : listField(frontmatter.tags),
+    timestamp,
+  };
+  if (source || existingResource) mapped.resource = source ?? existingResource!;
+  return { relPath: doc.relPath, frontmatter: mapped, body, title, description, timestamp };
+}
+
+export function typeFromPath(relPath: string): string {
+  const segments = relPath.toLowerCase().split('/');
+  if (segments.includes('learnings')) return 'Learning';
+  if (segments.includes('retrospectives')) return 'Retrospective';
+  if (segments.includes('plans')) return 'Plan';
+  if (segments.includes('handoff') || segments.includes('handoffs')) return 'Handoff';
+  if (segments.includes('inbox')) return 'Message';
+  if (segments.includes('outbox')) return 'Note';
+  return 'Note';
+}
+
+function deriveTitle(body: string, relPath: string): string {
+  const heading = body.match(/^#\s+(.+)$/m)?.[1]?.trim();
+  if (heading) return stripMarkdown(heading);
+  const base = path.posix.basename(relPath, '.md');
+  const withoutDate = base.replace(/^\d{4}-\d{2}-\d{2}[_-]?/, '');
+  const words = (withoutDate || base).replace(/[-_]+/g, ' ').trim();
+  return words ? words.replace(/\b\w/g, (char) => char.toUpperCase()) : 'Untitled';
+}
+
+function firstParagraph(body: string): string | null {
+  for (const block of body.split(/\n\s*\n/)) {
+    const text = block.trim();
+    if (!text || text.startsWith('#') || text.startsWith('```')) continue;
+    return stripMarkdown(text.replace(/\s+/g, ' '));
+  }
+  return null;
+}
+
+function oneSentence(value: string): string {
+  const clean = value.replace(/\s+/g, ' ').trim();
+  const sentence = clean.match(/^(.{20,}?[.!?])\s/)?.[1] ?? clean;
+  return sentence.length <= 200 ? sentence : `${sentence.slice(0, 197).trimEnd()}...`;
+}
+
+function deriveTimestamp(frontmatter: Frontmatter, mtimeMs: number): string {
+  const raw = stringField(frontmatter.date) ?? stringField(frontmatter.timestamp);
+  const parsed = raw ? Date.parse(raw) : NaN;
+  const time = Number.isFinite(parsed) ? parsed : mtimeMs;
+  return new Date(time).toISOString();
+}
+
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/[`*_#>]/g, '')
+    .trim();
+}

--- a/tests/cli/okf/export.test.ts
+++ b/tests/cli/okf/export.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { exportOkfBundle, parseOkfArgs } from '../../../src/cli/okf/index.ts';
+import { splitMarkdown } from '../../../src/cli/okf/frontmatter.ts';
+
+const REPO_ROOT = new URL('../../../', import.meta.url).pathname.replace(/\/$/, '');
+const BIN_ENTRY = path.join(REPO_ROOT, 'bin/arra.ts');
+
+let tempDir = '';
+
+afterEach(() => {
+  if (tempDir && fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true });
+  tempDir = '';
+});
+
+function tmp(): string {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-okf-'));
+  return tempDir;
+}
+
+function writeFixture(root: string): { sourceFile: string; original: string } {
+  const sourceDir = path.join(root, 'ψ');
+  fs.mkdirSync(path.join(sourceDir, 'learnings'), { recursive: true });
+  fs.mkdirSync(path.join(sourceDir, 'plans'), { recursive: true });
+  const original = [
+    '---',
+    'pattern: OKF export keeps vault files read-only while adding bundle metadata.',
+    'date: 2026-07-06',
+    'source: https://example.test/source',
+    'concepts: [okf, vault]',
+    'custom_field: keep-me',
+    '---',
+    '',
+    '# Alpha Learning',
+    '',
+    'See [[beta-plan|the beta plan]] and [[missing-note]].',
+    '',
+  ].join('\n');
+  const sourceFile = path.join(sourceDir, 'learnings', 'alpha.md');
+  fs.writeFileSync(sourceFile, original, 'utf8');
+  fs.writeFileSync(
+    path.join(sourceDir, 'plans', 'beta-plan.md'),
+    '# Beta Plan\n\nFirst paragraph describes the beta plan. Second sentence stays body text.\n',
+    'utf8',
+  );
+  return { sourceFile, original };
+}
+
+describe('OKF export mapping', () => {
+  test('parses export flags and rejects bad input', () => {
+    expect(parseOkfArgs(['export', '--source', 'ψ', '--out=/tmp/out']).export).toEqual({
+      sourceDir: 'ψ',
+      outDir: '/tmp/out',
+    });
+    expect(parseOkfArgs(['--help']).help).toBe(true);
+    expect(() => parseOkfArgs(['export', '--bad'])).toThrow('unknown okf option: --bad');
+    expect(() => parseOkfArgs(['mine'])).toThrow('okf requires subcommand: export');
+  });
+
+  test('exports a fixture vault without touching source files', () => {
+    const root = tmp();
+    const outDir = path.join(root, 'bundle');
+    const { sourceFile, original } = writeFixture(root);
+    const beforeStat = fs.statSync(sourceFile).mtimeMs;
+
+    const result = exportOkfBundle({ sourceDir: path.join(root, 'ψ'), outDir });
+
+    expect(result.documents).toBe(2);
+    expect(fs.readFileSync(sourceFile, 'utf8')).toBe(original);
+    expect(fs.statSync(sourceFile).mtimeMs).toBe(beforeStat);
+
+    const alpha = splitMarkdown(fs.readFileSync(path.join(outDir, 'learnings', 'alpha.md'), 'utf8'));
+    expect(alpha.frontmatter.type).toBe('Learning');
+    expect(alpha.frontmatter.title).toBe('Alpha Learning');
+    expect(alpha.frontmatter.description).toBe('OKF export keeps vault files read-only while adding bundle metadata.');
+    expect(alpha.frontmatter.resource).toBe('https://example.test/source');
+    expect(alpha.frontmatter.tags).toEqual(['okf', 'vault']);
+    expect(alpha.frontmatter.timestamp).toBe('2026-07-06T00:00:00.000Z');
+    expect(alpha.frontmatter.custom_field).toBe('keep-me');
+    expect(alpha.body).toContain('[the beta plan](/plans/beta-plan.md)');
+    expect(alpha.body).toContain('[[missing-note]]');
+
+    const beta = splitMarkdown(fs.readFileSync(path.join(outDir, 'plans', 'beta-plan.md'), 'utf8'));
+    expect(beta.frontmatter.type).toBe('Plan');
+    expect(beta.frontmatter.title).toBe('Beta Plan');
+    expect(beta.frontmatter.description).toBe('First paragraph describes the beta plan.');
+
+    const rootIndex = fs.readFileSync(path.join(outDir, 'index.md'), 'utf8');
+    expect(rootIndex).toContain('okf_version: "0.1"');
+    expect(rootIndex).toContain('[Learnings](learnings/index.md)');
+
+    const log = fs.readFileSync(path.join(outDir, 'log.md'), 'utf8');
+    expect(log).toContain('## 2026-07-06');
+    expect(log).toContain('[Alpha Learning](/learnings/alpha.md)');
+  });
+});
+
+describe('arra okf CLI seam', () => {
+  test('runs okf export through bin/arra.ts', async () => {
+    const root = tmp();
+    const outDir = path.join(root, 'bundle');
+    writeFixture(root);
+    const proc = Bun.spawn(['bun', 'run', BIN_ENTRY, 'okf', 'export', '--source', path.join(root, 'ψ'), '--out', outDir], {
+      cwd: REPO_ROOT,
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: { ...process.env, ORACLE_DATA_DIR: path.join(root, 'data') },
+    });
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(code).toBe(0);
+    expect(stderr).toBe('');
+    expect(stdout).toContain('Exported 2 OKF documents');
+    expect(fs.existsSync(path.join(outDir, 'index.md'))).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #2741\n\n## Summary\n- add `arra-oracle okf export` CLI seam\n- export ψ markdown into OKF v0.1 documents with mapped frontmatter\n- resolve known wikilinks to absolute bundle markdown links\n- generate per-directory `index.md` files and root `log.md`\n\n## Validation\n- `bun test tests/cli/okf/`\n- `bunx tsc --noEmit`\n- `bun test tests/cli/bin/arra.test.ts`\n- changed files ≤250 lines