### PR TITLE
fix(test): server-unready pinned one error string, so load decided whether it passed

### DIFF
--- a/tests/http/plugins/server-unready.test.ts
+++ b/tests/http/plugins/server-unready.test.ts
@@ -10,10 +10,21 @@ describe('unready plugin server', () => {
       expect(fixture.servers.started).toBe(0);
       const res = await fetch(`${fixture.baseUrl}/api/plugins/${fixture.pluginName}/server/health`);
       expect(res.status).toBe(502);
-      expect((await res.json()) as { ok: boolean; error: string }).toMatchObject({
-        ok: false,
-        error: 'plugin server health check failed',
-      });
+      // Assert the CONTRACT (502 + ok:false + a stated reason), not the wording.
+      // src/plugins/unified-server.ts:148 is `result.error ?? 'plugin server health
+      // check failed'`, so the literal previously pinned here was only the FALLBACK.
+      // An unready server legitimately fails in more than one way and each reports
+      // its own reason: "health check failed: <url>" when the probe answers unhealthy,
+      // "Unable to connect. Is the computer able to access the url?" when it never
+      // listens. Both are correctly 502 + ok:false. Which one you get depends on
+      // machine load, so pinning either makes the suite fail by contention.
+      // Measured: passes alone and as tests/http/plugins/ (36/36); failed ONLY in the
+      // full `bun test --isolate tests/http/` run over 300 files — the exact
+      // invocation the nightly tier added in #2999 executes.
+      const body = (await res.json()) as { ok: boolean; error: string };
+      expect(body.ok).toBe(false);
+      expect(typeof body.error).toBe('string');
+      expect(body.error.length).toBeGreaterThan(0);
     } finally {
       if (oldStart === undefined) delete process.env.ARRA_PLUGIN_START_TIMEOUT_MS;
       else process.env.ARRA_PLUGIN_START_TIMEOUT_MS = oldStart;


### PR DESCRIPTION
## Found while verifying #2999 — it would have shipped a nightly that was red on night one

`tests/http/plugins/server-unready.test.ts` passes alone and passes as a directory, but
fails inside the **full 300-file `bun test --isolate tests/http/` run** — which is exactly
the invocation the nightly tier added in #2999 executes.

```
bun test --isolate tests/http/plugins/server-unready.test.ts   1 pass / 0 fail
bun test --isolate tests/http/plugins/                        36 pass / 0 fail
bun test --isolate tests/http/                              1079 pass / 1 fail   ← here
```

## Cause: the assertion pinned the fallback

`src/plugins/unified-server.ts:148`

```ts
return failure(config.plugin, 502, result.error ?? 'plugin server health check failed');
```

The literal the test pinned was only the **`??` fallback** — reached only when the health
check produced no specific error. An unready server legitimately fails in more than one
way, and each reports its own reason:

| failure mode | reported error | status |
|---|---|---|
| probe answers unhealthy | `health check failed: <url>` | 502 |
| server never listens | `Unable to connect. Is the computer able to access the url?` | 502 |

Both are correct. **Which one fires depends on machine load** — under 300 concurrent test
files the connect never completes, so the specific error wins and the fallback never
appears. The test was therefore a contention detector, not a behaviour check.

## Fix

Assert the contract — `502` + `ok: false` + a non-empty reason — and stop pinning wording
that is an implementation detail.

```
bun test --isolate tests/http/     1080 pass / 0 fail   (twice, to confirm it is stable)
bun test --isolate tests/http/plugins/   36 pass / 0 fail
bunx tsc --noEmit                  exit 0
```

## Why this matters beyond one test

This is the **second over-specified assertion today**, after `tests/docs/claude-md-claims.test.ts`
pinned the whole `pathIgnorePatterns = ["**/agents/**"]` array literal and failed the moment
a second pattern was added. Both tests still fail correctly if the behaviour they exist to
protect regresses; both failed on things they were never meant to police.

A nightly that is red from its first run is a nightly everyone learns to ignore, which
would have quietly undone the point of #2999.

🤖 Generated with [Claude Code](https://claude.com/claude-code)