### PR TITLE
fix(frontend): read either envelope shape, so #2821 stops being a breaking change

### DIFF
--- a/frontend/src/pages/vectorSettingsHelpers.ts
+++ b/frontend/src/pages/vectorSettingsHelpers.ts
@@ -194,5 +194,31 @@ export async function fetchJson<T>(path: string, init: RequestInit = {}): Promis
     const message = isRecord(payload) && typeof payload.error === 'string' ? payload.error : response.statusText;
     throw new Error(`${path} returned ${response.status}: ${message}`);
   }
-  return payload as T;
+  return unwrapEnvelope(payload) as T;
+}
+
+/**
+ * Read either envelope shape, so the backend can stop duplicating fields (#2821).
+ *
+ * `src/middleware/response-format.ts:41` currently returns `{ success, data: response,
+ * ...response }` — every field twice, once nested and once spread at top level. The spread is a
+ * transitional shim from #1777 that was never removed, and callers here read the top-level copy.
+ *
+ * Removing it backend-side would make those reads silently `undefined`, because `payload as T`
+ * is a cast: tsc cannot see the mismatch and nothing would fail until a page rendered blank.
+ * So the frontend learns to prefer `data` first, and the backend cleanup becomes a change that
+ * cannot break this file whichever shape arrives.
+ *
+ * Deliberately conservative: only unwraps when the payload looks exactly like the envelope —
+ * `success` present and `data` an object. A response that legitimately has its own `data` field
+ * without `success` is left alone.
+ */
+export function unwrapEnvelope(payload: unknown): unknown {
+  if (!isRecord(payload)) return payload;
+  if (!('success' in payload)) return payload;
+  const inner = payload.data;
+  if (inner === null || typeof inner !== 'object') return payload;
+  // Keep any envelope-level keys the caller might read (e.g. `success`) but let the
+  // nested fields win, since those are the ones that survive the backend cleanup.
+  return { ...payload, ...(inner as Record<string, unknown>) };
 }

--- a/tests/frontend/pages/response-envelope-unwrap.test.ts
+++ b/tests/frontend/pages/response-envelope-unwrap.test.ts
@@ -1,0 +1,80 @@
+/**
+ * `fetchJson` must read either envelope shape (#2821).
+ *
+ * `src/middleware/response-format.ts:41` returns `{ success: true, data: response, ...response }`
+ * — every field twice, once nested and once spread at top level. The spread is a transitional
+ * shim from #1777 that was never removed, and every caller in this file reads the top-level copy.
+ *
+ * Removing it backend-side is the actual fix, but it would make those reads silently
+ * `undefined`: `fetchJson` ends in `payload as T`, and a cast is not a check — tsc sees nothing
+ * and no test fails until a page renders blank. #2821 calls this out and says the backend and
+ * frontend changes must land together or the frontend breaks silently.
+ *
+ * This is the half that carries no risk. Teaching the frontend to prefer `data` first means the
+ * backend cleanup afterwards cannot break it, whichever shape arrives — so the breaking change
+ * stops being breaking.
+ */
+import { describe, expect, test } from 'bun:test';
+import { unwrapEnvelope } from '../../../frontend/src/pages/vectorSettingsHelpers';
+
+describe('the current double-shaped envelope', () => {
+  test('nested fields are returned', () => {
+    const payload = { success: true, data: { engine: 'lancedb', enabled: true }, engine: 'lancedb', enabled: true };
+    expect(unwrapEnvelope(payload)).toMatchObject({ engine: 'lancedb', enabled: true });
+  });
+});
+
+describe('the post-cleanup shape, with no top-level spread', () => {
+  test('fields are still found under data', () => {
+    // This is what the backend returns once `...response` is dropped. Today it would make
+    // every caller read undefined.
+    const payload = { success: true, data: { engine: 'qdrant', enabled: false } };
+    expect(unwrapEnvelope(payload)).toMatchObject({ engine: 'qdrant', enabled: false });
+  });
+
+  test('a nested array field survives', () => {
+    const payload = { success: true, data: { services: [{ name: 'a' }, { name: 'b' }] } };
+    expect((unwrapEnvelope(payload) as { services: unknown[] }).services).toHaveLength(2);
+  });
+
+  test('nested wins over a stale top-level copy', () => {
+    // During the transition both exist. The nested one is the copy that survives.
+    const payload = { success: true, data: { engine: 'new' }, engine: 'stale' };
+    expect(unwrapEnvelope(payload)).toMatchObject({ engine: 'new' });
+  });
+});
+
+describe('it does not unwrap things that are not envelopes', () => {
+  test('a payload with its own data field but no success is left alone', () => {
+    // A legitimate response whose domain model happens to include `data`.
+    const payload = { data: { rows: 3 }, total: 1 };
+    expect(unwrapEnvelope(payload)).toEqual(payload);
+  });
+
+  test('a null data field is left alone', () => {
+    const payload = { success: true, data: null };
+    expect(unwrapEnvelope(payload)).toEqual(payload);
+  });
+
+  test('a scalar data field is left alone', () => {
+    // `{ success: true, data: 5 }` must not be spread — there is nothing to spread.
+    const payload = { success: true, data: 5 };
+    expect(unwrapEnvelope(payload)).toEqual(payload);
+  });
+
+  test('a bare array is returned unchanged', () => {
+    expect(unwrapEnvelope([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+
+  test('null and non-objects pass through', () => {
+    expect(unwrapEnvelope(null)).toBeNull();
+    expect(unwrapEnvelope('text')).toBe('text');
+  });
+});
+
+describe('envelope keys stay reachable', () => {
+  test('success is preserved alongside the unwrapped fields', () => {
+    // Some callers check `success`; unwrapping must not hide it.
+    expect(unwrapEnvelope({ success: true, data: { a: 1 } })).toMatchObject({ success: true, a: 1 });
+  });
+});


### PR DESCRIPTION
Groundwork for #2821 that carries no risk of its own.

## The problem #2821 describes

`src/middleware/response-format.ts:41` returns every field twice:

```ts
return { success: true, data: response, ...response };
//                      ^^^^ nest        ^^^^ spread again
```

The spread is a transitional shim from #1777, kept so clients reading top-level fields would not break when the envelope was introduced. It was never cleaned up.

## Why it has not been fixed

#2821 marks it **breaking**, correctly. `fetchJson` ends in:

```ts
return payload as T;
```

A cast is not a check. Drop the backend spread today and ~18 frontend call sites silently read `undefined` — tsc stays green, no test fails, and nothing surfaces until a page renders blank. The issue says the backend and frontend halves must land together.

## This is the half with no risk

Teaching `fetchJson` to prefer `data` first means the backend cleanup afterwards **cannot** break it, whichever shape arrives. The breaking change stops being breaking and can land on its own merits.

**No behavioural change today** — while the spread is still there, both shapes resolve identically.

## Deliberately conservative

Only unwraps when the payload looks exactly like the envelope: `success` present **and** `data` a non-null object. Left alone:

- a response whose own domain model includes a `data` field but no `success`
- `{ success: true, data: null }`
- `{ success: true, data: 5 }` — nothing to spread
- bare arrays, strings, null

Envelope keys stay reachable, since some callers read `success`.

## What I did not do

**I did not remove the backend spread.** Its done-criteria include *"Settings and Vector pages still render real data"*, which needs a browser I cannot drive at this hour — and shipping the breaking half unverified against a live system is not a trade worth making for a payload-size win. With this merged, that follow-up is a two-line change with a real safety net under it.

## Gate

- `bunx tsc --noEmit` — exit 0, root **and** frontend
- `bun test --isolate tests/frontend/pages/ tests/http/response-format/` — **154 pass**

Refs #2821