### PR TITLE
chore(mcp): warn on the deprecated muninn_ alias before removing it

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "arra-oracle",
   "version": "26.5.30",
-  "description": "MCP memory layer with semantic search over your Oracle vault — SQLite FTS5 + LanceDB hybrid, 20 oracle_* tools across search / knowledge / session / forum / trace / standalone groups. Backward-compatible aliases: arra_* and muninn_* both resolve to oracle_*.",
+  "description": "MCP memory layer with semantic search over your Oracle vault — SQLite FTS5 + LanceDB hybrid, 20 oracle_* tools across search / knowledge / session / forum / trace / standalone groups. Backward-compatible aliases: arra_* resolves to oracle_*; muninn_* still resolves but is DEPRECATED and will be removed next release.",
   "homepage": "https://github.com/Soul-Brews-Studio/arra-oracle-v3",
   "license": "BUSL-1.1"
 }

--- a/src/__tests__/resolve-tool-name.test.ts
+++ b/src/__tests__/resolve-tool-name.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { resolveToolName } from '../index.ts';
+import { resolveToolName, deprecatedAliasWarning, resolveInboundToolName } from '../index.ts';
 
 describe('resolveToolName — 3-generation alias chain (arra_* | muninn_* → oracle_*)', () => {
   describe('arra_* (original, pre-#1172)', () => {
@@ -86,6 +86,62 @@ describe('resolveToolName — 3-generation alias chain (arra_* | muninn_* → or
       // Highly unlikely real-world name, but verify deterministic behavior:
       // first prefix in ALIAS_PREFIXES wins (arra_ comes before muninn_).
       expect(resolveToolName('arra_muninn_x')).toBe('oracle_muninn_x');
+    });
+  });
+
+  describe('deprecation warning (#2824 — muninn_* warns for one release, then goes)', () => {
+    const collect = (name: string) => {
+      const logs: string[] = [];
+      const resolved = resolveInboundToolName(name, (m) => logs.push(m));
+      return { resolved, logs };
+    };
+
+    it('still resolves muninn_* AND warns, naming the replacement', () => {
+      const { resolved, logs } = collect('muninn_search');
+      expect(resolved).toBe('oracle_search');
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).toBe(
+        '[MCP] tool alias "muninn_search" is deprecated — use "oracle_search" (removal planned next release)',
+      );
+    });
+
+    it('resolves arra_* with NO warning — arra_ is not deprecated', () => {
+      const { resolved, logs } = collect('arra_search');
+      expect(resolved).toBe('oracle_search');
+      expect(logs).toEqual([]);
+      expect(deprecatedAliasWarning('arra_search')).toBeNull();
+    });
+
+    it('stays silent when no rewrite happened', () => {
+      // Nothing was aliased away, so there is nothing to migrate off of.
+      for (const name of ['oracle_search', 'muninn_', 'not_muninn_thing', 'search', '']) {
+        expect(deprecatedAliasWarning(name)).toBeNull();
+        expect(collect(name).logs).toEqual([]);
+      }
+    });
+
+    it('does not warn for arra_muninn_x — arra_ wins the prefix scan', () => {
+      const { resolved, logs } = collect('arra_muninn_x');
+      expect(resolved).toBe('oracle_muninn_x');
+      expect(logs).toEqual([]);
+    });
+
+    it('warns on the trimmed name for padded muninn_* input', () => {
+      expect(deprecatedAliasWarning('  muninn_oracle_search  ')).toBe(
+        '[MCP] tool alias "muninn_oracle_search" is deprecated — use "oracle_search" (removal planned next release)',
+      );
+    });
+
+    it('keeps resolveToolName itself pure — resolving never logs', () => {
+      const errors: unknown[] = [];
+      const original = console.error;
+      console.error = (...args: unknown[]) => void errors.push(args);
+      try {
+        expect(resolveToolName('muninn_search')).toBe('oracle_search');
+      } finally {
+        console.error = original;
+      }
+      expect(errors).toEqual([]);
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@
 import { OracleMCPServer } from './mcp/server.ts';
 import { resolveToolName } from './mcp/aliases.ts';
 export { OracleMCPServer } from './mcp/server.ts';
-export { resolveToolName } from './mcp/aliases.ts';
+export { resolveToolName, deprecatedAliasWarning, resolveInboundToolName } from './mcp/aliases.ts';
 
 export type AdvertisedTool = { name: string };
 

--- a/src/mcp/aliases.ts
+++ b/src/mcp/aliases.ts
@@ -1,6 +1,13 @@
 /** Backward-compatible MCP tool alias resolution. */
 const ALIAS_PREFIXES = ['arra_', 'muninn_'] as const;
 
+/**
+ * Aliases slated for removal in the NEXT release. `arra_` is deliberately
+ * absent — it stays supported and silent. Removing a prefix from here is a
+ * no-op; removal also requires dropping it from ALIAS_PREFIXES above.
+ */
+const DEPRECATED_PREFIXES = ['muninn_'] as const;
+
 export function resolveToolName(name: string): string {
   const clean = name.trim();
   for (const prefix of ALIAS_PREFIXES) {
@@ -10,4 +17,28 @@ export function resolveToolName(name: string): string {
     return suffix.startsWith('oracle_') ? suffix : `oracle_${suffix}`;
   }
   return clean;
+}
+
+/**
+ * Deprecation notice for `name`, or null when none is warranted.
+ * Null when no rewrite happened (bare `muninn_`, `not_muninn_thing`, canonical
+ * `oracle_*`) and null for non-deprecated aliases (`arra_*`, `arra_muninn_x`).
+ */
+export function deprecatedAliasWarning(name: string): string | null {
+  const clean = name.trim();
+  const resolved = resolveToolName(clean);
+  if (resolved === clean) return null;
+  if (!DEPRECATED_PREFIXES.some((prefix) => clean.startsWith(prefix))) return null;
+  return `[MCP] tool alias "${clean}" is deprecated — use "${resolved}" (removal planned next release)`;
+}
+
+/**
+ * Resolve an inbound tool name, emitting one deprecation warning per call when
+ * a deprecated alias was used. `log` is injectable for tests; production passes
+ * nothing so the notice reaches the operator on stderr.
+ */
+export function resolveInboundToolName(name: string, log: (m: string) => void = console.error): string {
+  const warning = deprecatedAliasWarning(name);
+  if (warning) log(warning);
+  return resolveToolName(name);
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -15,7 +15,7 @@ import { defaultMcpToolOrder, mcpToolByName, mcpTools, toMcpToolDefinition, type
 import type { UnifiedRuntime } from '../plugins/unified-loader.ts';
 import type { EmbeddedDeps, OracleMCPServerOptions } from './server-options.ts';
 import { formatEmbedderDegradedWarning, getEmbedderRuntimeStatus, probeConfiguredEmbedder, setEmbedderRuntimeStatus, type EmbedderRuntimeStatus } from '../vector/embedder-config.ts';
-import { resolveToolName } from './aliases.ts';
+import { resolveInboundToolName } from './aliases.ts';
 import { proxyToolCall, resolveOracleApiBase } from './http-proxy.ts';
 import { pluginMcpToolsFrom } from './plugin-tools.ts';
 import { runWithTenant } from '../middleware/tenant.ts';
@@ -197,7 +197,7 @@ export class OracleMCPServer {
       if (typeof request.params.name !== 'string' || !request.params.name.trim()) {
         return errorResponse('Error: Tool name must be a non-empty string');
       }
-      const toolName = resolveToolName(request.params.name);
+      const toolName = resolveInboundToolName(request.params.name);
       const tool = (await this.toolRegistry()).get(toolName);
       if (!tool) return errorResponse(`Error: Unknown tool: ${toolName}`);
       if (!this.isAllowed(tool)) return errorResponse(`Error: Unknown tool: ${toolName}`);

--- a/tests/mcp/aliases-silent-on-arra-prefix.test.ts
+++ b/tests/mcp/aliases-silent-on-arra-prefix.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'bun:test';
+import { deprecatedAliasWarning, resolveInboundToolName } from '../../src/mcp/aliases.ts';
+
+test('MCP aliases resolve arra prefixes silently — arra_ is not deprecated', () => {
+  expect(deprecatedAliasWarning('arra_search')).toBeNull();
+  const logs: string[] = [];
+  expect(resolveInboundToolName('arra_search', (m) => logs.push(m))).toBe('oracle_search');
+  expect(logs).toEqual([]);
+});
+
+test('MCP aliases stay silent for arra_muninn_x — the arra_ prefix wins the scan', () => {
+  const logs: string[] = [];
+  expect(resolveInboundToolName('arra_muninn_x', (m) => logs.push(m))).toBe('oracle_muninn_x');
+  expect(logs).toEqual([]);
+});

--- a/tests/mcp/aliases-warns-on-muninn-prefix.test.ts
+++ b/tests/mcp/aliases-warns-on-muninn-prefix.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from 'bun:test';
+import { deprecatedAliasWarning, resolveInboundToolName } from '../../src/mcp/aliases.ts';
+
+test('MCP aliases warn that muninn prefixes are deprecated, naming the replacement', () => {
+  expect(deprecatedAliasWarning('muninn_read')).toBe(
+    '[MCP] tool alias "muninn_read" is deprecated — use "oracle_read" (removal planned next release)',
+  );
+  const logs: string[] = [];
+  expect(resolveInboundToolName('muninn_read', (m) => logs.push(m))).toBe('oracle_read');
+  expect(logs).toHaveLength(1);
+});

--- a/tests/mcp/server-call-handler-warns-deprecated-alias.test.ts
+++ b/tests/mcp/server-call-handler-warns-deprecated-alias.test.ts
@@ -1,0 +1,22 @@
+import { expect, test, spyOn } from 'bun:test';
+import { OracleMCPServer } from '../../src/mcp/server.ts';
+import { allToolGroups, callToolHandler } from './support/server.ts';
+
+test('MCP server call handler warns once when dispatching a deprecated muninn_ alias', async () => {
+  const api = Bun.serve({ port: 0, fetch: (request) => Response.json({ q: new URL(request.url).searchParams.get('q') }) });
+  process.env.ORACLE_HTTP_URL = `http://127.0.0.1:${api.port}`;
+  const server = new OracleMCPServer({ toolGroups: allToolGroups });
+  const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+  try {
+    const response = await callToolHandler(server)({ params: { name: 'muninn_search', arguments: { query: 'alias-ok' } } });
+    expect(response.content[0].text).toContain('alias-ok');
+    const warnings = errorSpy.mock.calls
+      .map((call) => String(call[0]))
+      .filter((line) => /muninn_search.*deprecated.*oracle_search/.test(line));
+    expect(warnings).toHaveLength(1);
+  } finally {
+    errorSpy.mockRestore();
+    await server.cleanup();
+    await api.stop();
+  }
+});


### PR DESCRIPTION
Closes #2824 (step 1 of 2 — removal is the follow-up release)

`muninn_*` was briefly the canonical tool prefix (#1172 → #1236) and is now dead: `tools/list` exposes zero `muninn_*` tools. It survives only as an inbound alias that `resolveToolName()` rewrites to `oracle_*`.

Nat's decision: **remove it, but warn for one release first.** Cutting it outright fails silently — `resolveToolName` returns an unmatched name unchanged, so the call dies later as a bare tool-not-found with no hint about the rename.

## What this does

- `muninn_` stays in `ALIAS_PREFIXES` this release
- A new `resolveInboundToolName` wrapper (`src/mcp/aliases.ts:40`) emits the deprecation warning, wired at the single CallTool boundary (`src/mcp/server.ts:200`)
- `arra_` keeps resolving **silently** — it is not being deprecated
- Tests assert both: `muninn_` resolves *and* warns; `arra_` resolves and does not

## Verified by behaviour

An adversarial pass captured the real stderr rather than trusting the tests:

- 5 direct resolutions → 5 warning lines
- 3 real `tools/call` dispatches → 3 warning lines
- `arra_search` → resolves to `oracle_search`, **zero** warning lines
- `ALIAS_PREFIXES` still contains `muninn_` (removal deliberately deferred)

## Known gaps — disclosed

- **A second, unwarned `muninn_` path is still live.** `src/config/tool-groups-core.ts:60-64` has an independent `normalizeToolName` reached by `PUT /api/settings/tools` (`tools.ts:58`). A `muninn_` name submitted there is rewritten with no notice. Should be covered before the removal PR.
- **No spam guard.** The warning fires once per call with no dedupe. Matches the issue's literal wording, but a client looping on `muninn_*` floods stderr 1:1 with call volume.
- **Edge inputs still fail silently**: `muninn_`, `muninn_ `, `MUNINN_search` resolve to nothing and warn nothing. Low impact — none is a plausible tool name.
- **Docs still advertise the alias**: `docs/HUGINN-MUNINN.md:19,37,67` and `docs/TONIGHT-SHIPPED.md:51,62`. Not covered by `tests/docs/readme-claims.test.ts`.
- ⚠️ **The highest-impact consumer is outside this repo.** `~/.claude/CLAUDE.md` instructs every session to call `mcp__arra-oracle__muninn_search`. **This must be corrected before the removal PR merges**, or every session's first Oracle call becomes a tool-not-found.
- `src/mcp/server.ts` is at exactly 250 lines — compliant, zero headroom. It was already 250 before this change (diff is +2/−2).

## Gates

```
bunx tsc --noEmit                                                       exit 0
bun test src/__tests__/resolve-tool-name.test.ts --path-ignore-patterns='**/agents/**'
  all green
```

⚠️ `--path-ignore-patterns` required — see #2825.

🤖 Generated with [Claude Code](https://claude.com/claude-code)