### PR TITLE
fix(server): bind loopback by default, opt into 0.0.0.0 via ORACLE_HOST

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,8 +67,11 @@ ENV ORACLE_LOG_TARGET=stderr
 CMD ["bun", "dist/index.js"]
 
 FROM production AS http-server
+# ORACLE_HOST: the app binds loopback by default (see src/config.ts). A container
+# must listen on every interface for `docker run -p` / compose `ports:` to reach it.
 ENV ORACLE_PORT=47778 \
-    PORT=47778
+    PORT=47778 \
+    ORACLE_HOST=0.0.0.0
 EXPOSE 47778
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD bun -e "const r=await fetch('http://127.0.0.1:47778/api/health');process.exit(r.ok?0:1)"

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,20 @@ function pathFromDatabaseUrl(value?: string): string {
 
 export const PORT = parseInt(String(envText('ORACLE_PORT') || envText('PORT') || C.ORACLE_DEFAULT_PORT), 10);
 /**
+ * Interface to bind.
+ *
+ * Defaults to loopback because the HTTP API is unauthenticated unless
+ * ARRA_API_TOKEN is set - isApiAuthorized() returns true when the token is
+ * empty (src/server/api-token-auth.ts). Bun binds every interface when
+ * `hostname` is omitted, so the previous behaviour published the whole
+ * knowledge base to the local network the moment the host firewall let the
+ * runtime through, with nothing in the logs to say so.
+ *
+ * Set ORACLE_HOST=0.0.0.0 to opt back in. Containers need it, and the
+ * Dockerfile sets it for that reason.
+ */
+export const HOST = envText('ORACLE_HOST') || envText('HOST') || '127.0.0.1';
+/**
  * The user's real data directory, independent of any env override.
  *
  * `ORACLE_DATA_DIR` below honours `process.env.ORACLE_DATA_DIR`, so a test that redirects it

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { swagger } from '@elysiajs/swagger';
 import { eq } from 'drizzle-orm';
 import { configure, writePidFile, removePidFile } from './process-manager/index.ts';
-import { PORT, ORACLE_DATA_DIR, VECTOR_URL } from './config.ts';
+import { HOST, PORT, ORACLE_DATA_DIR, VECTOR_URL } from './config.ts';
 import { MCP_SERVER_NAME } from './const.ts';
 import { db, sqlite, closeDb, indexingStatus, settings } from './db/index.ts';
 import { isApiAuthorized, isApiPathProtected, unauthorizedApiResponse } from './server/api-token-auth.ts';
@@ -82,7 +82,7 @@ import { simpleModeResponse } from './simple-mode.ts';
 import pkg from '../package.json' with { type: 'json' };
 
 type UnifiedRuntime = Awaited<ReturnType<typeof loadUnifiedPlugins>>;
-type ServerSpec = { port: number; fetch(request: Request): Response | Promise<Response> };
+type ServerSpec = { port: number; hostname: string; fetch(request: Request): Response | Promise<Response> };
 type ElysiaApp = Elysia<any, any, any, any, any, any, any>;
 type RouteModule = Parameters<ElysiaApp['use']>[0];
 export interface StartServerOptions { writePidFile?: boolean }
@@ -243,7 +243,7 @@ export async function createStartedApp(options: StartServerOptions = {}): Promis
   await seedMenus(app, unifiedPlugins);
   await announceStartup(app, startupConfig);
   const serverFetch = createRequestTimeoutFetch(createRequestDedupFetch(createApiVersionedFetch(createTenantFetch(createDbContextFetch((request: Request) => app.fetch(request))))));
-  return { port: Number(PORT), fetch: (request) => drainingResponseFor(request) ?? trackRequest(() => serverFetch(request)) };
+  return { port: Number(PORT), hostname: HOST, fetch: (request) => drainingResponseFor(request) ?? trackRequest(() => serverFetch(request)) };
 }
 
 function resetIndexerStatus(): void {


### PR DESCRIPTION
## Problem

`createStartedApp()` returns `{ port, fetch }` with no `hostname`, and **Bun listens on every interface when `hostname` is omitted**. Combined with the auth model:

```ts
// src/server/api-token-auth.ts
export function isApiAuthorized(request: Request) {
  const configured = apiToken();
  if (!configured) return true;   // no ARRA_API_TOKEN → every request authorized
```

…an install that has not set `ARRA_API_TOKEN` accepts unauthenticated reads **and writes** from any host that can reach the port — `/api/search`, `/api/list`, `/api/learn` and the rest are all past the gate.

Two things make this easy to miss rather than easy to notice:

- The startup banner prints `URL: http://localhost:47778`. That reads as a promise of loopback-only, and there is no counter-signal anywhere in normal operation — no warning, no log line, nothing in `/api/health`.
- On a desktop OS the first run raises the platform's "allow this app through the firewall?" prompt for the *runtime* (`bun`), not for Oracle. Approving it is the obvious answer to an unrelated-looking question, and on Windows that prompt defaults to a rule scoped to the Public profile with `RemoteAddress=Any`.

So the exposed configuration is the one you get by following the happy path, and the safe one is the one you have to know to ask for. That seems worth inverting.

## Change

| file | change |
|---|---|
| `src/config.ts` | new `HOST` export — `ORACLE_HOST` / `HOST`, **default `127.0.0.1`** |
| `src/server.ts` | `ServerSpec` gains `hostname`; `createStartedApp()` passes `HOST` |
| `Dockerfile` | `http-server` stage sets `ORACLE_HOST=0.0.0.0` |

The Dockerfile change is load-bearing: a container has to listen on every interface for `docker run -p` and compose `ports:` to reach it, so the published image keeps today's behaviour explicitly rather than by accident.

This follows the convention already in `src/canvas/standalone.ts`:

```ts
hostname: readFlag(args, '--host') ?? readEnv(env, 'CANVAS_HOST') ?? '0.0.0.0',
```

— same shape, inverted default.

## Compatibility

| | effect |
|---|---|
| Local use / MCP proxy (`ORACLE_HTTP_URL=http://localhost:47778`) | unchanged |
| Test suite | unchanged — integration tests dial `http://127.0.0.1:${port}` |
| Docker / compose | unchanged — `ORACLE_HOST=0.0.0.0` set in the `http-server` stage |
| **Deliberate LAN/remote access** | **breaking** — must set `ORACLE_HOST=0.0.0.0` |

That last row is the intent: exposure becomes something a deployment writes down, rather than something it inherits.

## Verification

Run against this branch:

- `bunx tsc --noEmit` → clean
- `bun test src/integration/api-token-auth.test.ts` → 4 pass / 0 fail
- With `ORACLE_HOST` unset, the listener binds `127.0.0.1` only; with `ORACLE_HOST=0.0.0.0` it binds all interfaces as before

I have not run the full suite or exercised the Docker images — flagged in the checklist below.

## Reviewer checklist

- [ ] full `bun test --isolate`
- [ ] `docker compose up` → host still reaches `:47778`
- [ ] `scripts/deploy-do.sh` — provisions a droplet; confirm whether the app is fronted by a proxy or exposed directly, since it relied on the implicit `0.0.0.0`

## Out of scope, but noticed nearby

1. **`isApiAuthorized` fails open.** An unset token grants everyone access silently. Fail-closed with an explicit `ARRA_ALLOW_ANONYMOUS=1` escape hatch would make the open mode a decision rather than an omission. Left out here because it is a behaviour change that deserves its own discussion.
2. **`src/canvas/standalone.ts` defaults to `0.0.0.0`** — same reasoning gap, different surface.
3. **CORS trusts every `https://*.buildwithoracle.com` subdomain** (`src/middleware/cors.ts` `isTrustedSubdomain`) and answers `Access-Control-Allow-Private-Network: true`. Deliberate for Studio, but the wildcard means any single subdomain that ever ends up under someone else's control reaches every user's local instance through their browser — an allowlist of the origins actually in use would cost nothing and bound that. Separately, `DEFAULT_ORIGINS` carries `arra-oracle-studio.laris.workers.dev`, which currently serves Cloudflare's "There is nothing here yet" — a stale entry rather than a live origin. Worth a look even if the answer is "accepted risk".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
