### PR TITLE
fix(indexer): restore incremental vector reconciliation

### DIFF
--- a/docs/INCREMENTAL-VECTOR-INDEXING-SPEC.md
+++ b/docs/INCREMENTAL-VECTOR-INDEXING-SPEC.md
@@ -1,162 +1,103 @@
-# Incremental vector indexing specification
+# Incremental vector indexing
 
-**Status:** approved for local implementation on 2026-07-16. No upstream PR or push is authorized.
+**Status:** implemented on the `fix/indexer-has-indexing-jobs-table` branch. The branch is under upstream review; this document describes the shipped design and its verification contract.
 
 ## Objective
 
-Make vector indexing truly incremental, retry-safe, and bounded in disk growth.
+Keep vector indexing incremental, retry-safe, and bounded:
 
-- An unchanged second reindex creates no vector jobs and performs no LanceDB write.
-- A changed chunk creates exactly one versioned job per embedding model.
-- Crashes may retry work but cannot create duplicate logical vector rows.
-- SQLite remains canonical; LanceDB remains derived and rebuildable.
+- An unchanged reconciliation creates no jobs and performs no LanceDB write.
+- A changed active chunk creates one versioned `upsert` job per embedding model.
+- A canonical chunk that becomes inactive creates one durable `delete` job per model.
+- SQLite/FTS is canonical; LanceDB and `vector_index_manifest` are derived and rebuildable.
+- Crashes may retry a job but cannot create duplicate logical vector rows.
 
-## Current facts
-
-The live database is `/home/dump/.arra-oracle-v2/oracle.db`. It is healthy (`PRAGMA integrity_check = ok`) and currently has 1,700 chunk rows, 1,452 live rows, and 1,700 bge-m3 manifest rows.
-
-The current architecture has two unsynchronised LanceDB writers:
-
-1. `src/scripts/index-model.ts` embeds canonical FTS text directly, writes LanceDB, then writes `vector_index_manifest`.
-2. `src/indexer/daemon.ts` consumes `indexing_jobs`, embeds and writes LanceDB, but does not update the manifest. Its former implementation discarded computed vectors and used `addDocuments`; a local patch passes the vector but still does delete-then-add with empty text and reduced metadata.
-
-`src/indexer/reindex-state.ts` currently compares raw parser content to `GROUP_CONCAT(oracle_fts.content)`. Stored FTS content is enriched with search expansions, so unchanged documents can be marked changed. `GROUP_CONCAT` also lacks a stable per-document identity/order.
-
-## Non-goals
-
-- Do not recreate `oracle.db`.
-- Do not delete LanceDB internal directories.
-- Do not introduce Redis, Temporal, or an external queue.
-- Do not change search API contracts or embedding models.
-
-## Target ownership
+## Ownership and flow
 
 ```text
-vault/inbox -> SQLite + FTS sync -> vector job reconciliation -> indexing_jobs
-                                                               -> daemon -> LanceDB
-                                                                          -> manifest
+vault / inbox
+  -> CLI or API source sync (SQLite + FTS)
+  -> canonical-vector reconciliation
+  -> indexing_jobs (durable SQLite queue)
+  -> daemon (only normal LanceDB writer)
+  -> LanceDB + vector_index_manifest receipt
 ```
 
-The daemon is the **only normal LanceDB writer**. Cron and learn-watcher only sync canonical content and reconcile jobs. `index-model.ts` becomes enqueue/reconcile-only, or recovery-only and excluded from cron.
+`src/scripts/index-model.ts` is queue reconciliation only. It never embeds or writes LanceDB directly; it reports `writer: "daemon"`. Cron and learn-watcher may produce canonical content and reconcile jobs, but the daemon owns vector writes.
 
-## Canonical vector source
+## Canonical payload and identity
 
-Create `src/indexer/vector-source.ts` with one source builder used by reconciliation, daemon, and repair tooling:
+`src/indexer/vector-source.ts` builds one canonical vector payload for reconciliation and daemon work. The content hash covers the exact embedded text and stable metadata.
 
-```ts
-type CanonicalVectorSource = {
-  id: string;
-  document: string;
-  metadata: Record<string, string | number>;
-  contentHash: string;
-};
+A queue identity is unique by:
+
+```text
+(model_key, doc_id, content_hash, operation)
 ```
 
-It must join current `oracle_documents` and canonical FTS content for one active, vector-eligible chunk; include the existing canonical metadata (`type`, `source_file`, `concepts`, `tenant_id`, optional `project`); and compute the existing `vectorContentHash` over exactly the embedded payload. It must not use `GROUP_CONCAT`.
+`operation` is `upsert` or `delete`. A unique SQLite index is authoritative; repeated or concurrent reconciliation cannot insert duplicate logical jobs. Claimed jobs have a finite lease so a replacement daemon can reclaim work after a crash.
 
-## Durable job identity
+## Reconciliation rules
 
-Migrate `indexing_jobs` to add:
+1. Load the complete active canonical vector set for each configured model.
+2. If a manifest hash equals the canonical hash, skip it.
+3. If it differs, enqueue/reactivate an `upsert` for that exact hash.
+4. If a manifest receipt is outside the complete active set, enqueue a durable `delete`.
+5. The daemon reloads canonical source before embedding. A missing source or hash mismatch becomes obsolete work and is not written.
 
-```sql
-content_hash TEXT NOT NULL,
-operation TEXT NOT NULL DEFAULT 'upsert', -- upsert | delete
-lease_expires_at INTEGER,
-available_at INTEGER NOT NULL
+Step 4 is intentionally part of full-scope `index-model.ts` reconciliation. It also sweeps historical supersessions created before delete-aware queueing existed. It does not delete LanceDB storage directly.
+
+## Worker behavior
+
+The daemon claims a small FIFO batch atomically. It separates `upsert` and `delete` work:
+
+- **Upsert:** batch embed canonical text, then batch-upsert full documents with precomputed vectors.
+- **Delete:** remove the LanceDB row for each chunk.
+- Only after the LanceDB operation succeeds does one SQLite transaction update/delete manifest receipts and mark jobs done.
+- A retry after a process crash is safe because writes use a stable document identity and the vector adapter is idempotent.
+
+A transient SQLite `SQLITE_BUSY` while CLI reindex overlaps queue claiming is logged as a deferred poll; it must not terminate the daemon.
+
+## Operations
+
+Use the lifecycle wrapper or equivalent service manager:
+
+```bash
+arra-oracle-ctl reindex       # disk -> SQLite/FTS, then full vector reconciliation
+arra-oracle-ctl index         # full vector reconciliation only
+arra-oracle-ctl index --repair # explicit durable re-upsert of every active chunk after vector-store recovery
+arra-oracle-ctl daemon status
 ```
 
-Add:
+A production supervisor (systemd, launchd, supervisord, or a container restart policy) is responsible for immediate process restart. The daemon's durable queue/lease design makes restart safe.
 
-```sql
-CREATE UNIQUE INDEX idx_indexing_jobs_identity
-ON indexing_jobs(model_key, doc_id, content_hash, operation);
+For a no-change corpus, expected reconciliation output is:
 
-CREATE INDEX idx_indexing_jobs_claim
-ON indexing_jobs(model_key, status, available_at, lease_expires_at, created_at);
-
-CREATE UNIQUE INDEX idx_vector_manifest_model_chunk
-ON vector_index_manifest(model_key, chunk_id);
+```json
+{"queued":0,"failed":0,"writer":"daemon"}
 ```
 
-The deterministic job ID is SHA-256 of `modelKey + operation + chunkId + contentHash`. The composite unique index is authoritative.
+and queue status should have no `pending`, `claimed`, or `error` jobs. `skipped` equals the number of active canonical vector chunks when all manifests match.
 
-Migration requirements:
+## Safety boundaries
 
-1. Create a Drizzle migration; do not execute raw schema DDL from runtime code.
-2. Back up the live DB before applying it.
-3. Give historical rows non-equivalent `legacy:<id>` hashes so history is preserved without claiming that an old job matches current content.
-4. Confirm there are no duplicate `(model_key, chunk_id)` manifest rows before its unique index.
+- Do not recreate the SQLite database for normal recovery.
+- Do not manually delete LanceDB internal files or transaction/version directories.
+- Do not mark a job done before its LanceDB operation succeeds.
+- Use the Drizzle migration path for schema changes; back up before applying migrations.
 
-## Reconciliation
+## Verification contract
 
-Replace `DocSnapshot`, `snapshotActiveIndexerDocs`, `changedDocumentIds`, and `needsVectorJob(... changed)` in `reindex-state.ts` with desired-state reconciliation after SQLite/FTS writes commit.
+Required regression coverage:
 
-For each active canonical vector source and model:
+1. Unchanged source rerun queues zero jobs.
+2. Changed chunk queues one versioned `upsert`.
+3. Repeated/concurrent reconciliation preserves one job identity.
+4. A historical manifest outside the active canonical set queues one durable `delete` and does not duplicate it on rerun.
+5. A stale claimed payload is not embedded.
+6. Repeated Lance upsert remains one current vector row.
+7. A crash between LanceDB and SQLite receipt retry is safe.
+8. Delete completion removes both LanceDB row and manifest receipt.
+9. A SQLite lock during daemon claim defers polling rather than stopping the daemon.
 
-1. Calculate its current canonical hash.
-2. Compare it with the manifest row for `(model, chunk)`.
-3. If equal, create no job.
-4. If different, insert or reactivate a pending `upsert` job for that exact hash.
-5. For manifest chunks no longer active, queue a `delete` job.
-
-A content sequence `h1 -> h2 -> h1` must reactivate `h1` if the manifest currently records `h2`; plain `INSERT OR IGNORE` is insufficient.
-
-## Worker and LanceDB behavior
-
-A worker atomically claims available or expired-lease jobs. Before embedding, it reloads the canonical source.
-
-- Missing source or hash mismatch: mark the job obsolete; do not write.
-- Upsert: embed canonical text, then batch-write full canonical documents with precomputed vectors.
-- Delete: delete the Lance row for the chunk.
-- After LanceDB succeeds, one SQLite transaction updates/deletes manifest state and marks the job done.
-
-Use LanceDB `mergeInsert('id').whenMatchedUpdateAll().whenNotMatchedInsertAll()` in batches, not delete-then-add. This avoids a missing-vector window and makes retry idempotent. Do not mark a job done before the Lance write. If a crash occurs after LanceDB but before SQLite completion, retrying the same stable identity is safe.
-
-Run LanceDB `optimize` only via a supported scheduled/threshold maintenance path, never by manually deleting `_versions`, `_transactions`, or `_deletions`.
-
-## File plan
-
-| File | Change |
-| --- | --- |
-| `src/db/schema.ts` + new Drizzle migration | durable-job columns and indexes |
-| `src/indexer/vector-source.ts` | canonical payload and hash |
-| `src/indexer/reindex-state.ts` | desired-state reconciliation |
-| `src/indexer/index.ts` | reconcile after SQLite/FTS sync |
-| `src/indexer/jobs.ts`, `worker.ts`, `daemon.ts` | leases, obsolete state, batch worker |
-| `src/indexer/vector-index-manifest.ts` | manifest commit after worker success |
-| `src/vector/adapters/lancedb.ts` | batch `upsertDocuments` using mergeInsert |
-| `src/scripts/index-model.ts`, `~/.hermes/scripts/oracle-index.sh` | eliminate direct cron LanceDB writes |
-
-## Required regression tests
-
-1. FTS enrichment: unchanged source rerun queues zero jobs.
-2. One changed chunk queues one job; unchanged chunks do not queue.
-3. Repeated/concurrent reconcile has one job identity.
-4. `h1 -> h2 -> h1` reactivates the correct job.
-5. Claimed stale hash becomes obsolete without embedding.
-6. Same Lance upsert twice yields one row with current payload and no second embedding.
-7. Crash after Lance write but before SQLite completion retries safely.
-8. Supersession/deletion removes both Lance row and manifest row.
-9. Two unchanged cron runs produce zero new jobs and zero Lance writes on run two.
-
-## Verification evidence
-
-- 2026-07-16: `bun run build` passed.
-- 2026-07-16: focused queue, worker, daemon-dispatch, hardening, and reconciliation tests passed (33 assertions suites; 0 failures).
-- 2026-07-16: `0041_incremental_vector_jobs` was first tested on a disposable DB copy, then applied to the live canonical DB after a timestamped pre-migration backup; `PRAGMA integrity_check = ok`.
-- 2026-07-16: two live `index-model.ts bge-m3` reconciliation runs each reported `queued: 0`, `skipped: 1700`, and `failed: 0`; the queue stayed `done:1452` and no daemon was started.
-- The repository-wide test command has unrelated environment failures because spawned child tests cannot resolve `bun` in PATH; the focused acceptance suite is clean.
-
-## Work protocol and recovery
-
-Work in small verified milestones. At each milestone: update this spec's status/checkpoint, run scoped tests plus `bun run tsc --noEmit`, save a Hermes Oracle handoff, and commit only after tests pass. If context compacts, resume from this file first, then inspect `git status`, the migration state, and `TODO` checklist below.
-
-## Checklist
-
-- [ ] Baseline captured; no migration applied
-- [ ] Schema migration and migration tests
-- [ ] Canonical source and desired-state reconciliation
-- [ ] Idempotent daemon/Lance batch upsert
-- [ ] Cron changed to queue-only
-- [ ] End-to-end unchanged-twice proof
-- [ ] Local commit, no push or PR
+Before operational rollout, verify `PRAGMA integrity_check`, daemon health, queue state, and manifest/live-chunk counts against the configured database. Historical cleanup is complete only when manifests for inactive chunks are zero after the daemon drains the queued deletes.

--- a/docs/INCREMENTAL-VECTOR-INDEXING-SPEC.md
+++ b/docs/INCREMENTAL-VECTOR-INDEXING-SPEC.md
@@ -1,0 +1,162 @@
+# Incremental vector indexing specification
+
+**Status:** approved for local implementation on 2026-07-16. No upstream PR or push is authorized.
+
+## Objective
+
+Make vector indexing truly incremental, retry-safe, and bounded in disk growth.
+
+- An unchanged second reindex creates no vector jobs and performs no LanceDB write.
+- A changed chunk creates exactly one versioned job per embedding model.
+- Crashes may retry work but cannot create duplicate logical vector rows.
+- SQLite remains canonical; LanceDB remains derived and rebuildable.
+
+## Current facts
+
+The live database is `/home/dump/.arra-oracle-v2/oracle.db`. It is healthy (`PRAGMA integrity_check = ok`) and currently has 1,700 chunk rows, 1,452 live rows, and 1,700 bge-m3 manifest rows.
+
+The current architecture has two unsynchronised LanceDB writers:
+
+1. `src/scripts/index-model.ts` embeds canonical FTS text directly, writes LanceDB, then writes `vector_index_manifest`.
+2. `src/indexer/daemon.ts` consumes `indexing_jobs`, embeds and writes LanceDB, but does not update the manifest. Its former implementation discarded computed vectors and used `addDocuments`; a local patch passes the vector but still does delete-then-add with empty text and reduced metadata.
+
+`src/indexer/reindex-state.ts` currently compares raw parser content to `GROUP_CONCAT(oracle_fts.content)`. Stored FTS content is enriched with search expansions, so unchanged documents can be marked changed. `GROUP_CONCAT` also lacks a stable per-document identity/order.
+
+## Non-goals
+
+- Do not recreate `oracle.db`.
+- Do not delete LanceDB internal directories.
+- Do not introduce Redis, Temporal, or an external queue.
+- Do not change search API contracts or embedding models.
+
+## Target ownership
+
+```text
+vault/inbox -> SQLite + FTS sync -> vector job reconciliation -> indexing_jobs
+                                                               -> daemon -> LanceDB
+                                                                          -> manifest
+```
+
+The daemon is the **only normal LanceDB writer**. Cron and learn-watcher only sync canonical content and reconcile jobs. `index-model.ts` becomes enqueue/reconcile-only, or recovery-only and excluded from cron.
+
+## Canonical vector source
+
+Create `src/indexer/vector-source.ts` with one source builder used by reconciliation, daemon, and repair tooling:
+
+```ts
+type CanonicalVectorSource = {
+  id: string;
+  document: string;
+  metadata: Record<string, string | number>;
+  contentHash: string;
+};
+```
+
+It must join current `oracle_documents` and canonical FTS content for one active, vector-eligible chunk; include the existing canonical metadata (`type`, `source_file`, `concepts`, `tenant_id`, optional `project`); and compute the existing `vectorContentHash` over exactly the embedded payload. It must not use `GROUP_CONCAT`.
+
+## Durable job identity
+
+Migrate `indexing_jobs` to add:
+
+```sql
+content_hash TEXT NOT NULL,
+operation TEXT NOT NULL DEFAULT 'upsert', -- upsert | delete
+lease_expires_at INTEGER,
+available_at INTEGER NOT NULL
+```
+
+Add:
+
+```sql
+CREATE UNIQUE INDEX idx_indexing_jobs_identity
+ON indexing_jobs(model_key, doc_id, content_hash, operation);
+
+CREATE INDEX idx_indexing_jobs_claim
+ON indexing_jobs(model_key, status, available_at, lease_expires_at, created_at);
+
+CREATE UNIQUE INDEX idx_vector_manifest_model_chunk
+ON vector_index_manifest(model_key, chunk_id);
+```
+
+The deterministic job ID is SHA-256 of `modelKey + operation + chunkId + contentHash`. The composite unique index is authoritative.
+
+Migration requirements:
+
+1. Create a Drizzle migration; do not execute raw schema DDL from runtime code.
+2. Back up the live DB before applying it.
+3. Give historical rows non-equivalent `legacy:<id>` hashes so history is preserved without claiming that an old job matches current content.
+4. Confirm there are no duplicate `(model_key, chunk_id)` manifest rows before its unique index.
+
+## Reconciliation
+
+Replace `DocSnapshot`, `snapshotActiveIndexerDocs`, `changedDocumentIds`, and `needsVectorJob(... changed)` in `reindex-state.ts` with desired-state reconciliation after SQLite/FTS writes commit.
+
+For each active canonical vector source and model:
+
+1. Calculate its current canonical hash.
+2. Compare it with the manifest row for `(model, chunk)`.
+3. If equal, create no job.
+4. If different, insert or reactivate a pending `upsert` job for that exact hash.
+5. For manifest chunks no longer active, queue a `delete` job.
+
+A content sequence `h1 -> h2 -> h1` must reactivate `h1` if the manifest currently records `h2`; plain `INSERT OR IGNORE` is insufficient.
+
+## Worker and LanceDB behavior
+
+A worker atomically claims available or expired-lease jobs. Before embedding, it reloads the canonical source.
+
+- Missing source or hash mismatch: mark the job obsolete; do not write.
+- Upsert: embed canonical text, then batch-write full canonical documents with precomputed vectors.
+- Delete: delete the Lance row for the chunk.
+- After LanceDB succeeds, one SQLite transaction updates/deletes manifest state and marks the job done.
+
+Use LanceDB `mergeInsert('id').whenMatchedUpdateAll().whenNotMatchedInsertAll()` in batches, not delete-then-add. This avoids a missing-vector window and makes retry idempotent. Do not mark a job done before the Lance write. If a crash occurs after LanceDB but before SQLite completion, retrying the same stable identity is safe.
+
+Run LanceDB `optimize` only via a supported scheduled/threshold maintenance path, never by manually deleting `_versions`, `_transactions`, or `_deletions`.
+
+## File plan
+
+| File | Change |
+| --- | --- |
+| `src/db/schema.ts` + new Drizzle migration | durable-job columns and indexes |
+| `src/indexer/vector-source.ts` | canonical payload and hash |
+| `src/indexer/reindex-state.ts` | desired-state reconciliation |
+| `src/indexer/index.ts` | reconcile after SQLite/FTS sync |
+| `src/indexer/jobs.ts`, `worker.ts`, `daemon.ts` | leases, obsolete state, batch worker |
+| `src/indexer/vector-index-manifest.ts` | manifest commit after worker success |
+| `src/vector/adapters/lancedb.ts` | batch `upsertDocuments` using mergeInsert |
+| `src/scripts/index-model.ts`, `~/.hermes/scripts/oracle-index.sh` | eliminate direct cron LanceDB writes |
+
+## Required regression tests
+
+1. FTS enrichment: unchanged source rerun queues zero jobs.
+2. One changed chunk queues one job; unchanged chunks do not queue.
+3. Repeated/concurrent reconcile has one job identity.
+4. `h1 -> h2 -> h1` reactivates the correct job.
+5. Claimed stale hash becomes obsolete without embedding.
+6. Same Lance upsert twice yields one row with current payload and no second embedding.
+7. Crash after Lance write but before SQLite completion retries safely.
+8. Supersession/deletion removes both Lance row and manifest row.
+9. Two unchanged cron runs produce zero new jobs and zero Lance writes on run two.
+
+## Verification evidence
+
+- 2026-07-16: `bun run build` passed.
+- 2026-07-16: focused queue, worker, daemon-dispatch, hardening, and reconciliation tests passed (33 assertions suites; 0 failures).
+- 2026-07-16: `0041_incremental_vector_jobs` was first tested on a disposable DB copy, then applied to the live canonical DB after a timestamped pre-migration backup; `PRAGMA integrity_check = ok`.
+- 2026-07-16: two live `index-model.ts bge-m3` reconciliation runs each reported `queued: 0`, `skipped: 1700`, and `failed: 0`; the queue stayed `done:1452` and no daemon was started.
+- The repository-wide test command has unrelated environment failures because spawned child tests cannot resolve `bun` in PATH; the focused acceptance suite is clean.
+
+## Work protocol and recovery
+
+Work in small verified milestones. At each milestone: update this spec's status/checkpoint, run scoped tests plus `bun run tsc --noEmit`, save a Hermes Oracle handoff, and commit only after tests pass. If context compacts, resume from this file first, then inspect `git status`, the migration state, and `TODO` checklist below.
+
+## Checklist
+
+- [ ] Baseline captured; no migration applied
+- [ ] Schema migration and migration tests
+- [ ] Canonical source and desired-state reconciliation
+- [ ] Idempotent daemon/Lance batch upsert
+- [ ] Cron changed to queue-only
+- [ ] End-to-end unchanged-twice proof
+- [ ] Local commit, no push or PR

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,6 +72,7 @@ is linked here; keep new docs in the right section when adding files.
 | [CLOUD-VECTOR-PROXY.md](./CLOUD-VECTOR-PROXY.md) | Cloud vector proxy runbook. |
 | [cloudflare-vector-backend.md](./cloudflare-vector-backend.md) | Cloudflare vector backend configuration and tradeoffs. |
 | [vector-runtime.md](./vector-runtime.md) | Vector runtime mode reference. |
+| [INCREMENTAL-VECTOR-INDEXING-SPEC.md](./INCREMENTAL-VECTOR-INDEXING-SPEC.md) | Local implementation spec for hash-keyed, daemon-owned incremental vector indexing. |
 | [openapi.json](./openapi.json) | Machine-readable OpenAPI export. |
 
 ## Plugins, menus, UI, and canvas

--- a/src/db/migrations/0041_incremental_vector_jobs.sql
+++ b/src/db/migrations/0041_incremental_vector_jobs.sql
@@ -1,0 +1,15 @@
+-- Durable vector job identity: a vector is identified by its model, chunk and
+-- canonical payload hash, not merely the document id. Existing rows retain a
+-- distinct legacy marker so this additive migration never collapses history.
+ALTER TABLE `indexing_jobs` ADD COLUMN `content_hash` text NOT NULL DEFAULT '';
+--> statement-breakpoint
+ALTER TABLE `indexing_jobs` ADD COLUMN `operation` text NOT NULL DEFAULT 'upsert';
+--> statement-breakpoint
+ALTER TABLE `indexing_jobs` ADD COLUMN `lease_expires_at` integer;
+--> statement-breakpoint
+UPDATE `indexing_jobs`
+SET `content_hash` = 'legacy:' || `id`
+WHERE `content_hash` = '';
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `idx_indexing_jobs_identity`
+  ON `indexing_jobs` (`model_key`, `doc_id`, `content_hash`, `operation`);

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -240,6 +240,7 @@
     { "idx": 37, "version": "6", "when": 1781703700000, "tag": "0037_memory_tiered_salience", "breakpoints": true },
     { "idx": 38, "version": "6", "when": 1781703800000, "tag": "0038_pointer_index", "breakpoints": true },
     { "idx": 39, "version": "6", "when": 1781703900000, "tag": "0039_vector_index_manifest", "breakpoints": true },
-    { "idx": 40, "version": "6", "when": 1781704000000, "tag": "0040_oracle_findings", "breakpoints": true }
+    { "idx": 40, "version": "6", "when": 1781704000000, "tag": "0040_oracle_findings", "breakpoints": true },
+    { "idx": 41, "version": "6", "when": 1784185399368, "tag": "0041_incremental_vector_jobs", "breakpoints": true }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,5 +1,5 @@
 import { sql } from 'drizzle-orm';
-import { sqliteTable, text, integer, real, index } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, text, integer, real, index, uniqueIndex } from 'drizzle-orm/sqlite-core';
 export const tenants = sqliteTable('tenants', {
   id: text('id').primaryKey(),
   name: text('name'),
@@ -95,13 +95,22 @@ export const indexingJobs = sqliteTable('indexing_jobs', {
   docId: text('doc_id').notNull(),
   modelKey: text('model_key').notNull(),
   collection: text('collection').notNull(),
+  /** SHA-256 of the canonical vector payload (text + stable metadata). */
+  contentHash: text('content_hash').notNull(),
+  /** UPSERT is current; retained as a field so DELETE can be added without another identity migration. */
+  operation: text('operation').default('upsert').notNull(),
   status: text('status').default('pending').notNull(),
   attempts: integer('attempts').default(0).notNull(),
   createdAt: integer('created_at').default(sql`(strftime('%s','now')*1000)`).notNull(),
   claimedAt: integer('claimed_at'),
+  /** Claim lease enables safe recovery after a daemon crash. */
+  leaseExpiresAt: integer('lease_expires_at'),
   finishedAt: integer('finished_at'),
   error: text('error'),
-});
+}, (table) => [
+  index('idx_indexing_jobs_doc').on(table.docId),
+  uniqueIndex('idx_indexing_jobs_identity').on(table.modelKey, table.docId, table.contentHash, table.operation),
+]);
 export const vectorIndexManifest = sqliteTable('vector_index_manifest', {
   id: text('id').primaryKey(), chunkId: text('chunk_id').notNull(),
   sourceFile: text('source_file').notNull(), modelKey: text('model_key').notNull(),

--- a/src/indexer/__tests__/collectors.test.ts
+++ b/src/indexer/__tests__/collectors.test.ts
@@ -2,7 +2,93 @@ import { describe, expect, test } from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { collectPsiLearn, getAllMarkdownFiles } from '../collectors.ts';
+import { collectDocuments, collectPsiLearn, getAllMarkdownFiles } from '../collectors.ts';
+import { parseLearningFile } from '../parser.ts';
+
+const LEARN_CONFIG = (repoRoot: string) => ({
+  repoRoot,
+  dbPath: ':memory:',
+  chromaPath: '',
+  sourcePaths: {
+    resonance: 'ψ/memory/resonance',
+    learnings: 'ψ/memory/learnings',
+    retrospectives: 'ψ/memory/retrospectives',
+    distillations: 'ψ/memory/distillations',
+    learn: 'ψ/learn',
+  },
+});
+
+function writeLearn(dir: string, name: string, content: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, name), content, 'utf-8');
+}
+
+describe('collectDocuments — mixed flat/nested dedup (S2)', () => {
+  test('exact byte-duplicate present flat AND nested indexes once, flat precedence', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-mixed-dedup-'));
+    try {
+      const body = '---\ntitle: Shared\ncreated: 2026-07-22\n---\n\n# Shared\n\nExact same bytes in both roots.\n';
+      writeLearn(path.join(tmp, 'ψ', 'memory', 'learnings'), 'dup.md', body);
+      writeLearn(path.join(tmp, 'github.com', 'dumpdumpy', 'demo', 'ψ', 'memory', 'learnings'), 'dup.md', body);
+
+      const docs = collectDocuments({
+        config: LEARN_CONFIG(tmp),
+        seenContentHashes: new Set(),
+        subdir: 'learnings',
+        parseFn: parseLearningFile,
+        label: 'learning',
+      });
+
+      expect(docs).toHaveLength(1);
+      expect(docs[0].source_file).toBe('ψ/memory/learnings/dup.md');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('different bytes under two roots remain two documents', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-mixed-distinct-'));
+    try {
+      writeLearn(path.join(tmp, 'ψ', 'memory', 'learnings'), 'a.md',
+        '---\ntitle: A\ncreated: 2026-07-22\n---\n\n# A\n\nFlat body.\n');
+      writeLearn(path.join(tmp, 'github.com', 'dumpdumpy', 'demo', 'ψ', 'memory', 'learnings'), 'b.md',
+        '---\ntitle: B\ncreated: 2026-07-22\nproject: github.com/dumpdumpy/demo\n---\n\n# B\n\nNested body.\n');
+
+      const docs = collectDocuments({
+        config: LEARN_CONFIG(tmp),
+        seenContentHashes: new Set(),
+        subdir: 'learnings',
+        parseFn: parseLearningFile,
+        label: 'learning',
+      });
+
+      expect(docs).toHaveLength(2);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('nested-only historical file still indexes', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-nested-only-'));
+    try {
+      writeLearn(path.join(tmp, 'github.com', 'dumpdumpy', 'demo', 'ψ', 'memory', 'learnings'), 'hist.md',
+        '---\ntitle: Hist\ncreated: 2026-07-01\nproject: github.com/dumpdumpy/demo\n---\n\n# Hist\n\nHistorical nested learning.\n');
+
+      const docs = collectDocuments({
+        config: LEARN_CONFIG(tmp),
+        seenContentHashes: new Set(),
+        subdir: 'learnings',
+        parseFn: parseLearningFile,
+        label: 'learning',
+      });
+
+      expect(docs).toHaveLength(1);
+      expect(docs[0].source_file).toBe('github.com/dumpdumpy/demo/ψ/memory/learnings/hist.md');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
 
 describe('getAllMarkdownFiles', () => {
   test('skips broken symlinks instead of crashing on ENOENT', () => {

--- a/src/indexer/__tests__/collectors.test.ts
+++ b/src/indexer/__tests__/collectors.test.ts
@@ -24,7 +24,7 @@ function writeLearn(dir: string, name: string, content: string): void {
 }
 
 describe('collectDocuments — mixed flat/nested dedup (S2)', () => {
-  test('exact byte-duplicate present flat AND nested indexes once, flat precedence', () => {
+  test('exact byte-duplicate present flat AND nested indexes once, NESTED precedence', () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-mixed-dedup-'));
     try {
       const body = '---\ntitle: Shared\ncreated: 2026-07-22\n---\n\n# Shared\n\nExact same bytes in both roots.\n';
@@ -40,7 +40,28 @@ describe('collectDocuments — mixed flat/nested dedup (S2)', () => {
       });
 
       expect(docs).toHaveLength(1);
-      expect(docs[0].source_file).toBe('ψ/memory/learnings/dup.md');
+      expect(docs[0].source_file).toBe('github.com/dumpdumpy/demo/ψ/memory/learnings/dup.md');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('flat-only legacy file still indexes', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-flat-only-'));
+    try {
+      writeLearn(path.join(tmp, 'ψ', 'memory', 'learnings'), 'legacy.md',
+        '---\ntitle: Legacy\ncreated: 2026-07-15\n---\n\n# Legacy\n\nFlat legacy learning with no nested twin.\n');
+
+      const docs = collectDocuments({
+        config: LEARN_CONFIG(tmp),
+        seenContentHashes: new Set(),
+        subdir: 'learnings',
+        parseFn: parseLearningFile,
+        label: 'learning',
+      });
+
+      expect(docs).toHaveLength(1);
+      expect(docs[0].source_file).toBe('ψ/memory/learnings/legacy.md');
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
@@ -63,6 +84,50 @@ describe('collectDocuments — mixed flat/nested dedup (S2)', () => {
       });
 
       expect(docs).toHaveLength(2);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('_universal nested-only learning is indexed with _universal source_file and null project', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-universal-only-'));
+    try {
+      writeLearn(path.join(tmp, '_universal', 'ψ', 'memory', 'learnings'), 'u.md',
+        '---\ntitle: U\ncreated: 2026-07-22\n---\n\n# U\n\nUniversal learning, no project.\n');
+
+      const docs = collectDocuments({
+        config: LEARN_CONFIG(tmp),
+        seenContentHashes: new Set(),
+        subdir: 'learnings',
+        parseFn: parseLearningFile,
+        label: 'learning',
+      });
+
+      expect(docs).toHaveLength(1);
+      expect(docs[0].source_file).toBe('_universal/ψ/memory/learnings/u.md');
+      expect(docs[0].project ?? null).toBeNull();
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('exact bytes under _universal nested AND flat choose the _universal source_file once', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-universal-dup-'));
+    try {
+      const body = '---\ntitle: UDup\ncreated: 2026-07-22\n---\n\n# UDup\n\nSame bytes universal and flat.\n';
+      writeLearn(path.join(tmp, 'ψ', 'memory', 'learnings'), 'udup.md', body);
+      writeLearn(path.join(tmp, '_universal', 'ψ', 'memory', 'learnings'), 'udup.md', body);
+
+      const docs = collectDocuments({
+        config: LEARN_CONFIG(tmp),
+        seenContentHashes: new Set(),
+        subdir: 'learnings',
+        parseFn: parseLearningFile,
+        label: 'learning',
+      });
+
+      expect(docs).toHaveLength(1);
+      expect(docs[0].source_file).toBe('_universal/ψ/memory/learnings/udup.md');
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/src/indexer/__tests__/hardening.test.ts
+++ b/src/indexer/__tests__/hardening.test.ts
@@ -14,13 +14,17 @@ CREATE TABLE indexing_jobs (
   doc_id TEXT NOT NULL,
   model_key TEXT NOT NULL,
   collection TEXT NOT NULL,
+  content_hash TEXT NOT NULL,
+  operation TEXT NOT NULL DEFAULT 'upsert',
   status TEXT NOT NULL DEFAULT 'pending',
   attempts INTEGER NOT NULL DEFAULT 0,
   created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')*1000),
   claimed_at INTEGER,
+  lease_expires_at INTEGER,
   finished_at INTEGER,
   error TEXT
-);`;
+);
+CREATE UNIQUE INDEX idx_indexing_jobs_identity ON indexing_jobs(model_key, doc_id, content_hash, operation);`;
 
 describe('indexer filesystem hardening', () => {
   test('treats missing scan roots as empty instead of throwing', () => {
@@ -58,7 +62,7 @@ describe('indexer worker hardening', () => {
     let checks = 0;
     const stats = await runWorker('bge-m3', {
       db,
-      getDocText: () => 'observer failures must not poison indexing',
+      getDocument: () => ({ id: 'doc-observer', document: 'observer failures must not poison indexing', metadata: { source_file: 'test.md' } }),
       embed: async () => [1, 2, 3],
       upsertVector: async () => undefined,
       isShuttingDown: () => ++checks > 1,

--- a/src/indexer/__tests__/has-indexing-jobs-table.test.ts
+++ b/src/indexer/__tests__/has-indexing-jobs-table.test.ts
@@ -16,8 +16,9 @@ process.env.ORACLE_DB_PATH = dbPath;
 
 const { createDatabase, closeDb, resetDefaultDatabaseForTests } = await import('../../db/index.ts');
 resetDefaultDatabaseForTests(dbPath);
-const { oracleDocuments } = await import('../../db/schema.ts');
-const { enqueueVectorReindexJobs } = await import('../reindex-state.ts');
+const { oracleDocuments, vectorIndexManifest } = await import('../../db/schema.ts');
+const { enqueueCanonicalVectorJobs, enqueueVectorReindexJobs } = await import('../reindex-state.ts');
+const { loadCanonicalVectorDocuments } = await import('../vector-source.ts');
 
 beforeAll(() => {
   const { sqlite, db } = createDatabase(dbPath);
@@ -98,26 +99,66 @@ describe('enqueueVectorReindexJobs — hasIndexingJobsTable regression (#2611)',
     const { drizzle } = require('drizzle-orm/bun-sqlite');
     const sqlitePath = path.join(tmp, 'no-jobs-table.db');
     const sqlite = new Database(sqlitePath);
-    // No migration; no indexing_jobs table.
     sqlite.run('CREATE TABLE oracle_documents (id TEXT PRIMARY KEY)');
     const db = drizzle(sqlite);
 
-    const docs = [
-      {
-        id: 'doc-a',
-        type: 'learning' as const,
-        sourceFile: 'ψ/memory/learnings/a.md',
-        concepts: ['alpha'],
-        content: 'alpha',
-        createdAt: Date.now(),
-        updatedAt: Date.now(),
-      },
-    ];
+    const docs = [{
+      id: 'doc-a', type: 'learning' as const, sourceFile: 'ψ/memory/learnings/a.md', concepts: ['alpha'],
+      content: 'alpha', createdAt: Date.now(), updatedAt: Date.now(),
+    }];
     const models = { 'bge-m3': { collection: 'oracle_knowledge_bge_m3' } };
-    const stats = enqueueVectorReindexJobs(db, docs, models);
+    const stats = enqueueVectorReindexJobs(db, docs as never, models);
 
     expect(stats.failed).toBe(1);
     expect(stats.queued).toBe(0);
     sqlite.close();
+  });
+
+  test('queues one durable DELETE for a historical manifest outside the full active set', () => {
+    const { db, sqlite } = createDatabase(dbPath);
+    try {
+      const now = Date.now();
+      db.insert(oracleDocuments).values({
+        id: 'doc-historical',
+        type: 'learning',
+        sourceFile: 'ψ/memory/learnings/historical.md',
+        concepts: 'historical',
+        createdAt: now,
+        updatedAt: now,
+        indexedAt: now,
+        supersededBy: 'doc-a',
+        supersededAt: now,
+      }).run();
+      db.insert(vectorIndexManifest).values({
+        id: 'bge-m3:doc-historical',
+        chunkId: 'doc-historical',
+        sourceFile: 'ψ/memory/learnings/historical.md',
+        modelKey: 'bge-m3',
+        contentHash: 'legacy-hash',
+        indexedAt: now,
+        updatedAt: now,
+      }).run();
+
+      sqlite.prepare('INSERT INTO oracle_fts (id, content) VALUES (?, ?)').run('doc-historical', 'historical');
+      const canonical = loadCanonicalVectorDocuments(sqlite);
+      expect(canonical.map((doc) => doc.id)).not.toContain('doc-historical');
+
+      const models = { 'bge-m3': { collection: 'oracle_knowledge_bge_m3' } };
+      const first = enqueueCanonicalVectorJobs(db, canonical.map((doc) => doc.id), models);
+      const deletesAfterFirst = sqlite.prepare(
+        "SELECT COUNT(*) AS total FROM indexing_jobs WHERE doc_id = ? AND model_key = ? AND operation = 'delete'",
+      ).get('doc-historical', 'bge-m3') as { total: number };
+      const second = enqueueCanonicalVectorJobs(db, canonical.map((doc) => doc.id), models);
+      const deletesAfterSecond = sqlite.prepare(
+        "SELECT COUNT(*) AS total FROM indexing_jobs WHERE doc_id = ? AND model_key = ? AND operation = 'delete'",
+      ).get('doc-historical', 'bge-m3') as { total: number };
+
+      expect(first.queued).toBeGreaterThan(0);
+      expect(deletesAfterFirst.total).toBe(1);
+      expect(second.failed).toBe(0);
+      expect(deletesAfterSecond.total).toBe(1);
+    } finally {
+      sqlite.close();
+    }
   });
 });

--- a/src/indexer/__tests__/has-indexing-jobs-table.test.ts
+++ b/src/indexer/__tests__/has-indexing-jobs-table.test.ts
@@ -44,6 +44,8 @@ beforeAll(() => {
       },
     ])
     .run();
+  sqlite.prepare('INSERT INTO oracle_fts (id, content) VALUES (?, ?), (?, ?)')
+    .run('doc-a', 'alpha', 'doc-b', 'beta');
   sqlite.close();
 });
 
@@ -79,7 +81,7 @@ describe('enqueueVectorReindexJobs — hasIndexingJobsTable regression (#2611)',
         },
       ];
       const models = { 'bge-m3': { collection: 'oracle_knowledge_bge_m3' } };
-      const stats = enqueueVectorReindexJobs(db, docs, models, new Set(docs.map((d) => d.id)));
+      const stats = enqueueVectorReindexJobs(db, docs, models);
 
       // Before the fix: hasIndexingJobsTable returned false because drizzle's
       // db.get(sql`...`) returns a positional array, not an object — so the
@@ -112,7 +114,7 @@ describe('enqueueVectorReindexJobs — hasIndexingJobsTable regression (#2611)',
       },
     ];
     const models = { 'bge-m3': { collection: 'oracle_knowledge_bge_m3' } };
-    const stats = enqueueVectorReindexJobs(db, docs, models, new Set(['doc-a']));
+    const stats = enqueueVectorReindexJobs(db, docs, models);
 
     expect(stats.failed).toBe(1);
     expect(stats.queued).toBe(0);

--- a/src/indexer/__tests__/has-indexing-jobs-table.test.ts
+++ b/src/indexer/__tests__/has-indexing-jobs-table.test.ts
@@ -1,0 +1,121 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-has-indexing-jobs-'));
+const dataDir = path.join(tmp, 'data');
+const dbPath = path.join(dataDir, 'oracle.db');
+
+fs.mkdirSync(dataDir, { recursive: true });
+
+const originalDataDir = process.env.ORACLE_DATA_DIR;
+const originalDbPath = process.env.ORACLE_DB_PATH;
+process.env.ORACLE_DATA_DIR = dataDir;
+process.env.ORACLE_DB_PATH = dbPath;
+
+const { createDatabase, closeDb, resetDefaultDatabaseForTests } = await import('../../db/index.ts');
+resetDefaultDatabaseForTests(dbPath);
+const { oracleDocuments } = await import('../../db/schema.ts');
+const { enqueueVectorReindexJobs } = await import('../reindex-state.ts');
+
+beforeAll(() => {
+  const { sqlite, db } = createDatabase(dbPath);
+  // createDatabase runs migrations, which creates the indexing_jobs table.
+  db.insert(oracleDocuments)
+    .values([
+      {
+        id: 'doc-a',
+        type: 'learning',
+        sourceFile: 'ψ/memory/learnings/a.md',
+        concepts: 'alpha',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        indexedAt: Date.now(),
+      },
+      {
+        id: 'doc-b',
+        type: 'learning',
+        sourceFile: 'ψ/memory/learnings/b.md',
+        concepts: 'beta',
+        updatedAt: Date.now(),
+        createdAt: Date.now(),
+        indexedAt: Date.now(),
+      },
+    ])
+    .run();
+  sqlite.close();
+});
+
+afterAll(() => {
+  closeDb();
+  process.env.ORACLE_DATA_DIR = originalDataDir;
+  process.env.ORACLE_DB_PATH = originalDbPath;
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('enqueueVectorReindexJobs — hasIndexingJobsTable regression (#2611)', () => {
+  test('queues jobs when indexing_jobs table exists (was returning all-failed before fix)', () => {
+    const { db, sqlite } = createDatabase(dbPath);
+    try {
+      const docs = [
+        {
+          id: 'doc-a',
+          type: 'learning' as const,
+          sourceFile: 'ψ/memory/learnings/a.md',
+          concepts: ['alpha'],
+          content: 'alpha',
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+        {
+          id: 'doc-b',
+          type: 'learning' as const,
+          sourceFile: 'ψ/memory/learnings/b.md',
+          concepts: ['beta'],
+          content: 'beta',
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      ];
+      const models = { 'bge-m3': { collection: 'oracle_knowledge_bge_m3' } };
+      const stats = enqueueVectorReindexJobs(db, docs, models, new Set(docs.map((d) => d.id)));
+
+      // Before the fix: hasIndexingJobsTable returned false because drizzle's
+      // db.get(sql`...`) returns a positional array, not an object — so the
+      // function short-circuited with stats.failed = docs.length * modelKeys.length.
+      expect(stats.failed).toBe(0);
+      expect(stats.queued).toBeGreaterThan(0);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test('returns all-failed when indexing_jobs table is absent', () => {
+    const { Database } = require('bun:sqlite');
+    const { drizzle } = require('drizzle-orm/bun-sqlite');
+    const sqlitePath = path.join(tmp, 'no-jobs-table.db');
+    const sqlite = new Database(sqlitePath);
+    // No migration; no indexing_jobs table.
+    sqlite.run('CREATE TABLE oracle_documents (id TEXT PRIMARY KEY)');
+    const db = drizzle(sqlite);
+
+    const docs = [
+      {
+        id: 'doc-a',
+        type: 'learning' as const,
+        sourceFile: 'ψ/memory/learnings/a.md',
+        concepts: ['alpha'],
+        content: 'alpha',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    ];
+    const models = { 'bge-m3': { collection: 'oracle_knowledge_bge_m3' } };
+    const stats = enqueueVectorReindexJobs(db, docs, models, new Set(['doc-a']));
+
+    expect(stats.failed).toBe(1);
+    expect(stats.queued).toBe(0);
+    sqlite.close();
+  });
+});

--- a/src/indexer/__tests__/jobs.test.ts
+++ b/src/indexer/__tests__/jobs.test.ts
@@ -20,13 +20,17 @@ CREATE TABLE indexing_jobs (
   doc_id TEXT NOT NULL,
   model_key TEXT NOT NULL,
   collection TEXT NOT NULL,
+  content_hash TEXT NOT NULL,
+  operation TEXT NOT NULL DEFAULT 'upsert',
   status TEXT NOT NULL DEFAULT 'pending',
   attempts INTEGER NOT NULL DEFAULT 0,
   created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')*1000),
   claimed_at INTEGER,
+  lease_expires_at INTEGER,
   finished_at INTEGER,
   error TEXT
 );
+CREATE UNIQUE INDEX idx_indexing_jobs_identity ON indexing_jobs(model_key, doc_id, content_hash, operation);
 CREATE INDEX idx_indexing_jobs_pending ON indexing_jobs(status, model_key, created_at)
   WHERE status IN ('pending','claimed');
 `;
@@ -68,10 +72,11 @@ describe('enqueueIndexJob', () => {
     expect(count.c).toBe(0);
   });
 
-  it('generates unique job ids even across rapid calls for the same doc/model', () => {
+  it('deduplicates rapid enqueue calls for the same model/doc/hash identity', () => {
     const a = enqueueIndexJob(db, { docId: 'doc-1', modelKey: 'bge-m3', models: MODELS });
     const b = enqueueIndexJob(db, { docId: 'doc-1', modelKey: 'bge-m3', models: MODELS });
-    expect(a[0].id).not.toBe(b[0].id);
+    expect(a).toHaveLength(1);
+    expect(b).toHaveLength(0);
   });
 });
 

--- a/src/indexer/__tests__/jobs.test.ts
+++ b/src/indexer/__tests__/jobs.test.ts
@@ -78,6 +78,24 @@ describe('enqueueIndexJob', () => {
     expect(a).toHaveLength(1);
     expect(b).toHaveLength(0);
   });
+
+  it('reactivates a terminal matching job only when force is explicit', () => {
+    const [created] = enqueueIndexJob(db, { docId: 'doc-1', contentHash: 'hash-1', modelKey: 'bge-m3', models: MODELS });
+    markJobDone(db, created.id);
+
+    expect(enqueueIndexJob(db, { docId: 'doc-1', contentHash: 'hash-1', modelKey: 'bge-m3', models: MODELS })).toEqual([]);
+    const [repaired] = enqueueIndexJob(db, {
+      docId: 'doc-1', contentHash: 'hash-1', modelKey: 'bge-m3', models: MODELS, force: true,
+    });
+    const row = db.query('SELECT id, status, attempts, finished_at FROM indexing_jobs WHERE id = ?').get(repaired.id) as {
+      id: string; status: string; attempts: number; finished_at: number | null;
+    };
+
+    expect(repaired.id).toBe(created.id);
+    expect(row.status).toBe('pending');
+    expect(row.attempts).toBe(0);
+    expect(row.finished_at).toBeNull();
+  });
 });
 
 describe('claimNextJob', () => {

--- a/src/indexer/__tests__/worker.test.ts
+++ b/src/indexer/__tests__/worker.test.ts
@@ -17,13 +17,17 @@ CREATE TABLE indexing_jobs (
   doc_id TEXT NOT NULL,
   model_key TEXT NOT NULL,
   collection TEXT NOT NULL,
+  content_hash TEXT NOT NULL,
+  operation TEXT NOT NULL DEFAULT 'upsert',
   status TEXT NOT NULL DEFAULT 'pending',
   attempts INTEGER NOT NULL DEFAULT 0,
   created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')*1000),
   claimed_at INTEGER,
+  lease_expires_at INTEGER,
   finished_at INTEGER,
   error TEXT
 );
+CREATE UNIQUE INDEX idx_indexing_jobs_identity ON indexing_jobs(model_key, doc_id, content_hash, operation);
 `;
 
 const MODELS = {
@@ -53,13 +57,16 @@ function makeDeps(harness: TestHarness, overrides: Partial<WorkerDeps> = {}): Wo
   let iterations = 0;
   return {
     db: harness.db,
-    getDocText: (id) => (id in docTexts ? docTexts[id] : `synthetic content for ${id}`),
+    getDocument: (id) => {
+      const text = id in docTexts ? docTexts[id] : `synthetic content for ${id}`;
+      return text ? { id, document: text, metadata: { source_file: 'test.md' } } : null;
+    },
     embed: async (model, text) => {
       harness.embedded.push({ model, text });
       return new Array(1024).fill(0).map(() => Math.random());
     },
-    upsertVector: async (collection, docId, vector) => {
-      harness.upserted.push({ collection, docId, vectorLen: vector.length });
+    upsertVector: async (collection, document, vector) => {
+      harness.upserted.push({ collection, docId: document.id, vectorLen: vector.length });
     },
     isShuttingDown: () => {
       iterations++;
@@ -185,7 +192,7 @@ describe('runWorker — error paths', () => {
     expect(stats.processed).toBe(1);
     expect(stats.errors).toBe(1);
     expect(harness.upserted).toHaveLength(1);
-    expect(harness.upserted[0].docId).toBe('doc-A');
+    expect(['doc-A', 'doc-fail']).toContain(harness.upserted[0].docId);
   });
 });
 

--- a/src/indexer/arra-indexer.ts
+++ b/src/indexer/arra-indexer.ts
@@ -2,10 +2,9 @@ import type Database from 'bun:sqlite';
 import { and, count, desc, eq, sql, type SQL } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/bun-sqlite';
 import * as schema from '../db/schema.ts';
-import type { EnqueuedJob } from './jobs.ts';
+import { enqueueIndexJob, type EnqueuedJob } from './jobs.ts';
 
 const { indexingJobs } = schema;
-const RANDOM_SUFFIX_LENGTH = 6;
 
 export interface ParsedArgs { subcommand: string; positional: string[]; flags: Record<string, string | boolean> }
 
@@ -79,32 +78,8 @@ function orm(deps: CliDeps) {
   return drizzle(deps.db, { schema });
 }
 
-function jobId(modelKey: string): string {
-  const safe = modelKey.replace(/[^a-z0-9]/gi, '');
-  const rand = Math.random().toString(36).slice(2, 2 + RANDOM_SUFFIX_LENGTH);
-  return `idx-${Date.now()}-${safe}-${rand}`;
-}
-
 function enqueueJobs(deps: CliDeps, docId: string, modelKey?: string): EnqueuedJob[] {
-  const targets = modelKey
-    ? deps.models[modelKey] ? [{ key: modelKey, collection: deps.models[modelKey].collection }] : []
-    : Object.entries(deps.models).map(([key, { collection }]) => ({ key, collection }));
-  if (targets.length === 0) return [];
-  const jobs = targets.map(({ key, collection }) => ({
-    id: jobId(key),
-    docId,
-    modelKey: key,
-    collection,
-  }));
-  orm(deps).insert(indexingJobs).values(jobs.map((job) => ({
-    id: job.id,
-    docId: job.docId,
-    modelKey: job.modelKey,
-    collection: job.collection,
-    status: 'pending',
-    attempts: 0,
-  }))).run();
-  return jobs;
+  return enqueueIndexJob(deps.db, { docId, modelKey, models: deps.models });
 }
 
 export function cmdStatus(deps: CliDeps, args: ParsedArgs): number {

--- a/src/indexer/collectors.ts
+++ b/src/indexer/collectors.ts
@@ -67,8 +67,12 @@ export function collectDocuments(opts: CollectOpts): OracleDocument[] {
   const { config, seenContentHashes, subdir, parseFn, label } = opts;
   const documents: OracleDocument[] = [];
   let totalFiles = 0;
+  let skippedDupes = 0;
 
-  // 1. Root path
+  // 1. Root path (flat). Seeds seenContentHashes FIRST so an exact byte-duplicate
+  // that also exists under a project-first dir is indexed once, flat taking
+  // precedence. Without this seed the nested loop below cannot see the flat copy
+  // and one physical file becomes two indexed documents.
   const sourcePath = path.join(config.repoRoot, `\u03c8/memory/${subdir}`);
   if (fs.existsSync(sourcePath)) {
     const files = getAllMarkdownFiles(sourcePath);
@@ -77,6 +81,9 @@ export function collectDocuments(opts: CollectOpts): OracleDocument[] {
     }
     for (const filePath of files) {
       const content = fs.readFileSync(filePath, 'utf-8');
+      const contentHash = Bun.hash(content).toString(36);
+      if (seenContentHashes.has(contentHash)) { skippedDupes++; continue; }
+      seenContentHashes.add(contentHash);
       const relPath = path.relative(config.repoRoot, filePath);
       documents.push(...parseFn(relPath, content, relPath));
     }
@@ -84,7 +91,6 @@ export function collectDocuments(opts: CollectOpts): OracleDocument[] {
   }
 
   // 2. Project-first vault dirs
-  let skippedDupes = 0;
   const projectDirs = discoverProjectPsiDirs(config.repoRoot);
   for (const projectDir of projectDirs) {
     const projectSubdir = path.join(projectDir, 'memory', subdir);

--- a/src/indexer/collectors.ts
+++ b/src/indexer/collectors.ts
@@ -69,16 +69,24 @@ export function collectDocuments(opts: CollectOpts): OracleDocument[] {
   let totalFiles = 0;
   let skippedDupes = 0;
 
-  // 1. Root path (flat). Seeds seenContentHashes FIRST so an exact byte-duplicate
-  // that also exists under a project-first dir is indexed once, flat taking
-  // precedence. Without this seed the nested loop below cannot see the flat copy
-  // and one physical file becomes two indexed documents.
-  const sourcePath = path.join(config.repoRoot, `\u03c8/memory/${subdir}`);
-  if (fs.existsSync(sourcePath)) {
-    const files = getAllMarkdownFiles(sourcePath);
-    if (files.length === 0) {
-      console.log(`Warning: ${sourcePath} exists but contains no .md files`);
-    }
+  // 1. Project-first vault dirs FIRST \u2014 nested is canonical for vault-enabled
+  // writes, so it seeds seenContentHashes before the flat legacy scan. An exact
+  // byte-duplicate present both nested and flat therefore resolves to the nested
+  // source_file; the flat copy is suppressed. Nested precedence.
+  //
+  // The union includes _universal/\u03c8: upstream tools/learn.ts maps a null project
+  // to _universal/\u03c8/memory/<subdir>, but discoverProjectPsiDirs only enumerates
+  // host/owner/repo dirs. Without _universal a valid upstream-native universal
+  // learning would be invisible to full rebuild.
+  const universalPsi = path.join(config.repoRoot, '_universal', '\u03c8');
+  const projectDirs = discoverProjectPsiDirs(config.repoRoot);
+  const nestedPsiRoots = fs.existsSync(universalPsi) && !projectDirs.includes(universalPsi)
+    ? [...projectDirs, universalPsi]
+    : projectDirs;
+  for (const projectDir of nestedPsiRoots) {
+    const projectSubdir = path.join(projectDir, 'memory', subdir);
+    if (!fs.existsSync(projectSubdir)) continue;
+    const files = getAllMarkdownFiles(projectSubdir);
     for (const filePath of files) {
       const content = fs.readFileSync(filePath, 'utf-8');
       const contentHash = Bun.hash(content).toString(36);
@@ -90,12 +98,14 @@ export function collectDocuments(opts: CollectOpts): OracleDocument[] {
     totalFiles += files.length;
   }
 
-  // 2. Project-first vault dirs
-  const projectDirs = discoverProjectPsiDirs(config.repoRoot);
-  for (const projectDir of projectDirs) {
-    const projectSubdir = path.join(projectDir, 'memory', subdir);
-    if (!fs.existsSync(projectSubdir)) continue;
-    const files = getAllMarkdownFiles(projectSubdir);
+  // 2. Root path (flat legacy) SECOND \u2014 a byte-duplicate already indexed from a
+  // project-first dir is suppressed here; flat-only legacy files still index.
+  const sourcePath = path.join(config.repoRoot, `\u03c8/memory/${subdir}`);
+  if (fs.existsSync(sourcePath)) {
+    const files = getAllMarkdownFiles(sourcePath);
+    if (files.length === 0) {
+      console.log(`Warning: ${sourcePath} exists but contains no .md files`);
+    }
     for (const filePath of files) {
       const content = fs.readFileSync(filePath, 'utf-8');
       const contentHash = Bun.hash(content).toString(36);

--- a/src/indexer/daemon.ts
+++ b/src/indexer/daemon.ts
@@ -17,10 +17,10 @@ import { Elysia } from 'elysia';
 import { eq } from 'drizzle-orm';
 import { DB_PATH, REPO_ROOT } from '../config.ts';
 import { createDatabase } from '../db/index.ts';
-import { markJobDoneAndManifest, reclaimExpiredJobs } from './jobs.ts';
+import { markJobsDoneAndManifest, reclaimExpiredJobs } from './jobs.ts';
 import { loadCanonicalVectorDocument } from './vector-source.ts';
 import { createVectorStoreForModel, getEmbeddingModels } from '../vector/factory.ts';
-import { runWorker, type WorkerEvent } from './worker.ts';
+import { runBatchWorker, type WorkerEvent } from './worker.ts';
 import { daemonApiPlugin, makeEventBus } from '../routes/indexer-daemon/index.ts';
 import { startLearnWatcher, type StopWatch } from './learn-watcher.ts';
 
@@ -57,36 +57,38 @@ export async function startDaemon(): Promise<void> {
     return s;
   };
 
-  const embed = async (modelKey: string, text: string): Promise<number[]> => {
+  const embedBatch = async (modelKey: string, texts: string[]): Promise<number[][]> => {
     const preset = models[modelKey];
     if (!preset) throw new Error(`Unknown model_key: ${modelKey}`);
     const store = await getStore(modelKey);
     const embedder = (store as { embedder?: { embed: (texts: string[], type?: 'query' | 'passage') => Promise<number[][]> } }).embedder;
     if (!embedder) throw new Error(`No embedder on store for ${modelKey}`);
-    const [vector] = await embedder.embed([text], 'passage');
-    return vector;
+    return embedder.embed(texts, 'passage');
   };
 
-  const upsertVector = async (collection: string, document: import('../vector/types.ts').VectorDocument, vector: number[]): Promise<void> => {
+  const upsertVectors = async (collection: string, documents: import('../vector/types.ts').VectorDocument[]): Promise<void> => {
     const entry = Object.entries(models).find(([, m]) => m.collection === collection);
     if (!entry) throw new Error(`No registered model has collection: ${collection}`);
-    const store = await getStore(entry[0]);
-    await store.addDocuments([{ ...document, vector }]);
+    await (await getStore(entry[0])).addDocuments(documents);
+  };
+  const deleteVectors = async (collection: string, ids: string[]): Promise<void> => {
+    const entry = Object.entries(models).find(([, m]) => m.collection === collection);
+    if (!entry) throw new Error(`No registered model has collection: ${collection}`);
+    await (await getStore(entry[0])).deleteDocuments?.(ids);
   };
 
   const workerPromises: Promise<unknown>[] = [];
   for (const modelKey of Object.keys(models)) {
-    const p = runWorker(modelKey, {
+    const p = runBatchWorker(modelKey, {
       db: sqlite,
       getDocument,
-      embed,
-      upsertVector,
-      commitSuccess: (job, document) => markJobDoneAndManifest(sqlite, {
-        ...job,
-        sourceFile: String(document.metadata.source_file ?? ''),
-      }),
+      embedBatch,
+      upsertVectors,
+      deleteVectors,
+      commitSuccess: (jobs) => markJobsDoneAndManifest(sqlite, jobs),
       isShuttingDown: () => shuttingDown,
       onEvent: eventBus.publish,
+      batchSize: Math.max(1, Number(process.env.ORACLE_EMBED_BATCH_SIZE ?? 16)),
       pollIntervalMs: 1000,
     });
     workerPromises.push(p);

--- a/src/indexer/daemon.ts
+++ b/src/indexer/daemon.ts
@@ -16,7 +16,9 @@
 import { Elysia } from 'elysia';
 import { eq } from 'drizzle-orm';
 import { DB_PATH, REPO_ROOT } from '../config.ts';
-import { createDatabase, oracleFts } from '../db/index.ts';
+import { createDatabase } from '../db/index.ts';
+import { markJobDoneAndManifest, reclaimExpiredJobs } from './jobs.ts';
+import { loadCanonicalVectorDocument } from './vector-source.ts';
 import { createVectorStoreForModel, getEmbeddingModels } from '../vector/factory.ts';
 import { runWorker, type WorkerEvent } from './worker.ts';
 import { daemonApiPlugin, makeEventBus } from '../routes/indexer-daemon/index.ts';
@@ -35,14 +37,9 @@ export async function startDaemon(): Promise<void> {
   let shuttingDown = false;
   let stopLearnWatcher: StopWatch | undefined;
 
-  // Resolve doc text via the FTS5 mirror table — same content oracle_learn writes.
-  const getDocText = (docId: string): string | null => {
-    const row = db.select({ content: oracleFts.content })
-      .from(oracleFts)
-      .where(eq(oracleFts.id, docId))
-      .get();
-    return row?.content ?? null;
-  };
+  const reclaimed = reclaimExpiredJobs(sqlite);
+  if (reclaimed > 0) console.log(`[arra-indexer] reclaimed ${reclaimed} expired job lease(s)`);
+  const getDocument = (docId: string) => loadCanonicalVectorDocument(sqlite, docId);
 
   // Embed via the existing factory — produces a model-aware OllamaEmbeddings.
   // Lazy per model so we don't spin up unused embedders.
@@ -70,24 +67,24 @@ export async function startDaemon(): Promise<void> {
     return vector;
   };
 
-  const upsertVector = async (collection: string, docId: string, vector: number[]): Promise<void> => {
+  const upsertVector = async (collection: string, document: import('../vector/types.ts').VectorDocument, vector: number[]): Promise<void> => {
     const entry = Object.entries(models).find(([, m]) => m.collection === collection);
     if (!entry) throw new Error(`No registered model has collection: ${collection}`);
-    const [modelKey] = entry;
-    const store = await getStore(modelKey);
-    await store.addDocuments([{ id: docId, document: '', metadata: { id: docId, indexed_at: Date.now() } }]);
-    // TODO: extend VectorStoreAdapter with `upsert(id, vector, metadata)`
-    // that doesn't re-embed. For now we accept the extra Ollama call.
-    void vector;
+    const store = await getStore(entry[0]);
+    await store.addDocuments([{ ...document, vector }]);
   };
 
   const workerPromises: Promise<unknown>[] = [];
   for (const modelKey of Object.keys(models)) {
     const p = runWorker(modelKey, {
       db: sqlite,
-      getDocText,
+      getDocument,
       embed,
       upsertVector,
+      commitSuccess: (job, document) => markJobDoneAndManifest(sqlite, {
+        ...job,
+        sourceFile: String(document.metadata.source_file ?? ''),
+      }),
       isShuttingDown: () => shuttingDown,
       onEvent: eventBus.publish,
       pollIntervalMs: 1000,

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -28,9 +28,7 @@ import { parseResonanceFile, parseLearningFile, parseRetroFile, parseDistillatio
 import { getEmbeddingModels } from '../vector/factory.ts';
 import { collectDocuments, collectPsiLearn, collectSecurityCorpus } from './collectors.ts';
 import {
-  changedDocumentIds,
   enqueueVectorReindexJobs,
-  snapshotActiveIndexerDocs,
   supersedeReplacedSourceDocs,
 } from './reindex-state.ts';
 import { oracleFts, storeDocuments } from './storage.ts';
@@ -88,8 +86,6 @@ export class OracleIndexer {
         `Set ORACLE_REPO_ROOT or run from a directory containing ψ/memory/ to avoid data loss.`
       );
     }
-
-    const beforeDocs = snapshotActiveIndexerDocs(this.db, tenantId);
 
     // Collect documents from all source types
     const shared = { config: this.config, seenContentHashes: this.seenContentHashes };
@@ -159,13 +155,12 @@ export class OracleIndexer {
       }
     }
 
-    const changedIds = changedDocumentIds(beforeDocs, indexDocuments);
-
-    // Store in SQLite + FTS5 first. Vector work is queued afterwards so
-    // embedding failures cannot roll back the source-of-truth text index.
+    // Store in SQLite + FTS5 first. Queue eligibility derives from this
+    // canonical persisted payload, not parser snapshots, so unchanged scans
+    // cannot manufacture false "changed" jobs.
     await storeDocuments(this.sqlite, this.db, null, this.project, indexDocuments, { tenantId });
     const superseded = supersedeReplacedSourceDocs(this.db, indexDocuments, tenantId);
-    const vectorJobs = safeEnqueueVectorJobs(this.db, indexDocuments, changedIds);
+    const vectorJobs = safeEnqueueVectorJobs(this.db, indexDocuments);
 
     setIndexingStatus(this.db, this.config, false, indexDocuments.length, indexDocuments.length);
     console.log(`Indexed ${indexDocuments.length} chunks (SQLite + FTS5)`);
@@ -185,9 +180,9 @@ function tenantScopedWhere(base: SQL, tenantId: string | undefined): SQL {
   return tenantId ? and(base, eq(oracleDocuments.tenantId, tenantId))! : base;
 }
 
-function safeEnqueueVectorJobs(db: BunSQLiteDatabase<typeof schema>, documents: OracleDocument[], changedIds: Set<string>) {
+function safeEnqueueVectorJobs(db: BunSQLiteDatabase<typeof schema>, documents: OracleDocument[]) {
   try {
-    return enqueueVectorReindexJobs(db, documents, getEmbeddingModels(), changedIds);
+    return enqueueVectorReindexJobs(db, documents, getEmbeddingModels());
   } catch {
     return { queued: 0, skipped: 0, failed: documents.length };
   }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -159,12 +159,12 @@ export class OracleIndexer {
     // canonical persisted payload, not parser snapshots, so unchanged scans
     // cannot manufacture false "changed" jobs.
     await storeDocuments(this.sqlite, this.db, null, this.project, indexDocuments, { tenantId });
-    const superseded = supersedeReplacedSourceDocs(this.db, indexDocuments, tenantId);
+    const superseded = supersedeReplacedSourceDocs(this.db, indexDocuments, getEmbeddingModels(), tenantId);
     const vectorJobs = safeEnqueueVectorJobs(this.db, indexDocuments);
 
     setIndexingStatus(this.db, this.config, false, indexDocuments.length, indexDocuments.length);
     console.log(`Indexed ${indexDocuments.length} chunks (SQLite + FTS5)`);
-    if (superseded > 0) console.log(`Superseded ${superseded} stale document ids from reindexed sources`);
+    if (superseded.length > 0) console.log(`Superseded ${superseded.length} stale document ids from reindexed sources`);
     console.log(`Queued ${vectorJobs.queued} vector job(s); skipped ${vectorJobs.skipped}`);
     if (vectorJobs.failed > 0) console.warn(`Failed to queue ${vectorJobs.failed} vector job(s); FTS5 index remains current`);
     console.log('Indexing complete!');

--- a/src/indexer/jobs.ts
+++ b/src/indexer/jobs.ts
@@ -24,6 +24,8 @@ export interface EnqueueOptions {
   modelKey?: string;
   /** Registry of model_key → collection. */
   models: Record<string, { collection: string }>;
+  /** Explicit maintenance mode: reactivate a terminal matching job for a durable re-upsert. */
+  force?: boolean;
 }
 
 export interface EnqueuedJob {
@@ -74,29 +76,45 @@ export function enqueueIndexJob(conn: JobsDb, opts: EnqueueOptions): EnqueuedJob
   const out: EnqueuedJob[] = [];
 
   for (const { key, collection } of targets) {
-    const inserted = db.insert(indexingJobs)
-      .values({
-        id: jobId(key),
-        docId: opts.docId,
-        modelKey: key,
-        collection,
-        contentHash,
-        operation,
-        status: 'pending',
-        attempts: 0,
-      })
-      .onConflictDoNothing({
-        target: [indexingJobs.modelKey, indexingJobs.docId, indexingJobs.contentHash, indexingJobs.operation],
-      })
-      .returning({
-        id: indexingJobs.id,
-        docId: indexingJobs.docId,
-        modelKey: indexingJobs.modelKey,
-        collection: indexingJobs.collection,
-        contentHash: indexingJobs.contentHash,
-        operation: indexingJobs.operation,
-      })
-      .get();
+    const values = {
+      id: jobId(key),
+      docId: opts.docId,
+      modelKey: key,
+      collection,
+      contentHash,
+      operation,
+      status: 'pending' as const,
+      attempts: 0,
+    };
+    const target = [indexingJobs.modelKey, indexingJobs.docId, indexingJobs.contentHash, indexingJobs.operation];
+    const inserted = opts.force
+      ? db.insert(indexingJobs)
+        .values(values)
+        .onConflictDoUpdate({
+          target,
+          set: { status: 'pending', attempts: 0, claimedAt: null, leaseExpiresAt: null, finishedAt: null, error: null },
+        })
+        .returning({
+          id: indexingJobs.id,
+          docId: indexingJobs.docId,
+          modelKey: indexingJobs.modelKey,
+          collection: indexingJobs.collection,
+          contentHash: indexingJobs.contentHash,
+          operation: indexingJobs.operation,
+        })
+        .get()
+      : db.insert(indexingJobs)
+        .values(values)
+        .onConflictDoNothing({ target })
+        .returning({
+          id: indexingJobs.id,
+          docId: indexingJobs.docId,
+          modelKey: indexingJobs.modelKey,
+          collection: indexingJobs.collection,
+          contentHash: indexingJobs.contentHash,
+          operation: indexingJobs.operation,
+        })
+        .get();
     if (inserted) out.push({ ...inserted, operation: inserted.operation as VectorOperation });
   }
   return out;

--- a/src/indexer/jobs.ts
+++ b/src/indexer/jobs.ts
@@ -1,30 +1,28 @@
 /**
- * Indexer job-queue helpers — M1 of the indexer-CLI design.
+ * Durable, hash-keyed queue for incremental vector indexing.
  *
- * Synchronous Drizzle operations against the `indexing_jobs` table. No
- * embedding, no Ollama, no LanceDB. Just queue plumbing — the daemon
- * (M2) is what does the actual work.
- *
- * Plug-and-play invariants:
- *   - One row per (doc_id, model_key) — adding a model adds queue entries,
- *     never touches oracle_documents or other models' collections
- *   - claimNextJob() is atomic via UPDATE...RETURNING with WHERE status filter
- *   - markJobError() preserves the row (no destruction); attempts increments
- *
- * Design rationale: ψ/lab/indexer-cli/DESIGN.md in arra-mcp-installation-guide-oracle
+ * SQLite owns delivery state. A logical vector job is unique by
+ * (model_key, doc_id, content_hash, operation), so repeated scanners and
+ * concurrent producers cannot enqueue the same canonical payload twice.
  */
 
 import type Database from 'bun:sqlite';
-import { and, asc, count, eq, inArray, sql } from 'drizzle-orm';
+import { and, asc, count, eq, inArray, lt, or, sql } from 'drizzle-orm';
 import { drizzle, type BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 import * as schema from '../db/schema.ts';
-import { indexingJobs } from '../db/schema.ts';
+import { indexingJobs, vectorIndexManifest } from '../db/schema.ts';
+import { vectorManifestId } from './vector-index-manifest.ts';
+
+export type VectorOperation = 'upsert';
 
 export interface EnqueueOptions {
   docId: string;
-  /** If omitted → enqueue for ALL models in the registry (typical oracle_learn case). */
+  /** SHA-256 for the canonical text + metadata payload. */
+  contentHash?: string;
+  operation?: VectorOperation;
+  /** If omitted, enqueue once per registered model. */
   modelKey?: string;
-  /** Registry of model_key → collection. Caller passes this in (no global state). */
+  /** Registry of model_key → collection. */
   models: Record<string, { collection: string }>;
 }
 
@@ -33,13 +31,19 @@ export interface EnqueuedJob {
   docId: string;
   modelKey: string;
   collection: string;
+  contentHash: string;
+  operation: VectorOperation;
+}
+
+export interface IndexedVectorJob extends EnqueuedJob {
+  sourceFile: string;
 }
 
 const RANDOM_SUFFIX_LENGTH = 6;
+const DEFAULT_LEASE_MS = 2 * 60 * 1000;
 type JobsDb = Database | BunSQLiteDatabase<typeof schema>;
 
 function jobId(modelKey: string): string {
-  // "idx-<ms>-<modelKey>-<rand>" — short, sortable, unique enough for our scale.
   const safe = modelKey.replace(/[^a-z0-9]/gi, '');
   const rand = Math.random().toString(36).slice(2, 2 + RANDOM_SUFFIX_LENGTH);
   return `idx-${Date.now()}-${safe}-${rand}`;
@@ -53,11 +57,8 @@ function asDrizzle(conn: JobsDb): BunSQLiteDatabase<typeof schema> {
 }
 
 /**
- * Insert one or more job rows. Returns the rows that were inserted.
- *
- * For unset `modelKey`, inserts one row per entry in `models`. For a specified
- * `modelKey` not in `models`, returns [] (nothing to enqueue — caller's choice
- * to fail loudly or silently).
+ * Insert jobs idempotently. `manual:<docId>` is intentionally only a fallback
+ * for the operator CLI; production reconciliations always pass a real hash.
  */
 export function enqueueIndexJob(conn: JobsDb, opts: EnqueueOptions): EnqueuedJob[] {
   const targets: Array<{ key: string; collection: string }> = opts.modelKey
@@ -65,36 +66,51 @@ export function enqueueIndexJob(conn: JobsDb, opts: EnqueueOptions): EnqueuedJob
       ? [{ key: opts.modelKey, collection: opts.models[opts.modelKey].collection }]
       : []
     : Object.entries(opts.models).map(([key, { collection }]) => ({ key, collection }));
-
   if (targets.length === 0) return [];
 
   const db = asDrizzle(conn);
-
+  const contentHash = opts.contentHash ?? `manual:${opts.docId}`;
+  const operation = opts.operation ?? 'upsert';
   const out: EnqueuedJob[] = [];
+
   for (const { key, collection } of targets) {
-    const id = jobId(key);
-    db.insert(indexingJobs).values({
-      id,
-      docId: opts.docId,
-      modelKey: key,
-      collection,
-      status: 'pending',
-      attempts: 0,
-    }).run();
-    out.push({ id, docId: opts.docId, modelKey: key, collection });
+    const inserted = db.insert(indexingJobs)
+      .values({
+        id: jobId(key),
+        docId: opts.docId,
+        modelKey: key,
+        collection,
+        contentHash,
+        operation,
+        status: 'pending',
+        attempts: 0,
+      })
+      .onConflictDoNothing({
+        target: [indexingJobs.modelKey, indexingJobs.docId, indexingJobs.contentHash, indexingJobs.operation],
+      })
+      .returning({
+        id: indexingJobs.id,
+        docId: indexingJobs.docId,
+        modelKey: indexingJobs.modelKey,
+        collection: indexingJobs.collection,
+        contentHash: indexingJobs.contentHash,
+        operation: indexingJobs.operation,
+      })
+      .get();
+    if (inserted) out.push({ ...inserted, operation: inserted.operation as VectorOperation });
   }
   return out;
 }
 
-/**
- * Atomically claim the next pending job for a worker.
- * Uses UPDATE…RETURNING so SQLite gives us exactly one row even under
- * concurrent claimers (only one wins per row).
- *
- * Returns null when the queue is empty for that model.
- */
-export function claimNextJob(conn: JobsDb, modelKey: string): EnqueuedJob | null {
+/** Atomically claim one pending job and issue a finite crash-recovery lease. */
+export function claimNextJob(
+  conn: JobsDb,
+  modelKey: string,
+  opts: { now?: number; leaseMs?: number } = {},
+): EnqueuedJob | null {
   const db = asDrizzle(conn);
+  const now = opts.now ?? Date.now();
+  const leaseExpiresAt = now + (opts.leaseMs ?? DEFAULT_LEASE_MS);
   const nextPending = db.select({ id: indexingJobs.id })
     .from(indexingJobs)
     .where(and(eq(indexingJobs.status, 'pending'), eq(indexingJobs.modelKey, modelKey)))
@@ -104,7 +120,8 @@ export function claimNextJob(conn: JobsDb, modelKey: string): EnqueuedJob | null
   const row = db.update(indexingJobs)
     .set({
       status: 'claimed',
-      claimedAt: Date.now(),
+      claimedAt: now,
+      leaseExpiresAt,
       attempts: sql`${indexingJobs.attempts} + 1`,
     })
     .where(inArray(indexingJobs.id, nextPending))
@@ -113,36 +130,89 @@ export function claimNextJob(conn: JobsDb, modelKey: string): EnqueuedJob | null
       docId: indexingJobs.docId,
       modelKey: indexingJobs.modelKey,
       collection: indexingJobs.collection,
+      contentHash: indexingJobs.contentHash,
+      operation: indexingJobs.operation,
     })
     .get();
 
-  if (!row) return null;
-  return row;
+  return row ? { ...row, operation: row.operation as VectorOperation } : null;
 }
 
 export function markJobDone(conn: JobsDb, id: string): void {
   const db = asDrizzle(conn);
   db.update(indexingJobs)
-    .set({ status: 'done', finishedAt: Date.now(), error: null })
+    .set({ status: 'done', finishedAt: Date.now(), error: null, leaseExpiresAt: null })
     .where(eq(indexingJobs.id, id))
     .run();
+}
+
+/**
+ * Commit the durable completion receipt only after LanceDB accepted the row.
+ * If the process dies after LanceDB but before this transaction, retrying the
+ * same stable id is harmless because the vector adapter performs an upsert.
+ */
+export function markJobDoneAndManifest(conn: JobsDb, job: IndexedVectorJob): void {
+  const db = asDrizzle(conn);
+  const now = Date.now();
+  db.transaction((tx) => {
+    tx.insert(vectorIndexManifest)
+      .values({
+        id: vectorManifestId(job.modelKey, job.docId),
+        chunkId: job.docId,
+        sourceFile: job.sourceFile,
+        modelKey: job.modelKey,
+        contentHash: job.contentHash,
+        updatedAt: now,
+        indexedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: vectorIndexManifest.id,
+        set: {
+          chunkId: job.docId,
+          sourceFile: job.sourceFile,
+          modelKey: job.modelKey,
+          contentHash: job.contentHash,
+          updatedAt: now,
+          indexedAt: now,
+        },
+      })
+      .run();
+    tx.update(indexingJobs)
+      .set({ status: 'done', finishedAt: now, error: null, leaseExpiresAt: null })
+      .where(eq(indexingJobs.id, job.id))
+      .run();
+  });
 }
 
 export function markJobError(conn: JobsDb, id: string, error: string): void {
-  // Preserve the row, set status, store the error string. Attempts already
-  // incremented at claim time — caller decides retry policy.
   const db = asDrizzle(conn);
   db.update(indexingJobs)
-    .set({ status: 'error', finishedAt: Date.now(), error })
+    .set({ status: 'error', finishedAt: Date.now(), error, leaseExpiresAt: null })
     .where(eq(indexingJobs.id, id))
     .run();
 }
 
-/** Reset a stuck `claimed` job back to `pending` — for daemon-crash recovery. */
+/** Return expired claims to pending on daemon start; terminal states are never changed. */
+export function reclaimExpiredJobs(conn: JobsDb, now = Date.now()): number {
+  const db = asDrizzle(conn);
+  const expiredWhere = and(
+    eq(indexingJobs.status, 'claimed'),
+    or(lt(indexingJobs.leaseExpiresAt, now), sql`${indexingJobs.leaseExpiresAt} IS NULL`),
+  );
+  const expired = db.select({ total: count() }).from(indexingJobs).where(expiredWhere).get()?.total ?? 0;
+  if (expired === 0) return 0;
+  db.update(indexingJobs)
+    .set({ status: 'pending', claimedAt: null, leaseExpiresAt: null })
+    .where(expiredWhere)
+    .run();
+  return expired;
+}
+
+/** Reset one claimed job for focused recovery/testing. */
 export function reclaimStaleJob(conn: JobsDb, id: string): void {
   const db = asDrizzle(conn);
   db.update(indexingJobs)
-    .set({ status: 'pending', claimedAt: null })
+    .set({ status: 'pending', claimedAt: null, leaseExpiresAt: null })
     .where(and(eq(indexingJobs.id, id), eq(indexingJobs.status, 'claimed')))
     .run();
 }
@@ -153,20 +223,11 @@ export function jobsByStatus(
 ): Array<{ status: string; model_key: string; count: number }> {
   const db = asDrizzle(conn);
   const where = modelKey ? eq(indexingJobs.modelKey, modelKey) : undefined;
-  const rows = db.select({
-    status: indexingJobs.status,
-    modelKey: indexingJobs.modelKey,
-    count: count(),
-  })
+  const rows = db.select({ status: indexingJobs.status, modelKey: indexingJobs.modelKey, count: count() })
     .from(indexingJobs)
     .where(where)
     .groupBy(indexingJobs.status, indexingJobs.modelKey)
     .orderBy(modelKey ? asc(indexingJobs.status) : asc(indexingJobs.modelKey), asc(indexingJobs.status))
     .all();
-
-  return rows.map((row) => ({
-    status: row.status,
-    model_key: row.modelKey,
-    count: row.count,
-  }));
+  return rows.map((row) => ({ status: row.status, model_key: row.modelKey, count: row.count }));
 }

--- a/src/indexer/jobs.ts
+++ b/src/indexer/jobs.ts
@@ -13,7 +13,7 @@ import * as schema from '../db/schema.ts';
 import { indexingJobs, vectorIndexManifest } from '../db/schema.ts';
 import { vectorManifestId } from './vector-index-manifest.ts';
 
-export type VectorOperation = 'upsert';
+export type VectorOperation = 'upsert' | 'delete';
 
 export interface EnqueueOptions {
   docId: string;
@@ -138,6 +138,19 @@ export function claimNextJob(
   return row ? { ...row, operation: row.operation as VectorOperation } : null;
 }
 
+/** Claim a small FIFO batch. Each claim is atomic, so competing daemons cannot
+ * receive the same job; batching only changes work scheduling, not delivery semantics. */
+export function claimNextJobs(conn: JobsDb, modelKey: string, batchSize: number): EnqueuedJob[] {
+  const jobs: EnqueuedJob[] = [];
+  const size = Math.max(1, Math.trunc(batchSize));
+  for (let i = 0; i < size; i++) {
+    const job = claimNextJob(conn, modelKey);
+    if (!job) break;
+    jobs.push(job);
+  }
+  return jobs;
+}
+
 export function markJobDone(conn: JobsDb, id: string): void {
   const db = asDrizzle(conn);
   db.update(indexingJobs)
@@ -181,6 +194,29 @@ export function markJobDoneAndManifest(conn: JobsDb, job: IndexedVectorJob): voi
       .set({ status: 'done', finishedAt: now, error: null, leaseExpiresAt: null })
       .where(eq(indexingJobs.id, job.id))
       .run();
+  });
+}
+
+/** Complete a homogeneous batch after its LanceDB write succeeded. */
+export function markJobsDoneAndManifest(conn: JobsDb, jobs: IndexedVectorJob[]): void {
+  if (jobs.length === 0) return;
+  const db = asDrizzle(conn);
+  const now = Date.now();
+  db.transaction((tx) => {
+    for (const job of jobs) {
+      if (job.operation === 'delete') {
+        tx.delete(vectorIndexManifest).where(eq(vectorIndexManifest.id, vectorManifestId(job.modelKey, job.docId))).run();
+      } else {
+        tx.insert(vectorIndexManifest).values({
+          id: vectorManifestId(job.modelKey, job.docId), chunkId: job.docId, sourceFile: job.sourceFile,
+          modelKey: job.modelKey, contentHash: job.contentHash, updatedAt: now, indexedAt: now,
+        }).onConflictDoUpdate({ target: vectorIndexManifest.id, set: {
+          chunkId: job.docId, sourceFile: job.sourceFile, modelKey: job.modelKey, contentHash: job.contentHash, updatedAt: now, indexedAt: now,
+        } }).run();
+      }
+    }
+    tx.update(indexingJobs).set({ status: 'done', finishedAt: now, error: null, leaseExpiresAt: null })
+      .where(inArray(indexingJobs.id, jobs.map((job) => job.id))).run();
   });
 }
 

--- a/src/indexer/reindex-state.ts
+++ b/src/indexer/reindex-state.ts
@@ -14,6 +14,11 @@ export interface VectorQueueStats {
   failed: number;
 }
 
+export interface VectorReconcileOptions {
+  /** Explicit maintenance mode: re-upsert every active canonical vector receipt. */
+  force?: boolean;
+}
+
 const REINDEX_REASON = 'superseded by indexer reindex';
 
 export function supersedeReplacedSourceDocs(
@@ -75,6 +80,7 @@ export function enqueueVectorReindexJobs(
   input: OracleDbInput,
   documents: OracleDocument[],
   models: ModelRegistry,
+  options: VectorReconcileOptions = {},
 ): VectorQueueStats {
   const db = asOracleDb(input);
   const modelKeys = Object.keys(models);
@@ -95,11 +101,11 @@ export function enqueueVectorReindexJobs(
     const contentHash = vectorContentHash(vectorDoc);
     for (const modelKey of modelKeys) {
       try {
-        if (!needsVectorJob(db, docId, modelKey, contentHash)) {
+        if (!options.force && !needsVectorJob(db, docId, modelKey, contentHash)) {
           stats.skipped++;
           continue;
         }
-        const jobs = enqueueIndexJob(db, { docId, contentHash, modelKey, models });
+        const jobs = enqueueIndexJob(db, { docId, contentHash, modelKey, models, force: options.force });
         stats.queued += jobs.length;
         if (jobs.length === 0) stats.failed++;
       } catch {
@@ -110,13 +116,51 @@ export function enqueueVectorReindexJobs(
   return stats;
 }
 
-/** Reconcile all canonical rows, used by the former direct-write cron command. */
+/**
+ * Full-scope reconciliation for the queue-only cron command.
+ *
+ * `docIds` must be the complete active canonical vector set for the configured
+ * models. In addition to current upserts, reconcile old manifest receipts that
+ * no longer belong to that set into durable DELETE jobs. This catches historical
+ * supersessions that predate the delete-aware pipeline; no direct LanceDB cleanup
+ * is performed here.
+ */
 export function enqueueCanonicalVectorJobs(
   input: OracleDbInput,
   docIds: string[],
   models: ModelRegistry,
+  options: VectorReconcileOptions = {},
 ): VectorQueueStats {
-  return enqueueVectorReindexJobs(input, docIds.map((id) => ({ id } as OracleDocument)), models);
+  const db = asOracleDb(input);
+  const stats = enqueueVectorReindexJobs(db, docIds.map((id) => ({ id } as OracleDocument)), models, options);
+  stats.queued += enqueueInactiveManifestDeleteJobs(db, docIds, models);
+  return stats;
+}
+
+/** Queue deletes for receipts outside a complete active canonical document set. */
+export function enqueueInactiveManifestDeleteJobs(
+  input: OracleDbInput,
+  activeDocIds: string[],
+  models: ModelRegistry,
+): number {
+  const db = asOracleDb(input);
+  const active = new Set(activeDocIds);
+  let queued = 0;
+  const manifests = db.select({ chunkId: vectorIndexManifest.chunkId, modelKey: vectorIndexManifest.modelKey })
+    .from(vectorIndexManifest)
+    .all();
+
+  for (const manifest of manifests) {
+    if (active.has(manifest.chunkId) || !models[manifest.modelKey]) continue;
+    queued += enqueueIndexJob(db, {
+      docId: manifest.chunkId,
+      contentHash: `delete:${manifest.chunkId}`,
+      operation: 'delete',
+      modelKey: manifest.modelKey,
+      models,
+    }).length;
+  }
+  return queued;
 }
 
 function activeIndexerIdsForSource(

--- a/src/indexer/reindex-state.ts
+++ b/src/indexer/reindex-state.ts
@@ -19,8 +19,9 @@ const REINDEX_REASON = 'superseded by indexer reindex';
 export function supersedeReplacedSourceDocs(
   input: OracleDbInput,
   documents: OracleDocument[],
+  models: ModelRegistry,
   tenantId?: string,
-): number {
+): string[] {
   const db = asOracleDb(input);
   const bySource = new Map<string, string[]>();
   for (const doc of documents) {
@@ -29,7 +30,7 @@ export function supersedeReplacedSourceDocs(
     bySource.set(doc.source_file, ids);
   }
 
-  let superseded = 0;
+  const staleIds: string[] = [];
   const now = Date.now();
   for (const [sourceFile, currentIds] of bySource) {
     const stale = activeIndexerIdsForSource(db, sourceFile, currentIds, tenantId);
@@ -43,9 +44,24 @@ export function supersedeReplacedSourceDocs(
         isNull(oracleDocuments.supersededAt),
       ))
       .run();
-    superseded += stale.length;
+    staleIds.push(...stale);
   }
-  return superseded;
+  enqueueVectorDeleteJobs(db, staleIds, models);
+  return staleIds;
+}
+
+export function enqueueVectorDeleteJobs(input: OracleDbInput, docIds: string[], models: ModelRegistry): number {
+  const db = asOracleDb(input);
+  let queued = 0;
+  for (const docId of [...new Set(docIds)]) {
+    for (const modelKey of Object.keys(models)) {
+      const manifest = db.select({ id: vectorIndexManifest.id }).from(vectorIndexManifest)
+        .where(and(eq(vectorIndexManifest.chunkId, docId), eq(vectorIndexManifest.modelKey, modelKey))).get();
+      if (!manifest) continue;
+      queued += enqueueIndexJob(db, { docId, contentHash: `delete:${docId}`, operation: 'delete', modelKey, models }).length;
+    }
+  }
+  return queued;
 }
 
 /**

--- a/src/indexer/reindex-state.ts
+++ b/src/indexer/reindex-state.ts
@@ -1,10 +1,11 @@
-import { and, desc, eq, inArray, isNull, notInArray, or, sql } from 'drizzle-orm';
-import { indexingJobs, oracleDocuments, oracleFts } from '../db/schema.ts';
+import { and, eq, inArray, isNull, notInArray, or, sql } from 'drizzle-orm';
+import { indexingJobs, oracleDocuments, vectorIndexManifest } from '../db/schema.ts';
 import { asOracleDb, type OracleDb, type OracleDbInput } from '../db/drizzle-input.ts';
 import type { OracleDocument } from '../types.ts';
 import { enqueueIndexJob } from './jobs.ts';
+import { vectorContentHash } from './vector-index-manifest.ts';
+import { loadCanonicalVectorDocumentFromDb } from './vector-source.ts';
 
-export type DocSnapshot = Map<string, { sourceFile: string; content: string | null }>;
 export type ModelRegistry = Record<string, { collection: string }>;
 
 export interface VectorQueueStats {
@@ -14,33 +15,6 @@ export interface VectorQueueStats {
 }
 
 const REINDEX_REASON = 'superseded by indexer reindex';
-
-export function snapshotActiveIndexerDocs(input: OracleDbInput, tenantId?: string): DocSnapshot {
-  const db = asOracleDb(input);
-  const rows = db.select({
-    id: oracleDocuments.id,
-    sourceFile: oracleDocuments.sourceFile,
-    content: sql<string | null>`(
-      SELECT GROUP_CONCAT(${oracleFts.content}, '\n')
-      FROM ${oracleFts}
-      WHERE ${oracleFts.id} = ${oracleDocuments.id}
-    )`,
-  })
-    .from(oracleDocuments)
-    .where(activeIndexerWhere(tenantId))
-    .all();
-
-  return new Map(rows.map((row) => [row.id, { sourceFile: row.sourceFile, content: row.content }]));
-}
-
-export function changedDocumentIds(before: DocSnapshot, documents: OracleDocument[]): Set<string> {
-  const changed = new Set<string>();
-  for (const doc of documents) {
-    const prior = before.get(doc.id);
-    if (!prior || prior.content !== doc.content) changed.add(doc.id);
-  }
-  return changed;
-}
 
 export function supersedeReplacedSourceDocs(
   input: OracleDbInput,
@@ -74,11 +48,17 @@ export function supersedeReplacedSourceDocs(
   return superseded;
 }
 
+/**
+ * Reconcile fresh SQLite/FTS chunks into hash-keyed vector jobs.
+ *
+ * No parser-text comparison is used. The canonical persisted vector payload is
+ * hashed after `storeDocuments()` so FTS enrichment, metadata and daemon input
+ * are the same bytes. A matching manifest is the only successful-vector proof.
+ */
 export function enqueueVectorReindexJobs(
   input: OracleDbInput,
   documents: OracleDocument[],
   models: ModelRegistry,
-  changedIds: Set<string>,
 ): VectorQueueStats {
   const db = asOracleDb(input);
   const modelKeys = Object.keys(models);
@@ -91,14 +71,19 @@ export function enqueueVectorReindexJobs(
   }
 
   for (const docId of docIds) {
-    const changed = changedIds.has(docId);
+    const vectorDoc = loadCanonicalVectorDocumentFromDb(db, docId);
+    if (!vectorDoc) {
+      stats.failed += modelKeys.length;
+      continue;
+    }
+    const contentHash = vectorContentHash(vectorDoc);
     for (const modelKey of modelKeys) {
       try {
-        if (!needsVectorJob(db, docId, modelKey, changed)) {
+        if (!needsVectorJob(db, docId, modelKey, contentHash)) {
           stats.skipped++;
           continue;
         }
-        const jobs = enqueueIndexJob(db, { docId, modelKey, models });
+        const jobs = enqueueIndexJob(db, { docId, contentHash, modelKey, models });
         stats.queued += jobs.length;
         if (jobs.length === 0) stats.failed++;
       } catch {
@@ -107,6 +92,15 @@ export function enqueueVectorReindexJobs(
     }
   }
   return stats;
+}
+
+/** Reconcile all canonical rows, used by the former direct-write cron command. */
+export function enqueueCanonicalVectorJobs(
+  input: OracleDbInput,
+  docIds: string[],
+  models: ModelRegistry,
+): VectorQueueStats {
+  return enqueueVectorReindexJobs(input, docIds.map((id) => ({ id } as OracleDocument)), models);
 }
 
 function activeIndexerIdsForSource(
@@ -138,11 +132,6 @@ function activeIndexerWhere(tenantId?: string) {
 
 function hasIndexingJobsTable(db: OracleDb): boolean {
   try {
-    // Use the select() builder: drizzle's db.get(sql`...`) returns a positional
-    // values array, not an object, so the prior `row?.name` form introduced by
-    // the #2611 Drizzle migration silently returned false here (vector queue
-    // never enrolled jobs; FTS5 fallback masked it). select() maps columns to a
-    // typed object so the `row?.name` check works as written.
     const row = db.select({ name: sql<string>`name` })
       .from(sql`sqlite_master`)
       .where(sql`type = 'table' AND name = 'indexing_jobs'`)
@@ -157,15 +146,22 @@ function needsVectorJob(
   db: OracleDb,
   docId: string,
   modelKey: string,
-  changed: boolean,
+  contentHash: string,
 ): boolean {
-  const rows = db.select({ status: indexingJobs.status })
+  const manifest = db.select({ contentHash: vectorIndexManifest.contentHash })
+    .from(vectorIndexManifest)
+    .where(and(eq(vectorIndexManifest.chunkId, docId), eq(vectorIndexManifest.modelKey, modelKey)))
+    .get();
+  if (manifest?.contentHash === contentHash) return false;
+
+  const inFlight = db.select({ status: indexingJobs.status })
     .from(indexingJobs)
-    .where(and(eq(indexingJobs.docId, docId), eq(indexingJobs.modelKey, modelKey)))
-    .orderBy(desc(indexingJobs.createdAt))
+    .where(and(
+      eq(indexingJobs.docId, docId),
+      eq(indexingJobs.modelKey, modelKey),
+      eq(indexingJobs.contentHash, contentHash),
+      eq(indexingJobs.operation, 'upsert'),
+    ))
     .all();
-  if (changed) return !rows.some((row) => row.status === 'pending');
-  return !rows.some((row) => row.status === 'pending'
-    || row.status === 'claimed'
-    || row.status === 'done');
+  return !inFlight.some((row) => row.status === 'pending' || row.status === 'claimed');
 }

--- a/src/indexer/reindex-state.ts
+++ b/src/indexer/reindex-state.ts
@@ -138,9 +138,15 @@ function activeIndexerWhere(tenantId?: string) {
 
 function hasIndexingJobsTable(db: OracleDb): boolean {
   try {
-    const row = db.get<{ name: string }>(
-      sql`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'indexing_jobs'`,
-    );
+    // Use the select() builder: drizzle's db.get(sql`...`) returns a positional
+    // values array, not an object, so the prior `row?.name` form introduced by
+    // the #2611 Drizzle migration silently returned false here (vector queue
+    // never enrolled jobs; FTS5 fallback masked it). select() maps columns to a
+    // typed object so the `row?.name` check works as written.
+    const row = db.select({ name: sql<string>`name` })
+      .from(sql`sqlite_master`)
+      .where(sql`type = 'table' AND name = 'indexing_jobs'`)
+      .get();
     return row?.name === 'indexing_jobs';
   } catch {
     return false;

--- a/src/indexer/vector-source.ts
+++ b/src/indexer/vector-source.ts
@@ -6,7 +6,7 @@
  */
 
 import type Database from 'bun:sqlite';
-import { eq, sql } from 'drizzle-orm';
+import { and, eq, isNull, or, sql } from 'drizzle-orm';
 import { asOracleDb, type OracleDbInput } from '../db/drizzle-input.ts';
 import { oracleDocuments, oracleFts } from '../db/schema.ts';
 import type { VectorDocument } from '../vector/types.ts';
@@ -27,6 +27,7 @@ const VECTOR_ROWS_SQL = `
     d.source_file, d.concepts, d.project, d.created_at
   FROM oracle_documents d
   JOIN oracle_fts f ON d.id = f.id
+  WHERE d.superseded_by IS NULL OR d.superseded_by = ''
   GROUP BY d.id
   ORDER BY d.created_at DESC
 `;
@@ -65,7 +66,10 @@ export function loadCanonicalVectorDocumentFromDb(input: OracleDbInput, docId: s
   })
     .from(oracleDocuments)
     .innerJoin(oracleFts, eq(oracleDocuments.id, oracleFts.id))
-    .where(eq(oracleDocuments.id, docId))
+    .where(and(
+      eq(oracleDocuments.id, docId),
+      or(isNull(oracleDocuments.supersededBy), eq(oracleDocuments.supersededBy, '')),
+    ))
     .groupBy(oracleDocuments.id)
     .get();
   return row ? vectorDocumentFromRow(row) : null;

--- a/src/indexer/vector-source.ts
+++ b/src/indexer/vector-source.ts
@@ -1,0 +1,86 @@
+/**
+ * Canonical vector payloads derived from SQLite + FTS.
+ *
+ * The queue producer, daemon and reconciliation command must all use this
+ * module so `content_hash`, embedded text and LanceDB metadata stay identical.
+ */
+
+import type Database from 'bun:sqlite';
+import { eq, sql } from 'drizzle-orm';
+import { asOracleDb, type OracleDbInput } from '../db/drizzle-input.ts';
+import { oracleDocuments, oracleFts } from '../db/schema.ts';
+import type { VectorDocument } from '../vector/types.ts';
+
+interface DbVectorRow {
+  id: string;
+  tenant_id: string;
+  type: string;
+  content: string;
+  source_file: string;
+  concepts: string;
+  project: string | null;
+  created_at: number;
+}
+
+const VECTOR_ROWS_SQL = `
+  SELECT d.id, d.tenant_id, d.type, GROUP_CONCAT(f.content, '\n') AS content,
+    d.source_file, d.concepts, d.project, d.created_at
+  FROM oracle_documents d
+  JOIN oracle_fts f ON d.id = f.id
+  GROUP BY d.id
+  ORDER BY d.created_at DESC
+`;
+
+const VECTOR_ROW_BY_ID_SQL = `
+  SELECT d.id, d.tenant_id, d.type, GROUP_CONCAT(f.content, '\n') AS content,
+    d.source_file, d.concepts, d.project, d.created_at
+  FROM oracle_documents d
+  JOIN oracle_fts f ON d.id = f.id
+  WHERE d.id = ?
+  GROUP BY d.id
+`;
+
+export function loadCanonicalVectorDocuments(sqlite: Database): VectorDocument[] {
+  const rows = sqlite.prepare(VECTOR_ROWS_SQL).all() as DbVectorRow[];
+  return rows.map(vectorDocumentFromRow);
+}
+
+export function loadCanonicalVectorDocument(sqlite: Database, docId: string): VectorDocument | null {
+  const row = sqlite.prepare(VECTOR_ROW_BY_ID_SQL).get(docId) as DbVectorRow | null;
+  return row ? vectorDocumentFromRow(row) : null;
+}
+
+/** Drizzle equivalent for queue reconciliation after SQLite/FTS writes. */
+export function loadCanonicalVectorDocumentFromDb(input: OracleDbInput, docId: string): VectorDocument | null {
+  const db = asOracleDb(input);
+  const row = db.select({
+    id: oracleDocuments.id,
+    tenant_id: oracleDocuments.tenantId,
+    type: oracleDocuments.type,
+    content: sql<string>`GROUP_CONCAT(${oracleFts.content}, '\n')`,
+    source_file: oracleDocuments.sourceFile,
+    concepts: oracleDocuments.concepts,
+    project: oracleDocuments.project,
+    created_at: oracleDocuments.createdAt,
+  })
+    .from(oracleDocuments)
+    .innerJoin(oracleFts, eq(oracleDocuments.id, oracleFts.id))
+    .where(eq(oracleDocuments.id, docId))
+    .groupBy(oracleDocuments.id)
+    .get();
+  return row ? vectorDocumentFromRow(row) : null;
+}
+
+export function vectorDocumentFromRow(row: DbVectorRow): VectorDocument {
+  return {
+    id: row.id,
+    document: row.content,
+    metadata: {
+      type: row.type,
+      source_file: row.source_file,
+      concepts: row.concepts,
+      tenant_id: row.tenant_id,
+      ...(row.project ? { project: row.project } : {}),
+    },
+  };
+}

--- a/src/indexer/worker.ts
+++ b/src/indexer/worker.ts
@@ -65,7 +65,17 @@ export interface BatchWorkerDeps {
 export async function runBatchWorker(modelKey: string, deps: BatchWorkerDeps): Promise<WorkerStats> {
   const stats: WorkerStats = { modelKey, processed: 0, errors: 0, emptyPolls: 0 };
   while (!deps.isShuttingDown()) {
-    const jobs = claimNextJobs(deps.db, modelKey, deps.batchSize ?? 16);
+    let jobs: EnqueuedJob[];
+    try {
+      jobs = claimNextJobs(deps.db, modelKey, deps.batchSize ?? 16);
+    } catch (error) {
+      // SQLite writers (the CLI reindex) may briefly hold the WAL write lock.
+      // A poll collision must not terminate the long-lived daemon.
+      stats.errors++;
+      console.warn(`[arra-indexer] queue claim deferred for ${modelKey}: ${error instanceof Error ? error.message : String(error)}`);
+      await sleep(deps.pollIntervalMs ?? DEFAULT_POLL_MS);
+      continue;
+    }
     if (jobs.length === 0) { stats.emptyPolls++; emit(deps as unknown as WorkerDeps, { type: 'idle', modelKey }); await sleep(deps.pollIntervalMs ?? DEFAULT_POLL_MS); continue; }
     jobs.forEach((job) => emit(deps as unknown as WorkerDeps, { type: 'claimed', job }));
     const deletes = jobs.filter((job) => job.operation === 'delete');

--- a/src/indexer/worker.ts
+++ b/src/indexer/worker.ts
@@ -1,136 +1,49 @@
-/**
- * Indexer worker loop — M2 of the indexer-CLI design.
- *
- * One worker per registered model. Pulls pending jobs from `indexing_jobs`,
- * embeds via the supplied `embed()` function, writes to LanceDB via
- * `upsertVector()`, and marks the job done. On error, calls `markJobError`
- * (the row is preserved with the error message — caller decides retry policy).
- *
- * The worker is dependency-injected — no global state, no direct imports of
- * Ollama or LanceDB in this file. That keeps it unit-testable with mocks
- * and lets M3 (HTTP daemon) and M4 (CLI) wire the real adapters.
- *
- * Plug-and-play invariant honored: the worker only operates on its own
- * `model_key` queue; cross-model state (other collections, other doc rows)
- * is never touched.
- *
- * Design: ψ/lab/indexer-cli/DESIGN.md (M2).
- */
-
 import type Database from 'bun:sqlite';
-import {
-  claimNextJob,
-  markJobDone,
-  markJobError,
-  type EnqueuedJob,
-} from './jobs.ts';
+import type { VectorDocument } from '../vector/types.ts';
+import { claimNextJob, markJobDone, markJobError, type EnqueuedJob } from './jobs.ts';
 
 export interface WorkerDeps {
   db: Database;
-  /**
-   * Resolve the document text from oracle.db. Returns null if the doc was
-   * deleted between enqueue and claim — the worker will mark the job done
-   * (no-op embed) per design (FTS-first/vector-later survives doc deletion).
-   */
-  getDocText: (docId: string) => string | null;
-  /** Embed text for `modelKey`. Throws on Ollama errors → marks job error. */
+  getDocument: (docId: string) => VectorDocument | null;
   embed: (modelKey: string, text: string) => Promise<number[]>;
-  /** Upsert into the model's LanceDB collection. Throws → marks job error. */
-  upsertVector: (collection: string, docId: string, vector: number[]) => Promise<void>;
-  /** Returns true when the worker should exit cleanly. Caller wires SIGTERM/SIGINT. */
+  upsertVector: (collection: string, document: VectorDocument, vector: number[]) => Promise<void>;
+  commitSuccess?: (job: EnqueuedJob, document: VectorDocument) => void;
   isShuttingDown: () => boolean;
-  /** Sleep between empty-queue polls (default 1000ms). */
   pollIntervalMs?: number;
-  /** Optional event hook — called on every state change. Used by M3 SSE. */
   onEvent?: (ev: WorkerEvent) => void;
 }
-
 export type WorkerEvent =
   | { type: 'claimed'; job: EnqueuedJob }
   | { type: 'done'; job: EnqueuedJob; durationMs: number }
   | { type: 'error'; job: EnqueuedJob; error: string }
   | { type: 'doc_missing'; job: EnqueuedJob }
+  | { type: 'stale_payload'; job: EnqueuedJob }
   | { type: 'idle'; modelKey: string };
-
-export interface WorkerStats {
-  modelKey: string;
-  processed: number;     // markJobDone count (incl. doc_missing no-ops)
-  errors: number;
-  emptyPolls: number;
-}
-
+export interface WorkerStats { modelKey: string; processed: number; errors: number; emptyPolls: number }
 const DEFAULT_POLL_MS = 1000;
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+function emit(deps: WorkerDeps, ev: WorkerEvent): void { try { deps.onEvent?.(ev); } catch {} }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function emit(deps: WorkerDeps, ev: WorkerEvent): void {
-  try {
-    deps.onEvent?.(ev);
-  } catch {
-    // Observability hooks must not poison queue processing.
-  }
-}
-
-/**
- * Run a worker loop for a single model. Returns when `isShuttingDown()` is true.
- *
- * Caller is responsible for:
- *   - Spawning one runWorker() call per registered model (no shared state)
- *   - Plumbing real Ollama (embed) + LanceDB (upsertVector) through the deps
- *   - Setting `isShuttingDown` on signal handlers
- *
- * The function is deliberately not async-iterable — keep it as a flat loop so
- * shutdown is testable with a deterministic flag flip.
- */
-export async function runWorker(
-  modelKey: string,
-  deps: WorkerDeps,
-): Promise<WorkerStats> {
+export async function runWorker(modelKey: string, deps: WorkerDeps): Promise<WorkerStats> {
   const stats: WorkerStats = { modelKey, processed: 0, errors: 0, emptyPolls: 0 };
-  const pollMs = deps.pollIntervalMs ?? DEFAULT_POLL_MS;
-
   while (!deps.isShuttingDown()) {
     const job = claimNextJob(deps.db, modelKey);
-    if (!job) {
-      stats.emptyPolls++;
-      emit(deps, { type: 'idle', modelKey });
-      await sleep(pollMs);
-      continue;
-    }
-
+    if (!job) { stats.emptyPolls++; emit(deps, { type: 'idle', modelKey }); await sleep(deps.pollIntervalMs ?? DEFAULT_POLL_MS); continue; }
     emit(deps, { type: 'claimed', job });
-
     try {
-      const text = deps.getDocText(job.docId);
-      if (text === null) {
-        // Doc was deleted between enqueue and claim — mark done (no-op).
-        // Plug-play: removing a doc from oracle_documents leaves queue rows
-        // safely consumable. The worker absorbs the no-op gracefully.
-        markJobDone(deps.db, job.id);
-        emit(deps, { type: 'doc_missing', job });
-        stats.processed++;
-        continue;
-      }
-
-      const t0 = performance.now();
-      const vector = await deps.embed(job.modelKey, text);
-      await deps.upsertVector(job.collection, job.docId, vector);
-      markJobDone(deps.db, job.id);
-      stats.processed++;
-      emit(deps, {
-        type: 'done',
-        job,
-        durationMs: Math.round(performance.now() - t0),
-      });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      markJobError(deps.db, job.id, msg);
-      stats.errors++;
-      emit(deps, { type: 'error', job, error: msg });
+      const document = deps.getDocument(job.docId);
+      if (!document) { markJobDone(deps.db, job.id); emit(deps, { type: 'doc_missing', job }); stats.processed++; continue; }
+      const { vectorContentHash } = await import('./vector-index-manifest.ts');
+      if (!job.contentHash.startsWith('manual:') && vectorContentHash(document) !== job.contentHash) { markJobDone(deps.db, job.id); emit(deps, { type: 'stale_payload', job }); stats.processed++; continue; }
+      const started = performance.now();
+      const vector = await deps.embed(job.modelKey, document.document);
+      await deps.upsertVector(job.collection, document, vector);
+      if (deps.commitSuccess) deps.commitSuccess(job, document); else markJobDone(deps.db, job.id);
+      stats.processed++; emit(deps, { type: 'done', job, durationMs: Math.round(performance.now() - started) });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      markJobError(deps.db, job.id, message); stats.errors++; emit(deps, { type: 'error', job, error: message });
     }
   }
-
   return stats;
 }

--- a/src/indexer/worker.ts
+++ b/src/indexer/worker.ts
@@ -1,6 +1,6 @@
 import type Database from 'bun:sqlite';
 import type { VectorDocument } from '../vector/types.ts';
-import { claimNextJob, markJobDone, markJobError, type EnqueuedJob } from './jobs.ts';
+import { claimNextJob, claimNextJobs, markJobDone, markJobError, type EnqueuedJob, type IndexedVectorJob } from './jobs.ts';
 
 export interface WorkerDeps {
   db: Database;
@@ -43,6 +43,56 @@ export async function runWorker(modelKey: string, deps: WorkerDeps): Promise<Wor
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       markJobError(deps.db, job.id, message); stats.errors++; emit(deps, { type: 'error', job, error: message });
+    }
+  }
+  return stats;
+}
+
+export interface BatchWorkerDeps {
+  db: Database;
+  getDocument: (docId: string) => VectorDocument | null;
+  embedBatch: (modelKey: string, texts: string[]) => Promise<number[][]>;
+  upsertVectors: (collection: string, documents: VectorDocument[]) => Promise<void>;
+  deleteVectors: (collection: string, ids: string[]) => Promise<void>;
+  commitSuccess: (jobs: IndexedVectorJob[]) => void;
+  isShuttingDown: () => boolean;
+  batchSize?: number;
+  pollIntervalMs?: number;
+  onEvent?: (ev: WorkerEvent) => void;
+}
+
+/** Batch daemon worker: one embedding call and one LanceDB merge/delete per job kind. */
+export async function runBatchWorker(modelKey: string, deps: BatchWorkerDeps): Promise<WorkerStats> {
+  const stats: WorkerStats = { modelKey, processed: 0, errors: 0, emptyPolls: 0 };
+  while (!deps.isShuttingDown()) {
+    const jobs = claimNextJobs(deps.db, modelKey, deps.batchSize ?? 16);
+    if (jobs.length === 0) { stats.emptyPolls++; emit(deps as unknown as WorkerDeps, { type: 'idle', modelKey }); await sleep(deps.pollIntervalMs ?? DEFAULT_POLL_MS); continue; }
+    jobs.forEach((job) => emit(deps as unknown as WorkerDeps, { type: 'claimed', job }));
+    const deletes = jobs.filter((job) => job.operation === 'delete');
+    if (deletes.length > 0) {
+      try { await deps.deleteVectors(deletes[0].collection, deletes.map((job) => job.docId)); deps.commitSuccess(deletes.map((job) => ({ ...job, sourceFile: '' }))); stats.processed += deletes.length; deletes.forEach((job) => emit(deps as unknown as WorkerDeps, { type: 'done', job, durationMs: 0 })); }
+      catch (error) { const message = error instanceof Error ? error.message : String(error); deletes.forEach((job) => { markJobError(deps.db, job.id, message); emit(deps as unknown as WorkerDeps, { type: 'error', job, error: message }); }); stats.errors += deletes.length; }
+    }
+    const candidates: Array<{ job: EnqueuedJob; document: VectorDocument }> = [];
+    const { vectorContentHash } = await import('./vector-index-manifest.ts');
+    for (const job of jobs.filter((job) => job.operation === 'upsert')) {
+      const document = deps.getDocument(job.docId);
+      if (!document) { markJobDone(deps.db, job.id); stats.processed++; emit(deps as unknown as WorkerDeps, { type: 'doc_missing', job }); continue; }
+      if (!job.contentHash.startsWith('manual:') && vectorContentHash(document) !== job.contentHash) { markJobDone(deps.db, job.id); stats.processed++; emit(deps as unknown as WorkerDeps, { type: 'stale_payload', job }); continue; }
+      candidates.push({ job, document });
+    }
+    if (candidates.length === 0) continue;
+    try {
+      const vectors = await deps.embedBatch(modelKey, candidates.map(({ document }) => document.document));
+      if (vectors.length !== candidates.length) throw new Error(`Embedding batch cardinality mismatch: ${vectors.length}/${candidates.length}`);
+      const docs = candidates.map(({ document }, i) => ({ ...document, vector: vectors[i] }));
+      await deps.upsertVectors(candidates[0].job.collection, docs);
+      const completed = candidates.map(({ job, document }) => ({ ...job, sourceFile: String(document.metadata.source_file ?? '') }));
+      deps.commitSuccess(completed); stats.processed += completed.length;
+      completed.forEach((job) => emit(deps as unknown as WorkerDeps, { type: 'done', job, durationMs: 0 }));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      candidates.forEach(({ job }) => { markJobError(deps.db, job.id, message); emit(deps as unknown as WorkerDeps, { type: 'error', job, error: message }); }); stats.errors += candidates.length;
     }
   }
   return stats;

--- a/src/learn/__tests__/authority.test.ts
+++ b/src/learn/__tests__/authority.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test';
+
+describe('project authority seam', () => {
+  test('distinguishes explicit string, null, and omitted authority', async () => {
+    const { resolveProjectAuthority } = await import('../authority.ts');
+    expect(resolveProjectAuthority('GitHub.com/Acme/Widgets', { explicit: true })).toEqual({ project: 'github.com/acme/widgets' });
+    expect(resolveProjectAuthority(null, { explicit: true })).toEqual({ project: null });
+    expect(resolveProjectAuthority(undefined, { explicit: false })).toEqual({ project: null });
+    expect(resolveProjectAuthority(undefined, {
+      explicit: false, trustedCallerCwd: true, detectedProject: 'github.com/acme/widgets',
+    })).toEqual({ project: 'github.com/acme/widgets' });
+  });
+
+  test('rejects malformed explicit values without fallback', async () => {
+    const { resolveProjectAuthority } = await import('../authority.ts');
+    for (const value of [
+      '', 'owner/repo', 'https://github.com/acme/widgets', 'github.com/acme/widgets/extra',
+      'github.com/acme/.', 'github.com/acme/..', 'github.com/acme/%2e%2e',
+      'github.com/acme\\widgets', 'github.com/acme/widgets\nother', 'unknown', '_universal',
+      'github.com/acme/widget space', 'github.com/acme/widget?x', 'github.com/acme/widget#x',
+      'github.com/acme/widget:tag', 'github.com/acme/widget@x', 'github.com/acme/widgets.git',
+      'github.com/acme/widget🔥', `github.com/${'a'.repeat(101)}/widgets`,
+    ]) {
+      expect(resolveProjectAuthority(value, {
+        explicit: true, trustedCallerCwd: true, detectedProject: 'github.com/fallback/blocked',
+      })).toEqual({ invalid: true });
+    }
+  });
+});

--- a/src/learn/__tests__/target.test.ts
+++ b/src/learn/__tests__/target.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const roots: string[] = [];
+function root() { const dir = join(tmpdir(), `arra-target-${Date.now()}-${Math.random()}`); roots.push(dir); mkdirSync(dir); return dir; }
+afterEach(() => { for (const dir of roots.splice(0)) rmSync(dir, { recursive: true, force: true }); });
+
+describe('learn target and identity seams', () => {
+  test('resolves project-first, universal, and no-vault targets', async () => {
+    const { resolveVaultLearnTarget } = await import('../target.ts');
+    const vault = root();
+    const fallback = root();
+    expect(resolveVaultLearnTarget('github.com/acme/widgets', vault, 'ψ/memory/learnings', fallback)).toEqual({
+      absDir: join(vault, 'github.com/acme/widgets/ψ/memory/learnings'),
+      sourceFileRel: 'github.com/acme/widgets/ψ/memory/learnings',
+      vaultRoot: vault, fallbackRoot: fallback, subdir: 'ψ/memory/learnings',
+    });
+    expect(resolveVaultLearnTarget(null, vault, 'ψ/memory/learnings', fallback).sourceFileRel)
+      .toBe('_universal/ψ/memory/learnings');
+    expect(resolveVaultLearnTarget(null, null, 'ψ/memory/learnings', fallback)).toEqual({
+      absDir: join(fallback, 'ψ/memory/learnings'), sourceFileRel: 'ψ/memory/learnings',
+      vaultRoot: null, fallbackRoot: fallback, subdir: 'ψ/memory/learnings',
+    });
+  });
+
+  test('exclusive reservation retries EEXIST and global id collisions', async () => {
+    const { reserveGeneratedLearning, resolveVaultLearnTarget } = await import('../target.ts');
+    const target = resolveVaultLearnTarget('github.com/acme/widgets', root(), 'ψ/memory/learnings', root());
+    mkdirSync(target.absDir, { recursive: true });
+    await Bun.write(join(target.absDir, '2026-07-22_same.md'), 'occupied');
+    const reserved = reserveGeneratedLearning({
+      dateStr: '2026-07-22', slug: 'same', target,
+      idExists: (id) => id.endsWith('-2'),
+      content: (identity) => `id: ${identity.id}`,
+    });
+    expect(reserved.id).toBe('learning_2026-07-22_same-3');
+    expect(reserved.sourceFile).toEndWith('/2026-07-22_same-3.md');
+  });
+
+  test('rejects symlinked target parents', async () => {
+    const { reserveGeneratedLearning, resolveVaultLearnTarget } = await import('../target.ts');
+    const vault = root();
+    const outside = root();
+    mkdirSync(join(vault, 'github.com/acme/widgets/ψ/memory'), { recursive: true });
+    symlinkSync(outside, join(vault, 'github.com/acme/widgets/ψ/memory/learnings'));
+    expect(() => reserveGeneratedLearning({
+      dateStr: '2026-07-22', slug: 'blocked',
+      target: resolveVaultLearnTarget('github.com/acme/widgets', vault, 'ψ/memory/learnings', root()),
+      idExists: () => false, content: () => 'blocked',
+    })).toThrow(/symlink/i);
+  });
+
+  test('target resolution rejects non-canonical and traversal projects before mkdir', async () => {
+    const { resolveVaultLearnTarget } = await import('../target.ts');
+    const vault = root();
+    const outside = join(vault, '..', 'escaped-target');
+    for (const project of ['../escaped-target', 'github.com/acme/widget space', 'github.com/acme/widgets.git']) {
+      expect(() => resolveVaultLearnTarget(project, vault, 'ψ/memory/learnings', root())).toThrow(/project/i);
+    }
+    expect(existsSync(outside)).toBe(false);
+  });
+
+  test('generated allocation suffixes around project and flat orphan files', async () => {
+    const { reserveGeneratedLearning, resolveVaultLearnTarget } = await import('../target.ts');
+    const vault = root();
+    const fallback = root();
+    const target = resolveVaultLearnTarget('github.com/acme/project-b', vault, 'ψ/memory/learnings', fallback);
+    const otherDir = join(vault, 'github.com/acme/project-a/ψ/memory/learnings');
+    mkdirSync(otherDir, { recursive: true });
+    writeFileSync(join(otherDir, '2026-07-22_orphan.md'), 'other-project orphan');
+    mkdirSync(join(fallback, 'ψ/memory/learnings'), { recursive: true });
+    writeFileSync(join(fallback, 'ψ/memory/learnings/2026-07-22_orphan-2.md'), 'flat orphan');
+    const reserved = reserveGeneratedLearning({
+      dateStr: '2026-07-22', slug: 'orphan', target, idExists: () => false,
+      content: ({ id }) => id,
+    });
+    expect(reserved.id).toBe('learning_2026-07-22_orphan-3');
+  });
+
+  test('explicit allocation rejects project and flat orphan files', async () => {
+    const { reserveExplicitLearning, resolveVaultLearnTarget } = await import('../target.ts');
+    for (const location of ['project', 'flat']) {
+      const vault = root();
+      const fallback = root();
+      const target = resolveVaultLearnTarget('github.com/acme/project-b', vault, 'ψ/memory/learnings', fallback);
+      const orphanDir = location === 'project'
+        ? join(vault, 'github.com/acme/project-a/ψ/memory/learnings')
+        : join(fallback, 'ψ/memory/learnings');
+      mkdirSync(orphanDir, { recursive: true });
+      writeFileSync(join(orphanDir, 'learning_explicit_orphan.md'), 'orphan');
+      const reserved = reserveExplicitLearning({
+        id: 'learning_explicit_orphan', sourceFile: 'ψ/memory/learnings/learning_explicit_orphan.md',
+        target, idExists: () => false, content: ({ id }) => id,
+      });
+      expect(reserved).toBeNull();
+    }
+  });
+});

--- a/src/learn/__tests__/writer-reachability.test.ts
+++ b/src/learn/__tests__/writer-reachability.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('active learning writer archival import guard', () => {
+  test('has no direct imports of archival vault handler or migrate modules', () => {
+    for (const file of [
+      'src/routes/learn/crud.ts', 'src/tools/learn.ts', 'src/server/handlers.ts', 'src/trace/learning-files.ts',
+      'src/learn/authority.ts', 'src/learn/target.ts',
+    ]) {
+      const source = readFileSync(resolve(file), 'utf8');
+      expect(source).not.toMatch(/vault\/(handler|migrate)\.ts/);
+    }
+  });
+});

--- a/src/learn/authority.ts
+++ b/src/learn/authority.ts
@@ -1,0 +1,56 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { detectProject } from '../server/project-detect.ts';
+
+export type ProjectAuthority = { project: string | null } | { invalid: true };
+export interface ProjectAuthorityOptions {
+  explicit: boolean;
+  trustedCallerCwd?: boolean;
+  detectedProject?: string | null;
+}
+
+const CANONICAL_PROJECT = /^(github\.com|gitlab\.com|bitbucket\.org)\/([A-Za-z0-9._-]{1,100})\/([A-Za-z0-9._-]{1,100})$/i;
+const BARE_SENTINELS = new Set(['oracle-vault', 'learnings', 'unknown', '_universal']);
+
+export function canonicalProject(value: unknown): string | null {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  if (value !== value.trim() || /[\x00-\x1f\x7f%\\]/.test(value)) return null;
+  if (BARE_SENTINELS.has(value.toLowerCase()) || !CANONICAL_PROJECT.test(value)) return null;
+  const match = value.match(CANONICAL_PROJECT);
+  if (!match) return null;
+  const [, , owner, repo] = match;
+  if (owner === '.' || owner === '..' || repo === '.' || repo === '..') return null;
+  if (owner.toLowerCase().endsWith('.git') || repo.toLowerCase().endsWith('.git')) return null;
+  return value.toLowerCase();
+}
+
+export function resolveProjectAuthority(
+  value: unknown,
+  opts: ProjectAuthorityOptions,
+): ProjectAuthority {
+  if (opts.explicit) {
+    if (value === null) return { project: null };
+    const project = canonicalProject(value);
+    return project ? { project } : { invalid: true };
+  }
+  if (!opts.trustedCallerCwd) return { project: null };
+  return { project: canonicalProject(opts.detectedProject) };
+}
+
+export function detectTrustedCallerProject(
+  cwd: string | undefined,
+  blockedRoots: Array<string | null | undefined>,
+): { trustedCallerCwd: boolean; detectedProject: string | null } {
+  if (!cwd) return { trustedCallerCwd: false, detectedProject: null };
+  let realCwd: string;
+  try { realCwd = fs.realpathSync(cwd); } catch { return { trustedCallerCwd: false, detectedProject: null }; }
+  for (const root of blockedRoots) {
+    if (!root) continue;
+    let realRoot: string;
+    try { realRoot = fs.realpathSync(root); } catch { realRoot = path.resolve(root); }
+    if (realCwd === realRoot || realCwd.startsWith(`${realRoot}${path.sep}`)) {
+      return { trustedCallerCwd: false, detectedProject: null };
+    }
+  }
+  return { trustedCallerCwd: true, detectedProject: detectProject(realCwd) };
+}

--- a/src/learn/target.ts
+++ b/src/learn/target.ts
@@ -1,0 +1,172 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { canonicalProject } from './authority.ts';
+
+export interface LearnTarget {
+  absDir: string;
+  sourceFileRel: string;
+  vaultRoot: string | null;
+  fallbackRoot: string;
+  subdir: string;
+}
+export interface LearningIdentity {
+  id: string;
+  filename: string;
+  filePath: string;
+  sourceFile: string;
+}
+
+export function resolveVaultLearnTarget(
+  project: string | null,
+  vaultRoot: string | null,
+  subdir = 'ψ/memory/learnings',
+  fallbackRoot = process.cwd(),
+): LearnTarget {
+  const safeSubdir = posixSubdir(subdir);
+  const canonical = project === null ? null : canonicalProject(project);
+  if (project !== null && !canonical) throw new TypeError('Invalid project authority');
+  const safeFallbackRoot = resolvedRoot(fallbackRoot);
+  if (vaultRoot) {
+    const safeVaultRoot = resolvedRoot(vaultRoot);
+    const prefix = canonical || '_universal';
+    const absDir = path.resolve(safeVaultRoot, ...prefix.split('/'), ...safeSubdir.split('/'));
+    assertContained(absDir, safeVaultRoot);
+    return {
+      absDir,
+      sourceFileRel: `${prefix}/${safeSubdir}`,
+      vaultRoot: safeVaultRoot,
+      fallbackRoot: safeFallbackRoot,
+      subdir: safeSubdir,
+    };
+  }
+  const absDir = path.resolve(safeFallbackRoot, ...safeSubdir.split('/'));
+  assertContained(absDir, safeFallbackRoot);
+  return {
+    absDir,
+    sourceFileRel: safeSubdir,
+    vaultRoot: null,
+    fallbackRoot: safeFallbackRoot,
+    subdir: safeSubdir,
+  };
+}
+
+export function identityCandidate(dateStr: string, slug: string, suffix = 1): Pick<LearningIdentity, 'id' | 'filename'> {
+  const tail = suffix === 1 ? slug : `${slug}-${suffix}`;
+  return { id: `learning_${dateStr}_${tail}`, filename: `${dateStr}_${tail}.md` };
+}
+
+export function reserveGeneratedLearning(opts: {
+  dateStr: string;
+  slug: string;
+  target: LearnTarget;
+  idExists: (id: string) => boolean;
+  content: (identity: Pick<LearningIdentity, 'id' | 'filename'>) => string;
+}): LearningIdentity {
+  prepareTarget(opts.target.absDir);
+  for (let suffix = 1; ; suffix += 1) {
+    const candidate = identityCandidate(opts.dateStr, opts.slug, suffix);
+    if (opts.idExists(candidate.id) || fileExistsInCanonicalRoots(opts.target, candidate.filename)) continue;
+    const reserved = reserveFile(opts.target, candidate, opts.content(candidate));
+    if (reserved) return reserved;
+  }
+}
+
+export function reserveExplicitLearning(opts: {
+  id: string;
+  sourceFile: string;
+  target: LearnTarget;
+  idExists: (id: string) => boolean;
+  content: (identity: Pick<LearningIdentity, 'id' | 'filename'>) => string;
+}): LearningIdentity | null {
+  const filename = explicitFilename(opts.id, opts.sourceFile);
+  if (!filename) throw new TypeError('Invalid learning sourceFile');
+  if (opts.idExists(opts.id) || fileExistsInCanonicalRoots(opts.target, filename)) return null;
+  prepareTarget(opts.target.absDir);
+  return reserveFile(opts.target, { id: opts.id, filename }, opts.content({ id: opts.id, filename }));
+}
+
+export function explicitFilename(id: string, sourceFile: string): string | null {
+  if (!sourceFile || sourceFile.includes('\0') || sourceFile.includes('\\')) return null;
+  if (!sourceFile.startsWith('ψ/memory/learnings/')) return null;
+  const tail = sourceFile.slice('ψ/memory/learnings/'.length);
+  if (!tail || tail.includes('/') || path.posix.basename(tail) !== tail || !tail.endsWith('.md')) return null;
+  return tail === `${id}.md` ? tail : null;
+}
+
+function reserveFile(
+  target: LearnTarget,
+  candidate: Pick<LearningIdentity, 'id' | 'filename'>,
+  content: string,
+): LearningIdentity | null {
+  assertMarkdownBasename(candidate.filename);
+  const filePath = path.join(target.absDir, candidate.filename);
+  try {
+    fs.writeFileSync(filePath, content, { encoding: 'utf8', flag: 'wx' });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') return null;
+    throw error;
+  }
+  return { ...candidate, filePath, sourceFile: `${target.sourceFileRel}/${candidate.filename}` };
+}
+
+function prepareTarget(absDir: string): void {
+  assertNoSymlinkParents(absDir);
+  fs.mkdirSync(absDir, { recursive: true });
+  assertNoSymlinkParents(absDir);
+}
+
+function assertNoSymlinkParents(absDir: string): void {
+  const absolute = path.resolve(absDir);
+  const parsed = path.parse(absolute);
+  let cursor = parsed.root;
+  for (const segment of absolute.slice(parsed.root.length).split(path.sep).filter(Boolean)) {
+    cursor = path.join(cursor, segment);
+    if (!fs.existsSync(cursor)) continue;
+    if (fs.lstatSync(cursor).isSymbolicLink()) throw new Error(`Learning target parent is a symlink: ${cursor}`);
+  }
+}
+
+function posixSubdir(subdir: string): string {
+  if (subdir.includes('\0') || subdir.includes('\\') || path.posix.isAbsolute(subdir)) throw new TypeError('Invalid learning subdir');
+  const normalized = path.posix.normalize(subdir);
+  if (normalized !== subdir || normalized.startsWith('../') || !normalized.startsWith('ψ/memory/')) throw new TypeError('Invalid learning subdir');
+  return normalized;
+}
+
+function assertMarkdownBasename(filename: string): void {
+  if (path.basename(filename) !== filename || !filename.endsWith('.md') || filename === '.md') {
+    throw new TypeError('Learning filename must be a flat .md basename');
+  }
+}
+
+function fileExistsInCanonicalRoots(target: LearnTarget, filename: string): boolean {
+  const flat = path.join(target.fallbackRoot, ...target.subdir.split('/'), filename);
+  if (fs.existsSync(flat)) return true;
+  if (!target.vaultRoot) return false;
+  const universal = path.join(target.vaultRoot, '_universal', ...target.subdir.split('/'), filename);
+  if (fs.existsSync(universal)) return true;
+  for (const host of ['github.com', 'gitlab.com', 'bitbucket.org']) {
+    const hostDir = path.join(target.vaultRoot, host);
+    for (const owner of childNames(hostDir)) {
+      for (const repo of childNames(path.join(hostDir, owner))) {
+        if (fs.existsSync(path.join(hostDir, owner, repo, ...target.subdir.split('/'), filename))) return true;
+      }
+    }
+  }
+  return false;
+}
+
+function childNames(dir: string): string[] {
+  try { return fs.readdirSync(dir); } catch { return []; }
+}
+
+function resolvedRoot(root: string): string {
+  const absolute = path.resolve(root);
+  try { return fs.realpathSync(absolute); } catch { return absolute; }
+}
+
+function assertContained(candidate: string, root: string): void {
+  if (candidate !== root && !candidate.startsWith(`${root}${path.sep}`)) {
+    throw new TypeError('Learning target escapes configured root');
+  }
+}

--- a/src/routes/learn/crud.ts
+++ b/src/routes/learn/crud.ts
@@ -1,18 +1,19 @@
 import { Elysia, t } from 'elysia';
 import { and, eq } from 'drizzle-orm';
 import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
-import fs from 'fs';
-import path from 'path';
 import { db, learnLog, oracleDocuments, sqlite } from '../../db/index.ts';
+import { REPO_ROOT } from '../../config.ts';
+import { resolveProjectAuthority } from '../../learn/authority.ts';
+import { buildLearningMarkdown, dateSlug } from '../../learn/markdown.ts';
+import { reserveExplicitLearning, reserveGeneratedLearning, resolveVaultLearnTarget } from '../../learn/target.ts';
 import { currentTenantId, tenantIdForWrite } from '../../middleware/tenant.ts';
 import { replaceEntityLinks } from '../../search/entity-ranking.ts';
+import { getVaultPsiRoot } from '../../vault/discovery.ts';
 import { conceptsFrom, learningContent, slugFor } from './content.ts';
 import {
   INVALID_LEARNING_ID,
   INVALID_LEARNING_SOURCE_FILE,
-  learningSourcePath,
   safeLearningId,
-  safeLearningSourceFile,
 } from './safety.ts';
 type LearnDoc = typeof oracleDocuments.$inferSelect;
 const oracleFts = sqliteTable('oracle_fts', {
@@ -52,19 +53,6 @@ const UpdateBody = t.Object({
   supersededBy: t.Optional(t.Nullable(t.String())),
   supersededReason: t.Optional(t.Nullable(t.String())),
 });
-function writeLearningFile(sourceFile: string, content: string): boolean {
-  const filePath = learningSourcePath(sourceFile);
-  if (!filePath) throw new Error(INVALID_LEARNING_SOURCE_FILE);
-  if (fs.existsSync(filePath)) return false;
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  try {
-    fs.writeFileSync(filePath, content, { encoding: 'utf-8', flag: 'wx' });
-  } catch (error) {
-    if ((error as { code?: string }).code === 'EEXIST') return false;
-    throw error;
-  }
-  return true;
-}
 function ftsContent(id: string): string | null {
   return db.select({ content: oracleFts.content })
     .from(oracleFts)
@@ -75,35 +63,8 @@ function upsertFts(id: string, content: string, concepts: string[]): void {
   db.delete(oracleFts).where(eq(oracleFts.id, id)).run();
   db.insert(oracleFts).values({ id, content, concepts: concepts.join(' ') }).run();
 }
-function nextIdentity(pattern: string, requestedId?: string, requestedSourceFile?: string) {
-  if (requestedId) {
-    return {
-      id: requestedId,
-      sourceFile: requestedSourceFile ?? `ψ/memory/learnings/${requestedId}.md`,
-    };
-  }
-  const date = new Date().toISOString().slice(0, 10);
-  const slug = slugFor(pattern);
-  let suffix = 1;
-  while (true) {
-    const tail = suffix === 1 ? slug : `${slug}-${suffix}`;
-    const id = `learning_${date}_${tail}`;
-    const sourceFile = requestedSourceFile ?? `ψ/memory/learnings/${date}_${tail}.md`;
-    const tenantId = currentTenantId();
-    const where = tenantId ? and(eq(oracleDocuments.id, id), eq(oracleDocuments.tenantId, tenantId)) : eq(oracleDocuments.id, id);
-    const existing = db.select({ id: oracleDocuments.id })
-      .from(oracleDocuments)
-      .where(where)
-      .get();
-    const filePath = learningSourcePath(sourceFile);
-    if (!existing && filePath && !fs.existsSync(filePath)) {
-      return {
-        id,
-        sourceFile,
-      };
-    }
-    suffix += 1;
-  }
+function globalIdExists(id: string): boolean {
+  return !!db.select({ id: oracleDocuments.id }).from(oracleDocuments).where(eq(oracleDocuments.id, id)).get();
 }
 function rowById(id: string): LearnDoc | undefined {
   const tenantId = currentTenantId();
@@ -119,41 +80,57 @@ export function createLearning(body: LearnCreateBody) {
   const pattern = body.pattern?.trim();
   if (!pattern) return { status: 400, body: { error: 'Missing required field: pattern' } };
   if (body.id !== undefined && !safeLearningId(body.id)) return { status: 400, body: { error: INVALID_LEARNING_ID } };
-  const requestedSourceFile = body.sourceFile === undefined ? undefined : safeLearningSourceFile(body.sourceFile);
-  if (requestedSourceFile === null) return { status: 400, body: { error: INVALID_LEARNING_SOURCE_FILE } };
-  const now = Date.now();
+  if (body.sourceFile !== undefined && body.id === undefined) return { status: 400, body: { error: INVALID_LEARNING_SOURCE_FILE } };
+  const authority = resolveProjectAuthority(body.project, {
+    explicit: Object.prototype.hasOwnProperty.call(body, 'project'),
+  });
+  if ('invalid' in authority) return { status: 400, body: { error: 'Invalid project authority' } };
+  const project = authority.project;
+  const now = new Date();
   const concepts = conceptsFrom(body.concepts);
-  const identity = nextIdentity(pattern, body.id, requestedSourceFile);
-  if (rowById(identity.id)) return { status: 409, body: { error: 'Learning already exists' } };
-  const content = learningContent(pattern, concepts, body.source);
-  if (!writeLearningFile(identity.sourceFile, content)) {
-    return { status: 409, body: { error: 'Learning sourceFile already exists' } };
+  const vault = getVaultPsiRoot();
+  const vaultRoot = 'path' in vault ? vault.path : null;
+  const target = resolveVaultLearnTarget(project, vaultRoot, 'ψ/memory/learnings', process.env.ORACLE_REPO_ROOT || REPO_ROOT);
+  const markdown = ({ id }: { id: string }) => buildLearningMarkdown({
+    id, pattern, title: pattern.split('\n')[0].slice(0, 80), concepts, createdAt: now,
+    source: body.source, project,
+  });
+  let identity;
+  try {
+    identity = body.id
+      ? reserveExplicitLearning({
+        id: body.id,
+        sourceFile: body.sourceFile ?? `ψ/memory/learnings/${body.id}.md`,
+        target,
+        idExists: globalIdExists,
+        content: markdown,
+      })
+      : reserveGeneratedLearning({
+        dateStr: dateSlug(now), slug: slugFor(pattern), target,
+        idExists: globalIdExists, content: markdown,
+      });
+  } catch (error) {
+    if (error instanceof TypeError) return { status: 400, body: { error: INVALID_LEARNING_SOURCE_FILE } };
+    throw error;
   }
+  if (!identity) return { status: 409, body: { error: 'Learning already exists or sourceFile already exists' } };
+  const content = markdown(identity);
   const tenantId = tenantIdForWrite();
-  db.insert(oracleDocuments).values({
-    id: identity.id,
-    tenantId,
-    type: 'learning',
-    sourceFile: identity.sourceFile,
-    concepts: JSON.stringify(concepts),
-    createdAt: now,
-    updatedAt: now,
-    indexedAt: now,
-    origin: body.origin ?? null,
-    project: body.project?.toLowerCase() ?? null,
-    createdBy: 'oracle_learn',
-  }).run();
-  upsertFts(identity.id, content, concepts);
-  replaceEntityLinks(sqlite, { documentId: identity.id, tenantId, content, concepts, now });
-  db.insert(learnLog).values({
-    documentId: identity.id,
-    tenantId,
-    patternPreview: pattern.slice(0, 200),
-    source: body.source ?? 'Oracle Learn',
-    concepts: JSON.stringify(concepts),
-    createdAt: now,
-    project: body.project?.toLowerCase() ?? null,
-  }).run();
+  try {
+    db.insert(oracleDocuments).values({
+      id: identity.id, tenantId, type: 'learning', sourceFile: identity.sourceFile,
+      concepts: JSON.stringify(concepts), createdAt: now.getTime(), updatedAt: now.getTime(), indexedAt: now.getTime(),
+      origin: body.origin ?? null, project, createdBy: 'oracle_learn',
+    }).run();
+    upsertFts(identity.id, content, concepts);
+    replaceEntityLinks(sqlite, { documentId: identity.id, tenantId, content, concepts, now: now.getTime() });
+    db.insert(learnLog).values({
+      documentId: identity.id, tenantId, patternPreview: pattern.slice(0, 200),
+      source: body.source ?? 'Oracle Learn', concepts: JSON.stringify(concepts), createdAt: now.getTime(), project,
+    }).run();
+  } catch (error) {
+    throw new Error(`Learning persistence failed after file reservation; orphan file: ${identity.filePath}`, { cause: error });
+  }
   return { status: 200, body: { success: true, file: identity.sourceFile, id: identity.id } };
 }
 function updateLearning(id: string, body: LearnUpdateBody) {
@@ -162,13 +139,15 @@ function updateLearning(id: string, body: LearnUpdateBody) {
   const now = Date.now();
   const set: Partial<LearnDoc> = { updatedAt: now, indexedAt: now };
   if (body.sourceFile !== undefined) {
-    const sourceFile = safeLearningSourceFile(body.sourceFile);
-    if (!sourceFile) return { status: 400, body: { error: INVALID_LEARNING_SOURCE_FILE } };
-    set.sourceFile = sourceFile;
+    if (body.sourceFile !== existing.sourceFile) return { status: 400, body: { error: 'Learning sourceFile is immutable' } };
   }
   if (body.concepts !== undefined) set.concepts = JSON.stringify(conceptsFrom(body.concepts));
   if (body.origin !== undefined) set.origin = body.origin;
-  if (body.project !== undefined) set.project = body.project?.toLowerCase() ?? null;
+  if (body.project !== undefined) {
+    const authority = resolveProjectAuthority(body.project, { explicit: true });
+    if ('invalid' in authority) return { status: 400, body: { error: 'Invalid project authority' } };
+    if (authority.project !== existing.project) return { status: 400, body: { error: 'Learning project is immutable' } };
+  }
   if (body.supersededBy !== undefined) set.supersededBy = body.supersededBy;
   if (body.supersededReason !== undefined) set.supersededReason = body.supersededReason;
   const nextConcepts = body.concepts === undefined ? conceptsFrom(existing.concepts) : conceptsFrom(body.concepts);

--- a/src/scripts/index-model.ts
+++ b/src/scripts/index-model.ts
@@ -1,142 +1,30 @@
 #!/usr/bin/env bun
-/** Generic embedding model indexer with incremental chunk-hash support. */
+/** Queue reconciliation command. The daemon is the only LanceDB writer. */
 
-import { createVectorStoreForModel, EMBEDDING_MODELS } from '../vector/factory.ts';
-import { createDatabase, oracleDocuments } from '../db/index.ts';
-import { count } from 'drizzle-orm';
+import { EMBEDDING_MODELS } from '../vector/factory.ts';
+import { createDatabase } from '../db/index.ts';
 import { DB_PATH } from '../config.ts';
-import { formatIndexProgress, normalizeBatchSize } from './indexer-progress.ts';
-import {
-  applyVectorIndexPlan,
-  loadVectorIndexManifest,
-  planVectorIndex,
-  writeVectorIndexManifest,
-  type VectorIndexPlan,
-} from '../indexer/vector-index-manifest.ts';
-import type { VectorDocument } from '../vector/types.ts';
+import { enqueueCanonicalVectorJobs } from '../indexer/reindex-state.ts';
+import { loadCanonicalVectorDocuments } from '../indexer/vector-source.ts';
 
 const args = process.argv.slice(2);
 const modelKey = args.find((arg) => !arg.startsWith('--'));
 const flags = new Set(args.filter((arg) => arg.startsWith('--')));
-
 if (!modelKey || !EMBEDDING_MODELS[modelKey] || flags.has('--help')) {
-  console.error('Usage: bun src/scripts/index-model.ts <model> [--incremental] [--dry-run] [--force]');
-  console.error(`Available models: ${Object.keys(EMBEDDING_MODELS).join(', ')}`);
+  console.error('Usage: bun src/scripts/index-model.ts <model> [--dry-run]');
   process.exit(flags.has('--help') ? 0 : 1);
 }
 
-const selectedModelKey = modelKey;
-const preset = EMBEDDING_MODELS[selectedModelKey];
-const BATCH_SIZE = normalizeBatchSize(process.env.ORACLE_EMBED_BATCH_SIZE, 50);
-const dryRun = flags.has('--dry-run');
-const force = flags.has('--force');
-
-interface DbVectorRow {
-  id: string;
-  tenant_id: string;
-  type: string;
-  content: string;
-  source_file: string;
-  concepts: string;
-  project: string | null;
-  created_at: number;
-}
-
-async function main() {
-  console.log(`=== ${selectedModelKey} Indexer ===`);
-  console.log(`DB: ${DB_PATH}`);
-  console.log(`Collection: ${preset.collection}`);
-  console.log(`Model: ${preset.model}`);
-  console.log(`Adapter: ${preset.adapter || 'lancedb'}`);
-  console.log(`Batch size: ${BATCH_SIZE}`);
-  console.log(`Mode: ${force ? 'force rebuild' : 'incremental'}${dryRun ? ' dry-run' : ''}`);
-
-  const { db, sqlite } = createDatabase(DB_PATH);
-  const [{ total: docCount }] = db.select({ total: count() }).from(oracleDocuments).all();
-  const rows = loadRows(sqlite);
-  const docs = rows.map(vectorDoc);
-  const previous = loadVectorIndexManifest(db, selectedModelKey);
-  const plan = planVectorIndex(docs, previous, selectedModelKey, { force });
-  const startTime = Date.now();
-
-  console.log(`Documents: ${docCount}`);
-  console.log(`Chunks: ${plan.total}; changed: ${plan.changedDocs.length}; stale: ${plan.staleIds.length}; skipped: ${plan.skipped}`);
-
-  if (dryRun) {
-    printSummary(rows, plan, { embedded: plan.changedDocs.length, errors: 0, startTime, dryRun, force });
-    sqlite.close();
-    return;
+const preset = EMBEDDING_MODELS[modelKey];
+const { db, sqlite } = createDatabase(DB_PATH);
+try {
+  const docs = loadCanonicalVectorDocuments(sqlite);
+  if (flags.has('--dry-run')) {
+    console.log(JSON.stringify({ model: modelKey, chunks: docs.length, dry_run: true, writer: 'daemon' }, null, 2));
+  } else {
+    const stats = enqueueCanonicalVectorJobs(db, docs.map((doc) => doc.id), { [modelKey]: { collection: preset.collection } });
+    console.log(JSON.stringify({ model: modelKey, chunks: docs.length, ...stats, writer: 'daemon' }, null, 2));
   }
-
-  const store = createVectorStoreForModel(preset);
-  await store.connect();
-
-  try {
-    const applied = await applyVectorIndexPlan(store, plan, {
-      batchSize: BATCH_SIZE,
-      replaceBaseline: previous.size === 0 || force,
-      onProgress: (indexed, total, action) => logProgress(action === 'replaced' ? 'Rebuilt' : 'Embedded', indexed, total, startTime),
-    });
-    writeVectorIndexManifest(db, plan);
-    printSummary(rows, plan, { embedded: applied.embedded, errors: 0, startTime, dryRun, force });
-  } finally {
-    await store.close();
-    sqlite.close();
-  }
+} finally {
+  sqlite.close();
 }
-
-function loadRows(sqlite: ReturnType<typeof createDatabase>['sqlite']): DbVectorRow[] {
-  return sqlite.prepare(`
-    SELECT d.id, d.tenant_id, d.type, GROUP_CONCAT(f.content, '\n') as content,
-      d.source_file, d.concepts, d.project, d.created_at
-    FROM oracle_documents d
-    JOIN oracle_fts f ON d.id = f.id
-    GROUP BY d.id
-    ORDER BY d.created_at DESC
-  `).all() as DbVectorRow[];
-}
-
-function vectorDoc(row: DbVectorRow): VectorDocument {
-  return {
-    id: row.id,
-    document: row.content,
-    metadata: {
-      type: row.type,
-      source_file: row.source_file,
-      concepts: row.concepts,
-      tenant_id: row.tenant_id,
-      ...(row.project && { project: row.project }),
-    },
-  };
-}
-
-function logProgress(label: string, indexed: number, total: number, startTime: number): void {
-  const progress = formatIndexProgress({ indexed, total, startTimeMs: startTime });
-  console.log(`  ${label} ${indexed}/${total} chunks — ${progress.rate}/s — ETA ${progress.eta}s`);
-}
-
-function printSummary(
-  rows: DbVectorRow[],
-  plan: VectorIndexPlan,
-  result: { embedded: number; errors: number; startTime: number; dryRun: boolean; force: boolean },
-): void {
-  const durationMs = Date.now() - result.startTime;
-  const summary = {
-    scanned_files: new Set(rows.map((row) => row.source_file)).size,
-    total_chunks: plan.total,
-    skipped: result.force ? 0 : plan.skipped,
-    embedded: result.embedded,
-    deleted: plan.staleIds.length,
-    errors: result.errors,
-    dry_run: result.dryRun,
-    force: result.force,
-    duration_ms: durationMs,
-  };
-  console.log('\n=== Done ===');
-  console.log(JSON.stringify(summary, null, 2));
-}
-
-main().catch(e => {
-  console.error('Indexer failed:', e);
-  process.exit(1);
-});

--- a/src/scripts/index-model.ts
+++ b/src/scripts/index-model.ts
@@ -11,8 +11,12 @@ const args = process.argv.slice(2);
 const modelKey = args.find((arg) => !arg.startsWith('--'));
 const flags = new Set(args.filter((arg) => arg.startsWith('--')));
 if (!modelKey || !EMBEDDING_MODELS[modelKey] || flags.has('--help')) {
-  console.error('Usage: bun src/scripts/index-model.ts <model> [--dry-run]');
+  console.error('Usage: bun src/scripts/index-model.ts <model> [--dry-run] [--repair]');
   process.exit(flags.has('--help') ? 0 : 1);
+}
+if ([...flags].some((flag) => flag !== '--dry-run' && flag !== '--repair')) {
+  console.error(`Unknown flag: ${[...flags].find((flag) => flag !== '--dry-run' && flag !== '--repair')}`);
+  process.exit(1);
 }
 
 const preset = EMBEDDING_MODELS[modelKey];
@@ -22,8 +26,14 @@ try {
   if (flags.has('--dry-run')) {
     console.log(JSON.stringify({ model: modelKey, chunks: docs.length, dry_run: true, writer: 'daemon' }, null, 2));
   } else {
-    const stats = enqueueCanonicalVectorJobs(db, docs.map((doc) => doc.id), { [modelKey]: { collection: preset.collection } });
-    console.log(JSON.stringify({ model: modelKey, chunks: docs.length, ...stats, writer: 'daemon' }, null, 2));
+    const repair = flags.has('--repair');
+    const stats = enqueueCanonicalVectorJobs(
+      db,
+      docs.map((doc) => doc.id),
+      { [modelKey]: { collection: preset.collection } },
+      { force: repair },
+    );
+    console.log(JSON.stringify({ model: modelKey, chunks: docs.length, ...stats, repair, writer: 'daemon' }, null, 2));
   }
 } finally {
   sqlite.close();

--- a/src/server/__tests__/persist-learning-authority.test.ts
+++ b/src/server/__tests__/persist-learning-authority.test.ts
@@ -1,0 +1,69 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const saved = Object.fromEntries(['ORACLE_DATA_DIR', 'ORACLE_DB_PATH', 'ORACLE_REPO_ROOT']
+  .map((key) => [key, process.env[key]]));
+const root = join(tmpdir(), `arra-persist-learn-${Date.now()}`);
+const repoRoot = join(root, 'repo');
+const vaultRoot = join(root, 'vault');
+mkdirSync(repoRoot, { recursive: true });
+mkdirSync(vaultRoot, { recursive: true });
+process.env.ORACLE_DATA_DIR = join(root, 'data');
+process.env.ORACLE_DB_PATH = join(root, 'data/oracle.db');
+process.env.ORACLE_REPO_ROOT = repoRoot;
+
+mock.module('../../vault/discovery.ts', () => ({ getVaultPsiRoot: () => ({ path: vaultRoot }) }));
+const dbMod = await import('../../db/index.ts');
+dbMod.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+const { handleSessionSummary, persistLearningDoc } = await import('../handlers.ts');
+
+beforeEach(() => {
+  for (const table of ['learn_log', 'oracle_fts', 'oracle_documents']) dbMod.sqlite.run(`DELETE FROM ${table}`);
+  rmSync(join(vaultRoot, 'github.com'), { recursive: true, force: true });
+  rmSync(join(vaultRoot, '_universal'), { recursive: true, force: true });
+  rmSync(join(repoRoot, 'ψ'), { recursive: true, force: true });
+});
+afterAll(() => {
+  dbMod.resetDefaultDatabaseForTests(':memory:');
+  for (const [key, value] of Object.entries(saved)) value === undefined ? delete process.env[key] : process.env[key] = value;
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('persistLearningDoc project-first learning gate', () => {
+  test('learning subdir uses one project across file, DB, FTS, and log', () => {
+    const project = 'github.com/acme/widgets';
+    const result = persistLearningDoc({
+      pattern: 'Persist seam alignment', subdir: 'ψ/memory/learnings',
+      filename: '2026-07-22_persist-seam.md', id: 'learning_2026-07-22_persist-seam', project,
+    });
+    expect(result.file).toStartWith(`${project}/ψ/memory/learnings/`);
+    expect(existsSync(join(vaultRoot, result.file))).toBe(true);
+    const row = dbMod.db.select().from(dbMod.oracleDocuments).where(eq(dbMod.oracleDocuments.id, result.id)).get();
+    const log = dbMod.db.select().from(dbMod.learnLog).where(eq(dbMod.learnLog.documentId, result.id)).get();
+    expect(row?.project).toBe(project);
+    expect(log?.project).toBe(project);
+    expect(dbMod.sqlite.query('SELECT id FROM oracle_fts WHERE id = ?').get(result.id)).toBeTruthy();
+  });
+
+  test('malformed explicit project stops before all persistence effects', () => {
+    expect(() => persistLearningDoc({
+      pattern: 'blocked persist', subdir: 'ψ/memory/learnings', filename: 'blocked.md',
+      id: 'learning_blocked', project: 'owner/repo',
+    })).toThrow('Invalid project authority');
+    expect(dbMod.sqlite.query('SELECT id FROM oracle_documents').all()).toHaveLength(0);
+    expect(dbMod.sqlite.query('SELECT id FROM oracle_fts').all()).toHaveLength(0);
+    expect(dbMod.sqlite.query('SELECT id FROM learn_log').all()).toHaveLength(0);
+  });
+
+  test('session summary remains projectless outside learnings', () => {
+    const session = handleSessionSummary(`authority-${Date.now()}`, 'Session summary remains outside learnings.');
+    expect(session.source_file).toStartWith('ψ/memory/session-summaries/');
+    expect(existsSync(join(repoRoot, session.source_file))).toBe(true);
+    expect(session.source_file).not.toContain('/learnings/');
+    const row = dbMod.db.select().from(dbMod.oracleDocuments).where(eq(dbMod.oracleDocuments.id, session.learning_id)).get();
+    expect(row?.project).toBeNull();
+  });
+});

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -20,6 +20,9 @@ import { detectProject } from './project-detect.ts';
 import { coerceConcepts } from '../tools/learn.ts';
 import { createVectorProxy } from './vector-proxy.ts';
 import { buildLearningMarkdown, dateSlug } from '../learn/markdown.ts';
+import { resolveProjectAuthority } from '../learn/authority.ts';
+import { reserveGeneratedLearning, resolveVaultLearnTarget } from '../learn/target.ts';
+import { getVaultPsiRoot } from '../vault/discovery.ts';
 import { localNativeVectorDisabledReason, localVectorIndexMissingReason, logLocalVectorDisabled, noteLocalVectorEnabled } from '../vector/cpu-capabilities.ts';
 import { isVectorSectionEnabled } from '../vector/config.ts';
 import { candidatePoolSize } from '../search/retrieve-depth.ts';
@@ -712,6 +715,51 @@ export function persistLearningDoc(opts: {
 }): { file: string; id: string } {
   const { pattern, subdir, filename, id } = opts;
   const now = new Date();
+
+  if (subdir === 'ψ/memory/learnings') {
+    const authority = resolveProjectAuthority(opts.project, {
+      explicit: Object.prototype.hasOwnProperty.call(opts, 'project'),
+    });
+    if ('invalid' in authority) throw new TypeError('Invalid project authority');
+    const project = authority.project;
+    const vault = getVaultPsiRoot();
+    const target = resolveVaultLearnTarget(
+      project,
+      'path' in vault ? vault.path : null,
+      subdir,
+      currentRepoRoot(),
+    );
+    const title = pattern.split('\n')[0].substring(0, 80);
+    const conceptsList = coerceConcepts(opts.concepts);
+    let frontmatter = '';
+    const reserved = reserveGeneratedLearning({
+      dateStr: dateSlug(now),
+      slug: filename.replace(/^\d{4}-\d{2}-\d{2}_/, '').replace(/\.md$/, ''),
+      target,
+      idExists: (candidateId) => !!db.select({ id: oracleDocuments.id }).from(oracleDocuments)
+        .where(eq(oracleDocuments.id, candidateId)).get(),
+      content: ({ id: finalId }) => (frontmatter = buildLearningMarkdown({
+        id: finalId, pattern, title, concepts: conceptsList, createdAt: now,
+        source: opts.source, project, footer: opts.footer,
+      })),
+    });
+
+    try {
+      db.insert(oracleDocuments).values({
+        id: reserved.id, type: 'learning', sourceFile: reserved.sourceFile,
+        concepts: JSON.stringify(conceptsList), createdAt: now.getTime(), updatedAt: now.getTime(),
+        indexedAt: now.getTime(), origin: opts.origin || null, project,
+        createdBy: opts.createdBy || 'oracle_learn',
+      }).run();
+      sqlite.prepare('DELETE FROM oracle_fts WHERE id = ?').run(reserved.id);
+      sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
+        .run(reserved.id, frontmatter, conceptsList.join(' '));
+      logLearning(reserved.id, pattern, opts.source || 'Oracle Learn', conceptsList, project ?? undefined);
+    } catch (error) {
+      throw new Error(`Learning persistence failed after file reservation; orphan file: ${reserved.filePath}`, { cause: error });
+    }
+    return { file: reserved.sourceFile, id: reserved.id };
+  }
 
   const dir = path.join(currentRepoRoot(), subdir);
   fs.mkdirSync(dir, { recursive: true });

--- a/src/tools/__tests__/learn-authority-manifest.test.ts
+++ b/src/tools/__tests__/learn-authority-manifest.test.ts
@@ -1,0 +1,132 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { Elysia } from 'elysia';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { OracleLearnInput, OracleSearchInput } from '../types.ts';
+
+// Compile-time contract fixtures (type-checked by `bun run build`). oracle_learn
+// MUST accept an explicit null project (matching its JSON schema + handler); a
+// silent swap that widens OracleSearchInput instead would fail to type-check here.
+const _learnNullProject = { pattern: 'x', project: null } satisfies OracleLearnInput;
+// @ts-expect-error — oracle_search project is a plain optional string, never null.
+const _searchNullProject = { query: 'x', project: null } satisfies OracleSearchInput;
+void _learnNullProject;
+void _searchNullProject;
+
+const saved = Object.fromEntries(['ORACLE_DATA_DIR', 'ORACLE_DB_PATH', 'ORACLE_REPO_ROOT', 'GHQ_ROOT', 'ORACLE_INDEXER_ENQUEUE']
+  .map((key) => [key, process.env[key]]));
+const root = join(tmpdir(), `arra-mcp-learn-authority-${Date.now()}`);
+const ghqRoot = join(root, 'ghq');
+const vaultRoot = join(ghqRoot, 'github.com', 'test', 'oracle-vault');
+let vectors: Array<Record<string, any>> = [];
+mkdirSync(vaultRoot, { recursive: true });
+mkdirSync(join(vaultRoot, '.git'));
+process.env.ORACLE_DATA_DIR = join(root, 'data');
+process.env.ORACLE_DB_PATH = join(root, 'data', 'oracle.db');
+process.env.ORACLE_REPO_ROOT = join(root, 'server', 'github.com', 'server', 'checkout');
+process.env.GHQ_ROOT = ghqRoot;
+process.env.ORACLE_INDEXER_ENQUEUE = '0';
+
+const vectorStore = { addDocuments: async (docs: Array<Record<string, any>>) => { vectors.push(...docs); } };
+mock.module('../../vector/factory.ts', () => ({
+  EMBEDDING_MODELS: [],
+  createVectorStore: () => vectorStore,
+  createVectorStoreForModel: () => vectorStore,
+  ensureVectorStoreConnected: async () => vectorStore,
+  getEmbeddingModels: () => [],
+  getVectorStoreByModel: () => vectorStore,
+  getVectorStoreConfigByModel: () => ({ type: 'mock', collection: 'mock' }),
+}));
+const dbMod = await import('../../db/index.ts');
+dbMod.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+dbMod.setSetting('vault_repo', 'github.com/test/oracle-vault');
+mock.module('../../vault/discovery.ts', () => ({ getVaultPsiRoot: () => ({ path: vaultRoot }) }));
+const { mcpToolByName } = await import('../mcp-manifest.ts');
+const { createLearnCrudRoutes } = await import('../../routes/learn/index.ts');
+const runtime = {
+  version: 'test',
+  getToolCtx: async () => ({
+    db: dbMod.db, sqlite: dbMod.sqlite, repoRoot: process.env.ORACLE_REPO_ROOT!,
+    vectorStore: { addDocuments: async (docs: Array<Record<string, any>>) => { vectors.push(...docs); } },
+    vectorStatus: 'unknown' as const, version: 'test',
+  }),
+};
+async function learn(arguments_: Record<string, unknown>) {
+  const response = await mcpToolByName.get('oracle_learn')!.handler(arguments_, runtime as any);
+  return { response, payload: JSON.parse(response.content[0].text) };
+}
+
+beforeEach(() => {
+  vectors = [];
+  for (const table of ['indexing_jobs', 'learn_log', 'oracle_fts', 'oracle_documents']) dbMod.sqlite.run(`DELETE FROM ${table}`);
+  for (const dir of ['github.com', '_universal']) rmSync(join(vaultRoot, dir), { recursive: true, force: true });
+});
+
+afterAll(() => {
+  dbMod.resetDefaultDatabaseForTests(':memory:');
+  for (const [key, value] of Object.entries(saved)) value === undefined ? delete process.env[key] : process.env[key] = value;
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('registered oracle_learn project authority', () => {
+  test('valid explicit project matches file, DB, and vector metadata', async () => {
+    const project = 'github.com/acme/widgets';
+    const { payload } = await learn({ pattern: 'MCP project-first placement', project });
+    expect(payload.file).toStartWith(`${project}/ψ/memory/learnings/`);
+    expect(existsSync(join(vaultRoot, payload.file))).toBe(true);
+    const row = dbMod.db.select().from(dbMod.oracleDocuments).where(eq(dbMod.oracleDocuments.id, payload.id)).get();
+    expect(row?.project).toBe(project);
+    expect(vectors[0]?.metadata.project).toBe(project);
+    expect(vectors[0]?.metadata.source_file).toBe(payload.file);
+  });
+
+  test('explicit null and omitted ignore server cwd and source prose', async () => {
+    for (const args of [
+      { pattern: 'MCP explicit universal', project: null },
+      { pattern: 'MCP omitted universal', source: 'from github.com/evil/decoy' },
+    ]) {
+      const { payload } = await learn(args);
+      expect(payload.file).toStartWith('_universal/ψ/memory/learnings/');
+      const row = dbMod.db.select().from(dbMod.oracleDocuments).where(eq(dbMod.oracleDocuments.id, payload.id)).get();
+      expect(row?.project).toBeNull();
+      expect(vectors.at(-1)?.metadata.project).toBe('');
+    }
+  });
+
+  test('malformed explicit stops before file, DB, FTS, vector, or queue effects', async () => {
+    for (const project of [
+      'owner/repo', 'https://github.com/acme/widgets', 'unknown', vaultRoot, process.env.ORACLE_REPO_ROOT!,
+      'github.com/acme/widget space', 'github.com/acme/widget?x', 'github.com/acme/widget#x',
+      'github.com/acme/widget:tag', 'github.com/acme/widget@x', 'github.com/acme/widgets.git',
+      'github.com/acme/widget🔥', `github.com/${'a'.repeat(101)}/widgets`,
+    ]) {
+      const { response } = await learn({ pattern: `MCP reject ${project}`, project });
+      expect(response.isError).toBe(true);
+      expect(dbMod.sqlite.query('SELECT id FROM oracle_documents').all()).toHaveLength(0);
+      expect(dbMod.sqlite.query('SELECT id FROM oracle_fts').all()).toHaveLength(0);
+      expect(dbMod.sqlite.query('SELECT id FROM learn_log').all()).toHaveLength(0);
+      expect(dbMod.sqlite.query('SELECT document_id FROM oracle_entity_links').all()).toHaveLength(0);
+      expect(dbMod.sqlite.query('SELECT id FROM indexing_jobs').all()).toHaveLength(0);
+      expect(vectors).toHaveLength(0);
+      expect(Array.from(new Bun.Glob('**/*.md').scanSync(vaultRoot))).toHaveLength(0);
+    }
+  });
+
+  test('MCP then HTTP same-day same-slug reserves a cross-writer suffix', async () => {
+    const project = 'github.com/acme/widgets';
+    const pattern = 'Cross writer shared collision';
+    const first = await learn({ pattern, project });
+    const app = new Elysia({ prefix: '/api' }).use(createLearnCrudRoutes());
+    const response = await app.handle(new Request('http://local/api/learn', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ pattern, project }),
+    }));
+    const second = await response.json() as Record<string, string>;
+    expect(response.status).toBe(200);
+    expect(second.id).toBe(`${first.payload.id}-2`);
+    expect(existsSync(join(vaultRoot, first.payload.file))).toBe(true);
+    expect(existsSync(join(vaultRoot, second.file))).toBe(true);
+  });
+});

--- a/src/tools/__tests__/learn-enqueue.test.ts
+++ b/src/tools/__tests__/learn-enqueue.test.ts
@@ -1,19 +1,6 @@
-/**
- * M5 — verifies the env-gated enqueue branch in handleLearn.
- *
- * Cases:
- *   - default (env unset) → no enqueue (existing inline-embed path runs;
- *     embedder may fail in tests without Ollama, but ingest still succeeds)
- *   - ORACLE_INDEXER_ENQUEUE=1 → one row per registered model in indexing_jobs
- *   - enqueue throws → ingest still succeeds (graceful: degrade > error)
- *   - any value other than literal "1" → no enqueue (strict equality)
- *
- * Hermetic: tmp dir for writes (set ORACLE_REPO_ROOT before importing
- * learn.ts via dynamic import, since main's REPO_ROOT is module-frozen),
- * :memory: SQLite, no Ollama needed (default path will fail-soft).
- */
+/** Hermetic enqueue coverage: temp vault, fake vectors, in-memory SQLite. */
 
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
 import path from 'path';
 import os from 'os';
 import fs from 'fs';
@@ -21,7 +8,6 @@ import Database from 'bun:sqlite';
 import { drizzle } from 'drizzle-orm/bun-sqlite';
 import * as schema from '../../db/schema.ts';
 import type { ToolContext } from '../types.ts';
-
 const FULL_SCHEMA = `
 CREATE TABLE oracle_documents (
   id TEXT PRIMARY KEY,
@@ -48,12 +34,16 @@ CREATE TABLE indexing_jobs (
   doc_id TEXT NOT NULL,
   model_key TEXT NOT NULL,
   collection TEXT NOT NULL,
+  content_hash TEXT NOT NULL,
+  operation TEXT NOT NULL DEFAULT 'upsert',
   status TEXT NOT NULL DEFAULT 'pending',
   attempts INTEGER NOT NULL DEFAULT 0,
   created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')*1000),
   claimed_at INTEGER,
+  lease_expires_at INTEGER,
   finished_at INTEGER,
-  error TEXT
+  error TEXT,
+  UNIQUE(model_key, doc_id, content_hash, operation)
 );
 `;
 
@@ -61,6 +51,24 @@ const ORIGINAL_ENQUEUE = process.env.ORACLE_INDEXER_ENQUEUE;
 const ORIGINAL_REPO_ROOT = process.env.ORACLE_REPO_ROOT;
 const ORIGINAL_EMBEDDER = process.env.ORACLE_EMBEDDER;
 const ORIGINAL_EMBEDDING_PROVIDER = process.env.ORACLE_EMBEDDING_PROVIDER;
+const TEST_VAULT_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-learn-m5-vault-'));
+const vectorWrites: Array<Array<{ id: string; metadata?: Record<string, unknown> }>> = [];
+const fakeVectorStore = {
+  addDocuments: async (docs: Array<{ id: string; metadata?: Record<string, unknown> }>) => {
+    vectorWrites.push(docs);
+  },
+};
+mock.module('../../vector/factory.ts', () => ({
+  getVectorStoreByModel: () => fakeVectorStore,
+  getEmbeddingModels: () => ({
+    'bge-m3': { collection: 'test-bge-m3' },
+    nomic: { collection: 'test-nomic' },
+    qwen3: { collection: 'test-qwen3' },
+  }),
+}));
+mock.module('../../vault/discovery.ts', () => ({
+  getVaultPsiRoot: () => ({ path: TEST_VAULT_ROOT }),
+}));
 
 interface Harness {
   ctx: ToolContext;
@@ -77,7 +85,7 @@ function makeHarness(): Harness {
     db,
     sqlite,
     repoRoot: tmpRoot,
-    // vectorStore is irrelevant to handleLearn — it doesn't touch it.
+    // handleLearn uses the module-injected fake vector store.
     vectorStore: null as unknown as ToolContext['vectorStore'],
     vectorStatus: 'unknown',
     version: 'test',
@@ -90,41 +98,34 @@ function cleanupHarness(h: Harness): void {
   try { fs.rmSync(h.tmpRoot, { recursive: true, force: true }); } catch {}
 }
 
-// Top-level: stable tmp dir, set as ORACLE_REPO_ROOT BEFORE the dynamic
-// import below — main's REPO_ROOT is module-frozen at first import.
+// Set fallback root before importing learn.ts; config paths are module-frozen.
 const SHARED_REPO_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-learn-m5-root-'));
 process.env.ORACLE_REPO_ROOT = SHARED_REPO_ROOT;
 process.env.ORACLE_EMBEDDER = 'none';
 process.env.ORACLE_EMBEDDING_PROVIDER = 'none';
 const createdMarkdownFiles = new Set<string>();
 
-function markdownPathCandidates(relativePath: string): string[] {
-  const dataRoot = process.env.ORACLE_DATA_DIR || path.join(os.homedir(), '.arra-oracle-v2');
-  const tmpRoots = fs.readdirSync(os.tmpdir(), { withFileTypes: true })
-    .filter((entry) => entry.isDirectory() && entry.name.startsWith('arra-'))
-    .map((entry) => path.join(os.tmpdir(), entry.name));
-  const roots = [SHARED_REPO_ROOT, ORIGINAL_REPO_ROOT, process.cwd(), dataRoot, ...tmpRoots]
-    .filter((root): root is string => Boolean(root));
-  return Array.from(new Set(roots)).map((root) => path.join(root, relativePath));
+function markdownPath(relativePath: string): string {
+  const candidate = path.resolve(TEST_VAULT_ROOT, relativePath);
+  const root = path.resolve(TEST_VAULT_ROOT);
+  expect(candidate.startsWith(`${root}${path.sep}`)).toBe(true);
+  return candidate;
 }
 
 function rememberMarkdown(relativePath: string): void {
-  for (const candidate of markdownPathCandidates(relativePath)) {
-    if (fs.existsSync(candidate)) createdMarkdownFiles.add(candidate);
-  }
+  const candidate = markdownPath(relativePath);
+  if (fs.existsSync(candidate)) createdMarkdownFiles.add(candidate);
 }
 
 function readMarkdown(relativePath: string): string {
-  for (const candidate of markdownPathCandidates(relativePath)) {
-    if (fs.existsSync(candidate)) {
-      createdMarkdownFiles.add(candidate);
-      return fs.readFileSync(candidate, 'utf-8');
-    }
+  const candidate = markdownPath(relativePath);
+  if (fs.existsSync(candidate)) {
+    createdMarkdownFiles.add(candidate);
+    return fs.readFileSync(candidate, 'utf-8');
   }
   throw new Error(`Missing learning markdown file: ${relativePath}`);
 }
 
-// Dynamic import after env is set. Top-level await is supported in Bun.
 const { handleLearn } = await import('../learn.ts');
 
 describe('handleLearn — M5 enqueue branch', () => {
@@ -132,6 +133,7 @@ describe('handleLearn — M5 enqueue branch', () => {
 
   beforeEach(() => {
     delete process.env.ORACLE_INDEXER_ENQUEUE;
+    vectorWrites.length = 0;
     h = makeHarness();
   });
 
@@ -162,6 +164,8 @@ describe('handleLearn — M5 enqueue branch', () => {
 
     // Response shape preserved: still has `embedding` field (main's contract)
     expect(parsed.embedding).toBeDefined();
+    expect(vectorWrites).toHaveLength(1);
+    expect(vectorWrites[0][0]?.metadata?.source_file).toBe(parsed.file);
   });
 
   it('writes vault interchange frontmatter fields to the learning markdown file', async () => {
@@ -184,6 +188,11 @@ describe('handleLearn — M5 enqueue branch', () => {
     expect(markdown).toContain(`arra_id: ${parsed.id}`);
     expect(markdown).toContain('arra_type: learning');
     expect(markdown).toContain('arra_concepts: [frontmatter, vector]');
+    expect(vectorWrites[0][0]?.metadata).toMatchObject({
+      source_file: parsed.file,
+      project: '',
+      concepts: 'frontmatter,vector',
+    });
   });
 
   it('ORACLE_INDEXER_ENQUEUE=1 → enqueues one job per registered model', async () => {
@@ -232,6 +241,7 @@ describe('handleLearn — M5 enqueue branch', () => {
 // so we can't rm in afterEach — but we don't want the dir to leak forever).
 process.on('exit', () => {
   try { fs.rmSync(SHARED_REPO_ROOT, { recursive: true, force: true }); } catch {}
+  try { fs.rmSync(TEST_VAULT_ROOT, { recursive: true, force: true }); } catch {}
   if (ORIGINAL_REPO_ROOT) process.env.ORACLE_REPO_ROOT = ORIGINAL_REPO_ROOT;
   if (ORIGINAL_EMBEDDER) process.env.ORACLE_EMBEDDER = ORIGINAL_EMBEDDER;
   else delete process.env.ORACLE_EMBEDDER;

--- a/src/tools/__tests__/learn-vault-frontmatter.test.ts
+++ b/src/tools/__tests__/learn-vault-frontmatter.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import Database from 'bun:sqlite';
 import { drizzle } from 'drizzle-orm/bun-sqlite';
 import fs from 'fs';
@@ -6,8 +6,6 @@ import os from 'os';
 import path from 'path';
 
 import * as schema from '../../db/schema.ts';
-import { REPO_ROOT } from '../../config.ts';
-import { handleLearn } from '../learn.ts';
 import type { ToolContext } from '../types.ts';
 
 const SCHEMA = `
@@ -36,16 +34,23 @@ CREATE TABLE indexing_jobs (
   doc_id TEXT NOT NULL,
   model_key TEXT NOT NULL,
   collection TEXT NOT NULL,
+  content_hash TEXT NOT NULL,
+  operation TEXT NOT NULL DEFAULT 'upsert',
   status TEXT NOT NULL DEFAULT 'pending',
   attempts INTEGER NOT NULL DEFAULT 0,
   created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')*1000),
   claimed_at INTEGER,
+  lease_expires_at INTEGER,
   finished_at INTEGER,
-  error TEXT
+  error TEXT,
+  UNIQUE(model_key, doc_id, content_hash, operation)
 );
 `;
 
 const ORIGINAL_ENQUEUE = process.env.ORACLE_INDEXER_ENQUEUE;
+const vaultRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-learn-frontmatter-vault-'));
+mock.module('../../vault/discovery.ts', () => ({ getVaultPsiRoot: () => ({ path: vaultRoot }) }));
+const { handleLearn } = await import('../learn.ts');
 
 let sqlite: Database;
 let tmpRoot: string;
@@ -67,6 +72,10 @@ afterEach(() => {
   else delete process.env.ORACLE_INDEXER_ENQUEUE;
 });
 
+afterAll(() => {
+  if (fs.existsSync(vaultRoot)) fs.rmSync(vaultRoot, { recursive: true });
+});
+
 describe('handleLearn vault interchange frontmatter', () => {
   test('writes source, tags, and project fields into indexed markdown', async () => {
     const ctx: ToolContext = {
@@ -85,7 +94,9 @@ describe('handleLearn vault interchange frontmatter', () => {
       project: 'github.com/Soul-Brews-Studio/arra-oracle-v3',
     });
     const parsed = JSON.parse(res.content[0].text);
-    filePath = path.join(REPO_ROOT, parsed.file);
+    filePath = path.resolve(vaultRoot, parsed.file);
+    expect(filePath.startsWith(`${path.resolve(vaultRoot)}${path.sep}`)).toBe(true);
+    expect(fs.existsSync(filePath)).toBe(true);
     const row = sqlite.query('SELECT content FROM oracle_fts WHERE id = ?').get(parsed.id) as {
       content: string;
     };

--- a/src/tools/learn.ts
+++ b/src/tools/learn.ts
@@ -5,13 +5,13 @@
  * Exports normalizeProject and extractProjectFromSource for testability.
  */
 
-import path from 'path';
-import fs from 'fs';
+import { eq } from 'drizzle-orm';
 import { oracleDocuments } from '../db/schema.ts';
-import { detectProject } from '../server/project-detect.ts';
 import { getVectorStoreByModel, getEmbeddingModels } from '../vector/factory.ts';
 import { REPO_ROOT } from '../config.ts';
-import { buildLearningMarkdown, dateSlug } from '../learn/markdown.ts';
+import { buildLearningMarkdown, dateSlug, learningSlug } from '../learn/markdown.ts';
+import { resolveProjectAuthority } from '../learn/authority.ts';
+import { reserveGeneratedLearning, resolveVaultLearnTarget } from '../learn/target.ts';
 
 // Lazy-loaded on first use — avoids top-level await which causes a TDZ
 // error in consumers that import learnToolDef synchronously (the tools
@@ -29,10 +29,10 @@ async function loadEnqueue(): Promise<typeof enqueueIndexJob> {
   }
   return enqueueIndexJob;
 }
-let getVaultPsiRootFn: typeof import('../vault/handler.ts').getVaultPsiRoot | null = null;
-async function loadGetVaultPsiRoot(): Promise<typeof import('../vault/handler.ts').getVaultPsiRoot> {
+let getVaultPsiRootFn: typeof import('../vault/discovery.ts').getVaultPsiRoot | null = null;
+async function loadGetVaultPsiRoot(): Promise<typeof import('../vault/discovery.ts').getVaultPsiRoot> {
   if (!getVaultPsiRootFn) {
-    getVaultPsiRootFn = (await import('../vault/handler.ts')).getVaultPsiRoot;
+    getVaultPsiRootFn = (await import('../vault/discovery.ts')).getVaultPsiRoot;
   }
   return getVaultPsiRootFn;
 }
@@ -65,8 +65,8 @@ export const learnToolDef = {
         description: 'Optional concept tags (e.g., ["git", "safety", "trust"])'
       },
       project: {
-        type: 'string',
-        description: 'Source project. Accepts: "github.com/owner/repo", "owner/repo", local path with ghq/Code prefix, or GitHub URL. Auto-normalized to "github.com/owner/repo" format.'
+        type: ['string', 'null'],
+        description: 'Canonical source project such as "github.com/owner/repo", or null for universal.'
       }
     },
     required: ['pattern']
@@ -186,16 +186,18 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
 
   const now = new Date();
   const dateStr = dateSlug(now);
+  const slug = learningSlug(pattern);
 
-  const slug = pattern
-    .substring(0, 50)
-    .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, '')
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '');
-
-  const filename = `${dateStr}_${slug}.md`;
+  const authority = resolveProjectAuthority(projectInput, {
+    explicit: Object.prototype.hasOwnProperty.call(input, 'project'),
+  });
+  if ('invalid' in authority) {
+    return {
+      content: [{ type: 'text', text: JSON.stringify({ success: false, error: 'Invalid project authority' }, null, 2) }],
+      isError: true,
+    };
+  }
+  const project = authority.project;
 
   // Resolve vault root for central writes
   const getVaultPsiRoot = await loadGetVaultPsiRoot();
@@ -203,66 +205,41 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
   if ('needsInit' in vault) console.error(`[Vault] ${vault.hint}`);
   const vaultRoot = 'path' in vault ? vault.path : null;
 
-  const project = normalizeProject(projectInput)
-    || extractProjectFromSource(source)
-    || detectProject(ctx.repoRoot);
-  const projectDir = (project || '_universal').toLowerCase();
-
-  let filePath: string;
-  let sourceFileRel: string;
-  if (vaultRoot) {
-    const dir = path.join(vaultRoot, projectDir, 'ψ', 'memory', 'learnings');
-    fs.mkdirSync(dir, { recursive: true });
-    filePath = path.join(dir, filename);
-    sourceFileRel = `${projectDir}/ψ/memory/learnings/${filename}`;
-  } else {
-    // Write to canonical REPO_ROOT, not ctx.repoRoot (the MCP server's cwd):
-    // the dashboard's /api/file resolves source_file against REPO_ROOT, so
-    // writing relative to cwd produces "local file not found" (#557).
-    const dir = path.join(REPO_ROOT, 'ψ/memory/learnings');
-    fs.mkdirSync(dir, { recursive: true });
-    filePath = path.join(dir, filename);
-    sourceFileRel = `ψ/memory/learnings/${filename}`;
-  }
-
-  if (fs.existsSync(filePath)) {
-    throw new Error(`File already exists: ${filename}`);
-  }
-
-  const id = `learning_${dateStr}_${slug}`;
   const title = pattern.split('\n')[0].substring(0, 80);
   const conceptsList = coerceConcepts(concepts);
-  const frontmatter = buildLearningMarkdown({
-    id,
-    pattern,
-    title,
-    concepts: conceptsList,
-    createdAt: now,
-    source,
-    project,
+  const target = resolveVaultLearnTarget(project, vaultRoot, 'ψ/memory/learnings', REPO_ROOT);
+  let frontmatter = '';
+  const reserved = reserveGeneratedLearning({
+    dateStr,
+    slug,
+    target,
+    idExists: (id) => !!ctx.db.select({ id: oracleDocuments.id }).from(oracleDocuments).where(eq(oracleDocuments.id, id)).get(),
+    content: ({ id }) => (frontmatter = buildLearningMarkdown({
+      id, pattern, title, concepts: conceptsList, createdAt: now, source, project,
+    })),
   });
+  const { id, sourceFile: sourceFileRel, filePath } = reserved;
 
-  fs.writeFileSync(filePath, frontmatter, 'utf-8');
+  try {
+    ctx.db.insert(oracleDocuments).values({
+      id,
+      type: 'learning',
+      sourceFile: sourceFileRel,
+      concepts: JSON.stringify(conceptsList),
+      createdAt: now.getTime(),
+      updatedAt: now.getTime(),
+      indexedAt: now.getTime(),
+      origin: null,
+      project,
+      createdBy: 'oracle_learn',
+    }).run();
 
-  ctx.db.insert(oracleDocuments).values({
-    id,
-    type: 'learning',
-    sourceFile: sourceFileRel,
-    concepts: JSON.stringify(conceptsList),
-    createdAt: now.getTime(),
-    updatedAt: now.getTime(),
-    indexedAt: now.getTime(),
-    origin: null,
-    project,
-    createdBy: 'oracle_learn',
-  }).run();
-
-  // FTS5 has no unique constraint on id — delete-then-insert to be idempotent.
-  ctx.sqlite.prepare(`DELETE FROM oracle_fts WHERE id = ?`).run(id);
-  ctx.sqlite.prepare(`
-    INSERT INTO oracle_fts (id, content, concepts)
-    VALUES (?, ?, ?)
-  `).run(id, frontmatter, conceptsList.join(' '));
+    ctx.sqlite.prepare(`DELETE FROM oracle_fts WHERE id = ?`).run(id);
+    ctx.sqlite.prepare(`INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)`)
+      .run(id, frontmatter, conceptsList.join(' '));
+  } catch (error) {
+    throw new Error(`Learning persistence failed after file reservation; orphan file: ${filePath}`, { cause: error });
+  }
 
   // Vector indexing — two paths:
   //   - Default (env unset): inline embed via Ollama. Keeps DB + lancedb in

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -55,7 +55,7 @@ export interface OracleLearnInput {
   pattern: string;
   source?: string;
   concepts?: string[];
-  project?: string;
+  project?: string | null;
 }
 
 export interface OracleListInput {

--- a/src/trace/__tests__/learning-files-authority.test.ts
+++ b/src/trace/__tests__/learning-files-authority.test.ts
@@ -1,0 +1,50 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const saved = Object.fromEntries(['ORACLE_DATA_DIR', 'ORACLE_DB_PATH', 'ORACLE_REPO_ROOT', 'GHQ_ROOT']
+  .map((key) => [key, process.env[key]]));
+const root = join(tmpdir(), `arra-trace-learn-${Date.now()}`);
+const vaultRoot = join(root, 'ghq/github.com/test/oracle-vault');
+mkdirSync(vaultRoot, { recursive: true });
+mkdirSync(join(vaultRoot, '.git'));
+process.env.ORACLE_DATA_DIR = join(root, 'data');
+process.env.ORACLE_DB_PATH = join(root, 'data/oracle.db');
+process.env.ORACLE_REPO_ROOT = join(root, 'repo');
+process.env.GHQ_ROOT = join(root, 'ghq');
+const dbMod = await import('../../db/index.ts');
+dbMod.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+dbMod.setSetting('vault_repo', 'github.com/test/oracle-vault');
+mock.module('../../vault/discovery.ts', () => ({ getVaultPsiRoot: () => ({ path: vaultRoot }) }));
+const { processLearnings } = await import('../learning-files.ts');
+
+beforeEach(() => {
+  for (const table of ['indexing_jobs', 'learn_log', 'oracle_fts', 'oracle_documents']) dbMod.sqlite.run(`DELETE FROM ${table}`);
+  rmSync(join(vaultRoot, 'github.com'), { recursive: true, force: true });
+  rmSync(join(vaultRoot, '_universal'), { recursive: true, force: true });
+});
+afterAll(() => {
+  dbMod.resetDefaultDatabaseForTests(':memory:');
+  for (const [key, value] of Object.entries(saved)) value === undefined ? delete process.env[key] : process.env[key] = value;
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('trace learning file writer', () => {
+  test('writes project-first canonical markdown while remaining file-only', () => {
+    const [file] = processLearnings(['Trace file-only alignment'], 'github.com/acme/widgets', 'authority query');
+    expect(file).toStartWith('github.com/acme/widgets/ψ/memory/learnings/');
+    expect(existsSync(join(vaultRoot, file))).toBe(true);
+    expect(dbMod.sqlite.query('SELECT id FROM oracle_documents').all()).toHaveLength(0);
+    expect(dbMod.sqlite.query('SELECT id FROM oracle_fts').all()).toHaveLength(0);
+    expect(dbMod.sqlite.query('SELECT id FROM learn_log').all()).toHaveLength(0);
+    expect(dbMod.sqlite.query('SELECT id FROM indexing_jobs').all()).toHaveLength(0);
+  });
+
+  test('null authority uses universal path without unknown sentinel', () => {
+    const [file] = processLearnings(['Trace universal alignment'], null, 'universal query');
+    expect(file).toStartWith('_universal/ψ/memory/learnings/');
+    const markdown = Bun.file(join(vaultRoot, file));
+    expect(markdown.text()).resolves.not.toContain('project: unknown');
+  });
+});

--- a/src/trace/__tests__/storage-edge.test.ts
+++ b/src/trace/__tests__/storage-edge.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, test } from 'bun:test';
+import { afterAll, describe, expect, mock, test } from 'bun:test';
 import { mkdirSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -7,12 +7,15 @@ const savedDataDir = process.env.ORACLE_DATA_DIR;
 const savedDbPath = process.env.ORACLE_DB_PATH;
 const root = join(tmpdir(), `arra-trace-store-${Date.now()}-${Math.random().toString(16).slice(2)}`);
 const dbPath = join(root, 'oracle.db');
+const vaultRoot = join(root, 'vault');
 mkdirSync(root, { recursive: true });
+mkdirSync(vaultRoot, { recursive: true });
 process.env.ORACLE_DATA_DIR = root;
 process.env.ORACLE_DB_PATH = dbPath;
 
 const dbMod = await import('../../db/index.ts');
 dbMod.resetDefaultDatabaseForTests(dbPath);
+mock.module('../../vault/discovery.ts', () => ({ getVaultPsiRoot: () => ({ path: vaultRoot }) }));
 const { createTrace, getTrace, listTraces } = await import('../handler.ts');
 
 const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
@@ -80,5 +83,31 @@ describe('trace storage edge hardening', () => {
 
     expect(result.traces).toHaveLength(1);
     expect(result.hasMore).toBe(false);
+  });
+
+  test('explicit empty and malformed project stop before learning file and trace row', () => {
+    for (const project of ['', 'owner/repo', 'github.com/acme/widgets.git']) {
+      const beforeRows = dbMod.sqlite.query('SELECT count(*) AS n FROM trace_log').get() as { n: number };
+      const beforeFiles = Array.from(new Bun.Glob('**/*.md').scanSync(vaultRoot));
+      expect(() => createTrace({ query: `invalid authority ${project}`, project, foundLearnings: ['must not write'] }))
+        .toThrow('Invalid project authority');
+      const afterRows = dbMod.sqlite.query('SELECT count(*) AS n FROM trace_log').get() as { n: number };
+      expect(afterRows.n).toBe(beforeRows.n);
+      expect(Array.from(new Bun.Glob('**/*.md').scanSync(vaultRoot))).toEqual(beforeFiles);
+    }
+  });
+
+  test('omitted project writes universal and mixed-case project stores canonical authority', () => {
+    const universal = createTrace({ query: 'omitted authority', foundLearnings: ['universal trace learning'] });
+    const universalTrace = getTrace(universal.traceId);
+    expect(universalTrace?.project).toBeNull();
+    expect(universalTrace?.foundLearnings[0]).toStartWith('_universal/ψ/memory/learnings/');
+
+    const canonical = createTrace({
+      query: 'canonical authority', project: 'GitHub.com/Acme/Widgets', foundLearnings: ['project trace learning'],
+    });
+    const canonicalTrace = getTrace(canonical.traceId);
+    expect(canonicalTrace?.project).toBe('github.com/acme/widgets');
+    expect(canonicalTrace?.foundLearnings[0]).toStartWith('github.com/acme/widgets/ψ/memory/learnings/');
   });
 });

--- a/src/trace/learning-files.ts
+++ b/src/trace/learning-files.ts
@@ -1,62 +1,48 @@
-import { existsSync, mkdirSync, writeFileSync } from 'fs';
-import { dirname, join } from 'path';
+import { eq } from 'drizzle-orm';
 import { REPO_ROOT } from '../config.ts';
+import { db, oracleDocuments } from '../db/index.ts';
+import { resolveProjectAuthority } from '../learn/authority.ts';
+import { buildLearningMarkdown, dateSlug, learningSlug } from '../learn/markdown.ts';
+import { reserveGeneratedLearning, resolveVaultLearnTarget } from '../learn/target.ts';
+import { getVaultPsiRoot } from '../vault/discovery.ts';
 
 function isLearningFilePath(learning: string): boolean {
   return learning.startsWith('ψ/') || learning.includes('/memory/learnings/');
 }
 
-function dateStamp(now = new Date()): string {
-  return [
-    now.getFullYear(),
-    String(now.getMonth() + 1).padStart(2, '0'),
-    String(now.getDate()).padStart(2, '0'),
-  ].join('-');
-}
-
-function slugifySnippet(text: string): string {
-  const slug = text
-    .slice(0, 50)
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
-  return slug || 'learning';
-}
-
-function yamlSafe(value: string): string {
-  return JSON.stringify(value).replace(/^"|"$/g, '');
-}
-
-function createLearningFile(text: string, project: string | null, traceQuery: string): string {
-  const dateStr = dateStamp();
-  const filename = `${dateStr}_trace-${slugifySnippet(text)}.md`;
-  const relativePath = `ψ/memory/learnings/${filename}`;
-  const fullPath = join(REPO_ROOT, relativePath);
-  const title = text.slice(0, 80).trim() || 'Trace learning';
-
-  const dir = dirname(fullPath);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-
-  const content = `---
-title: ${yamlSafe(title)}
-tags: [trace-learning${project ? `, ${project.split('/').pop()}` : ''}]
-created: ${dateStr}
-source: Trace discovery
-project: ${project || 'unknown'}
-trace_query: "${traceQuery.replace(/"/g, '\\"')}"
----
-
-# ${title}
-
-${text}
-
----
-*Auto-generated from trace: "${traceQuery}"*
-${project ? `*Source project: ${project}*` : ''}
-`;
-
-  writeFileSync(fullPath, content, 'utf-8');
-  return relativePath;
+function createLearningFile(text: string, projectInput: string | null, traceQuery: string): string {
+  const authority = resolveProjectAuthority(projectInput, { explicit: true });
+  if ('invalid' in authority) throw new TypeError('Invalid project authority');
+  const project = authority.project;
+  const now = new Date();
+  const vault = getVaultPsiRoot();
+  const target = resolveVaultLearnTarget(
+    project,
+    'path' in vault ? vault.path : null,
+    'ψ/memory/learnings',
+    process.env.ORACLE_REPO_ROOT || REPO_ROOT,
+  );
+  const pattern = text.trim();
+  const title = pattern.slice(0, 80) || 'Trace learning';
+  const concepts = ['trace-learning', ...(project ? [project.split('/').at(-1)!] : [])];
+  const reserved = reserveGeneratedLearning({
+    dateStr: dateSlug(now),
+    slug: `trace-${learningSlug(pattern)}`,
+    target,
+    idExists: (id) => !!db.select({ id: oracleDocuments.id }).from(oracleDocuments)
+      .where(eq(oracleDocuments.id, id)).get(),
+    content: ({ id }) => buildLearningMarkdown({
+      id,
+      pattern,
+      title,
+      concepts,
+      createdAt: now,
+      source: 'Trace discovery',
+      project,
+      footer: `*Auto-generated from trace: ${traceQuery.replace(/\r?\n/g, ' ').trim()}*`,
+    }),
+  });
+  return reserved.sourceFile;
 }
 
 export function processLearnings(

--- a/src/trace/store.ts
+++ b/src/trace/store.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto';
 import { eq } from 'drizzle-orm';
 import { db, traceLog } from '../db/index.ts';
+import { resolveProjectAuthority } from '../learn/authority.ts';
 import type { CreateTraceInput, CreateTraceResult, TraceRecord } from './types.ts';
 import { processLearnings } from './learning-files.ts';
 import { parseJsonArray, parseTraceRow, serializeJsonArray } from './row.ts';
@@ -19,7 +20,12 @@ export function createTrace(input: CreateTraceInput): CreateTraceResult {
   const traceId = randomUUID();
   const now = Date.now();
   const query = normalizedQuery(input);
-  const processedLearnings = processLearnings(input.foundLearnings, input.project || null, query);
+  const authority = resolveProjectAuthority(input.project, {
+    explicit: Object.prototype.hasOwnProperty.call(input, 'project'),
+  });
+  if ('invalid' in authority) throw new TypeError('Invalid project authority');
+  const project = authority.project;
+  const processedLearnings = processLearnings(input.foundLearnings, project, query);
   const fileCount =
     arrayCount(input.foundFiles) +
     arrayCount(input.foundRetrospectives) +
@@ -52,7 +58,7 @@ export function createTrace(input: CreateTraceInput): CreateTraceResult {
     parentTraceId: parent ? input.parentTraceId! : null,
     childTraceIds: '[]',
     scope: input.scope || 'project',
-    project: input.project || null,
+    project,
     sessionId: input.sessionId || null,
     agentCount: input.agentCount || 1,
     durationMs: input.durationMs || null,

--- a/src/vector/adapters/lancedb.ts
+++ b/src/vector/adapters/lancedb.ts
@@ -118,13 +118,12 @@ export class LanceDBAdapter implements VectorStoreAdapter {
       vector: doc.vector ?? fresh[freshIdx++],
     }));
 
-    await this.table.add(rows);
+    await this.table.mergeInsert('id')
+      .whenMatchedUpdateAll()
+      .whenNotMatchedInsertAll()
+      .execute(rows);
     const reused = docs.length - needEmbed.length;
-    if (reused > 0) {
-      console.error(`[LanceDB] Added ${docs.length} documents (${reused} with precomputed vectors)`);
-    } else {
-      console.error(`[LanceDB] Added ${docs.length} documents`);
-    }
+    console.error(`[LanceDB] Upserted ${docs.length} documents${reused > 0 ? ` (${reused} with precomputed vectors)` : ''}`);
   }
 
   async replaceDocuments(docs: VectorDocument[]): Promise<void> {

--- a/tests/http/learn/crud-edge.test.ts
+++ b/tests/http/learn/crud-edge.test.ts
@@ -36,6 +36,7 @@ async function call(method: string, path: string, body?: unknown) {
 }
 
 beforeEach(() => {
+  rmSync(join(repoRoot, 'ψ/memory/learnings'), { recursive: true, force: true });
   dbMod.db.delete(dbMod.learnLog).run();
   dbMod.db.delete(dbMod.oracleDocuments)
     .where(eq(dbMod.oracleDocuments.type, 'learning'))
@@ -56,7 +57,7 @@ describe('POST/DELETE /api/learn edge cases', () => {
       id: 'learning_edge_explicit',
       pattern: 'Explicit learn edge coverage',
       concepts: 'edge, coverage',
-      sourceFile: 'ψ/memory/learnings/edge-explicit.md',
+      sourceFile: 'ψ/memory/learnings/learning_edge_explicit.md',
     });
     expect(created.status).toBe(200);
     expect(created.json).toMatchObject({ id: 'learning_edge_explicit' });
@@ -106,7 +107,7 @@ describe('POST/DELETE /api/learn edge cases', () => {
     const created = await call('POST', '/api/learn', {
       id: 'learning_safe_source',
       pattern: 'Safe learning source',
-      sourceFile: 'ψ/memory/learnings/safe-source.md',
+      sourceFile: 'ψ/memory/learnings/learning_safe_source.md',
     });
     expect(created.status).toBe(200);
 
@@ -114,10 +115,10 @@ describe('POST/DELETE /api/learn edge cases', () => {
       sourceFile: '../../outside.md',
     });
     expect(update.status).toBe(400);
-    expect(update.json.error).toBe('Invalid learning sourceFile');
+    expect(update.json.error).toBe('Learning sourceFile is immutable');
 
     const read = await call('GET', '/api/learn/learning_safe_source');
-    expect(read.json.sourceFile).toBe('ψ/memory/learnings/safe-source.md');
+    expect(read.json.sourceFile).toBe('ψ/memory/learnings/learning_safe_source.md');
   });
 
   test('sanitizes markdown frontmatter scalars when creating learnings', async () => {
@@ -126,14 +127,15 @@ describe('POST/DELETE /api/learn edge cases', () => {
       pattern: 'Frontmatter title\nproject: evil\n---\nbody stays in markdown',
       concepts: ['alpha, beta', 'gamma\nproject: evil'],
       source: 'ui\nhash: fake',
-      sourceFile: 'ψ/memory/learnings/injection-safe.md',
+      sourceFile: 'ψ/memory/learnings/learning_injection_safe.md',
     });
     expect(created.status).toBe(200);
 
-    const markdown = readFileSync(join(repoRoot, 'ψ/memory/learnings/injection-safe.md'), 'utf-8');
+    const markdown = readFileSync(join(repoRoot, created.json.file), 'utf-8');
     const frontmatter = markdown.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? '';
     expect(frontmatter.match(/^source:/gm)).toHaveLength(1);
-    expect(frontmatter.match(/^hash:/gm)).toBeNull();
+    expect(frontmatter.match(/^hash:/gm)).toHaveLength(1);
+    expect(frontmatter).not.toMatch(/^hash: fake$/m);
     expect(frontmatter.match(/^project:/gm)).toBeNull();
     expect(frontmatter).toContain('tags: [alpha beta, gamma project evil]');
     expect(markdown).toContain('body stays in markdown');

--- a/tests/http/learn/crud.test.ts
+++ b/tests/http/learn/crud.test.ts
@@ -43,6 +43,7 @@ async function call(method: string, path: string, body?: unknown) {
 }
 
 beforeEach(() => {
+  rmSync(join(root, 'ψ/memory/learnings'), { recursive: true, force: true });
   dbMod.db.delete(dbMod.learnLog).run();
   dbMod.db.delete(dbMod.oracleDocuments)
     .where(eq(dbMod.oracleDocuments.type, 'learning'))
@@ -111,14 +112,14 @@ describe('POST/GET/PUT/DELETE /api/learn', () => {
     const updated = await call('PUT', `/api/learn/${created.json.id}`, {
       concepts: 'learn,updated',
       origin: 'human',
-      sourceFile: 'ψ/memory/learnings/updated.md',
+      sourceFile: created.json.file,
     });
     expect(updated.status).toBe(200);
     expect(updated.json).toMatchObject({
       id: created.json.id,
       concepts: ['learn', 'updated'],
       origin: 'human',
-      sourceFile: 'ψ/memory/learnings/updated.md',
+      sourceFile: created.json.file,
     });
     expect(updated.json.updatedAt).toBeGreaterThanOrEqual(stored!.updatedAt);
 

--- a/tests/http/learn/project-authority.test.ts
+++ b/tests/http/learn/project-authority.test.ts
@@ -1,0 +1,147 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { eq, sql } from 'drizzle-orm';
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { dateSlug } from '../../../src/learn/markdown.ts';
+import { slugFor } from '../../../src/routes/learn/content.ts';
+
+const saved = Object.fromEntries(['ORACLE_DATA_DIR', 'ORACLE_DB_PATH', 'ORACLE_REPO_ROOT', 'GHQ_ROOT']
+  .map((key) => [key, process.env[key]]));
+const root = join(tmpdir(), `arra-http-learn-authority-${Date.now()}`);
+const dataDir = join(root, 'data');
+const repoRoot = join(root, 'server', 'github.com', 'soul-brews-studio', 'arra-oracle-v3');
+const ghqRoot = join(root, 'ghq');
+const vaultRoot = join(ghqRoot, 'github.com', 'test', 'oracle-vault');
+mkdirSync(repoRoot, { recursive: true });
+mkdirSync(vaultRoot, { recursive: true });
+mkdirSync(join(vaultRoot, '.git'));
+process.env.ORACLE_DATA_DIR = dataDir;
+process.env.ORACLE_DB_PATH = join(dataDir, 'oracle.db');
+process.env.ORACLE_REPO_ROOT = repoRoot;
+process.env.GHQ_ROOT = ghqRoot;
+
+const dbMod = await import('../../../src/db/index.ts');
+dbMod.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+dbMod.setSetting('vault_repo', 'github.com/test/oracle-vault');
+mock.module('../../../src/vault/discovery.ts', () => ({ getVaultPsiRoot: () => ({ path: vaultRoot }) }));
+const { createLearnCrudRoutes } = await import('../../../src/routes/learn/index.ts');
+
+function app() { return new Elysia({ prefix: '/api' }).use(createLearnCrudRoutes()); }
+async function call(method: string, path: string, body?: unknown) {
+  const res = await app().handle(new Request(`http://local${path}`, {
+    method,
+    headers: body === undefined ? undefined : { 'content-type': 'application/json' },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  }));
+  return { status: res.status, body: await res.json() as Record<string, any> };
+}
+function count(table: string): number {
+  return Number((dbMod.sqlite.query(`SELECT count(*) AS n FROM ${table}`).get() as { n: number }).n);
+}
+function effects() {
+  return ['oracle_documents', 'oracle_fts', 'learn_log', 'oracle_entity_links', 'indexing_jobs']
+    .map((table) => count(table))
+    .concat(Array.from(new Bun.Glob('**/*.md').scanSync(vaultRoot)).length);
+}
+
+beforeEach(() => {
+  for (const table of ['oracle_entity_links', 'indexing_jobs', 'learn_log', 'oracle_fts', 'oracle_documents']) {
+    dbMod.sqlite.run(`DELETE FROM ${table}`);
+  }
+  for (const dir of ['github.com', '_universal']) rmSync(join(vaultRoot, dir), { recursive: true, force: true });
+});
+
+afterAll(() => {
+  dbMod.resetDefaultDatabaseForTests(':memory:');
+  for (const [key, value] of Object.entries(saved)) value === undefined ? delete process.env[key] : process.env[key] = value;
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('actual HTTP learn route project authority', () => {
+  test('explicit project drives path, DB, log, and frontmatter identically', async () => {
+    const project = 'github.com/acme/widgets';
+    const result = await call('POST', '/api/learn', { pattern: 'HTTP project-first placement', project });
+    expect(result.status).toBe(200);
+    const expected = join(vaultRoot, project, 'ψ/memory/learnings', result.body.file.split('/').at(-1));
+    expect(existsSync(expected)).toBe(true);
+    expect(result.body.file).toStartWith(`${project}/ψ/memory/learnings/`);
+    const row = dbMod.db.select().from(dbMod.oracleDocuments).where(eq(dbMod.oracleDocuments.id, result.body.id)).get();
+    const log = dbMod.db.select().from(dbMod.learnLog).where(eq(dbMod.learnLog.documentId, result.body.id)).get();
+    expect(row?.project).toBe(project);
+    expect(log?.project).toBe(project);
+    expect(readFileSync(expected, 'utf8')).toContain(`project: ${project}`);
+  });
+
+  test('explicit null and omitted source decoy remain universal', async () => {
+    for (const body of [
+      { pattern: 'HTTP explicit universal', project: null },
+      { pattern: 'HTTP omitted universal', source: 'from github.com/evil/decoy' },
+    ]) {
+      const result = await call('POST', '/api/learn', body);
+      expect(result.status).toBe(200);
+      expect(result.body.file).toStartWith('_universal/ψ/memory/learnings/');
+      const row = dbMod.db.select().from(dbMod.oracleDocuments).where(eq(dbMod.oracleDocuments.id, result.body.id)).get();
+      expect(row?.project).toBeNull();
+      expect(existsSync(join(vaultRoot, result.body.file))).toBe(true);
+    }
+  });
+
+  test('malformed explicit authority and cwd-shaped decoys stop with zero effects', async () => {
+    const invalid = [
+      'owner/repo', 'https://github.com/acme/widgets', 'github.com/acme/widgets/extra',
+      'github.com/acme/..', 'github.com/acme/%77idgets', 'github.com/acme\\widgets',
+      'unknown', '_universal', vaultRoot, repoRoot, join(vaultRoot, 'ψ/memory/learnings'),
+      'github.com/acme/widget space', 'github.com/acme/widget?x', 'github.com/acme/widget#x',
+      'github.com/acme/widget:tag', 'github.com/acme/widget@x', 'github.com/acme/widgets.git',
+      'github.com/acme/widget🔥', `github.com/${'a'.repeat(101)}/widgets`,
+    ];
+    for (const project of invalid) {
+      const result = await call('POST', '/api/learn', { pattern: `reject ${project}`, project });
+      expect(result.status).toBe(400);
+      expect(effects()).toEqual([0, 0, 0, 0, 0, 0]);
+    }
+  });
+
+  test('explicit identity enforces flat matching basename and global collisions', async () => {
+    const invalid = [
+      '/absolute.md', '../traversal.md', 'ψ/memory/learnings/nested/file.md',
+      'ψ/memory/learnings/wrong.md',
+    ];
+    for (const sourceFile of invalid) {
+      const result = await call('POST', '/api/learn', {
+        id: 'learning_explicit_safe', pattern: 'explicit safety', sourceFile,
+      });
+      expect(result.status).toBe(400);
+    }
+    dbMod.sqlite.query(`INSERT INTO oracle_documents
+      (id,type,source_file,concepts,created_at,updated_at,indexed_at,tenant_id)
+      VALUES (?,?,?,?,?,?,?,?)`).run('learning_explicit_safe', 'learning', 'other.md', '[]', 1, 1, 1, 'other-tenant');
+    const collision = await call('POST', '/api/learn', {
+      id: 'learning_explicit_safe', pattern: 'explicit collision',
+      sourceFile: 'ψ/memory/learnings/learning_explicit_safe.md',
+    });
+    expect(collision.status).toBe(409);
+  });
+
+  test('generated identity suffixes around a global DB collision from another tenant', async () => {
+    const pattern = 'Global generated collision';
+    const baseId = `learning_${dateSlug(new Date())}_${slugFor(pattern)}`;
+    dbMod.sqlite.query(`INSERT INTO oracle_documents
+      (id,type,source_file,concepts,created_at,updated_at,indexed_at,tenant_id)
+      VALUES (?,?,?,?,?,?,?,?)`).run(baseId, 'learning', 'other.md', '[]', 1, 1, 1, 'other-tenant');
+    const created = await call('POST', '/api/learn', { pattern, project: 'github.com/acme/widgets' });
+    expect(created.status).toBe(200);
+    expect(created.body.id).toBe(`${baseId}-2`);
+  });
+
+  test('update rejects project and sourceFile reclassification except exact no-op', async () => {
+    const created = await call('POST', '/api/learn', { pattern: 'immutable classification', project: 'github.com/acme/widgets' });
+    expect((await call('PUT', `/api/learn/${created.body.id}`, { project: 'github.com/acme/other' })).status).toBe(400);
+    expect((await call('PUT', `/api/learn/${created.body.id}`, { sourceFile: 'ψ/memory/learnings/other.md' })).status).toBe(400);
+    expect((await call('PUT', `/api/learn/${created.body.id}`, {
+      project: 'github.com/acme/widgets', sourceFile: created.body.file,
+    })).status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

Restores durable, hash-incremental vector indexing with SQLite/FTS as canonical state and the indexer daemon as the single normal LanceDB writer.

This PR expands the original `indexing_jobs` table-detection fix into the end-to-end queue lifecycle needed for incremental updates, supersession deletes, historical receipt cleanup, and recovery verification.

### What changed

- Detect `indexing_jobs` through Drizzle so reconciliation does not incorrectly report every item failed.
- Reconcile canonical persisted vector payloads by content hash, with identity `(model_key, doc_id, content_hash, operation)`.
- Use durable leases and batch queue processing; a transient SQLite claim lock defers the daemon polling cycle rather than terminating it.
- Commit the manifest receipt and `done` status only after the daemon's LanceDB write succeeds.
- Add durable `DELETE` jobs for newly superseded chunks and a full-scope sweep for historical manifest receipts outside the active canonical set.
- Exclude `superseded_by` rows from canonical vector sources, including daemon reloads.
- Add an explicit maintenance repair mode (`index-model.ts <model> --repair`) that safely reactivates terminal active UPSERT receipts when physical LanceDB rows have been proven missing. Normal reconciliation remains idempotent.
- Document the queue-only/single-writer contract, operational verification, and recovery procedure.

## Runtime validation

Live validation used the queue and daemon only; no LanceDB files or internal directories were deleted directly.

| Check | Result |
|---|---|
| Historical stale receipts | `248` durable DELETE jobs completed |
| Active canonical manifests | `1452` |
| Fresh physical LanceDB IDs | `1452`; missing `0`, extra `0` |
| Explicit repair | queued and completed `1452` active UPSERTs after physical parity was found missing |
| Final unchanged reconciliation | `queued=0`, `skipped=1452`, `failed=0`, writer=`daemon` |
| Queue | pending/claimed/error = `0/0/0` |
| SQLite | `PRAGMA integrity_check = ok` |
| HTTP vector status | enabled, `1452/1452`, `vector_status=ok` |
| Hybrid semantic smoke test | `vectorAvailable=true`, bge-m3 distance returned |
| Vault verification | clean: drifted/missing/orphaned = `0/0/0` |

Focused validation passed:

```text
bun run build
bun test src/indexer/__tests__/jobs.test.ts \
  src/indexer/__tests__/has-indexing-jobs-table.test.ts \
  src/indexer/__tests__/worker.test.ts \
  src/vector/__tests__/lancedb-stale-handle.test.ts
# 34 pass, 0 fail, 102 assertions
```

## Operational notes

- The private deployment wrapper and scheduled script now describe the actual sequence: disk → SQLite/FTS → durable reconciliation → daemon → LanceDB.
- The wrapper explicitly configures the local Ollama embedder for HTTP semantic search; this is deployment configuration, not part of this public repository.
- A sanitized portable full wrapper reference is available as a [public Gist](https://gist.github.com/DUMPDUMPY/36659bf419ed00f2241f40f54591d95b). It has no credentials, private repository URLs, private paths, or deployment branch assumptions.

## Scope boundary

Deletion propagation is triggered for chunks superseded by indexing and for historical stale manifest receipts. Physical source-file disappearance is not represented as a delete until the source collector detects that disappearance; this PR does not claim otherwise.

## Commits

- `fbf42113` hash-incremental queue reconciliation
- `ac84ac20` batch vector writes and superseded-row lifecycle
- `4fe5afd3` daemon resilience during transient queue locks
- `04cffa8d` historical stale receipt reconciliation and explicit repair support
