### PR TITLE
fix(mcp): the tool catalogue now says which tools are actually served

### DIFF
--- a/src/routes/mcp/tools.ts
+++ b/src/routes/mcp/tools.ts
@@ -4,18 +4,35 @@ import type { UnifiedRuntimeRef } from '../../plugins/runtime-routes.ts';
 import { currentTenantId } from '../../middleware/tenant.ts';
 import { mcpToolByName, toMcpToolDefinition, type RuntimeMcpToolManifest } from '../../tools/mcp-manifest.ts';
 import { mcpRestMap, type McpRestMapEntry } from '../../tools/mcp-rest-map.ts';
+import { getEnabledToolNames, loadToolGroupConfig } from '../../config/tool-groups-core.ts';
 
 type PluginTool = UnifiedRuntime['mcpTools'][number];
 type PluginToolSource = PluginTool[] | (() => PluginTool[]);
 type McpRouteOptions = PluginToolSource | {
   pluginTools?: PluginToolSource;
   runtimeRef?: UnifiedRuntimeRef<Pick<UnifiedRuntime, 'mcpTools'>>;
+  /**
+   * Which tools the running config serves. Injectable because `loadToolGroupConfig()`
+   * resolves `ORACLE_DATA_DIR` as a module constant read at import time, so a test cannot
+   * redirect it with an env var after the fact — the same trap #2837 fixed by threading
+   * `dataDir` through explicitly.
+   */
+  servedToolNames?: () => Iterable<string>;
 };
 
 type PublicTool = ReturnType<typeof toMcpToolDefinition> & {
   group?: string;
   readOnly?: boolean;
+  /**
+   * The tool's own manifest default — NOT whether it is currently served.
+   *
+   * These are easy to confuse, and the difference was large: with the tool-groups config on
+   * this machine, 32 tools were listed here while an MCP client was offered 2. Read `served`
+   * for the live answer.
+   */
   enabledByDefault?: boolean;
+  /** Whether the running tool-groups config actually serves this tool right now. */
+  served?: boolean;
   remoteable?: boolean;
   rest?: { method: string; path: string };
   localOnlyReason?: string;
@@ -73,9 +90,27 @@ function currentPluginTools(options: McpRouteOptions): PluginTool[] {
 export function createMcpRoutes(options: McpRouteOptions = []) {
   return new Elysia({ prefix: '/api' }).get('/mcp/tools', () => {
     const coreTools = mcpRestMap.map(coreTool).filter((tool): tool is PublicTool => !!tool);
-    const tools = [...coreTools, ...currentPluginTools(options).filter(isValidPluginTool).map(pluginTool)];
+    const listed = [...coreTools, ...currentPluginTools(options).filter(isValidPluginTool).map(pluginTool)];
+
+    // This endpoint is a catalogue: it lists every tool that EXISTS, which is what the
+    // /tools/config surface needs in order to offer a disabled tool for enabling. It said
+    // nothing about which are actually served, so a reader could not tell the catalogue from
+    // the offer — 32 listed here against 2 reachable over MCP, with no field expressing the
+    // gap. Same declared-but-not-true shape as #2822 and #2870.
+    //
+    // Filtering the list would break /tools/config. Marking each entry does not.
+    const resolveServed = !Array.isArray(options) && typeof options === 'object' && options.servedToolNames
+      ? options.servedToolNames
+      : () => getEnabledToolNames(loadToolGroupConfig());
+    const servedNames = new Set(resolveServed());
+    const tools = listed.map((tool) => ({ ...tool, served: servedNames.has(tool.name) }));
     const tenantId = currentTenantId();
-    return { tools, total: tools.length, ...(tenantId ? { tenant: { id: tenantId, scope: 'tenant_id' } } : {}) };
+    return {
+      tools,
+      total: tools.length,
+      served: tools.filter((tool) => tool.served).length,
+      ...(tenantId ? { tenant: { id: tenantId, scope: 'tenant_id' } } : {}),
+    };
   }, {
     detail: {
       tags: ['mcp'],

--- a/tests/http/mcp/tools-served-flag.test.ts
+++ b/tests/http/mcp/tools-served-flag.test.ts
@@ -1,0 +1,107 @@
+/**
+ * `GET /api/v1/mcp/tools` is a catalogue, and it must say which entries are actually served.
+ *
+ * It listed every core tool from the static `mcpRestMap` and never consulted the tool-groups
+ * config. Measured on a real machine: **32 tools listed, 2 reachable over MCP** — the config
+ * had `enabled_tools: ["oracle_search", "oracle_learn"]`. Nothing in the payload expressed
+ * that gap, and the field that looks like it should (`enabledByDefault`) is the tool's own
+ * manifest default, not the live answer.
+ *
+ * Filtering the list would be the wrong fix: `/tools/config` needs disabled tools present in
+ * order to offer them for enabling. So each entry is marked instead, and the response carries
+ * a `served` count beside `total`.
+ *
+ * Same declared-but-not-true family as #2822 (levers that turn nothing) and #2870 (the root
+ * endpoint advertising a 404).
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+import { createMcpRoutes } from '../../../src/routes/mcp/tools.ts';
+import { getEnabledToolNames, loadToolGroupConfig } from '../../../src/config/tool-groups-core.ts';
+
+type ToolsPayload = {
+  tools: Array<{ name: string; served?: boolean; enabledByDefault?: boolean }>;
+  total: number;
+  served: number;
+};
+
+/**
+ * The served set is injected rather than written to a temp config directory. An earlier draft
+ * did the latter and silently read the DEVELOPER'S OWN config instead: `ORACLE_DATA_DIR` is a
+ * module constant resolved at import time, so setting the env var inside a test changes
+ * nothing. #2837 is the same lesson.
+ */
+let served: string[] = [];
+
+afterEach(() => {
+  served = [];
+});
+
+function withServed(names: string[]): void {
+  served = names;
+}
+
+async function fetchTools(): Promise<ToolsPayload> {
+  const app = createMcpRoutes({ pluginTools: [], servedToolNames: () => served });
+  const res = await app.handle(new Request('http://local/api/mcp/tools'));
+  const body = (await res.json()) as ToolsPayload | { data: ToolsPayload };
+  return 'data' in body && body.data ? body.data : (body as ToolsPayload);
+}
+
+describe('the tool catalogue reports what is actually served', () => {
+  test('every entry carries a served flag', async () => {
+    withServed(['oracle_search', 'oracle_learn']);
+    const payload = await fetchTools();
+
+    expect(payload.tools.length).toBeGreaterThan(0);
+    expect(payload.tools.every((tool) => typeof tool.served === 'boolean')).toBe(true);
+  });
+
+  test('a narrow allow-list is reflected — this was 32 listed against 2 served', async () => {
+    withServed(['oracle_search', 'oracle_learn']);
+    const payload = await fetchTools();
+
+    const served = payload.tools.filter((tool) => tool.served).map((tool) => tool.name);
+    expect(served.sort()).toEqual(['oracle_learn', 'oracle_search']);
+    expect(payload.served).toBe(2);
+  });
+
+  test('the catalogue still lists disabled tools — /tools/config needs them to offer', async () => {
+    withServed(['oracle_search']);
+    const payload = await fetchTools();
+
+    // The fix must not be "filter the list".
+    expect(payload.total).toBeGreaterThan(payload.served);
+    expect(payload.tools.some((tool) => tool.served === false)).toBe(true);
+  });
+
+  test('served and total disagree when the config is narrow, and that is visible', async () => {
+    withServed(['oracle_search']);
+    const payload = await fetchTools();
+
+    expect(payload.served).toBe(1);
+    expect(payload.total).toBe(payload.tools.length);
+    expect(payload.served).toBeLessThan(payload.total);
+  });
+
+  test('a permissive config serves more than a narrow one', async () => {
+    withServed(['oracle_search']);
+    const narrow = (await fetchTools()).served;
+
+    withServed(getEnabledToolNames(loadToolGroupConfig(undefined, '/nonexistent-dir')));
+    const wide = (await fetchTools()).served;
+
+    expect(wide).toBeGreaterThan(narrow);
+  });
+
+  test('served is not merely a copy of enabledByDefault', async () => {
+    // The distinction that made the old payload misleading: a tool can be enabled by default
+    // in its manifest and still not be served by the running config.
+    withServed(['oracle_search']);
+    const payload = await fetchTools();
+
+    const defaultOnButNotServed = payload.tools.filter(
+      (tool) => tool.enabledByDefault === true && tool.served === false,
+    );
+    expect(defaultOnButNotServed.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
`GET /api/v1/mcp/tools` listed every core tool from the static `mcpRestMap` and never consulted the tool-groups config.

Measured on this machine:

```
advertised by /api/v1/mcp/tools : 32
actually served over MCP        :  2      (config: enabled_tools = [oracle_search, oracle_learn])
```

Nothing in the payload expressed that gap. The field that looks like it should — `enabledByDefault` — is the tool's **manifest default**, not the live answer, which makes it worse than silence: a reader who checks it gets a confident wrong answer.

Same declared-but-not-true family as #2822 (the tool-config surface's dead levers) and #2870 (the root endpoint advertising a 404). Slightly pointed, given #2826 fixed the levers and left the display saying whatever it liked.

## Marked, not filtered

Filtering would have been the wrong fix: `/tools/config` needs disabled tools **present** in order to offer them for enabling. So each entry gains `served`, and the response carries a `served` count beside `total`. Both readers get what they need, and one test asserts the catalogue still contains unserved entries so nobody "simplifies" it into a filter later.

Another test asserts a tool exists that is `enabledByDefault: true` **and** `served: false` — so the two fields cannot quietly become synonyms.

## The injectable seam, and why it exists

`servedToolNames` is injectable because `loadToolGroupConfig()` resolves `ORACLE_DATA_DIR` as a **module constant read at import time**. Setting the env var inside a test changes nothing.

My first draft did exactly that — wrote a temp `config.json`, pointed `ORACLE_DATA_DIR` at it, and silently read **the developer's own config** instead. Two tests failed for the right reason and I only noticed the cause because bun logged:

```
[ToolGroups] Using /Users/nat/.arra-oracle-v2/config.json
```

#2837 fixed the identical trap by threading `dataDir` through explicitly. Same lesson, different door.

## Verified

Live server, default config:

```
total listed : 32
served       : 30
sample flags : [('____IMPORTANT', True), ('oracle_recap', True), ('oracle_ask', True), ('oracle_search', True)]
```

```
bunx tsc --noEmit             exit 0
tests/http/mcp/               14 pass / 0 fail
tests/build/                  14 pass / 0 fail
```

**Mutation-checked**: dropping the `served` flag turns all 6 new tests red.

Refs #2822, #2870

🤖 Generated with [Claude Code](https://claude.com/claude-code)