### PR TITLE
feat(mcp): add Windows stdio shim for the MCP server

### DIFF
--- a/scripts/mcp-bridge.cjs
+++ b/scripts/mcp-bridge.cjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * A Node stdio shim in front of the Oracle MCP server — for WINDOWS HOSTS.
+ *
+ * On Windows some MCP clients hand a spawned server a stdin handle Bun does not
+ * read from, so `bun bin/mcp.ts` starts, prints its banner, and then sits there
+ * forever having never seen the client's `initialize`. The client eventually
+ * times out and reports the server as broken, which it is not.
+ *
+ * Node's `child_process.spawn` always creates an ordinary named pipe for the
+ * child's stdin. Putting Node in front therefore normalises the handle: the
+ * client talks to Node, Node talks to Bun over a pipe Bun is happy to read, and
+ * this file copies bytes between the two without touching them — JSON-RPC
+ * framing is byte-exact in both directions, and only stderr is passed through
+ * for logging, so nothing here can corrupt the protocol stream.
+ *
+ * On macOS and Linux the bridge is a pure pass-through with an extra process in
+ * it. Point those clients straight at `bun bin/mcp.ts` instead.
+ *
+ * Windows MCP client config:
+ *   {
+ *     "command": "node",
+ *     "args": ["C:\\path\\to\\arra-oracle-v3\\scripts\\mcp-bridge.cjs"]
+ *   }
+ *
+ * Set `ORACLE_BUN_BIN` if `bun` is not on the PATH the MCP client spawns with —
+ * on Windows that PATH is often the one the desktop client inherited at login,
+ * not the one your shell has. Every other environment variable is passed
+ * through unchanged.
+ *
+ * `.cjs`, not `.js`: package.json declares `"type": "module"`.
+ *
+ * Salvaged from PR #2749 by @mdes-innova-th.
+ */
+const { spawn } = require('node:child_process');
+const { existsSync } = require('node:fs');
+const { constants } = require('node:os');
+const path = require('node:path');
+
+/** The repo root, from this file's own location. */
+function resolveRoot() {
+  return path.resolve(__dirname, '..');
+}
+
+/**
+ * `bin/mcp.ts`, the launcher CLAUDE.md documents — not `src/index.ts` directly.
+ * The launcher validates the entrypoint and sets ORACLE_REPO_ROOT, so bridging
+ * through it keeps Windows behaving like every other host, and keeps this shim
+ * correct if the entrypoint moves.
+ */
+function resolveEntry(root = resolveRoot()) {
+  return path.join(root, 'bin', 'mcp.ts');
+}
+
+function resolveBun() {
+  return process.env.ORACLE_BUN_BIN || 'bun';
+}
+
+/** Shell convention for "died by signal", so a Bun crash is never reported as success. */
+function exitCodeFor(code, signal) {
+  if (signal) return 128 + (constants.signals[signal] || 0);
+  return code === null || code === undefined ? 0 : code;
+}
+
+function bridge(args = process.argv.slice(2)) {
+  const root = resolveRoot();
+  const entry = resolveEntry(root);
+  if (!existsSync(entry)) {
+    console.error(`[mcp-bridge] MCP entrypoint not found: ${entry}`);
+    process.exit(1);
+  }
+
+  const bun = resolveBun();
+  const child = spawn(bun, [entry, ...args], {
+    cwd: root,
+    env: process.env,
+    // stderr is inherited so the server's logs reach the client's log pane
+    // without ever entering the stdout stream the protocol owns.
+    stdio: ['pipe', 'pipe', 'inherit'],
+    windowsHide: true,
+  });
+
+  child.on('error', (error) => {
+    console.error(`[mcp-bridge] could not start "${bun}": ${error.message}`);
+    console.error('[mcp-bridge] set ORACLE_BUN_BIN to the full path of bun.exe');
+    process.exit(127);
+  });
+
+  process.stdin.pipe(child.stdin);
+  child.stdout.pipe(process.stdout);
+
+  // Either half of a pipe can go away first — the client closing stdin while the
+  // server is still writing, or the server dying mid-request. Both surface as an
+  // EPIPE 'error' event, and an unhandled one would take the bridge down with a
+  // Node stack trace on the stream the MCP client is trying to parse.
+  child.stdin.on('error', () => {});
+  child.stdout.on('error', () => {});
+  process.stdin.on('error', () => {});
+
+  for (const signal of ['SIGINT', 'SIGTERM']) {
+    // Without this the client kills the bridge and leaves Bun running, holding
+    // the vector store open until the machine is rebooted.
+    process.on(signal, () => child.kill(signal));
+  }
+
+  // 'close' rather than 'exit': 'exit' fires as soon as the child is reaped,
+  // which can be before its last stdout chunk has been copied to ours, and a
+  // truncated final JSON-RPC frame is worse than a slow shutdown. Setting
+  // exitCode instead of calling process.exit() lets that copy finish; the stdin
+  // read handle has to be released by hand or it holds the loop open forever.
+  child.on('close', (code, signal) => {
+    process.exitCode = exitCodeFor(code, signal);
+    process.stdin.destroy();
+  });
+
+  return child;
+}
+
+module.exports = { bridge, exitCodeFor, resolveBun, resolveEntry, resolveRoot };
+
+if (require.main === module) bridge();

--- a/tests/bin/mcp-bridge-resolution.test.ts
+++ b/tests/bin/mcp-bridge-resolution.test.ts
@@ -1,0 +1,68 @@
+/**
+ * `scripts/mcp-bridge.cjs` resolves what it claims to resolve.
+ *
+ * The bridge is only ever executed on Windows, so every one of its assumptions
+ * is unverified by the rest of the suite: it hardcodes a path to `bin/mcp.ts`
+ * that nothing else on this platform reads, and if that entrypoint is renamed
+ * the shim keeps type-checking, keeps linting, and starts failing for the one
+ * group of users who cannot be reached by CI. These are the cheap assertions
+ * that make the rename go red here instead of there.
+ *
+ * The module is required rather than spawned — it only calls `bridge()` under
+ * `require.main === module`, so importing it starts nothing.
+ */
+import { expect, test } from "bun:test";
+import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dir, "../..");
+const require_ = createRequire(import.meta.url);
+const shim = require_(join(repoRoot, "scripts/mcp-bridge.cjs")) as {
+  exitCodeFor: (code: number | null, signal: string | null) => number;
+  resolveBun: () => string;
+  resolveEntry: (root?: string) => string;
+  resolveRoot: () => string;
+};
+
+test("the entrypoint the bridge spawns is a file that exists in this repo", () => {
+  const entry = shim.resolveEntry();
+  // Existence first, deliberately: if the launcher is renamed and resolveEntry
+  // is updated to match, this stays green and only the line below needs
+  // touching. If the launcher is renamed and the shim is NOT updated, this is
+  // the assertion that fires, with the dead path in the message. Do not delete
+  // it — nothing else on this platform reads that path.
+  expect(existsSync(entry), `${entry} does not exist`).toBe(true);
+  expect(entry).toBe(join(repoRoot, "bin", "mcp.ts"));
+});
+
+test("the bridge roots itself at the repo, not at the caller's cwd", () => {
+  // An MCP client spawns the bridge from whatever directory it happens to be
+  // in. Resolving from __dirname is what makes that irrelevant.
+  expect(shim.resolveRoot()).toBe(repoRoot);
+});
+
+test("ORACLE_BUN_BIN overrides the bun on PATH", () => {
+  const original = process.env.ORACLE_BUN_BIN;
+  try {
+    delete process.env.ORACLE_BUN_BIN;
+    expect(shim.resolveBun()).toBe("bun");
+    // The knob exists because a Windows MCP client spawns with the PATH it
+    // inherited at login, which frequently has no bun in it.
+    process.env.ORACLE_BUN_BIN = "C:\\bun\\bun.exe";
+    expect(shim.resolveBun()).toBe("C:\\bun\\bun.exe");
+  } finally {
+    if (original === undefined) delete process.env.ORACLE_BUN_BIN;
+    else process.env.ORACLE_BUN_BIN = original;
+  }
+});
+
+test("a child killed by a signal is not reported to the client as success", () => {
+  // The salvaged original did `process.exit(code || 0)`, and a child that dies
+  // by signal reports code === null — so a Bun crash, the exact thing this shim
+  // exists to work around, was handed to the MCP client as a clean exit.
+  expect(shim.exitCodeFor(null, "SIGSEGV")).toBeGreaterThan(128);
+  expect(shim.exitCodeFor(null, "SIGTERM")).toBeGreaterThan(128);
+  expect(shim.exitCodeFor(0, null)).toBe(0);
+  expect(shim.exitCodeFor(3, null)).toBe(3);
+});

--- a/tests/bin/mcp-bridge-shutdown.test.ts
+++ b/tests/bin/mcp-bridge-shutdown.test.ts
@@ -1,0 +1,69 @@
+/**
+ * `scripts/mcp-bridge.cjs` goes away when the client does.
+ *
+ * A stdio MCP server is shut down by closing its stdin. With a bridge in the
+ * middle there are two processes to shut down, and two ways to get it wrong:
+ * the child keeps running (an orphaned Bun holding the vector store open, which
+ * on Windows means a lock nobody can find), or the bridge itself never exits
+ * because the stdin read handle keeps its event loop alive. Both look like
+ * "the MCP server won't restart" to whoever hits them.
+ *
+ * The bridge deliberately does not call `process.exit()` — it sets exitCode and
+ * releases stdin so buffered stdout still drains — so "it exits at all" is a
+ * real claim about that code, not a triviality.
+ */
+import { afterEach, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dir, "../..");
+const bridge = join(repoRoot, "scripts/mcp-bridge.cjs");
+const tempDirs: string[] = [];
+const childProcesses: Array<{ kill: () => void }> = [];
+
+afterEach(async () => {
+  for (const proc of childProcesses.splice(0)) proc.kill();
+  for (const dir of tempDirs.splice(0)) {
+    if (existsSync(dir)) rmSync(dir, { recursive: true });
+  }
+});
+
+test("closing the bridge's stdin shuts down bun and then the bridge", async () => {
+  const dataDir = mkdtempSync(join(tmpdir(), "arra-oracle-mcp-bridge-exit-"));
+  tempDirs.push(dataDir);
+
+  const proc = Bun.spawn(["node", bridge], {
+    cwd: repoRoot,
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      ORACLE_DATA_DIR: dataDir,
+      ORACLE_DB_PATH: join(dataDir, "oracle.db"),
+      ORACLE_INDEXER_ENQUEUE: "0",
+    },
+  });
+  childProcesses.push(proc);
+  // Drain both streams: an unread pipe fills and would stall the shutdown this
+  // test is timing, turning a real hang and a full buffer into the same red.
+  const drained = Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+
+  proc.stdin.end();
+
+  const exited = await Promise.race([
+    proc.exited,
+    Bun.sleep(20_000).then(() => "timeout" as const),
+  ]);
+  expect(exited).not.toBe("timeout");
+  // Not `toBe(0)`: what matters is that EOF is an ordinary shutdown and not
+  // reported to the client as a crash. 143 (SIGTERM) would mean something had
+  // to kill it.
+  expect(exited).toBe(0);
+
+  await drained;
+}, 30_000);

--- a/tests/bin/mcp-bridge-stdio.test.ts
+++ b/tests/bin/mcp-bridge-stdio.test.ts
@@ -1,0 +1,127 @@
+/**
+ * `scripts/mcp-bridge.cjs` really does carry JSON-RPC in both directions.
+ *
+ * The bridge exists for Windows hosts, and nothing in CI runs Windows — so the
+ * failure mode it guards against is that the shim quietly rots (entrypoint
+ * moves, flag changes, a stray `console.log` lands in the stdout stream the
+ * protocol owns) and nobody finds out until a Windows user reports the server
+ * as dead. The copying itself is platform-independent, so it can be proven
+ * here: spawn the bridge with node, hand it an `initialize`, read the response.
+ *
+ * Sibling of `arra-oracle-dispatch.test.ts`, which asserts the same handshake
+ * against the launcher the bridge wraps.
+ */
+import { afterEach, expect, test } from "bun:test";
+import type { ReadableStream } from "node:stream/web";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dir, "../..");
+const bridge = join(repoRoot, "scripts/mcp-bridge.cjs");
+const tempDirs: string[] = [];
+const childProcesses: Array<{ kill: () => void }> = [];
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+/**
+ * The first line the bridge emits is not necessarily the response: the server
+ * itself writes `[sqlite-vec] Connected` to stdout from
+ * `src/vector/adapters/sqlite-vec.ts:67`, a `console.log` in a process whose
+ * stdout is the protocol stream. That happens identically when the launcher is
+ * spawned directly, so it is not the bridge's doing and not this test's to
+ * assert on — collect lines until one parses as the reply we asked for.
+ */
+async function readJsonRpcLine(
+  stdout: ReadableStream<Uint8Array>,
+  id: number,
+  timeoutMs: number,
+): Promise<{ line: string; seen: string[] }> {
+  const reader = stdout.getReader();
+  const decoder = new TextDecoder();
+  const seen: string[] = [];
+  let buffer = "";
+  let timer: Timer | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error("timed out waiting for stdout JSON-RPC")), timeoutMs);
+  });
+
+  try {
+    while (true) {
+      const { value, done } = await Promise.race([reader.read(), timeout]);
+      if (done) throw new Error(`stdout closed before JSON-RPC response; saw ${seen.join(" | ")}`);
+      buffer += decoder.decode(value);
+      let newline = buffer.indexOf("\n");
+      while (newline !== -1) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        seen.push(line);
+        try {
+          const parsed = JSON.parse(line) as { id?: number };
+          if (parsed.id === id) return { line, seen };
+        } catch { /* not a JSON-RPC frame — keep reading */ }
+        newline = buffer.indexOf("\n");
+      }
+    }
+  } finally {
+    if (timer) clearTimeout(timer);
+    reader.releaseLock();
+  }
+}
+
+afterEach(async () => {
+  for (const proc of childProcesses.splice(0)) proc.kill();
+  for (const dir of tempDirs.splice(0)) {
+    if (existsSync(dir)) rmSync(dir, { recursive: true });
+  }
+});
+
+test("mcp-bridge.cjs forwards initialize to bun and the reply back on stdout", async () => {
+  const dataDir = tempDir("arra-oracle-mcp-bridge-");
+  const proc = Bun.spawn(["node", bridge], {
+    cwd: repoRoot,
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      ORACLE_DATA_DIR: dataDir,
+      ORACLE_DB_PATH: join(dataDir, "oracle.db"),
+      ORACLE_INDEXER_ENQUEUE: "0",
+    },
+  });
+  childProcesses.push(proc);
+  const stderrText = new Response(proc.stderr).text();
+
+  proc.stdin.write(JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "arra-oracle-mcp-bridge-test", version: "0.0.0" },
+    },
+  }) + "\n");
+
+  const { line, seen } = await readJsonRpcLine(proc.stdout, 1, 30_000);
+  const response = JSON.parse(line) as { id?: number; result?: unknown };
+  expect(response.id).toBe(1);
+  expect(response.result).toBeDefined();
+
+  // The bridge must be invisible on stdout: its own diagnostics, and the
+  // server's banner, belong on the inherited stderr. One stray line from the
+  // shim and every client parses a protocol error instead of a response.
+  expect(seen.join("\n")).not.toContain("[mcp-bridge]");
+  expect(seen.join("\n")).not.toContain("Arra Oracle MCP Server running");
+
+  proc.kill();
+  await proc.exited;
+
+  const stderr = await stderrText;
+  expect(stderr).toContain("Arra Oracle MCP Server running on stdio");
+}, 40_000);


### PR DESCRIPTION
## Credit

From @mdes-innova-th's **#2749**. Only `scripts/mcp-bridge.cjs` is taken — the rest of
that PR documents a `web/` Astro dashboard on port 4321 and a `scripts/bootstrap.sh` that
don't exist in this repo, plus a `docs/architecture.md` rewrite from a June baseline that
predates recent changes (including this repo's own #2997/#2999/#3000). None of that is
included here.

## What this adds

A Node `.cjs` stdio shim so MCP clients that can only launch a plain Node executable
(Windows-heavy tooling, some IDE integrations) can still reach the Bun-based MCP server.

Re-implemented rather than copied verbatim, on top of the documented `bin/mcp.ts`
launcher (not `src/index.ts` directly):

- `ORACLE_BUN_BIN` env var to point at a non-default `bun` binary.
- Signal exits mapped to `128+n`, matching shell convention.
- EPIPE races on the piped stdio guarded.
- `SIGINT`/`SIGTERM` forwarded to the child so it isn't orphaned on shutdown.
- Waits for the child's `'close'` event, not `'exit'`, so buffered stdout isn't truncated.

## Gate

```
bunx tsc --noEmit    clean
bun test --isolate tests/bin/ tests/build/    97 pass / 0 fail, 11 files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)