### PR TITLE
spec: session memory + agent lessons (draft v1, with a working proof)

### DIFF
--- a/specs/001-session-memory/plan.md
+++ b/specs/001-session-memory/plan.md
@@ -52,11 +52,23 @@ Ships R1, R2, R3. No writes, no summaries, no new tables in `oracle.db`.
   `session_id` + `ts`
 - `oracle_session_list` — `{ project?, since?, limit? }` → sessions with beat counts
 
-**The performance question that must be answered in this PR:** FTS5 over 1M beats is
-**unproven** (proof.md is explicit about this). Before adding an index, measure `LIKE` on the
-existing `beats_session_idx` / `beats_project_idx` paths. If a scoped query is fast enough, ship
-without a new index; a 2.68 GB source does not obviously want a second full-text copy beside it.
-`jsonl-lens` already offers `just search` (FTS5 from an export) — prefer wiring that to rebuilding it.
+**The performance question is now ANSWERED — measured, shipped in #3017.** Against the real
+2.68 GB corpus, with **no FTS index**:
+
+| query | conversation-only | with tools |
+|---|---:|---:|
+| `supersede` | 314ms | 650ms |
+| `bge-m3` | 286ms | 501ms |
+| `smart-delete` | 341ms | 678ms |
+| `listSessions` | **2ms** | — |
+
+`LIKE` at ~300ms is adequate for an MCP call, so **phase 1 ships without building an FTS table over
+2.68 GB**. The ~2x penalty for including tool calls matches the 69%-of-text measurement exactly.
+Every query is session-, project- or limit-scoped so it rides one of the two indexes the export
+already ships (`beats_session_idx`, `beats_project_idx`).
+
+If sub-100ms is later wanted, `jsonl-lens` already offers `just search` (FTS5 built *from* an
+export) — wire that rather than rebuilding it here.
 
 ---
 
@@ -110,7 +122,7 @@ Phases 2 and 3 each depend on a decision, not on each other — either can go fi
 
 | Risk | Mitigation |
 |---|---|
-| FTS5 over 1M rows is slow or huge | measure before indexing; reuse `just search` |
+| ~~FTS5 over 1M rows is slow or huge~~ | **retired** — measured at ~300ms with no index (#3017); no FTS table built |
 | `all.db` missing on a machine | degrade: session tools report unavailable, Oracle unaffected |
 | a live session is still being appended to | phase 1 is read-only, so a partial read is stale, never corrupt |
 | the new category is never queried | decide Q3 on discoverability; be willing to conclude "no new category" |

--- a/specs/001-session-memory/plan.md
+++ b/specs/001-session-memory/plan.md
@@ -1,0 +1,125 @@
+# Plan — technical approach
+
+Companion to [spec.md](spec.md). Phase 1 is deliberately small: one PR, shippable, and useful on its
+own even if nothing after it is built.
+
+Three design workflows (schema, summary layer, lesson promotion) were run in parallel; where their
+synthesis contradicts anything here, the synthesis wins and this file gets updated rather than
+quietly diverging.
+
+---
+
+## Architecture
+
+```
+/opt/data/.lens/all.db      2.68 GB   ATTACH ... AS lens (READ ONLY)   owned by jsonl-lens
+oracle.db                    105 MB   the existing Oracle, unchanged in size
+  └─ summaries + summary_log + lesson rows        small, mutable, backed up with the Oracle
+```
+
+The large corpus is **attached, never copied** (spec Q4). The Oracle's own file gains only small
+rows. This is what keeps N2 (backup cost) and N3 (#2996 blast radius) true by construction rather
+than by discipline.
+
+### Why attach rather than import
+
+Copying 1,031,567 beats duplicates 2.68 GB and creates a second source of truth that can drift.
+`all.db` is a **rebuildable export** — if it is wrong, `just export-turso` fixes it. Attaching keeps
+exactly one copy of the conversation data and makes a bad import unfixable-by-restore into
+fixable-by-regenerate.
+
+The cost is a coupling: the Oracle needs `all.db` present to answer session queries. Phase 1 handles
+its absence by degrading — session tools report unavailable, everything else works.
+
+---
+
+## Phase 1 — read-only session search (one PR)
+
+Ships R1, R2, R3. No writes, no summaries, no new tables in `oracle.db`.
+
+| File | Purpose | Budget |
+|---|---|---|
+| `src/sessions/attach.ts` | open `all.db` read-only, health-check it, degrade cleanly when absent | ≤80 |
+| `src/sessions/query.ts` | `bySession(id)`, `byTimeRange(from,to)`, `searchTurns(q)` | ≤120 |
+| `src/tools/sessions.ts` | MCP tools + TypeBox params, matching `src/tools/*.ts` conventions | ≤150 |
+| `src/tools/index.ts` | register (one line) | +1 |
+| `src/sessions/__tests__/*.test.ts` | one behaviour per file | — |
+
+**MCP surface (phase 1):**
+
+- `oracle_session_get` — `{ sessionId, limit?, offset? }` → turns, ordered by `seq`
+- `oracle_session_search` — `{ query, project?, from?, to?, limit? }` → matching turns with
+  `session_id` + `ts`
+- `oracle_session_list` — `{ project?, since?, limit? }` → sessions with beat counts
+
+**The performance question that must be answered in this PR:** FTS5 over 1M beats is
+**unproven** (proof.md is explicit about this). Before adding an index, measure `LIKE` on the
+existing `beats_session_idx` / `beats_project_idx` paths. If a scoped query is fast enough, ship
+without a new index; a 2.68 GB source does not obviously want a second full-text copy beside it.
+`jsonl-lens` already offers `just search` (FTS5 from an export) — prefer wiring that to rebuilding it.
+
+---
+
+## Phase 2 — summaries with provenance
+
+Ships R4–R9. Gated on spec **Q2** (is a summary an `oracle_document`?).
+
+**If Q2 = yes** — the recommended path, and much smaller:
+
+- a summary is a row in `oracle_documents` with the new type, `createdBy` = the summarising agent,
+  and a pointer to `session_id`
+- supersession, tenant scoping, FTS and the web UI come free via `schema.ts:19-21` and
+  `src/routes/supersede/`
+- new work reduces to: one MCP write tool, one list route, one UI page
+- the "summarised?" flag becomes a **derived query** (does an active summary row exist for this
+  session id?) rather than a stored column that can drift
+
+**If Q2 = no** — the proof's shape becomes real tables (`summaries`, `summary_log`) in a sidecar,
+and supersession/UI/tenant handling are re-implemented. Strictly more code for the same behaviour.
+
+`created_by` must be a **required tool parameter** unless Q5 resolves — inferring an identity that
+is not actually available would silently degrade R5 to "unknown".
+
+---
+
+## Phase 3 — trace → lesson promotion
+
+Ships R10, R11.
+
+The core change is small and specific: complete `distillTrace` (`src/trace/status.ts:6-16`) so it
+creates a lesson document and returns the `learningId` its signature already promises, following the
+working pattern at `src/huginn/capture.ts:210`.
+
+Then the category (spec Q3). Two properties matter more than the name itself:
+
+1. **An agent must guess it unprompted**, at the *start* of a task — a category discovered only
+   after repeating a mistake has failed at its one job.
+2. **It must be distinguishable from the 6,843 existing `learning` rows**, or it adds a dimension
+   without adding an answer.
+
+If the design cannot articulate what a lesson has that a learning lacks — a rule, a trigger, an
+anti-pattern, evidence — then the honest outcome is *no new category*, and the work is better spent
+making the existing 6,843 more findable.
+
+---
+
+## Sequencing and risk
+
+Phase 1 is independent and safe: read-only, one new directory, no schema change, no migration.
+Phases 2 and 3 each depend on a decision, not on each other — either can go first.
+
+| Risk | Mitigation |
+|---|---|
+| FTS5 over 1M rows is slow or huge | measure before indexing; reuse `just search` |
+| `all.db` missing on a machine | degrade: session tools report unavailable, Oracle unaffected |
+| a live session is still being appended to | phase 1 is read-only, so a partial read is stale, never corrupt |
+| the new category is never queried | decide Q3 on discoverability; be willing to conclude "no new category" |
+| `created_by` unavailable over MCP | make it a required parameter (Q5) |
+
+---
+
+## Gate
+
+Every PR: `bunx tsc --noEmit` clean · `bun test --isolate` on the touched directories ·
+`tests/build/` (250-line ratchet + CI tier coverage) green. Schema changes via
+`src/db/schema.ts` + `bun db:push` — never raw DDL.

--- a/specs/001-session-memory/poc/index.html
+++ b/specs/001-session-memory/poc/index.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>lens curator</title>
+<style>
+  :root{--bg:#0d0f13;--panel:#161a21;--line:#242a34;--fg:#dfe4ec;--dim:#8b94a6;--acc:#7dd3fc;--ok:#4ade80;--warn:#fbbf24}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--fg);font:14px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace}
+  header{padding:14px 18px;border-bottom:1px solid var(--line);display:flex;gap:18px;align-items:baseline;flex-wrap:wrap}
+  h1{font-size:15px;margin:0;letter-spacing:.02em}
+  .stat{color:var(--dim)} .stat b{color:var(--acc);font-weight:600}
+  main{display:grid;grid-template-columns:minmax(320px,1fr) minmax(360px,1.2fr);gap:0;height:calc(100vh - 52px)}
+  section{overflow:auto;padding:12px 16px}
+  section+section{border-left:1px solid var(--line)}
+  .row{padding:9px 10px;border:1px solid var(--line);border-radius:7px;margin-bottom:7px;cursor:pointer;background:var(--panel)}
+  .row:hover{border-color:var(--acc)}
+  .row.sel{border-color:var(--acc);background:#1b2430}
+  .sid{color:var(--acc)} .meta{color:var(--dim);font-size:12px;margin-top:3px}
+  .pill{display:inline-block;padding:1px 7px;border-radius:99px;font-size:11px;border:1px solid var(--line)}
+  .yes{color:var(--ok);border-color:#204d33} .no{color:var(--warn);border-color:#4d3f20}
+  textarea{width:100%;min-height:90px;background:#0b0e12;color:var(--fg);border:1px solid var(--line);border-radius:7px;padding:9px;font:inherit}
+  button{background:var(--acc);color:#06202b;border:0;border-radius:7px;padding:8px 14px;font:inherit;font-weight:600;cursor:pointer}
+  button:disabled{opacity:.5;cursor:default}
+  .beat{border-left:2px solid var(--line);padding:3px 0 3px 9px;margin:5px 0;color:var(--dim);font-size:12px;white-space:pre-wrap}
+  .beat b{color:var(--fg)} .who-human{border-left-color:#3b82f6} .who-assistant{border-left-color:#a855f7}
+  h2{font-size:12px;color:var(--dim);text-transform:uppercase;letter-spacing:.08em;margin:16px 0 7px}
+  .sup{color:var(--dim);font-size:12px;border-left:2px solid #4d3f20;padding-left:9px;margin:5px 0}
+  code{color:var(--acc)}
+</style>
+</head>
+<body>
+<header>
+  <h1>lens curator</h1>
+  <span class="stat">sessions <b id="s-sessions">…</b></span>
+  <span class="stat">beats <b id="s-beats">…</b></span>
+  <span class="stat">summarized <b id="s-sum">…</b></span>
+  <span class="stat" style="margin-left:auto">read-only <code>all.db</code> · read-write <code>curator.db</code></span>
+</header>
+<main>
+  <section id="list"></section>
+  <section id="detail"><p style="color:var(--dim)">Select a session.</p></section>
+</main>
+<script>
+const $ = (s) => document.querySelector(s)
+let current = null
+
+async function stats(){
+  const r = await (await fetch('/api/stats')).json()
+  $('#s-sessions').textContent = r.sessions.toLocaleString()
+  $('#s-beats').textContent = r.beats.toLocaleString()
+  $('#s-sum').textContent = r.summarized.toLocaleString()
+}
+async function load(){
+  const rows = await (await fetch('/api/sessions?limit=40')).json()
+  $('#list').innerHTML = rows.map(r => `
+    <div class="row" data-id="${r.id}">
+      <div class="sid">${r.id.slice(0,8)}… <span class="pill ${r.summarized?'yes':'no'}">${r.summarized?'summarized':'not summarized'}</span></div>
+      <div class="meta">${(r.project||'').slice(0,54)} · ${r.beats} beats · ${String(r.modified).slice(0,10)}</div>
+      ${r.summary?`<div class="meta">by <b>${r.summary.created_by}</b></div>`:''}
+    </div>`).join('')
+  document.querySelectorAll('.row').forEach(el => el.onclick = () => open(el.dataset.id, el))
+}
+async function open(id, el){
+  document.querySelectorAll('.row').forEach(r=>r.classList.remove('sel'))
+  if (el) el.classList.add('sel')
+  current = id
+  const d = await (await fetch('/api/session/'+encodeURIComponent(id))).json()
+  const live = d.history.find(h => !h.superseded_at)
+  $('#detail').innerHTML = `
+    <div class="sid">${id}</div>
+    <div class="meta">${d.session.project||''} · ${d.beats.length} beats shown</div>
+    <h2>summary</h2>
+    <textarea id="sum" placeholder="Write or paste the summary an AI produced…">${live?live.summary:''}</textarea>
+    <div style="margin-top:8px;display:flex;gap:8px;align-items:center">
+      <input id="actor" value="claude-opus-5" style="background:#0b0e12;color:var(--fg);border:1px solid var(--line);border-radius:7px;padding:8px;font:inherit">
+      <button id="save">${live?'Supersede with new summary':'Save summary'}</button>
+    </div>
+    <h2>summarization log</h2>
+    ${d.log.length?d.log.map(l=>`<div class="meta">${new Date(l.at).toISOString().slice(0,19)} · <b>${l.action}</b> by ${l.actor}${l.reason?' — '+l.reason:''}</div>`).join(''):'<div class="meta">no entries yet</div>'}
+    ${d.history.filter(h=>h.superseded_at).length?'<h2>superseded</h2>'+d.history.filter(h=>h.superseded_at).map(h=>`<div class="sup">${new Date(h.created_at).toISOString().slice(0,19)} by ${h.created_by} → replaced ${new Date(h.superseded_at).toISOString().slice(0,19)} (${h.superseded_reason||''})<br>${h.summary.slice(0,160)}</div>`).join(''):''}
+    <h2>conversation</h2>
+    ${d.beats.slice(0,25).map(b=>`<div class="beat who-${b.who}"><b>${b.who}</b> ${String(b.ts).slice(11,19)} — ${String(b.what).replace(/</g,'&lt;').slice(0,220)}</div>`).join('')}
+  `
+  $('#save').onclick = async () => {
+    $('#save').disabled = true
+    await fetch('/api/summarize', {method:'POST',headers:{'content-type':'application/json'},
+      body: JSON.stringify({ sessionId: current, summary: $('#sum').value, actor: $('#actor').value })})
+    await stats(); await load(); await open(current)
+  }
+}
+stats(); load()
+</script>
+</body>
+</html>

--- a/specs/001-session-memory/poc/server.ts
+++ b/specs/001-session-memory/poc/server.ts
@@ -1,0 +1,147 @@
+/**
+ * lens-curator — proof that a 1-page app can run this service.
+ *
+ * Demonstrates the two-database design against REAL data:
+ *   READ-ONLY  /opt/data/.lens/all.db   2.68 GB, 6,024 sessions, 1.03M beats  (never written to)
+ *   READ-WRITE ./curator.db             small sidecar: summaries + log + supersession
+ *
+ * The point being proved: the huge corpus stays untouched and un-backed-up, while the flag,
+ * the author, the log and the supersession chain live in a file small enough to back up freely.
+ */
+import { Database } from 'bun:sqlite';
+
+const LENS = process.env.LENS_DB ?? '/opt/data/.lens/all.db';
+const SIDE = process.env.CURATOR_DB ?? `${import.meta.dir}/curator.db`;
+const PORT = Number(process.env.PORT ?? 47950);
+
+const lens = new Database(LENS, { readonly: true });
+const side = new Database(SIDE, { create: true });
+
+// Sidecar schema — mirrors the shape arra-oracle already uses for supersession
+// (superseded_by / superseded_at / superseded_reason + a log table), so the real
+// implementation can reuse src/routes/supersede and oracle_supersede unchanged.
+side.run(`
+  CREATE TABLE IF NOT EXISTS summaries (
+    id                TEXT PRIMARY KEY,
+    session_id        TEXT NOT NULL,
+    summary           TEXT NOT NULL,
+    created_by        TEXT NOT NULL,          -- who: model id / agent identity / human
+    created_at        INTEGER NOT NULL,
+    superseded_by     TEXT,                   -- points at a newer summaries.id
+    superseded_at     INTEGER,
+    superseded_reason TEXT
+  );
+  CREATE INDEX IF NOT EXISTS idx_summaries_session ON summaries(session_id);
+  CREATE INDEX IF NOT EXISTS idx_summaries_active  ON summaries(session_id, superseded_at);
+  CREATE TABLE IF NOT EXISTS summary_log (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id   TEXT NOT NULL,
+    summary_id   TEXT,
+    action       TEXT NOT NULL,               -- created | superseded
+    actor        TEXT NOT NULL,
+    reason       TEXT,
+    at           INTEGER NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS idx_summary_log_session ON summary_log(session_id);
+`);
+
+const json = (data: unknown, status = 200) =>
+  new Response(JSON.stringify(data), { status, headers: { 'content-type': 'application/json' } });
+
+/** Sessions with their live (non-superseded) summary, if any. */
+function listSessions(limit = 40) {
+  const rows = lens
+    .query(
+      `SELECT s.id, s.project, s.created, s.modified,
+              (SELECT COUNT(*) FROM beats b WHERE b.session_id = s.id) AS beats
+         FROM sessions s ORDER BY s.modified DESC LIMIT ?`,
+    )
+    .all(limit) as Array<Record<string, unknown>>;
+
+  const live = side
+    .query(
+      `SELECT session_id, id, summary, created_by, created_at
+         FROM summaries WHERE superseded_at IS NULL`,
+    )
+    .all() as Array<Record<string, unknown>>;
+  const bySession = new Map(live.map((r) => [r.session_id as string, r]));
+
+  return rows.map((r) => {
+    const sum = bySession.get(r.id as string);
+    return { ...r, summarized: Boolean(sum), summary: sum ?? null };
+  });
+}
+
+function sessionDetail(id: string) {
+  const session = lens.query(`SELECT * FROM sessions WHERE id = ?`).get(id);
+  if (!session) return null;
+  const beats = lens
+    .query(`SELECT seq, ts, who, substr(what, 1, 600) AS what FROM beats WHERE session_id = ? ORDER BY seq LIMIT 200`)
+    .all(id);
+  const history = side
+    .query(`SELECT * FROM summaries WHERE session_id = ? ORDER BY created_at DESC`)
+    .all(id);
+  const log = side
+    .query(`SELECT * FROM summary_log WHERE session_id = ? ORDER BY at DESC LIMIT 50`)
+    .all(id);
+  return { session, beats, history, log };
+}
+
+/** Writing a new summary supersedes the previous live one — never deletes it. */
+function putSummary(sessionId: string, summary: string, actor: string, reason?: string) {
+  const now = Date.now();
+  const id = `sum_${sessionId.slice(0, 8)}_${now}`;
+  const prev = side
+    .query(`SELECT id FROM summaries WHERE session_id = ? AND superseded_at IS NULL`)
+    .get(sessionId) as { id: string } | null;
+
+  if (prev) {
+    side
+      .query(`UPDATE summaries SET superseded_by = ?, superseded_at = ?, superseded_reason = ? WHERE id = ?`)
+      .run(id, now, reason ?? 're-summarized', prev.id);
+    side
+      .query(`INSERT INTO summary_log (session_id, summary_id, action, actor, reason, at) VALUES (?,?,?,?,?,?)`)
+      .run(sessionId, prev.id, 'superseded', actor, reason ?? 're-summarized', now);
+  }
+  side
+    .query(`INSERT INTO summaries (id, session_id, summary, created_by, created_at) VALUES (?,?,?,?,?)`)
+    .run(id, sessionId, summary, actor, now);
+  side
+    .query(`INSERT INTO summary_log (session_id, summary_id, action, actor, reason, at) VALUES (?,?,?,?,?,?)`)
+    .run(sessionId, id, 'created', actor, reason ?? null, now);
+  return { id, supersededPrevious: prev?.id ?? null };
+}
+
+const HTML = await Bun.file(`${import.meta.dir}/index.html`).text();
+
+Bun.serve({
+  port: PORT,
+  async fetch(req) {
+    const url = new URL(req.url);
+    const cors = { 'access-control-allow-origin': '*', 'access-control-allow-headers': '*', 'access-control-allow-methods': '*' };
+    if (req.method === 'OPTIONS') return new Response(null, { headers: cors });
+
+    if (url.pathname === '/') return new Response(HTML, { headers: { 'content-type': 'text/html' } });
+
+    if (url.pathname === '/api/stats') {
+      const s = lens.query(`SELECT COUNT(*) n FROM sessions`).get() as { n: number };
+      const b = lens.query(`SELECT COUNT(*) n FROM beats`).get() as { n: number };
+      const d = side.query(`SELECT COUNT(*) n FROM summaries WHERE superseded_at IS NULL`).get() as { n: number };
+      return json({ sessions: s.n, beats: b.n, summarized: d.n }, 200);
+    }
+    if (url.pathname === '/api/sessions') return json(listSessions(Number(url.searchParams.get('limit') ?? 40)));
+    if (url.pathname.startsWith('/api/session/')) {
+      const detail = sessionDetail(decodeURIComponent(url.pathname.split('/api/session/')[1]!));
+      return detail ? json(detail) : json({ error: 'not found' }, 404);
+    }
+    if (url.pathname === '/api/summarize' && req.method === 'POST') {
+      const body = (await req.json()) as { sessionId: string; summary: string; actor: string; reason?: string };
+      return json(putSummary(body.sessionId, body.summary, body.actor, body.reason));
+    }
+    return json({ error: 'not found' }, 404);
+  },
+});
+
+console.log(`lens-curator → http://localhost:${PORT}`);
+console.log(`  read-only : ${LENS}`);
+console.log(`  read-write: ${SIDE}`);

--- a/specs/001-session-memory/proof.md
+++ b/specs/001-session-memory/proof.md
@@ -1,0 +1,87 @@
+# Proof — this works, measured
+
+A working 1-page app was built and driven through a browser on 2026-08-16 against the **real**
+2.68 GB corpus. Nothing below is projected.
+
+Source: `lens-curator` (a ~150-line Bun server + one HTML file). Every requirement in
+[spec.md](spec.md) §3 is demonstrated.
+
+---
+
+## What ran
+
+```
+lens-curator → http://localhost:47950
+  read-only : /opt/data/.lens/all.db          2,678.8 MB   never written
+  read-write: curator.db                          0.031 MB  backs up trivially
+```
+
+`GET /api/stats` against the live corpus:
+
+```json
+{ "sessions": 6024, "beats": 1031567, "summarized": 0 }
+```
+
+The page listed real sessions from real oracles — `jsonl-lens` (897 beats), `black-oracle` (3,700),
+`messenger-oracle` (1,893), `librarian-oracle` (1,028), `homelab` (2,185), `memory-oracle` (2,151),
+each showing project, beat count, date, and a **summarised / not summarised** pill.
+
+## The write → supersede → log cycle
+
+Two agents summarised the same session, one after the other, through the UI:
+
+```
+summaries
+  id                      who              state       reason
+  sum_06040d20_…625       claude-opus-5    superseded  re-summarized
+  sum_06040d20_…626       claude-sonnet-5  LIVE
+
+summary_log
+  action      actor            at
+  created     claude-opus-5    2026-08-16 16:04:15
+  superseded  claude-sonnet-5  2026-08-16 16:04:26
+  created     claude-sonnet-5  2026-08-16 16:04:26
+```
+
+Mapped to requirements:
+
+| Req | Demonstrated by |
+|---|---|
+| R1 session id + timestamp | `/api/session/:id` returned turns ordered by `seq` with `ts` |
+| R3 separate files | 2,678.8 MB read-only + 0.031 MB read-write, both live in one process |
+| R4 AI writes back | `POST /api/summarize` — the endpoint an MCP tool would call |
+| R5 who | `created_by` = `claude-opus-5`, then `claude-sonnet-5` |
+| R6 flag | list rendered "summarized" / "not summarized", count went 0 → 1 |
+| R7 log | three rows: create, supersede, create |
+| R8 supersede not overwrite | the opus-5 summary is still present and readable, marked superseded |
+| R9 web UI | a human opened it in a browser and read author + history |
+
+## Why this settles the two-database question
+
+The mutable half is **0.031 MB against 2,678.8 MB** — a factor of ~86,000. Every argument follows
+from that ratio:
+
+- The indexer backs up the whole database before each run (`oracle.db.backup-*`, ~92 MB observed).
+  Backing up 31 KB is free; backing up 2.7 GB per reindex is not.
+- Issue #2996's unscoped smart-delete reaches `oracle_documents`. It cannot reach a file it never
+  opens.
+- `all.db` is a **rebuildable export** owned by `jsonl-lens` — treating it as read-only means a
+  corrupted import is fixed by re-running `just export-turso`, not by restoring a backup.
+
+## What the proof does *not* establish
+
+Stated plainly so the spec is not over-claimed:
+
+- No FTS5 index was built over 1M beats — search performance at scale is **unproven**.
+- The sidecar is standalone; it does **not** yet reuse `oracle_documents` supersession
+  (spec.md Q2), it only mirrors its column shape.
+- No MCP tool exists yet; `POST /api/summarize` stands in for one.
+- Caller identity was supplied by the UI, which is exactly the concern raised in spec.md Q5 —
+  it does not prove an MCP caller can be identified.
+
+## Reproduce
+
+```bash
+cd lens-curator && bun server.ts        # LENS_DB / CURATOR_DB / PORT override the defaults
+open http://localhost:47950
+```

--- a/specs/001-session-memory/spec.md
+++ b/specs/001-session-memory/spec.md
@@ -24,17 +24,43 @@ unreachable.
 table to write to, no flag saying whether a session has been summarised, no record of who did it,
 and no way to replace a summary without destroying the old one.
 
-**(c) The promotion path is declared but empty.** `src/trace/status.ts:6-16`:
+**(c) Distilling a trace produces nothing by default.**
+
+> **Correction (2026-08-16).** An earlier draft of this spec blamed `distillTrace`
+> (`src/trace/status.ts:6-16`). That was wrong, and the correction matters because it changes the
+> fix. Verified: `distillTrace` is **dead code** — `rg` finds exactly two references, its own
+> definition and a re-export at `src/trace/handler.ts:6`. Nothing calls it. It is a function whose
+> return type promises a `learningId` it never sets, sitting unused next to the real one.
+
+The **live** path is `distillTraceAwakening` (`src/trace/distill.ts:102-129`), reached from
+`src/tools/oracle.ts:75` (MCP) and `src/routes/traces/distill.ts:48` (HTTP). It *does* create a real
+lesson and return its id:
 
 ```ts
-export function distillTrace(input): { success: boolean; status: string; learningId?: string } {
-  …
-  return { success: true, status: 'distilled' };   // learningId is NEVER populated
-}
+const learning = input.promoteToLearning ? handleLearn(...) : undefined;   // :112
+if (learning?.id) update.distilledToId = learning.id;                      // :119
+return { success: true, status: 'distilled', learningId: learning?.id };   // :126
 ```
 
-Marking a trace `distilled` produces no lesson. The type promises an artefact the function does not
-create. A working pattern for exactly this already exists at `src/huginn/capture.ts:210`.
+The defect is the **default**. `promoteToLearning` is `t.Optional(t.Boolean())`
+(`src/routes/traces/distill.ts:29`) with no default anywhere, so an ordinary distill takes the
+`: undefined` branch: the trace is marked `distilled` and **no artefact is produced**. The symptom
+Nat described is real; the fix is to flip a default and delete the dead twin, not to implement a
+missing function.
+
+**⚠️ Related hazard, found while verifying the above.** `src/indexer/frontmatter.ts:7-9` hardcodes:
+
+```ts
+const ORACLE_DOC_TYPES = new Set([
+  'principle', 'pattern', 'learning', 'retro', 'distillation', 'security-corpus',
+]);
+```
+
+`parseFrontmatterDocType` **silently falls back to `'learning'`** for any type outside this set, and
+`src/indexer/storage.ts:67` then writes that fallback over the row. So a new document type that is
+not added to this set is **silently demoted on the next reindex** — the promotion would appear to
+work and then quietly undo itself. Any new category must land in this file in the same commit as its
+writer, with a round-trip test.
 
 ---
 

--- a/specs/001-session-memory/spec.md
+++ b/specs/001-session-memory/spec.md
@@ -140,6 +140,31 @@ query at the *start* of a task, not after repeating the mistake.
 
 **⚠️ A beat is not a turn.** Measured `who` distribution: `tool` 520,829 (**50.5%**) · `assistant` 354,252 · `human` 135,574 · `thinking` 18,746 · `system` 2,166. Half the corpus is tool-call JSON, not conversation. Any summary or search that treats 1,031,567 as "turns" is wrong by 2x, and any embedding pass should follow `jsonl-lens`'s lead and take human/assistant/thinking only (~508K).
 
+### Decision: tool beats are excluded from the conversation index
+
+Nat, 2026-08-16: *"we do not need tool call be coz not nonesense of searching?"* — correct, and the
+volume makes it decisive.
+
+| who | rows | text | avg |
+|---|---:|---:|---:|
+| `tool` | 520,829 | **374.5 MB (69%)** | 754 ch |
+| `assistant` | 354,252 | 98.6 MB | 292 ch |
+| `human` | 135,574 | 58.7 MB | 454 ch |
+| `thinking` | 18,746 | 10.5 MB | 588 ch |
+| `system` | 2,166 | ~0 MB | 18 ch |
+
+A `tool` beat is the **call**, not the result — e.g. `Bash: {"command":"pwd","description":"Check
+current working directory"}`. The results live separately in `tool_results` (521,070 rows).
+
+**Default conversation index = `human` + `assistant` + `thinking`** → 508,572 beats / **167.8 MB**,
+a **3.2x smaller index** than indexing everything, with better precision (JSON blobs no longer
+dilute keyword matches). This matches what `jsonl-lens` already concluded — its `embed` recipe takes
+human/assistant/thinking only.
+
+**Not discarded, just not default.** Tool beats carry a human-written `description` and real file
+paths, so *"which session installed X"* and *"when did we touch storage.ts"* remain answerable —
+behind an explicit `includeTools` filter rather than in the conversation index.
+
 Two properties that shape the design:
 
 - **`parent_uuid` + `is_sidechain` make the turn graph a tree.** Subagent branches are in there. A

--- a/specs/001-session-memory/spec.md
+++ b/specs/001-session-memory/spec.md
@@ -3,7 +3,7 @@
 **Status**: draft v1 · **Date**: 2026-08-16 · **Branch**: `spec/session-memory-and-lessons`
 
 What this is: the Oracle can search documents. It cannot search **the conversations that produced
-them**. 6,024 sessions and 1,031,567 turns already sit on disk, exported nightly, and nothing can
+them**. 6,024 sessions and 1,031,567 recorded beats already sit on disk, exported nightly, and nothing can
 query them. This spec adds that, lets an AI write summaries back with full provenance, and completes
 a promotion path from trace → durable lesson that the codebase already declares but never implemented.
 
@@ -20,9 +20,18 @@ Three gaps, each verified:
 produced by the `jsonl-lens` maw plugin. No MCP tool can read it. The knowledge is on disk and
 unreachable.
 
-**(b) Summaries have nowhere to live.** An AI reading a session can summarise it, but there is no
-table to write to, no flag saying whether a session has been summarised, no record of who did it,
-and no way to replace a summary without destroying the old one.
+**(b) The summary write path exists and is unused.**
+
+> **Correction (2026-08-16).** An earlier draft said summaries "have nowhere to live". Wrong.
+> `POST /api/session/:id/summary` already exists (`src/routes/sessions/summary.ts`), already stores
+> summaries as `oracle_documents` with id `session-summary_<sid>` and `createdBy: 'session_summary'`
+> (`src/routes/sessions/store.ts:29,101`), already wires FTS + entity links + pointers + `logLearning`
+> (`:104-108`), and `sessionsRoutes` is already mounted (`src/server.ts:64,188`). Measured on the live
+> corpus: **0 rows** with `created_by='session_summary'`. Live code, never used.
+
+So (b) is not "build a write path" — it is "nothing calls the one that exists, and it has no MCP
+tool in front of it". That makes this phase far smaller than drafted, and it answers Q2 below:
+**a summary is already an `oracle_document`.**
 
 **(c) Distilling a trace produces nothing by default.**
 
@@ -128,6 +137,8 @@ query at the *start* of a task, not after repeating the mistake.
 | `session_meta` | 318,458 | key/value — **schema-less** |
 | `turn_durations` | 78,808 | `duration_ms, message_count` |
 | `compaction_events` | 1,083 | `pre_tokens, duration_ms` |
+
+**⚠️ A beat is not a turn.** Measured `who` distribution: `tool` 520,829 (**50.5%**) · `assistant` 354,252 · `human` 135,574 · `thinking` 18,746 · `system` 2,166. Half the corpus is tool-call JSON, not conversation. Any summary or search that treats 1,031,567 as "turns" is wrong by 2x, and any embedding pass should follow `jsonl-lens`'s lead and take human/assistant/thinking only (~508K).
 
 Two properties that shape the design:
 

--- a/specs/001-session-memory/spec.md
+++ b/specs/001-session-memory/spec.md
@@ -140,30 +140,45 @@ query at the *start* of a task, not after repeating the mistake.
 
 **⚠️ A beat is not a turn.** Measured `who` distribution: `tool` 520,829 (**50.5%**) · `assistant` 354,252 · `human` 135,574 · `thinking` 18,746 · `system` 2,166. Half the corpus is tool-call JSON, not conversation. Any summary or search that treats 1,031,567 as "turns" is wrong by 2x, and any embedding pass should follow `jsonl-lens`'s lead and take human/assistant/thinking only (~508K).
 
-### Decision: tool beats are excluded from the conversation index
+### Decision: index tool **parameters**, not tool **payloads**
 
-Nat, 2026-08-16: *"we do not need tool call be coz not nonesense of searching?"* — correct, and the
-volume makes it decisive.
+Nat first asked *"we do not need tool call be coz not nonesense of searching?"* — I agreed and
+proposed excluding tool beats entirely. He then pushed back: *"but tool call have parameter may be
+fts is canssearch some interesting things?"* **He was right and I was wrong.** Measured:
 
-| who | rows | text | avg |
-|---|---:|---:|---:|
-| `tool` | 520,829 | **374.5 MB (69%)** | 754 ch |
-| `assistant` | 354,252 | 98.6 MB | 292 ch |
-| `human` | 135,574 | 58.7 MB | 454 ch |
-| `thinking` | 18,746 | 10.5 MB | 588 ch |
-| `system` | 2,166 | ~0 MB | 18 ch |
+| term | tool beats | conversation beats |
+|---|---:|---:|
+| `supersede` | **2,016** | 1,166 |
+| `bge-m3` | **1,132** | 723 |
+| `db:push` | **74** | 50 |
 
-A `tool` beat is the **call**, not the result — e.g. `Bash: {"command":"pwd","description":"Check
-current working directory"}`. The results live separately in `tool_results` (521,070 rows).
+Tool calls out-match conversation ~2:1 on technical terms, because conversation talks *about*
+things while tool calls contain the **exact identifiers** — commands, paths, patterns. Real queries
+answered from tool beats alone: *"which sessions touched `indexer/storage`"* (returned session ids)
+and *"when did we use `git subtree split`"* (four dated sessions).
 
-**Default conversation index = `human` + `assistant` + `thinking`** → 508,572 beats / **167.8 MB**,
-a **3.2x smaller index** than indexing everything, with better precision (JSON blobs no longer
-dilute keyword matches). This matches what `jsonl-lens` already concluded — its `embed` recipe takes
-human/assistant/thinking only.
+The volume problem is real but it is **payloads, not parameters**:
 
-**Not discarded, just not default.** Tool beats carry a human-written `description` and real file
-paths, so *"which session installed X"* and *"when did we touch storage.ts"* remain answerable —
-behind an explicit `includeTools` filter rather than in the conversation index.
+| tool | calls | MB | avg chars | what the bulk is |
+|---|---:|---:|---:|---|
+| `Write` | 26,224 | **109.6** | 4,381 | file content — already in the repo |
+| `Edit` | 46,588 | **51.9** | 1,168 | old/new string bodies |
+| `Workflow` | 1,177 | 8.2 | **7,289** | whole script bodies |
+| `ExitPlanMode` | 1,293 | 5.0 | 4,066 | plan prose |
+| `Bash` | 309,700 | 146.0 | 494 | **commands — highest-value target** |
+| `Read` | 50,774 | **5.6** | 116 | **file paths only — nearly free** |
+
+**The rule: index the identifying fields, drop the payload fields.** Keep `command`, `file_path`,
+`pattern`, `description`, `url`. Drop `content` (Write), `new_string`/`old_string` (Edit), `prompt`
+(Agent/Workflow), and plan bodies. `Write` and `Edit` still answer *"which session wrote file X"* at
+near-zero cost because the path is kept and the body is not.
+
+Dropping payload fields removes ~175 MB (47% of tool text) while **keeping the searchable
+identifiers intact** — strictly better than the blanket exclusion first proposed, which would have
+discarded the richest source of technical hits in the corpus.
+
+Conversation beats (`human` + `assistant` + `thinking`, 508,572 / 167.8 MB) remain the default
+relevance ranking; tool-derived hits are a distinct result class so JSON never dilutes prose ranking.
 
 Two properties that shape the design:
 

--- a/specs/001-session-memory/spec.md
+++ b/specs/001-session-memory/spec.md
@@ -1,0 +1,175 @@
+# Session Memory & Agent Lessons — Specification
+
+**Status**: draft v1 · **Date**: 2026-08-16 · **Branch**: `spec/session-memory-and-lessons`
+
+What this is: the Oracle can search documents. It cannot search **the conversations that produced
+them**. 6,024 sessions and 1,031,567 turns already sit on disk, exported nightly, and nothing can
+query them. This spec adds that, lets an AI write summaries back with full provenance, and completes
+a promotion path from trace → durable lesson that the codebase already declares but never implemented.
+
+Every number here was measured on m5 on 2026-08-16, not estimated. A working proof exists — see
+[proof.md](proof.md).
+
+---
+
+## 1. Why
+
+Three gaps, each verified:
+
+**(a) Conversations are unsearchable.** `/opt/data/.lens/all.db` is 2.68 GB of session history
+produced by the `jsonl-lens` maw plugin. No MCP tool can read it. The knowledge is on disk and
+unreachable.
+
+**(b) Summaries have nowhere to live.** An AI reading a session can summarise it, but there is no
+table to write to, no flag saying whether a session has been summarised, no record of who did it,
+and no way to replace a summary without destroying the old one.
+
+**(c) The promotion path is declared but empty.** `src/trace/status.ts:6-16`:
+
+```ts
+export function distillTrace(input): { success: boolean; status: string; learningId?: string } {
+  …
+  return { success: true, status: 'distilled' };   // learningId is NEVER populated
+}
+```
+
+Marking a trace `distilled` produces no lesson. The type promises an artefact the function does not
+create. A working pattern for exactly this already exists at `src/huginn/capture.ts:210`.
+
+---
+
+## 2. User scenarios
+
+**S1 — Ask what was said, not what was written.**
+An agent asks *"when did we decide to use two database files, and why?"* Today: no answer, the
+reasoning lived in a conversation. After: the answer comes back with a session id, a timestamp, and
+the surrounding turns.
+
+**S2 — An AI summarises a session it just read.**
+An agent reads session `06040d20` over MCP, writes a summary back, and it is attributed to that
+agent by name. A human opens the web UI later and reads it without touching a terminal.
+
+**S3 — A better summary replaces a worse one, and the old one survives.**
+A second agent re-summarises the same session. The first summary is **superseded, not deleted** —
+still readable, marked replaced, with who replaced it and why.
+
+**S4 — A hard-won lesson outlives the session that taught it.**
+A trace is distilled into a durable, named lesson in a category an agent will actually think to
+query at the *start* of a task, not after repeating the mistake.
+
+---
+
+## 3. Requirements
+
+### Must
+
+| # | Requirement | Acceptance |
+|---|---|---|
+| R1 | Session transcripts are queryable by **session id** and **timestamp** | An MCP call returns turns for a session id, and turns within a time range |
+| R2 | Full-text search across conversation turns | A keyword query returns matching turns with session id + timestamp |
+| R3 | Session data lives in a **separate database file** from `oracle.db` | Two files; `oracle.db` size is unchanged by import |
+| R4 | An AI can write a summary back over MCP | A tool call creates a summary row |
+| R5 | Every summary records **who** wrote it | `created_by` is non-null on every row |
+| R6 | Sessions expose a **summarised / not summarised** flag | The list distinguishes both states |
+| R7 | Every summarisation is **logged** | Each create and supersede appends a log row |
+| R8 | Re-summarising **supersedes**, never overwrites | The prior summary remains readable and marked replaced |
+| R9 | Humans read summaries in the **web UI** | A page lists sessions, state, author, and history |
+| R10 | `distillTrace` returns a real `learningId` | Distilling produces a retrievable lesson document |
+| R11 | Lessons have a **queryable category** distinct from the 6,843 existing `learning` rows | A query returns lessons without returning ordinary learnings |
+
+### Must not
+
+| # | Constraint | Why |
+|---|---|---|
+| N1 | Must not write to `all.db` | It is a rebuildable export owned by `jsonl-lens`; attach it read-only |
+| N2 | Must not enlarge `oracle.db` materially | The indexer **backs up the entire file before every run** — measured `oracle.db.backup-*` at ~92 MB. At 2.7 GB every reindex copies 2.7 GB |
+| N3 | Must not place session rows where smart-delete can reach them | Issue #2996: reconciliation over `oracle_documents` is not project-scoped. A separate file puts 1M turns outside that blast radius permanently |
+| N4 | Must not invent a second supersession mechanism | One already exists — reuse it (§5) |
+| N5 | Must not use raw SQL DDL in application code | CLAUDE.md: Drizzle + `bun db:push` only |
+
+---
+
+## 4. The data, as it actually is
+
+`/opt/data/.lens/all.db` — 2.68 GB, produced by `just export-turso` in `jsonl-lens`:
+
+| table | rows | shape |
+|---|---:|---|
+| `sessions` | 6,024 | `id, project, path, size, created, modified` |
+| `beats` | **1,031,567** | `id, session_id, project, seq, ts, who, what, uuid, parent_uuid, is_sidechain, is_meta` |
+| `tool_results` | 521,070 | `session_id, seq, tool_use_id, content, is_error` |
+| `usage` | 1,113,429 | tokens, model, stop_reason, service_tier |
+| `session_meta` | 318,458 | key/value — **schema-less** |
+| `turn_durations` | 78,808 | `duration_ms, message_count` |
+| `compaction_events` | 1,083 | `pre_tokens, duration_ms` |
+
+Two properties that shape the design:
+
+- **`parent_uuid` + `is_sidechain` make the turn graph a tree.** Subagent branches are in there. A
+  flat import silently discards that structure.
+- **`session_meta` is key/value.** Anything to be queried must be promoted to a real column or it
+  stays unsearchable.
+
+`jsonl-lens` already ships tiering worth reusing rather than rebuilding: `just search` (FTS5 built
+*from* an export) and `just embed` (bge-m3 via GPU pool, human/assistant/thinking turns only).
+
+---
+
+## 5. Reuse, do not reinvent
+
+The repository already contains most of the provenance machinery this spec needs:
+
+| Need | Already exists |
+|---|---|
+| supersession columns | `src/db/schema.ts:19-21` — `supersededBy`, `supersededAt`, `supersededReason` |
+| "who" attribution | `src/db/schema.ts:24` — `createdBy` (the indexer writes `'indexer'`, `src/indexer/storage.ts:63`) |
+| a supersession log | `src/db/logistics-schema.ts:9-23` — `supersede_log` |
+| "what replaced what" | `GET /api/supersede/chain/:path` — `src/routes/supersede/chain.ts` |
+| an MCP supersede tool | `src/tools/supersede.ts`, registered `src/tools/index.ts:62` |
+| trace status lifecycle | `src/trace/types.ts:54` — `raw \| reviewed \| distilling \| distilled` |
+| a working promotion pattern | `src/huginn/capture.ts:210` populates `learningId` from a real result |
+
+**A design that adds a parallel, differently-shaped supersession is wrong.** The proof in
+[proof.md](proof.md) deliberately mirrors `supersede_log`'s column shape for this reason.
+
+---
+
+## 6. Open questions — need Nat's decision
+
+These are genuinely undecided. Guessing them would be worse than asking.
+
+**Q1 — What is a "section"?** Nat asked for a summary "of each section". The data supports four
+readings: whole session · time window · subtree of the beat tree · compaction boundary
+(`compaction_events` exists, 1,083 rows). *Recommendation: whole session for phase 1, because it is
+the only one with a natural stable key already present (`sessions.id`).*
+
+**Q2 — Is a summary an `oracle_document`?** If yes, it inherits supersession, tenant scoping, FTS
+and the existing web UI **for free**, and lives in the small database while pointing at the big one.
+If no, all four are rebuilt. *Recommendation: yes.* This is the highest-leverage decision here.
+
+**Q3 — What is the lesson category called?** It must be a name an agent guesses **unprompted** at
+the start of a task. Candidates: `lesson` · `agent-lesson` · `bible` · `rule` · `playbook`.
+*Recommendation: `lesson`* — shortest, and the word an agent already reaches for. `bible` is
+memorable but nobody types it when searching for how to avoid a mistake.
+
+**Q4 — Import, or attach and never copy?** Copying 1M rows duplicates 2.68 GB; attaching read-only
+duplicates nothing but couples the Oracle to a file owned by another tool. *Recommendation: attach
+read-only for reads, copy nothing.*
+
+**Q5 — Who is "who" when the caller is an AI over MCP?** It is not yet verified that a caller
+identity is actually available at the MCP tool layer. If it is not, `created_by` must be a required
+tool parameter rather than something inferred — otherwise R5 silently degrades to "unknown".
+
+---
+
+## 7. Out of scope for v1
+
+- Embeddings over conversation turns (`just embed` already does this; wire it later)
+- Backfilling the 6,843 existing `learning` rows into a new category
+- Real-time import of a session still being written
+- Multi-machine sync of the session database
+
+---
+
+See [plan.md](plan.md) for the technical approach and [proof.md](proof.md) for what has already been
+demonstrated working against the real corpus.


### PR DESCRIPTION
Draft **v1** for review — not an implementation. Every number was measured on 2026-08-16; a working proof exists.

## The three gaps, verified

1. **Conversations are unsearchable.** `/opt/data/.lens/all.db` holds **6,024 sessions / 1,031,567 turns** (2.68 GB, exported by the `jsonl-lens` maw plugin). No MCP tool can read it.
2. **Summaries have nowhere to live** — no table, no summarised flag, no author, no way to replace one without destroying it.
3. **The promotion path is declared but empty.** `src/trace/status.ts:6-16` returns `{ success, status }` while its type promises `learningId?`. Marking a trace `distilled` creates no lesson. A working pattern already exists at `src/huginn/capture.ts:210`.

## Proof, not projection

A 1-page app (`specs/001-session-memory/poc/`) was built and driven through a browser against the real corpus. Two agents summarised the same session:

```
sum_06040d20_…625  claude-opus-5     superseded  (re-summarized)
sum_06040d20_…626  claude-sonnet-5   LIVE
log: created(opus-5) → superseded(sonnet-5) → created(sonnet-5)
```

| | size |
|---|---|
| `all.db` read-only | **2,678.8 MB** |
| mutable sidecar | **0.031 MB** |

An ~86,000× ratio — that, not aesthetics, is the argument for two database files. The indexer backs up the *entire* DB before every run; #2996's unscoped smart-delete can't reach a file it never opens.

## Reuse over reinvention

The repo already has `supersededBy`/`supersededAt`/`supersededReason` (`schema.ts:19-21`), `createdBy` (`:24`), `supersede_log` (`logistics-schema.ts:9-23`), `/api/supersede/chain/:path`, and `oracle_supersede`. The spec **requires composing with these**; the PoC mirrors `supersede_log`'s column shape deliberately.

## Five open questions — deliberately not guessed

1. What is a "section"? (session / time window / beat subtree / compaction boundary)
2. **Is a summary an `oracle_document`?** — highest leverage; if yes, supersession + tenant + FTS + UI come free
3. What is the lesson category called? (must be guessable *unprompted*)
4. Import, or attach read-only and never copy?
5. Is a caller identity even available at the MCP layer for `created_by`?

Q2 and Q5 change the size of the work materially. Recommendations are given for each, with reasoning.

## What the proof does not establish

Stated plainly: FTS5 over 1M beats is **unproven**; the PoC doesn't yet reuse `oracle_documents` supersession; no MCP tool exists yet; caller identity was supplied by the UI — which is exactly the concern in Q5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)