### PR TITLE
fix: gate /mcp streamable surface by config

### DIFF
--- a/src/config/__tests__/tool-groups.test.ts
+++ b/src/config/__tests__/tool-groups.test.ts
@@ -112,6 +112,7 @@ describe('tool-groups', () => {
     expect(config.forum).toBe(true);
     expect(config.oracle).toBe(true);
     expect(config.trace).toBe(true);
+    expect(config.mcp).toBe(true);
   });
 
   it('all tool names follow oracle_ prefix convention', () => {
@@ -203,6 +204,18 @@ describe('tool-groups', () => {
       expect(config.search).toBe(false);
       expect(config.knowledge).toBe(true);
       expect(config.plugins).toEqual([{ name: 'dig', enabled: true, weight: 1 }, { name: 'search' }]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reads mcp surface toggle from config file', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-plugin-manifest-'));
+    try {
+      fs.writeFileSync(path.join(dir, 'arra.config.json'), JSON.stringify({ mcp: false }));
+      const config = loadToolGroupConfig(dir);
+      expect(config.mcp).toBe(false);
+      expect(config.search).toBe(true);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/src/config/tool-groups-core.ts
+++ b/src/config/tool-groups-core.ts
@@ -36,6 +36,7 @@ export type ToolGroupConfig = Record<ToolGroupName, boolean> & {
   plugins?: PluginManifestEntry[];
   disabled_tools?: string[];
   enabled_tools?: string[];
+  mcp?: boolean;
 };
 
 const DEFAULT_CONFIG: ToolGroupConfig = {
@@ -46,6 +47,7 @@ const DEFAULT_CONFIG: ToolGroupConfig = {
   oracle: true,
   trace: true,
   standalone: true,
+  mcp: true,
 };
 
 const ALL_TOOL_NAMES: ReadonlySet<string> = new Set(
@@ -77,12 +79,21 @@ function mergeRaw(raw: Record<string, any>): ToolGroupConfig {
       if (typeof raw.tools[group] === 'boolean') merged[group] = raw.tools[group];
     }
   }
+  if (typeof raw.mcp === 'boolean') merged.mcp = raw.mcp;
   if (Array.isArray(raw.plugins)) {
     merged.plugins = raw.plugins.map(normalizePluginEntry).filter((p): p is PluginManifestEntry => !!p);
   }
   if (Array.isArray(raw.disabled_tools)) merged.disabled_tools = raw.disabled_tools.filter((t: unknown) => typeof t === 'string').map(normalizeToolName);
   if (Array.isArray(raw.enabled_tools)) merged.enabled_tools = raw.enabled_tools.filter((t: unknown) => typeof t === 'string').map(normalizeToolName);
   return merged;
+}
+
+function hasToolConfig(raw: Record<string, any>): boolean {
+  return Array.isArray(raw.plugins)
+    || isRecord(raw.tools)
+    || Array.isArray(raw.disabled_tools)
+    || Array.isArray(raw.enabled_tools)
+    || typeof raw.mcp === 'boolean';
 }
 
 function normalizePluginEntry(entry: unknown): PluginManifestEntry | null {
@@ -106,7 +117,7 @@ function isRecord(value: unknown): value is Record<string, any> {
 export function loadToolGroupConfig(repoRoot?: string): ToolGroupConfig {
   const root = repoRoot || process.env.ORACLE_REPO_ROOT || process.cwd();
   const localConfig = readJsonSafe(path.join(root, 'arra.config.json'));
-  if (localConfig && (localConfig.plugins || localConfig.tools || localConfig.disabled_tools || localConfig.enabled_tools)) {
+  if (localConfig && hasToolConfig(localConfig)) {
     console.error('[ToolGroups] Using arra.config.json from repo root');
     return mergeRaw(localConfig);
   }
@@ -116,7 +127,7 @@ export function loadToolGroupConfig(repoRoot?: string): ToolGroupConfig {
     return mergeRaw(localPluginManifest);
   }
   const globalConfig = readJsonSafe(path.join(ORACLE_DATA_DIR, 'config.json'));
-  if (globalConfig && (globalConfig.plugins || globalConfig.tools || globalConfig.disabled_tools || globalConfig.enabled_tools)) {
+  if (globalConfig && hasToolConfig(globalConfig)) {
     console.error(`[ToolGroups] Using ${ORACLE_DATA_DIR}/config.json`);
     return mergeRaw(globalConfig);
   }

--- a/src/routes/mcp/streamable.ts
+++ b/src/routes/mcp/streamable.ts
@@ -6,6 +6,7 @@ import type { HttpOracleMcpServerOptions } from '../../mcp/http-server.ts';
 import { OracleMCPServer } from '../../mcp/server.ts';
 import { createHttpOracleMcpServer } from '../../mcp/http-server.ts';
 import { requireMcpBearerAuth } from '../../mcp/http-auth.ts';
+import { loadToolGroupConfig } from '../../config/tool-groups-core.ts';
 
 type Session = { transport: WebStandardStreamableHTTPServerTransport; oracle: OracleMCPServer };
 export type McpStreamableRoutesOptions =
@@ -13,9 +14,20 @@ export type McpStreamableRoutesOptions =
 
 export function createMcpStreamableRoutes(options: McpStreamableRoutesOptions = {}) {
   const manager = new McpHttpSessionManager(options);
-  return new Elysia({ name: 'mcp-streamable-http' }).all('/mcp', ({ request }) => manager.handle(request), {
+  return new Elysia({ name: 'mcp-streamable-http' }).all('/mcp', ({ request, set }) => {
+    if (!isMcpStreamableEnabled(options)) {
+      set.status = 404;
+      return { error: 'Not Found' };
+    }
+    return manager.handle(request);
+  }, {
     detail: { tags: ['mcp'], menu: { group: 'hidden' }, summary: 'Streamable HTTP MCP endpoint' },
   });
+}
+
+function isMcpStreamableEnabled(options: McpStreamableRoutesOptions): boolean {
+  const repoRoot = options.env?.ORACLE_REPO_ROOT;
+  return loadToolGroupConfig(repoRoot).mcp !== false;
 }
 
 class McpHttpSessionManager {

--- a/tests/mcp/http/streamable-auth.test.ts
+++ b/tests/mcp/http/streamable-auth.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { Elysia } from 'elysia';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { createApp } from '../../../src/server.ts';
 import { createMcpStreamableRoutes } from '../../../src/routes/mcp/index.ts';
 import type { ToolGroupConfig } from '../../../src/config/tool-groups.ts';
@@ -9,6 +12,7 @@ const originalEnv = {
   ORACLE_HTTP_URL: process.env.ORACLE_HTTP_URL,
   ORACLE_MCP_HTTP_TOKEN: process.env.ORACLE_MCP_HTTP_TOKEN,
   ARRA_API_TOKEN: process.env.ARRA_API_TOKEN,
+  ORACLE_REPO_ROOT: process.env.ORACLE_REPO_ROOT,
 };
 
 const allToolGroups: ToolGroupConfig = {
@@ -31,6 +35,7 @@ afterEach(() => {
   restoreEnv('ORACLE_HTTP_URL', originalEnv.ORACLE_HTTP_URL);
   restoreEnv('ORACLE_MCP_HTTP_TOKEN', originalEnv.ORACLE_MCP_HTTP_TOKEN);
   restoreEnv('ARRA_API_TOKEN', originalEnv.ARRA_API_TOKEN);
+  restoreEnv('ORACLE_REPO_ROOT', originalEnv.ORACLE_REPO_ROOT);
 });
 
 describe('Streamable HTTP MCP bearer auth', () => {
@@ -114,6 +119,28 @@ describe('Streamable HTTP MCP bearer auth', () => {
 
     expect(deleted.status).toBe(200);
     expect(afterDelete.status).toBe(404);
+  });
+
+  test('disables and re-enables /mcp by config live', async () => {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-streamable-gate-'));
+    try {
+      const configPath = path.join(repoRoot, 'arra.config.json');
+      fs.writeFileSync(configPath, JSON.stringify({ mcp: false }));
+
+      const app = mcpApp({
+        ORACLE_MCP_HTTP_TOKEN: 'mcp-secret',
+        ORACLE_REPO_ROOT: repoRoot,
+      });
+      const offResponse = await postMcp(app, initializeRequest(), 'mcp-secret');
+      expect(offResponse.status).toBe(404);
+
+      fs.writeFileSync(configPath, JSON.stringify({ mcp: true }));
+      const onResponse = await postMcp(app, initializeRequest(), 'mcp-secret');
+      expect(onResponse.status).toBe(200);
+      expect(onResponse.headers.get('mcp-session-id')).not.toBeNull();
+    } finally {
+      fs.rmSync(repoRoot, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
Implements #2774 config-driven gating for the `/mcp` streamable MCP surface.

## Changes
- Add optional `mcp` boolean to tool-group config with default `true`.
- Allow `arra.config.json`/`config.json` to be recognized when only `mcp` is set.
- Wrap MCP streamable handler with a live config check (`loadToolGroupConfig`) to return `404` when disabled.
- Add tests for config loading and live disable/re-enable behavior.

Closes #2774
