### PR TITLE
fix(vault): stop migrate sweeping .git, node_modules and fleet comms into the vault

### DIFF
--- a/src/vault/__tests__/discovery-never-walk.test.ts
+++ b/src/vault/__tests__/discovery-never-walk.test.ts
@@ -1,0 +1,66 @@
+/**
+ * #2802 (@tenzaitech) — the vault walker descended into nested `.git` and `node_modules`.
+ *
+ * A repo with a submodule, a worktree, or a vendored dependency under ψ/ dragged its whole
+ * object database into the walk: thousands of binary pack files, and an EACCES on the
+ * read-only ones. `vault:migrate` then tried to copy them into the shared vault.
+ *
+ * These tests fail if the `NEVER_WALK` guard is removed — they assert on the walk's *contents*,
+ * not just its size, so a count that happens to match cannot make them pass.
+ */
+import { afterAll, describe, expect, test } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { walkFiles } from '../discovery.ts';
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-vault-never-walk-'));
+const psi = path.join(root, 'ψ');
+
+function put(relative: string, body = 'x'): void {
+  const full = path.join(psi, relative);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, body);
+}
+
+put('memory/learnings/real.md', '# real knowledge');
+put('.git/HEAD', 'ref: refs/heads/main');
+put('.git/objects/pack/pack-deadbeef.idx', 'binary');
+put('vendor/node_modules/left-pad/index.js', 'module.exports = 1');
+put('vendor/node_modules/.package-lock.json', '{}');
+
+// A submodule or a linked worktree leaves `.git` behind as a FILE, not a directory.
+// Written via put() so the parent directory is actually created — writing it directly made
+// the walk throw ENOENT at module scope, and the "not.toContain" assertion below then
+// passed because the file had never existed. `--isolate` is what surfaced that.
+put('sub/.git', 'gitdir: ../../.git/modules/sub');
+
+const walked = walkFiles(psi, root).map((file) => file.relativePath);
+
+afterAll(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('walkFiles never descends into .git or node_modules', () => {
+  test('a nested object database contributes nothing', () => {
+    expect(walked.filter((p) => p.includes('/.git/'))).toEqual([]);
+  });
+
+  test('a vendored node_modules contributes nothing', () => {
+    expect(walked.filter((p) => p.includes('/node_modules/'))).toEqual([]);
+  });
+
+  test('a gitfile pointer is skipped too — it is not knowledge either', () => {
+    expect(walked).not.toContain('ψ/sub/.git');
+  });
+
+  test('real knowledge is still walked — the guard is a filter, not a wall', () => {
+    expect(walked).toContain('ψ/memory/learnings/real.md');
+  });
+
+  test('nothing but the real file survives this tree', () => {
+    // The strongest form: name the whole expected set. Any leak fails here even if the
+    // three targeted assertions above were weakened or deleted.
+    expect(walked.sort()).toEqual(['ψ/memory/learnings/real.md']);
+  });
+});

--- a/src/vault/__tests__/migrate-inbox-carveout.test.ts
+++ b/src/vault/__tests__/migrate-inbox-carveout.test.ts
@@ -1,0 +1,100 @@
+/**
+ * #2803 (@tenzaitech) — `vault:migrate` swept all of `ψ/inbox/` into the shared vault.
+ *
+ * `ψ/inbox/` is fleet comms: messages addressed to this oracle. Copying it made one house's
+ * unread mail part of another house's knowledge corpus. `migrate.ts` already imported
+ * `isProjectCategory`, but used it only to decide whether to inject frontmatter — the copy
+ * loop still took everything the walker returned.
+ *
+ * The carve-out that ships here is NOT "skip ψ/inbox except handoff/", which is the shape the
+ * report proposed. `path-mapping.ts` lists `ψ/inbox/schedule.md` and
+ * `ψ/inbox/focus-agent-main.md` in UNIVERSAL_CATEGORIES and maps them to the vault root on
+ * purpose, so that shape would silently drop two files the vault is supposed to hold. The
+ * final two tests below are the ones that catch that mistake.
+ */
+import { afterAll, describe, expect, test } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { migratableFiles } from '../migrate.ts';
+import { belongsInVault } from '../path-mapping.ts';
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-vault-inbox-'));
+const psi = path.join(root, 'ψ');
+
+function put(relative: string, body = 'x'): void {
+  const full = path.join(psi, relative);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, body);
+}
+
+put('memory/learnings/2026-07-25_lesson.md', '# lesson');
+put('inbox/handoff/2026-07-25_19-51_handoff.md', '# handoff');
+put('inbox/schedule.md', '# schedule');
+put('inbox/focus-agent-main.md', '# focus');
+put('inbox/2026-07-25_report-from-jan.md', '# a message, not knowledge');
+put('inbox/tracks/INDEX.md', '# tracks');
+put('memory/.gitkeep', '');
+
+const copied = migratableFiles(psi, root).map((file) => file.relativePath).sort();
+
+afterAll(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('migrate skips fleet comms but keeps declared vault categories', () => {
+  test('a message addressed to this oracle is not copied', () => {
+    expect(copied).not.toContain('ψ/inbox/2026-07-25_report-from-jan.md');
+  });
+
+  test('an inbox subtree that is not a declared category is not copied', () => {
+    expect(copied).not.toContain('ψ/inbox/tracks/INDEX.md');
+  });
+
+  test('handoffs are copied — they are a PROJECT_CATEGORY', () => {
+    expect(copied).toContain('ψ/inbox/handoff/2026-07-25_19-51_handoff.md');
+  });
+
+  test('ψ/inbox/schedule.md survives — UNIVERSAL_CATEGORIES declares it vault-bound', () => {
+    expect(copied).toContain('ψ/inbox/schedule.md');
+  });
+
+  test('ψ/inbox/focus-agent-main.md survives for the same reason', () => {
+    expect(copied).toContain('ψ/inbox/focus-agent-main.md');
+  });
+
+  test('.gitkeep is still skipped', () => {
+    expect(copied).not.toContain('ψ/memory/.gitkeep');
+  });
+
+  test('the exact copy set, so no leak passes by matching a count', () => {
+    expect(copied).toEqual([
+      'ψ/inbox/focus-agent-main.md',
+      'ψ/inbox/handoff/2026-07-25_19-51_handoff.md',
+      'ψ/inbox/schedule.md',
+      'ψ/memory/learnings/2026-07-25_lesson.md',
+    ]);
+  });
+});
+
+describe('belongsInVault reads its answer off the category declarations', () => {
+  test('non-inbox knowledge is unconditionally vault-bound', () => {
+    expect(belongsInVault('ψ/memory/retrospectives/2026-07/25/20.00_r.md')).toBe(true);
+    expect(belongsInVault('ψ/writing/draft.md')).toBe(true);
+  });
+
+  test('bare inbox files are not', () => {
+    expect(belongsInVault('ψ/inbox/anything.md')).toBe(false);
+    expect(belongsInVault('ψ/inbox/nested/deep/thing.md')).toBe(false);
+  });
+
+  test('a path with backslashes still resolves — normalisation happens first', () => {
+    // The private walker this replaced did not normalise separators, so a prefix test
+    // against 'ψ/inbox/handoff/' could not have matched on a platform using '\'.
+    expect(belongsInVault('ψ\\inbox\\handoff\\x.md')).toBe(true);
+  });
+
+  test('traversal is rejected rather than silently mapped', () => {
+    expect(() => belongsInVault('ψ/inbox/../../../etc/passwd')).toThrow();
+  });
+});

--- a/src/vault/discovery.ts
+++ b/src/vault/discovery.ts
@@ -8,6 +8,19 @@ import { getSetting } from '../db/index.ts';
 import { ghqListPaths } from './ghq.ts';
 
 /**
+ * Directory names that are never knowledge, and are never descended into.
+ *
+ * A repo with a nested checkout or a vendored dependency inside ψ/ otherwise drags its
+ * whole object database into the walk — thousands of binary pack files, and an EACCES on
+ * the read-only ones. `.git` is matched as a bare name so the gitfile *pointer* a
+ * submodule or worktree leaves behind is skipped too; that file is not knowledge either.
+ *
+ * Reported against `vault:migrate` by @tenzaitech (#2802), but the guard belongs here:
+ * every caller of this walker wants it, and `vault:sync` walked the same trees.
+ */
+const NEVER_WALK = new Set(['.git', 'node_modules']);
+
+/**
  * Walk all files under dir, skipping symlinks.
  * Returns paths relative to baseDir.
  */
@@ -26,6 +39,7 @@ export function walkFiles(
   }
 
   for (const item of items) {
+    if (NEVER_WALK.has(item)) continue;
     const fullPath = path.join(dir, item);
     let stat: fs.Stats;
     try {

--- a/src/vault/migrate-cli.ts
+++ b/src/vault/migrate-cli.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { detectProject } from '../server/project-detect.ts';
-import { findPsiRepos, migrate, walkFiles } from './migrate.ts';
+import { findPsiRepos, migrate, migratableFiles } from './migrate.ts';
 
 export function runVaultMigrateCli(args = process.argv.slice(2)): void {
   if (args.includes('--list')) {
@@ -10,7 +10,7 @@ export function runVaultMigrateCli(args = process.argv.slice(2)): void {
       const project = detectProject(repoPath) ?? '(unknown)';
       const isSymlink = fs.lstatSync(psiDir).isSymbolicLink();
       if (isSymlink) console.log(`  ${project} ✓ symlinked`);
-      else console.log(`  ${project} (${walkFiles(psiDir, repoPath).length} files) ← local`);
+      else console.log(`  ${project} (${migratableFiles(psiDir, repoPath).length} files) ← local`);
       console.log(`    ${repoPath}`);
     }
     return;

--- a/src/vault/migrate.ts
+++ b/src/vault/migrate.ts
@@ -5,7 +5,8 @@ import path from 'path';
 import { execSync } from 'child_process';
 import { getSetting } from '../db/index.ts';
 import { detectProject } from '../server/project-detect.ts';
-import { mapToVaultPath, ensureFrontmatterProject } from './handler.ts';
+import { belongsInVault, ensureFrontmatterProject, isProjectCategory, mapToVaultPath } from './path-mapping.ts';
+import { walkFiles } from './discovery.ts';
 import { ghqListPaths } from './ghq.ts';
 
 function resolveVaultPath(repo: string): string {
@@ -14,24 +15,21 @@ function resolveVaultPath(repo: string): string {
   return first;
 }
 
-function walkFiles(dir: string, baseDir: string): Array<{ relativePath: string; fullPath: string }> {
-  const results: Array<{ relativePath: string; fullPath: string }> = [];
-  if (!fs.existsSync(dir)) return results;
-
-  for (const item of fs.readdirSync(dir)) {
-    const fullPath = path.join(dir, item);
-    const stat = fs.lstatSync(fullPath);
-    if (stat.isSymbolicLink()) continue;
-    if (stat.isDirectory()) results.push(...walkFiles(fullPath, baseDir));
-    else results.push({ relativePath: path.relative(baseDir, fullPath), fullPath });
-  }
-  return results;
-}
-
-const PROJECT_CATEGORIES = ['ψ/memory/learnings/', 'ψ/memory/retrospectives/', 'ψ/inbox/handoff/'];
-
-function isProjectCategory(relativePath: string): boolean {
-  return PROJECT_CATEGORIES.some((cat) => relativePath.startsWith(cat));
+/**
+ * The files a migrate run would actually copy out of one repo's ψ/.
+ *
+ * `--list` and the copy loop must agree on this number, so both call it. They used to
+ * disagree: `--list` printed the raw walk while the loop skipped `.gitkeep` inline, so the
+ * count it advertised was never the count it copied.
+ *
+ * This replaces a private near-duplicate of `walkFiles` that had drifted from the exported
+ * one in `discovery.ts` — it lacked the `try/catch` around `lstat` and the separator
+ * normalisation that `belongsInVault`/`isProjectCategory` need to match a `ψ/…` prefix.
+ */
+function migratableFiles(psiDir: string, repoPath: string): Array<{ relativePath: string; fullPath: string }> {
+  return walkFiles(psiDir, repoPath).filter(
+    ({ relativePath }) => path.basename(relativePath) !== '.gitkeep' && belongsInVault(relativePath),
+  );
 }
 
 function sameFileContent(dest: string, source: string, content?: string): boolean {
@@ -117,10 +115,9 @@ function migrate(opts: MigrateOptions): MigrateResult {
       continue;
     }
 
-    const files = walkFiles(psiDir, repoPath);
+    const files = migratableFiles(psiDir, repoPath);
     let fileCount = 0;
     for (const { relativePath, fullPath } of files) {
-      if (path.basename(relativePath) === '.gitkeep') continue;
       const vaultRelPath = mapToVaultPath(relativePath, project);
       const dest = path.join(vaultPath, vaultRelPath);
       const content = fullPath.endsWith('.md') && isProjectCategory(relativePath)
@@ -172,7 +169,7 @@ function migrate(opts: MigrateOptions): MigrateResult {
   return result;
 }
 
-export { findPsiRepos, migrate, projectMatchesTenant, walkFiles };
+export { findPsiRepos, migrate, migratableFiles, projectMatchesTenant };
 export type { MigrateOptions, MigrateResult, RepoInfo };
 
 if (import.meta.main) {

--- a/src/vault/path-mapping.ts
+++ b/src/vault/path-mapping.ts
@@ -27,6 +27,28 @@ export function isProjectCategory(relativePath: string): boolean {
   return PROJECT_CATEGORIES.some((cat) => safePath.startsWith(cat));
 }
 
+const INBOX_PREFIX = 'ψ/inbox/';
+
+/**
+ * Does this local ψ/ path hold knowledge that belongs in a shared vault?
+ *
+ * `ψ/inbox/` is fleet comms — messages addressed to this oracle. `vault:migrate` swept all
+ * of it into the vault (#2803, @tenzaitech), so one house's unread mail became another
+ * house's knowledge corpus.
+ *
+ * The carve-out is **derived from the category lists above, not hardcoded**, and that
+ * distinction is load-bearing: `ψ/inbox/handoff/` is a PROJECT_CATEGORY, and
+ * `ψ/inbox/schedule.md` + `ψ/inbox/focus-agent-main.md` are UNIVERSAL_CATEGORIES. A blanket
+ * "skip ψ/inbox/ except handoff/" — the shape the original report proposed — would silently
+ * drop those two files, which `mapToVaultPath` deliberately maps to the vault root. Reading
+ * the answer off the declarations means adding a category can never desync the two.
+ */
+export function belongsInVault(relativePath: string): boolean {
+  const safePath = normalizeVaultRelativePath(relativePath);
+  if (!safePath.startsWith(INBOX_PREFIX)) return true;
+  return [...PROJECT_CATEGORIES, ...UNIVERSAL_CATEGORIES].some((cat) => safePath.startsWith(cat));
+}
+
 export function normalizeVaultRelativePath(value: string, label = 'vault path'): string {
   const raw = String(value ?? '').replaceAll('\\', '/').trim();
   if (!raw || raw.includes('\0') || raw.startsWith('/')) {


### PR DESCRIPTION
First item of #2849 — landing @tenzaitech's two reports (#2802, #2803) against current `alpha`.
Their PRs stay open; the design is theirs, only the base moved.

## What was actually wrong

Both bugs live in the same loop, which is why they ship together.

**#2802** — the vault walker descended into nested `.git` and `node_modules`. A repo with a
submodule, a linked worktree, or a vendored dep under `ψ/` dragged its whole object database
into the walk.

**#2803** — `migrate.ts` already imported `isProjectCategory`, but used it **only** to decide
whether to inject frontmatter (`:126`). The copy at `:135` still took everything the walker
returned, so `ψ/inbox/` — fleet comms, messages addressed to this oracle — was swept into the
shared vault.

Measured on a synthetic repo containing a nested `.git`, a vendored `node_modules`, real inbox
mail, and genuine knowledge:

```
before:  11 walked → 11 copied
after:    7 walked →  5 copied

.git leaked:          2 → 0
node_modules leaked:  2 → 0
fleet comms leaked:   2 → 0
```

## One correction to the report, and it matters

The proposed carve-out was *"skip `ψ/inbox/**` except `ψ/inbox/handoff/**`"*. That shape is
wrong here, and it took reading `path-mapping.ts` to see why:

```ts
export const UNIVERSAL_CATEGORIES = [
  'ψ/memory/resonance/',
  'ψ/inbox/schedule.md',          // ← vault-bound, on purpose
  'ψ/inbox/focus-agent-main.md',  // ← vault-bound, on purpose
  'ψ/active/',
];
```

`mapToVaultPath` maps those two to the vault root deliberately. A blanket inbox skip would have
**silently dropped both** — trading one data-loss bug for another.

So `belongsInVault()` reads its answer off `PROJECT_CATEGORIES` + `UNIVERSAL_CATEGORIES` instead
of hardcoding a list. Adding a category can no longer desync the two, and two tests exist purely
to catch a regression to the naive shape.

## Also removed: a fourth copy of the same walker

`src/vault/migrate.ts:17` held a private near-duplicate of the exported `walkFiles` in
`discovery.ts`. It had drifted: **no** `try/catch` around `lstat`, and **no** separator
normalisation — the very thing a `startsWith('ψ/…')` prefix test needs. Deleted; migrate now
uses the exported walker, and the guard lives in one place where `vault:sync` gets it too.

Same for `PROJECT_CATEGORIES`, which existed **three** times (`path-mapping.ts`,
`migrate.ts`, and a test fixture). `migrate.ts`'s copy is gone.

Side effect worth naming: `vault:migrate --list` printed the raw walk while the copy loop
skipped `.gitkeep` inline, so **the count it advertised was never the count it copied**. Both
now call `migratableFiles()`.

## On the symptom description

#2802 reports `EACCES` on read-only pack files. Accurate, but the consequence is
`vault:migrate` **crashing**, not data loss — `migrate.ts`'s walker had no `try/catch`, so the
throw escaped the whole run before `:146`'s `rmSync`. The hard failure was the safe outcome.
Recording that so nobody later "fixes" the crash by swallowing the error.

## Gates

```
bunx tsc --noEmit                                                    exit 0
bun test --isolate src/vault/ src/routes/vault/ tests/http/vault/ \
                   src/tools/… src/indexer/… tests/build/           75 pass / 0 fail (12 files)
```

Files: 99 / 140 / 178 / 24 / 66 / 100 lines — all under 250.

**The tests were mutation-checked, not just run.** With the guard and the carve-out removed:
**8 of 16 fail**. A test that cannot go red proves nothing (#2847).

## Two things this turned up that are not mine to fix here

1. **`bun test src/vault/` is red on `alpha` without `--isolate`** — 2 failures in
   `handler.test.ts`'s `syncVault lock` tests. Cause: `handler.test.ts:25` registers a
   *process-wide* `mock.module('../discovery.ts')`, and `discovery-edge.test.ts:5` statically
   imports the real module; whichever loads first wins. The two failures are exactly the tests
   that do a real non-dry-run sync, i.e. the path using the mocked `resolveVaultPath` /
   `cleanEmptyDirs`. Bisected: `handler + ghq` green, `handler + path-mapping-edge` green,
   `handler + discovery-edge` **red**. Same class as #2842. CI is unaffected because it runs
   `--isolate`; **CLAUDE.md tells contributors to run the scoped form that isn't.** Filed
   separately.
2. My own first draft of `discovery-never-walk.test.ts` wrote the gitfile without creating its
   parent, so the file never existed and `not.toContain` passed for the wrong reason. Only
   `--isolate` surfaced it, as an unhandled module-scope error. Fixed here; it is also the
   evidence for (1) being worth filing.

Refs #2849 · Closes #2802 · Closes #2803

🤖 Generated with [Claude Code](https://claude.com/claude-code)
