### PR TITLE
chore(mcp): warn on the second, silent muninn_ rewrite path

### DIFF
--- a/src/config/tool-alias-warn.ts
+++ b/src/config/tool-alias-warn.ts
@@ -1,0 +1,54 @@
+import { deprecatedAliasWarning } from '../mcp/aliases.ts';
+
+/**
+ * Deprecation warnings for the NON-MCP inbound surfaces.
+ *
+ * `src/mcp/server.ts` warns on its own CallTool path via `resolveInboundToolName`,
+ * but that is not the only door a `muninn_` name walks through: the settings API,
+ * the `arra.config.json` file and the ORACLE_*_TOOLS env vars all rewrite the
+ * alias through `normalizeToolName` and, before this module, did so in silence.
+ *
+ * The MESSAGE deliberately lives in exactly one place — `deprecatedAliasWarning`
+ * in src/mcp/aliases.ts — so these surfaces can never drift into a second dialect
+ * of the same notice. The `[MCP]` tag it carries is kept even here: the noun being
+ * labelled is an MCP tool name, whatever transport carried it.
+ */
+
+/**
+ * Warn once per call. Use at boundaries where each call is a genuinely new
+ * operator action — an HTTP PUT, an MCP CallTool — so suppressing a repeat would
+ * hide a real second event.
+ *
+ * Silent for `arra_` (supported, not deprecated) and for canonical `oracle_*`,
+ * because `deprecatedAliasWarning` returns null for both.
+ */
+export function warnDeprecatedAlias(name: string, log: (m: string) => void = console.error): void {
+  const warning = deprecatedAliasWarning(name);
+  if (warning) log(warning);
+}
+
+/** Aliases already warned about, keyed by the raw inbound name. */
+const warned = new Set<string>();
+
+/**
+ * Warn at most once per distinct alias for the life of the process.
+ *
+ * MANDATORY for the config-file and env paths, not a nicety: the watcher in
+ * `tool-groups-watch.ts` polls `loadToolGroupConfig` every 100ms, so those call
+ * sites re-read the same persistent input 10x/sec. An unguarded warn there is a
+ * log flood, not a notice — one `muninn_` entry would emit ~864k lines/day.
+ */
+export function warnDeprecatedAliasOnce(name: string, log: (m: string) => void = console.error): void {
+  const warning = deprecatedAliasWarning(name);
+  if (!warning || warned.has(name)) return;
+  warned.add(name);
+  log(warning);
+}
+
+/**
+ * Clear the once-guard. Tests only — the Set is process-global, so without this
+ * a test asserting "it warns" would depend on no earlier test having warmed it.
+ */
+export function resetAliasWarnings(): void {
+  warned.clear();
+}

--- a/src/config/tool-groups-core.ts
+++ b/src/config/tool-groups-core.ts
@@ -1,4 +1,5 @@
 import { envToolList, isRecord, resolveConfigSourceWithRaw } from './tool-config-source.ts';
+import { warnDeprecatedAliasOnce } from './tool-alias-warn.ts';
 
 export const TOOL_GROUPS = {
   search: ['oracle_search', 'oracle_search_chain', 'oracle_read', 'oracle_list', 'oracle_concepts', 'oracle_ask'],
@@ -84,6 +85,19 @@ export function normalizeToolName(name: string): string {
   return name;
 }
 
+/**
+ * Normalize a name arriving from OUTSIDE — a user-authored config file or an
+ * operator's env var — announcing the rewrite when the alias is deprecated.
+ *
+ * Only for inbound boundaries. The re-normalization inside `getDisabledTools` /
+ * `getEnabledToolNames` runs over values `mergeRaw` already canonicalized, so
+ * warning there would double-report a rewrite the operator has been told about.
+ */
+function normalizeInboundToolName(name: string): string {
+  warnDeprecatedAliasOnce(name);
+  return normalizeToolName(name);
+}
+
 function mergeRaw(raw: Record<string, any>): ToolGroupConfig {
   const merged: ToolGroupConfig = { ...DEFAULT_CONFIG };
   if (isRecord(raw.tools)) {
@@ -95,8 +109,8 @@ function mergeRaw(raw: Record<string, any>): ToolGroupConfig {
   if (Array.isArray(raw.plugins)) {
     merged.plugins = raw.plugins.map(normalizePluginEntry).filter((p): p is PluginManifestEntry => !!p);
   }
-  if (Array.isArray(raw.disabled_tools)) merged.disabled_tools = raw.disabled_tools.filter((t: unknown) => typeof t === 'string').map(normalizeToolName);
-  if (Array.isArray(raw.enabled_tools)) merged.enabled_tools = raw.enabled_tools.filter((t: unknown) => typeof t === 'string').map(normalizeToolName);
+  if (Array.isArray(raw.disabled_tools)) merged.disabled_tools = raw.disabled_tools.filter((t: unknown) => typeof t === 'string').map(normalizeInboundToolName);
+  if (Array.isArray(raw.enabled_tools)) merged.enabled_tools = raw.enabled_tools.filter((t: unknown) => typeof t === 'string').map(normalizeInboundToolName);
   return merged;
 }
 
@@ -125,8 +139,8 @@ function isPluginTier(value: unknown): value is PluginTier {
  * container or in CI where no config file can be written. (#2822 defect 2)
  */
 export function applyToolEnvOverrides(config: ToolGroupConfig): ToolGroupConfig {
-  const allowEnv = envToolList('ORACLE_ENABLED_TOOLS')?.map(normalizeToolName);
-  const blockEnv = envToolList('ORACLE_DISABLED_TOOLS')?.map(normalizeToolName);
+  const allowEnv = envToolList('ORACLE_ENABLED_TOOLS')?.map(normalizeInboundToolName);
+  const blockEnv = envToolList('ORACLE_DISABLED_TOOLS')?.map(normalizeInboundToolName);
   if (!allowEnv && !blockEnv) return config;
   const next: ToolGroupConfig = { ...config };
   if (allowEnv) {

--- a/src/routes/settings/tools.ts
+++ b/src/routes/settings/tools.ts
@@ -13,6 +13,7 @@ import {
   resolveToolConfigSource,
   type ToolGroupName,
 } from '../../config/tool-groups.ts';
+import { warnDeprecatedAlias } from '../../config/tool-alias-warn.ts';
 
 /** Ordered projection of the shared config vocabulary — the same set the loader governs. */
 const ALL_TOOL_LIST = [...ALL_TOOL_NAMES];
@@ -67,6 +68,11 @@ export const toolSettingsRoute = new Elysia()
     },
   })
   .put('/tools', ({ body, set }) => {
+    // Announce the rewrite BEFORE validation, so a body that also carries an
+    // unknown tool still tells the caller its `muninn_` names are on the way out
+    // rather than 400-ing with that half of the story missing. Unguarded on
+    // purpose: every PUT is a fresh operator action, unlike the polled config file.
+    for (const name of body.enabled_tools) warnDeprecatedAlias(name);
     const normalized = Array.from(new Set(body.enabled_tools.map(normalizeToolName)));
     const unknown = normalized.filter((name) => !ALL_TOOL_NAMES.has(name));
     if (unknown.length) {

--- a/tests/config/tool-alias-warn-config-file.test.ts
+++ b/tests/config/tool-alias-warn-config-file.test.ts
@@ -1,0 +1,87 @@
+import { afterAll, beforeEach, expect, test } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { loadToolGroupConfig } from '../../src/config/tool-groups.ts';
+import { resetAliasWarnings } from '../../src/config/tool-alias-warn.ts';
+
+// A repo-root arra.config.json wins resolution outright (first match wins), so
+// seeding one here keeps this test off both the developer's global config and
+// the real repo's. Read-only either way — nothing below writes config.
+const tempRepo = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-alias-cfg-'));
+const repoConfig = path.join(tempRepo, 'arra.config.json');
+
+afterAll(() => {
+  fs.rmSync(tempRepo, { recursive: true });
+});
+
+beforeEach(() => {
+  resetAliasWarnings();
+});
+
+function seed(config: Record<string, unknown>): void {
+  fs.writeFileSync(repoConfig, JSON.stringify(config) + '\n');
+}
+
+/** Load the seeded config `times` over, returning only the deprecation lines. */
+function loadCapturingWarnings(times = 1): { warnings: string[]; last: ReturnType<typeof loadToolGroupConfig> } {
+  const lines: string[] = [];
+  const real = console.error;
+  console.error = (...args: unknown[]) => { lines.push(args.join(' ')); };
+  try {
+    let last = loadToolGroupConfig(tempRepo);
+    for (let i = 1; i < times; i += 1) last = loadToolGroupConfig(tempRepo);
+    return { warnings: lines.filter((line) => line.includes('is deprecated')), last };
+  } finally {
+    console.error = real;
+  }
+}
+
+test('a muninn_ entry in arra.config.json warns once and still resolves', () => {
+  seed({ enabled_tools: ['muninn_search'], disabled_tools: ['muninn_read'] });
+  const { warnings, last } = loadCapturingWarnings();
+
+  // Order is incidental (mergeRaw happens to read disabled_tools first), so assert
+  // the exact format of each line without pinning the sequence.
+  expect(warnings).toHaveLength(2);
+  expect(warnings).toContain(
+    '[MCP] tool alias "muninn_search" is deprecated — use "oracle_search" (removal planned next release)',
+  );
+  expect(warnings).toContain(
+    '[MCP] tool alias "muninn_read" is deprecated — use "oracle_read" (removal planned next release)',
+  );
+  expect(last.enabled_tools).toEqual(['oracle_search']);
+  expect(last.disabled_tools).toEqual(['oracle_read']);
+});
+
+test('repeated loads do NOT re-warn — the watcher polls this path 10x/sec', () => {
+  seed({ enabled_tools: ['muninn_search'] });
+
+  // 20 loads stands in for two seconds of tool-groups-watch.ts polling. Without
+  // the once-guard this is 20 lines, and a long-running server emits ~864k/day.
+  const { warnings, last } = loadCapturingWarnings(20);
+  expect(warnings).toHaveLength(1);
+  expect(last.enabled_tools).toEqual(['oracle_search']);
+});
+
+test('an arra_ entry in arra.config.json resolves silently — arra_ is not deprecated', () => {
+  seed({ enabled_tools: ['arra_read'] });
+  const { warnings, last } = loadCapturingWarnings();
+
+  expect(warnings).toEqual([]);
+  expect(last.enabled_tools).toEqual(['oracle_read']);
+});
+
+test('canonical oracle_ names never warn', () => {
+  seed({ enabled_tools: ['oracle_search'], disabled_tools: ['oracle_read'] });
+  expect(loadCapturingWarnings().warnings).toEqual([]);
+});
+
+test('resetAliasWarnings clears the guard, so the notice can be observed again', () => {
+  seed({ enabled_tools: ['muninn_search'] });
+  expect(loadCapturingWarnings().warnings).toHaveLength(1);
+  expect(loadCapturingWarnings().warnings).toHaveLength(0);
+
+  resetAliasWarnings();
+  expect(loadCapturingWarnings().warnings).toHaveLength(1);
+});

--- a/tests/config/tool-alias-warn-env.test.ts
+++ b/tests/config/tool-alias-warn-env.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, expect, test } from 'bun:test';
+import { applyToolEnvOverrides, type ToolGroupConfig } from '../../src/config/tool-groups.ts';
+import { resetAliasWarnings } from '../../src/config/tool-alias-warn.ts';
+
+// ORACLE_ENABLED_TOOLS / ORACLE_DISABLED_TOOLS are the third inbound surface that
+// rewrites muninn_ names — the only lever available on a read-only container, and
+// silent before this change.
+const saved = {
+  allow: process.env.ORACLE_ENABLED_TOOLS,
+  block: process.env.ORACLE_DISABLED_TOOLS,
+};
+
+const BASE: ToolGroupConfig = {
+  search: true, knowledge: true, session: true, forum: true,
+  oracle: true, trace: true, standalone: true, mcp: true,
+};
+
+beforeEach(() => {
+  resetAliasWarnings();
+  delete process.env.ORACLE_ENABLED_TOOLS;
+  delete process.env.ORACLE_DISABLED_TOOLS;
+});
+
+afterEach(() => {
+  for (const [key, value] of [
+    ['ORACLE_ENABLED_TOOLS', saved.allow], ['ORACLE_DISABLED_TOOLS', saved.block],
+  ] as const) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+function applyCapturingWarnings(): { warnings: string[]; next: ToolGroupConfig } {
+  const lines: string[] = [];
+  const real = console.error;
+  console.error = (...args: unknown[]) => { lines.push(args.join(' ')); };
+  try {
+    const next = applyToolEnvOverrides({ ...BASE });
+    return { warnings: lines.filter((line) => line.includes('is deprecated')), next };
+  } finally {
+    console.error = real;
+  }
+}
+
+test('ORACLE_ENABLED_TOOLS warns on a muninn_ name and still resolves it', () => {
+  process.env.ORACLE_ENABLED_TOOLS = 'muninn_search,arra_read,oracle_list';
+  const { warnings, next } = applyCapturingWarnings();
+
+  // arra_read rides along in the same list and must NOT produce a line.
+  expect(warnings).toEqual([
+    '[MCP] tool alias "muninn_search" is deprecated — use "oracle_search" (removal planned next release)',
+  ]);
+  expect(next.enabled_tools).toEqual(['oracle_search', 'oracle_read', 'oracle_list']);
+});
+
+test('ORACLE_DISABLED_TOOLS warns on a muninn_ name and still resolves it', () => {
+  process.env.ORACLE_DISABLED_TOOLS = 'muninn_read';
+  const { warnings, next } = applyCapturingWarnings();
+
+  expect(warnings).toEqual([
+    '[MCP] tool alias "muninn_read" is deprecated — use "oracle_read" (removal planned next release)',
+  ]);
+  expect(next.disabled_tools).toContain('oracle_read');
+});
+
+test('an all-arra_ env list stays completely silent', () => {
+  process.env.ORACLE_ENABLED_TOOLS = 'arra_search,arra_read';
+  const { warnings, next } = applyCapturingWarnings();
+
+  expect(warnings).toEqual([]);
+  expect(next.enabled_tools).toEqual(['oracle_search', 'oracle_read']);
+});

--- a/tests/http/settings/tools-alias-deprecation.test.ts
+++ b/tests/http/settings/tools-alias-deprecation.test.ts
@@ -1,0 +1,103 @@
+import { afterAll, expect, test } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tempData = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-alias-data-'));
+const tempRepo = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-alias-repo-'));
+const previous = {
+  data: process.env.ORACLE_DATA_DIR,
+  db: process.env.ORACLE_DB_PATH,
+  root: process.env.ORACLE_REPO_ROOT,
+  allow: process.env.ORACLE_ENABLED_TOOLS,
+  block: process.env.ORACLE_DISABLED_TOOLS,
+};
+process.env.ORACLE_DATA_DIR = tempData;
+process.env.ORACLE_DB_PATH = path.join(tempData, 'oracle.db');
+process.env.ORACLE_REPO_ROOT = tempRepo;
+delete process.env.ORACLE_ENABLED_TOOLS;
+delete process.env.ORACLE_DISABLED_TOOLS;
+
+// Pin the write target to the repo-root tier — see tools-mounted.test.ts. Without
+// this seed the resolver falls through to $ORACLE_DATA_DIR/config.json, whose path
+// was fixed at src/config.ts import time, and the PUT would overwrite the
+// developer's REAL global config. (This is not hypothetical: it happened while
+// probing this defect.)
+const repoConfig = path.join(tempRepo, 'arra.config.json');
+fs.writeFileSync(repoConfig, JSON.stringify({ disabled_tools: [] }) + '\n');
+
+const dbModule = await import('../../../src/db/index.ts');
+dbModule.resetDefaultDatabaseForTests(process.env.ORACLE_DB_PATH);
+const { settingsRoutes } = await import('../../../src/routes/settings/index.ts');
+const { createApiVersionedFetch } = await import('../../../src/middleware/api-version.ts');
+
+const handle = createApiVersionedFetch((request) => settingsRoutes.handle(request));
+const server = Bun.serve({ port: 0, fetch: (request) => handle(request) });
+const base = `http://127.0.0.1:${server.port}`;
+
+afterAll(() => {
+  server.stop(true);
+  for (const [key, value] of [
+    ['ORACLE_DATA_DIR', previous.data], ['ORACLE_DB_PATH', previous.db],
+    ['ORACLE_REPO_ROOT', previous.root], ['ORACLE_ENABLED_TOOLS', previous.allow],
+    ['ORACLE_DISABLED_TOOLS', previous.block],
+  ] as const) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  fs.rmSync(tempData, { recursive: true });
+  fs.rmSync(tempRepo, { recursive: true });
+});
+
+/** PUT the body, returning the response plus only the deprecation lines it logged. */
+async function putCapturingWarnings(enabled_tools: string[]): Promise<{ res: Response; warnings: string[] }> {
+  const lines: string[] = [];
+  const real = console.error;
+  console.error = (...args: unknown[]) => { lines.push(args.join(' ')); };
+  try {
+    const res = await fetch(`${base}/api/v1/settings/tools`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ enabled_tools }),
+    });
+    // Body must be drained before restoring: the handler logs while serializing.
+    await res.clone().text();
+    return { res, warnings: lines.filter((line) => line.includes('is deprecated')) };
+  } finally {
+    console.error = real;
+  }
+}
+
+test('PUT /api/v1/settings/tools warns that a muninn_ name is deprecated, and still resolves it', async () => {
+  const { res, warnings } = await putCapturingWarnings(['muninn_search', 'oracle_list']);
+  expect(res.status).toBe(200);
+
+  // Exact format, shared with the MCP path via deprecatedAliasWarning.
+  expect(warnings).toEqual([
+    '[MCP] tool alias "muninn_search" is deprecated — use "oracle_search" (removal planned next release)',
+  ]);
+
+  // Warning is an announcement, not a rejection — the rewrite still happens.
+  const written = JSON.parse(fs.readFileSync(repoConfig, 'utf-8')) as Record<string, string[]>;
+  expect(written.enabled_tools).toEqual(['oracle_search', 'oracle_list']);
+  expect((await res.json() as { enabled_tools: string[] }).enabled_tools).toEqual(['oracle_search', 'oracle_list']);
+});
+
+test('PUT /api/v1/settings/tools stays silent for arra_ names, and still resolves them', async () => {
+  const { res, warnings } = await putCapturingWarnings(['arra_read', 'oracle_list']);
+  expect(res.status).toBe(200);
+
+  // arra_ is supported, not deprecated — warning about it would be a false alarm.
+  expect(warnings).toEqual([]);
+
+  const written = JSON.parse(fs.readFileSync(repoConfig, 'utf-8')) as Record<string, string[]>;
+  expect(written.enabled_tools).toEqual(['oracle_read', 'oracle_list']);
+  expect((await res.json() as { enabled_tools: string[] }).enabled_tools).toEqual(['oracle_read', 'oracle_list']);
+});
+
+test('a second PUT re-warns — each PUT is a fresh operator action, not a polled re-read', async () => {
+  const first = await putCapturingWarnings(['muninn_read', 'oracle_list']);
+  expect(first.warnings).toHaveLength(1);
+  const second = await putCapturingWarnings(['muninn_read', 'oracle_list']);
+  expect(second.warnings).toEqual(first.warnings);
+});


### PR DESCRIPTION
Follow-up to #2827, which warned only the MCP CallTool boundary.

An adversarial pass found a **second rewrite engine** that performed the same `muninn_ → oracle_` alias rewrite with no warning at all: `normalizeToolName()` in `src/config/tool-groups-core.ts`, reached by **three** inbound surfaces —

- `PUT /api/settings/tools`
- `arra.config.json` via `mergeRaw`
- `ORACLE_ENABLED_TOOLS` / `ORACLE_DISABLED_TOOLS` via `applyToolEnvOverrides`

All three silently accepted a retired alias. After the planned removal they would have started failing with a bare tool-not-found and no hint about the rename.

## Verified at the file-descriptor level, not through a mock

The verifier **refused the tests' own evidence** — all three new test files monkey-patch `console.error`, which proves nothing about fd 2 — and built a subprocess probe that boots the real Elysia `settingsRoutes` on a real port, issues a real `PUT`, and brackets the request with markers on raw stderr.

```
PUT ["muninn_search","oracle_list"]  -> 200
  stderr, verbatim, exactly one line:
  [MCP] tool alias "muninn_search" is deprecated — use "oracle_search" (removal planned next release)

PUT ["arra_search","oracle_list"]    -> 200, deprecation lines: 0   (arra_ is NOT deprecated)
PUT ["oracle_search","oracle_list"]  -> 200, deprecation lines: 0

both persist identically: ["oracle_search","oracle_list"] re-read from disk
```

**The defect was real and the fix is not a no-op** — the same probe run against the base commit in a detached worktree emitted **0** deprecation lines for the identical request.

The once-guard is real too: 20 consecutive `loadToolGroupConfig` calls (≈2s of the 100ms watcher poll) emitted exactly **1** line.

## No third door

An exhaustive census found exactly **two** rewrite engines — `mcp/aliases.ts:2` and `tool-groups-core.ts:84` — and every other regex hit is unrelated URL/slug normalisation. The most promising lead, MCP-over-HTTP (`routes/mcp/streamable.ts`), dispatches through the same CallTool handler and therefore already inherits #2827's warning.

## Known problems, disclosed

- **Whitespace-padded names get advice the same request rejects.** `PUT [" muninn_search "]` → **400**, yet stderr says *use "oracle_search"*. `deprecatedAliasWarning` trims, `normalizeToolName` does not. The advice is correct and actionable; the request still fails. Pre-existing 400, newly self-contradicting.
- **`muninn_oracle_search` → 400** while the warning says `oracle_search`. The two engines disagree: `normalizeToolName` concatenates unconditionally (`oracle_oracle_search`), `resolveToolName` checks for an existing `oracle_` prefix. Root fix is collapsing one onto the other; `normalizeToolName` still has no direct tests pinning its edge semantics.
- **The once-guard is keyed on the raw name with no surface dimension**, so the same alias present in *both* the config file and the env var yields one notice, not two. Fixing only one surface leaves the other silently deprecated.

## Gate

The verifier reported this branch red. The single failure was `tool-groups > defaults to all groups enabled`, **proven pre-existing** by running it on the base — a non-hermetic test that read the developer's own `~/.arra-oracle-v2/config.json`. That is fixed separately in #2837, now merged, so after rebasing onto alpha:

```
bunx tsc --noEmit                                                        exit 0
bun test tests/http/settings/ tests/config/ src/config/ src/__tests__/…   94 pass / 0 fail
```

That command deliberately includes `tests/config/` — the verifier found the original gate's `src/config/` substring did **not** match the two new test files living under `tests/config/`, so two of three new files were never being run by the stated gate.

All touched files ≤ 250 lines (largest 223).

🤖 Generated with [Claude Code](https://claude.com/claude-code)