### PR TITLE
fix: honour route-declared menu path and studio

### DIFF
--- a/src/db/seeders/menu-seeder.ts
+++ b/src/db/seeders/menu-seeder.ts
@@ -77,7 +77,10 @@ export function collectRouteMenuRows(sources: HasRoutes[]): RouteMenuRow[] {
       const menu = detail.menu;
       if (!menu || !menu.group || !isVisibleMenuGroup(menu.group)) continue;
 
-      const studio = studioPathFor(route.path);
+      // Honour a route-declared path, same as menu-items.ts — the two builders must not
+      // disagree about where a route lives (#2862).
+      const declaredPath = typeof menu.path === 'string' && menu.path.trim() ? menu.path.trim() : undefined;
+      const studio = declaredPath ?? studioPathFor(route.path);
       if (!studio) continue;
 
       const slug = studio.replace(/^\//, '') || 'home';
@@ -91,7 +94,7 @@ export function collectRouteMenuRows(sources: HasRoutes[]): RouteMenuRow[] {
         position: order,
         access: menu.access ?? 'public',
         icon: menu.icon ?? null,
-        studio: null,
+        studio: menu.studio ?? null,
       };
       const seenRow = { ...row, apiPath: route.path };
       const key = routeMenuKey(row.path, row.studio);

--- a/src/routes/menu/__tests__/menu-route-metadata.test.ts
+++ b/src/routes/menu/__tests__/menu-route-metadata.test.ts
@@ -37,15 +37,18 @@ function routeSource() {
  * every one has `studio: null`. `MenuMeta.studio` is typed, documented and schema-validated
  * (model.ts:19-22, :53) and read by nothing.
  *
- * Skipped rather than deleted because the assertion is a specification, and un-skipping it is
- * the acceptance criterion for #2862. Honouring the fields would take /api/menu from 10
- * route-derived entries to ~90 — a product decision, not a test fix.
+ * UN-SKIPPED: the specification is now implemented, and the estimate that made it a product
+ * decision did not survive measurement.
  *
- * Skipped rather than left failing because #2853 expands CI to run src/, and a permanently
- * red gate teaches everyone to ignore it. A skip that names its issue stays visible in the
- * test output; an unrun directory does not.
+ * "Honouring the fields would take /api/menu from 10 route-derived entries to ~90" counted the
+ * 93 routes declaring `menu: {…}`. Only **11 declare a `path`**, and 9 of those 11 already
+ * resolve to the same value through `API_TO_STUDIO`. Honouring the field adds exactly two
+ * entries — `/ask` and `/tools/config` — so this is a bug fix, not a navigation redesign.
+ *
+ * The skip was still the right call at the time: it kept a specification visible instead of
+ * teaching everyone to ignore a permanently red gate. It just needed the number checked.
  */
-describe.skip('route-declared menu metadata', () => {
+describe('route-declared menu metadata', () => {
   it('uses detail.menu.path/studio instead of deriving from API path', () => {
     expect(menuItemsFromRoutes([routeSource()])).toEqual([
       {

--- a/src/routes/menu/menu-items.ts
+++ b/src/routes/menu/menu-items.ts
@@ -50,7 +50,16 @@ export function menuItemsFromRoutes(sources: HasRoutes[]): MenuItem[] {
       const menu = detail.menu;
       if (!menu?.group) continue;
 
-      const studio = studioPathFor(route.path);
+      // A route that declares its own frontend path is believed. `API_TO_STUDIO` stays as the
+      // fallback for the ~80 routes that declare a group but no path (#2862).
+      //
+      // Measured before changing this: 93 routes declare `menu: {…}` but only 11 declare a
+      // `path`, and 9 of those 11 already resolve to the same value through the lookup table.
+      // So honouring the field adds exactly two entries — `/ask` and `/tools/config` — not the
+      // ~80 the issue estimated. That is what makes this a bug fix rather than a navigation
+      // redesign: the declaration and the behaviour now agree, and the menu barely moves.
+      const declaredPath = typeof menu.path === 'string' && menu.path.trim() ? menu.path.trim() : undefined;
+      const studio = declaredPath ?? studioPathFor(route.path);
       if (!studio) continue;
 
       const key = `${menu.group}:${studio}`;
@@ -61,7 +70,15 @@ export function menuItemsFromRoutes(sources: HasRoutes[]): MenuItem[] {
         typeof menu.order === 'number' && Number.isFinite(menu.order) ? menu.order : 999;
       const slug = studio.replace(/^\//, '') || 'home';
       const label = menu.label ?? slug.charAt(0).toUpperCase() + slug.slice(1);
-      items.push({ path: studio, label, group: menu.group, order, source: 'api' });
+      items.push({
+        path: studio,
+        label,
+        group: menu.group,
+        order,
+        source: 'api',
+        // Declared, typed, documented and schema'd since #1857 — and never emitted until now.
+        ...(menu.studio ? { studio: menu.studio } : {}),
+      });
     }
   }
 


### PR DESCRIPTION
`MenuMeta.path` and `.studio` were typed, documented and schema-validated — and read by nothing. Both builders derived the path from a 14-entry lookup instead.

## The estimate that made this a product decision did not survive measurement

#2862 filed this as a navigation decision rather than a bug, because honouring the fields would take `/api/menu` **from 10 route-derived entries to ~90**. That number counted the routes declaring `menu: {…}` at all.

Measured:

| | count |
|---|---|
| routes declaring `menu: {…}` | **93** |
| routes declaring an explicit `menu.path` | **11** |
| of those 11, already resolving to the same value via `API_TO_STUDIO` | **9** |

The real delta is **two entries**: `/ask` and `/tools/config` — neither `/api/ask` nor `/api/settings` is one of the 14 prefixes. Everything else already resolved identically.

So this is a bug fix, not a navigation redesign. Routes that declare a group but no path are untouched; `API_TO_STUDIO` still serves them as the fallback.

## What changed

Both builders — `menuItemsFromRoutes` and `collectRouteMenuRows` — now believe a declared `menu.path` and fall back to the lookup otherwise, and both emit `menu.studio` instead of a hard-coded `null`. Keeping them in step matters: two builders disagreeing about where a route lives is its own bug.

## The skipped specification

`menu-route-metadata.test.ts` was `describe.skip`, with a comment stating that un-skipping it *is* the acceptance criterion for #2862. It is now un-skipped and green.

**Mutation-checked** — without the builder change, both go red:

```
WITHOUT the fix:  0 pass, 2 fail
WITH the fix:     2 pass, 0 fail
```

The original skip was the right call: it kept a specification visible rather than leaving a permanently red gate that teaches everyone to ignore it. It just needed its number checked.

## Acceptance criteria (#2862)

- **A decision on (1)–(3), recorded** — see below
- **`MenuMeta.path` / `.studio` honoured, not silently ignored** — done
- **`menu-route-metadata.test.ts` green** — done, un-skipped

**(1) Is `menu: {…}` opt-in advertising or documentation?** Advertising, but only the `path` field is a claim about placement. A route declaring group+order without a path is asking to be placed by convention, and the lookup still does that. No declarations need removing.

**(2) Should `API_TO_STUDIO` exist?** Yes, as the fallback for the ~80 routes with no declared path. It stops being a *contradictory* source of truth because the declaration now wins where both apply.

**(3) Cross-studio entries** — intended and lost in the divergence, not something that never shipped: the field is documented with an example (`canvas.buildwithoracle.com`) and schema'd. Now emitted.

## Gate

- `bunx tsc --noEmit` — exit 0
- `bun test --isolate src/routes/ tests/http/menu/ tests/build/ tests/plugins/` — **267 pass**
- All files ≤250

Refs #2862
