### PR TITLE
feat: enrich root / endpoint with debug detail

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -123,7 +123,31 @@ export function createApp({ unifiedPlugins, runtimeRef = createUnifiedRuntimeRef
     .get('/swagger/json', () => Response.redirect('/api/docs/json', 308), { detail: { hide: true } })
     .get('/api/openapi.json', () => Response.redirect('/api/docs/json', 308), { detail: { hide: true } })
     .get('/simple', ({ set }) => simpleModeResponse(set), { detail: { tags: ['frontend'], summary: 'Simple Mode entry page' } })
-    .get('/', () => ({ server: MCP_SERVER_NAME, version: pkg.version, status: 'ok', docs: '/api/docs', api: '/api/v1' }));
+    .get('/', () => ({
+      server: MCP_SERVER_NAME,
+      version: pkg.version,
+      status: 'ok',
+      uptimeSeconds: Math.floor(process.uptime()),
+      plugins: unifiedPlugins.pluginCount,
+      pluginMcpTools: unifiedPlugins.mcpTools.length,
+      docs: '/api/docs',
+      api: '/api/v1',
+      endpoints: {
+        docs: '/api/docs',
+        openapi: '/api/docs/json',
+        api: '/api/v1',
+        mcp: '/mcp',
+        health: '/api/v1/health',
+        simple: '/simple',
+      },
+      config: {
+        port: Number(PORT),
+        dataDir,
+        vector: vectorUrl ? `proxy:${vectorUrl}` : 'local',
+      },
+      runtime: { bun: Bun.version },
+      generatedAt: new Date().toISOString(),
+    }));
 
   const routeModules = createServerRouteModules(unifiedPlugins, runtimeRef);
   mountRouteModules(app, routeModules);


### PR DESCRIPTION
## Overview
The root \`GET /\` endpoint returned only \`server/version/status/docs/api\`. This enriches it with debug-useful detail so a single \`curl /\` answers **"which instance is this, and what data dir does it serve?"** — the exact confusion that cost time today reconciling the shared instance (47778 → \`~/.arra-oracle-v2\`) vs a fresh separate one (47788 → \`~/.arra-oracle-muninn\`).

## Change
\`src/server.ts\` root handler now also returns:
- \`uptimeSeconds\`, \`plugins\`, \`pluginMcpTools\`
- \`endpoints\` map (docs/openapi/api/mcp/health/simple)
- \`config\` — **\`port\`, \`dataDir\`, \`vector\`** ← the debug win
- \`runtime.bun\`, \`generatedAt\`

## Notes
- **Backward-compatible**: all original fields (\`server/version/status/docs/api\`) kept, so existing UI/clients don't break.
- \`pluginMcpTools\` named honestly — it's the plugin-provided MCP tool count only (not the full core MCP tool count), so the \`0\` it reports won't mislead during debugging.
- No \`package.json\` change → no CalVer release triggered.

## Verify
- \`bunx tsc --noEmit\` green
- \`bun test tests/integration/server-boot/composition.test.ts\` → 24 pass
- Real JSON captured via \`app.handle()\` (not guessed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)