### PR TITLE
feat(sessions): give the summary write path an MCP tool, so an AI can actually reach it

### DIFF
--- a/src/tools/__tests__/session-summarize.test.ts
+++ b/src/tools/__tests__/session-summarize.test.ts
@@ -1,0 +1,101 @@
+/**
+ * The MCP write path for session summaries.
+ *
+ * The route it wraps had zero rows in the live corpus despite being mounted and working — the
+ * only plausible caller is an AI, and an AI arrives over MCP, where no tool existed. These tests
+ * pin the three things that make the tool trustworthy rather than merely present: it writes a real
+ * document, it refuses to record an unattributed author, and a second summary is reported as a
+ * supersession decision rather than an opaque filesystem error.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const TMP = mkdtempSync(join(tmpdir(), 'session-summarize-'));
+const ORIGINAL_DATA_DIR = process.env.ORACLE_DATA_DIR;
+const ORIGINAL_REPO_ROOT = process.env.ORACLE_REPO_ROOT;
+const ctx = {} as Parameters<typeof import('../session-summary.ts').handleSessionSummarize>[0];
+
+beforeAll(() => {
+  process.env.ORACLE_DATA_DIR = TMP;
+  process.env.ORACLE_REPO_ROOT = TMP;
+});
+
+afterAll(() => {
+  if (ORIGINAL_DATA_DIR) process.env.ORACLE_DATA_DIR = ORIGINAL_DATA_DIR;
+  else delete process.env.ORACLE_DATA_DIR;
+  if (ORIGINAL_REPO_ROOT) process.env.ORACLE_REPO_ROOT = ORIGINAL_REPO_ROOT;
+  else delete process.env.ORACLE_REPO_ROOT;
+  try { rmSync(TMP, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+const parse = (res: { content: Array<{ text: string }> }) => JSON.parse(res.content[0]!.text);
+
+describe('oracle_session_summarize', () => {
+  test('writes a summary and returns the document it created', async () => {
+    const { handleSessionSummarize } = await import('../session-summary.ts');
+    const sessionId = `sess-${Date.now()}`;
+
+    const res = await handleSessionSummarize(ctx, {
+      sessionId,
+      summary: 'Chose two database files because the indexer backs up the whole DB each run.',
+      author: 'claude-opus-5',
+    });
+
+    const body = parse(res);
+    expect(res.isError).toBeUndefined();
+    expect(body.success).toBe(true);
+    expect(body.sessionId).toBe(sessionId);
+    expect(body.author).toBe('claude-opus-5');
+    expect(body.documentId).toContain(sessionId);
+    expect(body.sourceFile).toContain(sessionId);
+  });
+
+  test('the summary is a real, retrievable oracle_document — not just a file', async () => {
+    const { handleSessionSummarize } = await import('../session-summary.ts');
+    const { db, oracleDocuments } = await import('../../db/index.ts');
+    const { eq } = await import('drizzle-orm');
+    const sessionId = `sess-doc-${Date.now()}`;
+
+    const body = parse(await handleSessionSummarize(ctx, {
+      sessionId, summary: 'A durable summary.', author: 'claude-sonnet-5',
+    }));
+
+    const row = db.select().from(oracleDocuments).where(eq(oracleDocuments.id, body.documentId)).get();
+    expect(row).toBeDefined();
+    // createdBy marks the write path; the claimed author lives in the document body.
+    expect(row!.createdBy).toBe('session_summary');
+    expect(row!.supersededBy).toBeNull();   // a fresh summary is the live one
+  });
+
+  test('refuses an unattributed summary rather than recording "unknown"', async () => {
+    const { handleSessionSummarize } = await import('../session-summary.ts');
+    const res = await handleSessionSummarize(ctx, {
+      sessionId: `sess-anon-${Date.now()}`,
+      summary: 'Who wrote this?',
+    });
+    expect(res.isError).toBe(true);
+    expect(parse(res).error).toContain('author');
+  });
+
+  test('a second summary is a supersession decision, not an opaque error', async () => {
+    const { handleSessionSummarize } = await import('../session-summary.ts');
+    const sessionId = `sess-dup-${Date.now()}`;
+    const first = await handleSessionSummarize(ctx, { sessionId, summary: 'First.', author: 'a' });
+    expect(parse(first).success).toBe(true);
+
+    const second = await handleSessionSummarize(ctx, { sessionId, summary: 'Second.', author: 'b' });
+    const body = parse(second);
+    expect(second.isError).toBe(true);
+    expect(body.error).toContain('already exists');
+    // the caller is told what to do, not just what failed
+    expect(body.hint).toContain('supersede');
+  });
+
+  test('missing sessionId and summary are rejected before any write', async () => {
+    const { handleSessionSummarize } = await import('../session-summary.ts');
+    expect(parse(await handleSessionSummarize(ctx, { summary: 'x', author: 'a' })).error).toContain('sessionId');
+    expect(parse(await handleSessionSummarize(ctx, { sessionId: 's', author: 'a' })).error).toContain('summary');
+  });
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -109,6 +109,7 @@ export type {
 } from './types.ts';
 export { reflectToolDef, handleReflect } from './reflect.ts';
 export { verifyToolDef, handleVerify } from './verify.ts';
+export { sessionSummarizeToolDef, handleSessionSummarize } from './session-summary.ts';
 
 // MCP-IN bridge tools: consume tools from external stdio MCP servers.
 export type { OracleMcpServerInput, OracleMcpCallInput } from './mcp-in.ts';

--- a/src/tools/session-summary.ts
+++ b/src/tools/session-summary.ts
@@ -1,0 +1,103 @@
+/**
+ * MCP write path for session summaries.
+ *
+ * `POST /api/session/:id/summary` has existed and worked for some time
+ * (`src/routes/sessions/summary.ts`, mounted at `src/server.ts:188`): it stores a summary as an
+ * ordinary `oracle_document` with id `session-summary_<sid>` and `createdBy: 'session_summary'`,
+ * wiring FTS, entity links, document pointers and the learn log. Measured on the live corpus:
+ * **0 rows** with that `created_by`. Live code, never called — because the only caller would be an
+ * AI, and an AI reaches this Oracle over MCP, where no tool existed.
+ *
+ * This is that tool. It adds no storage and no schema: a summary was already an oracle_document,
+ * so supersession, tenant scoping, FTS and the web UI all apply to it for free.
+ *
+ * On "who": `ToolContext` carries no principal (`src/tools/types.ts:15-23`), so the author cannot
+ * be verified at this layer — it is a *claim* made by the caller. `author` is therefore a required
+ * argument rather than something inferred, so the record says who claimed authorship instead of
+ * silently recording "unknown".
+ */
+import type { ToolContext, ToolResponse } from './types.ts';
+
+const text = (payload: unknown, isError = false): ToolResponse => ({
+  content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }],
+  ...(isError ? { isError: true } : {}),
+});
+
+export const sessionSummarizeToolDef = {
+  name: 'oracle_session_summarize',
+  description:
+    'Write a summary of a session back to the Oracle, so a human can read it in the web UI and ' +
+    'search finds it later. Stored as an ordinary document, so it is searchable and supersedable ' +
+    'like any other. Read the session first with oracle_session_get.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      sessionId: {
+        type: 'string',
+        description: 'The session being summarised, e.g. from oracle_session_list',
+      },
+      summary: {
+        type: 'string',
+        description: 'The summary text. Write what a person would need to know without reading the session.',
+      },
+      author: {
+        type: 'string',
+        description:
+          'Who is writing this — your model or agent name, e.g. "claude-opus-5". Required, and ' +
+          'recorded as a claim: this layer cannot verify caller identity, so an unattributed ' +
+          'summary would be worse than an attributed one.',
+      },
+    },
+    required: ['sessionId', 'summary', 'author'],
+  },
+};
+
+interface SummarizeInput {
+  sessionId?: string;
+  summary?: string;
+  author?: string;
+}
+
+export async function handleSessionSummarize(
+  _ctx: ToolContext,
+  input: SummarizeInput = {},
+): Promise<ToolResponse> {
+  const sessionId = input?.sessionId?.trim();
+  const summary = input?.summary?.trim();
+  const author = input?.author?.trim();
+
+  if (!sessionId) return text({ success: false, error: 'oracle_session_summarize requires sessionId' }, true);
+  if (!summary) return text({ success: false, error: 'oracle_session_summarize requires summary' }, true);
+  if (!author) {
+    return text({
+      success: false,
+      error: 'oracle_session_summarize requires author — name your model or agent. Provenance is not inferable here.',
+    }, true);
+  }
+
+  try {
+    const { persistSessionSummary } = await import('../routes/sessions/store.ts');
+    const result = persistSessionSummary(sessionId, summary, author);
+    return text({
+      success: true,
+      sessionId,
+      author,
+      documentId: result.learning_id,
+      sourceFile: result.source_file,
+      tenantId: result.tenant_id,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    // A summary already existing is an ordinary outcome, not a crash. Say so plainly, and say
+    // what to do about it, rather than returning a raw filesystem error.
+    if (message.startsWith('File already exists:')) {
+      return text({
+        success: false,
+        sessionId,
+        error: `A summary already exists for session ${sessionId}.`,
+        hint: 'Replacing a summary is a supersession, not an overwrite — supersede the existing document with arra_supersede so the previous summary stays readable.',
+      }, true);
+    }
+    return text({ success: false, sessionId, error: message }, true);
+  }
+}


### PR DESCRIPTION
## A finished feature nobody could call

`POST /api/session/:id/summary` has existed, worked, and been mounted (`src/server.ts:188`) for some time. It stores a summary as an ordinary `oracle_document` (`session-summary_<sid>`, `createdBy: 'session_summary'`), wiring FTS, entity links, document pointers and the learn log.

Measured on the live corpus:

```sql
SELECT COUNT(*) FROM oracle_documents WHERE created_by='session_summary';  -- 0
```

**Live code, zero rows.** The only plausible caller is an AI; an AI arrives over MCP; no MCP tool existed. The feature was built and unreachable.

## This PR is wiring, not architecture

Adds **no storage and no schema**. A summary was already an `oracle_document`, so supersession, tenant scoping, FTS and the web UI apply to it for free. (This is the same conclusion spec #3013's Q2 was asking about — it turns out the codebase answered it already.)

## `author` is required, on purpose

`ToolContext` (`src/tools/types.ts:15-23`) carries `db, sqlite, repoRoot, vector*, version` — **no principal**. Authorship cannot be verified at this layer; it is a **claim**.

So `author` is a required argument rather than something inferred. The record then says *who claimed it* instead of silently storing "unknown" — and inferring an identity we cannot check would be worse than asking for one. A test pins the refusal.

## Re-summarising

A second summary returns the existing 409, but as a **supersession decision** with a hint pointing at `arra_supersede`, rather than an opaque `File already exists`.

The route's 409 behaviour is **unchanged** and its existing tests still pass. Turning re-summarise into an automatic supersession is a real behaviour change and belongs in its own PR with your call — the spec's R8 wants supersession, but silently changing a mounted route's semantics underneath its tests is not the way to get there.

## Gate

```
bunx tsc --noEmit                                                     0 errors
src/tools/ + src/routes/sessions/ + tests/http/sessions/ + build/     227 pass / 0 fail
new file                                                              103 lines
```

Refs #3013

🤖 Generated with [Claude Code](https://claude.com/claude-code)