### PR TITLE
chore: extract the start lock, taking ensure-server.ts off the size allow-list

### DIFF
--- a/src/ensure-server.ts
+++ b/src/ensure-server.ts
@@ -12,14 +12,9 @@ import {
   isProcessAlive,
   spawnDaemon,
   configure,
-  removePidFile,
-  getDataDir,
 } from './process-manager/index.ts';
 import { waitForHealth, isPortInUse } from './process-manager/HealthMonitor.ts';
-
-// Simple file-based lock to prevent race conditions
-const LOCK_FILE = () => path.join(getDataDir(), 'oracle-http.lock');
-const LOCK_TIMEOUT = 30000; // 30 seconds max lock age
+import { acquireStartLock, releaseStartLock, cleanupStalePidFile } from './server/start-lock.ts';
 
 import { PORT, ORACLE_DATA_DIR } from './config.ts';
 
@@ -39,59 +34,6 @@ export interface EnsureServerOptions {
 /**
  * Acquire lock (prevents race conditions in parallel calls)
  */
-function acquireLock(): boolean {
-  const lockFile = LOCK_FILE();
-  try {
-    // Check for stale lock
-    if (fs.existsSync(lockFile)) {
-      const content = fs.readFileSync(lockFile, 'utf-8').trim();
-      const lockPid = parseInt(content, 10);
-      const stat = fs.statSync(lockFile);
-      const age = Date.now() - stat.mtimeMs;
-
-      // Release if: lock is old OR lock holder process is dead
-      const isStale = age > LOCK_TIMEOUT;
-      const isOrphan = !isNaN(lockPid) && !isProcessAlive(lockPid);
-
-      if (isStale || isOrphan) {
-        fs.unlinkSync(lockFile); // Stale/orphan lock, remove it
-      } else {
-        return false; // Lock held by live process
-      }
-    }
-    // Create lock with exclusive flag
-    fs.writeFileSync(lockFile, String(process.pid), { flag: 'wx' });
-    return true;
-  } catch {
-    return false; // Lock exists or write failed
-  }
-}
-
-/**
- * Release lock
- */
-function releaseLock(): void {
-  try {
-    const lockFile = LOCK_FILE();
-    if (fs.existsSync(lockFile)) {
-      fs.unlinkSync(lockFile);
-    }
-  } catch {
-    // Ignore errors
-  }
-}
-
-/**
- * Clean up stale PID file if process is dead
- */
-function cleanupStalePidFile(verbose = false): void {
-  const pidInfo = readPidFile();
-  if (pidInfo && !isProcessAlive(pidInfo.pid)) {
-    if (verbose) console.log(`🧹 Cleaning stale PID file (PID ${pidInfo.pid} is dead)`);
-    removePidFile();
-  }
-}
-
 /**
  * Check if server is healthy via HTTP
  */
@@ -143,7 +85,7 @@ export async function ensureServerRunning(options: EnsureServerOptions = {}): Pr
   }
 
   // 3. Acquire lock to prevent race conditions
-  if (!acquireLock()) {
+  if (!acquireStartLock()) {
     if (verbose) console.log('🔒 Another process is starting the server, waiting...');
     // Wait and re-check health
     const healthy = await waitForHealthWithTimeout(timeout);
@@ -196,7 +138,7 @@ export async function ensureServerRunning(options: EnsureServerOptions = {}): Pr
       return false;
     }
   } finally {
-    releaseLock();
+    releaseStartLock();
   }
 }
 

--- a/src/server/start-lock.ts
+++ b/src/server/start-lock.ts
@@ -1,0 +1,69 @@
+/**
+ * File lock guarding server auto-start.
+ *
+ * Extracted from `src/ensure-server.ts` (#2833): that file was 258 lines against the 250-line
+ * rule, and process locking is a separable concern from server lifecycle — the lock answers
+ * "is another process already trying to start one?", which is true regardless of what starting
+ * involves.
+ *
+ * The staleness handling is the part worth keeping intact. A lock file left behind by a crashed
+ * process would otherwise block auto-start forever, so a lock is released when it is either too
+ * old OR held by a PID that is no longer alive. Both conditions matter: a live process can hold
+ * a lock longer than the timeout during a slow start, and a dead one can leave a fresh lock.
+ */
+import path from 'path';
+import fs from 'fs';
+import { getDataDir, isProcessAlive, readPidFile, removePidFile } from '../process-manager/index.ts';
+
+/** Maximum age before a lock is presumed abandoned. */
+export const LOCK_TIMEOUT_MS = 30_000;
+
+export function lockFilePath(): string {
+  return path.join(getDataDir(), 'oracle-http.lock');
+}
+
+/**
+ * Take the start lock, or report that someone else holds it.
+ *
+ * Written with the `wx` flag so creation is atomic — two processes racing here cannot both
+ * believe they won.
+ */
+export function acquireStartLock(): boolean {
+  const lockFile = lockFilePath();
+  try {
+    if (fs.existsSync(lockFile)) {
+      const content = fs.readFileSync(lockFile, 'utf-8').trim();
+      const lockPid = parseInt(content, 10);
+      const age = Date.now() - fs.statSync(lockFile).mtimeMs;
+
+      const isStale = age > LOCK_TIMEOUT_MS;
+      const isOrphan = !Number.isNaN(lockPid) && !isProcessAlive(lockPid);
+
+      if (isStale || isOrphan) fs.unlinkSync(lockFile);
+      else return false;
+    }
+    fs.writeFileSync(lockFile, String(process.pid), { flag: 'wx' });
+    return true;
+  } catch {
+    // Lost the race, or the data dir is not writable. Either way we do not hold it.
+    return false;
+  }
+}
+
+export function releaseStartLock(): void {
+  try {
+    const lockFile = lockFilePath();
+    if (fs.existsSync(lockFile)) fs.unlinkSync(lockFile);
+  } catch {
+    // Best effort: a lock we cannot remove ages out via LOCK_TIMEOUT_MS.
+  }
+}
+
+/** Remove a PID file whose process is gone, so it does not look like a running server. */
+export function cleanupStalePidFile(verbose = false): void {
+  const pidInfo = readPidFile();
+  if (pidInfo && !isProcessAlive(pidInfo.pid)) {
+    if (verbose) console.log(`🧹 Cleaning stale PID file (PID ${pidInfo.pid} is dead)`);
+    removePidFile();
+  }
+}

--- a/tests/build/file-size.test.ts
+++ b/tests/build/file-size.test.ts
@@ -49,7 +49,6 @@ const GRANDFATHERED: Record<string, number> = {
   'src/vector/__tests__/benchmark.ts': 278,
   'src/indexer/__tests__/api.test.ts': 269,
   'src/indexer/__tests__/worker.test.ts': 265,
-  'src/ensure-server.ts': 258,
 };
 
 /**


### PR DESCRIPTION
Retires one entry from #2833's allow-list — properly, by splitting a concern rather than by lowering a number.

`src/ensure-server.ts`: **258 → 202 lines**, and its allow-list entry is **removed**, not reduced. It can never drift back over 250 without the ratchet catching it.

## The seam

Process locking is separable from server lifecycle. The lock answers *"is another process already trying to start one?"* — true regardless of what starting involves. `src/server/start-lock.ts` now owns `acquireStartLock` / `releaseStartLock` / `cleanupStalePidFile` and the staleness rule.

Pure move plus renames. No logic changed. Two imports only the moved code used are dropped.

## Verified behaviourally, not just by tsc

```
lock path     : /Users/nat/.arra-oracle-v2/oracle-http.lock
first acquire : true   exists: true
second acquire: false  (correctly held)
after release : removed
re-acquire    : true
```

The staleness handling is the part worth not breaking: a lock is released when it is **either** too old **or** held by a dead PID. Both matter — a live process can hold one past the timeout during a slow start, and a crashed one can leave a fresh lock that would otherwise block auto-start forever.

## A note on my first probe

It reported `false` for every acquire, which looked like the extraction had broken something. It hadn't — the probe had. `start-lock.ts` reads `getDataDir()`, and `configure({ dataDir })` runs at `ensure-server.ts` module load; importing the lock module alone never triggers it, so the probe resolved the default `~/.bun-process-manager`, which does not exist.

Recording it because the failure was indistinguishable from a real regression until I checked the harness. **A red from your own probe is a hypothesis, not a verdict.**

## Gate

- `bunx tsc --noEmit` — exit 0
- `bun test --isolate tests/build/ tests/lifecycle/ tests/process-manager/ tests/smoke/` — **61 pass**

Refs #2833