### PR TITLE
perf(stats): cache /api/stats briefly and collapse concurrent callers

### DIFF
--- a/src/routes/health/stats-cache.ts
+++ b/src/routes/health/stats-cache.ts
@@ -1,0 +1,72 @@
+/**
+ * Short-lived cache for `GET /api/stats`.
+ *
+ * The route does live work on every call — a tenant-scoped document count, an
+ * FTS health read, an embedder runtime probe, and a per-engine vector stats
+ * fetch. The Studio calls it on every page load, and Elysia is single-threaded,
+ * so each call occupies the only loop there is.
+ *
+ * It was NOT the cause of the 2026-07-25 wedge — that was
+ * `/api/memory/consolidation/suggestions` (#2843), and `/api/stats` merely
+ * queued behind it and looked guilty in the log. This is defence in depth: the
+ * exposure is real regardless of who blocked the loop that day.
+ *
+ * Deliberately small: a TTL, an in-flight promise so a burst collapses into one
+ * computation, and nothing else. No LRU, no invalidation hooks — stats are a
+ * dashboard read, and a few seconds of staleness costs nothing.
+ */
+
+export const DEFAULT_STATS_TTL_MS = 5_000;
+
+function ttlFrom(env: Record<string, string | undefined>): number {
+  const raw = env.ORACLE_STATS_CACHE_TTL_MS?.trim();
+  if (!raw) return DEFAULT_STATS_TTL_MS;
+  const parsed = Number(raw);
+  // 0 is a legitimate value: it disables caching. Only reject nonsense.
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_STATS_TTL_MS;
+}
+
+export type StatsCache<T> = {
+  get(compute: () => Promise<T>): Promise<T>;
+  clear(): void;
+};
+
+export function createStatsCache<T>(options: {
+  ttlMs?: number;
+  env?: Record<string, string | undefined>;
+  now?: () => number;
+} = {}): StatsCache<T> {
+  const ttlMs = options.ttlMs ?? ttlFrom(options.env ?? process.env);
+  const now = options.now ?? Date.now;
+
+  let value: T | undefined;
+  let storedAt = -Infinity;
+  let inFlight: Promise<T> | null = null;
+
+  return {
+    async get(compute: () => Promise<T>): Promise<T> {
+      if (ttlMs > 0 && value !== undefined && now() - storedAt < ttlMs) return value;
+      // Collapse a burst: N concurrent callers do ONE computation, not N. This is
+      // the part that matters on a single-threaded server — a dashboard opening
+      // several panels at once used to mean several full probes.
+      if (inFlight) return inFlight;
+
+      inFlight = compute()
+        .then((next) => {
+          value = next;
+          storedAt = now();
+          return next;
+        })
+        .finally(() => {
+          inFlight = null;
+        });
+      return inFlight;
+    },
+
+    clear(): void {
+      value = undefined;
+      storedAt = -Infinity;
+      inFlight = null;
+    },
+  };
+}

--- a/src/routes/health/stats.ts
+++ b/src/routes/health/stats.ts
@@ -5,11 +5,12 @@ import { currentTenantId } from '../../middleware/tenant.ts';
 import { readEmbedderRuntimeStatus, type EmbedderRuntimeStatus } from '../../vector/embedder-config.ts';
 import { handleStats } from '../../server/handlers.ts';
 import { handleVectorStats } from '../../server/vector-handlers.ts';
+import { createStatsCache, type StatsCache } from './stats-cache.ts';
 import { tenantStats } from './tenant-stats.ts';
 import { withEnvelope } from '../response-envelope.ts';
 
 type VectorStats = Awaited<ReturnType<typeof handleVectorStats>>;
-type StatsEndpointOptions = { vectorStats?: () => Promise<VectorStats>; embedderRuntime?: () => Promise<EmbedderRuntimeStatus> };
+type StatsEndpointOptions = { vectorStats?: () => Promise<VectorStats>; embedderRuntime?: () => Promise<EmbedderRuntimeStatus>; cache?: StatsCache<any> };
 type FtsStatus = 'healthy' | 'empty' | 'missing' | 'partial' | 'unavailable';
 type VectorStatus = 'ok' | 'degraded' | 'down';
 
@@ -78,7 +79,11 @@ function vectorStatus(stats: VectorStats): VectorStatus {
 
 export function createStatsEndpoint(options: StatsEndpointOptions = {}) {
   const readVectorStats = options.vectorStats ?? handleVectorStats;
-  return new Elysia().get('/stats', async (): Promise<any> => {
+  // Short TTL + in-flight collapsing. Every field below is a live probe, the
+  // Studio calls this on each page load, and the server is single-threaded.
+  // ORACLE_STATS_CACHE_TTL_MS=0 disables it. See #2843.
+  const cache = options.cache ?? createStatsCache<any>();
+  return new Elysia().get('/stats', async (): Promise<any> => cache.get(async () => {
     try {
       const stats = tenantStats() ?? handleStats(DB_PATH);
       const vaultRepo = getSetting('vault_repo');
@@ -97,7 +102,7 @@ export function createStatsEndpoint(options: StatsEndpointOptions = {}) {
       if (isDbLockError(err)) return { total_docs: 0, by_type: {}, indexing: true, error: 'db temporarily unavailable' };
       throw err;
     }
-  }, {
+  }), {
     response: withEnvelope(statsResponseSchema()),
     detail: {
       tags: ['health'],

--- a/tests/http/health/stats-cache.test.ts
+++ b/tests/http/health/stats-cache.test.ts
@@ -1,0 +1,114 @@
+/**
+ * `GET /api/stats` does live work on every field: a document count, an FTS
+ * health read, an embedder probe, and per-engine vector stats. The Studio calls
+ * it on every page load and Elysia is single-threaded, so each call occupies the
+ * only loop there is.
+ *
+ * It was NOT the cause of the 2026-07-25 wedge — `/api/memory/consolidation/
+ * suggestions` was (#2843), and `/api/stats` merely queued behind it and looked
+ * guilty in the log. This is defence in depth.
+ *
+ * The property that matters most is not the TTL but the **in-flight collapse**:
+ * a dashboard opening several panels at once must cause ONE computation, not
+ * one per panel.
+ */
+import { describe, expect, test } from 'bun:test';
+import { DEFAULT_STATS_TTL_MS, createStatsCache } from '../../../src/routes/health/stats-cache.ts';
+
+function counter() {
+  let calls = 0;
+  return {
+    get calls() { return calls; },
+    compute: async () => { calls += 1; return { n: calls }; },
+  };
+}
+
+describe('stats cache', () => {
+  test('a second call inside the TTL does not recompute', async () => {
+    const c = counter();
+    const cache = createStatsCache<{ n: number }>({ ttlMs: 1_000, now: () => 0 });
+    expect(await cache.get(c.compute)).toEqual({ n: 1 });
+    expect(await cache.get(c.compute)).toEqual({ n: 1 });
+    expect(c.calls).toBe(1);
+  });
+
+  test('a call after the TTL recomputes', async () => {
+    const c = counter();
+    let clock = 0;
+    const cache = createStatsCache<{ n: number }>({ ttlMs: 1_000, now: () => clock });
+    await cache.get(c.compute);
+    clock = 1_001;
+    expect(await cache.get(c.compute)).toEqual({ n: 2 });
+    expect(c.calls).toBe(2);
+  });
+
+  test('a burst of concurrent callers causes ONE computation', async () => {
+    // The point of the cache on a single-threaded server. Without in-flight
+    // collapsing, a TTL alone does nothing for callers that arrive together —
+    // none of them has a cached value to read yet.
+    const c = counter();
+    const cache = createStatsCache<{ n: number }>({ ttlMs: 1_000, now: () => 0 });
+    const results = await Promise.all(Array.from({ length: 8 }, () => cache.get(c.compute)));
+    expect(c.calls).toBe(1);
+    expect(results.every((r) => r.n === 1)).toBe(true);
+  });
+
+  test('a failed computation is not cached and does not wedge the cache', async () => {
+    let attempt = 0;
+    const cache = createStatsCache<string>({ ttlMs: 10_000, now: () => 0 });
+    const flaky = async () => {
+      attempt += 1;
+      if (attempt === 1) throw new Error('probe failed');
+      return 'ok';
+    };
+    await expect(cache.get(flaky)).rejects.toThrow('probe failed');
+    // A rejected in-flight promise must be cleared, or every later call inherits it.
+    expect(await cache.get(flaky)).toBe('ok');
+  });
+
+  test('ttl 0 disables caching entirely', async () => {
+    const c = counter();
+    const cache = createStatsCache<{ n: number }>({ ttlMs: 0, now: () => 0 });
+    await cache.get(c.compute);
+    await cache.get(c.compute);
+    expect(c.calls).toBe(2);
+  });
+
+  test('ORACLE_STATS_CACHE_TTL_MS is honoured, including an explicit 0', async () => {
+    const c = counter();
+    const off = createStatsCache<{ n: number }>({ env: { ORACLE_STATS_CACHE_TTL_MS: '0' }, now: () => 0 });
+    await off.get(c.compute);
+    await off.get(c.compute);
+    expect(c.calls).toBe(2);
+
+    const c2 = counter();
+    const on = createStatsCache<{ n: number }>({ env: { ORACLE_STATS_CACHE_TTL_MS: '9999' }, now: () => 0 });
+    await on.get(c2.compute);
+    await on.get(c2.compute);
+    expect(c2.calls).toBe(1);
+  });
+
+  test('nonsense in the env falls back to the default rather than disabling', async () => {
+    const c = counter();
+    const cache = createStatsCache<{ n: number }>({ env: { ORACLE_STATS_CACHE_TTL_MS: 'soon' }, now: () => 0 });
+    await cache.get(c.compute);
+    await cache.get(c.compute);
+    expect(c.calls).toBe(1);
+    expect(DEFAULT_STATS_TTL_MS).toBeGreaterThan(0);
+  });
+
+  test('the default TTL is short enough to stay a dashboard read', () => {
+    // If someone raises this to minutes the endpoint stops reflecting reality
+    // and becomes misleading rather than merely stale.
+    expect(DEFAULT_STATS_TTL_MS).toBeLessThanOrEqual(30_000);
+  });
+
+  test('clear() forces the next call to recompute', async () => {
+    const c = counter();
+    const cache = createStatsCache<{ n: number }>({ ttlMs: 10_000, now: () => 0 });
+    await cache.get(c.compute);
+    cache.clear();
+    await cache.get(c.compute);
+    expect(c.calls).toBe(2);
+  });
+});


### PR DESCRIPTION
Refs #2843 (follow-up), defence in depth.

Every field `GET /api/stats` returns is a **live probe** — a tenant-scoped document count, an FTS health read, an embedder runtime probe, and per-engine vector stats. The Studio calls it on every page load, and Elysia is single-threaded, so each call occupies the only loop there is.

## Explicitly not a fix for today's wedge

The 2026-07-25 outage was `/api/memory/consolidation/suggestions` (#2843, fixed in #2844). `/api/stats` merely **queued behind it** and looked guilty in the log — its 593,916 ms was queue time, not execution time. It measures 134 ms in isolation.

This is not that fix. It closes a real exposure that exists regardless of who blocked the loop.

## The in-flight collapse matters more than the TTL

A TTL alone does nothing for callers that arrive **together** — none of them has a cached value to read yet. A dashboard opening several panels at once meant several full probes, concurrently, on the one loop.

```
cold       141ms
warm         1ms
burst x8     2ms total     (previously ~8 × 141ms of loop time)
```

## Design

Deliberately small: a TTL, an in-flight promise, `clear()`. No LRU, no invalidation hooks — stats are a dashboard read and a few seconds of staleness costs nothing.

- `ORACLE_STATS_CACHE_TTL_MS` overrides the 5s default; **`0` disables caching**, and is treated as a legitimate value rather than falsy-defaulted
- nonsense in that variable falls back to the default rather than silently disabling the cache
- a **failed** computation is not cached, and the rejected in-flight promise is cleared — otherwise every later call would inherit the same rejection

Each of those is pinned by a test, because each is a way this could be quietly wrong.

## Tests

Nine cases in `tests/http/health/stats-cache.test.ts`, including the two that would let this ship broken:

- a burst of 8 concurrent callers causes **one** computation
- a rejected probe does not poison the cache

Plus a guard that the default TTL stays ≤ 30s — past that the endpoint stops reflecting reality and becomes misleading rather than merely stale.

## Gates

```
bunx tsc --noEmit                       exit 0
bun test tests/http/health/ tests/build/  52 pass / 0 fail
```

Both new files are well under the 250-line limit (114 / 72).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
