### PR TITLE
refactor: extract HTTP MCP server policy

### DIFF
--- a/src/mcp/http-policy.ts
+++ b/src/mcp/http-policy.ts
@@ -1,21 +1,14 @@
-import type { ToolGroupConfig } from '../config/tool-groups.ts';
+import { loadToolGroupConfig, type ToolGroupConfig } from '../config/tool-groups.ts';
 import type { UnifiedRuntime } from '../plugins/unified-loader.ts';
-import { mcpTools } from '../tools/mcp-manifest.ts';
 import { remoteableMcpRestMap } from '../tools/mcp-rest-map.ts';
 
 const REMOTEABLE_TOOL_NAMES = new Set(remoteableMcpRestMap.map((entry) => entry.name));
-const DISABLED_HTTP_TOOL_NAMES = mcpTools.map((tool) => tool.name).filter((name) => !REMOTEABLE_TOOL_NAMES.has(name));
+export const remoteableMcpToolNames = [...REMOTEABLE_TOOL_NAMES];
 
-export function remoteHttpToolGroups(): ToolGroupConfig {
+export function remoteHttpToolGroups(base: ToolGroupConfig = loadToolGroupConfig()): ToolGroupConfig {
   return {
-    search: true,
-    knowledge: true,
-    session: true,
-    forum: true,
-    oracle: true,
-    trace: true,
-    standalone: true,
-    disabled_tools: DISABLED_HTTP_TOOL_NAMES,
+    ...base,
+    enabled_tools: base.enabled_tools?.filter((name) => REMOTEABLE_TOOL_NAMES.has(name)),
   };
 }
 

--- a/src/mcp/http-server.ts
+++ b/src/mcp/http-server.ts
@@ -1,0 +1,22 @@
+import type { ToolGroupConfig } from '../config/tool-groups.ts';
+import { OracleMCPServer } from './server.ts';
+import { emptyHttpPluginRuntime, remoteableMcpToolNames, remoteHttpToolGroups } from './http-policy.ts';
+
+type Env = Record<string, string | undefined>;
+
+export type HttpOracleMcpServerOptions = {
+  env?: Env;
+  readOnly?: boolean;
+  toolGroups?: ToolGroupConfig;
+};
+
+export function createHttpOracleMcpServer(options: HttpOracleMcpServerOptions = {}): OracleMCPServer {
+  const env = options.env ?? process.env;
+  return new OracleMCPServer({
+    readOnly: options.readOnly ?? env.ORACLE_READ_ONLY === 'true',
+    toolGroups: remoteHttpToolGroups(options.toolGroups),
+    toolAllowlist: remoteableMcpToolNames,
+    unifiedRuntime: emptyHttpPluginRuntime(),
+    installSignalHandlers: false,
+  });
+}

--- a/src/mcp/server-options.ts
+++ b/src/mcp/server-options.ts
@@ -1,0 +1,27 @@
+import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
+import type { Database } from 'bun:sqlite';
+import type * as schema from '../db/schema.ts';
+import type { ToolGroupConfig, watchToolGroupConfig } from '../config/tool-groups.ts';
+import type { VectorStoreAdapter } from '../vector/types.ts';
+import type { McpPluginRuntimeOptions } from './plugin-runtime.ts';
+
+export type EmbeddedDeps = {
+  createVectorStoreForModel: (preset: any) => VectorStoreAdapter;
+  getEmbeddingModels: () => Record<string, any>;
+  createDatabase: (dbPath?: string) => {
+    sqlite: Database;
+    db: BunSQLiteDatabase<typeof schema>;
+  };
+};
+
+export type OracleMCPServerOptions = {
+  readOnly?: boolean;
+  toolGroups?: ToolGroupConfig;
+  toolAllowlist?: readonly string[];
+  embeddedDeps?: EmbeddedDeps | Promise<EmbeddedDeps>;
+  watchToolGroups?: typeof watchToolGroupConfig;
+  unifiedRuntime?: McpPluginRuntimeOptions['runtime'];
+  unifiedRuntimeRef?: McpPluginRuntimeOptions['runtimeRef'];
+  watchPlugins?: McpPluginRuntimeOptions['watch'];
+  installSignalHandlers?: boolean;
+};

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,5 +1,6 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { type BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 import type { Database } from 'bun:sqlite';
@@ -13,12 +14,15 @@ import type { ToolContext, ToolResponse } from '../tools/types.ts';
 import type { VectorStoreAdapter } from '../vector/types.ts';
 import { defaultMcpToolOrder, mcpToolByName, mcpTools, toMcpToolDefinition, type RuntimeMcpToolManifest } from '../tools/mcp-manifest.ts';
 import type { UnifiedRuntime } from '../plugins/unified-loader.ts';
+import type { EmbeddedDeps, OracleMCPServerOptions } from './server-options.ts';
 import { resolveToolName } from './aliases.ts';
 import { proxyToolCall, resolveOracleApiBase } from './http-proxy.ts';
 import { pluginMcpToolsFrom } from './plugin-tools.ts';
 import { runWithTenant } from '../middleware/tenant.ts';
 import { stripMcpTenantArgs, tenantIdFromMcpArgs } from './tenant.ts';
-import { createMcpPluginRuntime, type McpPluginRuntime, type McpPluginRuntimeOptions } from './plugin-runtime.ts';
+import { createMcpPluginRuntime, type McpPluginRuntime } from './plugin-runtime.ts';
+
+export type { OracleMCPServerOptions } from './server-options.ts';
 
 function errorResponse(text: string): ToolResponse {
   return { content: [{ type: 'text', text }], isError: true };
@@ -28,26 +32,6 @@ function loadPackageVersion(): string {
   const pkgPath = path.join(import.meta.dir, '..', '..', 'package.json');
   return JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version;
 }
-
-type EmbeddedDeps = {
-  createVectorStoreForModel: (preset: any) => VectorStoreAdapter;
-  getEmbeddingModels: () => Record<string, any>;
-  createDatabase: (dbPath?: string) => {
-    sqlite: Database;
-    db: BunSQLiteDatabase<typeof schema>;
-  };
-};
-
-export type OracleMCPServerOptions = {
-  readOnly?: boolean;
-  toolGroups?: ToolGroupConfig;
-  embeddedDeps?: EmbeddedDeps | Promise<EmbeddedDeps>;
-  watchToolGroups?: typeof watchToolGroupConfig;
-  unifiedRuntime?: McpPluginRuntimeOptions['runtime'];
-  unifiedRuntimeRef?: McpPluginRuntimeOptions['runtimeRef'];
-  watchPlugins?: McpPluginRuntimeOptions['watch'];
-  installSignalHandlers?: boolean;
-};
 
 export class OracleMCPServer {
   private server: Server;
@@ -68,11 +52,13 @@ export class OracleMCPServer {
   private readonly unifiedRuntime: McpPluginRuntime;
   private readonly embeddedDeps?: EmbeddedDeps | Promise<EmbeddedDeps>;
   private readonly watchToolGroups: typeof watchToolGroupConfig;
+  private readonly toolAllowlist: ReadonlySet<string> | null;
 
   constructor(options: OracleMCPServerOptions = {}) {
     this.readOnly = options.readOnly ?? false;
     this.embeddedDeps = options.embeddedDeps;
     this.watchToolGroups = options.watchToolGroups ?? watchToolGroupConfig;
+    this.toolAllowlist = options.toolAllowlist ? new Set(options.toolAllowlist) : null;
     if (this.readOnly) console.error('[Oracle] Running in READ-ONLY mode');
     this.oracleApiBase = resolveOracleApiBase();
     console.error(this.oracleApiBase
@@ -180,6 +166,10 @@ export class OracleMCPServer {
     return this.disabledTools.has(tool.name) || this.explicitDisabledTools.has(tool.name);
   }
 
+  private isAllowed(tool: RuntimeMcpToolManifest): boolean {
+    return !this.toolAllowlist || this.toolAllowlist.has(tool.name);
+  }
+
   private async availableTools() {
     const registry = await this.toolRegistry();
     const configured = defaultMcpToolOrder(this.enabledToolNames);
@@ -189,6 +179,7 @@ export class OracleMCPServer {
     return [...configured, ...dynamic]
       .map((name) => registry.get(name))
       .filter((tool): tool is RuntimeMcpToolManifest => !!tool)
+      .filter((tool) => this.isAllowed(tool))
       .filter((tool) => !this.isDisabled(tool))
       .filter((tool) => !this.readOnly || tool.readOnly !== false);
   }
@@ -205,6 +196,7 @@ export class OracleMCPServer {
       const toolName = resolveToolName(request.params.name);
       const tool = (await this.toolRegistry()).get(toolName);
       if (!tool) return errorResponse(`Error: Unknown tool: ${toolName}`);
+      if (!this.isAllowed(tool)) return errorResponse(`Error: Unknown tool: ${toolName}`);
       if (this.isDisabled(tool)) {
         return errorResponse(`Error: Tool "${toolName}" is disabled by tool group config. Check ${ORACLE_DATA_DIR}/config.json or arra.config.json.`);
       }
@@ -235,9 +227,13 @@ export class OracleMCPServer {
     await this.vectorStore?.connect();
   }
 
+  async connect(transport: Transport): Promise<void> {
+    await this.server.connect(transport);
+  }
+
   async run(): Promise<void> {
     const transport = new StdioServerTransport();
-    await this.server.connect(transport);
+    await this.connect(transport);
     console.error('Arra Oracle MCP Server running on stdio (FTS5 mode)');
   }
 

--- a/src/routes/mcp/streamable.ts
+++ b/src/routes/mcp/streamable.ts
@@ -2,13 +2,14 @@ import { Elysia } from 'elysia';
 import { WebStandardStreamableHTTPServerTransport, type WebStandardStreamableHTTPServerTransportOptions } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import type { HttpOracleMcpServerOptions } from '../../mcp/http-server.ts';
 import { OracleMCPServer } from '../../mcp/server.ts';
+import { createHttpOracleMcpServer } from '../../mcp/http-server.ts';
 import { requireMcpBearerAuth } from '../../mcp/http-auth.ts';
-import { emptyHttpPluginRuntime, remoteHttpToolGroups } from '../../mcp/http-policy.ts';
 
-type Env = Record<string, string | undefined>;
 type Session = { transport: WebStandardStreamableHTTPServerTransport; oracle: OracleMCPServer };
-export type McpStreamableRoutesOptions = Pick<WebStandardStreamableHTTPServerTransportOptions, 'enableJsonResponse'> & { env?: Env };
+export type McpStreamableRoutesOptions =
+  Pick<WebStandardStreamableHTTPServerTransportOptions, 'enableJsonResponse'> & HttpOracleMcpServerOptions;
 
 export function createMcpStreamableRoutes(options: McpStreamableRoutesOptions = {}) {
   const manager = new McpHttpSessionManager(options);
@@ -47,7 +48,7 @@ class McpHttpSessionManager {
     session = { transport, oracle };
     transport.onclose = () => { if (transport.sessionId) void this.releaseSession(transport.sessionId, false); };
     try {
-      await (oracle as unknown as { server: { connect: (transport: WebStandardStreamableHTTPServerTransport) => Promise<void> } }).server.connect(transport);
+      await oracle.connect(transport);
       return await transport.handleRequest(request, { authInfo, parsedBody });
     } catch (error) {
       if (transport.sessionId) await this.releaseSession(transport.sessionId, true);
@@ -61,13 +62,7 @@ class McpHttpSessionManager {
   }
 
   private createOracleServer(): OracleMCPServer {
-    const env = this.options.env ?? process.env;
-    return new OracleMCPServer({
-      readOnly: env.ORACLE_READ_ONLY === 'true',
-      toolGroups: remoteHttpToolGroups(),
-      unifiedRuntime: emptyHttpPluginRuntime(),
-      installSignalHandlers: false,
-    });
+    return createHttpOracleMcpServer(this.options);
   }
 
   private async releaseSession(sessionId: string, closeTransport: boolean): Promise<void> {

--- a/tests/mcp/http/streamable-auth.test.ts
+++ b/tests/mcp/http/streamable-auth.test.ts
@@ -2,12 +2,23 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { Elysia } from 'elysia';
 import { createApp } from '../../../src/server.ts';
 import { createMcpStreamableRoutes } from '../../../src/routes/mcp/index.ts';
+import type { ToolGroupConfig } from '../../../src/config/tool-groups.ts';
 import type { UnifiedRuntime } from '../../../src/plugins/unified-loader.ts';
 
 const originalEnv = {
   ORACLE_HTTP_URL: process.env.ORACLE_HTTP_URL,
   ORACLE_MCP_HTTP_TOKEN: process.env.ORACLE_MCP_HTTP_TOKEN,
   ARRA_API_TOKEN: process.env.ARRA_API_TOKEN,
+};
+
+const allToolGroups: ToolGroupConfig = {
+  search: true,
+  knowledge: true,
+  session: true,
+  forum: true,
+  oracle: true,
+  trace: true,
+  standalone: true,
 };
 
 beforeEach(() => {
@@ -45,15 +56,50 @@ describe('Streamable HTTP MCP bearer auth', () => {
     const sessionId = await initialize(app, 'mcp-secret');
     await notifyInitialized(app, sessionId, 'mcp-secret');
 
-    const res = await postMcp(app, toolsListRequest(), 'mcp-secret', sessionId);
-    const body = await res.json() as any;
-    const names = body.result.tools.map((tool: { name: string }) => tool.name);
+    const names = await listToolNames(app, sessionId, 'mcp-secret');
 
-    expect(res.status).toBe(200);
     expect(names).toContain('oracle_search');
     expect(names).not.toContain('____IMPORTANT');
     expect(names).not.toContain('oracle_recap');
     expect(names).not.toContain('oracle_mcp_call');
+  });
+
+  test('applies read-only filtering to remote HTTP sessions', async () => {
+    const app = mcpApp({ ORACLE_MCP_HTTP_TOKEN: 'mcp-secret', ORACLE_READ_ONLY: 'true' });
+    const sessionId = await initialize(app, 'mcp-secret');
+    await notifyInitialized(app, sessionId, 'mcp-secret');
+
+    const names = await listToolNames(app, sessionId, 'mcp-secret');
+
+    expect(names).toContain('oracle_search');
+    expect(names).not.toContain('oracle_learn');
+    expect(names).not.toContain('oracle_verify');
+  });
+
+  test('layers existing tool group filters under the remote allowlist', async () => {
+    const app = mcpApp({ ORACLE_MCP_HTTP_TOKEN: 'mcp-secret' }, { toolGroups: { ...allToolGroups, search: false } });
+    const sessionId = await initialize(app, 'mcp-secret');
+    await notifyInitialized(app, sessionId, 'mcp-secret');
+
+    const names = await listToolNames(app, sessionId, 'mcp-secret');
+
+    expect(names).not.toContain('oracle_search');
+    expect(names).toContain('oracle_stats');
+  });
+
+  test('remote allowlist blocks local-only tool calls even when explicitly enabled', async () => {
+    const toolGroups = { ...allToolGroups, enabled_tools: ['oracle_mcp_call'] };
+    const app = mcpApp({ ORACLE_MCP_HTTP_TOKEN: 'mcp-secret' }, { toolGroups });
+    const sessionId = await initialize(app, 'mcp-secret');
+    await notifyInitialized(app, sessionId, 'mcp-secret');
+
+    const names = await listToolNames(app, sessionId, 'mcp-secret');
+    const res = await postMcp(app, toolCallRequest('oracle_mcp_call'), 'mcp-secret', sessionId);
+    const body = await res.json() as any;
+
+    expect(names).not.toContain('oracle_mcp_call');
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content[0].text).toContain('Unknown tool: oracle_mcp_call');
   });
 
   test('falls back to ARRA_API_TOKEN and deletes sessions', async () => {
@@ -71,8 +117,8 @@ describe('Streamable HTTP MCP bearer auth', () => {
   });
 });
 
-function mcpApp(env: Record<string, string>) {
-  return new Elysia().use(createMcpStreamableRoutes({ env, enableJsonResponse: true }));
+function mcpApp(env: Record<string, string>, options: { toolGroups?: ToolGroupConfig; readOnly?: boolean } = {}) {
+  return new Elysia().use(createMcpStreamableRoutes({ env, enableJsonResponse: true, ...options }));
 }
 
 async function initialize(app: Elysia, token: string): Promise<string> {
@@ -86,6 +132,13 @@ async function initialize(app: Elysia, token: string): Promise<string> {
 async function notifyInitialized(app: Elysia, sessionId: string, token: string) {
   const res = await postMcp(app, { jsonrpc: '2.0', method: 'notifications/initialized' }, token, sessionId);
   expect(res.status).toBe(202);
+}
+
+async function listToolNames(app: Elysia, sessionId: string, token: string): Promise<string[]> {
+  const res = await postMcp(app, toolsListRequest(), token, sessionId);
+  const body = await res.json() as any;
+  expect(res.status).toBe(200);
+  return body.result.tools.map((tool: { name: string }) => tool.name);
 }
 
 function postMcp(app: Elysia, body: unknown, token?: string, sessionId?: string) {
@@ -116,6 +169,10 @@ function initializeRequest() {
 
 function toolsListRequest() {
   return { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} };
+}
+
+function toolCallRequest(name: string) {
+  return { jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name, arguments: {} } };
 }
 
 function runtime(): UnifiedRuntime {


### PR DESCRIPTION
## Summary
- extract HTTP MCP per-session server creation into `createHttpOracleMcpServer`
- expose a public `OracleMCPServer.connect(Transport)` seam so Streamable HTTP no longer reaches into private SDK server internals
- preserve the existing `OracleMCPServerOptions` type export while moving option/deps types out of the 250-line server file
- apply a hard remoteable-only MCP allowlist on list and call paths, layered with existing tool-group config and read-only filtering
- keep stdio behavior equivalent (`run()` still connects a `StdioServerTransport`)

## Guardrails
- stdio path behavior verified with existing stdio smoke tests
- bearer auth remains scoped to `/mcp`; no global middleware changes
- no changes to `src/middleware/cors.ts` or server bind defaults

## Tests
- `bun test tests/mcp/http/` → 7 pass / 0 fail
- stdio smoke (`server-run-connects-stdio`, `server-list-handler-exposes-tools`) → 2 pass / 0 fail
- repo-local absolute-path MCP suite → 122 pass / 0 fail
- `bunx tsc --noEmit` → pass
- changed files <= 250 lines

Continues #2743 Phase 2.