### PR TITLE
fix: give each acronym expansion a boundary so entity extraction stops merging them

### DIFF
--- a/src/search/acronyms.ts
+++ b/src/search/acronyms.ts
@@ -48,9 +48,37 @@ export function expansionPhrasesForText(text: string): string[] {
   return phrases;
 }
 
+/**
+ * Separator between the query and each appended expansion (#2876).
+ *
+ * Expansions used to be appended as bare space-joined text, so two adjacent ones merged under
+ * entity extraction into a phrase that matches nothing:
+ *
+ *   "what does the API and db do"
+ *     → "… Application Programming Interface Database"
+ *     → entities: ["API", "Application Programming Interface Database"]
+ *
+ * Neither `application-programming-interface` nor `database` survived as a key, so entity-link
+ * boosting was **silently skipped**. Even a single acronym merged with its own expansion:
+ * `"API"` produced the entity `"API Application Programming Interface"`.
+ *
+ * **This does not change retrieval.** `buildTenantFtsQuery` (src/search/query.ts:49) and
+ * `src/tools/search/helpers.ts` both build the FTS query with `.match(/[\p{L}\p{N}_]+/gu)`,
+ * which takes only letters, digits and underscores — punctuation is invisible to them, so the
+ * token set is byte-identical either way. That is what made this safe to change: the issue
+ * deferred the fix because the augmented string also feeds FTS, and it turns out the FTS path
+ * never sees the separator at all. `tests/search/acronym-boundary.test.ts` pins that.
+ *
+ * A semicolon rather than a comma or period: `extractEntities` treats a period as part of the
+ * run (`"…Interface. Database"` stays merged), and commas occur in ordinary queries.
+ */
+export const ACRONYM_EXPANSION_SEPARATOR = ';';
+
 export function augmentQueryWithAcronyms(query: string): string {
   const additions = expansionsForText(query);
-  return additions.length ? `${query} ${additions.join(' ')}` : query;
+  if (!additions.length) return query;
+  const sep = `${ACRONYM_EXPANSION_SEPARATOR} `;
+  return `${query}${sep}${additions.join(sep)}`;
 }
 
 export function enrichTextWithAcronyms(text: string): string {

--- a/src/search/entity-ranking.ts
+++ b/src/search/entity-ranking.ts
@@ -5,6 +5,7 @@ import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 import * as schema from '../db/schema.ts';
 import { extractEntities } from '../vector/entities.ts';
 import { expansionPhrasesForText } from './acronyms.ts';
+import { noteEntityBoostOutcome } from './signal-health.ts';
 
 const ENTITY_BOOST_PER_MATCH = 0.08;
 const ENTITY_BOOST_CAP = 0.24;
@@ -90,6 +91,9 @@ export function rerankByEntityLinks<T extends Rankable>(
 ): Array<T & EntityRankFields> {
   const ids = results.map((result) => result.id).filter(Boolean).slice(0, MAX_RANKING_CANDIDATES);
   const signals = entitySignalsForCandidates(dbInput, ids, query, tenantId);
+  // Recorded either way: a boost that never applies is otherwise indistinguishable from one
+  // that applies and changes nothing (#2876, #2878).
+  noteEntityBoostOutcome(signals.size > 0);
   if (signals.size === 0) return results;
 
   return results.map((result, index) => {

--- a/src/search/signal-health.ts
+++ b/src/search/signal-health.ts
@@ -58,6 +58,36 @@ export function noteRankingSignalCoverage(sqlite: Database, signal: string, tabl
 }
 
 /** Tests only — the guard is process-global. */
+const entityBoostCounters = { applied: 0, skipped: 0 };
+
+export function noteEntityBoostOutcome(applied: boolean): void {
+  if (applied) entityBoostCounters.applied += 1;
+  else entityBoostCounters.skipped += 1;
+}
+
+/**
+ * A snapshot of ranking-signal outcomes since process start.
+ *
+ * `skipped` climbing while `applied` stays at zero is the shape of a silently dead boost — the
+ * thing that was invisible in #2876 and #2878.
+ */
+export function rankingSignalCounters(): { entityBoost: { applied: number; skipped: number } } {
+  return { entityBoost: { ...entityBoostCounters } };
+}
 export function resetSignalHealth(): void {
   checked.clear();
+  entityBoostCounters.applied = 0;
+  entityBoostCounters.skipped = 0;
 }
+
+/**
+ * Cumulative outcomes for the entity boost (#2876, acceptance criterion 4).
+ *
+ * A *warning* would be wrong here: a query that matches no linked entity is an ordinary,
+ * frequent outcome, not a defect, so warning per query would cry wolf on the search hot path.
+ * What was missing is the ability to answer "is this boost ever applying?" at all — #2876 shows
+ * the boost being skipped for every two-acronym query with nothing recording it, and #2878
+ * shows a fix that was a no-op in production for the same reason: no counter, no signal.
+ *
+ * Counting is O(1) and allocation-free, so it is safe on every request.
+ */

--- a/tests/search/acronym-boundary.test.ts
+++ b/tests/search/acronym-boundary.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Acronym expansions must not merge into one entity (#2876).
+ *
+ * `augmentQueryWithAcronyms` appended expansions as bare space-joined text, so two adjacent
+ * ones merged under entity extraction into a phrase that matches nothing:
+ *
+ *   "what does the API and db do"
+ *     → "… Application Programming Interface Database"
+ *     → entities: ["API", "Application Programming Interface Database"]
+ *
+ * Neither `application-programming-interface` nor `database` survived as a key, so entity-link
+ * boosting was silently skipped — results still returned, ranked by FTS alone, looking entirely
+ * normal. Same shape as #2857 and #2863: a stage does nothing while the pipeline reports
+ * success.
+ *
+ * #2876 deferred the fix because the augmented string also feeds FTS, and changing its shape
+ * would change retrieval for every query. **It turns out the FTS path never sees the
+ * separator**: both `buildTenantFtsQuery` and `src/tools/search/helpers.ts` tokenise with
+ * `/[\p{L}\p{N}_]+/gu`, which takes only letters, digits and underscores. The third describe
+ * block below is the one that made this shippable — it pins that invariance rather than
+ * assuming it.
+ */
+import { describe, expect, test } from 'bun:test';
+import { augmentQueryWithAcronyms } from '../../src/search/acronyms.ts';
+import { buildTenantFtsQuery } from '../../src/search/query.ts';
+import { extractEntities } from '../../src/vector/entities.ts';
+import { noteEntityBoostOutcome, rankingSignalCounters, resetSignalHealth } from '../../src/search/signal-health.ts';
+
+const TWO_ACRONYMS = 'what does the API and db do';
+
+describe('expansions stay separate entities', () => {
+  test('a two-acronym query yields both expansions as distinct entities', () => {
+    const entities = extractEntities(augmentQueryWithAcronyms(TWO_ACRONYMS));
+    expect(entities).toContain('Application Programming Interface');
+    expect(entities).toContain('Database');
+  });
+
+  test('the merged phrase is gone', () => {
+    // This exact string was the bug: not a thing, matched nothing, and displaced two real keys.
+    expect(extractEntities(augmentQueryWithAcronyms(TWO_ACRONYMS)))
+      .not.toContain('Application Programming Interface Database');
+  });
+
+  test('a single acronym does not merge with its own expansion', () => {
+    // "API" used to extract as the single entity "API Application Programming Interface".
+    const entities = extractEntities(augmentQueryWithAcronyms('API'));
+    expect(entities).toContain('Application Programming Interface');
+    expect(entities).not.toContain('API Application Programming Interface');
+  });
+
+  test('order does not matter — "db API" behaves like "API db"', () => {
+    // The issue's table showed the two orderings failing differently, which is its own tell.
+    for (const query of ['API db', 'db API']) {
+      const entities = extractEntities(augmentQueryWithAcronyms(query));
+      expect(entities).toContain('Application Programming Interface');
+      expect(entities).toContain('Database');
+    }
+  });
+});
+
+describe('a query with no acronyms is untouched', () => {
+  test('no separator is appended when there is nothing to append', () => {
+    const plain = 'deployment plan for the cluster';
+    expect(augmentQueryWithAcronyms(plain)).toBe(plain);
+  });
+});
+
+describe('retrieval is unchanged — the reason #2876 deferred this', () => {
+  /**
+   * The FTS query is built from `/[\p{L}\p{N}_]+/gu` matches, so punctuation cannot appear in
+   * it. These tests compare against a locally reconstructed "old format" (bare space-joined)
+   * to show the token sets are identical, rather than asserting a hard-coded string that would
+   * pass for the wrong reason if the tokeniser changed.
+   */
+  function ftsTokens(query: string): string[] {
+    return buildTenantFtsQuery(query).split(' OR ').map((t) => t.replace(/^"|"$/g, ''));
+  }
+
+  /** What the tokeniser would produce from the pre-fix, bare-joined augmented string. */
+  function tokensOfOldFormat(augmented: string): string[] {
+    const bare = augmented.replaceAll('; ', ' ');
+    const matched = bare.normalize('NFKC').match(/[\p{L}\p{N}_]+/gu) ?? [];
+    return [...new Set(matched)];
+  }
+
+  for (const query of [TWO_ACRONYMS, 'API', 'API db', 'db API', 'deployment plan']) {
+    test(`"${query}" produces the same FTS tokens as the old format`, () => {
+      expect(ftsTokens(query)).toEqual(tokensOfOldFormat(augmentQueryWithAcronyms(query)));
+    });
+  }
+
+  test('the separator never reaches the FTS query', () => {
+    expect(buildTenantFtsQuery(TWO_ACRONYMS)).not.toContain(';');
+  });
+});
+
+describe('the entity boost records whether it applied (#2876 criterion 4)', () => {
+  /**
+   * A *warning* would be wrong: a query matching no linked entity is ordinary, so warning per
+   * query would cry wolf on the search hot path. What was missing is any way to answer "is this
+   * boost ever applying?" — #2876 had it skipped for every two-acronym query, and #2878 shipped
+   * a fix that was a no-op in production. Both were invisible for the same reason.
+   */
+  test('a skipped boost increments the skipped counter', () => {
+    resetSignalHealth();
+    const before = rankingSignalCounters().entityBoost;
+    noteEntityBoostOutcome(false);
+    expect(rankingSignalCounters().entityBoost.skipped).toBe(before.skipped + 1);
+    expect(rankingSignalCounters().entityBoost.applied).toBe(before.applied);
+  });
+
+  test('an applied boost increments the applied counter', () => {
+    resetSignalHealth();
+    noteEntityBoostOutcome(true);
+    expect(rankingSignalCounters().entityBoost).toEqual({ applied: 1, skipped: 0 });
+  });
+
+  test('the snapshot is a copy, not a live reference', () => {
+    // Handing out the mutable object would let a caller corrupt the counters by accident.
+    resetSignalHealth();
+    const snapshot = rankingSignalCounters();
+    noteEntityBoostOutcome(true);
+    expect(snapshot.entityBoost.applied).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes out #2876's five acceptance criteria.

## The fix is one character, and the reason it was safe is the interesting part

Expansions were appended as bare space-joined text, so two adjacent ones merged under entity extraction into a phrase that matches nothing:

```
"what does the API and db do"
  → "… Application Programming Interface Database"
  → entities: ["API", "Application Programming Interface Database"]
```

Neither `application-programming-interface` nor `database` survived as a key, so the entity boost was **silently skipped**. Even a single acronym merged with its own expansion — `"API"` extracted as `"API Application Programming Interface"`.

**#2876 deferred the fix for a good reason**: the augmented string also feeds FTS, and reshaping it would change retrieval for every query. *That reason turns out not to apply.* Both `buildTenantFtsQuery` (`src/search/query.ts:49`) and `src/tools/search/helpers.ts` build the FTS query with

```ts
.match(/[\p{L}\p{N}_]+/gu)
```

— letters, digits and underscores only. **Punctuation never reaches the FTS path**, so the token set is byte-identical with or without a separator.

That fact is what made this shippable, so it is pinned by test rather than assumed. The tests compare against a *reconstructed pre-fix string* rather than a hard-coded expectation, so they cannot pass for the wrong reason if the tokeniser changes:

```ts
expect(ftsTokens(query)).toEqual(tokensOfOldFormat(augmentQueryWithAcronyms(query)));
```

**Why a semicolon**: `extractEntities` treats a period as part of the run (`"…Interface. Database"` stays merged), and commas occur in ordinary queries.

## Acceptance criteria

| # | criterion | status |
|---|---|---|
| 1 | two-acronym query yields both expansions separately | done, tested |
| 2 | single acronym does not merge with its own expansion | done, tested |
| 3 | FTS results unchanged | **proven** by token-set equivalence |
| 4 | empty entity signals observable | done — a **counter**, see below |
| 5 | #2874's assertion passes 20 consecutive runs | **20 runs, 0 failures** |

## On criterion 4: a counter, not a warning

A per-query warning would be wrong. A query matching no linked entity is an ordinary, frequent outcome, not a defect — warning on it would cry wolf on the search hot path, which is precisely the mistake #2826 made and #2846 had to undo.

What was actually missing is the ability to answer *"is this boost ever applying?"*. `rankingSignalCounters()` answers it: `skipped` climbing while `applied` stays at zero is the shape of a silently dead boost. That is exactly the state #2878 shipped into production undetected.

Counting is O(1) and allocation-free, so it is safe on every request.

## Gate

- `bunx tsc --noEmit` — exit 0
- `bun test --isolate tests/search/ src/search/ tests/http/{search,vector}/ tests/build/ tests/mcp/` — **337 pass**
- All files ≤250

Refs #2876
