### PR TITLE
fix(config): an unusable ORACLE_ENABLED_TOOLS no longer serves zero tools

### DIFF
--- a/src/config/tool-alias-warn.ts
+++ b/src/config/tool-alias-warn.ts
@@ -46,6 +46,19 @@ export function warnDeprecatedAliasOnce(name: string, log: (m: string) => void =
 }
 
 /**
+ * Warn at most once per distinct key, for warnings that are NOT about aliases.
+ *
+ * Same mandate as above: anything reached from `loadToolGroupConfig` is on the
+ * 100ms watcher path, so an unguarded `console.error` there is ~864k lines/day.
+ * `knownTool()` shipped exactly that in #2826 — three lines from this file.
+ */
+export function warnOnce(key: string, message: string, log: (m: string) => void = console.error): void {
+  if (warned.has(key)) return;
+  warned.add(key);
+  log(message);
+}
+
+/**
  * Clear the once-guard. Tests only — the Set is process-global, so without this
  * a test asserting "it warns" would depend on no earlier test having warmed it.
  */

--- a/src/config/tool-groups-core.ts
+++ b/src/config/tool-groups-core.ts
@@ -1,5 +1,5 @@
 import { envToolList, isRecord, resolveConfigSourceWithRaw } from './tool-config-source.ts';
-import { warnDeprecatedAliasOnce } from './tool-alias-warn.ts';
+import { warnDeprecatedAliasOnce, warnOnce } from './tool-alias-warn.ts';
 
 export const TOOL_GROUPS = {
   search: ['oracle_search', 'oracle_search_chain', 'oracle_read', 'oracle_list', 'oracle_concepts', 'oracle_ask'],
@@ -145,8 +145,20 @@ export function applyToolEnvOverrides(config: ToolGroupConfig): ToolGroupConfig 
   const next: ToolGroupConfig = { ...config };
   if (allowEnv) {
     const keep = new Set(allowEnv.filter((tool) => knownTool(tool, 'ORACLE_ENABLED_TOOLS')));
-    next.enabled_tools = [...keep];
-    next.disabled_tools = [...ALL_TOOL_NAMES].filter((tool) => !keep.has(tool));
+    // An allow-list naming ONLY unrecognised tools must not serve zero tools.
+    // `ORACLE_ENABLED_TOOLS=oracle_dig` did exactly that — oracle_dig is a
+    // plugin tool the product advertises but which lives outside ALL_TOOL_NAMES,
+    // so a plausible value silently disabled the entire MCP surface. A filter
+    // that matches nothing means "no usable filter", not "allow nothing".
+    if (keep.size === 0) {
+      warnOnce(
+        'allowlist-empty',
+        '[ToolGroups] ORACLE_ENABLED_TOOLS named no recognised tool — ignoring it rather than serving zero tools',
+      );
+    } else {
+      next.enabled_tools = [...keep];
+      next.disabled_tools = [...ALL_TOOL_NAMES].filter((tool) => !keep.has(tool));
+    }
   }
   if (blockEnv) {
     const block = new Set(blockEnv.filter((tool) => knownTool(tool, 'ORACLE_DISABLED_TOOLS')));
@@ -158,7 +170,9 @@ export function applyToolEnvOverrides(config: ToolGroupConfig): ToolGroupConfig 
 
 function knownTool(tool: string, source: string): boolean {
   if (ALL_TOOL_NAMES.has(tool)) return true;
-  console.error(`[ToolGroups] ${source}: unknown tool "${tool}" — ignored`);
+  // Through the once-guard: this is reached from loadToolGroupConfig, which the
+  // watcher polls at 10Hz, so an unguarded console.error here is ~864k lines/day.
+  warnOnce(`unknown:${source}:${tool}`, `[ToolGroups] ${source}: unknown tool "${tool}" — ignored`);
   return false;
 }
 

--- a/tests/config/tool-env-allowlist-safety.test.ts
+++ b/tests/config/tool-env-allowlist-safety.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Two regressions shipped by #2826 and caught by adversarial verification of
+ * #2822, both on the `applyToolEnvOverrides` path.
+ *
+ * 1. **An allow-list naming only unrecognised tools served ZERO tools.**
+ *    `ORACLE_ENABLED_TOOLS=oracle_dig` emptied the entire MCP surface —
+ *    and `oracle_dig` is a name the product advertises at
+ *    `GET /api/v1/mcp/tools`. It is a *plugin* tool, so it lives outside
+ *    `ALL_TOOL_NAMES` (the orphan class #2822 is itself about), which made a
+ *    plausible value silently disable everything.
+ *    A filter that matches nothing means "no usable filter", not "allow nothing".
+ *
+ * 2. **`knownTool()` logged unguarded on the 10 Hz watcher path** —
+ *    `tool-groups-watch.ts` polls `loadToolGroupConfig` every 100ms, so one
+ *    unrecognised name emitted ~864,000 stderr lines/day. The repo already
+ *    documents that exact figure in `tool-alias-warn.ts`, and already enforced
+ *    it for the alias branch — #2826 added an unguarded branch three lines away.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getEnabledToolNames, loadToolGroupConfig } from '../../src/config/tool-groups-core.ts';
+import { resetAliasWarnings } from '../../src/config/tool-alias-warn.ts';
+
+const EMPTY_DATA = mkdtempSync(join(tmpdir(), 'tool-env-safety-'));
+const NO_REPO = '/nonexistent/repo/root';
+
+const previous = {
+  allow: process.env.ORACLE_ENABLED_TOOLS,
+  block: process.env.ORACLE_DISABLED_TOOLS,
+};
+
+function served(): string[] {
+  return getEnabledToolNames(loadToolGroupConfig(NO_REPO, EMPTY_DATA));
+}
+
+function countingConsole(match: string) {
+  const original = console.error;
+  let lines = 0;
+  console.error = (...args: unknown[]) => {
+    if (String(args[0] ?? '').includes(match)) lines += 1;
+  };
+  return { get lines() { return lines; }, restore: () => { console.error = original; } };
+}
+
+beforeEach(() => {
+  delete process.env.ORACLE_ENABLED_TOOLS;
+  delete process.env.ORACLE_DISABLED_TOOLS;
+  resetAliasWarnings();
+});
+
+afterEach(() => {
+  for (const [key, value] of [
+    ['ORACLE_ENABLED_TOOLS', previous.allow],
+    ['ORACLE_DISABLED_TOOLS', previous.block],
+  ] as const) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe('ORACLE_ENABLED_TOOLS cannot silently disable everything', () => {
+  test('an allow-list of only unrecognised names is ignored, not obeyed', () => {
+    const baseline = served().length;
+    expect(baseline).toBeGreaterThan(0);
+
+    process.env.ORACLE_ENABLED_TOOLS = 'oracle_dig';
+    expect(served().length).toBe(baseline);
+  });
+
+  test('a plausible plugin-tool name does not empty the surface', () => {
+    // oracle_dig is advertised by GET /api/v1/mcp/tools but is a plugin tool,
+    // so it is absent from ALL_TOOL_NAMES. Before the fix this served 0 tools.
+    process.env.ORACLE_ENABLED_TOOLS = 'oracle_dig,oracle_sessions';
+    expect(served().length).toBeGreaterThan(0);
+  });
+
+  test('a partly-valid allow-list still filters to the valid names', () => {
+    process.env.ORACLE_ENABLED_TOOLS = 'oracle_search,typo_name';
+    expect(served()).toEqual(['oracle_search']);
+  });
+
+  test('a fully-valid allow-list is unchanged in behaviour', () => {
+    process.env.ORACLE_ENABLED_TOOLS = 'oracle_search,oracle_read';
+    expect(new Set(served())).toEqual(new Set(['oracle_search', 'oracle_read']));
+  });
+
+  test('ignoring an unusable allow-list is announced, not silent', () => {
+    const spy = countingConsole('named no recognised tool');
+    try {
+      process.env.ORACLE_ENABLED_TOOLS = 'oracle_dig';
+      served();
+      expect(spy.lines).toBe(1);
+    } finally {
+      spy.restore();
+    }
+  });
+});
+
+describe('unknown-tool warnings are once per process, not once per poll', () => {
+  test('20 loads emit one line, not 20', () => {
+    // 20 loads is 2 seconds of the 100ms watcher poll. Unguarded this was
+    // ~864,000 lines/day — the figure tool-alias-warn.ts documents.
+    const spy = countingConsole('unknown tool');
+    try {
+      process.env.ORACLE_DISABLED_TOOLS = 'definitely_not_a_tool';
+      for (let i = 0; i < 20; i += 1) loadToolGroupConfig(NO_REPO, EMPTY_DATA);
+      expect(spy.lines).toBe(1);
+    } finally {
+      spy.restore();
+    }
+  });
+
+  test('distinct unknown names each warn once', () => {
+    const spy = countingConsole('unknown tool');
+    try {
+      process.env.ORACLE_DISABLED_TOOLS = 'not_a_tool_a,not_a_tool_b';
+      for (let i = 0; i < 5; i += 1) loadToolGroupConfig(NO_REPO, EMPTY_DATA);
+      expect(spy.lines).toBe(2);
+    } finally {
+      spy.restore();
+    }
+  });
+});


### PR DESCRIPTION
Refs #2822 — two regressions that PR shipped, found by adversarially verifying it.

A triage pass concluded #2822 was FIXED. A second agent was tasked with **refuting** that and overturned it to `NEEDS_WORK`. Both findings reproduce.

## 1. `ORACLE_ENABLED_TOOLS` could silently disable the entire MCP surface

```
ORACLE_ENABLED_TOOLS=oracle_dig   ->  0 tools served
```

`oracle_dig` is a name the product **advertises** at `GET /api/v1/mcp/tools`. It is a *plugin* tool, so it lives outside `ALL_TOOL_NAMES` — the exact orphan class #2822 is about. `knownTool()` filtered it out, `keep` came back empty, and the code then wrote **all** of `ALL_TOOL_NAMES` into `disabled_tools`.

A plausible value, taken from the product's own output, turned the Oracle off. Silently.

A filter that matches nothing means *"no usable filter"*, not *"allow nothing"*. It is now ignored, with a warning.

```
ORACLE_ENABLED_TOOLS=oracle_dig                 0  ->  30 tools   (+ one warning line)
ORACLE_ENABLED_TOOLS=oracle_search,typo_name    ->  ['oracle_search']   (unchanged)
ORACLE_ENABLED_TOOLS=oracle_search,oracle_read  ->  both               (unchanged)
```

Partly-valid and fully-valid allow-lists behave exactly as before — only the all-invalid case changed.

## 2. ~864,000 stderr lines a day

`knownTool()` called `console.error` unguarded. It is reached from `loadToolGroupConfig`, which `tool-groups-watch.ts` polls **every 100ms**. One unrecognised name in the config or env produced a continuous log flood.

The repo already knows this. `src/config/tool-alias-warn.ts` documents the **~864k lines/day** figure verbatim and enforces a once-guard for the alias branch. #2826 added an unguarded branch **three lines away in the same function**.

```
20 loads (2s of the poll)   before: 20 lines   after: 1 line
distinct unknown names      each warn once, not once per poll
```

`warnDeprecatedAliasOnce`'s guard is generalised as `warnOnce(key, message)` and reused rather than duplicated.

## Why this is worth reading beyond the diff

#2822 was the issue about **levers that are declared but do not work**. Fixing it introduced a lever that works *too well* — silently disabling everything — plus a log flood the codebase had already written down the cost of, in a file three lines away.

It was only caught because a verifier was told to *refute* rather than confirm. Of three issues triaged FIXED in that pass, **two were overturned**.

## Gates

```
bunx tsc --noEmit                                              exit 0
bun test tests/config/ src/config/ tests/http/settings/ tests/build/
  97 pass / 0 fail
```

All touched files under the 250-line limit (237 / 67 / 125).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
