### PR TITLE
test(gateway): make the rate-limit refill test advance time instead of awaiting it

### DIFF
--- a/src/gateway/__tests__/rate-limit.test.ts
+++ b/src/gateway/__tests__/rate-limit.test.ts
@@ -63,16 +63,42 @@ describe('rate-limit hook', () => {
     expect((blocked as Response).status).toBe(429);
   });
 
+  /**
+   * Time is advanced, not awaited.
+   *
+   * This used to `await setTimeout(50)` and assume 50ms of wall clock had produced 50 tokens.
+   * That is a race with the machine: it passed 5/5 locally and failed on CI once the runner
+   * started executing all 29 test groups in one job (#2853). A refill test should assert the
+   * refill *arithmetic*, which is deterministic — the scheduler's punctuality is not the
+   * behaviour under test.
+   *
+   * `Date.now` is stubbed rather than injected because the hook reads it directly
+   * (`hooks/rate-limit.ts:95`) and a flaky test does not justify reshaping production code.
+   */
   it('refills tokens over time', async () => {
-    // 100 tokens per 100ms = 1 per ms. burst=1 → 1ms of wait should refill.
+    // 100 tokens per 100ms = 1 per ms, burst 1.
     const opts = { tokens_per_window: 100, window_ms: 100, burst: 1 };
-    expect(await run(ctxFor('5.5.5.5', opts))).toBeUndefined();
-    // Immediately after, blocked
-    const blocked = await run(ctxFor('5.5.5.5', opts));
-    expect((blocked as Response).status).toBe(429);
-    // Wait long enough for the bucket to refill
-    await new Promise((r) => setTimeout(r, 50));
-    expect(await run(ctxFor('5.5.5.5', opts))).toBeUndefined();
+    const realNow = Date.now;
+    try {
+      let clock = realNow();
+      Date.now = () => clock;
+
+      expect(await run(ctxFor('5.5.5.5', opts))).toBeUndefined();
+
+      // Same instant: the single burst token is spent.
+      const blocked = await run(ctxFor('5.5.5.5', opts));
+      expect((blocked as Response).status).toBe(429);
+
+      // Still blocked just before a whole token has accrued.
+      clock += 0.5;
+      expect(((await run(ctxFor('5.5.5.5', opts))) as Response).status).toBe(429);
+
+      // One full token later, allowed — no sleeping, no tolerance window.
+      clock += 50;
+      expect(await run(ctxFor('5.5.5.5', opts))).toBeUndefined();
+    } finally {
+      Date.now = realNow;
+    }
   });
 
   it('uses leftmost IP from a comma-separated X-Forwarded-For chain', async () => {


### PR DESCRIPTION
A flaky gate found by CI, not by a person: `rate-limit hook > refills tokens over time` failed on #2865's run while passing 5/5 locally.

## Why it started failing now

```ts
await new Promise((r) => setTimeout(r, 50));   // hope 50 tokens accrued
expect(await run(ctxFor('5.5.5.5', opts))).toBeUndefined();
```

The test sleeps and assumes the wall clock delivered. That assumption held until #2853 made CI execute **all 29 test groups in one job** — a busier runner, and the sleep stopped being reliable.

Nothing about the rate limiter changed. The test was always a race; the machine just got loaded enough to expose it.

## The fix

Advance time rather than await it:

```ts
let clock = realNow();
Date.now = () => clock;
…
clock += 0.5;    // still blocked — less than one token has accrued
clock += 50;     // allowed — no sleeping, no tolerance window
```

A refill test should assert the refill **arithmetic**, which is deterministic. The scheduler's punctuality is not the behaviour under test.

The added just-before-threshold assertion (`clock += 0.5` → still 429) is something the sleeping version could not express at all: you cannot reliably sleep for half a token.

`Date.now` is stubbed rather than injected because the hook reads it directly (`src/gateway/hooks/rate-limit.ts:95`). A flaky test does not justify reshaping production code, and the stub is restored in a `finally`.

## Verified

```
8 consecutive runs                     0 fail every time
bun test --isolate src/gateway/        all green
bunx tsc --noEmit                      exit 0
```

**Mutation-checked**: zeroing the refill (`bucket.tokens + refilled * 0`) turns it red — so it still catches a genuinely broken refill, which is the only reason to keep it.

Unrelated to #2865; it was blocking that gate, so it is split out to land on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)