### PR TITLE
fix: mcp subcommand never runs main() (import.meta.main false when imported)

### DIFF
--- a/bin/arra.ts
+++ b/bin/arra.ts
@@ -29,7 +29,11 @@ if (args.includes("--help") || args.includes("-h")) {
 if (command === "mcp") {
   process.env.ORACLE_LOG_TARGET ??= "stderr";
   console.log = (...data: unknown[]) => console.error(...data);
-  await import("../src/index.ts");
+  // `import.meta.main` inside src/index.ts is false when loaded via this
+  // wrapper's `await import()` (same pattern as the serve path above), so
+  // main() must be invoked explicitly instead of relying on the guard.
+  const { main } = await import("../src/index.ts");
+  await main();
 } else {
   const serveArgs = command === "serve" ? args.slice(1) : args;
   const portIdx = serveArgs.indexOf("--port");

--- a/src/index.ts
+++ b/src/index.ts
@@ -673,7 +673,7 @@ class OracleMCPServer {
   }
 }
 
-async function main() {
+export async function main() {
   const readOnly = process.env.ORACLE_READ_ONLY === 'true' || process.argv.includes('--read-only');
   const server = new OracleMCPServer({ readOnly });
 


### PR DESCRIPTION
## Summary
- `bin/arra.ts` loads `src/index.ts` via `await import()` for the `mcp` subcommand, but `src/index.ts` only starts the stdio server when `import.meta.main` is true — which is never the case when imported this way. `main()` was never called, so `arra-oracle mcp` would load, do nothing, and exit 0 with zero output (no MCP handshake response, ever).
- Same root cause as the `serve` path's already-documented auto-server gotcha (see existing comment in `bin/arra.ts`) — that path was fixed with an explicit call, but the `mcp` path never got the equivalent fix.
- Fix: export `main()` from `src/index.ts` and call it explicitly from the `mcp` branch in `bin/arra.ts`, mirroring the pattern already used for `serve`.

## Test plan
- [x] Manual JSON-RPC `initialize` handshake via stdin against `bun bin/arra.ts mcp` — before fix: zero stdout/stderr, exit 0. After fix: proper `initialize` response + expected startup logs on stderr.
- [x] `claude mcp list` against a local Claude Code config pointed at the patched checkout — shows `✔ Connected` (was `✘ Failed to connect`, both the original timeout and the post-partial-fix "Connection closed").