### PR TITLE
fix(test): stop the HTTP suites adopting a live server and seeding its database

### DIFF
--- a/tests/http/_live-server.ts
+++ b/tests/http/_live-server.ts
@@ -1,0 +1,101 @@
+/**
+ * A server owned by one test file: its own port, its own database, torn down after.
+ *
+ * `compare.test.ts` and `knowledge.test.ts` each carried a near-identical copy of this, and
+ * both copies had the same defect — they began with `if (await isUp()) return;`, adopting
+ * whatever was already listening and then seeding it through `POST /api/learn`. On a
+ * developer machine that is the live Oracle: 616 test documents reached the real corpus
+ * between 2026-05-03 and 2026-06-16, indexed, and ranking in real search results.
+ *
+ * In `knowledge.test.ts` the early `return` skipped **past** the temp data directory created
+ * two lines below, so the isolation only ever applied on the path that did not need it.
+ *
+ * The rule this encodes: **a test never writes to a database it did not create.** An occupied
+ * port is an error, not an invitation.
+ */
+import type { Subprocess } from 'bun';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const REPO_ROOT = path.resolve(import.meta.dir, '../..');
+
+export interface LiveServer {
+  baseUrl: string;
+  dataDir: string;
+  stop(): void;
+  post(route: string, body: unknown): Promise<Response>;
+}
+
+async function healthy(baseUrl: string): Promise<boolean> {
+  try {
+    return (await fetch(`${baseUrl}/api/health`, { signal: AbortSignal.timeout(2000) })).ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Start a server this suite owns.
+ *
+ * @param port  must be unique per test file — sharing one is what raced `core.test.ts`
+ *              against `compare.test.ts` and produced a mid-run 503 in CI.
+ * @param label prefix for the temp data directory, so a leftover is traceable to its suite.
+ */
+export async function startOwnedServer(
+  port: number,
+  label: string,
+  /** Extra env for suites that need more isolation than port + data dir. */
+  extraEnv: Record<string, string> = {},
+): Promise<LiveServer> {
+  const baseUrl = `http://localhost:${port}`;
+
+  if (await healthy(baseUrl)) {
+    throw new Error(
+      `Port ${port} is already in use. This suite must own its server — refusing to seed data into someone else's.`,
+    );
+  }
+
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), `${label}-`));
+  const proc: Subprocess = Bun.spawn(['bun', 'run', 'src/server.ts'], {
+    cwd: REPO_ROOT,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      ...process.env,
+      ORACLE_PORT: String(port),
+      ORACLE_DATA_DIR: dataDir,
+      ORACLE_DB_PATH: path.join(dataDir, 'oracle.db'),
+      // Also point the repo root at the temp dir so a spawned server cannot read or write
+      // the developer's real ψ/ vault.
+      ORACLE_REPO_ROOT: dataDir,
+      ORACLE_CHROMA_TIMEOUT: '3000',
+      ...extraEnv,
+    },
+  });
+
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    if (await healthy(baseUrl)) {
+      return {
+        baseUrl,
+        dataDir,
+        stop() {
+          proc.kill();
+          fs.rmSync(dataDir, { recursive: true, force: true });
+        },
+        post(route, body) {
+          return fetch(`${baseUrl}${route}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+          });
+        },
+      };
+    }
+    await Bun.sleep(500);
+  }
+
+  proc.kill();
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  throw new Error(`Server on ${baseUrl} failed to become healthy within 15s`);
+}

--- a/tests/http/compare.test.ts
+++ b/tests/http/compare.test.ts
@@ -7,10 +7,7 @@
  * Pattern mirrors tests/http/knowledge.test.ts (subprocess + fetch).
  */
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
-import type { Subprocess } from "bun";
-import fs from "fs";
-import os from "os";
-import path from "path";
+import { startOwnedServer, type LiveServer } from "./_live-server.ts";
 
 /**
  * Its own port and its own data directory.
@@ -23,20 +20,10 @@ import path from "path";
  */
 const PORT = 47792;
 const BASE_URL = `http://localhost:${PORT}`;
-let dataDir = "";
+let server: LiveServer;
 const SEED_TAG = `compare-http-test-${Date.now()}`;
-const JSON_HEADERS = { "Content-Type": "application/json" };
-let serverProcess: Subprocess | null = null;
 
-const isUp = async () => {
-  try { return (await fetch(`${BASE_URL}/api/health`)).ok; } catch { return false; }
-};
-const waitUp = async (n = 30) => {
-  for (let i = 0; i < n; i++) { if (await isUp()) return true; await Bun.sleep(500); }
-  return false;
-};
-const post = (url: string, body: unknown) =>
-  fetch(`${BASE_URL}${url}`, { method: "POST", headers: JSON_HEADERS, body: JSON.stringify(body) });
+const post = (url: string, body: unknown) => server.post(url, body);
 
 async function seedLearn(pattern: string, concepts: string[] = []) {
   const res = await post("/api/learn", { pattern, source: SEED_TAG, concepts: [SEED_TAG, ...concepts] });
@@ -46,32 +33,16 @@ async function seedLearn(pattern: string, concepts: string[] = []) {
 
 describe("HTTP Contract — GET /api/compare", () => {
   beforeAll(async () => {
-    if (await isUp()) {
-      throw new Error(
-        `Port ${PORT} is already in use. This suite must own its server — refusing to seed data into someone else's.`,
-      );
-    }
-    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "compare-http-"));
-    serverProcess = Bun.spawn(["bun", "run", "src/server.ts"], {
-      cwd: path.resolve(import.meta.dir, "../.."),
-      stdout: "pipe", stderr: "pipe",
-      env: {
-        ...process.env,
-        ORACLE_PORT: String(PORT),
-        ORACLE_DATA_DIR: dataDir,
-        ORACLE_DB_PATH: path.join(dataDir, "oracle.db"),
-        ORACLE_CHROMA_TIMEOUT: "3000",
-      },
-    });
-    if (!(await waitUp())) throw new Error("Server failed to start within 15s");
-    // Best-effort seed so some model columns have real results
+    // Owns its server — see _live-server.ts. This used to point at 47778 (the developer
+    // default) and adopt whatever was listening, putting 168 documents into the live corpus
+    // and racing core.test.ts on the same port.
+    server = await startOwnedServer(PORT, "compare-http");
+    // Best-effort seed so some model columns have real results.
     try { await seedLearn(`${SEED_TAG} — alpha about compare endpoint`); } catch { /* ignore */ }
     try { await seedLearn(`${SEED_TAG} — beta on compare agreement`); } catch { /* ignore */ }
   }, 60_000);
-  afterAll(() => {
-    if (serverProcess) serverProcess.kill();
-    if (dataDir) fs.rmSync(dataDir, { recursive: true, force: true });
-  });
+
+  afterAll(() => { server?.stop(); });
 
   test("rejects missing query param", async () => {
     const res = await fetch(`${BASE_URL}/api/compare`);

--- a/tests/http/compare.test.ts
+++ b/tests/http/compare.test.ts
@@ -8,9 +8,22 @@
  */
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import type { Subprocess } from "bun";
+import fs from "fs";
+import os from "os";
 import path from "path";
 
-const BASE_URL = "http://localhost:47778";
+/**
+ * Its own port and its own data directory.
+ *
+ * This used to point at **47778 — the developer default** — and begin with
+ * `if (await isUp()) return;`, adopting whatever was listening and then POSTing to
+ * /api/learn. 168 `compare-http-test-*` documents reached the live corpus that way between
+ * 2026-05-03 and 2026-06-16. It also raced `core.test.ts` on the same port, which is how CI
+ * saw a healthy /api/health and then a 503 mid-run.
+ */
+const PORT = 47792;
+const BASE_URL = `http://localhost:${PORT}`;
+let dataDir = "";
 const SEED_TAG = `compare-http-test-${Date.now()}`;
 const JSON_HEADERS = { "Content-Type": "application/json" };
 let serverProcess: Subprocess | null = null;
@@ -33,18 +46,32 @@ async function seedLearn(pattern: string, concepts: string[] = []) {
 
 describe("HTTP Contract — GET /api/compare", () => {
   beforeAll(async () => {
-    if (await isUp()) return;
+    if (await isUp()) {
+      throw new Error(
+        `Port ${PORT} is already in use. This suite must own its server — refusing to seed data into someone else's.`,
+      );
+    }
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "compare-http-"));
     serverProcess = Bun.spawn(["bun", "run", "src/server.ts"], {
       cwd: path.resolve(import.meta.dir, "../.."),
       stdout: "pipe", stderr: "pipe",
-      env: { ...process.env, ORACLE_CHROMA_TIMEOUT: "3000" },
+      env: {
+        ...process.env,
+        ORACLE_PORT: String(PORT),
+        ORACLE_DATA_DIR: dataDir,
+        ORACLE_DB_PATH: path.join(dataDir, "oracle.db"),
+        ORACLE_CHROMA_TIMEOUT: "3000",
+      },
     });
     if (!(await waitUp())) throw new Error("Server failed to start within 15s");
     // Best-effort seed so some model columns have real results
     try { await seedLearn(`${SEED_TAG} — alpha about compare endpoint`); } catch { /* ignore */ }
     try { await seedLearn(`${SEED_TAG} — beta on compare agreement`); } catch { /* ignore */ }
   }, 60_000);
-  afterAll(() => { if (serverProcess) serverProcess.kill(); });
+  afterAll(() => {
+    if (serverProcess) serverProcess.kill();
+    if (dataDir) fs.rmSync(dataDir, { recursive: true, force: true });
+  });
 
   test("rejects missing query param", async () => {
     const res = await fetch(`${BASE_URL}/api/compare`);

--- a/tests/http/knowledge.test.ts
+++ b/tests/http/knowledge.test.ts
@@ -1,27 +1,13 @@
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
-import type { Subprocess } from "bun";
-import fs from "fs";
-import os from "os";
-import path from "path";
+import { startOwnedServer, type LiveServer } from "./_live-server.ts";
 
 const PORT = 47791;
+let server: LiveServer;
 const BASE_URL = `http://localhost:${PORT}`;
-const JSON_HEADERS = { "Content-Type": "application/json" };
 const SEED_TAG = `yellow-http-test-${Date.now()}`;
-let serverProcess: Subprocess | null = null;
-let dataDir = "";
 
-const isUp = async () => {
-  try { return (await fetch(`${BASE_URL}/api/health`)).ok; } catch { return false; }
-};
-
-const waitUp = async (n = 30) => {
-  for (let i = 0; i < n; i++) { if (await isUp()) return true; await Bun.sleep(500); }
-  return false;
-};
-
-const post = (url: string, body: unknown) =>
-  fetch(`${BASE_URL}${url}`, { method: "POST", headers: JSON_HEADERS, body: JSON.stringify(body) });
+const JSON_HEADERS = { "Content-Type": "application/json" };
+const post = (url: string, body: unknown) => server.post(url, body);
 
 async function seedLearn(pattern: string, concepts: string[] = []) {
   const res = await post("/api/learn", { pattern, source: SEED_TAG, concepts: [SEED_TAG, ...concepts] });
@@ -31,40 +17,14 @@ async function seedLearn(pattern: string, concepts: string[] = []) {
 
 describe("HTTP Contract — search / knowledge / supersede", () => {
   beforeAll(async () => {
-    // NEVER adopt a server that happens to be listening. This used to begin with
-    // `if (await isUp()) return;`, which short-circuited PAST the temp dataDir below — so an
-    // adopted server was seeded through /api/learn with no isolation whatsoever. On a
-    // developer machine that is the live Oracle: 432 `yellow-http-test-*` documents reached
-    // the real corpus between 2026-05-03 and 2026-06-16, indexed, and ranking in real search.
-    // Writes only stopped by accident, when /api/learn began 308-ing to /api/v1/learn and the
-    // failure was swallowed by seedLearn's try/catch — dormant, not fixed.
-    if (await isUp()) {
-      throw new Error(
-        `Port ${PORT} is already in use. This suite must own its server — refusing to seed data into someone else's.`,
-      );
-    }
-    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-http-"));
-    serverProcess = Bun.spawn(["bun", "run", "src/server.ts"], {
-      cwd: path.resolve(import.meta.dir, "../.."),
-      stdout: "pipe", stderr: "pipe",
-      env: {
-        ...process.env,
-        ORACLE_CHROMA_TIMEOUT: "3000",
-        ORACLE_DATA_DIR: dataDir,
-        ORACLE_DB_PATH: path.join(dataDir, "oracle.db"),
-        ORACLE_REPO_ROOT: dataDir,
-        ORACLE_PORT: String(PORT),
-      },
-    });
-    if (!(await waitUp())) throw new Error("Server failed to start within 15s");
+    // This suite OWNS its server — see _live-server.ts for why that matters. It used to begin
+    // with `if (await isUp()) return;`, adopting whatever was listening and seeding it, which
+    // put 432 `yellow-http-test-*` documents into the live corpus.
+    server = await startOwnedServer(PORT, "knowledge-http");
   }, 30_000);
-  afterAll(async () => {
-    if (serverProcess) {
-      serverProcess.kill();
-      await serverProcess.exited;
-      await Bun.sleep(500);
-    }
-    if (dataDir) fs.rmSync(dataDir, { recursive: true, force: true });
+
+  afterAll(() => {
+    server?.stop();
   });
 
   describe("POST /api/learn", () => {

--- a/tests/http/knowledge.test.ts
+++ b/tests/http/knowledge.test.ts
@@ -31,7 +31,18 @@ async function seedLearn(pattern: string, concepts: string[] = []) {
 
 describe("HTTP Contract — search / knowledge / supersede", () => {
   beforeAll(async () => {
-    if (await isUp()) return;
+    // NEVER adopt a server that happens to be listening. This used to begin with
+    // `if (await isUp()) return;`, which short-circuited PAST the temp dataDir below — so an
+    // adopted server was seeded through /api/learn with no isolation whatsoever. On a
+    // developer machine that is the live Oracle: 432 `yellow-http-test-*` documents reached
+    // the real corpus between 2026-05-03 and 2026-06-16, indexed, and ranking in real search.
+    // Writes only stopped by accident, when /api/learn began 308-ing to /api/v1/learn and the
+    // failure was swallowed by seedLearn's try/catch — dormant, not fixed.
+    if (await isUp()) {
+      throw new Error(
+        `Port ${PORT} is already in use. This suite must own its server — refusing to seed data into someone else's.`,
+      );
+    }
     dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-http-"));
     serverProcess = Bun.spawn(["bun", "run", "src/server.ts"], {
       cwd: path.resolve(import.meta.dir, "../.."),


### PR DESCRIPTION
Found while tracing why CI returned **503 mid-run** on #2863. The race was real, and it was a symptom of something larger.

## Two suites wrote into the developer's live Oracle

```ts
if (await isUp()) return;                       // adopt whatever is listening
…
const res = await post("/api/learn", { … });    // and seed it
```

`tests/http/compare.test.ts` pointed at **47778 — the developer default**. `knowledge.test.ts` is subtler and worse: its `return` short-circuits **past** the temp `dataDir` created two lines below, so the isolation existed only on the path that didn't need it.

Measured in the live database on this machine:

| tag | docs | first | last |
|---|---:|---|---|
| `yellow-http-test-*` (knowledge) | **432** | 2026-05-03 | 2026-06-16 |
| `compare-http-test-*` (compare) | **168** | 2026-05-03 | 2026-06-16 |
| other `*http-test*` | 16 | 2026-06-07 | 2026-06-07 |

**616 test documents in the real corpus**, indexed in FTS and ranking in real results — the top hit for "compare agreement" is a test artifact from 2026-05-03.

## It stopped by accident, not by fix

`POST /api/learn` now returns **308** to `/api/v1/learn`; `res.ok` is false, `seedLearn` throws, and the caller's `try/catch` swallows it. Verified: running `compare.test.ts` today adds **0** rows.

So this was **dormant, not fixed** — it resumes the moment that path answers a POST again. Which is exactly the kind of thing that should not be left to luck.

## The fix

Each suite owns its server or fails:

- no adopt path — an occupied port is an error, not an invitation
- `compare` moves 47778 → 47792, with its own `ORACLE_DATA_DIR` / `ORACLE_DB_PATH` and cleanup
- moving off 47778 also ends the race with `core.test.ts` that produced CI's 503

## Verified

```
compare.test.ts    8 pass / 0 fail
knowledge.test.ts  24 pass / 0 fail
writes to the live DB across both runs:  0   (616 → 616)
```

**Mutation-checked** by occupying 47792 with a stub answering `/api/health`:

```
error: Port 47792 is already in use. This suite must own its server —
       refusing to seed data into someone else's.
```

It refuses instead of adopting; with the port free it passes again.

## Not done here

Removing the 616 existing rows is a data operation on a live corpus, so it is filed separately rather than performed. One row was created by my own probe while diagnosing this and has been removed — that one was unambiguously mine.

Refs #2853

🤖 Generated with [Claude Code](https://claude.com/claude-code)