### PR TITLE
feat: add oracle dig phase 3 bridge

### DIFF
--- a/src/plugins/oracle-dig/__tests__/sessions.test.ts
+++ b/src/plugins/oracle-dig/__tests__/sessions.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { mkdtempSync } from 'node:fs';
+import { ORACLE_SESSIONS_SINGLE_MACHINE_NOTE, oracleSessions } from '../sessions.ts';
+
+const cleanup: string[] = [];
+
+afterEach(() => {
+  while (cleanup.length) {
+    const dir = cleanup.pop()!;
+    if (existsSync(dir)) rmSync(dir, { recursive: true });
+  }
+});
+
+function tempProjectsDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'oracle-sessions-'));
+  cleanup.push(dir);
+  return dir;
+}
+
+describe('oracle_sessions scanner', () => {
+  test('scans local claude project jsonl files without shelling out', async () => {
+    const projectsDir = tempProjectsDir();
+    const projectDir = join(projectsDir, 'github-com-Soul-Brews-Studio-arra-oracle-v3');
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(join(projectDir, 'session-a.jsonl'), [
+      JSON.stringify({ sessionId: 'session-a', timestamp: '2026-07-12T00:00:00.000Z', message: { role: 'user', content: 'Find oracle dig schema' } }),
+      'not json',
+      JSON.stringify({ sessionId: 'session-a', timestamp: '2026-07-12T00:01:00.000Z', model: 'claude-opus', message: { role: 'assistant', content: [{ type: 'text', text: 'Found schema evidence' }] } }),
+    ].join('\n'));
+    writeFileSync(join(projectDir, 'ignore.txt'), '{}\n');
+
+    const result = await oracleSessions({ projectsDir });
+
+    expect(result.capability).toBe('oracle_sessions');
+    expect(result.scope).toBe('single-machine');
+    expect(result.note).toBe(ORACLE_SESSIONS_SINGLE_MACHINE_NOTE);
+    expect(result.note).toContain('single-machine only');
+    expect(result.total).toBe(1);
+    expect(result.sessions[0]).toEqual(expect.objectContaining({
+      sessionId: 'session-a',
+      project: 'github-com-Soul-Brews-Studio-arra-oracle-v3',
+      messageCount: 2,
+      userMessages: 1,
+      assistantMessages: 1,
+      oracle: 'claude-opus',
+      preview: 'Find oracle dig schema',
+      firstTimestamp: Date.parse('2026-07-12T00:00:00.000Z'),
+      lastTimestamp: Date.parse('2026-07-12T00:01:00.000Z'),
+    }));
+    expect(result.sessions[0].path.endsWith('session-a.jsonl')).toBe(true);
+  });
+
+  test('returns an empty single-machine result when the local cache is missing', async () => {
+    const result = await oracleSessions({ projectsDir: join(tempProjectsDir(), 'missing') });
+    expect(result.total).toBe(0);
+    expect(result.sessions).toEqual([]);
+  });
+});

--- a/src/plugins/oracle-dig/__tests__/trace-bridge.test.ts
+++ b/src/plugins/oracle-dig/__tests__/trace-bridge.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test';
+import type { ToolResponse } from '../../../tools/types.ts';
+import { bridgeTraceToGithubEvidence, mapTraceGithubEvidence } from '../trace-bridge.ts';
+
+const toolJson = (value: unknown): ToolResponse => ({
+  content: [{ type: 'text', text: JSON.stringify(value) }],
+});
+
+describe('oracle dig trace bridge', () => {
+  test('calls trace core handlers and maps dig points to github evidence', async () => {
+    const calls: string[] = [];
+    const result = await bridgeTraceToGithubEvidence({
+      findingId: 'finding-1',
+      tenantId: 'tenant-a',
+      asOfCommit: 'abc123',
+      createdAt: 1234,
+      trace: {
+        query: 'phase 3 bridge',
+        project: 'github.com/Soul-Brews-Studio/arra-oracle-v3',
+        foundFiles: [{ path: 'src/plugins/oracle-dig/trace-bridge.ts:42', type: 'other' }],
+        foundCommits: [{ hash: 'deadbeef', shortHash: 'deadbee', date: '2026-07-12', message: 'bridge' }],
+        foundIssues: [{ number: 2771, title: 'schema', state: 'closed', url: 'https://github.com/Soul-Brews-Studio/arra-oracle-v3/issues/2771' }],
+      },
+    }, {
+      handleTrace: async (input) => {
+        calls.push(`trace:${input.query}`);
+        return toolJson({ success: true, trace_id: 'trace-1' });
+      },
+      handleTraceList: async (input) => {
+        calls.push(`list:${input.query}`);
+        return toolJson({ traces: [{ trace_id: 'trace-1' }], total: 1, has_more: false });
+      },
+    });
+
+    expect(calls).toEqual(['trace:phase 3 bridge', 'list:phase 3 bridge']);
+    expect(result.traceId).toBe('trace-1');
+    expect(result.evidenceRows).toEqual([
+      expect.objectContaining({
+        findingId: 'finding-1', tenantId: 'tenant-a', kind: 'github',
+        githubOwner: 'Soul-Brews-Studio', githubRepo: 'arra-oracle-v3',
+        githubPath: 'src/plugins/oracle-dig/trace-bridge.ts', githubLine: 42,
+        githubRef: 'abc123', commit: 'abc123', createdAt: 1234,
+      }),
+      expect.objectContaining({
+        githubOwner: 'Soul-Brews-Studio', githubRepo: 'arra-oracle-v3',
+        githubRef: 'deadbeef', commit: 'deadbeef', kind: 'github',
+      }),
+      expect.objectContaining({
+        githubOwner: 'Soul-Brews-Studio', githubRepo: 'arra-oracle-v3',
+        githubPath: 'issues/2771', githubRef: '#2771', kind: 'github',
+      }),
+    ]);
+  });
+
+  test('does not treat local multi-segment paths as owner/repo paths', () => {
+    const [row] = mapTraceGithubEvidence({
+      findingId: 'finding-local',
+      trace: { query: 'local', foundFiles: [{ path: 'src/routes/health/index.ts#L7', type: 'other' }] },
+      createdAt: 77,
+    });
+    expect(row).toEqual(expect.objectContaining({
+      githubPath: 'src/routes/health/index.ts',
+      githubLine: 7,
+      githubOwner: undefined,
+      githubRepo: undefined,
+      kind: 'github',
+      createdAt: 77,
+    }));
+  });
+});

--- a/src/plugins/oracle-dig/sessions.ts
+++ b/src/plugins/oracle-dig/sessions.ts
@@ -1,0 +1,161 @@
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { basename, join } from 'node:path';
+
+export const ORACLE_SESSIONS_SINGLE_MACHINE_NOTE =
+  'oracle_sessions is single-machine only: it scans local ~/.claude/projects/*/*.jsonl transcripts and is not fleet-wide.';
+
+type JsonObject = Record<string, unknown>;
+
+export interface OracleSessionsOptions {
+  homeDir?: string;
+  projectsDir?: string;
+  limit?: number;
+}
+
+export interface OracleSessionSummary {
+  sessionId: string;
+  project: string;
+  path: string;
+  messageCount: number;
+  userMessages: number;
+  assistantMessages: number;
+  oracle?: string;
+  firstTimestamp?: number;
+  lastTimestamp?: number;
+  preview?: string;
+}
+
+export interface OracleSessionsResult {
+  capability: 'oracle_sessions';
+  scope: 'single-machine';
+  note: string;
+  root: string;
+  total: number;
+  sessions: OracleSessionSummary[];
+}
+
+/**
+ * Single-machine capability: scans only this host's local Claude JSONL cache.
+ * It intentionally does not claim fleet-wide/federated session visibility.
+ */
+export async function oracleSessions(options: OracleSessionsOptions = {}): Promise<OracleSessionsResult> {
+  const root = options.projectsDir ?? join(options.homeDir ?? homedir(), '.claude', 'projects');
+  const files = await listJsonlFiles(root);
+  const sessions = [] as OracleSessionSummary[];
+  for (const file of files) sessions.push(await summarizeSession(file.path, file.project));
+  sessions.sort((a, b) => (b.lastTimestamp ?? 0) - (a.lastTimestamp ?? 0) || a.path.localeCompare(b.path));
+  const limit = boundedLimit(options.limit, sessions.length);
+  return {
+    capability: 'oracle_sessions',
+    scope: 'single-machine',
+    note: ORACLE_SESSIONS_SINGLE_MACHINE_NOTE,
+    root,
+    total: sessions.length,
+    sessions: sessions.slice(0, limit),
+  };
+}
+
+export const scanOracleSessions = oracleSessions;
+export const oracle_sessions = oracleSessions;
+
+async function listJsonlFiles(root: string): Promise<Array<{ path: string; project: string }>> {
+  try {
+    if (!(await stat(root)).isDirectory()) return [];
+  } catch {
+    return [];
+  }
+  const projects = await readdir(root, { withFileTypes: true });
+  const files = [] as Array<{ path: string; project: string }>;
+  for (const project of projects) {
+    if (!project.isDirectory()) continue;
+    const projectDir = join(root, project.name);
+    for (const entry of await readdir(projectDir, { withFileTypes: true })) {
+      if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+        files.push({ path: join(projectDir, entry.name), project: project.name });
+      }
+    }
+  }
+  return files.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+async function summarizeSession(path: string, project: string): Promise<OracleSessionSummary> {
+  const lines = (await readFile(path, 'utf8')).split(/\r?\n/);
+  const summary: OracleSessionSummary = {
+    sessionId: basename(path, '.jsonl'),
+    project,
+    path,
+    messageCount: 0,
+    userMessages: 0,
+    assistantMessages: 0,
+  };
+
+  for (const line of lines) {
+    const row = parseLine(line);
+    if (!row) continue;
+    summary.messageCount += 1;
+    summary.sessionId = stringField(row, 'sessionId') ?? stringField(row, 'session_id') ?? summary.sessionId;
+    summary.oracle = summary.oracle ?? stringField(row, 'oracle') ?? stringField(row, 'model') ?? stringField(asObject(row.message), 'model');
+    const role = stringField(asObject(row.message), 'role') ?? stringField(row, 'role') ?? stringField(row, 'type');
+    if (role === 'user') summary.userMessages += 1;
+    if (role === 'assistant') summary.assistantMessages += 1;
+    const timestamp = timestampMs(row.timestamp ?? row.created_at ?? row.createdAt);
+    if (timestamp !== undefined) {
+      summary.firstTimestamp = Math.min(summary.firstTimestamp ?? timestamp, timestamp);
+      summary.lastTimestamp = Math.max(summary.lastTimestamp ?? timestamp, timestamp);
+    }
+    summary.preview = summary.preview ?? clippedText(extractText(row));
+  }
+
+  return summary;
+}
+
+function parseLine(line: string): JsonObject | undefined {
+  const trimmed = line.trim();
+  if (!trimmed) return undefined;
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    return asObject(parsed);
+  } catch {
+    return undefined;
+  }
+}
+
+function extractText(row: JsonObject): string | undefined {
+  const message = asObject(row.message);
+  return textFromValue(message?.content) ?? textFromValue(row.content) ?? textFromValue(row.text);
+}
+
+function textFromValue(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) return value.map((part) => textFromValue(part)).filter(Boolean).join(' ');
+  const object = asObject(value);
+  return object ? textFromValue(object.text) : undefined;
+}
+
+function clippedText(value: string | undefined): string | undefined {
+  const normalized = value?.replace(/\s+/g, ' ').trim();
+  if (!normalized) return undefined;
+  return normalized.length > 160 ? `${normalized.slice(0, 157)}...` : normalized;
+}
+
+function timestampMs(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value !== 'string') return undefined;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function asObject(value: unknown): JsonObject | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as JsonObject : undefined;
+}
+
+function stringField(object: JsonObject | undefined, key: string): string | undefined {
+  const value = object?.[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function boundedLimit(value: number | undefined, fallback: number): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.max(0, Math.trunc(value!));
+}

--- a/src/plugins/oracle-dig/trace-bridge.ts
+++ b/src/plugins/oracle-dig/trace-bridge.ts
@@ -1,0 +1,177 @@
+import { handleTrace, handleTraceList } from '../../tools/trace.ts';
+import type { ToolResponse } from '../../tools/types.ts';
+import type { CreateTraceInput, FoundFile, FoundIssue, ListTracesInput } from '../../trace/types.ts';
+import type { oracleFindingEvidence } from '../../db/oracle-dig-schema.ts';
+
+export type OracleFindingEvidenceInsert = typeof oracleFindingEvidence.$inferInsert;
+
+type JsonObject = Record<string, unknown>;
+
+interface RepoRef {
+  owner?: string;
+  repo?: string;
+}
+
+interface FileRef extends RepoRef {
+  path?: string;
+  ref?: string;
+  line?: number;
+}
+
+export interface TraceBridgeInput {
+  findingId: string;
+  trace: CreateTraceInput;
+  tenantId?: string;
+  asOfCommit?: string;
+  createdAt?: number;
+  listInput?: ListTracesInput;
+}
+
+export interface TraceBridgeHandlers {
+  handleTrace: typeof handleTrace;
+  handleTraceList: typeof handleTraceList;
+}
+
+export interface TraceBridgeResult {
+  traceId?: string;
+  trace: JsonObject;
+  traceList: JsonObject;
+  evidenceRows: OracleFindingEvidenceInsert[];
+}
+
+export const defaultTraceBridgeHandlers: TraceBridgeHandlers = { handleTrace, handleTraceList };
+
+export async function bridgeTraceToGithubEvidence(
+  input: TraceBridgeInput,
+  handlers: TraceBridgeHandlers = defaultTraceBridgeHandlers,
+): Promise<TraceBridgeResult> {
+  const traceResponse = await handlers.handleTrace(input.trace);
+  const tracePayload = parseToolJson(traceResponse);
+  if (traceResponse.isError || tracePayload.success === false) {
+    throw new Error(`oracle_trace failed: ${JSON.stringify(tracePayload)}`);
+  }
+
+  const listResponse = await handlers.handleTraceList(input.listInput ?? {
+    limit: 20,
+    project: input.trace.project,
+    query: input.trace.query,
+  });
+  const traceList = parseToolJson(listResponse);
+
+  return {
+    traceId: stringValue(tracePayload.trace_id),
+    trace: tracePayload,
+    traceList,
+    // handleTrace stores, but does not echo, dig points; derive evidence from
+    // the exact found* payload sent to the direct core call above.
+    evidenceRows: mapTraceGithubEvidence(input),
+  };
+}
+
+export function mapTraceGithubEvidence(input: TraceBridgeInput): OracleFindingEvidenceInsert[] {
+  const tenantId = input.tenantId ?? 'default';
+  const createdAt = input.createdAt ?? Date.now();
+  const baseRepo = parseRepoRef(input.trace.project);
+  const common = { findingId: input.findingId, tenantId, kind: 'github' as const, createdAt };
+  const rows: OracleFindingEvidenceInsert[] = [];
+
+  for (const file of input.trace.foundFiles ?? []) {
+    const fileRef = parseFileRef(file, baseRepo);
+    rows.push({
+      ...common,
+      githubOwner: fileRef.owner,
+      githubRepo: fileRef.repo,
+      githubPath: fileRef.path,
+      githubRef: input.asOfCommit ?? fileRef.ref,
+      githubLine: fileRef.line,
+      commit: input.asOfCommit,
+    });
+  }
+
+  for (const commit of input.trace.foundCommits ?? []) {
+    rows.push({
+      ...common,
+      githubOwner: baseRepo.owner,
+      githubRepo: baseRepo.repo,
+      githubRef: commit.hash || commit.shortHash,
+      commit: commit.hash || commit.shortHash,
+    });
+  }
+
+  for (const issue of input.trace.foundIssues ?? []) {
+    const issueRepo = parseIssueRepo(issue) ?? baseRepo;
+    rows.push({
+      ...common,
+      githubOwner: issueRepo.owner,
+      githubRepo: issueRepo.repo,
+      githubPath: `issues/${issue.number}`,
+      githubRef: `#${issue.number}`,
+      commit: input.asOfCommit,
+    });
+  }
+
+  return rows;
+}
+
+function parseToolJson(response: ToolResponse): JsonObject {
+  const text = response.content.find((part) => part.type === 'text')?.text ?? '{}';
+  const parsed = JSON.parse(text) as unknown;
+  return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed as JsonObject : { value: parsed };
+}
+
+function parseFileRef(file: FoundFile, baseRepo: RepoRef): FileRef {
+  let raw = file.path.trim();
+  let line: number | undefined;
+  const hashLine = raw.match(/#L(\d+)$/i);
+  const colonLine = raw.match(/:(\d+)$/);
+  if (hashLine) {
+    line = Number(hashLine[1]);
+    raw = raw.slice(0, -hashLine[0].length);
+  } else if (colonLine) {
+    line = Number(colonLine[1]);
+    raw = raw.slice(0, -colonLine[0].length);
+  }
+
+  const embedded = parseRepoPath(raw);
+  return {
+    owner: embedded.owner ?? baseRepo.owner,
+    repo: embedded.repo ?? baseRepo.repo,
+    path: embedded.path ?? raw,
+    ref: embedded.ref,
+    line,
+  };
+}
+
+function parseIssueRepo(issue: FoundIssue): RepoRef | undefined {
+  if (!issue.url) return undefined;
+  const match = issue.url.match(/github\.com\/([^/]+)\/([^/]+)\/(?:issues|pull)\/\d+/i);
+  if (!match) return undefined;
+  return { owner: match[1], repo: trimGit(match[2]) };
+}
+
+function parseRepoPath(value: string): FileRef {
+  const clean = value.replace(/^https?:\/\//, '');
+  if (!clean.startsWith('github.com/')) return {};
+  const parts = clean.replace(/^github\.com\//, '').split('/').filter(Boolean);
+  if (parts.length < 3) return {};
+  if ((parts[2] === 'blob' || parts[2] === 'tree') && parts.length >= 5) {
+    return { owner: parts[0], repo: trimGit(parts[1]), ref: parts[3], path: parts.slice(4).join('/') };
+  }
+  return { owner: parts[0], repo: trimGit(parts[1]), path: parts.slice(2).join('/') };
+}
+
+function parseRepoRef(value?: string): RepoRef {
+  if (!value) return {};
+  const clean = value.replace(/^https?:\/\//, '').replace(/^github\.com\//, '').replace(/\.git$/, '');
+  const parts = clean.split('/').filter(Boolean);
+  if (parts.length < 2) return {};
+  return { owner: parts.at(-2), repo: trimGit(parts.at(-1) ?? '') };
+}
+
+function trimGit(value: string): string {
+  return value.replace(/\.git$/, '');
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}


### PR DESCRIPTION
## Summary
- add oracle_dig trace bridge that calls core oracle_trace handlers and converts trace dig points into github evidence rows
- add local single-machine oracle_sessions JSONL scanner for ~/.claude/projects/*/*.jsonl
- add unit tests with fixture data for both modules

## Validation
- bun test src/plugins/oracle-dig/__tests__/trace-bridge.test.ts src/plugins/oracle-dig/__tests__/sessions.test.ts
- bunx tsc --noEmit
- git diff --cached --check
- wc -l changed files <=250
