### PR TITLE
feat: add Oracle project memory retrieval integrity

### DIFF
--- a/src/indexer/__tests__/collect-projects.test.ts
+++ b/src/indexer/__tests__/collect-projects.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type { IndexerConfig } from '../../types.ts';
+import { collectPsiProjects } from '../collect-projects.ts';
+
+const tmpRoots: string[] = [];
+
+function config(repoRoot: string): IndexerConfig {
+  return {
+    repoRoot,
+    dbPath: ':memory:',
+    chromaPath: path.join(repoRoot, '.vectors'),
+    sourcePaths: {
+      resonance: 'ψ/memory/resonance',
+      learnings: 'ψ/memory/learnings',
+      retrospectives: 'ψ/memory/retrospectives',
+      distillations: 'ψ/memory/distillations',
+      learn: 'ψ/learn',
+      projects: 'ψ/projects',
+    },
+  };
+}
+
+afterEach(() => {
+  for (const root of tmpRoots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('collectPsiProjects', () => {
+  test('collects canonical project Markdown and rejects invalid/empty project files', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-projects-'));
+    tmpRoots.push(root);
+
+    fs.mkdirSync(path.join(root, 'ψ/projects/oracle'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'ψ/projects/client-alpha'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'ψ/projects/Bad_ID'), { recursive: true });
+
+    fs.writeFileSync(path.join(root, 'ψ/projects/README.md'), '# Projects\n\nContract.');
+    fs.writeFileSync(path.join(root, 'ψ/projects/oracle/context.md'), '# Context\n\nShared phrase.');
+    fs.writeFileSync(path.join(root, 'ψ/projects/client-alpha/context.md'), '# Context\n\nShared phrase.');
+    fs.writeFileSync(path.join(root, 'ψ/projects/Bad_ID/context.md'), '# Invalid\n\nDo not index.');
+    fs.writeFileSync(path.join(root, 'ψ/projects/oracle/empty.md'), '   \n');
+
+    const docs = collectPsiProjects({ config: config(root) });
+    const sourceFiles = new Set(docs.map((doc) => doc.source_file));
+
+    expect(sourceFiles.has('ψ/projects/README.md')).toBe(true);
+    expect(sourceFiles.has('ψ/projects/oracle/context.md')).toBe(true);
+    expect(sourceFiles.has('ψ/projects/client-alpha/context.md')).toBe(true);
+    expect(sourceFiles.has('ψ/projects/Bad_ID/context.md')).toBe(false);
+    expect(sourceFiles.has('ψ/projects/oracle/empty.md')).toBe(false);
+
+    const oracleDocs = docs.filter((doc) => doc.source_file === 'ψ/projects/oracle/context.md');
+    const clientDocs = docs.filter((doc) => doc.source_file === 'ψ/projects/client-alpha/context.md');
+    expect(oracleDocs.length).toBeGreaterThan(0);
+    expect(clientDocs.length).toBeGreaterThan(0);
+    expect(oracleDocs.every((doc) => doc.project === 'oracle')).toBe(true);
+    expect(clientDocs.every((doc) => doc.project === 'client-alpha')).toBe(true);
+  });
+
+  test('missing ψ/projects is a clean empty collection', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-projects-missing-'));
+    tmpRoots.push(root);
+    expect(collectPsiProjects({ config: config(root) })).toEqual([]);
+  });
+});

--- a/src/indexer/__tests__/collectors.test.ts
+++ b/src/indexer/__tests__/collectors.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { collectPsiLearn, getAllMarkdownFiles } from '../collectors.ts';
+import { collectPsiInbox } from '../collect-inbox.ts';
 
 describe('getAllMarkdownFiles', () => {
   test('skips broken symlinks instead of crashing on ENOENT', () => {
@@ -48,6 +49,46 @@ describe('getAllMarkdownFiles', () => {
       expect(docs).toHaveLength(1);
       expect(docs[0].source_file).toBe('github.com/Soul-Brews-Studio/demo/ψ/learn/codex/finding.md');
       expect(docs[0].project).toBe('github.com/soul-brews-studio/demo');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('collectPsiInbox', () => {
+  test('collects local ψ/inbox markdown as learning knowledge with inbox provenance', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-psi-inbox-'));
+    try {
+      const inboxDir = path.join(tmp, 'ψ', 'inbox', 'reports');
+      fs.mkdirSync(inboxDir, { recursive: true });
+
+      fs.writeFileSync(
+        path.join(inboxDir, 'oracle-report.md'),
+        '# Oracle Report\n\n## Lesson\n\ngate6inboxregressiontoken'
+      );
+
+      const docs = collectPsiInbox({
+        config: {
+          repoRoot: tmp,
+          dbPath: ':memory:',
+          chromaPath: '',
+          sourcePaths: {
+            resonance: 'ψ/memory/resonance',
+            learnings: 'ψ/memory/learnings',
+            retrospectives: 'ψ/memory/retrospectives',
+            distillations: 'ψ/memory/distillations',
+            learn: 'ψ/learn',
+            inbox: 'ψ/inbox',
+          },
+        },
+        seenContentHashes: new Set(),
+      });
+
+      expect(docs).toHaveLength(1);
+      expect(docs[0].type).toBe('learning');
+      expect(docs[0].source_file).toBe('ψ/inbox/reports/oracle-report.md');
+      expect(docs[0].id.startsWith('learning_psi_inbox_')).toBe(true);
+      expect(docs[0].content).toContain('gate6inboxregressiontoken');
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/src/indexer/__tests__/project-doc-source.test.ts
+++ b/src/indexer/__tests__/project-doc-source.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  isPsiProjectsSource,
+  parsePsiProjectFile,
+  projectIdFromProjectsSource,
+} from '../project-doc-source.ts';
+
+describe('ψ/projects source contract', () => {
+  test('derives canonical project id from nested project paths', () => {
+    expect(projectIdFromProjectsSource('ψ/projects/oracle/context.md')).toBe('oracle');
+    expect(projectIdFromProjectsSource('ψ/projects/client-alpha/research/note.md')).toBe('client-alpha');
+  });
+
+  test('indexes root README as universal learning documentation', () => {
+    const docs = parsePsiProjectFile('ψ/projects/README.md', '# Projects\n\nCanonical project contract.');
+    expect(docs.length).toBeGreaterThan(0);
+    expect(docs.every((doc) => doc.type === 'learning')).toBe(true);
+    expect(docs.every((doc) => doc.project === null)).toBe(true);
+    expect(docs.every((doc) => doc.source_file === 'ψ/projects/README.md')).toBe(true);
+  });
+
+  test('indexes valid project context with exact project metadata', () => {
+    const docs = parsePsiProjectFile(
+      'ψ/projects/oracle/context.md',
+      '# Oracle\n\nUnique project context phrase.'
+    );
+    expect(docs.length).toBeGreaterThan(0);
+    expect(docs.every((doc) => doc.type === 'learning')).toBe(true);
+    expect(docs.every((doc) => doc.project === 'oracle')).toBe(true);
+    expect(docs.every((doc) => doc.source_file === 'ψ/projects/oracle/context.md')).toBe(true);
+    expect(docs.every((doc) => doc.id.startsWith('learning_psi_project_'))).toBe(true);
+  });
+
+  test('rejects invalid or non-project paths instead of universalizing them', () => {
+    expect(parsePsiProjectFile('ψ/projects/Bad_ID/context.md', '# Bad')).toEqual([]);
+    expect(parsePsiProjectFile('ψ/projects/orphan.md', '# Orphan')).toEqual([]);
+    expect(parsePsiProjectFile('ψ/inbox/context.md', '# Other')).toEqual([]);
+    expect(isPsiProjectsSource('ψ/inbox/context.md')).toBe(false);
+  });
+
+  test('path-namespaced ids differ for identical text in different projects', () => {
+    const content = '# Shared\n\nIdentical text is still project-specific.';
+    const left = parsePsiProjectFile('ψ/projects/alpha/context.md', content);
+    const right = parsePsiProjectFile('ψ/projects/beta/context.md', content);
+    expect(left.length).toBeGreaterThan(0);
+    expect(right.length).toBeGreaterThan(0);
+    expect(left[0]?.id).not.toBe(right[0]?.id);
+    expect(left[0]?.project).toBe('alpha');
+    expect(right[0]?.project).toBe('beta');
+  });
+});

--- a/src/indexer/__tests__/project-watcher.test.ts
+++ b/src/indexer/__tests__/project-watcher.test.ts
@@ -1,0 +1,673 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import Database from 'bun:sqlite';
+import { startProjectWatcher } from '../project-watcher.ts';
+import { parsePsiProjectFile } from '../project-doc-source.ts';
+import { storeSqliteDocuments } from '../learn-doc-source.ts';
+
+const FULL_SCHEMA = `
+CREATE TABLE oracle_documents (
+  id TEXT PRIMARY KEY,
+  type TEXT NOT NULL,
+  source_file TEXT NOT NULL,
+  concepts TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  indexed_at INTEGER NOT NULL,
+  superseded_by TEXT,
+  superseded_at INTEGER,
+  superseded_reason TEXT,
+  origin TEXT,
+  project TEXT,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  created_by TEXT,
+  usage_count INTEGER NOT NULL DEFAULT 0,
+  last_accessed_at INTEGER
+);
+CREATE VIRTUAL TABLE oracle_fts USING fts5(id UNINDEXED, content, concepts, tokenize='porter unicode61');
+CREATE TABLE oracle_pointer_index (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  kind TEXT NOT NULL,
+  key TEXT NOT NULL,
+  doc_ids TEXT NOT NULL DEFAULT '[]',
+  updated_at INTEGER NOT NULL
+);
+CREATE TABLE indexing_jobs (
+  id TEXT PRIMARY KEY,
+  doc_id TEXT NOT NULL,
+  model_key TEXT NOT NULL,
+  collection TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  attempts INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')*1000),
+  claimed_at INTEGER,
+  finished_at INTEGER,
+  error TEXT
+);
+`;
+
+const MODELS = {
+  'bge-m3': { collection: 'oracle_knowledge_bge_m3' },
+  qwen3: { collection: 'oracle_knowledge_qwen3' },
+};
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(check: () => boolean, timeoutMs = 2_500): Promise<void> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    if (check()) return;
+    await wait(25);
+  }
+  throw new Error('timed out waiting for project watcher');
+}
+
+describe('startProjectWatcher', () => {
+  let repoRoot: string;
+  let db: Database;
+  let stop: (() => void) | undefined;
+
+  beforeEach(() => {
+    repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'project-watcher-'));
+    fs.mkdirSync(path.join(repoRoot, 'ψ', 'projects'), { recursive: true });
+    db = new Database(':memory:');
+    db.exec(FULL_SCHEMA);
+  });
+
+  afterEach(() => {
+    try { stop?.(); } catch {}
+    stop = undefined;
+    try { db.close(); } catch {}
+    try { fs.rmSync(repoRoot, { recursive: true, force: true }); } catch {}
+  });
+
+  it('auto-indexes a new canonical project Markdown file', async () => {
+    stop = startProjectWatcher({ db, models: MODELS, repoRoot, debounceMs: 20 });
+
+    const filePath = path.join(repoRoot, 'ψ', 'projects', 'oracle', 'context.md');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, '# Oracle\n\ngatefivefreshprojecttoken', 'utf8');
+
+    await waitFor(() => {
+      const row = db.query<{ count: number }, []>(
+        "SELECT COUNT(*) AS count FROM oracle_documents WHERE source_file='ψ/projects/oracle/context.md'"
+      ).get();
+      return (row?.count ?? 0) > 0;
+    });
+
+    const doc = db.query<{ project: string }, []>(
+      "SELECT project FROM oracle_documents WHERE source_file='ψ/projects/oracle/context.md'"
+    ).get();
+    expect(doc?.project).toBe('oracle');
+
+    const fts = db.query<{ count: number }, []>(
+      "SELECT COUNT(*) AS count FROM oracle_fts WHERE oracle_fts MATCH 'gatefivefreshprojecttoken'"
+    ).get();
+    expect(fts?.count).toBeGreaterThan(0);
+
+    const jobs = db.query<{ count: number }, []>(
+      'SELECT COUNT(*) AS count FROM indexing_jobs'
+    ).get();
+    expect(jobs?.count).toBe(Object.keys(MODELS).length);
+  });
+
+  it('refreshes FTS when an existing project file is edited', async () => {
+    const filePath = path.join(repoRoot, 'ψ', 'projects', 'oracle', 'context.md');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, '# Oracle\n\ngatefiveoldtoken', 'utf8');
+
+    storeSqliteDocuments(
+      db,
+      parsePsiProjectFile('ψ/projects/oracle/context.md', fs.readFileSync(filePath, 'utf8'))
+    );
+    stop = startProjectWatcher({ db, models: MODELS, repoRoot, debounceMs: 20 });
+    fs.writeFileSync(filePath, '# Oracle\n\ngatefivenewtoken', 'utf8');
+
+    await waitFor(() => {
+      const row = db.query<{ count: number }, []>(
+        "SELECT COUNT(*) AS count FROM oracle_fts WHERE oracle_fts MATCH 'gatefivenewtoken'"
+      ).get();
+      return (row?.count ?? 0) > 0;
+    });
+
+    const oldHit = db.query<{ count: number }, []>(
+      "SELECT COUNT(*) AS count FROM oracle_fts WHERE oracle_fts MATCH 'gatefiveoldtoken'"
+    ).get();
+    expect(oldHit?.count).toBe(0);
+
+    const doc = db.query<{ project: string }, []>(
+      "SELECT project FROM oracle_documents WHERE source_file='ψ/projects/oracle/context.md' AND superseded_at IS NULL"
+    ).get();
+    expect(doc?.project).toBe('oracle');
+  });
+
+  it('keeps ψ/projects/README.md universal on automatic refresh', async () => {
+    const filePath = path.join(repoRoot, 'ψ', 'projects', 'README.md');
+    fs.writeFileSync(filePath, '# Projects\n\ninitialreadmetoken', 'utf8');
+    storeSqliteDocuments(
+      db,
+      parsePsiProjectFile('ψ/projects/README.md', fs.readFileSync(filePath, 'utf8'))
+    );
+
+    stop = startProjectWatcher({ db, models: MODELS, repoRoot, debounceMs: 20 });
+    fs.writeFileSync(filePath, '# Projects\n\nupdatedreadmetoken', 'utf8');
+
+    await waitFor(() => {
+      const row = db.query<{ count: number }, []>(
+        "SELECT COUNT(*) AS count FROM oracle_fts WHERE oracle_fts MATCH 'updatedreadmetoken'"
+      ).get();
+      return (row?.count ?? 0) > 0;
+    });
+
+    const row = db.query<{ project: string | null }, []>(
+      "SELECT project FROM oracle_documents WHERE source_file='ψ/projects/README.md' AND superseded_at IS NULL"
+    ).get();
+    expect(row?.project).toBeNull();
+  });
+
+  it('fails closed for invalid project ids and ignores non-Markdown files', async () => {
+    stop = startProjectWatcher({ db, models: MODELS, repoRoot, debounceMs: 20 });
+
+    const invalid = path.join(repoRoot, 'ψ', 'projects', 'Bad_ID', 'context.md');
+    const nonMd = path.join(repoRoot, 'ψ', 'projects', 'oracle', 'note.txt');
+    fs.mkdirSync(path.dirname(invalid), { recursive: true });
+    fs.mkdirSync(path.dirname(nonMd), { recursive: true });
+    fs.writeFileSync(invalid, '# Invalid\n\nshouldnotindex', 'utf8');
+    fs.writeFileSync(nonMd, 'shouldnotindexeither', 'utf8');
+
+    await wait(400);
+    const docs = db.query<{ count: number }, []>(
+      'SELECT COUNT(*) AS count FROM oracle_documents'
+    ).get();
+    expect(docs?.count).toBe(0);
+  });
+
+  it('observes a project directory created after watcher startup', async () => {
+    stop = startProjectWatcher({ db, models: MODELS, repoRoot, debounceMs: 20 });
+    await wait(50);
+
+    const filePath = path.join(repoRoot, 'ψ', 'projects', 'client-alpha', 'research', 'note.md');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, '# Research\n\ndynamicprojecttreetoken', 'utf8');
+
+    await waitFor(() => {
+      const row = db.query<{ count: number }, []>(
+        "SELECT COUNT(*) AS count FROM oracle_documents WHERE project='client-alpha'"
+      ).get();
+      return (row?.count ?? 0) > 0;
+    });
+
+    const fts = db.query<{ count: number }, []>(
+      "SELECT COUNT(*) AS count FROM oracle_fts WHERE oracle_fts MATCH 'dynamicprojecttreetoken'"
+    ).get();
+    expect(fts?.count).toBeGreaterThan(0);
+  });
+
+  it('removes the indexed projection and queues vector cleanup when a project source disappears', async () => {
+    const filePath = path.join(repoRoot, 'ψ', 'projects', 'oracle', 'context.md');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, '# Oracle\n\ndeferreddeletiontoken', 'utf8');
+    storeSqliteDocuments(
+      db,
+      parsePsiProjectFile('ψ/projects/oracle/context.md', fs.readFileSync(filePath, 'utf8'))
+    );
+
+    const stored = db.query<{ id: string }, []>(
+      "SELECT id FROM oracle_documents WHERE source_file='ψ/projects/oracle/context.md' LIMIT 1"
+    ).get();
+    expect(stored?.id).toBeTruthy();
+
+    const pointersBefore = db.query<{ count: number }, [string]>(
+      "SELECT COUNT(*) AS count FROM oracle_pointer_index WHERE doc_ids LIKE ?"
+    ).get(`%${stored!.id}%`);
+    expect(pointersBefore?.count).toBeGreaterThan(0);
+
+    stop = startProjectWatcher({ db, models: MODELS, repoRoot, debounceMs: 20 });
+    fs.unlinkSync(filePath);
+    await wait(300);
+
+    const docs = db.query<{ count: number }, []>(
+      "SELECT COUNT(*) AS count FROM oracle_documents WHERE source_file='ψ/projects/oracle/context.md'"
+    ).get();
+    expect(docs?.count).toBe(0);
+
+    const fts = db.query<{ count: number }, []>(
+      "SELECT COUNT(*) AS count FROM oracle_fts WHERE oracle_fts MATCH 'deferreddeletiontoken'"
+    ).get();
+    expect(fts?.count).toBe(0);
+
+    const cleanupJobs = db.query<{ count: number }, []>(
+      "SELECT COUNT(*) AS count FROM indexing_jobs"
+    ).get();
+    expect(cleanupJobs?.count).toBeGreaterThan(0);
+
+    const pointersAfter = db.query<{ count: number }, [string]>(
+      "SELECT COUNT(*) AS count FROM oracle_pointer_index WHERE doc_ids LIKE ?"
+    ).get(`%${stored!.id}%`);
+    expect(pointersAfter?.count).toBe(0);
+  });
+
+  it('reconciles a pre-existing stale project source on startup', async () => {
+    const sourceFile = 'ψ/projects/oracle/offline-delete.md';
+
+    // Seed the derived index as if this source existed before shutdown.
+    // Deliberately NEVER create the file on disk, so no filesystem deletion
+    // event can make this test pass accidentally.
+    storeSqliteDocuments(
+      db,
+      parsePsiProjectFile(
+        sourceFile,
+        '# Oracle\n\ngate6offlinedeletetoken'
+      )
+    );
+
+    const stored = db.query<{ id: string }, []>(
+      "SELECT id FROM oracle_documents WHERE source_file='ψ/projects/oracle/offline-delete.md' LIMIT 1"
+    ).get();
+    expect(stored?.id).toBeTruthy();
+
+    stop = startProjectWatcher({ db, models: MODELS, repoRoot, debounceMs: 20 });
+    await wait(100);
+
+    const docs = db.query<{ count: number }, []>(
+      "SELECT COUNT(*) AS count FROM oracle_documents WHERE source_file='ψ/projects/oracle/offline-delete.md'"
+    ).get();
+    expect(docs?.count).toBe(0);
+
+    const fts = db.query<{ count: number }, []>(
+      "SELECT COUNT(*) AS count FROM oracle_fts WHERE oracle_fts MATCH 'gate6offlinedeletetoken'"
+    ).get();
+    expect(fts?.count).toBe(0);
+
+    const cleanupJobs = db.query<{ count: number }, [string]>(
+      "SELECT COUNT(*) AS count FROM indexing_jobs WHERE doc_id = ?"
+    ).get(stored!.id);
+    expect(cleanupJobs?.count).toBeGreaterThan(0);
+  });
+
+  it('reconciles a project rename that happened while the watcher was stopped', async () => {
+    const oldSource = 'ψ/projects/oracle/offline-old.md';
+    const newSource = 'ψ/projects/oracle/offline-new.md';
+    const newPath = path.join(repoRoot, newSource);
+
+    // Derived DB state still reflects the old filename from before shutdown.
+    storeSqliteDocuments(
+      db,
+      parsePsiProjectFile(
+        oldSource,
+        '# Oracle\n\ngate6offlinerenametoken'
+      )
+    );
+
+    const oldStored = db.query<{ id: string }, []>(
+      "SELECT id FROM oracle_documents WHERE source_file='ψ/projects/oracle/offline-old.md' LIMIT 1"
+    ).get();
+    expect(oldStored?.id).toBeTruthy();
+
+    // Simulate the filesystem after an offline rename:
+    // old path is absent, new path already exists before watcher startup.
+    fs.mkdirSync(path.dirname(newPath), { recursive: true });
+    fs.writeFileSync(newPath, '# Oracle\n\ngate6offlinerenametoken', 'utf8');
+
+    stop = startProjectWatcher({ db, models: MODELS, repoRoot, debounceMs: 20 });
+    await wait(100);
+
+    const oldDocs = db.query<{ count: number }, []>(
+      "SELECT COUNT(*) AS count FROM oracle_documents WHERE source_file='ψ/projects/oracle/offline-old.md'"
+    ).get();
+    expect(oldDocs?.count).toBe(0);
+
+    const newDocs = db.query<{ count: number }, []>(
+      "SELECT COUNT(*) AS count FROM oracle_documents WHERE source_file='ψ/projects/oracle/offline-new.md'"
+    ).get();
+    expect(newDocs?.count).toBeGreaterThan(0);
+
+    const newStored = db.query<{ id: string }, []>(
+      "SELECT id FROM oracle_documents WHERE source_file='ψ/projects/oracle/offline-new.md' LIMIT 1"
+    ).get();
+    expect(newStored?.id).toBeTruthy();
+    expect(newStored?.id).not.toBe(oldStored!.id);
+
+    const fts = db.query<{ count: number }, []>(
+      "SELECT COUNT(*) AS count FROM oracle_fts WHERE oracle_fts MATCH 'gate6offlinerenametoken'"
+    ).get();
+    expect(fts?.count).toBeGreaterThan(0);
+
+    const cleanupJobs = db.query<{ count: number }, [string]>(
+      "SELECT COUNT(*) AS count FROM indexing_jobs WHERE doc_id = ?"
+    ).get(oldStored!.id);
+    expect(cleanupJobs?.count).toBeGreaterThan(0);
+  });
+
+  it('reconciles a project Markdown rename to the new canonical source path', async () => {
+    const oldPath = path.join(repoRoot, 'ψ', 'projects', 'oracle', 'context.md');
+    const newPath = path.join(repoRoot, 'ψ', 'projects', 'oracle', 'context-renamed.md');
+    fs.mkdirSync(path.dirname(oldPath), { recursive: true });
+    fs.writeFileSync(oldPath, '# Oracle\n\ngate6renametoken', 'utf8');
+
+    storeSqliteDocuments(
+      db,
+      parsePsiProjectFile(
+        'ψ/projects/oracle/context.md',
+        fs.readFileSync(oldPath, 'utf8')
+      )
+    );
+
+    const oldStored = db.query<{ id: string }, []>(
+      "SELECT id FROM oracle_documents WHERE source_file='ψ/projects/oracle/context.md' LIMIT 1"
+    ).get();
+    expect(oldStored?.id).toBeTruthy();
+
+    stop = startProjectWatcher({ db, models: MODELS, repoRoot, debounceMs: 20 });
+    await wait(50);
+
+    fs.renameSync(oldPath, newPath);
+    await wait(800);
+
+    const oldDocs = db.query<{ count: number }, []>(
+      "SELECT COUNT(*) AS count FROM oracle_documents WHERE source_file='ψ/projects/oracle/context.md'"
+    ).get();
+    expect(oldDocs?.count).toBe(0);
+
+    const newDocs = db.query<{ count: number }, []>(
+      "SELECT COUNT(*) AS count FROM oracle_documents WHERE source_file='ψ/projects/oracle/context-renamed.md'"
+    ).get();
+    expect(newDocs?.count).toBeGreaterThan(0);
+
+    const newStored = db.query<{ id: string }, []>(
+      "SELECT id FROM oracle_documents WHERE source_file='ψ/projects/oracle/context-renamed.md' LIMIT 1"
+    ).get();
+    expect(newStored?.id).toBeTruthy();
+    expect(newStored?.id).not.toBe(oldStored!.id);
+
+    const fts = db.query<{ count: number }, []>(
+      "SELECT COUNT(*) AS count FROM oracle_fts WHERE oracle_fts MATCH 'gate6renametoken'"
+    ).get();
+    expect(fts?.count).toBeGreaterThan(0);
+
+    const cleanupJobs = db.query<{ count: number }, [string]>(
+      "SELECT COUNT(*) AS count FROM indexing_jobs WHERE doc_id = ?"
+    ).get(oldStored!.id);
+    expect(cleanupJobs?.count).toBeGreaterThan(0);
+  });
+
+  it('does not create duplicate active rows across repeated edits and restart', async () => {
+    const filePath = path.join(repoRoot, 'ψ', 'projects', 'oracle', 'duplicate-check.md');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+
+    stop = startProjectWatcher({ db, models: MODELS, repoRoot, debounceMs: 20 });
+
+    fs.writeFileSync(filePath, '# Oracle\n\ngate6duptoken1', 'utf8');
+    await waitFor(() => {
+      const row = db.query<{ count: number }, []>(
+        "SELECT COUNT(*) AS count FROM oracle_fts WHERE oracle_fts MATCH 'gate6duptoken1'"
+      ).get();
+      return (row?.count ?? 0) > 0;
+    });
+
+    fs.writeFileSync(filePath, '# Oracle\n\ngate6duptoken2', 'utf8');
+    await waitFor(() => {
+      const row = db.query<{ count: number }, []>(
+        "SELECT COUNT(*) AS count FROM oracle_fts WHERE oracle_fts MATCH 'gate6duptoken2'"
+      ).get();
+      return (row?.count ?? 0) > 0;
+    });
+
+    fs.writeFileSync(filePath, '# Oracle\n\ngate6duptoken3', 'utf8');
+    await waitFor(() => {
+      const row = db.query<{ count: number }, []>(
+        "SELECT COUNT(*) AS count FROM oracle_fts WHERE oracle_fts MATCH 'gate6duptoken3'"
+      ).get();
+      return (row?.count ?? 0) > 0;
+    });
+
+    // Simulate daemon restart after repeated live edits.
+    stop();
+    stop = undefined;
+
+    stop = startProjectWatcher({ db, models: MODELS, repoRoot, debounceMs: 20 });
+    await wait(100);
+
+    const active = db.query<{ count: number; distinct_ids: number }, []>(
+      `SELECT
+         COUNT(*) AS count,
+         COUNT(DISTINCT id) AS distinct_ids
+       FROM oracle_documents
+       WHERE source_file='ψ/projects/oracle/duplicate-check.md'
+         AND superseded_at IS NULL`
+    ).get();
+
+    expect(active?.count).toBe(1);
+    expect(active?.distinct_ids).toBe(1);
+
+    const currentFts = db.query<{ count: number }, []>(
+      `SELECT COUNT(*) AS count
+       FROM oracle_fts
+       JOIN oracle_documents
+         ON oracle_documents.id = oracle_fts.id
+       WHERE oracle_documents.source_file='ψ/projects/oracle/duplicate-check.md'
+         AND oracle_documents.superseded_at IS NULL
+         AND oracle_fts MATCH 'gate6duptoken3'`
+    ).get();
+
+    expect(currentFts?.count).toBe(1);
+  });
+
+  it('supersedes stale chunk generations when an edit collapses a multi-chunk source', async () => {
+    const projectDir = path.join(repoRoot, 'ψ', 'projects', 'oracle');
+    const filePath = path.join(projectDir, 'chunk-lifecycle.md');
+    fs.mkdirSync(projectDir, { recursive: true });
+
+    stop = startProjectWatcher({ db, models: MODELS, repoRoot, debounceMs: 20 });
+    await wait(50);
+
+    const paragraph = (token: string, fill: string) =>
+      `${token} ${fill.repeat(650)}`;
+
+    const initialContent = [
+      '# Chunk Lifecycle',
+      '',
+      paragraph('gate6chunkoldalpha', 'a'),
+      '',
+      paragraph('gate6chunkoldbeta', 'b'),
+      '',
+      paragraph('gate6chunkoldgamma', 'c'),
+    ].join('\n');
+
+    fs.writeFileSync(filePath, initialContent, 'utf8');
+
+    await waitFor(() => {
+      const row = db.query<{ count: number }, []>(
+        `SELECT COUNT(*) AS count
+         FROM oracle_documents
+         WHERE source_file='ψ/projects/oracle/chunk-lifecycle.md'
+           AND superseded_at IS NULL`
+      ).get();
+      return (row?.count ?? 0) === 3;
+    });
+
+    const initialRows = db.query<{ id: string }, []>(
+      `SELECT id
+       FROM oracle_documents
+       WHERE source_file='ψ/projects/oracle/chunk-lifecycle.md'
+         AND superseded_at IS NULL
+       ORDER BY id`
+    ).all();
+
+    expect(initialRows).toHaveLength(3);
+    expect(initialRows.every((row) => row.id.includes('__chunk_'))).toBe(true);
+
+    fs.writeFileSync(
+      filePath,
+      '# Chunk Lifecycle\n\ngate6chunkcurrenttoken',
+      'utf8'
+    );
+
+    await waitFor(() => {
+      const row = db.query<{ count: number }, []>(
+        `SELECT COUNT(*) AS count
+         FROM oracle_fts
+         JOIN oracle_documents
+           ON oracle_documents.id = oracle_fts.id
+         WHERE oracle_documents.source_file='ψ/projects/oracle/chunk-lifecycle.md'
+           AND oracle_documents.superseded_at IS NULL
+           AND oracle_fts MATCH 'content:gate6chunkcurrenttoken'`
+      ).get();
+      return (row?.count ?? 0) === 1;
+    });
+
+    const rows = db.query<
+      { id: string; superseded_at: number | null; superseded_by: string | null },
+      []
+    >(
+      `SELECT id, superseded_at, superseded_by
+       FROM oracle_documents
+       WHERE source_file='ψ/projects/oracle/chunk-lifecycle.md'
+       ORDER BY id`
+    ).all();
+
+    const active = rows.filter((row) => row.superseded_at === null);
+    const stale = rows.filter((row) => row.superseded_at !== null);
+
+    expect(active).toHaveLength(1);
+    expect(stale).toHaveLength(3);
+    expect(active[0].id.includes('__chunk_')).toBe(false);
+
+    expect(stale.map((row) => row.id).sort()).toEqual(
+      initialRows.map((row) => row.id).sort()
+    );
+    expect(stale.every((row) => row.superseded_by === active[0].id)).toBe(true);
+
+    // P-001: historical superseded chunks remain in raw searchable history.
+    const historicalFts = db.query<{ count: number }, []>(
+      `SELECT COUNT(*) AS count
+       FROM oracle_fts
+       WHERE oracle_fts MATCH 'content:gate6chunkoldalpha'`
+    ).get();
+    expect(historicalFts?.count).toBe(1);
+
+    // But historical chunks are no longer part of the active projection.
+    const activeHistoricalFts = db.query<{ count: number }, []>(
+      `SELECT COUNT(*) AS count
+       FROM oracle_fts
+       JOIN oracle_documents
+         ON oracle_documents.id = oracle_fts.id
+       WHERE oracle_documents.source_file='ψ/projects/oracle/chunk-lifecycle.md'
+         AND oracle_documents.superseded_at IS NULL
+         AND oracle_fts MATCH 'content:gate6chunkoldalpha'`
+    ).get();
+    expect(activeHistoricalFts?.count).toBe(0);
+
+    const currentFts = db.query<{ count: number }, []>(
+      `SELECT COUNT(*) AS count
+       FROM oracle_fts
+       JOIN oracle_documents
+         ON oracle_documents.id = oracle_fts.id
+       WHERE oracle_documents.source_file='ψ/projects/oracle/chunk-lifecycle.md'
+         AND oracle_documents.superseded_at IS NULL
+         AND oracle_fts MATCH 'content:gate6chunkcurrenttoken'`
+    ).get();
+    expect(currentFts?.count).toBe(1);
+  });
+
+  it('keeps identical knowledge distinct across different projects', async () => {
+    const alphaDir = path.join(repoRoot, 'ψ', 'projects', 'client-alpha');
+    const betaDir = path.join(repoRoot, 'ψ', 'projects', 'client-beta');
+    fs.mkdirSync(alphaDir, { recursive: true });
+    fs.mkdirSync(betaDir, { recursive: true });
+
+    stop = startProjectWatcher({ db, models: MODELS, repoRoot, debounceMs: 20 });
+    await wait(50);
+
+    const sharedContent = '# Shared Research\n\ngate6crossprojectsharedtoken';
+
+    fs.writeFileSync(path.join(alphaDir, 'research.md'), sharedContent, 'utf8');
+    fs.writeFileSync(path.join(betaDir, 'research.md'), sharedContent, 'utf8');
+
+    await waitFor(() => {
+      const row = db.query<{ count: number }, []>(
+        `SELECT COUNT(*) AS count
+         FROM oracle_documents
+         WHERE source_file IN (
+           'ψ/projects/client-alpha/research.md',
+           'ψ/projects/client-beta/research.md'
+         )
+         AND superseded_at IS NULL`
+      ).get();
+      return (row?.count ?? 0) === 2;
+    });
+
+    const rows = db.query<
+      { id: string; project: string; source_file: string },
+      []
+    >(
+      `SELECT id, project, source_file
+       FROM oracle_documents
+       WHERE source_file IN (
+         'ψ/projects/client-alpha/research.md',
+         'ψ/projects/client-beta/research.md'
+       )
+       AND superseded_at IS NULL
+       ORDER BY project`
+    ).all();
+
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.project)).toEqual(['client-alpha', 'client-beta']);
+    expect(rows[0].id).not.toBe(rows[1].id);
+
+    const fts = db.query<{ count: number }, []>(
+      `SELECT COUNT(*) AS count
+       FROM oracle_fts
+       JOIN oracle_documents
+         ON oracle_documents.id = oracle_fts.id
+       WHERE oracle_documents.superseded_at IS NULL
+         AND oracle_documents.project IN ('client-alpha', 'client-beta')
+         AND oracle_fts MATCH 'gate6crossprojectsharedtoken'`
+    ).get();
+
+    expect(fts?.count).toBe(2);
+  });
+
+  it('fails closed when a project Markdown symlink resolves outside ψ/projects', async () => {
+    const projectDir = path.join(repoRoot, 'ψ', 'projects', 'oracle');
+    fs.mkdirSync(projectDir, { recursive: true });
+
+    stop = startProjectWatcher({ db, models: MODELS, repoRoot, debounceMs: 20 });
+    await wait(50);
+
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'project-watcher-outside-'));
+    const outsideFile = path.join(outsideDir, 'outside.md');
+    fs.writeFileSync(outsideFile, '# Outside\n\ngate6symlinkescapetoken', 'utf8');
+
+    const linkPath = path.join(
+      repoRoot,
+      'ψ',
+      'projects',
+      'oracle',
+      'linked-outside.md',
+    );
+
+    fs.mkdirSync(path.dirname(linkPath), { recursive: true });
+    fs.symlinkSync(outsideFile, linkPath);
+
+    await wait(400);
+
+    const docs = db.query<{ count: number }, []>(
+      "SELECT COUNT(*) AS count FROM oracle_documents WHERE source_file='ψ/projects/oracle/linked-outside.md'"
+    ).get();
+
+    const fts = db.query<{ count: number }, []>(
+      "SELECT COUNT(*) AS count FROM oracle_fts WHERE oracle_fts MATCH 'gate6symlinkescapetoken'"
+    ).get();
+
+    expect(docs?.count).toBe(0);
+    expect(fts?.count).toBe(0);
+
+    fs.rmSync(outsideDir, { recursive: true, force: true });
+  });
+});

--- a/src/indexer/__tests__/worker-harness.ts
+++ b/src/indexer/__tests__/worker-harness.ts
@@ -37,6 +37,7 @@ export interface TestHarness {
   db: Database;
   embedded: Array<{ model: string; text: string }>;
   upserted: Array<{ collection: string; docId: string; vectorLen: number }>;
+  deleted?: Array<{ collection: string; docId: string }>;
   events: WorkerEvent[];
   shutdownAfter: number;  // signal shutdown after this many job iterations
 }
@@ -57,6 +58,11 @@ export function makeDeps(harness: TestHarness, overrides: Partial<WorkerDeps> = 
     },
     upsertVector: async (collection, docId, vector) => {
       harness.upserted.push({ collection, docId, vectorLen: vector.length });
+    },
+    deleteVector: async (modelKey, docId) => {
+      const model = MODELS[modelKey as keyof typeof MODELS];
+      const collection = model?.collection ?? modelKey;
+      harness.deleted?.push({ collection, docId });
     },
     isShuttingDown: () => {
       iterations++;

--- a/src/indexer/__tests__/worker.test.ts
+++ b/src/indexer/__tests__/worker.test.ts
@@ -131,17 +131,27 @@ describe('runWorker — error paths', () => {
 });
 
 describe('runWorker — doc-missing graceful handling', () => {
-  it('marks job done (no embed/upsert) when doc text is null', async () => {
+  it('deletes the stale vector and marks job done when doc text is null', async () => {
     const db = freshDb();
     enqueueIndexJob(db, { docId: 'doc-deleted', models: MODELS });
 
-    const harness: TestHarness = { db, embedded: [], upserted: [], events: [], shutdownAfter: 2 };
+    const harness: TestHarness = {
+      db,
+      embedded: [],
+      upserted: [],
+      deleted: [],
+      events: [],
+      shutdownAfter: 2,
+    };
     const stats = await runWorker('bge-m3', makeDeps(harness));
 
     expect(stats.processed).toBe(1);
     expect(stats.errors).toBe(0);
-    expect(harness.embedded).toHaveLength(0);  // no embed call
+    expect(harness.embedded).toHaveLength(0);
     expect(harness.upserted).toHaveLength(0);
+    expect(harness.deleted).toEqual([
+      { collection: 'oracle_knowledge_bge_m3', docId: 'doc-deleted' },
+    ]);
 
     const row = db.query('SELECT status FROM indexing_jobs').get() as { status: string };
     expect(row.status).toBe('done');

--- a/src/indexer/cli.ts
+++ b/src/indexer/cli.ts
@@ -40,6 +40,7 @@ export function createIndexerConfig(repoRootOverride = process.env.ORACLE_REPO_R
       retrospectives: '\u03c8/memory/retrospectives',
       distillations: '\u03c8/memory/distillations',
       learn: '\u03c8/learn',
+      projects: '\u03c8/projects',
       // Opt-in: set ORACLE_INDEX_SECURITY_CORPUS=1 to include \u03c8/learn/security-corpus/.
       // Default OFF because the corpus has ~36k files (one-time index ~10-30 min).
       security_corpus: process.env.ORACLE_INDEX_SECURITY_CORPUS === '1'

--- a/src/indexer/collect-projects.ts
+++ b/src/indexer/collect-projects.ts
@@ -1,0 +1,86 @@
+/**
+ * Bulk collector for canonical Oracle work-project context under `ψ/projects/`.
+ *
+ * Unlike fleet inbox copies, project documents are deliberately NOT deduplicated
+ * by content hash. Project identity and source path are semantic: two projects
+ * may legitimately carry identical wording and both must remain retrievable.
+ */
+import fs from 'fs';
+import path from 'path';
+import type { IndexerConfig, OracleDocument } from '../types.ts';
+import { getAllMarkdownFiles } from './collectors.ts';
+import {
+  PSI_PROJECTS_REL,
+  isPsiProjectsSource,
+  parsePsiProjectFile,
+} from './project-doc-source.ts';
+
+function isWithin(realRoot: string, realFile: string): boolean {
+  const rel = path.relative(realRoot, realFile);
+  return rel === '' || (!rel.startsWith('..' + path.sep) && rel !== '..' && !path.isAbsolute(rel));
+}
+
+export function collectPsiProjects(opts: {
+  config: IndexerConfig;
+}): OracleDocument[] {
+  const { config } = opts;
+  const subPath = config.sourcePaths.projects ?? PSI_PROJECTS_REL;
+  const sourceRoot = path.join(config.repoRoot, subPath);
+  if (!fs.existsSync(sourceRoot)) return [];
+
+  let realRoot: string;
+  try {
+    realRoot = fs.realpathSync(sourceRoot);
+  } catch {
+    return [];
+  }
+
+  const documents: OracleDocument[] = [];
+  const files = getAllMarkdownFiles(sourceRoot);
+  let skippedOutsideRoot = 0;
+  let skippedInvalid = 0;
+  let skippedEmpty = 0;
+
+  for (const filePath of files) {
+    let realFile: string;
+    try {
+      realFile = fs.realpathSync(filePath);
+    } catch {
+      continue;
+    }
+    if (!isWithin(realRoot, realFile)) {
+      skippedOutsideRoot++;
+      continue;
+    }
+
+    const relPath = path.relative(config.repoRoot, filePath).split(path.sep).join('/');
+    if (!isPsiProjectsSource(relPath)) {
+      skippedInvalid++;
+      continue;
+    }
+
+    let content: string;
+    try {
+      content = fs.readFileSync(filePath, 'utf-8');
+    } catch {
+      continue;
+    }
+    if (!content.trim()) {
+      skippedEmpty++;
+      continue;
+    }
+
+    const parsed = parsePsiProjectFile(relPath, content);
+    if (parsed.length === 0) {
+      skippedInvalid++;
+      continue;
+    }
+    documents.push(...parsed);
+  }
+
+  console.log(
+    `Indexed ${documents.length} ψ/projects documents from ${files.length} files ` +
+    `(skipped ${skippedInvalid} invalid, ${skippedEmpty} empty, ${skippedOutsideRoot} outside-root)`
+  );
+  return documents;
+}

--- a/src/indexer/daemon.ts
+++ b/src/indexer/daemon.ts
@@ -22,6 +22,7 @@ import { runWorker, type WorkerEvent } from './worker.ts';
 import { makeUpsertVector } from './upsert-vector.ts';
 import { daemonApiPlugin, makeEventBus } from '../routes/indexer-daemon/index.ts';
 import { startLearnWatcher, type StopWatch } from './learn-watcher.ts';
+import { startProjectWatcher } from './project-watcher.ts';
 
 const PORT = parseInt(process.env.INDEXER_PORT || '47779', 10);
 const HOST = process.env.INDEXER_HOST || '127.0.0.1';
@@ -35,6 +36,7 @@ export async function startDaemon(): Promise<void> {
   const eventBus = makeEventBus<WorkerEvent>();
   let shuttingDown = false;
   let stopLearnWatcher: StopWatch | undefined;
+  let stopProjectWatcher: StopWatch | undefined;
 
   // Resolve doc text via the FTS5 mirror table — same content oracle_learn writes.
   const getDocText = (docId: string): string | null => {
@@ -76,6 +78,14 @@ export async function startDaemon(): Promise<void> {
   // because it is untestable from here — that is why #2806 survived on both branches.
   const upsertVector = makeUpsertVector({ models, getStore });
 
+  const deleteVector = async (modelKey: string, docId: string): Promise<void> => {
+    const store = await getStore(modelKey);
+    if (!store.deleteDocuments) {
+      throw new Error(`Vector store for ${modelKey} does not support document deletion`);
+    }
+    await store.deleteDocuments([docId]);
+  };
+
   const workerPromises: Promise<unknown>[] = [];
   for (const modelKey of Object.keys(models)) {
     const p = runWorker(modelKey, {
@@ -83,6 +93,7 @@ export async function startDaemon(): Promise<void> {
       getDocText,
       embed,
       upsertVector,
+      deleteVector,
       isShuttingDown: () => shuttingDown,
       onEvent: eventBus.publish,
       pollIntervalMs: 1000,
@@ -116,12 +127,19 @@ export async function startDaemon(): Promise<void> {
     models,
     repoRoot: REPO_ROOT,
   });
+  stopProjectWatcher = startProjectWatcher({
+    db: sqlite,
+    models,
+    repoRoot: REPO_ROOT,
+  });
 
   const shutdown = async (signal: string) => {
     console.log(`[arra-indexer] ${signal} — draining…`);
     shuttingDown = true;
     stopLearnWatcher?.();
     stopLearnWatcher = undefined;
+    stopProjectWatcher?.();
+    stopProjectWatcher = undefined;
     await app.stop();
     // Workers exit on next loop tick. Give them up to 5s of in-flight grace.
     const timeout = new Promise((resolve) => setTimeout(resolve, 5000));

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -28,6 +28,7 @@ import { parseResonanceFile, parseLearningFile, parseRetroFile, parseDistillatio
 import { getEmbeddingModels } from '../vector/factory.ts';
 import { collectDocuments, collectPsiLearn, collectSecurityCorpus } from './collectors.ts';
 import { collectPsiInbox } from './collect-inbox.ts';
+import { collectPsiProjects } from './collect-projects.ts';
 import {
   changedDocumentIds,
   enqueueVectorReindexJobs,
@@ -101,6 +102,7 @@ export class OracleIndexer {
       ...collectDocuments({ ...shared, subdir: 'distillations', parseFn: parseDistillationFile, label: 'distillation' }),
       ...collectPsiLearn(shared),
       ...collectPsiInbox(shared),
+      ...collectPsiProjects({ config: this.config }),
       ...collectSecurityCorpus(shared),
     ];
 

--- a/src/indexer/project-doc-source.ts
+++ b/src/indexer/project-doc-source.ts
@@ -1,0 +1,77 @@
+/**
+ * Indexing helpers for canonical Oracle work-project context under `ψ/projects/`.
+ *
+ * Project files reuse OracleDocument type `learning` rather than widening the
+ * closed document-type union. Their durable discriminator is `source_file`.
+ *
+ * Canonical project identity is derived only from:
+ *   recursive Markdown files under ψ/projects/<project-id>/
+ * where project-id matches lowercase-hyphenated Oracle project ids (<=64 chars).
+ *
+ * `ψ/projects/README.md` is indexed as universal project-contract documentation
+ * with project=null. Invalid project directories fail closed and are not indexed.
+ */
+import path from 'path';
+import type { OracleDocument } from '../types.ts';
+import { parseLearningFile } from './parser.ts';
+
+export const PSI_PROJECTS_REL = path.join('ψ', 'projects');
+const PROJECT_ID_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const PROJECT_ID_MAX = 64;
+
+function normalizeSource(sourceFile: string): string {
+  return sourceFile.split(path.sep).join('/');
+}
+
+export function isPsiProjectsSource(sourceFile: string): boolean {
+  const normalized = normalizeSource(sourceFile);
+  return normalized === 'ψ/projects/README.md' || normalized.startsWith('ψ/projects/');
+}
+
+export function projectIdFromProjectsSource(sourceFile: string): string | null {
+  const normalized = normalizeSource(sourceFile);
+  if (normalized === 'ψ/projects/README.md') return null;
+  if (!normalized.startsWith('ψ/projects/')) return null;
+
+  const rest = normalized.slice('ψ/projects/'.length);
+  const parts = rest.split('/');
+  if (parts.length < 2) return null;
+
+  const candidate = parts[0] ?? '';
+  if (
+    candidate.length === 0 ||
+    candidate.length > PROJECT_ID_MAX ||
+    !PROJECT_ID_RE.test(candidate)
+  ) return null;
+
+  return candidate;
+}
+
+function projectDocId(pathHash: string, id: string): string {
+  const suffix = id
+    .replace(/^learning_/, '')
+    .replace(/[^a-zA-Z0-9._-]+/g, '-')
+    .replace(/^[._-]+|[._-]+$/g, '');
+  return `learning_psi_project_${pathHash}_${suffix || 'doc'}`;
+}
+
+export function parsePsiProjectFile(relativePath: string, content: string): OracleDocument[] {
+  const sourceFile = normalizeSource(relativePath);
+  if (!isPsiProjectsSource(sourceFile)) return [];
+
+  const isRootReadme = sourceFile === 'ψ/projects/README.md';
+  const project = projectIdFromProjectsSource(sourceFile);
+
+  if (!isRootReadme && project === null) return [];
+
+  const basename = path.basename(sourceFile);
+  const pathHash = Bun.hash(sourceFile).toString(36);
+
+  return parseLearningFile(basename, content, sourceFile).map((doc) => ({
+    ...doc,
+    id: projectDocId(pathHash, doc.id),
+    type: 'learning',
+    source_file: sourceFile,
+    project,
+  }));
+}

--- a/src/indexer/project-watcher.ts
+++ b/src/indexer/project-watcher.ts
@@ -1,0 +1,308 @@
+/**
+ * Auto-index canonical Oracle project documents under `ψ/projects/`.
+ *
+ * Canonical project watcher:
+ * - new Markdown files are stored into SQLite/FTS and queued for vector work;
+ * - edits replace current content and supersede stale chunk ids;
+ * - deleted Markdown sources remove their derived index projection and queue
+ *   vector cleanup;
+ * - invalid project ids, non-Markdown files, and paths outside the canonical
+ *   projects root fail closed.
+ */
+import fs from 'fs';
+import path from 'path';
+import type Database from 'bun:sqlite';
+import { and, count, eq, inArray, isNull, type SQL } from 'drizzle-orm';
+import { drizzle, type BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
+import * as schema from '../db/schema.ts';
+import { REPO_ROOT } from '../config.ts';
+import { enqueueIndexJob } from './jobs.ts';
+import {
+  PSI_PROJECTS_REL,
+  isPsiProjectsSource,
+  parsePsiProjectFile,
+} from './project-doc-source.ts';
+import { storeSqliteDocuments } from './learn-doc-source.ts';
+import { chunkDocumentsForIndexing } from './chunker.ts';
+import { supersedeReplacedSourceDocs } from './reindex-state.ts';
+import {
+  isWithinRoot,
+  listDirs,
+  listFiles,
+  safeClearTimeout,
+  safeClose,
+  watchDir,
+} from './watch-utils.ts';
+import { currentTenantId } from '../middleware/tenant.ts';
+import { removeDocumentPointers } from '../search/pointer-index.ts';
+
+const { indexingJobs, oracleDocuments } = schema;
+type WatcherDb = BunSQLiteDatabase<typeof schema>;
+
+export interface ProjectWatcherOptions {
+  db: Database;
+  models: Record<string, { collection: string }>;
+  repoRoot?: string;
+  debounceMs?: number;
+}
+
+export type StopProjectWatch = () => void;
+const DEFAULT_DEBOUNCE_MS = 250;
+
+function isMarkdownFile(filePath: string): boolean {
+  return path.extname(filePath).toLowerCase() === '.md';
+}
+
+function normalizeSourceFile(root: string, filePath: string): string {
+  return path.relative(root, filePath).split(path.sep).join('/');
+}
+
+function hasActiveJobs(db: WatcherDb, docId: string): boolean {
+  const row = db.select({ count: count(indexingJobs.id) })
+    .from(indexingJobs)
+    .where(and(eq(indexingJobs.docId, docId), inArray(indexingJobs.status, ['pending', 'claimed'])))
+    .get();
+  return (row?.count ?? 0) > 0;
+}
+
+function enqueueDocIds(
+  sqlite: Database,
+  db: WatcherDb,
+  models: Record<string, { collection: string }>,
+  ids: string[],
+): number {
+  let queued = 0;
+  for (const id of ids) {
+    if (hasActiveJobs(db, id)) continue;
+    try { queued += enqueueIndexJob(sqlite, { docId: id, models }).length; }
+    catch { continue; }
+  }
+  return queued;
+}
+
+function activeProjectIds(db: WatcherDb, sourceFile: string): string[] {
+  const tenantId = currentTenantId();
+  const filters: SQL[] = [
+    eq(oracleDocuments.sourceFile, sourceFile),
+    eq(oracleDocuments.type, 'learning'),
+    isNull(oracleDocuments.supersededAt),
+  ];
+  if (tenantId) filters.push(eq(oracleDocuments.tenantId, tenantId));
+  return db.select({ id: oracleDocuments.id })
+    .from(oracleDocuments)
+    .where(and(...filters))
+    .all()
+    .map((row) => row.id);
+}
+
+function activeProjectSources(db: WatcherDb): string[] {
+  const tenantId = currentTenantId();
+  const filters: SQL[] = [
+    eq(oracleDocuments.type, 'learning'),
+    isNull(oracleDocuments.supersededAt),
+  ];
+  if (tenantId) filters.push(eq(oracleDocuments.tenantId, tenantId));
+
+  return [
+    ...new Set(
+      db.select({ sourceFile: oracleDocuments.sourceFile })
+        .from(oracleDocuments)
+        .where(and(...filters))
+        .all()
+        .map((row) => row.sourceFile)
+        .filter(isPsiProjectsSource)
+    ),
+  ];
+}
+
+function cleanupMissingProjectSource(
+  sqlite: Database,
+  db: WatcherDb,
+  models: Record<string, { collection: string }>,
+  sourceFile: string,
+): number {
+  const ids = activeProjectIds(db, sourceFile);
+  if (ids.length === 0) return 0;
+
+  const tenantId = currentTenantId();
+
+  // Projection removal and cleanup-job creation are atomic. Cleanup jobs are
+  // deliberately NOT deduplicated against pending/claimed indexing jobs:
+  // a later cleanup job must remain behind any in-flight stale upsert.
+  const cleanup = sqlite.transaction(() => {
+    for (const id of ids) {
+      sqlite.query('DELETE FROM oracle_documents WHERE id = ?').run(id);
+      sqlite.query('DELETE FROM oracle_fts WHERE id = ?').run(id);
+    }
+
+    removeDocumentPointers(sqlite, tenantId, ids);
+
+    let queued = 0;
+    for (const id of ids) {
+      queued += enqueueIndexJob(sqlite, { docId: id, models }).length;
+    }
+    return queued;
+  });
+
+  return cleanup();
+}
+
+export function startProjectWatcher({
+  db: sqlite,
+  models,
+  repoRoot = REPO_ROOT,
+  debounceMs = DEFAULT_DEBOUNCE_MS,
+}: ProjectWatcherOptions): StopProjectWatch {
+  const db = drizzle(sqlite, { schema });
+  const root = path.resolve(repoRoot);
+  const projectsRoot = path.join(root, PSI_PROJECTS_REL);
+
+  let realRoot: string;
+  let realProjectsRoot: string;
+  try {
+    fs.mkdirSync(projectsRoot, { recursive: true });
+    realRoot = fs.realpathSync(root);
+    realProjectsRoot = fs.realpathSync(projectsRoot);
+  } catch {
+    return () => {};
+  }
+
+  // The canonical projects root itself must remain physically inside repoRoot.
+  if (!isWithinRoot(realRoot, realProjectsRoot)) return () => {};
+
+  const watchers: fs.FSWatcher[] = [];
+  const watchedDirs = new Set<string>();
+  const pending = new Map<string, ReturnType<typeof setTimeout>>();
+
+  const timerFor = (filePath: string, fn: () => void) => {
+    safeClearTimeout(pending.get(filePath));
+    const timer = setTimeout(() => {
+      pending.delete(filePath);
+      fn();
+    }, debounceMs);
+    pending.set(filePath, timer);
+  };
+
+  const indexOrQueue = (filePath: string) => {
+    const fullPath = path.resolve(filePath);
+    if (!isWithinRoot(projectsRoot, fullPath)) return;
+
+    if (!fs.existsSync(fullPath)) {
+      // A disappeared file has no realpath to validate, so constrain cleanup
+      // by its canonical logical path before touching any indexed projection.
+      if (!isMarkdownFile(fullPath)) return;
+
+      const sourceFile = normalizeSourceFile(root, fullPath);
+      if (!isPsiProjectsSource(sourceFile)) return;
+
+      cleanupMissingProjectSource(sqlite, db, models, sourceFile);
+
+      // macOS fs.watch may report only the old side of a rename. Reconcile
+      // current canonical sources so a renamed/new path is indexed even when
+      // no reliable second filesystem event arrives for the destination.
+      indexMissingSources();
+      return;
+    }
+
+    // Lexical containment is insufficient for symlinks. Resolve the actual
+    // filesystem target and fail closed if it escapes the canonical projects root.
+    let realPath: string;
+    try { realPath = fs.realpathSync(fullPath); }
+    catch { return; }
+    if (!isWithinRoot(realProjectsRoot, realPath)) return;
+
+    let stat: fs.Stats;
+    try { stat = fs.statSync(fullPath); }
+    catch { return; }
+
+    if (stat.isDirectory()) {
+      addWatchTree(fullPath);
+      indexTree(fullPath);
+      return;
+    }
+    if (!stat.isFile() || !isMarkdownFile(fullPath)) return;
+
+    const sourceFile = normalizeSourceFile(root, fullPath);
+    if (!isPsiProjectsSource(sourceFile)) return;
+
+    let content: string;
+    try { content = fs.readFileSync(fullPath, 'utf8'); }
+    catch { return; }
+    if (!content.trim()) return;
+
+    const documents = parsePsiProjectFile(sourceFile, content);
+    if (documents.length === 0) return;
+
+    const chunked = chunkDocumentsForIndexing(documents);
+    const ids = storeSqliteDocuments(sqlite, documents);
+    supersedeReplacedSourceDocs(sqlite, chunked, currentTenantId());
+    enqueueDocIds(sqlite, db, models, ids);
+  };
+
+  function indexTree(dir: string): void {
+    for (const filePath of listFiles(dir, isMarkdownFile)) indexOrQueue(filePath);
+  }
+
+  function indexMissingSources(): void {
+    for (const filePath of listFiles(projectsRoot, isMarkdownFile)) {
+      const sourceFile = normalizeSourceFile(root, filePath);
+      if (activeProjectIds(db, sourceFile).length === 0) {
+        indexOrQueue(filePath);
+      }
+    }
+  }
+
+  function cleanupMissingSources(): void {
+    for (const sourceFile of activeProjectSources(db)) {
+      const fullPath = path.resolve(root, sourceFile);
+
+      // Fail closed before allowing DB provenance to influence filesystem-based
+      // reconciliation outside the canonical projects root.
+      if (!isWithinRoot(projectsRoot, fullPath)) continue;
+      if (!isMarkdownFile(fullPath)) continue;
+
+      if (!fs.existsSync(fullPath)) {
+        cleanupMissingProjectSource(sqlite, db, models, sourceFile);
+      }
+    }
+  }
+
+  function addWatchTree(dir: string): void {
+    const resolved = path.resolve(dir);
+    if (!isWithinRoot(projectsRoot, resolved) || watchedDirs.has(resolved)) return;
+
+    let realDir: string;
+    try { realDir = fs.realpathSync(resolved); }
+    catch { return; }
+    if (!isWithinRoot(realProjectsRoot, realDir)) return;
+
+    const watcher = watchDir(resolved, (candidate) =>
+      timerFor(candidate, () => indexOrQueue(candidate))
+    );
+    if (watcher) {
+      watchedDirs.add(resolved);
+      watchers.push(watcher);
+    }
+    for (const child of listDirs(resolved)) {
+      if (path.resolve(child) !== resolved) addWatchTree(child);
+    }
+  }
+
+  // Watching the root observes README edits and newly-created project dirs.
+  addWatchTree(projectsRoot);
+
+  // Startup convergence is bidirectional:
+  // - active DB project sources missing from disk are cleaned;
+  // - canonical disk sources missing from the active DB are indexed.
+  // Existing active sources that still exist are left untouched.
+  cleanupMissingSources();
+  indexMissingSources();
+
+  return () => {
+    for (const [filePath, timer] of pending) {
+      safeClearTimeout(timer);
+      pending.delete(filePath);
+    }
+    safeClose(watchers);
+  };
+}

--- a/src/indexer/worker.ts
+++ b/src/indexer/worker.ts
@@ -45,6 +45,8 @@ export interface WorkerDeps {
    * the same meaningless embedding (#2806, reported by Berlin).
    */
   upsertVector: (collection: string, docId: string, vector: number[], text: string) => Promise<void>;
+  /** Delete one stale vector row for a document that no longer exists in the text index. */
+  deleteVector: (modelKey: string, docId: string) => Promise<void>;
   /** Returns true when the worker should exit cleanly. Caller wires SIGTERM/SIGINT. */
   isShuttingDown: () => boolean;
   /** Sleep between empty-queue polls (default 1000ms). */
@@ -113,9 +115,11 @@ export async function runWorker(
     try {
       const text = deps.getDocText(job.docId);
       if (text === null) {
-        // Doc was deleted between enqueue and claim — mark done (no-op).
-        // Plug-play: removing a doc from oracle_documents leaves queue rows
-        // safely consumable. The worker absorbs the no-op gracefully.
+        // The canonical text row disappeared after this job was queued.
+        // Delete any previously stored vector before completing the job.
+        // A later cleanup job is therefore safe even if an older claimed job
+        // races and briefly re-upserts the stale vector first.
+        await deps.deleteVector(job.modelKey, job.docId);
         markJobDone(deps.db, job.id);
         emit(deps, { type: 'doc_missing', job });
         stats.processed++;

--- a/src/search/__tests__/pointer-index.test.ts
+++ b/src/search/__tests__/pointer-index.test.ts
@@ -105,3 +105,45 @@ test('oracle_search surfaces pointer-only hits when FTS misses', async () => {
     hits: 1,
   });
 });
+
+test('oracle_search pointer hydration excludes superseded documents', async () => {
+  const conn = connection();
+
+  conn.db.insert((await import('../../db/schema.ts')).oracleDocuments).values({
+    id: 'superseded-pointer-doc',
+    type: 'learning',
+    sourceFile: 'ψ/memory/learnings/superseded-pointer.md',
+    concepts: JSON.stringify(['Superseded Pointer']),
+    createdAt: stamp,
+    updatedAt: stamp,
+    indexedAt: stamp,
+    supersededAt: stamp,
+    supersededBy: 'replacement-doc',
+  }).run();
+
+  conn.sqlite.prepare(
+    'INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)'
+  ).run(
+    'superseded-pointer-doc',
+    'opaque stale payload without query terms',
+    'unrelated'
+  );
+
+  replaceDocumentPointers(conn.sqlite, {
+    documentId: 'superseded-pointer-doc',
+    content: 'Superseded Pointer historical note',
+    concepts: ['Superseded Pointer'],
+    timestamp: stamp,
+  });
+
+  const response = await handleSearch(ctx(conn), {
+    query: 'Superseded Pointer',
+    mode: 'fts',
+    limit: 3,
+  });
+
+  const body = JSON.parse(response.content[0].text);
+
+  expect(body.results.map((result: { id: string }) => result.id))
+    .not.toContain('superseded-pointer-doc');
+});

--- a/src/search/pointer-hydrate.ts
+++ b/src/search/pointer-hydrate.ts
@@ -46,6 +46,7 @@ export function hydratePointerDocs(db: OracleDb, ranked: Map<string, { score: nu
   if (ids.length === 0) return [];
   const filters = [
     eq(schema.oracleDocuments.tenantId, options.tenantId),
+    isNull(schema.oracleDocuments.supersededAt),
     inArray(schema.oracleDocuments.id, ids),
     ...(options.type && options.type !== 'all' ? [eq(schema.oracleDocuments.type, options.type)] : []),
     ...(options.project ? [or(eq(schema.oracleDocuments.project, options.project), isNull(schema.oracleDocuments.project))] : []),

--- a/src/tools/search/definition.ts
+++ b/src/tools/search/definition.ts
@@ -27,7 +27,7 @@ export const searchToolDef = {
       mode: {
         type: 'string',
         enum: ['hybrid', 'fts', 'vector'],
-        description: 'Search mode: hybrid (default), fts (keywords only), vector (semantic only)',
+        description: 'Search mode: hybrid (FTS5 + vectors + pointer signals), fts (FTS5 + pointer signals, no vectors), vector (vectors + pointer signals, no FTS5)',
         default: 'hybrid',
       },
       retrieval: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,6 +131,7 @@ export interface IndexerConfig {
     distillations: string;
     learn: string;              // ψ/learn/ — auto-learned repo exploration docs
     inbox?: string;             // ψ/inbox/ — fleet correspondence, indexed as knowledge (#2855)
+    projects?: string;          // ψ/projects/ — canonical Oracle work-project context
     security_corpus?: string;  // Optional: ψ/learn/security-corpus/ — opt-in via ORACLE_INDEX_SECURITY_CORPUS=1
   };
 }


### PR DESCRIPTION
## Summary

Adds the Gate 6 Oracle project-memory / retrieval-integrity work on top of current `alpha`.

This includes:
- canonical `ψ/projects/**/*.md` project-memory collection and source parsing
- project watcher support for create/edit/delete/rename/restart reconciliation
- active-row deduplication, path containment, and cross-project separation
- legacy `ψ/learn`, `ψ/memory/learnings`, and `ψ/inbox` regression coverage
- vector cleanup when source documents disappear
- superseded-chunk lifecycle coverage
- pointer hydration filtering so superseded documents cannot resurface through pointer-only retrieval
- corrected `oracle_search` mode description to match intentional pointer participation

## Verification

Post-rebase focused regression suite against current upstream `alpha`:

- **71 pass / 0 fail**
- **423 assertions**
- **9 files**

The branch was rebased cleanly onto upstream commit `6e245e44` before the final verification run.

## Notes

No force-push or destructive history rewrite was used. The Oracle runtime remains configured with `ORACLE_EMBEDDER=none`, so live vector cleanup is not applicable in the production runtime configuration; the worker cleanup path is covered by regression tests.