### PR TITLE
fix(supersede): the MCP path never wrote its own audit log

### DIFF
--- a/src/tools/__tests__/supersede-writes-log.test.ts
+++ b/src/tools/__tests__/supersede-writes-log.test.ts
@@ -1,0 +1,105 @@
+/**
+ * arra_supersede must leave an audit row.
+ *
+ * Until this test, only the HTTP route (`src/routes/supersede/create.ts:46`) wrote
+ * `supersede_log`. `runSupersede` — the MCP path — updated `oracle_documents` and returned
+ * success without recording anything, so every supersession performed by an agent was invisible
+ * to the audit table that exists precisely to record them. Nothing failed; the history was just
+ * absent, which is the worst shape for a logging bug.
+ *
+ * The distinction the log depends on, and the easiest thing to get wrong:
+ *   oracle_documents.superseded_by  = the SUCCESSOR DOCUMENT id
+ *   supersede_log.superseded_by     = the ACTOR who performed it
+ * They share a name and mean different things.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const TMP = mkdtempSync(join(tmpdir(), 'supersede-log-'));
+const ORIGINAL_DATA_DIR = process.env.ORACLE_DATA_DIR;
+
+beforeAll(() => {
+  process.env.ORACLE_DATA_DIR = TMP;
+});
+
+afterAll(() => {
+  if (ORIGINAL_DATA_DIR) process.env.ORACLE_DATA_DIR = ORIGINAL_DATA_DIR;
+  else delete process.env.ORACLE_DATA_DIR;
+  try { rmSync(TMP, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+describe('arra_supersede writes an audit row', () => {
+  test('a successful supersession appends exactly one supersede_log row', async () => {
+    const { db, oracleDocuments } = await import('../../db/index.ts');
+    const { supersedeLog } = await import('../../db/logistics-schema.ts');
+    const { runSupersede } = await import('../supersede.ts');
+    const { eq } = await import('drizzle-orm');
+
+    const now = Date.now();
+    const oldId = `t_old_${now}`;
+    const newId = `t_new_${now}`;
+
+    for (const [id, file] of [[oldId, `ψ/a-${now}.md`], [newId, `ψ/b-${now}.md`]] as const) {
+      db.insert(oracleDocuments).values({
+        id, type: 'learning', sourceFile: file, project: 'github.com/test/repo',
+        concepts: '[]', createdAt: now, updatedAt: now, indexedAt: now,
+      }).run();
+    }
+
+    const before = db.select().from(supersedeLog).all().length;
+    const result = runSupersede(db, { oldId, newId, reason: 'audit-row test' });
+    expect((result.payload as { success: boolean }).success).toBe(true);
+
+    const rows = db.select().from(supersedeLog).all();
+    expect(rows.length).toBe(before + 1);
+
+    const row = rows.find((r) => r.oldId === oldId);
+    expect(row).toBeDefined();
+    expect(row!.newId).toBe(newId);
+    expect(row!.reason).toBe('audit-row test');
+    expect(row!.oldPath).toBe(`ψ/a-${now}.md`);        // notNull — must be a real path
+    expect(row!.newPath).toBe(`ψ/b-${now}.md`);
+    expect(row!.project).toBe('github.com/test/repo');
+    expect(row!.supersededAt).toBeGreaterThan(0);
+
+    // The actor, NOT the successor id. Writing newId here would silently corrupt the audit
+    // trail into a duplicate of a column oracle_documents already holds.
+    expect(row!.supersededBy).toBe('mcp');
+    expect(row!.supersededBy).not.toBe(newId);
+
+    // and the document itself still records the successor, unchanged by the logging
+    const doc = db.select().from(oracleDocuments).where(eq(oracleDocuments.id, oldId)).get();
+    expect(doc?.supersededBy).toBe(newId);
+  });
+
+  test('an already-superseded no-op does not append a second row', async () => {
+    const { db, oracleDocuments } = await import('../../db/index.ts');
+    const { supersedeLog } = await import('../../db/logistics-schema.ts');
+    const { runSupersede } = await import('../supersede.ts');
+
+    const now = Date.now();
+    const oldId = `t_noop_old_${now}`;
+    const newId = `t_noop_new_${now}`;
+    for (const [id, file] of [[oldId, `ψ/c-${now}.md`], [newId, `ψ/d-${now}.md`]] as const) {
+      db.insert(oracleDocuments).values({
+        id, type: 'learning', sourceFile: file,
+        concepts: '[]', createdAt: now, updatedAt: now, indexedAt: now,
+      }).run();
+    }
+
+    runSupersede(db, { oldId, newId, reason: 'first' });
+    const afterFirst = db.select().from(supersedeLog).all().length;
+
+    // repeating the same supersession is a no-op; it must not double-log
+    const again = runSupersede(db, { oldId, newId, reason: 'second' });
+    expect((again.payload as { unchanged?: boolean }).unchanged).toBe(true);
+    expect(db.select().from(supersedeLog).all().length).toBe(afterFirst);
+  });
+});
+
+test('the temp data dir was actually used, not the real one', () => {
+  expect(process.env.ORACLE_DATA_DIR).toBe(TMP);
+  expect(existsSync(TMP)).toBe(true);
+});

--- a/src/tools/supersede.ts
+++ b/src/tools/supersede.ts
@@ -7,6 +7,7 @@
 
 import { and, eq } from 'drizzle-orm';
 import { oracleDocuments } from '../db/schema.ts';
+import { supersedeLog } from '../db/logistics-schema.ts';
 import { currentTenantId } from '../middleware/tenant.ts';
 import type { ToolContext, ToolResponse, OracleSupersededInput } from './types.ts';
 
@@ -116,6 +117,8 @@ export function runSupersede(db: ToolContext['db'], input: OracleSupersededInput
   const oldDoc = db.select({
     id: oracleDocuments.id,
     type: oracleDocuments.type,
+    sourceFile: oracleDocuments.sourceFile,
+    project: oracleDocuments.project,
     supersededBy: oracleDocuments.supersededBy,
     supersededAt: oracleDocuments.supersededAt,
     supersededReason: oracleDocuments.supersededReason,
@@ -123,7 +126,7 @@ export function runSupersede(db: ToolContext['db'], input: OracleSupersededInput
     .from(oracleDocuments)
     .where(docWhere(oldId))
     .get();
-  const newDoc = db.select({ id: oracleDocuments.id, type: oracleDocuments.type })
+  const newDoc = db.select({ id: oracleDocuments.id, type: oracleDocuments.type, sourceFile: oracleDocuments.sourceFile })
     .from(oracleDocuments)
     .where(docWhere(newId))
     .get();
@@ -172,6 +175,23 @@ export function runSupersede(db: ToolContext['db'], input: OracleSupersededInput
     })
     .where(docWhere(oldId))
     .run();
+
+  // #7: the audit row. Until now only the HTTP route (routes/supersede/create.ts:46) wrote
+  // supersede_log, so every supersession performed over MCP was silently unlogged.
+  // `supersededBy` here is the ACTOR, not the successor id — the successor lives in
+  // oracleDocuments.supersededBy. There is no principal on ToolContext, so 'mcp' names the
+  // channel we can actually vouch for rather than inventing a user we cannot.
+  db.insert(supersedeLog).values({
+    oldPath: oldDoc.sourceFile,
+    oldId,
+    oldType: oldDoc.type,
+    newPath: newDoc.sourceFile,
+    newId,
+    reason,
+    supersededAt: now,
+    supersededBy: 'mcp',
+    project: oldDoc.project,
+  }).run();
 
   console.error(`[SUPERSEDE] ${oldId} → superseded by → ${newId}`);
 


### PR DESCRIPTION
## The bug

`supersede_log` exists to record supersessions. Only the **HTTP route** ever wrote it (`src/routes/supersede/create.ts:46`).

`runSupersede` — the path every agent takes via `arra_supersede` — updated `oracle_documents` and returned success **without recording anything**.

Nothing failed. The history was simply absent, which is the worst shape a logging bug can take: the table looks healthy while quietly missing every agent-initiated supersession.

## The distinction it turns on

```
oracle_documents.superseded_by  = the SUCCESSOR DOCUMENT id
supersede_log.superseded_by     = the ACTOR who performed it
```

Same column name, different meaning. Writing `newId` into the log would have produced a plausible-looking audit trail that merely duplicated a column we already have — so the test asserts `supersededBy === 'mcp'` **and** `!== newId`.

## Why the actor is `'mcp'`

`ToolContext` (`src/tools/types.ts:15-23`) carries `db, sqlite, repoRoot, vectorStore, vectorStatus, vectorReason, embedderProvider, version` — **no principal**. There is no caller identity at the MCP layer.

So `'mcp'` names the channel we can actually vouch for rather than inventing a user we cannot. If a principal ever reaches that layer, that is the one line to change. (This is the same finding that makes "who summarized" a *claim* rather than verified identity in spec #3013's Q5.)

## Verified fail-closed

A ratchet that cannot fail is worthless, so I checked it can:

```
remove the insert  → 2 pass / 1 fail
restore it         → 3 pass / 0 fail
```

## Gate

```
bunx tsc --noEmit                              0 errors
bun test --isolate src/tools/ tests/build/     218 pass / 0 fail
bun test --isolate src/routes/supersede/ …     6 pass / 0 fail
src/tools/supersede.ts                         221 lines (limit 250)
```

Also widened the existing selects to carry `sourceFile` and `project`, so `oldPath` (which is `NOT NULL`) is a real path rather than a placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)