### PR TITLE
fix(server): the root endpoint advertised a 404 and two redirects

### DIFF
--- a/src/routes/meta/endpoints.ts
+++ b/src/routes/meta/endpoints.ts
@@ -1,0 +1,49 @@
+/**
+ * The endpoint map the root `/` advertises, and the API root that answers at `/api/v1`.
+ *
+ * One definition, because it used to be two: `server.ts` listed `docs` both as a top-level
+ * field and inside `endpoints`, and they could drift independently.
+ *
+ * Measured against the live server before this existed:
+ *
+ * ```
+ * /api/docs        308   → only works if the client follows redirects
+ * /api/docs/json   308   → same
+ * /api/v1          404   → advertised as "api", dead even when followed
+ * ```
+ *
+ * That map is the product's front door — `maw arra` and the #2820 enrichment read it. A
+ * discovery document that sends a client to a 404 is the declared-but-not-true defect of
+ * #2822 / #2831 / #2862, in the one place where being wrong is most expensive.
+ *
+ * **Paths here are the PUBLIC ones.** `middleware/api-version.ts` rewrites an incoming
+ * `/api/v1/foo` to `/api/foo` before routing, so a handler for the public `/api/v1` must be
+ * registered at `/api`. Getting that backwards is why the first attempt still 404'd.
+ *
+ * Pinned by `tests/http/root/advertised-endpoints.test.ts`, which derives its cases from the
+ * running server — so adding an entry here puts it under the same obligation automatically.
+ */
+
+/** Public paths, as a client sees them. Every one must answer without a redirect. */
+export const PUBLIC_ENDPOINTS = {
+  docs: '/api/v1/docs',
+  openapi: '/api/v1/docs/json',
+  api: '/api/v1',
+  mcp: '/mcp',
+  health: '/api/v1/health',
+  stats: '/api/v1/stats',
+  simple: '/simple',
+} as const;
+
+/** What `/api/v1` returns: the versioned endpoints, so one GET describes the API. */
+export function apiRootResponse(version: string) {
+  return {
+    version,
+    endpoints: {
+      docs: PUBLIC_ENDPOINTS.docs,
+      openapi: PUBLIC_ENDPOINTS.openapi,
+      health: PUBLIC_ENDPOINTS.health,
+      stats: PUBLIC_ENDPOINTS.stats,
+    },
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,7 @@ import { closeCachedVectorStores } from './vector/factory.ts';
 import { warmEmbeddingProviderDetection } from './vector/provider-detection.ts';
 import { preflightVectorRuntime } from './vector/preflight.ts';
 import { drainingResponseFor, isDraining, registerGracefulShutdown, runShutdownSteps, trackRequest } from './lifecycle/shutdown.ts';
+import { PUBLIC_ENDPOINTS, apiRootResponse } from './routes/meta/endpoints.ts';
 import { createErrorMiddleware } from './middleware/errors.ts';
 import { validateStartupEnv } from './config/validate.ts';
 import { printStartupBanner } from './lifecycle/banner.ts';
@@ -147,6 +148,11 @@ export function createApp({ unifiedPlugins, runtimeRef = createUnifiedRuntimeRef
     .get('/swagger', () => Response.redirect('/api/docs', 308), { detail: { hide: true } })
     .get('/swagger/json', () => Response.redirect('/api/docs/json', 308), { detail: { hide: true } })
     .get('/api/openapi.json', () => Response.redirect('/api/docs/json', 308), { detail: { hide: true } })
+    // Registered at '/api', which is the PUBLIC '/api/v1' — api-version.ts rewrites the
+    // versioned prefix away before routing. Advertised as `api` and returned 404 until now.
+    .get('/api', () => apiRootResponse(pkg.version), {
+      detail: { tags: ['meta'], summary: 'API root — lists versioned endpoints' },
+    })
     .get('/simple', ({ set }) => simpleModeResponse(set), { detail: { tags: ['frontend'], summary: 'Simple Mode entry page' } })
     .get('/', () => ({
       server: MCP_SERVER_NAME,
@@ -156,17 +162,9 @@ export function createApp({ unifiedPlugins, runtimeRef = createUnifiedRuntimeRef
       plugins: unifiedPlugins.pluginCount,
       pluginMcpTools: unifiedPlugins.mcpTools.length,
       counts: rootCounts(),
-      docs: '/api/docs',
-      api: '/api/v1',
-      endpoints: {
-        docs: '/api/docs',
-        openapi: '/api/docs/json',
-        api: '/api/v1',
-        mcp: '/mcp',
-        health: '/api/v1/health',
-        stats: '/api/v1/stats',
-        simple: '/simple',
-      },
+      docs: PUBLIC_ENDPOINTS.docs,
+      api: PUBLIC_ENDPOINTS.api,
+      endpoints: PUBLIC_ENDPOINTS,
       config: {
         port: Number(PORT),
         dataDir,

--- a/tests/http/root/advertised-endpoints.test.ts
+++ b/tests/http/root/advertised-endpoints.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Every endpoint the root advertises must actually answer.
+ *
+ * `GET /` returns an `endpoints` map — it is the product's front door, read by `maw arra` and
+ * by the #2820 enrichment. Measured against the live server before this test existed:
+ *
+ * ```
+ * /api/docs        308   → only works if the client follows redirects
+ * /api/docs/json   308   → same
+ * /api/v1          404   → advertised as "api", and dead even when followed
+ * ```
+ *
+ * A map of endpoints where one entry 404s and two need redirect-following is the same
+ * declared-but-not-true defect as #2822 (levers that turn nothing), #2831 (docs describing
+ * behaviour that did not exist) and #2862 (typed fields nothing reads). It is worse here
+ * because this map is what a client reads *in order to discover the API*.
+ *
+ * This test derives its cases from the running server rather than a hardcoded list, so adding
+ * an endpoint to the map automatically puts it under the same obligation.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { startOwnedServer, type LiveServer } from '../_live-server.ts';
+
+const PORT = 47793;
+let server: LiveServer;
+let endpoints: Record<string, string> = {};
+
+beforeAll(async () => {
+  server = await startOwnedServer(PORT, 'root-endpoints');
+  const body = (await (await fetch(`${server.baseUrl}/`)).json()) as {
+    endpoints?: Record<string, string>;
+    data?: { endpoints?: Record<string, string> };
+  };
+  endpoints = body.endpoints ?? body.data?.endpoints ?? {};
+}, 60_000);
+
+afterAll(() => {
+  server?.stop();
+});
+
+/** `/mcp` is bearer-gated: 401 is it working correctly, not a missing route. */
+const AUTH_GATED = new Set(['/mcp']);
+
+describe('the root endpoint map is honest', () => {
+  test('the map is present and non-trivial', () => {
+    expect(Object.keys(endpoints).length).toBeGreaterThanOrEqual(5);
+  });
+
+  test('no advertised endpoint 404s', async () => {
+    const dead: string[] = [];
+    for (const [name, route] of Object.entries(endpoints)) {
+      const res = await fetch(`${server.baseUrl}${route}`, { redirect: 'manual' });
+      if (res.status === 404) dead.push(`${name} → ${route} (404)`);
+    }
+    // `/api/v1` was advertised as `api` and returned 404.
+    expect(dead).toEqual([]);
+  });
+
+  test('no advertised endpoint requires following a redirect', async () => {
+    // A client that does not follow redirects — `curl` without -L, and plenty of library
+    // defaults — gets nothing. Advertise the destination, not the forwarding address.
+    const redirecting: string[] = [];
+    for (const [name, route] of Object.entries(endpoints)) {
+      const res = await fetch(`${server.baseUrl}${route}`, { redirect: 'manual' });
+      if (res.status >= 300 && res.status < 400) {
+        redirecting.push(`${name} → ${route} (${res.status} → ${res.headers.get('location')})`);
+      }
+    }
+    expect(redirecting).toEqual([]);
+  });
+
+  test('every advertised endpoint responds successfully, or 401 if it is auth-gated', async () => {
+    const bad: string[] = [];
+    for (const [name, route] of Object.entries(endpoints)) {
+      const res = await fetch(`${server.baseUrl}${route}`, { redirect: 'manual' });
+      const acceptable = res.ok || (AUTH_GATED.has(route) && res.status === 401);
+      if (!acceptable) bad.push(`${name} → ${route} (${res.status})`);
+    }
+    expect(bad).toEqual([]);
+  });
+});
+
+describe('the advertised API root answers', () => {
+  test('GET /api/v1 returns its own endpoint list', async () => {
+    const res = await fetch(`${server.baseUrl}/api/v1`);
+    expect(res.ok).toBe(true);
+    const body = (await res.json()) as { data?: { endpoints?: Record<string, string> }; endpoints?: Record<string, string> };
+    const listed = body.endpoints ?? body.data?.endpoints ?? {};
+    expect(Object.keys(listed).length).toBeGreaterThan(0);
+  });
+
+  test('the endpoints it lists also answer', async () => {
+    const res = await fetch(`${server.baseUrl}/api/v1`);
+    const body = (await res.json()) as { data?: { endpoints?: Record<string, string> }; endpoints?: Record<string, string> };
+    const listed = body.endpoints ?? body.data?.endpoints ?? {};
+    const bad: string[] = [];
+    for (const [name, route] of Object.entries(listed)) {
+      const probe = await fetch(`${server.baseUrl}${route}`, { redirect: 'manual' });
+      if (!probe.ok) bad.push(`${name} → ${route} (${probe.status})`);
+    }
+    expect(bad).toEqual([]);
+  });
+});


### PR DESCRIPTION
`GET /` returns an `endpoints` map. It is the product's discovery document — `maw arra` and the #2820 enrichment read it. Probed against the live server:

```
/api/docs        308   → only works if the client follows redirects
/api/docs/json   308   → same
/api/v1          404   → advertised as "api", and dead even when followed
/mcp             401   → bearer-gated, correct
/api/v1/health   200
/api/v1/stats    200
/simple          200
```

Three of seven entries did not work as advertised. A client that does not follow redirects — `curl` without `-L`, and plenty of library defaults — gets nothing from two of them, and the third is simply gone.

Same declared-but-not-true family as #2822 (levers that turn nothing), #2831 (docs describing behaviour that did not exist) and #2862 (typed fields nothing reads) — but in the one place where being wrong is most expensive, because this map is what a client reads *in order to discover the API*.

## The fix

- `docs` / `openapi` now name the real paths (`/api/v1/docs`, `/api/v1/docs/json`)
- `/api/v1` answers with its own endpoint list instead of 404ing
- one `PUBLIC_ENDPOINTS` constant — the map existed **twice** in `server.ts` (`docs` as a top-level field and again inside `endpoints`), free to drift apart

## The part I got wrong first

I registered the route at the literal `/api/v1`. It still 404'd, and the test caught it:

```ts
// middleware/api-version.ts
const suffix = url.pathname.slice(VERSIONED_PREFIX.length);
url.pathname = `${API_PREFIX}${suffix}`;      // /api/v1/foo → /api/foo
```

Incoming `/api/v1/*` is rewritten to `/api/*` **before** routing, so a handler for the public `/api/v1` must be registered at `/api`. That is now stated in the module, since it is not guessable from the outside.

## The guard

`tests/http/root/advertised-endpoints.test.ts` derives its cases from the running server rather than a hardcoded list, so adding an entry to the map automatically puts it under the same obligation: no 404, no redirect, must respond (401 permitted for `/mcp`, which is auth-gated by design).

**Mutation-checked**: reinstating both original defects turns **4 of its 6** red.

## Gates

```
bunx tsc --noEmit                     exit 0
src/                                  971 pass / 0 fail
tests/http/ (all 65 subdirs)          no failures
tests/docs/ tests/build/ tests/mcp/   green
tests/smoke/                          10 pass / 0 fail  ×3
```

`server.ts` is 291 against its grandfathered ceiling of 293 — the ratchet refused an earlier version of this change at 310, which is what prompted extracting the map rather than growing the file.

One measurement note: a first `tests/smoke/` run showed 2 failures that did not reproduce in 3 subsequent runs, and clean `alpha` is 10/10. They were my own concurrent test runs contending for ports, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)