### PR TITLE
test(learn): seed the corpus so the #2835 DoS guard can actually fail

### DIFF
--- a/tests/helpers/seed-learn-corpus.ts
+++ b/tests/helpers/seed-learn-corpus.ts
@@ -1,0 +1,107 @@
+/**
+ * Seed the test database with learning documents.
+ *
+ * `bun test` sets `NODE_ENV=test`, and `src/db/index.ts:57` returns `':memory:'` — correct, so
+ * a test run can never touch a developer's real database. But nothing seeded it, so every
+ * corpus-dependent assertion in the suite was evaluating against **zero rows** and passing
+ * trivially. `tests/http/knowledge/learn-list-bounded.test.ts` — written as the regression
+ * guard for the #2835 denial of service — was asserting `0 <= 500` and reporting green (#2847).
+ *
+ * A guard that cannot see data cannot guard anything. This gives such tests rows to assert on.
+ *
+ * Writes through the same `db` singleton the routes import, so a route under test sees exactly
+ * what was seeded here — no second connection, no separate file.
+ */
+import { sql } from 'drizzle-orm';
+import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { db, oracleDocuments } from '../../src/db/index.ts';
+
+/** Mirrors the FTS5 virtual table the learn routes read content from. */
+const oracleFts = sqliteTable('oracle_fts', {
+  id: text('id'),
+  content: text('content'),
+  concepts: text('concepts'),
+});
+
+export interface SeedOptions {
+  /** How many learning documents to create. */
+  count?: number;
+  /** Id prefix, so two suites can seed without colliding. */
+  prefix?: string;
+  /** Tenant for the rows. Defaults to the schema default. */
+  tenantId?: string;
+}
+
+export interface SeededCorpus {
+  ids: string[];
+  /** Content keyed by id, so a test can assert the route returned the right body. */
+  contentById: Map<string, string>;
+}
+
+/**
+ * Insert `count` learning documents plus their FTS content.
+ *
+ * `updatedAt` descends with the index so the natural ordering (`ORDER BY updated_at DESC`) is
+ * deterministic: `${prefix}-0` is always the newest. Paging assertions depend on a stable
+ * order — without it an offset test can pass or fail on insertion timing alone.
+ */
+export function seedLearnCorpus(options: SeedOptions = {}): SeededCorpus {
+  const count = options.count ?? 12;
+  const prefix = options.prefix ?? 'seed-learning';
+  const base = 1_700_000_000_000;
+
+  const ids: string[] = [];
+  const contentById = new Map<string, string>();
+
+  for (let i = 0; i < count; i += 1) {
+    const id = `${prefix}-${i}`;
+    const content = `# Learning ${i}\n\nbody for ${id} with searchable words`;
+    ids.push(id);
+    contentById.set(id, content);
+
+    db.insert(oracleDocuments).values({
+      id,
+      ...(options.tenantId ? { tenantId: options.tenantId } : {}),
+      type: 'learning',
+      sourceFile: `ψ/memory/learnings/${id}.md`,
+      concepts: JSON.stringify([`concept-${i % 3}`]),
+      createdAt: base,
+      updatedAt: base - i, // strictly descending → deterministic paging
+      indexedAt: base,
+      origin: 'test',
+      project: 'github.com/acme/app',
+    }).run();
+
+    db.insert(oracleFts).values({ id, content, concepts: `concept-${i % 3}` }).run();
+  }
+
+  return { ids, contentById };
+}
+
+/** Remove everything a previous `seedLearnCorpus` inserted under `prefix`. */
+export function clearLearnCorpus(prefix = 'seed-learning'): void {
+  db.run(sql`DELETE FROM oracle_documents WHERE id LIKE ${`${prefix}-%`}`);
+  db.run(sql`DELETE FROM oracle_fts WHERE id LIKE ${`${prefix}-%`}`);
+}
+
+/**
+ * Fail loudly if the database a test is about to assert against is empty.
+ *
+ * This is the guard #2847 asks for. Call it from any suite whose assertions only mean
+ * something when rows exist — it converts "silently vacuous" into a failing test, which is the
+ * whole difference between a guard and a decoration.
+ */
+export function assertCorpusNotEmpty(): number {
+  const row = db.get<[number] | { c: number }>(
+    sql`SELECT COUNT(*) AS c FROM oracle_documents WHERE type = 'learning'`,
+  );
+  // Drizzle returns raw-sql rows as positional arrays; see reindex-state.ts, where assuming
+  // the object shape made a table-existence check silently false forever.
+  const total = Array.isArray(row) ? Number(row[0]) : Number(row?.c ?? 0);
+  if (total === 0) {
+    throw new Error(
+      'Corpus is empty — every assertion in this suite would pass vacuously. Call seedLearnCorpus() first (#2847).',
+    );
+  }
+  return total;
+}

--- a/tests/http/knowledge/learn-list-bounded.test.ts
+++ b/tests/http/knowledge/learn-list-bounded.test.ts
@@ -18,7 +18,8 @@
  * blocking. It has to be an OS-level timeout, or an assertion on the shape of
  * the work as below.
  */
-import { describe, expect, test } from 'bun:test';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { assertCorpusNotEmpty, clearLearnCorpus, seedLearnCorpus } from '../../helpers/seed-learn-corpus.ts';
 import {
   DEFAULT_LEARN_LIMIT,
   MAX_LEARN_LIMIT,
@@ -61,27 +62,72 @@ describe('learn list pagination guards', () => {
   });
 });
 
+/**
+ * These ran against an EMPTY in-memory database (#2847). `bun test` sets NODE_ENV=test, which
+ * makes the default DB `':memory:'`, and nothing seeded it — so "never returns more items than
+ * the limit" was asserting `0 <= 500`, and the overlap check compared two empty arrays. All
+ * green, all meaningless: reintroducing the per-row FTS lookup left this file at 10 pass / 0
+ * fail. They now run against a seeded corpus, and refuse to run against an empty one.
+ */
+const SEED_COUNT = 12;
+
 describe('learn list response contract', () => {
+  beforeAll(() => {
+    clearLearnCorpus();
+    seedLearnCorpus({ count: SEED_COUNT });
+  });
+
+  afterAll(() => {
+    clearLearnCorpus();
+  });
+
+  test('the corpus is actually populated — otherwise nothing below means anything', () => {
+    expect(assertCorpusNotEmpty()).toBeGreaterThanOrEqual(SEED_COUNT);
+    expect(listLearnEntries(SEED_COUNT, 0).items.length).toBe(SEED_COUNT);
+  });
+
   test('never returns more items than the requested limit', () => {
     const page = listLearnEntries(5, 0);
-    expect(page.items.length).toBeLessThanOrEqual(5);
+    // The point: there ARE more than 5 rows, so the limit is doing work.
+    expect(page.total).toBeGreaterThan(5);
+    expect(page.items.length).toBe(5);
     expect(page.limit).toBe(5);
     expect(page.offset).toBe(0);
   });
 
   test('total reports the full set, not just the page', () => {
     const page = listLearnEntries(1, 0);
-    expect(typeof page.total).toBe('number');
-    expect(page.total).toBeGreaterThanOrEqual(page.items.length);
+    expect(page.items.length).toBe(1);
+    expect(page.total).toBeGreaterThanOrEqual(SEED_COUNT);
+    expect(page.total).toBeGreaterThan(page.items.length);
   });
 
   test('offset advances the window without changing total', () => {
     const first = listLearnEntries(2, 0);
     const second = listLearnEntries(2, 2);
+    expect(first.items.length).toBe(2);
+    expect(second.items.length).toBe(2);
     expect(second.offset).toBe(2);
     expect(second.total).toBe(first.total);
     const overlap = first.items.filter((item) => second.items.some((other) => other.id === item.id));
     expect(overlap).toEqual([]);
+  });
+
+  test('a page carries the real content, not an empty body', () => {
+    // Content comes from oracle_fts via ONE `IN (...)` scan. If that join breaks, every item
+    // still arrives — with an empty body. An empty corpus could never have caught that.
+    const page = listLearnEntries(3, 0);
+    expect(page.items.length).toBe(3);
+    for (const item of page.items) {
+      expect(item.content.length).toBeGreaterThan(0);
+      expect(item.title.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('ordering is newest-first and stable across pages', () => {
+    const all = listLearnEntries(SEED_COUNT, 0).items;
+    const updatedAts = all.map((item) => item.updatedAt);
+    expect([...updatedAts].sort((a, b) => b - a)).toEqual(updatedAts);
   });
 
   test('the route caps a hostile limit rather than honouring it', async () => {
@@ -99,5 +145,75 @@ describe('learn list response contract', () => {
     const body = (await res.json()) as { items: unknown[]; limit: number };
     expect(body.limit).toBe(DEFAULT_LEARN_LIMIT);
     expect(body.items.length).toBeLessThanOrEqual(DEFAULT_LEARN_LIMIT);
+  });
+});
+
+/**
+ * The assertion that actually catches the #2835 denial of service.
+ *
+ * A seeded corpus proves the route returns the *right* rows; it says nothing about how much
+ * work it did to get them. The original bug returned perfectly correct results — it just
+ * issued one full FTS5 scan per row (~20ms each, 17,500 of them, on one event loop).
+ *
+ * So the property is **the number of FTS statements**, not the number of rows. Counted by
+ * wrapping `Database.prototype.prepare`, which is where drizzle compiles its SQL.
+ */
+describe('one FTS scan per request, whatever the page size', () => {
+  const PAGE_SIZES = [1, 5, 25, 50];
+  let restore: () => void;
+  let ftsStatements: string[] = [];
+
+  beforeAll(async () => {
+    clearLearnCorpus('fts-count');
+    seedLearnCorpus({ count: 60, prefix: 'fts-count' });
+
+    const { Database } = await import('bun:sqlite');
+    const proto = Database.prototype as unknown as Record<string, (sql: string, ...rest: unknown[]) => unknown>;
+    const originals: Record<string, (sql: string, ...rest: unknown[]) => unknown> = {};
+    for (const name of ['prepare', 'query']) {
+      originals[name] = proto[name];
+      proto[name] = function (this: unknown, sql: string, ...rest: unknown[]) {
+        if (typeof sql === 'string' && sql.includes('oracle_fts')) ftsStatements.push(sql);
+        return originals[name].call(this, sql, ...rest);
+      };
+    }
+    restore = () => { for (const name of ['prepare', 'query']) proto[name] = originals[name]; };
+  });
+
+  afterAll(() => {
+    restore?.();
+    clearLearnCorpus('fts-count');
+  });
+
+  for (const size of PAGE_SIZES) {
+    test(`a page of ${size} costs exactly one FTS statement`, () => {
+      ftsStatements = [];
+      const page = listLearnEntries(size, 0);
+
+      // Guard the guard: if the page came back empty the count would be trivially low.
+      expect(page.items.length).toBe(size);
+      expect(ftsStatements.length).toBe(1);
+    });
+  }
+
+  test('cost does not grow with page size — that is the whole defect', () => {
+    ftsStatements = [];
+    listLearnEntries(1, 0);
+    const forOne = ftsStatements.length;
+
+    ftsStatements = [];
+    listLearnEntries(50, 0);
+    const forFifty = ftsStatements.length;
+
+    // Per-row lookups would make this 1 vs 50.
+    expect(forFifty).toBe(forOne);
+  });
+
+  test('the one statement fetches the whole page at once', () => {
+    ftsStatements = [];
+    listLearnEntries(25, 0);
+    expect(ftsStatements).toHaveLength(1);
+    // `IN (...)` for the page, not `id = ?` per row.
+    expect(ftsStatements[0]).toMatch(/\bin\b/i);
   });
 });


### PR DESCRIPTION
Closes #2847.

## The guard was asserting `0 <= 500`

`bun test` sets `NODE_ENV=test`; `src/db/index.ts:57` returns `':memory:'` — correct, so a run
can never touch a developer's real database. But nothing seeded it, so
`tests/http/knowledge/learn-list-bounded.test.ts` — written as the regression guard for the
#2835 denial of service — was asserting against **zero rows**:

| assertion | actually evaluated |
|---|---|
| never returns more items than the requested limit | `0 <= 500` |
| total reports the full set, not just the page | `0 >= 0` |
| offset advances the window without changing total | overlap of two empty arrays |

## Seeding alone would not have fixed it

This is the part worth reading. **The original bug returned perfectly correct results.** It just
issued one full FTS5 scan per row — ~20ms each, 17,500 of them, on one event loop. A seeded
corpus proves the route returns the *right* rows and says nothing about the work done to get
them. With 12 seeded rows, the per-row version passes every content assertion.

So the property is **the number of FTS statements**, counted by wrapping
`Database.prototype.prepare`, where drizzle compiles its SQL:

```
a page of  1  → 1 FTS statement
a page of  5  → 1
a page of 25  → 1
a page of 50  → 1        ← per-row lookups would make this 50
```

Plus an assertion that the single statement is an `IN (…)` over the page rather than `id = ?`.

Each of those also asserts the page came back **full** first — otherwise a low statement count
would itself be trivially satisfied by an empty result. The guard needed its own guard.

## Mutation-checked against the real defect

Restoring the per-row `WHERE id = ?` loop in `contentByIds`:

```
before this PR (per #2847):  10 pass / 0 fail    ← the DoS reintroduced, undetected
after  this PR:              14 pass / 5 fail
```

That is #2847's stated done-criterion: *"reintroducing the per-row FTS lookup turns
learn-list-bounded red."*

## Reusable pieces

- `seedLearnCorpus()` — writes through the same `db` singleton the routes import, so a route
  under test sees exactly what was seeded. `updatedAt` descends with the index so paging
  assertions are deterministic rather than dependent on insertion timing.
- `assertCorpusNotEmpty()` — the guard #2847 asks for, turning "silently vacuous" into a
  failing test. Any corpus-dependent suite can call it.

It reads its count defensively (`Array.isArray(row) ? row[0] : row.c`) with a comment pointing
at `reindex-state.ts`, where assuming the object shape of a raw-`sql` row made a table-existence
check silently false forever — the bug fixed in #2863.

## Gates

```
bunx tsc --noEmit               exit 0
bun test --isolate tests/http/   1033 pass / 0 fail  (twice)
bun test --isolate tests/build/  8 pass / 0 fail
```

Files: 107 / 219 lines.

Closes #2847 · Refs #2835, #2836

🤖 Generated with [Claude Code](https://claude.com/claude-code)