### PR TITLE
feat(server): serve the built frontend, as the docs already claimed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,7 +206,16 @@ cd frontend && bun run build
 bun run server              # http://localhost:47778
 ```
 
-In production, the backend serves both API endpoints and the built React app from `frontend/dist/`.
+In production, the backend serves both API endpoints and the built React app from `frontend/dist/`
+(`src/middleware/spa.ts`). It **content-negotiates** rather than mounting the app at `/`: a request
+that explicitly accepts `text/html` gets the app shell — including deep links like `/settings` and
+`/tools/config` — while every other client keeps today's JSON byte-for-byte, because `/` is the JSON
+root endpoint that `maw arra` and the #2820 enrichment read. Paths under `/api`, `/mcp` and `/simple`
+are never intercepted, so a missing endpoint still 404s as JSON instead of silently returning HTML.
+
+Set `ORACLE_FRONTEND_DIST` to serve a build from elsewhere. If no build exists the middleware is
+inert, so API-only deploys need no flag. Pinned by `tests/http/frontend/spa-serving.test.ts` — this
+paragraph described behaviour that did not exist until #2831.
 
 ## Development Workflows
 

--- a/src/middleware/spa.ts
+++ b/src/middleware/spa.ts
@@ -1,0 +1,123 @@
+/**
+ * Serve the built React app from `frontend/dist`.
+ *
+ * CLAUDE.md documented single-process production mode ("the backend serves both
+ * API endpoints and the built React app from frontend/dist/") but nothing
+ * implemented it: `/settings`, `/plugins`, `/status` all 404'd while
+ * `frontend/dist/index.html` sat on disk. See #2831.
+ *
+ * Two constraints shaped this:
+ *
+ * 1. `/` must keep returning the JSON root endpoint for non-browser clients.
+ *    `maw arra` and the enrichment added in #2820 read it. So the SPA is served
+ *    by CONTENT NEGOTIATION: a request that accepts `text/html` gets the app,
+ *    everything else keeps today's JSON byte-for-byte.
+ *
+ * 2. API surfaces must never be shadowed. Anything under an API prefix falls
+ *    through untouched, so a missing endpoint still 404s as JSON rather than
+ *    silently returning HTML — which would turn a routing bug into a confusing
+ *    parse error at the caller.
+ */
+import { Elysia } from 'elysia';
+import { existsSync } from 'node:fs';
+import { join, normalize, resolve } from 'node:path';
+
+/** Prefixes the SPA must never intercept. */
+const RESERVED_PREFIXES = ['/api', '/mcp', '/simple', '/health', '/metrics', '/plugins/'];
+
+const CONTENT_TYPES: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.map': 'application/json; charset=utf-8',
+  '.txt': 'text/plain; charset=utf-8',
+  '.webmanifest': 'application/manifest+json',
+};
+
+export function contentTypeFor(pathname: string): string {
+  const dot = pathname.lastIndexOf('.');
+  if (dot === -1) return 'application/octet-stream';
+  return CONTENT_TYPES[pathname.slice(dot).toLowerCase()] ?? 'application/octet-stream';
+}
+
+export function isReservedPath(pathname: string): boolean {
+  return RESERVED_PREFIXES.some((prefix) =>
+    prefix.endsWith('/') ? pathname.startsWith(prefix) : pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+export function wantsHtml(request: Request): boolean {
+  const accept = request.headers.get('accept') ?? '';
+  // `*/*` (curl, fetch defaults) must NOT count — otherwise every JSON client
+  // gets HTML. Only an explicit text/html preference wins.
+  return accept.split(',').some((part) => part.trim().toLowerCase().startsWith('text/html'));
+}
+
+/** Resolve a request path inside distDir, refusing anything that escapes it. */
+export function safeAssetPath(distDir: string, pathname: string): string | null {
+  const decoded = (() => {
+    try {
+      return decodeURIComponent(pathname);
+    } catch {
+      return null;
+    }
+  })();
+  if (decoded == null || decoded.includes('\0')) return null;
+  const root = resolve(distDir);
+  const candidate = resolve(root, `.${normalize(decoded)}`);
+  return candidate === root || candidate.startsWith(`${root}/`) ? candidate : null;
+}
+
+export function resolveDistDir(env: Record<string, string | undefined> = process.env): string {
+  const explicit = env.ORACLE_FRONTEND_DIST?.trim();
+  if (explicit) return resolve(explicit);
+  const repoRoot = env.ORACLE_REPO_ROOT?.trim() || process.cwd();
+  return join(resolve(repoRoot), 'frontend', 'dist');
+}
+
+export type SpaOptions = { distDir?: string; env?: Record<string, string | undefined> };
+
+export function createSpaMiddleware(options: SpaOptions = {}) {
+  const distDir = options.distDir ?? resolveDistDir(options.env);
+  const indexPath = join(distDir, 'index.html');
+
+  return new Elysia({ name: 'spa' }).onRequest(({ request }) => {
+    // A build may legitimately be absent (dev, CI, API-only deploys). Checked per
+    // request rather than at construction so `bun run build` needs no restart.
+    if (!existsSync(indexPath)) return;
+    if (request.method !== 'GET' && request.method !== 'HEAD') return;
+
+    const pathname = new URL(request.url).pathname;
+    if (isReservedPath(pathname)) return;
+
+    // Real build artefacts (/assets/*, favicon, …) are served regardless of Accept.
+    if (pathname !== '/') {
+      const asset = safeAssetPath(distDir, pathname);
+      if (asset && asset !== indexPath && existsSync(asset)) {
+        const file = Bun.file(asset);
+        if (file.size > 0) {
+          return new Response(file, { headers: { 'content-type': contentTypeFor(pathname) } });
+        }
+      }
+    }
+
+    // Everything else: browsers get the app shell so deep links work; JSON
+    // clients fall through to the routes they asked for.
+    if (!wantsHtml(request)) return;
+    return new Response(Bun.file(indexPath), {
+      headers: { 'content-type': 'text/html; charset=utf-8', 'cache-control': 'no-cache' },
+    });
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -75,6 +75,7 @@ import { fileWatcherService } from './services/file-watcher.ts';
 import { createSleepConsolidationWorker } from './workers/sleep-consolidation.ts';
 import { createEntityBackfillWorker } from './workers/entity-backfill.ts';
 import { gatewayPlugin } from './gateway/index.ts';
+import { createSpaMiddleware } from './middleware/spa.ts';
 import { simpleModeResponse } from './simple-mode.ts';
 import pkg from '../package.json' with { type: 'json' };
 
@@ -131,6 +132,7 @@ export function createApp({ unifiedPlugins, runtimeRef = createUnifiedRuntimeRef
     .use(swagger(createOpenApiSwaggerConfig(pkg.version)))
     .use(createResponseFormatMiddleware())
     .use(createCompressMiddleware())
+    .use(createSpaMiddleware())
     .use(createEtagMiddleware())
     .onBeforeHandle(({ request, set }) => {
       const pathname = new URL(request.url).pathname;

--- a/tests/http/frontend/spa-serving.test.ts
+++ b/tests/http/frontend/spa-serving.test.ts
@@ -1,0 +1,168 @@
+/**
+ * The backend must serve the built React app — and must not shadow the API doing it.
+ *
+ * CLAUDE.md documented single-process production mode, but nothing implemented it:
+ * `/settings`, `/plugins` and `/status` all 404'd with `frontend/dist/index.html`
+ * present on disk. See #2831.
+ *
+ * The delicate part is `/`: it is the JSON root endpoint that `maw arra` and the
+ * #2820 enrichment read. Serving the SPA there unconditionally would break them, so
+ * the middleware content-negotiates. These tests pin BOTH sides of that.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  contentTypeFor,
+  createSpaMiddleware,
+  isReservedPath,
+  safeAssetPath,
+  wantsHtml,
+} from '../../../src/middleware/spa.ts';
+
+const INDEX_HTML = '<!doctype html><title>Arra</title><div id="root"></div>';
+const ASSET_JS = 'export const built = true;';
+
+let distDir = '';
+let app: Elysia;
+
+function get(path: string, accept?: string) {
+  return app.handle(
+    new Request(`http://local${path}`, accept ? { headers: { accept } } : undefined),
+  );
+}
+
+beforeAll(() => {
+  distDir = mkdtempSync(join(tmpdir(), 'spa-dist-'));
+  writeFileSync(join(distDir, 'index.html'), INDEX_HTML);
+  mkdirSync(join(distDir, 'assets'));
+  writeFileSync(join(distDir, 'assets', 'app.js'), ASSET_JS);
+
+  app = new Elysia()
+    .use(createSpaMiddleware({ distDir }))
+    .get('/', () => ({ server: 'arra-oracle-v3', status: 'ok' }))
+    .get('/api/v1/health', () => ({ status: 'ok' }))
+    .all('*', ({ set }) => {
+      set.status = 404;
+      return { error: 'Not Found' };
+    });
+});
+
+afterAll(() => {
+  // Leave the temp dir for inspection rather than deleting — nothing is deleted.
+});
+
+describe('SPA serving', () => {
+  test('a browser deep link gets the app shell instead of 404', async () => {
+    const res = await get('/settings', 'text/html,application/xhtml+xml');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/html');
+    expect(await res.text()).toContain('<div id="root">');
+  });
+
+  test('a nested deep link also gets the shell', async () => {
+    const res = await get('/tools/config', 'text/html');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('<div id="root">');
+  });
+
+  test('build assets are served regardless of Accept', async () => {
+    const res = await get('/assets/app.js');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/javascript');
+    expect(await res.text()).toBe(ASSET_JS);
+  });
+});
+
+describe('SPA must not shadow the API', () => {
+  test('/ still returns JSON for non-browser clients', async () => {
+    const res = await get('/');
+    expect(res.headers.get('content-type')).toContain('application/json');
+    expect(await res.json()).toMatchObject({ server: 'arra-oracle-v3' });
+  });
+
+  test('/ returns JSON even when the client sends */*', async () => {
+    const res = await get('/', '*/*');
+    expect(await res.json()).toMatchObject({ server: 'arra-oracle-v3' });
+  });
+
+  test('a browser visiting / gets the app, not the JSON root', async () => {
+    const res = await get('/', 'text/html,*/*;q=0.8');
+    expect(await res.text()).toContain('<div id="root">');
+  });
+
+  test('an unknown API path still 404s as JSON, never as HTML', async () => {
+    // Serving HTML here would turn a routing bug into a parse error at the caller.
+    const res = await get('/api/v1/does-not-exist', 'text/html');
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ error: 'Not Found' });
+  });
+
+  test('a known API route is untouched by the middleware', async () => {
+    const res = await get('/api/v1/health', 'text/html');
+    expect(await res.json()).toMatchObject({ status: 'ok' });
+  });
+
+  test('POST is never intercepted', async () => {
+    const res = await app.handle(
+      new Request('http://local/settings', { method: 'POST', headers: { accept: 'text/html' } }),
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('helpers', () => {
+  test('only an explicit text/html preference counts as a browser', () => {
+    expect(wantsHtml(new Request('http://x/', { headers: { accept: 'text/html' } }))).toBe(true);
+    expect(wantsHtml(new Request('http://x/', { headers: { accept: '*/*' } }))).toBe(false);
+    expect(wantsHtml(new Request('http://x/', { headers: { accept: 'application/json' } }))).toBe(false);
+    expect(wantsHtml(new Request('http://x/'))).toBe(false);
+  });
+
+  test('reserved prefixes are excluded, lookalikes are not', () => {
+    expect(isReservedPath('/api')).toBe(true);
+    expect(isReservedPath('/api/v1/health')).toBe(true);
+    expect(isReservedPath('/mcp')).toBe(true);
+    expect(isReservedPath('/simple')).toBe(true);
+    expect(isReservedPath('/settings')).toBe(false);
+    expect(isReservedPath('/apixyz')).toBe(false);
+  });
+
+  test('path traversal is contained inside the dist directory', () => {
+    // The security property is CONTAINMENT, not rejection. `normalize` collapses
+    // leading `..` on an absolute path, so a traversal attempt lands on a path
+    // inside dist that simply does not exist — the request then falls through.
+    // An earlier revision of this test asserted `toBeNull()` and went red; the
+    // probe was wrong, not the code.
+    for (const attempt of [
+      '/../../etc/passwd',
+      '/assets/%2e%2e%2f%2e%2e%2fetc/passwd',
+      '/assets/../../../../etc/passwd',
+    ]) {
+      const resolved = safeAssetPath('/tmp/dist', attempt);
+      expect(resolved).not.toBeNull();
+      expect(resolved!.startsWith('/tmp/dist/')).toBe(true);
+      expect(resolved).not.toBe('/etc/passwd');
+    }
+    expect(safeAssetPath('/tmp/dist', '/assets/app.js')).toBe('/tmp/dist/assets/app.js');
+    // A NUL byte is rejected outright rather than contained.
+    expect(safeAssetPath('/tmp/dist', '/assets/app.js\0.png')).toBeNull();
+  });
+
+  test('a traversal attempt does not serve a file from outside dist', async () => {
+    // End-to-end proof of the property above, through the real middleware.
+    const res = await get('/assets/../../../../etc/passwd', 'text/html');
+    const body = await res.text();
+    expect(body).not.toContain('root:');
+    expect(body).toContain('<div id="root">'); // fell through to the app shell
+  });
+
+  test('content types cover the build output', () => {
+    expect(contentTypeFor('/a.js')).toContain('text/javascript');
+    expect(contentTypeFor('/a.css')).toContain('text/css');
+    expect(contentTypeFor('/a.woff2')).toBe('font/woff2');
+    expect(contentTypeFor('/noext')).toBe('application/octet-stream');
+  });
+});


### PR DESCRIPTION
Closes #2831

`CLAUDE.md` documented single-process production mode — build the frontend, run the server, get both. No code path served `frontend/dist`. With `dist/index.html` sitting on disk, `/settings`, `/plugins` and `/status` all 404'd; `/` returned the JSON root endpoint, not the app.

This makes the claim true instead of deleting it.

## The delicate part is `/`

`/` is the JSON root endpoint that `maw arra` and the enrichment from #2820 read. Mounting the SPA there would break them. So `src/middleware/spa.ts` **content-negotiates**:

| Request | Result |
|---|---|
| `GET /` with `Accept: text/html` | app shell |
| `GET /` with `Accept: */*` or none | **JSON root endpoint, byte-for-byte unchanged** |
| `GET /settings` from a browser | app shell (deep links work) |
| `GET /assets/app.js` | the real file, any `Accept` |
| Anything under `/api`, `/mcp`, `/simple` | never intercepted |

`*/*` deliberately does **not** count as a browser — curl and `fetch` defaults send it, and treating it as HTML would hand every JSON client an app shell.

API paths are excluded outright so a missing endpoint still 404s as JSON. Returning HTML there would turn a routing bug into a parse error at the caller, which is strictly harder to debug than a 404.

## Verified live, not just in tests

Against the running server after `bun run build`:

```
PATH                      CODE   BODY
/            (browser)    200    id="root"
/settings    (browser)    200    id="root"
/plugins     (browser)    200    id="root"
/tools/config(browser)    200    id="root"
/status      (browser)    200    id="root"

/            (json)       200    "server":"arra-oracle-v3"
/api/v1/settings/tools    200    (accept: */*)
```

Every one of those browser paths was a 404 before this commit.

## A red test that was my own fault

`safeAssetPath('/tmp/dist', '/../../etc/passwd')` returned `/tmp/dist/etc/passwd`, and the first version of the test asserted `toBeNull()`. The probe was wrong, not the code: `normalize` collapses leading `..` on an absolute path, so a traversal attempt lands *inside* dist on a file that does not exist and falls through.

The security property is **containment**, not rejection, so the test now asserts containment — plus an end-to-end case proving `/assets/../../../../etc/passwd` returns the app shell and never `root:`. NUL bytes are still rejected outright.

## Notes

- **`Accept: text/html` on an API path returns 406.** Pre-existing (`src/middleware/content-type.ts:89`), unchanged here — verified `/api/v1/health` behaves identically with and without this branch.
- **`src/server.ts` is 293 lines, over the ≤250 rule.** It was already 291 on alpha; this adds one `.use()` line. Not introduced here, and 22 tracked files currently exceed the limit with nothing enforcing it — filed separately.
- The middleware checks for `index.html` **per request**, so `bun run build` takes effect without a restart, and API-only deploys with no build need no flag.
- `ORACLE_FRONTEND_DIST` overrides the location.

## Gates

```
bunx tsc --noEmit              exit 0
bun test tests/http/frontend/  14 pass / 0 fail
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
