### PR TITLE
chore: CI control — is tests/http/ green on alpha itself?

### DIFF
--- a/tests/http/vector/turbovec-sidecar.test.ts
+++ b/tests/http/vector/turbovec-sidecar.test.ts
@@ -91,3 +91,4 @@ test('TurboVec sidecar reference speaks the vector proxy protocol', async () => 
   expect(await json(`${base}/vectors/collection`, { method: 'DELETE' })).toMatchObject({ success: true });
   expect(await json(`${base}/vectors/stats`)).toMatchObject({ count: 0 });
 }, 10_000);
+


### PR DESCRIPTION
Control experiment for #2894, which went red **twice** on `TurboVec sidecar reference speaks the vector proxy protocol` — ECONNRESET, the python sidecar crashing on `POST /vectors/query` after `/health`, `/vectors/stats` and `/vectors/add` all succeed.

The **Test** workflow only triggers `on: pull_request`, so it has never run against `alpha` itself — the "alpha green" runs I first checked turned out to be **Docker Publish**. This branch is alpha plus a single blank line, so whatever it reports is the base, not a change.

- **Red here** → `alpha` is red and #2894 is innocent.
- **Green here** → the failure tracks #2894 and I keep digging.

Draft; closed either way.