### PR TITLE
fix(bun): align lockfile workspace name for gha add -g

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2,7 +2,7 @@
   "lockfileVersion": 1,
   "workspaces": {
     "": {
-      "name": "oracle-v2-mcp",
+      "name": "arra-oracle-v3",
       "dependencies": {
         "@elysiajs/cors": "^1.4.1",
         "@elysiajs/swagger": "^1.3.1",


### PR DESCRIPTION
Phase 1 fix attempt for #2753: align bun.lock root workspace name with package.json to avoid potential self-dependency loop on github install.