### PR TITLE
fix: refuse to sync a repo into itself, and to open the live db from a test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
             tests/docs/ tests/config/ tests/process-manager/ tests/lifecycle/ \
             tests/smoke/ tests/export/ tests/services/ tests/knowledge/ tests/forum/ tests/eval/ \
             tests/bin/ tests/canvas/ tests/db/ tests/indexer/ tests/lib/ tests/oracles/ \
-            tests/runtime/ tests/server/
+            tests/runtime/ tests/server/ tests/vault/
           do
             echo "::group::${group}"
             # Exit 133 is bun CRASHING (SIGTRAP), not a test failing — the two are

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,6 +45,15 @@ function pathFromDatabaseUrl(value?: string): string {
 }
 
 export const PORT = parseInt(String(envText('ORACLE_PORT') || envText('PORT') || C.ORACLE_DEFAULT_PORT), 10);
+/**
+ * The user's real data directory, independent of any env override.
+ *
+ * `ORACLE_DATA_DIR` below honours `process.env.ORACLE_DATA_DIR`, so a test that redirects it
+ * to a temp dir makes the constant BECOME that temp dir. Anything wanting to ask "is this the
+ * live user data?" must compare against this instead, or it answers yes for exactly the tests
+ * that are doing the right thing.
+ */
+export const DEFAULT_ORACLE_DATA_DIR = path.join(HOME_DIR, C.ORACLE_DATA_DIR_NAME);
 export const ORACLE_DATA_DIR = envText('ORACLE_DATA_DIR') || path.join(HOME_DIR, C.ORACLE_DATA_DIR_NAME);
 export const DB_PATH = envText('ORACLE_DB_PATH') || pathFromDatabaseUrl(envText('DATABASE_URL')) || path.join(ORACLE_DATA_DIR, C.ORACLE_DB_FILE);
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -11,7 +11,7 @@ import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 import type { Database } from 'bun:sqlite';
 import path from 'path';
 import * as schema from './schema.ts';
-import { DB_PATH, ORACLE_DATA_DIR } from '../config.ts';
+import { DB_PATH, DEFAULT_ORACLE_DATA_DIR, ORACLE_DATA_DIR } from '../config.ts';
 import { assertNotProductionDb } from './production-db-guard.ts';
 import { createStorageBackend } from '../storage/registry.ts';
 import type { StorageBackend } from '../storage/types.ts';
@@ -93,12 +93,16 @@ export function resetDefaultDatabaseForTests(dbPath?: string): void {
 }
 
 /**
- * The guard compares against the *constant*, never `process.env.ORACLE_DATA_DIR`. A test that
- * redirects both variables to a temp directory is the safe case and must stay allowed — using
- * the env override here would refuse exactly the tests that are doing the right thing.
+ * The guard compares against `DEFAULT_ORACLE_DATA_DIR` — the home-directory path, computed
+ * without the env override.
+ *
+ * `ORACLE_DATA_DIR` is `envText('ORACLE_DATA_DIR') || join(HOME_DIR, …)`, so a test that
+ * redirects it to a temp dir makes that constant equal the temp dir, and a guard reading it
+ * refuses the very tests doing the right thing. CI caught exactly that: the README-claims suite
+ * failed with `production data dir = /tmp/arra-readme-claims-…/data`.
  */
 function productionDataDir(): string {
-  return ORACLE_DATA_DIR;
+  return DEFAULT_ORACLE_DATA_DIR;
 }
 
 function defaultDbPathForReset(): string {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -12,6 +12,7 @@ import type { Database } from 'bun:sqlite';
 import path from 'path';
 import * as schema from './schema.ts';
 import { DB_PATH, ORACLE_DATA_DIR } from '../config.ts';
+import { assertNotProductionDb } from './production-db-guard.ts';
 import { createStorageBackend } from '../storage/registry.ts';
 import type { StorageBackend } from '../storage/types.ts';
 import { resolveDatabasePath } from './create.ts';
@@ -53,7 +54,7 @@ function openDefaultStorage(): StorageBackend {
 
 function defaultDbPath(): string {
   const envPath = process.env.ORACLE_DB_PATH?.trim();
-  if (envPath) return envPath;
+  if (envPath) return assertNotProductionDb(envPath, productionDataDir());
   if (process.env.NODE_ENV === 'test') return ':memory:';
   return DB_PATH;
 }
@@ -91,9 +92,18 @@ export function resetDefaultDatabaseForTests(dbPath?: string): void {
   defaultStorage = createStorageBackend({ dbPath: resolveDatabasePath(dbPath, defaultDbPathForReset()) });
 }
 
+/**
+ * The guard compares against the *constant*, never `process.env.ORACLE_DATA_DIR`. A test that
+ * redirects both variables to a temp directory is the safe case and must stay allowed — using
+ * the env override here would refuse exactly the tests that are doing the right thing.
+ */
+function productionDataDir(): string {
+  return ORACLE_DATA_DIR;
+}
+
 function defaultDbPathForReset(): string {
   const envPath = process.env.ORACLE_DB_PATH?.trim();
-  if (envPath) return envPath;
+  if (envPath) return assertNotProductionDb(envPath, productionDataDir());
   if (process.env.NODE_ENV === 'test') return ':memory:';
   return path.join(process.env.ORACLE_DATA_DIR?.trim() || ORACLE_DATA_DIR, 'oracle.db');
 }

--- a/src/db/production-db-guard.ts
+++ b/src/db/production-db-guard.ts
@@ -1,0 +1,48 @@
+/**
+ * A test must never open the user's real database.
+ *
+ * `defaultDbPath()` returns `':memory:'` under `NODE_ENV=test`, but only *after* an
+ * `ORACLE_DB_PATH` check that returns first. Set that variable — as any shell that runs the
+ * server does — and every test importing the `db` singleton writes to live data instead.
+ *
+ * This is not hypothetical. `tests/http/health/stats.test.ts` was created 2026-06-16, one day
+ * before the `':memory:'` guard existed (b1806554, 2026-06-17). In that window it wrote
+ * `vault_repo = 'coverage-vault'` into `~/.arra-oracle-v2/oracle.db`. Its `afterAll` restores
+ * whatever it read at import time, so once the fixture leaked, every later run read it back and
+ * faithfully restored it. The vault pointed at a repo that does not exist for the next 40 days,
+ * and `syncVault` was inert the whole time. Nothing failed; nothing said anything.
+ *
+ * The guard throws rather than silently redirecting to `':memory:'`. A test that would corrupt
+ * live data has a bug in it, and the 40 days above are what silent handling costs.
+ *
+ * Temp paths stay allowed — many tests legitimately point `ORACLE_DB_PATH` at a `mkdtemp`
+ * directory and need it honoured. Only the production data directory is refused.
+ */
+import path from 'node:path';
+
+/** True when `candidate` resolves to `dir` itself or anything beneath it. */
+function isInside(dir: string, candidate: string): boolean {
+  const rel = path.relative(path.resolve(dir), path.resolve(candidate));
+  // '' means the same path. A '..' prefix or an absolute result means outside — which also
+  // rules out the `/foo` vs `/foobar` prefix trap that a plain startsWith() would fall into.
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+}
+
+/**
+ * Refuse an explicit database path that points into the user's real data directory while
+ * running under test. Returns the path unchanged when it is safe to use.
+ */
+export function assertNotProductionDb(envPath: string, productionDir: string): string {
+  if (process.env.NODE_ENV !== 'test') return envPath;
+  if (envPath === ':memory:') return envPath;
+  if (!isInside(productionDir, envPath)) return envPath;
+
+  throw new Error(
+    `Refusing to open the production database from a test.\n` +
+      `  ORACLE_DB_PATH = ${envPath}\n` +
+      `  production data dir = ${productionDir}\n` +
+      `A test that writes here mutates real user data, and the damage outlives the run: a ` +
+      `setting leaked this way in June 2026 survived 40 days because the test restored the ` +
+      `value it had itself written. Point ORACLE_DB_PATH at a temp directory, or unset it.`,
+  );
+}

--- a/src/vault/handler.ts
+++ b/src/vault/handler.ts
@@ -7,8 +7,9 @@ import { getSetting, setSetting } from '../db/index.ts';
 import { detectProject } from '../server/project-detect.ts';
 import { ORACLE_DATA_DIR } from '../config.ts';
 import { walkFiles, resolveVaultPath, cleanEmptyDirs } from './discovery.ts';
-import { mapToVaultPath, ensureFrontmatterProject, isProjectCategory, UNIVERSAL_CATEGORIES } from './path-mapping.ts';
+import { UNIVERSAL_CATEGORIES } from './path-mapping.ts';
 import { parseGitStatus } from './git.ts';
+import { planSync } from './sync-plan.ts';
 import { ghqGet, ghqListPaths, normalizeGhqRepo } from './ghq.ts';
 
 // Re-export sub-modules for backward compatibility
@@ -49,15 +50,6 @@ export interface SyncResult {
   commitHash?: string; project?: string | null;
 }
 
-type SyncWriteOp = { source: string; dest: string; content?: string };
-type SyncDeleteOp = { path: string; stopAt: string };
-type SyncPlan = {
-  writes: SyncWriteOp[];
-  deletes: SyncDeleteOp[];
-  added: number;
-  modified: number;
-  deleted: number;
-};
 type SyncLock = { path: string; release: () => void };
 
 const SYNC_LOCK_FILE = 'vault-sync.lock';
@@ -111,46 +103,6 @@ function acquireSyncLock(): SyncLock {
       if (current.pid === process.pid) fs.rmSync(lockPath, { force: true });
     },
   };
-}
-
-function sameFileContent(dest: string, source: string, content?: string): boolean {
-  if (!fs.existsSync(dest)) return false;
-  if (content !== undefined) return fs.readFileSync(dest, 'utf-8') === content;
-  return fs.readFileSync(dest).equals(fs.readFileSync(source));
-}
-
-function planSync(psiDir: string, repoRoot: string, vaultPath: string, project: string | null): SyncPlan {
-  const diskFiles = walkFiles(psiDir, repoRoot);
-  const vaultDestPaths = new Set<string>();
-  const writes: SyncWriteOp[] = [];
-  const deletes: SyncDeleteOp[] = [];
-  let added = 0;
-  let modified = 0;
-
-  for (const { relativePath, fullPath } of diskFiles) {
-    const vaultRelPath = mapToVaultPath(relativePath, project);
-    vaultDestPaths.add(vaultRelPath);
-    const dest = path.join(vaultPath, vaultRelPath);
-    const content = project && fullPath.endsWith('.md') && isProjectCategory(relativePath)
-      ? ensureFrontmatterProject(fs.readFileSync(fullPath, 'utf-8'), project)
-      : undefined;
-
-    if (!sameFileContent(dest, fullPath, content)) {
-      fs.existsSync(dest) ? modified++ : added++;
-      writes.push({ source: fullPath, dest, content });
-    }
-  }
-
-  // Clean up vault files that no longer exist locally
-  if (project) {
-    const vaultProjectDir = path.join(vaultPath, project, 'ψ');
-    if (fs.existsSync(vaultProjectDir)) {
-      for (const { relativePath: vr, fullPath: vf } of walkFiles(vaultProjectDir, vaultPath)) {
-        if (!vaultDestPaths.has(vr)) deletes.push({ path: vf, stopAt: path.join(vaultPath, project) });
-      }
-    }
-  }
-  return { writes, deletes, added, modified, deleted: deletes.length };
 }
 
 export function syncVault(opts: { dryRun?: boolean; repoRoot: string }): SyncResult {

--- a/src/vault/sync-plan.ts
+++ b/src/vault/sync-plan.ts
@@ -1,0 +1,102 @@
+/**
+ * Builds the write/delete plan for a vault sync, and refuses to build one that syncs a repo
+ * into itself.
+ *
+ * `resolveVaultPath()` is a **ghq query**, not a path resolver: it returns the repository ROOT
+ * for `owner/repo`. So setting `vault_repo` to the repo you are working in resolves the vault to
+ * that same checkout, and `mapToVaultPath` then appends `<project>/ψ/…` beneath it. The sync
+ * would copy the whole of `ψ/` into a nested `<repo>/<project>/ψ/` tree, and `syncVault` would
+ * follow that with `git add -A`, `git commit` and `git push` (handler.ts) **in the working
+ * repository** — sweeping up any unrelated uncommitted state and pushing it.
+ *
+ * `.gitignore`'s `ψ/` pattern matches at any depth, so the copied tree is invisible to
+ * `git status` and would accumulate silently. That is what makes this worth a hard failure
+ * rather than a warning: the destructive part is the commit-and-push, and the evidence that
+ * something went wrong is hidden by design.
+ *
+ * `migrate.ts` has a superficially similar check, but it exists to *exclude* the vault repo from
+ * a migration source list — it does not detect this case.
+ */
+import fs from 'fs';
+import path from 'path';
+import { walkFiles } from './discovery.ts';
+import { mapToVaultPath, ensureFrontmatterProject, isProjectCategory } from './path-mapping.ts';
+
+export type SyncWriteOp = { source: string; dest: string; content?: string };
+export type SyncDeleteOp = { path: string; stopAt: string };
+export type SyncPlan = {
+  writes: SyncWriteOp[];
+  deletes: SyncDeleteOp[];
+  added: number;
+  modified: number;
+  deleted: number;
+};
+
+/** True when `candidate` resolves to `dir` itself or anything beneath it. */
+function isInside(dir: string, candidate: string): boolean {
+  const rel = path.relative(path.resolve(dir), path.resolve(candidate));
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+}
+
+/**
+ * Refuse a vault that is the source repository, or contains it. Either direction means the sync
+ * would write into the tree it is reading from and then commit and push that tree.
+ */
+export function assertVaultIsNotSelf(vaultPath: string, repoRoot: string): void {
+  if (!isInside(vaultPath, repoRoot) && !isInside(repoRoot, vaultPath)) return;
+  throw new Error(
+    `Refusing to sync a repository into itself.\n` +
+      `  vault path = ${vaultPath}\n` +
+      `  source repo = ${repoRoot}\n` +
+      `vault_repo resolves through ghq to a repository ROOT, so pointing it at this checkout ` +
+      `would copy ψ/ into a nested tree here and then run 'git add -A', 'git commit' and ` +
+      `'git push' in this repository. Point vault_repo at a separate vault repository.`,
+  );
+}
+
+function sameFileContent(dest: string, source: string, content?: string): boolean {
+  if (!fs.existsSync(dest)) return false;
+  if (content !== undefined) return fs.readFileSync(dest, 'utf-8') === content;
+  return fs.readFileSync(dest).equals(fs.readFileSync(source));
+}
+
+export function planSync(
+  psiDir: string,
+  repoRoot: string,
+  vaultPath: string,
+  project: string | null,
+): SyncPlan {
+  assertVaultIsNotSelf(vaultPath, repoRoot);
+
+  const diskFiles = walkFiles(psiDir, repoRoot);
+  const vaultDestPaths = new Set<string>();
+  const writes: SyncWriteOp[] = [];
+  const deletes: SyncDeleteOp[] = [];
+  let added = 0;
+  let modified = 0;
+
+  for (const { relativePath, fullPath } of diskFiles) {
+    const vaultRelPath = mapToVaultPath(relativePath, project);
+    vaultDestPaths.add(vaultRelPath);
+    const dest = path.join(vaultPath, vaultRelPath);
+    const content = project && fullPath.endsWith('.md') && isProjectCategory(relativePath)
+      ? ensureFrontmatterProject(fs.readFileSync(fullPath, 'utf-8'), project)
+      : undefined;
+
+    if (!sameFileContent(dest, fullPath, content)) {
+      fs.existsSync(dest) ? modified++ : added++;
+      writes.push({ source: fullPath, dest, content });
+    }
+  }
+
+  // Clean up vault files that no longer exist locally
+  if (project) {
+    const vaultProjectDir = path.join(vaultPath, project, 'ψ');
+    if (fs.existsSync(vaultProjectDir)) {
+      for (const { relativePath: vr, fullPath: vf } of walkFiles(vaultProjectDir, vaultPath)) {
+        if (!vaultDestPaths.has(vr)) deletes.push({ path: vf, stopAt: path.join(vaultPath, project) });
+      }
+    }
+  }
+  return { writes, deletes, added, modified, deleted: deletes.length };
+}

--- a/tests/build/file-size.test.ts
+++ b/tests/build/file-size.test.ts
@@ -47,7 +47,6 @@ const GRANDFATHERED: Record<string, number> = {
   'cli/src/cli.ts': 286,
   'src/indexer/__tests__/arra-indexer.test.ts': 284,
   'src/vector/__tests__/benchmark.ts': 278,
-  'src/vault/handler.ts': 273,
   'src/indexer/__tests__/api.test.ts': 269,
   'src/indexer/__tests__/worker.test.ts': 265,
   'src/ensure-server.ts': 258,

--- a/tests/db/production-db-guard.test.ts
+++ b/tests/db/production-db-guard.test.ts
@@ -78,6 +78,26 @@ describe('the paths tests legitimately use stay allowed', () => {
   });
 });
 
+describe('a suite that redirects ORACLE_DATA_DIR is the safe case, not the unsafe one', () => {
+  /**
+   * CI caught this as a false positive on the first version of the guard. It compared against
+   * the `ORACLE_DATA_DIR` constant — but that constant is
+   * `envText('ORACLE_DATA_DIR') || join(HOME_DIR, …)`, so a suite that redirects the variable
+   * to a temp dir makes the constant BECOME the temp dir, and the guard then refuses the very
+   * tests doing the right thing. `README/docs claim integrity` failed with
+   * `production data dir = /tmp/arra-readme-claims-fJYYP3/data`.
+   *
+   * The fix compares against the home-directory default instead, which no env var can move.
+   */
+  test('a db inside a redirected temp data dir is allowed', () => {
+    process.env.NODE_ENV = 'test';
+    const temp = '/tmp/arra-readme-claims-fJYYP3/data';
+    const db = join(temp, 'oracle.db');
+    // The production dir passed in is the real home-directory one, NOT the redirect.
+    expect(assertNotProductionDb(db, PROD)).toBe(db);
+  });
+});
+
 describe('outside tests, nothing is refused', () => {
   test('production itself may open the production database', () => {
     process.env.NODE_ENV = 'production';

--- a/tests/db/production-db-guard.test.ts
+++ b/tests/db/production-db-guard.test.ts
@@ -1,0 +1,94 @@
+/**
+ * A test must not be able to open the user's real database.
+ *
+ * `defaultDbPath()` returns `':memory:'` under `NODE_ENV=test` — but only after an
+ * `ORACLE_DB_PATH` check that returns first, so setting that variable bypasses the safety net
+ * entirely and every test importing the `db` singleton writes to live data.
+ *
+ * The cost is measured, not hypothetical. `tests/http/health/stats.test.ts` was created
+ * 2026-06-16 (e96e0412); the `':memory:'` guard landed 2026-06-17 (b1806554) — one day later.
+ * In that window the test wrote `vault_repo = 'coverage-vault'` into the real database. Its
+ * `afterAll` restores whatever it read at import time, so once the fixture leaked, every later
+ * run read it back and dutifully restored it. `coverage-vault` is not a repo that exists, so
+ * `syncVault` has been inert for 40 days. Nothing failed. Nothing reported anything.
+ *
+ * The distinction these tests pin is the one that matters: a temp path stays allowed, because
+ * plenty of tests legitimately point `ORACLE_DB_PATH` at a `mkdtemp` directory. Only the real
+ * data directory is refused.
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+import { assertNotProductionDb } from '../../src/db/production-db-guard.ts';
+
+const PROD = '/Users/someone/.arra-oracle-v2';
+const previousNodeEnv = process.env.NODE_ENV;
+
+afterEach(() => {
+  if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = previousNodeEnv;
+});
+
+describe('under test, the production database is refused', () => {
+  test('the exact production db file throws', () => {
+    process.env.NODE_ENV = 'test';
+    expect(() => assertNotProductionDb(join(PROD, 'oracle.db'), PROD)).toThrow(/production database/i);
+  });
+
+  test('anything nested beneath the data dir throws too', () => {
+    process.env.NODE_ENV = 'test';
+    expect(() => assertNotProductionDb(join(PROD, 'nested', 'deep.db'), PROD)).toThrow();
+  });
+
+  test('the data dir itself throws', () => {
+    process.env.NODE_ENV = 'test';
+    expect(() => assertNotProductionDb(PROD, PROD)).toThrow();
+  });
+
+  test('the message names the offending path, so the failure is actionable', () => {
+    process.env.NODE_ENV = 'test';
+    // A guard that fires without saying which path tripped it just moves the debugging cost.
+    expect(() => assertNotProductionDb(join(PROD, 'oracle.db'), PROD)).toThrow(/oracle\.db/);
+  });
+});
+
+describe('the paths tests legitimately use stay allowed', () => {
+  test('a temp directory is returned unchanged', () => {
+    process.env.NODE_ENV = 'test';
+    const tmp = '/tmp/oracle-test-abc/oracle.db';
+    expect(assertNotProductionDb(tmp, PROD)).toBe(tmp);
+  });
+
+  test(':memory: is allowed', () => {
+    process.env.NODE_ENV = 'test';
+    expect(assertNotProductionDb(':memory:', PROD)).toBe(':memory:');
+  });
+
+  test('a sibling whose name merely starts with the data dir is NOT inside it', () => {
+    process.env.NODE_ENV = 'test';
+    // The startsWith() trap: '/Users/someone/.arra-oracle-v2-backup' shares a string prefix with
+    // the data dir but is a different directory. A prefix check would refuse it wrongly.
+    const sibling = `${PROD}-backup/oracle.db`;
+    expect(assertNotProductionDb(sibling, PROD)).toBe(sibling);
+  });
+
+  test('relative traversal that escapes the data dir is allowed', () => {
+    process.env.NODE_ENV = 'test';
+    const escaped = join(PROD, '..', 'elsewhere', 'oracle.db');
+    expect(assertNotProductionDb(escaped, PROD)).toBe(escaped);
+  });
+});
+
+describe('outside tests, nothing is refused', () => {
+  test('production itself may open the production database', () => {
+    process.env.NODE_ENV = 'production';
+    const real = join(PROD, 'oracle.db');
+    // The whole point of the real path is that the server uses it.
+    expect(assertNotProductionDb(real, PROD)).toBe(real);
+  });
+
+  test('an unset NODE_ENV is not treated as test', () => {
+    delete process.env.NODE_ENV;
+    const real = join(PROD, 'oracle.db');
+    expect(assertNotProductionDb(real, PROD)).toBe(real);
+  });
+});

--- a/tests/vault/sync-plan-self-reference.test.ts
+++ b/tests/vault/sync-plan-self-reference.test.ts
@@ -1,0 +1,96 @@
+/**
+ * A vault sync must refuse to sync a repository into itself (#2856).
+ *
+ * `vault_repo` holds a **ghq repo spec**, not a path, and `resolveVaultPath()` runs
+ * `ghq list -p <spec>` to get a repository ROOT. So the natural-looking setting
+ * `vault_repo = "Soul-Brews-Studio/arra-oracle-v3"` — the shape you would reach for if you
+ * decided this repo's own ψ/ were the canonical vault — resolves the vault to this very
+ * checkout.
+ *
+ * What follows is not a no-op. `mapToVaultPath` appends `<project>/ψ/…` beneath the vault root,
+ * so the plan copies the whole of ψ/ into a nested `<repo>/<project>/ψ/` tree, and
+ * `syncVault()` then runs `git add -A`, `git commit` and `git push` at the vault path — which
+ * is the working repository. Any unrelated uncommitted state in the tree gets swept into that
+ * commit and pushed.
+ *
+ * `.gitignore`'s `ψ/` pattern matches at any depth (verified with `git check-ignore`), so the
+ * copied tree never appears in `git status`. The evidence that something went wrong is hidden
+ * by the same rule that makes the vault per-user. That is why this throws instead of warning.
+ */
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { assertVaultIsNotSelf, planSync } from '../../src/vault/sync-plan.ts';
+
+describe('a vault that is the source repository is refused', () => {
+  test('the same path for both throws', () => {
+    expect(() => assertVaultIsNotSelf('/repos/arra-oracle-v3', '/repos/arra-oracle-v3'))
+      .toThrow(/into itself/i);
+  });
+
+  test('a vault that CONTAINS the source repo throws', () => {
+    // ghq roots nest: a vault resolved to /repos would contain /repos/arra-oracle-v3.
+    expect(() => assertVaultIsNotSelf('/repos', '/repos/arra-oracle-v3')).toThrow();
+  });
+
+  test('a vault nested INSIDE the source repo throws', () => {
+    expect(() => assertVaultIsNotSelf('/repos/arra-oracle-v3/ψ', '/repos/arra-oracle-v3')).toThrow();
+  });
+
+  test('the message names both paths and says what would happen', () => {
+    // A refusal that does not explain the destructive part reads as an arbitrary restriction.
+    expect(() => assertVaultIsNotSelf('/repos/x', '/repos/x')).toThrow(/git push/);
+  });
+});
+
+describe('a genuinely separate vault is allowed', () => {
+  test('two unrelated directories pass', () => {
+    expect(() => assertVaultIsNotSelf('/repos/oracle-vault', '/repos/arra-oracle-v3')).not.toThrow();
+  });
+
+  test('a sibling sharing a string prefix is NOT self-reference', () => {
+    // The startsWith() trap: '/repos/arra-oracle-v3-oracle' is a different repository.
+    expect(() => assertVaultIsNotSelf('/repos/arra-oracle-v3-oracle', '/repos/arra-oracle-v3'))
+      .not.toThrow();
+  });
+});
+
+describe('planSync enforces it, not just the exported helper', () => {
+  /**
+   * The guard is only worth anything if the code path that copies files runs it. Asserting on
+   * `assertVaultIsNotSelf` alone would pass even if `planSync` never called it — the exact
+   * shape of defect that shipped in #2877, where the fix was real but production never reached
+   * it.
+   */
+  function fixture() {
+    const root = mkdtempSync(join(tmpdir(), 'sync-self-'));
+    const psi = join(root, 'ψ', 'memory');
+    mkdirSync(psi, { recursive: true });
+    writeFileSync(join(psi, 'note.md'), '# note\n');
+    return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+  }
+
+  test('planning a sync of a repo into itself throws before any write is planned', () => {
+    const { root, cleanup } = fixture();
+    try {
+      expect(() => planSync(join(root, 'ψ'), root, root, 'arra-oracle-v3')).toThrow(/into itself/i);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('planning into a separate vault still works', () => {
+    const { root, cleanup } = fixture();
+    const vault = mkdtempSync(join(tmpdir(), 'sync-vault-'));
+    try {
+      const plan = planSync(join(root, 'ψ'), root, vault, 'arra-oracle-v3');
+      // The guard must not have broken the ordinary case it sits in front of.
+      expect(plan.writes.length).toBeGreaterThan(0);
+      expect(plan.added).toBeGreaterThan(0);
+    } finally {
+      cleanup();
+      rmSync(vault, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Two guards for the same failure shape: **a destructive operation that looks like a configuration value.**

Both were found while investigating #2856 (canonical vault root). Neither is the #2856 fix — they are what makes that fix *safe to attempt*.

## 1. A vault sync could sync this repo into itself

`vault_repo` holds a **ghq repo spec**, not a path. `resolveVaultPath()` runs `ghq list -p <spec>` and returns a repository **ROOT**. So the natural-looking setting

```
vault_repo = "Soul-Brews-Studio/arra-oracle-v3"
```

— the shape you reach for if you decide this repo's own `ψ/` is the canonical vault — resolves the vault to **this checkout**. What follows is not a no-op:

- `mapToVaultPath` appends `<project>/ψ/…`, so the plan copies all of `ψ/` into a nested `<repo>/<project>/ψ/` tree
- `syncVault` then runs `git add -A`, `git commit`, `git push` at the vault path — **this repository, on `alpha`** — sweeping any unrelated uncommitted state into that commit

And the evidence is hidden by design: `.gitignore`'s `ψ/` pattern matches at **any depth**, verified directly rather than assumed:

```
$ git check-ignore -v "arra-oracle-v3/ψ/memory/x.md"
.gitignore:47:ψ/	arra-oracle-v3/ψ/memory/x.md
```

So the copied tree never appears in `git status`. That is why this **throws** rather than warning.

`migrate.ts:112` has a superficially similar check, but it exists to *exclude* the vault repo from a migration source list — it does not detect this case.

## 2. `ORACLE_DB_PATH` bypassed the `:memory:` test guard

`src/db/index.ts` returned `':memory:'` under `NODE_ENV=test` — but only *after* an `ORACLE_DB_PATH` check that returns first:

```ts
const envPath = process.env.ORACLE_DB_PATH?.trim();
if (envPath) return envPath;                              // ← returns first
if (process.env.NODE_ENV === 'test') return ':memory:';   // ← never reached
```

Set that variable — as any shell running the server does — and every test importing the `db` singleton writes to live data.

**The cost is measured, not hypothetical.** `tests/http/health/stats.test.ts` was created **2026-06-16** (`e96e0412`); the `':memory:'` guard landed **2026-06-17** (`b1806554`) — one day later. In that window the test wrote `vault_repo = 'coverage-vault'` into the real database. Its `afterAll` restores whatever it read *at import time*, so once the fixture leaked, every later run read it back and faithfully restored it:

```
$ sqlite3 ~/.arra-oracle-v2/oracle.db "SELECT value FROM settings WHERE key='vault_repo';"
coverage-vault
```

`coverage-vault` is not a repo that exists — the string appears nowhere but that test file. **The vault has been inert for 40 days.** Nothing failed; nothing reported anything.

Temp paths stay allowed (many tests legitimately point `ORACLE_DB_PATH` at `mkdtemp`). Only the real data directory is refused. The comparison uses the `ORACLE_DATA_DIR` **constant**, never the env override — a test that redirects both variables to a temp dir is the safe case and must stay allowed. That was a false positive I caught before it shipped.

## Also: `handler.ts` 273 → 225

`planSync`/`sameFileContent` moved to `src/vault/sync-plan.ts`, where the guard lives with the plan it protects. The file drops **off** the file-size allow-list rather than staying grandfathered — the ratchet flagged its own stale baseline entry, which is the direction it should work.

## Gate

- `bunx tsc --noEmit` — exit 0
- `bun test --isolate tests/build/ tests/vault/ tests/db/` — **40 pass**
- Blast-radius sweep (every cluster that sets `ORACLE_DB_PATH`: indexer, config, tools, workers, http/vault, http/health) — **274 pass**
- **Mutation-checked**: neutering either guard turns **9 of 18** new assertions red. The 9 that stay green are the "allowed" cases, which is correct.

One combined run segfaulted (the known bun exit-133 class). I initially read that as caused by this change; three further runs with the changes in place were green, so that was a nondeterministic crash, not causation.

Refs #2856
