### PR TITLE
fix(test): stop bun from running Playwright specs, and wire the commands the docs promise

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,15 @@ Updated 2026-04-19. These override anything below that conflicts.
   sibling worktrees under `agents/`. Measured before the fix: `bun test tests/http/response-format/`
   reported 36 tests across 6 files where 1 file exists; `bun test tests/http/` ran 1,692 files in 111s.
   Do not remove that line — `tests/build/test-scope.test.ts` fails if you do. See #2825.
+- ⚠️ **Playwright specs are excluded too.** bun auto-discovers `*.spec.ts` as well as
+  `*.test.ts`, so the two tracked Playwright files (`tests/e2e/contrast.spec.ts`,
+  `tests/ui-audit/audit.spec.ts`) were loaded by bun and crashed with *"Playwright Test did
+  not expect test.describe() to be called here"*. `pathIgnorePatterns` now also carries a
+  spec-suffix glob. Run those suites with **`bun run test:e2e`** and
+  **`bun run test:ui-audit`** — commands `bunfig.toml` referenced for months without them
+  existing. `tests/build/playwright-scope.test.ts` keeps the exclusion honest: every
+  `*.spec.ts` must import `@playwright/test` and none may import `bun:test`, so a real bun
+  test named `*.spec.ts` fails the gate instead of being silently skipped. See #2997.
 - HTTP contract tests are fetch-based against a spawned Elysia server (see `src/integration/http.test.ts` pattern).
 - ⚠️ **Exit 133 is bun crashing, not a test failing.** `bun test --isolate tests/http/` (290
   files) crashes intermittently on bun 1.3.14 — ~1 run in 4 on macOS, no single file at fault

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,8 +1,13 @@
 [test]
 # Scan src/ (unit + integration) and tests/ (HTTP contract tests).
-# E2E tests use Playwright (run with: bun run test:e2e) — they live in
-# tests/e2e/*.e2e.ts so bun's auto-discovery (*.test.ts, *.spec.ts) skips
-# them and does not try to import @playwright/test.
+# E2E tests use Playwright (run with: bun run test:e2e). Most live in
+# tests/e2e/*.e2e.ts, which bun's auto-discovery ignores — but auto-discovery
+# DOES match *.spec.ts, and two Playwright files use that suffix on purpose:
+# tests/e2e/contrast.spec.ts (named in playwright.config.ts testMatch) and
+# tests/ui-audit/audit.spec.ts (its own playwright.config.ts). Both are
+# excluded below; see pathIgnorePatterns. This comment previously claimed
+# bun skipped them, and it did not — `bun test --isolate tests/e2e/` failed
+# with "Playwright Test did not expect test.describe() to be called here".
 roots = ["src", "tests"]
 # Isolate test files to prevent cross-file DB lock contamination.
 # Without this, parallel test files sharing oracle.db cause "disk I/O error".
@@ -14,4 +19,10 @@ isolate = true
 # existed: `bun test tests/http/response-format/` reported 36 tests across 6
 # files where exactly 1 file exists, and `bun test tests/http/` ran 1,692
 # files (282 exist) in 111s. See #2825.
-pathIgnorePatterns = ["**/agents/**"]
+#
+# `**/*.spec.ts` keeps bun's runner away from Playwright specs. Only two exist
+# (tests/e2e/contrast.spec.ts, tests/ui-audit/audit.spec.ts); neither imports
+# bun:test, so nothing real is lost. tests/build/playwright-scope.test.ts fails
+# if a *.spec.ts ever starts using bun:test, which would mean this line is
+# hiding a genuine test.
+pathIgnorePatterns = ["**/agents/**", "**/*.spec.ts"]

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Soul-Brews-Studio/arra-oracle-v2.git"
+    "url": "https://github.com/Soul-Brews-Studio/arra-oracle-v3.git"
   },
   "publishConfig": {
     "access": "public"
@@ -75,6 +75,8 @@
     "test": "bun run test:unit && bun run test:integration",
     "test:unit": "bun test --isolate src/tools/__tests__/ src/server/__tests__/ tests/storage/ tests/http/swagger/ tests/http/health/ tests/lifecycle/ tests/plugins/ src/vault/__tests__/ src/indexer/__tests__/ src/drizzle-migration.test.ts src/indexer-preservation.test.ts",
     "test:integration": "bun test --isolate src/integration/",
+    "test:e2e": "bunx --bun playwright test",
+    "test:ui-audit": "bunx --bun playwright test --config tests/ui-audit/playwright.config.ts",
     "test:integration:db": "bun test --isolate src/integration/database.test.ts",
     "test:integration:mcp": "bun test src/integration/mcp.test.ts",
     "test:integration:http": "bun test src/integration/http.test.ts",

--- a/tests/build/playwright-scope.test.ts
+++ b/tests/build/playwright-scope.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Playwright specs must not be run by bun's test runner.
+ *
+ * bun auto-discovers BOTH `*.test.ts` and `*.spec.ts`. Two Playwright files use
+ * the `.spec.ts` suffix on purpose — tests/e2e/contrast.spec.ts (named in
+ * playwright.config.ts `testMatch`) and tests/ui-audit/audit.spec.ts (its own
+ * config) — so bun picked them up and blew up on import:
+ *
+ *   bun test --isolate tests/e2e/       -> error: Playwright Test did not expect
+ *   bun test --isolate tests/ui-audit/     test.describe() to be called here.
+ *
+ * bunfig.toml's comment asserted the opposite ("bun's auto-discovery skips
+ * them"), and .github/workflows/test.yml:130 repeated it ("not picked up by bun
+ * test anyway"). Both were describing an intent, not the artifact. CI never
+ * caught it because tests/ui-audit/ is absent from the CI group list and
+ * tests/e2e/ is deliberately excluded.
+ *
+ * The fix is a spec-suffix glob in bunfig.toml's pathIgnorePatterns. That
+ * exclusion is only safe while no `.spec.ts` is a real bun test — this file is
+ * the guard on that.
+ */
+import { describe, expect, test } from 'bun:test';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const REPO_ROOT = join(import.meta.dir, '..', '..');
+const SKIP_DIRS = new Set(['node_modules', '.git', 'agents', 'dist', '.tmp']);
+
+function read(rel: string): string {
+  return readFileSync(join(REPO_ROOT, rel), 'utf-8');
+}
+
+/** Walk tests/ for *.spec.ts. Kept subprocess-free so the gate cannot depend on git. */
+function specFiles(dir = 'tests'): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(join(REPO_ROOT, dir), { withFileTypes: true })) {
+    if (SKIP_DIRS.has(entry.name)) continue;
+    const rel = `${dir}/${entry.name}`;
+    if (entry.isDirectory()) found.push(...specFiles(rel));
+    else if (entry.name.endsWith('.spec.ts')) found.push(rel);
+  }
+  return found;
+}
+
+/** playwright configs hold regex source, so `contrast\.spec\.ts` — drop the escapes. */
+function unescaped(rel: string): string {
+  return read(rel).replaceAll('\\', '');
+}
+
+describe('playwright specs stay out of the bun gate', () => {
+  test('bunfig.toml excludes *.spec.ts from bun test discovery', () => {
+    const raw = read('bunfig.toml');
+    expect(raw).toContain('**/*.spec.ts');
+  });
+
+  test('no *.spec.ts imports bun:test (the exclusion would hide a real test)', () => {
+    const usingBunTest = specFiles().filter((f) => /from ['"]bun:test['"]/.test(read(f)));
+    expect(usingBunTest).toEqual([]);
+  });
+
+  // The negative above is not enough on its own: a *.spec.ts importing NEITHER
+  // runner would pass it while being run by nothing at all — which is exactly
+  // the state tests/ui-audit/audit.spec.ts was in. Assert the positive too, so
+  // the exclusion only ever covers files a playwright runner actually claims.
+  test('every *.spec.ts imports @playwright/test', () => {
+    const specs = specFiles();
+    const notPlaywright = specs.filter((f) => !/from ['"]@playwright\/test['"]/.test(read(f)));
+    expect(notPlaywright).toEqual([]);
+  });
+
+  test('every *.spec.ts is claimed by a playwright config', () => {
+    const specs = specFiles();
+    expect(specs.length).toBeGreaterThan(0);
+
+    const rootConfig = unescaped('playwright.config.ts');
+    const uiAuditConfig = read('tests/ui-audit/playwright.config.ts');
+
+    for (const spec of specs) {
+      const base = spec.split('/').pop() ?? spec;
+      const claimed =
+        rootConfig.includes(base) ||
+        (spec.startsWith('tests/ui-audit/') && uiAuditConfig.includes('*.spec.ts'));
+      expect(claimed, `${spec} is run by no playwright config and no bun gate`).toBe(true);
+    }
+  });
+
+  test('the scripts bunfig.toml tells you to run actually exist', () => {
+    const pkg = JSON.parse(read('package.json')) as { scripts?: Record<string, string> };
+    const scripts = pkg.scripts ?? {};
+    // bunfig.toml says: "E2E tests use Playwright (run with: bun run test:e2e)".
+    // That script did not exist when the comment was written.
+    expect(Object.keys(scripts)).toContain('test:e2e');
+    expect(scripts['test:e2e']).toContain('playwright');
+  });
+
+  test('package.json repository url points at this repo, not its predecessor', () => {
+    const pkg = JSON.parse(read('package.json')) as { repository?: { url?: string } };
+    expect(pkg.repository?.url).toContain('arra-oracle-v3.git');
+  });
+});

--- a/tests/build/playwright-scope.test.ts
+++ b/tests/build/playwright-scope.test.ts
@@ -30,16 +30,27 @@ function read(rel: string): string {
   return readFileSync(join(REPO_ROOT, rel), 'utf-8');
 }
 
-/** Walk tests/ for *.spec.ts. Kept subprocess-free so the gate cannot depend on git. */
-function specFiles(dir = 'tests'): string[] {
+/**
+ * Walk for *.spec.ts. Kept subprocess-free so the gate cannot depend on git.
+ *
+ * BOTH bunfig roots, not just tests/. The exclusion glob is repo-wide, so a
+ * src/**-spec file would be silently skipped by bun AND invisible to this guard
+ * if we only walked tests/. Verified by planting src/rogue-probe.spec.ts
+ * importing bun:test: the tests/-only version stayed 6 pass / 0 fail.
+ */
+function walkSpecs(dir: string): string[] {
   const found: string[] = [];
   for (const entry of readdirSync(join(REPO_ROOT, dir), { withFileTypes: true })) {
     if (SKIP_DIRS.has(entry.name)) continue;
     const rel = `${dir}/${entry.name}`;
-    if (entry.isDirectory()) found.push(...specFiles(rel));
+    if (entry.isDirectory()) found.push(...walkSpecs(rel));
     else if (entry.name.endsWith('.spec.ts')) found.push(rel);
   }
   return found;
+}
+
+function specFiles(): string[] {
+  return ['src', 'tests'].flatMap(walkSpecs);
 }
 
 /** playwright configs hold regex source, so `contrast\.spec\.ts` — drop the escapes. */

--- a/tests/docs/claude-md-claims.test.ts
+++ b/tests/docs/claude-md-claims.test.ts
@@ -69,8 +69,12 @@ describe('test-layout claims match bunfig.toml', () => {
   });
 
   test('pathIgnorePatterns excludes agents/, and CLAUDE.md says why', () => {
-    // Removing this line is what let sibling worktrees run in every suite (#2825).
-    expect(bunfig).toContain('pathIgnorePatterns = ["**/agents/**"]');
+    // Removing this ENTRY is what let sibling worktrees run in every suite (#2825).
+    // Asserted by entry, not by the whole array literal: the list legitimately grows
+    // (a spec-suffix glob joined it in #2997), and pinning the literal made an
+    // unrelated addition fail this test while agents/ was still excluded.
+    const patterns = /pathIgnorePatterns\s*=\s*\[(.*?)\]/s.exec(bunfig)?.[1] ?? '';
+    expect(patterns).toContain('**/agents/**');
     expect(CLAUDE_MD).toContain('pathIgnorePatterns');
   });
 


### PR DESCRIPTION
## Three declared-but-not-wired defects, one root cause each

**1. `bunfig.toml` promised an exclusion it never implemented.** Its comment claimed
bun's auto-discovery skips the e2e suite — in the same sentence that names `*.spec.ts`
as a discovered pattern. Two tracked files sit in that hole:

| file | claimed by | actually run by |
|---|---|---|
| `tests/e2e/contrast.spec.ts` | `playwright.config.ts` `testMatch` | also picked up by bun → crash |
| `tests/ui-audit/audit.spec.ts` | its own `playwright.config.ts` | **nothing** — and bun → crash |

```
bun test --isolate tests/e2e/       → error: Playwright Test did not expect
bun test --isolate tests/ui-audit/    test.describe() to be called here.
```

`.github/workflows/test.yml:130` repeats the same false claim ("not picked up by bun test
anyway"). CI never caught it: `tests/e2e/` is deliberately excluded and **`tests/ui-audit/`
is in no CI group at all**.

**2. The escape hatch didn't exist.** That comment says to run `bun run test:e2e`. There
was no such script. Added `test:e2e` and `test:ui-audit`.

**3. `package.json:30` pointed at the wrong repository** — `arra-oracle-v2.git`. Release
tooling and install docs read that field, and there are **160 commits unreleased** since
`v26.7.26-alpha.227` (2026-07-25), so a cut today would have shipped it.

## The ratchet

`tests/build/playwright-scope.test.ts` asserts the exclusion stays *honest*, not merely
present: every `*.spec.ts` must import `@playwright/test` and none may import `bun:test`.
A future bun test named `*.spec.ts` therefore fails the gate instead of being silently
skipped — the failure mode the exclusion would otherwise introduce.

## Gate

```
bunx tsc --noEmit          exit 0
bun test --isolate tests/build/    77 pass / 0 fail
bun test --isolate tests/e2e/       4 pass / 0 fail   (was 4 pass / 1 error)
bun test --isolate src/          1002 pass / 0 fail
```

Full non-http sweep run locally: 35 directories, no exit 133, no regressions.

## Left alone deliberately

`package.json:14` still declares the legacy bin `"arra-oracle-v2": "./src/index.ts"`.
Removing an installed command name is user-facing and is a separate call.

Reviewed against an independent read by `arra-oracle-v3@m5-alpha` at the same commit,
which reached items 1–3 separately; the `@playwright/test` positive assertion in the
ratchet is its suggestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)