### PR TITLE
feat: unify Oracle document and vector identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ arra-oracle-v3/
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ORACLE_PORT` | `47778` | HTTP server port |
-| `ORACLE_REPO_ROOT` | `process.cwd()` | Knowledge base root |
+| `ORACLE_REPO_ROOT` | Auto-resolved | Knowledge base root. Uses `ORACLE_DATA_DIR` when it contains `ψ/`, then the source project root when it contains `ψ/`, and otherwise `ORACLE_DATA_DIR`. |
 
 ## Testing
 

--- a/cli/src/plugin/__tests__/invoke.test.ts
+++ b/cli/src/plugin/__tests__/invoke.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { invokePlugin } from "../invoke.ts";
+import type { InvokeContext, LoadedPlugin } from "../types.ts";
+
+// Handler that hangs forever — the ONLY way its invocation settles is the
+// timeout, so the abort test is deterministic without racing a real delay.
+const HANGING_HANDLER = "export default () => Promise.withResolvers().promise;";
+// Handler gated on a test-controlled signal — the test resolves it and awaits
+// the real completion, so the pass tests never wait on a wall-clock duration.
+const GATED_HANDLER =
+  'export default async () => { await globalThis.__ARRA_PROBE__; return { ok: true, output: "done" }; };';
+
+// Named cast (rule: no inline cast in member access): a test-only global channel
+// used to gate the probe handler, which lives in a separate imported file.
+const probeGlobal = globalThis as typeof globalThis & { __ARRA_PROBE__?: Promise<void> };
+
+const dirs: string[] = [];
+afterAll(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+afterEach(() => {
+  delete probeGlobal.__ARRA_PROBE__;
+});
+
+function pluginWith(handlerSource: string, timeoutMs?: number): LoadedPlugin {
+  const dir = mkdtempSync(join(tmpdir(), "arra-invoke-"));
+  dirs.push(dir);
+  const entryPath = join(dir, "index.ts");
+  writeFileSync(entryPath, handlerSource);
+  return {
+    manifest: { name: "probe", version: "1.0.0", entry: "./index.ts", sdk: "^0.0.1", timeoutMs },
+    dir,
+    entryPath,
+  };
+}
+
+const ctx: InvokeContext = { source: "cli", args: [] };
+
+describe("invokePlugin per-plugin timeout", () => {
+  // The arra-server plugin needs >5s for a cold HTTP start; the global default
+  // cap is 5000ms. These prove manifest.timeoutMs is the effective cap, so the
+  // server plugin's 20000ms lets a slow-but-healthy start finish instead of
+  // being aborted at the 5s default.
+
+  // Exception to no-real-timers: this exercises invokePlugin's OWN setTimeout
+  // against the platform clock. The handler never settles, so only the 60ms
+  // timeout can resolve the invocation — deterministic, no race, no tuned wait.
+  test("handler is aborted at manifest.timeoutMs", async () => {
+    const result = await invokePlugin(pluginWith(HANGING_HANDLER, 60), ctx);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("timed out after 60ms");
+  });
+
+  test("handler completing under a raised cap passes (manifest overrides the 5000ms default)", async () => {
+    const gate = Promise.withResolvers<void>();
+    probeGlobal.__ARRA_PROBE__ = gate.promise;
+    const invocation = invokePlugin(pluginWith(GATED_HANDLER, 20000), ctx);
+    gate.resolve(); // release the handler; we await its real completion
+    const result = await invocation;
+    expect(result.ok).toBe(true);
+    expect(result.output).toBe("done");
+  });
+
+  test("a completed handler returns without waiting out the timeout window", async () => {
+    // If the timer were awaited/leaked instead of cleared, this invocation
+    // would hang for the full 20000ms and blow the test runner's own timeout.
+    const gate = Promise.withResolvers<void>();
+    probeGlobal.__ARRA_PROBE__ = gate.promise;
+    const invocation = invokePlugin(pluginWith(GATED_HANDLER, 20000), ctx);
+    gate.resolve();
+    expect((await invocation).ok).toBe(true);
+  });
+});

--- a/cli/src/plugin/__tests__/learn.test.ts
+++ b/cli/src/plugin/__tests__/learn.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { InvokeContext } from "../types.ts";
+import handler from "../../plugins/learn/index.ts";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function captureRequest(response: Record<string, unknown>) {
+  let body: Record<string, unknown> | undefined;
+  globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+    body = JSON.parse(String(init?.body));
+    return Response.json(response);
+  }) as typeof fetch;
+  return () => body;
+}
+
+function context(args: string[]): InvokeContext {
+  return { source: "cli", args };
+}
+
+describe("arra learn CLI", () => {
+  test("forwards explicit project scope and reports the created file", async () => {
+    const captured = captureRequest({ id: "learning_test", file: "ψ/memory/learnings/test.md" });
+
+    const result = await handler(context([
+      "the lesson",
+      "--concepts", "origin-tool-observation,scope-project,confidence-verified",
+      "--source", "rrr:soul-brews-studio/arra-oracle-v3",
+      "--project", "github.com/soul-brews-studio/arra-oracle-v3",
+    ]));
+
+    expect(result.ok).toBe(true);
+    expect(captured()).toEqual({
+      pattern: "the lesson",
+      concepts: ["origin-tool-observation", "scope-project", "confidence-verified"],
+      source: "rrr:soul-brews-studio/arra-oracle-v3",
+      project: "github.com/soul-brews-studio/arra-oracle-v3",
+    });
+    expect(result.output).toContain("file: ψ/memory/learnings/test.md");
+  });
+
+  test("rejects --project without a value before calling the API", async () => {
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return Response.json({});
+    }) as typeof fetch;
+
+    const result = await handler(context(["the lesson", "--project"]));
+
+    expect(result).toEqual({ ok: false, error: "--project requires a value" });
+    expect(called).toBe(false);
+  });
+});

--- a/cli/src/plugin/__tests__/manifest.test.ts
+++ b/cli/src/plugin/__tests__/manifest.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { validateManifest } from "../manifest.ts";
+import type { PluginManifest } from "../types.ts";
+
+const base: PluginManifest = { name: "probe", version: "1.0.0", entry: "./index.ts", sdk: "^0.0.1" };
+
+describe("validateManifest timeoutMs", () => {
+  test("accepts a positive number", () => {
+    expect(() => validateManifest({ ...base, timeoutMs: 20000 })).not.toThrow();
+  });
+
+  test("accepts an omitted timeoutMs", () => {
+    expect(() => validateManifest(base)).not.toThrow();
+  });
+
+  test("rejects zero", () => {
+    expect(() => validateManifest({ ...base, timeoutMs: 0 })).toThrow(/timeoutMs must be a positive number/);
+  });
+
+  test("rejects a negative value", () => {
+    expect(() => validateManifest({ ...base, timeoutMs: -1 })).toThrow(/positive number/);
+  });
+
+  test("rejects a non-number (e.g. a string from malformed plugin.json)", () => {
+    // Named cast (rule: no inline cast in member access): a malformed manifest as
+    // it would arrive from untyped JSON, to prove the runtime guard fires.
+    const malformed = { ...base, timeoutMs: "20000" } as unknown as PluginManifest;
+    expect(() => validateManifest(malformed)).toThrow(/positive number/);
+  });
+});

--- a/cli/src/plugin/invoke.ts
+++ b/cli/src/plugin/invoke.ts
@@ -1,6 +1,6 @@
 import type { LoadedPlugin, InvokeContext, InvokeResult } from "./types.ts";
 
-const TIMEOUT_MS = Number(process.env.ARRA_PLUGIN_TIMEOUT_MS ?? 5000);
+const DEFAULT_TIMEOUT_MS = Number(process.env.ARRA_PLUGIN_TIMEOUT_MS ?? 5000);
 
 export async function invokePlugin(plugin: LoadedPlugin, ctx: InvokeContext): Promise<InvokeResult> {
   try {
@@ -10,12 +10,20 @@ export async function invokePlugin(plugin: LoadedPlugin, ctx: InvokeContext): Pr
       return { ok: false, error: `plugin ${plugin.manifest.name}: default export must be a function` };
     }
 
-    const result = await Promise.race([
-      handler(ctx) as Promise<InvokeResult>,
-      new Promise<InvokeResult>((_, reject) =>
-        setTimeout(() => reject(new Error(`plugin ${plugin.manifest.name} timed out after ${TIMEOUT_MS}ms`)), TIMEOUT_MS)
-      ),
-    ]);
+    const timeoutMs = plugin.manifest.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const { promise: timeout, reject } = Promise.withResolvers<InvokeResult>();
+    const timer = setTimeout(
+      () => reject(new Error(`plugin ${plugin.manifest.name} timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+    let result: InvokeResult;
+    try {
+      // Whichever settles first wins; clearing the timer stops a fast success
+      // from keeping the event loop alive for the full timeout window.
+      result = await Promise.race([handler(ctx) as Promise<InvokeResult>, timeout]);
+    } finally {
+      clearTimeout(timer);
+    }
 
     return result ?? { ok: true };
   } catch (err) {

--- a/cli/src/plugin/manifest.ts
+++ b/cli/src/plugin/manifest.ts
@@ -32,6 +32,9 @@ export function validateManifest(m: PluginManifest): void {
   if (m.seedMenu !== undefined && typeof m.seedMenu !== "boolean") {
     throw new Error(`manifest.seedMenu must be a boolean`);
   }
+  if (m.timeoutMs !== undefined && (typeof m.timeoutMs !== "number" || !Number.isFinite(m.timeoutMs) || m.timeoutMs <= 0)) {
+    throw new Error(`manifest.timeoutMs must be a positive number`);
+  }
   if (m.api) {
     if (!m.api.path || typeof m.api.path !== "string" || !m.api.path.startsWith("/")) {
       throw new Error(`manifest.api.path must be an absolute path`);

--- a/cli/src/plugin/types.ts
+++ b/cli/src/plugin/types.ts
@@ -9,6 +9,8 @@ export interface PluginManifest {
   tier?: "core" | "standard" | "extra";
   enabled?: boolean;
   seedMenu?: boolean;
+  /** Max ms invokePlugin waits for this plugin before aborting. Overrides the global ARRA_PLUGIN_TIMEOUT_MS default. */
+  timeoutMs?: number;
   cli?: {
     command: string;
     aliases?: string[];

--- a/cli/src/plugins/learn/index.ts
+++ b/cli/src/plugins/learn/index.ts
@@ -1,5 +1,5 @@
-// arra-cli learn "<pattern>" [--concepts a,b] [--source s]
-// Calls: POST /api/learn { pattern, concepts?, source? }
+// arra-cli learn "<pattern>" [--concepts a,b] [--source s] [--project p]
+// Calls: POST /api/learn { pattern, concepts?, source?, project? }
 // Note: issue #770 listed this as POST /api/muninn_learn — using actual POST /api/learn route
 
 import type { InvokeContext, InvokeResult } from "../../plugin/types.ts";
@@ -11,24 +11,33 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
   let pattern = "";
   let concepts: string[] | undefined;
   let source: string | undefined;
+  let project: string | undefined;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--concepts" && args[i + 1]) {
       concepts = args[++i].split(",").map(c => c.trim()).filter(Boolean);
     } else if (args[i] === "--source" && args[i + 1]) {
       source = args[++i];
+    } else if (args[i] === "--project") {
+      const value = args[i + 1];
+      if (!value || value.startsWith("--")) {
+        return { ok: false, error: "--project requires a value" };
+      }
+      project = value;
+      i++;
     } else if (!args[i].startsWith("--")) {
       pattern = args[i];
     }
   }
 
   if (!pattern) {
-    return { ok: false, error: 'Usage: arra-cli learn "<pattern>" [--concepts a,b] [--source s]' };
+    return { ok: false, error: 'Usage: arra-cli learn "<pattern>" [--concepts a,b] [--source s] [--project p]' };
   }
 
   const body: Record<string, unknown> = { pattern };
   if (concepts?.length) body.concepts = concepts;
   if (source) body.source = source;
+  if (project) body.project = project;
 
   const res = await apiFetch("/api/learn", {
     method: "POST",
@@ -41,7 +50,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     return { ok: false, error: `Learn failed: ${text}` };
   }
 
-  const data = await res.json() as any;
+  const data = await res.json() as Record<string, unknown>;
   const id = data.id ?? data.docId ?? "unknown";
-  return { ok: true, output: `Learned: ${id}\n  "${pattern}"` };
+  const file = typeof data.file === "string" ? `\n  file: ${data.file}` : "";
+  return { ok: true, output: `Learned: ${String(id)}${file}\n  "${pattern}"` };
 }

--- a/cli/src/plugins/learn/plugin.json
+++ b/cli/src/plugins/learn/plugin.json
@@ -7,10 +7,11 @@
   "description": "Add a new pattern or learning to ARRA Oracle",
   "cli": {
     "command": "learn",
-    "help": "arra-cli learn \"<pattern>\" [--concepts a,b] [--source s]",
+    "help": "arra-cli learn \"<pattern>\" [--concepts a,b] [--source s] [--project p]",
     "flags": {
       "--concepts": "Comma-separated concept tags",
-      "--source": "Source file or context label"
+      "--source": "Source file or context label",
+      "--project": "Project identity (for example github.com/owner/repo)"
     }
   }
 }

--- a/cli/src/plugins/server/index.ts
+++ b/cli/src/plugins/server/index.ts
@@ -1,5 +1,6 @@
 import type { InvokeContext, InvokeResult } from "../../plugin/types.ts";
 import { apiFetch } from "../../lib/api.ts";
+import { ensureServerRunning, getServerStatus } from "../../../../src/ensure-server.ts";
 
 const PORT = process.env.ORACLE_PORT || process.env.PORT || "47778";
 
@@ -32,14 +33,21 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
   }
 
   if (sub === "start") {
-    const { spawn } = await import("child_process");
-    const child = spawn("bun", ["src/server.ts"], {
-      cwd: process.env.ORACLE_REPO_ROOT || process.cwd(),
-      detached: true, stdio: "ignore",
-    });
-    child.unref();
-    if (json) return { ok: true, output: JSON.stringify({ started: true, pid: child.pid, port: PORT }) };
-    return { ok: true, output: `Oracle server starting (PID ${child.pid}, port ${PORT}).` };
+    // Delegate to ensureServerRunning: it cleans stale PID files, resolves an
+    // absolute server path, refuses to claim success when the port is held by
+    // an unhealthy process, and waits for real health before returning — so a
+    // spawned child that dies on a bad cwd/env/port can never be reported as
+    // started.
+    const before = await getServerStatus();
+    const ready = await ensureServerRunning({ timeout: 15000 });
+    if (!ready) {
+      const reason = `server did not become healthy on port ${PORT} (check the port, ${process.env.ORACLE_DATA_DIR ?? "~/.oracle"}/oracle-http.lock, and server logs)`;
+      if (json) return { ok: false, error: JSON.stringify({ started: false, port: PORT, reason }) };
+      return { ok: false, error: `Oracle server failed to start: ${reason}.` };
+    }
+    const alreadyRunning = before.healthy;
+    if (json) return { ok: true, output: JSON.stringify({ started: true, alreadyRunning, port: PORT }) };
+    return { ok: true, output: alreadyRunning ? `Oracle server already running on :${PORT}.` : `Oracle server started on :${PORT}.` };
   }
 
   return { ok: false, error: `Unknown subcommand: ${sub}. Use: start | stop | status` };

--- a/cli/src/plugins/server/plugin.json
+++ b/cli/src/plugins/server/plugin.json
@@ -5,6 +5,7 @@
   "sdk": "^0.0.1",
   "weight": 3,
   "description": "Manage Oracle HTTP server (start/stop/status)",
+  "timeoutMs": 20000,
   "cli": {
     "command": "server",
     "help": "arra-cli server [start|stop|status] [--json]",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -174,7 +174,7 @@ CREATE TABLE indexing_status (
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `ORACLE_REPO_ROOT` | `process.cwd()` | Knowledge base location (your ψ/ repo) |
+| `ORACLE_REPO_ROOT` | Auto-resolved | Knowledge base location. Uses `ORACLE_DATA_DIR` when it contains `ψ/`, then the source project root when it contains `ψ/`, and otherwise `ORACLE_DATA_DIR`. |
 | `PORT` | `47778` | HTTP server port |
 
 ### MCP Configuration

--- a/docs/plans/2026-08-01-oracle-storage-identity.md
+++ b/docs/plans/2026-08-01-oracle-storage-identity.md
@@ -1,0 +1,206 @@
+# Oracle Storage Identity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow equal display IDs from different projects to coexist and prevent stale/cross-project vectors from affecting RRF ranking.
+
+**Architecture:** Persist a deterministic project-namespaced storage ID while retaining the original display ID. Store full-content digests in SQLite and vector metadata, filter project/universal records inside the production LanceDB query, and reject the entire vector channel before RRF when returned metadata does not match SQLite. Cut over to a new vector collection and preserve the old collection for rollback.
+
+**Tech Stack:** Bun, TypeScript, bun:sqlite, Drizzle ORM, SQLite FTS5, LanceDB, Node `crypto` standard library.
+
+## Global Constraints
+
+- Universal records use the exact sentinel `__universal__` for identity and vector metadata; SQLite `project` remains `NULL` for compatibility.
+- `storage_id = "doc:" + sha256(canonicalProject + "\0" + displayId)`.
+- Canonicalization uses an explicit alias registry. The verified alias `my second brain v2` maps to `github.com/mengazaa/my-second-brain-v2`; similar spellings are distinct and never fuzzy-mapped.
+- No new dependency.
+- Pure vector metadata must match SQLite `project`, `display_id`, and `content_digest` before RRF.
+- Any returned vector metadata mismatch disables the vector channel for that query and falls back to FTS.
+- Use worktree-local tests/runners before merge; `arra search` imports absolute paths from the main checkout and is only a valid live acceptance after merge.
+- Preserve the old `oracle_knowledge_qwen3` collection for rollback; write the new index to `oracle_knowledge_qwen3_v2`.
+
+---
+
+### Task 1: Document Identity and Persistent Migration
+
+**Files:**
+- Create: `src/document-identity.ts`
+- Create: `src/db/document-identity-migration.ts`
+- Modify: `src/db/schema.ts`
+- Modify: `src/db/index.ts`
+- Create: `src/db/migrations/0007_document_identity.sql`
+- Test: `src/document-identity.test.ts`
+
+**Interfaces:**
+- Produces: `UNIVERSAL_PROJECT`, `canonicalProject(project)`, `documentStorageId(project, displayId)`, and `contentDigest(content)`.
+- Produces: idempotent `migrateDocumentIdentity(sqlite)` called after Drizzle migrations and FTS initialization.
+
+- [ ] **Step 1: Add failing identity tests**
+
+Test that the same display ID yields different `doc:` IDs across projects, the same inputs are stable, universal uses `__universal__`, the verified legacy alias and canonical vault project yield the same ID, an unregistered similar spelling remains distinct, and content digest changes with content.
+
+- [ ] **Step 2: Implement identity helpers with `node:crypto`**
+
+Use SHA-256 directly and a small explicit alias map; do not add an identity class, fuzzy matching, or dependency.
+
+- [ ] **Step 3: Add schema columns and migration SQL**
+
+Add nullable `display_id` and `content_digest` columns plus a unique `(project, display_id)` index. Nullable migration columns allow existing rows to be transformed by the runtime migration.
+
+- [ ] **Step 4: Implement idempotent rekey migration**
+
+Inside one SQLite transaction, read every legacy row and its latest FTS content, compute canonical project/storage ID/digest, rewrite `oracle_documents`, collapse its FTS rows to one row under the storage ID, and remap `superseded_by` within the same project. A row with populated `display_id` and a correct storage ID is unchanged.
+
+- [ ] **Step 5: Run targeted identity and migration tests**
+
+Run `bun test src/document-identity.test.ts src/drizzle-migration.test.ts`. Expected: all new tests pass; no existing migration test regresses.
+
+- [ ] **Step 6: Commit**
+
+Commit message: `feat: namespace oracle document identities`.
+
+### Task 2: Namespace Every Write Path
+
+**Files:**
+- Modify: `src/indexer/storage.ts`
+- Modify: `src/tools/learn.ts`
+- Modify: `src/indexer/index.ts`
+- Test: `src/indexer-preservation.test.ts`
+- Test: `src/tools/__tests__/learn.test.ts`
+
+**Interfaces:**
+- Consumes: identity helpers from Task 1.
+- Produces: SQLite/FTS/vector writes keyed by storage ID while preserving `display_id`.
+
+- [ ] **Step 1: Add collision regression**
+
+Store two documents with the same parser ID under two projects. Assert two SQLite rows, two FTS rows, distinct storage IDs, equal display IDs, and intact content.
+
+- [ ] **Step 2: Update `storeDocuments`**
+
+Compute canonical project, storage ID, and content digest once per document. Use storage ID for existing-row detection, SQLite, FTS, vector update detection, deletion, and vector writes. Include `project`, `display_id`, and `content_digest` in vector metadata.
+
+- [ ] **Step 3: Update indexer deletion bookkeeping**
+
+Compare incoming namespaced IDs to stored IDs so smart deletion cannot remove another project with the same display ID.
+
+- [ ] **Step 4: Update `handleLearn`**
+
+Use the same helper and columns; return both internal `id` and `display_id` in the response.
+
+- [ ] **Step 5: Run write-path tests**
+
+Run `bun test src/indexer-preservation.test.ts src/tools/__tests__/learn.test.ts`. Expected: collision and preservation tests pass.
+
+- [ ] **Step 6: Commit**
+
+Commit message: `feat: namespace oracle write paths`.
+
+### Task 3: Versioned Vector Collection and Native LanceDB Filtering
+
+**Files:**
+- Modify: `src/vector/factory.ts`
+- Modify: `src/vector/adapters/lancedb.ts`
+- Modify: `src/scripts/index-qwen3.ts`
+- Modify: `src/vector/__tests__/adapters.test.ts`
+
+**Interfaces:**
+- Consumes: vector metadata `project`, `display_id`, `content_digest`.
+- Produces: `oracle_knowledge_qwen3_v2` and LanceDB native equality filters applied before `.limit()`.
+
+- [ ] **Step 1: Add LanceDB filter regression**
+
+Index equal display IDs for project A, project B, and universal. Query with `{ project: projectA }` and assert project B is never returned before application slicing.
+
+- [ ] **Step 2: Add filterable LanceDB columns**
+
+Store `type`, `project`, and `content_digest` as top-level LanceDB columns as well as metadata. Build escaped equality predicates from `where` and apply `.where(predicate)` before `.limit(limit)`.
+
+- [ ] **Step 3: Switch qwen3 to v2 collection**
+
+Update factory and reindex script to the exact collection name `oracle_knowledge_qwen3_v2`; keep the old table untouched.
+
+- [ ] **Step 4: Include complete metadata during reindex**
+
+Read `display_id` and `content_digest` from SQLite and include them with canonical project/sentinel in every vector row.
+
+- [ ] **Step 5: Run adapter tests**
+
+Run the targeted LanceDB adapter test. Expected: project filtering occurs before limit and collision fixtures coexist.
+
+- [ ] **Step 6: Commit**
+
+Commit message: `feat: add project-bound vector collection`.
+
+### Task 4: Validate Vectors Before Fusion
+
+**Files:**
+- Modify: `src/tools/search.ts`
+- Modify: `src/tools/read.ts`
+- Modify: `src/tools/types.ts`
+- Test: `src/tools/__tests__/search.test.ts`
+
+**Interfaces:**
+- Consumes: namespaced IDs and vector metadata from Tasks 1–3.
+- Produces: search results containing internal `id` plus `display_id`; only DB-validated vectors reach `combineResults`.
+
+- [ ] **Step 1: Add pure-vector and hybrid ranking regressions**
+
+Cover valid same-project vector, cross-project same-display-ID vector, stale digest vector, and an FTS row sharing a stale vector ID. Assert stale/cross vectors never enter RRF and never add a hybrid `vecRank` boost.
+
+- [ ] **Step 2: Apply project filters in `vectorSearch`**
+
+For scoped search, query canonical project and `__universal__` separately with native filters, merge by distance, deduplicate by storage ID, and slice to the requested vector limit.
+
+- [ ] **Step 3: Batch-validate vector metadata**
+
+Lookup all returned storage IDs in SQLite and require exact project, display ID, and digest matches. If any returned candidate mismatches or is absent, set vector results to empty and emit an FTS-fallback warning before normalization and `combineResults`.
+
+- [ ] **Step 4: Return display IDs and preserve internal reads**
+
+Expose `display_id` in search/read output while keeping internal storage ID as `id` for unambiguous reads.
+
+- [ ] **Step 5: Run search regressions through a worktree-local runner**
+
+Run `bun test src/tools/__tests__/search.test.ts` and a worktree-local invocation importing `./src/tools/search.ts`. Do not use `arra search` before merge because its runner imports the main checkout.
+
+- [ ] **Step 6: Commit**
+
+Commit message: `fix: reject stale vectors before oracle fusion`.
+
+### Task 5: Migrate, Reindex, Merge, and Live Acceptance
+
+**Files:**
+- Modify only if tests expose a contract defect in Tasks 1–4.
+
+**Interfaces:**
+- Consumes: completed storage/search implementation.
+- Produces: migrated production SQLite/FTS and populated qwen3 v2 collection.
+
+- [ ] **Step 1: Run targeted worktree suite**
+
+Run identity, migration, preservation, learn, search, and LanceDB filter tests. Existing unrelated TypeScript errors in `server-legacy.ts` and `contradictions.ts` remain outside scope and must be reported, not relabeled.
+
+- [ ] **Step 2: Exercise an isolated database migration twice**
+
+Seed equal display IDs in two projects plus a universal row, run migration twice, and assert idempotency, three distinct storage IDs, preserved FTS content, and remapped supersession.
+
+- [ ] **Step 3: Merge the verified branch into main**
+
+Merge only after targeted tests pass. The main checkout already contains checkpoint commits `423b5e1` and `b30bf5e`.
+
+- [ ] **Step 4: Back up and migrate production data**
+
+Use the existing database backup path before opening the migrated runtime. Record pre/post document counts and project distribution; do not claim recovery for a source file that no longer exists.
+
+- [ ] **Step 5: Reindex the v2 vector collection**
+
+Run the main-checkout qwen3 reindex script, confirm vector count equals the SQLite/FTS source set, and leave `oracle_knowledge_qwen3` untouched.
+
+- [ ] **Step 6: Restart and run live acceptance**
+
+Restart Oracle HTTP/runtime, then use `arra search` from main. Verify same-display-ID project isolation, universal inclusion, stale pure-vector rejection, stale hybrid rejection, and grounded `/api/read` by internal ID.
+
+- [ ] **Step 7: Update `/brain` and AC-5 evidence**
+
+Replace the temporary v7.14 synthesis workaround with the verified engine contract and record observed migration/reindex/live-search evidence only.

--- a/docs/plans/2026-08-01-oracle-storage-identity.md
+++ b/docs/plans/2026-08-01-oracle-storage-identity.md
@@ -35,27 +35,27 @@
 - Produces: `UNIVERSAL_PROJECT`, `canonicalProject(project)`, `documentStorageId(project, displayId)`, and `contentDigest(content)`.
 - Produces: idempotent `migrateDocumentIdentity(sqlite)` called after Drizzle migrations and FTS initialization.
 
-- [ ] **Step 1: Add failing identity tests**
+- [x] **Step 1: Add failing identity tests**
 
 Test that the same display ID yields different `doc:` IDs across projects, the same inputs are stable, universal uses `__universal__`, the verified legacy alias and canonical vault project yield the same ID, an unregistered similar spelling remains distinct, and content digest changes with content.
 
-- [ ] **Step 2: Implement identity helpers with `node:crypto`**
+- [x] **Step 2: Implement identity helpers with `node:crypto`**
 
 Use SHA-256 directly and a small explicit alias map; do not add an identity class, fuzzy matching, or dependency.
 
-- [ ] **Step 3: Add schema columns and migration SQL**
+- [x] **Step 3: Add schema columns and migration SQL**
 
 Add nullable `display_id` and `content_digest` columns plus a unique `(project, display_id)` index. Nullable migration columns allow existing rows to be transformed by the runtime migration.
 
-- [ ] **Step 4: Implement idempotent rekey migration**
+- [x] **Step 4: Implement idempotent rekey migration**
 
 Inside one SQLite transaction, read every legacy row and its latest FTS content, compute canonical project/storage ID/digest, rewrite `oracle_documents`, collapse its FTS rows to one row under the storage ID, and remap `superseded_by` within the same project. A row with populated `display_id` and a correct storage ID is unchanged.
 
-- [ ] **Step 5: Run targeted identity and migration tests**
+- [x] **Step 5: Run targeted identity and migration tests**
 
 Run `bun test src/document-identity.test.ts src/drizzle-migration.test.ts`. Expected: all new tests pass; no existing migration test regresses.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 Commit message: `feat: namespace oracle document identities`.
 
@@ -72,27 +72,27 @@ Commit message: `feat: namespace oracle document identities`.
 - Consumes: identity helpers from Task 1.
 - Produces: SQLite/FTS/vector writes keyed by storage ID while preserving `display_id`.
 
-- [ ] **Step 1: Add collision regression**
+- [x] **Step 1: Add collision regression**
 
 Store two documents with the same parser ID under two projects. Assert two SQLite rows, two FTS rows, distinct storage IDs, equal display IDs, and intact content.
 
-- [ ] **Step 2: Update `storeDocuments`**
+- [x] **Step 2: Update `storeDocuments`**
 
 Compute canonical project, storage ID, and content digest once per document. Use storage ID for existing-row detection, SQLite, FTS, vector update detection, deletion, and vector writes. Include `project`, `display_id`, and `content_digest` in vector metadata.
 
-- [ ] **Step 3: Update indexer deletion bookkeeping**
+- [x] **Step 3: Update indexer deletion bookkeeping**
 
 Compare incoming namespaced IDs to stored IDs so smart deletion cannot remove another project with the same display ID.
 
-- [ ] **Step 4: Update `handleLearn`**
+- [x] **Step 4: Update `handleLearn`**
 
 Use the same helper and columns; return both internal `id` and `display_id` in the response.
 
-- [ ] **Step 5: Run write-path tests**
+- [x] **Step 5: Run write-path tests**
 
 Run `bun test src/indexer-preservation.test.ts src/tools/__tests__/learn.test.ts`. Expected: collision and preservation tests pass.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 Commit message: `feat: namespace oracle write paths`.
 
@@ -108,27 +108,27 @@ Commit message: `feat: namespace oracle write paths`.
 - Consumes: vector metadata `project`, `display_id`, `content_digest`.
 - Produces: `oracle_knowledge_qwen3_v2` and LanceDB native equality filters applied before `.limit()`.
 
-- [ ] **Step 1: Add LanceDB filter regression**
+- [x] **Step 1: Add LanceDB filter regression**
 
 Index equal display IDs for project A, project B, and universal. Query with `{ project: projectA }` and assert project B is never returned before application slicing.
 
-- [ ] **Step 2: Add filterable LanceDB columns**
+- [x] **Step 2: Add filterable LanceDB columns**
 
 Store `type`, `project`, and `content_digest` as top-level LanceDB columns as well as metadata. Build escaped equality predicates from `where` and apply `.where(predicate)` before `.limit(limit)`.
 
-- [ ] **Step 3: Switch qwen3 to v2 collection**
+- [x] **Step 3: Switch qwen3 to v2 collection**
 
 Update factory and reindex script to the exact collection name `oracle_knowledge_qwen3_v2`; keep the old table untouched.
 
-- [ ] **Step 4: Include complete metadata during reindex**
+- [x] **Step 4: Include complete metadata during reindex**
 
 Read `display_id` and `content_digest` from SQLite and include them with canonical project/sentinel in every vector row.
 
-- [ ] **Step 5: Run adapter tests**
+- [x] **Step 5: Run adapter tests**
 
 Run the targeted LanceDB adapter test. Expected: project filtering occurs before limit and collision fixtures coexist.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 Commit message: `feat: add project-bound vector collection`.
 
@@ -144,27 +144,27 @@ Commit message: `feat: add project-bound vector collection`.
 - Consumes: namespaced IDs and vector metadata from Tasks 1–3.
 - Produces: search results containing internal `id` plus `display_id`; only DB-validated vectors reach `combineResults`.
 
-- [ ] **Step 1: Add pure-vector and hybrid ranking regressions**
+- [x] **Step 1: Add pure-vector and hybrid ranking regressions**
 
 Cover valid same-project vector, cross-project same-display-ID vector, stale digest vector, and an FTS row sharing a stale vector ID. Assert stale/cross vectors never enter RRF and never add a hybrid `vecRank` boost.
 
-- [ ] **Step 2: Apply project filters in `vectorSearch`**
+- [x] **Step 2: Apply project filters in `vectorSearch`**
 
 For scoped search, query canonical project and `__universal__` separately with native filters, merge by distance, deduplicate by storage ID, and slice to the requested vector limit.
 
-- [ ] **Step 3: Batch-validate vector metadata**
+- [x] **Step 3: Batch-validate vector metadata**
 
 Lookup all returned storage IDs in SQLite and require exact project, display ID, and digest matches. If any returned candidate mismatches or is absent, set vector results to empty and emit an FTS-fallback warning before normalization and `combineResults`.
 
-- [ ] **Step 4: Return display IDs and preserve internal reads**
+- [x] **Step 4: Return display IDs and preserve internal reads**
 
 Expose `display_id` in search/read output while keeping internal storage ID as `id` for unambiguous reads.
 
-- [ ] **Step 5: Run search regressions through a worktree-local runner**
+- [x] **Step 5: Run search regressions through a worktree-local runner**
 
 Run `bun test src/tools/__tests__/search.test.ts` and a worktree-local invocation importing `./src/tools/search.ts`. Do not use `arra search` before merge because its runner imports the main checkout.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 Commit message: `fix: reject stale vectors before oracle fusion`.
 
@@ -177,30 +177,30 @@ Commit message: `fix: reject stale vectors before oracle fusion`.
 - Consumes: completed storage/search implementation.
 - Produces: migrated production SQLite/FTS and populated qwen3 v2 collection.
 
-- [ ] **Step 1: Run targeted worktree suite**
+- [x] **Step 1: Run targeted worktree suite**
 
 Run identity, migration, preservation, learn, search, and LanceDB filter tests. Existing unrelated TypeScript errors in `server-legacy.ts` and `contradictions.ts` remain outside scope and must be reported, not relabeled.
 
-- [ ] **Step 2: Exercise an isolated database migration twice**
+- [x] **Step 2: Exercise an isolated database migration twice**
 
 Seed equal display IDs in two projects plus a universal row, run migration twice, and assert idempotency, three distinct storage IDs, preserved FTS content, and remapped supersession.
 
-- [ ] **Step 3: Merge the verified branch into main**
+- [x] **Step 3: Merge the verified branch into main**
 
 Merge only after targeted tests pass. The main checkout already contains checkpoint commits `423b5e1` and `b30bf5e`.
 
-- [ ] **Step 4: Back up and migrate production data**
+- [x] **Step 4: Back up and migrate production data**
 
 Use the existing database backup path before opening the migrated runtime. Record pre/post document counts and project distribution; do not claim recovery for a source file that no longer exists.
 
-- [ ] **Step 5: Reindex the v2 vector collection**
+- [x] **Step 5: Reindex the v2 vector collection**
 
 Run the main-checkout qwen3 reindex script, confirm vector count equals the SQLite/FTS source set, and leave `oracle_knowledge_qwen3` untouched.
 
-- [ ] **Step 6: Restart and run live acceptance**
+- [x] **Step 6: Restart and run live acceptance**
 
 Restart Oracle HTTP/runtime, then use `arra search` from main. Verify same-display-ID project isolation, universal inclusion, stale pure-vector rejection, stale hybrid rejection, and grounded `/api/read` by internal ID.
 
-- [ ] **Step 7: Update `/brain` and AC-5 evidence**
+- [x] **Step 7: Update `/brain` and AC-5 evidence**
 
 Replace the temporary v7.14 synthesis workaround with the verified engine contract and record observed migration/reindex/live-search evidence only.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "build": "tsc --noEmit",
     "start": "bun dist/index.js",
     "test": "bun run test:unit && bun run test:integration",
-    "test:unit": "bun test --isolate src/tools/__tests__/ src/server/__tests__/ src/vault/__tests__/ src/indexer/__tests__/ src/drizzle-migration.test.ts src/indexer-preservation.test.ts",
+    "test:unit": "bun test --isolate src/tools/__tests__/ src/server/__tests__/ src/vault/__tests__/ src/indexer/__tests__/ src/drizzle-migration.test.ts src/indexer-preservation.test.ts cli/src/plugin/__tests__/",
     "test:integration": "bun test --isolate src/integration/",
     "test:integration:db": "bun test --isolate src/integration/database.test.ts",
     "test:integration:mcp": "bun test src/integration/mcp.test.ts",

--- a/src/db/document-identity-migration.test.ts
+++ b/src/db/document-identity-migration.test.ts
@@ -32,6 +32,11 @@ function createIdentityDatabase(path = ':memory:'): Database {
       created_by TEXT
     );
     CREATE VIRTUAL TABLE oracle_fts USING fts5(id UNINDEXED, content, concepts);
+    CREATE TABLE settings (
+      key TEXT PRIMARY KEY,
+      value TEXT,
+      updated_at INTEGER NOT NULL
+    );
   `);
   return db;
 }
@@ -82,6 +87,18 @@ describe('document identity migration', () => {
     expect(second.prepare('SELECT count(*) AS count FROM oracle_fts').get()).toEqual({ count: 1 });
     second.close();
     first.close();
+  });
+
+  test('returns from the durable marker without reading FTS again', () => {
+    const db = createIdentityDatabase();
+    insertDocument(db, 'legacy', null);
+    db.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
+      .run('legacy', 'content', 'concept');
+
+    expect(migrateDocumentIdentity(db)).toBe(1);
+    db.exec('DROP TABLE oracle_fts');
+    expect(migrateDocumentIdentity(db)).toBe(0);
+    db.close();
   });
 
   test('rolls back rather than merging duplicate canonical identities', () => {

--- a/src/db/document-identity-migration.test.ts
+++ b/src/db/document-identity-migration.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { contentDigest, documentStorageId } from '../document-identity.ts';
+import { migrateDocumentIdentity } from './document-identity-migration.ts';
+
+const tempDirs: string[] = [];
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function createIdentityDatabase(path = ':memory:'): Database {
+  const db = new Database(path);
+  db.exec(`
+    CREATE TABLE oracle_documents (
+      id TEXT PRIMARY KEY,
+      display_id TEXT,
+      content_digest TEXT,
+      type TEXT NOT NULL,
+      source_file TEXT NOT NULL,
+      concepts TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      indexed_at INTEGER NOT NULL,
+      superseded_by TEXT,
+      superseded_at INTEGER,
+      superseded_reason TEXT,
+      origin TEXT,
+      project TEXT,
+      created_by TEXT
+    );
+    CREATE VIRTUAL TABLE oracle_fts USING fts5(id UNINDEXED, content, concepts);
+  `);
+  return db;
+}
+
+function insertDocument(db: Database, id: string, project: string | null, supersededBy: string | null = null): void {
+  db.prepare(`
+    INSERT INTO oracle_documents (
+      id, type, source_file, concepts, created_at, updated_at, indexed_at, superseded_by, project
+    ) VALUES (?, 'learning', ?, '[]', 1, 1, 1, ?, ?)
+  `).run(id, `${id}.md`, supersededBy, project);
+}
+
+describe('document identity migration', () => {
+  test('rekeys SQLite and FTS rows while preserving display IDs and supersession', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'oracle-document-identity-'));
+    tempDirs.push(dir);
+    const path = join(dir, 'oracle.db');
+    const first = createIdentityDatabase(path);
+    insertDocument(first, 'legacy-a', 'My Second Brain V2', 'legacy-b');
+    insertDocument(first, 'legacy-b', null);
+    first.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
+      .run('legacy-a', 'old content', 'old');
+    first.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
+      .run('legacy-a', 'latest content', 'latest');
+
+    expect(migrateDocumentIdentity(first)).toBe(2);
+
+    const projectA = 'github.com/mengazaa/my-second-brain-v2';
+    const idA = documentStorageId(projectA, 'legacy-a');
+    const idB = documentStorageId(null, 'legacy-b');
+    expect(first.prepare(`
+      SELECT id, display_id, content_digest, project, superseded_by
+      FROM oracle_documents WHERE display_id = 'legacy-a'
+    `).get()).toEqual({
+      id: idA,
+      display_id: 'legacy-a',
+      content_digest: contentDigest('latest content'),
+      project: projectA,
+      superseded_by: idB,
+    });
+    expect(first.prepare('SELECT id, content, concepts FROM oracle_fts').all()).toEqual([
+      { id: idA, content: 'latest content', concepts: 'latest' },
+    ]);
+
+    const second = new Database(path);
+    expect(migrateDocumentIdentity(second)).toBe(0);
+    expect(second.prepare('SELECT count(*) AS count FROM oracle_documents').get()).toEqual({ count: 2 });
+    expect(second.prepare('SELECT count(*) AS count FROM oracle_fts').get()).toEqual({ count: 1 });
+    second.close();
+    first.close();
+  });
+
+  test('rolls back rather than merging duplicate canonical identities', () => {
+    const db = createIdentityDatabase();
+    insertDocument(db, 'old-a', 'My Second Brain V2');
+    insertDocument(db, 'old-b', 'github.com/mengazaa/my-second-brain-v2');
+    db.exec("UPDATE oracle_documents SET display_id = 'shared'");
+
+    expect(() => migrateDocumentIdentity(db)).toThrow('Duplicate canonical document identity detected');
+    expect(db.prepare('SELECT id FROM oracle_documents ORDER BY id').all()).toEqual([
+      { id: 'old-a' },
+      { id: 'old-b' },
+    ]);
+    db.close();
+  });
+});

--- a/src/db/document-identity-migration.test.ts
+++ b/src/db/document-identity-migration.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { contentDigest, documentStorageId } from '../document-identity.ts';
-import { migrateDocumentIdentity } from './document-identity-migration.ts';
+import { migrateDocumentIdentity, migrateProvenanceIdentity } from './document-identity-migration.ts';
 
 const tempDirs: string[] = [];
 afterEach(() => {
@@ -112,6 +112,65 @@ describe('document identity migration', () => {
       { id: 'old-a' },
       { id: 'old-b' },
     ]);
+    db.close();
+  });
+});
+
+describe('provenance identity migration', () => {
+  const createProvenanceDatabase = (): Database => {
+    const db = createIdentityDatabase();
+    db.exec(`
+      CREATE TABLE learn_log (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        document_id TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        project TEXT
+      );
+      CREATE TABLE document_access (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        document_id TEXT NOT NULL,
+        access_type TEXT,
+        created_at INTEGER NOT NULL,
+        project TEXT
+      );
+    `);
+    return db;
+  };
+
+  test('remaps stale references to storage ids and is idempotent', () => {
+    const db = createProvenanceDatabase();
+    insertDocument(db, 'legacy-a', 'github.com/mengazaa/my-second-brain-v2');
+    insertDocument(db, 'legacy-b', null);
+    // Provenance logs captured the pre-migration id (== display_id), project unreliable.
+    db.prepare('INSERT INTO learn_log (document_id, created_at, project) VALUES (?, 1, NULL)').run('legacy-a');
+    db.prepare('INSERT INTO document_access (document_id, access_type, created_at, project) VALUES (?, ?, 1, NULL)')
+      .run('legacy-b', 'search');
+
+    expect(migrateDocumentIdentity(db)).toBe(2);
+    expect(migrateProvenanceIdentity(db)).toBe(2);
+
+    const idA = documentStorageId('github.com/mengazaa/my-second-brain-v2', 'legacy-a');
+    const idB = documentStorageId(null, 'legacy-b');
+    expect(db.prepare('SELECT document_id FROM learn_log').get()).toEqual({ document_id: idA });
+    expect(db.prepare('SELECT document_id FROM document_access').get()).toEqual({ document_id: idB });
+    // No dangling references remain.
+    expect(db.prepare(`
+      SELECT COUNT(*) AS dangling FROM learn_log l
+      LEFT JOIN oracle_documents d ON d.id = l.document_id WHERE d.id IS NULL
+    `).get()).toEqual({ dangling: 0 });
+
+    expect(migrateProvenanceIdentity(db)).toBe(0);
+    db.close();
+  });
+
+  test('leaves references untouched when the display id no longer resolves', () => {
+    const db = createProvenanceDatabase();
+    insertDocument(db, 'legacy-a', null);
+    db.prepare('INSERT INTO learn_log (document_id, created_at, project) VALUES (?, 1, NULL)').run('deleted-doc');
+    migrateDocumentIdentity(db);
+
+    expect(migrateProvenanceIdentity(db)).toBe(0);
+    expect(db.prepare('SELECT document_id FROM learn_log').get()).toEqual({ document_id: 'deleted-doc' });
     db.close();
   });
 });

--- a/src/db/document-identity-migration.test.ts
+++ b/src/db/document-identity-migration.test.ts
@@ -174,3 +174,11 @@ describe('provenance identity migration', () => {
     db.close();
   });
 });
+
+describe('migration journal', () => {
+  test('keeps migration timestamps strictly increasing', async () => {
+    const journal = await Bun.file(join(import.meta.dir, 'migrations/meta/_journal.json')).json();
+    const timestamps = journal.entries.map((entry: { when: number }) => entry.when);
+    expect(timestamps.every((timestamp: number, index: number) => index === 0 || timestamp > timestamps[index - 1])).toBe(true);
+  });
+});

--- a/src/db/document-identity-migration.ts
+++ b/src/db/document-identity-migration.ts
@@ -1,0 +1,136 @@
+import type { Database } from 'bun:sqlite';
+import {
+  UNIVERSAL_PROJECT,
+  canonicalProject,
+  contentDigest,
+  documentStorageId,
+} from '../document-identity.ts';
+
+interface DocumentRow {
+  id: string;
+  display_id: string | null;
+  content_digest: string | null;
+  project: string | null;
+  superseded_by: string | null;
+}
+
+interface FtsRow {
+  content: string;
+  concepts: string;
+}
+
+interface MigrationPlan {
+  oldId: string;
+  currentId: string;
+  storageId: string;
+  displayId: string;
+  project: string | null;
+  digest: string | null;
+  supersededBy: string | null;
+  fts: FtsRow | null;
+}
+
+export function ensureDocumentIdentityColumns(sqlite: Database): void {
+  const columns = sqlite.prepare('PRAGMA table_info(oracle_documents)').all() as Array<{ name: string }>;
+  const names = new Set(columns.map(({ name }) => name));
+  if (!names.has('display_id')) {
+    sqlite.exec('ALTER TABLE oracle_documents ADD COLUMN display_id text');
+  }
+  if (!names.has('content_digest')) {
+    sqlite.exec('ALTER TABLE oracle_documents ADD COLUMN content_digest text');
+  }
+  sqlite.exec('CREATE INDEX IF NOT EXISTS idx_project_display ON oracle_documents (project, display_id)');
+}
+
+export function migrateDocumentIdentity(sqlite: Database): number {
+  ensureDocumentIdentityColumns(sqlite);
+
+  sqlite.exec('BEGIN IMMEDIATE');
+  try {
+    const rows = sqlite.prepare(`
+      SELECT id, display_id, content_digest, project, superseded_by
+      FROM oracle_documents
+      ORDER BY id
+    `).all() as DocumentRow[];
+    const latestFts = sqlite.prepare(`
+      SELECT content, concepts
+      FROM oracle_fts
+      WHERE id = ?
+      ORDER BY rowid DESC
+      LIMIT 1
+    `);
+
+    const plans: MigrationPlan[] = rows.map((row) => {
+      const displayId = row.display_id || row.id;
+      const canonical = canonicalProject(row.project);
+      const fts = latestFts.get(row.id) as FtsRow | null;
+      return {
+        oldId: row.id,
+        currentId: row.id,
+        storageId: documentStorageId(canonical, displayId),
+        displayId,
+        project: canonical === UNIVERSAL_PROJECT ? null : canonical,
+        digest: fts ? contentDigest(fts.content) : null,
+        supersededBy: row.superseded_by,
+        fts,
+      };
+    });
+    const rowById = new Map(rows.map((row) => [row.id, row]));
+    const changed = plans.filter((plan) => {
+      const row = rowById.get(plan.oldId);
+      return plan.oldId !== plan.storageId
+        || row?.display_id !== plan.displayId
+        || row?.content_digest !== plan.digest
+        || row?.project !== plan.project;
+    });
+
+    if (changed.length === 0) {
+      sqlite.exec('COMMIT');
+      return 0;
+    }
+
+    const storageIds = new Set(plans.map(({ storageId }) => storageId));
+    if (storageIds.size !== plans.length) {
+      throw new Error('Duplicate canonical document identity detected');
+    }
+
+    const idMap = new Map(plans.map(({ oldId, storageId }) => [oldId, storageId]));
+    const updateId = sqlite.prepare('UPDATE oracle_documents SET id = ? WHERE id = ?');
+    const updateFtsId = sqlite.prepare('UPDATE oracle_fts SET id = ? WHERE id = ?');
+    const finalize = sqlite.prepare(`
+      UPDATE oracle_documents
+      SET id = ?, display_id = ?, content_digest = ?, project = ?, superseded_by = ?
+      WHERE id = ?
+    `);
+    const deleteFts = sqlite.prepare('DELETE FROM oracle_fts WHERE id = ?');
+    const insertFts = sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)');
+
+    for (const plan of plans) {
+      if (plan.oldId === plan.storageId) continue;
+      const tempId = `__document_identity_migration__${contentDigest(plan.oldId)}`;
+      updateId.run(tempId, plan.oldId);
+      updateFtsId.run(tempId, plan.oldId);
+      plan.currentId = tempId;
+    }
+
+    for (const plan of plans) {
+      const supersededBy = plan.supersededBy ? (idMap.get(plan.supersededBy) || plan.supersededBy) : null;
+      finalize.run(
+        plan.storageId,
+        plan.displayId,
+        plan.digest,
+        plan.project,
+        supersededBy,
+        plan.currentId,
+      );
+      deleteFts.run(plan.currentId);
+      if (plan.fts) insertFts.run(plan.storageId, plan.fts.content, plan.fts.concepts);
+    }
+
+    sqlite.exec('COMMIT');
+    return changed.length;
+  } catch (error) {
+    sqlite.exec('ROLLBACK');
+    throw error;
+  }
+}

--- a/src/db/document-identity-migration.ts
+++ b/src/db/document-identity-migration.ts
@@ -15,6 +15,7 @@ interface DocumentRow {
 }
 
 interface FtsRow {
+  id: string;
   content: string;
   concepts: string;
 }
@@ -52,18 +53,18 @@ export function migrateDocumentIdentity(sqlite: Database): number {
       FROM oracle_documents
       ORDER BY id
     `).all() as DocumentRow[];
-    const latestFts = sqlite.prepare(`
-      SELECT content, concepts
+    const ftsRows = sqlite.prepare(`
+      SELECT id, content, concepts
       FROM oracle_fts
-      WHERE id = ?
-      ORDER BY rowid DESC
-      LIMIT 1
-    `);
+      ORDER BY rowid
+    `).all() as FtsRow[];
+    const latestFts = new Map<string, FtsRow>();
+    for (const row of ftsRows) latestFts.set(row.id, row);
 
     const plans: MigrationPlan[] = rows.map((row) => {
       const displayId = row.display_id || row.id;
       const canonical = canonicalProject(row.project);
-      const fts = latestFts.get(row.id) as FtsRow | null;
+      const fts = latestFts.get(row.id) || null;
       return {
         oldId: row.id,
         currentId: row.id,
@@ -84,7 +85,8 @@ export function migrateDocumentIdentity(sqlite: Database): number {
         || row?.project !== plan.project;
     });
 
-    if (changed.length === 0) {
+    const needsFtsRebuild = ftsRows.length !== plans.filter(({ fts }) => fts).length;
+    if (changed.length === 0 && !needsFtsRebuild) {
       sqlite.exec('COMMIT');
       return 0;
     }
@@ -96,20 +98,18 @@ export function migrateDocumentIdentity(sqlite: Database): number {
 
     const idMap = new Map(plans.map(({ oldId, storageId }) => [oldId, storageId]));
     const updateId = sqlite.prepare('UPDATE oracle_documents SET id = ? WHERE id = ?');
-    const updateFtsId = sqlite.prepare('UPDATE oracle_fts SET id = ? WHERE id = ?');
     const finalize = sqlite.prepare(`
       UPDATE oracle_documents
       SET id = ?, display_id = ?, content_digest = ?, project = ?, superseded_by = ?
       WHERE id = ?
     `);
-    const deleteFts = sqlite.prepare('DELETE FROM oracle_fts WHERE id = ?');
     const insertFts = sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)');
 
+    sqlite.exec('DELETE FROM oracle_fts');
     for (const plan of plans) {
       if (plan.oldId === plan.storageId) continue;
       const tempId = `__document_identity_migration__${contentDigest(plan.oldId)}`;
       updateId.run(tempId, plan.oldId);
-      updateFtsId.run(tempId, plan.oldId);
       plan.currentId = tempId;
     }
 
@@ -123,7 +123,6 @@ export function migrateDocumentIdentity(sqlite: Database): number {
         supersededBy,
         plan.currentId,
       );
-      deleteFts.run(plan.currentId);
       if (plan.fts) insertFts.run(plan.storageId, plan.fts.content, plan.fts.concepts);
     }
 

--- a/src/db/document-identity-migration.ts
+++ b/src/db/document-identity-migration.ts
@@ -7,6 +7,8 @@ import {
 } from '../document-identity.ts';
 
 const MIGRATION_MARKER = 'migration_document_identity_v1';
+const PROVENANCE_MARKER = 'migration_provenance_identity_v1';
+const PROVENANCE_TABLES = ['learn_log', 'document_access'] as const;
 
 interface DocumentRow {
   id: string;
@@ -141,6 +143,56 @@ export function migrateDocumentIdentity(sqlite: Database): number {
     markComplete.run(MIGRATION_MARKER, Date.now());
     sqlite.exec('COMMIT');
     return changed.length;
+  } catch (error) {
+    sqlite.exec('ROLLBACK');
+    throw error;
+  }
+}
+
+/**
+ * Backfill provenance references (`learn_log`, `document_access`) that still point
+ * at pre-migration document ids. New writes already use storage ids; only rows
+ * captured before {@link migrateDocumentIdentity} are stale. A stale id equals the
+ * document's `display_id`, which is globally unique, so it resolves unambiguously
+ * to one storage id. Rows whose display id no longer resolves to exactly one
+ * document are left untouched and reported.
+ */
+export function migrateProvenanceIdentity(sqlite: Database): number {
+  const hasDocuments = sqlite.prepare(
+    "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'oracle_documents'",
+  ).get();
+  if (!hasDocuments) return 0;
+  const completed = sqlite.prepare('SELECT value FROM settings WHERE key = ?')
+    .get(PROVENANCE_MARKER) as { value: string | null } | null;
+  if (completed?.value === '1') return 0;
+
+  sqlite.exec('BEGIN IMMEDIATE');
+  try {
+    let remapped = 0;
+    for (const table of PROVENANCE_TABLES) {
+      const exists = sqlite.prepare(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+      ).get(table);
+      if (!exists) continue;
+      const result = sqlite.prepare(`
+        UPDATE ${table}
+        SET document_id = (
+          SELECT d.id FROM oracle_documents d WHERE d.display_id = ${table}.document_id
+        )
+        WHERE document_id NOT LIKE 'doc:%'
+          AND (
+            SELECT COUNT(*) FROM oracle_documents d WHERE d.display_id = ${table}.document_id
+          ) = 1
+      `).run();
+      remapped += result.changes;
+    }
+    sqlite.prepare(`
+      INSERT INTO settings (key, value, updated_at)
+      VALUES (?, '1', ?)
+      ON CONFLICT(key) DO UPDATE SET value = '1', updated_at = excluded.updated_at
+    `).run(PROVENANCE_MARKER, Date.now());
+    sqlite.exec('COMMIT');
+    return remapped;
   } catch (error) {
     sqlite.exec('ROLLBACK');
     throw error;

--- a/src/db/document-identity-migration.ts
+++ b/src/db/document-identity-migration.ts
@@ -6,6 +6,8 @@ import {
   documentStorageId,
 } from '../document-identity.ts';
 
+const MIGRATION_MARKER = 'migration_document_identity_v1';
+
 interface DocumentRow {
   id: string;
   display_id: string | null;
@@ -45,6 +47,15 @@ export function ensureDocumentIdentityColumns(sqlite: Database): void {
 
 export function migrateDocumentIdentity(sqlite: Database): number {
   ensureDocumentIdentityColumns(sqlite);
+  const completed = sqlite.prepare('SELECT value FROM settings WHERE key = ?')
+    .get(MIGRATION_MARKER) as { value: string | null } | null;
+  if (completed?.value === '1') return 0;
+
+  const markComplete = sqlite.prepare(`
+    INSERT INTO settings (key, value, updated_at)
+    VALUES (?, '1', ?)
+    ON CONFLICT(key) DO UPDATE SET value = '1', updated_at = excluded.updated_at
+  `);
 
   sqlite.exec('BEGIN IMMEDIATE');
   try {
@@ -87,6 +98,7 @@ export function migrateDocumentIdentity(sqlite: Database): number {
 
     const needsFtsRebuild = ftsRows.length !== plans.filter(({ fts }) => fts).length;
     if (changed.length === 0 && !needsFtsRebuild) {
+      markComplete.run(MIGRATION_MARKER, Date.now());
       sqlite.exec('COMMIT');
       return 0;
     }
@@ -126,6 +138,7 @@ export function migrateDocumentIdentity(sqlite: Database): number {
       if (plan.fts) insertFts.run(plan.storageId, plan.fts.content, plan.fts.concepts);
     }
 
+    markComplete.run(MIGRATION_MARKER, Date.now());
     sqlite.exec('COMMIT');
     return changed.length;
   } catch (error) {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -15,6 +15,7 @@ import path from 'path';
 import fs from 'fs';
 import * as schema from './schema.ts';
 import { DB_PATH, ORACLE_DATA_DIR } from '../config.ts';
+import { ensureDocumentIdentityColumns, migrateDocumentIdentity } from './document-identity-migration.ts';
 
 // Migrations folder (relative to this file)
 const MIGRATIONS_FOLDER = path.join(import.meta.dirname || __dirname, 'migrations');
@@ -77,9 +78,11 @@ function initializeDatabase(sqliteDb: Database, drizzleDb: BunSQLiteDatabase<typ
 
   // Run Drizzle migrations (creates/updates all schema tables)
   migrate(drizzleDb, { migrationsFolder: MIGRATIONS_FOLDER });
+  ensureDocumentIdentityColumns(sqliteDb);
 
   // FTS5 (raw SQL, idempotent)
   initFts5(sqliteDb);
+  migrateDocumentIdentity(sqliteDb);
 
   // Supersede log table (migration 0003 - idempotent for existing DBs)
   initSupersedeLog(sqliteDb);

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -15,7 +15,7 @@ import path from 'path';
 import fs from 'fs';
 import * as schema from './schema.ts';
 import { DB_PATH, ORACLE_DATA_DIR } from '../config.ts';
-import { ensureDocumentIdentityColumns, migrateDocumentIdentity } from './document-identity-migration.ts';
+import { ensureDocumentIdentityColumns, migrateDocumentIdentity, migrateProvenanceIdentity } from './document-identity-migration.ts';
 
 // Migrations folder (relative to this file)
 const MIGRATIONS_FOLDER = path.join(import.meta.dirname || __dirname, 'migrations');
@@ -83,6 +83,7 @@ function initializeDatabase(sqliteDb: Database, drizzleDb: BunSQLiteDatabase<typ
   // FTS5 (raw SQL, idempotent)
   initFts5(sqliteDb);
   migrateDocumentIdentity(sqliteDb);
+  migrateProvenanceIdentity(sqliteDb);
 
   // Supersede log table (migration 0003 - idempotent for existing DBs)
   initSupersedeLog(sqliteDb);

--- a/src/db/migrations/meta/0007_snapshot.json
+++ b/src/db/migrations/meta/0007_snapshot.json
@@ -762,6 +762,7 @@
           "notNull": true,
           "autoincrement": false
         },
+
         "type": {
           "name": "type",
           "type": "text",
@@ -882,6 +883,7 @@
             "project"
           ],
           "isUnique": false
+
         }
       },
       "foreignKeys": {},

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -124,7 +124,7 @@
     {
       "idx": 17,
       "version": "6",
-      "when": 1746547200000,
+      "when": 1780272000000,
       "tag": "0017_fts5_bootstrap",
       "breakpoints": true
     }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -11,6 +11,8 @@ import { sqliteTable, text, integer, index, type AnySQLiteColumn } from 'drizzle
 // Main document index table
 export const oracleDocuments = sqliteTable('oracle_documents', {
   id: text('id').primaryKey(),
+  displayId: text('display_id'),
+  contentDigest: text('content_digest'),
   type: text('type').notNull(),
   sourceFile: text('source_file').notNull(),
   concepts: text('concepts').notNull(), // JSON array
@@ -31,7 +33,9 @@ export const oracleDocuments = sqliteTable('oracle_documents', {
   index('idx_superseded').on(table.supersededBy),
   index('idx_origin').on(table.origin),
   index('idx_project').on(table.project),
+  index('idx_project_display').on(table.project, table.displayId),
 ]);
+
 
 // Indexing status tracking
 export const indexingStatus = sqliteTable('indexing_status', {

--- a/src/document-identity.test.ts
+++ b/src/document-identity.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  UNIVERSAL_PROJECT,
+  canonicalProject,
+  contentDigest,
+  documentStorageId,
+} from './document-identity.ts';
+
+describe('document identity', () => {
+  test('namespaces equal display IDs by verified project identity', () => {
+    const displayId = 'learning_shared_0';
+    const projectA = documentStorageId('github.com/acme/a', displayId);
+    const projectB = documentStorageId('github.com/acme/b', displayId);
+
+    expect(projectA).toStartWith('doc:');
+    expect(projectA).not.toBe(projectB);
+    expect(projectA).toBe(documentStorageId(' GITHUB.COM/ACME/A ', displayId));
+  });
+
+  test('uses the universal sentinel for missing projects', () => {
+    expect(canonicalProject(null)).toBe(UNIVERSAL_PROJECT);
+    expect(documentStorageId(null, 'principle_1')).toBe(
+      documentStorageId(UNIVERSAL_PROJECT, 'principle_1'),
+    );
+  });
+
+  test('maps only the verified current-vault alias', () => {
+    const canonical = 'github.com/mengazaa/my-second-brain-v2';
+    expect(canonicalProject('My Second Brain V2')).toBe(canonical);
+    expect(documentStorageId('my second brain v2', 'lesson_1')).toBe(
+      documentStorageId(canonical, 'lesson_1'),
+    );
+    expect(canonicalProject('my-second-brain-v2')).toBe('my-second-brain-v2');
+    expect(canonicalProject('mengazaa/my-second-brain-v2')).toBe('mengazaa/my-second-brain-v2');
+  });
+
+  test('hashes full content deterministically', () => {
+    expect(contentDigest('same')).toBe(contentDigest('same'));
+    expect(contentDigest('same')).not.toBe(contentDigest('different'));
+  });
+
+  test('rejects an empty display ID', () => {
+    expect(() => documentStorageId('github.com/acme/a', '')).toThrow('displayId is required');
+  });
+});

--- a/src/document-identity.ts
+++ b/src/document-identity.ts
@@ -1,0 +1,31 @@
+import { createHash } from 'node:crypto';
+
+export const UNIVERSAL_PROJECT = '__universal__';
+
+const PROJECT_ALIASES: Record<string, string> = {
+  'my second brain v2': 'github.com/mengazaa/my-second-brain-v2',
+};
+
+export function canonicalProject(project?: string | null): string {
+  const value = project?.trim().toLowerCase();
+  if (!value) return UNIVERSAL_PROJECT;
+
+  const alias = PROJECT_ALIASES[value];
+  if (alias) return alias;
+
+  return value;
+}
+
+export function storedProject(project?: string | null): string | null {
+  const canonical = canonicalProject(project);
+  return canonical === UNIVERSAL_PROJECT ? null : canonical;
+}
+
+export function documentStorageId(project: string | null | undefined, displayId: string): string {
+  if (!displayId) throw new Error('displayId is required');
+  return `doc:${contentDigest(`${canonicalProject(project)}\0${displayId}`)}`;
+}
+
+export function contentDigest(content: string): string {
+  return createHash('sha256').update(content, 'utf8').digest('hex');
+}

--- a/src/indexer-preservation.test.ts
+++ b/src/indexer-preservation.test.ts
@@ -14,6 +14,10 @@ import { drizzle, BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 import { eq, and, or, isNull, inArray } from 'drizzle-orm';
 import * as schema from './db/schema.ts';
 import { oracleDocuments } from './db/schema.ts';
+import { storeDocuments } from './indexer/storage.ts';
+import { parseRetroFile } from './indexer/parser.ts';
+import type { VectorDocument, VectorStoreAdapter } from './vector/types.ts';
+import { documentStorageId } from './document-identity.ts';
 import fs from 'fs';
 
 // ============================================================================
@@ -38,6 +42,8 @@ beforeAll(() => {
     -- Main document index
     CREATE TABLE oracle_documents (
       id TEXT PRIMARY KEY,
+      display_id TEXT,
+      content_digest TEXT,
       type TEXT NOT NULL,
       source_file TEXT NOT NULL,
       concepts TEXT NOT NULL DEFAULT '[]',
@@ -456,5 +462,105 @@ describe('Indexer Preservation - edge cases', () => {
     const remainingIds = remaining.map(d => d.id);
     expect(remainingIds).toContain('oracle-learn-doc');
     expect(remainingIds).toContain('manual-doc');
+  });
+});
+
+class RecordingVectorStore implements VectorStoreAdapter {
+  readonly name = 'recording';
+  readonly batches: string[][] = [];
+
+  async connect() {}
+  async close() {}
+  async ensureCollection() {}
+  async deleteCollection() {}
+  async addDocuments(documents: VectorDocument[]) {
+    this.batches.push(documents.map(document => document.id));
+  }
+  async query() {
+    return { ids: [], documents: [], distances: [], metadatas: [] };
+  }
+  async queryById() {
+    return { ids: [], documents: [], distances: [], metadatas: [] };
+  }
+  async getStats() {
+    return { count: 0 };
+  }
+  async getCollectionInfo() {
+    return { count: 0, name: this.name };
+  }
+}
+
+describe('Document storage - FTS replacement', () => {
+  it('keeps one current FTS row when a document is re-indexed', async () => {
+    const now = Date.now();
+    const base = {
+      id: 'fts-replacement-doc',
+      type: 'learning' as const,
+      source_file: 'learnings/fts-replacement.md',
+      content: 'old content',
+      concepts: ['fts'],
+      created_at: now,
+      updated_at: now,
+    };
+    const storageId = documentStorageId(null, base.id);
+
+    await storeDocuments(sqlite, db, null, null, [base]);
+    await storeDocuments(sqlite, db, null, null, [{ ...base, content: 'new content' }]);
+
+    const rows = sqlite.prepare(
+      'SELECT content FROM oracle_fts WHERE id = ?'
+    ).all(storageId) as Array<{ content: string }>;
+    expect(rows).toEqual([{ content: 'new content' }]);
+  });
+
+  it('re-indexes changed or missing vectors but skips complete unchanged rows', async () => {
+    const now = Date.now();
+    const vectorStore = new RecordingVectorStore();
+    const document = {
+      id: 'incremental-vector-doc',
+      type: 'learning' as const,
+      source_file: 'ψ/memory/learnings/incremental.md',
+      content: 'stable content',
+      concepts: ['indexing'],
+      created_at: now,
+      updated_at: now,
+    };
+    const storageId = documentStorageId(null, document.id);
+
+    await storeDocuments(sqlite, db, vectorStore, null, [document]);
+    await storeDocuments(sqlite, db, vectorStore, null, [document], false, new Set([storageId]));
+    await storeDocuments(sqlite, db, vectorStore, null, [document], false, new Set());
+    await storeDocuments(sqlite, db, vectorStore, null, [{
+      ...document,
+      content: 'changed content',
+    }], false, new Set([storageId]));
+
+    expect(vectorStore.batches).toEqual([
+      [storageId],
+      [storageId],
+      [storageId],
+    ]);
+  });
+});
+
+describe('Retrospective parser - stable document identity', () => {
+  it('distinguishes the same basename in different directories', () => {
+    const content = '# Session Retrospective\n\n## Summary\n\nA sufficiently long retrospective section that must produce one indexed document.';
+    const marchEight = parseRetroFile(
+      'ψ/memory/retrospectives/2026-03/08/17.09_same-name.md',
+      content
+    );
+    const marchNine = parseRetroFile(
+      'ψ/memory/retrospectives/2026-03/09/17.09_same-name.md',
+      content
+    );
+
+    expect(marchEight).toHaveLength(1);
+    expect(marchNine).toHaveLength(1);
+    expect(marchEight[0].id).not.toBe(marchNine[0].id);
+    expect(parseRetroFile(
+      'ψ/memory/retrospectives/2026-03/08/17.09_same-name.md',
+      content
+    )[0].id).toBe(marchEight[0].id);
   });
 });

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -20,6 +20,7 @@ import { oracleDocuments } from '../db/schema.ts';
 import { createDatabase } from '../db/index.ts';
 import { detectProject } from '../server/project-detect.ts';
 import type { OracleDocument, IndexerConfig } from '../types.ts';
+import { documentStorageId, storedProject } from '../document-identity.ts';
 
 import { setIndexingStatus } from './status.ts';
 import { backupDatabase } from './backup.ts';
@@ -43,7 +44,7 @@ export class OracleIndexer {
     const { sqlite, db } = createDatabase(config.dbPath);
     this.sqlite = sqlite;
     this.db = db;
-    this.project = detectProject(config.repoRoot);
+    this.project = storedProject(detectProject(config.repoRoot));
     console.log(`[Indexer] Detected project: ${this.project || '(universal)'}`);
   }
 
@@ -84,8 +85,7 @@ export class OracleIndexer {
       ...collectSecurityCorpus(shared),
     ];
 
-    // Safety: if we found zero source documents but the DB has existing
-    // indexer-created content, abort rather than smart-deleting everything.
+    // Safety: never wipe an existing index when source discovery is empty.
     if (!append && documents.length === 0 && existingIndexerDocCount > 0) {
       throw new Error(
         `Refusing to index: found 0 source documents but DB has ${existingIndexerDocCount} indexer docs. ` +
@@ -96,15 +96,35 @@ export class OracleIndexer {
     if (append) {
       console.log('Append mode: skipping smart delete (preserving existing docs from other repo roots)');
     } else {
-      // Smart deletion: remove indexer-created docs whose source file no longer exists
-      const allIndexerDocs = this.db.select({ id: oracleDocuments.id, sourceFile: oracleDocuments.sourceFile })
+      const incomingBySource = new Map<string, Set<string>>();
+      const indexedProjects = new Set<string | null>([this.project]);
+      for (const document of documents) {
+        const documentProject = storedProject(document.project === undefined ? this.project : document.project);
+        indexedProjects.add(documentProject);
+        const ids = incomingBySource.get(document.source_file) || new Set<string>();
+        ids.add(documentStorageId(documentProject, document.id));
+        incomingBySource.set(document.source_file, ids);
+      }
+
+      const allIndexerDocs = this.db.select({
+        id: oracleDocuments.id,
+        sourceFile: oracleDocuments.sourceFile,
+        project: oracleDocuments.project,
+      })
         .from(oracleDocuments)
         .where(or(eq(oracleDocuments.createdBy, 'indexer'), isNull(oracleDocuments.createdBy)))
         .all();
-
       const idsToDelete = allIndexerDocs
-        .filter(d => !fs.existsSync(path.join(this.config.repoRoot, d.sourceFile)))
-        .map(d => d.id);
+        .filter(document => {
+          if (!indexedProjects.has(document.project)) return false;
+          const sourcePath = path.isAbsolute(document.sourceFile)
+            ? document.sourceFile
+            : path.join(this.config.repoRoot, document.sourceFile);
+          const incomingIds = incomingBySource.get(document.sourceFile);
+          return !fs.existsSync(sourcePath) || (incomingIds !== undefined && !incomingIds.has(document.id));
+        })
+        .map(document => document.id);
+
 
       // Safety: if smart-delete would drop more than half of existing indexer
       // docs, we're almost certainly running from the wrong repoRoot — the docs

--- a/src/indexer/parser.ts
+++ b/src/indexer/parser.ts
@@ -2,6 +2,7 @@
  * Markdown file parsers for resonance, learning, and retrospective files
  */
 
+import { createHash } from 'node:crypto';
 import path from 'path';
 import type { OracleDocument } from '../types.ts';
 import { extractConcepts, mergeConceptsWithTags } from './concepts.ts';
@@ -173,8 +174,11 @@ export function parseRetroFile(relativePath: string, content: string): OracleDoc
     const body = lines.slice(1).join('\n').trim();
     if (!body || body.length < 50) return;
 
-    const filename = path.basename(relativePath, '.md');
-    const id = `retro_${filename}_${index}`;
+    const pathKey = createHash('sha256')
+      .update(relativePath.replaceAll('\\', '/'))
+      .digest('hex')
+      .slice(0, 16);
+    const id = `retro_${pathKey}_${index}`;
     const extracted = extractConcepts(sectionTitle, body);
 
     documents.push({

--- a/src/indexer/runner.ts
+++ b/src/indexer/runner.ts
@@ -10,6 +10,7 @@ import fs from 'fs';
 import path from 'path';
 import { DB_PATH, CHROMADB_DIR } from '../config.ts';
 import { getVaultPsiRoot } from '../vault/handler.ts';
+import { sqlite } from '../db/index.ts';
 import type { IndexerConfig } from '../types.ts';
 import { OracleIndexer } from './index.ts';
 
@@ -28,7 +29,7 @@ export function resolveIndexerRepoRoot(explicitRoot?: string | null): string {
   if (explicitRoot?.trim()) return normalizeIndexerRepoRoot(explicitRoot);
   if (process.env.ORACLE_REPO_ROOT?.trim()) return normalizeIndexerRepoRoot(process.env.ORACLE_REPO_ROOT);
 
-  const vaultResult = getVaultPsiRoot();
+  const vaultResult = getVaultPsiRoot(sqlite);
   const vaultRoot = 'path' in vaultResult ? vaultResult.path : null;
   const vaultHasContent = vaultRoot && (
     fs.existsSync(path.join(vaultRoot, 'ψ')) ||

--- a/src/indexer/storage.ts
+++ b/src/indexer/storage.ts
@@ -8,6 +8,7 @@ import * as schema from '../db/schema.ts';
 import { oracleDocuments } from '../db/schema.ts';
 import type { VectorStoreAdapter } from '../vector/types.ts';
 import type { OracleDocument } from '../types.ts';
+import { UNIVERSAL_PROJECT, contentDigest, documentStorageId, storedProject } from '../document-identity.ts';
 
 /**
  * Store documents in SQLite + vector store
@@ -19,8 +20,11 @@ export async function storeDocuments(
   vectorClient: VectorStoreAdapter | null,
   project: string | null,
   documents: OracleDocument[],
-  opts: { createdBy?: string } = {}
+  opts: { createdBy?: string } | boolean = {},
+  existingVectorIds?: ReadonlySet<string>
 ): Promise<void> {
+  const forceVectorIndex = typeof opts === 'boolean' ? opts : false;
+  const createdBy = typeof opts === 'boolean' ? 'indexer' : opts.createdBy || 'indexer';
   const now = Date.now();
 
   // Prepare FTS statements. FTS5 virtual tables have no UNIQUE constraint on
@@ -33,6 +37,14 @@ export async function storeDocuments(
     INSERT INTO oracle_fts (id, content, concepts)
     VALUES (?, ?, ?)
   `);
+  const selectExisting = sqlite.prepare(`
+    SELECT d.type, d.source_file, d.concepts, d.project, f.content
+    FROM oracle_documents d
+    LEFT JOIN oracle_fts f ON f.id = d.id
+    WHERE d.id = ?
+    ORDER BY f.rowid DESC
+    LIMIT 1
+  `);
 
   // Prepare for vector store
   const ids: string[] = [];
@@ -43,13 +55,33 @@ export async function storeDocuments(
   sqlite.exec('BEGIN');
   try {
     for (const doc of documents) {
-      // SQLite metadata - use doc.project if available, fall back to repo project
-      const docProject = (doc.project || project)?.toLowerCase();
+      const docProject = storedProject(doc.project === undefined ? project : doc.project);
+      const displayId = doc.id;
+      const storageId = documentStorageId(docProject, displayId);
+      const digest = contentDigest(doc.content);
+      const serializedConcepts = JSON.stringify(doc.concepts);
+      const existing = selectExisting.get(storageId) as {
+        type: string;
+        source_file: string;
+        concepts: string;
+        project: string | null;
+        content: string | null;
+      } | null;
+      const needsVectorUpdate = forceVectorIndex
+        || !existing
+        || (existingVectorIds !== undefined && !existingVectorIds.has(storageId))
+        || existing.type !== doc.type
+        || existing.source_file !== doc.source_file
+        || existing.concepts !== serializedConcepts
+        || existing.project !== (docProject ?? null)
+        || existing.content !== doc.content;
 
       // Drizzle upsert with createdBy: 'indexer'
       db.insert(oracleDocuments)
         .values({
-          id: doc.id,
+          id: storageId,
+          displayId,
+          contentDigest: digest,
           type: doc.type,
           sourceFile: doc.source_file,
           concepts: JSON.stringify(doc.concepts),
@@ -57,7 +89,7 @@ export async function storeDocuments(
           updatedAt: doc.updated_at,
           indexedAt: now,
           project: docProject,
-          createdBy: opts.createdBy || 'indexer',
+          createdBy,
         })
         .onConflictDoUpdate({
           target: oracleDocuments.id,
@@ -68,27 +100,27 @@ export async function storeDocuments(
             updatedAt: doc.updated_at,
             indexedAt: now,
             project: docProject,
+            displayId,
+            contentDigest: digest,
           }
         })
         .run();
 
-      // SQLite FTS (raw SQL required for FTS5): delete then insert to avoid
-      // duplicates across re-index runs.
-      deleteFts.run(doc.id);
-      insertFts.run(
-        doc.id,
-        doc.content,
-        doc.concepts.join(' ')
-      );
+      deleteFts.run(storageId);
+      insertFts.run(storageId, doc.content, doc.concepts.join(' '));
 
-      // Vector store metadata (must be primitives, not arrays)
-      ids.push(doc.id);
-      contents.push(doc.content);
-      metadatas.push({
-        type: doc.type,
-        source_file: doc.source_file,
-        concepts: doc.concepts.join(',')
-      });
+      if (needsVectorUpdate) {
+        ids.push(storageId);
+        contents.push(doc.content);
+        metadatas.push({
+          type: doc.type,
+          source_file: doc.source_file,
+          concepts: doc.concepts.join(','),
+          display_id: displayId,
+          content_digest: digest,
+          project: docProject || UNIVERSAL_PROJECT,
+        });
+      }
     }
     sqlite.exec('COMMIT');
   } catch (e) {

--- a/src/integration/database.test.ts
+++ b/src/integration/database.test.ts
@@ -13,6 +13,7 @@ import { homedir } from "os";
 
 // Import schema
 import * as schema from "../db/schema";
+import { migrateDocumentIdentity, migrateProvenanceIdentity } from "../db/document-identity-migration";
 
 // Test database (separate from production)
 const TEST_DB_PATH = join(homedir(), ".oracle", "test-integration.db");
@@ -76,6 +77,12 @@ describe("Database Integration (Drizzle ORM)", () => {
         tokenize='porter unicode61'
       );
     `);
+
+    // Apply runtime identity migrations (display_id/content_digest columns +
+    // provenance remap) the same way production initializeDatabase does — these
+    // live outside the numbered SQL files.
+    migrateDocumentIdentity(sqlite);
+    migrateProvenanceIdentity(sqlite);
   });
 
   afterAll(() => {

--- a/src/routes/files/file.ts
+++ b/src/routes/files/file.ts
@@ -11,6 +11,7 @@ import fs from 'fs';
 import path from 'path';
 import { REPO_ROOT } from '../../config.ts';
 import { getVaultPsiRoot } from '../../vault/handler.ts';
+import { sqlite } from '../../db/index.ts';
 import { fileQuery } from './model.ts';
 
 export const fileRoute = new Elysia().get(
@@ -90,7 +91,7 @@ export const fileRoute = new Elysia().get(
         }
       }
 
-      const vault = getVaultPsiRoot();
+      const vault = getVaultPsiRoot(sqlite);
       if ('path' in vault) {
         const vaultFullPath = path.join(vault.path, filePath);
         const realVaultPath = path.resolve(vaultFullPath);

--- a/src/scripts/index-qwen3.ts
+++ b/src/scripts/index-qwen3.ts
@@ -5,22 +5,23 @@
  *
  * Usage: bun src/scripts/index-qwen3.ts
  *
- * Creates: ~/.chromadb/oracle_knowledge_qwen3.lance/
+ * Creates the `oracle_knowledge_qwen3_v2` LanceDB table.
  * (same LanceDB dir as default, different table name)
  */
 
-import { createVectorStore } from '../vector/factory.ts';
+import { createVectorStore, getEmbeddingModels } from '../vector/factory.ts';
 import { Database } from 'bun:sqlite';
 import { DB_PATH } from '../config.ts';
+import { UNIVERSAL_PROJECT } from '../document-identity.ts';
 
 const BATCH_SIZE = 50; // Smaller batches — qwen3 is slower per embedding
-const COLLECTION = 'oracle_knowledge_qwen3';
+const PRESET = getEmbeddingModels().qwen3;
 
 async function main() {
   console.log('=== Qwen3-Embedding Indexer ===');
   console.log(`DB: ${DB_PATH}`);
-  console.log(`Collection: ${COLLECTION}`);
-  console.log(`Model: qwen3-embedding (4096 dims)`);
+  console.log(`Collection: ${PRESET.collection}`);
+  console.log(`Model: ${PRESET.model}`);
 
   // Open oracle.db to read documents
   const db = new Database(DB_PATH, { readonly: true });
@@ -30,9 +31,9 @@ async function main() {
   // Create LanceDB store with qwen3
   const store = createVectorStore({
     type: 'lancedb',
-    collectionName: COLLECTION,
+    collectionName: PRESET.collection,
     embeddingProvider: 'ollama',
-    embeddingModel: 'qwen3-embedding',
+    embeddingModel: PRESET.model,
   });
 
   await store.connect();
@@ -43,13 +44,15 @@ async function main() {
 
   // Read all docs (join oracle_documents + oracle_fts for content, GROUP BY to dedupe FTS chunks)
   const rows = db.query(`
-    SELECT d.id, d.type, GROUP_CONCAT(f.content, '\n') as content, d.source_file, d.concepts, d.project, d.created_at
+    SELECT d.id, d.display_id, d.content_digest, d.type, GROUP_CONCAT(f.content, '\n') as content, d.source_file, d.concepts, d.project, d.created_at
     FROM oracle_documents d
     JOIN oracle_fts f ON d.id = f.id
     GROUP BY d.id
     ORDER BY d.created_at DESC
   `).all() as Array<{
     id: string;
+    display_id: string;
+    content_digest: string;
     type: string;
     content: string;
     source_file: string;
@@ -71,10 +74,12 @@ async function main() {
       id: row.id,
       document: row.content,
       metadata: {
+        display_id: row.display_id,
+        content_digest: row.content_digest,
         type: row.type,
         source_file: row.source_file,
         concepts: row.concepts,
-        ...(row.project && { project: row.project }),
+        project: row.project || UNIVERSAL_PROJECT,
       },
     }));
 

--- a/src/scripts/reindex-vector-identity.ts
+++ b/src/scripts/reindex-vector-identity.ts
@@ -12,6 +12,9 @@ const TARGET_COLLECTION = getEmbeddingModels().qwen3.collection;
 const PAGE_SIZE = 250;
 const EMBED_BATCH_SIZE = 50;
 const MIN_COMPATIBILITY_COSINE = 0.999;
+const MAX_NORMALIZED_L2 = 0.05;
+const MAX_NORMALIZED_COMPONENT_DIFF = 0.01;
+const MAX_NORM_DEVIATION = 0.01;
 const embeddingModel = getEmbeddingModels().qwen3.model;
 const embedder = new OllamaEmbeddings({ model: embeddingModel });
 
@@ -33,6 +36,14 @@ interface VectorRow {
   vector: Iterable<number>;
 }
 
+interface VectorComparison {
+  cosine: number;
+  normalized_l2: number;
+  max_diff: number;
+  left_norm: number;
+  right_norm: number;
+}
+
 const projectKey = (project: string | null | undefined) => canonicalProject(project);
 const documentKey = (project: string | null | undefined, displayId: string) => `${projectKey(project)}\0${displayId}`;
 const vectorMetadata = (document: DocumentRow) => ({
@@ -43,7 +54,44 @@ const vectorMetadata = (document: DocumentRow) => ({
   display_id: document.display_id,
   content_digest: document.content_digest,
 });
-const lanceRow = (document: DocumentRow, vector: number[] | Float32Array) => ({
+const normalizeVector = (vector: Iterable<number>) => {
+  const values = Array.from(vector);
+  const norm = Math.sqrt(values.reduce((sum, value) => sum + value * value, 0));
+  if (!Number.isFinite(norm) || norm === 0) throw new Error('Cannot normalize an invalid embedding');
+  return values.map(value => value / norm);
+};
+const compareVectors = (left: number[], right: number[]) => {
+  if (left.length !== right.length) {
+    return { cosine: 0, normalized_l2: Infinity, max_diff: Infinity, left_norm: 0, right_norm: 0 };
+  }
+  const leftNorm = Math.sqrt(left.reduce((sum, value) => sum + value * value, 0));
+  const rightNorm = Math.sqrt(right.reduce((sum, value) => sum + value * value, 0));
+  const leftNormalized = normalizeVector(left);
+  const rightNormalized = normalizeVector(right);
+  let dot = 0;
+  let squaredDifference = 0;
+  let maxDifference = 0;
+  for (let index = 0; index < left.length; index++) {
+    dot += leftNormalized[index] * rightNormalized[index];
+    const difference = leftNormalized[index] - rightNormalized[index];
+    squaredDifference += difference * difference;
+    maxDifference = Math.max(maxDifference, Math.abs(difference));
+  }
+  return {
+    cosine: dot,
+    normalized_l2: Math.sqrt(squaredDifference),
+    max_diff: maxDifference,
+    left_norm: leftNorm,
+    right_norm: rightNorm,
+  };
+};
+const compatible = (comparison: VectorComparison) =>
+  comparison.cosine >= MIN_COMPATIBILITY_COSINE
+  && comparison.normalized_l2 <= MAX_NORMALIZED_L2
+  && comparison.max_diff <= MAX_NORMALIZED_COMPONENT_DIFF
+  && Math.abs(comparison.left_norm - 1) <= MAX_NORM_DEVIATION
+  && Math.abs(comparison.right_norm - 1) <= MAX_NORM_DEVIATION;
+const lanceRow = (document: DocumentRow, vector: Iterable<number>) => ({
   id: document.id,
   text: document.content,
   type: document.type,
@@ -51,21 +99,8 @@ const lanceRow = (document: DocumentRow, vector: number[] | Float32Array) => ({
   display_id: document.display_id,
   content_digest: document.content_digest,
   metadata: JSON.stringify(vectorMetadata(document)),
-  vector,
+  vector: normalizeVector(vector),
 });
-
-const cosine = (left: number[], right: number[]) => {
-  if (left.length !== right.length) return 0;
-  let dot = 0;
-  let leftNorm = 0;
-  let rightNorm = 0;
-  for (let index = 0; index < left.length; index++) {
-    dot += left[index] * right[index];
-    leftNorm += left[index] * left[index];
-    rightNorm += right[index] * right[index];
-  }
-  return dot / Math.sqrt(leftNorm * rightNorm);
-};
 const isNumberArray = (value: unknown): value is number[] =>
   Array.isArray(value) && value.every(item => typeof item === 'number');
 
@@ -110,14 +145,14 @@ const compatibilityTexts = [
 ];
 const currentVectors = await embedder.embed(compatibilityTexts);
 const legacyVectors = await Promise.all(compatibilityTexts.map(legacyEmbed));
-const endpointCosines = legacyVectors.map((vector, index) => cosine(vector, currentVectors[index]));
+const endpointComparisons = legacyVectors.map((vector, index) => compareVectors(vector, currentVectors[index]));
 const storedVector = Array.from(storedSample.vector);
-const storedCosines = [
-  cosine(storedVector, legacyVectors[3]),
-  cosine(storedVector, currentVectors[3]),
+const storedComparisons = [
+  compareVectors(storedVector, legacyVectors[3]),
+  compareVectors(storedVector, currentVectors[3]),
 ];
-const compatibility = { endpoint_cosines: endpointCosines, stored_cosines: storedCosines };
-if ([...endpointCosines, ...storedCosines].some(value => value < MIN_COMPATIBILITY_COSINE)) {
+const compatibility = { endpoint_comparisons: endpointComparisons, stored_comparisons: storedComparisons };
+if ([...endpointComparisons, ...storedComparisons].some(comparison => !compatible(comparison))) {
   throw new Error(`Embedding pipelines are incompatible: ${JSON.stringify(compatibility)}`);
 }
 console.error(`Embedding compatibility verified: ${JSON.stringify(compatibility)}`);

--- a/src/scripts/reindex-vector-identity.ts
+++ b/src/scripts/reindex-vector-identity.ts
@@ -1,0 +1,189 @@
+#!/usr/bin/env bun
+import * as lancedb from '@lancedb/lancedb';
+import type { Table } from '@lancedb/lancedb';
+import { sqlite } from '../db/index.ts';
+import { LANCEDB_DIR } from '../config.ts';
+import { canonicalProject, contentDigest } from '../document-identity.ts';
+import { OllamaEmbeddings } from '../vector/embeddings.ts';
+import { getEmbeddingModels } from '../vector/factory.ts';
+
+const SOURCE_COLLECTION = 'oracle_knowledge_qwen3';
+const TARGET_COLLECTION = getEmbeddingModels().qwen3.collection;
+const PAGE_SIZE = 250;
+const EMBED_BATCH_SIZE = 50;
+const MIN_COMPATIBILITY_COSINE = 0.999;
+const embeddingModel = getEmbeddingModels().qwen3.model;
+const embedder = new OllamaEmbeddings({ model: embeddingModel });
+
+interface DocumentRow {
+  id: string;
+  display_id: string;
+  content_digest: string;
+  type: string;
+  source_file: string;
+  concepts: string;
+  project: string | null;
+  content: string;
+}
+
+interface VectorRow {
+  id: string;
+  text: string;
+  metadata: string;
+  vector: Iterable<number>;
+}
+
+const projectKey = (project: string | null | undefined) => canonicalProject(project);
+const documentKey = (project: string | null | undefined, displayId: string) => `${projectKey(project)}\0${displayId}`;
+const vectorMetadata = (document: DocumentRow) => ({
+  type: document.type,
+  source_file: document.source_file,
+  concepts: document.concepts,
+  project: projectKey(document.project),
+  display_id: document.display_id,
+  content_digest: document.content_digest,
+});
+const lanceRow = (document: DocumentRow, vector: number[] | Float32Array) => ({
+  id: document.id,
+  text: document.content,
+  type: document.type,
+  project: projectKey(document.project),
+  display_id: document.display_id,
+  content_digest: document.content_digest,
+  metadata: JSON.stringify(vectorMetadata(document)),
+  vector,
+});
+
+const cosine = (left: number[], right: number[]) => {
+  if (left.length !== right.length) return 0;
+  let dot = 0;
+  let leftNorm = 0;
+  let rightNorm = 0;
+  for (let index = 0; index < left.length; index++) {
+    dot += left[index] * right[index];
+    leftNorm += left[index] * left[index];
+    rightNorm += right[index] * right[index];
+  }
+  return dot / Math.sqrt(leftNorm * rightNorm);
+};
+const isNumberArray = (value: unknown): value is number[] =>
+  Array.isArray(value) && value.every(item => typeof item === 'number');
+
+
+const legacyEmbed = async (text: string) => {
+  const response = await fetch('http://127.0.0.1:11434/api/embeddings', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model: embeddingModel, prompt: text.length > 2000 ? text.slice(0, 2000) : text }),
+  });
+  if (!response.ok) throw new Error(`Legacy Ollama API error: ${await response.text()}`);
+  const payload: unknown = await response.json();
+  if (!payload || typeof payload !== 'object' || !('embedding' in payload) || !isNumberArray(payload.embedding)) {
+    throw new Error('Legacy Ollama API returned an invalid embedding');
+  }
+  return payload.embedding;
+};
+
+const documents = sqlite.prepare(`
+  SELECT d.id, d.display_id, d.content_digest, d.type, d.source_file,
+         d.concepts, d.project, f.content
+  FROM oracle_documents d
+  JOIN oracle_fts f ON f.id = d.id
+  ORDER BY d.id
+`).all() as DocumentRow[];
+const byIdentity = new Map(documents.map(document => [documentKey(document.project, document.display_id), document]));
+const byDisplay = new Map<string, DocumentRow | null>();
+for (const document of documents) {
+  byDisplay.set(document.display_id, byDisplay.has(document.display_id) ? null : document);
+}
+
+const db = await lancedb.connect(LANCEDB_DIR);
+const tableNames = await db.tableNames();
+if (!tableNames.includes(SOURCE_COLLECTION)) throw new Error(`Missing source collection: ${SOURCE_COLLECTION}`);
+const source = await db.openTable(SOURCE_COLLECTION);
+const [storedSample] = await source.query().limit(1).toArray() as unknown as VectorRow[];
+const compatibilityTexts = [
+  'Pump discharge pressure review before commissioning.',
+  'ตรวจสอบความดันด้านจ่ายของปั๊มก่อนเริ่มเดินเครื่อง',
+  '调试前检查泵出口压力。',
+  storedSample.text,
+];
+const currentVectors = await embedder.embed(compatibilityTexts);
+const legacyVectors = await Promise.all(compatibilityTexts.map(legacyEmbed));
+const endpointCosines = legacyVectors.map((vector, index) => cosine(vector, currentVectors[index]));
+const storedVector = Array.from(storedSample.vector);
+const storedCosines = [
+  cosine(storedVector, legacyVectors[3]),
+  cosine(storedVector, currentVectors[3]),
+];
+const compatibility = { endpoint_cosines: endpointCosines, stored_cosines: storedCosines };
+if ([...endpointCosines, ...storedCosines].some(value => value < MIN_COMPATIBILITY_COSINE)) {
+  throw new Error(`Embedding pipelines are incompatible: ${JSON.stringify(compatibility)}`);
+}
+console.error(`Embedding compatibility verified: ${JSON.stringify(compatibility)}`);
+if (process.argv.includes('--compat-only')) {
+  console.log(JSON.stringify(compatibility));
+  sqlite.close();
+  process.exit(0);
+}
+
+if (tableNames.includes(TARGET_COLLECTION)) await db.dropTable(TARGET_COLLECTION);
+
+let target: Table | null = null;
+let reused = 0;
+let stale = 0;
+let unmapped = 0;
+const indexedIds = new Set<string>();
+const sourceCount = await source.countRows();
+
+for (let offset = 0; offset < sourceCount; offset += PAGE_SIZE) {
+  const rows = await source.query().offset(offset).limit(PAGE_SIZE).toArray() as unknown as VectorRow[];
+  const output = [];
+  for (const row of rows) {
+    const metadata = JSON.parse(row.metadata || '{}') as { project?: string };
+    const document = byIdentity.get(documentKey(metadata.project, row.id)) || byDisplay.get(row.id);
+    if (!document) {
+      unmapped++;
+      continue;
+    }
+    if (indexedIds.has(document.id)) continue;
+    if (contentDigest(row.text) !== document.content_digest) {
+      stale++;
+      continue;
+    }
+    indexedIds.add(document.id);
+    output.push(lanceRow(document, Array.from(row.vector)));
+  }
+  if (output.length > 0) {
+    if (target) await target.add(output);
+    else target = await db.createTable(TARGET_COLLECTION, output);
+    reused += output.length;
+  }
+  console.error(`Reused ${reused}/${sourceCount} legacy vectors`);
+}
+
+const missing = documents.filter(document => !indexedIds.has(document.id));
+for (let offset = 0; offset < missing.length; offset += EMBED_BATCH_SIZE) {
+  const batch = missing.slice(offset, offset + EMBED_BATCH_SIZE);
+  const vectors = await embedder.embed(batch.map(document => document.content));
+  const output = batch.map((document, index) => lanceRow(document, vectors[index]));
+  if (target) await target.add(output);
+  else target = await db.createTable(TARGET_COLLECTION, output);
+  console.error(`Embedded ${Math.min(offset + batch.length, missing.length)}/${missing.length} missing vectors`);
+}
+
+if (!target) throw new Error('No vectors written');
+const finalCount = await target.countRows();
+console.log(JSON.stringify({
+  source_collection: SOURCE_COLLECTION,
+  target_collection: TARGET_COLLECTION,
+  source_count: sourceCount,
+  reused,
+  reembedded: missing.length,
+  stale,
+  unmapped,
+  final_count: finalCount,
+  expected_count: documents.length,
+  complete: finalCount === documents.length,
+}));
+sqlite.close();

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -20,6 +20,7 @@ import { createVectorProxy } from './vector-proxy.ts';
 import { buildLearningMarkdown, dateSlug } from '../learn/markdown.ts';
 import { localNativeVectorDisabledReason, localVectorIndexMissingReason, logLocalVectorDisabled } from '../vector/cpu-capabilities.ts';
 import { isVectorSectionEnabled } from '../vector/config.ts';
+import { contentDigest, documentStorageId, storedProject } from '../document-identity.ts';
 
 // Module-level proxy instance — bound to VECTOR_URL at boot. If VECTOR_URL is
 // unset, this is null and the local vector adapter runs in-process (legacy
@@ -93,10 +94,9 @@ export async function handleSearch(
   mode: 'hybrid' | 'fts' | 'vector' = 'hybrid',
   project?: string,  // If set: project + universal. If null/undefined: universal only
   cwd?: string,      // Auto-detect project from cwd if project not specified
-  model?: string     // Embedding model: 'bge-m3' (default, multilingual) or 'nomic' (fast)
+  model?: string     // Embedding model selected by the vector registry
 ): Promise<SearchResponse & { mode?: string; warning?: string; model?: string; vectorAvailable?: boolean }> {
-  // Auto-detect project from cwd if not explicitly specified
-  const resolvedProject = (project ?? detectProject(cwd))?.toLowerCase() ?? null;
+  const resolvedProject = storedProject(project ?? detectProject(cwd));
   const startTime = Date.now();
   const ftsQuery = buildFtsQuery(query);
   if (!ftsQuery) {
@@ -153,7 +153,7 @@ export async function handleSearch(
       ftsTotal = (runFtsGet(countStmt, [ftsQuery, ...projectParams]) as { total: number } | null)?.total ?? 0;
 
       const stmt = sqlite.prepare(`
-        SELECT f.id, f.content, d.type, d.source_file, d.concepts, d.project, rank as score
+        SELECT f.id, d.display_id, f.content, d.type, d.source_file, d.concepts, d.project, rank as score
         FROM oracle_fts f
         JOIN oracle_documents d ON f.id = d.id
         WHERE oracle_fts MATCH ? AND ${projectFilter}
@@ -161,6 +161,7 @@ export async function handleSearch(
         LIMIT ?
       `);
       ftsResults = runFtsAll<any>(stmt, [ftsQuery, ...projectParams, limit * 3]).map((row: any) => ({
+        display_id: row.display_id,
         id: row.id,
         type: row.type,
         content: row.content,
@@ -180,7 +181,7 @@ export async function handleSearch(
       ftsTotal = (runFtsGet(countStmt, [ftsQuery, type, ...projectParams]) as { total: number } | null)?.total ?? 0;
 
       const stmt = sqlite.prepare(`
-        SELECT f.id, f.content, d.type, d.source_file, d.concepts, d.project, rank as score
+        SELECT f.id, d.display_id, f.content, d.type, d.source_file, d.concepts, d.project, rank as score
         FROM oracle_fts f
         JOIN oracle_documents d ON f.id = d.id
         WHERE oracle_fts MATCH ? AND d.type = ? AND ${projectFilter}
@@ -188,6 +189,7 @@ export async function handleSearch(
         LIMIT ?
       `);
       ftsResults = runFtsAll<any>(stmt, [ftsQuery, type, ...projectParams, limit * 3]).map((row: any) => ({
+        display_id: row.display_id,
         id: row.id,
         type: row.type,
         content: row.content,
@@ -243,6 +245,7 @@ export async function handleSearch(
       if (vectorResults.length > 0) {
         console.log(`[Vector] ${vectorResults.length} results, top scores: ${vectorResults.slice(0, 3).map(r => r.score?.toFixed(3))}`);
       }
+
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       console.error('[Vector Search Error]', msg);
@@ -689,6 +692,7 @@ export function handleGraph(limitPerType = 310) {
 }
 
 
+
 /**
  * Add new pattern/learning to knowledge base
  * @param origin - 'mother' | 'arthur' | 'volt' | 'human' (null = universal)
@@ -710,7 +714,7 @@ export function persistLearningDoc(opts: {
   project?: string | null;
   createdBy?: string;      // oracle_documents.created_by
   footer?: string;         // footer line under the content, e.g. '*Added via Oracle Learn*'
-}): { file: string; id: string } {
+}): { file: string; id: string; display_id: string } {
   const { pattern, subdir, filename, id } = opts;
   const now = new Date();
 
@@ -738,9 +742,13 @@ export function persistLearningDoc(opts: {
   fs.writeFileSync(filePath, frontmatter, 'utf-8');
 
   const sourceFile = `${subdir}/${filename}`;
+  const project = storedProject(opts.project);
+  const storageId = documentStorageId(project, id);
 
   db.insert(oracleDocuments).values({
-    id,
+    id: storageId,
+    displayId: id,
+    contentDigest: contentDigest(frontmatter),
     type: 'learning',
     sourceFile,
     concepts: JSON.stringify(conceptsList),
@@ -748,20 +756,20 @@ export function persistLearningDoc(opts: {
     updatedAt: now.getTime(),
     indexedAt: now.getTime(),
     origin: opts.origin || null,
-    project: opts.project || null,
+    project,
     createdBy: opts.createdBy || 'oracle_learn',
   }).run();
 
   // FTS5 has no unique constraint on id — delete-then-insert to be idempotent.
-  sqlite.prepare(`DELETE FROM oracle_fts WHERE id = ?`).run(id);
+  sqlite.prepare(`DELETE FROM oracle_fts WHERE id = ?`).run(storageId);
   sqlite.prepare(`
     INSERT INTO oracle_fts (id, content, concepts)
     VALUES (?, ?, ?)
-  `).run(id, frontmatter, conceptsList.join(' '));
+  `).run(storageId, frontmatter, conceptsList.join(' '));
 
-  logLearning(id, pattern, opts.source || 'Oracle Learn', conceptsList);
+  logLearning(storageId, pattern, opts.source || 'Oracle Learn', conceptsList);
 
-  return { file: sourceFile, id };
+  return { file: sourceFile, id: storageId, display_id: id };
 }
 
 export function handleLearn(
@@ -772,7 +780,7 @@ export function handleLearn(
   project?: string,
   cwd?: string
 ) {
-  const resolvedProject = (project ?? detectProject(cwd))?.toLowerCase() ?? null;
+  const resolvedProject = storedProject(project ?? detectProject(cwd));
   const d = new Date();
   const dateStr = dateSlug(d);
 

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -4,10 +4,12 @@
 
 export interface SearchResult {
   id: string;
+  display_id?: string;
   type: string;
   content: string;
   source_file: string;
   concepts: string[];
+  project?: string | null;
   source?: 'fts' | 'vector' | 'hybrid';
   score?: number;
   distance?: number;

--- a/src/server/vector-operations.ts
+++ b/src/server/vector-operations.ts
@@ -1,5 +1,4 @@
-import { inArray } from 'drizzle-orm';
-import { db, oracleDocuments } from '../db/index.ts';
+import { db, sqlite, oracleDocuments } from '../db/index.ts';
 import {
   createVectorStore,
   ensureVectorStoreConnected,
@@ -7,6 +6,8 @@ import {
   getVectorStoreConfigByModel,
 } from '../vector/factory.ts';
 import { localNativeVectorDisabledReason, localVectorIndexMissingReason } from '../vector/cpu-capabilities.ts';
+import { UNIVERSAL_PROJECT } from '../document-identity.ts';
+import { validateVectorResults, type VectorSearchResult } from '../tools/search.ts';
 import type { EmbeddingProviderType, VectorDBType, VectorDocument, VectorStoreAdapter } from '../vector/types.ts';
 import type { SearchResult } from './types.ts';
 
@@ -75,37 +76,39 @@ async function searchOneModel(input: VectorSearchInput, model: string | undefine
   const client = await ensureVectorStoreConnected(model);
   const limit = input.limit ?? 10;
   const isMulti = input.model === 'multi';
-  const whereFilter = input.type && input.type !== 'all' ? { type: input.type } : undefined;
-  const vectorRows = await client.query(input.query, isMulti ? limit : limit * 2, whereFilter);
+  const resolvedProject = input.project?.toLowerCase() ?? null;
+  const where: Record<string, string | string[]> = {};
+  if (input.type && input.type !== 'all') where.type = input.type;
+  if (resolvedProject) where.project = [resolvedProject, UNIVERSAL_PROJECT];
+  const vectorRows = await client.query(
+    input.query,
+    isMulti ? limit : limit * 2,
+    Object.keys(where).length > 0 ? where : undefined,
+  );
 
   if (!vectorRows.ids || vectorRows.ids.length === 0) return [];
 
-  const rows = db.select({ id: oracleDocuments.id, project: oracleDocuments.project })
-    .from(oracleDocuments)
-    .where(inArray(oracleDocuments.id, vectorRows.ids))
-    .all();
-  const projectMap = new Map<string, string | null>();
-  rows.forEach(r => projectMap.set(r.id, r.project));
-
-  const resolvedProject = input.project?.toLowerCase() ?? null;
-  return vectorRows.ids
-    .map((id: string, i: number) => {
-      const distance = vectorRows.distances?.[i] || 0;
-      const docProject = projectMap.get(id);
-      return {
-        id,
-        type: vectorRows.metadatas?.[i]?.type || 'unknown',
-        content: vectorRows.documents?.[i] || '',
-        source_file: vectorRows.metadatas?.[i]?.source_file || '',
-        concepts: [],
-        project: docProject,
-        source: 'vector' as const,
-        score: cosineDistanceToSimilarity(distance),
-        distance,
-        model: modelName,
-      };
-    })
-    .filter(r => !resolvedProject || r.project === resolvedProject || r.project === null);
+  const candidates: VectorSearchResult[] = vectorRows.ids.map((id: string, index: number) => {
+    const metadata = vectorRows.metadatas?.[index] as Record<string, unknown> | undefined;
+    const distance = vectorRows.distances?.[index] || 0;
+    return {
+      id,
+      display_id: String(metadata?.display_id || ''),
+      project: String(metadata?.project || ''),
+      content_digest: String(metadata?.content_digest || ''),
+      type: String(metadata?.type || 'unknown'),
+      content: vectorRows.documents?.[index] || '',
+      source_file: String(metadata?.source_file || ''),
+      concepts: [],
+      score: cosineDistanceToSimilarity(distance),
+      distance,
+      model: modelName,
+      source: 'vector',
+    };
+  });
+  const validation = validateVectorResults(sqlite, candidates, resolvedProject);
+  if (validation.error) throw new Error(validation.error);
+  return validation.results;
 }
 
 function dedupeMultiModel(results: SearchResult[]): SearchResult[] {

--- a/src/tools/__tests__/graph.test.ts
+++ b/src/tools/__tests__/graph.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { handleGraphSearch } from '../graph-search.ts';
+import { handleGraphPath } from '../graph-path.ts';
+import { handleGraphInfo } from '../graph-info.ts';
+import type { ToolContext } from '../types.ts';
+
+// Only `sqlite` is exercised by the graph handlers; the rest of ToolContext is unused.
+const contextFor = (sqlite: Database) => ({ sqlite }) as unknown as ToolContext;
+
+const parse = (text: string) => JSON.parse(text);
+
+describe('graph handlers without a graph_edges table', () => {
+  test('graph-search returns "not populated" instead of throwing', async () => {
+    const sqlite = new Database(':memory:');
+    const resp = await handleGraphSearch(contextFor(sqlite), { concept: 'X' });
+    expect(parse(resp.content[0].text).error).toContain('Graph not populated');
+    sqlite.close();
+  });
+
+  test('graph-path returns "not populated" instead of throwing', async () => {
+    const sqlite = new Database(':memory:');
+    const resp = await handleGraphPath(contextFor(sqlite), { from_concept: 'A', to_concept: 'B' });
+    expect(parse(resp.content[0].text).error).toContain('Graph not populated');
+    sqlite.close();
+  });
+
+  test('graph-info returns "not populated" instead of throwing', async () => {
+    const sqlite = new Database(':memory:');
+    const resp = await handleGraphInfo(contextFor(sqlite), { concept: 'X' });
+    expect(parse(resp.content[0].text).error).toContain('Graph not populated');
+    sqlite.close();
+  });
+});
+
+describe('graph handlers with a populated graph_edges table', () => {
+  const seed = () => {
+    const sqlite = new Database(':memory:');
+    sqlite.exec(`
+      CREATE TABLE graph_edges (
+        source_path TEXT NOT NULL,
+        target_name TEXT NOT NULL,
+        relationship_type TEXT NOT NULL
+      );
+      INSERT INTO graph_edges (source_path, target_name, relationship_type) VALUES
+        ('note-1.md', 'Claude Code', 'body_wikilink'),
+        ('note-1.md', 'Obsidian', 'body_wikilink'),
+        ('note-2.md', 'Obsidian', 'body_wikilink'),
+        ('note-2.md', 'MCP', 'keyword');
+    `);
+    return sqlite;
+  };
+
+  test('graph-search finds neighbors via shared notes', async () => {
+    const sqlite = seed();
+    const resp = await handleGraphSearch(contextFor(sqlite), { concept: 'Claude Code', max_hops: 1 });
+    const result = parse(resp.content[0].text);
+    expect(result.nodes.map((node: { name: string }) => node.name)).toContain('Obsidian');
+    sqlite.close();
+  });
+
+  test('graph-path finds a direct path through a shared note', async () => {
+    const sqlite = seed();
+    const resp = await handleGraphPath(contextFor(sqlite), { from_concept: 'Claude Code', to_concept: 'MCP' });
+    const result = parse(resp.content[0].text);
+    expect(result.found).toBe(true);
+    expect(result.path[0]).toBe('Claude Code');
+    expect(result.path.at(-1)).toBe('MCP');
+    sqlite.close();
+  });
+
+  test('graph-info reports edges and neighbors for a concept', async () => {
+    const sqlite = seed();
+    const resp = await handleGraphInfo(contextFor(sqlite), { concept: 'Obsidian' });
+    const result = parse(resp.content[0].text);
+    expect(result.found).toBe(true);
+    expect(result.total_edges).toBe(2);
+    expect(result.top_neighbors.map((neighbor: { name: string }) => neighbor.name)).toContain('Claude Code');
+    sqlite.close();
+  });
+});

--- a/src/tools/__tests__/search.test.ts
+++ b/src/tools/__tests__/search.test.ts
@@ -3,13 +3,17 @@
  * These were previously duplicated in oracle-core.test.ts.
  */
 
-import { describe, it, expect } from 'bun:test';
+import { afterAll, beforeAll, describe, it, expect } from 'bun:test';
+import { Database } from 'bun:sqlite';
 import {
   sanitizeFtsQuery,
   normalizeFtsScore,
   parseConceptsFromMetadata,
   combineResults,
+  validateVectorResults,
 } from '../search.ts';
+import type { VectorSearchResult } from '../search.ts';
+import { contentDigest, documentStorageId } from '../../document-identity.ts';
 
 // ============================================================================
 // sanitizeFtsQuery
@@ -103,6 +107,84 @@ describe('parseConceptsFromMetadata', () => {
 
   it('should return empty for invalid JSON', () => {
     expect(parseConceptsFromMetadata('not json')).toEqual([]);
+  });
+});
+
+describe('validateVectorResults', () => {
+  let db: Database;
+  const digest = contentDigest('current content');
+  const idA = documentStorageId('project-a', 'shared');
+  const idB = documentStorageId('project-b', 'shared');
+  const candidateA: VectorSearchResult = {
+    id: idA,
+    display_id: 'shared',
+    project: 'project-a',
+    content_digest: digest,
+    type: 'learning',
+    content: 'current content',
+    source_file: 'a.md',
+    concepts: [],
+    score: 0.1,
+    distance: 0.1,
+    model: 'qwen3',
+    source: 'vector',
+  };
+
+  beforeAll(() => {
+    db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE oracle_documents (
+        id TEXT PRIMARY KEY,
+        display_id TEXT,
+        content_digest TEXT,
+        project TEXT,
+        type TEXT,
+        source_file TEXT,
+        concepts TEXT
+      )
+    `);
+    const insert = db.prepare(`
+      INSERT INTO oracle_documents
+      (id, display_id, content_digest, project, type, source_file, concepts)
+      VALUES (?, 'shared', ?, ?, 'learning', ?, '[]')
+    `);
+    insert.run(idA, digest, 'project-a', 'a.md');
+    insert.run(idB, digest, 'project-b', 'b.md');
+  });
+
+  afterAll(() => db.close());
+
+  it('admits exact metadata and content matches', () => {
+    expect(validateVectorResults(db, [candidateA], 'project-a')).toEqual({
+      results: [candidateA],
+    });
+  });
+
+  it('rejects the whole channel for cross-project or stale vectors', () => {
+    const crossProject = {
+      ...candidateA,
+      id: idB,
+      project: 'project-b',
+      source_file: 'b.md',
+    };
+    expect(validateVectorResults(db, [candidateA, crossProject], 'project-a').results).toEqual([]);
+    expect(validateVectorResults(db, [{ ...candidateA, content_digest: 'stale' }], 'project-a').results).toEqual([]);
+  });
+
+  it('prevents a stale matching ID from gaining hybrid rank', () => {
+    const validation = validateVectorResults(db, [{ ...candidateA, content: 'stale content' }], 'project-a');
+    const combined = combineResults([{
+      id: idA,
+      display_id: 'shared',
+      type: 'learning',
+      content: 'current content',
+      source_file: 'a.md',
+      concepts: [],
+      score: 1,
+      source: 'fts',
+    }], validation.results);
+    expect(combined[0]?.source).toBe('fts');
+    expect(combined[0]?.vectorScore).toBeUndefined();
   });
 });
 

--- a/src/tools/graph-info.ts
+++ b/src/tools/graph-info.ts
@@ -1,0 +1,138 @@
+/**
+ * Graph Info — concept details + fuzzy search.
+ *
+ * Ported from Oracle v2 Python (oracle-mcp/sources/graph.py).
+ */
+
+import type { ToolContext, ToolResponse, GraphInfoInput } from './types.ts';
+
+export const graphInfoToolDef = {
+  name: 'arra_graph_info',
+  description:
+    'Get detailed info about a concept in the knowledge graph: which files reference it, relationship types, and top neighbors. If the exact concept is not found, falls back to fuzzy search.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      concept: {
+        type: 'string',
+        description: 'Concept name to look up (e.g., "Claude Code", "MCP")',
+      },
+    },
+    required: ['concept'],
+  },
+};
+
+export async function handleGraphInfo(
+  ctx: ToolContext,
+  input: GraphInfoInput,
+): Promise<ToolResponse> {
+  const concept = input.concept;
+
+  const edgeCount = ctx.sqlite.prepare('SELECT COUNT(*) as c FROM graph_edges').get() as { c: number } | undefined;
+  if (!edgeCount || edgeCount.c === 0) {
+    return {
+      content: [{ type: 'text', text: JSON.stringify({ error: 'Graph not populated.' }) }],
+    };
+  }
+
+  // Try exact match first
+  const rows = ctx.sqlite
+    .prepare(
+      `SELECT source_path, relationship_type
+       FROM graph_edges
+       WHERE target_name = ?
+       ORDER BY source_path`,
+    )
+    .all(concept) as Array<{ source_path: string; relationship_type: string }>;
+
+  if (rows.length > 0) {
+    const files: Array<{ path: string; type: string }> = [];
+    const relCounts: Record<string, number> = {};
+
+    for (const row of rows) {
+      files.push({ path: row.source_path, type: row.relationship_type });
+      relCounts[row.relationship_type] = (relCounts[row.relationship_type] ?? 0) + 1;
+    }
+
+    const neighbors = ctx.sqlite
+      .prepare(
+        `SELECT g2.target_name, COUNT(DISTINCT g1.source_path) as shared_files
+         FROM graph_edges g1
+         JOIN graph_edges g2 ON g1.source_path = g2.source_path
+         WHERE g1.target_name = ? AND g2.target_name != ?
+         GROUP BY g2.target_name
+         ORDER BY shared_files DESC
+         LIMIT 20`,
+      )
+      .all(concept, concept) as Array<{ target_name: string; shared_files: number }>;
+
+    const topNeighbors = neighbors.map((n) => ({
+      name: n.target_name,
+      shared_files: n.shared_files,
+    }));
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              concept,
+              found: true,
+              total_edges: files.length,
+              relationship_types: relCounts,
+              files: files.slice(0, 20),
+              top_neighbors: topNeighbors,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
+  }
+
+  // Fallback: fuzzy search
+  const searchRows = ctx.sqlite
+    .prepare(
+      `SELECT target_name, COUNT(*) as edge_count
+       FROM graph_edges
+       WHERE target_name LIKE ?
+       GROUP BY target_name
+       ORDER BY edge_count DESC
+       LIMIT 20`,
+    )
+    .all(`%${concept}%`) as Array<{ target_name: string; edge_count: number }>;
+
+  if (searchRows.length > 0) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              concept,
+              found: false,
+              message: `Exact match not found. Did you mean one of these?`,
+              suggestions: searchRows.map((r) => ({
+                name: r.target_name,
+                edge_count: r.edge_count,
+              })),
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
+  }
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify({ concept, found: false, total_edges: 0 }),
+      },
+    ],
+  };
+}

--- a/src/tools/graph-info.ts
+++ b/src/tools/graph-info.ts
@@ -28,7 +28,8 @@ export async function handleGraphInfo(
 ): Promise<ToolResponse> {
   const concept = input.concept;
 
-  const edgeCount = ctx.sqlite.prepare('SELECT COUNT(*) as c FROM graph_edges').get() as { c: number } | undefined;
+  const graphTable = ctx.sqlite.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'graph_edges'").get();
+  const edgeCount = graphTable ? ctx.sqlite.prepare('SELECT COUNT(*) as c FROM graph_edges').get() as { c: number } | undefined : undefined;
   if (!edgeCount || edgeCount.c === 0) {
     return {
       content: [{ type: 'text', text: JSON.stringify({ error: 'Graph not populated.' }) }],

--- a/src/tools/graph-path.ts
+++ b/src/tools/graph-path.ts
@@ -1,0 +1,150 @@
+/**
+ * Graph Path — BFS shortest path between two concepts.
+ *
+ * Ported from Oracle v2 Python (oracle-mcp/sources/graph.py).
+ */
+
+import type { ToolContext, ToolResponse, GraphPathInput } from './types.ts';
+
+export const graphPathToolDef = {
+  name: 'arra_graph_path',
+  description:
+    'Find the shortest path between two concepts in the vault knowledge graph. Shows how ideas connect through shared notes.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      from_concept: {
+        type: 'string',
+        description: 'Starting concept',
+      },
+      to_concept: {
+        type: 'string',
+        description: 'Target concept',
+      },
+      max_depth: {
+        type: 'number',
+        description: 'Maximum path length (default 4, max 6)',
+      },
+    },
+    required: ['from_concept', 'to_concept'],
+  },
+};
+
+function getNeighborsForPath(
+  ctx: ToolContext,
+  concept: string,
+  visited: Set<string>,
+  limit: number = 30,
+): Array<{ name: string; weight: number }> {
+  const phV = Array.from(visited).map(() => '?').join(',');
+  const params: (string | number)[] = [concept, ...Array.from(visited), limit];
+
+  const rows = ctx.sqlite
+    .prepare(
+      `SELECT g2.target_name, COUNT(DISTINCT g1.source_path) as shared_files
+       FROM graph_edges g1
+       JOIN graph_edges g2 ON g1.source_path = g2.source_path
+       WHERE g1.target_name = ?
+         AND g2.target_name NOT IN (${phV})
+       GROUP BY g2.target_name
+       ORDER BY shared_files DESC
+       LIMIT ?`,
+    )
+    .all(...params) as Array<{ target_name: string; shared_files: number }>;
+
+  return rows.map((r) => ({ name: r.target_name, weight: r.shared_files }));
+}
+
+function buildPathDetails(
+  ctx: ToolContext,
+  pathList: string[],
+): Array<{ from: string; to: string; shared_files: number }> {
+  const details: Array<{ from: string; to: string; shared_files: number }> = [];
+  for (let i = 0; i < pathList.length - 1; i++) {
+    const row = ctx.sqlite
+      .prepare(
+        `SELECT COUNT(DISTINCT g1.source_path) as shared_files
+         FROM graph_edges g1
+         JOIN graph_edges g2 ON g1.source_path = g2.source_path
+         WHERE g1.target_name = ? AND g2.target_name = ?`,
+      )
+      .get(pathList[i], pathList[i + 1]) as { shared_files: number } | undefined;
+
+    details.push({
+      from: pathList[i],
+      to: pathList[i + 1],
+      shared_files: row?.shared_files ?? 0,
+    });
+  }
+  return details;
+}
+
+export async function handleGraphPath(
+  ctx: ToolContext,
+  input: GraphPathInput,
+): Promise<ToolResponse> {
+  const from = input.from_concept;
+  const to = input.to_concept;
+  const maxDepth = Math.min(input.max_depth ?? 4, 6);
+
+  const edgeCount = ctx.sqlite.prepare('SELECT COUNT(*) as c FROM graph_edges').get() as { c: number } | undefined;
+  if (!edgeCount || edgeCount.c === 0) {
+    return {
+      content: [{ type: 'text', text: JSON.stringify({ error: 'Graph not populated.' }) }],
+    };
+  }
+
+  if (from === to) {
+    return {
+      content: [{ type: 'text', text: JSON.stringify({ found: true, path: [from], depth: 0 }) }],
+    };
+  }
+
+  const visited = new Set<string>([from]);
+  const queue: Array<{ current: string; path: string[] }> = [{ current: from, path: [from] }];
+  let totalVisited = 0;
+
+  while (queue.length > 0 && totalVisited < 500) {
+    const item = queue.shift()!;
+    if (item.path.length > maxDepth) continue;
+
+    const neighbors = getNeighborsForPath(ctx, item.current, visited);
+    totalVisited += neighbors.length;
+
+    for (const neighbor of neighbors) {
+      const newPath = [...item.path, neighbor.name];
+      if (neighbor.name === to) {
+        const pathDetails = buildPathDetails(ctx, newPath);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                { found: true, from, to, path: newPath, path_details: pathDetails, depth: newPath.length - 1 },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      }
+      visited.add(neighbor.name);
+      if (newPath.length <= maxDepth) {
+        queue.push({ current: neighbor.name, path: newPath });
+      }
+    }
+  }
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(
+          { found: false, from, to, searched_depth: maxDepth, nodes_visited: totalVisited },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}

--- a/src/tools/graph-path.ts
+++ b/src/tools/graph-path.ts
@@ -87,7 +87,8 @@ export async function handleGraphPath(
   const to = input.to_concept;
   const maxDepth = Math.min(input.max_depth ?? 4, 6);
 
-  const edgeCount = ctx.sqlite.prepare('SELECT COUNT(*) as c FROM graph_edges').get() as { c: number } | undefined;
+  const graphTable = ctx.sqlite.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'graph_edges'").get();
+  const edgeCount = graphTable ? ctx.sqlite.prepare('SELECT COUNT(*) as c FROM graph_edges').get() as { c: number } | undefined : undefined;
   if (!edgeCount || edgeCount.c === 0) {
     return {
       content: [{ type: 'text', text: JSON.stringify({ error: 'Graph not populated.' }) }],

--- a/src/tools/graph-search.ts
+++ b/src/tools/graph-search.ts
@@ -1,0 +1,121 @@
+/**
+ * Graph Search — BFS neighbor exploration via shared files.
+ *
+ * Ported from Oracle v2 Python (oracle-mcp/sources/graph.py).
+ * The graph is bipartite: files (source_path) ↔ concepts (target_name).
+ * Two concepts are neighbors if they appear in the same file(s).
+ */
+
+import type { ToolContext, ToolResponse, GraphSearchInput } from './types.ts';
+
+export const graphSearchToolDef = {
+  name: 'arra_graph_search',
+  description:
+    'Explore the vault knowledge graph. Find concepts connected to a starting concept via shared notes. Use to discover related topics, find knowledge clusters, and understand how ideas connect across the vault.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      concept: {
+        type: 'string',
+        description: 'Starting concept (e.g., "Claude Code", "Obsidian", "MCP")',
+      },
+      max_hops: {
+        type: 'number',
+        description: 'Hops to traverse (1=direct, 2=neighbors of neighbors). Default 1, max 3',
+      },
+      relationship_types: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'Filter: body_wikilink, keyword, topic_hierarchy, source_reference, related_note, yaml_wikilink',
+      },
+      limit: {
+        type: 'number',
+        description: 'Max neighbors per hop (default 20)',
+      },
+    },
+    required: ['concept'],
+  },
+};
+
+export async function handleGraphSearch(
+  ctx: ToolContext,
+  input: GraphSearchInput,
+): Promise<ToolResponse> {
+  const concept = input.concept;
+  const maxHops = Math.min(input.max_hops ?? 1, 3);
+  const limit = input.limit ?? 20;
+  const relTypes = input.relationship_types;
+
+  const edgeCount = ctx.sqlite.prepare('SELECT COUNT(*) as c FROM graph_edges').get() as { c: number } | undefined;
+  if (!edgeCount || edgeCount.c === 0) {
+    return {
+      content: [{ type: 'text', text: JSON.stringify({ error: 'Graph not populated. Copy graph_edges from Oracle v2 or run a vault graph builder.' }) }],
+    };
+  }
+
+  const visited = new Set<string>([concept]);
+  let frontier: string[] = [concept];
+  const allNodes: Array<{ name: string; hop: number; weight?: number }> = [{ name: concept, hop: 0 }];
+  const allEdges: Array<{ from: string; to: string; weight: number; hop: number }> = [];
+
+  for (let hop = 1; hop <= maxHops; hop++) {
+    if (frontier.length === 0 || visited.size > 500) break;
+
+    const phF = frontier.map(() => '?').join(',');
+    const phV = Array.from(visited).map(() => '?').join(',');
+    const params: (string | number)[] = [...frontier];
+
+    let relFilter = '';
+    if (relTypes && relTypes.length > 0) {
+      const phR = relTypes.map(() => '?').join(',');
+      relFilter = `AND g2.relationship_type IN (${phR})`;
+      params.push(...relTypes);
+    }
+
+    params.push(...Array.from(visited));
+    params.push(limit);
+
+    const query = `
+      SELECT g2.target_name, COUNT(DISTINCT g1.source_path) as shared_files
+      FROM graph_edges g1
+      JOIN graph_edges g2 ON g1.source_path = g2.source_path
+      WHERE g1.target_name IN (${phF})
+        ${relFilter}
+        AND g2.target_name NOT IN (${phV})
+      GROUP BY g2.target_name
+      ORDER BY shared_files DESC
+      LIMIT ?
+    `;
+
+    const rows = ctx.sqlite.prepare(query).all(...params) as Array<{
+      target_name: string;
+      shared_files: number;
+    }>;
+
+    const newFrontier: string[] = [];
+    for (const row of rows) {
+      newFrontier.push(row.target_name);
+      visited.add(row.target_name);
+      allNodes.push({ name: row.target_name, hop, weight: row.shared_files });
+      allEdges.push({
+        from: hop === 1 ? concept : `hop${hop - 1}`,
+        to: row.target_name,
+        weight: row.shared_files,
+        hop,
+      });
+    }
+
+    frontier = newFrontier;
+  }
+
+  const result = {
+    start: concept,
+    hops_completed: maxHops,
+    nodes: allNodes,
+    total_nodes: allNodes.length,
+    total_edges: allEdges.length,
+  };
+
+  return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+}

--- a/src/tools/graph-search.ts
+++ b/src/tools/graph-search.ts
@@ -47,7 +47,8 @@ export async function handleGraphSearch(
   const limit = input.limit ?? 20;
   const relTypes = input.relationship_types;
 
-  const edgeCount = ctx.sqlite.prepare('SELECT COUNT(*) as c FROM graph_edges').get() as { c: number } | undefined;
+  const graphTable = ctx.sqlite.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'graph_edges'").get();
+  const edgeCount = graphTable ? ctx.sqlite.prepare('SELECT COUNT(*) as c FROM graph_edges').get() as { c: number } | undefined : undefined;
   if (!edgeCount || edgeCount.c === 0) {
     return {
       content: [{ type: 'text', text: JSON.stringify({ error: 'Graph not populated. Copy graph_edges from Oracle v2 or run a vault graph builder.' }) }],

--- a/src/tools/handoff.ts
+++ b/src/tools/handoff.ts
@@ -7,6 +7,7 @@
 
 import path from 'path';
 import fs from 'fs';
+
 import { detectProject } from '../server/project-detect.ts';
 import type { ToolContext, ToolResponse, OracleHandoffInput } from './types.ts';
 
@@ -105,7 +106,7 @@ export async function handleHandoff(ctx: ToolContext, input: OracleHandoffInput)
 
   // Resolve vault root for central writes
   const getVaultPsiRoot = await loadGetVaultPsiRoot();
-  const vault = getVaultPsiRoot();
+  const vault = getVaultPsiRoot(ctx.sqlite);
   if ('needsInit' in vault) console.error(`[Vault] ${vault.hint}`);
   const vaultRoot = 'path' in vault ? vault.path : null;
 

--- a/src/tools/learn.ts
+++ b/src/tools/learn.ts
@@ -37,6 +37,7 @@ async function loadGetVaultPsiRoot(): Promise<typeof import('../vault/handler.ts
   return getVaultPsiRootFn;
 }
 import type { ToolContext, ToolResponse, OracleLearnInput } from './types.ts';
+import { UNIVERSAL_PROJECT, contentDigest, documentStorageId, storedProject } from '../document-identity.ts';
 
 /** Coerce concepts to string[] — handles string, array, or undefined from MCP input */
 export function coerceConcepts(concepts: unknown): string[] {
@@ -199,13 +200,16 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
 
   // Resolve vault root for central writes
   const getVaultPsiRoot = await loadGetVaultPsiRoot();
-  const vault = getVaultPsiRoot();
+  const vault = getVaultPsiRoot(ctx.sqlite);
   if ('needsInit' in vault) console.error(`[Vault] ${vault.hint}`);
   const vaultRoot = 'path' in vault ? vault.path : null;
 
-  const project = normalizeProject(projectInput)
-    || extractProjectFromSource(source)
-    || detectProject(ctx.repoRoot);
+  const project = storedProject(
+    normalizeProject(projectInput)
+      || projectInput
+      || extractProjectFromSource(source)
+      || detectProject(ctx.repoRoot),
+  );
   const projectDir = (project || '_universal').toLowerCase();
 
   let filePath: string;
@@ -244,8 +248,11 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
 
   fs.writeFileSync(filePath, frontmatter, 'utf-8');
 
+  const storageId = documentStorageId(project, id);
   ctx.db.insert(oracleDocuments).values({
-    id,
+    id: storageId,
+    displayId: id,
+    contentDigest: contentDigest(frontmatter),
     type: 'learning',
     sourceFile: sourceFileRel,
     concepts: JSON.stringify(conceptsList),
@@ -258,11 +265,11 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
   }).run();
 
   // FTS5 has no unique constraint on id — delete-then-insert to be idempotent.
-  ctx.sqlite.prepare(`DELETE FROM oracle_fts WHERE id = ?`).run(id);
+  ctx.sqlite.prepare(`DELETE FROM oracle_fts WHERE id = ?`).run(storageId);
   ctx.sqlite.prepare(`
     INSERT INTO oracle_fts (id, content, concepts)
     VALUES (?, ?, ?)
-  `).run(id, frontmatter, conceptsList.join(' '));
+  `).run(storageId, frontmatter, conceptsList.join(' '));
 
   // Vector indexing — two paths:
   //   - Default (env unset): inline embed via Ollama. Keeps DB + lancedb in
@@ -277,7 +284,7 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
   const enqueue = process.env.ORACLE_INDEXER_ENQUEUE === '1' ? await loadEnqueue() : null;
   if (enqueue) {
     try {
-      enqueue(ctx.sqlite, { docId: id, models: getEmbeddingModels() });
+      enqueue(ctx.sqlite, { docId: storageId, models: getEmbeddingModels() });
       embeddingStatus = 'enqueued';
     } catch (err) {
       // Never block ingest on the queue — same posture as the inline path.
@@ -290,13 +297,15 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
       const model = process.env.ORACLE_EMBEDDING_MODEL || 'bge-m3';
       const vectorStore = getVectorStoreByModel(model);
       await vectorStore.addDocuments([{
-        id,
+        id: storageId,
         document: frontmatter,
         metadata: {
           type: 'learning',
           source_file: sourceFileRel,
-          project: project || '',
+          project: project || UNIVERSAL_PROJECT,
           concepts: conceptsList.join(','),
+          display_id: id,
+          content_digest: contentDigest(frontmatter),
         },
       }]);
       embeddingStatus = 'ok';
@@ -314,7 +323,8 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
       text: JSON.stringify({
         success: true,
         file: sourceFileRel,
-        id,
+        id: storageId,
+        display_id: id,
         embedding: embeddingStatus,
         ...(embeddingError && { embeddingError }),
         message: `Pattern added to Oracle knowledge base${vaultRoot ? ' (vault)' : ''}${embeddingStatus === 'failed' ? ' — vector embedding failed, see server log' : ''}`

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -7,6 +7,7 @@
 
 import fs from 'fs';
 import path from 'path';
+
 import type { ToolContext, ToolResponse, OracleReadInput } from './types.ts';
 
 let getVaultPsiRootFn: typeof import('../vault/handler.ts').getVaultPsiRoot | null = null;
@@ -65,6 +66,7 @@ async function resolveFilePath(
   sourceFile: string,
   repoRoot: string,
   ghqRoot: string,
+  sqlite: ToolContext['sqlite'],
 ): Promise<string | null> {
   // 1. Try direct from repoRoot (handles "ψ/memory/..." paths)
   const directPath = path.join(repoRoot, sourceFile);
@@ -79,7 +81,7 @@ async function resolveFilePath(
 
   // 3. Try vault fallback
   const getVaultPsiRoot = await loadGetVaultPsiRoot();
-  const vault = getVaultPsiRoot();
+  const vault = getVaultPsiRoot(sqlite);
   if ('path' in vault) {
     const vaultPath = path.join(vault.path, sourceFile);
     if (fs.existsSync(vaultPath)) return fs.realpathSync(vaultPath);
@@ -115,12 +117,14 @@ export async function handleRead(ctx: ToolContext, input: OracleReadInput): Prom
 
   let sourceFile = file;
   let project: string | null = null;
+  let storageId: string | null = null;
+  let displayId: string | null = null;
 
   // ID lookup: resolve source_file from DB
   if (id) {
     const row = ctx.sqlite.prepare(
-      'SELECT source_file, project FROM oracle_documents WHERE id = ?'
-    ).get(id) as { source_file: string; project: string | null } | null;
+      'SELECT id, display_id, source_file, project FROM oracle_documents WHERE id = ?'
+    ).get(id) as { id: string; display_id: string; source_file: string; project: string | null } | null;
 
     if (!row) {
       return {
@@ -130,11 +134,12 @@ export async function handleRead(ctx: ToolContext, input: OracleReadInput): Prom
     }
     sourceFile = sourceFile || row.source_file;
     project = row.project;
+    storageId = row.id;
+    displayId = row.display_id;
   }
 
   const ghqRoot = detectGhqRoot(ctx.repoRoot);
-  const resolvedPath = await resolveFilePath(sourceFile!, ctx.repoRoot, ghqRoot);
-
+  const resolvedPath = await resolveFilePath(sourceFile!, ctx.repoRoot, ghqRoot, ctx.sqlite);
   // File found on disk
   if (resolvedPath && isPathAllowed(resolvedPath, ctx.repoRoot, ghqRoot)) {
     const content = fs.readFileSync(resolvedPath, 'utf-8');
@@ -146,6 +151,7 @@ export async function handleRead(ctx: ToolContext, input: OracleReadInput): Prom
           source_file: sourceFile,
           resolved_path: resolvedPath,
           source: 'file',
+          ...(storageId ? { id: storageId, display_id: displayId } : {}),
           ...(project ? { project } : {}),
         }),
       }],
@@ -153,10 +159,10 @@ export async function handleRead(ctx: ToolContext, input: OracleReadInput): Prom
   }
 
   // Fallback: try FTS indexed content (if we have an id)
-  if (id) {
+  if (storageId) {
     const ftsRow = ctx.sqlite.prepare(
       'SELECT content FROM oracle_fts WHERE id = ?'
-    ).get(id) as { content: string } | null;
+    ).get(storageId) as { content: string } | null;
 
     if (ftsRow) {
       return {
@@ -167,6 +173,8 @@ export async function handleRead(ctx: ToolContext, input: OracleReadInput): Prom
             source_file: sourceFile,
             resolved_path: null,
             source: 'fts_cache',
+            id: storageId,
+            display_id: displayId,
             ...(project ? { project } : {}),
           }),
         }],

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -12,6 +12,7 @@ import { ensureVectorStoreConnected } from '../vector/factory.ts';
 import { isVectorSectionEnabled } from '../vector/config.ts';
 import type { SearchResult } from '../server/types.ts';
 import type { ToolContext, ToolResponse, OracleSearchInput } from './types.ts';
+import { UNIVERSAL_PROJECT, contentDigest, storedProject } from '../document-identity.ts';
 
 let logSearchFn: typeof import('../server/logging.ts').logSearch | null = null;
 async function loadLogSearch(): Promise<typeof import('../server/logging.ts').logSearch> {
@@ -119,6 +120,21 @@ export function parseConceptsFromMetadata(concepts: unknown): string[] {
   return [];
 }
 
+export interface VectorSearchResult {
+  id: string;
+  display_id: string;
+  project: string;
+  content_digest: string;
+  type: string;
+  content: string;
+  source_file: string;
+  concepts: string[];
+  score: number;
+  distance: number;
+  model: string;
+  source: 'vector';
+}
+
 /**
  * Vector search using ChromaMcpClient.
  * Performs semantic similarity search on the oracle_knowledge collection.
@@ -128,66 +144,112 @@ export async function vectorSearch(
   query: string,
   type: string,
   limit: number,
-  model?: string
-): Promise<Array<{
-  id: string;
-  type: string;
-  content: string;
-  source_file: string;
-  concepts: string[];
-  score: number;
-  distance: number;
-  model: string;
-  source: 'vector';
-}>> {
+  model?: string,
+  project?: string | null,
+): Promise<VectorSearchResult[]> {
   try {
-    const whereFilter = type !== 'all' ? { type } : undefined;
     const store = model ? await ensureVectorStoreConnected(model) : ctx.vectorStore;
+    const baseFilter = type !== 'all' ? { type } : {};
+    const projectFilters = project
+      ? [project, UNIVERSAL_PROJECT]
+      : [null];
     console.error(`[VectorSearch] Query: "${query.substring(0, 50)}..." limit=${limit} model=${model || 'default'}`);
 
-    const results = await store.query(query, limit, whereFilter);
-    console.error(`[VectorSearch] Results: ${results.ids?.length || 0} documents`);
+    const channels = await Promise.all(projectFilters.map((projectFilter) => {
+      const where = projectFilter
+        ? { ...baseFilter, project: projectFilter }
+        : (Object.keys(baseFilter).length > 0 ? baseFilter : undefined);
+      return store.query(query, limit, where);
+    }));
+    const candidates: VectorSearchResult[] = [];
 
-    if (!results.ids || results.ids.length === 0) {
-      return [];
+    for (const results of channels) {
+      for (let index = 0; index < results.ids.length; index++) {
+        const metadata = results.metadatas[index] as Record<string, unknown> | null;
+        const rawDistance = results.distances[index] || 0;
+        candidates.push({
+          id: results.ids[index],
+          display_id: String(metadata?.display_id || ''),
+          project: String(metadata?.project || ''),
+          content_digest: String(metadata?.content_digest || ''),
+          type: String(metadata?.type || 'unknown'),
+          content: results.documents[index] || '',
+          source_file: String(metadata?.source_file || ''),
+          concepts: parseConceptsFromMetadata(metadata?.concepts),
+          score: rawDistance,
+          distance: rawDistance,
+          model: 'qwen3',
+          source: 'vector',
+        });
+      }
     }
 
-    const resolvedModelName = model || 'bge-m3';
-    const mappedResults: Array<{
-      id: string;
-      type: string;
-      content: string;
-      source_file: string;
-      concepts: string[];
-      score: number;
-      distance: number;
-      model: string;
-      source: 'vector';
-    }> = [];
-
-    for (let i = 0; i < results.ids.length; i++) {
-      const metadata = results.metadatas[i] as Record<string, unknown> | null;
-
-      const rawDistance = results.distances[i] || 0;
-      mappedResults.push({
-        id: results.ids[i],
-        type: (metadata?.type as string) || 'unknown',
-        content: (results.documents[i] || '').substring(0, 500),
-        source_file: (metadata?.source_file as string) || '',
-        concepts: parseConceptsFromMetadata(metadata?.concepts),
-        score: rawDistance,
-        distance: rawDistance,
-        model: resolvedModelName,
-        source: 'vector',
-      });
-    }
-
-    return mappedResults;
+    candidates.sort((a, b) => (a.distance - b.distance) || a.id.localeCompare(b.id));
+    const seen = new Set<string>();
+    const results = candidates.filter((candidate) => {
+      if (seen.has(candidate.id)) return false;
+      seen.add(candidate.id);
+      return true;
+    }).slice(0, limit);
+    console.error(`[VectorSearch] Results: ${results.length} documents`);
+    return results;
   } catch (error) {
     const errorMsg = error instanceof Error ? error.stack || error.message : String(error);
-    console.error('[ChromaDB ERROR]', errorMsg);
+    console.error('[VectorSearch ERROR]', errorMsg);
     return [];
   }
+}
+
+export function validateVectorResults(
+  sqlite: ToolContext['sqlite'],
+  candidates: VectorSearchResult[],
+  project?: string | null,
+): { results: VectorSearchResult[]; error?: string } {
+  if (candidates.length === 0) return { results: [] };
+
+  const placeholders = candidates.map(() => '?').join(',');
+  const rows = sqlite.prepare(`
+    SELECT id, display_id, content_digest, project, type, source_file, concepts
+    FROM oracle_documents
+    WHERE id IN (${placeholders})
+  `).all(...candidates.map(({ id }) => id)) as Array<{
+    id: string;
+    display_id: string | null;
+    content_digest: string | null;
+    project: string | null;
+    type: string;
+    source_file: string;
+    concepts: string;
+  }>;
+  const rowsById = new Map(rows.map((row) => [row.id, row]));
+  const allowedProjects = project ? new Set([project, UNIVERSAL_PROJECT]) : null;
+
+  for (const candidate of candidates) {
+    const row = rowsById.get(candidate.id);
+    const rowProject = row?.project || UNIVERSAL_PROJECT;
+    if (!row
+      || candidate.project !== rowProject
+      || candidate.display_id !== row.display_id
+      || candidate.content_digest !== row.content_digest
+      || contentDigest(candidate.content) !== row.content_digest
+      || (allowedProjects !== null && !allowedProjects.has(rowProject))) {
+      return { results: [], error: `Vector identity validation failed for ${candidate.id}` };
+    }
+  }
+
+  return {
+    results: candidates.map((candidate) => {
+      const row = rowsById.get(candidate.id)!;
+      return {
+        ...candidate,
+        display_id: row.display_id!,
+        project: row.project || UNIVERSAL_PROJECT,
+        type: row.type,
+        source_file: row.source_file,
+        concepts: JSON.parse(row.concepts || '[]') as string[],
+      };
+    }),
+  };
 }
 
 /**
@@ -197,6 +259,7 @@ export async function vectorSearch(
 export function combineResults(
   ftsResults: Array<{
     id: string;
+    display_id?: string;
     type: string;
     content: string;
     source_file: string;
@@ -206,6 +269,7 @@ export function combineResults(
   }>,
   vectorResults: Array<{
     id: string;
+    display_id?: string;
     type: string;
     content: string;
     source_file: string;
@@ -219,6 +283,7 @@ export function combineResults(
   vectorWeight: number = 0.5
 ): Array<{
   id: string;
+  display_id?: string;
   type: string;
   content: string;
   source_file: string;
@@ -232,6 +297,7 @@ export function combineResults(
 }> {
   const resultMap = new Map<string, {
     id: string;
+    display_id?: string;
     type: string;
     content: string;
     source_file: string;
@@ -247,6 +313,7 @@ export function combineResults(
   for (const result of ftsResults) {
     resultMap.set(result.id, {
       id: result.id,
+      display_id: result.display_id,
       type: result.type,
       content: result.content,
       source_file: result.source_file,
@@ -267,6 +334,7 @@ export function combineResults(
     } else {
       resultMap.set(result.id, {
         id: result.id,
+        display_id: result.display_id,
         type: result.type,
         content: result.content,
         source_file: result.source_file,
@@ -295,6 +363,7 @@ export function combineResults(
 
     return {
       id: result.id,
+      display_id: result.display_id,
       type: result.type,
       content: result.content,
       source_file: result.source_file,
@@ -327,7 +396,7 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
   const safeQuery = sanitizeFtsQuery(query);
 
   // Auto-detect project from cwd if not explicitly specified
-  const resolvedProject = (project ?? detectProject(cwd))?.toLowerCase() ?? null;
+  const resolvedProject = storedProject(project ?? detectProject(cwd));
 
   // Project filter: if project specified, include project + universal (NULL)
   // If no project, return ALL documents (no filter)
@@ -353,7 +422,7 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
     try {
       if (type === 'all') {
         const stmt = ctx.sqlite.prepare(`
-          SELECT f.id, f.content, d.type, d.source_file, d.concepts, rank
+          SELECT f.id, d.display_id, f.content, d.type, d.source_file, d.concepts, d.project, rank
           FROM oracle_fts f
           JOIN oracle_documents d ON f.id = d.id
           WHERE oracle_fts MATCH ? ${projectFilter}
@@ -363,7 +432,7 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
         ftsRawResults = stmt.all(safeQuery, ...projectParams, limit * 3);
       } else {
         const stmt = ctx.sqlite.prepare(`
-          SELECT f.id, f.content, d.type, d.source_file, d.concepts, rank
+          SELECT f.id, d.display_id, f.content, d.type, d.source_file, d.concepts, d.project, rank
           FROM oracle_fts f
           JOIN oracle_documents d ON f.id = d.id
           WHERE oracle_fts MATCH ? AND d.type = ? ${projectFilter}
@@ -384,7 +453,12 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
   let vecResults: Awaited<ReturnType<typeof vectorSearch>> = [];
   if (effectiveMode !== 'fts') {
     try {
-      vecResults = await vectorSearch(ctx, query, type, limit * 2, model);
+      vecResults = await vectorSearch(ctx, query, type, limit * 2, model, resolvedProject);
+      const validation = validateVectorResults(ctx.sqlite, vecResults, resolvedProject);
+      vecResults = validation.results;
+      if (validation.error) {
+        warning = `${validation.error}. Using FTS5 only.`;
+      }
     } catch (error) {
       vectorSearchError = true;
       vectorAvailable = false;
@@ -401,10 +475,12 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
   // Transform FTS results to normalized format
   const ftsResults = ftsRawResults.map((row: any) => ({
     id: row.id,
+    display_id: row.display_id,
     type: row.type,
     content: row.content.substring(0, 500),
     source_file: row.source_file,
     concepts: JSON.parse(row.concepts || '[]') as string[],
+    project: row.project,
     score: normalizeFtsScore(row.rank),
     source: 'fts' as const,
   }));
@@ -412,6 +488,7 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
   // Normalize vector scores (ChromaDB distances: lower = better → invert)
   const normalizedVectorResults = vecResults.map((result) => ({
     ...result,
+    content: result.content.substring(0, 500),
     score: 1 - (result.score || 0),
   }));
 

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -105,3 +105,20 @@ export interface OracleReadInput {
   file?: string;
   id?: string;
 }
+
+export interface GraphSearchInput {
+  concept: string;
+  max_hops?: number;
+  relationship_types?: string[];
+  limit?: number;
+}
+
+export interface GraphPathInput {
+  from_concept: string;
+  to_concept: string;
+  max_depth?: number;
+}
+
+export interface GraphInfoInput {
+  concept: string;
+}

--- a/src/vault/discovery.ts
+++ b/src/vault/discovery.ts
@@ -5,7 +5,7 @@
 import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
-import { getSetting } from '../db/index.ts';
+import type { Database } from 'bun:sqlite';
 
 /**
  * Walk all files under dir, skipping symlinks.
@@ -54,8 +54,9 @@ export function cleanEmptyDirs(dir: string, stopAt: string): void {
  * Resolve the vault ψ/ root for shared use by oracle_learn, oracle_handoff, indexer, etc.
  * Returns the vault repo local path, or a setup hint if not configured.
  */
-export function getVaultPsiRoot(): { path: string } | { needsInit: true; hint: string } {
-  const repo = getSetting('vault_repo');
+export function getVaultPsiRoot(sqlite: Database): { path: string } | { needsInit: true; hint: string } {
+  const setting = sqlite.prepare("SELECT value FROM settings WHERE key = 'vault_repo'").get() as { value: string | null } | null;
+  const repo = setting?.value;
   if (!repo) {
     return {
       needsInit: true,

--- a/src/vector/__tests__/adapters.test.ts
+++ b/src/vector/__tests__/adapters.test.ts
@@ -13,11 +13,12 @@ import { SqliteVecAdapter } from '../adapters/sqlite-vec.ts';
 import { ChromaMcpAdapter } from '../adapters/chroma-mcp.ts';
 import { LanceDBAdapter } from '../adapters/lancedb.ts';
 import { QdrantAdapter } from '../adapters/qdrant.ts';
-import type { VectorStoreAdapter, VectorDocument } from '../types.ts';
+import type { EmbeddingProvider, VectorStoreAdapter, VectorDocument } from '../types.ts';
 import { Database } from 'bun:sqlite';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
+import { UNIVERSAL_PROJECT, contentDigest, documentStorageId } from '../../document-identity.ts';
 
 /**
  * Probe whether the sqlite-vec (vec0) extension can be loaded.
@@ -362,6 +363,15 @@ describe('ChromaMcpAdapter', () => {
 // Adapter Interface Compliance: LanceDB + Ollama
 // ============================================================================
 
+class FixedEmbeddingProvider implements EmbeddingProvider {
+  readonly name = 'fixed';
+  readonly dimensions = 2;
+
+  async embed(texts: string[]): Promise<number[][]> {
+    return texts.map(() => [1, 0]);
+  }
+}
+
 describe('LanceDBAdapter + Ollama', () => {
   let store: VectorStoreAdapter;
   let tmpDir: string;
@@ -429,6 +439,46 @@ describe('LanceDBAdapter + Ollama', () => {
 
     for (const meta of result.metadatas) {
       expect(meta.type).toBe('learning');
+    }
+  });
+
+  test('applies project filtering before limit and preserves equal display IDs', async () => {
+    const filterDir = path.join(os.tmpdir(), `oracle-lance-filter-${Date.now()}`);
+    const filteredStore = new LanceDBAdapter(
+      'oracle_test_lance_filter',
+      filterDir,
+      new FixedEmbeddingProvider(),
+    );
+    const digest = contentDigest('same content');
+    const document = (project: string, displayId: string): VectorDocument => ({
+      id: documentStorageId(project === UNIVERSAL_PROJECT ? null : project, displayId),
+      document: 'same content',
+      metadata: {
+        type: 'learning',
+        source_file: `${project}/${displayId}.md`,
+        concepts: '[]',
+        project,
+        display_id: displayId,
+        content_digest: digest,
+      },
+    });
+
+    try {
+      await filteredStore.connect();
+      await filteredStore.ensureCollection();
+      await filteredStore.addDocuments([
+        ...Array.from({ length: 10 }, (_, index) => document('project-b', `blocker-${index}`)),
+        document('project-b', 'shared'),
+        document('project-a', 'shared'),
+        document(UNIVERSAL_PROJECT, 'shared'),
+      ]);
+
+      const result = await filteredStore.query('same content', 1, { project: 'project-a' });
+      expect(result.ids).toEqual([documentStorageId('project-a', 'shared')]);
+      expect(result.metadatas[0]?.display_id).toBe('shared');
+    } finally {
+      await filteredStore.close();
+      fs.rmSync(filterDir, { recursive: true, force: true });
     }
   });
 

--- a/src/vector/adapters/lancedb.ts
+++ b/src/vector/adapters/lancedb.ts
@@ -7,6 +7,26 @@
 
 import type { VectorStoreAdapter, VectorDocument, VectorQueryResult, EmbeddingProvider } from '../types.ts';
 
+const FILTER_COLUMNS: Record<string, true> = {
+  type: true,
+  project: true,
+  display_id: true,
+  content_digest: true,
+};
+
+function filterPredicate(where: Record<string, unknown>): string {
+  return Object.entries(where).map(([column, value]) => {
+    if (!FILTER_COLUMNS[column]) throw new Error(`Unsupported LanceDB filter: ${column}`);
+    if (Array.isArray(value) && value.length > 0 && value.every((item) => typeof item === 'string')) {
+      return `${column} IN (${value.map((item) => `'${item.replaceAll("'", "''")}'`).join(', ')})`;
+    }
+    if (typeof value === 'string') return `${column} = '${value.replaceAll("'", "''")}'`;
+    if (typeof value === 'number' && Number.isFinite(value)) return `${column} = ${value}`;
+    if (typeof value === 'boolean') return `${column} = ${value}`;
+    throw new Error(`Unsupported LanceDB filter value for ${column}`);
+  }).join(' AND ');
+}
+
 export class LanceDBAdapter implements VectorStoreAdapter {
   readonly name = 'lancedb';
   private db: any = null;
@@ -58,6 +78,10 @@ export class LanceDBAdapter implements VectorStoreAdapter {
       this.table = await this.db.createTable(this.collectionName, [{
         id: '__init__',
         text: '',
+        type: '',
+        project: '',
+        display_id: '',
+        content_digest: '',
         metadata: '{}',
         vector: new Array(dims).fill(0),
       }]);
@@ -167,6 +191,10 @@ export class LanceDBAdapter implements VectorStoreAdapter {
       id: doc.id,
       text: doc.document,
       metadata: JSON.stringify(doc.metadata),
+      type: String(doc.metadata.type || ''),
+      project: String(doc.metadata.project || ''),
+      display_id: String(doc.metadata.display_id || ''),
+      content_digest: String(doc.metadata.content_digest || ''),
       vector: doc.vector ?? fresh[freshIdx++],
     }));
     return rows;
@@ -178,18 +206,13 @@ export class LanceDBAdapter implements VectorStoreAdapter {
 
     const [queryEmbedding] = await this.embedder.embed([text], 'query');
 
-    // Fetch extra results if filtering in JS (metadata is stored as string, not binary)
-    const fetchLimit = where ? limit * 3 : limit;
-    const results = await this.table.search(queryEmbedding).distanceType('cosine').limit(fetchLimit).toArray();
-
-    // Filter metadata in JavaScript (LanceDB json_extract requires LargeBinary, not Utf8)
-    let filtered = results;
-    if (where) {
-      filtered = results.filter((r: any) => {
-        const meta = JSON.parse(r.metadata || '{}');
-        return Object.entries(where).every(([k, v]) => meta[k] === v);
-      }).slice(0, limit);
+    let search = this.table.search(queryEmbedding).distanceType('cosine');
+    if (where && Object.keys(where).length > 0) {
+      search = search.where(filterPredicate(where));
     }
+    const results = await search.limit(limit).toArray();
+
+    const filtered = results;
 
     return {
       ids: filtered.map((r: any) => r.id),
@@ -204,7 +227,7 @@ export class LanceDBAdapter implements VectorStoreAdapter {
     await this.checkoutLatest();
 
     // Get the document's vector using filter query (not vector search)
-    const rows = await this.table.query().where(`id = '${id}'`).limit(1).toArray();
+    const rows = await this.table.query().where(`id = '${id.replaceAll("'", "''")}'`).limit(1).toArray();
     if (rows.length === 0) {
       throw new Error(`No embedding found for document: ${id}`);
     }

--- a/src/vector/factory.ts
+++ b/src/vector/factory.ts
@@ -154,8 +154,8 @@ export function getEmbeddingModels(): Record<string, VectorModelRegistryEntry> {
     },
     qwen3: {
       adapter: 'lancedb',
-      collection: 'oracle_knowledge_qwen3',
-      model: 'qwen3-embedding',
+      collection: 'oracle_knowledge_qwen3_v2',
+      model: process.env.ORACLE_EMBEDDING_MODEL || 'qwen3-embedding:8b',
       dataPath: LANCEDB_DIR,
       provider: 'ollama',
     },


### PR DESCRIPTION
## Summary

- namespace stored document identities by project while preserving display IDs for users
- migrate SQLite, FTS, provenance references, and LanceDB metadata without re-embedding unchanged content
- reject cross-project and stale-content vector matches before hybrid ranking
- restore in-process graph commands and guard graph handlers when `graph_edges` is absent
- make `arra server start` path-independent, health-gated, and configurable with a per-plugin timeout
- align `ORACLE_REPO_ROOT` documentation with runtime resolution

## Verification

- identity regression suite: 76 passed
- graph handler suite: 6 passed
- plugin/server regression suites: 18 passed
- database integration suite: 34 passed
- isolated HTTP integration: 17 passed on the branch and baseline
- `bun run build`: passed
- production smoke: scoped Qwen3 vector retrieval, graph search/path/info, server cold start from `/tmp`, and health check passed

The full unit suite has the same 24 named pre-existing failures on upstream `main` and this branch; this change adds no new failing test names.