### PR TITLE
fix(learn): GET /api/learn wedged the server — bound it

### DIFF
--- a/src/routes/learn/list.ts
+++ b/src/routes/learn/list.ts
@@ -1,5 +1,5 @@
 import { Elysia } from 'elysia';
-import { and, desc, eq, isNull, type SQL } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, isNull, type SQL } from 'drizzle-orm';
 import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
 import { db, oracleDocuments } from '../../db/index.ts';
 import { currentTenantId } from '../../middleware/tenant.ts';
@@ -36,15 +36,31 @@ function displayContentFrom(content: string, title: string): string {
   return display.startsWith(`${title}\n\n`) ? display.slice(title.length).trim() : display || content;
 }
 
-function contentById(id: string): string {
-  return db.select({ content: oracleFts.content })
-    .from(oracleFts)
-    .where(eq(oracleFts.id, id))
-    .get()?.content ?? '';
+export const DEFAULT_LEARN_LIMIT = 50;
+export const MAX_LEARN_LIMIT = 500;
+
+/** Blank/absent means "not supplied" — `Number('')` is 0, which is finite. */
+function numeric(raw: unknown): number | null {
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw === 'string' && raw.trim() === '') return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
 }
 
-function learnEntry(row: LearnDoc) {
-  const content = contentById(row.id);
+export function clampLimit(raw: unknown): number {
+  const n = numeric(raw);
+  if (n === null) return DEFAULT_LEARN_LIMIT;
+  return Math.min(Math.max(Math.trunc(n), 1), MAX_LEARN_LIMIT);
+}
+
+export function clampOffset(raw: unknown): number {
+  const n = numeric(raw);
+  if (n === null || n < 0) return 0;
+  return Math.trunc(n);
+}
+
+function learnEntry(row: LearnDoc & { ftsContent: string | null }) {
+  const content = row.ftsContent ?? '';
   const title = titleFrom(content, row);
   return {
     id: row.id,
@@ -59,22 +75,79 @@ function learnEntry(row: LearnDoc) {
   };
 }
 
-function listLearnEntries() {
+function learnFilters(): SQL[] {
   const filters: SQL[] = [eq(oracleDocuments.type, 'learning'), isNull(oracleDocuments.supersededAt)];
   const tenantId = currentTenantId();
   if (tenantId) filters.push(eq(oracleDocuments.tenantId, tenantId));
+  return filters;
+}
+
+/**
+ * Content for a page of ids, in ONE query.
+ *
+ * `oracle_fts` is an FTS5 virtual table whose `id` column is UNINDEXED, so any
+ * lookup by id costs a full scan of the FTS content (~20ms here). The shape that
+ * matters is therefore *how many scans*, not how many rows come back:
+ *
+ *   per-row `WHERE id = ?`   17,500 scans  ≈ 350s   (the original — a wedged server)
+ *   LEFT JOIN on f.id = d.id  did not finish in 2 minutes even with LIMIT 50
+ *   `WHERE id IN (…50 ids)`   ONE scan     ≈ 25ms   ← this
+ *
+ * Measured against the reference corpus (35,179 docs / 17,500 learnings).
+ */
+function contentByIds(ids: string[]): Map<string, string> {
+  if (ids.length === 0) return new Map();
+  const rows = db.select({ id: oracleFts.id, content: oracleFts.content })
+    .from(oracleFts)
+    .where(inArray(oracleFts.id, ids))
+    .all();
+  return new Map(rows.flatMap((row) => (row.id ? [[row.id, row.content ?? '']] as const : [])));
+}
+
+/**
+ * Paginated listing: page the real (indexed) table first, then fetch content for
+ * just that page. Never touches the FTS table more than once per request.
+ *
+ * The previous version selected EVERY matching row with no LIMIT and then issued
+ * one further synchronous FTS query per row. On the reference corpus that is
+ * ~17,500 full scans in a single request on Elysia's one event loop — it pinned
+ * the server at 100% CPU indefinitely, so a plain GET was a denial of service.
+ */
+export function listLearnEntries(limit = DEFAULT_LEARN_LIMIT, offset = 0) {
+  const filters = learnFilters();
   const rows = db.select().from(oracleDocuments)
     .where(and(...filters))
     .orderBy(desc(oracleDocuments.updatedAt))
+    .limit(limit)
+    .offset(offset)
     .all();
-  const items = rows.map(learnEntry);
-  return { items, total: items.length };
+
+  const contents = contentByIds(rows.map((row) => row.id));
+  const total = db.select({ value: count() })
+    .from(oracleDocuments)
+    .where(and(...filters))
+    .get()?.value ?? 0;
+
+  return {
+    items: rows.map((row) => learnEntry({ ...row, ftsContent: contents.get(row.id) ?? '' })),
+    total,
+    limit,
+    offset,
+  };
 }
 
 export function createLearnListRoutes() {
-  return new Elysia().get('/learn', () => listLearnEntries(), {
-    detail: { tags: ['knowledge'], menu: { group: 'main', label: 'Learn', order: 35 }, summary: 'List learn entries' },
-  });
+  return new Elysia().get(
+    '/learn',
+    ({ query }) => listLearnEntries(clampLimit(query?.limit), clampOffset(query?.offset)),
+    {
+      detail: {
+        tags: ['knowledge'],
+        menu: { group: 'main', label: 'Learn', order: 35 },
+        summary: 'List learn entries (paginated)',
+      },
+    },
+  );
 }
 
 export const learnListRoutes = createLearnListRoutes();

--- a/tests/http/knowledge/learn-list-bounded.test.ts
+++ b/tests/http/knowledge/learn-list-bounded.test.ts
@@ -1,0 +1,103 @@
+/**
+ * `GET /api/learn` must do a BOUNDED amount of work, whatever the corpus size.
+ *
+ * It used to select every matching row with no LIMIT and then issue one further
+ * synchronous FTS query per row. `oracle_fts` is an FTS5 virtual table with
+ * `id UNINDEXED`, so each of those lookups is a full scan (~20ms measured). On
+ * the reference corpus — 35,179 documents, 17,500 learnings — that is roughly
+ * 350 seconds of blocking work on Elysia's single event loop. The server pinned
+ * at 100% CPU and stopped answering anything at all: a plain unauthenticated GET
+ * was a denial of service.
+ *
+ * Two things this test exists to stop coming back:
+ *   1. an unbounded result set
+ *   2. per-row FTS lookups
+ *
+ * Note on how the bug hid: an in-process `Promise.race` with `setTimeout` will
+ * NOT catch it, because the timer lives on the same event loop the handler is
+ * blocking. It has to be an OS-level timeout, or an assertion on the shape of
+ * the work as below.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  DEFAULT_LEARN_LIMIT,
+  MAX_LEARN_LIMIT,
+  clampLimit,
+  clampOffset,
+  createLearnListRoutes,
+  listLearnEntries,
+} from '../../../src/routes/learn/list.ts';
+
+describe('learn list pagination guards', () => {
+  test('an absent or unparseable limit falls back to the default', () => {
+    expect(clampLimit(undefined)).toBe(DEFAULT_LEARN_LIMIT);
+    expect(clampLimit('')).toBe(DEFAULT_LEARN_LIMIT);
+    expect(clampLimit('not-a-number')).toBe(DEFAULT_LEARN_LIMIT);
+  });
+
+  test('limit is clamped to a hard ceiling — this is the DoS guard', () => {
+    expect(clampLimit(99999)).toBe(MAX_LEARN_LIMIT);
+    expect(clampLimit('99999')).toBe(MAX_LEARN_LIMIT);
+    expect(clampLimit(Number.MAX_SAFE_INTEGER)).toBe(MAX_LEARN_LIMIT);
+    expect(clampLimit(Infinity)).toBe(DEFAULT_LEARN_LIMIT); // not finite -> default
+  });
+
+  test('limit can never be zero or negative', () => {
+    expect(clampLimit(0)).toBe(1);
+    expect(clampLimit(-10)).toBe(1);
+  });
+
+  test('offset is non-negative and integral', () => {
+    expect(clampOffset(undefined)).toBe(0);
+    expect(clampOffset(-5)).toBe(0);
+    expect(clampOffset('12')).toBe(12);
+    expect(clampOffset(7.9)).toBe(7);
+  });
+
+  test('the ceiling is low enough to stay bounded', () => {
+    // If someone raises MAX_LEARN_LIMIT to "unlimited", the guard is gone.
+    expect(MAX_LEARN_LIMIT).toBeLessThanOrEqual(1000);
+    expect(DEFAULT_LEARN_LIMIT).toBeLessThanOrEqual(MAX_LEARN_LIMIT);
+  });
+});
+
+describe('learn list response contract', () => {
+  test('never returns more items than the requested limit', () => {
+    const page = listLearnEntries(5, 0);
+    expect(page.items.length).toBeLessThanOrEqual(5);
+    expect(page.limit).toBe(5);
+    expect(page.offset).toBe(0);
+  });
+
+  test('total reports the full set, not just the page', () => {
+    const page = listLearnEntries(1, 0);
+    expect(typeof page.total).toBe('number');
+    expect(page.total).toBeGreaterThanOrEqual(page.items.length);
+  });
+
+  test('offset advances the window without changing total', () => {
+    const first = listLearnEntries(2, 0);
+    const second = listLearnEntries(2, 2);
+    expect(second.offset).toBe(2);
+    expect(second.total).toBe(first.total);
+    const overlap = first.items.filter((item) => second.items.some((other) => other.id === item.id));
+    expect(overlap).toEqual([]);
+  });
+
+  test('the route caps a hostile limit rather than honouring it', async () => {
+    const app = createLearnListRoutes();
+    const res = await app.handle(new Request('http://local/learn?limit=999999'));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: unknown[]; limit: number };
+    expect(body.limit).toBe(MAX_LEARN_LIMIT);
+    expect(body.items.length).toBeLessThanOrEqual(MAX_LEARN_LIMIT);
+  });
+
+  test('a default request is bounded even with no query string', async () => {
+    const app = createLearnListRoutes();
+    const res = await app.handle(new Request('http://local/learn'));
+    const body = (await res.json()) as { items: unknown[]; limit: number };
+    expect(body.limit).toBe(DEFAULT_LEARN_LIMIT);
+    expect(body.items.length).toBeLessThanOrEqual(DEFAULT_LEARN_LIMIT);
+  });
+});


### PR DESCRIPTION
Closes #2835

**A single unauthenticated `GET /api/learn` pinned the server at 100% CPU indefinitely.** Elysia is single-threaded, so one request took the whole process down — port still LISTEN, every other request timing out. Observed live: 95% CPU for 19 minutes.

## Root cause

`src/routes/learn/list.ts` selected **every** matching row with no `LIMIT`, then issued **one synchronous FTS query per row**.

The multiplier is what makes it fatal: `oracle_fts` is an FTS5 virtual table declared `id UNINDEXED`, so a lookup by id cannot seek — it is a full scan of the FTS content.

Measured on the real corpus (35,179 docs / **17,500** learnings): ~20 ms per scan × 17,500 = **≈ 350 s of blocking work per request**.

## The wrong turn, kept in the record

The obvious fix — `LEFT JOIN oracle_fts ON f.id = d.id` with `LIMIT 50` — **was worse**. In raw `sqlite3` it did not finish in 2 minutes even with the limit applied, because SQLite re-scans the virtual table rather than seeking into it.

The cost is *number of FTS scans*, not rows returned:

| Approach | FTS scans | Time |
|---|---|---|
| per-row `WHERE id = ?` (original) | 17,500 | ≈ 350 s |
| `LEFT JOIN` + `LIMIT 50` | — | did not finish in 2 min |
| page the indexed table, then **one** `WHERE id IN (…50 ids)` | **1** | **43 ms** |

## Result

```
before:  /api/learn                ⚠️  HUNG (OS-killed at 45s)
after:   /api/learn                200  66ms
         /api/learn?limit=99999    200  77ms   (capped, not honoured)
         /api/learn?offset=17000   200  80ms
```

## How it stayed hidden

Two probes missed it:

1. **A plausible wrong explanation closed the case early.** The wedge first appeared while 33 agent processes were running, so "resource contention, not a bug" fit the evidence. It was wrong, and it was the comfortable answer because it blamed the observer.
2. **`Promise.race` + `setTimeout` cannot see this class of bug** — the timer lives on the same event loop the handler is blocking, so it never fires and the probe hangs along with it. Only an **OS-level timeout** (separate process) surfaced it.

## Compatibility — checked before shipping

Response gains `limit`/`offset`; `items` is now a page.

- `frontend/` never calls it
- `maw-plugin` uses only the **POST** verb (`index.ts:139`)
- `src/routes/menu/menu-items.ts:15` maps route metadata only
- existing tests pass unchanged

## Guard

`tests/http/knowledge/learn-list-bounded.test.ts` — the ceiling holds, `limit=999999` is capped, a bare request stays bounded, and `MAX_LEARN_LIMIT` cannot be raised to "unlimited" without failing.

It also caught a real edge in the first fix: `Number('')` is `0`, so an empty `?limit=` returned 1 item instead of the default.

## Gates

```
bunx tsc --noEmit                                                    exit 0
bun test tests/http/knowledge/ src/routes/menu/__tests__/…           16 pass / 0 fail
```

Credit: ui-oracle spotted the wedge and correctly diagnosed single-threaded blocking before the cause was known, and flagged the pagination-compatibility risk before it shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)