### PR TITLE
fix(indexer): scope smart-delete to projects this run produced (closes #2996)

### DIFF
--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -126,11 +126,34 @@ export class OracleIndexer {
     if (append) {
       console.log('Append mode: skipping smart delete (preserving existing docs from other repo roots)');
     } else {
-      // Smart deletion: remove indexer-created docs whose source file no longer exists
-      const allIndexerDocs = this.db.select({ id: oracleDocuments.id, sourceFile: oracleDocuments.sourceFile })
+      // Smart deletion: remove indexer-created docs whose source file no longer exists.
+      //
+      // Deletion MUST be scoped to what this run actually produced. Writes are
+      // project-scoped (storage.ts tags every row with doc.project || project), so an
+      // unscoped delete pulls in every OTHER project's rows and marks them stale purely
+      // because their sourceFile does not resolve under *this* repoRoot — silently
+      // destroying a shared oracle.db from an unrelated repo. See arra-oracle-v3#2996.
+      //
+      // Scoping by `project === this.project` alone would be wrong: a run legitimately
+      // emits docs for OTHER projects (e.g. ψ/learn/<org>/<repo>/ is tagged with that
+      // nested repo). So the owned set is "every project this run just produced", which
+      // both covers nested projects and excludes projects this repoRoot never writes.
+      const runProjects = new Set(
+        indexDocuments.map(doc => (doc.project ?? this.project)?.toLowerCase() ?? null),
+      );
+
+      const allIndexerDocs = this.db.select({
+        id: oracleDocuments.id,
+        sourceFile: oracleDocuments.sourceFile,
+        project: oracleDocuments.project,
+      })
         .from(oracleDocuments)
         .where(indexerOwnedWhere)
-        .all();
+        .all()
+        // Trade-off: rows for a project this run no longer emits are never reclaimed
+        // (they leak as staleness). That is deliberate — leaking a stale row is
+        // recoverable, deleting another repo's index is not.
+        .filter(d => runProjects.has(d.project ?? null));
 
       const idsToDelete = allIndexerDocs
         .filter(d => !fs.existsSync(path.join(this.config.repoRoot, d.sourceFile)))


### PR DESCRIPTION
Closes #2996.

## The defect

Writes are project-scoped — `storage.ts` tags every row with `doc.project || project`. The smart-delete reconciliation SELECT was not: it filtered only on `createdBy IN ('indexer', NULL)`, pulled **every** project's rows out of the shared `oracle.db`, then marked stale anything whose `sourceFile` did not resolve under the *current* run's `repoRoot`.

Another repo's paths never resolve under your `repoRoot` — so **indexing repo A could delete repo B's entire index.**

## Reproduced, then verified fixed

Against a copy of a real 7,127-doc / 12-project `oracle.db`, indexing from an unrelated `repoRoot`:

| | result |
|---|---|
| before | `error: Refusing to delete 7097/7097 docs (>50%)` — exit 1 |
| after | `Smart delete: 0 stale docs` — exit 0, foreign rows untouched |

**100% of the database**, held back only by the guard.

## The guard is a coincidence detector, not a safety net

It fires only when the reindexing project is a *minority* of rows. Where that project holds a **majority**, stale computes under 50%, the guard never fires, and the remaining projects are deleted **silently at exit 0** — no flag required, indistinguishable from a clean reindex.

It protects large multi-project DBs *by accident* and abandons concentrated ones *by design*. The abort message also recommends `ORACLE_FORCE_REINDEX=1` — precisely the flag that disables the only check that would have stopped it.

## Why not simply `project === this.project`

A run legitimately emits docs for **other** projects: `ψ/learn/<org>/<repo>/` is tagged with that nested repo (one real run produced 2,080 rows belonging to a different oracle). Scoping to the run's own project would strand those forever, unreclaimable.

The owned set is therefore **every project this run just produced** — which covers nested projects and still excludes projects this `repoRoot` never writes. This composes correctly with #3003: the new `collectVaultExtraDocuments` collector simply contributes more projects to that set.

## Legitimate reclamation still works

This is not a disable. Deleting a real source file and reindexing the same `repoRoot` still removes its row — `7129 → 7128`, `Smart delete: 1 stale docs`.

## Trade-off (deliberate)

Rows for a project this run no longer emits are never reclaimed and leak as staleness. **A leaked row is recoverable; another repo's deleted index is not.**

## Scope note

`indexer-pro` carries the identical defect at `src/indexer/index.ts`, but that repo is **archived and read-only**, so it cannot be patched upstream. Anyone still running it from a checkout should apply the same change locally.

## Credit

Found by **memory-oracle** (its run computed 4,919/6,832 = 72% to delete, caught by the guard). Independently source-verified by **digger@m5-alpha** and **digger@black** — the latter confirming live exposure on a 640-project, 175,907-row shared index.

🤖 ตอบโดย digger จาก Nat → digger-oracle