### PR TITLE
feat: add oracle dig findings schema

### DIFF
--- a/src/db/__tests__/oracle-dig-schema.test.ts
+++ b/src/db/__tests__/oracle-dig-schema.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, expect, test } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { drizzle } from 'drizzle-orm/bun-sqlite';
+import { migrate } from 'drizzle-orm/bun-sqlite/migrator';
+import { eq } from 'drizzle-orm';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as schema from '../schema.ts';
+import { oracleFindingEvidence, oracleFindings } from '../schema.ts';
+
+const cleanup: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanup.length) cleanup.pop()?.();
+});
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), 'oracle-dig-schema-'));
+  const sqlite = new Database(join(dir, 'oracle.db'));
+  sqlite.exec('PRAGMA foreign_keys = ON');
+  const db = drizzle(sqlite, { schema });
+  migrate(db, { migrationsFolder: join(import.meta.dir, '../migrations') });
+  cleanup.push(() => { sqlite.close(); rmSync(dir, { recursive: true, force: true }); });
+  return { db, sqlite };
+}
+
+test('oracle dig schema creates findings and evidence with enforced FK/defaults', () => {
+  const { db, sqlite } = freshDb();
+  const now = Date.now();
+  const tables = sqlite.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all() as Array<{ name: string }>;
+  expect(tables.map((row) => row.name)).toContain('oracle_findings');
+  expect(tables.map((row) => row.name)).toContain('oracle_finding_evidence');
+  const indexes = sqlite.prepare("SELECT name FROM sqlite_master WHERE type = 'index'").all() as Array<{ name: string }>;
+  expect(indexes.map((row) => row.name)).toEqual(expect.arrayContaining([
+    'idx_findings_tenant', 'idx_findings_subject', 'idx_findings_topic', 'idx_findings_dug_by',
+    'idx_evidence_finding', 'idx_evidence_kind', 'idx_evidence_github', 'idx_evidence_session',
+  ]));
+
+  db.insert(oracleFindings).values({
+    id: 'finding-1', subject: 'oracle_dig', relation: 'stores', object: 'provenance',
+    dugBy: 'metis', asOfTs: now, asOfCommit: 'abc123', confidence: 0.91,
+    topic: 'schema', frictionScore: 0.2, commissionedBy: 'm5', createdAt: now, updatedAt: now,
+  }).run();
+  db.insert(oracleFindingEvidence).values({
+    findingId: 'finding-1', kind: 'github', githubOwner: 'Soul-Brews-Studio',
+    githubRepo: 'arra-oracle-v3', githubPath: 'src/db/schema.ts', githubRef: 'alpha',
+    githubLine: 210, commit: 'abc123', createdAt: now,
+  }).run();
+
+  const rows = db.select({
+    findingId: oracleFindings.id, evidenceFindingId: oracleFindingEvidence.findingId,
+    findingTenant: oracleFindings.tenantId, evidenceTenant: oracleFindingEvidence.tenantId,
+    iterations: oracleFindings.iterations, kind: oracleFindingEvidence.kind,
+  }).from(oracleFindings)
+    .innerJoin(oracleFindingEvidence, eq(oracleFindings.id, oracleFindingEvidence.findingId))
+    .all();
+  expect(rows).toEqual([{ findingId: 'finding-1', evidenceFindingId: 'finding-1', findingTenant: 'default', evidenceTenant: 'default', iterations: 1, kind: 'github' }]);
+  expect(() => db.insert(oracleFindingEvidence).values({ findingId: 'missing', kind: 'web', webUrl: 'https://example.test', createdAt: now }).run())
+    .toThrow(/FOREIGN KEY|constraint/i);
+});

--- a/src/db/migrations/0040_oracle_findings.sql
+++ b/src/db/migrations/0040_oracle_findings.sql
@@ -1,0 +1,53 @@
+CREATE TABLE IF NOT EXISTS oracle_findings (
+  id TEXT PRIMARY KEY NOT NULL,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  subject TEXT NOT NULL,
+  relation TEXT,
+  object TEXT,
+  dug_by TEXT NOT NULL,
+  as_of_ts INTEGER NOT NULL,
+  as_of_commit TEXT,
+  confidence REAL NOT NULL,
+  topic TEXT,
+  friction_score REAL,
+  commissioned_by TEXT,
+  iterations INTEGER NOT NULL DEFAULT 1,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS oracle_finding_evidence (
+  id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+  finding_id TEXT NOT NULL REFERENCES oracle_findings(id) ON DELETE CASCADE,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  kind TEXT NOT NULL,
+  github_owner TEXT,
+  github_repo TEXT,
+  github_path TEXT,
+  github_ref TEXT,
+  github_line INTEGER,
+  session_id TEXT,
+  session_oracle TEXT,
+  oracle_msg_from TEXT,
+  oracle_msg_at INTEGER,
+  web_url TEXT,
+  web_fetched_at INTEGER,
+  "commit" TEXT,
+  created_at INTEGER NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_findings_tenant ON oracle_findings (tenant_id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_findings_subject ON oracle_findings (subject);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_findings_topic ON oracle_findings (topic);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_findings_dug_by ON oracle_findings (dug_by);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_evidence_finding ON oracle_finding_evidence (finding_id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_evidence_kind ON oracle_finding_evidence (kind);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_evidence_github ON oracle_finding_evidence (github_owner, github_repo, github_path);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_evidence_session ON oracle_finding_evidence (session_id);

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -239,6 +239,7 @@
     { "idx": 36, "version": "6", "when": 1781703600000, "tag": "0036_memory_consolidation", "breakpoints": true },
     { "idx": 37, "version": "6", "when": 1781703700000, "tag": "0037_memory_tiered_salience", "breakpoints": true },
     { "idx": 38, "version": "6", "when": 1781703800000, "tag": "0038_pointer_index", "breakpoints": true },
-    { "idx": 39, "version": "6", "when": 1781703900000, "tag": "0039_vector_index_manifest", "breakpoints": true }
+    { "idx": 39, "version": "6", "when": 1781703900000, "tag": "0039_vector_index_manifest", "breakpoints": true },
+    { "idx": 40, "version": "6", "when": 1781704000000, "tag": "0040_oracle_findings", "breakpoints": true }
   ]
 }

--- a/src/db/oracle-dig-schema.ts
+++ b/src/db/oracle-dig-schema.ts
@@ -1,0 +1,49 @@
+import { index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+export const oracleFindings = sqliteTable('oracle_findings', {
+  id: text('id').primaryKey(),
+  tenantId: text('tenant_id').default('default').notNull(),
+  subject: text('subject').notNull(),
+  relation: text('relation'),
+  object: text('object'),
+  dugBy: text('dug_by').notNull(),
+  asOfTs: integer('as_of_ts').notNull(),
+  asOfCommit: text('as_of_commit'),
+  confidence: real('confidence').notNull(),
+  topic: text('topic'),
+  frictionScore: real('friction_score'),
+  commissionedBy: text('commissioned_by'),
+  iterations: integer('iterations').default(1).notNull(),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+}, (table) => [
+  index('idx_findings_tenant').on(table.tenantId),
+  index('idx_findings_subject').on(table.subject),
+  index('idx_findings_topic').on(table.topic),
+  index('idx_findings_dug_by').on(table.dugBy),
+]);
+
+export const oracleFindingEvidence = sqliteTable('oracle_finding_evidence', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  findingId: text('finding_id').notNull().references(() => oracleFindings.id, { onDelete: 'cascade' }),
+  tenantId: text('tenant_id').default('default').notNull(),
+  kind: text('kind', { enum: ['github', 'session', 'oracle-msg', 'web'] }).notNull(),
+  githubOwner: text('github_owner'),
+  githubRepo: text('github_repo'),
+  githubPath: text('github_path'),
+  githubRef: text('github_ref'),
+  githubLine: integer('github_line'),
+  sessionId: text('session_id'),
+  sessionOracle: text('session_oracle'),
+  oracleMsgFrom: text('oracle_msg_from'),
+  oracleMsgAt: integer('oracle_msg_at'),
+  webUrl: text('web_url'),
+  webFetchedAt: integer('web_fetched_at'),
+  commit: text('commit'),
+  createdAt: integer('created_at').notNull(),
+}, (table) => [
+  index('idx_evidence_finding').on(table.findingId),
+  index('idx_evidence_kind').on(table.kind),
+  index('idx_evidence_github').on(table.githubOwner, table.githubRepo, table.githubPath),
+  index('idx_evidence_session').on(table.sessionId),
+]);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -4,8 +4,7 @@ export const tenants = sqliteTable('tenants', {
   id: text('id').primaryKey(),
   name: text('name'),
   status: text('status').default('active').notNull(),
-  createdAt: integer('created_at').notNull(),
-  updatedAt: integer('updated_at').notNull(),
+  createdAt: integer('created_at').notNull(), updatedAt: integer('updated_at').notNull(),
 }, (table) => [index('idx_tenants_status').on(table.status)]);
 export const oracleDocuments = sqliteTable('oracle_documents', {
   id: text('id').primaryKey(),
@@ -246,5 +245,6 @@ export const traceLog = sqliteTable('trace_log', {
   index('idx_trace_created').on(table.createdAt),
 ]);
 export { exportJobs } from './export-schema.ts';
+export { oracleFindingEvidence, oracleFindings } from './oracle-dig-schema.ts';
 export { activityLog, menuItems, schedule, settings, supersedeLog } from './logistics-schema.ts';
 export { assertSqliteIdentifier, oracleVectorDocuments, sqliteVecEmbeddingsTable, sqliteVecMetadataTable, vectorDocumentsTable } from './vector-schema.ts';


### PR DESCRIPTION
## Summary
- add oracle_findings and oracle_finding_evidence Drizzle schema in a split oracle-dig schema file
- register 0040 migration with required tables and query indexes
- add migration/schema regression test covering table creation, indexes, FK enforcement, and tenant defaults

## Verification
- bun test src/db/__tests__/oracle-dig-schema.test.ts
- bunx tsc --noEmit

Closes #2771