### PR TITLE
feat: Fleet Log read routes — GET /api/fleet-log/search and /thread/:key

### DIFF
--- a/src/routes/fleet-log/filters.ts
+++ b/src/routes/fleet-log/filters.ts
@@ -1,0 +1,104 @@
+/**
+ * Query-parameter parsing for the Fleet Log read routes (#2879).
+ *
+ * The contract is not invented here — `frontend/src/pages/fleetLogMock.ts` already declares it:
+ *
+ *   GET /api/fleet-log/search?query=&channel=&from=&to=&since=&until=
+ *
+ * and `FleetLogFilters` shows what those names mean. `from`/`to` are **sender and recipient**
+ * (`from_id` / `to_id`), not a time range — `since`/`until` are the window. Reading them as a
+ * date range would have produced an endpoint that matched the string and not the intent.
+ *
+ * **Unknown filter values are a 400, never a silent pass-through.** A filter that quietly
+ * matches everything when it does not understand its input is the defect shape this repo spent
+ * the night removing: a stage does nothing while the pipeline reports success (#2857, #2863,
+ * #2877, #2880). A typo'd channel returning the whole corpus looks exactly like a working
+ * search.
+ */
+import { and, eq, gte, inArray, like, lte, type SQL } from 'drizzle-orm';
+import { fleetMessages } from '../../db/fleet-log-schema.ts';
+
+/** Mirrors FLEET_CHANNELS in frontend/src/pages/fleetLogMock.ts. */
+export const FLEET_CHANNELS = ['maw', 'vault', 'webhook', 'discord', 'agent-team', 'git'] as const;
+export type FleetChannel = typeof FLEET_CHANNELS[number];
+
+export const DEFAULT_LIMIT = 50;
+export const MAX_LIMIT = 200;
+
+export class FleetFilterError extends Error {}
+
+export interface FleetSearchQuery {
+  query?: string;
+  channel?: string;
+  from?: string;
+  to?: string;
+  since?: string;
+  until?: string;
+  limit?: string;
+  offset?: string;
+}
+
+/** Accepts epoch milliseconds or anything `Date` parses, including the `YYYY-MM-DD` a date input sends. */
+export function parseTimestamp(raw: string, field: string): number {
+  const trimmed = raw.trim();
+  if (/^\d+$/.test(trimmed)) return Number(trimmed);
+  const parsed = Date.parse(trimmed);
+  if (Number.isNaN(parsed)) {
+    throw new FleetFilterError(`${field} must be epoch milliseconds or a parseable date, got "${raw}"`);
+  }
+  return parsed;
+}
+
+/** Comma-separated, because the frontend holds `channels: FleetChannel[]`. */
+export function parseChannels(raw: string): FleetChannel[] {
+  const parts = raw.split(',').map((p) => p.trim()).filter(Boolean);
+  const unknown = parts.filter((p) => !FLEET_CHANNELS.includes(p as FleetChannel));
+  if (unknown.length > 0) {
+    throw new FleetFilterError(
+      `unknown channel(s): ${unknown.join(', ')}. Known channels: ${FLEET_CHANNELS.join(', ')}`,
+    );
+  }
+  return parts as FleetChannel[];
+}
+
+export function parsePagination(query: FleetSearchQuery): { limit: number; offset: number } {
+  const limitRaw = query.limit?.trim();
+  const offsetRaw = query.offset?.trim();
+  const limit = limitRaw ? Number(limitRaw) : DEFAULT_LIMIT;
+  const offset = offsetRaw ? Number(offsetRaw) : 0;
+  if (!Number.isInteger(limit) || limit < 1) throw new FleetFilterError(`limit must be a positive integer, got "${limitRaw}"`);
+  if (!Number.isInteger(offset) || offset < 0) throw new FleetFilterError(`offset must be a non-negative integer, got "${offsetRaw}"`);
+  // Capped rather than rejected: a client asking for too much gets the most it may have.
+  return { limit: Math.min(limit, MAX_LIMIT), offset };
+}
+
+/** `%` and `_` are LIKE wildcards; a user searching for "100%" means the literal characters. */
+export function escapeLikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}
+
+/**
+ * Build the WHERE clause. `tenantId` is always applied — it is not optional and not derived
+ * from user input, so one tenant can never read another's messages.
+ */
+export function buildFleetWhere(tenantId: string, query: FleetSearchQuery): SQL | undefined {
+  const conditions: SQL[] = [eq(fleetMessages.tenantId, tenantId)];
+
+  const text = query.query?.trim();
+  if (text) conditions.push(like(fleetMessages.text, `%${escapeLikePattern(text)}%`));
+
+  const channels = query.channel?.trim() ? parseChannels(query.channel) : [];
+  if (channels.length > 0) conditions.push(inArray(fleetMessages.channel, channels));
+
+  const from = query.from?.trim();
+  if (from) conditions.push(eq(fleetMessages.fromId, from));
+  const to = query.to?.trim();
+  if (to) conditions.push(eq(fleetMessages.toId, to));
+
+  const since = query.since?.trim();
+  if (since) conditions.push(gte(fleetMessages.ts, parseTimestamp(since, 'since')));
+  const until = query.until?.trim();
+  if (until) conditions.push(lte(fleetMessages.ts, parseTimestamp(until, 'until')));
+
+  return and(...conditions);
+}

--- a/src/routes/fleet-log/index.ts
+++ b/src/routes/fleet-log/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Fleet Log read routes (Elysia) — /api/fleet-log/search, /api/fleet-log/thread/:key
+ *
+ * #2871 landed `fleet_messages` + `fleet_ingest_cursor` and the vault ingest; these are the two
+ * read routes the frontend has been declaring in `fleetLogMock.ts` while rendering fixtures.
+ *
+ * Whether an oracle's own correspondence is searchable knowledge was the open question that
+ * kept this filed rather than built. #2855 answered it — inbox is knowledge and is indexed —
+ * and fleet messages are the same category of data, so they answer it the same way.
+ */
+import { Elysia } from 'elysia';
+import { createFleetLogSearchEndpoint } from './search.ts';
+import { createFleetLogThreadEndpoint } from './thread.ts';
+
+export function createFleetLogRoutes() {
+  return new Elysia({ prefix: '/api' })
+    .use(createFleetLogSearchEndpoint())
+    .use(createFleetLogThreadEndpoint());
+}

--- a/src/routes/fleet-log/message-schema.ts
+++ b/src/routes/fleet-log/message-schema.ts
@@ -1,0 +1,24 @@
+/**
+ * The wire shape of a fleet message, matching `FleetMessage` in
+ * `frontend/src/pages/fleetLogMock.ts` field for field — the mock is the contract, and the
+ * frontend swaps its fixture for a real fetch without changing its types.
+ */
+import { t } from 'elysia';
+
+export function fleetMessageSchema() {
+  return t.Object({
+    id: t.String(),
+    tenantId: t.String(),
+    channel: t.String(),
+    source: t.Nullable(t.String()),
+    direction: t.Nullable(t.String()),
+    fromId: t.Nullable(t.String()),
+    toId: t.Nullable(t.String()),
+    threadKey: t.Nullable(t.String()),
+    text: t.Nullable(t.String()),
+    raw: t.Nullable(t.String()),
+    rawPath: t.Nullable(t.String()),
+    ts: t.Number(),
+    ingestedAt: t.Number(),
+  });
+}

--- a/src/routes/fleet-log/search.ts
+++ b/src/routes/fleet-log/search.ts
@@ -1,0 +1,90 @@
+/**
+ * `GET /api/fleet-log/search` (#2879).
+ *
+ * Matches the string `frontend/src/pages/fleetLogMock.ts` has been declaring while the page
+ * rendered fixtures:
+ *
+ *   GET /api/fleet-log/search?query=&channel=&from=&to=&since=&until=
+ *
+ * Ordered newest-first, which is what a log console wants and what
+ * `idx_fleet_msg_tenant_ts` is built for.
+ */
+import { Elysia, t } from 'elysia';
+import { desc, sql } from 'drizzle-orm';
+import { db } from '../../db/index.ts';
+import { fleetMessages } from '../../db/fleet-log-schema.ts';
+import { activeTenantId } from '../../middleware/tenant.ts';
+import {
+  buildFleetWhere,
+  FleetFilterError,
+  parsePagination,
+  type FleetSearchQuery,
+} from './filters.ts';
+import { fleetMessageSchema } from './message-schema.ts';
+
+export function createFleetLogSearchEndpoint() {
+  return new Elysia().get(
+    '/fleet-log/search',
+    ({ query, set }) => {
+      const tenantId = activeTenantId();
+      let where;
+      let page;
+      try {
+        where = buildFleetWhere(tenantId, query as FleetSearchQuery);
+        page = parsePagination(query as FleetSearchQuery);
+      } catch (err) {
+        if (!(err instanceof FleetFilterError)) throw err;
+        // A rejected filter is the point — see the note in filters.ts about silent pass-through.
+        set.status = 400;
+        return { success: false, error: err.message };
+      }
+
+      const rows = db
+        .select()
+        .from(fleetMessages)
+        .where(where)
+        .orderBy(desc(fleetMessages.ts))
+        .limit(page.limit)
+        .offset(page.offset)
+        .all();
+
+      const counted = db
+        .select({ total: sql<number>`count(*)` })
+        .from(fleetMessages)
+        .where(where)
+        .get();
+
+      return {
+        success: true,
+        data: {
+          messages: rows,
+          total: Number(counted?.total ?? 0),
+          limit: page.limit,
+          offset: page.offset,
+        },
+      };
+    },
+    {
+      query: t.Object({
+        query: t.Optional(t.String()),
+        channel: t.Optional(t.String()),
+        from: t.Optional(t.String()),
+        to: t.Optional(t.String()),
+        since: t.Optional(t.String()),
+        until: t.Optional(t.String()),
+        limit: t.Optional(t.String()),
+        offset: t.Optional(t.String()),
+      }),
+      response: t.Object({
+        success: t.Boolean(),
+        error: t.Optional(t.String()),
+        data: t.Optional(t.Object({
+          messages: t.Array(fleetMessageSchema()),
+          total: t.Number(),
+          limit: t.Number(),
+          offset: t.Number(),
+        })),
+      }),
+    },
+  );
+}

--- a/src/routes/fleet-log/thread.ts
+++ b/src/routes/fleet-log/thread.ts
@@ -1,0 +1,46 @@
+/**
+ * `GET /api/fleet-log/thread/:key` (#2879).
+ *
+ * A separate endpoint rather than a `search` filter, because that is what
+ * `FLEET_THREAD_CONTRACT` declares and because the ordering differs: a thread reads oldest-first
+ * as a conversation, while search reads newest-first as a log.
+ *
+ * `thread_key` is a heuristic grouping and explicitly NOT a foreign key (see
+ * `src/db/fleet-log-schema.ts:11`), so an unknown key is an empty thread, not a 404 — the same
+ * answer as a thread whose messages have not been ingested yet.
+ */
+import { Elysia, t } from 'elysia';
+import { and, asc, eq } from 'drizzle-orm';
+import { db } from '../../db/index.ts';
+import { fleetMessages } from '../../db/fleet-log-schema.ts';
+import { activeTenantId } from '../../middleware/tenant.ts';
+import { fleetMessageSchema } from './message-schema.ts';
+
+export function createFleetLogThreadEndpoint() {
+  return new Elysia().get(
+    '/fleet-log/thread/:key',
+    ({ params }) => {
+      const tenantId = activeTenantId();
+      const rows = db
+        .select()
+        .from(fleetMessages)
+        .where(and(eq(fleetMessages.tenantId, tenantId), eq(fleetMessages.threadKey, params.key)))
+        .orderBy(asc(fleetMessages.ts))
+        .all();
+
+      return { success: true, data: { key: params.key, messages: rows, total: rows.length } };
+    },
+    {
+      params: t.Object({ key: t.String() }),
+      response: t.Object({
+        success: t.Boolean(),
+        error: t.Optional(t.String()),
+        data: t.Optional(t.Object({
+          key: t.String(),
+          messages: t.Array(fleetMessageSchema()),
+          total: t.Number(),
+        })),
+      }),
+    },
+  );
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -45,6 +45,7 @@ import { authRoutes } from './routes/auth/index.ts';
 import { settingsRoutes } from './routes/settings/index.ts';
 import { feedRoutes } from './routes/feed/index.ts';
 import { createHealthRoutes } from './routes/health/index.ts';
+import { createFleetLogRoutes } from './routes/fleet-log/index.ts';
 import { dashboardRoutes } from './routes/dashboard/index.ts';
 import { searchRoutes } from './routes/search/index.ts';
 import { askRoutes } from './routes/ask/index.ts';
@@ -184,7 +185,7 @@ export function createApp({ unifiedPlugins, runtimeRef = createUnifiedRuntimeRef
 
 export function createServerRouteModules(unifiedPlugins: UnifiedRuntime, runtimeRef: UnifiedRuntimeRef<UnifiedRuntime>): RouteModule[] {
   const healthRoutes = createHealthRoutes({ pluginCount: unifiedPlugins.pluginCount, pluginMcpToolCount: unifiedPlugins.mcpTools.length, pluginStatuses: unifiedPlugins.pluginStatuses, isDraining });
-  const apiModules = [authRoutes, settingsRoutes, feedRoutes, healthRoutes, dashboardRoutes, searchRoutes, askRoutes, vectorRoutes, vectorConfigApiRoutes, conceptsRoutes, knowledgeRoutes, researchRoutes, verifyRoutes, supersedeRoutes, forumApi, tracesApi, scheduleApi, filesRouter, createPluginsRouter({ registry: () => runtimeRef.current.pluginRegistry(), runtimeRef }), sessionsRoutes, oldStudioCompatRoutes, vaultRoutes, metricsRoutes, exportRoutes, memoryRoutes, canvasRoutes, tenantsRoutes, watcherRoutes, indexerRoutes];
+  const apiModules = [authRoutes, settingsRoutes, feedRoutes, healthRoutes, dashboardRoutes, searchRoutes, askRoutes, vectorRoutes, vectorConfigApiRoutes, conceptsRoutes, knowledgeRoutes, researchRoutes, verifyRoutes, supersedeRoutes, forumApi, tracesApi, scheduleApi, filesRouter, createPluginsRouter({ registry: () => runtimeRef.current.pluginRegistry(), runtimeRef }), sessionsRoutes, oldStudioCompatRoutes, vaultRoutes, metricsRoutes, exportRoutes, memoryRoutes, canvasRoutes, tenantsRoutes, watcherRoutes, indexerRoutes, createFleetLogRoutes()];
   return [...apiModules, createMcpRoutes({ runtimeRef }), createMcpStreamableRoutes(), createMenuRoutes(menuItemsFromUnifiedPlugins(unifiedPlugins.menu))];
 }
 

--- a/tests/http/fleet-log/contract-matches-frontend.test.ts
+++ b/tests/http/fleet-log/contract-matches-frontend.test.ts
@@ -1,0 +1,78 @@
+/**
+ * The routes must match the contract strings the frontend declares (#2879, acceptance criterion 1).
+ *
+ * `frontend/src/pages/fleetLogMock.ts` is the source of truth here: it declared
+ * `FLEET_SEARCH_CONTRACT` and `FLEET_THREAD_CONTRACT` while the page rendered fixtures, and the
+ * page told users so, visibly. That was the correct handling of a mocked surface — the value
+ * only survives if the contract and the routes cannot drift apart afterwards.
+ *
+ * This guard is deliberately mechanical. It compares the declared path and parameter names
+ * against the implementation, so renaming a query parameter on either side fails here rather
+ * than becoming a filter that silently never matches.
+ */
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = join(import.meta.dir, '..', '..', '..');
+const MOCK = readFileSync(join(ROOT, 'frontend/src/pages/fleetLogMock.ts'), 'utf-8');
+const SEARCH = readFileSync(join(ROOT, 'src/routes/fleet-log/search.ts'), 'utf-8');
+const THREAD = readFileSync(join(ROOT, 'src/routes/fleet-log/thread.ts'), 'utf-8');
+const FILTERS = readFileSync(join(ROOT, 'src/routes/fleet-log/filters.ts'), 'utf-8');
+
+function declaredContract(name: string): string {
+  const match = MOCK.match(new RegExp(`${name} = '([^']+)'`));
+  if (!match) throw new Error(`${name} not found in fleetLogMock.ts`);
+  return match[1]!;
+}
+
+describe('the declared contracts still exist in the frontend', () => {
+  test('both contract constants are present', () => {
+    expect(declaredContract('FLEET_SEARCH_CONTRACT')).toContain('/api/fleet-log/search');
+    expect(declaredContract('FLEET_THREAD_CONTRACT')).toContain('/api/fleet-log/thread/:key');
+  });
+});
+
+describe('the routes implement those exact paths', () => {
+  test('search is registered at the declared path', () => {
+    // The cluster mounts with prefix '/api', so the route declares the remainder.
+    expect(SEARCH).toContain("'/fleet-log/search'");
+  });
+
+  test('thread is registered at the declared path, with :key', () => {
+    expect(THREAD).toContain("'/fleet-log/thread/:key'");
+  });
+});
+
+describe('every declared query parameter is actually read', () => {
+  const params = declaredContract('FLEET_SEARCH_CONTRACT')
+    .split('?')[1]!
+    .split('&')
+    .map((pair) => pair.split('=')[0]!)
+    .filter(Boolean);
+
+  test('the contract declares the six documented parameters', () => {
+    expect(params).toEqual(['query', 'channel', 'from', 'to', 'since', 'until']);
+  });
+
+  for (const param of ['query', 'channel', 'from', 'to', 'since', 'until']) {
+    test(`"${param}" is accepted by the route and used by the filter builder`, () => {
+      // Accepted in the Elysia query schema...
+      expect(SEARCH).toContain(`${param}: t.Optional(t.String())`);
+      // ...and actually consumed, not merely declared. A parameter that is parsed and then
+      // dropped is the #2877 shape: real-looking code that changes nothing.
+      expect(FILTERS).toContain(`query.${param}`);
+    });
+  }
+});
+
+describe('the channel list matches the frontend', () => {
+  test('FLEET_CHANNELS is identical on both sides', () => {
+    const extract = (src: string) => {
+      const raw = src.match(/FLEET_CHANNELS = \[([^\]]+)\]/)![1]!;
+      return raw.split(',').map((s) => s.trim().replace(/^'|'$/g, '')).filter(Boolean);
+    };
+    // A channel accepted by one side and rejected by the other is a 400 the user cannot explain.
+    expect(extract(FILTERS)).toEqual(extract(MOCK));
+  });
+});

--- a/tests/http/fleet-log/search.test.ts
+++ b/tests/http/fleet-log/search.test.ts
@@ -1,0 +1,156 @@
+/**
+ * `GET /api/fleet-log/search` must satisfy the contract the frontend already declares (#2879).
+ *
+ * `frontend/src/pages/fleetLogMock.ts` has held `FLEET_SEARCH_CONTRACT` while the page rendered
+ * fixtures. These tests read `from`/`to` as sender/recipient and `since`/`until` as the time
+ * window, which is what `FleetLogFilters` means — reading them as a date range would produce an
+ * endpoint that matched the string and not the intent.
+ *
+ * The 400 tests are the ones worth keeping. A filter that silently matches everything when it
+ * does not understand its input is this repo's dominant defect shape (#2857, #2863, #2877,
+ * #2880): a stage does nothing while the pipeline reports success.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { db, resetDefaultDatabaseForTests, sqlite } from '../../../src/db/index.ts';
+
+resetDefaultDatabaseForTests();
+import { fleetMessages } from '../../../src/db/fleet-log-schema.ts';
+import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
+import { createFleetLogRoutes } from '../../../src/routes/fleet-log/index.ts';
+
+const stamp = `${Date.now()}`;
+const TENANT = `fleet-search-${stamp}`;
+const T0 = 1_750_000_000_000;
+
+function search(tenantId: string, qs: string) {
+  return createTenantFetch((request) => createFleetLogRoutes().handle(request))(
+    new Request(`http://local/api/fleet-log/search${qs}`, { headers: { [TENANT_HEADER]: tenantId } }),
+  );
+}
+
+async function body(res: Response) {
+  return (await res.json()) as { success: boolean; error?: string; data?: { messages: Array<Record<string, unknown>>; total: number; limit: number; offset: number } };
+}
+
+const ROWS = [
+  { id: `${stamp}-1`, channel: 'maw', fromId: 'claude48', toId: 'm5:arra-oracle-v3', threadKey: 'th-1', text: 'the indexer queued zero vector jobs', ts: T0 },
+  { id: `${stamp}-2`, channel: 'vault', fromId: 'digger', toId: 'm5:digger', threadKey: 'th-1', text: 'keep rawPath and threadKey approximate', ts: T0 + 1000 },
+  { id: `${stamp}-3`, channel: 'discord', fromId: 'atlas', toId: 'jan', threadKey: 'th-2', text: 'unrelated chatter', ts: T0 + 2000 },
+];
+
+beforeAll(() => {
+  for (const row of ROWS) {
+    db.insert(fleetMessages).values({ ...row, tenantId: TENANT, ingestedAt: T0 }).run();
+  }
+});
+
+afterAll(() => {
+  for (const row of ROWS) db.delete(fleetMessages).where(eq(fleetMessages.id, row.id)).run();
+  sqlite.prepare('DELETE FROM fleet_messages WHERE tenant_id = ?').run(TENANT);
+});
+
+describe('the route exists and answers the declared contract', () => {
+  test('an unfiltered search returns this tenant messages, newest first', async () => {
+    const res = await search(TENANT, '');
+    expect(res.status).toBe(200);
+    const json = await body(res);
+    expect(json.success).toBe(true);
+    expect(json.data?.total).toBe(3);
+    // Newest-first is what a log console wants, and what idx_fleet_msg_tenant_ts serves.
+    expect(json.data?.messages.map((m) => m.id)).toEqual([`${stamp}-3`, `${stamp}-2`, `${stamp}-1`]);
+  });
+
+  test('query matches message text', async () => {
+    const json = await body(await search(TENANT, '?query=vector%20jobs'));
+    expect(json.data?.messages.map((m) => m.id)).toEqual([`${stamp}-1`]);
+  });
+
+  test('channel filters, and accepts several', async () => {
+    const one = await body(await search(TENANT, '?channel=vault'));
+    expect(one.data?.messages.map((m) => m.id)).toEqual([`${stamp}-2`]);
+
+    const two = await body(await search(TENANT, '?channel=vault,discord'));
+    expect(two.data?.total).toBe(2);
+  });
+
+  test('from and to are sender and recipient, not a date range', async () => {
+    // The single most likely misreading of the contract string.
+    const from = await body(await search(TENANT, '?from=digger'));
+    expect(from.data?.messages.map((m) => m.id)).toEqual([`${stamp}-2`]);
+
+    const to = await body(await search(TENANT, '?to=jan'));
+    expect(to.data?.messages.map((m) => m.id)).toEqual([`${stamp}-3`]);
+  });
+
+  test('since and until bound the time window, inclusive', async () => {
+    const json = await body(await search(TENANT, `?since=${T0 + 1000}&until=${T0 + 2000}`));
+    expect(json.data?.total).toBe(2);
+  });
+
+  test('since accepts an ISO date, which is what a date input sends', async () => {
+    const json = await body(await search(TENANT, '?since=2000-01-01'));
+    expect(json.data?.total).toBe(3);
+  });
+});
+
+describe('an unusable filter is a 400, never a silent match-everything', () => {
+  test('an unknown channel is rejected and names the known ones', async () => {
+    const res = await search(TENANT, '?channel=slack');
+    expect(res.status).toBe(400);
+    const json = await body(res);
+    expect(json.success).toBe(false);
+    expect(json.error).toContain('slack');
+    expect(json.error).toContain('maw');
+  });
+
+  test('one bad channel in a list rejects the whole request', async () => {
+    // Otherwise a typo silently widens the result set.
+    expect((await search(TENANT, '?channel=vault,slack')).status).toBe(400);
+  });
+
+  test('an unparseable since is rejected', async () => {
+    const res = await search(TENANT, '?since=not-a-date');
+    expect(res.status).toBe(400);
+    expect((await body(res)).error).toContain('since');
+  });
+
+  test('a negative offset is rejected', async () => {
+    expect((await search(TENANT, '?offset=-1')).status).toBe(400);
+  });
+
+  test('a zero limit is rejected rather than returning everything', async () => {
+    expect((await search(TENANT, '?limit=0')).status).toBe(400);
+  });
+});
+
+describe('pagination', () => {
+  test('limit and offset page through the results', async () => {
+    const first = await body(await search(TENANT, '?limit=2&offset=0'));
+    expect(first.data?.messages).toHaveLength(2);
+    expect(first.data?.total).toBe(3);
+
+    const second = await body(await search(TENANT, '?limit=2&offset=2'));
+    expect(second.data?.messages).toHaveLength(1);
+    // total is the unpaginated count, so a client can render "3 results".
+    expect(second.data?.total).toBe(3);
+  });
+
+  test('an oversized limit is capped, not rejected', async () => {
+    const json = await body(await search(TENANT, '?limit=100000'));
+    expect(json.data?.limit).toBe(200);
+  });
+});
+
+describe('tenant isolation', () => {
+  test('a second tenant cannot read the first tenant messages', async () => {
+    const other = await body(await search(`other-${stamp}`, ''));
+    expect(other.data?.total).toBe(0);
+    expect(other.data?.messages).toEqual([]);
+  });
+
+  test('a text query cannot reach across tenants either', async () => {
+    const other = await body(await search(`other-${stamp}`, '?query=vector%20jobs'));
+    expect(other.data?.messages).toEqual([]);
+  });
+});

--- a/tests/http/fleet-log/search.test.ts
+++ b/tests/http/fleet-log/search.test.ts
@@ -12,9 +12,7 @@
  */
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { eq } from 'drizzle-orm';
-import { db, resetDefaultDatabaseForTests, sqlite } from '../../../src/db/index.ts';
-
-resetDefaultDatabaseForTests();
+import { db } from '../../../src/db/index.ts';
 import { fleetMessages } from '../../../src/db/fleet-log-schema.ts';
 import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
 import { createFleetLogRoutes } from '../../../src/routes/fleet-log/index.ts';
@@ -47,7 +45,6 @@ beforeAll(() => {
 
 afterAll(() => {
   for (const row of ROWS) db.delete(fleetMessages).where(eq(fleetMessages.id, row.id)).run();
-  sqlite.prepare('DELETE FROM fleet_messages WHERE tenant_id = ?').run(TENANT);
 });
 
 describe('the route exists and answers the declared contract', () => {

--- a/tests/http/fleet-log/thread.test.ts
+++ b/tests/http/fleet-log/thread.test.ts
@@ -8,9 +8,7 @@
  */
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { eq } from 'drizzle-orm';
-import { db, resetDefaultDatabaseForTests, sqlite } from '../../../src/db/index.ts';
-
-resetDefaultDatabaseForTests();
+import { db } from '../../../src/db/index.ts';
 import { fleetMessages } from '../../../src/db/fleet-log-schema.ts';
 import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
 import { createFleetLogRoutes } from '../../../src/routes/fleet-log/index.ts';
@@ -45,7 +43,6 @@ beforeAll(() => {
 
 afterAll(() => {
   for (const row of ROWS) db.delete(fleetMessages).where(eq(fleetMessages.id, row.id)).run();
-  sqlite.prepare('DELETE FROM fleet_messages WHERE tenant_id = ?').run(TENANT);
 });
 
 describe('a thread reads as a conversation', () => {

--- a/tests/http/fleet-log/thread.test.ts
+++ b/tests/http/fleet-log/thread.test.ts
@@ -1,0 +1,93 @@
+/**
+ * `GET /api/fleet-log/thread/:key` (#2879).
+ *
+ * A separate endpoint rather than a `search` filter, because that is what
+ * `FLEET_THREAD_CONTRACT` declares and because the ordering genuinely differs: a thread reads
+ * oldest-first as a conversation, search reads newest-first as a log. Those two orderings are
+ * the reason this is not just a query parameter, so both are pinned here.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { db, resetDefaultDatabaseForTests, sqlite } from '../../../src/db/index.ts';
+
+resetDefaultDatabaseForTests();
+import { fleetMessages } from '../../../src/db/fleet-log-schema.ts';
+import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
+import { createFleetLogRoutes } from '../../../src/routes/fleet-log/index.ts';
+
+const stamp = `${Date.now()}`;
+const TENANT = `fleet-thread-${stamp}`;
+const T0 = 1_750_000_000_000;
+
+function thread(tenantId: string, key: string) {
+  return createTenantFetch((request) => createFleetLogRoutes().handle(request))(
+    new Request(`http://local/api/fleet-log/thread/${encodeURIComponent(key)}`, {
+      headers: { [TENANT_HEADER]: tenantId },
+    }),
+  );
+}
+
+async function body(res: Response) {
+  return (await res.json()) as { success: boolean; data?: { key: string; messages: Array<Record<string, unknown>>; total: number } };
+}
+
+const KEY = `thread-${stamp}`;
+const ROWS = [
+  { id: `${stamp}-b`, channel: 'maw', threadKey: KEY, text: 'second', ts: T0 + 2000 },
+  { id: `${stamp}-a`, channel: 'maw', threadKey: KEY, text: 'first', ts: T0 + 1000 },
+  { id: `${stamp}-c`, channel: 'maw', threadKey: KEY, text: 'third', ts: T0 + 3000 },
+  { id: `${stamp}-x`, channel: 'maw', threadKey: `other-${stamp}`, text: 'different thread', ts: T0 },
+];
+
+beforeAll(() => {
+  for (const row of ROWS) db.insert(fleetMessages).values({ ...row, tenantId: TENANT, ingestedAt: T0 }).run();
+});
+
+afterAll(() => {
+  for (const row of ROWS) db.delete(fleetMessages).where(eq(fleetMessages.id, row.id)).run();
+  sqlite.prepare('DELETE FROM fleet_messages WHERE tenant_id = ?').run(TENANT);
+});
+
+describe('a thread reads as a conversation', () => {
+  test('messages come back oldest-first, unlike search', async () => {
+    const res = await thread(TENANT, KEY);
+    expect(res.status).toBe(200);
+    const json = await body(res);
+    // Inserted out of order on purpose — the ordering must come from ts, not insertion.
+    expect(json.data?.messages.map((m) => m.text)).toEqual(['first', 'second', 'third']);
+  });
+
+  test('only the requested thread is returned', async () => {
+    const json = await body(await thread(TENANT, KEY));
+    expect(json.data?.total).toBe(3);
+  });
+
+  test('the key is echoed back', async () => {
+    expect((await body(await thread(TENANT, KEY))).data?.key).toBe(KEY);
+  });
+});
+
+describe('an unknown key is an empty thread, not a 404', () => {
+  test('a key that matches nothing returns 200 with no messages', async () => {
+    /**
+     * `thread_key` is a heuristic grouping and explicitly NOT a foreign key
+     * (src/db/fleet-log-schema.ts:11). A key with no rows is indistinguishable from one whose
+     * messages have not been ingested yet, so 404 would be claiming knowledge the table does
+     * not have.
+     */
+    const res = await thread(TENANT, `nonexistent-${stamp}`);
+    expect(res.status).toBe(200);
+    const json = await body(res);
+    expect(json.success).toBe(true);
+    expect(json.data?.messages).toEqual([]);
+    expect(json.data?.total).toBe(0);
+  });
+});
+
+describe('tenant isolation', () => {
+  test('a second tenant cannot read the first tenant thread', async () => {
+    const other = await body(await thread(`other-${stamp}`, KEY));
+    expect(other.data?.messages).toEqual([]);
+    expect(other.data?.total).toBe(0);
+  });
+});


### PR DESCRIPTION
Implements both acceptance criteria on #2879.

#2871 landed the tables and the ingest; these are the two read routes `frontend/src/pages/fleetLogMock.ts` has been declaring while the page rendered fixtures.

## The open question was already answered

#2879 said this should be decided together with #2855 — whether an oracle's own inbox is searchable knowledge — because fleet messages are the same category of data. **#2855 is decided and shipped**: inbox is knowledge, and `ψ/inbox/` is now indexed (#2893, +4,275 documents). Fleet messages answer it the same way, so this was unblocked.

## The contract was read, not invented

`FLEET_SEARCH_CONTRACT` is a bare string, and the tempting misreading is that `from`/`to` are a date range. `FleetLogFilters` settles it:

```ts
export type FleetLogFilters = {
  query: string; channels: FleetChannel[];
  from: string; to: string;      // ← sender / recipient (from_id / to_id)
  since: string; until: string;  // ← the time window
};
```

Reading them as a date range would have produced an endpoint that matched the contract *string* and not its *intent*. There is a test named for exactly that misreading.

## Decisions I made

| Decision | Choice | Why |
|---|---|---|
| `channel` | comma-separated list | the frontend holds `channels: FleetChannel[]`, not one channel |
| `thread/:key` | separate endpoint | ordering genuinely differs — oldest-first as a conversation, newest-first as a log. That's why it isn't a query param |
| pagination | `limit` default 50, cap 200; `offset` | oversized limit is **capped**, not rejected — a client asking for too much gets the most it may have |
| unknown thread key | empty thread, 200 | `thread_key` is heuristic and explicitly **not** a FK (`fleet-log-schema.ts:11`); a 404 would claim knowledge the table doesn't have |
| unusable filter | **400** | see below |

**An unusable filter is a 400, never a silent pass-through.** A filter that quietly matches everything when it doesn't understand its input is this repo's dominant defect shape — #2857, #2863, #2877, #2880 — *a stage does nothing while the pipeline reports success*. A typo'd `channel=slack` returning the whole corpus looks exactly like a working search. So it's rejected, and the error names the known channels.

## Contract-drift guard

`tests/http/fleet-log/contract-matches-frontend.test.ts` parses the contract strings out of `fleetLogMock.ts` and asserts each declared parameter is both accepted by the Elysia schema **and** consumed by the filter builder. A parameter that's parsed and then dropped is the #2877 shape: real-looking code that changes nothing. It also asserts `FLEET_CHANNELS` is identical on both sides, since a channel accepted by one and rejected by the other is a 400 the user cannot explain.

## Gate

- `bunx tsc --noEmit` — exit 0
- `bun test --isolate tests/http/fleet-log/ tests/build/ tests/http/tenant/ tests/http/health/` — **125 pass**
- All new files ≤250 lines. `src/server.ts` 291 → 292, within its 293 allowance
- No new CI group needed — `tests/http/` already covers this cluster

**Mutation-checked**: removing tenant scoping from either route turns all three isolation tests red:

```
(fail) tenant isolation > a second tenant cannot read the first tenant messages
(fail) tenant isolation > a text query cannot reach across tenants either
(fail) tenant isolation > a second tenant cannot read the first tenant thread
```

Acceptance criterion 2 is proven, not asserted.

## Explicitly not in this PR

**The frontend still renders its mock, and still says so.** Swapping `fleetLogMock` for a real fetch is a user-visible change that wants a screenshot on the issue, and it isn't in the acceptance criteria. The page's honesty about its own mocked state is the thing #2879 praised — it stays accurate until the swap lands deliberately.

Refs #2879
