### PR TITLE
fix(learn): Thai and other non-ASCII learnings were silently lost

### DIFF
--- a/src/learn/markdown.ts
+++ b/src/learn/markdown.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import path from 'path';
 import { createHash } from 'node:crypto';
 
 export interface LearningMarkdownOptions {
@@ -32,6 +34,19 @@ export function learningSlug(pattern: string): string {
     .replace(/-+/g, '-')
     .replace(/^-|-$/g, '');
   return slug || 'learning';
+}
+
+/**
+ * First free `<date>_<slug>[-N]` in `dir`. Bounded so a pathological directory
+ * cannot spin the caller; past the cap we fall back to a timestamp, which is
+ * always unique — losing the learning is never an acceptable outcome. (#2819)
+ */
+export function uniqueTail(dir: string, dateStr: string, slug: string, max = 500): string {
+  for (let suffix = 1; suffix <= max; suffix += 1) {
+    const tail = suffix === 1 ? slug : `${slug}-${suffix}`;
+    if (!fs.existsSync(path.join(dir, `${dateStr}_${tail}.md`))) return tail;
+  }
+  return `${slug}-${Date.now()}`;
 }
 
 export function dateSlug(date: Date): string {

--- a/src/tools/learn.ts
+++ b/src/tools/learn.ts
@@ -11,7 +11,7 @@ import { oracleDocuments } from '../db/schema.ts';
 import { detectProject } from '../server/project-detect.ts';
 import { getVectorStoreByModel, getEmbeddingModels } from '../vector/factory.ts';
 import { REPO_ROOT } from '../config.ts';
-import { buildLearningMarkdown, dateSlug } from '../learn/markdown.ts';
+import { buildLearningMarkdown, dateSlug, learningSlug, uniqueTail } from '../learn/markdown.ts';
 
 // Lazy-loaded on first use — avoids top-level await which causes a TDZ
 // error in consumers that import learnToolDef synchronously (the tools
@@ -187,15 +187,13 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
   const now = new Date();
   const dateStr = dateSlug(now);
 
-  const slug = pattern
-    .substring(0, 50)
-    .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, '')
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '');
-
-  const filename = `${dateStr}_${slug}.md`;
+  // Was an inline copy of the slug logic WITHOUT learningSlug's `|| 'learning'`
+  // fallback. The regex strips everything outside [a-z0-9\s-], so a wholly
+  // non-ASCII pattern — Thai, Japanese, Cyrillic — slugged to the empty string,
+  // the file became `<date>_.md`, and the SECOND such learning on the same day
+  // hit the "File already exists" throw below. The caller is an AI that does not
+  // retry, so the learning was silently lost. See #2819.
+  const slug = learningSlug(pattern);
 
   // Resolve vault root for central writes
   const getVaultPsiRoot = await loadGetVaultPsiRoot();
@@ -208,28 +206,26 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
     || detectProject(ctx.repoRoot);
   const projectDir = (project || '_universal').toLowerCase();
 
-  let filePath: string;
-  let sourceFileRel: string;
-  if (vaultRoot) {
-    const dir = path.join(vaultRoot, projectDir, 'ψ', 'memory', 'learnings');
-    fs.mkdirSync(dir, { recursive: true });
-    filePath = path.join(dir, filename);
-    sourceFileRel = `${projectDir}/ψ/memory/learnings/${filename}`;
-  } else {
+  const dir = vaultRoot
+    ? path.join(vaultRoot, projectDir, 'ψ', 'memory', 'learnings')
     // Write to canonical REPO_ROOT, not ctx.repoRoot (the MCP server's cwd):
     // the dashboard's /api/file resolves source_file against REPO_ROOT, so
     // writing relative to cwd produces "local file not found" (#557).
-    const dir = path.join(REPO_ROOT, 'ψ/memory/learnings');
-    fs.mkdirSync(dir, { recursive: true });
-    filePath = path.join(dir, filename);
-    sourceFileRel = `ψ/memory/learnings/${filename}`;
-  }
+    : path.join(REPO_ROOT, 'ψ/memory/learnings');
+  fs.mkdirSync(dir, { recursive: true });
 
-  if (fs.existsSync(filePath)) {
-    throw new Error(`File already exists: ${filename}`);
-  }
+  // Suffix instead of throwing. Two learnings a day sharing a slug is ordinary —
+  // and now guaranteed for non-ASCII patterns, which all fall back to the same
+  // 'learning' slug. Throwing loses the second one because the caller is an AI
+  // that does not retry. Mirrors routes/learn/crud.ts:78-107. (#2819)
+  const tail = uniqueTail(dir, dateStr, slug);
+  const filename = `${dateStr}_${tail}.md`;
+  const filePath = path.join(dir, filename);
+  const sourceFileRel = vaultRoot
+    ? `${projectDir}/ψ/memory/learnings/${filename}`
+    : `ψ/memory/learnings/${filename}`;
 
-  const id = `learning_${dateStr}_${slug}`;
+  const id = `learning_${dateStr}_${tail}`;
   const title = pattern.split('\n')[0].substring(0, 80);
   const conceptsList = coerceConcepts(concepts);
   const frontmatter = buildLearningMarkdown({

--- a/tests/http/knowledge/learn-non-ascii-slug.test.ts
+++ b/tests/http/knowledge/learn-non-ascii-slug.test.ts
@@ -1,0 +1,100 @@
+/**
+ * A learning written in a non-Latin script must never be lost.
+ *
+ * `src/tools/learn.ts` carried an inline copy of the slug logic that omitted
+ * `learningSlug`'s `|| 'learning'` fallback. The regex keeps only `[a-z0-9\s-]`,
+ * so a wholly non-ASCII pattern slugged to the empty string:
+ *
+ *   'ทดสอบภาษาไทย'  -> ''      'Кириллица' -> ''
+ *   '日本語のテスト'   -> ''      'mixed ไทย text' -> 'mixed-text'  (survived — has ASCII)
+ *
+ * The file became `<date>_.md`, and the SECOND such learning on the same day hit
+ * `throw new Error('File already exists')`. The caller is an AI, which does not
+ * retry — so the learning was **silently and permanently lost**. Thai is the
+ * primary working language here, so this fired most days. See #2819.
+ *
+ * Both halves are required. The fallback alone makes every non-ASCII learning
+ * slug to `learning`, which then collides with itself on the second one — the
+ * same data loss with a different filename.
+ */
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, readdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { dateSlug, learningSlug, uniqueTail } from '../../../src/learn/markdown.ts';
+
+const NON_ASCII = ['ทดสอบภาษาไทย', 'บันทึกที่สอง', '日本語のテスト', 'Кириллица', '한국어 테스트'];
+
+function freshDir(): string {
+  return mkdtempSync(join(tmpdir(), 'learn-non-ascii-'));
+}
+
+describe('non-ASCII learning slugs', () => {
+  test('never produce an empty slug', () => {
+    for (const pattern of NON_ASCII) {
+      expect(learningSlug(pattern)).not.toBe('');
+    }
+  });
+
+  test('ASCII patterns are unaffected', () => {
+    expect(learningSlug('Deploy checklist')).toBe('deploy-checklist');
+    expect(learningSlug('mixed ไทย text')).toBe('mixed-text');
+  });
+
+  test('a punctuation-only pattern falls back rather than slugging to empty', () => {
+    expect(learningSlug('...')).toBe('learning');
+    expect(learningSlug('!!!')).toBe('learning');
+  });
+
+  test('a whitespace-only pattern is rejected upstream, not slugged', () => {
+    // `handleLearn` already refuses an empty pattern with a usage message before
+    // reaching here (learn.ts guards it), so throwing is the correct contract —
+    // asserted so nobody "fixes" it into a silent fallback that writes a file
+    // for input the caller never meant to save.
+    expect(() => learningSlug('   ')).toThrow('pattern is required');
+  });
+});
+
+describe('same-day collisions are suffixed, never dropped', () => {
+  test('five non-ASCII learnings on one day produce five distinct files', () => {
+    const dir = freshDir();
+    const date = dateSlug(new Date());
+    const written = NON_ASCII.map((pattern) => {
+      const tail = uniqueTail(dir, date, learningSlug(pattern));
+      const name = `${date}_${tail}.md`;
+      writeFileSync(join(dir, name), 'x');
+      return name;
+    });
+
+    expect(new Set(written).size).toBe(NON_ASCII.length);
+    expect(readdirSync(dir)).toHaveLength(NON_ASCII.length);
+  });
+
+  test('identical ASCII patterns also get suffixed rather than colliding', () => {
+    const dir = freshDir();
+    const date = dateSlug(new Date());
+    const first = uniqueTail(dir, date, learningSlug('Deploy checklist'));
+    writeFileSync(join(dir, `${date}_${first}.md`), 'x');
+    const second = uniqueTail(dir, date, learningSlug('Deploy checklist'));
+
+    expect(first).toBe('deploy-checklist');
+    expect(second).toBe('deploy-checklist-2');
+  });
+
+  test('the suffix search is bounded and still returns something unique', () => {
+    // A pathological directory must not spin the caller, and must not lose data.
+    const dir = freshDir();
+    const date = dateSlug(new Date());
+    for (let i = 1; i <= 3; i += 1) {
+      writeFileSync(join(dir, `${date}_${i === 1 ? 'x' : `x-${i}`}.md`), 'x');
+    }
+    expect(uniqueTail(dir, date, 'x', 3)).toMatch(/^x-\d{10,}$/); // timestamp fallback
+    expect(uniqueTail(dir, date, 'x', 10)).toBe('x-4');
+  });
+
+  test('a fresh day starts from the unsuffixed name again', () => {
+    const dir = freshDir();
+    writeFileSync(join(dir, '2020-01-01_learning.md'), 'x');
+    expect(uniqueTail(dir, '2026-07-25', 'learning')).toBe('learning');
+  });
+});


### PR DESCRIPTION
Closes #2819

**Data loss, happening most days.** Thai is the primary working language in this repo, and the second Thai learning saved on any given day was thrown away.

## Chain

`src/tools/learn.ts` carried an **inline copy** of the slug logic that omitted `learningSlug`'s `|| 'learning'` fallback. The regex keeps only `[a-z0-9\s-]`:

```
'ทดสอบภาษาไทย'    -> ''
'日本語のテสト'      -> ''
'Кириллица'       -> ''
'mixed ไทย text'  -> 'mixed-text'   ← survived only because it contains ASCII
```

Empty slug → `<date>_.md` → the **second** such learning that day hit `throw new Error('File already exists')`. The caller is an AI, which does not retry. The learning was gone.

The working version already existed one directory away — `src/learn/markdown.ts` `learningSlug()` — and `learn.ts` was *already importing `dateSlug` from that same module*. It just used its own copy for the slug.

## Both halves are required

Adding the fallback alone would make **every** non-ASCII learning slug to `learning`, which then collides with itself on the second one — the same data loss under a different filename. So collisions now get a `-2`/`-3` suffix instead of throwing, mirroring `routes/learn/crud.ts:78-107`.

## Proof, end-to-end through the real `handleLearn`

Three non-ASCII learnings, one day:

```
ทดสอบภาษาไทยอันแรก      ok=true  ψ/memory/learnings/2026-07-25_learning.md
บันทึกภาษาไทยอันที่สอง   ok=true  ψ/memory/learnings/2026-07-25_learning-2.md
日本語のテスト             ok=true  ψ/memory/learnings/2026-07-25_learning-3.md
```

Before this commit, rows 2 and 3 threw and were lost.

## Scope

MCP **embedded** mode (no `ORACLE_HTTP_URL`) — which is the default. The HTTP path was already safe: `POST /api/learn` goes through `slugFor()` plus a suffix loop.

## Notes

- `uniqueTail` lives in `learn/markdown.ts` beside `learningSlug`/`dateSlug`, not in `learn.ts` — that file is already over the 250-line limit and the **ratchet from #2834 caught the attempt to grow it**, which is exactly what it was added for.
- The suffix search is bounded (500) with a timestamp fallback past the cap. Losing a learning is never an acceptable outcome, so the degenerate case still writes.
- One test assertion of mine was wrong and got corrected: `learningSlug('   ')` **throws** rather than falling back, because `handleLearn` already rejects empty patterns upstream. Pinned as the intended contract so nobody turns it into a silent fallback that writes a file for input the caller never meant to save.

## Gates

```
bunx tsc --noEmit                                                exit 0
bun test tests/http/knowledge/ src/tools/__tests__/ src/learn/ tests/build/
  155 pass / 0 fail
```

Credit: ui-oracle root-caused this to `learn.ts:193`, identified the existing dead-code fix, and warned that the fallback alone would re-collide — all three were correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)