### PR TITLE
chore: extract the arra-indexer CLI test fixture

### DIFF
--- a/src/indexer/__tests__/arra-indexer-harness.ts
+++ b/src/indexer/__tests__/arra-indexer-harness.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared fixture for the arra-indexer CLI tests.
+ *
+ * Extracted from `arra-indexer.test.ts` (#2833): 284 lines against the 250-line rule, ~45 of
+ * them setup shared by all five describe blocks. Not named `*.test.ts` — bun collects by
+ * filename, and a fixture with that suffix would run as a suite containing no assertions.
+ */
+/**
+ * M4 CLI tests — argument parsing + subcommand handlers.
+ * Hermetic via in-memory SQLite + recording out/err functions.
+ */
+
+import { describe, it, expect, beforeEach } from 'bun:test';
+import Database from 'bun:sqlite';
+import { enqueueIndexJob } from '../jobs.ts';
+import {
+  parseCli,
+  cmdStatus,
+  cmdEnqueue,
+  cmdCancel,
+  cmdHelp,
+  dispatch,
+  type CliDeps,
+} from '../arra-indexer.ts';
+
+export const MIGRATION_SQL = `
+CREATE TABLE indexing_jobs (
+  id TEXT PRIMARY KEY,
+  doc_id TEXT NOT NULL,
+  model_key TEXT NOT NULL,
+  collection TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  attempts INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')*1000),
+  claimed_at INTEGER,
+  finished_at INTEGER,
+  error TEXT
+);
+`;
+
+export const MODELS = {
+  'bge-m3': { collection: 'oracle_knowledge_bge_m3' },
+  qwen3: { collection: 'oracle_knowledge_qwen3' },
+};
+
+export interface RecordingDeps extends CliDeps {
+  stdout: string[];
+  stderr: string[];
+}
+
+export function makeDeps(): RecordingDeps {
+  const db = new Database(':memory:');
+  db.exec(MIGRATION_SQL);
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  return {
+    db,
+    models: MODELS,
+    stdout,
+    stderr,
+    out: (s) => { stdout.push(s); },
+    err: (s) => { stderr.push(s); },
+  };
+}
+
+// ============================================================================
+// parseCli
+// ============================================================================

--- a/src/indexer/__tests__/arra-indexer.test.ts
+++ b/src/indexer/__tests__/arra-indexer.test.ts
@@ -15,50 +15,7 @@ import {
   dispatch,
   type CliDeps,
 } from '../arra-indexer.ts';
-
-const MIGRATION_SQL = `
-CREATE TABLE indexing_jobs (
-  id TEXT PRIMARY KEY,
-  doc_id TEXT NOT NULL,
-  model_key TEXT NOT NULL,
-  collection TEXT NOT NULL,
-  status TEXT NOT NULL DEFAULT 'pending',
-  attempts INTEGER NOT NULL DEFAULT 0,
-  created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')*1000),
-  claimed_at INTEGER,
-  finished_at INTEGER,
-  error TEXT
-);
-`;
-
-const MODELS = {
-  'bge-m3': { collection: 'oracle_knowledge_bge_m3' },
-  qwen3: { collection: 'oracle_knowledge_qwen3' },
-};
-
-interface RecordingDeps extends CliDeps {
-  stdout: string[];
-  stderr: string[];
-}
-
-function makeDeps(): RecordingDeps {
-  const db = new Database(':memory:');
-  db.exec(MIGRATION_SQL);
-  const stdout: string[] = [];
-  const stderr: string[] = [];
-  return {
-    db,
-    models: MODELS,
-    stdout,
-    stderr,
-    out: (s) => { stdout.push(s); },
-    err: (s) => { stderr.push(s); },
-  };
-}
-
-// ============================================================================
-// parseCli
-// ============================================================================
+import { MODELS, makeDeps, type RecordingDeps } from './arra-indexer-harness.ts';
 
 describe('parseCli', () => {
   it('returns empty subcommand for empty argv', () => {

--- a/tests/build/file-size.test.ts
+++ b/tests/build/file-size.test.ts
@@ -44,7 +44,6 @@ const GRANDFATHERED: Record<string, number> = {
   // alpha red the moment it lands (P9 — green in a worktree is not green on base).
   'src/server.ts': 293,
   'cli/src/cli.ts': 286,
-  'src/indexer/__tests__/arra-indexer.test.ts': 284,
   'src/vector/__tests__/benchmark.ts': 278,
 };
 


### PR DESCRIPTION
One more entry off #2833's allow-list. **22 at filing → 16.**

`src/indexer/__tests__/arra-indexer.test.ts`: **284 → 241 lines**, entry **removed** rather than lowered.

~45 lines of setup shared by all five describe blocks move to `arra-indexer-harness.ts`. Same treatment as #2917, and it moves the file toward CLAUDE.md's *"nested, one behavior per file"*.

## The naming stays load-bearing

The fixture is **not** `*.test.ts`. Bun collects by filename, so a fixture with that suffix runs as a suite containing zero assertions — passing, and reading as coverage.

## One thing I fixed in my own method

The import is inserted after the last line that **closes** an import statement, not the last line that **starts with** `import`. That heuristic broke two files earlier tonight by inserting into the middle of a multi-line import:

```ts
import {
import { createDaemonApp, ... } from './api-harness.ts';   // ← inserted here
  daemonApiPlugin,
```

tsc caught it both times, but it is the kind of edit that is easy to repeat.

## Gate

- `bunx tsc --noEmit` — exit 0
- `bun test --isolate src/indexer/__tests__/ tests/build/` — **153 pass**

Refs #2833