### PR TITLE
fix(config): wire the five dead levers in the tool-config surface

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -56,15 +56,23 @@ When the tool list is too large for the task, trim it.
 
 ### Config file / env
 
-Persist a strict allow-list in `.arra/config.json`:
+Persist a strict allow-list in `arra.config.json` (repo root) or
+`~/.arra-oracle-v2/config.json` (global). Both keys are required: `enabled_tools`
+is additive, so an allow-list only becomes exclusive once its complement is in
+`disabled_tools`.
 
 ```json
 {
-  "allowed_tools": ["oracle_search", "oracle_read", "oracle_list", "oracle_stats"]
+  "enabled_tools": ["oracle_search", "oracle_read", "oracle_list", "oracle_stats"],
+  "disabled_tools": ["oracle_learn", "oracle_thread", "oracle_trace"]
 }
 ```
 
-Equivalent env controls are available for deploys and temporary sessions:
+See [mcp-tools.md](./mcp-tools.md) for the full first-match-wins precedence
+chain — a repo-root file shadows the global one rather than merging with it.
+
+Equivalent env controls are available for deploys and temporary sessions. They
+are applied on top of whichever config file wins:
 
 ```bash
 ORACLE_ENABLED_TOOLS=oracle_search,oracle_read,oracle_list,oracle_stats bun src/index.ts
@@ -72,16 +80,21 @@ ORACLE_ENABLED_TOOLS=oracle_search,oracle_read,oracle_list,oracle_stats bun src/
 ORACLE_DISABLED_TOOLS=oracle_trace,oracle_thread bun src/index.ts
 ```
 
-### Web toggle UI
+### HTTP API
 
-Open `/tools/config`. It reads and writes the same MCP tool enablement surface through:
+The same MCP tool enablement surface is reachable over HTTP:
 
 | Endpoint | Purpose |
 | --- | --- |
-| `GET /api/settings/tools` | Read current groups, enabled tools, disabled tools, and config path. |
-| `PUT /api/settings/tools` | Persist selected MCP tools as `allowed_tools`. |
+| `GET /api/v1/settings/tools` | Read current groups, enabled/disabled tools, always-on tools, and the config file that is actually in play (`config_path`, `config_exists`, `env_override`). |
+| `PUT /api/v1/settings/tools` | Persist the selected MCP tools to `config_path` as `enabled_tools` plus the complementary `disabled_tools`. |
 
-Saved toggles apply on the next MCP tool-list refresh / process reload.
+`PUT` writes to the file the loader will read next, so saved toggles apply on the
+next MCP tool-list refresh / process reload. When `env_override` is `true` the
+environment still wins over the saved file.
+
+There is no `/tools/config` web page yet — the menu entry on these routes is
+reserved for one.
 
 ## 3. Connect page, token, and MCP install snippet (#1374)
 

--- a/docs/UNIFIED-PLUGIN.md
+++ b/docs/UNIFIED-PLUGIN.md
@@ -129,12 +129,16 @@ Resolution should stay the same:
 
 1. disabled groups;
 2. `disabled_tools` blocklist;
-3. `enabled_tools` whitelist;
-4. `allowed_tools` strict allow-list.
+3. `enabled_tools` whitelist (additive — pair it with the complementary
+   `disabled_tools` for a strict allow-list).
 
-For groups, plugin tools can use their manifest `group` field. If no group is
-provided, default to `plugin:<manifest.name>`. Existing config files keep working
-because no static tool names change.
+There is no `allowed_tools` key. It was written by the settings API but never
+read by the loader; #2822 removed it rather than leaving a lever that looks
+authoritative and does nothing.
+
+Manifest `group` is inert display metadata and must stay that way — it is not
+validated against `TOOL_GROUPS` and steers no enablement. Existing config files
+keep working because no static tool names change.
 
 ## Mapping existing plugin types
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -6,6 +6,28 @@ arra-oracle-v3 exposes 30 MCP tools across configurable groups, Oracle profiles,
 
 Groups can be enabled/disabled via `arra.config.json` (repo-local) or `~/.arra-oracle-v2/config.json` (global).
 
+**Precedence — FIRST MATCH WINS, tiers are never merged.** The loader takes the
+first file below that carries a tool-config key (`tools`, `plugins`,
+`disabled_tools`, `enabled_tools` or `mcp`) and ignores the rest entirely:
+
+1. `<repo root>/arra.config.json`
+2. `<repo root>/plugins.json` (plugin manifest only)
+3. `$ORACLE_DATA_DIR/config.json` (default `~/.arra-oracle-v2/config.json`)
+4. `$ORACLE_DATA_DIR/plugins.json` (plugin manifest only)
+
+A repo-root file therefore shadows your global config completely — it does not
+add to it. `GET /api/v1/settings/tools` reports the winning file as
+`config_path`, which is also the file `PUT` writes.
+
+Environment variables are applied on top of whichever file wins:
+`ORACLE_ENABLED_TOOLS` is a strict allow-list, `ORACLE_DISABLED_TOOLS` is
+subtractive, and the block list wins where both name the same tool.
+
+> **Known inert:** the top-level `mcp` boolean is parsed and counts toward
+> whether a file is treated as tool config, but nothing reads it — it does not
+> disable the MCP surface. Tracked separately from #2822; use `disabled_tools`
+> for the bridge tools instead.
+
 ```json
 {
   "tools": {
@@ -20,12 +42,13 @@ Groups can be enabled/disabled via `arra.config.json` (repo-local) or `~/.arra-o
 }
 ```
 
-## Search (5 tools)
+## Search (6 tools)
 
 | Tool | Description |
 |------|-------------|
 | `oracle_ask` | Grounded ask over Oracle memory/search. Returns `answer`, `citations`, `citationIndexes`, `warnings`, `noEvidence`, `sources`, and optional `asOf`. |
 | `oracle_search` | Hybrid search (FTS5 keywords + vector similarity). Supports `asOf` valid-time lookup. |
+| `oracle_search_chain` | Multi-hop search that follows citations across documents. |
 | `oracle_read` | Read full content of a document by file path or document ID. |
 | `oracle_list` | Browse all documents without searching. Supports type/date/asOf filters and pagination. |
 | `oracle_concepts` | List all concept tags with document counts. Discover topic coverage. |
@@ -88,6 +111,11 @@ Groups can be enabled/disabled via `arra.config.json` (repo-local) or `~/.arra-o
 | `____IMPORTANT` | Meta-documentation tool — workflow guide shown in tool list. |
 | `oracle_mcp_list_tools` | List tools exposed by configured external MCP servers. |
 | `oracle_mcp_call` | Call a tool exposed by a configured external MCP server. |
+
+The two bridge tools belong to no group **on purpose** (`ALWAYS_ON_TOOLS` in
+`src/config/tool-groups-core.ts`): a config that turns every group off must still
+be able to reach a remote Oracle. This is a default, not a lock — name them in
+`disabled_tools` or `ORACLE_DISABLED_TOOLS` to switch them off.
 
 ## Consolidation governance decision
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -23,10 +23,12 @@ Environment variables are applied on top of whichever file wins:
 `ORACLE_ENABLED_TOOLS` is a strict allow-list, `ORACLE_DISABLED_TOOLS` is
 subtractive, and the block list wins where both name the same tool.
 
-> **Known inert:** the top-level `mcp` boolean is parsed and counts toward
-> whether a file is treated as tool config, but nothing reads it — it does not
-> disable the MCP surface. Tracked separately from #2822; use `disabled_tools`
-> for the bridge tools instead.
+> **`mcp` is a live kill-switch, not a tool filter.** Setting `"mcp": false`
+> removes the Streamable HTTP `/mcp` endpoint entirely —
+> `src/routes/mcp/streamable.ts:30` reads it (`loadToolGroupConfig(repoRoot).mcp !== false`).
+> Verified: `{"mcp": true}` → `POST /mcp` returns 401 (auth challenge, endpoint live);
+> `{"mcp": false}` → 404 (endpoint gone). It does not filter individual tools —
+> use `disabled_tools` for that.
 
 ```json
 {

--- a/src/config/__tests__/tool-env-overrides.test.ts
+++ b/src/config/__tests__/tool-env-overrides.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  ALL_TOOL_NAMES,
+  applyToolEnvOverrides,
+  getDisabledTools,
+  getEnabledToolNames,
+  loadToolGroupConfig,
+  resolveToolConfigSource,
+  type ToolGroupConfig,
+} from '../tool-groups.ts';
+import { configSources } from '../tool-config-source.ts';
+
+const ALL_ON: ToolGroupConfig = {
+  search: true, knowledge: true, session: true,
+  forum: true, oracle: true, trace: true, standalone: true,
+};
+
+const ENV_KEYS = ['ORACLE_ENABLED_TOOLS', 'ORACLE_DISABLED_TOOLS'] as const;
+
+function withEnv(values: Partial<Record<(typeof ENV_KEYS)[number], string>>, run: () => void): void {
+  const previous = ENV_KEYS.map((key) => [key, process.env[key]] as const);
+  try {
+    for (const key of ENV_KEYS) delete process.env[key];
+    for (const [key, value] of Object.entries(values)) process.env[key] = value;
+    run();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+describe('ORACLE_ENABLED_TOOLS / ORACLE_DISABLED_TOOLS', () => {
+  it('treats ORACLE_ENABLED_TOOLS as a strict allow-list', () => {
+    withEnv({ ORACLE_ENABLED_TOOLS: 'oracle_search,oracle_read,oracle_list,oracle_stats' }, () => {
+      const names = getEnabledToolNames(applyToolEnvOverrides(ALL_ON));
+      expect(names.sort()).toEqual(['oracle_list', 'oracle_read', 'oracle_search', 'oracle_stats']);
+    });
+  });
+
+  it('subtracts ORACLE_DISABLED_TOOLS from an otherwise full surface', () => {
+    withEnv({ ORACLE_DISABLED_TOOLS: 'oracle_thread, oracle_threads,oracle_thread_read,oracle_thread_update' }, () => {
+      const config = applyToolEnvOverrides(ALL_ON);
+      const names = getEnabledToolNames(config);
+      expect(names).not.toContain('oracle_thread');
+      expect(names).not.toContain('oracle_thread_update');
+      expect(names).toContain('oracle_search');
+      expect(getDisabledTools(config).has('oracle_threads')).toBe(true);
+    });
+  });
+
+  it('composes both variables, with the block list winning', () => {
+    withEnv({ ORACLE_ENABLED_TOOLS: 'oracle_search,oracle_read', ORACLE_DISABLED_TOOLS: 'oracle_read' }, () => {
+      expect(getEnabledToolNames(applyToolEnvOverrides(ALL_ON))).toEqual(['oracle_search']);
+    });
+  });
+
+  it('can disable an always-on bridge tool from the environment', () => {
+    withEnv({ ORACLE_DISABLED_TOOLS: 'oracle_mcp_call' }, () => {
+      const config = applyToolEnvOverrides(ALL_ON);
+      expect(getEnabledToolNames(config)).not.toContain('oracle_mcp_call');
+      expect(getEnabledToolNames(config)).toContain('oracle_mcp_list_tools');
+    });
+  });
+
+  it('normalizes aliases and ignores unknown names', () => {
+    withEnv({ ORACLE_ENABLED_TOOLS: 'arra_search,muninn_read,not_a_tool' }, () => {
+      expect(getEnabledToolNames(applyToolEnvOverrides(ALL_ON)).sort()).toEqual(['oracle_read', 'oracle_search']);
+    });
+  });
+
+  it('ignores an exported-but-empty variable instead of wiping the surface', () => {
+    withEnv({ ORACLE_ENABLED_TOOLS: '  , ,' }, () => {
+      expect(getEnabledToolNames(applyToolEnvOverrides(ALL_ON))).toHaveLength(ALL_TOOL_NAMES.size);
+    });
+  });
+
+  it('applies env overrides through loadToolGroupConfig, beating the config file', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-tool-env-'));
+    try {
+      fs.writeFileSync(path.join(dir, 'arra.config.json'), JSON.stringify({ disabled_tools: [] }));
+      withEnv({ ORACLE_DISABLED_TOOLS: 'oracle_search' }, () => {
+        expect(getEnabledToolNames(loadToolGroupConfig(dir))).not.toContain('oracle_search');
+      });
+      withEnv({}, () => {
+        expect(getEnabledToolNames(loadToolGroupConfig(dir))).toContain('oracle_search');
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+    }
+  });
+});
+
+describe('resolveToolConfigSource', () => {
+  it('always names a path the loader itself reads', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-tool-source-'));
+    try {
+      const candidates = configSources(dir).map((candidate) => candidate.path);
+      expect(candidates).toContain(resolveToolConfigSource(dir).path);
+      // The pre-#2822 writer targeted `<root>/.arra/config.json`, which is on no tier.
+      expect(candidates).not.toContain(path.join(dir, '.arra', 'config.json'));
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('resolves to the repo-root file the loader will pick, and reads back what was written', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-tool-source-'));
+    try {
+      fs.writeFileSync(path.join(dir, 'arra.config.json'), JSON.stringify({ disabled_tools: ['oracle_search'] }));
+      const resolved = resolveToolConfigSource(dir);
+      expect(resolved.found).toBe(true);
+      expect(resolved.path).toBe(path.join(dir, 'arra.config.json'));
+      withEnv({}, () => {
+        expect(loadToolGroupConfig(dir).disabled_tools).toEqual(['oracle_search']);
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('skips a repo-root file that carries no tool-config key at all', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-tool-source-'));
+    try {
+      fs.writeFileSync(path.join(dir, 'arra.config.json'), JSON.stringify({ unrelated: true }));
+      expect(resolveToolConfigSource(dir).path).not.toBe(path.join(dir, 'arra.config.json'));
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+    }
+  });
+});

--- a/src/config/__tests__/tool-groups.test.ts
+++ b/src/config/__tests__/tool-groups.test.ts
@@ -3,6 +3,8 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import {
+  ALL_TOOL_NAMES,
+  ALWAYS_ON_TOOLS,
   TOOL_GROUPS,
   TOOL_PLUGINS,
   getDisabledTools,
@@ -14,9 +16,10 @@ import {
 describe('tool-groups', () => {
   it('defines groups with correct tool counts', () => {
     expect(Object.keys(TOOL_GROUPS)).toHaveLength(7);
-    expect(TOOL_GROUPS.search).toHaveLength(5);
+    expect(TOOL_GROUPS.search).toHaveLength(6);
+    expect(TOOL_GROUPS.search).toContain('oracle_ask');
     expect(TOOL_GROUPS.knowledge).toHaveLength(4);
-    expect(TOOL_GROUPS.oracle).toEqual(['oracle_profile']);
+    expect(TOOL_GROUPS.oracle).toEqual(['oracle_profile', 'oracle_recap']);
     expect(TOOL_GROUPS.trace).toHaveLength(7);
     expect(TOOL_GROUPS.standalone).toHaveLength(2);
   });
@@ -25,7 +28,24 @@ describe('tool-groups', () => {
     expect(TOOL_PLUGINS.trace.tools).toEqual(['oracle_trace', 'oracle_trace_distill']);
     expect(TOOL_PLUGINS.dig.tools).toContain('oracle_trace_get');
     expect(TOOL_PLUGINS.dig.tools).not.toContain('oracle_trace');
-    expect(TOOL_PLUGINS.oracle.tools).toEqual(['oracle_profile']);
+    expect(TOOL_PLUGINS.oracle.tools).toEqual(['oracle_profile', 'oracle_recap']);
+  });
+
+  it('keeps always-on bridge tools enabled by default but still disableable', () => {
+    const config: ToolGroupConfig = {
+      search: false, knowledge: false, session: false,
+      forum: false, oracle: false, trace: false, standalone: false,
+    };
+    for (const tool of ALWAYS_ON_TOOLS) {
+      expect(ALL_TOOL_NAMES.has(tool)).toBe(true);
+      expect(getEnabledToolNames(config)).toContain(tool);
+      expect(getDisabledTools(config).has(tool)).toBe(false);
+    }
+    const blocked = { ...config, disabled_tools: [...ALWAYS_ON_TOOLS] };
+    for (const tool of ALWAYS_ON_TOOLS) {
+      expect(getEnabledToolNames(blocked)).not.toContain(tool);
+      expect(getDisabledTools(blocked).has(tool)).toBe(true);
+    }
   });
 
   it('returns empty set when all groups enabled', () => {

--- a/src/config/tool-config-source.ts
+++ b/src/config/tool-config-source.ts
@@ -1,0 +1,105 @@
+import fs from 'fs';
+import path from 'path';
+import { ORACLE_DATA_DIR } from '../config.ts';
+
+/**
+ * Where tool configuration is read from, and — critically — where the settings
+ * API writes it. Before #2822 the writer (`.arra/config.json`) and the reader
+ * (`arra.config.json` / `$ORACLE_DATA_DIR/config.json`) used different
+ * filenames, so every save through the UI was a silent no-op. One resolver now
+ * answers both questions so they can never drift apart again.
+ */
+export interface ToolConfigSource {
+  /** Absolute path the loader reads — and the settings API writes. */
+  path: string;
+  /** Human-readable label used in logs. */
+  label: string;
+  /** True when the file exists AND carries a key the loader accepts. */
+  found: boolean;
+}
+
+export function readJsonSafe(filePath: string): Record<string, any> | null {
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+export function isRecord(value: unknown): value is Record<string, any> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Keys that make a JSON file count as tool configuration. A file missing all of
+ * them is skipped, and resolution falls through to the next tier.
+ *
+ * NOTE: `allowed_tools` is deliberately NOT here. It never was, which is why the
+ * pre-#2822 settings API — which persisted exactly that key — had no effect.
+ */
+export function hasToolConfig(raw: Record<string, any>): boolean {
+  return Array.isArray(raw.plugins)
+    || isRecord(raw.tools)
+    || Array.isArray(raw.disabled_tools)
+    || Array.isArray(raw.enabled_tools)
+    || typeof raw.mcp === 'boolean';
+}
+
+function hasPluginManifest(raw: Record<string, any>): boolean {
+  return Array.isArray(raw.plugins);
+}
+
+interface SourceCandidate extends Omit<ToolConfigSource, 'found'> {
+  accept: (raw: Record<string, any>) => boolean;
+}
+
+/**
+ * FIRST MATCH WINS. A repo-root file shadows the global one entirely — the tiers
+ * are not merged. Keep this list and the watcher in `tool-groups-watch.ts` in
+ * sync; both must observe the same files.
+ */
+export function configSources(root: string): SourceCandidate[] {
+  return [
+    { path: path.join(root, 'arra.config.json'), label: 'arra.config.json from repo root', accept: hasToolConfig },
+    { path: path.join(root, 'plugins.json'), label: 'plugins.json from repo root', accept: hasPluginManifest },
+    { path: path.join(ORACLE_DATA_DIR, 'config.json'), label: `${ORACLE_DATA_DIR}/config.json`, accept: hasToolConfig },
+    { path: path.join(ORACLE_DATA_DIR, 'plugins.json'), label: `${ORACLE_DATA_DIR}/plugins.json`, accept: hasPluginManifest },
+  ];
+}
+
+/** Tier used when no config file exists yet — the settings API creates this one. */
+function writeTarget(root: string): SourceCandidate {
+  return configSources(root)[2]!;
+}
+
+export function resolveConfigSourceWithRaw(root: string): { source: ToolConfigSource; raw: Record<string, any> | null } {
+  for (const candidate of configSources(root)) {
+    const raw = readJsonSafe(candidate.path);
+    if (!raw || !candidate.accept(raw)) continue;
+    return { source: { path: candidate.path, label: candidate.label, found: true }, raw };
+  }
+  const fallback = writeTarget(root);
+  return { source: { path: fallback.path, label: fallback.label, found: false }, raw: null };
+}
+
+/**
+ * The file the loader will read next. When nothing exists yet this returns the
+ * global `$ORACLE_DATA_DIR/config.json` — the file the settings API should
+ * create — so a fresh install writes somewhere the loader already looks.
+ */
+export function resolveToolConfigSource(repoRoot?: string): ToolConfigSource {
+  const root = repoRoot || process.env.ORACLE_REPO_ROOT || process.cwd();
+  return resolveConfigSourceWithRaw(root).source;
+}
+
+/**
+ * Parse a comma-separated env tool list. Returns null when unset or empty so an
+ * exported-but-blank variable never wipes the tool surface.
+ */
+export function envToolList(name: string): string[] | null {
+  const raw = process.env[name];
+  if (typeof raw !== 'string') return null;
+  const items = raw.split(',').map((entry) => entry.trim()).filter(Boolean);
+  return items.length ? items : null;
+}

--- a/src/config/tool-groups-core.ts
+++ b/src/config/tool-groups-core.ts
@@ -1,16 +1,26 @@
-import fs from 'fs';
-import path from 'path';
-import { ORACLE_DATA_DIR } from '../config.ts';
+import { envToolList, isRecord, resolveConfigSourceWithRaw } from './tool-config-source.ts';
 
 export const TOOL_GROUPS = {
-  search: ['oracle_search', 'oracle_search_chain', 'oracle_read', 'oracle_list', 'oracle_concepts'],
+  search: ['oracle_search', 'oracle_search_chain', 'oracle_read', 'oracle_list', 'oracle_concepts', 'oracle_ask'],
   knowledge: ['oracle_learn', 'oracle_stats', 'oracle_supersede', 'oracle_research_note'],
   session: ['oracle_handoff', 'oracle_inbox'],
   forum: ['oracle_thread', 'oracle_threads', 'oracle_thread_read', 'oracle_thread_update'],
-  oracle: ['oracle_profile'],
+  oracle: ['oracle_profile', 'oracle_recap'],
   trace: ['oracle_trace', 'oracle_trace_list', 'oracle_trace_get', 'oracle_trace_link', 'oracle_trace_unlink', 'oracle_trace_chain', 'oracle_trace_distill'],
   standalone: ['oracle_reflect', 'oracle_verify'],
 } as const;
+
+/**
+ * DELIBERATELY ALWAYS ON: the local↔remote MCP bridge. These two belong to no
+ * TOOL_GROUPS key on purpose — a config that turns every group off must still be
+ * able to reach a remote Oracle, which is the whole point of the bridge.
+ *
+ * They ARE members of ALL_TOOL_NAMES, so this is a default, not a lock:
+ * `disabled_tools` (or ORACLE_DISABLED_TOOLS) still switches them off explicitly.
+ * Adding an `mcp` key to TOOL_GROUPS instead would regress them — every existing
+ * config literal omits it, so the group loop would read it as false. (#2822)
+ */
+export const ALWAYS_ON_TOOLS: readonly string[] = ['oracle_mcp_list_tools', 'oracle_mcp_call'];
 
 export type ToolGroupName = keyof typeof TOOL_GROUPS;
 export type PluginTier = 'core' | 'standard' | 'extra';
@@ -50,8 +60,19 @@ const DEFAULT_CONFIG: ToolGroupConfig = {
   mcp: true,
 };
 
-const ALL_TOOL_NAMES: ReadonlySet<string> = new Set(
-  [...Object.values(TOOL_PLUGINS).flatMap((p) => p.tools), ...Object.values(TOOL_GROUPS).flat()] as string[],
+/**
+ * Every tool the config system knows how to govern. A tool absent from this set
+ * escapes configuration entirely: `src/mcp/server.ts` re-appends any registry
+ * tool with `enabledByDefault !== false` that the whitelist did not name, so an
+ * unknown tool is unconditionally exposed. `tests/mcp/tool-registry-invariant.test.ts`
+ * fails the build if a built-in MCP tool ever drifts back out of this set.
+ */
+export const ALL_TOOL_NAMES: ReadonlySet<string> = new Set(
+  [
+    ...Object.values(TOOL_PLUGINS).flatMap((p) => p.tools),
+    ...Object.values(TOOL_GROUPS).flat(),
+    ...ALWAYS_ON_TOOLS,
+  ] as string[],
 );
 const DEFAULT_TOOL_ORDER = Object.values(TOOL_PLUGINS)
   .sort((a, b) => a.weight - b.weight || a.name.localeCompare(b.name))
@@ -61,15 +82,6 @@ export function normalizeToolName(name: string): string {
   if (name.startsWith('arra_')) return `oracle_${name.slice('arra_'.length)}`;
   if (name.startsWith('muninn_')) return `oracle_${name.slice('muninn_'.length)}`;
   return name;
-}
-
-function readJsonSafe(filePath: string): Record<string, any> | null {
-  try {
-    if (!fs.existsSync(filePath)) return null;
-    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-  } catch {
-    return null;
-  }
 }
 
 function mergeRaw(raw: Record<string, any>): ToolGroupConfig {
@@ -88,14 +100,6 @@ function mergeRaw(raw: Record<string, any>): ToolGroupConfig {
   return merged;
 }
 
-function hasToolConfig(raw: Record<string, any>): boolean {
-  return Array.isArray(raw.plugins)
-    || isRecord(raw.tools)
-    || Array.isArray(raw.disabled_tools)
-    || Array.isArray(raw.enabled_tools)
-    || typeof raw.mcp === 'boolean';
-}
-
 function normalizePluginEntry(entry: unknown): PluginManifestEntry | null {
   if (!isRecord(entry) || typeof entry.name !== 'string' || !entry.name.trim()) return null;
   return {
@@ -110,33 +114,46 @@ function isPluginTier(value: unknown): value is PluginTier {
   return value === 'core' || value === 'standard' || value === 'extra';
 }
 
-function isRecord(value: unknown): value is Record<string, any> {
-  return !!value && typeof value === 'object' && !Array.isArray(value);
+/**
+ * Apply ORACLE_ENABLED_TOOLS / ORACLE_DISABLED_TOOLS on top of file config.
+ *
+ * - ORACLE_ENABLED_TOOLS is a STRICT allow-list: everything it does not name is
+ *   written into disabled_tools, because `enabled_tools` alone is additive.
+ * - ORACLE_DISABLED_TOOLS is subtractive and composes with the allow-list.
+ *
+ * Env wins over the config file — it is the only lever available on a read-only
+ * container or in CI where no config file can be written. (#2822 defect 2)
+ */
+export function applyToolEnvOverrides(config: ToolGroupConfig): ToolGroupConfig {
+  const allowEnv = envToolList('ORACLE_ENABLED_TOOLS')?.map(normalizeToolName);
+  const blockEnv = envToolList('ORACLE_DISABLED_TOOLS')?.map(normalizeToolName);
+  if (!allowEnv && !blockEnv) return config;
+  const next: ToolGroupConfig = { ...config };
+  if (allowEnv) {
+    const keep = new Set(allowEnv.filter((tool) => knownTool(tool, 'ORACLE_ENABLED_TOOLS')));
+    next.enabled_tools = [...keep];
+    next.disabled_tools = [...ALL_TOOL_NAMES].filter((tool) => !keep.has(tool));
+  }
+  if (blockEnv) {
+    const block = new Set(blockEnv.filter((tool) => knownTool(tool, 'ORACLE_DISABLED_TOOLS')));
+    next.disabled_tools = [...new Set([...(next.disabled_tools ?? []), ...block])];
+    next.enabled_tools = (next.enabled_tools ?? []).filter((tool) => !block.has(tool));
+  }
+  return next;
+}
+
+function knownTool(tool: string, source: string): boolean {
+  if (ALL_TOOL_NAMES.has(tool)) return true;
+  console.error(`[ToolGroups] ${source}: unknown tool "${tool}" — ignored`);
+  return false;
 }
 
 export function loadToolGroupConfig(repoRoot?: string): ToolGroupConfig {
   const root = repoRoot || process.env.ORACLE_REPO_ROOT || process.cwd();
-  const localConfig = readJsonSafe(path.join(root, 'arra.config.json'));
-  if (localConfig && hasToolConfig(localConfig)) {
-    console.error('[ToolGroups] Using arra.config.json from repo root');
-    return mergeRaw(localConfig);
-  }
-  const localPluginManifest = readJsonSafe(path.join(root, 'plugins.json'));
-  if (localPluginManifest && Array.isArray(localPluginManifest.plugins)) {
-    console.error('[ToolGroups] Using plugins.json from repo root');
-    return mergeRaw(localPluginManifest);
-  }
-  const globalConfig = readJsonSafe(path.join(ORACLE_DATA_DIR, 'config.json'));
-  if (globalConfig && hasToolConfig(globalConfig)) {
-    console.error(`[ToolGroups] Using ${ORACLE_DATA_DIR}/config.json`);
-    return mergeRaw(globalConfig);
-  }
-  const globalPluginManifest = readJsonSafe(path.join(ORACLE_DATA_DIR, 'plugins.json'));
-  if (globalPluginManifest && Array.isArray(globalPluginManifest.plugins)) {
-    console.error(`[ToolGroups] Using ${ORACLE_DATA_DIR}/plugins.json`);
-    return mergeRaw(globalPluginManifest);
-  }
-  return { ...DEFAULT_CONFIG };
+  const { source, raw } = resolveConfigSourceWithRaw(root);
+  if (!raw) return applyToolEnvOverrides({ ...DEFAULT_CONFIG });
+  console.error(`[ToolGroups] Using ${source.label}`);
+  return applyToolEnvOverrides(mergeRaw(raw));
 }
 
 export function getDisabledTools(config: ToolGroupConfig): Set<string> {
@@ -160,7 +177,7 @@ export function getDisabledTools(config: ToolGroupConfig): Set<string> {
 }
 
 export function getEnabledToolNames(config: ToolGroupConfig): string[] {
-  const ordered = config.plugins ? pluginOrderedTools(config.plugins) : DEFAULT_TOOL_ORDER;
+  const ordered = [...(config.plugins ? pluginOrderedTools(config.plugins) : DEFAULT_TOOL_ORDER), ...ALWAYS_ON_TOOLS];
   const seen = new Set<string>();
   const enabled = ordered.filter((tool) => !seen.has(tool) && seen.add(tool) && ALL_TOOL_NAMES.has(tool));
   for (const [group, tools] of Object.entries(TOOL_GROUPS)) {

--- a/src/config/tool-groups.ts
+++ b/src/config/tool-groups.ts
@@ -1,6 +1,9 @@
 export {
+  ALL_TOOL_NAMES,
+  ALWAYS_ON_TOOLS,
   TOOL_GROUPS,
   TOOL_PLUGINS,
+  applyToolEnvOverrides,
   getDisabledTools,
   getEnabledToolNames,
   loadToolGroupConfig,
@@ -13,4 +16,6 @@ export type {
   ToolGroupName,
   ToolPlugin,
 } from './tool-groups-core.ts';
+export { envToolList, resolveToolConfigSource } from './tool-config-source.ts';
+export type { ToolConfigSource } from './tool-config-source.ts';
 export { watchToolGroupConfig } from './tool-groups-watch.ts';

--- a/src/plugins/unified-manifest.ts
+++ b/src/plugins/unified-manifest.ts
@@ -11,6 +11,7 @@ export interface UnifiedMcpToolManifest {
   description: string;
   inputSchema: Record<string, unknown>;
   handler: string;
+  /** INERT display metadata — unvalidated, steers no enablement; that lives in src/config/tool-groups*.ts (#2822). */
   group?: string;
   readOnly?: boolean;
   enabled?: boolean;

--- a/src/routes/settings/index.ts
+++ b/src/routes/settings/index.ts
@@ -3,6 +3,7 @@ import { SESSION_COOKIE_NAME, isAuthenticated } from '../auth/index.ts';
 import { getSettingsRoute } from './get.ts';
 import { updateSettingsRoute } from './update.ts';
 import { systemSettingsRoute } from './system.ts';
+import { toolSettingsRoute } from './tools.ts';
 
 export const settingsRoutes = new Elysia({ prefix: '/api/settings' })
   .onBeforeHandle(({ server, request, cookie, set }) => {
@@ -14,6 +15,7 @@ export const settingsRoutes = new Elysia({ prefix: '/api/settings' })
   })
   .use(getSettingsRoute)
   .use(systemSettingsRoute)
-  .use(updateSettingsRoute);
+  .use(updateSettingsRoute)
+  .use(toolSettingsRoute);
 
 export * from './model.ts';

--- a/src/routes/settings/tools.ts
+++ b/src/routes/settings/tools.ts
@@ -3,22 +3,26 @@ import path from 'path';
 import { Elysia, t } from 'elysia';
 import { REPO_ROOT } from '../../config.ts';
 import {
+  ALL_TOOL_NAMES,
+  ALWAYS_ON_TOOLS,
   TOOL_GROUPS,
+  envToolList,
   getEnabledToolNames,
   loadToolGroupConfig,
   normalizeToolName,
+  resolveToolConfigSource,
   type ToolGroupName,
 } from '../../config/tool-groups.ts';
 
-const ALL_TOOL_NAMES = Object.values(TOOL_GROUPS).flat();
-const ALL_TOOL_SET: ReadonlySet<string> = new Set(ALL_TOOL_NAMES);
+/** Ordered projection of the shared config vocabulary — the same set the loader governs. */
+const ALL_TOOL_LIST = [...ALL_TOOL_NAMES];
 
 const UpdateToolsBody = t.Object({
   enabled_tools: t.Array(t.String()),
 });
 
-function configPath(): string {
-  return path.join(process.env.ORACLE_REPO_ROOT || REPO_ROOT, '.arra', 'config.json');
+function repoRoot(): string {
+  return process.env.ORACLE_REPO_ROOT || REPO_ROOT;
 }
 
 function readExistingConfig(filePath: string): Record<string, unknown> {
@@ -31,18 +35,26 @@ function readExistingConfig(filePath: string): Record<string, unknown> {
 }
 
 function serializeToolConfig() {
-  const config = loadToolGroupConfig(process.env.ORACLE_REPO_ROOT || REPO_ROOT);
+  const source = resolveToolConfigSource(repoRoot());
+  const config = loadToolGroupConfig(repoRoot());
   const enabled = new Set(getEnabledToolNames(config));
-  const envOverride = Boolean(process.env.ORACLE_ENABLED_TOOLS?.trim() || process.env.ORACLE_DISABLED_TOOLS?.trim());
   return {
     groups: Object.entries(TOOL_GROUPS).map(([group, tools]) => ({
       group: group as ToolGroupName,
       tools: tools.map((name) => ({ name, enabled: enabled.has(name) })),
     })),
-    enabled_tools: ALL_TOOL_NAMES.filter((name) => enabled.has(name)),
-    disabled_tools: ALL_TOOL_NAMES.filter((name) => !enabled.has(name)),
-    config_path: configPath(),
-    env_override: envOverride,
+    enabled_tools: ALL_TOOL_LIST.filter((name) => enabled.has(name)),
+    disabled_tools: ALL_TOOL_LIST.filter((name) => !enabled.has(name)),
+    // Tools with no group: deliberately on by default, still disableable. See
+    // ALWAYS_ON_TOOLS in src/config/tool-groups-core.ts.
+    always_on_tools: [...ALWAYS_ON_TOOLS],
+    // The file a PUT will write. First-match-wins: a repo-root arra.config.json
+    // shadows the global one, so surface which file is actually in play.
+    config_path: source.path,
+    config_exists: source.found,
+    // True when ORACLE_ENABLED_TOOLS / ORACLE_DISABLED_TOOLS are in effect. Env
+    // beats the file, so a PUT will not visibly change the surface while set.
+    env_override: Boolean(envToolList('ORACLE_ENABLED_TOOLS') || envToolList('ORACLE_DISABLED_TOOLS')),
   };
 }
 
@@ -56,21 +68,25 @@ export const toolSettingsRoute = new Elysia()
   })
   .put('/tools', ({ body, set }) => {
     const normalized = Array.from(new Set(body.enabled_tools.map(normalizeToolName)));
-    const unknown = normalized.filter((name) => !ALL_TOOL_SET.has(name));
+    const unknown = normalized.filter((name) => !ALL_TOOL_NAMES.has(name));
     if (unknown.length) {
       set.status = 400;
       return { error: 'Unknown MCP tools', unknown };
     }
 
-    const filePath = configPath();
+    const filePath = resolveToolConfigSource(repoRoot()).path;
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
-    const existing = readExistingConfig(filePath);
+    const { allowed_tools: _dead, ...existing } = readExistingConfig(filePath);
+    const selected = new Set(normalized);
     const next = {
       ...existing,
-      // allowed_tools is the strict allow-list that #1372 already resolves via
-      // getEnabledToolNames/getDisabledTools. Persisting the visual toggle as
-      // an allow-list avoids duplicating group/filter semantics in the UI.
-      allowed_tools: ALL_TOOL_NAMES.filter((name) => normalized.includes(name)),
+      // BOTH sides are required. `enabled_tools` is additive in
+      // getEnabledToolNames, so an allow-list only becomes exclusive once its
+      // complement lands in `disabled_tools`. The old `allowed_tools` key this
+      // endpoint used to write is not a key the loader reads at all — it is
+      // dropped here rather than left behind looking authoritative. (#2822)
+      enabled_tools: ALL_TOOL_LIST.filter((name) => selected.has(name)),
+      disabled_tools: ALL_TOOL_LIST.filter((name) => !selected.has(name)),
     };
     fs.writeFileSync(filePath, JSON.stringify(next, null, 2) + '\n');
     return { success: true, ...serializeToolConfig() };

--- a/src/tools/mcp-manifest.ts
+++ b/src/tools/mcp-manifest.ts
@@ -1,4 +1,5 @@
 import type { UnifiedMcpToolManifest } from '../plugins/unified-manifest.ts';
+import { ALWAYS_ON_TOOLS } from '../config/tool-groups.ts';
 import { GUIDE_TOOL_NAME, guideToolDefinition, guideToolResponse } from '../mcp/guide.ts';
 import type { ToolContext, ToolResponse } from './types.ts';
 import { recapToolDef, handleRecap } from './recap.ts';
@@ -82,6 +83,9 @@ export function toMcpToolDefinition(tool: RuntimeMcpToolManifest) {
 
 export function defaultMcpToolOrder(configOrder: string[]): string[] {
   const seen = new Set<string>();
-  return [GUIDE_TOOL_NAME, ...configOrder, ...mcpTools.filter((t) => t.group === 'mcp' && t.enabledByDefault !== false).map((t) => t.name)]
+  // ALWAYS_ON_TOOLS, not a `group === 'mcp'` scan: manifest groups are display
+  // metadata (see UnifiedMcpToolManifest.group) and must not steer enablement.
+  // Tools appended here are still subject to disabled_tools in the caller.
+  return [GUIDE_TOOL_NAME, ...configOrder, ...ALWAYS_ON_TOOLS]
     .filter((name) => mcpToolByName.has(name) && !seen.has(name) && seen.add(name));
 }

--- a/tests/http/settings/tools-mounted.test.ts
+++ b/tests/http/settings/tools-mounted.test.ts
@@ -1,0 +1,120 @@
+import { afterAll, expect, test } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tempData = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-tools-data-'));
+const tempRepo = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-tools-repo-'));
+const previous = {
+  data: process.env.ORACLE_DATA_DIR,
+  db: process.env.ORACLE_DB_PATH,
+  root: process.env.ORACLE_REPO_ROOT,
+  allow: process.env.ORACLE_ENABLED_TOOLS,
+  block: process.env.ORACLE_DISABLED_TOOLS,
+};
+process.env.ORACLE_DATA_DIR = tempData;
+process.env.ORACLE_DB_PATH = path.join(tempData, 'oracle.db');
+process.env.ORACLE_REPO_ROOT = tempRepo;
+delete process.env.ORACLE_ENABLED_TOOLS;
+delete process.env.ORACLE_DISABLED_TOOLS;
+
+// Pin the write target to the repo-root tier. ORACLE_DATA_DIR is read once at
+// src/config.ts import and bun shares that module across test files, so the
+// global tier is NOT ours to control — without this seed a solo run of this
+// file would resolve to (and overwrite) the developer's real global config.
+const repoConfig = path.join(tempRepo, 'arra.config.json');
+fs.writeFileSync(repoConfig, JSON.stringify({ disabled_tools: [] }) + '\n');
+
+const dbModule = await import('../../../src/db/index.ts');
+dbModule.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+const { settingsRoutes } = await import('../../../src/routes/settings/index.ts');
+const { createApiVersionedFetch } = await import('../../../src/middleware/api-version.ts');
+
+// A real listening server, not `.handle()` on an uncompiled app: the direct
+// handle path is order-sensitive during module init and has produced phantom
+// 404s while the mount was in fact fine. Matches CLAUDE.md's "fetch-based
+// against a spawned Elysia server" rule.
+const handle = createApiVersionedFetch((request) => settingsRoutes.handle(request));
+const server = Bun.serve({ port: 0, fetch: (request) => handle(request) });
+const base = `http://127.0.0.1:${server.port}`;
+
+afterAll(() => {
+  server.stop(true);
+  for (const [key, value] of [
+    ['ORACLE_DATA_DIR', previous.data], ['ORACLE_DB_PATH', previous.db],
+    ['ORACLE_REPO_ROOT', previous.root], ['ORACLE_ENABLED_TOOLS', previous.allow],
+    ['ORACLE_DISABLED_TOOLS', previous.block],
+  ] as const) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  fs.rmSync(tempData, { recursive: true });
+  fs.rmSync(tempRepo, { recursive: true });
+});
+
+type ToolsBody = {
+  groups: Array<{ group: string; tools: Array<{ name: string; enabled: boolean }> }>;
+  enabled_tools: string[];
+  disabled_tools: string[];
+  always_on_tools: string[];
+  config_path: string;
+  config_exists: boolean;
+  env_override: boolean;
+};
+
+const readTools = async (): Promise<ToolsBody> => {
+  const res = await fetch(`${base}/api/v1/settings/tools`);
+  expect(res.status).toBe(200);
+  return await res.json() as ToolsBody;
+};
+
+test('GET /api/v1/settings/tools is mounted and returns group data', async () => {
+  const body = await readTools();
+  expect(body.groups.length).toBeGreaterThan(0);
+  expect(body.groups.map((entry) => entry.group)).toContain('search');
+  const named = body.groups.flatMap((entry) => entry.tools.map((tool) => tool.name));
+  expect(named).toContain('oracle_ask');
+  expect(named).toContain('oracle_recap');
+  expect(body.always_on_tools).toEqual(['oracle_mcp_list_tools', 'oracle_mcp_call']);
+  expect(body.env_override).toBe(false);
+});
+
+test('the unversioned alias redirects to the versioned path', async () => {
+  const res = await fetch(`${base}/api/settings/tools`, { redirect: 'manual' });
+  expect(res.status).toBe(308);
+  expect(res.headers.get('location')).toContain('/api/v1/settings/tools');
+});
+
+test('PUT rejects unknown tool names without writing anything', async () => {
+  const res = await fetch(`${base}/api/v1/settings/tools`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ enabled_tools: ['oracle_search', 'not_a_real_tool'] }),
+  });
+  expect(res.status).toBe(400);
+  expect((await res.json() as { unknown: string[] }).unknown).toEqual(['not_a_real_tool']);
+});
+
+test('PUT writes a file the loader reads back — the round-trip #2822 lacked', async () => {
+  const before = await readTools();
+  expect(before.config_path).toBe(repoConfig);
+  expect(before.config_exists).toBe(true);
+  expect(before.enabled_tools).toContain('oracle_thread');
+
+  const res = await fetch(`${base}/api/v1/settings/tools`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ enabled_tools: ['oracle_search', 'oracle_read'] }),
+  });
+  expect(res.status).toBe(200);
+
+  const written = JSON.parse(fs.readFileSync(before.config_path, 'utf-8')) as Record<string, string[]>;
+  expect(written.enabled_tools).toEqual(['oracle_search', 'oracle_read']);
+  expect(written.disabled_tools).toContain('oracle_thread');
+  expect(written.allowed_tools).toBeUndefined();
+
+  const after = await readTools();
+  expect(after.config_exists).toBe(true);
+  expect(after.enabled_tools).toEqual(['oracle_search', 'oracle_read']);
+  expect(after.disabled_tools).toContain('oracle_thread');
+});

--- a/tests/mcp/tool-registry-invariant.test.ts
+++ b/tests/mcp/tool-registry-invariant.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  ALL_TOOL_NAMES,
+  ALWAYS_ON_TOOLS,
+  getDisabledTools,
+  type ToolGroupConfig,
+} from '../../src/config/tool-groups.ts';
+import { mcpTools } from '../../src/tools/mcp-manifest.ts';
+
+const ALL_GROUPS_ON: ToolGroupConfig = {
+  search: true, knowledge: true, session: true,
+  forum: true, oracle: true, trace: true, standalone: true,
+};
+
+/**
+ * A built-in tool the config system does not know about cannot be turned off.
+ * src/mcp/server.ts re-appends every registry tool with `enabledByDefault !== false`
+ * that the whitelist did not name, so anything outside ALL_TOOL_NAMES is exposed
+ * unconditionally — which is exactly how oracle_ask, oracle_recap and the two
+ * bridge tools drifted out of reach in #2822.
+ *
+ * If you add a tool to `mcpTools`, give it a TOOL_GROUPS home (or add it to
+ * ALWAYS_ON_TOOLS with a stated reason). These tests are the guard.
+ */
+describe('MCP tool registry ↔ tool-group config invariant', () => {
+  test('every built-in MCP tool is governed by the config vocabulary', () => {
+    const orphans = mcpTools.map((tool) => tool.name).filter((name) => !ALL_TOOL_NAMES.has(name));
+    expect(orphans).toEqual([]);
+  });
+
+  test('every built-in MCP tool can actually be disabled by config', () => {
+    const unreachable = mcpTools
+      .map((tool) => tool.name)
+      .filter((name) => !getDisabledTools({ ...ALL_GROUPS_ON, disabled_tools: [name] }).has(name));
+    expect(unreachable).toEqual([]);
+  });
+
+  test('always-on tools are declared, not accidental', () => {
+    for (const name of ALWAYS_ON_TOOLS) {
+      expect(ALL_TOOL_NAMES.has(name)).toBe(true);
+      expect(mcpTools.some((tool) => tool.name === name)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Closes #2822

Five surfaces were declared but not wired. Each is now either working or honestly documented as inert.

| Lever | Before | After |
|---|---|---|
| `GET/PUT /api/v1/settings/tools` | route defined, never mounted → 404 | mounted, 200 with group data |
| `ORACLE_DISABLED_TOOLS` / `ORACLE_ENABLED_TOOLS` | read only to compute a display flag | applied in `loadToolGroupConfig` |
| `.arra/config.json` | written by the API, never read by the loader | API and loader agree on one path |
| `oracle_ask` `oracle_recap` `oracle_mcp_call` `oracle_mcp_list_tools` | outside `ALL_TOOL_NAMES`, unconfigurable | in real groups, or in a documented `ALWAYS_ON_TOOLS` |
| `mcpTools[].group` | looked like a toggle, governed nothing | documented inert at `unified-manifest.ts:14` |

Plus an invariant test so a tool can never drift out of the registry silently again.

## Verified by behaviour, not by diff

An adversarial pass re-ran every gate itself and refused the build's pasted output.

**Cross-process round-trip** — settings API → config file → real MCP stdio server, two separate OS processes:
```
tools/list BEFORE                                    30
PUT disabling oracle_thread, oracle_ask,
    oracle_recap, oracle_mcp_call            → HTTP 200
tools/list AFTER                                     26
removed: oracle_ask, oracle_recap, oracle_thread, oracle_mcp_call
```
Not cosmetic — exactly the four targeted tools disappeared from a separate process.

**A/B against alpha**, same probe both sides:
```
ORACLE_DISABLED_TOOLS=oracle_search,oracle_learn
  alpha  30 tools, both still present   → lever dead
  head   28 tools, both gone            → lever works

ORACLE_ENABLED_TOOLS=oracle_search,oracle_read
  alpha  30 tools, 27 beyond allow-list → lever dead
  head    2 tools,  0 beyond allow-list → lever works
```

**The invariant test has teeth** — injecting a group-less MCP tool turns it red:
```
(fail) every built-in MCP tool is governed by the config vocabulary
       - []  + ["oracle_adv_fake_probe"]
```
Reverted; `git status` clean; 3 pass / 0 fail.

## A false claim was caught and fixed before merge

The first commit documented the top-level `mcp` key as inert. **It is not.** `src/routes/mcp/streamable.ts:30` reads it (`loadToolGroupConfig(repoRoot).mcp !== false`) and gates the whole Streamable HTTP endpoint:
```
{"mcp": true}  → POST /mcp  401   (auth challenge, endpoint live)
{"mcp": false} → POST /mcp  404   (endpoint gone)
```
The follow-up commit corrects the doc. Left uncorrected, it would have invited someone to delete a working kill-switch.

## Known gaps — disclosed, not hidden

- **The committed round-trip test is self-referential.** `tests/http/settings/tools-mounted.test.ts:98-120` calls GET after PUT, but `serializeToolConfig()` derives its answer from the same `getEnabledToolNames()` the PUT's effect comes from. If the config layer and the MCP surface diverged again — precisely the #2822 defect — it would stay green. The real cross-process proof above is not yet a committed test.
- **New nav entry points at a page that does not exist.** Mounting the route publishes `menu:{path:'/tools/config'}` (`tools.ts:65,97`). No such frontend page exists. Disclosed at `docs/ONBOARDING.md:96`.
- **Strict allow-list drops the guide tool.** `ORACLE_ENABLED_TOOLS` yields exactly the named tools — `____IMPORTANT` goes too, since `applyToolEnvOverrides` writes the complement of `ALL_TOOL_NAMES`. Defensible, currently undocumented.
- Plugin-contributed MCP tools stay outside `ALL_TOOL_NAMES` by design, governed via `POST /api/plugins/:name/toggle`. No integration test for that path yet.

## Gates

```
bunx tsc --noEmit                                                    exit 0
bun test tests/http/settings/ src/config/ --path-ignore-patterns='**/agents/**'
  52 pass / 0 fail across 9 files
```

⚠️ The `--path-ignore-patterns` flag is required — see #2825. Without it, scoped `bun test` also runs five stale copies from `agents/` worktrees.

Pre-existing unrelated failure, confirmed present on alpha too: `tests/http/compat/old-studio.test.ts` has a 750ms wall-clock budget that fails under load. Solo run: 12 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)