### PR TITLE
fix: degrade embedder boot to FTS5-only

### DIFF
--- a/src/mcp/fts-only-vector-store.ts
+++ b/src/mcp/fts-only-vector-store.ts
@@ -1,0 +1,33 @@
+import type { VectorQueryResult, VectorStoreAdapter } from '../vector/types.ts';
+
+const emptyResult = (): VectorQueryResult => ({
+  ids: [],
+  documents: [],
+  distances: [],
+  metadatas: [],
+});
+
+function unavailable(reason: string): Error {
+  return new Error(`Vector store unavailable; degraded to FTS5-only (${reason})`);
+}
+
+export function createFtsOnlyVectorStore(reason: string): VectorStoreAdapter {
+  return {
+    name: 'fts5-only',
+    async connect() {},
+    async close() {},
+    async ensureCollection() {},
+    async deleteCollection() {},
+    async addDocuments() { throw unavailable(reason); },
+    async deleteDocuments() {},
+    async replaceDocuments() { throw unavailable(reason); },
+    async query() { return emptyResult(); },
+    async queryById() { return emptyResult(); },
+    async queryByVector() { return emptyResult(); },
+    async getStats() { return { count: 0 }; },
+    async getCollectionInfo() { return { count: 0, name: 'fts5-only' }; },
+    async getAllEmbeddings() {
+      return { ids: [], embeddings: [], metadatas: [], documents: [] };
+    },
+  };
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -21,9 +21,8 @@ import { pluginMcpToolsFrom } from './plugin-tools.ts';
 import { runWithTenant } from '../middleware/tenant.ts';
 import { stripMcpTenantArgs, tenantIdFromMcpArgs } from './tenant.ts';
 import { createMcpPluginRuntime, type McpPluginRuntime } from './plugin-runtime.ts';
-
+import { createFtsOnlyVectorStore } from './fts-only-vector-store.ts';
 export type { OracleMCPServerOptions } from './server-options.ts';
-
 function errorResponse(text: string): ToolResponse { return { content: [{ type: 'text', text }], isError: true }; }
 export class OracleMCPServer {
   private server: Server;
@@ -32,7 +31,7 @@ export class OracleMCPServer {
   private repoRoot = REPO_ROOT;
   private vectorStore: VectorStoreAdapter | null = null;
   private vectorStatus: ToolContext['vectorStatus'] = 'unknown';
-  private vectorReason: string | undefined; private embedderProvider: string | undefined;
+  private vectorReason: string | undefined; private embedderProvider: string | undefined; private lastEmbedderWarning: string | undefined;
   private readOnly: boolean;
   private version = pkg.version;
   private disabledTools = new Set<string>();
@@ -46,7 +45,6 @@ export class OracleMCPServer {
   private readonly embeddedDeps?: EmbeddedDeps | Promise<EmbeddedDeps>;
   private readonly watchToolGroups: typeof watchToolGroupConfig;
   private readonly toolAllowlist: ReadonlySet<string> | null;
-
   constructor(options: OracleMCPServerOptions = {}) {
     this.readOnly = options.readOnly ?? false;
     this.embeddedDeps = options.embeddedDeps;
@@ -57,13 +55,11 @@ export class OracleMCPServer {
     console.error(this.oracleApiBase
       ? `[Oracle] Running in HTTP-proxy mode (ORACLE_HTTP_URL → ${this.oracleApiBase})`
       : '[Oracle] Running in embedded mode (ORACLE_HTTP_URL unset)');
-
     const groupConfig = options.toolGroups ?? loadToolGroupConfig(this.repoRoot);
     this.applyToolGroupConfig(groupConfig);
     this.logToolGroupConfig(groupConfig);
     this.unifiedRuntime = createMcpPluginRuntime({ runtime: options.unifiedRuntime, runtimeRef: options.unifiedRuntimeRef, watch: options.watchPlugins, warn: (message) => console.error(message) });
     this.watchToolGroupsIfNeeded(options.toolGroups);
-
     this.server = new Server(
       { name: MCP_SERVER_NAME, version: this.version },
       { capabilities: { tools: {} } },
@@ -72,7 +68,6 @@ export class OracleMCPServer {
     this.setupHandlers();
     this.setupErrorHandling(options.installSignalHandlers !== false);
   }
-
   private applyToolGroupConfig(config: ToolGroupConfig): void {
     this.disabledTools = getDisabledTools(config);
     this.enabledToolNames = getEnabledToolNames(config);
@@ -109,11 +104,15 @@ export class OracleMCPServer {
     const { createVectorStoreForModel, getEmbeddingModels, createDatabase, probeEmbedder = probeConfiguredEmbedder } = await this.loadEmbeddedDeps();
     const models = getEmbeddingModels();
     const preset = models['bge-m3'] ?? Object.values(models)[0];
-    this.vectorStore = createVectorStoreForModel(preset);
+    const embedderStatus = await probeEmbedder(preset);
+    this.applyEmbedderStatus(embedderStatus);
+    try { this.vectorStore = createVectorStoreForModel(preset); } catch (error) {
+      if (embedderStatus.status !== 'degraded') throw error;
+      this.vectorStore = createFtsOnlyVectorStore(embedderStatus.reason ?? 'embedder unavailable');
+    }
     const { sqlite, db } = createDatabase(DB_PATH);
     this.sqlite = sqlite;
     this.db = db;
-    this.applyEmbedderStatus(await probeEmbedder(preset));
     await this.verifyVectorHealth();
   }
 
@@ -129,11 +128,12 @@ export class OracleMCPServer {
   private applyEmbedderStatus(status: EmbedderRuntimeStatus): void {
     setEmbedderRuntimeStatus(status);
     this.embedderProvider = status.provider;
-    if (status.status === 'connected') { this.vectorStatus = 'connected'; this.vectorReason = undefined; return; }
+    if (status.status === 'connected') { this.vectorStatus = 'connected'; this.vectorReason = undefined; this.lastEmbedderWarning = undefined; return; }
     if (status.status !== 'degraded') return;
     this.vectorStatus = 'degraded';
     this.vectorReason = status.reason;
-    console.error(formatEmbedderDegradedWarning(status.provider, status.reason ?? 'unknown'));
+    const warning = formatEmbedderDegradedWarning(status.provider, status.reason ?? 'unknown');
+    if (this.lastEmbedderWarning !== warning) { console.error(warning); this.lastEmbedderWarning = warning; }
   }
 
   private async verifyVectorHealth(): Promise<void> {

--- a/tests/mcp/server-embedder-degraded.test.ts
+++ b/tests/mcp/server-embedder-degraded.test.ts
@@ -58,6 +58,42 @@ test('MCP embedder degradation is observable and FTS5 search still returns', asy
   }
 });
 
+test('MCP keeps FTS5 tools available when degraded embedder prevents vector store construction', async () => {
+  process.env.ORACLE_HTTP_URL = '';
+  process.env.ORACLE_VECTOR_ENABLED = '1';
+  delete process.env.ORACLE_RERANKER_URL;
+  const connection = createDatabase(':memory:');
+  seedFtsDoc(connection);
+  const warningLines: string[] = [];
+  const originalError = console.error;
+  console.error = (...args: unknown[]) => warningLines.push(args.map(String).join(' '));
+  const server = new OracleMCPServer({
+    toolGroups: allToolGroups,
+    embeddedDeps: {
+      createVectorStoreForModel: () => { throw new Error('OpenAI API key required. Set OPENAI_API_KEY.'); },
+      getEmbeddingModels: () => ({ 'bge-m3': { collection: 'oracle_knowledge', model: 'bge-m3', provider: 'openai' } }),
+      createDatabase: () => connection,
+      probeEmbedder: async () => ({
+        status: 'degraded', provider: 'openai', source: 'env', explicit: true,
+        reason: 'no embedder configured/reachable — FTS5-only (OpenAI API key required. Set OPENAI_API_KEY.)',
+        checkedAt: 'now',
+      }),
+    },
+  });
+  try {
+    const stats = await toolJson(server, 'oracle_stats', {});
+    expect(stats.vector_status).toBe('degraded');
+    expect(stats.embedder_provider).toBe('openai');
+    const search = await toolJson(server, 'oracle_search', { query: 'needle', mode: 'hybrid', limit: 3 });
+    expect(search.results.map((item: { id: string }) => item.id)).toContain('fts-doc');
+    expect(search.metadata.vectorAvailable).toBe(false);
+    expect(warningLines.join('\n')).toContain('[Oracle] embedder openai unreachable');
+  } finally {
+    console.error = originalError;
+    await server.cleanup();
+  }
+});
+
 async function toolJson(server: OracleMCPServer, name: string, args: Record<string, unknown>) {
   const response = await callToolHandler(server)({ params: { name, arguments: args } });
   expect(response.isError).toBeUndefined();

--- a/tests/vector/embedder-runtime-status.test.ts
+++ b/tests/vector/embedder-runtime-status.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from 'bun:test';
+import {
+  clearEmbedderRuntimeStatusForTests,
+  formatEmbedderDegradedWarning,
+  probeConfiguredEmbedder,
+} from '../../src/vector/embedder-config.ts';
+import { clearVectorEnv } from './helpers.ts';
+
+test('boot probe reports unset auto embedder as degraded FTS5-only without network', async () => {
+  clearVectorEnv();
+  clearEmbedderRuntimeStatusForTests();
+
+  const status = await probeConfiguredEmbedder(undefined, { timeoutMs: 10 });
+
+  expect(status).toMatchObject({
+    status: 'degraded',
+    provider: 'ollama',
+    source: 'auto-default',
+    explicit: false,
+    reason: 'no embedder configured/reachable — FTS5-only',
+  });
+  expect(formatEmbedderDegradedWarning(status.provider, status.reason!))
+    .toBe('[Oracle] embedder ollama unreachable (no embedder configured/reachable — FTS5-only) → degraded to FTS5-only');
+});
+
+test('boot probe turns missing OpenAI credentials into degraded status', async () => {
+  clearVectorEnv();
+  clearEmbedderRuntimeStatusForTests();
+  process.env.ORACLE_EMBEDDER = 'openai';
+
+  const status = await probeConfiguredEmbedder(undefined, { timeoutMs: 10 });
+
+  expect(status.status).toBe('degraded');
+  expect(status.provider).toBe('openai');
+  expect(status.reason).toContain('FTS5-only');
+  expect(status.reason).toContain('OPENAI_API_KEY');
+});


### PR DESCRIPTION
## Summary
- probe the configured embedder before embedded MCP vector-store construction
- install an FTS5-only placeholder vector store when degraded embedder config would otherwise crash boot
- surface degraded vector status/warning while keeping MCP FTS search working

## Verification
- bunx tsc --noEmit
- bun test tests/mcp tests/vector
- bun test tests/mcp/server-embedder-degraded.test.ts tests/vector/embedder-runtime-status.test.ts tests/http/stats/embedder-runtime.test.ts tests/http/health/embedder-autodetect.test.ts tests/http/health/stats.test.ts

Closes #2746