### PR TITLE
test: make the mcp-proxy server timeout explain itself

### DIFF
--- a/src/tools/__tests__/mcp-trace-proxy.test.ts
+++ b/src/tools/__tests__/mcp-trace-proxy.test.ts
@@ -21,15 +21,39 @@ function tempDir(prefix: string): string {
   return dir;
 }
 
-async function waitForHealth(baseUrl: string): Promise<void> {
+/**
+ * Wait for the spawned server, and say why if it never arrives (#2918).
+ *
+ * The server is spawned with `stdout: 'pipe', stderr: 'pipe'`, which captures both into
+ * streams nothing read — so a startup failure discarded the one artefact that would explain
+ * it, and CI showed only `server did not become healthy: http://127.0.0.1:PORT`.
+ *
+ * That silence is what let the turbovec flake (#2905) survive three CI cycles and two wrong
+ * diagnoses. #2906 added exactly this there, and the next failure identified the root cause
+ * in ten minutes.
+ */
+async function waitForHealth(baseUrl: string, server: Bun.Subprocess): Promise<void> {
   for (let i = 0; i < 60; i++) {
     try {
       const res = await fetch(`${baseUrl}/api/health`);
       if (res.ok) return;
     } catch { /* server still booting */ }
+    if (server.exitCode !== null) break;   // died — stop waiting out the full 15s
     await Bun.sleep(250);
   }
-  throw new Error(`server did not become healthy: ${baseUrl}`);
+
+  const read = async (stream: ReadableStream<Uint8Array> | null | undefined) => {
+    if (!stream) return '';
+    try { return (await new Response(stream).text()).trim(); } catch { return ''; }
+  };
+  const [out, err] = await Promise.all([read(server.stdout as never), read(server.stderr as never)]);
+  const detail = [
+    server.exitCode !== null ? `child exited: code=${server.exitCode} signal=${server.signalCode ?? 'null'}` : 'child still running',
+    err && `--- server stderr ---\n${err}`,
+    out && `--- server stdout ---\n${out}`,
+  ].filter(Boolean).join('\n');
+
+  throw new Error(`server did not become healthy: ${baseUrl}\n${detail || '(server produced no output)'}`);
 }
 
 afterEach(() => {
@@ -59,7 +83,7 @@ test('oracle_trace proxies through ORACLE_API without opening the MCP DB', async
     },
   });
   childProcesses.push(server);
-  await waitForHealth(baseUrl);
+  await waitForHealth(baseUrl, server);
 
   const transport = new StdioClientTransport({
     command: 'bun',


### PR DESCRIPTION
Prerequisite for #2918, following the pattern that worked for #2905.

## The failure said nothing

The server is spawned with `stdout: 'pipe', stderr: 'pipe'` — both captured into streams nothing reads. When startup fails, CI showed only:

```
error: server did not become healthy: http://127.0.0.1:49390
(fail) oracle_concepts proxies through ORACLE_API without opening the MCP DB [15178.55ms]
```

No exit code, no stderr, no indication whether the port was taken, the process died, or it was merely slow.

**That silence is what let the turbovec flake survive three CI cycles and two wrong diagnoses from me.** #2906 added exactly this treatment there; the very next failure produced the line that identified the root cause in ten minutes (#2908).

## What changes

`waitForHealth` now reports the child's exit code, signal, stderr and stdout — and breaks as soon as the child exits rather than waiting out the full 15 s.

**Verified by forcing a real startup failure**, not by assuming the path works:

```
error: server did not become healthy: http://127.0.0.1:49021
child exited: code=1 signal=null
```

## This does not fix the flake

It makes the next occurrence evidence instead of a shrug. #2918 also records that the port is `48600 + random(500)` with no free-port check — a plausible cause, and one worth testing once the logs can confirm or rule it out.

Tests only; nothing asserted changes.

Refs #2918