### PR TITLE
feat: wire oracle dig plugin

### DIFF
--- a/src/plugins/oracle-dig/__tests__/wiring.test.ts
+++ b/src/plugins/oracle-dig/__tests__/wiring.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Elysia } from 'elysia';
+
+import { closeDb, db, oracleFindingEvidence, oracleFindings, resetDefaultDatabaseForTests } from '../../../db/index.ts';
+import { createApiVersionedFetch } from '../../../middleware/api-version.ts';
+import { OracleMCPServer } from '../../../mcp/server.ts';
+import { loadUnifiedPlugins } from '../../unified-loader.ts';
+import { createPluginsRouter } from '../../../routes/plugins/index.ts';
+
+const pluginsDir = join(process.cwd(), 'src/plugins');
+const manifestPath = join(pluginsDir, 'oracle-dig/plugin.json');
+const toolGroups = { search: true, knowledge: true, session: true, forum: true, oracle: true, trace: true, standalone: true };
+let tmp = '';
+let manifest = '';
+let previousDb: string | undefined;
+let previousDirs: string | undefined;
+let previousHttp: string | undefined;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'oracle-dig-wiring-'));
+  manifest = readFileSync(manifestPath, 'utf8');
+  previousDb = process.env.ORACLE_DB_PATH;
+  previousDirs = process.env.ARRA_PLUGIN_DIRS;
+  previousHttp = process.env.ORACLE_HTTP_URL;
+  process.env.ORACLE_DB_PATH = join(tmp, 'oracle.db');
+  process.env.ARRA_PLUGIN_DIRS = pluginsDir;
+  process.env.ORACLE_HTTP_URL = 'http://127.0.0.1:1';
+  resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+});
+
+afterEach(() => {
+  writeFileSync(manifestPath, manifest, 'utf8');
+  closeDb();
+  restoreEnv('ORACLE_DB_PATH', previousDb);
+  restoreEnv('ARRA_PLUGIN_DIRS', previousDirs);
+  restoreEnv('ORACLE_HTTP_URL', previousHttp);
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+function sessionRoot(): string {
+  const root = join(tmp, 'claude-projects');
+  const project = join(root, 'arra-oracle-v3');
+  mkdirSync(project, { recursive: true });
+  writeFileSync(join(project, 'session-2781.jsonl'), [
+    JSON.stringify({ sessionId: 'session-2781', timestamp: '2026-07-12T00:00:00.000Z', message: { role: 'user', content: 'wire oracle_dig' } }),
+    JSON.stringify({ sessionId: 'session-2781', timestamp: '2026-07-12T00:01:00.000Z', message: { role: 'assistant', model: '[m5:digger]', content: 'found plugin wiring evidence' } }),
+  ].join('\n'));
+  return root;
+}
+
+async function callMcpTool(server: OracleMCPServer, name: string, args: Record<string, unknown>) {
+  const raw = (server as any).server._requestHandlers.get('tools/call') as (request: unknown) => Promise<any>;
+  return raw({ method: 'tools/call', params: { name, arguments: args } });
+}
+
+async function pluginRegistryBody(runtime: Awaited<ReturnType<typeof loadUnifiedPlugins>>) {
+  const app = new Elysia().use(createPluginsRouter({ dir: pluginsDir, registry: runtime.pluginRegistry, runtime }));
+  const fetch = createApiVersionedFetch((request) => app.handle(request));
+  const response = await fetch(new Request('http://local/api/v1/plugins'));
+  expect(response.status).toBe(200);
+  return response.json() as Promise<{ plugins: Array<Record<string, any>> }>;
+}
+
+describe('oracle-dig unified plugin wiring', () => {
+  test('registers tools, toggles live, and stores a real MCP dig call', async () => {
+    const runtime = await loadUnifiedPlugins({ dirs: [pluginsDir] });
+    const body = await pluginRegistryBody(runtime);
+    const plugin = body.plugins.find((entry) => entry.name === 'oracle-dig');
+
+    expect(plugin).toMatchObject({ name: 'oracle-dig', surfaces: ['mcpTools', 'apiRoutes', 'menu'] });
+    expect(plugin?.mcpTools.map((tool: Record<string, unknown>) => tool.name).sort()).toEqual(['oracle_dig', 'oracle_sessions']);
+
+    const app = new Elysia().use(createPluginsRouter({ dir: pluginsDir, registry: runtime.pluginRegistry, runtime }));
+    const off = await app.handle(new Request('http://local/api/plugins/oracle-dig/toggle', {
+      method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ enabled: false }),
+    }));
+    expect(off.status).toBe(200);
+    expect((await off.json()) as unknown).toMatchObject({ ok: true, plugin: 'oracle-dig', mcpTools: [] });
+    expect(runtime.mcpTools.map((tool) => tool.name)).not.toContain('oracle_dig');
+
+    const on = await app.handle(new Request('http://local/api/plugins/oracle-dig/toggle', {
+      method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ enabled: true }),
+    }));
+    expect(on.status).toBe(200);
+    expect((await on.json()) as unknown).toMatchObject({ ok: true, plugin: 'oracle-dig', mcpTools: ['oracle_dig', 'oracle_sessions'] });
+
+    const server = new OracleMCPServer({ toolGroups, unifiedRuntime: runtime, installSignalHandlers: false });
+    try {
+      const response = await callMcpTool(server, 'oracle_dig', {
+        subject: 'oracle_dig phase4 wiring',
+        relation: 'registers',
+        object: 'callable MCP tools',
+        dug_by: '[m5:arra-oracle-v3]',
+        as_of_ts: Date.parse('2026-07-12T00:00:00.000Z'),
+        as_of_commit: 'phase4-test',
+        confidence: 'high',
+        topic: 'phase4',
+        evidence: [{ kind: 'web', web: { url: 'https://github.com/Soul-Brews-Studio/arra-oracle-v3/issues/2781', fetched_at: '2026-07-12T00:00:00.000Z' } }],
+        trace: {
+          query: 'oracle_dig phase4 wiring',
+          project: 'Soul-Brews-Studio/arra-oracle-v3',
+          foundFiles: [{ path: 'github.com/Soul-Brews-Studio/arra-oracle-v3/blob/alpha/src/plugins/oracle-dig/index.ts#L1', type: 'other', confidence: 'high' }],
+          foundCommits: [{ hash: 'abc123', shortHash: 'abc123', date: '2026-07-12', message: 'test commit' }],
+          foundIssues: [{ number: 2781, title: 'Phase 4 wiring', state: 'open', url: 'https://github.com/Soul-Brews-Studio/arra-oracle-v3/issues/2781' }],
+        },
+        sessions: { projectsDir: sessionRoot(), limit: 1 },
+      });
+      const payload = JSON.parse(response.content[0].text);
+      expect(response.isError).not.toBe(true);
+      expect(payload.finding.subject).toBe('oracle_dig phase4 wiring');
+      expect(payload.evidenceCount).toBe(5);
+    } finally {
+      await server.cleanup();
+    }
+
+    const findings = db.select().from(oracleFindings).all();
+    const evidence = db.select().from(oracleFindingEvidence).all();
+    expect(findings).toHaveLength(1);
+    expect(evidence).toHaveLength(5);
+    expect(evidence.map((row) => row.kind).sort()).toEqual(['github', 'github', 'github', 'session', 'web']);
+
+    const routeApp = new Elysia();
+    for (const route of runtime.routes) routeApp.use(route as any);
+    const apiResponse = await routeApp.handle(new Request('http://local/api/plugins/oracle-dig?topic=phase4'));
+    expect(apiResponse.status).toBe(200);
+    expect(await apiResponse.json()).toMatchObject({ ok: true, total: 1 });
+  });
+});

--- a/src/plugins/oracle-dig/index.ts
+++ b/src/plugins/oracle-dig/index.ts
@@ -1,0 +1,222 @@
+import { randomUUID } from 'node:crypto';
+import type { CreateTraceInput } from '../../trace/types.ts';
+import { getFinding } from './get.ts';
+import { listFindings } from './list.ts';
+import { oracleSessions, type OracleSessionsOptions, type OracleSessionsResult } from './sessions.ts';
+import { insertEvidence, insertFinding } from './store.ts';
+import { bridgeTraceToGithubEvidence } from './trace-bridge.ts';
+import type { InsertEvidenceInput, InsertFindingInput, ListFindingsInput } from './types.ts';
+
+type JsonRecord = Record<string, unknown>;
+type Source = 'api' | 'mcp' | 'cli' | 'server' | 'init' | 'destroy';
+type PluginContext = {
+  source: Source;
+  plugin: string;
+  args?: unknown[] | JsonRecord;
+  body?: unknown;
+  query?: JsonRecord;
+  request?: Request;
+};
+type PluginResult = { ok: boolean; body?: unknown; error?: string; status?: number };
+
+const CONFIDENCE: Record<string, number> = { high: 0.9, confirmed: 0.9, medium: 0.6, plausible: 0.6, low: 0.3 };
+const KINDS = new Set(['github', 'session', 'oracle-msg', 'web']);
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function inputRecord(ctx: PluginContext): JsonRecord {
+  if (isRecord(ctx.body)) return ctx.body;
+  if (Array.isArray(ctx.args) && isRecord(ctx.args[0])) return ctx.args[0];
+  if (isRecord(ctx.args)) return ctx.args;
+  if (isRecord(ctx.query)) return ctx.query;
+  return {};
+}
+
+function text(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length ? value.trim() : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function required(value: unknown, label: string): string {
+  const normalized = text(value);
+  if (!normalized) throw new Error(`${label} is required`);
+  return normalized;
+}
+
+function timestamp(value: unknown, fallback?: number): number {
+  const numeric = numberValue(value);
+  if (numeric !== undefined) return numeric;
+  const parsed = typeof value === 'string' ? Date.parse(value) : NaN;
+  if (!Number.isNaN(parsed)) return parsed;
+  if (fallback !== undefined) return fallback;
+  throw new Error('timestamp is required');
+}
+
+function optionalTimestamp(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  return timestamp(value);
+}
+
+function confidence(value: unknown): number {
+  const numeric = numberValue(value);
+  if (numeric !== undefined) return numeric;
+  const named = text(value)?.toLowerCase();
+  return named ? CONFIDENCE[named] ?? 0.5 : 0.5;
+}
+
+function nested(record: JsonRecord, key: string): JsonRecord {
+  return isRecord(record[key]) ? record[key] as JsonRecord : {};
+}
+
+function findingInput(raw: JsonRecord, id: string): InsertFindingInput {
+  return {
+    id,
+    tenantId: text(raw.tenantId) ?? text(raw.tenant_id) ?? 'default',
+    subject: required(raw.subject, 'subject'),
+    relation: text(raw.relation),
+    object: text(raw.object),
+    dugBy: required(raw.dugBy ?? raw.dug_by, 'dug_by'),
+    asOfTs: timestamp(raw.asOfTs ?? raw.as_of_ts ?? raw.asOf ?? raw.as_of, Date.now()),
+    asOfCommit: text(raw.asOfCommit) ?? text(raw.as_of_commit),
+    confidence: confidence(raw.confidence),
+    topic: text(raw.topic),
+    frictionScore: numberValue(raw.frictionScore ?? raw.friction_score),
+    commissionedBy: text(raw.commissionedBy) ?? text(raw.commissioned_by),
+    iterations: numberValue(raw.iterations),
+  };
+}
+
+function evidenceKind(value: unknown): InsertEvidenceInput['kind'] {
+  const kind = text(value)?.replace('_', '-');
+  if (!kind || !KINDS.has(kind)) throw new Error(`unsupported evidence kind: ${String(value)}`);
+  return kind as InsertEvidenceInput['kind'];
+}
+
+function directEvidence(raw: JsonRecord, findingId: string, tenantId: string): InsertEvidenceInput[] {
+  const items = Array.isArray(raw.evidence) ? raw.evidence : [];
+  return items.map((item) => evidenceRow(item, findingId, tenantId));
+}
+
+function evidenceRow(item: unknown, findingId: string, tenantId: string): InsertEvidenceInput {
+  if (!isRecord(item)) throw new Error('evidence entries must be objects');
+  const github = nested(item, 'github');
+  const session = nested(item, 'session');
+  const oracleMsg = nested(item, 'oracleMsg').from ? nested(item, 'oracleMsg') : nested(item, 'oracle_msg');
+  const web = nested(item, 'web');
+  return {
+    findingId,
+    tenantId,
+    kind: evidenceKind(item.kind ?? item.type),
+    githubOwner: text(item.githubOwner) ?? text(item.github_owner) ?? text(github.owner),
+    githubRepo: text(item.githubRepo) ?? text(item.github_repo) ?? text(github.repo),
+    githubPath: text(item.githubPath) ?? text(item.github_path) ?? text(github.path),
+    githubRef: text(item.githubRef) ?? text(item.github_ref) ?? text(github.ref),
+    githubLine: numberValue(item.githubLine ?? item.github_line ?? github.line),
+    sessionId: text(item.sessionId) ?? text(item.session_id) ?? text(session.sessionId) ?? text(session.session_id),
+    sessionOracle: text(item.sessionOracle) ?? text(item.session_oracle) ?? text(session.oracle),
+    oracleMsgFrom: text(item.oracleMsgFrom) ?? text(item.oracle_msg_from) ?? text(oracleMsg.from),
+    oracleMsgAt: optionalTimestamp(item.oracleMsgAt ?? item.oracle_msg_at ?? oracleMsg.at),
+    webUrl: text(item.webUrl) ?? text(item.web_url) ?? text(web.url),
+    webFetchedAt: optionalTimestamp(item.webFetchedAt ?? item.web_fetched_at ?? web.fetched_at),
+    commit: text(item.commit),
+  };
+}
+
+function traceInput(raw: JsonRecord): CreateTraceInput | undefined {
+  return isRecord(raw.trace) ? raw.trace as unknown as CreateTraceInput : undefined;
+}
+
+function wantsSessions(raw: JsonRecord): boolean {
+  if (raw.sessions === false || raw.includeSessions === false || raw.include_sessions === false) return false;
+  return isRecord(raw.sessions) || raw.includeSessions === true || raw.include_sessions === true;
+}
+
+function sessionOptions(raw: JsonRecord): OracleSessionsOptions {
+  const source = isRecord(raw.sessions) ? raw.sessions : raw;
+  return {
+    homeDir: text(source.homeDir) ?? text(source.home_dir),
+    projectsDir: text(source.projectsDir) ?? text(source.projects_dir),
+    limit: numberValue(source.limit),
+  };
+}
+
+function sessionEvidence(result: OracleSessionsResult, findingId: string, tenantId: string, dugBy: string): InsertEvidenceInput[] {
+  return result.sessions.map((session) => ({
+    findingId,
+    tenantId,
+    kind: 'session' as const,
+    sessionId: session.sessionId,
+    sessionOracle: session.oracle ?? dugBy,
+  }));
+}
+
+function listInput(raw: JsonRecord): ListFindingsInput {
+  return {
+    subject: text(raw.subject),
+    topic: text(raw.topic),
+    dugBy: text(raw.dugBy),
+    dug_by: text(raw.dug_by),
+    confidence: numberValue(raw.confidence),
+    limit: numberValue(raw.limit),
+    offset: numberValue(raw.offset),
+  };
+}
+
+function failure(error: unknown, status = 400): PluginResult {
+  return { ok: false, status, error: error instanceof Error ? error.message : String(error) };
+}
+
+export async function oracleDig(ctx: PluginContext): Promise<PluginResult> {
+  try {
+    const raw = inputRecord(ctx);
+    const id = randomUUID();
+    const finding = findingInput(raw, id);
+    const rows = directEvidence(raw, id, finding.tenantId ?? 'default');
+    const trace = traceInput(raw);
+    const traceResult = trace ? await bridgeTraceToGithubEvidence({
+      findingId: id,
+      tenantId: finding.tenantId,
+      asOfCommit: finding.asOfCommit ?? undefined,
+      trace,
+    }) : undefined;
+    if (traceResult) rows.push(...traceResult.evidenceRows as InsertEvidenceInput[]);
+    const sessions = wantsSessions(raw) ? await oracleSessions(sessionOptions(raw)) : undefined;
+    if (sessions) rows.push(...sessionEvidence(sessions, id, finding.tenantId ?? 'default', finding.dugBy));
+    if (rows.length === 0) throw new Error('oracle_dig requires evidence[], trace dig points, or session results');
+
+    const stored = insertFinding(finding);
+    const evidence = rows.map((row) => insertEvidence(row));
+    return { ok: true, body: { ok: true, finding: getFinding(stored.id), evidenceCount: evidence.length, trace: traceResult, sessions } };
+  } catch (error) {
+    return failure(error);
+  }
+}
+
+export async function oracleSessionsTool(ctx: PluginContext): Promise<PluginResult> {
+  try {
+    return { ok: true, body: { ok: true, ...(await oracleSessions(sessionOptions(inputRecord(ctx)))) } };
+  } catch (error) {
+    return failure(error);
+  }
+}
+
+export async function oracleDigApiRoute(ctx: PluginContext): Promise<PluginResult> {
+  const method = ctx.request?.method.toUpperCase() ?? 'GET';
+  if (method === 'GET') return { ok: true, body: { ok: true, ...listFindings(listInput(inputRecord(ctx))) } };
+  if (method === 'POST') return oracleDig(ctx);
+  return failure('method not allowed', 405);
+}
+
+export default function handler(ctx: PluginContext) {
+  return ctx.source === 'mcp' ? oracleDig(ctx) : oracleDigApiRoute(ctx);
+}

--- a/src/plugins/oracle-dig/plugin.json
+++ b/src/plugins/oracle-dig/plugin.json
@@ -1,0 +1,70 @@
+{
+  "name": "oracle-dig",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^0.1.0",
+  "tier": "extra",
+  "enabled": true,
+  "description": "Provenance-first oracle_dig findings store with trace and local session evidence.",
+  "mcpTools": [
+    {
+      "name": "oracle_dig",
+      "description": "Store a relationship finding with typed provenance evidence, optionally composing oracle_trace and oracle_sessions results.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "subject": { "type": "string", "description": "Finding subject; relationship triples start here." },
+          "relation": { "type": "string" },
+          "object": { "type": "string" },
+          "dug_by": { "type": "string", "description": "Federation tag for the oracle that produced the finding." },
+          "as_of_ts": { "type": "number", "description": "Timestamp in milliseconds when this finding was known true." },
+          "as_of_commit": { "type": "string" },
+          "confidence": { "description": "Number or high/medium/low confidence value." },
+          "topic": { "type": "string" },
+          "evidence": { "type": "array", "description": "Typed evidence rows: github, session, oracle-msg, or web." },
+          "trace": { "type": "object", "description": "Optional oracle_trace CreateTraceInput to convert into GitHub evidence." },
+          "sessions": { "description": "Optional oracle_sessions options, or false to skip session evidence." }
+        },
+        "required": ["subject", "dug_by"]
+      },
+      "handler": "oracleDig",
+      "group": "dig",
+      "enabled": true,
+      "readOnly": false,
+      "enabledByDefault": true
+    },
+    {
+      "name": "oracle_sessions",
+      "description": "Scan local Claude session JSONL files on this machine only; not a fleet-wide session search.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "homeDir": { "type": "string" },
+          "projectsDir": { "type": "string" },
+          "limit": { "type": "number" }
+        }
+      },
+      "handler": "oracleSessionsTool",
+      "group": "dig",
+      "enabled": true,
+      "readOnly": true,
+      "enabledByDefault": true
+    }
+  ],
+  "apiRoutes": [
+    {
+      "path": "/api/plugins/oracle-dig",
+      "methods": ["GET", "POST"],
+      "handler": "oracleDigApiRoute"
+    }
+  ],
+  "menu": [
+    {
+      "label": "Oracle Dig",
+      "path": "/oracle-dig",
+      "group": "tools",
+      "order": 42,
+      "icon": "⛏️"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add the `oracle-dig` unified plugin manifest with `oracle_dig` and `oracle_sessions` MCP tools, `/api/plugins/oracle-dig` API route, and `/oracle-dig` menu entry.
- Wire `index.ts` handlers to Phase 2/3 `store`, `list`, `get`, `trace-bridge`, and `sessions` functions.
- Add scoped integration coverage for plugin registry discovery, live toggle reload, real MCP call persistence, and API list handler.

## Verification
- `bunx tsc --noEmit` ✅
- `bun test src/plugins/oracle-dig/` ✅ (5 pass)
- Live/integration verify in `src/plugins/oracle-dig/__tests__/wiring.test.ts`:
  - `GET /api/v1/plugins` lists `oracle-dig` with `oracle_dig` + `oracle_sessions`.
  - `POST /api/plugins/oracle-dig/toggle` flips MCP tools off/on without restart.
  - Real MCP `tools/call` for `oracle_dig` created 1 `oracle_findings` row and 5 `oracle_finding_evidence` rows (`github` x3, `session` x1, `web` x1).
- File sizes: `plugin.json` 70 lines, `index.ts` 222 lines, `wiring.test.ts` 136 lines.

Closes #2781
