### PR TITLE
fix: populate plugin MCP tools from runtime registry

### DIFF
--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -10,7 +10,8 @@ import {
 import type { LoadedUnifiedPlugin, UnifiedPluginStatus } from './unified-loader.ts';
 
 type PluginManifest = LoadedUnifiedPlugin['manifest'];
-type PublicMcpTool = Omit<PluginManifest['mcpTools'][number], 'handler'> & { source: 'plugin'; plugin: string };
+export type RegisteredMcpTool = PluginManifest['mcpTools'][number] & { plugin?: string };
+export type PublicMcpTool = Omit<PluginManifest['mcpTools'][number], 'handler'> & { source: 'plugin'; plugin: string };
 type PublicApiRoute = Omit<PluginManifest['apiRoutes'][number], 'handler'>;
 type PublicCliSubcommand = Omit<PluginManifest['cliSubcommands'][number], 'handler'>;
 type PublicExportFormat = { name: string; extension: string };
@@ -45,6 +46,17 @@ function publicMcpTools(manifest: PluginManifest): PublicMcpTool[] {
     .map(({ handler, ...tool }) => ({ ...tool, source: 'plugin', plugin: manifest.name }));
 }
 
+export function publicMcpToolsByPlugin(tools: RegisteredMcpTool[]): Map<string, PublicMcpTool[]> {
+  const byPlugin = new Map<string, PublicMcpTool[]>();
+  for (const { handler, plugin, ...tool } of tools) {
+    if (!plugin || tool.enabled === false) continue;
+    const current = byPlugin.get(plugin) ?? [];
+    current.push({ ...tool, source: 'plugin', plugin });
+    byPlugin.set(plugin, current);
+  }
+  return byPlugin;
+}
+
 function publicApiRoutes(manifest: PluginManifest): PublicApiRoute[] {
   return manifest.apiRoutes.map(({ handler, ...route }) => route);
 }
@@ -60,8 +72,10 @@ function publicExportFormats(manifest: PluginManifest): PublicExportFormat[] {
 export function pluginRegistryFromLoadedPlugins(
   plugins: LoadedUnifiedPlugin[],
   statuses: UnifiedPluginStatus[],
+  registeredMcpTools?: RegisteredMcpTool[],
 ): LoadedPluginRegistryEntry[] {
   const statusByName = new Map(statuses.map((status) => [status.name, status]));
+  const runtimeMcpTools = registeredMcpTools ? publicMcpToolsByPlugin(registeredMcpTools) : null;
   return plugins.map((plugin) => {
     const status = statusByName.get(plugin.manifest.name);
     return {
@@ -74,7 +88,7 @@ export function pluginRegistryFromLoadedPlugins(
       description: plugin.manifest.description,
       menu: plugin.manifest.menu[0],
       server: publicUnifiedServerManifest(plugin.manifest.server),
-      mcpTools: publicMcpTools(plugin.manifest),
+      mcpTools: runtimeMcpTools ? (runtimeMcpTools.get(plugin.manifest.name) ?? []) : publicMcpTools(plugin.manifest),
       apiRoutes: publicApiRoutes(plugin.manifest),
       proxy: plugin.manifest.proxy,
       cliSubcommands: publicCliSubcommands(plugin.manifest),

--- a/src/plugins/unified-loader.ts
+++ b/src/plugins/unified-loader.ts
@@ -191,7 +191,7 @@ function runtimeFrom(initialPlugins: LoadedUnifiedPlugin[], options: UnifiedLoad
   };
   const pluginStatuses = () => plugins.map((plugin) => pluginStatus.get(plugin.manifest.name)
     ?? { name: plugin.manifest.name, status: 'ok' as const });
-  const pluginRegistry = () => pluginRegistryFromLoadedPlugins(plugins, pluginStatuses());
+  const pluginRegistry = () => pluginRegistryFromLoadedPlugins(plugins, pluginStatuses(), mcpTools);
   const rebuild = (next: LoadedUnifiedPlugin[]) => {
     plugins = next; mcpInvokers.clear(); pluginStatus.clear(); initialized.clear();
     replaceAll(routes, []); replaceAll(mcpTools, []); replaceAll(menu, []); replaceAll(cliSubcommands, []); replaceAll(servers, []);

--- a/src/routes/plugins/registry.ts
+++ b/src/routes/plugins/registry.ts
@@ -1,13 +1,24 @@
 import { Elysia, t } from 'elysia';
-import type { LoadedPluginRegistryEntry } from '../../plugins/registry.ts';
+import { publicMcpToolsByPlugin, type LoadedPluginRegistryEntry } from '../../plugins/registry.ts';
+import type { UnifiedRuntime } from '../../plugins/unified-loader.ts';
+import type { UnifiedRuntimeRef } from '../../plugins/runtime-routes.ts';
 import { basePluginDir, scanPlugins } from './model.ts';
 import { readPluginEnabled } from './state.ts';
 import { hasTenantPluginScope, tenantScopedPluginDir } from './tenant.ts';
 
+type RegistryRuntime = Pick<UnifiedRuntime, 'mcpTools'>;
+
 export interface PluginsRegistryRouteOptions {
   dir?: string;
   registry?: () => LoadedPluginRegistryEntry[];
+  runtime?: RegistryRuntime;
+  runtimeRef?: UnifiedRuntimeRef<RegistryRuntime>;
   canvasMetadataRegistry?: () => unknown | Promise<unknown>;
+}
+
+function runtimeMcpTools(options: PluginsRegistryRouteOptions) {
+  const tools = options.runtimeRef?.current.mcpTools ?? options.runtime?.mcpTools;
+  return tools ? publicMcpToolsByPlugin(tools) : null;
 }
 
 export function createPluginsRegistryRoute(options: PluginsRegistryRouteOptions = {}) {
@@ -19,9 +30,11 @@ export function createPluginsRegistryRoute(options: PluginsRegistryRouteOptions 
     }
     const dir = tenantScopedPluginDir(options.dir ?? basePluginDir());
     if (!options.registry || hasTenantPluginScope()) return scanPlugins(dir);
+    const toolsByPlugin = runtimeMcpTools(options);
     const plugins = options.registry().map((plugin) => ({
       ...plugin,
       enabled: readPluginEnabled(plugin.name) ?? plugin.enabled ?? true,
+      mcpTools: toolsByPlugin ? (toolsByPlugin.get(plugin.name) ?? []) : plugin.mcpTools,
     }));
     return { plugins, count: plugins.length, dir };
   }, {

--- a/tests/http/plugins/registry-hardening.test.ts
+++ b/tests/http/plugins/registry-hardening.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Elysia } from 'elysia';
 
+import { createApiVersionedFetch } from '../../../src/middleware/api-version.ts';
+import { createUnifiedRuntimeRef } from '../../../src/plugins/runtime-routes.ts';
 import { loadUnifiedPlugins } from '../../../src/plugins/unified-loader.ts';
 import { createPluginsRouter } from '../../../src/routes/plugins/index.ts';
 import { pluginDir } from '../../plugins/_fixtures.ts';
@@ -21,8 +23,10 @@ function tempRoot(prefix: string): string {
   return root;
 }
 
-async function pluginsBody(app: Elysia) {
-  const res = await app.handle(new Request('http://local/api/plugins'));
+async function pluginsBody(app: Elysia, path = '/api/plugins') {
+  const handle = (request: Request) => app.handle(request);
+  const fetch = path.startsWith('/api/v1') ? createApiVersionedFetch(handle) : handle;
+  const res = await fetch(new Request(`http://local${path}`));
   expect(res.status).toBe(200);
   return await res.json() as { count: number; plugins: Array<Record<string, any>>; dir: string };
 }
@@ -63,6 +67,41 @@ describe('GET /api/plugins registry hardening', () => {
     });
     expect(plugin.mcpTools.map((tool: Record<string, unknown>) => tool.name)).not.toContain('oracle_surface_disabled');
     expect(plugin.mcpTools[0]).not.toHaveProperty('handler');
+  });
+
+  test('populates MCP tools from the live runtime registry', async () => {
+    const root = tempRoot('arra-plugin-runtime-tools-');
+    const modified = new Date().toISOString();
+    const runtimeRef = createUnifiedRuntimeRef({
+      mcpTools: [{ name: 'oracle_runtime_tool', description: 'runtime tool', inputSchema: {}, handler: 'tool', plugin: 'runtime-pack' }],
+      reload: async () => {},
+    });
+    const app = new Elysia().use(createPluginsRouter({
+      dir: root,
+      runtimeRef,
+      registry: () => [{
+        name: 'runtime-pack', version: '1.0.0', status: 'ok', surfaces: ['mcpTools'],
+        enabled: true, mcpTools: [], apiRoutes: [], proxy: [], cliSubcommands: [],
+        exportFormats: [], file: '', size: 0, modified,
+      } as any],
+    }));
+
+    let body = await pluginsBody(app, '/api/v1/plugins');
+    expect(body.plugins[0].mcpTools).toEqual([{
+      name: 'oracle_runtime_tool', description: 'runtime tool', inputSchema: {},
+      source: 'plugin', plugin: 'runtime-pack',
+    }]);
+
+    runtimeRef.current = {
+      mcpTools: [{ name: 'oracle_runtime_after_reload', description: 'after', inputSchema: {}, handler: 'tool', plugin: 'runtime-pack' }],
+      reload: async () => {},
+    };
+    body = await pluginsBody(app);
+    expect(body.plugins[0].mcpTools.map((tool: Record<string, unknown>) => tool.name)).toEqual(['oracle_runtime_after_reload']);
+
+    runtimeRef.current = { mcpTools: [], reload: async () => {} };
+    body = await pluginsBody(app);
+    expect(body.plugins[0].mcpTools).toEqual([]);
   });
 
   test('returns an empty registered-plugin listing without scanning fallbacks', async () => {


### PR DESCRIPTION
## Summary
- populate plugin registry mcpTools from the live runtime MCP tool array instead of static/stale manifest metadata
- wire /api/plugins registry route to runtimeRef so /api/v1/plugins reflects reloads and clears removed tools
- add regression coverage for /api/v1/plugins returning runtime MCP tools and clearing them after reload

## Tests
- bunx tsc --noEmit
- bun test tests/http/plugins/
- bun test tests/http/plugins/registry-hardening.test.ts src/plugins/__tests__/unified-loader.test.ts