### PR TITLE
fix(search): record the resolved project in search telemetry

### DIFF
--- a/src/tools/search/__tests__/telemetry-project.test.ts
+++ b/src/tools/search/__tests__/telemetry-project.test.ts
@@ -1,0 +1,70 @@
+/**
+ * `search_log.project` records the project a search was actually scoped to.
+ *
+ * The handler resolves a project from either the explicit `project` input or `cwd`
+ * detection, uses it to scope FTS and pointer retrieval — and then called `logSearch`
+ * without it. `logSearch` has always accepted the parameter (`src/server/logging.ts:22`),
+ * so every row landed with `project` NULL and scoped searches were indistinguishable from
+ * unscoped ones in telemetry. See #2955.
+ *
+ * This pins the caller, not the logger: the assertion is that the resolved value reaches
+ * `logSearch`, including the cwd-detected case, which is the one an "explicit input only"
+ * fix would silently miss.
+ */
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const savedNodeEnv = process.env.NODE_ENV;
+const savedDataDir = process.env.ORACLE_DATA_DIR;
+const savedDbPath = process.env.ORACLE_DB_PATH;
+const root = join(tmpdir(), `arra-search-telemetry-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+const dbPath = join(root, 'oracle.db');
+mkdirSync(root, { recursive: true });
+process.env.NODE_ENV = 'test';
+process.env.ORACLE_DATA_DIR = root;
+process.env.ORACLE_DB_PATH = dbPath;
+
+const dbMod = await import('../../../db/index.ts');
+dbMod.resetDefaultDatabaseForTests(dbPath);
+
+function restore(name: string, value: string | undefined) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+describe('search telemetry — project scope', () => {
+  test('logSearch still declares the trailing project parameter the handler relies on', async () => {
+    // Guards the contract the handler depends on: if logSearch loses its trailing
+    // `project` parameter, the handler's extra argument becomes silently inert.
+    // `Function.length` cannot see it — it stops counting at the first defaulted
+    // parameter (`results`) — so read the declaration.
+    const { readFileSync } = await import('node:fs');
+    const loggingSrc = readFileSync(
+      join(import.meta.dir, '..', '..', '..', 'server', 'logging.ts'),
+      'utf-8',
+    );
+    const signature = loggingSrc.match(/export function logSearch\(([^)]*)\)/s)?.[1] ?? '';
+    expect(signature).toContain('project');
+  });
+
+  test('the handler passes its resolved project, not just the explicit input', async () => {
+    // Read the call site rather than round-tripping the DB: the defect was a missing
+    // argument, and the resolved-vs-explicit distinction is exactly what regressed.
+    const { readFileSync } = await import('node:fs');
+    const handlerSrc = readFileSync(join(import.meta.dir, '..', 'handler.ts'), 'utf-8');
+    const logCall = handlerSrc.match(/logSearch\([^)]*\)/s)?.[0] ?? '';
+
+    expect(logCall).toContain('resolvedProject');
+    // `project` alone would drop every cwd-detected scope on the floor.
+    expect(logCall).not.toMatch(/,\s*project\s*\)/);
+  });
+});
+
+afterAll(() => {
+  try { rmSync(root, { recursive: true, force: true }); } catch {}
+  restore('NODE_ENV', savedNodeEnv);
+  restore('ORACLE_DATA_DIR', savedDataDir);
+  restore('ORACLE_DB_PATH', savedDbPath);
+});

--- a/src/tools/search/handler.ts
+++ b/src/tools/search/handler.ts
@@ -162,7 +162,11 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
   console.error(`[MCP:SEARCH] "${query}" (${type}, ${mode}, model=${model || 'default'}) → ${results.length} results in ${searchTime}ms`);
   try {
     const logSearch = await loadLogSearch();
-    logSearch(query, type, mode, results.length, searchTime, results as unknown as SearchResult[]);
+    // `resolvedProject`, not `project`: the caller may omit it and let cwd detection
+    // supply it, and telemetry that only recorded the explicit form would report those
+    // searches as unscoped. Omitting it entirely left `search_log.project` NULL for every
+    // row, so scoped and unscoped searches were indistinguishable after the fact (#2955).
+    logSearch(query, type, mode, results.length, searchTime, results as unknown as SearchResult[], resolvedProject ?? undefined);
   } catch (error) {
     console.error('[MCP:SEARCH] Failed to log search to database:', error);
   }


### PR DESCRIPTION
Partial fix for #2955 — the telemetry half only.

## The bug

`src/tools/search/handler.ts` resolves a project (explicit `project` input, else `cwd`
detection) at line 38 and uses it to scope FTS and pointer retrieval — then called
`logSearch` without it. `logSearch` has accepted a trailing `project` parameter the whole
time (`src/server/logging.ts:22`), so every `search_log` row landed with `project` NULL and
scoped searches were indistinguishable from unscoped ones after the fact.

## The fix

One argument, plus a regression test.

It passes `resolvedProject` rather than `project` deliberately: a caller can omit the input
and let cwd detection supply it, and a fix that only forwarded the explicit form would drop
every detected scope on the floor while looking correct. The test asserts against that
specific case.

**Verified failing-closed** — reverting the argument turns the test red:
```
(fail) search telemetry — project scope > the handler passes its resolved project, not just the explicit input
```
and restoring it returns 2 pass / 0 fail.

## What this does NOT fix

#2955's larger half — vector retrieval ignoring the resolved project, so `mode=hybrid` and
`mode=vector` can still return documents from unrelated projects. That's a real
cross-project data-leak path and needs its own change; the issue stays open for it. This PR
deliberately doesn't touch retrieval behaviour.

## Gate

```
bunx tsc --noEmit                                    clean
bun test --isolate src/tools/search/ tests/build/     92 pass / 0 fail
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)