### PR TITLE
ci: fail deploys fast when Cloudflare credentials are absent

### DIFF
--- a/.github/workflows/deploy-canvas-worker.yml
+++ b/.github/workflows/deploy-canvas-worker.yml
@@ -60,6 +60,24 @@ jobs:
           tests/http/canvas/
           tests/canvas/
 
+      - name: Check deploy credentials
+        env:
+          CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          # Fail here rather than after install + typecheck + build. Both deploys have been
+          # red since 2026-07-05 (#2680) with the cause — an absent token — buried under
+          # ~3 minutes of successful build output and a wrangler stack trace. A workflow that
+          # is permanently red for an unreadable reason trains everyone to ignore it.
+          missing=""
+          [ -z "${CF_TOKEN}" ]   && missing="${missing} CLOUDFLARE_API_TOKEN"
+          [ -z "${CF_ACCOUNT}" ] && missing="${missing} CLOUDFLARE_ACCOUNT_ID"
+          if [ -n "${missing}" ]; then
+            echo "::error::Missing deploy credential(s):${missing}. Add them as repository secrets, or as environment secrets on this job's environment. Measured 2026-07-27: the repo had 0 Actions secrets and both worker environments had 0. See #2680."
+            exit 1
+          fi
+          echo "Deploy credentials present."
+
       - name: Deploy Cloudflare Worker
         uses: cloudflare/wrangler-action@v3
         with:

--- a/.github/workflows/deploy-studio-worker.yml
+++ b/.github/workflows/deploy-studio-worker.yml
@@ -70,6 +70,24 @@ jobs:
             echo "No Studio worker tests found yet."
           fi
 
+      - name: Check deploy credentials
+        env:
+          CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          # Fail here rather than after install + typecheck + build. Both deploys have been
+          # red since 2026-07-05 (#2680) with the cause — an absent token — buried under
+          # ~3 minutes of successful build output and a wrangler stack trace. A workflow that
+          # is permanently red for an unreadable reason trains everyone to ignore it.
+          missing=""
+          [ -z "${CF_TOKEN}" ]   && missing="${missing} CLOUDFLARE_API_TOKEN"
+          [ -z "${CF_ACCOUNT}" ] && missing="${missing} CLOUDFLARE_ACCOUNT_ID"
+          if [ -n "${missing}" ]; then
+            echo "::error::Missing deploy credential(s):${missing}. Add them as repository secrets, or as environment secrets on this job's environment. Measured 2026-07-27: the repo had 0 Actions secrets and both worker environments had 0. See #2680."
+            exit 1
+          fi
+          echo "Deploy credentials present."
+
       - name: Deploy Cloudflare Worker
         if: steps.studio.outputs.ready == 'true'
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
Root cause for #2680, plus the in-repo half of its done-criteria.

## Root cause

```
✘ [ERROR] In a non-interactive environment, it's necessary to set a
CLOUDFLARE_API_TOKEN environment variable for wrangler to work.
```

The workflows *do* pass `apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}`. The failing run's `with:` block shows only `command` and `quiet` — GitHub omits empty inputs, so **the secret resolved to empty**.

Measured with the GitHub API rather than inferred from the log:

| scope | Actions secrets |
|---|---|
| repository | **0** |
| `studio-worker` environment | **0** |
| `canvas-worker` environment | **0** |
| organization | cannot read — 403, needs `admin:org` |

So the credentials are absent everywhere I can see. I cannot rule out an org-level secret that simply is not shared with this repo, and I am not going to assert it either way.

**The fix is external**: add `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` as repository secrets, or as environment secrets on `studio-worker` and `canvas-worker`. Nothing in the repo needs changing to make the deploys work.

## What this PR does change

Both deploys have been red since **2026-07-05** — three weeks — and every push to `alpha` re-runs them. The cause is stated plainly by wrangler, but only after ~3 minutes of install, typecheck and build, so the log reads as a build that succeeded followed by an opaque stack trace.

This adds a preflight that fails in seconds with an actionable `::error::` naming the missing secret.

## What it deliberately does not do

**It does not skip the deploy when credentials are missing.** A skipped deploy is a deploy silently not happening — the exact defect shape this repo spent the night removing (#2857, #2863, #2877, #2880). Red is the honest state; it should just be *legible* red.

The same reasoning as #2862's skipped test: a permanently red gate nobody can read teaches everyone to ignore red.

CI only — no application code touched.

Refs #2680