### PR TITLE
fix(search): my own #2877 fix was a no-op in production — and pointer-index had the same bug

### DIFF
--- a/src/search/acronyms.ts
+++ b/src/search/acronyms.ts
@@ -26,6 +26,28 @@ export function expansionsForText(text: string): string[] {
   return uniqueMissing(text, additions);
 }
 
+/**
+ * Every full form applicable to `text`, whether or not it already appears in it.
+ *
+ * `expansionsForText` returns only what is **missing**, which is right for augmenting a query
+ * — you do not append what is already there. It is wrong for anything that consumes an
+ * already-augmented string: ranking receives the augmented query, so `expansionsForText`
+ * returns `[]` and a caller relying on it silently gets nothing.
+ *
+ * That is not hypothetical. #2877 added `expansionsForText` to entity-key derivation and was a
+ * no-op in production for exactly this reason — its test passed the raw query while
+ * `rerankByEntityLinks` is called with the augmented one.
+ */
+export function expansionPhrasesForText(text: string): string[] {
+  const normalized = normalize(text);
+  const phrases: string[] = [];
+  for (const item of EXPANSIONS) {
+    if (!matchesExpansion(normalized, item)) continue;
+    for (const form of item.fullForms) if (!phrases.includes(form)) phrases.push(form);
+  }
+  return phrases;
+}
+
 export function augmentQueryWithAcronyms(query: string): string {
   const additions = expansionsForText(query);
   return additions.length ? `${query} ${additions.join(' ')}` : query;

--- a/src/search/entity-ranking.ts
+++ b/src/search/entity-ranking.ts
@@ -4,7 +4,7 @@ import { drizzle } from 'drizzle-orm/bun-sqlite';
 import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 import * as schema from '../db/schema.ts';
 import { extractEntities } from '../vector/entities.ts';
-import { expansionsForText } from './acronyms.ts';
+import { expansionPhrasesForText } from './acronyms.ts';
 
 const ENTITY_BOOST_PER_MATCH = 0.08;
 const ENTITY_BOOST_CAP = 0.24;
@@ -169,7 +169,7 @@ function entityKeysForQuery(query: string): string[] {
   //
   // Inserted before the loop so these survive the MAX_ENTITY_QUERY_KEYS cap — a Set keeps
   // insertion order, and these are the highest-signal keys in the query.
-  for (const expansion of expansionsForText(query)) keys.add(entityKey(expansion));
+  for (const expansion of expansionPhrasesForText(query)) keys.add(entityKey(expansion));
 
   const words = query.normalize('NFKC').match(/[\p{L}\p{N}][\p{L}\p{N}._-]{2,}/gu)
     ?.map((word) => word.toLowerCase()).filter((word) => !QUERY_STOPWORDS.has(word)) ?? [];

--- a/src/search/pointer-index.ts
+++ b/src/search/pointer-index.ts
@@ -4,6 +4,7 @@ import { drizzle, type BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
 import * as schema from '../db/schema.ts';
 import { extractEntities } from '../vector/entities.ts';
+import { expansionPhrasesForText } from './acronyms.ts';
 import { entityKey } from './entity-ranking.ts';
 
 type OracleDb = BunSQLiteDatabase<typeof schema>;
@@ -131,6 +132,15 @@ export function queryPointers(query: string): Pointer[] {
     ...words.map((word) => pointer('topic', word)),
     ...adjacent(words).map((phrase) => pointer('topic', phrase)),
     ...extractEntities(query).map((entity) => pointer('entity', entity)),
+    // Acronym expansions as known phrases, not recovered from the text.
+    //
+    // `augmentQueryWithAcronyms` appends expansions bare, so two of them end up adjacent and
+    // `extractEntities` merges them: "what does the API and db do" yields the entity pointer
+    // `application-programming-interface-database`, and the real
+    // `application-programming-interface` is absent. Single-word expansions like `database`
+    // survive only by accident — every word is also added as an entity pointer below — so the
+    // loss is silent and hits multi-word expansions only. Same defect as #2876, second signal.
+    ...expansionPhrasesForText(query).map((expansion) => pointer('entity', expansion)),
     ...words.map((word) => pointer('entity', word)),
     ...dateKeysFromText(query).map((key) => ({ kind: 'date' as const, key, label: key })),
   ]).slice(0, 24);

--- a/tests/http/search/acronym-entity-keys.test.ts
+++ b/tests/http/search/acronym-entity-keys.test.ts
@@ -22,6 +22,15 @@
  * These assertions are about *what the ranker looks for*, which is the thing that broke. They
  * do not assert an ordering: #2874 showed that pinning an exact ranking order is itself a
  * source of flakiness.
+ *
+ * ⚠️ Every query below goes through `augmentQueryWithAcronyms` FIRST, because that is what
+ * production passes: `ask/index.ts:80` and `tools/search/handler.ts:89` both call
+ * `rerankByEntityLinks` with the augmented string.
+ *
+ * The first version of this file passed the RAW query. It went green while the fix it guarded
+ * was a no-op in production — `expansionsForText` returns only what is *missing*, and nothing
+ * is missing from an already-augmented query, so it returned `[]`. A test that feeds different
+ * input than production proves nothing about production.
  */
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { mkdtempSync, rmSync } from 'node:fs';
@@ -31,6 +40,7 @@ import { createDatabase } from '../../../src/db/create.ts';
 import { oracleDocuments, oracleEntityLinks, tenants } from '../../../src/db/schema.ts';
 import { entityKey, entitySignalsForCandidates } from '../../../src/search/entity-ranking.ts';
 import { augmentQueryWithAcronyms } from '../../../src/search/acronyms.ts';
+import { queryPointers } from '../../../src/search/pointer-index.ts';
 
 const API_KEY = entityKey('Application Programming Interface');
 const DB_KEY = entityKey('Database');
@@ -94,7 +104,7 @@ describe('the expansion keys actually find an entity link', () => {
   });
 
   test('a two-acronym query finds the document linked to both expansions', () => {
-    const signals = entitySignalsForCandidates(db as never, [DOC], 'what does the API and db do');
+    const signals = entitySignalsForCandidates(db as never, [DOC], augmentQueryWithAcronyms('what does the API and db do'));
     const matches = signals.get(DOC)?.matches ?? [];
 
     // Before the fix the merged phrase produced no key, so this map was empty.
@@ -103,11 +113,38 @@ describe('the expansion keys actually find an entity link', () => {
   });
 
   test('a single-acronym query finds its own expansion', () => {
-    const matches = entitySignalsForCandidates(db as never, [DOC], 'tell me about the API').get(DOC)?.matches ?? [];
+    const matches = entitySignalsForCandidates(db as never, [DOC], augmentQueryWithAcronyms('tell me about the API')).get(DOC)?.matches ?? [];
     expect(matches).toContain('Application Programming Interface');
   });
 
   test('an unrelated query finds nothing — the match is not unconditional', () => {
-    expect(entitySignalsForCandidates(db as never, [DOC], 'unrelated words entirely').size).toBe(0);
+    expect(entitySignalsForCandidates(db as never, [DOC], augmentQueryWithAcronyms('unrelated words entirely')).size).toBe(0);
+  });
+});
+
+describe('pointer-index loses the same keys, and must not', () => {
+  /**
+   * `queryPointers` builds entity pointers from `extractEntities` too, so the merged phrase hit
+   * it identically. `tools/search/handler.ts:63` passes the augmented query.
+   *
+   * Single-word expansions survived by accident — every word is separately added as an entity
+   * pointer — so only multi-word expansions were lost. That is why `database` looked fine while
+   * `application-programming-interface` vanished.
+   */
+  const augmented = augmentQueryWithAcronyms('what does the API and db do');
+  const entityPointers = () => queryPointers(augmented).filter((p) => p.kind === 'entity').map((p) => p.key);
+
+  test('the multi-word expansion is a pointer', () => {
+    expect(entityPointers()).toContain(API_KEY);
+  });
+
+  test('the single-word expansion is too', () => {
+    expect(entityPointers()).toContain(DB_KEY);
+  });
+
+  test('the merged phrase may still appear, but it is not the only entity pointer', () => {
+    const keys = entityPointers();
+    expect(keys.length).toBeGreaterThan(1);
+    expect(keys).toContain(API_KEY);
   });
 });


### PR DESCRIPTION
I merged #2877 an hour ago. **It did nothing in production.** This corrects it and fixes a second instance of the same defect.

## What went wrong

#2877 added `expansionsForText(query)` to entity-key derivation. That function returns only the expansions **missing** from the text — correct for augmenting a query, since you do not append what is already there.

But ranking receives the **already-augmented** query:

```
ask/index.ts:80             rerankByEntityLinks(sqlite, results, augmentedQ, tenantId)
tools/search/handler.ts:89  rerankByEntityLinks(ctx.sqlite, combined, augmentedQuery, …)
```

```
expansionsForText("what does the API and db do")            → ["Application Programming Interface","Database"]
expansionsForText("… API and db do Application Programming Interface Database") → []   ← production
```

So the added line contributed zero keys.

**The test passed the raw query.** It went green against an input production never uses. That is the defect worth naming — not the missing keys, but a guard that agreed with itself.

I found it only because I went looking for the same *shape* elsewhere and hit the identical dead end in `pointer-index.ts`.

## The fix

`expansionPhrasesForText` returns applicable full forms **whether or not** they already appear — the right question for a consumer of augmented text. Both call sites use it.

Measured on the production input:

```
before:  entity pointers: [… application-programming-interface-database …]
         has 'application-programming-interface'?  false
after:   has 'application-programming-interface'?  true
```

## Second instance: pointer-index

`queryPointers` derives entity pointers from `extractEntities` too, and `tools/search/handler.ts:63` passes it the augmented query. Same merge, same loss.

Subtle detail that made it easy to miss: **single-word expansions survived by accident**, because every word is separately added as an entity pointer. So `database` looked fine while `application-programming-interface` vanished. Only multi-word expansions were lost — which is precisely the case a human would notice least.

## Verification

```
bunx tsc --noEmit                                       exit 0
src/ tests/build/ tests/http/{search,ask,knowledge}/
tests/mcp/ tests/vector/ tests/docs/                    failing: NONE
```

**Mutation-checked against two different wrong versions:**

| mutation | result |
|---|---|
| revert to `expansionsForText` (what #2877 shipped) | **4 of 9 fail** |
| remove the lines entirely | **4 of 9 fail** |

The previous test caught **neither**. That is the measurable difference between this test and the one it replaces.

Refs #2876, #2877

🤖 Generated with [Claude Code](https://claude.com/claude-code)