### PR TITLE
fix(vault): unify learn-write path + declare handoff UNIVERSAL — end two-root drift

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "oracle-v2-mcp",

--- a/src/routes/learn/crud.ts
+++ b/src/routes/learn/crud.ts
@@ -4,6 +4,9 @@ import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
 import fs from 'fs';
 import path from 'path';
 import { db, learnLog, oracleDocuments, sqlite } from '../../db/index.ts';
+import { REPO_ROOT } from '../../config.ts';
+import { getVaultPsiRoot } from '../../vault/discovery.ts';
+import { resolveLearnDir } from '../../vault/learn-path.ts';
 import { currentTenantId, tenantIdForWrite } from '../../middleware/tenant.ts';
 import { replaceEntityLinks } from '../../search/entity-ranking.ts';
 import { conceptsFrom, learningContent, slugFor } from './content.ts';
@@ -75,11 +78,27 @@ function upsertFts(id: string, content: string, concepts: string[]): void {
   db.delete(oracleFts).where(eq(oracleFts.id, id)).run();
   db.insert(oracleFts).values({ id, content, concepts: concepts.join(' ') }).run();
 }
-function nextIdentity(pattern: string, requestedId?: string, requestedSourceFile?: string) {
+/**
+ * Default write dir for a new learning — shared resolveLearnDir contract
+ * (project-first under the vault; see src/vault/learn-path.ts for the
+ * two-root drift history). Anchoring stays with learningSourcePath
+ * (repoRoot), so the relDir is what carries the project nesting.
+ */
+function defaultLearnRelDir(project?: string | null): string {
+  const vault = getVaultPsiRoot();
+  const vaultRoot = 'path' in vault ? vault.path : null;
+  return resolveLearnDir({
+    project: project ?? null,
+    vaultRoot,
+    repoRoot: process.env.ORACLE_REPO_ROOT || REPO_ROOT,
+  }).relDir;
+}
+function nextIdentity(pattern: string, requestedId?: string, requestedSourceFile?: string, project?: string | null) {
+  const relDir = defaultLearnRelDir(project);
   if (requestedId) {
     return {
       id: requestedId,
-      sourceFile: requestedSourceFile ?? `ψ/memory/learnings/${requestedId}.md`,
+      sourceFile: requestedSourceFile ?? `${relDir}/${requestedId}.md`,
     };
   }
   const date = new Date().toISOString().slice(0, 10);
@@ -88,7 +107,7 @@ function nextIdentity(pattern: string, requestedId?: string, requestedSourceFile
   while (true) {
     const tail = suffix === 1 ? slug : `${slug}-${suffix}`;
     const id = `learning_${date}_${tail}`;
-    const sourceFile = requestedSourceFile ?? `ψ/memory/learnings/${date}_${tail}.md`;
+    const sourceFile = requestedSourceFile ?? `${relDir}/${date}_${tail}.md`;
     const tenantId = currentTenantId();
     const where = tenantId ? and(eq(oracleDocuments.id, id), eq(oracleDocuments.tenantId, tenantId)) : eq(oracleDocuments.id, id);
     const existing = db.select({ id: oracleDocuments.id })
@@ -123,7 +142,7 @@ export function createLearning(body: LearnCreateBody) {
   if (requestedSourceFile === null) return { status: 400, body: { error: INVALID_LEARNING_SOURCE_FILE } };
   const now = Date.now();
   const concepts = conceptsFrom(body.concepts);
-  const identity = nextIdentity(pattern, body.id, requestedSourceFile);
+  const identity = nextIdentity(pattern, body.id, requestedSourceFile, body.project);
   if (rowById(identity.id)) return { status: 409, body: { error: 'Learning already exists' } };
   const content = learningContent(pattern, concepts, body.source);
   if (!writeLearningFile(identity.sourceFile, content)) {

--- a/src/server/__tests__/learn-project-path.test.ts
+++ b/src/server/__tests__/learn-project-path.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Regression test — two-root vault drift (POST /api/learn ignores project for the write path).
+ *
+ * Bug: `handleLearn` (HTTP path) hardcoded `ψ/memory/learnings` at REPO_ROOT, so a
+ * learning with an explicit `project` param landed flat at the vault root, while the
+ * embedded MCP tool (src/tools/learn.ts) wrote project-first `{project}/ψ/memory/learnings`.
+ * Two code paths → two roots → successors must search both (observed live 2026-07-06/07:
+ * 17 misplaced files at the vault root).
+ *
+ * Fix contract (shared helper `resolveLearnDir` in src/vault/learn-path.ts, consumed by
+ * BOTH paths):
+ *   - vault configured + project      → {project}/ψ/memory/learnings under the vault root
+ *   - vault configured + no project   → _universal/ψ/memory/learnings under the vault root
+ *   - vault NOT configured            → flat ψ/memory/learnings under REPO_ROOT (local-ψ
+ *     convention — matches mapToVaultPath semantics where project nesting is a vault concept)
+ *
+ * Hermetic: ORACLE_DATA_DIR + ORACLE_REPO_ROOT point at tmp dirs, set BEFORE the dynamic
+ * import. Vault resolution is mocked so the test does not depend on ghq or real settings.
+ */
+
+import { describe, it, expect, afterAll, mock } from 'bun:test';
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+
+const TMP_REPO_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-learn-projpath-repo-'));
+const TMP_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-learn-projpath-data-'));
+const TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-learn-projpath-vault-'));
+
+const ORIGINAL_REPO_ROOT = process.env.ORACLE_REPO_ROOT;
+const ORIGINAL_DATA_DIR = process.env.ORACLE_DATA_DIR;
+
+process.env.ORACLE_REPO_ROOT = TMP_REPO_ROOT;
+process.env.ORACLE_DATA_DIR = TMP_DATA_DIR;
+
+// Vault is "configured" for this suite — both paths must nest by project under it.
+mock.module('../../vault/discovery.ts', () => ({
+  getVaultPsiRoot: () => ({ path: TMP_VAULT }),
+}));
+
+// Dynamic imports after env + mock are set (REPO_ROOT and DB_PATH are module-frozen).
+const { handleLearn } = await import('../handlers.ts');
+const { resolveLearnDir } = await import('../../vault/learn-path.ts');
+const { db } = await import('../../db/index.ts');
+const { oracleDocuments } = await import('../../db/schema.ts');
+const { eq } = await import('drizzle-orm');
+
+const PROJECT = 'github.com/dumpdumpy/orchestrator-oracle';
+
+function dbSourceFile(id: string): string | null {
+  const row = db.select({ sourceFile: oracleDocuments.sourceFile })
+    .from(oracleDocuments)
+    .where(eq(oracleDocuments.id, id))
+    .get();
+  return row?.sourceFile ?? null;
+}
+
+describe('resolveLearnDir — shared path contract (unit)', () => {
+  it('vault + project → project-nested under vault', () => {
+    const r = resolveLearnDir({ project: PROJECT, vaultRoot: TMP_VAULT, repoRoot: TMP_REPO_ROOT });
+    expect(r.relDir).toBe(`${PROJECT}/ψ/memory/learnings`);
+    expect(r.absDir).toBe(path.join(TMP_VAULT, PROJECT, 'ψ/memory/learnings'));
+  });
+
+  it('vault + no project → _universal under vault', () => {
+    const r = resolveLearnDir({ project: null, vaultRoot: TMP_VAULT, repoRoot: TMP_REPO_ROOT });
+    expect(r.relDir).toBe('_universal/ψ/memory/learnings');
+  });
+
+  it('project is lowercased (one canonical dir per project)', () => {
+    const r = resolveLearnDir({ project: 'github.com/DUMPDUMPY/Repo', vaultRoot: TMP_VAULT, repoRoot: TMP_REPO_ROOT });
+    expect(r.relDir).toBe('github.com/dumpdumpy/repo/ψ/memory/learnings');
+  });
+
+  it('no vault → flat local-ψ under repoRoot, project ignored for the path', () => {
+    const r = resolveLearnDir({ project: PROJECT, vaultRoot: null, repoRoot: TMP_REPO_ROOT });
+    expect(r.relDir).toBe('ψ/memory/learnings');
+    expect(r.absDir).toBe(path.join(TMP_REPO_ROOT, 'ψ/memory/learnings'));
+  });
+});
+
+describe('handleLearn (HTTP path) — project-first writes', () => {
+  it('write WITH project lands project-nested in the vault, DB sourceFile prefixed', () => {
+    const res = handleLearn('project nested write probe', 'test', [], undefined, PROJECT);
+    expect(res.success).toBe(true);
+    expect(res.file).toMatch(new RegExp(`^${PROJECT}/ψ/memory/learnings/`));
+    expect(fs.existsSync(path.join(TMP_VAULT, res.file))).toBe(true);
+    expect(dbSourceFile(res.id)).toBe(res.file);
+  });
+
+  it('write WITHOUT project lands under _universal (B1 binding — no more vault-root flat writes)', () => {
+    const res = handleLearn('universal write probe');
+    expect(res.success).toBe(true);
+    expect(res.file).toMatch(/^_universal\/ψ\/memory\/learnings\//);
+    expect(fs.existsSync(path.join(TMP_VAULT, res.file))).toBe(true);
+  });
+
+  it('slug-collision loop operates inside the project dir (-2 suffix, no 500)', () => {
+    const prefix = 'collision probe shared first line kept exactly fifty';
+    const a = handleLearn(`${prefix}\nbody one`, 'test', [], undefined, PROJECT);
+    const b = handleLearn(`${prefix}\nbody two`, 'test', [], undefined, PROJECT);
+    expect(a.success).toBe(true);
+    expect(b.success).toBe(true);
+    expect(b.file).toMatch(new RegExp(`^${PROJECT}/ψ/memory/learnings/.*-2\\.md$`));
+    expect(fs.existsSync(path.join(TMP_VAULT, b.file))).toBe(true);
+  });
+});
+
+describe('backward compat — pre-fix rows still readable', () => {
+  it('old flat root sourceFile still resolves by direct join against REPO_ROOT', async () => {
+    // Simulate a pre-fix artifact: file at the old flat root location.
+    const oldRel = 'ψ/memory/learnings/2026-07-06_prefix-era-file.md';
+    fs.mkdirSync(path.join(TMP_REPO_ROOT, 'ψ/memory/learnings'), { recursive: true });
+    fs.writeFileSync(path.join(TMP_REPO_ROOT, oldRel), '---\nid: prefix-era\n---\nold row', 'utf-8');
+
+    const { resolveFilePath } = await import('../../tools/read.ts');
+    const resolved = await resolveFilePath(oldRel, TMP_REPO_ROOT, path.join(os.homedir(), 'ghq'));
+    expect(resolved).toBe(fs.realpathSync(path.join(TMP_REPO_ROOT, oldRel)));
+  });
+});
+
+describe('anti-divergence tripwire — both write paths consume the shared helper', () => {
+  it('server/handlers.ts and tools/learn.ts both call resolveLearnDir', () => {
+    const handlers = fs.readFileSync(path.join(import.meta.dir, '../handlers.ts'), 'utf-8');
+    const mcpLearn = fs.readFileSync(path.join(import.meta.dir, '../../tools/learn.ts'), 'utf-8');
+    expect(handlers).toContain('resolveLearnDir(');
+    expect(mcpLearn).toContain('resolveLearnDir(');
+  });
+});
+
+afterAll(() => {
+  for (const d of [TMP_REPO_ROOT, TMP_DATA_DIR, TMP_VAULT]) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
+  }
+  if (ORIGINAL_REPO_ROOT) process.env.ORACLE_REPO_ROOT = ORIGINAL_REPO_ROOT;
+  else delete process.env.ORACLE_REPO_ROOT;
+  if (ORIGINAL_DATA_DIR) process.env.ORACLE_DATA_DIR = ORIGINAL_DATA_DIR;
+  else delete process.env.ORACLE_DATA_DIR;
+});

--- a/src/server/__tests__/learn-project-path.test.ts
+++ b/src/server/__tests__/learn-project-path.test.ts
@@ -119,12 +119,41 @@ describe('backward compat — pre-fix rows still readable', () => {
   });
 });
 
-describe('anti-divergence tripwire — both write paths consume the shared helper', () => {
-  it('server/handlers.ts and tools/learn.ts both call resolveLearnDir', () => {
-    const handlers = fs.readFileSync(path.join(import.meta.dir, '../handlers.ts'), 'utf-8');
-    const mcpLearn = fs.readFileSync(path.join(import.meta.dir, '../../tools/learn.ts'), 'utf-8');
-    expect(handlers).toContain('resolveLearnDir(');
-    expect(mcpLearn).toContain('resolveLearnDir(');
+describe('createLearning (learn CRUD route) — third write path, same contract', () => {
+  // Upstream alpha added routes/learn/crud.ts with its own hardcoded default
+  // 'ψ/memory/learnings/...' — the exact divergence class this suite guards.
+  // Caught live 2026-07-07: POST /api/learn on v26.7.5-alpha.1608 wrote to the
+  // vault root despite the handlers.ts fix, because the CRUD route won the mount.
+  it('default sourceFile is project-nested when project is passed', async () => {
+    const { createLearning } = await import('../../routes/learn/crud.ts');
+    const res = createLearning({ pattern: `crud project probe ${Date.now()}`, project: PROJECT });
+    expect(res.status).toBe(200);
+    const body = res.body as { success: boolean; file: string };
+    expect(body.file).toMatch(new RegExp(`^${PROJECT}/ψ/memory/learnings/`));
+  });
+
+  it('default sourceFile is _universal when no project', async () => {
+    const { createLearning } = await import('../../routes/learn/crud.ts');
+    const res = createLearning({ pattern: `crud universal probe ${Date.now()}` });
+    expect(res.status).toBe(200);
+    const body = res.body as { success: boolean; file: string };
+    expect(body.file).toMatch(/^_universal\/ψ\/memory\/learnings\//);
+  });
+});
+
+describe('anti-divergence tripwire — ALL write paths consume the shared helper', () => {
+  it('server/handlers.ts, tools/learn.ts, and routes/learn/crud.ts all call resolveLearnDir', () => {
+    for (const rel of ['../handlers.ts', '../../tools/learn.ts', '../../routes/learn/crud.ts']) {
+      const src = fs.readFileSync(path.join(import.meta.dir, rel), 'utf-8');
+      expect(src).toContain('resolveLearnDir(');
+    }
+  });
+
+  it('no learn write path carries a hardcoded root learnings literal outside the helper', () => {
+    for (const rel of ['../handlers.ts', '../../routes/learn/crud.ts']) {
+      const src = fs.readFileSync(path.join(import.meta.dir, rel), 'utf-8');
+      expect(src).not.toMatch(/[`'"]ψ\/memory\/learnings\//);
+    }
   });
 });
 

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -18,6 +18,8 @@ import { ensureVectorStoreConnected, EMBEDDING_MODELS, getVectorStoreConfigByMod
 import { localVectorOperations } from './vector-operations.ts';
 import { detectProject } from './project-detect.ts';
 import { coerceConcepts } from '../tools/learn.ts';
+import { getVaultPsiRoot } from '../vault/discovery.ts';
+import { resolveLearnDir } from '../vault/learn-path.ts';
 import { createVectorProxy } from './vector-proxy.ts';
 import { buildLearningMarkdown, dateSlug } from '../learn/markdown.ts';
 import { localNativeVectorDisabledReason, localVectorIndexMissingReason, logLocalVectorDisabled, noteLocalVectorEnabled } from '../vector/cpu-capabilities.ts';
@@ -719,11 +721,12 @@ export function persistLearningDoc(opts: {
   project?: string | null;
   createdBy?: string;      // oracle_documents.created_by
   footer?: string;         // footer line under the content, e.g. '*Added via Oracle Learn*'
+  baseDir?: string;        // write anchor (vault root when configured); defaults to REPO_ROOT
 }): { file: string; id: string } {
   const { pattern, subdir, filename, id } = opts;
   const now = new Date();
 
-  const dir = path.join(currentRepoRoot(), subdir);
+  const dir = path.join(opts.baseDir ?? currentRepoRoot(), subdir);
   fs.mkdirSync(dir, { recursive: true });
   const filePath = path.join(dir, filename);
 
@@ -793,11 +796,20 @@ export function handleLearn(
     .replace(/-+/g, '-')
     .replace(/^-|-$/g, '');
 
+  // Project-first vault layout via the shared helper — kept in lockstep with the
+  // embedded MCP tool (src/tools/learn.ts). See src/vault/learn-path.ts for the
+  // two-root drift history.
+  const vault = getVaultPsiRoot();
+  const vaultRoot = 'path' in vault ? vault.path : null;
+  const { baseDir, relDir: subdir, absDir: learningsDir } = resolveLearnDir({
+    project: resolvedProject,
+    vaultRoot,
+    repoRoot: currentRepoRoot(),
+  });
+
   // On slug collision (same date + same first-50-char prefix), append -2, -3, …
   // until unique. Prevents 500s when two writes share a slug within one day
   // (e.g. repeated hot-write snapshots from the same agent).
-  const subdir = 'ψ/memory/learnings';
-  const learningsDir = path.join(currentRepoRoot(), subdir);
   let uniqueSlug = slug;
   let suffix = 2;
   while (fs.existsSync(path.join(learningsDir, `${dateStr}_${uniqueSlug}.md`))) {
@@ -808,6 +820,7 @@ export function handleLearn(
   const { file, id } = persistLearningDoc({
     pattern,
     subdir,
+    baseDir,
     filename: `${dateStr}_${uniqueSlug}.md`,
     id: `learning_${dateStr}_${uniqueSlug}`,
     concepts,
@@ -841,6 +854,8 @@ export function handleSessionSummary(
 
   const { file, id } = persistLearningDoc({
     pattern: summary,
+    // INTENTIONALLY UNIVERSAL: session summaries are cross-project session artifacts,
+    // not project learnings — flat root is by design (do not re-flag in surface audits).
     subdir: 'ψ/memory/session-summaries',
     filename: `${safeSession}.md`,
     id: `session-summary_${safeSession}`,

--- a/src/tools/__tests__/handoff-universal-inbox.test.ts
+++ b/src/tools/__tests__/handoff-universal-inbox.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Handoff = UNIVERSAL single inbox — regression suite for the handoff sibling
+ * of the two-root learn drift (design bound 2026-07-07, oracle Option B).
+ *
+ * Consumed reality: EVERY reader (oracle_inbox MCP, GET /api/inbox,
+ * knowledge/inbox listHandoffFiles, maw-plugin via HTTP, ctl verify) reads the
+ * single ROOT ψ/inbox/handoff. Project-nesting was declared in
+ * PROJECT_CATEGORIES but never consumed by any reader — mail written
+ * project-nested is DARK. The embedded MCP writer (tools/handoff.ts) was the
+ * only project-nested writer, and embedded mode is the lazy fallback when the
+ * HTTP server is down — i.e. handoffs written during an outage went exactly
+ * where nobody looks, precisely when they matter most.
+ *
+ * Contract:
+ *   - vault configured   → write vaultRoot/ψ/inbox/handoff (ROOT, no project dir)
+ *   - vault unavailable  → write ctx.repoRoot/ψ/inbox/handoff as LAST resort,
+ *     with a loud console.error naming the orphan path (outage mail must at
+ *     least be findable in logs)
+ *   - mapToVaultPath treats ψ/inbox/handoff/ as UNIVERSAL (identity mapping)
+ *   - migrate.ts carries NO duplicate category list (divergence-by-copy seed)
+ */
+
+import { describe, it, expect, afterAll, mock } from 'bun:test';
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+
+const TMP_REPO_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-handoff-repo-'));
+const TMP_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-handoff-data-'));
+const TMP_VAULT = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-handoff-vault-'));
+
+const ORIGINAL_REPO_ROOT = process.env.ORACLE_REPO_ROOT;
+const ORIGINAL_DATA_DIR = process.env.ORACLE_DATA_DIR;
+process.env.ORACLE_REPO_ROOT = TMP_REPO_ROOT;
+process.env.ORACLE_DATA_DIR = TMP_DATA_DIR;
+
+// Controllable vault resolution — flipped per-test.
+let vaultAvailable = true;
+mock.module('../../vault/handler.ts', () => ({
+  getVaultPsiRoot: () =>
+    vaultAvailable ? { path: TMP_VAULT } : { needsInit: true, hint: 'no vault (test)' },
+}));
+
+const { handleHandoff } = await import('../handoff.ts');
+const { mapToVaultPath, isProjectCategory } = await import('../../vault/path-mapping.ts');
+
+const ctx = { repoRoot: TMP_REPO_ROOT } as unknown as import('../types.ts').ToolContext;
+
+function parseResponse(res: { content: Array<{ text: string }> }): { success: boolean; file: string } {
+  return JSON.parse(res.content[0].text);
+}
+
+describe('oracle_handoff (embedded) — universal ROOT inbox', () => {
+  it('vault configured → writes vaultRoot/ψ/inbox/handoff with NO project prefix', async () => {
+    vaultAvailable = true;
+    const res = await handleHandoff(ctx, { content: 'universal inbox probe', slug: 'universal-probe' });
+    const body = parseResponse(res);
+    expect(body.success).toBe(true);
+    expect(body.file).toMatch(/^ψ\/inbox\/handoff\//);
+    expect(body.file).not.toMatch(/^(github\.com|_universal)\//);
+    expect(fs.existsSync(path.join(TMP_VAULT, body.file))).toBe(true);
+  });
+
+  it('vault unavailable → last-resort repoRoot write + LOUD orphan warning in logs', async () => {
+    vaultAvailable = false;
+    const errors: string[] = [];
+    const origError = console.error;
+    console.error = (...args: unknown[]) => { errors.push(args.map(String).join(' ')); };
+    try {
+      const res = await handleHandoff(ctx, { content: 'outage mail probe', slug: 'outage-probe' });
+      const body = parseResponse(res);
+      expect(body.success).toBe(true);
+      expect(fs.existsSync(path.join(TMP_REPO_ROOT, body.file))).toBe(true);
+      // Outage mail must be findable from logs: a loud line naming the orphan path.
+      const loud = errors.filter((line) => line.includes('ORPHAN') && line.includes('handoff'));
+      expect(loud.length).toBeGreaterThan(0);
+      expect(loud.join(' ')).toContain(TMP_REPO_ROOT);
+    } finally {
+      console.error = origError;
+      vaultAvailable = true;
+    }
+  });
+});
+
+describe('path-mapping — handoff is a UNIVERSAL category', () => {
+  it('mapToVaultPath leaves ψ/inbox/handoff paths unprefixed (identity)', () => {
+    expect(mapToVaultPath('ψ/inbox/handoff/2026-07-07_10-00_context.md', 'github.com/owner/repo'))
+      .toBe('ψ/inbox/handoff/2026-07-07_10-00_context.md');
+  });
+
+  it('isProjectCategory(ψ/inbox/handoff/…) is false', () => {
+    expect(isProjectCategory('ψ/inbox/handoff/x.md')).toBe(false);
+  });
+
+  it('learnings/retrospectives stay project-nested (unchanged)', () => {
+    expect(isProjectCategory('ψ/memory/learnings/x.md')).toBe(true);
+    expect(mapToVaultPath('ψ/memory/learnings/x.md', 'github.com/owner/repo'))
+      .toBe('github.com/owner/repo/ψ/memory/learnings/x.md');
+  });
+});
+
+describe('anti-divergence tripwire — one category list only', () => {
+  it('migrate.ts declares no local PROJECT_CATEGORIES copy (imports the shared one)', () => {
+    const src = fs.readFileSync(path.join(import.meta.dir, '../../vault/migrate.ts'), 'utf-8');
+    expect(src).not.toMatch(/const PROJECT_CATEGORIES\s*=/);
+    expect(src).toContain('isProjectCategory');
+  });
+});
+
+afterAll(() => {
+  for (const d of [TMP_REPO_ROOT, TMP_DATA_DIR, TMP_VAULT]) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
+  }
+  if (ORIGINAL_REPO_ROOT) process.env.ORACLE_REPO_ROOT = ORIGINAL_REPO_ROOT;
+  else delete process.env.ORACLE_REPO_ROOT;
+  if (ORIGINAL_DATA_DIR) process.env.ORACLE_DATA_DIR = ORIGINAL_DATA_DIR;
+  else delete process.env.ORACLE_DATA_DIR;
+});

--- a/src/tools/__tests__/learn-enqueue.test.ts
+++ b/src/tools/__tests__/learn-enqueue.test.ts
@@ -96,6 +96,12 @@ const SHARED_REPO_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-learn-m5-ro
 process.env.ORACLE_REPO_ROOT = SHARED_REPO_ROOT;
 process.env.ORACLE_EMBEDDER = 'none';
 process.env.ORACLE_EMBEDDING_PROVIDER = 'none';
+// Hermetic ORACLE_DATA_DIR: without this, getSetting('vault_repo') reads the REAL
+// settings DB on any host with a configured vault and handleLearn writes test junk
+// into the real vault's _universal/ dir (observed live 2026-07-07: 20 test-pattern
+// files leaked into oracle-vault). DB_PATH is module-frozen — set before import.
+const SHARED_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-learn-m5-data-'));
+process.env.ORACLE_DATA_DIR = SHARED_DATA_DIR;
 const createdMarkdownFiles = new Set<string>();
 
 function markdownPathCandidates(relativePath: string): string[] {

--- a/src/tools/handoff.ts
+++ b/src/tools/handoff.ts
@@ -7,7 +7,6 @@
 
 import path from 'path';
 import fs from 'fs';
-import { detectProject } from '../server/project-detect.ts';
 import type { ToolContext, ToolResponse, OracleHandoffInput } from './types.ts';
 
 let getVaultPsiRootFn: typeof import('../vault/handler.ts').getVaultPsiRoot | null = null;
@@ -109,16 +108,24 @@ export async function handleHandoff(ctx: ToolContext, input: OracleHandoffInput)
   if ('needsInit' in vault) console.error(`[Vault] ${vault.hint}`);
   const vaultRoot = 'path' in vault ? vault.path : null;
 
-  const project = detectProject(ctx.repoRoot)?.toLowerCase() || '_universal';
-
+  // Handoff = UNIVERSAL single inbox (bound 2026-07-07): every reader
+  // (oracle_inbox, GET /api/inbox, maw-plugin) reads ROOT ψ/inbox/handoff only.
+  // The old project-nested vault write put mail where no reader looks — and
+  // embedded mode is the lazy fallback during server outages, i.e. exactly
+  // when handoffs matter most. Do NOT reintroduce project nesting here.
   let dirPath: string;
-  let sourceFileRel: string;
+  const sourceFileRel = `ψ/inbox/handoff/${filename}`;
   if (vaultRoot) {
-    dirPath = path.join(vaultRoot, project, 'ψ', 'inbox', 'handoff');
-    sourceFileRel = `${project}/ψ/inbox/handoff/${filename}`;
+    dirPath = path.join(vaultRoot, 'ψ', 'inbox', 'handoff');
   } else {
+    // Last resort: vault unresolvable (unconfigured, or ghq lookup failed).
+    // Write locally so the mail is not lost, and SCREAM so it is findable —
+    // an orphan inbox outside the vault is invisible to every reader.
     dirPath = path.join(ctx.repoRoot, 'ψ/inbox/handoff');
-    sourceFileRel = `ψ/inbox/handoff/${filename}`;
+    console.error(
+      `[MCP:HANDOFF] ORPHAN handoff path — vault unresolvable, writing to ${dirPath}. ` +
+      `No inbox reader looks here; recover this file manually into the vault root inbox.`,
+    );
   }
 
   fs.mkdirSync(dirPath, { recursive: true });

--- a/src/tools/learn.ts
+++ b/src/tools/learn.ts
@@ -11,6 +11,7 @@ import { oracleDocuments } from '../db/schema.ts';
 import { detectProject } from '../server/project-detect.ts';
 import { getVectorStoreByModel, getEmbeddingModels } from '../vector/factory.ts';
 import { REPO_ROOT } from '../config.ts';
+import { resolveLearnDir } from '../vault/learn-path.ts';
 import { buildLearningMarkdown, dateSlug } from '../learn/markdown.ts';
 
 // Lazy-loaded on first use — avoids top-level await which causes a TDZ
@@ -206,24 +207,16 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
   const project = normalizeProject(projectInput)
     || extractProjectFromSource(source)
     || detectProject(ctx.repoRoot);
-  const projectDir = (project || '_universal').toLowerCase();
 
-  let filePath: string;
-  let sourceFileRel: string;
-  if (vaultRoot) {
-    const dir = path.join(vaultRoot, projectDir, 'ψ', 'memory', 'learnings');
-    fs.mkdirSync(dir, { recursive: true });
-    filePath = path.join(dir, filename);
-    sourceFileRel = `${projectDir}/ψ/memory/learnings/${filename}`;
-  } else {
-    // Write to canonical REPO_ROOT, not ctx.repoRoot (the MCP server's cwd):
-    // the dashboard's /api/file resolves source_file against REPO_ROOT, so
-    // writing relative to cwd produces "local file not found" (#557).
-    const dir = path.join(REPO_ROOT, 'ψ/memory/learnings');
-    fs.mkdirSync(dir, { recursive: true });
-    filePath = path.join(dir, filename);
-    sourceFileRel = `ψ/memory/learnings/${filename}`;
-  }
+  // Shared path resolution — kept in lockstep with the HTTP handler
+  // (src/server/handlers.ts handleLearn) via src/vault/learn-path.ts.
+  // No-vault fallback anchors at canonical REPO_ROOT, not ctx.repoRoot (the MCP
+  // server's cwd): the dashboard's /api/file resolves source_file against
+  // REPO_ROOT, so writing relative to cwd produces "local file not found" (#557).
+  const { absDir, relDir } = resolveLearnDir({ project, vaultRoot, repoRoot: REPO_ROOT });
+  fs.mkdirSync(absDir, { recursive: true });
+  const filePath = path.join(absDir, filename);
+  const sourceFileRel = `${relDir}/${filename}`;
 
   if (fs.existsSync(filePath)) {
     throw new Error(`File already exists: ${filename}`);

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -111,7 +111,7 @@ function existingPathInside(root: string, relativePath: string): string | null {
  * Try to resolve a source_file path to a readable absolute path.
  * Returns the absolute path if found, null otherwise.
  */
-async function resolveFilePath(
+export async function resolveFilePath(
   sourceFile: string,
   repoRoot: string,
   ghqRoot: string,

--- a/src/vault/__tests__/handler.test.ts
+++ b/src/vault/__tests__/handler.test.ts
@@ -198,9 +198,13 @@ describe('mapToVaultPath', () => {
       .toBe('github.com/soul-brews-studio/oracle-v2/ψ/memory/retrospectives/2026-01/15/session.md');
   });
 
-  it('prefixes inbox/handoff with project', () => {
+  it('keeps inbox/handoff universal (no project prefix) — bound 2026-07-07', () => {
+    // SPEC CHANGE (oracle-bound, Option B universal-inbox): handoff is
+    // host-level session mail with ONE inbox; every reader reads the root
+    // ψ/inbox/handoff only, so project-nested handoff mail was dark.
+    // Full contract: src/tools/__tests__/handoff-universal-inbox.test.ts
     expect(mapToVaultPath('ψ/inbox/handoff/context.md', project))
-      .toBe('github.com/soul-brews-studio/oracle-v2/ψ/inbox/handoff/context.md');
+      .toBe('ψ/inbox/handoff/context.md');
   });
 
   it('keeps resonance universal (no project prefix)', () => {

--- a/src/vault/learn-path.ts
+++ b/src/vault/learn-path.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared learn-write path resolution — the single source of truth for where a
+ * learning document lands on disk.
+ *
+ * Consumed by BOTH write paths:
+ *   - HTTP handler `handleLearn` (src/server/handlers.ts, POST /api/learn)
+ *   - embedded MCP tool `handleLearn` (src/tools/learn.ts, oracle_learn)
+ *
+ * History: these two paths carried duplicated, diverged logic — the MCP tool
+ * wrote project-first `{project}/ψ/memory/learnings` under the vault while the
+ * HTTP handler hardcoded flat `ψ/memory/learnings` at REPO_ROOT and ignored the
+ * `project` param for the path. Result: learnings split across two roots
+ * depending on transport (observed live 2026-07-06/07, 17 misplaced files).
+ * Do NOT reintroduce per-path layout logic; extend this helper instead.
+ */
+
+import path from 'path';
+
+export const LEARNINGS_SUBPATH = 'ψ/memory/learnings';
+
+export interface LearnDirResolution {
+  /** Base the write is anchored to (vault root when configured, else repoRoot). */
+  baseDir: string;
+  /** Directory relative to baseDir — also the prefix of the stored sourceFile. */
+  relDir: string;
+  /** Absolute directory to write into. */
+  absDir: string;
+}
+
+/**
+ * Resolve the directory a learning should be written to.
+ *
+ * - vault configured + project     → `{project}/ψ/memory/learnings` under the vault
+ * - vault configured + no project  → `_universal/ψ/memory/learnings` under the vault
+ * - vault NOT configured           → flat `ψ/memory/learnings` under repoRoot
+ *   (local-ψ convention: project nesting is a vault-layout concept — see
+ *   src/vault/path-mapping.ts `mapToVaultPath`)
+ */
+export function resolveLearnDir(opts: {
+  project: string | null | undefined;
+  vaultRoot: string | null;
+  repoRoot: string;
+}): LearnDirResolution {
+  if (!opts.vaultRoot) {
+    const relDir = LEARNINGS_SUBPATH;
+    return { baseDir: opts.repoRoot, relDir, absDir: path.join(opts.repoRoot, relDir) };
+  }
+  const projectDir = (opts.project || '_universal').toLowerCase();
+  const relDir = `${projectDir}/${LEARNINGS_SUBPATH}`;
+  return { baseDir: opts.vaultRoot, relDir, absDir: path.join(opts.vaultRoot, relDir) };
+}

--- a/src/vault/migrate.ts
+++ b/src/vault/migrate.ts
@@ -6,6 +6,7 @@ import { execSync } from 'child_process';
 import { getSetting } from '../db/index.ts';
 import { detectProject } from '../server/project-detect.ts';
 import { mapToVaultPath, ensureFrontmatterProject } from './handler.ts';
+import { isProjectCategory } from './path-mapping.ts';
 import { ghqListPaths } from './ghq.ts';
 
 function resolveVaultPath(repo: string): string {
@@ -28,11 +29,10 @@ function walkFiles(dir: string, baseDir: string): Array<{ relativePath: string; 
   return results;
 }
 
-const PROJECT_CATEGORIES = ['ψ/memory/learnings/', 'ψ/memory/retrospectives/', 'ψ/inbox/handoff/'];
-
-function isProjectCategory(relativePath: string): boolean {
-  return PROJECT_CATEGORIES.some((cat) => relativePath.startsWith(cat));
-}
+// Category membership comes from the ONE shared list in path-mapping.ts.
+// A local duplicate list lived here until 2026-07-07 and had already drifted
+// from the shared one (handoff) — the same divergence-by-copy seed as the
+// three-path learn drift. Do not re-declare categories in this file.
 
 function sameFileContent(dest: string, source: string, content?: string): boolean {
   if (!fs.existsSync(dest)) return false;

--- a/src/vault/path-mapping.ts
+++ b/src/vault/path-mapping.ts
@@ -11,12 +11,18 @@ import path from 'node:path';
 export const PROJECT_CATEGORIES = [
   'ψ/memory/learnings/',
   'ψ/memory/retrospectives/',
-  'ψ/inbox/handoff/',
 ];
 
-// Universal categories — no project prefix
+// Universal categories — no project prefix.
+// handoff is UNIVERSAL by bound design (2026-07-07): host-level session mail
+// with ONE inbox — every reader (oracle_inbox, GET /api/inbox, maw-plugin)
+// reads root ψ/inbox/handoff only. It was previously declared project-nested
+// here while never consumed that way; mail written project-nested was dark.
+// Declaration aligned to consumed behavior — do not re-nest without moving
+// every reader in lockstep.
 export const UNIVERSAL_CATEGORIES = [
   'ψ/memory/resonance/',
+  'ψ/inbox/handoff/',
   'ψ/inbox/schedule.md',
   'ψ/inbox/focus-agent-main.md',
   'ψ/active/',


### PR DESCRIPTION
## Summary

Three production bug fixes around a single pattern: **multiple write paths to the vault diverged, splitting learnings across two roots and making handoffs invisible to every reader**. Plus one test-isolation fix and a bun.lock refresh.

Opening as **Draft** because fix #3 (handoff UNIVERSAL) is a visible behavior change and I want to align on the spec decision before marking ready.

---

## The pattern: multi-path write divergence

The vault has three separate write paths for learnings:

1. `src/server/handlers.ts` `handleLearn()` — HTTP `POST /api/learn`
2. `src/tools/learn.ts` `handleLearn()` — embedded MCP `oracle_learn`
3. `src/routes/learn/crud.ts` `createLearning()` — CRUD route added in v26.7.5-alpha

Each one carried its own hardcoded copy of the path-resolution logic, and the copies drifted:

- The MCP tool wrote project-first `{project}/ψ/memory/learnings` under the vault ✅
- The HTTP handler hardcoded flat `ψ/memory/learnings` at `REPO_ROOT` and **ignored the `project` param for the path** ❌
- The CRUD route (added in alpha.1608) re-introduced the flat default ❌

Net effect: deployments running the MCP server in HTTP-client mode (`ORACLE_API` set) split learnings across two roots depending on transport. Observed live: **17 misplaced files at the vault root over 2026-07-06/07**.

---

## Fix 1 — `daf0a923` learn path unify (critical)

Extract one shared helper `src/vault/learn-path.ts` `resolveLearnDir()` consumed by **both** legacy paths (HTTP handler + MCP tool):

```
vault configured + project    → {project}/ψ/memory/learnings under vault
vault configured + no project → _universal/ψ/memory/learnings under vault
vault NOT configured          → flat ψ/memory/learnings at REPO_ROOT
                                  (local-ψ convention, matches mapToVaultPath)
```

`persistLearningDoc` gains an optional `baseDir` anchor (defaults to `REPO_ROOT` for back-compat).

**Backward compat**: pre-fix flat `sourceFile` rows still resolve via `resolveFilePath` (covered by `'old flat root sourceFile still resolves'` test). No migration needed for old data.

9 new tests in `learn-project-path.test.ts` — helper contract, project-nested write with DB prefix, `_universal` fallback, slug collision inside project dir, backward-compat read of pre-fix rows, and an **anti-divergence tripwire** asserting both write paths consume `resolveLearnDir`.

---

## Fix 2 — `ce8d6fef` CRUD route third path (same bug class)

Caught live: `POST /api/learn` on alpha.1608 is actually served by the CRUD route, not `handlers.ts`. So a project-tagged learning still landed flat at the vault root **despite** fix #1 being cherry-picked in.

`nextIdentity()` in `crud.ts` now derives its default `relDir` from `resolveLearnDir`. Explicit `body.sourceFile` still wins; anchoring/traversal safety stays in `learningSourcePath` unchanged.

Tripwire suite extended: 12/12 — all **three** write paths must call `resolveLearnDir` + no hardcoded root `learnings` literal allowed in `handlers.ts` / `crud.ts`. This is the regression gate for the pattern.

---

## Fix 3 — `ef3a3eb7` handoff UNIVERSAL (behavior change — want to discuss)

Sibling of the learn drift. `PROJECT_CATEGORIES` declared `ψ/inbox/handoff` as project-nested, and the embedded MCP writer honored that. But **every reader** reads only the root:

- `oracle_inbox` MCP tool
- `GET /api/inbox` HTTP route
- `knowledge/inbox` reader
- `maw-plugin` inbox view
- `arra-oracle-ctl verify`

Result: project-nested handoffs were invisible to all readers. And embedded mode is the **lazy fallback when the HTTP server is down** — handoffs written during an outage went dark exactly when they mattered most.

Zero dark mail existed yet on this fleet (sweep: one handoff dir, 16 files, all root). Fixed before first casualty.

Changes (declaration aligned to consumed behavior; no reader changed):
- `tools/handoff.ts`: vault write → `vaultRoot/ψ/inbox/handoff` (no project dir). No-vault last resort keeps local write but **SCREAMS** an `ORPHAN` `console.error` naming the path so outage mail is findable in logs.
- `path-mapping.ts`: `ψ/inbox/handoff/` moved `PROJECT` → `UNIVERSAL` categories.
- `migrate.ts`: local duplicate `PROJECT_CATEGORIES` list deleted (had already drifted from the shared one — same divergence-by-copy seed as the three-path learn drift). Imports `isProjectCategory` instead.

5 RED-first tests + 5 controls in `handoff-universal-inbox.test.ts`. `vault/handler.test.ts` nesting assertion updated to match the bound spec.

### Question for maintainer

The underlying spec ambiguity is real: **should `ψ/inbox/handoff` be project-nested or universal?**

This PR chooses UNIVERSAL because that is what every reader already does. The alternative is to keep project-nesting on the writer and update every reader to scan per-project. I'm open to either, but please decide before merge — happy to flip the implementation if readers should change instead.

---

## Fix 4 — `62eb94e9` test hermetic ORACLE_DATA_DIR

6 lines in `learn-enqueue.test.ts`. The test was leaking into the real vault when `vault_repo` was configured in env, causing a flaky frontmatter assertion. Pins `ORACLE_DATA_DIR` to a temp dir per test.

Pre-existing on clean HEAD — not caused by these fixes.

---

## Fix 5 — `81a430d9` bun.lock refresh

Single-line `bun.lock` bump for the alpha-1608 workspace install. No source change.

---

## Test results

```
src/tools/__tests__/learn-enqueue.test.ts
src/server/__tests__/learn-project-path.test.ts
src/vault/__tests__/handler.test.ts
src/tools/__tests__/handoff-universal-inbox.test.ts

54 pass / 0 fail / 125 expect() calls
```

Live-verified on the `house-keeper-oracle` fleet:
- `oracle_learn` with `project` param now lands at `github.com/dumpdumpy/{project}/ψ/memory/learnings/`
- `oracle_handoff` lands at vault root inbox, rank 1 in `oracle_inbox` (write→read loop closed)

---

## Why Draft

- Fix #3 is a visible behavior change and the spec decision (writer-UNIVERSAL vs reader-per-project) deserves maintainer sign-off before merge.
- I'd like CI to run on upstream env before marking ready.
- Happy to split into smaller PRs if preferred (e.g. learn-only first, handoff as separate discussion).

## Files

- `src/vault/learn-path.ts` (new, 51 lines) — shared helper
- `src/tools/learn.ts` — use helper
- `src/server/handlers.ts` — use helper, add `baseDir` to `persistLearningDoc`
- `src/routes/learn/crud.ts` — use helper for default relDir
- `src/tools/read.ts` — export `resolveFilePath` for reader-compat testing
- `src/tools/handoff.ts` — UNIVERSAL vault write, loud ORPHAN fallback
- `src/vault/path-mapping.ts` — handoff moved to UNIVERSAL
- `src/vault/migrate.ts` — import shared `isProjectCategory`, delete duplicate
- `src/tools/__tests__/handoff-universal-inbox.test.ts` (new)
- `src/server/__tests__/learn-project-path.test.ts` — extended
- `src/vault/__tests__/handler.test.ts` — assertion updated to bound spec
- `src/tools/__tests__/learn-enqueue.test.ts` — hermetic env pin
- `bun.lock` — alpha-1608 refresh

Co-authored-by: house-keeper-oracle fleet session 2026-07-07
