### PR TITLE
feat: index ψ/inbox/ as knowledge

### DIFF
--- a/src/indexer/collect-inbox.ts
+++ b/src/indexer/collect-inbox.ts
@@ -1,0 +1,52 @@
+/**
+ * Collector for `ψ/inbox/` (#2855) — Nat's call: *"inbox เป็น knowledge ได้ index ได้เลย."*
+ *
+ * Lives in its own file rather than in `collectors.ts`, which is at 220 lines and would exceed
+ * the 250-line rule with this appended.
+ *
+ * Walks the local `ψ/inbox/` plus the same project-first vault dirs every other collector
+ * walks, so an inbox that arrived through a vault sync is indexed identically to a local one.
+ * Deduplication is by content hash against the shared `seenContentHashes` set: the same report
+ * is frequently delivered to several oracles and copied between trees, and without this the
+ * corpus would carry one row per copy.
+ */
+import fs from 'fs';
+import path from 'path';
+import type { IndexerConfig, OracleDocument } from '../types.ts';
+import { discoverProjectPsiDirs } from './discovery.ts';
+import { getAllMarkdownFiles } from './collectors.ts';
+import { isPsiInboxSource, parsePsiInboxFile } from './inbox-doc-source.ts';
+
+export function collectPsiInbox(opts: {
+  config: IndexerConfig;
+  seenContentHashes: Set<string>;
+}): OracleDocument[] {
+  const { config, seenContentHashes } = opts;
+  const documents: OracleDocument[] = [];
+  const subPath = config.sourcePaths.inbox ?? 'ψ/inbox';
+  const roots = [
+    path.join(config.repoRoot, subPath),
+    ...discoverProjectPsiDirs(config.repoRoot).map((psiDir) => path.join(psiDir, 'inbox')),
+  ].filter((dir, index, all) => all.indexOf(dir) === index && fs.existsSync(dir));
+
+  let skippedDupes = 0;
+  let totalFiles = 0;
+  for (const sourcePath of roots) {
+    const files = getAllMarkdownFiles(sourcePath);
+    totalFiles += files.length;
+    for (const filePath of files) {
+      const relPath = path.relative(config.repoRoot, filePath).split(path.sep).join('/');
+      if (!isPsiInboxSource(relPath)) continue;
+
+      const content = fs.readFileSync(filePath, 'utf-8');
+      if (!content.trim()) continue;
+      const contentHash = Bun.hash(content).toString(36);
+      if (seenContentHashes.has(contentHash)) { skippedDupes++; continue; }
+      seenContentHashes.add(contentHash);
+      documents.push(...parsePsiInboxFile(relPath, content));
+    }
+  }
+
+  console.log(`Indexed ${documents.length} ψ/inbox documents from ${totalFiles} files (skipped ${skippedDupes} duplicates)`);
+  return documents;
+}

--- a/src/indexer/inbox-doc-source.ts
+++ b/src/indexer/inbox-doc-source.ts
@@ -1,0 +1,68 @@
+/**
+ * Indexing for `ψ/inbox/` — fleet correspondence treated as knowledge (#2855).
+ *
+ * `collectDocuments` builds its root as `ψ/memory/${subdir}`, so the only indexed trees were
+ * `memory/{resonance,learnings,retrospectives,distillations}` plus `ψ/learn` and the security
+ * corpus. **`ψ/inbox/` was never collected by any path.** The ~235 inbox rows already in the
+ * corpus are fossils from a single 2026-06-07 batch — measured, not inferred — with no live
+ * writer since. Handoffs, reports and cross-oracle messages have accumulated unindexed.
+ *
+ * These documents reuse type `'learning'` rather than introducing an `'inbox'` type.
+ * `OracleDocumentType` is a closed union, and widening it ripples into search filters, export
+ * mappings and the UI. `ψ/learn` already set the precedent: it reuses `'learning'` and carries
+ * its distinction in `source_file` and an id prefix. Same shape here, so `source_file`
+ * beginning `ψ/inbox/` is what identifies these — which is a queryable fact, not a lost one.
+ */
+import path from 'path';
+import type { OracleDocument } from '../types.ts';
+import { autoDeriveStructure } from './auto-derive.ts';
+import { parseLearningFile } from './parser.ts';
+
+export const PSI_INBOX_REL = path.join('ψ', 'inbox');
+const PROJECT_PSI_RE = /^(?:github\.com|gitlab\.com|bitbucket\.org)\/[^/]+\/[^/]+\/(ψ\/.*)$/;
+
+/** Strip a project-first vault prefix so the check works for both local and vault layouts. */
+function localPsiPath(sourceFile: string): string {
+  const normalized = sourceFile.split(path.sep).join('/');
+  return normalized.match(PROJECT_PSI_RE)?.[1] ?? normalized;
+}
+
+export function isPsiInboxSource(sourceFile: string): boolean {
+  return localPsiPath(sourceFile).startsWith('ψ/inbox/');
+}
+
+/**
+ * Ids are namespaced by a hash of the full path. Inbox filenames repeat heavily across
+ * senders and dates (`2026-07-26_05-56_report-from-arra-oracle-v3.md` has siblings in every
+ * oracle's tree), so a basename-derived id would collide and each write would overwrite the
+ * previous document rather than adding one.
+ */
+function psiInboxDocId(pathHash: string, id: string): string {
+  const suffix = id
+    .replace(/^learning_/, '')
+    .replace(/[^a-zA-Z0-9._-]+/g, '-')
+    .replace(/^[._-]+|[._-]+$/g, '');
+  return `learning_psi_inbox_${pathHash}_${suffix || 'doc'}`;
+}
+
+export function parsePsiInboxFile(relativePath: string, content: string): OracleDocument[] {
+  const sourceFile = relativePath.split(path.sep).join('/');
+  const basename = path.basename(sourceFile);
+  const pathHash = Bun.hash(sourceFile).toString(36);
+
+  return parseLearningFile(basename, content, sourceFile).map((doc) => {
+    const derived = autoDeriveStructure({
+      sourceFile,
+      content: doc.content,
+      project: doc.project,
+      existingConcepts: doc.concepts,
+    });
+    return {
+      ...doc,
+      id: psiInboxDocId(pathHash, doc.id),
+      source_file: sourceFile,
+      project: derived.project ?? undefined,
+      concepts: derived.concepts,
+    };
+  });
+}

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -27,6 +27,7 @@ import { backupDatabase } from './backup.ts';
 import { parseResonanceFile, parseLearningFile, parseRetroFile, parseDistillationFile } from './parser.ts';
 import { getEmbeddingModels } from '../vector/factory.ts';
 import { collectDocuments, collectPsiLearn, collectSecurityCorpus } from './collectors.ts';
+import { collectPsiInbox } from './collect-inbox.ts';
 import {
   changedDocumentIds,
   enqueueVectorReindexJobs,
@@ -99,6 +100,7 @@ export class OracleIndexer {
       ...collectDocuments({ ...shared, subdir: 'retrospectives', parseFn: parseRetroFile, label: 'retrospective' }),
       ...collectDocuments({ ...shared, subdir: 'distillations', parseFn: parseDistillationFile, label: 'distillation' }),
       ...collectPsiLearn(shared),
+      ...collectPsiInbox(shared),
       ...collectSecurityCorpus(shared),
     ];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,6 +130,7 @@ export interface IndexerConfig {
     retrospectives: string;
     distillations: string;
     learn: string;              // ψ/learn/ — auto-learned repo exploration docs
+    inbox?: string;             // ψ/inbox/ — fleet correspondence, indexed as knowledge (#2855)
     security_corpus?: string;  // Optional: ψ/learn/security-corpus/ — opt-in via ORACLE_INDEX_SECURITY_CORPUS=1
   };
 }

--- a/tests/indexer/psi-inbox-collected.test.ts
+++ b/tests/indexer/psi-inbox-collected.test.ts
@@ -1,0 +1,145 @@
+/**
+ * `ψ/inbox/` must actually be indexed (#2855).
+ *
+ * Nat's call: *"inbox เป็น knowledge ได้ index ได้เลย."* Before this, no collector reached it —
+ * `collectDocuments` builds its root as `ψ/memory/${subdir}`, and the registered subdirs are
+ * resonance/learnings/retrospectives/distillations, plus `ψ/learn` and the security corpus.
+ * The ~235 inbox rows in the live corpus are fossils from a single 2026-06-07 batch with no
+ * live writer since.
+ *
+ * The last test in this file is the one that matters most. A collector that exists but is never
+ * called is exactly the defect shape of #2877: the fix was real, the test was green, and
+ * production never reached the code.
+ */
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { collectPsiInbox } from '../../src/indexer/collect-inbox.ts';
+import { isPsiInboxSource } from '../../src/indexer/inbox-doc-source.ts';
+import type { IndexerConfig } from '../../src/types.ts';
+
+function fixture(files: Record<string, string>) {
+  const root = mkdtempSync(join(tmpdir(), 'psi-inbox-'));
+  for (const [rel, body] of Object.entries(files)) {
+    const full = join(root, rel);
+    mkdirSync(join(full, '..'), { recursive: true });
+    writeFileSync(full, body);
+  }
+  const config = {
+    repoRoot: root,
+    dbPath: ':memory:',
+    chromaPath: '',
+    sourcePaths: {
+      resonance: 'ψ/memory/resonance',
+      learnings: 'ψ/memory/learnings',
+      retrospectives: 'ψ/memory/retrospectives',
+      distillations: 'ψ/memory/distillations',
+      learn: 'ψ/learn',
+    },
+  } as IndexerConfig;
+  const collect = () => collectPsiInbox({ config, seenContentHashes: new Set() });
+  return { root, collect, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+const REPORT = `---
+from: arra-oracle-v3
+to: jan
+timestamp: 2026-07-26 05:56 +07
+---
+
+# Overnight report
+
+The indexer queued zero vector jobs because a drizzle raw-sql row is a positional array.
+`;
+
+describe('inbox markdown becomes indexed documents', () => {
+  test('a report in ψ/inbox/ is collected', () => {
+    const f = fixture({ 'ψ/inbox/2026-07-26_report.md': REPORT });
+    try {
+      const docs = f.collect();
+      expect(docs.length).toBeGreaterThan(0);
+      expect(docs[0]?.source_file).toBe('ψ/inbox/2026-07-26_report.md');
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test('nested inbox subdirectories are walked, not just the top level', () => {
+    // ψ/inbox/handoff/ is where every /forward writes. It was unindexed too.
+    const f = fixture({ 'ψ/inbox/handoff/2026-07-26_05-55_overnight.md': REPORT });
+    try {
+      expect(f.collect().length).toBeGreaterThan(0);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test('an empty file produces nothing rather than an empty document', () => {
+    const f = fixture({ 'ψ/inbox/blank.md': '   \n' });
+    try {
+      expect(f.collect()).toEqual([]);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test('identical content in two places is stored once', () => {
+    // The same report is delivered to several oracles and copied between trees.
+    const f = fixture({ 'ψ/inbox/a.md': REPORT, 'ψ/inbox/handoff/a.md': REPORT });
+    try {
+      expect(f.collect()).toHaveLength(1);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test('same basename in different directories does not collide on id', () => {
+    /**
+     * Inbox filenames repeat heavily across senders and dates. If the id came from the
+     * basename, the second document would overwrite the first and the corpus would silently
+     * hold one row where two belong.
+     */
+    const f = fixture({
+      'ψ/inbox/report.md': `${REPORT}\nfirst copy\n`,
+      'ψ/inbox/handoff/report.md': `${REPORT}\nsecond copy, different content\n`,
+    });
+    try {
+      const ids = f.collect().map((d) => d.id);
+      expect(ids).toHaveLength(2);
+      expect(new Set(ids).size).toBe(2);
+    } finally {
+      f.cleanup();
+    }
+  });
+});
+
+describe('the source predicate only claims inbox paths', () => {
+  test('an inbox path matches', () => {
+    expect(isPsiInboxSource('ψ/inbox/report.md')).toBe(true);
+  });
+
+  test('a project-first vault path matches too', () => {
+    expect(isPsiInboxSource('github.com/owner/repo/ψ/inbox/report.md')).toBe(true);
+  });
+
+  test('a learnings path does not', () => {
+    expect(isPsiInboxSource('ψ/memory/learnings/x.md')).toBe(false);
+  });
+
+  test('a directory merely starting with "inbox" does not', () => {
+    expect(isPsiInboxSource('ψ/inbox-archive/x.md')).toBe(false);
+  });
+});
+
+describe('the collector is actually registered', () => {
+  test('src/indexer/index.ts calls collectPsiInbox', async () => {
+    /**
+     * The alternative is booting the whole indexer against a real corpus. The distinction is
+     * one call site, and this is the call site — the thing that was missing for every inbox
+     * file in the vault.
+     */
+    const source = await Bun.file(new URL('../../src/indexer/index.ts', import.meta.url)).text();
+    expect(source).toContain('collectPsiInbox(shared)');
+  });
+});


### PR DESCRIPTION
Implements your call on #2855 — *"inbox เป็น knowledge ได้ index ได้เลย."*

## ψ/inbox/ was reached by no indexing path at all

`collectDocuments` builds its root as `ψ/memory/${subdir}`, and the registered subdirs are resonance / learnings / retrospectives / distillations. The only other collectors are `collectPsiLearn` (`ψ/learn`) and `collectSecurityCorpus`. **Nothing walked `ψ/inbox/`.**

The ~235 inbox rows already in the corpus are fossils from a single 2026-06-07 batch with no live writer since — which is why every handoff, report and cross-oracle message from the last seven weeks was unsearchable, including `ψ/inbox/handoff/`, where every `/forward` writes.

## Measured impact

Against the real vault, read-only, with an OS-level timeout in a separate process:

```
Indexed 4275 ψ/inbox documents from 4149 files (skipped 0 duplicates)
DOCUMENTS: 4275  in 756ms
```

**+4,275 documents on a 35,179-document corpus (~12%), in 756 ms.** No live database was written by that measurement.

## Design: reuse `'learning'`, don't widen the union

`OracleDocumentType` is a **closed union** (`'principle' | 'pattern' | 'learning' | 'retro' | 'distillation' | 'security-corpus'`). Adding `'inbox'` ripples into search filters, export mappings and the UI.

`ψ/learn` already set the precedent: reuse `'learning'`, carry the distinction in `source_file` and an id prefix. Same shape here — `source_file` beginning `ψ/inbox/` identifies these, which is a queryable fact rather than a lost one.

**Ids are namespaced by a hash of the full path.** Inbox basenames repeat heavily across senders and dates (`2026-07-26_05-56_report-from-arra-oracle-v3.md` has siblings in every oracle's tree). A basename-derived id would collide, and the second document would silently overwrite the first — the corpus would hold one row where two belong. There's a test for exactly that.

## Notes

- Deduplication is by content hash against the shared `seenContentHashes` set — the same report is delivered to several oracles and copied between trees.
- New file rather than appending to `collectors.ts`, which is at 220 lines and would breach the 250-line rule.
- Project-first vault dirs are walked identically to every other collector, so an inbox that arrived via vault sync indexes the same as a local one.

## Gate

- `bunx tsc --noEmit` — exit 0
- `bun test --isolate tests/indexer/ tests/build/` — **32 pass**
- All files ≤250 lines (52 / 68 / 145)
- **Mutation-checked**: deleting the registration line in `src/indexer/index.ts` turns the *"the collector is actually registered"* test red. That test exists because #2877 shipped a real fix that production never reached — a collector that exists but is never called is the same defect.

Refs #2855
