### PR TITLE
test(indexer): cover collectPsiInbox provenance and dedup, and pin pointer supersession semantics

### DIFF
--- a/src/indexer/__tests__/collectors.test.ts
+++ b/src/indexer/__tests__/collectors.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { collectPsiLearn, getAllMarkdownFiles } from '../collectors.ts';
+import { collectPsiInbox } from '../collect-inbox.ts';
 
 describe('getAllMarkdownFiles', () => {
   test('skips broken symlinks instead of crashing on ENOENT', () => {
@@ -48,6 +49,46 @@ describe('getAllMarkdownFiles', () => {
       expect(docs).toHaveLength(1);
       expect(docs[0].source_file).toBe('github.com/Soul-Brews-Studio/demo/ψ/learn/codex/finding.md');
       expect(docs[0].project).toBe('github.com/soul-brews-studio/demo');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('collectPsiInbox', () => {
+  test('collects local ψ/inbox markdown as learning knowledge with inbox provenance', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'arra-psi-inbox-'));
+    try {
+      const inboxDir = path.join(tmp, 'ψ', 'inbox', 'reports');
+      fs.mkdirSync(inboxDir, { recursive: true });
+
+      fs.writeFileSync(
+        path.join(inboxDir, 'oracle-report.md'),
+        '# Oracle Report\n\n## Lesson\n\ngate6inboxregressiontoken'
+      );
+
+      const docs = collectPsiInbox({
+        config: {
+          repoRoot: tmp,
+          dbPath: ':memory:',
+          chromaPath: '',
+          sourcePaths: {
+            resonance: 'ψ/memory/resonance',
+            learnings: 'ψ/memory/learnings',
+            retrospectives: 'ψ/memory/retrospectives',
+            distillations: 'ψ/memory/distillations',
+            learn: 'ψ/learn',
+            inbox: 'ψ/inbox',
+          },
+        },
+        seenContentHashes: new Set(),
+      });
+
+      expect(docs).toHaveLength(1);
+      expect(docs[0].type).toBe('learning');
+      expect(docs[0].source_file).toBe('ψ/inbox/reports/oracle-report.md');
+      expect(docs[0].id.startsWith('learning_psi_inbox_')).toBe(true);
+      expect(docs[0].content).toContain('gate6inboxregressiontoken');
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/src/search/__tests__/pointer-supersede.test.ts
+++ b/src/search/__tests__/pointer-supersede.test.ts
@@ -1,0 +1,140 @@
+/**
+ * How the pointer fast path treats superseded documents.
+ *
+ * The pointer index is a recall path, not a visibility policy. `handleSearch` merges pointer
+ * hits into the same array as FTS and vector hits, then runs `enrichSupersedeFlags` over the
+ * merged array (`src/tools/search/handler.ts`), so a superseded document is *returned and
+ * labelled* whichever path recalled it — the same contract
+ * `src/tools/__tests__/search-supersede.test.ts` pins for FTS.
+ *
+ * Excluding superseded documents is `asOf`'s job, and only `asOf`'s job:
+ * `filterResultsAsOf` runs over the merged array too, so it can weigh a document's whole
+ * valid-time interval. A `supersededAt IS NULL` filter inside `hydratePointerDocs` would drop
+ * the row *before* that filter ever sees it, which is why the last two tests here are a pair —
+ * a document must be reachable at a timestamp when it was live and gone at one when it wasn't.
+ * This file exists because that filter was proposed in PR #2998 and nothing was red.
+ */
+import { afterEach, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createDatabase } from '../../db/index.ts';
+import type { DatabaseConnection } from '../../db/create.ts';
+import { oracleDocuments } from '../../db/schema.ts';
+import { handleSearch } from '../../tools/search.ts';
+import type { ToolContext } from '../../tools/types.ts';
+import { replaceDocumentPointers } from '../pointer-index.ts';
+
+const roots: string[] = [];
+const connections: DatabaseConnection[] = [];
+const created = Date.parse('2026-01-01T00:00:00.000Z');
+const superseded = Date.parse('2026-06-05T12:00:00.000Z');
+
+function tempRoot(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'arra-pointer-supersede-'));
+  roots.push(dir);
+  return dir;
+}
+
+function ctx(): ToolContext {
+  const conn = createDatabase(join(tempRoot(), 'oracle.db'));
+  connections.push(conn);
+  return {
+    db: conn.db,
+    sqlite: conn.sqlite,
+    repoRoot: tempRoot(),
+    vectorStore: { name: 'mock-vector' } as any,
+    vectorStatus: 'connected',
+    version: 'test',
+  };
+}
+
+/**
+ * A superseded document reachable by pointer alone.
+ *
+ * Its FTS row deliberately carries none of the query's terms, so an FTS5 MATCH cannot return
+ * it. Anything the search does return for `Ledger Rotation` arrived through the pointer index,
+ * which is what makes these assertions about the pointer path rather than about FTS.
+ */
+function seedPointerOnly(context: ToolContext): void {
+  context.db.insert(oracleDocuments).values({
+    id: 'rotation-note',
+    type: 'learning',
+    sourceFile: 'ψ/memory/learnings/rotation.md',
+    concepts: JSON.stringify(['Ledger Rotation']),
+    createdAt: created,
+    updatedAt: created,
+    indexedAt: created,
+    supersededAt: superseded,
+    supersededBy: 'rotation-note-v2',
+    supersededReason: 'rewritten after the 06-05 incident',
+  }).run();
+  context.sqlite.prepare('INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)')
+    .run('rotation-note', 'opaque body sharing no term with the query', 'unrelated');
+  replaceDocumentPointers(context.sqlite, {
+    documentId: 'rotation-note',
+    content: 'Ledger Rotation runbook',
+    concepts: ['Ledger Rotation'],
+    timestamp: created,
+  });
+}
+
+async function search(context: ToolContext, asOf?: string) {
+  const response = await handleSearch(context, {
+    query: 'Ledger Rotation',
+    mode: 'fts',
+    limit: 5,
+    ...(asOf ? { asOf } : {}),
+  });
+  return JSON.parse(response.content[0].text);
+}
+
+afterEach(() => {
+  for (const conn of connections.splice(0)) conn.storage.close();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+test('a superseded document recalled only by pointer is still returned', async () => {
+  const context = ctx();
+  seedPointerOnly(context);
+
+  const body = await search(context);
+
+  expect(body.results.map((result: { id: string }) => result.id)).toEqual(['rotation-note']);
+  expect(body.results[0].provenance.source).toBe('pointer');
+  expect(body.metadata.pointerIndex.hits).toBe(1);
+});
+
+test('a superseded pointer hit carries its successor, not silence', async () => {
+  // Dropping the row would take this warning with it: the caller would lose both the stale
+  // answer and the pointer to the fresh one.
+  const context = ctx();
+  seedPointerOnly(context);
+
+  const body = await search(context);
+
+  expect(body.results[0]).toMatchObject({
+    superseded_by: 'rotation-note-v2',
+    superseded_reason: 'rewritten after the 06-05 incident',
+  });
+  expect(body.results[0].superseded_at).toMatch(/T.*Z$/);
+});
+
+test('asOf before the supersession still reaches the pointer-only document', async () => {
+  const context = ctx();
+  seedPointerOnly(context);
+
+  const body = await search(context, '2026-03-01T00:00:00.000Z');
+
+  expect(body.results.map((result: { id: string }) => result.id)).toEqual(['rotation-note']);
+  expect(body.results[0].valid_until).toMatch(/^2026-06-05/);
+});
+
+test('asOf after the supersession drops it — exclusion is asOf, not hydration', async () => {
+  const context = ctx();
+  seedPointerOnly(context);
+
+  const body = await search(context, '2026-08-01T00:00:00.000Z');
+
+  expect(body.results).toEqual([]);
+});

--- a/src/tools/search/definition.ts
+++ b/src/tools/search/definition.ts
@@ -27,7 +27,10 @@ export const searchToolDef = {
       mode: {
         type: 'string',
         enum: ['hybrid', 'fts', 'vector'],
-        description: 'Search mode: hybrid (default), fts (keywords only), vector (semantic only)',
+        // Pointer signals are not a mode. `queryPointerIndex` runs unconditionally in the
+        // handler, so `fts` was never "keywords only" — it can and does return `source:
+        // "pointer"` results the FTS5 MATCH never saw.
+        description: 'Search mode: hybrid (FTS5 + vectors + pointer signals), fts (FTS5 + pointer signals, no vectors), vector (vectors + pointer signals, no FTS5)',
         default: 'hybrid',
       },
       retrieval: {


### PR DESCRIPTION
## Credit

From @fuxmask's **#2998**, which found two real untested seams in this repo:

1. `collectPsiInbox` (backing #2855's inbox indexing) had zero dedicated test coverage
   anywhere.
2. The interaction between the pointer-recall fast path and document supersession was
   also untested.

## What was and wasn't taken

Of the 4 files the original review flagged as cleanly mergeable from #2998, only 1 held
anything actually worth taking:

- **Taken:** a new `collectPsiInbox` test in `src/indexer/__tests__/collectors.test.ts`
  (41 lines) — genuine gap, doesn't touch the rejected watcher code.
- **`src/tools/search/definition.ts`** — the description fix here is superseded by better
  wording already on this branch.
- **`src/search/pointer-hydrate.ts` / `pointer-index.test.ts` — rejected, not taken.**
  The PR's fix and its test both encode an `isNull(supersededAt)` filter. That's the
  *wrong* fix: it breaks bitemporal `asOf` time travel — a superseded document recalled
  only via the pointer index would incorrectly vanish even when queried `asOf` a time
  before its supersession. `src/search/__tests__/pointer-supersede.test.ts` pins the
  correct behavior instead: superseded docs stay reachable via the pointer path, carry
  `superseded_by`/`_at`/`_reason`, and only drop out `asOf` a time *after* supersession.

So this PR takes the seam #2998 correctly identified and rejects the fix it proposed for
it, while adding the coverage that would have caught the difference.

Not from `frontend/src-tauri/**` — no Rust to run.

## Gate

```
bunx tsc --noEmit    clean
bun test --isolate src/indexer/__tests__/collectors.test.ts \
  src/search/__tests__/ src/tools/search/ tests/build/    107 pass / 0 fail, 14 files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)