### PR TITLE
feat: add Streamable HTTP MCP bearer auth route

### DIFF
--- a/src/mcp/http-auth.ts
+++ b/src/mcp/http-auth.ts
@@ -1,0 +1,74 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+import { requireBearerAuth } from '@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js';
+import { InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
+import type { OAuthTokenVerifier } from '@modelcontextprotocol/sdk/server/auth/provider.js';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+
+export const MCP_HTTP_AUTH_SCOPE = 'mcp:streamable-http';
+type Env = Record<string, string | undefined>;
+type AuthResult = { ok: true; authInfo: AuthInfo } | { ok: false; response: Response };
+
+type ExpressRequestShim = { headers: { authorization?: string }; auth?: AuthInfo };
+
+class ExpressResponseShim {
+  readonly headers = new Headers();
+  statusCode = 200;
+  body: unknown = null;
+
+  set(field: string | Record<string, string>, value?: string) {
+    if (typeof field === 'string') this.headers.set(field, value ?? '');
+    else for (const [key, next] of Object.entries(field)) this.headers.set(key, next);
+    return this;
+  }
+
+  status(code: number) {
+    this.statusCode = code;
+    return this;
+  }
+
+  json(body: unknown) {
+    this.body = body;
+    return this;
+  }
+
+  toResponse() {
+    return Response.json(this.body ?? { error: 'invalid_token' }, {
+      status: this.statusCode || 401,
+      headers: this.headers,
+    });
+  }
+}
+
+export function configuredMcpHttpToken(env: Env = process.env): string | null {
+  return env.ORACLE_MCP_HTTP_TOKEN?.trim() || env.ARRA_API_TOKEN?.trim() || null;
+}
+
+export function createStaticMcpBearerVerifier(env: Env = process.env): OAuthTokenVerifier {
+  return {
+    async verifyAccessToken(token: string): Promise<AuthInfo> {
+      const configured = configuredMcpHttpToken(env);
+      if (!configured) throw new InvalidTokenError('MCP HTTP bearer token is not configured');
+      if (!constantTimeTokenEquals(token, configured)) throw new InvalidTokenError('Invalid bearer token');
+      return {
+        token,
+        clientId: 'arra-oracle-mcp-http',
+        scopes: [MCP_HTTP_AUTH_SCOPE],
+        expiresAt: Math.floor(Date.now() / 1000) + 315360000,
+      };
+    },
+  };
+}
+
+export async function requireMcpBearerAuth(request: Request, env: Env = process.env): Promise<AuthResult> {
+  const req: ExpressRequestShim = { headers: { authorization: request.headers.get('authorization') ?? undefined } };
+  const res = new ExpressResponseShim();
+  const middleware = requireBearerAuth({ verifier: createStaticMcpBearerVerifier(env), requiredScopes: [MCP_HTTP_AUTH_SCOPE] });
+  await middleware(req as any, res as any, () => undefined);
+  return req.auth ? { ok: true, authInfo: req.auth } : { ok: false, response: res.toResponse() };
+}
+
+function constantTimeTokenEquals(actual: string, expected: string): boolean {
+  const actualDigest = createHash('sha256').update(actual).digest();
+  const expectedDigest = createHash('sha256').update(expected).digest();
+  return timingSafeEqual(actualDigest, expectedDigest);
+}

--- a/src/mcp/http-policy.ts
+++ b/src/mcp/http-policy.ts
@@ -1,0 +1,37 @@
+import type { ToolGroupConfig } from '../config/tool-groups.ts';
+import type { UnifiedRuntime } from '../plugins/unified-loader.ts';
+import { mcpTools } from '../tools/mcp-manifest.ts';
+import { remoteableMcpRestMap } from '../tools/mcp-rest-map.ts';
+
+const REMOTEABLE_TOOL_NAMES = new Set(remoteableMcpRestMap.map((entry) => entry.name));
+const DISABLED_HTTP_TOOL_NAMES = mcpTools.map((tool) => tool.name).filter((name) => !REMOTEABLE_TOOL_NAMES.has(name));
+
+export function remoteHttpToolGroups(): ToolGroupConfig {
+  return {
+    search: true,
+    knowledge: true,
+    session: true,
+    forum: true,
+    oracle: true,
+    trace: true,
+    standalone: true,
+    disabled_tools: DISABLED_HTTP_TOOL_NAMES,
+  };
+}
+
+export function emptyHttpPluginRuntime(): UnifiedRuntime {
+  return {
+    pluginCount: 0,
+    routes: [],
+    mcpTools: [],
+    menu: [],
+    cliSubcommands: [],
+    servers: [],
+    callMcpTool: async () => { throw new Error('Plugin MCP tools are not exposed over Streamable HTTP'); },
+    pluginStatuses: () => [],
+    pluginRegistry: () => [],
+    init: async () => {},
+    reload: async () => {},
+    stop: async () => {},
+  };
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -46,6 +46,7 @@ export type OracleMCPServerOptions = {
   unifiedRuntime?: McpPluginRuntimeOptions['runtime'];
   unifiedRuntimeRef?: McpPluginRuntimeOptions['runtimeRef'];
   watchPlugins?: McpPluginRuntimeOptions['watch'];
+  installSignalHandlers?: boolean;
 };
 
 export class OracleMCPServer {
@@ -90,9 +91,8 @@ export class OracleMCPServer {
     );
     if (!this.oracleApiBase) this.embeddedReady = this.initEmbedded();
     this.setupHandlers();
-    this.setupErrorHandling();
+    this.setupErrorHandling(options.installSignalHandlers !== false);
   }
-
 
   private applyToolGroupConfig(config: ToolGroupConfig): void {
     this.disabledTools = getDisabledTools(config);
@@ -160,8 +160,9 @@ export class OracleMCPServer {
     }
   }
 
-  private setupErrorHandling(): void {
+  private setupErrorHandling(installSignalHandlers: boolean): void {
     this.server.onerror = (error) => console.error('[MCP Error]', error);
+    if (!installSignalHandlers) return;
     process.on('SIGINT', async () => {
       await this.cleanup();
       process.exit(0);

--- a/src/routes/mcp/index.ts
+++ b/src/routes/mcp/index.ts
@@ -1,1 +1,2 @@
 export { createMcpRoutes } from './tools.ts';
+export { createMcpStreamableRoutes } from './streamable.ts';

--- a/src/routes/mcp/streamable.ts
+++ b/src/routes/mcp/streamable.ts
@@ -1,0 +1,93 @@
+import { Elysia } from 'elysia';
+import { WebStandardStreamableHTTPServerTransport, type WebStandardStreamableHTTPServerTransportOptions } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import { OracleMCPServer } from '../../mcp/server.ts';
+import { requireMcpBearerAuth } from '../../mcp/http-auth.ts';
+import { emptyHttpPluginRuntime, remoteHttpToolGroups } from '../../mcp/http-policy.ts';
+
+type Env = Record<string, string | undefined>;
+type Session = { transport: WebStandardStreamableHTTPServerTransport; oracle: OracleMCPServer };
+export type McpStreamableRoutesOptions = Pick<WebStandardStreamableHTTPServerTransportOptions, 'enableJsonResponse'> & { env?: Env };
+
+export function createMcpStreamableRoutes(options: McpStreamableRoutesOptions = {}) {
+  const manager = new McpHttpSessionManager(options);
+  return new Elysia({ name: 'mcp-streamable-http' }).all('/mcp', ({ request }) => manager.handle(request), {
+    detail: { tags: ['mcp'], menu: { group: 'hidden' }, summary: 'Streamable HTTP MCP endpoint' },
+  });
+}
+
+class McpHttpSessionManager {
+  private readonly sessions = new Map<string, Session>();
+  constructor(private readonly options: McpStreamableRoutesOptions) {}
+
+  async handle(request: Request): Promise<Response> {
+    const auth = await requireMcpBearerAuth(request, this.options.env);
+    if (!auth.ok) return auth.response;
+    const sessionId = request.headers.get('mcp-session-id') ?? undefined;
+    const session = sessionId ? this.sessions.get(sessionId) : undefined;
+    if (session) return session.transport.handleRequest(request, { authInfo: auth.authInfo });
+    if (sessionId) return jsonRpcError(404, -32001, 'Session not found');
+    if (request.method !== 'POST') return jsonRpcError(400, -32000, 'Bad Request: No valid session ID provided');
+    const parsed = await parseJsonRpcBody(request);
+    if (!parsed.ok) return parsed.response;
+    if (!containsInitializeRequest(parsed.body)) return jsonRpcError(400, -32000, 'Bad Request: No valid session ID provided');
+    return this.initialize(request, auth.authInfo, parsed.body);
+  }
+
+  private async initialize(request: Request, authInfo: AuthInfo, parsedBody: unknown): Promise<Response> {
+    let session: Session | undefined;
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: () => crypto.randomUUID(),
+      enableJsonResponse: this.options.enableJsonResponse,
+      onsessioninitialized: (sessionId) => { if (session) this.sessions.set(sessionId, session); },
+      onsessionclosed: (sessionId) => this.releaseSession(sessionId, false),
+    });
+    const oracle = this.createOracleServer();
+    session = { transport, oracle };
+    transport.onclose = () => { if (transport.sessionId) void this.releaseSession(transport.sessionId, false); };
+    try {
+      await (oracle as unknown as { server: { connect: (transport: WebStandardStreamableHTTPServerTransport) => Promise<void> } }).server.connect(transport);
+      return await transport.handleRequest(request, { authInfo, parsedBody });
+    } catch (error) {
+      if (transport.sessionId) await this.releaseSession(transport.sessionId, true);
+      else {
+        await oracle.cleanup();
+        await transport.close().catch(() => {});
+      }
+      console.error('[MCP HTTP Error]', error);
+      return jsonRpcError(500, -32603, 'Internal server error');
+    }
+  }
+
+  private createOracleServer(): OracleMCPServer {
+    const env = this.options.env ?? process.env;
+    return new OracleMCPServer({
+      readOnly: env.ORACLE_READ_ONLY === 'true',
+      toolGroups: remoteHttpToolGroups(),
+      unifiedRuntime: emptyHttpPluginRuntime(),
+      installSignalHandlers: false,
+    });
+  }
+
+  private async releaseSession(sessionId: string, closeTransport: boolean): Promise<void> {
+    const session = this.sessions.get(sessionId);
+    if (!session) return;
+    this.sessions.delete(sessionId);
+    if (closeTransport) await session.transport.close().catch(() => {});
+    await session.oracle.cleanup();
+  }
+}
+
+async function parseJsonRpcBody(request: Request): Promise<{ ok: true; body: unknown } | { ok: false; response: Response }> {
+  try { return { ok: true, body: await request.clone().json() }; }
+  catch { return { ok: false, response: jsonRpcError(400, -32700, 'Parse error: Invalid JSON') }; }
+}
+
+function containsInitializeRequest(body: unknown): boolean {
+  return Array.isArray(body) ? body.some(isInitializeRequest) : isInitializeRequest(body);
+}
+
+function jsonRpcError(status: number, code: number, message: string): Response {
+  return Response.json({ jsonrpc: '2.0', error: { code, message }, id: null }, { status });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -63,7 +63,7 @@ import { sessionsRoutes } from './routes/sessions/index.ts';
 import { oldStudioCompatRoutes } from './routes/compat.ts';
 import { vaultRoutes } from './routes/vault/index.ts';
 import { createMenuRoutes, menuItemsFromUnifiedPlugins } from './routes/menu/index.ts';
-import { createMcpRoutes } from './routes/mcp/index.ts';
+import { createMcpRoutes, createMcpStreamableRoutes } from './routes/mcp/index.ts';
 import { createMetricsLifecycle, metricsRoutes } from './routes/metrics/index.ts';
 import { exportRoutes } from './routes/export/index.ts';
 import { memoryRoutes } from './routes/memory/index.ts';
@@ -136,7 +136,7 @@ export function createApp({ unifiedPlugins, runtimeRef = createUnifiedRuntimeRef
 export function createServerRouteModules(unifiedPlugins: UnifiedRuntime, runtimeRef: UnifiedRuntimeRef<UnifiedRuntime>): RouteModule[] {
   const healthRoutes = createHealthRoutes({ pluginCount: unifiedPlugins.pluginCount, pluginMcpToolCount: unifiedPlugins.mcpTools.length, pluginStatuses: unifiedPlugins.pluginStatuses, isDraining });
   const apiModules = [authRoutes, settingsRoutes, feedRoutes, healthRoutes, dashboardRoutes, searchRoutes, askRoutes, vectorRoutes, vectorConfigApiRoutes, conceptsRoutes, knowledgeRoutes, researchRoutes, verifyRoutes, supersedeRoutes, forumApi, tracesApi, scheduleApi, filesRouter, createPluginsRouter({ registry: () => runtimeRef.current.pluginRegistry(), runtimeRef }), sessionsRoutes, oldStudioCompatRoutes, vaultRoutes, metricsRoutes, exportRoutes, memoryRoutes, canvasRoutes, tenantsRoutes, watcherRoutes, indexerRoutes];
-  return [...apiModules, createMcpRoutes({ runtimeRef }), createMenuRoutes(menuItemsFromUnifiedPlugins(unifiedPlugins.menu))];
+  return [...apiModules, createMcpRoutes({ runtimeRef }), createMcpStreamableRoutes(), createMenuRoutes(menuItemsFromUnifiedPlugins(unifiedPlugins.menu))];
 }
 
 export function mountRouteModules(app: ElysiaApp, modules: RouteModule[]): void {

--- a/tests/mcp/http/streamable-auth.test.ts
+++ b/tests/mcp/http/streamable-auth.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createApp } from '../../../src/server.ts';
+import { createMcpStreamableRoutes } from '../../../src/routes/mcp/index.ts';
+import type { UnifiedRuntime } from '../../../src/plugins/unified-loader.ts';
+
+const originalEnv = {
+  ORACLE_HTTP_URL: process.env.ORACLE_HTTP_URL,
+  ORACLE_MCP_HTTP_TOKEN: process.env.ORACLE_MCP_HTTP_TOKEN,
+  ARRA_API_TOKEN: process.env.ARRA_API_TOKEN,
+};
+
+beforeEach(() => {
+  process.env.ORACLE_HTTP_URL = 'http://127.0.0.1:1';
+  delete process.env.ORACLE_MCP_HTTP_TOKEN;
+  delete process.env.ARRA_API_TOKEN;
+});
+
+afterEach(() => {
+  restoreEnv('ORACLE_HTTP_URL', originalEnv.ORACLE_HTTP_URL);
+  restoreEnv('ORACLE_MCP_HTTP_TOKEN', originalEnv.ORACLE_MCP_HTTP_TOKEN);
+  restoreEnv('ARRA_API_TOKEN', originalEnv.ARRA_API_TOKEN);
+});
+
+describe('Streamable HTTP MCP bearer auth', () => {
+  test('does not require a token for existing /api/health route', async () => {
+    process.env.ORACLE_MCP_HTTP_TOKEN = 'mcp-secret';
+    const app = createApp({ unifiedPlugins: runtime() });
+
+    const res = await app.handle(new Request('http://local/api/health'));
+
+    expect(res.status).toBe(200);
+  });
+
+  test('rejects unauthenticated /mcp requests', async () => {
+    const app = mcpApp({ ORACLE_MCP_HTTP_TOKEN: 'mcp-secret' });
+    const res = await postMcp(app, initializeRequest());
+
+    expect(res.status).toBe(401);
+    expect(res.headers.get('www-authenticate')).toContain('Bearer');
+  });
+
+  test('accepts ORACLE_MCP_HTTP_TOKEN and exposes only remoteable tools', async () => {
+    const app = mcpApp({ ORACLE_MCP_HTTP_TOKEN: 'mcp-secret' });
+    const sessionId = await initialize(app, 'mcp-secret');
+    await notifyInitialized(app, sessionId, 'mcp-secret');
+
+    const res = await postMcp(app, toolsListRequest(), 'mcp-secret', sessionId);
+    const body = await res.json() as any;
+    const names = body.result.tools.map((tool: { name: string }) => tool.name);
+
+    expect(res.status).toBe(200);
+    expect(names).toContain('oracle_search');
+    expect(names).not.toContain('____IMPORTANT');
+    expect(names).not.toContain('oracle_recap');
+    expect(names).not.toContain('oracle_mcp_call');
+  });
+
+  test('falls back to ARRA_API_TOKEN and deletes sessions', async () => {
+    const app = mcpApp({ ARRA_API_TOKEN: 'fallback-secret' });
+    const sessionId = await initialize(app, 'fallback-secret');
+
+    const deleted = await app.handle(new Request('http://local/mcp', {
+      method: 'DELETE',
+      headers: authedHeaders('fallback-secret', sessionId),
+    }));
+    const afterDelete = await postMcp(app, toolsListRequest(), 'fallback-secret', sessionId);
+
+    expect(deleted.status).toBe(200);
+    expect(afterDelete.status).toBe(404);
+  });
+});
+
+function mcpApp(env: Record<string, string>) {
+  return new Elysia().use(createMcpStreamableRoutes({ env, enableJsonResponse: true }));
+}
+
+async function initialize(app: Elysia, token: string): Promise<string> {
+  const res = await postMcp(app, initializeRequest(), token);
+  expect(res.status).toBe(200);
+  const sessionId = res.headers.get('mcp-session-id');
+  expect(sessionId).toBeTruthy();
+  return sessionId!;
+}
+
+async function notifyInitialized(app: Elysia, sessionId: string, token: string) {
+  const res = await postMcp(app, { jsonrpc: '2.0', method: 'notifications/initialized' }, token, sessionId);
+  expect(res.status).toBe(202);
+}
+
+function postMcp(app: Elysia, body: unknown, token?: string, sessionId?: string) {
+  return app.handle(new Request('http://local/mcp', {
+    method: 'POST',
+    headers: token ? authedHeaders(token, sessionId) : { 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+    body: JSON.stringify(body),
+  }));
+}
+
+function authedHeaders(token: string, sessionId?: string): Record<string, string> {
+  return {
+    'content-type': 'application/json',
+    accept: 'application/json, text/event-stream',
+    authorization: `Bearer ${token}`,
+    ...(sessionId ? { 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-11-25' } : {}),
+  };
+}
+
+function initializeRequest() {
+  return {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: { protocolVersion: '2025-11-25', capabilities: {}, clientInfo: { name: 'test', version: '0.0.0' } },
+  };
+}
+
+function toolsListRequest() {
+  return { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} };
+}
+
+function runtime(): UnifiedRuntime {
+  return {
+    pluginCount: 0,
+    routes: [],
+    mcpTools: [],
+    menu: [],
+    cliSubcommands: [],
+    servers: [],
+    callMcpTool: async () => ({}),
+    pluginStatuses: () => [],
+    pluginRegistry: () => [],
+    init: async () => {},
+    reload: async () => {},
+    stop: async () => {},
+  };
+}
+
+function restoreEnv(name: keyof typeof originalEnv, value: string | undefined) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}


### PR DESCRIPTION
## Summary
- mount SDK WebStandard Streamable HTTP transport at root `/mcp` as a route-local Elysia sub-app
- add SDK `requireBearerAuth` glue with `ORACLE_MCP_HTTP_TOKEN` fallback to `ARRA_API_TOKEN`
- keep stdio behavior untouched while disabling per-session SIGINT listeners for HTTP sessions
- restrict remote HTTP MCP tool listing to remoteable core tools and no plugin MCP tools by default
- add regression coverage proving `GET /api/health` still returns 200 without Authorization

## Guardrails
- bearer auth is scoped to `/mcp` only; no global auth middleware
- did not modify `src/middleware/cors.ts`
- did not modify server bind defaults

## Tests
- `bun test tests/mcp/http/streamable-auth.test.ts`
- absolute-path scoped MCP suite: 119 pass / 0 fail
- `bunx tsc --noEmit`
- changed files <= 250 lines

Closes part of #2743 (Phase 1).