### PR TITLE
ci: retry a test group only when bun crashes, never when a test fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,30 @@ jobs:
             tests/runtime/ tests/server/
           do
             echo "::group::${group}"
+            # Exit 133 is bun CRASHING (SIGTRAP), not a test failing — the two are
+            # indistinguishable by exit status alone, and conflating them is how a sweep ends
+            # up reporting "tests/http/ FAILED" when nothing failed. `bun test --isolate
+            # tests/http/` (290 files) crashes intermittently on bun 1.3.14: measured ~1 run
+            # in 4 on macOS, with no single file or subdirectory responsible — all 65 subdirs
+            # pass together, all 8 loose files pass together, and it still happens with the
+            # server-spawning suites removed. It is the size of one invocation. See #2867.
+            #
+            # So: retry ONCE on 133 only. A real test failure (any other non-zero) fails
+            # immediately and is never retried — retrying those would hide flaky tests, which
+            # is the opposite of what this gate is for.
+            set +e
             bun test --isolate "${group}"
+            status=$?
+            if [ "$status" -eq 133 ]; then
+              echo "::warning::bun crashed (exit 133) on ${group} — retrying once, see #2867"
+              bun test --isolate "${group}"
+              status=$?
+            fi
+            set -e
+            if [ "$status" -ne 0 ]; then
+              echo "::error::${group} failed with exit ${status}"
+              exit "$status"
+            fi
             echo "::endgroup::"
           done
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,12 @@ Updated 2026-04-19. These override anything below that conflicts.
   reported 36 tests across 6 files where 1 file exists; `bun test tests/http/` ran 1,692 files in 111s.
   Do not remove that line — `tests/build/test-scope.test.ts` fails if you do. See #2825.
 - HTTP contract tests are fetch-based against a spawned Elysia server (see `src/integration/http.test.ts` pattern).
+- ⚠️ **Exit 133 is bun crashing, not a test failing.** `bun test --isolate tests/http/` (290
+  files) crashes intermittently on bun 1.3.14 — ~1 run in 4 on macOS, no single file at fault
+  (all 65 subdirs pass together; all 8 loose files pass together). Run `tests/http/<subdir>/`
+  locally instead. A local sweep that reports a group as "failing" on exit 133 is reporting a
+  crash; check the code before believing a test broke (#2867). CI retries once on 133 only, and
+  never on a real failure.
 - **`tests/http/core.test.ts` is opt-in**: it is the only file under `tests/http/` that talks to a
   real port (:47778). Run it deliberately with `ORACLE_LIVE_CONTRACT=1 bun test --isolate
   tests/http/core.test.ts`; otherwise it skips. It first tried auto-detecting a live server,


### PR DESCRIPTION
Mitigates #2867, after bisecting it far enough to know what it is — and what it isn't.

## What the bisect established

`bun test --isolate tests/http/` crashes bun 1.3.14 with **exit 133** (SIGTRAP). It is not one bad file:

| what was run | files | result |
|---|---:|---|
| each of the 65 subdirectories, individually | — | all pass |
| **all 65 subdirectories in one invocation** | 282 | passes |
| each of the 8 loose top-level files, individually | — | all pass |
| **all 8 loose files in one invocation** | 8 | passes |
| 65 subdirs + 6 loose files (server-spawners removed) | 288 | **crashes ~1 in 4** |
| the whole group | 290 | **crashes ~1 in 4** |

So it is the **size of a single invocation**, not any file, subdirectory, or the two suites that spawn real servers.

One correction to my own method: an earlier single run of the 282-file set passed and I nearly recorded that as "282 is safe". At a ~25% crash rate a single pass proves nothing — it needed repeating before it meant anything.

## The fix: retry the crash, never the failure

A crash and a test failure both exit non-zero. That ambiguity is not academic — a local sweep reported `FAILING: tests/http/` **twice** tonight when nothing had failed.

```bash
bun test --isolate "${group}"
status=$?
if [ "$status" -eq 133 ]; then
  echo "::warning::bun crashed (exit 133) on ${group} — retrying once, see #2867"
  bun test --isolate "${group}"; status=$?
fi
[ "$status" -ne 0 ] && exit "$status"
```

Deliberately narrow. **Retrying a failing test would hide flaky tests**, which is the opposite of what this gate is for — #2868 exists precisely because a flake was found and *fixed* rather than retried away.

## An approach I discarded, and why

The first attempt split `tests/http/` into per-letter groups (`tests/http/a`, `tests/http/b`, …) so no invocation would be large enough to crash. Checked before shipping:

```
$ bun test --isolate tests/http/g     # no subdir starts with g
exit=1
```

A filter matching nothing exits 1, so the split would have failed CI outright. It would also have broken `tests/build/ci-covers-the-suite.test.ts`, which expects groups shaped `tests/<subdir>` — the guard doing its job against me.

## Also documented

`CLAUDE.md` now states that exit 133 is a crash rather than a failure, and that `tests/http/<subdir>/` is the local workaround. That distinction cost me time twice; the next person shouldn't pay it again.

## Gates

```
bunx tsc --noEmit                exit 0
bun test --isolate tests/build/  14 pass / 0 fail   (group-coverage guard still green)
```

Refs #2867

🤖 Generated with [Claude Code](https://claude.com/claude-code)