### PR TITLE
chore(mcp): retire the muninn_ alias, keeping a voice on the retired prefix

### DIFF
--- a/src/__tests__/resolve-tool-name.test.ts
+++ b/src/__tests__/resolve-tool-name.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'bun:test';
-import { resolveToolName, deprecatedAliasWarning, resolveInboundToolName } from '../index.ts';
+import { resolveToolName, deprecatedAliasWarning, resolveInboundToolName, retiredAliasNotice } from '../index.ts';
 
-describe('resolveToolName — 3-generation alias chain (arra_* | muninn_* → oracle_*)', () => {
+describe('resolveToolName — alias chain (arra_* → oracle_*; muninn_* retired)', () => {
   describe('arra_* (original, pre-#1172)', () => {
     it('maps every legacy arra_* tool to oracle_*', () => {
       const pairs: Array<[string, string]> = [
@@ -31,32 +31,43 @@ describe('resolveToolName — 3-generation alias chain (arra_* | muninn_* → or
     });
   });
 
-  describe('muninn_* (briefly canonical, #1172 → #1236)', () => {
-    it('maps every muninn_* tool to oracle_*', () => {
-      const pairs: Array<[string, string]> = [
-        ['muninn_search', 'oracle_search'],
-        ['muninn_read', 'oracle_read'],
-        ['muninn_list', 'oracle_list'],
-        ['muninn_stats', 'oracle_stats'],
-        ['muninn_concepts', 'oracle_concepts'],
-        ['muninn_learn', 'oracle_learn'],
-        ['muninn_supersede', 'oracle_supersede'],
-        ['muninn_handoff', 'oracle_handoff'],
-        ['muninn_inbox', 'oracle_inbox'],
-        ['muninn_thread', 'oracle_thread'],
-        ['muninn_threads', 'oracle_threads'],
-        ['muninn_thread_read', 'oracle_thread_read'],
-        ['muninn_thread_update', 'oracle_thread_update'],
-        ['muninn_trace', 'oracle_trace'],
-        ['muninn_trace_list', 'oracle_trace_list'],
-        ['muninn_trace_get', 'oracle_trace_get'],
-        ['muninn_trace_link', 'oracle_trace_link'],
-        ['muninn_trace_unlink', 'oracle_trace_unlink'],
-        ['muninn_trace_chain', 'oracle_trace_chain'],
-      ];
-      for (const [old, neu] of pairs) {
-        expect(resolveToolName(old)).toBe(neu);
+  describe('muninn_* (briefly canonical #1172 → #1236, REMOVED #2824)', () => {
+    /**
+     * It no longer resolves. #2824's cycle: warn for one release (#2839), ship it
+     * (v26.7.26-alpha.227 contains that commit), then remove — which is this.
+     */
+    it('no longer maps muninn_* to oracle_*', () => {
+      for (const name of ['muninn_search', 'muninn_read', 'muninn_trace_chain']) {
+        expect(resolveToolName(name)).toBe(name);
       }
+    });
+
+    it('says what to call instead, rather than failing silently', () => {
+      /**
+       * The reason #2824 required a deprecation release first: `resolveToolName` returns an
+       * unmatched name unchanged, so the call dies later as a generic tool-not-found with
+       * nothing pointing at the rename. Removal keeps a voice on the retired prefix.
+       */
+      expect(retiredAliasNotice('muninn_search')).toContain('was REMOVED');
+      expect(retiredAliasNotice('muninn_search')).toContain('oracle_search');
+    });
+
+    it('resolveInboundToolName logs the notice and does not resolve', () => {
+      const logs: string[] = [];
+      const resolved = resolveInboundToolName('muninn_search', (m) => void logs.push(m));
+      // Unchanged on purpose — resolving it anyway would make the removal cosmetic.
+      expect(resolved).toBe('muninn_search');
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).toContain('was REMOVED');
+    });
+
+    it('a bare muninn_ prefix has no replacement to name', () => {
+      expect(retiredAliasNotice('muninn_')).toBeNull();
+    });
+
+    it('does not fire on a name that merely contains muninn_', () => {
+      expect(retiredAliasNotice('not_muninn_thing')).toBeNull();
+      expect(resolveToolName('not_muninn_thing')).toBe('not_muninn_thing');
     });
   });
 
@@ -77,9 +88,9 @@ describe('resolveToolName — 3-generation alias chain (arra_* | muninn_* → or
 
     it('only strips the LEADING legacy prefix — preserves the rest of the name', () => {
       expect(resolveToolName('arra_new_thing')).toBe('oracle_new_thing');
-      expect(resolveToolName('muninn_new_thing')).toBe('oracle_new_thing');
+      expect(resolveToolName('muninn_new_thing')).toBe('muninn_new_thing');
       expect(resolveToolName('arra_a_b_c_d')).toBe('oracle_a_b_c_d');
-      expect(resolveToolName('muninn_a_b_c_d')).toBe('oracle_a_b_c_d');
+      expect(resolveToolName('muninn_a_b_c_d')).toBe('muninn_a_b_c_d');
     });
 
     it('does not double-strip when a name contains both prefixes', () => {
@@ -97,12 +108,9 @@ describe('resolveToolName — 3-generation alias chain (arra_* | muninn_* → or
     };
 
     it('still resolves muninn_* AND warns, naming the replacement', () => {
-      const { resolved, logs } = collect('muninn_search');
-      expect(resolved).toBe('oracle_search');
-      expect(logs).toHaveLength(1);
-      expect(logs[0]).toBe(
-        '[MCP] tool alias "muninn_search" is deprecated — use "oracle_search" (removal planned next release)',
-      );
+      // muninn_ has completed the cycle; DEPRECATED_PREFIXES is empty, so nothing warns.
+      expect(deprecatedAliasWarning('muninn_search')).toBeNull();
+      expect(deprecatedAliasWarning('arra_search')).toBeNull();
     });
 
     it('resolves arra_* with NO warning — arra_ is not deprecated', () => {
@@ -126,10 +134,8 @@ describe('resolveToolName — 3-generation alias chain (arra_* | muninn_* → or
       expect(logs).toEqual([]);
     });
 
-    it('warns on the trimmed name for padded muninn_* input', () => {
-      expect(deprecatedAliasWarning('  muninn_oracle_search  ')).toBe(
-        '[MCP] tool alias "muninn_oracle_search" is deprecated — use "oracle_search" (removal planned next release)',
-      );
+    it('trims padded input before deciding on a retired alias', () => {
+      expect(retiredAliasNotice('  muninn_oracle_search  ')).toContain('oracle_search');
     });
 
     it('keeps resolveToolName itself pure — resolving never logs', () => {
@@ -137,7 +143,7 @@ describe('resolveToolName — 3-generation alias chain (arra_* | muninn_* → or
       const original = console.error;
       console.error = (...args: unknown[]) => void errors.push(args);
       try {
-        expect(resolveToolName('muninn_search')).toBe('oracle_search');
+        expect(resolveToolName('arra_search')).toBe('oracle_search');
       } finally {
         console.error = original;
       }

--- a/src/__tests__/tool-list-filter.test.ts
+++ b/src/__tests__/tool-list-filter.test.ts
@@ -23,12 +23,22 @@ describe('filterAdvertisedTools', () => {
     expect(listed.map((t) => t.name)).toEqual(['oracle_search']);
   });
 
-  test('normalizes legacy aliases before matching disabled tools', () => {
+  test('normalizes the arra_ alias before matching disabled tools', () => {
     const listed = filterAdvertisedTools(
-      [{ name: 'muninn_search' }, { name: 'arra_learn' }, { name: 'custom_tool' }],
+      [{ name: 'arra_learn' }, { name: 'custom_tool' }],
       new Set(['oracle_search', 'oracle_learn']),
     );
 
     expect(listed.map((t) => t.name)).toEqual(['custom_tool']);
+  });
+
+  test('muninn_ is no longer normalized, so it no longer matches its oracle_ target (#2824)', () => {
+    // Retired: `muninn_search` is now just a name, not an alias for `oracle_search`.
+    const listed = filterAdvertisedTools(
+      [{ name: 'muninn_search' }, { name: 'custom_tool' }],
+      new Set(['oracle_search']),
+    );
+
+    expect(listed.map((t) => t.name)).toEqual(['muninn_search', 'custom_tool']);
   });
 });

--- a/src/config/__tests__/tool-env-overrides.test.ts
+++ b/src/config/__tests__/tool-env-overrides.test.ts
@@ -67,9 +67,11 @@ describe('ORACLE_ENABLED_TOOLS / ORACLE_DISABLED_TOOLS', () => {
     });
   });
 
-  it('normalizes aliases and ignores unknown names', () => {
+  it('normalizes the arra_ alias and ignores unknown names', () => {
+    // `muninn_read` is now an unknown name, not an alias — retired in #2824, so it is
+    // dropped exactly like `not_a_tool` rather than resolving to `oracle_read`.
     withEnv({ ORACLE_ENABLED_TOOLS: 'arra_search,muninn_read,not_a_tool' }, () => {
-      expect(getEnabledToolNames(applyToolEnvOverrides(ALL_ON)).sort()).toEqual(['oracle_read', 'oracle_search']);
+      expect(getEnabledToolNames(applyToolEnvOverrides(ALL_ON)).sort()).toEqual(['oracle_search']);
     });
   });
 

--- a/src/config/tool-alias-warn.ts
+++ b/src/config/tool-alias-warn.ts
@@ -1,4 +1,4 @@
-import { deprecatedAliasWarning } from '../mcp/aliases.ts';
+import { aliasNotice } from '../mcp/aliases.ts';
 
 /**
  * Deprecation warnings for the NON-MCP inbound surfaces.
@@ -8,7 +8,7 @@ import { deprecatedAliasWarning } from '../mcp/aliases.ts';
  * the `arra.config.json` file and the ORACLE_*_TOOLS env vars all rewrite the
  * alias through `normalizeToolName` and, before this module, did so in silence.
  *
- * The MESSAGE deliberately lives in exactly one place — `deprecatedAliasWarning`
+ * The MESSAGE deliberately lives in exactly one place — `aliasNotice`
  * in src/mcp/aliases.ts — so these surfaces can never drift into a second dialect
  * of the same notice. The `[MCP]` tag it carries is kept even here: the noun being
  * labelled is an MCP tool name, whatever transport carried it.
@@ -20,10 +20,10 @@ import { deprecatedAliasWarning } from '../mcp/aliases.ts';
  * hide a real second event.
  *
  * Silent for `arra_` (supported, not deprecated) and for canonical `oracle_*`,
- * because `deprecatedAliasWarning` returns null for both.
+ * because `aliasNotice` returns null for both.
  */
 export function warnDeprecatedAlias(name: string, log: (m: string) => void = console.error): void {
-  const warning = deprecatedAliasWarning(name);
+  const warning = aliasNotice(name);
   if (warning) log(warning);
 }
 
@@ -39,7 +39,7 @@ const warned = new Set<string>();
  * log flood, not a notice — one `muninn_` entry would emit ~864k lines/day.
  */
 export function warnDeprecatedAliasOnce(name: string, log: (m: string) => void = console.error): void {
-  const warning = deprecatedAliasWarning(name);
+  const warning = aliasNotice(name);
   if (!warning || warned.has(name)) return;
   warned.add(name);
   log(warning);

--- a/src/config/tool-groups-core.ts
+++ b/src/config/tool-groups-core.ts
@@ -1,5 +1,6 @@
 import { envToolList, isRecord, resolveConfigSourceWithRaw } from './tool-config-source.ts';
 import { warnDeprecatedAliasOnce, warnOnce } from './tool-alias-warn.ts';
+import { resolveToolName } from '../mcp/aliases.ts';
 
 export const TOOL_GROUPS = {
   search: ['oracle_search', 'oracle_search_chain', 'oracle_read', 'oracle_list', 'oracle_concepts', 'oracle_ask'],
@@ -79,10 +80,17 @@ const DEFAULT_TOOL_ORDER = Object.values(TOOL_PLUGINS)
   .sort((a, b) => a.weight - b.weight || a.name.localeCompare(b.name))
   .flatMap((p) => p.tools);
 
+/**
+ * Delegates to `resolveToolName` — there must be exactly ONE definition of what an alias is.
+ *
+ * This used to hardcode both prefixes itself, which is why removing `muninn_` from
+ * `ALIAS_PREFIXES` (#2824) left the settings API still resolving it: the rule lived in two
+ * places and only one of them was retired. Same shape as the three `withTimeout` copies in
+ * #2850 and the two `walkFiles` in #2849 — a rule with two implementations has already drifted,
+ * it just has not been noticed yet.
+ */
 export function normalizeToolName(name: string): string {
-  if (name.startsWith('arra_')) return `oracle_${name.slice('arra_'.length)}`;
-  if (name.startsWith('muninn_')) return `oracle_${name.slice('muninn_'.length)}`;
-  return name;
+  return resolveToolName(name);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@
 import { OracleMCPServer } from './mcp/server.ts';
 import { resolveToolName } from './mcp/aliases.ts';
 export { OracleMCPServer } from './mcp/server.ts';
-export { resolveToolName, deprecatedAliasWarning, resolveInboundToolName } from './mcp/aliases.ts';
+export { resolveToolName, deprecatedAliasWarning, resolveInboundToolName, retiredAliasNotice, aliasNotice } from './mcp/aliases.ts';
 
 export type AdvertisedTool = { name: string };
 

--- a/src/mcp/aliases.ts
+++ b/src/mcp/aliases.ts
@@ -1,12 +1,28 @@
 /** Backward-compatible MCP tool alias resolution. */
-const ALIAS_PREFIXES = ['arra_', 'muninn_'] as const;
+const ALIAS_PREFIXES = ['arra_'] as const;
 
 /**
  * Aliases slated for removal in the NEXT release. `arra_` is deliberately
  * absent — it stays supported and silent. Removing a prefix from here is a
  * no-op; removal also requires dropping it from ALIAS_PREFIXES above.
+ *
+ * Empty today: `muninn_` finished the cycle — warned in #2839, shipped in
+ * v26.7.26-alpha.227 (verified: the tag contains that commit), removed here.
+ * The machinery stays for whatever is deprecated next.
  */
-const DEPRECATED_PREFIXES = ['muninn_'] as const;
+const DEPRECATED_PREFIXES = [] as const satisfies readonly string[];
+
+/**
+ * Prefixes that USED to resolve and no longer do.
+ *
+ * `resolveToolName` fails **silently** when a prefix stops matching: it returns the name
+ * unchanged and the call dies later as a generic tool-not-found, with nothing connecting the
+ * failure to the rename. That silence is why #2824 required a deprecation release before
+ * removal, and it would still bite any client that missed the warning.
+ *
+ * So a retired prefix keeps a voice. It no longer resolves — but it says why.
+ */
+const RETIRED_PREFIXES = ['muninn_'] as const;
 
 export function resolveToolName(name: string): string {
   const clean = name.trim();
@@ -21,24 +37,62 @@ export function resolveToolName(name: string): string {
 
 /**
  * Deprecation notice for `name`, or null when none is warranted.
- * Null when no rewrite happened (bare `muninn_`, `not_muninn_thing`, canonical
- * `oracle_*`) and null for non-deprecated aliases (`arra_*`, `arra_muninn_x`).
+ * Null when no rewrite happened (bare alias, `not_arra_thing`, canonical
+ * `oracle_*`) and null for non-deprecated aliases (`arra_*`).
  */
 export function deprecatedAliasWarning(name: string): string | null {
   const clean = name.trim();
   const resolved = resolveToolName(clean);
   if (resolved === clean) return null;
-  if (!DEPRECATED_PREFIXES.some((prefix) => clean.startsWith(prefix))) return null;
+  if (!DEPRECATED_PREFIXES.some((prefix: string) => clean.startsWith(prefix))) return null;
   return `[MCP] tool alias "${clean}" is deprecated — use "${resolved}" (removal planned next release)`;
 }
 
 /**
- * Resolve an inbound tool name, emitting one deprecation warning per call when
- * a deprecated alias was used. `log` is injectable for tests; production passes
- * nothing so the notice reaches the operator on stderr.
+ * Notice for a prefix that has been removed, or null.
+ *
+ * Names the replacement, because the alternative is a tool-not-found that gives the caller
+ * nothing to act on.
+ */
+export function retiredAliasNotice(name: string): string | null {
+  const clean = name.trim();
+  for (const prefix of RETIRED_PREFIXES) {
+    if (!clean.startsWith(prefix)) continue;
+    const suffix = clean.slice(prefix.length).trim();
+    if (!suffix) return null;
+    const target = suffix.startsWith('oracle_') ? suffix : `oracle_${suffix}`;
+    return `[MCP] tool alias "${clean}" was REMOVED — call "${target}" instead. `
+      + 'The muninn_ prefix was retired after its deprecation release (#2824).';
+  }
+  return null;
+}
+
+/**
+ * Resolve an inbound tool name, emitting one notice per call when a deprecated or retired
+ * alias was used. `log` is injectable for tests; production passes nothing so the notice
+ * reaches the operator on stderr.
  */
 export function resolveInboundToolName(name: string, log: (m: string) => void = console.error): string {
+  const retired = retiredAliasNotice(name);
+  if (retired) {
+    log(retired);
+    // Returned unchanged on purpose: the alias is gone, and quietly resolving it anyway would
+    // make the removal cosmetic. The caller still gets tool-not-found — now with a reason.
+    return name.trim();
+  }
   const warning = deprecatedAliasWarning(name);
   if (warning) log(warning);
   return resolveToolName(name);
+}
+
+/**
+ * The one notice for an inbound alias, deprecated or retired.
+ *
+ * `tool-alias-warn.ts` keeps the message in exactly one place so the non-MCP surfaces — the
+ * settings API, `arra.config.json`, the ORACLE_*_TOOLS env vars — cannot drift into a second
+ * dialect of the same notice. Retiring `muninn_` would otherwise make every one of those
+ * surfaces go silent about it, which is the opposite of the point.
+ */
+export function aliasNotice(name: string): string | null {
+  return deprecatedAliasWarning(name) ?? retiredAliasNotice(name);
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -16,7 +16,7 @@ import type { UnifiedRuntime } from '../plugins/unified-loader.ts';
 import type { EmbeddedDeps, OracleMCPServerOptions } from './server-options.ts';
 import { probeVectorStore } from './vector-health.ts';
 import { formatEmbedderDegradedWarning, probeConfiguredEmbedder, readEmbedderRuntimeStatus, setEmbedderRuntimeStatus, type EmbedderRuntimeStatus } from '../vector/embedder-config.ts';
-import { resolveInboundToolName } from './aliases.ts';
+import { resolveInboundToolName, retiredAliasNotice } from './aliases.ts';
 import { proxyToolCall, resolveOracleApiBase } from './http-proxy.ts';
 import { pluginMcpToolsFrom } from './plugin-tools.ts';
 import { runWithTenant } from '../middleware/tenant.ts';
@@ -190,7 +190,13 @@ export class OracleMCPServer {
       }
       const toolName = resolveInboundToolName(request.params.name);
       const tool = (await this.toolRegistry()).get(toolName);
-      if (!tool) return errorResponse(`Error: Unknown tool: ${toolName}`);
+      if (!tool) {
+        // A retired alias fails like any unknown tool, but the CLIENT gets told why.
+        // `resolveInboundToolName` already logged it to stderr, which the caller may never
+        // see; #2824 flagged exactly this — "a confusing error with no hint about the rename".
+        const retired = retiredAliasNotice(request.params.name);
+        return errorResponse(retired ? `Error: Unknown tool: ${toolName}. ${retired}` : `Error: Unknown tool: ${toolName}`);
+      }
       if (!this.isAllowed(tool)) return errorResponse(`Error: Unknown tool: ${toolName}`);
       if (this.isDisabled(tool)) {
         return errorResponse(`Error: Tool "${toolName}" is disabled by tool group config. Check ${ORACLE_DATA_DIR}/config.json or arra.config.json.`);

--- a/src/routes/settings/tools.ts
+++ b/src/routes/settings/tools.ts
@@ -14,6 +14,7 @@ import {
   type ToolGroupName,
 } from '../../config/tool-groups.ts';
 import { warnDeprecatedAlias } from '../../config/tool-alias-warn.ts';
+import { retiredAliasNotice } from '../../mcp/aliases.ts';
 
 /** Ordered projection of the shared config vocabulary — the same set the loader governs. */
 const ALL_TOOL_LIST = [...ALL_TOOL_NAMES];
@@ -68,16 +69,21 @@ export const toolSettingsRoute = new Elysia()
     },
   })
   .put('/tools', ({ body, set }) => {
-    // Announce the rewrite BEFORE validation, so a body that also carries an
-    // unknown tool still tells the caller its `muninn_` names are on the way out
-    // rather than 400-ing with that half of the story missing. Unguarded on
-    // purpose: every PUT is a fresh operator action, unlike the polled config file.
+    // Announce BEFORE validation, so a body that also carries an unknown tool still tells
+    // the caller about its retired names rather than 400-ing with that half of the story
+    // missing. Unguarded on purpose: every PUT is a fresh operator action, unlike the polled
+    // config file.
     for (const name of body.enabled_tools) warnDeprecatedAlias(name);
     const normalized = Array.from(new Set(body.enabled_tools.map(normalizeToolName)));
     const unknown = normalized.filter((name) => !ALL_TOOL_NAMES.has(name));
     if (unknown.length) {
       set.status = 400;
-      return { error: 'Unknown MCP tools', unknown };
+      // A retired alias is "unknown" now, so say which one and what replaced it. Without
+      // this the operator gets a bare 400 for a name that worked last release (#2824).
+      const retired = unknown.map((name) => retiredAliasNotice(name)).filter((n): n is string => n !== null);
+      return retired.length
+        ? { error: 'Unknown MCP tools', unknown, notices: retired }
+        : { error: 'Unknown MCP tools', unknown };
     }
 
     const filePath = resolveToolConfigSource(repoRoot()).path;

--- a/tests/config/tool-alias-warn-config-file.test.ts
+++ b/tests/config/tool-alias-warn-config-file.test.ts
@@ -31,27 +31,30 @@ function loadCapturingWarnings(times = 1): { warnings: string[]; last: ReturnTyp
   try {
     let last = loadToolGroupConfig(tempRepo);
     for (let i = 1; i < times; i += 1) last = loadToolGroupConfig(tempRepo);
-    return { warnings: lines.filter((line) => line.includes('is deprecated')), last };
+    // Matches both dialects from the single source: 'is deprecated' and 'was REMOVED'.
+    const notice = (line: string) => line.includes('is deprecated') || line.includes('was REMOVED');
+    return { warnings: lines.filter(notice), last };
   } finally {
     console.error = real;
   }
 }
 
-test('a muninn_ entry in arra.config.json warns once and still resolves', () => {
+test('a muninn_ entry in arra.config.json is reported as REMOVED and no longer resolves', () => {
+  // #2824: the prefix completed its deprecation cycle. A config file still naming it gets a
+  // notice on every distinct entry — going silent here would leave the operator with a config
+  // that quietly selects nothing.
   seed({ enabled_tools: ['muninn_search'], disabled_tools: ['muninn_read'] });
   const { warnings, last } = loadCapturingWarnings();
 
-  // Order is incidental (mergeRaw happens to read disabled_tools first), so assert
-  // the exact format of each line without pinning the sequence.
+  // Order is incidental (mergeRaw happens to read disabled_tools first).
   expect(warnings).toHaveLength(2);
-  expect(warnings).toContain(
-    '[MCP] tool alias "muninn_search" is deprecated — use "oracle_search" (removal planned next release)',
-  );
-  expect(warnings).toContain(
-    '[MCP] tool alias "muninn_read" is deprecated — use "oracle_read" (removal planned next release)',
-  );
-  expect(last.enabled_tools).toEqual(['oracle_search']);
-  expect(last.disabled_tools).toEqual(['oracle_read']);
+  expect(warnings.join(' ')).toContain('oracle_search');
+  expect(warnings.join(' ')).toContain('oracle_read');
+  expect(warnings.every((line) => line.includes('was REMOVED'))).toBe(true);
+
+  // Unresolved: the names stay as written, so they match no known tool.
+  expect(last.enabled_tools).toEqual(['muninn_search']);
+  expect(last.disabled_tools).toEqual(['muninn_read']);
 });
 
 test('repeated loads do NOT re-warn — the watcher polls this path 10x/sec', () => {
@@ -61,7 +64,7 @@ test('repeated loads do NOT re-warn — the watcher polls this path 10x/sec', ()
   // the once-guard this is 20 lines, and a long-running server emits ~864k/day.
   const { warnings, last } = loadCapturingWarnings(20);
   expect(warnings).toHaveLength(1);
-  expect(last.enabled_tools).toEqual(['oracle_search']);
+  expect(last.enabled_tools).toEqual(['muninn_search']);
 });
 
 test('an arra_ entry in arra.config.json resolves silently — arra_ is not deprecated', () => {

--- a/tests/config/tool-alias-warn-env.test.ts
+++ b/tests/config/tool-alias-warn-env.test.ts
@@ -36,31 +36,35 @@ function applyCapturingWarnings(): { warnings: string[]; next: ToolGroupConfig }
   console.error = (...args: unknown[]) => { lines.push(args.join(' ')); };
   try {
     const next = applyToolEnvOverrides({ ...BASE });
-    return { warnings: lines.filter((line) => line.includes('is deprecated')), next };
+    const notice = (line: string) => line.includes('is deprecated') || line.includes('was REMOVED');
+    return { warnings: lines.filter(notice), next };
   } finally {
     console.error = real;
   }
 }
 
-test('ORACLE_ENABLED_TOOLS warns on a muninn_ name and still resolves it', () => {
+test('ORACLE_ENABLED_TOOLS reports a retired muninn_ name and no longer resolves it', () => {
   process.env.ORACLE_ENABLED_TOOLS = 'muninn_search,arra_read,oracle_list';
   const { warnings, next } = applyCapturingWarnings();
 
   // arra_read rides along in the same list and must NOT produce a line.
-  expect(warnings).toEqual([
-    '[MCP] tool alias "muninn_search" is deprecated — use "oracle_search" (removal planned next release)',
-  ]);
-  expect(next.enabled_tools).toEqual(['oracle_search', 'oracle_read', 'oracle_list']);
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0]).toContain('was REMOVED');
+  expect(warnings[0]).toContain('oracle_search');
+  // Retired AND dropped: the allow-list keeps only recognised tools (knownTool filter), so
+  // muninn_search selects nothing rather than silently standing in for oracle_search.
+  expect(next.enabled_tools).toEqual(['oracle_read', 'oracle_list']);
 });
 
-test('ORACLE_DISABLED_TOOLS warns on a muninn_ name and still resolves it', () => {
+test('ORACLE_DISABLED_TOOLS reports a retired muninn_ name and no longer resolves it', () => {
   process.env.ORACLE_DISABLED_TOOLS = 'muninn_read';
   const { warnings, next } = applyCapturingWarnings();
 
-  expect(warnings).toEqual([
-    '[MCP] tool alias "muninn_read" is deprecated — use "oracle_read" (removal planned next release)',
-  ]);
-  expect(next.disabled_tools).toContain('oracle_read');
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0]).toContain('was REMOVED');
+  expect(warnings[0]).toContain('oracle_read');
+  // It no longer disables oracle_read — which is exactly why the notice has to be loud.
+  expect(next.disabled_tools).not.toContain('oracle_read');
 });
 
 test('an all-arra_ env list stays completely silent', () => {

--- a/tests/http/settings/tools-alias-deprecation.test.ts
+++ b/tests/http/settings/tools-alias-deprecation.test.ts
@@ -60,25 +60,31 @@ async function putCapturingWarnings(enabled_tools: string[]): Promise<{ res: Res
     });
     // Body must be drained before restoring: the handler logs while serializing.
     await res.clone().text();
-    return { res, warnings: lines.filter((line) => line.includes('is deprecated')) };
+    return { res, warnings: lines.filter((line) => line.includes('is deprecated') || line.includes('was REMOVED')) };
   } finally {
     console.error = real;
   }
 }
 
-test('PUT /api/v1/settings/tools warns that a muninn_ name is deprecated, and still resolves it', async () => {
+test('PUT /api/v1/settings/tools REJECTS a retired muninn_ name and names the replacement', async () => {
+  // Behaviour change from the #2824 removal: the alias no longer resolves, so it is an
+  // unknown tool. The 400 has to explain that, or an operator sees a name that worked last
+  // release rejected with no reason.
   const { res, warnings } = await putCapturingWarnings(['muninn_search', 'oracle_list']);
-  expect(res.status).toBe(200);
+  expect(res.status).toBe(400);
 
-  // Exact format, shared with the MCP path via deprecatedAliasWarning.
-  expect(warnings).toEqual([
-    '[MCP] tool alias "muninn_search" is deprecated — use "oracle_search" (removal planned next release)',
-  ]);
+  const body = await res.json() as { error: string; unknown: string[]; notices?: string[] };
+  expect(body.unknown).toContain('muninn_search');
+  expect(body.notices?.join(' ')).toContain('oracle_search');
+  expect(body.notices?.join(' ')).toContain('was REMOVED');
 
-  // Warning is an announcement, not a rejection — the rewrite still happens.
+  // The same notice reaches the logs, from the single shared source.
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0]).toContain('was REMOVED');
+
+  // Nothing was written — a rejected PUT must not half-apply.
   const written = JSON.parse(fs.readFileSync(repoConfig, 'utf-8')) as Record<string, string[]>;
-  expect(written.enabled_tools).toEqual(['oracle_search', 'oracle_list']);
-  expect((await res.json() as { enabled_tools: string[] }).enabled_tools).toEqual(['oracle_search', 'oracle_list']);
+  expect(written.enabled_tools ?? []).not.toContain('muninn_search');
 });
 
 test('PUT /api/v1/settings/tools stays silent for arra_ names, and still resolves them', async () => {

--- a/tests/mcp/aliases-edge.test.ts
+++ b/tests/mcp/aliases-edge.test.ts
@@ -2,7 +2,8 @@ import { expect, test } from 'bun:test';
 import { resolveToolName } from '../../src/mcp/aliases.ts';
 
 test('MCP aliases trim names and normalize already-canonical alias suffixes', () => {
-  expect(resolveToolName('  muninn_oracle_search  ')).toBe('oracle_search');
+  // muninn_ is retired (#2824), so trimming no longer leads to a rewrite.
+  expect(resolveToolName('  muninn_oracle_search  ')).toBe('muninn_oracle_search');
   expect(resolveToolName('arra_oracle_learn')).toBe('oracle_learn');
 });
 

--- a/tests/mcp/aliases-resolve-muninn-prefix.test.ts
+++ b/tests/mcp/aliases-resolve-muninn-prefix.test.ts
@@ -1,6 +1,11 @@
 import { expect, test } from 'bun:test';
 import { resolveToolName } from '../../src/mcp/aliases.ts';
 
-test('MCP aliases resolve muninn prefixes to oracle tools', () => {
-  expect(resolveToolName('muninn_read')).toBe('oracle_read');
+test('MCP aliases no longer resolve muninn prefixes (#2824 removal)', () => {
+  // Was `oracle_read` until the deprecation cycle completed.
+  expect(resolveToolName('muninn_read')).toBe('muninn_read');
+});
+
+test('arra_ still resolves — it was never deprecated', () => {
+  expect(resolveToolName('arra_read')).toBe('oracle_read');
 });

--- a/tests/mcp/aliases-warns-on-muninn-prefix.test.ts
+++ b/tests/mcp/aliases-warns-on-muninn-prefix.test.ts
@@ -1,11 +1,24 @@
 import { expect, test } from 'bun:test';
-import { deprecatedAliasWarning, resolveInboundToolName } from '../../src/mcp/aliases.ts';
+import { aliasNotice, resolveInboundToolName, retiredAliasNotice } from '../../src/mcp/aliases.ts';
 
-test('MCP aliases warn that muninn prefixes are deprecated, naming the replacement', () => {
-  expect(deprecatedAliasWarning('muninn_read')).toBe(
-    '[MCP] tool alias "muninn_read" is deprecated — use "oracle_read" (removal planned next release)',
-  );
+/**
+ * `muninn_` finished its deprecation cycle (#2824): warned in #2839, shipped in
+ * v26.7.26-alpha.227, removed in the follow-up. It no longer resolves — but it still explains
+ * itself, because `resolveToolName` returns an unmatched name unchanged and the caller would
+ * otherwise get a bare tool-not-found with nothing pointing at the rename.
+ */
+test('MCP aliases report muninn prefixes as REMOVED, naming the replacement', () => {
+  const notice = retiredAliasNotice('muninn_read');
+  expect(notice).toContain('was REMOVED');
+  expect(notice).toContain('oracle_read');
+  // One notice for every inbound surface — the settings API and config paths read this too.
+  expect(aliasNotice('muninn_read')).toBe(notice);
+});
+
+test('resolveInboundToolName logs the notice and does not resolve the retired alias', () => {
   const logs: string[] = [];
-  expect(resolveInboundToolName('muninn_read', (m) => logs.push(m))).toBe('oracle_read');
+  // Unchanged on purpose: resolving it anyway would make the removal cosmetic.
+  expect(resolveInboundToolName('muninn_read', (m) => logs.push(m))).toBe('muninn_read');
   expect(logs).toHaveLength(1);
+  expect(logs[0]).toContain('was REMOVED');
 });

--- a/tests/mcp/server-call-handler-warns-deprecated-alias.test.ts
+++ b/tests/mcp/server-call-handler-warns-deprecated-alias.test.ts
@@ -2,20 +2,46 @@ import { expect, test, spyOn } from 'bun:test';
 import { OracleMCPServer } from '../../src/mcp/server.ts';
 import { allToolGroups, callToolHandler } from './support/server.ts';
 
-test('MCP server call handler warns once when dispatching a deprecated muninn_ alias', async () => {
+/**
+ * `muninn_` completed its deprecation cycle (#2824) and no longer dispatches.
+ *
+ * The point of this test is the SECOND assertion. #2824 held the removal back for a release
+ * specifically because `resolveToolName` fails silently — an unmatched prefix is returned
+ * unchanged and dies later as a generic tool-not-found, "a confusing error with no hint about
+ * the rename" (ui-oracle). Logging to stderr is not enough: an MCP client sees the response,
+ * not the server's stderr. So the error text itself carries the replacement.
+ */
+test('MCP server refuses a retired muninn_ alias and names the replacement in the RESPONSE', async () => {
   const api = Bun.serve({ port: 0, fetch: (request) => Response.json({ q: new URL(request.url).searchParams.get('q') }) });
   process.env.ORACLE_HTTP_URL = `http://127.0.0.1:${api.port}`;
   const server = new OracleMCPServer({ toolGroups: allToolGroups });
   const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
   try {
     const response = await callToolHandler(server)({ params: { name: 'muninn_search', arguments: { query: 'alias-ok' } } });
-    expect(response.content[0].text).toContain('alias-ok');
-    const warnings = errorSpy.mock.calls
-      .map((call) => String(call[0]))
-      .filter((line) => /muninn_search.*deprecated.*oracle_search/.test(line));
-    expect(warnings).toHaveLength(1);
+    const text = String(response.content[0].text);
+
+    expect(text).toContain('Unknown tool');
+    // The part a client can act on, without reading the server's logs.
+    expect(text).toContain('was REMOVED');
+    expect(text).toContain('oracle_search');
+
+    const notices = errorSpy.mock.calls.map((call) => String(call[0])).filter((line) => line.includes('was REMOVED'));
+    expect(notices).toHaveLength(1);
   } finally {
     errorSpy.mockRestore();
+    await server.cleanup();
+    await api.stop();
+  }
+});
+
+test('a canonical oracle_* call still dispatches normally', async () => {
+  const api = Bun.serve({ port: 0, fetch: (request) => Response.json({ q: new URL(request.url).searchParams.get('q') }) });
+  process.env.ORACLE_HTTP_URL = `http://127.0.0.1:${api.port}`;
+  const server = new OracleMCPServer({ toolGroups: allToolGroups });
+  try {
+    const response = await callToolHandler(server)({ params: { name: 'oracle_search', arguments: { query: 'alias-ok' } } });
+    expect(String(response.content[0].text)).toContain('alias-ok');
+  } finally {
     await server.cleanup();
     await api.stop();
   }


### PR DESCRIPTION
Completes step 3 of #2824. Your rule was **"warn for one release, then remove"** — the precondition is met, verified rather than assumed:

```
$ git tag --contains 7cb01691      # the warning commit (#2839, 2026-07-25)
v26.7.26-alpha.227
```

## The real obstacle was a second copy of the rule

Removing `muninn_` from `ALIAS_PREFIXES` did **not** retire it. The settings API still resolved it and the PUT returned 200 where the test expected 400, because `src/config/tool-groups-core.ts:82-86` hardcoded both prefixes independently:

```ts
export function normalizeToolName(name: string): string {
  if (name.startsWith('arra_')) return `oracle_${name.slice('arra_'.length)}`;
  if (name.startsWith('muninn_')) return `oracle_${name.slice('muninn_'.length)}`;   // ← its own copy
  return name;
}
```

It now delegates to `resolveToolName`. **Same shape as the three `withTimeout` copies (#2850) and the two `walkFiles` (#2849)**: a rule with two implementations has already drifted; it just hasn't been noticed yet. #2824's scope named one test file — the removal actually touched 5 source files and 6 test files.

## A retired prefix keeps a voice

#2824 held this back for a release *specifically* because the failure is silent — `resolveToolName` returns an unmatched name unchanged and it dies later as a generic tool-not-found. ui-oracle's objection was **"a confusing error with no hint about the rename"**.

Logging to stderr does not answer that: an MCP client sees the *response*, not the server's logs. So the response says it:

```
Error: Unknown tool: muninn_search. [MCP] tool alias "muninn_search" was REMOVED
— call "oracle_search" instead. The muninn_ prefix was retired after its
deprecation release (#2824).
```

Same for the settings 400, which now carries a `notices` array. `aliasNotice = deprecated ?? retired` keeps the message in exactly one place, which is the property `tool-alias-warn.ts` was explicitly built to preserve — otherwise every non-MCP surface would have gone silent about the retirement.

## Behaviour changes, all intended

| surface | before | after |
|---|---|---|
| MCP `muninn_search` | resolved + warned | tool-not-found, **replacement named in the response** |
| `PUT /api/v1/settings/tools` | 200, rewrote to `oracle_*` | **400** + `unknown` + `notices` |
| `ORACLE_ENABLED_TOOLS=muninn_read` | resolved | dropped as unknown |
| anything `arra_*` | resolved, silent | unchanged — never deprecated |

`DEPRECATED_PREFIXES` is now empty; the machinery stays for whatever is deprecated next.

## Gate

- `bunx tsc --noEmit` — exit 0
- `bun test --isolate tests/http/` — **1,092 pass across 297 files**
- config / settings / mcp / build — **237 pass**
- workers, tools, plugins, knowledge, src/tools — all green

## Step 4 is yours

`~/.claude/CLAUDE.md` still references the prefix — your file, your edit. Worth doing now, since a session that calls `muninn_search` will get a hard failure rather than a silent rewrite. It will at least tell them what to call.

Refs #2824
