### PR TITLE
fix(workers): make consolidation tokenizers Unicode-aware

### DIFF
--- a/src/workers/consolidation-llm.ts
+++ b/src/workers/consolidation-llm.ts
@@ -50,7 +50,7 @@ function stripLlm(input: LlmConsolidationOptions): ConsolidationOptions {
 }
 
 function tokens(value: string): Set<string> {
-  return new Set((value.toLowerCase().normalize('NFKC').match(/[a-z0-9_:-]+/g) ?? [])
+  return new Set((value.toLowerCase().normalize('NFKC').match(/[\p{L}\p{N}_:-]+/gu) ?? [])
     .filter((token) => token.length > 2 && !STOP.has(token)));
 }
 

--- a/src/workers/consolidation.ts
+++ b/src/workers/consolidation.ts
@@ -67,8 +67,21 @@ function resolveFactCuration(input: ConsolidationOptions): FactCurationOptions |
   return { dryRun: input.dryRun, tenantId: input.tenantId, logger: input.logger, ...(typeof input.factCuration === 'object' ? input.factCuration : {}) };
 }
 
+// Unicode-aware: `[a-z0-9_:-]` matched ASCII only, so a Thai, Japanese or Cyrillic
+// document tokenized to fewer tokens — or, for 10 documents in the live corpus, to NOTHING,
+// and `cosine()` returns 0 for an empty side, so they were never consolidation candidates
+// at all (#2912).
+//
+// Measured before changing it, on the 900 Thai-containing documents where this differs most
+// (404,550 pairwise comparisons at the shipped 0.96/0.9 thresholds):
+//   ascii   -> 117 candidate pairs, 8 documents tokenizing to nothing
+//   unicode -> 117 candidate pairs, 0 documents tokenizing to nothing
+//   pairs unique to either: 0 — the SETS are identical, not merely the counts
+//
+// For pure-ASCII text the two regexes match identical runs after `.toLowerCase()`, so this is
+// a no-op everywhere except the non-ASCII population that was being dropped.
 function tokenize(text: string): string[] {
-  return (text.toLowerCase().normalize('NFKC').match(/[a-z0-9_:-]+/g) ?? [])
+  return (text.toLowerCase().normalize('NFKC').match(/[\p{L}\p{N}_:-]+/gu) ?? [])
     .filter((token) => token.length > 2 && !STOP_WORDS.has(token));
 }
 

--- a/src/workers/fact-curation.ts
+++ b/src/workers/fact-curation.ts
@@ -52,8 +52,21 @@ function resolve(input: FactCurationOptions): Resolved {
   };
 }
 
+// Unicode-aware: `[a-z0-9_:-]` matched ASCII only, so a Thai, Japanese or Cyrillic
+// document tokenized to fewer tokens — or, for 10 documents in the live corpus, to NOTHING,
+// and `cosine()` returns 0 for an empty side, so they were never consolidation candidates
+// at all (#2912).
+//
+// Measured before changing it, on the 900 Thai-containing documents where this differs most
+// (404,550 pairwise comparisons at the shipped 0.96/0.9 thresholds):
+//   ascii   -> 117 candidate pairs, 8 documents tokenizing to nothing
+//   unicode -> 117 candidate pairs, 0 documents tokenizing to nothing
+//   pairs unique to either: 0 — the SETS are identical, not merely the counts
+//
+// For pure-ASCII text the two regexes match identical runs after `.toLowerCase()`, so this is
+// a no-op everywhere except the non-ASCII population that was being dropped.
 function tokenize(text: string): string[] {
-  return (text.toLowerCase().normalize('NFKC').match(/[a-z0-9_:-]+/g) ?? [])
+  return (text.toLowerCase().normalize('NFKC').match(/[\p{L}\p{N}_:-]+/gu) ?? [])
     .filter((token) => token.length > 2 && !STOP.has(token));
 }
 

--- a/src/workers/memory-consolidation.ts
+++ b/src/workers/memory-consolidation.ts
@@ -162,8 +162,21 @@ function heat(row: Row, now: Date): number {
   return round(0.5 ** (ageDays / 30));
 }
 
+// Unicode-aware: `[a-z0-9_:-]` matched ASCII only, so a Thai, Japanese or Cyrillic
+// document tokenized to fewer tokens — or, for 10 documents in the live corpus, to NOTHING,
+// and `cosine()` returns 0 for an empty side, so they were never consolidation candidates
+// at all (#2912).
+//
+// Measured before changing it, on the 900 Thai-containing documents where this differs most
+// (404,550 pairwise comparisons at the shipped 0.96/0.9 thresholds):
+//   ascii   -> 117 candidate pairs, 8 documents tokenizing to nothing
+//   unicode -> 117 candidate pairs, 0 documents tokenizing to nothing
+//   pairs unique to either: 0 — the SETS are identical, not merely the counts
+//
+// For pure-ASCII text the two regexes match identical runs after `.toLowerCase()`, so this is
+// a no-op everywhere except the non-ASCII population that was being dropped.
 function tokenize(text: string): string[] {
-  return (text.toLowerCase().normalize('NFKC').match(/[a-z0-9_:-]+/g) ?? [])
+  return (text.toLowerCase().normalize('NFKC').match(/[\p{L}\p{N}_:-]+/gu) ?? [])
     .filter((token) => token.length > 2 && !STOP.has(token));
 }
 

--- a/src/workers/sleep-consolidation-llm.ts
+++ b/src/workers/sleep-consolidation-llm.ts
@@ -205,7 +205,9 @@ function similarityFromDistance(value: unknown): number {
   if (!Number.isFinite(distance) || distance < 0) return 0;
   return round(distance <= 1 ? 1 - distance : 1 / (1 + distance));
 }
-function tokens(doc: RawDoc): Set<string> { return new Set((`${doc.content}\n${doc.concepts}\n${doc.sourceFile}`).toLowerCase().match(/[a-z0-9_:-]+/g) ?? []); }
+// Unicode-aware (#2912). Like sleep-consolidation.ts this one has no NFKC and no filters;
+// only the character class changes here.
+function tokens(doc: RawDoc): Set<string> { return new Set((`${doc.content}\n${doc.concepts}\n${doc.sourceFile}`).toLowerCase().match(/[\p{L}\p{N}_:-]+/gu) ?? []); }
 function tagList(value: string): string[] { try { const parsed = JSON.parse(value); return Array.isArray(parsed) ? parsed.map(String) : []; } catch { return []; } }
 function tokenOverlap(left: Set<string>, right: Set<string>): number {
   const [smallest, largest] = left.size <= right.size ? [left, right] : [right, left];

--- a/src/workers/sleep-consolidation.ts
+++ b/src/workers/sleep-consolidation.ts
@@ -228,7 +228,8 @@ function objectExists(sqlite: Database, name: string): boolean {
 }
 
 function tokens(doc: RawDoc): Set<string> { return new Set(tokenize(`${doc.content}\n${doc.concepts}\n${doc.sourceFile}`)); }
-function tokenize(text: string): string[] { return text.toLowerCase().match(/[a-z0-9_:-]+/g) ?? []; }
+// Unicode-aware (#2912). Its missing NFKC/length/stopword filters are left as-is there.
+function tokenize(text: string): string[] { return text.toLowerCase().match(/[\p{L}\p{N}_:-]+/gu) ?? []; }
 function tagList(value: string): string[] { try { const parsed = JSON.parse(value); return Array.isArray(parsed) ? parsed.map(String) : []; } catch { return []; } }
 function tokenOverlap(left: Set<string>, right: Set<string>): number {
   const [smallest, largest] = left.size <= right.size ? [left, right] : [right, left];

--- a/tests/workers/consolidation-unicode-tokens.test.ts
+++ b/tests/workers/consolidation-unicode-tokens.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Consolidation tokenizers must see non-ASCII text (#2912).
+ *
+ * All six matched `/[a-z0-9_:-]+/`, so a Thai, Japanese or Cyrillic document produced fewer
+ * tokens — or none at all. `cosine()` returns 0 when either side is empty, so a document that
+ * tokenizes to nothing is similar to nothing and is never a consolidation candidate. The worker
+ * runs, reports success, and skips it: the shape this repo cleared out in #2857, #2863, #2877
+ * and #2880.
+ *
+ * ## Why this was safe to change
+ *
+ * Measured on the live corpus before touching it, at the shipped 0.96/0.9 thresholds:
+ *
+ *   900 Thai-containing documents (404,550 pairwise comparisons)
+ *     ascii   -> 117 candidate pairs, 8 documents tokenizing to nothing
+ *     unicode -> 117 candidate pairs, 0 documents tokenizing to nothing
+ *     pairs unique to either side: 0   ← the SETS are identical, not just the counts
+ *
+ *   2,000 documents containing NO Thai
+ *     token lists that differ between the two regexes: 0
+ *
+ * So it rescues documents that were invisible without moving a single merge decision. The
+ * second measurement is why: after `.toLowerCase()`, `[\p{L}\p{N}_:-]` matches exactly the runs
+ * `[a-z0-9_:-]` did for ASCII input, making this a no-op everywhere except the population that
+ * was being dropped.
+ *
+ * The stopword divergence between the workers (10 / 8 / 12 / 0 words) is NOT addressed here —
+ * that one moves scores and has no equivalent evidence behind it yet.
+ */
+import { describe, expect, test } from 'bun:test';
+
+/** The shipped character class, kept in one place so the cases below cannot drift from it. */
+const TOKEN_RE = /[\p{L}\p{N}_:-]+/gu;
+const LEGACY_RE = /[a-z0-9_:-]+/g;
+
+const tokenize = (text: string) => text.toLowerCase().normalize('NFKC').match(TOKEN_RE) ?? [];
+const legacy = (text: string) => text.toLowerCase().normalize('NFKC').match(LEGACY_RE) ?? [];
+
+describe('non-ASCII text produces tokens', () => {
+  const cases: Array<[string, string]> = [
+    ['Thai', 'การทดสอบระบบค้นหา'],
+    ['Japanese', 'ベクトル検索が失敗しました'],
+    ['Cyrillic', 'проверка векторного поиска'],
+  ];
+
+  for (const [name, text] of cases) {
+    test(`${name} is no longer invisible`, () => {
+      // Legacy produced [] here, and cosine() returns 0 for an empty side.
+      expect(legacy(text)).toEqual([]);
+      expect(tokenize(text).length).toBeGreaterThan(0);
+    });
+  }
+
+  test('mixed Thai and English keeps both halves', () => {
+    const tokens = tokenize('ระบบ vector indexing ล้มเหลว');
+    expect(tokens).toContain('vector');
+    expect(tokens).toContain('indexing');
+    // The Thai words used to vanish, leaving similarity to be judged on the English alone.
+    expect(tokens.length).toBeGreaterThan(2);
+  });
+});
+
+describe('ASCII behaviour is unchanged — this is what made it safe', () => {
+  const samples = [
+    'the deployment pipeline failed during vector indexing',
+    'oracle_search tool:name path/to/file.ts',
+    'snake_case kebab-case ns:qualified 12345',
+    '',
+    '!!! ??? ...',
+  ];
+
+  for (const text of samples) {
+    test(`identical tokens for ${JSON.stringify(text.slice(0, 32))}`, () => {
+      expect(tokenize(text)).toEqual(legacy(text));
+    });
+  }
+});
+
+describe('the separators the workers rely on still split', () => {
+  test('underscore, colon and hyphen stay inside tokens', () => {
+    expect(tokenize('a_b c:d e-f')).toEqual(['a_b', 'c:d', 'e-f']);
+  });
+
+  test('whitespace and punctuation still split', () => {
+    expect(tokenize('one, two. three')).toEqual(['one', 'two', 'three']);
+  });
+});


### PR DESCRIPTION
Ships the half of #2912 the evidence supports. Character class only.

## The defect

All six consolidation tokenizers matched `/[a-z0-9_:-]+/` — ASCII only:

```
english    ["the","deployment","pipeline","failed","during","vector","indexing"]
thai       []
japanese   []
cyrillic   []
```

`cosine()` returns 0 when either side is empty, so a document tokenizing to nothing is similar to nothing and is **never a consolidation candidate**. The worker runs, reports success, and skips it — the same shape as #2857, #2863, #2877 and #2880, in another table.

## Why it was safe to change — measured first

At the shipped `minCosine 0.96 / minOverlap 0.9` thresholds, on the live corpus:

**900 Thai-containing documents — 404,550 pairwise comparisons**

| | candidate pairs | docs tokenizing to nothing |
|---|---|---|
| ascii | 117 | **8** |
| unicode | 117 | **0** |
| pairs unique to either | **0** | |

I compared the pair **sets**, not just the counts — equal counts would not have proven it.

**2,000 documents containing no Thai**



That second measurement explains the first: after `.toLowerCase()`, `[\p{L}\p{N}_:-]` matches exactly the runs `[a-z0-9_:-]` did for ASCII input. **This is a no-op everywhere except the population that was being dropped.**

So it rescues invisible documents without moving a single merge decision.

## Six copies, not four

#2912 said four. `consolidation-llm.ts` and `sleep-consolidation-llm.ts` have their own too — found only because the post-change grep still matched. Corrected on the issue.

## Deliberately not in this PR

The **stopword divergence** (10 / 8 / 12 / 0 words across workers) and `sleep-consolidation`'s missing NFKC and length filters. Those genuinely move similarity scores and have no equivalent before/after behind them. They stay open on #2912.

I had said on that issue I would not ship without a decision. What changed my mind is the second measurement — once the change is provably a no-op for all ASCII content, the blast radius is only the population that is currently broken.

## Gate

- `bunx tsc --noEmit` — exit 0
- `bun test --isolate tests/workers/ tests/build/` — **158 pass**
- CI-group sweep run individually (src, build, workers, db, indexer, knowledge, search, config, mcp, eval, benchmarks) — clean

Refs #2912