### PR TITLE
test: make the turbovec sidecar failure explain itself

### DIFF
--- a/tests/http/vector/turbovec-sidecar.test.ts
+++ b/tests/http/vector/turbovec-sidecar.test.ts
@@ -31,9 +31,44 @@ async function waitForHealth(base: string): Promise<void> {
   throw new Error(`sidecar did not become healthy: ${last}`);
 }
 
+/**
+ * Everything the sidecar told us, for when it dies mid-test (#2905).
+ *
+ * The process is spawned with `stdio: 'pipe'`, which captures stdout and stderr into streams
+ * that nothing read — so on failure the python traceback, the one artefact that would explain
+ * the crash, was discarded. This test has failed intermittently in CI with ECONNRESET on
+ * `/vectors/query` and the logs said nothing about why, which is most of the reason it was
+ * misdiagnosed twice.
+ */
+const sidecarOutput = { stdout: '', stderr: '', exit: '' as string };
+
+function attachDiagnostics(child: ChildProcessWithoutNullStreams): void {
+  child.stdout?.on('data', (chunk) => { sidecarOutput.stdout += String(chunk); });
+  child.stderr?.on('data', (chunk) => { sidecarOutput.stderr += String(chunk); });
+  child.on('exit', (code, signal) => {
+    sidecarOutput.exit = `exited early: code=${code ?? 'null'} signal=${signal ?? 'null'}`;
+  });
+}
+
+function diagnostics(): string {
+  const parts = [
+    sidecarOutput.exit,
+    sidecarOutput.stderr.trim() && `--- sidecar stderr ---\n${sidecarOutput.stderr.trim()}`,
+    sidecarOutput.stdout.trim() && `--- sidecar stdout ---\n${sidecarOutput.stdout.trim()}`,
+  ].filter(Boolean);
+  return parts.length ? `\n${parts.join('\n')}` : '\n(sidecar produced no output)';
+}
+
 async function json(path: string, init?: RequestInit) {
-  const res = await fetch(path, init);
-  expect(res.ok).toBe(true);
+  let res: Response;
+  try {
+    res = await fetch(path, init);
+  } catch (error) {
+    // Without this the CI log shows only "socket connection was closed unexpectedly".
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`${init?.method ?? 'GET'} ${path} failed: ${reason}${diagnostics()}`);
+  }
+  if (!res.ok) throw new Error(`${init?.method ?? 'GET'} ${path} → HTTP ${res.status}${diagnostics()}`);
   return await res.json() as Record<string, any>;
 }
 
@@ -48,6 +83,7 @@ test('TurboVec sidecar reference speaks the vector proxy protocol', async () => 
     cwd: process.cwd(),
     stdio: 'pipe',
   });
+  attachDiagnostics(sidecar);
   sidecar.on('error', (error) => { throw error; });
   await waitForHealth(base);
 


### PR DESCRIPTION
Prerequisite for #2905, which I could not diagnose because the evidence was being thrown away.

## The sidecar's own output was captured and discarded

`spawn(..., { stdio: 'pipe' })` routes stdout and stderr into streams that nothing reads. When the sidecar dies mid-test, CI shows only:

```
error: The socket connection was closed unexpectedly
  path: "http://127.0.0.1:PORT/vectors/query", code: "ECONNRESET"
```

No traceback, no exit code, no signal. **That silence is most of why this test got misdiagnosed twice in one night** — first dismissed as an unrelated flake with no evidence, then blamed on an unrelated PR after two control runs came back green (which, at a ~50% flake rate, is exactly what chance produces). There was nothing in the logs to argue with in either direction.

## What changes

stdout, stderr and exit status are collected and appended to any fetch failure or health-timeout message.

**Verified by actually killing the sidecar mid-test**, not by assuming the path works:

```
error: POST http://127.0.0.1:64138/vectors/query failed: Unable to connect...
exited early: code=null signal=SIGKILL
```

A diagnostic that has never been seen to fire is not a diagnostic.

## This does not fix the flake

It makes the next occurrence diagnosable, which is the prerequisite for fixing it. #2905 lists what would actually settle the cause.

Tests only — no change to what is asserted.

Refs #2905