### PR TITLE
feat(search): a ranking signal with no data now says so, once

### DIFF
--- a/src/search/signal-health.ts
+++ b/src/search/signal-health.ts
@@ -1,0 +1,63 @@
+/**
+ * Say something when a ranking signal is wired but has no data.
+ *
+ * `handleSearch` merges several signals — FTS, vectors, entity links, pointers. If one has no
+ * rows, search still returns results ranked by the others, looking entirely normal.
+ * `oracle_pointer_index` held **zero rows against 35,179 documents** indefinitely and nothing
+ * anywhere said so (#2880).
+ *
+ * Fourth instance of one shape in a single night: #2806 (daemon stored an empty-string
+ * embedding), #2863 (indexer queued no vector jobs), #2876 (entity boost silently skipped),
+ * and this. Each time the pipeline reported success while a stage did nothing.
+ *
+ * Two properties this deliberately has:
+ *
+ * - **Once per process.** This sits on the search hot path. An unguarded `console.error` here
+ *   is the ~864,000 lines/day failure `tool-alias-warn.ts` documents and #2826 shipped for
+ *   real, so `warnOnce` is reused rather than reinvented.
+ * - **One COUNT per process, not per request.** The check is definitive — it asks the table,
+ *   rather than inferring emptiness from a query that happened to match nothing — but it runs
+ *   at most once, so it cannot become a per-search cost.
+ */
+import type { Database } from 'bun:sqlite';
+import { warnOnce } from '../config/tool-alias-warn.ts';
+
+const checked = new Set<string>();
+
+function count(sqlite: Database, table: string): number {
+  try {
+    return Number((sqlite.query(`SELECT COUNT(*) AS c FROM ${table}`).get() as { c?: number } | undefined)?.c ?? 0);
+  } catch {
+    // A missing table is itself "no data", and is not worth throwing on a search request.
+    return 0;
+  }
+}
+
+/**
+ * Warn once if `table` is empty while the document corpus is not.
+ *
+ * An empty corpus is not a defect — a fresh install has no documents and every signal is
+ * legitimately silent — so the corpus check is what stops this crying wolf on day one.
+ *
+ * Callers pass the *table* rather than a row count so the verdict is about the signal's data,
+ * not about one query's luck: a query can legitimately match nothing.
+ */
+export function noteRankingSignalCoverage(sqlite: Database, signal: string, table: string): void {
+  if (checked.has(signal)) return;
+  checked.add(signal);
+
+  if (count(sqlite, table) > 0) return;
+  const corpus = count(sqlite, 'oracle_documents');
+  if (corpus <= 0) return;
+
+  warnOnce(
+    `dark-signal:${signal}`,
+    `[Search] ranking signal "${signal}" has 0 rows in ${table} while oracle_documents has ${corpus}. `
+    + 'It is wired into search and contributes nothing. Warns once per process. See #2880.',
+  );
+}
+
+/** Tests only — the guard is process-global. */
+export function resetSignalHealth(): void {
+  checked.clear();
+}

--- a/src/tools/search/handler.ts
+++ b/src/tools/search/handler.ts
@@ -3,6 +3,7 @@ import { augmentQueryWithAcronyms } from '../../search/acronyms.ts';
 import { currentTenantId } from '../../middleware/tenant.ts';
 import { rerankByEntityLinks } from '../../search/entity-ranking.ts';
 import { queryPointerIndex } from '../../search/pointer-index.ts';
+import { noteRankingSignalCoverage } from '../../search/signal-health.ts';
 import { rerankCandidates } from '../../server/reranker.ts';
 import type { SearchResult } from '../../server/types.ts';
 import { filterResultsAsOf, parseAsOf } from '../../search/bitemporal.ts';
@@ -59,6 +60,8 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
     }
   }
 
+  // Announce a dark signal once rather than letting it stay invisible (#2880).
+  noteRankingSignalCoverage(ctx.sqlite, 'pointer-index', 'oracle_pointer_index');
   const pointerResults = queryPointerIndex(ctx.sqlite, {
     query: augmentedQuery,
     type,

--- a/tests/http/search/dark-signal-warning.test.ts
+++ b/tests/http/search/dark-signal-warning.test.ts
@@ -1,0 +1,156 @@
+/**
+ * A ranking signal with no data must say so — once (#2880).
+ *
+ * `oracle_pointer_index` held zero rows against 35,179 documents indefinitely. `handleSearch`
+ * called it on every request and merged an empty result, so search looked entirely normal
+ * while one of its inputs contributed nothing. Nothing logged, nothing counted, nothing to
+ * notice.
+ *
+ * The tests below pin the two properties that make this useful rather than noisy:
+ *   - it fires when the signal is empty and the corpus is not
+ *   - it fires ONCE, because this is the search hot path — `tool-alias-warn.ts` documents the
+ *     ~864,000 lines/day an unguarded warning costs there, and #2826 shipped exactly that
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createDatabase } from '../../../src/db/create.ts';
+import { oracleDocuments, oraclePointerIndex, tenants } from '../../../src/db/schema.ts';
+import { noteRankingSignalCoverage, resetSignalHealth } from '../../../src/search/signal-health.ts';
+import { resetAliasWarnings } from '../../../src/config/tool-alias-warn.ts';
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), 'dark-signal-'));
+  const { db, sqlite } = createDatabase(join(dir, 'oracle.db'));
+  return { db, sqlite, cleanup: () => { sqlite.close(); rmSync(dir, { recursive: true, force: true }); } };
+}
+
+function seedDocument(db: ReturnType<typeof freshDb>['db'], id = 'doc-1') {
+  const now = Date.now();
+  db.insert(tenants).values({ id: 'default', status: 'active', createdAt: now, updatedAt: now }).onConflictDoNothing().run();
+  db.insert(oracleDocuments).values({
+    id, tenantId: 'default', type: 'learning', sourceFile: `notes/${id}.md`,
+    concepts: '[]', createdAt: now, updatedAt: now, indexedAt: now,
+  }).run();
+}
+
+function captureWarnings(): { lines: string[]; restore: () => void } {
+  const original = console.error;
+  const lines: string[] = [];
+  console.error = (...args: unknown[]) => { lines.push(String(args[0] ?? '')); };
+  return { lines, restore: () => { console.error = original; } };
+}
+
+afterEach(() => {
+  resetSignalHealth();
+  resetAliasWarnings();
+});
+
+describe('a dark ranking signal announces itself', () => {
+  test('warns when the signal table is empty and the corpus is not', () => {
+    const { db, sqlite, cleanup } = freshDb();
+    const spy = captureWarnings();
+    try {
+      seedDocument(db);
+      noteRankingSignalCoverage(sqlite, 'pointer-index', 'oracle_pointer_index');
+
+      expect(spy.lines).toHaveLength(1);
+      expect(spy.lines[0]).toContain('pointer-index');
+      expect(spy.lines[0]).toContain('oracle_pointer_index');
+      expect(spy.lines[0]).toContain('contributes nothing');
+    } finally {
+      spy.restore();
+      cleanup();
+    }
+  });
+
+  test('says how many documents it is dark against', () => {
+    const { db, sqlite, cleanup } = freshDb();
+    const spy = captureWarnings();
+    try {
+      for (const id of ['a', 'b', 'c']) seedDocument(db, id);
+      noteRankingSignalCoverage(sqlite, 'pointer-index', 'oracle_pointer_index');
+      expect(spy.lines[0]).toContain('oracle_documents has 3');
+    } finally {
+      spy.restore();
+      cleanup();
+    }
+  });
+});
+
+describe('it does not cry wolf', () => {
+  test('an empty corpus is silent — a fresh install is not a defect', () => {
+    const { sqlite, cleanup } = freshDb();
+    const spy = captureWarnings();
+    try {
+      noteRankingSignalCoverage(sqlite, 'pointer-index', 'oracle_pointer_index');
+      expect(spy.lines).toEqual([]);
+    } finally {
+      spy.restore();
+      cleanup();
+    }
+  });
+
+  test('a populated signal is silent', () => {
+    const { db, sqlite, cleanup } = freshDb();
+    const spy = captureWarnings();
+    try {
+      seedDocument(db);
+      const now = Date.now();
+      db.insert(oraclePointerIndex).values({
+        id: 'ptr-1', tenantId: 'default', kind: 'topic', key: 'deploy',
+        label: 'deploy', docIds: JSON.stringify(['doc-1']), docCount: 1,
+        createdAt: now, updatedAt: now,
+      }).run();
+
+      noteRankingSignalCoverage(sqlite, 'pointer-index', 'oracle_pointer_index');
+      expect(spy.lines).toEqual([]);
+    } finally {
+      spy.restore();
+      cleanup();
+    }
+  });
+
+  test('a missing table is treated as no data, not an exception', () => {
+    const { db, sqlite, cleanup } = freshDb();
+    const spy = captureWarnings();
+    try {
+      seedDocument(db);
+      // A search request must not fail because a signal's table was never created.
+      expect(() => noteRankingSignalCoverage(sqlite, 'imaginary', 'table_that_does_not_exist')).not.toThrow();
+    } finally {
+      spy.restore();
+      cleanup();
+    }
+  });
+});
+
+describe('once per process, because this is the search hot path', () => {
+  test('fifty calls emit one line', () => {
+    const { db, sqlite, cleanup } = freshDb();
+    const spy = captureWarnings();
+    try {
+      seedDocument(db);
+      for (let i = 0; i < 50; i += 1) noteRankingSignalCoverage(sqlite, 'pointer-index', 'oracle_pointer_index');
+      expect(spy.lines).toHaveLength(1);
+    } finally {
+      spy.restore();
+      cleanup();
+    }
+  });
+
+  test('distinct signals warn independently', () => {
+    const { db, sqlite, cleanup } = freshDb();
+    const spy = captureWarnings();
+    try {
+      seedDocument(db);
+      noteRankingSignalCoverage(sqlite, 'pointer-index', 'oracle_pointer_index');
+      noteRankingSignalCoverage(sqlite, 'entity-links', 'oracle_entity_links');
+      expect(spy.lines).toHaveLength(2);
+    } finally {
+      spy.restore();
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
`oracle_pointer_index` has held **zero rows against 35,179 documents** indefinitely (#2880). `handleSearch` calls `queryPointerIndex` on every request and merges an empty result, so search returns normal-looking results while one of its inputs contributes nothing. Nothing logged it, nothing counted it, nothing made it noticeable.

This does not fix the empty table — that is #2880, and its two halves need to land together or the fix makes ranking *worse* (recent documents would gain a signal older ones cannot earn). This makes the condition **visible**.

## Why it is worth its own change

Four instances of one shape tonight:

| | what did nothing | what the pipeline said |
|---|---|---|
| #2806 | daemon stored `embed('')` for every document | `done: N, error: 0`, exit 0 |
| #2863 | indexer queued **zero** vector jobs | "FTS5 index remains current" |
| #2876 | entity boost silently skipped | results returned, ranked by FTS |
| #2880 | pointer signal has no data at all | results returned, looking normal |

Every one was found by accident. The cheapest defence is for a dark signal to announce itself.

## Two deliberate properties, both mutation-checked

**Once per process.** This is the search hot path. `tool-alias-warn.ts` documents the ~864,000 lines/day an unguarded `console.error` costs there, and #2826 shipped exactly that — so `warnOnce` is reused rather than reinvented. *Dropping the guard fails a test.*

**Silent on an empty corpus.** A fresh install legitimately has nothing in any signal, and a guard that cries wolf on day one gets muted and stops working. *Dropping that check fails a test.*

It also asks **the table**, not the query result — one `COUNT` per process, never per request — so the verdict is about the signal's data rather than one query's luck. A query matching nothing is not evidence of a dark signal.

## Verified against the live database

```
[Search] ranking signal "pointer-index" has 0 rows in oracle_pointer_index while
oracle_documents has 35179. It is wired into search and contributes nothing.
Warns once per process. See #2880.
```

Fired once across five calls, with the real numbers.

## Gates

```
bunx tsc --noEmit                                        exit 0
src/ tests/build/ tests/http/search/ tests/mcp/
tests/config/ tests/docs/                                failing: NONE
tests/http/search/dark-signal-warning.test.ts            7 pass / 0 fail
```

Refs #2880

🤖 Generated with [Claude Code](https://claude.com/claude-code)