### PR TITLE
fix(memory): consolidation/suggestions pinned the server for 11 minutes

### DIFF
--- a/src/workers/consolidation-docs.ts
+++ b/src/workers/consolidation-docs.ts
@@ -1,0 +1,43 @@
+/**
+ * Candidate-document loading for the consolidation worker.
+ *
+ * Split out of consolidation.ts so the SQL shape and the reason for it stay
+ * together — and because the file was at the 250-line limit.
+ */
+import type { Database } from 'bun:sqlite';
+
+export function objectExists(sqlite: Database, name: string): boolean {
+  return Boolean(
+    sqlite.query<{ name: string }, [string]>(
+      'SELECT name FROM sqlite_master WHERE name = ? LIMIT 1',
+    ).get(name),
+  );
+}
+
+// No join to oracle_fts: joining it then ORDER BY ... LIMIT makes SQLite
+// materialise the whole join before sorting, and oracle_fts.id is UNINDEXED, so
+// each probe is a full scan — the query does not finish in 100s even at LIMIT 50
+// (0.9s without the ORDER BY). Inline on a GET it pinned the server ~11min. #2836
+export function docsSql(tenantId?: string): string {
+  const tenant = tenantId ? 'AND d.tenant_id = ?' : '';
+  return `
+    SELECT d.id, d.tenant_id AS tenantId, d.type, d.source_file AS sourceFile,
+      d.concepts, d.created_at AS createdAt, d.updated_at AS updatedAt,
+      d.indexed_at AS indexedAt, d.project, d.created_by AS createdBy
+    FROM oracle_documents d
+    WHERE d.superseded_by IS NULL ${tenant}
+    ORDER BY d.updated_at DESC
+    LIMIT ?`;
+}
+
+/** Content for one page of ids: ONE FTS scan, not one per row. */
+export function contentForPage(sqlite: Database, ids: string[]): Map<string, string> {
+  if (ids.length === 0 || !objectExists(sqlite, 'oracle_fts')) return new Map();
+  const placeholders = ids.map(() => '?').join(',');
+  const rows = sqlite
+    .query<{ id: string; content: string | null }, string[]>(
+      `SELECT id, content FROM oracle_fts WHERE id IN (${placeholders})`,
+    )
+    .all(...ids);
+  return new Map(rows.map((row) => [row.id, row.content ?? '']));
+}

--- a/src/workers/consolidation.ts
+++ b/src/workers/consolidation.ts
@@ -2,6 +2,7 @@ import type { Database } from 'bun:sqlite';
 import { runWithTenant } from '../middleware/tenant.ts';
 import { runSupersede } from '../tools/supersede.ts';
 import type { ToolContext } from '../tools/types.ts';
+import { contentForPage, docsSql, objectExists } from './consolidation-docs.ts';
 import { runFactCuration, type FactCurationOptions, type FactCurationResult } from './fact-curation.ts';
 
 type Db = ToolContext['db'];
@@ -108,35 +109,15 @@ function confidenceFor(doc: RawDoc, tokens: string[], now: number, staleDays: nu
     reasons: [stale ? 'stale_document' : 'fresh_document', doc.project ? 'project_provenance' : 'missing_project', tokens.length >= 40 ? 'content_complete' : 'content_sparse'] };
 }
 
-function docsSql(hasFts: boolean, tenantId?: string): string {
-  const content = hasFts ? "coalesce(f.content, '')" : "''";
-  const join = hasFts ? 'LEFT JOIN oracle_fts f ON f.id = d.id' : '';
-  const tenant = tenantId ? 'AND d.tenant_id = ?' : '';
-  return `
-    SELECT d.id, d.tenant_id AS tenantId, d.type, d.source_file AS sourceFile,
-      d.concepts, d.created_at AS createdAt, d.updated_at AS updatedAt,
-      d.indexed_at AS indexedAt, d.project, d.created_by AS createdBy, ${content} AS content
-    FROM oracle_documents d
-    ${join}
-    WHERE d.superseded_by IS NULL ${tenant}
-    ORDER BY d.updated_at DESC
-    LIMIT ?`;
-}
-
-function objectExists(sqlite: Database, name: string): boolean {
-  const row = sqlite.query<{ name: string }, [string]>(
-    'SELECT name FROM sqlite_master WHERE name = ? LIMIT 1',
-  ).get(name);
-  return Boolean(row);
-}
 
 function loadDocs(sqlite: Database, options: ResolvedOptions): CandidateDoc[] {
   const params = options.tenantId ? [options.tenantId, options.limit] : [options.limit];
-  const rows = sqlite.query<RawDoc, (string | number)[]>(docsSql(objectExists(sqlite, 'oracle_fts'), options.tenantId))
-    .all(...params);
+  const rows = sqlite.query<RawDoc, (string | number)[]>(docsSql(options.tenantId)).all(...params);
+  const contents = contentForPage(sqlite, rows.map((row) => row.id));
   return rows.map((row) => {
-    const tokens = tokenize(`${row.content}\n${row.concepts}\n${row.sourceFile}`);
-    return { ...row, content: row.content ?? '', tokens, tokenSet: new Set(tokens), confidence: confidenceFor(row, tokens, options.now, options.staleDays) };
+    const content = contents.get(row.id) ?? '';
+    const tokens = tokenize(`${content}\n${row.concepts}\n${row.sourceFile}`);
+    return { ...row, content, tokens, tokenSet: new Set(tokens), confidence: confidenceFor(row, tokens, options.now, options.staleDays) };
   });
 }
 


### PR DESCRIPTION
Closes #2843

A single unauthenticated **GET** pinned the single-threaded server for ~11 minutes. Everything else queued behind it; the Studio showed "backend not responding". Observed live twice today.

## Root cause — identical to #2836, different endpoint

`src/routes/memory/consolidation.ts:77` runs the whole consolidation worker **inline on a GET**, and the worker's candidate query joined the FTS table and sorted across it:

```sql
FROM oracle_documents d
LEFT JOIN oracle_fts f ON f.id = d.id
WHERE d.superseded_by IS NULL AND d.tenant_id = ?
ORDER BY d.updated_at DESC
LIMIT ?
```

`oracle_fts.id` is **UNINDEXED** (FTS5), so every probe is a full scan — and the `ORDER BY` forces SQLite to materialise the entire joined set before applying `LIMIT`.

Measured on the real corpus (35,179 docs), raw sqlite3:

| Query | Time |
|---|---|
| the exact query, **LIMIT 50** | **did not finish in 100s** |
| same query **without ORDER BY** | 0.9s |
| `runConsolidationWorker(limit: 50)` in-process | did not finish in 110s |

`limit` does not bound it — the `LIMIT` is applied after the expensive part.

## Fix

Page `oracle_documents` alone (indexed, sorted, bounded), then fetch content for that page in **one** `WHERE id IN (…)` scan. The cost metric is *number of FTS scans*, not rows returned.

```
before:  /api/memory/consolidation/suggestions  HUNG (OS-killed at 60s)
after:   /api/memory/consolidation/suggestions  200 in  96ms
         /api/memory/consolidation/pending      200 in  99ms
         /api/stats                             200 in 114ms
         /api/health                            200 in 203ms
```

## Two wrong turns, both caught

**`/api/stats` was blamed first.** The log showed `GET /api/stats 200 593916.25ms` — but five other requests, including three `/api/health`, completed at the *same timestamp* with the *same* ~593916ms. That is **queue time**, not execution time. Both are fine in isolation (134ms / 239ms). Credit to ui-oracle for separating the two.

**Then we jointly concluded "not reproducible in a clean process — add a stats cache and move on."** Wrong. Filtering the log for a duration that was *not* the round 593916 surfaced this endpoint at **686,729.65ms** — its own number, longer, started earlier. Probed with an OS-level timeout in a clean process with zero load: **HUNG**.

> An explanation that lets you stop looking deserves extra suspicion, however disciplined it sounds. "Can't reproduce, add a cache" is the same premature close as "it was just load from my own agents" — which nearly buried #2835 earlier the same day.

## Notes

- Split into `consolidation-docs.ts`. The **#2834 ratchet caught this PR** pushing `consolidation.ts` from 240 to 261 lines and forced the split rather than a squeezed comment — third time today it has caught its own author.
- Follow-ups in #2843: a read endpoint should not run a batch worker inline at all; `/api/stats` deserves a TTL cache as defence in depth; and `vector-operations.ts:77` `withTimeout` is `Promise.race` + `setTimeout`, blind to synchronous blocking.

## Gates

```
bunx tsc --noEmit                                     exit 0
bun test tests/build/ src/workers/ tests/http/memory/  62 pass / 0 fail
```

Credit: ui-oracle reported the wedge, produced the queue-time analysis that made the real blocker findable, and independently reproduced the hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)