### PR TITLE
feat(indexer): index ψ/outbox and the crew brain outside memory/

### DIFF
--- a/src/indexer/__tests__/vault-extras-collected.test.ts
+++ b/src/indexer/__tests__/vault-extras-collected.test.ts
@@ -1,0 +1,232 @@
+/**
+ * #2800 (@Anurak112), second half — the vault trees no collector reached.
+ *
+ * Sibling of `crew-psi-discovery.test.ts`, which pins the `memory/` half that landed in
+ * #2854. This file pins the rest: `ψ/outbox`, a crew member's non-memory subtrees, and the
+ * `CLAUDE.md` that says who that member is.
+ *
+ * The two things worth more than "does it find the file":
+ *  - `ORACLE_INDEX_CREW` gates the crew half and **only** the crew half. `ψ/outbox` is not a
+ *    crew tree; a lever that switches off more than its name says is the #2822 / #2846
+ *    defect wearing a different hat.
+ *  - ids are namespaced by path hash. `CLAUDE.md` exists under every member, so a
+ *    basename-derived id would silently keep one identity file and drop the rest.
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { collectVaultExtraDocuments } from '../collect-vault-extras.ts';
+import type { IndexerConfig, OracleDocument } from '../../types.ts';
+
+const NOTE = '# Handoff\n\nThe queue drained before the embedder came back.\n';
+
+function fixture(files: Record<string, string>) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vault-extras-'));
+  for (const [rel, body] of Object.entries(files)) {
+    const full = path.join(root, rel);
+    fs.mkdirSync(path.join(full, '..'), { recursive: true });
+    fs.writeFileSync(full, body);
+  }
+  const config = {
+    repoRoot: root,
+    dbPath: ':memory:',
+    chromaPath: '',
+    sourcePaths: {
+      resonance: 'ψ/memory/resonance',
+      learnings: 'ψ/memory/learnings',
+      retrospectives: 'ψ/memory/retrospectives',
+      distillations: 'ψ/memory/distillations',
+      learn: 'ψ/learn',
+    },
+  } as IndexerConfig;
+  const collect = (seen = new Set<string>()): OracleDocument[] =>
+    collectVaultExtraDocuments({ config, seenContentHashes: seen });
+  return { root, collect, cleanup: () => fs.rmSync(root, { recursive: true, force: true }) };
+}
+
+function sources(docs: OracleDocument[]): string[] {
+  return [...new Set(docs.map((doc) => doc.source_file))].sort();
+}
+
+const previous = process.env.ORACLE_INDEX_CREW;
+afterEach(() => {
+  if (previous === undefined) delete process.env.ORACLE_INDEX_CREW;
+  else process.env.ORACLE_INDEX_CREW = previous;
+});
+
+describe('the outgoing half of fleet correspondence is indexed', () => {
+  test('a note in ψ/outbox/ is collected', () => {
+    const f = fixture({ 'ψ/outbox/2026-08-16_report.md': NOTE });
+    try {
+      expect(sources(f.collect())).toEqual(['ψ/outbox/2026-08-16_report.md']);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test('nested outbox subdirectories are walked, not just the top level', () => {
+    const f = fixture({ 'ψ/outbox/handoff/2026-08-16_05-55.md': NOTE });
+    try {
+      expect(f.collect().length).toBeGreaterThan(0);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test('an empty file produces nothing rather than an empty document', () => {
+    const f = fixture({ 'ψ/outbox/blank.md': '   \n' });
+    try {
+      expect(f.collect()).toEqual([]);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test('a vault with none of these trees is not an error', () => {
+    const f = fixture({ 'ψ/memory/learnings/only-this.md': NOTE });
+    try {
+      expect(f.collect()).toEqual([]);
+    } finally {
+      f.cleanup();
+    }
+  });
+});
+
+describe('a crew member is indexed beyond their memory/ brain', () => {
+  test("the member's CLAUDE.md identity file is collected", () => {
+    const f = fixture({ 'ψ/crew/omar/CLAUDE.md': '# omar\n\nOwns the vector queue.\n' });
+    try {
+      expect(sources(f.collect())).toEqual(['ψ/crew/omar/CLAUDE.md']);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test('subtrees beyond the three the PR listed are walked too', () => {
+    // learn/inbox/outbox were the enumerated three; an allow-list would drop writing/.
+    const f = fixture({
+      'ψ/crew/omar/learn/repo.md': `${NOTE}learn\n`,
+      'ψ/crew/omar/inbox/from-jeera.md': `${NOTE}inbox\n`,
+      'ψ/crew/omar/outbox/to-jeera.md': `${NOTE}outbox\n`,
+      'ψ/crew/omar/writing/essay.md': `${NOTE}writing\n`,
+    });
+    try {
+      expect(sources(f.collect())).toEqual([
+        'ψ/crew/omar/inbox/from-jeera.md',
+        'ψ/crew/omar/learn/repo.md',
+        'ψ/crew/omar/outbox/to-jeera.md',
+        'ψ/crew/omar/writing/essay.md',
+      ]);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test('memory/ is left to collectDocuments rather than collected twice', () => {
+    const f = fixture({ 'ψ/crew/omar/memory/learnings/a.md': NOTE });
+    try {
+      expect(f.collect()).toEqual([]);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test('the crew roster README is collected', () => {
+    const f = fixture({ 'ψ/crew/README.md': '# crew\n\nomar, jeera.\n' });
+    try {
+      expect(sources(f.collect())).toEqual(['ψ/crew/README.md']);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test('a crew document is attributed to crew/<member>', () => {
+    const f = fixture({ 'ψ/crew/omar/outbox/to-jeera.md': NOTE });
+    try {
+      expect(f.collect()[0]?.project).toBe('crew/omar');
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test('same basename under two members does not collide on id', () => {
+    const f = fixture({
+      'ψ/crew/omar/CLAUDE.md': '# omar\n\nOwns the vector queue.\n',
+      'ψ/crew/jeera/CLAUDE.md': '# jeera\n\nOwns the retro cadence.\n',
+    });
+    try {
+      const ids = f.collect().map((doc) => doc.id);
+      expect(ids).toHaveLength(2);
+      expect(new Set(ids).size).toBe(2);
+    } finally {
+      f.cleanup();
+    }
+  });
+});
+
+describe('ORACLE_INDEX_CREW gates the crew half and nothing else', () => {
+  const tree = {
+    'ψ/crew/omar/CLAUDE.md': '# omar\n\nOwns the vector queue.\n',
+    'ψ/outbox/report.md': NOTE,
+  };
+
+  test('both halves are collected by default', () => {
+    delete process.env.ORACLE_INDEX_CREW;
+    const f = fixture(tree);
+    try {
+      expect(sources(f.collect())).toEqual(['ψ/crew/omar/CLAUDE.md', 'ψ/outbox/report.md']);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  for (const value of ['0', 'false', 'off', 'no', 'FALSE', ' Off ']) {
+    test(`ORACLE_INDEX_CREW=${JSON.stringify(value)} drops crew but keeps ψ/outbox`, () => {
+      // The raw `=== '0'` this replaced would have indexed crew for five of these six.
+      process.env.ORACLE_INDEX_CREW = value;
+      const f = fixture(tree);
+      try {
+        expect(sources(f.collect())).toEqual(['ψ/outbox/report.md']);
+      } finally {
+        f.cleanup();
+      }
+    });
+  }
+
+  test('ORACLE_INDEX_CREW=1 leaves both enabled', () => {
+    process.env.ORACLE_INDEX_CREW = '1';
+    const f = fixture(tree);
+    try {
+      expect(sources(f.collect())).toHaveLength(2);
+    } finally {
+      f.cleanup();
+    }
+  });
+});
+
+describe('deduplication and registration', () => {
+  test('identical content in two places is stored once', () => {
+    const f = fixture({ 'ψ/outbox/a.md': NOTE, 'ψ/crew/omar/outbox/a.md': NOTE });
+    try {
+      expect(f.collect()).toHaveLength(1);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test('content an earlier collector already claimed is skipped', () => {
+    const f = fixture({ 'ψ/outbox/a.md': NOTE });
+    try {
+      expect(f.collect(new Set([Bun.hash(NOTE).toString(36)]))).toEqual([]);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  test('src/indexer/index.ts actually calls the collector', async () => {
+    // #2800 shipped none of this; a collector nothing calls is the #2877 shape.
+    const source = await Bun.file(new URL('../index.ts', import.meta.url)).text();
+    expect(source).toContain('collectVaultExtraDocuments(shared)');
+  });
+});

--- a/src/indexer/__tests__/vault-extras-size-cap.test.ts
+++ b/src/indexer/__tests__/vault-extras-size-cap.test.ts
@@ -1,0 +1,147 @@
+/**
+ * The byte budget on `collectVaultExtraDocuments` (#2800 salvage).
+ *
+ * `ψ/outbox/` is append-only by construction — every `/forward`, every fleet report, forever,
+ * with no writer that prunes. The collector holds every document it returns in memory, and
+ * `src/indexer/index.ts` then chunks all of them and queues a vector job per chunk. Without a
+ * cap, one unattended outbox does not degrade the extras collector; it takes the whole index
+ * run down with it, including `ψ/memory/` — which is the part nobody can afford to lose.
+ *
+ * So the contract under test is: **truncate loudly, never explode**. Everything under budget
+ * still lands, and what got dropped is stated on the console rather than silently missing.
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  VAULT_EXTRA_LIMITS,
+  collectVaultExtraDocuments,
+  type VaultExtraLimits,
+} from '../collect-vault-extras.ts';
+import type { IndexerConfig } from '../../types.ts';
+
+const roots: string[] = [];
+
+afterEach(() => {
+  while (roots.length) fs.rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+/** Bodies are unique per index so content-hash dedupe never masks a budget decision. */
+function vault(files: Record<string, string>) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vault-extras-cap-'));
+  roots.push(root);
+  for (const [rel, body] of Object.entries(files)) {
+    const full = path.join(root, rel);
+    fs.mkdirSync(path.join(full, '..'), { recursive: true });
+    fs.writeFileSync(full, body);
+  }
+  const config = {
+    repoRoot: root,
+    dbPath: ':memory:',
+    chromaPath: '',
+    sourcePaths: {
+      resonance: 'ψ/memory/resonance',
+      learnings: 'ψ/memory/learnings',
+      retrospectives: 'ψ/memory/retrospectives',
+      distillations: 'ψ/memory/distillations',
+      learn: 'ψ/learn',
+    },
+  } as IndexerConfig;
+  return (limits?: Partial<VaultExtraLimits>) =>
+    collectVaultExtraDocuments({ config, seenContentHashes: new Set(), limits });
+}
+
+function note(marker: string, bytes: number): string {
+  const head = `# note ${marker}\n\n`;
+  return head + 'x'.repeat(Math.max(0, bytes - head.length)) + '\n';
+}
+
+describe('the shipped defaults are a real bound', () => {
+  test('per-file and per-run caps are both set, and the run cap is the larger', () => {
+    expect(VAULT_EXTRA_LIMITS.maxFileBytes).toBeGreaterThan(0);
+    expect(VAULT_EXTRA_LIMITS.maxTotalBytes).toBeGreaterThan(VAULT_EXTRA_LIMITS.maxFileBytes);
+  });
+});
+
+describe('one oversized file cannot become one enormous document', () => {
+  test('a file over maxFileBytes is skipped', () => {
+    const collect = vault({ 'ψ/outbox/huge.md': note('huge', 4096) });
+    expect(collect({ maxFileBytes: 1024 })).toEqual([]);
+  });
+
+  test('its normal-sized siblings are still collected', () => {
+    const collect = vault({
+      'ψ/outbox/huge.md': note('huge', 4096),
+      'ψ/outbox/small.md': note('small', 200),
+      'ψ/crew/omar/CLAUDE.md': note('omar', 200),
+    });
+    const kept = collect({ maxFileBytes: 1024 }).map((doc) => doc.source_file).sort();
+    expect(kept).toEqual(['ψ/crew/omar/CLAUDE.md', 'ψ/outbox/small.md']);
+  });
+});
+
+describe('an unbounded tree degrades into a partial index, not an OOM', () => {
+  const many = Object.fromEntries(
+    Array.from({ length: 12 }, (_, i) => [
+      `ψ/outbox/${String(i).padStart(2, '0')}.md`,
+      note(`n${i}`, 1000),
+    ]),
+  );
+
+  test('collection stops adding files once the run budget is spent', () => {
+    const collect = vault(many);
+    const docs = collect({ maxFileBytes: 4096, maxTotalBytes: 3500 });
+    expect(docs.length).toBeGreaterThan(0);
+    expect(docs.length).toBeLessThan(12);
+  });
+
+  test('the whole tree lands when the budget is not the constraint', () => {
+    const collect = vault(many);
+    expect(collect({ maxFileBytes: 4096, maxTotalBytes: 1024 * 1024 })).toHaveLength(12);
+  });
+
+  test('the kept prefix is stable across runs rather than readdir-ordered', () => {
+    const collect = vault(many);
+    const limits = { maxFileBytes: 4096, maxTotalBytes: 3500 };
+    const first = collect(limits).map((doc) => doc.source_file);
+    expect(collect(limits).map((doc) => doc.source_file)).toEqual(first);
+    // A genuine prefix of the sorted names — not "whatever readdir happened to yield".
+    const expected = Object.keys(many).sort().slice(0, first.length);
+    expect(first).toEqual(expected);
+    expect(first.length).toBeLessThan(12);
+  });
+
+  test('a budget too small for even one file yields nothing instead of throwing', () => {
+    const collect = vault(many);
+    expect(collect({ maxFileBytes: 4096, maxTotalBytes: 10 })).toEqual([]);
+  });
+});
+
+describe('truncation is announced, not silent', () => {
+  test('skipped files produce a console warning naming both limits', () => {
+    const collect = vault({ 'ψ/outbox/huge.md': note('huge', 4096) });
+    const original = console.warn;
+    const warnings: string[] = [];
+    console.warn = (...args: unknown[]) => { warnings.push(args.join(' ')); };
+    try {
+      collect({ maxFileBytes: 1024 });
+    } finally {
+      console.warn = original;
+    }
+    expect(warnings.join('\n')).toContain('Vault-extras byte budget hit');
+  });
+
+  test('a run that skipped nothing stays quiet', () => {
+    const collect = vault({ 'ψ/outbox/small.md': note('small', 200) });
+    const original = console.warn;
+    const warnings: string[] = [];
+    console.warn = (...args: unknown[]) => { warnings.push(args.join(' ')); };
+    try {
+      collect({ maxFileBytes: 4096 });
+    } finally {
+      console.warn = original;
+    }
+    expect(warnings).toEqual([]);
+  });
+});

--- a/src/indexer/collect-vault-extras.ts
+++ b/src/indexer/collect-vault-extras.ts
@@ -1,0 +1,183 @@
+/**
+ * Collector for the vault trees no other collector reaches — design by @Anurak112 (#2800).
+ *
+ * What was already covered before this: `collectDocuments` walks `{root,project,crew}/memory/
+ * {resonance,learnings,retrospectives,distillations}`, `collectPsiLearn` walks `ψ/learn`,
+ * `collectPsiInbox` walks `ψ/inbox`, and `collectSecurityCorpus` walks its opt-in corpus.
+ * Nothing walked `ψ/outbox` — the outgoing half of exactly the correspondence #2855 decided
+ * was knowledge — and nothing walked a crew member's brain outside `memory/`, so
+ * `ψ/crew/<member>/CLAUDE.md` (who that member *is*) was unindexed while their learnings
+ * were. #2854 landed the `memory/` half of #2800; this is the rest of it.
+ *
+ * Lives in its own module because `collectors.ts` is 220 lines and the ≤250 rule leaves no
+ * room — the same reason `collect-inbox.ts` exists.
+ *
+ * Not done here, deliberately: project-first vault dirs (`github.com/org/repo/ψ/outbox`).
+ * `collectPsiInbox` reaches those for inbox and outbox deserves the same, but that is a
+ * separate change with its own dedupe surface, not a quiet rider on this one.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import type { IndexerConfig, OracleDocument } from '../types.ts';
+import { crewIndexingDisabled } from './discovery.ts';
+import { getAllMarkdownFiles } from './collectors.ts';
+import { parseLearningFile } from './parser.ts';
+
+/**
+ * Byte budget for one collection pass.
+ *
+ * The per-file cap matches `SECURITY_CORPUS_MAX_FILE_BYTES` — a single 40MB transcript
+ * dumped into `ψ/outbox/` should not become one enormous document. The run cap is the part
+ * that matters more: every collected document is held in memory, chunked, and queued for
+ * embedding, so an outbox that grows unattended must degrade into "indexed the first 16MB"
+ * rather than into an OOM that takes the whole index run — including `ψ/memory/` — with it.
+ *
+ * Overridable per call so the cap is testable without writing 16MB to disk.
+ */
+export interface VaultExtraLimits {
+  maxFileBytes: number;
+  maxTotalBytes: number;
+}
+
+export const VAULT_EXTRA_LIMITS: VaultExtraLimits = {
+  maxFileBytes: 200 * 1024,
+  maxTotalBytes: 16 * 1024 * 1024,
+};
+
+/** `memory/` is #2854's territory; re-walking it here would only produce dedupe churn. */
+const CREW_SUBTREE_ALREADY_INDEXED = 'memory';
+
+function readDirents(dir: string): fs.Dirent[] {
+  try {
+    return fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Every crew file outside `memory/`: loose `.md` at the crew root (the roster README),
+ * a member's `CLAUDE.md` identity file, and any subtree a member keeps — `learn/`,
+ * `inbox/`, `outbox/`, and whatever they invent next. An allow-list of three subdirectory
+ * names would silently drop the fourth, which is the defect shape of #2822 / #2846.
+ */
+function crewFiles(crewRoot: string): string[] {
+  const files: string[] = [];
+  for (const entry of readDirents(crewRoot)) {
+    const memberDir = path.join(crewRoot, entry.name);
+    if (!entry.isDirectory()) {
+      if (entry.isFile() && entry.name.endsWith('.md')) files.push(memberDir);
+      continue;
+    }
+    for (const sub of readDirents(memberDir)) {
+      if (sub.name === CREW_SUBTREE_ALREADY_INDEXED) continue;
+      const subPath = path.join(memberDir, sub.name);
+      if (sub.isDirectory()) files.push(...getAllMarkdownFiles(subPath));
+      else if (sub.isFile() && sub.name.endsWith('.md')) files.push(subPath);
+    }
+  }
+  return files;
+}
+
+/** Sorted so a run that hits the byte budget keeps a stable prefix, not a readdir-order one. */
+function vaultExtraFiles(repoRoot: string): string[] {
+  const psiDir = (...parts: string[]) => path.join(repoRoot, 'ψ', ...parts);
+  const files = getAllMarkdownFiles(psiDir('outbox'));
+  // Only the crew half answers to ORACLE_INDEX_CREW. ψ/outbox is not a crew tree, and a
+  // lever that turns off more than its name says is worse than no lever.
+  if (!crewIndexingDisabled()) files.push(...crewFiles(psiDir('crew')));
+  return [...new Set(files)].sort();
+}
+
+interface BudgetedFiles {
+  kept: string[];
+  skippedTooLarge: number;
+  skippedOverBudget: number;
+}
+
+function applyBudget(files: string[], limits: VaultExtraLimits): BudgetedFiles {
+  const kept: string[] = [];
+  let usedBytes = 0;
+  let skippedTooLarge = 0;
+  let skippedOverBudget = 0;
+  for (const filePath of files) {
+    let size: number;
+    try {
+      size = fs.statSync(filePath).size;
+    } catch {
+      continue;
+    }
+    if (size === 0) continue;
+    if (size > limits.maxFileBytes) { skippedTooLarge++; continue; }
+    if (usedBytes + size > limits.maxTotalBytes) { skippedOverBudget++; continue; }
+    usedBytes += size;
+    kept.push(filePath);
+  }
+  return { kept, skippedTooLarge, skippedOverBudget };
+}
+
+/**
+ * Ids are namespaced by a hash of the full path, matching `psiInboxDocId` / `psiLearnDocId`.
+ * `CLAUDE.md` and `README.md` repeat under every crew member, so a basename-derived id would
+ * collide and each member's identity file would overwrite the previous one.
+ */
+function vaultExtraDocId(pathHash: string, id: string): string {
+  const suffix = id
+    .replace(/^learning_/, '')
+    .replace(/[^a-zA-Z0-9._-]+/g, '-')
+    .replace(/^[._-]+|[._-]+$/g, '');
+  return `learning_vault_extra_${pathHash}_${suffix || 'doc'}`;
+}
+
+export function parseVaultExtraFile(relativePath: string, content: string): OracleDocument[] {
+  const sourceFile = relativePath.split(path.sep).join('/');
+  const pathHash = Bun.hash(sourceFile).toString(36);
+  // Basename, not the whole path: parseLearningFile derives the title and the fallback id
+  // from this argument, and "ψ/crew/omar/CLAUDE.md" is not a title.
+  return parseLearningFile(path.basename(sourceFile), content, sourceFile).map((doc) => ({
+    ...doc,
+    id: vaultExtraDocId(pathHash, doc.id),
+    source_file: sourceFile,
+  }));
+}
+
+export function collectVaultExtraDocuments(opts: {
+  config: IndexerConfig;
+  seenContentHashes: Set<string>;
+  limits?: Partial<VaultExtraLimits>;
+}): OracleDocument[] {
+  const { config, seenContentHashes } = opts;
+  const limits = { ...VAULT_EXTRA_LIMITS, ...opts.limits };
+  const budgeted = applyBudget(vaultExtraFiles(config.repoRoot), limits);
+
+  const documents: OracleDocument[] = [];
+  let skippedDupes = 0;
+  for (const filePath of budgeted.kept) {
+    let content: string;
+    try {
+      content = fs.readFileSync(filePath, 'utf-8');
+    } catch {
+      continue;
+    }
+    if (!content.trim()) continue;
+    const contentHash = Bun.hash(content).toString(36);
+    if (seenContentHashes.has(contentHash)) { skippedDupes++; continue; }
+    seenContentHashes.add(contentHash);
+    const relPath = path.relative(config.repoRoot, filePath).split(path.sep).join('/');
+    documents.push(...parseVaultExtraFile(relPath, content));
+  }
+
+  console.log(
+    `Indexed ${documents.length} vault-extra documents from ${budgeted.kept.length} files ` +
+    `(skipped ${skippedDupes} duplicates)`
+  );
+  if (budgeted.skippedTooLarge > 0 || budgeted.skippedOverBudget > 0) {
+    console.warn(
+      `Vault-extras byte budget hit: skipped ${budgeted.skippedTooLarge} file(s) over ` +
+      `${limits.maxFileBytes} bytes and ${budgeted.skippedOverBudget} file(s) past the ` +
+      `${limits.maxTotalBytes}-byte run budget`
+    );
+  }
+  return documents;
+}

--- a/src/indexer/discovery.ts
+++ b/src/indexer/discovery.ts
@@ -46,8 +46,12 @@ export function discoverProjectPsiDirs(repoRoot: string): string[] {
  * honours one spelling of "off" is a known-expensive shortcut here. There are ~14 other
  * `process.env.ORACLE_* === '0'|'1'` sites that would benefit from one shared parser; that
  * is a separate change, deliberately not made here.
+ *
+ * Exported because `collect-vault-extras.ts` gates the *other* half of a crew brain
+ * (`learn/`, `inbox/`, `outbox/`, `CLAUDE.md`) on the same lever. Two call sites reading the
+ * env var with two different notions of "off" is how a documented flag starts lying.
  */
-function crewIndexingDisabled(): boolean {
+export function crewIndexingDisabled(): boolean {
   const raw = process.env.ORACLE_INDEX_CREW;
   if (raw === undefined) return false;
   return ['0', 'false', 'off', 'no'].includes(raw.trim().toLowerCase());

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -28,6 +28,7 @@ import { parseResonanceFile, parseLearningFile, parseRetroFile, parseDistillatio
 import { getEmbeddingModels } from '../vector/factory.ts';
 import { collectDocuments, collectPsiLearn, collectSecurityCorpus } from './collectors.ts';
 import { collectPsiInbox } from './collect-inbox.ts';
+import { collectVaultExtraDocuments } from './collect-vault-extras.ts';
 import {
   changedDocumentIds,
   enqueueVectorReindexJobs,
@@ -101,6 +102,10 @@ export class OracleIndexer {
       ...collectDocuments({ ...shared, subdir: 'distillations', parseFn: parseDistillationFile, label: 'distillation' }),
       ...collectPsiLearn(shared),
       ...collectPsiInbox(shared),
+      // Last of the markdown collectors on purpose: it is the catch-all for ψ/outbox and the
+      // non-memory crew trees, so every more specific parser gets first claim on a content
+      // hash before this one sees it.
+      ...collectVaultExtraDocuments(shared),
       ...collectSecurityCorpus(shared),
     ];
 


### PR DESCRIPTION
## Credit

From @Anurak112's **#2800**. The crew-brain half of that PR already landed via #2854; its
`discovery.ts` half is superseded and narrower than what's already shipped, so neither is
taken here. What's left — `collectVaultExtraDocuments` — never landed: roughly 70 lines
indexing `ψ/outbox` and per-member crew subtrees (`learn/`, `inbox/`, `outbox/`) outside
`memory/`, plus loose `CLAUDE.md`/`README.md` identity files.

## What changed

- New module `src/indexer/collect-vault-extras.ts` (183 lines) — kept separate rather
  than appended to `collectors.ts`, which is already near the 250-line limit.
- Uses the existing `crewIndexingDisabled()` helper (now exported from
  `src/indexer/discovery.ts`) instead of a raw `process.env.ORACLE_INDEX_CREW === '0'`
  check, so the two crew-indexing gates can't drift into disagreeing about what "off"
  means.
- Adds a byte budget — 200KB/file, 16MB/run — so a large outbox can't blow up an index
  run.
- Wired into `src/indexer/index.ts`.
- Two new tests mirroring the existing crew-psi-discovery pattern:
  `vault-extras-collected.test.ts`, `vault-extras-size-cap.test.ts`.

## Gate

```
bunx tsc --noEmit    clean
bun test --isolate src/indexer/__tests__/vault-extras-collected.test.ts \
  src/indexer/__tests__/vault-extras-size-cap.test.ts tests/build/    119 pass / 0 fail, 9 files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)