### PR TITLE
fix(search): split query tokens on underscore, matching the FTS index tokenizer

### DIFF
--- a/src/search/__tests__/fts-token-boundary.test.ts
+++ b/src/search/__tests__/fts-token-boundary.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Query-side token boundaries must match the FTS index's.
+ *
+ * The index is built with `tokenize='porter unicode61'` (migration 0017), which treats `_`
+ * as a separator. All three query builders extracted tokens with `/[\p{L}\p{N}_]+/gu`,
+ * keeping the underscore, and then quoted each token — so `pane_pid` became the phrase
+ * query `"pane_pid"`, which FTS5 evaluates as the adjacency phrase `pane pid`.
+ *
+ * The effect was silent, not an error: `pane_pid` returned 4 rows where `pane OR pid`
+ * returned 141 on the same corpus, and one of those 4 contained no literal `pane_pid` at
+ * all — it matched adjacent "pane PID". Reported in #2953.
+ *
+ * The tokenizer is deliberately NOT changed: that would need a fleet-wide reindex and would
+ * alter index semantics for everyone. Exact-identifier search, if wanted, belongs in its own
+ * field rather than overloading natural-language FTS.
+ */
+import { describe, expect, test } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { buildTenantFtsQuery } from '../query.ts';
+import { sanitizeFtsQuery } from '../../tools/search/helpers.ts';
+import { buildFtsQuery } from '../../server/handlers.ts';
+
+const BUILDERS: Array<[string, (q: string) => string]> = [
+  ['sanitizeFtsQuery', sanitizeFtsQuery],
+  ['buildTenantFtsQuery', buildTenantFtsQuery],
+  ['buildFtsQuery', buildFtsQuery],
+];
+
+describe('FTS query builders split on underscore, as the index does', () => {
+  for (const [name, build] of BUILDERS) {
+    test(`${name} splits pane_pid into separate OR terms`, () => {
+      const out = build('pane_pid');
+      expect(out).toContain('"pane"');
+      expect(out).toContain('"pid"');
+      expect(out).toContain('OR');
+      // The regression: one quoted token containing the underscore.
+      expect(out).not.toContain('"pane_pid"');
+    });
+
+    test(`${name} treats . and - the same way`, () => {
+      for (const input of ['pane.pid', 'pane-pid']) {
+        const out = build(input);
+        expect(out).toContain('"pane"');
+        expect(out).toContain('"pid"');
+      }
+    });
+
+    test(`${name} still handles non-Latin input`, () => {
+      const out = build('ทดสอบ_ไทย');
+      expect(out).toContain('"ทดสอบ"');
+      expect(out).toContain('"ไทย"');
+    });
+
+    test(`${name} collapses repeated separators without emitting empty tokens`, () => {
+      const out = build('pane___pid');
+      expect(out).not.toContain('""');
+      expect(out).toContain('"pane"');
+      expect(out).toContain('"pid"');
+    });
+  }
+
+  test('against a real FTS5 index, OR recall beats the old phrase behaviour', () => {
+    // The proof that this is a recall bug and not a formatting preference: run both query
+    // shapes against a real index with the production tokenizer.
+    const db = new Database(':memory:');
+    db.run("CREATE VIRTUAL TABLE t USING fts5(body, tokenize='porter unicode61')");
+    db.run("INSERT INTO t(body) VALUES ('the pane_pid value')");
+    db.run("INSERT INTO t(body) VALUES ('a pane holds a pid')");
+    db.run("INSERT INTO t(body) VALUES ('pid alone')");
+
+    const count = (match: string) =>
+      (db.query(`SELECT COUNT(*) c FROM t WHERE t MATCH ?`).get(match) as { c: number }).c;
+
+    const oldPhrase = count('"pane_pid"');
+    const fixed = count(buildFtsQuery('pane_pid'));
+
+    expect(fixed).toBeGreaterThan(oldPhrase);
+    db.close();
+  });
+});

--- a/src/search/query.ts
+++ b/src/search/query.ts
@@ -46,7 +46,10 @@ export function buildTenantFtsQuery(query: string): string {
   const tokens = augmentQueryWithAcronyms(query)
     .replace(/<[^>]*>/g, ' ')
     .normalize('NFKC')
-    .match(/[\p{L}\p{N}_]+/gu)
+    // No `_` — see the note in src/tools/search/helpers.ts. The index tokenizer
+    // (`porter unicode61`) splits on underscore, so keeping it here turns an identifier
+    // into an adjacency phrase instead of an OR. #2953.
+    .match(/[\p{L}\p{N}]+/gu)
     ?.map((token) => token.trim())
     .filter(Boolean) ?? [];
   return [...new Set(tokens)]

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -47,7 +47,7 @@ export function buildFtsQuery(query: string): string {
   const tokens = query
     .replace(/<[^>]*>/g, ' ')
     .normalize('NFKC')
-    .match(/[\p{L}\p{N}_]+/gu)
+    .match(/[\p{L}\p{N}]+/gu) // no `_`: matches the index tokenizer, see helpers.ts (#2953)
     ?.map((token) => token.trim())
     .filter((token) => token.length > 0)
     .slice(0, FTS_TOKEN_LIMIT) ?? [];

--- a/src/tools/search/helpers.ts
+++ b/src/tools/search/helpers.ts
@@ -8,7 +8,14 @@ export function sanitizeFtsQuery(query: string): string {
   const tokens = augmentQueryWithAcronyms(query)
     .replace(/<[^>]*>/g, ' ')
     .normalize('NFKC')
-    .match(/[\p{L}\p{N}_]+/gu)
+    // No `_`: the FTS index is built with `porter unicode61` (migration 0017), which
+    // treats underscore as a separator. Keeping it here produced a single token that was
+    // then quoted — turning `pane_pid` into the adjacency phrase `"pane pid"` rather than
+    // the documented OR-per-term behaviour, so identifier searches collapsed to whatever
+    // happened to have the two words next to each other. Measured: `pane_pid` returned 4
+    // rows where `pane OR pid` returned 141, and one of the 4 contained no literal
+    // `pane_pid` at all. Query-side boundaries must match the index's. See #2953.
+    .match(/[\p{L}\p{N}]+/gu)
     ?.map((token) => token.trim())
     .filter((token) => token.length > 0) ?? [];
 


### PR DESCRIPTION
Fixes #2953 (reported by @TTT3P with a full root-cause trace — this implements essentially
the fix described there).

## The bug

The FTS index is built with `tokenize='porter unicode61'` (migration 0017), which treats `_`
as a separator. All three query builders extracted tokens with `/[\p{L}\p{N}_]+/gu` — keeping
the underscore — then quoted each token. So `pane_pid` became `"pane_pid"`, which FTS5
evaluates as the **adjacency phrase** `pane pid`, not the documented OR-per-term behaviour.

Reported effect: `pane_pid` returned **4 rows** where `pane OR pid` returned **141** on the
same corpus — and one of those 4 contained no literal `pane_pid` at all, matching only
adjacent "pane PID". Silent recall loss with no error.

## Verified the premise, didn't assume it

Rather than trust the tokenizer documentation, ran both query shapes against a real
in-memory FTS5 table with the production tokenizer:

```
phrase "pane_pid" -> 1   |   "pane" OR "pid" -> 2      (of 2 seeded rows)
```

That probe is now part of the regression test, so the claim stays checkable.

## Scope

Three builders, one regex each: `src/tools/search/helpers.ts`, `src/search/query.ts`,
`src/server/handlers.ts` — the MCP tool, tenant path, and HTTP handler respectively.

**The tokenizer is deliberately not changed.** That would require a fleet-wide reindex and
alter index semantics for every consumer. As #2953 argues, exact-identifier search deserves
its own field rather than overloading natural-language FTS.

## Tests

Per builder: underscore splitting, `.`/`-` equivalence, non-Latin input (`ทดสอบ_ไทย`),
repeated separators not emitting empty tokens — plus the real-FTS5 recall comparison.

**Verified failing-closed**: restoring the `_` in any builder turns 3 assertions red for
that builder; restoring the fix returns 13 pass / 0 fail.

Worth noting the 250-line ratchet did its job during this change — an earlier version of my
comment pushed `handlers.ts` to 845 lines against its grandfathered 844 and failed the gate.
Fixed by shortening the comment rather than raising the ceiling.

## Gate

```
bunx tsc --noEmit                                              clean
bun test --isolate src/search/ src/tools/search/ src/server/__tests__/ \
  tests/http/search/ tests/search/ tests/build/                268 pass / 0 fail, 53 files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)