### PR TITLE
fix(mcp): auto-start the daemon that HTTP-proxy mode proxies to

### DIFF
--- a/src/mcp/__tests__/ensure-proxy-target.test.ts
+++ b/src/mcp/__tests__/ensure-proxy-target.test.ts
@@ -1,0 +1,47 @@
+/**
+ * The guard that keeps auto-start from making an outage worse.
+ *
+ * HTTP-proxy mode may legitimately point at another machine. If a *remote* Oracle is down and we
+ * responded by spawning a *local* daemon, that daemon would open a different database, report
+ * healthy, and answer every query with the wrong corpus — silently. A remote target that is down
+ * must stay down and surface its own transport error.
+ */
+import { describe, expect, test } from 'bun:test';
+import { ensureProxyTarget, isLocalDaemonTarget } from '../ensure-proxy-target.ts';
+import { PORT } from '../../config.ts';
+
+describe('isLocalDaemonTarget', () => {
+  test('accepts the local daemon on our port', () => {
+    expect(isLocalDaemonTarget(`http://localhost:${PORT}`)).toBe(true);
+    expect(isLocalDaemonTarget(`http://127.0.0.1:${PORT}`)).toBe(true);
+    expect(isLocalDaemonTarget(`http://[::1]:${PORT}/`)).toBe(true);
+  });
+
+  test('rejects a remote host even on our port — the case that would serve the wrong corpus', () => {
+    expect(isLocalDaemonTarget(`http://black.local:${PORT}`)).toBe(false);
+    expect(isLocalDaemonTarget(`https://oracle.example.com:${PORT}`)).toBe(false);
+    expect(isLocalDaemonTarget(`http://192.168.1.123:${PORT}`)).toBe(false);
+  });
+
+  test('rejects localhost on a different port — that is someone else s server', () => {
+    expect(isLocalDaemonTarget(`http://localhost:${PORT + 1}`)).toBe(false);
+    expect(isLocalDaemonTarget('http://localhost')).toBe(false);
+  });
+
+  test('rejects garbage rather than throwing', () => {
+    expect(isLocalDaemonTarget('not a url')).toBe(false);
+    expect(isLocalDaemonTarget('')).toBe(false);
+  });
+});
+
+describe('ensureProxyTarget', () => {
+  test('is a no-op for a remote target: returns without attempting a local start', async () => {
+    // If this ever tried to start a server it would hang on health polling or spawn a daemon;
+    // resolving promptly is the assertion.
+    await expect(ensureProxyTarget('http://black.local:47778')).resolves.toBeUndefined();
+  });
+
+  test('never throws, so an auto-start failure cannot turn a degraded Oracle into a dead one', async () => {
+    await expect(ensureProxyTarget('nonsense://://')).resolves.toBeUndefined();
+  });
+});

--- a/src/mcp/ensure-proxy-target.ts
+++ b/src/mcp/ensure-proxy-target.ts
@@ -1,0 +1,57 @@
+/**
+ * Auto-start the daemon that HTTP-proxy mode proxies *to*.
+ *
+ * `OracleMCPServer` resolves `ORACLE_HTTP_URL`, logs "Running in HTTP-proxy mode", and then
+ * proxies every tool call to it — but it never called `ensureServerRunning()`. The only callers
+ * were `src/cli/commands/serve.ts` and `ensure-server.ts`'s own main, so nothing on the MCP path
+ * ever restarted a dead daemon. Observed 2026-08-16 on m5: `oracle-http.pid` held PID 53395 from
+ * `2026-08-14T11:43:30Z`, that process was long gone, nothing listened on :47778, and four live
+ * `bin/mcp.ts` processes proxied into the hole. Every `oracle_search` failed with "Cannot reach
+ * ARRA Oracle" while 7,127 documents sat healthy in the database underneath.
+ *
+ * The stale PID file was never the bug — `cleanupStalePidFile()` handles it correctly. It just
+ * never ran, because nothing called the function that calls it.
+ */
+import { PORT } from '../config.ts';
+
+/**
+ * Only a *local* daemon on *our* port may be auto-started.
+ *
+ * `resolveOracleApiBase()` accepts `ORACLE_HTTP_URL` / `ORACLE_API` / `NEO_ARRA_API`, any of
+ * which can legitimately point at another machine (a shared fleet Oracle, a cloud deployment).
+ * Spawning a local server because a *remote* one is unreachable would be worse than the outage:
+ * the local daemon opens a different database, comes up healthy, and answers with the wrong
+ * corpus. A remote target that is down must stay down and surface its own error.
+ */
+export function isLocalDaemonTarget(apiBase: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(apiBase);
+  } catch {
+    return false;
+  }
+  const host = url.hostname.replace(/^\[|\]$/g, '');
+  if (host !== 'localhost' && host !== '127.0.0.1' && host !== '::1') return false;
+  // An explicit port must match ours; a bare host:// with no port is not this daemon.
+  return url.port !== '' && Number(url.port) === PORT;
+}
+
+/**
+ * Idempotent and safe to race: `ensureServerRunning()` health-checks first, cleans a stale PID
+ * file, and takes a start lock, so the four concurrent `bin/mcp.ts` processes on one machine
+ * converge on a single daemon rather than spawning four.
+ *
+ * Never throws. If the daemon cannot be started, the proxied call proceeds and fails with the
+ * real transport error — an auto-start failure must not turn a degraded Oracle into a dead one.
+ */
+export async function ensureProxyTarget(apiBase: string): Promise<void> {
+  if (!isLocalDaemonTarget(apiBase)) return;
+  try {
+    const { ensureServerRunning } = await import('../ensure-server.ts');
+    await ensureServerRunning({ verbose: false, timeout: 15000 });
+  } catch (error) {
+    console.error(
+      `[Oracle] proxy target ${apiBase} is down and auto-start failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -18,6 +18,7 @@ import { probeVectorStore } from './vector-health.ts';
 import { formatEmbedderDegradedWarning, probeConfiguredEmbedder, readEmbedderRuntimeStatus, setEmbedderRuntimeStatus, type EmbedderRuntimeStatus } from '../vector/embedder-config.ts';
 import { resolveInboundToolName, retiredAliasNotice } from './aliases.ts';
 import { proxyToolCall, resolveOracleApiBase } from './http-proxy.ts';
+import { ensureProxyTarget } from './ensure-proxy-target.ts';
 import { pluginMcpToolsFrom } from './plugin-tools.ts';
 import { runWithTenant } from '../middleware/tenant.ts';
 import { stripMcpTenantArgs, tenantIdFromMcpArgs } from './tenant.ts';
@@ -41,6 +42,7 @@ export class OracleMCPServer {
   private explicitEnabledTools = new Set<string>();
   private stopToolGroupsWatch: (() => void) | null = null;
   private embeddedReady: Promise<void> | null = null;
+  private proxyReady: Promise<void> | null = null;
   private readonly oracleApiBase: string | null;
   private readonly unifiedRuntime: McpPluginRuntime;
   private readonly embeddedDeps?: EmbeddedDeps | Promise<EmbeddedDeps>;
@@ -210,6 +212,7 @@ export class OracleMCPServer {
           : {};
         const tenantId = tenantIdFromMcpArgs(rawArgs);
         const args = stripMcpTenantArgs(rawArgs);
+        if (this.oracleApiBase) await (this.proxyReady ??= ensureProxyTarget(this.oracleApiBase));
         const proxied = await proxyToolCall(this.oracleApiBase, toolName, args, tenantId);
         if (proxied) return proxied;
         return await runWithTenant(tenantId, () => tool.handler(args, { version: this.version, getToolCtx: () => this.getToolCtx() }));


### PR DESCRIPTION
## The bug

In HTTP-proxy mode, `OracleMCPServer` resolves `ORACLE_HTTP_URL`, logs *"Running in HTTP-proxy mode"*, and proxies every tool call to it — **but never called `ensureServerRunning()`**.

```
src/mcp/server.ts:68   if (!this.oracleApiBase) this.embeddedReady = this.initEmbedded();
src/mcp/server.ts:213  const proxied = await proxyToolCall(this.oracleApiBase, ...)
```

Its only callers were `src/cli/commands/serve.ts:84` and `ensure-server.ts`'s own main. So once `:47778` died, **nothing on the MCP path ever brought it back.**

## Found live, not hypothetically

On m5 today the daemon had been down for **two days**:

| Evidence | Value |
|---|---|
| `oracle-http.pid` | `{"pid":53395,"port":47778,"startedAt":"2026-08-14T11:43:30.751Z"}` |
| `ps -p 53395` | dead |
| `lsof -iTCP:47778` | nothing listening |
| live `bun bin/mcp.ts` under nat | 4 processes, all proxying into the hole |
| documents in the DB | 7,127, healthy |

Every `oracle_search` failed with "Cannot reach ARRA Oracle" while the data sat fine underneath. The stale PID file was **not** the bug — `cleanupStalePidFile()` (`start-lock.ts:63-69`) handles it correctly. It just never ran, because nothing called the function that calls it.

## The guard is the important part

`ORACLE_HTTP_URL` / `ORACLE_API` / `NEO_ARRA_API` can legitimately point at **another machine**. Spawning a local daemon because a *remote* one is unreachable would be worse than the outage: the local daemon opens a different database, comes up healthy, and answers with the **wrong corpus**, silently.

So `isLocalDaemonTarget()` only accepts `localhost` / `127.0.0.1` / `::1` **on our `PORT`**. A remote target that is down stays down and surfaces its own transport error. That function carries most of the tests.

## Safety

- **Race-safe**: `ensureServerRunning()` health-checks first, cleans stale PIDs, and takes a start lock — the four concurrent `bin/mcp.ts` processes converge on one daemon.
- **Never throws**: an auto-start failure must not turn a degraded Oracle into a dead one; the proxied call proceeds and fails with the real error.
- **Memoised**: ensured once per process, not per tool call.

## Gate

```
bunx tsc --noEmit                              clean
bun test --isolate tests/build/ src/mcp/       99 pass / 0 fail
bun test --isolate src/mcp/__tests__/ensure-proxy-target.test.ts   6 pass / 0 fail
```

`src/mcp/server.ts` grows 3 lines to **exactly 250** — within the ratchet.

Refs #2930

🤖 Generated with [Claude Code](https://claude.com/claude-code)