### PR TITLE
feat: add Oracle Dig mock UI

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -78,6 +78,7 @@ export function AppShell({
     { to: '/learn', label: 'Learn', description: 'Create and edit learnings' },
     { to: '/memory', label: 'Memory Dashboard', description: 'Confidence, heat, provenance, valid-time, and recency' },
     { to: '/memory/consolidation', label: 'Consolidation Queue', description: 'Review suggested supersede actions' },
+    { to: '/oracle-dig', label: 'Oracle Dig', description: 'Mocked provenance findings and evidence' },
     { to: '/metrics', label: 'Metrics', description: 'Runtime counters from /api/v1/metrics' },
     { to: '/mcp', label: 'MCP', description: 'Tool schemas and groups' },
     { to: '/storage', label: 'Storage', description: 'Backend config from /api/settings/system' },

--- a/frontend/src/components/NavSidebar.tsx
+++ b/frontend/src/components/NavSidebar.tsx
@@ -16,7 +16,7 @@ type NavGroup = {
 const navGroups: NavGroup[] = [
   { label: 'Core', paths: ['/', '/plugins', '/status'] },
   { label: 'Search', paths: ['/search', '/ask', '/feed'] },
-  { label: 'Knowledge', paths: ['/memory', '/memory/consolidation', '/learn', '/fleet-log', '/forum', '/activity', '/traces'] },
+  { label: 'Knowledge', paths: ['/memory', '/memory/consolidation', '/oracle-dig', '/learn', '/fleet-log', '/forum', '/activity', '/traces'] },
   { label: 'Vector', paths: ['/vector', '/vector/documents', '/vector/index', '/vector/first-run', '/vector/search', '/vector/settings', '/vector/export'] },
   { label: 'System', paths: ['/mcp', '/canvas', '/canvas/plugins', '/metrics', '/storage', '/settings', '/export'] },
 ];

--- a/frontend/src/components/OracleDigToggle.tsx
+++ b/frontend/src/components/OracleDigToggle.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ErrorMessage, Spinner } from './AsyncState';
+import { fetchJson } from '../pages/vectorSettingsHelpers';
+
+export type OracleDigToggleResponse = {
+  enabled?: boolean;
+  mode?: 'mock' | 'live';
+  findingCount?: number;
+  evidenceCount?: number;
+};
+
+const TOGGLE_ENDPOINT = '/api/plugins/oracle-dig/toggle';
+const mockStatus: Required<OracleDigToggleResponse> = {
+  enabled: true,
+  mode: 'mock',
+  findingCount: 5,
+  evidenceCount: 7,
+};
+
+function summary(status: OracleDigToggleResponse | null): string {
+  if (!status) return 'Oracle Dig status has not loaded yet.';
+  const findings = status.findingCount ?? mockStatus.findingCount;
+  const evidence = status.evidenceCount ?? mockStatus.evidenceCount;
+  return `${findings} mocked findings · ${evidence} typed evidence rows · ${status.mode ?? 'mock'} mode.`;
+}
+
+function fallbackMessage(nextEnabled: boolean, cause: unknown): string {
+  const reason = cause instanceof Error ? cause.message : String(cause);
+  return `Backend toggle endpoint is pending; locally mocked Oracle Dig ${nextEnabled ? 'enabled' : 'disabled'}. (${reason})`;
+}
+
+export function OracleDigToggle() {
+  const [status, setStatus] = useState<OracleDigToggleResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [message, setMessage] = useState('');
+  const enabled = status?.enabled !== false;
+  const statusText = useMemo(() => summary(status), [status]);
+
+  async function load() {
+    setError('');
+    setLoading(true);
+    try {
+      setStatus(mockStatus);
+      setMessage('Oracle Dig is running from the local mock until the plugin endpoint ships.');
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { void load(); }, []);
+
+  async function toggle(nextEnabled: boolean) {
+    setSaving(true);
+    setError('');
+    setMessage('');
+    try {
+      const response = await fetchJson<OracleDigToggleResponse>(TOGGLE_ENDPOINT, {
+        method: 'POST',
+        body: JSON.stringify({ enabled: nextEnabled }),
+      });
+      setStatus({ ...mockStatus, ...response, enabled: response.enabled ?? nextEnabled, mode: response.mode ?? 'live' });
+      setMessage(`Oracle Dig ${nextEnabled ? 'enabled' : 'disabled'} through ${TOGGLE_ENDPOINT}.`);
+    } catch (cause) {
+      setStatus((current) => ({ ...mockStatus, ...current, enabled: nextEnabled, mode: 'mock' }));
+      setMessage(fallbackMessage(nextEnabled, cause));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section className="rounded-3xl border border-border bg-surface p-5 sm:p-6" aria-labelledby="oracle-dig-toggle-title">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Oracle Dig panel</p>
+          <h2 id="oracle-dig-toggle-title" className="mt-2 text-2xl font-semibold text-text">Enable Oracle Dig</h2>
+          <p className="mt-2 text-sm text-text-muted">Mock-first control for provenance finding capture. The future backend target is POST {TOGGLE_ENDPOINT}.</p>
+          <p className="mt-2 text-xs text-text-muted">{loading ? 'Loading Oracle Dig switch…' : statusText}</p>
+        </div>
+        <label className="flex items-center gap-3 rounded-2xl border border-border bg-surface-muted px-4 py-3 text-sm font-semibold text-text">
+          <input checked={enabled} disabled={loading || saving} type="checkbox" onChange={(event) => void toggle(event.target.checked)} />
+          {saving ? <Spinner label="Saving" /> : enabled ? 'Enabled' : 'Disabled'}
+        </label>
+      </div>
+      {message ? <p className="mt-4 rounded-2xl border border-accent-border p-3 text-sm text-accent">{message}</p> : null}
+      {error ? <div className="mt-4"><ErrorMessage title="Oracle Dig toggle failed." message={error} /></div> : null}
+    </section>
+  );
+}

--- a/frontend/src/pages/OracleDigPage.tsx
+++ b/frontend/src/pages/OracleDigPage.tsx
@@ -1,0 +1,208 @@
+import { useMemo, useState } from 'react';
+import { Badge, type BadgeTone } from '../components/Badge';
+import { EmptyState } from '../components/EmptyState';
+import { StatCard } from '../components/StatCard';
+import {
+  EVIDENCE_KINDS,
+  FINDING_TOPICS,
+  ORACLE_DIG_CONTRACT,
+  emptyOracleDigFilters,
+  evidenceForFinding,
+  searchMockOracleFindings,
+  type EvidenceKind,
+  type FindingTopic,
+  type OracleDigFilters,
+  type OracleEvidence,
+  type OracleFinding,
+} from './oracleDigMock';
+
+const inputClass = 'focus-ring min-w-0 rounded-xl border border-border bg-field px-3 py-2 text-sm text-text placeholder:text-text-muted';
+const quietButton = 'focus-ring rounded-xl border border-border px-3 py-2 text-sm font-semibold text-text-muted transition hover:border-accent-border hover:text-text';
+const activeButton = 'border-accent-border bg-accent-soft text-accent';
+const confidenceOptions = ['all', 'high', 'medium', 'low'] as const;
+const evidenceTones: Record<EvidenceKind, BadgeTone> = { github: 'success', session: 'accent', 'oracle-msg': 'warning', web: 'neutral' };
+
+function formatTime(value: number | null): string {
+  return value ? new Date(value).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' }) : 'not recorded';
+}
+
+function confidenceLabel(value: number): 'high' | 'medium' | 'low' {
+  if (value >= 0.85) return 'high';
+  if (value >= 0.7) return 'medium';
+  return 'low';
+}
+
+function findingText(finding: OracleFinding): string {
+  return [finding.subject, finding.relation, finding.object].filter(Boolean).join(' ');
+}
+
+function endpointLabel(filters: OracleDigFilters): string {
+  const params = new URLSearchParams();
+  if (filters.query.trim()) params.set('query', filters.query.trim());
+  if (filters.topics.length) params.set('topic', filters.topics.join(','));
+  if (filters.confidence !== 'all') params.set('confidence', filters.confidence);
+  if (filters.evidenceKinds.length) params.set('evidenceKind', filters.evidenceKinds.join(','));
+  if (filters.dugBy.trim()) params.set('dugBy', filters.dugBy.trim());
+  if (filters.since) params.set('since', filters.since);
+  if (filters.until) params.set('until', filters.until);
+  const query = params.toString();
+  return `/api/plugins/oracle-dig${query ? `?${query}` : ''}`;
+}
+
+function ToggleGroup<T extends string>({ label, options, selected, onToggle }: {
+  label: string;
+  options: readonly T[];
+  selected: T[];
+  onToggle: (value: T) => void;
+}) {
+  return (
+    <fieldset className="grid gap-2">
+      <legend className="text-xs font-semibold uppercase tracking-[0.18em] text-text-muted">{label}</legend>
+      <div className="flex flex-wrap gap-2">
+        {options.map((option) => (
+          <button key={option} aria-pressed={selected.includes(option)} className={`${quietButton} ${selected.includes(option) ? activeButton : ''}`} type="button" onClick={() => onToggle(option)}>
+            {option}
+          </button>
+        ))}
+      </div>
+    </fieldset>
+  );
+}
+
+function FilterBar({ filters, onChange, onTopic, onKind, onReset }: {
+  filters: OracleDigFilters;
+  onChange: (updates: Partial<OracleDigFilters>) => void;
+  onTopic: (topic: FindingTopic) => void;
+  onKind: (kind: EvidenceKind) => void;
+  onReset: () => void;
+}) {
+  return (
+    <section className="glass grid gap-4 rounded-3xl p-4 sm:p-5" aria-label="Oracle Dig filters">
+      <div className="grid gap-3 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)_repeat(3,minmax(0,0.7fr))_auto] lg:items-end">
+        <label className="grid gap-2 text-sm font-semibold text-text" htmlFor="oracle-dig-query">
+          Search findings
+          <input id="oracle-dig-query" className={inputClass} type="search" placeholder="schema, provenance, fleet…" value={filters.query} onChange={(event) => onChange({ query: event.currentTarget.value })} />
+        </label>
+        <label className="grid gap-2 text-sm font-semibold text-text" htmlFor="oracle-dig-dug-by">
+          Dug by
+          <input id="oracle-dig-dug-by" className={inputClass} placeholder="metis" value={filters.dugBy} onChange={(event) => onChange({ dugBy: event.currentTarget.value })} />
+        </label>
+        <label className="grid gap-2 text-sm font-semibold text-text" htmlFor="oracle-dig-confidence">
+          Confidence
+          <select id="oracle-dig-confidence" className={inputClass} value={filters.confidence} onChange={(event) => onChange({ confidence: event.currentTarget.value as OracleDigFilters['confidence'] })}>
+            {confidenceOptions.map((option) => <option key={option} value={option}>{option}</option>)}
+          </select>
+        </label>
+        <label className="grid gap-2 text-sm font-semibold text-text" htmlFor="oracle-dig-since">
+          Since
+          <input id="oracle-dig-since" className={inputClass} type="date" value={filters.since} onChange={(event) => onChange({ since: event.currentTarget.value })} />
+        </label>
+        <label className="grid gap-2 text-sm font-semibold text-text" htmlFor="oracle-dig-until">
+          Until
+          <input id="oracle-dig-until" className={inputClass} type="date" value={filters.until} onChange={(event) => onChange({ until: event.currentTarget.value })} />
+        </label>
+        <button className={`${quietButton} justify-self-start lg:justify-self-stretch`} type="button" onClick={onReset}>Reset</button>
+      </div>
+      <ToggleGroup label="Topic" options={FINDING_TOPICS} selected={filters.topics} onToggle={onTopic} />
+      <ToggleGroup label="Evidence" options={EVIDENCE_KINDS} selected={filters.evidenceKinds} onToggle={onKind} />
+    </section>
+  );
+}
+
+function FindingRow({ finding, active, onSelect }: { finding: OracleFinding; active: boolean; onSelect: () => void }) {
+  const evidence = evidenceForFinding(finding.id);
+  return (
+    <li>
+      <button aria-pressed={active} className={`focus-ring grid w-full min-w-0 gap-3 rounded-2xl border p-4 text-left transition hover:border-accent-border hover:bg-surface-muted md:grid-cols-[9rem_minmax(0,1fr)_auto] md:items-start ${active ? 'border-accent-border bg-accent-soft' : 'border-border bg-surface'}`} type="button" onClick={onSelect}>
+        <time className="font-mono text-xs text-text-muted" dateTime={new Date(finding.asOfTs).toISOString()}>{formatTime(finding.asOfTs)}</time>
+        <span className="min-w-0">
+          <span className="block break-words text-sm font-semibold text-text">{findingText(finding)}</span>
+          <span className="mt-1 block text-sm leading-6 text-text-muted">{finding.dugBy} · {finding.topic} · {evidence.length} evidence record{evidence.length === 1 ? '' : 's'}</span>
+        </span>
+        <Badge tone={finding.confidence >= 0.85 ? 'success' : finding.confidence >= 0.7 ? 'accent' : 'warning'} dot>{confidenceLabel(finding.confidence)} {Math.round(finding.confidence * 100)}%</Badge>
+      </button>
+    </li>
+  );
+}
+
+function FindingsList({ findings, activeId, onSelect }: { findings: OracleFinding[]; activeId: string; onSelect: (id: string) => void }) {
+  if (!findings.length) return <EmptyState text="No mocked oracle_dig findings match the current filters." />;
+  return (
+    <ol className="grid gap-3" aria-label="Oracle Dig findings">
+      {findings.map((finding) => <FindingRow key={finding.id} finding={finding} active={finding.id === activeId} onSelect={() => onSelect(finding.id)} />)}
+    </ol>
+  );
+}
+
+function EvidenceLine({ item }: { item: OracleEvidence }) {
+  const label = item.githubPath ?? item.sessionId ?? item.oracleMsgFrom ?? item.webUrl ?? 'typed evidence';
+  const detail = item.kind === 'github'
+    ? `${item.githubOwner}/${item.githubRepo}@${item.githubRef}:${item.githubLine ?? 'path'}`
+    : item.kind === 'session'
+      ? `${item.sessionOracle} · ${item.sessionId}`
+      : item.kind === 'oracle-msg'
+        ? `${item.oracleMsgFrom} · ${formatTime(item.oracleMsgAt)}`
+        : `${item.webUrl} · fetched ${formatTime(item.webFetchedAt)}`;
+  return (
+    <article className="rounded-2xl border border-border bg-surface p-4">
+      <div className="flex flex-wrap items-center gap-2"><Badge tone={evidenceTones[item.kind]}>{item.kind}</Badge><span className="font-mono text-xs text-text-muted">#{item.id}</span></div>
+      <p className="mt-3 break-all text-sm font-semibold text-text">{label}</p>
+      <p className="mt-2 break-words text-sm leading-6 text-text-muted">{detail}</p>
+      <p className="mt-3 break-all font-mono text-xs text-text-muted">commit {item.commit ?? 'not pinned'}</p>
+    </article>
+  );
+}
+
+function EvidenceView({ finding }: { finding: OracleFinding | undefined }) {
+  if (!finding) return <EmptyState text="Select a finding to inspect typed evidence." />;
+  const evidence = evidenceForFinding(finding.id);
+  return (
+    <aside className="glass grid min-w-0 gap-4 rounded-3xl p-4 sm:p-5" aria-labelledby="oracle-dig-evidence-title">
+      <div className="min-w-0">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-accent">Evidence view</p>
+        <h2 id="oracle-dig-evidence-title" className="mt-2 break-words text-xl font-semibold text-text">{findingText(finding)}</h2>
+        <p className="mt-2 break-all font-mono text-xs text-text-muted">finding {finding.id} · as of {formatTime(finding.asOfTs)}</p>
+      </div>
+      <div className="grid gap-3">{evidence.map((item) => <EvidenceLine key={item.id} item={item} />)}</div>
+    </aside>
+  );
+}
+
+export function OracleDigPage() {
+  const [filters, setFilters] = useState<OracleDigFilters>(emptyOracleDigFilters);
+  const [selectedId, setSelectedId] = useState('');
+  const findings = useMemo(() => searchMockOracleFindings(filters), [filters]);
+  const activeId = selectedId && findings.some((finding) => finding.id === selectedId) ? selectedId : findings[0]?.id ?? '';
+  const activeFinding = findings.find((finding) => finding.id === activeId);
+  const evidenceCount = findings.reduce((count, finding) => count + evidenceForFinding(finding.id).length, 0);
+  const highCount = findings.filter((finding) => confidenceLabel(finding.confidence) === 'high').length;
+
+  function toggleTopic(topic: FindingTopic) {
+    setFilters((current) => ({ ...current, topics: current.topics.includes(topic) ? current.topics.filter((value) => value !== topic) : [...current.topics, topic] }));
+  }
+
+  function toggleKind(kind: EvidenceKind) {
+    setFilters((current) => ({ ...current, evidenceKinds: current.evidenceKinds.includes(kind) ? current.evidenceKinds.filter((value) => value !== kind) : [...current.evidenceKinds, kind] }));
+  }
+
+  return (
+    <section className="grid w-full min-w-0 gap-5" aria-labelledby="oracle-dig-title">
+      <header className="glass rounded-3xl p-5 sm:p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Oracle Dig / Provenance</p>
+        <h1 id="oracle-dig-title" className="mt-2 text-3xl font-semibold text-text">Oracle Dig findings</h1>
+        <p className="mt-2 max-w-3xl text-sm leading-6 text-text-muted">Mocked Phase 5 browser for relationship findings and typed evidence. The fixture mirrors oracle_findings + oracle_finding_evidence and the pending {ORACLE_DIG_CONTRACT} contract.</p>
+      </header>
+      <section className="grid gap-3 sm:grid-cols-3" aria-label="Oracle Dig summary">
+        <StatCard label="Findings" value={findings.length} detail="mocked relationship triples after filters" tone="accent" />
+        <StatCard label="Evidence" value={evidenceCount} detail="typed records linked to visible findings" tone="success" />
+        <StatCard label="High confidence" value={highCount} detail="findings at or above 85%" tone="neutral" />
+      </section>
+      <FilterBar filters={filters} onChange={(updates) => setFilters((current) => ({ ...current, ...updates }))} onTopic={toggleTopic} onKind={toggleKind} onReset={() => { setFilters(emptyOracleDigFilters); setSelectedId(''); }} />
+      <p className="break-all font-mono text-xs text-text-muted">Mock endpoint: {endpointLabel(filters)}</p>
+      <div className="grid min-w-0 gap-5 xl:grid-cols-[minmax(0,1.25fr)_minmax(22rem,0.75fr)] xl:items-start">
+        <FindingsList findings={findings} activeId={activeId} onSelect={setSelectedId} />
+        <EvidenceView finding={activeFinding} />
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, type ReactNode } from 'react';
 import { fetchSettingsSystem } from '../api';
 import { ErrorMessage, LoadingPanel, Spinner } from '../components/AsyncState';
+import { OracleDigToggle } from '../components/OracleDigToggle';
 import { VectorConfigPanel } from '../components/VectorConfigPanel';
 import { VectorProviderServicePanel } from '../components/VectorProviderServicePanel';
 import { VectorSearchToggle } from '../components/VectorSearchToggle';
@@ -112,6 +113,10 @@ export function SettingsPage({ menuCount, pluginCount, surfaceCount, updatedAt, 
       <section className="grid gap-5 xl:grid-cols-2" aria-label="Vector backend configuration">
         <div className="xl:col-span-2">
           <VectorSearchToggle />
+        </div>
+
+        <div className="xl:col-span-2">
+          <OracleDigToggle />
         </div>
 
         <div className="xl:col-span-2">

--- a/frontend/src/pages/oracleDigMock.ts
+++ b/frontend/src/pages/oracleDigMock.ts
@@ -1,0 +1,136 @@
+export const ORACLE_DIG_CONTRACT = 'GET /api/plugins/oracle-dig?query=&topic=&confidence=&evidenceKind=&dugBy=&since=&until=';
+export const EVIDENCE_KINDS = ['github', 'session', 'oracle-msg', 'web'] as const;
+export const FINDING_TOPICS = ['schema', 'frontend', 'fleet-log', 'mcp', 'ops'] as const;
+export type EvidenceKind = typeof EVIDENCE_KINDS[number];
+export type FindingTopic = typeof FINDING_TOPICS[number];
+export type ConfidenceFilter = 'all' | 'high' | 'medium' | 'low';
+
+export type OracleFinding = {
+  id: string;
+  tenantId: string;
+  subject: string;
+  relation: string | null;
+  object: string | null;
+  dugBy: string;
+  asOfTs: number;
+  asOfCommit: string | null;
+  confidence: number;
+  topic: FindingTopic;
+  frictionScore: number | null;
+  commissionedBy: string | null;
+  iterations: number;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type OracleEvidence = {
+  id: number;
+  findingId: string;
+  tenantId: string;
+  kind: EvidenceKind;
+  githubOwner: string | null;
+  githubRepo: string | null;
+  githubPath: string | null;
+  githubRef: string | null;
+  githubLine: number | null;
+  sessionId: string | null;
+  sessionOracle: string | null;
+  oracleMsgFrom: string | null;
+  oracleMsgAt: number | null;
+  webUrl: string | null;
+  webFetchedAt: number | null;
+  commit: string | null;
+  createdAt: number;
+};
+
+export type OracleDigFilters = {
+  query: string;
+  topics: FindingTopic[];
+  evidenceKinds: EvidenceKind[];
+  confidence: ConfidenceFilter;
+  dugBy: string;
+  since: string;
+  until: string;
+};
+
+const at = (value: string) => Date.parse(value);
+export const emptyOracleDigFilters: OracleDigFilters = { query: '', topics: [], evidenceKinds: [], confidence: 'all', dugBy: '', since: '', until: '' };
+
+export const mockOracleFindings: OracleFinding[] = [
+  {
+    id: 'dig_mock_001', tenantId: 'default', subject: 'oracle_dig', relation: 'stores', object: 'typed provenance',
+    dugBy: 'metis', asOfTs: at('2026-07-12T02:10:00.000Z'), asOfCommit: 'c8ae41ff', confidence: 0.94,
+    topic: 'schema', frictionScore: 0.18, commissionedBy: 'm5:arra-oracle-v3', iterations: 2,
+    createdAt: at('2026-07-12T02:12:00.000Z'), updatedAt: at('2026-07-12T02:20:00.000Z'),
+  },
+  {
+    id: 'dig_mock_002', tenantId: 'default', subject: 'Fleet Log console', relation: 'mirrors', object: 'mock-first API contract',
+    dugBy: 'frontend', asOfTs: at('2026-07-12T03:05:00.000Z'), asOfCommit: 'f0b3f169', confidence: 0.88,
+    topic: 'frontend', frictionScore: 0.24, commissionedBy: 'claude48', iterations: 1,
+    createdAt: at('2026-07-12T03:06:00.000Z'), updatedAt: at('2026-07-12T03:08:00.000Z'),
+  },
+  {
+    id: 'dig_mock_003', tenantId: 'default', subject: 'oracle_trace', relation: 'remains separate from', object: 'oracle_dig',
+    dugBy: 'oracle', asOfTs: at('2026-07-12T01:30:00.000Z'), asOfCommit: 'alpha', confidence: 0.79,
+    topic: 'mcp', frictionScore: 0.42, commissionedBy: 'schema-review', iterations: 3,
+    createdAt: at('2026-07-12T01:33:00.000Z'), updatedAt: at('2026-07-12T01:40:00.000Z'),
+  },
+  {
+    id: 'dig_mock_004', tenantId: 'default', subject: 'silent maw agents', relation: 'need', object: 'phase-5 git-log ingestion evidence',
+    dugBy: 'digger', asOfTs: at('2026-07-11T22:37:29.000Z'), asOfCommit: null, confidence: 0.63,
+    topic: 'ops', frictionScore: 0.61, commissionedBy: 'ops-room', iterations: 1,
+    createdAt: at('2026-07-11T22:38:00.000Z'), updatedAt: at('2026-07-11T22:45:00.000Z'),
+  },
+  {
+    id: 'dig_mock_005', tenantId: 'default', subject: 'fleet_messages', relation: 'connects to', object: 'oracle_dig evidence browse',
+    dugBy: 'm5:arra-oracle-v3', asOfTs: at('2026-07-12T04:00:00.000Z'), asOfCommit: 'alpha', confidence: 0.72,
+    topic: 'fleet-log', frictionScore: 0.31, commissionedBy: 'phase5', iterations: 1,
+    createdAt: at('2026-07-12T04:02:00.000Z'), updatedAt: at('2026-07-12T04:04:00.000Z'),
+  },
+];
+
+export const mockOracleEvidence: OracleEvidence[] = [
+  { id: 1, findingId: 'dig_mock_001', tenantId: 'default', kind: 'github', githubOwner: 'Soul-Brews-Studio', githubRepo: 'arra-oracle-v3', githubPath: 'src/db/oracle-dig-schema.ts', githubRef: 'alpha', githubLine: 3, sessionId: null, sessionOracle: null, oracleMsgFrom: null, oracleMsgAt: null, webUrl: null, webFetchedAt: null, commit: 'c8ae41ff', createdAt: at('2026-07-12T02:12:30.000Z') },
+  { id: 2, findingId: 'dig_mock_001', tenantId: 'default', kind: 'web', githubOwner: null, githubRepo: null, githubPath: null, githubRef: null, githubLine: null, sessionId: null, sessionOracle: null, oracleMsgFrom: null, oracleMsgAt: null, webUrl: 'https://github.com/Soul-Brews-Studio/arra-oracle-v3/issues/2770', webFetchedAt: at('2026-07-12T02:13:00.000Z'), commit: null, createdAt: at('2026-07-12T02:13:00.000Z') },
+  { id: 3, findingId: 'dig_mock_002', tenantId: 'default', kind: 'github', githubOwner: 'Soul-Brews-Studio', githubRepo: 'arra-oracle-v3', githubPath: 'frontend/src/pages/FleetLogPage.tsx', githubRef: 'feat/2765-fleet-log-console', githubLine: 1, sessionId: null, sessionOracle: null, oracleMsgFrom: null, oracleMsgAt: null, webUrl: null, webFetchedAt: null, commit: 'f0b3f169', createdAt: at('2026-07-12T03:07:00.000Z') },
+  { id: 4, findingId: 'dig_mock_002', tenantId: 'default', kind: 'session', githubOwner: null, githubRepo: null, githubPath: null, githubRef: null, githubLine: null, sessionId: 'omx-1783774150868-dsg7ho', sessionOracle: 'm5:arra-oracle-v3', oracleMsgFrom: null, oracleMsgAt: null, webUrl: null, webFetchedAt: null, commit: null, createdAt: at('2026-07-12T03:08:00.000Z') },
+  { id: 5, findingId: 'dig_mock_003', tenantId: 'default', kind: 'github', githubOwner: 'Soul-Brews-Studio', githubRepo: 'arra-oracle-v3', githubPath: 'docs/decisions/oracle-dig-provenance-schema.md', githubRef: 'alpha', githubLine: 26, sessionId: null, sessionOracle: null, oracleMsgFrom: null, oracleMsgAt: null, webUrl: null, webFetchedAt: null, commit: 'alpha', createdAt: at('2026-07-12T01:35:00.000Z') },
+  { id: 6, findingId: 'dig_mock_004', tenantId: 'default', kind: 'oracle-msg', githubOwner: null, githubRepo: null, githubPath: null, githubRef: null, githubLine: null, sessionId: null, sessionOracle: null, oracleMsgFrom: 'discord:ops-room', oracleMsgAt: at('2026-07-11T22:37:29.000Z'), webUrl: null, webFetchedAt: null, commit: null, createdAt: at('2026-07-11T22:38:00.000Z') },
+  { id: 7, findingId: 'dig_mock_005', tenantId: 'default', kind: 'github', githubOwner: 'Soul-Brews-Studio', githubRepo: 'arra-oracle-v3', githubPath: 'frontend/src/pages/fleetLogMock.ts', githubRef: 'alpha', githubLine: 1, sessionId: null, sessionOracle: null, oracleMsgFrom: null, oracleMsgAt: null, webUrl: null, webFetchedAt: null, commit: 'alpha', createdAt: at('2026-07-12T04:03:00.000Z') },
+];
+
+function includes(value: string | null | undefined, query: string): boolean {
+  return value?.toLowerCase().includes(query.toLowerCase()) ?? false;
+}
+
+function confidenceBand(value: number): Exclude<ConfidenceFilter, 'all'> {
+  if (value >= 0.85) return 'high';
+  if (value >= 0.7) return 'medium';
+  return 'low';
+}
+
+function afterDate(ts: number, since: string): boolean {
+  return !since || ts >= new Date(`${since}T00:00:00`).getTime();
+}
+
+function beforeDate(ts: number, until: string): boolean {
+  return !until || ts <= new Date(`${until}T23:59:59.999`).getTime();
+}
+
+export function evidenceForFinding(findingId: string): OracleEvidence[] {
+  return mockOracleEvidence.filter((item) => item.findingId === findingId);
+}
+
+export function searchMockOracleFindings(filters: OracleDigFilters): OracleFinding[] {
+  const q = filters.query.trim();
+  const dugBy = filters.dugBy.trim().toLowerCase();
+  return mockOracleFindings
+    .filter((finding) => !filters.topics.length || filters.topics.includes(finding.topic))
+    .filter((finding) => filters.confidence === 'all' || confidenceBand(finding.confidence) === filters.confidence)
+    .filter((finding) => !dugBy || includes(finding.dugBy, dugBy))
+    .filter((finding) => afterDate(finding.asOfTs, filters.since) && beforeDate(finding.asOfTs, filters.until))
+    .filter((finding) => !filters.evidenceKinds.length || evidenceForFinding(finding.id).some((item) => filters.evidenceKinds.includes(item.kind)))
+    .filter((finding) => !q || [finding.subject, finding.relation, finding.object, finding.topic, finding.dugBy]
+      .some((value) => includes(value, q)) || evidenceForFinding(finding.id).some((item) => [item.githubPath, item.sessionId, item.oracleMsgFrom, item.webUrl].some((value) => includes(value, q))))
+    .sort((left, right) => right.asOfTs - left.asOfTs);
+}

--- a/frontend/src/routeMeta.ts
+++ b/frontend/src/routeMeta.ts
@@ -97,6 +97,10 @@ export function routeMeta(pathname: string, search = ''): RouteMeta {
     ]);
   }
 
+  if (pathname === '/oracle-dig') {
+    return base('Oracle Dig findings', 'Oracle Dig', 'Browse mocked provenance findings and typed evidence before the plugin endpoint lands.', [{ label: 'Oracle Dig' }]);
+  }
+
   if (pathname === '/plugins') return base('Plugin list', 'Plugins', 'Registered plugins and exposed runtime surfaces.', [{ label: 'Plugins' }]);
   if (pathname === '/status') return base('Server status', 'Status', 'Server health from /api/v1/health.', [{ label: 'Status' }]);
   if (pathname === '/canvas') return base('Canvas app', 'Canvas', 'Studio alias for canvas.buildwithoracle.com.', [{ label: 'Canvas app' }]);

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -12,6 +12,7 @@ import { LearnPage } from './pages/LearnPage';
 import { MemoryPage } from './pages/MemoryPage';
 import { MemoryConsolidationPage } from './pages/MemoryConsolidationPage';
 import { MenuPage } from './pages/MenuPage';
+import { OracleDigPage } from './pages/OracleDigPage';
 import { PluginsPage } from './pages/PluginsPage';
 import { CanvasAliasPage } from './pages/CanvasAliasPage';
 import { CanvasPluginsPage } from './pages/CanvasPluginsPage';
@@ -52,6 +53,7 @@ export const frontendRoutes = [
   '/learn',
   '/memory',
   '/memory/consolidation',
+  '/oracle-dig',
   '/vector',
   '/vector/search',
   '/vector/documents',
@@ -130,6 +132,7 @@ export function DashboardRoutes({
       <Route path="/learn" element={<LearnPage />} />
       <Route path="/memory" element={<MemoryPage />} />
       <Route path="/memory/consolidation" element={<MemoryConsolidationPage />} />
+      <Route path="/oracle-dig" element={<OracleDigPage />} />
       <Route path="/menu" element={menuPage} />
       <Route path="/vector" element={<VectorPage />} />
       <Route path="/vector/search" element={<VectorSearchPage />} />


### PR DESCRIPTION
## Summary
- Adds mock-first `/oracle-dig` dashboard route for browsing provenance findings and typed evidence.
- Adds `frontend/src/pages/oracleDigMock.ts` with typed `OracleFinding` / `OracleEvidence` arrays, pure filter functions, and future `GET /api/plugins/oracle-dig` contract constant following the Fleet Log fixture pattern.
- Adds `OracleDigToggle` to Settings next to `VectorSearchToggle`; it uses `fetchJson` and targets `POST /api/plugins/oracle-dig/toggle`, falling back to local mock state while the backend endpoint is pending.
- Registers route metadata, router entry, sidebar group, and shell nav item.

## Mock contract notes
Future browse endpoint documented by `ORACLE_DIG_CONTRACT`:
`GET /api/plugins/oracle-dig?query=&topic=&confidence=&evidenceKind=&dugBy=&since=&until=`

Fixture shape mirrors the accepted oracle_dig provenance schema:
- findings: `id`, `tenantId`, `subject`, `relation`, `object`, `dugBy`, `asOfTs`, `asOfCommit`, `confidence`, `topic`, `frictionScore`, `commissionedBy`, `iterations`, `createdAt`, `updatedAt`
- evidence: `id`, `findingId`, `tenantId`, `kind`, GitHub fields, session fields, oracle message fields, web fields, `commit`, `createdAt`

## Verification
- `cd frontend && bunx tsc --noEmit` ✅
- `cd frontend && bun run build` ✅ (existing Vite chunk-size warning only)
- `cd frontend && bun test` ✅ (16 pass)
- changed source files ≤250 lines ✅
