### PR TITLE
fix(indexer): say something when a document type is not recognised

### DIFF
--- a/src/indexer/__tests__/unknown-doc-type-warns.test.ts
+++ b/src/indexer/__tests__/unknown-doc-type-warns.test.ts
@@ -1,0 +1,62 @@
+/**
+ * An unrecognised document type must be loud.
+ *
+ * `parseFrontmatterDocType` falls back to a default when it does not recognise a type, and
+ * `src/indexer/storage.ts` then writes that fallback over the row. So a document type that is not
+ * in `ORACLE_DOC_TYPES` appears to work when written and is **demoted on the next reindex** — no
+ * error, no failed test, just a type that quietly reverts. The document survives; only its
+ * classification is lost, which is the hardest kind of loss to notice.
+ *
+ * The distinction that makes the warning correct: declaring NO type is ordinary and must stay
+ * silent; declaring an UNKNOWN type is a mistake and must not.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { parseFrontmatterDocType } from '../frontmatter.ts';
+
+const doc = (type?: string) => `---\n${type ? `type: ${type}\n` : ''}title: A document\n---\n\nbody\n`;
+
+let warnings: string[] = [];
+const realWarn = console.warn;
+
+beforeEach(() => {
+  warnings = [];
+  console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(' ')); };
+});
+
+afterEach(() => {
+  console.warn = realWarn;
+});
+
+describe('parseFrontmatterDocType', () => {
+  test('a known type is returned unchanged, silently', () => {
+    expect(parseFrontmatterDocType(doc('retro'), ['type'], 'learning')).toBe('retro');
+    expect(parseFrontmatterDocType(doc('principle'), ['type'], 'learning')).toBe('principle');
+    expect(warnings).toEqual([]);
+  });
+
+  test('no declared type falls back silently — this is the ordinary case', () => {
+    expect(parseFrontmatterDocType(doc(), ['type'], 'learning')).toBe('learning');
+    expect(warnings).toEqual([]);
+  });
+
+  test('an UNKNOWN declared type still falls back, but says so', () => {
+    // e.g. someone adds a `lesson` type to the writer and forgets ORACLE_DOC_TYPES
+    const result = parseFrontmatterDocType(doc('lesson'), ['type'], 'learning');
+    expect(result).toBe('learning');                       // behaviour unchanged — still safe
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain('lesson');
+    expect(warnings[0]).toContain('ORACLE_DOC_TYPES');     // names the file to edit
+    expect(warnings[0]).toContain('reindex');              // names the consequence
+  });
+
+  test('warns once per unknown type, not once per document', () => {
+    for (let i = 0; i < 5; i++) parseFrontmatterDocType(doc('lesson'), ['type'], 'learning');
+    // a corpus with thousands of such documents must not produce thousands of lines
+    expect(warnings.filter((w) => w.includes('lesson')).length).toBeLessThanOrEqual(1);
+  });
+
+  test('a different unknown type gets its own warning', () => {
+    parseFrontmatterDocType(doc('bible'), ['type'], 'learning');
+    expect(warnings.some((w) => w.includes('bible'))).toBe(true);
+  });
+});

--- a/src/indexer/frontmatter.ts
+++ b/src/indexer/frontmatter.ts
@@ -50,9 +50,29 @@ export function parseFrontmatterTime(content: string, keys: string[]): number | 
   return Number.isFinite(timestamp) ? timestamp : null;
 }
 
+/**
+ * Warn once per unrecognised type, per process. A document declaring an unknown type is a
+ * *different* situation from one declaring none, and the old code could not tell them apart.
+ */
+const warnedTypes = new Set<string>();
+
 export function parseFrontmatterDocType(content: string, keys: string[], fallback: OracleDocumentType): OracleDocumentType {
   const raw = parseFrontmatterString(content, keys);
-  return raw && ORACLE_DOC_TYPES.has(raw) ? raw as OracleDocumentType : fallback;
+  if (!raw) return fallback;                                  // no type declared — fallback is correct
+  if (ORACLE_DOC_TYPES.has(raw)) return raw as OracleDocumentType;
+
+  // A type WAS declared and we do not recognise it. Silently returning the fallback is how a new
+  // document type appears to work and then quietly undoes itself: storage.ts writes this value
+  // over the row on every reindex, so the type reverts with no error and no diff to notice.
+  if (!warnedTypes.has(raw)) {
+    warnedTypes.add(raw);
+    console.warn(
+      `[indexer] unknown document type "${raw}" — using "${fallback}" instead. ` +
+      'Add it to ORACLE_DOC_TYPES in src/indexer/frontmatter.ts, or every document of this type ' +
+      'will be demoted on every reindex.',
+    );
+  }
+  return fallback;
 }
 
 /**


### PR DESCRIPTION
## One expression, two very different situations

```ts
return raw && ORACLE_DOC_TYPES.has(raw) ? raw as OracleDocumentType : fallback;
```

- Declaring **no** type → fallback is correct, and should be silent.
- Declaring an **unknown** type → a mistake, and was *equally* silent.

Since `src/indexer/storage.ts:67` writes the parsed value over the row, a type missing from that `Set` **appears to work when written and is demoted on the next reindex** — no error, no failing test, just a classification that quietly reverts. The document survives; only its type is lost, which is the hardest kind of loss to notice.

## Not hypothetical

`ORACLE_DOC_TYPES` holds six types:

```ts
['principle', 'pattern', 'learning', 'retro', 'distillation', 'security-corpus']
```

The live corpus contains **two** (`learning` 6,843, `retro` 284). Anyone adding a seventh — the `lesson` category under discussion in #3013 — walks straight into this unless they also edit this file. Now the message names the file *and* the consequence:

```
[indexer] unknown document type "lesson" — using "learning" instead.
Add it to ORACLE_DOC_TYPES in src/indexer/frontmatter.ts, or every document of
this type will be demoted on every reindex.
```

## Behaviour is unchanged

It still falls back. Nothing new is rejected, nothing new is written — this only removes the silence. Warns **once per unknown type per process**, so a corpus with thousands of such files doesn't produce thousands of lines.

## Gate

```
bunx tsc --noEmit                                       0 errors
src/indexer/ + tests/indexer/ + tests/build/            280 pass / 0 fail
```

Refs #3013

🤖 Generated with [Claude Code](https://claude.com/claude-code)