### PR TITLE
fix(search): acronym expansions were merged into one entity and lost their keys

### DIFF
--- a/src/search/entity-ranking.ts
+++ b/src/search/entity-ranking.ts
@@ -4,6 +4,7 @@ import { drizzle } from 'drizzle-orm/bun-sqlite';
 import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 import * as schema from '../db/schema.ts';
 import { extractEntities } from '../vector/entities.ts';
+import { expansionsForText } from './acronyms.ts';
 
 const ENTITY_BOOST_PER_MATCH = 0.08;
 const ENTITY_BOOST_CAP = 0.24;
@@ -154,6 +155,22 @@ export function entitySignalsForCandidates(
 
 function entityKeysForQuery(query: string): string[] {
   const keys = new Set(extractEntities(query).map(entityKey).filter(Boolean));
+
+  // Acronym expansions are added as known phrases rather than recovered from the text.
+  //
+  // `augmentQueryWithAcronyms` appends expansions bare — `"…API and db do Application
+  // Programming Interface Database"` — so `extractEntities` merges the adjacent capitalised
+  // runs into one entity ("Application Programming Interface Database") whose key matches
+  // nothing. Both real keys were lost, silently, and entity-link boosting simply did not
+  // happen for any query containing two acronyms (#2876).
+  //
+  // The word/bigram loop below cannot recover them either: those phrases are trigrams and it
+  // only builds adjacent pairs.
+  //
+  // Inserted before the loop so these survive the MAX_ENTITY_QUERY_KEYS cap — a Set keeps
+  // insertion order, and these are the highest-signal keys in the query.
+  for (const expansion of expansionsForText(query)) keys.add(entityKey(expansion));
+
   const words = query.normalize('NFKC').match(/[\p{L}\p{N}][\p{L}\p{N}._-]{2,}/gu)
     ?.map((word) => word.toLowerCase()).filter((word) => !QUERY_STOPWORDS.has(word)) ?? [];
   for (const word of words) keys.add(entityKey(word));

--- a/tests/http/search/acronym-entity-keys.test.ts
+++ b/tests/http/search/acronym-entity-keys.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Acronym expansions must survive into entity-link ranking (#2876).
+ *
+ * `augmentQueryWithAcronyms` appends expansions as bare text, so two of them end up adjacent
+ * and `extractEntities` merges the capitalised runs into a single entity:
+ *
+ * ```
+ * "what does the API and db do"
+ *   → "… Application Programming Interface Database"
+ *   → entities: ["API", "Application Programming Interface Database"]
+ * ```
+ *
+ * Neither `application-programming-interface` nor `database` survived as a key, so
+ * `entitySignalsForCandidates` found no link and the boost was **silently not applied** —
+ * results still returned, ranked by FTS alone, looking entirely normal. Same failure shape as
+ * #2806 and #2863: a stage does nothing while the pipeline reports success.
+ *
+ * The fix adds each expansion as a known phrase rather than trying to recover it from the
+ * concatenated text, which leaves the FTS query string untouched — it feeds retrieval, and
+ * changing its shape would change results for every query.
+ *
+ * These assertions are about *what the ranker looks for*, which is the thing that broke. They
+ * do not assert an ordering: #2874 showed that pinning an exact ranking order is itself a
+ * source of flakiness.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createDatabase } from '../../../src/db/create.ts';
+import { oracleDocuments, oracleEntityLinks, tenants } from '../../../src/db/schema.ts';
+import { entityKey, entitySignalsForCandidates } from '../../../src/search/entity-ranking.ts';
+import { augmentQueryWithAcronyms } from '../../../src/search/acronyms.ts';
+
+const API_KEY = entityKey('Application Programming Interface');
+const DB_KEY = entityKey('Database');
+
+describe('acronym expansions reach entity-link ranking', () => {
+  test('a two-acronym query expands to both full forms', () => {
+    const augmented = augmentQueryWithAcronyms('what does the API and db do');
+    expect(augmented).toContain('Application Programming Interface');
+    expect(augmented).toContain('Database');
+  });
+
+  test('the two expansions are distinct keys, not one merged phrase', () => {
+    // "Application Programming Interface Database" was the merged entity that matched nothing.
+    expect(API_KEY).not.toBe(DB_KEY);
+    expect(entityKey('Application Programming Interface Database')).not.toBe(API_KEY);
+    expect(entityKey('Application Programming Interface Database')).not.toBe(DB_KEY);
+  });
+
+  test('a single acronym query still yields its expansion key', () => {
+    const augmented = augmentQueryWithAcronyms('API');
+    expect(augmented).toContain('Application Programming Interface');
+  });
+
+});
+
+describe('the expansion keys actually find an entity link', () => {
+  /**
+   * A real database rather than a stubbed drizzle builder.
+   *
+   * The first version of this test stubbed `db.select().from().where()` and tried to read the
+   * key list out of drizzle's internal query chunks. It captured `["(", ")"]` — the internal
+   * shape is not what it looked like from outside, and a test that reverse-engineers a
+   * library's internals fails for reasons unrelated to the code it guards.
+   *
+   * Seeding a row and asking whether the signal is found tests the property directly: does a
+   * query containing an acronym locate a document linked to that acronym's *expansion*?
+   */
+  const tmp = mkdtempSync(join(tmpdir(), 'acronym-entity-'));
+  const { db, sqlite } = createDatabase(join(tmp, 'oracle.db'));
+
+  const DOC = 'doc-api-linked';
+  const now = Date.now();
+
+  beforeAll(() => {
+    db.insert(tenants).values({ id: 'default', status: 'active', createdAt: now, updatedAt: now }).onConflictDoNothing().run();
+    db.insert(oracleDocuments).values({
+      id: DOC, tenantId: 'default', type: 'learning', sourceFile: `notes/${DOC}.md`,
+      concepts: '[]', createdAt: now, updatedAt: now, indexedAt: now,
+    }).run();
+    for (const phrase of ['Application Programming Interface', 'Database']) {
+      db.insert(oracleEntityLinks).values({
+        id: `${DOC}-${entityKey(phrase)}`, tenantId: 'default', documentId: DOC,
+        entity: phrase, entityKey: entityKey(phrase), weight: 1, createdAt: now, updatedAt: now,
+      }).run();
+    }
+  });
+
+  afterAll(() => {
+    sqlite.close();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test('a two-acronym query finds the document linked to both expansions', () => {
+    const signals = entitySignalsForCandidates(db as never, [DOC], 'what does the API and db do');
+    const matches = signals.get(DOC)?.matches ?? [];
+
+    // Before the fix the merged phrase produced no key, so this map was empty.
+    expect(matches).toContain('Application Programming Interface');
+    expect(matches).toContain('Database');
+  });
+
+  test('a single-acronym query finds its own expansion', () => {
+    const matches = entitySignalsForCandidates(db as never, [DOC], 'tell me about the API').get(DOC)?.matches ?? [];
+    expect(matches).toContain('Application Programming Interface');
+  });
+
+  test('an unrelated query finds nothing — the match is not unconditional', () => {
+    expect(entitySignalsForCandidates(db as never, [DOC], 'unrelated words entirely').size).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes the mechanism behind #2876, found by root-causing the intermittent #2874.

## The defect, on an ordinary query

```
"what does the API and db do"
→ augmented: "… Application Programming Interface Database"
→ entities:  ["API", "Application Programming Interface Database"]
```

`augmentQueryWithAcronyms` appends expansions as bare text, so two of them land adjacent and `extractEntities` merges the capitalised runs into **one entity that is not a thing**. Neither `application-programming-interface` nor `database` survives as a key, `entitySignalsForCandidates` finds no link, and **entity-link boosting silently does not happen**.

Results still return, ranked by FTS alone, looking entirely normal. That is the third instance of this exact shape tonight — #2806 (daemon storing `embed('')`) and #2863 (indexer queueing nothing) were the others: *a stage does nothing while the pipeline reports success.*

Even a single acronym merges with its own expansion: `"API"` → `["API Application Programming Interface"]`.

## The fix, and what it deliberately does not touch

Add each expansion as a **known phrase** rather than hoping to recover it from concatenated text:

```ts
for (const expansion of expansionsForText(query)) keys.add(entityKey(expansion));
```

`expansionsForText` was already exported and already returns them cleanly. Inserted before the word/bigram loop so they survive `MAX_ENTITY_QUERY_KEYS` — and that loop could never have recovered them anyway, since both are **trigrams** and it builds adjacent pairs only.

**`augmentQueryWithAcronyms` is left alone.** Its output also feeds FTS, so reshaping it changes retrieval for every query — not something to do at 3am on a hunch.

Worth recording for whoever takes #2876: the codebase *already* separates expansions with `'; '` in `enrichTextWithAcronyms` (the indexing path) and not in the query path. That asymmetry is the underlying defect; this PR fixes the consequence without betting on the cure.

## How it was found

#2874 was an intermittent CI failure. Two hypotheses died first, and killing them is what located this:

- **"rounding collapses the tie"** — no. One match contributes `0.0592` to askRank against a `0.0005` threshold: **118× too large**. So a flip meant the boost was never applied.
- **"MAX_ENTITY_QUERY_KEYS truncates it"** — no. Only 9 keys generated, well under the cap of 16.

The test's `Math.random().toString(16)` stamp sometimes contains `db`, triggering a second expansion and the merge. **11/200 runs — 5.5%**, matching the observed CI rate.

## Verification

The first version of this test stubbed drizzle's query builder to capture the key list. It captured `["(", ")"]` — the internals are not what they look like from outside. Replaced with a **real database**: seed a document linked to both expansions, ask whether the query finds it.

```
bunx tsc --noEmit                                   exit 0
src/ tests/build/ tests/http/{search,ask,knowledge}/
tests/mcp/ tests/vector/ tests/docs/                failing: NONE
tests/http/ask/contract.test.ts  ×5                 0 fail each
```

**Mutation-checked**: removing the expansion line turns 2 of 6 red.

Refs #2876, #2874

🤖 Generated with [Claude Code](https://claude.com/claude-code)