### PR TITLE
feat(frontend): add the /tools/config page the mounted settings route advertises

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -75,6 +75,7 @@ export function AppShell({
     { to: '/vector/search', label: 'Vector Search', description: 'Semantic preview by collection' },
     { to: '/vector/settings', label: 'Vector settings', description: 'Collection config and index controls' },
     { to: '/vector/export', label: 'Export', description: 'Download vector collections' },
+    { to: '/tools/config', label: 'Tool configuration', description: 'Enable or disable served MCP tools' },
     { to: '/learn', label: 'Learn', description: 'Create and edit learnings' },
     { to: '/memory', label: 'Memory Dashboard', description: 'Confidence, heat, provenance, valid-time, and recency' },
     { to: '/memory/consolidation', label: 'Consolidation Queue', description: 'Review suggested supersede actions' },

--- a/frontend/src/components/NavSidebar.tsx
+++ b/frontend/src/components/NavSidebar.tsx
@@ -18,7 +18,7 @@ const navGroups: NavGroup[] = [
   { label: 'Search', paths: ['/search', '/ask', '/feed'] },
   { label: 'Knowledge', paths: ['/memory', '/memory/consolidation', '/oracle-dig', '/learn', '/fleet-log', '/forum', '/activity', '/traces'] },
   { label: 'Vector', paths: ['/vector', '/vector/documents', '/vector/index', '/vector/first-run', '/vector/search', '/vector/settings', '/vector/export'] },
-  { label: 'System', paths: ['/mcp', '/canvas', '/canvas/plugins', '/metrics', '/storage', '/settings', '/export'] },
+  { label: 'System', paths: ['/mcp', '/canvas', '/canvas/plugins', '/metrics', '/storage', '/settings', '/tools/config', '/export'] },
 ];
 
 function itemPath(item: NavItem): string {

--- a/frontend/src/pages/ToolsConfigPage.tsx
+++ b/frontend/src/pages/ToolsConfigPage.tsx
@@ -1,0 +1,204 @@
+import { useCallback, useEffect, useState } from 'react';
+import { ErrorMessage, LoadingPanel } from '../components/AsyncState';
+import {
+  groupState,
+  loadToolConfig,
+  saveEnabledTools,
+  toggleGroup,
+  toggleTool,
+  type ToolConfigResponse,
+} from './toolsConfigHelpers';
+
+const STATE_LABEL = { all: 'All on', some: 'Partial', none: 'All off' } as const;
+
+function SourceBanner({ config }: { config: ToolConfigResponse }) {
+  return (
+    <div className="rounded-3xl border border-border bg-surface p-5 sm:p-6">
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">Config source</p>
+      <p className="mt-2 break-all text-sm text-text">{config.config_path || 'not resolved'}</p>
+      <p className="mt-2 text-xs text-text-muted">
+        {config.config_exists
+          ? 'This file exists and is the one a save writes to.'
+          : 'No file yet — saving creates it.'}{' '}
+        Lookup is first-match-wins, so a repo-root <code>arra.config.json</code> shadows the global
+        one entirely.
+      </p>
+      {config.env_override ? (
+        <p className="mt-4 rounded-2xl border border-accent-border p-3 text-sm text-accent">
+          <strong>Environment override active.</strong> ORACLE_ENABLED_TOOLS or
+          ORACLE_DISABLED_TOOLS is set, and environment beats the file — saving here will not change
+          the tools actually served until you unset it.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function AlwaysOn({ tools }: { tools: string[] }) {
+  if (tools.length === 0) return null;
+  return (
+    <div className="rounded-3xl border border-border bg-surface p-5 sm:p-6">
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">
+        On by default
+      </p>
+      <p className="mt-2 text-sm text-text-muted">
+        These belong to no group, so group switches do not reach them. They are still disableable
+        individually.
+      </p>
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        {tools.map((name) => (
+          <span
+            key={name}
+            className="flex items-center gap-3 rounded-2xl border border-border bg-surface-muted px-4 py-3 text-sm font-semibold text-text"
+          >
+            {name}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function GroupCard({
+  config,
+  group,
+  busy,
+  onToggleGroup,
+  onToggleTool,
+}: {
+  config: ToolConfigResponse;
+  group: string;
+  busy: boolean;
+  onToggleGroup: (group: string) => void;
+  onToggleTool: (name: string) => void;
+}) {
+  const entry = config.groups.find((g) => g.group === group);
+  if (!entry) return null;
+  const state = groupState(config, group);
+
+  return (
+    <div className="rounded-3xl border border-border bg-surface p-5 sm:p-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-accent">{group}</p>
+          <p className="mt-2 text-sm text-text-muted">
+            {entry.tools.length} tool{entry.tools.length === 1 ? '' : 's'} · {STATE_LABEL[state]}
+          </p>
+        </div>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => onToggleGroup(group)}
+          className="focus-ring rounded-xl border border-border bg-field px-3 py-2 text-sm text-text"
+        >
+          {state === 'none' ? `Enable ${group}` : `Disable ${group}`}
+        </button>
+      </div>
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        {entry.tools.map((tool) => (
+          <button
+            key={tool.name}
+            type="button"
+            disabled={busy}
+            aria-pressed={tool.enabled}
+            onClick={() => onToggleTool(tool.name)}
+            className={
+              tool.enabled
+                ? 'focus-ring flex items-center gap-3 rounded-2xl border border-accent-border bg-surface-muted px-4 py-3 text-sm font-semibold text-accent'
+                : 'focus-ring flex items-center gap-3 rounded-2xl border border-border bg-field px-4 py-3 text-sm text-text-muted'
+            }
+          >
+            {tool.enabled ? '●' : '○'} {tool.name}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function ToolsConfigPage() {
+  const [config, setConfig] = useState<ToolConfigResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [saved, setSaved] = useState('');
+
+  const refresh = useCallback(async () => {
+    setError('');
+    setLoading(true);
+    try {
+      setConfig(await loadToolConfig());
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const submit = useCallback(async (enabled: string[]) => {
+    setError('');
+    setSaved('');
+    setBusy(true);
+    try {
+      const next = await saveEnabledTools(enabled);
+      setConfig(next);
+      setSaved(`Saved — ${next.enabled_tools.length} tools enabled.`);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const retry = (
+    <button
+      type="button"
+      onClick={() => void refresh()}
+      className="focus-ring rounded-xl border border-border bg-field px-3 py-2 text-sm text-text"
+    >
+      Retry
+    </button>
+  );
+
+  if (loading) return <LoadingPanel title="Loading tool configuration" />;
+  if (error && !config) {
+    return <ErrorMessage title="Could not load tool configuration" message={error} action={retry} />;
+  }
+  if (!config) return null;
+
+  return (
+    <div className="grid gap-4">
+      {/* No page title here — AppShell renders it from routeMeta ('/tools/config').
+          Repeating it would duplicate the heading and put a second <h1> on the page. */}
+      <p className="text-sm text-text-muted">
+        {config.enabled_tools.length} of{' '}
+        {config.enabled_tools.length + config.disabled_tools.length} tools are served. Changes take
+        effect without a restart — the config file is watched.
+      </p>
+
+      {error ? <ErrorMessage title="Save failed" message={error} action={retry} /> : null}
+      {saved ? (
+        <p className="rounded-2xl border border-accent-border p-3 text-sm text-accent">{saved}</p>
+      ) : null}
+
+      <SourceBanner config={config} />
+
+      {config.groups.map((entry) => (
+        <GroupCard
+          key={entry.group}
+          config={config}
+          group={entry.group}
+          busy={busy}
+          onToggleGroup={(group) => void submit(toggleGroup(config, group))}
+          onToggleTool={(name) => void submit(toggleTool(config, name))}
+        />
+      ))}
+
+      <AlwaysOn tools={config.always_on_tools} />
+    </div>
+  );
+}

--- a/frontend/src/pages/toolsConfigHelpers.ts
+++ b/frontend/src/pages/toolsConfigHelpers.ts
@@ -1,0 +1,116 @@
+import { fetchJson } from './vectorSettingsHelpers';
+
+/**
+ * Shape of GET /api/v1/settings/tools — see src/routes/settings/tools.ts
+ * (serializeToolConfig). The route was defined but never mounted until #2822;
+ * this page is the first consumer.
+ */
+export interface ToolEntry {
+  name: string;
+  enabled: boolean;
+}
+
+export interface ToolGroupEntry {
+  group: string;
+  tools: ToolEntry[];
+}
+
+export interface ToolConfigResponse {
+  groups: ToolGroupEntry[];
+  enabled_tools: string[];
+  disabled_tools: string[];
+  /** No group — on by default, still disableable. ALWAYS_ON_TOOLS in tool-groups-core.ts. */
+  always_on_tools: string[];
+  /** The file a PUT will write. First-match-wins, so this may not be the global one. */
+  config_path: string;
+  config_exists: boolean;
+  /** ORACLE_ENABLED_TOOLS / ORACLE_DISABLED_TOOLS in effect — env beats the file. */
+  env_override: boolean;
+}
+
+const TOOLS_ENDPOINT = '/api/v1/settings/tools';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asStringList(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : [];
+}
+
+function asGroups(value: unknown): ToolGroupEntry[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((raw) => {
+    if (!isRecord(raw) || typeof raw.group !== 'string') return [];
+    const tools = Array.isArray(raw.tools)
+      ? raw.tools.flatMap((t) =>
+          isRecord(t) && typeof t.name === 'string'
+            ? [{ name: t.name, enabled: t.enabled === true }]
+            : [],
+        )
+      : [];
+    return [{ group: raw.group, tools }];
+  });
+}
+
+/**
+ * Parse defensively rather than casting. `fetchJson` returns `payload as T`,
+ * so a shape change would otherwise surface as a silent `undefined` at render
+ * time instead of an error here — the exact failure mode #2821 documents.
+ */
+export function parseToolConfig(body: unknown): ToolConfigResponse {
+  if (!isRecord(body)) throw new Error(`${TOOLS_ENDPOINT} returned a non-object payload`);
+  const groups = asGroups(body.groups);
+  if (groups.length === 0) throw new Error(`${TOOLS_ENDPOINT} returned no tool groups`);
+  return {
+    groups,
+    enabled_tools: asStringList(body.enabled_tools),
+    disabled_tools: asStringList(body.disabled_tools),
+    always_on_tools: asStringList(body.always_on_tools),
+    config_path: typeof body.config_path === 'string' ? body.config_path : '',
+    config_exists: body.config_exists === true,
+    env_override: body.env_override === true,
+  };
+}
+
+export async function loadToolConfig(): Promise<ToolConfigResponse> {
+  return parseToolConfig(await fetchJson<unknown>(TOOLS_ENDPOINT));
+}
+
+/** PUT takes the full allow-list — anything omitted becomes disabled. */
+export async function saveEnabledTools(enabled: string[]): Promise<ToolConfigResponse> {
+  const body = await fetchJson<unknown>(TOOLS_ENDPOINT, {
+    method: 'PUT',
+    body: JSON.stringify({ enabled_tools: enabled }),
+  });
+  return parseToolConfig(body);
+}
+
+/** Flip one tool and return the allow-list to submit. */
+export function toggleTool(config: ToolConfigResponse, name: string): string[] {
+  const enabled = new Set(config.enabled_tools);
+  if (enabled.has(name)) enabled.delete(name);
+  else enabled.add(name);
+  return [...enabled];
+}
+
+/** Flip a whole group at once — off if any member is on, otherwise on. */
+export function toggleGroup(config: ToolConfigResponse, group: string): string[] {
+  const entry = config.groups.find((g) => g.group === group);
+  if (!entry) return config.enabled_tools;
+  const enabled = new Set(config.enabled_tools);
+  const anyOn = entry.tools.some((t) => enabled.has(t.name));
+  for (const tool of entry.tools) {
+    if (anyOn) enabled.delete(tool.name);
+    else enabled.add(tool.name);
+  }
+  return [...enabled];
+}
+
+export function groupState(config: ToolConfigResponse, group: string): 'all' | 'some' | 'none' {
+  const entry = config.groups.find((g) => g.group === group);
+  if (!entry || entry.tools.length === 0) return 'none';
+  const on = entry.tools.filter((t) => config.enabled_tools.includes(t.name)).length;
+  if (on === 0) return 'none';
+  return on === entry.tools.length ? 'all' : 'some';
+}

--- a/frontend/src/routeMeta.ts
+++ b/frontend/src/routeMeta.ts
@@ -82,6 +82,13 @@ export function routeMeta(pathname: string, search = ''): RouteMeta {
     ]);
   }
 
+  if (pathname === '/tools/config') {
+    return base('Tool configuration', 'Settings', 'Enable or disable the MCP tools this Oracle serves.', [
+      { label: 'Settings', to: '/settings' },
+      { label: 'Tools' },
+    ]);
+  }
+
   if (pathname === '/memory') {
     const query = new URLSearchParams(search).get('q')?.trim();
     const description = query

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -28,6 +28,7 @@ import { VectorSearchPage } from './pages/VectorSearchPage';
 import { VectorDocumentsPage } from './pages/VectorDocumentsPage';
 import { VectorSearchResultsPage } from './pages/VectorSearchResultsPage';
 import { VectorExportPage } from './pages/VectorExportPage';
+import { ToolsConfigPage } from './pages/ToolsConfigPage';
 import { VectorSettingsPage } from './pages/VectorSettingsPage';
 import { VectorFirstRunWizardPage } from './pages/FirstRunWizard';
 import { IndexManagerPanel } from './pages/IndexManagerPanel';
@@ -65,6 +66,7 @@ export const frontendRoutes = [
   '/mcp',
   '/storage',
   '/settings',
+  '/tools/config',
   '/simple',
 ] as const;
 export type FrontendRoute = typeof frontendRoutes[number];
@@ -149,6 +151,7 @@ export function DashboardRoutes({
         path="/settings"
         element={<SettingsPage menuCount={menu.length} pluginCount={plugins.length} surfaceCount={surfaceCount} updatedAt={updatedAt} onRefresh={onRefresh} />}
       />
+      <Route path="/tools/config" element={<ToolsConfigPage />} />
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   );


### PR DESCRIPTION
Refs #2822

Mounting `toolSettingsRoute` published its menu metadata — `menu: { path: '/tools/config' }` at `src/routes/settings/tools.ts:65,97` — but no such page existed. On alpha the route was unmounted so the entry never surfaced; after #2822 it does, pointing at nothing.

The API is real and working, so this builds the page rather than hiding the entry.

## What it does

- **Group switches** — enable/disable a whole tool group in one click, with `All on` / `Partial` / `All off` state
- **Per-tool toggles** — flip any individual tool
- **Config source panel** — shows *which file actually wins*. Lookup is first-match-wins, so a repo-root `arra.config.json` shadows the global one entirely; the page names the file a save will write to and whether it exists yet
- **Env-override warning** — when `ORACLE_ENABLED_TOOLS` / `ORACLE_DISABLED_TOOLS` are set, environment beats the file and saving here changes nothing visible. The page says so instead of silently lying
- **On-by-default section** — `ALWAYS_ON_TOOLS` belong to no group, so group switches do not reach them. Shown separately rather than looking like an omission

## Verified against the running backend, not mocked

Driven through the real UI with Playwright, clicking the nav entry rather than deep-linking — which also proves the previously-dead nav link now resolves:

```
nav link present: true
url:              http://localhost:5199/tools/config
groups rendered:  search knowledge session forum oracle trace standalone
config path shown: true
console errors:   none

clicked "Enable session"
  session group: All off -> All on
  backend after: 15 tools enabled, oracle_inbox present
```

The toggle went UI → `PUT /api/v1/settings/tools` → config file → `GET` reflecting it. Not a mock.

The developer's real `~/.arra-oracle-v2/config.json` was mutated by that probe and **restored afterwards**; a copy of both states is kept outside the repo.

## Notes

- **No page title in the component.** `AppShell` already renders the title and description from `routeMeta` for `/tools/config`. An earlier revision repeated it, which duplicated the heading and put a second `<h1>` on the page. Removed, with a comment so it does not come back.
- **Defensive parsing, not casting.** `fetchJson` returns `payload as T`, so a shape change would otherwise surface as a silent `undefined` at render time — the exact failure mode #2821 documents. `parseToolConfig` validates and throws with the endpoint name instead.
- **Deep-linking to `/tools/config` returns 404 from the backend.** So do `/settings` and `/plugins` — the server has no SPA fallback. Pre-existing, unrelated to this change, and worth its own issue.

## Gates

```
bunx tsc --noEmit          exit 0
cd frontend && bun run build   ✓ built in 965ms
```

All touched files ≤ 250 lines (largest: `ToolsConfigPage.tsx` at 204).

Screenshot saved locally at `ψ/outbox/2026-07-25_tools-config-page.png` (that directory is gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
