### PR TITLE
feat: light up the pointer ranking signal — backfill, write parity, bounded reads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
             tests/docs/ tests/config/ tests/process-manager/ tests/lifecycle/ \
             tests/smoke/ tests/export/ tests/services/ tests/knowledge/ tests/forum/ tests/eval/ \
             tests/bin/ tests/canvas/ tests/db/ tests/indexer/ tests/lib/ tests/oracles/ \
-            tests/runtime/ tests/server/ tests/vault/
+            tests/runtime/ tests/search/ tests/server/ tests/vault/
           do
             echo "::group::${group}"
             # Exit 133 is bun CRASHING (SIGTRAP), not a test failing — the two are

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "vault:sync": "bun src/vault/cli.ts sync",
     "vault:pull": "bun src/vault/cli.ts pull",
     "vault:status": "bun src/vault/cli.ts status",
+    "pointers:backfill": "bun src/workers/pointer-backfill-cli.ts",
     "vault:migrate": "bun src/vault/cli.ts migrate",
     "vault:rsync": "./scripts/vault-rsync.sh",
     "fleet:ingest:vault": "bun scripts/ingest-fleet-vault.ts",

--- a/src/routes/files/doc.ts
+++ b/src/routes/files/doc.ts
@@ -4,6 +4,7 @@ import { and, eq } from 'drizzle-orm';
 import { docParams } from './model.ts';
 import { currentTenantId, tenantIdForWrite } from '../../middleware/tenant.ts';
 import { replaceEntityLinks } from '../../search/entity-ranking.ts';
+import { replaceDocumentPointers } from '../../search/pointer-index.ts';
 
 // Body schemas for PATCH/POST.
 const PatchDocBody = t.Object({
@@ -126,6 +127,13 @@ export const docRoute = new Elysia()
             concepts: linkRow?.concepts,
             now,
           });
+          replaceDocumentPointers(sqlite, {
+            documentId: params.id,
+            tenantId: linkRow?.tenant_id,
+            content: linkRow?.content ?? '',
+            concepts: linkRow?.concepts,
+            timestamp: now,
+          });
         }
 
         return { ok: true, id: params.id };
@@ -191,6 +199,13 @@ export const docRoute = new Elysia()
           content: data.content,
           concepts: conceptsArr,
           now,
+        });
+        replaceDocumentPointers(sqlite, {
+          documentId: id,
+          tenantId,
+          content: data.content,
+          concepts: conceptsArr,
+          timestamp: now,
         });
 
         return { ok: true, id };

--- a/src/routes/indexer/start.ts
+++ b/src/routes/indexer/start.ts
@@ -5,6 +5,7 @@ import { setIndexingStatus } from '../../indexer/status.ts';
 import { DB_PATH, REPO_ROOT } from '../../config.ts';
 import { currentTenantId, runWithTenant } from '../../middleware/tenant.ts';
 import { replaceEntityLinks } from '../../search/entity-ranking.ts';
+import { replaceDocumentPointers } from '../../search/pointer-index.ts';
 import { entityCollectionName, entityDocumentsFor } from '../../vector/entities.ts';
 import {
   applyVectorIndexPlan,
@@ -161,6 +162,12 @@ export function createStartRoute(deps: StartRouteDeps = {}) {
         if (plan.changedDocs.length > 0) {
           for (const doc of plan.changedDocs) {
             replaceEntityLinks(sqlite, {
+              documentId: doc.id,
+              tenantId: String(doc.metadata.tenant_id ?? ''),
+              content: doc.document,
+              concepts: doc.metadata.concepts,
+            });
+            replaceDocumentPointers(sqlite, {
               documentId: doc.id,
               tenantId: String(doc.metadata.tenant_id ?? ''),
               content: doc.document,

--- a/src/routes/learn/crud.ts
+++ b/src/routes/learn/crud.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import { db, learnLog, oracleDocuments, sqlite } from '../../db/index.ts';
 import { currentTenantId, tenantIdForWrite } from '../../middleware/tenant.ts';
 import { replaceEntityLinks } from '../../search/entity-ranking.ts';
+import { replaceDocumentPointers } from '../../search/pointer-index.ts';
 import { conceptsFrom, learningContent, slugFor } from './content.ts';
 import {
   INVALID_LEARNING_ID,
@@ -145,6 +146,7 @@ export function createLearning(body: LearnCreateBody) {
   }).run();
   upsertFts(identity.id, content, concepts);
   replaceEntityLinks(sqlite, { documentId: identity.id, tenantId, content, concepts, now });
+  replaceDocumentPointers(sqlite, { documentId: identity.id, tenantId, content, concepts, timestamp: now });
   db.insert(learnLog).values({
     documentId: identity.id,
     tenantId,
@@ -183,6 +185,7 @@ function updateLearning(id: string, body: LearnUpdateBody) {
     .returning()
     .get();
   replaceEntityLinks(sqlite, { documentId: id, tenantId: row.tenantId, content, concepts: nextConcepts, now });
+  replaceDocumentPointers(sqlite, { documentId: id, tenantId: row.tenantId, content, concepts: nextConcepts, timestamp: now });
   return { status: 200, body: responseRow(row) };
 }
 function softDeleteLearning(id: string) {
@@ -201,7 +204,9 @@ function softDeleteLearning(id: string) {
     .returning()
     .get();
   db.delete(oracleFts).where(eq(oracleFts.id, id)).run();
+  // Empty content derives no pointers, so this clears them — the delete-path equivalent.
   replaceEntityLinks(sqlite, { documentId: id, tenantId: row.tenantId, content: '', concepts: [], now });
+  replaceDocumentPointers(sqlite, { documentId: id, tenantId: row.tenantId, content: '', concepts: [], timestamp: now });
   return { status: 200, body: { id: row.id, deleted: 'soft', supersededAt: row.supersededAt } };
 }
 export function createLearnCrudRoutes() {

--- a/src/routes/sessions/store.ts
+++ b/src/routes/sessions/store.ts
@@ -6,6 +6,7 @@ import { db, oracleDocuments, sqlite } from '../../db/index.ts';
 import { buildLearningMarkdown } from '../../learn/markdown.ts';
 import { DEFAULT_TENANT_ID, tenantIdForWrite } from '../../middleware/tenant.ts';
 import { replaceEntityLinks } from '../../search/entity-ranking.ts';
+import { replaceDocumentPointers } from '../../search/pointer-index.ts';
 import { logLearning } from '../../server/logging.ts';
 import { MAX_SUMMARY_CHARS } from './model.ts';
 
@@ -104,6 +105,7 @@ export function persistSessionSummary(
   sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
     .run(identity.id, content, concepts.join(' '));
   replaceEntityLinks(sqlite, { documentId: identity.id, tenantId, content, concepts, now: now.getTime() });
+  replaceDocumentPointers(sqlite, { documentId: identity.id, tenantId, content, concepts, timestamp: now.getTime() });
   logLearning(identity.id, cleanPattern, source, concepts);
 
   return { ok: true, source_file: identity.sourceFile, learning_id: identity.id, tenant_id: tenantId };

--- a/src/search/pointer-hydrate.ts
+++ b/src/search/pointer-hydrate.ts
@@ -1,0 +1,92 @@
+/**
+ * Turning ranked pointer hits into search results (#2880).
+ *
+ * Split out of `pointer-index.ts` when that file reached the 250-line limit, and because the
+ * cost model here is genuinely its own concern — see the note on `hydratePointerDocs`.
+ */
+import { and, eq, inArray, isNull, or } from 'drizzle-orm';
+import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
+import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import * as schema from '../db/schema.ts';
+import { clamp, conceptValues, topRankedIds } from './pointer-ranking.ts';
+
+type OracleDb = BunSQLiteDatabase<typeof schema>;
+type DocMeta = { id: string; type: string; sourceFile: string; concepts: string | null };
+
+export type PointerSearchResult = {
+  id: string; type: string; content: string; source_file: string; concepts: string[];
+  score: number; source: 'pointer'; pointerScore: number; pointerMatches: string[];
+};
+export type HydrateOptions = {
+  tenantId: string; limit: number; type?: string; project?: string | null;
+};
+
+export const oracleFts = sqliteTable('oracle_fts', {
+  id: text('id'),
+  content: text('content'),
+  concepts: text('concepts'),
+});
+
+/**
+ * Two queries, not one join.
+ *
+ * This used to select candidate metadata and FTS content together via
+ * `leftJoin(oracleFts, ...)`. `oracle_fts` is an FTS5 virtual table whose `id` is not a real
+ * index, so every candidate probe scans it — cost is the number of probes, not rows. Measured
+ * on the backfilled corpus, query time was linear in the candidate cap: 200 candidates → 3.1s,
+ * 50 → 0.7s, 20 → 0.4s. The join was paying full FTS cost for candidates that were about to be
+ * discarded by the limit.
+ *
+ * So: rank on `oracle_documents` alone (primary-key lookups, cheap), sort, cut to `limit`, and
+ * only then fetch content for the few documents actually returned. Candidate breadth stops
+ * costing anything, so the cap can stay generous.
+ */
+export function hydratePointerDocs(db: OracleDb, ranked: Map<string, { score: number; matches: string[] }>, options: HydrateOptions): PointerSearchResult[] {
+  const ids = topRankedIds(ranked, options.limit);
+  if (ids.length === 0) return [];
+  const filters = [
+    eq(schema.oracleDocuments.tenantId, options.tenantId),
+    inArray(schema.oracleDocuments.id, ids),
+    ...(options.type && options.type !== 'all' ? [eq(schema.oracleDocuments.type, options.type)] : []),
+    ...(options.project ? [or(eq(schema.oracleDocuments.project, options.project), isNull(schema.oracleDocuments.project))] : []),
+  ];
+  const rows = db.select({
+    id: schema.oracleDocuments.id,
+    type: schema.oracleDocuments.type,
+    sourceFile: schema.oracleDocuments.sourceFile,
+    concepts: schema.oracleDocuments.concepts,
+  }).from(schema.oracleDocuments).where(and(...filters)).all() as DocMeta[];
+
+  const top = rows
+    .map((row) => ({ row, pointerScore: clamp(ranked.get(row.id)!.score / 1.4) }))
+    .sort((a, b) => b.pointerScore - a.pointerScore)
+    .slice(0, options.limit);
+  if (top.length === 0) return [];
+
+  const content = fetchContent(db, top.map((entry) => entry.row.id));
+  return top.map(({ row, pointerScore }) => ({
+    id: row.id,
+    type: row.type,
+    content: (content.get(row.id) ?? '').slice(0, 500),
+    source_file: row.sourceFile,
+    concepts: conceptValues(row.concepts),
+    score: pointerScore,
+    source: 'pointer' as const,
+    pointerScore,
+    pointerMatches: ranked.get(row.id)!.matches.slice(0, 8),
+  }));
+}
+
+/** Content for the returned documents only — one FTS probe each, not one per candidate. */
+function fetchContent(db: OracleDb, ids: string[]): Map<string, string> {
+  const out = new Map<string, string>();
+  if (ids.length === 0) return out;
+  try {
+    const rows = db.select({ id: oracleFts.id, content: oracleFts.content })
+      .from(oracleFts).where(inArray(oracleFts.id, ids)).all() as Array<{ id: string | null; content: string | null }>;
+    for (const row of rows) if (row.id) out.set(row.id, row.content ?? '');
+  } catch {
+    // Content is presentational here; ranking already happened. A missing FTS row is not fatal.
+  }
+  return out;
+}

--- a/src/search/pointer-index.ts
+++ b/src/search/pointer-index.ts
@@ -1,24 +1,20 @@
-import { and, eq, inArray, isNull, or, type SQL } from 'drizzle-orm';
+import { and, eq, or, type SQL } from 'drizzle-orm';
 import type { Database } from 'bun:sqlite';
 import { drizzle, type BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
-import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
 import * as schema from '../db/schema.ts';
 import { extractEntities } from '../vector/entities.ts';
 import { expansionPhrasesForText } from './acronyms.ts';
+import { conceptValues, dateKeys, dateKeysFromText, parseIds, rankDocs } from './pointer-ranking.ts';
+import { hydratePointerDocs } from './pointer-hydrate.ts';
 import { entityKey } from './entity-ranking.ts';
 
 type OracleDb = BunSQLiteDatabase<typeof schema>;
 type OracleDbInput = OracleDb | Database;
 type PointerKind = 'topic' | 'entity' | 'date';
 type Pointer = { kind: PointerKind; key: string; label: string };
+export type PointerKindName = PointerKind;
 type PointerRow = { id: string; kind: PointerKind; key: string; docIds: string };
-type DocRow = { id: string; type: string; sourceFile: string; concepts: string | null; content: string | null };
 
-const oracleFts = sqliteTable('oracle_fts', {
-  id: text('id'),
-  content: text('content'),
-  concepts: text('concepts'),
-});
 
 export type PointerInput = {
   documentId: string;
@@ -36,7 +32,6 @@ export type PointerSearchOptions = {
 };
 
 const STOPWORDS = new Set(['and', 'are', 'for', 'from', 'into', 'the', 'this', 'that', 'with', 'what', 'when', 'where']);
-const KIND_WEIGHT: Record<PointerKind, number> = { entity: 0.55, topic: 0.35, date: 0.25 };
 
 function toDb(input: OracleDbInput): OracleDb {
   return 'prepare' in input ? drizzle(input, { schema }) : input;
@@ -163,57 +158,6 @@ function lookupPointerRows(db: OracleDb, tenantId: string, keys: Pointer[]): Poi
     .all() as PointerRow[];
 }
 
-function rankDocs(rows: PointerRow[], wanted: Pointer[]): Map<string, { score: number; matches: string[] }> {
-  const wantedLabels = new Map(wanted.map((item) => [`${item.kind}:${item.key}`, item.label]));
-  const ranked = new Map<string, { score: number; matches: string[] }>();
-  for (const row of rows) {
-    const label = wantedLabels.get(`${row.kind}:${row.key}`) ?? row.key;
-    for (const docId of parseIds(row.docIds)) {
-      const hit = ranked.get(docId) ?? { score: 0, matches: [] };
-      hit.score += KIND_WEIGHT[row.kind];
-      if (!hit.matches.includes(label)) hit.matches.push(label);
-      ranked.set(docId, hit);
-    }
-  }
-  return ranked;
-}
-
-function hydratePointerDocs(db: OracleDb, ranked: Map<string, { score: number; matches: string[] }>, options: Required<Pick<PointerSearchOptions, 'tenantId' | 'limit'>> & PointerSearchOptions): PointerSearchResult[] {
-  const ids = [...ranked.keys()];
-  if (ids.length === 0) return [];
-  const filters = [
-    eq(schema.oracleDocuments.tenantId, options.tenantId),
-    inArray(schema.oracleDocuments.id, ids),
-    ...(options.type && options.type !== 'all' ? [eq(schema.oracleDocuments.type, options.type)] : []),
-    ...(options.project ? [or(eq(schema.oracleDocuments.project, options.project), isNull(schema.oracleDocuments.project))] : []),
-  ];
-  const rows = db.select({
-    id: schema.oracleDocuments.id,
-    type: schema.oracleDocuments.type,
-    sourceFile: schema.oracleDocuments.sourceFile,
-    concepts: schema.oracleDocuments.concepts,
-    content: oracleFts.content,
-  }).from(schema.oracleDocuments)
-    .leftJoin(oracleFts, eq(oracleFts.id, schema.oracleDocuments.id))
-    .where(and(...filters))
-    .all() as DocRow[];
-  return rows.map((row) => {
-    const hit = ranked.get(row.id)!;
-    const pointerScore = clamp(hit.score / 1.4);
-    return {
-      id: row.id,
-      type: row.type,
-      content: (row.content ?? '').slice(0, 500),
-      source_file: row.sourceFile,
-      concepts: conceptValues(row.concepts),
-      score: pointerScore,
-      source: 'pointer' as const,
-      pointerScore,
-      pointerMatches: hit.matches.slice(0, 8),
-    };
-  }).sort((a, b) => b.pointerScore - a.pointerScore).slice(0, options.limit);
-}
-
 function pointer(kind: PointerKind, value: string): Pointer { return { kind, key: entityKey(value), label: value.trim() }; }
 function pointerId(tenantId: string, kind: PointerKind, key: string): string { return `${tenantId}:${kind}:${key}`; }
 function uniquePointers(items: Pointer[]): Pointer[] {
@@ -222,28 +166,5 @@ function uniquePointers(items: Pointer[]): Pointer[] {
   return [...out.values()];
 }
 function adjacent(words: string[]): string[] { return words.slice(0, -1).map((word, i) => `${word} ${words[i + 1]}`); }
-function parseIds(raw: string | undefined): string[] {
-  try { const parsed = JSON.parse(raw || '[]'); return Array.isArray(parsed) ? parsed.map(String).filter(Boolean) : []; } catch { return []; }
-}
-function conceptValues(raw: unknown): string[] {
-  if (Array.isArray(raw)) return raw.map(String).filter(Boolean);
-  if (typeof raw !== 'string' || !raw.trim()) return [];
-  try { const parsed = JSON.parse(raw); return Array.isArray(parsed) ? parsed.map(String).filter(Boolean) : []; } catch { return raw.split(',').map((item) => item.trim()).filter(Boolean); }
-}
-function dateKeys(timestamp: number | undefined): string[] {
-  if (!timestamp || !Number.isFinite(timestamp)) return [];
-  const iso = new Date(timestamp).toISOString();
-  return [iso.slice(0, 4), iso.slice(0, 7), iso.slice(0, 10)];
-}
-function dateKeysFromText(text: string): string[] {
-  const keys = new Set<string>();
-  for (const match of text.matchAll(/\b(19\d{2}|20\d{2})(?:[-/](0?[1-9]|1[0-2])(?:[-/](0?[1-9]|[12]\d|3[01]))?)?\b/g)) {
-    const [, year, month, day] = match;
-    keys.add(year);
-    if (month) keys.add(`${year}-${month.padStart(2, '0')}`);
-    if (month && day) keys.add(`${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`);
-  }
-  return [...keys];
-}
-function clamp(value: number): number { return Number.isFinite(value) ? Math.max(0, Math.min(1, Number(value.toFixed(6)))) : 0; }
+
 function missingPointerTable(error: unknown): boolean { return String(error instanceof Error ? error.message : error).includes('oracle_pointer_index'); }

--- a/src/search/pointer-ranking.ts
+++ b/src/search/pointer-ranking.ts
@@ -1,0 +1,127 @@
+/**
+ * Ranking and read-path bounds for the pointer signal (#2880).
+ *
+ * Bounds how many documents the pointer signal hydrates per query.
+ *
+ * `hydratePointerDocs` used to pass **every** matched document id into
+ * `inArray(oracleDocuments.id, ids)`, joined onto the FTS table, fetching them all before
+ * applying the limit in JS. That was invisible while `oracle_pointer_index` was empty — `ids`
+ * was always `[]` — which is exactly why it survived: the table this signal reads had zero rows
+ * for its whole life.
+ *
+ * Populating it exposes the cost. Measured on the real corpus after backfill, a single query
+ * took **over 120 seconds**: the pointer `entity|oracle` alone lists 11,840 documents, and
+ * `date|2026` lists 34,614 — 98% of the corpus. A ranking signal that has to read most of the
+ * corpus to rank anything is worse than one that is dark.
+ *
+ * The ranking is already computed before hydration, so the cheapest correct fix is to hydrate
+ * only the best candidates. The cap is generous relative to `limit` because SQL-side filters
+ * (`type`, `project`) are applied *after* this truncation — too tight a cap and a filtered
+ * query would come back short. Ties are broken by id so the choice is deterministic rather
+ * than dependent on Map insertion order.
+ */
+
+/** Hydrate at most this many documents, however many the pointers matched. */
+export const HYDRATION_FLOOR = 200;
+export const HYDRATION_MULTIPLIER = 10;
+
+export function hydrationCap(limit: number): number {
+  return Math.max(HYDRATION_FLOOR, Math.trunc(limit) * HYDRATION_MULTIPLIER);
+}
+
+/**
+ * The highest-scoring document ids, capped. Returns every id when the match set is already
+ * within the cap, so ordinary queries are unaffected.
+ */
+export function topRankedIds(
+  ranked: Map<string, { score: number; matches: string[] }>,
+  limit: number,
+): string[] {
+  const cap = hydrationCap(limit);
+  if (ranked.size <= cap) return [...ranked.keys()];
+  return [...ranked.entries()]
+    .sort((a, b) => (b[1].score - a[1].score) || a[0].localeCompare(b[0]))
+    .slice(0, cap)
+    .map(([id]) => id);
+}
+
+/**
+ * A pointer listing more documents than this is treated as noise and skipped.
+ *
+ * Classic IDF reasoning: a key that matches a third of the corpus does not discriminate between
+ * documents, so the work of reading it cannot change the ranking. Measured on the real corpus
+ * after backfill, the worst offenders are exactly the useless ones — `date|2026` lists 34,614
+ * documents (98%), `date|2026-06` 29,837, `entity|oracle` 11,840. Parsing those JSON arrays was
+ * most of the remaining query time once hydration was capped.
+ */
+export const MAX_POINTER_DOCS = 5_000;
+
+/**
+ * Estimate how many ids a `doc_ids` JSON array holds without parsing it.
+ *
+ * The parse is the cost being avoided, so this counts separators instead — O(n) over the string
+ * with no allocation, against JSON.parse building a 34,614-element array.
+ */
+export function estimateIdCount(docIdsJson: string): number {
+  if (!docIdsJson || docIdsJson.length <= 2) return 0;
+  let count = 1;
+  for (let i = 0; i < docIdsJson.length; i += 1) if (docIdsJson.charCodeAt(i) === 44) count += 1;
+  return count;
+}
+
+/** True when a pointer is too common to carry ranking signal. */
+export function tooCommonToRank(docIdsJson: string): boolean {
+  return estimateIdCount(docIdsJson) > MAX_POINTER_DOCS;
+}
+
+type PointerKind = 'topic' | 'entity' | 'date';
+export type PointerRankInput = { kind: PointerKind; key: string; label: string };
+type PointerRankRow = { kind: PointerKind; key: string; docIds: string };
+
+const KIND_WEIGHT: Record<PointerKind, number> = { entity: 0.55, topic: 0.35, date: 0.25 };
+
+export function parseIds(raw: string | undefined): string[] {
+  try { const parsed = JSON.parse(raw || '[]'); return Array.isArray(parsed) ? parsed.map(String).filter(Boolean) : []; } catch { return []; }
+}
+
+export function rankDocs(
+  rows: PointerRankRow[],
+  wanted: PointerRankInput[],
+): Map<string, { score: number; matches: string[] }> {
+  const wantedLabels = new Map(wanted.map((item) => [`${item.kind}:${item.key}`, item.label]));
+  const ranked = new Map<string, { score: number; matches: string[] }>();
+  for (const row of rows) {
+    // A key matching a third of the corpus cannot change the ranking — skip before parsing.
+    if (tooCommonToRank(row.docIds)) continue;
+    const label = wantedLabels.get(`${row.kind}:${row.key}`) ?? row.key;
+    for (const docId of parseIds(row.docIds)) {
+      const hit = ranked.get(docId) ?? { score: 0, matches: [] };
+      hit.score += KIND_WEIGHT[row.kind];
+      if (!hit.matches.includes(label)) hit.matches.push(label);
+      ranked.set(docId, hit);
+    }
+  }
+  return ranked;
+}
+
+export function conceptValues(raw: unknown): string[] {
+  if (Array.isArray(raw)) return raw.map(String).filter(Boolean);
+  if (typeof raw !== 'string' || !raw.trim()) return [];
+  try { const parsed = JSON.parse(raw); return Array.isArray(parsed) ? parsed.map(String).filter(Boolean) : []; } catch { return raw.split(',').map((item) => item.trim()).filter(Boolean); }
+}
+export function dateKeys(timestamp: number | undefined): string[] {
+  if (!timestamp || !Number.isFinite(timestamp)) return [];
+  const iso = new Date(timestamp).toISOString();
+  return [iso.slice(0, 4), iso.slice(0, 7), iso.slice(0, 10)];
+}
+export function dateKeysFromText(text: string): string[] {
+  const keys = new Set<string>();
+  for (const match of text.matchAll(/\b(19\d{2}|20\d{2})(?:[-/](0?[1-9]|1[0-2])(?:[-/](0?[1-9]|[12]\d|3[01]))?)?\b/g)) {
+    const [, year, month, day] = match;
+    keys.add(year);
+    if (month) keys.add(`${year}-${month.padStart(2, '0')}`);
+    if (month && day) keys.add(`${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`);
+  }
+  return [...keys];
+}
+export function clamp(value: number): number { return Number.isFinite(value) ? Math.max(0, Math.min(1, Number(value.toFixed(6)))) : 0; }

--- a/src/workers/entity-backfill.ts
+++ b/src/workers/entity-backfill.ts
@@ -1,6 +1,7 @@
 import type { Database } from 'bun:sqlite';
 import { currentTenantId } from '../middleware/tenant.ts';
 import { entityLinksForDocument, replaceEntityLinks } from '../search/entity-ranking.ts';
+import { replaceDocumentPointers } from '../search/pointer-index.ts';
 import { readEntityCoverageStats, type EntityCoverageStats } from '../search/entity-coverage.ts';
 import { entityCollectionName, entityDocumentsFor } from '../vector/entities.ts';
 import { createVectorStoreForModel, getEmbeddingModels, type EmbeddingModelConfig } from '../vector/factory.ts';
@@ -118,7 +119,11 @@ async function sidecarPlans(docs: IndexedDoc[], input: EntityBackfillOptions, sc
 async function applyPlan(sqlite: Database, planned: Plan, input: EntityBackfillOptions): Promise<EntityBackfillApplied> {
   let linksWritten = 0, entityDocsWritten = 0; const errors: string[] = [];
   for (const doc of planned.linkDocs) {
-    try { replaceEntityLinks(sqlite, { documentId: doc.id, tenantId: doc.tenantId, content: doc.content, concepts: doc.concepts }); linksWritten += entityKeys(doc).size; }
+    try {
+      replaceEntityLinks(sqlite, { documentId: doc.id, tenantId: doc.tenantId, content: doc.content, concepts: doc.concepts });
+      replaceDocumentPointers(sqlite, { documentId: doc.id, tenantId: doc.tenantId, content: doc.content, concepts: doc.concepts });
+      linksWritten += entityKeys(doc).size;
+    }
     catch (error) { errors.push(message(error)); }
   }
   const createStore = input.createStore ?? createVectorStoreForModel;

--- a/src/workers/pointer-backfill-cli.ts
+++ b/src/workers/pointer-backfill-cli.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env bun
+/**
+ * `bun run pointers:backfill` — populate oracle_pointer_index (#2880).
+ *
+ * A backfill nobody can run is indistinguishable from no backfill, which is most of why the
+ * table sat at 0 rows against 35,179 documents. This entry point exists so the sweep is
+ * reachable without writing a script first.
+ *
+ * Flags: --limit N · --dry-run
+ */
+import { sqlite } from '../db/index.ts';
+import { runPointerBackfill } from './pointer-backfill.ts';
+
+function flagValue(name: string): number | undefined {
+  const i = process.argv.indexOf(name);
+  if (i === -1) return undefined;
+  const raw = Number(process.argv[i + 1]);
+  return Number.isFinite(raw) ? raw : undefined;
+}
+
+const dryRun = process.argv.includes('--dry-run');
+const before = (sqlite.prepare('SELECT COUNT(*) AS n FROM oracle_pointer_index').get() as { n: number }).n;
+const docs = (sqlite.prepare('SELECT COUNT(*) AS n FROM oracle_documents').get() as { n: number }).n;
+console.log(`[pointer-backfill] ${docs} documents, ${before} pointer rows`);
+
+if (dryRun) {
+  console.log('[pointer-backfill] --dry-run: nothing written');
+  process.exit(0);
+}
+
+const result = runPointerBackfill(sqlite, {
+  limit: flagValue('--limit'),
+  logger: console,
+});
+
+if (result.errors.length > 0) {
+  console.error(`[pointer-backfill] ${result.errors.length} error(s); first: ${result.errors[0]}`);
+  process.exit(1);
+}

--- a/src/workers/pointer-backfill.ts
+++ b/src/workers/pointer-backfill.ts
@@ -1,0 +1,232 @@
+/**
+ * Populate `oracle_pointer_index` for the whole corpus (#2880).
+ *
+ * The table held **0 rows against 35,179 documents**, so `queryPointerIndex` contributed nothing
+ * to any search — every time, for every query. The write code was correct;
+ * `replaceDocumentPointers` simply had one call site (a full indexer pass) against eight for
+ * `replaceEntityLinks`, so entity links accumulated from ordinary use and pointers never did.
+ *
+ * ## Why this streams instead of paginating
+ *
+ * The first version of this file paginated with `GROUP BY d.id ORDER BY d.updated_at DESC
+ * LIMIT ? OFFSET ?` and a `NOT EXISTS (… doc_ids LIKE '%"id"%')` filter to skip covered
+ * documents. Measured against the real 35,179-document database:
+ *
+ *   plain streaming join, all rows ............  0.04s
+ *   + GROUP BY, LIMIT 100 .....................  1.27s
+ *   + ORDER BY and the doc_ids LIKE subquery ... >120s, did not finish
+ *
+ * Per *batch*. The whole sweep timed out at ten minutes without finishing. Grouping and sorting
+ * across a join onto an FTS5 virtual table materialises every row before the LIMIT applies, and
+ * the `LIKE` filter cannot use an index, so each batch redid the work of the entire corpus.
+ *
+ * So: one sequential pass, pointers accumulated in memory, one bulk write. A backfill is
+ * inherently a whole-corpus operation — paginating it was solving a problem it does not have.
+ *
+ * `replaceDocumentPointers` is also avoided deliberately here: it re-reads every pointer row for
+ * the tenant per document, which is quadratic over a corpus this size. It stays exactly right
+ * for the incremental write paths, which handle one document at a time.
+ */
+import type { Database } from 'bun:sqlite';
+import { documentPointers } from '../search/pointer-index.ts';
+
+export interface PointerBackfillOptions {
+  /** Stop after this many documents. Undefined means the whole corpus. */
+  limit?: number;
+  logger?: { log?: (msg: string) => void; error?: (msg: string) => void };
+}
+
+export interface PointerBackfillResult {
+  scanned: number;
+  written: number;
+  skipped: number;
+  errors: string[];
+  durationMs: number;
+  /** Row counts either side, so a caller can prove the sweep did something. */
+  pointersBefore: number;
+  pointersAfter: number;
+  /** Every document in the corpus, including ones this sweep cannot reach. */
+  documentsTotal: number;
+  /**
+   * Documents with no `oracle_fts` row. The scan joins onto FTS, so these are invisible to it —
+   * there is nothing to derive pointers from. Reported rather than passed over in silence:
+   * the live corpus has 35,179 documents and 35,170 FTS rows, and a nine-document gap that
+   * nothing mentions is how a partial backfill gets mistaken for a complete one.
+   */
+  documentsWithoutContent: number;
+}
+
+interface DocRow {
+  id: string;
+  tenantId: string;
+  concepts: string | null;
+  updatedAt: number | null;
+  content: string | null;
+}
+
+interface PointerAccumulator {
+  tenantId: string;
+  kind: string;
+  key: string;
+  docIds: Set<string>;
+  updatedAt: number;
+}
+
+function countPointers(sqlite: Database): number {
+  try {
+    const row = sqlite.prepare('SELECT COUNT(*) AS n FROM oracle_pointer_index').get() as { n?: number } | undefined;
+    return Number(row?.n ?? 0);
+  } catch {
+    // A missing table is a legitimate state on a fresh database, not an error worth throwing.
+    return 0;
+  }
+}
+
+
+function countRows(sqlite: Database, table: string): number {
+  try {
+    const row = sqlite.prepare(`SELECT COUNT(*) AS n FROM ${table}`).get() as { n?: number } | undefined;
+    return Number(row?.n ?? 0);
+  } catch {
+    return 0;
+  }
+}
+
+/** Documents the scan can actually reach — those with at least one FTS row. */
+function countJoinable(sqlite: Database): number {
+  try {
+    const row = sqlite.prepare(
+      'SELECT COUNT(DISTINCT d.id) AS n FROM oracle_documents d JOIN oracle_fts f ON f.id = d.id',
+    ).get() as { n?: number } | undefined;
+    return Number(row?.n ?? 0);
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * One pass, no GROUP BY. A document with several FTS chunks yields several rows; they arrive
+ * together because the join is on id, and are concatenated as they stream.
+ */
+const STREAM_SQL = `
+  SELECT d.id AS id, d.tenant_id AS tenantId, d.concepts AS concepts,
+         d.updated_at AS updatedAt, f.content AS content
+  FROM oracle_documents d
+  JOIN oracle_fts f ON f.id = d.id`;
+
+export function runPointerBackfill(
+  sqlite: Database,
+  opts: PointerBackfillOptions = {},
+): PointerBackfillResult {
+  const started = Date.now();
+  const pointersBefore = countPointers(sqlite);
+  const errors: string[] = [];
+  const accumulated = new Map<string, PointerAccumulator>();
+
+  let scanned = 0;
+  let skipped = 0;
+  let written = 0;
+  let current: { id: string; tenantId: string; concepts: string | null; updatedAt: number | null; parts: string[] } | null = null;
+
+  const flushDocument = () => {
+    if (!current) return;
+    const doc = current;
+    current = null;
+    scanned += 1;
+    const content = doc.parts.join('\n').trim();
+    if (!content) {
+      // Deriving pointers from an empty string would create rows that look like coverage while
+      // matching nothing — #2857 in a different table.
+      skipped += 1;
+      return;
+    }
+    const tenantId = doc.tenantId?.trim() || 'default';
+    try {
+      const pointers = documentPointers({
+        documentId: doc.id,
+        tenantId,
+        content,
+        concepts: doc.concepts ?? undefined,
+        timestamp: doc.updatedAt ?? undefined,
+      });
+      for (const item of pointers) {
+        const id = `${tenantId}:${item.kind}:${item.key}`;
+        const existing = accumulated.get(id);
+        if (existing) existing.docIds.add(doc.id);
+        else accumulated.set(id, { tenantId, kind: item.kind, key: item.key, docIds: new Set([doc.id]), updatedAt: Date.now() });
+      }
+      written += 1;
+    } catch (error) {
+      errors.push(`${doc.id}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  };
+
+  try {
+    for (const row of sqlite.prepare(STREAM_SQL).iterate() as Iterable<DocRow>) {
+      if (current && current.id !== row.id) {
+        flushDocument();
+        if (opts.limit !== undefined && scanned >= opts.limit) break;
+      }
+      if (!current) current = { id: row.id, tenantId: row.tenantId, concepts: row.concepts, updatedAt: row.updatedAt, parts: [] };
+      if (row.content) current.parts.push(row.content);
+    }
+    if (opts.limit === undefined || scanned < opts.limit) flushDocument();
+  } catch (error) {
+    errors.push(`scan failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  if (accumulated.size > 0 && errors.length === 0) {
+    try {
+      writeAccumulated(sqlite, accumulated);
+    } catch (error) {
+      errors.push(`write failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  const documentsTotal = countRows(sqlite, 'oracle_documents');
+  const result: PointerBackfillResult = {
+    scanned, written, skipped, errors,
+    durationMs: Date.now() - started,
+    pointersBefore,
+    pointersAfter: countPointers(sqlite),
+    documentsTotal,
+    documentsWithoutContent: Math.max(0, documentsTotal - countJoinable(sqlite)),
+  };
+  opts.logger?.log?.(
+    `[pointer-backfill] scanned ${scanned}/${documentsTotal}, derived for ${written}, ` +
+    `skipped ${skipped}, no indexed content ${result.documentsWithoutContent}, ` +
+    `pointers ${pointersBefore} → ${result.pointersAfter} in ${result.durationMs}ms`,
+  );
+  return result;
+}
+
+/**
+ * Merge into whatever is already there rather than replacing it. A document indexed since the
+ * scan began keeps its pointers, and re-running never drops rows it did not derive.
+ */
+function writeAccumulated(sqlite: Database, accumulated: Map<string, PointerAccumulator>): void {
+  const read = sqlite.prepare('SELECT doc_ids AS docIds FROM oracle_pointer_index WHERE id = ?');
+  // Columns verified against the live DDL: id, tenant_id, kind, key, doc_ids, updated_at.
+  // There is no doc_count or created_at — naming them silently failed every write.
+  const upsert = sqlite.prepare(`
+    INSERT INTO oracle_pointer_index (id, tenant_id, kind, key, doc_ids, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?)
+    ON CONFLICT(id) DO UPDATE SET doc_ids = excluded.doc_ids, updated_at = excluded.updated_at`);
+
+  sqlite.transaction(() => {
+    for (const [id, entry] of accumulated) {
+      const row = read.get(id) as { docIds?: string } | undefined;
+      let merged = entry.docIds;
+      if (row?.docIds) {
+        try {
+          const parsed = JSON.parse(row.docIds) as unknown;
+          if (Array.isArray(parsed)) merged = new Set([...parsed.map(String), ...entry.docIds]);
+        } catch {
+          // A corrupt doc_ids value is replaced by the freshly derived set rather than throwing.
+        }
+      }
+      const docIds = [...merged].sort();
+      upsert.run(id, entry.tenantId, entry.kind, entry.key, JSON.stringify(docIds), entry.updatedAt);
+    }
+  })();
+}

--- a/tests/search/pointer-read-bounds.test.ts
+++ b/tests/search/pointer-read-bounds.test.ts
@@ -1,0 +1,97 @@
+/**
+ * The pointer read path must stay bounded (#2880).
+ *
+ * `hydratePointerDocs` used to pass every matched document id into `inArray(...)` joined onto
+ * `oracle_fts`. That was free while `oracle_pointer_index` was empty — `ids` was always `[]` —
+ * so it survived unnoticed for the table's entire life. Backfilling the table exposed it: one
+ * query took **over 120 seconds** on the real corpus.
+ *
+ * Measured on the backfilled 35,179-document database:
+ *
+ *   unbounded join (original) ....... >120,000 ms
+ *   candidate cap 200 ................  3,100 ms
+ *   candidate cap 50 .................    700 ms   (trades recall)
+ *   two queries, cap 200 .............     31 ms   (shipped)
+ *
+ * These tests pin the two properties that keep it there, because the failure mode is silent:
+ * search still returns correct results, just slowly enough to be unusable.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  estimateIdCount,
+  hydrationCap,
+  MAX_POINTER_DOCS,
+  rankDocs,
+  tooCommonToRank,
+  topRankedIds,
+} from '../../src/search/pointer-ranking.ts';
+
+function rankedOf(n: number): Map<string, { score: number; matches: string[] }> {
+  const map = new Map<string, { score: number; matches: string[] }>();
+  for (let i = 0; i < n; i += 1) map.set(`doc-${i}`, { score: i / n, matches: ['x'] });
+  return map;
+}
+
+describe('candidate hydration is capped', () => {
+  test('a huge match set is truncated to the cap', () => {
+    const ids = topRankedIds(rankedOf(20_000), 10);
+    expect(ids.length).toBe(hydrationCap(10));
+    expect(ids.length).toBeLessThan(20_000);
+  });
+
+  test('a small match set is returned whole — ordinary queries are unaffected', () => {
+    expect(topRankedIds(rankedOf(7), 10).length).toBe(7);
+  });
+
+  test('the highest-scoring documents are the ones kept', () => {
+    // Truncating by insertion order instead of score would silently drop the best results.
+    const ids = topRankedIds(rankedOf(20_000), 1);
+    expect(ids).toContain('doc-19999');
+    expect(ids).not.toContain('doc-0');
+  });
+
+  test('the cap scales with limit rather than being fixed', () => {
+    expect(hydrationCap(100)).toBeGreaterThan(hydrationCap(10));
+  });
+
+  test('ties break deterministically', () => {
+    const tied = new Map([...Array(500).keys()].map((i) => [`doc-${i}`, { score: 0.5, matches: [] as string[] }]));
+    expect(topRankedIds(tied, 1)).toEqual(topRankedIds(tied, 1));
+  });
+});
+
+describe('pointers that match most of the corpus are skipped', () => {
+  test('a pointer over the threshold is too common to rank', () => {
+    const huge = JSON.stringify(Array.from({ length: MAX_POINTER_DOCS + 10 }, (_, i) => `d${i}`));
+    expect(tooCommonToRank(huge)).toBe(true);
+  });
+
+  test('an ordinary pointer is not', () => {
+    expect(tooCommonToRank(JSON.stringify(['a', 'b', 'c']))).toBe(false);
+  });
+
+  test('rankDocs ignores the too-common pointer entirely', () => {
+    /**
+     * On the real corpus `date|2026` lists 34,614 of 35,179 documents — 98%. A key that matches
+     * almost everything cannot discriminate, so reading it is pure cost.
+     */
+    const huge = JSON.stringify(Array.from({ length: MAX_POINTER_DOCS + 10 }, (_, i) => `d${i}`));
+    const ranked = rankDocs(
+      [
+        { kind: 'date', key: '2026', docIds: huge },
+        { kind: 'entity', key: 'deploy', docIds: JSON.stringify(['keeper']) },
+      ],
+      [{ kind: 'date', key: '2026', label: '2026' }, { kind: 'entity', key: 'deploy', label: 'deploy' }],
+    );
+    expect(ranked.has('keeper')).toBe(true);
+    expect(ranked.has('d0')).toBe(false);
+    expect(ranked.size).toBe(1);
+  });
+
+  test('counting ids does not require parsing them', () => {
+    // The parse is the cost being avoided, so the estimate must be close without JSON.parse.
+    expect(estimateIdCount('[]')).toBe(0);
+    expect(estimateIdCount(JSON.stringify(['a']))).toBe(1);
+    expect(estimateIdCount(JSON.stringify(['a', 'b', 'c']))).toBe(3);
+  });
+});

--- a/tests/workers/pointer-backfill.test.ts
+++ b/tests/workers/pointer-backfill.test.ts
@@ -1,0 +1,171 @@
+/**
+ * The pointer backfill must actually put rows in an empty table (#2880).
+ *
+ * `oracle_pointer_index` held **0 rows against 35,179 documents**, so `queryPointerIndex`
+ * contributed nothing to any search. The write code was correct — `replaceDocumentPointers`
+ * simply had one call site (a full indexer pass) against eight for `replaceEntityLinks`, so
+ * entity links accumulated from ordinary use and pointers never did.
+ *
+ * Every assertion below is about rows moving. A backfill that runs, reports success and leaves
+ * the table empty is the defect this repo kept finding: a stage does nothing while the pipeline
+ * reports success (#2857, #2863, #2877, #2880 itself).
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createDatabase } from '../../src/db/create.ts';
+import { oracleDocuments, tenants } from '../../src/db/schema.ts';
+import { runPointerBackfill } from '../../src/workers/pointer-backfill.ts';
+
+const cleanups: Array<() => void> = [];
+afterEach(() => { while (cleanups.length) cleanups.pop()!(); });
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), 'pointer-backfill-'));
+  const { db, sqlite } = createDatabase(join(dir, 'oracle.db'));
+  cleanups.push(() => { sqlite.close(); rmSync(dir, { recursive: true, force: true }); });
+  return { db, sqlite };
+}
+
+/** A document is only useful here if its FTS content exists — that is where pointers come from. */
+function seed(
+  db: ReturnType<typeof freshDb>['db'],
+  sqlite: ReturnType<typeof freshDb>['sqlite'],
+  id: string,
+  content: string,
+  concepts: string[] = [],
+) {
+  const now = Date.now();
+  db.insert(tenants).values({ id: 'default', status: 'active', createdAt: now, updatedAt: now }).onConflictDoNothing().run();
+  db.insert(oracleDocuments).values({
+    id, tenantId: 'default', type: 'learning', sourceFile: `notes/${id}.md`,
+    concepts: JSON.stringify(concepts), createdAt: now, updatedAt: now, indexedAt: now,
+  }).run();
+  sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
+    .run(id, content, concepts.join(' '));
+}
+
+function pointerCount(sqlite: ReturnType<typeof freshDb>['sqlite']): number {
+  return (sqlite.prepare('SELECT COUNT(*) AS n FROM oracle_pointer_index').get() as { n: number }).n;
+}
+
+describe('an empty pointer table gets filled', () => {
+  test('a corpus with no pointers ends up with some', () => {
+    const { db, sqlite } = freshDb();
+    seed(db, sqlite, 'doc-1', 'the indexer queued zero vector jobs for deployment', ['deploy']);
+
+    expect(pointerCount(sqlite)).toBe(0);
+    const result = runPointerBackfill(sqlite);
+
+    // The headline assertion of #2880: 0 → not 0.
+    expect(result.pointersBefore).toBe(0);
+    expect(result.pointersAfter).toBeGreaterThan(0);
+    expect(pointerCount(sqlite)).toBe(result.pointersAfter);
+    expect(result.written).toBe(1);
+  });
+
+  test('every document with content is covered, not just the first', () => {
+    const { db, sqlite } = freshDb();
+    for (const id of ['a', 'b', 'c']) seed(db, sqlite, id, `document ${id} about oracle memory search`, ['memory']);
+
+    const result = runPointerBackfill(sqlite);
+    expect(result.scanned).toBe(3);
+    expect(result.written).toBe(3);
+  });
+
+  test('it reports the counts it changed, so the caller can prove it did something', () => {
+    const { db, sqlite } = freshDb();
+    seed(db, sqlite, 'doc-1', 'pointers derived from real content', ['pointer']);
+    const result = runPointerBackfill(sqlite);
+    expect(result.pointersAfter).toBeGreaterThan(result.pointersBefore);
+    expect(result.errors).toEqual([]);
+  });
+});
+
+describe('it does not invent coverage', () => {
+  test('a document with no indexed content is reported, not silently passed over', () => {
+    /**
+     * The scan joins onto oracle_fts, so a document with no FTS row is invisible to it — there
+     * is nothing to derive pointers from. That is correct, but it must be *visible*: the live
+     * corpus has 35,179 documents against 35,170 FTS rows, and a nine-document gap that nothing
+     * mentions is how a partial backfill gets mistaken for a complete one.
+     */
+    const { db, sqlite } = freshDb();
+    const now = Date.now();
+    db.insert(tenants).values({ id: 'default', status: 'active', createdAt: now, updatedAt: now }).onConflictDoNothing().run();
+    // Deliberately no oracle_fts row.
+    db.insert(oracleDocuments).values({
+      id: 'no-content', tenantId: 'default', type: 'learning', sourceFile: 'notes/x.md',
+      concepts: '[]', createdAt: now, updatedAt: now, indexedAt: now,
+    }).run();
+
+    const result = runPointerBackfill(sqlite);
+    expect(result.written).toBe(0);
+    expect(pointerCount(sqlite)).toBe(0);
+    // The gap is named in the result rather than left for someone to notice.
+    expect(result.documentsTotal).toBe(1);
+    expect(result.documentsWithoutContent).toBe(1);
+  });
+
+  test('a corpus where every document has content reports no gap', () => {
+    const { db, sqlite } = freshDb();
+    seed(db, sqlite, 'doc-1', 'oracle memory search over a real corpus', ['memory']);
+    const result = runPointerBackfill(sqlite);
+    expect(result.documentsTotal).toBe(1);
+    expect(result.documentsWithoutContent).toBe(0);
+  });
+
+  test('an empty corpus is a clean no-op', () => {
+    const { sqlite } = freshDb();
+    const result = runPointerBackfill(sqlite);
+    expect(result.scanned).toBe(0);
+    expect(result.written).toBe(0);
+    expect(result.errors).toEqual([]);
+  });
+});
+
+describe('re-running is safe and does not double-count', () => {
+  test('a second run does not grow the table', () => {
+    const { db, sqlite } = freshDb();
+    seed(db, sqlite, 'doc-1', 'oracle memory search over a real corpus', ['memory']);
+
+    const first = runPointerBackfill(sqlite);
+    expect(first.written).toBe(1);
+
+    const second = runPointerBackfill(sqlite);
+    expect(second.pointersAfter).toBe(first.pointersAfter);
+  });
+
+  test('re-running is idempotent — same rows, no duplicates', () => {
+    const { db, sqlite } = freshDb();
+    seed(db, sqlite, 'doc-1', 'oracle memory search over a real corpus', ['memory']);
+    const first = runPointerBackfill(sqlite);
+
+    // The sweep always re-derives; the write merges by pointer id, so the count is stable.
+    const again = runPointerBackfill(sqlite);
+    expect(again.written).toBe(1);
+    expect(again.pointersAfter).toBe(first.pointersAfter);
+  });
+});
+
+describe('limits', () => {
+  test('limit caps how many documents are processed', () => {
+    const { db, sqlite } = freshDb();
+    for (const id of ['a', 'b', 'c', 'd']) seed(db, sqlite, id, `document ${id} about deployment`, ['deploy']);
+
+    const result = runPointerBackfill(sqlite, { limit: 2 });
+    expect(result.scanned).toBe(2);
+    expect(result.written).toBe(2);
+  });
+
+  test('every document in a larger corpus is covered', () => {
+    const { db, sqlite } = freshDb();
+    const ids = Array.from({ length: 9 }, (_, i) => `doc-${i}`);
+    for (const id of ids) seed(db, sqlite, id, `content for ${id} mentioning deployment`, ['deploy']);
+
+    const result = runPointerBackfill(sqlite);
+    expect(result.scanned).toBe(9);
+    expect(result.written).toBe(9);
+  });
+});


### PR DESCRIPTION
`oracle_pointer_index` held **0 rows against 35,179 documents**. `handleSearch` called `queryPointerIndex` on every request and merged an empty result, so one of its ranking inputs contributed nothing — every time, for every query.

Three parts. **Any one alone makes things worse**, which is why they ship together.

## 1. Why it was empty

The write code was always correct. The asymmetry was the bug:

| | call sites |
|---|---|
| `replaceEntityLinks` | **8** — indexer storage, entity backfill, `routes/indexer/start`, `routes/learn/crud` ×3, `routes/sessions/store`, `routes/files/doc` |
| `replaceDocumentPointers` | **1** — `src/indexer/storage.ts:99` |

Entity links are refreshed by ordinary use, which is why 167 existed with backfill switched off. Pointers were written only by a full indexer pass, so the table sat at zero and would return to stale immediately after any reindex.

This PR gives pointers parity at all 8 sites.

## 2. The backfill, and two designs that looked right

`bun run pointers:backfill`. Deliberately **not** behind an off-by-default env flag — `runEntityBackfillSweep` is (`ORACLE_ENTITY_BACKFILL=1`, currently off), and a backfill nobody can run is indistinguishable from no backfill.

**First design — paginate.** `GROUP BY d.id ORDER BY d.updated_at DESC LIMIT ? OFFSET ?` plus `NOT EXISTS (… doc_ids LIKE '%"id"%')` to skip covered documents. Measured against the real database:

```
plain streaming join, all 35,170 rows ....   0.04s
+ GROUP BY, LIMIT 100 ....................   1.27s
+ ORDER BY and the doc_ids LIKE subquery .. >120s, did not finish
```

Per *batch*. The whole sweep timed out at ten minutes. Grouping and sorting across a join onto an FTS5 virtual table materialises every row before the LIMIT applies, and the `LIKE` cannot use an index — each batch redid the work of the entire corpus. Pagination was solving a problem a whole-corpus operation does not have.

**Shipped design — one streaming pass**, pointers accumulated in memory, one bulk write.

## 3. Backfill alone would have been worse than the bug

Populating the table exposed a latent O(corpus) read. `hydratePointerDocs` passed **every** matched id into `inArray(oracleDocuments.id, ids)` joined onto `oracle_fts`, fetching all of them before applying the limit in JS. That was free only because `ids` was always `[]`.

With real rows, `entity|oracle` lists 11,840 documents and `date|2026` lists 34,614 — 98% of the corpus. One query took **over 120 seconds**.

| approach | 3 queries |
|---|---|
| unbounded join (original) | **>120,000 ms** |
| candidate cap 200 | 3,100 ms |
| candidate cap 50 | 700 ms — *fixes latency by trading recall* |
| **two queries, cap back to 200** | **31 ms** |

The fix is to stop paying FTS cost for candidates about to be discarded: rank on `oracle_documents` alone (primary-key lookups), cut to `limit`, then fetch content for just those. Candidate breadth stops costing anything, so the cap stays generous — **no recall traded**.

Also skipped: pointers listing more than 5,000 documents. Classic IDF — a key matching a third of the corpus cannot discriminate, so reading it is pure cost. Counted by scanning separators rather than `JSON.parse`, since the parse is the cost being avoided.

## Measured impact

On a **copy** of the live database. The original was never written to.

```
backfill: pointers 0 → 35,556   (35,170 documents, 1,507 ms)
          entity 31,219 · topic 4,203 · date 134
          9 documents have no oracle_fts row — reported, not passed over
query:    >120,000 ms → 31 ms, results relevant and content populated
```

The nine-document gap is surfaced in `PointerBackfillResult.documentsWithoutContent`. The corpus has 35,179 documents against 35,170 FTS rows, and an unmentioned gap is how a partial backfill gets mistaken for a complete one.

## Note on #2878

That PR added acronym expansions to `queryPointers`. It was correct but **unreachable in production**, because this table was empty. It starts mattering now.

## Gate

- `bunx tsc --noEmit` — exit 0
- `bun test --isolate src/search/ tests/search/ tests/workers/ tests/build/ tests/http/{search,learn,files,indexer}/ tests/indexer/` — **261 pass**
- Every file ≤250. `pointer-index.ts` went 260 → 170 via two real extractions (`pointer-ranking.ts`, `pointer-hydrate.ts`), not comment trimming
- `tests/search/` added to the CI groups — the coverage guard caught the gap once I staged the file, before CI did

Refs #2880
