### PR TITLE
fix(verify): scan indexed vault roots

### DIFF
--- a/src/verify/__tests__/handler-edge.test.ts
+++ b/src/verify/__tests__/handler-edge.test.ts
@@ -22,12 +22,16 @@ const now = Date.now();
 const relAbsolute = `ψ/memory/learnings/verify-absolute-${stamp}.md`;
 const relBackslash = `ψ/memory/learnings/verify-backslash-${stamp}.md`;
 const relOrphan = `ψ/memory/learnings/verify-orphan-${stamp}.md`;
+const relProjectFirst = `github.com/acme/demo/ψ/memory/learnings/verify-project-first-${stamp}.md`;
+const relProjectFirstOrphan = `github.com/acme/demo/ψ/memory/learnings/verify-project-first-orphan-${stamp}.md`;
 const ids = {
   absolute: `verify-absolute-${stamp}`,
   backslash: `verify-backslash-${stamp}`,
   blank: `verify-blank-${stamp}`,
   orphanA: `verify-orphan-a-${stamp}`,
   orphanB: `verify-orphan-b-${stamp}`,
+  projectFirst: `verify-project-first-${stamp}`,
+  projectFirstOrphan: `verify-project-first-orphan-${stamp}`,
 };
 
 function writeRepoFile(relPath: string) {
@@ -50,11 +54,14 @@ function seedDoc(id: string, sourceFile: string) {
 
 writeRepoFile(relAbsolute);
 writeRepoFile(relBackslash);
+writeRepoFile(relProjectFirst);
 seedDoc(ids.absolute, path.join(repoRoot, relAbsolute));
 seedDoc(ids.backslash, relBackslash.replaceAll('/', '\\'));
 seedDoc(ids.blank, '   ');
 seedDoc(ids.orphanA, relOrphan.replaceAll('/', '\\'));
 seedDoc(ids.orphanB, relOrphan);
+seedDoc(ids.projectFirst, relProjectFirst);
+seedDoc(ids.projectFirstOrphan, relProjectFirstOrphan);
 
 function restore(name: string, value: string | undefined) {
   if (value === undefined) delete process.env[name];
@@ -73,9 +80,9 @@ describe('verifyKnowledgeBase edge cases', () => {
   test('normalizes absolute and backslash DB source paths before classification', () => {
     const result = verifyKnowledgeBase({ repoRoot, type: ' learning ' });
 
-    expect(result.counts.healthy).toBe(2);
+    expect(result.counts.healthy).toBe(3);
     expect(result.missing).toEqual([]);
-    expect(result.orphaned).toEqual([relOrphan]);
+    expect(result.orphaned).toEqual([relOrphan, relProjectFirstOrphan]);
     expect(result.orphaned).not.toContain('');
   });
 
@@ -86,9 +93,17 @@ describe('verifyKnowledgeBase edge cases', () => {
       .all();
     const superseded = Object.fromEntries(rows.map((row) => [row.id, row.supersededBy]));
 
-    expect(result.fixedOrphans).toBe(2);
+    expect(result.fixedOrphans).toBe(3);
     expect(superseded[ids.orphanA]).toBe('_verified_orphan');
     expect(superseded[ids.orphanB]).toBe('_verified_orphan');
+    expect(superseded[ids.projectFirstOrphan]).toBe('_verified_orphan');
     expect(superseded[ids.blank]).toBeNull();
+  });
+
+  test('classifies project-first vault files as healthy when file exists on disk', () => {
+    const result = verifyKnowledgeBase({ repoRoot, type: 'learning' });
+
+    expect(result.orphaned).not.toContain(relProjectFirst);
+    expect(result.counts.healthy).toBeGreaterThanOrEqual(3);
   });
 });

--- a/src/verify/__tests__/handler-edge.test.ts
+++ b/src/verify/__tests__/handler-edge.test.ts
@@ -25,6 +25,8 @@ const relOrphan = `ψ/memory/learnings/verify-orphan-${stamp}.md`;
 const relProjectFirst = `github.com/acme/demo/ψ/memory/learnings/verify-project-first-${stamp}.md`;
 const relProjectFirstOrphan = `github.com/acme/demo/ψ/memory/learnings/verify-project-first-orphan-${stamp}.md`;
 const relCrew = `ψ/crew/reviewer/memory/learnings/verify-crew-${stamp}.md`;
+const relProjectInbox = `github.com/acme/demo/ψ/inbox/handoff/verify-project-inbox-${stamp}.md`;
+const relCrewInbox = `ψ/crew/reviewer/inbox/handoff/verify-crew-inbox-${stamp}.md`;
 const ids = {
   absolute: `verify-absolute-${stamp}`,
   backslash: `verify-backslash-${stamp}`,
@@ -58,6 +60,8 @@ writeRepoFile(relAbsolute);
 writeRepoFile(relBackslash);
 writeRepoFile(relProjectFirst);
 writeRepoFile(relCrew);
+writeRepoFile(relProjectInbox);
+writeRepoFile(relCrewInbox);
 seedDoc(ids.absolute, path.join(repoRoot, relAbsolute));
 seedDoc(ids.backslash, relBackslash.replaceAll('/', '\\'));
 seedDoc(ids.blank, '   ');
@@ -116,5 +120,12 @@ describe('verifyKnowledgeBase edge cases', () => {
 
     expect(result.orphaned).not.toContain(relCrew);
     expect(result.counts.healthy).toBeGreaterThanOrEqual(4);
+  });
+
+  test('reports project-first and crew inbox files as untracked', () => {
+    const result = verifyKnowledgeBase({ repoRoot, type: 'learning' });
+
+    expect(result.untracked).toContain(relProjectInbox);
+    expect(result.untracked).toContain(relCrewInbox);
   });
 });

--- a/src/verify/__tests__/handler-edge.test.ts
+++ b/src/verify/__tests__/handler-edge.test.ts
@@ -24,6 +24,7 @@ const relBackslash = `ψ/memory/learnings/verify-backslash-${stamp}.md`;
 const relOrphan = `ψ/memory/learnings/verify-orphan-${stamp}.md`;
 const relProjectFirst = `github.com/acme/demo/ψ/memory/learnings/verify-project-first-${stamp}.md`;
 const relProjectFirstOrphan = `github.com/acme/demo/ψ/memory/learnings/verify-project-first-orphan-${stamp}.md`;
+const relCrew = `ψ/crew/reviewer/memory/learnings/verify-crew-${stamp}.md`;
 const ids = {
   absolute: `verify-absolute-${stamp}`,
   backslash: `verify-backslash-${stamp}`,
@@ -32,6 +33,7 @@ const ids = {
   orphanB: `verify-orphan-b-${stamp}`,
   projectFirst: `verify-project-first-${stamp}`,
   projectFirstOrphan: `verify-project-first-orphan-${stamp}`,
+  crew: `verify-crew-${stamp}`,
 };
 
 function writeRepoFile(relPath: string) {
@@ -55,6 +57,7 @@ function seedDoc(id: string, sourceFile: string) {
 writeRepoFile(relAbsolute);
 writeRepoFile(relBackslash);
 writeRepoFile(relProjectFirst);
+writeRepoFile(relCrew);
 seedDoc(ids.absolute, path.join(repoRoot, relAbsolute));
 seedDoc(ids.backslash, relBackslash.replaceAll('/', '\\'));
 seedDoc(ids.blank, '   ');
@@ -62,6 +65,7 @@ seedDoc(ids.orphanA, relOrphan.replaceAll('/', '\\'));
 seedDoc(ids.orphanB, relOrphan);
 seedDoc(ids.projectFirst, relProjectFirst);
 seedDoc(ids.projectFirstOrphan, relProjectFirstOrphan);
+seedDoc(ids.crew, relCrew);
 
 function restore(name: string, value: string | undefined) {
   if (value === undefined) delete process.env[name];
@@ -80,7 +84,7 @@ describe('verifyKnowledgeBase edge cases', () => {
   test('normalizes absolute and backslash DB source paths before classification', () => {
     const result = verifyKnowledgeBase({ repoRoot, type: ' learning ' });
 
-    expect(result.counts.healthy).toBe(3);
+    expect(result.counts.healthy).toBe(4);
     expect(result.missing).toEqual([]);
     expect(result.orphaned).toEqual([relOrphan, relProjectFirstOrphan]);
     expect(result.orphaned).not.toContain('');
@@ -105,5 +109,12 @@ describe('verifyKnowledgeBase edge cases', () => {
 
     expect(result.orphaned).not.toContain(relProjectFirst);
     expect(result.counts.healthy).toBeGreaterThanOrEqual(3);
+  });
+
+  test('classifies crew vault files as healthy when file exists on disk', () => {
+    const result = verifyKnowledgeBase({ repoRoot, type: 'learning' });
+
+    expect(result.orphaned).not.toContain(relCrew);
+    expect(result.counts.healthy).toBeGreaterThanOrEqual(4);
   });
 });

--- a/src/verify/handler.ts
+++ b/src/verify/handler.ts
@@ -157,11 +157,16 @@ export function verifyKnowledgeBase(opts: {
   }
 
   // 4. Count untracked files outside indexed dirs.
-  const untrackedDirs = ['ψ/inbox'];
+  // Mirror the psiDirs scope above: inbox lives at repoRoot, project-first ({project}/ψ/inbox),
+  // and crew ({member}/inbox). A root-only walk silently misses the project/crew layouts and
+  // lets those files fall through both phases — orphaned by the memory-only walk, invisible here.
+  const untrackedRoots = [path.join(repoRoot, 'ψ', 'inbox')];
+  for (const psiDir of psiDirs) {
+    untrackedRoots.push(path.join(psiDir, 'inbox'));
+  }
   const untracked: string[] = [];
   if (!tenantId) {
-    for (const dir of untrackedDirs) {
-      const fullDir = path.join(repoRoot, dir);
+    for (const fullDir of untrackedRoots) {
       const files = walkMarkdownFiles(fullDir, repoRoot);
       for (const f of files) {
         untracked.push(f.relativePath);

--- a/src/verify/handler.ts
+++ b/src/verify/handler.ts
@@ -11,7 +11,7 @@ import path from 'path';
 import { and, eq } from 'drizzle-orm';
 import { db, oracleDocuments } from '../db/index.ts';
 import { currentTenantId } from '../middleware/tenant.ts';
-import { discoverProjectPsiDirs } from '../indexer/discovery.ts';
+import { discoverCrewPsiDirs, discoverProjectPsiDirs } from '../indexer/discovery.ts';
 import { walkMarkdownFiles } from './files.ts';
 import { normalizeSourceFile } from './paths.ts';
 
@@ -48,12 +48,6 @@ export function verifyKnowledgeBase(opts: {
   const { check = true, type, repoRoot } = opts;
   const tenantId = currentTenantId();
 
-  // 1. Walk indexed directories on disk.
-  // Mirrors src/indexer/collectors.ts: walk project-first vault dirs
-  // (github.com/<org>/<repo>/ψ/memory/<sub>) AND legacy top-level ψ/memory/<sub>.
-  // Project-first is canonical since "central ψ/ via vault repo — Phase 1"
-  // (commit 43078d27). Without it, every project-first DB row is falsely
-  // reported as orphaned.
   const memorySubdirs = ['resonance', 'learnings', 'retrospectives'];
   const diskFiles = new Map<string, number>(); // relativePath -> mtimeMs
 
@@ -63,7 +57,8 @@ export function verifyKnowledgeBase(opts: {
     }
   };
 
-  for (const psiDir of discoverProjectPsiDirs(repoRoot)) {
+  const psiDirs = [...discoverProjectPsiDirs(repoRoot), ...discoverCrewPsiDirs(repoRoot)];
+  for (const psiDir of psiDirs) {
     for (const sub of memorySubdirs) {
       walkInto(path.join(psiDir, 'memory', sub));
     }

--- a/src/verify/handler.ts
+++ b/src/verify/handler.ts
@@ -11,6 +11,7 @@ import path from 'path';
 import { and, eq } from 'drizzle-orm';
 import { db, oracleDocuments } from '../db/index.ts';
 import { currentTenantId } from '../middleware/tenant.ts';
+import { discoverProjectPsiDirs } from '../indexer/discovery.ts';
 import { walkMarkdownFiles } from './files.ts';
 import { normalizeSourceFile } from './paths.ts';
 
@@ -47,22 +48,32 @@ export function verifyKnowledgeBase(opts: {
   const { check = true, type, repoRoot } = opts;
   const tenantId = currentTenantId();
 
-  // 1. Walk indexed directories on disk
-  const indexedDirs = [
-    'ψ/memory/resonance',
-    'ψ/memory/learnings',
-    'ψ/memory/retrospectives',
-    'ψ/learn',
-  ];
+  // 1. Walk indexed directories on disk.
+  // Mirrors src/indexer/collectors.ts: walk project-first vault dirs
+  // (github.com/<org>/<repo>/ψ/memory/<sub>) AND legacy top-level ψ/memory/<sub>.
+  // Project-first is canonical since "central ψ/ via vault repo — Phase 1"
+  // (commit 43078d27). Without it, every project-first DB row is falsely
+  // reported as orphaned.
+  const memorySubdirs = ['resonance', 'learnings', 'retrospectives'];
   const diskFiles = new Map<string, number>(); // relativePath -> mtimeMs
 
-  for (const dir of indexedDirs) {
-    const fullDir = path.join(repoRoot, dir);
-    const files = walkMarkdownFiles(fullDir, repoRoot);
-    for (const f of files) {
+  const walkInto = (fullDir: string) => {
+    for (const f of walkMarkdownFiles(fullDir, repoRoot)) {
       diskFiles.set(f.relativePath, f.mtimeMs);
     }
+  };
+
+  for (const psiDir of discoverProjectPsiDirs(repoRoot)) {
+    for (const sub of memorySubdirs) {
+      walkInto(path.join(psiDir, 'memory', sub));
+    }
+    walkInto(path.join(psiDir, 'learn'));
   }
+
+  for (const sub of memorySubdirs) {
+    walkInto(path.join(repoRoot, 'ψ', 'memory', sub));
+  }
+  walkInto(path.join(repoRoot, 'ψ', 'learn'));
 
   // 2. Query DB for all indexed documents
   const normalizedType = type?.trim();


### PR DESCRIPTION
## Summary
- scan project-first vault directories during oracle_verify disk discovery
- scan crew ψ-brain directories using the same discovery contract as the indexer
- preserve legacy top-level ψ roots and add regression coverage for healthy nested files plus true orphans

## Root cause
The indexer discovers project-first and crew ψ roots, while verify only walked top-level ψ directories. Valid indexed documents were therefore reported as orphaned, and check=false could incorrectly supersede those rows.

## Verification
- bun test on five verify-related test files: 13 pass, 0 fail
- bunx tsc --noEmit
- TypeScript no-excuse audit: clean
- git diff --check: clean
- live project-first vault proof before crew hardening: false orphan count 341 to 0

## Scope
Two files only: src/verify/handler.ts and src/verify/__tests__/handler-edge.test.ts.