### PR TITLE
fix(config): stop a test from reading the developer's own config

### DIFF
--- a/src/config/__tests__/tool-groups-config-source.test.ts
+++ b/src/config/__tests__/tool-groups-config-source.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Where `loadToolGroupConfig` reads from — the file-resolution tier, not the
+ * group algebra (that lives in tool-groups.test.ts).
+ *
+ * Resolution is FIRST-MATCH-WINS across four locations: two under the repo root,
+ * then two under the global data dir. That last tier is the trap these tests
+ * exist for: passing a nonexistent repoRoot does NOT isolate a test, because the
+ * lookup falls through to the developer's own ~/.arra-oracle-v2/config.json.
+ */
+import { describe, it, expect } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { loadToolGroupConfig } from '../tool-groups.ts';
+
+describe('tool-groups config source', () => {
+  it('defaults to all groups enabled', () => {
+    // A nonexistent repoRoot is NOT isolation: the lookup is first-match-wins and
+    // falls through to the DEVELOPER'S OWN ~/.arra-oracle-v2/config.json. This
+    // passed for years only because that file had no `tools` key — the day one
+    // was added it went red on pristine alpha with nothing in the diff to explain it.
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-defaults-'));
+    const config = loadToolGroupConfig('/nonexistent/path', empty);
+    expect(config.search).toBe(true);
+    expect(config.knowledge).toBe(true);
+    expect(config.session).toBe(true);
+    expect(config.forum).toBe(true);
+    expect(config.oracle).toBe(true);
+    expect(config.trace).toBe(true);
+    expect(config.mcp).toBe(true);
+  });
+
+  it('reads the injected data dir, never the developer machine config', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-isolation-'));
+    fs.writeFileSync(path.join(dir, 'config.json'), JSON.stringify({ tools: { forum: false } }));
+    const config = loadToolGroupConfig('/nonexistent/path', dir);
+    expect(config.forum).toBe(false);
+    expect(config.search).toBe(true);
+  });
+
+});

--- a/src/config/__tests__/tool-groups.test.ts
+++ b/src/config/__tests__/tool-groups.test.ts
@@ -124,17 +124,6 @@ describe('tool-groups', () => {
     expect(disabled.has('also_typo')).toBe(false);
   });
 
-  it('defaults to all groups enabled', () => {
-    const config = loadToolGroupConfig('/nonexistent/path');
-    expect(config.search).toBe(true);
-    expect(config.knowledge).toBe(true);
-    expect(config.session).toBe(true);
-    expect(config.forum).toBe(true);
-    expect(config.oracle).toBe(true);
-    expect(config.trace).toBe(true);
-    expect(config.mcp).toBe(true);
-  });
-
   it('all tool names follow oracle_ prefix convention', () => {
     for (const tools of Object.values(TOOL_GROUPS)) {
       for (const tool of tools) {

--- a/src/config/tool-config-source.ts
+++ b/src/config/tool-config-source.ts
@@ -59,22 +59,22 @@ interface SourceCandidate extends Omit<ToolConfigSource, 'found'> {
  * are not merged. Keep this list and the watcher in `tool-groups-watch.ts` in
  * sync; both must observe the same files.
  */
-export function configSources(root: string): SourceCandidate[] {
+export function configSources(root: string, dataDir: string = ORACLE_DATA_DIR): SourceCandidate[] {
   return [
     { path: path.join(root, 'arra.config.json'), label: 'arra.config.json from repo root', accept: hasToolConfig },
     { path: path.join(root, 'plugins.json'), label: 'plugins.json from repo root', accept: hasPluginManifest },
-    { path: path.join(ORACLE_DATA_DIR, 'config.json'), label: `${ORACLE_DATA_DIR}/config.json`, accept: hasToolConfig },
-    { path: path.join(ORACLE_DATA_DIR, 'plugins.json'), label: `${ORACLE_DATA_DIR}/plugins.json`, accept: hasPluginManifest },
+    { path: path.join(dataDir, 'config.json'), label: `${dataDir}/config.json`, accept: hasToolConfig },
+    { path: path.join(dataDir, 'plugins.json'), label: `${dataDir}/plugins.json`, accept: hasPluginManifest },
   ];
 }
 
 /** Tier used when no config file exists yet — the settings API creates this one. */
-function writeTarget(root: string): SourceCandidate {
-  return configSources(root)[2]!;
+function writeTarget(root: string, dataDir?: string): SourceCandidate {
+  return configSources(root, dataDir)[2]!;
 }
 
-export function resolveConfigSourceWithRaw(root: string): { source: ToolConfigSource; raw: Record<string, any> | null } {
-  for (const candidate of configSources(root)) {
+export function resolveConfigSourceWithRaw(root: string, dataDir?: string): { source: ToolConfigSource; raw: Record<string, any> | null } {
+  for (const candidate of configSources(root, dataDir)) {
     const raw = readJsonSafe(candidate.path);
     if (!raw || !candidate.accept(raw)) continue;
     return { source: { path: candidate.path, label: candidate.label, found: true }, raw };

--- a/src/config/tool-groups-core.ts
+++ b/src/config/tool-groups-core.ts
@@ -148,9 +148,14 @@ function knownTool(tool: string, source: string): boolean {
   return false;
 }
 
-export function loadToolGroupConfig(repoRoot?: string): ToolGroupConfig {
+/**
+ * @param dataDir override for the global tier. Exists so tests can isolate from
+ *   the developer's own ~/.arra-oracle-v2/config.json — passing a nonexistent
+ *   repoRoot is NOT enough, the lookup falls through to it.
+ */
+export function loadToolGroupConfig(repoRoot?: string, dataDir?: string): ToolGroupConfig {
   const root = repoRoot || process.env.ORACLE_REPO_ROOT || process.cwd();
-  const { source, raw } = resolveConfigSourceWithRaw(root);
+  const { source, raw } = resolveConfigSourceWithRaw(root, dataDir);
   if (!raw) return applyToolEnvOverrides({ ...DEFAULT_CONFIG });
   console.error(`[ToolGroups] Using ${source.label}`);
   return applyToolEnvOverrides(mergeRaw(raw));


### PR DESCRIPTION
`src/config/__tests__/tool-groups.test.ts` — *defaults to all groups enabled* — was failing on pristine `alpha` with nothing in the diff to explain it.

## Cause

```ts
const config = loadToolGroupConfig('/nonexistent/path');
expect(config.session).toBe(true);   // ← false
```

A nonexistent repo root is **not isolation**. Resolution is first-match-wins across four locations, and the last two are under `$ORACLE_DATA_DIR` — so it falls through to the developer's real `~/.arra-oracle-v2/config.json` and asserts against whatever they happen to have configured.

It passed for a long time only because that file contained no `tools` key. The day one was added, the test went red. Setting `process.env.ORACLE_DATA_DIR` in the test does not help either — `ORACLE_DATA_DIR` is a module-level const, frozen at import.

## Fix

`configSources`, `resolveConfigSourceWithRaw` and `loadToolGroupConfig` take an optional `dataDir` (default unchanged, so no production behaviour changes). It mirrors `repoRoot`, which was already a parameter — the asymmetry was the bug.

Verified both ways:

```
with the developer's real config present   18 pass / 0 fail
with ORACLE_DATA_DIR=<empty temp dir>      18 pass / 0 fail
```

A second test pins the isolation itself, so if `dataDir` stops being honoured the suite starts reading real user config again — silently — and that regression now fails loudly.

## Also

The file-resolution cases moved to `tool-groups-config-source.test.ts`, per the one-behavior-per-file convention. That also brought the original file from 256 back to 232 lines — **the ratchet added in #2834 caught its own author** trying to push a file over the limit.

## Gates

```
bunx tsc --noEmit              exit 0
bun test src/config/ tests/build/   50 pass / 0 fail
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)