### PR TITLE
fix(learn): await the vector store connection before writing to it

### DIFF
--- a/src/tools/__tests__/learn-vector-connect.test.ts
+++ b/src/tools/__tests__/learn-vector-connect.test.ts
@@ -1,0 +1,48 @@
+/**
+ * `oracle_learn` must await the vector store's connection before writing to it.
+ *
+ * `getVectorStoreByModel` returns the store synchronously while scheduling `connect()` as a
+ * fire-and-forget microtask (`src/vector/factory.ts:206`). Calling `addDocuments` on the
+ * returned store could therefore hit `requireDb()` with `this.db === null` and throw. The
+ * throw was caught and downgraded to `embedding: 'failed'` — while the response still
+ * reported `success: true`, so a caller had no way to tell the learning never reached the
+ * vector index. Reported in #2931 as an "exit-0-not-success at the tooling level".
+ *
+ * `ensureVectorStoreConnected` (factory.ts:212) awaits the pending connect promise for that
+ * model key first. This pins the call site, since the race is timing-dependent and would not
+ * reproduce reliably in a test.
+ */
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const learnSrc = readFileSync(join(import.meta.dir, '..', 'learn.ts'), 'utf-8');
+const factorySrc = readFileSync(
+  join(import.meta.dir, '..', '..', 'vector', 'factory.ts'),
+  'utf-8',
+);
+
+describe('oracle_learn vector store connection', () => {
+  test('awaits ensureVectorStoreConnected rather than the un-awaited getter', () => {
+    expect(learnSrc).toContain('await ensureVectorStoreConnected(');
+    // The regression: taking the store without awaiting its connect.
+    expect(learnSrc).not.toMatch(/const vectorStore = getVectorStoreByModel\(/);
+  });
+
+  test('ensureVectorStoreConnected still awaits the pending connect promise', () => {
+    // Guards the helper's contract: if it stopped awaiting, the call site above would be
+    // correct in shape and still racy in practice.
+    const body = factorySrc.match(
+      /export async function ensureVectorStoreConnected\([\s\S]*?\n}/,
+    )?.[0] ?? '';
+    expect(body).toContain('connectPromises.get(');
+    expect(body).toContain('await pending');
+  });
+
+  test('the failure path still reports embedding status to the caller', () => {
+    // The document is written and FTS-searchable even when embedding fails, so success:true
+    // is defensible — but only while the caller can see `embedding: 'failed'` and act on it.
+    expect(learnSrc).toContain("embeddingStatus = 'failed'");
+    expect(learnSrc).toContain('embedding: embeddingStatus');
+  });
+});

--- a/src/tools/learn.ts
+++ b/src/tools/learn.ts
@@ -9,7 +9,7 @@ import path from 'path';
 import fs from 'fs';
 import { oracleDocuments } from '../db/schema.ts';
 import { detectProject } from '../server/project-detect.ts';
-import { getVectorStoreByModel, getEmbeddingModels } from '../vector/factory.ts';
+import { getEmbeddingModels, ensureVectorStoreConnected } from '../vector/factory.ts';
 import { REPO_ROOT } from '../config.ts';
 import { buildLearningMarkdown, dateSlug, learningSlug, uniqueTail } from '../learn/markdown.ts';
 
@@ -284,7 +284,9 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
   } else {
     try {
       const model = process.env.ORACLE_EMBEDDING_MODEL || 'bge-m3';
-      const vectorStore = getVectorStoreByModel(model);
+      // Awaited: getVectorStoreByModel returns before its fire-and-forget connect()
+      // resolves, so addDocuments could throw on a null db and silently degrade (#2931).
+      const vectorStore = await ensureVectorStoreConnected(model);
       await vectorStore.addDocuments([{
         id,
         document: frontmatter,


### PR DESCRIPTION
Fixes #2931 (reported by @switchaphon with an exact root-cause trace — implemented as
specified there).

## The bug

`getVectorStoreByModel` returns the store synchronously while scheduling `connect()` as a
fire-and-forget microtask (`src/vector/factory.ts:206`):

```ts
const vectorStore = getVectorStoreByModel(model);   // returns immediately
await vectorStore.addDocuments([...]);              // this.db still null -> throws
```

The throw was caught and downgraded to `embedding: 'failed'` — while the response still
returned `success: true`. As the report puts it, an **exit-0-not-success at the tooling
level**: the learning was written to disk but never reached the vector index, and the caller
had no way to detect the gap. `oracle_search` then couldn't find it.

## The fix

One call swap. `ensureVectorStoreConnected` (`factory.ts:212`) already existed and already
awaits the pending connect promise for that model key — the learn path just wasn't using it.

## On `success: true`

Left as-is, deliberately. When embedding fails the markdown file **is** written and the
document **is** FTS-searchable, so it's a genuine partial success, and the caller already
learns about it via `embedding: 'failed'` + `embeddingError`. The test pins that signal so
it can't quietly vanish and turn this back into a silent failure.

## Tests

Pins the call site rather than trying to reproduce a timing-dependent race, and guards
**both** halves — a correct-looking call site is still racy if the helper stops awaiting, so
`ensureVectorStoreConnected`'s own `await pending` is asserted too.

**Verified failing-closed**: restoring the un-awaited getter turns the test red.

The 250-line ratchet also caught my first comment pushing `learn.ts` to 326 against its
grandfathered 324 — shortened the comment rather than raising the ceiling. Now 322.

## Gate

```
bunx tsc --noEmit                                                     clean
bun test --isolate src/tools/__tests__/ src/tools/search/ tests/build/  215 pass / 0 fail
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)