### PR TITLE
fix(sidecar): speak HTTP/1.1 so pooled connections are not reset

### DIFF
--- a/sidecar/turbovec/server.py
+++ b/sidecar/turbovec/server.py
@@ -26,6 +26,17 @@ from vector_index import DIMENSIONS, PROTOCOL, VERSION, VectorIndex
 class Handler(BaseHTTPRequestHandler):
     index: VectorIndex
 
+    # BaseHTTPRequestHandler defaults to HTTP/1.0, which closes the socket after every
+    # response. Clients that pool connections — bun's fetch does — reuse a socket the server
+    # has already closed and get ECONNRESET on a later request. That is the intermittent CI
+    # failure in #2905: no traceback, no exit, the server perfectly healthy, and the failing
+    # endpoint varying between /vectors/add and /vectors/query depending on which request
+    # happened to land on a reused connection.
+    #
+    # Safe to raise here because send_json() always sets content-length, so the client can
+    # find the message boundary — which is what HTTP/1.1 keep-alive requires.
+    protocol_version = "HTTP/1.1"
+
     def log_message(self, fmt: str, *args: Any) -> None:
         print(f"[turbovec-sidecar] {self.address_string()} {fmt % args}")
 


### PR DESCRIPTION
Root cause of #2905, the flake I misdiagnosed twice.

## The cause

`BaseHTTPRequestHandler` defaults to **HTTP/1.0**, which closes the socket after every response. Clients that pool connections — bun's `fetch` does — reuse a socket the server has already closed and get `ECONNRESET`.

Confirmed with curl against the running sidecar:

```
before:  HTTP/1.0 200 OK
after:   HTTP/1.1 200 OK
         req1 http=200 connects=1
         req2 http=200 connects=0    ← connection reused instead of reset
```

## It explains every symptom, including the confusing ones

| symptom | why |
|---|---|
| no python traceback, no early exit | the server never crashed; only the *connection* died |
| failing endpoint moved between `/vectors/query` and `/vectors/add` | whichever request happened to land on a reused socket |
| never reproduced locally, 20+ runs | whether a pooled socket gets reused is timing-dependent |
| ~130ms failures, far under the 5s health deadline | a reset is immediate, not a timeout |

## How it was found

**#2906 made it diagnosable two hours earlier.** The decisive line in the next CI failure was:

```
(sidecar produced no output)
```

A crash would have left a traceback. Its absence ruled out the entire class of explanation I had been assuming — and had twice asserted publicly, in opposite directions. The fix took ten minutes once the log said something.

That is the argument for spending a PR on diagnostics before a fix: the previous three CI cycles produced no information at all.

## Safety

Raising the protocol version is safe here because `send_json()` sets `content-length` on every response, which is what HTTP/1.1 keep-alive needs to find message boundaries. `ThreadingHTTPServer` already handles concurrent connections.

Sidecar only — no application code touched.

Closes #2905