### PR TITLE
feat(indexer): index crew ψ-brains, attributed to the member

### DIFF
--- a/src/indexer/__tests__/crew-psi-discovery.test.ts
+++ b/src/indexer/__tests__/crew-psi-discovery.test.ts
@@ -1,0 +1,113 @@
+/**
+ * #2800 (@Anurak112) — crew ψ-brains were never indexed.
+ *
+ * `ψ/crew/<member>/memory/{learnings,retrospectives,…}` satisfies the same
+ * `{dir}/memory/{subdir}` contract as a project-first vault dir, so the existing collector
+ * loop can walk it once discovery returns it.
+ *
+ * Two things these tests pin beyond "does it find the dir":
+ *  - the `ORACLE_INDEX_CREW` lever honours more than the literal string "0". A flag that
+ *    silently ignores `=false` is the defect class of #2822 / #2846.
+ *  - crew documents get a real `project` attribution (`crew/<member>`). Without it every
+ *    crew doc falls through to `null`, and the reason for indexing crew brains separately
+ *    — knowing whose brain a result came from — is lost.
+ */
+import { afterAll, afterEach, describe, expect, test } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { discoverCrewPsiDirs, inferProjectFromPath } from '../discovery.ts';
+
+const vault = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-crew-'));
+const crew = path.join(vault, 'ψ', 'crew');
+
+// Two members with a memory/ brain, one without, and one plain file among them.
+fs.mkdirSync(path.join(crew, 'omar', 'memory', 'learnings'), { recursive: true });
+fs.mkdirSync(path.join(crew, 'jeera', 'memory', 'retrospectives'), { recursive: true });
+fs.mkdirSync(path.join(crew, 'no-brain-yet'), { recursive: true });
+fs.writeFileSync(path.join(crew, 'README.md'), '# crew');
+
+const previous = process.env.ORACLE_INDEX_CREW;
+
+afterEach(() => {
+  if (previous === undefined) delete process.env.ORACLE_INDEX_CREW;
+  else process.env.ORACLE_INDEX_CREW = previous;
+});
+
+afterAll(() => {
+  fs.rmSync(vault, { recursive: true, force: true });
+});
+
+function members(): string[] {
+  return discoverCrewPsiDirs(vault).map((dir) => path.basename(dir)).sort();
+}
+
+describe('discoverCrewPsiDirs', () => {
+  test('returns only members that actually have a memory/ brain', () => {
+    expect(members()).toEqual(['jeera', 'omar']);
+  });
+
+  test('a member directory without memory/ is not returned', () => {
+    expect(members()).not.toContain('no-brain-yet');
+  });
+
+  test('a plain file under ψ/crew/ is not mistaken for a member', () => {
+    expect(members()).not.toContain('README.md');
+  });
+
+  test('each returned dir satisfies the {dir}/memory/{subdir} collector contract', () => {
+    for (const dir of discoverCrewPsiDirs(vault)) {
+      expect(fs.existsSync(path.join(dir, 'memory'))).toBe(true);
+    }
+  });
+
+  test('a vault with no ψ/crew at all is not an error', () => {
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-crew-empty-'));
+    try {
+      expect(discoverCrewPsiDirs(empty)).toEqual([]);
+    } finally {
+      fs.rmSync(empty, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('ORACLE_INDEX_CREW honours every plausible spelling of off', () => {
+  test('indexed by default, matching discoverProjectPsiDirs', () => {
+    delete process.env.ORACLE_INDEX_CREW;
+    expect(members()).toEqual(['jeera', 'omar']);
+  });
+
+  for (const value of ['0', 'false', 'off', 'no', 'FALSE', ' Off ']) {
+    test(`ORACLE_INDEX_CREW=${JSON.stringify(value)} disables it`, () => {
+      process.env.ORACLE_INDEX_CREW = value;
+      expect(discoverCrewPsiDirs(vault)).toEqual([]);
+    });
+  }
+
+  for (const value of ['1', 'true', 'on', '']) {
+    test(`ORACLE_INDEX_CREW=${JSON.stringify(value)} leaves it enabled`, () => {
+      process.env.ORACLE_INDEX_CREW = value;
+      expect(members()).toEqual(['jeera', 'omar']);
+    });
+  }
+});
+
+describe('crew documents are attributable to the member', () => {
+  test('a crew path infers crew/<member>', () => {
+    expect(inferProjectFromPath('ψ/crew/omar/memory/learnings/2026-07-25_a.md')).toBe('crew/omar');
+  });
+
+  test('the member name is lowercased like every other project value', () => {
+    expect(inferProjectFromPath('ψ/crew/Omar/memory/learnings/a.md')).toBe('crew/omar');
+  });
+
+  test('a bare ψ/crew path with no member is not attributed', () => {
+    expect(inferProjectFromPath('ψ/crew/README.md')).toBeNull();
+  });
+
+  test('existing project inference is unchanged', () => {
+    expect(inferProjectFromPath('github.com/acme/app/ψ/memory/learnings/a.md')).toBe('github.com/acme/app');
+    expect(inferProjectFromPath('ψ/learn/acme/app/notes.md')).toBe('github.com/acme/app');
+    expect(inferProjectFromPath('ψ/memory/learnings/loose.md')).toBeNull();
+  });
+});

--- a/src/indexer/collectors.ts
+++ b/src/indexer/collectors.ts
@@ -7,7 +7,7 @@ import path from 'path';
 import type { OracleDocument, IndexerConfig } from '../types.ts';
 import { parseResonanceFile, parseLearningFile, parseRetroFile, parseSecurityCorpusFile } from './parser.ts';
 import { isPsiLearnSource, parsePsiLearnFile } from './learn-doc-source.ts';
-import { discoverProjectPsiDirs } from './discovery.ts';
+import { discoverCrewPsiDirs, discoverProjectPsiDirs } from './discovery.ts';
 
 const SECURITY_CORPUS_EXTENSIONS = ['.md', '.txt', '.yaml', '.yml', '.json', '.rst'];
 const SECURITY_CORPUS_MAX_FILE_BYTES = 200 * 1024;  // 200KB cap per file
@@ -83,9 +83,13 @@ export function collectDocuments(opts: CollectOpts): OracleDocument[] {
     totalFiles += files.length;
   }
 
-  // 2. Project-first vault dirs
+  // 2. Project-first vault dirs, plus crew ψ-brains — both satisfy {dir}/memory/{subdir},
+  //    so the same loop walks them with no special-casing (#2800, @Anurak112).
   let skippedDupes = 0;
-  const projectDirs = discoverProjectPsiDirs(config.repoRoot);
+  const projectDirs = [
+    ...discoverProjectPsiDirs(config.repoRoot),
+    ...discoverCrewPsiDirs(config.repoRoot),
+  ];
   for (const projectDir of projectDirs) {
     const projectSubdir = path.join(projectDir, 'memory', subdir);
     if (!fs.existsSync(projectSubdir)) continue;

--- a/src/indexer/discovery.ts
+++ b/src/indexer/discovery.ts
@@ -38,6 +38,58 @@ export function discoverProjectPsiDirs(repoRoot: string): string[] {
 }
 
 /**
+ * A crew member's ψ-brain is disabled by any of these, not just the literal "0".
+ *
+ * The repo's prevailing style is a bare `=== '0'`, which quietly ignores
+ * `ORACLE_INDEX_CREW=false` / `=off` / `=no`. #2822 was the issue about levers that are
+ * declared but do nothing, and #2846 was two more of the same shape — so a flag that only
+ * honours one spelling of "off" is a known-expensive shortcut here. There are ~14 other
+ * `process.env.ORACLE_* === '0'|'1'` sites that would benefit from one shared parser; that
+ * is a separate change, deliberately not made here.
+ */
+function crewIndexingDisabled(): boolean {
+  const raw = process.env.ORACLE_INDEX_CREW;
+  if (raw === undefined) return false;
+  return ['0', 'false', 'off', 'no'].includes(raw.trim().toLowerCase());
+}
+
+/**
+ * Discover crew ψ-brain directories in the vault.
+ *
+ * Scans `{repoRoot}/ψ/crew/<member>/` for members that have a `memory/` subdir, so each
+ * returned path satisfies the same `{dir}/memory/{subdir}` contract as a project-first vault
+ * dir and `collectDocuments` can walk it unchanged.
+ *
+ * Indexed by default, matching `discoverProjectPsiDirs` — crew memory is the vault's own
+ * knowledge, so it follows the project-dir precedent rather than `collectSecurityCorpus`'s
+ * opt-in (that one ingests a *foreign* corpus). Set `ORACLE_INDEX_CREW=0` to disable.
+ *
+ * Design by @Anurak112 (#2800).
+ */
+export function discoverCrewPsiDirs(repoRoot: string): string[] {
+  const dirs: string[] = [];
+  if (crewIndexingDisabled()) return dirs;
+
+  const crewRoot = path.join(repoRoot, 'ψ', 'crew');
+  if (!fs.existsSync(crewRoot)) return dirs;
+
+  for (const member of fs.readdirSync(crewRoot)) {
+    const memberDir = path.join(crewRoot, member);
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(memberDir);
+    } catch {
+      continue;
+    }
+    if (!stat.isDirectory()) continue;
+    if (fs.existsSync(path.join(memberDir, 'memory'))) dirs.push(memberDir);
+  }
+
+  if (dirs.length > 0) console.log(`Discovered ${dirs.length} crew ψ-brain directories`);
+  return dirs;
+}
+
+/**
  * Infer project from a vault-nested path.
  * Project-first layout: "github.com/org/repo/psi/..." -> "github.com/org/repo"
  * Also supports legacy layout: "psi/memory/{category}/github.com/org/repo/..."
@@ -49,6 +101,16 @@ export function inferProjectFromPath(relativePath: string): string | null {
   );
   if (projectFirst) {
     return `${projectFirst[1]}/${projectFirst[2]}`.toLowerCase();
+  }
+
+  // Crew ψ-brain: ψ/crew/{member}/... -> crew/{member}
+  // Without this, every crew document falls through to null and lands in the same
+  // unattributed bucket as root-level docs — which makes "which crew member wrote this"
+  // unanswerable, and that attribution is the entire reason for indexing crew brains
+  // separately. Frontmatter `project:` still wins over this (see parser.ts:21).
+  const crew = relativePath.match(/^ψ\/crew\/([^/]+)\//);
+  if (crew) {
+    return `crew/${crew[1]}`.toLowerCase();
   }
 
   // Local bulk ingest: psi/learn/{org}/{repo}/... -> github.com/org/repo


### PR DESCRIPTION
Second item of #2849 — landing @Anurak112's crew ψ-brain indexing (#2800) against current
`alpha`. Their PR stays open; the design is theirs, only the base moved.

## What lands

`ψ/crew/<member>/memory/{learnings,retrospectives,…}` satisfies the same
`{dir}/memory/{subdir}` contract as a project-first vault dir, so once discovery returns those
directories the existing collector loop walks them with **no special-casing**. That contract
observation is the good idea in this PR and it is preserved exactly.

Verified unmet on `alpha` before starting: no `ORACLE_INDEX_CREW`, no `discoverCrewPsiDirs`,
no `ψ/crew` handling anywhere in `src/`.

## Two changes to the original

**1. Crew documents are now attributable.** `parser.ts:21` resolves project as
`parseFrontmatterProject(content) || inferProjectFromPath(sourceFile)`, and no branch of
`inferProjectFromPath` matches `ψ/crew/…`. Measured, not assumed:

```
$ bun attr-check.ts
alpha:  null            <- every crew doc unattributed
branch: "crew/omar"
```

So every crew document would have landed in the same bucket as unattributed root docs, and
"whose brain did this result come from" would be unanswerable — which is the entire reason to
index crew brains as their own dirs rather than lumping them in. Four lines and a regex.
Frontmatter `project:` still wins, and no existing inference result changes.

**2. `ORACLE_INDEX_CREW` accepts more than the literal `"0"`.** The original used
`process.env.ORACLE_INDEX_CREW === '0'`, matching the repo's prevailing style — which silently
ignores `ORACLE_INDEX_CREW=false`, `=off`, `=no`. #2822 was *the issue about levers that are
declared but do nothing*, and #2846 was two more of the same shape shipped while fixing it. A
flag that honours one spelling of "off" is a known-expensive shortcut in this repo, so it now
takes `0|false|off|no`, case- and whitespace-insensitive. Six tests cover the spellings.

There are ~14 other `process.env.ORACLE_* === '0'|'1'` sites with the same weakness. One shared
parser would be the real fix; deliberately **not** done here.

**Opt-out, not opt-in** — kept from the original. Two precedents disagree, so this is a call
worth stating: `discoverProjectPsiDirs` is unconditional, `collectSecurityCorpus` is opt-in via
`=== '1'`. The difference is ownership — security-corpus ingests a *foreign* corpus, while crew
memory is the vault's own knowledge in the same shape as project memory. Crew follows project.

## What does NOT land, and why

`collectVaultExtraDocuments` — the second half of #2800 — is held back. It is a much broader
sweep (`ψ/inbox`, `ψ/outbox`, all of `ψ/learn`, per-member `inbox`/`outbox`/`CLAUDE.md`), and
three things need deciding before it ships:

1. **It contradicts #2803, which merged from the same batch.** That change stops
   `vault:migrate` copying `ψ/inbox/` on the grounds that it is fleet comms, not knowledge.
   This one indexes `ψ/inbox` and `ψ/outbox` wholesale. There *is* a coherent distinction —
   indexing makes mail locally searchable, copying propagates one house's mail into a shared
   vault — but it should be written down deliberately, not left as two changes that read as
   opposites.
2. **One flag named for crew gates content that is not crew.**
   `if (process.env.ORACLE_INDEX_CREW === '0') return []` guards vault-level `ψ/inbox`,
   `ψ/outbox` and `ψ/learn` too. Turning off crew indexing silently turns off three unrelated
   sources.
3. **Everything is typed as a learning.** `parseLearningFile` is applied to inbox mail, outbox
   drafts and `CLAUDE.md` identity files alike, which flattens the corpus's type dimension. And
   unlike `collectSecurityCorpus` there is no size cap — `SECURITY_CORPUS_MAX_FILE_BYTES` exists
   for exactly this reason.

Filed separately so the idea isn't lost. Splitting it is not a rejection: the crew-memory half
has a clean contract and lands today, the vault-extras half changes what the corpus *is*.

## Gates

```
bunx tsc --noEmit                                          exit 0
bun test --isolate src/indexer/                            126 pass / 0 fail (19 files)
bun test --isolate …/crew-psi-discovery.test.ts             20 pass / 0 fail
```

Files: 131 / 220 / 113 lines — all under 250.

**Mutation-checked, not just run.** Reverting the flag parse to the bare `=== '0'` turns 5 of
the 20 green; the attribution test is proven against `alpha`'s own function above. A test that
cannot go red proves nothing (#2847).

Refs #2849 · Closes #2800

🤖 Generated with [Claude Code](https://claude.com/claude-code)
