### PR TITLE
fix(search): normalizeFtsScore read bm25 backwards, reversing every FTS result

### DIFF
--- a/src/tools/__tests__/search-supersede.test.ts
+++ b/src/tools/__tests__/search-supersede.test.ts
@@ -76,7 +76,12 @@ test('oracle_search includes inline supersede successor fields', async () => {
     id: 'old-supersede-doc',
     superseded_by: 'new-supersede-doc',
     superseded_reason: 'newer MCP memory',
-    confidence: { level: 'medium' },
+    // 'low', not 'medium': this fixture holds 2 documents, so bm25 has no
+    // discriminating power and FTS5 returns rank ~0 — i.e. the match carries no
+    // information. normalizeFtsScore used to map rank 0 to a score of 1.0 (a
+    // perfect match) because it read |rank| backwards; it now maps it to ~0.
+    // The supersede fields below are what this test is actually guarding.
+    confidence: { level: 'low' },
     provenance: { source: 'fts', source_file: 'ψ/memory/old.md' },
   });
   expect(body.results[0].confidence.signals).toContain('matched by keyword search');

--- a/src/tools/__tests__/search.test.ts
+++ b/src/tools/__tests__/search.test.ts
@@ -75,19 +75,39 @@ describe('normalizeFtsScore', () => {
     }
   });
 
-  it('should give better scores for better ranks (closer to 0)', () => {
-    expect(normalizeFtsScore(-1)).toBeGreaterThan(normalizeFtsScore(-5));
-    expect(normalizeFtsScore(-5)).toBeGreaterThan(normalizeFtsScore(-10));
+  // FTS5 `rank` is bm25(): negative, and MORE negative = better match — which is
+  // why fts.ts uses `ORDER BY rank` ascending to get best-first. Checked against
+  // SQLite directly: on a fresh table a row matching 7 of 7 query terms ranks
+  // -1.985 while rows matching 1-2 of them rank 0.0. The previous expectations
+  // here asserted the opposite ("closer to 0 is better"), which is how the
+  // inverted score shipped and stayed — the suite was green the whole time.
+  it('should give better scores for better ranks (further from 0)', () => {
+    expect(normalizeFtsScore(-10)).toBeGreaterThan(normalizeFtsScore(-5));
+    expect(normalizeFtsScore(-5)).toBeGreaterThan(normalizeFtsScore(-1));
   });
 
-  it('should provide exponential decay', () => {
-    const score1 = normalizeFtsScore(-1);
-    const score2 = normalizeFtsScore(-2);
-    const score3 = normalizeFtsScore(-3);
+  it('should rank a realistic spread the same way ORDER BY rank does', () => {
+    // Real ranks observed for one OR-joined query against a 1250-row index.
+    const bestFirst = [-30.42, -11.27, -9.97, -9.01, -8.65, -8.13];
+    const scores = bestFirst.map(normalizeFtsScore);
+    // mergeResults sorts by score descending, so scores must already be
+    // descending in the order SQL returned the rows.
+    for (let i = 1; i < scores.length; i++) {
+      expect(scores[i - 1]).toBeGreaterThan(scores[i]);
+    }
+  });
 
-    const ratio1 = score1 / score2;
-    const ratio2 = score2 / score3;
-    expect(ratio1).toBeCloseTo(ratio2, 1);
+  it('should saturate below 1 rather than overflow on very strong matches', () => {
+    expect(normalizeFtsScore(-100)).toBeLessThan(1);
+    expect(normalizeFtsScore(-100)).toBeGreaterThan(normalizeFtsScore(-30));
+  });
+
+  // Guards the downstream consumers of this score in helpers.ts: the
+  // 'strong keyword score' signal and the confidence level both threshold at
+  // >= 0.7, so an inverted score awarded them to the weakest matches.
+  it('should only clear the 0.7 signal threshold for genuinely strong matches', () => {
+    expect(normalizeFtsScore(-1)).toBeLessThan(0.7);
+    expect(normalizeFtsScore(-10)).toBeGreaterThanOrEqual(0.7);
   });
 });
 

--- a/src/tools/search/helpers.ts
+++ b/src/tools/search/helpers.ts
@@ -18,9 +18,25 @@ export function sanitizeFtsQuery(query: string): string {
     .join(' OR ');
 }
 
-/** Normalize FTS5 rank score using exponential decay. */
+/**
+ * Normalize FTS5 rank into a 0-1 score where higher = better.
+ *
+ * FTS5's `rank` is bm25(): negative, and MORE negative = better match, which is
+ * why fts.ts orders by it ascending. So `|rank|` is the match strength and the
+ * score has to rise with it. The previous form returned `exp(-0.3 * |rank|)`,
+ * which fell as the match got stronger — combined with the descending sort in
+ * `mergeResults` that reversed every FTS result set: SQL handed back its best
+ * rows and this ranked them last. Because callers over-fetch and then truncate,
+ * they received the weakest of the strong matches, which reads as
+ * plausible-but-wrong rather than empty, so nothing surfaced the fault.
+ *
+ * Saturating, so it stays inside 0-1 for the hybrid blend against cosine
+ * similarity. Note it compresses at the top (|rank| 10 -> 0.950, 30 -> 0.9999):
+ * ordering is correct throughout, but separating two strong FTS hits would want
+ * normalisation across the returned set rather than a fixed curve.
+ */
 export function normalizeFtsScore(rank: number): number {
-  return Math.exp(-0.3 * Math.abs(rank));
+  return 1 - Math.exp(-0.3 * Math.abs(rank));
 }
 
 export function parseConceptsFromMetadata(concepts: unknown): string[] {


### PR DESCRIPTION
Fixes the inversion reported in #2886. That issue cited `src/tools/search.ts:100` on `main`, which is ~1176 commits behind — the same expression lives on `alpha` at `src/tools/search/helpers.ts:22` after the search module split, so the bug is current. This PR targets `alpha`.

## The bug

```ts
export function normalizeFtsScore(rank: number): number {
  return Math.exp(-0.3 * Math.abs(rank));   // falls as the match gets stronger
}
```

FTS5's `rank` is `bm25()`: negative, and **more negative = better match** — which is why `fts.ts` uses `ORDER BY rank` ascending to get best-first. So `|rank|` *is* the match strength and the score has to rise with it. It falls instead, and `mergeResults` (`helpers.ts:120`) sorts by that score descending. SQL hands back its best rows; this ranks them last.

Because callers over-fetch and truncate, what comes back is **the weakest of the strong matches** — topically adjacent, plausible, wrong. Nothing looks broken, which is why it survived. On an FTS-only install (no embedding provider reachable) this is the only retrieval path.

## Measured

1250-row index, query `Crossref plain-file vector store MODEL MISMATCH`, sanitized to `"Crossref" OR "plain" OR "file" OR "vector" OR "store" OR "MODEL" OR "MISMATCH"`:

| SQL rank (best first) | score before | position before | score after |
|---|---|---|---|
| **−30.42** — contains all 7 terms | 0.000109 | **9th of 9, dropped** | **0.999891 → 1st** |
| −11.27 | 0.034 | 8th | 0.965980 |
| −9.97 | 0.050 | 7th | 0.949804 |
| −9.01 | 0.067 | 6th | … |
| −8.65 | 0.075 | 5th | … |
| −8.13 — weakest of the nine | **0.087** | **1st, returned** | … |

After the fix the ordering agrees with `ORDER BY rank`.

Rank direction verified against SQLite directly, no app code involved:

```sql
CREATE VIRTUAL TABLE t USING fts5(body, tokenize='porter unicode61');
INSERT INTO t(body) VALUES
  ('crossref crossref crossref vector store model mismatch plain file'),  -- all 7 terms
  ('vector store'), ('store');
SELECT rowid, round(rank,3) FROM t
WHERE t MATCH '"crossref" OR "vector" OR "store" OR "model" OR "mismatch" OR "plain" OR "file"'
ORDER BY rank;
-- 1|-1.985   2|0.0   3|0.0
```

## Blast radius beyond ordering

`helpers.ts:141` and `:149` threshold this score at `>= 0.7` for the `'strong keyword score'` signal and the confidence level. Inverted, `>= 0.7` meant `|rank| <= 1.19` — the label went to the weakest matches. A test now guards that threshold.

## The suite was green the whole time

`search.test.ts:78` asserted the inversion outright:

```ts
it('should give better scores for better ranks (closer to 0)', () => {
  expect(normalizeFtsScore(-1)).toBeGreaterThan(normalizeFtsScore(-5));
```

That says a weak match should beat a strong one, so any correct fix fails it. Flipped here. The neighbouring `'should provide exponential decay'` test (constant ratio between consecutive scores) cannot hold for a bounded increasing function either; replaced with a monotonicity check over a real rank spread, plus a saturation check.

## One deliberate behaviour change

`search-supersede.test.ts` expected `confidence: { level: 'medium' }`. Its fixture holds 2 documents, so bm25 has no discriminating power and returns `rank ~0`. The old curve mapped `rank 0` to a score of **1.0** — a no-information match scored as perfect, the inversion at its clearest. It now maps to ~0, so that fixture reports `'low'`.

**Any correct fix has this effect**, since fixing the direction necessarily puts `rank 0` at the low end. Flagging it because it is observable output, not just internal ordering. The supersede assertions that test is actually guarding are unchanged.

## Caveat worth a maintainer call

`1 - exp(-0.3|rank|)` saturates: `|rank| 10 → 0.950`, `30 → 0.9999`. Ordering is correct throughout, but it barely separates two strong FTS hits, which matters where `ftsScore` is blended with `vectorScore` in hybrid mode (`helpers.ts:110-112`). Normalising across the returned result set would preserve discrimination better. I kept the one-line form as the smallest correct change — happy to send the result-set variant instead if you prefer it.

## Tests

- `bun test src/tools/__tests__/search.test.ts` — 25 pass / 0 fail
- `bun test src/tools/ src/search/ src/server/` — 203 pass / 1 fail
- `bun test` (full, 1232 files) — **3553 pass / 17 fail**, against **3551 pass / 17 fail** on pristine `alpha`. Same 17 failures, pre-existing; verified by stashing the change and re-running.

---

🤖 Authored by Singhasingha Oracle (AI) on behalf of @mymint0840-web, who reviewed and approved sending it. Not merged by AI.
