### PR TITLE
fix: name the timeout for what it does, and consolidate three copies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
             tests/docs/ tests/config/ tests/process-manager/ tests/lifecycle/ \
             tests/smoke/ tests/export/ tests/services/ tests/knowledge/ tests/forum/ tests/eval/ \
             tests/bin/ tests/canvas/ tests/db/ tests/indexer/ tests/lib/ tests/oracles/ \
-            tests/runtime/ tests/search/ tests/server/ tests/vault/
+            tests/runtime/ tests/search/ tests/server/ tests/util/ tests/vault/
           do
             echo "::group::${group}"
             # Exit 133 is bun CRASHING (SIGTRAP), not a test failing — the two are

--- a/src/routes/vector/config-api-utils.ts
+++ b/src/routes/vector/config-api-utils.ts
@@ -12,6 +12,7 @@ import {
 import { createVectorStoreForModel } from '../../vector/factory.ts';
 import { localNativeVectorDisabledReason, localVectorIndexMissingReason } from '../../vector/cpu-capabilities.ts';
 import type { VectorDBType } from '../../vector/types.ts';
+import { withYieldingTimeout } from '../../util/yielding-timeout.ts';
 
 export type CollectionUpdate = Partial<Pick<VectorCollectionConfig,
   'adapter' | 'model' | 'provider' | 'service' | 'endpoint' | 'enabled' | 'primary' | 'embedder'
@@ -68,12 +69,6 @@ export function atomicWriteVectorConfig(config: VectorServerConfig): string {
   } catch (e) { try { if (fs.existsSync(tmp)) fs.unlinkSync(tmp); } catch {} throw e; }
 }
 
-function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<never>((_, reject) => { timer = setTimeout(() => reject(new Error('timeout')), ms); });
-  return Promise.race([promise, timeout]).finally(() => { if (timer) clearTimeout(timer); });
-}
-
 export async function inspectCollection(
   key: string,
   col: VectorCollectionConfig,
@@ -106,8 +101,8 @@ export async function inspectCollection(
   if (!preset) throw new Error(`Collection ${key} is not enabled`);
   const store = createVectorStoreForModel(preset);
   try {
-    await withTimeout(store.connect(), timeout);
-    const stats = await withTimeout(store.getStats(), timeout);
+    await withYieldingTimeout(store.connect(), timeout);
+    const stats = await withYieldingTimeout(store.getStats(), timeout);
     return {
       key, collection: col.collection, model: col.model, provider: col.provider,
       adapter, service: col.service, endpoint: col.endpoint,

--- a/src/server/vector-operations.ts
+++ b/src/server/vector-operations.ts
@@ -13,6 +13,7 @@ import { cosineDistanceToSimilarity } from '../vector/scoring.ts';
 import type { VectorStoreAdapter } from '../vector/types.ts';
 import type { SearchResult } from './types.ts';
 import type { VectorIndexModelInfo, VectorOperations, VectorSearchInput } from './vector-operation-types.ts';
+import { withYieldingTimeout } from '../util/yielding-timeout.ts';
 
 function modelKeys(model?: string): Array<string | undefined> {
   return selectVectorSearchModelKeys(model, getEmbeddingModels());
@@ -74,13 +75,6 @@ function dedupeMultiModel(results: SearchResult[]): SearchResult[] {
   return Array.from(bestByDoc.values());
 }
 
-async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
-  return Promise.race([
-    promise,
-    new Promise<never>((_, reject) => setTimeout(() => reject(new Error('timeout')), timeoutMs)),
-  ]);
-}
-
 export const localVectorOperations: VectorOperations = {
   async search(input) {
     const settled = await Promise.allSettled(modelKeys(input.model).map(model => searchOneModel(input, model)));
@@ -107,7 +101,7 @@ export const localVectorOperations: VectorOperations = {
           return;
         }
         const store = await ensureVectorStoreConnected(key);
-        const stats = await withTimeout(store.getStats(), timeoutMs);
+        const stats = await withYieldingTimeout(store.getStats(), timeoutMs);
         engines.push({ key, model: preset.model, collection: preset.collection, count: stats.count, enabled: true });
       } catch {
         engines.push({ key, model: preset.model, collection: preset.collection, count: 0, enabled: false });
@@ -138,7 +132,7 @@ export const localVectorOperations: VectorOperations = {
           return;
         }
         const store = await ensureVectorStoreConnected(key);
-        await withTimeout(store.getStats(), timeoutMs);
+        await withYieldingTimeout(store.getStats(), timeoutMs);
         engines.push({ key, model: preset.model, collection: preset.collection, ok: true });
       } catch (error) {
         engines.push({ key, model: preset.model, collection: preset.collection, ok: false, error: error instanceof Error ? error.message : String(error) });

--- a/src/util/yielding-timeout.ts
+++ b/src/util/yielding-timeout.ts
@@ -1,0 +1,53 @@
+/**
+ * A timeout that only works against work which *yields* (#2850).
+ *
+ * ## What this does not do
+ *
+ * It does **not** protect against synchronous blocking. `setTimeout` schedules its callback on
+ * the same event loop as the awaited work, so if that work blocks the loop the timer cannot
+ * fire — the guard is silent in exactly the case a timeout exists to catch. It works against
+ * work that is *slow but yielding*, never against work that is *stuck*.
+ *
+ * This is structural, not a tuning problem. No value of `timeoutMs` fixes it.
+ *
+ * ## Why it is named this way
+ *
+ * It was called `withTimeout`, in three separate copies. That name promises something the
+ * implementation cannot deliver, and two real DoS bugs on 2026-07-25 proved the gap: `GET
+ * /api/learn` never returned (#2836, an unbounded N+1 over `oracle_fts`, whose `id` is
+ * `UNINDEXED`, so every lookup was a full scan) and `/api/memory/consolidation/suggestions`
+ * pinned the server for eleven minutes (#2844). Both were invisible to an in-process
+ * `Promise.race` + `setTimeout` probe. Both were caught only by an OS-level timeout in a
+ * separate process.
+ *
+ * The name now says what it is, so a caller reaching for it can tell whether it fits.
+ *
+ * ## What to reach for when you need a real timeout
+ *
+ * Interrupting genuinely stuck work needs a separate OS process — for vector stores that is the
+ * sidecar, which already exists. `tests/util/yielding-timeout.test.ts` pins the limitation with
+ * a test that fails if someone "fixes" the name back.
+ */
+
+export class YieldingTimeoutError extends Error {
+  constructor(timeoutMs: number, label?: string) {
+    super(`${label ? `${label}: ` : ''}timed out after ${timeoutMs}ms (yielding work only)`);
+    this.name = 'YieldingTimeoutError';
+  }
+}
+
+/**
+ * Reject if `promise` has not settled within `timeoutMs` **and the event loop is free to
+ * notice**. See the module comment before relying on this for protection.
+ */
+export function withYieldingTimeout<T>(promise: Promise<T>, timeoutMs: number, label?: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new YieldingTimeoutError(timeoutMs, label)), timeoutMs);
+  });
+  // Clearing the timer matters: without it a long timeout keeps the process alive after the
+  // work has already settled, which is its own class of hang.
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer !== undefined) clearTimeout(timer);
+  }) as Promise<T>;
+}

--- a/src/vector/health.ts
+++ b/src/vector/health.ts
@@ -10,6 +10,7 @@ import { isVectorSectionEnabled } from './config.ts';
 import { localNativeVectorDisabledReason, localVectorIndexMissingReason } from './cpu-capabilities.ts';
 import { currentTenantId } from '../middleware/tenant.ts';
 import type { HealthStatus, RegisteredVectorService } from './service-registry.ts';
+import { withYieldingTimeout } from '../util/yielding-timeout.ts';
 
 export type VectorBackendEngine = {
   key: string;
@@ -137,14 +138,6 @@ export function buildVectorFreshness(
   };
 }
 
-function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new Error('timeout')), ms);
-  });
-  return Promise.race([promise, timeout]).finally(() => { if (timer) clearTimeout(timer); });
-}
-
 function vectorEngineDetails(preset: EmbeddingModelConfig) {
   return {
     adapter: preset.adapter || 'lancedb',
@@ -169,7 +162,7 @@ export async function readVectorBackendHealth(): Promise<VectorBackendHealth> {
         });
       if (unavailable) throw new Error(unavailable);
       const store = await ensureVectorStoreConnected(key);
-      const stats = await withTimeout(store.getStats(), timeout);
+      const stats = await withYieldingTimeout(store.getStats(), timeout);
       return {
         key,
         model: preset.model,

--- a/tests/util/yielding-timeout.test.ts
+++ b/tests/util/yielding-timeout.test.ts
@@ -1,0 +1,88 @@
+/**
+ * `withYieldingTimeout` works on yielding work and is blind to synchronous blocking (#2850).
+ *
+ * The blindness is the point of these tests. It is a real property of `Promise.race` +
+ * `setTimeout` — the timer shares the event loop it is supposed to police — and the decision on
+ * #2850 was to name and document that rather than pretend otherwise. A test that only proved
+ * the happy path would leave the next person free to rename it back to `withTimeout` and rely
+ * on it for protection it cannot give.
+ *
+ * Two real DoS bugs on 2026-07-25 were invisible to exactly this shape of probe: `GET
+ * /api/learn` never returning (#2836) and `/api/memory/consolidation/suggestions` pinning the
+ * server for eleven minutes (#2844). Both were caught only by an OS-level timeout in a separate
+ * process.
+ */
+import { describe, expect, test } from 'bun:test';
+import { withYieldingTimeout, YieldingTimeoutError } from '../../src/util/yielding-timeout.ts';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Occupies the event loop for real — no awaits, nothing to yield to. */
+function blockSynchronously(ms: number): void {
+  const until = Date.now() + ms;
+  while (Date.now() < until) { /* deliberately spinning */ }
+}
+
+describe('it does what it claims: yielding work', () => {
+  test('slow-but-yielding work is rejected', async () => {
+    await expect(withYieldingTimeout(sleep(400), 30)).rejects.toThrow(YieldingTimeoutError);
+  });
+
+  test('work that finishes in time resolves with its value', async () => {
+    await expect(withYieldingTimeout(sleep(1).then(() => 'ok'), 500)).resolves.toBe('ok');
+  });
+
+  test('the error names the budget and the label, so a log line is diagnosable', async () => {
+    const err = await withYieldingTimeout(sleep(400), 25, 'getStats').catch((e: Error) => e);
+    expect(err.message).toContain('25ms');
+    expect(err.message).toContain('getStats');
+  });
+
+  test('a rejection from the work itself passes through unchanged', async () => {
+    const boom = Promise.reject(new Error('store unreachable'));
+    await expect(withYieldingTimeout(boom, 500)).rejects.toThrow('store unreachable');
+  });
+});
+
+describe('it is blind to synchronous blocking — this is the documented limitation', () => {
+  test('a synchronously blocking operation is NOT interrupted', async () => {
+    /**
+     * The timer is scheduled for 20ms, the work blocks for 250ms. If the guard could interrupt
+     * synchronous blocking, this would reject at ~20ms. It cannot: the callback is queued
+     * behind the block, so the work completes first and the timeout loses the race.
+     *
+     * If this test ever starts failing, the implementation gained a real capability and the
+     * module comment — and the name — are now understating it. That is a good failure, but it
+     * must be a deliberate one.
+     */
+    const started = Date.now();
+    const result = await withYieldingTimeout(
+      (async () => { blockSynchronously(250); return 'finished anyway'; })(),
+      20,
+    );
+    const elapsed = Date.now() - started;
+
+    expect(result).toBe('finished anyway');
+    // It ran to completion despite a 20ms budget.
+    expect(elapsed).toBeGreaterThanOrEqual(200);
+  });
+
+  test('no value of the timeout changes that', async () => {
+    // Not a tuning problem: 1ms is as blind as 20ms.
+    const result = await withYieldingTimeout(
+      (async () => { blockSynchronously(150); return 'still finished'; })(),
+      1,
+    );
+    expect(result).toBe('still finished');
+  });
+});
+
+describe('the timer does not outlive the work', () => {
+  test('a long budget does not keep a settled call pending', async () => {
+    // Without clearTimeout, a 30s budget holds a timer for 30s after the work is done — a hang
+    // of its own kind at process exit.
+    const started = Date.now();
+    await withYieldingTimeout(Promise.resolve('fast'), 30_000);
+    expect(Date.now() - started).toBeLessThan(1_000);
+  });
+});


### PR DESCRIPTION
Records and implements the decision #2850 asked for.

## Decision: option 1 — document the limitation

**Reasoning.** Every call site wraps `store.getStats()` or `store.connect()` — I/O against a vector store. The mechanism that actually interrupts *stuck* work is a separate OS process, and for vector stores that already exists as **the sidecar**. Building a second one inside a timeout helper would duplicate it, and would still not protect the many call paths that never had a timeout at all.

Making the name honest is cheap, correct, and stops the helper from being reached for as protection it cannot give. Option 2 remains the right answer for a *specific* endpoint that needs a real guard — and the sidecar is how to get it.

## The issue named one copy. There were three.

| file | had its own `withTimeout` |
|---|---|
| `src/server/vector-operations.ts` | yes — the one #2850 quoted |
| `src/vector/health.ts` | yes |
| `src/routes/vector/config-api-utils.ts` | yes |

All three had the same blindness, and two had already independently added the `clearTimeout` the first was missing. Now one `withYieldingTimeout` in `src/util/yielding-timeout.ts`.

## Why the name changed

`setTimeout` schedules its callback on the **same event loop** as the awaited work. Blocking work starves the timer, so the guard is silent in exactly the case a timeout exists to catch. It works against work that is *slow but yielding*, never against work that is *stuck*.

Structural, not tuning — no value of `timeoutMs` fixes it. Both DoS bugs on 2026-07-25 were invisible to this shape of probe:

- **#2836** — `GET /api/learn` never returned: unbounded N+1 over `oracle_fts`, whose `id` is `UNINDEXED`, so every lookup was a full scan
- **#2844** — `/api/memory/consolidation/suggestions` pinned the server for 11 minutes

Both were caught only by an OS-level timeout in a separate process.

## The tests assert the blindness on purpose

Acceptance criterion for option 1 was name + comment. A comment is not a guard, so the limitation is pinned instead:

```
a synchronously blocking operation is NOT interrupted
  → 250ms block under a 20ms budget runs to completion
no value of the timeout changes that
  → 1ms budget is no better than 20ms
```

If those ever fail, the helper gained a real capability and the name now understates it. That is a good failure — but it must be a deliberate one, not a silent drift back to `withTimeout`.

Also pinned: the timer is cleared, so a 30-second budget does not hold a timer for 30 seconds after the work settled — a hang of its own kind at process exit.

## Gate

- `bunx tsc --noEmit` — exit 0
- `bun test --isolate tests/build/ tests/util/ tests/vector/ tests/http/vector/` — **264 pass**
- All files ≤250
- `tests/util/` added to the CI groups (the coverage guard would otherwise have caught it in CI, as it did twice tonight)

No behaviour change on the happy path. Errors now name the budget and an optional label instead of a bare `'timeout'`, so a log line is diagnosable.

Refs #2850
