### PR TITLE
test: assert the Fleet Log cluster is actually mounted in the server

### DIFF
--- a/tests/http/fleet-log/mounted-in-server.test.ts
+++ b/tests/http/fleet-log/mounted-in-server.test.ts
@@ -1,0 +1,55 @@
+/**
+ * The Fleet Log routes must be mounted in the composed app, not merely written.
+ *
+ * The other tests in this directory call `createFleetLogRoutes().handle(request)`, exercising
+ * the cluster in isolation — every one of them would still pass if the cluster were never added
+ * to `apiModules` in `src/server.ts`. That is the #2877 defect shape: a green suite guarding
+ * code production never reaches.
+ *
+ * Found by booting the real server after #2894 had already merged. It *was* mounted correctly —
+ * but nothing would have said so if it were not.
+ *
+ * Follows the `app.routes` approach from `tests/integration/server-boot/composition.test.ts`
+ * rather than issuing requests: it is the existing convention here, and it asserts the mount
+ * directly instead of inferring it from a response.
+ */
+import { describe, expect, test } from 'bun:test';
+import { createApp } from '../../../src/server.ts';
+import type { UnifiedRuntime } from '../../../src/plugins/unified-loader.ts';
+
+function runtime(): UnifiedRuntime {
+  return {
+    pluginCount: 0,
+    routes: [],
+    mcpTools: [],
+    menu: [],
+    cliSubcommands: [],
+    servers: [],
+    callMcpTool: async () => ({}),
+    pluginStatuses: () => [],
+    pluginRegistry: () => [],
+    init: async () => {},
+    reload: async () => {},
+    stop: async () => {},
+  };
+}
+
+describe('the Fleet Log cluster is wired into the server', () => {
+  const paths = () => createApp({ unifiedPlugins: runtime() }).routes.map((r) => `${r.method} ${r.path}`);
+
+  test('GET /api/fleet-log/search is mounted', () => {
+    expect(paths()).toContain('GET /api/fleet-log/search');
+  });
+
+  test('GET /api/fleet-log/thread/:key is mounted', () => {
+    expect(paths()).toContain('GET /api/fleet-log/thread/:key');
+  });
+
+  test('both contract paths from fleetLogMock.ts resolve to real routes', () => {
+    // The strings the frontend has been declaring since before the routes existed.
+    const mounted = paths();
+    for (const path of ['/api/fleet-log/search', '/api/fleet-log/thread/:key']) {
+      expect(mounted.some((entry) => entry.endsWith(` ${path}`))).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Closes a gap in **my own** #2894, found by booting the real server after it had already merged.

## The gap

Every test in `tests/http/fleet-log/` calls:

```ts
createFleetLogRoutes().handle(request)
```

That exercises the cluster **in isolation**. All 31 of them would still pass if the cluster were never added to `apiModules` in `src/server.ts` — the #2877 defect shape, shipped by me, in a PR whose own description praised catching that shape elsewhere.

## Mutation-checked, and the numbers are the argument

```
cluster removed from apiModules -> 31 pass, 3 fail   ← only the new guard notices
restored                        -> 34 pass, 0 fail
```

Thirty-one passing tests on a completely unmounted feature.

## Approach

Uses `app.routes` like `tests/integration/server-boot/composition.test.ts` rather than issuing requests — the existing convention here, and it asserts the mount directly instead of inferring it from a response.

## A note from the boot check

`/api/fleet-log/search` answers **308** to `/api/v1/fleet-log/search`. That is `api-version.ts` applied to every `/api/*` route, not anything specific to this cluster. `fetch` follows 308 by default and it preserves method and body, so the contract string `fleetLogMock.ts` advertises works exactly as written — verified against a live server:

```
/api/fleet-log/search       308 -> /api/v1/fleet-log/search
/api/v1/fleet-log/search    200  {"success":true,"data":{"messages":[],"total":0,...}}
?channel=slack (following)  400
```

## Gate

- `bunx tsc --noEmit` — exit 0
- `bun test --isolate tests/http/fleet-log/` — **34 pass**

Refs #2879