### PR TITLE
chore: extract shared fixtures from two oversized indexer test files

### DIFF
--- a/src/indexer/__tests__/api-harness.ts
+++ b/src/indexer/__tests__/api-harness.ts
@@ -1,0 +1,88 @@
+/**
+ * Shared fixture for the indexer daemon API tests.
+ *
+ * Extracted from `api.test.ts` (#2833): 269 lines against the 250-line rule, ~45 of them setup
+ * shared by all five describe blocks. Not named `*.test.ts`, so the runner does not collect a
+ * file with no assertions.
+ */
+/**
+ * Wave 2 — daemon HTTP API tests, ported from alpha's Hono harness to Elysia.
+ *
+ * Alpha used `app.fetch(new Request(...))` against a Hono app whose factory
+ * (`createDaemonApp(deps)`) lived at `src/indexer/api.ts`.
+ *
+ * Wave 2 splits responsibilities:
+ *   - `src/indexer/api.ts` will re-export the Elysia factory + `makeEventBus`
+ *   - or `src/routes/indexer-daemon/index.ts` will host the Elysia plugin
+ *
+ * Owner E owns that port (branch: port/wave2-elysia-daemon). This file ports
+ * the 14 alpha tests to Elysia's `app.handle(new Request(...))` API. The
+ * suite is currently `describe(...)` because Owner E's plugin has not
+ * yet landed — the import is wrapped in try/catch so the test file loads
+ * cleanly under bun even when the module is absent.
+ *
+ * When Owner E lands the Elysia daemon, drop `.skip` and the imports below
+ * should resolve.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import Database from 'bun:sqlite';
+import { Elysia } from 'elysia';
+import { enqueueIndexJob } from '../jobs.ts';
+import type { WorkerEvent } from '../worker.ts';
+import {
+  daemonApiPlugin,
+  makeEventBus,
+  type DaemonApiDeps,
+} from '../../routes/indexer-daemon/index.ts';
+
+type ApiDeps = DaemonApiDeps;
+
+type EventBus<E> = {
+  publish: (ev: E) => void;
+  subscribe: (cb: (ev: E) => void) => () => void;
+};
+
+export function createDaemonApp(deps: ApiDeps) {
+  return new Elysia().use(daemonApiPlugin(deps));
+}
+
+export const MIGRATION_SQL = `
+CREATE TABLE indexing_jobs (
+  id TEXT PRIMARY KEY,
+  doc_id TEXT NOT NULL,
+  model_key TEXT NOT NULL,
+  collection TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  attempts INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')*1000),
+  claimed_at INTEGER,
+  finished_at INTEGER,
+  error TEXT
+);
+`;
+
+export const MODELS = {
+  'bge-m3': { collection: 'oracle_knowledge_bge_m3' },
+  qwen3: { collection: 'oracle_knowledge_qwen3' },
+};
+
+export function makeDeps(): ApiDeps & { _shutdownFlag: { v: boolean }; _bus: EventBus<WorkerEvent> } {
+  const db = new Database(':memory:');
+  db.exec(MIGRATION_SQL);
+  const flag = { v: false };
+  const bus = makeEventBus<WorkerEvent>();
+  return {
+    db,
+    models: MODELS,
+    isShuttingDown: () => flag.v,
+    requestShutdown: () => { flag.v = true; },
+    subscribe: bus.subscribe,
+    _shutdownFlag: flag,
+    _bus: bus,
+  };
+}
+
+// The plugin mounts routes at the root (no prefix); the daemon entrypoint
+// uses `.use(daemonApiPlugin(deps))` directly on the root Elysia instance.
+export const URL_BASE = 'http://localhost';

--- a/src/indexer/__tests__/api.test.ts
+++ b/src/indexer/__tests__/api.test.ts
@@ -28,6 +28,7 @@ import {
   makeEventBus,
   type DaemonApiDeps,
 } from '../../routes/indexer-daemon/index.ts';
+import { createDaemonApp, MODELS, makeDeps, URL_BASE } from './api-harness.ts';
 
 type ApiDeps = DaemonApiDeps;
 
@@ -35,50 +36,6 @@ type EventBus<E> = {
   publish: (ev: E) => void;
   subscribe: (cb: (ev: E) => void) => () => void;
 };
-
-function createDaemonApp(deps: ApiDeps) {
-  return new Elysia().use(daemonApiPlugin(deps));
-}
-
-const MIGRATION_SQL = `
-CREATE TABLE indexing_jobs (
-  id TEXT PRIMARY KEY,
-  doc_id TEXT NOT NULL,
-  model_key TEXT NOT NULL,
-  collection TEXT NOT NULL,
-  status TEXT NOT NULL DEFAULT 'pending',
-  attempts INTEGER NOT NULL DEFAULT 0,
-  created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')*1000),
-  claimed_at INTEGER,
-  finished_at INTEGER,
-  error TEXT
-);
-`;
-
-const MODELS = {
-  'bge-m3': { collection: 'oracle_knowledge_bge_m3' },
-  qwen3: { collection: 'oracle_knowledge_qwen3' },
-};
-
-function makeDeps(): ApiDeps & { _shutdownFlag: { v: boolean }; _bus: EventBus<WorkerEvent> } {
-  const db = new Database(':memory:');
-  db.exec(MIGRATION_SQL);
-  const flag = { v: false };
-  const bus = makeEventBus<WorkerEvent>();
-  return {
-    db,
-    models: MODELS,
-    isShuttingDown: () => flag.v,
-    requestShutdown: () => { flag.v = true; },
-    subscribe: bus.subscribe,
-    _shutdownFlag: flag,
-    _bus: bus,
-  };
-}
-
-// The plugin mounts routes at the root (no prefix); the daemon entrypoint
-// uses `.use(daemonApiPlugin(deps))` directly on the root Elysia instance.
-const URL_BASE = 'http://localhost';
 
 describe('GET /health', () => {
   it('returns ok with queue depth + models', async () => {

--- a/src/indexer/__tests__/worker-harness.ts
+++ b/src/indexer/__tests__/worker-harness.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared fixture for the indexer worker tests.
+ *
+ * Extracted from `worker.test.ts` (#2833): that file was 265 lines against the 250-line rule,
+ * and ~60 of them were setup shared by all six describe blocks. Deliberately NOT named
+ * `*.test.ts` so the runner does not collect a file with no assertions in it.
+ */
+import Database from 'bun:sqlite';
+import type { WorkerDeps, WorkerEvent } from '../worker.ts';
+
+export const MIGRATION_SQL = `
+CREATE TABLE indexing_jobs (
+  id TEXT PRIMARY KEY,
+  doc_id TEXT NOT NULL,
+  model_key TEXT NOT NULL,
+  collection TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  attempts INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')*1000),
+  claimed_at INTEGER,
+  finished_at INTEGER,
+  error TEXT
+);
+`;
+
+export const MODELS = {
+  'bge-m3': { collection: 'oracle_knowledge_bge_m3' },
+};
+
+export function freshDb(): Database {
+  const db = new Database(':memory:');
+  db.exec(MIGRATION_SQL);
+  return db;
+}
+
+export interface TestHarness {
+  db: Database;
+  embedded: Array<{ model: string; text: string }>;
+  upserted: Array<{ collection: string; docId: string; vectorLen: number }>;
+  events: WorkerEvent[];
+  shutdownAfter: number;  // signal shutdown after this many job iterations
+}
+
+export function makeDeps(harness: TestHarness, overrides: Partial<WorkerDeps> = {}): WorkerDeps {
+  const docTexts: Record<string, string | null> = {
+    'doc-A': 'air quality monitoring with PM2.5 sensors',
+    'doc-B': 'flood radar accuracy on JIBCHAIN L1 blockchain',
+    'doc-deleted': null,
+  };
+  let iterations = 0;
+  return {
+    db: harness.db,
+    getDocText: (id) => (id in docTexts ? docTexts[id] : `synthetic content for ${id}`),
+    embed: async (model, text) => {
+      harness.embedded.push({ model, text });
+      return new Array(1024).fill(0).map(() => Math.random());
+    },
+    upsertVector: async (collection, docId, vector) => {
+      harness.upserted.push({ collection, docId, vectorLen: vector.length });
+    },
+    isShuttingDown: () => {
+      iterations++;
+      return iterations > harness.shutdownAfter;
+    },
+    pollIntervalMs: 5,  // fast empty-queue polls in tests
+    onEvent: (ev) => harness.events.push(ev),
+    ...overrides,
+  };
+}

--- a/src/indexer/__tests__/worker.test.ts
+++ b/src/indexer/__tests__/worker.test.ts
@@ -9,67 +9,8 @@
 import { describe, it, expect, beforeEach } from 'bun:test';
 import Database from 'bun:sqlite';
 import { enqueueIndexJob } from '../jobs.ts';
-import { runWorker, type WorkerDeps, type WorkerEvent } from '../worker.ts';
-
-const MIGRATION_SQL = `
-CREATE TABLE indexing_jobs (
-  id TEXT PRIMARY KEY,
-  doc_id TEXT NOT NULL,
-  model_key TEXT NOT NULL,
-  collection TEXT NOT NULL,
-  status TEXT NOT NULL DEFAULT 'pending',
-  attempts INTEGER NOT NULL DEFAULT 0,
-  created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')*1000),
-  claimed_at INTEGER,
-  finished_at INTEGER,
-  error TEXT
-);
-`;
-
-const MODELS = {
-  'bge-m3': { collection: 'oracle_knowledge_bge_m3' },
-};
-
-function freshDb(): Database {
-  const db = new Database(':memory:');
-  db.exec(MIGRATION_SQL);
-  return db;
-}
-
-interface TestHarness {
-  db: Database;
-  embedded: Array<{ model: string; text: string }>;
-  upserted: Array<{ collection: string; docId: string; vectorLen: number }>;
-  events: WorkerEvent[];
-  shutdownAfter: number;  // signal shutdown after this many job iterations
-}
-
-function makeDeps(harness: TestHarness, overrides: Partial<WorkerDeps> = {}): WorkerDeps {
-  const docTexts: Record<string, string | null> = {
-    'doc-A': 'air quality monitoring with PM2.5 sensors',
-    'doc-B': 'flood radar accuracy on JIBCHAIN L1 blockchain',
-    'doc-deleted': null,
-  };
-  let iterations = 0;
-  return {
-    db: harness.db,
-    getDocText: (id) => (id in docTexts ? docTexts[id] : `synthetic content for ${id}`),
-    embed: async (model, text) => {
-      harness.embedded.push({ model, text });
-      return new Array(1024).fill(0).map(() => Math.random());
-    },
-    upsertVector: async (collection, docId, vector) => {
-      harness.upserted.push({ collection, docId, vectorLen: vector.length });
-    },
-    isShuttingDown: () => {
-      iterations++;
-      return iterations > harness.shutdownAfter;
-    },
-    pollIntervalMs: 5,  // fast empty-queue polls in tests
-    onEvent: (ev) => harness.events.push(ev),
-    ...overrides,
-  };
-}
+import { runWorker } from '../worker.ts';
+import { MODELS, freshDb, makeDeps, type TestHarness } from './worker-harness.ts';
 
 describe('runWorker — happy path', () => {
   it('processes one job: claim → embed → upsert → mark done', async () => {

--- a/tests/build/file-size.test.ts
+++ b/tests/build/file-size.test.ts
@@ -46,8 +46,6 @@ const GRANDFATHERED: Record<string, number> = {
   'cli/src/cli.ts': 286,
   'src/indexer/__tests__/arra-indexer.test.ts': 284,
   'src/vector/__tests__/benchmark.ts': 278,
-  'src/indexer/__tests__/api.test.ts': 269,
-  'src/indexer/__tests__/worker.test.ts': 265,
 };
 
 /**


### PR DESCRIPTION
Two more entries off #2833's allow-list. **22 at filing → 17.**

| file | before | after |
|---|---|---|
| `src/indexer/__tests__/worker.test.ts` | 265 | **206** |
| `src/indexer/__tests__/api.test.ts` | 269 | **226** |

Both entries are **removed** from the allow-list, not lowered.

## Why a harness rather than splitting the tests

Each file had ~45–60 lines of setup shared by every describe block. Redistributing the tests would have duplicated it; extracting it leaves each behaviour where it is and removes only the preamble.

This also moves them toward the project's own convention — CLAUDE.md asks for *"nested, one behavior per file"*, which a 269-line file with five describe blocks is not. This does not finish that job, but it stops the files growing.

## The naming is load-bearing

The harnesses are **not** named `*.test.ts`. Bun collects by filename, so a fixture with that suffix would be run as a suite containing no assertions — which passes, and looks like coverage. Verified:

```
$ bun test src/indexer/__tests__/worker-harness.ts
note: Tests need ".test", "_test_", ".spec" or "_spec_" in the filename
```

## Gate

- `bunx tsc --noEmit` — exit 0
- `bun test --isolate tests/build/ src/indexer/ tests/indexer/` — **171 pass**

Pure move — same fixtures, imported instead of inlined.

Refs #2833