### PR TITLE
fix(test): stop three suites leaking the db singleton into later files

### DIFF
--- a/tests/http/settings/tools-alias-deprecation.test.ts
+++ b/tests/http/settings/tools-alias-deprecation.test.ts
@@ -7,13 +7,11 @@ const tempData = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-alias-data-'));
 const tempRepo = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-alias-repo-'));
 const previous = {
   data: process.env.ORACLE_DATA_DIR,
-  db: process.env.ORACLE_DB_PATH,
   root: process.env.ORACLE_REPO_ROOT,
   allow: process.env.ORACLE_ENABLED_TOOLS,
   block: process.env.ORACLE_DISABLED_TOOLS,
 };
 process.env.ORACLE_DATA_DIR = tempData;
-process.env.ORACLE_DB_PATH = path.join(tempData, 'oracle.db');
 process.env.ORACLE_REPO_ROOT = tempRepo;
 delete process.env.ORACLE_ENABLED_TOOLS;
 delete process.env.ORACLE_DISABLED_TOOLS;
@@ -38,7 +36,7 @@ const base = `http://127.0.0.1:${server.port}`;
 afterAll(() => {
   server.stop(true);
   for (const [key, value] of [
-    ['ORACLE_DATA_DIR', previous.data], ['ORACLE_DB_PATH', previous.db],
+    ['ORACLE_DATA_DIR', previous.data],
     ['ORACLE_REPO_ROOT', previous.root], ['ORACLE_ENABLED_TOOLS', previous.allow],
     ['ORACLE_DISABLED_TOOLS', previous.block],
   ] as const) {

--- a/tests/http/settings/tools-mounted.test.ts
+++ b/tests/http/settings/tools-mounted.test.ts
@@ -7,13 +7,11 @@ const tempData = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-tools-data-'));
 const tempRepo = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-tools-repo-'));
 const previous = {
   data: process.env.ORACLE_DATA_DIR,
-  db: process.env.ORACLE_DB_PATH,
   root: process.env.ORACLE_REPO_ROOT,
   allow: process.env.ORACLE_ENABLED_TOOLS,
   block: process.env.ORACLE_DISABLED_TOOLS,
 };
 process.env.ORACLE_DATA_DIR = tempData;
-process.env.ORACLE_DB_PATH = path.join(tempData, 'oracle.db');
 process.env.ORACLE_REPO_ROOT = tempRepo;
 delete process.env.ORACLE_ENABLED_TOOLS;
 delete process.env.ORACLE_DISABLED_TOOLS;
@@ -41,7 +39,7 @@ const base = `http://127.0.0.1:${server.port}`;
 afterAll(() => {
   server.stop(true);
   for (const [key, value] of [
-    ['ORACLE_DATA_DIR', previous.data], ['ORACLE_DB_PATH', previous.db],
+    ['ORACLE_DATA_DIR', previous.data],
     ['ORACLE_REPO_ROOT', previous.root], ['ORACLE_ENABLED_TOOLS', previous.allow],
     ['ORACLE_DISABLED_TOOLS', previous.block],
   ] as const) {

--- a/tests/integration/settings-tools-mcp-round-trip.test.ts
+++ b/tests/integration/settings-tools-mcp-round-trip.test.ts
@@ -85,6 +85,12 @@ afterAll(() => {
     if (value === undefined) delete process.env[key];
     else process.env[key] = value;
   }
+  // Rebind the shared db singleton back. Restoring the env alone is NOT enough:
+  // resetDefaultDatabaseForTests(tempDbPath) above bound the module-level handle
+  // to the temp file, and bun shares that module across test FILES. Leaving it
+  // bound made every later file read an empty database — tests/http/health/
+  // went red purely from run order, green in isolation. (P9 in miniature.)
+  dbModule.resetDefaultDatabaseForTests(previous.db);
   for (const dir of [tempData, tempRepo, tempHome]) fs.rmSync(dir, { recursive: true });
 });
 


### PR DESCRIPTION
`alpha` went red immediately after merging four PRs that were each green in their own worktree. **P9, exactly as `CLAUDE.md` documents it.**

```
combined gate on integrated alpha:   371 pass / 6 fail
tests/http/health/ run alone:         35 pass / 0 fail
```

Three health tests failed **purely from run order**.

## Cause

Restoring `process.env` in `afterAll` is **not** enough.

`ORACLE_DB_PATH` is read when `src/db/index.ts` first loads. Bun shares that module across test *files*, so once a suite pointed the shared handle at a temp database, every later file in the run read an empty database — long after the env var had been restored. The env restore ran; the handle stayed bound.

Bisected to two suites:

```
health + tests/config/          0 fail
health + tests/http/settings/   6 fail   ←
health + tests/http/frontend/   0 fail
health + src/config/            0 fail
health + tests/http/knowledge/  0 fail

  + tools-alias-deprecation.test.ts   1 fail
  + tools-mounted.test.ts             1 fail
```

## Fix

- **The two settings suites drop `ORACLE_DB_PATH` entirely.** They exercise the config-*file* layer — resolution tiers, the alias warning, the settings route — and never needed a database. They keep `ORACLE_DATA_DIR` and `ORACLE_REPO_ROOT`, which do not touch the shared handle.
- **The round-trip integration test rebinds the handle back**, since it deliberately calls `resetDefaultDatabaseForTests(tempDbPath)` and genuinely does need its own database. Its `afterAll` now resets to the previous path.

## Verified

```
tools-mounted alone                4 pass / 0 fail
tools-alias-deprecation alone      3 pass / 0 fail
round-trip alone                   1 pass / 0 fail
round-trip + health               36 pass / 0 fail
health + settings                 49 pass / 0 fail

the combined gate that was 6-red  382 pass / 0 fail
```

## Worth keeping

The failure was invisible to every per-PR gate, because each branch only ran its own cluster. It only appeared when the four landed together and something *else* ran after them — the property being broken belonged to neither the suite that broke it nor the suite that failed.

The generalisable rule: **restoring an env var does not undo a module singleton that already read it.** If a test rebinds shared module state, it has to rebind it back, not just reset the input the binding was derived from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
