### PR TITLE
feat: add oracle_dig store helpers

### DIFF
--- a/src/plugins/oracle-dig/get.ts
+++ b/src/plugins/oracle-dig/get.ts
@@ -1,0 +1,13 @@
+import { asc, eq } from 'drizzle-orm';
+import { db as defaultDb, oracleFindingEvidence, oracleFindings } from '../../db/index.ts';
+import type { FindingWithEvidence, OracleDigDb } from './types.ts';
+
+export function getFinding(id: string, database: OracleDigDb = defaultDb): FindingWithEvidence | null {
+  const finding = database.select().from(oracleFindings).where(eq(oracleFindings.id, id)).get();
+  if (!finding) return null;
+  const evidence = database.select().from(oracleFindingEvidence)
+    .where(eq(oracleFindingEvidence.findingId, id))
+    .orderBy(asc(oracleFindingEvidence.id))
+    .all();
+  return { ...finding, evidence };
+}

--- a/src/plugins/oracle-dig/list.ts
+++ b/src/plugins/oracle-dig/list.ts
@@ -1,0 +1,32 @@
+import { and, desc, eq, like, sql, type SQL } from 'drizzle-orm';
+import { db as defaultDb, oracleFindings } from '../../db/index.ts';
+import type { ListFindingsInput, ListFindingsResult, OracleDigDb } from './types.ts';
+
+function boundedInteger(value: number | undefined, fallback: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return fallback;
+  const integer = Math.trunc(value!);
+  return Math.min(max, Math.max(min, integer));
+}
+
+export function listFindings(input: ListFindingsInput = {}, database: OracleDigDb = defaultDb): ListFindingsResult {
+  const limit = boundedInteger(input.limit, 20, 1, 100);
+  const offset = boundedInteger(input.offset, 0, 0, 10_000);
+  const conditions: SQL[] = [];
+  const dugBy = input.dugBy ?? input.dug_by;
+
+  if (input.subject) conditions.push(like(oracleFindings.subject, `%${input.subject}%`));
+  if (input.topic) conditions.push(like(oracleFindings.topic, `%${input.topic}%`));
+  if (dugBy) conditions.push(eq(oracleFindings.dugBy, dugBy));
+  if (input.confidence !== undefined) conditions.push(eq(oracleFindings.confidence, input.confidence));
+
+  const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+  const countResult = database.select({ count: sql<number>`count(*)` }).from(oracleFindings).where(whereClause).get();
+  const findings = database.select().from(oracleFindings)
+    .where(whereClause)
+    .orderBy(desc(oracleFindings.updatedAt))
+    .limit(limit)
+    .offset(offset)
+    .all();
+  const total = countResult?.count ?? 0;
+  return { findings, total, hasMore: offset + findings.length < total };
+}

--- a/src/plugins/oracle-dig/store.ts
+++ b/src/plugins/oracle-dig/store.ts
@@ -1,0 +1,67 @@
+import { randomUUID } from 'crypto';
+import { eq } from 'drizzle-orm';
+import { db as defaultDb, oracleFindingEvidence, oracleFindings } from '../../db/index.ts';
+import type { Evidence, Finding, InsertEvidenceInput, InsertFindingInput, OracleDigDb } from './types.ts';
+
+function requiredText(value: string | undefined, label: string): string {
+  const normalized = value?.trim();
+  if (!normalized) throw new Error(`${label} is required`);
+  return normalized;
+}
+
+function finiteNumber(value: number | undefined, label: string): number {
+  if (!Number.isFinite(value)) throw new Error(`${label} is required`);
+  return value!;
+}
+
+export function insertFinding(input: InsertFindingInput, database: OracleDigDb = defaultDb): Finding {
+  const now = Date.now();
+  const id = input.id ?? randomUUID();
+  database.insert(oracleFindings).values({
+    id,
+    tenantId: input.tenantId ?? 'default',
+    subject: requiredText(input.subject, 'subject'),
+    relation: input.relation ?? null,
+    object: input.object ?? null,
+    dugBy: requiredText(input.dugBy, 'dugBy'),
+    asOfTs: finiteNumber(input.asOfTs, 'asOfTs'),
+    asOfCommit: input.asOfCommit ?? null,
+    confidence: finiteNumber(input.confidence, 'confidence'),
+    topic: input.topic ?? null,
+    frictionScore: input.frictionScore ?? null,
+    commissionedBy: input.commissionedBy ?? null,
+    iterations: input.iterations ?? 1,
+    createdAt: input.createdAt ?? now,
+    updatedAt: input.updatedAt ?? now,
+  }).run();
+  const row = database.select().from(oracleFindings).where(eq(oracleFindings.id, id)).get();
+  if (!row) throw new Error(`Failed to insert finding: ${id}`);
+  return row;
+}
+
+export function insertEvidence(input: InsertEvidenceInput, database: OracleDigDb = defaultDb): Evidence {
+  const result = database.insert(oracleFindingEvidence).values({
+    findingId: requiredText(input.findingId, 'findingId'),
+    tenantId: input.tenantId ?? 'default',
+    kind: input.kind,
+    githubOwner: input.githubOwner ?? null,
+    githubRepo: input.githubRepo ?? null,
+    githubPath: input.githubPath ?? null,
+    githubRef: input.githubRef ?? null,
+    githubLine: input.githubLine ?? null,
+    sessionId: input.sessionId ?? null,
+    sessionOracle: input.sessionOracle ?? null,
+    oracleMsgFrom: input.oracleMsgFrom ?? null,
+    oracleMsgAt: input.oracleMsgAt ?? null,
+    webUrl: input.webUrl ?? null,
+    webFetchedAt: input.webFetchedAt ?? null,
+    commit: input.commit ?? null,
+    createdAt: input.createdAt ?? Date.now(),
+  }).run() as unknown as { lastInsertRowid?: number | bigint };
+  const id = Number(result.lastInsertRowid);
+  const row = Number.isFinite(id)
+    ? database.select().from(oracleFindingEvidence).where(eq(oracleFindingEvidence.id, id)).get()
+    : null;
+  if (!row) throw new Error('Failed to insert finding evidence');
+  return row;
+}

--- a/src/plugins/oracle-dig/types.ts
+++ b/src/plugins/oracle-dig/types.ts
@@ -1,0 +1,35 @@
+import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
+import type * as schema from '../../db/schema.ts';
+import type { oracleFindingEvidence, oracleFindings } from '../../db/schema.ts';
+
+export type OracleDigDb = BunSQLiteDatabase<typeof schema>;
+
+export type Finding = typeof oracleFindings.$inferSelect;
+export type NewFinding = typeof oracleFindings.$inferInsert;
+export type Evidence = typeof oracleFindingEvidence.$inferSelect;
+export type NewEvidence = typeof oracleFindingEvidence.$inferInsert;
+export type EvidenceKind = Evidence['kind'];
+
+export type InsertFindingInput = Omit<NewFinding, 'id' | 'createdAt' | 'updatedAt'>
+  & Partial<Pick<NewFinding, 'id' | 'createdAt' | 'updatedAt'>>;
+
+export type InsertEvidenceInput = Omit<NewEvidence, 'id' | 'createdAt'>
+  & Partial<Pick<NewEvidence, 'createdAt'>>;
+
+export type ListFindingsInput = {
+  subject?: string;
+  topic?: string;
+  dugBy?: string;
+  dug_by?: string;
+  confidence?: number;
+  limit?: number;
+  offset?: number;
+};
+
+export type ListFindingsResult = {
+  findings: Finding[];
+  total: number;
+  hasMore: boolean;
+};
+
+export type FindingWithEvidence = Finding & { evidence: Evidence[] };

--- a/tests/plugins/oracle-dig-store.test.ts
+++ b/tests/plugins/oracle-dig-store.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, expect, test } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { createDatabase, type DatabaseConnection } from '../../src/db/index.ts';
+import { getFinding } from '../../src/plugins/oracle-dig/get.ts';
+import { listFindings } from '../../src/plugins/oracle-dig/list.ts';
+import { insertEvidence, insertFinding } from '../../src/plugins/oracle-dig/store.ts';
+
+let tempDir = '';
+let connection: DatabaseConnection | undefined;
+
+afterEach(() => {
+  connection?.storage.close();
+  connection = undefined;
+  if (tempDir && fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true });
+  tempDir = '';
+});
+
+function freshDb(): DatabaseConnection {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oracle-dig-store-'));
+  connection = createDatabase(path.join(tempDir, 'oracle.db'));
+  return connection;
+}
+
+test('insertFinding and insertEvidence persist typed provenance rows', () => {
+  const conn = freshDb();
+  const finding = insertFinding({
+    subject: 'oracle_dig',
+    relation: 'stores',
+    object: 'provenance',
+    dugBy: '[m5:digger]',
+    asOfTs: Date.parse('2026-07-12T00:00:00.000Z'),
+    asOfCommit: 'abc123',
+    confidence: 0.92,
+    topic: 'schema',
+    frictionScore: 0.15,
+    commissionedBy: '[m5:arra-oracle-v3]',
+  }, conn.db);
+
+  const github = insertEvidence({
+    findingId: finding.id,
+    kind: 'github',
+    githubOwner: 'Soul-Brews-Studio',
+    githubRepo: 'digger-oracle',
+    githubPath: 'ψ/ralph/126-oracle-dig-mcp-tool-schema.md',
+    githubRef: 'alpha',
+    githubLine: 12,
+    commit: 'abc123',
+  }, conn.db);
+  insertEvidence({ findingId: finding.id, kind: 'session', sessionId: 's-126', sessionOracle: '[m5:digger]' }, conn.db);
+
+  expect(finding).toMatchObject({ tenantId: 'default', iterations: 1, subject: 'oracle_dig' });
+  expect(github).toMatchObject({ tenantId: 'default', kind: 'github', githubRepo: 'digger-oracle' });
+
+  const loaded = getFinding(finding.id, conn.db);
+  expect(loaded?.evidence).toHaveLength(2);
+  expect(loaded?.evidence.map((row) => row.kind)).toEqual(['github', 'session']);
+});
+
+test('listFindings filters by subject topic dug_by and confidence', () => {
+  const conn = freshDb();
+  const base = { asOfTs: 1783814400000, dugBy: '[m5:digger]' };
+  insertFinding({ ...base, subject: 'oracle_dig schema', relation: 'has', object: 'evidence', confidence: 0.9, topic: 'schema' }, conn.db);
+  insertFinding({ ...base, subject: 'oracle_trace primitive', relation: 'feeds', object: 'oracle_dig', confidence: 0.7, topic: 'trace' }, conn.db);
+  insertFinding({ ...base, dugBy: '[m5:other]', subject: 'unrelated', relation: 'has', object: 'notes', confidence: 0.9, topic: 'schema' }, conn.db);
+
+  expect(listFindings({ subject: 'oracle_', dug_by: '[m5:digger]' }, conn.db).total).toBe(2);
+  expect(listFindings({ topic: 'schema', confidence: 0.9 }, conn.db).total).toBe(2);
+  expect(listFindings({ dugBy: '[m5:digger]', confidence: 0.7 }, conn.db).findings[0].subject).toBe('oracle_trace primitive');
+  expect(listFindings({ limit: 1, offset: 0 }, conn.db).hasMore).toBe(true);
+});
+
+test('getFinding returns null for missing ids and evidence requires a finding', () => {
+  const conn = freshDb();
+  expect(getFinding('missing', conn.db)).toBeNull();
+  expect(() => insertEvidence({ findingId: 'missing', kind: 'web', webUrl: 'https://example.test' }, conn.db))
+    .toThrow(/FOREIGN KEY|constraint/i);
+});


### PR DESCRIPTION
## Summary
- Add pure `src/plugins/oracle-dig` helpers for Phase 2 store access: schema-inferred types, insert helpers, list filters, and get-with-evidence lookup.
- `insertFinding` / `insertEvidence` mirror the trace store style with `randomUUID`, `db.insert(...).values(...).run()`, timestamps, and DB-injectable defaults for test isolation.
- Add unit tests against a migrated test SQLite DB for typed evidence persistence, get/list behavior, filters, pagination, and FK enforcement.

## Validation
- `bunx tsc --noEmit` ✅
- `bun test src/db/__tests__/oracle-dig-schema.test.ts tests/plugins/oracle-dig-store.test.ts` ✅ (`4 pass`)
- Changed files ≤250 lines ✅

No MCP/HTTP wiring in this phase.
