### PR TITLE
test: add workers/mcp tool registry parity check for #2737

### DIFF
--- a/workers/mcp/__tests__/mcp-tools-parity.test.ts
+++ b/workers/mcp/__tests__/mcp-tools-parity.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'bun:test';
+
+import { mcpRestMap, remoteableMcpRestMap } from '../../../src/tools/mcp-rest-map.ts';
+import { workerMcpToolEntries } from '../src/tools.ts';
+
+describe('workers/mcp tool registration parity', () => {
+  it('registers every current remoteable MCP REST tool and nothing else', () => {
+    const expected = remoteableMcpRestMap.map((entry) => entry.name).sort();
+    const registered = workerMcpToolEntries.map((entry) => entry.name).sort();
+
+    expect(registered).toEqual(expected);
+
+    const localOnly = mcpRestMap.filter((entry) => !entry.remoteable).map((entry) => entry.name);
+    for (const name of localOnly) {
+      expect(registered.includes(name)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
Closes #2737

## Audit + deploy-readiness for workers/mcp

- Verified `workers/mcp` already mirrors `remoteable` registrations from current `src/tools/mcp-rest-map.ts` via `remoteableMcpRestMap`.
- Added regression test:
  - `workers/mcp/__tests__/mcp-tools-parity.test.ts`
  - Asserts worker tool names equal current remoteable map and do not include `remoteable: false` entries.

## Validation
- `bunx tsc --noEmit` (repo root): pass
- `cd workers/mcp && bunx tsc --noEmit`: pass
- `bun test workers/mcp/__tests__/mcp-tools-parity.test.ts`: pass (1/1)

## Notes
- No deploy workflow/secrets changes. README already documents local wrangler smoke and map audit steps.
