### PR TITLE
feat: fleet vault ingestion, rebased onto alpha

### DIFF
--- a/docs/DB-MIGRATIONS.md
+++ b/docs/DB-MIGRATIONS.md
@@ -8,7 +8,7 @@ Schema changes must flow through `src/db/schema.ts`, generated migrations in
 
 `drizzle.config.ts` is the canonical drizzle-kit config:
 
-- `schema`: `./src/db/schema.ts`
+- `schema`: `./src/db/drizzle-schema.ts` (CLI barrel; excludes FTS5 virtual tables)
 - `out`: `./src/db/migrations`
 - `dialect`: `sqlite`
 - DB path: `ORACLE_DB_PATH`, or `${ORACLE_DATA_DIR}/oracle.db`, or
@@ -17,7 +17,7 @@ Schema changes must flow through `src/db/schema.ts`, generated migrations in
 
 ## Change workflow
 
-1. Edit `src/db/schema.ts` with Drizzle ORM table/index definitions.
+1. Edit `src/db/schema.ts` with Drizzle ORM table/index definitions, then export managed non-FTS tables through `src/db/drizzle-schema.ts`.
 2. Generate a migration:
 
    ```bash

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -8,12 +8,7 @@ const DB_PATH = process.env.ORACLE_DB_PATH || path.join(ORACLE_DATA_DIR, 'oracle
 
 export default defineConfig({
   dialect: 'sqlite',
-  schema: [
-    './src/db/schema.ts',
-    './src/db/export-schema.ts',
-    './src/db/plugin-schema.ts',
-    './src/storage/audit-log.ts',
-  ],
+  schema: './src/db/drizzle-schema.ts',
   out: './src/db/migrations',
   dbCredentials: {
     url: DB_PATH,
@@ -21,8 +16,13 @@ export default defineConfig({
   // Tables managed by Drizzle (excludes FTS5 internal tables)
   tablesFilter: [
     'oracle_documents',
+    'tenants',
+    'oracle_entity_links',
+    'oracle_pointer_index',
     'oracle_memories',
     'indexing_status',
+    'indexing_jobs',
+    'vector_index_manifest',
     'search_log',
     'consult_log',
     'learn_log',
@@ -39,5 +39,7 @@ export default defineConfig({
     'audit_log',      // Query write audit trail
     'export_jobs',    // Export run history
     'plugin_metadata', // Server-side plugin registrations
+    'fleet_messages',   // Unified fleet communication log
+    'fleet_ingest_cursor', // Fleet ingestion progress cursors
   ],
 });

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "vault:status": "bun src/vault/cli.ts status",
     "vault:migrate": "bun src/vault/cli.ts migrate",
     "vault:rsync": "./scripts/vault-rsync.sh",
+    "fleet:ingest:vault": "bun scripts/ingest-fleet-vault.ts",
     "huginn:capture": "bun scripts/huginn-capture-hook.ts",
     "test:huginn": "bun test src/huginn/__tests__/capture.test.ts src/huginn/__tests__/sweep.test.ts",
     "huginn:sweep": "bun scripts/huginn-sweep.ts",

--- a/scripts/ingest-fleet-vault.ts
+++ b/scripts/ingest-fleet-vault.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env bun
+import { ingestVaultInbox } from '../src/fleet-log/vault-ingest.ts';
+
+function value(args: string[], flag: string): string | undefined {
+  const index = args.indexOf(flag);
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+const args = Bun.argv.slice(2);
+if (args.includes('--help') || args.includes('-h')) {
+  console.log(`Usage: bun scripts/ingest-fleet-vault.ts [--repo-root PATH] [--db PATH]\n\nIngest this repo's ψ/inbox/*.md vault messages into fleet_messages.`);
+  process.exit(0);
+}
+
+const summary = ingestVaultInbox({
+  repoRoot: value(args, '--repo-root'),
+  dbPath: value(args, '--db'),
+});
+
+console.log(JSON.stringify(summary, null, 2));

--- a/src/db/drizzle-schema.ts
+++ b/src/db/drizzle-schema.ts
@@ -1,0 +1,23 @@
+export {
+  consultLog,
+  documentAccess,
+  fleetIngestCursor,
+  fleetMessages,
+  forumMessages,
+  forumThreads,
+  indexingJobs,
+  indexingStatus,
+  learnLog,
+  oracleDocuments,
+  oracleEntityLinks,
+  oracleMemories,
+  oraclePointerIndex,
+  searchLog,
+  tenants,
+  traceLog,
+  vectorIndexManifest,
+} from './schema.ts';
+export { exportJobs } from './export-schema.ts';
+export { activityLog, menuItems, schedule, settings, supersedeLog } from './logistics-schema.ts';
+export { pluginMetadata } from './plugin-schema.ts';
+export { auditLog } from '../storage/audit-log.ts';

--- a/src/db/fleet-log-schema.ts
+++ b/src/db/fleet-log-schema.ts
@@ -1,0 +1,31 @@
+import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
+
+export const fleetMessages = sqliteTable('fleet_messages', {
+  id: text('id').primaryKey(),
+  tenantId: text('tenant_id').default('default').notNull(),
+  channel: text('channel').notNull(),          // 'maw' | 'vault' | 'webhook' | 'discord' | 'agent-team' | 'git'
+  source: text('source'),
+  direction: text('direction'),                // 'outbound' | 'inbound' | 'forwarded' | null
+  fromId: text('from_id'),
+  toId: text('to_id'),
+  threadKey: text('thread_key'),                // heuristic grouping, NOT a hard FK — see below
+  text: text('text'),
+  raw: text('raw'),
+  rawPath: text('raw_path'),
+  ts: integer('ts').notNull(),
+  ingestedAt: integer('ingested_at').notNull(),
+}, (table) => [
+  index('idx_fleet_msg_channel_ts').on(table.channel, table.ts),
+  index('idx_fleet_msg_from').on(table.fromId),
+  index('idx_fleet_msg_to').on(table.toId),
+  index('idx_fleet_msg_thread').on(table.threadKey),
+  index('idx_fleet_msg_tenant_ts').on(table.tenantId, table.ts),
+]);
+
+export const fleetIngestCursor = sqliteTable('fleet_ingest_cursor', {
+  id: text('id').primaryKey(),                  // 'maw-ledger' | 'vault:<repo-name>' | ...
+  lastCursor: text('last_cursor'),
+  lastRunAt: integer('last_run_at'),
+  status: text('status').default('idle').notNull(),
+  error: text('error'),
+});

--- a/src/db/forum-schema.ts
+++ b/src/db/forum-schema.ts
@@ -1,0 +1,48 @@
+/**
+ * Forum tables — threads and their messages.
+ *
+ * Split out of `schema.ts` when that file hit the 250-line ceiling. It already follows this
+ * pattern for `export-schema`, `fleet-log-schema`, `oracle-dig-schema`, `logistics-schema`
+ * and `vector-schema`, so forum joins them rather than the file growing by one more line.
+ *
+ * Split rather than padded: the previous approach was to cram two `export {...}` statements
+ * onto a single line to stay at exactly 250, which satisfies the counter without addressing
+ * what it is counting.
+ */
+import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
+
+export const forumThreads = sqliteTable('forum_threads', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  title: text('title').notNull(),
+  tenantId: text('tenant_id').default('default').notNull(),
+  createdBy: text('created_by').default('human'),
+  status: text('status').default('active'),
+  issueUrl: text('issue_url'),
+  issueNumber: integer('issue_number'),
+  project: text('project'),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+  syncedAt: integer('synced_at'),
+}, (table) => [
+  index('idx_thread_status').on(table.status),
+  index('idx_thread_project').on(table.project),
+  index('idx_thread_tenant').on(table.tenantId),
+  index('idx_thread_created').on(table.createdAt),
+  index('idx_thread_tenant_status_updated').on(table.tenantId, table.status, table.updatedAt),
+]);
+export const forumMessages = sqliteTable('forum_messages', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  threadId: integer('thread_id').notNull().references(() => forumThreads.id),
+  role: text('role').notNull(),
+  content: text('content').notNull(),
+  author: text('author'),
+  principlesFound: integer('principles_found'),
+  patternsFound: integer('patterns_found'),
+  searchQuery: text('search_query'),
+  commentId: integer('comment_id'),
+  createdAt: integer('created_at').notNull(),
+}, (table) => [
+  index('idx_message_thread').on(table.threadId),
+  index('idx_message_role').on(table.role),
+  index('idx_message_created').on(table.createdAt),
+]);

--- a/src/db/migrations/0041_fleet_log.sql
+++ b/src/db/migrations/0041_fleet_log.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS fleet_messages (
+  id TEXT PRIMARY KEY NOT NULL,
+  tenant_id TEXT DEFAULT 'default' NOT NULL,
+  channel TEXT NOT NULL,
+  source TEXT,
+  direction TEXT,
+  from_id TEXT,
+  to_id TEXT,
+  thread_key TEXT,
+  text TEXT,
+  raw TEXT,
+  raw_path TEXT,
+  ts INTEGER NOT NULL,
+  ingested_at INTEGER NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_fleet_msg_channel_ts ON fleet_messages (channel, ts);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_fleet_msg_from ON fleet_messages (from_id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_fleet_msg_to ON fleet_messages (to_id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_fleet_msg_thread ON fleet_messages (thread_key);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_fleet_msg_tenant_ts ON fleet_messages (tenant_id, ts);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS fleet_ingest_cursor (
+  id TEXT PRIMARY KEY NOT NULL,
+  last_cursor TEXT,
+  last_run_at INTEGER,
+  status TEXT DEFAULT 'idle' NOT NULL,
+  error TEXT
+);

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -233,13 +233,68 @@
       "tag": "0032_schema_integrity_guards",
       "breakpoints": true
     },
-    { "idx": 33, "version": "6", "when": 1781686800000, "tag": "0033_memory_valid_time", "breakpoints": true },
-    { "idx": 34, "version": "6", "when": 1781700000000, "tag": "0034_memory_ttl", "breakpoints": true },
-    { "idx": 35, "version": "6", "when": 1781669700000, "tag": "0035_entity_links_ranking_sidecar", "breakpoints": true },
-    { "idx": 36, "version": "6", "when": 1781703600000, "tag": "0036_memory_consolidation", "breakpoints": true },
-    { "idx": 37, "version": "6", "when": 1781703700000, "tag": "0037_memory_tiered_salience", "breakpoints": true },
-    { "idx": 38, "version": "6", "when": 1781703800000, "tag": "0038_pointer_index", "breakpoints": true },
-    { "idx": 39, "version": "6", "when": 1781703900000, "tag": "0039_vector_index_manifest", "breakpoints": true },
-    { "idx": 40, "version": "6", "when": 1781704000000, "tag": "0040_oracle_findings", "breakpoints": true }
+    {
+      "idx": 33,
+      "version": "6",
+      "when": 1781686800000,
+      "tag": "0033_memory_valid_time",
+      "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "6",
+      "when": 1781700000000,
+      "tag": "0034_memory_ttl",
+      "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "6",
+      "when": 1781669700000,
+      "tag": "0035_entity_links_ranking_sidecar",
+      "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "6",
+      "when": 1781703600000,
+      "tag": "0036_memory_consolidation",
+      "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "6",
+      "when": 1781703700000,
+      "tag": "0037_memory_tiered_salience",
+      "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "6",
+      "when": 1781703800000,
+      "tag": "0038_pointer_index",
+      "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "6",
+      "when": 1781703900000,
+      "tag": "0039_vector_index_manifest",
+      "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "6",
+      "when": 1781704000000,
+      "tag": "0040_oracle_findings",
+      "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "6",
+      "when": 1783717000000,
+      "tag": "0041_fleet_log",
+      "breakpoints": true
+    }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -168,41 +168,6 @@ export const documentAccess = sqliteTable('document_access', {
   index('idx_access_created').on(table.createdAt),
   index('idx_access_doc').on(table.documentId),
 ]);
-export const forumThreads = sqliteTable('forum_threads', {
-  id: integer('id').primaryKey({ autoIncrement: true }),
-  title: text('title').notNull(),
-  tenantId: text('tenant_id').default('default').notNull(),
-  createdBy: text('created_by').default('human'),
-  status: text('status').default('active'),
-  issueUrl: text('issue_url'),
-  issueNumber: integer('issue_number'),
-  project: text('project'),
-  createdAt: integer('created_at').notNull(),
-  updatedAt: integer('updated_at').notNull(),
-  syncedAt: integer('synced_at'),
-}, (table) => [
-  index('idx_thread_status').on(table.status),
-  index('idx_thread_project').on(table.project),
-  index('idx_thread_tenant').on(table.tenantId),
-  index('idx_thread_created').on(table.createdAt),
-  index('idx_thread_tenant_status_updated').on(table.tenantId, table.status, table.updatedAt),
-]);
-export const forumMessages = sqliteTable('forum_messages', {
-  id: integer('id').primaryKey({ autoIncrement: true }),
-  threadId: integer('thread_id').notNull().references(() => forumThreads.id),
-  role: text('role').notNull(),
-  content: text('content').notNull(),
-  author: text('author'),
-  principlesFound: integer('principles_found'),
-  patternsFound: integer('patterns_found'),
-  searchQuery: text('search_query'),
-  commentId: integer('comment_id'),
-  createdAt: integer('created_at').notNull(),
-}, (table) => [
-  index('idx_message_thread').on(table.threadId),
-  index('idx_message_role').on(table.role),
-  index('idx_message_created').on(table.createdAt),
-]);
 export const traceLog = sqliteTable('trace_log', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   traceId: text('trace_id').unique().notNull(),
@@ -245,6 +210,8 @@ export const traceLog = sqliteTable('trace_log', {
   index('idx_trace_created').on(table.createdAt),
 ]);
 export { exportJobs } from './export-schema.ts';
+export { forumMessages, forumThreads } from './forum-schema.ts';
+export { fleetIngestCursor, fleetMessages } from './fleet-log-schema.ts';
 export { oracleFindingEvidence, oracleFindings } from './oracle-dig-schema.ts';
 export { activityLog, menuItems, schedule, settings, supersedeLog } from './logistics-schema.ts';
 export { assertSqliteIdentifier, oracleVectorDocuments, sqliteVecEmbeddingsTable, sqliteVecMetadataTable, vectorDocumentsTable } from './vector-schema.ts';

--- a/src/fleet-log/vault-ingest.ts
+++ b/src/fleet-log/vault-ingest.ts
@@ -1,0 +1,195 @@
+import fs from 'fs';
+import path from 'path';
+import { eq } from 'drizzle-orm';
+import { createDatabase, type DatabaseConnection } from '../db/index.ts';
+import { fleetIngestCursor, fleetMessages } from '../db/schema.ts';
+
+const SOURCE = 'arra-oracle-v3';
+const CHANNEL = 'vault';
+const CURSOR_ID = `vault:${SOURCE}`;
+const THREAD_WINDOW_MS = 30 * 60 * 1000;
+
+type Meta = { from: string; to: string; timestamp: string; read?: string };
+
+type FileEntry = { path: string; relativePath: string; mtimeMs: number };
+
+export type VaultIngestSummary = {
+  source: string;
+  cursorId: string;
+  repoRoot: string;
+  scanned: number;
+  skipped: number;
+  processed: number;
+  rowCount: number;
+  lastCursor: string;
+};
+
+export type ParsedVaultMessage = {
+  meta: Meta;
+  text: string;
+  raw: string;
+  ts: number;
+};
+
+export function parseVaultMessage(raw: string, fileName = ''): ParsedVaultMessage {
+  const frontmatter = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (frontmatter) {
+    const meta = parseFrontmatter(frontmatter[1]);
+    return { meta, text: raw.slice(frontmatter[0].length), raw, ts: parseTimestamp(meta.timestamp) };
+  }
+  const meta = parseLegacyHeader(raw, fileName);
+  return { meta, text: raw, raw, ts: parseTimestamp(meta.timestamp) };
+}
+
+function parseFrontmatter(block: string): Meta {
+  const fields = new Map<string, string>();
+  for (const line of block.split(/\r?\n/)) {
+    const idx = line.indexOf(':');
+    if (idx < 0) continue;
+    fields.set(line.slice(0, idx).trim(), line.slice(idx + 1).trim());
+  }
+  const from = fields.get('from');
+  const to = fields.get('to');
+  const timestamp = fields.get('timestamp');
+  if (!from || !to || !timestamp) throw new Error('Missing vault frontmatter from/to/timestamp');
+  return { from, to, timestamp, read: fields.get('read') };
+}
+
+function parseLegacyHeader(raw: string, fileName: string): Meta {
+  const head = raw.slice(0, 600);
+  const from = head.match(/\*\*From\*\*:\s*([^·\n]+)/i)?.[1].trim();
+  const to = head.match(/\*\*To\*\*:\s*([^·\n]+)/i)?.[1].trim();
+  const date = head.match(/(20\d{2}-\d{2}-\d{2})(?:T[\d:.]+Z)?/)?.[0]
+    ?? fileName.match(/20\d{2}-\d{2}-\d{2}/)?.[0];
+  if (!from || !to || !date) throw new Error('Missing vault legacy from/to/date');
+  const timestamp = date.includes('T') ? date : `${date}T00:00:00.000Z`;
+  return { from, to, timestamp, read: 'false' };
+}
+
+function parseTimestamp(value: string): number {
+  const ts = Date.parse(value);
+  if (!Number.isFinite(ts)) throw new Error(`Invalid vault timestamp: ${value}`);
+  return ts;
+}
+
+// Approximate only: vault messages have no real thread id, so the key groups
+// sorted participants by 30-minute windows; it is not source-of-truth threading.
+export function vaultThreadKey(fromId: string, toId: string, ts: number): string {
+  const participants = [fromId, toId].sort().join('|');
+  const bucket = Math.floor(ts / THREAD_WINDOW_MS) * THREAD_WINDOW_MS;
+  return `${CHANNEL}:${participants}:${bucket}`;
+}
+
+export function listVaultInbox(repoRoot: string): FileEntry[] {
+  const inbox = path.join(repoRoot, 'ψ', 'inbox');
+  if (!fs.existsSync(inbox)) throw new Error(`Vault inbox not found: ${inbox}`);
+  return fs.readdirSync(inbox, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+    .map((entry) => {
+      const fullPath = path.join(inbox, entry.name);
+      const relativePath = path.relative(repoRoot, fullPath).split(path.sep).join('/');
+      return { path: fullPath, relativePath, mtimeMs: fs.statSync(fullPath).mtimeMs };
+    })
+    .sort((a, b) => a.mtimeMs - b.mtimeMs || a.relativePath.localeCompare(b.relativePath));
+}
+
+export function ingestVaultInbox(options: {
+  repoRoot?: string;
+  dbPath?: string;
+  connection?: DatabaseConnection;
+  now?: () => number;
+} = {}): VaultIngestSummary {
+  const repoRoot = path.resolve(options.repoRoot ?? process.cwd());
+  const now = options.now ?? Date.now;
+  const owned = options.connection ? undefined : createDatabase(options.dbPath);
+  const connection = options.connection ?? owned!;
+  const startedAt = now();
+
+  try {
+    markCursor(connection, { status: 'running', lastRunAt: startedAt, error: null });
+    const cursor = connection.db.select().from(fleetIngestCursor)
+      .where(eq(fleetIngestCursor.id, CURSOR_ID)).get();
+    const parsedCursor = Number(cursor?.lastCursor ?? 0);
+    const lastSeen = Number.isFinite(parsedCursor) ? parsedCursor : 0;
+    const files = listVaultInbox(repoRoot);
+    const pending = files.filter((file) => !Number.isFinite(lastSeen) || file.mtimeMs > lastSeen);
+
+    for (const file of pending) ingestFile(connection, repoRoot, file, now());
+
+    const latest = pending.reduce((max, file) => Math.max(max, file.mtimeMs), lastSeen);
+    markCursor(connection, { status: 'idle', lastRunAt: now(), lastCursor: String(latest), error: null });
+    return {
+      source: SOURCE,
+      cursorId: CURSOR_ID,
+      repoRoot,
+      scanned: files.length,
+      skipped: files.length - pending.length,
+      processed: pending.length,
+      rowCount: countVaultRows(connection),
+      lastCursor: String(latest),
+    };
+  } catch (error) {
+    markCursor(connection, { status: 'error', lastRunAt: now(), error: errorMessage(error) });
+    throw error;
+  } finally {
+    owned?.storage.close();
+  }
+}
+
+function ingestFile(connection: DatabaseConnection, repoRoot: string, file: FileEntry, ingestedAt: number): void {
+  const raw = fs.readFileSync(file.path, 'utf8');
+  const parsed = parseVaultMessage(raw, path.basename(file.path));
+  connection.db.insert(fleetMessages).values({
+    id: `${CHANNEL}:${SOURCE}:${file.relativePath}`,
+    tenantId: 'default',
+    channel: CHANNEL,
+    source: SOURCE,
+    direction: 'inbound',
+    fromId: parsed.meta.from,
+    toId: parsed.meta.to,
+    threadKey: vaultThreadKey(parsed.meta.from, parsed.meta.to, parsed.ts),
+    text: parsed.text,
+    raw: parsed.raw,
+    rawPath: path.relative(repoRoot, file.path).split(path.sep).join('/'),
+    ts: parsed.ts,
+    ingestedAt,
+  }).onConflictDoUpdate({
+    target: fleetMessages.id,
+    set: {
+      tenantId: 'default',
+      channel: CHANNEL,
+      source: SOURCE,
+      direction: 'inbound',
+      fromId: parsed.meta.from,
+      toId: parsed.meta.to,
+      threadKey: vaultThreadKey(parsed.meta.from, parsed.meta.to, parsed.ts),
+      text: parsed.text,
+      raw: parsed.raw,
+      rawPath: file.relativePath,
+      ts: parsed.ts,
+      ingestedAt,
+    },
+  }).run();
+}
+
+function markCursor(connection: DatabaseConnection, values: {
+  status: string;
+  lastRunAt: number;
+  lastCursor?: string;
+  error: string | null;
+}): void {
+  connection.db.insert(fleetIngestCursor).values({ id: CURSOR_ID, ...values })
+    .onConflictDoUpdate({ target: fleetIngestCursor.id, set: values })
+    .run();
+}
+
+function countVaultRows(connection: DatabaseConnection): number {
+  const row = connection.sqlite.query<{ count: number }, []>(
+    "SELECT COUNT(*) AS count FROM fleet_messages WHERE channel = 'vault' AND source = 'arra-oracle-v3'",
+  ).get();
+  return row?.count ?? 0;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/tests/db/fleet-vault-ingest.test.ts
+++ b/tests/db/fleet-vault-ingest.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, expect, test } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { eq } from 'drizzle-orm';
+import { createDatabase, type DatabaseConnection } from '../../src/db/index.ts';
+import { fleetIngestCursor, fleetMessages } from '../../src/db/schema.ts';
+import { ingestVaultInbox, parseVaultMessage, vaultThreadKey } from '../../src/fleet-log/vault-ingest.ts';
+
+let tempDir = '';
+let connection: DatabaseConnection | undefined;
+
+afterEach(() => {
+  connection?.storage.close();
+  connection = undefined;
+  if (tempDir && fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true });
+  tempDir = '';
+});
+
+function freshHarness() {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-fleet-vault-'));
+  const repoRoot = path.join(tempDir, 'repo');
+  fs.mkdirSync(path.join(repoRoot, 'ψ', 'inbox'), { recursive: true });
+  connection = createDatabase(path.join(tempDir, 'oracle.db'));
+  return { repoRoot, connection };
+}
+
+function writeInbox(repoRoot: string, name: string, body: string, mtime: Date): void {
+  const file = path.join(repoRoot, 'ψ', 'inbox', name);
+  fs.writeFileSync(file, body);
+  fs.utimesSync(file, mtime, mtime);
+}
+
+test('vault inbox ingestion upserts frontmatter messages and cursor state', () => {
+  const { repoRoot, connection } = freshHarness();
+  const first = `---\nfrom: m5:digger\nto: digger\ntimestamp: 2026-07-01T00:05:00.000Z\nread: false\n---\n[m5:digger] first\n`;
+  const second = `---\nfrom: digger\nto: m5:digger\ntimestamp: 2026-07-01T00:10:00.000Z\nread: true\n---\nreply\n`;
+  writeInbox(repoRoot, '2026-07-01_00-05_m5-digger_first.md', first, new Date('2026-07-01T00:06:00Z'));
+  writeInbox(repoRoot, '2026-07-01_00-10_digger_reply.md', second, new Date('2026-07-01T00:11:00Z'));
+
+  const summary = ingestVaultInbox({ repoRoot, connection, now: () => 111 });
+  expect(summary).toMatchObject({ scanned: 2, skipped: 0, processed: 2, rowCount: 2 });
+
+  const rows = connection.db.select().from(fleetMessages).all();
+  expect(rows).toHaveLength(2);
+  expect(rows[0]).toMatchObject({
+    channel: 'vault',
+    source: 'arra-oracle-v3',
+    direction: 'inbound',
+    fromId: 'm5:digger',
+    toId: 'digger',
+    rawPath: 'ψ/inbox/2026-07-01_00-05_m5-digger_first.md',
+    text: '[m5:digger] first\n',
+  });
+  expect(rows[0].threadKey).toBe(rows[1].threadKey);
+
+  const cursor = connection.db.select().from(fleetIngestCursor)
+    .where(eq(fleetIngestCursor.id, 'vault:arra-oracle-v3')).get();
+  expect(cursor?.status).toBe('idle');
+  expect(Number(cursor?.lastCursor)).toBeGreaterThan(0);
+
+  const rerun = ingestVaultInbox({ repoRoot, connection, now: () => 222 });
+  expect(rerun).toMatchObject({ scanned: 2, skipped: 2, processed: 0, rowCount: 2 });
+});
+
+test('thread keys are participant-sorted 30-minute buckets', () => {
+  const ts = Date.parse('2026-07-01T00:29:00.000Z');
+  expect(vaultThreadKey('z', 'a', ts)).toBe(`vault:a|z:${Date.parse('2026-07-01T00:00:00.000Z')}`);
+});
+
+test('legacy inbox notes without YAML frontmatter still parse from header', () => {
+  const raw = '# Fix Guide\n\n**To**: maw-rs · **From**: arra-oracle-v3 · 2026-07-05\n\nbody';
+  const parsed = parseVaultMessage(raw, '2026-07-05_maw-rs-guide.md');
+  expect(parsed.meta).toMatchObject({ from: 'arra-oracle-v3', to: 'maw-rs' });
+  expect(parsed.ts).toBe(Date.parse('2026-07-05T00:00:00.000Z'));
+});


### PR DESCRIPTION
Lands **#2764**, which has been `CONFLICTING` since 2026-07-10. Item 9 of #2849.

## The conflicts were not about the change

```
Merge conflict in src/db/migrations/meta/_journal.json
Merge conflict in src/db/schema.ts
```

Both mechanical. `0040` was taken on `alpha` by `0040_oracle_findings.sql`, so the migration becomes **`0041_fleet_log`** and its journal entry is appended after it. The schema conflict is a single re-export line.

The change itself — 11 files, `fleet_messages` + `fleet_ingest_cursor`, an ingest module, a CLI script and a test — applies cleanly.

## Verified, not assumed

Applied the renumbered migration to a fresh database:

```
tables created: fleet_ingest_cursor, fleet_messages
```

Matching exactly the table names `fleet-log-schema.ts` declares. Renumbering is safe because the migration has never been applied anywhere — the PR was never merged.

## Why the forum tables moved

`src/db/schema.ts` sits at **exactly 250 lines**, so adding one re-export breaks the limit. That is why #2764 wrote:

```ts
export { exportJobs } from './export-schema.ts'; export { fleetIngestCursor, fleetMessages } from './fleet-log-schema.ts';
```

Two statements on one line. That satisfies the counter without addressing what it counts, and the ratchet's own comment says so: *"If this fails: split the file."*

So forum threads/messages move to `src/db/forum-schema.ts` — one cohesive concern, following the pattern `export-schema`, `oracle-dig-schema`, `logistics-schema` and `vector-schema` already set. `schema.ts` is now **217**, with room for the next table without anyone having to be clever.

## Gates

```
bunx tsc --noEmit           exit 0
tests/db/                   8 pass / 0 fail   (includes #2764's own test)
src/db/                     8 pass / 0 fail
tests/http/forum/           5 pass / 0 fail
tests/forum/                7 pass / 0 fail
tests/build/                14 pass / 0 fail
```

## On the branch

Opened as a new branch rather than rewriting #2764's, so that PR keeps its history and review thread — the same courtesy extended to the contributor PRs in #2849, and the reason force-pushing was never on the table.

Refs #2764, #2849

🤖 Generated with [Claude Code](https://claude.com/claude-code)