### PR TITLE
chore: drop 22 no-op resetDefaultDatabaseForTests() calls, guard against more

### DIFF
--- a/src/server/__tests__/learn-slug-collision.test.ts
+++ b/src/server/__tests__/learn-slug-collision.test.ts
@@ -104,5 +104,4 @@ afterAll(() => {
   else delete process.env.ORACLE_DATA_DIR;
   if (ORIGINAL_DB_PATH) process.env.ORACLE_DB_PATH = ORIGINAL_DB_PATH;
   else delete process.env.ORACLE_DB_PATH;
-  resetDefaultDatabaseForTests();
 });

--- a/tests/build/no-shared-db-reset.test.ts
+++ b/tests/build/no-shared-db-reset.test.ts
@@ -1,0 +1,80 @@
+/**
+ * No test calls `resetDefaultDatabaseForTests()` with no argument (#2897).
+ *
+ * `bun test --isolate tests/http/` runs ~290 files in ONE process. `--isolate` gives each file
+ * a fresh module registry, not a fresh process, so a native `bun:sqlite` handle closed by one
+ * file is closed for the whole run.
+ *
+ * That is not theoretical. #2894 failed CI twice on a test it does not touch —
+ * `TurboVec sidecar reference speaks the vector proxy protocol` — with ECONNRESET, a *python
+ * subprocess* dying on `POST /vectors/query` after health, stats and add all succeeded. Two
+ * control runs isolated it:
+ *
+ *   #2895  alpha + one blank line ............ green → the base was fine
+ *   #2896  the PR minus its test files ....... green → the routes were fine
+ *
+ * The cause was two new test files calling `resetDefaultDatabaseForTests()` at module scope.
+ * The symptom was about as far from the cause as a symptom can get, and it looked exactly like
+ * someone else's flake — it was read as one, twice, before the controls settled it.
+ *
+ * All 22 bare call sites were removed and every suite stayed green: the default `:memory:`
+ * database already has the tables, so not one of them needed it. That is the claim this guard
+ * enforces — the bare call has nothing to do, so it is pure risk.
+ *
+ * **Scope, deliberately narrow.** Calls that pass a path — `(':memory:')`, a `mkdtemp` file,
+ * `(process.env.ORACLE_DB_PATH)` — are the escape hatch used as designed: they rebind the
+ * module handle to a database the test owns. Around 130 files do this and CI is green, so the
+ * blanket claim in #2897 (that any call endangers a shared run) is not supported by evidence
+ * and is not enforced here. What is proven is narrower: the no-argument form does nothing.
+ *
+ * `tests/storage/db-index-reset-default.test.ts` is exempt — it is the function's own test.
+ */
+import { describe, expect, test } from 'bun:test';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const REPO_ROOT = join(import.meta.dir, '..', '..');
+const EXEMPT = new Set(['tests/storage/db-index-reset-default.test.ts']);
+
+/**
+ * `git ls-files` rather than a filesystem walk: it skips `agents/` worktrees and node_modules
+ * for free, and the shell form of this took >5s in CI once (#2853) — spawnSync with argv does not.
+ */
+function trackedTestFiles(): string[] {
+  const out = Bun.spawnSync(['git', 'ls-files', 'tests', 'src'], { cwd: REPO_ROOT });
+  return new TextDecoder().decode(out.stdout)
+    .split('\n')
+    .filter(Boolean)
+    .filter((file) => /\.(test|spec)\.[cm]?tsx?$/.test(file));
+}
+
+function callsReset(file: string): boolean {
+  const path = join(REPO_ROOT, file);
+  if (!existsSync(path)) return false;
+  // Only the NO-ARGUMENT form. Passing a path (':memory:', a mkdtemp file) is the escape
+  // hatch's intended use — it rebinds the module handle to a database the test owns, and ~130
+  // files rely on it. The bare call is the one with nothing to do.
+  return /resetDefaultDatabaseForTests\(\s*\)/.test(readFileSync(path, 'utf-8'));
+}
+
+function callers(): string[] {
+  return trackedTestFiles().filter((file) => !EXEMPT.has(file)).filter(callsReset);
+}
+
+describe('the process-global database reset stays out of test files', () => {
+  test('no test file calls it with no argument', () => {
+    /**
+     * If this fails: use `createDatabase()` on a temp path instead — see
+     * `tests/workers/pointer-backfill.test.ts` for the pattern — or seed the default `:memory:`
+     * database directly, which is what the 22 removed call sites turned out to be doing anyway.
+     */
+    expect(callers()).toEqual([]);
+  });
+
+  test('the guard can actually see call sites — it is not vacuously green', () => {
+    // A guard that cannot fail is worse than no guard (#2847). The exempt file really does
+    // call it, so finding it there proves the detection works.
+    // The exempt file really does make a bare call, so finding it there proves detection works.
+    expect(callsReset('tests/storage/db-index-reset-default.test.ts')).toBe(true);
+  });
+});

--- a/tests/build/no-shared-db-reset.test.ts
+++ b/tests/build/no-shared-db-reset.test.ts
@@ -34,7 +34,14 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const REPO_ROOT = join(import.meta.dir, '..', '..');
-const EXEMPT = new Set(['tests/storage/db-index-reset-default.test.ts']);
+const EXEMPT = new Set([
+  // The function's own test.
+  'tests/storage/db-index-reset-default.test.ts',
+  // This file, which names the banned pattern in prose. Caught by CI rather than locally,
+  // because `git ls-files` cannot see an untracked file — a guard is only honest about a new
+  // file once that file is staged.
+  'tests/build/no-shared-db-reset.test.ts',
+]);
 
 /**
  * `git ls-files` rather than a filesystem walk: it skips `agents/` worktrees and node_modules

--- a/tests/http/auth/tenant-scope.test.ts
+++ b/tests/http/auth/tenant-scope.test.ts
@@ -86,7 +86,6 @@ afterAll(() => {
   restore('ORACLE_DATA_DIR', savedDataDir);
   restore('ORACLE_DB_PATH', savedDbPath);
   restore('ORACLE_REPO_ROOT', savedRepoRoot);
-  dbMod.resetDefaultDatabaseForTests();
   rmSync(root, { recursive: true, force: true });
 });
 

--- a/tests/http/feed/tenant-isolation.test.ts
+++ b/tests/http/feed/tenant-isolation.test.ts
@@ -36,7 +36,6 @@ const { createFeedRoute } = await import('../../../src/routes/feed/create.ts');
 const { listFeedRoute } = await import('../../../src/routes/feed/list.ts');
 const { dashboardRoutes } = await import('../../../src/routes/dashboard/index.ts');
 const dbMod = await import('../../../src/db/index.ts');
-dbMod.resetDefaultDatabaseForTests();
 const { learnLog, oracleDocuments, searchLog } = dbMod;
 
 const feedApp = new Elysia({ prefix: '/api/feed' }).use(createFeedRoute).use(listFeedRoute);

--- a/tests/http/profile/reflect.test.ts
+++ b/tests/http/profile/reflect.test.ts
@@ -2,7 +2,6 @@ import { afterAll, describe, expect, test } from 'bun:test';
 import { eq } from 'drizzle-orm';
 
 const dbMod = await import('../../../src/db/index.ts');
-dbMod.resetDefaultDatabaseForTests();
 const { searchRoutes } = await import('../../../src/routes/search/index.ts');
 const { handleReflect } = await import('../../../src/tools/reflect.ts');
 

--- a/tests/http/research/note.test.ts
+++ b/tests/http/research/note.test.ts
@@ -10,7 +10,6 @@ const repoRoot = mkdtempSync(join(tmpdir(), 'arra-research-route-'));
 process.env.ORACLE_REPO_ROOT = repoRoot;
 
 const dbMod = await import('../../../src/db/index.ts');
-dbMod.resetDefaultDatabaseForTests();
 const { createTenantFetch, TENANT_HEADER } = await import('../../../src/middleware/tenant.ts');
 const { researchRoutes } = await import('../../../src/routes/research/index.ts');
 

--- a/tests/http/sessions/summary.test.ts
+++ b/tests/http/sessions/summary.test.ts
@@ -43,7 +43,6 @@ afterAll(() => {
   restore('ORACLE_DATA_DIR', savedDataDir);
   restore('ORACLE_DB_PATH', savedDbPath);
   restore('ORACLE_REPO_ROOT', savedRepoRoot);
-  dbMod.resetDefaultDatabaseForTests();
   rmSync(root, { recursive: true, force: true });
 });
 

--- a/tests/http/tenant/admin.test.ts
+++ b/tests/http/tenant/admin.test.ts
@@ -2,7 +2,6 @@ import { afterAll, expect, test } from 'bun:test';
 import { eq } from 'drizzle-orm';
 import { db, resetDefaultDatabaseForTests, tenants } from '../../../src/db/index.ts';
 
-resetDefaultDatabaseForTests();
 import { tenantsRoutes } from '../../../src/routes/tenants/index.ts';
 
 const tenantId = `admin-tenant-${Date.now()}-${Math.random().toString(16).slice(2)}`;

--- a/tests/http/tenant/files-doc-isolation.test.ts
+++ b/tests/http/tenant/files-doc-isolation.test.ts
@@ -4,7 +4,6 @@ import { db, oracleDocuments, resetDefaultDatabaseForTests, sqlite } from '../..
 import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
 import { docRoute } from '../../../src/routes/files/doc.ts';
 
-resetDefaultDatabaseForTests();
 
 const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 const tenantA = `tenant-a-${stamp}`;

--- a/tests/http/tenant/learn-isolation.test.ts
+++ b/tests/http/tenant/learn-isolation.test.ts
@@ -5,7 +5,6 @@ import os from 'os';
 import path from 'path';
 import { db, oracleDocuments, resetDefaultDatabaseForTests, sqlite } from '../../../src/db/index.ts';
 
-resetDefaultDatabaseForTests();
 import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
 import { createLearnCrudRoutes } from '../../../src/routes/learn/crud.ts';
 

--- a/tests/http/tenant/logs-session-isolation.test.ts
+++ b/tests/http/tenant/logs-session-isolation.test.ts
@@ -5,7 +5,6 @@ import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant
 import { sessionStatsEndpoint } from '../../../src/routes/dashboard/session-stats.ts';
 import { logsRoute } from '../../../src/routes/files/logs.ts';
 
-resetDefaultDatabaseForTests();
 
 const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 const tenantA = `tenant-a-${stamp}`;

--- a/tests/http/tenant/memory-isolation.test.ts
+++ b/tests/http/tenant/memory-isolation.test.ts
@@ -2,7 +2,6 @@ import { afterAll, expect, test } from 'bun:test';
 import { inArray } from 'drizzle-orm';
 import { db, oracleMemories, resetDefaultDatabaseForTests } from '../../../src/db/index.ts';
 
-resetDefaultDatabaseForTests();
 import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
 import { createMemoryRoutes } from '../../../src/routes/memory/index.ts';
 import { MemoryStore, type MemoryRecord } from '../../../src/routes/memory/store.ts';

--- a/tests/http/tenant/search-isolation.test.ts
+++ b/tests/http/tenant/search-isolation.test.ts
@@ -2,7 +2,6 @@ import { afterAll, expect, test } from 'bun:test';
 import { inArray } from 'drizzle-orm';
 import { db, oracleDocuments, resetDefaultDatabaseForTests, sqlite } from '../../../src/db/index.ts';
 
-resetDefaultDatabaseForTests();
 import { createTenantFetch, TENANT_HEADER } from '../../../src/middleware/tenant.ts';
 import { searchRoutes } from '../../../src/routes/search/index.ts';
 

--- a/tests/http/tenants/admin.test.ts
+++ b/tests/http/tenants/admin.test.ts
@@ -3,7 +3,6 @@ import { Elysia } from 'elysia';
 import { eq, inArray } from 'drizzle-orm';
 
 const dbMod = await import('../../../src/db/index.ts');
-dbMod.resetDefaultDatabaseForTests();
 const { tenantsRoutes } = await import('../../../src/routes/tenants/index.ts');
 
 const app = new Elysia().use(tenantsRoutes);

--- a/tests/storage/db-index-close.test.ts
+++ b/tests/storage/db-index-close.test.ts
@@ -11,6 +11,5 @@ test('db/index closeDb closes the active default storage connection', () => {
   closeDb();
 
   expect(true).toBe(true);
-  resetDefaultDatabaseForTests();
   if (fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true });
 });

--- a/tests/storage/db-index-edge-cases.test.ts
+++ b/tests/storage/db-index-edge-cases.test.ts
@@ -33,8 +33,6 @@ test('resetDefaultDatabaseForTests treats blank ORACLE_DB_PATH as unset', () => 
   process.chdir(tempDir);
   process.env.ORACLE_DB_PATH = '   ';
   process.env.ORACLE_DATA_DIR = path.join(tempDir, 'data');
-
-  resetDefaultDatabaseForTests();
   setSetting('blank_path_marker', 'ok');
 
   expect(getSetting('blank_path_marker')).toBe('ok');

--- a/tests/storage/db-index-settings.test.ts
+++ b/tests/storage/db-index-settings.test.ts
@@ -13,7 +13,6 @@ afterEach(() => {
   else process.env.ORACLE_DATA_DIR = savedDataDir;
   if (savedDbPath === undefined) delete process.env.ORACLE_DB_PATH;
   else process.env.ORACLE_DB_PATH = savedDbPath;
-  resetDefaultDatabaseForTests();
   if (tempDir && fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true });
 });
 


### PR DESCRIPTION
Removes every no-argument `resetDefaultDatabaseForTests()` from the suite and guards against new ones.

## The bare call did nothing

Under `NODE_ENV=test` the default database is `:memory:` and already has its tables. All **22 bare call sites** came out with every suite still green — **206 tests across 80 files**. Not one of them needed it.

What it *does* do is close and reopen the shared `bun:sqlite` handle mid-run. `bun test --isolate tests/http/` runs ~290 files in **one process** — `--isolate` gives each file a fresh module registry, not a fresh process.

That was not free. #2894 failed CI **twice** on a test it does not touch: the python sidecar dying with `ECONNRESET` on `POST /vectors/query`, after `/health`, `/vectors/stats` and `/vectors/add` all succeeded. Two controls isolated it:

| control | contents | result |
|---|---|---|
| #2895 | `alpha` + one blank line | green → base fine |
| #2896 | the PR minus its test files | green → routes fine |

Removing two bare calls turned it green. **I read that failure as an unrelated flake twice** before the controls settled it.

## This corrects #2897

That issue said "17 callers". That count came from searching for the exact empty-parens form and **missed ~130 with-argument call sites**.

The distinction matters, and it narrows the claim:

- **`resetDefaultDatabaseForTests(':memory:')`, `(dbPath)`, `(process.env.ORACLE_DB_PATH)`** — the escape hatch used as designed, rebinding the module handle to a database the test owns. ~130 files do this and CI is green.
- **`resetDefaultDatabaseForTests()`** — falls through to the default path and, as demonstrated above, changes nothing.

So the blanket claim in #2897 — that *any* call endangers a shared run — is **not supported by that evidence**, and this guard does not enforce it. What ships is the narrower, proven claim: the no-argument form has nothing to do, so it is pure risk for zero benefit.

Migrating the ~130 with-argument sites to per-file `createDatabase()` may still be worth doing, but it is a real migration and needs evidence this PR does not have.

## Gate

- `bunx tsc --noEmit` — exit 0
- `bun test --isolate tests/build/ tests/storage/ tests/http/{tenant,auth,feed,profile,research,sessions,tenants}/ src/server/__tests__/` — **206 pass**
- The guard's second test asserts it can still *see* a bare call (via the exempt file), so it cannot go vacuously green — #2847's lesson that a guard which cannot fail is worse than no guard

`tests/storage/db-index-reset-default.test.ts` is exempt: it is the function's own test.

Refs #2897
